### PR TITLE
fix(desktop): shorten Windows cwd in the status breadcrumb

### DIFF
--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -58,9 +58,10 @@ function avgRate(u?: WireUsage): number | null {
 }
 
 // shortCwd trims a path to its last two segments so the status line stays compact
-// (e.g. /Users/x/projects/reasonix → …/projects/reasonix).
+// (e.g. /Users/x/projects/reasonix → …/projects/reasonix). Splits on both
+// separators so Windows backslash paths (C:\…\reasonix) shorten too.
 function shortCwd(cwd: string): string {
-  const parts = cwd.split("/").filter(Boolean);
+  const parts = cwd.split(/[/\\]/).filter(Boolean);
   if (parts.length <= 2) return cwd;
   return "…/" + parts.slice(-2).join("/");
 }


### PR DESCRIPTION
Found during a desktop Windows-compatibility audit. `shortCwd` split only on `/`, but the backend sends `os.Getwd()` (app.go), which is backslash-separated on Windows — so the status breadcrumb showed the full unshortened path there instead of `…/projects/reasonix`. Split on both separators. `npm run typecheck` clean.