### PR TITLE
fix: restore pending edits before apply

### DIFF
--- a/src/cli/ui/hooks/useCodeMode.ts
+++ b/src/cli/ui/hooks/useCodeMode.ts
@@ -10,7 +10,11 @@ import {
   applyEditBlocks,
   snapshotBeforeEdits,
 } from "../../../code/edit-blocks.js";
-import { clearPendingEdits, savePendingEdits } from "../../../code/pending-edits.js";
+import {
+  clearPendingEdits,
+  loadPendingEdits,
+  savePendingEdits,
+} from "../../../code/pending-edits.js";
 import { t } from "../../../i18n/index.js";
 import { formatEditResults, partitionEdits } from "../edit-history.js";
 
@@ -39,10 +43,20 @@ export interface UseCodeModeOptions {
 export function useCodeMode(opts: UseCodeModeOptions): UseCodeModeResult {
   const { codeMode, pendingEdits, currentRootDir, session, syncPendingCount, recordEdit } = opts;
 
+  const activePendingEdits = useCallback((): EditBlock[] => {
+    if (pendingEdits.current.length > 0) return pendingEdits.current;
+    const restored = loadPendingEdits(session ?? null);
+    if (restored && restored.length > 0) {
+      pendingEdits.current = restored;
+      syncPendingCount();
+    }
+    return pendingEdits.current;
+  }, [session, syncPendingCount, pendingEdits]);
+
   const codeApply = useCallback(
     (indices?: readonly number[]): string => {
       if (!codeMode) return t("app.editHistoryNoCodeMode");
-      const blocks = pendingEdits.current;
+      const blocks = activePendingEdits();
       if (blocks.length === 0) {
         return t("app.noPendingEdits");
       }
@@ -67,12 +81,20 @@ export function useCodeMode(opts: UseCodeModeOptions): UseCodeModeResult {
         remaining.length > 0 ? `\n${t("app.blocksStillPending", { count: remaining.length })}` : "";
       return formatEditResults(results) + tail;
     },
-    [codeMode, currentRootDir, session, syncPendingCount, recordEdit, pendingEdits],
+    [
+      codeMode,
+      currentRootDir,
+      session,
+      syncPendingCount,
+      recordEdit,
+      pendingEdits,
+      activePendingEdits,
+    ],
   );
 
   const codeDiscard = useCallback(
     (indices?: readonly number[]): string => {
-      const blocks = pendingEdits.current;
+      const blocks = activePendingEdits();
       if (blocks.length === 0) return t("app.noPendingDiscard");
       const useSubset = indices !== undefined && indices.length > 0;
       const { selected, remaining } = useSubset
@@ -91,7 +113,7 @@ export function useCodeMode(opts: UseCodeModeOptions): UseCodeModeResult {
           : t("app.nothingWritten");
       return t("app.discardedCount", { count: selected.length }) + tail;
     },
-    [session, syncPendingCount, pendingEdits],
+    [session, syncPendingCount, pendingEdits, activePendingEdits],
   );
 
   return { codeApply, codeDiscard };

--- a/tests/use-code-mode-pending-apply.test.tsx
+++ b/tests/use-code-mode-pending-apply.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { cleanup, render } from "@testing-library/react";
+import React, { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCodeMode } from "../src/cli/ui/hooks/useCodeMode.js";
+import type { EditBlock } from "../src/code/edit-blocks.js";
+import { pendingEditsPath, savePendingEdits } from "../src/code/pending-edits.js";
+
+function block(overrides: Partial<EditBlock> = {}): EditBlock {
+  return {
+    path: "demo.txt",
+    search: "before\n",
+    replace: "after\n",
+    offset: 0,
+    ...overrides,
+  };
+}
+
+describe("useCodeMode pending edit apply", () => {
+  let home: string;
+  let root: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "reasonix-pending-home-"));
+    root = mkdtempSync(join(tmpdir(), "reasonix-pending-root-"));
+    vi.stubEnv("USERPROFILE", home);
+    vi.stubEnv("HOME", home);
+    vi.spyOn(require("node:os"), "homedir").mockReturnValue(home);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    rmSync(home, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("loads a saved pending edit when /apply runs with an empty in-memory queue", () => {
+    const session = "code-demo";
+    writeFileSync(join(root, "demo.txt"), "before\n", "utf8");
+    savePendingEdits(session, [block()]);
+
+    let api: ReturnType<typeof useCodeMode> | undefined;
+    function Harness() {
+      const pendingEdits = useRef<EditBlock[]>([]);
+      api = useCodeMode({
+        codeMode: true,
+        pendingEdits,
+        currentRootDir: root,
+        session,
+        syncPendingCount: () => undefined,
+        recordEdit: () => undefined,
+      });
+      return null;
+    }
+
+    render(<Harness />);
+
+    const info = api!.codeApply();
+
+    expect(info).toContain("1/1 applied");
+    expect(readFileSync(join(root, "demo.txt"), "utf8")).toBe("after\n");
+    expect(existsSync(pendingEditsPath(session))).toBe(false);
+  });
+
+  it("loads a saved pending edit when /discard runs with an empty in-memory queue", () => {
+    const session = "code-demo-discard";
+    writeFileSync(join(root, "demo.txt"), "before\n", "utf8");
+    savePendingEdits(session, [block()]);
+
+    let api: ReturnType<typeof useCodeMode> | undefined;
+    function Harness() {
+      const pendingEdits = useRef<EditBlock[]>([]);
+      api = useCodeMode({
+        codeMode: true,
+        pendingEdits,
+        currentRootDir: root,
+        session,
+        syncPendingCount: () => undefined,
+        recordEdit: () => undefined,
+      });
+      return null;
+    }
+
+    render(<Harness />);
+
+    const info = api!.codeDiscard();
+
+    expect(info).toContain("discarded 1 pending");
+    expect(readFileSync(join(root, "demo.txt"), "utf8")).toBe("before\n");
+    expect(existsSync(pendingEditsPath(session))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Restore saved pending edit queues when `/apply` or `/discard` runs with an empty in-memory queue.
- Keep review-mode queued edits recoverable after a session restart or delayed mount hydration.

## Validation
- `npm test -- tests/use-code-mode-pending-apply.test.tsx tests/pending-edits.test.ts tests/slash.test.ts tests/review-edit-gate.test.ts`
- `npx biome check src/cli/ui/hooks/useCodeMode.ts tests/use-code-mode-pending-apply.test.tsx`
- `npm run typecheck`
- `npm run verify`

## Review Evidence
- Linked issue: Fixes #2256
- Screenshots: not applicable, no visual UI/layout change.
- Performance data: not applicable, no cache, token, or runtime performance behavior change.

Fixes #2256
