### PR TITLE
feat(agent): segment read-only tool batch execution

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -410,11 +410,11 @@ func (a *Agent) stream(ctx context.Context) (string, string, string, []provider.
 
 // executeBatch dispatches one model turn's tool calls. A ToolDispatch event is
 // emitted for every call up front, in call order, so a frontend can show the
-// timeline chronologically. Calls fan out across goroutines only when every
-// call's tool is ReadOnly (canParallelise); a single non-ReadOnly call drops
-// the whole batch back to sequential to preserve write/read ordering. ToolResult
-// events are emitted after the batch in call order, so emission stays serial
-// even when execution parallelised.
+// timeline chronologically. Contiguous known ReadOnly calls fan out across
+// goroutines; unknown and writer calls run as single-call serial segments so
+// write/read ordering stays provider-ordered. ToolResult events are emitted
+// after the batch in call order, so emission stays serial even when execution
+// parallelised.
 func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []string {
 	for _, c := range calls {
 		t, ok := a.tools.Get(c.Name)
@@ -433,23 +433,12 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 		results[i] = outcomes[i].output
 	}
 
-	if canParallelise(a.tools, calls) && len(calls) > 1 {
-		const maxParallel = 8
-		sem := make(chan struct{}, maxParallel)
-		var wg sync.WaitGroup
-		for i := range calls {
-			i := i
-			sem <- struct{}{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				defer func() { <-sem }()
-				run(i)
-			}()
+	for _, batch := range partitionToolCalls(a.tools, calls) {
+		if batch.parallel && batch.end-batch.start > 1 {
+			runParallel(batch.start, batch.end, run)
+			continue
 		}
-		wg.Wait()
-	} else {
-		for i := range calls {
+		for i := batch.start; i < batch.end; i++ {
 			run(i)
 		}
 	}
@@ -472,6 +461,54 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 	}
 	a.applyStormBreaker(calls, outcomes, results)
 	return results
+}
+
+type toolCallBatch struct {
+	start    int
+	end      int
+	parallel bool
+}
+
+// partitionToolCalls keeps provider order while letting contiguous known
+// read-only tools run together. Unknown and writer tools are single-call serial
+// batches so they cannot reorder around reads or produce surprising errors.
+func partitionToolCalls(r *tool.Registry, calls []provider.ToolCall) []toolCallBatch {
+	var batches []toolCallBatch
+	for i := 0; i < len(calls); {
+		if t, ok := r.Get(calls[i].Name); ok && t.ReadOnly() {
+			start := i
+			i++
+			for i < len(calls) {
+				next, ok := r.Get(calls[i].Name)
+				if !ok || !next.ReadOnly() {
+					break
+				}
+				i++
+			}
+			batches = append(batches, toolCallBatch{start: start, end: i, parallel: true})
+			continue
+		}
+		batches = append(batches, toolCallBatch{start: i, end: i + 1})
+		i++
+	}
+	return batches
+}
+
+func runParallel(start, end int, run func(int)) {
+	const maxParallel = 8
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+	for i := start; i < end; i++ {
+		i := i
+		sem <- struct{}{}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			run(i)
+		}()
+	}
+	wg.Wait()
 }
 
 // stormBreakThreshold is how many times in a row the same tool may fail the same
@@ -636,19 +673,6 @@ func firstLine(s string) string {
 		return s[:i]
 	}
 	return s
-}
-
-// canParallelise returns true iff every call targets a known, ReadOnly tool.
-// Any unknown tool name (let the sequential path produce a clean error) or any
-// non-ReadOnly tool (preserve write ordering) forces serial execution.
-func canParallelise(r *tool.Registry, calls []provider.ToolCall) bool {
-	for _, c := range calls {
-		t, ok := r.Get(c.Name)
-		if !ok || !t.ReadOnly() {
-			return false
-		}
-	}
-	return true
 }
 
 // truncateToolOutput head+tails s when it exceeds maxToolOutputBytes, slicing

--- a/internal/agent/guards_test.go
+++ b/internal/agent/guards_test.go
@@ -3,13 +3,14 @@ package agent
 import (
 	"context"
 	"encoding/json"
-	"reasonix/internal/event"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
 
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -108,36 +109,50 @@ func (f fakeTool) Execute(ctx context.Context, _ json.RawMessage) (string, error
 	return f.name + " done", nil
 }
 
-func TestCanParalleliseAllReadOnly(t *testing.T) {
+func TestPartitionToolCallsAllReadOnly(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "ro1", readOnly: true})
 	reg.Add(fakeTool{name: "ro2", readOnly: true})
 	calls := []provider.ToolCall{{Name: "ro1"}, {Name: "ro2"}}
-	if !canParallelise(reg, calls) {
-		t.Error("all-readonly batch should be parallelisable")
+	got := partitionToolCalls(reg, calls)
+	want := []toolCallBatch{{start: 0, end: 2, parallel: true}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("partitionToolCalls = %+v, want %+v", got, want)
 	}
 }
 
-// TestCanParalleliseMixedSerial verifies that a single write in a batch flips
-// the whole batch back to serial, so read-after-write hazards can't reorder.
-func TestCanParalleliseMixedSerial(t *testing.T) {
+// TestPartitionToolCallsSegmentsAroundWriters verifies a writer only serializes
+// its own provider-order position; read-only runs on either side stay batchable.
+func TestPartitionToolCallsSegmentsAroundWriters(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "ro", readOnly: true})
 	reg.Add(fakeTool{name: "rw", readOnly: false})
 	calls := []provider.ToolCall{{Name: "ro"}, {Name: "rw"}, {Name: "ro"}}
-	if canParallelise(reg, calls) {
-		t.Error("mixed batch must be sequential")
+	got := partitionToolCalls(reg, calls)
+	want := []toolCallBatch{
+		{start: 0, end: 1, parallel: true},
+		{start: 1, end: 2},
+		{start: 2, end: 3, parallel: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("partitionToolCalls = %+v, want %+v", got, want)
 	}
 }
 
-// TestCanParalleliseUnknownToolSerial keeps unknown-tool errors deterministic
-// by forcing the batch through the sequential path.
-func TestCanParalleliseUnknownToolSerial(t *testing.T) {
+// TestPartitionToolCallsUnknownToolSerial keeps unknown-tool errors
+// deterministic by forcing unknown calls into single-call serial batches.
+func TestPartitionToolCallsUnknownToolSerial(t *testing.T) {
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "ro", readOnly: true})
-	calls := []provider.ToolCall{{Name: "ro"}, {Name: "vanished"}}
-	if canParallelise(reg, calls) {
-		t.Error("unknown tool should force sequential dispatch")
+	calls := []provider.ToolCall{{Name: "ro"}, {Name: "vanished"}, {Name: "ro"}}
+	got := partitionToolCalls(reg, calls)
+	want := []toolCallBatch{
+		{start: 0, end: 1, parallel: true},
+		{start: 1, end: 2},
+		{start: 2, end: 3, parallel: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("partitionToolCalls = %+v, want %+v", got, want)
 	}
 }
 
@@ -169,22 +184,45 @@ func TestExecuteBatchParallelReadOnly(t *testing.T) {
 	}
 }
 
-// TestExecuteBatchSerialOnWrite ensures a single write turn forces total
-// serial time even though the other calls would otherwise parallelise.
-func TestExecuteBatchSerialOnWrite(t *testing.T) {
+// TestExecuteBatchSegmentsAroundWrites ensures a write call only serializes its
+// own position in the provider-ordered batch: read-only runs before and after it
+// may still parallelise within their contiguous segments.
+func TestExecuteBatchSegmentsAroundWrites(t *testing.T) {
 	const delay = 40 * time.Millisecond
 	reg := tool.NewRegistry()
-	reg.Add(fakeTool{name: "ro", readOnly: true, delay: delay})
+	reg.Add(fakeTool{name: "ro1", readOnly: true, delay: delay})
+	reg.Add(fakeTool{name: "ro2", readOnly: true, delay: delay})
+	reg.Add(fakeTool{name: "ro3", readOnly: true, delay: delay})
+	reg.Add(fakeTool{name: "ro4", readOnly: true, delay: delay})
 	reg.Add(fakeTool{name: "rw", readOnly: false, delay: delay})
 
 	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
 
 	start := time.Now()
-	a.executeBatch(context.Background(), []provider.ToolCall{{Name: "ro"}, {Name: "rw"}, {Name: "ro"}})
+	results := a.executeBatch(context.Background(), []provider.ToolCall{
+		{Name: "ro1"},
+		{Name: "ro2"},
+		{Name: "rw"},
+		{Name: "ro3"},
+		{Name: "ro4"},
+	})
 	elapsed := time.Since(start)
 
-	// Three calls of `delay` in serial ≈ 3*delay; permit some slack.
+	want := []string{"ro1 done", "ro2 done", "rw done", "ro3 done", "ro4 done"}
+	if len(results) != len(want) {
+		t.Fatalf("got %d results, want %d: %v", len(results), len(want), results)
+	}
+	for i := range want {
+		if results[i] != want[i] {
+			t.Fatalf("results out of order or wrong: got %v want %v", results, want)
+		}
+	}
+	// Desired shape is roughly 3*delay: (ro1|ro2), then rw, then (ro3|ro4).
+	// Old all-serial behaviour is roughly 5*delay and should fail this bound.
+	if elapsed >= 4*delay {
+		t.Errorf("mixed batch took %v (>= %v) — read-only segments did not parallelise", elapsed, 4*delay)
+	}
 	if elapsed < 2*delay {
-		t.Errorf("mixed batch took only %v — looks like it ran in parallel", elapsed)
+		t.Errorf("mixed batch took only %v — write call appears to have overlapped a read-only segment", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary
- segment tool-call batches so contiguous known read-only tools can run concurrently around serial writer/unknown calls
- preserve provider-order dispatch, result emission, and session writeback
- update agent tests for batch partitioning and segmented execution timing

## Tests
- gofmt -l .
- git diff --check
- go test ./internal/agent -count=1