### PR TITLE
style: gofmt storm_test.go to unblock CI

### DIFF
--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -18,7 +18,7 @@ import (
 // the model re-words the payload).
 type failTool struct{ name string }
 
-func (f failTool) Name() string           { return f.name }
+func (f failTool) Name() string            { return f.name }
 func (f failTool) Description() string     { return "always fails" }
 func (f failTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
 func (f failTool) ReadOnly() bool          { return true }
@@ -29,10 +29,10 @@ func (f failTool) Execute(context.Context, json.RawMessage) (string, error) {
 // okTool always succeeds — a turn of real progress that breaks a failing run.
 type okTool struct{ name string }
 
-func (o okTool) Name() string                                   { return o.name }
-func (o okTool) Description() string                            { return "always succeeds" }
-func (o okTool) Schema() json.RawMessage                        { return json.RawMessage(`{"type":"object"}`) }
-func (o okTool) ReadOnly() bool                                 { return true }
+func (o okTool) Name() string                                             { return o.name }
+func (o okTool) Description() string                                      { return "always succeeds" }
+func (o okTool) Schema() json.RawMessage                                  { return json.RawMessage(`{"type":"object"}`) }
+func (o okTool) ReadOnly() bool                                           { return true }
 func (o okTool) Execute(context.Context, json.RawMessage) (string, error) { return "ok", nil }
 
 func warnNoticeRecorder() (event.Sink, *[]string) {
@@ -113,10 +113,10 @@ func TestStormBreakerResetsOnSuccess(t *testing.T) {
 	good := provider.ToolCall{Name: "read_file", Arguments: `{"path":"x"}`}
 	ctx := context.Background()
 
-	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 1
-	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 2
-	a.executeBatch(ctx, []provider.ToolCall{good}) // success → reset
-	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 1
+	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
+	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 2
+	a.executeBatch(ctx, []provider.ToolCall{good})            // success → reset
+	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
 	last := a.executeBatch(ctx, []provider.ToolCall{fail})[0] // count 2 — still below threshold
 
 	if strings.Contains(last, "[loop guard]") {


### PR DESCRIPTION
## Problem
`internal/agent/storm_test.go` (added in #2474) was committed with hand-adjusted method alignment that is not gofmt-clean. CI runs `gofmt -l . | grep -v desktop` over the whole tree, so this fails the gofmt step on main-v2 and **blocks the CI of every subsequent PR** (not just the one that touches it).

## Fix
`gofmt -w internal/agent/storm_test.go` — pure alignment fix, no semantic change. `go test ./internal/agent` still passes.

This unblocks the gofmt gate so other PRs can go green again.