### PR TITLE
feat(hooks): add lifecycle hook events + compaction focus & headroom

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -153,11 +153,13 @@ func (a *App) AnswerQuestion(id string, answers []QuestionAnswer) {
 }
 
 // Compact runs one compaction pass on demand.
+// Compact runs a plain compaction pass (the "compact now" button). Focus-guided
+// compaction goes through Submit("/compact <focus>") instead.
 func (a *App) Compact() error {
 	if a.ctrl == nil {
 		return nil
 	}
-	return a.ctrl.Compact(a.ctx)
+	return a.ctrl.Compact(a.ctx, "")
 }
 
 // NewSession snapshots the current conversation and rotates to a fresh one.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -88,6 +88,11 @@ type Gate interface {
 type ToolHooks interface {
 	PreToolUse(ctx context.Context, name string, args json.RawMessage) (block bool, message string)
 	PostToolUse(ctx context.Context, name string, args json.RawMessage, result string)
+	// SubagentStop fires when a `task` sub-agent finishes (foreground). PreCompact
+	// fires just before a compaction pass and returns extra summary guidance (its
+	// hooks' stdout) to fold into the summary prompt; "" when no hook contributes.
+	SubagentStop(ctx context.Context, last string)
+	PreCompact(ctx context.Context, trigger string) string
 }
 
 // Agent drives a single task: a Provider, a tool Registry, and a Session wired
@@ -214,11 +219,17 @@ func (a *Agent) SessionCache() (hit, miss int) { return a.sessCacheHit, a.sessCa
 // means compaction is disabled for this agent.
 func (a *Agent) ContextWindow() int { return a.contextWindow }
 
+// CompactRatio returns the fraction of the window at which auto-compaction
+// fires (e.g. 0.8). The status line uses it to show headroom to the next compact.
+func (a *Agent) CompactRatio() float64 { return a.compactRatio }
+
 // CompactNow runs one compaction pass immediately, regardless of the
 // usage-ratio threshold maybeCompact normally honours. Used by the chat
 // TUI's `/compact` command so the user can reset the prefix before it
 // naturally fills up.
-func (a *Agent) CompactNow(ctx context.Context) error { return a.compact(ctx, "manual") }
+func (a *Agent) CompactNow(ctx context.Context, instructions string) error {
+	return a.compact(ctx, "manual", instructions)
+}
 
 // Options configures an Agent.
 type Options struct {
@@ -591,8 +602,24 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		body, truncMsg := truncateToolOutput(fmt.Sprintf("error: %v\n%s", err, result))
 		return toolOutcome{output: body, errMsg: firstLine(err.Error()), truncated: truncMsg != "", truncMsg: truncMsg}
 	}
+	// A foreground `task` sub-agent just finished — its result is the final answer.
+	// (A backgrounded one returns a "Started…" string and stops later in a job, so
+	// it doesn't fire here.) SubagentStop lets a hook react to delegated work.
+	if a.hooks != nil && call.Name == "task" && !isBackgroundTaskCall(call.Arguments) {
+		a.hooks.SubagentStop(ctx, result)
+	}
 	body, truncMsg := truncateToolOutput(result)
 	return toolOutcome{output: body, truncated: truncMsg != "", truncMsg: truncMsg}
+}
+
+// isBackgroundTaskCall reports whether a `task` call set run_in_background, so a
+// fire-and-return dispatch isn't mistaken for a sub-agent that has stopped.
+func isBackgroundTaskCall(args string) bool {
+	var p struct {
+		RunInBackground bool `json:"run_in_background"`
+	}
+	_ = json.Unmarshal([]byte(args), &p)
+	return p.RunInBackground
 }
 
 // toolReadOnly reports a tool's ReadOnly classification by name (false for an

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -63,7 +63,7 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	if u.PromptTokens < int(float64(a.contextWindow)*a.compactRatio) {
 		return
 	}
-	if err := a.compact(ctx, "auto"); err != nil {
+	if err := a.compact(ctx, "auto", ""); err != nil {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("compaction skipped: %v", err)})
 	}
 }
@@ -72,10 +72,11 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 // the session becomes system + summary + recent tail. The dropped originals are
 // archived first, so the full history stays traceable. trigger is "auto" (the
 // window threshold) or "manual" (/compact); it rides the Compaction events so a
-// frontend can label the card. A Started event is emitted before the (network)
-// summarize so the UI can show a "compacting…" placeholder, and a Done event
-// (carrying the summary) replaces it.
-func (a *Agent) compact(ctx context.Context, trigger string) error {
+// frontend can label the card. instructions is optional extra summary guidance
+// (the user's `/compact <focus>` text); a PreCompact hook can contribute more. A
+// Started event is emitted before the (network) summarize so the UI can show a
+// "compacting…" placeholder, and a Done event (carrying the summary) replaces it.
+func (a *Agent) compact(ctx context.Context, trigger, instructions string) error {
 	msgs := a.session.Messages
 	head, start, ok := compactBounds(msgs, a.recentKeep, minCompactMessages)
 	if !ok {
@@ -84,6 +85,17 @@ func (a *Agent) compact(ctx context.Context, trigger string) error {
 	region := msgs[head:start]
 
 	a.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
+
+	// A PreCompact hook can steer what the summary keeps; its stdout joins any
+	// explicit /compact <focus> text.
+	if a.hooks != nil {
+		if hookInstr := a.hooks.PreCompact(ctx, trigger); hookInstr != "" {
+			if instructions != "" {
+				instructions += "\n"
+			}
+			instructions += hookInstr
+		}
+	}
 
 	archived := ""
 	if a.archiveDir != "" {
@@ -95,7 +107,7 @@ func (a *Agent) compact(ctx context.Context, trigger string) error {
 		archived = path
 	}
 
-	summary, err := a.summarize(ctx, region)
+	summary, err := a.summarize(ctx, region, instructions)
 	if err != nil {
 		a.emitCompactionAborted(trigger)
 		return err
@@ -137,7 +149,7 @@ func (a *Agent) SummarizeFrom(ctx context.Context, fromIdx int) error {
 	if a.archiveDir != "" {
 		_, _ = archiveMessages(a.archiveDir, region) // best-effort traceability
 	}
-	summary, err := a.summarize(ctx, region)
+	summary, err := a.summarize(ctx, region, "")
 	if err != nil {
 		return err
 	}
@@ -169,7 +181,7 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	if a.archiveDir != "" {
 		_, _ = archiveMessages(a.archiveDir, region)
 	}
-	summary, err := a.summarize(ctx, region)
+	summary, err := a.summarize(ctx, region, "")
 	if err != nil {
 		return err
 	}
@@ -210,11 +222,17 @@ func compactBounds(msgs []provider.Message, recentKeep, minCompact int) (head, s
 }
 
 // summarize asks the executor's own provider (no tools) to distill the region
-// into a briefing, returning the collected text.
-func (a *Agent) summarize(ctx context.Context, region []provider.Message) (string, error) {
+// into a briefing, returning the collected text. instructions, when non-empty,
+// is appended to the system prompt as extra focus guidance (from /compact <focus>
+// and/or a PreCompact hook).
+func (a *Agent) summarize(ctx context.Context, region []provider.Message, instructions string) (string, error) {
+	sys := summarySystemPrompt
+	if strings.TrimSpace(instructions) != "" {
+		sys += "\n\nAdditional focus for this compaction (prioritize keeping this):\n" + strings.TrimSpace(instructions)
+	}
 	ch, err := a.prov.Stream(ctx, provider.Request{
 		Messages: []provider.Message{
-			{Role: provider.RoleSystem, Content: summarySystemPrompt},
+			{Role: provider.RoleSystem, Content: sys},
 			{Role: provider.RoleUser, Content: renderTranscript(region)},
 		},
 		Temperature: a.temperature,

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -87,7 +87,7 @@ func TestCompactReplacesHistory(t *testing.T) {
 	dir := t.TempDir()
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: dir}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual"); err != nil {
+	if err := a.compact(context.Background(), "manual", ""); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -141,7 +141,7 @@ func TestCompactEmitsEvents(t *testing.T) {
 	sink := event.FuncSink(func(e event.Event) { got = append(got, e) })
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2}, sink)
 
-	if err := a.compact(context.Background(), "auto"); err != nil {
+	if err := a.compact(context.Background(), "auto", ""); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -169,6 +169,36 @@ func TestCompactEmitsEvents(t *testing.T) {
 	}
 	if startedAt > doneAt {
 		t.Errorf("CompactionStarted (%d) must precede CompactionDone (%d)", startedAt, doneAt)
+	}
+}
+
+// TestCompactInjectsFocusAndPreCompactHook checks that /compact <focus> text and
+// a PreCompact hook's output both reach the summarizer's system prompt.
+func TestCompactInjectsFocusAndPreCompactHook(t *testing.T) {
+	prov := &fakeProvider{reply: "- ok"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: "step one"},
+		{Role: provider.RoleUser, Content: "more"},
+		{Role: provider.RoleAssistant, Content: "step two"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, Hooks: &stubHooks{preCompactOut: "KEEP-THE-MIGRATION-PLAN"}}, event.Discard)
+
+	if err := a.compact(context.Background(), "manual", "focus on the auth refactor"); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if len(prov.got) == 0 || prov.got[0].Role != provider.RoleSystem {
+		t.Fatalf("summarizer wasn't asked with a system prompt: %+v", prov.got)
+	}
+	sys := prov.got[0].Content
+	if !strings.Contains(sys, "focus on the auth refactor") {
+		t.Errorf("summary system prompt missing the /compact focus text: %q", sys)
+	}
+	if !strings.Contains(sys, "KEEP-THE-MIGRATION-PLAN") {
+		t.Errorf("summary system prompt missing the PreCompact hook output: %q", sys)
 	}
 }
 

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -13,9 +13,11 @@ import (
 
 // stubHooks blocks PreToolUse for named tools and records what it saw.
 type stubHooks struct {
-	blockPre map[string]bool
-	preSeen  []string
-	postSeen []string
+	blockPre      map[string]bool
+	preSeen       []string
+	postSeen      []string
+	preCompactOut string   // returned from PreCompact (extra summary guidance)
+	subagentSeen  []string // last-answer text passed to each SubagentStop
 }
 
 func (h *stubHooks) PreToolUse(_ context.Context, name string, _ json.RawMessage) (bool, string) {
@@ -28,6 +30,31 @@ func (h *stubHooks) PreToolUse(_ context.Context, name string, _ json.RawMessage
 
 func (h *stubHooks) PostToolUse(_ context.Context, name string, _ json.RawMessage, _ string) {
 	h.postSeen = append(h.postSeen, name)
+}
+
+func (h *stubHooks) SubagentStop(_ context.Context, last string) {
+	h.subagentSeen = append(h.subagentSeen, last)
+}
+func (h *stubHooks) PreCompact(context.Context, string) string { return h.preCompactOut }
+
+// TestSubagentStopFiresForForegroundTask checks SubagentStop fires (with the
+// sub-agent's answer) when a foreground `task` call completes, but not for a
+// backgrounded one (which only returns a "started" handle and stops later).
+func TestSubagentStopFiresForForegroundTask(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(okTool{name: "task"}) // stands in for the real task tool; returns "ok"
+	h := &stubHooks{}
+	a := New(nil, reg, NewSession(""), Options{Hooks: h}, event.Discard)
+
+	a.executeBatch(context.Background(), []provider.ToolCall{{Name: "task", Arguments: `{"prompt":"x"}`}})
+	if len(h.subagentSeen) != 1 || h.subagentSeen[0] != "ok" {
+		t.Fatalf("foreground task should fire SubagentStop with the answer, saw %v", h.subagentSeen)
+	}
+
+	a.executeBatch(context.Background(), []provider.ToolCall{{Name: "task", Arguments: `{"run_in_background":true}`}})
+	if len(h.subagentSeen) != 1 {
+		t.Errorf("backgrounded task must not fire SubagentStop, saw %v", h.subagentSeen)
+	}
 }
 
 // TestPreToolUseHookBlocks proves a gating PreToolUse hook refuses a tool call

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -854,18 +854,41 @@ func compactionCardLines(c event.Compaction) []string {
 	return lines
 }
 
-// contextTag renders the prompt-vs-context-window gauge for the status line.
+// contextTag renders the prompt-vs-context-window gauge for the status line,
+// framed around the auto-compaction threshold: it shows how much headroom is
+// left until the next compaction (mirroring Claude Code's "context left until
+// auto-compact"), and colours by proximity to that point rather than the raw
+// window. Falls back to a plain percentage when compaction is disabled.
 func (m chatTUI) contextTag() string {
 	used, window := m.ctrl.ContextSnapshot()
 	if used == 0 || window == 0 {
 		return ""
 	}
 	pct := used * 100 / window
-	body := fmt.Sprintf("%s / %s ctx (%d%%)", shortTokens(used), shortTokens(window), pct)
+	ratio := m.ctrl.CompactRatio()
+	if ratio <= 0 || ratio >= 1 {
+		// Compaction disabled: just the raw gauge, coloured on window fill.
+		body := fmt.Sprintf("%s / %s ctx (%d%%)", shortTokens(used), shortTokens(window), pct)
+		switch {
+		case pct >= 85:
+			return lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(body)
+		case pct >= 60:
+			return lipgloss.NewStyle().Foreground(lipgloss.Color("220")).Render(body)
+		default:
+			return dim(body)
+		}
+	}
+	threshold := int(ratio * 100)
+	// Headroom to the compaction point, as a percentage of the window (clamped at 0).
+	left := threshold - pct
+	if left < 0 {
+		left = 0
+	}
+	body := fmt.Sprintf("%s ctx (%d%%) · %d%% to compact", shortTokens(used), pct, left)
 	switch {
-	case pct >= 85:
-		return lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(body)
-	case pct >= 60:
+	case pct >= threshold:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Render(fmt.Sprintf("%s ctx (%d%%) · compacting soon", shortTokens(used), pct))
+	case left <= 10:
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("220")).Render(body)
 	default:
 		return dim(body)
@@ -1285,8 +1308,10 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		// Compaction makes a (network) summarizer call; run it off the Update loop
 		// so the TUI doesn't freeze. The CompactionStarted/Done events render the
 		// card as they arrive; compactDoneMsg only handles the terminal error /
-		// snapshot once the pass returns.
-		return func() tea.Msg { return compactDoneMsg{err: m.ctrl.Compact(context.Background())} }
+		// snapshot once the pass returns. Any text after "/compact" is focus
+		// guidance steering what the summary keeps.
+		focus := strings.TrimSpace(strings.TrimPrefix(input, cmd))
+		return func() tea.Msg { return compactDoneMsg{err: m.ctrl.Compact(context.Background(), focus)} }
 	case "/new":
 		if err := m.ctrl.NewSession(); err != nil {
 			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashNewFailed, err))

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -53,6 +53,7 @@ type Controller struct {
 	hooks        *hook.Runner // session hook runner; nil-safe (no hooks configured)
 	mem          *memory.Set
 	cleanup      func()
+	startedOnce  bool // guards the one-shot SessionStart hook on first turn
 
 	// balanceURL/balanceKey target the active provider's optional wallet-balance
 	// endpoint (empty when the provider declares none). Captured at build so a
@@ -304,6 +305,7 @@ const planApprovedMessage = "Plan approved — plan mode is off; you're cleared 
 // next turn can revise. Plan mode is only ever set interactively, so the headless
 // `Run` path (which doesn't call this) never blocks on a prompt.
 func (c *Controller) runTurn(ctx context.Context, input string) error {
+	c.maybeSessionStart(ctx)
 	// Open a checkpoint for this turn before the user message is appended, so the
 	// recorded message boundary precedes it and pre-edit snapshots land here.
 	c.beginCheckpoint(input)
@@ -380,9 +382,10 @@ func lastAssistantText(msgs []provider.Message) string {
 func (c *Controller) Submit(input string) {
 	trimmed := strings.TrimSpace(input)
 	switch {
-	case trimmed == "/compact":
+	case trimmed == "/compact" || strings.HasPrefix(trimmed, "/compact "):
+		focus := strings.TrimSpace(strings.TrimPrefix(trimmed, "/compact"))
 		go func() {
-			if err := c.Compact(context.Background()); err != nil {
+			if err := c.Compact(context.Background(), focus); err != nil {
 				c.notice("compaction failed: " + err.Error())
 			} else {
 				c.notice("compacted")
@@ -471,6 +474,7 @@ func (c *Controller) notice(text string) {
 // headless `reasonix run` path, where the Sink renders to stdout and the caller
 // just needs the exit status — no TurnDone event, no cancel bookkeeping.
 func (c *Controller) Run(ctx context.Context, input string) error {
+	c.maybeSessionStart(ctx)
 	if c.hooks.Enabled() {
 		c.turn++
 		if block, _ := c.hooks.PromptSubmit(ctx, input, c.turn); block {
@@ -576,15 +580,31 @@ func (c *Controller) SetPlanMode(v bool) {
 }
 
 // Compact runs one compaction pass on the executor's session on demand.
-func (c *Controller) Compact(ctx context.Context) error {
+// instructions is optional `/compact <focus>` guidance steering what to keep.
+func (c *Controller) Compact(ctx context.Context, instructions string) error {
 	if c.executor == nil {
 		return nil
 	}
-	return c.executor.CompactNow(ctx)
+	return c.executor.CompactNow(ctx, instructions)
+}
+
+// maybeSessionStart fires the SessionStart hook exactly once per session, lazily
+// on the first turn — by then the sink/notify is wired, and a resumed session
+// fires it too (its first post-resume turn).
+func (c *Controller) maybeSessionStart(ctx context.Context) {
+	c.mu.Lock()
+	if c.startedOnce {
+		c.mu.Unlock()
+		return
+	}
+	c.startedOnce = true
+	c.mu.Unlock()
+	c.hooks.SessionStart(ctx)
 }
 
 // NewSession snapshots the current conversation, rotates to a fresh file, and
-// resets the executor to a clean session carrying the same system prompt.
+// resets the executor to a clean session carrying the same system prompt. It
+// ends the old session and starts the new one for lifecycle hooks.
 func (c *Controller) NewSession() error {
 	if c.executor == nil {
 		return nil
@@ -592,6 +612,7 @@ func (c *Controller) NewSession() error {
 	if err := c.Snapshot(); err != nil {
 		return err
 	}
+	c.hooks.SessionEnd(context.Background())
 	if c.sessionDir != "" {
 		c.mu.Lock()
 		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
@@ -599,6 +620,10 @@ func (c *Controller) NewSession() error {
 	}
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
 	c.rebindCheckpoints(c.SessionPath())
+	c.mu.Lock()
+	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
+	c.mu.Unlock()
+	c.hooks.SessionStart(context.Background())
 	return nil
 }
 
@@ -844,6 +869,15 @@ func (c *Controller) ContextSnapshot() (int, int) {
 	return u.PromptTokens, c.executor.ContextWindow()
 }
 
+// CompactRatio returns the auto-compaction threshold as a fraction of the window
+// (0 when the executor is unset). The status line shows headroom against it.
+func (c *Controller) CompactRatio() float64 {
+	if c.executor == nil {
+		return 0
+	}
+	return c.executor.CompactRatio()
+}
+
 // LastUsage returns the most recent turn's token telemetry (nil before the first
 // turn), so frontends can derive the prompt cache-hit rate for the status line.
 func (c *Controller) LastUsage() *provider.Usage {
@@ -961,8 +995,15 @@ func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error)
 // Label returns the human-readable model label, e.g. "deepseek-flash".
 func (c *Controller) Label() string { return c.label }
 
-// Close stops plugin subprocesses and releases resources.
+// Close stops plugin subprocesses and releases resources. A session that ever
+// started fires SessionEnd so a teardown hook runs.
 func (c *Controller) Close() {
+	c.mu.Lock()
+	started := c.startedOnce
+	c.mu.Unlock()
+	if started {
+		c.hooks.SessionEnd(context.Background())
+	}
 	if c.jobs != nil {
 		c.jobs.Close() // cancel any still-running background jobs
 	}
@@ -1209,6 +1250,13 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	c.mu.Unlock()
 
 	c.sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: id, Tool: tool, Subject: subject}})
+	// The agent now needs the user's attention; a Notification hook can ping an
+	// external channel (desktop notice, phone) while the run blocks on the reply.
+	if subject != "" {
+		go c.hooks.Notification(ctx, "approval needed: "+tool+" "+subject)
+	} else {
+		go c.hooks.Notification(ctx, "approval needed: "+tool)
+	}
 
 	select {
 	case r := <-reply:

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -33,13 +33,27 @@ const (
 	PostToolUse      Event = "PostToolUse"
 	UserPromptSubmit Event = "UserPromptSubmit"
 	Stop             Event = "Stop"
+	// SessionStart fires once when a session becomes active (fresh, resumed, or
+	// after /new). SessionEnd fires when it is closed or rotated. SubagentStop
+	// fires when a `task` sub-agent finishes. Notification fires when the agent
+	// needs the user's attention (e.g. a pending approval). PreCompact fires just
+	// before a compaction pass; its stdout is injected as extra summary guidance.
+	SessionStart Event = "SessionStart"
+	SessionEnd   Event = "SessionEnd"
+	SubagentStop Event = "SubagentStop"
+	Notification Event = "Notification"
+	PreCompact   Event = "PreCompact"
 )
 
 // Events is every event, in a stable order — drives loading and `/hooks`.
-var Events = []Event{PreToolUse, PostToolUse, UserPromptSubmit, Stop}
+var Events = []Event{
+	PreToolUse, PostToolUse, UserPromptSubmit, Stop,
+	SessionStart, SessionEnd, SubagentStop, Notification, PreCompact,
+}
 
 // IsBlocking reports whether a non-zero/exit-2 (or timed-out) hook on this event
-// can block the loop. Only the gating events qualify.
+// can block the loop. Only the gating events qualify. (PreCompact does not block;
+// it only contributes guidance via stdout.)
 func IsBlocking(e Event) bool { return e == PreToolUse || e == UserPromptSubmit }
 
 // defaultTimeout is the per-event timeout when a hook sets none. Tool/prompt
@@ -211,6 +225,8 @@ type Payload struct {
 	Prompt        string          `json:"prompt,omitempty"`
 	LastAssistant string          `json:"lastAssistantText,omitempty"`
 	Turn          int             `json:"turn,omitempty"`
+	Message       string          `json:"message,omitempty"` // Notification: what needs attention
+	Trigger       string          `json:"trigger,omitempty"` // PreCompact: "auto" | "manual"
 }
 
 // Decision is a single hook invocation's verdict.

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -75,6 +75,62 @@ func (r *Runner) Stop(ctx context.Context, lastAssistant string, turn int) {
 	r.handle(rep)
 }
 
+// SessionStart fires when a session becomes active. It can't block; its purpose
+// is setup side effects (logging, prepping the workspace, desktop notifications).
+func (r *Runner) SessionStart(ctx context.Context) {
+	if !r.Enabled() {
+		return
+	}
+	r.handle(Run(ctx, Payload{Event: SessionStart, Cwd: r.cwd}, r.hooks, r.spawner))
+}
+
+// SessionEnd fires when a session is closed or rotated (/new). It can't block.
+func (r *Runner) SessionEnd(ctx context.Context) {
+	if !r.Enabled() {
+		return
+	}
+	r.handle(Run(ctx, Payload{Event: SessionEnd, Cwd: r.cwd}, r.hooks, r.spawner))
+}
+
+// SubagentStop fires when a `task` sub-agent finishes. It can't block; last is
+// the sub-agent's final answer.
+func (r *Runner) SubagentStop(ctx context.Context, last string) {
+	if !r.Enabled() {
+		return
+	}
+	r.handle(Run(ctx, Payload{Event: SubagentStop, Cwd: r.cwd, LastAssistant: last}, r.hooks, r.spawner))
+}
+
+// Notification fires when the agent needs the user's attention (e.g. a pending
+// approval). It can't block; message describes what's waiting.
+func (r *Runner) Notification(ctx context.Context, message string) {
+	if !r.Enabled() {
+		return
+	}
+	r.handle(Run(ctx, Payload{Event: Notification, Cwd: r.cwd, Message: message}, r.hooks, r.spawner))
+}
+
+// PreCompact fires just before a compaction pass and returns the concatenated
+// stdout of its hooks as extra summary guidance (CC's additionalContext), so a
+// hook can steer what the summary keeps. Non-pass outcomes are surfaced via notify.
+func (r *Runner) PreCompact(ctx context.Context, trigger string) string {
+	if !r.Enabled() {
+		return ""
+	}
+	rep := Run(ctx, Payload{Event: PreCompact, Cwd: r.cwd, Trigger: trigger}, r.hooks, r.spawner)
+	r.handle(rep)
+	var b strings.Builder
+	for _, o := range rep.Outcomes {
+		if s := strings.TrimSpace(o.Stdout); s != "" {
+			if b.Len() > 0 {
+				b.WriteString("\n")
+			}
+			b.WriteString(s)
+		}
+	}
+	return b.String()
+}
+
 // handle surfaces every non-pass outcome to the user (notify) and returns the
 // block decision plus the blocking hook's message.
 func (r *Runner) handle(rep Report) (bool, string) {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -181,7 +181,7 @@ func (s *Server) plan(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) compact(w http.ResponseWriter, r *http.Request) {
-	if err := s.ctrl.Compact(r.Context()); err != nil {
+	if err := s.ctrl.Compact(r.Context(), ""); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Adds the lifecycle hook events we lacked (4 → 9) and the compaction follow-ups that pair with them.

## Hooks
| Event | Fires | Can |
|---|---|---|
| SessionStart | first turn (fresh/resumed) + /new | setup side effects |
| SessionEnd | Close + /new | teardown |
| SubagentStop | a **foreground** `task` sub-agent finishes | react to delegated work |
| Notification | a pending approval (agent needs attention) | ping an external channel |
| PreCompact | just before a compaction pass | inject summary guidance (stdout) |

All five load from settings.json and list in `/hooks`; the blocking set (PreToolUse/UserPromptSubmit) is unchanged. Backgrounded `task` calls don't fire SubagentStop (they return a handle and stop later in a job).

## Compaction
- **`/compact <focus>`**: text after `/compact` is threaded into the summary system prompt (CLI + desktop/serve), merged with any PreCompact hook output.
- **Status line**: the context gauge now frames headroom to the auto-compaction threshold ("N% to compact" / "compacting soon") instead of raw window fill.

## Verification
- Unit tests: PreCompact + `/compact` focus both reach the summary prompt; SubagentStop fires for foreground tasks only.
- Full `go test ./...` + desktop `go test ./...` green; gofmt clean.
- Live: auto-compaction runs through the new `compact(trigger, instructions)` path (nil-safe PreCompact) with no regression.
