### PR TITLE
feat(shell): expand leading ~ and reject unsupported shell expansion …

### DIFF
--- a/src/tools/shell.ts
+++ b/src/tools/shell.ts
@@ -11,11 +11,13 @@ import {
   type RunCommandResult,
   runCommand,
 } from "./shell/exec.js";
-import { isCommandAllowed } from "./shell/parse.js";
+import { detectUnsupportedExpansion, isCommandAllowed } from "./shell/parse.js";
 
 export {
   BUILTIN_ALLOWLIST,
   detectShellOperator,
+  detectUnsupportedExpansion,
+  expandTilde,
   hasSensitivePathArgs,
   isAllowed,
   isCommandAllowed,
@@ -48,6 +50,19 @@ export interface ShellToolsOptions {
   /** Fired after `run_background` / `stop_job` mutate the registry — used by the desktop popover for near-real-time updates without polling. */
   onJobsChanged?: () => void;
   sensitivePaths?: { prefixes?: readonly string[]; patterns?: readonly string[] };
+}
+
+/** Issue #2105 — message for a command that relies on shell expansion this tool can't do.
+ *  Turns a silent literal-passthrough into an actionable error telling the model what to substitute. */
+export function unsupportedExpansionError(
+  toolName: string,
+  d: { kind: "env" | "cmdsub"; sample: string },
+): string {
+  const what =
+    d.kind === "cmdsub"
+      ? `\`${d.sample}\` is shell command substitution`
+      : `\`${d.sample}\` is a shell variable`;
+  return `${toolName}: ${what}, but this tool runs WITHOUT a shell — it is not expanded and would reach the program literally (a silent mismatch, not an error). Substitute a concrete value: an absolute path in place of $VAR, or run the inner command yourself in place of $(…)/backticks. Single-quote it to pass the text literally. Note: a leading ~ IS expanded to the home directory.`;
 }
 
 /** Error thrown by `run_command` when the command isn't allowlisted. */
@@ -87,7 +102,7 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
   registry.register({
     name: "run_command",
     description:
-      'Run a shell command in the project root; returns combined stdout+stderr. Allowlisted read-only / test / lint / typecheck commands run immediately; mutating / network / install commands gate on user confirmation.\n\nDO NOT use run_command for file operations — use write_file, edit_file, multi_edit, copy_file, move_file, or delete_file instead. Shell utilities (echo, cp, sed, cat, tee, perl, python -c, etc.) bypass validation, lack rollback, and will trigger user confirmation gates that waste turns.\n\nNo real shell — argv parsed natively for cross-platform parity:\n• Supported: chains `|`/`||`/`&&`/`;` (each segment allowlist-checked) and file redirects `>`/`>>`/`<`/`2>`/`2>>`/`2>&1`/`&>`.\n• Rejected: background `&`, heredoc `<<`, `$(…)`, subshells, `$VAR` expansion, glob expansion. Quote operator chars as literals (`grep "a|b" file`).\n• `cd` is rejected in chains. By default, run generated scripts from the directory where the script was written; do not assume an input/data directory is the cwd. Pass input/data paths as arguments unless the command truly depends on that cwd. For package tools, use `npm --prefix <dir>`, `git -C <dir>`, `cargo -C <dir>`.\n• Filter at source — `grep -c` / `wc -l` / narrower paths over unbounded dumps.',
+      "Run a shell command in the project root; returns combined stdout+stderr. Allowlisted read-only / test / lint / typecheck commands run immediately; mutating / network / install commands gate on user confirmation.\n\nDO NOT use run_command for file operations — use write_file, edit_file, multi_edit, copy_file, move_file, or delete_file instead. Shell utilities (echo, cp, sed, cat, tee, perl, python -c, etc.) bypass validation, lack rollback, and will trigger user confirmation gates that waste turns.\n\nNo real shell — argv parsed natively for cross-platform parity:\n• Supported: chains `|`/`||`/`&&`/`;` (each segment allowlist-checked) and file redirects `>`/`>>`/`<`/`2>`/`2>>`/`2>&1`/`&>`. A leading `~` IS expanded to the home directory.\n• No expansion: `$VAR`/`${VAR}`/`$(…)`/backticks are rejected with an error — pass a concrete value. Globs (`*`) pass through literally (not shell-expanded): quote them or rely on the tool's own matching like `grep --include`/`find -name`. Background `&`, heredoc `<<`, subshells unsupported.\n• `cd` is rejected in chains. By default, run generated scripts from the directory where the script was written; do not assume an input/data directory is the cwd. Pass input/data paths as arguments unless the command truly depends on that cwd. For package tools, use `npm --prefix <dir>`, `git -C <dir>`, `cargo -C <dir>`.\n• Filter at source — `grep -c` / `wc -l` / narrower paths over unbounded dumps.",
     // Plan-mode gate: allow allowlisted commands through (git status,
     // cargo check, ls, grep …) so the model can actually investigate
     // during planning. Anything that would otherwise trigger a
@@ -116,6 +131,8 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     fn: async (args: { command: string; timeoutSec?: number }, ctx) => {
       const cmd = args.command.trim();
       if (!cmd) throw new Error("run_command: empty command");
+      const expansion = detectUnsupportedExpansion(cmd);
+      if (expansion) throw new Error(unsupportedExpansionError("run_command", expansion));
       const effectiveTimeout = Math.max(1, Math.min(600, args.timeoutSec ?? timeoutSec));
       if (
         !isAllowAll() &&
@@ -174,6 +191,8 @@ export function registerShellTools(registry: ToolRegistry, opts: ShellToolsOptio
     fn: async (args: { command: string; cwd?: string; waitSec?: number }, ctx) => {
       const cmd = args.command.trim();
       if (!cmd) throw new Error("run_background: empty command");
+      const expansion = detectUnsupportedExpansion(cmd);
+      if (expansion) throw new Error(unsupportedExpansionError("run_background", expansion));
       const cwd = resolveCwdInsideRoot(rootDir, args.cwd);
       if (
         !isAllowAll() &&

--- a/src/tools/shell/exec.ts
+++ b/src/tools/shell/exec.ts
@@ -2,7 +2,7 @@ import { type ChildProcess, type SpawnOptions, spawn, spawnSync } from "node:chi
 import { existsSync, statSync } from "node:fs";
 import * as pathMod from "node:path";
 import { parseCommandChain, runChain } from "../shell-chain.js";
-import { tokenizeCommand } from "./parse.js";
+import { expandTilde, tokenizeCommand } from "./parse.js";
 
 export const DEFAULT_TIMEOUT_SEC = 60;
 export const DEFAULT_MAX_OUTPUT_CHARS = 32_000;
@@ -306,13 +306,16 @@ function defaultIsFile(full: string): boolean {
   }
 }
 
-/** Windows workarounds: PATHEXT lookup + CVE-2024-27980 prohibition on direct `.cmd`/`.bat` spawn. */
+/** Final argv → spawn normalization: leading-`~` expansion (all platforms, issue #2105) +
+ *  Windows PATHEXT lookup + CVE-2024-27980 prohibition on direct `.cmd`/`.bat` spawn. The single
+ *  chokepoint shared by run_command (single + chains) and run_background, so `~` is expanded once. */
 export function prepareSpawn(
   argv: readonly string[],
   opts: ResolveExecutableOptions = {},
 ): { bin: string; args: string[]; spawnOverrides: SpawnOptions } {
-  const head = argv[0] ?? "";
-  const tail = argv.slice(1);
+  const expanded = argv.map(expandTilde);
+  const head = expanded[0] ?? "";
+  const tail = expanded.slice(1);
   const platform = opts.platform ?? process.platform;
   const resolved = resolveExecutable(head, opts);
 

--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -155,6 +155,72 @@ export function detectShellOperator(cmd: string): string | null {
   return check();
 }
 
+/** Expand a leading `~` / `~/` token to the home dir at exec (issue #2105). The allowlist already
+ *  canonicalizes `~` via `homedir()` for its checks, so this adds no bypass — it just makes a vetted
+ *  `~/…` path work instead of reaching the process literally. `~user` and a mid-token `~` are left as-is. */
+export function expandTilde(token: string): string {
+  if (token === "~") return homedir();
+  if (token.startsWith("~/") || token.startsWith("~\\")) {
+    return pathMod.join(homedir(), token.slice(2));
+  }
+  return token;
+}
+
+/** `$…`/backtick at index `i` that a real shell would expand. Returns null for a lone `$` (e.g. `$`, `$5`, `$?`). */
+function expansionAt(cmd: string, i: number): { kind: "env" | "cmdsub"; sample: string } | null {
+  const ch = cmd[i]!;
+  if (ch === "`") return { kind: "cmdsub", sample: "`…`" };
+  if (ch !== "$") return null;
+  const next = cmd[i + 1];
+  if (next === "(") return { kind: "cmdsub", sample: "$(…)" };
+  if (next === "{") {
+    const end = cmd.indexOf("}", i + 2);
+    return { kind: "env", sample: end > i ? cmd.slice(i, end + 1) : "${…}" };
+  }
+  if (next !== undefined && /[A-Za-z_]/.test(next)) {
+    let j = i + 1;
+    while (j < cmd.length && /[A-Za-z0-9_]/.test(cmd[j]!)) j++;
+    return { kind: "env", sample: cmd.slice(i, j) };
+  }
+  return null;
+}
+
+/** Issue #2105 — env-var / command-substitution / backticks never expand without a shell, so a
+ *  command like `cat $DIR/x` reaches the process verbatim and "silently produces wrong results".
+ *  Flag those so the caller can error; globs (`*`) are left for the program to match. Quote-aware. */
+export function detectUnsupportedExpansion(
+  cmd: string,
+): { kind: "env" | "cmdsub"; sample: string } | null {
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < cmd.length; i++) {
+    const ch = cmd[i]!;
+    if (quote === "'") {
+      if (ch === "'") quote = null;
+      continue;
+    }
+    if (quote === '"') {
+      if (isDqEscape(ch, cmd[i + 1])) {
+        i++;
+        continue;
+      }
+      if (ch === '"') {
+        quote = null;
+        continue;
+      }
+      const hit = expansionAt(cmd, i);
+      if (hit) return hit;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    const hit = expansionAt(cmd, i);
+    if (hit) return hit;
+  }
+  return null;
+}
+
 /** Per-prefix demotion: an otherwise-allowlisted match falls back to the confirm gate when one of these tokens appears in the tail. Issue #257: `git branch -D` skipped review. Each token also matches its `--flag=value` form. */
 const RISKY_ARGS: Readonly<Record<string, ReadonlyArray<string>>> = {
   // Branch / remote mutation

--- a/tests/shell-expansion.test.ts
+++ b/tests/shell-expansion.test.ts
@@ -1,0 +1,140 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { type ConfirmationChoice, PauseGate } from "../src/core/pause-gate.js";
+import { ToolRegistry } from "../src/tools.js";
+import {
+  detectUnsupportedExpansion,
+  expandTilde,
+  prepareSpawn,
+  registerShellTools,
+} from "../src/tools/shell.js";
+
+/** Records the gate call and denies — lets us assert whether the gate was reached at all. */
+class SpyGate extends PauseGate {
+  lastCall: Parameters<PauseGate["ask"]>[0] | null = null;
+  override ask = ((opts: Parameters<PauseGate["ask"]>[0]) => {
+    this.lastCall = opts;
+    return Promise.resolve({ type: "deny" } as ConfirmationChoice);
+  }) as PauseGate["ask"];
+}
+
+// Issue #2105 — detect shell expansion the no-shell executor can't perform.
+describe("detectUnsupportedExpansion", () => {
+  it("flags an unquoted env var", () => {
+    expect(detectUnsupportedExpansion("ls $PROJECT_DIR/src")).toEqual({
+      kind: "env",
+      sample: "$PROJECT_DIR",
+    });
+  });
+
+  it("flags ${BRACED} env vars and reports the braced sample", () => {
+    expect(detectUnsupportedExpansion("cat ${HOME}/.config")).toEqual({
+      kind: "env",
+      sample: "${HOME}",
+    });
+  });
+
+  it("flags command substitution — both $(…) and backticks", () => {
+    expect(detectUnsupportedExpansion("echo $(date)")).toEqual({ kind: "cmdsub", sample: "$(…)" });
+    expect(detectUnsupportedExpansion("echo `date`")).toEqual({ kind: "cmdsub", sample: "`…`" });
+  });
+
+  it("does NOT flag globs — the program may self-match, so they pass through literally", () => {
+    expect(detectUnsupportedExpansion("ls *.ts")).toBeNull();
+    expect(detectUnsupportedExpansion("grep --include=*.ts foo src")).toBeNull();
+    expect(detectUnsupportedExpansion("find . -name *.ts")).toBeNull();
+  });
+
+  it("flags $VAR even inside double quotes (a shell would expand it there)", () => {
+    expect(detectUnsupportedExpansion('echo "$HOME"')).toEqual({ kind: "env", sample: "$HOME" });
+  });
+
+  it("does NOT flag single-quoted spans (fully literal)", () => {
+    expect(detectUnsupportedExpansion("grep '$foo' file")).toBeNull();
+    expect(detectUnsupportedExpansion("awk '{print $1}' f")).toBeNull();
+    expect(detectUnsupportedExpansion("find . -name '*.ts'")).toBeNull();
+  });
+
+  it("does NOT flag a glob inside double quotes (literal there)", () => {
+    expect(detectUnsupportedExpansion('find . -name "*.ts"')).toBeNull();
+  });
+
+  it("does NOT flag a leading ~ (prepareSpawn expands it at exec)", () => {
+    expect(detectUnsupportedExpansion("cat ~/notes.txt")).toBeNull();
+  });
+
+  it("does NOT flag a lone $ or a `?` in a URL (avoids false positives)", () => {
+    expect(detectUnsupportedExpansion("echo costs 5$")).toBeNull();
+    expect(detectUnsupportedExpansion("curl http://x/y?z=1")).toBeNull();
+  });
+
+  it("returns null for ordinary allowlisted commands and chains/redirects", () => {
+    expect(detectUnsupportedExpansion("git status")).toBeNull();
+    expect(detectUnsupportedExpansion("grep -c TODO src | wc -l")).toBeNull();
+    expect(detectUnsupportedExpansion("npm test > out.log 2>&1")).toBeNull();
+  });
+});
+
+// Issue #2105 — a leading ~ is expanded at exec via prepareSpawn.
+describe("expandTilde / prepareSpawn ~ expansion", () => {
+  it("expandTilde resolves ~ and ~/… but leaves ~user and mid-token ~ alone", () => {
+    expect(expandTilde("~")).toBe(homedir());
+    expect(expandTilde("~/notes.txt")).toBe(join(homedir(), "notes.txt"));
+    expect(expandTilde("~bob/x")).toBe("~bob/x");
+    expect(expandTilde("a~b")).toBe("a~b");
+  });
+
+  it("prepareSpawn expands a leading ~ in arguments", () => {
+    const out = prepareSpawn(["cat", "~/notes.txt"], { platform: "linux" });
+    expect(out.bin).toBe("cat");
+    expect(out.args).toEqual([join(homedir(), "notes.txt")]);
+  });
+
+  it("prepareSpawn expands ~ in the executable position too", () => {
+    const out = prepareSpawn(["~/bin/tool", "arg"], { platform: "linux" });
+    expect(out.bin).toBe(join(homedir(), "bin/tool"));
+    expect(out.args).toEqual(["arg"]);
+  });
+
+  it("prepareSpawn leaves non-~ argv untouched", () => {
+    const out = prepareSpawn(["npm", "install"], { platform: "linux" });
+    expect(out.bin).toBe("npm");
+    expect(out.args).toEqual(["install"]);
+  });
+});
+
+describe("run_command — unsupported expansion gate (issue #2105)", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "reasonix-exp-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("errors on $VAR before consulting the confirmation gate", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp });
+    const spy = new SpyGate();
+    const out = await registry.dispatch(
+      "run_command",
+      JSON.stringify({ command: "ls $PROJECT_DIR/src" }),
+      { confirmationGate: spy },
+    );
+    expect(out).toMatch(/without a shell/i);
+    expect(out).toContain("$PROJECT_DIR");
+    // Short-circuited before the gate — no pointless confirmation prompt.
+    expect(spy.lastCall).toBeNull();
+  });
+
+  it("does NOT reject a glob — it passes through to the program (self-matching tools work)", async () => {
+    const registry = new ToolRegistry();
+    registerShellTools(registry, { rootDir: tmp, allowAll: true });
+    const out = await registry.dispatch("run_command", JSON.stringify({ command: "ls *.ts" }));
+    // ls receives the literal `*.ts` and reports its own exit status — not our expansion error.
+    expect(out).not.toMatch(/without a shell/i);
+    expect(out).toMatch(/\[exit/);
+  });
+});


### PR DESCRIPTION
## What

`run_command` / `run_background` run with `shell: false` and literal, tokenized argv — by design, since the per-segment allowlist and sensitive-path gating depend on argv being literal. This adds two improvements without weakening that model: (1) a leading `~` / `~/` is now expanded to the home directory at exec time in `prepareSpawn` — the single chokepoint shared by single commands, chain segments and `run_background`; (2) `$VAR` / `${VAR}` / `$(…)` / backticks are now rejected with an actionable error (before the confirmation gate) instead of being passed through literally. Globs (`*`) are deliberately left untouched — many tools self-match them (`grep --include`, `find -name`, `rg -g`, test runners), so they keep working.

## Why

Fixes esengine/reasonix#2105. The tool already documents `$VAR` / `$(…)` / globs as rejected, but the implementation silently passed them through literally, so natural-looking commands (`cat ~/x`, `ls $DIR`, `echo $(date)`) produced wrong results with no error and were hard to debug. Expanding `~` is safe because the allowlist layer **already** canonicalizes `~` via `homedir()` for its sensitive-path and workspace-escape checks, so exec-time expansion adds no new bypass — it just makes an already-vetted `~/…` path work. `$VAR` and glob expansion are intentionally NOT added: they could slip a sensitive or out-of-workspace path past those literal-token checks (`cat $SECRET_PATH`, `cat *.env`).

## How to verify

- `npx vitest run tests/shell-expansion.test.ts tests/shell-tools.test.ts tests/shell-chain.test.ts tests/shell-redirects.test.ts tests/comment-policy.test.ts`
- `npx biome check src tests` and `npx tsc --noEmit`
- Manual: `cat ~/somefile` reads the home file; `ls $HOME` and `echo $(date)` return a clear error (text: runs WITHOUT a shell) pointing at the fix; `grep --include=*.ts foo .` still runs (the glob passes through literally).

## Checklist

- [x] lint + typecheck + shell suites + comment-policy gate pass locally (the full `npm run verify` is not runnable in this sandbox — dashboard build / desktop deps / commit-signing are environment-only and unrelated to this change)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history; blocks of 3 lines or fewer)
- [x] No edits to `CHANGELOG.md`