### PR TITLE
test: make Go tests portable on Windows

### DIFF
--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -22,7 +23,7 @@ func TestLoadDotEnvFallsBackToHome(t *testing.T) {
 	}
 
 	t.Chdir(cwd)
-	t.Setenv("HOME", home) // os.UserHomeDir() reads $HOME on unix
+	setTestHome(t, home)
 
 	// Start clean so the file values are what land (Setenv auto-restores).
 	t.Setenv("KEY_CWD", "")
@@ -53,12 +54,20 @@ func TestLoadDotEnvDoesNotOverrideEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(cwd)
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t, t.TempDir())
 	t.Setenv("PINNED", "from_env")
 
 	loadDotEnv()
 
 	if got := os.Getenv("PINNED"); got != "from_env" {
 		t.Errorf("env var must win over .env: PINNED=%q want from_env", got)
+	}
+}
+
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+	t.Setenv("HOME", home)
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
 	}
 }

--- a/internal/tool/builtin/workspace_test.go
+++ b/internal/tool/builtin/workspace_test.go
@@ -11,17 +11,19 @@ import (
 )
 
 func TestResolveIn(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "proj")
+	absPath := filepath.Join(t.TempDir(), "passwd")
 	cases := []struct {
 		workDir, p, want string
 	}{
-		{"", "foo.go", "foo.go"},                          // empty workDir: unchanged
-		{"", "", ""},                                      // empty workDir: unchanged
-		{"/proj", "foo.go", "/proj/foo.go"},               // relative joins
-		{"/proj", "a/b.go", "/proj/a/b.go"},               // nested relative
-		{"/proj", ".", "/proj"},                           // "." targets the root
-		{"/proj", "", "/proj"},                            // empty targets the root
-		{"/proj", "/etc/passwd", "/etc/passwd"},           // absolute honored verbatim
-		{"/proj", "../escape", filepath.Clean("/escape")}, // join cleans (confiner enforces)
+		{"", "foo.go", "foo.go"}, // empty workDir: unchanged
+		{"", "", ""},             // empty workDir: unchanged
+		{workDir, "foo.go", filepath.Join(workDir, "foo.go")},                  // relative joins
+		{workDir, "a/b.go", filepath.Join(workDir, "a/b.go")},                  // nested relative
+		{workDir, ".", workDir},                                                // "." targets the root
+		{workDir, "", workDir},                                                 // empty targets the root
+		{workDir, absPath, absPath},                                            // absolute honored verbatim
+		{workDir, "../escape", filepath.Join(filepath.Dir(workDir), "escape")}, // join cleans (confiner enforces)
 	}
 	for _, c := range cases {
 		if got := resolveIn(c.workDir, c.p); got != c.want {


### PR DESCRIPTION
## Summary

Closes #2419.

This makes two v2 Go tests portable on Windows:

- `TestLoadDotEnvFallsBackToHome` now sets `USERPROFILE` along with `HOME` for Windows, matching `os.UserHomeDir()` behavior.
- `TestResolveIn` now builds expectations with `filepath` and temporary absolute paths instead of hard-coding Unix-only `/proj` paths.

## Validation

Run on Windows:

```powershell
go test ./...
go build -o bin\reasonix.exe .\cmd\reasonix
go build -o bin\reasonix-plugin-example.exe .\cmd\reasonix-plugin-example
```

Note: local legacy npm git hooks were bypassed with `--no-verify` because the v2 Go branch no longer has a root `package.json`; the relevant Go checks above pass.