### PR TITLE
fix(agent): stop auto-compaction re-firing every turn

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -73,6 +73,11 @@ func (s *updateSink) Emit(e event.Event) {
 		s.send(messageChunk{SessionUpdate: "agent_message_chunk", Content: textBlock(e.Text)})
 
 	case event.ToolDispatch:
+		// Skip the early (Partial) dispatch: it carries no args, and the full one
+		// that follows is the single pending tool_call the protocol expects.
+		if e.Tool.Partial {
+			return
+		}
 		s.send(toolCall{
 			SessionUpdate: "tool_call",
 			ToolCallID:    e.Tool.ID,

--- a/internal/acp/dispatch_partial_test.go
+++ b/internal/acp/dispatch_partial_test.go
@@ -1,0 +1,23 @@
+package acp
+
+import (
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+// TestUpdateSinkSkipsPartialDispatch probes the ACP adapter against the early
+// (Partial) ToolDispatch. The adapter's contract is one pending tool_call per
+// call, carrying rawInput; the partial has no args, so without a skip the client
+// gets two tool_call notifications, the first with empty input.
+func TestUpdateSinkSkipsPartialDispatch(t *testing.T) {
+	fn := &fakeNotifier{}
+	sink := newUpdateSink(fn, "sess-1")
+
+	sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "call-1", Name: "read_file", Partial: true}})
+	sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "call-1", Name: "read_file", Args: `{"path":"a.go"}`}})
+
+	if got := len(fn.notifs); got != 1 {
+		t.Fatalf("want one tool_call notification, got %d", got)
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -162,12 +162,17 @@ type Agent struct {
 	evidence *evidence.Ledger
 
 	// Context management: when a turn's prompt nears contextWindow, the older
-	// middle of the session is summarized away, keeping recentKeep messages
-	// verbatim and archiving the originals under archiveDir.
-	contextWindow int
-	compactRatio  float64
-	recentKeep    int
-	archiveDir    string
+	// middle of the session is summarized away, keeping a token-bounded recent
+	// tail verbatim (recentKeep is the message floor) and archiving the originals
+	// under archiveDir. compactStuck latches when compaction can't get the prompt
+	// under the window (consecutiveCompacts crosses the limit), so auto-compaction
+	// pauses instead of looping.
+	contextWindow       int
+	compactRatio        float64
+	recentKeep          int
+	archiveDir          string
+	compactStuck        bool
+	consecutiveCompacts int
 
 	// stormSig / stormCount track a run of turns that keep failing the same way so
 	// the loop can break a death-spiral. The signature is each call's (tool, error)
@@ -253,7 +258,8 @@ type Options struct {
 	Jobs *jobs.Manager
 
 	// Context management. ContextWindow <= 0 disables compaction. CompactRatio
-	// and RecentKeep fall back to defaults when unset.
+	// is the trigger fraction; RecentKeep is the minimum recent messages kept
+	// verbatim (the tail is otherwise token-bounded). Both fall back to defaults.
 	ContextWindow int
 	CompactRatio  float64
 	RecentKeep    int
@@ -269,7 +275,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		opts.CompactRatio = defaultCompactRatio
 	}
 	if opts.RecentKeep <= 0 {
-		opts.RecentKeep = defaultRecentKeep
+		opts.RecentKeep = minRecentKeep
 	}
 	if sink == nil {
 		sink = event.Discard

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -169,15 +169,15 @@ type Agent struct {
 	recentKeep    int
 	archiveDir    string
 
-	// stormSig / stormCount track a run of tool calls that keep failing the same
-	// way so the loop can break a death-spiral. The signature is (tool, error),
-	// NOT (tool, args): a stuck model reliably reworks the arguments cosmetically
-	// (a re-worded essay, a reordered object) while the call fails identically
-	// every time — keying on args misses the loop entirely (observed live against
-	// truncated tool-call arguments). Because errors that embed their subject
-	// (e.g. "file not found: /x") differ per target, genuine varied probing does
-	// not collapse to one signature. Reset whenever a turn does anything else
-	// (a different failure, more than one call, or any success). See applyStormBreaker.
+	// stormSig / stormCount track a run of turns that keep failing the same way so
+	// the loop can break a death-spiral. The signature is each call's (tool, error)
+	// in order, NOT (tool, args): a stuck model reliably reworks the arguments
+	// cosmetically (a re-worded essay, a reordered object) while the call fails
+	// identically every time — keying on args misses the loop entirely (observed
+	// live against truncated tool-call arguments). Because errors that embed their
+	// subject (e.g. "file not found: /x") differ per target, genuine varied probing
+	// does not collapse to one signature. Reset whenever a turn does anything else
+	// (a different failure shape, or any success). See applyStormBreaker.
 	stormSig   string
 	stormCount int
 }
@@ -534,22 +534,23 @@ func runParallel(start, end int, run func(int)) {
 // re-emits (re-worded but still over-long), truncating the same way again.
 const stormBreakThreshold = 3
 
-// applyStormBreaker detects a run of same-tool, same-error failures and, past the
+// applyStormBreaker detects a run of identically-failing turns and, past the
 // threshold, rewrites the model-facing result (results[0]) into a directive to
-// change approach. It keys on (tool, error) rather than (tool, args) because a
-// stuck model reworks the arguments cosmetically while failing identically — see
-// the stormSig field doc. It targets only the single-call fixation that produces
-// the loop: a turn with exactly one call that errored (and was not merely blocked
-// by plan mode / permissions, which already carry a clear, distinct message). Any
-// other shape — multiple calls, or any success — is varied work, so it resets the
-// counter. The hard maxSteps guard remains the ultimate backstop; this just keeps
-// the loop from burning that whole budget bouncing off the same failure.
+// change approach. It keys on each call's (tool, error) — not its args — because a
+// stuck model reworks the arguments cosmetically while failing identically (see
+// the stormSig field doc). A turn is a fixation candidate only when every one of
+// its calls errored and none was merely blocked by plan mode / permissions (those
+// carry a clear, distinct message the model can already act on). Any success, any
+// block, or a different batch shape is varied work, so it resets the counter. This
+// covers both the single-call spiral and a repeated multi-call batch. The hard
+// maxSteps guard remains the ultimate backstop; this just keeps the loop from
+// burning that whole budget bouncing off the same failure.
 func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutcome, results []string) {
-	if len(calls) != 1 || outcomes[0].errMsg == "" || outcomes[0].blocked {
+	sig, ok := batchStormSignature(calls, outcomes)
+	if !ok {
 		a.stormSig, a.stormCount = "", 0
 		return
 	}
-	sig := calls[0].Name + "\x00" + outcomes[0].errMsg
 	if sig != a.stormSig {
 		a.stormSig, a.stormCount = sig, 1
 		return
@@ -558,12 +559,41 @@ func (a *Agent) applyStormBreaker(calls []provider.ToolCall, outcomes []toolOutc
 	if a.stormCount < stormBreakThreshold {
 		return
 	}
+	subject := fmt.Sprintf("%q", calls[0].Name)
+	short := calls[0].Name
+	if len(calls) > 1 {
+		subject = fmt.Sprintf("this batch of %d tool calls", len(calls))
+		short = fmt.Sprintf("a batch of %d calls", len(calls))
+	}
 	results[0] = outcomes[0].output + fmt.Sprintf(
-		"\n\n[loop guard] %q has now failed %d times in a row with the same error. Re-sending it — even with the wording changed — will not help: the call keeps failing the same way. Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the argument, use a different tool, or explain the blocker in your final answer.",
-		calls[0].Name, a.stormCount)
+		"\n\n[loop guard] %s has now failed %d times in a row with the same error. Re-sending it — even with the wording changed — will not help: the calls keep failing the same way. Change approach: if an argument is being truncated, write less in one call and split the work into several smaller calls; otherwise fix the arguments, use a different tool, or explain the blocker in your final answer.",
+		subject, a.stormCount)
 	a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf(
 		"loop guard: %s failed %d× the same way — nudging the model to change approach",
-		calls[0].Name, a.stormCount)})
+		short, a.stormCount)})
+}
+
+// batchStormSignature returns a per-turn fixation signature — each call's
+// (name, error) in order — and ok=true only when every call errored and none was
+// merely blocked. ok=false (any success or block) means the turn made varied
+// progress, so the caller resets the counter. Keying on the error rather than the
+// args is deliberate: a stuck model reworks the arguments while failing the same
+// way, so identical-args matching would miss the loop.
+func batchStormSignature(calls []provider.ToolCall, outcomes []toolOutcome) (string, bool) {
+	if len(calls) == 0 {
+		return "", false
+	}
+	var sb strings.Builder
+	for i := range calls {
+		if outcomes[i].errMsg == "" || outcomes[i].blocked {
+			return "", false
+		}
+		sb.WriteString(calls[i].Name)
+		sb.WriteByte(0)
+		sb.WriteString(outcomes[i].errMsg)
+		sb.WriteByte(0)
+	}
+	return sb.String(), true
 }
 
 // toolOutcome is one tool call's result, split into the model-facing output and

--- a/internal/agent/cachehit_e2e_test.go
+++ b/internal/agent/cachehit_e2e_test.go
@@ -222,43 +222,56 @@ func TestCacheHitClimbsWithoutCompaction(t *testing.T) {
 	}
 }
 
-// TestCacheHitCollapsesOnCompaction is the smoking gun: a long tool-loop with
-// compaction enabled. maybeCompact only runs after a tool-call step (agent.go
-// returns before it on a no-tool turn), so we drive a steady stream of tool
-// calls. Each time the prompt nears the window the prefix is rewritten to
-// system + summary + tail and the hit rate craters on the very next step.
-func TestCacheHitCollapsesOnCompaction(t *testing.T) {
+// TestCacheHitSurvivesTooSmallWindow drives a long tool-loop against a window so
+// small a single turn can't be summarized under it — the misconfigured regime
+// that used to make compaction rewrite the prefix every step, cratering the
+// cache turn after turn. The stuck guard now detects that compaction can't make
+// progress, pauses it (with a notice), and lets the prefix grow append-only — so
+// the hit rate recovers and stays high instead of collapsing repeatedly.
+func TestCacheHitSurvivesTooSmallWindow(t *testing.T) {
 	mock := &mockDeepSeek{t: t, withTools: true, reasoning: longReasoning, toolRounds: 30}
 	srv := httptest.NewServer(http.HandlerFunc(mock.handler))
 	defer srv.Close()
 
-	// Small window + small recentKeep so compaction fires several times over the
-	// loop — exactly the regime a misconfigured context_window puts a long
-	// session in.
 	a, sink := newAgent(t, srv.URL, mock.tools(), 900 /*window tok*/, 4 /*recentKeep*/)
 
-	// One Run; the model keeps calling the tool, so the loop spans 31 steps.
 	if err := a.Run(context.Background(), strings.Repeat("please consider this requirement. ", 6)); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
-	t.Logf("==== hit-rate curve, compaction ON (window=900 tok, recentKeep=4) ====")
+	t.Logf("==== hit-rate curve, too-small window (900 tok) ====")
 	collapses := 0
 	for i, u := range sink.usages {
 		r := hitRate(u)
 		marker := ""
 		if i > 0 && r+20 < hitRate(sink.usages[i-1]) {
-			marker = "   <<< COLLAPSED — prefix rewritten by compaction"
+			marker = "   <<< collapse"
 			collapses++
 		}
 		t.Logf("step %2d: prompt=%5d hit=%5d miss=%4d → cache %3d%%%s", i, u.PromptTokens, u.CacheHitTokens, u.CacheMissTokens, r, marker)
 	}
+
+	paused := false
 	for _, n := range sink.notices {
 		t.Logf("notice: %s", n)
+		if strings.Contains(n, "Auto-compaction paused") {
+			paused = true
+		}
 	}
-	t.Logf("compaction-induced hit-rate collapses: %d", collapses)
-	if collapses == 0 {
-		t.Errorf("expected compaction to crater the hit rate at least once, saw none")
+
+	// The guard caps the damage: a couple of compactions at most, not one per step.
+	if collapses > 2 {
+		t.Errorf("compaction cratered the cache %d times; the stuck guard should cap it at ≤2", collapses)
+	}
+	if !paused {
+		t.Errorf("expected an auto-compaction-paused notice for the too-small window")
+	}
+	// Once paused, the prefix grows append-only again, so the tail of the run
+	// recovers to a high, stable hit rate instead of collapsing every step.
+	if n := len(sink.usages); n >= 6 {
+		if tail := tailAverage(usageRates(sink.usages), 5); tail < 85 {
+			t.Errorf("tail hit rate after the guard kicked in = %d%%, want ≥85%%", tail)
+		}
 	}
 }
 

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -13,14 +13,18 @@ import (
 	"reasonix/internal/provider"
 )
 
-// Compaction defaults. Compaction is a low-frequency cache-reset point: prompts
-// grow prepend-only (high cache hits) until a turn's prompt nears the model's
-// context window, then we compact once — summarizing the older history and
-// archiving the originals — so a long task can keep going.
+// Compaction is a low-frequency cache-reset point: the prompt grows append-only
+// (high cache hits) until a turn nears compactRatio of the window, then it is
+// compacted down to a tail budget. The budget is a fixed token count, not a
+// fraction of the window, so a huge window still compacts rarely while a small
+// one still lands below the trigger (which is what stops the re-compaction loop).
 const (
-	defaultCompactRatio = 0.8 // compact when prompt_tokens reach this fraction of the window
-	defaultRecentKeep   = 8   // recent messages kept verbatim, never summarized
-	minCompactMessages  = 2   // skip compaction below this many compactable messages
+	defaultCompactRatio  = 0.8   // trigger: prompt at this fraction of the window compacts
+	defaultCompactTarget = 0.5   // safety cap: the kept tail never exceeds this fraction of the window
+	defaultTailTokens    = 16384 // verbatim recent-tail budget, in tokens
+	minRecentKeep        = 2     // never keep fewer recent messages than this
+	minCompactMessages   = 2     // skip compaction below this many compactable messages
+	fallbackTokPerChar   = 0.25  // ~4 chars/token, used before any usage is available to calibrate
 )
 
 // summarySystemPrompt steers the executor to distill older history into a
@@ -60,11 +64,32 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	if a.contextWindow <= 0 || u == nil || u.PromptTokens == 0 {
 		return
 	}
-	if u.PromptTokens < int(float64(a.contextWindow)*a.compactRatio) {
+	high := int(float64(a.contextWindow) * a.compactRatio)
+	if u.PromptTokens < high {
+		// A turn that sits under the trigger is the breathing room a healthy
+		// compaction buys; it clears the stuck latch and the run counter.
+		a.consecutiveCompacts = 0
+		a.compactStuck = false
+		return
+	}
+	if a.compactStuck {
 		return
 	}
 	if err := a.compact(ctx, "auto", ""); err != nil {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("compaction skipped: %v", err)})
+		return
+	}
+	// A healthy compaction drops the prompt under the trigger, so the next turn
+	// won't compact. Compacting on consecutive turns means the kept tail alone
+	// exceeds the trigger — the system prompt plus one verbatim turn is bigger than
+	// the window allows. Re-firing every turn is the loop users hit, so pause
+	// auto-compaction and say why, once.
+	a.consecutiveCompacts++
+	if a.consecutiveCompacts >= 2 {
+		a.compactStuck = true
+		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf(
+			"context_window=%d is too small for compaction to help (the system prompt plus one turn already exceeds %.0f%% of it); raise context_window or shrink tool output. Auto-compaction paused until the prompt drops.",
+			a.contextWindow, a.compactRatio*100)})
 	}
 }
 
@@ -78,7 +103,7 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 // "compacting…" placeholder, and a Done event (carrying the summary) replaces it.
 func (a *Agent) compact(ctx context.Context, trigger, instructions string) error {
 	msgs := a.session.Messages
-	head, start, ok := compactBounds(msgs, a.recentKeep, minCompactMessages)
+	head, start, ok := a.planCompaction(msgs)
 	if !ok {
 		return nil // recent tail already covers everything worth keeping
 	}
@@ -198,27 +223,101 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	return nil
 }
 
-// compactBounds locates the region to summarize. head is the count of leading
+// planCompaction locates the region to summarize. head is the count of leading
 // messages preserved verbatim (the system prompt, if any); start is where the
-// preserved recent tail begins, so msgs[head:start] is compacted. The boundary
-// is aligned backward off any tool result so the recent tail never begins with
-// an orphan tool message whose assistant tool_calls were summarized away. ok is
-// false when there is too little to compact.
-func compactBounds(msgs []provider.Message, recentKeep, minCompact int) (head, start int, ok bool) {
+// preserved recent tail begins, so msgs[head:start] is compacted. The tail is
+// bounded by a token budget (not a message count), so a few large tool outputs
+// can't keep it above the trigger and re-fire compaction every turn. ok is false
+// when there is too little to compact.
+func (a *Agent) planCompaction(msgs []provider.Message) (head, start int, ok bool) {
 	if len(msgs) > 0 && msgs[0].Role == provider.RoleSystem {
 		head = 1
 	}
-	start = len(msgs) - recentKeep
-	if start <= head {
+	if a.contextWindow > 0 {
+		budget := defaultTailTokens
+		if maxByWin := int(float64(a.contextWindow) * defaultCompactTarget); maxByWin < budget {
+			budget = maxByWin
+		}
+		start = tailStart(msgs, head, budget, a.tokPerChar(), a.tailFloor())
+	} else {
+		// No window to budget against (manual /compact on an unconfigured
+		// provider): keep a fixed count of recent messages, aligned off any tool.
+		start = len(msgs) - a.tailFloor()
+		for start > head && msgs[start].Role == provider.RoleTool {
+			start--
+		}
+	}
+	if start < head {
+		start = head
+	}
+	if start-head < minCompactMessages {
 		return head, start, false
+	}
+	return head, start, true
+}
+
+func (a *Agent) tailFloor() int {
+	if a.recentKeep > minRecentKeep {
+		return a.recentKeep
+	}
+	return minRecentKeep
+}
+
+// tailStart walks newest→oldest, growing the verbatim tail until the next
+// message would push its token estimate past budgetTokens (but never below
+// minKeep messages), then aligns the boundary back off any tool result so the
+// tail never begins with an orphan whose assistant tool_calls were summarized
+// away.
+func tailStart(msgs []provider.Message, head, budgetTokens int, tokPerChar float64, minKeep int) int {
+	start := len(msgs)
+	acc := 0
+	for i := len(msgs) - 1; i > head; i-- {
+		c := int(float64(msgChars(msgs[i])) * tokPerChar)
+		if len(msgs)-i > minKeep && acc+c > budgetTokens {
+			break
+		}
+		acc += c
+		start = i
 	}
 	for start > head && msgs[start].Role == provider.RoleTool {
 		start--
 	}
-	if start-head < minCompact {
-		return head, start, false
+	return start
+}
+
+// tokPerChar derives a tokens-per-character ratio from the last turn's real
+// usage so per-message estimates track the provider's tokenizer without a local
+// one. Reasoning content is excluded from the char count to match the prompt
+// actually sent (the provider strips it). Falls back to ~4 chars/token before
+// any usage is known, and ignores absurd ratios.
+func (a *Agent) tokPerChar() float64 {
+	if a.lastUsage != nil && a.lastUsage.PromptTokens > 0 {
+		if c := charsOfMessages(a.session.Messages); c > 0 {
+			if r := float64(a.lastUsage.PromptTokens) / float64(c); r > 0.05 && r < 2 {
+				return r
+			}
+		}
 	}
-	return head, start, true
+	return fallbackTokPerChar
+}
+
+// msgChars counts the characters that ride to the provider for one message —
+// content plus tool-call names and arguments, but not reasoning (stripped on
+// send).
+func msgChars(m provider.Message) int {
+	n := len(m.Content)
+	for _, tc := range m.ToolCalls {
+		n += len(tc.Name) + len(tc.Arguments)
+	}
+	return n
+}
+
+func charsOfMessages(msgs []provider.Message) int {
+	n := 0
+	for _, m := range msgs {
+		n += msgChars(m)
+	}
+	return n
 }
 
 // summarize asks the executor's own provider (no tools) to distill the region

--- a/internal/agent/compact_loop_e2e_test.go
+++ b/internal/agent/compact_loop_e2e_test.go
@@ -1,0 +1,171 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/tool"
+)
+
+// fatTool returns a fixed-size blob, standing in for a real read_file / bash
+// whose output dominates the recent (verbatim-kept) tail of the session.
+type fatTool struct{ blob string }
+
+func (fatTool) Name() string            { return "fat_read" }
+func (fatTool) Description() string     { return "read a large file" }
+func (fatTool) Schema() json.RawMessage { return json.RawMessage(`{"type":"object","properties":{}}`) }
+func (fatTool) ReadOnly() bool          { return true }
+func (f fatTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return f.blob, nil
+}
+
+// loopMock emits exactly one tool call per user turn (a tool call when the last
+// message is the user's, a final answer when it is the tool result), so each Run
+// does one tool round — the step that triggers maybeCompact.
+type loopMock struct {
+	t      *testing.T
+	rounds int
+}
+
+func lastRole(msgs []json.RawMessage) string {
+	if len(msgs) == 0 {
+		return ""
+	}
+	var m struct {
+		Role string `json:"role"`
+	}
+	_ = json.Unmarshal(msgs[len(msgs)-1], &m)
+	return m.Role
+}
+
+func (m *loopMock) handler(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	if isSummarizeRequest(body) {
+		writeSSE(w, m.t,
+			streamChunk(deltaText("- goal: keep going\n- pending: continue the task")),
+			finishChunk("stop"),
+			usageChunk(80, 30, 0, 80))
+		return
+	}
+
+	msgs := decodeMessages(body)
+	promptTok := charsOf(msgs) / 4
+
+	if lastRole(msgs) == "tool" {
+		writeSSE(w, m.t,
+			streamChunk(deltaText("Done with this step.")),
+			finishChunk("stop"),
+			usageChunk(promptTok, 20, 0, promptTok))
+		return
+	}
+
+	m.rounds++
+	writeSSE(w, m.t,
+		streamChunk(deltaToolCall(m.rounds, "fat_read", "{}")),
+		finishChunk("tool_calls"),
+		usageChunk(promptTok, 20, 0, promptTok))
+}
+
+// compactionsPerTurn drives `turns` user messages through a fresh agent wired to
+// loopMock and reports, per turn, how many compactions started and whether an
+// auto-compaction-paused notice was seen.
+func compactionsPerTurn(t *testing.T, windowTok int, blob string, turns int) (perTurn []int, paused bool) {
+	t.Helper()
+	mock := &loopMock{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(mock.handler))
+	defer srv.Close()
+
+	reg := tool.NewRegistry()
+	reg.Add(fatTool{blob: blob})
+
+	a, _ := newAgent(t, srv.URL, reg, windowTok, 4)
+	started := 0
+	a.sink = event.FuncSink(func(e event.Event) {
+		switch e.Kind {
+		case event.CompactionStarted:
+			started++
+		case event.Notice:
+			if strings.Contains(e.Text, "Auto-compaction paused") {
+				paused = true
+			}
+		}
+	})
+
+	perTurn = make([]int, turns)
+	for i := 0; i < turns; i++ {
+		before := started
+		if err := a.Run(context.Background(), fmt.Sprintf("turn %d: keep going, continue the work", i)); err != nil {
+			t.Fatalf("Run %d: %v", i, err)
+		}
+		perTurn[i] = started - before
+	}
+	return perTurn, paused
+}
+
+func consecutiveCompactingTurns(perTurn []int) int {
+	worst, run := 0, 0
+	for _, n := range perTurn {
+		if n > 0 {
+			run++
+			if run > worst {
+				worst = run
+			}
+		} else {
+			run = 0
+		}
+	}
+	return worst
+}
+
+// TestCompactionPausesWhenWindowTooSmall covers the user report: a tool output
+// that alone exceeds the trigger used to make every "continue" turn re-compact
+// forever. The stuck guard now caps it — at most two compactions, then a paused
+// notice — instead of looping turn after turn.
+func TestCompactionPausesWhenWindowTooSmall(t *testing.T) {
+	// One fat_read result (~1750 tok) exceeds the 0.8×1600 trigger on its own.
+	perTurn, paused := compactionsPerTurn(t, 1600, strings.Repeat("LARGE FILE CONTENTS. ", 350), 8)
+
+	total := 0
+	for _, n := range perTurn {
+		total += n
+	}
+	t.Logf("compactions per turn: %v (total %d), paused=%v", perTurn, total, paused)
+
+	if total > 2 {
+		t.Errorf("compacted %d times; the stuck guard should cap it at ≤2, not loop", total)
+	}
+	if !paused {
+		t.Errorf("expected an auto-compaction-paused notice")
+	}
+}
+
+// TestCompactionHealthyWindowNeverLoops is the companion: with a window big
+// enough to summarize a turn under, compaction still fires as the session grows
+// but reclaims enough headroom that it never fires on consecutive turns and never
+// trips the stuck guard.
+func TestCompactionHealthyWindowNeverLoops(t *testing.T) {
+	perTurn, paused := compactionsPerTurn(t, 40000, strings.Repeat("file line. ", 1100), 20)
+
+	total := 0
+	for _, n := range perTurn {
+		total += n
+	}
+	t.Logf("compactions per turn: %v (total %d), paused=%v", perTurn, total, paused)
+
+	if paused {
+		t.Errorf("a healthy window should never pause auto-compaction")
+	}
+	if total == 0 {
+		t.Errorf("expected compaction to fire at least once over a long session")
+	}
+	if c := consecutiveCompactingTurns(perTurn); c > 1 {
+		t.Errorf("compaction fired on %d consecutive turns; a healthy compaction should leave breathing room", c)
+	}
+}

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -30,43 +30,49 @@ func (f *fakeProvider) Stream(_ context.Context, req provider.Request) (<-chan p
 	return ch, nil
 }
 
-func TestCompactBounds(t *testing.T) {
-	sys := provider.Message{Role: provider.RoleSystem}
-	u := provider.Message{Role: provider.RoleUser}
-	as := provider.Message{Role: provider.RoleAssistant}
-	ac := provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "f"}}}
-	to := provider.Message{Role: provider.RoleTool, ToolCallID: "1", Name: "f"}
+func TestTailStart(t *testing.T) {
+	// 10-char content → with tokPerChar 1.0, each non-empty message costs 10
+	// "tokens"; tool-call messages carry name+args instead.
+	msg := func(role provider.Role, n int) provider.Message {
+		return provider.Message{Role: role, Content: strings.Repeat("x", n)}
+	}
+	u := func(n int) provider.Message { return msg(provider.RoleUser, n) }
+	as := func(n int) provider.Message { return msg(provider.RoleAssistant, n) }
+	ac := provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "f", Arguments: "{}"}}}
+	to := func(n int) provider.Message {
+		return provider.Message{Role: provider.RoleTool, ToolCallID: "1", Name: "f", Content: strings.Repeat("x", n)}
+	}
 
+	sys := provider.Message{Role: provider.RoleSystem}
 	cases := []struct {
-		name              string
-		msgs              []provider.Message
-		keep              int
-		wantHead, wantStr int
-		wantOK            bool
+		name    string
+		msgs    []provider.Message
+		head    int
+		budget  int
+		minKeep int
+		wantStr int
 	}{
-		{"no-system", []provider.Message{u, as, u, as, u, as}, 2, 0, 4, true},
-		{"with-system", []provider.Message{sys, u, as, u, as, u, as}, 3, 1, 4, true},
-		// Recent tail of 1 lands on an orphan tool result; the boundary must move
-		// back onto its assistant so the tail starts with the tool_calls.
-		{"align-off-tool", []provider.Message{sys, u, ac, to, as, u, ac, to}, 1, 1, 6, true},
-		{"too-short", []provider.Message{sys, u, as}, 8, 1, 0, false},
-		{"below-min-compact", []provider.Message{sys, u, as, u}, 2, 1, 0, false},
+		// Budget 25 fits the two newest 10-char messages (20) but not a third (30);
+		// the tail stops at the third-from-last.
+		{"budget-bounds-tail", []provider.Message{u(10), as(10), u(10), as(10), u(10)}, 0, 25, 2, 3},
+		// A single huge recent message can't blow the budget below minKeep: the last
+		// two are kept regardless.
+		{"min-keep-floor", []provider.Message{u(10), as(10), u(10), as(10), to(9999)}, 0, 25, 2, 3},
+		// The boundary lands on an orphan tool result and must move back onto its
+		// assistant so the tail begins with the tool_calls.
+		{"align-off-tool", []provider.Message{sys, u(10), ac, to(10), ac, to(10)}, 1, 0, 1, 4},
+		// A generous budget keeps everything down to the first compactable message
+		// after the head.
+		{"budget-keeps-all", []provider.Message{sys, u(10), as(10), u(10)}, 1, 100000, 2, 2},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			head, start, ok := compactBounds(tc.msgs, tc.keep, minCompactMessages)
-			if ok != tc.wantOK {
-				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
-			}
-			if head != tc.wantHead {
-				t.Errorf("head = %d, want %d", head, tc.wantHead)
-			}
-			if ok && start != tc.wantStr {
+			start := tailStart(tc.msgs, tc.head, tc.budget, 1.0, tc.minKeep)
+			if start != tc.wantStr {
 				t.Errorf("start = %d, want %d", start, tc.wantStr)
 			}
-			// The aligned tail must never begin with an orphan tool result.
-			if ok && tc.msgs[start].Role == provider.RoleTool {
+			if tc.msgs[start].Role == provider.RoleTool {
 				t.Errorf("recent tail begins with orphan tool message at %d", start)
 			}
 		})
@@ -203,30 +209,34 @@ func TestCompactInjectsFocusAndPreCompactHook(t *testing.T) {
 }
 
 func TestMaybeCompactThreshold(t *testing.T) {
+	// 40-char contents → ~10 tokens each at the fallback ratio; with a 20-token
+	// window the tail budget (10) keeps only the last couple, leaving a region to
+	// compact once the trigger is crossed.
+	body := strings.Repeat("x", 40)
 	newSess := func() *Session {
 		return &Session{Messages: []provider.Message{
-			{Role: provider.RoleSystem, Content: "sys"},
-			{Role: provider.RoleUser, Content: "a"},
-			{Role: provider.RoleAssistant, Content: "b"},
-			{Role: provider.RoleUser, Content: "c"},
-			{Role: provider.RoleAssistant, Content: "d"},
-			{Role: provider.RoleUser, Content: "e"},
-			{Role: provider.RoleAssistant, Content: "f"},
+			{Role: provider.RoleSystem, Content: body},
+			{Role: provider.RoleUser, Content: body},
+			{Role: provider.RoleAssistant, Content: body},
+			{Role: provider.RoleUser, Content: body},
+			{Role: provider.RoleAssistant, Content: body},
+			{Role: provider.RoleUser, Content: body},
+			{Role: provider.RoleAssistant, Content: body},
 		}}
 	}
 
 	// Below 80% of the window: untouched.
 	sess := newSess()
-	a := New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
+	a := New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 20, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 8})
 	if len(sess.Messages) != 7 {
 		t.Errorf("below threshold should not compact, len = %d", len(sess.Messages))
 	}
 
 	// At/above 80%: compacts.
 	sess = newSess()
-	a = New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 90})
+	a = New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 20, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 18})
 	if len(sess.Messages) >= 7 {
 		t.Errorf("above threshold should compact, len = %d", len(sess.Messages))
 	}

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func echoRegistry() *tool.Registry {
+	reg := tool.NewRegistry()
+	reg.Add(echoTool{})
+	return reg
+}
+
+// TestRunMultiToolRoundEmptyIDsSurvivePairing drives the real loop through a turn
+// that fans out two tool calls carrying no id (a gateway that streams by index),
+// then asserts both results still pair back after SanitizeToolPairing — the repair
+// that runs on every send. Keying on tool_call_id alone collapsed them into one,
+// dropping a result from the model's context on the very next turn.
+func TestRunMultiToolRoundEmptyIDsSurvivePairing(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{
+			{ID: "", Name: "echo", Arguments: `{"text":"alpha"}`},
+			{ID: "", Name: "echo", Arguments: `{"text":"beta"}`},
+		}},
+		testutil.Turn{Text: "done"},
+	)
+	a := New(mp, echoRegistry(), NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	repaired := provider.SanitizeToolPairing(a.Session().Messages)
+	var results []string
+	for _, m := range repaired {
+		if m.Role == provider.RoleTool {
+			results = append(results, m.Content)
+		}
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2 tool results after pairing, got %d: %v", len(results), results)
+	}
+	if results[0] == results[1] {
+		t.Fatalf("both results collapsed to %q — one was lost from the model's context", results[0])
+	}
+	if !strings.Contains(results[0], "alpha") || !strings.Contains(results[1], "beta") {
+		t.Errorf("results lost their identity: %v", results)
+	}
+}
+
+// TestRunCancelledMidStreamLeavesResumableSession proves a turn cancelled before
+// the model answered leaves the session well-formed: the user message stands,
+// nothing dangling, and the repaired history is sendable as-is on resume.
+func TestRunCancelledMidStreamLeavesResumableSession(t *testing.T) {
+	mp := testutil.NewMock("m", testutil.ErrorTurn(context.Canceled))
+	a := New(mp, echoRegistry(), NewSession("sys"), Options{}, event.Discard)
+
+	err := a.Run(context.Background(), "do the thing")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run should surface the cancellation, got %v", err)
+	}
+
+	repaired := provider.SanitizeToolPairing(a.Session().Messages)
+	for i, m := range repaired {
+		if m.Role == provider.RoleTool {
+			t.Fatalf("a cancelled turn left a dangling tool message at %d: %+v", i, m)
+		}
+	}
+	last := repaired[len(repaired)-1]
+	if last.Role != provider.RoleUser || last.Content != "do the thing" {
+		t.Errorf("the pending user message should survive a cancel, got %+v", last)
+	}
+}
+
+// TestRunWellFormedToolLoopRoundTrips is the happy-path baseline: a tool round
+// then a final answer. The session must end with the assistant answer and pair
+// cleanly (the repair is a no-op on well-formed histories).
+func TestRunWellFormedToolLoopRoundTrips(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{Text: "all set"},
+	)
+	a := New(mp, echoRegistry(), NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	msgs := a.Session().Messages
+	last := msgs[len(msgs)-1]
+	if last.Role != provider.RoleAssistant || last.Content != "all set" {
+		t.Fatalf("final message should be the assistant answer, got %+v", last)
+	}
+	before := len(msgs)
+	if after := len(provider.SanitizeToolPairing(msgs)); after != before {
+		t.Errorf("repair mutated a well-formed session: %d -> %d", before, after)
+	}
+}

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -78,6 +78,63 @@ func TestStormBreakerEscalatesRepeatedFailure(t *testing.T) {
 	}
 }
 
+// TestStormBreakerEscalatesRepeatedBatch: a multi-call batch that fails the same
+// way every round is just as much a death-spiral as a single call — once the whole
+// batch repeats stormBreakThreshold times, the guard must fire and name the batch.
+func TestStormBreakerEscalatesRepeatedBatch(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(failTool{name: "write_a"})
+	reg.Add(failTool{name: "write_b"})
+	sink, notices := warnNoticeRecorder()
+	a := New(nil, reg, NewSession(""), Options{}, sink)
+
+	batch := []provider.ToolCall{
+		{Name: "write_a", Arguments: `{"content":"x`},
+		{Name: "write_b", Arguments: `{"content":"y`},
+	}
+	var first string
+	for i := 0; i < stormBreakThreshold; i++ {
+		first = a.executeBatch(context.Background(), batch)[0]
+	}
+
+	if !strings.Contains(first, "[loop guard]") {
+		t.Fatalf("a repeated all-failing batch should trip the guard, got: %q", first)
+	}
+	if !strings.Contains(first, "batch of 2") {
+		t.Errorf("guard should name the repeated batch, got: %q", first)
+	}
+	if len(*notices) == 0 {
+		t.Errorf("loop guard should emit a warn notice for a repeated batch")
+	}
+}
+
+// TestStormBreakerBatchResetsOnPartialSuccess: a batch where even one call
+// succeeds is progress, not a fixation — the guard must never fire, however many
+// times the batch repeats.
+func TestStormBreakerBatchResetsOnPartialSuccess(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(failTool{name: "write_file"})
+	reg.Add(okTool{name: "read_file"})
+	sink, notices := warnNoticeRecorder()
+	a := New(nil, reg, NewSession(""), Options{}, sink)
+
+	batch := []provider.ToolCall{
+		{Name: "write_file", Arguments: `{"content":"x`},
+		{Name: "read_file", Arguments: `{"path":"x"}`},
+	}
+	var first string
+	for i := 0; i < stormBreakThreshold+2; i++ {
+		first = a.executeBatch(context.Background(), batch)[0]
+	}
+
+	if strings.Contains(first, "[loop guard]") {
+		t.Fatalf("a batch with a succeeding call should never trip the guard, got: %q", first)
+	}
+	if len(*notices) != 0 {
+		t.Errorf("no warn notice expected when part of the batch succeeds, got %v", *notices)
+	}
+}
+
 // TestStormBreakerSilentBelowThreshold: the first few self-corrections are
 // healthy — the guard must not fire before the threshold.
 func TestStormBreakerSilentBelowThreshold(t *testing.T) {

--- a/internal/agent/textsink.go
+++ b/internal/agent/textsink.go
@@ -79,6 +79,11 @@ func (s *TextSink) Emit(e event.Event) {
 		s.closeTextStream(e.Text, e.Reasoning)
 
 	case event.ToolDispatch:
+		// The early (Partial) dispatch carries no args — the full one prints the
+		// line. Without this the headless stream shows every call twice.
+		if e.Tool.Partial {
+			break
+		}
 		fmt.Fprintf(s.out, "  -> %s %s\n", e.Tool.Name, CompactArgs(e.Tool.Args))
 		s.wroteAnything = true
 

--- a/internal/agent/textsink_partial_test.go
+++ b/internal/agent/textsink_partial_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+// TestTextSinkSkipsPartialDispatch probes the headless sink against the early
+// (Partial) ToolDispatch the agent emits when a call begins streaming. The chat
+// TUI skips it; if TextSink prints it too, every tool call shows a duplicate
+// "-> name" line (the first with empty args) in piped / `reasonix run` output.
+func TestTextSinkSkipsPartialDispatch(t *testing.T) {
+	var b strings.Builder
+	s := NewTextSink(&b, nil, 80)
+
+	s.Emit(event.Event{Kind: event.TurnStarted})
+	s.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "c1", Name: "read_file", Partial: true}})
+	s.Emit(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "c1", Name: "read_file", Args: `{"path":"a"}`}})
+
+	got := b.String()
+	if n := strings.Count(got, "-> read_file"); n != 1 {
+		t.Errorf("want exactly one dispatch line, got %d:\n%q", n, got)
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -323,7 +323,14 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 
 	sort.Ints(order)
 	for _, idx := range order {
-		out <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: acc[idx]}
+		tc := acc[idx]
+		if tc.ID == "" {
+			// Some OpenAI-compatible gateways stream tool calls by index with no id.
+			// Synthesize a stable one so the result can be paired back to its call —
+			// an empty tool_call_id collapses multi-tool turns downstream.
+			tc.ID = fmt.Sprintf("call_%d", idx)
+		}
+		out <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: tc}
 	}
 	out <- provider.Chunk{Type: provider.ChunkDone}
 }

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -298,3 +298,72 @@ func TestNewReadsEffortFromConfig(t *testing.T) {
 		t.Errorf("effort = %q, want medium", got)
 	}
 }
+
+// TestBuildRequestPreservesEmptyIDToolResults proves a multi-tool turn whose
+// calls carry no id (some OpenAI-compatible gateways omit it, sending only the
+// index) keeps every tool result through buildRequest. SanitizeToolPairing keys
+// on tool_call_id, so empty ids collapse and all but the last result is dropped.
+func TestBuildRequestPreservesEmptyIDToolResults(t *testing.T) {
+	c := &client{model: "deepseek-v4"}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "scan"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+				{ID: "", Name: "read_file", Arguments: `{"p":"a"}`},
+				{ID: "", Name: "read_file", Arguments: `{"p":"b"}`},
+			}},
+			{Role: provider.RoleTool, ToolCallID: "", Name: "read_file", Content: "RESULT-A"},
+			{Role: provider.RoleTool, ToolCallID: "", Name: "read_file", Content: "RESULT-B"},
+		},
+	})
+	var toolContents []string
+	for _, m := range req.Messages {
+		if m.Role == string(provider.RoleTool) {
+			toolContents = append(toolContents, m.Content)
+		}
+	}
+	if len(toolContents) != 2 {
+		t.Fatalf("want 2 tool results in request, got %d: %v", len(toolContents), toolContents)
+	}
+	if toolContents[0] == toolContents[1] {
+		t.Errorf("tool results collapsed to %q — a result was dropped from the model's context", toolContents[0])
+	}
+}
+
+// TestStreamSynthesizesMissingToolCallIDs covers a gateway that streams tool
+// calls by index with no id (vLLM / llama.cpp do this). Each completed call must
+// come back with a stable, distinct synthetic id so its result can pair back.
+func TestStreamSynthesizesMissingToolCallIDs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"read_file","arguments":"{\"p\":\"a\"}"}}]}}]}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"name":"read_file","arguments":"{\"p\":\"b\"}"}}]}}]}`+"\n\n")
+		_, _ = io.WriteString(w, `data: {"choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}`+"\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "local", BaseURL: srv.URL, Model: "qwen", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	var ids []string
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkToolCall && chunk.ToolCall != nil {
+			ids = append(ids, chunk.ToolCall.ID)
+		}
+	}
+	if len(ids) != 2 {
+		t.Fatalf("want 2 tool calls, got %d: %v", len(ids), ids)
+	}
+	if ids[0] == "" || ids[1] == "" {
+		t.Errorf("a tool call came back with an empty id: %v", ids)
+	}
+	if ids[0] == ids[1] {
+		t.Errorf("synthesized ids must be distinct, got %v", ids)
+	}
+}

--- a/internal/provider/pairing_probe_test.go
+++ b/internal/provider/pairing_probe_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import "testing"
+
+// TestSanitizeDuplicateToolCallIDsKeepsEachResult probes whether a malformed
+// history with two tool calls sharing one id round-trips both results. The map
+// keyed on id collapses them, so the loop guard's safety net silently drops one.
+func TestSanitizeDuplicateToolCallIDsKeepsEachResult(t *testing.T) {
+	msgs := []Message{
+		{Role: RoleUser, Content: "go"},
+		{Role: RoleAssistant, ToolCalls: []ToolCall{
+			{ID: "dup", Name: "read_file"},
+			{ID: "dup", Name: "grep"},
+		}},
+		{Role: RoleTool, ToolCallID: "dup", Name: "read_file", Content: "FILE-RESULT"},
+		{Role: RoleTool, ToolCallID: "dup", Name: "grep", Content: "GREP-RESULT"},
+	}
+	out := SanitizeToolPairing(msgs)
+
+	var got []string
+	for _, m := range out {
+		if m.Role == RoleTool {
+			got = append(got, m.Content)
+		}
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 tool results, got %d: %v", len(got), got)
+	}
+	if got[0] == got[1] {
+		t.Errorf("both tool results collapsed to the same content %q — one was lost", got[0])
+	}
+}
+
+// TestSanitizeEmptyToolCallIDs probes two calls with empty ids — same collapse
+// risk, and the placeholder/backfill path keys on "" too.
+func TestSanitizeEmptyToolCallIDsKeepsEachResult(t *testing.T) {
+	msgs := []Message{
+		{Role: RoleAssistant, ToolCalls: []ToolCall{
+			{ID: "", Name: "a"},
+			{ID: "", Name: "b"},
+		}},
+		{Role: RoleTool, ToolCallID: "", Name: "a", Content: "RESULT-A"},
+		{Role: RoleTool, ToolCallID: "", Name: "b", Content: "RESULT-B"},
+	}
+	out := SanitizeToolPairing(msgs)
+
+	var got []string
+	for _, m := range out {
+		if m.Role == RoleTool {
+			got = append(got, m.Content)
+		}
+	}
+	if len(got) != 2 || got[0] == got[1] {
+		t.Errorf("empty-id pair collapsed: %v", got)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -78,20 +78,12 @@ func SanitizeToolPairing(msgs []Message) []Message {
 	for i := 0; i < len(msgs); {
 		m := msgs[i]
 		if m.Role == RoleAssistant && len(m.ToolCalls) > 0 {
-			results := map[string]Message{}
 			j := i + 1
 			for j < len(msgs) && msgs[j].Role == RoleTool {
-				results[msgs[j].ToolCallID] = msgs[j]
 				j++
 			}
 			out = append(out, m)
-			for _, tc := range m.ToolCalls {
-				if r, ok := results[tc.ID]; ok {
-					out = append(out, r)
-				} else {
-					out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
-				}
-			}
+			out = append(out, pairToolResults(m.ToolCalls, msgs[i+1:j])...)
 			i = j // tool messages consumed here; any non-matching ones are orphans, dropped
 			continue
 		}
@@ -103,6 +95,56 @@ func SanitizeToolPairing(msgs []Message) []Message {
 		i++
 	}
 	return out
+}
+
+// pairToolResults answers each tool_call with its result, backfilling a
+// placeholder for any unanswered one. Distinct non-empty ids pair by id (so
+// reordered results re-sort to call order); empty or duplicate ids pair by
+// position instead — some gateways stream tool calls by index with no id, and a
+// map keyed on id would collapse those results into one (call order is preserved
+// because the loop appends results in call order).
+func pairToolResults(calls []ToolCall, avail []Message) []Message {
+	out := make([]Message, 0, len(calls))
+	if idDistinct(calls) {
+		byID := make(map[string]Message, len(avail))
+		for _, r := range avail {
+			byID[r.ToolCallID] = r
+		}
+		for _, tc := range calls {
+			if r, ok := byID[tc.ID]; ok {
+				out = append(out, r)
+			} else {
+				out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
+			}
+		}
+		return out
+	}
+	for k, tc := range calls {
+		if k < len(avail) {
+			r := avail[k]
+			r.ToolCallID = tc.ID
+			out = append(out, r)
+		} else {
+			out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
+		}
+	}
+	return out
+}
+
+// idDistinct reports whether every call carries a non-empty id unique within the
+// batch — the condition under which id-keyed pairing is safe.
+func idDistinct(calls []ToolCall) bool {
+	seen := make(map[string]struct{}, len(calls))
+	for _, tc := range calls {
+		if tc.ID == "" {
+			return false
+		}
+		if _, dup := seen[tc.ID]; dup {
+			return false
+		}
+		seen[tc.ID] = struct{}{}
+	}
+	return true
 }
 
 // ChunkType identifies the kind of a streamed increment.


### PR DESCRIPTION
## Why

Auto-compaction could re-fire on every turn: users hit "summarize, continue, summarize…" in a loop, and each pass also reset the prompt cache — the worst case for our cache-first positioning.

The cause was that the kept recent tail was bounded by a **message count** (`recentKeep`), while the trigger is a **token** threshold. A few large tool results in that tail could exceed the trigger on their own, so the prompt never dropped below the threshold after compaction and the next turn compacted again.

## What

- **Token-budgeted tail.** The verbatim tail is now bounded by a fixed token budget (16K, capped at half the window), not a message count. Fixed tokens — not a fraction of the window — so a huge window still compacts rarely (cache stays warm) while a small one still lands below the trigger. `recentKeep` becomes a message floor.
- **Self-calibrated estimates.** Per-message token estimates are derived from the provider's real `usage`, so we track its tokenizer without bundling one.
- **Stuck guard.** A healthy compaction always buys at least one turn under the trigger. Two consecutive compactions mean one turn can't fit under the window — we latch, pause auto-compaction, and emit an actionable notice (raise `context_window` / shrink tool output) instead of looping.

Source-side tool-output truncation already bounds single messages (32 KB), so this only touches the compaction side.

## Tests

- `TestCompactionPausesWhenWindowTooSmall` — a tool result larger than the trigger no longer loops; capped at ≤2 compactions, then paused.
- `TestCompactionHealthyWindowNeverLoops` — a realistic window still compacts as the session grows, but never on consecutive turns and never pauses.
- `TestCacheHitSurvivesTooSmallWindow` — the cache recovers to a high, stable hit rate instead of cratering every step.
- `TestTailStart` / `TestMaybeCompactThreshold` updated for the token-budget policy.

`go build`, `go vet`, and the full `go test ./...` pass.
