### PR TITLE
docs: drop external-agent references from two comments

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -895,9 +895,8 @@ func compactionCardLines(c event.Compaction) []string {
 
 // contextTag renders the prompt-vs-context-window gauge for the status line,
 // framed around the auto-compaction threshold: it shows how much headroom is
-// left until the next compaction (mirroring Claude Code's "context left until
-// auto-compact"), and colours by proximity to that point rather than the raw
-// window. Falls back to a plain percentage when compaction is disabled.
+// left until the next compaction, and colours by proximity to that point rather
+// than the raw window. Falls back to a plain percentage when compaction is disabled.
 func (m chatTUI) contextTag() string {
 	used, window := m.ctrl.ContextSnapshot()
 	if used == 0 || window == 0 {

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -111,8 +111,8 @@ func (r *Runner) Notification(ctx context.Context, message string) {
 }
 
 // PreCompact fires just before a compaction pass and returns the concatenated
-// stdout of its hooks as extra summary guidance (CC's additionalContext), so a
-// hook can steer what the summary keeps. Non-pass outcomes are surfaced via notify.
+// stdout of its hooks as extra summary guidance, so a hook can steer what the
+// summary keeps. Non-pass outcomes are surfaced via notify.
 func (r *Runner) PreCompact(ctx context.Context, trigger string) string {
 	if !r.Enabled() {
 		return ""


### PR DESCRIPTION
Removes two gratuitous third-party-tool mentions in code comments introduced with the lifecycle-hooks change (the PreCompact runner doc and the contextTag doc). Comment-only; no behaviour change.