### PR TITLE
fix(desktop): protect \[ spacing and swap | for \vert in math (#2017 parity)

### DIFF
--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -39,12 +39,22 @@ const components: Components = {
   ),
 };
 
-// DeepSeek and most LLMs emit \( \) and \[ \] math delimiters; remark-math only
-// parses $ / $$. Convert so the math actually reaches KaTeX.
+// LLMs emit \( \) \[ \] delimiters (remark-math only parses $/$$); convert them,
+// but protect LaTeX line-break spacing \\[ (e.g. \\[4pt]) from the rewrite, and
+// swap | for \vert inside math so remark-gfm can't read the bar as a table column.
 function normalizeMath(s: string): string {
-  return s
-    .replace(/\\\[([\s\S]+?)\\\]/g, (_m, body) => `$$${body}$$`)
-    .replace(/\\\(([\s\S]+?)\\\)/g, (_m, body) => `$${body}$`);
+  const lb = "\x00LB\x00";
+  let r = s.replace(/\\\\\[/g, lb);
+  r = r
+    .replace(/\\\[/g, () => "$$")
+    .replace(/\\\]/g, () => "$$")
+    .replace(/\\\(/g, () => "$")
+    .replace(/\\\)/g, () => "$");
+  r = r.replace(/\x00LB\x00/g, "\\\\[");
+  const vert = (m: string) => m.replace(/\|/g, "\\vert ");
+  r = r.replace(/\$\$([\s\S]*?)\$\$/g, (_m, m) => `$$${vert(m)}$$`);
+  r = r.replace(/\$([^$\n]+)\$/g, (_m, m) => `$${vert(m)}$`);
+  return r;
 }
 
 export function Markdown({ text }: { text: string }) {


### PR DESCRIPTION
## Problem

Ports the V1 fix (#2017) to V2. Two math-rendering bugs in the desktop Markdown renderer:

1. **`|` breaks GFM tables**: math such as `\left| \sec x + \tan x \right|` (absolute value) contains `|`, which `remark-gfm` reads as a table-column separator — corrupting the render.
2. **`\\[4pt]` corrupted**: the `\[...\]` → `$$` delimiter rewrite (added in #2510) also matches LaTeX line-break spacing like `\\[4pt]` inside aligned/matrix environments, turning it into a stray `$$`.

## Fix

In `normalizeMath`:
- Protect `\\[` with a sentinel before the delimiter rewrite, then restore it.
- Inside `$...$` / `$$...$$`, replace `|` with `\vert ` (same vertical-bar glyph in KaTeX, but invisible to the GFM table parser).

## Verification

End-to-end render check (real `react-markdown` + `remark-gfm` + `remark-math` + `rehype-katex`):
- abs-value display math → KaTeX, no spurious `<table>` ✅
- `\\[4pt]` in aligned env → preserved, KaTeX renders ✅
- multi-bar inline `$|a|+|b|=|c|$` → KaTeX, no table ✅

`pnpm build` passes.
