### PR TITLE
feat(desktop): indent layered-plan sub-steps in the todo panel

### DIFF
--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -39,7 +39,10 @@ export function TodoPanel({ todos, onDismiss }: { todos: Todo[]; onDismiss: () =
       {open && (
         <ul className="todobar__list">
           {todos.map((t, i) => (
-            <li key={i} className={`todobar__item todobar__item--${t.status}`}>
+            <li
+              key={i}
+              className={`todobar__item todobar__item--${t.status}${t.level ? " todobar__item--sub" : ""}`}
+            >
               {t.status === "completed" ? (
                 <Check size={14} className="todobar__ico todobar__ico--done" />
               ) : t.status === "in_progress" ? (

--- a/desktop/frontend/src/lib/tools.ts
+++ b/desktop/frontend/src/lib/tools.ts
@@ -87,6 +87,7 @@ export interface Todo {
   content: string;
   status: TodoStatus | string;
   activeForm?: string;
+  level?: number; // 0 = phase, 1 = sub-step of the phase above it
 }
 
 // parseTodos pulls the task list out of a todo_write call's args.

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2047,6 +2047,9 @@ body {
 .todobar__item--pending .todobar__text {
   color: var(--fg-dim);
 }
+.todobar__item--sub {
+  padding-left: 20px;
+}
 
 /* ── composer mode indicator (pinned above the input) ─────────────────────── */
 .composer__mode {


### PR DESCRIPTION
Completes the layered-plan work (#2539, #2543) on the desktop frontend. The kernel emits a `level` on each todo (0 phase / 1 sub-step); the desktop task panel ignored it and rendered flat. Carry `level` through the `Todo` type and indent level-1 items under their phase, matching the TUI panel. `npm run typecheck` clean.