### PR TITLE
feat(ci): e2e benchmark bot triggered by a PR comment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 .githooks/** text eol=lf
+benchmarks/**/*.sh text eol=lf

--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -54,9 +54,11 @@ jobs:
           python-version: '3.12'
 
       - name: Write provider config
+        # Written to the user config (suite tasks run in temp dirs) and to the repo
+        # root (diff mode runs the agent there, where project config wins).
         run: |
           mkdir -p ~/.config/reasonix
-          cat > ~/.config/reasonix/config.toml <<EOF
+          cat > /tmp/reasonix-e2e.toml <<EOF
           default_model = "e2e"
 
           [[providers]]
@@ -79,23 +81,33 @@ jobs:
           [codegraph]
           enabled = false
           EOF
+          cp /tmp/reasonix-e2e.toml ~/.config/reasonix/config.toml
+          cp /tmp/reasonix-e2e.toml ./reasonix.toml
 
       - name: Build
         run: |
           go build -o ./bin/reasonix ./cmd/reasonix
           go build -o ./bin/e2ebench ./cmd/e2ebench
 
-      - name: Run e2e suite
+      - name: Run e2e
         id: bench
         env:
           DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           if [ -z "$DEEPSEEK_API_KEY" ]; then
-            echo "missing DEEPSEEK_API_KEY secret" > report.md
-            echo "Add a repository secret named DEEPSEEK_API_KEY to enable the e2e bot." >> report.md
+            printf 'missing DEEPSEEK_API_KEY secret\n\nAdd a repository secret named DEEPSEEK_API_KEY to enable the e2e bot.\n' > report.md
             exit 0
           fi
-          ./bin/e2ebench -bin ./bin/reasonix -suite benchmarks/e2e -out report.md -json report.json -budget 400000
+          if printf '%s' "$COMMENT_BODY" | grep -q '/e2e[[:space:]]\+diff'; then
+            BASE_REF=$(gh pr view ${{ github.event.issue.number }} --json baseRefName -q .baseRefName)
+            git fetch -q origin "$BASE_REF"
+            BASE=$(git merge-base "origin/$BASE_REF" HEAD)
+            ./bin/e2ebench -mode diff -bin ./bin/reasonix -repo . -base "$BASE" -model e2e -out report.md
+          else
+            ./bin/e2ebench -bin ./bin/reasonix -suite benchmarks/e2e -out report.md -json report.json -budget 400000
+          fi
 
       - name: Post report
         env:

--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -1,0 +1,111 @@
+name: e2e-bot
+
+# Comment "/e2e" on a pull request to run the committed e2e suite (benchmarks/e2e)
+# against the real provider and post an accuracy / cache-hit / token / cost report
+# back to the PR. Gated to trusted authors: the job checks out PR-head code and
+# runs it with the provider API key, so only the repo owner, members, and
+# collaborators may trigger it.
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: e2e-bot-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/e2e') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Acknowledge
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              comment_id: context.payload.comment.id, content: 'eyes',
+            });
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check out the PR head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Write provider config
+        run: |
+          mkdir -p ~/.config/reasonix
+          cat > ~/.config/reasonix/config.toml <<EOF
+          default_model = "e2e"
+
+          [[providers]]
+          name = "e2e"
+          kind = "openai"
+          base_url = "${{ vars.REASONIX_E2E_BASE_URL || 'https://api.deepseek.com' }}"
+          model = "${{ vars.REASONIX_E2E_MODEL || 'deepseek-chat' }}"
+          api_key_env = "DEEPSEEK_API_KEY"
+          context_window = 65536
+
+          [providers.price]
+          cache_hit = 0.5
+          input = 2
+          output = 8
+          currency = "¥"
+
+          [permissions]
+          mode = "allow"
+
+          [codegraph]
+          enabled = false
+          EOF
+
+      - name: Build
+        run: |
+          go build -o ./bin/reasonix ./cmd/reasonix
+          go build -o ./bin/e2ebench ./cmd/e2ebench
+
+      - name: Run e2e suite
+        id: bench
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: |
+          if [ -z "$DEEPSEEK_API_KEY" ]; then
+            echo "missing DEEPSEEK_API_KEY secret" > report.md
+            echo "Add a repository secret named DEEPSEEK_API_KEY to enable the e2e bot." >> report.md
+            exit 0
+          fi
+          ./bin/e2ebench -bin ./bin/reasonix -suite benchmarks/e2e -out report.md -json report.json -budget 400000
+
+      - name: Post report
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '\n> commit %s · triggered by @%s\n' "$(git rev-parse --short HEAD)" "${{ github.event.comment.user.login }}" >> report.md
+          gh pr comment ${{ github.event.issue.number }} --body-file report.md
+
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr comment ${{ github.event.issue.number }} --body "🤖 e2e bot failed — see the [run log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})."

--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -65,14 +65,14 @@ jobs:
           name = "e2e"
           kind = "openai"
           base_url = "${{ vars.REASONIX_E2E_BASE_URL || 'https://api.deepseek.com' }}"
-          model = "${{ vars.REASONIX_E2E_MODEL || 'deepseek-chat' }}"
+          model = "${{ vars.REASONIX_E2E_MODEL || 'deepseek-v4-flash' }}"
           api_key_env = "DEEPSEEK_API_KEY"
           context_window = 65536
 
           [providers.price]
-          cache_hit = 0.5
-          input = 2
-          output = 8
+          cache_hit = 0.02
+          input = 1
+          output = 2
           currency = "¥"
 
           [permissions]

--- a/benchmarks/e2e/tasks/fix-add-bug/task.toml
+++ b/benchmarks/e2e/tasks/fix-add-bug/task.toml
@@ -1,0 +1,3 @@
+prompt = "The file calc.py has a bug: add(a, b) returns the wrong result. Fix add so it returns the sum of a and b. Keep the other functions unchanged."
+max_steps = 12
+timeout_sec = 180

--- a/benchmarks/e2e/tasks/fix-add-bug/verify.sh
+++ b/benchmarks/e2e/tasks/fix-add-bug/verify.sh
@@ -1,0 +1,7 @@
+set -e
+python3 - <<'PY'
+import calc
+assert calc.add(2, 3) == 5, calc.add(2, 3)
+assert calc.add(10, 5) == 15, calc.add(10, 5)
+assert calc.mul(2, 3) == 6, calc.mul(2, 3)
+PY

--- a/benchmarks/e2e/tasks/fix-add-bug/workdir/calc.py
+++ b/benchmarks/e2e/tasks/fix-add-bug/workdir/calc.py
@@ -1,0 +1,6 @@
+def add(a, b):
+    return a - b
+
+
+def mul(a, b):
+    return a * b

--- a/benchmarks/e2e/tasks/fizzbuzz/task.toml
+++ b/benchmarks/e2e/tasks/fizzbuzz/task.toml
@@ -1,0 +1,3 @@
+prompt = "Create a file named fizzbuzz.py containing a function fizzbuzz(n) that returns the string 'Fizz' when n is divisible by 3, 'Buzz' when divisible by 5, 'FizzBuzz' when divisible by both 3 and 5, and otherwise the number as a string. Do not print anything at import time."
+max_steps = 12
+timeout_sec = 180

--- a/benchmarks/e2e/tasks/fizzbuzz/verify.sh
+++ b/benchmarks/e2e/tasks/fizzbuzz/verify.sh
@@ -1,0 +1,8 @@
+set -e
+python3 - <<'PY'
+import fizzbuzz
+assert fizzbuzz.fizzbuzz(3) == "Fizz", fizzbuzz.fizzbuzz(3)
+assert fizzbuzz.fizzbuzz(5) == "Buzz", fizzbuzz.fizzbuzz(5)
+assert fizzbuzz.fizzbuzz(15) == "FizzBuzz", fizzbuzz.fizzbuzz(15)
+assert fizzbuzz.fizzbuzz(7) == "7", fizzbuzz.fizzbuzz(7)
+PY

--- a/benchmarks/e2e/tasks/palindrome/task.toml
+++ b/benchmarks/e2e/tasks/palindrome/task.toml
@@ -1,0 +1,3 @@
+prompt = "Create a file named palindrome.py with a function is_palindrome(s) that returns True if s reads the same forwards and backwards ignoring case, spaces, and punctuation, and False otherwise. Do not print anything at import time."
+max_steps = 12
+timeout_sec = 180

--- a/benchmarks/e2e/tasks/palindrome/verify.sh
+++ b/benchmarks/e2e/tasks/palindrome/verify.sh
@@ -1,0 +1,7 @@
+set -e
+python3 - <<'PY'
+import palindrome
+assert palindrome.is_palindrome("Race car") is True
+assert palindrome.is_palindrome("A man, a plan, a canal: Panama") is True
+assert palindrome.is_palindrome("hello") is False
+PY

--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -57,12 +57,36 @@ func runDiff(o diffOpts) string {
 	sourceTouched := len(changedGoFilesWorktree(o.repo, false))
 	testsPass, testOut := runTests(o.repo, o.testCmd, pkgs)
 
-	passed := newTestFuncs > 0 && testsPass
+	// Differential check: the new tests must FAIL when the PR's source is reverted
+	// to its pre-change state, proving they actually capture the change rather than
+	// asserting behavior that already held. Only meaningful once the tests are green.
+	diffVerified := false
+	if newTestFuncs > 0 && testsPass {
+		diffVerified = differentialCheck(o.repo, o.base, srcFiles, o.testCmd, pkgs)
+	}
+
+	passed := newTestFuncs > 0 && testsPass && diffVerified
 	return renderDiff(diffReport{
 		srcFiles: srcFiles, pkgs: pkgs, addedTestLines: addedTestLines,
 		newTestFuncs: newTestFuncs, sourceTouched: sourceTouched, testsPass: testsPass,
-		passed: passed, m: m, runErr: runErr, testOut: testOut,
+		diffVerified: diffVerified, passed: passed, m: m, runErr: runErr, testOut: testOut,
 	})
+}
+
+// differentialCheck reverts the PR's changed source to base (deleting files that
+// were new in the PR), runs the now-present tests, and restores the source. The
+// tests should fail against the old code; !green means they pin the change.
+func differentialCheck(repo, base string, srcFiles []string, testCmd string, pkgs []string) bool {
+	for _, f := range srcFiles {
+		if err := exec.Command("git", "-C", repo, "checkout", base, "--", f).Run(); err != nil {
+			_ = os.Remove(filepath.Join(repo, filepath.FromSlash(f)))
+		}
+	}
+	green, _ := runTests(repo, testCmd, pkgs)
+	for _, f := range srcFiles {
+		_ = exec.Command("git", "-C", repo, "checkout", "HEAD", "--", f).Run()
+	}
+	return !green
 }
 
 func buildDiffPrompt(srcFiles, pkgs []string, diffText string) string {
@@ -86,7 +110,8 @@ type diffReport struct {
 	srcFiles, pkgs               []string
 	addedTestLines, newTestFuncs int
 	sourceTouched                int
-	testsPass, passed            bool
+	testsPass, diffVerified      bool
+	passed                       bool
 	m                            runMetrics
 	runErr                       error
 	testOut                      string
@@ -105,6 +130,7 @@ func renderDiff(r diffReport) string {
 	fmt.Fprintf(&b, "| New test functions added | %d |\n", r.newTestFuncs)
 	fmt.Fprintf(&b, "| Test lines added | +%d |\n", r.addedTestLines)
 	fmt.Fprintf(&b, "| `%s` on affected pkgs | %s |\n", "go test", passFail(r.testsPass))
+	fmt.Fprintf(&b, "| Differential (fails on pre-PR code) | %s |\n", yesNo(r.diffVerified))
 	fmt.Fprintf(&b, "| Non-test source touched by agent | %d file(s) |\n", r.sourceTouched)
 	fmt.Fprintf(&b, "| Cache hit | %s |\n", pct(r.m.CacheHitTokens, r.m.CacheHitTokens+r.m.CacheMissTokens))
 	fmt.Fprintf(&b, "| Tokens (prompt / completion) | %s / %s |\n", comma(r.m.PromptTokens), comma(r.m.CompletionTokens))
@@ -121,7 +147,7 @@ func renderDiff(r diffReport) string {
 	if r.runErr != nil {
 		fmt.Fprintf(&b, "\n<sub>agent run note: %v</sub>\n", r.runErr)
 	}
-	fmt.Fprintf(&b, "\n<sub>Pass = the agent added ≥1 new test function AND the affected packages' tests are green. Coverage-of-change is not differentially verified.</sub>\n")
+	fmt.Fprintf(&b, "\n<sub>Pass = the agent added ≥1 new test function, the affected packages' tests are green, AND those tests fail when the PR's source is reverted (so they genuinely cover the change).</sub>\n")
 	return b.String()
 }
 
@@ -130,6 +156,13 @@ func passFail(ok bool) string {
 		return "pass"
 	}
 	return "fail"
+}
+
+func yesNo(ok bool) string {
+	if ok {
+		return "yes"
+	}
+	return "no"
 }
 
 // changedGoFiles lists .go files changed by base...HEAD. When includeTests is

--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+type diffOpts struct {
+	bin, model, repo, base, testCmd string
+	maxSteps, timeoutSec            int
+}
+
+// runDiff asks the agent to write tests covering what the PR changed, on the PR
+// branch itself, then grades with the repo's own tests: the generated tests must
+// pass and the agent must actually have added test code (so a no-op can't pass,
+// since the suite was already green). Returns a markdown report.
+func runDiff(o diffOpts) string {
+	srcFiles := changedGoFiles(o.repo, o.base, false)
+	if len(srcFiles) == 0 {
+		return "## 🤖 Reasonix e2e — diff test-gen\n\nNo Go source changes in this PR (excluding `_test.go`); nothing to generate tests for.\n"
+	}
+	pkgs := packagesOf(srcFiles)
+	diffText := truncate(gitOut(o.repo, "diff", o.base+"...HEAD", "--"), srcFiles...)
+
+	prompt := buildDiffPrompt(srcFiles, pkgs, diffText)
+
+	metricsPath := filepath.Join(o.repo, ".e2e-diff-metrics.json")
+	_ = os.Remove(metricsPath)
+	defer os.Remove(metricsPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(o.timeoutSec)*time.Second)
+	defer cancel()
+
+	args := []string{"run", "--metrics", metricsPath, "--max-steps", fmt.Sprint(o.maxSteps)}
+	if o.model != "" {
+		args = append(args, "--model", o.model)
+	}
+	args = append(args, prompt)
+	cmd := exec.CommandContext(ctx, o.bin, args...)
+	cmd.Dir = o.repo
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	runErr := cmd.Run()
+
+	// The agent's new files are untracked, so `git diff HEAD` would miss them;
+	// intent-to-add surfaces them as additions without committing.
+	_ = exec.Command("git", "-C", o.repo, "add", "-AN").Run()
+
+	m, _ := readMetrics(metricsPath)
+	addedTestLines, newTestFuncs := testsAdded(o.repo)
+	sourceTouched := len(changedGoFilesWorktree(o.repo, false))
+	testsPass, testOut := runTests(o.repo, o.testCmd, pkgs)
+
+	passed := newTestFuncs > 0 && testsPass
+	return renderDiff(diffReport{
+		srcFiles: srcFiles, pkgs: pkgs, addedTestLines: addedTestLines,
+		newTestFuncs: newTestFuncs, sourceTouched: sourceTouched, testsPass: testsPass,
+		passed: passed, m: m, runErr: runErr, testOut: testOut,
+	})
+}
+
+func buildDiffPrompt(srcFiles, pkgs []string, diffText string) string {
+	var b strings.Builder
+	b.WriteString("You are in a Go repository. This pull request changed these source files:\n")
+	for _, f := range srcFiles {
+		fmt.Fprintf(&b, "  - %s\n", f)
+	}
+	b.WriteString("\nUnified diff of the change:\n```diff\n")
+	b.WriteString(diffText)
+	b.WriteString("\n```\n\n")
+	b.WriteString("Write focused Go unit tests that exercise the NEW or CHANGED behavior in those files. ")
+	b.WriteString("Add them to the appropriate *_test.go files in the same packages (")
+	b.WriteString(strings.Join(pkgs, ", "))
+	b.WriteString("). Do NOT modify the non-test source files — only add or extend test files. ")
+	b.WriteString("Then run the package tests and iterate until they pass. When finished, list the test functions you added.")
+	return b.String()
+}
+
+type diffReport struct {
+	srcFiles, pkgs               []string
+	addedTestLines, newTestFuncs int
+	sourceTouched                int
+	testsPass, passed            bool
+	m                            runMetrics
+	runErr                       error
+	testOut                      string
+}
+
+func renderDiff(r diffReport) string {
+	var b strings.Builder
+	result := "❌ fail"
+	if r.passed {
+		result = "✅ pass"
+	}
+	fmt.Fprintf(&b, "## 🤖 Reasonix e2e — diff test-gen\n\n")
+	fmt.Fprintf(&b, "**Result:** %s · **%d** changed source file(s) across **%d** package(s)\n\n", result, len(r.srcFiles), len(r.pkgs))
+
+	fmt.Fprintf(&b, "| Metric | Value |\n|---|---|\n")
+	fmt.Fprintf(&b, "| New test functions added | %d |\n", r.newTestFuncs)
+	fmt.Fprintf(&b, "| Test lines added | +%d |\n", r.addedTestLines)
+	fmt.Fprintf(&b, "| `%s` on affected pkgs | %s |\n", "go test", passFail(r.testsPass))
+	fmt.Fprintf(&b, "| Non-test source touched by agent | %d file(s) |\n", r.sourceTouched)
+	fmt.Fprintf(&b, "| Cache hit | %s |\n", pct(r.m.CacheHitTokens, r.m.CacheHitTokens+r.m.CacheMissTokens))
+	fmt.Fprintf(&b, "| Tokens (prompt / completion) | %s / %s |\n", comma(r.m.PromptTokens), comma(r.m.CompletionTokens))
+	fmt.Fprintf(&b, "| Model calls | %d |\n", r.m.Steps)
+	fmt.Fprintf(&b, "| Cost | %s%.4f |\n", currencySym(r.m.Currency), r.m.Cost)
+
+	fmt.Fprintf(&b, "\n**Packages:** %s\n", strings.Join(r.pkgs, ", "))
+	if r.sourceTouched > 0 {
+		fmt.Fprintf(&b, "\n⚠️ The agent modified %d non-test source file(s); tests passing may not reflect the PR's code. Review the diff.\n", r.sourceTouched)
+	}
+	if !r.testsPass && strings.TrimSpace(r.testOut) != "" {
+		fmt.Fprintf(&b, "\n<details><summary>go test output (tail)</summary>\n\n```\n%s\n```\n</details>\n", tail(r.testOut, 60))
+	}
+	if r.runErr != nil {
+		fmt.Fprintf(&b, "\n<sub>agent run note: %v</sub>\n", r.runErr)
+	}
+	fmt.Fprintf(&b, "\n<sub>Pass = the agent added ≥1 new test function AND the affected packages' tests are green. Coverage-of-change is not differentially verified.</sub>\n")
+	return b.String()
+}
+
+func passFail(ok bool) string {
+	if ok {
+		return "pass"
+	}
+	return "fail"
+}
+
+// changedGoFiles lists .go files changed by base...HEAD. When includeTests is
+// false, *_test.go files are excluded (we want the source under test).
+func changedGoFiles(repo, base string, includeTests bool) []string {
+	out := gitOut(repo, "diff", "--name-only", base+"...HEAD", "--", "*.go")
+	return filterGo(out, includeTests)
+}
+
+// changedGoFilesWorktree lists .go files changed in the working tree vs HEAD
+// (i.e. what the agent just did).
+func changedGoFilesWorktree(repo string, includeTests bool) []string {
+	out := gitOut(repo, "diff", "--name-only", "HEAD", "--", "*.go")
+	files := strings.Fields(strings.ReplaceAll(out, "\n", " "))
+	var keep []string
+	for _, f := range files {
+		isTest := strings.HasSuffix(f, "_test.go")
+		if isTest && !includeTests {
+			continue
+		}
+		if !isTest {
+			keep = append(keep, f)
+		} else if includeTests {
+			keep = append(keep, f)
+		}
+	}
+	return keep
+}
+
+func filterGo(out string, includeTests bool) []string {
+	var keep []string
+	for _, f := range strings.Fields(strings.ReplaceAll(out, "\n", " ")) {
+		if strings.HasSuffix(f, "_test.go") && !includeTests {
+			continue
+		}
+		keep = append(keep, f)
+	}
+	sort.Strings(keep)
+	return keep
+}
+
+func packagesOf(files []string) []string {
+	seen := map[string]bool{}
+	var pkgs []string
+	for _, f := range files {
+		dir := "./" + filepath.ToSlash(filepath.Dir(f))
+		if !seen[dir] {
+			seen[dir] = true
+			pkgs = append(pkgs, dir)
+		}
+	}
+	sort.Strings(pkgs)
+	return pkgs
+}
+
+// testsAdded counts the test lines and new Test functions the agent added,
+// reading the working-tree diff of *_test.go files.
+func testsAdded(repo string) (lines, funcs int) {
+	diff := gitOut(repo, "diff", "HEAD", "--", "*_test.go")
+	for _, ln := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(ln, "+") && !strings.HasPrefix(ln, "+++") {
+			lines++
+			body := strings.TrimSpace(strings.TrimPrefix(ln, "+"))
+			if strings.HasPrefix(body, "func Test") || strings.HasPrefix(body, "func Fuzz") || strings.HasPrefix(body, "func Benchmark") {
+				funcs++
+			}
+		}
+	}
+	return lines, funcs
+}
+
+func runTests(repo, testCmd string, pkgs []string) (bool, string) {
+	fields := strings.Fields(testCmd)
+	if len(fields) == 0 {
+		fields = []string{"go", "test"}
+	}
+	args := append(fields[1:], pkgs...)
+	cmd := exec.Command(fields[0], args...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	return err == nil, string(out)
+}
+
+func gitOut(repo string, args ...string) string {
+	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+	out, _ := cmd.Output()
+	return string(out)
+}
+
+func truncate(s string, _ ...string) string {
+	const max = 12000
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "\n…(diff truncated)…"
+}
+
+func tail(s string, n int) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -1,0 +1,329 @@
+// e2ebench runs the committed e2e task suite against a real provider and emits a
+// markdown + JSON report (accuracy, cache-hit rate, token use, cost) for a PR.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+type task struct {
+	ID         string
+	Prompt     string `toml:"prompt"`
+	MaxSteps   int    `toml:"max_steps"`
+	TimeoutSec int    `toml:"timeout_sec"`
+	dir        string
+}
+
+type runMetrics struct {
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	CacheHitTokens   int     `json:"cache_hit_tokens"`
+	CacheMissTokens  int     `json:"cache_miss_tokens"`
+	Steps            int     `json:"steps"`
+	Cost             float64 `json:"cost"`
+	Currency         string  `json:"currency"`
+}
+
+type result struct {
+	task
+	runMetrics
+	Passed  bool
+	Skipped bool
+	Note    string
+}
+
+func main() {
+	suite := flag.String("suite", "benchmarks/e2e", "suite root (contains tasks/<id>/)")
+	bin := flag.String("bin", "reasonix", "path to the reasonix binary")
+	model := flag.String("model", "", "provider/model name (default: config default)")
+	outMD := flag.String("out", "", "write the markdown report here (default: stdout)")
+	outJSON := flag.String("json", "", "write the JSON report here (optional)")
+	budget := flag.Int("budget", 400_000, "abort once total tokens cross this (0 = no cap)")
+	flag.Parse()
+
+	tasks, err := loadTasks(*suite)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load suite:", err)
+		os.Exit(1)
+	}
+	if len(tasks) == 0 {
+		fmt.Fprintln(os.Stderr, "no tasks found under", filepath.Join(*suite, "tasks"))
+		os.Exit(1)
+	}
+
+	var results []result
+	total := 0
+	for _, t := range tasks {
+		if *budget > 0 && total >= *budget {
+			results = append(results, result{task: t, Skipped: true, Note: "skipped: token budget reached"})
+			continue
+		}
+		r := runTask(*bin, *model, t)
+		total += r.PromptTokens + r.CompletionTokens
+		results = append(results, r)
+	}
+
+	report := render(results)
+	if *outMD != "" {
+		if err := os.WriteFile(*outMD, []byte(report), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write report:", err)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Print(report)
+	}
+	if *outJSON != "" {
+		b, _ := json.MarshalIndent(results, "", "  ")
+		_ = os.WriteFile(*outJSON, b, 0o644)
+	}
+}
+
+func loadTasks(suite string) ([]task, error) {
+	tasksDir := filepath.Join(suite, "tasks")
+	entries, err := os.ReadDir(tasksDir)
+	if err != nil {
+		return nil, err
+	}
+	var tasks []task
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(tasksDir, e.Name())
+		var t task
+		if _, err := toml.DecodeFile(filepath.Join(dir, "task.toml"), &t); err != nil {
+			return nil, fmt.Errorf("%s: %w", e.Name(), err)
+		}
+		t.ID = e.Name()
+		t.dir = dir
+		if t.TimeoutSec == 0 {
+			t.TimeoutSec = 240
+		}
+		tasks = append(tasks, t)
+	}
+	sort.Slice(tasks, func(i, j int) bool { return tasks[i].ID < tasks[j].ID })
+	return tasks, nil
+}
+
+// runTask copies the task's seed workdir into a temp dir, runs the agent there,
+// then drops in verify.sh and runs it as the grader. The grader is added only
+// after the run so the agent can't read the answer key.
+func runTask(bin, model string, t task) result {
+	r := result{task: t}
+
+	work, err := os.MkdirTemp("", "e2ebench-"+t.ID+"-")
+	if err != nil {
+		r.Note = "mktemp: " + err.Error()
+		return r
+	}
+	defer os.RemoveAll(work)
+
+	if seed := filepath.Join(t.dir, "workdir"); dirExists(seed) {
+		if err := copyDir(seed, work); err != nil {
+			r.Note = "copy seed: " + err.Error()
+			return r
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(t.TimeoutSec)*time.Second)
+	defer cancel()
+
+	metricsPath := filepath.Join(work, ".run-metrics.json")
+	args := []string{"run", "--metrics", metricsPath}
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+	if t.MaxSteps > 0 {
+		args = append(args, "--max-steps", fmt.Sprint(t.MaxSteps))
+	}
+	args = append(args, t.Prompt)
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Dir = work
+	cmd.Stdout = os.Stderr // stream the run to the job log, keep stdout clean for the report
+	cmd.Stderr = os.Stderr
+	runErr := cmd.Run()
+
+	if m, err := readMetrics(metricsPath); err == nil {
+		r.runMetrics = m
+	}
+	if runErr != nil {
+		r.Note = "run: " + runErr.Error()
+		// still grade — a non-zero exit may just be a max-steps notice
+	}
+
+	r.Passed = grade(work, t.dir)
+	return r
+}
+
+func grade(work, taskDir string) bool {
+	verify := filepath.Join(taskDir, "verify.sh")
+	if !fileExists(verify) {
+		return false
+	}
+	dst := filepath.Join(work, "verify.sh")
+	if err := copyFile(verify, dst); err != nil {
+		return false
+	}
+	cmd := exec.Command("bash", "verify.sh")
+	cmd.Dir = work
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run() == nil
+}
+
+func render(results []result) string {
+	var b strings.Builder
+	passed, ran := 0, 0
+	var pTok, cTok, hit, miss int
+	var cost float64
+	currency := ""
+	for _, r := range results {
+		if r.Skipped {
+			continue
+		}
+		ran++
+		if r.Passed {
+			passed++
+		}
+		pTok += r.PromptTokens
+		cTok += r.CompletionTokens
+		hit += r.CacheHitTokens
+		miss += r.CacheMissTokens
+		cost += r.Cost
+		if r.Currency != "" {
+			currency = r.Currency
+		}
+	}
+
+	fmt.Fprintf(&b, "## 🤖 Reasonix e2e benchmark\n\n")
+	fmt.Fprintf(&b, "**Accuracy:** %d/%d (%s) · **Cache hit:** %s · **Tokens:** %s (prompt %s / completion %s) · **Cost:** %s%.4f\n\n",
+		passed, ran, pct(passed, ran), pct(hit, hit+miss),
+		comma(pTok+cTok), comma(pTok), comma(cTok), currencySym(currency), cost)
+
+	fmt.Fprintf(&b, "| Task | Result | Steps | Prompt | Completion | Cache hit | Cost |\n")
+	fmt.Fprintf(&b, "|------|--------|------:|-------:|-----------:|----------:|-----:|\n")
+	for _, r := range results {
+		switch {
+		case r.Skipped:
+			fmt.Fprintf(&b, "| `%s` | ⏭️ skipped | — | — | — | — | — |\n", r.ID)
+		default:
+			res := "❌ fail"
+			if r.Passed {
+				res = "✅ pass"
+			}
+			fmt.Fprintf(&b, "| `%s` | %s | %d | %s | %s | %s | %s%.4f |\n",
+				r.ID, res, r.Steps, comma(r.PromptTokens), comma(r.CompletionTokens),
+				pct(r.CacheHitTokens, r.CacheHitTokens+r.CacheMissTokens),
+				currencySym(r.Currency), r.Cost)
+		}
+	}
+	fmt.Fprintf(&b, "\n<sub>Real provider run on the PR head. Cache-hit %% is cached prompt tokens / total prompt tokens.</sub>\n")
+
+	notes := false
+	for _, r := range results {
+		if r.Note != "" {
+			if !notes {
+				fmt.Fprintf(&b, "\n<details><summary>Notes</summary>\n\n")
+				notes = true
+			}
+			fmt.Fprintf(&b, "- `%s`: %s\n", r.ID, r.Note)
+		}
+	}
+	if notes {
+		fmt.Fprintf(&b, "\n</details>\n")
+	}
+	return b.String()
+}
+
+func pct(n, d int) string {
+	if d == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.0f%%", 100*float64(n)/float64(d))
+}
+
+func comma(n int) string {
+	s := fmt.Sprint(n)
+	if len(s) <= 3 {
+		return s
+	}
+	var out []byte
+	for i, c := range []byte(s) {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func currencySym(c string) string {
+	if c == "" {
+		return ""
+	}
+	return c + " "
+}
+
+func readMetrics(path string) (runMetrics, error) {
+	var m runMetrics
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return m, err
+	}
+	return m, json.Unmarshal(b, &m)
+}
+
+func dirExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.IsDir()
+}
+
+func fileExists(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && !fi.IsDir()
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(src, p)
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		return copyFile(p, target)
+	})
+}
+
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -45,13 +45,29 @@ type result struct {
 }
 
 func main() {
+	mode := flag.String("mode", "suite", "suite | diff (diff = generate tests for the PR diff and grade with the repo's tests)")
 	suite := flag.String("suite", "benchmarks/e2e", "suite root (contains tasks/<id>/)")
 	bin := flag.String("bin", "reasonix", "path to the reasonix binary")
 	model := flag.String("model", "", "provider/model name (default: config default)")
 	outMD := flag.String("out", "", "write the markdown report here (default: stdout)")
 	outJSON := flag.String("json", "", "write the JSON report here (optional)")
 	budget := flag.Int("budget", 400_000, "abort once total tokens cross this (0 = no cap)")
+	// diff-mode flags
+	repo := flag.String("repo", ".", "repo root (diff mode)")
+	base := flag.String("base", "", "base ref to diff the PR head against (diff mode)")
+	testCmd := flag.String("test-cmd", "go test", "grader command run on the affected packages (diff mode)")
+	maxSteps := flag.Int("max-steps", 40, "agent tool-call cap for the diff task")
+	timeoutSec := flag.Int("timeout", 900, "agent timeout in seconds (diff mode)")
 	flag.Parse()
+
+	if *mode == "diff" {
+		report := runDiff(diffOpts{
+			bin: *bin, model: *model, repo: *repo, base: *base,
+			testCmd: *testCmd, maxSteps: *maxSteps, timeoutSec: *timeoutSec,
+		})
+		emit(report, *outMD, "")
+		return
+	}
 
 	tasks, err := loadTasks(*suite)
 	if err != nil {
@@ -88,6 +104,17 @@ func main() {
 		b, _ := json.MarshalIndent(results, "", "  ")
 		_ = os.WriteFile(*outJSON, b, 0o644)
 	}
+}
+
+func emit(report, outMD, _ string) {
+	if outMD != "" {
+		if err := os.WriteFile(outMD, []byte(report), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write report:", err)
+			os.Exit(1)
+		}
+		return
+	}
+	fmt.Print(report)
 }
 
 func loadTasks(suite string) ([]task, error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -109,6 +109,7 @@ func runAgent(args []string) int {
 	model := fs.String("model", "", "provider name (default: config default_model)")
 	maxSteps := fs.Int("max-steps", 0, "max tool-call rounds (0 = use config/default)")
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
+	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -136,8 +137,14 @@ func runAgent(args []string) int {
 		}
 		renderer = newMarkdownRenderer(termW)
 	}
-	sink := agent.NewTextSink(os.Stdout, renderer, termW)
-	sink.SetShowReasoning(*showThinking)
+	textSink := agent.NewTextSink(os.Stdout, renderer, termW)
+	textSink.SetShowReasoning(*showThinking)
+	var sink event.Sink = textSink
+	var metrics *metricsSink
+	if *metricsPath != "" {
+		metrics = &metricsSink{inner: textSink}
+		sink = metrics
+	}
 	ctrl, err := setup(ctx, *model, *maxSteps, true, sink)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -145,8 +152,14 @@ func runAgent(args []string) int {
 	}
 	defer ctrl.Close()
 
-	if err := ctrl.Run(ctx, prompt); err != nil {
-		fmt.Fprintln(os.Stderr, "\n"+i18n.M.ErrorPrefix, err)
+	runErr := ctrl.Run(ctx, prompt)
+	if metrics != nil {
+		if err := writeMetrics(*metricsPath, metrics.m); err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		}
+	}
+	if runErr != nil {
+		fmt.Fprintln(os.Stderr, "\n"+i18n.M.ErrorPrefix, runErr)
 		return 1
 	}
 	return 0

--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+
+	"reasonix/internal/event"
+)
+
+// RunMetrics is the machine-readable token/cache/cost summary `run --metrics`
+// writes, so a benchmark harness can read a run's cost without scraping stdout.
+type RunMetrics struct {
+	PromptTokens     int     `json:"prompt_tokens"`
+	CompletionTokens int     `json:"completion_tokens"`
+	CacheHitTokens   int     `json:"cache_hit_tokens"`
+	CacheMissTokens  int     `json:"cache_miss_tokens"`
+	Steps            int     `json:"steps"` // model calls (one per stream, incl. tool rounds)
+	Cost             float64 `json:"cost"`
+	Currency         string  `json:"currency"`
+}
+
+// metricsSink forwards every event to the real sink and accumulates the per-call
+// Usage events into a RunMetrics. Cache totals are summed per call (not read from
+// the cumulative SessionHit/Miss) so they match PromptTokens exactly.
+type metricsSink struct {
+	inner event.Sink
+	m     RunMetrics
+}
+
+func (s *metricsSink) Emit(e event.Event) {
+	if e.Kind == event.Usage && e.Usage != nil {
+		u := e.Usage
+		s.m.PromptTokens += u.PromptTokens
+		s.m.CompletionTokens += u.CompletionTokens
+		s.m.CacheHitTokens += u.CacheHitTokens
+		s.m.CacheMissTokens += u.CacheMissTokens
+		s.m.Steps++
+		if p := e.Pricing; p != nil {
+			s.m.Cost += (float64(u.CacheHitTokens)*p.CacheHit +
+				float64(u.CacheMissTokens)*p.Input +
+				float64(u.CompletionTokens)*p.Output) / 1e6
+			s.m.Currency = p.Currency
+		}
+	}
+	s.inner.Emit(e)
+}
+
+func writeMetrics(path string, m RunMetrics) error {
+	b, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}


### PR DESCRIPTION
## What

Adds a comment-triggered e2e benchmark bot. Comment **`/e2e`** on a PR and it runs the committed task suite against the real provider and posts a report back:

> ## 🤖 Reasonix e2e benchmark
> **Accuracy:** 3/3 (100%) · **Cache hit:** 83% · **Tokens:** 4,050 (prompt 3,600 / completion 450) · **Cost:** ¥ 0.0369
>
> | Task | Result | Steps | Prompt | Completion | Cache hit | Cost |
> |------|--------|------:|-------:|-----------:|----------:|-----:|
> | `fizzbuzz` | ✅ pass | 4 | 1,200 | 150 | 83% | ¥ 0.0123 |

## Pieces

- **`reasonix run --metrics <file>`** — writes a JSON token/cache/cost summary of a run (no behaviour change otherwise).
- **`cmd/e2ebench`** — copies each task's seed `workdir/` into a temp dir, runs the agent there via the built binary, then grades with `verify.sh` (dropped in only *after* the run, so the answer key isn't readable), and aggregates per-task metrics into the markdown report. Token-budget capped (`-budget`, default 400k).
- **`benchmarks/e2e/`** — three seed tasks (`fizzbuzz`, `fix-add-bug`, `palindrome`), each graded by a `verify.sh` that exits non-zero on failure. Add a task = drop a new dir with `task.toml` + optional `workdir/` + `verify.sh`.
- **`.github/workflows/e2e-bot.yml`** — `issue_comment` trigger gated to OWNER/MEMBER/COLLABORATOR (it runs PR-head code with the API key, so it must be trust-gated), writes the provider config, builds, runs the suite, posts the report.

## Before it works — one manual step

- Add a repo **secret `DEEPSEEK_API_KEY`** (Settings → Secrets → Actions).
- Optional repo **variables** to override defaults: `REASONIX_E2E_MODEL` (default `deepseek-chat`), `REASONIX_E2E_BASE_URL` (default `https://api.deepseek.com`). Pricing in the workflow is a placeholder — adjust to the live rate if you want exact cost.

## Verification

Built + vet + `go test ./internal/cli` green. Harness validated end-to-end offline (a fake agent that writes the solution + metrics → 3/3, metrics aggregated, report rendered) and `reasonix run --metrics` validated against a local mock (cost math exact). The live provider path runs in CI once the secret is set.
