### PR TITLE
feat(desktop): refine memory drawer management

### DIFF
--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -1,7 +1,31 @@
-import { useRef, useState, type ReactNode } from "react";
+import { ChevronDown, ChevronRight, Search, Trash2 } from "lucide-react";
+import { useMemo, useRef, useState, type ReactNode } from "react";
 import { useT } from "../lib/i18n";
-import type { MemoryView } from "../lib/types";
+import type { MemoryFact, MemoryView } from "../lib/types";
 import { ResizableDrawer } from "./ResizableDrawer";
+
+type LinkInfo = {
+  name: string;
+  exists: boolean;
+};
+
+function displayTitle(fact: MemoryFact): string {
+  return fact.title || fact.name.replaceAll("-", " ");
+}
+
+function uniqueLinks(body: string, names: Set<string>): LinkInfo[] {
+  const links: LinkInfo[] = [];
+  const seen = new Set<string>();
+  const re = /\[\[([^\]]+)\]\]/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(body)) !== null) {
+    const name = match[1].trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    links.push({ name, exists: names.has(name) });
+  }
+  return links;
+}
 
 // MemoryPanel is the desktop memory manager: a right-side drawer over the loaded
 // REASONIX.md hierarchy and saved auto-memories. Unlike Claude Code's /memory
@@ -29,10 +53,31 @@ export function MemoryPanel({
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
   const [highlight, setHighlight] = useState<string | null>(null);
-  const factRefs = useRef<Record<string, HTMLDivElement | null>>({});
+  const [query, setQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [confirmForget, setConfirmForget] = useState<string | null>(null);
+  const factRefs = useRef<Record<string, HTMLElement | null>>({});
 
   const facts = view?.facts ?? [];
-  const factNames = new Set(facts.map((f) => f.name));
+  const factNames = useMemo(() => new Set(facts.map((f) => f.name)), [facts]);
+  const factTypes = useMemo(
+    () => Array.from(new Set(facts.map((f) => f.type).filter(Boolean))).sort(),
+    [facts],
+  );
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredFacts = useMemo(
+    () =>
+      facts.filter((f) => {
+        if (typeFilter !== "all" && f.type !== typeFilter) return false;
+        if (!normalizedQuery) return true;
+        return [displayTitle(f), f.name, f.description, f.type, f.body]
+          .join(" ")
+          .toLowerCase()
+          .includes(normalizedQuery);
+      }),
+    [facts, normalizedQuery, typeFilter],
+  );
 
   // jumpTo scrolls a [[name]] target into view and flashes it, so cross-links
   // between saved memories are navigable inside the panel.
@@ -77,10 +122,12 @@ export function MemoryPanel({
   };
 
   const forgetFact = async (name: string) => {
-    if (busy || !window.confirm(t("memory.confirmForget", { name }))) return;
+    if (busy) return;
     setBusy(true);
     try {
       await onForget(name);
+      if (expanded === name) setExpanded(null);
+      setConfirmForget(null);
     } finally {
       setBusy(false);
     }
@@ -122,7 +169,14 @@ export function MemoryPanel({
   return (
     <ResizableDrawer onClose={onClose}>
         <header className="drawer__head">
-          <div className="drawer__title">{t("memory.title")}</div>
+          <div>
+            <div className="drawer__title">{t("memory.title")}</div>
+            {view?.available && (
+              <div className="drawer__summary">
+                {t("memory.summary", { facts: facts.length, docs: view.docs.length })}
+              </div>
+            )}
+          </div>
           <button className="chip" onClick={onClose} title={t("common.close")}>
             ✕
           </button>
@@ -132,6 +186,177 @@ export function MemoryPanel({
           <div className="empty">{t("memory.unavailable")}</div>
         ) : (
           <div className="drawer__body">
+            {/* Saved auto-memories — the model owns these via remember/forget;
+                the panel can delete one and follow [[name]] cross-links. */}
+            <section className="mem-section">
+              <div className="mem-section__row">
+                <div>
+                  <div className="mem-section__title">{t("memory.savedMemories")}</div>
+                  <div className="mem-note">{t("memory.fallibleNote")}</div>
+                </div>
+                <span className="mem-count">{facts.length}</span>
+              </div>
+              <div className="mem-toolbar">
+                <label className="mem-search">
+                  <Search size={14} />
+                  <input
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder={t("memory.searchPlaceholder")}
+                  />
+                </label>
+                <div className="mem-filter" role="tablist" aria-label={t("memory.typeFilter")}>
+                  <button
+                    className={`mem-filter__item${typeFilter === "all" ? " mem-filter__item--on" : ""}`}
+                    onClick={() => setTypeFilter("all")}
+                    type="button"
+                  >
+                    {t("memory.allTypes")}
+                  </button>
+                  {factTypes.map((type) => (
+                    <button
+                      className={`mem-filter__item${typeFilter === type ? " mem-filter__item--on" : ""}`}
+                      onClick={() => setTypeFilter(type)}
+                      type="button"
+                      key={type}
+                    >
+                      {type}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {facts.length === 0 ? (
+                <div className="mem-empty">{t("memory.noFacts")}</div>
+              ) : filteredFacts.length === 0 ? (
+                <div className="mem-empty">
+                  {t("memory.noMatches")}
+                  <button
+                    className="mem-empty__action"
+                    onClick={() => {
+                      setQuery("");
+                      setTypeFilter("all");
+                    }}
+                    type="button"
+                  >
+                    {t("memory.clearFilters")}
+                  </button>
+                </div>
+              ) : (
+                <div className="mem-facts">
+                  {filteredFacts.map((f) => {
+                    const isOpen = expanded === f.name;
+                    const links = uniqueLinks(f.body, factNames);
+                    const missing = links.filter((link) => !link.exists);
+                    return (
+                      <article
+                        className={`mem-fact${highlight === f.name ? " mem-fact--hl" : ""}`}
+                        key={f.name}
+                        ref={(el) => {
+                          factRefs.current[f.name] = el;
+                        }}
+                      >
+                        <button
+                          className="mem-fact__summary"
+                          onClick={() => {
+                            setExpanded(isOpen ? null : f.name);
+                            setConfirmForget(null);
+                          }}
+                          type="button"
+                        >
+                          {isOpen ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+                          <span className="mem-fact__main">
+                            <span className="mem-fact__title">{displayTitle(f)}</span>
+                            <span className="mem-fact__meta">
+                              {f.name} · {f.type}
+                            </span>
+                            <span className="mem-fact__desc">{f.description}</span>
+                          </span>
+                        </button>
+                        {links.length > 0 && (
+                          <div className="mem-fact__links" aria-label={t("memory.links")}>
+                            {links.map((link) =>
+                              link.exists ? (
+                                <button
+                                  className="mem-link-chip"
+                                  key={link.name}
+                                  onClick={() => jumpTo(link.name)}
+                                  type="button"
+                                >
+                                  [[{link.name}]]
+                                </button>
+                              ) : (
+                                <span
+                                  className="mem-link-chip mem-link-chip--dead"
+                                  key={link.name}
+                                  title={t("memory.deadLink", { name: link.name })}
+                                >
+                                  [[{link.name}]]
+                                </span>
+                              ),
+                            )}
+                          </div>
+                        )}
+                        {isOpen && (
+                          <div className="mem-fact__detail">
+                            {f.body ? (
+                              <div className="mem-fact__body">{renderWithLinks(f.body)}</div>
+                            ) : (
+                              <div className="mem-empty">{t("memory.noBody")}</div>
+                            )}
+                            {missing.length > 0 && (
+                              <div className="mem-deadline">
+                                {t("memory.missingLinks", { n: missing.length })}
+                              </div>
+                            )}
+                            <div className="mem-fact__actions">
+                              <span className="mem-hint mem-hint--inline">
+                                {t("memory.appliesNow")}
+                              </span>
+                              {confirmForget === f.name ? (
+                                <div className="mem-confirm">
+                                  <button
+                                    className="btn btn--small"
+                                    onClick={() => setConfirmForget(null)}
+                                    disabled={busy}
+                                    type="button"
+                                  >
+                                    {t("common.cancel")}
+                                  </button>
+                                  <button
+                                    className="btn btn--small mem-danger"
+                                    onClick={() => void forgetFact(f.name)}
+                                    disabled={busy}
+                                    type="button"
+                                  >
+                                    {t("memory.confirmForget")}
+                                  </button>
+                                </div>
+                              ) : (
+                                <button
+                                  className="btn btn--small mem-fact__forget"
+                                  onClick={() => setConfirmForget(f.name)}
+                                  disabled={busy}
+                                  type="button"
+                                >
+                                  <Trash2 size={13} />
+                                  {t("memory.forget")}
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        )}
+                      </article>
+                    );
+                  })}
+                </div>
+              )}
+              {view.storeDir && (
+                <div className="mem-hint" title={view.storeDir}>
+                  {t("memory.storedUnder", { dir: view.storeDir })}
+                </div>
+              )}
+            </section>
+
             {/* Quick-add: scope selector + note, mirroring the "#" shortcut. */}
             <section className="mem-section">
               <div className="mem-section__title">{t("memory.quickAdd")}</div>
@@ -225,47 +450,6 @@ export function MemoryPanel({
                   </div>
                 );
               })}
-            </section>
-
-            {/* Saved auto-memories — the model owns these via remember/forget;
-                the panel can delete one and follow [[name]] cross-links. */}
-            <section className="mem-section">
-              <div className="mem-section__title">{t("memory.savedMemories")}</div>
-              {facts.length === 0 ? (
-                <div className="mem-empty">{t("memory.noFacts")}</div>
-              ) : (
-                facts.map((f) => (
-                  <div
-                    className={`mem-fact${highlight === f.name ? " mem-fact--hl" : ""}`}
-                    key={f.name}
-                    ref={(el) => {
-                      factRefs.current[f.name] = el;
-                    }}
-                  >
-                    <span className={`badge badge--${f.type}`}>{f.type}</span>
-                    <div className="mem-fact__text">
-                      <div className="mem-fact__name">{f.title || f.name}</div>
-                      <div className="mem-fact__desc">{f.description}</div>
-                      {f.body && (
-                        <div className="mem-fact__body">{renderWithLinks(f.body)}</div>
-                      )}
-                    </div>
-                    <button
-                      className="btn btn--small mem-fact__forget"
-                      onClick={() => void forgetFact(f.name)}
-                      disabled={busy}
-                      title={t("memory.forget")}
-                    >
-                      ✕
-                    </button>
-                  </div>
-                ))
-              )}
-              {view.storeDir && (
-                <div className="mem-hint" title={view.storeDir}>
-                  {t("memory.storedUnder", { dir: view.storeDir })}
-                </div>
-              )}
             </section>
           </div>
         )}

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -79,14 +79,29 @@ export function MemoryPanel({
     [facts, normalizedQuery, typeFilter],
   );
 
-  // jumpTo scrolls a [[name]] target into view and flashes it, so cross-links
-  // between saved memories are navigable inside the panel.
-  const jumpTo = (name: string) => {
+  const scrollToFact = (name: string) => {
     const el = factRefs.current[name];
     if (!el) return;
     el.scrollIntoView({ block: "center", behavior: "smooth" });
     setHighlight(name);
     window.setTimeout(() => setHighlight((h) => (h === name ? null : h)), 1200);
+  };
+
+  // jumpTo scrolls a [[name]] target into view and flashes it, so cross-links
+  // between saved memories are navigable inside the panel. If filters hide the
+  // target, clear them first so an existing link never becomes a silent no-op.
+  const jumpTo = (name: string) => {
+    if (!factNames.has(name)) return;
+    const visible = filteredFacts.some((f) => f.name === name);
+    setExpanded(name);
+    setConfirmForget(null);
+    if (!visible) {
+      setQuery("");
+      setTypeFilter("all");
+      window.setTimeout(() => scrollToFact(name), 0);
+      return;
+    }
+    scrollToFact(name);
   };
 
   // renderWithLinks turns [[name]] tokens into in-panel jumps; a token with no

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -187,6 +187,7 @@ export const en = {
 
   // memory drawer
   "memory.title": "Memory",
+  "memory.summary": "{facts} saved · {docs} files",
   "memory.unavailable": "Memory unavailable.",
   "memory.quickAdd": "Quick add",
   "memory.whereToSave": "Where to save",
@@ -195,10 +196,20 @@ export const en = {
   "memory.instructionFiles": "Instruction files",
   "memory.noDocs": "No REASONIX.md found. Quick-add one above.",
   "memory.savedMemories": "Saved memories",
+  "memory.fallibleNote": "Background memory. Verify file, function, and flag references before relying on them.",
+  "memory.searchPlaceholder": "Search title, slug, description, or body…",
+  "memory.typeFilter": "Memory type filter",
+  "memory.allTypes": "All",
+  "memory.noMatches": "No memories match the current filters.",
+  "memory.clearFilters": "Clear filters",
   "memory.noFacts": "Nothing saved yet. The agent writes these with the remember tool.",
+  "memory.links": "Memory links",
+  "memory.noBody": "No body saved for this memory.",
+  "memory.missingLinks": "{n} missing linked memory",
+  "memory.appliesNow": "Changes apply in this session.",
   "memory.storedUnder": "stored under {dir}",
   "memory.forget": "Forget",
-  "memory.confirmForget": "Forget “{name}”? This deletes the saved memory.",
+  "memory.confirmForget": "Confirm forget",
   "memory.deadLink": "No memory named “{name}”",
 
   // settings drawer

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -188,6 +188,7 @@ export const zh: Record<DictKey, string> = {
 
   // 记忆抽屉
   "memory.title": "记忆",
+  "memory.summary": "{facts} 条已保存 · {docs} 个文件",
   "memory.unavailable": "记忆功能不可用。",
   "memory.quickAdd": "快速添加",
   "memory.whereToSave": "保存到哪里",
@@ -196,10 +197,20 @@ export const zh: Record<DictKey, string> = {
   "memory.instructionFiles": "指令文件",
   "memory.noDocs": "未找到 REASONIX.md。可在上方快速添加一条。",
   "memory.savedMemories": "已保存的记忆",
+  "memory.fallibleNote": "这些是背景记忆。引用文件、函数或配置项前仍需验证。",
+  "memory.searchPlaceholder": "搜索标题、slug、描述或正文…",
+  "memory.typeFilter": "记忆类型筛选",
+  "memory.allTypes": "全部",
+  "memory.noMatches": "没有符合当前筛选的记忆。",
+  "memory.clearFilters": "清空筛选",
   "memory.noFacts": "还没有保存任何内容。智能体会通过 remember 工具写入这些。",
+  "memory.links": "记忆互链",
+  "memory.noBody": "这条记忆没有正文。",
+  "memory.missingLinks": "{n} 条互链目标不存在",
+  "memory.appliesNow": "变更会在当前会话生效。",
   "memory.storedUnder": "存放于 {dir}",
   "memory.forget": "删除",
-  "memory.confirmForget": "删除「{name}」？这会移除这条已存记忆。",
+  "memory.confirmForget": "确认删除",
   "memory.deadLink": "没有名为「{name}」的记忆",
 
   // 设置抽屉

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2794,6 +2794,16 @@ body {
   flex-direction: column;
   gap: 22px;
 }
+.mem-section {
+  min-width: 0;
+}
+.mem-section__row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+}
 .mem-section__title {
   font-size: 11px;
   text-transform: uppercase;
@@ -2801,6 +2811,88 @@ body {
   color: var(--fg-dim);
   margin-bottom: 10px;
   font-weight: 650;
+}
+.mem-section__row .mem-section__title {
+  margin-bottom: 3px;
+}
+.mem-note {
+  max-width: 36em;
+  color: var(--fg-faint);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+.mem-count {
+  min-width: 24px;
+  height: 22px;
+  padding: 0 7px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  font-size: 11px;
+  font-family: var(--mono);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.mem-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.mem-search {
+  height: 32px;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  color: var(--fg-faint);
+}
+.mem-search:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.mem-search input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 12.5px;
+}
+.mem-filter {
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  padding-bottom: 1px;
+}
+.mem-filter__item {
+  flex: 0 0 auto;
+  height: 25px;
+  padding: 0 9px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 11.5px;
+  cursor: pointer;
+}
+.mem-filter__item:hover {
+  color: var(--fg);
+  border-color: var(--border);
+  background: var(--bg-soft);
+}
+.mem-filter__item--on {
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-color: transparent;
 }
 .mem-add {
   display: flex;
@@ -2840,7 +2932,20 @@ body {
 .mem-empty {
   font-size: 12px;
   color: var(--fg-faint);
-  padding: 4px 0;
+  padding: 8px 0;
+}
+.mem-empty__action {
+  margin-left: 8px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+.mem-empty__action:hover {
+  text-decoration: underline;
 }
 .mem-doc {
   border: 1px solid var(--border);
@@ -2898,42 +3003,157 @@ body {
   gap: 8px;
   margin-top: 8px;
 }
-.mem-fact {
+.mem-facts {
   display: flex;
+  flex-direction: column;
   gap: 8px;
-  align-items: flex-start;
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border-soft);
 }
-.mem-fact__text {
+.mem-fact {
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--bg-elev) 78%, var(--bg) 22%);
+  overflow: hidden;
+  transition: border-color 0.12s, background 0.12s;
+}
+.mem-fact:hover {
+  border-color: var(--border);
+}
+.mem-fact__summary {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 7px;
+  padding: 10px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+.mem-fact__summary > svg {
+  flex: 0 0 auto;
+  margin-top: 2px;
+  color: var(--fg-faint);
+}
+.mem-fact__main {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   min-width: 0;
   flex: 1;
 }
-.mem-fact__name {
+.mem-fact__title {
+  min-width: 0;
   font-size: 13px;
-  font-weight: 500;
+  font-weight: 650;
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mem-fact__meta {
+  min-width: 0;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .mem-fact__desc {
+  min-width: 0;
   font-size: 12px;
   color: var(--fg-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mem-fact__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  padding: 0 10px 9px 32px;
+}
+.mem-link-chip {
+  display: inline-flex;
+  max-width: 100%;
+  min-height: 22px;
+  align-items: center;
+  padding: 2px 7px;
+  border: 1px solid var(--accent-soft);
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent);
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+.mem-link-chip:hover {
+  border-color: color-mix(in srgb, var(--accent) 42%, transparent);
+}
+.mem-link-chip--dead {
+  border-color: color-mix(in srgb, var(--danger, #d66) 30%, transparent);
+  background: color-mix(in srgb, var(--danger, #d66) 10%, transparent);
+  color: var(--danger, #d66);
+  cursor: help;
+  text-decoration: line-through;
+}
+.mem-fact__detail {
+  border-top: 1px solid var(--border-soft);
+  padding: 10px;
+  background: color-mix(in srgb, var(--bg) 54%, transparent);
 }
 .mem-fact__body {
-  margin-top: 4px;
   font-size: 12px;
   color: var(--fg-dim);
+  line-height: 1.5;
   white-space: pre-wrap;
   word-break: break-word;
 }
 .mem-fact__forget {
-  flex-shrink: 0;
-  opacity: 0.5;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--fg-dim);
 }
 .mem-fact__forget:hover {
-  opacity: 1;
+  color: var(--danger, #d66);
+  border-color: color-mix(in srgb, var(--danger, #d66) 36%, transparent);
+}
+.mem-fact__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 10px;
+}
+.mem-confirm {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.mem-danger {
+  color: var(--danger, #d66);
+  border-color: color-mix(in srgb, var(--danger, #d66) 34%, transparent);
+  background: color-mix(in srgb, var(--danger, #d66) 10%, transparent);
+}
+.mem-danger:hover {
+  color: var(--danger, #d66);
+  border-color: color-mix(in srgb, var(--danger, #d66) 52%, transparent);
+}
+.mem-deadline {
+  margin-top: 8px;
+  color: var(--danger, #d66);
+  font-size: 11.5px;
 }
 .mem-fact--hl {
   background: var(--accent-soft, rgba(120, 170, 255, 0.12));
-  border-radius: 6px;
+  border-color: color-mix(in srgb, var(--accent) 42%, transparent);
 }
 .mem-link {
   background: none;
@@ -2948,6 +3168,11 @@ body {
   color: var(--danger, #d66);
   cursor: help;
   text-decoration: line-through;
+}
+.mem-hint--inline {
+  margin-top: 0;
+  font-family: inherit;
+  line-height: 1.35;
 }
 .btn--small {
   padding: 4px 10px;


### PR DESCRIPTION
## Summary

- Promote saved memories to the primary memory drawer surface with title-first rows, search, and type filters
- Add expandable memory details with inline [[memory]] links, dead-link chips, and safer two-step forget actions
- Refresh English and Chinese memory drawer copy for fallible recall and same-session effects

## Verification

- npm run build (desktop/frontend)
- Browser QA at http://127.0.0.1:5174/ for drawer open, memory expansion, and forget confirmation

## Cache impact

UI-only change. This does not alter provider-visible tool schemas, tool descriptions, or memory prompt text.