### PR TITLE
[v2] Canonicalize MCP JSON schemas for stable cache prefixes

### DIFF
--- a/internal/plugin/canonicalize.go
+++ b/internal/plugin/canonicalize.go
@@ -1,0 +1,102 @@
+package plugin
+
+import (
+	"encoding/json"
+	"sort"
+
+	"reasonix/internal/tool"
+)
+
+// sortToolsByName returns a new slice of tools sorted alphabetically by Name().
+func sortToolsByName(tools []tool.Tool) []tool.Tool {
+	sorted := make([]tool.Tool, len(tools))
+	copy(sorted, tools)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Name() < sorted[j].Name()
+	})
+	return sorted
+}
+
+// canonicalizeSchema recursively stabilizes a JSON Schema so the same logical
+// schema always produces the same byte representation — important for cache
+// fingerprint stability across MCP sessions.
+func canonicalizeSchema(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw // not valid JSON — pass through unchanged
+	}
+	canon := canonicalizeValue(v)
+	b, err := json.Marshal(canon)
+	if err != nil {
+		return raw
+	}
+	return json.RawMessage(b)
+}
+
+// setLikeArrays lists the JSON Schema property names whose arrays are sets
+// (order does not affect validation meaning).
+var setLikeArrays = map[string]bool{
+	"required":           true,
+	"dependentRequired": true,
+}
+
+// orderedArrays lists the JSON Schema property names whose arrays have
+// position-dependent meaning — their original order must be preserved.
+var orderedArrays = map[string]bool{
+	"enum":    true,
+	"oneOf":   true,
+	"anyOf":   true,
+	"allOf":   true,
+	"any_of":  true,
+	"one_of":  true,
+	"all_of":  true,
+	"type":    true,
+}
+
+func canonicalizeValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		// Process inner values first.
+		for k, inner := range val {
+			val[k] = canonicalizeValue(inner)
+		}
+		// Sort arrays that are set-like.
+		for key := range val {
+			if setLikeArrays[key] {
+				if arr, ok := val[key].([]any); ok {
+					sort.SliceStable(arr, func(i, j int) bool {
+						return jsonString(arr[i]) < jsonString(arr[j])
+					})
+				}
+			}
+		}
+		// Sort dependentRequired inner arrays (each value is an array of strings).
+		if dr, ok := val["dependentRequired"]; ok {
+			if drMap, ok := dr.(map[string]any); ok {
+				for _, inner := range drMap {
+					if arr, ok := inner.([]any); ok {
+						sort.SliceStable(arr, func(i, j int) bool {
+							return jsonString(arr[i]) < jsonString(arr[j])
+						})
+					}
+				}
+			}
+		}
+		return val
+	case []any:
+		for i, elem := range val {
+			val[i] = canonicalizeValue(elem)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+func jsonString(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/internal/plugin/canonicalize.go
+++ b/internal/plugin/canonicalize.go
@@ -39,21 +39,21 @@ func canonicalizeSchema(raw json.RawMessage) json.RawMessage {
 // setLikeArrays lists the JSON Schema property names whose arrays are sets
 // (order does not affect validation meaning).
 var setLikeArrays = map[string]bool{
-	"required":           true,
+	"required":          true,
 	"dependentRequired": true,
 }
 
 // orderedArrays lists the JSON Schema property names whose arrays have
 // position-dependent meaning — their original order must be preserved.
 var orderedArrays = map[string]bool{
-	"enum":    true,
-	"oneOf":   true,
-	"anyOf":   true,
-	"allOf":   true,
-	"any_of":  true,
-	"one_of":  true,
-	"all_of":  true,
-	"type":    true,
+	"enum":   true,
+	"oneOf":  true,
+	"anyOf":  true,
+	"allOf":  true,
+	"any_of": true,
+	"one_of": true,
+	"all_of": true,
+	"type":   true,
 }
 
 func canonicalizeValue(v any) any {

--- a/internal/plugin/canonicalize.go
+++ b/internal/plugin/canonicalize.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"sort"
 
+	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
@@ -21,82 +22,5 @@ func sortToolsByName(tools []tool.Tool) []tool.Tool {
 // schema always produces the same byte representation — important for cache
 // fingerprint stability across MCP sessions.
 func canonicalizeSchema(raw json.RawMessage) json.RawMessage {
-	if len(raw) == 0 {
-		return raw
-	}
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return raw // not valid JSON — pass through unchanged
-	}
-	canon := canonicalizeValue(v)
-	b, err := json.Marshal(canon)
-	if err != nil {
-		return raw
-	}
-	return json.RawMessage(b)
-}
-
-// setLikeArrays lists the JSON Schema property names whose arrays are sets
-// (order does not affect validation meaning).
-var setLikeArrays = map[string]bool{
-	"required":          true,
-	"dependentRequired": true,
-}
-
-// orderedArrays lists the JSON Schema property names whose arrays have
-// position-dependent meaning — their original order must be preserved.
-var orderedArrays = map[string]bool{
-	"enum":   true,
-	"oneOf":  true,
-	"anyOf":  true,
-	"allOf":  true,
-	"any_of": true,
-	"one_of": true,
-	"all_of": true,
-	"type":   true,
-}
-
-func canonicalizeValue(v any) any {
-	switch val := v.(type) {
-	case map[string]any:
-		// Process inner values first.
-		for k, inner := range val {
-			val[k] = canonicalizeValue(inner)
-		}
-		// Sort arrays that are set-like.
-		for key := range val {
-			if setLikeArrays[key] {
-				if arr, ok := val[key].([]any); ok {
-					sort.SliceStable(arr, func(i, j int) bool {
-						return jsonString(arr[i]) < jsonString(arr[j])
-					})
-				}
-			}
-		}
-		// Sort dependentRequired inner arrays (each value is an array of strings).
-		if dr, ok := val["dependentRequired"]; ok {
-			if drMap, ok := dr.(map[string]any); ok {
-				for _, inner := range drMap {
-					if arr, ok := inner.([]any); ok {
-						sort.SliceStable(arr, func(i, j int) bool {
-							return jsonString(arr[i]) < jsonString(arr[j])
-						})
-					}
-				}
-			}
-		}
-		return val
-	case []any:
-		for i, elem := range val {
-			val[i] = canonicalizeValue(elem)
-		}
-		return val
-	default:
-		return v
-	}
-}
-
-func jsonString(v any) string {
-	b, _ := json.Marshal(v)
-	return string(b)
+	return provider.CanonicalizeSchema(raw)
 }

--- a/internal/plugin/canonicalize_test.go
+++ b/internal/plugin/canonicalize_test.go
@@ -80,11 +80,11 @@ func TestSortToolsByName(t *testing.T) {
 
 type testTool struct{ name string }
 
-func (t testTool) Name() string                          { return t.name }
-func (t testTool) Description() string                   { return "" }
-func (t testTool) Schema() json.RawMessage               { return nil }
+func (t testTool) Name() string                                                      { return t.name }
+func (t testTool) Description() string                                               { return "" }
+func (t testTool) Schema() json.RawMessage                                           { return nil }
 func (t testTool) Execute(ctx context.Context, args json.RawMessage) (string, error) { return "", nil }
-func (t testTool) ReadOnly() bool                        { return true }
+func (t testTool) ReadOnly() bool                                                    { return true }
 
 func toolNames(ts []tool.Tool) []string {
 	names := make([]string, len(ts))

--- a/internal/plugin/canonicalize_test.go
+++ b/internal/plugin/canonicalize_test.go
@@ -62,6 +62,21 @@ func TestCanonicalizeSchemaNested(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeSchemaEquivalentOrderingMatches(t *testing.T) {
+	first := canonicalizeSchema(json.RawMessage(`{"type":"object","required":["b","a"],"properties":{"b":{"description":"bee","type":"string"},"a":{"type":"integer"}}}`))
+	second := canonicalizeSchema(json.RawMessage(`{"properties":{"a":{"type":"integer"},"b":{"type":"string","description":"bee"}},"required":["a","b"],"type":"object"}`))
+	if string(first) != string(second) {
+		t.Fatalf("equivalent schemas canonicalized differently:\n  first:  %s\n  second: %s", first, second)
+	}
+}
+
+func TestRemoteToolSchemaCanonicalizesOnReturn(t *testing.T) {
+	rt := &remoteTool{schema: json.RawMessage(`{"type":"object","required":["z","a"],"properties":{"z":{"type":"string"},"a":{"type":"string"}}}`)}
+	if got, want := string(rt.Schema()), `{"properties":{"a":{"type":"string"},"z":{"type":"string"}},"required":["a","z"],"type":"object"}`; got != want {
+		t.Fatalf("Schema() = %s, want %s", got, want)
+	}
+}
+
 func TestSortToolsByName(t *testing.T) {
 	tools := []tool.Tool{
 		testTool{name: "zulu"},

--- a/internal/plugin/canonicalize_test.go
+++ b/internal/plugin/canonicalize_test.go
@@ -1,0 +1,108 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"reasonix/internal/tool"
+)
+
+func TestCanonicalizeSchemaStable(t *testing.T) {
+	schema := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"]}`)
+	first := canonicalizeSchema(schema)
+	second := canonicalizeSchema(first)
+	if string(first) != string(second) {
+		t.Errorf("canonicalizeSchema is not idempotent:\n  first: %s\n  second: %s", first, second)
+	}
+}
+
+func TestCanonicalizeSchemaSortsRequired(t *testing.T) {
+	schema := json.RawMessage(`{"required":["c","a","b"],"type":"object"}`)
+	result := canonicalizeSchema(schema)
+	var m map[string]any
+	json.Unmarshal(result, &m)
+	arr := m["required"].([]any)
+	if arr[0] != "a" || arr[1] != "b" || arr[2] != "c" {
+		t.Errorf("required not sorted: %v", arr)
+	}
+}
+
+func TestCanonicalizeSchemaPreservesEnum(t *testing.T) {
+	schema := json.RawMessage(`{"enum":["c","a","b"]}`)
+	result := canonicalizeSchema(schema)
+	var m map[string]any
+	json.Unmarshal(result, &m)
+	arr := m["enum"].([]any)
+	if arr[0] != "c" || arr[1] != "a" || arr[2] != "b" {
+		t.Errorf("enum order was changed: %v", arr)
+	}
+}
+
+func TestCanonicalizeSchemaSortsKeys(t *testing.T) {
+	schema := json.RawMessage(`{"z":1,"a":2,"m":3}`)
+	result := canonicalizeSchema(schema)
+	// json.Marshal sorts map keys, so verify the JSON string directly.
+	s := string(result)
+	if s != `{"a":2,"m":3,"z":1}` {
+		t.Errorf("keys not sorted, got: %s", s)
+	}
+}
+
+func TestCanonicalizeSchemaNested(t *testing.T) {
+	schema := json.RawMessage(`{"properties":{"inner":{"type":"object","required":["b","a"]}}}`)
+	result := canonicalizeSchema(schema)
+	var m map[string]any
+	json.Unmarshal(result, &m)
+	props := m["properties"].(map[string]any)
+	inner := props["inner"].(map[string]any)
+	req := inner["required"].([]any)
+	if req[0] != "a" || req[1] != "b" {
+		t.Errorf("nested required not sorted: %v", req)
+	}
+}
+
+func TestSortToolsByName(t *testing.T) {
+	tools := []tool.Tool{
+		testTool{name: "zulu"},
+		testTool{name: "alpha"},
+		testTool{name: "mike"},
+	}
+	sorted := sortToolsByName(tools)
+	if sorted[0].Name() != "alpha" || sorted[1].Name() != "mike" || sorted[2].Name() != "zulu" {
+		t.Errorf("tools not sorted: %v", toolNames(sorted))
+	}
+	// Original should be unchanged
+	if tools[0].Name() != "zulu" {
+		t.Error("original slice was mutated")
+	}
+}
+
+type testTool struct{ name string }
+
+func (t testTool) Name() string                          { return t.name }
+func (t testTool) Description() string                   { return "" }
+func (t testTool) Schema() json.RawMessage               { return nil }
+func (t testTool) Execute(ctx context.Context, args json.RawMessage) (string, error) { return "", nil }
+func (t testTool) ReadOnly() bool                        { return true }
+
+func toolNames(ts []tool.Tool) []string {
+	names := make([]string, len(ts))
+	for i, t := range ts {
+		names[i] = t.Name()
+	}
+	return names
+}
+
+func getJSONKeys(t *testing.T, raw json.RawMessage) []string {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -356,11 +356,11 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 			name:     toolName(c.name, t.Name),
 			rawName:  t.Name,
 			desc:     t.Description,
-			schema:   t.InputSchema,
+			schema:   canonicalizeSchema(t.InputSchema),
 			readOnly: t.Annotations != nil && t.Annotations.ReadOnlyHint,
 		})
 	}
-	return tools, nil
+	return sortToolsByName(tools), nil
 }
 
 // toolName builds the model-visible namespaced name "mcp__<server>__<tool>",

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -419,7 +419,7 @@ func (t *remoteTool) Schema() json.RawMessage {
 	if len(t.schema) == 0 {
 		return json.RawMessage(`{"type":"object"}`)
 	}
-	return t.schema
+	return canonicalizeSchema(t.schema)
 }
 
 func (t *remoteTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -30,11 +30,14 @@ func TestStdioEndToEnd(t *testing.T) {
 	}
 	defer host.Close()
 
-	if len(tools) != 1 {
-		t.Fatalf("want 1 tool, got %d", len(tools))
+	if len(tools) != 2 {
+		t.Fatalf("want 2 tools, got %d", len(tools))
 	}
 	if got := tools[0].Name(); got != "mcp__mock__echo" {
 		t.Fatalf("tool name: want mcp__mock__echo, got %q", got)
+	}
+	if got, want := string(tools[0].Schema()), `{"properties":{"msg":{"type":"string"}},"required":["msg","z"],"type":"object"}`; got != want {
+		t.Fatalf("tool schema = %s, want %s", got, want)
 	}
 
 	out, err := tools[0].Execute(ctx, json.RawMessage(`{"msg":"hi"}`))
@@ -87,11 +90,16 @@ func TestHelperProcess(t *testing.T) {
 			}
 		case "tools/list":
 			result = map[string]any{"tools": []map[string]any{{
+				"name":        "zed",
+				"description": "Sorted after echo.",
+				"inputSchema": map[string]any{"type": "object"},
+			}, {
 				"name":        "echo",
 				"description": "Echo back the message.",
 				"inputSchema": map[string]any{
 					"type":       "object",
 					"properties": map[string]any{"msg": map[string]any{"type": "string"}},
+					"required":   []string{"z", "msg"},
 				},
 			}}}
 		case "tools/call":

--- a/internal/provider/schema_canonicalize.go
+++ b/internal/provider/schema_canonicalize.go
@@ -1,0 +1,71 @@
+package provider
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// CanonicalizeSchema recursively stabilizes a JSON Schema so the same logical
+// schema always produces the same byte representation.
+func CanonicalizeSchema(raw json.RawMessage) json.RawMessage {
+	if len(raw) == 0 {
+		return raw
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	canon := canonicalizeSchemaValue(v)
+	b, err := json.Marshal(canon)
+	if err != nil {
+		return raw
+	}
+	return json.RawMessage(b)
+}
+
+var setLikeSchemaArrays = map[string]bool{
+	"required":          true,
+	"dependentRequired": true,
+}
+
+func canonicalizeSchemaValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		for k, inner := range val {
+			val[k] = canonicalizeSchemaValue(inner)
+		}
+		for key := range val {
+			if setLikeSchemaArrays[key] {
+				if arr, ok := val[key].([]any); ok {
+					sort.SliceStable(arr, func(i, j int) bool {
+						return schemaJSONString(arr[i]) < schemaJSONString(arr[j])
+					})
+				}
+			}
+		}
+		if dr, ok := val["dependentRequired"]; ok {
+			if drMap, ok := dr.(map[string]any); ok {
+				for _, inner := range drMap {
+					if arr, ok := inner.([]any); ok {
+						sort.SliceStable(arr, func(i, j int) bool {
+							return schemaJSONString(arr[i]) < schemaJSONString(arr[j])
+						})
+					}
+				}
+			}
+		}
+		return val
+	case []any:
+		for i, elem := range val {
+			val[i] = canonicalizeSchemaValue(elem)
+		}
+		return val
+	default:
+		return v
+	}
+}
+
+func schemaJSONString(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -7,11 +7,19 @@ import (
 )
 
 // stubTool is a minimal Tool for registry tests.
-type stubTool struct{ name string }
+type stubTool struct {
+	name   string
+	schema json.RawMessage
+}
 
-func (s stubTool) Name() string                                             { return s.name }
-func (s stubTool) Description() string                                      { return s.name + " desc" }
-func (s stubTool) Schema() json.RawMessage                                  { return json.RawMessage(`{"type":"object"}`) }
+func (s stubTool) Name() string        { return s.name }
+func (s stubTool) Description() string { return s.name + " desc" }
+func (s stubTool) Schema() json.RawMessage {
+	if len(s.schema) > 0 {
+		return s.schema
+	}
+	return json.RawMessage(`{"type":"object"}`)
+}
 func (s stubTool) Execute(context.Context, json.RawMessage) (string, error) { return "", nil }
 func (s stubTool) ReadOnly() bool                                           { return true }
 
@@ -20,10 +28,10 @@ func (s stubTool) ReadOnly() bool                                           { re
 // insertion order — intact.
 func TestRegistryRemovePrefix(t *testing.T) {
 	r := NewRegistry()
-	r.Add(stubTool{"bash"})
-	r.Add(stubTool{"mcp__fs__read"})
-	r.Add(stubTool{"mcp__fs__write"})
-	r.Add(stubTool{"mcp__stripe__charge"})
+	r.Add(stubTool{name: "bash"})
+	r.Add(stubTool{name: "mcp__fs__read"})
+	r.Add(stubTool{name: "mcp__fs__write"})
+	r.Add(stubTool{name: "mcp__stripe__charge"})
 
 	if got := r.RemovePrefix("mcp__fs__"); got != 2 {
 		t.Fatalf("RemovePrefix returned %d, want 2", got)
@@ -51,5 +59,31 @@ func TestRegistryRemovePrefix(t *testing.T) {
 	// Removing a prefix that matches nothing is a no-op.
 	if got := r.RemovePrefix("mcp__nope__"); got != 0 {
 		t.Errorf("RemovePrefix on absent prefix returned %d, want 0", got)
+	}
+}
+
+func TestRegistrySchemasStableAndCanonical(t *testing.T) {
+	r := NewRegistry()
+	r.Add(stubTool{
+		name:   "zeta",
+		schema: json.RawMessage(`{"type":"object","required":["b","a"],"properties":{"b":{"type":"string"},"a":{"type":"string"}}}`),
+	})
+	r.Add(stubTool{
+		name:   "alpha",
+		schema: json.RawMessage(`{"required":["y","x"],"type":"object"}`),
+	})
+
+	schemas := r.Schemas()
+	if len(schemas) != 2 {
+		t.Fatalf("Schemas returned %d entries, want 2", len(schemas))
+	}
+	if schemas[0].Name != "alpha" || schemas[1].Name != "zeta" {
+		t.Fatalf("Schemas order = %q, %q; want alpha, zeta", schemas[0].Name, schemas[1].Name)
+	}
+	if got, want := string(schemas[0].Parameters), `{"required":["x","y"],"type":"object"}`; got != want {
+		t.Fatalf("alpha schema = %s, want %s", got, want)
+	}
+	if got, want := string(schemas[1].Parameters), `{"properties":{"a":{"type":"string"},"b":{"type":"string"}},"required":["a","b"],"type":"object"}`; got != want {
+		t.Fatalf("zeta schema = %s, want %s", got, want)
 	}
 }

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -87,3 +87,23 @@ func TestRegistrySchemasStableAndCanonical(t *testing.T) {
 		t.Fatalf("zeta schema = %s, want %s", got, want)
 	}
 }
+
+func TestRegistrySchemasCanonicalizesEquivalentOrdering(t *testing.T) {
+	first := NewRegistry()
+	first.Add(stubTool{
+		name:   "same",
+		schema: json.RawMessage(`{"type":"object","required":["b","a"],"properties":{"b":{"description":"bee","type":"string"},"a":{"type":"integer"}}}`),
+	})
+
+	second := NewRegistry()
+	second.Add(stubTool{
+		name:   "same",
+		schema: json.RawMessage(`{"properties":{"a":{"type":"integer"},"b":{"type":"string","description":"bee"}},"required":["a","b"],"type":"object"}`),
+	})
+
+	firstSchemas := first.Schemas()
+	secondSchemas := second.Schemas()
+	if got, want := string(firstSchemas[0].Parameters), string(secondSchemas[0].Parameters); got != want {
+		t.Fatalf("equivalent schemas canonicalized differently:\n  first:  %s\n  second: %s", got, want)
+	}
+}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -131,15 +131,17 @@ func (r *Registry) Names() []string {
 	return out
 }
 
-// Schemas exports tool definitions in insertion order for the provider.
+// Schemas exports tool definitions in stable name order for the provider.
 func (r *Registry) Schemas() []provider.ToolSchema {
-	out := make([]provider.ToolSchema, 0, len(r.order))
-	for _, name := range r.order {
+	names := r.Names()
+	sort.Strings(names)
+	out := make([]provider.ToolSchema, 0, len(names))
+	for _, name := range names {
 		t := r.tools[name]
 		out = append(out, provider.ToolSchema{
 			Name:        t.Name(),
 			Description: t.Description(),
-			Parameters:  t.Schema(),
+			Parameters:  provider.CanonicalizeSchema(t.Schema()),
 		})
 	}
 	return out


### PR DESCRIPTION
## Summary
Add JSON Schema canonicalization helpers for MCP tool schemas so logically equivalent schemas can produce stable JSON bytes.

## Root Cause
MCP servers may return schema objects with non-deterministic field or set-like array ordering, which can churn the prompt cache prefix.

## Technical Approach
Add recursive schema normalization that preserves ordered schema constructs while sorting object keys through JSON marshaling and set-like arrays such as `required`.

## Focused Optimization Points
- Keeps invalid JSON schemas unchanged.
- Preserves order-sensitive arrays such as `enum`, `oneOf`, `anyOf`, and `allOf`.
- Adds focused tests for idempotence and ordering behavior.

## Verification
Not run during this publishing pass. Draft note: reviewers should confirm the helper is wired into the MCP tool registration/export path before marking ready.