### PR TITLE
feat: extract test-detection and auto-test runner

### DIFF
--- a/src/goal/auto-test.ts
+++ b/src/goal/auto-test.ts
@@ -1,0 +1,124 @@
+import { spawn } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import { detectTestCommand } from "./test-detection.js";
+import { type AutoTestResult, DEFAULT_GOAL_TEST_TIMEOUT_MS } from "./types.js";
+import type { DetectedTestCommand, VerificationCounts } from "./types.js";
+
+export interface RunGoalAutoTestOptions {
+  timeoutMs?: number;
+  command?: DetectedTestCommand | null;
+  maxOutputChars?: number;
+}
+
+export async function runGoalAutoTest(
+  rootDir: string,
+  opts: RunGoalAutoTestOptions = {},
+): Promise<AutoTestResult> {
+  const started = performance.now();
+  const command = opts.command === undefined ? detectTestCommand(rootDir) : opts.command;
+  if (!command) {
+    return {
+      status: "skipped",
+      durationMs: Math.round(performance.now() - started),
+      outputTail: "",
+      counts: {},
+      reason: "no supported test command detected",
+    };
+  }
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_GOAL_TEST_TIMEOUT_MS;
+  const maxOutputChars = opts.maxOutputChars ?? 24_000;
+  let output = "";
+  let timedOut = false;
+
+  return await new Promise<AutoTestResult>((resolve) => {
+    const child = spawn(command.command, command.args, {
+      cwd: rootDir,
+      env: process.env,
+      shell: process.platform === "win32",
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    const append = (chunk: Buffer | string) => {
+      output += chunk.toString();
+      if (output.length > maxOutputChars) output = output.slice(output.length - maxOutputChars);
+    };
+
+    child.stdout?.on("data", append);
+    child.stderr?.on("data", append);
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      const outputTail = err.message;
+      resolve({
+        status: "failed",
+        command,
+        exitCode: null,
+        signal: null,
+        timedOut,
+        durationMs: Math.round(performance.now() - started),
+        outputTail,
+        counts: parseVerificationCounts(outputTail),
+        reason: err.message,
+      });
+    });
+    child.on("close", (exitCode, signal) => {
+      clearTimeout(timer);
+      const outputTail = tailLines(output, 40);
+      resolve({
+        status: !timedOut && exitCode === 0 ? "passed" : "failed",
+        command,
+        exitCode,
+        signal,
+        timedOut,
+        durationMs: Math.round(performance.now() - started),
+        outputTail,
+        counts: parseVerificationCounts(output),
+      });
+    });
+  });
+}
+
+export function parseVerificationCounts(output: string): VerificationCounts {
+  const passed = lastNumberBefore(output, /\b(\d+)\s+passed\b/gi);
+  const failed = lastNumberBefore(output, /\b(\d+)\s+failed\b/gi);
+  return {
+    ...(passed !== undefined ? { passed } : {}),
+    ...(failed !== undefined ? { failed } : {}),
+  };
+}
+
+export function formatAutoTestResult(result: AutoTestResult): string {
+  if (result.status === "skipped") {
+    return ["Tests:", `- Verification skipped: ${result.reason ?? "not detected"}`].join("\n");
+  }
+  const command = result.command?.display ?? "test command";
+  const status = result.status === "passed" ? "passed" : "failed";
+  const lines = [
+    "Tests:",
+    `${result.status === "passed" ? "✓" : "✗"} ${command} (${status}, ${result.durationMs}ms)`,
+  ];
+  if (result.counts.passed !== undefined) lines.push(`✓ ${result.counts.passed} passed`);
+  if (result.counts.failed !== undefined) lines.push(`✗ ${result.counts.failed} failed`);
+  if (result.timedOut) lines.push(`timeout: ${command}`);
+  if (result.status === "failed" && result.outputTail.trim()) {
+    lines.push("", "Output tail:", result.outputTail.trim());
+  }
+  return lines.join("\n");
+}
+
+function lastNumberBefore(output: string, pattern: RegExp): number | undefined {
+  let value: number | undefined;
+  for (const match of output.matchAll(pattern)) {
+    const n = Number.parseInt(match[1] ?? "", 10);
+    if (Number.isFinite(n)) value = n;
+  }
+  return value;
+}
+
+function tailLines(output: string, maxLines: number): string {
+  const lines = output.replace(/\r\n/g, "\n").split("\n");
+  return lines.slice(-maxLines).join("\n").trim();
+}

--- a/src/goal/test-detection.ts
+++ b/src/goal/test-detection.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { DetectedTestCommand } from "./types.js";
+
+export function detectTestCommand(rootDir: string): DetectedTestCommand | null {
+  const node = detectNodeTestCommand(rootDir);
+  if (node) return node;
+  if (existsSync(join(rootDir, "pytest.ini")) || hasPytestInPyproject(rootDir)) {
+    return {
+      kind: "python",
+      command: "pytest",
+      args: [],
+      display: "pytest",
+      reason: "pytest configuration detected",
+    };
+  }
+  if (existsSync(join(rootDir, "go.mod"))) {
+    return {
+      kind: "go",
+      command: "go",
+      args: ["test", "./..."],
+      display: "go test ./...",
+      reason: "go.mod detected",
+    };
+  }
+  if (existsSync(join(rootDir, "Cargo.toml"))) {
+    return {
+      kind: "rust",
+      command: "cargo",
+      args: ["test"],
+      display: "cargo test",
+      reason: "Cargo.toml detected",
+    };
+  }
+  return null;
+}
+
+function detectNodeTestCommand(rootDir: string): DetectedTestCommand | null {
+  const packagePath = join(rootDir, "package.json");
+  if (!existsSync(packagePath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(packagePath, "utf8")) as {
+      scripts?: Record<string, unknown>;
+      packageManager?: unknown;
+    };
+    const script = raw.scripts?.test;
+    if (typeof script !== "string" || !script.trim() || isDefaultNpmNoTest(script)) return null;
+    const usePnpm =
+      existsSync(join(rootDir, "pnpm-lock.yaml")) ||
+      (typeof raw.packageManager === "string" && raw.packageManager.startsWith("pnpm@"));
+    return {
+      kind: "node",
+      command: usePnpm ? "pnpm" : "npm",
+      args: ["test"],
+      display: usePnpm ? "pnpm test" : "npm test",
+      reason: "package.json test script detected",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isDefaultNpmNoTest(script: string): boolean {
+  return /no test specified/i.test(script) && /exit\s+1/.test(script);
+}
+
+function hasPytestInPyproject(rootDir: string): boolean {
+  for (const name of ["pyproject.toml", "setup.cfg"]) {
+    const path = join(rootDir, name);
+    if (!existsSync(path)) continue;
+    try {
+      const body = readFileSync(path, "utf8");
+      if (/\bpytest\b|\[tool\.pytest/i.test(body)) return true;
+    } catch {
+      /* ignore unreadable config */
+    }
+  }
+  return false;
+}

--- a/src/goal/types.ts
+++ b/src/goal/types.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_GOAL_TEST_TIMEOUT_MS = 120_000;
+
+export type TestProjectKind = "node" | "python" | "go" | "rust";
+
+export interface DetectedTestCommand {
+  kind: TestProjectKind;
+  command: string;
+  args: string[];
+  display: string;
+  reason: string;
+}
+
+export interface VerificationCounts {
+  passed?: number;
+  failed?: number;
+}
+
+export interface AutoTestResult {
+  status: "passed" | "failed" | "skipped";
+  command?: DetectedTestCommand;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  timedOut?: boolean;
+  durationMs: number;
+  outputTail: string;
+  counts: VerificationCounts;
+  reason?: string;
+}

--- a/tests/test-detection.test.ts
+++ b/tests/test-detection.test.ts
@@ -1,0 +1,263 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  formatAutoTestResult,
+  parseVerificationCounts,
+  runGoalAutoTest,
+} from "../src/goal/auto-test.js";
+import { detectTestCommand } from "../src/goal/test-detection.js";
+import type { AutoTestResult } from "../src/goal/types.js";
+
+describe("test-detection", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-test-detection-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects node test commands with npm as default", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run" } }),
+      "utf8",
+    );
+    writeFileSync(join(dir, "package-lock.json"), "{}", "utf8");
+    expect(detectTestCommand(dir)?.display).toBe("npm test");
+    expect(detectTestCommand(dir)?.kind).toBe("node");
+  });
+
+  it("detects pnpm when pnpm-lock.yaml exists", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run" } }),
+      "utf8",
+    );
+    writeFileSync(join(dir, "pnpm-lock.yaml"), "", "utf8");
+    expect(detectTestCommand(dir)?.display).toBe("pnpm test");
+  });
+
+  it("detects pnpm when packageManager field is set", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        scripts: { test: "vitest run" },
+        packageManager: "pnpm@9.0.0",
+      }),
+      "utf8",
+    );
+    writeFileSync(join(dir, "package-lock.json"), "{}", "utf8");
+    expect(detectTestCommand(dir)?.display).toBe("pnpm test");
+  });
+
+  it("ignores default npm no-test script", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        scripts: { test: 'echo "Error: no test specified" && exit 1' },
+      }),
+      "utf8",
+    );
+    expect(detectTestCommand(dir)).toBeNull();
+  });
+
+  it("returns null for package.json without test script", () => {
+    writeFileSync(join(dir, "package.json"), JSON.stringify({ scripts: {} }), "utf8");
+    expect(detectTestCommand(dir)).toBeNull();
+  });
+
+  it("detects pytest when pytest.ini exists", () => {
+    writeFileSync(join(dir, "pytest.ini"), "[pytest]", "utf8");
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("python");
+    expect(cmd?.display).toBe("pytest");
+  });
+
+  it("detects pytest when pyproject.toml has pytest config", () => {
+    writeFileSync(join(dir, "pyproject.toml"), "[tool.pytest.ini_options]", "utf8");
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("python");
+    expect(cmd?.display).toBe("pytest");
+  });
+
+  it("detects go test when go.mod exists", () => {
+    writeFileSync(join(dir, "go.mod"), "module example.com/test\n", "utf8");
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("go");
+    expect(cmd?.display).toBe("go test ./...");
+  });
+
+  it("detects cargo test when Cargo.toml exists", () => {
+    writeFileSync(join(dir, "Cargo.toml"), '[package]\nname = "test"\n', "utf8");
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("rust");
+    expect(cmd?.display).toBe("cargo test");
+  });
+
+  it("returns null for empty directory", () => {
+    expect(detectTestCommand(dir)).toBeNull();
+  });
+});
+
+describe("parseVerificationCounts", () => {
+  it("parses passed and failed counts", () => {
+    expect(parseVerificationCounts("15 passed, 2 failed")).toEqual({
+      passed: 15,
+      failed: 2,
+    });
+  });
+
+  it("parses only passed", () => {
+    expect(parseVerificationCounts("10 passed")).toEqual({ passed: 10 });
+  });
+
+  it("parses only failed", () => {
+    expect(parseVerificationCounts("3 failed")).toEqual({ failed: 3 });
+  });
+
+  it("returns empty for no counts", () => {
+    expect(parseVerificationCounts("some output")).toEqual({});
+  });
+
+  it("takes the last occurrence of each count", () => {
+    expect(parseVerificationCounts("5 passed\n10 passed\n2 failed")).toEqual({
+      passed: 10,
+      failed: 2,
+    });
+  });
+});
+
+describe("formatAutoTestResult", () => {
+  it("formats skipped result", () => {
+    const result: AutoTestResult = {
+      status: "skipped",
+      durationMs: 0,
+      outputTail: "",
+      counts: {},
+      reason: "no supported test command detected",
+    };
+    expect(formatAutoTestResult(result)).toContain("Verification skipped");
+    expect(formatAutoTestResult(result)).toContain("no supported test command detected");
+  });
+
+  it("formats passed result", () => {
+    const result: AutoTestResult = {
+      status: "passed",
+      command: {
+        kind: "node",
+        command: "npm",
+        args: ["test"],
+        display: "npm test",
+        reason: "package.json test script detected",
+      },
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      durationMs: 1234,
+      outputTail: "",
+      counts: { passed: 5 },
+    };
+    const formatted = formatAutoTestResult(result);
+    expect(formatted).toContain("✓ npm test (passed, 1234ms)");
+    expect(formatted).toContain("✓ 5 passed");
+  });
+
+  it("formats failed result with output tail", () => {
+    const result: AutoTestResult = {
+      status: "failed",
+      command: {
+        kind: "node",
+        command: "npm",
+        args: ["test"],
+        display: "npm test",
+        reason: "package.json test script detected",
+      },
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      durationMs: 500,
+      outputTail: "Error: test failed",
+      counts: { failed: 2 },
+    };
+    const formatted = formatAutoTestResult(result);
+    expect(formatted).toContain("✗ npm test (failed, 500ms)");
+    expect(formatted).toContain("✗ 2 failed");
+    expect(formatted).toContain("Error: test failed");
+  });
+
+  it("includes timeout info when timed out", () => {
+    const result: AutoTestResult = {
+      status: "failed",
+      command: {
+        kind: "node",
+        command: "npm",
+        args: ["test"],
+        display: "npm test",
+        reason: "package.json test script detected",
+      },
+      exitCode: null,
+      signal: "SIGTERM",
+      timedOut: true,
+      durationMs: 120000,
+      outputTail: "",
+      counts: {},
+    };
+    expect(formatAutoTestResult(result)).toContain("timeout: npm test");
+  });
+});
+
+describe("runGoalAutoTest", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-auto-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns skipped when no test command detected", async () => {
+    const result = await runGoalAutoTest(dir);
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toBe("no supported test command detected");
+  });
+
+  it("returns skipped when command is explicitly null", async () => {
+    const result = await runGoalAutoTest(dir, { command: null });
+    expect(result.status).toBe("skipped");
+  });
+
+  it("runs passing test and returns passed status", async () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ scripts: { test: "node -e \"console.log('1 passed')\"" } }),
+      "utf8",
+    );
+    writeFileSync(join(dir, "package-lock.json"), "{}", "utf8");
+    const result = await runGoalAutoTest(dir);
+    expect(result.status).toBe("passed");
+    expect(result.exitCode).toBe(0);
+    expect(result.counts.passed).toBe(1);
+  });
+
+  it("runs failing test and returns failed status", async () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        scripts: { test: "node -e \"console.log('1 failed'); process.exit(1)\"" },
+      }),
+      "utf8",
+    );
+    writeFileSync(join(dir, "package-lock.json"), "{}", "utf8");
+    const result = await runGoalAutoTest(dir);
+    expect(result.status).toBe("failed");
+    expect(result.exitCode).toBe(1);
+    expect(result.counts.failed).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract test-detection and auto-test runner from the rejected /goal mode PR (#2244)
- These modules are useful for any verification flow and don't depend on the retry loop
- Includes comprehensive tests (23 tests passing)

## What's included
- `src/goal/types.ts` - Type definitions for test detection (DetectedTestCommand, AutoTestResult, etc.)
- `src/goal/auto-test.ts` - Auto-test runner with timeout, output capture, and result formatting
- `src/goal/test-detection.ts` - Test command detection for Node/Python/Go/Rust projects
- `tests/test-detection.test.ts` - Comprehensive tests covering all detection and formatting logic

## Verification
- `npm run lint` - passes
- `npm test -- tests/test-detection.test.ts` - 23 tests passing
- `npm run typecheck` - no new errors introduced

## Context
As requested by @esengine in [PR #2244 comments](https://github.com/esengine/DeepSeek-Reasonix/pull/2244#issuecomment-4573518437):
> "The piece worth keeping is the test-detection / auto-test runner (`src/goal/auto-test.ts` + `src/goal/test-detection.ts`) — that's useful for any verification flow and doesn't depend on the retry loop. If you want to extract just those into a small PR I'll take it."