### PR TITLE
feat(desktop): support pasted image attachments

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -111,6 +111,16 @@ func (a *App) Submit(input string) {
 	}
 }
 
+// SavePastedImage persists an image pasted into the desktop composer and returns
+// a workspace-relative @-reference path the frontend can insert into the prompt.
+func (a *App) SavePastedImage(dataURL string) (string, error) {
+	return control.SaveImageDataURL(dataURL)
+}
+
+func (a *App) AttachmentDataURL(path string) (string, error) {
+	return control.ImageDataURL(path)
+}
+
 // Cancel aborts the in-flight turn.
 func (a *App) Cancel() {
 	if a.ctrl != nil {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -32,10 +32,12 @@ export function Composer({
   const t = useT();
   const [text, setText] = useState("");
   const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [pendingPastes, setPendingPastes] = useState(0);
   const [preview, setPreview] = useState<Attachment | null>(null);
   const [active, setActive] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
+  const pendingPastesRef = useRef(0);
 
   // --- slash commands (whole-input "/token") ---
   const [commands, setCommands] = useState<CommandInfo[]>([]);
@@ -166,13 +168,21 @@ export function Composer({
     });
   };
 
+  const canSubmit = !running && pendingPastes === 0 && (text.trim().length > 0 || attachments.length > 0);
+
   const submit = () => {
+    if (running || pendingPastesRef.current > 0) return;
     const t = text.trim();
     if (!t && attachments.length === 0) return;
     const refs = attachments.map((a) => `@${a.path}`).join(" ");
     onSend([t, refs].filter(Boolean).join(t && refs ? " " : ""));
     setText("");
     setAttachments([]);
+  };
+
+  const updatePendingPastes = (delta: number) => {
+    pendingPastesRef.current = Math.max(0, pendingPastesRef.current + delta);
+    setPendingPastes(pendingPastesRef.current);
   };
 
   const insertAtCaret = (insert: string) => {
@@ -277,15 +287,24 @@ export function Composer({
     const file = item.getAsFile();
     if (!file) return;
     e.preventDefault();
+    updatePendingPastes(1);
 
     const reader = new FileReader();
     reader.onload = () => {
       const dataUrl = typeof reader.result === "string" ? reader.result : "";
-      if (!dataUrl) return;
+      if (!dataUrl) {
+        updatePendingPastes(-1);
+        return;
+      }
       app
         .SavePastedImage(dataUrl)
         .then((path) => setAttachments((items) => [...items, { path, previewUrl: dataUrl }]))
-        .catch((err) => insertAtCaret(`[pasted image failed: ${err instanceof Error ? err.message : String(err)}]`));
+        .catch((err) => insertAtCaret(`[pasted image failed: ${err instanceof Error ? err.message : String(err)}]`))
+        .finally(() => updatePendingPastes(-1));
+    };
+    reader.onerror = () => {
+      updatePendingPastes(-1);
+      insertAtCaret("[pasted image failed]");
     };
     reader.readAsDataURL(file);
   };
@@ -354,8 +373,8 @@ export function Composer({
           <button
             className="composer__btn composer__btn--send"
             onClick={submit}
-            disabled={!text.trim() && attachments.length === 0}
-            title={t("composer.send")}
+            disabled={!canSubmit}
+            title={pendingPastes > 0 ? t("composer.savingImage") : t("composer.send")}
           >
             <ArrowUp size={16} />
           </button>

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,12 +1,18 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent } from "react";
-import { ArrowUp, Square } from "lucide-react";
+import type { ClipboardEvent, KeyboardEvent } from "react";
+import { ArrowUp, Square, X } from "lucide-react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import type { CommandInfo, DirEntry, Mode, SlashArgItem, SlashArgsResult } from "../lib/types";
 import { SlashMenu } from "./SlashMenu";
 import { ArgMenu } from "./ArgMenu";
 import { FileMenu } from "./FileMenu";
+import { ImagePreview } from "./ImagePreview";
+
+interface Attachment {
+  path: string;
+  previewUrl: string;
+}
 
 export function Composer({
   running,
@@ -25,6 +31,8 @@ export function Composer({
 }) {
   const t = useT();
   const [text, setText] = useState("");
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [preview, setPreview] = useState<Attachment | null>(null);
   const [active, setActive] = useState(0);
   const [dismissed, setDismissed] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
@@ -160,9 +168,30 @@ export function Composer({
 
   const submit = () => {
     const t = text.trim();
-    if (!t) return;
-    onSend(t);
+    if (!t && attachments.length === 0) return;
+    const refs = attachments.map((a) => `@${a.path}`).join(" ");
+    onSend([t, refs].filter(Boolean).join(t && refs ? " " : ""));
     setText("");
+    setAttachments([]);
+  };
+
+  const insertAtCaret = (insert: string) => {
+    const ta = taRef.current;
+    const start = ta?.selectionStart ?? text.length;
+    const end = ta?.selectionEnd ?? text.length;
+    const before = text.slice(0, start);
+    const after = text.slice(end);
+    const leftPad = before === "" || /\s$/.test(before) ? "" : " ";
+    const rightPad = after === "" || /^\s/.test(after) ? "" : " ";
+    const next = before + leftPad + insert + rightPad + after;
+    const caret = before.length + leftPad.length + insert.length + rightPad.length;
+    setText(next);
+    requestAnimationFrame(() => {
+      const el = taRef.current;
+      if (!el) return;
+      el.focus();
+      el.selectionStart = el.selectionEnd = caret;
+    });
   };
 
   // handleCancel stops the in-flight turn; if it was cancelled before the server
@@ -242,6 +271,25 @@ export function Composer({
     }
   };
 
+  const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const item = Array.from(e.clipboardData.items).find((it) => it.kind === "file" && it.type.startsWith("image/"));
+    if (!item) return;
+    const file = item.getAsFile();
+    if (!file) return;
+    e.preventDefault();
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = typeof reader.result === "string" ? reader.result : "";
+      if (!dataUrl) return;
+      app
+        .SavePastedImage(dataUrl)
+        .then((path) => setAttachments((items) => [...items, { path, previewUrl: dataUrl }]))
+        .catch((err) => insertAtCaret(`[pasted image failed: ${err instanceof Error ? err.message : String(err)}]`));
+    };
+    reader.readAsDataURL(file);
+  };
+
   return (
     <div className="composer-wrap">
       {menuMode === "slash" && (
@@ -262,15 +310,42 @@ export function Composer({
       </button>
       <div className="composer">
         <span className="composer__caret">›</span>
-        <textarea
-          ref={taRef}
-          className="composer__input"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onKeyDown={onKeyDown}
-          placeholder={t("composer.placeholder")}
-          rows={1}
-        />
+        <div className="composer__body">
+          {attachments.length > 0 && (
+            <div className="composer__attachments">
+              {attachments.map((a) => (
+                <div className="composer__attachment" key={a.path} title={a.path}>
+                  <button
+                    className="composer__attachment-preview"
+                    type="button"
+                    onClick={() => setPreview(a)}
+                    title={t("composer.attachmentPreview")}
+                  >
+                    <img className="composer__attachment-thumb" src={a.previewUrl} alt="" />
+                  </button>
+                  <button
+                    className="composer__attachment-remove"
+                    type="button"
+                    onClick={() => setAttachments((items) => items.filter((it) => it.path !== a.path))}
+                    title={t("composer.attachmentRemove")}
+                  >
+                    <X size={13} />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          <textarea
+            ref={taRef}
+            className="composer__input"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={onKeyDown}
+            onPaste={onPaste}
+            placeholder={attachments.length > 0 ? "" : t("composer.placeholder")}
+            rows={1}
+          />
+        </div>
         {running ? (
           <button className="composer__btn composer__btn--stop" onClick={handleCancel} title={t("composer.stop")}>
             <Square size={14} fill="currentColor" />
@@ -279,13 +354,20 @@ export function Composer({
           <button
             className="composer__btn composer__btn--send"
             onClick={submit}
-            disabled={!text.trim()}
+            disabled={!text.trim() && attachments.length === 0}
             title={t("composer.send")}
           >
             <ArrowUp size={16} />
           </button>
         )}
       </div>
+      {preview && (
+        <ImagePreview
+          src={preview.previewUrl}
+          label={preview.path}
+          onClose={() => setPreview(null)}
+        />
+      )}
     </div>
   );
 }

--- a/desktop/frontend/src/components/ImagePreview.tsx
+++ b/desktop/frontend/src/components/ImagePreview.tsx
@@ -1,0 +1,50 @@
+import { Download, Minus, Plus, X } from "lucide-react";
+import { useState } from "react";
+
+export function ImagePreview({
+  src,
+  label,
+  onClose,
+}: {
+  src: string;
+  label: string;
+  onClose: () => void;
+}) {
+  const [zoom, setZoom] = useState(1);
+  const pct = Math.round(zoom * 100);
+  const download = () => {
+    const a = document.createElement("a");
+    a.href = src;
+    a.download = label.split("/").pop() || "image.png";
+    a.click();
+  };
+
+  return (
+    <div className="imgpreview" role="dialog" aria-modal="true" onMouseDown={onClose}>
+      <div className="imgpreview__actions" onMouseDown={(e) => e.stopPropagation()}>
+        <button className="imgpreview__round" type="button" onClick={download} title="Download">
+          <Download size={20} />
+        </button>
+        <button className="imgpreview__round" type="button" onClick={onClose} title="Close">
+          <X size={22} />
+        </button>
+      </div>
+      <img
+        className="imgpreview__image"
+        src={src}
+        alt={label}
+        style={{ transform: `scale(${zoom})` }}
+        onMouseDown={(e) => e.stopPropagation()}
+      />
+      <div className="imgpreview__zoom" onMouseDown={(e) => e.stopPropagation()}>
+        <button type="button" onClick={() => setZoom((z) => Math.max(0.25, z - 0.25))} title="Zoom out">
+          <Minus size={18} />
+        </button>
+        <span>{pct}%</span>
+        <button type="button" onClick={() => setZoom((z) => Math.min(3, z + 0.25))} title="Zoom in">
+          <Plus size={18} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,11 +1,67 @@
-import { useState } from "react";
-import { ChevronRight } from "lucide-react";
+import { useEffect, useState } from "react";
+import { ChevronRight, Image as ImageIcon } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
 import { useT } from "../lib/i18n";
 import type { Item } from "../lib/useController";
+import { app } from "../lib/bridge";
+import { ImagePreview } from "./ImagePreview";
 
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
+
+interface ImageRef {
+  path: string;
+  time: string;
+}
+
+const imageRefRe = /(?:^|\s)@(\.reasonix\/attachments\/clipboard-\d{8}-(\d{2})(\d{2})(\d{2})\.\d+\.(?:png|jpg|jpeg|gif|webp|tiff))/gi;
+
+function splitImageRefs(text: string): { body: string; images: ImageRef[] } {
+  const images: ImageRef[] = [];
+  const body = text
+    .replace(imageRefRe, (_match, path: string, hh: string, mm: string, ss: string) => {
+      images.push({ path, time: `${hh}:${mm}:${ss}` });
+      return " ";
+    })
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+  return { body, images };
+}
+
+function UserImageAttachment({ img }: { img: ImageRef }) {
+  const t = useT();
+  const [src, setSrc] = useState("");
+  const [preview, setPreview] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    app
+      .AttachmentDataURL(img.path)
+      .then((data) => {
+        if (live) setSrc(data);
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, [img.path]);
+
+  const label = `${t("composer.attachmentImage")}${img.time ? ` · ${img.time}` : ""}`;
+  return (
+    <>
+      <button
+        className="msg__attachment"
+        type="button"
+        title={img.path}
+        onClick={() => src && setPreview(true)}
+      >
+        {src ? <img className="msg__attachment-thumb" src={src} alt="" /> : <ImageIcon size={15} />}
+        <span className="msg__attachment-label">{label}</span>
+      </button>
+      {preview && src && <ImagePreview src={src} label={img.path} onClose={() => setPreview(false)} />}
+    </>
+  );
+}
 
 export function UserMessage({
   text,
@@ -23,10 +79,20 @@ export function UserMessage({
   const t = useT();
   const canRewind = onRewind != null && turn != null;
   const rewind = (scope: string) => onRewind?.(turn as number, scope);
+  const { body, images } = splitImageRefs(text);
   return (
     <div className="msg msg--user">
       <span className="msg__caret">›</span>
-      <div className="msg__text">{text}</div>
+      <div className="msg__userbody">
+        {body && <div className="msg__text">{body}</div>}
+        {images.length > 0 && (
+          <div className="msg__attachments">
+            {images.map((img) => (
+              <UserImageAttachment img={img} key={img.path} />
+            ))}
+          </div>
+        )}
+      </div>
       {canRewind && (
         <div className="rewind">
           <button className="rewind__btn" title={t("rewind.label")} onClick={onToggle}>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -30,6 +30,8 @@ import type {
 // (or regenerate with `wails generate module` and import wailsjs instead).
 export interface AppBindings {
   Submit(input: string): Promise<void>;
+  SavePastedImage(dataUrl: string): Promise<string>;
+  AttachmentDataURL(path: string): Promise<string>;
   Cancel(): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean): Promise<void>;
   AnswerQuestion(id: string, answers: QuestionAnswer[]): Promise<void>;
@@ -271,6 +273,12 @@ function makeMockApp(): AppBindings {
         },
       });
       emit({ kind: "turn_done" });
+    },
+    async SavePastedImage() {
+      return ".reasonix/attachments/clipboard-dev.png";
+    },
+    async AttachmentDataURL() {
+      return "data:image/png;base64,iVBORw0KGgo=";
     },
     async Cancel() {
       cancelled = true;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -48,6 +48,7 @@ export const en = {
   "composer.attachmentRemove": "Remove image",
   "composer.attachmentPreview": "Preview image",
   "composer.send": "Send (Enter)",
+  "composer.savingImage": "Saving pasted image…",
   "composer.stop": "Stop (Esc)",
 
   // status bar

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -44,6 +44,9 @@ export const en = {
   "composer.modeTitle": "Cycle mode (shift+tab): normal → plan → YOLO (auto-approve everything)",
   "composer.enterPlanTitle": "Enter plan mode (shift+tab) — read-only; propose a plan before writing",
   "composer.exitPlanTitle": "Exit plan mode (shift+tab)",
+  "composer.attachmentImage": "Image",
+  "composer.attachmentRemove": "Remove image",
+  "composer.attachmentPreview": "Preview image",
   "composer.send": "Send (Enter)",
   "composer.stop": "Stop (Esc)",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -49,6 +49,7 @@ export const zh: Record<DictKey, string> = {
   "composer.attachmentRemove": "移除图片",
   "composer.attachmentPreview": "预览图片",
   "composer.send": "发送（Enter）",
+  "composer.savingImage": "正在保存粘贴图片…",
   "composer.stop": "停止（Esc）",
 
   // 状态栏

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -45,6 +45,9 @@ export const zh: Record<DictKey, string> = {
   "composer.modeTitle": "切换模式（shift+tab）：普通 → 计划 → YOLO（全部自动批准）",
   "composer.enterPlanTitle": "进入计划模式（shift+tab）—— 只读；先给出计划再动手",
   "composer.exitPlanTitle": "退出计划模式（shift+tab）",
+  "composer.attachmentImage": "图片",
+  "composer.attachmentRemove": "移除图片",
+  "composer.attachmentPreview": "预览图片",
   "composer.send": "发送（Enter）",
   "composer.stop": "停止（Esc）",
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -381,6 +381,50 @@ body {
   word-break: break-word;
   font-weight: 450;
 }
+.msg__userbody {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.msg__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.msg__attachment {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+  width: 88px;
+  padding: 0;
+  border: 1px solid var(--border-soft);
+  border-radius: 9px;
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 11.5px;
+  cursor: pointer;
+  overflow: hidden;
+}
+.msg__attachment:hover {
+  border-color: var(--fg-faint);
+  color: var(--fg);
+}
+.msg__attachment-thumb {
+  width: 88px;
+  height: 88px;
+  object-fit: cover;
+  background: var(--bg);
+}
+.msg__attachment-label {
+  max-width: 100%;
+  padding: 0 6px 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .msg--assistant {
   color: var(--fg);
 }
@@ -897,8 +941,134 @@ body {
   line-height: 1.55;
   flex-shrink: 0;
 }
-.composer__input {
+.composer__body {
   flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.composer__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.composer__attachment {
+  position: relative;
+  width: 88px;
+  height: 88px;
+  border: 1px solid var(--border-soft);
+  border-radius: 9px;
+  background: var(--bg-elev);
+  overflow: hidden;
+}
+.composer__attachment-preview {
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  display: block;
+}
+.composer__attachment-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: var(--bg);
+}
+.composer__attachment-remove {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: rgba(13, 14, 18, 0.86);
+  color: white;
+  cursor: pointer;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.35);
+}
+.composer__attachment-remove:hover {
+  background: rgba(28, 30, 36, 0.94);
+}
+
+.imgpreview {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px;
+  background: rgba(0, 0, 0, 0.82);
+  overflow: hidden;
+}
+.imgpreview__image {
+  max-width: min(1100px, 92vw);
+  max-height: 86vh;
+  object-fit: contain;
+  border-radius: 8px;
+  box-shadow: 0 20px 80px rgba(0, 0, 0, 0.55);
+  transition: transform 0.12s ease;
+}
+.imgpreview__actions {
+  position: fixed;
+  top: 22px;
+  right: 22px;
+  display: inline-flex;
+  gap: 14px;
+}
+.imgpreview__round,
+.imgpreview__zoom button {
+  border: none;
+  color: #111;
+  background: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+}
+.imgpreview__round {
+  width: 54px;
+  height: 54px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+.imgpreview__zoom {
+  position: fixed;
+  left: 50%;
+  bottom: 28px;
+  transform: translateX(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 54px;
+  padding: 0 8px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.92);
+  color: #111;
+  font-size: 15px;
+  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.28);
+}
+.imgpreview__zoom button {
+  width: 42px;
+  height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.08);
+}
+.imgpreview__zoom span {
+  min-width: 54px;
+  text-align: center;
+}
+.composer__input {
+  width: 100%;
   resize: none;
   border: none;
   background: none;

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.6
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/BurntSushi/toml v1.6.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/x/ansi v0.11.7
 	github.com/mattn/go-runewidth v0.0.23
 	github.com/yuin/goldmark v1.8.2
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260416155717-489999b90468 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
 
 	"reasonix/internal/event"
 )
@@ -15,6 +17,7 @@ func newTestChatTUI() chatTUI {
 	commit := []string{}
 	ti := textarea.New()
 	ti.SetWidth(80)
+	ti.Focus()
 	return chatTUI{
 		input:         ti,
 		reasoning:     &strings.Builder{},
@@ -70,5 +73,54 @@ func TestIngestEventFlushesAnswer(t *testing.T) {
 	}
 	if m.pending.Len() != 0 {
 		t.Errorf("answer buffer should be drained after the event line")
+	}
+}
+
+func TestAttachmentRefsStayOutOfComposerText(t *testing.T) {
+	attachments := []chatAttachment{{Path: ".reasonix/attachments/clipboard-20260601-120000.123456.png"}}
+
+	if got := withAttachmentLabels("what is this", attachments); got != "what is this\n[image1]" {
+		t.Fatalf("display line = %q", got)
+	}
+	if got := withAttachmentRefs("what is this", attachments); got != "what is this @.reasonix/attachments/clipboard-20260601-120000.123456.png" {
+		t.Fatalf("sent line = %q", got)
+	}
+}
+
+func TestRenderUserBubbleHidesAttachmentPaths(t *testing.T) {
+	got := renderUserBubble("what is this @.reasonix/attachments/clipboard-20260601-120000.123456.png", 80, false)
+	if strings.Contains(got, ".reasonix/attachments") {
+		t.Fatalf("user bubble leaked attachment path: %q", got)
+	}
+	if !strings.Contains(got, "[image1]") {
+		t.Fatalf("user bubble should show image label, got %q", got)
+	}
+}
+
+func TestPastedImagePathBecomesAttachment(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("shot.png", []byte("\x89PNG\r\n\x1a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := newTestChatTUI()
+	next, _ := m.Update(tea.PasteMsg{Content: "shot.png"})
+	got := next.(chatTUI)
+	if got.input.Value() != "" {
+		t.Fatalf("image paste should not insert raw text, input=%q", got.input.Value())
+	}
+	if len(got.attachments) != 1 || !strings.HasPrefix(got.attachments[0].Path, ".reasonix/attachments/clipboard-") {
+		t.Fatalf("attachments = %#v", got.attachments)
+	}
+}
+
+func TestPastedTextStaysInComposer(t *testing.T) {
+	m := newTestChatTUI()
+	next, _ := m.Update(tea.PasteMsg{Content: "hello"})
+	got := next.(chatTUI)
+	if got.input.Value() != "hello" {
+		t.Fatalf("text paste should stay in composer, got %q", got.input.Value())
+	}
+	if len(got.attachments) != 0 {
+		t.Fatalf("text paste should not create attachments: %#v", got.attachments)
 	}
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -197,6 +197,11 @@ type refsResolvedMsg struct {
 	errs  []string
 }
 
+type clipboardImageMsg struct {
+	path string
+	err  error
+}
+
 // newChatTUI assembles the initial model. The controller has already been wired
 // with an event sink that feeds eventCh; the TUI issues commands to it and
 // renders the events it emits. Label, history, host, and commands are read from
@@ -399,6 +404,12 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "ctrl+d":
 			return m, tea.Quit
+		case "ctrl+v", "ctrl+y":
+			if m.state == tuiRunning {
+				return m, nil
+			}
+			cmds = append(cmds, pasteClipboardImage())
+			return m, finalize(m, cmds)
 		case "tab":
 			if m.state == tuiRunning {
 				break
@@ -487,6 +498,13 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			sent = "Referenced context:\n\n" + msg.block + "\n\n" + msg.line
 		}
 		cmds = append(cmds, m.startTurn(m.ctrl.Compose(sent), msg.line))
+
+	case clipboardImageMsg:
+		if msg.err != nil {
+			m.notice("paste image: " + msg.err.Error())
+			break
+		}
+		m.insertInputRef("@" + msg.path)
 
 	case elapsedTickMsg:
 		if m.state == tuiRunning {
@@ -1011,6 +1029,25 @@ func (m *chatTUI) growInputToFit() {
 	}
 }
 
+func (m *chatTUI) insertInputRef(ref string) {
+	val := m.input.Value()
+	leftPad := ""
+	if val != "" && !strings.HasSuffix(val, " ") && !strings.HasSuffix(val, "\n") && !strings.HasSuffix(val, "\t") {
+		leftPad = " "
+	}
+	next := val + leftPad + ref
+	m.input.SetValue(next)
+	m.growInputToFit()
+	m.updateCompletion()
+}
+
+func pasteClipboardImage() tea.Cmd {
+	return func() tea.Msg {
+		path, err := control.SaveClipboardImage()
+		return clipboardImageMsg{path: path, err: err}
+	}
+}
+
 // cycleMode advances the input mode normal → plan → YOLO → normal (Tab),
 // mirroring the desktop composer's Shift+Tab. plan is read-only; YOLO
 // auto-approves every tool call for the session (deny rules still apply). The
@@ -1258,6 +1295,8 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.notice(i18n.M.SlashTodoCleared)
 	case "/rewind":
 		m.openRewind()
+	case "/paste-image":
+		return pasteClipboardImage()
 	case "/mcp":
 		m.runMCPSubcommand(input)
 	case "/model":

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -5,6 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"image/color"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,6 +18,7 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 
 	"reasonix/internal/agent"
@@ -103,6 +109,11 @@ type chatTUI struct {
 	pendingBubble string
 	bubblePending bool
 	turnDiscarded bool
+	// attachments are image refs queued for the next user turn. They render as a
+	// tray above the input and are appended to the provider-facing prompt as
+	// @-references only when the turn is sent.
+	attachments        []chatAttachment
+	pendingAttachments []chatAttachment
 
 	// pendingApproval holds the tool-call approval currently shown in the banner
 	// (nil when none). While set, the controller's run goroutine is blocked
@@ -192,14 +203,26 @@ type promptResolvedMsg struct {
 // refsResolvedMsg carries the result of resolving the @references in a
 // submitted line (async file reads / MCP resources/read).
 type refsResolvedMsg struct {
-	line  string
-	block string
-	errs  []string
+	sent        string
+	display     string
+	attachments []chatAttachment
+	block       string
+	errs        []string
 }
 
 type clipboardImageMsg struct {
 	path string
 	err  error
+}
+
+type clipboardPasteMsg struct {
+	path string
+	text string
+	err  error
+}
+
+type chatAttachment struct {
+	Path string
 }
 
 // newChatTUI assembles the initial model. The controller has already been wired
@@ -300,6 +323,11 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// status line) and the renderer can't skip it — repainting over the ghost.
 		m.repaintToggle = !m.repaintToggle
 
+	case tea.PasteMsg:
+		if m.state != tuiRunning && m.attachPastedImages(msg.Content) {
+			return m, finalize(m, cmds)
+		}
+
 	case tea.KeyPressMsg:
 		// A question card is modal: keys drive it. In its free-text ("Type
 		// something") mode, the keystroke goes to the textarea — Enter confirms the
@@ -376,6 +404,8 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case m.planMode:
 				m.planMode = false
 				m.ctrl.SetPlanMode(false)
+			case len(m.attachments) > 0 && strings.TrimSpace(m.input.Value()) == "":
+				m.attachments = nil
 			default:
 				// Idle with nothing to back out: a double-Esc on an empty composer
 				// opens the rewind picker (Claude Code's gesture); a first Esc just
@@ -404,7 +434,13 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, tea.Quit
 		case "ctrl+d":
 			return m, tea.Quit
-		case "ctrl+v", "ctrl+y":
+		case "ctrl+v", "ctrl+shift+v", "super+v", "meta+v":
+			if m.state == tuiRunning {
+				return m, nil
+			}
+			cmds = append(cmds, pasteClipboard())
+			return m, finalize(m, cmds)
+		case "ctrl+y":
 			if m.state == tuiRunning {
 				return m, nil
 			}
@@ -422,7 +458,7 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			line := strings.TrimSpace(m.input.Value())
 
-			if line == "" {
+			if line == "" && len(m.attachments) == 0 {
 				return m, nil
 			}
 			if line == "exit" || line == "quit" || line == ":q" {
@@ -446,25 +482,29 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			// Slash commands run locally without going through the model.
-			if strings.HasPrefix(line, "/") {
+			if strings.HasPrefix(line, "/") && len(m.attachments) == 0 {
 				m.input.Reset()
 				m.input.SetHeight(1)
 				cmds = append(cmds, m.runSlashCommand(line))
 				return m, finalize(m, cmds)
 			}
 
+			attachments := cloneAttachments(m.attachments)
+			sentLine := withAttachmentRefs(line, attachments)
+			displayLine := withAttachmentLabels(line, attachments)
 			m.input.Reset()
 			m.input.SetHeight(1)
+			m.attachments = nil
 
 			// @references (local files / MCP resources) are resolved off the event
 			// loop by the controller; the turn starts when they resolve
 			// (refsResolvedMsg).
-			if m.ctrl.HasRefs(line) {
-				cmds = append(cmds, m.resolveRefs(line))
+			if m.ctrl.HasRefs(sentLine) {
+				cmds = append(cmds, m.resolveRefs(sentLine, displayLine, attachments))
 				return m, finalize(m, cmds)
 			}
 
-			cmds = append(cmds, m.startTurn(m.ctrl.Compose(line), line))
+			cmds = append(cmds, m.startTurn(m.ctrl.Compose(sentLine), displayLine, attachments))
 			return m, finalize(m, cmds)
 		}
 
@@ -486,25 +526,40 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case strings.TrimSpace(msg.sent) == "":
 			m.notice(i18n.M.SlashPromptEmpty)
 		default:
-			cmds = append(cmds, m.startTurn(m.ctrl.Compose(msg.sent), msg.display))
+			cmds = append(cmds, m.startTurn(m.ctrl.Compose(msg.sent), msg.display, nil))
 		}
 
 	case refsResolvedMsg:
 		for _, e := range msg.errs {
 			m.notice(e) // surface a fetch failure but still send the turn
 		}
-		sent := msg.line
+		sent := msg.sent
 		if msg.block != "" {
-			sent = "Referenced context:\n\n" + msg.block + "\n\n" + msg.line
+			sent = "Referenced context:\n\n" + msg.block + "\n\n" + msg.sent
 		}
-		cmds = append(cmds, m.startTurn(m.ctrl.Compose(sent), msg.line))
+		cmds = append(cmds, m.startTurn(m.ctrl.Compose(sent), msg.display, msg.attachments))
 
 	case clipboardImageMsg:
 		if msg.err != nil {
 			m.notice("paste image: " + msg.err.Error())
 			break
 		}
-		m.insertInputRef("@" + msg.path)
+		m.attachments = append(m.attachments, chatAttachment{Path: msg.path})
+
+	case clipboardPasteMsg:
+		switch {
+		case msg.err != nil:
+			m.notice("paste: " + msg.err.Error())
+		case msg.path != "":
+			m.attachments = append(m.attachments, chatAttachment{Path: msg.path})
+		case msg.text != "":
+			if !m.attachPastedImages(msg.text) {
+				m.input.InsertString(msg.text)
+				m.growInputToFit()
+				m.updateCompletion()
+				return m, finalize(m, cmds)
+			}
+		}
 
 	case elapsedTickMsg:
 		if m.state == tuiRunning {
@@ -809,6 +864,10 @@ func (m chatTUI) View() tea.View {
 		parts = append(parts, card)
 		rowsAboveBox += strings.Count(card, "\n") + 1
 	}
+	if tray := m.renderAttachmentTray(); tray != "" {
+		parts = append(parts, tray)
+		rowsAboveBox += strings.Count(tray, "\n") + 1
+	}
 	if menu := m.renderCompletion(); menu != "" {
 		parts = append(parts, menu)
 		rowsAboveBox += strings.Count(menu, "\n") + 1
@@ -987,6 +1046,15 @@ func (m chatTUI) renderTodoPanel() string {
 	return todoPanelStyle.Width(max(m.width, 10)).Render(strings.TrimRight(b.String(), "\n"))
 }
 
+func (m chatTUI) renderAttachmentTray() string {
+	if len(m.attachments) == 0 {
+		return ""
+	}
+	labels := attachmentLabels(m.attachments)
+	body := strings.Join(labels, "  ")
+	return todoPanelStyle.Width(max(m.width, 10)).Render(body)
+}
+
 // truncateSubject trims a tool subject so the approval banner fits one line.
 func truncateSubject(s string, width int) string {
 	max := width - 28
@@ -1029,23 +1097,201 @@ func (m *chatTUI) growInputToFit() {
 	}
 }
 
-func (m *chatTUI) insertInputRef(ref string) {
-	val := m.input.Value()
-	leftPad := ""
-	if val != "" && !strings.HasSuffix(val, " ") && !strings.HasSuffix(val, "\n") && !strings.HasSuffix(val, "\t") {
-		leftPad = " "
-	}
-	next := val + leftPad + ref
-	m.input.SetValue(next)
-	m.growInputToFit()
-	m.updateCompletion()
-}
-
 func pasteClipboardImage() tea.Cmd {
 	return func() tea.Msg {
 		path, err := control.SaveClipboardImage()
 		return clipboardImageMsg{path: path, err: err}
 	}
+}
+
+func pasteClipboard() tea.Cmd {
+	return func() tea.Msg {
+		path, imageErr := control.SaveClipboardImage()
+		if imageErr == nil {
+			return clipboardPasteMsg{path: path}
+		}
+		text, textErr := clipboard.ReadAll()
+		if textErr == nil && text != "" {
+			return clipboardPasteMsg{text: text}
+		}
+		if textErr != nil {
+			return clipboardPasteMsg{err: fmt.Errorf("%v; text paste failed: %w", imageErr, textErr)}
+		}
+		return clipboardPasteMsg{err: imageErr}
+	}
+}
+
+func cloneAttachments(in []chatAttachment) []chatAttachment {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]chatAttachment, len(in))
+	copy(out, in)
+	return out
+}
+
+func attachmentLabels(in []chatAttachment) []string {
+	labels := make([]string, len(in))
+	for i := range in {
+		labels[i] = accent(fmt.Sprintf("[image%d]", i+1))
+	}
+	return labels
+}
+
+func withAttachmentLabels(line string, attachments []chatAttachment) string {
+	line = strings.TrimSpace(line)
+	if len(attachments) == 0 {
+		return line
+	}
+	labels := strings.Join(attachmentLabels(attachments), " ")
+	if line == "" {
+		return labels
+	}
+	return line + "\n" + labels
+}
+
+func withAttachmentRefs(line string, attachments []chatAttachment) string {
+	line = strings.TrimSpace(line)
+	if len(attachments) == 0 {
+		return line
+	}
+	refs := make([]string, len(attachments))
+	for i, a := range attachments {
+		refs[i] = "@" + a.Path
+	}
+	if line == "" {
+		return strings.Join(refs, " ")
+	}
+	return line + " " + strings.Join(refs, " ")
+}
+
+func (m *chatTUI) attachPastedImages(text string) bool {
+	sources, ok := pastedImageSources(text)
+	if !ok {
+		return false
+	}
+	for _, src := range sources {
+		path, err := savePastedImageSource(src)
+		if err != nil {
+			m.notice("paste image: " + err.Error())
+			continue
+		}
+		m.attachments = append(m.attachments, chatAttachment{Path: path})
+	}
+	return true
+}
+
+var markdownImageSourceRe = regexp.MustCompile(`!\[[^\]]*\]\(([^)]+)\)`)
+
+func pastedImageSources(text string) ([]string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return nil, false
+	}
+	if isDataImage(trimmed) {
+		return []string{trimmed}, true
+	}
+	if matches := markdownImageSourceRe.FindAllStringSubmatch(trimmed, -1); len(matches) > 0 {
+		rest := strings.TrimSpace(markdownImageSourceRe.ReplaceAllString(trimmed, ""))
+		if rest == "" {
+			sources := make([]string, 0, len(matches))
+			for _, m := range matches {
+				sources = append(sources, m[1])
+			}
+			return sources, true
+		}
+	}
+
+	lines := nonEmptyPasteLines(trimmed)
+	if len(lines) > 0 && allImageSources(lines) {
+		return lines, true
+	}
+	fields := strings.Fields(trimmed)
+	if len(fields) > 1 && allImageSources(fields) {
+		return fields, true
+	}
+	return nil, false
+}
+
+func nonEmptyPasteLines(text string) []string {
+	var out []string
+	for _, line := range strings.Split(strings.ReplaceAll(text, "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+func allImageSources(sources []string) bool {
+	if len(sources) == 0 {
+		return false
+	}
+	for _, src := range sources {
+		if !looksLikeImageSource(src) {
+			return false
+		}
+	}
+	return true
+}
+
+func looksLikeImageSource(src string) bool {
+	if isDataImage(strings.TrimSpace(src)) {
+		return true
+	}
+	path, ok := pastedImagePath(src)
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".tiff", ".tif":
+		return true
+	}
+	return false
+}
+
+func savePastedImageSource(src string) (string, error) {
+	src = strings.TrimSpace(src)
+	if isDataImage(src) {
+		return control.SaveImageDataURL(src)
+	}
+	path, ok := pastedImagePath(src)
+	if !ok {
+		return "", fmt.Errorf("unsupported pasted image source")
+	}
+	return control.SaveImageFile(path)
+}
+
+func isDataImage(src string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(src)), "data:image/")
+}
+
+func pastedImagePath(src string) (string, bool) {
+	src = strings.TrimSpace(src)
+	src = strings.TrimPrefix(src, "@")
+	src = strings.Trim(src, "\"'")
+	if src == "" {
+		return "", false
+	}
+	lower := strings.ToLower(src)
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return "", false
+	}
+	if strings.HasPrefix(lower, "file://") {
+		u, err := url.Parse(src)
+		if err != nil || u.Path == "" {
+			return "", false
+		}
+		src = u.Path
+	}
+	if strings.HasPrefix(src, "~/") {
+		home, err := os.UserHomeDir()
+		if err == nil && home != "" {
+			src = filepath.Join(home, strings.TrimPrefix(src, "~/"))
+		}
+	}
+	return filepath.Clean(src), true
 }
 
 // cycleMode advances the input mode normal → plan → YOLO → normal (Tab),
@@ -1069,7 +1315,7 @@ func (m *chatTUI) cycleMode() {
 // startTurn commits the user bubble to scrollback, resets the turn accumulator,
 // and kicks off runner.Run. `sent` goes to the model (may carry a plan-mode
 // marker); `displayed` is what the transcript shows.
-func (m *chatTUI) startTurn(sent, displayed string) tea.Cmd {
+func (m *chatTUI) startTurn(sent, displayed string, attachments []chatAttachment) tea.Cmd {
 	// Flush any half-streamed leftover before the new turn (defensive).
 	m.commitReasoning()
 	m.commitPending()
@@ -1078,6 +1324,7 @@ func (m *chatTUI) startTurn(sent, displayed string) tea.Cmd {
 	// pressing Esc before the server replies un-sends the message, restoring its
 	// text to the input box with nothing stranded in scrollback.
 	m.pendingBubble = displayed
+	m.pendingAttachments = cloneAttachments(attachments)
 	m.bubblePending = true
 	m.turnDiscarded = false
 
@@ -1103,6 +1350,7 @@ func (m *chatTUI) commitPendingBubble() {
 	m.commitLine("") // blank line separating turns
 	m.commitLine(renderUserBubble(m.pendingBubble, m.width, m.planMode))
 	m.pendingBubble = ""
+	m.pendingAttachments = nil
 }
 
 // unsendPending "un-sends" the in-flight turn while the server hasn't replied yet
@@ -1113,6 +1361,8 @@ func (m *chatTUI) commitPendingBubble() {
 func (m *chatTUI) unsendPending() {
 	m.input.SetValue(m.pendingBubble)
 	m.growInputToFit()
+	m.attachments = cloneAttachments(m.pendingAttachments)
+	m.pendingAttachments = nil
 	m.bubblePending = false
 	m.pendingBubble = ""
 	m.turnDiscarded = true
@@ -1315,10 +1565,10 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	default:
 		// A custom command wins over a skill of the same name; both resolve to a turn.
 		if sent, ok := m.ctrl.CustomCommand(input); ok {
-			return m.startTurn(m.ctrl.Compose(sent), input)
+			return m.startTurn(m.ctrl.Compose(sent), input, nil)
 		}
 		if sent, ok := m.ctrl.RunSkill(input); ok {
-			return m.startTurn(m.ctrl.Compose(sent), input)
+			return m.startTurn(m.ctrl.Compose(sent), input, nil)
 		}
 		m.notice(fmt.Sprintf("%s: %s", i18n.M.SlashUnknown, cmd))
 	}
@@ -1419,10 +1669,10 @@ func (m *chatTUI) notice(note string) {
 
 // resolveRefs resolves a line's @references off the event loop via the
 // controller, delivering a refsResolvedMsg with the tagged context block.
-func (m *chatTUI) resolveRefs(line string) tea.Cmd {
+func (m *chatTUI) resolveRefs(sent, display string, attachments []chatAttachment) tea.Cmd {
 	return func() tea.Msg {
-		block, errs := m.ctrl.ResolveRefs(context.Background(), line)
-		return refsResolvedMsg{line: line, block: block, errs: errs}
+		block, errs := m.ctrl.ResolveRefs(context.Background(), sent)
+		return refsResolvedMsg{sent: sent, display: display, attachments: attachments, block: block, errs: errs}
 	}
 }
 
@@ -1489,6 +1739,7 @@ func wrapForViewport(text string, width int, fg color.Color) string {
 
 // renderUserBubble styles the just-submitted line with a filled dim background.
 func renderUserBubble(line string, width int, planMode bool) string {
+	line = displayLineForImageRefs(line)
 	prefix := "› "
 	if planMode {
 		prefix = "› [plan] "
@@ -1505,6 +1756,17 @@ func renderUserBubble(line string, width int, planMode bool) string {
 		Width(w).
 		Padding(0, 1)
 	return bubble.Render(prefix + line)
+}
+
+var cliImageRefRe = regexp.MustCompile(`(?:^|\s)@\.reasonix/attachments/clipboard-\d{8}-\d{6}\.\d+\.(?:png|jpg|jpeg|gif|webp|tiff)`)
+
+func displayLineForImageRefs(line string) string {
+	idx := 0
+	out := cliImageRefRe.ReplaceAllStringFunc(line, func(_ string) string {
+		idx++
+		return " [image" + strconv.Itoa(idx) + "]"
+	})
+	return strings.TrimSpace(out)
 }
 
 // eventSink is the event.Sink the agent emits to in TUI mode. Each event

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -65,6 +65,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/hooks", insert: "/hooks ", hint: i18n.M.CmdHooks, descend: true},
 		{label: "/help", insert: "/help ", hint: i18n.M.CmdHelp},
 		{label: "/memory", insert: "/memory ", hint: i18n.M.CmdMemory},
+		{label: "/paste-image", insert: "/paste-image", hint: "paste clipboard image as @attachment"},
 	}
 	for _, c := range m.commands {
 		items = append(items, compItem{label: "/" + c.Name, insert: "/" + c.Name + " ", hint: c.Description})

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -3,6 +3,7 @@ package control
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -88,14 +89,14 @@ func ImageDataURL(path string) (string, error) {
 	if clean == "." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || !strings.HasPrefix(clean, prefix+string(filepath.Separator)) {
 		return "", fmt.Errorf("attachment path is outside .reasonix/attachments")
 	}
-	info, err := os.Stat(clean)
+	info, err := lstatAttachmentNoSymlinks(clean)
 	if err != nil {
 		return "", err
 	}
 	if info.IsDir() || info.Size() <= 0 || info.Size() > maxImageAttachmentBytes {
 		return "", fmt.Errorf("attachment image must be between 1 byte and 10 MB")
 	}
-	raw, err := os.ReadFile(clean)
+	raw, err := readVerifiedAttachment(clean, info)
 	if err != nil {
 		return "", err
 	}
@@ -109,6 +110,54 @@ func ImageDataURL(path string) (string, error) {
 		return "", fmt.Errorf("attachment is not an image")
 	}
 	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(raw), nil
+}
+
+func lstatAttachmentNoSymlinks(path string) (os.FileInfo, error) {
+	clean := filepath.Clean(path)
+	var info os.FileInfo
+	cur := ""
+	for _, part := range strings.Split(clean, string(filepath.Separator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		cur = filepath.Join(cur, part)
+		fi, err := os.Lstat(cur)
+		if err != nil {
+			return nil, err
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			return nil, fmt.Errorf("attachment path must not contain symlinks")
+		}
+		info = fi
+	}
+	if info == nil {
+		return nil, fmt.Errorf("invalid attachment path")
+	}
+	return info, nil
+}
+
+func readVerifiedAttachment(path string, expected os.FileInfo) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	opened, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !os.SameFile(expected, opened) {
+		return nil, fmt.Errorf("attachment changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, maxImageAttachmentBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) == 0 || len(raw) > maxImageAttachmentBytes {
+		return nil, fmt.Errorf("attachment image must be between 1 byte and 10 MB")
+	}
+	return raw, nil
 }
 
 func saveDarwinClipboardImage() (string, error) {

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -51,6 +51,28 @@ func SaveImageBytes(mime string, raw []byte) (string, error) {
 	return filepath.ToSlash(rel), nil
 }
 
+func SaveImageFile(path string) (string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("pasted image path is a directory")
+	}
+	if info.Size() <= 0 || info.Size() > maxImageAttachmentBytes {
+		return "", fmt.Errorf("pasted image must be between 1 byte and 10 MB")
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	mime := imageMime(raw, path)
+	if mime == "" {
+		return "", fmt.Errorf("unsupported image file: %s", path)
+	}
+	return SaveImageBytes(mime, raw)
+}
+
 func SaveClipboardImage() (string, error) {
 	switch runtime.GOOS {
 	case "darwin":
@@ -90,7 +112,24 @@ func ImageDataURL(path string) (string, error) {
 }
 
 func saveDarwinClipboardImage() (string, error) {
-	rel := attachmentPath(".png")
+	for _, format := range []struct {
+		class string
+		ext   string
+	}{
+		{class: "PNGf", ext: ".png"},
+		{class: "JPEG", ext: ".jpg"},
+		{class: "TIFF", ext: ".tiff"},
+	} {
+		rel, err := saveDarwinClipboardClass(format.class, format.ext)
+		if err == nil {
+			return rel, nil
+		}
+	}
+	return "", fmt.Errorf("clipboard does not contain a supported image")
+}
+
+func saveDarwinClipboardClass(class, ext string) (string, error) {
+	rel := attachmentPath(ext)
 	if err := os.MkdirAll(filepath.Dir(rel), 0o755); err != nil {
 		return "", err
 	}
@@ -101,9 +140,9 @@ func saveDarwinClipboardImage() (string, error) {
 	script := fmt.Sprintf(`
 set outPath to POSIX file %q
 try
-	set img to the clipboard as «class PNGf»
+	set img to the clipboard as «class %s»
 on error
-	error "clipboard does not contain a PNG-compatible image"
+	error "clipboard does not contain this image type"
 end try
 set f to open for access outPath with write permission
 try
@@ -116,7 +155,7 @@ on error errMsg
 	end try
 	error errMsg
 end try
-`, abs)
+`, abs, class)
 	if out, err := exec.Command("osascript", "-e", script).CombinedOutput(); err != nil {
 		_ = os.Remove(rel)
 		return "", fmt.Errorf("read clipboard image: %s", strings.TrimSpace(string(out)))
@@ -160,7 +199,7 @@ func imageMimeFromExt(ext string) string {
 		return "image/gif"
 	case ".webp":
 		return "image/webp"
-	case ".tiff":
+	case ".tiff", ".tif":
 		return "image/tiff"
 	}
 	return ""

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -1,0 +1,167 @@
+package control
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+const maxImageAttachmentBytes = 10 * 1024 * 1024
+
+func SaveImageDataURL(dataURL string) (string, error) {
+	const prefix = "data:"
+	const marker = ";base64,"
+
+	if !strings.HasPrefix(dataURL, prefix) {
+		return "", fmt.Errorf("unsupported pasted image")
+	}
+	i := strings.Index(dataURL, marker)
+	if i <= len(prefix) {
+		return "", fmt.Errorf("unsupported pasted image")
+	}
+	mime := strings.ToLower(dataURL[len(prefix):i])
+	raw, err := base64.StdEncoding.DecodeString(dataURL[i+len(marker):])
+	if err != nil {
+		return "", fmt.Errorf("decode pasted image: %w", err)
+	}
+	return SaveImageBytes(mime, raw)
+}
+
+func SaveImageBytes(mime string, raw []byte) (string, error) {
+	ext := imageExt(mime)
+	if ext == "" {
+		return "", fmt.Errorf("unsupported image type: %s", mime)
+	}
+	if len(raw) == 0 || len(raw) > maxImageAttachmentBytes {
+		return "", fmt.Errorf("pasted image must be between 1 byte and 10 MB")
+	}
+	rel := attachmentPath(ext)
+	if err := os.MkdirAll(filepath.Dir(rel), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(rel, raw, 0o644); err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func SaveClipboardImage() (string, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return saveDarwinClipboardImage()
+	default:
+		return "", fmt.Errorf("clipboard image paste is not supported on %s yet", runtime.GOOS)
+	}
+}
+
+func ImageDataURL(path string) (string, error) {
+	clean := filepath.Clean(path)
+	prefix := filepath.Join(".reasonix", "attachments")
+	if clean == "." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) || !strings.HasPrefix(clean, prefix+string(filepath.Separator)) {
+		return "", fmt.Errorf("attachment path is outside .reasonix/attachments")
+	}
+	info, err := os.Stat(clean)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() || info.Size() <= 0 || info.Size() > maxImageAttachmentBytes {
+		return "", fmt.Errorf("attachment image must be between 1 byte and 10 MB")
+	}
+	raw, err := os.ReadFile(clean)
+	if err != nil {
+		return "", err
+	}
+	mime := http.DetectContentType(raw[:min(len(raw), 512)])
+	if !strings.HasPrefix(mime, "image/") {
+		if extMime := imageMimeFromExt(filepath.Ext(clean)); extMime != "" {
+			mime = extMime
+		}
+	}
+	if !strings.HasPrefix(mime, "image/") {
+		return "", fmt.Errorf("attachment is not an image")
+	}
+	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(raw), nil
+}
+
+func saveDarwinClipboardImage() (string, error) {
+	rel := attachmentPath(".png")
+	if err := os.MkdirAll(filepath.Dir(rel), 0o755); err != nil {
+		return "", err
+	}
+	abs, err := filepath.Abs(rel)
+	if err != nil {
+		return "", err
+	}
+	script := fmt.Sprintf(`
+set outPath to POSIX file %q
+try
+	set img to the clipboard as «class PNGf»
+on error
+	error "clipboard does not contain a PNG-compatible image"
+end try
+set f to open for access outPath with write permission
+try
+	set eof f to 0
+	write img to f
+	close access f
+on error errMsg
+	try
+		close access f
+	end try
+	error errMsg
+end try
+`, abs)
+	if out, err := exec.Command("osascript", "-e", script).CombinedOutput(); err != nil {
+		_ = os.Remove(rel)
+		return "", fmt.Errorf("read clipboard image: %s", strings.TrimSpace(string(out)))
+	}
+	if info, err := os.Stat(rel); err != nil {
+		return "", err
+	} else if info.Size() == 0 || info.Size() > maxImageAttachmentBytes {
+		_ = os.Remove(rel)
+		return "", fmt.Errorf("clipboard image must be between 1 byte and 10 MB")
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+func attachmentPath(ext string) string {
+	return filepath.Join(".reasonix", "attachments", "clipboard-"+time.Now().Format("20060102-150405.000000")+ext)
+}
+
+func imageExt(mime string) string {
+	switch strings.ToLower(mime) {
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/tiff":
+		return ".tiff"
+	}
+	return ""
+}
+
+func imageMimeFromExt(ext string) string {
+	switch strings.ToLower(ext) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".tiff":
+		return "image/tiff"
+	}
+	return ""
+}

--- a/internal/control/attachments_test.go
+++ b/internal/control/attachments_test.go
@@ -1,0 +1,55 @@
+package control
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSaveImageDataURL(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	got, err := SaveImageDataURL("data:image/png;base64,iVBORw0KGgo=")
+	if err != nil {
+		t.Fatalf("SaveImageDataURL: %v", err)
+	}
+	if !strings.HasPrefix(got, ".reasonix/attachments/clipboard-") || !strings.HasSuffix(got, ".png") {
+		t.Fatalf("path = %q, want attachment png path", got)
+	}
+	if b, err := os.ReadFile(got); err != nil || string(b) != "\x89PNG\r\n\x1a\n" {
+		t.Fatalf("saved bytes = %q, err=%v", string(b), err)
+	}
+}
+
+func TestSaveImageDataURLRejectsUnsupportedMime(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if _, err := SaveImageDataURL("data:text/plain;base64,aGk="); err == nil {
+		t.Fatal("unsupported mime should fail")
+	}
+}
+
+func TestImageDataURL(t *testing.T) {
+	t.Chdir(t.TempDir())
+	path, err := SaveImageDataURL("data:image/png;base64,iVBORw0KGgo=")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := ImageDataURL(path)
+	if err != nil {
+		t.Fatalf("ImageDataURL: %v", err)
+	}
+	if !strings.HasPrefix(got, "data:image/png;base64,") {
+		t.Fatalf("data url = %q", got)
+	}
+}
+
+func TestImageDataURLRejectsOutsideAttachmentDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("x.png", []byte("\x89PNG\r\n\x1a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ImageDataURL("x.png"); err == nil {
+		t.Fatal("outside attachment dir should fail")
+	}
+}

--- a/internal/control/attachments_test.go
+++ b/internal/control/attachments_test.go
@@ -67,3 +67,39 @@ func TestImageDataURLRejectsOutsideAttachmentDir(t *testing.T) {
 		t.Fatal("outside attachment dir should fail")
 	}
 }
+
+func TestImageDataURLRejectsSymlinkAttachment(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(".reasonix/attachments", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("secret.txt", []byte("not actually an image"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := ".reasonix/attachments/clipboard-20260601-120000.123456.png"
+	if err := os.Symlink("../../secret.txt", link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := ImageDataURL(link); err == nil {
+		t.Fatal("symlink attachment should fail")
+	}
+}
+
+func TestImageDataURLRejectsSymlinkedAttachmentDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.MkdirAll(".reasonix", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll("outside", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("outside/clipboard-20260601-120000.123456.png", []byte("\x89PNG\r\n\x1a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../outside", ".reasonix/attachments"); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := ImageDataURL(".reasonix/attachments/clipboard-20260601-120000.123456.png"); err == nil {
+		t.Fatal("symlinked attachment directory should fail")
+	}
+}

--- a/internal/control/attachments_test.go
+++ b/internal/control/attachments_test.go
@@ -29,6 +29,20 @@ func TestSaveImageDataURLRejectsUnsupportedMime(t *testing.T) {
 	}
 }
 
+func TestSaveImageFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("shot.png", []byte("\x89PNG\r\n\x1a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := SaveImageFile("shot.png")
+	if err != nil {
+		t.Fatalf("SaveImageFile: %v", err)
+	}
+	if !strings.HasPrefix(got, ".reasonix/attachments/clipboard-") || !strings.HasSuffix(got, ".png") {
+		t.Fatalf("path = %q, want attachment png path", got)
+	}
+}
+
 func TestImageDataURL(t *testing.T) {
 	t.Chdir(t.TempDir())
 	path, err := SaveImageDataURL("data:image/png;base64,iVBORw0KGgo=")

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -196,6 +196,8 @@ func imageMime(data []byte, path string) string {
 		return "image/gif"
 	case ".webp":
 		return "image/webp"
+	case ".tiff", ".tif":
+		return "image/tiff"
 	}
 	return ""
 }

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -168,6 +170,9 @@ func readFileRef(path string) (content string, isDir bool, err error) {
 	}
 	data := buf[:n]
 
+	if mime := imageMime(data, path); mime != "" {
+		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — image bytes are not inlined. Use an available MCP image/OCR/vision tool with this path when visual understanding is needed.]", path, mime, info.Size()), false, nil
+	}
 	if bytes.IndexByte(data[:min(n, 8192)], 0) >= 0 {
 		return fmt.Sprintf("[binary file %s, %d bytes — not shown]", path, info.Size()), false, nil
 	}
@@ -175,4 +180,22 @@ func readFileRef(path string) (content string, isDir bool, err error) {
 		return string(data[:maxFileRefBytes]) + fmt.Sprintf("\n…[truncated; file is %d bytes]…", info.Size()), false, nil
 	}
 	return string(data), false, nil
+}
+
+func imageMime(data []byte, path string) string {
+	mime := http.DetectContentType(data[:min(len(data), 512)])
+	if strings.HasPrefix(mime, "image/") {
+		return mime
+	}
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	}
+	return ""
 }

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -70,6 +70,10 @@ func TestReadFileRef(t *testing.T) {
 	if err := os.WriteFile(binPath, []byte{'a', 0x00, 'b'}, 0o644); err != nil {
 		t.Fatal(err)
 	}
+	imgPath := filepath.Join(dir, "shot.png")
+	if err := os.WriteFile(imgPath, []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0x00, 0x00, 0x00, '\r', 'I', 'H', 'D', 'R'}, 0o644); err != nil {
+		t.Fatal(err)
+	}
 	bigPath := filepath.Join(dir, "big.txt")
 	if err := os.WriteFile(bigPath, []byte(strings.Repeat("a", maxFileRefBytes+100)), 0o644); err != nil {
 		t.Fatal(err)
@@ -83,6 +87,12 @@ func TestReadFileRef(t *testing.T) {
 	// Binary file: noted, not dumped.
 	if got, _, err := readFileRef(binPath); err != nil || !strings.Contains(got, "binary file") {
 		t.Errorf("binary file = (%q, %v), want a binary note", got, err)
+	}
+
+	// Image file: noted as image-specific context so MCP vision/OCR tools can use
+	// the path, but the bytes are not dumped into the prompt.
+	if got, _, err := readFileRef(imgPath); err != nil || !strings.Contains(got, "image file") || !strings.Contains(got, "MCP image/OCR/vision tool") {
+		t.Errorf("image file = (%q, %v), want an MCP-friendly image note", got, err)
 	}
 
 	// Large file: truncated with a marker.

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -31,7 +31,7 @@ var English = Messages{
 	PickSessionLabel:  "Resume which session?",
 
 	ChatStatusThinkingFmt:  "%s thinking… (%ds · Esc cancels)",
-	ChatStatusIdle:         "Tab toggles plan · Enter sends · Esc clears/exits state · PgUp/PgDn scrolls · Ctrl-D quits",
+	ChatStatusIdle:         "Tab toggles plan · Ctrl-V pastes image · Enter sends · Esc clears/exits state · PgUp/PgDn scrolls · Ctrl-D quits",
 	ChatStatusPlanApproval: "Enter/y approves & executes · n/Esc keeps planning · PgUp/PgDn scrolls",
 	PlanApprovalPrompt:     "Plan ready above — Enter/y to approve & execute, n/Esc to keep planning",
 	ChatStatusToolApproval: "y approve once · a allow this session · n deny · Ctrl-C cancels turn",
@@ -48,7 +48,7 @@ var English = Messages{
 	SlashUnavailable:   "command unavailable in this build",
 	SlashUnknown:       "unknown command",
 	SlashTodoCleared:   "task list dismissed",
-	SlashHelp:          "commands: /compact · /new · /todo · /model (switch model) · /mcp · /skill · /hooks · /memory · /help · plus skills (/init, /explore, …)",
+	SlashHelp:          "commands: /compact · /new · /todo · /paste-image · /model (switch model) · /mcp · /skill · /hooks · /memory · /help · plus skills (/init, /explore, …)",
 	SlashPromptEmpty:   "the MCP prompt returned no content to send",
 	SlashMCPNone:       "no MCP servers configured — add a [[plugins]] entry in reasonix.toml",
 	CompHintSlash:      "↑/↓ move · Tab/Enter select · Esc close",

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -31,7 +31,7 @@ var English = Messages{
 	PickSessionLabel:  "Resume which session?",
 
 	ChatStatusThinkingFmt:  "%s thinking… (%ds · Esc cancels)",
-	ChatStatusIdle:         "Tab toggles plan · Ctrl-V pastes image · Enter sends · Esc clears/exits state · PgUp/PgDn scrolls · Ctrl-D quits",
+	ChatStatusIdle:         "Tab toggles plan · Ctrl-V/⌘V pastes · Ctrl-Y pastes image · Enter sends · Esc clears/exits state · PgUp/PgDn scrolls · Ctrl-D quits",
 	ChatStatusPlanApproval: "Enter/y approves & executes · n/Esc keeps planning · PgUp/PgDn scrolls",
 	PlanApprovalPrompt:     "Plan ready above — Enter/y to approve & execute, n/Esc to keep planning",
 	ChatStatusToolApproval: "y approve once · a allow this session · n deny · Ctrl-C cancels turn",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -32,7 +32,7 @@ var Chinese = Messages{
 	PickSessionLabel:  "恢复哪个会话？",
 
 	ChatStatusThinkingFmt:  "%s 思考中… (%d 秒 · Esc 取消)",
-	ChatStatusIdle:         "Tab 切换 plan · Ctrl-V 粘贴图片 · Enter 发送 · Esc 退出当前状态 · PgUp/PgDn 滚动 · Ctrl-D 退出",
+	ChatStatusIdle:         "Tab 切换 plan · Ctrl-V/⌘V 粘贴 · Ctrl-Y 粘贴图片 · Enter 发送 · Esc 退出当前状态 · PgUp/PgDn 滚动 · Ctrl-D 退出",
 	ChatStatusPlanApproval: "Enter/y 批准并执行 · n/Esc 继续规划 · PgUp/PgDn 滚动",
 	PlanApprovalPrompt:     "计划已生成（见上方）— Enter/y 批准执行,n/Esc 继续规划",
 	ChatStatusToolApproval: "y 同意一次 · a 本会话允许 · n 拒绝 · Ctrl-C 取消本轮",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -32,7 +32,7 @@ var Chinese = Messages{
 	PickSessionLabel:  "恢复哪个会话？",
 
 	ChatStatusThinkingFmt:  "%s 思考中… (%d 秒 · Esc 取消)",
-	ChatStatusIdle:         "Tab 切换 plan · Enter 发送 · Esc 退出当前状态 · PgUp/PgDn 滚动 · Ctrl-D 退出",
+	ChatStatusIdle:         "Tab 切换 plan · Ctrl-V 粘贴图片 · Enter 发送 · Esc 退出当前状态 · PgUp/PgDn 滚动 · Ctrl-D 退出",
 	ChatStatusPlanApproval: "Enter/y 批准并执行 · n/Esc 继续规划 · PgUp/PgDn 滚动",
 	PlanApprovalPrompt:     "计划已生成（见上方）— Enter/y 批准执行,n/Esc 继续规划",
 	ChatStatusToolApproval: "y 同意一次 · a 本会话允许 · n 拒绝 · Ctrl-C 取消本轮",
@@ -49,7 +49,7 @@ var Chinese = Messages{
 	SlashUnavailable:   "当前构建不支持该命令",
 	SlashUnknown:       "未知命令",
 	SlashTodoCleared:   "已清除任务清单",
-	SlashHelp:          "命令：/compact · /new · /todo · /model（切换模型）· /mcp · /skill · /hooks · /memory · /help · 以及 skills（/init、/explore …）",
+	SlashHelp:          "命令：/compact · /new · /todo · /paste-image · /model（切换模型）· /mcp · /skill · /hooks · /memory · /help · 以及 skills（/init、/explore …）",
 	SlashPromptEmpty:   "该 MCP prompt 没有返回可发送的内容",
 	SlashMCPNone:       "没有配置 MCP 服务器 — 在 reasonix.toml 加一个 [[plugins]] 条目",
 	CompHintSlash:      "↑/↓ 移动 · Tab/Enter 选中 · Esc 关闭",


### PR DESCRIPTION
## Summary

Add image paste support for the desktop composer and terminal chat UI by saving pasted clipboard images as workspace attachments and inserting them into the prompt as `@.reasonix/attachments/...` references.

This gives users a practical image workflow even when the active DeepSeek model is text-only: the model receives a stable local image path and can call an MCP vision/OCR/image-understanding tool to inspect that file and continue the conversation from the returned text result.

## Root Cause

Reasonix previously treated chat input as plain text only. Desktop users could paste text, but pasted images were ignored by the composer. The backend also represented provider messages as text, so directly embedding image bytes as multimodal content would require a larger provider abstraction change and would not help text-only DeepSeek models.

## Technical Approach

- Persist pasted desktop images into `.reasonix/attachments/clipboard-*.{png,jpg,gif,webp}` and send them as `@` file references.
- Add a shared attachment helper that validates image MIME types, size limits, and safe `.reasonix/attachments` reads.
- Render image attachments as visual thumbnails instead of exposing internal file paths in the composer or transcript.
- Add an image preview overlay with download, close, and zoom controls.
- Teach `@` reference expansion to identify image files and guide the agent to use an available MCP image/OCR/vision tool instead of inlining binary bytes.
- Add CLI parity with `Ctrl+V` / `Ctrl+Y` and `/paste-image` for clipboard image attachment insertion on macOS.

## Focused Optimization Points

- Avoids changing provider-visible multimodal message schemas, preserving the existing text-first DeepSeek request path.
- Keeps image bytes out of prompts; only a local attachment path is included.
- Makes the MCP integration explicit: text-only models can still analyze images through MCP tools that read the saved file path.
- Hides implementation details from users by rendering attachments as thumbnails and image cards rather than raw `@.reasonix/attachments/...` paths.
- Restricts desktop preview reads to `.reasonix/attachments` and caps image size at 10 MB.

## Verification

- `go test ./...`
- `go test ./...` in `desktop/`
- `npm exec tsc -- --noEmit` in `desktop/frontend/`
- `npm run build` in `desktop/frontend/`
- `git diff --check`
