### PR TITLE
feat(memory): add idle daily auto summaries

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -57,6 +57,14 @@ What is still in progress or unstarted, and the single most concrete next action
 
 Rules: be terse — bullet points and fragments, not prose. Preserve identifiers, paths, and numbers exactly. Do NOT invent anything not present in the messages; if something is unknown, leave it out rather than guessing.`
 
+const dailyMemorySystemPrompt = `You are updating daily long-term memory for a coding-agent user.
+Merge the existing daily summary with the new transcript incrementally.
+
+Keep only durable information that helps future sessions: user preferences, project decisions, corrections, constraints, active goals, important external references, and unresolved follow-ups.
+Drop ephemeral chatter, obvious tool mechanics, repeated details already covered by the existing summary, and anything already recorded in files or git history unless the transcript adds a non-obvious decision about it.
+Write concise Markdown bullets or short sections. Do NOT invent facts. If the new transcript adds nothing durable, return the existing summary unchanged.
+Output the complete replacement daily summary only.`
+
 // maybeCompact compacts the session when the last turn's prompt has grown to the
 // configured fraction of the context window. It is a no-op when compaction is
 // disabled (no window) or usage is unavailable.
@@ -357,6 +365,68 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 		return "", fmt.Errorf("summarizer returned empty output")
 	}
 	return s, nil
+}
+
+// SummarizeDailyMemory distills a new slice of conversation into one complete
+// replacement for a day's long-term memory summary. It uses the executor's own
+// provider without tools, like compaction, but it does not rewrite the live
+// session: callers persist the returned text through memory.Store.
+func (a *Agent) SummarizeDailyMemory(ctx context.Context, day, existing string, region []provider.Message) (string, error) {
+	region = memorySummaryMessages(region)
+	if len(region) == 0 {
+		return strings.TrimSpace(existing), nil
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Date: %s\n\n", strings.TrimSpace(day))
+	b.WriteString("Existing daily summary:\n")
+	if strings.TrimSpace(existing) == "" {
+		b.WriteString("(none)\n")
+	} else {
+		b.WriteString(strings.TrimSpace(existing))
+		b.WriteString("\n")
+	}
+	b.WriteString("\nNew conversation transcript:\n")
+	b.WriteString(renderTranscript(region))
+
+	ch, err := a.prov.Stream(ctx, provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleSystem, Content: dailyMemorySystemPrompt},
+			{Role: provider.RoleUser, Content: b.String()},
+		},
+		Temperature: a.temperature,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var out strings.Builder
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkText:
+			out.WriteString(chunk.Text)
+		case provider.ChunkError:
+			return "", chunk.Err
+		}
+	}
+	s := strings.TrimSpace(out.String())
+	if s == "" {
+		return "", fmt.Errorf("daily memory summarizer returned empty output")
+	}
+	return s, nil
+}
+
+func memorySummaryMessages(msgs []provider.Message) []provider.Message {
+	out := make([]provider.Message, 0, len(msgs))
+	for _, m := range msgs {
+		if m.Role == provider.RoleSystem {
+			continue
+		}
+		if strings.TrimSpace(m.Content) == "" && len(m.ToolCalls) == 0 {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // renderTranscript flattens messages into a readable transcript for summarization.

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -228,6 +228,44 @@ func TestCompactInjectsFocusAndPreCompactHook(t *testing.T) {
 	}
 }
 
+func TestSummarizeDailyMemoryMergesPreviousSummary(t *testing.T) {
+	prov := &fakeProvider{reply: "- Kept the important decision"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "switch to the Go rewrite"},
+		{Role: provider.RoleAssistant, Content: "noted"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{}, event.Discard)
+
+	got, err := a.SummarizeDailyMemory(context.Background(), "2026-06-02", "Previous summary", sess.Messages[1:])
+	if err != nil {
+		t.Fatalf("SummarizeDailyMemory: %v", err)
+	}
+	if got != "- Kept the important decision" {
+		t.Fatalf("summary = %q", got)
+	}
+	if len(prov.got) != 2 {
+		t.Fatalf("summarizer messages = %d, want 2: %+v", len(prov.got), prov.got)
+	}
+	sys := prov.got[0].Content
+	if !strings.Contains(sys, "daily long-term memory") || !strings.Contains(sys, "incrementally") {
+		t.Fatalf("system prompt should describe incremental daily memory, got %q", sys)
+	}
+	user := prov.got[1].Content
+	if !strings.Contains(user, "Date: 2026-06-02") {
+		t.Errorf("request missing date: %q", user)
+	}
+	if !strings.Contains(user, "Previous summary") {
+		t.Errorf("request missing previous summary: %q", user)
+	}
+	if !strings.Contains(user, "[user]\nswitch to the Go rewrite") {
+		t.Errorf("request missing transcript: %q", user)
+	}
+	if strings.Contains(user, "[system]") {
+		t.Errorf("daily memory should not include system prompt transcript: %q", user)
+	}
+}
+
 func TestMaybeCompactThreshold(t *testing.T) {
 	// 40-char contents → ~10 tokens each at the fallback ratio; with a 20-token
 	// window the tail budget (10) keeps only the last couple, leaving a region to

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -358,28 +358,38 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 		classifier = control.NewProviderAutoPlanClassifier(classifierProv)
 	}
+	autoMemoryIdle := control.DefaultAutoMemoryIdle
+	if strings.EqualFold(strings.TrimSpace(cfg.Agent.AutoMemory), "on") {
+		d, err := control.ParseAutoMemoryIdle(cfg.Agent.AutoMemoryIdle)
+		if err != nil {
+			return nil, fmt.Errorf("agent.auto_memory_idle: %w", err)
+		}
+		autoMemoryIdle = d
+	}
 
 	ctrlOpts := control.Options{
-		Runner:        runner,
-		Executor:      executor,
-		Sink:          sink,
-		Policy:        policy,
-		Label:         label,
-		SystemPrompt:  sysPrompt,
-		SessionDir:    config.SessionDir(),
-		Host:          pluginHost,
-		Commands:      cmds,
-		Skills:        skills,
-		Hooks:         hookRunner,
-		Memory:        mem,
-		Cleanup:       cleanup,
-		BalanceURL:    entry.BalanceURL,
-		BalanceKey:    entry.APIKey(),
-		Jobs:          jm,
-		Registry:      reg,
-		PluginCtx:     ctx,
-		WorkspaceRoot: cwd,
-		AutoPlan:      cfg.Agent.AutoPlan,
+		Runner:         runner,
+		Executor:       executor,
+		Sink:           sink,
+		Policy:         policy,
+		Label:          label,
+		SystemPrompt:   sysPrompt,
+		SessionDir:     config.SessionDir(),
+		Host:           pluginHost,
+		Commands:       cmds,
+		Skills:         skills,
+		Hooks:          hookRunner,
+		Memory:         mem,
+		Cleanup:        cleanup,
+		BalanceURL:     entry.BalanceURL,
+		BalanceKey:     entry.APIKey(),
+		Jobs:           jm,
+		Registry:       reg,
+		PluginCtx:      ctx,
+		WorkspaceRoot:  cwd,
+		AutoPlan:       cfg.Agent.AutoPlan,
+		AutoMemory:     cfg.Agent.AutoMemory,
+		AutoMemoryIdle: autoMemoryIdle,
 	}
 	if classifier != nil {
 		ctrlOpts.Classifier = classifier

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -173,6 +173,12 @@ type AgentConfig struct {
 	// AutoPlanClassifier optionally names a provider/model used to classify
 	// borderline auto-plan decisions. Empty keeps the zero-cost heuristic path.
 	AutoPlanClassifier string `toml:"auto_plan_classifier"`
+	// AutoMemory controls whether idle chat sessions are summarized into the
+	// per-project long-term memory store. "off" disables it, "on" enables it.
+	AutoMemory string `toml:"auto_memory"`
+	// AutoMemoryIdle is a Go duration (for example "10m") waited after the last
+	// completed turn before the daily memory summary is refreshed.
+	AutoMemoryIdle string `toml:"auto_memory_idle"`
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's
@@ -328,8 +334,10 @@ func Default() *Config {
 			// the user cancels, or the provider errors. Context stays bounded by
 			// compaction, not by a round count. Set a positive agent.max_steps only
 			// if you want a hard guard against runaway.
-			MaxSteps: 0,
-			AutoPlan: "ask",
+			MaxSteps:       0,
+			AutoPlan:       "ask",
+			AutoMemory:     "off",
+			AutoMemoryIdle: "10m",
 		},
 		// Mode "ask" with no rules keeps `reasonix run` autonomous (no TTY → ask
 		// resolves to allow) while `reasonix chat` prompts before writers. Users add

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -46,6 +46,16 @@ func RenderTOML(c *Config) string {
 	} else {
 		b.WriteString("# auto_plan_classifier = \"deepseek-flash\"   # optional; only used for borderline tasks\n")
 	}
+	autoMemory := c.Agent.AutoMemory
+	if autoMemory == "" {
+		autoMemory = "off"
+	}
+	fmt.Fprintf(&b, "auto_memory = %q   # off|on; summarize idle chats into daily long-term memory\n", autoMemory)
+	autoMemoryIdle := c.Agent.AutoMemoryIdle
+	if autoMemoryIdle == "" {
+		autoMemoryIdle = "10m"
+	}
+	fmt.Fprintf(&b, "auto_memory_idle = %q   # wait after the last turn before refreshing the daily memory\n", autoMemoryIdle)
 	if c.Agent.PlannerModel != "" {
 		fmt.Fprintf(&b, "planner_model = %q   # low-frequency planner (two-model collaboration)\n", c.Agent.PlannerModel)
 	} else {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -12,6 +12,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig := Default()
 	orig.DefaultModel = "mimo-pro"
 	orig.Language = "zh"
+	orig.Agent.AutoMemory = "on"
+	orig.Agent.AutoMemoryIdle = "2m"
 	orig.Agent.AutoPlanClassifier = "deepseek-flash"
 	orig.Agent.SubagentModel = "mimo-pro"
 	orig.Agent.SubagentModels = map[string]string{"review": "deepseek-pro"}
@@ -53,6 +55,12 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Agent.AutoPlanClassifier != "deepseek-flash" {
 		t.Errorf("auto_plan_classifier = %q, want deepseek-flash", got.Agent.AutoPlanClassifier)
+	}
+	if got.Agent.AutoMemory != "on" {
+		t.Errorf("auto_memory = %q, want on", got.Agent.AutoMemory)
+	}
+	if got.Agent.AutoMemoryIdle != "2m" {
+		t.Errorf("auto_memory_idle = %q, want 2m", got.Agent.AutoMemoryIdle)
 	}
 	if got.Agent.SystemPrompt != orig.Agent.SystemPrompt {
 		t.Errorf("system_prompt mismatch:\n got %q\nwant %q", got.Agent.SystemPrompt, orig.Agent.SystemPrompt)

--- a/internal/control/auto_memory.go
+++ b/internal/control/auto_memory.go
@@ -1,0 +1,164 @@
+package control
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/memory"
+	"reasonix/internal/provider"
+)
+
+// DefaultAutoMemoryIdle is the conservative delay used when auto_memory is on
+// but auto_memory_idle is omitted.
+const DefaultAutoMemoryIdle = 10 * time.Minute
+
+func normalizeAutoMemory(mode string) bool {
+	return strings.EqualFold(strings.TrimSpace(mode), "on")
+}
+
+// ParseAutoMemoryIdle parses the config duration for auto-memory. An empty value
+// uses DefaultAutoMemoryIdle.
+func ParseAutoMemoryIdle(s string) (time.Duration, error) {
+	if strings.TrimSpace(s) == "" {
+		return DefaultAutoMemoryIdle, nil
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(s))
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be greater than zero")
+	}
+	return d, nil
+}
+
+func (c *Controller) cancelAutoMemoryTimerLocked() {
+	if c.autoMemoryTimer != nil {
+		c.autoMemoryTimer.Stop()
+		c.autoMemoryTimer = nil
+	}
+}
+
+func (c *Controller) scheduleAutoMemory() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if !c.autoMemoryReadyLocked() {
+		return
+	}
+	c.cancelAutoMemoryTimerLocked()
+	c.autoMemoryTimer = time.AfterFunc(c.autoMemoryIdle, func() {
+		if err := c.FlushAutoMemory(context.Background()); err != nil {
+			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "auto memory skipped: " + err.Error()})
+		}
+	})
+}
+
+func (c *Controller) autoMemoryReadyLocked() bool {
+	return c.autoMemory &&
+		c.autoMemoryIdle > 0 &&
+		c.executor != nil &&
+		c.mem != nil &&
+		c.mem.Store.Dir != ""
+}
+
+// FlushAutoMemory refreshes the day's long-term memory summary for conversation
+// messages that have not yet been folded into it. It is safe to call when
+// auto-memory is disabled; in that case it is a no-op.
+func (c *Controller) FlushAutoMemory(ctx context.Context) error {
+	c.mu.Lock()
+	if !c.autoMemoryReadyLocked() || c.running || c.autoMemoryFlushing {
+		c.mu.Unlock()
+		return nil
+	}
+	c.cancelAutoMemoryTimerLocked()
+	exec := c.executor
+	mem := c.mem
+	cursor := c.autoMemoryCursor
+	now := c.autoMemoryNow
+	c.autoMemoryFlushing = true
+	c.mu.Unlock()
+
+	capturedEnd := 0
+	var savedPath string
+	defer func() {
+		c.mu.Lock()
+		c.autoMemoryFlushing = false
+		c.mu.Unlock()
+	}()
+
+	msgs := exec.Session().Snapshot()
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor > len(msgs) {
+		c.mu.Lock()
+		c.autoMemoryCursor = len(msgs)
+		c.mu.Unlock()
+		return nil
+	}
+	capturedEnd = len(msgs)
+	region := msgs[cursor:]
+	if !hasMemorySummaryContent(region) {
+		c.mu.Lock()
+		if c.autoMemoryCursor < capturedEnd {
+			c.autoMemoryCursor = capturedEnd
+		}
+		c.mu.Unlock()
+		return nil
+	}
+
+	day := now().Format("2006-01-02")
+	name := "daily-summary-" + day
+	existing := existingMemoryBody(mem.Store, name)
+	summary, err := exec.SummarizeDailyMemory(ctx, day, existing, region)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(summary) == "" {
+		return nil
+	}
+	savedPath, err = mem.Store.Save(memory.Memory{
+		Name:        name,
+		Title:       "Daily summary " + day,
+		Description: "Daily auto memory summary for " + day,
+		Type:        memory.TypeProject,
+		Body:        summary,
+	})
+	if err != nil {
+		return err
+	}
+
+	c.mu.Lock()
+	if c.autoMemoryCursor < capturedEnd {
+		c.autoMemoryCursor = capturedEnd
+	}
+	c.pendingMemory = append(c.pendingMemory, "Daily auto memory summary for "+day+" was refreshed at "+savedPath+".")
+	c.refreshMemoryLocked()
+	c.mu.Unlock()
+	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "auto memory: refreshed daily summary"})
+	return nil
+}
+
+func hasMemorySummaryContent(msgs []provider.Message) bool {
+	for _, m := range msgs {
+		if m.Role == provider.RoleSystem {
+			continue
+		}
+		if strings.TrimSpace(m.Content) != "" || len(m.ToolCalls) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func existingMemoryBody(store memory.Store, name string) string {
+	for _, m := range store.List() {
+		if m.Name == name {
+			return m.Body
+		}
+	}
+	return ""
+}

--- a/internal/control/auto_memory_test.go
+++ b/internal/control/auto_memory_test.go
@@ -1,0 +1,98 @@
+package control
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/memory"
+	"reasonix/internal/tool"
+)
+
+func TestAutoMemorySummarizesAfterIdleAndMergesDailySummary(t *testing.T) {
+	userDir := t.TempDir()
+	cwd := t.TempDir()
+	store := memory.StoreFor(userDir, cwd)
+	mem := memory.Load(memory.Options{CWD: cwd, UserDir: userDir})
+	prov := testutil.NewMock("fake",
+		testutil.Turn{Text: "first answer"},
+		testutil.Turn{Text: "summary one"},
+		testutil.Turn{Text: "second answer"},
+		testutil.Turn{Text: "summary two"},
+	)
+	exec := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{}, event.Discard)
+	turnDone := make(chan struct{}, 2)
+	c := New(Options{
+		Runner:         exec,
+		Executor:       exec,
+		Memory:         mem,
+		AutoMemory:     "on",
+		AutoMemoryIdle: time.Millisecond,
+		AutoMemoryNow:  func() time.Time { return time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC) },
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.TurnDone {
+				turnDone <- struct{}{}
+			}
+		}),
+	})
+	defer c.Close()
+
+	c.Send("remember this project decision")
+	waitForSignal(t, turnDone)
+	waitForFileContains(t, store.Path("daily-summary-2026-06-02"), "summary one")
+
+	c.Send("add another decision")
+	waitForSignal(t, turnDone)
+	waitForFileContains(t, store.Path("daily-summary-2026-06-02"), "summary two")
+
+	requests := prov.Requests()
+	if len(requests) != 4 {
+		t.Fatalf("provider calls = %d, want turn+summary+turn+summary", len(requests))
+	}
+	secondSummary := requests[3].Messages[1].Content
+	if !strings.Contains(secondSummary, "Existing daily summary:\nsummary one") {
+		t.Fatalf("second summary should merge the prior daily memory, got:\n%s", secondSummary)
+	}
+	if strings.Contains(secondSummary, "remember this project decision") {
+		t.Fatalf("second summary should receive only new conversation messages, got:\n%s", secondSummary)
+	}
+	if !strings.Contains(secondSummary, "add another decision") {
+		t.Fatalf("second summary missing the new turn transcript:\n%s", secondSummary)
+	}
+	idx, err := os.ReadFile(filepath.Join(store.Dir, "MEMORY.md"))
+	if err != nil {
+		t.Fatalf("read MEMORY.md: %v", err)
+	}
+	if strings.Count(string(idx), "daily-summary-2026-06-02.md") != 1 {
+		t.Fatalf("daily memory should have one index entry, got:\n%s", idx)
+	}
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for turn completion")
+	}
+}
+
+func waitForFileContains(t *testing.T, path, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		b, err := os.ReadFile(path)
+		if err == nil && strings.Contains(string(b), want) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s did not contain %q; last err=%v body=%q", path, want, err, string(b))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/billing"
@@ -131,6 +132,13 @@ type Controller struct {
 	// a fresh memory takes effect this session without busting the prompt cache;
 	// it joins the prefix naturally on the next session.
 	pendingMemory []string
+
+	autoMemory         bool
+	autoMemoryIdle     time.Duration
+	autoMemoryNow      func() time.Time
+	autoMemoryTimer    *time.Timer
+	autoMemoryCursor   int
+	autoMemoryFlushing bool
 }
 
 type approvalReply struct {
@@ -171,6 +179,11 @@ type Options struct {
 	WorkspaceRoot string
 	AutoPlan      string
 	Classifier    autoPlanClassifier
+	// AutoMemory enables idle daily summaries into the long-term memory store.
+	// AutoMemoryIdle defaults to DefaultAutoMemoryIdle when enabled and unset.
+	AutoMemory     string
+	AutoMemoryIdle time.Duration
+	AutoMemoryNow  func() time.Time // test seam; nil uses time.Now
 }
 
 // New builds a Controller. A nil Sink is replaced with event.Discard.
@@ -187,32 +200,48 @@ func New(opts Options) *Controller {
 	if pluginCtx == nil {
 		pluginCtx = context.Background()
 	}
+	autoMemoryIdle := opts.AutoMemoryIdle
+	if autoMemoryIdle <= 0 {
+		autoMemoryIdle = DefaultAutoMemoryIdle
+	}
+	autoMemoryNow := opts.AutoMemoryNow
+	if autoMemoryNow == nil {
+		autoMemoryNow = time.Now
+	}
+	autoMemoryCursor := 0
+	if opts.Executor != nil {
+		autoMemoryCursor = len(opts.Executor.Session().Snapshot())
+	}
 	c := &Controller{
-		runner:       opts.Runner,
-		executor:     opts.Executor,
-		sink:         sink,
-		policy:       opts.Policy,
-		label:        opts.Label,
-		systemPrompt: opts.SystemPrompt,
-		sessionDir:   opts.SessionDir,
-		sessionPath:  opts.SessionPath,
-		host:         opts.Host,
-		commands:     opts.Commands,
-		skills:       opts.Skills,
-		hooks:        opts.Hooks,
-		mem:          opts.Memory,
-		cleanup:      opts.Cleanup,
-		autoPlan:     normalizeAutoPlan(opts.AutoPlan),
-		classifier:   classifier,
-		balanceURL:   opts.BalanceURL,
-		balanceKey:   opts.BalanceKey,
-		jobs:         opts.Jobs,
-		reg:          opts.Registry,
-		pluginCtx:    pluginCtx,
-		cpRoot:       opts.WorkspaceRoot,
-		approvals:    map[string]chan approvalReply{},
-		asks:         map[string]chan []event.AskAnswer{},
-		granted:      map[string]bool{},
+		runner:           opts.Runner,
+		executor:         opts.Executor,
+		sink:             sink,
+		policy:           opts.Policy,
+		label:            opts.Label,
+		systemPrompt:     opts.SystemPrompt,
+		sessionDir:       opts.SessionDir,
+		sessionPath:      opts.SessionPath,
+		host:             opts.Host,
+		commands:         opts.Commands,
+		skills:           opts.Skills,
+		hooks:            opts.Hooks,
+		mem:              opts.Memory,
+		cleanup:          opts.Cleanup,
+		autoPlan:         normalizeAutoPlan(opts.AutoPlan),
+		classifier:       classifier,
+		autoMemory:       normalizeAutoMemory(opts.AutoMemory),
+		autoMemoryIdle:   autoMemoryIdle,
+		autoMemoryNow:    autoMemoryNow,
+		autoMemoryCursor: autoMemoryCursor,
+		balanceURL:       opts.BalanceURL,
+		balanceKey:       opts.BalanceKey,
+		jobs:             opts.Jobs,
+		reg:              opts.Registry,
+		pluginCtx:        pluginCtx,
+		cpRoot:           opts.WorkspaceRoot,
+		approvals:        map[string]chan approvalReply{},
+		asks:             map[string]chan []event.AskAnswer{},
+		granted:          map[string]bool{},
 	}
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
 	c.rebindCheckpoints(opts.SessionPath)
@@ -278,6 +307,7 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 		c.mu.Unlock()
 		return
 	}
+	c.cancelAutoMemoryTimerLocked()
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
 	c.running = true
@@ -289,6 +319,9 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 		c.running = false
 		c.cancel = nil
 		c.mu.Unlock()
+		if err == nil {
+			c.scheduleAutoMemory()
+		}
 		c.sink.Emit(event.Event{Kind: event.TurnDone, Err: err})
 	}()
 }
@@ -684,6 +717,9 @@ func (c *Controller) NewSession() error {
 	if err := c.Snapshot(); err != nil {
 		return err
 	}
+	if err := c.FlushAutoMemory(context.Background()); err != nil {
+		c.notice("auto memory skipped: " + err.Error())
+	}
 	c.hooks.SessionEnd(context.Background())
 	if c.sessionDir != "" {
 		c.mu.Lock()
@@ -691,6 +727,9 @@ func (c *Controller) NewSession() error {
 		c.mu.Unlock()
 	}
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.mu.Lock()
+	c.autoMemoryCursor = len(c.executor.Session().Snapshot())
+	c.mu.Unlock()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
@@ -1024,6 +1063,11 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	}
 	c.mu.Lock()
 	c.sessionPath = path
+	if s != nil {
+		c.autoMemoryCursor = len(s.Snapshot())
+	} else {
+		c.autoMemoryCursor = 0
+	}
 	c.mu.Unlock()
 	c.rebindCheckpoints(path)
 }
@@ -1316,6 +1360,7 @@ func (c *Controller) Label() string { return c.label }
 func (c *Controller) Close() {
 	c.mu.Lock()
 	started := c.startedOnce
+	c.cancelAutoMemoryTimerLocked()
 	c.mu.Unlock()
 	if started {
 		c.hooks.SessionEnd(context.Background())

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -16,6 +16,8 @@ max_steps   = 25
 temperature = 0.0
 auto_plan   = "ask"   # off|ask|on; ask/on auto-enter plan mode for complex tasks
 # auto_plan_classifier = "deepseek-flash"   # optional; only used for borderline tasks
+auto_memory = "off"   # off|on; summarize idle chats into daily long-term memory
+auto_memory_idle = "10m"   # wait after the last turn before refreshing the daily memory
 # planner_model = "mimo-pro"   # optional: enable two-model collaboration
 # subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
 # subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }   # per-skill overrides


### PR DESCRIPTION
Closes #2565

## Summary
- adds opt-in `agent.auto_memory` and `agent.auto_memory_idle` settings
- refreshes a per-project `daily-summary-YYYY-MM-DD` memory after an idle chat window
- merges only new conversation messages into the existing daily summary, keeping the current prompt prefix stable until the next session

## Evidence
- No UI change; screenshots are not applicable.
- Validation: `D:\Go\go\bin\go.exe test ./internal/agent ./internal/control ./internal/config ./internal/boot`
- Validation: `D:\Go\go\bin\go.exe test ./...`