### PR TITLE
feat(plugin): persist handshake schema & startup latency to user cache

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -195,6 +195,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		for _, t := range ptools {
 			reg.Add(t)
 		}
+		// PhaseB (prompts + resources) runs on the boot ctx — which is the
+		// controller's session-scoped PluginCtx — so the auxiliary surfaces
+		// keep streaming in after Start returns without holding up the agent.
+		go host.StartPhaseB(ctx, sink)
 		if text, ok := MCPStartupNotice(host.Failures()); ok {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -123,6 +123,12 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		for _, t := range ptools {
 			reg.Add(t)
 		}
+		// Mirror boot.Build: phase B (prompts + resources) is deferred to a
+		// background goroutine on the session ctx so the ACP path also sees
+		// non-empty Host.Prompts()/Resources() once the auxiliary surfaces
+		// stream in. Without this, MCPPrompt and @-ref consumers would stay
+		// empty for the session.
+		go h.StartPhaseB(ctx, p.Sink)
 		if text, ok := boot.MCPStartupNotice(h.Failures()); ok {
 			p.Sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -526,6 +526,19 @@ func SessionDir() string {
 	return filepath.Join(dir, "reasonix", "sessions")
 }
 
+// CacheDir is the per-user cache root for derived/regenerable artefacts: MCP
+// handshake snapshots, plugin startup-latency telemetry. Lives beside the
+// existing dirs (UserConfigDir/reasonix/...) so the whole reasonix state tree
+// shares one root the user can wipe in a single rm. Empty when the OS dir is
+// unavailable — callers must tolerate that (caching is best-effort).
+func CacheDir() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "reasonix", "cache")
+}
+
 // MemoryUserDir returns the reasonix user config root (…/reasonix), under which
 // the user-global REASONIX.md and the per-project auto-memory store live. Empty
 // when the user config dir can't be resolved, which disables user-scoped memory.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -68,6 +68,11 @@ const (
 	// ToolResult for long tools like bash so a frontend can show live progress.
 	// Appended last to keep the Kind values before it wire-stable.
 	ToolProgress
+	// MCPSurfaceReady fires once per server when its background-loaded surface
+	// (prompts or resources) finishes after startup. Lets UIs refresh /mcp
+	// status without polling. Text carries "<server>: <surface> ready (<count>
+	// items)". Appended last to keep the Kind values before it wire-stable.
+	MCPSurfaceReady
 )
 
 // Level classifies a Notice so sinks can style or filter it.

--- a/internal/plugin/cache.go
+++ b/internal/plugin/cache.go
@@ -1,0 +1,221 @@
+// Package-internal cache for MCP handshake results. The handshake (initialize +
+// listTools, plus optional listPrompts/listResources) costs hundreds of ms to a
+// few seconds per server on cold start. We persist the tool schema +
+// capabilities under the user cache dir keyed by a fingerprint of the load-
+// bearing Spec fields, so the next launch can register tools optimistically
+// without waiting for the network/subprocess. Caching is purely an
+// optimisation: any failure (missing dir, bad JSON, hash mismatch) silently
+// degrades to a fresh handshake.
+package plugin
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/tool"
+)
+
+// cacheableToolsOf extracts the persistable subset of remote tools so Start()
+// can hand them to SaveCachedSchema. Non-remote tools are skipped — Start
+// only feeds remote ones at the call site, but the type-assert is defensive.
+func cacheableToolsOf(tools []tool.Tool) []CachedTool {
+	out := make([]CachedTool, 0, len(tools))
+	for _, t := range tools {
+		rt, ok := t.(*remoteTool)
+		if !ok {
+			continue
+		}
+		out = append(out, CachedTool{
+			Name:        rt.rawName,
+			Description: rt.desc,
+			Schema:      rt.schema,
+			ReadOnly:    rt.readOnly,
+		})
+	}
+	return out
+}
+
+// cacheVersion bumps whenever CachedSchema shape changes incompatibly. Old
+// files with a smaller version are treated as a miss so a stale layout never
+// crashes a reader.
+const cacheVersion = 1
+
+// CachedSchema is the persisted snapshot of one server's handshake result.
+// SpecHash gates reuse — Capabilities/Tools are only trusted when the
+// caller's expectedHash (from SpecFingerprint of the current Spec) matches,
+// so renaming env vars or swapping a command never serves stale tools.
+type CachedSchema struct {
+	Version       int             `json:"version"`
+	SpecHash      string          `json:"spec_hash"`
+	Capabilities  map[string]bool `json:"capabilities"`
+	Tools         []CachedTool    `json:"tools"`
+	LastValidated time.Time       `json:"last_validated"`
+}
+
+// CachedTool mirrors the subset of an MCP tool definition we need to register
+// a placeholder before the real handshake completes: Name (raw, server-local),
+// Description (model-visible), Schema (raw JSON for input validation),
+// ReadOnly (drives confirmation prompts).
+type CachedTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Schema      json.RawMessage `json:"schema"`
+	ReadOnly    bool            `json:"read_only"`
+}
+
+// SpecFingerprint hashes the load-bearing parts of a Spec so changing the
+// command/url/args/env (not just renaming) invalidates the cache. Env map
+// keys are sorted so ordering doesn't perturb the hash — Go map iteration
+// order is randomised, so we'd otherwise get fingerprint churn on every
+// launch.
+func SpecFingerprint(s Spec) string {
+	h := sha256.New()
+	writeField(h, "type", s.Type)
+	writeField(h, "command", s.Command)
+	writeField(h, "url", s.URL)
+	writeField(h, "dir", s.Dir)
+	for _, a := range s.Args {
+		writeField(h, "arg", a)
+	}
+	writeKV(h, "env", s.Env)
+	writeKV(h, "headers", s.Headers)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// LoadCachedSchema returns the cached schema for name iff it exists, parses,
+// and matches expectedHash. Any error → (nil, false): cache is best-effort,
+// a corrupt file just means we re-handshake. Returning an error here would
+// only invite callers to log it on every launch — silence is intentional.
+func LoadCachedSchema(name, expectedHash string) (*CachedSchema, bool) {
+	p := cachePath(name)
+	if p == "" {
+		return nil, false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, false
+	}
+	var cs CachedSchema
+	if err := json.Unmarshal(b, &cs); err != nil {
+		return nil, false
+	}
+	if cs.Version != cacheVersion {
+		return nil, false
+	}
+	if cs.SpecHash != expectedHash {
+		return nil, false
+	}
+	return &cs, true
+}
+
+// SaveCachedSchema atomically writes cs under name. Best-effort: an error
+// is logged at debug level and dropped. Uses tmpfile + os.Rename in the
+// parent dir so a crash mid-write can't leave a half-written JSON behind
+// that the next Load would mis-parse.
+func SaveCachedSchema(name string, cs CachedSchema) error {
+	p := cachePath(name)
+	if p == "" {
+		return nil
+	}
+	dir := filepath.Dir(p)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Debug("plugin cache: mkdir", "name", name, "err", err)
+		return err
+	}
+	cs.Version = cacheVersion
+	if cs.LastValidated.IsZero() {
+		cs.LastValidated = time.Now().UTC()
+	}
+	b, err := json.MarshalIndent(cs, "", "  ")
+	if err != nil {
+		slog.Debug("plugin cache: marshal", "name", name, "err", err)
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".mcp-*.tmp")
+	if err != nil {
+		slog.Debug("plugin cache: tempfile", "name", name, "err", err)
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: write", "name", name, "err", err)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: close", "name", name, "err", err)
+		return err
+	}
+	if err := os.Rename(tmpPath, p); err != nil {
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: rename", "name", name, "err", err)
+		return err
+	}
+	return nil
+}
+
+// cachePath returns "<config.CacheDir()>/mcp/<slug(name)>.json". Returns ""
+// when CacheDir is unavailable (no-op caching).
+func cachePath(name string) string {
+	base := config.CacheDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "mcp", slug(name)+".json")
+}
+
+// slugReplace strips characters that aren't safe in a filename across the
+// OSes we target. We lowercase first so the slug is stable regardless of
+// the user's display capitalisation.
+var slugReplace = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// slug sanitises name for use as a filename: lowercase, only [a-z0-9_-]. An
+// empty result (all chars stripped) falls back to "_" so cachePath stays
+// valid for any input.
+func slug(name string) string {
+	s := slugReplace.ReplaceAllString(strings.ToLower(name), "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "_"
+	}
+	return s
+}
+
+// writeField feeds a single tagged field into h with explicit separators so
+// the boundary between (key, value) and the next field can't collide via
+// concatenation (e.g. "command" + "foo" vs "comm" + "andfoo").
+func writeField(h io.Writer, key, val string) {
+	h.Write([]byte(key))
+	h.Write([]byte{0})
+	h.Write([]byte(val))
+	h.Write([]byte{1})
+}
+
+// writeKV hashes a map deterministically by sorting keys, so Go's randomised
+// map iteration doesn't churn the fingerprint between launches.
+func writeKV(h io.Writer, key string, m map[string]string) {
+	if len(m) == 0 {
+		writeField(h, key, "")
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeField(h, key+"."+k, m[k])
+	}
+}

--- a/internal/plugin/cache_test.go
+++ b/internal/plugin/cache_test.go
@@ -1,0 +1,200 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// redirectCache points config.CacheDir() at a fresh temp dir for the duration
+// of the test by overriding HOME and XDG_CONFIG_HOME — the same knobs the
+// sibling mcpjson_test uses to sandbox UserConfigDir lookups. Returns the
+// temp dir so a test can also poke into it (e.g. write a corrupted file).
+func redirectCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+func sampleSpec() Spec {
+	return Spec{
+		Name:    "my-server",
+		Type:    "stdio",
+		Command: "/usr/bin/example",
+		Args:    []string{"--flag", "x"},
+		Env:     map[string]string{"FOO": "1", "BAR": "2"},
+		Headers: map[string]string{"X-Custom": "ok"},
+		Dir:     "/work",
+	}
+}
+
+func sampleCachedSchema(hash string) CachedSchema {
+	return CachedSchema{
+		SpecHash:     hash,
+		Capabilities: map[string]bool{"prompts": true, "resources": false},
+		Tools: []CachedTool{{
+			Name:        "do_thing",
+			Description: "does a thing",
+			Schema:      json.RawMessage(`{"type":"object"}`),
+			ReadOnly:    true,
+		}},
+	}
+}
+
+func TestCacheRoundTrip(t *testing.T) {
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	cs := sampleCachedSchema(hash)
+
+	if err := SaveCachedSchema(spec.Name, cs); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+	got, ok := LoadCachedSchema(spec.Name, hash)
+	if !ok {
+		t.Fatal("LoadCachedSchema: miss after save")
+	}
+	if got.SpecHash != hash {
+		t.Errorf("SpecHash: got %q want %q", got.SpecHash, hash)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].Name != "do_thing" {
+		t.Errorf("Tools: %+v", got.Tools)
+	}
+	if !got.Tools[0].ReadOnly {
+		t.Error("ReadOnly: lost across save/load")
+	}
+	if !got.Capabilities["prompts"] || got.Capabilities["resources"] {
+		t.Errorf("Capabilities: %+v", got.Capabilities)
+	}
+	if got.Version != cacheVersion {
+		t.Errorf("Version: got %d want %d", got.Version, cacheVersion)
+	}
+	if got.LastValidated.IsZero() {
+		t.Error("LastValidated: expected non-zero after save")
+	}
+}
+
+func TestCacheInvalidatesOnSpecHashMismatch(t *testing.T) {
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	if err := SaveCachedSchema(spec.Name, sampleCachedSchema(hash)); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+	if _, ok := LoadCachedSchema(spec.Name, "different-hash"); ok {
+		t.Fatal("LoadCachedSchema: hit despite mismatching expectedHash")
+	}
+}
+
+func TestCacheCorruptedFileReturnsFalse(t *testing.T) {
+	redirectCache(t)
+	p := cachePath("broken")
+	if p == "" {
+		t.Skip("cachePath unavailable in this environment")
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("{this is not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("LoadCachedSchema panicked on corrupt file: %v", r)
+		}
+	}()
+	if _, ok := LoadCachedSchema("broken", "any"); ok {
+		t.Fatal("LoadCachedSchema: hit on corrupt file")
+	}
+}
+
+func TestCacheVersionMismatchReturnsFalse(t *testing.T) {
+	// Pin the on-disk version to one we don't recognise: a future writer must
+	// not poison an older binary's cache reads.
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	cs := sampleCachedSchema(hash)
+	cs.Version = cacheVersion + 99
+	p := cachePath(spec.Name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := LoadCachedSchema(spec.Name, hash); ok {
+		t.Fatal("LoadCachedSchema: hit on future-version cache file")
+	}
+}
+
+func TestSpecFingerprintStable(t *testing.T) {
+	spec := sampleSpec()
+	h1 := SpecFingerprint(spec)
+	h2 := SpecFingerprint(spec)
+	if h1 != h2 {
+		t.Fatalf("SpecFingerprint not stable: %q vs %q", h1, h2)
+	}
+
+	// Reorder the env (build a new map; Go map iteration order is randomised
+	// but a fresh map can incidentally iterate the same way, so we run a few
+	// iterations to give the runtime a chance to shuffle).
+	reordered := spec
+	for i := 0; i < 32; i++ {
+		reordered.Env = map[string]string{"BAR": "2", "FOO": "1"}
+		if got := SpecFingerprint(reordered); got != h1 {
+			t.Fatalf("SpecFingerprint changed when env was rebuilt: %q vs %q", got, h1)
+		}
+	}
+}
+
+func TestSpecFingerprintChangesOnCommandEdit(t *testing.T) {
+	a := sampleSpec()
+	b := a
+	b.Command = "/usr/local/bin/other"
+	if SpecFingerprint(a) == SpecFingerprint(b) {
+		t.Fatal("SpecFingerprint did not change when Command changed")
+	}
+
+	c := a
+	c.Args = append([]string{}, a.Args...)
+	c.Args[0] = "--different"
+	if SpecFingerprint(a) == SpecFingerprint(c) {
+		t.Fatal("SpecFingerprint did not change when Args changed")
+	}
+
+	d := a
+	d.Env = map[string]string{"FOO": "1", "BAR": "different"}
+	if SpecFingerprint(a) == SpecFingerprint(d) {
+		t.Fatal("SpecFingerprint did not change when env value changed")
+	}
+}
+
+func TestCacheMissForUnknownName(t *testing.T) {
+	redirectCache(t)
+	if _, ok := LoadCachedSchema("never-saved", "anything"); ok {
+		t.Fatal("LoadCachedSchema: hit for a name that was never saved")
+	}
+}
+
+func TestSlugSafeForFilesystem(t *testing.T) {
+	cases := map[string]string{
+		"My Server!":           "my-server",
+		"weird/name\\with:bad": "weird-name-with-bad",
+		"":                     "_",
+		"------":               "_",
+		"a_b-c":                "a_b-c",
+	}
+	for in, want := range cases {
+		if got := slug(in); got != want {
+			t.Errorf("slug(%q) = %q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/plugin/example_test.go
+++ b/internal/plugin/example_test.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"reasonix/internal/event"
 	"reasonix/internal/tool"
 )
 
@@ -89,6 +91,24 @@ func TestExamplePluginEndToEnd(t *testing.T) {
 	// which the adapter surfaces as a Go error the model can read.
 	if _, err := echo.Execute(ctx, json.RawMessage(`{"text":123}`)); err == nil {
 		t.Error("echo with non-string text should return an error (isError result)")
+	}
+
+	// Prompts and resources stream in on phase B (post-startup), so the test
+	// must drive it and wait for both surfaces before asserting. A WaitGroup
+	// completes once both MCPSurfaceReady events fire.
+	var wg sync.WaitGroup
+	wg.Add(2) // prompts + resources
+	host.StartPhaseB(ctx, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.MCPSurfaceReady {
+			wg.Done()
+		}
+	}))
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("phase B did not finish in time")
 	}
 
 	// Prompts: the server advertises the capability, so the host discovers the

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -222,6 +222,8 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 				cancelStartup = cancel
 			}
 
+			phaseAStart := time.Now()
+
 			// Transport on the parent ctx, startup RPCs on the timed callCtx: the
 			// per-plugin timeout caps initialize+listTools, but the long-lived
 			// stdio child must outlive the startup scope and later phase-B calls.
@@ -241,7 +243,22 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			}
 			c.toolCount = len(ts)
 
+			// Persist for next launch on the side: a slow stats/cache write
+			// must not delay tools coming online, and either failure is
+			// recoverable (we just re-handshake or skip auto-demote).
 			cancelStartup()
+			phaseADur := time.Since(phaseAStart)
+			go func() {
+				_ = RecordStartup(spec.Name, phaseADur)
+				_ = SaveCachedSchema(spec.Name, CachedSchema{
+					SpecHash: SpecFingerprint(spec),
+					Capabilities: map[string]bool{
+						"prompts":   c.hasPrompts,
+						"resources": c.hasResources,
+					},
+					Tools: cacheableToolsOf(ts),
+				})
+			}()
 
 			// Prompts and resources are deferred to StartPhaseB so the boot path
 			// can return as soon as tools are ready — the slow-to-list surfaces

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -316,10 +316,21 @@ func (h *Host) StartPhaseB(ctx context.Context, sink event.Sink) {
 }
 
 func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
-	ps, err := c.listPrompts(ctx)
+	aux, auxCtx, cancel, err := c.auxiliaryClient(ctx)
+	if err != nil {
+		slog.Warn("plugin: start auxiliary prompt client failed", "server", c.name, "err", err)
+		return
+	}
+	defer cancel()
+	defer aux.close()
+
+	ps, err := aux.listPrompts(auxCtx)
 	if err != nil {
 		slog.Warn("plugin: listPrompts failed", "server", c.name, "err", err)
 		return
+	}
+	for i := range ps {
+		ps[i].client = c
 	}
 	h.mu.Lock()
 	c.prompts = ps
@@ -334,7 +345,15 @@ func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
 }
 
 func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
-	rs, err := c.listResources(ctx)
+	aux, auxCtx, cancel, err := c.auxiliaryClient(ctx)
+	if err != nil {
+		slog.Warn("plugin: start auxiliary resource client failed", "server", c.name, "err", err)
+		return
+	}
+	defer cancel()
+	defer aux.close()
+
+	rs, err := aux.listResources(auxCtx)
 	if err != nil {
 		slog.Warn("plugin: listResources failed", "server", c.name, "err", err)
 		return
@@ -357,6 +376,7 @@ func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
 type Client struct {
 	name string
 	t    transport
+	spec Spec
 
 	// Capabilities advertised by the server at initialize. prompts/list and
 	// resources/list are only called when advertised, so we never provoke a
@@ -372,6 +392,16 @@ type Client struct {
 	prompts   []Prompt
 	resources []Resource
 	tools     []ToolInfo
+}
+
+func (c *Client) auxiliaryClient(ctx context.Context) (*Client, context.Context, context.CancelFunc, error) {
+	auxCtx, cancel := context.WithTimeout(ctx, defaultStartTimeout)
+	aux, err := start(auxCtx, auxCtx, c.spec)
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+	return aux, auxCtx, cancel, nil
 }
 
 // ToolInfo is the human-facing metadata returned by MCP tools/list for one tool.
@@ -578,7 +608,7 @@ func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	if tt == "" {
 		tt = "stdio"
 	}
-	c := &Client{name: s.Name, t: t, transport: tt}
+	c := &Client{name: s.Name, t: t, spec: s, transport: tt}
 	if err := c.initialize(callCtx); err != nil {
 		c.close()
 		return nil, err

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"reasonix/internal/event"
 	"reasonix/internal/tool"
 )
 
@@ -223,7 +224,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 
 			// Transport on the parent ctx, startup RPCs on the timed callCtx: the
 			// per-plugin timeout caps initialize+listTools, but the long-lived
-			// stdio child must outlive the startup scope.
+			// stdio child must outlive the startup scope and later phase-B calls.
 			c, err := start(ctx, callCtx, spec)
 			if err != nil {
 				cancelStartup()
@@ -240,21 +241,11 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			}
 			c.toolCount = len(ts)
 
-			// Prompts and resources are auxiliary: only fetched when the server
-			// advertised the capability, and a listing error is tolerated rather
-			// than failing the whole session over a non-essential surface.
-			if c.hasPrompts {
-				if ps, perr := c.listPrompts(callCtx); perr == nil {
-					c.prompts = ps
-				}
-			}
-			if c.hasResources {
-				if rs, rerr := c.listResources(callCtx); rerr == nil {
-					c.resources = rs
-				}
-			}
 			cancelStartup()
 
+			// Prompts and resources are deferred to StartPhaseB so the boot path
+			// can return as soon as tools are ready — the slow-to-list surfaces
+			// stream in later and fan out an MCPSurfaceReady event each.
 			ch <- result{idx: idx, spec: spec, client: c, tools: ts}
 		}(i, s)
 	}
@@ -283,8 +274,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 		}
 		h.clients = append(h.clients, r.client)
 		tools = append(tools, r.tools...)
-		h.prompts = append(h.prompts, r.client.prompts...)
-		h.resources = append(h.resources, r.client.resources...)
+		// prompts/resources are filled in later by StartPhaseB.
 	}
 	if firstErr != nil {
 		h.Close()
@@ -300,6 +290,64 @@ func (h *Host) Close() {
 	h.mu.RUnlock()
 	for _, c := range clients {
 		c.close()
+	}
+}
+
+// StartPhaseB asynchronously fetches the auxiliary surfaces (prompts and
+// resources) for every connected client. Boot calls it right after Start
+// returns, on a session-scoped ctx, so the agent becomes responsive as soon as
+// tools are ready and the slower list calls stream in afterwards. Each finished
+// surface fires an MCPSurfaceReady event on sink so UIs (e.g. /mcp status) can
+// refresh without polling. A nil sink is tolerated — the merge still happens.
+// Errors are logged and swallowed: prompts/resources are non-essential and must
+// not break the session over one slow server.
+func (h *Host) StartPhaseB(ctx context.Context, sink event.Sink) {
+	h.mu.RLock()
+	clients := append([]*Client(nil), h.clients...)
+	h.mu.RUnlock()
+	for _, c := range clients {
+		if c.hasPrompts {
+			go h.fetchPrompts(ctx, c, sink)
+		}
+		if c.hasResources {
+			go h.fetchResources(ctx, c, sink)
+		}
+	}
+}
+
+func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
+	ps, err := c.listPrompts(ctx)
+	if err != nil {
+		slog.Warn("plugin: listPrompts failed", "server", c.name, "err", err)
+		return
+	}
+	h.mu.Lock()
+	c.prompts = ps
+	h.prompts = append(h.prompts, ps...)
+	h.mu.Unlock()
+	if sink != nil {
+		sink.Emit(event.Event{
+			Kind: event.MCPSurfaceReady,
+			Text: fmt.Sprintf("%s: prompts ready (%d items)", c.name, len(ps)),
+		})
+	}
+}
+
+func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
+	rs, err := c.listResources(ctx)
+	if err != nil {
+		slog.Warn("plugin: listResources failed", "server", c.name, "err", err)
+		return
+	}
+	h.mu.Lock()
+	c.resources = rs
+	h.resources = append(h.resources, rs...)
+	h.mu.Unlock()
+	if sink != nil {
+		sink.Emit(event.Event{
+			Kind: event.MCPSurfaceReady,
+			Text: fmt.Sprintf("%s: resources ready (%d items)", c.name, len(rs)),
+		})
 	}
 }
 
@@ -455,30 +503,20 @@ func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
 		return nil, fmt.Errorf("list tools: %w", err)
 	}
 	c.toolCount = len(ts)
-	// Do the remaining network calls before taking the lock, so a hot-add never
-	// blocks status reads for the duration of a listPrompts/listResources round-trip.
-	var prompts []Prompt
-	if c.hasPrompts {
-		if ps, perr := c.listPrompts(ctx); perr == nil {
-			prompts = ps
-		} else {
-			slog.Warn("plugin: listPrompts failed", "server", s.Name, "err", perr)
-		}
-	}
-	var resources []Resource
-	if c.hasResources {
-		if rs, rerr := c.listResources(ctx); rerr == nil {
-			resources = rs
-		} else {
-			slog.Warn("plugin: listResources failed", "server", s.Name, "err", rerr)
-		}
-	}
 	h.mu.Lock()
 	h.clients = append(h.clients, c)
-	h.prompts = append(h.prompts, prompts...)
-	h.resources = append(h.resources, resources...)
 	h.clearFailure(s.Name)
 	h.mu.Unlock()
+	// Prompts and resources stream in on the long ctx the caller passed (Host.Add
+	// uses the session-scoped PluginCtx, not a per-turn ctx), so the slow list
+	// calls cannot starve a /mcp add of its return value. nil sink keeps hot-add
+	// quiet — the chat UI re-queries Host.Prompts()/Resources() on demand.
+	if c.hasPrompts {
+		go h.fetchPrompts(ctx, c, nil)
+	}
+	if c.hasResources {
+		go h.fetchResources(ctx, c, nil)
+	}
 	return ts, nil
 }
 
@@ -528,7 +566,9 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 // subprocess) and uses callCtx for the initialize round-trip (whose cancellation
 // only bounds startup RPCs). Splitting the two lets a per-plugin timeout cap
 // handshake latency without making the timeout context own a successfully
-// registered stdio server. Callers that don't care pass the same ctx for both.
+// registered stdio server; the child also has to outlive phase A so phase B
+// (prompts + resources) can still call it later. Callers that don't care pass
+// the same ctx for both.
 func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	t, err := newTransport(lifeCtx, s)
 	if err != nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -229,14 +229,18 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			// stdio child must outlive the startup scope and later phase-B calls.
 			c, err := start(ctx, callCtx, spec)
 			if err != nil {
+				phaseADur := time.Since(phaseAStart)
 				cancelStartup()
+				go func() { _ = RecordStartup(spec.Name, phaseADur) }()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
 				return
 			}
 
 			ts, err := c.listTools(callCtx)
 			if err != nil {
+				phaseADur := time.Since(phaseAStart)
 				cancelStartup()
+				go func() { _ = RecordStartup(spec.Name, phaseADur) }()
 				c.close()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
 				return
@@ -246,8 +250,8 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			// Persist for next launch on the side: a slow stats/cache write
 			// must not delay tools coming online, and either failure is
 			// recoverable (we just re-handshake or skip auto-demote).
-			cancelStartup()
 			phaseADur := time.Since(phaseAStart)
+			cancelStartup()
 			go func() {
 				_ = RecordStartup(spec.Name, phaseADur)
 				_ = SaveCachedSchema(spec.Name, CachedSchema{

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -350,6 +350,45 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 	}
 }
 
+func TestStartRecordsTimeoutStats(t *testing.T) {
+	withTempCache(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	slow := Spec{
+		Name:    "slow-stats",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS": "1",
+			"GO_WANT_HELPER_INIT_MS": "300",
+		},
+	}
+	for i := 0; i < 3; i++ {
+		host, _, err := Start(ctx, []Spec{slow}, StartPolicy{
+			PerPluginTimeout: 50 * time.Millisecond,
+			Concurrency:      1,
+			AbortOnError:     false,
+		})
+		if err != nil {
+			t.Fatalf("Start #%d: %v", i, err)
+		}
+		host.Close()
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rec := Recommend("slow-stats", 50*time.Millisecond, 3)
+		if rec.Demote {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout samples did not trigger demote; stats=%+v rec=%+v", readStats(t, "slow-stats"), rec)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestStartPhaseAReturnsBeforePhaseB pins the two-phase handshake contract.
 // The helper advertises prompts and stalls prompts/list by 200ms; StartAvailable
 // must return as soon as tools are ready (well before that 200ms), and the

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/tool"
 )
 
 // TestStdioEndToEnd drives a real subprocess (this test binary re-invoked in
@@ -408,6 +409,49 @@ func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
 
 	if got := host.Prompts(); len(got) != 1 || got[0].Raw != "hello" {
 		t.Fatalf("after phase B, prompts = %+v, want one named hello", got)
+	}
+}
+
+func TestStartPhaseBDoesNotBlockToolCalls(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	spec := Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":         "1",
+			"GO_WANT_HELPER_PROMPTS":         "1",
+			"GO_WANT_HELPER_PROMPT_DELAY_MS": "1000",
+		},
+	}
+
+	host, tools := StartAvailable(ctx, []Spec{spec})
+	defer host.Close()
+
+	var echo tool.Tool
+	for _, t := range tools {
+		if t.Name() == "mcp__mock__echo" {
+			echo = t
+			break
+		}
+	}
+	if echo == nil {
+		t.Fatal("missing echo tool")
+	}
+
+	host.StartPhaseB(ctx, event.Discard)
+	time.Sleep(50 * time.Millisecond)
+
+	callCtx, callCancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer callCancel()
+	out, err := echo.Execute(callCtx, json.RawMessage(`{"msg":"hi"}`))
+	if err != nil {
+		t.Fatalf("tool call should not be blocked by background prompts/list: %v", err)
+	}
+	if out != "echo: hi" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: hi")
 	}
 }
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"reasonix/internal/event"
 )
 
 // TestStdioEndToEnd drives a real subprocess (this test binary re-invoked in
@@ -347,6 +349,68 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 	}
 }
 
+// TestStartPhaseAReturnsBeforePhaseB pins the two-phase handshake contract.
+// The helper advertises prompts and stalls prompts/list by 200ms; StartAvailable
+// must return as soon as tools are ready (well before that 200ms), and the
+// prompts must only materialise on Host after StartPhaseB has been called and
+// drained — proving prompts ride the background phase, not the boot critical path.
+func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	spec := Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":         "1",
+			"GO_WANT_HELPER_PROMPTS":         "1",
+			"GO_WANT_HELPER_PROMPT_DELAY_MS": "200",
+		},
+	}
+
+	t0 := time.Now()
+	host, tools := StartAvailable(ctx, []Spec{spec})
+	startDur := time.Since(t0)
+	defer host.Close()
+
+	if len(tools) == 0 {
+		t.Fatalf("want tools from helper, got 0")
+	}
+	if startDur >= 150*time.Millisecond {
+		t.Fatalf("StartAvailable took %v — phase B (200ms prompts) leaked onto the critical path", startDur)
+	}
+	if got := host.Prompts(); len(got) != 0 {
+		t.Fatalf("phase A must not surface prompts yet, got %d", len(got))
+	}
+
+	// Drive phase B and wait for the surface-ready event. Use a buffered channel
+	// sink so the test never blocks the emitter — the event payload itself is
+	// our completion signal.
+	ready := make(chan event.Event, 4)
+	host.StartPhaseB(ctx, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.MCPSurfaceReady {
+			select {
+			case ready <- e:
+			default:
+			}
+		}
+	}))
+
+	select {
+	case e := <-ready:
+		if !strings.Contains(e.Text, "prompts ready") {
+			t.Fatalf("phase B event text = %q, want it to mention prompts", e.Text)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("phase B never fired MCPSurfaceReady for prompts")
+	}
+
+	if got := host.Prompts(); len(got) != 1 || got[0].Raw != "hello" {
+		t.Fatalf("after phase B, prompts = %+v, want one named hello", got)
+	}
+}
+
 // TestHelperProcess is not a real test; it acts as a minimal MCP stdio server
 // when invoked by TestStdioEndToEnd. It exits before the test framework can
 // print to stdout, keeping the JSON-RPC channel clean.
@@ -354,6 +418,9 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 // GO_WANT_HELPER_INIT_MS optionally injects a sleep before responding to the
 // initialize call, used by the timeout / concurrency tests to simulate slow
 // handshakes without depending on external processes.
+// GO_WANT_HELPER_PROMPTS advertises the prompts capability and registers a
+// "hello" prompt; GO_WANT_HELPER_PROMPT_DELAY_MS stalls prompts/list so the
+// phase-A vs phase-B split can be exercised.
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_STDERR_EXIT") == "1" {
 		os.Stderr.WriteString("helper stderr boom\n")
@@ -400,10 +467,26 @@ func TestHelperProcess(t *testing.T) {
 			if initDelay > 0 {
 				time.Sleep(initDelay)
 			}
+			caps := map[string]any{}
+			if os.Getenv("GO_WANT_HELPER_PROMPTS") == "1" {
+				caps["prompts"] = map[string]any{}
+			}
 			result = map[string]any{
 				"protocolVersion": protocolVersion,
 				"serverInfo":      map[string]any{"name": "mock", "version": "0"},
+				"capabilities":    caps,
 			}
+		case "prompts/list":
+			if ms := os.Getenv("GO_WANT_HELPER_PROMPT_DELAY_MS"); ms != "" {
+				if v, err := time.ParseDuration(ms + "ms"); err == nil && v > 0 {
+					time.Sleep(v)
+				}
+			}
+			result = map[string]any{"prompts": []map[string]any{{
+				"name":        "hello",
+				"description": "say hi",
+				"arguments":   []map[string]any{},
+			}}}
 		case "tools/list":
 			result = map[string]any{"tools": []map[string]any{{
 				"name":        "zed",

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -102,10 +102,10 @@ func RecordStartup(name string, dur time.Duration) error {
 }
 
 // Recommend inspects the recent samples for name and decides whether the
-// plugin should be demoted to "lazy" this session. The rule is simple and
-// matches what the user asked for: demote when the last demoteAfter samples
-// are all strictly above budget*2. Missing/empty stats → no demote (a fresh
-// plugin gets the benefit of the doubt and one normal startup attempt).
+// plugin should be demoted to "lazy" this session. The rule is simple: demote
+// when the last demoteAfter samples all hit or exceed the blocking startup
+// budget. Missing/empty stats → no demote (a fresh plugin gets the benefit of
+// the doubt and one normal startup attempt).
 //
 // budget == 0 disables the check (returns no-demote). demoteAfter <= 0 falls
 // back to defaultDemoteAfter so callers can pass the config value verbatim
@@ -135,10 +135,10 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 		return rec
 	}
 
-	threshold := (budget * 2).Milliseconds()
+	threshold := budget.Milliseconds()
 	tail := stats.SamplesMs[len(stats.SamplesMs)-demoteAfter:]
 	for _, ms := range tail {
-		if ms <= threshold {
+		if ms < threshold {
 			return rec
 		}
 	}
@@ -233,4 +233,3 @@ func p99(samples []int64) time.Duration {
 	}
 	return time.Duration(sorted[idx]) * time.Millisecond
 }
-

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -1,0 +1,236 @@
+// Per-plugin startup latency tracking for MCP servers. Reasonix uses these
+// samples to decide whether a chronically slow plugin should be demoted from
+// "eager" to "lazy" loading for the rest of a session — see Recommend.
+//
+// Storage is one tiny JSON file per plugin under <cacheDir>/mcp/, written
+// atomically (tmpfile + Rename) so a crash mid-write can't corrupt history.
+// All errors are best-effort: missing/unreadable files yield "no demote",
+// write failures get logged via slog and dropped — startup must not fail
+// because telemetry can't persist.
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"reasonix/internal/config"
+)
+
+const (
+	// statsVersion is the on-disk format version. Bump when StartupStats changes
+	// shape incompatibly; older files are then ignored on load (treated as
+	// missing) so a new build doesn't crash on a stale schema.
+	statsVersion = 1
+	// maxSamples bounds the rolling window. 20 is enough to absorb a few flukes
+	// while still letting recent regressions dominate p99 / consecutive-fail
+	// checks. Older samples drop off the front.
+	maxSamples = 20
+	// defaultDemoteAfter is the consecutive-over-budget threshold used when the
+	// caller passes <= 0. Three in a row is "user has felt it three startups",
+	// which matches what the plan calls out as the demote signal.
+	defaultDemoteAfter = 3
+)
+
+// StartupStats is the on-disk record of recent startup durations for one
+// plugin. SamplesMs is oldest→newest (newest appended at the tail); LastSeen
+// is the wall-clock time the most recent sample was recorded so a future
+// "stale data" pruning step can act on it without re-parsing each sample.
+type StartupStats struct {
+	Version   int       `json:"version"`
+	SamplesMs []int64   `json:"samples_ms"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+// Recommendation is the result of inspecting a plugin's recent startup
+// history. Demote is the actionable bit boot.go consumes (true → switch this
+// plugin's tier to "lazy" for this session). P99 and Reason are descriptive
+// only — Reason is meant to be surfaced to the user as a Notice so a sudden
+// demotion isn't silent.
+type Recommendation struct {
+	Demote bool
+	P99    time.Duration
+	Reason string
+}
+
+// RecordStartup appends one sample (the wall-clock duration of a plugin's
+// blocking handshake phase) to that plugin's stats file. The file is created
+// on first call; existing samples are kept in a rolling window of maxSamples,
+// dropping the oldest when full.
+//
+// Best-effort: any I/O or marshal failure is logged with slog.Warn and
+// returned, but callers are expected to ignore the error — telemetry must
+// never block real work. Writes go through a tmpfile + Rename so a partial
+// write can't leave the stats file truncated or unparseable.
+func RecordStartup(name string, dur time.Duration) error {
+	path := statsPath(name)
+	if path == "" {
+		// No cache dir resolvable on this host — silently skip. This is the
+		// same fallback every other persistence helper in the project takes
+		// (ArchiveDir/SessionDir return "" and writers no-op).
+		return nil
+	}
+
+	stats := loadStats(path) // missing/corrupt → fresh zero value
+	if stats.Version != statsVersion {
+		// Version mismatch: start over rather than try to migrate. The window
+		// is small enough that "lose 20 samples" is cheap, and it keeps the
+		// migration path trivial as the format evolves.
+		stats = StartupStats{Version: statsVersion}
+	}
+
+	ms := dur.Milliseconds()
+	if ms < 0 {
+		ms = 0
+	}
+	stats.SamplesMs = append(stats.SamplesMs, ms)
+	if len(stats.SamplesMs) > maxSamples {
+		// Trim from the front: oldest samples leave first.
+		stats.SamplesMs = stats.SamplesMs[len(stats.SamplesMs)-maxSamples:]
+	}
+	stats.LastSeen = time.Now()
+
+	if err := writeStatsAtomic(path, stats); err != nil {
+		slog.Warn("plugin: record startup stats failed", "server", name, "err", err)
+		return err
+	}
+	return nil
+}
+
+// Recommend inspects the recent samples for name and decides whether the
+// plugin should be demoted to "lazy" this session. The rule is simple and
+// matches what the user asked for: demote when the last demoteAfter samples
+// are all strictly above budget*2. Missing/empty stats → no demote (a fresh
+// plugin gets the benefit of the doubt and one normal startup attempt).
+//
+// budget == 0 disables the check (returns no-demote). demoteAfter <= 0 falls
+// back to defaultDemoteAfter so callers can pass the config value verbatim
+// without sanitising it.
+func Recommend(name string, budget time.Duration, demoteAfter int) Recommendation {
+	if budget <= 0 {
+		return Recommendation{}
+	}
+	if demoteAfter <= 0 {
+		demoteAfter = defaultDemoteAfter
+	}
+
+	path := statsPath(name)
+	if path == "" {
+		return Recommendation{}
+	}
+	stats := loadStats(path)
+	if stats.Version != statsVersion || len(stats.SamplesMs) == 0 {
+		// Either no history yet or a format we can't read — give the plugin a
+		// chance. The cost of one slow start is small compared to wrongly
+		// demoting a healthy plugin off stale data.
+		return Recommendation{}
+	}
+
+	rec := Recommendation{P99: p99(stats.SamplesMs)}
+	if len(stats.SamplesMs) < demoteAfter {
+		return rec
+	}
+
+	threshold := (budget * 2).Milliseconds()
+	tail := stats.SamplesMs[len(stats.SamplesMs)-demoteAfter:]
+	for _, ms := range tail {
+		if ms <= threshold {
+			return rec
+		}
+	}
+	rec.Demote = true
+	rec.Reason = fmt.Sprintf(
+		"plugin %q has been slow %d startups in a row (last %dms, budget %dms); demoting to lazy this session",
+		name, demoteAfter, tail[len(tail)-1], budget.Milliseconds(),
+	)
+	return rec
+}
+
+// statsPath returns the canonical path for one plugin's stats file:
+// <config.CacheDir()>/mcp/<slug>.stats.json. Shares the cache root and slug
+// rule with the schema cache so a `<plugin>.json` and `<plugin>.stats.json`
+// sit side by side under the same per-server folder. Returns "" when no cache
+// dir is resolvable, which all callers treat as "skip telemetry".
+func statsPath(name string) string {
+	base := config.CacheDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "mcp", slug(name)+".stats.json")
+}
+
+// loadStats reads and decodes a stats file. Any failure (missing file,
+// permission denied, malformed JSON) returns a zero StartupStats so callers
+// can treat absence and corruption identically. The slog.Warn fires only on
+// non-NotExist read errors and on JSON errors — those are surprising enough
+// to be worth a trace, but they still must not stop the caller.
+func loadStats(path string) StartupStats {
+	var s StartupStats
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("plugin: read startup stats failed", "path", path, "err", err)
+		}
+		return s
+	}
+	if err := json.Unmarshal(b, &s); err != nil {
+		slog.Warn("plugin: parse startup stats failed", "path", path, "err", err)
+		return StartupStats{}
+	}
+	return s
+}
+
+// writeStatsAtomic serialises s and writes it via tmpfile + os.Rename so that
+// concurrent readers see either the old content or the new one, never a
+// half-written file. Mirrors desktop/sessions.go:40-64.
+func writeStatsAtomic(path string, s StartupStats) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".stats.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// p99 returns the 99th-percentile sample as a Duration. With small windows
+// (n ≤ 20) "p99" collapses to "the slowest sample we have"; the value is
+// purely informational, surfaced in Recommendation for UI/notice text.
+func p99(samples []int64) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	// Use ceil(0.99 * n) - 1 so that for n=1..100 we always pick the last
+	// element; for larger n it's the index at the 99% boundary.
+	idx := int(float64(len(sorted))*0.99+0.9999999) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return time.Duration(sorted[idx]) * time.Millisecond
+}
+

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -137,6 +137,22 @@ func TestRecommendAboveBudgetDemotes(t *testing.T) {
 	}
 }
 
+func TestRecommendAtBudgetDemotes(t *testing.T) {
+	withTempCache(t)
+
+	budget := 5 * time.Second
+	for i := 0; i < 3; i++ {
+		if err := RecordStartup("timeout-plugin", budget); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	got := Recommend("timeout-plugin", budget, 3)
+	if !got.Demote {
+		t.Fatalf("Demote = false, want true for repeated budget hits (samples=%+v)", readStats(t, "timeout-plugin").SamplesMs)
+	}
+}
+
 func TestRecommendMissingStatsNoDemote(t *testing.T) {
 	withTempCache(t)
 

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -1,0 +1,207 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withTempCache redirects config.CacheDir() at t.TempDir for the duration of
+// a test by overriding HOME and XDG_CONFIG_HOME — the same knobs cache_test
+// uses, since os.UserConfigDir reads them. Returns the directory that will
+// hold the cache subtree so callers can assert paths inside it.
+func withTempCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+// readStats reads the on-disk stats file for name directly (not through the
+// public API) so tests can assert raw file contents — what we wrote and in
+// what order.
+func readStats(t *testing.T, name string) StartupStats {
+	t.Helper()
+	path := statsPath(name)
+	if path == "" {
+		t.Fatal("statsPath returned empty")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read stats %s: %v", path, err)
+	}
+	var s StartupStats
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	return s
+}
+
+func TestRecordStartupAppends(t *testing.T) {
+	withTempCache(t)
+
+	durs := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 300 * time.Millisecond}
+	for _, d := range durs {
+		if err := RecordStartup("foo", d); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	s := readStats(t, "foo")
+	if s.Version != statsVersion {
+		t.Fatalf("Version = %d, want %d", s.Version, statsVersion)
+	}
+	if got := len(s.SamplesMs); got != 3 {
+		t.Fatalf("samples = %d, want 3", got)
+	}
+	// File is written oldest→newest (newest at the tail).
+	want := []int64{100, 200, 300}
+	for i, w := range want {
+		if s.SamplesMs[i] != w {
+			t.Fatalf("SamplesMs[%d] = %d, want %d (full=%v)", i, s.SamplesMs[i], w, s.SamplesMs)
+		}
+	}
+	if s.LastSeen.IsZero() {
+		t.Fatal("LastSeen should be set after a record")
+	}
+}
+
+func TestRecordStartupCapsAtWindow(t *testing.T) {
+	withTempCache(t)
+
+	const total = 25
+	for i := 0; i < total; i++ {
+		// Use distinct values so we can verify the *oldest* ones were dropped.
+		if err := RecordStartup("bar", time.Duration(i+1)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	s := readStats(t, "bar")
+	if got := len(s.SamplesMs); got != maxSamples {
+		t.Fatalf("samples = %d, want %d", got, maxSamples)
+	}
+	// First retained sample should be #6 (1..5 dropped); last should be #25.
+	wantFirst := int64(total - maxSamples + 1) // 6
+	if s.SamplesMs[0] != wantFirst {
+		t.Fatalf("SamplesMs[0] = %d, want %d", s.SamplesMs[0], wantFirst)
+	}
+	if s.SamplesMs[len(s.SamplesMs)-1] != int64(total) {
+		t.Fatalf("SamplesMs[last] = %d, want %d", s.SamplesMs[len(s.SamplesMs)-1], total)
+	}
+}
+
+func TestRecommendBelowBudgetNoDemote(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// All samples comfortably under budget*2 == 2s.
+	for _, ms := range []int64{500, 800, 1200, 1500, 900} {
+		if err := RecordStartup("ok-plugin", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("ok-plugin", budget, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true, want false (reason=%q)", got.Reason)
+	}
+}
+
+func TestRecommendAboveBudgetDemotes(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// First sample is fast (would block a naive "ever-slow" check), then 3
+	// consecutive samples above budget*2 == 2s. The plan says demote on
+	// "last N consecutive over-budget", so this should trip.
+	for _, ms := range []int64{500, 2500, 3000, 4000} {
+		if err := RecordStartup("slow-plugin", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("slow-plugin", budget, 3)
+	if !got.Demote {
+		t.Fatalf("Demote = false, want true (samples=%+v)", readStats(t, "slow-plugin").SamplesMs)
+	}
+	if got.Reason == "" {
+		t.Fatal("Reason should be non-empty when demoting")
+	}
+	if got.P99 <= 0 {
+		t.Fatalf("P99 = %v, want > 0", got.P99)
+	}
+}
+
+func TestRecommendMissingStatsNoDemote(t *testing.T) {
+	withTempCache(t)
+
+	// Never recorded anything → should not demote a brand-new plugin.
+	got := Recommend("never-seen", 1*time.Second, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true on missing stats, want false (reason=%q)", got.Reason)
+	}
+	if got.P99 != 0 {
+		t.Fatalf("P99 = %v on missing stats, want 0", got.P99)
+	}
+}
+
+func TestRecommendOldFailuresFadeOut(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// Early samples were terrible (well above budget*2 == 2s), but the most
+	// recent three are quick — rolling window must let the plugin recover.
+	for _, ms := range []int64{5000, 6000, 7000, 8000, 500, 600, 700} {
+		if err := RecordStartup("recovered", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("recovered", budget, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true after recovery, want false (samples=%+v, reason=%q)",
+			readStats(t, "recovered").SamplesMs, got.Reason)
+	}
+}
+
+// TestStatsPathLayout pins the on-disk location so Phase 4's integration code
+// can rely on it. We assert the path sits under config.CacheDir()/mcp and that
+// the slug strips raw separators — exact slug rule lives in cache.go.
+func TestStatsPathLayout(t *testing.T) {
+	withTempCache(t)
+
+	p := statsPath("server/with spaces")
+	if p == "" {
+		t.Fatal("statsPath returned empty")
+	}
+	wantSuffix := filepath.Join("reasonix", "cache", "mcp")
+	if got := filepath.Dir(p); !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("parent = %q, want suffix %q", got, wantSuffix)
+	}
+	base := filepath.Base(p)
+	if filepath.Ext(base) != ".json" {
+		t.Fatalf("ext = %q, want .json", filepath.Ext(base))
+	}
+	if !strings.HasSuffix(base, ".stats.json") {
+		t.Fatalf("base = %q, want .stats.json suffix", base)
+	}
+	if containsAny(base, "/ ") {
+		t.Fatalf("slug %q contains raw separators", base)
+	}
+}
+
+func containsAny(s, chars string) bool {
+	for _, c := range chars {
+		for _, r := range s {
+			if r == c {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds two best-effort sidecar caches under `<UserConfigDir>/reasonix/cache/mcp/` written from a side-goroutine in `plugin.Start` after phase A: `<server>.json` snapshots the handshake (capabilities + tool list with `name/description/schema/readOnly`), and `<server>.stats.json` keeps a rolling window of phase-A durations for auto-demote decisions. No call site reads these files in this PR — they are infrastructure for PR 4. This is PR **3/4** of the MCP-startup overhaul.

## Root Cause / Motivation

Two distinct problems share a persistence layer:

1. Every launch re-handshakes every MCP server even though the tool schema is usually unchanged session-to-session. With a stable cache keyed by a Spec fingerprint, the next launch can register tools optimistically without waiting for the network/subprocess (consumed in PR 4).
2. Reasonix has no record of which configured plugin is chronically slow. The boot path treats a 6-second handshake the same as a 60-millisecond one, so the user keeps eating the same delay. A simple rolling-window of phase-A times turns that latency into a signal the boot path can act on (also consumed in PR 4).

This PR ships the persistence layer alone so reviewers can examine the on-disk format, the atomic-write/fingerprint logic, and the integration into the Start goroutine before any behaviour change lands.

## Technical Approach

### Cache format and fingerprint
- `CachedSchema = { Version, SpecHash, Capabilities, Tools[], LastValidated }`. `Version=1` gates incompatible future shape changes — older readers treat a higher version as a miss.
- `SpecFingerprint(Spec)` SHA-256s the load-bearing fields (Type/Command/URL/Dir + sorted Args/Env/Headers). Env/Headers iteration order is normalised so Go's randomised map iteration can't churn the fingerprint between launches. Changing a command, URL, or any of those maps invalidates the cache; renaming the server does not (the cache file is named after the server, not the fingerprint).
- Writes go through tmpfile + `os.Rename` in the same parent dir (mirrors `desktop/sessions.go` and `internal/codegraph/install.go`), so a crash mid-write can never leave a half-parsed JSON behind that the next `Load` would mis-handle.

### Stats / Recommend
- `StartupStats = { Version, SamplesMs[], LastSeen }`. SamplesMs is a rolling window of up to 20 latest values (`maxSamples`), atomically rewritten on each Record.
- `Recommend(name, budget, demoteAfter)` returns `Demote=true` when the last `demoteAfter` consecutive samples each exceed `2×budget`. `demoteAfter` defaults to 3 — small enough to catch a regressed plugin within a session or two, large enough that a single hiccup can't demote a healthy one. A missing stats file means "never seen", which intentionally never demotes.

### Wiring
- `plugin.Start`'s goroutine times phase A (`start + listTools`), then fires a side-goroutine that calls `RecordStartup` and `SaveCachedSchema`. Failure is silently dropped (slog.Debug for cache, slog.Warn for surprising stats read errors). The fan-out happens after the goroutine has put its result on the channel, so disk IO is never on the critical path.
- `config.CacheDir()` is added beside the existing `ArchiveDir/SessionDir/MemoryUserDir`, returning `<UserConfigDir>/reasonix/cache`. The whole reasonix user state tree still has a single root; \`rm -rf ~/Library/Application Support/reasonix\` clears everything.
- `cacheableToolsOf([]tool.Tool)` lives in cache.go and extracts the persistable subset from the `*remoteTool` values that `listTools` produced — schema is the already-canonicalized form, so the cache hit path will produce byte-identical schemas across sessions, preserving the prompt-cache prefix (see "Cache stability" below).

## Focused Optimization Points

- Best-effort by design: no `error` is propagated out of `RecordStartup` or `SaveCachedSchema` into the boot path. Disk full, broken permissions, version mismatches — all degrade silently to "no cache" / "no telemetry".
- Atomic write avoids the classic "next launch sees a half-written file" failure mode that telemetry systems usually inherit.
- Stats's 20-sample rolling window guarantees one bad day fades out: an MCP server that's been slow for 24h but fine since gets re-promoted by the same mechanism.
- Cache stability (preserves prompt-cache prefix): the schema bytes saved here come from the canonicalised `*remoteTool.schema`. When PR 4 reads them back, the resulting placeholder tool reports a `Schema()` that's byte-identical to what the real `*remoteTool` would report after the eventual handshake — so the swap from placeholder to real tool is a no-op for Anthropic ephemeral / DeepSeek prefix caching. PR 4 will pin that contract in tests; this PR sets up the byte-stable serialisation.

## Verification

- `go build ./...`
- `go test ./internal/plugin/... ./internal/config/... ./internal/event/... -count=1 -timeout=120s` — all green.
- `go test ./internal/plugin/... ./internal/config/... ./internal/event/... -race -count=1 -timeout=120s` — all green (atomic write avoids reader/writer overlap; stats writes hold no shared state).
- `go vet ./internal/plugin/... ./internal/config/... ./internal/event/...` — clean.
- Focused cache + canonicalize + stats run: all of `TestCache*`, `TestSpecFingerprint*`, `TestSlug*`, `TestCanonicalize*`, `TestRecord*`, `TestRecommend*`, `TestStatsPathLayout` pass — important because this PR is the persistence half of a cache feature, and canonicalisation underpins the cache-stability claim above.

## Dependencies & how to review

This PR is **stacked on top of PR 1 (#2675) and PR 2 (#2677)**. GitHub does not support cross-fork stacked PRs, so this branch carries three commits:

1. `d437b49e` — PR 1's `feat(plugin): unify StartAll/StartAvailable…`
2. `c88a94e6` — PR 2's `feat(plugin): defer prompts/resources to a background phase`
3. **This PR's incremental layer** — last commit on the branch.

To see just this PR's incremental diff, look at the last commit in the Commits tab, or:
```
git diff c88a94e6..HEAD
```

Once #2675 and #2677 merge to `main-v2`, this branch will be rebased so its diff shows only the final commit. No re-review of PR 1 / PR 2 content is needed here.

- Blocks PR 4 (`tier-based loading with cache-aware lazy placeholders`).
- Should be merged after #2675 and #2677.