### PR TITLE
fix(hash-memory): pass through #<digits> GitHub issue/PR references (#2261)

### DIFF
--- a/src/cli/ui/hash-memory.ts
+++ b/src/cli/ui/hash-memory.ts
@@ -36,6 +36,8 @@ export function detectHashMemory(text: string): HashMemoryParse | null {
   // resolve that ambiguity in favor of memory write and document the
   // `\#` escape for users who want a literal H1 in the prompt.
   if (text.startsWith("##")) return null;
+  // `#<digits>` — GitHub issue/PR reference style (e.g. `#123`); pass through.
+  if (/^#\d/.test(text)) return null;
   // `#g <note>` — global memory. The space after `g` is mandatory so
   // notes like `#golang preference` route to project memory, not global.
   // `#g` alone (or `#g` + only whitespace) is treated as null — the

--- a/tests/hash-memory.test.ts
+++ b/tests/hash-memory.test.ts
@@ -40,6 +40,12 @@ describe("detectHashMemory", () => {
     expect(detectHashMemory("#   ")).toBeNull();
   });
 
+  it("does NOT trigger on `#<digits>` GitHub issue/PR references", () => {
+    expect(detectHashMemory("#123")).toBeNull();
+    expect(detectHashMemory("#42 这个 bug 在哪个版本？")).toBeNull();
+    expect(detectHashMemory("#1")).toBeNull();
+  });
+
   it("does NOT trigger on `##` or higher markdown headings", () => {
     // Level-2+ headings pass through to the model so users can talk
     // about markdown without their headings being eaten.


### PR DESCRIPTION
## Summary

- `detectHashMemory` was intercepting messages like `#123` or `#42 which version?` as memory notes, writing them to `REASONIX.md` instead of sending to the model
- Added a guard after the `##` check: any `#` immediately followed by a digit returns `null` (normal chat flow)
- Text-body notes like `#記個筆記` still route to project memory as before

## Changes

- `src/cli/ui/hash-memory.ts` — one-line guard: `/^#\d/.test(text)` → return null
- `tests/hash-memory.test.ts` — new test case covering `#123`, `#42 ...`, `#1`

## Testing

All 21 hash-memory tests pass. Full suite (4052 tests) passes locally.

Closes #2261