### PR TITLE
feat(desktop): async startup — non-blocking boot.Build + parallel plugin init

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
@@ -36,9 +37,14 @@ type App struct {
 	sink *eventSink
 	ctrl *control.Controller
 
+	// mu protects ctrl, label, model, startupErr, and ready during the async
+	// boot sequence. startup() spawns a goroutine for boot.Build(); all methods
+	// that touch the controller acquire the lock.
+	mu         sync.RWMutex
 	startupErr string
 	label      string
 	model      string // active provider name (for the bottom model switcher)
+	ready      bool   // true once boot.Build completes (success or failure)
 }
 
 // NewApp constructs the bound object. The controller is built later, in startup,
@@ -47,13 +53,29 @@ func NewApp() *App { return &App{sink: &eventSink{}} }
 
 // startup runs once the webview process is up, before the frontend can issue any
 // bound call. It captures the Wails context (needed for EventsEmit), points the
-// sink at it, then builds the controller with that sink — so the event bridge is
-// live before the first command lands. RequireKey is false so a missing API key
-// opens the window in a "set your key" state rather than failing to launch; a
-// build error is surfaced through Meta instead of crashing the window.
+// sink at it, then kicks off the entire initialization (workspace, config, build)
+// in a background goroutine so the webview loads immediately. The frontend polls
+// Meta() and sees Ready flip to true once the controller is assembled. RequireKey
+// is false so a missing API key opens the window in a "set your key" state rather
+// than failing to launch; a build error is surfaced through Meta instead of
+// crashing the window.
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 	a.sink.ctx = ctx
+
+	// Everything else — workspace resolution, config loading, i18n setup, and
+	// boot.Build — runs in the background so the webview appears instantly.
+	// During this window Meta().Ready is false and the frontend shows a loading
+	// state; bound calls are no-ops (ctrl is nil).
+	go a.buildController()
+}
+
+// buildController runs the full initialization sequence in a background goroutine:
+// workspace resolution, config loading, i18n setup, and boot.Build. On success it
+// wires up the controller and flips ready; on failure it stores the error so
+// Meta().StartupErr surfaces it.
+func (a *App) buildController() {
+	ctx := a.ctx // captured by startup before this goroutine starts
 
 	// A GUI launch starts in "/" (read-only); move into a real, writable working
 	// folder (the remembered one, else home) before anything reads/writes config,
@@ -62,24 +84,37 @@ func (a *App) startup(ctx context.Context) {
 
 	// Resolve the active model to its canonical "provider/model" ref up front so
 	// the switcher can mark it current.
+	model := ""
 	if cfg, err := config.Load(); err == nil {
 		// Drive the Go-side catalogue (i18n.M) from the configured language so the
 		// backend-provided slash UI — command descriptions, sub-command hints,
 		// listing notices — comes through localized, matching the frontend.
 		i18n.DetectLanguage(cfg.Language)
-		a.model = cfg.DefaultModel
+		model = cfg.DefaultModel
 		if e, ok := cfg.ResolveModel(cfg.DefaultModel); ok {
-			a.model = e.Name + "/" + e.Model
+			model = e.Name + "/" + e.Model
 		}
 	}
 
-	ctrl, err := boot.Build(ctx, boot.Options{Model: a.model, RequireKey: false, Sink: a.sink})
+	a.mu.Lock()
+	a.model = model
+	a.mu.Unlock()
+
+	ctrl, err := boot.Build(ctx, boot.Options{Model: model, RequireKey: false, Sink: a.sink})
 	if err != nil {
+		a.mu.Lock()
 		a.startupErr = err.Error()
+		a.ready = true
+		a.mu.Unlock()
+		runtime.EventsEmit(ctx, "agent:ready")
 		return
 	}
+
+	a.mu.Lock()
 	a.ctrl = ctrl
 	a.label = ctrl.Label()
+	a.ready = true
+	a.mu.Unlock()
 
 	// Desktop is interactive: route "ask" gate decisions to the frontend as
 	// approval_request events, answered via Approve.
@@ -89,13 +124,20 @@ func (a *App) startup(ctx context.Context) {
 	if dir := ctrl.SessionDir(); dir != "" {
 		ctrl.SetSessionPath(agent.NewSessionPath(dir, ctrl.Label()))
 	}
+
+	// Notify the frontend that the controller is ready — it re-fetches Meta,
+	// ContextUsage, and History.
+	runtime.EventsEmit(ctx, "agent:ready")
 }
 
 // shutdown snapshots the conversation and stops plugin subprocesses on close.
 func (a *App) shutdown(context.Context) {
-	if a.ctrl != nil {
-		_ = a.ctrl.Snapshot()
-		a.ctrl.Close()
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		_ = ctrl.Snapshot()
+		ctrl.Close()
 	}
 }
 
@@ -106,30 +148,42 @@ func (a *App) shutdown(context.Context) {
 // Submit runs raw user input as a turn; slash commands and @-references are
 // resolved by the controller. Output arrives asynchronously on eventChannel.
 func (a *App) Submit(input string) {
-	if a.ctrl != nil {
-		a.ctrl.Submit(input)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Submit(input)
 	}
 }
 
 // Cancel aborts the in-flight turn.
 func (a *App) Cancel() {
-	if a.ctrl != nil {
-		a.ctrl.Cancel()
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Cancel()
 	}
 }
 
 // Approve answers a pending approval_request by ID: allow runs the call, session
 // also remembers the grant for the rest of the session.
 func (a *App) Approve(id string, allow, session bool) {
-	if a.ctrl != nil {
-		a.ctrl.Approve(id, allow, session)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Approve(id, allow, session)
 	}
 }
 
 // SetPlanMode toggles read-only plan mode.
 func (a *App) SetPlanMode(on bool) {
-	if a.ctrl != nil {
-		a.ctrl.SetPlanMode(on)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.SetPlanMode(on)
 	}
 }
 
@@ -142,30 +196,39 @@ type QuestionAnswer struct {
 // AnswerQuestion resolves a pending ask_request (the `ask` tool) by ID with the
 // user's selections per question.
 func (a *App) AnswerQuestion(id string, answers []QuestionAnswer) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return
 	}
 	out := make([]event.AskAnswer, len(answers))
 	for i, an := range answers {
 		out[i] = event.AskAnswer{QuestionID: an.QuestionID, Selected: an.Selected}
 	}
-	a.ctrl.AnswerQuestion(id, out)
+	ctrl.AnswerQuestion(id, out)
 }
 
 // Compact runs one compaction pass on demand.
 func (a *App) Compact() error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.Compact(a.ctx)
+	return ctrl.Compact(a.ctx)
 }
 
 // NewSession snapshots the current conversation and rotates to a fresh one.
 func (a *App) NewSession() error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.NewSession()
+	return ctrl.NewSession()
 }
 
 // CheckpointMeta summarises one rewind point (a user turn) for the desktop.
@@ -178,10 +241,13 @@ type CheckpointMeta struct {
 
 // Checkpoints lists the session's rewind points, oldest first, for the rewind UI.
 func (a *App) Checkpoints() []CheckpointMeta {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return []CheckpointMeta{}
 	}
-	metas := a.ctrl.Checkpoints()
+	metas := ctrl.Checkpoints()
 	out := make([]CheckpointMeta, 0, len(metas))
 	for _, m := range metas {
 		out = append(out, CheckpointMeta{Turn: m.Turn, Prompt: m.Prompt, Files: m.Paths, Time: m.Time.UnixMilli()})
@@ -193,7 +259,10 @@ func (a *App) Checkpoints() []CheckpointMeta {
 // "conversation", or "both" (anything else is treated as "both"). The frontend
 // re-reads History after this resolves.
 func (a *App) Rewind(turn int, scope string) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
 	s := control.RewindBoth
@@ -203,17 +272,20 @@ func (a *App) Rewind(turn int, scope string) error {
 	case "conversation":
 		s = control.RewindConversation
 	}
-	return a.ctrl.Rewind(turn, s)
+	return ctrl.Rewind(turn, s)
 }
 
 // Fork branches the conversation at the start of turn into a new session
 // (preserving the current one), keeping code intact, and switches to the branch.
 // The frontend re-reads History after this resolves.
 func (a *App) Fork(turn int) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	_, err := a.ctrl.Fork(turn)
+	_, err := ctrl.Fork(turn)
 	return err
 }
 
@@ -221,17 +293,23 @@ func (a *App) Fork(turn int) error {
 // of turn into one summary (Claude Code's "summarize from/up to here"), keeping
 // code intact. The frontend re-reads History after this resolves.
 func (a *App) SummarizeFrom(turn int) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.SummarizeFrom(a.ctx, turn)
+	return ctrl.SummarizeFrom(a.ctx, turn)
 }
 
 func (a *App) SummarizeUpTo(turn int) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.SummarizeUpTo(a.ctx, turn)
+	return ctrl.SummarizeUpTo(a.ctx, turn)
 }
 
 // SessionMeta summarises one saved session for the history panel.
@@ -254,9 +332,12 @@ func (a *App) ListSessions() []SessionMeta {
 		return []SessionMeta{}
 	}
 	titles := loadSessionTitles(dir)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
 	cur := ""
-	if a.ctrl != nil {
-		cur = a.ctrl.SessionPath()
+	if ctrl != nil {
+		cur = ctrl.SessionPath()
 	}
 	out := make([]SessionMeta, 0, len(infos))
 	for _, s := range infos {
@@ -276,7 +357,10 @@ func (a *App) ListSessions() []SessionMeta {
 // session — that's the conversation on screen, and auto-save would recreate the
 // file on the next turn; start a new session first to retire it.
 func (a *App) DeleteSession(path string) error {
-	if a.ctrl != nil && a.ctrl.SessionPath() == path {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil && ctrl.SessionPath() == path {
 		return errActiveSession
 	}
 	return deleteSessionFile(config.SessionDir(), path)
@@ -293,15 +377,18 @@ func (a *App) RenameSession(path, title string) error {
 // working folder are unchanged (same controller); only the transcript is swapped.
 // Returns the resumed messages for the frontend to render.
 func (a *App) ResumeSession(path string) ([]HistoryMessage, error) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return []HistoryMessage{}, nil
 	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
 		return nil, err
 	}
-	_ = a.ctrl.Snapshot() // persist the current session before switching away
-	a.ctrl.Resume(loaded, path)
+	_ = ctrl.Snapshot() // persist the current session before switching away
+	ctrl.Resume(loaded, path)
 	return a.History(), nil
 }
 
@@ -345,6 +432,7 @@ func (a *App) PickWorkspace() (string, error) {
 	}
 	// Commit the switch: save and tear down the old session, then swap in the new
 	// project's controller with a fresh session file.
+	a.mu.Lock()
 	if a.ctrl != nil {
 		_ = a.ctrl.Snapshot()
 		a.ctrl.Close()
@@ -353,6 +441,7 @@ func (a *App) PickWorkspace() (string, error) {
 	a.model = model
 	a.label = ctrl.Label()
 	a.startupErr = ""
+	a.mu.Unlock()
 	ctrl.EnableInteractiveApproval()
 	if d := ctrl.SessionDir(); d != "" {
 		ctrl.SetSessionPath(agent.NewSessionPath(d, ctrl.Label()))
@@ -369,10 +458,13 @@ type HistoryMessage struct {
 
 // History returns the session's message log.
 func (a *App) History() []HistoryMessage {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	msgs := a.ctrl.History()
+	msgs := ctrl.History()
 	out := make([]HistoryMessage, 0, len(msgs))
 	for _, m := range msgs {
 		out = append(out, HistoryMessage{Role: string(m.Role), Content: m.Content})
@@ -388,10 +480,13 @@ type ContextInfo struct {
 
 // ContextUsage returns the latest context-window gauge numbers.
 func (a *App) ContextUsage() ContextInfo {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return ContextInfo{}
 	}
-	used, window := a.ctrl.ContextSnapshot()
+	used, window := ctrl.ContextSnapshot()
 	return ContextInfo{Used: used, Window: window}
 }
 
@@ -410,10 +505,13 @@ type BalanceInfo struct {
 // controller is down, or the fetch fails — so the status bar simply shows nothing
 // rather than an error.
 func (a *App) Balance() BalanceInfo {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return BalanceInfo{}
 	}
-	b, err := a.ctrl.Balance(a.ctx)
+	b, err := ctrl.Balance(a.ctx)
 	if err != nil {
 		return BalanceInfo{Err: err.Error()}
 	}
@@ -437,10 +535,13 @@ type JobView struct {
 // on demand (mount, turn end, and on each notice the frontend receives).
 func (a *App) Jobs() []JobView {
 	out := []JobView{}
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return out
 	}
-	for _, v := range a.ctrl.Jobs() {
+	for _, v := range ctrl.Jobs() {
 		out = append(out, JobView{ID: v.ID, Kind: v.Kind, Label: v.Label, Status: v.Status, StartedAt: v.StartedAt})
 	}
 	return out
@@ -460,14 +561,20 @@ type Meta struct {
 // directory (for the status line), and the runtime event channel the frontend
 // subscribes to.
 func (a *App) Meta() Meta {
+	a.mu.RLock()
+	label := a.label
+	startupErr := a.startupErr
+	ready := a.ready
+	ctrl := a.ctrl
+	a.mu.RUnlock()
 	cwd, _ := os.Getwd()
 	return Meta{
-		Label:        a.label,
-		Ready:        a.ctrl != nil,
-		StartupErr:   a.startupErr,
+		Label:        label,
+		Ready:        ready,
+		StartupErr:   startupErr,
 		EventChannel: eventChannel,
 		Cwd:          cwd,
-		Bypass:       a.ctrl != nil && a.ctrl.Bypass(),
+		Bypass:       ctrl != nil && ctrl.Bypass(),
 	}
 }
 
@@ -475,8 +582,11 @@ func (a *App) Meta() Meta {
 // (writers and bash run without asking). Deny rules still apply. Runtime-only —
 // not written to config, so it resets on relaunch.
 func (a *App) SetBypass(on bool) {
-	if a.ctrl != nil {
-		a.ctrl.SetBypass(on)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.SetBypass(on)
 	}
 }
 
@@ -501,20 +611,23 @@ func (a *App) Commands() []CommandInfo {
 		{Name: "hooks", Description: i18n.M.CmdHooks, Kind: "builtin"},
 		{Name: "skill", Description: i18n.M.CmdSkill, Kind: "builtin"},
 	}
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return out
 	}
 	// Skills are invocable as /<name> (the model runs inline ones; subagent ones
 	// run isolated). Listing them here is what surfaces /init, /explore, … in the
 	// composer's slash menu; selecting one submits "/<name>", which the controller
 	// resolves via RunSkill.
-	for _, s := range a.ctrl.Skills() {
+	for _, s := range ctrl.Skills() {
 		out = append(out, CommandInfo{Name: s.Name, Description: s.Description, Kind: "skill"})
 	}
-	for _, c := range a.ctrl.Commands() {
+	for _, c := range ctrl.Commands() {
 		out = append(out, CommandInfo{Name: c.Name, Description: c.Description, Hint: c.ArgHint, Kind: "custom"})
 	}
-	if h := a.ctrl.Host(); h != nil {
+	if h := ctrl.Host(); h != nil {
 		for _, p := range h.Prompts() {
 			out = append(out, CommandInfo{Name: p.Name, Description: p.Description, Kind: "mcp"})
 		}
@@ -543,17 +656,21 @@ type SlashArgsResult struct {
 // /skill, /hooks) for the composer — the same logic the chat TUI uses. Empty
 // Items means the input has no structured arguments to complete.
 func (a *App) SlashArgs(input string) SlashArgsResult {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	model := a.model
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return SlashArgsResult{}
 	}
 	data := control.ArgData{
-		Skills:       a.ctrl.Skills(),
-		CurrentModel: a.model,
+		Skills:       ctrl.Skills(),
+		CurrentModel: model,
 	}
 	for _, m := range a.Models() {
 		data.ModelRefs = append(data.ModelRefs, m.Ref)
 	}
-	if h := a.ctrl.Host(); h != nil {
+	if h := ctrl.Host(); h != nil {
 		data.ServerNames = h.ServerNames()
 	}
 	items, from := control.SlashArgItems(input, data)
@@ -579,16 +696,19 @@ type ModelInfo struct {
 // the switcher's options — marking the active one. A vendor with a `models` list
 // yields one entry per model, all sharing the same endpoint/key.
 func (a *App) Models() []ModelInfo {
+	a.mu.RLock()
+	curModel := a.model
+	a.mu.RUnlock()
 	cfg, err := config.Load()
 	if err != nil {
 		return nil
 	}
-	var out []ModelInfo
+	out := []ModelInfo{}
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
 		for _, m := range p.ModelList() {
 			ref := p.Name + "/" + m
-			out = append(out, ModelInfo{Ref: ref, Provider: p.Name, Model: m, Current: ref == a.model})
+			out = append(out, ModelInfo{Ref: ref, Provider: p.Name, Model: m, Current: ref == curModel})
 		}
 	}
 	return out
@@ -599,36 +719,45 @@ func (a *App) Models() []ModelInfo {
 // the new model. (Switching models necessarily resets the prompt cache; that's the
 // cost of the switch.) No-op if name is already active or the controller is down.
 func (a *App) SetModel(name string) error {
-	if a.ctx == nil || name == "" || name == a.model {
+	if a.ctx == nil || name == "" {
+		return nil
+	}
+	a.mu.RLock()
+	curModel := a.model
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if name == curModel {
 		return nil
 	}
 
 	var carried []provider.Message
-	if a.ctrl != nil {
-		_ = a.ctrl.Snapshot()
-		carried = a.ctrl.History()
-		a.ctrl.Close()
+	if ctrl != nil {
+		_ = ctrl.Snapshot()
+		carried = ctrl.History()
+		ctrl.Close()
 	}
 
-	ctrl, err := boot.Build(a.ctx, boot.Options{Model: name, RequireKey: false, Sink: a.sink})
+	newCtrl, err := boot.Build(a.ctx, boot.Options{Model: name, RequireKey: false, Sink: a.sink})
 	if err != nil {
 		return err
 	}
-	a.ctrl = ctrl
+	a.mu.Lock()
+	a.ctrl = newCtrl
 	a.model = name
-	a.label = ctrl.Label()
-	ctrl.EnableInteractiveApproval()
+	a.label = newCtrl.Label()
+	a.mu.Unlock()
+	newCtrl.EnableInteractiveApproval()
 
 	path := ""
-	if dir := ctrl.SessionDir(); dir != "" {
-		path = agent.NewSessionPath(dir, ctrl.Label())
+	if dir := newCtrl.SessionDir(); dir != "" {
+		path = agent.NewSessionPath(dir, newCtrl.Label())
 	}
 	// Carry the prior conversation (full provider.Message log, incl. the system
 	// prompt) into the new session so history is preserved across the switch.
 	if len(carried) > 0 {
-		ctrl.Resume(&agent.Session{Messages: carried}, path)
+		newCtrl.Resume(&agent.Session{Messages: carried}, path)
 	} else if path != "" {
-		ctrl.SetSessionPath(path)
+		newCtrl.SetSessionPath(path)
 	}
 	return nil
 }
@@ -723,10 +852,13 @@ func (a *App) Memory() MemoryView {
 	// Always return non-nil slices: a nil Go slice marshals to JSON `null`, which
 	// would crash the panel's `view.facts.length` / `.map`.
 	view := MemoryView{Docs: []MemoryDoc{}, Facts: []MemoryFact{}, Scopes: []MemoryScope{}}
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return view
 	}
-	set := a.ctrl.Memory()
+	set := ctrl.Memory()
 	if set == nil {
 		return view
 	}
@@ -752,19 +884,25 @@ func (a *App) Memory() MemoryView {
 // panel's explicit "remember" action, equivalent to typing "#<note>". An unknown
 // scope falls back to project. Returns the file written.
 func (a *App) Remember(scope, note string) (string, error) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return "", nil
 	}
-	return a.ctrl.QuickAdd(parseScope(scope), note)
+	return ctrl.QuickAdd(parseScope(scope), note)
 }
 
 // SaveDoc overwrites a memory doc with the panel editor's contents. The controller
 // validates path against the recognized memory files. Returns the file written.
 func (a *App) SaveDoc(path, body string) (string, error) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return "", nil
 	}
-	return a.ctrl.SaveDoc(path, body)
+	return ctrl.SaveDoc(path, body)
 }
 
 // parseScope maps a frontend scope id to a memory.Scope, defaulting to project.

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -210,12 +210,26 @@ export default function App() {
       <UpdateBanner />
 
       <main className="main">
-        <Transcript items={state.items} onPrompt={send} onRewind={rewind} />
+        {state.meta?.ready === false && !state.meta?.startupErr ? (
+          <div className="loading-screen">
+            <div className="loading-screen__spinner" />
+            <span className="loading-screen__text">{t("common.loading")}</span>
+          </div>
+        ) : (
+          <Transcript items={state.items} onPrompt={send} onRewind={rewind} />
+        )}
       </main>
 
       <footer className="footer">
         {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
-        <Composer running={state.running} mode={mode} onSend={handleSend} onCancel={cancel} onCycleMode={cycleMode} />
+        <Composer
+          running={state.running}
+          mode={mode}
+          onSend={handleSend}
+          onCancel={cancel}
+          onCycleMode={cycleMode}
+          disabled={state.meta?.ready === false}
+        />
         <StatusBar
           meta={state.meta}
           context={state.context}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -14,6 +14,7 @@ export function Composer({
   onSend,
   onCancel,
   onCycleMode,
+  disabled,
 }: {
   running: boolean;
   mode: Mode;
@@ -22,6 +23,7 @@ export function Composer({
   // be restored to the input); undefined for a normal cancel.
   onCancel: () => string | undefined;
   onCycleMode: () => void;
+  disabled?: boolean;
 }) {
   const t = useT();
   const [text, setText] = useState("");
@@ -260,7 +262,7 @@ export function Composer({
         {mode === "yolo" ? t("composer.modeYolo") : mode === "plan" ? t("composer.modePlan") : t("composer.modeNormal")}
         <span className="composer__mode-hint">{t("composer.modeHint")}</span>
       </button>
-      <div className="composer">
+      <div className={`composer${disabled ? " composer--disabled" : ""}`}>
         <span className="composer__caret">›</span>
         <textarea
           ref={taRef}
@@ -268,8 +270,9 @@ export function Composer({
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={onKeyDown}
-          placeholder={t("composer.placeholder")}
+          placeholder={disabled ? t("common.loading") : t("composer.placeholder")}
           rows={1}
+          disabled={disabled}
         />
         {running ? (
           <button className="composer__btn composer__btn--stop" onClick={handleCancel} title={t("composer.stop")}>
@@ -279,7 +282,7 @@ export function Composer({
           <button
             className="composer__btn composer__btn--send"
             onClick={submit}
-            disabled={!text.trim()}
+            disabled={!text.trim() || disabled}
             title={t("composer.send")}
           >
             <ArrowUp size={16} />

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -148,6 +148,17 @@ export function onUpdaterProgress(cb: (p: UpdateProgress) => void): () => void {
   };
 }
 
+// onReady subscribes to the agent:ready event fired when boot.Build completes.
+// The frontend re-fetches Meta/Context/History when this lands.
+export function onReady(cb: () => void): () => void {
+  if (realApp() && typeof window !== "undefined" && window.runtime) {
+    return window.runtime.EventsOn("agent:ready", () => cb());
+  }
+  // In dev mock, fire immediately since there's no real boot sequence.
+  cb();
+  return () => {};
+}
+
 // app proxies each call to the live binding (or the dev mock only when truly
 // outside the shell), so a late-injected window.go is picked up transparently.
 export const app: AppBindings = new Proxy({} as AppBindings, {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -6,7 +6,7 @@
 // update loop — same controller, different renderer.
 
 import { useCallback, useEffect, useReducer, useRef } from "react";
-import { app, onEvent } from "./bridge";
+import { app, onEvent, onReady } from "./bridge";
 import type {
   BalanceInfo,
   ContextInfo,
@@ -397,6 +397,20 @@ export function useController() {
   const stateRef = useRef(state);
   stateRef.current = state;
 
+  // loadSessionData fetches Meta, ContextUsage, and History — called on mount
+  // and again when agent:ready fires (boot.Build completed in the background).
+  const loadSessionData = useCallback(async () => {
+    try {
+      dispatch({ type: "meta", meta: await app.Meta() });
+      dispatch({ type: "context", context: await app.ContextUsage() });
+      const history = await app.History();
+      if (history && history.length) dispatch({ type: "history", messages: history });
+    } catch {
+      // Bound methods unavailable (pre-startup / build error) — ignore; Meta's
+      // startupErr surfaces the reason once it's reachable.
+    }
+  }, []);
+
   useEffect(() => {
     const off = onEvent((e) => {
       dispatch({ type: "event", e });
@@ -423,17 +437,23 @@ export function useController() {
       }
     });
 
-    void (async () => {
-      try {
-        dispatch({ type: "meta", meta: await app.Meta() });
-        dispatch({ type: "context", context: await app.ContextUsage() });
-        const history = await app.History();
-        if (history && history.length) dispatch({ type: "history", messages: history });
-      } catch {
-        // Bound methods unavailable (pre-startup / build error) — ignore; Meta's
-        // startupErr surfaces the reason once it's reachable.
-      }
-    })();
+    // When boot.Build completes asynchronously, the Go side emits agent:ready.
+    // Re-fetch session data so the UI reflects the now-available controller.
+    const offReady = onReady(() => {
+      void loadSessionData();
+      app
+        .Balance()
+        .then((balance) => dispatch({ type: "balance", balance }))
+        .catch(() => {});
+      app
+        .Jobs()
+        .then((jobs) => dispatch({ type: "jobs", jobs }))
+        .catch(() => {});
+    });
+
+    // Initial load — picks up the pre-build Meta (ready=false) and, if the
+    // build already finished, the full session.
+    void loadSessionData();
 
     // Wallet balance is a network call — fetch it independently so it never delays
     // the transcript/meta load (and is a no-op readout when not configured).
@@ -446,8 +466,11 @@ export function useController() {
       .then((jobs) => dispatch({ type: "jobs", jobs }))
       .catch(() => {});
 
-    return off;
-  }, []);
+    return () => {
+      off();
+      offReady();
+    };
+  }, [loadSessionData]);
 
   const send = useCallback((text: string) => {
     dispatch({ type: "user", text });

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -14,6 +14,7 @@ export const en = {
   "common.submit": "Submit",
   "common.none": "none",
   "common.busyHint": "Finish or stop the current turn first",
+  "common.loading": "Loading…",
 
   // top bar
   "topbar.history": "History",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -15,6 +15,7 @@ export const zh: Record<DictKey, string> = {
   "common.submit": "提交",
   "common.none": "无",
   "common.busyHint": "请先完成或停止当前回合",
+  "common.loading": "加载中…",
 
   // 顶栏
   "topbar.history": "历史",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -217,6 +217,36 @@ body {
   flex: 1 1 auto;
   overflow: hidden;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* loading screen shown while boot.Build runs in the background */
+.loading-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  opacity: 0;
+  animation: anim-fade-in 0.4s ease forwards;
+}
+.loading-screen__spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.loading-screen__text {
+  font-size: 13px;
+  color: var(--fg-faint);
+  letter-spacing: 0.3px;
 }
 .transcript {
   height: 100%;
@@ -950,6 +980,14 @@ body {
 }
 .composer:focus-within {
   border-color: var(--fg-faint);
+}
+.composer--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+.composer--disabled:focus-within {
+  border-color: var(--border);
+  box-shadow: none;
 }
 .composer__caret {
   color: var(--accent);

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -46,8 +46,9 @@ func main() {
 		MinWidth:  760,
 		MinHeight: 480,
 		// Match the dark UI shell so first paint (before CSS loads) doesn't flash
-		// white — particularly visible on WebKitGTK.
-		BackgroundColour: &options.RGBA{R: 16, G: 17, B: 20, A: 255},
+		// white — particularly visible on WebKitGTK. Uses the dark theme's --bg
+		// colour (#1a1a2e = RGB 26,26,46).
+		BackgroundColour: &options.RGBA{R: 26, G: 26, B: 46, A: 255},
 		AssetServer:      &assetserver.Options{Assets: assets},
 		OnStartup:        app.startup,
 		OnShutdown:       app.shutdown,

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -84,44 +84,81 @@ func (h *Host) ReadResource(ctx context.Context, server, uri string) (string, er
 	return "", fmt.Errorf("no MCP server named %q", server)
 }
 
-// StartAll connects every plugin, performs the MCP handshake, and returns the
-// union of their tools (namespaced "mcp__<server>__<tool>"). On any failure it
-// tears down everything started so far. The caller must Close the Host.
+// StartAll connects every plugin in parallel, performs the MCP handshake, and
+// returns the union of their tools (namespaced "mcp__<server>__<tool>"). On any
+// failure it tears down everything started so far. The caller must Close the Host.
 //
 // For stdio plugins, subprocess lifetime is bound to ctx (via
 // exec.CommandContext): cancelling ctx kills the children and unblocks reads.
 func StartAll(ctx context.Context, specs []Spec) (*Host, []tool.Tool, error) {
+	if len(specs) == 0 {
+		return &Host{}, nil, nil
+	}
+
+	type result struct {
+		idx    int
+		client *Client
+		tools  []tool.Tool
+		err    error
+	}
+
+	// Start all plugins in parallel — each is an independent subprocess or
+	// HTTP connection with no cross-dependencies.
+	ch := make(chan result, len(specs))
+	for i, s := range specs {
+		go func(idx int, spec Spec) {
+			c, err := start(ctx, spec)
+			if err != nil {
+				ch <- result{idx: idx, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
+				return
+			}
+
+			ts, err := c.listTools(ctx)
+			if err != nil {
+				c.close()
+				ch <- result{idx: idx, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
+				return
+			}
+			c.toolCount = len(ts)
+
+			// Prompts and resources are auxiliary: only fetched when the server
+			// advertised the capability, and a listing error is tolerated (skipped)
+			// rather than failing the whole session over a non-essential surface.
+			if c.hasPrompts {
+				if ps, perr := c.listPrompts(ctx); perr == nil {
+					c.prompts = ps
+				}
+			}
+			if c.hasResources {
+				if rs, rerr := c.listResources(ctx); rerr == nil {
+					c.resources = rs
+				}
+			}
+
+			ch <- result{idx: idx, client: c, tools: ts}
+		}(i, s)
+	}
+
+	// Collect results in index order so the Host.clients slice matches the
+	// original specs order (stable for /mcp status display).
+	results := make([]result, len(specs))
+	for range specs {
+		r := <-ch
+		results[r.idx] = r
+	}
+
 	h := &Host{}
 	var tools []tool.Tool
-	for _, s := range specs {
-		c, err := start(ctx, s)
-		if err != nil {
+	for _, r := range results {
+		if r.err != nil {
+			// Close any plugins that already started before returning the error.
 			h.Close()
-			return nil, nil, fmt.Errorf("start plugin %q: %w", s.Name, err)
+			return nil, nil, r.err
 		}
-		h.clients = append(h.clients, c)
-
-		ts, err := c.listTools(ctx)
-		if err != nil {
-			h.Close()
-			return nil, nil, fmt.Errorf("list tools from %q: %w", s.Name, err)
-		}
-		tools = append(tools, ts...)
-		c.toolCount = len(ts)
-
-		// Prompts and resources are auxiliary: only fetched when the server
-		// advertised the capability, and a listing error is tolerated (skipped)
-		// rather than failing the whole session over a non-essential surface.
-		if c.hasPrompts {
-			if ps, perr := c.listPrompts(ctx); perr == nil {
-				h.prompts = append(h.prompts, ps...)
-			}
-		}
-		if c.hasResources {
-			if rs, rerr := c.listResources(ctx); rerr == nil {
-				h.resources = append(h.resources, rs...)
-			}
-		}
+		h.clients = append(h.clients, r.client)
+		tools = append(tools, r.tools...)
+		h.prompts = append(h.prompts, r.client.prompts...)
+		h.resources = append(h.resources, r.client.resources...)
 	}
 	return h, tools, nil
 }
@@ -148,6 +185,11 @@ type Client struct {
 
 	toolCount int    // tools discovered, for /mcp status
 	transport string // declared transport type, for /mcp status ("stdio"/"http")
+
+	// Prompts and resources discovered during StartAll, stored here so the
+	// parallel startup can collect them per-client before merging into Host.
+	prompts   []Prompt
+	resources []Resource
 }
 
 // ServerStatus summarises one connected server for the /mcp command.


### PR DESCRIPTION
## Summary

Desktop app was slow to open because boot.Build() ran synchronously in Wails OnStartup, blocking the webview from loading until all initialization completed (config loading, plugin subprocess startup, codegraph init, memory/skill scanning).

This PR makes the entire startup sequence non-blocking.

### Changes

**Go backend (app.go)**:
- Move ensureWorkspace(), config.Load(), i18n setup, and boot.Build() into a background goroutine
- startup() only sets up Wails context and returns immediately - webview loads instantly
- Add sync.RWMutex protecting ctrl/label/model fields accessed concurrently
- Emit agent:ready event when build completes; frontend re-fetches session

**Go backend (plugin.go)**:
- StartAll() now starts all MCP plugins in parallel instead of sequentially
- Each plugin runs concurrently: start subprocess, handshake, listTools, listPrompts/listResources
- Results collected in index order to preserve stable /mcp status display

**Frontend**:
- bridge.ts: add onReady() function subscribing to agent:ready event
- useController.ts: listen for agent:ready, re-fetch Meta/ContextUsage/History
- App.tsx: show loading spinner when meta.ready is false
- Composer.tsx: accept disabled prop, disable input during loading
- styles.css: add loading-screen and composer--disabled styles
- locales: add common.loading key

**main.go**:
- Update BackgroundColour from #101114 to #1a1a2e to match dark theme

### Testing

- go test ./desktop/... passes
- go test ./internal/plugin/... passes
- pnpm build succeeds