### PR TITLE
fix(agent): break the same-tool, same-error retry loop

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -158,6 +158,18 @@ type Agent struct {
 	compactRatio  float64
 	recentKeep    int
 	archiveDir    string
+
+	// stormSig / stormCount track a run of tool calls that keep failing the same
+	// way so the loop can break a death-spiral. The signature is (tool, error),
+	// NOT (tool, args): a stuck model reliably reworks the arguments cosmetically
+	// (a re-worded essay, a reordered object) while the call fails identically
+	// every time — keying on args misses the loop entirely (observed live against
+	// truncated tool-call arguments). Because errors that embed their subject
+	// (e.g. "file not found: /x") differ per target, genuine varied probing does
+	// not collapse to one signature. Reset whenever a turn does anything else
+	// (a different failure, more than one call, or any success). See applyStormBreaker.
+	stormSig   string
+	stormCount int
 }
 
 // SetPlanMode flips the read-only gate. While true, executeOne refuses any
@@ -447,7 +459,48 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: o.truncMsg})
 		}
 	}
+	a.applyStormBreaker(calls, outcomes, results)
 	return results
+}
+
+// stormBreakThreshold is how many times in a row the same tool may fail the same
+// way before the loop stops echoing the raw error back and instead returns a
+// directive to change approach. Two natural self-corrections are healthy; the
+// third identical failure is a death-spiral — the dominant case being a tool call
+// whose arguments are truncated at the output-token ceiling, which the model then
+// re-emits (re-worded but still over-long), truncating the same way again.
+const stormBreakThreshold = 3
+
+// applyStormBreaker detects a run of same-tool, same-error failures and, past the
+// threshold, rewrites the model-facing result (results[0]) into a directive to
+// change approach. It keys on (tool, error) rather than (tool, args) because a
+// stuck model reworks the arguments cosmetically while failing identically — see
+// the stormSig field doc. It targets only the single-call fixation that produces
+// the loop: a turn with exactly one call that errored (and was not merely blocked
+// by plan mode / permissions, which already carry a clear, distinct message). Any
+// other shape — multiple calls, or any success — is varied work, so it resets the
+// counter. The hard maxSteps guard remains the ultimate backstop; this just keeps
+// the loop from burning that whole budget bouncing off the same failure.
+func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, results []string) {
+	if len(calls) != 1 || outcomes[0].errMsg == "" || outcomes[0].blocked {
+		a.stormSig, a.stormCount = "", 0
+		return
+	}
+	sig := calls[0].Name + "\x00" + outcomes[0].errMsg
+	if sig != a.stormSig {
+		a.stormSig, a.stormCount = sig, 1
+		return
+	}
+	a.stormCount++
+	if a.stormCount < stormBreakThreshold {
+		return
+	}
+	results[0] = outcomes[0].output + fmt.Sprintf(
+		"\n\n[loop guard] %q has now failed %d times in a row with the same error. Re-sending it — even with the wording changed — will not help: the call keeps failing the same way. Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the argument, use a different tool, or explain the blocker in your final answer.",
+		calls[0].Name, a.stormCount)
+	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf(
+		"loop guard: %s failed %d× the same way — nudging the model to change approach",
+		calls[0].Name, a.stormCount)})
 }
 
 // toolOutcome is one tool call's result, split into the model-facing output and

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -1,0 +1,128 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// failTool always errors with the same message regardless of its arguments,
+// standing in for a call the model keeps re-emitting (e.g. arguments truncated at
+// the output-token ceiling, which fail to parse the same way every time even as
+// the model re-words the payload).
+type failTool struct{ name string }
+
+func (f failTool) Name() string           { return f.name }
+func (f failTool) Description() string     { return "always fails" }
+func (f failTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (f failTool) ReadOnly() bool          { return true }
+func (f failTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "", errors.New("unexpected end of JSON input")
+}
+
+// okTool always succeeds — a turn of real progress that breaks a failing run.
+type okTool struct{ name string }
+
+func (o okTool) Name() string                                   { return o.name }
+func (o okTool) Description() string                            { return "always succeeds" }
+func (o okTool) Schema() json.RawMessage                        { return json.RawMessage(`{"type":"object"}`) }
+func (o okTool) ReadOnly() bool                                 { return true }
+func (o okTool) Execute(context.Context, json.RawMessage) (string, error) { return "ok", nil }
+
+func warnNoticeRecorder() (event.Sink, *[]string) {
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice && e.Level == event.LevelWarn {
+			notices = append(notices, e.Text)
+		}
+	})
+	return sink, &notices
+}
+
+// TestStormBreakerEscalatesRepeatedFailure: once the same tool has failed the
+// same way stormBreakThreshold times in a row, the model-facing result must carry
+// the loop-guard directive (not just the raw error again), and the user must get
+// a warn notice. The arguments DIFFER on every call — mirroring the live failure
+// mode where a stuck model re-words the payload — to prove detection keys on the
+// error, not the bytes.
+func TestStormBreakerEscalatesRepeatedFailure(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(failTool{name: "write_file"})
+	sink, notices := warnNoticeRecorder()
+	a := New(nil, reg, NewSession(""), Options{}, sink)
+
+	args := []string{`{"content":"Mountains are`, `{"path":"n.txt","content":"Peaks rise`, `{}`}
+	var last string
+	for i := 0; i < stormBreakThreshold; i++ {
+		call := provider.ToolCall{Name: "write_file", Arguments: args[i]}
+		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+	}
+
+	if !strings.Contains(last, "[loop guard]") {
+		t.Fatalf("after %d same-error failures the result should carry the loop guard, got: %q", stormBreakThreshold, last)
+	}
+	if !strings.Contains(last, "write_file") {
+		t.Errorf("loop-guard text should name the offending tool, got: %q", last)
+	}
+	if !strings.Contains(last, "unexpected end of JSON input") {
+		t.Errorf("loop-guard result should still preserve the original error, got: %q", last)
+	}
+	if len(*notices) == 0 {
+		t.Errorf("loop guard should emit a warn notice to the user")
+	}
+}
+
+// TestStormBreakerSilentBelowThreshold: the first few self-corrections are
+// healthy — the guard must not fire before the threshold.
+func TestStormBreakerSilentBelowThreshold(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(failTool{name: "write_file"})
+	sink, notices := warnNoticeRecorder()
+	a := New(nil, reg, NewSession(""), Options{}, sink)
+
+	call := provider.ToolCall{Name: "write_file", Arguments: `{"content":"x`}
+	var last string
+	for i := 0; i < stormBreakThreshold-1; i++ {
+		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+	}
+
+	if strings.Contains(last, "[loop guard]") {
+		t.Fatalf("guard fired after only %d repeats (threshold %d)", stormBreakThreshold-1, stormBreakThreshold)
+	}
+	if len(*notices) != 0 {
+		t.Errorf("no warn notice expected below threshold, got %v", *notices)
+	}
+}
+
+// TestStormBreakerResetsOnSuccess: a run of failures broken by a successful turn
+// must reset the counter, so the guard does not fire prematurely afterward.
+func TestStormBreakerResetsOnSuccess(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(failTool{name: "write_file"})
+	reg.Add(okTool{name: "read_file"})
+	sink, notices := warnNoticeRecorder()
+	a := New(nil, reg, NewSession(""), Options{}, sink)
+
+	fail := provider.ToolCall{Name: "write_file", Arguments: `{"content":"x`}
+	good := provider.ToolCall{Name: "read_file", Arguments: `{"path":"x"}`}
+	ctx := context.Background()
+
+	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 1
+	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 2
+	a.executeBatch(ctx, []provider.ToolCall{good}) // success → reset
+	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 1
+	last := a.executeBatch(ctx, []provider.ToolCall{fail})[0] // count 2 — still below threshold
+
+	if strings.Contains(last, "[loop guard]") {
+		t.Fatalf("guard should have reset after a successful turn, got: %q", last)
+	}
+	if len(*notices) != 0 {
+		t.Errorf("no warn notice expected when a success breaks the run, got %v", *notices)
+	}
+}


### PR DESCRIPTION
When a single tool call keeps failing the same way, the model re-emits it (cosmetically re-worded but failing identically) until the `max_steps` backstop, burning the whole step budget. The dominant trigger is a tool call whose arguments are truncated at the output-token ceiling.

## Change
- Add a loop guard in `executeBatch`: after a tool fails `stormBreakThreshold` (3) times in a row with the **same error**, escalate the model-facing result from the raw error to a directive to change approach, and surface a warn notice.
- Keyed on **(tool, error)**, not (tool, args): a stuck model reworks the arguments while the failure is unchanged, so keying on args misses the loop entirely (confirmed live against truncated tool-call arguments).
- Errors that embed their subject (e.g. a path) differ per target, so genuine varied probing doesn't collapse to one signature.
- Resets on any success, a different failure, or a multi-call turn. `max_steps` stays the hard backstop.

## Verification
- New unit tests: escalate at threshold, silent below threshold, reset on success.
- Full `go test ./...` green; clean build.
- Live end-to-end (DeepSeek v4, forced output-token truncation): guard fires at the 3rd identical failure and the model switches approach; a normal multi-step task does not trigger it.