### PR TITLE
fix(ask): reject blank option labels

### DIFF
--- a/internal/agent/ask.go
+++ b/internal/agent/ask.go
@@ -88,17 +88,22 @@ func (*AskTool) Execute(ctx context.Context, args json.RawMessage) (string, erro
 
 	qs := make([]event.AskQuestion, 0, len(p.Questions))
 	for i, q := range p.Questions {
-		if q.Question == "" || len(q.Options) < 2 {
+		question := strings.TrimSpace(q.Question)
+		if question == "" || len(q.Options) < 2 {
 			return "", fmt.Errorf("question %d: a question and at least two options are required", i+1)
 		}
 		opts := make([]event.AskOption, len(q.Options))
 		for j, o := range q.Options {
-			opts[j] = event.AskOption{Label: o.Label, Description: o.Description}
+			label := strings.TrimSpace(o.Label)
+			if label == "" {
+				return "", fmt.Errorf("question %d option %d: label is required", i+1, j+1)
+			}
+			opts[j] = event.AskOption{Label: label, Description: strings.TrimSpace(o.Description)}
 		}
 		qs = append(qs, event.AskQuestion{
 			ID:      fmt.Sprintf("q%d", i+1),
-			Header:  q.Header,
-			Prompt:  q.Question,
+			Header:  strings.TrimSpace(q.Header),
+			Prompt:  question,
 			Options: opts,
 			Multi:   q.MultiSelect,
 		})

--- a/internal/agent/ask.go
+++ b/internal/agent/ask.go
@@ -93,11 +93,16 @@ func (*AskTool) Execute(ctx context.Context, args json.RawMessage) (string, erro
 			return "", fmt.Errorf("question %d: a question and at least two options are required", i+1)
 		}
 		opts := make([]event.AskOption, len(q.Options))
+		seenLabels := make(map[string]int, len(q.Options))
 		for j, o := range q.Options {
 			label := strings.TrimSpace(o.Label)
 			if label == "" {
 				return "", fmt.Errorf("question %d option %d: label is required", i+1, j+1)
 			}
+			if prev, ok := seenLabels[label]; ok {
+				return "", fmt.Errorf("question %d option %d: duplicate label %q also used by option %d", i+1, j+1, label, prev+1)
+			}
+			seenLabels[label] = j
 			opts[j] = event.AskOption{Label: label, Description: strings.TrimSpace(o.Description)}
 		}
 		qs = append(qs, event.AskQuestion{

--- a/internal/agent/ask_test.go
+++ b/internal/agent/ask_test.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+type recordingAsker struct {
+	questions []event.AskQuestion
+}
+
+func (r *recordingAsker) Ask(_ context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
+	r.questions = questions
+	return []event.AskAnswer{{QuestionID: "q1", Selected: []string{"Keep going"}}}, nil
+}
+
+func TestAskToolRejectsBlankOptionLabels(t *testing.T) {
+	_, err := NewAskTool().Execute(context.Background(), []byte(`{
+		"questions":[{
+			"header":"Direction",
+			"question":"Which path?",
+			"options":[
+				{"label":"Keep going"},
+				{"label":"   ","description":"blank labels render as empty picker rows"}
+			]
+		}]
+	}`))
+	if err == nil {
+		t.Fatal("expected blank option label to be rejected")
+	}
+	if !strings.Contains(err.Error(), "option 2") || !strings.Contains(err.Error(), "label") {
+		t.Fatalf("error = %v, want it to identify the blank option label", err)
+	}
+}
+
+func TestAskToolTrimsPromptAndOptionsBeforePrompting(t *testing.T) {
+	asker := &recordingAsker{}
+	ctx := withCallContext(context.Background(), "call_1", event.Discard, asker)
+	out, err := NewAskTool().Execute(ctx, []byte(`{
+		"questions":[{
+			"header":" Direction ",
+			"question":" Which path? ",
+			"options":[
+				{"label":" Keep going ","description":" normal path "},
+				{"label":" Stop "}
+			]
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "Direction: Keep going") {
+		t.Fatalf("answer summary = %q, want trimmed header and answer", out)
+	}
+	if len(asker.questions) != 1 {
+		t.Fatalf("questions = %+v, want one", asker.questions)
+	}
+	q := asker.questions[0]
+	if q.Header != "Direction" || q.Prompt != "Which path?" {
+		t.Fatalf("prompt text not trimmed: %+v", q)
+	}
+	if q.Options[0].Label != "Keep going" || q.Options[0].Description != "normal path" {
+		t.Fatalf("option text not trimmed: %+v", q.Options[0])
+	}
+}

--- a/internal/agent/ask_test.go
+++ b/internal/agent/ask_test.go
@@ -36,6 +36,44 @@ func TestAskToolRejectsBlankOptionLabels(t *testing.T) {
 	}
 }
 
+func TestAskToolRejectsDuplicateOptionLabelsAfterTrimming(t *testing.T) {
+	_, err := NewAskTool().Execute(context.Background(), []byte(`{
+		"questions":[{
+			"header":"Release",
+			"question":"What should happen next?",
+			"options":[
+				{"label":"Deploy"},
+				{"label":" Deploy ","description":"same label after trimming"}
+			]
+		}]
+	}`))
+	if err == nil {
+		t.Fatal("expected duplicate trimmed option label to be rejected")
+	}
+	if !strings.Contains(err.Error(), "option 2") || !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), "Deploy") {
+		t.Fatalf("error = %v, want it to identify the duplicate option label", err)
+	}
+}
+
+func TestAskToolRejectsExactDuplicateOptionLabels(t *testing.T) {
+	_, err := NewAskTool().Execute(context.Background(), []byte(`{
+		"questions":[{
+			"header":"Release",
+			"question":"What should happen next?",
+			"options":[
+				{"label":"Deploy"},
+				{"label":"Deploy"}
+			]
+		}]
+	}`))
+	if err == nil {
+		t.Fatal("expected duplicate option label to be rejected")
+	}
+	if !strings.Contains(err.Error(), "option 2") || !strings.Contains(err.Error(), "duplicate") || !strings.Contains(err.Error(), "Deploy") {
+		t.Fatalf("error = %v, want it to identify the duplicate option label", err)
+	}
+}
+
 func TestAskToolTrimsPromptAndOptionsBeforePrompting(t *testing.T) {
 	asker := &recordingAsker{}
 	ctx := withCallContext(context.Background(), "call_1", event.Discard, asker)


### PR DESCRIPTION
## What

Fixes #2422.

Validate `ask` tool question and option text before sending it to the interactive chooser.

- Trim question, header, option label, and option description text.
- Reject whitespace-only option labels with a targeted validation error.
- Add regression coverage for blank option labels.
- Add coverage that valid prompt/options are trimmed before prompting.

## Why

The `ask` tool previously validated the question text and option count, but did not validate each option label. A whitespace-only option label could reach the frontend chooser and render as an empty selectable row.

## Verification

- `go test ./internal/agent -run 'TestAskTool' -count=1 -v`
- `go test ./internal/agent -count=1`
- `gofmt -l .`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
