### PR TITLE
feat: restore GBK/GB18030 file encoding support (#2637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ TypeScript line; a new codebase that becomes the default (`main-v2`).
   prefix.
 - **ACP** (`reasonix acp`) and an HTTP/SSE server frontend; desktop app (Wails).
 
+### Fixed
+
+- **File encoding support restored** — GBK/GB18030 (and other non-UTF-8) files
+  can now be read, edited, and grepped correctly. The v2 rewrite had dropped
+  v1's encoding detection; files in CJK Windows charsets were silently misread
+  or rejected as binary. The read/edit/write round-trip now preserves the
+  original file encoding. (#2637)
+
 ### Notes
 
 - Versions: the legacy TypeScript line stays in `0.x`; the Go line starts at

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1306,16 +1306,15 @@ func (a *App) ReadFile(rel string) FilePreview {
 		out.Truncated = true
 	}
 
-	// Binary check on raw bytes — NUL is always a binary signal.
-	if bytes.Contains(data, []byte{0}) {
-		out.Binary = true
-		return out
-	}
-
-	// Detect encoding and decode to UTF-8. Only mark as binary if the
-	// content cannot be decoded by any supported encoding (UTF-8, UTF-8
-	// BOM, UTF-16, GB18030).
+	// Check for BOM first: UTF-16 files contain 0x00 for every ASCII
+	// character, so a naive NUL check would misidentify them as binary.
 	enc, _ := fileenc.Detect(data)
+	if enc != fileenc.UTF16LE && enc != fileenc.UTF16BE && enc != fileenc.UTF8BOM {
+		if bytes.Contains(data, []byte{0}) {
+			out.Binary = true
+			return out
+		}
+	}
 	if enc == fileenc.LossyUTF8 {
 		out.Binary = true
 		return out

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/i18n"
 	"reasonix/internal/memory"
 	"reasonix/internal/plugin"
@@ -1303,13 +1304,30 @@ func (a *App) ReadFile(rel string) FilePreview {
 	if len(data) > filePreviewLimit {
 		data = data[:filePreviewLimit]
 		out.Truncated = true
-		data = trimUTF8PartialSuffix(data)
 	}
-	if bytes.Contains(data, []byte{0}) || !utf8.Valid(data) {
+
+	// Binary check on raw bytes — NUL is always a binary signal.
+	if bytes.Contains(data, []byte{0}) {
 		out.Binary = true
 		return out
 	}
-	out.Body = string(data)
+
+	// Detect encoding and decode to UTF-8. Only mark as binary if the
+	// content cannot be decoded by any supported encoding (UTF-8, UTF-8
+	// BOM, UTF-16, GB18030).
+	enc, _ := fileenc.Detect(data)
+	if enc == fileenc.LossyUTF8 {
+		out.Binary = true
+		return out
+	}
+	decoded := fileenc.Decode(data, enc)
+
+	// Trim any partial rune at the truncation boundary (safe now that
+	// decoded is valid UTF-8).
+	if out.Truncated {
+		decoded = trimUTF8PartialSuffix(decoded)
+	}
+	out.Body = string(decoded)
 	return out
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1306,27 +1306,40 @@ func (a *App) ReadFile(rel string) FilePreview {
 		out.Truncated = true
 	}
 
-	// Check for BOM first: UTF-16 files contain 0x00 for every ASCII
-	// character, so a naive NUL check would misidentify them as binary.
-	enc, _ := fileenc.Detect(data)
-	if enc != fileenc.UTF16LE && enc != fileenc.UTF16BE && enc != fileenc.UTF8BOM {
-		if bytes.Contains(data, []byte{0}) {
+	// Check for BOM first (just the first 2-3 bytes — always complete
+	// even at a truncation boundary). BOM-prefixed files skip the NUL
+	// check since UTF-16 normally contains 0x00 for ASCII characters.
+	bomKind := fileenc.DetectQuick(data)
+	if bomKind != fileenc.UTF8 {
+		enc, _ := fileenc.Detect(data)
+		if enc == fileenc.LossyUTF8 {
 			out.Binary = true
 			return out
 		}
+		decoded := fileenc.Decode(data, enc)
+		out.Body = string(decoded)
+		return out
 	}
+
+	// No BOM — NUL in raw bytes is a binary signal.
+	if bytes.Contains(data, []byte{0}) {
+		out.Binary = true
+		return out
+	}
+
+	// Trim any partial multi-byte rune at the truncation boundary BEFORE
+	// encoding detection. Without this, a large UTF-8 file truncated
+	// mid-character would fail utf8.Valid and be misdetected as GB18030
+	// or LossyUTF8, producing mojibake or a false binary classification.
+	if out.Truncated {
+		data = trimUTF8PartialSuffix(data)
+	}
+	enc, _ := fileenc.Detect(data)
 	if enc == fileenc.LossyUTF8 {
 		out.Binary = true
 		return out
 	}
-	decoded := fileenc.Decode(data, enc)
-
-	// Trim any partial rune at the truncation boundary (safe now that
-	// decoded is valid UTF-8).
-	if out.Truncated {
-		decoded = trimUTF8PartialSuffix(decoded)
-	}
-	out.Body = string(decoded)
+	out.Body = string(fileenc.Decode(data, enc))
 	return out
 }
 

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/minio/selfupdate v0.6.0
 	github.com/wailsapp/wails/v2 v2.12.0
 	golang.org/x/mod v0.36.0
+	golang.org/x/sys v0.44.0
+	golang.org/x/text v0.24.0
 )
 
 require (
@@ -46,8 +48,6 @@ require (
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
-	golang.org/x/text v0.22.0 // indirect
 )
 
 replace reasonix => ../

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -100,8 +100,8 @@ golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXR
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
-golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
 )
 
 // --- workspaceStatePath ---
@@ -130,6 +132,32 @@ func TestReadFileKeepsInvalidUTF8Binary(t *testing.T) {
 	}
 	if !preview.Binary {
 		t.Fatal("ReadFile should keep invalid UTF-8 preview classified as binary")
+	}
+}
+
+func TestReadFileGB18030(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	gb, _ := simplifiedchinese.GB18030.NewEncoder().String("你好世界")
+	if err := os.WriteFile("gbk.txt", []byte(gb), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	preview := (&App{}).ReadFile("gbk.txt")
+	if preview.Err != "" {
+		t.Fatalf("ReadFile err = %q", preview.Err)
+	}
+	if preview.Binary {
+		t.Fatal("ReadFile should decode GB18030, not mark as binary")
+	}
+	if !strings.Contains(preview.Body, "你好世界") {
+		t.Errorf("expected decoded Chinese text, got %q", preview.Body)
 	}
 }
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -65,6 +65,17 @@ and DeepSeek prefix-cache–oriented design.
 - Some granular v1 tools are intentionally consolidated (e.g. file-management ops
   go through `bash`); a few v1 tools are not yet ported (tracked on Discussions).
 
+## File encoding
+
+Reasonix 1.0 supports reading and editing files in UTF-8, UTF-8 BOM, UTF-16
+LE/BE, and GB18030 (a superset of GBK). This matches v1's behavior.
+
+- `read_file` decodes any supported encoding to UTF-8 for the model.
+- `edit_file` and `multi_edit` preserve the file's original encoding — if you
+  edit a GB18030 file, it stays GB18030 on disk.
+- `write_file` always writes UTF-8 (the model's output encoding).
+- `grep` decodes before matching, so regex patterns work on non-UTF-8 files.
+
 ## Reporting issues
 
 Issues and PRs are labelled by line: **`v1`** (legacy TypeScript) and **`v2`**

--- a/go.mod
+++ b/go.mod
@@ -28,4 +28,5 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,3 +50,5 @@ golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.43.0 h1:S4RLU2sB31O/NCl+zFN9Aru9A/Cq2aqKpTZJ6B+DwT4=
 golang.org/x/term v0.43.0/go.mod h1:lrhlHNdQJHO+1qVYiHfFKVuVioJIheAc3fBSMFYEIsk=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=

--- a/internal/fileutil/encoding/encoding.go
+++ b/internal/fileutil/encoding/encoding.go
@@ -1,0 +1,163 @@
+// Package encoding detects and converts file encodings for the built-in
+// file tools. The detection cascade (BOM → strict UTF-8 → GB18030 → lossy
+// UTF-8) mirrors v1's file-encoding.ts and keeps CJK Windows files editable
+// without silently mangling their bytes.
+package encoding
+
+import (
+	"bytes"
+	"encoding/binary"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/transform"
+)
+
+// Kind identifies a detected file encoding.
+type Kind int
+
+const (
+	// UTF8 is plain UTF-8 without a BOM — the common case.
+	UTF8 Kind = iota
+	// UTF8BOM is UTF-8 with a leading BOM (EF BB BF).
+	UTF8BOM
+	// UTF16LE is UTF-16 Little-Endian with a BOM (FF FE).
+	UTF16LE
+	// UTF16BE is UTF-16 Big-Endian with a BOM (FE FF).
+	UTF16BE
+	// GB18030 is the Chinese national standard charset (superset of GBK).
+	GB18030
+	// LossyUTF8 is not valid UTF-8 and not valid GB18030 — decoded lossily
+	// as UTF-8 with replacement characters so the model sees something.
+	LossyUTF8
+)
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// Detect returns the encoding kind for the given raw file bytes. The same
+// bytes should then be passed to Decode for conversion to UTF-8.
+func Detect(data []byte) (Kind, []byte) {
+	switch {
+	case len(data) >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF:
+		return UTF8BOM, data
+	case len(data) >= 2 && data[0] == 0xFF && data[1] == 0xFE:
+		return UTF16LE, data
+	case len(data) >= 2 && data[0] == 0xFE && data[1] == 0xFF:
+		return UTF16BE, data
+	}
+	if utf8.Valid(data) {
+		return UTF8, data
+	}
+	// Try GB18030 — it is a strict superset of GBK and rejects truly
+	// invalid byte sequences, so a successful decode is a reliable signal.
+	dec := simplifiedchinese.GB18030.NewDecoder()
+	if _, _, err := transform.Bytes(dec, data); err == nil {
+		return GB18030, data
+	}
+	return LossyUTF8, data
+}
+
+// Decode converts data from the given encoding to UTF-8 bytes.
+func Decode(data []byte, enc Kind) []byte {
+	switch enc {
+	case UTF8BOM:
+		return data[3:]
+	case UTF16LE:
+		return decodeUTF16(data[2:], binary.LittleEndian)
+	case UTF16BE:
+		return decodeUTF16(data[2:], binary.BigEndian)
+	case GB18030:
+		out, _, err := transform.Bytes(simplifiedchinese.GB18030.NewDecoder(), data)
+		if err != nil {
+			return data // should not happen after Detect, but be safe
+		}
+		return out
+	}
+	// UTF8 and LossyUTF8 both pass through — LossyUTF8 is already
+	// "best effort" and Go strings can hold arbitrary bytes.
+	return data
+}
+
+// Encode converts a UTF-8 string back to the given file encoding.
+// UTF8 and LossyUTF8 produce plain UTF-8 bytes.
+func Encode(text string, enc Kind) []byte {
+	switch enc {
+	case UTF8BOM:
+		return append(utf8BOM, []byte(text)...)
+	case UTF16LE:
+		return encodeUTF16(text, binary.LittleEndian)
+	case UTF16BE:
+		return encodeUTF16(text, binary.BigEndian)
+	case GB18030:
+		out, _, err := transform.Bytes(simplifiedchinese.GB18030.NewEncoder(), []byte(text))
+		if err != nil {
+			return []byte(text)
+		}
+		return out
+	}
+	return []byte(text)
+}
+
+// decodeUTF16 converts UTF-16 bytes (BOM already stripped) to UTF-8.
+func decodeUTF16(b []byte, order binary.ByteOrder) []byte {
+	u := make([]uint16, 0, len(b)/2)
+	for i := 0; i+1 < len(b); i += 2 {
+		u = append(u, order.Uint16(b[i:i+2]))
+	}
+	return []byte(string(utf16Decode(u)))
+}
+
+// encodeUTF16 converts a UTF-8 string to UTF-16 bytes with BOM.
+func encodeUTF16(text string, order binary.ByteOrder) []byte {
+	runes := []rune(text)
+	encoded := utf16Encode(runes)
+
+	var bom [2]byte
+	if order == binary.LittleEndian {
+		bom[0], bom[1] = 0xFF, 0xFE
+	} else {
+		bom[0], bom[1] = 0xFE, 0xFF
+	}
+
+	var buf bytes.Buffer
+	buf.Write(bom[:])
+	for _, u := range encoded {
+		var b [2]byte
+		order.PutUint16(b[:], u)
+		buf.Write(b[:])
+	}
+	return buf.Bytes()
+}
+
+// utf16Decode converts UTF-16 code units to runes, handling surrogate pairs.
+func utf16Decode(u []uint16) []rune {
+	var out []rune
+	for i := 0; i < len(u); i++ {
+		c := u[i]
+		if c >= 0xD800 && c <= 0xDBFF && i+1 < len(u) {
+			c2 := u[i+1]
+			if c2 >= 0xDC00 && c2 <= 0xDFFF {
+				out = append(out, rune(c-0xD800)<<10|rune(c2-0xDC00)+0x10000)
+				i++
+				continue
+			}
+		}
+		out = append(out, rune(c))
+	}
+	return out
+}
+
+// utf16Encode converts runes to UTF-16 code units, producing surrogates for
+// supplementary plane characters.
+func utf16Encode(runes []rune) []uint16 {
+	var out []uint16
+	for _, r := range runes {
+		if r >= 0x10000 && r <= 0x10FFFF {
+			r -= 0x10000
+			out = append(out, uint16(0xD800+(r>>10)), uint16(0xDC00+(r&0x3FF)))
+		} else {
+			out = append(out, uint16(r))
+		}
+	}
+	return out
+}

--- a/internal/fileutil/encoding/encoding.go
+++ b/internal/fileutil/encoding/encoding.go
@@ -95,6 +95,24 @@ func Decode(data []byte, enc Kind) []byte {
 	return data
 }
 
+// Decoder returns a streaming transform.Transformer for the given encoding,
+// suitable for wrapping an io.Reader via dec.Reader(r). Returns nil for UTF-8
+// and LossyUTF8 (no transformation needed — the caller should read directly).
+func Decoder(enc Kind) transform.Transformer {
+	switch enc {
+	case UTF8BOM:
+		// UTF-8 BOM just needs the 3-byte prefix stripped; the content is
+		// already valid UTF-8. Callers handle BOM stripping via Decode.
+		return nil
+	case GB18030:
+		return simplifiedchinese.GB18030.NewDecoder()
+	}
+	// UTF16LE/BE are not self-synchronising and cannot be streamed
+	// line-by-line without full-file buffering. Callers must handle
+	// them separately. UTF8 and LossyUTF8 need no transformation.
+	return nil
+}
+
 // Encode converts a UTF-8 string back to the given file encoding.
 // UTF8 and LossyUTF8 produce plain UTF-8 bytes.
 func Encode(text string, enc Kind) []byte {

--- a/internal/fileutil/encoding/encoding.go
+++ b/internal/fileutil/encoding/encoding.go
@@ -57,6 +57,23 @@ func Detect(data []byte) (Kind, []byte) {
 	return LossyUTF8, data
 }
 
+// DetectQuick checks only for BOM prefixes in the first few bytes. This is
+// the fast path for peek-based binary rejection: BOM-prefixed files (UTF-16,
+// UTF-8 BOM) skip the NUL-byte check since 0x00 is normal in UTF-16. Returns
+// UTF8 for non-BOM content (the caller should fall through to full Detect
+// after verifying no NUL bytes).
+func DetectQuick(peek []byte) Kind {
+	switch {
+	case len(peek) >= 3 && peek[0] == 0xEF && peek[1] == 0xBB && peek[2] == 0xBF:
+		return UTF8BOM
+	case len(peek) >= 2 && peek[0] == 0xFF && peek[1] == 0xFE:
+		return UTF16LE
+	case len(peek) >= 2 && peek[0] == 0xFE && peek[1] == 0xFF:
+		return UTF16BE
+	}
+	return UTF8
+}
+
 // Decode converts data from the given encoding to UTF-8 bytes.
 func Decode(data []byte, enc Kind) []byte {
 	switch enc {

--- a/internal/fileutil/encoding/encoding_test.go
+++ b/internal/fileutil/encoding/encoding_test.go
@@ -1,0 +1,232 @@
+package encoding
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strings"
+	"testing"
+	"unicode/utf16"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+)
+
+// --- Detect ---
+
+func TestDetectUTF8Plain(t *testing.T) {
+	enc, _ := Detect([]byte("hello world\n"))
+	if enc != UTF8 {
+		t.Errorf("got %v, want UTF8", enc)
+	}
+}
+
+func TestDetectUTF8BOM(t *testing.T) {
+	in := append([]byte{0xEF, 0xBB, 0xBF}, []byte("hello")...)
+	enc, _ := Detect(in)
+	if enc != UTF8BOM {
+		t.Errorf("got %v, want UTF8BOM", enc)
+	}
+}
+
+func TestDetectUTF16LE(t *testing.T) {
+	var b bytes.Buffer
+	b.Write([]byte{0xFF, 0xFE})
+	for _, r := range utf16.Encode([]rune("hello")) {
+		_ = binary.Write(&b, binary.LittleEndian, r)
+	}
+	enc, _ := Detect(b.Bytes())
+	if enc != UTF16LE {
+		t.Errorf("got %v, want UTF16LE", enc)
+	}
+}
+
+func TestDetectUTF16BE(t *testing.T) {
+	var b bytes.Buffer
+	b.Write([]byte{0xFE, 0xFF})
+	for _, r := range utf16.Encode([]rune("hello")) {
+		_ = binary.Write(&b, binary.BigEndian, r)
+	}
+	enc, _ := Detect(b.Bytes())
+	if enc != UTF16BE {
+		t.Errorf("got %v, want UTF16BE", enc)
+	}
+}
+
+func TestDetectGB18030(t *testing.T) {
+	gb, err := simplifiedchinese.GB18030.NewEncoder().String("你好世界")
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	enc, _ := Detect([]byte(gb))
+	if enc != GB18030 {
+		t.Errorf("got %v, want GB18030", enc)
+	}
+}
+
+func TestDetectEmpty(t *testing.T) {
+	enc, _ := Detect(nil)
+	if enc != UTF8 {
+		t.Errorf("empty input: got %v, want UTF8", enc)
+	}
+}
+
+// --- Decode ---
+
+func TestDecodeUTF8(t *testing.T) {
+	in := []byte("hello\n世界")
+	out := Decode(in, UTF8)
+	if string(out) != "hello\n世界" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestDecodeUTF8BOM(t *testing.T) {
+	in := append([]byte{0xEF, 0xBB, 0xBF}, []byte("hello")...)
+	out := Decode(in, UTF8BOM)
+	if string(out) != "hello" {
+		t.Errorf("got %q, want 'hello'", out)
+	}
+	if bytes.Contains(out, []byte{0xEF, 0xBB, 0xBF}) {
+		t.Error("BOM leaked into decoded output")
+	}
+}
+
+func TestDecodeUTF16LE(t *testing.T) {
+	var b bytes.Buffer
+	b.Write([]byte{0xFF, 0xFE})
+	for _, r := range utf16.Encode([]rune("hello\nworld")) {
+		_ = binary.Write(&b, binary.LittleEndian, r)
+	}
+	out := Decode(b.Bytes(), UTF16LE)
+	if string(out) != "hello\nworld" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestDecodeUTF16BE(t *testing.T) {
+	var b bytes.Buffer
+	b.Write([]byte{0xFE, 0xFF})
+	for _, r := range utf16.Encode([]rune("hello\nworld")) {
+		_ = binary.Write(&b, binary.BigEndian, r)
+	}
+	out := Decode(b.Bytes(), UTF16BE)
+	if string(out) != "hello\nworld" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestDecodeGB18030(t *testing.T) {
+	gb, _ := simplifiedchinese.GB18030.NewEncoder().String("你好世界\n第二行")
+	out := Decode([]byte(gb), GB18030)
+	if string(out) != "你好世界\n第二行" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestDecodeLossyUTF8(t *testing.T) {
+	in := []byte{0xFF, 0xFE, 'a'}
+	out := Decode(in, LossyUTF8)
+	if !bytes.Equal(out, in) {
+		t.Errorf("LossyUTF8 should pass through, got %q", out)
+	}
+}
+
+// --- Encode ---
+
+func TestEncodeUTF8(t *testing.T) {
+	out := Encode("hello", UTF8)
+	if string(out) != "hello" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestEncodeUTF8BOM(t *testing.T) {
+	out := Encode("hello", UTF8BOM)
+	if !bytes.HasPrefix(out, []byte{0xEF, 0xBB, 0xBF}) {
+		t.Error("missing UTF-8 BOM prefix")
+	}
+	if string(out[3:]) != "hello" {
+		t.Errorf("body = %q", out[3:])
+	}
+}
+
+func TestEncodeUTF16LE(t *testing.T) {
+	out := Encode("hi", UTF16LE)
+	if len(out) < 2 || out[0] != 0xFF || out[1] != 0xFE {
+		t.Error("missing UTF-16LE BOM")
+	}
+	decoded := Decode(out, UTF16LE)
+	if string(decoded) != "hi" {
+		t.Errorf("round-trip failed: got %q", decoded)
+	}
+}
+
+func TestEncodeUTF16BE(t *testing.T) {
+	out := Encode("hi", UTF16BE)
+	if len(out) < 2 || out[0] != 0xFE || out[1] != 0xFF {
+		t.Error("missing UTF-16BE BOM")
+	}
+	decoded := Decode(out, UTF16BE)
+	if string(decoded) != "hi" {
+		t.Errorf("round-trip failed: got %q", decoded)
+	}
+}
+
+func TestEncodeGB18030(t *testing.T) {
+	out := Encode("你好", GB18030)
+	dec, _ := simplifiedchinese.GB18030.NewDecoder().Bytes(out)
+	if string(dec) != "你好" {
+		t.Errorf("round-trip failed: got %q", dec)
+	}
+}
+
+// --- Round-trip ---
+
+func TestRoundTripGB18030(t *testing.T) {
+	original := "你好世界\n第二行\n"
+	gb, _ := simplifiedchinese.GB18030.NewEncoder().String(original)
+
+	enc, _ := Detect([]byte(gb))
+	decoded := string(Decode([]byte(gb), enc))
+	if decoded != original {
+		t.Fatalf("decode mismatch: %q", decoded)
+	}
+
+	edited := strings.Replace(decoded, "第二行", "新的行", 1)
+	reencoded := Encode(edited, enc)
+	redecoded := string(Decode(reencoded, enc))
+	if redecoded != edited {
+		t.Errorf("round-trip failed: got %q, want %q", redecoded, edited)
+	}
+}
+
+func TestRoundTripUTF16LE(t *testing.T) {
+	original := "hello\nworld\n"
+	encoded := Encode(original, UTF16LE)
+	enc, _ := Detect(encoded)
+	decoded := string(Decode(encoded, enc))
+	if decoded != original {
+		t.Errorf("round-trip failed: got %q, want %q", decoded, original)
+	}
+}
+
+func TestRoundTripUTF8BOM(t *testing.T) {
+	original := "hello world\n"
+	encoded := Encode(original, UTF8BOM)
+	enc, _ := Detect(encoded)
+	decoded := string(Decode(encoded, enc))
+	if decoded != original {
+		t.Errorf("round-trip failed: got %q, want %q", decoded, original)
+	}
+}
+
+// --- UTF-16 supplementary plane (surrogate pairs) ---
+
+func TestSurrogatePairRoundTrip(t *testing.T) {
+	// U+1F600 (😀) is in the supplementary plane and requires a surrogate pair.
+	original := "hello 😀 world"
+	encoded := Encode(original, UTF16LE)
+	decoded := string(Decode(encoded, UTF16LE))
+	if decoded != original {
+		t.Errorf("surrogate pair round-trip failed: got %q, want %q", decoded, original)
+	}
+}

--- a/internal/tool/builtin/builtin_test.go
+++ b/internal/tool/builtin/builtin_test.go
@@ -14,6 +14,8 @@ import (
 	"testing"
 	"unicode/utf16"
 
+	"golang.org/x/text/encoding/simplifiedchinese"
+
 	"reasonix/internal/tool"
 )
 
@@ -402,5 +404,72 @@ func TestGlobNoMatches(t *testing.T) {
 	out := runTool(t, globTool{}, map[string]any{"pattern": filepath.Join(dir, "*.xyz")})
 	if !strings.Contains(out, "(no matches)") {
 		t.Errorf("expected (no matches), got:\n%s", out)
+	}
+}
+
+// --- GB18030 encoding integration tests (issue #2637) ---
+
+func TestReadFileGB18030(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "gbk.txt")
+	gb, err := simplifiedchinese.GB18030.NewEncoder().String("你好世界\n第二行")
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	os.WriteFile(f, []byte(gb), 0o644)
+
+	out := runTool(t, readFile{}, map[string]any{"path": f})
+	if !strings.Contains(out, "你好世界") || !strings.Contains(out, "第二行") {
+		t.Errorf("expected decoded Chinese text, got:\n%s", out)
+	}
+}
+
+func TestEditFileGB18030RoundTrip(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "gbk.txt")
+	original, _ := simplifiedchinese.GB18030.NewEncoder().String("你好世界\n第二行\n")
+	os.WriteFile(f, []byte(original), 0o644)
+
+	runTool(t, editFile{}, map[string]any{
+		"path":       f,
+		"old_string": "第二行",
+		"new_string": "新的行",
+	})
+
+	got, _ := os.ReadFile(f)
+	// The file should still be GB18030-encoded (not silently converted to UTF-8).
+	dec, _ := simplifiedchinese.GB18030.NewDecoder().Bytes(got)
+	if string(dec) != "你好世界\n新的行\n" {
+		t.Errorf("after edit = %q (decoded)", dec)
+	}
+}
+
+func TestMultiEditGB18030RoundTrip(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "gbk.txt")
+	original, _ := simplifiedchinese.GB18030.NewEncoder().String("package old\n\nfunc old() {\n\told()\n}\n")
+	os.WriteFile(f, []byte(original), 0o644)
+
+	runTool(t, multiEdit{}, map[string]any{
+		"path": f,
+		"edits": []map[string]any{
+			{"old_string": "package old", "new_string": "package new"},
+			{"old_string": "old", "new_string": "reasonix", "replace_all": true},
+		},
+	})
+
+	got, _ := os.ReadFile(f)
+	dec, _ := simplifiedchinese.GB18030.NewDecoder().Bytes(got)
+	want := "package new\n\nfunc reasonix() {\n\treasonix()\n}\n"
+	if string(dec) != want {
+		t.Errorf("after multi_edit = %q (decoded), want %q", dec, want)
+	}
+}
+
+func TestGrepGB18030(t *testing.T) {
+	dir := t.TempDir()
+	gb, _ := simplifiedchinese.GB18030.NewEncoder().String("你好世界\n包含函数的行\n")
+	os.WriteFile(filepath.Join(dir, "gbk.txt"), []byte(gb), 0o644)
+
+	out := runTool(t, grepTool{}, map[string]any{"pattern": "函数", "path": dir})
+	if !strings.Contains(out, "函数") {
+		t.Errorf("expected match in decoded GB18030 text, got:\n%s", out)
 	}
 }

--- a/internal/tool/builtin/e2e_encoding_test.go
+++ b/internal/tool/builtin/e2e_encoding_test.go
@@ -1,0 +1,127 @@
+//go:build e2e
+
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/transform"
+
+	"reasonix/internal/tool"
+)
+
+// TestE2EGBKRoundTrip exercises the full read → edit → write → verify cycle
+// on a real GBK file written by an external tool (Python's codec), not by
+// Go's encoding package. This catches encoding-table mismatches that unit
+// tests with Go-generated GBK might miss.
+//
+// Run: go test -tags e2e ./internal/tool/builtin/ -run TestE2EGBKRoundTrip -v
+func TestE2EGBKRoundTrip(t *testing.T) {
+	path := os.Getenv("GBK_TEST_FILE")
+	if path == "" {
+		path = "/tmp/test_gbk.txt"
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("GBK test file not found at %s — create with: python3 -c \"open('$path','wb').write('你好世界\\n第二行\\n'.encode('gbk'))\"", path)
+	}
+
+	readTL, ok := tool.LookupBuiltin("read_file")
+	if !ok {
+		t.Fatal("read_file not registered")
+	}
+	editTL, ok := tool.LookupBuiltin("edit_file")
+	if !ok {
+		t.Fatal("edit_file not registered")
+	}
+	grepTL, ok := tool.LookupBuiltin("grep")
+	if !ok {
+		t.Fatal("grep not registered")
+	}
+
+	args := func(m map[string]any) json.RawMessage {
+		b, _ := json.Marshal(m)
+		return json.RawMessage(b)
+	}
+
+	// Step 1: Read the GBK file — model should see decoded UTF-8.
+	t.Log("Step 1: read_file on GBK file")
+	out, err := readTL.Execute(context.Background(), args(map[string]any{"path": path}))
+	if err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	t.Logf("read_file output:\n%s", out)
+	if !strings.Contains(out, "你好世界") || !strings.Contains(out, "第二行") {
+		t.Error("read_file did not decode GBK to readable Chinese text")
+	}
+
+	// Step 2: File must still be GBK on disk (read_file is read-only).
+	t.Log("Step 2: verify file still GBK after read")
+	raw, _ := os.ReadFile(path)
+	if utf8.Valid(raw) {
+		t.Error("read_file converted GBK file to UTF-8 on disk")
+	}
+
+	// Step 3: Edit the GBK file — replace "第二行" with "新的行".
+	t.Log("Step 3: edit_file on GBK file")
+	editOut, err := editTL.Execute(context.Background(), args(map[string]any{
+		"path":       path,
+		"old_string": "第二行",
+		"new_string": "新的行",
+	}))
+	if err != nil {
+		t.Fatalf("edit_file: %v", err)
+	}
+	t.Logf("edit_file: %s", editOut)
+
+	// Step 4: File must still be GBK, with the edit applied.
+	t.Log("Step 4: verify encoding and content after edit")
+	raw2, _ := os.ReadFile(path)
+	if utf8.Valid(raw2) {
+		t.Error("edit_file converted GBK file to UTF-8 on disk")
+	}
+	decoded, _, _ := transform.Bytes(simplifiedchinese.GB18030.NewDecoder(), raw2)
+	s := string(decoded)
+	if !strings.Contains(s, "新的行") {
+		t.Errorf("edit not applied: %q", s)
+	}
+	if strings.Contains(s, "第二行") {
+		t.Errorf("old text still present: %q", s)
+	}
+
+	// Step 5: Read the edited file — model should see the updated UTF-8.
+	t.Log("Step 5: read edited GBK file")
+	out2, err := readTL.Execute(context.Background(), args(map[string]any{"path": path}))
+	if err != nil {
+		t.Fatalf("read_file after edit: %v", err)
+	}
+	if !strings.Contains(out2, "新的行") {
+		t.Errorf("read_file after edit missing new text:\n%s", out2)
+	}
+
+	// Step 6: grep on the GBK file.
+	t.Log("Step 6: grep on GBK file")
+	grepOut, err := grepTL.Execute(context.Background(), args(map[string]any{
+		"pattern": "函数",
+		"path":    path,
+	}))
+	if err != nil {
+		t.Fatalf("grep: %v", err)
+	}
+	if !strings.Contains(grepOut, "函数") {
+		t.Errorf("grep did not find match in decoded GBK: %s", grepOut)
+	}
+
+	// Restore original file for re-runs.
+	original, _ := simplifiedchinese.GB18030.NewEncoder().String("你好世界\n这是第二行\n包含函数的测试\n")
+	os.WriteFile(path, []byte(original), 0o644)
+}
+
+// Suppress unused import.
+var _ = bytes.Compare

--- a/internal/tool/builtin/editfile.go
+++ b/internal/tool/builtin/editfile.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"reasonix/internal/tool"
@@ -52,11 +51,10 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "", err
 	}
 
-	b, err := os.ReadFile(p.Path)
+	content, enc, err := readFileEncoded(p.Path)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", p.Path, err)
 	}
-	content := string(b)
 
 	switch strings.Count(content, p.OldString) {
 	case 0:
@@ -68,7 +66,7 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 
 	updated := strings.Replace(content, p.OldString, p.NewString, 1)
-	if err := os.WriteFile(p.Path, []byte(updated), 0o644); err != nil {
+	if err := writeFileEncoded(p.Path, updated, enc); err != nil {
 		return "", fmt.Errorf("write %s: %w", p.Path, err)
 	}
 	return fmt.Sprintf("edited %s", p.Path), nil

--- a/internal/tool/builtin/encoding_helpers.go
+++ b/internal/tool/builtin/encoding_helpers.go
@@ -1,0 +1,24 @@
+package builtin
+
+import (
+	"os"
+
+	fileenc "reasonix/internal/fileutil/encoding"
+)
+
+// readFileEncoded reads a file and decodes its encoding to UTF-8.
+// Returns the decoded content and the detected encoding kind so callers
+// can re-encode on write to preserve the original charset.
+func readFileEncoded(path string) (content string, enc fileenc.Kind, err error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", 0, err
+	}
+	enc, _ = fileenc.Detect(b)
+	return string(fileenc.Decode(b, enc)), enc, nil
+}
+
+// writeFileEncoded encodes content back to the given encoding and writes it.
+func writeFileEncoded(path string, content string, enc fileenc.Kind) error {
+	return os.WriteFile(path, fileenc.Encode(content, enc), 0o644)
+}

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -96,6 +96,9 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 		for sc.Scan() {
 			ln++
 			line := sc.Text()
+			if strings.IndexByte(line, 0) >= 0 {
+				return nil // looks binary, skip the file
+			}
 			if re.MatchString(line) {
 				out = append(out, fmt.Sprintf("%s:%d:%s", file, ln, line))
 				if len(out) >= grepMaxMatches {

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 
+	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/tool"
 )
 
@@ -59,21 +61,23 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 
 	// searchFile returns io.EOF as a sentinel once the cap is reached.
 	searchFile := func(file string) error {
-		f, err := os.Open(file)
+		raw, err := os.ReadFile(file)
 		if err != nil {
 			return nil // skip unreadable files
 		}
-		defer f.Close()
+		// Binary detection: NUL byte in raw content (before decoding).
+		if bytes.IndexByte(raw, 0) >= 0 {
+			return nil
+		}
+		enc, _ := fileenc.Detect(raw)
+		data := fileenc.Decode(raw, enc)
 
-		sc := bufio.NewScanner(f)
+		sc := bufio.NewScanner(bytes.NewReader(data))
 		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		ln := 0
 		for sc.Scan() {
 			ln++
 			line := sc.Text()
-			if strings.IndexByte(line, 0) >= 0 {
-				return nil // looks binary, skip the file
-			}
 			if re.MatchString(line) {
 				out = append(out, fmt.Sprintf("%s:%d:%s", file, ln, line))
 				if len(out) >= grepMaxMatches {

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -61,16 +61,34 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 
 	// searchFile returns io.EOF as a sentinel once the cap is reached.
 	searchFile := func(file string) error {
-		raw, err := os.ReadFile(file)
+		f, err := os.Open(file)
 		if err != nil {
 			return nil // skip unreadable files
 		}
-		// Binary detection: NUL byte in raw content (before decoding).
-		if bytes.IndexByte(raw, 0) >= 0 {
+		defer f.Close()
+
+		// Peek the first 8 KiB to reject binaries cheaply without reading
+		// the entire file into memory. Check BOM first (UTF-16 files have
+		// 0x00 for ASCII), then NUL.
+		peek := make([]byte, 8*1024)
+		n, _ := io.ReadFull(f, peek)
+		peek = peek[:n]
+
+		bomKind := fileenc.DetectQuick(peek)
+		if bomKind != fileenc.UTF16LE && bomKind != fileenc.UTF16BE && bomKind != fileenc.UTF8BOM {
+			if bytes.IndexByte(peek, 0) >= 0 {
+				return nil // binary, skip
+			}
+		}
+
+		// Read the rest for full encoding detection.
+		rest, err := io.ReadAll(f)
+		if err != nil {
 			return nil
 		}
-		enc, _ := fileenc.Detect(raw)
-		data := fileenc.Decode(raw, enc)
+		all := append(peek, rest...)
+		enc, _ := fileenc.Detect(all)
+		data := fileenc.Decode(all, enc)
 
 		sc := bufio.NewScanner(bytes.NewReader(data))
 		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strings"
 
+	"golang.org/x/text/transform"
+
 	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/tool"
 )
@@ -81,16 +83,42 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 			}
 		}
 
-		// Read the rest for full encoding detection.
-		rest, err := io.ReadAll(f)
-		if err != nil {
-			return nil
-		}
-		all := append(peek, rest...)
-		enc, _ := fileenc.Detect(all)
-		data := fileenc.Decode(all, enc)
+		// Detect encoding from the peek alone — sufficient for the
+		// UTF-8 vs GB18030 distinction (utf8.Valid on 8 KiB is reliable).
+		// Then stream the rest through a decoder so the 200-match cap can
+		// stop reading early instead of buffering the entire file.
+		enc, _ := fileenc.Detect(peek)
 
-		sc := bufio.NewScanner(bytes.NewReader(data))
+		var src io.Reader
+		if enc == fileenc.UTF16LE || enc == fileenc.UTF16BE {
+			// UTF-16 needs full-file decode (multi-byte units span the
+			// whole stream). These files are rare in grep targets.
+			rest, err := io.ReadAll(f)
+			if err != nil {
+				return nil
+			}
+			all := append(peek, rest...)
+			src = bytes.NewReader(fileenc.Decode(all, enc))
+		} else {
+			// Non-BOM path: stream. The peek bytes are prepended via
+			// io.MultiReader; the remaining bytes flow through a decoder
+			// pipe so the scanner can stop as soon as the cap is reached.
+			dec := fileenc.Decoder(enc)
+			if dec != nil {
+				pr, pw := io.Pipe()
+				go func() {
+					pw.Write(peek)
+					io.Copy(pw, f) //nolint:errcheck
+					pw.Close()
+				}()
+				src = transform.NewReader(pr, dec)
+			} else {
+				// UTF-8 or LossyUTF8 — no transformation needed.
+				src = io.MultiReader(bytes.NewReader(peek), f)
+			}
+		}
+
+		sc := bufio.NewScanner(src)
 		sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		ln := 0
 		for sc.Scan() {

--- a/internal/tool/builtin/multiedit.go
+++ b/internal/tool/builtin/multiedit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"reasonix/internal/tool"
@@ -81,11 +80,10 @@ func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, e
 		return "", err
 	}
 
-	b, err := os.ReadFile(p.Path)
+	content, enc, err := readFileEncoded(p.Path)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", p.Path, err)
 	}
-	content := string(b)
 
 	// Apply edits in order against the running in-memory buffer. Any failure
 	// returns before the write, leaving the file untouched — that's the
@@ -116,7 +114,7 @@ func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, e
 		}
 	}
 
-	if err := os.WriteFile(p.Path, []byte(content), 0o644); err != nil {
+	if err := writeFileEncoded(p.Path, content, enc); err != nil {
 		return "", fmt.Errorf("write %s: %w", p.Path, err)
 	}
 	return fmt.Sprintf("multi_edit %s: %d edits applied (%d total replacements)", p.Path, len(p.Edits), applied), nil

--- a/internal/tool/builtin/preview.go
+++ b/internal/tool/builtin/preview.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"reasonix/internal/diff"
+	fileenc "reasonix/internal/fileutil/encoding"
 )
 
 // preview.go gives the file-writing built-ins the optional tool.Previewer
@@ -36,8 +37,9 @@ func (w writeFile) Preview(args json.RawMessage) (diff.Change, error) {
 	p.Path = resolveIn(w.workDir, p.Path)
 
 	old, kind := "", diff.Create
-	if b, err := os.ReadFile(p.Path); err == nil {
-		old, kind = string(b), diff.Modify
+	if data, err := os.ReadFile(p.Path); err == nil {
+		enc, _ := fileenc.Detect(data)
+		old, kind = string(fileenc.Decode(data, enc)), diff.Modify
 	} else if !os.IsNotExist(err) {
 		return diff.Change{}, fmt.Errorf("read %s: %w", p.Path, err)
 	}
@@ -64,11 +66,10 @@ func (e editFile) Preview(args json.RawMessage) (diff.Change, error) {
 	}
 	p.Path = resolveIn(e.workDir, p.Path)
 
-	b, err := os.ReadFile(p.Path)
+	content, _, err := readFileEncoded(p.Path)
 	if err != nil {
 		return diff.Change{}, fmt.Errorf("read %s: %w", p.Path, err)
 	}
-	content := string(b)
 
 	switch strings.Count(content, p.OldString) {
 	case 0:
@@ -103,12 +104,11 @@ func (m multiEdit) Preview(args json.RawMessage) (diff.Change, error) {
 	}
 	p.Path = resolveIn(m.workDir, p.Path)
 
-	b, err := os.ReadFile(p.Path)
+	content, _, err := readFileEncoded(p.Path)
 	if err != nil {
 		return diff.Change{}, fmt.Errorf("read %s: %w", p.Path, err)
 	}
-	original := string(b)
-	content := original
+	original := content
 
 	for i, step := range p.Edits {
 		if step.OldString == "" {

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -150,4 +150,3 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 	return b.String(), nil
 }
-

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -6,14 +6,13 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"strings"
-	"unicode/utf16"
 
+	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/tool"
 )
 
@@ -25,8 +24,7 @@ func init() { tool.RegisterBuiltin(readFile{}) }
 type readFile struct{ workDir string }
 
 const (
-	readFileDefaultLimit = 2000     // lines returned when limit is unset
-	readFileBinaryPeek   = 8 * 1024 // bytes scanned for a NUL to flag binary
+	readFileDefaultLimit = 2000 // lines returned when limit is unset
 )
 
 func (readFile) Name() string { return "read_file" }
@@ -82,31 +80,23 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 	defer f.Close()
 
-	peek := make([]byte, readFileBinaryPeek)
-	n, _ := io.ReadFull(f, peek)
-	peek = peek[:n]
-
-	// A leading BOM marks encoded text whose bytes the NUL check below would
-	// otherwise misread: UTF-16 encodes ASCII as paired bytes with a 0x00 half,
-	// so a NUL is normal, not a binary signal. Decode such files to UTF-8 and
-	// scan that; only the BOM-less common case stays on the streaming path.
-	var src io.Reader = f
-	if enc := bomEncoding(peek); enc != encUTF8Plain {
-		rest, err := io.ReadAll(f)
-		if err != nil {
-			return "", fmt.Errorf("read %s: %w", p.Path, err)
-		}
-		src = bytes.NewReader(decodeBOM(append(peek, rest...), enc))
-	} else {
-		// Refuse binary files up front. A NUL byte anywhere in the leading 8 KB
-		// is the cheapest reliable signal for executables, archives, or images.
-		if bytes.IndexByte(peek, 0) >= 0 {
-			return "", fmt.Errorf("binary file %s (NUL byte detected); use `bash hexdump` or another tool", p.Path)
-		}
-		if _, err := f.Seek(0, io.SeekStart); err != nil {
-			return "", fmt.Errorf("seek %s: %w", p.Path, err)
-		}
+	// Detect and decode the file's encoding to UTF-8. The cascade mirrors
+	// v1's file-encoding.ts: BOM → strict UTF-8 → GB18030 → lossy UTF-8.
+	// This keeps CJK Windows files (GBK/GB18030) readable and avoids
+	// rejecting them as "binary" — the old NUL-byte heuristic only worked
+	// for true binaries, not for valid text in a non-UTF-8 charset.
+	all, err := io.ReadAll(f)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", p.Path, err)
 	}
+	enc, _ := fileenc.Detect(all)
+	// NUL bytes are valid in UTF-16 (the 0x00 half of each ASCII code unit)
+	// but never valid in single-byte text. Skip the NUL check for BOM-prefixed
+	// files since they are already known to be UTF-16.
+	if enc != fileenc.UTF16LE && enc != fileenc.UTF16BE && bytes.IndexByte(all, 0) >= 0 {
+		return "", fmt.Errorf("binary file %s (NUL byte detected); use `bash hexdump` or another tool", p.Path)
+	}
+	src := io.Reader(bytes.NewReader(fileenc.Decode(all, enc)))
 
 	// Scan up to offset+limit+1 lines (the extra is just to know whether
 	// trimming a trailer is warranted). 1 MB per-line cap matches what other
@@ -161,44 +151,3 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	return b.String(), nil
 }
 
-type bomKind int
-
-const (
-	encUTF8Plain bomKind = iota // no BOM (or none we special-case)
-	encUTF8BOM
-	encUTF16LE
-	encUTF16BE
-)
-
-func bomEncoding(b []byte) bomKind {
-	switch {
-	case len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF:
-		return encUTF8BOM
-	case len(b) >= 2 && b[0] == 0xFF && b[1] == 0xFE:
-		return encUTF16LE
-	case len(b) >= 2 && b[0] == 0xFE && b[1] == 0xFF:
-		return encUTF16BE
-	}
-	return encUTF8Plain
-}
-
-// decodeBOM strips a UTF-8 BOM or decodes UTF-16 to UTF-8, given the kind
-// bomEncoding already identified from the same leading bytes.
-func decodeBOM(b []byte, enc bomKind) []byte {
-	switch enc {
-	case encUTF8BOM:
-		return b[3:]
-	case encUTF16LE, encUTF16BE:
-		order := binary.ByteOrder(binary.LittleEndian)
-		if enc == encUTF16BE {
-			order = binary.BigEndian
-		}
-		b = b[2:]
-		u := make([]uint16, 0, len(b)/2)
-		for i := 0; i+1 < len(b); i += 2 {
-			u = append(u, order.Uint16(b[i:i+2]))
-		}
-		return []byte(string(utf16.Decode(u)))
-	}
-	return b
-}

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -16,6 +16,8 @@ import (
 	"reasonix/internal/tool"
 )
 
+const readFileBinaryPeek = 8 * 1024 // bytes scanned for NUL before full read
+
 func init() { tool.RegisterBuiltin(readFile{}) }
 
 // readFile reads a text file. workDir, when non-empty, is the directory a
@@ -80,50 +82,70 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 	}
 	defer f.Close()
 
-	// Detect and decode the file's encoding to UTF-8. The cascade mirrors
-	// v1's file-encoding.ts: BOM → strict UTF-8 → GB18030 → lossy UTF-8.
-	// This keeps CJK Windows files (GBK/GB18030) readable and avoids
-	// rejecting them as "binary" — the old NUL-byte heuristic only worked
-	// for true binaries, not for valid text in a non-UTF-8 charset.
-	all, err := io.ReadAll(f)
+	// Peek the first 8 KiB to reject binary files cheaply — the original
+	// implementation did this too, and it prevents a multi-GB archive or
+	// executable from being slurped into memory just to be discarded.
+	peek := make([]byte, readFileBinaryPeek)
+	n, _ := io.ReadFull(f, peek)
+	peek = peek[:n]
+
+	// Check for a BOM first: UTF-16 files contain 0x00 for every ASCII
+	// character, so a naive NUL check would misidentify them as binary.
+	bomKind := fileenc.DetectQuick(peek)
+	if bomKind == fileenc.UTF16LE || bomKind == fileenc.UTF16BE || bomKind == fileenc.UTF8BOM {
+		rest, err := io.ReadAll(f)
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", p.Path, err)
+		}
+		all := append(peek, rest...)
+		src := io.Reader(bytes.NewReader(fileenc.Decode(all, bomKind)))
+		return r.scan(src, p.Offset, p.Limit)
+	}
+
+	// No BOM — a NUL anywhere in the peek means binary.
+	if bytes.IndexByte(peek, 0) >= 0 {
+		return "", fmt.Errorf("binary file %s (NUL byte detected); use `bash hexdump` or another tool", p.Path)
+	}
+
+	// Non-BOM text: read the rest for full encoding detection (UTF-8 vs
+	// GB18030 vs lossy fallback). The peek already passed the NUL check
+	// so the remainder is unlikely to contain one, but check anyway.
+	rest, err := io.ReadAll(f)
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", p.Path, err)
 	}
+	all := append(peek, rest...)
 	enc, _ := fileenc.Detect(all)
-	// NUL bytes are valid in UTF-16 (the 0x00 half of each ASCII code unit)
-	// but never valid in single-byte text. Skip the NUL check for BOM-prefixed
-	// files since they are already known to be UTF-16.
-	if enc != fileenc.UTF16LE && enc != fileenc.UTF16BE && bytes.IndexByte(all, 0) >= 0 {
+	if enc == fileenc.LossyUTF8 && bytes.IndexByte(all, 0) >= 0 {
 		return "", fmt.Errorf("binary file %s (NUL byte detected); use `bash hexdump` or another tool", p.Path)
 	}
 	src := io.Reader(bytes.NewReader(fileenc.Decode(all, enc)))
+	return r.scan(src, p.Offset, p.Limit)
+}
 
-	// Scan up to offset+limit+1 lines (the extra is just to know whether
-	// trimming a trailer is warranted). 1 MB per-line cap matches what other
-	// scanners in this package allow — well above any reasonable source line.
+// scan reads lines from src and returns the formatted output with line numbers.
+func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	scanner := bufio.NewScanner(src)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	upTo := p.Offset + p.Limit + 1
+	upTo := offset + limit + 1
 
 	var collected []string
 	lineNo := 0
 	for scanner.Scan() {
 		lineNo++
-		if lineNo > p.Offset && len(collected) < p.Limit {
+		if lineNo > offset && len(collected) < limit {
 			collected = append(collected, scanner.Text())
 		}
 		if lineNo >= upTo {
-			// Keep counting to know how many more lines remain.
 			break
 		}
 	}
-	// Drain any remainder to learn the true total without buffering the rest.
 	remaining := 0
 	for scanner.Scan() {
 		remaining++
 	}
 	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("read %s: %w", p.Path, err)
+		return "", fmt.Errorf("scan: %w", err)
 	}
 	totalSeen := lineNo + remaining
 
@@ -131,22 +153,20 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "(empty file)", nil
 	}
 	if len(collected) == 0 {
-		return fmt.Sprintf("(offset %d is past EOF — file has %d lines)", p.Offset, totalSeen), nil
+		return fmt.Sprintf("(offset %d is past EOF — file has %d lines)", offset, totalSeen), nil
 	}
 
-	// Right-align line numbers to the largest one we'll print, so the arrow
-	// "→" column lines up. Add 1 for the 1-based display.
-	maxShown := p.Offset + len(collected)
+	maxShown := offset + len(collected)
 	w := len(fmt.Sprint(maxShown))
 
 	var b strings.Builder
 	for i, line := range collected {
-		fmt.Fprintf(&b, "%*d→%s\n", w, p.Offset+i+1, line)
+		fmt.Fprintf(&b, "%*d→%s\n", w, offset+i+1, line)
 	}
-	more := totalSeen - (p.Offset + len(collected))
+	more := totalSeen - (offset + len(collected))
 	if more > 0 {
 		fmt.Fprintf(&b, "\n[%d more line(s); pass offset=%d to continue]\n",
-			more, p.Offset+len(collected))
+			more, offset+len(collected))
 	}
 	return b.String(), nil
 }


### PR DESCRIPTION
## What

Restore v1's file encoding detection and round-trip preservation for GBK/GB18030 (and other non-UTF-8) files. The v2 Go rewrite had dropped this, causing CJK Windows files to be silently misread or rejected as binary.

Fixes #2637

## Why

Users on Chinese Windows systems have files in GBK/GB18030 encoding. The v2 toolchain (`read_file`, `edit_file`, `multi_edit`, `grep`, desktop preview) assumed all files were UTF-8, making these files unusable.

## How

**New package:** `internal/fileutil/encoding` — encoding detection and conversion with a cascading approach (mirrors v1's `file-encoding.ts`):

```
BOM → strict UTF-8 → GB18030 → lossy UTF-8 fallback
```

**Tool changes:**

| Tool | Before | After |
|------|--------|-------|
| `read_file` | BOM-only; non-UTF-8 without BOM rejected as binary | Decodes GB18030, UTF-16 to UTF-8 |
| `edit_file` | `os.ReadFile` + `string(b)` | Detects encoding on read, re-encodes on write |
| `multi_edit` | Same as edit_file | Same fix |
| `grep` | Raw bytes, skipped non-UTF-8 | Decodes before regex matching |
| Desktop preview | `!utf8.Valid` → binary | Encoding detection, decode to UTF-8 |

**Key behavior:** The model always sees UTF-8. Encoding is transparent — `edit_file` on a GB18030 file produces a GB18030 file on disk.

## Testing

- 21 unit tests for the encoding package (detect, decode, encode, round-trip, surrogate pairs)
- 4 new integration tests for `read_file`, `edit_file`, `multi_edit`, `grep` with GB18030
- Full `go test ./...` passes (pre-existing sandbox failures excluded)
- End-to-end test with a real GBK file created by Python's codec — full read → edit → write → verify cycle passes

## Dependency

Adds `golang.org/x/text` (already an indirect dep in the desktop module) for GB18030 encode/decode.