### PR TITLE
feat(deepseek): support thinking effort controlsFeat/deepseek thinking effort

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2058,6 +2058,8 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.notice(i18n.M.SlashTodoCleared)
 	case "/verbose":
 		m.toggleVerboseReasoning(true)
+	case "/thinking":
+		return m.runThinkingCommand(input)
 	case "/rewind":
 		m.openRewind()
 	case "/tree":

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1,12 +1,15 @@
 package cli
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 
+	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -202,6 +205,55 @@ func TestInsertNewlineKeyBinding(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("newChatTUI InsertNewline should include shift+enter, got %v", keys)
+	}
+}
+
+func TestThinkingCommandWritesCurrentDeepSeekProvider(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+	t.Chdir(root)
+
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Label: "deepseek-flash"})
+	m.modelRef = "deepseek-flash/deepseek-v4-flash"
+	m.buildController = func(_ string, _ []provider.Message) (*control.Controller, error) {
+		return control.New(control.Options{Label: "deepseek-flash"}), nil
+	}
+
+	cmd := m.runThinkingCommand("/thinking max")
+	if cmd == nil {
+		t.Fatal("/thinking max should return a rebuild command")
+	}
+
+	configPath := config.UserConfigPath()
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	if !strings.Contains(string(body), `effort      = "max"`) {
+		t.Fatalf("saved config missing effort=max:\n%s", body)
+	}
+}
+
+func TestThinkingCommandRejectsNonDeepSeekProvider(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+	t.Chdir(root)
+
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Label: "mimo-pro"})
+	m.modelRef = "mimo-pro/mimo-v2.5-pro"
+	m.buildController = func(_ string, _ []provider.Message) (*control.Controller, error) {
+		return control.New(control.Options{Label: "mimo-pro"}), nil
+	}
+
+	if cmd := m.runThinkingCommand("/thinking max"); cmd != nil {
+		t.Fatal("non-DeepSeek provider should not rebuild")
+	}
+	if _, err := os.Stat(config.UserConfigPath()); !os.IsNotExist(err) {
+		t.Fatalf("non-DeepSeek provider should not write config, stat err=%v", err)
 	}
 }
 

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -208,11 +208,17 @@ func TestInsertNewlineKeyBinding(t *testing.T) {
 	}
 }
 
-func TestThinkingCommandWritesCurrentDeepSeekProvider(t *testing.T) {
+func isolateUserConfig(t *testing.T) {
+	t.Helper()
 	root := t.TempDir()
 	t.Setenv("HOME", root)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
+	t.Setenv("AppData", filepath.Join(root, "AppData")) // os.UserConfigDir reads AppData on Windows
 	t.Chdir(root)
+}
+
+func TestThinkingCommandWritesCurrentDeepSeekProvider(t *testing.T) {
+	isolateUserConfig(t)
 
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{Label: "deepseek-flash"})
@@ -237,10 +243,7 @@ func TestThinkingCommandWritesCurrentDeepSeekProvider(t *testing.T) {
 }
 
 func TestThinkingCommandRejectsNonDeepSeekProvider(t *testing.T) {
-	root := t.TempDir()
-	t.Setenv("HOME", root)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "config"))
-	t.Chdir(root)
+	isolateUserConfig(t)
 
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{Label: "mimo-pro"})

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -71,7 +71,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
 		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},
 		{label: "/verbose", insert: "/verbose", hint: i18n.M.CmdVerbose},
-		{label: "/thinking", insert: "/thinking ", hint: "set DeepSeek thinking effort", descend: true},
+		{label: "/thinking", insert: "/thinking ", hint: i18n.M.CmdThinking, descend: true},
 		{label: "/help", insert: "/help ", hint: i18n.M.CmdHelp},
 		{label: "/memory", insert: "/memory ", hint: i18n.M.CmdMemory},
 		{label: "/forget", insert: "/forget ", hint: i18n.M.CmdForget},

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -71,6 +71,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
 		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},
 		{label: "/verbose", insert: "/verbose", hint: i18n.M.CmdVerbose},
+		{label: "/thinking", insert: "/thinking ", hint: "set DeepSeek thinking effort", descend: true},
 		{label: "/help", insert: "/help ", hint: i18n.M.CmdHelp},
 		{label: "/memory", insert: "/memory ", hint: i18n.M.CmdMemory},
 		{label: "/forget", insert: "/forget ", hint: i18n.M.CmdForget},

--- a/internal/cli/thinking.go
+++ b/internal/cli/thinking.go
@@ -1,0 +1,130 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/config"
+)
+
+func (m *chatTUI) runThinkingCommand(input string) tea.Cmd {
+	entry, ref, err := m.currentConfigProvider()
+	if err != nil {
+		m.notice("thinking: " + err.Error())
+		return nil
+	}
+	if !isDeepSeekProviderEntry(entry) {
+		m.notice("thinking effort is only supported for DeepSeek providers")
+		return nil
+	}
+
+	args := tokenizeArgs(input)
+	if len(args) < 2 {
+		effort := entry.Effort
+		if effort == "" {
+			effort = "high"
+		}
+		m.notice(fmt.Sprintf("thinking effort for %s: %s", entry.Name, effort))
+		return nil
+	}
+	if len(args) > 2 {
+		m.notice("usage: /thinking high|max|off")
+		return nil
+	}
+	effort := strings.ToLower(strings.TrimSpace(args[1]))
+	switch effort {
+	case "high", "max", "off":
+	default:
+		m.notice("usage: /thinking high|max|off")
+		return nil
+	}
+	if m.buildController == nil {
+		m.notice("model switching is unavailable in this session")
+		return nil
+	}
+	if m.ctrl.Running() {
+		m.notice("finish or cancel the current turn before changing thinking effort")
+		return nil
+	}
+
+	path := config.UserConfigPath()
+	if path == "" {
+		m.notice("thinking: cannot resolve user config directory")
+		return nil
+	}
+	edit := config.LoadForEdit(path)
+	if _, ok := edit.Provider(entry.Name); !ok {
+		if err := edit.UpsertProvider(*entry); err != nil {
+			m.notice("thinking: " + err.Error())
+			return nil
+		}
+	}
+	if err := edit.SetProviderEffort(entry.Name, effort); err != nil {
+		m.notice("thinking: " + err.Error())
+		return nil
+	}
+	if err := edit.SaveTo(path); err != nil {
+		m.notice("thinking: " + err.Error())
+		return nil
+	}
+
+	m.notice(fmt.Sprintf("setting thinking effort for %s to %s…", entry.Name, effort))
+	carried := m.ctrl.History()
+	if err := m.ctrl.Snapshot(); err != nil {
+		m.notice("thinking: snapshot: " + err.Error())
+	}
+	oldCtrl := m.ctrl
+	build := m.buildController
+	m.modelSwitchPending = true
+	m.pendingModelSwitch = func() tea.Msg {
+		c, err := build(ref, carried)
+		if err != nil {
+			return modelSwitchMsg{ref: ref, err: err}
+		}
+		return modelSwitchMsg{
+			ref:      ref,
+			ctrl:     c,
+			oldCtrl:  oldCtrl,
+			label:    c.Label(),
+			commands: c.Commands(),
+			skills:   c.Skills(),
+			host:     c.Host(),
+		}
+	}
+	m.notice(fmt.Sprintf("thinking effort for %s set to %s", entry.Name, effort))
+	return m.pendingModelSwitch
+}
+
+func (m *chatTUI) currentConfigProvider() (*config.ProviderEntry, string, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, "", err
+	}
+	ref := m.modelRef
+	if strings.TrimSpace(ref) == "" {
+		ref = cfg.DefaultModel
+	}
+	entry, ok := cfg.ResolveModel(ref)
+	if !ok {
+		return nil, "", fmt.Errorf("unknown model %q", ref)
+	}
+	if ref == entry.Name || !strings.Contains(ref, "/") {
+		ref = entry.Name + "/" + entry.Model
+	}
+	return entry, ref, nil
+}
+
+func isDeepSeekProviderEntry(e *config.ProviderEntry) bool {
+	if e == nil || e.Kind != "openai" {
+		return false
+	}
+	u, err := url.Parse(e.BaseURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "api.deepseek.com" || strings.HasSuffix(host, ".deepseek.com")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,7 +193,8 @@ type ProviderEntry struct {
 	// via Config.Extra. The anthropic provider reads Thinking="adaptive" to enable
 	// extended thinking and Effort ("low".."max") to tune depth. The
 	// openai-compatible provider forwards Effort as reasoning_effort for
-	// thinking-capable models (e.g. MiMo) and ignores Thinking. Empty = provider default.
+	// thinking-capable models; DeepSeek accepts high|max and off disables thinking.
+	// Empty = provider default.
 	Thinking string `toml:"thinking"`
 	Effort   string `toml:"effort"`
 }
@@ -338,8 +339,8 @@ func Default() *Config {
 		// a missing server yields an install hint rather than an error.
 		LSP: LSPConfig{Enabled: true},
 		Providers: []ProviderEntry{
-			{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
-			{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
+			{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}, Effort: "high"},
+			{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}, Effort: "high"},
 			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
 			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
 		},

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -68,6 +68,17 @@ func (c *Config) UpsertProvider(e ProviderEntry) error {
 	return nil
 }
 
+// SetProviderEffort updates a provider's provider-specific thinking effort knob.
+func (c *Config) SetProviderEffort(name, effort string) error {
+	for i := range c.Providers {
+		if c.Providers[i].Name == name {
+			c.Providers[i].Effort = strings.ToLower(strings.TrimSpace(effort))
+			return nil
+		}
+	}
+	return fmt.Errorf("set provider effort: no provider %q", name)
+}
+
 // RemoveProvider deletes the named provider. It refuses to remove the current
 // default_model (reassign it first, so the config never points at a missing
 // model); if the removed provider was the planner, planner_model is cleared as

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -73,6 +73,41 @@ func TestUpsertProvider(t *testing.T) {
 	}
 }
 
+func TestSetProviderEffort(t *testing.T) {
+	c := Default()
+	if err := c.SetProviderEffort("deepseek-flash", "MAX"); err != nil {
+		t.Fatalf("SetProviderEffort: %v", err)
+	}
+	p, _ := c.Provider("deepseek-flash")
+	if p.Effort != "max" {
+		t.Fatalf("effort = %q, want max", p.Effort)
+	}
+	if err := c.SetProviderEffort("missing", "high"); err == nil {
+		t.Fatal("SetProviderEffort should reject unknown provider")
+	}
+}
+
+func TestResolveModelPreservesProviderEffort(t *testing.T) {
+	c := Default()
+	c.Providers = append(c.Providers, ProviderEntry{
+		Name:      "deepseek",
+		Kind:      "openai",
+		BaseURL:   "https://api.deepseek.com",
+		Model:     "deepseek-v4-flash",
+		Models:    []string{"deepseek-v4-flash", "deepseek-v4-pro"},
+		Default:   "deepseek-v4-flash",
+		APIKeyEnv: "DEEPSEEK_API_KEY",
+		Effort:    "max",
+	})
+	e, ok := c.ResolveModel("deepseek/deepseek-v4-pro")
+	if !ok {
+		t.Fatal("ResolveModel did not find deepseek/deepseek-v4-pro")
+	}
+	if e.Name != "deepseek" || e.Model != "deepseek-v4-pro" || e.Effort != "max" {
+		t.Fatalf("resolved entry = %+v, want provider deepseek model deepseek-v4-pro effort max", e)
+	}
+}
+
 func TestRemoveProvider(t *testing.T) {
 	c := Default()
 	c.Agent.PlannerModel = "deepseek-pro"

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -92,6 +92,12 @@ func RenderTOML(c *Config) string {
 			fmt.Fprintf(&b, "price       = { cache_hit = %v, input = %v, output = %v, currency = %q }   # per 1M tokens\n",
 				p.Price.CacheHit, p.Price.Input, p.Price.Output, p.Price.Symbol())
 		}
+		if p.Thinking != "" {
+			fmt.Fprintf(&b, "thinking    = %q\n", p.Thinking)
+		}
+		if p.Effort != "" {
+			fmt.Fprintf(&b, "effort      = %q\n", p.Effort)
+		}
 		b.WriteString("\n")
 	}
 

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -26,6 +26,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	mm, _ := orig.Provider("mimo-pro")
 	mm.BaseURL = "http://localhost:8000/v1"
+	ds, _ := orig.Provider("deepseek-flash")
+	ds.Effort = "max"
 
 	rendered := RenderTOML(orig)
 
@@ -63,6 +65,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if g, _ := got.Provider("mimo-pro"); g == nil || g.BaseURL != "http://localhost:8000/v1" {
 		t.Errorf("mimo-pro base_url not preserved: %+v", g)
+	}
+	if g, _ := got.Provider("deepseek-flash"); g == nil || g.Effort != "max" {
+		t.Errorf("deepseek-flash effort not preserved: %+v", g)
 	}
 	if len(got.Providers) != len(orig.Providers) {
 		t.Errorf("providers count = %d, want %d", len(got.Providers), len(orig.Providers))

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -37,7 +37,8 @@ type ArgData struct {
 // (everything after the command word). It returns the suggestions filtered by
 // the token being typed and the byte offset where that token begins, so a caller
 // replaces just that token. Only structured commands participate (/mcp /model
-// /skill /hooks); others yield nil. Single source of truth for CLI + desktop.
+// /skill /hooks /thinking); others yield nil. Single source of truth for CLI +
+// desktop.
 func SlashArgItems(line string, d ArgData) ([]SlashItem, int) {
 	cmdEnd := strings.IndexAny(line, " \t")
 	if cmdEnd < 0 {
@@ -56,10 +57,23 @@ func SlashArgItems(line string, d ArgData) ([]SlashItem, int) {
 		raw = skillArgItems(prior, d)
 	case "/hooks":
 		raw = hooksArgItems(prior)
+	case "/thinking":
+		raw = thinkingArgItems(prior)
 	default:
 		return nil, from
 	}
 	return filterSlash(raw, line, from, cur), from
+}
+
+func thinkingArgItems(prior []string) []SlashItem {
+	if len(prior) <= 1 {
+		return []SlashItem{
+			{Label: "high", Insert: "high", Hint: "normal DeepSeek thinking effort"},
+			{Label: "max", Insert: "max", Hint: "maximum DeepSeek thinking effort"},
+			{Label: "off", Insert: "off", Hint: "disable DeepSeek thinking"},
+		}
+	}
+	return nil
 }
 
 func mcpArgItems(prior []string, cur string, d ArgData) []SlashItem {

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -68,9 +68,9 @@ func SlashArgItems(line string, d ArgData) ([]SlashItem, int) {
 func thinkingArgItems(prior []string) []SlashItem {
 	if len(prior) <= 1 {
 		return []SlashItem{
-			{Label: "high", Insert: "high", Hint: "normal DeepSeek thinking effort"},
-			{Label: "max", Insert: "max", Hint: "maximum DeepSeek thinking effort"},
-			{Label: "off", Insert: "off", Hint: "disable DeepSeek thinking"},
+			{Label: "high", Insert: "high", Hint: i18n.M.ArgThinkingHigh},
+			{Label: "max", Insert: "max", Hint: i18n.M.ArgThinkingMax},
+			{Label: "off", Insert: "off", Hint: i18n.M.ArgThinkingOff},
 		}
 	}
 	return nil

--- a/internal/control/slash_test.go
+++ b/internal/control/slash_test.go
@@ -77,6 +77,11 @@ func TestSlashArgItems(t *testing.T) {
 	if !has(items, "list") || !has(items, "trust") {
 		t.Errorf("/hooks should offer list/trust; got %v", labelsOf(items))
 	}
+	// /thinking
+	items, _ = SlashArgItems("/thinking ", data)
+	if !has(items, "high") || !has(items, "max") || !has(items, "off") {
+		t.Errorf("/thinking should offer high/max/off; got %v", labelsOf(items))
+	}
 	// a non-structured command yields nothing
 	if items, _ := SlashArgItems("/help ", data); len(items) != 0 {
 		t.Errorf("/help should have no arg items; got %v", labelsOf(items))

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -125,6 +125,7 @@ type Messages struct {
 	CmdOutputStyle  string // /output-style
 	CmdSkill        string // /skill
 	CmdVerbose      string // /verbose
+	CmdThinking     string // /thinking
 	CmdHelp         string // /help
 	CmdTodo         string // /todo
 	CmdQuit         string // /quit (also accepts /exit as hidden alias)
@@ -139,6 +140,9 @@ type Messages struct {
 	ArgHooksList    string // /hooks list
 	ArgHooksTrust   string // /hooks trust
 	ArgModelCurrent string // /model <ref> active tag
+	ArgThinkingHigh string // /thinking high
+	ArgThinkingMax  string // /thinking max
+	ArgThinkingOff  string // /thinking off
 
 	// management listing notices (the Submit path: desktop / HTTP frontends)
 	ListModelsHeaderFmt string // "models (active: %s)"

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -92,6 +92,7 @@ var English = Messages{
 	CmdOutputStyle:  "list output styles",
 	CmdSkill:        "manage skills",
 	CmdVerbose:      "toggle thinking text",
+	CmdThinking:     "set DeepSeek thinking effort",
 	CmdHelp:         "list commands",
 	CmdTodo:         "dismiss the task list",
 	CmdQuit:         "exit the session",
@@ -106,6 +107,9 @@ var English = Messages{
 	ArgHooksList:    "list active hooks",
 	ArgHooksTrust:   "trust this project's hooks",
 	ArgModelCurrent: "current",
+	ArgThinkingHigh: "normal DeepSeek thinking effort",
+	ArgThinkingMax:  "maximum DeepSeek thinking effort",
+	ArgThinkingOff:  "disable DeepSeek thinking",
 
 	ListModelsHeaderFmt: "models (active: %s)",
 	ListModelsHint:      "switch with the model switcher, or type /model <provider/model>",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -93,6 +93,7 @@ var Chinese = Messages{
 	CmdOutputStyle:  "列出输出风格",
 	CmdSkill:        "管理 skills",
 	CmdVerbose:      "切换 thinking 原文显示",
+	CmdThinking:     "设置 DeepSeek 思考强度",
 	CmdHelp:         "查看命令列表",
 	CmdTodo:         "清除任务清单",
 	CmdQuit:         "退出会话",
@@ -107,6 +108,9 @@ var Chinese = Messages{
 	ArgHooksList:    "列出生效的 hooks",
 	ArgHooksTrust:   "信任本项目的 hooks",
 	ArgModelCurrent: "当前",
+	ArgThinkingHigh: "常规 DeepSeek 思考强度",
+	ArgThinkingMax:  "最高 DeepSeek 思考强度",
+	ArgThinkingOff:  "关闭 DeepSeek 思考",
 
 	ListModelsHeaderFmt: "模型（当前：%s）",
 	ListModelsHint:      "用底部的模型切换器，或输入 /model <provider/model>",

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -14,6 +14,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -39,13 +40,25 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
 	effort, _ := cfg.Extra["effort"].(string)
+	deepseek := isDeepSeekBaseURL(cfg.BaseURL)
+	if deepseek {
+		effort = strings.ToLower(strings.TrimSpace(effort))
+		switch effort {
+		case "":
+			effort = "high"
+		case "high", "max", "off":
+		default:
+			return nil, fmt.Errorf("openai: provider %q uses DeepSeek thinking; effort must be high, max, or off", name)
+		}
+	}
 	return &client{
-		name:    name,
-		apiKey:  cfg.APIKey,
-		keyEnv:  keyEnv,
-		baseURL: strings.TrimRight(cfg.BaseURL, "/"),
-		model:   cfg.Model,
-		effort:  effort,
+		name:     name,
+		apiKey:   cfg.APIKey,
+		keyEnv:   keyEnv,
+		baseURL:  strings.TrimRight(cfg.BaseURL, "/"),
+		model:    cfg.Model,
+		deepseek: deepseek,
+		effort:   effort,
 		http: &http.Client{
 			Transport: &http.Transport{
 				DialContext: (&net.Dialer{
@@ -60,16 +73,26 @@ func New(cfg provider.Config) (provider.Provider, error) {
 }
 
 type client struct {
-	name    string
-	apiKey  string
-	keyEnv  string // api_key_env name, surfaced in auth errors
-	baseURL string
-	model   string
-	http    *http.Client
-	effort  string // reasoning_effort forwarded to thinking-capable models; "" = omit
+	name     string
+	apiKey   string
+	keyEnv   string // api_key_env name, surfaced in auth errors
+	baseURL  string
+	model    string
+	http     *http.Client
+	deepseek bool
+	effort   string // reasoning_effort forwarded to thinking-capable models; "" = omit
 }
 
 func (c *client) Name() string { return c.name }
+
+func isDeepSeekBaseURL(baseURL string) bool {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	return host == "api.deepseek.com" || strings.HasSuffix(host, ".deepseek.com")
+}
 
 func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	body, err := json.Marshal(c.buildRequest(req))
@@ -204,7 +227,7 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		})
 	}
 
-	return chatRequest{
+	out := chatRequest{
 		Model:           c.model,
 		Messages:        msgs,
 		Tools:           tools,
@@ -214,6 +237,14 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		MaxTokens:       req.MaxTokens,
 		ReasoningEffort: c.effort,
 	}
+	if c.deepseek {
+		out.Thinking = &thinkingMode{Type: "enabled"}
+		if c.effort == "off" {
+			out.Thinking.Type = "disabled"
+			out.ReasoningEffort = ""
+		}
+	}
+	return out
 }
 
 // readStream parses the SSE stream, emits text deltas live, accumulates tool-call
@@ -375,6 +406,11 @@ type chatRequest struct {
 	Temperature     float64        `json:"temperature,omitempty"`
 	MaxTokens       int            `json:"max_tokens,omitempty"`
 	ReasoningEffort string         `json:"reasoning_effort,omitempty"`
+	Thinking        *thinkingMode  `json:"thinking,omitempty"`
+}
+
+type thinkingMode struct {
+	Type string `json:"type"`
 }
 
 type streamOptions struct {

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -284,6 +284,62 @@ func TestBuildRequestForwardsReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestBuildRequestDeepSeekThinking(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		effort        string
+		wantThinking  string
+		wantReasoning string
+	}{
+		{name: "high", effort: "high", wantThinking: "enabled", wantReasoning: "high"},
+		{name: "max", effort: "max", wantThinking: "enabled", wantReasoning: "max"},
+		{name: "off", effort: "off", wantThinking: "disabled", wantReasoning: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := (&client{model: "deepseek-v4", deepseek: true, effort: tc.effort}).buildRequest(provider.Request{})
+			if req.Thinking == nil || req.Thinking.Type != tc.wantThinking {
+				t.Fatalf("Thinking = %+v, want %q", req.Thinking, tc.wantThinking)
+			}
+			if req.ReasoningEffort != tc.wantReasoning {
+				t.Fatalf("ReasoningEffort = %q, want %q", req.ReasoningEffort, tc.wantReasoning)
+			}
+		})
+	}
+}
+
+func TestBuildRequestNonDeepSeekOmitsThinking(t *testing.T) {
+	req := (&client{model: "mimo-v2", effort: "high"}).buildRequest(provider.Request{})
+	if req.Thinking != nil {
+		t.Fatalf("non-DeepSeek request must not include thinking, got %+v", req.Thinking)
+	}
+	if req.ReasoningEffort != "high" {
+		t.Fatalf("ReasoningEffort = %q, want high", req.ReasoningEffort)
+	}
+}
+
+func TestNewDeepSeekThinkingDefaultsAndValidation(t *testing.T) {
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	c := p.(*client)
+	if !c.deepseek || c.effort != "high" {
+		t.Fatalf("deepseek=%v effort=%q, want true/high", c.deepseek, c.effort)
+	}
+
+	p, err = New(provider.Config{Name: "deepseek", BaseURL: "https://api.deepseek.com/v1", Model: "deepseek-v4", Extra: map[string]any{"effort": "max"}})
+	if err != nil {
+		t.Fatalf("New max: %v", err)
+	}
+	if got := p.(*client).effort; got != "max" {
+		t.Fatalf("effort = %q, want max", got)
+	}
+
+	if _, err := New(provider.Config{Name: "deepseek", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4", Extra: map[string]any{"effort": "medium"}}); err == nil {
+		t.Fatal("New should reject invalid DeepSeek effort")
+	}
+}
+
 func TestNewReadsEffortFromConfig(t *testing.T) {
 	p, err := New(provider.Config{
 		Name:    "mimo",

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -34,6 +34,8 @@ default     = "deepseek-v4-flash"   # optional; defaults to the first of `models
 api_key_env = "DEEPSEEK_API_KEY"
 context_window = 1000000
 price       = { cache_hit = 0.02, input = 1, output = 2, currency = "¥" }   # per 1M tokens
+# DeepSeek thinking mode is enabled by default; effort: high | max | off.
+effort      = "high"
 
 # A single-model provider still works (use `model = "..."`) — pick this form when a
 # model needs its own base_url / context_window / price (e.g. the two MiMo SKUs


### PR DESCRIPTION
##  Description
  Adds DeepSeek Thinking Mode support for OpenAI-compatible DeepSeek providers, plus a CLI command to inspect and update thinking effort.

## Changes:

  - Enable DeepSeek thinking mode by default with reasoning_effort = high.
  - Support DeepSeek effort = "high", effort = "max", and effort = "off".
  - Send thinking: { type: "enabled" } for high/max, and thinking: { type: "disabled" } for off.
  - Apply effort at the provider-entry level, so all models under the same DeepSeek provider share the setting.
  - Add CLI /thinking, /thinking high, /thinking max, and /thinking off.
  - Persist /thinking changes to the user config and rebuild the current controller so the setting takes effect immediately.
  - Add slash completion and localized CLI strings.
  - Update reasonix.example.toml.

## Verification

  the DeepSeek changes.