### PR TITLE
feat: add terminal buddy companion

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -58,6 +58,7 @@ Type `/` mid-chat to open the picker. Aliases shown in parentheses. Code-mode-on
 | `/compact` | Fold older turns into a summary (cache-safe). Auto-fires at 50% ctx; this is the manual trigger |
 | `/stop` | Abort the current model turn (typed alternative to Esc) |
 | `/copy` | Open vim/tmux-style copy mode — `j`/`k` navigate, `v` select, `y` yank to clipboard. The right answer for SSH / mosh / tmux where drag-select can't extend past the viewport |
+| `/buddy [on\|off\|mute\|unmute\|pet\|name <name>\|status]` | Show or configure the Reasonix whale companion near the composer |
 
 ### Setup
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -34,9 +34,11 @@ import {
   type EngineeringLifecycleMode,
   type HistoryScrollMode,
   type ReasoningEffort,
+  type ResolvedBuddyConfig,
   defaultConfigPath,
   editModeHintShown,
   isReasoningEffort,
+  loadBuddyConfig,
   loadEndpoint,
   loadEngineeringLifecycleMode,
   loadHistoryScrollMode,
@@ -131,6 +133,12 @@ import { PlanReviseEditor } from "./PlanReviseEditor.js";
 import { PromptInput } from "./PromptInput.js";
 import { SessionPicker } from "./SessionPicker.js";
 import { ShellConfirm, type ShellConfirmChoice } from "./ShellConfirm.js";
+import {
+  BUDDY_PULSE_TTL_MS,
+  type BuddyPulse,
+  createBuddyPulse,
+  resolveBuddyMood,
+} from "./buddy/state.js";
 import { useRenderTrace } from "./render-trace.js";
 
 import { SlashArgPicker } from "./SlashArgPicker.js";
@@ -507,9 +515,19 @@ function AppInner({
   const [input, setInput] = useState("");
   const [composerCursor, setComposerCursor] = useState(0);
   const [busy, setBusy] = useState(false);
+  const [buddyConfig, setBuddyConfig] = useState<ResolvedBuddyConfig>(() => loadBuddyConfig());
+  const [buddyPulse, setBuddyPulse] = useState<BuddyPulse | null>(null);
   const [slashUsage, setSlashUsage] = useState<Readonly<Record<string, number>>>(() =>
     loadSlashUsage(),
   );
+  const pulseBuddy = useCallback((kind: BuddyPulse["kind"]) => {
+    setBuddyPulse(createBuddyPulse(kind));
+  }, []);
+  useEffect(() => {
+    if (!buddyPulse) return;
+    const timer = setTimeout(() => setBuddyPulse(null), BUDDY_PULSE_TTL_MS);
+    return () => clearTimeout(timer);
+  }, [buddyPulse]);
   // ctrl-o toggles full-tail view on the live streaming card.
   // Auto-resets at the end of every turn so the next reply starts collapsed.
   const [liveExpand, setLiveExpand] = useState(false);
@@ -3015,8 +3033,11 @@ function AppInner({
         }
         setSlashUsage(recordSlashUse(slash.cmd));
         const result = handleSlash(slash.cmd, slash.args, loop, {
+          configPath: defaultConfigPath(),
           mcpSpecs,
           mcpServers: liveMcpServers,
+          setBuddyConfig: (next) => setBuddyConfig(next),
+          pulseBuddy,
           codeUndo: codeMode ? codeUndo : undefined,
           codeApply: codeMode ? codeApply : undefined,
           codeDiscard: codeMode ? codeDiscard : undefined,
@@ -3634,6 +3655,7 @@ function AppInner({
       mcpSpecs,
       models,
       planMode,
+      pulseBuddy,
       session,
       slashSelected,
       slashUsage,
@@ -4425,6 +4447,14 @@ function AppInner({
   // Suspend cosmetic animations during modal interactions and idle so
   // a quiescent TUI is byte-stable.
   const tickerSuspended = modalOpen || (!busy && !isStreaming);
+  const buddyMood = resolveBuddyMood({
+    pulse: buddyPulse,
+    awaitingUser: !!(pendingShell || pendingPath || pendingEditReview || pendingPlan),
+    toolActive: !!(ongoingTool || toolProgress),
+    loopActive: isLoopFiring(),
+    busy,
+    streaming: isStreaming,
+  });
 
   if (!bootReady) return <BootSplash />;
 
@@ -4821,6 +4851,9 @@ function AppInner({
                           : editMode
                   }
                   model={`${sessionModel} \u00b7 ${sessionEffort ?? loop.reasoningEffort}`}
+                  buddy={buddyConfig}
+                  buddyMood={buddyMood}
+                  buddyPulse={buddyPulse}
                   input={input}
                   setInput={setInput}
                   busy={busy}

--- a/src/cli/ui/ComposerArea.tsx
+++ b/src/cli/ui/ComposerArea.tsx
@@ -6,8 +6,10 @@
 import { Box, Text } from "ink";
 import React from "react";
 
-import type { EditMode } from "../../config.js";
+import type { EditMode, ResolvedBuddyConfig } from "../../config.js";
 import type { JobRegistry } from "../../tools/jobs.js";
+import { BuddySprite } from "./buddy/BuddySprite.js";
+import type { BuddyMood, BuddyPulse } from "./buddy/state.js";
 import { useRenderTrace } from "./render-trace.js";
 
 import { AtMentionSuggestions } from "./AtMentionSuggestions.js";
@@ -43,6 +45,9 @@ export interface ComposerAreaProps {
   model?: string;
   /** Show the shortcuts help modal above the input box. */
   showShortcuts?: boolean;
+  buddy?: ResolvedBuddyConfig;
+  buddyMood?: BuddyMood;
+  buddyPulse?: BuddyPulse | null;
 
   // ── prompt ───────────────────────────────────────────────────────
   input: string;
@@ -89,6 +94,9 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
     mode,
     model,
     showShortcuts,
+    buddy,
+    buddyMood,
+    buddyPulse,
     input,
     setInput,
     busy,
@@ -141,6 +149,9 @@ export const ComposerArea: React.FC<ComposerAreaProps> = React.memo(
           ) : null}
         </Box>
         {showShortcuts ? <ShortcutsHelpModal /> : null}
+        {buddy?.enabled ? (
+          <BuddySprite config={buddy} mood={buddyMood ?? "idle"} pulse={buddyPulse ?? null} />
+        ) : null}
         <PromptInput
           value={input}
           onChange={setInput}

--- a/src/cli/ui/buddy/BuddySprite.tsx
+++ b/src/cli/ui/buddy/BuddySprite.tsx
@@ -1,0 +1,217 @@
+import type { ResolvedBuddyConfig } from "@/config.js";
+import { Box, type Color, Text, useAnimationFrame, useStdout } from "ink";
+import React from "react";
+import { graphemes, padToCells } from "../text-width.js";
+import { FG, TONE } from "../theme/tokens.js";
+import { type BuddyMood, type BuddyPulse, applyBuddyPulseToMood, buddyPhrase } from "./state.js";
+
+export interface BuddySpriteProps {
+  config: ResolvedBuddyConfig;
+  mood: BuddyMood;
+  pulse?: BuddyPulse | null;
+}
+
+const FRAME_MS = 140;
+const WAKE = "*";
+const PET_MARK = "<3";
+const WHALE_WIDTH = 33;
+const COMPACT_WIDTH = 27;
+const FACE_GLYPHS = "><_•";
+const OUTLINE_GLYPHS = ".-'`~/\\_|>()";
+const WAVE_FRONT = ["~", "^", "~", "~", "^", "~"] as const;
+
+const WHALE_LINES = [
+  "        .--~~~~--.",
+  "      .'          `.___/|",
+  "     |   •̀ _ •́  >>  ___ >",
+  "      \\           __/  \\|",
+  "       `-.____.-'",
+] as const;
+
+const COMPACT_WHALE_LINES = [
+  "    .--~~~--.",
+  "  .'        `.___/|",
+  " |  •̀ _ •́ >> __ >",
+  "  \\       __/ \\|",
+  "   `-.__.-'",
+] as const;
+
+function moodColor(mood: BuddyMood): Color {
+  if (mood === "pet") return TONE.accent;
+  if (mood === "thinking") return TONE.brand;
+  if (mood === "working") return TONE.info;
+  if (mood === "warning") return TONE.warn;
+  return FG.meta;
+}
+
+function glyphColor(ch: string): Color | undefined {
+  if (ch.includes("•") || FACE_GLYPHS.includes(ch)) return FG.strong;
+  if (OUTLINE_GLYPHS.includes(ch)) return TONE.info;
+  return undefined;
+}
+
+function renderOutlineLine(line: string, key: string): React.ReactElement {
+  const padded = padToCells(line, WHALE_WIDTH);
+  const nodes: React.ReactNode[] = [];
+  let buffer = "";
+  let currentColor: Color | undefined;
+  for (const ch of graphemes(padded)) {
+    const color = glyphColor(ch);
+    if (color !== currentColor && buffer.length > 0) {
+      nodes.push(
+        <Text key={`${key}-${nodes.length}`} color={currentColor}>
+          {buffer}
+        </Text>,
+      );
+      buffer = "";
+    }
+    currentColor = color;
+    buffer += ch;
+  }
+  if (buffer.length > 0) {
+    nodes.push(
+      <Text key={`${key}-${nodes.length}`} color={currentColor}>
+        {buffer}
+      </Text>,
+    );
+  }
+  return (
+    <Box key={key} height={1}>
+      {nodes}
+    </Box>
+  );
+}
+
+function blank(width: number): string[] {
+  return Array.from({ length: width }, () => " ");
+}
+
+function writeAt(row: string[], x: number, text: string): void {
+  for (let i = 0; i < text.length; i++) {
+    const pos = x + i;
+    if (pos >= 0 && pos < row.length) row[pos] = text[i] ?? " ";
+  }
+}
+
+function spoutRows(frame: number, width: number, mood: BuddyMood, compact: boolean): string[] {
+  const rows = [blank(width), blank(width), blank(width)];
+  const center = compact ? 9 : 10;
+  const sway = [0, 1, 0, -1][Math.floor(frame / 2) % 4] ?? 0;
+
+  if (mood === "pet") {
+    writeAt(rows[0]!, center - 3 + sway, PET_MARK);
+    writeAt(rows[0]!, center + 3 - sway, PET_MARK);
+    writeAt(rows[1]!, center + sway, "o");
+    writeAt(rows[2]!, center, "|");
+    return rows.map((row) => row.join(""));
+  }
+
+  if (mood === "warning") {
+    writeAt(rows[0]!, center + sway, "!");
+    writeAt(rows[1]!, center, "!");
+    writeAt(rows[2]!, center, "|");
+    return rows.map((row) => row.join(""));
+  }
+
+  writeAt(rows[0]!, center - 2 + sway, ". o");
+  writeAt(rows[1]!, center + 1 - sway, "o");
+  writeAt(rows[2]!, center + 1, "|");
+  if (mood === "working" || mood === "thinking") writeAt(rows[1]!, center + 4 - sway, "o");
+  return rows.map((row) => row.join(""));
+}
+
+function shiftedWave(
+  pattern: readonly string[],
+  width: number,
+  frame: number,
+  speed: number,
+): string {
+  let out = "";
+  const offset = Math.floor(frame / speed) % pattern.length;
+  for (let i = 0; i < width; i++) out += pattern[(i + offset) % pattern.length] ?? "~";
+  return out;
+}
+
+function waveLine(width: number, pad: number, wave: string): string {
+  return padToCells(`${" ".repeat(pad)}${wave}`, width);
+}
+
+function whaleBob(frame: number): boolean {
+  return ([false, false, true, true, false, false] as const)[Math.floor(frame / 3) % 6] ?? false;
+}
+
+function AnimatedWhaleScene({
+  mood,
+  pulse,
+  compact,
+}: {
+  mood: BuddyMood;
+  pulse?: BuddyPulse | null;
+  compact: boolean;
+}): React.ReactElement {
+  const [, time] = useAnimationFrame(FRAME_MS);
+  const frame = Math.floor(time / FRAME_MS);
+  const width = compact ? COMPACT_WIDTH : WHALE_WIDTH;
+  const art = compact ? COMPACT_WHALE_LINES : WHALE_LINES;
+  const bobDown = whaleBob(frame);
+  const currentMood = applyBuddyPulseToMood(mood, pulse);
+  const spoutColor =
+    currentMood === "pet" ? TONE.accent : currentMood === "warning" ? TONE.warn : TONE.info;
+  const spout = spoutRows(frame, width, currentMood, compact);
+  const wave = compact ? "~^~~^" : "~^~~^~";
+  const wavePad = compact ? 5 : 10;
+
+  return (
+    <Box flexDirection="column" alignItems="flex-end" width={width}>
+      <Text color={spoutColor}>{spout[0]}</Text>
+      <Text color={spoutColor}>{spout[1]}</Text>
+      <Text color={spoutColor}>{spout[2]}</Text>
+      {bobDown ? <Text> </Text> : null}
+      {art.map((line, index) => renderOutlineLine(line, `whale-outline-${index}`))}
+      <Text color={TONE.brand}>
+        {waveLine(width, wavePad, shiftedWave(WAVE_FRONT, wave.length, frame, 1))}
+      </Text>
+      {bobDown ? null : <Text> </Text>}
+    </Box>
+  );
+}
+
+const BuddyCaption = React.memo(function BuddyCaption({
+  config,
+  mood,
+}: {
+  config: ResolvedBuddyConfig;
+  mood: BuddyMood;
+}): React.ReactElement {
+  const message = config.muted ? "quiet" : buddyPhrase(mood);
+  return (
+    <Box>
+      <Text color={FG.faint}>{config.name}</Text>
+      <Text color={FG.faint}>{" | "}</Text>
+      <Text color={moodColor(mood)}>{message}</Text>
+    </Box>
+  );
+});
+
+export function BuddySprite({ config, mood, pulse }: BuddySpriteProps): React.ReactElement | null {
+  const { stdout } = useStdout();
+  const cols = stdout?.columns ?? process.stdout.columns ?? 80;
+  if (!config.enabled) return null;
+
+  const currentMood = applyBuddyPulseToMood(mood, pulse);
+  const compact = cols < 64;
+  const width = compact ? COMPACT_WIDTH : WHALE_WIDTH;
+  return (
+    <Box
+      flexDirection="column"
+      alignItems="flex-end"
+      alignSelf="flex-end"
+      width={width}
+      marginBottom={0}
+    >
+      <AnimatedWhaleScene mood={mood} pulse={pulse} compact={compact} />
+      <BuddyCaption config={config} mood={currentMood} />
+      {pulse?.kind === "wake" ? <Text color={TONE.accent}>{WAKE}</Text> : null}
+    </Box>
+  );
+}

--- a/src/cli/ui/buddy/state.ts
+++ b/src/cli/ui/buddy/state.ts
@@ -1,0 +1,57 @@
+export type BuddyMood = "idle" | "thinking" | "working" | "warning" | "pet";
+
+export type BuddyPulseKind = "pet" | "wake";
+
+export interface BuddyPulse {
+  kind: BuddyPulseKind;
+  at: number;
+}
+
+export interface BuddySignals {
+  pulse?: BuddyPulse | null;
+  awaitingUser?: boolean;
+  toolActive?: boolean;
+  loopActive?: boolean;
+  busy?: boolean;
+  streaming?: boolean;
+}
+
+export const BUDDY_PULSE_TTL_MS = 2400;
+
+export function createBuddyPulse(kind: BuddyPulseKind, now: number = Date.now()): BuddyPulse {
+  return { kind, at: now };
+}
+
+export function isBuddyPulseExpired(
+  pulse: BuddyPulse | null | undefined,
+  now: number = Date.now(),
+  ttlMs: number = BUDDY_PULSE_TTL_MS,
+): boolean {
+  return !pulse || now - pulse.at >= ttlMs;
+}
+
+export function applyBuddyPulseToMood(mood: BuddyMood, pulse?: BuddyPulse | null): BuddyMood {
+  if (pulse?.kind === "pet") return "pet";
+  if (pulse?.kind === "wake" && mood === "idle") return "thinking";
+  return mood;
+}
+
+export function resolveBuddyMood(signals: BuddySignals): BuddyMood {
+  const baseMood: BuddyMood = signals.awaitingUser
+    ? "warning"
+    : signals.toolActive || signals.loopActive
+      ? "working"
+      : signals.busy || signals.streaming
+        ? "thinking"
+        : "idle";
+
+  return applyBuddyPulseToMood(baseMood, signals.pulse);
+}
+
+export function buddyPhrase(mood: BuddyMood): string {
+  if (mood === "pet") return "bloop";
+  if (mood === "thinking") return "diving through context";
+  if (mood === "working") return "following tool wake";
+  if (mood === "warning") return "waiting for your choice";
+  return "ready at the surface";
+}

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -72,6 +72,14 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
   },
 
   {
+    cmd: "buddy",
+    group: "chat",
+    argsHint: "[on|off|mute|unmute|pet|name <name>|status]",
+    summary: "show or configure the Reasonix whale companion near the composer",
+    argCompleter: ["on", "off", "mute", "unmute", "pet", "name", "status"],
+  },
+
+  {
     cmd: "model",
     group: "setup",
     argsHint: "<id>",

--- a/src/cli/ui/slash/dispatch.ts
+++ b/src/cli/ui/slash/dispatch.ts
@@ -3,6 +3,7 @@ import type { CacheFirstLoop } from "../../../loop.js";
 import { resolveSlashAlias } from "./commands.js";
 import { handlers as adminHandlers } from "./handlers/admin.js";
 import { handlers as basicHandlers } from "./handlers/basic.js";
+import { handlers as buddyHandlers } from "./handlers/buddy.js";
 import { handlers as dashboardHandlers } from "./handlers/dashboard.js";
 import { handlers as diffHandlers } from "./handlers/diff.js";
 import { handlers as editsHandlers } from "./handlers/edits.js";
@@ -31,6 +32,7 @@ export type SlashHandler = (args: string[], loop: CacheFirstLoop, ctx: SlashCont
 const HANDLERS: Record<string, SlashHandler> = {
   ...adminHandlers,
   ...basicHandlers,
+  ...buddyHandlers,
   ...dashboardHandlers,
   ...diffHandlers,
   ...editsHandlers,

--- a/src/cli/ui/slash/handlers/buddy.ts
+++ b/src/cli/ui/slash/handlers/buddy.ts
@@ -1,0 +1,70 @@
+import { type ResolvedBuddyConfig, loadBuddyConfig, saveBuddyConfig } from "@/config.js";
+import type { SlashHandler } from "../dispatch.js";
+
+const WHALE = "\u{1F40B}";
+const USAGE = "Usage: /buddy [on|off|mute|unmute|pet|name <name>|status]";
+
+function statusLine(config: ResolvedBuddyConfig): string {
+  const enabled = config.enabled ? "on" : "off";
+  const voice = config.muted ? "muted" : "voice on";
+  return `${WHALE} Buddy is ${enabled}, ${voice}, name "${config.name}".`;
+}
+
+const buddy: SlashHandler = (args, _loop, ctx) => {
+  const action = (args[0] ?? "status").toLowerCase();
+  const configPath = ctx.configPath;
+
+  const save = (patch: Parameters<typeof saveBuddyConfig>[0]) => {
+    const next = saveBuddyConfig(patch, configPath);
+    ctx.setBuddyConfig?.(next);
+    return next;
+  };
+
+  if (action === "status" || action === "") {
+    return { info: `${statusLine(loadBuddyConfig(configPath))}\n${USAGE}` };
+  }
+
+  if (action === "on" || action === "enable") {
+    const next = save({ enabled: true });
+    ctx.pulseBuddy?.("wake");
+    return { info: `${statusLine(next)}\nThe Reasonix whale is back near the composer.` };
+  }
+
+  if (action === "off" || action === "disable") {
+    const next = save({ enabled: false });
+    return { info: `${statusLine(next)}\nThe Reasonix whale is hidden.` };
+  }
+
+  if (action === "mute") {
+    const next = save({ muted: true });
+    return { info: `${statusLine(next)}\nBuddy will stay visual-only.` };
+  }
+
+  if (action === "unmute") {
+    const next = save({ muted: false });
+    ctx.pulseBuddy?.("wake");
+    return { info: `${statusLine(next)}\nBuddy voice is enabled.` };
+  }
+
+  if (action === "pet") {
+    let next = loadBuddyConfig(configPath);
+    if (!next.enabled) next = save({ enabled: true });
+    ctx.setBuddyConfig?.(next);
+    ctx.pulseBuddy?.("pet");
+    return { info: `${WHALE} ${next.name}: bloop.` };
+  }
+
+  if (action === "name") {
+    const name = args.slice(1).join(" ");
+    if (!name.trim()) return { info: `Missing buddy name.\n${USAGE}` };
+    const next = save({ name });
+    ctx.pulseBuddy?.("wake");
+    return { info: `${WHALE} Buddy renamed to "${next.name}".` };
+  }
+
+  return { info: `${USAGE}\nUnknown buddy action: ${action}` };
+};
+
+export const handlers: Record<string, SlashHandler> = {
+  buddy,
+};

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -1,8 +1,9 @@
 import type { EngineeringLifecycleSnapshot } from "../../../code/lifecycle.js";
-import type { EditMode } from "../../../config.js";
+import type { EditMode, ResolvedBuddyConfig } from "../../../config.js";
 import type { McpServerSummary } from "../../../mcp/summary.js";
 import type { JobRegistry } from "../../../tools/jobs.js";
 import type { PlanStep } from "../../../tools/plan.js";
+import type { BuddyPulseKind } from "../buddy/state.js";
 import type { CodeUndoOutput } from "../undo-context.js";
 
 export type { McpServerSummary } from "../../../mcp/summary.js";
@@ -112,6 +113,10 @@ export interface SlashContext {
     footer?: string;
   }) => void;
   dispatch?: (event: import("../state/events.js").AgentEvent) => void;
+  /** Update the local TUI companion immediately after `/buddy` persists config. */
+  setBuddyConfig?: (config: ResolvedBuddyConfig) => void;
+  /** Trigger a short local companion reaction without touching model context. */
+  pulseBuddy?: (kind: BuddyPulseKind) => void;
   setPlanMode?: (on: boolean, source?: PlanModeToggleSource) => void;
   /** Manual escape valve when the model forgot to call `mark_step_complete` — used by `/plans done <id>`. */
   markPlanStepDone?: (stepId: string) => "ok" | "not-in-plan" | "already-done" | "no-plan";

--- a/src/config.ts
+++ b/src/config.ts
@@ -148,6 +148,18 @@ export interface WeixinBotConfig {
   allowlist?: string[];
 }
 
+export interface BuddyConfig {
+  enabled?: boolean;
+  muted?: boolean;
+  name?: string;
+}
+
+export interface ResolvedBuddyConfig {
+  enabled: boolean;
+  muted: boolean;
+  name: string;
+}
+
 export interface PricingOverride {
   inputCacheHit?: number;
   inputCacheMiss?: number;
@@ -181,6 +193,8 @@ export interface ReasonixConfig {
   mouseClipboardHintShown?: boolean;
   /** When false, skip the boot splash animation and show the main UI immediately. Default true. */
   banner?: boolean;
+  /** Terminal whale companion shown near the composer. */
+  buddy?: BuddyConfig;
   reasoningEffort?: ReasoningEffort;
   /** Per-turn output token cap sent as `max_tokens` in the API request (#2196). Null = no cap. */
   maxOutputTokens?: number | null;
@@ -456,6 +470,41 @@ const DEFAULT_BATCH_SIZE = 10;
 
 export function defaultConfigPath(): string {
   return join(homedir(), ".reasonix", "config.json");
+}
+
+const DEFAULT_BUDDY_NAME = "Whale";
+const BUDDY_NAME_MAX_CHARS = 24;
+
+function normalizeBuddyName(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.replace(/\s+/g, " ").trim();
+  if (!trimmed) return undefined;
+  return Array.from(trimmed).slice(0, BUDDY_NAME_MAX_CHARS).join("");
+}
+
+export function loadBuddyConfig(path: string = defaultConfigPath()): ResolvedBuddyConfig {
+  const raw = readConfig(path).buddy ?? {};
+  return {
+    enabled: raw.enabled !== false,
+    muted: raw.muted === true,
+    name: normalizeBuddyName(raw.name) ?? DEFAULT_BUDDY_NAME,
+  };
+}
+
+export function saveBuddyConfig(
+  patch: BuddyConfig,
+  path: string = defaultConfigPath(),
+): ResolvedBuddyConfig {
+  const cfg = readConfig(path);
+  const current = loadBuddyConfig(path);
+  const next: ResolvedBuddyConfig = {
+    enabled: patch.enabled ?? current.enabled,
+    muted: patch.muted ?? current.muted,
+    name: normalizeBuddyName(patch.name) ?? current.name,
+  };
+  cfg.buddy = next;
+  writeConfig(cfg, path);
+  return next;
 }
 
 const STRING_ARRAY_FIELDS: Array<readonly string[]> = [

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -453,6 +453,10 @@ export const EN: TranslationSchema = {
         "ask a quick side question — answered from a blank slate, never added to the conversation context",
       argsHint: "<question>",
     },
+    buddy: {
+      description: "show or configure the Reasonix whale companion near the composer",
+      argsHint: "[on|off|mute|unmute|pet|name <name>|status]",
+    },
     "search-engine": {
       description:
         "switch web search backend — bing (default, works from CN without proxy), bing-intl (international index), searxng (self-hosted), metaso (free 100/d), baidu (Baidu AI Search, free 1500/mo per docs), tavily (free 1000/mo), perplexity (AI-native), exa (AI-native), brave (independent index), or ollama (Ollama cloud web search)",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -421,6 +421,11 @@ export const de: TranslationSchema = {
       description:
         "Kurze Randfrage stellen — wird von Grund auf beantwortet, nie zum Gesprächskontext hinzugefügt",
     },
+    buddy: {
+      ...EN.slash.buddy,
+      argsHint: "[on|off|mute|unmute|pet|name <name>|status]",
+      description: "Reasonix-Wal-Begleiter neben dem Composer anzeigen oder konfigurieren",
+    },
     "search-engine": {
       ...EN.slash["search-engine"],
       description:

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -433,6 +433,10 @@ export const zhCN: TranslationSchema = {
       description: "顺便问一下 — 从空白上下文回答，不写入会话历史",
       argsHint: "<question>",
     },
+    buddy: {
+      description: "显示或配置输入区旁边的 Reasonix 鲸鱼桌宠",
+      argsHint: "[on|off|mute|unmute|pet|name <name>|status]",
+    },
     "search-engine": {
       description:
         "切换网络搜索后端 — bing（默认，国内裸 IP 直连）、bing-intl（国际版索引）、searxng（自托管）、metaso（每日 100 次）、baidu（百度 AI Search，官方文档写有每月 1500 次免费额度）、tavily（每月 1000 次免费）、perplexity（AI 直接回答）、exa（AI 直接回答）、brave（独立索引）或 ollama（Ollama 云端搜索）",

--- a/tests/buddy-state.test.ts
+++ b/tests/buddy-state.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import {
+  BUDDY_PULSE_TTL_MS,
+  buddyPhrase,
+  createBuddyPulse,
+  isBuddyPulseExpired,
+  resolveBuddyMood,
+} from "../src/cli/ui/buddy/state.js";
+
+describe("buddy state", () => {
+  it("maps idle, streaming, tool, and wait signals to moods", () => {
+    expect(resolveBuddyMood({})).toBe("idle");
+    expect(resolveBuddyMood({ streaming: true })).toBe("thinking");
+    expect(resolveBuddyMood({ busy: true })).toBe("thinking");
+    expect(resolveBuddyMood({ toolActive: true })).toBe("working");
+    expect(resolveBuddyMood({ loopActive: true })).toBe("working");
+    expect(resolveBuddyMood({ awaitingUser: true })).toBe("warning");
+  });
+
+  it("keeps user waits above tool and streaming activity", () => {
+    expect(
+      resolveBuddyMood({
+        awaitingUser: true,
+        toolActive: true,
+        busy: true,
+        streaming: true,
+      }),
+    ).toBe("warning");
+  });
+
+  it("lets pet pulses override every normal state", () => {
+    expect(resolveBuddyMood({ awaitingUser: true, pulse: createBuddyPulse("pet", 100) })).toBe(
+      "pet",
+    );
+  });
+
+  it("turns idle wake pulses into thinking without overriding active work", () => {
+    const pulse = createBuddyPulse("wake", 100);
+
+    expect(resolveBuddyMood({ pulse })).toBe("thinking");
+    expect(resolveBuddyMood({ toolActive: true, pulse })).toBe("working");
+    expect(resolveBuddyMood({ awaitingUser: true, pulse })).toBe("warning");
+  });
+
+  it("expires local pulses on the shared ttl", () => {
+    const pulse = createBuddyPulse("wake", 1000);
+
+    expect(isBuddyPulseExpired(pulse, 1000 + BUDDY_PULSE_TTL_MS - 1)).toBe(false);
+    expect(isBuddyPulseExpired(pulse, 1000 + BUDDY_PULSE_TTL_MS)).toBe(true);
+  });
+
+  it("keeps status captions centralized for the CLI and future desktop client", () => {
+    expect(buddyPhrase("idle")).toBe("ready at the surface");
+    expect(buddyPhrase("thinking")).toBe("diving through context");
+    expect(buddyPhrase("working")).toBe("following tool wake");
+    expect(buddyPhrase("warning")).toBe("waiting for your choice");
+    expect(buddyPhrase("pet")).toBe("bloop");
+  });
+});

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -161,6 +161,38 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/effort=high/);
   });
 
+  it("/buddy persists config and triggers local UI pulses", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "reasonix-slash-buddy-"));
+    const tempConfig = join(tempDir, "config.json");
+    const pulses: string[] = [];
+    let liveConfig: unknown;
+    try {
+      const nameResult = handleSlash("buddy", ["name", "Deep", "Whale"], makeLoop(), {
+        configPath: tempConfig,
+        setBuddyConfig: (config) => {
+          liveConfig = config;
+        },
+        pulseBuddy: (kind) => pulses.push(kind),
+      });
+      expect(nameResult.info).toContain("Deep Whale");
+      expect(liveConfig).toMatchObject({ enabled: true, muted: false, name: "Deep Whale" });
+      expect(readConfig(tempConfig).buddy).toMatchObject({
+        enabled: true,
+        muted: false,
+        name: "Deep Whale",
+      });
+
+      const petResult = handleSlash("buddy", ["pet"], makeLoop(), {
+        configPath: tempConfig,
+        pulseBuddy: (kind) => pulses.push(kind),
+      });
+      expect(petResult.info).toContain("Deep Whale");
+      expect(pulses).toEqual(["wake", "pet"]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("/model switches the model", () => {
     const loop = makeLoop();
     const tempDir = mkdtempSync(join(tmpdir(), "reasonix-slash-model-basic-"));
@@ -700,10 +732,11 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(48);
+    expect(suggestSlashCommands("", true)).toHaveLength(49);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("weixin");
+    expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("buddy");
     expect(suggestSlashCommands("lan").map((s) => s.cmd)).toContain("language");
   });
 

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -86,7 +86,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 48 total commands", () => {
+  it("renders the bare slash release command surface as 49 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -95,13 +95,14 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(48);
+    expect(matches).toHaveLength(49);
     expect(names).toContain("language");
     expect(names).toContain("weixin");
     expect(names).toContain("btw");
+    expect(names).toContain("buddy");
     expect(names).toContain("about");
     expect(countAdvancedCommands(true)).toBe(10);
-    expect(frame).toContain("48 commands");
+    expect(frame).toContain("49 commands");
     expect(frame).toContain("+ 10 advanced");
   });
 


### PR DESCRIPTION
## What
  为 Reasonix 增加了一个终端 Buddy 伴随功能。本次改动新增了可配置的 `/buddy` 斜杠命令、可持久化的 Buddy 配置、显示在输入区附近的小鲸鱼动画，以及一个可复用的 Buddy 状态层，用来 把 Agent 的运行状态映射成 Buddy 的不同情绪状态。
<img width="2541" height="882" alt="2c41f481754863925eb5b1147f4f37a9" src="https://github.com/user-attachments/assets/23a34ef2-b121-4b95-a84d-7aa795f357b7" />


## Why
 这个功能让 Reasonix 在终端里拥有一个轻量级的视觉伴随角色，同时不会影响模型上下文，也不会侵入核心 Agent 循环。Buddy 的状态映射逻辑和渲染逻辑是分离的，因此以后如果要扩展桌面端Buddy，也可以复用同一套状态逻辑，而不需要在不同 UI 里重复判断状态。

## How to verify
 ```bash
  npm run typecheck
  npm run lint
  npx vitest run tests/buddy-state.test.ts tests/slash.test.ts tests/ui-slash-suggestions.test.tsx --silent
  ```

## Checklist

- [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
