### PR TITLE
fix(desktop): render LaTeX with \( \) and \[ \] math delimiters

### DIFF
--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -39,11 +39,19 @@ const components: Components = {
   ),
 };
 
+// DeepSeek and most LLMs emit \( \) and \[ \] math delimiters; remark-math only
+// parses $ / $$. Convert so the math actually reaches KaTeX.
+function normalizeMath(s: string): string {
+  return s
+    .replace(/\\\[([\s\S]+?)\\\]/g, (_m, body) => `$$${body}$$`)
+    .replace(/\\\(([\s\S]+?)\\\)/g, (_m, body) => `$${body}$`);
+}
+
 export function Markdown({ text }: { text: string }) {
   return (
     <div className="md">
       <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={components}>
-        {text}
+        {normalizeMath(text)}
       </ReactMarkdown>
     </div>
   );


### PR DESCRIPTION
## Problem

After #2509 added KaTeX, math still rendered as raw LaTeX (user report: `integrate 1/cos(x)` showed `( \frac{1}{\cos x} = \sec x )` etc.).

Root cause: DeepSeek (and most LLMs) emit math with `\(...\)` (inline) and `\[...\]` (block) delimiters, but `remark-math` **only parses `$...$` / `$$...$$`**. So:
1. the math was never recognized as math, and
2. markdown treated the leading `\(` / `\[` as an escaped paren/bracket, eating the backslash — which is why the screenshot shows bare `(` / `[`.

## Fix

Normalize the delimiters before handing text to `react-markdown`: `\(...\)` → `$...$`, `\[...\]` → `$$...$$`. `$`-delimited math from the model still works unchanged.

## Verification

End-to-end render check (real `react-markdown` + `remark-math` + `rehype-katex`) on the reported integral:
- `\(...\)`/`\[...\]` raw → no katex (reproduces the bug)
- after normalize → `katex` HTML emitted ✅

`pnpm build` passes.
