### PR TITLE
fix(provider): repair dangling tool_call pairing before send

### DIFF
--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -198,7 +198,7 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 		msgs = append(msgs, anthMessage{Role: role, Content: blocks})
 	}
 
-	for _, m := range req.Messages {
+	for _, m := range provider.SanitizeToolPairing(req.Messages) {
 		switch m.Role {
 		case provider.RoleSystem:
 			if m.Content != "" {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -169,8 +169,12 @@ func isTransientErr(err error) bool {
 }
 
 func (c *client) buildRequest(req provider.Request) chatRequest {
-	msgs := make([]chatMessage, len(req.Messages))
-	for i, m := range req.Messages {
+	// Repair tool-call pairing before sending: an interrupted/resumed history can
+	// carry an assistant tool_calls turn whose results never landed, which DeepSeek
+	// rejects with a 400 ("must be followed by tool messages …").
+	src := provider.SanitizeToolPairing(req.Messages)
+	msgs := make([]chatMessage, len(src))
+	for i, m := range src {
 		// reasoning_content is deliberately NOT sent back: it's a response-only
 		// field. DeepSeek accepts it but counts it as ordinary prompt input
 		// (measured ~500 extra tokens per turn on a reasoner chain), and the

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -117,6 +118,87 @@ func TestBuildRequestAlwaysSerializesContent(t *testing.T) {
 	}
 	if _, ok := raw[1]["tool_calls"]; !ok {
 		t.Errorf("assistant message lost its tool_calls: %s", b)
+	}
+}
+
+// TestStreamRepairsDanglingToolCalls reproduces and guards the DeepSeek 400
+// "An assistant message with 'tool_calls' must be followed by tool messages
+// responding to each 'tool_call_id'". A resumed/interrupted session can carry an
+// assistant tool_calls turn whose tool results never landed; the server here
+// mimics DeepSeek and rejects any unpaired tool_call with that exact 400, so the
+// request must be repaired before it is sent.
+func TestStreamRepairsDanglingToolCalls(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Messages []struct {
+				Role      string `json:"role"`
+				ToolCalls []struct {
+					ID string `json:"id"`
+				} `json:"tool_calls"`
+				ToolCallID string `json:"tool_call_id"`
+			} `json:"messages"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		answered := map[string]bool{}
+		for _, m := range req.Messages {
+			if m.Role == "tool" {
+				answered[m.ToolCallID] = true
+			}
+		}
+		for _, m := range req.Messages {
+			if m.Role != "assistant" {
+				continue
+			}
+			for _, tc := range m.ToolCalls {
+				if !answered[tc.ID] {
+					w.WriteHeader(http.StatusBadRequest)
+					_, _ = w.Write([]byte(`{"error":{"message":"An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}`))
+					return
+				}
+			}
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"done\"}}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":1,\"total_tokens\":6}}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek-flash", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// An assistant tool_calls turn whose tool result never landed (an interrupted
+	// turn), followed by a fresh user message — the exact shape that 400s.
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "list the files"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+				{ID: "call_1", Name: "ls", Arguments: `{"path":"."}`},
+			}},
+			{Role: provider.RoleUser, Content: "never mind, what time is it?"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Stream sent a dangling tool_calls to the API: %v", err)
+	}
+	var streamErr error
+	var text strings.Builder
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkText:
+			text.WriteString(chunk.Text)
+		case provider.ChunkError:
+			streamErr = chunk.Err
+		}
+	}
+	if streamErr != nil {
+		t.Fatalf("stream errored: %v", streamErr)
+	}
+	if text.String() != "done" {
+		t.Fatalf("completion text = %q, want \"done\"", text.String())
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -59,6 +59,52 @@ type Request struct {
 	MaxTokens   int
 }
 
+// interruptedToolResult stands in for a tool result that never landed — an
+// assistant tool_calls turn whose execution was cut short (interrupt, crash) and
+// later resumed. Sending such a turn unanswered trips the OpenAI/DeepSeek 400
+// "An assistant message with 'tool_calls' must be followed by tool messages
+// responding to each 'tool_call_id'".
+const interruptedToolResult = "[no result: the previous turn was interrupted before this tool call completed]"
+
+// SanitizeToolPairing repairs a history so it satisfies the tool-call contract the
+// OpenAI-compatible and Anthropic APIs enforce: every assistant tool_calls entry
+// must be answered by a following tool message for its id, and a tool message must
+// follow such a call. It backfills a placeholder result for any unanswered call
+// (so the turn stays intact) and drops orphan tool messages. Well-formed histories
+// pass through unchanged (results stay in call order). Callers send the result;
+// the stored session keeps the original.
+func SanitizeToolPairing(msgs []Message) []Message {
+	out := make([]Message, 0, len(msgs))
+	for i := 0; i < len(msgs); {
+		m := msgs[i]
+		if m.Role == RoleAssistant && len(m.ToolCalls) > 0 {
+			results := map[string]Message{}
+			j := i + 1
+			for j < len(msgs) && msgs[j].Role == RoleTool {
+				results[msgs[j].ToolCallID] = msgs[j]
+				j++
+			}
+			out = append(out, m)
+			for _, tc := range m.ToolCalls {
+				if r, ok := results[tc.ID]; ok {
+					out = append(out, r)
+				} else {
+					out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
+				}
+			}
+			i = j // tool messages consumed here; any non-matching ones are orphans, dropped
+			continue
+		}
+		if m.Role == RoleTool {
+			i++ // orphan tool message (no preceding assistant tool_calls) — drop
+			continue
+		}
+		out = append(out, m)
+		i++
+	}
+	return out
+}
+
 // ChunkType identifies the kind of a streamed increment.
 type ChunkType int
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,6 +6,98 @@ import (
 	"testing"
 )
 
+// --- SanitizeToolPairing ---
+
+// toolIDsAnswered reports whether every assistant tool_call id has a following
+// tool message answering it — the contract the OpenAI/DeepSeek API enforces.
+func toolIDsAnswered(msgs []Message) bool {
+	answered := map[string]bool{}
+	for _, m := range msgs {
+		if m.Role == RoleTool {
+			answered[m.ToolCallID] = true
+		}
+	}
+	for _, m := range msgs {
+		for _, tc := range m.ToolCalls {
+			if !answered[tc.ID] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func TestSanitizeToolPairingBackfillsDanglingCall(t *testing.T) {
+	in := []Message{
+		{Role: RoleUser, Content: "list files"},
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "ls"}}},
+		{Role: RoleUser, Content: "never mind"},
+	}
+	out := SanitizeToolPairing(in)
+	if !toolIDsAnswered(out) {
+		t.Fatalf("dangling tool_call left unanswered: %+v", out)
+	}
+	// The backfilled result sits right after the assistant turn, keyed to its id.
+	if out[2].Role != RoleTool || out[2].ToolCallID != "c1" {
+		t.Fatalf("expected a backfilled tool result for c1 at index 2, got %+v", out[2])
+	}
+}
+
+func TestSanitizeToolPairingKeepsCallOrderAndMultiple(t *testing.T) {
+	in := []Message{
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "a"}, {ID: "b"}, {ID: "c"}}},
+		{Role: RoleTool, ToolCallID: "b", Content: "B"}, // out of order, c missing
+		{Role: RoleTool, ToolCallID: "a", Content: "A"},
+	}
+	out := SanitizeToolPairing(in)
+	if !toolIDsAnswered(out) {
+		t.Fatalf("not all calls answered: %+v", out)
+	}
+	gotOrder := []string{out[1].ToolCallID, out[2].ToolCallID, out[3].ToolCallID}
+	want := []string{"a", "b", "c"}
+	for i := range want {
+		if gotOrder[i] != want[i] {
+			t.Fatalf("tool results out of call order: got %v want %v", gotOrder, want)
+		}
+	}
+}
+
+func TestSanitizeToolPairingDropsOrphanToolMessage(t *testing.T) {
+	in := []Message{
+		{Role: RoleUser, Content: "hi"},
+		{Role: RoleTool, ToolCallID: "ghost", Content: "leftover"}, // no preceding call
+		{Role: RoleAssistant, Content: "hello"},
+	}
+	out := SanitizeToolPairing(in)
+	for _, m := range out {
+		if m.Role == RoleTool {
+			t.Fatalf("orphan tool message survived: %+v", out)
+		}
+	}
+	if len(out) != 2 {
+		t.Fatalf("want 2 messages after dropping the orphan, got %d: %+v", len(out), out)
+	}
+}
+
+func TestSanitizeToolPairingLeavesWellFormedUnchanged(t *testing.T) {
+	in := []Message{
+		{Role: RoleSystem, Content: "sys"},
+		{Role: RoleUser, Content: "q"},
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "ls"}}},
+		{Role: RoleTool, ToolCallID: "c1", Name: "ls", Content: "main.go"},
+		{Role: RoleAssistant, Content: "done"},
+	}
+	out := SanitizeToolPairing(in)
+	if len(out) != len(in) {
+		t.Fatalf("well-formed history changed length: %d -> %d", len(in), len(out))
+	}
+	for i := range in {
+		if out[i].Role != in[i].Role || out[i].Content != in[i].Content || out[i].ToolCallID != in[i].ToolCallID {
+			t.Fatalf("well-formed message %d mutated: %+v -> %+v", i, in[i], out[i])
+		}
+	}
+}
+
 // --- Pricing.Cost ---
 
 func TestPricingCostNil(t *testing.T) {


### PR DESCRIPTION
## Problem

A turn could fail with the DeepSeek 400:

> An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'. (insufficient tool messages following tool_calls message)

An interrupted or resumed session can leave an assistant `tool_calls` turn whose tool results never landed. `buildRequest` shipped the history verbatim with no pairing validation, so that malformed shape went straight to the API and was rejected.

## Fix

New pure helper `provider.SanitizeToolPairing(msgs)`, run at the request boundary before send:
- backfills a placeholder `tool` result for any unanswered `tool_call_id` (keeps the turn intact)
- drops orphan `tool` messages (no preceding assistant `tool_calls`)
- leaves well-formed histories **byte-identical** — no prompt-cache impact

Wired into both the `openai` (DeepSeek/MiMo/…) and `anthropic` backends, which enforce the same pairing contract.

## Reproduction & verification (end-to-end)

`TestStreamRepairsDanglingToolCalls` stands up a mock server that enforces DeepSeek's contract (returns that exact 400 on any unpaired `tool_call`), then streams a dangling-`tool_calls` history through the real client:
- against the unfixed code it reproduces the 400
- with the fix it passes — the request is repaired before it leaves the client

Plus four unit tests for the helper (backfill, orphan-drop, call-order, well-formed-unchanged). `go test ./internal/provider/... ./internal/agent/... ./internal/control/...`, `go vet`, and `gofmt` all clean.
