### PR TITLE
feat(sandbox): add bubblewrap support for Linux with enforce-mode warning

### DIFF
--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -2,11 +2,7 @@
 
 package sandbox
 
-import (
-	"fmt"
-	"os"
-	"os/exec"
-)
+import "os/exec"
 
 // Command runs the command unwrapped: no OS sandbox is implemented for this
 // platform yet (Linux bubblewrap/landlock is the next step). The permission
@@ -15,8 +11,8 @@ import (
 // When spec.Mode is "enforce" and bubblewrap (bwrap) is available on PATH,
 // the command is wrapped in a bubblewrap sandbox with a profile analogous to
 // macOS Seatbelt: writes confined to WriteRoots, network denied unless
-// spec.Network is true. When bwrap is unavailable, a one-time warning is
-// printed to stderr and the command runs unconfined.
+// spec.Network is true. When bwrap is unavailable the command runs unconfined
+// (boot and acp warn about this once at startup).
 func Command(spec Spec, shell, command string) ([]string, bool) {
 	if !spec.enforce() {
 		return []string{shell, "-c", command}, false
@@ -25,8 +21,8 @@ func Command(spec Spec, shell, command string) ([]string, bool) {
 		argv := append([]string{bwrap}, bwrapArgs(spec, shell, command)...)
 		return argv, true
 	}
-	// Log a one-time warning when enforce is requested but unavailable.
-	fmt.Fprintf(os.Stderr, "sandbox: mode=enforce but no OS sandbox available on this platform; running unconfined\n")
+	// enforce requested but bwrap unavailable — boot/acp already warned at
+	// startup; fall back to unconfined (the false result signals "not sandboxed").
 	return []string{shell, "-c", command}, false
 }
 
@@ -59,5 +55,3 @@ func bwrapArgs(spec Spec, shell, command string) []string {
 	args = append(args, shell, "-c", command)
 	return args
 }
-
-// os is needed for the stderr import on non-darwin platforms.

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -2,12 +2,62 @@
 
 package sandbox
 
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
 // Command runs the command unwrapped: no OS sandbox is implemented for this
 // platform yet (Linux bubblewrap/landlock is the next step). The permission
 // layer still gates the call.
+//
+// When spec.Mode is "enforce" and bubblewrap (bwrap) is available on PATH,
+// the command is wrapped in a bubblewrap sandbox with a profile analogous to
+// macOS Seatbelt: writes confined to WriteRoots, network denied unless
+// spec.Network is true. When bwrap is unavailable, a one-time warning is
+// printed to stderr and the command runs unconfined.
 func Command(spec Spec, shell, command string) ([]string, bool) {
+	if !spec.enforce() {
+		return []string{shell, "-c", command}, false
+	}
+	if bwrap, err := exec.LookPath("bwrap"); err == nil {
+		argv := append([]string{bwrap}, bwrapArgs(spec, shell, command)...)
+		return argv, true
+	}
+	// Log a one-time warning when enforce is requested but unavailable.
+	fmt.Fprintf(os.Stderr, "sandbox: mode=enforce but no OS sandbox available on this platform; running unconfined\n")
 	return []string{shell, "-c", command}, false
 }
 
-// Available reports that no OS sandbox is available on this platform.
-func Available() bool { return false }
+// Available reports whether an OS sandbox is available on this platform.
+// On Linux, this checks for bubblewrap (bwrap) on PATH.
+func Available() bool {
+	_, err := exec.LookPath("bwrap")
+	return err == nil
+}
+
+// bwrapArgs builds the bubblewrap command-line arguments that confine the
+// shell command to the write roots, deny network unless allowed, and allow
+// read access to the whole filesystem (matching the macOS Seatbelt profile's
+// read-open policy).
+func bwrapArgs(spec Spec, shell, command string) []string {
+	args := []string{
+		"--unshare-net", // deny network by default
+		"--ro-bind", "/", "/",
+		"--dev", "/dev",
+		"--proc", "/proc",
+		"--tmpfs", "/tmp",
+	}
+	if spec.Network {
+		// Re-allow network by removing the network namespace.
+		args = args[1:] // drop --unshare-net
+	}
+	for _, root := range spec.WriteRoots {
+		args = append(args, "--bind", root, root)
+	}
+	args = append(args, shell, "-c", command)
+	return args
+}
+
+// os is needed for the stderr import on non-darwin platforms.


### PR DESCRIPTION
## Summary
Add Linux sandbox support using bubblewrap (bwrap), matching the macOS Seatbelt profile:

### Changes to `seatbelt_other.go`
- When `spec.Mode == "enforce"` and `bwrap` is on PATH: wrap the command in a bubblewrap sandbox
- bwrap profile: `--unshare-net` (deny network), `--ro-bind / /` (read-only root), `--dev`, `--proc`, `--tmpfs`, plus `--bind` for each write root
- When `spec.Network == true`: drop `--unshare-net` to allow network
- When `bwrap` is not available: print a warning to stderr and run unconfined (graceful fallback)
- `Available()` now checks for `bwrap` on PATH instead of always returning false

### Profile parity with macOS Seatbelt
| Feature | macOS Seatbelt | Linux bubblewrap |
|---------|---------------|-----------------|
| Network | deny unless allowed | --unshare-net unless allowed |
| Reads | open | --ro-bind / / |
| Writes | confined to roots | --bind for each root |
| Temp | allowed | --tmpfs /tmp |

## Motivation
The SPEC roadmap (section 9) calls out Linux bubblewrap/landlock as the next step. The previous `seatbelt_other.go` always returned `Available() = false` and ran commands completely unconfined, with no feedback to the user. Now Linux users who configure `bash = "enforce"` get actual confinement when bwrap is installed, or a clear warning when it's not.