### PR TITLE
fix(desktop): recover from tiny context token overrides

### DIFF
--- a/desktop/src/App.test.ts
+++ b/desktop/src/App.test.ts
@@ -389,6 +389,25 @@ describe("Desktop App reducer — ApprovalPrompt integration", () => {
     expect(next.settings?.reasoningEffort).toBe("low");
     expect(next.settings?.editMode).toBe("auto");
   });
+
+  it("hydrates context token overrides from settings events", () => {
+    const next = reduce(initialState(), {
+      t: "incoming",
+      event: {
+        type: "$settings",
+        reasoningEffort: "high",
+        editMode: "review",
+        budgetUsd: null,
+        workspaceDir: "/workspace",
+        recentWorkspaces: [],
+        model: "deepseek-v4-pro",
+        contextTokens: { "deepseek-v4-pro": 1 },
+        version: "0.50.1",
+      },
+    });
+
+    expect(next.settings?.contextTokens).toEqual({ "deepseek-v4-pro": 1 });
+  });
 });
 
 describe("desktop thread layout", () => {

--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1047,6 +1047,7 @@ function applyIncomingRaw(state: State, ev: IncomingEvent): State {
           webSearchEndpoint: ev.webSearchEndpoint,
           webSearchApiKeys: ev.webSearchApiKeys,
           subagentModels: ev.subagentModels,
+          contextTokens: ev.contextTokens,
           showSystemEvents: ev.showSystemEvents,
           version: ev.version,
         },

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -368,6 +368,7 @@ export type SettingsEvent = {
     brave?: string;
   };
   subagentModels?: Record<string, "flash" | "pro">;
+  contextTokens?: Record<string, number>;
   showSystemEvents?: boolean;
   version: string;
 };

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -52,6 +52,8 @@ const PAGE_META: ReadonlyArray<{ id: PageId; icon: keyof typeof I }> = [
   { id: "shortcuts", icon: "cpu" },
 ];
 
+const MIN_CONTEXT_TOKENS = 1024;
+
 export function SettingsModal({
   settings,
   balance,
@@ -1094,18 +1096,18 @@ function PageModels({
             <input
               className="field mono"
               type="number"
-              min={1}
+              min={MIN_CONTEXT_TOKENS}
               value={settings.contextTokens?.[settings.model] ?? ""}
               onChange={(e) => {
                 const raw = e.target.value.trim();
-                const num = raw ? parseInt(raw, 10) : 0;
+                const num = raw ? Number.parseInt(raw, 10) : 0;
                 const next = { ...(settings.contextTokens ?? {}) };
-                if (num > 0 && Number.isFinite(num)) {
+                if (num >= MIN_CONTEXT_TOKENS && Number.isFinite(num)) {
                   next[settings.model] = num;
                 } else {
                   delete next[settings.model];
                 }
-                onSave({ contextTokens: Object.keys(next).length > 0 ? next : undefined });
+                onSave({ contextTokens: next });
               }}
               placeholder={t("settings.contextTokensPlaceholder")}
             />

--- a/src/config.ts
+++ b/src/config.ts
@@ -810,6 +810,8 @@ function isNonNegativeNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
+export const MIN_CONTEXT_TOKEN_OVERRIDE = 1024;
+
 export function loadPricingOverride(
   path: string = defaultConfigPath(),
 ): Record<string, PricingOverride> {
@@ -833,7 +835,11 @@ export function loadContextTokens(path: string = defaultConfigPath()): Record<st
   if (!isPlainObject(raw)) return {};
   const result: Record<string, number> = {};
   for (const [model, value] of Object.entries(raw)) {
-    if (typeof value === "number" && value > 0 && Number.isFinite(value)) {
+    if (
+      typeof value === "number" &&
+      value >= MIN_CONTEXT_TOKEN_OVERRIDE &&
+      Number.isFinite(value)
+    ) {
       result[model] = Math.floor(value);
     }
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1080,11 +1080,14 @@ describe("config", () => {
       expect(loadContextTokens(path)).toEqual({ mimo: 1_000_000, "qwen-72b": 131_072 });
     });
 
-    it("drops non-positive and non-finite values", () => {
+    it("drops implausibly small, non-positive, and non-finite values", () => {
       writeConfig(
         {
           contextTokens: {
             mimo: 1_000_000,
+            min: 1024,
+            tiny1: 1,
+            tiny2: 1023,
             bad1: -1,
             bad2: 0,
             bad3: Number.POSITIVE_INFINITY,
@@ -1093,7 +1096,7 @@ describe("config", () => {
         },
         path,
       );
-      expect(loadContextTokens(path)).toEqual({ mimo: 1_000_000 });
+      expect(loadContextTokens(path)).toEqual({ mimo: 1_000_000, min: 1024 });
     });
 
     it("floors fractional values", () => {


### PR DESCRIPTION
## Summary
- Ignore implausibly small context-window overrides so a persisted value like `1` cannot force every turn into the context guard.
- Hydrate desktop `contextTokens` from `` so the Settings UI reflects persisted overrides.
- Make the desktop context-window input clear invalid overrides by writing the updated map back, including `{}`.

## Root Cause
A persisted `contextTokens` override could be as small as `1`, and `loadContextTokens()` treated any positive finite number as valid. Desktop also received `contextTokens` from the backend but did not keep it in `state.settings`, so users could see an empty/auto field while the runtime continued reading the bad persisted override.

## Validation
- `npm test -- --run tests/config.test.ts desktop/src/App.test.ts tests/loop.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npx biome check src/config.ts tests/config.test.ts desktop/src/protocol.ts`
- `git diff --check`
- `npm run verify`

Fixes #2292