### PR TITLE
feat: native-Windows steering + optional ripgrep search engine

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -129,7 +129,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if sandbox.ResolveShell().Kind == sandbox.ShellPowerShell {
 		fmt.Fprintln(stderr, "warning: bash not found on PATH; the shell tool will run commands under Windows PowerShell. Install Git for Windows or WSL to use bash.")
 	}
-	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRoots(), bashSpec, stderr)
+	searchSpec := builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, stderr)
+	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRoots(), bashSpec, searchSpec, stderr)
 	// Always construct a host, even with no plugins configured, so the controller's
 	// host pointer is stable for the session and `/mcp add` can hot-add into it.
 	pluginHost := plugin.NewHost()
@@ -454,7 +455,7 @@ func NewProvider(e *config.ProviderEntry) (provider.Provider, error) {
 // them. writeRoots confines the file-writing built-ins to the workspace: after
 // the (unconfined) defaults are added, each enabled writer is replaced by an
 // instance bound to writeRoots (preserving registry order).
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, stderr io.Writer) {
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, searchSpec builtin.SearchSpec, stderr io.Writer) {
 	if len(enabled) == 0 {
 		for _, t := range tool.Builtins() {
 			reg.Add(t)
@@ -471,7 +472,7 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 	// Replace the unconfined defaults with confined instances (registry order is
 	// preserved on replace): file-writers bound to the workspace, bash to the OS
 	// sandbox. Only replace tools actually enabled/present.
-	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec))
+	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec), builtin.ConfineSearch(searchSpec))
 	for _, t := range confined {
 		if _, ok := reg.Get(t.Name()); ok {
 			reg.Add(t)

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -105,7 +105,7 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		writeRoots = []string{p.Cwd}
 	}
 	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: writeRoots, Network: cfg.Sandbox.Network}
-	ws := builtin.Workspace{Dir: p.Cwd, WriteRoots: writeRoots, Bash: bashSpec}
+	ws := builtin.Workspace{Dir: p.Cwd, WriteRoots: writeRoots, Bash: bashSpec, Search: builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, nil)}
 	for _, t := range ws.Tools(cfg.Tools.Enabled...) {
 		reg.Add(t)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -234,7 +234,17 @@ func (e *ProviderEntry) HasModel(m string) bool {
 
 // ToolsConfig selects which built-in tools are enabled. Empty means all of them.
 type ToolsConfig struct {
-	Enabled []string `toml:"enabled"`
+	Enabled []string     `toml:"enabled"`
+	Search  SearchConfig `toml:"search"`
+}
+
+// SearchConfig tunes the grep tool's engine. Engine is "auto" (default — use
+// ripgrep when it's on PATH, else the native Go scanner), "native" (always Go),
+// or "rg" (require ripgrep; warn at startup and fall back to native if absent).
+// RgPath optionally points at a specific ripgrep binary instead of a PATH lookup.
+type SearchConfig struct {
+	Engine string `toml:"engine"`
+	RgPath string `toml:"rg_path"`
 }
 
 // PermissionsConfig declares the per-call permission policy (see

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -36,12 +36,21 @@ func (bash) Name() string { return "bash" }
 func (b bash) Description() string {
 	if b.resolved().Kind == sandbox.ShellPowerShell {
 		return "Execute a command in the shell and return combined stdout/stderr. " +
-			"NOTE: bash is not available on this host — commands run under Windows PowerShell, " +
-			"so write PowerShell syntax (e.g. $null not /dev/null; ';' or separate calls, not '&&'; " +
-			"Get-ChildItem/Select-String, not ls/grep). Use for builds, tests, git, etc."
+			"NOTE: bash is not available on this host — commands run under Windows PowerShell, so write PowerShell, not bash:\n" +
+			"  - chaining: ';' runs both regardless; 'if ($?) { ... }' is conditional. '&&' and '||' are NOT parsed.\n" +
+			"  - redirect/vars: $null not /dev/null; $env:VAR not $VAR; '2>$null' drops stderr.\n" +
+			"  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Select-String (grep).\n" +
+			"  - no head/tail/which/touch: use Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n" +
+			"  - multi-line text to a native exe (e.g. git commit -m): use a single-quoted here-string @'...'@ (closing '@ at column 0)." +
+			bashToolSteer
 	}
-	return "Execute a command in the shell and return combined stdout/stderr. Use for builds, tests, git, etc."
+	return "Execute a command in the shell and return combined stdout/stderr." + bashToolSteer
 }
+
+// bashToolSteer points the model at the cross-platform built-in tools instead of
+// shell utilities, so it doesn't reach for grep/cat/ls/find (absent or different
+// on native Windows) when a native tool already does the job everywhere.
+const bashToolSteer = " Use for builds, tests, git, package managers, etc. To search/read/list/edit files, prefer the dedicated tools (grep, read_file, ls, glob, edit_file) over shell grep/cat/ls/find/sed — they behave identically on every OS."
 
 // resolved returns the bound shell, resolving lazily for the zero-value instance
 // (e.g. a registry that never went through ConfineBash).

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -2,11 +2,13 @@ package builtin
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -19,12 +21,19 @@ const grepMaxMatches = 200
 func init() { tool.RegisterBuiltin(grepTool{}) }
 
 // grepTool searches files by regex. workDir, when non-empty, is the directory a
-// relative path resolves against (see resolveIn).
-type grepTool struct{ workDir string }
+// relative path resolves against (see resolveIn). rg, when non-empty, is a
+// ripgrep binary the search delegates to instead of the native Go scanner.
+type grepTool struct {
+	workDir string
+	rg      string
+}
 
 func (grepTool) Name() string { return "grep" }
 
-func (grepTool) Description() string {
+func (g grepTool) Description() string {
+	if g.rg != "" {
+		return "Search for a regular expression in a file, or recursively under a directory — ripgrep-backed, so it honors .gitignore. Returns matching lines as path:line:text, capped at 200 matches."
+	}
 	return "Search for a regular expression in a file, or recursively under a directory. Returns matching lines as path:line:text, capped at 200 matches."
 }
 
@@ -49,6 +58,9 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 		p.Path = "."
 	}
 	p.Path = resolveIn(g.workDir, p.Path)
+	if g.rg != "" {
+		return g.runRipgrep(ctx, p.Pattern, p.Path)
+	}
 	re, err := regexp.Compile(p.Pattern)
 	if err != nil {
 		return "", fmt.Errorf("invalid pattern: %w", err)
@@ -118,4 +130,98 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 		res += fmt.Sprintf("\n... (truncated at %d matches)", grepMaxMatches)
 	}
 	return res, nil
+}
+
+// runRipgrep delegates the search to ripgrep, which already emits
+// path:line:text with these flags and honors .gitignore. Output is streamed and
+// capped at grepMaxMatches so a flood of hits can't blow up memory.
+func (g grepTool) runRipgrep(ctx context.Context, pattern, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, g.rg,
+		"--no-heading", "--line-number", "--with-filename", "--color", "never",
+		"--regexp", pattern, "--", path)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", err
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("ripgrep: %w", err)
+	}
+
+	var out []string
+	truncated := false
+	sc := bufio.NewScanner(stdout)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		out = append(out, sc.Text())
+		if len(out) >= grepMaxMatches {
+			truncated = true
+			break
+		}
+	}
+	if truncated {
+		_ = cmd.Process.Kill()
+	}
+	_, _ = io.Copy(io.Discard, stdout) // drain to EOF so Wait neither blocks nor races the reader
+	_ = cmd.Wait()
+
+	if len(out) == 0 {
+		// ripgrep exits 1 with no output for "no matches"; a real failure (bad
+		// pattern, unreadable path) writes a message to stderr.
+		if msg := strings.TrimSpace(stderr.String()); msg != "" {
+			return "", fmt.Errorf("ripgrep: %s", msg)
+		}
+		return "(no matches)", nil
+	}
+	res := strings.Join(out, "\n")
+	if truncated {
+		res += fmt.Sprintf("\n... (truncated at %d matches)", grepMaxMatches)
+	}
+	return res, nil
+}
+
+// SearchSpec configures the grep tool's engine. A non-empty RgPath makes grep
+// delegate to that ripgrep binary; empty uses the native Go scanner.
+type SearchSpec struct {
+	RgPath string
+}
+
+// ResolveSearch picks the grep engine from config. "native" forces the Go
+// scanner; "rg" requires ripgrep (warns and falls back to native if absent);
+// "auto"/"" uses ripgrep when found, else native. rgPath overrides the PATH
+// lookup. warn (may be nil) receives the fall-back notice for engine="rg".
+func ResolveSearch(engine, rgPath string, warn io.Writer) SearchSpec {
+	find := func() string {
+		if rgPath != "" {
+			if fi, err := os.Stat(rgPath); err == nil && !fi.IsDir() {
+				return rgPath
+			}
+			return ""
+		}
+		if p, err := exec.LookPath("rg"); err == nil {
+			return p
+		}
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(engine)) {
+	case "native":
+		return SearchSpec{}
+	case "rg":
+		if p := find(); p != "" {
+			return SearchSpec{RgPath: p}
+		}
+		if warn != nil {
+			fmt.Fprintln(warn, `warning: [tools.search] engine="rg" but ripgrep (rg) was not found; using the native search engine`)
+		}
+		return SearchSpec{}
+	default: // "auto", ""
+		return SearchSpec{RgPath: find()}
+	}
+}
+
+// ConfineSearch returns the grep built-in bound to a resolved search engine,
+// overriding the native instance registered at init.
+func ConfineSearch(spec SearchSpec) tool.Tool {
+	return grepTool{rg: spec.RgPath}
 }

--- a/internal/tool/builtin/grep_engine_test.go
+++ b/internal/tool/builtin/grep_engine_test.go
@@ -1,0 +1,69 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveSearch(t *testing.T) {
+	rgFile := filepath.Join(t.TempDir(), "rg")
+	if err := os.WriteFile(rgFile, []byte("x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	missing := filepath.Join(t.TempDir(), "absent")
+
+	if got := ResolveSearch("native", rgFile, nil); got.RgPath != "" {
+		t.Fatalf("native must ignore ripgrep, got %q", got.RgPath)
+	}
+	if got := ResolveSearch("rg", rgFile, nil); got.RgPath != rgFile {
+		t.Fatalf(`engine "rg" with an explicit path = %q, want %q`, got.RgPath, rgFile)
+	}
+	if got := ResolveSearch("auto", rgFile, nil); got.RgPath != rgFile {
+		t.Fatalf(`engine "auto" with an explicit path = %q, want %q`, got.RgPath, rgFile)
+	}
+
+	var warn bytes.Buffer
+	if got := ResolveSearch("rg", missing, &warn); got.RgPath != "" {
+		t.Fatalf(`engine "rg" with a missing binary must fall back to native, got %q`, got.RgPath)
+	}
+	if !strings.Contains(warn.String(), "ripgrep") {
+		t.Fatalf("expected a fall-back warning mentioning ripgrep, got %q", warn.String())
+	}
+}
+
+func TestConfineSearch(t *testing.T) {
+	g, ok := ConfineSearch(SearchSpec{RgPath: "/path/to/rg"}).(grepTool)
+	if !ok || g.rg != "/path/to/rg" {
+		t.Fatalf("ConfineSearch must bind the rg path, got %+v ok=%v", g, ok)
+	}
+}
+
+func TestGrepRipgrepEngine(t *testing.T) {
+	rg, err := exec.LookPath("rg")
+	if err != nil {
+		t.Skip("ripgrep not installed")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("alpha\nBETA needle here\ngamma\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	g := grepTool{rg: rg}
+
+	out := runTool(t, g, map[string]any{"pattern": "needle", "path": dir})
+	if !strings.Contains(out, "a.txt:2:BETA needle here") {
+		t.Fatalf("ripgrep output = %q, want path:line:text with the match", out)
+	}
+
+	if out := runTool(t, g, map[string]any{"pattern": "zzz_absent_token", "path": dir}); out != "(no matches)" {
+		t.Fatalf("no-match search = %q, want (no matches)", out)
+	}
+
+	if _, err := g.Execute(context.Background(), argsJSON(t, map[string]any{"pattern": "(unclosed", "path": dir})); err == nil {
+		t.Fatal("an invalid regex must surface ripgrep's error")
+	}
+}

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -22,6 +22,7 @@ type Workspace struct {
 	Dir        string
 	WriteRoots []string
 	Bash       sandbox.Spec
+	Search     SearchSpec
 }
 
 // Tools returns the built-in tools bound to the workspace, ready to Add to a
@@ -46,7 +47,7 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		bash{workDir: w.Dir, sb: w.Bash},
 		listDir{workDir: w.Dir},
 		globTool{workDir: w.Dir},
-		grepTool{workDir: w.Dir},
+		grepTool{workDir: w.Dir, rg: w.Search.RgPath},
 		webFetch{},
 	}
 	if len(enabled) == 0 {


### PR DESCRIPTION
Addresses user feedback: (1) better native-Windows support without needing Git Bash/MinGW/Cygwin, and (2) being able to specify the search binary (rg) at the tool level.

## Context

Our built-in tools are already native Go (grep via `regexp`, glob via `WalkDir`, read/write/edit/ls), so they don't depend on system unix utilities — that's the foundation of Windows-native support, and matches how Claude Code keeps Windows parity (native Read/Write/Edit/Glob, Grep on bundled ripgrep). This PR closes the two remaining gaps.

## 1. Windows steering (`bash.go`)

The shell tool already falls back to PowerShell when bash is absent, but the description only gave a one-line hint, so the model kept emitting bash that fails. Now:
- A full unix→PowerShell cheat-sheet in the description when running under PowerShell (chaining, `$null`/`$env:`, `Get-ChildItem`/`Get-Content`/`Remove-Item`, here-strings).
- Both branches now steer the model to the cross-platform built-in tools (`grep`/`read_file`/`ls`/`glob`/`edit_file`) instead of shell `grep`/`cat`/`ls`/`find` — so it leans on the shell less, which is what makes native Windows pleasant.

## 2. Ripgrep engine in the grep tool (`[tools.search]`)

Rather than rewriting bash `grep`→`rg` (the agent searches via the grep *tool*, not shell grep), the engine lives **inside the grep tool**:

```toml
[tools.search]
engine = "auto"   # "auto" (default) | "native" | "rg"
rg_path = ""      # optional explicit ripgrep path; else PATH lookup
```

- `auto` (default): delegate to ripgrep when it's on PATH, else native Go.
- `rg`: require ripgrep; warn at startup and fall back to native if absent.
- `native`: always the Go scanner (current behavior).

ripgrep is invoked to emit the same `path:line:text`, streamed and capped at the existing 200-match limit. Threaded through both assembly paths (boot `addBuiltins` and the ACP `Workspace`).

### ⚠️ Decision to confirm: default = `auto`

With `auto`, machines that have `rg` installed switch search to ripgrep, which **honors `.gitignore`** — i.e. it will *not* search gitignored files that the native scanner (fixed vendor-skip list) currently *would* search. Usually desirable (and faster), but it's a recall change. Easy to flip the default to `native` if we'd rather keep rg strictly opt-in.

## Tests

`go build ./...`, vet, and tool/cli/boot/config tests pass. New tests cover engine resolution (native/auto/rg, missing-binary fall-back + warning), `ConfineSearch` binding, and a real-ripgrep integration test (`path:line:text`, no-match, invalid-regex; skipped when rg is absent).
