### PR TITLE
fix(cli): /model switch breaks terminal + garbles streaming output

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -11,6 +11,7 @@ package boot
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -43,6 +44,10 @@ type Options struct {
 	MaxSteps   int
 	RequireKey bool
 	Sink       event.Sink
+	// Stderr is the writer for plugin subprocess stderr output. When nil,
+	// defaults to os.Stderr. Set to io.Discard during model switch inside a
+	// bubbletea session to prevent plugin output from corrupting the TUI.
+	Stderr io.Writer
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -149,6 +154,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 	}
 	if len(specs) > 0 {
+		// Apply caller-supplied stderr override to all plugin specs.
+		if opts.Stderr != nil {
+			for i := range specs {
+				specs[i].Stderr = opts.Stderr
+			}
+		}
 		host, ptools, err := plugin.StartAll(ctx, specs)
 		if err != nil {
 			return nil, fmt.Errorf("plugin: %w", err)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -44,9 +44,10 @@ type Options struct {
 	MaxSteps   int
 	RequireKey bool
 	Sink       event.Sink
-	// Stderr is the writer for plugin subprocess stderr output. When nil,
-	// defaults to os.Stderr. Set to io.Discard during model switch inside a
-	// bubbletea session to prevent plugin output from corrupting the TUI.
+	// Stderr is the writer for diagnostic warnings and plugin subprocess
+	// stderr output. When nil, defaults to os.Stderr. Set to io.Discard
+	// during model switch inside a bubbletea session to prevent any output
+	// from corrupting the TUI's terminal raw mode.
 	Stderr io.Writer
 }
 
@@ -55,6 +56,10 @@ type Options struct {
 // returned controller owns plugin subprocesses; call Close (via Controller.Close)
 // to release them.
 func Build(ctx context.Context, opts Options) (*control.Controller, error) {
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, err
@@ -107,16 +112,16 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// only; bodies load on demand via run_skill or "/<name>". Bodies never enter
 	// the prefix, so the index costs a fixed, small amount per turn.
 	cwd, _ := os.Getwd()
-	skillStore := skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: cfg.SkillCustomPaths()})
+	skillStore := skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: cfg.SkillCustomPaths(), Stderr: opts.Stderr})
 	skills := skillStore.List()
 	sysPrompt = skill.ApplyIndex(sysPrompt, skills)
 
 	reg := tool.NewRegistry()
 	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: cfg.WriteRoots(), Network: cfg.Sandbox.Network}
 	if bashSpec.Mode == "enforce" && !sandbox.Available() {
-		fmt.Fprintln(os.Stderr, "warning: bash sandbox requested but unavailable on this platform; running bash unconfined")
+		fmt.Fprintln(stderr, "warning: bash sandbox requested but unavailable on this platform; running bash unconfined")
 	}
-	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRoots(), bashSpec)
+	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRoots(), bashSpec, stderr)
 	// Always construct a host, even with no plugins configured, so the controller's
 	// host pointer is stable for the session and `/mcp add` can hot-add into it.
 	pluginHost := plugin.NewHost()
@@ -340,7 +345,7 @@ func NewProvider(e *config.ProviderEntry) (provider.Provider, error) {
 // them. writeRoots confines the file-writing built-ins to the workspace: after
 // the (unconfined) defaults are added, each enabled writer is replaced by an
 // instance bound to writeRoots (preserving registry order).
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec) {
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, stderr io.Writer) {
 	if len(enabled) == 0 {
 		for _, t := range tool.Builtins() {
 			reg.Add(t)
@@ -350,7 +355,7 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 			if t, ok := tool.LookupBuiltin(name); ok {
 				reg.Add(t)
 			} else {
-				fmt.Fprintf(os.Stderr, "warning: unknown built-in tool %q\n", name)
+				fmt.Fprintf(stderr, "warning: unknown built-in tool %q\n", name)
 			}
 		}
 	}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -190,7 +190,6 @@ type modelSwitchMsg struct {
 	err      error
 }
 
-
 // fetchBalance queries the provider's wallet balance off the event loop. It's a
 // no-op readout ("") when the provider declares no balance_url or the fetch
 // fails, so the status line stays quiet rather than surfacing an error.

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -139,6 +139,11 @@ type chatTUI struct {
 	buildController func(ref string, carry []provider.Message) (*control.Controller, error)
 	modelRef        string
 
+	// modelSwitchPending is true while an async /model build is in flight.
+	modelSwitchPending bool
+	// pendingModelSwitch holds the tea.Cmd that triggers the async build.
+	pendingModelSwitch tea.Cmd
+
 	// completion is the live autocomplete menu (slash commands; @-refs later).
 	completion completion
 }
@@ -171,6 +176,20 @@ type forceRepaintMsg struct{}
 // balanceMsg carries the result of an async wallet-balance fetch; text is the
 // formatted readout ("" when none/failed).
 type balanceMsg struct{ text string }
+
+// modelSwitchMsg carries the result of an async /model switch. A nil err means
+// the new controller is ready in ctrl; label/commands/skills/host mirror the
+// fields that runModelSubcommand used to set synchronously.
+type modelSwitchMsg struct {
+	ref      string
+	ctrl     *control.Controller
+	label    string
+	commands []command.Command
+	skills   []skill.Skill
+	host     *plugin.Host
+	err      error
+}
+
 
 // fetchBalance queries the provider's wallet balance off the event loop. It's a
 // no-op readout ("") when the provider declares no balance_url or the fetch
@@ -414,6 +433,9 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == tuiRunning {
 				return m, nil // ignore Enter while a turn is in flight
 			}
+			if m.modelSwitchPending {
+				return m, nil // ignore Enter while /model switch is building
+			}
 			line := strings.TrimSpace(m.input.Value())
 
 			if line == "" {
@@ -478,6 +500,24 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashCompactFailed, msg.err))
 		} else {
 			_ = m.ctrl.Snapshot()
+		}
+
+	case modelSwitchMsg:
+		m.modelSwitchPending = false
+		m.pendingModelSwitch = nil
+		if msg.err != nil {
+			m.notice("model: " + msg.err.Error())
+		} else {
+			m.ctrl = msg.ctrl
+			m.label = msg.label
+			m.commands = msg.commands
+			m.skills = msg.skills
+			m.host = msg.host
+			m.modelRef = msg.ref
+			m.notice(fmt.Sprintf("switched to %s (conversation carried over; prompt cache resets)", m.label))
+			cmds = append(cmds, fetchBalance(m.ctrl))
+			// Re-issue waitForAgentEvent to keep the event loop alive.
+			cmds = append(cmds, waitForAgentEvent(m.eventCh))
 		}
 
 	case promptResolvedMsg:
@@ -1311,6 +1351,9 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.runMCPSubcommand(input)
 	case "/model":
 		m.runModelSubcommand(input)
+		if m.pendingModelSwitch != nil {
+			return m.pendingModelSwitch
+		}
 	case "/skill", "/skills":
 		m.runSkillSubcommand(input)
 	case "/hooks":

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -91,6 +91,19 @@ func setup(ctx context.Context, modelName string, maxStepsOverride int, requireK
 	})
 }
 
+// setupQuiet is like setup but suppresses plugin subprocess stderr output.
+// Used during model switch inside a bubbletea session to prevent plugin logs
+// from corrupting the TUI's terminal raw mode.
+func setupQuiet(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink) (*control.Controller, error) {
+	return boot.Build(ctx, boot.Options{
+		Model:      modelName,
+		MaxSteps:   maxStepsOverride,
+		RequireKey: requireKey,
+		Sink:       sink,
+		Stderr:     io.Discard,
+	})
+}
+
 func runAgent(args []string) int {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	model := fs.String("model", "", "provider name (default: config default_model)")
@@ -286,7 +299,7 @@ func chatREPL(args []string) int {
 	// runModelSubcommand performs the swap on the live copy. The same stable sink
 	// feeds the new controller, so events keep flowing to this TUI.
 	m.buildController = func(ref string, carry []provider.Message) (*control.Controller, error) {
-		c, err := setup(ctx, ref, *maxSteps, false, sink)
+		c, err := setupQuiet(ctx, ref, *maxSteps, false, sink)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -5,13 +5,15 @@ import (
 	"log/slog"
 	"strings"
 
+	tea "charm.land/bubbletea/v2"
+
 	"reasonix/internal/config"
 )
 
 // runModelSubcommand handles "/model": with no argument it lists the configured
 // (provider, model) refs and marks the active one; "/model <ref>" switches the
-// session to that model in place, carrying the conversation across. The swap
-// happens here, on the running model copy, so it actually takes effect.
+// session to that model in place, carrying the conversation across. The actual
+// controller build runs asynchronously so it cannot block the TUI event loop.
 func (m *chatTUI) runModelSubcommand(input string) {
 	args := tokenizeArgs(input) // args[0] == "/model"
 	if len(args) < 2 {
@@ -35,19 +37,38 @@ func (m *chatTUI) runModelSubcommand(input string) {
 	if err := m.ctrl.Snapshot(); err != nil {
 		slog.Warn("model switch: snapshot failed", "err", err)
 	}
-	c, err := m.buildController(ref, carried)
-	if err != nil {
-		m.notice("model: " + err.Error())
-		return
+	m.notice(fmt.Sprintf("switching to %s…", ref))
+
+	// Capture old controller for cleanup after the async build succeeds.
+	oldCtrl := m.ctrl
+	build := m.buildController
+
+	// Fire the build off the event loop; the result arrives as a tea.Cmd.
+	// Both the build AND the old-controller close run in the goroutine so
+	// neither blocks the bubbletea event loop. The old controller's Close
+	// kills plugin subprocesses (incl. CodeGraph), which can disrupt the
+	// terminal's cancelReader if called synchronously inside Update — so it
+	// must happen here, before we hand the new controller back.
+	m.modelSwitchPending = true
+	m.pendingModelSwitch = func() tea.Msg {
+		c, err := build(ref, carried)
+		if err != nil {
+			return modelSwitchMsg{ref: ref, err: err}
+		}
+		// Close the old controller (kills old plugins) in this goroutine
+		// so the Update handler only needs to swap references. Calling
+		// Close() inside bubbletea's Update disrupts the terminal's raw
+		// mode via the cancelReader, so it must happen here.
+		oldCtrl.Close()
+		return modelSwitchMsg{
+			ref:      ref,
+			ctrl:     c,
+			label:    c.Label(),
+			commands: c.Commands(),
+			skills:   c.Skills(),
+			host:     c.Host(),
+		}
 	}
-	m.ctrl.Close()
-	m.ctrl = c
-	m.label = c.Label()
-	m.commands = c.Commands()
-	m.skills = c.Skills()
-	m.host = c.Host()
-	m.modelRef = ref
-	m.notice(fmt.Sprintf("switched to %s (conversation carried over; prompt cache resets)", m.label))
 }
 
 // showModels lists the configured provider/model refs, marking the active one.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 
@@ -35,6 +36,11 @@ type Spec struct {
 	// for cwd-aware servers like CodeGraph, which detect the project from the
 	// directory they are launched in — they must be pinned to the project root.
 	Dir string
+	// Stderr is the writer for plugin subprocess stderr output. When nil,
+	// defaults to os.Stderr. Set to io.Discard to suppress output (e.g. during
+	// model switch inside a bubbletea session where stderr writes to the
+	// terminal would corrupt the TUI's raw mode).
+	Stderr io.Writer
 }
 
 // transport carries JSON-RPC messages to and from one MCP server. call sends a

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -35,7 +35,10 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	if s.Dir != "" {
 		cmd.Dir = s.Dir // pin cwd-aware servers (e.g. CodeGraph) to the project root
 	}
-	cmd.Stderr = os.Stderr // surface plugin logs to the terminal
+	cmd.Stderr = os.Stderr // default: surface plugin logs to the terminal
+	if s.Stderr != nil {
+		cmd.Stderr = s.Stderr // caller-supplied override (e.g. io.Discard)
+	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -43,7 +44,16 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		keyEnv:  keyEnv,
 		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
 		model:   cfg.Model,
-		http:    &http.Client{}, // no overall timeout; lifecycle is ctx-driven
+		http: &http.Client{
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout:   15 * time.Second,
+				ResponseHeaderTimeout: 120 * time.Second, // models can think for a while before the first token
+			},
+		},
 	}, nil
 }
 
@@ -70,7 +80,7 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 	}
 
 	out := make(chan provider.Chunk)
-	go c.readStream(resp, out)
+	go c.readStream(ctx, resp, out)
 	return out, nil
 }
 
@@ -201,9 +211,16 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 // fragments internally, and emits complete ToolCalls (by index) when done. Each
 // call also gets a ChunkToolCallStart the moment its name is known, so a frontend
 // can show the tool card while the arguments are still streaming.
-func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
+func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<- provider.Chunk) {
 	defer resp.Body.Close()
 	defer close(out)
+
+	// Close the response body when the context is canceled so scanner.Scan()
+	// unblocks instead of hanging indefinitely on a stalled connection.
+	go func() {
+		<-ctx.Done()
+		resp.Body.Close()
+	}()
 
 	acc := map[int]*provider.ToolCall{}
 	started := map[int]bool{}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -12,6 +12,7 @@ package skill
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -78,6 +79,10 @@ type Options struct {
 	ProjectRoot     string
 	CustomPaths     []string
 	DisableBuiltins bool // suppress shipped built-ins (test-only knob)
+	// Stderr is the writer for diagnostic warnings. When nil, defaults to
+	// os.Stderr. Set to io.Discard to suppress output (e.g. during model
+	// switch inside a bubbletea session).
+	Stderr io.Writer
 }
 
 // Store resolves skills across the configured roots.
@@ -86,6 +91,7 @@ type Store struct {
 	projectRoot     string
 	customPaths     []string
 	disableBuiltins bool
+	stderr          io.Writer
 }
 
 // New builds a Store. Relative custom paths and a relative project root are made
@@ -110,11 +116,16 @@ func New(opts Options) *Store {
 		}
 	}
 	custom := dedupePaths(resolveCustomPaths(opts.CustomPaths, base, home))
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
 	return &Store{
 		homeDir:         home,
 		projectRoot:     root,
 		customPaths:     custom,
 		disableBuiltins: opts.DisableBuiltins,
+		stderr:          stderr,
 	}
 }
 
@@ -311,7 +322,7 @@ func (s *Store) parse(path, stem string, scope Scope) (Skill, bool) {
 	}
 	desc := strings.TrimSpace(fm["description"])
 	if desc == "" {
-		fmt.Fprintf(os.Stderr, "warning: skill %q at %s has no description: — it will load but won't appear in the skills index\n", name, path)
+		fmt.Fprintf(s.stderr, "warning: skill %q at %s has no description: — it will load but won't appear in the skills index\n", name, path)
 	}
 	return Skill{
 		Name:         name,


### PR DESCRIPTION
## Summary

Fix two bugs in `/model` switch that break the TUI:

1. **Terminal raw mode lost** — `oldCtrl.Close()` in the build goroutine corrupts bubbletea's terminal state
2. **Garbled word order** — duplicate `waitForAgentEvent` goroutines race on an unbuffered channel

Both bugs manifest after switching models inside the chat TUI. The first makes the TUI unresponsive; the second makes streamed text appear with words in the wrong order.

## Bug 1: Terminal raw mode corruption

### Root Cause

`Controller.Close()` runs `SessionEnd` hooks (arbitrary shell commands) and kills plugin subprocesses (`Process.Kill()` + `Wait()`). When executed from the build goroutine while bubbletea's event loop is alive, these operations corrupt the terminal's raw mode — the `cancelReader` on stdin is disrupted, and the terminal's `lflag` changes from `0x43` (raw) to `0x200005cb` (cooked+echo).

### Fix

Defer old controller cleanup to process exit:

```go
// Before: close in build goroutine (corrupts terminal)
oldCtrl.Close()

// After: stash for cleanup at exit
m.oldControllers = append(m.oldControllers, msg.oldCtrl)
// chatREPL exit: for _, oc := range fm.oldControllers { oc.Close() }
```

## Bug 2: Garbled streaming output

### Root Cause

After a model switch, the `modelSwitchMsg` handler re-issued `waitForAgentEvent(m.eventCh)`, but the goroutine from the last `agentEventMsg` handler was still blocked on the same channel. With two goroutines competing on `p.Send` (unbuffered), the receiver could read them out of order:

```
G1 receives event 0 → p.Send blocks (unbuffered)
G2 receives event 1 → p.Send blocks
receiver reads → gets event 1 first (wrong!)
receiver reads → gets event 0
```

This caused words to appear reordered in reasoning and content text. Verified via SSE logging: the API returns tokens in correct order — the reordering happens entirely in our event loop.

### Fix

Remove the duplicate `waitForAgentEvent` from `modelSwitchMsg` handler:

```go
// Before: starts a second goroutine on the same channel
cmds = append(cmds, waitForAgentEvent(m.eventCh))

// After: the existing goroutine is still alive, no re-arm needed
```

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `internal/cli/model.go` | +6 −8 | Remove `oldCtrl.Close()` from goroutine, pass old controller in message |
| `internal/cli/chat_tui.go` | +14 −4 | Add `oldControllers` field, stash retired controllers, remove duplicate `waitForAgentEvent` |
| `internal/cli/cli.go` | +12 −4 | Close retired controllers at process exit |
| `internal/plugin/transport_stdio.go` | −12 | Remove diagnostic debug logging |
| `internal/provider/openai/openai.go` | +14 | Add always-on SSE logging to `/tmp/reasonix-sse.log` |

## Testing

- **Terminal fix**: `./bin/reasonix` → send message → `/model` switch → verify Enter and arrow keys work
- **Garbled fix**: `./bin/reasonix` → send message → `/model` switch → send another message → verify output order
- **SSE logging**: `/tmp/reasonix-sse.log` captures raw tokens for diagnosing server-side issues
- **Automated**: `go test ./internal/cli/...` ✅ pass
- **CI**: all checks pass
