### PR TITLE
fix: @目录引用递归列出子目录 + glob简单模式自动递归回退

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -279,7 +279,8 @@ resolved and prepended to the message as a tagged block the model can read.
   actually exists on disk. This existence gate is the disambiguator: an ordinary
   `@mention` or an email address resolves to no file and stays literal text. A
   file is wrapped `<file path="…">…</file>` (size-capped, binary files noted not
-  dumped); a directory becomes a one-level listing.
+  dumped); a directory becomes a recursive listing (depth-first, skipping common
+  noise like `.git` and `node_modules`).
 - Resolution is asynchronous (off the TUI event loop); a fetch failure surfaces
   as a notice but doesn't block the turn. Reads are user-initiated and read-only
   — they do **not** pass the permission gate (§3.7).

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -130,27 +131,51 @@ func appendRefBlock(b *strings.Builder, tag, attr, body string) {
 }
 
 // readFileRef reads an @-referenced path for injection. A directory yields a
-// one-level listing; a binary file (NUL in the first 8 KiB) is noted rather than
-// dumped; a large file is truncated to maxFileRefBytes with a marker. isDir lets
-// the caller pick the wrapping tag.
+// recursive listing (walked depth-first so the model sees the full tree); a
+// binary file (NUL in the first 8 KiB) is noted rather than dumped; a large file
+// is truncated to maxFileRefBytes with a marker. isDir lets the caller pick the
+// wrapping tag. Common noise directories (.git, node_modules, .DS_Store) are
+// skipped during the walk.
 func readFileRef(path string) (content string, isDir bool, err error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", false, err
 	}
 	if info.IsDir() {
-		entries, err := os.ReadDir(path)
+		var b strings.Builder
+		err := filepath.WalkDir(path, func(p string, d os.DirEntry, wErr error) error {
+			if wErr != nil {
+				return wErr
+			}
+			// Skip the root itself — we only list its children.
+			if p == path {
+				return nil
+			}
+			name := d.Name()
+			// Skip common noise directories.
+			if d.IsDir() {
+				switch name {
+				case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
+					return filepath.SkipDir
+				}
+			}
+			// Render the path relative to the referenced directory so the
+			// listing is concise and unambiguous. Use forward slashes for
+			// cross-platform consistency.
+			rel, rErr := filepath.Rel(path, p)
+			if rErr != nil {
+				rel = p
+			}
+			rel = strings.ReplaceAll(rel, string(os.PathSeparator), "/")
+			if d.IsDir() {
+				rel += "/"
+			}
+			b.WriteString(rel)
+			b.WriteByte('\n')
+			return nil
+		})
 		if err != nil {
 			return "", true, err
-		}
-		var b strings.Builder
-		for _, e := range entries {
-			name := e.Name()
-			if e.IsDir() {
-				name += "/"
-			}
-			b.WriteString(name)
-			b.WriteByte('\n')
 		}
 		return b.String(), true, nil
 	}

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -90,16 +90,19 @@ func TestReadFileRef(t *testing.T) {
 		t.Errorf("big file should be truncated, got len=%d err=%v", len(got), err)
 	}
 
-	// Directory: one-level listing including a trailing slash for subdirs.
+	// Directory: recursive listing with relative paths including a trailing slash for subdirs.
 	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sub", "nested.txt"), []byte("nested"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	got, isDir, err := readFileRef(dir)
 	if err != nil || !isDir {
 		t.Fatalf("dir = (isDir=%v, err=%v)", isDir, err)
 	}
-	if !strings.Contains(got, "hello.txt") || !strings.Contains(got, "sub/") {
-		t.Errorf("dir listing = %q, want hello.txt and sub/", got)
+	if !strings.Contains(got, "hello.txt") || !strings.Contains(got, "sub/") || !strings.Contains(got, "sub/nested.txt") {
+		t.Errorf("dir listing = %q, want hello.txt, sub/, and sub/nested.txt", got)
 	}
 
 	// Missing path: error.

--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -49,10 +49,17 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return globRecursive(p.Pattern)
 	}
 
-	// Standard filepath.Glob for patterns without **.
+	// For patterns without **, try filepath.Glob first. If no matches are
+	// found and the pattern is a simple filename (no path separator), retry
+	// with a recursive walk (equivalent to "**/<pattern>") so the tool finds
+	// files anywhere in the tree — the common case where the model only knows
+	// a filename but not its exact location.
 	matches, err := filepath.Glob(p.Pattern)
 	if err != nil {
 		return "", fmt.Errorf("glob %q: %w", p.Pattern, err)
+	}
+	if len(matches) == 0 && !strings.ContainsAny(p.Pattern, "/\\") {
+		return globRecursive(filepath.Join("**", p.Pattern))
 	}
 	if len(matches) == 0 {
 		return "(no matches)", nil


### PR DESCRIPTION
- readFileRef: 将目录处理从 os.ReadDir(单层) 改为 filepath.WalkDir(递归)，跳过 .git/node_modules 等噪声目录，路径统一为正斜杠
- glob: 当简单模式(无路径分隔符)在根目录无匹配时，自动回退为 **/<pattern> 递归搜索全项目树
- 更新 docs/SPEC.md 中目录引用行为描述