### PR TITLE
feat(cli): add doctor diagnostics command

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -61,6 +61,8 @@ func Run(args []string, version string) int {
 		return mcpCommand(rest)
 	case "codegraph":
 		return codegraphCommand(rest)
+	case "doctor":
+		return doctorCommand(rest, version)
 	case "version", "--version", "-v":
 		fmt.Println("reasonix", version)
 		return 0

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,31 @@
+package cli
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"reasonix/internal/doctor"
+)
+
+func doctorCommand(args []string, version string) int {
+	fs := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	jsonOut := fs.Bool("json", false, "print diagnostics as JSON")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	report := doctor.Collect(doctor.Options{Version: version})
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+		return 0
+	}
+	fmt.Print(doctor.RenderText(report))
+	return 0
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDoctorCommandPrintsJSON(t *testing.T) {
+	out := captureStdout(t, func() {
+		if rc := doctorCommand([]string{"--json"}, "test-version"); rc != 0 {
+			t.Fatalf("doctorCommand rc = %d, want 0", rc)
+		}
+	})
+
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(out), &decoded); err != nil {
+		t.Fatalf("doctor --json output is not JSON: %v\n%s", err, out)
+	}
+	if decoded["version"] != "test-version" {
+		t.Fatalf("version = %v, want test-version", decoded["version"])
+	}
+}
+
+func TestRunDispatchesDoctor(t *testing.T) {
+	out := captureStdout(t, func() {
+		if rc := Run([]string{"doctor"}, "dispatch-version"); rc != 0 {
+			t.Fatalf("Run doctor rc = %d, want 0", rc)
+		}
+	})
+	if !strings.Contains(out, "reasonix dispatch-version doctor") {
+		t.Fatalf("doctor output missing header:\n%s", out)
+	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -1,0 +1,296 @@
+// Package doctor collects local, redacted diagnostics for issue reports.
+package doctor
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/codegraph"
+	"reasonix/internal/config"
+)
+
+type Options struct {
+	Version string
+	Config  *config.Config
+}
+
+type Report struct {
+	Version    string           `json:"version"`
+	OS         string           `json:"os"`
+	Arch       string           `json:"arch"`
+	CWD        string           `json:"cwd,omitempty"`
+	Config     ConfigReport     `json:"config"`
+	Providers  []ProviderReport `json:"providers"`
+	Plugins    []PluginReport   `json:"plugins,omitempty"`
+	Codegraph  CodegraphReport  `json:"codegraph"`
+	LSP        LSPReport        `json:"lsp"`
+	Sessions   SessionsReport   `json:"sessions"`
+	Sandbox    SandboxReport    `json:"sandbox"`
+	Permission PermissionReport `json:"permission"`
+	Warnings   []string         `json:"warnings,omitempty"`
+}
+
+type ConfigReport struct {
+	SourcePath   string `json:"source_path,omitempty"`
+	UserPath     string `json:"user_path,omitempty"`
+	DefaultModel string `json:"default_model"`
+}
+
+type ProviderReport struct {
+	Name          string   `json:"name"`
+	Kind          string   `json:"kind"`
+	BaseURLHost   string   `json:"base_url_host,omitempty"`
+	Model         string   `json:"model,omitempty"`
+	Models        []string `json:"models,omitempty"`
+	APIKeyEnv     string   `json:"api_key_env,omitempty"`
+	KeyPresent    bool     `json:"key_present"`
+	IsDefault     bool     `json:"is_default"`
+	ContextWindow int      `json:"context_window,omitempty"`
+}
+
+type PluginReport struct {
+	Name      string `json:"name"`
+	Transport string `json:"transport"`
+	AutoStart bool   `json:"auto_start"`
+	Target    string `json:"target,omitempty"`
+}
+
+type CodegraphReport struct {
+	Enabled     bool   `json:"enabled"`
+	AutoInstall bool   `json:"auto_install"`
+	Version     string `json:"version"`
+	CacheDir    string `json:"cache_dir,omitempty"`
+	Resolved    bool   `json:"resolved"`
+	Path        string `json:"path,omitempty"`
+}
+
+type LSPReport struct {
+	Enabled bool `json:"enabled"`
+	Servers int  `json:"servers"`
+}
+
+type SessionsReport struct {
+	Dir   string `json:"dir,omitempty"`
+	Count int    `json:"count"`
+	Bytes int64  `json:"bytes"`
+	Error string `json:"error,omitempty"`
+}
+
+type SandboxReport struct {
+	Bash       string   `json:"bash"`
+	Network    bool     `json:"network"`
+	WriteRoots []string `json:"write_roots,omitempty"`
+}
+
+type PermissionReport struct {
+	Mode       string `json:"mode"`
+	AllowRules int    `json:"allow_rules"`
+	AskRules   int    `json:"ask_rules"`
+	DenyRules  int    `json:"deny_rules"`
+}
+
+func Collect(opts Options) Report {
+	cfg := opts.Config
+	var warnings []string
+	if cfg == nil {
+		var err error
+		cfg, err = config.Load()
+		if err != nil {
+			warnings = append(warnings, err.Error())
+			cfg = config.Default()
+		}
+	}
+	cwd, _ := os.Getwd()
+	report := Report{
+		Version: opts.Version,
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+		CWD:     cwd,
+		Config: ConfigReport{
+			SourcePath:   config.SourcePath(),
+			UserPath:     config.UserConfigPath(),
+			DefaultModel: cfg.DefaultModel,
+		},
+		Codegraph: CodegraphReport{
+			Enabled:     cfg.Codegraph.Enabled,
+			AutoInstall: cfg.Codegraph.AutoInstall,
+			Version:     codegraph.Version,
+			CacheDir:    codegraph.CacheDir(),
+		},
+		LSP: LSPReport{
+			Enabled: cfg.LSP.Enabled,
+			Servers: len(cfg.LSP.Servers),
+		},
+		Sessions: collectSessions(config.SessionDir()),
+		Sandbox: SandboxReport{
+			Bash:       cfg.BashMode(),
+			Network:    cfg.Sandbox.Network,
+			WriteRoots: cfg.WriteRoots(),
+		},
+		Permission: PermissionReport{
+			Mode:       cfg.Permissions.Mode,
+			AllowRules: len(cfg.Permissions.Allow),
+			AskRules:   len(cfg.Permissions.Ask),
+			DenyRules:  len(cfg.Permissions.Deny),
+		},
+		Warnings: warnings,
+	}
+	if p, ok := codegraph.Resolve(cfg.Codegraph.Path); ok {
+		report.Codegraph.Resolved = true
+		report.Codegraph.Path = p
+	}
+	for i := range cfg.Providers {
+		p := cfg.Providers[i]
+		models := p.ModelList()
+		report.Providers = append(report.Providers, ProviderReport{
+			Name:          p.Name,
+			Kind:          p.Kind,
+			BaseURLHost:   hostOnly(p.BaseURL),
+			Model:         p.Model,
+			Models:        models,
+			APIKeyEnv:     p.APIKeyEnv,
+			KeyPresent:    p.Configured(),
+			IsDefault:     p.Name == cfg.DefaultModel,
+			ContextWindow: p.ContextWindow,
+		})
+	}
+	for _, p := range cfg.Plugins {
+		transport := p.Type
+		if transport == "" {
+			transport = "stdio"
+		}
+		report.Plugins = append(report.Plugins, PluginReport{
+			Name:      p.Name,
+			Transport: transport,
+			AutoStart: p.ShouldAutoStart(),
+			Target:    pluginTarget(p),
+		})
+	}
+	return report
+}
+
+func RenderText(r Report) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "reasonix %s doctor\n", r.Version)
+	fmt.Fprintf(&b, "  system       %s/%s\n", r.OS, r.Arch)
+	if r.CWD != "" {
+		fmt.Fprintf(&b, "  cwd          %s\n", r.CWD)
+	}
+	fmt.Fprintf(&b, "  config       %s\n", valueOr(r.Config.SourcePath, "not found - using defaults"))
+	fmt.Fprintf(&b, "  user config  %s\n", valueOr(r.Config.UserPath, "unavailable"))
+	fmt.Fprintf(&b, "  model        %s\n", valueOr(r.Config.DefaultModel, "(none)"))
+
+	fmt.Fprintf(&b, "\nproviders\n")
+	for _, p := range r.Providers {
+		key := "missing"
+		if p.KeyPresent {
+			key = "present"
+		}
+		marker := ""
+		if p.IsDefault {
+			marker = " default"
+		}
+		fmt.Fprintf(&b, "  %-16s %-8s %-24s key:%s%s\n", p.Name, p.Kind, valueOr(p.BaseURLHost, "(no host)"), key, marker)
+	}
+
+	fmt.Fprintf(&b, "\nplugins\n")
+	if len(r.Plugins) == 0 {
+		fmt.Fprintf(&b, "  none configured\n")
+	} else {
+		for _, p := range r.Plugins {
+			fmt.Fprintf(&b, "  %-16s %-8s %s\n", p.Name, p.Transport, valueOr(p.Target, "(redacted)"))
+		}
+	}
+
+	resolved := "missing"
+	if r.Codegraph.Resolved {
+		resolved = "resolved"
+	}
+	fmt.Fprintf(&b, "\ncodegraph\n")
+	fmt.Fprintf(&b, "  enabled      %v\n", r.Codegraph.Enabled)
+	fmt.Fprintf(&b, "  auto_install %v\n", r.Codegraph.AutoInstall)
+	fmt.Fprintf(&b, "  version      %s\n", r.Codegraph.Version)
+	fmt.Fprintf(&b, "  resolved     %s\n", resolved)
+
+	fmt.Fprintf(&b, "\nlsp\n")
+	fmt.Fprintf(&b, "  enabled      %v\n", r.LSP.Enabled)
+	fmt.Fprintf(&b, "  servers      %d configured overrides\n", r.LSP.Servers)
+
+	fmt.Fprintf(&b, "\nsessions\n")
+	fmt.Fprintf(&b, "  dir          %s\n", valueOr(r.Sessions.Dir, "unavailable"))
+	fmt.Fprintf(&b, "  saved        %d\n", r.Sessions.Count)
+	fmt.Fprintf(&b, "  bytes        %d\n", r.Sessions.Bytes)
+	if r.Sessions.Error != "" {
+		fmt.Fprintf(&b, "  warning      %s\n", r.Sessions.Error)
+	}
+
+	fmt.Fprintf(&b, "\nsandbox\n")
+	fmt.Fprintf(&b, "  bash         %s\n", r.Sandbox.Bash)
+	fmt.Fprintf(&b, "  network      %v\n", r.Sandbox.Network)
+	fmt.Fprintf(&b, "  write_roots  %s\n", strings.Join(r.Sandbox.WriteRoots, ", "))
+
+	fmt.Fprintf(&b, "\npermissions\n")
+	fmt.Fprintf(&b, "  mode         %s\n", valueOr(r.Permission.Mode, "ask"))
+	fmt.Fprintf(&b, "  rules        allow:%d ask:%d deny:%d\n", r.Permission.AllowRules, r.Permission.AskRules, r.Permission.DenyRules)
+	for _, w := range r.Warnings {
+		fmt.Fprintf(&b, "\nwarning: %s\n", w)
+	}
+	return b.String()
+}
+
+func collectSessions(dir string) SessionsReport {
+	r := SessionsReport{Dir: dir}
+	if dir == "" {
+		return r
+	}
+	sessions, err := agent.ListSessions(dir)
+	if err != nil {
+		r.Error = err.Error()
+	}
+	r.Count = len(sessions)
+	if err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Ext(path) != ".jsonl" {
+			return nil
+		}
+		if info, statErr := d.Info(); statErr == nil {
+			r.Bytes += info.Size()
+		}
+		return nil
+	}); err != nil && !os.IsNotExist(err) {
+		r.Error = err.Error()
+	}
+	return r
+}
+
+func pluginTarget(p config.PluginEntry) string {
+	if p.URL != "" {
+		return hostOnly(p.URL)
+	}
+	if p.Command == "" {
+		return ""
+	}
+	return filepath.Base(p.Command)
+}
+
+func hostOnly(raw string) string {
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" {
+		return ""
+	}
+	if port := u.Port(); port != "" {
+		return u.Hostname() + ":" + port
+	}
+	return u.Hostname()
+}
+
+func valueOr(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -1,0 +1,70 @@
+package doctor
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+func TestCollectReportRedactsSecrets(t *testing.T) {
+	t.Setenv("REASONIX_TEST_SECRET", "sk-live-secret")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "custom"
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "custom",
+		Kind:      "openai",
+		BaseURL:   "https://api.example.com/v1?token=secret-query",
+		Model:     "model-a",
+		APIKeyEnv: "REASONIX_TEST_SECRET",
+	}}
+	cfg.Plugins = []config.PluginEntry{{
+		Name:    "remote",
+		Type:    "http",
+		URL:     "https://mcp.example.com/path?api_key=secret-query",
+		Headers: map[string]string{"Authorization": "Bearer sk-live-secret"},
+	}}
+
+	report := Collect(Options{Version: "test-version", Config: cfg})
+	text := RenderText(report)
+	raw, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	combined := text + "\n" + string(raw)
+
+	for _, secret := range []string{"sk-live-secret", "secret-query", "Authorization"} {
+		if strings.Contains(combined, secret) {
+			t.Fatalf("doctor report leaked %q:\n%s", secret, combined)
+		}
+	}
+	if !strings.Contains(combined, "api.example.com") || !strings.Contains(combined, "mcp.example.com") {
+		t.Fatalf("doctor report should keep useful host diagnostics:\n%s", combined)
+	}
+}
+
+func TestCollectReportDoesNotRequireAPIKey(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "")
+
+	cfg := config.Default()
+	report := Collect(Options{Version: "1.2.3", Config: cfg})
+	text := RenderText(report)
+
+	if report.Version != "1.2.3" {
+		t.Fatalf("version = %q, want 1.2.3", report.Version)
+	}
+	if len(report.Providers) == 0 {
+		t.Fatal("expected built-in providers in report")
+	}
+	if report.Providers[0].KeyPresent {
+		t.Fatal("provider key should be reported missing when env is empty")
+	}
+	if !strings.Contains(text, "reasonix 1.2.3 doctor") {
+		t.Fatalf("text report missing header:\n%s", text)
+	}
+	if !strings.Contains(text, "missing") {
+		t.Fatalf("text report should mention missing key state:\n%s", text)
+	}
+}

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -147,6 +147,7 @@ Usage:
   reasonix serve [--model NAME] [--addr HOST:PORT]      serve the session over HTTP+SSE (browser client at /)
   reasonix setup [path]                                 interactive config wizard; writes reasonix.toml (+ .env)
   reasonix mcp <add|remove|list>                        manage MCP servers in reasonix.toml
+  reasonix doctor [--json]                              print redacted local diagnostics
   reasonix version
   reasonix help
 

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -148,6 +148,7 @@ var Chinese = Messages{
   reasonix serve [--model NAME] [--addr HOST:PORT]      通过 HTTP+SSE 提供会话（浏览器客户端在 /）
   reasonix setup [path]                                 交互式配置向导；生成 reasonix.toml（及 .env）
   reasonix mcp <add|remove|list>                        管理 reasonix.toml 里的 MCP 服务器
+  reasonix doctor [--json]                              输出脱敏的本地诊断信息
   reasonix version
   reasonix help
 


### PR DESCRIPTION
## Summary

Adds a top-level `reasonix doctor` command for redacted local diagnostics, plus `--json` output for machine-readable reports.

The report includes local environment/configuration context such as providers, key presence, MCP/plugin entries, CodeGraph, LSP, session storage, sandbox, and permission settings without exposing secrets.

## Testing
```bash
go test ./internal/doctor ./internal/cli ./internal/i18n
go build -o /tmp/reasonix-doctor-verify ./cmd/reasonix
/tmp/reasonix-doctor-verify doctor --json
```

Also ran go test ./...; the only failure is the pre-existing Linux internal/sandbox/bwrap expectation mismatch, unrelated to this change.

<img width="400" height="500" alt="doctor" src="https://github.com/user-attachments/assets/eceaf604-6f9f-465b-a24a-aca533ba74d3" />

## Related
Closes #2630
