### PR TITLE
feat(provider): support Anthropic extended thinking round-trip

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -275,7 +275,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
-		text, reasoning, calls, usage, err := a.stream(ctx)
+		text, reasoning, signature, calls, usage, err := a.stream(ctx)
 		if err != nil {
 			return err
 		}
@@ -292,10 +292,11 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		// when building the request, since DeepSeek bills re-sent reasoning as
 		// ordinary prompt input (~500 tok/turn) for no cache or coherence gain.
 		a.session.Add(provider.Message{
-			Role:             provider.RoleAssistant,
-			Content:          text,
-			ReasoningContent: reasoning,
-			ToolCalls:        calls,
+			Role:               provider.RoleAssistant,
+			Content:            text,
+			ReasoningContent:   reasoning,
+			ReasoningSignature: signature,
+			ToolCalls:          calls,
 		})
 
 		if len(calls) == 0 {
@@ -327,24 +328,30 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 // stream so a sink can re-render the streamed raw text as styled markdown. The
 // accumulated text and reasoning are also returned so the caller can round-trip
 // reasoning on the next turn.
-func (a *Agent) stream(ctx context.Context) (string, string, []provider.ToolCall, *provider.Usage, error) {
+func (a *Agent) stream(ctx context.Context) (string, string, string, []provider.ToolCall, *provider.Usage, error) {
 	ch, err := a.prov.Stream(ctx, provider.Request{
 		Messages:    a.session.Messages,
 		Tools:       a.tools.Schemas(),
 		Temperature: a.temperature,
 	})
 	if err != nil {
-		return "", "", nil, nil, err
+		return "", "", "", nil, nil, err
 	}
 
 	var text, reasoning strings.Builder
+	var signature string // provider-issued proof for the reasoning (Anthropic thinking)
 	var calls []provider.ToolCall
 	var usage *provider.Usage
 	for chunk := range ch {
 		switch chunk.Type {
 		case provider.ChunkReasoning:
 			reasoning.WriteString(chunk.Text)
-			a.sink.Emit(event.Event{Kind: event.Reasoning, Text: chunk.Text})
+			if chunk.Signature != "" {
+				signature = chunk.Signature
+			}
+			if chunk.Text != "" {
+				a.sink.Emit(event.Event{Kind: event.Reasoning, Text: chunk.Text})
+			}
 		case provider.ChunkText:
 			text.WriteString(chunk.Text)
 			a.sink.Emit(event.Event{Kind: event.Text, Text: chunk.Text})
@@ -366,7 +373,7 @@ func (a *Agent) stream(ctx context.Context) (string, string, []provider.ToolCall
 			a.sessCacheHit += chunk.Usage.CacheHitTokens
 			a.sessCacheMiss += chunk.Usage.CacheMissTokens
 		case provider.ChunkError:
-			return "", "", nil, nil, chunk.Err
+			return "", "", "", nil, nil, chunk.Err
 		}
 	}
 	// Close the text stream: a sink may re-render the streamed raw text as
@@ -375,7 +382,7 @@ func (a *Agent) stream(ctx context.Context) (string, string, []provider.ToolCall
 	if text.Len() > 0 || reasoning.Len() > 0 {
 		a.sink.Emit(event.Event{Kind: event.Message, Text: text.String(), Reasoning: reasoning.String()})
 	}
-	return text.String(), reasoning.String(), calls, usage, nil
+	return text.String(), reasoning.String(), signature, calls, usage, nil
 }
 
 // executeBatch dispatches one model turn's tool calls. A ToolDispatch event is

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -314,8 +314,14 @@ func NewProvider(e *config.ProviderEntry) (provider.Provider, error) {
 		BaseURL: e.BaseURL,
 		Model:   e.Model,
 		APIKey:  e.APIKey(),
-		// Pass the key's env var so auth failures can name where to fix it.
-		Extra: map[string]any{"api_key_env": e.APIKeyEnv},
+		// Pass the key's env var so auth failures can name where to fix it, plus
+		// provider-kind-specific knobs (the anthropic provider reads thinking/effort;
+		// the openai one ignores them).
+		Extra: map[string]any{
+			"api_key_env": e.APIKeyEnv,
+			"thinking":    e.Thinking,
+			"effort":      e.Effort,
+		},
 	})
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,12 @@ type ProviderEntry struct {
 	BalanceURL    string            `toml:"balance_url"` // optional; a provider-specific wallet-balance endpoint (DeepSeek: https://api.deepseek.com/user/balance). Empty = no balance readout.
 	ContextWindow int               `toml:"context_window"`
 	Price         *provider.Pricing `toml:"price"`
+	// Thinking / Effort are provider-kind-specific knobs forwarded to the provider
+	// via Config.Extra. The anthropic provider reads Thinking="adaptive" to enable
+	// extended thinking and Effort ("low".."max") to tune depth; the
+	// openai-compatible provider ignores them. Empty = off / provider default.
+	Thinking string `toml:"thinking"`
+	Effort   string `toml:"effort"`
 }
 
 // ModelList returns the models this provider exposes: the explicit `models` list,

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -3,15 +3,15 @@
 // self-registers under the "anthropic" kind, so any Claude model is a config
 // instance rather than code.
 //
-// Two deliberate v1 scope limits, both driven by the transport-agnostic
-// provider.Message abstraction:
+// Two notes, both rooted in the transport-agnostic provider.Message abstraction:
 //
-//   - No extended/adaptive thinking. Anthropic requires the signed `thinking`
-//     block be replayed on the next turn when a tool call followed thinking;
-//     provider.Message.ReasoningContent is a plain string with no signature, so it
-//     can't be round-tripped faithfully. Since reasonix is tool-heavy, enabling
-//     thinking would break multi-turn tool use — so the `thinking` field is omitted
-//     entirely. (Supporting it means extending Message to carry the signed block.)
+//   - Extended thinking is opt-in (provider config thinking="adaptive"). Anthropic
+//     requires the *signed* thinking block be replayed on the next turn when a tool
+//     call followed thinking, so Message carries ReasoningSignature alongside
+//     ReasoningContent and this provider replays the signed block on the next
+//     request. Off by default because the field is Anthropic-specific — an
+//     OpenAI-compatible gateway (e.g. DeepSeek's) would reject it. (redacted_thinking
+//     blocks are not yet captured/replayed.)
 //   - No temperature/top_p. Current Claude models (Opus 4.8/4.7) reject sampling
 //     parameters with a 400; Anthropic steers behavior via prompting instead.
 package anthropic
@@ -63,23 +63,29 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		baseURL = defaultBaseURL
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
+	thinking, _ := cfg.Extra["thinking"].(string)
+	effort, _ := cfg.Extra["effort"].(string)
 	return &client{
-		name:    name,
-		apiKey:  cfg.APIKey,
-		keyEnv:  keyEnv,
-		baseURL: strings.TrimRight(baseURL, "/"),
-		model:   cfg.Model,
-		http:    &http.Client{}, // no overall timeout; lifecycle is ctx-driven
+		name:     name,
+		apiKey:   cfg.APIKey,
+		keyEnv:   keyEnv,
+		baseURL:  strings.TrimRight(baseURL, "/"),
+		model:    cfg.Model,
+		thinking: thinking,
+		effort:   effort,
+		http:     &http.Client{}, // no overall timeout; lifecycle is ctx-driven
 	}, nil
 }
 
 type client struct {
-	name    string
-	apiKey  string
-	keyEnv  string // api_key_env name, surfaced in auth errors
-	baseURL string
-	model   string
-	http    *http.Client
+	name     string
+	apiKey   string
+	keyEnv   string // api_key_env name, surfaced in auth errors
+	baseURL  string
+	model    string
+	thinking string // "adaptive" enables extended thinking; "" = off (config-driven)
+	effort   string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
+	http     *http.Client
 }
 
 func (c *client) Name() string { return c.name }
@@ -210,6 +216,13 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 			appendBlocks("user", contentBlock{Type: "tool_result", ToolUseID: m.ToolCallID, Content: content})
 		case provider.RoleAssistant:
 			var blocks []contentBlock
+			// Replay the signed thinking block first (Anthropic requires it precede
+			// the tool_use it led to). Only when thinking is on and we have both the
+			// text and its signature — reasoning without a signature (e.g. from an
+			// openai-compatible provider) can't be replayed as a thinking block.
+			if c.thinking != "" && m.ReasoningContent != "" && m.ReasoningSignature != "" {
+				blocks = append(blocks, contentBlock{Type: "thinking", Thinking: m.ReasoningContent, Signature: m.ReasoningSignature})
+			}
 			if m.Content != "" {
 				blocks = append(blocks, contentBlock{Type: "text", Text: m.Content})
 			}
@@ -253,7 +266,7 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 	if maxTokens <= 0 {
 		maxTokens = defaultMaxTokens
 	}
-	return anthRequest{
+	r := anthRequest{
 		Model:     c.model,
 		MaxTokens: maxTokens,
 		System:    system,
@@ -261,6 +274,16 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 		Tools:     tools,
 		Stream:    true,
 	}
+	// Extended thinking is opt-in and Anthropic-specific (a compatible gateway like
+	// DeepSeek's would reject the field). "summarized" display streams the reasoning
+	// text; the default omits it but still emits the signature we round-trip.
+	if c.thinking == "adaptive" {
+		r.Thinking = &thinkingConfig{Type: "adaptive", Display: "summarized"}
+		if c.effort != "" {
+			r.OutputConfig = &outputConfig{Effort: c.effort}
+		}
+	}
+	return r
 }
 
 // readStream parses the Messages API SSE stream into Chunks. Text deltas emit live;
@@ -320,6 +343,14 @@ func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
 			case "text_delta":
 				if ev.Delta.Text != "" {
 					out <- provider.Chunk{Type: provider.ChunkText, Text: ev.Delta.Text}
+				}
+			case "thinking_delta":
+				if ev.Delta.Thinking != "" {
+					out <- provider.Chunk{Type: provider.ChunkReasoning, Text: ev.Delta.Thinking}
+				}
+			case "signature_delta":
+				if ev.Delta.Signature != "" {
+					out <- provider.Chunk{Type: provider.ChunkReasoning, Signature: ev.Delta.Signature}
 				}
 			case "input_json_delta":
 				if tc := tools[ev.Index]; tc != nil {
@@ -393,12 +424,23 @@ type cacheControl struct {
 }
 
 type anthRequest struct {
-	Model     string        `json:"model"`
-	MaxTokens int           `json:"max_tokens"`
-	System    []textBlock   `json:"system,omitempty"`
-	Messages  []anthMessage `json:"messages"`
-	Tools     []anthTool    `json:"tools,omitempty"`
-	Stream    bool          `json:"stream"`
+	Model        string          `json:"model"`
+	MaxTokens    int             `json:"max_tokens"`
+	System       []textBlock     `json:"system,omitempty"`
+	Messages     []anthMessage   `json:"messages"`
+	Tools        []anthTool      `json:"tools,omitempty"`
+	Thinking     *thinkingConfig `json:"thinking,omitempty"`
+	OutputConfig *outputConfig   `json:"output_config,omitempty"`
+	Stream       bool            `json:"stream"`
+}
+
+type thinkingConfig struct {
+	Type    string `json:"type"`              // "adaptive"
+	Display string `json:"display,omitempty"` // "summarized" to stream the reasoning text
+}
+
+type outputConfig struct {
+	Effort string `json:"effort,omitempty"` // low | medium | high | xhigh | max
 }
 
 type textBlock struct {
@@ -418,6 +460,8 @@ type anthMessage struct {
 type contentBlock struct {
 	Type         string          `json:"type"`
 	Text         string          `json:"text,omitempty"`        // text
+	Thinking     string          `json:"thinking,omitempty"`    // thinking
+	Signature    string          `json:"signature,omitempty"`   // thinking
 	ID           string          `json:"id,omitempty"`          // tool_use
 	Name         string          `json:"name,omitempty"`        // tool_use
 	Input        json.RawMessage `json:"input,omitempty"`       // tool_use
@@ -446,8 +490,10 @@ type streamEvent struct {
 		Name string `json:"name"`
 	} `json:"content_block"`
 	Delta *struct {
-		Type        string `json:"type"`         // text_delta | input_json_delta | thinking_delta
+		Type        string `json:"type"`         // text_delta | thinking_delta | signature_delta | input_json_delta
 		Text        string `json:"text"`         // text_delta
+		Thinking    string `json:"thinking"`     // thinking_delta
+		Signature   string `json:"signature"`    // signature_delta
 		PartialJSON string `json:"partial_json"` // input_json_delta
 		StopReason  string `json:"stop_reason"`  // message_delta
 	} `json:"delta"`

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -222,6 +222,112 @@ func TestReadStreamError(t *testing.T) {
 	}
 }
 
+// TestBuildRequestThinking checks that, with thinking enabled, the request carries
+// the adaptive thinking + effort config and the prior assistant turn's signed
+// thinking block is replayed first (before its tool_use).
+func TestBuildRequestThinking(t *testing.T) {
+	c := &client{model: "claude-opus-4-8", thinking: "adaptive", effort: "high"}
+	r := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "weather?"},
+			{Role: provider.RoleAssistant, ReasoningContent: "Let me check.", ReasoningSignature: "sig-abc",
+				ToolCalls: []provider.ToolCall{{ID: "t1", Name: "get_weather", Arguments: `{"city":"Paris"}`}}},
+			{Role: provider.RoleTool, ToolCallID: "t1", Content: "sunny"},
+		},
+	})
+	if r.Thinking == nil || r.Thinking.Type != "adaptive" || r.Thinking.Display != "summarized" {
+		t.Fatalf("thinking config = %+v", r.Thinking)
+	}
+	if r.OutputConfig == nil || r.OutputConfig.Effort != "high" {
+		t.Fatalf("output config = %+v", r.OutputConfig)
+	}
+	asst := r.Messages[1]
+	if asst.Role != "assistant" || len(asst.Content) != 2 {
+		t.Fatalf("assistant msg = %+v", asst)
+	}
+	if asst.Content[0].Type != "thinking" || asst.Content[0].Thinking != "Let me check." || asst.Content[0].Signature != "sig-abc" {
+		t.Fatalf("first block should be the signed thinking block: %+v", asst.Content[0])
+	}
+	if asst.Content[1].Type != "tool_use" {
+		t.Fatalf("tool_use should follow the thinking block: %+v", asst.Content[1])
+	}
+}
+
+// TestBuildRequestThinkingOff is the default: no thinking field, and reasoning is
+// NOT replayed (even with a signature present) since the model wasn't asked to think.
+func TestBuildRequestThinkingOff(t *testing.T) {
+	c := &client{model: "claude-opus-4-8"}
+	r := c.buildRequest(provider.Request{Messages: []provider.Message{
+		{Role: provider.RoleUser, Content: "hi"},
+		{Role: provider.RoleAssistant, Content: "ok", ReasoningContent: "x", ReasoningSignature: "sig"},
+	}})
+	if r.Thinking != nil || r.OutputConfig != nil {
+		t.Fatalf("thinking should be off by default: %+v / %+v", r.Thinking, r.OutputConfig)
+	}
+	for _, b := range r.Messages[1].Content {
+		if b.Type == "thinking" {
+			t.Fatal("thinking block must not be replayed when thinking is off")
+		}
+	}
+}
+
+const sseThinking = `event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"think."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"SIG123"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hi"}}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+// TestReadStreamThinking checks thinking_delta streams as reasoning text and
+// signature_delta carries the signature back on a ChunkReasoning.
+func TestReadStreamThinking(t *testing.T) {
+	c := &client{name: "anthropic"}
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(sseThinking))}
+	ch := make(chan provider.Chunk)
+	go c.readStream(resp, ch)
+
+	var reasoning, text strings.Builder
+	var sig string
+	for ck := range ch {
+		switch ck.Type {
+		case provider.ChunkReasoning:
+			reasoning.WriteString(ck.Text)
+			if ck.Signature != "" {
+				sig = ck.Signature
+			}
+		case provider.ChunkText:
+			text.WriteString(ck.Text)
+		}
+	}
+	if reasoning.String() != "Let me think." {
+		t.Fatalf("reasoning = %q", reasoning.String())
+	}
+	if sig != "SIG123" {
+		t.Fatalf("signature = %q", sig)
+	}
+	if text.String() != "Hi" {
+		t.Fatalf("text = %q", text.String())
+	}
+}
+
 // Ensure the package wires into the registry under the expected kind.
 func TestRegistered(t *testing.T) {
 	p, err := provider.New("anthropic", provider.Config{Model: "claude-opus-4-8", Name: "claude"})

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,12 +23,18 @@ const (
 
 // Message is a single conversation message.
 type Message struct {
-	Role             Role       `json:"role"`
-	Content          string     `json:"content,omitempty"`
-	ReasoningContent string     `json:"reasoning_content,omitempty"` // assistant: thinking-mode chain-of-thought, round-tripped on multi-turn
-	ToolCalls        []ToolCall `json:"tool_calls,omitempty"`        // set by assistant
-	ToolCallID       string     `json:"tool_call_id,omitempty"`      // links a tool result to its call
-	Name             string     `json:"name,omitempty"`              // tool message: tool name
+	Role             Role   `json:"role"`
+	Content          string `json:"content,omitempty"`
+	ReasoningContent string `json:"reasoning_content,omitempty"` // assistant: thinking-mode chain-of-thought, round-tripped on multi-turn
+	// ReasoningSignature is an opaque, provider-issued proof that ReasoningContent
+	// is genuine model output. Anthropic requires the signed thinking block be
+	// replayed on the next turn when a tool call followed thinking; providers
+	// without signed reasoning (e.g. the openai-compatible ones) leave it empty.
+	// Round-tripped alongside ReasoningContent.
+	ReasoningSignature string     `json:"reasoning_signature,omitempty"`
+	ToolCalls          []ToolCall `json:"tool_calls,omitempty"`   // set by assistant
+	ToolCallID         string     `json:"tool_call_id,omitempty"` // links a tool result to its call
+	Name               string     `json:"name,omitempty"`         // tool message: tool name
 }
 
 // ToolCall is a tool invocation requested by the model. Arguments is raw JSON.
@@ -112,11 +118,12 @@ func (p *Pricing) Symbol() string {
 
 // Chunk is a single streamed event. Read the field matching Type.
 type Chunk struct {
-	Type     ChunkType
-	Text     string    // ChunkText, ChunkReasoning
-	ToolCall *ToolCall // ChunkToolCallStart (ID+Name only), ChunkToolCall (complete)
-	Usage    *Usage    // ChunkUsage
-	Err      error     // ChunkError
+	Type      ChunkType
+	Text      string    // ChunkText, ChunkReasoning
+	Signature string    // ChunkReasoning: opaque proof for the reasoning (Anthropic thinking signature), when issued
+	ToolCall  *ToolCall // ChunkToolCallStart (ID+Name only), ChunkToolCall (complete)
+	Usage     *Usage    // ChunkUsage
+	Err       error     // ChunkError
 }
 
 // Provider is a chat-capable model backend.

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -61,6 +61,10 @@ model          = "claude-opus-4-8"
 api_key_env    = "ANTHROPIC_API_KEY"
 context_window = 1000000
 price          = { cache_hit = 0.5, input = 5, output = 25, currency = "$" }   # per 1M tokens
+# Extended thinking (anthropic kind only; round-trips the signed reasoning block
+# across tool calls). Omit to disable. effort: low | medium | high | xhigh | max.
+thinking       = "adaptive"
+effort         = "high"
 
 [tools]
 enabled = []   # empty = all built-in tools


### PR DESCRIPTION
Lets Claude run extended/adaptive thinking together with tool use across turns. Anthropic requires the *signed* thinking block be replayed on the next turn after a tool call; the plain-string `ReasoningContent` couldn't carry the signature, so v1 of the provider omitted thinking entirely. This extends the abstraction to support it.

## Changes
- **`provider.Message`** gains `ReasoningSignature` (round-trips with `ReasoningContent`); **`provider.Chunk`** gains `Signature` so a provider can return the proof through the stream.
- **`internal/agent`** threads the signature from the chunk stream onto the assistant turn it stores.
- **`internal/provider/anthropic`**: thinking is **opt-in** via provider config (`thinking = "adaptive"`, `effort = "low".."max"`). When on, it sends the adaptive-thinking + effort config, streams `thinking_delta` as reasoning, captures `signature_delta`, and replays the signed `thinking` block (before the `tool_use` it led to) on the next request. **Off by default** — the field is Anthropic-specific and an OpenAI-compatible gateway (e.g. DeepSeek's default path) would reject it. The knob rides through `config.ProviderEntry` → `Config.Extra`.

## Verified
- Unit tests: request building with thinking (adaptive+effort config, signed block replayed before tool_use; not replayed when off or unsigned), SSE parsing (`thinking_delta` → reasoning, `signature_delta` → signature).
- **End-to-end against DeepSeek's Anthropic endpoint**: a two-turn tool-use conversation with thinking on — turn 1 streams reasoning + captures a signature + calls the tool; turn 2 replays the signed thinking block + tool result and is **accepted (no 400)**, producing a coherent final answer.

Known gap: `redacted_thinking` blocks aren't yet captured/replayed (rare; documented in the package).
