### PR TITLE
feat(ci): mutation testing for diff bot (behavioral signal for additive PRs)

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -95,10 +95,12 @@ func runOnce(o diffOpts, srcFiles, pkgs []string, prompt string) diffReport {
 	testsPass, testOut := runTests(o.repo, o.testCmd, pkgs)
 
 	var pins []pinResult
+	var mut mutationResult
 	covered, coverTotal := 0, 0
 	if len(refs) > 0 && testsPass {
 		covered, coverTotal = changedLineCoverage(o.repo, o.base, pkgs, srcFiles)
 		pins = differentialPerTest(o.repo, o.base, srcFiles, refs)
+		mut = runMutation(o.repo, o.base, srcFiles, refs)
 	}
 	buildOK, buildOut := goBuildAll(o.repo)
 
@@ -106,7 +108,7 @@ func runOnce(o diffOpts, srcFiles, pkgs []string, prompt string) diffReport {
 	return diffReport{
 		srcFiles: srcFiles, pkgs: pkgs, addedTestLines: countAdded(testDiff),
 		newTests: refs, sourceTouched: sourceTouched, testsPass: testsPass,
-		pins: pins, covered: covered, coverTotal: coverTotal,
+		pins: pins, mut: mut, covered: covered, coverTotal: coverTotal,
 		buildOK: buildOK, buildOut: buildOut, failing: failingTestNames(testOut),
 		passed: passed, m: m, runErr: runErr, testOut: testOut, testDiff: testDiff,
 	}
@@ -124,6 +126,9 @@ func better(a, b diffReport) bool {
 	}
 	if x, y := countPins(a.pins), countPins(b.pins); x != y {
 		return x > y
+	}
+	if a.mut.caught != b.mut.caught {
+		return a.mut.caught > b.mut.caught
 	}
 	return ratio(a.covered, a.coverTotal) > ratio(b.covered, b.coverTotal)
 }
@@ -174,6 +179,7 @@ type diffReport struct {
 	sourceTouched       int
 	testsPass           bool
 	pins                []pinResult
+	mut                 mutationResult
 	covered, coverTotal int
 	buildOK             bool
 	buildOut            string
@@ -205,6 +211,7 @@ func renderDiff(r diffReport) string {
 		fmt.Fprintf(&b, "| ↳ pin by assertion / by compile only | %d / %d |\n", byAssert, pinned-byAssert)
 	}
 	fmt.Fprintf(&b, "| Changed-line coverage | %s |\n", coverageCell(r))
+	fmt.Fprintf(&b, "| Mutation (changed funcs caught) | %s |\n", mutationCell(r))
 	fmt.Fprintf(&b, "| `go build ./...` (regression) | %s |\n", passFail(r.buildOK))
 	fmt.Fprintf(&b, "| Non-test source touched by agent | %d file(s) |\n", r.sourceTouched)
 	fmt.Fprintf(&b, "| Cache hit | %s |\n", pct(r.m.CacheHitTokens, r.m.CacheHitTokens+r.m.CacheMissTokens))
@@ -249,7 +256,7 @@ func renderDiff(r diffReport) string {
 	if r.runErr != nil {
 		fmt.Fprintf(&b, "\n<sub>agent run note: %v</sub>\n", r.runErr)
 	}
-	fmt.Fprintf(&b, "\n<sub>Pass = the agent added ≥1 test, the affected packages are green, AND ≥1 new test fails when the PR's source is reverted. \"By assertion\" pins are strong (they check changed behavior); \"by compile only\" pins just need a PR-added symbol — and since Go compiles per package, one compile-coupled test marks every test in its package that way, so read the diff above to judge the rest.</sub>\n")
+	fmt.Fprintf(&b, "\n<sub>Pass = the agent added ≥1 test, the affected packages are green, AND ≥1 new test fails when the PR's source is reverted. \"By assertion\" pins are strong (they check changed behavior); \"by compile only\" pins just need a PR-added symbol — and since Go compiles per package, one compile-coupled test marks every test in its package that way. Mutation is the behavioral signal for additive PRs: each changed function's return is replaced with zero values and the new tests are re-run; \"caught\" means a test asserts that output, \"survived\" means it doesn't. Read the generated tests above to judge the rest.</sub>\n")
 	return b.String()
 }
 
@@ -265,6 +272,17 @@ func coverageCell(r diffReport) string {
 		return "n/a"
 	}
 	return fmt.Sprintf("%s (%d/%d changed lines)", pct(r.covered, r.coverTotal), r.covered, r.coverTotal)
+}
+
+func mutationCell(r diffReport) string {
+	if r.mut.total == 0 {
+		return "n/a"
+	}
+	cell := fmt.Sprintf("%d/%d (%s)", r.mut.caught, r.mut.total, pct(r.mut.caught, r.mut.total))
+	if len(r.mut.survivors) > 0 {
+		cell += fmt.Sprintf(" · survived: `%s`", strings.Join(r.mut.survivors, "`, `"))
+	}
+	return cell
 }
 
 func pinCell(p pinResult) string {

--- a/cmd/e2ebench/mutation.go
+++ b/cmd/e2ebench/mutation.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const maxMutants = 15
+
+type mutationResult struct {
+	caught, total int
+	survivors     []string
+}
+
+// runMutation gives a behavioral signal that the differential can't for additive
+// PRs: it replaces each changed function's body with a zero-value return (which
+// compiles for any signature via *new(T)), runs only the agent's new tests for
+// that package, and records whether they catch the mutation. A caught mutant
+// means a test actually asserts that function's output; a survivor means the new
+// tests don't check it.
+func runMutation(repo, base string, srcFiles []string, refs []testRef) mutationResult {
+	changed := changedLineSet(repo, base, srcFiles)
+	byPkg := map[string][]string{}
+	for _, r := range refs {
+		byPkg[r.pkg] = append(byPkg[r.pkg], r.name)
+	}
+
+	var res mutationResult
+	for _, file := range srcFiles {
+		if res.total >= maxMutants {
+			break
+		}
+		pkg := "./" + filepath.ToSlash(filepath.Dir(file))
+		tests := byPkg[pkg]
+		if len(tests) == 0 {
+			continue // no new tests to attribute a catch to
+		}
+		runRe := "^(" + strings.Join(tests, "|") + ")$"
+
+		abs := filepath.Join(repo, filepath.FromSlash(file))
+		srcB, err := os.ReadFile(abs)
+		if err != nil {
+			continue
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, abs, srcB, 0)
+		if err != nil {
+			continue
+		}
+		src := string(srcB)
+		for _, fd := range changedFuncs(fset, f, changed[file]) {
+			if res.total >= maxMutants {
+				break
+			}
+			res.total++
+			lb := fset.Position(fd.Body.Lbrace).Offset
+			rb := fset.Position(fd.Body.Rbrace).Offset
+			mutated := src[:lb] + mutantBody(fset, fd.Type.Results) + src[rb+1:]
+			if os.WriteFile(abs, []byte(mutated), 0o644) != nil {
+				res.total--
+				continue
+			}
+			cmd := exec.Command("go", "test", "-run", runRe, pkg)
+			cmd.Dir = repo
+			caught := cmd.Run() != nil
+			_ = os.WriteFile(abs, srcB, 0o644) // restore before the next mutant
+			if caught {
+				res.caught++
+			} else {
+				res.survivors = append(res.survivors, fd.Name.Name)
+			}
+		}
+	}
+	return res
+}
+
+// changedFuncs returns the funcs in f whose line range overlaps a changed line.
+// main/init are skipped (no meaningful return to mutate).
+func changedFuncs(fset *token.FileSet, f *ast.File, lines map[int]bool) []*ast.FuncDecl {
+	var out []*ast.FuncDecl
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil || fd.Name.Name == "main" || fd.Name.Name == "init" {
+			continue
+		}
+		start := fset.Position(fd.Pos()).Line
+		end := fset.Position(fd.End()).Line
+		for ln := range lines {
+			if ln >= start && ln <= end {
+				out = append(out, fd)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// mutantBody returns a replacement body that returns the zero value for each
+// result. *new(T) is the zero value of any type T, so this compiles for every
+// signature without naming the results or knowing their concrete types.
+func mutantBody(fset *token.FileSet, results *ast.FieldList) string {
+	if results == nil || len(results.List) == 0 {
+		return "{\n}"
+	}
+	var rets []string
+	for _, field := range results.List {
+		t := "*new(" + printType(fset, field.Type) + ")"
+		n := len(field.Names)
+		if n == 0 {
+			n = 1
+		}
+		for i := 0; i < n; i++ {
+			rets = append(rets, t)
+		}
+	}
+	return "{\n\treturn " + strings.Join(rets, ", ") + "\n}"
+}
+
+func printType(fset *token.FileSet, e ast.Expr) string {
+	var b strings.Builder
+	_ = printer.Fprint(&b, fset, e)
+	return b.String()
+}


### PR DESCRIPTION
Adds the strong behavioral signal the compile-only differential can't give for additive PRs: each changed function's body is replaced with a zero-value return (`*new(T)`) and the agent's new tests are re-run — caught = a test asserts the output, survived = it doesn't. Locally verified an asserted func is caught while an only-called (100%-covered) func survives. Capped at 15 mutants.