### PR TITLE
refactor: deduplicate compactArgs between agent and cli

### DIFF
--- a/internal/agent/textsink.go
+++ b/internal/agent/textsink.go
@@ -68,7 +68,7 @@ func (s *TextSink) Emit(e event.Event) {
 		s.closeTextStream(e.Text, e.Reasoning)
 
 	case event.ToolDispatch:
-		fmt.Fprintf(s.out, "  -> %s %s\n", e.Tool.Name, compactArgs(e.Tool.Args))
+		fmt.Fprintf(s.out, "  -> %s %s\n", e.Tool.Name, CompactArgs(e.Tool.Args))
 		s.wroteAnything = true
 
 	case event.ToolResult:
@@ -181,8 +181,9 @@ func FormatUsageLine(u *provider.Usage, p *provider.Pricing) string {
 // recede from the final answer.
 func dimText(s string) string { return "\x1b[2m" + s + "\x1b[0m" }
 
-// compactArgs trims and caps a tool's raw JSON arguments for the dispatch line.
-func compactArgs(s string) string {
+// CompactArgs trims and caps a tool's raw JSON arguments for the dispatch line.
+// Exported so the CLI can reuse the same rendering without duplicating the logic.
+func CompactArgs(s string) string {
 	s = strings.TrimSpace(s)
 	r := []rune(s)
 	if len(r) > 120 {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1477,13 +1477,6 @@ type eventSink struct {
 
 func (s *eventSink) Emit(e event.Event) { s.ch <- e }
 
-// compactArgs trims and caps a tool's raw JSON arguments for the dispatch line,
-// matching the agent's headless rendering so the chat timeline reads the same.
-func compactArgs(s string) string {
-	s = strings.TrimSpace(s)
-	r := []rune(s)
-	if len(r) > 120 {
-		return string(r[:120]) + "..."
-	}
-	return s
-}
+// compactArgs delegates to agent.CompactArgs so the CLI and headless rendering
+// stay identical.
+func compactArgs(s string) string { return agent.CompactArgs(s) }


### PR DESCRIPTION
## Summary
The `compactArgs` function (trim whitespace, cap at 120 runes) was defined identically in two places:
- `internal/agent/textsink.go` (headless rendering)
- `internal/cli/chat_tui.go` (TUI rendering)

### Changes
- Export `CompactArgs` from `internal/agent/textsink.go`
- Replace the CLI's local copy with a thin wrapper calling `agent.CompactArgs(s)`
- The wrapper preserves the local name for backward compatibility with call sites

### Files changed
- `internal/agent/textsink.go`: rename `compactArgs` → `CompactArgs` (exported)
- `internal/cli/chat_tui.go`: replace 8-line function with 1-line delegate

## Motivation
DRY violation: two identical functions risk drifting when one is updated. The CLI comment even said "matching the agent's headless rendering" — now it literally calls the same function.