### PR TITLE
feat: 添加 Windows ARM64 构建支持

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           - { os: macos-15-intel, label: "macos-x64", rust: "x86_64-apple-darwin", tauri: "x86_64-apple-darwin" }
           - { os: macos-14, label: "macos-arm64", rust: "aarch64-apple-darwin", tauri: "aarch64-apple-darwin" }
           - { os: windows-latest, label: "windows-x64", rust: "x86_64-pc-windows-msvc", tauri: "x86_64-pc-windows-msvc" }
+          - { os: windows-latest, label: "windows-arm64", rust: "aarch64-pc-windows-msvc", tauri: "aarch64-pc-windows-msvc" }
     runs-on: ${{ matrix.target.os }}
     # secrets.* isn't accessible from step-level if:, so expose presence as a
     # job-level env. Treat "true"/"false" strings as booleans downstream.
@@ -92,6 +93,8 @@ jobs:
 
       - name: Download bundled Node runtime
         working-directory: desktop
+        env:
+          BUNDLE_ARCH: ${{ matrix.target.label == 'windows-arm64' && 'arm64' || '' }}
         run: npm run bundle:node
 
       - name: Verify bundled Node matches host arch (macOS)

--- a/desktop/scripts/bundle-node.mjs
+++ b/desktop/scripts/bundle-node.mjs
@@ -12,7 +12,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const binDir = join(here, "..", "src-tauri", "binaries");
 
 const PLAT = process.platform;
-const ARCH_RAW = process.arch;
+const ARCH_RAW = process.env.BUNDLE_ARCH || process.arch;
 const HOST_ARCH = ARCH_RAW === "arm64" ? "arm64" : ARCH_RAW === "x64" ? "x64" : null;
 
 if (!HOST_ARCH || !["win32", "darwin", "linux"].includes(PLAT)) {


### PR DESCRIPTION
## 概述

本 PR 为 DeepSeek-Reasonix 添加 Windows ARM64 构建支持，解决 [#2129](https://github.com/esengine/DeepSeek-Reasonix/issues/2129) 中的功能请求。

## 修改内容

### 1. 更新 CI 工作流 (`.github/workflows/release.yml`)
- 添加 `windows-arm64` 构建目标到构建矩阵
- 配置 Rust 目标为 `aarch64-pc-windows-msvc`
- 设置 `BUNDLE_ARCH=arm64` 环境变量用于交叉编译

### 2. 更新 Node.js 打包脚本 (`desktop/scripts/bundle-node.mjs`)
- 添加对 `BUNDLE_ARCH` 环境变量的支持
- 允许在交叉编译时指定目标架构
- 当设置为 `arm64` 时下载 ARM64 版本的 Node.js

## 技术细节

- **交叉编译方案**：使用 x64 GitHub Actions 运行器交叉编译 ARM64 版本
- **Rust 目标**：`aarch64-pc-windows-msvc`
- **Node.js 版本**：22.13.0（已提供 Windows ARM64 构建）
- **Tauri 支持**：Tauri 2.x 原生支持 Windows ARM64 交叉编译

## 测试说明

由于 GitHub Actions 没有原生 Windows ARM64 运行器，建议：
1. 合并后通过 `workflow_dispatch` 手动触发构建
2. 在 Windows ARM64 设备上测试生成的安装包

## 相关链接

- 原始 Issue: [#2129](https://github.com/esengine/DeepSeek-Reasonix/issues/2129)
- Node.js Windows ARM64 下载: https://nodejs.org/dist/v22.13.0/