### PR TITLE
fix: skip saving empty conversations to history when switching workspace/model

### DIFF
--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -108,6 +108,12 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 		}
 		full := filepath.Join(dir, e.Name())
 		preview, turns := previewSession(full)
+		if turns == 0 {
+			// Skip sessions that have never had user interaction — they are
+			// empty conversations that should not appear in the history panel
+			// or the resume picker.
+			continue
+		}
 		out = append(out, SessionInfo{
 			Path:    full,
 			ModTime: info.ModTime(),

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -22,3 +22,15 @@ func NewSession(system string) *Session {
 func (s *Session) Add(m provider.Message) {
 	s.Messages = append(s.Messages, m)
 }
+
+// HasContent returns true when the session carries at least one user,
+// assistant, or tool message — i.e. more than just a system prompt. An
+// "empty" conversation that has never been used should not be persisted.
+func (s *Session) HasContent() bool {
+	for _, m := range s.Messages {
+		if m.Role != provider.RoleSystem {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -538,8 +538,9 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 }
 
 // Snapshot writes the executor's conversation to the active session file. No-op
-// when persistence is unavailable. Called after every turn so a crash loses at
-// most one in-flight prompt.
+// when persistence is unavailable or the session has never been used (no user
+// interaction). Called after every turn so a crash loses at most one in-flight
+// prompt.
 func (c *Controller) Snapshot() error {
 	c.mu.Lock()
 	path := c.sessionPath
@@ -547,7 +548,11 @@ func (c *Controller) Snapshot() error {
 	if c.executor == nil || path == "" {
 		return nil
 	}
-	return c.executor.Session().Save(path)
+	s := c.executor.Session()
+	if !s.HasContent() {
+		return nil
+	}
+	return s.Save(path)
 }
 
 // SetSessionPath pins where auto-save lands (a fresh session file minted by the


### PR DESCRIPTION
## Summary

When switching workspace directory or model while the current conversation is empty (only system prompt, no user interaction), `Snapshot()` would still write an empty `.jsonl` file to disk. Repeated switches created cascading empty entries in the history panel.

The same issue existed in the CLI's \`/model\` command.

## Changes

Three layers of defense — prevent creation, clean up pre-existing, all in shared code.

| File | Change |
|---|---|
| \`internal/agent/session.go\` | Added \`HasContent()\` method — returns \`true\` when the session has any user/assistant/tool message beyond the system prompt |
| \`internal/control/controller.go\` | \`Snapshot()\` now checks \`HasContent()\` before writing; empty sessions are silently skipped |
| \`internal/agent/save.go\` | \`ListSessions()\` filters out entries with \`Turns == 0\` (no user messages), hiding pre-existing empty sessions from the history panel and the resume picker |

All changes are in \`internal/\` packages shared by desktop (Wails), CLI (chat TUI), and ACP (HTTP/SSE) frontends — one fix covers all surfaces.

## Testing

- \`go build ./...\` — compiles clean
- \`go test ./internal/agent/... ./internal/control/...\` — all 69 tests pass
- Desktop app built & launched with \`wails dev\`, ready for manual verification

Closes #2400