### PR TITLE
fix(model): skip providers without an API key in all model pickers

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -579,7 +579,8 @@ type ModelInfo struct {
 
 // Models flattens the configured providers into their (provider, model) pairs —
 // the switcher's options — marking the active one. A vendor with a `models` list
-// yields one entry per model, all sharing the same endpoint/key.
+// yields one entry per model, all sharing the same endpoint/key. Providers whose
+// API key isn't set are skipped: the switcher only offers models you can select.
 func (a *App) Models() []ModelInfo {
 	cfg, err := config.Load()
 	if err != nil {
@@ -588,6 +589,9 @@ func (a *App) Models() []ModelInfo {
 	var out []ModelInfo
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
 		for _, m := range p.ModelList() {
 			ref := p.Name + "/" + m
 			out = append(out, ModelInfo{Ref: ref, Provider: p.Name, Model: m, Current: ref == a.model})

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -581,12 +581,15 @@ type ModelInfo struct {
 // the switcher's options — marking the active one. A vendor with a `models` list
 // yields one entry per model, all sharing the same endpoint/key. Providers whose
 // API key isn't set are skipped: the switcher only offers models you can select.
+// The result is non-nil so it serializes as a JSON array, never null — the
+// frontend reads .length and maps over it directly (an empty list is the normal
+// "no keys configured yet" state, not an error).
 func (a *App) Models() []ModelInfo {
+	out := []ModelInfo{}
 	cfg, err := config.Load()
 	if err != nil {
-		return nil
+		return out
 	}
-	var out []ModelInfo
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
 		if !p.Configured() {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -579,11 +579,9 @@ type ModelInfo struct {
 
 // Models flattens the configured providers into their (provider, model) pairs —
 // the switcher's options — marking the active one. A vendor with a `models` list
-// yields one entry per model, all sharing the same endpoint/key. Providers whose
-// API key isn't set are skipped: the switcher only offers models you can select.
-// The result is non-nil so it serializes as a JSON array, never null — the
-// frontend reads .length and maps over it directly (an empty list is the normal
-// "no keys configured yet" state, not an error).
+// yields one entry per model, all sharing the same endpoint/key. Unconfigured
+// providers are skipped. Result is non-nil: the frontend reads .length, so a nil
+// slice (JSON null) would crash the switcher on an empty list.
 func (a *App) Models() []ModelInfo {
 	out := []ModelInfo{}
 	cfg, err := config.Load()

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -84,6 +84,9 @@ func (m *chatTUI) showModels() {
 	b.WriteString(dim("  · models (/model <provider/model> to switch)\n"))
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
 		for _, model := range p.ModelList() {
 			ref := p.Name + "/" + model
 			marker := "  "
@@ -105,6 +108,9 @@ func modelRefs() []string {
 	var out []string
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
 		for _, model := range p.ModelList() {
 			out = append(out, p.Name+"/"+model)
 		}

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -6,9 +6,14 @@ import (
 )
 
 // TestModelRefsFromConfig verifies the /model picker enumerates configured
-// provider/model refs (built-in defaults when no reasonix.toml is present).
+// provider/model refs (built-in defaults when no reasonix.toml is present), and
+// only those whose provider API key is set.
 func TestModelRefsFromConfig(t *testing.T) {
 	t.Chdir(t.TempDir()) // no reasonix.toml → built-in default providers
+	// The built-in providers split across two keys (DeepSeek, MiMo). With only
+	// DeepSeek set, the picker must list DeepSeek refs and omit the MiMo ones.
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("MIMO_API_KEY", "")
 	refs := modelRefs()
 	if len(refs) == 0 {
 		t.Fatal("expected default provider/model refs, got none")
@@ -17,6 +22,20 @@ func TestModelRefsFromConfig(t *testing.T) {
 		if !strings.Contains(r, "/") {
 			t.Errorf("ref %q should be provider/model", r)
 		}
+		if strings.HasPrefix(r, "mimo") {
+			t.Errorf("ref %q from a provider without an API key should be filtered out", r)
+		}
+	}
+}
+
+// TestModelRefsSkipsUnconfigured verifies that with no provider keys set, the
+// picker offers nothing rather than listing models the user can't select.
+func TestModelRefsSkipsUnconfigured(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	t.Setenv("MIMO_API_KEY", "")
+	if refs := modelRefs(); len(refs) != 0 {
+		t.Errorf("no keys set → no refs, got %v", refs)
 	}
 }
 
@@ -24,6 +43,7 @@ func TestModelRefsFromConfig(t *testing.T) {
 // through the shared completion path.
 func TestModelArgCompletion(t *testing.T) {
 	t.Chdir(t.TempDir())
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	m := newTestChatTUI()
 	items, _, ok := m.slashArgItems("/model ")
 	if !ok || len(items) == 0 {

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -10,8 +10,7 @@ import (
 // only those whose provider API key is set.
 func TestModelRefsFromConfig(t *testing.T) {
 	t.Chdir(t.TempDir()) // no reasonix.toml → built-in default providers
-	// The built-in providers split across two keys (DeepSeek, MiMo). With only
-	// DeepSeek set, the picker must list DeepSeek refs and omit the MiMo ones.
+	// Only DeepSeek keyed → MiMo refs must be filtered out.
 	t.Setenv("DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("MIMO_API_KEY", "")
 	refs := modelRefs()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -506,10 +506,8 @@ func (e *ProviderEntry) APIKey() string {
 	return os.Getenv(e.APIKeyEnv)
 }
 
-// Configured reports whether this provider's API key is set, i.e. its models can
-// actually be selected. It mirrors the key check in Validate, so a provider that
-// fails Configured would also fail Validate at build time — model pickers filter
-// on it to avoid listing models the user hasn't set up yet.
+// Configured reports whether the provider's api_key_env is set — the same check
+// Validate enforces, so pickers can filter on it.
 func (e *ProviderEntry) Configured() bool {
 	return e.APIKey() != ""
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -506,6 +506,14 @@ func (e *ProviderEntry) APIKey() string {
 	return os.Getenv(e.APIKeyEnv)
 }
 
+// Configured reports whether this provider's API key is set, i.e. its models can
+// actually be selected. It mirrors the key check in Validate, so a provider that
+// fails Configured would also fail Validate at build time — model pickers filter
+// on it to avoid listing models the user hasn't set up yet.
+func (e *ProviderEntry) Configured() bool {
+	return e.APIKey() != ""
+}
+
 // ResolveSystemPrompt returns the system prompt, reading system_prompt_file if set.
 func (c *Config) ResolveSystemPrompt() (string, error) {
 	if c.Agent.SystemPromptFile != "" {

--- a/internal/config/configured_test.go
+++ b/internal/config/configured_test.go
@@ -1,0 +1,27 @@
+package config
+
+import "testing"
+
+// TestProviderConfigured verifies Configured tracks whether the api_key_env
+// resolves to a non-empty value — the same key check Validate enforces at build
+// time, so model pickers can filter on it.
+func TestProviderConfigured(t *testing.T) {
+	t.Setenv("REASONIX_TEST_KEY", "secret")
+	t.Setenv("REASONIX_TEST_EMPTY", "")
+
+	cases := []struct {
+		name string
+		p    ProviderEntry
+		want bool
+	}{
+		{"key set", ProviderEntry{APIKeyEnv: "REASONIX_TEST_KEY"}, true},
+		{"key env empty", ProviderEntry{APIKeyEnv: "REASONIX_TEST_EMPTY"}, false},
+		{"key env unset", ProviderEntry{APIKeyEnv: "REASONIX_TEST_MISSING"}, false},
+		{"no api_key_env", ProviderEntry{}, false},
+	}
+	for _, c := range cases {
+		if got := c.p.Configured(); got != c.want {
+			t.Errorf("%s: Configured() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -192,6 +192,9 @@ func (c *Controller) modelListText() string {
 	fmt.Fprintf(&b, i18n.M.ListModelsHeaderFmt+"\n", c.label)
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
 		for _, m := range p.ModelList() {
 			fmt.Fprintf(&b, "  %s/%s\n", p.Name, m)
 		}


### PR DESCRIPTION
## Summary

Model pickers listed models from providers whose **API key isn't set**, and let you select them. This affected the desktop bottom-bar switcher, the CLI `/model` list and completion, and the shared `/model` notice. Selecting an unconfigured model wasn't caught up front — it only failed later at build time in `Config.Validate` (`missing env ...`).

Adding that filter on the desktop side then surfaced a latent frontend crash: with no provider keys set, opening the switcher blanked the whole window.

Fixes esengine/DeepSeek-Reasonix#2518.

## Root cause

All four enumeration points iterated `ProviderEntry.ModelList()` without checking whether the provider's API key was set:

- `desktop/app.go` `Models()` — the switcher
- `internal/control/slash.go` `modelListText()` — the desktop/HTTP `/model` notice
- `internal/cli/model.go` `showModels()` and `modelRefs()` — the CLI list and completion

The "is it configured" check already existed and was consistent across the code: `settings_app.go`'s `KeySet` and `config.go`'s `Validate()` both use `os.Getenv(apiKeyEnv) != ""`.

The desktop crash: `Models()` built its result with `var out []ModelInfo`, so an empty result was a nil slice that Wails serializes as JSON `null`. `ModelSwitcher.tsx` reads `models.length` directly, and `null.length` threw, crashing the React tree. The list was never empty before, so this stayed latent; filtering made the empty list reachable.

## Changes

- Add `ProviderEntry.Configured()` (mirrors `Validate`'s `api_key_env` check) as the single source of truth, and filter on it at every enumeration point, so the pickers offer only models the user can actually select.
- Return a non-nil slice from `Models()` on both paths, matching the existing "never null — the frontend filters over it directly" contract that `SlashArgs` and `Settings` already follow. An empty list now renders the "no models" empty state instead of crashing.

## Tests

- `TestProviderConfigured` — covers key-set / empty-env / unset-env / no-`api_key_env`.
- `TestModelRefsFromConfig` — updated to assert MiMo refs are filtered out when only `DEEPSEEK_API_KEY` is set.
- `TestModelRefsSkipsUnconfigured` — no keys set → no refs.
- `TestModelArgCompletion` — updated to set a key so completion still offers refs.

## Verification

- `go build ./...` (root + desktop modules): pass
- `go test ./...` for the affected packages: pass; `go vet`: clean
- Desktop, manual: switcher now filters by configured key, and the empty-list white-screen is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
