### PR TITLE
Fix typed nil interface panics

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"reasonix/internal/evidence"
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
+	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -212,7 +213,12 @@ func (a *Agent) SetPlanMode(v bool) { a.planMode.Store(v) }
 // SetGate installs the per-call permission gate. Used by `reasonix chat` to swap the
 // headless gate built in setup for an interactive one that prompts the user;
 // nil disables gating. Safe to call before the run loop starts.
-func (a *Agent) SetGate(g Gate) { a.gate = g }
+func (a *Agent) SetGate(g Gate) {
+	if nilutil.IsNil(g) {
+		g = nil
+	}
+	a.gate = g
+}
 
 // SetAsker installs the asker the `ask` tool uses to question the user.
 // Interactive frontends wire one in; headless runs leave it nil.
@@ -311,8 +317,16 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	if opts.RecentKeep <= 0 {
 		opts.RecentKeep = minRecentKeep
 	}
-	if sink == nil {
+	if nilutil.IsNil(sink) {
 		sink = event.Discard
+	}
+	gate := opts.Gate
+	if nilutil.IsNil(gate) {
+		gate = nil
+	}
+	hooks := opts.Hooks
+	if nilutil.IsNil(hooks) {
+		hooks = nil
 	}
 	return &Agent{
 		prov:          prov,
@@ -322,8 +336,8 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		temperature:   opts.Temperature,
 		pricing:       opts.Pricing,
 		sink:          sink,
-		gate:          opts.Gate,
-		hooks:         opts.Hooks,
+		gate:          gate,
+		hooks:         hooks,
 		jobs:          opts.Jobs,
 		evidence:      evidence.NewLedger(),
 		contextWindow: opts.ContextWindow,

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"reasonix/internal/event"
+	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
 )
 
@@ -39,7 +40,7 @@ type Coordinator struct {
 // own events to its own sink (the CLI wires the same sink into both). A nil
 // sink is replaced with event.Discard.
 func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerPricing *provider.Pricing, executor *Agent, temperature float64, sink event.Sink) *Coordinator {
-	if sink == nil {
+	if nilutil.IsNil(sink) {
 		sink = event.Discard
 	}
 	return &Coordinator{

--- a/internal/agent/nil_boundary_test.go
+++ b/internal/agent/nil_boundary_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/tool"
+)
+
+type typedNilAgentSink struct{}
+
+func (*typedNilAgentSink) Emit(event.Event) {}
+
+type typedNilGate struct{}
+
+func (*typedNilGate) Check(context.Context, string, json.RawMessage, bool) (bool, string, error) {
+	return true, "", nil
+}
+
+type typedNilHooks struct{}
+
+func (*typedNilHooks) PreToolUse(context.Context, string, json.RawMessage) (bool, string) {
+	return false, ""
+}
+func (*typedNilHooks) PostToolUse(context.Context, string, json.RawMessage, string) {}
+func (*typedNilHooks) PostLLMCall(context.Context, string, int) string              { return "" }
+func (*typedNilHooks) HasPostLLMCall() bool                                         { return false }
+func (*typedNilHooks) SubagentStop(context.Context, string)                         {}
+func (*typedNilHooks) PreCompact(context.Context, string) string                    { return "" }
+
+func TestNewNormalizesTypedNilInterfaces(t *testing.T) {
+	var sink *typedNilAgentSink
+	var gate *typedNilGate
+	var hooks *typedNilHooks
+
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{Gate: gate, Hooks: hooks}, sink)
+	a.sink.Emit(event.Event{Kind: event.Text, Text: "typed nil sink should not panic"})
+	if a.gate != nil {
+		t.Fatal("typed nil gate should be normalized to nil")
+	}
+	if a.hooks != nil {
+		t.Fatal("typed nil hooks should be normalized to nil")
+	}
+}
+
+func TestSetGateNormalizesTypedNil(t *testing.T) {
+	var gate *typedNilGate
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	a.SetGate(gate)
+	if a.gate != nil {
+		t.Fatal("typed nil gate should be normalized to nil")
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -358,7 +358,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		classifier = control.NewProviderAutoPlanClassifier(classifierProv)
 	}
 
-	return control.New(control.Options{
+	ctrlOpts := control.Options{
 		Runner:        runner,
 		Executor:      executor,
 		Sink:          sink,
@@ -379,8 +379,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		PluginCtx:     ctx,
 		WorkspaceRoot: cwd,
 		AutoPlan:      cfg.Agent.AutoPlan,
-		Classifier:    classifier,
-	}), nil
+	}
+	if classifier != nil {
+		ctrlOpts.Classifier = classifier
+	}
+	return control.New(ctrlOpts), nil
 }
 
 func subagentModelRef(cfg *config.Config, sk skill.Skill) string {

--- a/internal/control/auto_plan_classifier.go
+++ b/internal/control/auto_plan_classifier.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
 )
 
@@ -19,13 +20,16 @@ type ProviderAutoPlanClassifier struct {
 }
 
 func NewProviderAutoPlanClassifier(prov provider.Provider) *ProviderAutoPlanClassifier {
-	if prov == nil {
+	if nilutil.IsNil(prov) {
 		return nil
 	}
 	return &ProviderAutoPlanClassifier{prov: prov}
 }
 
 func (c *ProviderAutoPlanClassifier) NeedsPlan(ctx context.Context, input string, score int) (bool, string, error) {
+	if c == nil || nilutil.IsNil(c.prov) {
+		return false, "", fmt.Errorf("auto plan classifier is not initialized")
+	}
 	ch, err := c.prov.Stream(ctx, provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleSystem, Content: autoPlanClassifierPrompt},

--- a/internal/control/auto_plan_classifier_test.go
+++ b/internal/control/auto_plan_classifier_test.go
@@ -66,3 +66,11 @@ func TestProviderAutoPlanClassifierRequiresNeedsPlan(t *testing.T) {
 		t.Fatal("NeedsPlan should reject JSON without needs_plan")
 	}
 }
+
+func TestProviderAutoPlanClassifierNilReceiverReturnsError(t *testing.T) {
+	var c *ProviderAutoPlanClassifier
+
+	if _, _, err := c.NeedsPlan(context.Background(), "x", 1); err == nil {
+		t.Fatal("NeedsPlan should reject nil classifier")
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -29,6 +29,7 @@ import (
 	"reasonix/internal/hook"
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
+	"reasonix/internal/nilutil"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -173,8 +174,12 @@ type Options struct {
 // New builds a Controller. A nil Sink is replaced with event.Discard.
 func New(opts Options) *Controller {
 	sink := opts.Sink
-	if sink == nil {
+	if nilutil.IsNil(sink) {
 		sink = event.Discard
+	}
+	classifier := opts.Classifier
+	if nilutil.IsNil(classifier) {
+		classifier = nil
 	}
 	pluginCtx := opts.PluginCtx
 	if pluginCtx == nil {
@@ -196,7 +201,7 @@ func New(opts Options) *Controller {
 		mem:          opts.Memory,
 		cleanup:      opts.Cleanup,
 		autoPlan:     normalizeAutoPlan(opts.AutoPlan),
-		classifier:   opts.Classifier,
+		classifier:   classifier,
 		balanceURL:   opts.BalanceURL,
 		balanceKey:   opts.BalanceKey,
 		jobs:         opts.Jobs,

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -7,6 +7,17 @@ import (
 	"reasonix/internal/event"
 )
 
+type typedNilControllerSink struct{}
+
+func (*typedNilControllerSink) Emit(event.Event) {}
+
+func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
+	var sink *typedNilControllerSink
+	c := New(Options{Sink: sink})
+
+	c.notice("typed nil sink should not panic")
+}
+
 // approvalIDs returns a Controller whose Sink forwards each ApprovalRequest's ID
 // onto the channel, plus a counter of how many requests it emitted.
 func approvalIDs() (*Controller, chan string, *int) {

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -185,6 +185,19 @@ func TestRunTurnAutoPlanClassifierFallback(t *testing.T) {
 	}
 }
 
+func TestRunTurnAutoPlanTypedNilClassifierFallsBack(t *testing.T) {
+	var classifier *ProviderAutoPlanClassifier
+	runner := &fakeTurnRunner{}
+	c := New(Options{AutoPlan: "ask", Classifier: classifier, Runner: runner})
+
+	if err := c.runTurn(context.Background(), "实现 README 文档更新"); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.inputs) != 1 || !strings.HasPrefix(runner.inputs[0], PlanModeMarker) {
+		t.Fatalf("typed nil classifier should fall back to heuristic auto-plan, inputs=%q", runner.inputs)
+	}
+}
+
 func TestRunTurnAutoPlanScoresRawPromptNotResolvedRefs(t *testing.T) {
 	runner := &fakeTurnRunner{}
 	c := New(Options{AutoPlan: "ask", Runner: runner})

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -178,7 +178,11 @@ type Sink interface {
 type FuncSink func(Event)
 
 // Emit calls the wrapped function.
-func (f FuncSink) Emit(e Event) { f(e) }
+func (f FuncSink) Emit(e Event) {
+	if f != nil {
+		f(e)
+	}
+}
 
 // Discard is a Sink that drops every event. Useful in tests and for runs that
 // only care about the final session state.

--- a/internal/event/event_test.go
+++ b/internal/event/event_test.go
@@ -45,6 +45,22 @@ func TestFuncSinkEmit(t *testing.T) {
 	}
 }
 
+func TestFuncSinkNilEmitIsNoop(t *testing.T) {
+	var fs FuncSink
+
+	fs.Emit(Event{Kind: Text, Text: "hello"})
+}
+
+type typedNilSink struct{}
+
+func (*typedNilSink) Emit(Event) {}
+
+func TestSyncTreatsTypedNilSinkAsDiscard(t *testing.T) {
+	var base *typedNilSink
+
+	Sync(base).Emit(Event{Kind: Text, Text: "hello"})
+}
+
 // --- Discard ---
 
 func TestDiscardSink(t *testing.T) {

--- a/internal/event/sync.go
+++ b/internal/event/sync.go
@@ -1,6 +1,10 @@
 package event
 
-import "sync"
+import (
+	"sync"
+
+	"reasonix/internal/nilutil"
+)
 
 // Sync wraps a Sink so concurrent Emit calls are serialized. The base Sink
 // contract assumes serial emission — the agent's run loop emits one event at a
@@ -10,7 +14,7 @@ import "sync"
 // EventsEmit, a TUI channel) without each having to lock. A nil sink yields
 // Discard.
 func Sync(s Sink) Sink {
-	if s == nil {
+	if nilutil.IsNil(s) {
 		return Discard
 	}
 	return &syncSink{inner: s}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/nilutil"
 )
 
 // Status is a job's lifecycle state.
@@ -87,7 +88,7 @@ type Manager struct {
 // context (cancelled by Close). sink receives job-lifecycle notices; pass the
 // session's synchronized sink (event.Sync) since jobs emit from goroutines.
 func NewManager(sink event.Sink) *Manager {
-	if sink == nil {
+	if nilutil.IsNil(sink) {
 		sink = event.Discard
 	}
 	root, cancel := context.WithCancel(context.Background())

--- a/internal/jobs/jobs_extra_test.go
+++ b/internal/jobs/jobs_extra_test.go
@@ -9,6 +9,24 @@ import (
 	"reasonix/internal/event"
 )
 
+type typedNilJobSink struct{}
+
+func (*typedNilJobSink) Emit(event.Event) {}
+
+func TestNewManagerTreatsTypedNilSinkAsDiscard(t *testing.T) {
+	var sink *typedNilJobSink
+	m := NewManager(sink)
+	defer m.Close()
+
+	j := m.Start("bash", "typed nil sink", func(context.Context, io.Writer) (string, error) {
+		return "done", nil
+	})
+	res := m.Wait(context.Background(), []string{j.ID}, 1000)
+	if len(res) != 1 || res[0].Status != Done {
+		t.Fatalf("job result = %+v, want one done job", res)
+	}
+}
+
 // --- Wait with timeout ---
 
 func TestWaitTimeout(t *testing.T) {

--- a/internal/nilutil/nil.go
+++ b/internal/nilutil/nil.go
@@ -1,0 +1,17 @@
+package nilutil
+
+import "reflect"
+
+// IsNil reports whether v is nil or an interface holding a typed nil value.
+func IsNil(v any) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}

--- a/internal/nilutil/nil_test.go
+++ b/internal/nilutil/nil_test.go
@@ -1,0 +1,31 @@
+package nilutil
+
+import "testing"
+
+type sampleInterface interface {
+	Do()
+}
+
+type sampleImpl struct{}
+
+func (*sampleImpl) Do() {}
+
+func TestIsNilDetectsTypedNilInterface(t *testing.T) {
+	var p *sampleImpl
+	var i sampleInterface = p
+
+	if !IsNil(i) {
+		t.Fatal("IsNil should detect typed nil interface")
+	}
+}
+
+func TestIsNilRejectsConcreteValues(t *testing.T) {
+	var p sampleInterface = &sampleImpl{}
+
+	if IsNil(p) {
+		t.Fatal("IsNil should not reject a concrete interface value")
+	}
+	if IsNil("x") {
+		t.Fatal("IsNil should not reject non-nil scalar values")
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+
+	"reasonix/internal/nilutil"
 )
 
 // Role is the role of a message.
@@ -273,7 +275,14 @@ func New(kind string, cfg Config) (Provider, error) {
 	if !ok {
 		return nil, fmt.Errorf("provider: unknown kind %q (registered: %v)", kind, Kinds())
 	}
-	return f(cfg)
+	p, err := f(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if nilutil.IsNil(p) {
+		return nil, fmt.Errorf("provider: factory %q returned nil provider", kind)
+	}
+	return p, nil
 }
 
 // Kinds returns the registered kinds, sorted.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -233,6 +233,22 @@ func TestNewWithRegisteredKind(t *testing.T) {
 	// We can't easily unregister, but we can test it doesn't panic.
 }
 
+func TestNewRejectsTypedNilProvider(t *testing.T) {
+	kind := "test-typed-nil-__" + t.Name()
+	Register(kind, func(cfg Config) (Provider, error) {
+		var p *mockProvider
+		return p, nil
+	})
+
+	_, err := New(kind, Config{})
+	if err == nil {
+		t.Fatal("New should reject typed nil provider")
+	}
+	if !contains(err.Error(), "returned nil provider") {
+		t.Fatalf("New error = %v, want returned nil provider", err)
+	}
+}
+
 // --- Role constants ---
 
 func TestRoleConstants(t *testing.T) {


### PR DESCRIPTION
Summary
- Harden constructor and runtime boundaries against Go typed nil interface values.
- Prevent auto-plan classifier, sinks, gates, hooks, jobs, and provider factory outputs from turning nil pointers into later nil receiver panics.
- Add regression coverage for typed nil classifier, sink, provider, gate, hooks, and shared nil detection behavior.

Root Cause
- Go interfaces can hold a concrete nil pointer and still compare non-nil.
- The desktop crash was triggered when a nil *ProviderAutoPlanClassifier was assigned to an interface field, passed a non-nil interface check, and was later invoked through NeedsPlan.
- Similar long-lived interface boundaries existed for event sinks, agent gates/hooks, job manager sinks, and provider factory outputs.

Technical Approach
- Added an internal nilutil.IsNil helper that detects both nil interfaces and interfaces wrapping typed nil values.
- Normalized optional interface inputs at constructor/update boundaries before storing them for later calls.
- Made ProviderAutoPlanClassifier return a recoverable error when uninitialized, allowing existing heuristic fallback behavior instead of crashing.
- Rejected provider factories that return nil or typed nil providers so invalid provider setup fails early.

Focused Optimization Points
- Kept the fix at internal boundary normalization points instead of adding broad defensive checks through the call graph.
- Preserved provider-visible prompts, tool schemas, and message serialization to avoid prompt-cache churn.
- Added focused regression tests for the exact typed nil failure mode and adjacent interface boundaries.

Verification
- go test ./internal/nilutil ./internal/event ./internal/jobs ./internal/provider ./internal/control ./internal/agent ./internal/boot
- go test ./...
