### PR TITLE
chore(desktop): drop dead MCP group-title strings and CSS

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -68,8 +68,6 @@ export const en = {
   "caps.skillsTab": "Agent skills",
   "caps.servers": "MCP servers",
   "caps.noServers": "No MCP servers configured. Add one with /mcp add.",
-  "caps.connectedGroup": "Connected",
-  "caps.disabledGroup": "Disabled",
   "caps.failureTitle": "{failed} MCP startup issues",
   "caps.failureHint": "Connected servers still work. Expand a row only when you need the raw log.",
   "caps.showLog": "Show log",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -69,8 +69,6 @@ export const zh: Record<DictKey, string> = {
   "caps.skillsTab": "Agent 技能",
   "caps.servers": "MCP 服务器",
   "caps.noServers": "未配置 MCP 服务器。用 /mcp add 添加。",
-  "caps.connectedGroup": "已连接",
-  "caps.disabledGroup": "已停用",
   "caps.failureTitle": "{failed} 个 MCP 启动异常",
   "caps.failureHint": "已连接的服务器仍可使用。只有需要排障时再展开原始日志。",
   "caps.showLog": "查看日志",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3068,17 +3068,6 @@ body {
   flex-direction: column;
   margin-top: 12px;
 }
-.cap-server-group__title {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 2px;
-  color: var(--fg-faint);
-  font-size: 11px;
-  font-weight: 650;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
 .cap-tabs {
   display: grid;
   grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
@
## Summary
Follow-up cleanup after #2634. The MCP server list is now a single
reversible group, so the per-group "Connected" / "Disabled" headers are
gone — but their strings and styling were left behind.

Removes the now-unreferenced:
- `caps.connectedGroup` / `caps.disabledGroup` in `en.ts` and `zh.ts`
- `.cap-server-group__title` rule in `styles.css`

No behavior change; the dictionaries and stylesheet only carry live keys.

## Verification
- `npm run typecheck` in `desktop/frontend` passes (confirms the locale
  dictionaries stay complete against `DictKey`).
@