### PR TITLE
feat(tool): add notebook_edit for Jupyter .ipynb cells

### DIFF
--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -15,9 +15,9 @@ import (
 func ConfineBash(spec sandbox.Spec) tool.Tool { return bash{sb: spec} }
 
 // ConfineWriters returns the file-writing built-ins (write_file, edit_file,
-// multi_edit) bound to roots — the only directories they may modify. The
-// composition root adds these to the per-run registry to override the
-// unconfined instances registered at init time, so writes stay inside the
+// multi_edit, notebook_edit) bound to roots — the only directories they may
+// modify. The composition root adds these to the per-run registry to override
+// the unconfined instances registered at init time, so writes stay inside the
 // workspace by default. roots may be relative; they are resolved to absolute,
 // symlink-free paths once here. An empty roots slice yields unconfined writers.
 func ConfineWriters(roots []string) []tool.Tool {
@@ -26,6 +26,7 @@ func ConfineWriters(roots []string) []tool.Tool {
 		writeFile{roots: rs},
 		editFile{roots: rs},
 		multiEdit{roots: rs},
+		notebookEdit{roots: rs},
 	}
 }
 

--- a/internal/tool/builtin/notebookedit.go
+++ b/internal/tool/builtin/notebookedit.go
@@ -1,0 +1,329 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"reasonix/internal/diff"
+	"reasonix/internal/tool"
+)
+
+func init() { tool.RegisterBuiltin(notebookEdit{}) }
+
+// notebookEdit edits a single cell of a Jupyter notebook (.ipynb). A notebook is
+// JSON with a "cells" array; editing it with edit_file means matching escaped
+// JSON by hand, which is fragile. This tool targets a cell by index (or id) and
+// replaces, inserts, or deletes it, re-serialising so the JSON stays valid and
+// unrelated cells, outputs, and top-level metadata are preserved.
+//
+// roots, when non-empty, confines the target to the workspace (see confine); the
+// zero value registered at init is unconfined and is overridden per run by
+// ConfineWriters. workDir, when non-empty, is the directory a relative path
+// resolves against (see resolveIn).
+type notebookEdit struct {
+	roots   []string
+	workDir string
+}
+
+func (notebookEdit) Name() string { return "notebook_edit" }
+
+func (notebookEdit) ReadOnly() bool { return false }
+
+func (notebookEdit) Description() string {
+	return "Edit one cell of a Jupyter notebook (.ipynb). Target a cell by 0-based " +
+		"cell_number (or cell_id). edit_mode: \"replace\" (default) swaps the cell's " +
+		"source; \"insert\" adds a new cell after cell_number (use -1 to prepend at the " +
+		"top), taking cell_type and new_source; \"delete\" removes the cell. cell_type is " +
+		"\"code\" or \"markdown\" (required for insert). Editing a code cell clears its " +
+		"outputs. Prefer this over edit_file for notebooks — it keeps the JSON valid."
+}
+
+func (notebookEdit) Schema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"path": {"type": "string", "description": "Path to the .ipynb notebook."},
+			"cell_number": {"type": "integer", "description": "0-based index of the target cell. For insert, the new cell goes after this one (-1 prepends)."},
+			"cell_id": {"type": "string", "description": "Target the cell by its id instead of cell_number (replace/delete)."},
+			"new_source": {"type": "string", "description": "The cell's new source text (replace/insert)."},
+			"cell_type": {"type": "string", "enum": ["code", "markdown"], "description": "Cell type for insert (and optional retype on replace)."},
+			"edit_mode": {"type": "string", "enum": ["replace", "insert", "delete"], "description": "replace (default), insert, or delete."}
+		},
+		"required": ["path"]
+	}`)
+}
+
+type notebookArgs struct {
+	Path       string `json:"path"`
+	CellNumber *int   `json:"cell_number"`
+	CellID     string `json:"cell_id"`
+	NewSource  string `json:"new_source"`
+	CellType   string `json:"cell_type"`
+	EditMode   string `json:"edit_mode"`
+}
+
+// notebook is the minimal .ipynb shape we touch. Unknown top-level keys
+// (metadata, nbformat, …) and unknown per-cell keys are preserved verbatim via
+// json.RawMessage round-tripping.
+type notebook struct {
+	rest  map[string]json.RawMessage
+	cells []map[string]json.RawMessage
+}
+
+func (n notebookEdit) Execute(ctx context.Context, raw json.RawMessage) (string, error) {
+	a, err := parseNotebookArgs(raw)
+	if err != nil {
+		return "", err
+	}
+	a.Path = resolveIn(n.workDir, a.Path)
+	if err := confine(n.roots, a.Path); err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(a.Path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", a.Path, err)
+	}
+	nb, err := parseNotebook(data)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", a.Path, err)
+	}
+
+	idx, summary, err := applyNotebookEdit(nb, a)
+	if err != nil {
+		return "", err
+	}
+
+	out, err := nb.marshal()
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(a.Path, out, 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", a.Path, err)
+	}
+	return fmt.Sprintf("%s in %s (cell %d; %d cells total)", summary, a.Path, idx, len(nb.cells)), nil
+}
+
+// Preview implements tool.Previewer so a checkpoint can snapshot the notebook's
+// before/after for rewind. It mirrors Execute's transformation exactly but never
+// writes — same arg parsing and targeting rules, so the previewed change equals
+// what Execute would persist.
+func (n notebookEdit) Preview(raw json.RawMessage) (diff.Change, error) {
+	a, err := parseNotebookArgs(raw)
+	if err != nil {
+		return diff.Change{}, err
+	}
+	a.Path = resolveIn(n.workDir, a.Path)
+	data, err := os.ReadFile(a.Path)
+	if err != nil {
+		return diff.Change{}, fmt.Errorf("read %s: %w", a.Path, err)
+	}
+	nb, err := parseNotebook(data)
+	if err != nil {
+		return diff.Change{}, fmt.Errorf("%s: %w", a.Path, err)
+	}
+	if _, _, err := applyNotebookEdit(nb, a); err != nil {
+		return diff.Change{}, err
+	}
+	out, err := nb.marshal()
+	if err != nil {
+		return diff.Change{}, err
+	}
+	return diff.Build(a.Path, string(data), string(out), diff.Modify), nil
+}
+
+func parseNotebookArgs(raw json.RawMessage) (notebookArgs, error) {
+	var a notebookArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return a, fmt.Errorf("invalid args: %w", err)
+	}
+	// Be forgiving about the source field: models reach for the write_file/edit_file
+	// vocabulary ("content"/"source"/"new_string"). Accept those as new_source when
+	// new_source itself wasn't given, so a near-miss call succeeds instead of looping.
+	if a.NewSource == "" {
+		var alias struct {
+			Content   string `json:"content"`
+			Source    string `json:"source"`
+			NewString string `json:"new_string"`
+		}
+		_ = json.Unmarshal(raw, &alias)
+		switch {
+		case alias.Content != "":
+			a.NewSource = alias.Content
+		case alias.Source != "":
+			a.NewSource = alias.Source
+		case alias.NewString != "":
+			a.NewSource = alias.NewString
+		}
+	}
+	if a.Path == "" {
+		return a, fmt.Errorf("path is required")
+	}
+	if a.EditMode == "" {
+		a.EditMode = "replace"
+	}
+	switch a.EditMode {
+	case "replace", "insert", "delete":
+	default:
+		return a, fmt.Errorf("edit_mode must be replace, insert, or delete (got %q)", a.EditMode)
+	}
+	return a, nil
+}
+
+// applyNotebookEdit mutates nb.cells per the args and returns the affected index
+// and a one-line summary. Cell targeting is by cell_id when set, else cell_number.
+func applyNotebookEdit(nb *notebook, a notebookArgs) (int, string, error) {
+	if a.EditMode == "insert" {
+		if a.CellType == "" {
+			return 0, "", fmt.Errorf("cell_type is required for insert")
+		}
+		after := -1
+		if a.CellNumber != nil {
+			after = *a.CellNumber
+		}
+		if after < -1 || after >= len(nb.cells) {
+			return 0, "", fmt.Errorf("cell_number %d out of range for insert (notebook has %d cells; use -1 to prepend)", after, len(nb.cells))
+		}
+		cell := newCell(a.CellType, a.NewSource)
+		at := after + 1 // insert after `after`; -1 → prepend at 0
+		nb.cells = append(nb.cells[:at], append([]map[string]json.RawMessage{cell}, nb.cells[at:]...)...)
+		return at, "inserted " + a.CellType + " cell", nil
+	}
+
+	idx, err := nb.targetIndex(a)
+	if err != nil {
+		return 0, "", err
+	}
+	if a.EditMode == "delete" {
+		nb.cells = append(nb.cells[:idx], nb.cells[idx+1:]...)
+		return idx, "deleted cell", nil
+	}
+	// replace
+	setCellSource(nb.cells[idx], a.NewSource)
+	if a.CellType != "" {
+		nb.cells[idx]["cell_type"] = jsonString(a.CellType)
+	}
+	clearCellOutputs(nb.cells[idx])
+	return idx, "replaced cell source", nil
+}
+
+// targetIndex resolves the cell to act on: cell_id wins when given, else
+// cell_number (which must be in range).
+func (nb *notebook) targetIndex(a notebookArgs) (int, error) {
+	if a.CellID != "" {
+		for i, c := range nb.cells {
+			if cellID(c) == a.CellID {
+				return i, nil
+			}
+		}
+		return 0, fmt.Errorf("no cell with id %q", a.CellID)
+	}
+	if a.CellNumber == nil {
+		// A one-cell notebook is unambiguous: default to cell 0 rather than forcing
+		// the caller to restate it. With more than one cell, require an explicit target.
+		if len(nb.cells) == 1 {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("cell_number or cell_id is required for %s (notebook has %d cells; pass the 0-based cell_number)", a.EditMode, len(nb.cells))
+	}
+	n := *a.CellNumber
+	if n < 0 || n >= len(nb.cells) {
+		return 0, fmt.Errorf("cell_number %d out of range (notebook has %d cells)", n, len(nb.cells))
+	}
+	return n, nil
+}
+
+// parseNotebook decodes just enough of the .ipynb to edit cells while preserving
+// every other key (top-level and per-cell) verbatim for re-serialisation.
+func parseNotebook(data []byte) (*notebook, error) {
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		return nil, fmt.Errorf("not valid notebook JSON: %w", err)
+	}
+	rawCells, ok := top["cells"]
+	if !ok {
+		return nil, fmt.Errorf("no \"cells\" array — not a notebook")
+	}
+	var cells []map[string]json.RawMessage
+	if err := json.Unmarshal(rawCells, &cells); err != nil {
+		return nil, fmt.Errorf("cells is not an array of objects: %w", err)
+	}
+	return &notebook{rest: top, cells: cells}, nil
+}
+
+// marshal re-serialises the notebook with the edited cells, pretty-printed with
+// the one-space indent Jupyter uses, and a trailing newline.
+func (nb *notebook) marshal() ([]byte, error) {
+	cellsJSON, err := json.Marshal(nb.cells)
+	if err != nil {
+		return nil, err
+	}
+	nb.rest["cells"] = cellsJSON
+	out, err := json.MarshalIndent(nb.rest, "", " ")
+	if err != nil {
+		return nil, err
+	}
+	return append(out, '\n'), nil
+}
+
+// newCell builds a fresh cell. Jupyter stores source as an array of lines (each
+// ending in \n except the last); outputs/execution_count exist only for code.
+func newCell(cellType, source string) map[string]json.RawMessage {
+	c := map[string]json.RawMessage{
+		"cell_type": jsonString(cellType),
+		"metadata":  json.RawMessage(`{}`),
+		"source":    sourceLines(source),
+	}
+	if cellType == "code" {
+		c["outputs"] = json.RawMessage(`[]`)
+		c["execution_count"] = json.RawMessage(`null`)
+	}
+	return c
+}
+
+func setCellSource(cell map[string]json.RawMessage, source string) {
+	cell["source"] = sourceLines(source)
+}
+
+// clearCellOutputs resets a code cell's outputs/execution_count after an edit, so
+// stale results don't linger; no-op for markdown cells.
+func clearCellOutputs(cell map[string]json.RawMessage) {
+	if _, ok := cell["outputs"]; ok {
+		cell["outputs"] = json.RawMessage(`[]`)
+	}
+	if _, ok := cell["execution_count"]; ok {
+		cell["execution_count"] = json.RawMessage(`null`)
+	}
+}
+
+func cellID(cell map[string]json.RawMessage) string {
+	raw, ok := cell["id"]
+	if !ok {
+		return ""
+	}
+	var id string
+	_ = json.Unmarshal(raw, &id)
+	return id
+}
+
+// sourceLines encodes a string as Jupyter's line-array source form: split on
+// newlines, keeping the \n on every line but the last (matching nbformat).
+func sourceLines(s string) json.RawMessage {
+	if s == "" {
+		return json.RawMessage(`[]`)
+	}
+	parts := strings.SplitAfter(s, "\n")
+	// SplitAfter leaves a trailing "" when s ends in \n; drop it.
+	if parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	b, _ := json.Marshal(parts)
+	return b
+}
+
+func jsonString(s string) json.RawMessage {
+	b, _ := json.Marshal(s)
+	return b
+}

--- a/internal/tool/builtin/notebookedit_test.go
+++ b/internal/tool/builtin/notebookedit_test.go
@@ -1,0 +1,231 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sampleNotebook is a minimal but realistic .ipynb: a markdown cell and a code
+// cell with an output + execution_count, plus top-level metadata/nbformat that
+// must survive a round-trip.
+const sampleNotebook = `{
+ "cells": [
+  {"cell_type": "markdown", "id": "intro", "metadata": {}, "source": ["# Title\n", "text"]},
+  {"cell_type": "code", "id": "c1", "metadata": {}, "execution_count": 5, "outputs": [{"output_type": "stream", "text": "old"}], "source": ["print(1)\n"]}
+ ],
+ "metadata": {"kernelspec": {"name": "python3"}},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}`
+
+func writeNotebook(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "nb.ipynb")
+	if err := os.WriteFile(p, []byte(sampleNotebook), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func runNotebookEdit(t *testing.T, path string, args map[string]any) (string, error) {
+	t.Helper()
+	args["path"] = path
+	raw, _ := json.Marshal(args)
+	return notebookEdit{}.Execute(context.Background(), raw)
+}
+
+func readCells(t *testing.T, path string) []map[string]json.RawMessage {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nb, err := parseNotebook(data)
+	if err != nil {
+		t.Fatalf("result is not valid notebook JSON: %v", err)
+	}
+	return nb.cells
+}
+
+func TestNotebookReplaceBySource(t *testing.T) {
+	p := writeNotebook(t)
+	if _, err := runNotebookEdit(t, p, map[string]any{"cell_number": 1, "new_source": "print(42)\n"}); err != nil {
+		t.Fatal(err)
+	}
+	cells := readCells(t, p)
+	if len(cells) != 2 {
+		t.Fatalf("replace changed cell count: %d", len(cells))
+	}
+	if got := string(cells[1]["source"]); !strings.Contains(got, "print(42)") {
+		t.Errorf("source not replaced: %s", got)
+	}
+	// Editing a code cell clears its outputs + execution_count.
+	if got := string(cells[1]["outputs"]); got != "[]" {
+		t.Errorf("outputs not cleared: %s", got)
+	}
+	if got := string(cells[1]["execution_count"]); got != "null" {
+		t.Errorf("execution_count not cleared: %s", got)
+	}
+}
+
+func TestNotebookReplaceByID(t *testing.T) {
+	p := writeNotebook(t)
+	if _, err := runNotebookEdit(t, p, map[string]any{"cell_id": "intro", "new_source": "# New"}); err != nil {
+		t.Fatal(err)
+	}
+	cells := readCells(t, p)
+	if got := string(cells[0]["source"]); !strings.Contains(got, "# New") {
+		t.Errorf("cell_id target not replaced: %s", got)
+	}
+}
+
+func TestNotebookInsertAfter(t *testing.T) {
+	p := writeNotebook(t)
+	if _, err := runNotebookEdit(t, p, map[string]any{"edit_mode": "insert", "cell_number": 0, "cell_type": "code", "new_source": "x = 1\n"}); err != nil {
+		t.Fatal(err)
+	}
+	cells := readCells(t, p)
+	if len(cells) != 3 {
+		t.Fatalf("insert should add a cell, got %d", len(cells))
+	}
+	if got := string(cells[1]["cell_type"]); got != `"code"` {
+		t.Errorf("inserted cell type wrong: %s", got)
+	}
+	if got := string(cells[1]["source"]); !strings.Contains(got, "x = 1") {
+		t.Errorf("inserted source wrong: %s", got)
+	}
+	// A code cell gets outputs/execution_count scaffolding.
+	if _, ok := cells[1]["outputs"]; !ok {
+		t.Error("inserted code cell missing outputs")
+	}
+}
+
+func TestNotebookInsertPrepend(t *testing.T) {
+	p := writeNotebook(t)
+	if _, err := runNotebookEdit(t, p, map[string]any{"edit_mode": "insert", "cell_number": -1, "cell_type": "markdown", "new_source": "top"}); err != nil {
+		t.Fatal(err)
+	}
+	cells := readCells(t, p)
+	if got := string(cells[0]["source"]); !strings.Contains(got, "top") {
+		t.Errorf("prepend should land at index 0: %s", got)
+	}
+}
+
+func TestNotebookDelete(t *testing.T) {
+	p := writeNotebook(t)
+	if _, err := runNotebookEdit(t, p, map[string]any{"edit_mode": "delete", "cell_number": 0}); err != nil {
+		t.Fatal(err)
+	}
+	cells := readCells(t, p)
+	if len(cells) != 1 {
+		t.Fatalf("delete should leave 1 cell, got %d", len(cells))
+	}
+	if got := cellID(cells[0]); got != "c1" {
+		t.Errorf("wrong cell deleted; remaining id = %q", got)
+	}
+}
+
+func TestNotebookPreservesTopLevelKeys(t *testing.T) {
+	p := writeNotebook(t)
+	if _, err := runNotebookEdit(t, p, map[string]any{"cell_number": 0, "new_source": "# x"}); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(p)
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatal(err)
+	}
+	for _, k := range []string{"metadata", "nbformat", "nbformat_minor"} {
+		if _, ok := top[k]; !ok {
+			t.Errorf("top-level key %q lost on round-trip", k)
+		}
+	}
+}
+
+func TestNotebookErrors(t *testing.T) {
+	p := writeNotebook(t)
+	if _, err := runNotebookEdit(t, p, map[string]any{"cell_number": 9, "new_source": "x"}); err == nil {
+		t.Error("out-of-range cell_number should error")
+	}
+	if _, err := runNotebookEdit(t, p, map[string]any{"cell_id": "nope", "edit_mode": "delete"}); err == nil {
+		t.Error("unknown cell_id should error")
+	}
+	if _, err := runNotebookEdit(t, p, map[string]any{"edit_mode": "insert", "cell_number": 0, "new_source": "x"}); err == nil {
+		t.Error("insert without cell_type should error")
+	}
+	if _, err := runNotebookEdit(t, p, map[string]any{"edit_mode": "bogus"}); err == nil {
+		t.Error("bad edit_mode should error")
+	}
+}
+
+// TestNotebookPreviewMatchesExecute checks the Previewer mirrors Execute: the
+// previewed NewText equals the file content Execute persists.
+func TestNotebookPreviewMatchesExecute(t *testing.T) {
+	p := writeNotebook(t)
+	args := map[string]any{"path": p, "cell_number": 1, "new_source": "print(99)\n"}
+	raw, _ := json.Marshal(args)
+
+	change, err := notebookEdit{}.Preview(raw)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if _, err := notebookEdit{}.Execute(context.Background(), raw); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	persisted, _ := os.ReadFile(p)
+	if change.NewText != string(persisted) {
+		t.Errorf("preview NewText != persisted content:\npreview:\n%s\npersisted:\n%s", change.NewText, persisted)
+	}
+}
+
+// TestNotebookContentAlias accepts the write_file-style "content" field as an
+// alias for new_source, and defaults to the only cell when no target is given —
+// the near-miss shape a model reaches for, which should succeed not loop.
+func TestNotebookContentAlias(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "one.ipynb")
+	one := `{"cells":[{"cell_type":"code","id":"a","metadata":{},"execution_count":null,"outputs":[],"source":["print('hi')\n"]}],"metadata":{},"nbformat":4,"nbformat_minor":5}`
+	if err := os.WriteFile(p, []byte(one), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// {content, path} with no cell_number — the exact shape that looped before.
+	if _, err := runNotebookEdit(t, p, map[string]any{"content": "print(\"world\")\n"}); err != nil {
+		t.Fatalf("content-alias single-cell replace should succeed, got: %v", err)
+	}
+	cells := readCells(t, p)
+	if got := string(cells[0]["source"]); !strings.Contains(got, `print(\"world\")`) {
+		t.Errorf("alias source not applied: %s", got)
+	}
+}
+
+// TestNotebookMissingTargetMultiCell still requires an explicit target when the
+// notebook is ambiguous (more than one cell), with an instructive message.
+func TestNotebookMissingTargetMultiCell(t *testing.T) {
+	p := writeNotebook(t) // 2 cells
+	_, err := runNotebookEdit(t, p, map[string]any{"new_source": "x"})
+	if err == nil {
+		t.Fatal("multi-cell replace with no target should error")
+	}
+	if !strings.Contains(err.Error(), "cell_number") {
+		t.Errorf("error should name cell_number: %v", err)
+	}
+}
+
+// TestNotebookSourceLines checks the nbformat line-array encoding: \n kept on
+// every line but the last.
+func TestNotebookSourceLines(t *testing.T) {
+	if got := string(sourceLines("a\nb\n")); got != `["a\n","b\n"]` {
+		t.Errorf("source line encoding = %s", got)
+	}
+	if got := string(sourceLines("solo")); got != `["solo"]` {
+		t.Errorf("single line = %s", got)
+	}
+	if got := string(sourceLines("")); got != `[]` {
+		t.Errorf("empty = %s", got)
+	}
+}


### PR DESCRIPTION
Adds a `notebook_edit` tool so the agent edits Jupyter notebooks structurally instead of hand-matching escaped JSON with `edit_file`.

## What
- Target a cell by 0-based `cell_number` (or `cell_id`); `edit_mode`:
  - **replace** (default) — swap the cell source; a code cell's `outputs`/`execution_count` are cleared.
  - **insert** — add a typed (`code`/`markdown`) cell after `cell_number` (`-1` prepends).
  - **delete** — remove the cell.
- Re-serialises the whole notebook, preserving unrelated cells, outputs, and top-level keys (`metadata`, `nbformat`, …). Source uses nbformat's line-array form.
- Writer tool: joins `ConfineWriters` (sandbox-confined like the other writers) and is a `Previewer` (mirrors Execute) so checkpoints snapshot the notebook for rewind.
- **Ergonomics from a live run:** the model reached for the `write_file` vocabulary (`content`) and looped against a strict schema, so the tool now accepts `content`/`source`/`new_string` as aliases for `new_source` and defaults to cell 0 on a single-cell notebook. A multi-cell notebook still requires an explicit target (with an instructive error).

## Verification
- Unit tests (11): replace by number/id, insert after/prepend, delete, top-level key preservation, error cases, preview==execute, content alias + single-cell default, multi-cell target required, line-array encoder.
- Full `go test ./...` (30 pkgs) + desktop build green; gofmt clean.
- Live (DeepSeek): the agent replaces a code cell with `print("world")` and inserts a `# Done` markdown cell **via notebook_edit** (confirmed in the dispatch trace, not write_file), producing a valid 2-cell notebook.