### PR TITLE
fix: resolve stdio MCP commands with effective PATH

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -690,11 +690,3 @@ func parseToolResult(res json.RawMessage) (string, error) {
 	}
 	return text, nil
 }
-
-func envSlice(m map[string]string) []string {
-	out := make([]string, 0, len(m))
-	for k, v := range m {
-		out = append(out, k+"="+v)
-	}
-	return out
-}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -218,6 +218,29 @@ func TestStdioCommandNotFoundSuggestsPATHFix(t *testing.T) {
 	}
 }
 
+func TestStdioIgnoresRelativePATHEntries(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	name := "mock-mcp"
+	target := filepath.Join(bin, name)
+	env := []string{"PATH=bin"}
+	if runtime.GOOS == "windows" {
+		target += ".cmd"
+		env = append(env, "PATHEXT=.CMD")
+	}
+	if err := os.WriteFile(target, []byte(""), 0o755); err != nil {
+		t.Fatalf("write fake executable: %v", err)
+	}
+	t.Chdir(dir)
+
+	if exe, ok := lookPathInEnv(name, env); ok {
+		t.Fatalf("relative PATH entry resolved to %q; want no match", exe)
+	}
+}
+
 func helperLauncher(t *testing.T, name string) (dir, command string) {
 	t.Helper()
 	if runtime.GOOS == "windows" {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -136,6 +138,103 @@ func TestStdioFailureCapturesStderr(t *testing.T) {
 	if !strings.Contains(failures[0].Error, "helper stderr boom") {
 		t.Fatalf("failure should include stderr, got %q", failures[0].Error)
 	}
+}
+
+func TestStdioUsesConfiguredPATHForCommandLookup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dir, command := helperLauncher(t, "mock-mcp")
+	t.Setenv("PATH", "")
+
+	host, tools, err := StartAll(ctx, []Spec{{
+		Name:    "path",
+		Command: command,
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS": "1",
+			"PATH":                   dir,
+		},
+	}})
+	if err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+	defer host.Close()
+	if len(tools) != 2 {
+		t.Fatalf("want helper tools, got %d", len(tools))
+	}
+}
+
+func TestStdioFallsBackToShellPATHForCommandLookup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dir, command := helperLauncher(t, "shell-mcp")
+	t.Setenv("PATH", "")
+	old := stdioShellPATH
+	stdioShellPATH = func(context.Context) string { return dir }
+	t.Cleanup(func() { stdioShellPATH = old })
+
+	host, tools, err := StartAll(ctx, []Spec{{
+		Name:    "shell-path",
+		Command: command,
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env:     map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
+	}})
+	if err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+	defer host.Close()
+	if len(tools) != 2 {
+		t.Fatalf("want helper tools, got %d", len(tools))
+	}
+}
+
+func TestStdioCommandNotFoundSuggestsPATHFix(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	t.Setenv("PATH", "")
+	old := stdioShellPATH
+	stdioShellPATH = func(context.Context) string { return "" }
+	t.Cleanup(func() { stdioShellPATH = old })
+
+	host, _ := StartAvailable(ctx, []Spec{{Name: "missing", Command: "reasonix-missing-mcp-binary"}})
+	defer host.Close()
+
+	failures := host.Failures()
+	if len(failures) != 1 {
+		t.Fatalf("failures = %+v, want one", failures)
+	}
+	msg := failures[0].Error
+	for _, want := range []string{
+		`command "reasonix-missing-mcp-binary" not found on PATH`,
+		"absolute command path",
+		"MCP server env",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("failure %q missing %q", msg, want)
+		}
+	}
+}
+
+func helperLauncher(t *testing.T, name string) (dir, command string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell launcher fixture is POSIX-only")
+	}
+	dir = t.TempDir()
+	command = name
+	target := filepath.Join(dir, name)
+	script := "#!/bin/sh\nexec " + shellQuote(os.Args[0]) + " \"$@\"\n"
+	if err := os.WriteFile(target, []byte(script), 0o755); err != nil {
+		t.Fatalf("write helper launcher: %v", err)
+	}
+	return dir, command
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
 // TestHelperProcess is not a real test; it acts as a minimal MCP stdio server

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -9,8 +9,11 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 // stdioTransport speaks newline-delimited JSON-RPC 2.0 over a subprocess's
@@ -38,11 +41,16 @@ type stdioTransport struct {
 }
 
 func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
-	if s.Command == "" {
+	if strings.TrimSpace(s.Command) == "" {
 		return nil, fmt.Errorf("stdio plugin %q: command is required", s.Name)
 	}
-	cmd := exec.CommandContext(ctx, s.Command, s.Args...)
-	cmd.Env = append(os.Environ(), envSlice(s.Env)...)
+	env := mergeEnv(os.Environ(), s.Env)
+	exe, env, err := resolveStdioExecutable(ctx, s, env)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, exe, s.Args...)
+	cmd.Env = env
 	if s.Dir != "" {
 		cmd.Dir = s.Dir // pin cwd-aware servers (e.g. CodeGraph) to the project root
 	}
@@ -73,6 +81,212 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	}
 	go t.readLoop()
 	return t, nil
+}
+
+var stdioShellPATH = defaultStdioShellPATH
+
+func resolveStdioExecutable(ctx context.Context, s Spec, env []string) (string, []string, error) {
+	if hasPathSeparator(s.Command) {
+		return s.Command, env, nil
+	}
+	if exe, ok := lookPathInEnv(s.Command, env); ok {
+		return exe, env, nil
+	}
+
+	currentPath, _ := envValue(env, "PATH")
+	if shellPath := strings.TrimSpace(stdioShellPATH(ctx)); shellPath != "" {
+		fallbackPath := mergePathLists(shellPath, currentPath)
+		if fallbackPath != currentPath {
+			fallbackEnv := setEnvValue(env, "PATH", fallbackPath)
+			if exe, ok := lookPathInEnv(s.Command, fallbackEnv); ok {
+				return exe, fallbackEnv, nil
+			}
+			env = fallbackEnv
+			currentPath = fallbackPath
+		}
+	}
+
+	return "", env, fmt.Errorf("stdio plugin %q: command %q not found on PATH; GUI launches and non-interactive sessions may not inherit your shell PATH. Use an absolute command path or set PATH in the MCP server env. PATH=%q",
+		s.Name, s.Command, currentPath)
+}
+
+func hasPathSeparator(s string) bool {
+	return strings.ContainsAny(s, `/\`)
+}
+
+func lookPathInEnv(command string, env []string) (string, bool) {
+	path, _ := envValue(env, "PATH")
+	pathext, _ := envValue(env, "PATHEXT")
+	for _, dir := range filepath.SplitList(path) {
+		if dir == "" {
+			continue
+		}
+		for _, name := range executableNames(command, pathext) {
+			candidate := filepath.Join(dir, name)
+			if isExecutableFile(candidate) {
+				return candidate, true
+			}
+		}
+	}
+	return "", false
+}
+
+func executableNames(command, pathext string) []string {
+	if runtime.GOOS != "windows" || filepath.Ext(command) != "" {
+		return []string{command}
+	}
+	if strings.TrimSpace(pathext) == "" {
+		pathext = ".COM;.EXE;.BAT;.CMD"
+	}
+	names := []string{command}
+	seen := map[string]bool{strings.ToLower(command): true}
+	for _, ext := range strings.Split(pathext, ";") {
+		ext = strings.TrimSpace(ext)
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		name := command + ext
+		key := strings.ToLower(name)
+		if !seen[key] {
+			seen[key] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+func defaultStdioShellPATH(ctx context.Context) string {
+	if runtime.GOOS == "windows" {
+		return ""
+	}
+	shell := stdioShell()
+	if shell == "" {
+		return ""
+	}
+	const marker = "__REASONIX_PATH__="
+	script := "printf '\\n" + marker + "%s\\n' \"$PATH\""
+	for _, args := range [][]string{
+		{"-l", "-i", "-c", script},
+		{"-l", "-c", script},
+		{"-c", script},
+	} {
+		out := runShellPATHCommand(ctx, shell, args)
+		if path := parseShellPATH(out, marker); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func stdioShell() string {
+	if shell := strings.TrimSpace(os.Getenv("SHELL")); shell != "" {
+		if hasPathSeparator(shell) {
+			if isExecutableFile(shell) {
+				return shell
+			}
+		} else if exe, ok := lookPathInEnv(shell, os.Environ()); ok {
+			return exe
+		}
+	}
+	for _, shell := range []string{"/bin/zsh", "/bin/bash", "/bin/sh"} {
+		if isExecutableFile(shell) {
+			return shell
+		}
+	}
+	return ""
+}
+
+func runShellPATHCommand(parent context.Context, shell string, args []string) []byte {
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, shell, args...)
+	cmd.Stdin = strings.NewReader("")
+	out, _ := cmd.CombinedOutput()
+	return out
+}
+
+func parseShellPATH(out []byte, marker string) string {
+	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.HasPrefix(lines[i], marker) {
+			return strings.TrimSpace(strings.TrimPrefix(lines[i], marker))
+		}
+	}
+	return ""
+}
+
+func mergeEnv(base []string, overrides map[string]string) []string {
+	out := append([]string(nil), base...)
+	for k, v := range overrides {
+		out = setEnvValue(out, k, v)
+	}
+	return out
+}
+
+func setEnvValue(env []string, key, value string) []string {
+	out := make([]string, 0, len(env)+1)
+	replaced := false
+	for _, kv := range env {
+		k, _, ok := strings.Cut(kv, "=")
+		if ok && envKeyEqual(k, key) {
+			if !replaced {
+				out = append(out, key+"="+value)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !replaced {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func envValue(env []string, key string) (string, bool) {
+	for i := len(env) - 1; i >= 0; i-- {
+		k, v, ok := strings.Cut(env[i], "=")
+		if ok && envKeyEqual(k, key) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func envKeyEqual(a, b string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func mergePathLists(primary, secondary string) string {
+	var out []string
+	seen := map[string]bool{}
+	for _, path := range []string{primary, secondary} {
+		for _, dir := range filepath.SplitList(path) {
+			if dir == "" || seen[dir] {
+				continue
+			}
+			seen[dir] = true
+			out = append(out, dir)
+		}
+	}
+	return strings.Join(out, string(os.PathListSeparator))
 }
 
 // readLoop owns stdout for the transport's lifetime: it reads one JSON-RPC

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -118,7 +118,7 @@ func lookPathInEnv(command string, env []string) (string, bool) {
 	path, _ := envValue(env, "PATH")
 	pathext, _ := envValue(env, "PATHEXT")
 	for _, dir := range filepath.SplitList(path) {
-		if dir == "" {
+		if dir == "" || !filepath.IsAbs(dir) {
 			continue
 		}
 		for _, name := range executableNames(command, pathext) {

--- a/internal/plugin/transport_stdio_windows_test.go
+++ b/internal/plugin/transport_stdio_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -23,7 +24,7 @@ func TestResolveStdioExecutableWindowsPathAndPATHEXT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveStdioExecutable: %v", err)
 	}
-	if exe != npx {
+	if !strings.EqualFold(exe, npx) {
 		t.Fatalf("resolved executable = %q, want %q", exe, npx)
 	}
 	if got, ok := envValue(env, "PATH"); !ok || got != dir {

--- a/internal/plugin/transport_stdio_windows_test.go
+++ b/internal/plugin/transport_stdio_windows_test.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package plugin
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveStdioExecutableWindowsPathAndPATHEXT(t *testing.T) {
+	dir := t.TempDir()
+	npx := filepath.Join(dir, "npx.cmd")
+	if err := os.WriteFile(npx, []byte("@echo off\r\n"), 0o644); err != nil {
+		t.Fatalf("write fake npx.cmd: %v", err)
+	}
+
+	exe, env, err := resolveStdioExecutable(context.Background(), Spec{Name: "fs", Command: "npx"}, []string{
+		"Path=" + dir,
+		"PATHEXT=.CMD;.EXE",
+	})
+	if err != nil {
+		t.Fatalf("resolveStdioExecutable: %v", err)
+	}
+	if exe != npx {
+		t.Fatalf("resolved executable = %q, want %q", exe, npx)
+	}
+	if got, ok := envValue(env, "PATH"); !ok || got != dir {
+		t.Fatalf("env PATH = %q, %v; want %q, true", got, ok, dir)
+	}
+}
+
+func TestSetEnvValueWindowsReplacesPathCaseInsensitively(t *testing.T) {
+	env := setEnvValue([]string{"Path=C:\\old", "OTHER=x"}, "PATH", "C:\\new")
+	if got, ok := envValue(env, "Path"); !ok || got != "C:\\new" {
+		t.Fatalf("env Path = %q, %v; want C:\\new, true", got, ok)
+	}
+	if len(env) != 2 {
+		t.Fatalf("setEnvValue should replace Path instead of appending PATH, got %v", env)
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve stdio MCP commands against the effective environment before spawning, so configured PATH entries can locate commands like npx.
- Add a shell-derived PATH fallback for GUI/non-interactive launches on Unix-like platforms while still execing the resolved executable directly.
- Add regression coverage for configured PATH, shell PATH fallback, actionable command-not-found errors, and Windows PATHEXT/Path handling.

## Tests
- go test -count=1 ./internal/plugin
- HOME=$(mktemp -d) go test -count=1 ./internal/plugin ./internal/boot ./internal/cli
- GOOS=windows GOARCH=amd64 go test -run TestResolveStdioExecutableWindowsPathAndPATHEXT -c ./internal/plugin