### PR TITLE
feat(attach): file drag attach + inline image tokens (+ classifier panic fix)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1348,6 +1348,13 @@ func (a *App) SavePastedImage(dataURL string) (string, error) {
 	return control.SaveImageDataURL(dataURL)
 }
 
+// SavePastedFile stores a dropped non-image file (the browser exposes its bytes
+// as a data URL but not a real path) under .reasonix/attachments and returns the
+// relative @-reference path.
+func (a *App) SavePastedFile(name, dataURL string) (string, error) {
+	return control.SaveAttachmentDataURL(name, dataURL)
+}
+
 // AttachmentDataURL returns a safe data URL for a stored image attachment.
 func (a *App) AttachmentDataURL(path string) (string, error) {
 	return control.ImageDataURL(path)

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -11,7 +11,7 @@ import { FileMenu } from "./FileMenu";
 
 interface Attachment {
   path: string;
-  previewUrl: string;
+  previewUrl?: string;
 }
 
 const LONG_PASTE_MIN_CHARS = 2000;
@@ -254,18 +254,21 @@ export function Composer({
     setAttachments([]);
   };
 
+  const readFileAsDataURL = (file: File) =>
+    new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+    });
+
   const attachImageFiles = async (files: File[]) => {
     const images = files.filter((f) => f.type.startsWith("image/"));
     if (images.length === 0) return;
     for (const file of images) {
       setPendingPaste((n) => n + 1);
       try {
-        const dataUrl = await new Promise<string>((resolve, reject) => {
-          const reader = new FileReader();
-          reader.onload = () => resolve(String(reader.result));
-          reader.onerror = () => reject(reader.error);
-          reader.readAsDataURL(file);
-        });
+        const dataUrl = await readFileAsDataURL(file);
         const path = await app.SavePastedImage(dataUrl);
         const previewUrl = await app.AttachmentDataURL(path);
         setAttachments((prev) => [...prev, { path, previewUrl }]);
@@ -277,11 +280,35 @@ export function Composer({
     }
   };
 
+  // Non-image drops (PDFs, docs): the browser hands us bytes, not a path, so the
+  // kernel stores them and we reference the saved path — attached, not ignored.
+  const attachOtherFiles = async (files: File[]) => {
+    const others = files.filter((f) => !f.type.startsWith("image/"));
+    if (others.length === 0) return;
+    for (const file of others) {
+      setPendingPaste((n) => n + 1);
+      try {
+        const dataUrl = await readFileAsDataURL(file);
+        const path = await app.SavePastedFile(file.name, dataUrl);
+        setAttachments((prev) => [...prev, { path }]);
+      } catch {
+        // non-fatal: a failed attach must not block normal text input
+      } finally {
+        setPendingPaste((n) => Math.max(0, n - 1));
+      }
+    }
+  };
+
+  const attachFiles = (files: File[]) => {
+    void attachImageFiles(files);
+    void attachOtherFiles(files);
+  };
+
   const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
-    const files = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith("image/"));
+    const files = Array.from(e.clipboardData.files);
     if (files.length > 0) {
       e.preventDefault();
-      void attachImageFiles(files);
+      attachFiles(files);
       return;
     }
 
@@ -312,10 +339,10 @@ export function Composer({
 
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     const files = Array.from(e.dataTransfer.files);
-    if (!files.some((f) => f.type.startsWith("image/"))) return;
+    if (files.length === 0) return;
     e.preventDefault();
     setDragOver(false);
-    void attachImageFiles(files);
+    attachFiles(files);
   };
 
   const onDragOver = (e: DragEvent<HTMLDivElement>) => {
@@ -569,11 +596,11 @@ export function Composer({
         <div className="composer__attachments">
           {attachments.map((a) => (
             <div className="composer__attachment" key={a.path}>
-              <img src={a.previewUrl} alt="" />
+              {a.previewUrl ? <img src={a.previewUrl} alt="" /> : <FileText size={16} />}
               <span>{a.path.split("/").pop()}</span>
               <button
                 type="button"
-                title="Remove image"
+                title="Remove attachment"
                 onClick={() => setAttachments((prev) => prev.filter((x) => x.path !== a.path))}
               >
                 <X size={14} />

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -87,6 +87,7 @@ export interface AppBindings {
   OpenWorkspacePath(rel: string): Promise<void>;
   RevealWorkspacePath(rel: string): Promise<void>;
   SavePastedImage(dataUrl: string): Promise<string>;
+  SavePastedFile(name: string, dataUrl: string): Promise<string>;
   AttachmentDataURL(path: string): Promise<string>;
   Models(): Promise<ModelInfo[]>;
   SetModel(name: string): Promise<void>;
@@ -524,6 +525,9 @@ function makeMockApp(): AppBindings {
     },
     async SavePastedImage(_dataUrl: string) {
       return ".reasonix/attachments/mock.png";
+    },
+    async SavePastedFile(name: string, _dataUrl: string) {
+      return `.reasonix/attachments/mock-${name}`;
     },
     async AttachmentDataURL(_path: string) {
       return "data:image/png;base64,iVBORw0KGgo=";

--- a/internal/cli/chat_attachment_test.go
+++ b/internal/cli/chat_attachment_test.go
@@ -1,19 +1,25 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
 
-func TestWithAttachmentRefs(t *testing.T) {
-	attachments := []chatAttachment{
-		{Path: ".reasonix/attachments/clipboard-20260601-010203.000001.png"},
-		{Path: ".reasonix/attachments/clipboard-20260601-010204.000002.jpg"},
-	}
-	got := withAttachmentRefs("describe", attachments)
-	want := "describe @.reasonix/attachments/clipboard-20260601-010203.000001.png @.reasonix/attachments/clipboard-20260601-010204.000002.jpg"
+func TestExpandPastedBlocksImage(t *testing.T) {
+	m := &chatTUI{pastedBlocks: []pastedBlock{
+		{label: "[image #1]", text: "@.reasonix/attachments/clipboard-20260601-010203.000001.png", image: true},
+		{label: "[Pasted text #2 · 3 lines]", text: "a\nb\nc"},
+	}}
+	got := m.expandPastedBlocks("look at [image #1] and [Pasted text #2 · 3 lines]")
+	want := "look at @.reasonix/attachments/clipboard-20260601-010203.000001.png and " +
+		renderFoldedPasteBlock(m.pastedBlocks[1])
 	if got != want {
-		t.Fatalf("withAttachmentRefs = %q, want %q", got, want)
+		t.Fatalf("expandPastedBlocks = %q, want %q", got, want)
+	}
+	if displayLineForImageRefs(got) != "look at [image1] and "+renderFoldedPasteBlock(m.pastedBlocks[1]) {
+		t.Fatalf("image ref should collapse to a label in the bubble: %q", displayLineForImageRefs(got))
 	}
 }
 
@@ -22,6 +28,30 @@ func TestDisplayLineForImageRefs(t *testing.T) {
 	want := "describe [image1] [image2]"
 	if got != want {
 		t.Fatalf("displayLineForImageRefs = %q, want %q", got, want)
+	}
+}
+
+func TestPastedFileRef(t *testing.T) {
+	dir := t.TempDir()
+	pdf := filepath.Join(dir, "report.pdf")
+	if err := os.WriteFile(pdf, []byte("%PDF-1.4 fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := pastedFileRef(pdf); !ok || got != "@"+filepath.Clean(pdf) {
+		t.Fatalf("pastedFileRef(existing pdf) = %q, %v", got, ok)
+	}
+	if got, ok := pastedFileRef(`"` + pdf + `"`); !ok || got != "@"+filepath.Clean(pdf) {
+		t.Fatalf("pastedFileRef(quoted pdf) = %q, %v", got, ok)
+	}
+	if _, ok := pastedFileRef("just-a-word"); ok {
+		t.Fatal("a bare word with no separator must not be a file ref")
+	}
+	if _, ok := pastedFileRef(filepath.Join(dir, "missing.pdf")); ok {
+		t.Fatal("a non-existent path must not be a file ref")
+	}
+	if _, ok := pastedFileRef(dir); ok {
+		t.Fatal("a directory must not be a file ref")
 	}
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -139,11 +139,6 @@ type chatTUI struct {
 	bubbleStartIdx int
 	bubblePending  bool
 	turnDiscarded  bool
-	// attachments are image refs queued for the next user turn. They render as a
-	// tray above the input and are appended to the provider-facing prompt as
-	// @-references only when the turn is sent.
-	attachments        []chatAttachment
-	pendingAttachments []chatAttachment
 
 	// pendingApproval holds the tool-call approval currently shown in the banner
 	// (nil when none). While set, the controller's run goroutine is blocked
@@ -314,12 +309,11 @@ type promptResolvedMsg struct {
 // refsResolvedMsg carries the result of resolving the @references in a
 // submitted line (async file reads / MCP resources/read).
 type refsResolvedMsg struct {
-	sent        string
-	display     string
-	restore     string
-	attachments []chatAttachment
-	block       string
-	errs        []string
+	sent    string
+	display string
+	restore string
+	block   string
+	errs    []string
 }
 
 type clipboardImageMsg struct {
@@ -331,10 +325,6 @@ type clipboardPasteMsg struct {
 	path string
 	text string
 	err  error
-}
-
-type chatAttachment struct {
-	Path string
 }
 
 // newChatTUI assembles the initial model. The controller has already been wired
@@ -538,6 +528,12 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.state != tuiRunning && m.attachPastedImages(msg.Content) {
 			return m, finalize(m, cmds)
 		}
+		if ref, ok := pastedFileRef(msg.Content); ok {
+			m.input.InsertString(ref + " ")
+			m.growInputToFit()
+			m.updateCompletion()
+			return m, finalize(m, cmds)
+		}
 		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.shouldFoldPaste(msg.Content) {
 			m.insertFoldedPaste(msg.Content)
 			m.growInputToFit()
@@ -632,8 +628,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case m.planMode:
 				m.planMode = false
 				m.ctrl.SetPlanMode(false)
-			case len(m.attachments) > 0 && strings.TrimSpace(m.input.Value()) == "":
-				m.attachments = nil
 			default:
 				// Idle with nothing to back out: a double-Esc on an empty composer
 				// opens the rewind picker (Claude Code's gesture); a first Esc just
@@ -699,7 +693,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			line := strings.TrimSpace(m.input.Value())
 
-			if line == "" && len(m.attachments) == 0 {
+			if line == "" {
 				return m, nil
 			}
 			if line == "exit" || line == "quit" || line == ":q" {
@@ -723,33 +717,34 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, finalize(m, cmds)
 			}
 
-			// Slash commands run locally without going through the model unless
-			// attachments are queued; then the line is a normal multimodal prompt.
-			if strings.HasPrefix(line, "/") && len(m.attachments) == 0 {
-				m.input.Reset()
-				m.input.SetHeight(1)
-				m.pastedBlocks = nil
-				cmds = append(cmds, m.runSlashCommand(line))
-				return m, finalize(m, cmds)
+			// Slash commands run locally without going through the model. A
+			// '/'-leading line that's actually a dragged file path is an attachment,
+			// not a command, so it's rewritten to an @reference instead.
+			if strings.HasPrefix(line, "/") {
+				if ref, ok := control.FileRefLine(line); ok {
+					line = ref
+				} else {
+					m.input.Reset()
+					m.input.SetHeight(1)
+					m.pastedBlocks = nil
+					cmds = append(cmds, m.runSlashCommand(line))
+					return m, finalize(m, cmds)
+				}
 			}
 
-			attachments := cloneAttachments(m.attachments)
-			sentText := m.expandPastedBlocks(line)
-			sentLine := withAttachmentRefs(sentText, attachments)
-			displayLine := withAttachmentLabels(sentText, attachments)
+			sentLine := m.expandPastedBlocks(line)
 			m.input.Reset()
 			m.input.SetHeight(1)
-			m.attachments = nil
 
-			// @references (local files / MCP resources) are resolved off the event
-			// loop by the controller; the turn starts when they resolve
-			// (refsResolvedMsg).
+			// @references (local files / MCP resources, including inline image
+			// attachments) are resolved off the event loop by the controller; the turn
+			// starts when they resolve (refsResolvedMsg).
 			if m.ctrl.HasRefs(sentLine) {
-				cmds = append(cmds, m.resolveRefs(sentLine, displayLine, line, attachments))
+				cmds = append(cmds, m.resolveRefs(sentLine, sentLine, line))
 				return m, finalize(m, cmds)
 			}
 
-			cmds = append(cmds, m.startTurnWithRaw(sentLine, displayLine, line, line, attachments))
+			cmds = append(cmds, m.startTurnWithRaw(sentLine, sentLine, line, line))
 			return m, finalize(m, cmds)
 		}
 
@@ -814,7 +809,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case strings.TrimSpace(msg.sent) == "":
 			m.notice(i18n.M.SlashPromptEmpty)
 		default:
-			cmds = append(cmds, m.startTurn(msg.sent, msg.display, msg.display, nil))
+			cmds = append(cmds, m.startTurn(msg.sent, msg.display, msg.display))
 		}
 
 	case refsResolvedMsg:
@@ -825,32 +820,35 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.block != "" {
 			sent = "Referenced context:\n\n" + msg.block + "\n\n" + msg.sent
 		}
-		cmds = append(cmds, m.startTurnWithRaw(sent, msg.display, msg.restore, msg.restore, msg.attachments))
+		cmds = append(cmds, m.startTurnWithRaw(sent, msg.display, msg.restore, msg.restore))
 
 	case clipboardImageMsg:
 		if msg.err != nil {
 			m.notice("paste image: " + msg.err.Error())
 			break
 		}
-		m.attachments = append(m.attachments, chatAttachment{Path: msg.path})
+		m.insertImageRef(msg.path)
 
 	case clipboardPasteMsg:
 		switch {
 		case msg.err != nil:
 			m.notice("paste: " + msg.err.Error())
 		case msg.path != "":
-			m.attachments = append(m.attachments, chatAttachment{Path: msg.path})
+			m.insertImageRef(msg.path)
 		case msg.text != "":
-			if !m.attachPastedImages(msg.text) {
-				if m.shouldFoldPaste(msg.text) {
-					m.insertFoldedPaste(msg.text)
-				} else {
-					m.input.InsertString(msg.text)
-				}
-				m.growInputToFit()
-				m.updateCompletion()
+			if m.attachPastedImages(msg.text) {
 				return m, finalize(m, cmds)
 			}
+			if ref, ok := pastedFileRef(msg.text); ok {
+				m.input.InsertString(ref + " ")
+			} else if m.shouldFoldPaste(msg.text) {
+				m.insertFoldedPaste(msg.text)
+			} else {
+				m.input.InsertString(msg.text)
+			}
+			m.growInputToFit()
+			m.updateCompletion()
+			return m, finalize(m, cmds)
 		}
 
 	case elapsedTickMsg:
@@ -1181,10 +1179,6 @@ func (m chatTUI) View() tea.View {
 		parts = append(parts, card)
 		rowsAboveBox += strings.Count(card, "\n") + 1
 	}
-	if tray := m.renderAttachmentTray(); tray != "" {
-		parts = append(parts, tray)
-		rowsAboveBox += strings.Count(tray, "\n") + 1
-	}
 	if menu := m.renderCompletion(); menu != "" {
 		parts = append(parts, menu)
 		rowsAboveBox += strings.Count(menu, "\n") + 1
@@ -1431,15 +1425,6 @@ func (m chatTUI) renderTodoPanel() string {
 	return todoPanelStyle.Width(max(m.width, 10)).Render(strings.TrimRight(b.String(), "\n"))
 }
 
-func (m chatTUI) renderAttachmentTray() string {
-	if len(m.attachments) == 0 {
-		return ""
-	}
-	labels := attachmentLabels(m.attachments)
-	body := strings.Join(labels, "  ")
-	return todoPanelStyle.Width(max(m.width, 10)).Render(body)
-}
-
 // truncateSubject trims a tool subject so the approval banner fits one line.
 func truncateSubject(s string, width int) string {
 	max := width - 28
@@ -1474,6 +1459,7 @@ const foldedPasteMinLines = 5
 type pastedBlock struct {
 	label string
 	text  string
+	image bool // an image attachment: expands to its bare @ref, not a wrapped block
 }
 
 func pastedLineCount(s string) int {
@@ -1510,12 +1496,29 @@ func (m *chatTUI) insertFoldedPaste(s string) {
 	m.input.InsertString(label + " ")
 }
 
+// insertImageRef puts a deletable [image #N] token in the input box (mapped to
+// the saved attachment's @ref, expanded on submit) so a dragged/pasted image is
+// edited and removed like any other text, not stranded in a separate tray.
+func (m *chatTUI) insertImageRef(path string) {
+	label := fmt.Sprintf("[image #%d]", m.nextPasteID)
+	m.nextPasteID++
+	m.pastedBlocks = append(m.pastedBlocks, pastedBlock{label: label, text: "@" + path, image: true})
+	m.input.InsertString(label + " ")
+	m.growInputToFit()
+	m.updateCompletion()
+}
+
 func (m *chatTUI) expandPastedBlocks(displayed string) string {
 	sent := displayed
 	for _, block := range m.pastedBlocks {
-		if strings.Contains(sent, block.label) {
-			sent = strings.ReplaceAll(sent, block.label, renderFoldedPasteBlock(block))
+		if !strings.Contains(sent, block.label) {
+			continue
 		}
+		repl := renderFoldedPasteBlock(block)
+		if block.image {
+			repl = block.text
+		}
+		sent = strings.ReplaceAll(sent, block.label, repl)
 	}
 	return sent
 }
@@ -1585,50 +1588,6 @@ func pasteClipboard() tea.Cmd {
 	}
 }
 
-func cloneAttachments(in []chatAttachment) []chatAttachment {
-	if len(in) == 0 {
-		return nil
-	}
-	out := make([]chatAttachment, len(in))
-	copy(out, in)
-	return out
-}
-
-func attachmentLabels(in []chatAttachment) []string {
-	labels := make([]string, len(in))
-	for i := range in {
-		labels[i] = accent(fmt.Sprintf("[image%d]", i+1))
-	}
-	return labels
-}
-
-func withAttachmentLabels(line string, attachments []chatAttachment) string {
-	line = strings.TrimSpace(line)
-	if len(attachments) == 0 {
-		return line
-	}
-	labels := strings.Join(attachmentLabels(attachments), " ")
-	if line == "" {
-		return labels
-	}
-	return line + "\n" + labels
-}
-
-func withAttachmentRefs(line string, attachments []chatAttachment) string {
-	line = strings.TrimSpace(line)
-	if len(attachments) == 0 {
-		return line
-	}
-	refs := make([]string, len(attachments))
-	for i, a := range attachments {
-		refs[i] = "@" + a.Path
-	}
-	if line == "" {
-		return strings.Join(refs, " ")
-	}
-	return line + " " + strings.Join(refs, " ")
-}
-
 func (m *chatTUI) attachPastedImages(text string) bool {
 	sources, ok := pastedImageSources(text)
 	if !ok {
@@ -1640,7 +1599,7 @@ func (m *chatTUI) attachPastedImages(text string) bool {
 			m.notice("paste image: " + err.Error())
 			continue
 		}
-		m.attachments = append(m.attachments, chatAttachment{Path: path})
+		m.insertImageRef(path)
 	}
 	return true
 }
@@ -1762,6 +1721,22 @@ func pastedImagePath(src string) (string, bool) {
 	return filepath.Clean(src), true
 }
 
+// pastedFileRef turns a dragged/pasted non-image file path into an @reference so
+// it attaches instead of landing as literal text (and, for a POSIX path, being
+// misread as a slash command). Images are handled earlier; only path-shaped
+// content (a separator) that points at a real file qualifies, so an ordinary
+// pasted word is left alone.
+func pastedFileRef(content string) (string, bool) {
+	path, ok := pastedImagePath(content)
+	if !ok || !strings.ContainsAny(path, `/\`) {
+		return "", false
+	}
+	if info, err := os.Stat(path); err != nil || info.IsDir() {
+		return "", false
+	}
+	return "@" + path, true
+}
+
 // cycleMode advances the input mode normal → plan → YOLO → normal (Tab),
 // mirroring the desktop composer's Shift+Tab. plan is read-only; YOLO
 // auto-approves every tool call for the session (deny rules still apply). The
@@ -1796,14 +1771,14 @@ func (m *chatTUI) toggleVerboseReasoning(notify bool) {
 // and kicks off the controller turn. `sent` goes to the model uncomposed (the
 // controller frames it with any plan marker); `displayed` is what the transcript
 // shows, and `restore` is what Esc puts back while the bubble is still deferred.
-func (m *chatTUI) startTurn(sent, displayed, restore string, attachments []chatAttachment) tea.Cmd {
-	return m.startTurnWithRaw(sent, displayed, restore, sent, attachments)
+func (m *chatTUI) startTurn(sent, displayed, restore string) tea.Cmd {
+	return m.startTurnWithRaw(sent, displayed, restore, sent)
 }
 
 // startTurnWithRaw is startTurn plus an explicit `raw` (the un-resolved user
 // prompt) used only for the controller's auto-plan scoring, so resolved
 // @-reference payloads can't inflate the complexity signal.
-func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string, attachments []chatAttachment) tea.Cmd {
+func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string) tea.Cmd {
 	// Flush any half-streamed leftover before the new turn (defensive).
 	m.commitReasoning()
 	m.commitPending()
@@ -1814,7 +1789,6 @@ func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string, attachm
 	// restores the text to the input box, leaving nothing stranded.
 	m.pendingRestore = restore
 	m.pendingPastes = m.pasteLabelsIn(restore)
-	m.pendingAttachments = cloneAttachments(attachments)
 	m.bubbleStartIdx = len(m.transcript)
 	m.commitLine("") // blank line separating turns
 	m.commitLine(renderUserBubble(displayed, m.width, m.planMode))
@@ -1840,7 +1814,6 @@ func (m *chatTUI) confirmBubbleSent() {
 	}
 	m.bubblePending = false
 	m.pendingRestore = ""
-	m.pendingAttachments = nil
 }
 
 // unsendPending "un-sends" the in-flight turn while the server hasn't replied yet
@@ -1851,8 +1824,6 @@ func (m *chatTUI) confirmBubbleSent() {
 func (m *chatTUI) unsendPending() {
 	m.input.SetValue(m.pendingRestore)
 	m.growInputToFit()
-	m.attachments = cloneAttachments(m.pendingAttachments)
-	m.pendingAttachments = nil
 	m.transcript = m.transcript[:m.bubbleStartIdx]
 	m.transcriptDirty = true
 	m.bubblePending = false
@@ -2100,10 +2071,10 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	default:
 		// A custom command wins over a skill of the same name; both resolve to a turn.
 		if sent, ok := m.ctrl.CustomCommand(input); ok {
-			return m.startTurn(sent, input, input, nil)
+			return m.startTurn(sent, input, input)
 		}
 		if sent, ok := m.ctrl.RunSkill(input); ok {
-			return m.startTurn(sent, input, input, nil)
+			return m.startTurn(sent, input, input)
 		}
 		m.notice(fmt.Sprintf("%s: %s", i18n.M.SlashUnknown, cmd))
 	}
@@ -2219,10 +2190,10 @@ func (m *chatTUI) notice(note string) {
 
 // resolveRefs resolves a line's @references off the event loop via the
 // controller, delivering a refsResolvedMsg with the tagged context block.
-func (m *chatTUI) resolveRefs(sent, display, restore string, attachments []chatAttachment) tea.Cmd {
+func (m *chatTUI) resolveRefs(sent, display, restore string) tea.Cmd {
 	return func() tea.Msg {
 		block, errs := m.ctrl.ResolveRefs(context.Background(), sent)
-		return refsResolvedMsg{sent: sent, display: display, restore: restore, attachments: attachments, block: block, errs: errs}
+		return refsResolvedMsg{sent: sent, display: display, restore: restore, block: block, errs: errs}
 	}
 }
 

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync/atomic"
@@ -15,10 +16,52 @@ import (
 )
 
 const maxImageAttachmentBytes = 10 * 1024 * 1024
+const maxFileAttachmentBytes = 25 * 1024 * 1024
 const maxAttachmentCreateAttempts = 1000
 
 var attachmentPathSeq atomic.Uint64
 var attachmentNow = time.Now
+var safeAttachmentExt = regexp.MustCompile(`^\.[a-z0-9]{1,12}$`)
+
+// SaveAttachmentDataURL stores a non-image file (dropped/pasted in the desktop
+// app, where the browser exposes bytes but not a real path) under
+// .reasonix/attachments and returns its repo-relative path for @referencing.
+// origName supplies only the extension; the stored name is generated.
+func SaveAttachmentDataURL(origName, dataURL string) (string, error) {
+	const marker = ";base64,"
+	i := strings.Index(dataURL, marker)
+	if !strings.HasPrefix(dataURL, "data:") || i < 0 {
+		return "", fmt.Errorf("unsupported pasted file")
+	}
+	raw, err := base64.StdEncoding.DecodeString(dataURL[i+len(marker):])
+	if err != nil {
+		return "", fmt.Errorf("decode pasted file: %w", err)
+	}
+	if len(raw) == 0 || len(raw) > maxFileAttachmentBytes {
+		return "", fmt.Errorf("attachment must be between 1 byte and 25 MB")
+	}
+	ext := strings.ToLower(filepath.Ext(origName))
+	if !safeAttachmentExt.MatchString(ext) {
+		ext = ".bin"
+	}
+	if err := ensureAttachmentRoot(); err != nil {
+		return "", err
+	}
+	rel, f, err := createAttachmentFile(ext)
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.Write(raw); err != nil {
+		_ = f.Close()
+		_ = os.Remove(rel)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(rel)
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
 
 func SaveImageDataURL(dataURL string) (string, error) {
 	const prefix = "data:"

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -457,6 +457,10 @@ func (c *Controller) Submit(input string) {
 			return c.runTurnWithRaw(ctx, sent, sent)
 		})
 	case strings.HasPrefix(trimmed, "/"):
+		if ref, ok := FileRefLine(trimmed); ok {
+			c.runRefTurn(ref)
+			return
+		}
 		// Read-only management verbs (/model /memory /skill /hooks /mcp) emit a
 		// listing Notice, so Submit-based frontends (desktop, HTTP) get them with
 		// no extra wiring. (The chat TUI handles these itself with richer output.)
@@ -505,18 +509,24 @@ func (c *Controller) Submit(input string) {
 		}
 		c.notice("unknown command: " + trimmed)
 	default:
-		c.runGuarded(func(ctx context.Context) error {
-			block, errs := c.ResolveRefs(ctx, input)
-			for _, e := range errs {
-				c.notice(e)
-			}
-			sent := input
-			if block != "" {
-				sent = "Referenced context:\n\n" + block + "\n\n" + input
-			}
-			return c.runTurnWithRaw(ctx, sent, input)
-		})
+		c.runRefTurn(input)
 	}
+}
+
+// runRefTurn resolves a line's @references into a context block and starts a
+// turn with it prepended (or the raw line when nothing resolved).
+func (c *Controller) runRefTurn(input string) {
+	c.runGuarded(func(ctx context.Context) error {
+		block, errs := c.ResolveRefs(ctx, input)
+		for _, e := range errs {
+			c.notice(e)
+		}
+		sent := input
+		if block != "" {
+			sent = "Referenced context:\n\n" + block + "\n\n" + input
+		}
+		return c.runTurnWithRaw(ctx, sent, input)
+	})
 }
 
 // notice emits an informational Notice event.

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -97,6 +97,21 @@ func (c *Controller) HasRefs(line string) bool {
 	return len(c.detectRefs(line)) > 0
 }
 
+// FileRefLine reports whether a submitted line is nothing but a path to an
+// existing file — a dragged or pasted file lands as its bare path, which on
+// POSIX starts with '/' and would otherwise be misread as a slash command. The
+// returned string is that path turned into an @reference so it attaches.
+func FileRefLine(line string) (string, bool) {
+	p := strings.Trim(strings.TrimSpace(line), `"'`)
+	if p == "" {
+		return "", false
+	}
+	if info, err := os.Stat(p); err != nil || info.IsDir() {
+		return "", false
+	}
+	return "@" + p, true
+}
+
 // ResolveRefs resolves the @references in a line into a single tagged context
 // block (file/dir contents, MCP resource bodies), plus per-reference error
 // strings for any that failed. An empty block means no references resolved.

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -8,6 +8,30 @@ import (
 	"testing"
 )
 
+func TestFileRefLine(t *testing.T) {
+	dir := t.TempDir()
+	pdf := filepath.Join(dir, "report.pdf")
+	if err := os.WriteFile(pdf, []byte("%PDF-1.4 fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, ok := FileRefLine("  " + pdf + "  "); !ok || got != "@"+pdf {
+		t.Fatalf("FileRefLine(existing) = %q, %v", got, ok)
+	}
+	if got, ok := FileRefLine(`"` + pdf + `"`); !ok || got != "@"+pdf {
+		t.Fatalf("FileRefLine(quoted) = %q, %v", got, ok)
+	}
+	if _, ok := FileRefLine("/compact"); ok {
+		t.Fatal("a slash command must not resolve as a file ref")
+	}
+	if _, ok := FileRefLine(dir); ok {
+		t.Fatal("a directory must not resolve as a file ref")
+	}
+	if _, ok := FileRefLine(""); ok {
+		t.Fatal("empty must not resolve as a file ref")
+	}
+}
+
 func TestParseRefTokens(t *testing.T) {
 	cases := []struct {
 		line string


### PR DESCRIPTION
## What

Dragging a PDF (or any non-image file) into the composer used to fail: a
dropped file pastes its path, which on POSIX starts with `/` and got misread
as a slash command — `unknown command: /Users/...`. This makes a dropped/pasted
file path resolve to an `@reference` instead, across the TUI, the controller
(desktop/HTTP frontends), and the desktop composer (which previously ignored
non-image drops outright).

It also reworks how images attach. They no longer sit in a separate tray row
that pushed the input box down (hiding the status line) and could only be
cleared all-at-once. An image now becomes an inline **`[image #N]`** token in
the composer — edited and deleted like any other text — and expands to its
`@ref` on submit. The redundant attachment-tray subsystem is removed.

## Also fixed (surfaced while testing)

A latent **typed-nil interface panic**: boot left the auto-plan classifier a nil
`*ProviderAutoPlanClassifier` when no `auto_plan_classifier` model is configured
(the common case), then boxed it into the interface field. The typed-nil passes
`!= nil` but its receiver is nil, so any turn scoring 1–2 panicked on
`NeedsPlan`. Now assigned only when non-nil at the boot seam, with a defensive
normalize in `control.New`.

## Notes

- Per the chosen scope, a PDF attaches as a reference; the model layer is
  text-only, so its contents aren't extracted (no new dependency).
- Tests: file-ref resolution, inline image-token expansion, and a regression
  test reproducing the classifier panic. `go build ./...`, control/cli/boot
  tests, and the desktop frontend typecheck all pass.
