### PR TITLE
fix(boot): detach codegraph background install from the Build context

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -155,7 +155,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			notify := func(msg string) { sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg}) }
 			notify("codegraph: fetching code-intelligence runtime in the background (one-time) — symbol-graph tools available next session")
 			go func() {
-				if _, err := codegraph.Install(ctx, nil); err != nil {
+				if _, err := codegraph.Install(context.WithoutCancel(ctx), nil); err != nil {
 					notify("codegraph: install failed (" + err.Error() + ") — using grep/glob; retries next session")
 				} else {
 					notify("codegraph: installed — symbol-graph tools available next session")

--- a/internal/codegraph/install_test.go
+++ b/internal/codegraph/install_test.go
@@ -5,11 +5,16 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestAssetNameForCurrentPlatform(t *testing.T) {
@@ -129,5 +134,65 @@ func TestInstallReturnsCachedWithoutNetwork(t *testing.T) {
 	// Resolve should also find it (no override, cache wins).
 	if p, ok := Resolve(""); !ok || p != launcher {
 		t.Fatalf("Resolve = %q, %v; want %q", p, ok, launcher)
+	}
+}
+
+func TestHTTPGetDetachedCtxSurvivesParentCancel(t *testing.T) {
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		select {
+		case <-time.After(300 * time.Millisecond):
+		case <-r.Context().Done():
+		}
+		w.Write([]byte("payload"))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var got []byte
+	var gotErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		got, gotErr = httpGet(context.WithoutCancel(ctx), srv.URL)
+	}()
+
+	<-started
+	cancel()
+	wg.Wait()
+
+	if gotErr != nil {
+		t.Fatalf("detached download aborted after parent cancel: %v", gotErr)
+	}
+	if string(got) != "payload" {
+		t.Fatalf("got %q, want payload", got)
+	}
+}
+
+func TestHTTPGetPlainCtxAbortsOnParentCancel(t *testing.T) {
+	started := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(started)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	var gotErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, gotErr = httpGet(ctx, srv.URL)
+	}()
+
+	<-started
+	cancel()
+	wg.Wait()
+
+	if !errors.Is(gotErr, context.Canceled) {
+		t.Fatalf("plain ctx should abort on parent cancel, got %v", gotErr)
 	}
 }


### PR DESCRIPTION
Closes #2611

## Summary

The background goroutine running `codegraph.Install` captures `Build`'s `ctx`, which is typically cancelled once `Build` returns. This causes the install to fail with a misleading "context canceled" error — the one-time fetch is valid but gets killed prematurely.

## Fix

One-line change: `ctx` → `context.WithoutCancel(ctx)`, the standard Go 1.21+ pattern for goroutines that should outlive the caller's context lifetime.

```diff
- if _, err := codegraph.Install(ctx, nil); err != nil {
+ if _, err := codegraph.Install(context.WithoutCancel(ctx), nil); err != nil {
```

## Verification

- `go vet ./internal/boot/` — clean
- `go test ./internal/boot/ -count=1` — all pass
- `gofmt` — clean