### PR TITLE
Fix desktop transcript streaming autoscroll

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -6,6 +6,21 @@ import { Welcome } from "./Welcome";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 
+function scrollVersion(items: Item[]): string {
+  return items
+    .map((it) => {
+      switch (it.kind) {
+        case "assistant":
+          return `${it.id}:a:${it.text.length}:${it.reasoning.length}:${it.streaming ? 1 : 0}`;
+        case "tool":
+          return `${it.id}:t:${it.status}:${it.output?.length ?? 0}:${it.error?.length ?? 0}:${it.truncated ? 1 : 0}`;
+        default:
+          return `${it.id}:${it.kind}`;
+      }
+    })
+    .join("|");
+}
+
 export function Transcript({
   items,
   onPrompt,
@@ -27,7 +42,10 @@ export function Transcript({
 
   // Follow new content by setting scrollTop directly (no scrollIntoView fighting
   // the browser's scroll anchoring), and inside rAF so layout has settled first —
-  // together with plain-text streaming this keeps the view from jittering.
+  // together with plain-text streaming this keeps the view from jittering. The
+  // dependency tracks rendered content, not just array identity, so streaming
+  // still follows the bottom if a reducer reuses the items array.
+  const contentVersion = scrollVersion(items);
   useEffect(() => {
     if (!stick.current) return;
     const el = scrollRef.current;
@@ -36,7 +54,7 @@ export function Transcript({
       el.scrollTop = el.scrollHeight;
     });
     return () => cancelAnimationFrame(id);
-  }, [items]);
+  }, [contentVersion]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -13,7 +13,7 @@ function scrollVersion(items: Item[]): string {
         case "assistant":
           return `${it.id}:a:${it.text.length}:${it.reasoning.length}:${it.streaming ? 1 : 0}`;
         case "tool":
-          return `${it.id}:t:${it.status}:${it.output?.length ?? 0}:${it.error?.length ?? 0}:${it.truncated ? 1 : 0}`;
+          return `${it.id}:t:${it.name}:${it.status}:${it.args.length}:${it.output?.length ?? 0}:${it.error?.length ?? 0}:${it.truncated ? 1 : 0}`;
         default:
           return `${it.id}:${it.kind}`;
       }


### PR DESCRIPTION
## Summary
- Fixes #2483.
- Keeps the desktop transcript pinned to the bottom while assistant text, reasoning, or tool output streams in.

## Root Cause
The transcript autoscroll effect was coupled to the `items` array identity. That works when every streaming reducer update creates a new array, but it is fragile: if the reducer reuses the same array while mutating the active assistant item, the UI can render new content without rerunning the scroll effect.

## Technical Approach
- Add a transcript content version derived from visible message state.
- Include assistant `text`/`reasoning` lengths, streaming state, and tool output/error lengths in that version.
- Drive the autoscroll effect from rendered content changes instead of only `items` identity.

## Focused Optimization Points
- Keeps the existing `requestAnimationFrame` scroll timing and bottom-stick behavior.
- Avoids provider, prompt, tool schema, cache, and backend changes.
- Leaves user scroll-away behavior unchanged: if the user is not near the bottom, the transcript still does not yank them down.

## Verification
- `npm run build`
- `go test ./...`
- Browser dev mock streaming regression on the clean PR worktree: transcript height grew from 422px to 623px while staying pinned, with max bottom distance 1px.
