### PR TITLE
refactor(desktop): dedupe transcript re-pin logic from #2670

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -21,6 +21,23 @@ function scrollVersion(items: Item[]): string {
     .join("|");
 }
 
+function repinIfWasPinned(
+  el: HTMLDivElement,
+  stick: { current: boolean },
+  frame: { current: number | null },
+  containerHeightDelta: number,
+) {
+  const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
+  // + delta reconstructs the bottom distance from before the height changed
+  if (!stick.current && bottomDistance + containerHeightDelta >= 80) return;
+  stick.current = true;
+  if (frame.current !== null) cancelAnimationFrame(frame.current);
+  frame.current = requestAnimationFrame(() => {
+    if (stick.current) el.scrollTop = el.scrollHeight;
+    frame.current = null;
+  });
+}
+
 export function Transcript({
   items,
   footerHeight = 0,
@@ -66,18 +83,9 @@ export function Transcript({
     if (!el || typeof ResizeObserver === "undefined") return;
     lastClientHeight.current = el.clientHeight;
     const observer = new ResizeObserver(() => {
-      const previousHeight = lastClientHeight.current ?? el.clientHeight;
-      const heightDelta = el.clientHeight - previousHeight;
+      const previous = lastClientHeight.current ?? el.clientHeight;
       lastClientHeight.current = el.clientHeight;
-      const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      const wasPinnedBeforeResize = bottomDistance + heightDelta < 80;
-      if (!stick.current && !wasPinnedBeforeResize) return;
-      stick.current = true;
-      if (resizeFrame.current !== null) cancelAnimationFrame(resizeFrame.current);
-      resizeFrame.current = requestAnimationFrame(() => {
-        if (stick.current) el.scrollTop = el.scrollHeight;
-        resizeFrame.current = null;
-      });
+      repinIfWasPinned(el, stick, resizeFrame, el.clientHeight - previous);
     });
     observer.observe(el);
     return () => {
@@ -92,17 +100,15 @@ export function Transcript({
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    const previousHeight = lastFooterHeight.current ?? footerHeight;
-    const heightDelta = footerHeight - previousHeight;
+    const previous = lastFooterHeight.current ?? footerHeight;
     lastFooterHeight.current = footerHeight;
-    const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const wasPinnedBeforeFooterResize = bottomDistance - heightDelta < 80;
-    if (!stick.current && !wasPinnedBeforeFooterResize) return;
-    stick.current = true;
-    const id = requestAnimationFrame(() => {
-      if (stick.current) el.scrollTop = el.scrollHeight;
-    });
-    return () => cancelAnimationFrame(id);
+    repinIfWasPinned(el, stick, resizeFrame, previous - footerHeight);
+    return () => {
+      if (resizeFrame.current !== null) {
+        cancelAnimationFrame(resizeFrame.current);
+        resizeFrame.current = null;
+      }
+    };
   }, [footerHeight]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`


### PR DESCRIPTION
Follow-up to #2670.

#2670 added two re-pin paths to `Transcript` — a container `ResizeObserver` and a `footerHeight` effect — and each one inlined the same logic: reconstruct whether the view was pinned to the bottom *before* the height change, and if so re-pin after layout settles.

This extracts that into a single `repinIfWasPinned(el, stick, frame, containerHeightDelta)` helper that both paths call, sharing one rAF slot. The footer path passes the negated footer delta (footer grows by `fd` → container shrinks by `fd`), which is algebraically identical to the container path's `bottomDistance + clientHeightDelta` test — so behavior is unchanged, the `80px` threshold and the re-pin scheduling now live in one place.

## Validation
- `npm run typecheck` in `desktop/frontend`
- `npm run build` in `desktop/frontend`