### PR TITLE
fix(desktop): sidebar new-chat button text overflow on narrow containers

### DIFF
--- a/desktop/src/styles.css
+++ b/desktop/src/styles.css
@@ -1057,6 +1057,8 @@ html[data-platform="macos"] .titlebar .tb-left {
   background: var(--accent);
   color: oklch(99% 0 0);
   box-shadow: var(--shadow-sm);
+  white-space: nowrap;
+  overflow: hidden;
 }
 .side-head .new-btn:hover {
   background: var(--accent-strong);
@@ -1066,6 +1068,7 @@ html[data-platform="macos"] .titlebar .tb-left {
 }
 .side-head .new-btn > span:not(.shortcut) {
   min-width: 0;
+  display: inline-block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/tests/desktop-sidebar-new-chat-layout.test.ts
+++ b/tests/desktop-sidebar-new-chat-layout.test.ts
@@ -14,11 +14,14 @@ describe("desktop sidebar new chat button layout", () => {
     expect(cssRule(".sidebar")).toContain("container: sidebar / inline-size");
     expect(cssRule(".side-head .new-btn")).toContain("flex-wrap: nowrap");
     expect(cssRule(".side-head .new-btn")).toContain("min-width: 0");
+    expect(cssRule(".side-head .new-btn")).toContain("white-space: nowrap");
+    expect(cssRule(".side-head .new-btn")).toContain("overflow: hidden");
     expect(cssRule(".side-head .new-btn svg")).toContain("flex: 0 0 auto");
     expect(cssRule(".side-head .new-btn > span:not(.shortcut)")).toContain("white-space: nowrap");
     expect(cssRule(".side-head .new-btn > span:not(.shortcut)")).toContain(
       "text-overflow: ellipsis",
     );
+    expect(cssRule(".side-head .new-btn > span:not(.shortcut)")).toContain("display: inline-block");
     expect(cssRule(".side-head .new-btn .shortcut")).toContain("flex: 0 0 auto");
     expect(cssRule(".side-head .new-btn .shortcut")).toContain("display: none");
     expect(css).toContain("@container sidebar (min-width: 191px)");


### PR DESCRIPTION
## What

修复桌面端侧边栏"New Chat"按钮在窄容器下的文本溢出问题。为 `.side-head .new-btn` 添加 `white-space: nowrap` 和 `overflow: hidden`，并为文本 span 添加 `display: inline-block` 以确保 `text-overflow: ellipsis` 正确生效。

## Why

侧边栏缩窄时，"New Chat"按钮内的文本可能换行或溢出，破坏按钮布局的整洁性。这是 `flex-wrap: nowrap` 和 `min-width: 0` 设置后的补充修复，确保 ellipsis 截断在 flex 子元素上正常工作。

## How to verify

1. 启动桌面端：`cd desktop && npm run dev`
2. 将侧边栏宽度缩至 191px 以下
3. 确认"New Chat"按钮文本显示为单行省略号，不换行溢出

#2113 