### PR TITLE
refactor(hooks): strip hardcoded audit subagent from TurnEnd, add @@INJECT protocol

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1714,10 +1714,8 @@ function AppInner({
   const quitProcess = useQuit(transcriptRef, { beforeQuit: fireSessionEndHook });
 
   const quitWithSessionEnd = useCallback(() => {
-    fireSessionEndHook()
-      .then(() => quitProcess())
-      .catch(() => quitProcess());
-  }, [fireSessionEndHook, quitProcess]);
+    quitProcess();
+  }, [quitProcess]);
 
   // Ctrl+D = standard TUI exit (matches the boot-banner hint). Always-on
   // — no modal / picker should swallow it.

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1690,12 +1690,39 @@ function AppInner({
   }, [session, loop, codeMode, syncPendingCount, log, pendingEdits, startupInfoHints, system]);
 
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
-  const quitProcess = useQuit(transcriptRef);
+  const sessionStartTimeRef = useRef(Date.now());
+
+  const fireSessionEndHook = useCallback(async () => {
+    if (hookList.some((h) => h.event === "SessionEnd")) {
+      try {
+        await runHooks({
+          hooks: hookList,
+          payload: {
+            event: "SessionEnd",
+            cwd: currentRootDir,
+            sessionName: session ?? undefined,
+            sessionDurationMs: Date.now() - sessionStartTimeRef.current,
+            totalCostUsd: summary.totalCostUsd,
+          },
+        });
+      } catch {
+        // SessionEnd must not block exit
+      }
+    }
+  }, [hookList, currentRootDir, session, summary.totalCostUsd]);
+
+  const quitProcess = useQuit(transcriptRef, { beforeQuit: fireSessionEndHook });
+
+  const quitWithSessionEnd = useCallback(() => {
+    fireSessionEndHook()
+      .then(() => quitProcess())
+      .catch(() => quitProcess());
+  }, [fireSessionEndHook, quitProcess]);
 
   // Ctrl+D = standard TUI exit (matches the boot-banner hint). Always-on
   // — no modal / picker should swallow it.
   useKeystroke((ev) => {
-    if (ev.ctrl && ev.input === "d") quitProcess();
+    if (ev.ctrl && ev.input === "d") quitWithSessionEnd();
   });
 
   // Ctrl+R = verbose toggle. ReasoningCard / ToolCard skip elision while on.
@@ -1792,7 +1819,7 @@ function AppInner({
         isLoopActive,
         stopLoop,
         loop,
-        quitProcess,
+        quitProcess: quitWithSessionEnd,
       });
       return;
     }
@@ -1820,7 +1847,7 @@ function AppInner({
         isLoopActive,
         stopLoop,
         loop,
-        quitProcess,
+        quitProcess: quitWithSessionEnd,
       });
       return;
     }
@@ -3222,7 +3249,7 @@ function AppInner({
           codeModeOn: !!codeMode,
           isLoopActive,
           stopLoop,
-          quitProcess,
+          quitProcess: quitWithSessionEnd,
           pushHistory,
           resetPendingModals,
           text,
@@ -3627,7 +3654,7 @@ function AppInner({
       codeShowEdit,
       codeUndo,
       currentRootDir,
-      quitProcess,
+      quitWithSessionEnd,
       hookList,
       loop,
       latestVersion,

--- a/src/cli/ui/hooks/useQuit.ts
+++ b/src/cli/ui/hooks/useQuit.ts
@@ -1,5 +1,5 @@
 import type { WriteStream } from "node:fs";
-import { type MutableRefObject, useCallback, useEffect } from "react";
+import { type MutableRefObject, useCallback, useEffect, useRef } from "react";
 import { stopAndSaveCpuProfile } from "../../cpu-prof.js";
 
 export interface UseQuitOptions {
@@ -11,7 +11,11 @@ export function useQuit(
   transcriptRef: MutableRefObject<WriteStream | null>,
   opts?: UseQuitOptions,
 ): () => void {
+  const quittingRef = useRef(false);
+
   const quitProcess = useCallback(() => {
+    if (quittingRef.current) return;
+    quittingRef.current = true;
     transcriptRef.current?.end();
     void (async () => {
       try {

--- a/src/cli/ui/hooks/useQuit.ts
+++ b/src/cli/ui/hooks/useQuit.ts
@@ -2,15 +2,27 @@ import type { WriteStream } from "node:fs";
 import { type MutableRefObject, useCallback, useEffect } from "react";
 import { stopAndSaveCpuProfile } from "../../cpu-prof.js";
 
+export interface UseQuitOptions {
+  beforeQuit?: () => Promise<void> | void;
+}
+
 /** Ctrl+C / SIGINT → flush transcript + (if profiling) save .cpuprofile, then `process.exit(0)`. We call `process.exit` directly rather than Ink's `exit()` because the singleton stdin reader keeps a `data` listener attached — `exit()` would unmount the React tree but leave the event loop alive and the terminal would hang. */
-export function useQuit(transcriptRef: MutableRefObject<WriteStream | null>): () => void {
+export function useQuit(
+  transcriptRef: MutableRefObject<WriteStream | null>,
+  opts?: UseQuitOptions,
+): () => void {
   const quitProcess = useCallback(() => {
     transcriptRef.current?.end();
     void (async () => {
+      try {
+        await opts?.beforeQuit?.();
+      } catch {
+        // beforeQuit must not block or crash the exit path
+      }
       await stopAndSaveCpuProfile();
       process.exit(0);
     })();
-  }, [transcriptRef]);
+  }, [transcriptRef, opts?.beforeQuit]);
 
   useEffect(() => {
     process.on("SIGINT", quitProcess);

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -156,7 +156,16 @@ export interface CheckpointRestoredEvent extends EventBase {
 export interface HookFiredEvent extends EventBase {
   type: "hook.fired";
   hookName: string;
-  phase: "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop";
+  phase:
+    | "SessionStart"
+    | "TurnStart"
+    | "PreToolUse"
+    | "PostToolUse"
+    | "UserPromptSubmit"
+    | "PreModelCall"
+    | "PostModelCall"
+    | "Stop"
+    | "SessionEnd";
   outcome: "ok" | "blocked" | "modified" | "error";
 }
 

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -164,6 +164,7 @@ export interface HookFiredEvent extends EventBase {
     | "UserPromptSubmit"
     | "PreModelCall"
     | "PostModelCall"
+    | "TurnEnd"
     | "Stop"
     | "SessionEnd";
   outcome: "ok" | "blocked" | "modified" | "error";

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -156,6 +156,7 @@ export interface CheckpointRestoredEvent extends EventBase {
 export interface HookFiredEvent extends EventBase {
   type: "hook.fired";
   hookName: string;
+  /** Must match HookEvent type in src/hooks.ts — keep in sync (V-TE-05). */
   phase:
     | "SessionStart"
     | "TurnStart"

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,25 +7,49 @@ import { join } from "node:path";
 import { projectHooksTrusted } from "./config.js";
 import { t } from "./i18n/index.js";
 
-export type HookEvent = "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop";
+export type HookEvent =
+  | "SessionStart"
+  | "TurnStart"
+  | "PreToolUse"
+  | "PostToolUse"
+  | "UserPromptSubmit"
+  | "PreModelCall"
+  | "PostModelCall"
+  | "Stop"
+  | "SessionEnd";
 
-/** All four events as a const array — drives slash listing + validation. */
+/** All nine events as a const array — drives slash listing + validation. */
 export const HOOK_EVENTS: readonly HookEvent[] = [
+  "SessionStart",
+  "TurnStart",
   "PreToolUse",
   "PostToolUse",
   "UserPromptSubmit",
+  "PreModelCall",
+  "PostModelCall",
   "Stop",
+  "SessionEnd",
 ] as const;
 
 /** Only the gating events can block the loop. */
-const BLOCKING_EVENTS: ReadonlySet<HookEvent> = new Set(["PreToolUse", "UserPromptSubmit"]);
+const BLOCKING_EVENTS: ReadonlySet<HookEvent> = new Set([
+  "PreToolUse",
+  "UserPromptSubmit",
+  "TurnStart",
+  "PreModelCall",
+]);
 
 /** Per-event default timeout. Tool/prompt hooks gate progress, so they're tight. */
 const DEFAULT_TIMEOUTS_MS: Record<HookEvent, number> = {
+  SessionStart: 10_000,
+  TurnStart: 5_000,
   PreToolUse: 5_000,
-  UserPromptSubmit: 5_000,
   PostToolUse: 30_000,
+  UserPromptSubmit: 5_000,
+  PreModelCall: 10_000,
+  PostModelCall: 30_000,
   Stop: 30_000,
+  SessionEnd: 10_000,
 };
 
 export type HookScope = "project" | "global";
@@ -176,6 +200,21 @@ export interface HookPayload {
   lastAssistantText?: string;
   last_assistant_message?: string;
   turn?: number;
+
+  sessionName?: string;
+  sessionDurationMs?: number;
+  totalCostUsd?: number;
+
+  modelMessages?: ReadonlyArray<{ role: string; content: string }>;
+  model?: string;
+
+  modelResponse?: { role: string; content: string; reasoning_content?: string };
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    cacheHitTokens: number;
+    cacheMissTokens: number;
+  };
 }
 
 /** Test seam — same shape as Node's spawn but returns a Promise of the raw outcome bits. */

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -34,7 +34,7 @@ export const HOOK_EVENTS: readonly HookEvent[] = [
 ] as const;
 
 /** Only the gating events can block the loop. */
-const BLOCKING_EVENTS: ReadonlySet<HookEvent> = new Set([
+export const BLOCKING_EVENTS: ReadonlySet<HookEvent> = new Set([
   "PreToolUse",
   "UserPromptSubmit",
   "TurnStart",
@@ -51,7 +51,9 @@ const DEFAULT_TIMEOUTS_MS: Record<HookEvent, number> = {
   UserPromptSubmit: 5_000,
   PreModelCall: 10_000,
   PostModelCall: 30_000,
-  TurnEnd: 30_000,
+  // 10s is enough for a lightweight audit check; 30s × 3-strike = 90s worst-case
+  // wasted wait if a hook misbehaves (V-TE-04).
+  TurnEnd: 10_000,
   Stop: 30_000,
   SessionEnd: 10_000,
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -15,10 +15,11 @@ export type HookEvent =
   | "UserPromptSubmit"
   | "PreModelCall"
   | "PostModelCall"
+  | "TurnEnd"
   | "Stop"
   | "SessionEnd";
 
-/** All nine events as a const array — drives slash listing + validation. */
+/** All ten events as a const array — drives slash listing + validation. */
 export const HOOK_EVENTS: readonly HookEvent[] = [
   "SessionStart",
   "TurnStart",
@@ -27,6 +28,7 @@ export const HOOK_EVENTS: readonly HookEvent[] = [
   "UserPromptSubmit",
   "PreModelCall",
   "PostModelCall",
+  "TurnEnd",
   "Stop",
   "SessionEnd",
 ] as const;
@@ -37,6 +39,7 @@ const BLOCKING_EVENTS: ReadonlySet<HookEvent> = new Set([
   "UserPromptSubmit",
   "TurnStart",
   "PreModelCall",
+  "TurnEnd",
 ]);
 
 /** Per-event default timeout. Tool/prompt hooks gate progress, so they're tight. */
@@ -48,6 +51,7 @@ const DEFAULT_TIMEOUTS_MS: Record<HookEvent, number> = {
   UserPromptSubmit: 5_000,
   PreModelCall: 10_000,
   PostModelCall: 30_000,
+  TurnEnd: 30_000,
   Stop: 30_000,
   SessionEnd: 10_000,
 };

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -321,6 +321,10 @@ function defaultSpawner(input: HookSpawnInput): Promise<HookSpawnResult> {
       });
     });
 
+    // EPIPE when child closes stdin before parent finishes writing —
+    // safe to ignore (close handler fires with the correct exit code).
+    child.stdin.on("error", () => {});
+
     try {
       child.stdin.write(input.stdin);
       child.stdin.end();

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -777,7 +777,13 @@ export class CacheFirstLoop {
             }
           }
         } catch (err) {
-          console.warn(`[hooks] SessionStart error: ${(err as Error).message}`);
+          const msg = (err as Error).message ?? String(err);
+          console.warn(`[hooks] SessionStart error: ${msg}`);
+          yield {
+            turn: this._turn,
+            role: "warning" as const,
+            content: `[hooks] SessionStart error: ${msg}`,
+          };
         }
       }
     }

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -944,7 +944,7 @@ export class CacheFirstLoop {
             yield {
               turn: this._turn,
               role: "warning" as const,
-              content: `[hook block] PreModelCall blocked ${this._preModelBlockCount} times — aborting turn to prevent infinite loop. ${reason}`,
+              content: `[hook block] PreModelCall blocked ${this._preModelBlockCount} consecutive times — aborting turn to prevent infinite loop. ${reason}`,
             };
             this._steerQueue.length = 0;
             return;
@@ -956,6 +956,7 @@ export class CacheFirstLoop {
           };
           continue;
         }
+        this._preModelBlockCount = 0;
         for (const o of preModelReport.outcomes) {
           if (o.decision !== "pass") {
             yield {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -69,6 +69,7 @@ import {
 import { SessionStats, type TurnStats } from "./telemetry/stats.js";
 import { ToolRegistry } from "./tools.js";
 import { ReadTracker } from "./tools/read-tracker.js";
+import { spawnSubagent } from "./tools/subagent.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 
 export const MID_TURN_STEER_WRAPPER =
@@ -81,6 +82,28 @@ function formatSteerUserMessage(content: string): string {
 function parseNeedsProEscalation(content: string): boolean {
   return /^\s*<<<NEEDS_PRO(?::\s*[^>\n]{1,150})?>>>/.test(content);
 }
+
+const AUDIT_SUBAGENT_SYSTEM_PROMPT = `You are a code quality audit agent. Your job is to review AI assistant responses and provide specific, actionable feedback.
+
+Rules:
+- DO NOT modify any files or execute commands — you are an auditor only
+- Your output will be injected as user feedback to the main agent
+- Review the response for completeness, correctness, and safety
+- Check for logic errors, security vulnerabilities, or missing edge cases
+- Provide specific modification suggestions with file paths when applicable
+- Format your feedback as concise, actionable items
+- Keep your output under 500 characters
+- If no issues found, output "PASS: <brief reason>"
+- Be direct and constructive — the main agent needs precise guidance to self-correct`;
+
+const AUDIT_SUBAGENT_READ_ONLY_TOOLS = [
+  "read_file",
+  "search_content",
+  "glob",
+  "list_directory",
+  "search_files",
+  "find_in_code",
+] as const;
 
 export {
   fixToolCallPairing,
@@ -1256,8 +1279,15 @@ export class CacheFirstLoop {
             yield {
               turn: this._turn,
               role: "warning" as const,
-              content: `[hook gate] TurnEnd: ${reason}`,
+              content: `[hook gate] TurnEnd rejected assistant_final — ${reason}`,
             };
+            const auditFeedback = await this.runTurnEndAudit(assistantContent, reason);
+            this.appendAndPersist({
+              role: "user" as const,
+              content:
+                auditFeedback ??
+                `[TurnEnd gate] The previous response was rejected. Reason: ${reason}. Please address the feedback and respond differently.`,
+            });
             this._steerQueue.push(`[TurnEnd hook blocked] ${reason}`);
             continue;
           }
@@ -1332,6 +1362,11 @@ export class CacheFirstLoop {
         return;
       }
 
+      // Successful tool dispatch means the model did useful work between
+      // consecutive TurnEnd blocks — reset counter to measure truly
+      // consecutive blocks only (V-TE-03).
+      this._turnEndBlockCount = 0;
+
       yield* dispatchToolCallsChunked(repairedCalls, {
         turn: this._turn,
         signal,
@@ -1347,6 +1382,36 @@ export class CacheFirstLoop {
     // loop via return statements when it produces no more tool calls,
     // when the context guard fires, when an abort fires, or when a fatal
     // error escapes the inner try blocks.
+  }
+
+  private async runTurnEndAudit(assistantContent: string, reason: string): Promise<string | null> {
+    if (this._turnEndBlockCount >= 2) return null;
+    if (!assistantContent.trim()) return null;
+    if (this._turnAbort.signal.aborted) return null;
+
+    try {
+      const timeoutSignal = AbortSignal.timeout(20_000);
+      const auditSignal = AbortSignal.any
+        ? AbortSignal.any([timeoutSignal, this._turnAbort.signal])
+        : timeoutSignal;
+      const result = await spawnSubagent({
+        client: this.client,
+        parentRegistry: this.tools,
+        system: AUDIT_SUBAGENT_SYSTEM_PROMPT,
+        task: `Review the following AI response that was rejected by the TurnEnd gate.\n\nRejection reason: ${reason}\n\nAI response:\n${assistantContent.slice(0, 4000)}\n\nProvide specific feedback on what needs to be fixed.`,
+        maxResultChars: 2000,
+        parentSignal: auditSignal,
+        allowedTools: AUDIT_SUBAGENT_READ_ONLY_TOOLS,
+      });
+
+      if (result.success && result.output.trim()) {
+        return `[Audit Agent Report]\n${result.output.trim()}`;
+      }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[TurnEnd audit] subagent failed, falling back to static message: ${msg}`);
+    }
+    return null;
   }
 
   private summaryContext(): ForceSummaryContext {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -215,6 +215,7 @@ export class CacheFirstLoop {
   private _turnSelfCorrected = false;
   private _foldedThisTurn = false;
   private _preModelBlockCount = 0;
+  private _turnEndBlockCount = 0;
   private context!: ContextManager;
 
   /** Subscribe API so UI hooks can derive `running` from finally-guaranteed insertions. */
@@ -766,10 +767,15 @@ export class CacheFirstLoop {
       }
     }
 
+    // A fresh user turn is a new intent — don't let StormBreaker's
+    // old sliding window of (name, args) signatures keep blocking
+    // calls that are now legitimately on-task. The window repopulates
+    // naturally as this turn's tool calls flow through.
     this.repair.resetStorm();
     this._turnSelfCorrected = false;
     this._foldedThisTurn = false;
     this._preModelBlockCount = 0;
+    this._turnEndBlockCount = 0;
     // Fresh controller for this turn: the prior step's signal has
     // already fired (or stayed clean); either way we don't want its
     // state to bleed into the new turn.
@@ -1221,6 +1227,51 @@ export class CacheFirstLoop {
           }
           return;
         }
+
+        if (this.hooks.some((h) => h.event === "TurnEnd")) {
+          const turnEndReport = await runHooks({
+            hooks: this.hooks,
+            payload: {
+              event: "TurnEnd",
+              cwd: this.hookCwd,
+              turn: this._turn,
+              lastAssistantText: assistantContent,
+              last_assistant_message: assistantContent,
+            },
+          });
+          if (turnEndReport.blocked) {
+            this._turnEndBlockCount++;
+            const blocking = turnEndReport.outcomes[turnEndReport.outcomes.length - 1];
+            const reason = (blocking?.stderr || blocking?.stdout || "TurnEnd hook blocked").trim();
+            if (this._turnEndBlockCount >= 3) {
+              yield {
+                turn: this._turn,
+                role: "warning" as const,
+                content: `[hook gate] TurnEnd blocked ${this._turnEndBlockCount} consecutive times — ending turn to prevent infinite loop. ${reason}`,
+              };
+              yield { turn: this._turn, role: "done", content: assistantContent };
+              this._steerQueue.length = 0;
+              return;
+            }
+            yield {
+              turn: this._turn,
+              role: "warning" as const,
+              content: `[hook gate] TurnEnd: ${reason}`,
+            };
+            continue;
+          }
+          this._turnEndBlockCount = 0;
+          for (const o of turnEndReport.outcomes) {
+            if (o.decision !== "pass") {
+              yield {
+                turn: this._turn,
+                role: "warning" as const,
+                content: formatHookOutcomeMessage(o),
+              };
+            }
+          }
+        }
+
         restoreModelIfNeeded();
         yield { turn: this._turn, role: "done", content: assistantContent };
         this._steerQueue.length = 0;

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -214,6 +214,7 @@ export class CacheFirstLoop {
 
   private _turnSelfCorrected = false;
   private _foldedThisTurn = false;
+  private _preModelBlockCount = 0;
   private context!: ContextManager;
 
   /** Subscribe API so UI hooks can derive `running` from finally-guaranteed insertions. */
@@ -768,6 +769,7 @@ export class CacheFirstLoop {
     this.repair.resetStorm();
     this._turnSelfCorrected = false;
     this._foldedThisTurn = false;
+    this._preModelBlockCount = 0;
     // Fresh controller for this turn: the prior step's signal has
     // already fired (or stayed clean); either way we don't want its
     // state to bleed into the new turn.
@@ -931,12 +933,22 @@ export class CacheFirstLoop {
           },
         });
         if (preModelReport.blocked) {
+          this._preModelBlockCount++;
           const blocking = preModelReport.outcomes[preModelReport.outcomes.length - 1];
           const reason = (
             blocking?.stderr ||
             blocking?.stdout ||
             "PreModelCall hook blocked"
           ).trim();
+          if (this._preModelBlockCount >= 3) {
+            yield {
+              turn: this._turn,
+              role: "warning" as const,
+              content: `[hook block] PreModelCall blocked ${this._preModelBlockCount} times — aborting turn to prevent infinite loop. ${reason}`,
+            };
+            this._steerQueue.length = 0;
+            return;
+          }
           yield {
             turn: this._turn,
             role: "warning" as const,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -2,7 +2,12 @@ import { type DeepSeekClient, Usage } from "./client.js";
 import type { ReasoningEffort } from "./config.js";
 import type { PauseGate } from "./core/pause-gate.js";
 import { pauseGate as defaultPauseGate } from "./core/pause-gate.js";
-import { type HookPayload, type ResolvedHook, runHooks } from "./hooks.js";
+import {
+  type HookPayload,
+  type ResolvedHook,
+  formatHookOutcomeMessage,
+  runHooks,
+} from "./hooks.js";
 import {
   DEFAULT_MAX_RESULT_CHARS,
   DEFAULT_MAX_RESULT_TOKENS,
@@ -315,6 +320,20 @@ export class CacheFirstLoop {
       getFewShots: () => this.prefix.fewShots,
       onLogRewrite: () => this.readTracker.reset(),
     });
+
+    if (this.hooks.some((h) => h.event === "SessionStart")) {
+      runHooks({
+        hooks: this.hooks,
+        payload: {
+          event: "SessionStart",
+          cwd: this.hookCwd,
+          sessionName: this.sessionName ?? undefined,
+          turn: 0,
+        },
+      }).catch((err) => {
+        process.stderr.write(`[hooks] SessionStart error: ${(err as Error).message}\n`);
+      });
+    }
   }
 
   /** Replace older turns with one summary message; keep tail within keepRecentTokens budget. */
@@ -714,10 +733,38 @@ export class CacheFirstLoop {
 
     this._turn++;
     this.scratch.reset();
-    // A fresh user turn is a new intent — don't let StormBreaker's
-    // old sliding window of (name, args) signatures keep blocking
-    // calls that are now legitimately on-task. The window repopulates
-    // naturally as this turn's tool calls flow through.
+
+    if (this.hooks.some((h) => h.event === "TurnStart")) {
+      const turnStartReport = await runHooks({
+        hooks: this.hooks,
+        payload: {
+          event: "TurnStart",
+          cwd: this.hookCwd,
+          turn: this._turn,
+        },
+      });
+      if (turnStartReport.blocked) {
+        const blocking = turnStartReport.outcomes[turnStartReport.outcomes.length - 1];
+        const reason = (blocking?.stderr || blocking?.stdout || "TurnStart hook blocked").trim();
+        yield {
+          turn: this._turn,
+          role: "warning" as const,
+          content: `[hook block] ${blocking?.hook.command ?? "<unknown>"}\n${reason}`,
+        };
+        this._steerQueue.length = 0;
+        return;
+      }
+      for (const o of turnStartReport.outcomes) {
+        if (o.decision !== "pass") {
+          yield {
+            turn: this._turn,
+            role: "warning" as const,
+            content: formatHookOutcomeMessage(o),
+          };
+        }
+      }
+    }
+
     this.repair.resetStorm();
     this._turnSelfCorrected = false;
     this._foldedThisTurn = false;
@@ -869,6 +916,45 @@ export class CacheFirstLoop {
         };
       }
 
+      if (this.hooks.some((h) => h.event === "PreModelCall")) {
+        const preModelReport = await runHooks({
+          hooks: this.hooks,
+          payload: {
+            event: "PreModelCall",
+            cwd: this.hookCwd,
+            turn: this._turn,
+            model: this.model,
+            modelMessages: messages.map((m) => ({
+              role: m.role,
+              content: typeof m.content === "string" ? m.content : JSON.stringify(m.content),
+            })),
+          },
+        });
+        if (preModelReport.blocked) {
+          const blocking = preModelReport.outcomes[preModelReport.outcomes.length - 1];
+          const reason = (
+            blocking?.stderr ||
+            blocking?.stdout ||
+            "PreModelCall hook blocked"
+          ).trim();
+          yield {
+            turn: this._turn,
+            role: "warning" as const,
+            content: `[hook block] PreModelCall: ${reason}`,
+          };
+          continue;
+        }
+        for (const o of preModelReport.outcomes) {
+          if (o.decision !== "pass") {
+            yield {
+              turn: this._turn,
+              role: "warning" as const,
+              content: formatHookOutcomeMessage(o),
+            };
+          }
+        }
+      }
+
       let assistantContent = "";
       let reasoningContent = "";
       let toolCalls: ToolCall[] = [];
@@ -1013,6 +1099,39 @@ export class CacheFirstLoop {
       this.stats.addCacheDiagnostic(cacheDiagnostic);
 
       this.scratch.reasoning = reasoningContent || null;
+
+      if (this.hooks.some((h) => h.event === "PostModelCall")) {
+        const postModelReport = await runHooks({
+          hooks: this.hooks,
+          payload: {
+            event: "PostModelCall",
+            cwd: this.hookCwd,
+            turn: this._turn,
+            modelResponse: {
+              role: "assistant",
+              content: assistantContent,
+              reasoning_content: reasoningContent || undefined,
+            },
+            usage: usage
+              ? {
+                  promptTokens: usage.promptTokens,
+                  completionTokens: usage.completionTokens,
+                  cacheHitTokens: usage.promptCacheHitTokens ?? 0,
+                  cacheMissTokens: usage.promptCacheMissTokens ?? 0,
+                }
+              : undefined,
+          },
+        });
+        for (const o of postModelReport.outcomes) {
+          if (o.decision !== "pass") {
+            yield {
+              turn: this._turn,
+              role: "warning" as const,
+              content: formatHookOutcomeMessage(o),
+            };
+          }
+        }
+      }
 
       const { calls: repairedCalls, report } = this.repair.process(
         toolCalls,

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -69,7 +69,6 @@ import {
 import { SessionStats, type TurnStats } from "./telemetry/stats.js";
 import { ToolRegistry } from "./tools.js";
 import { ReadTracker } from "./tools/read-tracker.js";
-import { spawnSubagent } from "./tools/subagent.js";
 import type { ChatMessage, ToolCall } from "./types.js";
 
 export const MID_TURN_STEER_WRAPPER =
@@ -82,28 +81,6 @@ function formatSteerUserMessage(content: string): string {
 function parseNeedsProEscalation(content: string): boolean {
   return /^\s*<<<NEEDS_PRO(?::\s*[^>\n]{1,150})?>>>/.test(content);
 }
-
-const AUDIT_SUBAGENT_SYSTEM_PROMPT = `You are a code quality audit agent. Your job is to review AI assistant responses and provide specific, actionable feedback.
-
-Rules:
-- DO NOT modify any files or execute commands — you are an auditor only
-- Your output will be injected as user feedback to the main agent
-- Review the response for completeness, correctness, and safety
-- Check for logic errors, security vulnerabilities, or missing edge cases
-- Provide specific modification suggestions with file paths when applicable
-- Format your feedback as concise, actionable items
-- Keep your output under 500 characters
-- If no issues found, output "PASS: <brief reason>"
-- Be direct and constructive — the main agent needs precise guidance to self-correct`;
-
-const AUDIT_SUBAGENT_READ_ONLY_TOOLS = [
-  "read_file",
-  "search_content",
-  "glob",
-  "list_directory",
-  "search_files",
-  "find_in_code",
-] as const;
 
 export {
   fixToolCallPairing,
@@ -1310,13 +1287,36 @@ export class CacheFirstLoop {
               role: "warning" as const,
               content: `[hook gate] TurnEnd rejected assistant_final — ${reason}`,
             };
-            const auditFeedback = await this.runTurnEndAudit(assistantContent, reason);
-            this.appendAndPersist({
-              role: "user" as const,
-              content:
-                auditFeedback ??
-                `[TurnEnd gate] The previous response was rejected. Reason: ${reason}. Please address the feedback and respond differently.`,
-            });
+
+            const injectMessages: string[] = [];
+            const warnMessages: string[] = [];
+            for (const o of turnEndReport.outcomes) {
+              if (typeof o.stdout === "string" && o.stdout) {
+                for (const m of o.stdout.matchAll(/@@INJECT:\s*(.*?)(?:\n|$)/g)) {
+                  if (m[1]?.trim()) injectMessages.push(m[1].trim());
+                }
+                for (const m of o.stdout.matchAll(/@@WARN:\s*(.*?)(?:\n|$)/g)) {
+                  if (m[1]?.trim()) warnMessages.push(m[1].trim());
+                }
+              }
+            }
+
+            for (const w of warnMessages) {
+              yield { turn: this._turn, role: "warning" as const, content: w };
+            }
+
+            if (injectMessages.length > 0) {
+              this.appendAndPersist({
+                role: "user" as const,
+                content: injectMessages.join("\n"),
+              });
+            } else {
+              this.appendAndPersist({
+                role: "user" as const,
+                content: `[TurnEnd gate] The previous response was rejected. Reason: ${reason}. Please address the feedback and respond differently.`,
+              });
+            }
+
             this._steerQueue.push(`[TurnEnd hook blocked] ${reason}`);
             continue;
           }
@@ -1411,36 +1411,6 @@ export class CacheFirstLoop {
     // loop via return statements when it produces no more tool calls,
     // when the context guard fires, when an abort fires, or when a fatal
     // error escapes the inner try blocks.
-  }
-
-  private async runTurnEndAudit(assistantContent: string, reason: string): Promise<string | null> {
-    if (this._turnEndBlockCount >= 2) return null;
-    if (!assistantContent.trim()) return null;
-    if (this._turnAbort.signal.aborted) return null;
-
-    try {
-      const timeoutSignal = AbortSignal.timeout(20_000);
-      const auditSignal = AbortSignal.any
-        ? AbortSignal.any([timeoutSignal, this._turnAbort.signal])
-        : timeoutSignal;
-      const result = await spawnSubagent({
-        client: this.client,
-        parentRegistry: this.tools,
-        system: AUDIT_SUBAGENT_SYSTEM_PROMPT,
-        task: `Review the following AI response that was rejected by the TurnEnd gate.\n\nRejection reason: ${reason}\n\nAI response:\n${assistantContent.slice(0, 4000)}\n\nProvide specific feedback on what needs to be fixed.`,
-        maxResultChars: 2000,
-        parentSignal: auditSignal,
-        allowedTools: AUDIT_SUBAGENT_READ_ONLY_TOOLS,
-      });
-
-      if (result.success && result.output.trim()) {
-        return `[Audit Agent Report]\n${result.output.trim()}`;
-      }
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : String(e);
-      console.warn(`[TurnEnd audit] subagent failed, falling back to static message: ${msg}`);
-    }
-    return null;
   }
 
   private summaryContext(): ForceSummaryContext {

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -239,6 +239,7 @@ export class CacheFirstLoop {
   private _foldedThisTurn = false;
   private _preModelBlockCount = 0;
   private _turnEndBlockCount = 0;
+  private _sessionStartExecuted = false;
   private context!: ContextManager;
 
   /** Subscribe API so UI hooks can derive `running` from finally-guaranteed insertions. */
@@ -345,20 +346,6 @@ export class CacheFirstLoop {
       getFewShots: () => this.prefix.fewShots,
       onLogRewrite: () => this.readTracker.reset(),
     });
-
-    if (this.hooks.some((h) => h.event === "SessionStart")) {
-      runHooks({
-        hooks: this.hooks,
-        payload: {
-          event: "SessionStart",
-          cwd: this.hookCwd,
-          sessionName: this.sessionName ?? undefined,
-          turn: 0,
-        },
-      }).catch((err) => {
-        process.stderr.write(`[hooks] SessionStart error: ${(err as Error).message}\n`);
-      });
-    }
   }
 
   /** Replace older turns with one summary message; keep tail within keepRecentTokens budget. */
@@ -758,6 +745,42 @@ export class CacheFirstLoop {
 
     this._turn++;
     this.scratch.reset();
+
+    if (!this._sessionStartExecuted) {
+      this._sessionStartExecuted = true;
+      if (this.hooks.some((h) => h.event === "SessionStart")) {
+        try {
+          const sessionStartReport = await runHooks({
+            hooks: this.hooks,
+            payload: {
+              event: "SessionStart",
+              cwd: this.hookCwd,
+              sessionName: this.sessionName ?? undefined,
+              turn: 0,
+            },
+          });
+          const fragments = sessionStartReport.outcomes
+            .filter((o) => o.decision === "pass" && o.stdout.trim())
+            .map((o) => o.stdout.trim());
+          if (fragments.length > 0) {
+            this.prefix.replaceSystem(
+              `${this.prefix.system}\n\n[Session context]\n${fragments.join("\n")}`,
+            );
+          }
+          for (const o of sessionStartReport.outcomes) {
+            if (o.decision !== "pass") {
+              yield {
+                turn: this._turn,
+                role: "warning" as const,
+                content: formatHookOutcomeMessage(o),
+              };
+            }
+          }
+        } catch (err) {
+          console.warn(`[hooks] SessionStart error: ${(err as Error).message}`);
+        }
+      }
+    }
 
     if (this.hooks.some((h) => h.event === "TurnStart")) {
       const turnStartReport = await runHooks({

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1258,6 +1258,7 @@ export class CacheFirstLoop {
               role: "warning" as const,
               content: `[hook gate] TurnEnd: ${reason}`,
             };
+            this._steerQueue.push(`[TurnEnd hook blocked] ${reason}`);
             continue;
           }
           this._turnEndBlockCount = 0;

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -761,7 +761,7 @@ export class CacheFirstLoop {
           });
           const fragments = sessionStartReport.outcomes
             .filter((o) => o.decision === "pass" && o.stdout.trim())
-            .map((o) => o.stdout.trim());
+            .map((o) => o.stdout.trim().slice(0, 4096));
           if (fragments.length > 0) {
             this.prefix.replaceSystem(
               `${this.prefix.system}\n\n[Session context]\n${fragments.join("\n")}`,

--- a/src/server/api/hooks-events.ts
+++ b/src/server/api/hooks-events.ts
@@ -4,6 +4,7 @@ import { sessionsDir as defaultSessionsDir } from "../../memory/session.js";
 
 export interface HookRunRow {
   hookName: string;
+  /** Must match HookEvent type in src/hooks.ts — keep in sync (V-TE-05). */
   phase:
     | "SessionStart"
     | "TurnStart"

--- a/src/server/api/hooks-events.ts
+++ b/src/server/api/hooks-events.ts
@@ -4,7 +4,16 @@ import { sessionsDir as defaultSessionsDir } from "../../memory/session.js";
 
 export interface HookRunRow {
   hookName: string;
-  phase: "PreToolUse" | "PostToolUse" | "UserPromptSubmit" | "Stop";
+  phase:
+    | "SessionStart"
+    | "TurnStart"
+    | "PreToolUse"
+    | "PostToolUse"
+    | "UserPromptSubmit"
+    | "PreModelCall"
+    | "PostModelCall"
+    | "Stop"
+    | "SessionEnd";
   outcome: "ok" | "blocked" | "modified" | "error";
   whenMs: number;
 }

--- a/src/server/api/hooks-events.ts
+++ b/src/server/api/hooks-events.ts
@@ -12,6 +12,7 @@ export interface HookRunRow {
     | "UserPromptSubmit"
     | "PreModelCall"
     | "PostModelCall"
+    | "TurnEnd"
     | "Stop"
     | "SessionEnd";
   outcome: "ok" | "blocked" | "modified" | "error";

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -5,6 +5,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  BLOCKING_EVENTS,
+  HOOK_EVENTS,
   type HookSpawnInput,
   type HookSpawnResult,
   type ResolvedHook,
@@ -372,7 +374,7 @@ describe("runHooks", () => {
     expect(log[1]?.timeoutMs).toBe(5_000);
     expect(log[2]?.timeoutMs).toBe(10_000);
     expect(log[3]?.timeoutMs).toBe(30_000);
-    expect(log[4]?.timeoutMs).toBe(30_000);
+    expect(log[4]?.timeoutMs).toBe(10_000);
   });
 
   it("per-hook timeout overrides the default", async () => {
@@ -484,5 +486,52 @@ describe("runHooks output truncation", () => {
       spawner,
     });
     expect(report.outcomes[0]?.truncated).toBeUndefined();
+  });
+});
+
+describe("V-TE-05: HookEvent phase type synchronization", () => {
+  it("HOOK_EVENTS array matches all phase values in events.ts and hooks-events.ts", () => {
+    const canonicalPhases = new Set<string>(HOOK_EVENTS);
+
+    const eventsTsPhases = new Set<string>([
+      "SessionStart",
+      "TurnStart",
+      "PreToolUse",
+      "PostToolUse",
+      "UserPromptSubmit",
+      "PreModelCall",
+      "PostModelCall",
+      "TurnEnd",
+      "Stop",
+      "SessionEnd",
+    ]);
+
+    const hooksEventsTsPhases = new Set<string>([
+      "SessionStart",
+      "TurnStart",
+      "PreToolUse",
+      "PostToolUse",
+      "UserPromptSubmit",
+      "PreModelCall",
+      "PostModelCall",
+      "TurnEnd",
+      "Stop",
+      "SessionEnd",
+    ]);
+
+    expect(canonicalPhases).toEqual(eventsTsPhases);
+    expect(canonicalPhases).toEqual(hooksEventsTsPhases);
+  });
+
+  it("HOOK_EVENTS array has no duplicates", () => {
+    const unique = new Set(HOOK_EVENTS);
+    expect(unique.size).toBe(HOOK_EVENTS.length);
+  });
+
+  it("BLOCKING_EVENTS is a subset of HOOK_EVENTS", () => {
+    const allEvents = new Set<string>(HOOK_EVENTS);
+    for (const b of BLOCKING_EVENTS) {
+      expect(allEvents.has(b)).toBe(true);
+    }
   });
 });

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -307,6 +307,74 @@ describe("runHooks", () => {
     expect(log[1]?.timeoutMs).toBe(30_000);
   });
 
+  it("TurnStart is a blocking event (exit code 2 → block)", async () => {
+    const spawner = makeSpawner([ok({ exitCode: 2, stderr: "nope" })]);
+    const report = await runHooks({
+      hooks: [hook({ event: "TurnStart", command: "gate" })],
+      spawner,
+      payload: { event: "TurnStart", cwd: "/tmp", turn: 1 },
+    });
+    expect(report.blocked).toBe(true);
+  });
+
+  it("PreModelCall is a blocking event (exit code 2 → block)", async () => {
+    const spawner = makeSpawner([ok({ exitCode: 2, stderr: "budget" })]);
+    const report = await runHooks({
+      hooks: [hook({ event: "PreModelCall", command: "budget-check" })],
+      spawner,
+      payload: { event: "PreModelCall", cwd: "/tmp", turn: 1, model: "deepseek-r1" },
+    });
+    expect(report.blocked).toBe(true);
+  });
+
+  it("TurnEnd is a blocking event (exit code 2 → block)", async () => {
+    const spawner = makeSpawner([ok({ exitCode: 2, stderr: "incomplete" })]);
+    const report = await runHooks({
+      hooks: [hook({ event: "TurnEnd", command: "completeness" })],
+      spawner,
+      payload: {
+        event: "TurnEnd",
+        cwd: "/tmp",
+        turn: 1,
+        lastAssistantText: "partial answer",
+      },
+    });
+    expect(report.blocked).toBe(true);
+  });
+
+  it("PostModelCall is a non-blocking event (exit code 2 → warn, not block)", async () => {
+    const spawner = makeSpawner([ok({ exitCode: 2, stderr: "log" })]);
+    const report = await runHooks({
+      hooks: [hook({ event: "PostModelCall", command: "logger" })],
+      spawner,
+      payload: { event: "PostModelCall", cwd: "/tmp", turn: 1 },
+    });
+    expect(report.blocked).toBe(false);
+    expect(report.outcomes[0]?.decision).toBe("warn");
+  });
+
+  it("new events use their configured default timeouts", async () => {
+    const log: HookSpawnInput[] = [];
+    const spawner = makeSpawner([ok(), ok(), ok(), ok(), ok()], log);
+    const h: ResolvedHook[] = [
+      hook({ event: "SessionStart", command: "s" }),
+      hook({ event: "TurnStart", command: "ts" }),
+      hook({ event: "PreModelCall", command: "pm" }),
+      hook({ event: "PostModelCall", command: "pom" }),
+      hook({ event: "TurnEnd", command: "te" }),
+    ];
+    await runHooks({ hooks: [h[0]!], spawner, payload: { event: "SessionStart", cwd: "/tmp" } });
+    await runHooks({ hooks: [h[1]!], spawner, payload: { event: "TurnStart", cwd: "/tmp" } });
+    await runHooks({ hooks: [h[2]!], spawner, payload: { event: "PreModelCall", cwd: "/tmp" } });
+    await runHooks({ hooks: [h[3]!], spawner, payload: { event: "PostModelCall", cwd: "/tmp" } });
+    await runHooks({ hooks: [h[4]!], spawner, payload: { event: "TurnEnd", cwd: "/tmp" } });
+    expect(log[0]?.timeoutMs).toBe(10_000);
+    expect(log[1]?.timeoutMs).toBe(5_000);
+    expect(log[2]?.timeoutMs).toBe(10_000);
+    expect(log[3]?.timeoutMs).toBe(30_000);
+    expect(log[4]?.timeoutMs).toBe(30_000);
+  });
+
   it("per-hook timeout overrides the default", async () => {
     const log: HookSpawnInput[] = [];
     const spawner = makeSpawner([ok()], log);

--- a/tests/loop-hooks.test.ts
+++ b/tests/loop-hooks.test.ts
@@ -116,7 +116,53 @@ describe("CacheFirstLoop hook wiring", () => {
     expect(events.find((e) => e.role === "assistant_final")?.content).toBe("just chatting");
   });
 
-  it("TurnEnd gate falls back to static message when audit subagent is unavailable", async () => {
+  it("TurnEnd @@INJECT protocol injects user message", async () => {
+    const client = makeClient([{ content: "first response" }, { content: "corrected response" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      hooks: [
+        {
+          event: "TurnEnd",
+          scope: "global",
+          source: "/x",
+          command: "echo @@INJECT: Fix the TODO markers && exit 2",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) events.push(ev);
+    const doneEvent = events.find((e) => e.role === "done");
+    expect(doneEvent).toBeDefined();
+    const warnings = events.filter((e) => e.role === "warning");
+    expect(warnings.some((w) => w.content.includes("TurnEnd rejected"))).toBe(true);
+  });
+
+  it("TurnEnd @@WARN protocol yields warning", async () => {
+    const client = makeClient([{ content: "first response" }, { content: "corrected response" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      hooks: [
+        {
+          event: "TurnEnd",
+          scope: "global",
+          source: "/x",
+          command: "echo @@WARN: Quality check failed && exit 2",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) events.push(ev);
+    const doneEvent = events.find((e) => e.role === "done");
+    expect(doneEvent).toBeDefined();
+    const warnings = events.filter((e) => e.role === "warning");
+    expect(warnings.some((w) => w.content.includes("Quality check failed"))).toBe(true);
+  });
+
+  it("TurnEnd without @@INJECT uses default message", async () => {
     const client = makeClient([{ content: "first response" }, { content: "corrected response" }]);
     const loop = new CacheFirstLoop({
       client,
@@ -135,6 +181,8 @@ describe("CacheFirstLoop hook wiring", () => {
     for await (const ev of loop.step("test")) events.push(ev);
     const doneEvent = events.find((e) => e.role === "done");
     expect(doneEvent).toBeDefined();
+    const warnings = events.filter((e) => e.role === "warning");
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
   });
 
   it("PreModelCall blocked 3 consecutive times aborts the turn", async () => {
@@ -201,6 +249,7 @@ describe("CacheFirstLoop hook wiring", () => {
   });
 
   it("TurnEnd gate blocks then allows on next iteration", async () => {
+    let blockCount = 0;
     const client = makeClient([{ content: "first response" }, { content: "corrected response" }]);
     const loop = new CacheFirstLoop({
       client,
@@ -216,11 +265,18 @@ describe("CacheFirstLoop hook wiring", () => {
       ],
     });
     const events: LoopEvent[] = [];
-    for await (const ev of loop.step("test")) events.push(ev);
+    for await (const ev of loop.step("test")) {
+      events.push(ev);
+      if (ev.role === "warning" && ev.content.includes("TurnEnd")) {
+        blockCount++;
+        if (blockCount >= 1) {
+          loop.hooks = [];
+        }
+      }
+    }
     const doneEvent = events.find((e) => e.role === "done");
     expect(doneEvent).toBeDefined();
-    const warnings = events.filter((e) => e.role === "warning");
-    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(blockCount).toBe(1);
   });
 
   it("TurnEnd 3-strike guard forces turn end after 3 consecutive blocks", async () => {

--- a/tests/loop-hooks.test.ts
+++ b/tests/loop-hooks.test.ts
@@ -251,4 +251,89 @@ describe("CacheFirstLoop hook wiring", () => {
     const has3StrikeMsg = warnings.some((w) => w.content.includes("3 consecutive times"));
     expect(has3StrikeMsg).toBe(true);
   });
+
+  it("SessionStart hook stdout is injected into system prompt", async () => {
+    const client = makeClient([{ content: "hello" }]);
+    const prefix = new ImmutablePrefix({ system: "original system" });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix,
+      stream: false,
+      hooks: [
+        {
+          event: "SessionStart",
+          scope: "global",
+          source: "/x",
+          command: "echo injected-context-from-hook",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) events.push(ev);
+    expect(prefix.system).toContain("injected-context-from-hook");
+    expect(prefix.system).toContain("[Session context]");
+    expect(prefix.system).toContain("original system");
+  });
+
+  it("SessionStart hook only runs once across multiple steps", async () => {
+    const client1 = makeClient([{ content: "first" }]);
+    const client2 = makeClient([{ content: "second" }]);
+    const prefix = new ImmutablePrefix({ system: "s" });
+    const loop = new CacheFirstLoop({
+      client: client1,
+      prefix,
+      stream: false,
+      hooks: [
+        {
+          event: "SessionStart",
+          scope: "global",
+          source: "/x",
+          command: "echo once-only",
+        },
+      ],
+    });
+    for await (const ev of loop.step("test")) {
+    }
+    const systemAfterFirst = prefix.system;
+    expect(systemAfterFirst).toContain("once-only");
+
+    loop.client = client2;
+    for await (const ev of loop.step("test2")) {
+    }
+    expect(prefix.system).toBe(systemAfterFirst);
+  });
+
+  it("SessionStart hook with no stdout does not modify system prompt", async () => {
+    const client = makeClient([{ content: "hello" }]);
+    const prefix = new ImmutablePrefix({ system: "original" });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix,
+      stream: false,
+      hooks: [
+        {
+          event: "SessionStart",
+          scope: "global",
+          source: "/x",
+          command: "exit 0",
+        },
+      ],
+    });
+    for await (const ev of loop.step("test")) {
+    }
+    expect(prefix.system).toBe("original");
+  });
+
+  it("no SessionStart hook means zero overhead", async () => {
+    const client = makeClient([{ content: "hello" }]);
+    const prefix = new ImmutablePrefix({ system: "original" });
+    const loop = new CacheFirstLoop({
+      client,
+      prefix,
+      stream: false,
+    });
+    for await (const ev of loop.step("test")) {
+    }
+    expect(prefix.system).toBe("original");
+  });
 });

--- a/tests/loop-hooks.test.ts
+++ b/tests/loop-hooks.test.ts
@@ -115,4 +115,140 @@ describe("CacheFirstLoop hook wiring", () => {
     expect(events.find((e) => e.role === "warning")).toBeUndefined();
     expect(events.find((e) => e.role === "assistant_final")?.content).toBe("just chatting");
   });
+
+  it("TurnEnd gate falls back to static message when audit subagent is unavailable", async () => {
+    const client = makeClient([{ content: "first response" }, { content: "corrected response" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      hooks: [
+        {
+          event: "TurnEnd",
+          scope: "global",
+          source: "/x",
+          command: "exit 2",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) events.push(ev);
+    const doneEvent = events.find((e) => e.role === "done");
+    expect(doneEvent).toBeDefined();
+  });
+
+  it("PreModelCall blocked 3 consecutive times aborts the turn", async () => {
+    const client = makeClient([
+      { content: "response 1" },
+      { content: "response 2" },
+      { content: "response 3" },
+      { content: "response 4" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      hooks: [
+        {
+          event: "PreModelCall",
+          scope: "global",
+          source: "/x",
+          command: "exit 2",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) events.push(ev);
+    const warnings = events.filter((e) => e.role === "warning");
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+    expect(warnings.some((w) => w.content.includes("PreModelCall blocked"))).toBe(true);
+    expect(events.some((e) => e.role === "done")).toBe(false);
+  });
+
+  it("PreModelCall blocked twice then passing does not abort", async () => {
+    let blockCount = 0;
+    const client = makeClient([
+      { content: "blocked 1" },
+      { content: "blocked 2" },
+      { content: "final answer" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      hooks: [
+        {
+          event: "PreModelCall",
+          scope: "global",
+          source: "/x",
+          command: "exit 2",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) {
+      events.push(ev);
+      if (ev.role === "warning" && ev.content.includes("PreModelCall")) {
+        blockCount++;
+        if (blockCount >= 2) {
+          loop.hooks = [];
+        }
+      }
+    }
+    const doneEvent = events.find((e) => e.role === "done");
+    expect(doneEvent).toBeDefined();
+    expect(blockCount).toBe(2);
+  });
+
+  it("TurnEnd gate blocks then allows on next iteration", async () => {
+    const client = makeClient([{ content: "first response" }, { content: "corrected response" }]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      hooks: [
+        {
+          event: "TurnEnd",
+          scope: "global",
+          source: "/x",
+          command: "exit 2",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) events.push(ev);
+    const doneEvent = events.find((e) => e.role === "done");
+    expect(doneEvent).toBeDefined();
+    const warnings = events.filter((e) => e.role === "warning");
+    expect(warnings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("TurnEnd 3-strike guard forces turn end after 3 consecutive blocks", async () => {
+    const client = makeClient([
+      { content: "response 1" },
+      { content: "response 2" },
+      { content: "response 3" },
+      { content: "response 4" },
+    ]);
+    const loop = new CacheFirstLoop({
+      client,
+      prefix: new ImmutablePrefix({ system: "s" }),
+      stream: false,
+      hooks: [
+        {
+          event: "TurnEnd",
+          scope: "global",
+          source: "/x",
+          command: "exit 2",
+        },
+      ],
+    });
+    const events: LoopEvent[] = [];
+    for await (const ev of loop.step("test")) events.push(ev);
+    const doneEvent = events.find((e) => e.role === "done");
+    expect(doneEvent).toBeDefined();
+    const warnings = events.filter((e) => e.role === "warning");
+    const has3StrikeMsg = warnings.some((w) => w.content.includes("3 consecutive times"));
+    expect(has3StrikeMsg).toBe(true);
+  });
 });

--- a/tests/useQuit-reentry.test.tsx
+++ b/tests/useQuit-reentry.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useQuit } from "../src/cli/ui/hooks/useQuit.js";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("useQuit reentry guard", () => {
+  it("quittingRef prevents multiple process.exit calls", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const endSpy = vi.fn();
+    const transcriptRef = { current: { end: endSpy } } as never;
+    const beforeQuit = vi.fn();
+
+    let quitFn: ReturnType<typeof useQuit> | undefined;
+    function Harness() {
+      quitFn = useQuit(transcriptRef, { beforeQuit });
+      return null;
+    }
+
+    render(<Harness />);
+    expect(quitFn).toBeDefined();
+
+    quitFn!();
+    await vi.waitFor(() => {
+      expect(exitSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(endSpy).toHaveBeenCalledTimes(1);
+    expect(beforeQuit).toHaveBeenCalledTimes(1);
+
+    exitSpy.mockClear();
+    endSpy.mockClear();
+    beforeQuit.mockClear();
+
+    quitFn!();
+    await new Promise((r) => setTimeout(r, 50));
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(endSpy).not.toHaveBeenCalled();
+    expect(beforeQuit).not.toHaveBeenCalled();
+  });
+
+  it("beforeQuit error does not prevent process.exit", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const endSpy = vi.fn();
+    const transcriptRef = { current: { end: endSpy } } as never;
+    const beforeQuit = vi.fn().mockRejectedValue(new Error("beforeQuit boom"));
+
+    let quitFn: ReturnType<typeof useQuit> | undefined;
+    function Harness() {
+      quitFn = useQuit(transcriptRef, { beforeQuit });
+      return null;
+    }
+
+    render(<Harness />);
+
+    quitFn!();
+    await vi.waitFor(() => {
+      expect(exitSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("null transcriptRef does not crash", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    const transcriptRef = { current: null };
+
+    let quitFn: ReturnType<typeof useQuit> | undefined;
+    function Harness() {
+      quitFn = useQuit(transcriptRef as never);
+      return null;
+    }
+
+    render(<Harness />);
+
+    quitFn!();
+    await vi.waitFor(() => {
+      expect(exitSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #2155 — supersedes #2156

## What

Extend Reasonix hook system from 4 lifecycle events to 10, covering the full AI Agent lifecycle. This PR also refactors TurnEnd from a hardcoded audit-subagent gate into a pure hook mechanism with @@INJECT/@@WARN stdout protocol — providing the interface, not the business logic.

## All hook events (4 existing + 6 new)

| # | Event | Fire point | Blocking | Timeout | Purpose |
|:-:|:------|:-----------|:--------:|:-------:|:--------|
| 1 | SessionStart | First step() call, before TurnStart | warn only | 10s | Environment check, project validation, context injection |
| 2 | TurnStart | step() start, per-turn | block | 5s | Budget check, context check, per-turn prompt injection |
| 3 | PreToolUse | Before tool dispatch (existing) | block | 5s | Security blocking, auto-approve |
| 4 | PostToolUse | After tool success (existing) | warn | 30s | Lint, log, result validation |
| 5 | UserPromptSubmit | User submits prompt (existing) | block | 5s | Input validation, filtering |
| 6 | PreModelCall | Before model chat | block (3-strike) | 10s | Prompt audit, sensitive content filter, custom system prompt injection |
| 7 | PostModelCall | After model response | warn | 30s | Post-processing, usage logging |
| 8 | TurnEnd | Agent finishes responding, before yield done | block (3-strike) | 10s | Quality gate |
| 9 | Stop | Turn end (existing) | warn | 30s | Logging, session tracking |
| 10 | SessionEnd | Session exit | warn | 10s | Cleanup, summary report, cross-session persistence |

## Key features

### SessionStart — context injection (Claude Code parity)

SessionStart hook stdout is injected into the system prompt, achieving Claude Code parity. Users write their own scripts to inject cross-session recovery, project briefs, etc. Empty stdout or no hook = zero overhead.

### TurnEnd — pure hook gate with @@INJECT/@@WARN protocol

TurnEnd fires when the agent finishes its response and is about to end the turn. It is in BLOCKING_EVENTS:

- **exit 2 = block**: the loop executes continue, keeping the turn alive for self-correction.
- **exit 0 = pass**: normal turn completion.
- **3-strike guard**: 3 consecutive blocks force the turn to end, preventing infinite loops.

The @@INJECT/@@WARN stdout protocol lets hook scripts communicate back:

| Protocol | Effect |
|:---------|:-------|
| @@INJECT:<message> | Injected as user message — tells the agent what to fix |
| @@WARN:<message> | Yields a system warning |
| No @@INJECT | Default fallback message used |

This replaced the previously hardcoded audit subagent. TurnEnd now provides the mechanism only — users write their own scripts to decide what checks to run and what feedback to inject.

Example hook script:

```python
import json, sys
payload = json.load(sys.stdin)
text = payload.get('lastAssistantText', '')
if 'TODO' in text.upper():
    print('@@INJECT: Remove TODO markers before finalizing.')
    print('@@WARN: TurnEnd gate blocked.')
    sys.exit(2)
sys.exit(0)
```

### Safety mechanisms

- PreModelCall 3-strike guard, TurnEnd 3-strike guard
- SessionEnd reentry guard (quittingRef)
- EPIPE protection for fast-exit hook scripts
- All new HookPayload fields optional — zero breakage

### Backward compatibility

- Existing 4 events unchanged, existing settings.json unmodified
- All 124 hook/loop/quit tests pass

## Changes (9 files)

| File | Change |
|:-----|:-------|
| src/hooks.ts | Event types, arrays, timeouts, payload fields |
| src/loop.ts | 6 new fire points + TurnEnd @@INJECT/@@WARN parsing |
| src/cli/ui/App.tsx | SessionEnd hook integration |
| src/cli/ui/hooks/useQuit.ts | beforeQuit + quittingRef reentry guard |
| src/core/events.ts, src/server/api/hooks-events.ts | Phase type sync |
| tests/ | New tests for all events |

## Refactor note

Supersedes #2156 which had a hardcoded audit subagent. Based on review feedback, hooks should not embed business logic. Replaced with @@INJECT/@@WARN protocol.

## Checklist

- [x] npm run verify passes locally
- [x] No Co-Authored-By: Claude trailer
- [x] No edits to CHANGELOG.md