### PR TITLE
fix(gitignore): update v2 build ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,50 @@
 # Build artifacts
 /bin/
 /dist/
+/stage/
 /reasonix
+/reasonix.exe
+
+# Go test/build scratch
+*.test
+*.out
+*.coverprofile
+coverage.out
+cpu.prof
+mem.prof
+
+# Wails desktop artifacts
+/desktop/build/*
+!/desktop/build/appicon.png
+/desktop/desktop
+/desktop/frontend/dist/*
+!/desktop/frontend/dist/.gitkeep
+/desktop/frontend/wailsjs/
+/desktop/frontend/package.json.md5
 
 # Environment / local config (reasonix.example.toml is the shared template)
 .env
 .env.local
+*.local
 /reasonix.toml
+/desktop/.env
+/desktop/reasonix.toml
 
-# Editor / OS
-.DS_Store
-.idea/
-.vscode/
+# Node / frontend dependencies and caches
+node_modules/
+.pnpm-store/
+.npm/
 
-# Go
-*.test
-*.out
+# Project-local Reasonix state; keep the checked-in review command.
+/.reasonix/*
+!/.reasonix/commands/
+!/.reasonix/commands/review.md
 
 # CodeGraph per-project index (rebuilt locally; never committed)
 .codegraph/
-/stage/
+
+# Editor / OS
+.DS_Store
+Thumbs.db
+.idea/
+.vscode/


### PR DESCRIPTION
## Summary
- update root .gitignore for the Go v2 layout
- ignore Go build/test scratch files, Wails desktop outputs, frontend caches, and local Reasonix state
- keep tracked placeholders/assets such as desktop/build/appicon.png, desktop/frontend/dist/.gitkeep, and .reasonix/commands/review.md

## Tests
- Not run (gitignore-only change).
