### PR TITLE
feat(tui): require double Ctrl+C to quit, preventing accidental exits (#2358)

### DIFF
--- a/src/cli/ui/App.tsx
+++ b/src/cli/ui/App.tsx
@@ -1691,6 +1691,7 @@ function AppInner({
 
   // Esc handles "abort the current turn" separately; Ctrl+C is the universal "I'm done" key.
   const quitProcess = useQuit(transcriptRef);
+  const quitArmedAt = useRef<number | null>(null);
 
   // Ctrl+D = standard TUI exit (matches the boot-banner hint). Always-on
   // — no modal / picker should swallow it.
@@ -1785,7 +1786,7 @@ function AppInner({
       return;
     }
     if (key.ctrl && key.input === "c") {
-      handleTurnInterrupt("ctrl-c", {
+      const outcome = handleTurnInterrupt("ctrl-c", {
         turnActiveRef: submittingRef,
         abortedThisTurn,
         resetPendingModals,
@@ -1793,7 +1794,9 @@ function AppInner({
         stopLoop,
         loop,
         quitProcess,
+        quitArmedAt,
       });
+      if (outcome === "quit-armed") log.pushInfo(t("app.quitArmed"));
       return;
     }
     if (key.ctrl && key.input === "p" && !busy && (!modalOpen || pendingShortcuts)) {
@@ -1821,6 +1824,7 @@ function AppInner({
         stopLoop,
         loop,
         quitProcess,
+        quitArmedAt,
       });
       return;
     }

--- a/src/cli/ui/turn-interrupt.ts
+++ b/src/cli/ui/turn-interrupt.ts
@@ -1,5 +1,14 @@
 export type TurnInterruptKey = "escape" | "ctrl-c";
-export type TurnInterruptOutcome = "aborted" | "already-aborted" | "stopped-loop" | "idle" | "quit";
+export type TurnInterruptOutcome =
+  | "aborted"
+  | "already-aborted"
+  | "stopped-loop"
+  | "idle"
+  | "quit"
+  | "quit-armed";
+
+/** ms window in which a second Ctrl+C confirms the exit intent. */
+export const QUIT_ARM_WINDOW_MS = 1500;
 
 export interface TurnInterruptController {
   turnActiveRef: { readonly current: boolean };
@@ -9,6 +18,8 @@ export interface TurnInterruptController {
   stopLoop: () => void;
   loop: { abort: () => void };
   quitProcess: () => void;
+  /** Tracks when the quit intent was first armed; null = not armed. */
+  quitArmedAt: { current: number | null };
 }
 
 export function handleTurnInterrupt(
@@ -21,6 +32,7 @@ export function handleTurnInterrupt(
     stopLoop,
     loop,
     quitProcess,
+    quitArmedAt,
   }: TurnInterruptController,
 ): TurnInterruptOutcome {
   if (turnActiveRef.current) {
@@ -38,8 +50,13 @@ export function handleTurnInterrupt(
   }
 
   if (key === "ctrl-c") {
-    quitProcess();
-    return "quit";
+    const now = Date.now();
+    if (quitArmedAt.current !== null && now - quitArmedAt.current <= QUIT_ARM_WINDOW_MS) {
+      quitProcess();
+      return "quit";
+    }
+    quitArmedAt.current = now;
+    return "quit-armed";
   }
 
   return "idle";

--- a/src/i18n/EN.ts
+++ b/src/i18n/EN.ts
@@ -674,6 +674,7 @@ export const EN: TranslationSchema = {
     startingBackground: "▸ starting (background): {cmd}",
     checkpointSaved:
       "⛁ checkpoint saved · {id} · {count} file{s} · /restore {id} to roll back this step",
+    quitArmed: "Press Ctrl+C again to exit.",
     continuingAfter: "▸ continuing after {label}{counter}",
     planStoppedAt: "▸ plan stopped at {label}{counter}",
     revisingAfter: "▸ revising after {label} — {feedback}",

--- a/src/i18n/JA.ts
+++ b/src/i18n/JA.ts
@@ -764,6 +764,7 @@ export const JA: TranslationSchema = {
     startingBackground: "▸ 起動中（バックグラウンド）: {cmd}",
     checkpointSaved:
       "⛁ チェックポイント保存 · {id} · {count} ファイル · /restore {id} でこのステップをロールバック",
+    quitArmed: "もう一度 Ctrl+C で終了します。",
     continuingAfter: "▸ {label}{counter} の後に続行",
     planStoppedAt: "▸ {label}{counter} でプランを停止",
     revisingAfter: "▸ {label} の後に修正 — {feedback}",

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -666,6 +666,7 @@ export const de: TranslationSchema = {
     startingBackground: "▸ starte (Hintergrund): {cmd}",
     checkpointSaved:
       "⛁ Checkpoint gespeichert · {id} · {count} Datei(en) · /restore {id} zum Zurücksetzen",
+    quitArmed: "Erneut Ctrl+C drücken zum Beenden.",
     continuingAfter: "▸ fortgesetzt nach {label}{counter}",
     planStoppedAt: "▸ Plan angehalten bei {label}{counter}",
     revisingAfter: "▸ überarbeite nach {label} — {feedback}",

--- a/src/i18n/types.ts
+++ b/src/i18n/types.ts
@@ -226,6 +226,7 @@ export interface TranslationSchema {
     runningCommand: string;
     startingBackground: string;
     checkpointSaved: string;
+    quitArmed: string;
     continuingAfter: string;
     planStoppedAt: string;
     revisingAfter: string;

--- a/src/i18n/zh-CN.ts
+++ b/src/i18n/zh-CN.ts
@@ -650,6 +650,7 @@ export const zhCN: TranslationSchema = {
     runningCommand: "▸ 正在执行：{cmd}",
     startingBackground: "▸ 后台启动：{cmd}",
     checkpointSaved: "⛁ 已保存检查点 · {id} · {count} 个文件 · /restore {id} 可回滚此步",
+    quitArmed: "再按一次 Ctrl+C 即可退出。",
     continuingAfter: "▸ 在 {label}{counter} 之后继续",
     planStoppedAt: "▸ 计划在 {label}{counter} 处停止",
     revisingAfter: "▸ 在 {label} 之后修订 — {feedback}",

--- a/tests/turn-interrupt.test.ts
+++ b/tests/turn-interrupt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleTurnInterrupt } from "../src/cli/ui/turn-interrupt.js";
+import { QUIT_ARM_WINDOW_MS, handleTurnInterrupt } from "../src/cli/ui/turn-interrupt.js";
 
 describe("handleTurnInterrupt", () => {
   it("aborts an active Ctrl+C turn without quitting the process", () => {
@@ -15,6 +15,7 @@ describe("handleTurnInterrupt", () => {
       stopLoop,
       loop: { abort },
       quitProcess,
+      quitArmedAt: { current: null as number | null },
     };
 
     expect(handleTurnInterrupt("ctrl-c", controller)).toBe("aborted");
@@ -25,25 +26,51 @@ describe("handleTurnInterrupt", () => {
     expect(quitProcess).not.toHaveBeenCalled();
   });
 
-  it("quits on Ctrl+C when no model turn is active", () => {
-    const resetPendingModals = vi.fn();
-    const abort = vi.fn();
+  it("arms quit on first idle Ctrl+C and exits on second within the window", () => {
     const quitProcess = vi.fn();
-
-    const outcome = handleTurnInterrupt("ctrl-c", {
+    const quitArmedAt = { current: null as number | null };
+    const base = {
       turnActiveRef: { current: false },
       abortedThisTurn: { current: false },
-      resetPendingModals,
-      isLoopActive: () => true,
+      resetPendingModals: vi.fn(),
+      isLoopActive: () => false,
       stopLoop: vi.fn(),
-      loop: { abort },
+      loop: { abort: vi.fn() },
       quitProcess,
-    });
+      quitArmedAt,
+    };
 
-    expect(outcome).toBe("quit");
+    // First press — arms, does NOT quit
+    expect(handleTurnInterrupt("ctrl-c", base)).toBe("quit-armed");
+    expect(quitProcess).not.toHaveBeenCalled();
+    expect(quitArmedAt.current).not.toBeNull();
+
+    // Second press within window — quits
+    expect(handleTurnInterrupt("ctrl-c", base)).toBe("quit");
     expect(quitProcess).toHaveBeenCalledTimes(1);
-    expect(resetPendingModals).not.toHaveBeenCalled();
-    expect(abort).not.toHaveBeenCalled();
+  });
+
+  it("re-arms if second Ctrl+C arrives after the window expires", () => {
+    const quitProcess = vi.fn();
+    const quitArmedAt = { current: null as number | null };
+    const base = {
+      turnActiveRef: { current: false },
+      abortedThisTurn: { current: false },
+      resetPendingModals: vi.fn(),
+      isLoopActive: () => false,
+      stopLoop: vi.fn(),
+      loop: { abort: vi.fn() },
+      quitProcess,
+      quitArmedAt,
+    };
+
+    handleTurnInterrupt("ctrl-c", base);
+    // Expire the window by backdating armedAt
+    quitArmedAt.current = Date.now() - QUIT_ARM_WINDOW_MS - 1;
+
+    // Second press after expiry → re-arms, does not quit
+    expect(handleTurnInterrupt("ctrl-c", base)).toBe("quit-armed");
+    expect(quitProcess).not.toHaveBeenCalled();
   });
 
   it("stops an idle auto-loop on Esc without aborting the next turn", () => {
@@ -60,6 +87,7 @@ describe("handleTurnInterrupt", () => {
       stopLoop,
       loop: { abort },
       quitProcess,
+      quitArmedAt: { current: null },
     });
 
     expect(outcome).toBe("stopped-loop");
@@ -82,6 +110,7 @@ describe("handleTurnInterrupt", () => {
       stopLoop: vi.fn(),
       loop: { abort },
       quitProcess,
+      quitArmedAt: { current: null },
     });
 
     expect(outcome).toBe("idle");


### PR DESCRIPTION
## Summary

- Single idle Ctrl+C no longer exits immediately — it arms a quit intent and prints a localized hint
- A second Ctrl+C within 1.5s confirms and calls quitProcess(); a press outside the window re-arms
- Ctrl+C during an active model turn continues to abort the turn as before (unchanged)

## Changes

- turn-interrupt.ts — add quit-armed outcome, QUIT_ARM_WINDOW_MS=1500, quitArmedAt ref in controller
- turn-interrupt.test.ts — updated existing test + 2 new cases (arm→confirm, arm→expire→rearm)
- App.tsx — pass quitArmedAt ref; show hint on quit-armed outcome
- i18n types/EN/zh-CN/JA/de — add app.quitArmed in all four locales

## Testing

5 turn-interrupt tests pass. Full suite (4042+ tests) passes locally.

Closes #2358