### PR TITLE
fix(desktop): save provider/config to global user config, surviving workspace switch

### DIFF
--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -132,17 +132,20 @@ func orDefault(s, def string) string {
 
 // --- apply (write config, then rebuild the controller so it's live) ---
 
-// applyConfigChange loads the config, applies mutate, saves it, and rebuilds the
-// controller so the change takes effect this session.
+// applyConfigChange mutates the user-global config and rebuilds the controller so
+// the change takes effect this session. Desktop settings (providers, keys,
+// language) are account-level, not per-project: writing them to the global config
+// rather than the cwd's reasonix.toml is what lets them survive a workspace switch.
 func (a *App) applyConfigChange(mutate func(*config.Config) error) error {
-	cfg, err := config.Load()
-	if err != nil {
-		return err
+	path := config.UserConfigPath()
+	if path == "" {
+		return fmt.Errorf("cannot resolve user config directory")
 	}
+	cfg := config.LoadForEdit(path)
 	if err := mutate(cfg); err != nil {
 		return err
 	}
-	if err := cfg.Save(); err != nil {
+	if err := cfg.SaveTo(path); err != nil {
 		return err
 	}
 	return a.rebuild()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -355,6 +355,10 @@ func userConfigPath() string {
 	return filepath.Join(dir, "reasonix", "config.toml")
 }
 
+// UserConfigPath is the user-global config file (~/.config/reasonix/config.toml),
+// or "" when the user config dir can't be resolved.
+func UserConfigPath() string { return userConfigPath() }
+
 // ArchiveDir is where compacted conversation history is archived for
 // traceability (one timestamped .jsonl per compaction). Empty if the user config
 // directory cannot be resolved, in which case archiving is skipped.


### PR DESCRIPTION
## Problem

Providers configured in the desktop app disappear after switching the working folder.

Root cause: desktop settings flow through `applyConfigChange` → `config.Load()` → `cfg.Save()`, and `Save()` writes to `SourcePath()` — the cwd's `reasonix.toml` if present, otherwise it *creates* a project-level `reasonix.toml`. So providers were written **per-project**. `PickWorkspace` then does `os.Chdir(newDir)` + `config.Load()`, and the new directory has no such `reasonix.toml`, so the providers are gone.

## Fix

Providers, API keys, and language are **account-level**, not per-project. `applyConfigChange` now loads and saves the user-global config (`~/.config/reasonix/config.toml`) directly via `LoadForEdit` + `SaveTo`, instead of the cwd-dependent `Save()`. Added `config.UserConfigPath()` for this.

`config.Save()`'s project-level semantics are left intact for the CLI (`reasonix setup`).

## Note

Providers already written into a project `reasonix.toml` won't auto-migrate — re-saving them once in the desktop app now writes them to the global config.

## Verification

`go build` + `go vet` pass for both the main module (`internal/config`) and the desktop module (settings_app typechecks against the new `UserConfigPath`).
