### PR TITLE
Fix app scroll viewport height

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -4425,6 +4425,7 @@ function AppInner({
   // Suspend cosmetic animations during modal interactions and idle so
   // a quiescent TUI is byte-stable.
   const tickerSuspended = modalOpen || (!busy && !isStreaming);
+  const viewportHeight = historyScrollMode === "app" ? Math.max(1, stdout?.rows ?? 24) : undefined;
 
   if (!bootReady) return <BootSplash />;
 
@@ -4432,7 +4433,12 @@ function AppInner({
     <>
       <TickerProvider disabled={tickerSuspended}>
         <InflightProvider inflight={loop.inflight}>
-          <Box flexDirection="row" backgroundColor={SURFACE.bg}>
+          <Box
+            flexDirection="row"
+            backgroundColor={SURFACE.bg}
+            height={viewportHeight}
+            flexShrink={viewportHeight ? 0 : undefined}
+          >
             <Box
               flexDirection="column"
               flexGrow={planPanelOpen ? 0 : 1}


### PR DESCRIPTION
## Summary
- bound the TUI root height when app-managed history scrolling is active
- let CardStream compute a real viewport instead of expanding to content height
- fixes wheel scrolling in Ghostty where app scroll events were clamped because maxScroll stayed at zero

Fixes #2065

## Verification
- npm test -- tests/chat-scroll-wheel.test.ts tests/cardstream-architecture.test.tsx
- npm run typecheck
- pre-push npm run verify (build, lint, typecheck, full test suite)