### PR TITLE
fix(plugin): log prompt/resource listing failures in Host.Add

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"reasonix/internal/tool"
@@ -216,11 +217,15 @@ func (h *Host) Add(ctx context.Context, s Spec) ([]tool.Tool, error) {
 	if c.hasPrompts {
 		if ps, perr := c.listPrompts(ctx); perr == nil {
 			h.prompts = append(h.prompts, ps...)
+		} else {
+			slog.Warn("plugin: listPrompts failed", "server", s.Name, "err", perr)
 		}
 	}
 	if c.hasResources {
 		if rs, rerr := c.listResources(ctx); rerr == nil {
 			h.resources = append(h.resources, rs...)
+		} else {
+			slog.Warn("plugin: listResources failed", "server", s.Name, "err", rerr)
 		}
 	}
 	return ts, nil


### PR DESCRIPTION
## Summary
When `Host.Add` connects an MCP server that advertises prompts or resources capabilities but fails to list them, the errors are now logged via `slog.Warn` instead of being silently swallowed.

### Before
```go
if c.hasPrompts {
    if ps, perr := c.listPrompts(ctx); perr == nil {
        h.prompts = append(h.prompts, ps...)
    }
    // perr silently discarded
}
```

### After
```go
if c.hasPrompts {
    if ps, perr := c.listPrompts(ctx); perr == nil {
        h.prompts = append(h.prompts, ps...)
    } else {
        slog.Warn("plugin: listPrompts failed", "server", s.Name, "err", perr)
    }
}
```

Same for `listResources`.

## Motivation
A user connecting a server that fails to list its prompts gets no feedback — the server appears connected but its prompts are missing. Logging the error makes debugging possible without breaking the non-fatal contract (prompts/resources are auxiliary).