### PR TITLE
feat(desktop): use a fresh signing key; add genkey/verify

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -112,13 +112,13 @@ When Developer ID / Authenticode certificates are added, the release workflow's
 
 ### Verifying a download
 
-Artifacts are signed with minisign (public key ID `29FA7D2CA832AC6C`). The `.minisig`
+Artifacts are signed with minisign (public key ID `AF12CA46F4A9EBB0`). The `.minisig`
 signature sits next to each artifact in the release; verify with the
 [minisign](https://jedisct1.github.io/minisign/) CLI:
 
 ```sh
 minisign -Vm Reasonix-darwin-arm64.zip \
-  -P RWRsrDKoLH36KZpr4v2vY1myxnrvt+EBmv7mxRbhqzrq4762oOVsi4dq
+  -P RWSw66n0RsoSr6Zhh6qt5YO95YkpCayTOCMFVDNUQSjJYwxoYngNVBSq
 ```
 
 ## Editor seam (Monaco / CodeMirror)

--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -49,6 +50,16 @@ func main() {
 			usage()
 		}
 		err = genManifest(os.Args[2], os.Args[3], os.Args[4])
+	case "genkey":
+		if len(os.Args) != 3 {
+			usage()
+		}
+		err = genKey(os.Args[2])
+	case "verify":
+		if len(os.Args) != 3 {
+			usage()
+		}
+		err = verifyFile(os.Args[2])
 	default:
 		usage()
 	}
@@ -59,8 +70,65 @@ func main() {
 }
 
 func usage() {
-	fmt.Fprintln(os.Stderr, "usage:\n  sign <file>...\n  manifest <dir> <version> <tag>")
+	fmt.Fprintln(os.Stderr, "usage:\n  sign <file>...\n  manifest <dir> <version> <tag>\n  genkey <dir>\n  verify <file>")
 	os.Exit(2)
+}
+
+// verifyFile checks <file> against <file>.minisig using the embedded public key —
+// the same check the updater runs before applying. A self-test that the signing
+// key matches what's compiled in. Returns an error (nonzero exit) on mismatch.
+func verifyFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	sig, err := os.ReadFile(path + ".minisig")
+	if err != nil {
+		return err
+	}
+	if err := update.Verify(data, sig); err != nil {
+		return err
+	}
+	fmt.Printf("OK: %s verifies against the embedded public key\n", path)
+	return nil
+}
+
+// genKey generates a fresh minisign key pair, writing the encrypted private key
+// (reasonix.key) and the public key (reasonix.pub) into dir. The password comes
+// from $MINISIGN_PASSWORD. The public key is printed — it's safe to publish; embed
+// it in internal/update/verify.go. The private key never leaves dir.
+func genKey(dir string) error {
+	pw := os.Getenv("MINISIGN_PASSWORD")
+	if strings.TrimSpace(pw) == "" {
+		return fmt.Errorf("genkey: MINISIGN_PASSWORD is empty")
+	}
+	pub, priv, err := minisign.GenerateKey(rand.Reader)
+	if err != nil {
+		return err
+	}
+	enc, err := minisign.EncryptKey(pw, priv)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	keyPath := filepath.Join(dir, "reasonix.key")
+	pubPath := filepath.Join(dir, "reasonix.pub")
+	if err := os.WriteFile(keyPath, enc, 0o600); err != nil {
+		return err
+	}
+	pubText, err := pub.MarshalText()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(pubPath, pubText, 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("private key -> %s (keep secret; this is the MINISIGN_PRIVATE_KEY value)\n", keyPath)
+	fmt.Printf("public key  -> %s\n\n", pubPath)
+	fmt.Printf("public key (embed in internal/update/verify.go, key ID %016X):\n%s\n", pub.ID(), pubText)
+	return nil
 }
 
 // signFiles writes a detached .minisig next to each input file. The private key is

--- a/desktop/internal/update/update_test.go
+++ b/desktop/internal/update/update_test.go
@@ -16,8 +16,8 @@ func TestEmbeddedPublicKeyParses(t *testing.T) {
 	if err := key.UnmarshalText([]byte(publicKey)); err != nil {
 		t.Fatalf("embedded public key does not parse: %v", err)
 	}
-	if got := fmt.Sprintf("%016X", key.ID()); got != "29FA7D2CA832AC6C" {
-		t.Fatalf("embedded public key ID = %s, want 29FA7D2CA832AC6C", got)
+	if got := fmt.Sprintf("%016X", key.ID()); got != "AF12CA46F4A9EBB0" {
+		t.Fatalf("embedded public key ID = %s, want AF12CA46F4A9EBB0", got)
 	}
 }
 

--- a/desktop/internal/update/verify.go
+++ b/desktop/internal/update/verify.go
@@ -8,12 +8,12 @@ import (
 )
 
 // publicKey is the minisign public key that desktop release artifacts are signed
-// with. It is the same key pair as the v1 (Tauri) desktop line — the public half
-// is safe to embed; the private half lives only in CI secrets. Key ID
-// 29FA7D2CA832AC6C. If the signing key is ever rotated, update this constant in
-// lockstep with the CI secret.
-const publicKey = `untrusted comment: minisign public key: 29FA7D2CA832AC6C
-RWRsrDKoLH36KZpr4v2vY1myxnrvt+EBmv7mxRbhqzrq4762oOVsi4dq`
+// with. The public half is safe to embed; the private half lives only in CI
+// secrets (generated with `cmd/sign genkey`). Key ID AF12CA46F4A9EBB0. If the
+// signing key is ever rotated, regenerate and update this constant in lockstep
+// with the CI secret.
+const publicKey = `untrusted comment: minisign public key: AF12CA46F4A9EBB0
+RWSw66n0RsoSr6Zhh6qt5YO95YkpCayTOCMFVDNUQSjJYwxoYngNVBSq`
 
 // Verify reports whether sig (the contents of a .minisig file) is a valid minisign
 // signature of data under the embedded public key. A nil return means the artifact


### PR DESCRIPTION
The v1 minisign private key wasn't recoverable (no local backup, and a GitHub secret can't be read back), so the desktop updater uses a fresh minisign key pair instead of reusing v1's — v2 is an independent update line anyway.

- `internal/update`: embed the new public key (ID `AF12CA46F4A9EBB0`).
- `cmd/sign`: `genkey <dir>` generates a pair; `verify <file>` checks a `.minisig` against the embedded key (a sign/verify self-test).
- README: updated verification key.

Verified locally: `go test ./...` green; signed an artifact with the new private key and `verify` confirmed it against the embedded public key.

Before the first `desktop-v*` release, set `MINISIGN_PRIVATE_KEY` / `MINISIGN_PASSWORD` secrets (the key generated into ~/.reasonix-keys).
