### PR TITLE
chore(cache): localize /status cache-detail line + locale-independent tool sort

### DIFF
--- a/src/cli/ui/slash/handlers/observability.ts
+++ b/src/cli/ui/slash/handlers/observability.ts
@@ -64,11 +64,18 @@ const status: SlashHandler = (_args, loop, ctx) => {
         });
   const churn =
     summary.lastPrefixChangeReasons.length > 0
-      ? ` · churn ${summary.lastPrefixChangeReasons.join(",")}`
+      ? t("handlers.observability.statusCacheChurn", {
+          reasons: summary.lastPrefixChangeReasons.join(","),
+        })
       : "";
   const cacheDetailLine =
     summary.turns > 0
-      ? `cache detail: miss ${compactNum(summary.totalCacheMissTokens)} total · last ${compactNum(summary.lastCacheMissTokens)} · schemas ${compactNum(summary.lastToolSchemaTokens)}${churn}`
+      ? t("handlers.observability.statusCacheDetail", {
+          miss: compactNum(summary.totalCacheMissTokens),
+          last: compactNum(summary.lastCacheMissTokens),
+          schemas: compactNum(summary.lastToolSchemaTokens),
+          churn,
+        })
       : "";
 
   const budgetLine =

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -1224,6 +1224,8 @@ export const EN: TranslationSchema = {
       statusCtxNone: "  ctx     no turns yet",
       statusCost: "  cost    ${cost} · cache {bar} {pct}% · turns {turns}",
       statusCostCold: "  cost    ${cost} · turns {turns} (cache warming up)",
+      statusCacheDetail: "  cache   miss {miss} total · last {last} · schemas {schemas}{churn}",
+      statusCacheChurn: " · churn {reasons}",
       statusBudget: "  budget  ${spent} / ${cap} ({pct}%){tag}",
       statusSession: '  session "{name}" · {count} messages in log (resumed {resumed})',
       statusSessionEphemeral: "  session (ephemeral — no persistence)",

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -1152,6 +1152,8 @@ export const zhCN: TranslationSchema = {
       statusCtxNone: "  上下文  尚无轮次",
       statusCost: "  成本    ${cost} · 缓存 {bar} {pct}% · 轮次 {turns}",
       statusCostCold: "  成本    ${cost} · 轮次 {turns}（缓存预热中）",
+      statusCacheDetail: "  缓存    未命中 {miss} 累计 · 最近 {last} · schema {schemas}{churn}",
+      statusCacheChurn: " · 前缀变化 {reasons}",
       statusBudget: "  预算    ${spent} / ${cap}（{pct}%）{tag}",
       statusSession: '  会话    "{name}" · 日志中 {count} 条消息（恢复了 {resumed} 条）',
       statusSessionEphemeral: "  会话    （临时 — 无持久化）",

--- a/src/memory/runtime.ts
+++ b/src/memory/runtime.ts
@@ -28,9 +28,15 @@ function toolName(spec: ToolSpec): string {
 }
 
 export function sortToolSpecs(specs: readonly ToolSpec[]): ToolSpec[] {
+  // Locale-independent codepoint compare — localeCompare would let the host
+  // locale reshuffle the serialized tool prefix and reintroduce cache churn.
   return [...specs]
     .map((spec) => structuredClone(spec) as ToolSpec)
-    .sort((a, b) => toolName(a).localeCompare(toolName(b)));
+    .sort((a, b) => {
+      const an = toolName(a);
+      const bn = toolName(b);
+      return an < bn ? -1 : an > bn ? 1 : 0;
+    });
 }
 
 export class ImmutablePrefix {


### PR DESCRIPTION
Follow-up polish to the cache-efficiency guardrails merged in #2314. Two non-blocking nits surfaced during review.

## Changes

### 1. Localize the `/status` cache-detail line
`#2314` added a `cache detail: …` row to `/status` but built it as a hard-coded English string, unlike every other status row which goes through `t()`. Routed it through i18n:
- New keys `statusCacheDetail` / `statusCacheChurn` under `handlers.observability`.
- `EN` + `zh-CN` translated; `ja`/`de`/`ru` inherit `EN.handlers` exactly like the rest of their observability block (which is already English).
- Reformatted to the aligned `  cache   …` label style so it lines up with `  cost    …` / `  ctx     …`.

### 2. Locale-independent tool-spec sort
`sortToolSpecs` used `String.prototype.localeCompare`, which is locale-sensitive. Since the whole point of the sort is to make the serialized tool prefix byte-stable (so MCP reconnect/registration order can't churn the prompt cache), a locale-dependent comparator could itself reshuffle the order on a differently-configured host and reintroduce the churn it's meant to prevent. Switched to a stable codepoint compare.

No behavior change for ASCII tool names — all existing tool-order/fingerprint tests pass unchanged.

## Verification
- `tsc --noEmit`: clean (the unrelated pre-existing `qrcode` resolution error from #2246 is the only diagnostic; not touched here)
- `biome check`: clean on changed files
- Targeted suites pass: `cache-shape`, `mcp-reconnect-prefix-invariant`, `mcp-cache-canonicalization`, `tools`, `loop`, `slash`, `loop-slash`, `telemetry`, `context-manager-cache-aligned-fold`, plus i18n suites
- Runtime-verified the new keys resolve correctly across `EN`/`zh-CN`/`ja`/`de`/`ru`

🤖 Generated with [Claude Code](https://claude.com/claude-code)