### PR TITLE
feat(desktop): make approval modal draggable

### DIFF
--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState, type PointerEvent } from "react";
 import { useT } from "../lib/i18n";
 import type { WireApproval } from "../lib/types";
 
@@ -9,14 +10,56 @@ export function ApprovalModal({
   onAnswer: (allow: boolean, session: boolean) => void;
 }) {
   const t = useT();
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [dragging, setDragging] = useState(false);
+  const drag = useRef<{ x: number; y: number; ox: number; oy: number } | null>(null);
+
+  useEffect(() => {
+    setOffset({ x: 0, y: 0 });
+  }, [approval.id]);
+
+  const startDrag = (event: PointerEvent<HTMLDivElement>) => {
+    if (event.button !== 0) return;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    drag.current = { x: event.clientX, y: event.clientY, ox: offset.x, oy: offset.y };
+    setDragging(true);
+  };
+
+  const moveDrag = (event: PointerEvent<HTMLDivElement>) => {
+    if (!drag.current) return;
+    setOffset({
+      x: drag.current.ox + event.clientX - drag.current.x,
+      y: drag.current.oy + event.clientY - drag.current.y,
+    });
+  };
+
+  const stopDrag = (event: PointerEvent<HTMLDivElement>) => {
+    if (!drag.current) return;
+    drag.current = null;
+    setDragging(false);
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const modalStyle = { transform: `translate(${offset.x}px, ${offset.y}px)` };
+  const dragHandleProps = {
+    onPointerDown: startDrag,
+    onPointerMove: moveDrag,
+    onPointerUp: stopDrag,
+    onPointerCancel: stopDrag,
+  };
+
   // A plan approval is special: the controller proposes it when a plan-mode turn
   // ends with a proposal. The plan itself is already shown above as the assistant's
   // reply, so this is just the gate — start coding vs keep planning.
   if (approval.tool === "exit_plan_mode") {
     return (
       <div className="modal-backdrop">
-        <div className="modal modal--plan">
-          <div className="modal__title">{t("approval.planTitle")}</div>
+        <div className={`modal modal--plan${dragging ? " modal--dragging" : ""}`} style={modalStyle}>
+          <div className="modal__title modal__drag-handle" {...dragHandleProps}>
+            {t("approval.planTitle")}
+          </div>
           <div className="modal__plannote">{t("approval.planNote")}</div>
           <div className="modal__actions">
             <button className="btn" onClick={() => onAnswer(false, false)}>
@@ -33,8 +76,10 @@ export function ApprovalModal({
 
   return (
     <div className="modal-backdrop">
-      <div className="modal">
-        <div className="modal__title">{t("approval.toolTitle")}</div>
+      <div className={`modal${dragging ? " modal--dragging" : ""}`} style={modalStyle}>
+        <div className="modal__title modal__drag-handle" {...dragHandleProps}>
+          {t("approval.toolTitle")}
+        </div>
         <div className="modal__tool">
           <span className="tool__name">{approval.tool}</span>
         </div>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1873,10 +1873,18 @@ body {
   border-radius: 12px;
   padding: 18px;
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+  --wails-draggable: no-drag;
+}
+.modal--dragging {
+  user-select: none;
 }
 .modal__title {
   font-weight: 600;
   margin-bottom: 12px;
+}
+.modal__drag-handle {
+  cursor: move;
+  touch-action: none;
 }
 .modal__tool {
   margin-bottom: 8px;


### PR DESCRIPTION
## Summary

  Fixes #2605.

  This PR makes the desktop approval modal draggable by its title area, so users can move the plan approval dialog away when it covers the proposed plan content.

  Changes:
  - Add pointer-based drag handling to the approval modal.
  - Support dragging both plan approval and normal tool approval modals.
  - Reset the modal position when a new approval request appears.
  - Mark the modal as `no-drag` for Wails window dragging to avoid conflicts.

  ## Tests

  - `npm run typecheck`
  - `npm run build`