### PR TITLE
fix(desktop): pin vite dev server to 127.0.0.1 (fix Windows blank window)

### DIFF
--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     target: "es2021",
   },
   server: {
+    host: "127.0.0.1",
     port: 5173,
     strictPort: true,
   },


### PR DESCRIPTION
On Windows (node 17+), vite's default localhost host resolves to IPv6 [::1]. The wails dev webview proxy then fails to dial [::1]:5173 (socket forbidden by access permissions) and the app renders a blank window — markdown/KaTeX are fine, the frontend just never loads. Pinning vite server.host to 127.0.0.1 makes wails connect over IPv4. Verified locally: blank before, app loads with 0 proxy errors after.