### PR TITLE
docs: add Git commit convention to REASONIX.md

### DIFF
--- a/REASONIX.md
+++ b/REASONIX.md
@@ -42,7 +42,7 @@ agent. It is the Reasonix analog of Claude Code's CLAUDE.md.
 特性/影响：
 - <业务逻辑说明或影响范围>
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Reasonix <noreply@reasonix.com>
 ```
 
 ### 规则
@@ -51,7 +51,7 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 - **scope** 使用英文模块名（如 `agent`、`desktop`、`tool`、`control`）或工单号
 - **subject** 不超过 50 字，清晰描述改动
 - **强制多行提交**：必须包含详细描述、修改内容清单、影响范围
-- **强制 Co-Authored-By**：末尾必须追加 `Co-Authored-By: Claude <noreply@anthropic.com>`
+- **强制 Co-Authored-By**：末尾必须追加 `Co-Authored-By: Reasonix <noreply@reasonix.com>`
 - 提交信息必须结合实际改动生成，禁止空泛模板
 
 ### 示例
@@ -70,7 +70,7 @@ feat(desktop): add MCP drawer skill metadata badges
 - 用户可查看 MCP 工具的详细元数据
 - 技能展示增加版本和作者信息
 
-Co-Authored-By: Claude <noreply@anthropic.com>
+Co-Authored-By: Reasonix <noreply@reasonix.com>
 ```
 
 ## Notes

--- a/REASONIX.md
+++ b/REASONIX.md
@@ -25,4 +25,52 @@ agent. It is the Reasonix analog of Claude Code's CLAUDE.md.
   facts to the per-project auto-memory store (frontmatter files + `MEMORY.md`
   index), which loads into the prefix on the next session.
 
+## Git 提交规范
+
+遵循 [Conventional Commits](https://www.conventionalcommits.org/) 规范，同时满足以下要求：
+
+### 提交格式
+
+```
+<type>(<scope>): <subject>
+
+<详细描述背景、修改内容和核心逻辑>
+
+修改内容：
+- <文件/模块> <具体改动>
+
+特性/影响：
+- <业务逻辑说明或影响范围>
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### 规则
+
+- **type** 限定：`feat`、`fix`、`docs`、`style`、`refactor`、`test`、`chore`、`perf`、`ci`、`build`、`revert`
+- **scope** 使用英文模块名（如 `agent`、`desktop`、`tool`、`control`）或工单号
+- **subject** 不超过 50 字，清晰描述改动
+- **强制多行提交**：必须包含详细描述、修改内容清单、影响范围
+- **强制 Co-Authored-By**：末尾必须追加 `Co-Authored-By: Claude <noreply@anthropic.com>`
+- 提交信息必须结合实际改动生成，禁止空泛模板
+
+### 示例
+
+```bash
+feat(desktop): add MCP drawer skill metadata badges
+
+详细描述：
+新增 MCP 抽屉中的技能元数据徽章展示，包括版本、作者信息
+
+修改内容：
+- internal/desktop/mcp_drawer.go 新增详情面板布局
+- internal/desktop/skill_badge.go 实现元数据徽章组件
+
+特性/影响：
+- 用户可查看 MCP 工具的详细元数据
+- 技能展示增加版本和作者信息
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
 ## Notes


### PR DESCRIPTION
## 变更说明

在 REASONIX.md 中添加了 Git 提交规范，兼容 Conventional Commits 标准，同时保持原有的严格要求。

### 主要改动

1. **扩展 type 列表**：在原有 7 种类型基础上增加了 、、、，兼容 Conventional Commits 全部 11 种类型

2. **明确 scope 规范**：使用英文模块名（如 、、、）或工单号

3. **保留严格要求**：
   - 强制多行提交（详细描述 + 修改内容清单 + 影响范围）
   - 强制 Co-Authored-By
   - subject 不超过 50 字

4. **提供完整示例**：展示符合规范的提交信息格式

### 提交格式示例



### 规则

- **type** 限定：、、、、、、、、、、
- **scope** 使用英文模块名或工单号
- **subject** 不超过 50 字，清晰描述改动
- **强制多行提交**：必须包含详细描述、修改内容清单、影响范围
- **强制 Co-Authored-By**：末尾必须追加 

### 测试

已按新规范提交了两个 commit：
- 
- 

提交信息均符合新规范格式。