### PR TITLE
feat(tool): add slash_command for model-invoked slash commands

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -284,6 +284,30 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// file is skipped, and a load error never blocks the session.
 	cmds, _ := command.Load(config.CommandDirs()...)
 
+	// Expose the loaded slash commands (skills + custom commands) to the model via
+	// the slash_command tool, so it can invoke a project playbook by name the way a
+	// user types "/name". Skills are added first, then commands, so a command wins
+	// a name clash — matching the prompt's command-over-skill precedence.
+	var slashEntries []command.SlashEntry
+	for _, sk := range skills {
+		sk := sk
+		slashEntries = append(slashEntries, command.SlashEntry{
+			Name:        sk.Name,
+			Description: sk.Description,
+			Render:      func(args []string) string { return skill.Render(sk, strings.Join(args, " ")) },
+		})
+	}
+	for _, cmd := range cmds {
+		cmd := cmd
+		slashEntries = append(slashEntries, command.SlashEntry{
+			Name:        cmd.Name,
+			Description: cmd.Description,
+			ArgHint:     cmd.ArgHint,
+			Render:      func(args []string) string { return cmd.Render(args) },
+		})
+	}
+	reg.Add(command.NewSlashCommandTool(slashEntries))
+
 	var runner agent.Runner = executor
 	label := entry.Model
 

--- a/internal/command/slashtool.go
+++ b/internal/command/slashtool.go
@@ -1,0 +1,133 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"reasonix/internal/tool"
+)
+
+// SlashEntry is one invocable slash command exposed to the model through the
+// slash_command tool. It is a uniform view over the two kinds the user can also
+// type at the prompt — custom commands and skills — so the tool need not know
+// which is which. Render turns positional args into the prompt text the command
+// expands to (the same text typing "/name args" would send).
+type SlashEntry struct {
+	Name        string // without the leading slash, e.g. "review" or "git:commit"
+	Description string
+	ArgHint     string                     // optional argument hint, for the listing
+	Render      func(args []string) string // expands the template/playbook with args
+}
+
+// slashCommandTool lets the model invoke a loaded slash command by name. Unlike a
+// tool that performs an action and returns a result, a slash command is a *prompt
+// template*: the tool returns the expanded prompt text, which the model then reads
+// and acts on within the same turn — mirroring what typing "/name" does for a
+// human. Calling with no name (or "list") returns the available commands.
+type slashCommandTool struct {
+	entries map[string]SlashEntry
+	names   []string // sorted, for a stable listing
+}
+
+// NewSlashCommandTool builds the tool from the invocable entries (custom commands
+// + skills, adapted by the caller). A later entry wins on a name clash, matching
+// the prompt's command>skill precedence when the caller orders them that way.
+func NewSlashCommandTool(entries []SlashEntry) tool.Tool {
+	m := make(map[string]SlashEntry, len(entries))
+	for _, e := range entries {
+		name := strings.TrimPrefix(strings.TrimSpace(e.Name), "/")
+		if name == "" {
+			continue
+		}
+		e.Name = name
+		m[name] = e
+	}
+	names := make([]string, 0, len(m))
+	for n := range m {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return &slashCommandTool{entries: m, names: names}
+}
+
+func (*slashCommandTool) Name() string { return "slash_command" }
+
+func (*slashCommandTool) ReadOnly() bool { return true }
+
+func (t *slashCommandTool) Description() string {
+	var b strings.Builder
+	b.WriteString("Invoke a project slash command (a reusable prompt template or skill) by name. " +
+		"Returns the command's expanded prompt text for you to act on in this turn — it does not run on its own. " +
+		"Call with an empty command (or \"list\") to see what's available. ")
+	if len(t.names) == 0 {
+		b.WriteString("No slash commands are configured in this project.")
+		return b.String()
+	}
+	b.WriteString("Available: ")
+	for i, n := range t.names {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(n)
+	}
+	b.WriteString(".")
+	return b.String()
+}
+
+func (*slashCommandTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"command": {"type": "string", "description": "Slash command name (with or without a leading slash). Empty or \"list\" returns the available commands."},
+			"arguments": {"type": "string", "description": "Arguments passed to the command, as you'd type them after the name (space-separated)."}
+		}
+	}`)
+}
+
+func (t *slashCommandTool) Execute(_ context.Context, raw json.RawMessage) (string, error) {
+	var p struct {
+		Command   string `json:"command"`
+		Arguments string `json:"arguments"`
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return "", fmt.Errorf("invalid args: %w", err)
+		}
+	}
+	name := strings.TrimPrefix(strings.TrimSpace(p.Command), "/")
+	if name == "" || strings.EqualFold(name, "list") {
+		return t.list(), nil
+	}
+	e, ok := t.entries[name]
+	if !ok {
+		return "", fmt.Errorf("no slash command %q; available: %s", name, strings.Join(t.names, ", "))
+	}
+	args := strings.Fields(p.Arguments)
+	expanded := e.Render(args)
+	// Frame the expansion so the model treats it as an instruction to follow now,
+	// not as data to echo back.
+	return fmt.Sprintf("Expanded /%s — follow these instructions now:\n\n%s", name, expanded), nil
+}
+
+func (t *slashCommandTool) list() string {
+	if len(t.names) == 0 {
+		return "No slash commands are configured in this project."
+	}
+	var b strings.Builder
+	b.WriteString("Available slash commands:\n")
+	for _, n := range t.names {
+		e := t.entries[n]
+		line := "- /" + n
+		if e.ArgHint != "" {
+			line += " " + e.ArgHint
+		}
+		if e.Description != "" {
+			line += " — " + e.Description
+		}
+		b.WriteString(line + "\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/command/slashtool_test.go
+++ b/internal/command/slashtool_test.go
@@ -1,0 +1,128 @@
+package command
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func runSlash(t *testing.T, tl interface {
+	Execute(context.Context, json.RawMessage) (string, error)
+}, args map[string]any) (string, error) {
+	t.Helper()
+	raw, _ := json.Marshal(args)
+	return tl.Execute(context.Background(), raw)
+}
+
+func sampleTool() interface {
+	Execute(context.Context, json.RawMessage) (string, error)
+	Name() string
+	ReadOnly() bool
+	Description() string
+} {
+	return NewSlashCommandTool([]SlashEntry{
+		{Name: "review", Description: "review the diff", ArgHint: "[path]",
+			Render: func(a []string) string { return "REVIEW " + strings.Join(a, ",") }},
+		// Leading slash on Name should be tolerated.
+		{Name: "/git:commit", Description: "commit",
+			Render: func(a []string) string { return "COMMIT" }},
+	}).(interface {
+		Execute(context.Context, json.RawMessage) (string, error)
+		Name() string
+		ReadOnly() bool
+		Description() string
+	})
+}
+
+func TestSlashToolBasics(t *testing.T) {
+	tl := sampleTool()
+	if tl.Name() != "slash_command" {
+		t.Errorf("name = %q", tl.Name())
+	}
+	if !tl.ReadOnly() {
+		t.Error("slash_command should be read-only")
+	}
+	if !strings.Contains(tl.Description(), "review") || !strings.Contains(tl.Description(), "git:commit") {
+		t.Errorf("description should list available commands: %q", tl.Description())
+	}
+}
+
+func TestSlashToolExpandsWithArgs(t *testing.T) {
+	tl := sampleTool()
+	out, err := runSlash(t, tl, map[string]any{"command": "review", "arguments": "a b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "REVIEW a,b") {
+		t.Errorf("args not passed to Render: %q", out)
+	}
+	if !strings.Contains(out, "follow these instructions now") {
+		t.Errorf("expansion should be framed as an instruction: %q", out)
+	}
+}
+
+func TestSlashToolLeadingSlashAndName(t *testing.T) {
+	tl := sampleTool()
+	// Caller passes a leading slash; entry was also registered with one.
+	out, err := runSlash(t, tl, map[string]any{"command": "/git:commit"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "COMMIT") {
+		t.Errorf("leading-slash command not resolved: %q", out)
+	}
+}
+
+func TestSlashToolList(t *testing.T) {
+	tl := sampleTool()
+	for _, cmd := range []string{"", "list", "LIST"} {
+		out, err := runSlash(t, tl, map[string]any{"command": cmd})
+		if err != nil {
+			t.Fatalf("list(%q): %v", cmd, err)
+		}
+		if !strings.Contains(out, "/review") || !strings.Contains(out, "[path]") || !strings.Contains(out, "/git:commit") {
+			t.Errorf("list(%q) missing entries: %q", cmd, out)
+		}
+	}
+}
+
+func TestSlashToolUnknown(t *testing.T) {
+	tl := sampleTool()
+	_, err := runSlash(t, tl, map[string]any{"command": "nope"})
+	if err == nil {
+		t.Fatal("unknown command should error")
+	}
+	if !strings.Contains(err.Error(), "review") {
+		t.Errorf("error should list available commands: %v", err)
+	}
+}
+
+func TestSlashToolEmptyRegistry(t *testing.T) {
+	tl := NewSlashCommandTool(nil)
+	out, err := tl.Execute(context.Background(), json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "No slash commands") {
+		t.Errorf("empty list = %q", out)
+	}
+	if !strings.Contains(tl.Description(), "No slash commands") {
+		t.Errorf("empty description = %q", tl.Description())
+	}
+}
+
+func TestSlashToolNameClashCommandWins(t *testing.T) {
+	// Skills added first, command second — command should win the name.
+	tl := NewSlashCommandTool([]SlashEntry{
+		{Name: "dup", Render: func([]string) string { return "FROM-SKILL" }},
+		{Name: "dup", Render: func([]string) string { return "FROM-COMMAND" }},
+	})
+	out, err := tl.Execute(context.Background(), json.RawMessage(`{"command":"dup"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "FROM-COMMAND") {
+		t.Errorf("later entry should win the clash: %q", out)
+	}
+}


### PR DESCRIPTION
Lets the model invoke a project slash command (a custom command or a skill) by name — the way a user types `/name`.

## What
- A slash command is a *prompt template*, so `slash_command` returns the **expanded prompt text** for the model to act on in the same turn; it does not run anything on its own. Empty/`list` command returns the available commands.
- `internal/command`: the tool over a uniform `SlashEntry` view (Name, Description, ArgHint, Render). Read-only; tolerates a leading slash; later entry wins a name clash. `command` does not import `skill` (no import cycle).
- `boot`: adapts loaded **skills then custom commands** into `SlashEntry` (commands win clashes, matching prompt precedence) and registers the tool after the command load.

## Verification
- Unit tests (7): expand-with-args, leading-slash resolution, list (empty/`list`/`LIST`), unknown-command error, empty registry, name-clash precedence, basics.
- Full `go test ./...` green (29 pkgs); gofmt clean; build clean.