### PR TITLE
fix(mcp): sanitize bridged tool names to the API charset

### DIFF
--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -111,6 +111,7 @@ import {
   ImmutablePrefix,
   type LoopAbortOptions,
 } from "../../index.js";
+import { sanitizeRegisteredName } from "../../mcp/registry.js";
 import { type McpServerSpec, parseMcpSpec, specToRaw } from "../../mcp/spec.js";
 import {
   type PromptHistoryCursor,
@@ -1215,9 +1216,11 @@ function mcpToolsForSummary(
 ): McpToolInfo[] {
   if (!summary || !summary.report.tools.supported) return [];
   const prefix = summary.bridgeEnv.prefix ?? "";
+  // Best-effort display name. Mirrors the registry's sanitizer so the panel matches the
+  // dispatch name; it shows the base form and won't reflect a collision `_N` suffix.
   return summary.report.tools.items.map((tool) => ({
     name: tool.name,
-    registeredName: `${prefix}${tool.name}`,
+    registeredName: sanitizeRegisteredName(`${prefix}${tool.name}`),
     description: tool.description,
   }));
 }

--- a/src/cli/commands/mcp-runtime.ts
+++ b/src/cli/commands/mcp-runtime.ts
@@ -211,6 +211,13 @@ export function createMcpRuntime(ctx: RuntimeContext): McpRuntime {
             sampleSize: info.sampleSize,
           }),
       });
+      for (const r of bridge.renamed) {
+        sink({
+          kind: "warn",
+          name: label,
+          reason: `tool "${r.from}" exposed as "${r.to}" (API name charset)`,
+        });
+      }
       // Tools are registered — record the bridge NOW so the UI shows
       // "bridged" even if later non-critical steps (inspect, hot-add) fail.
       const ms = Date.now() - t0;

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -54,6 +54,8 @@ export interface BridgeResult {
   registeredNames: string[];
   /** Names the server listed but the bridge skipped (e.g. invalid schemas). */
   skipped: Array<{ name: string; reason: string }>;
+  /** Tools whose model-facing name was rewritten to satisfy the API charset / avoid a collision. */
+  renamed: Array<{ from: string; to: string }>;
 }
 
 /** Resolved bridge environment that `registerSingleMcpTool` needs. Stored on summaries so reconnect can append new tools later. */
@@ -72,11 +74,39 @@ export interface BridgeEnv {
   serverName?: string;
 }
 
+/** OpenAI-style function names (DeepSeek follows the same schema) must match this. A raw MCP
+ *  name like `unity/health` is rejected with a 400 before the loop runs, so we rewrite it. */
+const API_TOOL_NAME_MAX = 64;
+
+/** FNV-1a — deterministic, dependency-free; used only to keep over-length names unique. */
+function nameHash(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** Rewrite a tool name to the OpenAI/DeepSeek function-name charset `[a-zA-Z0-9_-]`, capped at
+ *  64 chars. This only affects the *model-facing* name; the bridge still calls the MCP server
+ *  with the original name (see `registerSingleMcpTool`), so no reverse mapping is needed. */
+export function sanitizeRegisteredName(raw: string): string {
+  const cleaned = raw.replace(/[^a-zA-Z0-9_-]/g, "_");
+  if (cleaned.length <= API_TOOL_NAME_MAX) return cleaned;
+  const suffix = `_${nameHash(raw).toString(36)}`;
+  return `${cleaned.slice(0, API_TOOL_NAME_MAX - suffix.length)}${suffix}`;
+}
+
 /** Register one MCP tool's bridged closure into the registry. Returns the registered name (or "" if skipped). */
 export function registerSingleMcpTool(mcpTool: McpTool, env: BridgeEnv): string {
   const stableTool = canonicalizeMcpToolForCache(mcpTool);
   if (!stableTool.name) return "";
-  const registeredName = `${env.prefix}${stableTool.name}`;
+  const base = sanitizeRegisteredName(`${env.prefix}${stableTool.name}`);
+  let registeredName = base;
+  for (let n = 2; env.registry.has(registeredName); n++) {
+    registeredName = `${base}_${n}`;
+  }
   env.registry.register({
     name: registeredName,
     description: stableTool.description ?? "",
@@ -169,7 +199,7 @@ export async function bridgeMcpTools(
   const registry = opts.registry ?? new ToolRegistry({ autoFlatten: opts.autoFlatten });
   const prefix = opts.namePrefix ?? "";
   const maxResultChars = opts.maxResultChars ?? DEFAULT_MAX_RESULT_CHARS;
-  const result: BridgeResult = { registry, registeredNames: [], skipped: [] };
+  const result: BridgeResult = { registry, registeredNames: [], skipped: [], renamed: [] };
 
   const serverName = opts.serverName ?? prefix.replace(/_$/, "") ?? "anon";
   const tracker = opts.onSlow
@@ -200,8 +230,14 @@ export async function bridgeMcpTools(
       result.skipped.push({ name: "?", reason: "empty tool name" });
       continue;
     }
+    const original = `${prefix}${mcpTool.name}`;
     const registeredName = registerSingleMcpTool(mcpTool, env);
-    if (registeredName) result.registeredNames.push(registeredName);
+    if (registeredName) {
+      result.registeredNames.push(registeredName);
+      if (registeredName !== original) {
+        result.renamed.push({ from: original, to: registeredName });
+      }
+    }
   }
   return { ...result, env };
 }

--- a/tests/chat-mcp-startup-summary.test.ts
+++ b/tests/chat-mcp-startup-summary.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => {
   const closeMock = vi.fn(async () => undefined);
   const bridgeMcpToolsMock = vi.fn(async (_client: unknown, opts: any) => ({
     registeredNames: [],
+    renamed: [],
     env: {
       registry: opts.registry,
       host: opts.host,
@@ -173,6 +174,7 @@ async function captureStartupState(opts?: {
     if (opts?.bridgeError) throw opts.bridgeError;
     return {
       registeredNames: [],
+      renamed: [],
       env: {
         registry: bridgeOpts.registry,
         host: bridgeOpts.host,

--- a/tests/mcp-registered-name-sanitize.test.ts
+++ b/tests/mcp-registered-name-sanitize.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { McpClient } from "../src/mcp/client.js";
+import { bridgeMcpTools, sanitizeRegisteredName } from "../src/mcp/registry.js";
+import type { ListToolsResult } from "../src/mcp/types.js";
+
+const API_TOOL_NAME = /^[a-zA-Z0-9_-]{1,64}$/;
+
+function client(tools: ListToolsResult["tools"], onCall?: (name: string) => void): McpClient {
+  return {
+    listTools: async () => ({ tools }),
+    callTool: async (name: string) => {
+      onCall?.(name);
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  } as unknown as McpClient;
+}
+
+describe("MCP registered-name sanitization", () => {
+  it("rewrites '/' to an API-safe name and records the rename", async () => {
+    const bridged = await bridgeMcpTools(
+      client([{ name: "unity/health", inputSchema: { type: "object" } }]),
+    );
+
+    expect(bridged.registeredNames).toEqual(["unity_health"]);
+    expect(bridged.renamed).toEqual([{ from: "unity/health", to: "unity_health" }]);
+  });
+
+  it("dispatches to the original server endpoint, not the sanitized name", async () => {
+    let calledWith: string | undefined;
+    const bridged = await bridgeMcpTools(
+      client([{ name: "unity/health", inputSchema: { type: "object" } }], (n) => {
+        calledWith = n;
+      }),
+    );
+
+    await bridged.registry.dispatch("unity_health", "{}");
+    expect(calledWith).toBe("unity/health");
+  });
+
+  it("auto-suffixes a colliding sanitized name (deterministic via shared registry)", async () => {
+    const first = await bridgeMcpTools(client([{ name: "a_b", inputSchema: { type: "object" } }]));
+    const second = await bridgeMcpTools(
+      client([{ name: "a/b", inputSchema: { type: "object" } }]),
+      { registry: first.registry },
+    );
+
+    expect(first.registeredNames).toEqual(["a_b"]);
+    expect(second.registeredNames).toEqual(["a_b_2"]);
+    expect(second.renamed).toEqual([{ from: "a/b", to: "a_b_2" }]);
+    expect(first.registry.has("a_b")).toBe(true);
+    expect(first.registry.has("a_b_2")).toBe(true);
+  });
+
+  it("caps an over-length name at 64 chars while staying in the API charset", async () => {
+    const longName = "x".repeat(70);
+    const bridged = await bridgeMcpTools(
+      client([{ name: longName, inputSchema: { type: "object" } }]),
+    );
+
+    const [registered] = bridged.registeredNames;
+    expect(registered).toBeDefined();
+    expect(registered!.length).toBeLessThanOrEqual(64);
+    expect(registered).toMatch(API_TOOL_NAME);
+    expect(bridged.renamed).toHaveLength(1);
+  });
+
+  it("keeps every registered MCP name within the API charset", async () => {
+    const bridged = await bridgeMcpTools(
+      client([
+        { name: "unity/changes/apply", inputSchema: { type: "object" } },
+        { name: "unity/project/info", inputSchema: { type: "object" } },
+        { name: "read_file", inputSchema: { type: "object" } },
+      ]),
+    );
+
+    for (const name of bridged.registeredNames) {
+      expect(name).toMatch(API_TOOL_NAME);
+    }
+  });
+
+  it("leaves an already-valid name untouched and out of renamed", async () => {
+    const bridged = await bridgeMcpTools(
+      client([{ name: "read_file", inputSchema: { type: "object" } }]),
+    );
+
+    expect(bridged.registeredNames).toEqual(["read_file"]);
+    expect(bridged.renamed).toEqual([]);
+  });
+
+  it("sanitizeRegisteredName replaces only out-of-charset characters", () => {
+    expect(sanitizeRegisteredName("unity/health")).toBe("unity_health");
+    expect(sanitizeRegisteredName("a.b c:d")).toBe("a_b_c_d");
+    expect(sanitizeRegisteredName("already-valid_NAME-9")).toBe("already-valid_NAME-9");
+  });
+});

--- a/tests/mcp-runtime-failures.test.ts
+++ b/tests/mcp-runtime-failures.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => {
   const closeMock = vi.fn(async () => undefined);
   const bridgeMcpToolsMock = vi.fn(async (_client: unknown, opts: any) => ({
     registeredNames: [],
+    renamed: [],
     env: {
       registry: opts.registry,
       host: opts.host,

--- a/tests/mcp-tui-survival.test.ts
+++ b/tests/mcp-tui-survival.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => {
     opts.registry.register({ name: "mcp_fs_write", fn: () => "ok", description: "write" });
     return {
       registeredNames: ["mcp_fs_read", "mcp_fs_write"],
+      renamed: [],
       env: {
         registry: opts.registry,
         host: opts.host,


### PR DESCRIPTION
## What

Sanitizes bridged MCP tool names to the OpenAI/DeepSeek function-name charset (`[a-zA-Z0-9_-]`, 64-char cap) at the single registration chokepoint in `registerSingleMcpTool`. The bridge closure still dispatches to the server with the **original** name, so no reverse mapping is needed. Sanitized names that collide get a numeric suffix and a startup warning.

## Why

MCP servers whose tools are named with characters outside the API charset — e.g. `unity/health`, `unity/changes/apply` from a Unity MCP bridge — were sent to the DeepSeek API verbatim and rejected with a 400 before the agent loop could run, making the entire server unusable.

The bridge already separates the model-facing/registered name from the server-side name (the dispatch closure captures the original `stableTool.name`), so the fix only needs to make the registered name API-safe; dispatch is untouched.

Verified end-to-end against a live Unity MCP (streamable HTTP): tools bridge with rename notices (`unity/health` → `unity_health`), the model calls the sanitized name, and Unity receives the original endpoint.

## How to verify

- `npm run verify` (lint + typecheck + tests + comment-policy gate) — passes locally.
- New `tests/mcp-registered-name-sanitize.test.ts` covers: `/` sanitized, **dispatch hits the original endpoint, not the sanitized name** (the key regression guard), collision auto-suffix, charset/length invariant, and no-op for already-valid names.

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time