### PR TITLE
feat(provider): add Anthropic Messages API provider

### DIFF
--- a/cmd/reasonix/main.go
+++ b/cmd/reasonix/main.go
@@ -7,6 +7,7 @@ import (
 	"reasonix/internal/cli"
 
 	// Blank imports wire compile-time built-ins into their registries.
+	_ "reasonix/internal/provider/anthropic"
 	_ "reasonix/internal/provider/openai"
 	_ "reasonix/internal/tool/builtin"
 )

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -18,6 +18,7 @@ import (
 
 	// Blank imports wire compile-time built-ins into their registries, exactly as
 	// cmd/reasonix does — boot.Build resolves providers/tools from these registries.
+	_ "reasonix/internal/provider/anthropic"
 	_ "reasonix/internal/provider/openai"
 	_ "reasonix/internal/tool/builtin"
 )

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -1,0 +1,466 @@
+// Package anthropic implements the Anthropic Messages API provider (POST
+// /v1/messages, SSE streaming) with a hand-written net/http client — no SDK. It
+// self-registers under the "anthropic" kind, so any Claude model is a config
+// instance rather than code.
+//
+// Two deliberate v1 scope limits, both driven by the transport-agnostic
+// provider.Message abstraction:
+//
+//   - No extended/adaptive thinking. Anthropic requires the signed `thinking`
+//     block be replayed on the next turn when a tool call followed thinking;
+//     provider.Message.ReasoningContent is a plain string with no signature, so it
+//     can't be round-tripped faithfully. Since reasonix is tool-heavy, enabling
+//     thinking would break multi-turn tool use — so the `thinking` field is omitted
+//     entirely. (Supporting it means extending Message to carry the signed block.)
+//   - No temperature/top_p. Current Claude models (Opus 4.8/4.7) reject sampling
+//     parameters with a 400; Anthropic steers behavior via prompting instead.
+package anthropic
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+const (
+	// anthropicVersion is the required API version header value.
+	anthropicVersion = "2023-06-01"
+	// defaultBaseURL is the first-party endpoint; config may override it (e.g. a
+	// gateway). Bedrock/Vertex use a different request shape and are out of scope.
+	defaultBaseURL = "https://api.anthropic.com"
+	// defaultMaxTokens is the output ceiling used when the request leaves MaxTokens
+	// unset. Anthropic *requires* max_tokens, and the agent currently doesn't set
+	// it, so this is the de-facto cap. Generous (you only pay for tokens actually
+	// produced) and within every catalog model's limit (Sonnet/Haiku 64K, Opus 128K).
+	defaultMaxTokens = 32768
+)
+
+func init() {
+	provider.Register("anthropic", New)
+}
+
+// New builds an Anthropic provider from a resolved config.
+func New(cfg provider.Config) (provider.Provider, error) {
+	if cfg.Model == "" {
+		return nil, fmt.Errorf("anthropic: model is required for provider %q", cfg.Name)
+	}
+	name := cfg.Name
+	if name == "" {
+		name = "anthropic"
+	}
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
+	return &client{
+		name:    name,
+		apiKey:  cfg.APIKey,
+		keyEnv:  keyEnv,
+		baseURL: strings.TrimRight(baseURL, "/"),
+		model:   cfg.Model,
+		http:    &http.Client{}, // no overall timeout; lifecycle is ctx-driven
+	}, nil
+}
+
+type client struct {
+	name    string
+	apiKey  string
+	keyEnv  string // api_key_env name, surfaced in auth errors
+	baseURL string
+	model   string
+	http    *http.Client
+}
+
+func (c *client) Name() string { return c.name }
+
+func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	body, err := json.Marshal(c.buildRequest(req))
+	if err != nil {
+		return nil, fmt.Errorf("%s: marshal request: %w", c.name, err)
+	}
+
+	resp, err := c.sendWithRetry(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make(chan provider.Chunk)
+	go c.readStream(resp, out)
+	return out, nil
+}
+
+// sendWithRetry POSTs the request and returns the streaming response, retrying the
+// connection+header phase on transient errors and retryable statuses (408, 429,
+// 5xx — which covers Anthropic's 529 overloaded) with exponential backoff + jitter.
+// Mid-stream failures are not retried (the model has already emitted tokens).
+func (c *client) sendWithRetry(ctx context.Context, body []byte) (*http.Response, error) {
+	const maxAttempts = 3
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			delay := time.Duration(1<<(attempt-1))*500*time.Millisecond + time.Duration(rand.Intn(250))*time.Millisecond
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
+		if err != nil {
+			return nil, fmt.Errorf("%s: build request: %w", c.name, err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("x-api-key", c.apiKey)
+		httpReq.Header.Set("anthropic-version", anthropicVersion)
+
+		resp, err := c.http.Do(httpReq)
+		if err != nil {
+			if !isTransientErr(err) {
+				return nil, fmt.Errorf("%s: request failed: %w", c.name, err)
+			}
+			lastErr = fmt.Errorf("%s: request failed: %w", c.name, err)
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+		// A rejected key is a configuration problem, not a transient one.
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, &provider.AuthError{Provider: c.name, KeyEnv: c.keyEnv, Status: resp.StatusCode}
+		}
+		statusErr := fmt.Errorf("%s: status %d: %s", c.name, resp.StatusCode, strings.TrimSpace(string(msg)))
+		if !isRetryableStatus(resp.StatusCode) {
+			return nil, statusErr
+		}
+		lastErr = statusErr
+	}
+	return nil, lastErr
+}
+
+// isRetryableStatus matches 408, 429, and 5xx (incl. Anthropic's 529 overloaded).
+func isRetryableStatus(s int) bool {
+	return s == http.StatusRequestTimeout || s == http.StatusTooManyRequests || (s >= 500 && s <= 599)
+}
+
+// isTransientErr never retries ctx cancellation/deadline (caller intent); retries
+// everything else (DNS, connection reset, abrupt EOF).
+func isTransientErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return true
+}
+
+// buildRequest converts the transport-agnostic Request into the Messages API shape:
+// RoleSystem messages lift to the top-level `system` field; assistant tool calls
+// become `tool_use` blocks; RoleTool results become `tool_result` blocks in a user
+// turn. Consecutive same-role messages are coalesced because the API requires
+// alternating user/assistant turns (tool results are user turns).
+func (c *client) buildRequest(req provider.Request) anthRequest {
+	var system []textBlock
+	var msgs []anthMessage
+
+	// appendBlocks adds blocks under role, merging into the previous message when
+	// it shares the role (keeps user/assistant strictly alternating).
+	appendBlocks := func(role string, blocks ...contentBlock) {
+		if len(blocks) == 0 {
+			return
+		}
+		if n := len(msgs); n > 0 && msgs[n-1].Role == role {
+			msgs[n-1].Content = append(msgs[n-1].Content, blocks...)
+			return
+		}
+		msgs = append(msgs, anthMessage{Role: role, Content: blocks})
+	}
+
+	for _, m := range req.Messages {
+		switch m.Role {
+		case provider.RoleSystem:
+			if m.Content != "" {
+				system = append(system, textBlock{Type: "text", Text: m.Content})
+			}
+		case provider.RoleUser:
+			if m.Content != "" {
+				appendBlocks("user", contentBlock{Type: "text", Text: m.Content})
+			}
+		case provider.RoleTool:
+			content := m.Content
+			if content == "" {
+				content = "(no output)" // tool_result content must be non-empty
+			}
+			appendBlocks("user", contentBlock{Type: "tool_result", ToolUseID: m.ToolCallID, Content: content})
+		case provider.RoleAssistant:
+			var blocks []contentBlock
+			if m.Content != "" {
+				blocks = append(blocks, contentBlock{Type: "text", Text: m.Content})
+			}
+			for _, tc := range m.ToolCalls {
+				input := json.RawMessage(tc.Arguments)
+				if len(input) == 0 {
+					input = json.RawMessage("{}") // input is required, even when empty
+				}
+				blocks = append(blocks, contentBlock{Type: "tool_use", ID: tc.ID, Name: tc.Name, Input: input})
+			}
+			appendBlocks("assistant", blocks...)
+		}
+	}
+
+	var tools []anthTool
+	for _, t := range req.Tools {
+		schema := t.Parameters
+		if len(schema) == 0 {
+			schema = json.RawMessage(`{"type":"object","properties":{}}`)
+		}
+		tools = append(tools, anthTool{Name: t.Name, Description: t.Description, InputSchema: schema})
+	}
+
+	// Prompt-cache breakpoints (ephemeral, prefix-match). Render order is
+	// tools → system → messages, so a marker on the last system block caches
+	// tools+system together; with no system, mark the last tool. A marker on the
+	// last block of the last message caches the conversation prefix, accruing hits
+	// incrementally as turns are appended. Max 4 breakpoints; we use ≤2.
+	if n := len(system); n > 0 {
+		system[n-1].CacheControl = ephemeral()
+	} else if n := len(tools); n > 0 {
+		tools[n-1].CacheControl = ephemeral()
+	}
+	if n := len(msgs); n > 0 {
+		if k := len(msgs[n-1].Content); k > 0 {
+			msgs[n-1].Content[k-1].CacheControl = ephemeral()
+		}
+	}
+
+	maxTokens := req.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = defaultMaxTokens
+	}
+	return anthRequest{
+		Model:     c.model,
+		MaxTokens: maxTokens,
+		System:    system,
+		Messages:  msgs,
+		Tools:     tools,
+		Stream:    true,
+	}
+}
+
+// readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;
+// each tool_use content block emits a ChunkToolCallStart when its id+name are known
+// and a complete ChunkToolCall when the block closes; usage is assembled from
+// message_start (input/cache) + message_delta (output + stop_reason) and emitted
+// once before ChunkDone.
+func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
+	defer resp.Body.Close()
+	defer close(out)
+
+	tools := map[int]*provider.ToolCall{} // tool_use blocks, keyed by content index
+	var inTok, outTok, cacheCreate, cacheRead int
+	var stopReason string
+	haveUsage := false
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		// SSE carries `event:` and `data:` lines; the data JSON's own `type` field
+		// is authoritative, so we only need the data payloads.
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if data == "" {
+			continue
+		}
+
+		var ev streamEvent
+		if err := json.Unmarshal([]byte(data), &ev); err != nil {
+			out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: decode stream: %w", c.name, err)}
+			return
+		}
+
+		switch ev.Type {
+		case "message_start":
+			if ev.Message != nil && ev.Message.Usage != nil {
+				inTok = ev.Message.Usage.InputTokens
+				cacheCreate = ev.Message.Usage.CacheCreationInputTokens
+				cacheRead = ev.Message.Usage.CacheReadInputTokens
+				haveUsage = true
+			}
+		case "content_block_start":
+			if ev.ContentBlock != nil && ev.ContentBlock.Type == "tool_use" {
+				tc := &provider.ToolCall{ID: ev.ContentBlock.ID, Name: ev.ContentBlock.Name}
+				tools[ev.Index] = tc
+				out <- provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: tc.ID, Name: tc.Name}}
+			}
+		case "content_block_delta":
+			if ev.Delta == nil {
+				continue
+			}
+			switch ev.Delta.Type {
+			case "text_delta":
+				if ev.Delta.Text != "" {
+					out <- provider.Chunk{Type: provider.ChunkText, Text: ev.Delta.Text}
+				}
+			case "input_json_delta":
+				if tc := tools[ev.Index]; tc != nil {
+					tc.Arguments += ev.Delta.PartialJSON
+				}
+			}
+		case "content_block_stop":
+			if tc := tools[ev.Index]; tc != nil {
+				out <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: tc}
+				delete(tools, ev.Index)
+			}
+		case "message_delta":
+			if ev.Delta != nil && ev.Delta.StopReason != "" {
+				stopReason = ev.Delta.StopReason
+			}
+			if ev.Usage != nil {
+				outTok = ev.Usage.OutputTokens
+				haveUsage = true
+			}
+		case "message_stop":
+			// Stream complete; fall through to finalize below.
+		case "error":
+			msg := "stream error"
+			if ev.Error != nil && ev.Error.Message != "" {
+				msg = ev.Error.Message
+			}
+			out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: %s", c.name, msg)}
+			return
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: read stream: %w", c.name, err)}
+		return
+	}
+
+	if haveUsage {
+		out <- provider.Chunk{Type: provider.ChunkUsage, Usage: &provider.Usage{
+			PromptTokens:     inTok + cacheCreate + cacheRead,
+			CompletionTokens: outTok,
+			TotalTokens:      inTok + cacheCreate + cacheRead + outTok,
+			CacheHitTokens:   cacheRead,
+			CacheMissTokens:  inTok + cacheCreate, // uncached input + cache writes (billed ≥1×)
+			FinishReason:     mapStopReason(stopReason),
+		}}
+	}
+	out <- provider.Chunk{Type: provider.ChunkDone}
+}
+
+// mapStopReason translates Anthropic stop reasons to the OpenAI-style finish
+// reasons the agent already recognises (it surfaces abnormal ones like "length").
+func mapStopReason(s string) string {
+	switch s {
+	case "end_turn", "stop_sequence":
+		return "stop"
+	case "tool_use":
+		return "tool_calls"
+	case "max_tokens":
+		return "length"
+	default:
+		return s // "refusal", "pause_turn", "" — pass through
+	}
+}
+
+// --- Messages API wire protocol ---
+
+func ephemeral() *cacheControl { return &cacheControl{Type: "ephemeral"} }
+
+type cacheControl struct {
+	Type string `json:"type"`
+}
+
+type anthRequest struct {
+	Model     string        `json:"model"`
+	MaxTokens int           `json:"max_tokens"`
+	System    []textBlock   `json:"system,omitempty"`
+	Messages  []anthMessage `json:"messages"`
+	Tools     []anthTool    `json:"tools,omitempty"`
+	Stream    bool          `json:"stream"`
+}
+
+type textBlock struct {
+	Type         string        `json:"type"`
+	Text         string        `json:"text"`
+	CacheControl *cacheControl `json:"cache_control,omitempty"`
+}
+
+type anthMessage struct {
+	Role    string         `json:"role"`
+	Content []contentBlock `json:"content"`
+}
+
+// contentBlock is the union of the block kinds we emit in a request: text,
+// tool_use (echoing a prior assistant call), and tool_result. Unused fields are
+// omitted so each block serialises to its canonical shape.
+type contentBlock struct {
+	Type         string          `json:"type"`
+	Text         string          `json:"text,omitempty"`        // text
+	ID           string          `json:"id,omitempty"`          // tool_use
+	Name         string          `json:"name,omitempty"`        // tool_use
+	Input        json.RawMessage `json:"input,omitempty"`       // tool_use
+	ToolUseID    string          `json:"tool_use_id,omitempty"` // tool_result
+	Content      string          `json:"content,omitempty"`     // tool_result
+	CacheControl *cacheControl   `json:"cache_control,omitempty"`
+}
+
+type anthTool struct {
+	Name         string          `json:"name"`
+	Description  string          `json:"description,omitempty"`
+	InputSchema  json.RawMessage `json:"input_schema"`
+	CacheControl *cacheControl   `json:"cache_control,omitempty"`
+}
+
+// streamEvent is the discriminated SSE event; read the fields matching Type.
+type streamEvent struct {
+	Type    string `json:"type"`
+	Index   int    `json:"index"`
+	Message *struct {
+		Usage *wireUsage `json:"usage"`
+	} `json:"message"`
+	ContentBlock *struct {
+		Type string `json:"type"`
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"content_block"`
+	Delta *struct {
+		Type        string `json:"type"`         // text_delta | input_json_delta | thinking_delta
+		Text        string `json:"text"`         // text_delta
+		PartialJSON string `json:"partial_json"` // input_json_delta
+		StopReason  string `json:"stop_reason"`  // message_delta
+	} `json:"delta"`
+	Usage *wireUsage `json:"usage"` // message_delta (cumulative output_tokens)
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+type wireUsage struct {
+	InputTokens              int `json:"input_tokens"`
+	OutputTokens             int `json:"output_tokens"`
+	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+}

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -1,0 +1,239 @@
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// TestBuildRequest covers the protocol conversion: system lift, tool_use /
+// tool_result blocks, coalescing consecutive tool results into one user turn,
+// cache_control placement, and the max_tokens fallback.
+func TestBuildRequest(t *testing.T) {
+	c := &client{name: "anthropic", model: "claude-opus-4-8"}
+	req := provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: "You are helpful."},
+			{Role: provider.RoleUser, Content: "weather in Paris and Berlin?"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+				{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`},
+				{ID: "t2", Name: "get_weather", Arguments: `{"city":"Berlin"}`},
+			}},
+			{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
+			{Role: provider.RoleTool, ToolCallID: "t2", Content: "cloudy"},
+		},
+		Tools: []provider.ToolSchema{{Name: "get_weather", Description: "w", Parameters: json.RawMessage(`{"type":"object"}`)}},
+	}
+	r := c.buildRequest(req)
+
+	if r.Model != "claude-opus-4-8" {
+		t.Fatalf("model = %q", r.Model)
+	}
+	if r.MaxTokens != defaultMaxTokens {
+		t.Fatalf("max_tokens = %d, want default %d", r.MaxTokens, defaultMaxTokens)
+	}
+	// System lifted to the top level, with a cache breakpoint on its last block.
+	if len(r.System) != 1 || r.System[0].Text != "You are helpful." {
+		t.Fatalf("system = %+v", r.System)
+	}
+	if r.System[0].CacheControl == nil {
+		t.Fatal("system block should carry cache_control")
+	}
+	// System present ⇒ the tool does NOT also get a breakpoint (system caches tools).
+	if r.Tools[0].CacheControl != nil {
+		t.Fatal("tool should not carry cache_control when system does")
+	}
+	// user, assistant(tool_use ×2), user(tool_result ×2 coalesced) = 3 messages.
+	if len(r.Messages) != 3 {
+		t.Fatalf("want 3 messages, got %d: %+v", len(r.Messages), r.Messages)
+	}
+	if r.Messages[0].Role != "user" || r.Messages[0].Content[0].Text != "weather in Paris and Berlin?" {
+		t.Fatalf("msg[0] = %+v", r.Messages[0])
+	}
+	if r.Messages[1].Role != "assistant" || len(r.Messages[1].Content) != 2 ||
+		r.Messages[1].Content[0].Type != "tool_use" || r.Messages[1].Content[0].ID != "t1" ||
+		string(r.Messages[1].Content[0].Input) != `{"city":"Paris"}` {
+		t.Fatalf("msg[1] = %+v", r.Messages[1])
+	}
+	last := r.Messages[2]
+	if last.Role != "user" || len(last.Content) != 2 {
+		t.Fatalf("tool results should coalesce into one user turn: %+v", last)
+	}
+	if last.Content[0].Type != "tool_result" || last.Content[0].ToolUseID != "t1" || last.Content[0].Content != "sunny" {
+		t.Fatalf("tool_result[0] = %+v", last.Content[0])
+	}
+	if last.Content[1].ToolUseID != "t2" {
+		t.Fatalf("tool_result[1] = %+v", last.Content[1])
+	}
+	// Conversation cache breakpoint on the last block of the last message.
+	if last.Content[len(last.Content)-1].CacheControl == nil {
+		t.Fatal("last message block should carry cache_control")
+	}
+}
+
+// TestBuildRequestNoSystem checks the breakpoint falls back to the last tool when
+// there is no system message.
+func TestBuildRequestNoSystem(t *testing.T) {
+	c := &client{model: "claude-opus-4-8"}
+	r := c.buildRequest(provider.Request{
+		Messages:  []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		Tools:     []provider.ToolSchema{{Name: "a"}, {Name: "b"}},
+		MaxTokens: 1000,
+	})
+	if r.MaxTokens != 1000 {
+		t.Fatalf("explicit max_tokens should win: %d", r.MaxTokens)
+	}
+	if r.Tools[1].CacheControl == nil {
+		t.Fatal("last tool should carry cache_control when there is no system")
+	}
+	// A tool with no schema gets a minimal valid object schema.
+	if string(r.Tools[0].InputSchema) != `{"type":"object","properties":{}}` {
+		t.Fatalf("empty schema not defaulted: %s", r.Tools[0].InputSchema)
+	}
+}
+
+func TestMapStopReason(t *testing.T) {
+	cases := map[string]string{
+		"end_turn":      "stop",
+		"stop_sequence": "stop",
+		"tool_use":      "tool_calls",
+		"max_tokens":    "length",
+		"refusal":       "refusal",
+		"":              "",
+	}
+	for in, want := range cases {
+		if got := mapStopReason(in); got != want {
+			t.Errorf("mapStopReason(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+const sseFixture = `event: message_start
+data: {"type":"message_start","message":{"usage":{"input_tokens":100,"cache_creation_input_tokens":0,"cache_read_input_tokens":50,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_1","name":"get_weather"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"city\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"Paris\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":25}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+// TestReadStream feeds a canned Messages API SSE stream through readStream and
+// asserts the emitted chunk sequence: text deltas, a tool-call start + complete,
+// a usage record, then done.
+func TestReadStream(t *testing.T) {
+	c := &client{name: "anthropic"}
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(sseFixture))}
+	ch := make(chan provider.Chunk)
+	go c.readStream(resp, ch)
+
+	var text strings.Builder
+	var started, full *provider.ToolCall
+	var usage *provider.Usage
+	done := false
+	for ck := range ch {
+		switch ck.Type {
+		case provider.ChunkText:
+			text.WriteString(ck.Text)
+		case provider.ChunkToolCallStart:
+			started = ck.ToolCall
+		case provider.ChunkToolCall:
+			full = ck.ToolCall
+		case provider.ChunkUsage:
+			usage = ck.Usage
+		case provider.ChunkDone:
+			done = true
+		case provider.ChunkError:
+			t.Fatalf("unexpected error chunk: %v", ck.Err)
+		}
+	}
+
+	if text.String() != "Hello world" {
+		t.Fatalf("text = %q", text.String())
+	}
+	if started == nil || started.ID != "toolu_1" || started.Name != "get_weather" {
+		t.Fatalf("tool start = %+v", started)
+	}
+	if full == nil || full.Arguments != `{"city":"Paris"}` {
+		t.Fatalf("tool full = %+v", full)
+	}
+	if usage == nil {
+		t.Fatal("expected a usage chunk")
+	}
+	if usage.PromptTokens != 150 || usage.CompletionTokens != 25 || usage.TotalTokens != 175 {
+		t.Fatalf("usage tokens = %+v", usage)
+	}
+	if usage.CacheHitTokens != 50 || usage.CacheMissTokens != 100 {
+		t.Fatalf("usage cache = hit %d miss %d", usage.CacheHitTokens, usage.CacheMissTokens)
+	}
+	if usage.FinishReason != "tool_calls" {
+		t.Fatalf("finish reason = %q", usage.FinishReason)
+	}
+	if !done {
+		t.Fatal("expected a done chunk")
+	}
+}
+
+// TestReadStreamError surfaces a mid-stream error event as a ChunkError.
+func TestReadStreamError(t *testing.T) {
+	sse := "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"overloaded\"}}\n\n"
+	c := &client{name: "anthropic"}
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(sse))}
+	ch := make(chan provider.Chunk)
+	go c.readStream(resp, ch)
+
+	var gotErr error
+	for ck := range ch {
+		if ck.Type == provider.ChunkError {
+			gotErr = ck.Err
+		}
+	}
+	if gotErr == nil || !strings.Contains(gotErr.Error(), "overloaded") {
+		t.Fatalf("expected an error chunk mentioning overloaded, got %v", gotErr)
+	}
+}
+
+// Ensure the package wires into the registry under the expected kind.
+func TestRegistered(t *testing.T) {
+	p, err := provider.New("anthropic", provider.Config{Model: "claude-opus-4-8", Name: "claude"})
+	if err != nil {
+		t.Fatalf("provider.New: %v", err)
+	}
+	if p.Name() != "claude" {
+		t.Fatalf("name = %q", p.Name())
+	}
+	// Missing model is rejected.
+	if _, err := provider.New("anthropic", provider.Config{}); err == nil {
+		t.Fatal("expected error for missing model")
+	}
+	_ = context.Background()
+}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -50,6 +50,18 @@ model          = "mimo-v2-flash"   # thinking-mode off by default; cheaper / fas
 api_key_env    = "MIMO_API_KEY"
 context_window = 65536
 
+# Anthropic (Claude) — the "anthropic" kind speaks the Messages API directly (no
+# OpenAI shim). base_url is optional (defaults to https://api.anthropic.com). Note:
+# this provider does not enable extended thinking and does not send temperature —
+# current Claude models reject sampling params (see internal/provider/anthropic).
+[[providers]]
+name           = "claude"
+kind           = "anthropic"
+model          = "claude-opus-4-8"
+api_key_env    = "ANTHROPIC_API_KEY"
+context_window = 1000000
+price          = { cache_hit = 0.5, input = 5, output = 25, currency = "$" }   # per 1M tokens
+
 [tools]
 enabled = []   # empty = all built-in tools
 


### PR DESCRIPTION
Reasonix only had the OpenAI-compatible provider. This adds a hand-written net/http `anthropic` provider for Claude and Anthropic-compatible endpoints (e.g. DeepSeek's) — no SDK. It self-registers, so any Claude model is a config instance.

## What
- `internal/provider/anthropic`: `POST /v1/messages`, SSE streaming. Maps the transport-agnostic `Message`/`ToolCall`/`Chunk`/`Usage` abstraction onto the Messages API:
  - `RoleSystem` lifts to the top-level `system` field; assistant tool calls → `tool_use` blocks; `RoleTool` → `tool_result` blocks (consecutive ones coalesced into a single user turn for strict user/assistant alternation).
  - prompt-cache breakpoints (`cache_control: ephemeral`) on the last system block + last message block.
  - usage mapped (`cache_read`→hit, `input+cache_creation`→miss), `stop_reason`→OpenAI-style finish reason.
  - `AuthError` on 401/403; backoff retry on 408/429/5xx (incl. 529 overloaded).
- Blank import wired into `cmd/reasonix` and `desktop`; `reasonix.example.toml` gains a Claude example. The desktop Settings "kind" picker surfaces `anthropic` automatically via `provider.Kinds()`.

## v1 scope limits (documented in the package)
- **No extended/adaptive thinking** — Anthropic requires the *signed* `thinking` block be replayed after a tool call, but `Message.ReasoningContent` is a plain string with no signature, so it can't round-trip; enabling it would break multi-turn tool use. Supporting it means extending the `Message` abstraction.
- **No temperature/top_p** — current Claude models (Opus 4.8/4.7) 400 on sampling params; Anthropic steers via prompting.

## Verified
- Unit tests: protocol conversion (system lift, tool_use/tool_result, coalescing, cache breakpoints, max_tokens fallback), SSE parsing (text + tool-call start/complete + usage + done), error events, registry.
- **End-to-end against DeepSeek's Anthropic-compatible endpoint**: text streaming, `tool_use` (args assembled from `input_json_delta`), and usage/stop_reason mapping all correct.
