### PR TITLE
fix: bash tool WSL launcher probe fallback to Git Bash

### DIFF
--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -104,17 +104,20 @@ func TestResolveShellDecisionTable(t *testing.T) {
 		lookPath   func(string) (string, error)
 		candidates []string
 		exists     func(string) bool
+		probe      func(string) bool
 		wantKind   ShellKind
 	}{
-		{"bash on PATH wins", "windows", onPath("bash", "powershell"), gitBash, never, ShellBash},
-		{"no bash, git-bash on disk", "windows", onPath("powershell"), gitBash, always, ShellBash},
-		{"no bash anywhere, pwsh", "windows", onPath("pwsh", "powershell"), gitBash, never, ShellPowerShell},
-		{"no bash, only powershell", "windows", onPath("powershell"), gitBash, never, ShellPowerShell},
-		{"windows, nothing found", "windows", onPath(), nil, never, ShellBash},
-		{"linux, no bash → no PS fallback", "linux", onPath("powershell"), gitBash, always, ShellBash},
+		{"bash on PATH wins", "windows", onPath("bash", "powershell"), gitBash, never, always, ShellBash},
+		{"bash on PATH but probe fails", "windows", onPath("bash", "powershell"), gitBash, never, never, ShellPowerShell},
+		{"no bash, git-bash on disk", "windows", onPath("powershell"), gitBash, always, always, ShellBash},
+		{"git-bash on disk but probe fails", "windows", onPath("powershell"), gitBash, always, never, ShellPowerShell},
+		{"no bash anywhere, pwsh", "windows", onPath("pwsh", "powershell"), gitBash, never, never, ShellPowerShell},
+		{"no bash, only powershell", "windows", onPath("powershell"), gitBash, never, never, ShellPowerShell},
+		{"windows, nothing found", "windows", onPath(), nil, never, never, ShellBash},
+		{"linux, no bash → no PS fallback", "linux", onPath("powershell"), gitBash, always, always, ShellBash},
 	}
 	for _, c := range cases {
-		got := resolveShell(c.goos, c.lookPath, c.exists, c.candidates)
+		got := resolveShell(c.goos, c.lookPath, c.exists, c.candidates, c.probe)
 		if got.Kind != c.wantKind {
 			t.Errorf("%s: kind = %s, want %s (path=%s)", c.name, got.Kind, c.wantKind, got.Path)
 		}

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -40,20 +40,20 @@ type Shell struct {
 // is usually absent from PATH, it probes the Git-for-Windows install locations
 // and only then falls back to PowerShell so the tool still functions.
 func ResolveShell() Shell {
-	return resolveShell(runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates())
+	return resolveShell(runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates(), probeBash)
 }
 
 // resolveShell is ResolveShell with its environment lookups injected — including
 // the Git-for-Windows bash candidates, which derive from %ProgramFiles% and so
 // are empty off Windows — so the decision table is deterministically testable on
 // any host.
-func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string) Shell {
-	if p, err := lookPath("bash"); err == nil {
+func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string, probe func(string) bool) Shell {
+	if p, err := lookPath("bash"); err == nil && probe(p) {
 		return Shell{Kind: ShellBash, Path: p}
 	}
 	if goos == "windows" {
 		for _, p := range winBashCandidates {
-			if exists(p) {
+			if exists(p) && probe(p) {
 				return Shell{Kind: ShellBash, Path: p}
 			}
 		}
@@ -64,6 +64,21 @@ func resolveShell(goos string, lookPath func(string) (string, error), exists fun
 		}
 	}
 	return Shell{Kind: ShellBash, Path: "bash"}
+}
+
+// probeBash returns true iff path is a working bash that can run a trivial
+// command. Windows ships a `bash.exe` launcher stub in %SystemRoot% that opens
+// the WSL install prompt when invoked; we must skip it, otherwise the bash
+// tool hangs/errors on every call. The probe runs `true` because that exists
+// in both bash and Git Bash (not WSL's stub) and exits fast.
+func probeBash(path string) bool {
+	if runtime.GOOS != "windows" {
+		return true
+	}
+	cmd := exec.Command(path, "-c", "true")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run() == nil
 }
 
 func fileExists(p string) bool {


### PR DESCRIPTION
## 问题

Windows 上 `C:\Windows\System32\bash.exe` 是 WSL 启动器（不是真 bash）。`where bash` 能找到它但执行时卡在 Microsoft Store 的"安装 Linux 分发版"提示。上游 resolveShell() 只查 PATH 找到就用，导致 bash 工具每次都失败。

## 方案

在 resolveShell() 加 probeBash 探测函数，每个候选 bash 都先跑 `bash -c "true"` 验证：

```go
func probeBash(path string) bool {
    if runtime.GOOS != "windows" { return true }
    cmd := exec.Command(path, "-c", "true")
    return cmd.Run() == nil
}
```

## 决策流程

1. lookPath("bash") → C:\Windows\System32\bash.exe (WSL stub)
2. probeBash() → 失败
3. 跳过 WSL stub，探测 C:\Program Files\Git\bin\bash.exe (Git Bash)
4. probeBash(Git Bash) → 成功
5. 用 Git Bash

## 改动文件

- internal/sandbox/shell.go — probeBash() + resolveShell() 加 probe 参数
- internal/sandbox/sandbox_test.go — TestResolveShellDecisionTable 加 probe 字段

## 关联

Closes #2598
