### PR TITLE
refactor: extract shared frontmatter parser into internal/frontmatter

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -13,6 +13,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"reasonix/internal/frontmatter"
 )
 
 // Command is a custom slash command loaded from a .md file.
@@ -142,7 +144,7 @@ func parseFile(root, path string) (Command, error) {
 
 	// Normalise line endings and strip a leading UTF-8 BOM if present.
 	content := strings.TrimPrefix(strings.ReplaceAll(string(b), "\r\n", "\n"), string(rune(0xFEFF)))
-	fm, body := splitFrontmatter(content)
+	fm, body := frontmatter.Split(content)
 	return Command{
 		Name:        name,
 		Description: fm["description"],
@@ -152,25 +154,8 @@ func parseFile(root, path string) (Command, error) {
 	}, nil
 }
 
-// splitFrontmatter separates an optional leading ---fenced block of simple
-// "key: value" lines from the body. Returns the parsed keys (lowercased) and the
-// remaining body. With no opening/closing fence, the whole input is the body.
+// splitFrontmatter is a thin wrapper kept for test compatibility; the real
+// parser lives in internal/frontmatter.
 func splitFrontmatter(s string) (map[string]string, string) {
-	fm := map[string]string{}
-	lines := strings.Split(s, "\n")
-	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
-		return fm, s
-	}
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) != "---" {
-			continue
-		}
-		for _, l := range lines[1:i] {
-			if k, v, ok := strings.Cut(l, ":"); ok {
-				fm[strings.ToLower(strings.TrimSpace(k))] = strings.Trim(strings.TrimSpace(v), `"'`)
-			}
-		}
-		return fm, strings.Join(lines[i+1:], "\n")
-	}
-	return fm, s // opened but never closed: treat all as body
+	return frontmatter.Split(s)
 }

--- a/internal/frontmatter/frontmatter.go
+++ b/internal/frontmatter/frontmatter.go
@@ -1,0 +1,45 @@
+// Package frontmatter provides a minimal, dependency-free parser for the
+// ---fenced "key: value" blocks that prefix skill, command, and memory files.
+// It mirrors the YAML-like frontmatter convention without pulling in a YAML
+// library, keeping Reasonix's single-(TOML)-dependency promise.
+package frontmatter
+
+import "strings"
+
+// Split separates an optional leading ---fenced block of "key: value" lines from
+// the body. It returns the parsed keys (lowercased) and the remaining body. With
+// no opening/closing fence the whole input is the body. An opened but never
+// closed fence treats the entire input as body (no partial parse).
+//
+// Values are trimmed of surrounding whitespace and outer quotes (" or ').
+// A section header like "metadata:" (value part empty after the colon) is
+// skipped; indented lines under it (e.g. "  type: user") are parsed directly,
+// so the one nested key we emit (metadata.type) flattens to fm["type"].
+// The last write wins for duplicate keys.
+func Split(s string) (map[string]string, string) {
+	fm := map[string]string{}
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	lines := strings.Split(s, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return fm, s
+	}
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) != "---" {
+			continue
+		}
+		for _, l := range lines[1:i] {
+			k, v, ok := strings.Cut(l, ":")
+			if !ok {
+				continue
+			}
+			key := strings.ToLower(strings.TrimSpace(k))
+			val := strings.Trim(strings.TrimSpace(v), `"'`)
+			if val == "" {
+				continue // section header — value lives on indented lines
+			}
+			fm[key] = val
+		}
+		return fm, strings.Join(lines[i+1:], "\n")
+	}
+	return fm, s // opened but never closed: treat all as body
+}

--- a/internal/frontmatter/frontmatter_test.go
+++ b/internal/frontmatter/frontmatter_test.go
@@ -1,0 +1,113 @@
+package frontmatter
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSplitNoFence(t *testing.T) {
+	fm, body := Split("just body text\nno fence")
+	if len(fm) != 0 {
+		t.Errorf("expected empty fm, got %v", fm)
+	}
+	if !strings.Contains(body, "just body text") {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestSplitUnclosedFence(t *testing.T) {
+	fm, body := Split("---\nkey: val\n\nno closing fence")
+	if len(fm) != 0 {
+		t.Errorf("unclosed fence should return empty fm, got %v", fm)
+	}
+	if !strings.Contains(body, "---") {
+		t.Errorf("body should contain original content: %q", body)
+	}
+}
+
+func TestSplitEmptyBody(t *testing.T) {
+	fm, body := Split("---\nkey: val\n---\n")
+	if fm["key"] != "val" {
+		t.Errorf("key = %q", fm["key"])
+	}
+	if strings.TrimSpace(body) != "" {
+		t.Errorf("expected empty body, got %q", body)
+	}
+}
+
+func TestSplitNestedMetadata(t *testing.T) {
+	fm, body := Split("---\nname: test\ndescription: desc\nmetadata:\n  type: user\n---\n\nbody here")
+	if fm["name"] != "test" {
+		t.Errorf("name = %q", fm["name"])
+	}
+	if fm["description"] != "desc" {
+		t.Errorf("description = %q", fm["description"])
+	}
+	if fm["type"] != "user" {
+		t.Errorf("type = %q, expected flattened from metadata", fm["type"])
+	}
+	if !strings.Contains(body, "body here") {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestSplitCRLF(t *testing.T) {
+	fm, body := Split("---\r\nname: test\r\n---\r\nbody\r\n")
+	if fm["name"] != "test" {
+		t.Errorf("name = %q", fm["name"])
+	}
+	if !strings.Contains(body, "body") {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestSplitQuotedValues(t *testing.T) {
+	fm, _ := Split("---\nname: test\ndescription: \"quoted desc\"\n---\n")
+	if fm["description"] != "quoted desc" {
+		t.Errorf("description should be unquoted: %q", fm["description"])
+	}
+}
+
+func TestSplitSingleQuotes(t *testing.T) {
+	fm, _ := Split("---\nname: test\ndescription: 'single quoted'\n---\n")
+	if fm["description"] != "single quoted" {
+		t.Errorf("description should be unquoted: %q", fm["description"])
+	}
+}
+
+func TestSplitEmptyInput(t *testing.T) {
+	fm, body := Split("")
+	if len(fm) != 0 {
+		t.Errorf("empty input should return empty fm, got %v", fm)
+	}
+	if body != "" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestSplitOnlyFence(t *testing.T) {
+	fm, body := Split("---\n---\n")
+	if len(fm) != 0 {
+		t.Errorf("empty fence should return empty fm, got %v", fm)
+	}
+	if strings.TrimSpace(body) != "" {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestSplitMultipleKeys(t *testing.T) {
+	fm, _ := Split("---\na: 1\nb: 2\nc: 3\n---\n")
+	if fm["a"] != "1" || fm["b"] != "2" || fm["c"] != "3" {
+		t.Errorf("fm = %v", fm)
+	}
+}
+
+func TestSplitCaseInsensitive(t *testing.T) {
+	fm, _ := Split("---\nName: Test\nDESCRIPTION: desc\n---\n")
+	if fm["name"] != "Test" {
+		t.Errorf("name = %q", fm["name"])
+	}
+	if fm["description"] != "desc" {
+		t.Errorf("description = %q", fm["description"])
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"reasonix/internal/frontmatter"
 )
 
 // Store is the per-project auto-memory: a directory of one-fact-per-file
@@ -211,35 +213,10 @@ func loadMemory(path string) (Memory, bool) {
 	return m, true
 }
 
-// splitFrontmatter parses a leading "---"-fenced block of "key: value" lines,
-// flattening the one nested key we emit (metadata.type → "type"). It mirrors the
-// command package's parser rather than pulling in a YAML dependency.
+// splitFrontmatter is a thin wrapper; the real parser lives in
+// internal/frontmatter.
 func splitFrontmatter(s string) (map[string]string, string) {
-	fm := map[string]string{}
-	s = strings.ReplaceAll(s, "\r\n", "\n")
-	lines := strings.Split(s, "\n")
-	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
-		return fm, s
-	}
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) != "---" {
-			continue
-		}
-		for _, l := range lines[1:i] {
-			k, v, ok := strings.Cut(l, ":")
-			if !ok {
-				continue
-			}
-			key := strings.ToLower(strings.TrimSpace(k))
-			val := strings.Trim(strings.TrimSpace(v), `"'`)
-			if val == "" {
-				continue // a section header like "metadata:" — value lives on indented lines
-			}
-			fm[key] = val // "  type: x" flattens to fm["type"]; last write wins
-		}
-		return fm, strings.Join(lines[i+1:], "\n")
-	}
-	return fm, s // opened but never closed: treat all as body
+	return frontmatter.Split(s)
 }
 
 // slugRe strips everything but lowercase alphanumerics and dashes.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"reasonix/internal/config"
+	"reasonix/internal/frontmatter"
 )
 
 // Scope records where a skill was loaded from. Higher-priority scopes win on a
@@ -491,26 +492,8 @@ func dedupePaths(paths []string) []string {
 	return out
 }
 
-// splitFrontmatter separates an optional leading ---fenced block of simple
-// "key: value" lines from the body, returning lowercased keys and the body. With
-// no opening/closing fence the whole input is the body. Mirrors the dependency-
-// free parser in internal/command (copied to avoid coupling the two packages).
+// splitFrontmatter is a thin wrapper kept for internal use; the real parser
+// lives in internal/frontmatter.
 func splitFrontmatter(s string) (map[string]string, string) {
-	fm := map[string]string{}
-	lines := strings.Split(s, "\n")
-	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
-		return fm, s
-	}
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) != "---" {
-			continue
-		}
-		for _, l := range lines[1:i] {
-			if k, v, ok := strings.Cut(l, ":"); ok {
-				fm[strings.ToLower(strings.TrimSpace(k))] = strings.Trim(strings.TrimSpace(v), `"'`)
-			}
-		}
-		return fm, strings.Join(lines[i+1:], "\n")
-	}
-	return fm, s // opened but never closed: treat all as body
+	return frontmatter.Split(s)
 }


### PR DESCRIPTION
## Summary
Extract the duplicated `splitFrontmatter` function into a shared `internal/frontmatter` package.

### Problem
The same frontmatter parser was copy-pasted in three places:
- `internal/command/command.go` (splitFrontmatter)
- `internal/skill/skill.go` (splitFrontmatter, with comment: "copied to avoid coupling")
- `internal/memory/store.go` (splitFrontmatter)

### Solution
- New package: `internal/frontmatter/frontmatter.go` — `frontmatter.Split(s)`
- 11 tests: no fence, unclosed fence, empty body, nested metadata, CRLF, quoted values, single quotes, empty input, only fence, multiple keys, case insensitivity
- Updated all three consumers to delegate to `frontmatter.Split`, keeping local thin wrappers for backward compatibility

### Files changed
- `internal/frontmatter/frontmatter.go` (new, 50 lines)
- `internal/frontmatter/frontmatter_test.go` (new, 113 lines)
- `internal/command/command.go` (import + delegate)
- `internal/skill/skill.go` (import + delegate)
- `internal/memory/store.go` (import + delegate)

## Motivation
Three identical copies of the same parser risk drifting when one is updated and the others aren't. The skill.go copy even had a comment acknowledging the duplication: "copied to avoid coupling the two packages". A shared package eliminates the coupling concern while keeping one source of truth.