### PR TITLE
test(cli): add tests for visibleWidth, padRight, and boxed helpers

### DIFF
--- a/internal/cli/box_test.go
+++ b/internal/cli/box_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -77,7 +78,7 @@ func TestBoxedMultipleLines(t *testing.T) {
 	}
 	// All lines should be present.
 	for _, want := range []string{"line1", "longer line", "short"} {
-		if !containsStr(got, want) {
+		if !strings.Contains(got, want) {
 			t.Errorf("boxed missing %q", want)
 		}
 	}
@@ -88,13 +89,4 @@ func TestBoxedEmpty(t *testing.T) {
 	if len(got) == 0 {
 		t.Error("boxed empty should still produce a box")
 	}
-}
-
-func containsStr(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cli/box_test.go
+++ b/internal/cli/box_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"testing"
+)
+
+// --- visibleWidth ---
+
+func TestVisibleWidthPlain(t *testing.T) {
+	if got := visibleWidth("hello"); got != 5 {
+		t.Errorf("visibleWidth(hello) = %d, want 5", got)
+	}
+}
+
+func TestVisibleWidthEmpty(t *testing.T) {
+	if got := visibleWidth(""); got != 0 {
+		t.Errorf("visibleWidth(\"\") = %d, want 0", got)
+	}
+}
+
+func TestVisibleWidthANSI(t *testing.T) {
+	// ANSI SGR codes should not count toward width.
+	colored := "\x1b[31mhello\x1b[0m"
+	if got := visibleWidth(colored); got != 5 {
+		t.Errorf("visibleWidth(colored) = %d, want 5", got)
+	}
+}
+
+// --- padRight ---
+
+func TestPadRightAlreadyWide(t *testing.T) {
+	got := padRight("hello", 3)
+	if got != "hello" {
+		t.Errorf("padRight(hello, 3) = %q, want hello", got)
+	}
+}
+
+func TestPadRightExact(t *testing.T) {
+	got := padRight("hello", 5)
+	if got != "hello" {
+		t.Errorf("padRight(hello, 5) = %q, want hello", got)
+	}
+}
+
+func TestPadRightPads(t *testing.T) {
+	got := padRight("hi", 5)
+	if got != "hi   " {
+		t.Errorf("padRight(hi, 5) = %q, want %q", got, "hi   ")
+	}
+}
+
+func TestPadRightEmpty(t *testing.T) {
+	got := padRight("", 3)
+	if got != "   " {
+		t.Errorf("padRight(\"\", 3) = %q, want %q", got, "   ")
+	}
+}
+
+// --- boxed ---
+
+func TestBoxedSingleLine(t *testing.T) {
+	got := boxed([]string{"hello"})
+	// Should contain the content and the box characters.
+	if len(got) == 0 {
+		t.Error("boxed should not be empty")
+	}
+	// Should end with newline.
+	if got[len(got)-1] != '\n' {
+		t.Error("boxed should end with newline")
+	}
+}
+
+func TestBoxedMultipleLines(t *testing.T) {
+	got := boxed([]string{"line1", "longer line", "short"})
+	if len(got) == 0 {
+		t.Error("boxed should not be empty")
+	}
+	// All lines should be present.
+	for _, want := range []string{"line1", "longer line", "short"} {
+		if !containsStr(got, want) {
+			t.Errorf("boxed missing %q", want)
+		}
+	}
+}
+
+func TestBoxedEmpty(t *testing.T) {
+	got := boxed([]string{})
+	if len(got) == 0 {
+		t.Error("boxed empty should still produce a box")
+	}
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
Add 10 tests for the CLI's terminal rendering helpers:

### visibleWidth (3 tests)
- Plain ASCII: correct column count
- Empty string: 0
- ANSI SGR codes: stripped, not counted

### padRight (4 tests)
- Already wider: returned unchanged
- Exact width: returned unchanged
- Shorter: padded with spaces
- Empty string: all padding

### boxed (3 tests)
- Single line: produces box with trailing newline
- Multiple lines: all content present
- Empty input: still produces a box

## Motivation
The CLI's `box.go` helpers (visibleWidth, padRight, boxed) had zero tests. These functions handle ANSI code stripping and CJK width calculation — edge cases that are easy to get wrong.