### PR TITLE
fix(ui): keep chat transcript pinned while streaming

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { Item } from "../lib/useController";
 import { AssistantMessage, UserMessage } from "./Message";
 import { ToolCard } from "./ToolCard";
@@ -16,10 +16,24 @@ export function Transcript({
   onRewind?: (turn: number, scope: string) => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const frameRef = useRef<number | null>(null);
   // stick tracks whether the view is pinned to the bottom; once the user scrolls
   // up to read, we stop yanking them back down.
   const stick = useRef(true);
 
+  const followBottom = () => {
+    if (!stick.current) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  };
+  const queueFollowBottom = () => {
+    if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      followBottom();
+    });
+  };
   const onScroll = () => {
     const el = scrollRef.current;
     if (el) stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
@@ -28,15 +42,24 @@ export function Transcript({
   // Follow new content by setting scrollTop directly (no scrollIntoView fighting
   // the browser's scroll anchoring), and inside rAF so layout has settled first —
   // together with plain-text streaming this keeps the view from jittering.
+  useLayoutEffect(() => {
+    followBottom();
+    queueFollowBottom();
+  }, [items]);
+
   useEffect(() => {
-    if (!stick.current) return;
     const el = scrollRef.current;
     if (!el) return;
-    const id = requestAnimationFrame(() => {
-      el.scrollTop = el.scrollHeight;
-    });
-    return () => cancelAnimationFrame(id);
-  }, [items]);
+    const mutation = new MutationObserver(queueFollowBottom);
+    mutation.observe(el, { childList: true, subtree: true, characterData: true });
+    const resize = new ResizeObserver(queueFollowBottom);
+    resize.observe(el);
+    return () => {
+      mutation.disconnect();
+      resize.disconnect();
+      if (frameRef.current !== null) cancelAnimationFrame(frameRef.current);
+    };
+  }, []);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -33,13 +33,29 @@ const log = document.getElementById('log');
 const input = document.getElementById('in');
 const approval = document.getElementById('approval');
 let asst = null; // current assistant text node being streamed
+let stick = true;
+let scrollFrame = 0;
+
+function atBottom() {
+  return log.scrollHeight - log.scrollTop - log.clientHeight < 80;
+}
+function followBottom() {
+  if (!stick) return;
+  if (scrollFrame) cancelAnimationFrame(scrollFrame);
+  scrollFrame = requestAnimationFrame(() => {
+    scrollFrame = 0;
+    if (!stick) return;
+    log.scrollTop = log.scrollHeight;
+  });
+}
+log.addEventListener('scroll', () => { stick = atBottom(); });
 
 function line(cls, text) {
   const el = document.createElement('div');
   if (cls) el.className = cls;
   el.textContent = text;
   log.appendChild(el);
-  log.scrollTop = log.scrollHeight;
+  followBottom();
   return el;
 }
 function post(path, body) {
@@ -71,10 +87,10 @@ const es = new EventSource('/events');
 es.onmessage = ev => {
   const e = JSON.parse(ev.data);
   switch (e.kind) {
-    case 'reasoning': (asst && asst.dataset.r ? asst : (asst = line('reason', ''), asst.dataset.r = '1')); asst.textContent += e.text; break;
+    case 'reasoning': (asst && asst.dataset.r ? asst : (asst = line('reason', ''), asst.dataset.r = '1')); asst.textContent += e.text; followBottom(); break;
     case 'text':
       if (!asst || asst.dataset.r) { asst = line('', ''); }
-      asst.textContent += e.text; break;
+      asst.textContent += e.text; followBottom(); break;
     case 'message': asst = null; break;
     case 'tool_dispatch': asst = null; line('tool', '→ ' + e.tool.name + ' ' + (e.tool.args || '')); break;
     case 'tool_result': if (e.tool && e.tool.err) line('err', '⊘ ' + e.tool.name + ' ' + e.tool.err); break;


### PR DESCRIPTION
Fixes #2468.

## Summary
- keep the lightweight HTTP transcript pinned while assistant text/reasoning streams into an existing DOM node
- preserve user intent by disabling follow mode when the user scrolls up and resuming it once they return to the bottom
- make the desktop transcript follow DOM text mutations/resizes during streaming, not only new item array changes

## Testing
- `git diff --check`
- `go test ./internal/serve`
- `cd desktop/frontend && npx -y pnpm@9.15.9 build`
- Chrome extension local scroll harness against `internal/serve/index.html`: pass; streaming follows at bottom, stays put after manual scroll-up, resumes after returning to bottom

## Local note
- Full `go test ./...` was attempted, but this machine has unrelated local-environment failures: user-global skill index content affects `internal/boot`, and macOS sandbox enforcement tests do not deny writes in this environment.
