### PR TITLE
feat(subagent): configure skill model overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ never stored in config files.
 default_model = "deepseek-flash"   # executor; set [agent].planner_model to add a planner
 # language    = "zh"               # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
 
+[agent]
+# planner_model = "mimo-pro"          # optional low-frequency planner
+# subagent_model = "deepseek-pro"     # optional default for runAs=subagent skills
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
+
 [[providers]]
 name        = "deepseek-flash"
 kind        = "openai"
@@ -213,6 +218,10 @@ separate cache-stable sessions) is a one-line edit afterwards — set
 [agent]
 planner_model = "deepseek-pro"   # used as the low-frequency planner
 ```
+
+Subagent skills inherit the executor model by default. Set `subagent_model` to
+run them on another configured model, or use `subagent_models` to override only
+specific skills such as `review` or `security_review`.
 
 ## Architecture
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,6 +85,11 @@ echo "解释这段代码" | reasonix run
 default_model = "deepseek-flash"   # 执行器；设 [agent].planner_model 可加规划器
 # language    = "zh"               # 界面语言；为空则按 $LANG / $REASONIX_LANG 自动检测
 
+[agent]
+# planner_model = "mimo-pro"          # 可选的低频规划器
+# subagent_model = "deepseek-pro"     # runAs=subagent skill 的默认模型
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
+
 [[providers]]
 name        = "deepseek-flash"
 kind        = "openai"
@@ -196,6 +201,9 @@ session），向导后手动在 `reasonix.toml` 加一行即可：
 [agent]
 planner_model = "deepseek-pro"   # 作为低频规划器
 ```
+
+Subagent skills 默认继承执行器模型。设置 `subagent_model` 可让它们统一走另一个已配置
+模型；设置 `subagent_models` 则只覆盖 `review`、`security_review` 等指定 skill。
 
 ## 架构
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -336,6 +336,8 @@ system_prompt = "You are Reasonix, a coding agent..."  # or system_prompt_file =
 max_steps     = 25
 temperature   = 0.0
 # planner_model = "mimo"   # optional: two-model collaboration (low-frequency planner)
+# subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
 
 # A vendor endpoint exposing several models under one base_url/key.
 [[providers]]

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -216,8 +216,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// Its tool activity nests under the invoking call, like `task`.
 	skillRunner := func(sctx context.Context, sk skill.Skill, task string) (string, error) {
 		prov, price, ctxWin := execProv, entry.Price, entry.ContextWindow
-		if sk.Model != "" {
-			if me, ok := cfg.ResolveModel(sk.Model); ok {
+		if modelRef := subagentModelRef(cfg, sk); modelRef != "" {
+			if me, ok := cfg.ResolveModel(modelRef); ok {
 				if p, err := NewProvider(me); err == nil {
 					prov, price, ctxWin = p, me.Price, me.ContextWindow
 				}
@@ -303,6 +303,50 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		PluginCtx:     ctx,
 		WorkspaceRoot: cwd,
 	}), nil
+}
+
+func subagentModelRef(cfg *config.Config, sk skill.Skill) string {
+	if cfg != nil {
+		for _, key := range subagentModelKeys(sk.Name) {
+			if m := strings.TrimSpace(cfg.Agent.SubagentModels[key]); m != "" {
+				return m
+			}
+		}
+	}
+	if m := strings.TrimSpace(sk.Model); m != "" {
+		return m
+	}
+	if cfg == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Agent.SubagentModel)
+}
+
+func subagentModelKeys(name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	keys := []string{name}
+	for _, alias := range []string{
+		strings.ReplaceAll(name, "-", "_"),
+		strings.ReplaceAll(name, "_", "-"),
+	} {
+		if alias == "" {
+			continue
+		}
+		seen := false
+		for _, key := range keys {
+			if key == alias {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			keys = append(keys, alias)
+		}
+	}
+	return keys
 }
 
 // NewProvider builds a provider.Provider from a configured entry. Exported so

--- a/internal/boot/subagent_model_test.go
+++ b/internal/boot/subagent_model_test.go
@@ -1,0 +1,52 @@
+package boot
+
+import (
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/skill"
+)
+
+func TestSubagentModelRefUsesConfiguredDefault(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.SubagentModel = "deepseek-pro"
+
+	got := subagentModelRef(cfg, skill.Skill{Name: "explore", RunAs: skill.RunSubagent})
+	if got != "deepseek-pro" {
+		t.Fatalf("subagent model = %q, want deepseek-pro", got)
+	}
+}
+
+func TestSubagentModelRefHonorsPrecedence(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.SubagentModel = "mimo-pro"
+	cfg.Agent.SubagentModels = map[string]string{"review": "deepseek-pro"}
+
+	got := subagentModelRef(cfg, skill.Skill{
+		Name:  "review",
+		RunAs: skill.RunSubagent,
+		Model: "mimo-flash",
+	})
+	if got != "deepseek-pro" {
+		t.Fatalf("per-skill config should override skill frontmatter and default, got %q", got)
+	}
+
+	got = subagentModelRef(cfg, skill.Skill{
+		Name:  "custom",
+		RunAs: skill.RunSubagent,
+		Model: "mimo-flash",
+	})
+	if got != "mimo-flash" {
+		t.Fatalf("skill frontmatter should override default config, got %q", got)
+	}
+}
+
+func TestSubagentModelRefAcceptsToolNameAliases(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.SubagentModels = map[string]string{"security_review": "deepseek-pro"}
+
+	got := subagentModelRef(cfg, skill.Skill{Name: "security-review", RunAs: skill.RunSubagent})
+	if got != "deepseek-pro" {
+		t.Fatalf("security_review alias should configure security-review, got %q", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -120,13 +120,16 @@ func (c *Config) BashMode() string {
 // AgentConfig configures the harness loop. PlannerModel is optional: when set
 // to another provider's name it enables two-model collaboration, where the
 // planner handles low-frequency planning in its own session (kept separate so
-// each model's prompt prefix stays cache-stable).
+// each model's prompt prefix stays cache-stable). SubagentModel is the optional
+// default for runAs=subagent skills; SubagentModels overrides it per skill name.
 type AgentConfig struct {
-	SystemPrompt     string  `toml:"system_prompt"`
-	SystemPromptFile string  `toml:"system_prompt_file"`
-	MaxSteps         int     `toml:"max_steps"` // tool-call rounds per turn; 0 = unlimited
-	Temperature      float64 `toml:"temperature"`
-	PlannerModel     string  `toml:"planner_model"`
+	SystemPrompt     string            `toml:"system_prompt"`
+	SystemPromptFile string            `toml:"system_prompt_file"`
+	MaxSteps         int               `toml:"max_steps"` // tool-call rounds per turn; 0 = unlimited
+	Temperature      float64           `toml:"temperature"`
+	PlannerModel     string            `toml:"planner_model"`
+	SubagentModel    string            `toml:"subagent_model"`
+	SubagentModels   map[string]string `toml:"subagent_models"`
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -22,7 +22,8 @@ func TestLoadDotEnvFallsBackToHome(t *testing.T) {
 	}
 
 	t.Chdir(cwd)
-	t.Setenv("HOME", home) // os.UserHomeDir() reads $HOME on unix
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
 
 	// Start clean so the file values are what land (Setenv auto-restores).
 	t.Setenv("KEY_CWD", "")
@@ -53,7 +54,9 @@ func TestLoadDotEnvDoesNotOverrideEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Chdir(cwd)
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("PINNED", "from_env")
 
 	loadDotEnv()

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -41,6 +41,16 @@ func RenderTOML(c *Config) string {
 	} else {
 		b.WriteString("# planner_model = \"mimo\"   # optional: enable two-model collaboration\n")
 	}
+	if c.Agent.SubagentModel != "" {
+		fmt.Fprintf(&b, "subagent_model = %q   # default model for runAs=subagent skills\n", c.Agent.SubagentModel)
+	} else {
+		b.WriteString("# subagent_model = \"deepseek-pro\"   # optional default for runAs=subagent skills\n")
+	}
+	if len(c.Agent.SubagentModels) > 0 {
+		fmt.Fprintf(&b, "subagent_models = %s   # per-skill overrides\n", renderStringMap(c.Agent.SubagentModels))
+	} else {
+		b.WriteString("# subagent_models = { review = \"deepseek-pro\", security_review = \"deepseek-pro\" }   # per-skill overrides\n")
+	}
 	b.WriteString("\n")
 
 	for _, p := range c.Providers {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -12,6 +12,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig := Default()
 	orig.DefaultModel = "mimo-pro"
 	orig.Language = "zh"
+	orig.Agent.SubagentModel = "mimo-pro"
+	orig.Agent.SubagentModels = map[string]string{"review": "deepseek-pro"}
 	orig.Permissions = PermissionsConfig{
 		Mode:  "deny",
 		Deny:  []string{"bash(rm -rf*)"},
@@ -45,6 +47,12 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Agent.SystemPrompt != orig.Agent.SystemPrompt {
 		t.Errorf("system_prompt mismatch:\n got %q\nwant %q", got.Agent.SystemPrompt, orig.Agent.SystemPrompt)
+	}
+	if got.Agent.SubagentModel != "mimo-pro" {
+		t.Errorf("subagent_model = %q, want mimo-pro", got.Agent.SubagentModel)
+	}
+	if got.Agent.SubagentModels["review"] != "deepseek-pro" {
+		t.Errorf("subagent_models.review = %q, want deepseek-pro", got.Agent.SubagentModels["review"])
 	}
 	if g, _ := got.Provider("mimo-pro"); g == nil || g.BaseURL != "http://localhost:8000/v1" {
 		t.Errorf("mimo-pro base_url not preserved: %+v", g)

--- a/internal/config/subagent_model_test.go
+++ b/internal/config/subagent_model_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/BurntSushi/toml"
+)
+
+func TestAgentSubagentModelConfigDecodesFromTOML(t *testing.T) {
+	var cfg Config
+	if _, err := toml.Decode(`
+[agent]
+subagent_model = "deepseek-pro"
+subagent_models = { explore = "deepseek-pro", "security-review" = "mimo-pro" }
+`, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if cfg.Agent.SubagentModel != "deepseek-pro" {
+		t.Fatalf("subagent_model = %q, want deepseek-pro", cfg.Agent.SubagentModel)
+	}
+	if cfg.Agent.SubagentModels["explore"] != "deepseek-pro" {
+		t.Fatalf("explore model = %q", cfg.Agent.SubagentModels["explore"])
+	}
+	if cfg.Agent.SubagentModels["security-review"] != "mimo-pro" {
+		t.Fatalf("security-review model = %q", cfg.Agent.SubagentModels["security-review"])
+	}
+}

--- a/internal/tool/builtin/workspace_test.go
+++ b/internal/tool/builtin/workspace_test.go
@@ -11,17 +11,19 @@ import (
 )
 
 func TestResolveIn(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "proj")
+	absolute := filepath.Join(t.TempDir(), "etc", "passwd")
 	cases := []struct {
 		workDir, p, want string
 	}{
-		{"", "foo.go", "foo.go"},                          // empty workDir: unchanged
-		{"", "", ""},                                      // empty workDir: unchanged
-		{"/proj", "foo.go", "/proj/foo.go"},               // relative joins
-		{"/proj", "a/b.go", "/proj/a/b.go"},               // nested relative
-		{"/proj", ".", "/proj"},                           // "." targets the root
-		{"/proj", "", "/proj"},                            // empty targets the root
-		{"/proj", "/etc/passwd", "/etc/passwd"},           // absolute honored verbatim
-		{"/proj", "../escape", filepath.Clean("/escape")}, // join cleans (confiner enforces)
+		{"", "foo.go", "foo.go"}, // empty workDir: unchanged
+		{"", "", ""},             // empty workDir: unchanged
+		{workDir, "foo.go", filepath.Join(workDir, "foo.go")},                  // relative joins
+		{workDir, "a/b.go", filepath.Join(workDir, "a", "b.go")},               // nested relative
+		{workDir, ".", workDir},                                                // "." targets the root
+		{workDir, "", workDir},                                                 // empty targets the root
+		{workDir, absolute, absolute},                                          // absolute honored verbatim
+		{workDir, "../escape", filepath.Join(filepath.Dir(workDir), "escape")}, // join cleans (confiner enforces)
 	}
 	for _, c := range cases {
 		if got := resolveIn(c.workDir, c.p); got != c.want {

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -15,6 +15,8 @@ guessing; keep changes minimal and correct; briefly summarize what you did."""
 max_steps   = 25
 temperature = 0.0
 # planner_model = "mimo-pro"   # optional: enable two-model collaboration
+# subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }   # per-skill overrides
 
 # A provider is a vendor endpoint (one base_url + key) that offers one or more
 # models. Use `models = [...]` to expose several under a single entry — switching


### PR DESCRIPTION
Closes #2435

## Summary
- add `[agent].subagent_model` as the default model for `runAs: subagent` skills
- add `[agent].subagent_models` for per-skill overrides such as `review` and `security_review`
- preserve existing behavior when no override is configured, and keep skill frontmatter `model:` as the fallback before the global default
- document the new TOML settings and make existing Windows tests portable for Go validation

## Validation
- `D:\Go\go\bin\go.exe test ./...`

No UI or performance behavior changed, so screenshots and metrics are not applicable.