### PR TITLE
fix(tool): repair notebook_edit test compile error

### DIFF
--- a/internal/tool/builtin/notebookedit_test.go
+++ b/internal/tool/builtin/notebookedit_test.go
@@ -174,7 +174,7 @@ func TestNotebookPreviewMatchesExecute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("preview: %v", err)
 	}
-	if _, err := notebookEdit{}.Execute(context.Background(), raw); err != nil {
+	if _, err := (notebookEdit{}).Execute(context.Background(), raw); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 	persisted, _ := os.ReadFile(p)


### PR DESCRIPTION
`notebookedit_test.go:177` used a composite literal directly in an `if` init clause (`if _, err := notebookEdit{}.Execute(...)`), which Go's parser rejects ("expected boolean expression") — the `{` is ambiguous with the if-block. Parenthesised as `(notebookEdit{}).Execute(...)`.

This broke the `internal/tool/builtin` test binary and slipped through #2491's merge, leaving main-v2's `go test ./...` red. With the fix, all 11 notebook_edit tests pass and `go test ./...` is green (29 pkgs). One-line, test-only.