### PR TITLE
fix: clarify edit gate prompt for review mode queued edits

### DIFF
--- a/src/code/prompt.ts
+++ b/src/code/prompt.ts
@@ -52,7 +52,8 @@ The pinned Skills index below lists every available playbook (built-ins + user-i
 Only propose edits when the user explicitly says change / fix / add / remove / refactor / write. For "analyze / read / explain / describe / summarize" requests, gather with tools and reply in prose — no SEARCH/REPLACE, no file changes. If unclear, ask.
 
 The **edit gate** routes \`edit_file\` / \`write_file\` / \`multi_edit\` / \`delete_range\` / \`delete_symbol\` based on the user's mode (\`review\` or \`auto\`) — you don't see which is active, write the same way in both. Responses:
-- \`"edit blocks: 1/1 applied"\` — proceed.
+- \`"edit blocks: 1/1 applied"\` — the user approved and the edit was applied to disk. Proceed.
+- \`"Queued N edit(s) for review. No files were changed."\` — the edit is pending user approval; files have NOT been modified yet. Do NOT assume the file was changed. Do NOT continue editing dependent code. Wait for the user to run \`/apply\` or ask them to review.
 - \`"User rejected this edit to <path>. Don't retry the same SEARCH/REPLACE…"\` — do NOT re-emit the same block, do NOT switch tools to sneak it past (write_file → edit_file, or text-form SEARCH/REPLACE). Take a clearly different approach or ask.
 - Esc mid-prompt aborts the whole turn — don't keep calling tools after.
 


### PR DESCRIPTION
## 修改文件 / Changed Files

### `src/code/prompt.ts`

**中文：**
在 edit gate 响应说明中，明确区分 "applied"（已写入磁盘）和 "Queued for review"（待审核，文件未修改）两种状态。原提示词仅说明 `"edit blocks: 1/1 applied"` 后继续执行，未告知 AI 当编辑进入审核队列时文件实际上并未被修改，导致 AI 在 review 模式下误认为文件已变更并继续编辑依赖代码。

新增一行说明：`"Queued N edit(s) for review. No files were changed."` — 编辑正在等待用户批准，文件尚未修改，AI 不应假设文件已变更，不应继续编辑依赖代码，需等待用户执行 `/apply` 或手动审核。

**English:**
Added explicit distinction between "applied" (written to disk) and "Queued for review" (pending approval, no file changes) in the edit gate response documentation. Previously, only `"edit blocks: 1/1 applied"` was documented, with no guidance for the queued state — causing the AI to assume files were modified when edits were actually awaiting user approval in review mode.

Added: `"Queued N edit(s) for review. No files were changed."` — the edit is pending user approval; files have NOT been modified yet. The AI must not assume the file was changed, must not continue editing dependent code, and should wait for the user to run `/apply` or review manually.

## 问题来源 / Issue

Closes [HUO-34](mention://issue/09b30af3-7e96-4fd6-b931-e86af8ba661f)
Related: https://github.com/esengine/DeepSeek-Reasonix/issues/2107

## 测试 / Tests

- 全量测试通过：314 test files, 4035 tests passed
- 无新增回归
