### PR TITLE
fix(tui): add shift+enter to InsertNewline key binding, with test

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -211,8 +211,8 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 	// it at the insertion point and IME candidate windows anchor to the input.
 	ti.SetVirtualCursor(false)
 	// Plain Enter submits (the chatTUI handler intercepts it), so the textarea's
-	// own InsertNewline binding moves to Alt+Enter / Ctrl+J.
-	ti.KeyMap.InsertNewline = key.NewBinding(key.WithKeys("alt+enter", "ctrl+j"))
+	// own InsertNewline binding moves to Alt+Enter / Ctrl+J / Shift+Enter.
+	ti.KeyMap.InsertNewline = key.NewBinding(key.WithKeys("alt+enter", "ctrl+j", "shift+enter"))
 	ti.Focus()
 
 	sp := spinner.New()

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -4,9 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"charm.land/bubbles/v2/key"
-	"charm.land/bubbles/v2/textarea"
-
+	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
@@ -129,10 +127,13 @@ func TestAnswerTextStartingWithBracketStaysInAnswer(t *testing.T) {
 	}
 }
 
+// TestInsertNewlineKeyBinding verifies newChatTUI actually wires shift+enter
+// into the textarea's InsertNewline binding (plain Enter submits, so a newline
+// needs a modifier). It exercises the real constructor, not a hand-built binding.
 func TestInsertNewlineKeyBinding(t *testing.T) {
-	ti := textarea.New()
-	ti.KeyMap.InsertNewline = key.NewBinding(key.WithKeys("alt+enter", "ctrl+j", "shift+enter"))
-	keys := ti.KeyMap.InsertNewline.Keys()
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	keys := m.input.KeyMap.InsertNewline.Keys()
 	found := false
 	for _, k := range keys {
 		if k == "shift+enter" {
@@ -141,6 +142,6 @@ func TestInsertNewlineKeyBinding(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("InsertNewline should include shift+enter, got %v", keys)
+		t.Errorf("newChatTUI InsertNewline should include shift+enter, got %v", keys)
 	}
 }

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 	"testing"
 
+	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/textarea"
+
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
@@ -123,5 +126,21 @@ func TestAnswerTextStartingWithBracketStaysInAnswer(t *testing.T) {
 		if m.pending.String() != txt {
 			t.Errorf("answer text should buffer verbatim, got %q want %q", m.pending.String(), txt)
 		}
+	}
+}
+
+func TestInsertNewlineKeyBinding(t *testing.T) {
+	ti := textarea.New()
+	ti.KeyMap.InsertNewline = key.NewBinding(key.WithKeys("alt+enter", "ctrl+j", "shift+enter"))
+	keys := ti.KeyMap.InsertNewline.Keys()
+	found := false
+	for _, k := range keys {
+		if k == "shift+enter" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("InsertNewline should include shift+enter, got %v", keys)
 	}
 }


### PR DESCRIPTION
## What

\`InsertNewline\` binding now includes \`shift+enter\` (was only \`alt+enter\` and \`ctrl+j\`).

## Why

Shift+Enter for newline is standard TUI behaviour. The existing comment already expresses the intent (Enter=submit, modifier+Enter=newline), but Shift+Enter was simply missed from the key list.

## Test

\`TestInsertNewlineKeyBinding\` verifies \`shift+enter\` appears in the binding's keys.

## Note

Only works when the terminal actually distinguishes Shift+Enter from Enter (Kitty, WezTerm, iTerm2 with config). Terminals that don't (macOS Terminal.app, VS Code) are unchanged — use Alt+Enter or Ctrl+J instead.