### PR TITLE
Restore CLI TUI Scroll and Copy / 恢复 CLI TUI 滚动与复制

### DIFF
--- a/docs/CLI-REFERENCE.md
+++ b/docs/CLI-REFERENCE.md
@@ -40,7 +40,7 @@ Run `reasonix --help` (or any subcommand with `--help`) for the full flag list. 
 | `--no-config` | Ignore `~/.reasonix/config.json` for this run |
 | `--no-dashboard` | Don't auto-start the embedded web dashboard |
 | `--no-alt-screen` | Render to scrollback instead of the alt-screen buffer (preserves chat in shell history; legacy mode, can ghost on resize) |
-| `--no-mouse` | Disable DECSET 1007 (alternate-scroll); wheel reverts to native terminal scroll |
+| `--no-mouse` | Disable app-managed mouse tracking; wheel reverts to native terminal scroll |
 
 ---
 
@@ -57,7 +57,7 @@ Type `/` mid-chat to open the picker. Aliases shown in parentheses. Code-mode-on
 | `/retry` | Truncate and resend your last message — fresh sample |
 | `/compact` | Fold older turns into a summary (cache-safe). Auto-fires at 50% ctx; this is the manual trigger |
 | `/stop` | Abort the current model turn (typed alternative to Esc) |
-| `/copy` | Open vim/tmux-style copy mode — `j`/`k` navigate, `v` select, `y` yank to clipboard. The right answer for SSH / mosh / tmux where drag-select can't extend past the viewport |
+| `/copy [all\|last\|assistant\|N]` | Copy the latest assistant response by default; `all` copies the whole chat and `N` copies the last N items |
 
 ### Setup
 
@@ -176,7 +176,7 @@ Type `/` mid-chat to open the picker. Aliases shown in parentheses. Code-mode-on
 | Drag | Selects text natively — no modifier needed |
 | Right-click | Terminal-native (e.g. paste menu on Windows Terminal) |
 
-Reasonix sets DECSET 1007 (alternate-scroll) only — wheel events translate to ↑/↓ keypresses for the app, but native click/drag selection is left untouched. Pass `--no-mouse` to opt out entirely.
+In auto/app scroll mode, Reasonix captures mouse-wheel reports so chat history can scroll inside terminals whose native scrollback does not move TUI content. Pass `--no-mouse` to opt out entirely.
 
 ---
 
@@ -195,22 +195,8 @@ The default path is **terminal-native**. Drag to select, then use your terminal'
 
 In SSH / mosh / tmux, the alt-screen buffer prevents the terminal from extending the selection past the visible viewport — there is no scrollback above the alt-screen to drag into. Two fixes:
 
-1. **`/copy`** — open vim/tmux-style copy mode in-app. Snapshots the current chat to a navigable buffer; `y` yanks to clipboard via OSC 52 (with a temp-file fallback for terminals that don't support it).
+1. **`/copy`** — copy the latest assistant response through OSC 52. Use `/copy all` for the full chat or `/copy N` for the last N serialized chat items. Oversized content falls back to a temp file path.
 2. **`--no-alt-screen`** — render to shell scrollback instead. Drag-select then works terminal-natively (the chat content is real lines in the scrollback above your cursor). Trade-off: redraw can ghost on resize.
-
-### `/copy` — copy mode keys
-
-| Key | What it does |
-|---|---|
-| `j` / `↓` | Cursor down one line |
-| `k` / `↑` | Cursor up one line |
-| `PgUp` / `PgDn` | Page up / down |
-| `g` / `G` | Jump to top / bottom |
-| `v` | Start (or cancel) selection at the cursor |
-| `y` / `Enter` | Yank selection to clipboard, exit |
-| `q` / `Esc` | Quit without yanking |
-
-`y` with no active selection yanks just the current line. The yank goes through OSC 52 first (works through SSH, mosh, tmux with `set -g set-clipboard on`); content larger than 75 KB falls back to a temp file whose path is printed on exit.
 
 ---
 

--- a/docs/cli-ref-i18n.js
+++ b/docs/cli-ref-i18n.js
@@ -47,7 +47,7 @@
 
     "ms.title": "Mouse",
     "ms.body":
-      "Reasonix sets DECSET 1007 (alternate-scroll) only — wheel events translate to ↑/↓ keypresses for the app, but native click/drag selection is left untouched. Pass <code>--no-mouse</code> to opt out entirely.",
+      "In auto/app scroll mode, Reasonix captures mouse-wheel reports so chat history can scroll inside terminals whose native scrollback does not move TUI content. Pass <code>--no-mouse</code> to opt out entirely.",
 
     "cp.title": "Copy / paste",
     "cp.body":
@@ -56,12 +56,11 @@
     "cp.body.drag":
       "In SSH / mosh / tmux, the alt-screen buffer prevents the terminal from extending the selection past the visible viewport — there is no scrollback above the alt-screen to drag into. Two fixes:",
     "cp.fix1":
-      "<strong><code>/copy</code></strong> — open vim/tmux-style copy mode in-app. Snapshots the current chat to a navigable buffer; <code>y</code> yanks to clipboard via OSC 52 (with a temp-file fallback for terminals that don't support it).",
+      "<strong><code>/copy</code></strong> — copy the latest assistant response through OSC 52. Use <code>/copy all</code> for the full chat or <code>/copy N</code> for the last N serialized chat items. Oversized content falls back to a temp file path.",
     "cp.fix2":
       "<strong><code>--no-alt-screen</code></strong> — render to shell scrollback instead. Drag-select then works terminal-natively (the chat content is real lines in the scrollback above your cursor). Trade-off: redraw can ghost on resize.",
-    "cp.h.copymode": "<code>/copy</code> — copy mode keys",
-    "cp.body.osc":
-      "<code>y</code> with no active selection yanks just the current line. The yank goes through OSC 52 first (works through SSH, mosh, tmux with <code>set -g set-clipboard on</code>); content larger than 75 KB falls back to a temp file whose path is printed on exit.",
+    "cp.h.copymode": "<code>/copy</code>",
+    "cp.body.osc": "<code>/copy</code> uses OSC 52 first; large content falls back to a temp file.",
   };
 
   var zh = {
@@ -105,7 +104,7 @@
 
     "ms.title": "鼠标",
     "ms.body":
-      "Reasonix 只设置 DECSET 1007（alternate-scroll）——滚轮事件转为 ↑/↓ 按键传给应用，原生点击/拖拽选择不受影响。加 <code>--no-mouse</code> 可完全关闭。",
+      "在 auto/app 滚动模式下，Reasonix 会捕获鼠标滚轮事件，让原生 scrollback 无法滚动 TUI 内容的终端也能滚聊天。加 <code>--no-mouse</code> 可完全关闭。",
 
     "cp.title": "复制 / 粘贴",
     "cp.body":
@@ -114,12 +113,11 @@
     "cp.body.drag":
       "SSH / mosh / tmux 下，alt-screen 缓冲区会阻止终端把选区延伸到可视视口以外——alt-screen 上方根本没有 scrollback 可拖入。两种解决方式：",
     "cp.fix1":
-      "<strong><code>/copy</code></strong> — 在应用内打开 vim/tmux 风格的复制模式，把当前聊天快照到可导航的缓冲区；<code>y</code> 通过 OSC 52 复制到剪贴板（不支持 OSC 52 的终端会退到临时文件）。",
+      "<strong><code>/copy</code></strong> — 通过 OSC 52 复制最近一条 assistant 回复。用 <code>/copy all</code> 复制完整聊天，或 <code>/copy N</code> 复制最近 N 个序列化聊天项；内容过大时退到临时文件路径。",
     "cp.fix2":
       "<strong><code>--no-alt-screen</code></strong> — 改为渲染到 shell scrollback。拖拽选择恢复终端原生（聊天内容就是光标上方的真实行）。代价：窗口大小改变时可能出现重绘残影。",
-    "cp.h.copymode": "<code>/copy</code> — 复制模式快捷键",
-    "cp.body.osc":
-      "没有活动选区时按 <code>y</code> 只复制当前行。复制先走 OSC 52（通过 SSH、mosh、开了 <code>set -g set-clipboard on</code> 的 tmux 均可用）；超过 75 KB 的内容退到临时文件，路径在退出时打印。",
+    "cp.h.copymode": "<code>/copy</code>",
+    "cp.body.osc": "<code>/copy</code> 优先使用 OSC 52；大内容会退到临时文件。",
   };
 
   var DICT = { en: en, zh: zh };

--- a/docs/cli-reference.html
+++ b/docs/cli-reference.html
@@ -302,7 +302,7 @@
                 </tr>
                 <tr>
                   <td><code>--no-mouse</code></td>
-                  <td>Disable DECSET 1007 (alternate-scroll); wheel reverts to native terminal scroll</td>
+                  <td>Disable app-managed mouse tracking; wheel reverts to native terminal scroll</td>
                 </tr>
               </tbody>
             </table>
@@ -345,8 +345,8 @@
                   <td>Abort the current model turn (typed alternative to Esc)</td>
                 </tr>
                 <tr>
-                  <td><code>/copy</code></td>
-                  <td>Open vim/tmux-style copy mode — <code>j</code>/<code>k</code> navigate, <code>v</code> select, <code>y</code> yank to clipboard. The right answer for SSH / mosh / tmux where drag-select can't extend past the viewport</td>
+                  <td><code>/copy [all|last|assistant|N]</code></td>
+                  <td>Copy the latest assistant response by default; <code>all</code> copies the whole chat and <code>N</code> copies the last N items</td>
                 </tr>
               </tbody>
             </table>
@@ -685,9 +685,9 @@
               </tbody>
             </table>
             <p data-i18n="ms.body">
-              Reasonix sets DECSET 1007 (alternate-scroll) only — wheel events translate to
-              ↑/↓ keypresses for the app, but native click/drag selection is left untouched.
-              Pass <code>--no-mouse</code> to opt out entirely.
+              In auto/app scroll mode, Reasonix captures mouse-wheel reports so chat history can
+              scroll inside terminals whose native scrollback does not move TUI content. Pass
+              <code>--no-mouse</code> to opt out entirely.
             </p>
           </section>
 
@@ -732,10 +732,10 @@
             </p>
             <ol>
               <li data-i18n="cp.fix1">
-                <strong><code>/copy</code></strong> — open vim/tmux-style copy mode in-app.
-                Snapshots the current chat to a navigable buffer; <code>y</code> yanks to
-                clipboard via OSC 52 (with a temp-file fallback for terminals that don't
-                support it).
+                <strong><code>/copy</code></strong> — copy the latest assistant response through
+                OSC 52. Use <code>/copy all</code> for the full chat or <code>/copy N</code>
+                for the last N serialized chat items. Oversized content falls back to a temp
+                file path.
               </li>
               <li data-i18n="cp.fix2">
                 <strong><code>--no-alt-screen</code></strong> — render to shell scrollback
@@ -744,52 +744,6 @@
                 resize.
               </li>
             </ol>
-
-            <h3 data-i18n="cp.h.copymode"><code>/copy</code> — copy mode keys</h3>
-            <table class="cmd-table">
-              <thead>
-                <tr>
-                  <th data-i18n="th.key">Key</th>
-                  <th data-i18n="th.what">What it does</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td><code>j</code> / <code>↓</code></td>
-                  <td>Cursor down one line</td>
-                </tr>
-                <tr>
-                  <td><code>k</code> / <code>↑</code></td>
-                  <td>Cursor up one line</td>
-                </tr>
-                <tr>
-                  <td><code>PgUp</code> / <code>PgDn</code></td>
-                  <td>Page up / down</td>
-                </tr>
-                <tr>
-                  <td><code>g</code> / <code>G</code></td>
-                  <td>Jump to top / bottom</td>
-                </tr>
-                <tr>
-                  <td><code>v</code></td>
-                  <td>Start (or cancel) selection at the cursor</td>
-                </tr>
-                <tr>
-                  <td><code>y</code> / <code>Enter</code></td>
-                  <td>Yank selection to clipboard, exit</td>
-                </tr>
-                <tr>
-                  <td><code>q</code> / <code>Esc</code></td>
-                  <td>Quit without yanking</td>
-                </tr>
-              </tbody>
-            </table>
-            <p data-i18n="cp.body.osc">
-              <code>y</code> with no active selection yanks just the current line. The yank
-              goes through OSC 52 first (works through SSH, mosh, tmux with
-              <code>set -g set-clipboard on</code>); content larger than 75 KB falls back to
-              a temp file whose path is printed on exit.
-            </p>
           </section>
         </article>
       </div>

--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -314,11 +314,14 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const mcpSpecs = [...requestedSpecs];
   const mcpServers: McpServerSummary[] = [];
   const cfg = readConfig();
-  const historyScrollMode = resolveHistoryScrollMode({
-    configured: loadHistoryScrollMode(),
-    env: process.env,
-    platform: process.platform,
-  });
+  const historyScrollMode =
+    opts.noMouse || cfg.mouseTracking === false
+      ? "native"
+      : resolveHistoryScrollMode({
+          configured: loadHistoryScrollMode(),
+          env: process.env,
+          platform: process.platform,
+        });
   const startupInfoHints: string[] = [];
   const hasAnyMcp = normalizeMcpConfig(cfg).length > 0 || mcpSpecs.length > 0;
   if (cfg.setupCompleted === true && !hasAnyMcp) {
@@ -424,10 +427,10 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // path so N cards don't accumulate N native stdout listeners.
   installResizeBroadcaster();
 
-  // Wheel scrolling. Opt-out via `mouseTracking: false` for users who
-  // prefer native drag-select copy (Shift+drag still selects with mouse
-  // mode on in most terminals). exit hooks cover hard kills so the
-  // sequence doesn't leak into the parent shell.
+  // Wheel scrolling. Opt-out via `--no-mouse` / `mouseTracking: false` also
+  // forces native history mode so the terminal, not CardStream, owns wheel
+  // movement. Exit hooks cover hard kills so the sequence doesn't leak into
+  // the parent shell.
   if (!opts.noMouse && cfg.mouseTracking !== false) {
     enableMouseMode(historyScrollMode);
     process.once("exit", disableMouseMode);

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -196,6 +196,7 @@ import {
   type PlanModeToggleSource,
   handleSlash,
   parseSlash,
+  shouldExposeTuiCardsToSlash,
   suggestSlashCommands,
 } from "./slash.js";
 import { TurnTranslator } from "./state/TurnTranslator.js";
@@ -3009,6 +3010,11 @@ function AppInner({
       if (slash) {
         const sink = eventSinkRef.current;
         const eventizer = eventizerRef.current;
+        const exposeTuiCards = shouldExposeTuiCardsToSlash({
+          fromQQ,
+          fromTelegram,
+          fromWeixin,
+        });
         if (sink && eventizer) {
           sink.append(
             eventizer.emitSlashInvoked(loop.currentTurn, slash.cmd, slash.args.join(" ")),
@@ -3084,7 +3090,7 @@ function AppInner({
               footer: args.footer,
               oneTime: false,
             }),
-          getCards: getCardsForSlash,
+          getCards: exposeTuiCards ? getCardsForSlash : undefined,
           dispatch: agentStore.dispatch,
           markPlanStepDone: (stepId: string) => {
             const steps = planStepsRef.current;

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -488,6 +488,7 @@ function AppInner({
   markPhase("app_inner_start");
   const log = useScrollback();
   const agentStore = useAgentStore();
+  const getCardsForSlash = useCallback(() => agentStore.getState().cards, [agentStore]);
   const hasConversation = useAgentState((s) =>
     s.cards.some((c) => c.kind === "user" || c.kind === "streaming"),
   );
@@ -3083,6 +3084,7 @@ function AppInner({
               footer: args.footer,
               oneTime: false,
             }),
+          getCards: getCardsForSlash,
           dispatch: agentStore.dispatch,
           markPlanStepDone: (stepId: string) => {
             const steps = planStepsRef.current;
@@ -3678,6 +3680,7 @@ function AppInner({
       startDashboard,
       stopDashboard,
       getDashboardUrl,
+      getCardsForSlash,
       broadcastDashboardEvent,
       touchedPaths,
       model,

--- a/src/cli/ui/copy-history.ts
+++ b/src/cli/ui/copy-history.ts
@@ -1,0 +1,211 @@
+import type { Card } from "./state/cards.js";
+
+export type CopyHistoryMode =
+  | { kind: "latest-assistant" }
+  | { kind: "all" }
+  | { kind: "last"; count: number };
+
+export interface CopyHistorySelection {
+  label: string;
+  text: string;
+}
+
+export function parseCopyHistoryArgs(args: readonly string[]): CopyHistoryMode | { error: string } {
+  if (args.length === 0) return { kind: "latest-assistant" };
+  if (args.length === 1) {
+    const raw = args[0]!.toLowerCase();
+    if (raw === "last" || raw === "assistant" || raw === "reply" || raw === "response") {
+      return { kind: "latest-assistant" };
+    }
+    if (raw === "all") return { kind: "all" };
+    if (/^\d+$/.test(raw)) {
+      const count = Number.parseInt(raw, 10);
+      if (count > 0) return { kind: "last", count };
+    }
+  }
+  return { error: "usage" };
+}
+
+export function selectCopyHistory(
+  cards: ReadonlyArray<Card>,
+  mode: CopyHistoryMode = { kind: "latest-assistant" },
+): CopyHistorySelection | null {
+  if (mode.kind === "latest-assistant") {
+    for (let i = cards.length - 1; i >= 0; i--) {
+      const card = cards[i]!;
+      if (card.kind !== "streaming") continue;
+      const text = normalize(card.text);
+      if (text) return { label: "last assistant response", text };
+    }
+    return null;
+  }
+
+  const entries = cards.flatMap(cardToCopyEntries).filter((entry) => entry.text.length > 0);
+  const selected = mode.kind === "all" ? entries : entries.slice(-mode.count);
+  if (selected.length === 0) return null;
+  return {
+    label: mode.kind === "all" ? "conversation" : `last ${selected.length} item(s)`,
+    text: selected.map((entry) => `${entry.label}:\n${entry.text}`).join("\n\n"),
+  };
+}
+
+interface CopyEntry {
+  label: string;
+  text: string;
+}
+
+function cardToCopyEntries(card: Card): CopyEntry[] {
+  switch (card.kind) {
+    case "user":
+      return [{ label: "User", text: normalize(card.text) }];
+    case "streaming":
+      return [{ label: "Assistant", text: normalize(card.text) }];
+    case "tool": {
+      const args = card.args === undefined ? "" : formatJson(card.args);
+      const body = [args ? `Args:\n${args}` : "", card.output ? `Output:\n${card.output}` : ""]
+        .filter(Boolean)
+        .join("\n\n");
+      return [{ label: `Tool ${card.name}`, text: normalize(body) }];
+    }
+    case "reasoning":
+      return [{ label: "Reasoning", text: normalize(card.text) }];
+    case "live":
+      return [
+        { label: "Info", text: normalize(card.meta ? `${card.text}\n${card.meta}` : card.text) },
+      ];
+    case "warn":
+      return [
+        {
+          label: "Warning",
+          text: normalize([card.title, card.message, card.detail].filter(Boolean).join("\n")),
+        },
+      ];
+    case "error":
+      return [
+        {
+          label: "Error",
+          text: normalize([card.title, card.message, card.stack].filter(Boolean).join("\n")),
+        },
+      ];
+    case "plan":
+      return [
+        {
+          label: "Plan",
+          text: normalize(
+            [card.title, ...card.steps.map((step) => `- [${step.status}] ${step.title}`)].join(
+              "\n",
+            ),
+          ),
+        },
+      ];
+    case "task":
+      return [
+        {
+          label: "Task",
+          text: normalize(
+            [
+              `${card.title} (${card.status})`,
+              ...card.steps.map((step) => `- [${step.status}] ${step.title}`),
+            ].join("\n"),
+          ),
+        },
+      ];
+    case "diff":
+      return [
+        {
+          label: `Diff ${card.file}`,
+          text: normalize(
+            card.hunks
+              .map((hunk) =>
+                [
+                  hunk.header,
+                  ...hunk.lines.map(
+                    (line) =>
+                      `${line.kind === "add" ? "+" : line.kind === "del" ? "-" : " "}${line.text}`,
+                  ),
+                ].join("\n"),
+              )
+              .join("\n\n"),
+          ),
+        },
+      ];
+    case "usage":
+      return [
+        {
+          label: "Usage",
+          text: normalize(
+            `turn ${card.turn}: prompt ${card.tokens.prompt}, reasoning ${card.tokens.reason}, output ${card.tokens.output}, cost $${card.cost}`,
+          ),
+        },
+      ];
+    case "memory":
+      return [
+        {
+          label: "Memory",
+          text: normalize(
+            card.entries.map((entry) => `- ${entry.category}: ${entry.summary}`).join("\n"),
+          ),
+        },
+      ];
+    case "subagent":
+      return [
+        {
+          label: `Subagent ${card.name}`,
+          text: normalize(
+            [
+              `${card.task} (${card.status})`,
+              ...card.children
+                .flatMap(cardToCopyEntries)
+                .map((entry) => `${entry.label}:\n${entry.text}`),
+            ].join("\n\n"),
+          ),
+        },
+      ];
+    case "search":
+      return [
+        {
+          label: "Search",
+          text: normalize(
+            [
+              `query: ${card.query}`,
+              ...card.hits.map((hit) => `${hit.file}:${hit.line}: ${hit.preview}`),
+            ].join("\n"),
+          ),
+        },
+      ];
+    case "ctx":
+      return [{ label: "Context", text: normalize(card.text) }];
+    case "tip":
+      return [
+        {
+          label: "Tip",
+          text: normalize(
+            [
+              card.topic,
+              ...card.sections.flatMap((section) => [
+                section.title ? `[${section.title}]` : "",
+                ...section.rows.map((row) => `${row.key}\t${row.text}`),
+              ]),
+              card.footer ?? "",
+            ].join("\n"),
+          ),
+        },
+      ];
+    case "compaction":
+      return [{ label: "Compaction", text: normalize(card.summary) }];
+    default:
+      return [];
+  }
+}
+
+function normalize(text: string): string {
+  return text.trim();
+}
+
+function formatJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}

--- a/src/cli/ui/history-scroll-mode.ts
+++ b/src/cli/ui/history-scroll-mode.ts
@@ -15,11 +15,12 @@ export function resolveHistoryScrollMode({
 }: ResolveHistoryScrollModeInput = {}): ResolvedHistoryScrollMode {
   if (configured === "native") return "native";
   if (configured === "app") return "app";
+  if ((env.TERM_PROGRAM ?? "").toLowerCase() === "apple_terminal") return "native";
   if (isKnownJumpProneTerminal(env)) return "app";
   if (platform === "win32" && env.TERM_PROGRAM === undefined && env.MSYSTEM === undefined) {
     return "native";
   }
-  return "native";
+  return "app";
 }
 
 function isKnownJumpProneTerminal(env: NodeJS.ProcessEnv | Record<string, string | undefined>) {

--- a/src/cli/ui/mouse-mode.ts
+++ b/src/cli/ui/mouse-mode.ts
@@ -1,8 +1,8 @@
-// Reasonix is append-only now: the terminal owns scrollback, copy, and the
-// mouse wheel. On most terminals, startup emits disables for common
-// mouse-capture modes so stale state from a prior crashed TUI can't keep
-// eating wheel events. Apple Terminal has had native crashes in its renderer
-// after receiving these private mouse-mode toggles, so its default is silent.
+// In native history mode the terminal owns scrollback, copy, and the mouse
+// wheel. In app history mode Reasonix captures wheel reports so CardStream can
+// scroll consistently in terminals whose native scrollback does not move TUI
+// content. Apple Terminal has had native crashes in its renderer after
+// receiving these private mouse-mode toggles, so its default is silent.
 // REASONIX_MOUSE_MODE remains an escape hatch.
 
 type Mode = "alternate-scroll" | "sgr" | "off" | "apple-terminal-off";

--- a/src/cli/ui/slash.ts
+++ b/src/cli/ui/slash.ts
@@ -14,6 +14,7 @@ export {
   suggestSlashCommands,
 } from "./slash/commands.js";
 export { handleSlash } from "./slash/dispatch.js";
+export { shouldExposeTuiCardsToSlash } from "./slash/submit-origin.js";
 export type { SlashHandler } from "./slash/dispatch.js";
 export type {
   McpServerSummary,

--- a/src/cli/ui/slash/commands.ts
+++ b/src/cli/ui/slash/commands.ts
@@ -64,6 +64,12 @@ export const SLASH_COMMANDS: readonly SlashCommandSpec[] = [
     summary: "abort the current model turn (typed alternative to Esc)",
   },
   {
+    cmd: "copy",
+    group: "chat",
+    argsHint: "[all|last|assistant|N]",
+    summary: "copy the latest assistant response, the whole conversation, or the last N items",
+  },
+  {
     cmd: "btw",
     group: "chat",
     argsHint: "<question>",

--- a/src/cli/ui/slash/handlers/basic.ts
+++ b/src/cli/ui/slash/handlers/basic.ts
@@ -1,6 +1,8 @@
 import { wrapToCells } from "@/cli/ui/text-width.js";
 import { t, tObj } from "@/i18n/index.js";
 import { VERSION } from "@/version.js";
+import { writeClipboard } from "../../clipboard.js";
+import { parseCopyHistoryArgs, selectCopyHistory } from "../../copy-history.js";
 import { formatDuration, formatLoopStatus, parseLoopCommand } from "../../loop.js";
 import { SLASH_COMMANDS, SLASH_GROUP_ORDER, orderSlashCommandsByGroup } from "../commands.js";
 import type { SlashHandler } from "../dispatch.js";
@@ -151,6 +153,27 @@ const keys: SlashHandler = (_args, _loop, ctx) => {
   return {};
 };
 
+const copy: SlashHandler = (args, _loop, ctx) => {
+  if (!ctx.getCards) return { info: t("handlers.basic.copyNeedsTui") };
+  const mode = parseCopyHistoryArgs(args);
+  if ("error" in mode) return { info: t("handlers.basic.copyUsage") };
+  const selection = selectCopyHistory(ctx.getCards(), mode);
+  if (!selection) return { info: t("handlers.basic.copyNothing") };
+  const result = writeClipboard(selection.text);
+  if (!result.osc52 && result.filePath) {
+    return {
+      info: t("handlers.basic.copySavedFile", {
+        label: selection.label,
+        chars: result.size,
+        path: result.filePath,
+      }),
+    };
+  }
+  return {
+    info: t("handlers.basic.copyDone", { label: selection.label, chars: result.size }),
+  };
+};
+
 const about: SlashHandler = () => {
   const lines = [
     t("handlers.basic.aboutHeader", { version: VERSION }),
@@ -169,5 +192,6 @@ export const handlers: Record<string, SlashHandler> = {
   retry,
   loop,
   keys,
+  copy,
   about,
 };

--- a/src/cli/ui/slash/submit-origin.ts
+++ b/src/cli/ui/slash/submit-origin.ts
@@ -1,0 +1,9 @@
+export interface SlashSubmitOrigin {
+  fromQQ: boolean;
+  fromTelegram: boolean;
+  fromWeixin: boolean;
+}
+
+export function shouldExposeTuiCardsToSlash(origin: SlashSubmitOrigin): boolean {
+  return !(origin.fromQQ || origin.fromTelegram || origin.fromWeixin);
+}

--- a/src/cli/ui/slash/types.ts
+++ b/src/cli/ui/slash/types.ts
@@ -3,6 +3,7 @@ import type { EditMode } from "../../../config.js";
 import type { McpServerSummary } from "../../../mcp/summary.js";
 import type { JobRegistry } from "../../../tools/jobs.js";
 import type { PlanStep } from "../../../tools/plan.js";
+import type { Card } from "../state/cards.js";
 import type { CodeUndoOutput } from "../undo-context.js";
 
 export type { McpServerSummary } from "../../../mcp/summary.js";
@@ -111,6 +112,8 @@ export interface SlashContext {
     }>;
     footer?: string;
   }) => void;
+  /** Current TUI scrollback cards; used by `/copy`. */
+  getCards?: () => ReadonlyArray<Card>;
   dispatch?: (event: import("../state/events.js").AgentEvent) => void;
   setPlanMode?: (on: boolean, source?: PlanModeToggleSource) => void;
   /** Manual escape valve when the model forgot to call `mark_step_complete` — used by `/plans done <id>`. */

--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -131,8 +131,12 @@ function decodeSgrMouseBody(body: string): KeyEvent | null {
   if (!Number.isFinite(btn) || !Number.isFinite(col) || !Number.isFinite(row)) return null;
   const tail = m[4]!;
   if (tail === "m") return { input: "", mouseRelease: true, mouseRow: row, mouseCol: col };
-  if (btn === 64) return { input: "", mouseScrollUp: true, mouseRow: row, mouseCol: col };
-  if (btn === 65) return { input: "", mouseScrollDown: true, mouseRow: row, mouseCol: col };
+  const wheelButton = btn & 0x43;
+  if (wheelButton === 64 || wheelButton === 65) {
+    return wheelButton === 64
+      ? { input: "", mouseScrollUp: true, mouseRow: row, mouseCol: col }
+      : { input: "", mouseScrollDown: true, mouseRow: row, mouseCol: col };
+  }
   if (btn === 0) return { input: "", mouseClick: true, mouseRow: row, mouseCol: col };
   if (btn === 32) return { input: "", mouseDrag: true, mouseRow: row, mouseCol: col };
   return null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -238,11 +238,11 @@ export interface ReasonixConfig {
   /** Brave Search API key. Falls back to BRAVE_SEARCH_API_KEY env var. Free 2000/mo signup at https://brave.com/search/api/ */
   braveApiKey?: string;
 
-  /** TUI mouse-wheel scrolling via SGR mouse tracking. Default true. Set false to fall back to native terminal drag-select for copy (then wheel is terminal-dependent — most terminals translate wheel→arrow in alt-screen, some don't). */
+  /** TUI mouse-wheel scrolling via app-managed mouse tracking when historyScrollMode resolves to "app". Default true. Set false to leave the wheel entirely to the terminal. */
   mouseTracking?: boolean;
   /** Rows scrolled per single SGR mouse-wheel report. Default 1 — most terminals emit 2-5 reports per physical notch, so 1 already produces 2-5 rows per notch (#1419). Bump to 3-5 only if your terminal emits one report per notch and scrolling feels slow (#1494). Clamped to [1, 10]. */
   mouseWheelRows?: number;
-  /** Chat-history scrolling: "native" leaves terminal scrollback in charge; "app" captures wheel/PgUp/PgDn/End inside the TUI; "auto" enables app mode for terminals with known jumpy native scrollback. */
+  /** Chat-history scrolling: "native" leaves terminal scrollback in charge; "app" captures wheel/PgUp/PgDn/End inside the TUI; "auto" prefers app mode except terminals where native scrollback is safer. */
   historyScrollMode?: HistoryScrollMode;
   /** Diff display mode for edit_file / write_file / multi_edit results in CLI. */
   diffDisplay?: DiffDisplay;

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -121,6 +121,10 @@ export const EN: TranslationSchema = {
             },
             { key: "wheel", text: "scrolls chat history (works on web/cloud/SSH terminals too)" },
             {
+              key: "/copy",
+              text: "copy the latest assistant response; `/copy all` copies the chat",
+            },
+            {
               key: "↑ / ↓",
               text: "prompt history (or per-line cursor in a multi-line draft) — Ctrl+P / Ctrl+N alias",
             },
@@ -176,6 +180,10 @@ export const EN: TranslationSchema = {
             },
             { key: "paste", text: "Ctrl+V or Ctrl+Shift+V (Win/Linux) · Cmd+V (macOS)" },
             {
+              key: "/copy",
+              text: "copy latest assistant response · `/copy all` for the full chat · `/copy N` for last N items",
+            },
+            {
               key: "bracketed paste",
               text: "multi-line pastes stay one block — no auto-submit on intermediate newlines",
             },
@@ -191,7 +199,7 @@ export const EN: TranslationSchema = {
         },
       ],
       footer:
-        "Wheel scrolls chat on most terminals (web/cloud/SSH included) — SGR mouse tracking is on by default and stays out of the way of native drag-select and right-click. Pass --no-mouse to opt out.",
+        "Wheel scrolls chat on most terminals (web/cloud/SSH included). If your terminal traps selection while mouse tracking is active, use /copy or pass --no-mouse.",
     },
     tipShownOnce: "shown once",
     modelOverride: "override the default model",
@@ -357,6 +365,11 @@ export const EN: TranslationSchema = {
     feedback: { description: "open a GitHub issue with diagnostic info copied to clipboard" },
     about: { description: "project info — version, website, repo, license" },
     keys: { description: "keyboard + mouse + copy/paste reference" },
+    copy: {
+      description:
+        "copy the latest assistant response, the whole conversation (`all`), or the last N items",
+      argsHint: "[all|last|assistant|N]",
+    },
     plans: { description: "list this session's active + archived plans, newest first" },
     replay: {
       description: "load an archived plan as a read-only Time Travel snapshot (default: newest)",
@@ -856,6 +869,11 @@ export const EN: TranslationSchema = {
       loopStarted:
         '▸ loop started — re-submitting "{prompt}" every {duration}. Type anything (or /loop stop) to cancel.',
       keysNeedsTui: "/keys needs a TUI context (postKeys wired).",
+      copyNeedsTui: "/copy is only available in the interactive TUI.",
+      copyUsage: "usage: /copy [all|last|assistant|N]",
+      copyNothing: "nothing to copy yet.",
+      copyDone: "▸ copied {label} to clipboard ({chars} chars).",
+      copySavedFile: "▸ {label} is too large for terminal clipboard; saved {chars} chars to {path}",
       aboutHeader: "Reasonix v{version} — a cache-first DeepSeek coding agent",
       aboutWebsiteLabel: "Website",
       aboutRepoLabel: "GitHub ",
@@ -1937,7 +1955,7 @@ export const EN: TranslationSchema = {
     scrollAbovePlural: " \u2191 {scroll} / {max} rows above",
     scrollMore: " \u2014 {remaining} more",
     scrollPgUp: " \u00b7 PgUp / wheel",
-    scrollCopy: " \u00b7 /copy enters copy mode",
+    scrollCopy: " \u00b7 /copy copies reply",
   },
   slashArgPicker: {
     noMatch: 'no match for "{partial}"',

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -1985,7 +1985,7 @@ export const JA: TranslationSchema = {
     scrollAbovePlural: " \u2191 {scroll} / {max} 行上",
     scrollMore: " \u2014 さらに {remaining} 件",
     scrollPgUp: " \u00b7 PgUp / ホイール",
-    scrollCopy: " \u00b7 /copy でコピーモード",
+    scrollCopy: " \u00b7 /copy で返信をコピー",
   },
   slashArgPicker: {
     ...EN.slashArgPicker,

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1889,7 +1889,7 @@ export const de: TranslationSchema = {
     scrollAbovePlural: " ↑ {scroll} / {max} Zeilen darüber",
     scrollMore: " — {remaining} weitere",
     scrollPgUp: " · Bild↑ / Mausrad",
-    scrollCopy: " · /copy aktiviert Kopiermodus",
+    scrollCopy: " · /copy kopiert Antwort",
   },
   slashArgPicker: {
     ...EN.slashArgPicker,

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -116,6 +116,7 @@ export const zhCN: TranslationSchema = {
               text: "终端原生菜单（Windows Terminal 等的复制 / 粘贴）",
             },
             { key: "滚轮", text: "滚动聊天记录（Web / 云端 / SSH 终端也能用）" },
+            { key: "/copy", text: "复制最近一条 assistant 回复；`/copy all` 复制整个聊天" },
             {
               key: "↑ / ↓",
               text: "输入历史（多行草稿时按行移动光标）— Ctrl+P / Ctrl+N 同义",
@@ -169,6 +170,10 @@ export const zhCN: TranslationSchema = {
             },
             { key: "粘贴", text: "Ctrl+V 或 Ctrl+Shift+V（Win/Linux）· Cmd+V（macOS）" },
             {
+              key: "/copy",
+              text: "复制最近回复 · `/copy all` 复制完整聊天 · `/copy N` 复制最近 N 项",
+            },
+            {
               key: "bracketed paste",
               text: "多行粘贴整体进入 — 中间换行不会触发提交",
             },
@@ -184,7 +189,7 @@ export const zhCN: TranslationSchema = {
         },
       ],
       footer:
-        "滚轮在大多数终端（含 Web / 云端 / SSH）都能滚聊天 — 默认开启 SGR 鼠标跟踪，但不会影响终端原生拖选和右键菜单。直接拖动选中文本无需 Shift。传入 --no-mouse 可关闭。",
+        "滚轮在大多数终端（含 Web / 云端 / SSH）都能滚聊天。如果鼠标跟踪让终端选区受限，可用 /copy 或传入 --no-mouse。",
     },
     tipShownOnce: "仅显示一次",
     modelOverride: "覆盖默认模型",
@@ -335,6 +340,10 @@ export const zhCN: TranslationSchema = {
       argsHint: "[tokens]",
     },
     keys: { description: "键盘 + 鼠标 + 复制粘贴参考" },
+    copy: {
+      description: "复制最近一条 assistant 回复、完整聊天（all），或最近 N 项",
+      argsHint: "[all|last|assistant|N]",
+    },
     cwd: {
       description:
         "切换工作区根目录 — 重新指向文件/Shell/记忆工具，重载项目 hooks，刷新 @ 引用遍历器",
@@ -813,6 +822,11 @@ export const zhCN: TranslationSchema = {
       loopStarted:
         '▸ 循环已启动 — 每 {duration} 重新提交 "{prompt}"。输入任何内容（或 /loop stop）取消。',
       keysNeedsTui: "/keys 需要 TUI 上下文（postKeys 已连接）。",
+      copyNeedsTui: "/copy 仅在交互式 TUI 中可用。",
+      copyUsage: "用法：/copy [all|last|assistant|N]",
+      copyNothing: "还没有可复制的内容。",
+      copyDone: "▸ 已复制 {label} 到剪贴板（{chars} 字符）。",
+      copySavedFile: "▸ {label} 超出终端剪贴板限制；已将 {chars} 字符保存到 {path}",
       aboutHeader: "Reasonix v{version} — 缓存优先的 DeepSeek 编码代理",
       aboutWebsiteLabel: "官网",
       aboutRepoLabel: "仓库",
@@ -1830,7 +1844,7 @@ export const zhCN: TranslationSchema = {
     scrollAbovePlural: " \u2191 {scroll}/{max} 行",
     scrollMore: " \u2014 还有 {remaining} 行",
     scrollPgUp: " \u00b7 PgUp/\u6eda\u8f6e",
-    scrollCopy: " \u00b7 /copy \u8fdb\u5165\u590d\u5236\u6a21\u5f0f",
+    scrollCopy: " \u00b7 /copy \u590d\u5236\u56de\u590d",
   },
   slashArgPicker: {
     noMatch: '\u6ca1\u6709\u5339\u914d "{partial}"',

--- a/tests/auto-git-rollback.test.ts
+++ b/tests/auto-git-rollback.test.ts
@@ -9,6 +9,8 @@ import { ToolRegistry } from "../src/tools.js";
 import { registerFilesystemTools } from "../src/tools/filesystem.js";
 import { ReadTracker } from "../src/tools/read-tracker.js";
 
+const AMBIENT_GIT_ENV_TEST_TIMEOUT_MS = process.platform === "win32" ? 20_000 : 5_000;
+
 function cleanGitEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env };
   for (const key of Object.keys(env)) {
@@ -175,32 +177,36 @@ describe("auto-git-rollback memory guard", () => {
     expect(await fs.readFile(join(root, "tracked.txt"), "utf8")).toBe("baseline\n");
   });
 
-  it("ignores ambient Git hook environment variables when checkpointing", async () => {
-    const outerRoot = await mkdtemp(join(tmpdir(), "reasonix-auto-git-outer-"));
-    git(outerRoot, ["init", "-q"]);
-    const previousGitDir = process.env.GIT_DIR;
-    const previousGitWorkTree = process.env.GIT_WORK_TREE;
-    process.env.GIT_DIR = join(outerRoot, ".git");
-    process.env.GIT_WORK_TREE = outerRoot;
+  it(
+    "ignores ambient Git hook environment variables when checkpointing",
+    async () => {
+      const outerRoot = await mkdtemp(join(tmpdir(), "reasonix-auto-git-outer-"));
+      git(outerRoot, ["init", "-q"]);
+      const previousGitDir = process.env.GIT_DIR;
+      const previousGitWorkTree = process.env.GIT_WORK_TREE;
+      process.env.GIT_DIR = join(outerRoot, ".git");
+      process.env.GIT_WORK_TREE = outerRoot;
 
-    try {
-      enableAutoGitRollback(home, root);
-      await fs.writeFile(join(root, "tracked.txt"), "dirty-before-edit\n", "utf8");
+      try {
+        enableAutoGitRollback(home, root);
+        await fs.writeFile(join(root, "tracked.txt"), "dirty-before-edit\n", "utf8");
 
-      await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
-      const out = await tools.dispatch(
-        "edit_file",
-        { path: "tracked.txt", search: "dirty-before-edit", replace: "after-edit" },
-        { readTracker },
-      );
+        await tools.dispatch("read_file", { path: "tracked.txt" }, { readTracker });
+        const out = await tools.dispatch(
+          "edit_file",
+          { path: "tracked.txt", search: "dirty-before-edit", replace: "after-edit" },
+          { readTracker },
+        );
 
-      expect(out).toMatch(/edited tracked\.txt/);
-      expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
-      expect(git(root, ["log", "-1", "--format=%s"])).toMatch(/pre-edit: edit_file tracked\.txt/);
-    } finally {
-      restoreProcessEnv("GIT_DIR", previousGitDir);
-      restoreProcessEnv("GIT_WORK_TREE", previousGitWorkTree);
-      await rm(outerRoot, { recursive: true, force: true });
-    }
-  });
+        expect(out).toMatch(/edited tracked\.txt/);
+        expect(git(root, ["show", "HEAD:tracked.txt"])).toBe("dirty-before-edit");
+        expect(git(root, ["log", "-1", "--format=%s"])).toMatch(/pre-edit: edit_file tracked\.txt/);
+      } finally {
+        restoreProcessEnv("GIT_DIR", previousGitDir);
+        restoreProcessEnv("GIT_WORK_TREE", previousGitWorkTree);
+        await rm(outerRoot, { recursive: true, force: true });
+      }
+    },
+    AMBIENT_GIT_ENV_TEST_TIMEOUT_MS,
+  );
 });

--- a/tests/chat-scroll-wheel.test.ts
+++ b/tests/chat-scroll-wheel.test.ts
@@ -94,12 +94,30 @@ describe("history scroll mode resolution", () => {
     );
   });
 
-  it("keeps native scrollback for unknown terminals in auto mode", () => {
+  it("prefers app-managed scrolling for unknown terminals in auto mode", () => {
     expect(
       resolveHistoryScrollMode({
         configured: "auto",
         env: { TERM: "xterm-256color" },
         platform: "linux",
+      }),
+    ).toBe("app");
+  });
+
+  it("keeps native scrollback for terminals where app mouse tracking is risky", () => {
+    expect(
+      resolveHistoryScrollMode({
+        configured: "auto",
+        env: { TERM_PROGRAM: "Apple_Terminal" },
+        platform: "darwin",
+      }),
+    ).toBe("native");
+
+    expect(
+      resolveHistoryScrollMode({
+        configured: "auto",
+        env: {},
+        platform: "win32",
       }),
     ).toBe("native");
   });

--- a/tests/copy-history.test.ts
+++ b/tests/copy-history.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CopyHistoryMode,
+  parseCopyHistoryArgs,
+  selectCopyHistory,
+} from "../src/cli/ui/copy-history.js";
+import type { Card } from "../src/cli/ui/state/cards.js";
+
+const ts = 1;
+
+function user(id: string, text: string): Card {
+  return { kind: "user", id, ts, text };
+}
+
+function assistant(id: string, text: string): Card {
+  return { kind: "streaming", id, ts, text, done: true };
+}
+
+function tool(id: string, name: string, output: string): Card {
+  return { kind: "tool", id, ts, name, args: { ok: true }, output, done: true, elapsedMs: 12 };
+}
+
+describe("copy history selection", () => {
+  it("defaults to the latest assistant response", () => {
+    const selected = selectCopyHistory([
+      user("u1", "hello"),
+      assistant("a1", "first"),
+      assistant("a2", "second"),
+    ]);
+
+    expect(selected).toEqual({ label: "last assistant response", text: "second" });
+  });
+
+  it("copies the whole conversation when requested", () => {
+    const selected = selectCopyHistory(
+      [user("u1", "hello"), assistant("a1", "hi"), tool("t1", "run_command", "done")],
+      { kind: "all" },
+    );
+
+    expect(selected?.text).toContain("User:\nhello");
+    expect(selected?.text).toContain("Assistant:\nhi");
+    expect(selected?.text).toContain("Tool run_command:");
+    expect(selected?.text).toContain("Output:\ndone");
+  });
+
+  it("copies the last N serializable entries", () => {
+    const selected = selectCopyHistory(
+      [user("u1", "one"), assistant("a1", "two"), user("u2", "three")],
+      { kind: "last", count: 2 },
+    );
+
+    expect(selected?.label).toBe("last 2 item(s)");
+    expect(selected?.text).not.toContain("one");
+    expect(selected?.text).toContain("Assistant:\ntwo");
+    expect(selected?.text).toContain("User:\nthree");
+  });
+
+  it("returns null when there is no matching content", () => {
+    expect(selectCopyHistory([], { kind: "latest-assistant" })).toBeNull();
+  });
+});
+
+describe("parseCopyHistoryArgs", () => {
+  it.each([
+    [[], { kind: "latest-assistant" }],
+    [["all"], { kind: "all" }],
+    [["assistant"], { kind: "latest-assistant" }],
+    [["3"], { kind: "last", count: 3 }],
+  ] as Array<[string[], CopyHistoryMode]>)("parses %j", (args, expected) => {
+    expect(parseCopyHistoryArgs(args)).toEqual(expected);
+  });
+
+  it("rejects unsupported forms", () => {
+    expect(parseCopyHistoryArgs(["0"])).toEqual({ error: "usage" });
+    expect(parseCopyHistoryArgs(["all", "extra"])).toEqual({ error: "usage" });
+  });
+});

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -8,6 +8,7 @@ import {
   detectSlashArgContext,
   handleSlash,
   parseSlash,
+  shouldExposeTuiCardsToSlash,
   suggestSlashCommands,
 } from "../src/cli/ui/slash.js";
 import { DeepSeekClient, Usage } from "../src/client.js";
@@ -560,6 +561,24 @@ describe("handleSlash", () => {
   it("/copy requires TUI cards", () => {
     const r = handleSlash("copy", [], makeLoop());
     expect(r.info).toMatch(/interactive TUI/);
+  });
+
+  it("only exposes TUI card history to local slash submissions", () => {
+    expect(
+      shouldExposeTuiCardsToSlash({
+        fromQQ: false,
+        fromTelegram: false,
+        fromWeixin: false,
+      }),
+    ).toBe(true);
+
+    for (const origin of [
+      { fromQQ: true, fromTelegram: false, fromWeixin: false },
+      { fromQQ: false, fromTelegram: true, fromWeixin: false },
+      { fromQQ: false, fromTelegram: false, fromWeixin: true },
+    ]) {
+      expect(shouldExposeTuiCardsToSlash(origin)).toBe(false);
+    }
   });
 
   describe("detectSlashArgContext", () => {

--- a/tests/slash.test.ts
+++ b/tests/slash.test.ts
@@ -520,6 +520,48 @@ describe("handleSlash", () => {
     expect(r.info).toMatch(/\/retry/);
   });
 
+  it("/copy copies the latest assistant response through OSC 52", () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const r = handleSlash("copy", [], makeLoop(), {
+        getCards: () => [
+          { kind: "user", id: "u1", ts: 1, text: "hello" },
+          { kind: "streaming", id: "a1", ts: 2, text: "copy me", done: true },
+        ],
+      });
+
+      expect(r.info).toContain("copied");
+      const expectedB64 = Buffer.from("copy me", "utf8").toString("base64");
+      expect(write).toHaveBeenCalledWith(`\x1b]52;c;${expectedB64}\x1b\\`);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("/copy all serializes the conversation", () => {
+    const write = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const r = handleSlash("copy", ["all"], makeLoop(), {
+        getCards: () => [
+          { kind: "user", id: "u1", ts: 1, text: "hello" },
+          { kind: "streaming", id: "a1", ts: 2, text: "hi back", done: true },
+        ],
+      });
+
+      expect(r.info).toContain("copied");
+      const expected = "User:\nhello\n\nAssistant:\nhi back";
+      const expectedB64 = Buffer.from(expected, "utf8").toString("base64");
+      expect(write).toHaveBeenCalledWith(`\x1b]52;c;${expectedB64}\x1b\\`);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it("/copy requires TUI cards", () => {
+    const r = handleSlash("copy", [], makeLoop());
+    expect(r.info).toMatch(/interactive TUI/);
+  });
+
   describe("detectSlashArgContext", () => {
     it("returns null before the user commits to a slash name", () => {
       expect(detectSlashArgContext("/pr")).toBeNull();
@@ -684,6 +726,7 @@ describe("handleSlash", () => {
       "compact",
       "sessions",
       "new",
+      "copy",
       "exit",
       "apply",
       "discard",
@@ -700,7 +743,7 @@ describe("handleSlash", () => {
     // Case-insensitive.
     expect(suggestSlashCommands("HE").map((s) => s.cmd)).toEqual(["help"]);
     // Empty prefix returns the full non-advanced release list, including code commands.
-    expect(suggestSlashCommands("", true)).toHaveLength(48);
+    expect(suggestSlashCommands("", true)).toHaveLength(49);
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("logs");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("language");
     expect(suggestSlashCommands("", true).map((s) => s.cmd)).toContain("weixin");

--- a/tests/stdin-reader.test.ts
+++ b/tests/stdin-reader.test.ts
@@ -391,6 +391,18 @@ describe("StdinReader — SGR mouse reports (issue #867)", () => {
     expect(events).toEqual([{ input: "", mouseScrollDown: true, mouseRow: 5, mouseCol: 10 }]);
   });
 
+  it("decodes modified wheel reports as scroll events", () => {
+    const { reader, events } = setup();
+    reader.feed("\x1b[<68;10;5M");
+    reader.feed("\x1b[<69;11;5M");
+    reader.feed("\x1b[<80;12;5M");
+    expect(events).toEqual([
+      { input: "", mouseScrollUp: true, mouseRow: 5, mouseCol: 10 },
+      { input: "", mouseScrollDown: true, mouseRow: 5, mouseCol: 11 },
+      { input: "", mouseScrollUp: true, mouseRow: 5, mouseCol: 12 },
+    ]);
+  });
+
   it("dispatches left-click press + release", () => {
     const { reader, events } = setup();
     reader.feed("\x1b[<0;3;7M");

--- a/tests/ui-slash-suggestions.test.tsx
+++ b/tests/ui-slash-suggestions.test.tsx
@@ -86,7 +86,7 @@ describe("SlashSuggestions", () => {
     );
   });
 
-  it("renders the bare slash release command surface as 48 total commands", () => {
+  it("renders the bare slash release command surface as 49 total commands", () => {
     const matches = suggestSlashCommands("", true);
     const names = matches.map((spec) => spec.cmd);
     const { lastFrame, unmount } = render(
@@ -95,13 +95,13 @@ describe("SlashSuggestions", () => {
     const frame = lastFrame() ?? "";
     unmount();
 
-    expect(matches).toHaveLength(48);
+    expect(matches).toHaveLength(49);
     expect(names).toContain("language");
     expect(names).toContain("weixin");
     expect(names).toContain("btw");
     expect(names).toContain("about");
     expect(countAdvancedCommands(true)).toBe(10);
-    expect(frame).toContain("48 commands");
+    expect(frame).toContain("49 commands");
     expect(frame).toContain("+ 10 advanced");
   });
 


### PR DESCRIPTION
## Summary

- restore app-managed wheel scrolling by default for CLI TUI terminals while keeping native mode for Apple Terminal, classic Windows console, and explicit `--no-mouse` / `mouseTracking:false` opt-outs
- add `/copy` for copying the latest assistant response, the whole chat (`/copy all`), or the last N serializable items through OSC 52 with the existing temp-file fallback
- decode modified SGR mouse wheel reports and update CLI docs/help text so they describe the implemented copy behavior

## Scope

This partially addresses #2260 for the CLI scrolling and copy problems. Image input is intentionally left out of this PR.

## Verification

- `npx biome check --write src/cli/commands/chat.tsx src/cli/ui/App.tsx src/cli/ui/copy-history.ts src/cli/ui/history-scroll-mode.ts src/cli/ui/mouse-mode.ts src/cli/ui/slash/commands.ts src/cli/ui/slash/handlers/basic.ts src/cli/ui/slash/types.ts src/cli/ui/stdin-reader.ts src/config.ts src/i18n/EN.ts src/i18n/JA.ts src/i18n/de.ts src/i18n/zh-CN.ts tests/chat-scroll-wheel.test.ts tests/copy-history.test.ts tests/slash.test.ts tests/stdin-reader.test.ts`
- `npm run typecheck`
- `npm test -- --run tests/copy-history.test.ts tests/slash.test.ts tests/chat-scroll-wheel.test.ts tests/stdin-reader.test.ts tests/clipboard.test.ts`
- `npm run build`
- `env -u PERPLEXITY_API_KEY HOME=/tmp/reasonix-empty-home-verify npm run verify`

Note: `npm run lint` reports an existing non-blocking warning in `src/cli/ui/PlanPanel.tsx` about a type-only React import; this PR does not touch that file.
