### PR TITLE
fix(sandbox): make shell-resolution tests host-independent

### DIFF
--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -95,22 +95,26 @@ func TestResolveShellDecisionTable(t *testing.T) {
 			return "", exec.ErrNotFound
 		}
 	}
+	gitBash := []string{`C:\fake\Git\bin\bash.exe`}
+	always := func(string) bool { return true }
+	never := func(string) bool { return false }
 	cases := []struct {
-		name     string
-		goos     string
-		lookPath func(string) (string, error)
-		exists   func(string) bool
-		wantKind ShellKind
+		name       string
+		goos       string
+		lookPath   func(string) (string, error)
+		candidates []string
+		exists     func(string) bool
+		wantKind   ShellKind
 	}{
-		{"bash on PATH wins", "windows", onPath("bash", "powershell"), func(string) bool { return false }, ShellBash},
-		{"no bash, git-bash on disk", "windows", onPath("powershell"), func(string) bool { return true }, ShellBash},
-		{"no bash anywhere, pwsh", "windows", onPath("pwsh", "powershell"), func(string) bool { return false }, ShellPowerShell},
-		{"no bash, only powershell", "windows", onPath("powershell"), func(string) bool { return false }, ShellPowerShell},
-		{"windows, nothing found", "windows", onPath(), func(string) bool { return false }, ShellBash},
-		{"linux, no bash → no PS fallback", "linux", onPath("powershell"), func(string) bool { return true }, ShellBash},
+		{"bash on PATH wins", "windows", onPath("bash", "powershell"), gitBash, never, ShellBash},
+		{"no bash, git-bash on disk", "windows", onPath("powershell"), gitBash, always, ShellBash},
+		{"no bash anywhere, pwsh", "windows", onPath("pwsh", "powershell"), gitBash, never, ShellPowerShell},
+		{"no bash, only powershell", "windows", onPath("powershell"), gitBash, never, ShellPowerShell},
+		{"windows, nothing found", "windows", onPath(), nil, never, ShellBash},
+		{"linux, no bash → no PS fallback", "linux", onPath("powershell"), gitBash, always, ShellBash},
 	}
 	for _, c := range cases {
-		got := resolveShell(c.goos, c.lookPath, c.exists)
+		got := resolveShell(c.goos, c.lookPath, c.exists, c.candidates)
 		if got.Kind != c.wantKind {
 			t.Errorf("%s: kind = %s, want %s (path=%s)", c.name, got.Kind, c.wantKind, got.Path)
 		}

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -40,18 +40,19 @@ type Shell struct {
 // is usually absent from PATH, it probes the Git-for-Windows install locations
 // and only then falls back to PowerShell so the tool still functions.
 func ResolveShell() Shell {
-	return resolveShell(runtime.GOOS, exec.LookPath, fileExists)
+	return resolveShell(runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates())
 }
 
-// resolveShell is ResolveShell with its environment lookups injected, so the
-// decision table — including the no-bash PowerShell fallback that can't be
-// triggered on a host that has bash installed — is deterministically testable.
-func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool) Shell {
+// resolveShell is ResolveShell with its environment lookups injected — including
+// the Git-for-Windows bash candidates, which derive from %ProgramFiles% and so
+// are empty off Windows — so the decision table is deterministically testable on
+// any host.
+func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string) Shell {
 	if p, err := lookPath("bash"); err == nil {
 		return Shell{Kind: ShellBash, Path: p}
 	}
 	if goos == "windows" {
-		for _, p := range windowsBashCandidates() {
+		for _, p := range winBashCandidates {
 			if exists(p) {
 				return Shell{Kind: ShellBash, Path: p}
 			}
@@ -110,6 +111,9 @@ func (s Shell) SupportsChaining() bool {
 	if s.Kind != ShellPowerShell {
 		return true
 	}
-	base := strings.ToLower(filepath.Base(s.Path))
+	base := strings.ToLower(s.Path)
+	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
+		base = base[i+1:] // Windows path; split on either separator off-Windows too
+	}
 	return base == "pwsh" || base == "pwsh.exe"
 }


### PR DESCRIPTION
## Summary

The sandbox `test` job has been red on `ubuntu-latest` / `macos-latest` since #2532/#2533, taking every open PR's CI down with it (the `pull_request` checks test each PR merged into main-v2).

Two decision-table tests were exercising real-OS primitives that only behave correctly on Windows:

- `TestResolveShellDecisionTable` — `resolveShell` walked `windowsBashCandidates()`, which derives its roots from `%ProgramFiles%` etc. Those env vars are empty off Windows, so the candidate list was empty and the injected `exists` probe was never reached — the "git-bash on disk" case fell through to PowerShell.
- `TestSupportsChaining` — `SupportsChaining` used `filepath.Base` on a backslash path, which doesn't split on non-Windows, so `...\pwsh.exe` never matched.

## Fix

- `resolveShell` takes the Windows bash candidates as a parameter; `ResolveShell` passes `windowsBashCandidates()`, the test injects a fixed list. No real env in the tested path.
- `SupportsChaining` splits the base on either separator (`strings.LastIndexAny`), so a Windows path resolves the same on any host.

Both tables are now deterministic regardless of the runner OS. `go test ./internal/sandbox/` passes.