### PR TITLE
fix: validate option labels are non-blank in ask tool

### DIFF
--- a/internal/agent/ask.go
+++ b/internal/agent/ask.go
@@ -93,6 +93,9 @@ func (*AskTool) Execute(ctx context.Context, args json.RawMessage) (string, erro
 		}
 		opts := make([]event.AskOption, len(q.Options))
 		for j, o := range q.Options {
+			if strings.TrimSpace(o.Label) == "" {
+				return "", fmt.Errorf("question %d: option %d has a blank label", i+1, j+1)
+			}
 			opts[j] = event.AskOption{Label: o.Label, Description: o.Description}
 		}
 		qs = append(qs, event.AskQuestion{


### PR DESCRIPTION
## Problem

The `ask` tool accepts options with blank or whitespace-only `label` values, producing empty selectable rows in the interactive chooser that can confuse users and produce useless answers.

## Root Cause

`AskTool.Execute` only validates that the question text exists (`q.Question == ""`) and that there are at least two options (`len(q.Options) < 2`). It does not trim or validate individual option labels, so an option like `{"label": "   "}` passes through untouched.

## Changes

Added a `strings.TrimSpace(o.Label) == ""` check inside the option-building loop in `internal/agent/ask.go`. If any option has a blank label, the tool returns a descriptive error (`question %d: option %d has a blank label`) instead of silently accepting it.

This is consistent with the existing validation pattern — the tool already rejects a blank question text and too-few options; blank labels should be rejected for the same reason.

## Closes

Closes #2422