### PR TITLE
Remove No Project option from workspace menu

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
-import { ArrowUp, Check, ChevronDown, FolderGit2, FolderPlus, FolderX, Search, Square, X } from "lucide-react";
+import { ArrowUp, Check, ChevronDown, FolderGit2, FolderPlus, Search, Square, X } from "lucide-react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
@@ -527,10 +527,6 @@ export function Composer({
             <button onClick={() => void chooseWorkspace()}>
               <FolderPlus size={15} />
               <span>{t("composer.addProject")}</span>
-            </button>
-            <button onClick={() => void chooseWorkspace("")}>
-              <FolderX size={15} />
-              <span>{t("composer.noProject")}</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
Summary
- Removes the “No project” action from the workspace switcher menu.
- Keeps the existing project list and “Add new project” action intact.

Root Cause
- The workspace switcher rendered an explicit action that called the folder picker with an empty path, exposing a “No project” option that should no longer be available in the UI.

Technical Approach
- Removed the menu action that selected an empty workspace path.
- Removed the now-unused FolderX icon import from the composer component.

Focused Optimization Points
- Kept the change scoped to the workspace menu rendering path.
- Avoided changing locale strings or workspace switching behavior outside the removed action.

Verification
- PATH="/Users/<developer>/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" ./node_modules/.bin/tsc --noEmit
- Verified in the local browser UI that the workspace menu still shows project entries and “Add new project”, while “No project” is no longer shown.