### PR TITLE
test: make path and codegraph tests Windows-portable

### DIFF
--- a/internal/acp/protocol_test.go
+++ b/internal/acp/protocol_test.go
@@ -1,6 +1,7 @@
 package acp
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -157,9 +158,10 @@ func TestMcpSpecsConversion(t *testing.T) {
 // --- transcriptPath ---
 
 func TestTranscriptPath(t *testing.T) {
-	got := transcriptPath("/sessions", "abc-123")
-	if got != "/sessions/abc-123.jsonl" {
-		t.Errorf("transcriptPath = %q", got)
+	dir := t.TempDir()
+	got := transcriptPath(dir, "abc-123")
+	if want := filepath.Join(dir, "abc-123.jsonl"); got != want {
+		t.Errorf("transcriptPath = %q, want %q", got, want)
 	}
 }
 

--- a/internal/agent/session_test.go
+++ b/internal/agent/session_test.go
@@ -291,14 +291,15 @@ func TestPreviewSessionMalformed(t *testing.T) {
 // --- NewSessionPath ---
 
 func TestNewSessionPath(t *testing.T) {
-	path := NewSessionPath("/sessions", "deepseek-chat")
+	dir := t.TempDir()
+	path := NewSessionPath(dir, "deepseek-chat")
 	if !strings.HasSuffix(path, ".jsonl") {
 		t.Errorf("should end with .jsonl: %s", path)
 	}
 	if !strings.Contains(path, "deepseek-chat") {
 		t.Errorf("should contain model name: %s", path)
 	}
-	if !strings.HasPrefix(path, "/sessions/") {
+	if !strings.HasPrefix(path, dir) {
 		t.Errorf("should be under dir: %s", path)
 	}
 }

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -26,6 +26,9 @@ func TestBuildFoldsProjectMemoryIntoSystemPrompt(t *testing.T) {
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
 
+[codegraph]
+enabled = false
+
 [agent]
 system_prompt = "BASE SYSTEM PROMPT"
 
@@ -71,6 +74,9 @@ func TestBuildDiscoversSkills(t *testing.T) {
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
+
+[codegraph]
+enabled = false
 
 [agent]
 system_prompt = "BASE"
@@ -120,6 +126,9 @@ func TestBuildWithoutMemoryLeavesPromptUnchanged(t *testing.T) {
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
+
+[codegraph]
+enabled = false
 
 [agent]
 system_prompt = "JUST THE BASE"

--- a/internal/memory/store_extra_test.go
+++ b/internal/memory/store_extra_test.go
@@ -260,9 +260,10 @@ func TestSaveCreatesDir(t *testing.T) {
 // --- Store.Path ---
 
 func TestStorePath(t *testing.T) {
-	s := Store{Dir: "/tmp/memory"}
+	dir := filepath.Join(t.TempDir(), "memory")
+	s := Store{Dir: dir}
 	got := s.Path("My Fact")
-	if got != "/tmp/memory/my-fact.md" {
-		t.Errorf("Path = %q", got)
+	if want := filepath.Join(dir, "my-fact.md"); got != want {
+		t.Errorf("Path = %q, want %q", got, want)
 	}
 }

--- a/internal/skill/skill_extra_test.go
+++ b/internal/skill/skill_extra_test.go
@@ -153,22 +153,25 @@ func TestParseRunAsDefault(t *testing.T) {
 // --- resolveCustomPaths ---
 
 func TestResolveCustomPathsTilde(t *testing.T) {
-	got := resolveCustomPaths([]string{"~/skills"}, "/base", "/home/user")
-	if len(got) != 1 || got[0] != "/home/user/skills" {
+	home := t.TempDir()
+	got := resolveCustomPaths([]string{"~/skills"}, "/base", home)
+	if len(got) != 1 || got[0] != filepath.Join(home, "skills") {
 		t.Errorf("tilde expansion = %v", got)
 	}
 }
 
 func TestResolveCustomPathsRelative(t *testing.T) {
-	got := resolveCustomPaths([]string{"./my-skills"}, "/base", "/home")
-	if len(got) != 1 || got[0] != "/base/my-skills" {
+	base := t.TempDir()
+	got := resolveCustomPaths([]string{"./my-skills"}, base, "/home")
+	if len(got) != 1 || got[0] != filepath.Join(base, "my-skills") {
 		t.Errorf("relative = %v", got)
 	}
 }
 
 func TestResolveCustomPathsAbsolute(t *testing.T) {
-	got := resolveCustomPaths([]string{"/absolute/path"}, "/base", "/home")
-	if len(got) != 1 || got[0] != "/absolute/path" {
+	abs := filepath.Join(t.TempDir(), "absolute", "path")
+	got := resolveCustomPaths([]string{abs}, "/base", "/home")
+	if len(got) != 1 || got[0] != abs {
 		t.Errorf("absolute = %v", got)
 	}
 }


### PR DESCRIPTION
## Problem

`go test ./...` fails across **6 packages on Windows** — all green in CI because CI only runs Linux/macOS:

- **Hard-coded Unix paths**: `transcriptPath` (acp), `NewSessionPath` (agent), `Store.Path` (memory), `resolveCustomPaths` ×3 (skill) assert against literals like `/sessions/...`; on Windows `filepath` joins with `\` and `/x` isn't absolute, so the assertions fail.
- **CodeGraph file lock**: the three `boot.Build` tests leave CodeGraph enabled (default `true`). When a `codegraph` binary is present on the dev's machine it spawns an MCP child that holds `codegraph.db` open, so `t.TempDir` cleanup fails on Windows (can't unlink a locked file). CI never hits this — no codegraph binary there.

## Fix

- Path tests: `t.TempDir()` + `filepath.Join` for both inputs and expectations (platform-native).
- boot tests: `[codegraph] enabled = false` — they cover memory/skill folding, not codegraph.

Full suite now green on Windows; unchanged on Linux/macOS. Follows up #2500, which fixed the same class in `internal/tool/builtin`.
