### PR TITLE
feat(outputstyle): selectable persona/tone output styles

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/hook"
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
+	"reasonix/internal/outputstyle"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -93,6 +94,12 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	sysPrompt, err := cfg.ResolveSystemPrompt()
 	if err != nil {
 		return nil, err
+	}
+	// Output style: fold the selected persona/tone block into the base prompt
+	// before language/memory/skills append, so a "replace" style (keep-coding
+	// false) still keeps those. Applied once, into the cache-stable prefix.
+	if st, ok := outputstyle.Resolve(cfg.Agent.OutputStyle, outputstyle.Dirs()); ok {
+		sysPrompt = outputstyle.Apply(sysPrompt, st)
 	}
 	// Append the language policy so the model answers in the user's own language
 	// (the UI `language` setting governs only the interface). Static text, so it

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/i18n"
 	"reasonix/internal/memory"
+	"reasonix/internal/outputstyle"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 	"reasonix/internal/skill"
@@ -138,6 +139,10 @@ type chatTUI struct {
 	// modelRef is the active "provider/model" ref, marked current in the picker.
 	buildController func(ref string, carry []provider.Message) (*control.Controller, error)
 	modelRef        string
+
+	// outputStyle is the active output-style name (config agent.output_style),
+	// shown as the current entry in the /output-style listing. "" = default.
+	outputStyle string
 
 	// modelSwitchPending is true while an async /model build is in flight.
 	modelSwitchPending bool
@@ -1381,6 +1386,13 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.runSkillSubcommand(input)
 	case "/hooks":
 		m.runHooksSubcommand(input)
+	case "/output-style", "/output-styles":
+		styles := outputstyle.List(outputstyle.Dirs())
+		if len(styles) == 0 {
+			m.notice(i18n.M.OutputStyleNone)
+		} else {
+			m.notice(i18n.M.OutputStyleHeader + "\n" + outputstyle.DescribeList(styles, m.outputStyle) + "\n" + i18n.M.OutputStyleHint)
+		}
 	case "/help":
 		m.notice(i18n.M.SlashHelp)
 		if names := m.commandNames(); names != "" {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -293,6 +293,9 @@ func chatREPL(args []string) int {
 	}
 
 	m := newChatTUI(ctrl, missing, eventCh, termW)
+	if cfg, err := config.Load(); err == nil {
+		m.outputStyle = cfg.Agent.OutputStyle // shown as the active entry in /output-style
+	}
 
 	// /model support: a pure builder the TUI calls to rebuild on a different
 	// model (carrying the conversation). It must NOT touch the running model —

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -63,6 +63,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/model", insert: "/model ", hint: i18n.M.CmdModel, descend: true},
 		{label: "/skill", insert: "/skill ", hint: i18n.M.CmdSkill, descend: true},
 		{label: "/hooks", insert: "/hooks ", hint: i18n.M.CmdHooks, descend: true},
+		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},
 		{label: "/help", insert: "/help ", hint: i18n.M.CmdHelp},
 		{label: "/memory", insert: "/memory ", hint: i18n.M.CmdMemory},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,10 @@ type AgentConfig struct {
 	PlannerModel     string            `toml:"planner_model"`
 	SubagentModel    string            `toml:"subagent_model"`
 	SubagentModels   map[string]string `toml:"subagent_models"`
+	// OutputStyle selects a persona/tone block folded into the system prompt at
+	// startup (a built-in like "explanatory"/"learning"/"concise", or a custom
+	// .reasonix/output-styles/<name>.md). Empty = the unmodified prompt.
+	OutputStyle string `toml:"output_style"`
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -51,6 +51,11 @@ func RenderTOML(c *Config) string {
 	} else {
 		b.WriteString("# subagent_models = { review = \"deepseek-pro\", security_review = \"deepseek-pro\" }   # per-skill overrides\n")
 	}
+	if c.Agent.OutputStyle != "" {
+		fmt.Fprintf(&b, "output_style = %q   # persona/tone folded into the prompt\n", c.Agent.OutputStyle)
+	} else {
+		b.WriteString("# output_style = \"explanatory\"   # explanatory | learning | concise | custom; empty = default\n")
+	}
 	b.WriteString("\n")
 
 	for _, p := range c.Providers {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -68,6 +68,11 @@ type Messages struct {
 	AskChatInstead     string // the "don't pick, just chat" option label
 	ChatStatusQuestion string // shortcuts hint while a question card is open
 
+	// output style listing (/output-style).
+	OutputStyleNone   string // no styles available
+	OutputStyleHeader string // header above the listing
+	OutputStyleHint   string // how to select one
+
 	// context compaction card (CompactionStarted / CompactionDone events).
 	CompactionWorking string // shown while the summarizer runs
 	CompactionTitle   string // card header before "· N messages · <trigger>"
@@ -98,6 +103,7 @@ type Messages struct {
 	CmdMemory       string // /memory
 	CmdMcp          string // /mcp
 	CmdHooks        string // /hooks
+	CmdOutputStyle  string // /output-style
 	CmdSkill        string // /skill
 	CmdHelp         string // /help
 	CmdTodo         string // /todo

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -41,6 +41,10 @@ var English = Messages{
 	ChatStatusQuestion:     "↑/↓ move · number to pick · space multi · Enter confirm · ←/→ switch · Esc cancel",
 	ToolApprovalPromptFmt:  "Allow %s%s? — [y] once · [a] this session · [n] no",
 
+	OutputStyleNone:   "no output styles available",
+	OutputStyleHeader: "output styles:",
+	OutputStyleHint:   "set agent.output_style in reasonix.toml to apply one (takes effect next session)",
+
 	CompactionWorking: "compacting conversation…",
 	CompactionTitle:   "Context compacted",
 	CompactionUnit:    "messages",
@@ -67,6 +71,7 @@ var English = Messages{
 	CmdMemory:       "show memory files",
 	CmdMcp:          "MCP servers",
 	CmdHooks:        "manage hooks",
+	CmdOutputStyle:  "list output styles",
 	CmdSkill:        "manage skills",
 	CmdHelp:         "list commands",
 	CmdTodo:         "dismiss the task list",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -42,6 +42,10 @@ var Chinese = Messages{
 	ChatStatusQuestion:     "↑/↓ 选 · 数字快选 · 空格多选 · Enter 确认 · ←/→ 切换问题 · Esc 取消",
 	ToolApprovalPromptFmt:  "允许 %s%s？— [y] 本次 · [a] 本会话 · [n] 拒绝",
 
+	OutputStyleNone:   "没有可用的输出风格",
+	OutputStyleHeader: "输出风格：",
+	OutputStyleHint:   "在 reasonix.toml 设置 agent.output_style 即可启用（下次会话生效）",
+
 	CompactionWorking: "正在压缩对话…",
 	CompactionTitle:   "上下文已压缩",
 	CompactionUnit:    "条消息",
@@ -68,6 +72,7 @@ var Chinese = Messages{
 	CmdMemory:       "查看记忆文件",
 	CmdMcp:          "MCP 服务器",
 	CmdHooks:        "管理 hooks",
+	CmdOutputStyle:  "列出输出风格",
 	CmdSkill:        "管理 skills",
 	CmdHelp:         "查看命令列表",
 	CmdTodo:         "清除任务清单",

--- a/internal/outputstyle/outputstyle.go
+++ b/internal/outputstyle/outputstyle.go
@@ -1,0 +1,197 @@
+// Package outputstyle adds a selectable "output style" — a block of persona /
+// tone instructions appended to (or replacing) the system prompt — so the user
+// can shift how the agent communicates without rewriting the system prompt. It
+// mirrors the skill/command loaders: built-in styles plus markdown files with
+// frontmatter discovered under the project and home convention dirs.
+package outputstyle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"reasonix/internal/frontmatter"
+)
+
+// OutputStyle is one selectable persona. Body is appended to the system prompt
+// (KeepCoding true) or used as the whole prompt (false). Name is the selector
+// (case-insensitive); Builtin marks the baked-in ones for listing.
+type OutputStyle struct {
+	Name        string
+	Description string
+	Body        string
+	KeepCoding  bool // true: append to the coding system prompt; false: replace it
+	Builtin     bool
+	Path        string // file it loaded from ("" for built-ins)
+}
+
+// builtins are the always-available styles. Default ("" / "default") is absent
+// on purpose — no style means the unmodified system prompt.
+var builtins = []OutputStyle{
+	{
+		Name:        "explanatory",
+		Description: "Explain non-obvious implementation choices as you go",
+		KeepCoding:  true,
+		Builtin:     true,
+		Body: "Communication style — Explanatory: as you work, surface the reasoning behind " +
+			"non-obvious choices. After a substantive change, add a short \"## Insight\" note " +
+			"covering the key trade-off or why an alternative was rejected. Teach the why, not just the what; keep it brief.",
+	},
+	{
+		Name:        "learning",
+		Description: "Collaborate and leave TODO(human) stubs for the user to complete",
+		KeepCoding:  true,
+		Builtin:     true,
+		Body: "Communication style — Learning: work collaboratively rather than doing everything. " +
+			"When a meaningful implementation decision comes up, pause and ask the user to make the call. " +
+			"For the most instructive pieces, write the surrounding code but leave a small, clearly-marked " +
+			"`TODO(human)` stub with a one-line description for the user to implement themselves.",
+	},
+	{
+		Name:        "concise",
+		Description: "Terse replies: minimal prose, code and bullets only",
+		KeepCoding:  true,
+		Builtin:     true,
+		Body: "Communication style — Concise: keep replies terse. No preamble or postamble, no restating " +
+			"the request. Prefer code and short bullet points over paragraphs; answer in the fewest words that are still clear.",
+	},
+}
+
+// Dirs returns the output-style search directories in load order (later wins),
+// mirroring command/skill discovery: home convention dirs, then project ones.
+func Dirs() []string {
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil {
+		for i := len(conventionDirs) - 1; i >= 0; i-- {
+			dirs = append(dirs, filepath.Join(home, conventionDirs[i], "output-styles"))
+		}
+	}
+	for i := len(conventionDirs) - 1; i >= 0; i-- {
+		dirs = append(dirs, filepath.Join(".", conventionDirs[i], "output-styles"))
+	}
+	return dirs
+}
+
+// conventionDirs mirrors config.ConventionDirs (kept local to avoid an import
+// cycle; config imports nothing from here, but this package stays dependency-light).
+var conventionDirs = []string{".reasonix", ".agents", ".agent", ".claude"}
+
+// List returns every available style — built-ins plus the markdown files under
+// dirs — deduped by lowercased name, with custom files overriding built-ins.
+// Sorted by name. Malformed files are skipped.
+func List(dirs []string) []OutputStyle {
+	byName := map[string]OutputStyle{}
+	for _, b := range builtins {
+		byName[strings.ToLower(b.Name)] = b
+	}
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			st, ok := parseFile(filepath.Join(dir, e.Name()))
+			if !ok {
+				continue
+			}
+			byName[strings.ToLower(st.Name)] = st
+		}
+	}
+	out := make([]OutputStyle, 0, len(byName))
+	for _, st := range byName {
+		out = append(out, st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// Resolve finds the style named name (case-insensitive) among dirs + built-ins.
+// An empty or "default" name returns ok=false (no style — leave the prompt as-is).
+func Resolve(name string, dirs []string) (OutputStyle, bool) {
+	n := strings.ToLower(strings.TrimSpace(name))
+	if n == "" || n == "default" {
+		return OutputStyle{}, false
+	}
+	for _, st := range List(dirs) {
+		if strings.ToLower(st.Name) == n {
+			return st, true
+		}
+	}
+	return OutputStyle{}, false
+}
+
+// Apply folds a style into a base system prompt: appended when KeepCoding is set,
+// otherwise the style replaces the prompt (a pure persona). A style with an empty
+// body leaves the base untouched.
+func Apply(base string, st OutputStyle) string {
+	if strings.TrimSpace(st.Body) == "" {
+		return base
+	}
+	if !st.KeepCoding {
+		return st.Body
+	}
+	if strings.TrimSpace(base) == "" {
+		return st.Body
+	}
+	return base + "\n\n" + st.Body
+}
+
+// parseFile loads one <name>.md output-style file. The name is the filename
+// stem; frontmatter supplies description and keep-coding-instructions; the body
+// is the prompt text.
+func parseFile(path string) (OutputStyle, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return OutputStyle{}, false
+	}
+	meta, body := frontmatter.Split(string(b))
+	name := meta["name"]
+	if name == "" {
+		name = strings.TrimSuffix(filepath.Base(path), ".md")
+	}
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return OutputStyle{}, false
+	}
+	keep := true // default: augment the coding prompt rather than replace it
+	if v, ok := meta["keep-coding-instructions"]; ok {
+		keep = !isFalse(v)
+	}
+	return OutputStyle{
+		Name:        name,
+		Description: meta["description"],
+		Body:        body,
+		KeepCoding:  keep,
+		Path:        path,
+	}, true
+}
+
+func isFalse(s string) bool {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "false", "no", "0", "off":
+		return true
+	}
+	return false
+}
+
+// DescribeList renders the available styles as a short listing for /output-style.
+func DescribeList(styles []OutputStyle, active string) string {
+	var b strings.Builder
+	for _, st := range styles {
+		marker := "  "
+		if strings.EqualFold(st.Name, active) {
+			marker = "* "
+		}
+		scope := "builtin"
+		if !st.Builtin {
+			scope = "custom"
+		}
+		fmt.Fprintf(&b, "%s%s (%s) — %s\n", marker, st.Name, scope, st.Description)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/outputstyle/outputstyle_test.go
+++ b/internal/outputstyle/outputstyle_test.go
@@ -1,0 +1,93 @@
+package outputstyle
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveBuiltin(t *testing.T) {
+	st, ok := Resolve("explanatory", nil)
+	if !ok {
+		t.Fatal("explanatory built-in should resolve")
+	}
+	if !st.Builtin || !st.KeepCoding || strings.TrimSpace(st.Body) == "" {
+		t.Errorf("unexpected built-in shape: %+v", st)
+	}
+	// Case-insensitive.
+	if _, ok := Resolve("LEARNING", nil); !ok {
+		t.Error("resolve should be case-insensitive")
+	}
+}
+
+func TestResolveDefaultIsNone(t *testing.T) {
+	for _, name := range []string{"", "  ", "default"} {
+		if _, ok := Resolve(name, nil); ok {
+			t.Errorf("Resolve(%q) should be no-style", name)
+		}
+	}
+}
+
+func TestApply(t *testing.T) {
+	append1 := Apply("BASE", OutputStyle{Body: "X", KeepCoding: true})
+	if append1 != "BASE\n\nX" {
+		t.Errorf("keep-coding append = %q", append1)
+	}
+	replace := Apply("BASE", OutputStyle{Body: "X", KeepCoding: false})
+	if replace != "X" {
+		t.Errorf("replace = %q, want X", replace)
+	}
+	if got := Apply("BASE", OutputStyle{Body: "   "}); got != "BASE" {
+		t.Errorf("empty body should leave base untouched, got %q", got)
+	}
+}
+
+func TestListIncludesBuiltinsSorted(t *testing.T) {
+	got := List(nil)
+	if len(got) < 3 {
+		t.Fatalf("expected at least the 3 built-ins, got %d", len(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Name > got[i].Name {
+			t.Errorf("not sorted by name: %q before %q", got[i-1].Name, got[i].Name)
+		}
+	}
+}
+
+func TestCustomFileOverridesBuiltinAndParses(t *testing.T) {
+	dir := t.TempDir()
+	// Override the built-in "explanatory" with a custom replace-style file.
+	md := "---\ndescription: my persona\nkeep-coding-instructions: false\n---\nYou are a pirate. Answer in pirate speak.\n"
+	if err := os.WriteFile(filepath.Join(dir, "explanatory.md"), []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st, ok := Resolve("explanatory", []string{dir})
+	if !ok {
+		t.Fatal("custom explanatory should resolve")
+	}
+	if st.Builtin {
+		t.Error("custom file should override the built-in (Builtin=false)")
+	}
+	if st.KeepCoding {
+		t.Error("keep-coding-instructions: false should disable KeepCoding")
+	}
+	if st.Description != "my persona" || !strings.Contains(st.Body, "pirate") {
+		t.Errorf("frontmatter/body not parsed: %+v", st)
+	}
+	if got := Apply("CODING PROMPT", st); got != st.Body {
+		t.Errorf("a replace-style should drop the base prompt, got %q", got)
+	}
+}
+
+func TestParseFileNameFromFilename(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "snappy.md"), []byte("Be snappy."), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	st, ok := Resolve("snappy", []string{dir})
+	if !ok || st.Name != "snappy" || !st.KeepCoding { // default keep-coding when unspecified
+		t.Errorf("filename-derived style wrong: %+v ok=%v", st, ok)
+	}
+}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -17,6 +17,8 @@ temperature = 0.0
 # planner_model = "mimo-pro"   # optional: enable two-model collaboration
 # subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
 # subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }   # per-skill overrides
+# output_style = "explanatory"   # persona/tone folded into the prompt: explanatory | learning | concise,
+#                                  or a custom .reasonix/output-styles/<name>.md ; empty = default
 
 # A provider is a vendor endpoint (one base_url + key) that offers one or more
 # models. Use `models = [...]` to expose several under a single entry — switching


### PR DESCRIPTION
Adds an **output style** — a block of persona/tone instructions folded into the system prompt — so the user can shift how the agent communicates without rewriting the system prompt.

## What
- **internal/outputstyle**: built-in styles (`explanatory`, `learning`, `concise`) plus custom markdown files with frontmatter discovered under the project/home convention dirs (`.reasonix/output-styles/`, …). `keep-coding-instructions` controls whether the style augments the coding prompt or replaces it (pure persona).
- **config**: `agent.output_style` selects one; resolved and applied at boot, before the language policy / memory / skills append, into the cache-stable prefix.
- **cli**: `/output-style` lists available styles (built-in + custom) with the active one marked; slash-menu entry + en/zh strings.
- example config + `render` round-trip the field.

## Verification
- Unit tests: Resolve (built-in, case-insensitive, default = none), Apply (append vs replace vs empty body), custom-file override + frontmatter parse, filename-derived name.
- Full `go test ./...` (29 pkgs) + desktop build green; gofmt clean.
- Live (DeepSeek): with `output_style = "explanatory"`, the agent adds a reasoned explanation of a division-by-zero design trade-off (and alternatives) it omits by default — confirming the style reaches the model end-to-end.

Note: `/output-style` is read-only listing for now; live mid-session switching (a prompt-prefix rebuild like `/model`) is a follow-up.