### PR TITLE
feat(compaction): surface context compaction as a card across CLI, desktop, headless

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -111,8 +111,40 @@ export function Transcript({
                 {it.text}
               </div>
             );
+          case "compaction":
+            return <CompactionCard key={it.id} item={it} />;
         }
       })}
+    </div>
+  );
+}
+
+type CompactionItem = Extract<Item, { kind: "compaction" }>;
+
+// CompactionCard marks a context-compaction boundary in the transcript. While
+// the pass runs it shows a "compacting…" placeholder; once done it shows the
+// message count and trigger with the summary collapsed behind a toggle (the
+// summary is the new context base, so it's available but doesn't flood the view).
+function CompactionCard({ item }: { item: CompactionItem }) {
+  const [open, setOpen] = useState(false);
+  if (item.pending) {
+    return (
+      <div className="compaction compaction--pending">
+        <span className="compaction__spinner">⋯</span> Compacting conversation…
+      </div>
+    );
+  }
+  return (
+    <div className="compaction">
+      <button className="compaction__head" onClick={() => setOpen((v) => !v)}>
+        <span className="compaction__icon">◆</span>
+        <span className="compaction__title">Context compacted</span>
+        <span className="compaction__meta">
+          {item.messages} messages · {item.trigger}
+        </span>
+        <span className="compaction__toggle">{open ? "hide summary" : "show summary"}</span>
+      </button>
+      {open && <pre className="compaction__summary">{item.summary}</pre>}
     </div>
   );
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -13,7 +13,16 @@ export type EventKind =
   | "phase"
   | "approval_request"
   | "ask_request"
-  | "turn_done";
+  | "turn_done"
+  | "compaction_started"
+  | "compaction_done";
+
+export interface WireCompaction {
+  trigger?: string; // "auto" | "manual"
+  messages?: number; // done: how many messages were folded into the summary
+  summary?: string; // done: the briefing (empty on an aborted pass)
+  archive?: string; // done: archive path, if any
+}
 
 export interface WireTool {
   id?: string;
@@ -80,6 +89,7 @@ export interface WireEvent {
   usage?: WireUsage;
   approval?: WireApproval;
   ask?: WireAsk;
+  compaction?: WireCompaction;
   err?: string;
 }
 

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -30,6 +30,15 @@ export type Item =
   | { kind: "phase"; id: string; text: string }
   | { kind: "notice"; id: string; level: "info" | "warn"; text: string }
   | {
+      kind: "compaction";
+      id: string;
+      pending: boolean; // true between compaction_started and compaction_done
+      trigger: string; // "auto" | "manual"
+      messages: number;
+      summary: string;
+      archive: string;
+    }
+  | {
       kind: "tool";
       id: string;
       name: string;
@@ -258,6 +267,49 @@ function applyEvent(s: State, e: WireEvent): State {
         seq: s.seq + 1,
         items: [...s.items, { kind: "phase", id: `p${s.seq}`, text: e.text ?? "" }],
       };
+
+    case "compaction_started":
+      // Drop a pending card the moment the summarizer starts, so the user sees
+      // the pass is running rather than a frozen window.
+      return {
+        ...s,
+        seq: s.seq + 1,
+        items: [
+          ...s.items,
+          {
+            kind: "compaction",
+            id: `c${s.seq}`,
+            pending: true,
+            trigger: e.compaction?.trigger ?? "",
+            messages: 0,
+            summary: "",
+            archive: "",
+          },
+        ],
+      };
+
+    case "compaction_done": {
+      const c = e.compaction;
+      // An aborted pass (no summary) drops the pending placeholder; the
+      // accompanying notice explains why. Otherwise fill the last pending card.
+      const idx = [...s.items].reverse().findIndex((it) => it.kind === "compaction" && it.pending);
+      const at = idx < 0 ? -1 : s.items.length - 1 - idx;
+      if (!c?.summary) {
+        const items = at < 0 ? s.items : s.items.filter((_, i) => i !== at);
+        return { ...s, running: s.turnActive ? s.running : false, items };
+      }
+      const filled: Item = {
+        kind: "compaction",
+        id: at < 0 ? `c${s.seq}` : (s.items[at] as Extract<Item, { kind: "compaction" }>).id,
+        pending: false,
+        trigger: c.trigger ?? "",
+        messages: c.messages ?? 0,
+        summary: c.summary,
+        archive: c.archive ?? "",
+      };
+      const items = at < 0 ? [...s.items, filled] : s.items.map((it, i) => (i === at ? filled : it));
+      return { ...s, running: s.turnActive ? s.running : false, seq: s.seq + 1, items };
+    }
 
     case "approval_request":
       return { ...s, approval: e.approval };

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -796,6 +796,67 @@ body {
   color: var(--fg-faint);
 }
 
+/* ── compaction card ─────────────────────────────────────────────────────── */
+.compaction {
+  margin: 12px auto;
+  border: 1px solid var(--accent-soft, var(--border));
+  border-radius: var(--radius, 6px);
+  background: var(--bg-soft);
+  overflow: hidden;
+}
+.compaction--pending {
+  padding: 7px 12px;
+  font-size: 12.5px;
+  color: var(--fg-dim);
+  border-style: dashed;
+}
+.compaction__spinner {
+  color: var(--accent);
+}
+.compaction__head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--fg);
+  text-align: left;
+}
+.compaction__head:hover {
+  background: var(--bg-elev);
+}
+.compaction__icon {
+  color: var(--accent);
+}
+.compaction__title {
+  font-weight: 600;
+}
+.compaction__meta {
+  color: var(--fg-dim);
+}
+.compaction__toggle {
+  margin-left: auto;
+  color: var(--clickable, var(--accent));
+  font-size: 11.5px;
+}
+.compaction__summary {
+  margin: 0;
+  padding: 10px 12px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg-dim);
+  font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* ── footer: composer + status line ──────────────────────────────────────── */
 .footer {
   flex: 0 0 auto;

--- a/desktop/wire.go
+++ b/desktop/wire.go
@@ -12,15 +12,26 @@ import "reasonix/internal/event"
 // may diverge later; if they don't, this is the obvious thing to lift into a
 // shared event.ToWire.)
 type wireEvent struct {
-	Kind      string        `json:"kind"`
-	Text      string        `json:"text,omitempty"`
-	Reasoning string        `json:"reasoning,omitempty"`
-	Level     string        `json:"level,omitempty"`
-	Tool      *wireTool     `json:"tool,omitempty"`
-	Usage     *wireUsage    `json:"usage,omitempty"`
-	Approval  *wireApproval `json:"approval,omitempty"`
-	Ask       *wireAsk      `json:"ask,omitempty"`
-	Err       string        `json:"err,omitempty"`
+	Kind       string          `json:"kind"`
+	Text       string          `json:"text,omitempty"`
+	Reasoning  string          `json:"reasoning,omitempty"`
+	Level      string          `json:"level,omitempty"`
+	Tool       *wireTool       `json:"tool,omitempty"`
+	Usage      *wireUsage      `json:"usage,omitempty"`
+	Approval   *wireApproval   `json:"approval,omitempty"`
+	Ask        *wireAsk        `json:"ask,omitempty"`
+	Compaction *wireCompaction `json:"compaction,omitempty"`
+	Err        string          `json:"err,omitempty"`
+}
+
+// wireCompaction is the JSON form of an event.Compaction. On a compaction_started
+// event only Trigger is set; compaction_done carries the rest (an aborted pass
+// leaves Summary empty so the frontend drops its placeholder).
+type wireCompaction struct {
+	Trigger  string `json:"trigger,omitempty"`
+	Messages int    `json:"messages,omitempty"`
+	Summary  string `json:"summary,omitempty"`
+	Archive  string `json:"archive,omitempty"`
 }
 
 type wireAskOption struct {
@@ -75,18 +86,20 @@ type wireApproval struct {
 
 // kindNames maps the event.Kind enum to stable wire strings.
 var kindNames = map[event.Kind]string{
-	event.TurnStarted:     "turn_started",
-	event.Reasoning:       "reasoning",
-	event.Text:            "text",
-	event.Message:         "message",
-	event.ToolDispatch:    "tool_dispatch",
-	event.ToolResult:      "tool_result",
-	event.Usage:           "usage",
-	event.Notice:          "notice",
-	event.Phase:           "phase",
-	event.ApprovalRequest: "approval_request",
-	event.AskRequest:      "ask_request",
-	event.TurnDone:        "turn_done",
+	event.TurnStarted:       "turn_started",
+	event.Reasoning:         "reasoning",
+	event.Text:              "text",
+	event.Message:           "message",
+	event.ToolDispatch:      "tool_dispatch",
+	event.ToolResult:        "tool_result",
+	event.Usage:             "usage",
+	event.Notice:            "notice",
+	event.Phase:             "phase",
+	event.ApprovalRequest:   "approval_request",
+	event.AskRequest:        "ask_request",
+	event.TurnDone:          "turn_done",
+	event.CompactionStarted: "compaction_started",
+	event.CompactionDone:    "compaction_done",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.
@@ -135,6 +148,11 @@ func toWire(e event.Event) wireEvent {
 		w.Approval = &wireApproval{ID: e.Approval.ID, Tool: e.Approval.Tool, Subject: e.Approval.Subject}
 	case event.AskRequest:
 		w.Ask = toWireAsk(e.Ask)
+	case event.CompactionStarted, event.CompactionDone:
+		w.Compaction = &wireCompaction{
+			Trigger: e.Compaction.Trigger, Messages: e.Compaction.Messages,
+			Summary: e.Compaction.Summary, Archive: e.Compaction.Archive,
+		}
 	case event.TurnDone:
 		if e.Err != nil {
 			w.Err = e.Err.Error()

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -102,6 +103,16 @@ func (s *updateSink) Emit(e event.Event) {
 			s.send(messageChunk{
 				SessionUpdate: "agent_message_chunk",
 				Content:       textBlock("\n\n[warning] " + e.Text),
+			})
+		}
+
+	case event.CompactionDone:
+		// ACP has no compaction-card concept; surface a one-line note so the host
+		// knows the context was summarized (an aborted pass has no summary).
+		if e.Compaction.Summary != "" {
+			s.send(messageChunk{
+				SessionUpdate: "agent_message_chunk",
+				Content:       textBlock(fmt.Sprintf("\n\n[compacted %d earlier messages to save context]", e.Compaction.Messages)),
 			})
 		}
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -218,7 +218,7 @@ func (a *Agent) ContextWindow() int { return a.contextWindow }
 // usage-ratio threshold maybeCompact normally honours. Used by the chat
 // TUI's `/compact` command so the user can reset the prefix before it
 // naturally fills up.
-func (a *Agent) CompactNow(ctx context.Context) error { return a.compact(ctx) }
+func (a *Agent) CompactNow(ctx context.Context) error { return a.compact(ctx, "manual") }
 
 // Options configures an Agent.
 type Options struct {

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -24,15 +24,34 @@ const (
 )
 
 // summarySystemPrompt steers the executor to distill older history into a
-// briefing it can keep relying on after the originals are dropped.
+// structured briefing it can keep relying on after the originals are dropped.
+// The section layout mirrors what a coding agent actually needs to resume work
+// mid-task: the goal verbatim, the concrete state of the code, and an explicit
+// next step — so the post-compaction turn doesn't lose the thread or re-derive
+// decisions already made.
 const summarySystemPrompt = `You are compacting the earlier part of a coding agent's conversation to save context.
-Summarize the messages below into a compact briefing the agent can rely on to continue the task. Preserve:
-- the user's goal and any explicit requirements or constraints
-- key decisions made and their rationale
-- files read or modified and the important facts learned about them
-- commands run and their relevant outcomes
-- what is still pending or in progress
-Omit small talk and redundant detail. Use terse bullet points. Do not invent information.`
+The agent will keep ONLY your summary (the original messages are dropped), so it must be able to resume the task from it alone.
+Write a briefing under these exact headings, omitting a heading only if it has no content:
+
+## Goal
+The user's request and intent, kept close to their own words. Include explicit requirements, constraints, and preferences.
+
+## Decisions & rationale
+Key choices made so far and why — so they are not re-litigated or reversed.
+
+## Files & code
+Files read or modified, with the specific facts that matter: signatures, line locations, data shapes, and exact edits applied. Be concrete; this is what lets the agent act without re-reading everything.
+
+## Commands & outcomes
+Commands run (builds, tests, git) and their relevant results — what passed, what failed, and the error text that matters.
+
+## Errors & fixes
+Problems hit and how they were resolved (or not), so the same dead ends are not repeated.
+
+## Pending & next step
+What is still in progress or unstarted, and the single most concrete next action to take.
+
+Rules: be terse — bullet points and fragments, not prose. Preserve identifiers, paths, and numbers exactly. Do NOT invent anything not present in the messages; if something is unknown, leave it out rather than guessing.`
 
 // maybeCompact compacts the session when the last turn's prompt has grown to the
 // configured fraction of the context window. It is a no-op when compaction is
@@ -44,15 +63,19 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	if u.PromptTokens < int(float64(a.contextWindow)*a.compactRatio) {
 		return
 	}
-	if err := a.compact(ctx); err != nil {
+	if err := a.compact(ctx, "auto"); err != nil {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("compaction skipped: %v", err)})
 	}
 }
 
 // compact summarizes the older middle of the session and replaces it in place:
 // the session becomes system + summary + recent tail. The dropped originals are
-// archived first, so the full history stays traceable.
-func (a *Agent) compact(ctx context.Context) error {
+// archived first, so the full history stays traceable. trigger is "auto" (the
+// window threshold) or "manual" (/compact); it rides the Compaction events so a
+// frontend can label the card. A Started event is emitted before the (network)
+// summarize so the UI can show a "compacting…" placeholder, and a Done event
+// (carrying the summary) replaces it.
+func (a *Agent) compact(ctx context.Context, trigger string) error {
 	msgs := a.session.Messages
 	head, start, ok := compactBounds(msgs, a.recentKeep, minCompactMessages)
 	if !ok {
@@ -60,10 +83,13 @@ func (a *Agent) compact(ctx context.Context) error {
 	}
 	region := msgs[head:start]
 
+	a.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
+
 	archived := ""
 	if a.archiveDir != "" {
 		path, err := archiveMessages(a.archiveDir, region)
 		if err != nil {
+			a.emitCompactionAborted(trigger)
 			return fmt.Errorf("archive: %w", err)
 		}
 		archived = path
@@ -71,6 +97,7 @@ func (a *Agent) compact(ctx context.Context) error {
 
 	summary, err := a.summarize(ctx, region)
 	if err != nil {
+		a.emitCompactionAborted(trigger)
 		return err
 	}
 
@@ -83,12 +110,18 @@ func (a *Agent) compact(ctx context.Context) error {
 	compacted = append(compacted, msgs[start:]...)
 	a.session.Messages = compacted
 
-	note := fmt.Sprintf("compacted %d messages → summary", len(region))
-	if archived != "" {
-		note += " (archived " + archived + ")"
-	}
-	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: note})
+	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
+		Trigger: trigger, Messages: len(region), Summary: summary, Archive: archived,
+	}})
 	return nil
+}
+
+// emitCompactionAborted resolves a "compacting…" placeholder when a pass fails
+// after the Started event: a Done with no summary tells a frontend to drop the
+// placeholder. The caller still surfaces the reason (a Notice), so this carries
+// no text of its own.
+func (a *Agent) emitCompactionAborted(trigger string) {
+	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{Trigger: trigger}})
 }
 
 // SummarizeFrom replaces the messages from fromIdx onward with a single summary,

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -87,7 +87,7 @@ func TestCompactReplacesHistory(t *testing.T) {
 	dir := t.TempDir()
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: dir}, event.Discard)
 
-	if err := a.compact(context.Background()); err != nil {
+	if err := a.compact(context.Background(), "manual"); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -120,6 +120,55 @@ func TestCompactReplacesHistory(t *testing.T) {
 	}
 	if !strings.HasSuffix(entries[0].Name(), ".jsonl") {
 		t.Errorf("archive name = %q, want .jsonl", entries[0].Name())
+	}
+}
+
+// TestCompactEmitsEvents covers the card-driving signals: a CompactionStarted
+// (before the summarizer runs) then a CompactionDone carrying the trigger,
+// message count, and summary — in that order.
+func TestCompactEmitsEvents(t *testing.T) {
+	prov := &fakeProvider{reply: "- goal: do X"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: "step one"},
+		{Role: provider.RoleUser, Content: "more"},
+		{Role: provider.RoleAssistant, Content: "step two"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	var got []event.Event
+	sink := event.FuncSink(func(e event.Event) { got = append(got, e) })
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2}, sink)
+
+	if err := a.compact(context.Background(), "auto"); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	startedAt, doneAt := -1, -1
+	for i, e := range got {
+		switch e.Kind {
+		case event.CompactionStarted:
+			startedAt = i
+			if e.Compaction.Trigger != "auto" {
+				t.Errorf("started trigger = %q, want auto", e.Compaction.Trigger)
+			}
+		case event.CompactionDone:
+			doneAt = i
+			c := e.Compaction
+			if c.Trigger != "auto" || c.Messages == 0 || !strings.Contains(c.Summary, "do X") {
+				t.Errorf("done event = %+v", c)
+			}
+		}
+	}
+	if startedAt < 0 {
+		t.Fatal("no CompactionStarted event emitted")
+	}
+	if doneAt < 0 {
+		t.Fatal("no CompactionDone event emitted")
+	}
+	if startedAt > doneAt {
+		t.Errorf("CompactionStarted (%d) must precede CompactionDone (%d)", startedAt, doneAt)
 	}
 }
 

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -18,7 +18,7 @@ import (
 // the model re-words the payload).
 type failTool struct{ name string }
 
-func (f failTool) Name() string           { return f.name }
+func (f failTool) Name() string            { return f.name }
 func (f failTool) Description() string     { return "always fails" }
 func (f failTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
 func (f failTool) ReadOnly() bool          { return true }
@@ -29,10 +29,10 @@ func (f failTool) Execute(context.Context, json.RawMessage) (string, error) {
 // okTool always succeeds — a turn of real progress that breaks a failing run.
 type okTool struct{ name string }
 
-func (o okTool) Name() string                                   { return o.name }
-func (o okTool) Description() string                            { return "always succeeds" }
-func (o okTool) Schema() json.RawMessage                        { return json.RawMessage(`{"type":"object"}`) }
-func (o okTool) ReadOnly() bool                                 { return true }
+func (o okTool) Name() string                                             { return o.name }
+func (o okTool) Description() string                                      { return "always succeeds" }
+func (o okTool) Schema() json.RawMessage                                  { return json.RawMessage(`{"type":"object"}`) }
+func (o okTool) ReadOnly() bool                                           { return true }
 func (o okTool) Execute(context.Context, json.RawMessage) (string, error) { return "ok", nil }
 
 func warnNoticeRecorder() (event.Sink, *[]string) {
@@ -113,10 +113,10 @@ func TestStormBreakerResetsOnSuccess(t *testing.T) {
 	good := provider.ToolCall{Name: "read_file", Arguments: `{"path":"x"}`}
 	ctx := context.Background()
 
-	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 1
-	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 2
-	a.executeBatch(ctx, []provider.ToolCall{good}) // success → reset
-	a.executeBatch(ctx, []provider.ToolCall{fail}) // count 1
+	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
+	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 2
+	a.executeBatch(ctx, []provider.ToolCall{good})            // success → reset
+	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
 	last := a.executeBatch(ctx, []provider.ToolCall{fail})[0] // count 2 — still below threshold
 
 	if strings.Contains(last, "[loop guard]") {

--- a/internal/agent/textsink.go
+++ b/internal/agent/textsink.go
@@ -102,6 +102,21 @@ func (s *TextSink) Emit(e event.Event) {
 		}
 		fmt.Fprintf(s.out, "[%s]\n", e.Text)
 		s.wroteAnything = true
+
+	case event.CompactionStarted:
+		fmt.Fprintln(s.out, dimText("  ⋯ compacting conversation…"))
+		s.wroteAnything = true
+
+	case event.CompactionDone:
+		c := e.Compaction
+		if c.Summary == "" {
+			break // aborted pass — the caller's Notice already explained why
+		}
+		fmt.Fprintln(s.out, dimText(fmt.Sprintf("  ⋯ compacted %d messages (%s)", c.Messages, c.Trigger)))
+		for _, ln := range strings.Split(strings.TrimRight(c.Summary, "\n"), "\n") {
+			fmt.Fprintln(s.out, dimText("    "+ln))
+		}
+		s.wroteAnything = true
 	}
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -153,6 +153,11 @@ const (
 // agentEventMsg is one typed event from the agent's run loop.
 type agentEventMsg event.Event
 
+// compactDoneMsg reports that an async /compact pass returned. The card was
+// already drawn from the CompactionDone event; this only surfaces a failure and
+// snapshots on success.
+type compactDoneMsg struct{ err error }
+
 // elapsedTickMsg fires once a second while a turn runs, driving the "thinking
 // Ns" counter in the status line.
 type elapsedTickMsg struct{}
@@ -467,6 +472,13 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case balanceMsg:
 		m.balance = msg.text
+
+	case compactDoneMsg:
+		if msg.err != nil {
+			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashCompactFailed, msg.err))
+		} else {
+			_ = m.ctrl.Snapshot()
+		}
 
 	case promptResolvedMsg:
 		switch {
@@ -819,6 +831,29 @@ func (m chatTUI) View() tea.View {
 	return v
 }
 
+// compactionCardLines renders a finished compaction as a titled card: a header
+// with the message count and trigger, then the structured summary under a dim
+// gutter so it reads as one block in scrollback. The summary is also the new
+// context base, so this card is the user's window into exactly what was kept.
+func compactionCardLines(c event.Compaction) []string {
+	trigger := c.Trigger
+	switch c.Trigger {
+	case "auto":
+		trigger = i18n.M.CompactionAuto
+	case "manual":
+		trigger = i18n.M.CompactionManual
+	}
+	header := fmt.Sprintf("%s · %d %s · %s", i18n.M.CompactionTitle, c.Messages, i18n.M.CompactionUnit, trigger)
+	lines := []string{accent("◆ " + header)}
+	for _, ln := range strings.Split(strings.TrimRight(c.Summary, "\n"), "\n") {
+		lines = append(lines, dim("  │ "+ln))
+	}
+	if c.Archive != "" {
+		lines = append(lines, dim("  │ archived "+c.Archive))
+	}
+	return lines
+}
+
 // contextTag renders the prompt-vs-context-window gauge for the status line.
 func (m chatTUI) contextTag() string {
 	used, window := m.ctrl.ContextSnapshot()
@@ -1162,6 +1197,21 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		m.finalizeStreamed()
 		m.commitLine(fmt.Sprintf("  %s %s", glyph, e.Text))
 
+	case event.CompactionStarted:
+		m.finalizeStreamed()
+		m.commitLine(dim("  ⋯ " + i18n.M.CompactionWorking))
+
+	case event.CompactionDone:
+		// An aborted pass carries no summary; the accompanying Notice (auto) or
+		// compactDoneMsg error (manual) explains why, so don't draw an empty card.
+		if e.Compaction.Summary == "" {
+			break
+		}
+		m.finalizeStreamed()
+		for _, ln := range compactionCardLines(e.Compaction) {
+			m.commitLine(ln)
+		}
+
 	case event.Phase:
 		m.finalizeStreamed()
 		m.commitLine(fmt.Sprintf("[%s]", e.Text))
@@ -1232,12 +1282,11 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 
 	switch cmd {
 	case "/compact":
-		if err := m.ctrl.Compact(context.Background()); err != nil {
-			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashCompactFailed, err))
-			return nil
-		}
-		m.notice(i18n.M.SlashCompactDone)
-		_ = m.ctrl.Snapshot()
+		// Compaction makes a (network) summarizer call; run it off the Update loop
+		// so the TUI doesn't freeze. The CompactionStarted/Done events render the
+		// card as they arrive; compactDoneMsg only handles the terminal error /
+		// snapshot once the pass returns.
+		return func() tea.Msg { return compactDoneMsg{err: m.ctrl.Compact(context.Background())} }
 	case "/new":
 		if err := m.ctrl.NewSession(); err != nil {
 			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashNewFailed, err))

--- a/internal/cli/compaction_test.go
+++ b/internal/cli/compaction_test.go
@@ -1,0 +1,46 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+// TestCompactionCardLines locks the finished-compaction card: a header naming
+// the count and trigger, the summary under a gutter, and an archive line.
+func TestCompactionCardLines(t *testing.T) {
+	lines := compactionCardLines(event.Compaction{
+		Trigger:  "auto",
+		Messages: 12,
+		Summary:  "## Goal\n- do X\n## Files & code\n- a.go edited",
+		Archive:  "/tmp/arch/20260531.jsonl",
+	})
+
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(lines[0], "◆") {
+		t.Errorf("header should carry the card glyph, got %q", lines[0])
+	}
+	for _, want := range []string{"Context compacted", "12", "auto"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("header missing %q: %q", want, lines[0])
+		}
+	}
+	// Every summary line (and the archive line) sits under the "│" gutter.
+	for _, want := range []string{"│ ## Goal", "│ - do X", "│ - a.go edited", "│ archived /tmp/arch/20260531.jsonl"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("card missing gutter line %q in:\n%s", want, joined)
+		}
+	}
+}
+
+// TestCompactionCardLinesNoArchive omits the archive line when none was written.
+func TestCompactionCardLinesNoArchive(t *testing.T) {
+	lines := compactionCardLines(event.Compaction{Trigger: "manual", Messages: 3, Summary: "- brief"})
+	if strings.Contains(strings.Join(lines, "\n"), "archived") {
+		t.Errorf("no archive path should mean no archive line: %v", lines)
+	}
+	if !strings.Contains(lines[0], "manual") {
+		t.Errorf("header should reflect the manual trigger: %q", lines[0])
+	}
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -54,6 +54,15 @@ const (
 	// nil also for a user cancellation, which is not an error). Always the
 	// last event of a turn.
 	TurnDone
+	// CompactionStarted marks the start of a context-compaction pass (Compaction
+	// payload: Trigger). A frontend shows a "compacting…" placeholder while the
+	// summarizer runs; CompactionDone replaces it. Mirrors ToolDispatch/ToolResult.
+	CompactionStarted
+	// CompactionDone reports a finished compaction pass (Compaction payload:
+	// Trigger/Messages/Summary/Archive). An aborted pass emits this with an empty
+	// Summary so the placeholder still resolves. Replaces the older plain Notice
+	// so a sink can render a distinct, expandable card.
+	CompactionDone
 )
 
 // Level classifies a Notice so sinks can style or filter it.
@@ -115,6 +124,18 @@ type Ask struct {
 	Questions []AskQuestion
 }
 
+// Compaction carries a context-compaction pass for the CompactionStarted /
+// CompactionDone events. On CompactionStarted only Trigger is set. On
+// CompactionDone, Messages/Summary/Archive are filled in (an aborted pass leaves
+// Summary empty). Trigger is "auto" (the prompt reached the window threshold) or
+// "manual" (the user ran /compact).
+type Compaction struct {
+	Trigger  string // "auto" | "manual"
+	Messages int    // Done: how many messages were folded into the summary
+	Summary  string // Done: the briefing the agent keeps relying on
+	Archive  string // Done: path the dropped originals were archived to ("" if none)
+}
+
 // AskAnswer is the user's reply to one AskQuestion: the chosen option label(s)
 // (a free-typed answer is carried as a single Selected entry).
 type AskAnswer struct {
@@ -135,12 +156,13 @@ type Event struct {
 	// session (Usage events only), so a frontend can show the aggregate hit-rate
 	// — which doesn't crater on a short turn or after compaction — alongside
 	// Usage's single-turn numbers.
-	SessionHit  int      // Usage: cumulative cache-hit prompt tokens this session
-	SessionMiss int      // Usage: cumulative cache-miss prompt tokens this session
-	Level       Level    // Notice
-	Approval    Approval // ApprovalRequest
-	Ask         Ask      // AskRequest
-	Err         error    // TurnDone: non-nil on failure
+	SessionHit  int        // Usage: cumulative cache-hit prompt tokens this session
+	SessionMiss int        // Usage: cumulative cache-miss prompt tokens this session
+	Level       Level      // Notice
+	Approval    Approval   // ApprovalRequest
+	Ask         Ask        // AskRequest
+	Err         error      // TurnDone: non-nil on failure
+	Compaction  Compaction // Compaction
 }
 
 // Sink consumes a turn's events. The agent calls Emit serially from its run

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -68,6 +68,13 @@ type Messages struct {
 	AskChatInstead     string // the "don't pick, just chat" option label
 	ChatStatusQuestion string // shortcuts hint while a question card is open
 
+	// context compaction card (CompactionStarted / CompactionDone events).
+	CompactionWorking string // shown while the summarizer runs
+	CompactionTitle   string // card header before "· N messages · <trigger>"
+	CompactionUnit    string // the noun counted, e.g. "messages"
+	CompactionAuto    string // trigger label: reached the window threshold
+	CompactionManual  string // trigger label: user ran /compact
+
 	// chat TUI slash commands.
 	SlashCompactDone   string // "/compact" succeeded
 	SlashCompactFailed string // "/compact" errored, prefixed before the underlying error

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -41,6 +41,12 @@ var English = Messages{
 	ChatStatusQuestion:     "↑/↓ move · number to pick · space multi · Enter confirm · ←/→ switch · Esc cancel",
 	ToolApprovalPromptFmt:  "Allow %s%s? — [y] once · [a] this session · [n] no",
 
+	CompactionWorking: "compacting conversation…",
+	CompactionTitle:   "Context compacted",
+	CompactionUnit:    "messages",
+	CompactionAuto:    "auto",
+	CompactionManual:  "manual",
+
 	SlashCompactDone:   "session compacted — older middle replaced by a summary, recent turns kept",
 	SlashCompactFailed: "compaction failed",
 	SlashNewDone:       "fresh session started — previous transcript saved",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -42,6 +42,12 @@ var Chinese = Messages{
 	ChatStatusQuestion:     "↑/↓ 选 · 数字快选 · 空格多选 · Enter 确认 · ←/→ 切换问题 · Esc 取消",
 	ToolApprovalPromptFmt:  "允许 %s%s？— [y] 本次 · [a] 本会话 · [n] 拒绝",
 
+	CompactionWorking: "正在压缩对话…",
+	CompactionTitle:   "上下文已压缩",
+	CompactionUnit:    "条消息",
+	CompactionAuto:    "自动",
+	CompactionManual:  "手动",
+
 	SlashCompactDone:   "已压缩 — 旧的中段换成一段摘要，最近几轮保留原样",
 	SlashCompactFailed: "压缩失败",
 	SlashNewDone:       "已新建会话 — 之前的对话已存档",

--- a/internal/serve/wire.go
+++ b/internal/serve/wire.go
@@ -8,15 +8,26 @@ import "reasonix/internal/event"
 // error becomes a message — so a browser frontend renders the same typed stream
 // the TUI does.
 type wireEvent struct {
-	Kind      string        `json:"kind"`
-	Text      string        `json:"text,omitempty"`
-	Reasoning string        `json:"reasoning,omitempty"`
-	Level     string        `json:"level,omitempty"`
-	Tool      *wireTool     `json:"tool,omitempty"`
-	Usage     *wireUsage    `json:"usage,omitempty"`
-	Approval  *wireApproval `json:"approval,omitempty"`
-	Ask       *wireAsk      `json:"ask,omitempty"`
-	Err       string        `json:"err,omitempty"`
+	Kind       string          `json:"kind"`
+	Text       string          `json:"text,omitempty"`
+	Reasoning  string          `json:"reasoning,omitempty"`
+	Level      string          `json:"level,omitempty"`
+	Tool       *wireTool       `json:"tool,omitempty"`
+	Usage      *wireUsage      `json:"usage,omitempty"`
+	Approval   *wireApproval   `json:"approval,omitempty"`
+	Ask        *wireAsk        `json:"ask,omitempty"`
+	Compaction *wireCompaction `json:"compaction,omitempty"`
+	Err        string          `json:"err,omitempty"`
+}
+
+// wireCompaction is the JSON form of an event.Compaction. On a compaction_started
+// event only Trigger is set; compaction_done carries the rest (an aborted pass
+// leaves Summary empty so the frontend drops its placeholder).
+type wireCompaction struct {
+	Trigger  string `json:"trigger,omitempty"`
+	Messages int    `json:"messages,omitempty"`
+	Summary  string `json:"summary,omitempty"`
+	Archive  string `json:"archive,omitempty"`
 }
 
 type wireAskOption struct {
@@ -71,18 +82,20 @@ type wireApproval struct {
 
 // kindNames maps the event.Kind enum to stable wire strings.
 var kindNames = map[event.Kind]string{
-	event.TurnStarted:     "turn_started",
-	event.Reasoning:       "reasoning",
-	event.Text:            "text",
-	event.Message:         "message",
-	event.ToolDispatch:    "tool_dispatch",
-	event.ToolResult:      "tool_result",
-	event.Usage:           "usage",
-	event.Notice:          "notice",
-	event.Phase:           "phase",
-	event.ApprovalRequest: "approval_request",
-	event.AskRequest:      "ask_request",
-	event.TurnDone:        "turn_done",
+	event.TurnStarted:       "turn_started",
+	event.Reasoning:         "reasoning",
+	event.Text:              "text",
+	event.Message:           "message",
+	event.ToolDispatch:      "tool_dispatch",
+	event.ToolResult:        "tool_result",
+	event.Usage:             "usage",
+	event.Notice:            "notice",
+	event.Phase:             "phase",
+	event.ApprovalRequest:   "approval_request",
+	event.AskRequest:        "ask_request",
+	event.TurnDone:          "turn_done",
+	event.CompactionStarted: "compaction_started",
+	event.CompactionDone:    "compaction_done",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.
@@ -131,6 +144,11 @@ func toWire(e event.Event) wireEvent {
 		w.Approval = &wireApproval{ID: e.Approval.ID, Tool: e.Approval.Tool, Subject: e.Approval.Subject}
 	case event.AskRequest:
 		w.Ask = toWireAsk(e.Ask)
+	case event.CompactionStarted, event.CompactionDone:
+		w.Compaction = &wireCompaction{
+			Trigger: e.Compaction.Trigger, Messages: e.Compaction.Messages,
+			Summary: e.Compaction.Summary, Archive: e.Compaction.Archive,
+		}
 	case event.TurnDone:
 		if e.Err != nil {
 			w.Err = e.Err.Error()


### PR DESCRIPTION
Context compaction was nearly invisible — a single info `Notice` ("compacted N messages → summary"), no in-progress signal, no way to see what was kept, and a thin five-bullet summary. This gives the pass a dedicated, structured card on every frontend.

## Backend
- **event**: new `CompactionStarted` / `CompactionDone` kinds + a `Compaction` payload (trigger, message count, summary, archive), mirroring `ToolDispatch`/`ToolResult`.
- **agent**: emit `Started` before the (network) summarize so a frontend shows a "compacting…" placeholder, then `Done` carrying the summary; an aborted pass resolves the placeholder. Trigger threaded (auto vs manual `/compact`).
- **agent**: summary prompt rewritten into a structured briefing (goal · decisions · files & code · commands & outcomes · errors & fixes · pending & next step) so the post-compaction turn can resume the task.

## Frontends
- **cli**: titled card (count · trigger, summary under a gutter); `/compact` now runs off the Update loop so the TUI no longer freezes during the pass.
- **desktop**: collapsible compaction card (pending → filled) in the transcript + styles.
- **headless `run` + acp**: surface the pass too.
- **i18n**: en/zh strings.

## Verification
- Unit tests: event emission, CLI card rendering.
- Full `go test ./...` + desktop `go test ./...` + `tsc --noEmit` green; gofmt clean.
- Live auto-compaction against DeepSeek (tiny context_window): shows the placeholder, the structured summary, and the card.
