### PR TITLE
feat(ci): surface generated tests + per-test differential

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -16,17 +16,30 @@ type diffOpts struct {
 	maxSteps, timeoutSec            int
 }
 
+type testRef struct{ name, pkg string }
+
+// pinResult records whether one generated test fails when the PR's source is
+// reverted (so it pins the change) and, if so, whether it failed by assertion
+// (strong: it checks the new behavior) or only by compile error (weak: it just
+// references a symbol the PR added).
+type pinResult struct {
+	testRef
+	pins        bool
+	byAssertion bool
+}
+
 // runDiff asks the agent to write tests covering what the PR changed, on the PR
-// branch itself, then grades with the repo's own tests: the generated tests must
-// pass and the agent must actually have added test code (so a no-op can't pass,
-// since the suite was already green). Returns a markdown report.
+// branch, then grades with the repo's own tests: the new tests must pass on the
+// PR code, and at least one must fail when the source is reverted to its pre-PR
+// state. Returns a markdown report that includes the generated test diff so the
+// assertions can be audited, not just trusted.
 func runDiff(o diffOpts) string {
 	srcFiles := changedGoFiles(o.repo, o.base, false)
 	if len(srcFiles) == 0 {
 		return "## 🤖 Reasonix e2e — diff test-gen\n\nNo Go source changes in this PR (excluding `_test.go`); nothing to generate tests for.\n"
 	}
 	pkgs := packagesOf(srcFiles)
-	diffText := truncate(gitOut(o.repo, "diff", o.base+"...HEAD", "--"), srcFiles...)
+	diffText := truncate(gitOut(o.repo, "diff", o.base+"...HEAD", "--"))
 
 	prompt := buildDiffPrompt(srcFiles, pkgs, diffText)
 
@@ -53,61 +66,23 @@ func runDiff(o diffOpts) string {
 	_ = exec.Command("git", "-C", o.repo, "add", "-AN").Run()
 
 	m, _ := readMetrics(metricsPath)
-	addedTestLines, newTestFuncs := testsAdded(o.repo)
+	testDiff := gitOut(o.repo, "diff", "HEAD", "--", "*_test.go")
+	refs := parseNewTests(testDiff)
 	sourceTouched := len(changedGoFilesWorktree(o.repo, false))
 	testsPass, testOut := runTests(o.repo, o.testCmd, pkgs)
 
-	// Differential check: the new tests must FAIL when the PR's source is reverted
-	// to its pre-change state, proving they actually capture the change rather than
-	// asserting behavior that already held. Only meaningful once the tests are green.
-	diffChecked := newTestFuncs > 0 && testsPass
-	diffVerified := false
-	if diffChecked {
-		diffVerified = differentialCheck(o.repo, o.base, srcFiles, o.testCmd, pkgs)
+	var pins []pinResult
+	if len(refs) > 0 && testsPass {
+		pins = differentialPerTest(o.repo, o.base, srcFiles, refs)
 	}
 
-	passed := diffChecked && diffVerified
+	passed := len(refs) > 0 && testsPass && countPins(pins) > 0
 	return renderDiff(diffReport{
-		srcFiles: srcFiles, pkgs: pkgs, addedTestLines: addedTestLines,
-		newTestFuncs: newTestFuncs, sourceTouched: sourceTouched, testsPass: testsPass,
-		diffChecked: diffChecked, diffVerified: diffVerified, failing: failingTestNames(testOut),
-		passed: passed, m: m, runErr: runErr, testOut: testOut,
+		srcFiles: srcFiles, pkgs: pkgs, addedTestLines: countAdded(testDiff),
+		newTests: refs, sourceTouched: sourceTouched, testsPass: testsPass,
+		pins: pins, failing: failingTestNames(testOut), passed: passed,
+		m: m, runErr: runErr, testOut: testOut, testDiff: testDiff,
 	})
-}
-
-// failingTestNames pulls the names out of `--- FAIL: TestX (…)` lines.
-func failingTestNames(out string) []string {
-	var names []string
-	seen := map[string]bool{}
-	for _, ln := range strings.Split(out, "\n") {
-		ln = strings.TrimSpace(ln)
-		if !strings.HasPrefix(ln, "--- FAIL:") {
-			continue
-		}
-		rest := strings.TrimSpace(strings.TrimPrefix(ln, "--- FAIL:"))
-		name := strings.Fields(rest)
-		if len(name) > 0 && !seen[name[0]] {
-			seen[name[0]] = true
-			names = append(names, name[0])
-		}
-	}
-	return names
-}
-
-// differentialCheck reverts the PR's changed source to base (deleting files that
-// were new in the PR), runs the now-present tests, and restores the source. The
-// tests should fail against the old code; !green means they pin the change.
-func differentialCheck(repo, base string, srcFiles []string, testCmd string, pkgs []string) bool {
-	for _, f := range srcFiles {
-		if err := exec.Command("git", "-C", repo, "checkout", base, "--", f).Run(); err != nil {
-			_ = os.Remove(filepath.Join(repo, filepath.FromSlash(f)))
-		}
-	}
-	green, _ := runTests(repo, testCmd, pkgs)
-	for _, f := range srcFiles {
-		_ = exec.Command("git", "-C", repo, "checkout", "HEAD", "--", f).Run()
-	}
-	return !green
 }
 
 func buildDiffPrompt(srcFiles, pkgs []string, diffText string) string {
@@ -123,20 +98,24 @@ func buildDiffPrompt(srcFiles, pkgs []string, diffText string) string {
 	b.WriteString("Add them to the appropriate *_test.go files in the same packages (")
 	b.WriteString(strings.Join(pkgs, ", "))
 	b.WriteString("). Do NOT modify the non-test source files — only add or extend test files. ")
+	b.WriteString("Prefer small, focused edits and run `gofmt`/`go vet` on the test files as you go to avoid syntax errors. ")
 	b.WriteString("Then run the package tests and iterate until they pass. When finished, list the test functions you added.")
 	return b.String()
 }
 
 type diffReport struct {
-	srcFiles, pkgs               []string
-	addedTestLines, newTestFuncs int
-	sourceTouched                int
-	testsPass, diffChecked       bool
-	diffVerified, passed         bool
-	failing                      []string
-	m                            runMetrics
-	runErr                       error
-	testOut                      string
+	srcFiles, pkgs []string
+	addedTestLines int
+	newTests       []testRef
+	sourceTouched  int
+	testsPass      bool
+	pins           []pinResult
+	failing        []string
+	passed         bool
+	m              runMetrics
+	runErr         error
+	testOut        string
+	testDiff       string
 }
 
 func renderDiff(r diffReport) string {
@@ -148,27 +127,38 @@ func renderDiff(r diffReport) string {
 	fmt.Fprintf(&b, "## 🤖 Reasonix e2e — diff test-gen\n\n")
 	fmt.Fprintf(&b, "**Result:** %s · **%d** changed source file(s) across **%d** package(s)\n\n", result, len(r.srcFiles), len(r.pkgs))
 
+	pinned, byAssert := countPins(r.pins), countAssertionPins(r.pins)
 	fmt.Fprintf(&b, "| Metric | Value |\n|---|---|\n")
-	fmt.Fprintf(&b, "| New test functions added | %d |\n", r.newTestFuncs)
+	fmt.Fprintf(&b, "| New test functions added | %d |\n", len(r.newTests))
 	fmt.Fprintf(&b, "| Test lines added | +%d |\n", r.addedTestLines)
-	fmt.Fprintf(&b, "| `%s` on affected pkgs | %s |\n", "go test", passFail(r.testsPass))
-	diffCell := "n/a (tests not green)"
-	if r.diffChecked {
-		diffCell = yesNo(r.diffVerified)
-	}
-	fmt.Fprintf(&b, "| Differential (fails on pre-PR code) | %s |\n", diffCell)
-	if len(r.failing) > 0 {
-		fmt.Fprintf(&b, "| Failing tests | `%s` |\n", strings.Join(r.failing, "`, `"))
+	fmt.Fprintf(&b, "| `go test` on affected pkgs | %s |\n", passFail(r.testsPass))
+	fmt.Fprintf(&b, "| Differential (fail on pre-PR code) | %s |\n", differentialCell(r))
+	if pinned > 0 {
+		fmt.Fprintf(&b, "| ↳ pin by assertion / by compile only | %d / %d |\n", byAssert, pinned-byAssert)
 	}
 	fmt.Fprintf(&b, "| Non-test source touched by agent | %d file(s) |\n", r.sourceTouched)
 	fmt.Fprintf(&b, "| Cache hit | %s |\n", pct(r.m.CacheHitTokens, r.m.CacheHitTokens+r.m.CacheMissTokens))
 	fmt.Fprintf(&b, "| Tokens (prompt / completion) | %s / %s |\n", comma(r.m.PromptTokens), comma(r.m.CompletionTokens))
 	fmt.Fprintf(&b, "| Model calls | %d |\n", r.m.Steps)
 	fmt.Fprintf(&b, "| Cost | %s%.4f |\n", currencySym(r.m.Currency), r.m.Cost)
+	if len(r.failing) > 0 {
+		fmt.Fprintf(&b, "| Failing tests | `%s` |\n", strings.Join(r.failing, "`, `"))
+	}
 
 	fmt.Fprintf(&b, "\n**Packages:** %s\n", strings.Join(r.pkgs, ", "))
 	if r.sourceTouched > 0 {
-		fmt.Fprintf(&b, "\n⚠️ The agent modified %d non-test source file(s); tests passing may not reflect the PR's code. Review the diff.\n", r.sourceTouched)
+		fmt.Fprintf(&b, "\n⚠️ The agent modified %d non-test source file(s); a green run may not reflect the PR's code. Review the diff.\n", r.sourceTouched)
+	}
+
+	if len(r.pins) > 0 {
+		fmt.Fprintf(&b, "\n<details><summary>Per-test differential</summary>\n\n| Test | Package | Pins the change? |\n|---|---|---|\n")
+		for _, p := range r.pins {
+			fmt.Fprintf(&b, "| `%s` | %s | %s |\n", p.name, p.pkg, pinCell(p))
+		}
+		fmt.Fprintf(&b, "\n</details>\n")
+	}
+	if strings.TrimSpace(r.testDiff) != "" {
+		fmt.Fprintf(&b, "\n<details><summary>Generated tests (review the assertions)</summary>\n\n```diff\n%s\n```\n</details>\n", truncateFor(r.testDiff, 20000))
 	}
 	if !r.testsPass && strings.TrimSpace(r.testOut) != "" {
 		fmt.Fprintf(&b, "\n<details><summary>go test output (tail)</summary>\n\n```\n%s\n```\n</details>\n", tail(r.testOut, 60))
@@ -176,49 +166,152 @@ func renderDiff(r diffReport) string {
 	if r.runErr != nil {
 		fmt.Fprintf(&b, "\n<sub>agent run note: %v</sub>\n", r.runErr)
 	}
-	fmt.Fprintf(&b, "\n<sub>Pass = the agent added ≥1 new test function, the affected packages' tests are green, AND those tests fail when the PR's source is reverted (so they genuinely cover the change).</sub>\n")
+	fmt.Fprintf(&b, "\n<sub>Pass = the agent added ≥1 test, the affected packages are green, AND ≥1 new test fails when the PR's source is reverted. \"By assertion\" pins are strong (they check changed behavior); \"by compile only\" pins just need a PR-added symbol — and since Go compiles per package, one compile-coupled test marks every test in its package that way, so read the diff above to judge the rest.</sub>\n")
 	return b.String()
 }
 
-func passFail(ok bool) string {
-	if ok {
-		return "pass"
+func differentialCell(r diffReport) string {
+	if !(len(r.newTests) > 0 && r.testsPass) {
+		return "n/a (tests not green)"
 	}
-	return "fail"
+	return fmt.Sprintf("%d/%d new tests", countPins(r.pins), len(r.pins))
 }
 
-func yesNo(ok bool) string {
-	if ok {
-		return "yes"
+func pinCell(p pinResult) string {
+	switch {
+	case p.pins && p.byAssertion:
+		return "✅ by assertion"
+	case p.pins:
+		return "⚠️ by compile only"
+	default:
+		return "❌ no (passes on old code)"
 	}
-	return "no"
 }
 
-// changedGoFiles lists .go files changed by base...HEAD. When includeTests is
-// false, *_test.go files are excluded (we want the source under test).
-func changedGoFiles(repo, base string, includeTests bool) []string {
-	out := gitOut(repo, "diff", "--name-only", base+"...HEAD", "--", "*.go")
-	return filterGo(out, includeTests)
+// differentialPerTest reverts the PR's changed source to base (deleting files
+// new in the PR), runs each generated test on its own against the old code, and
+// restores the source. A test that fails on the old code pins the change.
+func differentialPerTest(repo, base string, srcFiles []string, refs []testRef) []pinResult {
+	for _, f := range srcFiles {
+		if err := exec.Command("git", "-C", repo, "checkout", base, "--", f).Run(); err != nil {
+			_ = os.Remove(filepath.Join(repo, filepath.FromSlash(f)))
+		}
+	}
+	out := make([]pinResult, 0, len(refs))
+	for _, r := range refs {
+		cmd := exec.Command("go", "test", "-run", "^"+r.name+"$", r.pkg)
+		cmd.Dir = repo
+		raw, err := cmd.CombinedOutput()
+		out = append(out, pinResult{
+			testRef:     r,
+			pins:        err != nil,
+			byAssertion: strings.Contains(string(raw), "--- FAIL: "+r.name),
+		})
+	}
+	for _, f := range srcFiles {
+		_ = exec.Command("git", "-C", repo, "checkout", "HEAD", "--", f).Run()
+	}
+	return out
 }
 
-// changedGoFilesWorktree lists .go files changed in the working tree vs HEAD
-// (i.e. what the agent just did).
-func changedGoFilesWorktree(repo string, includeTests bool) []string {
-	out := gitOut(repo, "diff", "--name-only", "HEAD", "--", "*.go")
-	files := strings.Fields(strings.ReplaceAll(out, "\n", " "))
-	var keep []string
-	for _, f := range files {
-		isTest := strings.HasSuffix(f, "_test.go")
-		if isTest && !includeTests {
+func countPins(ps []pinResult) int {
+	n := 0
+	for _, p := range ps {
+		if p.pins {
+			n++
+		}
+	}
+	return n
+}
+
+func countAssertionPins(ps []pinResult) int {
+	n := 0
+	for _, p := range ps {
+		if p.pins && p.byAssertion {
+			n++
+		}
+	}
+	return n
+}
+
+// parseNewTests reads the working-tree *_test.go diff and returns the Test/Fuzz/
+// Benchmark functions the agent added, each tagged with its package directory.
+func parseNewTests(diff string) []testRef {
+	var refs []testRef
+	pkg := ""
+	for _, ln := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(ln, "+++ b/") {
+			pkg = "./" + filepath.ToSlash(filepath.Dir(strings.TrimPrefix(ln, "+++ b/")))
 			continue
 		}
-		if !isTest {
-			keep = append(keep, f)
-		} else if includeTests {
-			keep = append(keep, f)
+		if !strings.HasPrefix(ln, "+") || strings.HasPrefix(ln, "+++") {
+			continue
+		}
+		body := strings.TrimSpace(ln[1:])
+		if !strings.HasPrefix(body, "func ") {
+			continue
+		}
+		sig := strings.TrimPrefix(body, "func ")
+		paren := strings.IndexByte(sig, '(')
+		if paren <= 0 {
+			continue
+		}
+		name := sig[:paren]
+		if strings.HasPrefix(name, "Test") || strings.HasPrefix(name, "Fuzz") || strings.HasPrefix(name, "Benchmark") {
+			refs = append(refs, testRef{name: name, pkg: pkg})
 		}
 	}
-	return keep
+	return refs
+}
+
+func countAdded(diff string) int {
+	n := 0
+	for _, ln := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(ln, "+") && !strings.HasPrefix(ln, "+++") {
+			n++
+		}
+	}
+	return n
+}
+
+// failingTestNames pulls the names out of `--- FAIL: TestX (…)` lines.
+func failingTestNames(out string) []string {
+	var names []string
+	seen := map[string]bool{}
+	for _, ln := range strings.Split(out, "\n") {
+		ln = strings.TrimSpace(ln)
+		if !strings.HasPrefix(ln, "--- FAIL:") {
+			continue
+		}
+		rest := strings.Fields(strings.TrimSpace(strings.TrimPrefix(ln, "--- FAIL:")))
+		if len(rest) > 0 && !seen[rest[0]] {
+			seen[rest[0]] = true
+			names = append(names, rest[0])
+		}
+	}
+	return names
+}
+
+func runTests(repo, testCmd string, pkgs []string) (bool, string) {
+	fields := strings.Fields(testCmd)
+	if len(fields) == 0 {
+		fields = []string{"go", "test"}
+	}
+	args := append(fields[1:], pkgs...)
+	cmd := exec.Command(fields[0], args...)
+	cmd.Dir = repo
+	out, err := cmd.CombinedOutput()
+	return err == nil, string(out)
+}
+
+// changedGoFiles lists .go files changed by base...HEAD, excluding *_test.go
+// when includeTests is false (we want the source under test).
+func changedGoFiles(repo, base string, includeTests bool) []string {
+	return filterGo(gitOut(repo, "diff", "--name-only", base+"...HEAD", "--", "*.go"), includeTests)
+}
+
+func changedGoFilesWorktree(repo string, includeTests bool) []string {
+	return filterGo(gitOut(repo, "diff", "--name-only", "HEAD", "--", "*.go"), includeTests)
 }
 
 func filterGo(out string, includeTests bool) []string {
@@ -247,46 +340,19 @@ func packagesOf(files []string) []string {
 	return pkgs
 }
 
-// testsAdded counts the test lines and new Test functions the agent added,
-// reading the working-tree diff of *_test.go files.
-func testsAdded(repo string) (lines, funcs int) {
-	diff := gitOut(repo, "diff", "HEAD", "--", "*_test.go")
-	for _, ln := range strings.Split(diff, "\n") {
-		if strings.HasPrefix(ln, "+") && !strings.HasPrefix(ln, "+++") {
-			lines++
-			body := strings.TrimSpace(strings.TrimPrefix(ln, "+"))
-			if strings.HasPrefix(body, "func Test") || strings.HasPrefix(body, "func Fuzz") || strings.HasPrefix(body, "func Benchmark") {
-				funcs++
-			}
-		}
-	}
-	return lines, funcs
-}
-
-func runTests(repo, testCmd string, pkgs []string) (bool, string) {
-	fields := strings.Fields(testCmd)
-	if len(fields) == 0 {
-		fields = []string{"go", "test"}
-	}
-	args := append(fields[1:], pkgs...)
-	cmd := exec.Command(fields[0], args...)
-	cmd.Dir = repo
-	out, err := cmd.CombinedOutput()
-	return err == nil, string(out)
-}
-
 func gitOut(repo string, args ...string) string {
 	cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
 	out, _ := cmd.Output()
 	return string(out)
 }
 
-func truncate(s string, _ ...string) string {
-	const max = 12000
+func truncate(s string) string { return truncateFor(s, 12000) }
+
+func truncateFor(s string, max int) string {
 	if len(s) <= max {
 		return s
 	}
-	return s[:max] + "\n…(diff truncated)…"
+	return s[:max] + "\n…(truncated)…"
 }
 
 func tail(s string, n int) string {
@@ -295,4 +361,11 @@ func tail(s string, n int) string {
 		lines = lines[len(lines)-n:]
 	}
 	return strings.Join(lines, "\n")
+}
+
+func passFail(ok bool) string {
+	if ok {
+		return "pass"
+	}
+	return "fail"
 }


### PR DESCRIPTION
Makes a green `/e2e diff` auditable instead of trusted-on-a-proxy: attaches the agent's generated test diff to the report, and runs each new test individually against the reverted source to classify it as pinning the change *by assertion* (strong) vs *by compile only* (weak). Addresses the 'how do I know the pass is real' gap.