### PR TITLE
[v2] Make compaction summaries structured and economical

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -161,7 +161,7 @@ func (a *Agent) ContextWindow() int { return a.contextWindow }
 // usage-ratio threshold maybeCompact normally honours. Used by the chat
 // TUI's `/compact` command so the user can reset the prefix before it
 // naturally fills up.
-func (a *Agent) CompactNow(ctx context.Context) error { return a.compact(ctx) }
+func (a *Agent) CompactNow(ctx context.Context) error { return a.compact(ctx, true) }
 
 // Options configures an Agent.
 type Options struct {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -117,10 +117,13 @@ type Agent struct {
 	// Context management: when a turn's prompt nears contextWindow, the older
 	// middle of the session is summarized away, keeping recentKeep messages
 	// verbatim and archiving the originals under archiveDir.
-	contextWindow int
-	compactRatio  float64
-	recentKeep    int
-	archiveDir    string
+	contextWindow      int
+	softCompactRatio   float64
+	compactRatio       float64
+	compactForceRatio  float64
+	softCompactNoticed bool
+	recentKeep         int
+	archiveDir         string
 }
 
 // SetPlanMode flips the read-only gate. While true, executeOne refuses any
@@ -172,12 +175,14 @@ type Options struct {
 	// Gate is the per-call permission gate. nil disables gating.
 	Gate Gate
 
-	// Context management. ContextWindow <= 0 disables compaction. CompactRatio
-	// and RecentKeep fall back to defaults when unset.
-	ContextWindow int
-	CompactRatio  float64
-	RecentKeep    int
-	ArchiveDir    string
+	// Context management. ContextWindow <= 0 disables compaction. Ratios and
+	// RecentKeep fall back to defaults when unset.
+	ContextWindow     int
+	SoftCompactRatio  float64
+	CompactRatio      float64
+	CompactForceRatio float64
+	RecentKeep        int
+	ArchiveDir        string
 }
 
 // New constructs an Agent. MaxSteps <= 0 means no cap — the run loop continues
@@ -185,8 +190,14 @@ type Options struct {
 // provider errors (compaction keeps the context bounded). A nil sink is replaced
 // with event.Discard so the agent can always emit unconditionally.
 func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Options, sink event.Sink) *Agent {
+	if opts.SoftCompactRatio <= 0 {
+		opts.SoftCompactRatio = defaultSoftCompactRatio
+	}
 	if opts.CompactRatio <= 0 {
 		opts.CompactRatio = defaultCompactRatio
+	}
+	if opts.CompactForceRatio <= 0 {
+		opts.CompactForceRatio = defaultCompactForceRatio
 	}
 	if opts.RecentKeep <= 0 {
 		opts.RecentKeep = defaultRecentKeep
@@ -195,18 +206,20 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		sink = event.Discard
 	}
 	return &Agent{
-		prov:          prov,
-		tools:         tools,
-		session:       session,
-		maxSteps:      opts.MaxSteps,
-		temperature:   opts.Temperature,
-		pricing:       opts.Pricing,
-		sink:          sink,
-		gate:          opts.Gate,
-		contextWindow: opts.ContextWindow,
-		compactRatio:  opts.CompactRatio,
-		recentKeep:    opts.RecentKeep,
-		archiveDir:    opts.ArchiveDir,
+		prov:              prov,
+		tools:             tools,
+		session:           session,
+		maxSteps:          opts.MaxSteps,
+		temperature:       opts.Temperature,
+		pricing:           opts.Pricing,
+		sink:              sink,
+		gate:              opts.Gate,
+		contextWindow:     opts.ContextWindow,
+		softCompactRatio:  opts.SoftCompactRatio,
+		compactRatio:      opts.CompactRatio,
+		compactForceRatio: opts.CompactForceRatio,
+		recentKeep:        opts.RecentKeep,
+		archiveDir:        opts.ArchiveDir,
 	}
 }
 

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -19,8 +19,9 @@ import (
 // context window, then we compact once — summarizing the older history and
 // archiving the originals — so a long task can keep going.
 const (
-	defaultCompactRatio      = 0.5 // try compacting when prompt_tokens reach this fraction of the window
-	defaultCompactForceRatio = 0.8 // force compaction at this high-water mark even for low-value folds
+	defaultSoftCompactRatio  = 0.5 // report growing context here, but keep the cache-stable prefix intact
+	defaultCompactRatio      = 0.8 // try compacting when prompt_tokens reach this fraction of the window
+	defaultCompactForceRatio = 0.9 // force compaction at this high-water mark even for low-value folds
 	defaultRecentKeep        = 8   // recent messages kept verbatim, never summarized
 	minCompactMessages       = 2   // skip compaction below this many compactable messages
 )
@@ -63,7 +64,14 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
 		return
 	}
-	force := u.PromptTokens >= int(float64(a.contextWindow)*defaultCompactForceRatio)
+	if u.PromptTokens >= int(float64(a.contextWindow)*a.softCompactRatio) &&
+		u.PromptTokens < int(float64(a.contextWindow)*a.compactRatio) &&
+		!a.softCompactNoticed {
+		a.softCompactNoticed = true
+		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("context reached %.0f%% of window; keeping cache-first prefix until compact threshold %.0f%%", a.softCompactRatio*100, a.compactRatio*100)})
+		return
+	}
+	force := u.PromptTokens >= int(float64(a.contextWindow)*a.compactForceRatio)
 	if !force && u.PromptTokens < int(float64(a.contextWindow)*a.compactRatio) {
 		return
 	}

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -23,16 +23,36 @@ const (
 	minCompactMessages  = 2   // skip compaction below this many compactable messages
 )
 
+// summaryTag wraps the compaction summary so the model can distinguish it from
+// live user input and the agent can later strip or skip it when reasoning about
+// the current turn.
+const (
+	summaryTagOpen  = "<compaction-summary>"
+	summaryTagClose = "</compaction-summary>"
+)
+
 // summarySystemPrompt steers the executor to distill older history into a
-// briefing it can keep relying on after the originals are dropped.
+// structured briefing with Goal / Decisions / Files / Commands / Pending
+// sections so the compacted summary remains scannable and reliable.
 const summarySystemPrompt = `You are compacting the earlier part of a coding agent's conversation to save context.
-Summarize the messages below into a compact briefing the agent can rely on to continue the task. Preserve:
-- the user's goal and any explicit requirements or constraints
-- key decisions made and their rationale
-- files read or modified and the important facts learned about them
-- commands run and their relevant outcomes
-- what is still pending or in progress
-Omit small talk and redundant detail. Use terse bullet points. Do not invent information.`
+Summarize the messages below into a structured briefing using these five sections exactly:
+
+## Goal
+- The user's original request, explicit requirements, and constraints.
+
+## Decisions
+- Key architectural and implementation decisions made, with rationale.
+
+## Files
+- Files examined, created, or modified, with important facts learned.
+
+## Commands
+- Commands executed and their relevant outcomes.
+
+## Pending
+- Tasks still in progress, unresolved issues, and next steps.
+
+Be concise. Use bullet points. Do not invent information not present in the transcript.`
 
 // maybeCompact compacts the session when the last turn's prompt has grown to the
 // configured fraction of the context window. It is a no-op when compaction is
@@ -49,6 +69,21 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	}
 }
 
+// foldEconomics estimates whether compacting the given region saves enough
+// tokens to justify the summarization API call. It returns false when the
+// region is too small for the savings to outweigh the extra round-trip cost
+// and latency of calling the summarizer.
+//
+// Economic model: the summarizer call itself consumes roughly region (input) +
+// summary (output) tokens, and each future turn saves roughly region - summary
+// tokens. A region below ~400 estimated tokens rarely breaks even across the
+// handful of turns that typically follow a compaction.
+func foldEconomics(region []provider.Message) bool {
+	const avgTokensPerMessage = 100
+	const minFoldTokens = 400
+	return len(region)*avgTokensPerMessage >= minFoldTokens
+}
+
 // compact summarizes the older middle of the session and replaces it in place:
 // the session becomes system + summary + recent tail. The dropped originals are
 // archived first, so the full history stays traceable.
@@ -59,6 +94,12 @@ func (a *Agent) compact(ctx context.Context) error {
 		return nil // recent tail already covers everything worth keeping
 	}
 	region := msgs[head:start]
+
+	// Economic check: skip if the region is too small to justify the
+	// summarizer call.
+	if !foldEconomics(region) {
+		return nil
+	}
 
 	archived := ""
 	if a.archiveDir != "" {
@@ -77,8 +118,11 @@ func (a *Agent) compact(ctx context.Context) error {
 	compacted := make([]provider.Message, 0, head+1+len(msgs)-start)
 	compacted = append(compacted, msgs[:head]...)
 	compacted = append(compacted, provider.Message{
-		Role:    provider.RoleUser,
-		Content: "Summary of earlier conversation (older messages were compacted to save context):\n" + summary,
+		Role: provider.RoleUser,
+		Content: summaryTagOpen + "\n" +
+			"Summary of earlier conversation (older messages were compacted to save context):\n" +
+			summary + "\n" +
+			summaryTagClose,
 	})
 	compacted = append(compacted, msgs[start:]...)
 	a.session.Messages = compacted

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -73,15 +74,42 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 // tokens to justify the summarization API call. It returns false when the
 // region is too small for the savings to outweigh the extra round-trip cost
 // and latency of calling the summarizer.
-//
-// Economic model: the summarizer call itself consumes roughly region (input) +
-// summary (output) tokens, and each future turn saves roughly region - summary
-// tokens. A region below ~400 estimated tokens rarely breaks even across the
-// handful of turns that typically follow a compaction.
 func foldEconomics(region []provider.Message) bool {
-	const avgTokensPerMessage = 100
 	const minFoldTokens = 400
-	return len(region)*avgTokensPerMessage >= minFoldTokens
+	return estimateMessagesTokens(region) >= minFoldTokens
+}
+
+func estimateMessagesTokens(msgs []provider.Message) int {
+	total := 0
+	for _, m := range msgs {
+		total += 4 // chat-message framing overhead
+		total += estimateTextTokens(m.Content)
+		total += estimateTextTokens(m.ReasoningContent)
+		total += estimateTextTokens(m.Name)
+		total += estimateTextTokens(m.ToolCallID)
+		for _, tc := range m.ToolCalls {
+			total += 8
+			total += estimateTextTokens(tc.ID)
+			total += estimateTextTokens(tc.Name)
+			total += estimateTextTokens(tc.Arguments)
+		}
+	}
+	return total
+}
+
+func estimateTextTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	// A conservative cross-language approximation: English-ish text trends near
+	// four bytes per token, while CJK-heavy text is closer to one rune per token.
+	bytes := len(s)
+	runes := utf8.RuneCountInString(s)
+	byBytes := (bytes + 3) / 4
+	if runes > byBytes {
+		return runes
+	}
+	return byBytes
 }
 
 // compact summarizes the older middle of the session and replaces it in place:
@@ -90,6 +118,12 @@ func foldEconomics(region []provider.Message) bool {
 func (a *Agent) compact(ctx context.Context) error {
 	msgs := a.session.Messages
 	head, start, ok := compactBounds(msgs, a.recentKeep, minCompactMessages)
+	if !ok {
+		// A single huge message can still be worth folding. Keep the normal
+		// message-count guard for small histories, but let content size decide
+		// whether a one-message region has real compaction value.
+		head, start, ok = compactBounds(msgs, a.recentKeep, 1)
+	}
 	if !ok {
 		return nil // recent tail already covers everything worth keeping
 	}

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -19,9 +19,10 @@ import (
 // context window, then we compact once — summarizing the older history and
 // archiving the originals — so a long task can keep going.
 const (
-	defaultCompactRatio = 0.8 // compact when prompt_tokens reach this fraction of the window
-	defaultRecentKeep   = 8   // recent messages kept verbatim, never summarized
-	minCompactMessages  = 2   // skip compaction below this many compactable messages
+	defaultCompactRatio      = 0.5 // try compacting when prompt_tokens reach this fraction of the window
+	defaultCompactForceRatio = 0.8 // force compaction at this high-water mark even for low-value folds
+	defaultRecentKeep        = 8   // recent messages kept verbatim, never summarized
+	minCompactMessages       = 2   // skip compaction below this many compactable messages
 )
 
 // summaryTag wraps the compaction summary so the model can distinguish it from
@@ -62,10 +63,11 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
 		return
 	}
-	if u.PromptTokens < int(float64(a.contextWindow)*a.compactRatio) {
+	force := u.PromptTokens >= int(float64(a.contextWindow)*defaultCompactForceRatio)
+	if !force && u.PromptTokens < int(float64(a.contextWindow)*a.compactRatio) {
 		return
 	}
-	if err := a.compact(ctx); err != nil {
+	if err := a.compact(ctx, force); err != nil {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("compaction skipped: %v", err)})
 	}
 }
@@ -115,7 +117,7 @@ func estimateTextTokens(s string) int {
 // compact summarizes the older middle of the session and replaces it in place:
 // the session becomes system + summary + recent tail. The dropped originals are
 // archived first, so the full history stays traceable.
-func (a *Agent) compact(ctx context.Context) error {
+func (a *Agent) compact(ctx context.Context, force bool) error {
 	msgs := a.session.Messages
 	head, start, ok := compactBounds(msgs, a.recentKeep, minCompactMessages)
 	if !ok {
@@ -130,8 +132,8 @@ func (a *Agent) compact(ctx context.Context) error {
 	region := msgs[head:start]
 
 	// Economic check: skip if the region is too small to justify the
-	// summarizer call.
-	if !foldEconomics(region) {
+	// summarizer call, unless the prompt has reached the force ceiling.
+	if !force && !foldEconomics(region) {
 		return nil
 	}
 

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -75,9 +75,10 @@ func TestCompactBounds(t *testing.T) {
 
 func TestCompactReplacesHistory(t *testing.T) {
 	prov := &fakeProvider{reply: "- goal: do X\n- changed file Y"}
+	bigStep := strings.Repeat("important implementation detail ", 80)
 	sess := &Session{Messages: []provider.Message{
 		{Role: provider.RoleSystem, Content: "sys"},
-		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleUser, Content: "task " + bigStep},
 		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "read_file", Arguments: "{}"}}},
 		{Role: provider.RoleTool, ToolCallID: "1", Name: "read_file", Content: "file contents"},
 		{Role: provider.RoleAssistant, Content: "did a step"},
@@ -123,11 +124,56 @@ func TestCompactReplacesHistory(t *testing.T) {
 	}
 }
 
+func TestCompactFoldsSingleLargeMessage(t *testing.T) {
+	prov := &fakeProvider{reply: "- captured the large file contents"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "read_file", Content: strings.Repeat("large output line\n", 500)},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	if err := a.compact(context.Background()); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if got := len(sess.Messages); got != 4 {
+		t.Fatalf("len = %d, want 4: %+v", got, sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[1].Content, "large file contents") {
+		t.Fatalf("single large message was not summarized: %+v", sess.Messages)
+	}
+	if len(prov.got) == 0 || !strings.Contains(prov.got[1].Content, "large output line") {
+		t.Fatalf("summarizer did not receive the large message: %+v", prov.got)
+	}
+}
+
+func TestCompactSkipsSingleSmallMessage(t *testing.T) {
+	prov := &fakeProvider{reply: "- should not be called"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "tiny"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	if err := a.compact(context.Background()); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if got := len(sess.Messages); got != 4 {
+		t.Fatalf("small single message should not compact, len = %d", got)
+	}
+	if len(prov.got) != 0 {
+		t.Fatalf("summarizer was called for tiny region: %+v", prov.got)
+	}
+}
+
 func TestMaybeCompactThreshold(t *testing.T) {
 	newSess := func() *Session {
 		return &Session{Messages: []provider.Message{
 			{Role: provider.RoleSystem, Content: "sys"},
-			{Role: provider.RoleUser, Content: "a"},
+			{Role: provider.RoleUser, Content: strings.Repeat("a ", 500)},
 			{Role: provider.RoleAssistant, Content: "b"},
 			{Role: provider.RoleUser, Content: "c"},
 			{Role: provider.RoleAssistant, Content: "d"},
@@ -158,5 +204,23 @@ func TestMaybeCompactThreshold(t *testing.T) {
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 1 << 30})
 	if len(sess.Messages) != 7 {
 		t.Errorf("no window should disable compaction, len = %d", len(sess.Messages))
+	}
+}
+
+func TestMaybeCompactFoldsSingleLargeMessageAtThreshold(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("large prompt chunk ", 500)},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(&fakeProvider{reply: "single large summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 90})
+	if got := len(sess.Messages); got != 4 {
+		t.Fatalf("len = %d, want 4: %+v", got, sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[1].Content, "single large summary") {
+		t.Fatalf("single large message was not compacted at threshold: %+v", sess.Messages)
 	}
 }

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -190,12 +190,36 @@ func TestMaybeCompactThreshold(t *testing.T) {
 		t.Errorf("below threshold should not compact, len = %d", len(sess.Messages))
 	}
 
-	// At/above 50%: compacts when the fold is economically worthwhile.
+	// At/above 50% only emits a soft notice; it does not rewrite the cache prefix.
+	sess = newSess()
+	prov := &fakeProvider{reply: "s"}
+	var notices []event.Event
+	a = New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e)
+		}
+	}))
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
+	if len(sess.Messages) != 7 {
+		t.Errorf("soft threshold should not compact, len = %d", len(sess.Messages))
+	}
+	if len(prov.got) != 0 {
+		t.Fatalf("soft threshold called summarizer: %+v", prov.got)
+	}
+	if len(notices) != 1 || !strings.Contains(notices[0].Text, "context reached 50%") {
+		t.Fatalf("soft threshold notice = %+v", notices)
+	}
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 60})
+	if len(notices) != 1 {
+		t.Fatalf("soft threshold notice should only emit once, got %d", len(notices))
+	}
+
+	// At/above 80%: compacts when the fold is economically worthwhile.
 	sess = newSess()
 	a = New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
 	if len(sess.Messages) >= 7 {
-		t.Errorf("above threshold should compact, len = %d", len(sess.Messages))
+		t.Errorf("compact threshold should compact, len = %d", len(sess.Messages))
 	}
 
 	// No context window: compaction disabled.
@@ -218,7 +242,7 @@ func TestMaybeCompactForceCeilingBypassesEconomics(t *testing.T) {
 	prov := &fakeProvider{reply: "forced summary"}
 	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 90})
 	if got := len(sess.Messages); got != 4 {
 		t.Fatalf("len = %d, want 4 after forced compact: %+v", got, sess.Messages)
 	}
@@ -241,7 +265,7 @@ func TestMaybeCompactSkipsLowValueRegionBeforeForceCeiling(t *testing.T) {
 	prov := &fakeProvider{reply: "should not summarize"}
 	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
 	if got := len(sess.Messages); got != 5 {
 		t.Fatalf("low-value region should not compact before force ceiling, len = %d", got)
 	}
@@ -259,7 +283,7 @@ func TestMaybeCompactFoldsSingleLargeMessageAtThreshold(t *testing.T) {
 	}}
 	a := New(&fakeProvider{reply: "single large summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 90})
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
 	if got := len(sess.Messages); got != 4 {
 		t.Fatalf("len = %d, want 4: %+v", got, sess.Messages)
 	}

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -88,7 +88,7 @@ func TestCompactReplacesHistory(t *testing.T) {
 	dir := t.TempDir()
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: dir}, event.Discard)
 
-	if err := a.compact(context.Background()); err != nil {
+	if err := a.compact(context.Background(), false); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -134,7 +134,7 @@ func TestCompactFoldsSingleLargeMessage(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	if err := a.compact(context.Background()); err != nil {
+	if err := a.compact(context.Background(), false); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if got := len(sess.Messages); got != 4 {
@@ -158,7 +158,7 @@ func TestCompactSkipsSingleSmallMessage(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
-	if err := a.compact(context.Background()); err != nil {
+	if err := a.compact(context.Background(), false); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if got := len(sess.Messages); got != 4 {
@@ -182,18 +182,18 @@ func TestMaybeCompactThreshold(t *testing.T) {
 		}}
 	}
 
-	// Below 80% of the window: untouched.
+	// Below 50% of the window: untouched.
 	sess := newSess()
 	a := New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 49})
 	if len(sess.Messages) != 7 {
 		t.Errorf("below threshold should not compact, len = %d", len(sess.Messages))
 	}
 
-	// At/above 80%: compacts.
+	// At/above 50%: compacts when the fold is economically worthwhile.
 	sess = newSess()
 	a = New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 90})
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
 	if len(sess.Messages) >= 7 {
 		t.Errorf("above threshold should compact, len = %d", len(sess.Messages))
 	}
@@ -204,6 +204,49 @@ func TestMaybeCompactThreshold(t *testing.T) {
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 1 << 30})
 	if len(sess.Messages) != 7 {
 		t.Errorf("no window should disable compaction, len = %d", len(sess.Messages))
+	}
+}
+
+func TestMaybeCompactForceCeilingBypassesEconomics(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "small old request"},
+		{Role: provider.RoleAssistant, Content: "small old answer"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	prov := &fakeProvider{reply: "forced summary"}
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
+	if got := len(sess.Messages); got != 4 {
+		t.Fatalf("len = %d, want 4 after forced compact: %+v", got, sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[1].Content, "forced summary") {
+		t.Fatalf("forced compact did not install summary: %+v", sess.Messages)
+	}
+	if len(prov.got) == 0 {
+		t.Fatalf("summarizer was not called at force ceiling")
+	}
+}
+
+func TestMaybeCompactSkipsLowValueRegionBeforeForceCeiling(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "small old request"},
+		{Role: provider.RoleAssistant, Content: "small old answer"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	prov := &fakeProvider{reply: "should not summarize"}
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
+	if got := len(sess.Messages); got != 5 {
+		t.Fatalf("low-value region should not compact before force ceiling, len = %d", got)
+	}
+	if len(prov.got) != 0 {
+		t.Fatalf("summarizer was called for low-value non-forced region: %+v", prov.got)
 	}
 }
 

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -27,15 +27,18 @@ If you need to ask for clarification, fail with a precise question instead of gu
 // parallel research across independent areas (the parallel-dispatch path picks
 // these up only when readOnly, which task is not).
 type TaskTool struct {
-	prov          provider.Provider
-	pricing       *provider.Pricing
-	parentReg     *tool.Registry
-	maxSteps      int
-	contextWindow int
-	temperature   float64
-	archiveDir    string
-	sysPrompt     string
-	gate          Gate
+	prov              provider.Provider
+	pricing           *provider.Pricing
+	parentReg         *tool.Registry
+	maxSteps          int
+	contextWindow     int
+	softCompactRatio  float64
+	compactRatio      float64
+	compactForceRatio float64
+	temperature       float64
+	archiveDir        string
+	sysPrompt         string
+	gate              Gate
 }
 
 // NewTaskTool wires a task tool to the parent agent's environment so its
@@ -45,20 +48,23 @@ type TaskTool struct {
 // deny rules still bite while autonomous sub-agents are never blocked on an
 // interactive prompt (there is no UI to answer one).
 func NewTaskTool(prov provider.Provider, pricing *provider.Pricing, parentReg *tool.Registry,
-	maxSteps, contextWindow int, temperature float64, archiveDir, sysPrompt string, gate Gate) *TaskTool {
+	maxSteps, contextWindow int, softCompactRatio, compactRatio, compactForceRatio, temperature float64, archiveDir, sysPrompt string, gate Gate) *TaskTool {
 	if sysPrompt == "" {
 		sysPrompt = DefaultTaskSystemPrompt
 	}
 	return &TaskTool{
-		prov:          prov,
-		pricing:       pricing,
-		parentReg:     parentReg,
-		maxSteps:      maxSteps,
-		contextWindow: contextWindow,
-		temperature:   temperature,
-		archiveDir:    archiveDir,
-		sysPrompt:     sysPrompt,
-		gate:          gate,
+		prov:              prov,
+		pricing:           pricing,
+		parentReg:         parentReg,
+		maxSteps:          maxSteps,
+		contextWindow:     contextWindow,
+		softCompactRatio:  softCompactRatio,
+		compactRatio:      compactRatio,
+		compactForceRatio: compactForceRatio,
+		temperature:       temperature,
+		archiveDir:        archiveDir,
+		sysPrompt:         sysPrompt,
+		gate:              gate,
 	}
 }
 
@@ -142,12 +148,15 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	// below, surfaces to the parent model.
 	subSession := NewSession(t.sysPrompt)
 	subAgent := New(t.prov, subReg, subSession, Options{
-		MaxSteps:      maxSteps,
-		Temperature:   t.temperature,
-		Pricing:       t.pricing,
-		Gate:          t.gate,
-		ContextWindow: t.contextWindow,
-		ArchiveDir:    t.archiveDir,
+		MaxSteps:          maxSteps,
+		Temperature:       t.temperature,
+		Pricing:           t.pricing,
+		Gate:              t.gate,
+		ContextWindow:     t.contextWindow,
+		SoftCompactRatio:  t.softCompactRatio,
+		CompactRatio:      t.compactRatio,
+		CompactForceRatio: t.compactForceRatio,
+		ArchiveDir:        t.archiveDir,
 	}, subSink(ctx))
 
 	if err := subAgent.Run(ctx, p.Prompt); err != nil {

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -18,7 +18,7 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 		{Type: provider.ChunkDone},
 	}}
 	parentReg := tool.NewRegistry()
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "test-sys-prompt", nil)
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "test-sys-prompt", nil)
 
 	out, err := task.Execute(context.Background(), []byte(`{"prompt":"find callers of Foo"}`))
 	if err != nil {
@@ -51,7 +51,7 @@ func TestTaskToolFiltersTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
 	parentReg.Add(fakeTool{name: "write_file", readOnly: false})
 	parentReg.Add(fakeTool{name: "bash", readOnly: false})
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task) // simulate the wiring in cli.setup
 
 	args := []byte(`{"prompt":"x","tools":["read_file","task","write_file"]}`)
@@ -78,7 +78,7 @@ func TestTaskToolDefaultsToParentToolsWithoutTask(t *testing.T) {
 	parentReg := tool.NewRegistry()
 	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
 	parentReg.Add(fakeTool{name: "grep", readOnly: true})
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task)
 
 	if _, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`)); err != nil {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -123,7 +123,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// nesting out of the picture). It registers into the same reg the
 	// executor uses, so the model surfaces it like any other tool.
 	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
-		entry.ContextWindow, cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
+		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
+		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
 
 	// The `remember` tool lets the model persist durable facts to the project's
 	// auto-memory store; the saved index loads into the prefix on the next session.
@@ -137,12 +138,15 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 
 	execSess := agent.NewSession(sysPrompt)
 	executor := agent.New(execProv, reg, execSess, agent.Options{
-		MaxSteps:      maxSteps,
-		Temperature:   cfg.Agent.Temperature,
-		Pricing:       entry.Price,
-		Gate:          headlessGate,
-		ContextWindow: entry.ContextWindow,
-		ArchiveDir:    config.ArchiveDir(),
+		MaxSteps:          maxSteps,
+		Temperature:       cfg.Agent.Temperature,
+		Pricing:           entry.Price,
+		Gate:              headlessGate,
+		ContextWindow:     entry.ContextWindow,
+		SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
+		CompactRatio:      cfg.Agent.CompactRatio,
+		CompactForceRatio: cfg.Agent.CompactForceRatio,
+		ArchiveDir:        config.ArchiveDir(),
 	}, opts.Sink)
 
 	// Custom slash commands (.reasonix/commands + user dir). Best-effort: a malformed

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -130,15 +130,19 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 	policy := permission.New(cfg.Permissions.Mode, cfg.Permissions.Allow, cfg.Permissions.Ask, cfg.Permissions.Deny)
 	headlessGate := permission.NewGate(policy, nil)
 	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
-		entry.ContextWindow, cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
+		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
+		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
 
 	executor := agent.New(execProv, reg, agent.NewSession(sysPrompt), agent.Options{
-		MaxSteps:      maxSteps,
-		Temperature:   cfg.Agent.Temperature,
-		Pricing:       entry.Price,
-		Gate:          headlessGate,
-		ContextWindow: entry.ContextWindow,
-		ArchiveDir:    config.ArchiveDir(),
+		MaxSteps:          maxSteps,
+		Temperature:       cfg.Agent.Temperature,
+		Pricing:           entry.Price,
+		Gate:              headlessGate,
+		ContextWindow:     entry.ContextWindow,
+		SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
+		CompactRatio:      cfg.Agent.CompactRatio,
+		CompactForceRatio: cfg.Agent.CompactForceRatio,
+		ArchiveDir:        config.ArchiveDir(),
 	}, p.Sink)
 
 	cmds, _ := command.Load(config.CommandDirs()...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,11 +84,14 @@ func (c *Config) BashMode() string {
 // planner handles low-frequency planning in its own session (kept separate so
 // each model's prompt prefix stays cache-stable).
 type AgentConfig struct {
-	SystemPrompt     string  `toml:"system_prompt"`
-	SystemPromptFile string  `toml:"system_prompt_file"`
-	MaxSteps         int     `toml:"max_steps"` // tool-call rounds per turn; 0 = unlimited
-	Temperature      float64 `toml:"temperature"`
-	PlannerModel     string  `toml:"planner_model"`
+	SystemPrompt      string  `toml:"system_prompt"`
+	SystemPromptFile  string  `toml:"system_prompt_file"`
+	MaxSteps          int     `toml:"max_steps"` // tool-call rounds per turn; 0 = unlimited
+	Temperature       float64 `toml:"temperature"`
+	PlannerModel      string  `toml:"planner_model"`
+	SoftCompactRatio  float64 `toml:"soft_compact_ratio"`
+	CompactRatio      float64 `toml:"compact_ratio"`
+	CompactForceRatio float64 `toml:"compact_force_ratio"`
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's
@@ -201,7 +204,10 @@ func Default() *Config {
 			// the user cancels, or the provider errors. Context stays bounded by
 			// compaction, not by a round count. Set a positive agent.max_steps only
 			// if you want a hard guard against runaway.
-			MaxSteps: 0,
+			MaxSteps:          0,
+			SoftCompactRatio:  0.5,
+			CompactRatio:      0.8,
+			CompactForceRatio: 0.9,
 		},
 		// Mode "ask" with no rules keeps `reasonix run` autonomous (no TTY → ask
 		// resolves to allow) while `reasonix chat` prompts before writers. Users add

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -36,6 +36,9 @@ func RenderTOML(c *Config) string {
 	}
 	fmt.Fprintf(&b, "max_steps   = %d\n", c.Agent.MaxSteps)
 	fmt.Fprintf(&b, "temperature = %s\n", formatFloat(c.Agent.Temperature))
+	fmt.Fprintf(&b, "soft_compact_ratio  = %s   # notice only; keeps cache-first prefix intact\n", formatFloat(c.Agent.SoftCompactRatio))
+	fmt.Fprintf(&b, "compact_ratio       = %s   # try compacting when prompt reaches this fraction\n", formatFloat(c.Agent.CompactRatio))
+	fmt.Fprintf(&b, "compact_force_ratio = %s   # force compacting at this high-water mark\n", formatFloat(c.Agent.CompactForceRatio))
 	if c.Agent.PlannerModel != "" {
 		fmt.Fprintf(&b, "planner_model = %q   # low-frequency planner (two-model collaboration)\n", c.Agent.PlannerModel)
 	} else {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -43,6 +43,15 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if got.Agent.Temperature != orig.Agent.Temperature {
 		t.Errorf("temperature = %v, want %v", got.Agent.Temperature, orig.Agent.Temperature)
 	}
+	if got.Agent.SoftCompactRatio != orig.Agent.SoftCompactRatio {
+		t.Errorf("soft_compact_ratio = %v, want %v", got.Agent.SoftCompactRatio, orig.Agent.SoftCompactRatio)
+	}
+	if got.Agent.CompactRatio != orig.Agent.CompactRatio {
+		t.Errorf("compact_ratio = %v, want %v", got.Agent.CompactRatio, orig.Agent.CompactRatio)
+	}
+	if got.Agent.CompactForceRatio != orig.Agent.CompactForceRatio {
+		t.Errorf("compact_force_ratio = %v, want %v", got.Agent.CompactForceRatio, orig.Agent.CompactForceRatio)
+	}
 	if got.Agent.SystemPrompt != orig.Agent.SystemPrompt {
 		t.Errorf("system_prompt mismatch:\n got %q\nwant %q", got.Agent.SystemPrompt, orig.Agent.SystemPrompt)
 	}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -14,6 +14,9 @@ guessing; keep changes minimal and correct; briefly summarize what you did."""
 # system_prompt_file = "prompts/system.md"   # overrides system_prompt when set
 max_steps   = 25
 temperature = 0.0
+soft_compact_ratio  = 0.5   # notice only; keeps the cache-first prefix intact
+compact_ratio       = 0.8   # try compacting when prompt reaches this fraction
+compact_force_ratio = 0.9   # force compacting at this high-water mark
 # planner_model = "mimo-pro"   # optional: enable two-model collaboration
 
 # A provider is a vendor endpoint (one base_url + key) that offers one or more


### PR DESCRIPTION
## Summary
Change compaction summaries to a fixed five-section structure and skip summarization when the compactable region is too small to be worthwhile.

## Root Cause
Free-form summaries are harder for the agent to resume from, and compacting very small regions can cost more latency and tokens than it saves.

## Technical Approach
Update the summarizer prompt to emit Goal, Decisions, Files, Commands, and Pending sections; wrap summaries in a dedicated tag; add a simple fold-economics threshold.

## Focused Optimization Points
- Improves resumability after compaction.
- Makes compacted summaries easier to distinguish from live user input.
- Avoids low-value summarization calls for tiny regions.

## Verification
Not run during this publishing pass. This is opened as a draft PR for upstream review of the split branch.