### PR TITLE
fix(subagent): tighten inherited tool boundaries

### DIFF
--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -20,6 +20,26 @@ Use the provided tools to investigate or act. Return a single final answer that 
 and self-contained — the parent will see only that answer, not your tool calls or reasoning.
 If you need to ask for clarification, fail with a precise question instead of guessing.`
 
+var subagentMetaTools = []string{
+	"task",
+	"run_skill",
+	"install_skill",
+	"explore",
+	"research",
+	"review",
+	"security_review",
+}
+
+// SubagentMetaTools returns the tool names that spawned agents should not inherit
+// from the parent registry unless a future call site deliberately opts into a
+// different boundary. They can spawn or author more agent work, so excluding them
+// preserves one layer of delegation without adding a spawn-count cap.
+func SubagentMetaTools() []string {
+	out := make([]string, len(subagentMetaTools))
+	copy(out, subagentMetaTools)
+	return out
+}
+
 // TaskTool spawns a sub-agent in its own session for a focused sub-task. The
 // sub-agent runs with a filtered tool whitelist and the same step budget shape
 // as the parent (see Execute); its tool calls are forwarded to the parent's
@@ -67,7 +87,7 @@ func NewTaskTool(prov provider.Provider, pricing *provider.Pricing, parentReg *t
 func (t *TaskTool) Name() string { return "task" }
 
 func (t *TaskTool) Description() string {
-	return "Spawn a sub-agent for a focused sub-task. The sub-agent runs in its own session with the same provider and a filtered tool list (defaults to every parent tool except 'task' — no recursive nesting). Only its final answer is returned. Use this to (a) keep long exploration sequences out of the parent's context budget, or (b) delegate self-contained work like 'find every place that calls X and summarise the patterns'."
+	return "Spawn a sub-agent for a focused sub-task. The sub-agent runs in its own session with the same provider and a filtered tool list (defaults to every parent tool except subagent/skill meta-tools, so delegation stays one layer deep). Only its final answer is returned. Use this to (a) keep long exploration sequences out of the parent's context budget, or (b) delegate self-contained work like 'find every place that calls X and summarise the patterns'."
 }
 
 func (t *TaskTool) Schema() json.RawMessage {
@@ -76,7 +96,7 @@ func (t *TaskTool) Schema() json.RawMessage {
 "properties":{
   "prompt":{"type":"string","description":"What the sub-agent should accomplish. Be specific about the deliverable — the sub-agent does not see this conversation."},
   "description":{"type":"string","description":"Short label for the sub-task (3-7 words). Surfaced in the dispatch line so the user sees what's running."},
-  "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist. Defaults to every parent tool except 'task'."},
+  "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist. Subagent/skill meta-tools are still excluded so delegation stays one layer deep."},
   "max_steps":{"type":"integer","description":"Optional cap on tool-call rounds. Defaults to half the parent's cap (min 5).","minimum":1},
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."}
 },
@@ -147,9 +167,10 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 }
 
 // buildSubReg returns the sub-agent's tool set: the named whitelist (minus
-// `task`, to bar recursive nesting), or every parent tool except `task`.
+// subagent/skill meta-tools, to bar recursive nesting), or every parent tool
+// except those meta-tools.
 func (t *TaskTool) buildSubReg(names []string) *tool.Registry {
-	return FilterRegistry(t.parentReg, names, t.Name())
+	return FilterRegistry(t.parentReg, names, SubagentMetaTools()...)
 }
 
 // FilterRegistry builds a sub-registry from parent: the named whitelist (empty =

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -40,8 +40,8 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 }
 
 // TestTaskToolFiltersTools verifies the whitelist behaviour: when the caller
-// names a subset of tools, the sub-agent's registry contains exactly that
-// set (with "task" stripped to prevent recursion).
+// names a subset of tools, the sub-agent's registry contains exactly that set
+// with subagent/skill meta-tools stripped to prevent recursive delegation.
 func TestTaskToolFiltersTools(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "ok"},
@@ -53,24 +53,26 @@ func TestTaskToolFiltersTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "bash", readOnly: false})
 	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task) // simulate the wiring in cli.setup
+	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
+	parentReg.Add(fakeTool{name: "research", readOnly: false})
 
-	args := []byte(`{"prompt":"x","tools":["read_file","task","write_file"]}`)
+	args := []byte(`{"prompt":"x","tools":["read_file","task","write_file","run_skill","research"]}`)
 	if _, err := task.Execute(context.Background(), args); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	// The sub-agent's tool schemas should reflect the whitelist minus task.
+	// The sub-agent's tool schemas should reflect the whitelist minus meta-tools.
 	got := map[string]bool{}
 	for _, s := range sub.lastReq.Tools {
 		got[s.Name] = true
 	}
-	if !got["read_file"] || !got["write_file"] || got["task"] || got["bash"] {
-		t.Errorf("sub-agent tools = %v, want {read_file, write_file} (task stripped, bash not requested)", got)
+	if !got["read_file"] || !got["write_file"] || got["task"] || got["run_skill"] || got["research"] || got["bash"] {
+		t.Errorf("sub-agent tools = %v, want {read_file, write_file} (meta-tools stripped, bash not requested)", got)
 	}
 }
 
-// TestTaskToolDefaultsToParentToolsWithoutTask covers the no-whitelist path:
-// the sub-agent inherits every parent tool except the task tool itself.
-func TestTaskToolDefaultsToParentToolsWithoutTask(t *testing.T) {
+// TestTaskToolDefaultsToParentToolsWithoutMetaTools covers the no-whitelist
+// path: the sub-agent inherits parent tools except subagent/skill meta-tools.
+func TestTaskToolDefaultsToParentToolsWithoutMetaTools(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "ok"},
 		{Type: provider.ChunkDone},
@@ -80,6 +82,12 @@ func TestTaskToolDefaultsToParentToolsWithoutTask(t *testing.T) {
 	parentReg.Add(fakeTool{name: "grep", readOnly: true})
 	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task)
+	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
+	parentReg.Add(fakeTool{name: "explore", readOnly: false})
+	parentReg.Add(fakeTool{name: "research", readOnly: false})
+	parentReg.Add(fakeTool{name: "review", readOnly: false})
+	parentReg.Add(fakeTool{name: "security_review", readOnly: false})
+	parentReg.Add(fakeTool{name: "remember", readOnly: false})
 
 	if _, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`)); err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -88,7 +96,8 @@ func TestTaskToolDefaultsToParentToolsWithoutTask(t *testing.T) {
 	for _, s := range sub.lastReq.Tools {
 		got[s.Name] = true
 	}
-	if !got["read_file"] || !got["grep"] || got["task"] {
-		t.Errorf("default sub-agent tools = %v, want {read_file, grep} only", got)
+	if !got["read_file"] || !got["grep"] || !got["remember"] ||
+		got["task"] || got["run_skill"] || got["explore"] || got["research"] || got["review"] || got["security_review"] {
+		t.Errorf("default sub-agent tools = %v, want normal tools inherited and meta-tools stripped", got)
 	}
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -223,8 +223,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				}
 			}
 		}
-		subReg := agent.FilterRegistry(reg, sk.AllowedTools,
-			"task", "run_skill", "install_skill", "explore", "research", "review", "security_review")
+		subReg := agent.FilterRegistry(reg, sk.AllowedTools, agent.SubagentMetaTools()...)
 		steps := maxSteps
 		if steps > 0 {
 			if steps /= 2; steps < 5 {

--- a/internal/skill/builtins.go
+++ b/internal/skill/builtins.go
@@ -151,6 +151,8 @@ Rules:
 // builtinSkills returns the shipped skills. A fresh slice each call so callers
 // can't mutate the shared set.
 func builtinSkills() []Skill {
+	readCodeTools := []string{"read_file", "ls", "glob", "grep"}
+	reviewTools := []string{"read_file", "ls", "glob", "grep", "bash"}
 	return []Skill{
 		{
 			Name:        "init",
@@ -161,36 +163,40 @@ func builtinSkills() []Skill {
 			RunAs:       RunInline,
 		},
 		{
-			Name:        "explore",
-			Description: "Explore the codebase in an isolated subagent — wide-net read-only investigation that returns one distilled answer. Best for: 'find all places that...', 'how does X work across the project', 'survey the code for Y'.",
-			Body:        builtinExploreBody,
-			Scope:       ScopeBuiltin,
-			Path:        "(builtin)",
-			RunAs:       RunSubagent,
+			Name:         "explore",
+			Description:  "Explore the codebase in an isolated subagent — wide-net read-only investigation that returns one distilled answer. Best for: 'find all places that...', 'how does X work across the project', 'survey the code for Y'.",
+			Body:         builtinExploreBody,
+			Scope:        ScopeBuiltin,
+			Path:         "(builtin)",
+			RunAs:        RunSubagent,
+			AllowedTools: append([]string(nil), readCodeTools...),
 		},
 		{
-			Name:        "research",
-			Description: "Research a question by combining web_fetch + code reading in an isolated subagent. Best for: 'is X supported by lib Y', 'what's the canonical way to do Z', 'compare our impl against the spec'.",
-			Body:        builtinResearchBody,
-			Scope:       ScopeBuiltin,
-			Path:        "(builtin)",
-			RunAs:       RunSubagent,
+			Name:         "research",
+			Description:  "Research a question by combining web_fetch + code reading in an isolated subagent. Best for: 'is X supported by lib Y', 'what's the canonical way to do Z', 'compare our impl against the spec'.",
+			Body:         builtinResearchBody,
+			Scope:        ScopeBuiltin,
+			Path:         "(builtin)",
+			RunAs:        RunSubagent,
+			AllowedTools: append(append([]string(nil), readCodeTools...), "web_fetch"),
 		},
 		{
-			Name:        "review",
-			Description: "Review the pending changes (current branch diff by default) in an isolated subagent — flags correctness, security, missing tests, hidden behavior changes; reports a verdict + per-issue file:line. Read-only.",
-			Body:        builtinReviewBody,
-			Scope:       ScopeBuiltin,
-			Path:        "(builtin)",
-			RunAs:       RunSubagent,
+			Name:         "review",
+			Description:  "Review the pending changes (current branch diff by default) in an isolated subagent — flags correctness, security, missing tests, hidden behavior changes; reports a verdict + per-issue file:line. Read-only.",
+			Body:         builtinReviewBody,
+			Scope:        ScopeBuiltin,
+			Path:         "(builtin)",
+			RunAs:        RunSubagent,
+			AllowedTools: append([]string(nil), reviewTools...),
 		},
 		{
-			Name:        "security-review",
-			Description: "Security-focused review of the current branch diff in an isolated subagent — flags injection/authz/secrets/deserialization/path-traversal/crypto issues, severity-tagged. Read-only.",
-			Body:        builtinSecurityReviewBody,
-			Scope:       ScopeBuiltin,
-			Path:        "(builtin)",
-			RunAs:       RunSubagent,
+			Name:         "security-review",
+			Description:  "Security-focused review of the current branch diff in an isolated subagent — flags injection/authz/secrets/deserialization/path-traversal/crypto issues, severity-tagged. Read-only.",
+			Body:         builtinSecurityReviewBody,
+			Scope:        ScopeBuiltin,
+			Path:         "(builtin)",
+			RunAs:        RunSubagent,
+			AllowedTools: append([]string(nil), reviewTools...),
 		},
 		{
 			Name:        "test",

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -147,6 +147,33 @@ func TestBuiltinInitIsInlineSkill(t *testing.T) {
 	}
 }
 
+func TestBuiltinSubagentSkillsDeclareAllowedTools(t *testing.T) {
+	st := New(Options{HomeDir: t.TempDir()})
+	cases := map[string][]string{
+		"explore":         {"read_file", "ls", "glob", "grep"},
+		"research":        {"read_file", "ls", "glob", "grep", "web_fetch"},
+		"review":          {"read_file", "ls", "glob", "grep", "bash"},
+		"security-review": {"read_file", "ls", "glob", "grep", "bash"},
+	}
+	for name, want := range cases {
+		sk, ok := st.Read(name)
+		if !ok {
+			t.Fatalf("built-in %s skill not found", name)
+		}
+		if sk.RunAs != RunSubagent {
+			t.Fatalf("%s RunAs = %s, want subagent", name, sk.RunAs)
+		}
+		if !sameStrings(sk.AllowedTools, want) {
+			t.Errorf("%s AllowedTools = %v, want %v", name, sk.AllowedTools, want)
+		}
+		for _, meta := range []string{"task", "run_skill", "install_skill", "explore", "research", "review", "security_review"} {
+			if containsString(sk.AllowedTools, meta) {
+				t.Errorf("%s AllowedTools should not include meta-tool %q: %v", name, meta, sk.AllowedTools)
+			}
+		}
+	}
+}
+
 func TestBuiltinsPresentAndOverridable(t *testing.T) {
 	st := New(Options{HomeDir: t.TempDir()})
 	if _, ok := find(st.List(), "explore"); !ok {
@@ -160,6 +187,27 @@ func TestBuiltinsPresentAndOverridable(t *testing.T) {
 	if ex.Scope == ScopeBuiltin || ex.Description != "mine" {
 		t.Errorf("user explore should override builtin: scope=%s desc=%q", ex.Scope, ex.Description)
 	}
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestInvalidNamesSkipped(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #2431.

This tightens v2 subagent tool inheritance boundaries without adding any spawn-count cap or threshold:

- plain `task` subagents now exclude the shared subagent/skill meta-tool set by default, not just `task` itself
- skill subagents reuse the same shared meta-tool exclusion list
- built-in subagent skills declare explicit tool scopes:
  - `explore`: read/list/search code tools
  - `research`: code read/search + `web_fetch`
  - `review` and `security-review`: code read/search + `bash` for diff/status inspection
- tests cover task inheritance filtering and built-in skill `AllowedTools`

## Non-goals

This intentionally does not add a hard spawn cap, soft threshold, token budget, or time budget. The change only narrows accidental recursive/tool-surface inheritance.

## Validation

Run on Windows:

```powershell
go test ./internal/agent ./internal/skill ./internal/boot
go build -o bin\reasonix.exe .\cmd\reasonix
go build -o bin\reasonix-plugin-example.exe .\cmd\reasonix-plugin-example
```

Note: local legacy npm git hooks were bypassed with `--no-verify` because the v2 Go branch no longer has a root `package.json`. Full `go test ./...` on this Windows checkout is still blocked by the known unrelated Windows test portability issue tracked in #2419 / #2420.