### PR TITLE
test(boot): disable codegraph in the MCP-failure test

### DIFF
--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -125,6 +125,9 @@ func TestBuildRecordsMCPStartupFailure(t *testing.T) {
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
 
+[codegraph]
+enabled = false
+
 [agent]
 system_prompt = "BASE"
 


### PR DESCRIPTION
`TestBuildRecordsMCPStartupFailure` was the only boot test missing `[codegraph] enabled = false`, so `Build` started a real codegraph daemon that held `codegraph.db` open. On Windows the `t.TempDir` cleanup then failed to unlink it (`unlinkat ... being used by another process`) — the test's own assertions passed, only teardown failed. Match the three sibling tests, which already disable codegraph for exactly this reason. The test is about MCP startup failure, not codegraph.

Verified: passes on repeated runs on Windows.