### PR TITLE
feat: extract test-detection and auto-test runner from #2244

### DIFF
--- a/src/goal/auto-test.ts
+++ b/src/goal/auto-test.ts
@@ -1,0 +1,124 @@
+import { spawn } from "node:child_process";
+import { performance } from "node:perf_hooks";
+import { detectTestCommand } from "./test-detection.js";
+import { type AutoTestResult, DEFAULT_GOAL_TEST_TIMEOUT_MS } from "./types.js";
+import type { DetectedTestCommand, VerificationCounts } from "./types.js";
+
+export interface RunGoalAutoTestOptions {
+  timeoutMs?: number;
+  command?: DetectedTestCommand | null;
+  maxOutputChars?: number;
+}
+
+export async function runGoalAutoTest(
+  rootDir: string,
+  opts: RunGoalAutoTestOptions = {},
+): Promise<AutoTestResult> {
+  const started = performance.now();
+  const command = opts.command === undefined ? detectTestCommand(rootDir) : opts.command;
+  if (!command) {
+    return {
+      status: "skipped",
+      durationMs: Math.round(performance.now() - started),
+      outputTail: "",
+      counts: {},
+      reason: "no supported test command detected",
+    };
+  }
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_GOAL_TEST_TIMEOUT_MS;
+  const maxOutputChars = opts.maxOutputChars ?? 24_000;
+  let output = "";
+  let timedOut = false;
+
+  return await new Promise<AutoTestResult>((resolve) => {
+    const child = spawn(command.command, command.args, {
+      cwd: rootDir,
+      env: process.env,
+      shell: process.platform === "win32",
+    });
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+    }, timeoutMs);
+
+    const append = (chunk: Buffer | string) => {
+      output += chunk.toString();
+      if (output.length > maxOutputChars) output = output.slice(output.length - maxOutputChars);
+    };
+
+    child.stdout?.on("data", append);
+    child.stderr?.on("data", append);
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      const outputTail = err.message;
+      resolve({
+        status: "failed",
+        command,
+        exitCode: null,
+        signal: null,
+        timedOut,
+        durationMs: Math.round(performance.now() - started),
+        outputTail,
+        counts: parseVerificationCounts(outputTail),
+        reason: err.message,
+      });
+    });
+    child.on("close", (exitCode, signal) => {
+      clearTimeout(timer);
+      const outputTail = tailLines(output, 40);
+      resolve({
+        status: !timedOut && exitCode === 0 ? "passed" : "failed",
+        command,
+        exitCode,
+        signal,
+        timedOut,
+        durationMs: Math.round(performance.now() - started),
+        outputTail,
+        counts: parseVerificationCounts(output),
+      });
+    });
+  });
+}
+
+export function parseVerificationCounts(output: string): VerificationCounts {
+  const passed = lastNumberBefore(output, /\b(\d+)\s+passed\b/gi);
+  const failed = lastNumberBefore(output, /\b(\d+)\s+failed\b/gi);
+  return {
+    ...(passed !== undefined ? { passed } : {}),
+    ...(failed !== undefined ? { failed } : {}),
+  };
+}
+
+export function formatAutoTestResult(result: AutoTestResult): string {
+  if (result.status === "skipped") {
+    return ["Tests:", `- Verification skipped: ${result.reason ?? "not detected"}`].join("\n");
+  }
+  const command = result.command?.display ?? "test command";
+  const status = result.status === "passed" ? "passed" : "failed";
+  const lines = [
+    "Tests:",
+    `${result.status === "passed" ? "✓" : "✗"} ${command} (${status}, ${result.durationMs}ms)`,
+  ];
+  if (result.counts.passed !== undefined) lines.push(`✓ ${result.counts.passed} passed`);
+  if (result.counts.failed !== undefined) lines.push(`✗ ${result.counts.failed} failed`);
+  if (result.timedOut) lines.push(`timeout: ${command}`);
+  if (result.status === "failed" && result.outputTail.trim()) {
+    lines.push("", "Output tail:", result.outputTail.trim());
+  }
+  return lines.join("\n");
+}
+
+function lastNumberBefore(output: string, pattern: RegExp): number | undefined {
+  let value: number | undefined;
+  for (const match of output.matchAll(pattern)) {
+    const n = Number.parseInt(match[1] ?? "", 10);
+    if (Number.isFinite(n)) value = n;
+  }
+  return value;
+}
+
+function tailLines(output: string, maxLines: number): string {
+  const lines = output.replace(/\r\n/g, "\n").split("\n");
+  return lines.slice(-maxLines).join("\n").trim();
+}

--- a/src/goal/test-detection.ts
+++ b/src/goal/test-detection.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { DetectedTestCommand } from "./types.js";
+
+export function detectTestCommand(rootDir: string): DetectedTestCommand | null {
+  const node = detectNodeTestCommand(rootDir);
+  if (node) return node;
+  if (existsSync(join(rootDir, "pytest.ini")) || hasPytestInPyproject(rootDir)) {
+    return {
+      kind: "python",
+      command: "pytest",
+      args: [],
+      display: "pytest",
+      reason: "pytest configuration detected",
+    };
+  }
+  if (existsSync(join(rootDir, "go.mod"))) {
+    return {
+      kind: "go",
+      command: "go",
+      args: ["test", "./..."],
+      display: "go test ./...",
+      reason: "go.mod detected",
+    };
+  }
+  if (existsSync(join(rootDir, "Cargo.toml"))) {
+    return {
+      kind: "rust",
+      command: "cargo",
+      args: ["test"],
+      display: "cargo test",
+      reason: "Cargo.toml detected",
+    };
+  }
+  return null;
+}
+
+function detectNodeTestCommand(rootDir: string): DetectedTestCommand | null {
+  const packagePath = join(rootDir, "package.json");
+  if (!existsSync(packagePath)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(packagePath, "utf8")) as {
+      scripts?: Record<string, unknown>;
+      packageManager?: unknown;
+    };
+    const script = raw.scripts?.test;
+    if (typeof script !== "string" || !script.trim() || isDefaultNpmNoTest(script)) return null;
+    const usePnpm =
+      existsSync(join(rootDir, "pnpm-lock.yaml")) ||
+      (typeof raw.packageManager === "string" && raw.packageManager.startsWith("pnpm@"));
+    return {
+      kind: "node",
+      command: usePnpm ? "pnpm" : "npm",
+      args: ["test"],
+      display: usePnpm ? "pnpm test" : "npm test",
+      reason: "package.json test script detected",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function isDefaultNpmNoTest(script: string): boolean {
+  return /no test specified/i.test(script) && /exit\s+1/.test(script);
+}
+
+function hasPytestInPyproject(rootDir: string): boolean {
+  for (const name of ["pyproject.toml", "setup.cfg"]) {
+    const path = join(rootDir, name);
+    if (!existsSync(path)) continue;
+    try {
+      const body = readFileSync(path, "utf8");
+      if (/\bpytest\b|\[tool\.pytest/i.test(body)) return true;
+    } catch {
+      /* ignore unreadable config */
+    }
+  }
+  return false;
+}

--- a/src/goal/types.ts
+++ b/src/goal/types.ts
@@ -1,0 +1,28 @@
+export const DEFAULT_GOAL_TEST_TIMEOUT_MS = 120_000;
+
+export type TestProjectKind = "node" | "python" | "go" | "rust";
+
+export interface DetectedTestCommand {
+  kind: TestProjectKind;
+  command: string;
+  args: string[];
+  display: string;
+  reason: string;
+}
+
+export interface VerificationCounts {
+  passed?: number;
+  failed?: number;
+}
+
+export interface AutoTestResult {
+  status: "passed" | "failed" | "skipped";
+  command?: DetectedTestCommand;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+  timedOut?: boolean;
+  durationMs: number;
+  outputTail: string;
+  counts: VerificationCounts;
+  reason?: string;
+}

--- a/tests/auto-test.test.ts
+++ b/tests/auto-test.test.ts
@@ -1,0 +1,233 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  formatAutoTestResult,
+  parseVerificationCounts,
+  runGoalAutoTest,
+} from "../src/goal/auto-test.js";
+import { detectTestCommand } from "../src/goal/test-detection.js";
+
+function writeNodeTestScript(rootDir: string, script: string): void {
+  writeFileSync(
+    join(rootDir, "package.json"),
+    JSON.stringify({ scripts: { test: script } }),
+    "utf8",
+  );
+}
+
+describe("test-detection", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-test-detection-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("detects npm test command by default", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run" } }),
+      "utf8",
+    );
+    writeFileSync(join(dir, "package-lock.json"), "{}", "utf8");
+    expect(detectTestCommand(dir)?.display).toBe("npm test");
+  });
+
+  it("detects pnpm test command when pnpm-lock.yaml exists", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run" } }),
+      "utf8",
+    );
+    writeFileSync(join(dir, "pnpm-lock.yaml"), "", "utf8");
+    expect(detectTestCommand(dir)?.display).toBe("pnpm test");
+  });
+
+  it("detects pnpm when packageManager field starts with pnpm@", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({
+        scripts: { test: "vitest run" },
+        packageManager: "pnpm@9.0.0",
+      }),
+      "utf8",
+    );
+    expect(detectTestCommand(dir)?.display).toBe("pnpm test");
+  });
+
+  it("ignores default npm no-test script", () => {
+    writeFileSync(
+      join(dir, "package.json"),
+      JSON.stringify({ scripts: { test: 'echo "Error: no test specified" && exit 1' } }),
+      "utf8",
+    );
+    expect(detectTestCommand(dir)).toBeNull();
+  });
+
+  it("detects pytest when pytest.ini exists", () => {
+    writeFileSync(join(dir, "pytest.ini"), "[pytest]\n", "utf8");
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("python");
+    expect(cmd?.display).toBe("pytest");
+  });
+
+  it("detects pytest when pyproject.toml contains pytest config", () => {
+    writeFileSync(
+      join(dir, "pyproject.toml"),
+      '[tool.pytest.ini_options]\nminversion = "6.0"\n',
+      "utf8",
+    );
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("python");
+    expect(cmd?.display).toBe("pytest");
+  });
+
+  it("detects go test when go.mod exists", () => {
+    writeFileSync(join(dir, "go.mod"), "module example.com/test\n", "utf8");
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("go");
+    expect(cmd?.display).toBe("go test ./...");
+  });
+
+  it("detects cargo test when Cargo.toml exists", () => {
+    writeFileSync(join(dir, "Cargo.toml"), '[package]\nname = "test"\n', "utf8");
+    const cmd = detectTestCommand(dir);
+    expect(cmd?.kind).toBe("rust");
+    expect(cmd?.display).toBe("cargo test");
+  });
+
+  it("returns null for empty directory", () => {
+    expect(detectTestCommand(dir)).toBeNull();
+  });
+});
+
+describe("auto-test runner", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "reasonix-auto-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("returns skipped when no test command detected", async () => {
+    const result = await runGoalAutoTest(dir);
+    expect(result.status).toBe("skipped");
+    expect(result.reason).toContain("no supported test command detected");
+  });
+
+  it("returns passed for successful test command", async () => {
+    const scriptPath = join(dir, "test-pass.js");
+    writeFileSync(scriptPath, 'console.log("1 passed");\n', "utf8");
+    writeNodeTestScript(dir, `node ${scriptPath}`);
+    const result = await runGoalAutoTest(dir, { timeoutMs: 10_000 });
+    expect(result.status).toBe("passed");
+    expect(result.command?.display).toBe("npm test");
+    expect(result.counts.passed).toBe(1);
+  });
+
+  it("returns failed for failing test command", async () => {
+    const scriptPath = join(dir, "test-fail.js");
+    writeFileSync(scriptPath, 'console.log("1 failed");\nprocess.exit(1);\n', "utf8");
+    writeNodeTestScript(dir, `node ${scriptPath}`);
+    const result = await runGoalAutoTest(dir, { timeoutMs: 10_000 });
+    expect(result.status).toBe("failed");
+    expect(result.counts.failed).toBe(1);
+  });
+
+  it("respects custom command override", async () => {
+    const scriptPath = join(dir, "pass.js");
+    writeFileSync(scriptPath, "process.exit(0);\n", "utf8");
+    const result = await runGoalAutoTest(dir, {
+      command: {
+        kind: "node",
+        command: "node",
+        args: [scriptPath],
+        display: "custom test",
+        reason: "override",
+      },
+      timeoutMs: 10_000,
+    });
+    expect(result.status).toBe("passed");
+    expect(result.command?.display).toBe("custom test");
+  });
+});
+
+describe("parseVerificationCounts", () => {
+  it("extracts passed and failed counts", () => {
+    expect(parseVerificationCounts("5 passed, 2 failed")).toEqual({ passed: 5, failed: 2 });
+  });
+
+  it("extracts only passed", () => {
+    expect(parseVerificationCounts("10 passed")).toEqual({ passed: 10 });
+  });
+
+  it("extracts only failed", () => {
+    expect(parseVerificationCounts("3 failed")).toEqual({ failed: 3 });
+  });
+
+  it("returns empty object for no matches", () => {
+    expect(parseVerificationCounts("no tests run")).toEqual({});
+  });
+
+  it("takes the last match when multiple exist", () => {
+    expect(parseVerificationCounts("5 passed\nre-run: 10 passed")).toEqual({ passed: 10 });
+  });
+});
+
+describe("formatAutoTestResult", () => {
+  it("formats skipped result", () => {
+    const formatted = formatAutoTestResult({
+      status: "skipped",
+      durationMs: 0,
+      outputTail: "",
+      counts: {},
+      reason: "no supported test command detected",
+    });
+    expect(formatted).toContain("Verification skipped");
+  });
+
+  it("formats passed result with counts", () => {
+    const formatted = formatAutoTestResult({
+      status: "passed",
+      command: {
+        kind: "node",
+        command: "npm",
+        args: ["test"],
+        display: "npm test",
+        reason: "test",
+      },
+      durationMs: 1234,
+      outputTail: "",
+      counts: { passed: 5 },
+    });
+    expect(formatted).toContain("✓ npm test (passed, 1234ms)");
+    expect(formatted).toContain("✓ 5 passed");
+  });
+
+  it("formats failed result with output tail", () => {
+    const formatted = formatAutoTestResult({
+      status: "failed",
+      command: {
+        kind: "node",
+        command: "npm",
+        args: ["test"],
+        display: "npm test",
+        reason: "test",
+      },
+      durationMs: 500,
+      outputTail: "Error: test failed",
+      counts: { failed: 2 },
+    });
+    expect(formatted).toContain("✗ npm test (failed, 500ms)");
+    expect(formatted).toContain("✗ 2 failed");
+    expect(formatted).toContain("Error: test failed");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract the reusable test-detection and auto-test runner modules from PR #2244, as requested by the maintainer.
- These modules are useful for any verification flow and don't depend on the /goal retry loop.

## Changes
- `src/goal/test-detection.ts`: Auto-detect test commands (npm/pnpm/pytest/go/cargo) based on project files
- `src/goal/auto-test.ts`: Run tests with timeout, output capture, and result parsing
- `src/goal/types.ts`: Shared types for test detection and auto-test results
- `tests/auto-test.test.ts`: Comprehensive tests for both modules (21 tests)

## Verification
- `npm test -- tests/auto-test.test.ts` — 21 tests passed
- `npm run lint` — no new lint errors (pre-existing PlanPanel.tsx warning only)
- Full test suite: 315 test files, 4056 passed, 15 skipped

## Context
As discussed in #2244, the /goal retry loop was rejected due to the project's "cheapness" positioning, but the test-detection and auto-test modules were identified as independently useful. This PR extracts just those components.

Closes #2198