### PR TITLE
feat(cli): in-chat /resume to switch saved sessions live

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1838,6 +1838,8 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.commitLine("")
 		m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
 		m.notice(i18n.M.SlashNewDone)
+	case "/resume":
+		m.runResumeCommand(input)
 	case "/todo":
 		// Dismiss the pinned task list; a later todo_write brings it back.
 		m.todoArgs = ""

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -59,6 +59,7 @@ func (m *chatTUI) slashItems() []compItem {
 	items := []compItem{
 		{label: "/compact", insert: "/compact ", hint: i18n.M.CmdCompact},
 		{label: "/new", insert: "/new ", hint: i18n.M.CmdNew},
+		{label: "/resume", insert: "/resume ", hint: i18n.M.CmdResume},
 		{label: "/rewind", insert: "/rewind", hint: i18n.M.CmdRewind},
 		{label: "/tree", insert: "/tree", hint: i18n.M.CmdTree},
 		{label: "/branch", insert: "/branch ", hint: i18n.M.CmdBranch},
@@ -128,6 +129,9 @@ func (m *chatTUI) updateCompletion() {
 // so they yield nothing.
 func (m *chatTUI) slashArgItems(val string) ([]compItem, int, bool) {
 	if items, from, ok := m.branchArgItems(val); ok {
+		return items, from, len(items) > 0
+	}
+	if items, from, ok := m.resumeArgItems(val); ok {
 		return items, from, len(items) > 0
 	}
 	// Delegate to the shared completion logic so the chat TUI and the desktop

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -1,0 +1,123 @@
+package cli
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/i18n"
+)
+
+const resumeListCap = 10
+
+// recentSessions returns the newest saved sessions under dir, capped so the
+// 1-based indices the list shows match what /resume <n> and its completion
+// resolve. A missing dir or read error yields an empty list.
+func recentSessions(dir string) []agent.SessionInfo {
+	if dir == "" {
+		return nil
+	}
+	sessions, err := agent.ListSessions(dir)
+	if err != nil {
+		return nil
+	}
+	if len(sessions) > resumeListCap {
+		sessions = sessions[:resumeListCap]
+	}
+	return sessions
+}
+
+// runResumeCommand handles "/resume": with no argument it lists the most recent
+// saved sessions (newest first, active one marked); "/resume <n>" loads that
+// session into the running controller in place — keeping the current model and
+// replaying the transcript into scrollback.
+func (m *chatTUI) runResumeCommand(input string) {
+	sessions := recentSessions(m.ctrl.SessionDir())
+	if len(sessions) == 0 {
+		m.notice(i18n.M.NoSessionToResume)
+		return
+	}
+
+	args := tokenizeArgs(input) // args[0] == "/resume"
+	if len(args) < 2 {
+		m.showSessions(sessions)
+		return
+	}
+	if m.ctrl.Running() {
+		m.notice(i18n.M.ResumeBusy)
+		return
+	}
+	idx, err := strconv.Atoi(strings.TrimSpace(args[1]))
+	if err != nil || idx < 1 || idx > len(sessions) {
+		m.notice(fmt.Sprintf(i18n.M.ResumeBadIndexFmt, len(sessions)))
+		return
+	}
+	target := sessions[idx-1]
+	if target.Path == m.ctrl.SessionPath() {
+		m.notice(i18n.M.ResumeAlreadyActive)
+		return
+	}
+	loaded, err := agent.LoadSession(target.Path)
+	if err != nil {
+		m.notice("resume: " + err.Error())
+		return
+	}
+	// Persist the conversation we're leaving so switching back later restores it.
+	_ = m.ctrl.Snapshot()
+	m.ctrl.Resume(loaded, target.Path)
+	m.replayActiveBranch(i18n.M.ResumedTitle)
+}
+
+// showSessions renders the recent-session list with 1-based indices, timestamp,
+// turn count and preview, marking the one currently active.
+func (m *chatTUI) showSessions(sessions []agent.SessionInfo) {
+	active := m.ctrl.SessionPath()
+	var b strings.Builder
+	b.WriteString(dim("  · " + i18n.M.ResumeListHeader + "\n"))
+	for i, s := range sessions {
+		marker := "  "
+		if s.Path == active {
+			marker = accent("› ")
+		}
+		fmt.Fprintf(&b, "%s%d  %s  %s\n", marker, i+1,
+			s.ModTime.Local().Format("01-02 15:04"), dim(sessionSummary(s)))
+	}
+	m.notice(strings.TrimRight(b.String(), "\n"))
+}
+
+// resumeArgItems completes the index argument of "/resume <n>": once past the
+// command word it lists recent sessions, inserting the 1-based index and
+// showing timestamp + turn count + preview as the hint. Indices match
+// showSessions because both window through recentSessions.
+func (m *chatTUI) resumeArgItems(val string) ([]compItem, int, bool) {
+	cmdEnd := strings.IndexAny(val, " \t")
+	if cmdEnd < 0 || val[:cmdEnd] != "/resume" {
+		return nil, 0, false
+	}
+	from := strings.LastIndexAny(val, " \t") + 1
+	if len(strings.Fields(val[:from])) != 1 || m.ctrl == nil {
+		return nil, from, true
+	}
+	cur := val[from:]
+	var out []compItem
+	for i, s := range recentSessions(m.ctrl.SessionDir()) {
+		idx := strconv.Itoa(i + 1)
+		if cur != "" && !strings.HasPrefix(idx, cur) {
+			continue
+		}
+		hint := fmt.Sprintf("%s · %s", s.ModTime.Local().Format("01-02 15:04"), sessionSummary(s))
+		out = append(out, compItem{label: idx, insert: idx, hint: hint})
+	}
+	return out, from, true
+}
+
+// sessionSummary is the "N turns · first message" line shared by the /resume
+// list and its argument completion.
+func sessionSummary(s agent.SessionInfo) string {
+	preview := s.Preview
+	if preview == "" {
+		preview = "(no user message yet)"
+	}
+	return fmt.Sprintf("%d turns · %s", s.Turns, preview)
+}

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+func saveTestSession(t *testing.T, path, prompt string) {
+	t.Helper()
+	s := agent.NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: prompt})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestResumeArgCompletionListsSessions proves "/resume " opens an indexed menu
+// of the saved sessions, mirroring the /switch branch completion.
+func TestResumeArgCompletionListsSessions(t *testing.T) {
+	dir := t.TempDir()
+	saveTestSession(t, filepath.Join(dir, "a.jsonl"), "first")
+	saveTestSession(t, filepath.Join(dir, "b.jsonl"), "second")
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Executor: exec, SessionDir: dir, Label: "test"})
+
+	m.input.SetValue("/resume ")
+	m.updateCompletion()
+	if !m.completion.active || m.completion.kind != compSlashArg {
+		t.Fatalf("/resume should open argument completion: %+v", m.completion)
+	}
+	if got := labels(m.completion.items); len(got) != 2 || got[0] != "1" || got[1] != "2" {
+		t.Fatalf("resume completion = %v, want [1 2]", got)
+	}
+}
+
+// TestRunResumeSwitchesSession proves "/resume <n>" repoints the running
+// controller to the chosen saved session and loads its history.
+func TestRunResumeSwitchesSession(t *testing.T) {
+	dir := t.TempDir()
+
+	active := agent.NewSession("sys")
+	active.Add(provider.Message{Role: provider.RoleUser, Content: "active prompt"})
+	exec := agent.New(nil, nil, active, agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: exec, SessionDir: dir, Label: "test"})
+	activePath := filepath.Join(dir, "active.jsonl")
+	ctrl.SetSessionPath(activePath)
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	otherPath := filepath.Join(dir, "other.jsonl")
+	saveTestSession(t, otherPath, "other prompt")
+
+	m := newTestChatTUI()
+	m.width = 80
+	m.ctrl = ctrl
+
+	target := 0
+	for i, s := range recentSessions(dir) {
+		if s.Path == otherPath {
+			target = i + 1
+		}
+	}
+	if target == 0 {
+		t.Fatal("saved session not listed by recentSessions")
+	}
+
+	m.runResumeCommand("/resume " + strconv.Itoa(target))
+
+	if got := ctrl.SessionPath(); got != otherPath {
+		t.Fatalf("session path = %q, want %q", got, otherPath)
+	}
+	hist := ctrl.History()
+	if len(hist) == 0 || hist[len(hist)-1].Content != "other prompt" {
+		t.Fatalf("history not loaded from target: %+v", hist)
+	}
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -54,6 +54,13 @@ type Messages struct {
 	ResumeRequiresTTY string // shown when --resume runs piped instead of on a terminal
 	PickSessionLabel  string // header on the --resume picker
 
+	// in-chat /resume command
+	ResumeListHeader    string // header above the /resume session list
+	ResumeBusy          string // shown when /resume is used mid-turn
+	ResumeBadIndexFmt   string // shown when /resume gets an out-of-range index (one %d)
+	ResumeAlreadyActive string // shown when /resume targets the current session
+	ResumedTitle        string // banner title after a /resume switch
+
 	// chat TUI status line / approval banner.
 	ChatStatusThinkingFmt  string // "%s thinking… (%ds · <cancel hint>)" — %s = spinner, %d = elapsed s
 	ChatStatusIdle         string // shortcuts hint when idle
@@ -105,6 +112,7 @@ type Messages struct {
 	CmdTree         string // /tree
 	CmdBranch       string // /branch
 	CmdSwitchBranch string // /switch
+	CmdResume       string // /resume
 	CmdModel        string // /model
 	CmdMemory       string // /memory
 	CmdMcp          string // /mcp

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -30,6 +30,12 @@ var English = Messages{
 	ResumeRequiresTTY: "--resume needs an interactive terminal; pass --continue for the most recent session",
 	PickSessionLabel:  "Resume which session?",
 
+	ResumeListHeader:    "sessions (/resume <n> to switch)",
+	ResumeBusy:          "finish or cancel the current turn before resuming",
+	ResumeBadIndexFmt:   "pick a session 1–%d (run /resume to list)",
+	ResumeAlreadyActive: "already in that session",
+	ResumedTitle:        "resumed session",
+
 	ChatStatusThinkingFmt:  "%s thinking… (%ds · Esc cancels)",
 	ChatStatusIdle:         "Tab toggles plan · Enter sends · Esc clears/exits state · PgUp/PgDn scrolls · Ctrl-D quits",
 	ChatStatusPlanApproval: "Enter/y approves & executes · n/Esc keeps planning · PgUp/PgDn scrolls",
@@ -61,7 +67,7 @@ var English = Messages{
 	SlashUnavailable:   "command unavailable in this build",
 	SlashUnknown:       "unknown command",
 	SlashTodoCleared:   "task list dismissed",
-	SlashHelp:          "commands: /compact · /new · /rewind · /tree · /branch · /switch · /todo · /model (switch model) · /mcp · /skill · /hooks · /paste-image · /memory · /help · plus skills (/init, /explore, …)",
+	SlashHelp:          "commands: /compact · /new · /resume · /rewind · /tree · /branch · /switch · /todo · /model (switch model) · /mcp · /skill · /hooks · /paste-image · /memory · /help · plus skills (/init, /explore, …)",
 	SlashPromptEmpty:   "the MCP prompt returned no content to send",
 	SlashMCPNone:       "no MCP servers configured — add a [[plugins]] entry in reasonix.toml",
 	CompHintSlash:      "↑/↓ move · Tab/Enter select · Esc close",
@@ -73,6 +79,7 @@ var English = Messages{
 	CmdTree:         "show conversation branches",
 	CmdBranch:       "create a conversation branch",
 	CmdSwitchBranch: "switch conversation branch",
+	CmdResume:       "resume a saved session",
 	CmdModel:        "switch model",
 	CmdMemory:       "show memory files",
 	CmdMcp:          "MCP servers",
@@ -129,7 +136,7 @@ var English = Messages{
 	UsageBody: `reasonix — a config- and plugin-driven coding agent (multi-model)
 
 Usage:
-  reasonix chat [--model NAME]                          interactive session (multi-turn)
+  reasonix chat [--model NAME] [-c|--continue] [--resume]   interactive session (multi-turn; -c resumes the latest, --resume picks one)
   reasonix run  [--model NAME] [--max-steps N] <task>   run one task and exit
   reasonix serve [--model NAME] [--addr HOST:PORT]      serve the session over HTTP+SSE (browser client at /)
   reasonix setup [path]                                 interactive config wizard; writes reasonix.toml (+ .env)
@@ -139,6 +146,7 @@ Usage:
 
 Examples:
   reasonix chat
+  reasonix chat --continue
   reasonix run "implement the TODOs in main.go"
   reasonix run --model mimo-pro "add unit tests for this function"
   echo "explain this code" | reasonix run

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -31,6 +31,12 @@ var Chinese = Messages{
 	ResumeRequiresTTY: "--resume 需要交互式终端；用 --continue 直接恢复最近一次",
 	PickSessionLabel:  "恢复哪个会话？",
 
+	ResumeListHeader:    "会话（/resume <n> 切换）",
+	ResumeBusy:          "请先完成或取消当前这一轮再恢复会话",
+	ResumeBadIndexFmt:   "请选择 1–%d 的会话（用 /resume 查看列表）",
+	ResumeAlreadyActive: "已在该会话中",
+	ResumedTitle:        "已恢复会话",
+
 	ChatStatusThinkingFmt:  "%s 思考中… (%d 秒 · Esc 取消)",
 	ChatStatusIdle:         "Tab 切换 plan · Enter 发送 · Esc 退出当前状态 · PgUp/PgDn 滚动 · Ctrl-D 退出",
 	ChatStatusPlanApproval: "Enter/y 批准并执行 · n/Esc 继续规划 · PgUp/PgDn 滚动",
@@ -62,7 +68,7 @@ var Chinese = Messages{
 	SlashUnavailable:   "当前构建不支持该命令",
 	SlashUnknown:       "未知命令",
 	SlashTodoCleared:   "已清除任务清单",
-	SlashHelp:          "命令：/compact · /new · /rewind · /tree · /branch · /switch · /todo · /model（切换模型）· /mcp · /skill · /hooks · /paste-image · /memory · /help · 以及 skills（/init、/explore …）",
+	SlashHelp:          "命令：/compact · /new · /resume · /rewind · /tree · /branch · /switch · /todo · /model（切换模型）· /mcp · /skill · /hooks · /paste-image · /memory · /help · 以及 skills（/init、/explore …）",
 	SlashPromptEmpty:   "该 MCP prompt 没有返回可发送的内容",
 	SlashMCPNone:       "没有配置 MCP 服务器 — 在 reasonix.toml 加一个 [[plugins]] 条目",
 	CompHintSlash:      "↑/↓ 移动 · Tab/Enter 选中 · Esc 关闭",
@@ -74,6 +80,7 @@ var Chinese = Messages{
 	CmdTree:         "查看对话分支树",
 	CmdBranch:       "创建对话分支",
 	CmdSwitchBranch: "切换对话分支",
+	CmdResume:       "恢复已保存的会话",
 	CmdModel:        "切换模型",
 	CmdMemory:       "查看记忆文件",
 	CmdMcp:          "MCP 服务器",
@@ -130,7 +137,7 @@ var Chinese = Messages{
 	UsageBody: `reasonix — 由配置和插件驱动的 coding agent（多模型）
 
 用法：
-  reasonix chat [--model NAME]                          交互式会话（多轮）
+  reasonix chat [--model NAME] [-c|--continue] [--resume]   交互式会话（多轮；-c 恢复最近一次，--resume 选择一个）
   reasonix run  [--model NAME] [--max-steps N] <task>   执行单次任务后退出
   reasonix serve [--model NAME] [--addr HOST:PORT]      通过 HTTP+SSE 提供会话（浏览器客户端在 /）
   reasonix setup [path]                                 交互式配置向导；生成 reasonix.toml（及 .env）
@@ -140,6 +147,7 @@ var Chinese = Messages{
 
 示例：
   reasonix chat
+  reasonix chat --continue
   reasonix run "把 main.go 里的 TODO 实现掉"
   reasonix run --model mimo-pro "给这个函数补单元测试"
   echo "解释这段代码" | reasonix run


### PR DESCRIPTION
## What

Adds an in-chat `/resume` slash command so a saved conversation can be loaded mid-session, not just at launch.

- `/resume` — lists the most recent saved sessions (newest first, active one marked) with timestamp · turn count · first-message preview.
- `/resume <n>` — repoints the **running** controller to that session via `Controller.Resume`, keeping the current model and replaying the transcript into scrollback.
- Tab-completion after `/resume ` lists the sessions, mirroring the `/switch` branch completer.

## Why

Resume was launch-only (`chat --continue` / `--resume`). Once inside a session there was no way to jump to another saved conversation without quitting and relaunching.

## How

Reuses the existing session machinery rather than adding new surface:

- Switching goes through `Controller.Resume(loaded, path)` — swaps the executor's session and repoints auto-save in place, so no controller rebuild (unlike `/model`, which must rebuild because the model changes).
- Snapshots the current session before switching, so going back and forth never loses history.
- Redraw reuses `replayActiveBranch` (the same helper `/switch` uses).
- List and completion share `recentSessions()` so the indices line up; `/resume` is refused mid-turn (same guard as `/model`).

Also surfaces `--continue` / `--resume` in the `reasonix help` usage text, which never advertised them — the likely reason resume felt missing.

## Tests

- `TestResumeArgCompletionListsSessions` — `/resume ` opens an indexed menu of saved sessions.
- `TestRunResumeSwitchesSession` — `/resume <n>` repoints the controller and loads the target's history.

`go build ./...`, `go test ./internal/cli/ ./internal/i18n/` green (i18n parity test covers the new en/zh strings).
