### PR TITLE
fix: remove content-visibility: auto that causes text jitter on scroll

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2190,10 +2190,8 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
 .thread-inner--standalone {
   margin-top: 28px;
 }
-.thread-inner > div[data-turn] {
-  content-visibility: auto;
-  contain-intrinsic-size: auto 100px;
-}
+/* content-visibility: auto removed — conflicts with Virtuoso virtualization
+   and causes text jitter on scroll (issue #2076). */
 
 /* ---------- JUMP BAR (message navigation dock) ---------- */
 


### PR DESCRIPTION
## Summary

- 移除 `.thread-inner > div[data-turn]` 上的 `content-visibility: auto` 和 `contain-intrinsic-size: auto 100px`
- 这两个 CSS 属性与 Virtuoso 的虚拟化机制冲突，导致快速滚动时文本抖动

## Root Cause

`content-visibility: auto` 让浏览器跳过渲染视口外的元素，用 100px 固定值估算高度。Virtuoso 已经自行管理虚拟化，其高度计算基于实际渲染的 DOM 元素。用户来回滚动时，浏览器在"估算高度"和"实际渲染高度"之间反复切换，Virtuoso 检测到高度变化后重新计算所有 item 位置，导致文本抖动。

## Test plan

- [ ] 打开桌面版 Windows 客户端
- [ ] 加载一段较长的对话
- [ ] 用鼠标滚轮上下多次来回滚动
- [ ] 最后向下滚动到底
- [ ] 确认文本不再抖动

Fixes #2076