### PR TITLE
feat(plan): layered two-level plans (phases → sub-steps)

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1284,6 +1284,7 @@ func (m chatTUI) renderTodoPanel() string {
 			Content    string `json:"content"`
 			Status     string `json:"status"`
 			ActiveForm string `json:"activeForm"`
+			Level      int    `json:"level"`
 		} `json:"todos"`
 	}
 	if err := json.Unmarshal([]byte(m.todoArgs), &p); err != nil || len(p.Todos) == 0 {
@@ -1308,17 +1309,21 @@ func (m chatTUI) renderTodoPanel() string {
 			break
 		}
 		shown++
+		indent := "  "
+		if t.Level >= 1 {
+			indent = "      " // sub-steps sit under their phase
+		}
 		switch t.Status {
 		case "completed":
-			b.WriteString("  " + green("✔") + " " + dim(t.Content) + "\n")
+			b.WriteString(indent + green("✔") + " " + dim(t.Content) + "\n")
 		case "in_progress":
 			label := t.Content
 			if t.ActiveForm != "" {
 				label = t.ActiveForm
 			}
-			b.WriteString("  " + yellow("▶ "+label) + "\n")
+			b.WriteString(indent + yellow("▶ "+label) + "\n")
 		default:
-			b.WriteString("  " + dim("○ "+t.Content) + "\n")
+			b.WriteString(indent + dim("○ "+t.Content) + "\n")
 		}
 	}
 	return todoPanelStyle.Width(max(m.width, 10)).Render(strings.TrimRight(b.String(), "\n"))

--- a/internal/cli/todopanel_test.go
+++ b/internal/cli/todopanel_test.go
@@ -1,0 +1,26 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// TestRenderTodoPanelNesting proves a level-1 sub-step renders indented under
+// its level-0 phase in the pinned task panel.
+func TestRenderTodoPanelNesting(t *testing.T) {
+	m := newTestChatTUI()
+	m.width = 60
+	m.todoArgs = `{"todos":[` +
+		`{"content":"Phase A","status":"in_progress","level":0},` +
+		`{"content":"sub one","status":"pending","level":1}]}`
+
+	out := ansi.Strip(m.renderTodoPanel())
+	if !strings.Contains(out, "Phase A") {
+		t.Fatalf("panel missing phase:\n%s", out)
+	}
+	if !strings.Contains(out, "      ○ sub one") {
+		t.Fatalf("sub-step not indented under its phase:\n%s", out)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -293,7 +293,7 @@ const planApprovalTool = "exit_plan_mode"
 
 // planApprovedMessage is the follow-up turn sent once the user approves a plan —
 // the in-context nudge to execute and keep the (already-seeded) task list honest.
-const planApprovedMessage = "Plan approved — plan mode is off; you're cleared to make the changes without asking again. Implement the plan now. Keep the task list current with todo_write (mark the step you start as in_progress; one in_progress at a time), and sign off each finished step with complete_step, attaching the evidence it's done — the verification you ran, the diff/files you changed, or a manual check. Don't claim a step is done without evidence."
+const planApprovedMessage = "Plan approved — plan mode is off; you're cleared to make the changes without asking again. Implement the plan now. Keep the task list current with todo_write, preserving its two-level shape (phases at level 0, their sub-steps at level 1): mark the sub-step you start as in_progress, one in_progress at a time. Sign off each finished sub-step with complete_step, attaching the evidence it's done — the verification you ran, the diff/files you changed, or a manual check. Don't claim a step is done without evidence."
 
 // runTurn runs one model turn, then applies the plan-approval gate. This is the
 // single, frontend-agnostic plan flow: in plan mode the model just researches
@@ -1295,6 +1295,7 @@ func (g gateApprover) Approve(ctx context.Context, tool, subject string, args js
 type seedTodo struct {
 	Content string `json:"content"`
 	Status  string `json:"status"`
+	Level   int    `json:"level,omitempty"`
 }
 
 // seedPlanTodos turns an approved plan into a starter task list and emits it as a
@@ -1341,15 +1342,15 @@ func PlanTodosJSON(plan string) string {
 func parsePlanTodos(plan string) []seedTodo {
 	var todos []seedTodo
 	for _, raw := range strings.Split(plan, "\n") {
-		item := listItemContent(raw)
-		if item == "" {
+		item, level, ok := listItem(raw)
+		if !ok {
 			continue
 		}
 		status := "pending"
 		if len(todos) == 0 {
 			status = "in_progress"
 		}
-		todos = append(todos, seedTodo{Content: item, Status: status})
+		todos = append(todos, seedTodo{Content: item, Status: status, Level: level})
 		if len(todos) >= 20 {
 			break
 		}
@@ -1357,14 +1358,25 @@ func parsePlanTodos(plan string) []seedTodo {
 	return todos
 }
 
-// listItemContent returns the task text of a markdown list line ("- x", "* x",
-// "1. x", "2) x"), or "" if the line isn't a list item. Light inline-markdown
+// listItem parses a markdown list line ("- x", "* x", "1. x", "2) x") into its
+// task text and a nesting level derived from leading indentation (0 for a
+// top-level item, 1 for an indented sub-step — capped at 1 since the plan is
+// two-level). ok is false when the line isn't a list item. Light inline-markdown
 // stripping keeps the checklist readable.
-func listItemContent(line string) string {
-	s := strings.TrimSpace(line)
-	if s == "" {
-		return ""
+func listItem(line string) (content string, level int, ok bool) {
+	trimmed := strings.TrimLeft(line, " \t")
+	if trimmed == "" {
+		return "", 0, false
 	}
+	indent := 0
+	for _, c := range line[:len(line)-len(trimmed)] {
+		if c == '\t' {
+			indent += 4
+		} else {
+			indent++
+		}
+	}
+	s := trimmed
 	switch {
 	case strings.HasPrefix(s, "- "), strings.HasPrefix(s, "* "), strings.HasPrefix(s, "+ "):
 		s = s[2:]
@@ -1375,7 +1387,7 @@ func listItemContent(line string) string {
 			i++
 		}
 		if i == 0 || i+1 >= len(s) || (s[i] != '.' && s[i] != ')') || s[i+1] != ' ' {
-			return ""
+			return "", 0, false
 		}
 		s = s[i+2:]
 	}
@@ -1384,7 +1396,14 @@ func listItemContent(line string) string {
 	s = strings.TrimPrefix(s, "[x] ")
 	s = strings.ReplaceAll(s, "`", "")
 	s = strings.ReplaceAll(s, "**", "")
-	return strings.TrimSpace(s)
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", 0, false
+	}
+	if indent >= 2 {
+		return s, 1, true
+	}
+	return s, 0, true
 }
 
 // requestApproval emits an ApprovalRequest and blocks until Approve(ID, …)

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -10,7 +10,7 @@ import (
 // PlanModeMarker is prepended to every user turn while plan mode is on. It rides
 // in the user message (not the system prompt or tools), so the cache-stable
 // prompt prefix is left untouched and the toggle costs nothing in cache hits.
-const PlanModeMarker = "[Plan mode — read-only. Explore and propose; do not write files, edit, or run side-effecting bash. Read-only tools (read_file, ls, grep, glob, web_fetch, task) are available; writers are refused by the harness. When you have a concrete plan, present it as your reply and stop — write the steps as a markdown numbered list (one concrete step per item) so they become the task list. The user will be asked to approve before any changes are made.]"
+const PlanModeMarker = "[Plan mode — read-only. Explore the codebase first (read_file, ls, grep, glob, web_fetch, task are available; writers are refused by the harness), then present a LAYERED plan as your reply and stop — do not write files, edit, or run side-effecting bash. Structure the plan as a two-level markdown list so it becomes a layered task list: each top-level numbered item is a PHASE (a coherent milestone, e.g. \"1. Add the config loader\"), optionally followed by a one-line rationale; under each phase, indent the concrete, verifiable sub-steps as bullets (e.g. \"   - parse the TOML into Config\"). Keep phases few (about 2-6) and sub-steps concrete. The user will be asked to approve before any changes are made.]"
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,
 // returning the message to actually send to the model. The frontend keeps

--- a/internal/control/plan_seed_test.go
+++ b/internal/control/plan_seed_test.go
@@ -52,6 +52,25 @@ func TestParsePlanTodos(t *testing.T) {
 			plan: "Version 2 is the target.\n- Real item",
 			want: []seedTodo{{Content: "Real item", Status: "in_progress"}},
 		},
+		{
+			name: "two-level plan: phases at level 0, indented sub-steps at level 1",
+			plan: "1. Add the loader\n   - parse the TOML\n   - validate fields\n2. Wire it up\n  - call from boot",
+			want: []seedTodo{
+				{Content: "Add the loader", Status: "in_progress", Level: 0},
+				{Content: "parse the TOML", Status: "pending", Level: 1},
+				{Content: "validate fields", Status: "pending", Level: 1},
+				{Content: "Wire it up", Status: "pending", Level: 0},
+				{Content: "call from boot", Status: "pending", Level: 1},
+			},
+		},
+		{
+			name: "tab-indented sub-step is level 1",
+			plan: "- Phase one\n\t- nested by tab",
+			want: []seedTodo{
+				{Content: "Phase one", Status: "in_progress", Level: 0},
+				{Content: "nested by tab", Status: "pending", Level: 1},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/tool/builtin/todo.go
+++ b/internal/tool/builtin/todo.go
@@ -21,12 +21,13 @@ type todoItem struct {
 	Content    string `json:"content"`
 	Status     string `json:"status"`
 	ActiveForm string `json:"activeForm,omitempty"`
+	Level      int    `json:"level,omitempty"`
 }
 
 func (todoWrite) Name() string { return "todo_write" }
 
 func (todoWrite) Description() string {
-	return "Record and update a structured task list for the current work. Send the COMPLETE list every call — it replaces the previous one. Use it to plan multi-step work and show progress: keep exactly one item in_progress at a time, and flip an item to completed the moment it's done (don't batch completions). Skip it for trivial single-step tasks. Each item has `content` (imperative, e.g. \"Add the parser\"), `status` (pending|in_progress|completed), and `activeForm` (present-continuous shown while in progress, e.g. \"Adding the parser\")."
+	return "Record and update a structured task list for the current work. Send the COMPLETE list every call — it replaces the previous one. Use it to plan multi-step work and show progress: keep exactly one item in_progress at a time, and flip an item to completed the moment it's done (don't batch completions). Skip it for trivial single-step tasks. The list is two-level: a `level` 0 item is a PHASE (a milestone) and the `level` 1 items after it are its concrete sub-steps; omit `level` (0) for a flat list. Each item has `content` (imperative, e.g. \"Add the parser\"), `status` (pending|in_progress|completed), `activeForm` (present-continuous shown while in progress, e.g. \"Adding the parser\"), and optional `level` (0 phase | 1 sub-step)."
 }
 
 func (todoWrite) Schema() json.RawMessage {
@@ -41,7 +42,8 @@ func (todoWrite) Schema() json.RawMessage {
       "properties":{
         "content":{"type":"string","description":"Imperative description of the task."},
         "status":{"type":"string","enum":["pending","in_progress","completed"],"description":"Task state. Keep at most one in_progress."},
-        "activeForm":{"type":"string","description":"Present-continuous form shown while the task is in progress (e.g. \"Running tests\")."}
+        "activeForm":{"type":"string","description":"Present-continuous form shown while the task is in progress (e.g. \"Running tests\")."},
+        "level":{"type":"integer","enum":[0,1],"description":"Nesting level: 0 = phase/milestone, 1 = a sub-step of the phase above it. Omit for a flat list."}
       },
       "required":["content","status"]
     }
@@ -67,6 +69,9 @@ func (todoWrite) Execute(ctx context.Context, args json.RawMessage) (string, err
 	for i, t := range p.Todos {
 		if t.Content == "" {
 			return "", fmt.Errorf("todo %d: content is required", i+1)
+		}
+		if t.Level < 0 || t.Level > 1 {
+			return "", fmt.Errorf("todo %d: invalid level %d (want 0 phase | 1 sub-step)", i+1, t.Level)
 		}
 		switch t.Status {
 		case "completed":

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -1,0 +1,25 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestTodoWriteAcceptsLevels(t *testing.T) {
+	args := json.RawMessage(`{"todos":[` +
+		`{"content":"Phase","status":"in_progress","level":0},` +
+		`{"content":"sub","status":"pending","level":1}]}`)
+	if _, err := (todoWrite{}).Execute(context.Background(), args); err != nil {
+		t.Fatalf("levels 0/1 should be accepted: %v", err)
+	}
+}
+
+func TestTodoWriteRejectsBadLevel(t *testing.T) {
+	args := json.RawMessage(`{"todos":[{"content":"x","status":"pending","level":2}]}`)
+	_, err := (todoWrite{}).Execute(context.Background(), args)
+	if err == nil || !strings.Contains(err.Error(), "level") {
+		t.Fatalf("level 2 should be rejected with a level error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Context

The user wanted plan mode aligned with Claude Code and stronger — specifically a **layered** plan. Worth noting: Claude Code's plan mode is itself *flat* (research → one markdown plan via `ExitPlanMode` → approve → flat todo list). Reasonix was already aligned with that mechanically (read-only gate, `exit_plan_mode` approval, seeded todos, execution discipline). What read as "weak" was that everything steered toward a single flat checklist: the marker asked for "a numbered list, one concrete step per item", the parser flattened all list items, and the todo model had no hierarchy.

This PR adds genuine two-level planning — a step **beyond** Claude Code, not just parity.

## Change

Two-level plans, kept to a **single research+plan turn** (no extra model calls, no extra approvals — cheap by design; the cache-stable marker still rides the user turn so there's no prompt-cache cost):

- **Marker** (`input.go`): steers a two-level markdown list — top-level numbered **phases** (milestones), each decomposing into indented, concrete **sub-steps**.
- **Parser** (`controller.go`): `listItem` reads leading indentation into a level (0 phase / 1 sub-step, capped at 1); `parsePlanTodos` seeds a nested starter list.
- **todo_write** (`todo.go`): optional `level` (0/1), validated and documented, so the model preserves the hierarchy as it works. The post-approval nudge tells it to keep the two-level shape and track sub-steps.
- **Task panel** (`chat_tui.go`): indents sub-steps under their phase.

Flat plans still work unchanged — `level` defaults to 0.

## Tests

- `parsePlanTodos`: new cases for space- and tab-indented sub-steps → level 1; existing flat cases unchanged.
- `todo_write`: accepts levels 0/1, rejects level 2 with a clear error.
- `renderTodoPanel`: a level-1 sub-step renders indented under its level-0 phase.
- `go build ./...`, `go vet ./...`, `go test ./...` green.

## Not covered here

Whether the model *reliably* emits a clean two-level list given the new marker is prompt-quality and only a live run confirms it; the parser is forgiving (falls back to flat, and the model refines via `todo_write` during execution regardless).
