### PR TITLE
chore(desktop): drop orphaned composer.noProject locale string

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -121,7 +121,6 @@ export const en = {
   "composer.searchProjects": "Search projects",
   "composer.noProjectMatches": "No matching projects",
   "composer.addProject": "Add new project",
-  "composer.noProject": "No project",
   "composer.send": "Send (Enter)",
   "composer.stop": "Stop (Esc)",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -122,7 +122,6 @@ export const zh: Record<DictKey, string> = {
   "composer.searchProjects": "搜索项目",
   "composer.noProjectMatches": "没有匹配的项目",
   "composer.addProject": "添加新项目",
-  "composer.noProject": "不使用项目",
   "composer.send": "发送（Enter）",
   "composer.stop": "停止（Esc）",
 


### PR DESCRIPTION
Follow-up to #2624.

#2624 removed the "No project" workspace action but left its locale string behind. Removes the now-orphaned `composer.noProject` key from both `en` and `zh` (the still-used `composer.noProjectMatches` is a different key and is untouched).

`typecheck` passes.
