### PR TITLE
fix(subagent): hard-cap session spawns at 50 to prevent runaway recursion (#2272)

### DIFF
--- a/src/tools/subagent.ts
+++ b/src/tools/subagent.ts
@@ -124,6 +124,8 @@ const SUBAGENT_TOOL_NAME = "spawn_subagent";
 /** spawn_subagent excluded → depth=1 hard cap; submit_plan excluded → no picker mid-parent-turn. */
 const NEVER_INHERITED_TOOLS = new Set<string>([SUBAGENT_TOOL_NAME, "submit_plan"]);
 
+/** Hard cap on subagent spawns per session — prevents runaway recursion (issue #2272). */
+export const MAX_SUBAGENT_SPAWNS_PER_SESSION = 50;
 /** Per-session spawn count past which the soft hint fires on every subsequent return. */
 const SOFT_HINT_AFTER_SPAWNS = 1;
 /** Per-session count past which the strong hint fires (asks the model to justify the next spawn). */
@@ -527,6 +529,11 @@ export function registerSubagentTool(
       if (!task) {
         return JSON.stringify({
           error: "spawn_subagent requires a non-empty 'task' argument.",
+        });
+      }
+      if (sessionSpawnCount >= MAX_SUBAGENT_SPAWNS_PER_SESSION) {
+        return JSON.stringify({
+          error: `spawn_subagent hard limit reached: this session has already spawned ${sessionSpawnCount} subagents (max ${MAX_SUBAGENT_SPAWNS_PER_SESSION}). Use direct tools to answer remaining questions.`,
         });
       }
       const typeSpec = getSubagentType(args.type);

--- a/tests/subagent.test.ts
+++ b/tests/subagent.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DeepSeekClient, Usage } from "../src/client.js";
 import { ToolRegistry } from "../src/tools.js";
 import {
+  MAX_SUBAGENT_SPAWNS_PER_SESSION,
   type SubagentEvent,
   type SubagentResult,
   type SubagentSink,
@@ -535,6 +536,21 @@ describe("registerSubagentTool — per-session budget feedback", () => {
     expect(outs[2]).toMatch(/\[note: this session has spawned 3 subagents/);
     expect(outs[3]).toMatch(/\[note: this session has spawned 4 subagents/);
     expect(outs[4]).toMatch(/\[budget: this session has now spawned 5 subagents/);
+  });
+
+  it("hard-caps at MAX_SUBAGENT_SPAWNS_PER_SESSION and returns an error without spawning", async () => {
+    const parent = new ToolRegistry();
+    const client = makeClient([{ content: "answer" }]);
+    registerSubagentTool(parent, { client });
+
+    for (let i = 0; i < MAX_SUBAGENT_SPAWNS_PER_SESSION; i++) {
+      await parent.dispatch("spawn_subagent", JSON.stringify({ task: `q${i}` }));
+    }
+
+    const over = await parent.dispatch("spawn_subagent", JSON.stringify({ task: "one too many" }));
+    const parsed = JSON.parse(over) as { error?: string };
+    expect(parsed.error).toMatch(/hard limit reached/);
+    expect(parsed.error).toMatch(new RegExp(`max ${MAX_SUBAGENT_SPAWNS_PER_SESSION}`));
   });
 });
 


### PR DESCRIPTION
## Summary

- A single `/autoresearch` call triggered 12,744 subagents, 235M tokens, \$3.40 in ~12 minutes (issue #2272)
- The existing soft hints (warn at spawn 2 / 5) rely entirely on model self-regulation — a looping external skill ignores them
- Add a **hard cap**: `MAX_SUBAGENT_SPAWNS_PER_SESSION = 50`; once reached, `spawn_subagent` returns an error JSON instead of spawning

## Changes

- `src/tools/subagent.ts` — export `MAX_SUBAGENT_SPAWNS_PER_SESSION = 50`; check before every spawn and return `{ error: "hard limit reached..." }` if exceeded
- `tests/subagent.test.ts` — new test: exhausts the cap then verifies the 51st call returns the error without spawning

## Testing

All 36 subagent tests pass. Full suite (4052 tests) passes locally.

Closes #2272