### PR TITLE
test(builtin): make resolveIn absolute-path test cross-platform

### DIFF
--- a/internal/tool/builtin/write_tool_test.go
+++ b/internal/tool/builtin/write_tool_test.go
@@ -270,9 +270,10 @@ func TestConfineEmptyRootsAllowsAll(t *testing.T) {
 // --- resolveIn tests ---
 
 func TestResolveInAbsolute(t *testing.T) {
-	got := resolveIn("/workdir", "/absolute/path")
-	if got != "/absolute/path" {
-		t.Errorf("resolveIn absolute = %q", got)
+	abs := filepath.Join(t.TempDir(), "absolute", "path")
+	got := resolveIn("/workdir", abs)
+	if got != abs {
+		t.Errorf("resolveIn absolute = %q, want %q", got, abs)
 	}
 }
 


### PR DESCRIPTION
`TestResolveInAbsolute` hard-coded a Unix absolute path (`/absolute/path`). On Windows that string isn't absolute (`filepath.IsAbs` wants a drive letter), so `resolveIn` joined it onto the workDir and the test failed for anyone running the suite locally on Windows.

Switched to a real absolute path from `t.TempDir()`, matching the cross-platform approach already used elsewhere in the builtin tests. No production code changed; CI (Linux/macOS) is unaffected.

This closes a gap left over from the earlier Windows test-portability pass, which only covered `workspace_test.go`.