### PR TITLE
Fix auto-plan classifier nil panic

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -359,7 +359,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		classifier = control.NewProviderAutoPlanClassifier(classifierProv)
 	}
 
-	return control.New(control.Options{
+	ctrlOpts := control.Options{
 		Runner:        runner,
 		Executor:      executor,
 		Sink:          sink,
@@ -380,8 +380,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		PluginCtx:     ctx,
 		WorkspaceRoot: cwd,
 		AutoPlan:      cfg.Agent.AutoPlan,
-		Classifier:    classifier,
-	}), nil
+	}
+	if classifier != nil {
+		ctrlOpts.Classifier = classifier
+	}
+	return control.New(ctrlOpts), nil
 }
 
 func subagentModelRef(cfg *config.Config, sk skill.Skill) string {

--- a/internal/control/auto_plan_classifier.go
+++ b/internal/control/auto_plan_classifier.go
@@ -26,6 +26,9 @@ func NewProviderAutoPlanClassifier(prov provider.Provider) *ProviderAutoPlanClas
 }
 
 func (c *ProviderAutoPlanClassifier) NeedsPlan(ctx context.Context, input string, score int) (bool, string, error) {
+	if c == nil || c.prov == nil {
+		return false, "", fmt.Errorf("auto plan classifier is not initialized")
+	}
 	ch, err := c.prov.Stream(ctx, provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleSystem, Content: autoPlanClassifierPrompt},

--- a/internal/control/auto_plan_classifier_test.go
+++ b/internal/control/auto_plan_classifier_test.go
@@ -66,3 +66,11 @@ func TestProviderAutoPlanClassifierRequiresNeedsPlan(t *testing.T) {
 		t.Fatal("NeedsPlan should reject JSON without needs_plan")
 	}
 }
+
+func TestProviderAutoPlanClassifierNilReceiverReturnsError(t *testing.T) {
+	var c *ProviderAutoPlanClassifier
+
+	if _, _, err := c.NeedsPlan(context.Background(), "x", 1); err == nil {
+		t.Fatal("NeedsPlan should reject nil classifier")
+	}
+}

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -169,6 +169,19 @@ func TestRunTurnAutoPlanClassifierFallback(t *testing.T) {
 	}
 }
 
+func TestRunTurnAutoPlanTypedNilClassifierFallsBack(t *testing.T) {
+	var classifier *ProviderAutoPlanClassifier
+	runner := &fakeTurnRunner{}
+	c := New(Options{AutoPlan: "ask", Classifier: classifier, Runner: runner})
+
+	if err := c.runTurn(context.Background(), "实现 README 文档更新"); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+		t.Fatalf("typed nil classifier should fall back to heuristic auto-plan, inputs=%q", runner.inputs)
+	}
+}
+
 func TestRunTurnAutoPlanScoresRawPromptNotResolvedRefs(t *testing.T) {
 	runner := &fakeTurnRunner{}
 	c := New(Options{AutoPlan: "ask", Runner: runner})


### PR DESCRIPTION
## Summary

Fixes a desktop runtime crash triggered when the auto-plan classifier was configured as a typed nil interface. The controller now avoids injecting an uninitialized classifier, and the classifier itself returns a recoverable error if called before initialization.

## Root Cause

A `*ProviderAutoPlanClassifier` nil pointer was assigned to the `autoPlanClassifier` interface field. In Go, that creates a non-nil interface value with a nil concrete pointer. The existing `classifier != nil` guard then passed, and `NeedsPlan` was invoked on a nil receiver.

Sanitized crash log from the issue:

```text
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1052e3458]

goroutine 459 [running]:
reasonix/internal/control.(*ProviderAutoPlanClassifier).NeedsPlan(0x0, {0x105da43a0, 0x1674665102a0}, {0x16746640c280, 0x71}, 0x1)
        /Users/<developer>/Desktop/DeepSeek-Reasonix/internal/control/auto_plan_classifier.go:29 +0x298
reasonix/internal/control.(*Controller).shouldAutoPlan(0x1674661b6600, {0x105da4330, 0x167466096140}, {0x16746640c280, 0x71})
        /Users/<developer>/Desktop/DeepSeek-Reasonix/internal/control/auto_plan.go:59 +0x278
reasonix/internal/control.(*Controller).maybeAutoPlan(0x1674661b6600, {0x105da4330, 0x167466096140}, {0x16746640c280, 0x71})
        /Users/<developer>/Desktop/DeepSeek-Reasonix/internal/control/auto_plan.go:37 +0x30
reasonix/internal/control.(*Controller).runTurnWithRaw(0x1674661b6600, {0x105da4330, 0x167466096140}, {0x16746640c280, 0x71}, {0x16746640c280, 0x71})
        /Users/<developer>/Desktop/DeepSeek-Reasonix/internal/control/controller.go:327 +0x6c
reasonix/internal/control.(*Controller).Submit.func6({0x105da4330, 0x167466096140})
        /Users/<developer>/Desktop/DeepSeek-Reasonix/internal/control/controller.go:503 +0x1c4
reasonix/internal/control.(*Controller).runGuarded.func1()
        /Users/<developer>/Desktop/DeepSeek-Reasonix/internal/control/controller.go:279 +0x54
```

## Technical Approach

- Build `control.Options` first in boot wiring, and assign `Classifier` only when the concrete classifier pointer is non-nil.
- Add a nil receiver/provider guard in `ProviderAutoPlanClassifier.NeedsPlan` so unexpected typed nil paths degrade into a normal classifier error.
- Rely on the existing auto-plan fallback path to continue with heuristic planning instead of crashing the process.

## Focused Optimization Points

- Keeps the fix scoped to auto-plan classifier wiring and runtime guards.
- Does not change provider-visible prompts, tool schemas, or conversation prefix construction.
- Adds regression coverage for both direct nil receiver calls and typed nil classifier injection through the controller.

## Verification

```bash
go test ./internal/boot ./internal/control
```