### PR TITLE
test(desktop): make sessionTitlesPath test platform-agnostic

### DIFF
--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -157,8 +157,9 @@ func TestDeleteSessionFileMissing(t *testing.T) {
 
 func TestSessionTitlesPath(t *testing.T) {
 	got := sessionTitlesPath("/sessions")
-	if got != "/sessions/.titles.json" {
-		t.Errorf("sessionTitlesPath = %q", got)
+	want := filepath.Join("/sessions", ".titles.json")
+	if got != want {
+		t.Errorf("sessionTitlesPath = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Pre-existing Windows failure: `TestSessionTitlesPath` hardcoded `/sessions/.titles.json`, but `filepath.Join` yields `\sessions\.titles.json` on Windows — green on Unix CI, red on Windows. Compare against `filepath.Join` so it holds on every OS. (The `desktop` module is separate from `reasonix/...`, so the main-module test runs never covered it.)