### PR TITLE
fix(desktop): keep plan approvals outside virtual list

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -2499,6 +2499,13 @@ function TabRuntime({
     void navigator.clipboard.writeText(md);
     flashToast(t("app.toast.copiedMd"));
   }, [state.messages, flashToast]);
+  const hasPendingApprovals =
+    state.pendingPlans.length > 0 ||
+    state.pendingCheckpoints.length > 0 ||
+    state.pendingRevisions.length > 0 ||
+    state.pendingConfirms.length > 0 ||
+    state.pendingPathAccess.length > 0 ||
+    state.pendingChoices.length > 0;
 
   return (
     <WorkspaceProvider
@@ -2631,7 +2638,7 @@ function TabRuntime({
                 ) : (
                   <Virtuoso
                     ref={virtuosoRef}
-                    style={{ height: "90%" }}
+                    style={{ height: "100%" }}
                     className="virtuoso-scroll"
                     totalCount={messageItems.length}
                     followOutput={"auto"}
@@ -2648,17 +2655,6 @@ function TabRuntime({
                           <ActivePlanTaskCard plan={state.activePlan!} />
                         </div>
                       ) : undefined,
-                      Footer: () => (
-                        <div className="thread-inner">
-                          {state.pendingPlans.map((p) => <PlanApprovalCard key={`pp-${p.id}`} p={p} onApprove={() => resolvePlan(p.id, { type: "approve" })} onRefine={() => resolvePlan(p.id, { type: "refine" })} onCancel={() => resolvePlan(p.id, { type: "cancel" })} />)}
-                          {state.pendingCheckpoints.map((c) => <CheckpointApprovalCard key={`cp-${c.id}`} c={c} onContinue={() => resolveCheckpoint(c.id, { type: "continue" })} onRevise={() => resolveCheckpoint(c.id, { type: "revise" })} onStop={() => resolveCheckpoint(c.id, { type: "stop" })} />)}
-                          {state.pendingRevisions.map((r) => <RevisionApprovalCard key={`rv-${r.id}`} r={r} onAccept={() => resolveRevision(r.id, { type: "accepted" })} onReject={() => resolveRevision(r.id, { type: "rejected" })} />)}
-                          {state.pendingConfirms.map((c) => <ConfirmApprovalCard key={`cc-${c.id}`} prompt={c.prompt} onAllow={() => resolveConfirm(c.id, { type: "run_once" })} onAlwaysAllow={(prefix) => resolveConfirm(c.id, { type: "always_allow", prefix })} onDeny={() => resolveConfirm(c.id, { type: "deny" })} />)}
-                          {state.pendingPathAccess.map((p) => <PathAccessApprovalCard key={`pa-${p.id}`} prompt={p.prompt} onAllow={() => resolvePathAccess(p.id, { type: "run_once" })} onAlwaysAllow={(prefix) => resolvePathAccess(p.id, { type: "always_allow", prefix })} onDeny={() => resolvePathAccess(p.id, { type: "deny" })} />)}
-                          {state.pendingChoices.map((c) => <ChoiceApprovalCard key={`ch-${c.id}`} c={c} onPick={(optionId) => resolveChoice(c.id, { type: "pick", optionId })} onCancel={() => resolveChoice(c.id, { type: "cancel" })} />)}
-                          {!state.ready ? <div style={{ padding: 12, color: "var(--muted)", fontFamily: "Geist Mono, monospace", fontSize: 11 }}>{t("app.connecting")}</div> : null}
-                        </div>
-                      ),
                     }}
                     itemContent={(index) => {
                       const m = state.messages[index]!;
@@ -2731,6 +2727,79 @@ function TabRuntime({
                   </button>
                 ) : null}
               </div>
+
+              {hasPendingApprovals || !state.ready ? (
+                <div className="thread-inner approval-dock">
+                  {state.pendingPlans.map((p) => (
+                    <PlanApprovalCard
+                      key={`pp-${p.id}`}
+                      p={p}
+                      onApprove={() => resolvePlan(p.id, { type: "approve" })}
+                      onRefine={(feedback) => resolvePlan(p.id, { type: "refine", feedback })}
+                      onCancel={(feedback) => resolvePlan(p.id, { type: "cancel", feedback })}
+                    />
+                  ))}
+                  {state.pendingCheckpoints.map((c) => (
+                    <CheckpointApprovalCard
+                      key={`cp-${c.id}`}
+                      c={c}
+                      onContinue={() => resolveCheckpoint(c.id, { type: "continue" })}
+                      onRevise={() => resolveCheckpoint(c.id, { type: "revise" })}
+                      onStop={() => resolveCheckpoint(c.id, { type: "stop" })}
+                    />
+                  ))}
+                  {state.pendingRevisions.map((r) => (
+                    <RevisionApprovalCard
+                      key={`rv-${r.id}`}
+                      r={r}
+                      onAccept={() => resolveRevision(r.id, { type: "accepted" })}
+                      onReject={() => resolveRevision(r.id, { type: "rejected" })}
+                    />
+                  ))}
+                  {state.pendingConfirms.map((c) => (
+                    <ConfirmApprovalCard
+                      key={`cc-${c.id}`}
+                      prompt={c.prompt}
+                      onAllow={() => resolveConfirm(c.id, { type: "run_once" })}
+                      onAlwaysAllow={(prefix) =>
+                        resolveConfirm(c.id, { type: "always_allow", prefix })
+                      }
+                      onDeny={() => resolveConfirm(c.id, { type: "deny" })}
+                    />
+                  ))}
+                  {state.pendingPathAccess.map((p) => (
+                    <PathAccessApprovalCard
+                      key={`pa-${p.id}`}
+                      prompt={p.prompt}
+                      onAllow={() => resolvePathAccess(p.id, { type: "run_once" })}
+                      onAlwaysAllow={(prefix) =>
+                        resolvePathAccess(p.id, { type: "always_allow", prefix })
+                      }
+                      onDeny={() => resolvePathAccess(p.id, { type: "deny" })}
+                    />
+                  ))}
+                  {state.pendingChoices.map((c) => (
+                    <ChoiceApprovalCard
+                      key={`ch-${c.id}`}
+                      c={c}
+                      onPick={(optionId) => resolveChoice(c.id, { type: "pick", optionId })}
+                      onCancel={() => resolveChoice(c.id, { type: "cancel" })}
+                    />
+                  ))}
+                  {!state.ready ? (
+                    <div
+                      style={{
+                        padding: 12,
+                        color: "var(--muted)",
+                        fontFamily: "Geist Mono, monospace",
+                        fontSize: 11,
+                      }}
+                    >
+                      {t("app.connecting")}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
 
               <Composer
                 draft={draft}

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -2187,6 +2187,14 @@ html:not([data-platform="macos"]) .shortcut kbd[data-key="mod"] {
   margin: 0 auto 28px;
   padding: 0 32px;
 }
+.approval-dock {
+  flex-shrink: 0;
+  width: 100%;
+  margin-bottom: 10px;
+}
+.approval-dock .approval + .approval {
+  margin-top: 8px;
+}
 .thread-inner--standalone {
   margin-top: 28px;
 }

--- a/desktop/src/ui/thread.test.tsx
+++ b/desktop/src/ui/thread.test.tsx
@@ -10,8 +10,12 @@ vi.mock("./cards", () => ({
   ToolCard: () => null,
   ReasoningCard: () => null,
 }));
+vi.mock("../Markdown", () => ({
+  Markdown: ({ source }: { source: string }) => <div>{source}</div>,
+}));
 
-import { ConfirmApprovalCard, PathAccessApprovalCard } from "./thread";
+import { t } from "../i18n";
+import { ConfirmApprovalCard, PathAccessApprovalCard, PlanApprovalCard } from "./thread";
 
 function makeShellPrompt(command: string): import("@reasonix/core-utils").ApprovalPrompt {
   return {
@@ -67,6 +71,70 @@ function makePathPrompt(
 }
 
 afterEach(cleanup);
+
+function makePendingPlan() {
+  return {
+    id: 7,
+    plan: "## Plan\n1. Update the approval UI",
+    summary: "Update plan approval",
+    steps: [{ id: "s1", title: "Patch approval UI", action: "edit_file" }],
+  };
+}
+
+describe("PlanApprovalCard — plan action buttons", () => {
+  it("approves the plan directly from the primary button", () => {
+    const onApprove = vi.fn();
+    render(
+      <PlanApprovalCard
+        p={makePendingPlan()}
+        onApprove={onApprove}
+        onRefine={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: t("thread.approve") }));
+
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends cancel feedback after entering feedback mode", () => {
+    const onCancel = vi.fn();
+    render(
+      <PlanApprovalCard
+        p={makePendingPlan()}
+        onApprove={() => {}}
+        onRefine={() => {}}
+        onCancel={onCancel}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: t("thread.cancel") }));
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "too risky" } });
+    fireEvent.click(screen.getByRole("button", { name: t("thread.sendFeedback") }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(onCancel).toHaveBeenCalledWith("too risky");
+  });
+
+  it("can refine without optional feedback", () => {
+    const onRefine = vi.fn();
+    render(
+      <PlanApprovalCard
+        p={makePendingPlan()}
+        onApprove={() => {}}
+        onRefine={onRefine}
+        onCancel={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: t("thread.refine") }));
+    fireEvent.click(screen.getByRole("button", { name: t("thread.skipFeedback") }));
+
+    expect(onRefine).toHaveBeenCalledTimes(1);
+    expect(onRefine.mock.calls[0]).toEqual([]);
+  });
+});
 
 describe("ConfirmApprovalCard — ApprovalPrompt rendering", () => {
   it("renders title, subtitle, and action buttons from prompt", () => {


### PR DESCRIPTION
## What

Keep desktop pending approvals outside the Virtuoso message list by restoring a stable approval dock below the virtualized thread. This covers plan approvals and the other approval card types, and restores cancel/refine feedback forwarding for plan approvals.

## Why

Fixes #2289. Plan approval cards were rendered through Virtuoso Footer after the split-pane hotfix, so list remeasurement/remounts could disturb hover/click handling in Windows WebView. Keeping approvals outside the virtual list gives the buttons a stable lifecycle while the message stream remains virtualized.

## How to verify

- `npm test -- desktop/src/ui/thread.test.tsx`
- `npm test -- tests/plan-confirm.test.tsx`
- `npm --prefix desktop run build`
- `npm test -- tests/loop-r1-reasoning.test.ts`
- `npm run verify`

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time