### PR TITLE
fix(tool): make the shell tool work on Windows without bash

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -128,6 +128,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if bashSpec.Mode == "enforce" && !sandbox.Available() {
 		fmt.Fprintln(stderr, "warning: bash sandbox requested but unavailable on this platform; running bash unconfined")
 	}
+	if sandbox.ResolveShell().Kind == sandbox.ShellPowerShell {
+		fmt.Fprintln(stderr, "warning: bash not found on PATH; the shell tool will run commands under Windows PowerShell. Install Git for Windows or WSL to use bash.")
+	}
 	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRoots(), bashSpec, stderr)
 	// Always construct a host, even with no plugins configured, so the controller's
 	// host pointer is stable for the session and `/mcp add` can hot-add into it.

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -45,7 +45,7 @@ func TestSpecZeroValue(t *testing.T) {
 
 func TestCommandNonEnforce(t *testing.T) {
 	spec := Spec{Mode: "off"}
-	cmd, wrapped := Command(spec, "bash", "ls")
+	cmd, wrapped := Command(spec, Shell{Kind: ShellBash, Path: "bash"}, "ls")
 	if wrapped {
 		t.Error("non-enforce should not wrap")
 	}
@@ -56,12 +56,55 @@ func TestCommandNonEnforce(t *testing.T) {
 
 func TestCommandEmptyMode(t *testing.T) {
 	spec := Spec{}
-	cmd, wrapped := Command(spec, "sh", "echo hi")
+	cmd, wrapped := Command(spec, Shell{Kind: ShellBash, Path: "sh"}, "echo hi")
 	if wrapped {
 		t.Error("empty mode should not wrap")
 	}
 	if len(cmd) != 3 {
 		t.Errorf("cmd length = %d, want 3", len(cmd))
+	}
+}
+
+func TestCommandPowerShell(t *testing.T) {
+	cmd, wrapped := Command(Spec{Mode: "off"}, Shell{Kind: ShellPowerShell, Path: "powershell"}, "Get-ChildItem")
+	if wrapped {
+		t.Error("non-enforce should not wrap")
+	}
+	want := []string{"powershell", "-NoProfile", "-NonInteractive", "-Command", psUTF8Prologue + "Get-ChildItem"}
+	if len(cmd) != len(want) {
+		t.Fatalf("argv = %v, want %v", cmd, want)
+	}
+	for i := range want {
+		if cmd[i] != want[i] {
+			t.Fatalf("argv[%d] = %q, want %q", i, cmd[i], want[i])
+		}
+	}
+}
+
+func TestSupportsChaining(t *testing.T) {
+	cases := []struct {
+		sh   Shell
+		want bool
+	}{
+		{Shell{Kind: ShellBash, Path: "bash"}, true},
+		{Shell{Kind: ShellPowerShell, Path: `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`}, false},
+		{Shell{Kind: ShellPowerShell, Path: "powershell"}, false},
+		{Shell{Kind: ShellPowerShell, Path: `C:\Program Files\PowerShell\7\pwsh.exe`}, true},
+		{Shell{Kind: ShellPowerShell, Path: "pwsh"}, true},
+	}
+	for _, c := range cases {
+		if got := c.sh.SupportsChaining(); got != c.want {
+			t.Errorf("SupportsChaining(%+v) = %v, want %v", c.sh, got, c.want)
+		}
+	}
+}
+
+func TestShellArgvDefaultsPath(t *testing.T) {
+	if got := (Shell{Kind: ShellBash}).argv("ls"); got[0] != "bash" {
+		t.Errorf("empty bash path argv[0] = %q, want bash", got[0])
+	}
+	if got := (Shell{Kind: ShellPowerShell}).argv("ls"); got[0] != "powershell" {
+		t.Errorf("empty powershell path argv[0] = %q, want powershell", got[0])
 	}
 }
 
@@ -72,7 +115,7 @@ func TestCommandNonDarwin(t *testing.T) {
 		t.Skip("testing non-darwin path")
 	}
 	spec := Spec{Mode: "enforce", WriteRoots: []string{"/tmp"}}
-	cmd, wrapped := Command(spec, "sh", "echo hi")
+	cmd, wrapped := Command(spec, Shell{Kind: ShellBash, Path: "sh"}, "echo hi")
 	if wrapped {
 		t.Error("non-darwin should never wrap")
 	}
@@ -89,7 +132,7 @@ func TestCommandDarwinEnforce(t *testing.T) {
 		t.Skip("sandbox-exec not available")
 	}
 	spec := Spec{Mode: "enforce", WriteRoots: []string{"/workspace"}}
-	cmd, wrapped := Command(spec, "sh", "echo hi")
+	cmd, wrapped := Command(spec, Shell{Kind: ShellBash, Path: "sh"}, "echo hi")
 	if !wrapped {
 		t.Error("darwin enforce with sandbox-exec should wrap")
 	}
@@ -106,7 +149,7 @@ func TestCommandDarwinNonEnforce(t *testing.T) {
 		t.Skip("darwin-only test")
 	}
 	spec := Spec{Mode: "off", WriteRoots: []string{"/workspace"}}
-	_, wrapped := Command(spec, "sh", "echo hi")
+	_, wrapped := Command(spec, Shell{Kind: ShellBash, Path: "sh"}, "echo hi")
 	if wrapped {
 		t.Error("non-enforce should not wrap even on darwin")
 	}

--- a/internal/sandbox/seatbelt_darwin.go
+++ b/internal/sandbox/seatbelt_darwin.go
@@ -8,16 +8,16 @@ import (
 	"strings"
 )
 
-// Command returns the argv to run `command` through `shell -c`, wrapped in
-// sandbox-exec when the spec enforces and the tool is available. The second
-// return is whether wrapping happened; false means the command runs unconfined
-// (sandbox off, or sandbox-exec missing — a graceful fallback rather than a
-// hard failure, since the permission layer still gates the call).
-func Command(spec Spec, shell, command string) ([]string, bool) {
+// Command returns the argv to run `command` through sh, wrapped in sandbox-exec
+// when the spec enforces and the tool is available. The second return is whether
+// wrapping happened; false means the command runs unconfined (sandbox off, or
+// sandbox-exec missing — a graceful fallback rather than a hard failure, since
+// the permission layer still gates the call).
+func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 	if !spec.enforce() || !Available() {
-		return []string{shell, "-c", command}, false
+		return sh.argv(command), false
 	}
-	return []string{"sandbox-exec", "-p", seatbeltProfile(spec), shell, "-c", command}, true
+	return append([]string{"sandbox-exec", "-p", seatbeltProfile(spec)}, sh.argv(command)...), true
 }
 
 // Available reports whether sandbox-exec is on PATH (it ships with macOS).

--- a/internal/sandbox/seatbelt_darwin_test.go
+++ b/internal/sandbox/seatbelt_darwin_test.go
@@ -140,7 +140,7 @@ func TestSeatbeltProfileContainsRoots(t *testing.T) {
 }
 
 func TestCommandUnwrappedWhenOff(t *testing.T) {
-	argv, wrapped := Command(Spec{Mode: "off"}, "bash", "echo hi")
+	argv, wrapped := Command(Spec{Mode: "off"}, Shell{Kind: ShellBash, Path: "bash"}, "echo hi")
 	if wrapped {
 		t.Error("Mode=off should not wrap")
 	}
@@ -192,7 +192,7 @@ func TestSandboxEnforcesWrites(t *testing.T) {
 
 	spec := Spec{Mode: "enforce", WriteRoots: []string{workRoot}, Network: true}
 	run := func(command string) error {
-		argv, wrapped := Command(spec, "bash", command)
+		argv, wrapped := Command(spec, Shell{Kind: ShellBash, Path: "bash"}, command)
 		if !wrapped {
 			t.Fatalf("expected wrapping for command %q", command)
 		}
@@ -252,7 +252,7 @@ func TestGoBuildUnderSandbox(t *testing.T) {
 	write("main.go", "package main\nfunc main() { println(\"ok\") }\n")
 
 	spec := Spec{Mode: "enforce", WriteRoots: []string{work}, Network: true}
-	argv, _ := Command(spec, "bash", "cd "+work+" && go build -o sbtest .")
+	argv, _ := Command(spec, Shell{Kind: ShellBash, Path: "bash"}, "cd "+work+" && go build -o sbtest .")
 	if out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput(); err != nil {
 		t.Fatalf("go build under sandbox failed (profile too tight?): %v\n%s", err, out)
 	}

--- a/internal/sandbox/seatbelt_other.go
+++ b/internal/sandbox/seatbelt_other.go
@@ -13,17 +13,17 @@ import "os/exec"
 // macOS Seatbelt: writes confined to WriteRoots, network denied unless
 // spec.Network is true. When bwrap is unavailable the command runs unconfined
 // (boot and acp warn about this once at startup).
-func Command(spec Spec, shell, command string) ([]string, bool) {
+func Command(spec Spec, sh Shell, command string) ([]string, bool) {
 	if !spec.enforce() {
-		return []string{shell, "-c", command}, false
+		return sh.argv(command), false
 	}
 	if bwrap, err := exec.LookPath("bwrap"); err == nil {
-		argv := append([]string{bwrap}, bwrapArgs(spec, shell, command)...)
+		argv := append([]string{bwrap}, bwrapArgs(spec, sh, command)...)
 		return argv, true
 	}
 	// enforce requested but bwrap unavailable — boot/acp already warned at
 	// startup; fall back to unconfined (the false result signals "not sandboxed").
-	return []string{shell, "-c", command}, false
+	return sh.argv(command), false
 }
 
 // Available reports whether an OS sandbox is available on this platform.
@@ -37,7 +37,7 @@ func Available() bool {
 // shell command to the write roots, deny network unless allowed, and allow
 // read access to the whole filesystem (matching the macOS Seatbelt profile's
 // read-open policy).
-func bwrapArgs(spec Spec, shell, command string) []string {
+func bwrapArgs(spec Spec, sh Shell, command string) []string {
 	args := []string{
 		"--unshare-net", // deny network by default
 		"--ro-bind", "/", "/",
@@ -52,6 +52,5 @@ func bwrapArgs(spec Spec, shell, command string) []string {
 	for _, root := range spec.WriteRoots {
 		args = append(args, "--bind", root, root)
 	}
-	args = append(args, shell, "-c", command)
-	return args
+	return append(args, sh.argv(command)...)
 }

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -1,0 +1,103 @@
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// psUTF8Prologue forces PowerShell to emit UTF-8 instead of the host's OEM code
+// page (e.g. CP936 on a Chinese Windows), so non-ASCII command output and error
+// text come back as valid UTF-8 rather than mojibake.
+const psUTF8Prologue = "$OutputEncoding=[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;"
+
+// ShellKind is the interpreter a shell command runs under.
+type ShellKind int
+
+const (
+	ShellBash ShellKind = iota
+	ShellPowerShell
+)
+
+func (k ShellKind) String() string {
+	if k == ShellPowerShell {
+		return "powershell"
+	}
+	return "bash"
+}
+
+// Shell is the resolved interpreter the bash tool executes commands with: a kind
+// (so callers can adapt prompts) and the executable to invoke.
+type Shell struct {
+	Kind ShellKind
+	Path string
+}
+
+// ResolveShell picks the interpreter the shell tool runs commands under. It
+// prefers a real bash so the model's POSIX habits work; on Windows, where bash
+// is usually absent from PATH, it probes the Git-for-Windows install locations
+// and only then falls back to PowerShell so the tool still functions.
+func ResolveShell() Shell {
+	if p, err := exec.LookPath("bash"); err == nil {
+		return Shell{Kind: ShellBash, Path: p}
+	}
+	if runtime.GOOS == "windows" {
+		for _, p := range windowsBashCandidates() {
+			if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+				return Shell{Kind: ShellBash, Path: p}
+			}
+		}
+		for _, name := range []string{"pwsh", "powershell"} {
+			if p, err := exec.LookPath(name); err == nil {
+				return Shell{Kind: ShellPowerShell, Path: p}
+			}
+		}
+	}
+	return Shell{Kind: ShellBash, Path: "bash"}
+}
+
+// windowsBashCandidates lists the bash.exe paths a Git-for-Windows install
+// ships, across the usual program-files roots and a per-user install.
+func windowsBashCandidates() []string {
+	var roots []string
+	for _, env := range []string{"ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"} {
+		if v := os.Getenv(env); v != "" {
+			roots = append(roots, v)
+		}
+	}
+	if v := os.Getenv("LOCALAPPDATA"); v != "" {
+		roots = append(roots, filepath.Join(v, "Programs"))
+	}
+	var out []string
+	for _, r := range roots {
+		out = append(out,
+			filepath.Join(r, "Git", "bin", "bash.exe"),
+			filepath.Join(r, "Git", "usr", "bin", "bash.exe"),
+		)
+	}
+	return out
+}
+
+// argv builds the exec argv that runs command under this shell.
+func (s Shell) argv(command string) []string {
+	path := s.Path
+	if path == "" {
+		path = s.Kind.String()
+	}
+	if s.Kind == ShellPowerShell {
+		return []string{path, "-NoProfile", "-NonInteractive", "-Command", psUTF8Prologue + command}
+	}
+	return []string{path, "-c", command}
+}
+
+// SupportsChaining reports whether the shell parses '&&' / '||'. bash does;
+// Windows PowerShell 5.1 (powershell.exe) does not — only PowerShell 7+ (pwsh).
+func (s Shell) SupportsChaining() bool {
+	if s.Kind != ShellPowerShell {
+		return true
+	}
+	base := strings.ToLower(filepath.Base(s.Path))
+	return base == "pwsh" || base == "pwsh.exe"
+}

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -21,17 +21,35 @@ func init() { tool.RegisterBuiltin(bash{}) }
 
 // bash runs a shell command with a timeout to avoid hangs. sb, when it enforces,
 // wraps the command in an OS sandbox; the zero value registered at init runs
-// unconfined and is overridden per run by ConfineBash. workDir, when non-empty,
-// is the directory the command runs in (cmd.Dir); empty uses the process cwd.
+// unconfined and is overridden per run by ConfineBash. shell is the resolved
+// interpreter (real bash, or PowerShell on a Windows host without bash); the
+// zero value resolves lazily. workDir, when non-empty, is the directory the
+// command runs in (cmd.Dir); empty uses the process cwd.
 type bash struct {
 	sb      sandbox.Spec
+	shell   sandbox.Shell
 	workDir string
 }
 
 func (bash) Name() string { return "bash" }
 
-func (bash) Description() string {
+func (b bash) Description() string {
+	if b.resolved().Kind == sandbox.ShellPowerShell {
+		return "Execute a command in the shell and return combined stdout/stderr. " +
+			"NOTE: bash is not available on this host — commands run under Windows PowerShell, " +
+			"so write PowerShell syntax (e.g. $null not /dev/null; ';' or separate calls, not '&&'; " +
+			"Get-ChildItem/Select-String, not ls/grep). Use for builds, tests, git, etc."
+	}
 	return "Execute a command in the shell and return combined stdout/stderr. Use for builds, tests, git, etc."
+}
+
+// resolved returns the bound shell, resolving lazily for the zero-value instance
+// (e.g. a registry that never went through ConfineBash).
+func (b bash) resolved() sandbox.Shell {
+	if b.shell.Path != "" {
+		return b.shell
+	}
+	return sandbox.ResolveShell()
 }
 
 func (bash) Schema() json.RawMessage {
@@ -55,8 +73,15 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		return "", fmt.Errorf("command is required")
 	}
 
-	// Wrap in the OS sandbox when configured; otherwise argv is just bash -c.
-	argv, _ := sandbox.Command(b.sb, "bash", p.Command)
+	sh := b.resolved()
+	if !sh.SupportsChaining() && (hasUnquotedSeq(p.Command, "&&") || hasUnquotedSeq(p.Command, "||")) {
+		return "", fmt.Errorf("this shell is Windows PowerShell, which does not parse '&&' or '||'. " +
+			"Sequence with ';' (both run regardless of the first's result), use 'if ($?) { ... }' for " +
+			"conditional chaining, or issue the commands as separate calls")
+	}
+
+	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
+	argv, _ := sandbox.Command(b.sb, sh, p.Command)
 
 	if p.RunInBackground {
 		jm, ok := jobs.FromContext(ctx)
@@ -95,6 +120,30 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		return out, fmt.Errorf("command exited: %w", err)
 	}
 	return out, nil
+}
+
+// hasUnquotedSeq reports whether seq appears in s outside any single- or
+// double-quoted span, so a literal "a && b" string argument doesn't trip the
+// PowerShell chaining guard.
+func hasUnquotedSeq(s, seq string) bool {
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' {
+			quote = c
+			continue
+		}
+		if strings.HasPrefix(s[i:], seq) {
+			return true
+		}
+	}
+	return false
 }
 
 // commandPreview is a short single-line label for a background bash job, surfaced

--- a/internal/tool/builtin/bash_powershell_test.go
+++ b/internal/tool/builtin/bash_powershell_test.go
@@ -1,0 +1,113 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"reasonix/internal/sandbox"
+)
+
+func powershellPath(t *testing.T) string {
+	t.Helper()
+	for _, n := range []string{"pwsh", "powershell"} {
+		if p, err := exec.LookPath(n); err == nil {
+			return p
+		}
+	}
+	t.Skip("no PowerShell on PATH")
+	return ""
+}
+
+func runPS(t *testing.T, command string) (string, error) {
+	t.Helper()
+	b := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: powershellPath(t)}}
+	args, _ := json.Marshal(map[string]string{"command": command})
+	return b.Execute(context.Background(), args)
+}
+
+func TestBashPowerShellRunsNativeCommand(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	out, err := runPS(t, "Write-Output reasonix-ok")
+	if err != nil {
+		t.Fatalf("powershell command failed: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "reasonix-ok") {
+		t.Fatalf("output = %q, want it to contain reasonix-ok", out)
+	}
+}
+
+func TestBashPowerShellSurfacesNonZeroExit(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	if _, err := runPS(t, "exit 3"); err == nil {
+		t.Fatal("non-zero exit should surface as an error")
+	}
+}
+
+func TestBashPowerShellRejectsChaining(t *testing.T) {
+	b := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "powershell"}}
+	for _, cmd := range []string{"echo a && echo b", "echo a || echo b"} {
+		args, _ := json.Marshal(map[string]string{"command": cmd})
+		out, err := b.Execute(context.Background(), args)
+		if err == nil {
+			t.Errorf("%q should be rejected on powershell, got out=%q", cmd, out)
+		} else if !strings.Contains(err.Error(), "PowerShell") {
+			t.Errorf("%q error should explain PowerShell, got %v", cmd, err)
+		}
+	}
+}
+
+func TestBashPowerShellAllowsQuotedOperator(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("runs a real powershell command")
+	}
+	// "&&" inside a string literal is data, not chaining — must not be rejected.
+	out, err := runPS(t, `Write-Output "a && b"`)
+	if err != nil {
+		t.Fatalf("quoted && should run: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "a && b") {
+		t.Fatalf("output = %q", out)
+	}
+}
+
+func TestBashPwshAllowsChaining(t *testing.T) {
+	// pwsh (PowerShell 7+) parses && — the guard must not block it.
+	b := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "pwsh"}}
+	args, _ := json.Marshal(map[string]string{"command": "echo a && echo b"})
+	_, err := b.Execute(context.Background(), args)
+	if err != nil && strings.Contains(err.Error(), "does not parse") {
+		t.Errorf("pwsh should not be blocked by the chaining guard: %v", err)
+	}
+}
+
+func TestBashPowerShellOutputIsUTF8(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("powershell e2e is windows-only")
+	}
+	out, err := runPS(t, "Write-Output 'AB-中文-CD'")
+	if err != nil {
+		t.Fatalf("command failed: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "中文") {
+		t.Fatalf("non-ASCII output mojibake — got %q (want it to contain 中文)", out)
+	}
+}
+
+func TestBashDescriptionReflectsShell(t *testing.T) {
+	ps := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "powershell"}}
+	if !strings.Contains(ps.Description(), "PowerShell") {
+		t.Errorf("powershell description should warn about PowerShell: %q", ps.Description())
+	}
+	sh := bash{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "bash"}}
+	if strings.Contains(sh.Description(), "PowerShell") {
+		t.Errorf("bash description should not mention PowerShell: %q", sh.Description())
+	}
+}

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -12,7 +12,9 @@ import (
 // ConfineBash returns the bash built-in bound to an OS-sandbox spec, overriding
 // the unconfined instance registered at init. When the spec enforces, bash runs
 // each command through the sandbox (see package sandbox).
-func ConfineBash(spec sandbox.Spec) tool.Tool { return bash{sb: spec} }
+func ConfineBash(spec sandbox.Spec) tool.Tool {
+	return bash{sb: spec, shell: sandbox.ResolveShell()}
+}
 
 // ConfineWriters returns the file-writing built-ins (write_file, edit_file,
 // multi_edit, notebook_edit) bound to roots — the only directories they may


### PR DESCRIPTION
## Problem

A Windows user reported the agent had no bash. Root cause: the shell tool ran a literal `bash` via `exec`, and stock Windows has no `bash` on PATH (even Git for Windows doesn't add it). Every call failed with `exec: "bash": executable file not found`, so the model concluded it had no shell and told users to run elsewhere. There was no warning that the *interpreter* was missing — only a sandbox-availability warning.

## Fix

Resolve the shell instead of hard-coding `bash`:

- `sandbox.ResolveShell()` prefers a real bash (so POSIX habits work), probing the Git-for-Windows install locations when `bash` isn't on PATH. Only when no bash exists does it fall back to PowerShell, so the tool still functions on a bare Windows box. Real toolchain exes (`go`, `git`, `npm`, …) work identically either way.

Two **structural** guarantees for the PowerShell path (code-enforced, not prompt guidance), both verified end-to-end on Windows PowerShell 5.1:

- **`&&` / `||` guard** — these are hard parse errors on PowerShell 5.1. The tool rejects them (outside quotes) before exec with an actionable message (`use ';'`, `if ($?) { ... }`, or separate calls) instead of the cryptic `At line:1 char:12`. `pwsh` 7, which supports them, is not blocked; a `&&` inside a quoted string is treated as data.
- **UTF-8 output** — PowerShell emitted output/errors in the host OEM code page (CP936 here), which came back as mojibake under UTF-8. The tool now forces `[Console]::OutputEncoding = UTF-8`, verified: `余额: ¥3.50 中文OK` round-trips intact.

The `bash` tool's description reflects the resolved shell (warns it's PowerShell + lists syntax differences), and `boot` warns once at startup when falling back, pointing the user to install Git for Windows / WSL.

## Verification

End-to-end through the real tool on Windows (PowerShell 5.1):

| Command | Result |
|---|---|
| `echo build && go version` | rejected with structural error explaining `&&` |
| `git log -1` | runs, output clean |
| `Write-Output '余额: ¥3.50 中文OK'` | `余额: ¥3.50 中文OK` (was mojibake) |

Tests: PowerShell e2e (native command, non-zero exit, UTF-8 output, chaining guard, quoted-operator allowed, pwsh not blocked), `SupportsChaining` table, description-reflects-shell, plus updated `sandbox.Command(Shell, …)` call sites. `go build ./...`, `go vet ./...`, `go test ./...` all green.

## Scope note

Non-ASCII mojibake also affects native Windows exes run *under bash* (e.g. localized git output); that broader console-codepage decoding is left as a follow-up — this PR fixes the PowerShell path that the report surfaced.
