### PR TITLE
fix(control): surface errors from /branch and /switch slash commands

### DIFF
--- a/internal/control/branches_test.go
+++ b/internal/control/branches_test.go
@@ -97,6 +97,65 @@ func TestParseBranchTarget(t *testing.T) {
 	}
 }
 
+func TestSubmitSwitchEmitsErrorNotice(t *testing.T) {
+	var notices []string
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{
+		Executor: exec,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e.Text)
+			}
+		}),
+	})
+
+	c.Submit("/switch")
+	if len(notices) == 0 {
+		t.Fatal("/switch with empty ref should emit an error notice")
+	}
+	if !strings.Contains(notices[len(notices)-1], "usage") {
+		t.Fatalf("notice = %q, want usage hint", notices[len(notices)-1])
+	}
+
+	notices = notices[:0]
+	c.Submit("/switch nonexistent")
+	if len(notices) == 0 {
+		t.Fatal("/switch with unknown ref should emit an error notice")
+	}
+}
+
+func TestSubmitBranchEmitsErrorNoticeWhileRunning(t *testing.T) {
+	var notices []string
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{
+		Executor:   exec,
+		SessionDir: t.TempDir(),
+		Label:      "test",
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e.Text)
+			}
+		}),
+	})
+	c.SetSessionPath(agent.NewSessionPath(c.sessionDir, "test"))
+
+	c.mu.Lock()
+	c.running = true
+	c.mu.Unlock()
+
+	c.Submit("/branch experiment")
+	if len(notices) == 0 {
+		t.Fatal("/branch while running should emit an error notice")
+	}
+	if !strings.Contains(notices[len(notices)-1], "cannot branch") {
+		t.Fatalf("notice = %q, want 'cannot branch' error", notices[len(notices)-1])
+	}
+}
+
 func TestFormatBranchTreeMarksCurrent(t *testing.T) {
 	branches := []agent.BranchInfo{
 		{BranchMeta: agent.BranchMeta{ID: "root"}, Preview: "root", Turns: 1},

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -463,14 +463,20 @@ func (c *Controller) Submit(input string) {
 			if turn, name, fromTurn, err := ParseBranchTarget(args); err != nil {
 				c.notice(err.Error())
 			} else if fromTurn {
-				_, _ = c.ForkNamed(turn-1, name)
+				if _, err := c.ForkNamed(turn-1, name); err != nil {
+					c.notice(err.Error())
+				}
 			} else {
-				_, _ = c.Branch(name)
+				if _, err := c.Branch(name); err != nil {
+					c.notice(err.Error())
+				}
 			}
 			return
 		case "/switch":
 			ref := strings.TrimSpace(strings.TrimPrefix(trimmed, fields[0]))
-			_, _ = c.SwitchBranch(ref)
+			if _, err := c.SwitchBranch(ref); err != nil {
+				c.notice(err.Error())
+			}
 			return
 		}
 		if c.managementNotice(trimmed) {
@@ -781,7 +787,9 @@ func (c *Controller) ForkNamed(turn int, name string) (string, error) {
 
 	// Persist the current conversation first so the branch point survives, then
 	// seed a fresh session with the messages up to the fork and switch to it.
-	_ = c.Snapshot()
+	if err := c.Snapshot(); err != nil {
+		slog.Warn("controller: pre-fork snapshot", "err", err)
+	}
 	parentPath := c.SessionPath()
 	parentID := agent.BranchID(parentPath)
 	src := c.executor.Session().Snapshot()
@@ -985,7 +993,9 @@ func (c *Controller) summarizeAt(ctx context.Context, turn int, from bool) error
 	c.mu.Lock()
 	c.cpBound = map[int]int{}
 	c.mu.Unlock()
-	_ = c.Snapshot()
+	if err := c.Snapshot(); err != nil {
+		slog.Warn("controller: post-summarize snapshot", "err", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Closes #2609

## Summary

`/branch` and `/switch` silently discarded errors from `ForkNamed`, `Branch`, and `SwitchBranch` via `_, _ =`. Users received no feedback when these operations failed.

## Changes

- **`internal/control/controller.go`**
  - `/branch`: check `ForkNamed`/`Branch` errors and emit `c.notice(err.Error())`, matching the `/compact` pattern
  - `/switch`: check `SwitchBranch` errors and emit `c.notice(err.Error())`
  - `ForkNamed`: log `Snapshot()` failure via `slog.Warn` instead of `_ = c.Snapshot()`
  - `summarizeAt`: log `Snapshot()` failure via `slog.Warn` instead of `_ = c.Snapshot()`

- **`internal/control/branches_test.go`**
  - `TestSubmitSwitchEmitsErrorNotice`: verifies `/switch` with empty and invalid ref emits error notices
  - `TestSubmitBranchEmitsErrorNoticeWhileRunning`: verifies `/branch` while a turn is running emits an error notice

## Verification

- `go vet ./internal/control/` — clean
- `go test ./internal/control/ -count=1` — all pass
- `gofmt` — clean