### PR TITLE
[v2] Stabilize tool schema ordering for prompt cache reuse

### DIFF
--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -53,3 +53,39 @@ func TestRegistryRemovePrefix(t *testing.T) {
 		t.Errorf("RemovePrefix on absent prefix returned %d, want 0", got)
 	}
 }
+
+// TestRegistrySchemasSorted proves Schemas() emits tool definitions in
+// deterministic alphabetical order regardless of insertion order, so a logically
+// identical tool set produces a stable provider-facing request prefix (prompt
+// cache reuse). Names() must stay in insertion order — only the provider export
+// is sorted.
+func TestRegistrySchemasSorted(t *testing.T) {
+	r := NewRegistry()
+	// Add deliberately out of alphabetical order.
+	insertion := []string{"write", "bash", "read", "apply_patch"}
+	for _, n := range insertion {
+		r.Add(stubTool{n})
+	}
+
+	var got []string
+	for _, s := range r.Schemas() {
+		got = append(got, s.Name)
+	}
+	want := []string{"apply_patch", "bash", "read", "write"}
+	if len(got) != len(want) {
+		t.Fatalf("Schemas() names = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("Schemas() names = %v, want %v (alphabetical)", got, want)
+		}
+	}
+
+	// The sort must not leak into Names(): display order stays insertion order.
+	gotNames := r.Names()
+	for i := range insertion {
+		if gotNames[i] != insertion[i] {
+			t.Fatalf("Names() = %v, want %v (insertion order)", gotNames, insertion)
+		}
+	}
+}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -131,10 +131,15 @@ func (r *Registry) Names() []string {
 	return out
 }
 
-// Schemas exports tool definitions in insertion order for the provider.
+// Schemas exports tool definitions in alphabetical order for the provider.
 func (r *Registry) Schemas() []provider.ToolSchema {
-	out := make([]provider.ToolSchema, 0, len(r.order))
-	for _, name := range r.order {
+	names := make([]string, 0, len(r.tools))
+	for n := range r.tools {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]provider.ToolSchema, 0, len(names))
+	for _, name := range names {
 		t := r.tools[name]
 		out = append(out, provider.ToolSchema{
 			Name:        t.Name(),


### PR DESCRIPTION
## Summary
Sort tool schemas alphabetically before sending them to the provider so equivalent tool sets produce a stable request prefix.

## Root Cause
The provider prompt cache is sensitive to byte-level changes in the request prefix. Tool registration order can vary across sessions even when the available tool set is logically identical.

## Technical Approach
`Registry.Schemas()` now builds a sorted list of tool names and emits schemas in deterministic alphabetical order.

## Focused Optimization Points
- Keeps tool display order APIs untouched.
- Stabilizes the provider-facing schema list.
- Limits the change to the registry export path.

## Verification
Not run during this publishing pass. This is opened as a draft PR for upstream review of the split branch.