### PR TITLE
[v2] Add range and Go symbol deletion tools

### DIFF
--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -27,6 +27,8 @@ func ConfineWriters(roots []string) []tool.Tool {
 		editFile{roots: rs},
 		multiEdit{roots: rs},
 		notebookEdit{roots: rs},
+		deleteRange{roots: rs},
+		deleteSymbol{roots: rs},
 	}
 }
 

--- a/internal/tool/builtin/delete_range.go
+++ b/internal/tool/builtin/delete_range.go
@@ -1,0 +1,150 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"reasonix/internal/diff"
+	"reasonix/internal/tool"
+)
+
+func init() { tool.RegisterBuiltin(deleteRange{}) }
+
+type deleteRange struct {
+	roots   []string
+	workDir string
+}
+
+func (deleteRange) Name() string { return "delete_range" }
+
+func (deleteRange) Description() string {
+	return "Delete a contiguous text range from a file using exact start/end text anchors. Each anchor must match exactly one line. Returns unified diff on success. Use for large deletions — smaller changes should use edit_file."
+}
+
+func (deleteRange) Schema() json.RawMessage {
+	return json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"path":{"type":"string","description":"File path"},
+			"start_anchor":{"type":"string","description":"Exact text of the first line to delete (must be unique in the file)"},
+			"end_anchor":{"type":"string","description":"Exact text of the last line to delete (must be unique in the file)"},
+			"inclusive":{"type":"boolean","description":"Whether to include the anchor lines in the deletion (default true)"}
+		},
+		"required":["path","start_anchor","end_anchor"]
+	}`)
+}
+
+func (deleteRange) ReadOnly() bool { return false }
+
+func (d deleteRange) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	change, err := d.preview(args)
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(change.Path, []byte(change.NewText), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", change.Path, err)
+	}
+	return change.Diff, nil
+}
+
+func (d deleteRange) Preview(args json.RawMessage) (diff.Change, error) {
+	return d.preview(args)
+}
+
+func (d deleteRange) preview(args json.RawMessage) (diff.Change, error) {
+	var p struct {
+		Path        string `json:"path"`
+		StartAnchor string `json:"start_anchor"`
+		EndAnchor   string `json:"end_anchor"`
+		Inclusive   *bool  `json:"inclusive"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return diff.Change{}, fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Path == "" {
+		return diff.Change{}, fmt.Errorf("path is required")
+	}
+	if p.StartAnchor == "" {
+		return diff.Change{}, fmt.Errorf("start_anchor is required")
+	}
+	if p.EndAnchor == "" {
+		return diff.Change{}, fmt.Errorf("end_anchor is required")
+	}
+
+	inclusive := true
+	if p.Inclusive != nil {
+		inclusive = *p.Inclusive
+	}
+
+	p.Path = resolveIn(d.workDir, p.Path)
+	if err := confine(d.roots, p.Path); err != nil {
+		return diff.Change{}, err
+	}
+
+	b, err := os.ReadFile(p.Path)
+	if err != nil {
+		return diff.Change{}, fmt.Errorf("read %s: %w", p.Path, err)
+	}
+	original := string(b)
+
+	// Detect line ending style so we can preserve it on write.
+	lineSep := "\n"
+	if strings.Contains(original, "\r\n") {
+		lineSep = "\r\n"
+	}
+
+	// Strip \r for matching (split on \n after removing \r).
+	lines := strings.Split(strings.ReplaceAll(original, "\r", ""), "\n")
+	startLine := findUniqueLine(lines, p.StartAnchor)
+	if startLine == -2 {
+		return diff.Change{}, fmt.Errorf("start_anchor is not unique in %s; add more surrounding context", p.Path)
+	}
+	if startLine == -1 {
+		return diff.Change{}, fmt.Errorf("start_anchor not found in %s", p.Path)
+	}
+	endLine := findUniqueLine(lines, p.EndAnchor)
+	if endLine == -2 {
+		return diff.Change{}, fmt.Errorf("end_anchor is not unique in %s; add more surrounding context", p.Path)
+	}
+	if endLine == -1 {
+		return diff.Change{}, fmt.Errorf("end_anchor not found in %s", p.Path)
+	}
+	if startLine > endLine {
+		return diff.Change{}, fmt.Errorf("start_anchor appears after end_anchor (lines %d and %d)", startLine+1, endLine+1)
+	}
+
+	// Build new content
+	var keep []string
+	if inclusive {
+		keep = append(keep, lines[:startLine]...)
+		keep = append(keep, lines[endLine+1:]...)
+	} else {
+		keep = append(keep, lines[:startLine+1]...)
+		keep = append(keep, lines[endLine:]...)
+	}
+	newContent := strings.Join(keep, lineSep)
+	// Preserve trailing newline if original had one.
+	if strings.HasSuffix(original, lineSep) && !strings.HasSuffix(newContent, lineSep) {
+		newContent += lineSep
+	}
+
+	return diff.Build(p.Path, original, newContent, diff.Modify), nil
+}
+
+// findUniqueLine returns the index of the line that equals target.
+// Returns -1 if not found, -2 if found on multiple lines.
+func findUniqueLine(lines []string, target string) int {
+	idx := -1
+	for i, l := range lines {
+		if l == target {
+			if idx >= 0 {
+				return -2
+			}
+			idx = i
+		}
+	}
+	return idx
+}

--- a/internal/tool/builtin/delete_range.go
+++ b/internal/tool/builtin/delete_range.go
@@ -127,7 +127,7 @@ func (d deleteRange) preview(args json.RawMessage) (diff.Change, error) {
 	}
 	newContent := strings.Join(keep, lineSep)
 	// Preserve trailing newline if original had one.
-	if strings.HasSuffix(original, lineSep) && !strings.HasSuffix(newContent, lineSep) {
+	if newContent != "" && strings.HasSuffix(original, lineSep) && !strings.HasSuffix(newContent, lineSep) {
 		newContent += lineSep
 	}
 

--- a/internal/tool/builtin/delete_range_test.go
+++ b/internal/tool/builtin/delete_range_test.go
@@ -118,6 +118,19 @@ func TestDeleteRangeCRLF(t *testing.T) {
 	}
 }
 
+func TestDeleteRangeWholeNewlineTerminatedFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "whole.txt")
+	os.WriteFile(f, []byte("line1\n"), 0o644)
+
+	runTool(t, deleteRange{}, map[string]any{
+		"path": f, "start_anchor": "line1", "end_anchor": "line1",
+	})
+	got, _ := os.ReadFile(f)
+	if string(got) != "" {
+		t.Errorf("whole-file delete left content %q, want empty", got)
+	}
+}
+
 func TestDeleteRangePreview(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "preview.txt")
 	body := "line1\nline2\nline3\nline4\nline5\n"

--- a/internal/tool/builtin/delete_range_test.go
+++ b/internal/tool/builtin/delete_range_test.go
@@ -1,0 +1,144 @@
+package builtin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeleteRangeBasic(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "a.txt")
+	body := "line1\nline2\nline3\nline4\nline5\n"
+	os.WriteFile(f, []byte(body), 0o644)
+
+	out := runTool(t, deleteRange{}, map[string]any{
+		"path": f, "start_anchor": "line2", "end_anchor": "line4",
+	})
+	if !strings.Contains(out, "---") || !strings.Contains(out, "+++") {
+		t.Errorf("expected unified diff output, got: %s", out)
+	}
+	got, _ := os.ReadFile(f)
+	want := "line1\nline5\n"
+	if string(got) != want {
+		t.Errorf("file = %q, want %q", got, want)
+	}
+}
+
+func TestDeleteRangeInclusive(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "a.txt")
+	os.WriteFile(f, []byte("line1\nline2\nline3\nline4\nline5\n"), 0o644)
+	runTool(t, deleteRange{}, map[string]any{
+		"path": f, "start_anchor": "line2", "end_anchor": "line4", "inclusive": true,
+	})
+	got, _ := os.ReadFile(f)
+	if string(got) != "line1\nline5\n" {
+		t.Errorf("inclusive=true: got %q, want %q", got, "line1\\nline5\\n")
+	}
+
+	f2 := filepath.Join(t.TempDir(), "b.txt")
+	os.WriteFile(f2, []byte("line1\nline2\nline3\nline4\nline5\n"), 0o644)
+	runTool(t, deleteRange{}, map[string]any{
+		"path": f2, "start_anchor": "line2", "end_anchor": "line4", "inclusive": false,
+	})
+	got2, _ := os.ReadFile(f2)
+	if string(got2) != "line1\nline2\nline4\nline5\n" {
+		t.Errorf("inclusive=false: got %q, want %q", got2, "line1\\nline2\\nline4\\nline5\\n")
+	}
+}
+
+func TestDeleteRangeDuplicateAnchor(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "dup.txt")
+	body := "line1\nline2\nline3\nline2\nline5\n"
+	os.WriteFile(f, []byte(body), 0o644)
+
+	args := argsJSON(t, map[string]any{
+		"path": f, "start_anchor": "line2", "end_anchor": "line5",
+	})
+	_, err := (deleteRange{}).Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected duplicate anchor error")
+	}
+	if !strings.Contains(err.Error(), "not unique") {
+		t.Errorf("error should mention 'not unique': %v", err)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != body {
+		t.Errorf("file modified despite error: %q", got)
+	}
+}
+
+func TestDeleteRangeMissingAnchor(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "missing.txt")
+	body := "line1\nline2\nline3\n"
+	os.WriteFile(f, []byte(body), 0o644)
+
+	args := argsJSON(t, map[string]any{
+		"path": f, "start_anchor": "line2", "end_anchor": "no_such_line",
+	})
+	_, err := (deleteRange{}).Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected missing anchor error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found': %v", err)
+	}
+}
+
+func TestDeleteRangeReversed(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "rev.txt")
+	body := "line1\nline2\nline3\nline4\nline5\n"
+	os.WriteFile(f, []byte(body), 0o644)
+
+	args := argsJSON(t, map[string]any{
+		"path": f, "start_anchor": "line4", "end_anchor": "line2",
+	})
+	_, err := (deleteRange{}).Execute(context.Background(), args)
+	if err == nil {
+		t.Fatal("expected reversed anchor error")
+	}
+	if !strings.Contains(err.Error(), "after") {
+		t.Errorf("error should mention ordering: %v", err)
+	}
+}
+
+func TestDeleteRangeCRLF(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "crlf.txt")
+	body := "line1\r\nline2\r\nline3\r\nline4\r\nline5\r\n"
+	os.WriteFile(f, []byte(body), 0o644)
+
+	runTool(t, deleteRange{}, map[string]any{
+		"path": f, "start_anchor": "line2", "end_anchor": "line4",
+	})
+	got, _ := os.ReadFile(f)
+	want := "line1\r\nline5\r\n"
+	if string(got) != want {
+		t.Errorf("CRLF file: got %q, want %q", got, want)
+	}
+}
+
+func TestDeleteRangePreview(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "preview.txt")
+	body := "line1\nline2\nline3\nline4\nline5\n"
+	os.WriteFile(f, []byte(body), 0o644)
+
+	change, err := deleteRange{}.Preview(argsJSON(t, map[string]any{
+		"path": f, "start_anchor": "line2", "end_anchor": "line4",
+	}))
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+
+	got, _ := os.ReadFile(f)
+	if string(got) != body {
+		t.Errorf("Preview mutated the file: %q", got)
+	}
+
+	if change.Kind != "modify" {
+		t.Errorf("kind = %q, want modify", change.Kind)
+	}
+	if change.OldText != body {
+		t.Errorf("OldText = %q, want %q", change.OldText, body)
+	}
+}

--- a/internal/tool/builtin/delete_symbol.go
+++ b/internal/tool/builtin/delete_symbol.go
@@ -1,0 +1,282 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/diff"
+	"reasonix/internal/tool"
+)
+
+func init() { tool.RegisterBuiltin(deleteSymbol{}) }
+
+type deleteSymbol struct {
+	roots   []string
+	workDir string
+}
+
+type symbolMatch struct {
+	name   string
+	kind   string
+	parent string
+	line   int
+	start  token.Pos
+	end    token.Pos
+}
+
+func (deleteSymbol) Name() string { return "delete_symbol" }
+
+func (deleteSymbol) Description() string {
+	return "Delete a named symbol (function, method, type, interface, const, var) from a Go source file using AST parsing. For non-Go files, use delete_range with manual anchors."
+}
+
+func (deleteSymbol) Schema() json.RawMessage {
+	return json.RawMessage(`{
+	"type":"object",
+	"properties":{
+		"path":{"type":"string","description":"Path to the source file"},
+		"name":{"type":"string","description":"Name of the symbol to delete"},
+		"kind":{"type":"string","description":"Optional kind filter: func, method, type, interface, const, var"},
+		"parent":{"type":"string","description":"Optional parent struct name for method disambiguation"}
+	},
+	"required":["path","name"]
+}`)
+}
+
+func (deleteSymbol) ReadOnly() bool { return false }
+
+func (d deleteSymbol) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Path   string `json:"path"`
+		Name   string `json:"name"`
+		Kind   string `json:"kind"`
+		Parent string `json:"parent"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if p.Name == "" {
+		return "", fmt.Errorf("name is required")
+	}
+	p.Path = resolveIn(d.workDir, p.Path)
+	if err := confine(d.roots, p.Path); err != nil {
+		return "", err
+	}
+
+	ext := strings.ToLower(filepath.Ext(p.Path))
+	if ext != ".go" {
+		return "", fmt.Errorf("delete_symbol only supports Go files — use delete_range for %s files", ext)
+	}
+
+	m, fset, err := d.findSymbol(p.Path, p.Name, p.Kind, p.Parent)
+	if err != nil {
+		return "", err
+	}
+
+	src, err := os.ReadFile(p.Path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", p.Path, err)
+	}
+	original := string(src)
+
+	newContent := deleteLines(original, fset, m)
+	if err := os.WriteFile(p.Path, []byte(newContent), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", p.Path, err)
+	}
+
+	change := diff.Build(p.Path, original, newContent, diff.Modify)
+	return change.Diff, nil
+}
+
+func (d deleteSymbol) Preview(args json.RawMessage) (diff.Change, error) {
+	var p struct {
+		Path   string `json:"path"`
+		Name   string `json:"name"`
+		Kind   string `json:"kind"`
+		Parent string `json:"parent"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return diff.Change{}, fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Path == "" {
+		return diff.Change{}, fmt.Errorf("path is required")
+	}
+	if p.Name == "" {
+		return diff.Change{}, fmt.Errorf("name is required")
+	}
+	p.Path = resolveIn(d.workDir, p.Path)
+	if err := confine(d.roots, p.Path); err != nil {
+		return diff.Change{}, err
+	}
+
+	ext := strings.ToLower(filepath.Ext(p.Path))
+	if ext != ".go" {
+		return diff.Change{}, fmt.Errorf("delete_symbol only supports Go files")
+	}
+
+	m, fset, err := d.findSymbol(p.Path, p.Name, p.Kind, p.Parent)
+	if err != nil {
+		return diff.Change{}, err
+	}
+
+	src, err := os.ReadFile(p.Path)
+	if err != nil {
+		return diff.Change{}, fmt.Errorf("read %s: %w", p.Path, err)
+	}
+	original := string(src)
+
+	newContent := deleteLines(original, fset, m)
+	return diff.Build(p.Path, original, newContent, diff.Modify), nil
+}
+
+func (d deleteSymbol) findSymbol(path, name, kind, parent string) (symbolMatch, *token.FileSet, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+	if err != nil {
+		return symbolMatch{}, nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	matches := collectSymbols(fset, f)
+
+	var byName []symbolMatch
+	for _, m := range matches {
+		if m.name == name {
+			byName = append(byName, m)
+		}
+	}
+	if len(byName) == 0 {
+		return symbolMatch{}, nil, fmt.Errorf("symbol %q not found in %s", name, path)
+	}
+
+	filtered := byName
+	if kind != "" {
+		var byKind []symbolMatch
+		for _, m := range filtered {
+			if m.kind == kind {
+				byKind = append(byKind, m)
+			}
+		}
+		if len(byKind) == 0 {
+			return symbolMatch{}, nil, fmt.Errorf("symbol %q with kind %q not found", name, kind)
+		}
+		filtered = byKind
+	}
+	if parent != "" {
+		var byParent []symbolMatch
+		for _, m := range filtered {
+			if m.parent == parent {
+				byParent = append(byParent, m)
+			}
+		}
+		if len(byParent) == 0 {
+			return symbolMatch{}, nil, fmt.Errorf("symbol %q (kind=%q parent=%q) not found", name, kind, parent)
+		}
+		filtered = byParent
+	}
+
+	if len(filtered) > 1 {
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("Multiple matches for %q — disambiguate with kind/parent:\n", name))
+		for _, m := range filtered {
+			b.WriteString(fmt.Sprintf("  line %d: %s %s", m.line, m.kind, m.name))
+			if m.parent != "" {
+				b.WriteString(fmt.Sprintf(" (on %s)", m.parent))
+			}
+			b.WriteString("\n")
+		}
+		return symbolMatch{}, nil, fmt.Errorf("%s", b.String())
+	}
+
+	return filtered[0], fset, nil
+}
+
+func collectSymbols(fset *token.FileSet, f *ast.File) []symbolMatch {
+	var matches []symbolMatch
+	for _, decl := range f.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			m := symbolMatch{
+				name:  d.Name.Name,
+				kind:  "func",
+				start: d.Pos(),
+				end:   d.End(),
+				line:  fset.Position(d.Pos()).Line,
+			}
+			if d.Recv != nil && len(d.Recv.List) > 0 {
+				m.kind = "method"
+				recvType := d.Recv.List[0].Type
+				if se, ok := recvType.(*ast.StarExpr); ok {
+					if ident, ok := se.X.(*ast.Ident); ok {
+						m.parent = ident.Name
+					}
+				} else if ident, ok := recvType.(*ast.Ident); ok {
+					m.parent = ident.Name
+				}
+			}
+			matches = append(matches, m)
+		case *ast.GenDecl:
+			for _, spec := range d.Specs {
+				switch s := spec.(type) {
+				case *ast.TypeSpec:
+					m := symbolMatch{
+						name:  s.Name.Name,
+						start: s.Pos(),
+						end:   s.End(),
+						line:  fset.Position(s.Pos()).Line,
+					}
+					if _, ok := s.Type.(*ast.InterfaceType); ok {
+						m.kind = "interface"
+					} else {
+						m.kind = "type"
+					}
+					matches = append(matches, m)
+				case *ast.ValueSpec:
+					kind := "var"
+					if d.Tok == token.CONST {
+						kind = "const"
+					}
+					for _, ident := range s.Names {
+						matches = append(matches, symbolMatch{
+							name:  ident.Name,
+							kind:  kind,
+							start: ident.Pos(),
+							end:   ident.End(),
+							line:  fset.Position(ident.Pos()).Line,
+						})
+					}
+				}
+			}
+		}
+	}
+	return matches
+}
+
+func deleteLines(content string, fset *token.FileSet, m symbolMatch) string {
+	startOff := fset.Position(m.start).Offset
+	endOff := fset.Position(m.end).Offset
+
+	lineStart := startOff
+	for lineStart > 0 && content[lineStart-1] != '\n' {
+		lineStart--
+	}
+
+	lineEnd := endOff
+	for lineEnd < len(content) && content[lineEnd] != '\n' {
+		lineEnd++
+	}
+	if lineEnd < len(content) {
+		lineEnd++
+	}
+
+	return content[:lineStart] + content[lineEnd:]
+}

--- a/internal/tool/builtin/delete_symbol.go
+++ b/internal/tool/builtin/delete_symbol.go
@@ -23,12 +23,13 @@ type deleteSymbol struct {
 }
 
 type symbolMatch struct {
-	name   string
-	kind   string
-	parent string
-	line   int
-	start  token.Pos
-	end    token.Pos
+	name     string
+	kind     string
+	parent   string
+	line     int
+	start    token.Pos
+	end      token.Pos
+	siblings []string
 }
 
 func (deleteSymbol) Name() string { return "delete_symbol" }
@@ -197,6 +198,10 @@ func (d deleteSymbol) findSymbol(path, name, kind, parent string) (symbolMatch, 
 		return symbolMatch{}, nil, fmt.Errorf("%s", b.String())
 	}
 
+	if len(filtered[0].siblings) > 1 {
+		return symbolMatch{}, nil, fmt.Errorf("%s %q is declared in a multi-name %s spec with %s; delete_symbol refuses to remove it because that would also delete sibling symbols", filtered[0].kind, name, filtered[0].kind, strings.Join(filtered[0].siblings, ", "))
+	}
+
 	return filtered[0], fset, nil
 }
 
@@ -245,13 +250,18 @@ func collectSymbols(fset *token.FileSet, f *ast.File) []symbolMatch {
 					if d.Tok == token.CONST {
 						kind = "const"
 					}
+					names := make([]string, 0, len(s.Names))
+					for _, ident := range s.Names {
+						names = append(names, ident.Name)
+					}
 					for _, ident := range s.Names {
 						matches = append(matches, symbolMatch{
-							name:  ident.Name,
-							kind:  kind,
-							start: ident.Pos(),
-							end:   ident.End(),
-							line:  fset.Position(ident.Pos()).Line,
+							name:     ident.Name,
+							kind:     kind,
+							start:    ident.Pos(),
+							end:      ident.End(),
+							line:     fset.Position(ident.Pos()).Line,
+							siblings: names,
 						})
 					}
 				}

--- a/internal/tool/builtin/delete_symbol_test.go
+++ b/internal/tool/builtin/delete_symbol_test.go
@@ -1,0 +1,119 @@
+package builtin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeleteSymbolGoFunc(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "example.go")
+	src := "package example\n\nfunc Greet() string {\n\treturn \"hello\"\n}\n\nfunc Farewell() string {\n\treturn \"bye\"\n}\n"
+	os.WriteFile(f, []byte(src), 0o644)
+
+	out := runTool(t, deleteSymbol{}, map[string]any{"path": f, "name": "Greet"})
+	if !strings.Contains(out, "--- a/") || !strings.Contains(out, "+++ b/") {
+		t.Errorf("expected unified diff, got %q", out)
+	}
+	got, _ := os.ReadFile(f)
+	if strings.Contains(string(got), "Greet") {
+		t.Error("Greet was not deleted")
+	}
+	if !strings.Contains(string(got), "Farewell") {
+		t.Error("Farewell was incorrectly deleted")
+	}
+}
+
+func TestDeleteSymbolMethod(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "example.go")
+	src := "package example\n\ntype Server struct{}\n\nfunc (s *Server) Start() error { return nil }\nfunc (s *Server) Stop() error { return nil }\n"
+	os.WriteFile(f, []byte(src), 0o644)
+
+	out := runTool(t, deleteSymbol{}, map[string]any{"path": f, "name": "Start", "kind": "method", "parent": "Server"})
+	if !strings.Contains(out, "--- a/") {
+		t.Errorf("expected unified diff, got %q", out)
+	}
+	got, _ := os.ReadFile(f)
+	if strings.Contains(string(got), "Start") {
+		t.Error("Start was not deleted")
+	}
+	if !strings.Contains(string(got), "Stop") {
+		t.Error("Stop was incorrectly deleted")
+	}
+}
+
+func TestDeleteSymbolType(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "example.go")
+	src := "package example\n\ntype User struct {\n\tName string\n}\n\ntype Admin struct {\n\tRole string\n}\n"
+	os.WriteFile(f, []byte(src), 0o644)
+
+	out := runTool(t, deleteSymbol{}, map[string]any{"path": f, "name": "User", "kind": "type"})
+	if !strings.Contains(out, "--- a/") {
+		t.Errorf("expected unified diff, got %q", out)
+	}
+	got, _ := os.ReadFile(f)
+	if strings.Contains(string(got), "type User") {
+		t.Error("User type was not deleted")
+	}
+	if !strings.Contains(string(got), "Admin") {
+		t.Error("Admin was incorrectly deleted")
+	}
+}
+
+func TestDeleteSymbolMultiMatch(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "example.go")
+	src := "package example\n\ntype Foo struct{}\ntype Foo int\n"
+	os.WriteFile(f, []byte(src), 0o644)
+
+	_, err := deleteSymbol{}.Execute(context.Background(), argsJSON(t, map[string]any{"path": f, "name": "Foo"}))
+	if err == nil || !strings.Contains(err.Error(), "Multiple") {
+		t.Errorf("expected multi-match error, got %v", err)
+	}
+}
+
+func TestDeleteSymbolNotFound(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "example.go")
+	os.WriteFile(f, []byte("package example\n"), 0o644)
+
+	_, err := deleteSymbol{}.Execute(context.Background(), argsJSON(t, map[string]any{"path": f, "name": "NoSuchFunc"}))
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got %v", err)
+	}
+}
+
+func TestDeleteSymbolNonGoFile(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "script.py")
+	os.WriteFile(f, []byte("def hello():\n    pass\n"), 0o644)
+
+	_, err := deleteSymbol{}.Execute(context.Background(), argsJSON(t, map[string]any{"path": f, "name": "hello"}))
+	if err == nil || !strings.Contains(err.Error(), "only supports Go") {
+		t.Errorf("expected unsupported-language error, got %v", err)
+	}
+}
+
+func TestDeleteSymbolPreview(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "example.go")
+	src := "package main\n\nfunc main() {}\n\nfunc helper() {}\n"
+	os.WriteFile(f, []byte(src), 0o644)
+
+	change, err := deleteSymbol{}.Preview(argsJSON(t, map[string]any{"path": f, "name": "helper"}))
+	if err != nil {
+		t.Fatalf("Preview: %v", err)
+	}
+	if !strings.Contains(change.Diff, "helper") {
+		t.Errorf("diff missing helper:\n%s", change.Diff)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != src {
+		t.Errorf("Preview mutated the file:\n got %q\nwant %q", got, src)
+	}
+}

--- a/internal/tool/builtin/delete_symbol_test.go
+++ b/internal/tool/builtin/delete_symbol_test.go
@@ -77,6 +77,30 @@ func TestDeleteSymbolMultiMatch(t *testing.T) {
 	}
 }
 
+func TestDeleteSymbolRejectsMultiNameValueSpec(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "example.go")
+	src := "package example\n\nvar A, B = 1, 2\nconst C, D = 3, 4\n"
+	os.WriteFile(f, []byte(src), 0o644)
+
+	_, err := deleteSymbol{}.Execute(context.Background(), argsJSON(t, map[string]any{
+		"path": f, "name": "A", "kind": "var",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "multi-name") {
+		t.Fatalf("expected multi-name var error, got %v", err)
+	}
+	_, err = deleteSymbol{}.Execute(context.Background(), argsJSON(t, map[string]any{
+		"path": f, "name": "C", "kind": "const",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "multi-name") {
+		t.Fatalf("expected multi-name const error, got %v", err)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != src {
+		t.Errorf("file modified despite rejected delete:\n got %q\nwant %q", got, src)
+	}
+}
+
 func TestDeleteSymbolNotFound(t *testing.T) {
 	dir := t.TempDir()
 	f := filepath.Join(dir, "example.go")

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -41,6 +41,8 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		writeFile{workDir: w.Dir, roots: roots},
 		editFile{workDir: w.Dir, roots: roots},
 		multiEdit{workDir: w.Dir, roots: roots},
+		deleteRange{workDir: w.Dir, roots: roots},
+		deleteSymbol{workDir: w.Dir, roots: roots},
 		bash{workDir: w.Dir, sb: w.Bash},
 		listDir{workDir: w.Dir},
 		globTool{workDir: w.Dir},


### PR DESCRIPTION
## Summary
Add two writer tools for deletion workflows: `delete_range` for exact text-anchor range deletion and `delete_symbol` for Go AST-based symbol deletion.

## Root Cause
Large deletions and symbol removals are awkward with small text replacement tools and can be error-prone when done manually.

## Technical Approach
Implement a previewable `delete_range` tool with unique start/end anchors and a previewable `delete_symbol` tool that parses Go files and removes selected declarations.

## Focused Optimization Points
- Integrates both tools with writer confinement and workspace-scoped tool construction.
- Provides unified diff output for review.
- Adds tests for duplicates, missing anchors, CRLF handling, methods, types, and preview behavior.

## Verification
Not run during this publishing pass. Draft note: this needs careful review of AST edge cases such as grouped declarations, comments, formatting, and multi-symbol specs.