### PR TITLE
test(sandbox): cover no-bash → PowerShell fallback deterministically

### DIFF
--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,6 +1,7 @@
 package sandbox
 
 import (
+	"os/exec"
 	"runtime"
 	"testing"
 )
@@ -77,6 +78,41 @@ func TestCommandPowerShell(t *testing.T) {
 	for i := range want {
 		if cmd[i] != want[i] {
 			t.Fatalf("argv[%d] = %q, want %q", i, cmd[i], want[i])
+		}
+	}
+}
+
+func TestResolveShellDecisionTable(t *testing.T) {
+	onPath := func(names ...string) func(string) (string, error) {
+		set := map[string]bool{}
+		for _, n := range names {
+			set[n] = true
+		}
+		return func(name string) (string, error) {
+			if set[name] {
+				return `C:\fake\` + name + ".exe", nil
+			}
+			return "", exec.ErrNotFound
+		}
+	}
+	cases := []struct {
+		name     string
+		goos     string
+		lookPath func(string) (string, error)
+		exists   func(string) bool
+		wantKind ShellKind
+	}{
+		{"bash on PATH wins", "windows", onPath("bash", "powershell"), func(string) bool { return false }, ShellBash},
+		{"no bash, git-bash on disk", "windows", onPath("powershell"), func(string) bool { return true }, ShellBash},
+		{"no bash anywhere, pwsh", "windows", onPath("pwsh", "powershell"), func(string) bool { return false }, ShellPowerShell},
+		{"no bash, only powershell", "windows", onPath("powershell"), func(string) bool { return false }, ShellPowerShell},
+		{"windows, nothing found", "windows", onPath(), func(string) bool { return false }, ShellBash},
+		{"linux, no bash → no PS fallback", "linux", onPath("powershell"), func(string) bool { return true }, ShellBash},
+	}
+	for _, c := range cases {
+		got := resolveShell(c.goos, c.lookPath, c.exists)
+		if got.Kind != c.wantKind {
+			t.Errorf("%s: kind = %s, want %s (path=%s)", c.name, got.Kind, c.wantKind, got.Path)
 		}
 	}
 }

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -40,22 +40,34 @@ type Shell struct {
 // is usually absent from PATH, it probes the Git-for-Windows install locations
 // and only then falls back to PowerShell so the tool still functions.
 func ResolveShell() Shell {
-	if p, err := exec.LookPath("bash"); err == nil {
+	return resolveShell(runtime.GOOS, exec.LookPath, fileExists)
+}
+
+// resolveShell is ResolveShell with its environment lookups injected, so the
+// decision table — including the no-bash PowerShell fallback that can't be
+// triggered on a host that has bash installed — is deterministically testable.
+func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool) Shell {
+	if p, err := lookPath("bash"); err == nil {
 		return Shell{Kind: ShellBash, Path: p}
 	}
-	if runtime.GOOS == "windows" {
+	if goos == "windows" {
 		for _, p := range windowsBashCandidates() {
-			if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			if exists(p) {
 				return Shell{Kind: ShellBash, Path: p}
 			}
 		}
 		for _, name := range []string{"pwsh", "powershell"} {
-			if p, err := exec.LookPath(name); err == nil {
+			if p, err := lookPath(name); err == nil {
 				return Shell{Kind: ShellPowerShell, Path: p}
 			}
 		}
 	}
 	return Shell{Kind: ShellBash, Path: "bash"}
+}
+
+func fileExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir()
 }
 
 // windowsBashCandidates lists the bash.exe paths a Git-for-Windows install


### PR DESCRIPTION
Follow-up to #2532. The PowerShell fallback only fires when no bash exists anywhere — unreachable on a host with Git for Windows installed, so it was the one branch left unverified at runtime. Inject the env lookups into `resolveShell` and assert the full decision table (bash-on-PATH, git-bash-on-disk, pwsh-only, powershell-only, nothing-found, and linux-no-PS-fallback).

`go test ./internal/sandbox/` green.