### PR TITLE
Worktree-Isolated Multi-Agent Runs with Secure Manager Logs

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"sort"
 	"strings"
 
@@ -116,6 +119,106 @@ func (a *App) Cancel() {
 	if a.ctrl != nil {
 		a.ctrl.Cancel()
 	}
+}
+
+// OpenPath reveals a local file or folder in the OS shell. The frontend uses it
+// for worktree agent results; it is explicit user action, not model-driven IO.
+func (a *App) OpenPath(path string) error {
+	abs, err := allowedOpenPath(path)
+	if err != nil {
+		return err
+	}
+	var cmd *exec.Cmd
+	switch goruntime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", abs)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", abs)
+	default:
+		cmd = exec.Command("xdg-open", abs)
+	}
+	return cmd.Start()
+}
+
+func allowedOpenPath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(abs)
+	if err != nil {
+		return "", err
+	}
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	for _, root := range allowedOpenRoots() {
+		if root == "" {
+			continue
+		}
+		if pathAllowedUnder(root, real) {
+			if !info.IsDir() && !pathAllowedUnder(config.ManagerRunDir(), real) {
+				return "", fmt.Errorf("only directories and manager run logs can be opened")
+			}
+			if info.IsDir() && strings.EqualFold(filepath.Ext(real), ".app") {
+				return "", fmt.Errorf("application bundles cannot be opened from desktop results")
+			}
+			return real, nil
+		}
+	}
+	return "", fmt.Errorf("path is outside allowed desktop open roots")
+}
+
+func allowedOpenRoots() []string {
+	var roots []string
+	if cwd, err := os.Getwd(); err == nil {
+		roots = append(roots, cwd)
+		roots = append(roots, gitWorktreeRoots(cwd)...)
+	}
+	if dir := config.ManagerRunDir(); dir != "" {
+		roots = append(roots, dir)
+	}
+	return roots
+}
+
+func gitWorktreeRoots(cwd string) []string {
+	cmd := exec.Command("git", "-C", cwd, "worktree", "list", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	var roots []string
+	for _, line := range strings.Split(string(out), "\n") {
+		path, ok := strings.CutPrefix(line, "worktree ")
+		if ok && strings.TrimSpace(path) != "" {
+			roots = append(roots, strings.TrimSpace(path))
+		}
+	}
+	return roots
+}
+
+func pathAllowedUnder(root, path string) bool {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return false
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	if realRoot, err := filepath.EvalSymlinks(rootAbs); err == nil {
+		rootAbs = realRoot
+	}
+	rel, err := filepath.Rel(rootAbs, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)))
 }
 
 // Approve answers a pending approval_request by ID: allow runs the call, session

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -7,6 +7,7 @@ import {
   FileText,
   FolderOpen,
   Globe,
+  Bot,
   Loader2,
   ListTree,
   Search,
@@ -17,6 +18,7 @@ import {
 } from "lucide-react";
 import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
+import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { diffsFor, subjectOf, summarize } from "../lib/tools";
 import type { Item } from "../lib/useController";
@@ -34,6 +36,8 @@ const ICONS: Record<string, LucideIcon> = {
   grep: Search,
   web_fetch: Globe,
   task: ListTree,
+  agents: ListTree,
+  agent: Bot,
 };
 
 function pretty(json: string): string {
@@ -42,6 +46,18 @@ function pretty(json: string): string {
   } catch {
     return json;
   }
+}
+
+function parseRecord(json: string): Record<string, unknown> {
+  try {
+    return JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+function shortLine(s?: string): string {
+  return (s ?? "").trim().split(/\r?\n/, 1)[0].slice(0, 120);
 }
 
 function StatusGlyph({ status }: { status: ToolItem["status"] }) {
@@ -54,7 +70,15 @@ function StatusGlyph({ status }: { status: ToolItem["status"] }) {
 // ToolCard renders one tool call. `subcalls` are sub-agent calls nested under a
 // `task` card (their ParentID points at this call); they render inline, live, so
 // the sub-agent's work is visible as it happens.
-export function ToolCard({ item, subcalls }: { item: ToolItem; subcalls?: ToolItem[] }) {
+export function ToolCard({
+  item,
+  subcalls,
+  subcallsFor,
+}: {
+  item: ToolItem;
+  subcalls?: ToolItem[];
+  subcallsFor?: (id: string) => ToolItem[] | undefined;
+}) {
   const t = useT();
   const diffs = diffsFor(item.name, item.args);
   const subject = subjectOf(item.name, item.args);
@@ -111,10 +135,12 @@ export function ToolCard({ item, subcalls }: { item: ToolItem; subcalls?: ToolIt
         </div>
       ))}
 
+      {item.name === "agents" && hasNested && <AgentPanel agents={nested} />}
+
       {hasNested && (
         <div className="tool__nested">
           {nested.map((c) => (
-            <ToolCard key={c.id} item={c} />
+            <ToolCard key={c.id} item={c} subcalls={subcallsFor?.(c.id)} subcallsFor={subcallsFor} />
           ))}
         </div>
       )}
@@ -132,6 +158,54 @@ export function ToolCard({ item, subcalls }: { item: ToolItem; subcalls?: ToolIt
       )}
 
       {item.error && <div className="tool__err">{item.error}</div>}
+    </div>
+  );
+}
+
+function AgentPanel({ agents }: { agents: ToolItem[] }) {
+  const t = useT();
+  const rows = agents.filter((a) => a.name === "agent");
+  if (rows.length === 0) return null;
+  return (
+    <div className="agentpanel">
+      {rows.map((a) => {
+        const meta = parseRecord(a.args);
+        const title = String(meta.description || meta.id || "agent");
+        const branch = String(meta.branch || "");
+        const isolation = String(meta.isolation || "");
+        const mode = String(meta.mode || "");
+        const worktree = String(meta.worktree || "");
+        const line = a.error || shortLine(a.output);
+        return (
+          <div className={`agentpanel__row agentpanel__row--${a.status}`} key={a.id}>
+            <span className="agentpanel__status">
+              <StatusGlyph status={a.status} />
+            </span>
+            <span className="agentpanel__main">
+              <span className="agentpanel__title">{title}</span>
+              {line && <span className="agentpanel__line">{line}</span>}
+            </span>
+            {(branch || isolation || mode) && (
+              <span className="agentpanel__meta">
+                {[branch, isolation, mode].filter(Boolean).join(" · ")}
+              </span>
+            )}
+            {worktree && (
+              <button
+                className="agentpanel__open"
+                title={`${t("tool.openWorktree")}: ${worktree}`}
+                aria-label={t("tool.openWorktree")}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void app.OpenPath(worktree).catch(() => {});
+                }}
+              >
+                <FolderOpen size={12} />
+              </button>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -98,7 +98,7 @@ export function Transcript({
             if (it.parentId) return null; // rendered nested under its parent
             if (it.name === "todo_write") return null; // shown live in the pinned TodoPanel
             if (it.name === "exit_plan_mode") return null; // the plan was shown in the approval card
-            return <ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />;
+            return <ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} subcallsFor={(id) => subcallsByParent.get(id)} />;
           case "phase":
             return (
               <div key={it.id} className="phase">

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -31,6 +31,7 @@ import type {
 export interface AppBindings {
   Submit(input: string): Promise<void>;
   Cancel(): Promise<void>;
+  OpenPath(path: string): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean): Promise<void>;
   AnswerQuestion(id: string, answers: QuestionAnswer[]): Promise<void>;
   SetPlanMode(on: boolean): Promise<void>;
@@ -275,6 +276,11 @@ function makeMockApp(): AppBindings {
     async Cancel() {
       cancelled = true;
       emit({ kind: "turn_done" });
+    },
+    async OpenPath(path: string) {
+      // Browser dev cannot reveal a local folder; log so the click remains
+      // observable while the real Wails shell opens it through desktop/app.go.
+      console.info("OpenPath", path);
     },
     async Approve() {},
     async AnswerQuestion() {},

--- a/desktop/frontend/src/lib/tools.ts
+++ b/desktop/frontend/src/lib/tools.ts
@@ -42,7 +42,10 @@ export function subjectOf(name: string, args: string): string {
     case "web_fetch":
       return str(a, "url");
     case "task":
+    case "agent":
       return str(a, "description") || str(a, "prompt");
+    case "agents":
+      return Array.isArray(a.agents) ? countOf(a.agents.length, "tool.agentOne", "tool.agentOther") : "";
     case "remember":
       return str(a, "name") || str(a, "description");
     case "todo_write":

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -194,6 +194,9 @@ export const en = {
   "tool.entryOther": "{n} entries",
   "tool.editOne": "{n} edit",
   "tool.editOther": "{n} edits",
+  "tool.agentOne": "{n} agent",
+  "tool.agentOther": "{n} agents",
+  "tool.openWorktree": "Open worktree",
   "tool.emptyFile": "empty file",
   "tool.noOutput": "no output",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -195,6 +195,9 @@ export const zh: Record<DictKey, string> = {
   "tool.entryOther": "{n} 项",
   "tool.editOne": "{n} 处编辑",
   "tool.editOther": "{n} 处编辑",
+  "tool.agentOne": "{n} 个智能体",
+  "tool.agentOther": "{n} 个智能体",
+  "tool.openWorktree": "打开 worktree",
   "tool.emptyFile": "空文件",
   "tool.noOutput": "无输出",
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1929,6 +1929,76 @@ body {
   margin: 6px 0;
   background: var(--bg);
 }
+.agentpanel {
+  margin: 1px 11px 8px 30px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--bg);
+}
+.agentpanel__row {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr) minmax(90px, auto) 22px;
+  gap: 7px;
+  align-items: center;
+  min-height: 30px;
+  padding: 5px 8px;
+  border-top: 1px solid var(--border);
+}
+.agentpanel__row:first-child {
+  border-top: 0;
+}
+.agentpanel__status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.agentpanel__main {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 1px;
+}
+.agentpanel__title,
+.agentpanel__line,
+.agentpanel__meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agentpanel__title {
+  font-size: 12px;
+  color: var(--fg);
+}
+.agentpanel__line,
+.agentpanel__meta {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+}
+.agentpanel__row--error .agentpanel__title {
+  color: var(--err);
+}
+.agentpanel__row--running .agentpanel__title {
+  color: var(--accent);
+}
+.agentpanel__open {
+  --wails-draggable: no-drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  cursor: pointer;
+}
+.agentpanel__open:hover {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+}
 
 /* ── live task list, pinned above the composer ─────────────────────────────── */
 .todobar {

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -2,8 +2,12 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"reasonix/internal/config"
 )
 
 // --- workspaceStatePath ---
@@ -58,6 +62,89 @@ func TestCwdWritableInTempDir(t *testing.T) {
 	os.Chdir(dir)
 	if !cwdWritable() {
 		t.Error("temp dir should be writable")
+	}
+}
+
+func TestAllowedOpenPathRestrictsToSafeRoots(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	workspace := t.TempDir()
+	t.Chdir(workspace)
+
+	insideDir := filepath.Join(workspace, "inside")
+	if err := os.Mkdir(insideDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := allowedOpenPath(insideDir); err != nil || got == "" {
+		t.Fatalf("workspace directory should be allowed, got %q err=%v", got, err)
+	}
+	appBundle := filepath.Join(workspace, "Tool.app")
+	if err := os.Mkdir(appBundle, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := allowedOpenPath(appBundle); err == nil {
+		t.Fatal("application bundles should not be opened")
+	}
+
+	insideFile := filepath.Join(workspace, "file.txt")
+	if err := os.WriteFile(insideFile, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := allowedOpenPath(insideFile); err == nil {
+		t.Fatal("workspace file should not be opened directly")
+	}
+
+	outsideDir := t.TempDir()
+	if _, err := allowedOpenPath(outsideDir); err == nil {
+		t.Fatal("directory outside safe roots should be rejected")
+	}
+
+	logDir := config.ManagerRunDir()
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(logDir, "run.jsonl")
+	if err := os.WriteFile(logPath, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := allowedOpenPath(logPath); err != nil || got == "" {
+		t.Fatalf("manager run log should be allowed, got %q err=%v", got, err)
+	}
+}
+
+func TestAllowedOpenPathAllowsRegisteredGitWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is required")
+	}
+	parent := t.TempDir()
+	repo := filepath.Join(parent, "repo")
+	if err := os.Mkdir(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runGitDesktop(t, repo, "init")
+	readme := filepath.Join(repo, "README.md")
+	if err := os.WriteFile(readme, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitDesktop(t, repo, "add", "README.md")
+	runGitDesktop(t, repo, "-c", "user.name=Reasonix Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	wt := filepath.Join(parent, "wt-feature")
+	runGitDesktop(t, repo, "worktree", "add", "-b", "feature/open-path", wt)
+	t.Chdir(repo)
+
+	if got, err := allowedOpenPath(wt); err != nil || got == "" {
+		t.Fatalf("registered git worktree should be allowed, got %q err=%v", got, err)
+	}
+	if _, err := allowedOpenPath(filepath.Join(wt, "README.md")); err == nil {
+		t.Fatal("worktree files should not be opened directly")
+	}
+}
+
+func runGitDesktop(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
 }
 

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -76,7 +76,7 @@ func (s *updateSink) Emit(e event.Event) {
 		s.send(toolCall{
 			SessionUpdate: "tool_call",
 			ToolCallID:    e.Tool.ID,
-			Title:         e.Tool.Name,
+			Title:         toolTitle(e.Tool),
 			Kind:          toolKindFor(e.Tool.Name),
 			Status:        "pending",
 			RawInput:      rawJSON(e.Tool.Args),
@@ -122,6 +122,13 @@ func (s *updateSink) Emit(e event.Event) {
 		// (the agent emits serially); the answer unblocks the loop.
 		go s.requestPermission(e.Approval)
 	}
+}
+
+func toolTitle(t event.Tool) string {
+	if t.ParentID == "" {
+		return t.Name
+	}
+	return "↳ " + t.Name
 }
 
 func (s *updateSink) send(update any) {

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -144,6 +144,19 @@ func TestUpdateSinkMapsEvents(t *testing.T) {
 	}
 }
 
+func TestUpdateSinkMarksNestedToolTitle(t *testing.T) {
+	fn := &fakeNotifier{}
+	sink := newUpdateSink(fn, "sess-1")
+
+	sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID: "parent/child", Name: "read_file", Args: `{"path":"a.go"}`, ParentID: "parent",
+	}})
+	u := fn.updateMap(t, 0)
+	if u["title"] != "↳ read_file" {
+		t.Fatalf("nested title = %v, want prefixed title", u["title"])
+	}
+}
+
 func TestUpdateSinkDropsAndWarns(t *testing.T) {
 	fn := &fakeNotifier{}
 	sink := newUpdateSink(fn, "sess-1")

--- a/internal/agent/manager_runs.go
+++ b/internal/agent/manager_runs.go
@@ -1,0 +1,163 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type managerRunRecorder struct {
+	path string
+	mu   sync.Mutex
+	err  error
+}
+
+type managerRunEvent struct {
+	Time  time.Time `json:"time"`
+	Event string    `json:"event"`
+	Data  any       `json:"data,omitempty"`
+}
+
+func newManagerRunRecorder(dir, runID string) (*managerRunRecorder, error) {
+	if dir == "" {
+		return nil, nil
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return nil, err
+	}
+	name := fmt.Sprintf("%s-%s.jsonl", time.Now().UTC().Format("20060102-150405.000"), safeID(runID))
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := f.Close(); err != nil {
+		return nil, err
+	}
+	return &managerRunRecorder{path: path}, nil
+}
+
+func (r *managerRunRecorder) Path() string {
+	if r == nil {
+		return ""
+	}
+	return r.path
+}
+
+func (r *managerRunRecorder) Record(event string, data any) {
+	if r == nil || r.path == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	f, err := os.OpenFile(r.path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		r.err = err
+		return
+	}
+	defer f.Close()
+	if err := json.NewEncoder(f).Encode(managerRunEvent{Time: time.Now().UTC(), Event: event, Data: data}); err != nil {
+		r.err = err
+	}
+}
+
+func (r *managerRunRecorder) Err() error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.err
+}
+
+type managerRunAgentSpec struct {
+	ID          string   `json:"id"`
+	Description string   `json:"description,omitempty"`
+	Branch      string   `json:"branch,omitempty"`
+	Worktree    string   `json:"worktree,omitempty"`
+	Isolation   string   `json:"isolation"`
+	Mode        string   `json:"mode"`
+	DependsOn   []string `json:"depends_on,omitempty"`
+}
+
+type managerRunStart struct {
+	Repo          string                `json:"repo,omitempty"`
+	Concurrency   int                   `json:"concurrency"`
+	Isolation     string                `json:"isolation"`
+	Mode          string                `json:"mode"`
+	BaseRef       string                `json:"base_ref,omitempty"`
+	MergeStrategy string                `json:"merge_strategy"`
+	Cleanup       string                `json:"cleanup"`
+	Agents        []managerRunAgentSpec `json:"agents"`
+}
+
+func managerRunStartRecord(repo string, p agentsPayload) managerRunStart {
+	agents := make([]managerRunAgentSpec, len(p.Agents))
+	for i, a := range p.Agents {
+		agents[i] = managerRunAgentSpec{
+			ID: a.ID, Description: a.Description, Branch: a.Branch,
+			Worktree: a.WorktreeDir, Isolation: a.Isolation, Mode: a.Mode,
+			DependsOn: append([]string(nil), a.DependsOn...),
+		}
+	}
+	return managerRunStart{
+		Repo: repo, Concurrency: p.Concurrency, Isolation: p.Isolation,
+		Mode: p.Mode, BaseRef: p.BaseRef, MergeStrategy: p.MergeStrategy,
+		Cleanup: p.Cleanup, Agents: agents,
+	}
+}
+
+type managerRunResult struct {
+	ID             string   `json:"id"`
+	Agent          string   `json:"agent"`
+	Branch         string   `json:"branch,omitempty"`
+	Worktree       string   `json:"worktree,omitempty"`
+	PromptBytes    int      `json:"prompt_bytes,omitempty"`
+	PromptRedacted bool     `json:"prompt_redacted,omitempty"`
+	Commits        []string `json:"commits,omitempty"`
+	Status         string   `json:"status"`
+	Next           string   `json:"next,omitempty"`
+	Error          string   `json:"error,omitempty"`
+	Isolation      string   `json:"isolation"`
+	Mode           string   `json:"mode"`
+}
+
+func managerRunResultRecord(r result) managerRunResult {
+	out := managerRunResult{
+		ID: r.id, Agent: r.label, Branch: r.branch, Worktree: r.worktree,
+		PromptBytes: len(r.task), PromptRedacted: r.task != "",
+		Commits: append([]string(nil), r.commits...),
+		Status:  r.status, Next: r.next, Isolation: r.isolation, Mode: r.mode,
+	}
+	if r.err != nil {
+		out.Error = r.err.Error()
+	}
+	return out
+}
+
+type managerRunActions struct {
+	Merged   []string `json:"merged,omitempty"`
+	Cleaned  []string `json:"cleaned,omitempty"`
+	Deleted  []string `json:"deleted,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+	Error    string   `json:"error,omitempty"`
+}
+
+func managerRunActionsRecord(a managerActions) managerRunActions {
+	out := managerRunActions{
+		Merged:   append([]string(nil), a.merged...),
+		Cleaned:  append([]string(nil), a.cleaned...),
+		Deleted:  append([]string(nil), a.deleted...),
+		Warnings: append([]string(nil), a.warnings...),
+	}
+	if a.err != nil {
+		out.Error = a.err.Error()
+	}
+	return out
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -5,7 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
+	"unicode"
 
 	"reasonix/internal/event"
 	"reasonix/internal/jobs"
@@ -22,6 +30,7 @@ If you need to ask for clarification, fail with a precise question instead of gu
 
 var subagentMetaTools = []string{
 	"task",
+	"agents",
 	"run_skill",
 	"install_skill",
 	"explore",
@@ -164,6 +173,983 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 
 	// Foreground: run synchronously, nesting events under this call.
 	return t.runSub(ctx, p.Prompt, subReg, subSink(ctx), maxSteps)
+}
+
+// AgentsTool runs several focused sub-agents as one coordinated batch. It gives
+// the model a stable, explicit way to fan out independent investigations without
+// relying on provider-side parallel tool dispatch, while keeping every child in
+// its own session so noisy exploration does not enter the parent's context.
+type AgentsTool struct {
+	task           *TaskTool
+	defaultMaxRuns int
+	worktreeTools  func(dir string, write bool, names []string) (*tool.Registry, func(), error)
+	runStoreDir    string
+}
+
+// NewAgentsTool builds the batch sub-agent tool on top of the existing task
+// machinery so both paths share model, tools, budget, permission, and cache
+// behavior.
+func NewAgentsTool(task *TaskTool) *AgentsTool {
+	return &AgentsTool{task: task, defaultMaxRuns: 4}
+}
+
+// SetWorktreeTools installs the per-worktree registry builder used by
+// isolation:"worktree". The agent package does not import built-in tools
+// directly; boot supplies a workspace-bound builder so child agents can run in
+// an isolated cwd/root without leaking that composition detail into the loop.
+func (t *AgentsTool) SetWorktreeTools(fn func(dir string, write bool, names []string) (*tool.Registry, func(), error)) {
+	t.worktreeTools = fn
+}
+
+// SetRunStore enables append-only manager run logs for agents batches. Empty
+// disables persistence.
+func (t *AgentsTool) SetRunStore(dir string) {
+	t.runStoreDir = dir
+}
+
+func (t *AgentsTool) Name() string { return "agents" }
+
+func (t *AgentsTool) Description() string {
+	return "Spawn multiple focused sub-agents for independent subtasks. Defaults to read-only session isolation for parallel exploration; set isolation:\"worktree\" and mode:\"write\" for physically isolated writable agents that work on separate git branches. Supports depends_on DAG ordering, returns branch/commit/status summaries, and nests live child tool activity under this batch."
+}
+
+func (t *AgentsTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "agents":{"type":"array","minItems":1,"maxItems":4,"items":{"type":"object","properties":{
+    "id":{"type":"string","description":"Stable short id for this sub-agent, e.g. frontend or api."},
+    "description":{"type":"string","description":"Short label for display (3-7 words)."},
+    "prompt":{"type":"string","description":"Self-contained task prompt. The sub-agent does not see this conversation."},
+    "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist. In read_only mode, writer tools are rejected. In worktree/write mode, writer tools are allowed inside that worktree."},
+    "max_steps":{"type":"integer","description":"Optional cap on tool-call rounds for this sub-agent. Defaults to half the parent's cap (min 5).","minimum":1},
+    "depends_on":{"type":"array","items":{"type":"string"},"description":"Agent ids that must finish with status done before this agent starts."},
+    "isolation":{"type":"string","enum":["session","worktree"],"description":"Override batch isolation for this agent. session is context-only; worktree creates a git worktree and branch."},
+    "mode":{"type":"string","enum":["read_only","write"],"description":"Override batch mode. write requires isolation worktree."},
+    "branch":{"type":"string","description":"Optional branch name for worktree isolation. Defaults to branch_prefix/id-run."},
+    "worktree_dir":{"type":"string","description":"Optional worktree directory. Relative paths resolve under worktree_base or the repository parent."}
+  },"required":["prompt"]}},
+  "concurrency":{"type":"integer","description":"Maximum sub-agents to run at once within one DAG layer. Defaults to 4.","minimum":1,"maximum":4},
+  "isolation":{"type":"string","enum":["session","worktree"],"description":"Default isolation for agents. Defaults to session."},
+  "mode":{"type":"string","enum":["read_only","write"],"description":"Default agent mode. Defaults to read_only. write requires worktree isolation."},
+  "branch_prefix":{"type":"string","description":"Branch prefix for generated worktree branches. Defaults to reasonix/agent."},
+  "worktree_base":{"type":"string","description":"Directory where generated worktrees are created. Relative paths resolve from the repository parent."},
+  "base_ref":{"type":"string","description":"Git ref used as the worktree base. Defaults to HEAD."},
+  "merge_strategy":{"type":"string","enum":["none","plan","merge"],"description":"How to handle successful worktree branches. plan returns merge commands; merge runs them when the parent repo is clean; none omits merge handling. Defaults to plan."},
+  "cleanup":{"type":"string","enum":["none","worktrees","merged_branches"],"description":"Optional cleanup after successful agents. worktrees removes clean worktree directories; merged_branches also deletes branches after merge_strategy merge succeeds. Defaults to none."}
+},
+"required":["agents"]
+}`)
+}
+
+// ReadOnly is false because this tool starts model loops, not a simple data
+// lookup. Child agents default to reader tools; the batch owns concurrency
+// instead of letting the generic dispatcher make ordering assumptions.
+func (t *AgentsTool) ReadOnly() bool { return false }
+
+func (t *AgentsTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	if t == nil || t.task == nil {
+		return "", fmt.Errorf("agents tool is not configured")
+	}
+	var p agentsPayload
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if err := p.normalize(t.defaultMaxRuns); err != nil {
+		return "", err
+	}
+	runID := batchRunID(ctx)
+	if err := p.fillAgentDefaults(runID); err != nil {
+		return "", err
+	}
+	layers, err := p.layers()
+	if err != nil {
+		return "", err
+	}
+	repo, err := maybeGitRoot()
+	if err != nil && p.needsWorktree() {
+		return "", err
+	}
+
+	parentID, parentSink, _, ok := CallContext(ctx)
+	if !ok || parentSink == nil {
+		parentSink = event.Discard
+	}
+	serialSink := event.Sync(parentSink)
+	rec, err := newManagerRunRecorder(t.runStoreDir, runID)
+	if err != nil {
+		serialSink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+			Text: "agents: manager run log disabled (" + err.Error() + ")"})
+	}
+	if rec != nil {
+		rec.Record("started", managerRunStartRecord(repo, p))
+	}
+
+	results := make([]result, len(p.Agents))
+	byID := map[string]int{}
+	for i, spec := range p.Agents {
+		byID[spec.ID] = i
+		results[i] = result{
+			id: spec.ID, label: spec.label(), task: spec.Prompt,
+			status: "pending", isolation: spec.Isolation, mode: spec.Mode,
+		}
+	}
+
+	var topoOrder []int
+	for _, layer := range layers {
+		topoOrder = append(topoOrder, layer...)
+		var runnable []int
+		for _, i := range layer {
+			blockedBy := blockedDependency(p.Agents[i], results, byID)
+			if blockedBy == "" {
+				runnable = append(runnable, i)
+				continue
+			}
+			results[i].status = "blocked"
+			results[i].next = "dependency " + blockedBy + " did not finish successfully"
+			t.emitSyntheticAgent(serialSink, parentID, i, p.Agents[i], results[i])
+			if rec != nil {
+				rec.Record("agent_finished", managerRunResultRecord(results[i]))
+			}
+		}
+		sem := make(chan struct{}, p.Concurrency)
+		var wg sync.WaitGroup
+		for _, i := range runnable {
+			i := i
+			sem <- struct{}{}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() { <-sem }()
+				results[i] = t.runAgentSpec(ctx, serialSink, parentID, i, p, p.Agents[i], repo, rec)
+			}()
+		}
+		wg.Wait()
+	}
+
+	failed := hasFailedAgent(results)
+	actions := managerActions{}
+	if rec != nil {
+		actions.runLog = rec.Path()
+	}
+	if !failed {
+		actions = runManagerActions(repo, results, topoOrder, p)
+		if rec != nil {
+			actions.runLog = rec.Path()
+			rec.Record("manager_actions", managerRunActionsRecord(actions))
+		}
+	}
+	if failed {
+		if rec != nil {
+			rec.Record("finished", map[string]any{"status": "failed"})
+		}
+		addManagerRunWarning(&actions, rec)
+		out := renderAgentsResult(results, p.MergeStrategy, topoOrder, actions)
+		return out, fmt.Errorf("one or more agents failed or blocked")
+	}
+	if actions.err != nil {
+		if rec != nil {
+			rec.Record("finished", map[string]any{"status": "failed", "error": actions.err.Error()})
+		}
+		addManagerRunWarning(&actions, rec)
+		out := renderAgentsResult(results, p.MergeStrategy, topoOrder, actions)
+		return out, actions.err
+	}
+	if rec != nil {
+		rec.Record("finished", map[string]any{"status": "done"})
+	}
+	addManagerRunWarning(&actions, rec)
+	out := renderAgentsResult(results, p.MergeStrategy, topoOrder, actions)
+	return out, nil
+}
+
+type agentsPayload struct {
+	Agents        []agentSpec `json:"agents"`
+	Concurrency   int         `json:"concurrency"`
+	Isolation     string      `json:"isolation"`
+	Mode          string      `json:"mode"`
+	BranchPrefix  string      `json:"branch_prefix"`
+	WorktreeBase  string      `json:"worktree_base"`
+	BaseRef       string      `json:"base_ref"`
+	MergeStrategy string      `json:"merge_strategy"`
+	Cleanup       string      `json:"cleanup"`
+}
+
+type agentSpec struct {
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	Prompt      string   `json:"prompt"`
+	Tools       []string `json:"tools"`
+	MaxSteps    int      `json:"max_steps"`
+	DependsOn   []string `json:"depends_on"`
+	Isolation   string   `json:"isolation"`
+	Mode        string   `json:"mode"`
+	Branch      string   `json:"branch"`
+	WorktreeDir string   `json:"worktree_dir"`
+}
+
+type result struct {
+	id        string
+	label     string
+	task      string
+	answer    string
+	status    string
+	next      string
+	err       error
+	branch    string
+	worktree  string
+	commits   []string
+	isolation string
+	mode      string
+}
+
+func (p *agentsPayload) normalize(maxRuns int) error {
+	if len(p.Agents) == 0 {
+		return fmt.Errorf("agents must contain at least one sub-agent")
+	}
+	if len(p.Agents) > maxRuns {
+		return fmt.Errorf("agents supports at most %d sub-agents per batch", maxRuns)
+	}
+	if p.Concurrency <= 0 || p.Concurrency > maxRuns {
+		p.Concurrency = maxRuns
+	}
+	if p.Concurrency > len(p.Agents) {
+		p.Concurrency = len(p.Agents)
+	}
+	p.Isolation = defaultString(p.Isolation, "session")
+	p.Mode = defaultString(p.Mode, "read_only")
+	p.BranchPrefix = defaultString(p.BranchPrefix, "reasonix/agent")
+	p.BaseRef = defaultString(p.BaseRef, "HEAD")
+	p.MergeStrategy = defaultString(p.MergeStrategy, "plan")
+	p.Cleanup = defaultString(p.Cleanup, "none")
+	if !validIsolation(p.Isolation) {
+		return fmt.Errorf("invalid isolation %q", p.Isolation)
+	}
+	if !validMode(p.Mode) {
+		return fmt.Errorf("invalid mode %q", p.Mode)
+	}
+	if p.Mode == "write" && p.Isolation != "worktree" {
+		return fmt.Errorf("mode write requires isolation worktree")
+	}
+	if p.MergeStrategy != "none" && p.MergeStrategy != "plan" && p.MergeStrategy != "merge" {
+		return fmt.Errorf("invalid merge_strategy %q", p.MergeStrategy)
+	}
+	if p.Cleanup != "none" && p.Cleanup != "worktrees" && p.Cleanup != "merged_branches" {
+		return fmt.Errorf("invalid cleanup %q", p.Cleanup)
+	}
+	if p.Cleanup == "merged_branches" && p.MergeStrategy != "merge" {
+		return fmt.Errorf("cleanup merged_branches requires merge_strategy merge")
+	}
+	return nil
+}
+
+func (p *agentsPayload) fillAgentDefaults(runID string) error {
+	seen := map[string]bool{}
+	for i := range p.Agents {
+		a := &p.Agents[i]
+		if strings.TrimSpace(a.Prompt) == "" {
+			return fmt.Errorf("agents[%d].prompt is required", i)
+		}
+		a.ID = safeID(defaultString(a.ID, fmt.Sprintf("agent-%d", i+1)))
+		if seen[a.ID] {
+			return fmt.Errorf("duplicate agent id %q", a.ID)
+		}
+		seen[a.ID] = true
+		a.Isolation = defaultString(a.Isolation, p.Isolation)
+		a.Mode = defaultString(a.Mode, p.Mode)
+		if !validIsolation(a.Isolation) {
+			return fmt.Errorf("agents[%d].isolation %q is invalid", i, a.Isolation)
+		}
+		if !validMode(a.Mode) {
+			return fmt.Errorf("agents[%d].mode %q is invalid", i, a.Mode)
+		}
+		if a.Mode == "write" && a.Isolation != "worktree" {
+			return fmt.Errorf("agents[%d]: mode write requires isolation worktree", i)
+		}
+		if a.Isolation == "worktree" {
+			if strings.TrimSpace(a.Branch) == "" {
+				a.Branch = strings.TrimRight(p.BranchPrefix, "/") + "/" + a.ID + "-" + runID
+			}
+			if strings.TrimSpace(a.WorktreeDir) == "" {
+				a.WorktreeDir = "wt-" + a.ID + "-" + runID
+			}
+		}
+		for j, dep := range a.DependsOn {
+			a.DependsOn[j] = safeID(dep)
+		}
+	}
+	for i, a := range p.Agents {
+		for _, dep := range a.DependsOn {
+			if !seen[dep] {
+				return fmt.Errorf("agents[%d] depends on unknown agent %q", i, dep)
+			}
+		}
+	}
+	return nil
+}
+
+func (p agentsPayload) needsWorktree() bool {
+	for _, a := range p.Agents {
+		if a.Isolation == "worktree" {
+			return true
+		}
+	}
+	return false
+}
+
+func (p agentsPayload) layers() ([][]int, error) {
+	indegree := make([]int, len(p.Agents))
+	next := make(map[int][]int, len(p.Agents))
+	byID := map[string]int{}
+	for i, a := range p.Agents {
+		byID[a.ID] = i
+	}
+	for i, a := range p.Agents {
+		for _, dep := range a.DependsOn {
+			j := byID[dep]
+			indegree[i]++
+			next[j] = append(next[j], i)
+		}
+	}
+	var ready []int
+	for i, n := range indegree {
+		if n == 0 {
+			ready = append(ready, i)
+		}
+	}
+	var layers [][]int
+	seen := 0
+	for len(ready) > 0 {
+		sort.Ints(ready)
+		layer := append([]int(nil), ready...)
+		layers = append(layers, layer)
+		seen += len(layer)
+		ready = nil
+		for _, i := range layer {
+			for _, child := range next[i] {
+				indegree[child]--
+				if indegree[child] == 0 {
+					ready = append(ready, child)
+				}
+			}
+		}
+	}
+	if seen != len(p.Agents) {
+		return nil, fmt.Errorf("agents dependency graph contains a cycle")
+	}
+	return layers, nil
+}
+
+func (a agentSpec) label() string {
+	label := strings.TrimSpace(a.Description)
+	if label == "" {
+		label = a.ID
+	}
+	return label
+}
+
+func (t *AgentsTool) runAgentSpec(ctx context.Context, sink event.Sink, parentID string, idx int, p agentsPayload, spec agentSpec, repo string, rec *managerRunRecorder) result {
+	res := result{
+		id: spec.ID, label: spec.label(), task: spec.Prompt, status: "done",
+		isolation: spec.Isolation, mode: spec.Mode, branch: spec.Branch,
+	}
+	childID := childAgentID(parentID, idx+1)
+	displayWorktree := spec.WorktreeDir
+	if spec.Isolation == "worktree" {
+		if wt, err := resolveWorktreeDir(repo, p.WorktreeBase, spec.WorktreeDir); err == nil {
+			displayWorktree = wt
+		}
+	}
+	childArgs := agentEventArgs(spec, displayWorktree)
+	sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID: childID, Name: "agent", Args: string(childArgs), ParentID: parentID,
+	}})
+
+	workDir, baseCommit, err := t.prepareAgentWorkspace(repo, p, spec)
+	if err != nil {
+		res.status, res.err, res.next = "failed", err, "fix worktree setup and retry"
+		t.emitAgentResult(sink, parentID, childID, childArgs, res)
+		if rec != nil {
+			rec.Record("agent_finished", managerRunResultRecord(res))
+		}
+		return res
+	}
+	res.worktree = workDir
+
+	subReg, cleanup, err := t.buildBatchSubReg(spec.Tools, spec.Isolation, spec.Mode, workDir)
+	if err != nil {
+		res.status, res.err, res.next = "failed", err, "adjust tools/isolation/mode"
+		t.emitAgentResult(sink, parentID, childID, childArgs, res)
+		if rec != nil {
+			rec.Record("agent_finished", managerRunResultRecord(res))
+		}
+		return res
+	}
+	if cleanup != nil {
+		defer cleanup()
+	}
+
+	answer, err := t.task.runSub(ctx, agentPrompt(spec, workDir), subReg, subSinkFor(childID, sink), agentMaxSteps(t.task.maxSteps, spec.MaxSteps))
+	res.answer, res.err = answer, err
+	if err != nil {
+		res.status, res.next = "failed", "inspect sub-agent error"
+	} else {
+		res.next = "ready"
+	}
+	if spec.Isolation == "worktree" {
+		res.commits = gitListCommits(workDir, baseCommit)
+		dirty := gitDirty(workDir)
+		if spec.Mode == "read_only" && (dirty || len(res.commits) > 0) {
+			res.status = "blocked"
+			res.next = "read_only agent modified the worktree; inspect and discard or rerun as mode write"
+		} else if dirty {
+			res.status = "blocked"
+			res.next = "commit or clean dirty worktree before merge"
+		} else if spec.Mode == "write" && len(res.commits) == 0 {
+			res.status = "blocked"
+			res.next = "no commits produced; inspect worktree or rerun with clearer task"
+		} else if len(res.commits) > 0 {
+			res.next = "ready to merge"
+		}
+	}
+	t.emitAgentResult(sink, parentID, childID, childArgs, res)
+	if rec != nil {
+		rec.Record("agent_finished", managerRunResultRecord(res))
+	}
+	return res
+}
+
+func (t *AgentsTool) prepareAgentWorkspace(repo string, p agentsPayload, spec agentSpec) (workDir, baseCommit string, err error) {
+	if spec.Isolation != "worktree" {
+		return "", "", nil
+	}
+	wtDir, err := resolveWorktreeDir(repo, p.WorktreeBase, spec.WorktreeDir)
+	if err != nil {
+		return "", "", err
+	}
+	baseCommit, err = gitOutput(repo, "rev-parse", p.BaseRef)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve base_ref %q: %w", p.BaseRef, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(wtDir), 0o755); err != nil {
+		return "", "", err
+	}
+	if _, err := os.Stat(wtDir); err == nil {
+		return "", "", fmt.Errorf("worktree_dir already exists: %s", wtDir)
+	}
+	if _, err := gitOutput(repo, "worktree", "add", "-b", spec.Branch, wtDir, p.BaseRef); err != nil {
+		return "", "", err
+	}
+	return wtDir, strings.TrimSpace(baseCommit), nil
+}
+
+func (t *AgentsTool) emitSyntheticAgent(sink event.Sink, parentID string, idx int, spec agentSpec, res result) {
+	childID := childAgentID(parentID, idx+1)
+	childArgs := agentEventArgs(spec, spec.WorktreeDir)
+	sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID: childID, Name: "agent", Args: string(childArgs), ParentID: parentID,
+	}})
+	t.emitAgentResult(sink, parentID, childID, childArgs, res)
+}
+
+func (t *AgentsTool) emitAgentResult(sink event.Sink, parentID, childID string, childArgs []byte, res result) {
+	ev := event.Event{Kind: event.ToolResult, Tool: event.Tool{
+		ID: childID, Name: "agent", Args: string(childArgs), ParentID: parentID,
+		Output: agentResultText(res),
+	}}
+	if res.err != nil {
+		ev.Tool.Err = firstLine(res.err.Error())
+	}
+	sink.Emit(ev)
+}
+
+func agentEventArgs(spec agentSpec, worktree string) []byte {
+	args, _ := json.Marshal(map[string]string{
+		"id":          spec.ID,
+		"description": spec.label(),
+		"isolation":   spec.Isolation,
+		"mode":        spec.Mode,
+		"branch":      spec.Branch,
+		"worktree":    worktree,
+	})
+	return args
+}
+
+func (t *AgentsTool) buildBatchSubReg(names []string, isolation, mode, workDir string) (*tool.Registry, func(), error) {
+	writeMode := mode == "write"
+	if writeMode && isolation != "worktree" {
+		return nil, nil, fmt.Errorf("mode write requires isolation worktree")
+	}
+	if isolation == "worktree" {
+		if t.worktreeTools == nil {
+			return nil, nil, fmt.Errorf("worktree isolation is not available in this runtime")
+		}
+		if !writeMode {
+			for _, name := range names {
+				if tl, ok := t.task.parentReg.Get(name); ok && !tl.ReadOnly() {
+					return nil, nil, fmt.Errorf("%q is not read-only; use mode write with worktree isolation for writer tools", name)
+				}
+			}
+		}
+		return t.worktreeTools(workDir, writeMode, names)
+	}
+	if writeMode {
+		return nil, nil, fmt.Errorf("mode write requires isolation worktree")
+	}
+	if len(names) == 0 {
+		var readers []string
+		for _, name := range t.task.parentReg.Names() {
+			if tl, ok := t.task.parentReg.Get(name); ok && tl.ReadOnly() {
+				readers = append(readers, name)
+			}
+		}
+		return t.task.buildSubReg(readers), nil, nil
+	}
+	for _, name := range names {
+		if isSubagentMetaTool(name) {
+			continue
+		}
+		if tl, ok := t.task.parentReg.Get(name); ok && !tl.ReadOnly() {
+			return nil, nil, fmt.Errorf("%q is not read-only; use isolation worktree and mode write for writer tools", name)
+		}
+	}
+	return t.task.buildSubReg(names), nil, nil
+}
+
+func isSubagentMetaTool(name string) bool {
+	for _, meta := range subagentMetaTools {
+		if name == meta {
+			return true
+		}
+	}
+	return false
+}
+
+func childAgentID(parentID string, n int) string {
+	if parentID == "" {
+		return fmt.Sprintf("agent-%d", n)
+	}
+	return fmt.Sprintf("%s/agent-%d", parentID, n)
+}
+
+func blockedDependency(spec agentSpec, results []result, byID map[string]int) string {
+	for _, dep := range spec.DependsOn {
+		if r := results[byID[dep]]; r.status != "done" {
+			return dep
+		}
+	}
+	return ""
+}
+
+func agentMaxSteps(parent, explicit int) int {
+	if explicit > 0 {
+		return explicit
+	}
+	if parent <= 0 {
+		return 0
+	}
+	steps := parent / 2
+	if steps < 5 {
+		steps = 5
+	}
+	return steps
+}
+
+func agentPrompt(spec agentSpec, workDir string) string {
+	if spec.Isolation != "worktree" {
+		return spec.Prompt
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "You are a worktree-isolated sub-agent.\nWorktree: %s\nBranch: %s\nMode: %s\n", workDir, spec.Branch, spec.Mode)
+	if spec.Mode == "write" {
+		fmt.Fprintln(&b, "Edit only inside this worktree. Commit intended changes before your final answer. Use a concise commit message that starts with the agent id when practical.")
+	} else {
+		fmt.Fprintln(&b, "Stay read-only. Do not modify files or create commits.")
+	}
+	fmt.Fprintln(&b, "Final answer must be concise and include what changed or what you found, blockers, and next steps.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, spec.Prompt)
+	return b.String()
+}
+
+func agentResultText(r result) string {
+	if r.err != nil {
+		return "error: " + r.err.Error()
+	}
+	if strings.TrimSpace(r.answer) == "" && strings.TrimSpace(r.next) != "" {
+		return r.status + ": " + r.next
+	}
+	return r.answer
+}
+
+type managerActions struct {
+	runLog   string
+	merged   []string
+	cleaned  []string
+	deleted  []string
+	warnings []string
+	err      error
+}
+
+func runManagerActions(repo string, results []result, topoOrder []int, p agentsPayload) managerActions {
+	var actions managerActions
+	if repo == "" {
+		return actions
+	}
+	if p.MergeStrategy == "merge" {
+		branches := mergeBranches(results, topoOrder)
+		actions = mergeAgentBranches(repo, branches)
+		if actions.err != nil {
+			return actions
+		}
+	}
+	if p.Cleanup != "none" {
+		cleanup := cleanupAgentWorktrees(repo, results, p.Cleanup, actions.merged)
+		actions.cleaned = append(actions.cleaned, cleanup.cleaned...)
+		actions.deleted = append(actions.deleted, cleanup.deleted...)
+		actions.warnings = append(actions.warnings, cleanup.warnings...)
+		if cleanup.err != nil {
+			actions.err = cleanup.err
+		}
+	}
+	return actions
+}
+
+func mergeAgentBranches(repo string, branches []string) managerActions {
+	var actions managerActions
+	if len(branches) == 0 {
+		return actions
+	}
+	if gitDirty(repo) {
+		actions.err = fmt.Errorf("parent worktree is dirty; commit/stash changes before auto-merge")
+		return actions
+	}
+	for _, branch := range branches {
+		if _, err := gitOutput(repo, "merge", "--no-ff", branch, "-m", "merge: "+branch); err != nil {
+			_, _ = gitOutput(repo, "merge", "--abort")
+			actions.err = fmt.Errorf("merge %s failed: %w", branch, err)
+			return actions
+		}
+		actions.merged = append(actions.merged, branch)
+	}
+	return actions
+}
+
+func cleanupAgentWorktrees(repo string, results []result, cleanup string, merged []string) managerActions {
+	var actions managerActions
+	mergedSet := map[string]bool{}
+	for _, b := range merged {
+		mergedSet[b] = true
+	}
+	for _, r := range results {
+		if r.worktree == "" {
+			continue
+		}
+		if gitDirty(r.worktree) {
+			actions.warnings = append(actions.warnings, fmt.Sprintf("kept dirty worktree %s", r.worktree))
+			continue
+		}
+		if _, err := gitOutput(repo, "worktree", "remove", r.worktree); err != nil {
+			actions.err = fmt.Errorf("remove worktree %s: %w", r.worktree, err)
+			return actions
+		}
+		actions.cleaned = append(actions.cleaned, r.worktree)
+		if cleanup == "merged_branches" && r.branch != "" && mergedSet[r.branch] {
+			if _, err := gitOutput(repo, "branch", "-d", r.branch); err != nil {
+				actions.err = fmt.Errorf("delete branch %s: %w", r.branch, err)
+				return actions
+			}
+			actions.deleted = append(actions.deleted, r.branch)
+		}
+	}
+	return actions
+}
+
+func renderAgentsResult(results []result, mergeStrategy string, topoOrder []int, actions managerActions) string {
+	var out strings.Builder
+	fmt.Fprintf(&out, "| agent | branch | task | commits | status | next |\n|---|---|---|---|---|---|\n")
+	for _, r := range results {
+		commits := "-"
+		if len(r.commits) > 0 {
+			commits = strings.Join(shortCommits(r.commits), ", ")
+		}
+		next := r.next
+		if r.err != nil {
+			next = firstLine(r.err.Error())
+		}
+		if r.status == "pending" {
+			r.status = "blocked"
+			next = "not started"
+		}
+		fmt.Fprintf(&out, "| %s | %s | %s | %s | %s | %s |\n",
+			escapeTableCell(r.label),
+			escapeTableCell(defaultString(r.branch, "-")),
+			escapeTableCell(firstLine(r.task)),
+			escapeTableCell(commits),
+			escapeTableCell(r.status),
+			escapeTableCell(defaultString(next, "-")),
+		)
+	}
+	if mergeStrategy == "plan" {
+		branches := mergeBranches(results, topoOrder)
+		if len(branches) > 0 {
+			fmt.Fprintf(&out, "\nMerge plan:\n")
+			for i, b := range branches {
+				fmt.Fprintf(&out, "%d. git merge --no-ff %s\n", i+1, b)
+			}
+		}
+	}
+	if len(actions.merged) > 0 {
+		fmt.Fprintf(&out, "\nMerged:\n")
+		for _, b := range actions.merged {
+			fmt.Fprintf(&out, "- %s\n", b)
+		}
+	}
+	if len(actions.cleaned) > 0 || len(actions.deleted) > 0 {
+		fmt.Fprintf(&out, "\nCleanup:\n")
+		for _, wt := range actions.cleaned {
+			fmt.Fprintf(&out, "- removed worktree %s\n", wt)
+		}
+		for _, b := range actions.deleted {
+			fmt.Fprintf(&out, "- deleted branch %s\n", b)
+		}
+	}
+	if len(actions.warnings) > 0 {
+		fmt.Fprintf(&out, "\nWarnings:\n")
+		for _, w := range actions.warnings {
+			fmt.Fprintf(&out, "- %s\n", w)
+		}
+	}
+	if actions.err != nil {
+		fmt.Fprintf(&out, "\nManager action failed: %s\n", actions.err.Error())
+	}
+	if actions.runLog != "" {
+		fmt.Fprintf(&out, "\nManager run log:\n- %s\n", actions.runLog)
+	}
+	return out.String()
+}
+
+func mergeBranches(results []result, topoOrder []int) []string {
+	var out []string
+	if len(topoOrder) == 0 {
+		topoOrder = make([]int, len(results))
+		for i := range results {
+			topoOrder[i] = i
+		}
+	}
+	for _, idx := range topoOrder {
+		if idx < 0 || idx >= len(results) {
+			continue
+		}
+		r := results[idx]
+		if r.status == "done" && r.branch != "" && len(r.commits) > 0 {
+			out = append(out, r.branch)
+		}
+	}
+	return out
+}
+
+func hasFailedAgent(results []result) bool {
+	for _, r := range results {
+		if r.status != "done" {
+			return true
+		}
+	}
+	return false
+}
+
+func addManagerRunWarning(actions *managerActions, rec *managerRunRecorder) {
+	if actions == nil || rec == nil {
+		return
+	}
+	if err := rec.Err(); err != nil {
+		actions.warnings = append(actions.warnings, "manager run log incomplete: "+firstLine(err.Error()))
+	}
+}
+
+func shortCommits(commits []string) []string {
+	out := make([]string, len(commits))
+	for i, c := range commits {
+		if len(c) > 7 {
+			out[i] = c[:7]
+		} else {
+			out[i] = c
+		}
+	}
+	return out
+}
+
+func maybeGitRoot() (string, error) {
+	root, err := gitOutput(".", "rev-parse", "--show-toplevel")
+	if err != nil {
+		return "", fmt.Errorf("worktree isolation requires a git repository: %w", err)
+	}
+	return strings.TrimSpace(root), nil
+}
+
+func resolveWorktreeDir(repo, base, dir string) (string, error) {
+	if dir == "" {
+		return "", fmt.Errorf("worktree_dir is required")
+	}
+	if filepath.IsAbs(dir) {
+		return "", fmt.Errorf("worktree_dir must be relative to the repository parent")
+	}
+	repoAbs, err := filepath.Abs(repo)
+	if err != nil {
+		return "", err
+	}
+	repoParent := filepath.Dir(filepath.Clean(repoAbs))
+	root := repoParent
+	if base != "" {
+		if filepath.IsAbs(base) {
+			return "", fmt.Errorf("worktree_base must be relative to the repository parent")
+		}
+		cleanBase := filepath.Clean(base)
+		if pathEscapesRoot(cleanBase) {
+			return "", fmt.Errorf("worktree_base must stay under the repository parent")
+		}
+		root = filepath.Join(root, cleanBase)
+	}
+	cleanDir := filepath.Clean(dir)
+	if cleanDir == "." {
+		return "", fmt.Errorf("worktree_dir must name a child directory")
+	}
+	if pathEscapesRoot(cleanDir) {
+		return "", fmt.Errorf("worktree_dir must stay under the repository parent")
+	}
+	out, err := filepath.Abs(filepath.Join(root, cleanDir))
+	if err != nil {
+		return "", err
+	}
+	if !pathWithin(root, out) {
+		return "", fmt.Errorf("worktree_dir must stay under the selected worktree base")
+	}
+	if err := existingPathStaysUnder(repoParent, out); err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+func pathEscapesRoot(p string) bool {
+	return p == ".." || strings.HasPrefix(p, ".."+string(os.PathSeparator))
+}
+
+func pathWithin(root, p string) bool {
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false
+	}
+	return rel == "." || !pathEscapesRoot(rel)
+}
+
+func existingPathStaysUnder(root, p string) error {
+	rootReal, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return err
+	}
+	ancestor, err := existingAncestor(p)
+	if err != nil {
+		return err
+	}
+	ancestorReal, err := filepath.EvalSymlinks(ancestor)
+	if err != nil {
+		return err
+	}
+	if !pathWithin(rootReal, ancestorReal) {
+		return fmt.Errorf("worktree_dir must not pass through symlinks outside the repository parent")
+	}
+	return nil
+}
+
+func existingAncestor(p string) (string, error) {
+	for {
+		if _, err := os.Lstat(p); err == nil {
+			return p, nil
+		} else if !os.IsNotExist(err) {
+			return "", err
+		}
+		parent := filepath.Dir(p)
+		if parent == p {
+			return "", os.ErrNotExist
+		}
+		p = parent
+	}
+}
+
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	b, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(b), fmt.Errorf("git %s: %w\n%s", strings.Join(args, " "), err, strings.TrimSpace(string(b)))
+	}
+	return string(b), nil
+}
+
+func gitListCommits(dir, base string) []string {
+	if strings.TrimSpace(base) == "" {
+		return nil
+	}
+	out, err := gitOutput(dir, "rev-list", "--reverse", strings.TrimSpace(base)+"..HEAD")
+	if err != nil {
+		return nil
+	}
+	return strings.Fields(out)
+}
+
+func gitDirty(dir string) bool {
+	out, err := gitOutput(dir, "status", "--porcelain")
+	return err == nil && strings.TrimSpace(out) != ""
+}
+
+func batchRunID(ctx context.Context) string {
+	parentID, _, _, ok := CallContext(ctx)
+	if ok && strings.TrimSpace(parentID) != "" {
+		parts := strings.Split(parentID, "/")
+		if id := safeID(parts[len(parts)-1]); id != "" {
+			return id
+		}
+	}
+	return strconv.FormatInt(time.Now().UnixNano(), 36)
+}
+
+func defaultString(s, def string) string {
+	if strings.TrimSpace(s) == "" {
+		return def
+	}
+	return strings.TrimSpace(s)
+}
+
+func validIsolation(s string) bool { return s == "session" || s == "worktree" }
+func validMode(s string) bool      { return s == "read_only" || s == "write" }
+
+func safeID(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range s {
+		ok := unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
+		if ok {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+		if !lastDash {
+			b.WriteByte('-')
+			lastDash = true
+		}
+	}
+	out := strings.Trim(b.String(), "-_")
+	if out == "" {
+		return "agent"
+	}
+	return out
+}
+
+func escapeTableCell(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\n", "<br>")
+	s = strings.ReplaceAll(s, "|", "\\|")
+	return s
 }
 
 // buildSubReg returns the sub-agent's tool set: the named whitelist (minus

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -2,9 +2,15 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -53,10 +59,11 @@ func TestTaskToolFiltersTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "bash", readOnly: false})
 	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task) // simulate the wiring in cli.setup
+	parentReg.Add(NewAgentsTool(task))
 	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
 	parentReg.Add(fakeTool{name: "research", readOnly: false})
 
-	args := []byte(`{"prompt":"x","tools":["read_file","task","write_file","run_skill","research"]}`)
+	args := []byte(`{"prompt":"x","tools":["read_file","task","agents","write_file","run_skill","research"]}`)
 	if _, err := task.Execute(context.Background(), args); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -65,7 +72,7 @@ func TestTaskToolFiltersTools(t *testing.T) {
 	for _, s := range sub.lastReq.Tools {
 		got[s.Name] = true
 	}
-	if !got["read_file"] || !got["write_file"] || got["task"] || got["run_skill"] || got["research"] || got["bash"] {
+	if !got["read_file"] || !got["write_file"] || got["task"] || got["agents"] || got["run_skill"] || got["research"] || got["bash"] {
 		t.Errorf("sub-agent tools = %v, want {read_file, write_file} (meta-tools stripped, bash not requested)", got)
 	}
 }
@@ -82,6 +89,7 @@ func TestTaskToolDefaultsToParentToolsWithoutMetaTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "grep", readOnly: true})
 	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task)
+	parentReg.Add(NewAgentsTool(task))
 	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
 	parentReg.Add(fakeTool{name: "explore", readOnly: false})
 	parentReg.Add(fakeTool{name: "research", readOnly: false})
@@ -97,7 +105,380 @@ func TestTaskToolDefaultsToParentToolsWithoutMetaTools(t *testing.T) {
 		got[s.Name] = true
 	}
 	if !got["read_file"] || !got["grep"] || !got["remember"] ||
-		got["task"] || got["run_skill"] || got["explore"] || got["research"] || got["review"] || got["security_review"] {
+		got["task"] || got["agents"] || got["run_skill"] || got["explore"] || got["research"] || got["review"] || got["security_review"] {
 		t.Errorf("default sub-agent tools = %v, want normal tools inherited and meta-tools stripped", got)
 	}
+}
+
+func TestAgentsToolRunsBatchAndNestsSyntheticAgentEvents(t *testing.T) {
+	sub := &promptProvider{}
+	parentReg := tool.NewRegistry()
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	agents := NewAgentsTool(task)
+	parentReg.Add(task)
+	parentReg.Add(agents)
+
+	var got []event.Event
+	sink := event.FuncSink(func(e event.Event) { got = append(got, e) })
+	ctx := withCallContext(context.Background(), "root-call", sink, nil)
+	out, err := agents.Execute(ctx, []byte(`{"agents":[
+		{"id":"a","description":"first scan","prompt":"alpha"},
+		{"id":"b","description":"second scan","prompt":"beta"}
+	],"concurrency":2}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "| first scan | - | alpha | - | done | ready |") ||
+		!strings.Contains(out, "| second scan | - | beta | - | done | ready |") {
+		t.Fatalf("summary table missing answers:\n%s", out)
+	}
+
+	dispatches, results := 0, 0
+	for _, e := range got {
+		if e.Tool.Name != "agent" {
+			continue
+		}
+		if e.Tool.ParentID != "root-call" {
+			t.Fatalf("agent event parentID = %q, want root-call", e.Tool.ParentID)
+		}
+		switch e.Kind {
+		case event.ToolDispatch:
+			dispatches++
+		case event.ToolResult:
+			results++
+		}
+	}
+	if dispatches != 2 || results != 2 {
+		t.Fatalf("agent events dispatch/results = %d/%d, want 2/2", dispatches, results)
+	}
+}
+
+func TestAgentsToolPersistsManagerRunLog(t *testing.T) {
+	sub := &promptProvider{}
+	parentReg := tool.NewRegistry()
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	agents := NewAgentsTool(task)
+	logDir := t.TempDir()
+	if err := os.Chmod(logDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agents.SetRunStore(logDir)
+	parentReg.Add(task)
+	parentReg.Add(agents)
+
+	out, err := agents.Execute(context.Background(), []byte(`{"agents":[{"id":"scan","description":"scan code","prompt":"alpha"}]}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "Manager run log:") {
+		t.Fatalf("summary should include manager run log path:\n%s", out)
+	}
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("run log files = %d, want 1", len(entries))
+	}
+	dirInfo, err := os.Stat(logDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("run log dir mode = %o, want 700", got)
+	}
+	logPath := filepath.Join(logDir, entries[0].Name())
+	info, err := os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("run log mode = %o, want 600", got)
+	}
+	b, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(b)
+	for _, want := range []string{`"event":"started"`, `"event":"agent_finished"`, `"event":"finished"`, `"status":"done"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("run log missing %s:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "alpha") {
+		t.Fatalf("run log should not persist full agent prompt:\n%s", text)
+	}
+	if !strings.Contains(text, `"prompt_redacted":true`) {
+		t.Fatalf("run log should mark prompts redacted:\n%s", text)
+	}
+}
+
+func TestAgentsToolRejectsParallelWriterTools(t *testing.T) {
+	sub := &promptProvider{}
+	parentReg := tool.NewRegistry()
+	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
+	parentReg.Add(fakeTool{name: "write_file", readOnly: false})
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	agents := NewAgentsTool(task)
+	parentReg.Add(task)
+	parentReg.Add(agents)
+
+	out, err := agents.Execute(context.Background(), []byte(`{"agents":[
+		{"description":"first","prompt":"alpha","tools":["write_file"]},
+		{"description":"second","prompt":"beta","tools":["read_file"]}
+	],"concurrency":2}`))
+	if err == nil || !strings.Contains(out, "use isolation worktree") {
+		t.Fatalf("Execute error/output = %v\n%s\nwant writer-tool rejection", err, out)
+	}
+}
+
+func TestAgentsToolCreatesWorktreeAndReportsBranch(t *testing.T) {
+	repo := initGitRepo(t)
+	base := "agent-worktrees"
+	sub := &promptProvider{}
+	parentReg := tool.NewRegistry()
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	agents := NewAgentsTool(task)
+	cleanupCalls := 0
+	agents.SetWorktreeTools(func(dir string, write bool, names []string) (*tool.Registry, func(), error) {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("worktree dir should exist before registry build: %v", err)
+		}
+		return tool.NewRegistry(), func() { cleanupCalls++ }, nil
+	})
+	parentReg.Add(task)
+	parentReg.Add(agents)
+
+	args := marshalAgentsArgs(t, map[string]any{
+		"isolation":     "worktree",
+		"mode":          "write",
+		"worktree_base": base,
+		"agents": []map[string]any{{
+			"id":           "worker",
+			"description":  "worktree worker",
+			"prompt":       "do work",
+			"branch":       "feature/worker",
+			"worktree_dir": "worker",
+		}},
+	})
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := agents.Execute(context.Background(), args)
+	if err == nil {
+		t.Fatalf("Execute should block write-mode agent with no commits:\n%s", out)
+	}
+	if !strings.Contains(out, "| worktree worker | feature/worker |") ||
+		!strings.Contains(out, "| - | blocked | no commits produced") {
+		t.Fatalf("worktree summary missing branch/no-commit state:\n%s", out)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(repo), base, "worker")); err != nil {
+		t.Fatalf("worktree was not created: %v", err)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("worktree tool cleanup calls = %d, want 1", cleanupCalls)
+	}
+}
+
+func TestAgentsToolBlocksReadOnlyWorktreeMutation(t *testing.T) {
+	repo := initGitRepo(t)
+	base := "agent-worktrees"
+	sub := &promptProvider{}
+	parentReg := tool.NewRegistry()
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	agents := NewAgentsTool(task)
+	agents.SetWorktreeTools(func(dir string, write bool, names []string) (*tool.Registry, func(), error) {
+		if write {
+			t.Fatalf("read-only worktree agent should not request write tools")
+		}
+		if err := os.WriteFile(filepath.Join(dir, "unexpected.txt"), []byte("dirty\n"), 0o644); err != nil {
+			return nil, nil, err
+		}
+		return tool.NewRegistry(), nil, nil
+	})
+	parentReg.Add(task)
+	parentReg.Add(agents)
+
+	args := marshalAgentsArgs(t, map[string]any{
+		"isolation":     "worktree",
+		"worktree_base": base,
+		"agents": []map[string]any{{
+			"id":           "reader",
+			"description":  "read-only scan",
+			"prompt":       "inspect only",
+			"branch":       "feature/reader",
+			"worktree_dir": "reader",
+		}},
+	})
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	if err := os.Chdir(repo); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := agents.Execute(context.Background(), args)
+	if err == nil {
+		t.Fatalf("Execute should block read-only worktree mutation:\n%s", out)
+	}
+	if !strings.Contains(out, "| read-only scan | feature/reader |") ||
+		!strings.Contains(out, "| - | blocked | read_only agent modified the worktree") {
+		t.Fatalf("worktree summary missing read-only mutation block:\n%s", out)
+	}
+	if strings.Contains(out, "Merge plan:") {
+		t.Fatalf("blocked read-only mutation should not produce a merge plan:\n%s", out)
+	}
+}
+
+func TestResolveWorktreeDirStaysUnderRepoParent(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveWorktreeDir(repo, "agent-worktrees", "worker")
+	if err != nil {
+		t.Fatalf("resolveWorktreeDir: %v", err)
+	}
+	want := filepath.Join(filepath.Dir(repo), "agent-worktrees", "worker")
+	if got != want {
+		t.Fatalf("resolveWorktreeDir = %q, want %q", got, want)
+	}
+	for _, tc := range []struct {
+		name string
+		base string
+		dir  string
+	}{
+		{name: "absolute dir", dir: filepath.Join(t.TempDir(), "worker")},
+		{name: "absolute base", base: t.TempDir(), dir: "worker"},
+		{name: "escaping base", base: "../outside", dir: "worker"},
+		{name: "escaping dir", base: "agent-worktrees", dir: "../outside"},
+		{name: "root dir", base: "agent-worktrees", dir: "."},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := resolveWorktreeDir(repo, tc.base, tc.dir); err == nil {
+				t.Fatal("resolveWorktreeDir should reject unsafe path")
+			}
+		})
+	}
+	outside := t.TempDir()
+	linkBase := filepath.Join(filepath.Dir(repo), "linked-base")
+	if err := os.Symlink(outside, linkBase); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if _, err := resolveWorktreeDir(repo, filepath.Base(linkBase), "worker"); err == nil {
+		t.Fatal("resolveWorktreeDir should reject symlinked bases outside the repository parent")
+	}
+}
+
+func TestAgentsPayloadLayersRejectsCycles(t *testing.T) {
+	p := agentsPayload{Agents: []agentSpec{
+		{ID: "a", Prompt: "a", DependsOn: []string{"b"}},
+		{ID: "b", Prompt: "b", DependsOn: []string{"a"}},
+	}}
+	if err := p.normalize(4); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.fillAgentDefaults("run"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.layers(); err == nil || !strings.Contains(err.Error(), "cycle") {
+		t.Fatalf("layers error = %v, want cycle", err)
+	}
+}
+
+func TestAgentsManagerActionsMergeAndCleanup(t *testing.T) {
+	repo := initGitRepo(t)
+	wt := filepath.Join(t.TempDir(), "worker")
+	runGit(t, repo, "worktree", "add", "-b", "feature/worker", wt)
+	if err := os.WriteFile(filepath.Join(wt, "worker.txt"), []byte("done\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, wt, "add", "worker.txt")
+	runGit(t, wt, "-c", "user.name=Reasonix Test", "-c", "user.email=test@example.com", "commit", "-m", "worker: add file")
+	commit := strings.TrimSpace(gitOutputOrFatal(t, wt, "rev-parse", "HEAD"))
+
+	results := []result{{
+		label: "worker", task: "write file", status: "done",
+		branch: "feature/worker", worktree: wt, commits: []string{commit},
+	}}
+	actions := runManagerActions(repo, results, []int{0}, agentsPayload{
+		MergeStrategy: "merge",
+		Cleanup:       "merged_branches",
+	})
+	if actions.err != nil {
+		t.Fatalf("manager actions: %v", actions.err)
+	}
+	if len(actions.merged) != 1 || actions.merged[0] != "feature/worker" {
+		t.Fatalf("merged = %v, want feature/worker", actions.merged)
+	}
+	if len(actions.cleaned) != 1 || len(actions.deleted) != 1 {
+		t.Fatalf("cleanup cleaned/deleted = %v/%v, want one each", actions.cleaned, actions.deleted)
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Fatalf("worktree should be removed, stat err=%v", err)
+	}
+	if out := gitOutputOrFatal(t, repo, "branch", "--list", "feature/worker"); strings.TrimSpace(out) != "" {
+		t.Fatalf("branch should be deleted, got %q", out)
+	}
+	if b, err := os.ReadFile(filepath.Join(repo, "worker.txt")); err != nil || string(b) != "done\n" {
+		t.Fatalf("merged file = %q err=%v", b, err)
+	}
+}
+
+type promptProvider struct {
+	mu sync.Mutex
+}
+
+func (p *promptProvider) Name() string { return "prompt" }
+
+func (p *promptProvider) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	answer := "answer for " + lastUser(req)
+	p.mu.Unlock()
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: answer}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func marshalAgentsArgs(t *testing.T, v map[string]any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "-c", "user.name=Reasonix Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func gitOutputOrFatal(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return string(out)
 }

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -457,11 +457,13 @@ func initGitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.name", "Reasonix Test")
+	runGit(t, dir, "config", "user.email", "test@example.com")
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("hello\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	runGit(t, dir, "add", "README.md")
-	runGit(t, dir, "-c", "user.name=Reasonix Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+	runGit(t, dir, "commit", "-m", "init")
 	return dir
 }
 

--- a/internal/agent/textsink.go
+++ b/internal/agent/textsink.go
@@ -68,14 +68,14 @@ func (s *TextSink) Emit(e event.Event) {
 		s.closeTextStream(e.Text, e.Reasoning)
 
 	case event.ToolDispatch:
-		fmt.Fprintf(s.out, "  -> %s %s\n", e.Tool.Name, CompactArgs(e.Tool.Args))
+		fmt.Fprintf(s.out, "%s-> %s %s\n", toolIndent(e.Tool.ParentID), e.Tool.Name, CompactArgs(e.Tool.Args))
 		s.wroteAnything = true
 
 	case event.ToolResult:
 		// A successful result is silent (it only feeds the model); a blocked
 		// call surfaces the same "⊘ name <reason>" line the agent used to print.
 		if e.Tool.Err != "" {
-			fmt.Fprintf(s.out, "  ⊘ %s %s\n", e.Tool.Name, e.Tool.Err)
+			fmt.Fprintf(s.out, "%s⊘ %s %s\n", toolIndent(e.Tool.ParentID), e.Tool.Name, e.Tool.Err)
 			s.wroteAnything = true
 		}
 
@@ -205,4 +205,15 @@ func CompactArgs(s string) string {
 		return string(r[:120]) + "..."
 	}
 	return s
+}
+
+func toolIndent(parentID string) string {
+	if parentID == "" {
+		return "  "
+	}
+	depth := strings.Count(parentID, "/") + 1
+	if depth > 4 {
+		depth = 4
+	}
+	return strings.Repeat("  ", depth+1)
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -227,10 +227,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		spec := bashSpec
 		spec.WriteRoots = []string{dir}
 		ws := builtin.Workspace{Dir: dir, WriteRoots: []string{dir}, Bash: spec}
-		for _, tl := range ws.Tools(names...) {
-			if !write && !tl.ReadOnly() {
-				continue
-			}
+		for _, tl := range workspaceBuiltinsForParent(reg, ws, write, names) {
 			sub.Add(tl)
 		}
 		cleanup := func() {}
@@ -433,6 +430,29 @@ func pluginSpecsForWorktree(ctx context.Context, specs []plugin.Spec, dir string
 			s.Stderr = stderr
 		}
 		out = append(out, s)
+	}
+	return out
+}
+
+func workspaceBuiltinsForParent(parent *tool.Registry, ws builtin.Workspace, write bool, names []string) []tool.Tool {
+	if parent == nil {
+		return nil
+	}
+	enabled := names
+	if len(enabled) == 0 {
+		enabled = parent.Names()
+	}
+	candidates := ws.Tools(enabled...)
+	out := make([]tool.Tool, 0, len(candidates))
+	for _, tl := range candidates {
+		parentTool, ok := parent.Get(tl.Name())
+		if !ok {
+			continue
+		}
+		if !write && (!tl.ReadOnly() || !parentTool.ReadOnly()) {
+			continue
+		}
+		out = append(out, tl)
 	}
 	return out
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -218,8 +218,45 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// sub-agents inherit the full tool set (minus `task` itself, to keep
 	// nesting out of the picture). It registers into the same reg the
 	// executor uses, so the model surfaces it like any other tool.
-	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
-		entry.ContextWindow, cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
+	taskTool := agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
+		entry.ContextWindow, cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate)
+	reg.Add(taskTool)
+	agentsTool := agent.NewAgentsTool(taskTool)
+	agentsTool.SetWorktreeTools(func(dir string, write bool, names []string) (*tool.Registry, func(), error) {
+		sub := tool.NewRegistry()
+		spec := bashSpec
+		spec.WriteRoots = []string{dir}
+		ws := builtin.Workspace{Dir: dir, WriteRoots: []string{dir}, Bash: spec}
+		for _, tl := range ws.Tools(names...) {
+			if !write && !tl.ReadOnly() {
+				continue
+			}
+			sub.Add(tl)
+		}
+		cleanup := func() {}
+		pspecs := pluginSpecsForWorktree(ctx, pluginHost.Specs(), dir, names, stderr, sink)
+		if len(pspecs) == 0 {
+			return sub, cleanup, nil
+		}
+		host, ptools, err := plugin.StartAll(ctx, pspecs)
+		if err != nil {
+			return nil, nil, fmt.Errorf("worktree plugins: %w", err)
+		}
+		cleanup = host.Close
+		for _, tl := range ptools {
+			if !toolRequested(tl.Name(), names) {
+				continue
+			}
+			if !write && !tl.ReadOnly() {
+				cleanup()
+				return nil, nil, fmt.Errorf("%q is not read-only; use mode write with worktree isolation for writer tools", tl.Name())
+			}
+			sub.Add(tl)
+		}
+		return sub, cleanup, nil
+	})
+	agentsTool.SetRunStore(config.ManagerRunDir())
+	reg.Add(agentsTool)
 
 	// The `remember` tool lets the model persist durable facts to the project's
 	// auto-memory store; the saved index loads into the prefix on the next session.
@@ -370,6 +407,85 @@ func subagentModelKeys(name string) []string {
 		}
 	}
 	return keys
+}
+
+func pluginSpecsForWorktree(ctx context.Context, specs []plugin.Spec, dir string, names []string, stderr io.Writer, sink event.Sink) []plugin.Spec {
+	if !wantsPluginTools(names) {
+		return nil
+	}
+	out := make([]plugin.Spec, 0, len(specs))
+	for _, s := range specs {
+		s = copyPluginSpec(s)
+		if !pluginServerRequested(s, names) {
+			continue
+		}
+		tt := strings.ToLower(strings.TrimSpace(s.Type))
+		if tt == "" || tt == "stdio" {
+			s.Dir = dir
+			if s.Name == "codegraph" && s.Command != "" {
+				if err := codegraph.EnsureInit(ctx, s.Command, dir); err != nil && sink != nil {
+					sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+						Text: "codegraph: worktree init failed (" + err.Error() + ") — symbol-graph tools may be degraded for " + dir})
+				}
+			}
+		}
+		if stderr != nil {
+			s.Stderr = stderr
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func copyPluginSpec(s plugin.Spec) plugin.Spec {
+	out := s
+	if s.Args != nil {
+		out.Args = append([]string(nil), s.Args...)
+	}
+	if s.Env != nil {
+		out.Env = make(map[string]string, len(s.Env))
+		for k, v := range s.Env {
+			out.Env[k] = v
+		}
+	}
+	if s.Headers != nil {
+		out.Headers = make(map[string]string, len(s.Headers))
+		for k, v := range s.Headers {
+			out.Headers[k] = v
+		}
+	}
+	return out
+}
+
+func wantsPluginTools(names []string) bool {
+	for _, name := range names {
+		if strings.HasPrefix(name, "mcp__") {
+			return true
+		}
+	}
+	return false
+}
+
+func pluginServerRequested(s plugin.Spec, names []string) bool {
+	prefix := plugin.ToolPrefix(s.Name)
+	for _, name := range names {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func toolRequested(name string, names []string) bool {
+	if len(names) == 0 {
+		return true
+	}
+	for _, want := range names {
+		if want == name {
+			return true
+		}
+	}
+	return false
 }
 
 // NewProvider builds a provider.Provider from a configured entry. Exported so

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -2,10 +2,13 @@ package boot
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
 	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 
 	// Blank imports register the provider kind and built-in tools the same way
@@ -153,6 +156,48 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	base = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(base), config.LanguagePolicy))
 	if base != "JUST THE BASE" {
 		t.Fatalf("expected untouched base prompt, got:\n%s", sys)
+	}
+}
+
+func TestPluginSpecsForWorktreeRebindsStdioAndFiltersByToolNames(t *testing.T) {
+	specs := []plugin.Spec{{
+		Name:    "fs tools",
+		Command: "mcp-fs",
+		Args:    []string{"serve"},
+		Env:     map[string]string{"A": "B"},
+	}, {
+		Name: "remote",
+		Type: "http",
+		URL:  "https://example.invalid/mcp",
+	}}
+	names := []string{plugin.ToolPrefix("fs tools") + "read_file"}
+
+	got := pluginSpecsForWorktree(context.Background(), specs, "/tmp/wt", names, io.Discard, event.Discard)
+	if len(got) != 1 {
+		t.Fatalf("specs len = %d, want 1", len(got))
+	}
+	if got[0].Name != "fs tools" || got[0].Dir != "/tmp/wt" {
+		t.Fatalf("stdio spec was not rebound to worktree: %+v", got[0])
+	}
+	if got[0].Stderr == nil {
+		t.Fatal("stderr override should be propagated")
+	}
+	got[0].Env["A"] = "mutated"
+	if specs[0].Env["A"] != "B" {
+		t.Fatalf("pluginSpecsForWorktree should not mutate input specs: %+v", specs[0].Env)
+	}
+}
+
+func TestPluginSpecsForWorktreeSkipsPluginsWithoutExplicitToolNames(t *testing.T) {
+	specs := []plugin.Spec{{
+		Name:    "fs tools",
+		Command: "mcp-fs",
+		Args:    []string{"serve"},
+	}}
+
+	got := pluginSpecsForWorktree(context.Background(), specs, "/tmp/wt", nil, io.Discard, event.Discard)
+	if len(got) != 0 {
+		t.Fatalf("specs len = %d, want 0", len(got))
 	}
 }
 

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -10,12 +10,13 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
 
 	// Blank imports register the provider kind and built-in tools the same way
 	// cmd/reasonix's main does; without them Build sees an empty provider
 	// registry and a bare tool set.
 	_ "reasonix/internal/provider/openai"
-	_ "reasonix/internal/tool/builtin"
 )
 
 // TestBuildFoldsProjectMemoryIntoSystemPrompt is the end-to-end proof of the
@@ -201,6 +202,43 @@ func TestPluginSpecsForWorktreeSkipsPluginsWithoutExplicitToolNames(t *testing.T
 	}
 }
 
+func TestWorkspaceBuiltinsForParentHonorsParentEnabledTools(t *testing.T) {
+	parent := tool.NewRegistry()
+	readFile, ok := tool.LookupBuiltin("read_file")
+	if !ok {
+		t.Fatal("read_file builtin missing")
+	}
+	parent.Add(readFile)
+	ws := builtin.Workspace{Dir: t.TempDir()}
+
+	got := toolNames(workspaceBuiltinsForParent(parent, ws, true, nil))
+	if len(got) != 1 || !got["read_file"] {
+		t.Fatalf("default worktree builtins = %v, want only read_file", got)
+	}
+
+	got = toolNames(workspaceBuiltinsForParent(parent, ws, true, []string{"bash", "read_file"}))
+	if len(got) != 1 || !got["read_file"] {
+		t.Fatalf("explicit worktree builtins = %v, want disabled bash filtered out", got)
+	}
+}
+
+func TestWorkspaceBuiltinsForParentFiltersWritersInReadOnlyMode(t *testing.T) {
+	parent := tool.NewRegistry()
+	for _, name := range []string{"read_file", "write_file"} {
+		tl, ok := tool.LookupBuiltin(name)
+		if !ok {
+			t.Fatalf("%s builtin missing", name)
+		}
+		parent.Add(tl)
+	}
+	ws := builtin.Workspace{Dir: t.TempDir()}
+
+	got := toolNames(workspaceBuiltinsForParent(parent, ws, false, nil))
+	if len(got) != 1 || !got["read_file"] || got["write_file"] {
+		t.Fatalf("read-only worktree builtins = %v, want only read_file", got)
+	}
+}
+
 func systemMessage(msgs []provider.Message) string {
 	for _, m := range msgs {
 		if m.Role == provider.RoleSystem {
@@ -208,6 +246,14 @@ func systemMessage(msgs []provider.Message) string {
 		}
 	}
 	return ""
+}
+
+func toolNames(tools []tool.Tool) map[string]bool {
+	out := make(map[string]bool, len(tools))
+	for _, tl := range tools {
+		out[tl.Name()] = true
+	}
+	return out
 }
 
 func writeFile(t *testing.T, dir, name, body string) {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1293,7 +1293,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		case planApprovalTool:
 			// No longer a tool, but guard anyway: the plan is the assistant's reply.
 		default:
-			m.commitLine(fmt.Sprintf("  -> %s %s", e.Tool.Name, compactArgs(e.Tool.Args)))
+			m.commitLine(fmt.Sprintf("%s-> %s %s", toolIndent(e.Tool.ParentID), e.Tool.Name, compactArgs(e.Tool.Args)))
 		}
 
 	case event.ToolResult:
@@ -1301,7 +1301,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		// surfaces a "⊘ name <reason>" line.
 		if e.Tool.Err != "" {
 			m.finalizeStreamed()
-			m.commitLine(fmt.Sprintf("  ⊘ %s %s", e.Tool.Name, e.Tool.Err))
+			m.commitLine(fmt.Sprintf("%s⊘ %s %s", toolIndent(e.Tool.ParentID), e.Tool.Name, e.Tool.Err))
 		}
 
 	case event.Usage:
@@ -1665,3 +1665,14 @@ func (s *eventSink) Emit(e event.Event) { s.ch <- e }
 // compactArgs delegates to agent.CompactArgs so the CLI and headless rendering
 // stay identical.
 func compactArgs(s string) string { return agent.CompactArgs(s) }
+
+func toolIndent(parentID string) string {
+	if parentID == "" {
+		return "  "
+	}
+	depth := strings.Count(parentID, "/") + 1
+	if depth > 4 {
+		depth = 4
+	}
+	return strings.Repeat("  ", depth+1)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -376,6 +376,16 @@ func SessionDir() string {
 	return filepath.Join(dir, "reasonix", "sessions")
 }
 
+// ManagerRunDir is where `agents` manager DAG runs are persisted as append-only
+// JSONL logs. Empty disables persistence when the user config dir is unavailable.
+func ManagerRunDir() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "reasonix", "manager-runs")
+}
+
 // MemoryUserDir returns the reasonix user config root (…/reasonix), under which
 // the user-global REASONIX.md and the per-project auto-memory store live. Empty
 // when the user config dir can't be resolved, which disables user-scoped memory.

--- a/internal/plugin/hotadd_test.go
+++ b/internal/plugin/hotadd_test.go
@@ -44,7 +44,45 @@ func TestHostAddRemove(t *testing.T) {
 	if len(h.Servers()) != 0 {
 		t.Errorf("server should be gone after Remove, got %+v", h.Servers())
 	}
+	if len(h.Specs()) != 0 {
+		t.Errorf("specs should be gone after Remove, got %+v", h.Specs())
+	}
 	if _, found := h.Remove("h"); found {
 		t.Error("removing an absent server should report not found")
+	}
+}
+
+func TestHostSpecsReturnsCopies(t *testing.T) {
+	srv := mcpHTTPServer(t, false)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	h := NewHost()
+	defer h.Close()
+
+	spec := Spec{
+		Name:    "copy test",
+		Type:    "http",
+		URL:     srv.URL,
+		Headers: map[string]string{"Authorization": "Bearer secret"},
+		Env:     map[string]string{"A": "B"},
+	}
+	if _, err := h.Add(ctx, spec); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	got := h.Specs()
+	if len(got) != 1 {
+		t.Fatalf("Specs len = %d, want 1", len(got))
+	}
+	if got[0].Name != spec.Name || got[0].Headers["Authorization"] != "Bearer secret" || got[0].Env["A"] != "B" {
+		t.Fatalf("Specs = %+v, want original spec fields", got[0])
+	}
+	got[0].Headers["Authorization"] = "mutated"
+	got[0].Env["A"] = "mutated"
+	again := h.Specs()
+	if again[0].Headers["Authorization"] != "Bearer secret" || again[0].Env["A"] != "B" {
+		t.Fatalf("Specs should return deep copies, got %+v", again[0])
 	}
 }

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -59,6 +59,7 @@ type transport interface {
 // chat UI surfaces (prompts as slash commands, resources as @-references).
 type Host struct {
 	clients   []*Client
+	specs     []Spec
 	prompts   []Prompt
 	resources []Resource
 }
@@ -76,6 +77,17 @@ func (h *Host) ServerNames() []string {
 		names[i] = c.name
 	}
 	return names
+}
+
+// Specs returns the specs for connected servers, in connection order. The result
+// is a deep copy so callers can rebind fields like Dir without mutating the live
+// Host.
+func (h *Host) Specs() []Spec {
+	out := make([]Spec, len(h.specs))
+	for i, s := range h.specs {
+		out[i] = copySpec(s)
+	}
+	return out
 }
 
 // ReadResource reads a resource uri from the named server. It is how the chat
@@ -106,6 +118,7 @@ func StartAll(ctx context.Context, specs []Spec) (*Host, []tool.Tool, error) {
 			return nil, nil, fmt.Errorf("start plugin %q: %w", s.Name, err)
 		}
 		h.clients = append(h.clients, c)
+		h.specs = append(h.specs, copySpec(s))
 
 		ts, err := c.listTools(ctx)
 		if err != nil {
@@ -220,6 +233,7 @@ func (h *Host) Add(ctx context.Context, s Spec) ([]tool.Tool, error) {
 	}
 	c.toolCount = len(ts)
 	h.clients = append(h.clients, c)
+	h.specs = append(h.specs, copySpec(s))
 	if c.hasPrompts {
 		if ps, perr := c.listPrompts(ctx); perr == nil {
 			h.prompts = append(h.prompts, ps...)
@@ -253,6 +267,7 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 	}
 	h.clients[idx].close()
 	h.clients = append(h.clients[:idx], h.clients[idx+1:]...)
+	h.specs = append(h.specs[:idx], h.specs[idx+1:]...)
 
 	keptP := h.prompts[:0]
 	for _, p := range h.prompts {
@@ -270,7 +285,30 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 	}
 	h.resources = keptR
 
-	return "mcp__" + normalizeName(name) + "__", true
+	return ToolPrefix(name), true
+}
+
+// ToolPrefix is the model-visible prefix for tools from server.
+func ToolPrefix(server string) string { return "mcp__" + normalizeName(server) + "__" }
+
+func copySpec(s Spec) Spec {
+	out := s
+	if s.Args != nil {
+		out.Args = append([]string(nil), s.Args...)
+	}
+	if s.Env != nil {
+		out.Env = make(map[string]string, len(s.Env))
+		for k, v := range s.Env {
+			out.Env[k] = v
+		}
+	}
+	if s.Headers != nil {
+		out.Headers = make(map[string]string, len(s.Headers))
+		for k, v := range s.Headers {
+			out.Headers[k] = v
+		}
+	}
+	return out
 }
 
 func start(ctx context.Context, s Spec) (*Client, error) {
@@ -385,7 +423,7 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 // matching Claude Code. Spaces in either part are normalised to underscores so
 // the name is a clean identifier the model can call.
 func toolName(server, raw string) string {
-	return "mcp__" + normalizeName(server) + "__" + normalizeName(raw)
+	return ToolPrefix(server) + normalizeName(raw)
 }
 
 func normalizeName(s string) string { return strings.ReplaceAll(s, " ", "_") }


### PR DESCRIPTION
## Summary

Adds a first-class `agents` tool for coordinated multi-agent runs, including read-only parallel exploration, worktree-isolated write agents, DAG dependencies, branch/commit summaries, merge planning, and desktop visibility for nested agent activity.

## Root Cause

The previous sub-agent flow could delegate focused work, but it did not provide a durable manager-level contract for physically isolated write agents, branch/commit receipts, or persisted run state. Plugin/MCP tools also needed to be rebound per worktree so child agents operate against the intended workspace instead of the parent process directory.

## Technical Approach

- Introduce an `agents` batch tool that runs up to four sub-agents with per-agent `session` or `worktree` isolation, `read_only` or `write` mode, DAG `depends_on` ordering, and branch/worktree defaults.
- Add git worktree creation, commit detection, dirty-state blocking, merge planning, optional auto-merge, and cleanup handling.
- Rebind built-in workspace tools and explicitly requested MCP/plugin tools to each worktree; stdio plugin specs are deep-copied and restarted with the worktree directory.
- Persist manager run events as append-only JSONL logs under the Reasonix config directory.
- Surface nested multi-agent activity in CLI/ACP/desktop transcripts, including branch/worktree/status metadata and a desktop open-folder action.

## Focused Optimization Points

- Manager run logs use private permissions (`0700` directory, `0600` files) and redact full agent prompts while preserving prompt byte counts for auditability.
- Worktree paths are constrained to relative directories under the repository parent and reject absolute paths, `..` escapes, `.` roots, and symlink escapes.
- Desktop `OpenPath` is restricted to the current workspace, registered git worktrees, and manager-run logs; it rejects arbitrary files and `.app` bundles.
- Worktree agents no longer start all configured MCP/plugin servers by default. Plugin rebinding now happens only when an `mcp__...` tool is explicitly requested.
- Read-only worktree agents are blocked if they dirty the worktree or create commits.

## Verification

- `go test ./...`
- `(cd desktop && go test ./...)`
- `npm --prefix desktop/frontend run build`
- `git diff --check`
