### PR TITLE
test(desktop): add wire.go and sessions.go tests

### DIFF
--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// --- loadSessionTitles ---
+
+func TestLoadSessionTitlesMissing(t *testing.T) {
+	dir := t.TempDir()
+	m := loadSessionTitles(dir)
+	if len(m) != 0 {
+		t.Errorf("missing file should return empty map, got %v", m)
+	}
+}
+
+func TestLoadSessionTitlesCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(sessionTitlesPath(dir), []byte(`{not json`), 0o644)
+	m := loadSessionTitles(dir)
+	if len(m) != 0 {
+		t.Errorf("corrupt file should return empty map, got %v", m)
+	}
+}
+
+func TestLoadSessionTitlesValid(t *testing.T) {
+	dir := t.TempDir()
+	data := map[string]string{"session-1.jsonl": "My Session", "session-2.jsonl": "Another"}
+	b, _ := json.Marshal(data)
+	os.WriteFile(sessionTitlesPath(dir), b, 0o644)
+	m := loadSessionTitles(dir)
+	if m["session-1.jsonl"] != "My Session" || m["session-2.jsonl"] != "Another" {
+		t.Errorf("loaded = %v", m)
+	}
+}
+
+// --- saveSessionTitles ---
+
+func TestSaveSessionTitlesCreatesDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "sessions")
+	m := map[string]string{"a.jsonl": "title A"}
+	if err := saveSessionTitles(dir, m); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Verify file exists and is valid JSON.
+	b, err := os.ReadFile(sessionTitlesPath(dir))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var decoded map[string]string
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["a.jsonl"] != "title A" {
+		t.Errorf("decoded = %v", decoded)
+	}
+}
+
+func TestSaveSessionTitlesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	original := map[string]string{"s1.jsonl": "First", "s2.jsonl": "Second"}
+	if err := saveSessionTitles(dir, original); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	loaded := loadSessionTitles(dir)
+	if loaded["s1.jsonl"] != "First" || loaded["s2.jsonl"] != "Second" {
+		t.Errorf("round-trip = %v", loaded)
+	}
+}
+
+// --- setSessionTitle ---
+
+func TestSetSessionTitle(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "my-session.jsonl")
+
+	// Set a title.
+	if err := setSessionTitle(dir, sessionPath, "Custom Title"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	m := loadSessionTitles(dir)
+	if m["my-session.jsonl"] != "Custom Title" {
+		t.Errorf("title = %q", m["my-session.jsonl"])
+	}
+
+	// Clear the title (empty string).
+	if err := setSessionTitle(dir, sessionPath, ""); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	m = loadSessionTitles(dir)
+	if _, ok := m["my-session.jsonl"]; ok {
+		t.Error("cleared title should be removed from map")
+	}
+}
+
+func TestSetSessionTitleTrimsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "s.jsonl")
+	if err := setSessionTitle(dir, sessionPath, "  trimmed  "); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	m := loadSessionTitles(dir)
+	if m["s.jsonl"] != "trimmed" {
+		t.Errorf("title = %q, want trimmed", m["s.jsonl"])
+	}
+}
+
+// --- deleteSessionFile ---
+
+func TestDeleteSessionFile(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	os.WriteFile(sessionPath, []byte("data"), 0o644)
+
+	// Set a title first.
+	setSessionTitle(dir, sessionPath, "My Title")
+
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	// File should be gone.
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Error("session file should be deleted")
+	}
+	// Title should be gone.
+	m := loadSessionTitles(dir)
+	if _, ok := m["session.jsonl"]; ok {
+		t.Error("title should be removed after delete")
+	}
+}
+
+func TestDeleteSessionFileNoTitle(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "no-title.jsonl")
+	os.WriteFile(sessionPath, []byte("data"), 0o644)
+
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Error("session file should be deleted")
+	}
+}
+
+func TestDeleteSessionFileMissing(t *testing.T) {
+	dir := t.TempDir()
+	// Deleting a non-existent file should not error.
+	if err := deleteSessionFile(dir, filepath.Join(dir, "missing.jsonl")); err != nil {
+		t.Fatalf("delete missing: %v", err)
+	}
+}
+
+// --- sessionTitlesPath ---
+
+func TestSessionTitlesPath(t *testing.T) {
+	got := sessionTitlesPath("/sessions")
+	if got != "/sessions/.titles.json" {
+		t.Errorf("sessionTitlesPath = %q", got)
+	}
+}
+
+// --- errActiveSession ---
+
+func TestErrActiveSession(t *testing.T) {
+	if errActiveSession.Error() == "" {
+		t.Error("errActiveSession should have a message")
+	}
+}

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// --- toWire ---
+
+func TestToWireText(t *testing.T) {
+	e := event.Event{Kind: event.Text, Text: "hello"}
+	w := toWire(e)
+	if w.Kind != "text" || w.Text != "hello" {
+		t.Errorf("text wire = %+v", w)
+	}
+}
+
+func TestToWireReasoning(t *testing.T) {
+	e := event.Event{Kind: event.Reasoning, Text: "thinking..."}
+	w := toWire(e)
+	if w.Kind != "reasoning" || w.Text != "thinking..." {
+		t.Errorf("reasoning wire = %+v", w)
+	}
+}
+
+func TestToWireNoticeInfo(t *testing.T) {
+	e := event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "info"}
+	w := toWire(e)
+	if w.Kind != "notice" || w.Level != "info" {
+		t.Errorf("notice info = %+v", w)
+	}
+}
+
+func TestToWireNoticeWarn(t *testing.T) {
+	e := event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "warn"}
+	w := toWire(e)
+	if w.Level != "warn" {
+		t.Errorf("notice warn level = %q", w.Level)
+	}
+}
+
+func TestToWireToolDispatch(t *testing.T) {
+	e := event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "1", Name: "bash", Args: `{"c":"echo"}`, ReadOnly: false}}
+	w := toWire(e)
+	if w.Tool == nil || w.Tool.Name != "bash" || w.Tool.Args != `{"c":"echo"}` {
+		t.Errorf("tool dispatch = %+v", w.Tool)
+	}
+}
+
+func TestToWireToolResult(t *testing.T) {
+	e := event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "1", Output: "ok", Truncated: true}}
+	w := toWire(e)
+	if w.Tool == nil || w.Tool.Output != "ok" || !w.Tool.Truncated {
+		t.Errorf("tool result = %+v", w.Tool)
+	}
+}
+
+func TestToWireUsage(t *testing.T) {
+	e := event.Event{
+		Kind:        event.Usage,
+		Usage:       &provider.Usage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150, CacheHitTokens: 80, CacheMissTokens: 20},
+		SessionHit:  800,
+		SessionMiss: 200,
+	}
+	w := toWire(e)
+	if w.Usage == nil || w.Usage.PromptTokens != 100 || w.Usage.TotalTokens != 150 {
+		t.Errorf("usage = %+v", w.Usage)
+	}
+	if w.Usage.SessionCacheHitTokens != 800 || w.Usage.SessionCacheMissTokens != 200 {
+		t.Errorf("session cache = hit:%d miss:%d", w.Usage.SessionCacheHitTokens, w.Usage.SessionCacheMissTokens)
+	}
+}
+
+func TestToWireUsageWithPricing(t *testing.T) {
+	e := event.Event{
+		Kind:    event.Usage,
+		Usage:   &provider.Usage{CacheHitTokens: 1_000_000, CacheMissTokens: 0, CompletionTokens: 0},
+		Pricing: &provider.Pricing{CacheHit: 1.0, Input: 2.0, Output: 10.0},
+	}
+	w := toWire(e)
+	if w.Usage == nil || w.Usage.CostUSD != 1.0 {
+		t.Errorf("cost = %f, want 1.0", w.Usage.CostUSD)
+	}
+}
+
+func TestToWireApprovalRequest(t *testing.T) {
+	e := event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "42", Tool: "bash", Subject: "rm"}}
+	w := toWire(e)
+	if w.Approval == nil || w.Approval.ID != "42" || w.Approval.Tool != "bash" {
+		t.Errorf("approval = %+v", w.Approval)
+	}
+}
+
+func TestToWireAskRequest(t *testing.T) {
+	e := event.Event{Kind: event.AskRequest, Ask: event.Ask{
+		ID:        "ask-1",
+		Questions: []event.AskQuestion{{ID: "q1", Header: "Pick", Prompt: "Choose one", Options: []event.AskOption{{Label: "A"}, {Label: "B"}}, Multi: false}},
+	}}
+	w := toWire(e)
+	if w.Ask == nil || w.Ask.ID != "ask-1" {
+		t.Errorf("ask = %+v", w.Ask)
+	}
+	if len(w.Ask.Questions) != 1 || len(w.Ask.Questions[0].Options) != 2 {
+		t.Errorf("questions/options = %+v", w.Ask.Questions)
+	}
+}
+
+func TestToWireTurnDoneWithError(t *testing.T) {
+	e := event.Event{Kind: event.TurnDone, Err: errors.New("boom")}
+	w := toWire(e)
+	if w.Kind != "turn_done" || w.Err != "boom" {
+		t.Errorf("turn_done error = %+v", w)
+	}
+}
+
+func TestToWireTurnDoneNoError(t *testing.T) {
+	e := event.Event{Kind: event.TurnDone}
+	w := toWire(e)
+	if w.Err != "" {
+		t.Errorf("turn_done no-error should have empty err, got %q", w.Err)
+	}
+}
+
+// --- kindNames completeness ---
+
+func TestKindNamesComplete(t *testing.T) {
+	allKinds := []event.Kind{
+		event.TurnStarted, event.Reasoning, event.Text, event.Message,
+		event.ToolDispatch, event.ToolResult, event.Usage, event.Notice,
+		event.Phase, event.ApprovalRequest, event.AskRequest, event.TurnDone,
+	}
+	for _, k := range allKinds {
+		if _, ok := kindNames[k]; !ok {
+			t.Errorf("kind %d not in kindNames", k)
+		}
+	}
+}
+
+// --- wireEvent JSON round-trip ---
+
+func TestWireEventJSON(t *testing.T) {
+	w := wireEvent{Kind: "text", Text: "hello"}
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded wireEvent
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.Kind != "text" || decoded.Text != "hello" {
+		t.Errorf("round-trip = %+v", decoded)
+	}
+}


### PR DESCRIPTION
## Summary
Add 27 tests for the desktop package's pure-logic functions:

### wire.go tests (14 tests)
- toWire: text, reasoning, notice (info/warn), tool dispatch/result, usage (with/without pricing), approval request, ask request, turn_done (with/without error)
- kindNames completeness: all 12 event kinds mapped
- wireEvent JSON round-trip

### sessions.go tests (13 tests)
- loadSessionTitles: missing file, corrupt JSON, valid data
- saveSessionTitles: creates nested directory, round-trip
- setSessionTitle: set/clear, whitespace trimming
- deleteSessionFile: with title, without title, missing file
- sessionTitlesPath: correct path
- errActiveSession: has message

## Motivation
The desktop package had only `dotenv_test.go`. The `toWire()` function (event-to-JSON conversion) and session management (titles, delete) are pure logic testable without Wails runtime. These tests ensure the wire protocol stays consistent and session file operations are correct.