### PR TITLE
Add secure desktop image attachments

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -682,6 +682,17 @@ func (a *App) ListDir(rel string) []DirEntry {
 	return append(dirs, files...)
 }
 
+// SavePastedImage stores a browser clipboard image data URL under
+// .reasonix/attachments and returns the relative @-reference path.
+func (a *App) SavePastedImage(dataURL string) (string, error) {
+	return control.SaveImageDataURL(dataURL)
+}
+
+// AttachmentDataURL returns a safe data URL for a stored image attachment.
+func (a *App) AttachmentDataURL(path string) (string, error) {
+	return control.ImageDataURL(path)
+}
+
 // --- memory panel (frontend ⇄ controller) ---
 
 // MemoryDoc is one loaded doc-memory file for the panel: path, scope, and body.

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent } from "react";
-import { ArrowUp, Square } from "lucide-react";
+import type { ClipboardEvent, DragEvent, KeyboardEvent } from "react";
+import { ArrowUp, Square, X } from "lucide-react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import type { CommandInfo, DirEntry, Mode, SlashArgItem, SlashArgsResult } from "../lib/types";
 import { SlashMenu } from "./SlashMenu";
 import { ArgMenu } from "./ArgMenu";
 import { FileMenu } from "./FileMenu";
+
+interface Attachment {
+  path: string;
+  previewUrl: string;
+}
 
 export function Composer({
   running,
@@ -25,8 +30,11 @@ export function Composer({
 }) {
   const t = useT();
   const [text, setText] = useState("");
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+  const [pendingPaste, setPendingPaste] = useState(0);
   const [active, setActive] = useState(0);
   const [dismissed, setDismissed] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
 
   // --- slash commands (whole-input "/token") ---
@@ -160,10 +168,58 @@ export function Composer({
 
   const submit = () => {
     const t = text.trim();
-    if (!t) return;
-    onSend(t);
+    if ((!t && attachments.length === 0) || pendingPaste > 0) return;
+    const refs = attachments.map((a) => `@${a.path}`).join(" ");
+    onSend([t, refs].filter(Boolean).join(t && refs ? " " : ""));
     setText("");
+    setAttachments([]);
   };
+
+  const attachImageFiles = async (files: File[]) => {
+    const images = files.filter((f) => f.type.startsWith("image/"));
+    if (images.length === 0) return;
+    for (const file of images) {
+      setPendingPaste((n) => n + 1);
+      try {
+        const dataUrl = await new Promise<string>((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () => resolve(String(reader.result));
+          reader.onerror = () => reject(reader.error);
+          reader.readAsDataURL(file);
+        });
+        const path = await app.SavePastedImage(dataUrl);
+        const previewUrl = await app.AttachmentDataURL(path);
+        setAttachments((prev) => [...prev, { path, previewUrl }]);
+      } catch {
+        // non-fatal: a failed image attach must not block normal text input
+      } finally {
+        setPendingPaste((n) => Math.max(0, n - 1));
+      }
+    }
+  };
+
+  const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    const files = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith("image/"));
+    if (files.length === 0) return;
+    e.preventDefault();
+    void attachImageFiles(files);
+  };
+
+  const onDrop = (e: DragEvent<HTMLDivElement>) => {
+    const files = Array.from(e.dataTransfer.files);
+    if (!files.some((f) => f.type.startsWith("image/"))) return;
+    e.preventDefault();
+    setDragOver(false);
+    void attachImageFiles(files);
+  };
+
+  const onDragOver = (e: DragEvent<HTMLDivElement>) => {
+    if (!Array.from(e.dataTransfer.items).some((it) => it.kind === "file")) return;
+    e.preventDefault(); // required for the drop event to fire
+    setDragOver(true);
+  };
+
+  const onDragLeave = () => setDragOver(false);
 
   // handleCancel stops the in-flight turn; if it was cancelled before the server
   // replied, the just-sent text is handed back so we drop it back into the input.
@@ -251,6 +307,23 @@ export function Composer({
         <ArgMenu items={argRes.items} activeIndex={active} onPick={pickArg} onHover={setActive} />
       )}
       {menuMode === "at" && <FileMenu items={atMatches} activeIndex={active} onPick={pickEntry} onHover={setActive} />}
+      {attachments.length > 0 && (
+        <div className="composer__attachments">
+          {attachments.map((a) => (
+            <div className="composer__attachment" key={a.path}>
+              <img src={a.previewUrl} alt="" />
+              <span>{a.path.split("/").pop()}</span>
+              <button
+                type="button"
+                title="Remove image"
+                onClick={() => setAttachments((prev) => prev.filter((x) => x.path !== a.path))}
+              >
+                <X size={14} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
       <button
         className={`composer__mode composer__mode--${mode}`}
         onClick={onCycleMode}
@@ -260,13 +333,19 @@ export function Composer({
         {mode === "yolo" ? t("composer.modeYolo") : mode === "plan" ? t("composer.modePlan") : t("composer.modeNormal")}
         <span className="composer__mode-hint">{t("composer.modeHint")}</span>
       </button>
-      <div className="composer">
+      <div
+        className={`composer${dragOver ? " composer--dragover" : ""}`}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+      >
         <span className="composer__caret">›</span>
         <textarea
           ref={taRef}
           className="composer__input"
           value={text}
           onChange={(e) => setText(e.target.value)}
+          onPaste={onPaste}
           onKeyDown={onKeyDown}
           placeholder={t("composer.placeholder")}
           rows={1}
@@ -279,7 +358,7 @@ export function Composer({
           <button
             className="composer__btn composer__btn--send"
             onClick={submit}
-            disabled={!text.trim()}
+            disabled={pendingPaste > 0 || (!text.trim() && attachments.length === 0)}
             title={t("composer.send")}
           >
             <ArrowUp size={16} />

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -23,10 +23,11 @@ export function UserMessage({
   const t = useT();
   const canRewind = onRewind != null && turn != null;
   const rewind = (scope: string) => onRewind?.(turn as number, scope);
+  const displayText = text.replace(/@\.reasonix\/attachments\/[^\s]+/g, "[image]");
   return (
     <div className="msg msg--user">
       <span className="msg__caret">›</span>
-      <div className="msg__text">{text}</div>
+      <div className="msg__text">{displayText}</div>
       {canRewind && (
         <div className="rewind">
           <button className="rewind__btn" title={t("rewind.label")} onClick={onToggle}>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -64,6 +64,8 @@ export interface AppBindings {
   Commands(): Promise<CommandInfo[]>;
   SlashArgs(input: string): Promise<SlashArgsResult>;
   ListDir(rel: string): Promise<DirEntry[]>;
+  SavePastedImage(dataUrl: string): Promise<string>;
+  AttachmentDataURL(path: string): Promise<string>;
   Models(): Promise<ModelInfo[]>;
   SetModel(name: string): Promise<void>;
   // Memory panel: read the loaded REASONIX.md hierarchy + saved auto-memories,
@@ -389,6 +391,12 @@ function makeMockApp(): AppBindings {
         ];
       }
       return [{ name: "file.go", isDir: false }];
+    },
+    async SavePastedImage(_dataUrl: string) {
+      return ".reasonix/attachments/mock.png";
+    },
+    async AttachmentDataURL(_path: string) {
+      return "data:image/png;base64,iVBORw0KGgo=";
     },
     async Models() {
       return [

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -951,6 +951,10 @@ body {
 .composer:focus-within {
   border-color: var(--fg-faint);
 }
+.composer--dragover {
+  border-color: var(--accent);
+  border-style: dashed;
+}
 .composer__caret {
   color: var(--accent);
   font-family: var(--mono);
@@ -2106,4 +2110,52 @@ body {
 }
 .composer__mode--yolo .composer__mode-hint {
   color: rgba(255, 255, 255, 0.8);
+}
+
+.composer__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.composer__attachment {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 220px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg-dim);
+  font-size: 12px;
+}
+.composer__attachment img {
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+.composer__attachment span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.composer__attachment button {
+  --wails-draggable: no-drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--fg-faint);
+  cursor: pointer;
+}
+.composer__attachment button:hover {
+  color: var(--fg);
+  background: var(--hover);
 }


### PR DESCRIPTION
## Summary

Adds a focused, v2-native image attachment path for the Wails desktop app:

- Composer accepts pasted image files from the browser clipboard.
- Pasted images are stored under `.reasonix/attachments` and sent as `@.reasonix/attachments/...` references.
- User transcript display hides raw attachment paths as `[image]`.
- The provider-facing prompt receives an image attachment path block, not inlined image bytes.
- Wails bridge exposes `SavePastedImage` and `AttachmentDataURL` for the v2 frontend.

## Root Cause

DeepSeek text models can still work with images through MCP vision/OCR tools, but the desktop app had no safe way to capture pasted images and pass stable local paths into the turn context. The previous large PR mixed this useful attachment path with a wholesale v1 frontend port, so this PR rebuilds only the v2-native attachment surface.

## Technical Approach

- Adds `internal/control/attachments.go` for image data URL persistence and safe attachment preview reads.
- Uses a strict `.reasonix/attachments` containment check.
- Rejects absolute paths, traversal paths, symlinked attachment files, and symlinked attachment directories.
- Verifies opened files match the checked file and validates MIME from bytes.
- Keeps image bytes out of `ResolveRefs`; image refs become a short `<image path="...">` block instructing use of MCP vision/OCR tooling when needed.
- Extends the existing v2 Composer, Message, and bridge without importing any v1 shell/component code.

## Focused Optimization Points

- No v1 frontend files, v1 compatibility CSS, Tauri compatibility layer, screenshots, or generated attachment files are included.
- Attachment reads are bounded at 10 MB.
- Clipboard paste failures are non-fatal and do not affect normal text input.
- Frontend build artifacts and `node_modules` remain ignored and are not committed.

## Cache / Tool Schema Notes

This PR does not change system prompt bytes, tool schemas, tool ordering, or MCP startup behavior. Image attachment paths are appended only to the explicit user turn, so cache impact is limited to turns where the user attaches an image.

## Verification

Passed:

- `go test ./internal/control`
- `go test ./internal/agent -run TestPlanModeDoesNotMutateSystemOrTools`
- `cd desktop/frontend && pnpm install --frozen-lockfile`
- `cd desktop/frontend && pnpm run build`
