### PR TITLE
chore(desktop): tighten jumpTo comment

### DIFF
--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -87,9 +87,7 @@ export function MemoryPanel({
     window.setTimeout(() => setHighlight((h) => (h === name ? null : h)), 1200);
   };
 
-  // jumpTo scrolls a [[name]] target into view and flashes it, so cross-links
-  // between saved memories are navigable inside the panel. If filters hide the
-  // target, clear them first so an existing link never becomes a silent no-op.
+  // Clear active filters when the target is hidden, else the [[link]] is a silent no-op.
   const jumpTo = (name: string) => {
     if (!factNames.has(name)) return;
     const visible = filteredFacts.some((f) => f.name === name);


### PR DESCRIPTION
Follow-up nit on top of #2635.

The `jumpTo` comment ran three lines; the first two just restated what `scrollToFact` already does (scroll into view + flash). Only the filter-clearing is non-obvious, so collapse to that single load-bearing line.

No behavior change. `npm run typecheck` passes.
