### PR TITLE
fix: plan panel squeezing layout + storm breaker deadlock + Windows /-flag allowlist guard

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -918,8 +918,7 @@ function AppInner({
     stagedInput ||
     pendingCheckpoint ||
     pendingRevision ||
-    pendingReviseEditor ||
-    (planStepsRef.current && planStepsRef.current.length > 0 && !planMode)
+    pendingReviseEditor
   );
   // Wall-clock when the latest tool_start fired. Cleared when the
   // matching `tool` event arrives (or at turn end). Tools are

--- a/src/loop.ts
+++ b/src/loop.ts
@@ -1153,9 +1153,6 @@ export class CacheFirstLoop {
       }
 
       if (repairedCalls.length === 0) {
-        if (this._steerQueue.length > 0) {
-          continue;
-        }
         if (allSuppressed) {
           try {
             yield* forceSummaryAfterIterLimit(this.summaryContext(), { reason: "stuck" });
@@ -1164,6 +1161,9 @@ export class CacheFirstLoop {
             this._steerQueue.length = 0;
           }
           return;
+        }
+        if (this._steerQueue.length > 0) {
+          continue;
         }
         restoreModelIfNeeded();
         yield { turn: this._turn, role: "done", content: assistantContent };

--- a/src/tools/shell/parse.ts
+++ b/src/tools/shell/parse.ts
@@ -349,7 +349,14 @@ export function isAllowed(
     if (projectRoot) {
       const root = pathMod.resolve(projectRoot);
       for (const tok of argv) {
-        if (!tok || tok.startsWith("-") || tok.includes("://") || tok.startsWith("$")) continue;
+        if (
+          !tok ||
+          tok.startsWith("-") ||
+          tok.startsWith("/") ||
+          tok.includes("://") ||
+          tok.startsWith("$")
+        )
+          continue;
         let expanded = tok;
         if (expanded.startsWith("~")) expanded = pathMod.join(homedir(), expanded.slice(1));
         const resolved = pathMod.resolve(root, expanded);


### PR DESCRIPTION
## Summary

Three bug fixes:

### 1. Plan panel squeezing the conversation area (fixes #2338)

After accepting a plan, the right-side panel stayed open during execution, keeping the conversation area at 35% width. This was caused by the `planPanelOpen` condition including `(planStepsRef.current && planStepsRef.current.length > 0 && !planMode)`, which kept the panel open for the entire execution phase.

**Fix**: Removed that condition. The panel now only opens for interactive states (pendingPlan, stagedInput, checkpoint, revision, reviseEditor). During execution, plan progress is shown inline via the existing `PlanLiveRow` component.

### 2. Storm breaker deadlock (fixes #2345)

When the model kept calling the same tool with identical arguments, the storm breaker correctly suppressed the calls. However, after the self-correction attempt failed and the "stuck retry loop" warning was emitted, if `_steerQueue` had any messages, the code would `continue` the loop without resetting the storm breaker state—causing an infinite loop where every subsequent attempt was immediately suppressed again.

**Fix**: Moved the `allSuppressed` check above the `steerQueue` check. When all tool calls are suppressed and self-correction has failed, the turn now always terminates via `forceSummaryAfterIterLimit`, regardless of steer queue contents.

### 3. Windows /-prefixed flags breaking shell allowlist path guard

On Windows, `path.isAbsolute('/f')` returns `true` and `path.resolve(root, '/f')` resolves to `D:\f`, escaping the sandbox root. The allowlist check in `isAllowed` skipped `-`-prefixed tokens (Linux flags) but not `/`-prefixed tokens (Windows flags like `/f`, `/im`). This caused every Windows-flag shell command to fail the workspace path guard, making "Always allow" never take effect even after the prefix was saved to config.

**Fix**: Added `tok.startsWith("/")` to the skip conditions in the path-escape guard, so Windows flag tokens bypass the path resolution check — matching how Linux flags are already handled.

### Changes

- `src/cli/ui/App.tsx`: Remove execution-phase condition from `planPanelOpen`
- `src/loop.ts`: Reorder `allSuppressed`/`steerQueue` checks in repair path
- `src/tools/shell/parse.ts`: Skip `/`-prefixed tokens (Windows flags) in path guard