### PR TITLE
fix(openai): drain error response body for HTTP connection reuse

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -113,6 +113,9 @@ func (c *client) sendWithRetry(ctx context.Context, body []byte) (*http.Response
 			return resp, nil
 		}
 		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		// Drain any remaining body so the HTTP connection can be reused by the
+		// transport pool, then close.
+		_, _ = io.Copy(io.Discard, resp.Body)
 		resp.Body.Close()
 		// A rejected key is a configuration problem, not a transient one — give
 		// an actionable error instead of dumping the raw status body.


### PR DESCRIPTION
## Summary
After reading the limited (4KB) error body from a non-200 response, drain any remaining body to `io.Discard` before closing. This ensures the HTTP/2 connection can be reused by Go's transport pool.

### Before
```go
msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
resp.Body.Close()
```

### After
```go
msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
_, _ = io.Copy(io.Discard, resp.Body)
resp.Body.Close()
```

## Motivation
Go's `http.Transport` reuses connections only when the response body is fully drained. Without draining, each retry in `sendWithRetry` opens a new TCP connection instead of reusing the existing one. This is especially impactful for the retry loop (up to 3 attempts on transient errors).