### PR TITLE
fix(cli): restore mouse wheel scrolling for TUI

### DIFF
--- a/src/cli/commands/chat.tsx
+++ b/src/cli/commands/chat.tsx
@@ -314,11 +314,14 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   const mcpSpecs = [...requestedSpecs];
   const mcpServers: McpServerSummary[] = [];
   const cfg = readConfig();
-  const historyScrollMode = resolveHistoryScrollMode({
-    configured: loadHistoryScrollMode(),
-    env: process.env,
-    platform: process.platform,
-  });
+  const historyScrollMode =
+    opts.noMouse || cfg.mouseTracking === false
+      ? "native"
+      : resolveHistoryScrollMode({
+          configured: loadHistoryScrollMode(),
+          env: process.env,
+          platform: process.platform,
+        });
   const startupInfoHints: string[] = [];
   const hasAnyMcp = normalizeMcpConfig(cfg).length > 0 || mcpSpecs.length > 0;
   if (cfg.setupCompleted === true && !hasAnyMcp) {
@@ -424,10 +427,10 @@ export async function chatCommand(opts: ChatOptions): Promise<void> {
   // path so N cards don't accumulate N native stdout listeners.
   installResizeBroadcaster();
 
-  // Wheel scrolling. Opt-out via `mouseTracking: false` for users who
-  // prefer native drag-select copy (Shift+drag still selects with mouse
-  // mode on in most terminals). exit hooks cover hard kills so the
-  // sequence doesn't leak into the parent shell.
+  // Wheel scrolling. Opt-out via `--no-mouse` / `mouseTracking: false` also
+  // forces native history mode so the terminal, not CardStream, owns wheel
+  // movement. Exit hooks cover hard kills so the sequence doesn't leak into
+  // the parent shell.
   if (!opts.noMouse && cfg.mouseTracking !== false) {
     enableMouseMode(historyScrollMode);
     process.once("exit", disableMouseMode);

--- a/src/cli/ui/history-scroll-mode.ts
+++ b/src/cli/ui/history-scroll-mode.ts
@@ -15,11 +15,21 @@ export function resolveHistoryScrollMode({
 }: ResolveHistoryScrollModeInput = {}): ResolvedHistoryScrollMode {
   if (configured === "native") return "native";
   if (configured === "app") return "app";
+  // Apple Terminal has native renderer crashes when it receives
+  // private mouse-mode toggles — keep it on native so the terminal
+  // handles scrollback without any escape sequences.
+  if ((env.TERM_PROGRAM ?? "").toLowerCase() === "apple_terminal") return "native";
   if (isKnownJumpProneTerminal(env)) return "app";
+  // Classic Windows console (conhost) doesn't advertise TERM_PROGRAM
+  // and its alt-screen buffer doesn't forward wheel events — native
+  // scrollback is the safer default there.
   if (platform === "win32" && env.TERM_PROGRAM === undefined && env.MSYSTEM === undefined) {
     return "native";
   }
-  return "native";
+  // Default to app-managed scroll for all other terminals so the mouse
+  // wheel feeds into CardStream's scroll logic. Native scrollback
+  // cannot scroll TUI alt-screen content on most terminals.
+  return "app";
 }
 
 function isKnownJumpProneTerminal(env: NodeJS.ProcessEnv | Record<string, string | undefined>) {

--- a/src/cli/ui/stdin-reader.ts
+++ b/src/cli/ui/stdin-reader.ts
@@ -131,8 +131,17 @@ function decodeSgrMouseBody(body: string): KeyEvent | null {
   if (!Number.isFinite(btn) || !Number.isFinite(col) || !Number.isFinite(row)) return null;
   const tail = m[4]!;
   if (tail === "m") return { input: "", mouseRelease: true, mouseRow: row, mouseCol: col };
-  if (btn === 64) return { input: "", mouseScrollUp: true, mouseRow: row, mouseCol: col };
-  if (btn === 65) return { input: "", mouseScrollDown: true, mouseRow: row, mouseCol: col };
+  // SGR encodes wheel events with bit 6 set (btn & 64).
+  // Modifier keys add bits 4/8/16 (e.g. 68 = wheel-up+Ctrl, 80 = wheel-up+Shift).
+  // Masking with bit 6 is stricter than `btn >= 64` — it rejects theoretical
+  // non-wheel codes that happen to fall >= 64. The wheel direction is in bit 0:
+  // 0 = up, 1 = down. Issue #2260: some terminals (especially Windows Terminal
+  // previews) send modified codes 68/69/80 etc. that the old exact-match missed.
+  if (btn & 64) {
+    const wheelDir = btn & 1;
+    if (wheelDir === 0) return { input: "", mouseScrollUp: true, mouseRow: row, mouseCol: col };
+    return { input: "", mouseScrollDown: true, mouseRow: row, mouseCol: col };
+  }
   if (btn === 0) return { input: "", mouseClick: true, mouseRow: row, mouseCol: col };
   if (btn === 32) return { input: "", mouseDrag: true, mouseRow: row, mouseCol: col };
   return null;

--- a/tests/chat-scroll-wheel.test.ts
+++ b/tests/chat-scroll-wheel.test.ts
@@ -94,12 +94,32 @@ describe("history scroll mode resolution", () => {
     );
   });
 
-  it("keeps native scrollback for unknown terminals in auto mode", () => {
+  it("defaults to app-managed scroll for unknown terminals in auto mode", () => {
     expect(
       resolveHistoryScrollMode({
         configured: "auto",
         env: { TERM: "xterm-256color" },
         platform: "linux",
+      }),
+    ).toBe("app");
+  });
+
+  it("keeps native scrollback for Apple Terminal to avoid renderer crashes", () => {
+    expect(
+      resolveHistoryScrollMode({
+        configured: "auto",
+        env: { TERM_PROGRAM: "Apple_Terminal" },
+        platform: "darwin",
+      }),
+    ).toBe("native");
+  });
+
+  it("keeps native scrollback for classic Windows console (no TERM_PROGRAM)", () => {
+    expect(
+      resolveHistoryScrollMode({
+        configured: "auto",
+        env: {},
+        platform: "win32",
       }),
     ).toBe("native");
   });


### PR DESCRIPTION
## Summary

Fixes the scroll wheel portion of [#2260](https://github.com/esengine/DeepSeek-Reasonix/issues/2260) — mouse wheel not working in the CLI TUI after model finishes answering.

## Root cause

`src/cli/ui/history-scroll-mode.ts` defaulted to `"native"` for most terminals when `historyScrollMode` was `"auto"`. In `"native"` mode, `mouse-mode.ts` sends `RESET_ALL` (disabling all mouse tracking), relying on the terminal native scrollback. But in the TUI alt-screen buffer, there is nothing "above" the screen for native scrollback to scroll — wheel events produce no movement.

## Changes

### 1. `src/cli/ui/history-scroll-mode.ts` — default to app-managed scroll
- Changed the default return from `"native"` to `"app"` so CardStream captures wheel events
- Added explicit Apple Terminal exception (native renderer crashes on mouse-mode toggles)
- Classic Windows console (conhost, no TERM_PROGRAM) stays on `"native"` — it does not forward wheel events to the alt-screen

### 2. `src/cli/commands/chat.tsx` — honor opt-out flags
- `--no-mouse` and `mouseTracking: false` now force `"native"` as a hard override before the resolver runs

### 3. `src/cli/ui/stdin-reader.ts` — decode modified SGR wheel codes
- Changed from exact match `btn === 64` / `btn === 65` to bit masking `btn & 64` with `btn & 1` for direction
- This catches modified codes (68 = wheel-up+Ctrl, 69 = wheel-down+Ctrl, 80 = wheel-up+Shift) that some terminals emit

## Verification
- `npm run typecheck`
- `npm run lint`