### PR TITLE
Refactor grid layout for responsive design

### DIFF
--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -352,7 +352,8 @@ button:disabled {
 .app {
   display: grid;
   grid-template-rows: 36px 36px 1fr 26px;
-  grid-template-columns: 244px 1fr 320px;
+  /* sidebar ≈ 17vw, ctx panel ≈ 23vw — scale with viewport but keep sane bounds */
+  grid-template-columns: clamp(180px, 17vw, 280px) 1fr clamp(240px, 23vw, 380px);
   grid-template-areas:
     "title  title   title"
     "tabs   tabs    tabs"
@@ -370,10 +371,10 @@ html[data-platform="macos"] .app {
 }
 
 .app[data-ctx-collapsed="true"] {
-  grid-template-columns: 244px 1fr 0;
+  grid-template-columns: clamp(180px, 17vw, 280px) 1fr 0;
 }
 .app[data-side-collapsed="true"] {
-  grid-template-columns: 0 1fr 320px;
+  grid-template-columns: 0 1fr clamp(240px, 23vw, 380px);
 }
 .app[data-ctx-collapsed="true"][data-side-collapsed="true"] {
   grid-template-columns: 0 1fr 0;
@@ -6972,6 +6973,36 @@ html[data-web="true"] .win-controls {
 }
 
 /* ════════════════════════════════════════════════════════════
+   NARROW DESKTOP: ≤ 860px
+   Collapse context panel, sidebar scales with viewport.
+   At ≤768px the mobile breakpoint below takes over.
+   ════════════════════════════════════════════════════════════ */
+@media (max-width: 860px) {
+  .app,
+  .app[data-ctx-collapsed="true"] {
+    grid-template-columns: clamp(160px, 23vw, 240px) 1fr;
+    grid-template-areas:
+      "title  title"
+      "tabs   tabs"
+      "side   main"
+      "status status";
+  }
+  .app[data-side-collapsed="true"],
+  .app[data-ctx-collapsed="true"][data-side-collapsed="true"] {
+    grid-template-columns: 0 1fr;
+    grid-template-areas:
+      "title  title"
+      "tabs   tabs"
+      "side   main"
+      "status status";
+  }
+
+  .app .ctx {
+    display: none !important;
+  }
+}
+
+/* ════════════════════════════════════════════════════════════
    MOBILE BREAKPOINT: ≤ 768px
    ════════════════════════════════════════════════════════════ */
 @media (max-width: 768px) {
@@ -7017,7 +7048,7 @@ html[data-web="true"] .win-controls {
   }
 
   /* Hide tabs bar (single tab on mobile) */
-  .app .tab-bar {
+  .app .tabbar {
     display: none;
   }
 
@@ -7041,7 +7072,7 @@ html[data-web="true"] .win-controls {
   }
 
   /* ── Context panel hidden on mobile (optional bottom sheet later) ── */
-  .app .context-panel {
+  .app .ctx {
     display: none !important;
   }
 


### PR DESCRIPTION
fix:优化style.css #2304

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What
在 dashboard/src/styles.css 中做了以下 4 处具体修改：
1. 布局列宽从固定 px 改为响应式 clamp()（第 355-356 行）
2. 同步更新折叠状态的列宽（第 374、377 行）
3. 新增窄桌面断点 ≤860px（第 6975-7003 行）
4. 修正 CSS 选择器类名（第 7051、7075 行）
<!-- One paragraph: what does this change? -->

## Why
1.原来侧边栏和上下文面板是固定像素宽度，在不同屏幕下要么太挤要么太宽。改成 clamp()后，列宽会随视口宽度按比例缩放，同时设定了最小/最大边界，兼顾不同显示器（笔记本到宽屏）。
2.原来的移动端断点是 ≤768px，但从 768px 到 860px 左右，三栏布局已经非常拥挤。这个新增断点在 860px 就提前收起上下文面板，只保留两栏，避免中间主区域被压缩得过窄。
<!-- Bug fix? Pre-existing issue? Linked discussion? -->

## How to verify
本地web页面非常丝滑
<!-- Steps the reviewer can run. `npm run verify` is assumed. -->

## Checklist

- [ ] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [ ] No `Co-Authored-By: Claude` trailer in commits
- [ ] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [ ] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
