### PR TITLE
Keep MCP startup resilient to server failures

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -172,13 +172,25 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				specs[i].Stderr = opts.Stderr
 			}
 		}
-		host, ptools, err := plugin.StartAll(ctx, specs)
-		if err != nil {
-			return nil, fmt.Errorf("plugin: %w", err)
-		}
+		host, ptools := plugin.StartAvailable(ctx, specs)
 		pluginHost = host
 		for _, t := range ptools {
 			reg.Add(t)
+		}
+		if failures := host.Failures(); len(failures) > 0 {
+			names := make([]string, 0, min(len(failures), 3))
+			for i, f := range failures {
+				if i >= 3 {
+					break
+				}
+				names = append(names, f.Name)
+			}
+			more := ""
+			if len(failures) > len(names) {
+				more = fmt.Sprintf(" (+%d more)", len(failures)-len(names))
+			}
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+				Text: fmt.Sprintf("%d MCP server(s) failed to start: %s%s — run /mcp for details", len(failures), strings.Join(names, ", "), more)})
 		}
 	}
 	cleanup := pluginHost.Close

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -177,20 +177,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		for _, t := range ptools {
 			reg.Add(t)
 		}
-		if failures := host.Failures(); len(failures) > 0 {
-			names := make([]string, 0, min(len(failures), 3))
-			for i, f := range failures {
-				if i >= 3 {
-					break
-				}
-				names = append(names, f.Name)
-			}
-			more := ""
-			if len(failures) > len(names) {
-				more = fmt.Sprintf(" (+%d more)", len(failures)-len(names))
-			}
-			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
-				Text: fmt.Sprintf("%d MCP server(s) failed to start: %s%s — run /mcp for details", len(failures), strings.Join(names, ", "), more)})
+		if text, ok := MCPStartupNotice(host.Failures()); ok {
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}
 	}
 	cleanup := pluginHost.Close
@@ -475,6 +463,27 @@ func PluginSpecs(entries []config.PluginEntry) []plugin.Spec {
 		}
 	}
 	return specs
+}
+
+// MCPStartupNotice formats the warning shown when configured MCP servers failed
+// to connect, naming the first few; ok is false when none failed.
+func MCPStartupNotice(failures []plugin.Failure) (text string, ok bool) {
+	if len(failures) == 0 {
+		return "", false
+	}
+	names := make([]string, 0, min(len(failures), 3))
+	for i, f := range failures {
+		if i >= 3 {
+			break
+		}
+		names = append(names, f.Name)
+	}
+	more := ""
+	if len(failures) > len(names) {
+		more = fmt.Sprintf(" (+%d more)", len(failures)-len(names))
+	}
+	return fmt.Sprintf("%d MCP server(s) failed to start: %s%s — run /mcp for details",
+		len(failures), strings.Join(names, ", "), more), true
 }
 
 func providerNames(cfg *config.Config) string {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"reasonix/internal/config"
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 
 	// Blank imports register the provider kind and built-in tools the same way
@@ -109,6 +110,54 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 	if !strings.Contains(sys, "projskill") || !strings.Contains(sys, "explore") {
 		t.Fatalf("skill names missing from index:\n%s", sys)
+	}
+}
+
+func TestBuildRecordsMCPStartupFailure(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+
+[[plugins]]
+name = "missing"
+command = "reasonix-missing-mcp-binary"
+`)
+	var notices []event.Event
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build should not fail when an MCP server is unavailable: %v", err)
+	}
+	defer ctrl.Close()
+	failures := ctrl.Host().Failures()
+	if len(failures) != 1 || failures[0].Name != "missing" {
+		t.Fatalf("failures = %+v, want missing", failures)
+	}
+	foundNotice := false
+	for _, n := range notices {
+		if strings.Contains(n.Text, "failed to start") {
+			foundNotice = true
+			break
+		}
+	}
+	if !foundNotice {
+		t.Fatalf("missing startup warning notice: %+v", notices)
 	}
 }
 

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/command"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/event"
 	"reasonix/internal/i18n"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
@@ -115,14 +116,14 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 	var host *plugin.Host
 	specs := append(boot.PluginSpecs(cfg.Plugins), p.MCPServers...)
 	if len(specs) > 0 {
-		h, ptools, err := plugin.StartAll(ctx, specs)
-		if err != nil {
-			return nil, fmt.Errorf("plugin: %w", err)
-		}
+		h, ptools := plugin.StartAvailable(ctx, specs)
 		host = h
 		cleanup = h.Close
 		for _, t := range ptools {
 			reg.Add(t)
+		}
+		if text, ok := boot.MCPStartupNotice(h.Failures()); ok {
+			p.Sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}
 	}
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1579,7 +1579,7 @@ func (m *chatTUI) runMCPSubcommand(input string) {
 // showMCPStatus queues the connected MCP servers, their counts, and the prompt
 // commands / resource refs they expose — the discovery surface for /mcp.
 func (m *chatTUI) showMCPStatus() {
-	if m.host == nil || len(m.host.Servers()) == 0 {
+	if m.host == nil || (len(m.host.Servers()) == 0 && len(m.host.Failures()) == 0) {
 		m.notice(i18n.M.SlashMCPNone)
 		return
 	}
@@ -1599,6 +1599,9 @@ func (m *chatTUI) showMCPStatus() {
 			label = r.Description
 		}
 		fmt.Fprintf(&b, "      %s  %s\n", "@"+r.Server+":"+r.URI, dim(label))
+	}
+	for _, f := range m.host.Failures() {
+		fmt.Fprintf(&b, "    %s %s %s\n", yellow("!"), bold(f.Name), dim(fmt.Sprintf("(%s) — %s", f.Transport, f.Error)))
 	}
 	m.commitLine(strings.TrimRight(b.String(), "\n"))
 }

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -246,13 +246,24 @@ func (c *Controller) hookListText() string {
 }
 
 func (c *Controller) mcpListText() string {
-	if c.host == nil || len(c.host.ServerNames()) == 0 {
+	if c.host == nil || (len(c.host.ServerNames()) == 0 && len(c.host.Failures()) == 0) {
 		return i18n.M.ListMcpNone
 	}
 	var b strings.Builder
-	b.WriteString(i18n.M.ListMcpHeader + "\n")
-	for _, name := range c.host.ServerNames() {
-		fmt.Fprintf(&b, "  %s\n", name)
+	if len(c.host.ServerNames()) > 0 {
+		b.WriteString(i18n.M.ListMcpHeader + "\n")
+		for _, name := range c.host.ServerNames() {
+			fmt.Fprintf(&b, "  %s\n", name)
+		}
+	}
+	if failures := c.host.Failures(); len(failures) > 0 {
+		if b.Len() > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString("MCP startup failures:\n")
+		for _, f := range failures {
+			fmt.Fprintf(&b, "  %s (%s): %s\n", f.Name, f.Transport, f.Error)
+		}
 	}
 	return strings.TrimRight(b.String(), "\n")
 }

--- a/internal/plugin/canonicalize_test.go
+++ b/internal/plugin/canonicalize_test.go
@@ -96,15 +96,29 @@ func TestSortToolsByName(t *testing.T) {
 }
 
 func TestNormalizeNameForToolNames(t *testing.T) {
-	cases := map[string]string{
-		"@modelcontextprotocol/server-memory": "modelcontextprotocol_server-memory",
-		"mcp server/fetch":                    "mcp_server_fetch",
-		"   ":                                 "unnamed",
+	if got := normalizeName("valid_name-1"); got != "valid_name-1" {
+		t.Fatalf("valid name changed: %q", got)
 	}
-	for in, want := range cases {
-		if got := normalizeName(in); got != want {
-			t.Errorf("normalizeName(%q) = %q, want %q", in, got, want)
+	cases := []string{"@modelcontextprotocol/server-memory", "mcp server/fetch", "   "}
+	for _, in := range cases {
+		got := normalizeName(in)
+		if got == "" || strings.ContainsAny(got, " @/") {
+			t.Errorf("normalizeName(%q) = %q, want non-empty safe identifier", in, got)
 		}
+	}
+}
+
+func TestNormalizeNameAvoidsSanitizedCollisions(t *testing.T) {
+	a := normalizeName("search/code")
+	b := normalizeName("search_code")
+	if a == b {
+		t.Fatalf("normalized names collided: %q", a)
+	}
+	if b != "search_code" {
+		t.Fatalf("valid identifier should stay stable, got %q", b)
+	}
+	if normalizeName("@foo") == normalizeName("foo") {
+		t.Fatal("trimmed invalid prefix should not collapse onto valid name")
 	}
 }
 

--- a/internal/plugin/canonicalize_test.go
+++ b/internal/plugin/canonicalize_test.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	"reasonix/internal/tool"
@@ -90,6 +92,26 @@ func TestSortToolsByName(t *testing.T) {
 	// Original should be unchanged
 	if tools[0].Name() != "zulu" {
 		t.Error("original slice was mutated")
+	}
+}
+
+func TestNormalizeNameForToolNames(t *testing.T) {
+	cases := map[string]string{
+		"@modelcontextprotocol/server-memory": "modelcontextprotocol_server-memory",
+		"mcp server/fetch":                    "mcp_server_fetch",
+		"   ":                                 "unnamed",
+	}
+	for in, want := range cases {
+		if got := normalizeName(in); got != want {
+			t.Errorf("normalizeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSummarizeFailureErrorSingleLine(t *testing.T) {
+	got := summarizeFailureError(errors.New("npm error code ENOTEMPTY\nnpm error path /tmp/x"))
+	if strings.Contains(got, "\n") || !strings.Contains(got, "ENOTEMPTY") {
+		t.Fatalf("summary = %q", got)
 	}
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"log/slog"
 	"regexp"
@@ -433,11 +434,21 @@ func toolName(server, raw string) string {
 var invalidNameChars = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
 
 func normalizeName(s string) string {
+	raw := s
 	s = strings.Trim(invalidNameChars.ReplaceAllString(s, "_"), "_")
 	if s == "" {
-		return "unnamed"
+		s = "unnamed"
+	}
+	if s != raw {
+		s += "_" + shortNameHash(raw)
 	}
 	return s
+}
+
+func shortNameHash(s string) string {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return fmt.Sprintf("%08x", h.Sum32())[:6]
 }
 
 func summarizeFailureError(err error) string {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"reasonix/internal/tool"
@@ -36,10 +37,9 @@ type Spec struct {
 	// for cwd-aware servers like CodeGraph, which detect the project from the
 	// directory they are launched in — they must be pinned to the project root.
 	Dir string
-	// Stderr is the writer for plugin subprocess stderr output. When nil,
-	// defaults to os.Stderr. Set to io.Discard to suppress output (e.g. during
-	// model switch inside a bubbletea session where stderr writes to the
-	// terminal would corrupt the TUI's raw mode).
+	// Stderr optionally mirrors plugin subprocess stderr output. Stderr is always
+	// captured in a bounded buffer for failure diagnostics; nil keeps it out of
+	// the terminal so child logs cannot corrupt interactive UIs.
 	Stderr io.Writer
 }
 
@@ -61,6 +61,7 @@ type Host struct {
 	clients   []*Client
 	prompts   []Prompt
 	resources []Resource
+	failures  []Failure
 }
 
 // Prompts returns every MCP prompt discovered across connected servers.
@@ -100,36 +101,31 @@ func StartAll(ctx context.Context, specs []Spec) (*Host, []tool.Tool, error) {
 	h := &Host{}
 	var tools []tool.Tool
 	for _, s := range specs {
-		c, err := start(ctx, s)
+		ts, err := h.addConnected(ctx, s)
 		if err != nil {
 			h.Close()
 			return nil, nil, fmt.Errorf("start plugin %q: %w", s.Name, err)
 		}
-		h.clients = append(h.clients, c)
-
-		ts, err := c.listTools(ctx)
-		if err != nil {
-			h.Close()
-			return nil, nil, fmt.Errorf("list tools from %q: %w", s.Name, err)
-		}
 		tools = append(tools, ts...)
-		c.toolCount = len(ts)
-
-		// Prompts and resources are auxiliary: only fetched when the server
-		// advertised the capability, and a listing error is tolerated (skipped)
-		// rather than failing the whole session over a non-essential surface.
-		if c.hasPrompts {
-			if ps, perr := c.listPrompts(ctx); perr == nil {
-				h.prompts = append(h.prompts, ps...)
-			}
-		}
-		if c.hasResources {
-			if rs, rerr := c.listResources(ctx); rerr == nil {
-				h.resources = append(h.resources, rs...)
-			}
-		}
 	}
 	return h, tools, nil
+}
+
+// StartAvailable connects every plugin it can and records failures on the host
+// instead of aborting the whole session. The returned tools are the union of the
+// successfully connected servers.
+func StartAvailable(ctx context.Context, specs []Spec) (*Host, []tool.Tool) {
+	h := &Host{}
+	var tools []tool.Tool
+	for _, s := range specs {
+		ts, err := h.addConnected(ctx, s)
+		if err != nil {
+			h.RecordFailure(s, err)
+			continue
+		}
+		tools = append(tools, ts...)
+	}
+	return h, tools
 }
 
 // Close terminates all plugin connections.
@@ -165,6 +161,13 @@ type ServerStatus struct {
 	Resources int
 }
 
+// Failure records one MCP server that was configured but could not connect.
+type Failure struct {
+	Name      string
+	Transport string
+	Error     string
+}
+
 // Servers returns a status summary per connected server, in connection order.
 func (h *Host) Servers() []ServerStatus {
 	out := make([]ServerStatus, 0, len(h.clients))
@@ -183,6 +186,39 @@ func (h *Host) Servers() []ServerStatus {
 		out = append(out, s)
 	}
 	return out
+}
+
+// Failures returns configured MCP servers that failed to connect.
+func (h *Host) Failures() []Failure {
+	out := make([]Failure, len(h.failures))
+	copy(out, h.failures)
+	return out
+}
+
+// RecordFailure stores a failed MCP connection attempt for status UIs.
+func (h *Host) RecordFailure(s Spec, err error) {
+	tt := strings.ToLower(strings.TrimSpace(s.Type))
+	if tt == "" {
+		tt = "stdio"
+	}
+	f := Failure{Name: s.Name, Transport: tt, Error: summarizeFailureError(err)}
+	for i := range h.failures {
+		if h.failures[i].Name == s.Name {
+			h.failures[i] = f
+			return
+		}
+	}
+	h.failures = append(h.failures, f)
+}
+
+func (h *Host) clearFailure(name string) {
+	kept := h.failures[:0]
+	for _, f := range h.failures {
+		if f.Name != name {
+			kept = append(kept, f)
+		}
+	}
+	h.failures = kept
 }
 
 // NewHost returns an empty Host. Boot always constructs one — even with no
@@ -209,6 +245,10 @@ func (h *Host) Add(ctx context.Context, s Spec) ([]tool.Tool, error) {
 	if h.has(s.Name) {
 		return nil, fmt.Errorf("server %q is already connected", s.Name)
 	}
+	return h.addConnected(ctx, s)
+}
+
+func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
 	c, err := start(ctx, s)
 	if err != nil {
 		return nil, err
@@ -234,6 +274,7 @@ func (h *Host) Add(ctx context.Context, s Spec) ([]tool.Tool, error) {
 			slog.Warn("plugin: listResources failed", "server", s.Name, "err", rerr)
 		}
 	}
+	h.clearFailure(s.Name)
 	return ts, nil
 }
 
@@ -269,6 +310,7 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 		}
 	}
 	h.resources = keptR
+	h.clearFailure(name)
 
 	return "mcp__" + normalizeName(name) + "__", true
 }
@@ -388,7 +430,24 @@ func toolName(server, raw string) string {
 	return "mcp__" + normalizeName(server) + "__" + normalizeName(raw)
 }
 
-func normalizeName(s string) string { return strings.ReplaceAll(s, " ", "_") }
+var invalidNameChars = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)
+
+func normalizeName(s string) string {
+	s = strings.Trim(invalidNameChars.ReplaceAllString(s, "_"), "_")
+	if s == "" {
+		return "unnamed"
+	}
+	return s
+}
+
+func summarizeFailureError(err error) string {
+	msg := strings.Join(strings.Fields(err.Error()), " ")
+	const max = 500
+	if len(msg) > max {
+		msg = msg[:max] + "..."
+	}
+	return msg
+}
 
 // --- JSON-RPC message types (shared by every transport) ---
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -49,10 +50,62 @@ func TestStdioEndToEnd(t *testing.T) {
 	}
 }
 
+func TestStartAvailableKeepsGoodServers(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	good := Spec{
+		Name:    "good",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env:     map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
+	}
+	bad := Spec{Name: "bad", Command: "reasonix-missing-mcp-binary"}
+
+	host, tools := StartAvailable(ctx, []Spec{bad, good})
+	defer host.Close()
+
+	if len(tools) != 2 {
+		t.Fatalf("want tools from the good server, got %d", len(tools))
+	}
+	if got := host.ServerNames(); len(got) != 1 || got[0] != "good" {
+		t.Fatalf("connected servers = %v, want [good]", got)
+	}
+	failures := host.Failures()
+	if len(failures) != 1 || failures[0].Name != "bad" {
+		t.Fatalf("failures = %+v, want bad", failures)
+	}
+}
+
+func TestStdioFailureCapturesStderr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	host, _ := StartAvailable(ctx, []Spec{{
+		Name:    "stderr",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env:     map[string]string{"GO_WANT_HELPER_STDERR_EXIT": "1"},
+	}})
+	defer host.Close()
+
+	failures := host.Failures()
+	if len(failures) != 1 {
+		t.Fatalf("failures = %+v, want one", failures)
+	}
+	if !strings.Contains(failures[0].Error, "helper stderr boom") {
+		t.Fatalf("failure should include stderr, got %q", failures[0].Error)
+	}
+}
+
 // TestHelperProcess is not a real test; it acts as a minimal MCP stdio server
 // when invoked by TestStdioEndToEnd. It exits before the test framework can
 // print to stdout, keeping the JSON-RPC channel clean.
 func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_STDERR_EXIT") == "1" {
+		os.Stderr.WriteString("helper stderr boom\n")
+		os.Exit(2)
+	}
 	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
 		return
 	}

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -24,8 +24,9 @@ type stdioTransport struct {
 	stdout *bufio.Reader
 	stderr *tailBuffer
 
-	mu     sync.Mutex
-	nextID int
+	mu       sync.Mutex
+	nextID   int
+	waitOnce sync.Once
 }
 
 func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
@@ -123,11 +124,22 @@ func (t *stdioTransport) withStderr(err error) error {
 	if t.stderr == nil {
 		return err
 	}
+	t.wait() // reap the exited child so its stderr copy goroutine has flushed the tail
 	msg := t.stderr.String()
 	if msg == "" {
 		return err
 	}
 	return fmt.Errorf("%w: stderr: %s", err, msg)
+}
+
+// wait reaps the child exactly once; cmd.Wait blocks until the stderr-copy
+// goroutine completes, so the tail buffer is settled before anyone reads it.
+func (t *stdioTransport) wait() {
+	t.waitOnce.Do(func() {
+		if t.cmd != nil && t.cmd.Process != nil {
+			_ = t.cmd.Wait()
+		}
+	})
 }
 
 func (t *stdioTransport) close() {
@@ -136,7 +148,7 @@ func (t *stdioTransport) close() {
 	}
 	if t.cmd != nil && t.cmd.Process != nil {
 		_ = t.cmd.Process.Kill()
-		_ = t.cmd.Wait()
+		t.wait()
 	}
 }
 

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 )
 
@@ -21,6 +22,7 @@ type stdioTransport struct {
 	cmd    *exec.Cmd
 	stdin  io.WriteCloser
 	stdout *bufio.Reader
+	stderr *tailBuffer
 
 	mu     sync.Mutex
 	nextID int
@@ -35,9 +37,10 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	if s.Dir != "" {
 		cmd.Dir = s.Dir // pin cwd-aware servers (e.g. CodeGraph) to the project root
 	}
-	cmd.Stderr = os.Stderr // default: surface plugin logs to the terminal
+	stderr := &tailBuffer{limit: 16 * 1024}
+	cmd.Stderr = stderr
 	if s.Stderr != nil {
-		cmd.Stderr = s.Stderr // caller-supplied override (e.g. io.Discard)
+		cmd.Stderr = io.MultiWriter(stderr, s.Stderr)
 	}
 
 	stdin, err := cmd.StdinPipe()
@@ -51,7 +54,7 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	if err := cmd.Start(); err != nil {
 		return nil, err
 	}
-	return &stdioTransport{name: s.Name, cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdout)}, nil
+	return &stdioTransport{name: s.Name, cmd: cmd, stdin: stdin, stdout: bufio.NewReader(stdout), stderr: stderr}, nil
 }
 
 func (t *stdioTransport) call(ctx context.Context, method string, params any) (json.RawMessage, error) {
@@ -70,7 +73,7 @@ func (t *stdioTransport) call(ctx context.Context, method string, params any) (j
 		}
 		line, err := t.stdout.ReadBytes('\n')
 		if err != nil {
-			return nil, fmt.Errorf("plugin %q: read: %w", t.name, err)
+			return nil, t.withStderr(fmt.Errorf("plugin %q: read: %w", t.name, err))
 		}
 		line = bytes.TrimSpace(line)
 		if len(line) == 0 {
@@ -110,7 +113,21 @@ func (t *stdioTransport) write(v any) error {
 		return err
 	}
 	_, err = t.stdin.Write(append(b, '\n'))
-	return err
+	if err != nil {
+		return t.withStderr(err)
+	}
+	return nil
+}
+
+func (t *stdioTransport) withStderr(err error) error {
+	if t.stderr == nil {
+		return err
+	}
+	msg := t.stderr.String()
+	if msg == "" {
+		return err
+	}
+	return fmt.Errorf("%w: stderr: %s", err, msg)
 }
 
 func (t *stdioTransport) close() {
@@ -121,4 +138,26 @@ func (t *stdioTransport) close() {
 		_ = t.cmd.Process.Kill()
 		_ = t.cmd.Wait()
 	}
+}
+
+type tailBuffer struct {
+	mu    sync.Mutex
+	limit int
+	buf   []byte
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.buf = append(b.buf, p...)
+	if b.limit > 0 && len(b.buf) > b.limit {
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(string(b.buf))
 }


### PR DESCRIPTION
## Summary

Makes MCP startup resilient when one configured server is unavailable:

- Connects the MCP servers that can start successfully.
- Records failed servers on the host instead of aborting the whole chat startup.
- Shows failed MCP servers in `/mcp` status surfaces.
- Captures bounded stdio stderr tails for concise diagnostics without writing child-process logs directly into the TUI.
- Normalizes provider-visible MCP tool names to stable `a-zA-Z0-9_-` identifiers.

## Root Cause

A single broken MCP server currently prevents the entire session from starting. Stdio server stderr can also write directly into terminal UI output, making failures noisy and hard to inspect. MCP server and tool names from external configs may contain punctuation that is not safe for provider function names.

## Technical Approach

- Adds `plugin.StartAvailable`, which starts each server independently and records failures on `Host.Failures()`.
- Keeps `StartAll` strict for callers that still want all-or-nothing behavior.
- Refactors host connection setup through one `addConnected` path so startup and hot-add share prompt/resource/tool discovery behavior.
- Captures stdio stderr in a bounded tail buffer and appends it to startup failure summaries.
- Updates `boot.Build` to use `StartAvailable` and emit one concise warning notice when failures exist.
- Updates `/mcp` status output to show startup failures alongside connected servers.

## Focused Optimization Points

- Successful servers keep their configured order.
- Per-server tools still use canonical schema serialization and sorted tool names.
- Failure messages are single-line and capped to avoid flooding the UI.
- No desktop v1 frontend, attachment, autoscroll, or `auto_start` changes are included.

## Cache / Tool Schema Notes

This PR can change provider-visible tools only when a configured MCP server fails to start. In that degraded case, tools from the failed server are absent instead of blocking the session. Successful server ordering and schema canonicalization remain stable.

## Verification

Passed:

- `go test ./internal/plugin ./internal/boot -run 'TestStartAvailable|TestStdioFailure|TestNormalizeName|TestSummarize|TestBuildRecordsMCPStartupFailure'`
- `go test ./internal/control ./internal/cli`
- `go test ./internal/agent -run TestPlanModeDoesNotMutateSystemOrTools`

Known local environment note: the full `go test ./...` suite currently fails in `internal/boot TestBuildDiscoversSkills` on this machine because global user skills are discovered and included in the boot prompt. That same environment issue was observed outside this PR scope.
