### PR TITLE
fix: MiMo reasoning_content 不需要回传 — 实测验证

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -321,8 +321,8 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 		// Keep reasoning_content on the assistant turn for display and session
 		// archive. It is NOT re-uploaded to the API: the openai provider drops it
-		// when building the request, since DeepSeek bills re-sent reasoning as
-		// ordinary prompt input (~500 tok/turn) for no cache or coherence gain.
+		// when building the request, since re-sent reasoning is billable prompt
+		// input for no cache or coherence gain.
 		a.session.Add(provider.Message{
 			Role:               provider.RoleAssistant,
 			Content:            text,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -335,8 +335,8 @@ func Default() *Config {
 		Providers: []ProviderEntry{
 			{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
 			{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
-			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://api.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000},
-			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://api.xiaomimimo.com/v1", Model: "mimo-v2-flash", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 65_536},
+			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
+			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
 		},
 	}
 }

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -63,7 +63,14 @@ func RenderTOML(c *Config) string {
 		fmt.Fprintf(&b, "name        = %q\n", p.Name)
 		fmt.Fprintf(&b, "kind        = %q\n", p.Kind)
 		fmt.Fprintf(&b, "base_url    = %q\n", p.BaseURL)
-		fmt.Fprintf(&b, "model       = %q\n", p.Model)
+		if len(p.Models) > 0 {
+			fmt.Fprintf(&b, "models      = %s\n", renderStringArray(p.Models))
+			if p.Default != "" {
+				fmt.Fprintf(&b, "default     = %q\n", p.Default)
+			}
+		} else if p.Model != "" {
+			fmt.Fprintf(&b, "model       = %q\n", p.Model)
+		}
 		fmt.Fprintf(&b, "api_key_env = %q\n", p.APIKeyEnv)
 		if p.BalanceURL != "" {
 			fmt.Fprintf(&b, "balance_url = %q   # optional; wallet-balance endpoint shown in the status bar\n", p.BalanceURL)

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -38,12 +38,13 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		name = "openai"
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
+	base := strings.TrimRight(cfg.BaseURL, "/")
 	effort, _ := cfg.Extra["effort"].(string)
 	return &client{
 		name:    name,
 		apiKey:  cfg.APIKey,
 		keyEnv:  keyEnv,
-		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
+		baseURL: base,
 		model:   cfg.Model,
 		effort:  effort,
 		http: &http.Client{
@@ -176,10 +177,11 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 	msgs := make([]chatMessage, len(src))
 	for i, m := range src {
 		// reasoning_content is deliberately NOT sent back: it's a response-only
-		// field. DeepSeek accepts it but counts it as ordinary prompt input
-		// (measured ~500 extra tokens per turn on a reasoner chain), and the
-		// OpenAI-compatible convention is not to echo it. The session still keeps
-		// it (for display/archive); we just don't pay to re-upload it every turn.
+		// field. DeepSeek counts re-sent reasoning as billable prompt input
+		// (measured ~500 extra tokens per turn on a reasoner chain); MiMo accepts
+		// it but does not require it (verified empirically: multi-turn tool-call
+		// sessions work fine without it, saving ~18 tokens/turn). The session
+		// still keeps it (for display/archive); we just don't pay to re-upload it.
 		cm := chatMessage{
 			Role:       string(m.Role),
 			Content:    m.Content,
@@ -386,7 +388,7 @@ type chatMessage struct {
 	ToolCallID string         `json:"tool_call_id,omitempty"`
 	Name       string         `json:"name,omitempty"`
 	// no reasoning_content field: it is a response-only signal and is never sent
-	// back upstream (see buildRequest) — re-uploading it is paid prompt input.
+	// back upstream — re-uploading it is paid prompt input.
 }
 
 type chatTool struct {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -38,13 +38,12 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		name = "openai"
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
-	base := strings.TrimRight(cfg.BaseURL, "/")
 	effort, _ := cfg.Extra["effort"].(string)
 	return &client{
 		name:    name,
 		apiKey:  cfg.APIKey,
 		keyEnv:  keyEnv,
-		baseURL: base,
+		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
 		model:   cfg.Model,
 		effort:  effort,
 		http: &http.Client{


### PR DESCRIPTION
## 背景

MiMo 官方公告 (2026-05-28) 声称多轮工具调用会话中必须回传 \easoning_content\，否则返回 HTTP 400。

## 实测结论

在 \mimo-v2.5-pro\ (Token Plan) 上实测：

| 测试 | reasoning_content | HTTP | prompt tokens |
|------|-------------------|------|---------------|
| 不回传 | ❌ | 200 ✅ | 577 |
| 回传 | ✅ | 200 ✅ | 595 |

**MiMo 官方声称的 400 限制并未严格执行。**

## 改动文件

- \internal/provider/openai/openai.go\ — buildRequest() 不回传 reasoning_content，注释更新
- \internal/config/config.go\ — MiMo base_url 和 pricing 修正
- \internal/config/render.go\ — models[] 渲染支持
- \internal/agent/agent.go\ — 注释更新

## 关联

Closes #2594
替代 PR #2495