### PR TITLE
fix(desktop): increase sidebar min-width, prevent text wrap in new-ch…

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1049,6 +1049,7 @@ html[data-platform="macos"] .titlebar .tb-left {
   display: inline-flex;
   align-items: center;
   flex-wrap: nowrap;
+  overflow: hidden;
   gap: 8px;
   padding: 0 10px;
   font-size: 14px;

--- a/desktop/src/ui/useResizable.ts
+++ b/desktop/src/ui/useResizable.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getThreadMaxWidth } from "./thread-layout";
 
-const MIN_WIDTH = 200;
+const MIN_WIDTH = 220;
 const MAX_WIDTH_PCT = 0.4;
 const CSS_VAR = { side: "--side-width", ctx: "--ctx-width" } as const;
 const PERSIST_KEY_SIDE = "reasonix.sideWidth";


### PR DESCRIPTION

<!-- Read CONTRIBUTING.md first if this is your first PR. -->

## What

Increase sidebar minimum width from 200px to 220px and add `overflow: hidden` 
to the new-chat button to prevent CJK text wrapping. / 增大侧边栏最小宽度，
防止新会话按钮内中文文字换行。

## Why

The sidebar can be dragged to 200px wide, leaving only ~100px for the 
"new-chat" button. "新会话" (3 CJK characters) needs ~95px, leaving 
virtually no margin — "话" wraps to the next line on some font renderings. 
/ 侧边栏可拖拽至 200px，按钮可用空间不足 100px，三字约需 95px，
在部分字体渲染下"话"字被换行。

## How to verify

1. Drag sidebar to its narrowest position
2. "新会话" should stay on one line inside the button
3. `npm run verify` passes locally

## Checklist

- [x] `npm run verify` passes locally (lint + typecheck + tests + comment-policy gate)
- [x] No `Co-Authored-By: Claude` trailer in commits
- [x] Comments follow CONTRIBUTING.md (no module-essay headers, no incident history)
- [x] No edits to `CHANGELOG.md` — release notes are maintainer-written at release time
