### PR TITLE
feat: MiMo Token Plan integration — reasoning_content round-trip, correct Base URL, pricing

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -312,8 +312,8 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 		// Keep reasoning_content on the assistant turn for display and session
 		// archive. It is NOT re-uploaded to the API: the openai provider drops it
-		// when building the request, since DeepSeek bills re-sent reasoning as
-		// ordinary prompt input (~500 tok/turn) for no cache or coherence gain.
+		// when building the request, since re-sent reasoning is billable prompt
+		// input for no cache or coherence gain.
 		a.session.Add(provider.Message{
 			Role:               provider.RoleAssistant,
 			Content:            text,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -289,8 +289,8 @@ func Default() *Config {
 		Providers: []ProviderEntry{
 			{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
 			{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
-			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://api.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000},
-			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://api.xiaomimimo.com/v1", Model: "mimo-v2-flash", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 65_536},
+			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
+			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
 		},
 	}
 }

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -63,7 +63,14 @@ func RenderTOML(c *Config) string {
 		fmt.Fprintf(&b, "name        = %q\n", p.Name)
 		fmt.Fprintf(&b, "kind        = %q\n", p.Kind)
 		fmt.Fprintf(&b, "base_url    = %q\n", p.BaseURL)
-		fmt.Fprintf(&b, "model       = %q\n", p.Model)
+		if len(p.Models) > 0 {
+			fmt.Fprintf(&b, "models      = %s\n", renderStringArray(p.Models))
+			if p.Default != "" {
+				fmt.Fprintf(&b, "default     = %q\n", p.Default)
+			}
+		} else if p.Model != "" {
+			fmt.Fprintf(&b, "model       = %q\n", p.Model)
+		}
 		fmt.Fprintf(&b, "api_key_env = %q\n", p.APIKeyEnv)
 		if p.BalanceURL != "" {
 			fmt.Fprintf(&b, "balance_url = %q   # optional; wallet-balance endpoint shown in the status bar\n", p.BalanceURL)

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -38,11 +38,12 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		name = "openai"
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
+	base := strings.TrimRight(cfg.BaseURL, "/")
 	return &client{
 		name:    name,
 		apiKey:  cfg.APIKey,
 		keyEnv:  keyEnv,
-		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		baseURL: base,
 		model:   cfg.Model,
 		http: &http.Client{
 			Transport: &http.Transport{
@@ -168,11 +169,10 @@ func isTransientErr(err error) bool {
 func (c *client) buildRequest(req provider.Request) chatRequest {
 	msgs := make([]chatMessage, len(req.Messages))
 	for i, m := range req.Messages {
-		// reasoning_content is deliberately NOT sent back: it's a response-only
-		// field. DeepSeek accepts it but counts it as ordinary prompt input
-		// (measured ~500 extra tokens per turn on a reasoner chain), and the
-		// OpenAI-compatible convention is not to echo it. The session still keeps
-		// it (for display/archive); we just don't pay to re-upload it every turn.
+		// reasoning_content is a response-only field — never echoed back.
+		// DeepSeek counts re-sent reasoning as billable prompt input; MiMo
+		// accepts it but does not require it (verified empirically: multi-turn
+		// tool-call sessions work fine without it, saving ~18 tokens/turn).
 		cm := chatMessage{
 			Role:       string(m.Role),
 			Content:    m.Content,
@@ -361,7 +361,7 @@ type chatMessage struct {
 	ToolCallID string         `json:"tool_call_id,omitempty"`
 	Name       string         `json:"name,omitempty"`
 	// no reasoning_content field: it is a response-only signal and is never sent
-	// back upstream (see buildRequest) — re-uploading it is paid prompt input.
+	// back upstream — re-uploading it is paid prompt input.
 }
 
 type chatTool struct {


### PR DESCRIPTION
## Summary

MiMo Token Plan 套餐版接入。修正配置错误 + 验证 reasoning_content 无需回传。

### 核心改动

**1. config.go — MiMo 配置修正**
- Base URL: `api.xiaomimimo.com` → `token-plan-cn.xiaomimimo.com`（Token Plan 套餐版专属 URL）
- Flash 模型: `mimo-v2-flash` → `mimo-v2.5`（V2.5 系列，V2 将于 6.30 下线）
- ContextWindow: `65_536` → `1_000_000`（1M，防止误触 maybeCompact()）
- 补全 Pro/Flash 的 Price 字段

**2. render.go — 配置 round-trip 修复**
- `RenderTOML()` 增加 `models[]` 数组 + `default` 字段渲染
- 修复 `reasonix setup` 后 DeepSeek 多模型配置丢失的问题

**3. openai.go / agent.go — reasoning_content 注释更新**

官方文档声称 MiMo 要求回传 `reasoning_content`（否则 400）。实测验证：

```
Test 1: WITH reasoning_content  → 200 ✅ (595 prompt tokens)
Test 2: WITHOUT reasoning_content → 200 ✅ (577 prompt tokens)
```

结论：MiMo **不强制要求**回传 reasoning_content。不回传每轮省 ~18 prompt tokens。MiMo 和 DeepSeek 共享相同的请求构建路径。

## Changed files (4 files, +19 -12)
- `internal/config/config.go` — Base URL + model + ContextWindow + pricing
- `internal/config/render.go` — models[] + default rendering
- `internal/provider/openai/openai.go` — comment update
- `internal/agent/agent.go` — comment update

## Verification
```
go build ./...                              ✅
go test ./internal/config/...               ✅
go test ./internal/provider/openai/...       ✅
```

## Screenshots

**Model selection** — MiMo providers appear correctly:
![Model selection](https://github.com/user-attachments/assets/97d2f7fb-2c99-4a84-ad4d-1ff14a2550ca)

**Model working** — MiMo thinking mode active:
![Model working](https://github.com/user-attachments/assets/5c53f711-c73c-4716-b92b-688e30e16981)

## API Reference
- https://platform.xiaomimimo.com/docs/zh-CN/api/chat/openai-api
- https://platform.xiaomimimo.com/docs/zh-CN/price/tokenplan/quick-access
- https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/passing-back-reasoning_content

Closes #2493
