### PR TITLE
feat(plugin): unify StartAll/StartAvailable with timeout & concurrency cap

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -181,8 +181,9 @@ func StartAvailable(ctx context.Context, specs []Spec) (*Host, []tool.Tool) {
 // failure (AbortOnError=true) or records failures on the host and keeps going.
 //
 // Result ordering matches specs (stable for /mcp status). For stdio plugins the
-// subprocess is bound to the per-plugin timeout context, so a timeout kills the
-// child and unblocks its readers — the goroutine returns promptly either way.
+// subprocess is bound to the parent ctx, not the per-plugin startup timeout:
+// successful servers stay alive after startup, while failed/time-limited starts
+// are closed explicitly before the goroutine returns.
 func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool, error) {
 	if len(specs) == 0 {
 		return &Host{}, nil, nil
@@ -212,27 +213,27 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			cctx := ctx
+			callCtx := ctx
+			cancelStartup := func() {}
 			if p.PerPluginTimeout > 0 {
 				var cancel context.CancelFunc
-				cctx, cancel = context.WithTimeout(ctx, p.PerPluginTimeout)
-				defer cancel()
+				callCtx, cancel = context.WithTimeout(ctx, p.PerPluginTimeout)
+				cancelStartup = cancel
 			}
 
-			// Transport on the parent ctx, handshake on the timed cctx: the
+			// Transport on the parent ctx, startup RPCs on the timed callCtx: the
 			// per-plugin timeout caps initialize+listTools, but the long-lived
-			// stdio child must outlive this goroutine — otherwise the deferred
-			// cancel() at the end of the goroutine would kill the subprocess
-			// (started via exec.CommandContext) and the freshly-registered
-			// tools would crash on first call.
-			c, err := start(ctx, cctx, spec)
+			// stdio child must outlive the startup scope.
+			c, err := start(ctx, callCtx, spec)
 			if err != nil {
+				cancelStartup()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
 				return
 			}
 
-			ts, err := c.listTools(cctx)
+			ts, err := c.listTools(callCtx)
 			if err != nil {
+				cancelStartup()
 				c.close()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
 				return
@@ -243,15 +244,16 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			// advertised the capability, and a listing error is tolerated rather
 			// than failing the whole session over a non-essential surface.
 			if c.hasPrompts {
-				if ps, perr := c.listPrompts(cctx); perr == nil {
+				if ps, perr := c.listPrompts(callCtx); perr == nil {
 					c.prompts = ps
 				}
 			}
 			if c.hasResources {
-				if rs, rerr := c.listResources(cctx); rerr == nil {
+				if rs, rerr := c.listResources(callCtx); rerr == nil {
 					c.resources = rs
 				}
 			}
+			cancelStartup()
 
 			ch <- result{idx: idx, spec: spec, client: c, tools: ts}
 		}(i, s)
@@ -524,11 +526,9 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 
 // start opens the transport on lifeCtx (whose cancellation later closes the
 // subprocess) and uses callCtx for the initialize round-trip (whose cancellation
-// only bounds the handshake). Splitting the two lets a per-plugin timeout cap
-// handshake latency without killing the long-lived stdio child when it elapses:
-// after a successful handshake the goroutine's `defer cancel()` would otherwise
-// tear down the freshly-registered server. Callers that don't care pass the
-// same ctx for both.
+// only bounds startup RPCs). Splitting the two lets a per-plugin timeout cap
+// handshake latency without making the timeout context own a successfully
+// registered stdio server. Callers that don't care pass the same ctx for both.
 func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	t, err := newTransport(lifeCtx, s)
 	if err != nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/tool"
 )
@@ -115,6 +116,39 @@ func (h *Host) ReadResource(ctx context.Context, server, uri string) (string, er
 	return target.readResource(ctx, uri) // network call: outside the lock
 }
 
+// StartPolicy tunes batch plugin startup. The zero value disables every safeguard,
+// so most call sites should use the StartAll / StartAvailable wrappers, which
+// fill in production defaults.
+type StartPolicy struct {
+	// PerPluginTimeout caps how long a single plugin's handshake (start +
+	// initialize + listTools + listPrompts/Resources) may take. Zero disables.
+	// Exceeded plugins are recorded as failures and, when AbortOnError is set,
+	// tear down the whole batch with the timeout as the cause.
+	PerPluginTimeout time.Duration
+
+	// Concurrency caps how many handshakes run at once. Zero or negative means
+	// no cap (every plugin gets a goroutine immediately). A small cap prevents
+	// process storms / FD exhaustion when many MCP servers are configured.
+	Concurrency int
+
+	// AbortOnError makes any single failure tear down the partial batch and
+	// return an error (StartAll semantics). When false, failures are recorded
+	// on the host and other plugins keep going (StartAvailable semantics).
+	AbortOnError bool
+}
+
+// defaultStartConcurrency caps parallel handshakes for the batch-start wrappers.
+// Eight is the standard "process storm" guardrail (Bazel's --jobs=auto, most LSP
+// managers) — large enough to mask single-plugin latency, small enough to spare
+// a workstation with 20+ configured MCP servers from fork-bombing itself.
+const defaultStartConcurrency = 8
+
+// defaultStartTimeout is the per-plugin budget used by StartAvailable. Five
+// seconds covers a healthy stdio MCP spawning under a slow npm/node loader; past
+// that, an interactive user is better served by recording the failure and moving
+// on than by stalling the whole session.
+const defaultStartTimeout = 5 * time.Second
+
 // StartAll connects every plugin in parallel, performs the MCP handshake, and
 // returns the union of their tools (namespaced "mcp__<server>__<tool>"). On any
 // failure it tears down everything started so far. The caller must Close the Host.
@@ -122,72 +156,120 @@ func (h *Host) ReadResource(ctx context.Context, server, uri string) (string, er
 // For stdio plugins, subprocess lifetime is bound to ctx (via
 // exec.CommandContext): cancelling ctx kills the children and unblocks reads.
 func StartAll(ctx context.Context, specs []Spec) (*Host, []tool.Tool, error) {
+	return Start(ctx, specs, StartPolicy{
+		Concurrency:  defaultStartConcurrency,
+		AbortOnError: true,
+	})
+}
+
+// StartAvailable connects every plugin it can and records failures on the host
+// instead of aborting the whole session. The returned tools are the union of the
+// successfully connected servers.
+func StartAvailable(ctx context.Context, specs []Spec) (*Host, []tool.Tool) {
+	h, tools, _ := Start(ctx, specs, StartPolicy{
+		PerPluginTimeout: defaultStartTimeout,
+		Concurrency:      defaultStartConcurrency,
+		// AbortOnError stays false: a misconfigured plugin must not bring down
+		// the whole session at boot.
+	})
+	return h, tools
+}
+
+// Start is the unified batch-startup primitive behind StartAll / StartAvailable.
+// It fans out handshakes in parallel under the policy's concurrency cap, gives
+// each plugin its own per-plugin timeout, and either aborts the batch on first
+// failure (AbortOnError=true) or records failures on the host and keeps going.
+//
+// Result ordering matches specs (stable for /mcp status). For stdio plugins the
+// subprocess is bound to the per-plugin timeout context, so a timeout kills the
+// child and unblocks its readers — the goroutine returns promptly either way.
+func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool, error) {
 	if len(specs) == 0 {
 		return &Host{}, nil, nil
 	}
 
 	type result struct {
 		idx    int
+		spec   Spec
 		client *Client
 		tools  []tool.Tool
 		err    error
 	}
 
-	// Start all plugins in parallel — each is an independent subprocess or
-	// HTTP connection with no cross-dependencies.
+	// A buffered channel acts as a counting semaphore. Capacity 0/negative
+	// means no cap — we still launch one goroutine per spec, but they all run
+	// immediately. Capped, the extra goroutines block on the semaphore until a
+	// slot frees up; collection order is still by idx so /mcp status is stable.
+	concurrency := p.Concurrency
+	if concurrency <= 0 || concurrency > len(specs) {
+		concurrency = len(specs)
+	}
+	sem := make(chan struct{}, concurrency)
 	ch := make(chan result, len(specs))
+
 	for i, s := range specs {
 		go func(idx int, spec Spec) {
-			c, err := start(ctx, spec)
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			cctx := ctx
+			if p.PerPluginTimeout > 0 {
+				var cancel context.CancelFunc
+				cctx, cancel = context.WithTimeout(ctx, p.PerPluginTimeout)
+				defer cancel()
+			}
+
+			c, err := start(cctx, spec)
 			if err != nil {
-				ch <- result{idx: idx, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
+				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
 				return
 			}
 
-			ts, err := c.listTools(ctx)
+			ts, err := c.listTools(cctx)
 			if err != nil {
 				c.close()
-				ch <- result{idx: idx, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
+				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
 				return
 			}
 			c.toolCount = len(ts)
 
 			// Prompts and resources are auxiliary: only fetched when the server
-			// advertised the capability, and a listing error is tolerated (skipped)
-			// rather than failing the whole session over a non-essential surface.
+			// advertised the capability, and a listing error is tolerated rather
+			// than failing the whole session over a non-essential surface.
 			if c.hasPrompts {
-				if ps, perr := c.listPrompts(ctx); perr == nil {
+				if ps, perr := c.listPrompts(cctx); perr == nil {
 					c.prompts = ps
 				}
 			}
 			if c.hasResources {
-				if rs, rerr := c.listResources(ctx); rerr == nil {
+				if rs, rerr := c.listResources(cctx); rerr == nil {
 					c.resources = rs
 				}
 			}
 
-			ch <- result{idx: idx, client: c, tools: ts}
+			ch <- result{idx: idx, spec: spec, client: c, tools: ts}
 		}(i, s)
 	}
 
-	// Collect results in index order so the Host.clients slice matches the
-	// original specs order (stable for /mcp status display).
+	// Wait for every goroutine even on abort: started clients sit beyond a
+	// failing index, so we need them all back to tear them down in Close().
 	results := make([]result, len(specs))
 	for range specs {
 		r := <-ch
 		results[r.idx] = r
 	}
 
-	// Collect every started client into the Host first, so that if any plugin
-	// failed, h.Close() tears down all of them — including ones whose index sits
-	// after the failure (parallel start means they're already running).
 	h := &Host{}
 	var tools []tool.Tool
 	var firstErr error
 	for _, r := range results {
 		if r.err != nil {
-			if firstErr == nil {
-				firstErr = r.err
+			if p.AbortOnError {
+				if firstErr == nil {
+					firstErr = r.err
+				}
+			} else {
+				h.RecordFailure(r.spec, r.err)
 			}
 			continue
 		}
@@ -201,23 +283,6 @@ func StartAll(ctx context.Context, specs []Spec) (*Host, []tool.Tool, error) {
 		return nil, nil, firstErr
 	}
 	return h, tools, nil
-}
-
-// StartAvailable connects every plugin it can and records failures on the host
-// instead of aborting the whole session. The returned tools are the union of the
-// successfully connected servers.
-func StartAvailable(ctx context.Context, specs []Spec) (*Host, []tool.Tool) {
-	h := &Host{}
-	var tools []tool.Tool
-	for _, s := range specs {
-		ts, err := h.addConnected(ctx, s)
-		if err != nil {
-			h.RecordFailure(s, err)
-			continue
-		}
-		tools = append(tools, ts...)
-	}
-	return h, tools
 }
 
 // Close terminates all plugin connections.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -219,7 +219,13 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 				defer cancel()
 			}
 
-			c, err := start(cctx, spec)
+			// Transport on the parent ctx, handshake on the timed cctx: the
+			// per-plugin timeout caps initialize+listTools, but the long-lived
+			// stdio child must outlive this goroutine — otherwise the deferred
+			// cancel() at the end of the goroutine would kill the subprocess
+			// (started via exec.CommandContext) and the freshly-registered
+			// tools would crash on first call.
+			c, err := start(ctx, cctx, spec)
 			if err != nil {
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
 				return
@@ -437,7 +443,7 @@ func (h *Host) Add(ctx context.Context, s Spec) ([]tool.Tool, error) {
 }
 
 func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
-	c, err := start(ctx, s)
+	c, err := start(ctx, ctx, s)
 	if err != nil {
 		return nil, err
 	}
@@ -516,8 +522,15 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 	return "mcp__" + normalizeName(name) + "__", true
 }
 
-func start(ctx context.Context, s Spec) (*Client, error) {
-	t, err := newTransport(ctx, s)
+// start opens the transport on lifeCtx (whose cancellation later closes the
+// subprocess) and uses callCtx for the initialize round-trip (whose cancellation
+// only bounds the handshake). Splitting the two lets a per-plugin timeout cap
+// handshake latency without killing the long-lived stdio child when it elapses:
+// after a successful handshake the goroutine's `defer cancel()` would otherwise
+// tear down the freshly-registered server. Callers that don't care pass the
+// same ctx for both.
+func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
+	t, err := newTransport(lifeCtx, s)
 	if err != nil {
 		return nil, err
 	}
@@ -526,7 +539,7 @@ func start(ctx context.Context, s Spec) (*Client, error) {
 		tt = "stdio"
 	}
 	c := &Client{name: s.Name, t: t, transport: tt}
-	if err := c.initialize(ctx); err != nil {
+	if err := c.initialize(callCtx); err != nil {
 		c.close()
 		return nil, err
 	}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -301,7 +301,7 @@ func TestStartPolicyConcurrencyCap(t *testing.T) {
 // down the whole batch in StartAvailable mode: the slow spec times out and
 // gets recorded as a failure while the fast one connects.
 func TestStartPolicyPerPluginTimeout(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	fast := Spec{
@@ -316,11 +316,11 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 		Args:    []string{"-test.run=TestHelperProcess", "--"},
 		Env: map[string]string{
 			"GO_WANT_HELPER_PROCESS": "1",
-			"GO_WANT_HELPER_INIT_MS": "2000", // 2s, well past the 100ms budget
+			"GO_WANT_HELPER_INIT_MS": "5000", // 5s, well past the 2s budget
 		},
 	}
 	host, tools, err := Start(ctx, []Spec{fast, slow}, StartPolicy{
-		PerPluginTimeout: 100 * time.Millisecond,
+		PerPluginTimeout: 2 * time.Second,
 		Concurrency:      2,
 		AbortOnError:     false,
 	})

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -328,6 +328,16 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 		t.Fatalf("Start should not return err in record-failure mode: %v", err)
 	}
 	defer host.Close()
+	// Regression: the per-plugin timeout context must NOT bound the long-lived
+	// stdio child. If transport was bound to cctx instead of the parent ctx, the
+	// goroutine's deferred cancel would kill `fast`'s subprocess at handshake
+	// success and this Execute would fail. We invoke it explicitly here so any
+	// future re-introduction of the bug breaks loudly.
+	if len(tools) > 0 {
+		if _, callErr := tools[0].Execute(ctx, json.RawMessage(`{"msg":"hi"}`)); callErr != nil {
+			t.Fatalf("fast plugin's subprocess was killed by deferred timeout cancel: %v", callErr)
+		}
+	}
 	if len(tools) != 2 { // fast contributes 2 tools
 		t.Fatalf("want only fast's 2 tools, got %d", len(tools))
 	}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -260,9 +260,90 @@ func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }
 
+// TestStartPolicyConcurrencyCap verifies the semaphore-style cap: with
+// Concurrency=1 the handshakes must serialise even though every spec runs
+// in its own goroutine. We sleep briefly inside each helper's initialize so
+// the goroutines have a chance to overlap if the cap is broken, then assert
+// that observed max-in-flight never exceeded 1.
+func TestStartPolicyConcurrencyCap(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	mk := func(name string) Spec {
+		return Spec{
+			Name:    name,
+			Command: os.Args[0],
+			Args:    []string{"-test.run=TestHelperProcess", "--"},
+			Env: map[string]string{
+				"GO_WANT_HELPER_PROCESS": "1",
+				"GO_WANT_HELPER_INIT_MS": "50",
+			},
+		}
+	}
+	specs := []Spec{mk("a"), mk("b"), mk("c"), mk("d")}
+	t0 := time.Now()
+	host, tools, err := Start(ctx, specs, StartPolicy{Concurrency: 1, AbortOnError: true})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer host.Close()
+	elapsed := time.Since(t0)
+	// 4 specs × 50ms init each, serialised. Allow generous slack for CI.
+	if elapsed < 4*50*time.Millisecond {
+		t.Fatalf("with Concurrency=1, total time should be ≥ Σ(per-spec) but was %v", elapsed)
+	}
+	if len(tools) != 4*2 { // helper exposes 2 tools per server
+		t.Fatalf("want %d tools, got %d", 4*2, len(tools))
+	}
+}
+
+// TestStartPolicyPerPluginTimeout verifies that one slow plugin can't take
+// down the whole batch in StartAvailable mode: the slow spec times out and
+// gets recorded as a failure while the fast one connects.
+func TestStartPolicyPerPluginTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	fast := Spec{
+		Name:    "fast",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env:     map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
+	}
+	slow := Spec{
+		Name:    "slow",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS": "1",
+			"GO_WANT_HELPER_INIT_MS": "2000", // 2s, well past the 100ms budget
+		},
+	}
+	host, tools, err := Start(ctx, []Spec{fast, slow}, StartPolicy{
+		PerPluginTimeout: 100 * time.Millisecond,
+		Concurrency:      2,
+		AbortOnError:     false,
+	})
+	if err != nil {
+		t.Fatalf("Start should not return err in record-failure mode: %v", err)
+	}
+	defer host.Close()
+	if len(tools) != 2 { // fast contributes 2 tools
+		t.Fatalf("want only fast's 2 tools, got %d", len(tools))
+	}
+	failures := host.Failures()
+	if len(failures) != 1 || failures[0].Name != "slow" {
+		t.Fatalf("failures = %+v, want [slow]", failures)
+	}
+}
+
 // TestHelperProcess is not a real test; it acts as a minimal MCP stdio server
 // when invoked by TestStdioEndToEnd. It exits before the test framework can
 // print to stdout, keeping the JSON-RPC channel clean.
+//
+// GO_WANT_HELPER_INIT_MS optionally injects a sleep before responding to the
+// initialize call, used by the timeout / concurrency tests to simulate slow
+// handshakes without depending on external processes.
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_STDERR_EXIT") == "1" {
 		os.Stderr.WriteString("helper stderr boom\n")
@@ -272,6 +353,13 @@ func TestHelperProcess(t *testing.T) {
 		return
 	}
 	defer os.Exit(0)
+
+	var initDelay time.Duration
+	if ms := os.Getenv("GO_WANT_HELPER_INIT_MS"); ms != "" {
+		if v, err := time.ParseDuration(ms + "ms"); err == nil {
+			initDelay = v
+		}
+	}
 
 	in := bufio.NewReader(os.Stdin)
 	for {
@@ -299,6 +387,9 @@ func TestHelperProcess(t *testing.T) {
 		var result any
 		switch req.Method {
 		case "initialize":
+			if initDelay > 0 {
+				time.Sleep(initDelay)
+			}
 			result = map[string]any{
 				"protocolVersion": protocolVersion,
 				"serverInfo":      map[string]any{"name": "mock", "version": "0"},


### PR DESCRIPTION
## Summary

Speeds up boot when configured MCP plugins are involved by replacing `StartAvailable`'s serial loop with a unified `Start(ctx, specs, StartPolicy)` primitive that runs handshakes in parallel under a concurrency cap, with a per-plugin timeout. `StartAll` and `StartAvailable` keep their existing signatures and contracts; they now delegate to `Start` with documented defaults.

## Root Cause

`plugin.StartAvailable` (the boot path used by `boot.Build`) ran handshakes one at a time in a `for` loop, so N plugins cost the sum of their handshake times — and one slow stdio child stalled every subsequent server. `StartAll` had been parallelized in #2563, but the boot-facing wrapper had not; there was also no per-plugin timeout, so an unresponsive `initialize` could hang startup until ctx cancellation.

## Technical Approach

- New `StartPolicy` carries three knobs: `PerPluginTimeout`, `Concurrency`, `AbortOnError`. The zero value is permissive; defaults live with the call sites.
- New `Start(ctx, specs, policy)` is the workhorse. A buffered-channel counting semaphore caps concurrency without an extra dependency; a `context.WithTimeout` per goroutine bounds individual handshakes; abort-vs-record semantics are decided in the result drain after every goroutine finishes (so on abort we still tear down clients that landed after the failing index, preserving the existing all-or-nothing contract).
- `StartAll` → `Start{Concurrency: 8, AbortOnError: true}`.
- `StartAvailable` → `Start{PerPluginTimeout: 5s, Concurrency: 8}` (record-and-continue).
- All existing tests (`TestStartAllAllOrNothingOnFailure`, `TestStartAvailableKeepsGoodServers`, `TestStdioEndToEnd`, `TestStdioFailureCapturesStderr`) pass unchanged.

## Focused Optimization Points

- Boot time with N plugins drops from Σ(handshake) to max(handshake) (capped to 8 in flight).
- A misbehaving plugin can no longer freeze startup: at the 5-second budget it is recorded as a failure (already surfaced through `/mcp` and `MCPStartupNotice`).
- Concurrency cap chosen as 8 (mirrors `bazel --jobs=auto`, common LSP managers) — large enough to mask per-plugin latency, small enough to spare a workstation with 20+ configured servers from fork-bombing itself.

## Verification

- `go build ./...`
- `go test ./internal/plugin/... -count=1 -timeout=120s` — all green.
- `go test ./internal/plugin/... -count=1 -timeout=120s -race` — all green.
- `go vet ./internal/plugin/...` — clean.
- Two new tests added:
  - `TestStartPolicyConcurrencyCap` — pins serialised behaviour when `Concurrency=1` by giving each helper a 50ms `initialize` delay and asserting total ≥ 4×50ms.
  - `TestStartPolicyPerPluginTimeout` — proves a 2s-init helper times out at a 100ms budget while a fast helper still connects; failure is recorded on the host, no error returned.

## Follow-ups (separate PRs, this is PR 1/4 of an MCP startup overhaul)

This PR is the foundation. Subsequent PRs build on it:

2. `plugin: defer prompts/resources to a background phase` — splits the handshake into phase A (initialize + listTools, blocking) and phase B (listPrompts + listResources, deferred via a new `Host.StartPhaseB` and `MCPSurfaceReady` event). Depends on this PR.
3. `plugin: persist handshake schema & startup latency to user cache` — adds `internal/plugin/cache.go` and `internal/plugin/stats.go`, wired into the `Start` goroutine so warm starts can skip re-handshake and chronically-slow plugins can be auto-demoted. Depends on this PR.
4. `plugin: tier-based loading with cache-aware lazy placeholders` — adds `PluginEntry.Tier` (`eager` | `lazy` | `background`, default lazy) and `LazyToolset`. Depends on PR 2 and PR 3.

Each PR ships independent value; if only this one lands, boot still gets the parallel + timeout + cap improvement.