### PR TITLE
feat: auto-discover models from provider APIs (FetchModels)

### DIFF
--- a/internal/config/fetch.go
+++ b/internal/config/fetch.go
@@ -1,0 +1,81 @@
+// fetch.go — model auto-discovery via the OpenAI-compatible GET /models API.
+//
+// ProviderEntry.FetchModels calls the provider's /models endpoint and returns
+// the available model IDs. This is used by the setup wizard and /providers add
+// to auto-populate the models list instead of requiring users to type them.
+//
+// The function is NOT called during normal config loading (that would add
+// latency and require a network connection). It is only invoked when the user
+// interactively configures a provider.
+package config
+
+import (
+	"context"
+	"fmt"
+
+	"reasonix/internal/provider/openai"
+)
+
+// FetchModels queries the provider's OpenAI-compatible GET /models endpoint and
+// returns the available model IDs, sorted alphabetically. It uses the entry's
+// base_url and resolves the API key from api_key_env. The caller should handle
+// errors gracefully and fall back to hardcoded presets when the API is
+// unreachable.
+//
+// Example usage:
+//
+//	ids, err := entry.FetchModels(ctx)
+//	if err != nil {
+//	    log.Printf("fetch models failed: %v — using presets", err)
+//	    ids = presetModels
+//	}
+func (e *ProviderEntry) FetchModels(ctx context.Context) ([]string, error) {
+	if e.BaseURL == "" {
+		return nil, fmt.Errorf("fetch models: provider %q has no base_url", e.Name)
+	}
+	key := e.APIKey()
+	if key == "" {
+		return nil, fmt.Errorf("fetch models: provider %q has no API key (set %s in .env)", e.Name, e.APIKeyEnv)
+	}
+	return openai.FetchModels(ctx, e.BaseURL, key)
+}
+
+// RefreshModels fetches the latest model list from the provider's API and
+// updates the entry's Models field in place. It returns the new model list
+// and whether it changed from the previous value. The caller is responsible
+// for persisting the config (cfg.Save()) after calling this.
+func (e *ProviderEntry) RefreshModels(ctx context.Context) (models []string, changed bool, err error) {
+	models, err = e.FetchModels(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(models) == 0 {
+		return nil, false, fmt.Errorf("fetch models: provider %q returned empty model list", e.Name)
+	}
+	prev := e.Models
+	e.Models = models
+	// Update default if it no longer exists in the new list
+	if e.Default != "" && !e.HasModel(e.Default) {
+		e.Default = models[0]
+	}
+	// Update single model for back-compat single-model entries
+	if e.Model != "" && !e.HasModel(e.Model) {
+		e.Model = models[0]
+	}
+	changed = !stringSliceEqual(prev, models)
+	return models, changed, nil
+}
+
+// stringSliceEqual reports whether two string slices have the same elements in
+// the same order.
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/config/fetch_test.go
+++ b/internal/config/fetch_test.go
@@ -1,0 +1,133 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProviderEntryFetchModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data": []map[string]string{
+				{"id": "model-b", "object": "model"},
+				{"id": "model-a", "object": "model"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("TEST_API_KEY", "sk-test")
+
+	e := ProviderEntry{
+		Name:      "test",
+		Kind:      "openai",
+		BaseURL:   srv.URL,
+		APIKeyEnv: "TEST_API_KEY",
+	}
+
+	models, err := e.FetchModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("want 2 models, got %d", len(models))
+	}
+	if models[0] != "model-a" || models[1] != "model-b" {
+		t.Errorf("want sorted [model-a model-b], got %v", models)
+	}
+}
+
+func TestProviderEntryFetchModelsNoKey(t *testing.T) {
+	e := ProviderEntry{
+		Name:      "test",
+		BaseURL:   "http://localhost",
+		APIKeyEnv: "NONEXISTENT_KEY",
+	}
+	_, err := e.FetchModels(context.Background())
+	if err == nil {
+		t.Fatal("expected error for missing key")
+	}
+}
+
+func TestProviderEntryRefreshModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data": []map[string]string{
+				{"id": "new-model", "object": "model"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("TEST_API_KEY", "sk-test")
+
+	e := ProviderEntry{
+		Name:      "test",
+		Kind:      "openai",
+		BaseURL:   srv.URL,
+		APIKeyEnv: "TEST_API_KEY",
+		Model:     "old-model",
+		Models:    []string{"old-model"},
+		Default:   "old-model",
+	}
+
+	models, changed, err := e.RefreshModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Error("expected changed=true")
+	}
+	if len(models) != 1 || models[0] != "new-model" {
+		t.Errorf("want [new-model], got %v", models)
+	}
+	if e.Model != "new-model" {
+		t.Errorf("want Model=new-model, got %s", e.Model)
+	}
+	if e.Default != "new-model" {
+		t.Errorf("want Default=new-model, got %s", e.Default)
+	}
+}
+
+func TestProviderEntryRefreshModelsKeepsDefault(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"object": "list",
+			"data": []map[string]string{
+				{"id": "also-me", "object": "model"},
+				{"id": "keep-me", "object": "model"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	t.Setenv("TEST_API_KEY", "sk-test")
+
+	e := ProviderEntry{
+		Name:      "test",
+		BaseURL:   srv.URL,
+		APIKeyEnv: "TEST_API_KEY",
+		Models:    []string{"also-me", "keep-me"},
+		Default:   "keep-me",
+	}
+
+	_, changed, err := e.RefreshModels(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("expected changed=false (same models)")
+	}
+	if e.Default != "keep-me" {
+		t.Errorf("want Default=keep-me, got %s", e.Default)
+	}
+}

--- a/internal/provider/openai/fetch_models.go
+++ b/internal/provider/openai/fetch_models.go
@@ -1,0 +1,85 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// FetchModels calls the OpenAI-compatible GET /models endpoint and returns the
+// available model IDs. It works with DeepSeek, MiMo, and any backend that
+// implements the standard models listing API. The caller provides baseURL
+// (e.g. "https://api.deepseek.com" or "https://api.xiaomimimo.com/v1") and
+// a valid API key. On success the IDs are sorted alphabetically.
+//
+// This function is intended for interactive use (setup wizard, /providers add)
+// and uses a short timeout; it is NOT called during normal config loading.
+func FetchModels(ctx context.Context, baseURL, apiKey string) ([]string, error) {
+	return fetchModelsWithClient(ctx, baseURL, apiKey, &http.Client{
+		Timeout: 10 * time.Second,
+	})
+}
+
+// fetchModelsWithClient is the testable core; callers can inject a mock client.
+func fetchModelsWithClient(ctx context.Context, baseURL, apiKey string, cli *http.Client) ([]string, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("fetch models: base_url is required")
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("fetch models: api_key is required")
+	}
+
+	url := strings.TrimRight(baseURL, "/") + "/models"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetch models: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := cli.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch models: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 256*1024))
+	if err != nil {
+		return nil, fmt.Errorf("fetch models: read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch models: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var result modelsResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("fetch models: decode response: %w", err)
+	}
+
+	ids := make([]string, 0, len(result.Data))
+	for _, m := range result.Data {
+		if m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// modelsResponse is the wire format for GET /models.
+type modelsResponse struct {
+	Object string       `json:"object"`
+	Data   []modelEntry `json:"data"`
+}
+
+type modelEntry struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	OwnedBy string `json:"owned_by"`
+}

--- a/internal/provider/openai/fetch_models_test.go
+++ b/internal/provider/openai/fetch_models_test.go
@@ -1,0 +1,82 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFetchModels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer test-key" {
+			http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+			return
+		}
+		json.NewEncoder(w).Encode(modelsResponse{
+			Object: "list",
+			Data: []modelEntry{
+				{ID: "deepseek-v4-pro", Object: "model", OwnedBy: "deepseek"},
+				{ID: "deepseek-v4-flash", Object: "model", OwnedBy: "deepseek"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	models, err := FetchModels(context.Background(), srv.URL, "test-key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 2 {
+		t.Fatalf("want 2 models, got %d", len(models))
+	}
+	if models[0] != "deepseek-v4-flash" || models[1] != "deepseek-v4-pro" {
+		t.Errorf("want sorted [deepseek-v4-flash deepseek-v4-pro], got %v", models)
+	}
+}
+
+func TestFetchModelsAuthError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"invalid key"}}`, http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := FetchModels(context.Background(), srv.URL, "bad-key")
+	if err == nil {
+		t.Fatal("expected error for bad key")
+	}
+}
+
+func TestFetchModelsEmptyKey(t *testing.T) {
+	_, err := FetchModels(context.Background(), "http://localhost", "")
+	if err == nil {
+		t.Fatal("expected error for empty key")
+	}
+}
+
+func TestFetchModelsEmptyBaseURL(t *testing.T) {
+	_, err := FetchModels(context.Background(), "", "key")
+	if err == nil {
+		t.Fatal("expected error for empty base_url")
+	}
+}
+
+func TestFetchModelsEmptyResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(modelsResponse{Object: "list", Data: nil})
+	}))
+	defer srv.Close()
+
+	models, err := FetchModels(context.Background(), srv.URL, "key")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(models) != 0 {
+		t.Errorf("want empty list, got %v", models)
+	}
+}


### PR DESCRIPTION
## Summary

- Auto-discover available models from provider `GET /models` API endpoint
- `FetchModels(ctx, baseURL, apiKey)` function for DeepSeek, MiMo, and any OpenAI-compatible endpoint
- `ProviderEntry.FetchModels/RefreshModels` methods for config layer integration
- Unit tests with mock HTTP server

## Demo

![auto-discover-models-demo](https://github.com/user-attachments/assets/f77b0f16-4699-459a-812c-381ef86f0263)

## Changes

### New Files
- `internal/provider/openai/fetch_models.go` — `FetchModels` function
- `internal/config/fetch.go` — `ProviderEntry.FetchModels/RefreshModels` methods
- `internal/provider/openai/fetch_models_test.go` — Unit tests
- `internal/config/fetch_test.go` — Unit tests

## Design

- Calls `GET {base_url}/models` with `Authorization: Bearer {api_key}`
- Returns sorted list of model IDs
- Short timeout (10s) for interactive use
- Graceful error handling with actionable messages
- NOT called during normal config loading (only interactive setup)

## Testing

- Unit tests for normal response, auth error, empty key, empty URL, empty response
- All tests pass (`go test ./internal/config/ ./internal/provider/openai/`)

## Related

Closes #2657