### PR TITLE
feat(glob): add ** recursive pattern support

### DIFF
--- a/internal/tool/builtin/builtin_test.go
+++ b/internal/tool/builtin/builtin_test.go
@@ -291,3 +291,69 @@ func TestLsAndGlob(t *testing.T) {
 		t.Fatalf("glob result = %q", g)
 	}
 }
+
+func TestGlobRecursive(t *testing.T) {
+	dir := t.TempDir()
+	// Create a nested structure:
+	// dir/a.go
+	// dir/sub/b.go
+	// dir/sub/deep/c.go
+	// dir/sub/deep/c.txt
+	// dir/other.txt
+	os.WriteFile(filepath.Join(dir, "a.go"), []byte("package a"), 0o644)
+	os.MkdirAll(filepath.Join(dir, "sub", "deep"), 0o755)
+	os.WriteFile(filepath.Join(dir, "sub", "b.go"), []byte("package b"), 0o644)
+	os.WriteFile(filepath.Join(dir, "sub", "deep", "c.go"), []byte("package c"), 0o644)
+	os.WriteFile(filepath.Join(dir, "sub", "deep", "c.txt"), []byte("text"), 0o644)
+	os.WriteFile(filepath.Join(dir, "other.txt"), []byte("other"), 0o644)
+
+	// **  *.go should find all .go files recursively.
+	out := runTool(t, globTool{}, map[string]any{"pattern": filepath.Join(dir, "**", "*.go")})
+	if !strings.Contains(out, "a.go") {
+		t.Errorf("missing a.go in:\n%s", out)
+	}
+	if !strings.Contains(out, "b.go") {
+		t.Errorf("missing b.go in:\n%s", out)
+	}
+	if !strings.Contains(out, "c.go") {
+		t.Errorf("missing c.go in:\n%s", out)
+	}
+	// Should not include .txt files.
+	if strings.Contains(out, "other.txt") || strings.Contains(out, "c.txt") {
+		t.Errorf("should not include .txt files:\n%s", out)
+	}
+
+	// **  *.txt should find all .txt files recursively.
+	out2 := runTool(t, globTool{}, map[string]any{"pattern": filepath.Join(dir, "**", "*.txt")})
+	if !strings.Contains(out2, "other.txt") {
+		t.Errorf("missing other.txt in:\n%s", out2)
+	}
+	if !strings.Contains(out2, "c.txt") {
+		t.Errorf("missing c.txt in:\n%s", out2)
+	}
+
+	// **  with no suffix should find all files.
+	out3 := runTool(t, globTool{}, map[string]any{"pattern": filepath.Join(dir, "**")})
+	if !strings.Contains(out3, "a.go") || !strings.Contains(out3, "c.txt") {
+		t.Errorf("bare ** should find all files:\n%s", out3)
+	}
+}
+
+func TestGlobRecursiveNoMatches(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, "sub"), 0o755)
+	os.WriteFile(filepath.Join(dir, "sub", "a.go"), []byte("package a"), 0o644)
+
+	out := runTool(t, globTool{}, map[string]any{"pattern": filepath.Join(dir, "**", "*.py")})
+	if !strings.Contains(out, "(no matches)") {
+		t.Errorf("expected (no matches), got:\n%s", out)
+	}
+}
+
+func TestGlobNoMatches(t *testing.T) {
+	dir := t.TempDir()
+	out := runTool(t, globTool{}, map[string]any{"pattern": filepath.Join(dir, "*.xyz")})
+	if !strings.Contains(out, "(no matches)") {
+		t.Errorf("expected (no matches), got:\n%s", out)
+	}
+}

--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"reasonix/internal/tool"
@@ -19,14 +21,16 @@ type globTool struct{ workDir string }
 func (globTool) Name() string { return "glob" }
 
 func (globTool) Description() string {
-	return "Find files matching a glob pattern (e.g. \"*.go\", \"internal/*/*.go\"). Supports the shell metacharacters * ? [ ]; does not support ** — use bash find for recursive matching."
+	return "Find files matching a glob pattern (e.g. \"*.go\", \"internal/*/*.go\", \"**/*.test.ts\"). Supports shell metacharacters * ? [] and the recursive ** pattern."
 }
 
 func (globTool) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string","description":"Glob pattern"}},"required":["pattern"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"pattern":{"type":"string","description":"Glob pattern (supports ** for recursive matching)"}},"required":["pattern"]}`)
 }
 
 func (globTool) ReadOnly() bool { return true }
+
+const globMaxResults = 1000
 
 func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
@@ -40,6 +44,12 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 	p.Pattern = resolveIn(g.workDir, p.Pattern)
 
+	// If the pattern contains **, use recursive matching via filepath.WalkDir.
+	if strings.Contains(p.Pattern, "**") {
+		return globRecursive(p.Pattern)
+	}
+
+	// Standard filepath.Glob for patterns without **.
 	matches, err := filepath.Glob(p.Pattern)
 	if err != nil {
 		return "", fmt.Errorf("glob %q: %w", p.Pattern, err)
@@ -47,5 +57,111 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if len(matches) == 0 {
 		return "(no matches)", nil
 	}
+	if len(matches) > globMaxResults {
+		matches = matches[:globMaxResults]
+		return strings.Join(matches, "\n") + fmt.Sprintf("\n... (truncated at %d results)", globMaxResults), nil
+	}
 	return strings.Join(matches, "\n"), nil
+}
+
+// globRecursive handles patterns containing ** by walking the filesystem.
+// It splits the pattern at ** to get a root prefix and a suffix to match
+// against each file path found during the walk.
+func globRecursive(pattern string) (string, error) {
+	// Split on ** to find the root directory and the remaining pattern.
+	parts := strings.SplitN(pattern, "**", 2)
+	root := parts[0]
+	// If root doesn't end with a separator, walk from its parent or "."
+	// so we don't miss files at that level.
+	if root == "" {
+		root = "."
+	}
+	// Ensure root is a clean directory path.
+	root = filepath.Clean(root)
+
+	// Check root exists.
+	if info, err := os.Stat(root); err != nil {
+		return "", fmt.Errorf("glob %q: %w", pattern, err)
+	} else if !info.IsDir() {
+		return "(no matches)", nil
+	}
+
+	suffix := ""
+	if len(parts) > 1 {
+		suffix = strings.TrimPrefix(parts[1], string(os.PathSeparator))
+	}
+
+	var matches []string
+	truncated := false
+
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // skip unreadable entries
+		}
+		if d.Name() == ".git" && d.IsDir() {
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			return nil
+		}
+		// If there's no suffix, every file matches.
+		if suffix == "" {
+			matches = append(matches, path)
+		} else {
+			// Match the path against root + any-subdir + suffix.
+			// Try matching the path relative to root against the suffix pattern.
+			rel, rerr := filepath.Rel(root, path)
+			if rerr != nil {
+				return nil
+			}
+			if matchGlobSuffix(rel, suffix) {
+				matches = append(matches, path)
+			}
+		}
+		if len(matches) >= globMaxResults {
+			truncated = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("glob %q: %w", pattern, err)
+	}
+
+	if len(matches) == 0 {
+		return "(no matches)", nil
+	}
+	sort.Strings(matches)
+	result := strings.Join(matches, "\n")
+	if truncated {
+		result += fmt.Sprintf("\n... (truncated at %d results)", globMaxResults)
+	}
+	return result, nil
+}
+
+// matchGlobSuffix checks if path matches the suffix pattern after **.
+// It tries matching at each directory level: if the pattern is "*.go",
+// it matches "foo.go" and "dir/foo.go". If the pattern is "test/*.go",
+// it matches "test/foo.go" and "dir/test/foo.go".
+func matchGlobSuffix(path, pattern string) bool {
+	// Direct match of the full relative path.
+	if matched, _ := filepath.Match(pattern, path); matched {
+		return true
+	}
+	// Try matching at each directory level.
+	parts := strings.Split(path, string(os.PathSeparator))
+	for i := range parts {
+		sub := strings.Join(parts[i:], string(os.PathSeparator))
+		if matched, _ := filepath.Match(pattern, sub); matched {
+			return true
+		}
+	}
+	// Also try matching just the filename against the pattern (for patterns
+	// like "*.go" that should match any .go file at any depth).
+	if !strings.Contains(pattern, string(os.PathSeparator)) {
+		if matched, _ := filepath.Match(pattern, filepath.Base(path)); matched {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
Add `**` recursive glob pattern support to the `glob` tool. Previously the tool only supported `filepath.Glob` which does not handle `**`. The description told users to "use bash find for recursive matching" — now `**` works natively.

### Changes
- **glob.go**: Rewrite with `filepath.WalkDir`-based recursive matching when `**` is in the pattern; falls back to standard `filepath.Glob` for simple patterns. Skips `.git` directories. Caps results at 1000 to prevent runaway walks.
- **builtin_test.go**: Add 3 new tests: `TestGlobRecursive` (nested .go files found, .txt excluded), `TestGlobRecursiveNoMatches`, `TestGlobNoMatches`.

### Examples
- `**/*.go` — find all .go files recursively
- `internal/**/*.go` — find .go files under internal/
- `**` — find all files

## Motivation
The glob tool's inability to do recursive matching was a common friction point — every other CLI tool supports `**`. Requiring the model to fall back to bash for this is unnecessary now.