### PR TITLE
ci: run the root test matrix on windows-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -28,7 +28,10 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # Skipped on Windows: the runner checks out CRLF, so gofmt -l flags every
+      # file. gofmt output is OS-independent, so the Unix legs already cover it.
       - name: gofmt
+        if: runner.os != 'Windows'
         run: |
           # Root module only — desktop/ is a separate module with its own tooling.
           unformatted=$(gofmt -l . | grep -v '^desktop/' || true)


### PR DESCRIPTION
## What

Add `windows-latest` to the root CI test matrix.

## Why

CI runs Unix-only (ubuntu + macos), so Windows-specific code paths and `//go:build windows` tests never execute there. This blind spot has bitten us repeatedly: recent PRs shipped Windows test failures (PATHEXT executable resolution returning a different-cased path, `os.UserConfigDir` ignoring `HOME`/`XDG` on Windows) that only surfaced when run on a real Windows machine — `go test -c` compiles the Windows tests but never runs them.

## How

- Add `windows-latest` to the `test` matrix.
- Skip the `gofmt` step on Windows: the runner checks out CRLF so `gofmt -l` flags every file, and gofmt output is OS-independent, so the Unix legs already cover formatting. `vet`/`build`/`test` run on all three.

## Verification

Full root `go test ./...` passes natively on Windows against current `main-v2`.
