### PR TITLE
fix(cli): auto-scroll to bottom on turn end (#2378)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3700,6 +3700,7 @@ function AppInner({
       generateCurrentSessionTitle,
       switchWorkspaceRoot,
       system,
+      chatScroll,
     ],
   );
 

--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -3616,6 +3616,9 @@ function AppInner({
         setSummary(loop.stats.summary());
         busyRef.current = false;
         setBusy(false);
+        // Re-pin after turn end so scrolled-up users still land on the
+        // final answer without needing to press End manually.
+        chatScroll.jumpToBottom();
         submittingRef.current = false;
         qq.clearTurnReply();
         telegram.clearTurnReply();


### PR DESCRIPTION
## Summary

When the user scrolls up during a streaming turn, the chat-scroll-store sets `pinned=false` and the viewport stays at the user's position. On turn end, nothing re-pinned the viewport, so the user had to manually scroll down or press End to see the final answer.

This PR adds `chatScroll.jumpToBottom()` after `setBusy(false)` in the main turn execution path so the viewport always settles on the final output.

## Root Cause

Reasonix has two scroll implementations:

| | Desktop/Web (`useAutoScroll.ts`) | CLI/Ink (`chat-scroll-store.ts`) |
|---|---|---|
| Turn-end re-pin | Already handled via busy transition | Missing — `pinned` stayed `false` |

The desktop version already handles this correctly (fixed in #1182). This PR brings the CLI version to parity.

## Change

**1 file, +3 lines** — `src/cli/ui/App.tsx`

## Related

- Closes #2378
- Closes #2372
- Related: #2159, #2071