### PR TITLE
feat(tui): require double Ctrl+C to quit, preventing accidental exits

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -556,6 +556,8 @@ function AppInner({
   // Esc handler only fires once per turn (repeated presses would yield
   // stacked warning events).
   const abortedThisTurn = useRef(false);
+  // Timestamp of the last Ctrl+C while idle — enables "press Ctrl+C again to quit".
+  const lastCtrlCAtRef = useRef<number | null>(null);
   const stashRef = useRef("");
   // Mirrors the live `busy` flag for /loop's timer (it has no React
   // closure handle, only refs). Skips the firing when a prior turn is
@@ -1785,7 +1787,7 @@ function AppInner({
       return;
     }
     if (key.ctrl && key.input === "c") {
-      handleTurnInterrupt("ctrl-c", {
+      const outcome = handleTurnInterrupt("ctrl-c", {
         turnActiveRef: submittingRef,
         abortedThisTurn,
         resetPendingModals,
@@ -1793,7 +1795,11 @@ function AppInner({
         stopLoop,
         loop,
         quitProcess,
+        lastCtrlCAt: lastCtrlCAtRef,
       });
+      if (outcome === "quit-armed") {
+        log.pushInfo(t("composer.ctrlCQuitHint"));
+      }
       return;
     }
     if (key.ctrl && key.input === "p" && !busy && (!modalOpen || pendingShortcuts)) {
@@ -1821,6 +1827,7 @@ function AppInner({
         stopLoop,
         loop,
         quitProcess,
+        lastCtrlCAt: lastCtrlCAtRef,
       });
       return;
     }

--- a/src/cli/ui/turn-interrupt.ts
+++ b/src/cli/ui/turn-interrupt.ts
@@ -1,5 +1,14 @@
 export type TurnInterruptKey = "escape" | "ctrl-c";
-export type TurnInterruptOutcome = "aborted" | "already-aborted" | "stopped-loop" | "idle" | "quit";
+export type TurnInterruptOutcome =
+  | "aborted"
+  | "already-aborted"
+  | "stopped-loop"
+  | "idle"
+  | "quit-armed"
+  | "quit";
+
+/** 1.5-second window for double-Ctrl+C confirmation. */
+const DOUBLE_PRESS_WINDOW_MS = 1500;
 
 export interface TurnInterruptController {
   turnActiveRef: { readonly current: boolean };
@@ -9,6 +18,8 @@ export interface TurnInterruptController {
   stopLoop: () => void;
   loop: { abort: () => void };
   quitProcess: () => void;
+  /** Timestamp of the last Ctrl+C press while idle; null if none or expired. */
+  lastCtrlCAt: { current: number | null };
 }
 
 export function handleTurnInterrupt(
@@ -21,6 +32,7 @@ export function handleTurnInterrupt(
     stopLoop,
     loop,
     quitProcess,
+    lastCtrlCAt,
   }: TurnInterruptController,
 ): TurnInterruptOutcome {
   if (turnActiveRef.current) {
@@ -38,8 +50,13 @@ export function handleTurnInterrupt(
   }
 
   if (key === "ctrl-c") {
-    quitProcess();
-    return "quit";
+    const now = Date.now();
+    if (lastCtrlCAt.current !== null && now - lastCtrlCAt.current < DOUBLE_PRESS_WINDOW_MS) {
+      quitProcess();
+      return "quit";
+    }
+    lastCtrlCAt.current = now;
+    return "quit-armed";
   }
 
   return "idle";

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1494,6 +1494,7 @@ export const EN: TranslationSchema = {
     hintAbort: "abort",
     hintQuit: "quit",
     abortedHint: "turn aborted by user \u00b7 esc again to clear \u00b7 \u23ce to ask a follow-up",
+    ctrlCQuitHint: "Press Ctrl+C again to quit",
     editorNoRawMode:
       "external editor unavailable \u2014 stdin doesn't support raw-mode toggling on this terminal",
     editorFailed: "external editor:",

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -1520,6 +1520,7 @@ export const JA: TranslationSchema = {
     hintQuit: "終了",
     abortedHint:
       "ユーザーによりターン中断 \u00b7 もう一度escでクリア \u00b7 \u23ce でフォローアップ",
+    ctrlCQuitHint: "もう一度 Ctrl+C で終了",
     editorNoRawMode:
       "外部エディタが利用できません \u2014 この端末ではstdinのraw-mode切替がサポートされていません",
     editorFailed: "外部エディタ:",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -1433,6 +1433,7 @@ export const de: TranslationSchema = {
     hintAbort: "abbrechen",
     hintQuit: "beenden",
     abortedHint: "Turn vom Benutzer abgebrochen · erneut Esc zum Leeren · ⏎ für eine Folgefrage",
+    ctrlCQuitHint: "Ctrl+C erneut drücken zum Beenden",
     editorNoRawMode:
       "Externer Editor nicht verfügbar — stdin unterstützt Raw-Mode-Umschaltung auf diesem Terminal nicht",
     editorFailed: "Externer Editor:",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -491,6 +491,7 @@ export interface TranslationSchema {
     hintAbort: string;
     hintQuit: string;
     abortedHint: string;
+    ctrlCQuitHint: string;
     editorNoRawMode: string;
     editorFailed: string;
     editorMissing: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1408,6 +1408,7 @@ export const zhCN: TranslationSchema = {
     hintAbort: "中止",
     hintQuit: "退出",
     abortedHint: "用户已中止本轮 · 再按 Esc 清除 · ⏎ 继续提问",
+    ctrlCQuitHint: "再按一次 Ctrl+C 退出",
     editorNoRawMode: "外部编辑器不可用 — 当前终端不支持 raw-mode 切换",
     editorFailed: "外部编辑器：",
     editorMissing:

--- a/tests/turn-interrupt.test.ts
+++ b/tests/turn-interrupt.test.ts
@@ -15,6 +15,7 @@ describe("handleTurnInterrupt", () => {
       stopLoop,
       loop: { abort },
       quitProcess,
+      lastCtrlCAt: { current: null as number | null },
     };
 
     expect(handleTurnInterrupt("ctrl-c", controller)).toBe("aborted");
@@ -25,25 +26,58 @@ describe("handleTurnInterrupt", () => {
     expect(quitProcess).not.toHaveBeenCalled();
   });
 
-  it("quits on Ctrl+C when no model turn is active", () => {
+  it("arms quit on first Ctrl+C when idle, quits on second press within window", () => {
     const resetPendingModals = vi.fn();
     const abort = vi.fn();
     const quitProcess = vi.fn();
+    const lastCtrlCAt = { current: null as number | null };
 
-    const outcome = handleTurnInterrupt("ctrl-c", {
+    const base = {
       turnActiveRef: { current: false },
       abortedThisTurn: { current: false },
       resetPendingModals,
-      isLoopActive: () => true,
+      isLoopActive: () => false,
       stopLoop: vi.fn(),
       loop: { abort },
       quitProcess,
-    });
+      lastCtrlCAt,
+    };
 
-    expect(outcome).toBe("quit");
+    // First press: armed, does NOT quit
+    expect(handleTurnInterrupt("ctrl-c", base)).toBe("quit-armed");
+    expect(quitProcess).not.toHaveBeenCalled();
+    expect(lastCtrlCAt.current).not.toBeNull();
+
+    // Second press within 1.5s window: quits
+    expect(handleTurnInterrupt("ctrl-c", base)).toBe("quit");
     expect(quitProcess).toHaveBeenCalledTimes(1);
     expect(resetPendingModals).not.toHaveBeenCalled();
     expect(abort).not.toHaveBeenCalled();
+  });
+
+  it("re-arms if second Ctrl+C arrives after the window expires", () => {
+    const quitProcess = vi.fn();
+    const lastCtrlCAt = { current: null as number | null };
+    const base = {
+      turnActiveRef: { current: false },
+      abortedThisTurn: { current: false },
+      resetPendingModals: vi.fn(),
+      isLoopActive: () => false,
+      stopLoop: vi.fn(),
+      loop: { abort: vi.fn() },
+      quitProcess,
+      lastCtrlCAt,
+    };
+
+    // First press: armed
+    expect(handleTurnInterrupt("ctrl-c", base)).toBe("quit-armed");
+
+    // Simulate window expiry
+    lastCtrlCAt.current = Date.now() - 2000;
+
+    // Press after window: re-arms instead of quitting
+    expect(handleTurnInterrupt("ctrl-c", base)).toBe("quit-armed");
+    expect(quitProcess).not.toHaveBeenCalled();
   });
 
   it("stops an idle auto-loop on Esc without aborting the next turn", () => {
@@ -60,6 +94,7 @@ describe("handleTurnInterrupt", () => {
       stopLoop,
       loop: { abort },
       quitProcess,
+      lastCtrlCAt: { current: null },
     });
 
     expect(outcome).toBe("stopped-loop");
@@ -82,6 +117,7 @@ describe("handleTurnInterrupt", () => {
       stopLoop: vi.fn(),
       loop: { abort },
       quitProcess,
+      lastCtrlCAt: { current: null },
     });
 
     expect(outcome).toBe("idle");


### PR DESCRIPTION
## Summary

A single Ctrl+C while idle now exits the process immediately, which can cause accidental quits. This PR adds a "press again to confirm" pattern with a 1.5-second window.

## Behavior

| State | First Ctrl+C | Second Ctrl+C (within 1.5s) |
|-------|-------------|----------------------------|
| Model running | Abort current turn (unchanged) | No-op (unchanged) |
| Idle | Show hint message, arm quit | Exit process |

Hint messages are localized:

| Locale | Message |
|--------|---------|
| EN | `Press Ctrl+C again to quit` |
| zh-CN | `再按一次 Ctrl+C 退出` |
| JA | `もう一度 Ctrl+C で終了` |
| de | `Ctrl+C erneut drücken zum Beenden` |

## Changes

- `src/cli/ui/turn-interrupt.ts` — Added `"quit-armed"` outcome, `lastCtrlCAt` ref, 1.5s `DOUBLE_PRESS_WINDOW_MS`
- `src/cli/ui/App.tsx` — Pass `lastCtrlCAtRef` to `handleTurnInterrupt`, show hint via `log.pushInfo()` on `"quit-armed"`
- `src/i18n/{EN,zh-CN,JA,de}.ts` — Added `composer.ctrlCQuitHint` translations
- `src/i18n/types.ts` — Added `ctrlCQuitHint: string` to `composer` schema
- `tests/turn-interrupt.test.ts` — Updated tests: double-press within window, re-arm after expiry, active turn unchanged

## Tests

- 5 test cases in `turn-interrupt.test.ts` covering all scenarios
- **Full suite:** 4042 passed, 0 failed (314 test files)
- **Build:** Clean, no TypeScript errors