### PR TITLE
feat(settings): 新增 MCP 服务器启用/禁用开关

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -1618,6 +1618,10 @@ function TabRuntime({
     (raw: string) => sendRpc({ cmd: "mcp_specs_retry", raw }),
     [sendRpc],
   );
+  const toggleMcpSpec = useCallback(
+    (raw: string) => sendRpc({ cmd: "mcp_specs_toggle", raw }),
+    [sendRpc],
+  );
   const newChat = useCallback(() => {
     clearAbortDraft();
     resetPromptHistoryNav();
@@ -2891,6 +2895,7 @@ function TabRuntime({
             onRemoveMcpSpec={removeMcpSpec}
             onUpdateMcpSpec={updateMcpSpec}
             onRetryMcpSpec={retryMcpSpec}
+            onToggleMcpSpec={toggleMcpSpec}
             onReadMemory={(path) => sendRpc({ cmd: "memory_read", path })}
           />
         ) : null}

--- a/desktop/src/i18n/en.ts
+++ b/desktop/src/i18n/en.ts
@@ -658,6 +658,8 @@ export const en = {
     hideTools: "Hide tools",
     availableTools: "{count} available tools",
     noTools: "Connected, but this server did not expose callable tools",
+    toggleOn: "ON",
+    toggleOff: "OFF",
   },
   jobs: {
     title: "Background jobs",

--- a/desktop/src/i18n/zh-CN.ts
+++ b/desktop/src/i18n/zh-CN.ts
@@ -655,6 +655,8 @@ export const zhCN: typeof en = {
     hideTools: "收起工具",
     availableTools: "{count} 个可用工具",
     noTools: "已连接，但该服务器未暴露可调用工具",
+    toggleOn: "开启",
+    toggleOff: "关闭",
   },
   contextPanel: {
     reservedKey: "预留",

--- a/desktop/src/protocol.ts
+++ b/desktop/src/protocol.ts
@@ -622,6 +622,7 @@ export type OutgoingCommand = { tabId?: string } & (
   | { cmd: "mcp_import_servers"; servers: ImportedMcpServer[] }
   | { cmd: "mcp_specs_update"; raw: string; server: ImportedMcpServer }
   | { cmd: "mcp_specs_retry"; raw: string }
+  | { cmd: "mcp_specs_toggle"; raw: string }
   | { cmd: "skills_get" }
   | { cmd: "skill_run"; name: string; args?: string }
   | { cmd: "jobs_list" }

--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -5718,6 +5718,63 @@ html:not([data-platform="macos"]) .cmdk-row .kb .shortcut kbd[data-key="mod"] {
 .mcp-server-card .rot {
   transform: rotate(180deg);
 }
+.mcp-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.mcp-toggle.on {
+  background: color-mix(in srgb, var(--success) 15%, transparent);
+  border-color: color-mix(in srgb, var(--success) 40%, var(--border));
+}
+.mcp-toggle.off {
+  background: var(--bg-2);
+  border-color: var(--border);
+}
+.mcp-toggle:hover {
+  border-color: color-mix(in srgb, var(--fg) 30%, var(--border));
+}
+.mcp-toggle-track {
+  position: relative;
+  width: 28px;
+  height: 16px;
+  border-radius: 8px;
+  background: var(--bg-3);
+  transition: background 0.2s ease;
+}
+.mcp-toggle.on .mcp-toggle-track {
+  background: var(--success);
+}
+.mcp-toggle.off .mcp-toggle-track {
+  background: var(--muted);
+}
+.mcp-toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: white;
+  transition: transform 0.2s ease;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+.mcp-toggle.on .mcp-toggle-thumb {
+  transform: translateX(12px);
+}
+.mcp-toggle.off .mcp-toggle-thumb {
+  transform: translateX(0);
+}
+.mcp-toggle-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--fg);
+}
 .mcp-tools-detail {
   margin-top: 10px;
   padding: 10px;

--- a/desktop/src/ui/mcp-server-card.tsx
+++ b/desktop/src/ui/mcp-server-card.tsx
@@ -46,12 +46,14 @@ export function McpServerCard({
   onEdit,
   onRetry,
   onRemove,
+  onToggle,
 }: {
   spec: McpSpecInfo;
   mode?: McpServerCardMode;
   onEdit?: (spec: McpSpecInfo) => void;
   onRetry?: (raw: string) => void;
   onRemove?: (raw: string) => void;
+  onToggle?: (raw: string) => void;
 }) {
   const [toolsOpen, setToolsOpen] = useState(false);
   const [detailOpen, setDetailOpen] = useState(false);
@@ -66,6 +68,7 @@ export function McpServerCard({
     spec.status === "failed" && spec.statusReason
       ? `${statusText}\n${spec.statusReason}`
       : statusText;
+  const isDisabled = spec.status === "disabled";
 
   return (
     <div className="scard mcp-server-card" data-mode={mode} data-status={spec.status}>
@@ -85,6 +88,21 @@ export function McpServerCard({
           </Tooltip>
         </div>
         <div className="mcp-card-actions">
+          {mode === "settings" && onToggle && !spec.parseError ? (
+            <button
+              type="button"
+              className={`btn ghost mcp-toggle ${isDisabled ? "off" : "on"}`}
+              onClick={() => onToggle(spec.raw)}
+              title={isDisabled ? t("mcpCard.toggleOn") : t("mcpCard.toggleOff")}
+            >
+              <span className="mcp-toggle-track">
+                <span className="mcp-toggle-thumb" />
+              </span>
+              <span className="mcp-toggle-label">
+                {isDisabled ? t("mcpCard.toggleOff") : t("mcpCard.toggleOn")}
+              </span>
+            </button>
+          ) : null}
           {canExpandTools ? (
             <button type="button" className="btn ghost" onClick={() => setToolsOpen((v) => !v)}>
               <I.chev size={13} className={toolsOpen ? "rot" : ""} />

--- a/desktop/src/ui/settings.tsx
+++ b/desktop/src/ui/settings.tsx
@@ -90,6 +90,7 @@ export function SettingsModal({
   onRemoveMcpSpec,
   onUpdateMcpSpec,
   onRetryMcpSpec,
+  onToggleMcpSpec,
   onReadMemory,
 }: {
   settings: SettingsType;
@@ -129,6 +130,7 @@ export function SettingsModal({
   onRemoveMcpSpec: (spec: string) => void;
   onUpdateMcpSpec: (raw: string, server: ImportedMcpServer) => void;
   onRetryMcpSpec: (raw: string) => void;
+  onToggleMcpSpec: (raw: string) => void;
   onReadMemory: (path: string) => void;
 }) {
   const [page, setPage] = useState<PageId>(initialPage ?? "general");
@@ -213,6 +215,7 @@ export function SettingsModal({
                 onRemove={onRemoveMcpSpec}
                 onUpdate={onUpdateMcpSpec}
                 onRetry={onRetryMcpSpec}
+                onToggle={onToggleMcpSpec}
               />
             )}
             {page === "skills" && (
@@ -1146,6 +1149,7 @@ function PageMCP({
   onRemove,
   onUpdate,
   onRetry,
+  onToggle,
 }: {
   specs: McpSpecInfo[];
   bridged: boolean;
@@ -1156,6 +1160,7 @@ function PageMCP({
   onRemove: (spec: string) => void;
   onUpdate: (raw: string, server: ImportedMcpServer) => void;
   onRetry: (raw: string) => void;
+  onToggle: (raw: string) => void;
 }) {
   const [draft, setDraft] = useState("");
   const [importing, setImporting] = useState(false);
@@ -1268,6 +1273,7 @@ function PageMCP({
               onEdit={setEditing}
               onRetry={onRetry}
               onRemove={onRemove}
+              onToggle={onToggle}
             />
           ))
         )}

--- a/src/cli/commands/desktop.ts
+++ b/src/cli/commands/desktop.ts
@@ -232,6 +232,7 @@ type InMessage = { tabId?: string } & (
   | { cmd: "mcp_import_servers"; servers: unknown[] }
   | { cmd: "mcp_specs_update"; raw: string; server: unknown }
   | { cmd: "mcp_specs_retry"; raw: string }
+  | { cmd: "mcp_specs_toggle"; raw: string }
   | { cmd: "skills_get" }
   | { cmd: "skill_run"; name: string; args?: string }
   | { cmd: "jobs_list" }
@@ -3048,6 +3049,48 @@ export async function desktopCommand(opts: DesktopOptions): Promise<void> {
         void bridgeTabMcp(tab);
       } catch (err) {
         emit({ type: "$error", message: `mcp_specs_retry: ${(err as Error).message}` }, tab.id);
+      }
+      return;
+    }
+    if (msg.cmd === "mcp_specs_toggle") {
+      try {
+        const cfg = readConfig();
+        const parsed = parseMcpSpec(msg.raw);
+        const isCurrentlyDisabled =
+          (parsed.name && cfg.mcpServers?.[parsed.name]?.disabled === true) ||
+          (parsed.name && (cfg.mcpDisabled ?? []).includes(parsed.name));
+        const serverCfg = parsed.name ? cfg.mcpServers?.[parsed.name] : undefined;
+        if (parsed.name && serverCfg) {
+          serverCfg.disabled = !isCurrentlyDisabled;
+          if (!serverCfg.disabled) serverCfg.disabled = undefined;
+          if (Object.keys(serverCfg).length === 0 && cfg.mcpServers) {
+            delete cfg.mcpServers[parsed.name];
+          }
+          if (cfg.mcpServers && Object.keys(cfg.mcpServers).length === 0) {
+            cfg.mcpServers = undefined;
+          }
+        } else {
+          const disabled = new Set(cfg.mcpDisabled ?? []);
+          if (parsed.name && isCurrentlyDisabled) {
+            disabled.delete(parsed.name);
+          } else if (parsed.name) {
+            disabled.add(parsed.name);
+          }
+          cfg.mcpDisabled = disabled.size > 0 ? [...disabled].sort() : undefined;
+        }
+        writeConfig(cfg);
+        if (isCurrentlyDisabled) {
+          tab.mcpStatuses.delete(msg.raw);
+        } else {
+          tab.mcpStatuses.set(msg.raw, { kind: "disabled" });
+        }
+        emitMcpSpecs(tab);
+        void tab.mcpRuntime?.removeSpec(msg.raw, tab.runtime?.loop).catch(() => {});
+        if (!isCurrentlyDisabled) {
+          void tab.mcpRuntime?.addSpec(msg.raw, tab.runtime?.loop).catch(() => {});
+        }
+      } catch (err) {
+        emit({ type: "$error", message: `mcp_specs_toggle: ${(err as Error).message}` }, tab.id);
       }
       return;
     }


### PR DESCRIPTION
## 背景

目前启用或禁用 MCP 服务器需要手动编辑配置文件或使用斜杠命令，且需要重启应用才能生效。Desktop 设置界面中没有可视化的开关来管理 MCP 服务器状态。

## 变更内容

在设置 → MCP 页面中，为每个 MCP 服务器卡片添加了图形化 Toggle 开关，用户可以单击切换启用/禁用状态，变更立即生效，无需重启应用。

## 实现方式

- 前端：在 McpServerCard 组件中添加滑动开关，ON 为绿色，OFF 为灰色
- 后端：新增 mcp_specs_toggle RPC 命令，持久化配置并实时连接/断开

## 修改文件

```
 desktop/src/protocol.ts            |  1 +
 desktop/src/App.tsx                |  5 ++
 desktop/src/ui/settings.tsx        |  6 ++
 desktop/src/ui/mcp-server-card.tsx | 18 ++++
 desktop/src/styles.css             | 57 +++++
 desktop/src/i18n/en.ts             |  2 +
 desktop/src/i18n/zh-CN.ts          |  2 +
 src/cli/commands/desktop.ts        | 43 ++++
 8 files changed, 134 insertions(+)
```

## 测试

- TypeScript 类型检查通过
- 生产构建通过
- Toggle 开关 UI 正常显示并可切换