### PR TITLE
fix(desktop): keep transcript pinned when approval shelf appears

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -163,6 +163,8 @@ export default function App() {
   const [capsOpen, setCapsOpen] = useState(false);
   const [pendingPlanRevision, setPendingPlanRevision] = useState<string | null>(null);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
+  const [footerHeight, setFooterHeight] = useState(0);
+  const footerRef = useRef<HTMLElement>(null);
   const sidebarBeforeWorkspacePreviewRef = useRef<boolean | null>(null);
   const effectiveSidebarWidth = sidebarCollapsed ? SIDEBAR_COLLAPSED_WIDTH : sidebarWidth;
   const effectiveWorkspacePanelWidth = useMemo(
@@ -273,6 +275,16 @@ export default function App() {
     const onResize = () => setViewportWidth(window.innerWidth);
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  useEffect(() => {
+    const el = footerRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const update = () => setFooterHeight(Math.round(el.getBoundingClientRect().height));
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(el);
+    return () => observer.disconnect();
   }, []);
 
   useEffect(() => {
@@ -708,11 +720,11 @@ export default function App() {
                 <span className="loading-screen__text">{t("common.loading")}</span>
               </div>
             ) : (
-              <Transcript items={state.items} onPrompt={send} onRewind={rewind} />
+              <Transcript items={state.items} footerHeight={footerHeight} onPrompt={send} onRewind={rewind} />
             )}
           </main>
 
-          <footer className="footer">
+          <footer className="footer" ref={footerRef}>
             {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
             {state.approval && (
               <ApprovalModal

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -67,11 +67,11 @@ export function Transcript({
     lastClientHeight.current = el.clientHeight;
     const observer = new ResizeObserver(() => {
       const previousHeight = lastClientHeight.current ?? el.clientHeight;
-      const heightDelta = Math.abs(el.clientHeight - previousHeight);
+      const heightDelta = el.clientHeight - previousHeight;
       lastClientHeight.current = el.clientHeight;
       const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      const stillPinnedByResize = bottomDistance < heightDelta + 80;
-      if (!stick.current && !stillPinnedByResize) return;
+      const wasPinnedBeforeResize = bottomDistance + heightDelta < 80;
+      if (!stick.current && !wasPinnedBeforeResize) return;
       stick.current = true;
       if (resizeFrame.current !== null) cancelAnimationFrame(resizeFrame.current);
       resizeFrame.current = requestAnimationFrame(() => {
@@ -93,11 +93,11 @@ export function Transcript({
     const el = scrollRef.current;
     if (!el) return;
     const previousHeight = lastFooterHeight.current ?? footerHeight;
-    const heightDelta = Math.abs(footerHeight - previousHeight);
+    const heightDelta = footerHeight - previousHeight;
     lastFooterHeight.current = footerHeight;
     const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const stillPinnedByFooterResize = bottomDistance < heightDelta + 80;
-    if (!stick.current && !stillPinnedByFooterResize) return;
+    const wasPinnedBeforeFooterResize = bottomDistance - heightDelta < 80;
+    if (!stick.current && !wasPinnedBeforeFooterResize) return;
     stick.current = true;
     const id = requestAnimationFrame(() => {
       if (stick.current) el.scrollTop = el.scrollHeight;

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -23,10 +23,12 @@ function scrollVersion(items: Item[]): string {
 
 export function Transcript({
   items,
+  footerHeight = 0,
   onPrompt,
   onRewind,
 }: {
   items: Item[];
+  footerHeight?: number;
   onPrompt: (text: string) => void;
   onRewind?: (turn: number, scope: string) => void;
 }) {
@@ -34,6 +36,9 @@ export function Transcript({
   // stick tracks whether the view is pinned to the bottom; once the user scrolls
   // up to read, we stop yanking them back down.
   const stick = useRef(true);
+  const resizeFrame = useRef<number | null>(null);
+  const lastClientHeight = useRef<number | null>(null);
+  const lastFooterHeight = useRef<number | null>(null);
 
   const onScroll = () => {
     const el = scrollRef.current;
@@ -55,6 +60,50 @@ export function Transcript({
     });
     return () => cancelAnimationFrame(id);
   }, [contentVersion]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    lastClientHeight.current = el.clientHeight;
+    const observer = new ResizeObserver(() => {
+      const previousHeight = lastClientHeight.current ?? el.clientHeight;
+      const heightDelta = Math.abs(el.clientHeight - previousHeight);
+      lastClientHeight.current = el.clientHeight;
+      const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      const stillPinnedByResize = bottomDistance < heightDelta + 80;
+      if (!stick.current && !stillPinnedByResize) return;
+      stick.current = true;
+      if (resizeFrame.current !== null) cancelAnimationFrame(resizeFrame.current);
+      resizeFrame.current = requestAnimationFrame(() => {
+        if (stick.current) el.scrollTop = el.scrollHeight;
+        resizeFrame.current = null;
+      });
+    });
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      if (resizeFrame.current !== null) {
+        cancelAnimationFrame(resizeFrame.current);
+        resizeFrame.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const previousHeight = lastFooterHeight.current ?? footerHeight;
+    const heightDelta = Math.abs(footerHeight - previousHeight);
+    lastFooterHeight.current = footerHeight;
+    const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const stillPinnedByFooterResize = bottomDistance < heightDelta + 80;
+    if (!stick.current && !stillPinnedByFooterResize) return;
+    stick.current = true;
+    const id = requestAnimationFrame(() => {
+      if (stick.current) el.scrollTop = el.scrollHeight;
+    });
+    return () => cancelAnimationFrame(id);
+  }, [footerHeight]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.


### PR DESCRIPTION
Follow-up to #2663 for the review note in https://github.com/esengine/DeepSeek-Reasonix/pull/2663#discussion_r3338599081.

## Summary
- observe the desktop footer height and pass it to `Transcript`
- re-pin the transcript only when it was already sticky, or when the bottom gap is explained by the footer height delta
- preserve the user-scrolled-up state when the approval shelf appears

## Validation
- `npm run build` in `desktop/frontend`
- Browser DOM check on local Vite: pinned transcript stays at bottom distance 0 after shelf insertion; manually scrolled-up transcript remains scrolled up after shelf insertion