### PR TITLE
feat(memory): forget tool, fallible-recall framing, richer index

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1200,6 +1200,7 @@ type MemoryDoc struct {
 // MemoryFact is one saved auto-memory, surfaced read-only in the panel.
 type MemoryFact struct {
 	Name        string `json:"name"`
+	Title       string `json:"title,omitempty"`
 	Description string `json:"description"`
 	Type        string `json:"type"`
 	Body        string `json:"body"`
@@ -1248,7 +1249,7 @@ func (a *App) Memory() MemoryView {
 	}
 	for _, f := range set.Store.List() {
 		view.Facts = append(view.Facts, MemoryFact{
-			Name: f.Name, Description: f.Description, Type: string(f.Type), Body: f.Body,
+			Name: f.Name, Title: f.Title, Description: f.Description, Type: string(f.Type), Body: f.Body,
 		})
 	}
 	for _, sc := range writableScopes {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1273,6 +1273,18 @@ func (a *App) Remember(scope, note string) (string, error) {
 	return ctrl.QuickAdd(parseScope(scope), note)
 }
 
+// Forget deletes a saved auto-memory by name — the panel's delete action for a
+// fact the model owns. A no-op when no controller is attached.
+func (a *App) Forget(name string) error {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
+		return nil
+	}
+	return ctrl.ForgetMemory(name)
+}
+
 // SaveDoc overwrites a memory doc with the panel editor's contents. The controller
 // validates path against the recognized memory files. Returns the file written.
 func (a *App) SaveDoc(path, body string) (string, error) {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -135,6 +135,7 @@ export default function App() {
     setModel,
     fetchMemory,
     remember,
+    forget,
     saveDoc,
   } = useController();
   const t = useT();
@@ -446,6 +447,14 @@ export default function App() {
     [remember, fetchMemory],
   );
 
+  const onForget = useCallback(
+    async (name: string) => {
+      await forget(name);
+      setMemView(await fetchMemory());
+    },
+    [forget, fetchMemory],
+  );
+
   const onSaveDoc = useCallback(
     async (path: string, body: string) => {
       await saveDoc(path, body);
@@ -720,6 +729,7 @@ export default function App() {
           view={memView}
           onClose={closeMemory}
           onRemember={onRemember}
+          onForget={onForget}
           onSaveDoc={onSaveDoc}
         />
       )}

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState, type ReactNode } from "react";
 import { useT } from "../lib/i18n";
 import type { MemoryView } from "../lib/types";
 import { ResizableDrawer } from "./ResizableDrawer";
@@ -13,11 +13,13 @@ export function MemoryPanel({
   view,
   onClose,
   onRemember,
+  onForget,
   onSaveDoc,
 }: {
   view: MemoryView | null;
   onClose: () => void;
   onRemember: (scope: string, note: string) => Promise<void> | void;
+  onForget: (name: string) => Promise<void> | void;
   onSaveDoc: (path: string, body: string) => Promise<void> | void;
 }) {
   const t = useT();
@@ -26,6 +28,63 @@ export function MemoryPanel({
   const [editingPath, setEditingPath] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
+  const [highlight, setHighlight] = useState<string | null>(null);
+  const factRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const facts = view?.facts ?? [];
+  const factNames = new Set(facts.map((f) => f.name));
+
+  // jumpTo scrolls a [[name]] target into view and flashes it, so cross-links
+  // between saved memories are navigable inside the panel.
+  const jumpTo = (name: string) => {
+    const el = factRefs.current[name];
+    if (!el) return;
+    el.scrollIntoView({ block: "center", behavior: "smooth" });
+    setHighlight(name);
+    window.setTimeout(() => setHighlight((h) => (h === name ? null : h)), 1200);
+  };
+
+  // renderWithLinks turns [[name]] tokens into in-panel jumps; a token with no
+  // matching saved memory renders as a flagged dead link.
+  const renderWithLinks = (text: string): ReactNode[] => {
+    const out: ReactNode[] = [];
+    const re = /\[\[([^\]]+)\]\]/g;
+    let last = 0;
+    let k = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      if (m.index > last) out.push(text.slice(last, m.index));
+      const target = m[1].trim();
+      out.push(
+        factNames.has(target) ? (
+          <button key={k++} type="button" className="mem-link" onClick={() => jumpTo(target)}>
+            {target}
+          </button>
+        ) : (
+          <span
+            key={k++}
+            className="mem-link mem-link--dead"
+            title={t("memory.deadLink", { name: target })}
+          >
+            {target}
+          </span>
+        ),
+      );
+      last = re.lastIndex;
+    }
+    if (last < text.length) out.push(text.slice(last));
+    return out;
+  };
+
+  const forgetFact = async (name: string) => {
+    if (busy || !window.confirm(t("memory.confirmForget", { name }))) return;
+    setBusy(true);
+    try {
+      await onForget(name);
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const scopes = view?.scopes ?? [];
   // Default the scope selector to "project" when present, else the first option.
@@ -168,19 +227,37 @@ export function MemoryPanel({
               })}
             </section>
 
-            {/* Saved auto-memories — read-only; the model owns these. */}
+            {/* Saved auto-memories — the model owns these via remember/forget;
+                the panel can delete one and follow [[name]] cross-links. */}
             <section className="mem-section">
               <div className="mem-section__title">{t("memory.savedMemories")}</div>
-              {view.facts.length === 0 ? (
+              {facts.length === 0 ? (
                 <div className="mem-empty">{t("memory.noFacts")}</div>
               ) : (
-                view.facts.map((f) => (
-                  <div className="mem-fact" key={f.name} title={f.body}>
+                facts.map((f) => (
+                  <div
+                    className={`mem-fact${highlight === f.name ? " mem-fact--hl" : ""}`}
+                    key={f.name}
+                    ref={(el) => {
+                      factRefs.current[f.name] = el;
+                    }}
+                  >
                     <span className={`badge badge--${f.type}`}>{f.type}</span>
                     <div className="mem-fact__text">
-                      <div className="mem-fact__name">{f.name}</div>
+                      <div className="mem-fact__name">{f.title || f.name}</div>
                       <div className="mem-fact__desc">{f.description}</div>
+                      {f.body && (
+                        <div className="mem-fact__body">{renderWithLinks(f.body)}</div>
+                      )}
                     </div>
+                    <button
+                      className="btn btn--small mem-fact__forget"
+                      onClick={() => void forgetFact(f.name)}
+                      disabled={busy}
+                      title={t("memory.forget")}
+                    >
+                      ✕
+                    </button>
                   </div>
                 ))
               )}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -95,6 +95,7 @@ export interface AppBindings {
   // from the in-place editor.
   Memory(): Promise<MemoryView>;
   Remember(scope: string, note: string): Promise<string>;
+  Forget(name: string): Promise<void>;
   SaveDoc(path: string, body: string): Promise<string>;
   // Settings panel: read the resolved config and apply edits (each writes config
   // and rebuilds the controller live). Secrets go through SetProviderKey (→ .env).
@@ -544,6 +545,9 @@ function makeMockApp(): AppBindings {
     async Remember(scope: string, note: string) {
       emit({ kind: "notice", level: "info", text: `remembered → ${scope}` });
       return `${scope} REASONIX.md (mock): ${note}`;
+    },
+    async Forget(name: string) {
+      emit({ kind: "notice", level: "info", text: `forgot → ${name}` });
     },
     async SaveDoc(path: string, _body: string) {
       emit({ kind: "notice", level: "info", text: `saved → ${path}` });

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -221,6 +221,7 @@ export interface MemoryDoc {
 
 export interface MemoryFact {
   name: string;
+  title?: string;
   description: string;
   type: string; // "user" | "feedback" | "project" | "reference"
   body: string;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -608,6 +608,10 @@ export function useController() {
     await app.Remember(scope, note).catch(() => {});
   }, []);
 
+  const forget = useCallback(async (name: string) => {
+    await app.Forget(name).catch(() => {});
+  }, []);
+
   const saveDoc = useCallback(async (path: string, body: string) => {
     await app.SaveDoc(path, body).catch(() => {});
   }, []);
@@ -658,6 +662,7 @@ export function useController() {
     setModel,
     fetchMemory,
     remember,
+    forget,
     saveDoc,
   };
 }

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -180,6 +180,9 @@ export const en = {
   "memory.savedMemories": "Saved memories",
   "memory.noFacts": "Nothing saved yet. The agent writes these with the remember tool.",
   "memory.storedUnder": "stored under {dir}",
+  "memory.forget": "Forget",
+  "memory.confirmForget": "Forget “{name}”? This deletes the saved memory.",
+  "memory.deadLink": "No memory named “{name}”",
 
   // settings drawer
   "settings.title": "Settings",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -181,6 +181,9 @@ export const zh: Record<DictKey, string> = {
   "memory.savedMemories": "已保存的记忆",
   "memory.noFacts": "还没有保存任何内容。智能体会通过 remember 工具写入这些。",
   "memory.storedUnder": "存放于 {dir}",
+  "memory.forget": "删除",
+  "memory.confirmForget": "删除「{name}」？这会移除这条已存记忆。",
+  "memory.deadLink": "没有名为「{name}」的记忆",
 
   // 设置抽屉
   "settings.title": "设置",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2720,6 +2720,7 @@ body {
 }
 .mem-fact__text {
   min-width: 0;
+  flex: 1;
 }
 .mem-fact__name {
   font-size: 13px;
@@ -2728,6 +2729,38 @@ body {
 .mem-fact__desc {
   font-size: 12px;
   color: var(--fg-dim);
+}
+.mem-fact__body {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--fg-dim);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.mem-fact__forget {
+  flex-shrink: 0;
+  opacity: 0.5;
+}
+.mem-fact__forget:hover {
+  opacity: 1;
+}
+.mem-fact--hl {
+  background: var(--accent-soft, rgba(120, 170, 255, 0.12));
+  border-radius: 6px;
+}
+.mem-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  color: var(--accent, #6aa3ff);
+  text-decoration: underline dotted;
+}
+.mem-link--dead {
+  color: var(--danger, #d66);
+  cursor: help;
+  text-decoration: line-through;
 }
 .btn--small {
   padding: 4px 10px;

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
+	"reasonix/internal/memory"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -171,6 +172,11 @@ type Agent struct {
 	// complete_step validate that cited evidence happened before the claim.
 	evidence *evidence.Ledger
 
+	// memQueue, when non-nil, lets the remember/forget tools fold a turn-tail note
+	// about a just-made memory change into the next turn, so it applies this
+	// session without touching the cache-stable prefix. Set via SetMemoryQueue.
+	memQueue memory.Queue
+
 	// Context management: when a turn's prompt nears contextWindow, the older
 	// middle of the session is summarized away, keeping a token-bounded recent
 	// tail verbatim (recentKeep is the message floor) and archiving the originals
@@ -211,6 +217,10 @@ func (a *Agent) SetGate(g Gate) { a.gate = g }
 // SetAsker installs the asker the `ask` tool uses to question the user.
 // Interactive frontends wire one in; headless runs leave it nil.
 func (a *Agent) SetAsker(as Asker) { a.asker = as }
+
+// SetMemoryQueue installs the sink the remember/forget tools use to apply a
+// memory change in the current session. The controller wires itself in.
+func (a *Agent) SetMemoryQueue(q memory.Queue) { a.memQueue = q }
 
 // SetPreEditHook installs the pre-edit snapshot hook (see onPreEdit). The
 // controller wires it to its per-session checkpoint store; nil disables capture.
@@ -733,6 +743,9 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	if a.jobs != nil {
 		cctx = jobs.WithManager(cctx, a.jobs)
+	}
+	if a.memQueue != nil {
+		cctx = memory.WithQueue(cctx, a.memQueue)
 	}
 	result, err := t.Execute(cctx, json.RawMessage(call.Arguments))
 	if a.evidence != nil {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -236,8 +236,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		entry.ContextWindow, cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
 
 	// The `remember` tool lets the model persist durable facts to the project's
-	// auto-memory store; the saved index loads into the prefix on the next session.
+	// auto-memory store; `forget` prunes ones that turn out wrong. The saved index
+	// loads into the prefix on the next session.
 	reg.Add(memory.NewRememberTool(mem.Store))
+	reg.Add(memory.NewForgetTool(mem.Store))
 
 	// The `ask` tool puts structured multiple-choice questions to the user. It
 	// reaches them through the Asker on the call context, which interactive

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2095,6 +2095,8 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.showMemory()
 	case "/quit", "/exit":
 		return tea.Quit
+	case "/forget":
+		m.forgetMemory(strings.TrimSpace(strings.TrimPrefix(input, cmd)))
 	default:
 		// A custom command wins over a skill of the same name; both resolve to a turn.
 		if sent, ok := m.ctrl.CustomCommand(input); ok {

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -73,6 +73,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/verbose", insert: "/verbose", hint: i18n.M.CmdVerbose},
 		{label: "/help", insert: "/help ", hint: i18n.M.CmdHelp},
 		{label: "/memory", insert: "/memory ", hint: i18n.M.CmdMemory},
+		{label: "/forget", insert: "/forget ", hint: i18n.M.CmdForget},
 		{label: "/quit", insert: "/quit", hint: i18n.M.CmdQuit},
 	}
 	for _, c := range m.commands {

--- a/internal/cli/memory.go
+++ b/internal/cli/memory.go
@@ -16,8 +16,30 @@ func (m *chatTUI) showMemory() {
 	for _, d := range set.Docs {
 		m.notice(fmt.Sprintf("  • %s (%s)", d.Path, d.Scope))
 	}
-	if set.Index != "" {
-		m.notice("  • saved memories → " + set.Store.Dir)
+	if facts := set.Store.List(); len(facts) > 0 {
+		m.notice("  saved memories (delete with “/forget <name>”):")
+		for _, f := range facts {
+			label := f.Title
+			if label == "" {
+				label = f.Description
+			}
+			m.notice(fmt.Sprintf("    • %s — %s", f.Name, label))
+		}
+		m.notice("  stored under " + set.Store.Dir)
 	}
-	m.notice("edit those files or use “#<note>”; changes apply next session")
+	m.notice("edit doc files or use “#<note>”; doc edits apply next session")
+}
+
+// forgetMemory deletes a saved auto-memory by name (the slug shown in /memory).
+// It is the manual counterpart to the model's `forget` tool.
+func (m *chatTUI) forgetMemory(name string) {
+	if name == "" {
+		m.notice("usage: /forget <name> — the slug shown under “saved memories” in /memory")
+		return
+	}
+	if err := m.ctrl.ForgetMemory(name); err != nil {
+		m.notice(fmt.Sprintf("forget: %v", err))
+		return
+	}
+	m.notice("forgot memory: " + name)
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -215,6 +215,7 @@ func New(opts Options) *Controller {
 				c.cp.Snapshot(ch)
 			}
 		})
+		c.executor.SetMemoryQueue(c)
 	}
 	return c
 }
@@ -1349,6 +1350,36 @@ func (c *Controller) SaveDoc(path, body string) (string, error) {
 		"Memory file "+written+" was just edited. Its current contents:\n"+strings.TrimSpace(body))
 	c.refreshMemoryLocked()
 	return written, nil
+}
+
+// ForgetMemory deletes a saved auto-memory by name — the panel/TUI delete action,
+// the manual counterpart to the model's `forget` tool. It queues a turn-tail note
+// so the deletion applies this session (the cached prefix still lists the fact
+// until the next session re-folds the index).
+func (c *Controller) ForgetMemory(name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.mem == nil {
+		return nil
+	}
+	if err := c.mem.Store.Delete(name); err != nil {
+		return err
+	}
+	c.pendingMemory = append(c.pendingMemory,
+		"Deleted memory \""+name+"\" — disregard its line still shown in the saved-memories index until next session.")
+	c.refreshMemoryLocked()
+	return nil
+}
+
+// QueueMemory implements memory.Queue: when the model runs the remember/forget
+// tool, the tool calls this with a note that rides the next turn so the change
+// applies this session without touching the cache-stable prefix. It also
+// refreshes the snapshot a memory panel reads.
+func (c *Controller) QueueMemory(note string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pendingMemory = append(c.pendingMemory, note)
+	c.refreshMemoryLocked()
 }
 
 // Memory returns the loaded memory snapshot (nil when memory is disabled), for

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -32,7 +32,7 @@ func (c *Controller) Compose(text string) string {
 	if len(notes) > 0 {
 		var b strings.Builder
 		b.WriteString("<memory-update>\n")
-		b.WriteString("The following was just saved to project memory and applies from now on:\n")
+		b.WriteString("The following project-memory changes were just made and apply from now on:\n")
 		for _, n := range notes {
 			b.WriteString("- " + n + "\n")
 		}

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -59,6 +59,22 @@ func TestComposePlanModeMarker(t *testing.T) {
 	}
 }
 
+func TestComposeDrainsQueuedMemory(t *testing.T) {
+	c := New(Options{}) // no executor/memory — QueueMemory still queues a turn-tail note
+
+	c.QueueMemory("Saved memory \"rmb\": user's balance is in RMB")
+	got := c.Compose("hello")
+	if !strings.Contains(got, "<memory-update>") || !strings.Contains(got, "user's balance is in RMB") {
+		t.Fatalf("queued memory should ride the turn: %q", got)
+	}
+	if !strings.HasSuffix(got, "hello") {
+		t.Fatalf("user text should follow the memory block: %q", got)
+	}
+	if got2 := c.Compose("again"); got2 != "again" {
+		t.Fatalf("pendingMemory should drain after one turn, got %q", got2)
+	}
+}
+
 func TestRunTurnAutoPlanComplexTask(t *testing.T) {
 	var notices []string
 	runner := &fakeTurnRunner{}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -118,6 +118,7 @@ type Messages struct {
 	CmdResume       string // /resume
 	CmdModel        string // /model
 	CmdMemory       string // /memory
+	CmdForget       string // /forget
 	CmdMcp          string // /mcp
 	CmdHooks        string // /hooks
 	CmdPasteImage   string // /paste-image

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -85,6 +85,7 @@ var English = Messages{
 	CmdResume:       "resume a saved session",
 	CmdModel:        "switch model",
 	CmdMemory:       "show memory files",
+	CmdForget:       "delete a saved memory",
 	CmdMcp:          "MCP servers",
 	CmdHooks:        "manage hooks",
 	CmdPasteImage:   "paste clipboard image",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -86,6 +86,7 @@ var Chinese = Messages{
 	CmdResume:       "恢复已保存的会话",
 	CmdModel:        "切换模型",
 	CmdMemory:       "查看记忆文件",
+	CmdForget:       "删除一条已存记忆",
 	CmdMcp:          "MCP 服务器",
 	CmdHooks:        "管理 hooks",
 	CmdPasteImage:   "粘贴剪贴板图片",

--- a/internal/memory/forget.go
+++ b/internal/memory/forget.go
@@ -47,7 +47,10 @@ func (t forgetTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 	if err := t.store.Delete(in.Name); err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("Forgot memory %q (it will no longer load in future sessions).", in.Name), nil
+	if q, ok := QueueFromContext(ctx); ok {
+		q.QueueMemory("Deleted memory \"" + slug(in.Name) + "\" — disregard its line still shown in the saved-memories index until next session.")
+	}
+	return fmt.Sprintf("Forgot memory %q (it no longer applies and will not load in future sessions).", in.Name), nil
 }
 
 func (forgetTool) ReadOnly() bool { return false }

--- a/internal/memory/forget.go
+++ b/internal/memory/forget.go
@@ -1,0 +1,53 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"reasonix/internal/tool"
+)
+
+// forgetTool deletes a saved memory the model judges wrong or stale. Like
+// rememberTool it is stateful (bound to one project's Store), so boot constructs
+// it and adds it to the registry.
+type forgetTool struct{ store Store }
+
+// NewForgetTool returns the `forget` tool bound to store.
+func NewForgetTool(store Store) tool.Tool { return forgetTool{store: store} }
+
+func (forgetTool) Name() string { return "forget" }
+
+func (forgetTool) Description() string {
+	return "Delete a saved memory by name when it is wrong, stale, or superseded, so it stops loading into future sessions. " +
+		"Use the slug from the memory index — the \"<name>\" in \"[label](<name>.md)\". " +
+		"Prefer updating a memory with `remember` (reuse its name) over forget-then-recreate; reach for forget only when the fact should no longer exist at all."
+}
+
+func (forgetTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string", "description": "Slug of the memory to delete, as shown in the index (the \"<name>\" in \"[label](<name>.md)\")."}
+		},
+		"required": ["name"]
+	}`)
+}
+
+func (t forgetTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var in struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(args, &in); err != nil {
+		return "", fmt.Errorf("invalid arguments: %w", err)
+	}
+	if in.Name == "" {
+		return "", fmt.Errorf("name is required")
+	}
+	if err := t.store.Delete(in.Name); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("Forgot memory %q (it will no longer load in future sessions).", in.Name), nil
+}
+
+func (forgetTool) ReadOnly() bool { return false }

--- a/internal/memory/forget_test.go
+++ b/internal/memory/forget_test.go
@@ -43,3 +43,25 @@ func TestForgetToolValidates(t *testing.T) {
 		t.Fatal("expected error when name is missing")
 	}
 }
+
+// fakeQueue records the turn-tail notes the remember/forget tools queue.
+type fakeQueue struct{ notes []string }
+
+func (f *fakeQueue) QueueMemory(note string) { f.notes = append(f.notes, note) }
+
+// TestForgetToolQueuesDisregardNote verifies a forget injects a turn-tail note so
+// the model stops trusting the still-cached index line this session.
+func TestForgetToolQueuesDisregardNote(t *testing.T) {
+	store := Store{Dir: t.TempDir()}
+	if _, err := store.Save(Memory{Name: "old-fact", Description: "d", Type: TypeProject, Body: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	q := &fakeQueue{}
+	ctx := WithQueue(context.Background(), q)
+	if _, err := NewForgetTool(store).Execute(ctx, []byte(`{"name":"old-fact"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if len(q.notes) != 1 || !strings.Contains(q.notes[0], "old-fact") {
+		t.Fatalf("expected one queued note naming the deleted memory, got %v", q.notes)
+	}
+}

--- a/internal/memory/forget_test.go
+++ b/internal/memory/forget_test.go
@@ -1,0 +1,45 @@
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestForgetToolDeletes drives the tool with raw JSON args and verifies the fact
+// is removed from the store.
+func TestForgetToolDeletes(t *testing.T) {
+	store := Store{Dir: t.TempDir()}
+	if _, err := store.Save(Memory{Name: "stale-fact", Description: "d", Type: TypeProject, Body: "b"}); err != nil {
+		t.Fatal(err)
+	}
+
+	tl := NewForgetTool(store)
+	if tl.Name() != "forget" || tl.ReadOnly() {
+		t.Fatalf("unexpected tool identity: name=%q readonly=%v", tl.Name(), tl.ReadOnly())
+	}
+	if !json.Valid(tl.Schema()) {
+		t.Fatal("forget schema is not valid JSON")
+	}
+
+	out, err := tl.Execute(context.Background(), []byte(`{"name":"stale-fact"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "Forgot memory") {
+		t.Fatalf("unexpected tool output: %q", out)
+	}
+	if len(store.List()) != 0 {
+		t.Fatalf("memory not deleted: %+v", store.List())
+	}
+}
+
+// TestForgetToolValidates rejects an empty name rather than deleting nothing
+// silently.
+func TestForgetToolValidates(t *testing.T) {
+	tl := NewForgetTool(Store{Dir: t.TempDir()})
+	if _, err := tl.Execute(context.Background(), []byte(`{}`)); err == nil {
+		t.Fatal("expected error when name is missing")
+	}
+}

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -138,7 +138,9 @@ func (s *Set) Block() string {
 
 	if idx := strings.TrimSpace(s.Index); idx != "" {
 		b.WriteString("\n## Saved memories\n\n")
-		b.WriteString("You have previously saved these memories. Read the linked file with read_file when one looks relevant; save new durable facts with the `remember` tool.\n\n")
+		b.WriteString("Facts you saved in earlier sessions. They reflect what was true when written and may now be stale — treat them as background, not standing instructions. " +
+			"Read the linked file with read_file when one looks relevant, and before acting on one that names a file, function, or flag, verify it still exists. " +
+			"Save new durable facts with the `remember` tool; delete ones that turn out wrong with `forget`.\n\n")
 		b.WriteString(idx)
 		fmt.Fprintf(&b, "\n\n(stored under %s)\n", s.Store.Dir)
 	}

--- a/internal/memory/queue.go
+++ b/internal/memory/queue.go
@@ -1,0 +1,23 @@
+package memory
+
+import "context"
+
+// Queue receives a one-line note about a memory change a tool just made, so the
+// controller can fold it into the current turn — taking effect this session
+// without touching the cache-stable system prefix. The remember/forget tools
+// read it from their call context the same way background tools read the job
+// manager.
+type Queue interface{ QueueMemory(note string) }
+
+type queueKey struct{}
+
+// WithQueue stamps q onto ctx for the remember/forget tools to find.
+func WithQueue(ctx context.Context, q Queue) context.Context {
+	return context.WithValue(ctx, queueKey{}, q)
+}
+
+// QueueFromContext returns the memory queue the agent stamped, if any.
+func QueueFromContext(ctx context.Context) (Queue, bool) {
+	q, ok := ctx.Value(queueKey{}).(Queue)
+	return q, ok && q != nil
+}

--- a/internal/memory/remember.go
+++ b/internal/memory/remember.go
@@ -79,7 +79,10 @@ func (t rememberTool) Execute(ctx context.Context, args json.RawMessage) (string
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("Saved memory to %s (it will load automatically in future sessions).", path), nil
+	if q, ok := QueueFromContext(ctx); ok {
+		q.QueueMemory("Saved memory \"" + slug(name) + "\": " + oneLine(in.Description))
+	}
+	return fmt.Sprintf("Saved memory to %s (it applies now and loads automatically in future sessions).", path), nil
 }
 
 func (rememberTool) ReadOnly() bool { return false }

--- a/internal/memory/remember.go
+++ b/internal/memory/remember.go
@@ -26,19 +26,23 @@ func (rememberTool) Description() string {
 		"Use for things worth remembering long-term: who the user is and their preferences (type \"user\"); " +
 		"guidance on how to work, including the why (type \"feedback\"); ongoing goals or constraints not " +
 		"derivable from the code (type \"project\"); or pointers to external resources (type \"reference\"). " +
-		"Do NOT save what the repo already records (code structure, git history) or facts that only matter to " +
-		"the current conversation. Saving the same name again overwrites it — prefer updating over duplicating. " +
-		"The saved index is loaded into context at the start of each session."
+		"For feedback/project, structure the body with a \"**Why:**\" line and a \"**How to apply:**\" line so the fact is actionable later; " +
+		"link related memories inline with [[their-name]]. " +
+		"Do NOT save what the repo already records (code structure, git history) or facts that only matter to the current conversation; " +
+		"if asked to remember one of those, save instead the non-obvious point behind it. " +
+		"Before saving, check the loaded memory index for an entry that already covers this — reuse that name to update it rather than create a near-duplicate, and use `forget` to drop one that is now wrong. " +
+		"The saved index loads into context at the start of each session."
 }
 
 func (rememberTool) Schema() json.RawMessage {
 	return json.RawMessage(`{
 		"type": "object",
 		"properties": {
-			"name": {"type": "string", "description": "Short kebab-case slug identifying the fact, e.g. \"prefers-tabs\". Reusing a name overwrites that memory. Omit to derive one from the description."},
-			"description": {"type": "string", "description": "One-line summary used in the memory index and for recall."},
+			"name": {"type": "string", "description": "Short kebab-case slug identifying the fact, e.g. \"prefers-tabs\". Reusing a name overwrites that memory — do that to update an existing fact. Omit to derive one from the description."},
+			"title": {"type": "string", "description": "Short human-readable label shown in the memory index, e.g. \"Prefers tabs\". Omit to derive one from the name."},
+			"description": {"type": "string", "description": "One-line hook shown in the index — the phrase a future session reads to decide whether to open this memory. Make it specific."},
 			"type": {"type": "string", "enum": ["user", "feedback", "project", "reference"], "description": "Category of the fact."},
-			"body": {"type": "string", "description": "The fact itself (Markdown). For feedback/project, include why it matters and how to apply it."}
+			"body": {"type": "string", "description": "The fact itself (Markdown). For feedback/project, include a \"**Why:**\" line and a \"**How to apply:**\" line; link related memories with [[their-name]]."}
 		},
 		"required": ["description", "body"]
 	}`)
@@ -47,6 +51,7 @@ func (rememberTool) Schema() json.RawMessage {
 func (t rememberTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var in struct {
 		Name        string `json:"name"`
+		Title       string `json:"title"`
 		Description string `json:"description"`
 		Type        string `json:"type"`
 		Body        string `json:"body"`
@@ -59,10 +64,14 @@ func (t rememberTool) Execute(ctx context.Context, args json.RawMessage) (string
 	}
 	name := in.Name
 	if name == "" {
-		name = in.Description // Save slugifies; a description makes a serviceable slug
+		name = in.Title // Save slugifies; the title (or, below, the description) makes a serviceable slug
+	}
+	if name == "" {
+		name = in.Description
 	}
 	path, err := t.store.Save(Memory{
 		Name:        name,
+		Title:       in.Title,
 		Description: in.Description,
 		Type:        NormalizeType(in.Type),
 		Body:        in.Body,

--- a/internal/memory/remember_test.go
+++ b/internal/memory/remember_test.go
@@ -21,7 +21,7 @@ func TestRememberToolSaves(t *testing.T) {
 		t.Fatal("remember schema is not valid JSON")
 	}
 
-	args := []byte(`{"name":"likes-go","description":"User likes Go","type":"user","body":"Default to Go for backend work."}`)
+	args := []byte(`{"name":"likes-go","title":"Likes Go","description":"User likes Go","type":"user","body":"Default to Go for backend work."}`)
 	out, err := tl.Execute(context.Background(), args)
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
@@ -33,6 +33,9 @@ func TestRememberToolSaves(t *testing.T) {
 	list := store.List()
 	if len(list) != 1 || list[0].Name != "likes-go" || list[0].Type != TypeUser {
 		t.Fatalf("memory not saved correctly: %+v", list)
+	}
+	if list[0].Title != "Likes Go" {
+		t.Fatalf("title not persisted through the tool: %q", list[0].Title)
 	}
 }
 

--- a/internal/memory/remember_test.go
+++ b/internal/memory/remember_test.go
@@ -50,3 +50,17 @@ func TestRememberToolValidates(t *testing.T) {
 		t.Fatal("expected error when description is missing")
 	}
 }
+
+// TestRememberToolQueuesNote verifies a save injects a turn-tail note so the
+// fact applies this session, not only the next.
+func TestRememberToolQueuesNote(t *testing.T) {
+	q := &fakeQueue{}
+	ctx := WithQueue(context.Background(), q)
+	tl := NewRememberTool(Store{Dir: t.TempDir()})
+	if _, err := tl.Execute(ctx, []byte(`{"name":"uses-rmb","description":"balance is RMB","type":"user","body":"b"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if len(q.notes) != 1 || !strings.Contains(q.notes[0], "uses-rmb") {
+		t.Fatalf("expected one queued note naming the saved memory, got %v", q.notes)
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -48,6 +48,7 @@ func NormalizeType(s string) Type {
 // Memory is one stored fact.
 type Memory struct {
 	Name        string // kebab-case slug; also the file stem (<name>.md)
+	Title       string // human-readable index label; falls back to a de-kebabed Name
 	Description string // one-line summary used for the index and recall
 	Type        Type
 	Body        string // the fact itself (Markdown)
@@ -118,6 +119,23 @@ func (s Store) Save(m Memory) (string, error) {
 	return path, nil
 }
 
+// Delete removes a memory file and its MEMORY.md line — the model's `forget`
+// path and the user's way to prune a stale fact. A missing file is not an error;
+// the goal state (gone) holds either way.
+func (s Store) Delete(name string) error {
+	if s.Dir == "" {
+		return fmt.Errorf("memory store unavailable (no user config dir)")
+	}
+	name = slug(name)
+	if name == "" {
+		return fmt.Errorf("memory needs a name")
+	}
+	if err := os.Remove(filepath.Join(s.Dir, name+".md")); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return s.flushIndex(s.indexLinesExcept(name))
+}
+
 // render serializes a memory to frontmatter + body. The frontmatter mirrors the
 // auto-memory shape (name / description / metadata.type) so the files are
 // interchangeable with that ecosystem and re-readable by loadMemory.
@@ -125,6 +143,9 @@ func render(m Memory, name string) string {
 	var b strings.Builder
 	b.WriteString("---\n")
 	b.WriteString("name: " + name + "\n")
+	if t := oneLine(m.Title); t != "" {
+		b.WriteString("title: " + t + "\n")
+	}
 	b.WriteString("description: " + oneLine(m.Description) + "\n")
 	b.WriteString("metadata:\n")
 	b.WriteString("  type: " + string(NormalizeType(string(m.Type))) + "\n")
@@ -134,27 +155,28 @@ func render(m Memory, name string) string {
 	return b.String()
 }
 
-// indexLineRe matches a managed index line so reindex can replace the line for a
-// given memory without disturbing the rest of a hand-edited MEMORY.md.
+// indexLineRe matches a managed index line so reindex/Delete can target the line
+// for one memory by its filename without disturbing the rest of a hand-edited
+// MEMORY.md.
 var indexLineRe = regexp.MustCompile(`\]\(([^)]+)\.md\)`)
 
-// reindex rewrites the MEMORY.md line for name, preserving every other line and
-// keeping the list sorted by filename. The line format matches the auto-memory
-// index: "- [<name>](<name>.md) — <description>".
-func (s Store) reindex(name string, m Memory) error {
-	path := filepath.Join(s.Dir, indexFile)
-	existing, _ := os.ReadFile(path) // missing → start fresh
-
+// indexLinesExcept returns the managed MEMORY.md lines keyed by filename stem,
+// dropping the entry for name (a missing index → empty map).
+func (s Store) indexLinesExcept(name string) map[string]string {
+	existing, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
 	keep := map[string]string{}
 	for _, line := range strings.Split(string(existing), "\n") {
 		if mt := indexLineRe.FindStringSubmatch(line); mt != nil && mt[1] != name {
 			keep[mt[1]] = strings.TrimRight(line, "\r")
 		}
 	}
-	keep[name] = fmt.Sprintf("- [%s](%s.md) — %s", name, name, oneLine(m.Description))
+	return keep
+}
 
-	names := make([]string, 0, len(keep))
-	for n := range keep {
+// flushIndex rewrites MEMORY.md from the managed lines, sorted by filename.
+func (s Store) flushIndex(lines map[string]string) error {
+	names := make([]string, 0, len(lines))
+	for n := range lines {
 		names = append(names, n)
 	}
 	sort.Strings(names)
@@ -162,10 +184,19 @@ func (s Store) reindex(name string, m Memory) error {
 	var b strings.Builder
 	b.WriteString("# Memory\n\n")
 	for _, n := range names {
-		b.WriteString(keep[n])
+		b.WriteString(lines[n])
 		b.WriteString("\n")
 	}
-	return os.WriteFile(path, []byte(b.String()), 0o644)
+	return os.WriteFile(filepath.Join(s.Dir, indexFile), []byte(b.String()), 0o644)
+}
+
+// reindex rewrites the MEMORY.md line for name, preserving every other managed
+// line. The line is "- [<title>](<name>.md) — <description>"; title falls back
+// to a de-kebabed name so the index reads as a label, never a bare slug.
+func (s Store) reindex(name string, m Memory) error {
+	lines := s.indexLinesExcept(name)
+	lines[name] = fmt.Sprintf("- [%s](%s.md) — %s", displayTitle(m.Title, name), name, oneLine(m.Description))
+	return s.flushIndex(lines)
 }
 
 // List returns the saved memories parsed from their files, sorted by name. Used
@@ -203,6 +234,7 @@ func loadMemory(path string) (Memory, bool) {
 	fm, body := splitFrontmatter(string(b))
 	m := Memory{
 		Name:        fm["name"],
+		Title:       fm["title"],
 		Description: fm["description"],
 		Type:        NormalizeType(fm["type"]),
 		Body:        strings.TrimSpace(body),
@@ -231,4 +263,13 @@ func slug(s string) string {
 // index or frontmatter format.
 func oneLine(s string) string {
 	return strings.Join(strings.Fields(s), " ")
+}
+
+// displayTitle is the index link label: the given title, or a de-kebabed name
+// when none was supplied, so a bare slug never leaks into the index.
+func displayTitle(title, name string) string {
+	if t := oneLine(title); t != "" {
+		return t
+	}
+	return strings.ReplaceAll(name, "-", " ")
 }

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -74,6 +75,74 @@ func TestStoreIndexPreservesHandEdits(t *testing.T) {
 	idx := s.Index()
 	if !strings.Contains(idx, "alpha.md") || !strings.Contains(idx, "beta.md") {
 		t.Fatalf("an entry was lost on the second save:\n%s", idx)
+	}
+}
+
+// TestStoreSaveTitleInIndexAndFrontmatter verifies an explicit title becomes the
+// index link label and round-trips through the file's frontmatter.
+func TestStoreSaveTitleInIndexAndFrontmatter(t *testing.T) {
+	s := Store{Dir: t.TempDir()}
+	if _, err := s.Save(Memory{
+		Name:        "tabs-rule",
+		Title:       "Prefers tabs",
+		Description: "indent with tabs",
+		Type:        TypeUser,
+		Body:        "b",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if idx := s.Index(); !strings.Contains(idx, "[Prefers tabs](tabs-rule.md)") {
+		t.Fatalf("index link should use the title label:\n%s", idx)
+	}
+	if got := s.List()[0].Title; got != "Prefers tabs" {
+		t.Fatalf("title not round-tripped: %q", got)
+	}
+}
+
+// TestStoreIndexLabelFallsBackToDeKebabbedName checks a title-less memory still
+// gets a readable label instead of a bare slug.
+func TestStoreIndexLabelFallsBackToDeKebabbedName(t *testing.T) {
+	s := Store{Dir: t.TempDir()}
+	if _, err := s.Save(Memory{Name: "likes-go", Description: "d", Type: TypeUser, Body: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	if idx := s.Index(); !strings.Contains(idx, "[likes go](likes-go.md)") {
+		t.Fatalf("missing-title label should de-kebab the name:\n%s", idx)
+	}
+}
+
+// TestStoreDelete removes a fact's file and its index line while leaving others.
+func TestStoreDelete(t *testing.T) {
+	s := Store{Dir: t.TempDir()}
+	for _, n := range []string{"alpha", "beta"} {
+		if _, err := s.Save(Memory{Name: n, Description: "d", Type: TypeProject, Body: "b"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.Delete("alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(s.Dir, "alpha.md")); !os.IsNotExist(err) {
+		t.Fatalf("alpha.md should be gone, stat err = %v", err)
+	}
+	idx := s.Index()
+	if strings.Contains(idx, "alpha.md") {
+		t.Fatalf("deleted entry still in index:\n%s", idx)
+	}
+	if !strings.Contains(idx, "beta.md") {
+		t.Fatalf("unrelated entry lost on delete:\n%s", idx)
+	}
+	if names := s.List(); len(names) != 1 || names[0].Name != "beta" {
+		t.Fatalf("List after delete = %+v, want only beta", names)
+	}
+}
+
+// TestStoreDeleteMissingIsNoError treats deleting an absent memory as success —
+// the goal state (gone) already holds.
+func TestStoreDeleteMissingIsNoError(t *testing.T) {
+	s := Store{Dir: t.TempDir()}
+	if err := s.Delete("never-saved"); err != nil {
+		t.Fatalf("deleting a missing memory should not error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Why

Our memory was a faithful clone of the two-layer model (doc hierarchy + per-fact files + `MEMORY.md` index folded into the cache-stable prefix), but it lagged on three behaviours that make saved memory actually useful:

1. **It could only grow.** The model had `remember` but no way to drop a fact that turned out wrong or stale. Dedup was exact-name-only, so semantically duplicate facts under different slugs piled up forever — steadily degrading recall signal-to-noise.
2. **Stale facts read as standing orders.** The saved-memories block told the model to "treat as durable, user-authored guidance", so it would act on a memory naming a since-deleted file/flag as if it were a current instruction.
3. **The index read as slugs.** Link text was the bare kebab slug, weakening the relevance call the model makes when deciding which fact to open.

## What

- **`forget` tool + `Store.Delete`** — prune a fact's file and its `MEMORY.md` line (missing file is a no-op; the goal state is "gone"). Symmetric with `remember`: writes straight to disk, folds out of the prefix next session.
- **Recall reframed as fallible background** — the saved-memories block now says these reflect what was true when written, may be stale, are background not standing instructions, and a named file/function/flag must be verified to still exist before acting on it.
- **Richer index** — new optional `title` (frontmatter + round-trip); index links render `[Title](name.md)`, falling back to a de-kebabed name so a bare slug never leaks. `description` is repositioned as the relevance hook.
- **Stronger `remember` guidance** — `**Why:**`/`**How to apply:**` structure for feedback/project, `[[their-name]]` inline links, and reuse-the-name-to-update over near-duplicate saves.

Recall stays index-only in the cached prefix (zero added per-turn cost, fully cache-stable) by design — bodies are still read on demand.

## Tests

`go test ./...` (root + `desktop` module) green; frontend `tsc --noEmit` green; `go vet` clean. New: `TestStoreDelete`, `TestStoreDeleteMissingIsNoError`, `TestStoreSaveTitleInIndexAndFrontmatter`, `TestStoreIndexLabelFallsBackToDeKebabbedName`, `TestForgetToolDeletes`, `TestForgetToolValidates`, plus title round-trip in the remember test.
