### PR TITLE
feat(desktop): dock regular tool approvals above the composer

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -659,21 +659,6 @@ export default function App() {
 
           <footer className="footer">
             {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
-            {state.approval && (
-              <ApprovalModal
-                approval={state.approval}
-                onAnswer={(allow, session) => {
-                  // Approving an exit_plan_mode plan leaves plan mode (the controller
-                  // flips the executor; mirror it here for the indicator).
-                  if (state.approval!.tool === "exit_plan_mode" && allow) setMode("normal");
-                  approve(state.approval!.id, allow, session);
-                }}
-                onRevisePlan={(text) => {
-                  setPendingPlanRevision(text);
-                  approve(state.approval!.id, false, false);
-                }}
-              />
-            )}
             <Composer
               running={state.running}
               mode={mode}
@@ -682,7 +667,7 @@ export default function App() {
               onCancel={cancel}
               onCycleMode={cycleMode}
               onPickFolder={switchFolder}
-              disabled={state.meta?.ready === false}
+              disabled={state.meta?.ready === false || state.approval != null}
             />
             <StatusBar
               meta={state.meta}
@@ -725,6 +710,22 @@ export default function App() {
           onClose={() => setWorkspacePanel(false)}
           onToggleMaximized={() => setWorkspacePanelMaximized((value) => !value)}
         />
+
+        {state.approval && (
+          <ApprovalModal
+            approval={state.approval}
+            onAnswer={(allow, session) => {
+              // Approving an exit_plan_mode plan leaves plan mode (the controller
+              // flips the executor; mirror it here for the indicator).
+              if (state.approval!.tool === "exit_plan_mode" && allow) setMode("normal");
+              approve(state.approval!.id, allow, session);
+            }}
+            onRevisePlan={(text) => {
+              setPendingPlanRevision(text);
+              approve(state.approval!.id, false, false);
+            }}
+          />
+        )}
       </div>
 
       {state.ask && (

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -16,6 +16,7 @@ export function ApprovalModal({
   const [revisionText, setRevisionText] = useState("");
   const cardRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const isPlanApproval = approval.tool === "exit_plan_mode";
 
   const choosePlanAction = (key: string) => {
     if (key === "1") onAnswer(false, false);
@@ -24,23 +25,29 @@ export function ApprovalModal({
     else if (key === "Escape") onAnswer(false, false);
   };
 
-  useEffect(() => {
-    if (approval.tool === "exit_plan_mode") cardRef.current?.focus();
-  }, [approval.tool]);
+  const chooseToolAction = (key: string) => {
+    if (key === "1" || key === "Escape") onAnswer(false, false);
+    else if (key === "2") onAnswer(true, false);
+    else if (key === "3") onAnswer(true, true);
+  };
 
   useEffect(() => {
-    if (approval.tool !== "exit_plan_mode") return;
+    cardRef.current?.focus();
+  }, [approval.id]);
+
+  useEffect(() => {
     const onKeyDown = (event: globalThis.KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
       const tag = target?.tagName.toLowerCase();
       if (tag === "input" || tag === "textarea" || target?.isContentEditable) return;
       if (event.key !== "1" && event.key !== "2" && event.key !== "3" && event.key !== "Escape") return;
       event.preventDefault();
-      choosePlanAction(event.key);
+      if (isPlanApproval) choosePlanAction(event.key);
+      else chooseToolAction(event.key);
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [approval.tool, onAnswer]);
+  }, [isPlanApproval, onAnswer]);
 
   useEffect(() => {
     if (revisionOpen) inputRef.current?.focus();
@@ -56,7 +63,7 @@ export function ApprovalModal({
   };
 
   // The plan is already shown above as the assistant's reply; this is just the gate.
-  if (approval.tool === "exit_plan_mode") {
+  if (isPlanApproval) {
     return (
       <div className="plan-approval-dock" aria-live="polite">
         <div
@@ -128,22 +135,49 @@ export function ApprovalModal({
   }
 
   return (
-    <div className="modal-backdrop">
-      <div className="modal">
-        <div className="modal__title">{t("approval.toolTitle")}</div>
-        <div className="modal__tool">
+    <div className="plan-approval-dock" aria-live="polite">
+      <div
+        ref={cardRef}
+        className="plan-approval-card"
+        role="dialog"
+        aria-modal="false"
+        aria-labelledby="tool-approval-title"
+        tabIndex={-1}
+      >
+        <div className="plan-approval-card__header">
+          <div>
+            <div id="tool-approval-title" className="plan-approval-card__title">
+              {t("approval.toolTitle")}
+            </div>
+            <div className="plan-approval-card__note">{t("approval.toolNote")}</div>
+          </div>
+        </div>
+        <div className="approval-tool">
+          <span className="approval-tool__label">{t("approval.toolLabel")}</span>
           <span className="tool__name">{approval.tool}</span>
         </div>
-        {approval.subject && <pre className="modal__subject">{approval.subject}</pre>}
-        <div className="modal__actions">
-          <button className="btn" onClick={() => onAnswer(false, false)}>
-            {t("approval.deny")}
+        {approval.subject && <pre className="approval-subject">{approval.subject}</pre>}
+        <div className="plan-approval-card__choices">
+          <button className="plan-choice" onClick={() => onAnswer(false, false)}>
+            <span className="plan-choice__key">1</span>
+            <span className="plan-choice__copy">
+              <span className="plan-choice__label">{t("approval.deny")}</span>
+              <span className="plan-choice__hint">{t("approval.denyHint")}</span>
+            </span>
           </button>
-          <button className="btn" onClick={() => onAnswer(true, false)}>
-            {t("approval.allowOnce")}
+          <button className="plan-choice plan-choice--primary" onClick={() => onAnswer(true, false)}>
+            <span className="plan-choice__key">2</span>
+            <span className="plan-choice__copy">
+              <span className="plan-choice__label">{t("approval.allowOnce")}</span>
+              <span className="plan-choice__hint">{t("approval.allowOnceHint")}</span>
+            </span>
           </button>
-          <button className="btn btn--primary" onClick={() => onAnswer(true, true)}>
-            {t("approval.allowSession")}
+          <button className="plan-choice" onClick={() => onAnswer(true, true)}>
+            <span className="plan-choice__key">3</span>
+            <span className="plan-choice__copy">
+              <span className="plan-choice__label">{t("approval.allowSession")}</span>
+              <span className="plan-choice__hint">{t("approval.allowSessionHint")}</span>
+            </span>
           </button>
         </div>
       </div>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -159,9 +159,14 @@ export const en = {
   "approval.sendRevision": "Send update",
   "approval.proceed": "Proceed",
   "approval.toolTitle": "Allow this tool call?",
+  "approval.toolNote": "Review the requested tool before letting it run.",
+  "approval.toolLabel": "Tool",
   "approval.deny": "Deny",
+  "approval.denyHint": "Do not run this tool call",
   "approval.allowOnce": "Allow once",
+  "approval.allowOnceHint": "Run this request one time",
   "approval.allowSession": "Allow for session",
+  "approval.allowSessionHint": "Remember this grant for matching requests",
 
   // ask card
   "ask.customPlaceholder": "Type your own answer…",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -160,9 +160,14 @@ export const zh: Record<DictKey, string> = {
   "approval.sendRevision": "发送修改意见",
   "approval.proceed": "继续",
   "approval.toolTitle": "允许这次工具调用吗？",
+  "approval.toolNote": "先确认模型申请的工具调用，再决定是否放行。",
+  "approval.toolLabel": "工具",
   "approval.deny": "拒绝",
+  "approval.denyHint": "不执行这次工具调用",
   "approval.allowOnce": "允许一次",
+  "approval.allowOnceHint": "只放行当前这一次请求",
   "approval.allowSession": "本会话内允许",
+  "approval.allowSessionHint": "记住这类匹配请求的授权",
 
   // 提问卡片
   "ask.customPlaceholder": "输入你自己的答案…",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1928,6 +1928,27 @@ body {
   max-width: var(--maxw);
   margin: 0 auto 10px;
 }
+.layout > .plan-approval-dock {
+  position: absolute;
+  left: calc(var(--sidebar-width) + 32px);
+  right: 32px;
+  bottom: 192px;
+  z-index: 80;
+  max-width: none;
+  margin: 0;
+  pointer-events: none;
+}
+.layout--workspace-open > .plan-approval-dock {
+  right: calc(var(--workspace-width) + 32px);
+}
+.layout--workspace-maximized > .plan-approval-dock {
+  right: 32px;
+}
+.layout > .plan-approval-dock .plan-approval-card {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  pointer-events: auto;
+}
 .plan-approval-card {
   border: 1px solid var(--border);
   border-radius: 10px;
@@ -1961,6 +1982,38 @@ body {
   display: grid;
   grid-template-columns: 1fr;
   gap: 6px;
+}
+.approval-tool {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  margin: 0 0 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: var(--bg-soft);
+  padding: 5px 8px;
+}
+.approval-tool__label {
+  flex: 0 0 auto;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.approval-subject {
+  margin: 0 0 10px;
+  padding: 9px 11px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 140px;
+  overflow: auto;
 }
 .plan-choice {
   display: grid;
@@ -4016,6 +4069,9 @@ body {
   .layout--workspace-open {
     grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   }
+  .layout--workspace-open > .plan-approval-dock {
+    right: 32px;
+  }
   .workspace-panel,
   .workspace-panel-resizer,
   .topbar__workspace-toggle {
@@ -4050,6 +4106,11 @@ body {
   }
   .footer {
     padding: 10px 16px 8px;
+  }
+  .layout > .plan-approval-dock {
+    left: 16px;
+    right: 16px;
+    bottom: 176px;
   }
   .welcome__hints {
     flex-wrap: wrap;


### PR DESCRIPTION
Incorporates #2622 by @SivanCola, with one bug fix.

## What
Extends the plan-approval dock (#2616) to regular tool approvals. Deny / Allow once / Allow for session now render as numeric-shortcut choices in the same docked card above the composer, instead of a full-screen dimmed overlay. The dock is absolutely positioned above the composer and stays correctly placed across sidebar / workspace-open / workspace-maximized states.

## Fix on top of #2622
`#2622` disabled the composer while an approval was pending via `state.approval !== null`. But `state.approval` is `undefined` (not `null`) when there is no approval, so `undefined !== null` was always `true` — the composer was permanently disabled on a normal load. Changed to `!= null` so it only disables while an approval is actually pending.

## Verification
- `typecheck` clean (this is what surfaced the bug — `npm run build` alone does not type-check).
- `npm run build` passes (only the pre-existing Vite chunk-size warning).

Closes #2622
