### PR TITLE
feat(plugin): tier-based loading with cache-aware lazy placeholders

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -195,6 +195,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		for _, t := range ptools {
 			reg.Add(t)
 		}
+		// PhaseB (prompts + resources) runs on the boot ctx — which is the
+		// controller's session-scoped PluginCtx — so the auxiliary surfaces
+		// keep streaming in after Start returns without holding up the agent.
+		go host.StartPhaseB(ctx, sink)
 		if text, ok := MCPStartupNotice(host.Failures()); ok {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -145,7 +145,34 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// Always construct a host, even with no plugins configured, so the controller's
 	// host pointer is stable for the session and `/mcp add` can hot-add into it.
 	pluginHost := plugin.NewHost()
-	specs := PluginSpecs(cfg.AutoStartPlugins())
+
+	// Partition configured plugins by tier so eager/lazy/background can each
+	// take the path that fits them. User entries default to lazy — they don't
+	// slow the next launch unless the user explicitly opts in to eager.
+	eagerEntries, lazyEntries, bgEntries := partitionByTier(cfg.AutoStartPlugins())
+
+	// Auto-demote: any eager plugin that has been chronically slow (Phase 5
+	// telemetry says p99 > 2*budget over the last few starts) drops to lazy
+	// for this session. The user keeps eager intent, just doesn't pay for it
+	// on a server that's been misbehaving. A notice surfaces the demotion.
+	var demoteMessages []string
+	budget := plugin.DefaultStartupBudget()
+	kept := eagerEntries[:0]
+	for _, e := range eagerEntries {
+		rec := plugin.Recommend(e.Name, budget, 0)
+		if rec.Demote {
+			demoteMessages = append(demoteMessages, rec.Reason)
+			lazyEntries = append(lazyEntries, e)
+			continue
+		}
+		kept = append(kept, e)
+	}
+	eagerEntries = kept
+
+	eagerSpecs := PluginSpecs(eagerEntries)
+	lazySpecs := PluginSpecs(lazyEntries)
+	bgSpecs := PluginSpecs(bgEntries)
+
 	// CodeGraph is a built-in MCP server fetched on first use. When it resolves,
 	// inject it as one more stdio plugin pinned to the project root (it is
 	// cwd-aware); EnsureInit only creates .codegraph/ (fast, size-independent),
@@ -154,6 +181,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// (one-time, ~45MB) if auto_install is on — startup still never blocks, the
 	// tools come online next session — otherwise point the user at the explicit
 	// install command. A failed init or fetch is a notice, not fatal.
+	//
+	// Codegraph stays eager regardless of user tier — symbol-graph tools land
+	// in the system prompt, so the agent must see them on first turn.
 	if cfg.Codegraph.Enabled {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
@@ -162,7 +192,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 					Text: "codegraph: init failed (" + err.Error() + ") — symbol-graph tools disabled this session"})
 			}
-			specs = append(specs, plugin.Spec{Name: "codegraph", Command: bin, Args: []string{"serve", "--mcp"}, Dir: cwd})
+			eagerSpecs = append(eagerSpecs, plugin.Spec{Name: "codegraph", Command: bin, Args: []string{"serve", "--mcp"}, Dir: cwd})
 		case cfg.Codegraph.AutoInstall:
 			notify := func(msg string) { sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg}) }
 			notify("codegraph: fetching code-intelligence runtime in the background (one-time) — symbol-graph tools available next session")
@@ -183,14 +213,23 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				Text: "codegraph: not installed — run `reasonix codegraph install` to enable symbol-graph tools"})
 		}
 	}
-	if len(specs) > 0 {
-		// Apply caller-supplied stderr override to all plugin specs.
-		if opts.Stderr != nil {
-			for i := range specs {
-				specs[i].Stderr = opts.Stderr
-			}
+
+	// Apply caller-supplied stderr override to every spec across tiers.
+	if opts.Stderr != nil {
+		for i := range eagerSpecs {
+			eagerSpecs[i].Stderr = opts.Stderr
 		}
-		host, ptools := plugin.StartAvailable(ctx, specs)
+		for i := range lazySpecs {
+			lazySpecs[i].Stderr = opts.Stderr
+		}
+		for i := range bgSpecs {
+			bgSpecs[i].Stderr = opts.Stderr
+		}
+	}
+
+	// Eager: block until handshake. Failures show up in /mcp.
+	if len(eagerSpecs) > 0 {
+		host, ptools := plugin.StartAvailable(ctx, eagerSpecs)
 		pluginHost = host
 		for _, t := range ptools {
 			reg.Add(t)
@@ -203,6 +242,26 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}
 	}
+
+	// Lazy / background: register placeholder tools now; the real spawn waits
+	// for either the first model call (lazy) or a goroutine kicked off here
+	// (background). Both share the same pluginHost so /mcp status, hot-add,
+	// and Close see one cohesive set of servers regardless of tier.
+	registerDeferred := func(specs []plugin.Spec, kick bool) {
+		for _, s := range specs {
+			cs, _ := plugin.LoadCachedSchema(s.Name, plugin.SpecFingerprint(s))
+			for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, kick) {
+				reg.Add(t)
+			}
+		}
+	}
+	registerDeferred(lazySpecs, false)
+	registerDeferred(bgSpecs, true)
+
+	for _, msg := range demoteMessages {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg})
+	}
+
 	cleanup := pluginHost.Close
 
 	// LSP tools resolve their servers on PATH and spawn lazily on first query, so
@@ -506,6 +565,24 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 			reg.Add(t)
 		}
 	}
+}
+
+// partitionByTier splits configured plugin entries into the three startup
+// buckets — eager (block boot until ready), lazy (placeholder until first
+// model use), background (placeholder + start spawn now). Entries with an
+// unrecognised or empty tier land in lazy (the default).
+func partitionByTier(entries []config.PluginEntry) (eager, lazy, bg []config.PluginEntry) {
+	for _, e := range entries {
+		switch e.ResolvedTier() {
+		case "eager":
+			eager = append(eager, e)
+		case "background":
+			bg = append(bg, e)
+		default:
+			lazy = append(lazy, e)
+		}
+	}
+	return eager, lazy, bg
 }
 
 // PluginSpecs maps configured plugin entries to plugin.Spec, expanding ${VAR}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -151,8 +151,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// slow the next launch unless the user explicitly opts in to eager.
 	eagerEntries, lazyEntries, bgEntries := partitionByTier(cfg.AutoStartPlugins())
 
-	// Auto-demote: any eager plugin that has been chronically slow (Phase 5
-	// telemetry says p99 > 2*budget over the last few starts) drops to lazy
+	// Auto-demote: any eager plugin that has been chronically slow (recent
+	// samples repeatedly hit the blocking startup budget) drops to lazy
 	// for this session. The user keeps eager intent, just doesn't pay for it
 	// on a server that's been misbehaving. A notice surfaces the demotion.
 	var demoteMessages []string

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1,13 +1,20 @@
 package boot
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/config"
 	"reasonix/internal/event"
+	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 
 	// Blank imports register the provider kind and built-in tools the same way
@@ -145,6 +152,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 [[plugins]]
 name = "missing"
 command = "reasonix-missing-mcp-binary"
+tier = "eager"
 `)
 	var notices []event.Event
 	ctrl, err := Build(context.Background(), Options{
@@ -276,5 +284,325 @@ func writeFile(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := writeFileRaw(dir, name, body); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// isolateConfigHome redirects os.UserConfigDir() (and the cache subtree under
+// it) at a per-test temp dir by overriding the env vars Go's stdlib reads —
+// HOME on darwin, XDG_CONFIG_HOME on linux. Without this, Build's plugin path
+// would persist startup stats and cached schemas into the developer's real
+// ~/Library/Application Support tree and bleed state across tests. Mirrors the
+// withTempCache helper in internal/plugin/stats_test.go.
+func isolateConfigHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+// TestPartitionByTier pins the bucket assignment contract that the rest of
+// boot.go's plugin orchestration depends on: each tier string maps to its own
+// slice, the original order inside a tier is preserved (so /mcp status and
+// stats land deterministically), and a missing/unknown tier value falls into
+// lazy — the project default that keeps adding a plugin from ever slowing the
+// next launch.
+func TestPartitionByTier(t *testing.T) {
+	entries := []config.PluginEntry{
+		{Name: "e1", Tier: "eager"},
+		{Name: "l1", Tier: "lazy"},
+		{Name: "b1", Tier: "background"},
+		{Name: "default", Tier: ""}, // empty must default to lazy
+	}
+
+	eager, lazy, bg := partitionByTier(entries)
+
+	if len(eager) != 1 || eager[0].Name != "e1" {
+		t.Fatalf("eager bucket = %+v, want [e1]", eager)
+	}
+	if len(bg) != 1 || bg[0].Name != "b1" {
+		t.Fatalf("background bucket = %+v, want [b1]", bg)
+	}
+	// Lazy holds both the explicit lazy entry and the default-fallback one, in
+	// the order they appeared in the input — proves the empty-tier default
+	// flows through partition without reshuffling.
+	if len(lazy) != 2 || lazy[0].Name != "l1" || lazy[1].Name != "default" {
+		t.Fatalf("lazy bucket = %+v, want [l1, default] preserving input order", lazy)
+	}
+}
+
+// TestBuildEagerStartsAtBoot proves an eager-tier plugin actually completes
+// its handshake on the boot critical path: Host.ServerNames() must include the
+// plugin after Build returns. We point the plugin at this test binary running
+// as a stdio MCP helper (see TestHelperProcess), so the spawn is real but
+// deterministic and hermetic — no external MCP server required on PATH.
+func TestBuildEagerStartsAtBoot(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+
+[[plugins]]
+name = "eagermock"
+command = %q
+args = ["-test.run=TestHelperProcess", "--"]
+tier = "eager"
+env = { GO_WANT_HELPER_PROCESS = "1" }
+`, os.Args[0]))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	names := ctrl.Host().ServerNames()
+	found := false
+	for _, n := range names {
+		if n == "eagermock" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("eager plugin missing from Host.ServerNames() = %v — boot did not block on its handshake", names)
+	}
+	if got := ctrl.Host().Failures(); len(got) != 0 {
+		t.Fatalf("Host.Failures() = %+v, want empty for a healthy eager plugin", got)
+	}
+}
+
+// TestBuildLazyDoesNotConnectAtBoot is the inverse of the eager test: a
+// lazy-tier plugin must NOT trigger a subprocess handshake during Build, so
+// the boot critical path stays empty even with a slow-to-spawn server in
+// config. We assert through Host.ServerNames() (must not list the plugin) and
+// Host.Failures() (lazy plugins never appear here — a failure surfaces only on
+// first model use, not at boot). The placeholder tool registration itself is
+// covered by internal/plugin/lazy_test.go's TestLazy* suite; the Registry has
+// no public accessor on Controller, so at this layer we pin the load-bearing
+// boot-time invariant — no spawn — rather than re-validating the placeholder.
+func TestBuildLazyDoesNotConnectAtBoot(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+
+[[plugins]]
+name = "lazymock"
+command = %q
+args = ["-test.run=TestHelperProcess", "--"]
+tier = "lazy"
+env = { GO_WANT_HELPER_PROCESS = "1" }
+`, os.Args[0]))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, n := range ctrl.Host().ServerNames() {
+		if n == "lazymock" {
+			t.Fatalf("lazy plugin %q appeared in Host.ServerNames() — boot connected it eagerly", n)
+		}
+	}
+	if got := ctrl.Host().Failures(); len(got) != 0 {
+		t.Fatalf("Host.Failures() = %+v, want empty — lazy plugins must not even attempt a boot-time spawn", got)
+	}
+	// The configured plugin is still recognised as a configured-but-disconnected
+	// server, the same signal /mcp uses to render its "lazy, will connect on
+	// first use" line — proves the entry made it through partition into the
+	// lazy bucket rather than being dropped.
+	dconn := ctrl.DisconnectedMCPNames()
+	foundDisconnected := false
+	for _, n := range dconn {
+		if n == "lazymock" {
+			foundDisconnected = true
+			break
+		}
+	}
+	if !foundDisconnected {
+		t.Fatalf("DisconnectedMCPNames() = %v, want it to include the lazy plugin (configured but not connected)", dconn)
+	}
+}
+
+// TestBuildAutoDemoteFromStats proves the Phase 5 telemetry → Phase 4 tier
+// bridge: three consecutive over-budget startup samples must demote an
+// eager-tier plugin to lazy at the *next* boot, so the user pays for a slow
+// MCP server at most a handful of starts. We pre-seed three 30s samples for
+// "slowserver" (well above 2 * DefaultStartupBudget = 10s) via the public
+// RecordStartup API, then Build a config that declares "slowserver" eager and
+// verify (a) boot did NOT block on its handshake — the plugin is absent from
+// Host.ServerNames() — and (b) a Notice carrying the demote reason fired so
+// the user understands why their explicit "eager" was ignored this session.
+func TestBuildAutoDemoteFromStats(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Three samples above 2*budget — the rule in stats.go's Recommend triggers
+	// when the trailing window is entirely over the threshold. Use 30s so even
+	// future budget bumps stay below the threshold.
+	for i := 0; i < 3; i++ {
+		if err := plugin.RecordStartup("slowserver", 30*time.Second); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+
+[[plugins]]
+name = "slowserver"
+command = "reasonix-missing-slow-mcp-binary"
+tier = "eager"
+`)
+
+	var notices []event.Event
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, n := range ctrl.Host().ServerNames() {
+		if n == "slowserver" {
+			t.Fatalf("demoted plugin %q still appeared in Host.ServerNames() — auto-demote did not move it out of the eager bucket", n)
+		}
+	}
+	// Crucially the missing-binary command never ran: a real eager attempt
+	// would have surfaced as a Failure with a spawn error. An empty failures
+	// list proves boot skipped the spawn entirely, not that it tried and
+	// silently swallowed the error.
+	if got := ctrl.Host().Failures(); len(got) != 0 {
+		t.Fatalf("Host.Failures() = %+v, want empty — demoted plugin should never have been spawned", got)
+	}
+
+	foundDemoteNotice := false
+	for _, n := range notices {
+		if strings.Contains(n.Text, "demoting to lazy") {
+			foundDemoteNotice = true
+			break
+		}
+	}
+	if !foundDemoteNotice {
+		t.Fatalf("no demote notice surfaced; got %+v", notices)
+	}
+}
+
+// TestHelperProcess is invoked as a subprocess by TestBuildEagerStartsAtBoot
+// and TestBuildLazyDoesNotConnectAtBoot. It mirrors the minimal MCP stdio
+// server in internal/plugin/plugin_test.go so the boot package can drive an
+// end-to-end handshake without depending on the plugin package's test helper
+// (Go's testing framework only re-invokes the binary of the test package
+// currently running). The helper gates on GO_WANT_HELPER_PROCESS=1 so a
+// normal `go test ./internal/boot/...` does not trip it.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	in := bufio.NewReader(os.Stdin)
+	for {
+		line, err := in.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var req struct {
+			ID     *int            `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+		if req.ID == nil {
+			continue // notification: no response
+		}
+
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": "2024-11-05",
+				"serverInfo":      map[string]any{"name": "mock", "version": "0"},
+				"capabilities":    map[string]any{},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{{
+				"name":        "echo",
+				"description": "Echo back the message.",
+				"inputSchema": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"msg": map[string]any{"type": "string"}},
+					"required":   []string{"msg"},
+				},
+			}}}
+		}
+
+		resp := map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": result}
+		b, _ := json.Marshal(resp)
+		os.Stdout.Write(append(b, '\n'))
 	}
 }

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -123,6 +123,12 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		for _, t := range ptools {
 			reg.Add(t)
 		}
+		// Mirror boot.Build: phase B (prompts + resources) is deferred to a
+		// background goroutine on the session ctx so the ACP path also sees
+		// non-empty Host.Prompts()/Resources() once the auxiliary surfaces
+		// stream in. Without this, MCPPrompt and @-ref consumers would stay
+		// empty for the session.
+		go h.StartPhaseB(ctx, p.Sink)
 		if text, ok := boot.MCPStartupNotice(h.Failures()); ok {
 			p.Sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -526,6 +526,19 @@ func SessionDir() string {
 	return filepath.Join(dir, "reasonix", "sessions")
 }
 
+// CacheDir is the per-user cache root for derived/regenerable artefacts: MCP
+// handshake snapshots, plugin startup-latency telemetry. Lives beside the
+// existing dirs (UserConfigDir/reasonix/...) so the whole reasonix state tree
+// shares one root the user can wipe in a single rm. Empty when the OS dir is
+// unavailable — callers must tolerate that (caching is best-effort).
+func CacheDir() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "reasonix", "cache")
+}
+
 // MemoryUserDir returns the reasonix user config root (…/reasonix), under which
 // the user-global REASONIX.md and the per-project auto-memory store live. Empty
 // when the user config dir can't be resolved, which disables user-scoped memory.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,10 +326,34 @@ type PluginEntry struct {
 	// AutoStart controls whether the server connects during session startup.
 	// Nil preserves historical behavior: configured servers start automatically.
 	AutoStart *bool `toml:"auto_start"`
+	// Tier selects how aggressively the server is connected at boot:
+	//   "eager"      — blocks startup until the handshake completes; required for
+	//                  servers whose tools the system prompt depends on.
+	//   "lazy"       — registers placeholder tools immediately (from on-disk
+	//                  schema cache when available) and only spawns the real
+	//                  subprocess on first model use. Default for user plugins.
+	//   "background" — placeholder + spawn fired at boot but not waited on;
+	//                  swap happens once the spawn finishes.
+	// Empty defaults to "lazy" so adding a plugin never slows the next launch.
+	Tier string `toml:"tier"`
 }
 
 func (e PluginEntry) ShouldAutoStart() bool {
 	return e.AutoStart == nil || *e.AutoStart
+}
+
+// ResolvedTier returns the normalized tier ("eager"|"lazy"|"background") with
+// the project default applied. Unknown values fall back to "lazy" so a typo
+// never forces a slow boot.
+func (e PluginEntry) ResolvedTier() string {
+	switch strings.ToLower(strings.TrimSpace(e.Tier)) {
+	case "eager":
+		return "eager"
+	case "background":
+		return "background"
+	default:
+		return "lazy"
+	}
 }
 
 func (c *Config) AutoStartPlugins() []PluginEntry {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1234,6 +1234,7 @@ func (c *Controller) connectMCPSpec(s plugin.Spec) (int, error) {
 		return 0, err
 	}
 	if c.reg != nil {
+		c.reg.RemovePrefix(plugin.ToolPrefix(s.Name))
 		for _, t := range tools {
 			c.reg.Add(t)
 		}
@@ -1327,6 +1328,9 @@ func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error)
 	}
 	inConfig := cfg.RemovePlugin(name)
 	if inConfig {
+		if !disconnected && c.reg != nil {
+			c.reg.RemovePrefix(plugin.ToolPrefix(name))
+		}
 		if serr := cfg.Save(); serr != nil {
 			return disconnected, serr
 		}
@@ -1342,14 +1346,20 @@ func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error)
 // on the next session start, or now via ConnectConfiguredMCPServer (the "on").
 // Reports whether a live server was actually disconnected.
 func (c *Controller) DisconnectMCPServer(name string) bool {
-	if c.host == nil {
-		return false
+	disconnected := false
+	if c.host != nil {
+		if prefix, ok := c.host.Remove(name); ok {
+			disconnected = true
+			if c.reg != nil {
+				c.reg.RemovePrefix(prefix)
+			}
+		}
 	}
-	prefix, ok := c.host.Remove(name)
-	if ok && c.reg != nil {
-		c.reg.RemovePrefix(prefix)
+	removedPlaceholder := 0
+	if !disconnected && c.reg != nil {
+		removedPlaceholder = c.reg.RemovePrefix(plugin.ToolPrefix(name))
 	}
-	return ok
+	return disconnected || removedPlaceholder > 0
 }
 
 // Label returns the human-readable model label, e.g. "deepseek-flash".

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -2,13 +2,16 @@ package control
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/tool"
 )
 
 type typedNilControllerSink struct{}
@@ -23,6 +26,20 @@ func (r appendingRunner) Run(_ context.Context, input string) error {
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 	return nil
 }
+
+type fakeControlTool struct{ name string }
+
+func (t fakeControlTool) Name() string { return t.name }
+func (fakeControlTool) Description() string {
+	return "fake"
+}
+func (fakeControlTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (fakeControlTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "", nil
+}
+func (fakeControlTool) ReadOnly() bool { return true }
 
 func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
 	var sink *typedNilControllerSink
@@ -115,6 +132,19 @@ func TestSnapshotActivityRefreshesSessionActivity(t *testing.T) {
 	}
 	if !second.UpdatedAt.After(first.UpdatedAt) {
 		t.Fatalf("SnapshotActivity did not refresh activity: first=%s second=%s", first.UpdatedAt, second.UpdatedAt)
+	}
+}
+
+func TestDisconnectMCPServerRemovesLazyPlaceholder(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__mock__connect"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+
+	if ok := c.DisconnectMCPServer("mock"); !ok {
+		t.Fatal("DisconnectMCPServer returned false for a registered lazy placeholder")
+	}
+	if _, found := reg.Get("mcp__mock__connect"); found {
+		t.Fatalf("lazy placeholder still registered after disconnect; names=%v", reg.Names())
 	}
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -145,6 +146,37 @@ func TestDisconnectMCPServerRemovesLazyPlaceholder(t *testing.T) {
 	}
 	if _, found := reg.Get("mcp__mock__connect"); found {
 		t.Fatalf("lazy placeholder still registered after disconnect; names=%v", reg.Names())
+	}
+}
+
+func TestRemoveMCPServerRemovesUnconnectedLazyPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("reasonix.toml", []byte(`
+[[plugins]]
+name = "mock"
+command = "mock-mcp"
+tier = "lazy"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__mock__connect"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+
+	disconnected, err := c.RemoveMCPServer("mock")
+	if err != nil {
+		t.Fatalf("RemoveMCPServer: %v", err)
+	}
+	if disconnected {
+		t.Fatal("RemoveMCPServer reported a live disconnect for an unconnected lazy placeholder")
+	}
+	if _, found := reg.Get("mcp__mock__connect"); found {
+		t.Fatalf("lazy placeholder still registered after remove; names=%v", reg.Names())
+	}
+	if names := c.ConfiguredMCPNames(); len(names) != 0 {
+		t.Fatalf("ConfiguredMCPNames() = %v, want empty after remove", names)
 	}
 }
 

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -68,6 +68,11 @@ const (
 	// ToolResult for long tools like bash so a frontend can show live progress.
 	// Appended last to keep the Kind values before it wire-stable.
 	ToolProgress
+	// MCPSurfaceReady fires once per server when its background-loaded surface
+	// (prompts or resources) finishes after startup. Lets UIs refresh /mcp
+	// status without polling. Text carries "<server>: <surface> ready (<count>
+	// items)". Appended last to keep the Kind values before it wire-stable.
+	MCPSurfaceReady
 )
 
 // Level classifies a Notice so sinks can style or filter it.

--- a/internal/plugin/cache.go
+++ b/internal/plugin/cache.go
@@ -1,0 +1,221 @@
+// Package-internal cache for MCP handshake results. The handshake (initialize +
+// listTools, plus optional listPrompts/listResources) costs hundreds of ms to a
+// few seconds per server on cold start. We persist the tool schema +
+// capabilities under the user cache dir keyed by a fingerprint of the load-
+// bearing Spec fields, so the next launch can register tools optimistically
+// without waiting for the network/subprocess. Caching is purely an
+// optimisation: any failure (missing dir, bad JSON, hash mismatch) silently
+// degrades to a fresh handshake.
+package plugin
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/tool"
+)
+
+// cacheableToolsOf extracts the persistable subset of remote tools so Start()
+// can hand them to SaveCachedSchema. Non-remote tools are skipped — Start
+// only feeds remote ones at the call site, but the type-assert is defensive.
+func cacheableToolsOf(tools []tool.Tool) []CachedTool {
+	out := make([]CachedTool, 0, len(tools))
+	for _, t := range tools {
+		rt, ok := t.(*remoteTool)
+		if !ok {
+			continue
+		}
+		out = append(out, CachedTool{
+			Name:        rt.rawName,
+			Description: rt.desc,
+			Schema:      rt.schema,
+			ReadOnly:    rt.readOnly,
+		})
+	}
+	return out
+}
+
+// cacheVersion bumps whenever CachedSchema shape changes incompatibly. Old
+// files with a smaller version are treated as a miss so a stale layout never
+// crashes a reader.
+const cacheVersion = 1
+
+// CachedSchema is the persisted snapshot of one server's handshake result.
+// SpecHash gates reuse — Capabilities/Tools are only trusted when the
+// caller's expectedHash (from SpecFingerprint of the current Spec) matches,
+// so renaming env vars or swapping a command never serves stale tools.
+type CachedSchema struct {
+	Version       int             `json:"version"`
+	SpecHash      string          `json:"spec_hash"`
+	Capabilities  map[string]bool `json:"capabilities"`
+	Tools         []CachedTool    `json:"tools"`
+	LastValidated time.Time       `json:"last_validated"`
+}
+
+// CachedTool mirrors the subset of an MCP tool definition we need to register
+// a placeholder before the real handshake completes: Name (raw, server-local),
+// Description (model-visible), Schema (raw JSON for input validation),
+// ReadOnly (drives confirmation prompts).
+type CachedTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Schema      json.RawMessage `json:"schema"`
+	ReadOnly    bool            `json:"read_only"`
+}
+
+// SpecFingerprint hashes the load-bearing parts of a Spec so changing the
+// command/url/args/env (not just renaming) invalidates the cache. Env map
+// keys are sorted so ordering doesn't perturb the hash — Go map iteration
+// order is randomised, so we'd otherwise get fingerprint churn on every
+// launch.
+func SpecFingerprint(s Spec) string {
+	h := sha256.New()
+	writeField(h, "type", s.Type)
+	writeField(h, "command", s.Command)
+	writeField(h, "url", s.URL)
+	writeField(h, "dir", s.Dir)
+	for _, a := range s.Args {
+		writeField(h, "arg", a)
+	}
+	writeKV(h, "env", s.Env)
+	writeKV(h, "headers", s.Headers)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// LoadCachedSchema returns the cached schema for name iff it exists, parses,
+// and matches expectedHash. Any error → (nil, false): cache is best-effort,
+// a corrupt file just means we re-handshake. Returning an error here would
+// only invite callers to log it on every launch — silence is intentional.
+func LoadCachedSchema(name, expectedHash string) (*CachedSchema, bool) {
+	p := cachePath(name)
+	if p == "" {
+		return nil, false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, false
+	}
+	var cs CachedSchema
+	if err := json.Unmarshal(b, &cs); err != nil {
+		return nil, false
+	}
+	if cs.Version != cacheVersion {
+		return nil, false
+	}
+	if cs.SpecHash != expectedHash {
+		return nil, false
+	}
+	return &cs, true
+}
+
+// SaveCachedSchema atomically writes cs under name. Best-effort: an error
+// is logged at debug level and dropped. Uses tmpfile + os.Rename in the
+// parent dir so a crash mid-write can't leave a half-written JSON behind
+// that the next Load would mis-parse.
+func SaveCachedSchema(name string, cs CachedSchema) error {
+	p := cachePath(name)
+	if p == "" {
+		return nil
+	}
+	dir := filepath.Dir(p)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Debug("plugin cache: mkdir", "name", name, "err", err)
+		return err
+	}
+	cs.Version = cacheVersion
+	if cs.LastValidated.IsZero() {
+		cs.LastValidated = time.Now().UTC()
+	}
+	b, err := json.MarshalIndent(cs, "", "  ")
+	if err != nil {
+		slog.Debug("plugin cache: marshal", "name", name, "err", err)
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".mcp-*.tmp")
+	if err != nil {
+		slog.Debug("plugin cache: tempfile", "name", name, "err", err)
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: write", "name", name, "err", err)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: close", "name", name, "err", err)
+		return err
+	}
+	if err := os.Rename(tmpPath, p); err != nil {
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: rename", "name", name, "err", err)
+		return err
+	}
+	return nil
+}
+
+// cachePath returns "<config.CacheDir()>/mcp/<slug(name)>.json". Returns ""
+// when CacheDir is unavailable (no-op caching).
+func cachePath(name string) string {
+	base := config.CacheDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "mcp", slug(name)+".json")
+}
+
+// slugReplace strips characters that aren't safe in a filename across the
+// OSes we target. We lowercase first so the slug is stable regardless of
+// the user's display capitalisation.
+var slugReplace = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// slug sanitises name for use as a filename: lowercase, only [a-z0-9_-]. An
+// empty result (all chars stripped) falls back to "_" so cachePath stays
+// valid for any input.
+func slug(name string) string {
+	s := slugReplace.ReplaceAllString(strings.ToLower(name), "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "_"
+	}
+	return s
+}
+
+// writeField feeds a single tagged field into h with explicit separators so
+// the boundary between (key, value) and the next field can't collide via
+// concatenation (e.g. "command" + "foo" vs "comm" + "andfoo").
+func writeField(h io.Writer, key, val string) {
+	h.Write([]byte(key))
+	h.Write([]byte{0})
+	h.Write([]byte(val))
+	h.Write([]byte{1})
+}
+
+// writeKV hashes a map deterministically by sorting keys, so Go's randomised
+// map iteration doesn't churn the fingerprint between launches.
+func writeKV(h io.Writer, key string, m map[string]string) {
+	if len(m) == 0 {
+		writeField(h, key, "")
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeField(h, key+"."+k, m[k])
+	}
+}

--- a/internal/plugin/cache_test.go
+++ b/internal/plugin/cache_test.go
@@ -1,0 +1,200 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// redirectCache points config.CacheDir() at a fresh temp dir for the duration
+// of the test by overriding HOME and XDG_CONFIG_HOME — the same knobs the
+// sibling mcpjson_test uses to sandbox UserConfigDir lookups. Returns the
+// temp dir so a test can also poke into it (e.g. write a corrupted file).
+func redirectCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+func sampleSpec() Spec {
+	return Spec{
+		Name:    "my-server",
+		Type:    "stdio",
+		Command: "/usr/bin/example",
+		Args:    []string{"--flag", "x"},
+		Env:     map[string]string{"FOO": "1", "BAR": "2"},
+		Headers: map[string]string{"X-Custom": "ok"},
+		Dir:     "/work",
+	}
+}
+
+func sampleCachedSchema(hash string) CachedSchema {
+	return CachedSchema{
+		SpecHash:     hash,
+		Capabilities: map[string]bool{"prompts": true, "resources": false},
+		Tools: []CachedTool{{
+			Name:        "do_thing",
+			Description: "does a thing",
+			Schema:      json.RawMessage(`{"type":"object"}`),
+			ReadOnly:    true,
+		}},
+	}
+}
+
+func TestCacheRoundTrip(t *testing.T) {
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	cs := sampleCachedSchema(hash)
+
+	if err := SaveCachedSchema(spec.Name, cs); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+	got, ok := LoadCachedSchema(spec.Name, hash)
+	if !ok {
+		t.Fatal("LoadCachedSchema: miss after save")
+	}
+	if got.SpecHash != hash {
+		t.Errorf("SpecHash: got %q want %q", got.SpecHash, hash)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].Name != "do_thing" {
+		t.Errorf("Tools: %+v", got.Tools)
+	}
+	if !got.Tools[0].ReadOnly {
+		t.Error("ReadOnly: lost across save/load")
+	}
+	if !got.Capabilities["prompts"] || got.Capabilities["resources"] {
+		t.Errorf("Capabilities: %+v", got.Capabilities)
+	}
+	if got.Version != cacheVersion {
+		t.Errorf("Version: got %d want %d", got.Version, cacheVersion)
+	}
+	if got.LastValidated.IsZero() {
+		t.Error("LastValidated: expected non-zero after save")
+	}
+}
+
+func TestCacheInvalidatesOnSpecHashMismatch(t *testing.T) {
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	if err := SaveCachedSchema(spec.Name, sampleCachedSchema(hash)); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+	if _, ok := LoadCachedSchema(spec.Name, "different-hash"); ok {
+		t.Fatal("LoadCachedSchema: hit despite mismatching expectedHash")
+	}
+}
+
+func TestCacheCorruptedFileReturnsFalse(t *testing.T) {
+	redirectCache(t)
+	p := cachePath("broken")
+	if p == "" {
+		t.Skip("cachePath unavailable in this environment")
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("{this is not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("LoadCachedSchema panicked on corrupt file: %v", r)
+		}
+	}()
+	if _, ok := LoadCachedSchema("broken", "any"); ok {
+		t.Fatal("LoadCachedSchema: hit on corrupt file")
+	}
+}
+
+func TestCacheVersionMismatchReturnsFalse(t *testing.T) {
+	// Pin the on-disk version to one we don't recognise: a future writer must
+	// not poison an older binary's cache reads.
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	cs := sampleCachedSchema(hash)
+	cs.Version = cacheVersion + 99
+	p := cachePath(spec.Name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := LoadCachedSchema(spec.Name, hash); ok {
+		t.Fatal("LoadCachedSchema: hit on future-version cache file")
+	}
+}
+
+func TestSpecFingerprintStable(t *testing.T) {
+	spec := sampleSpec()
+	h1 := SpecFingerprint(spec)
+	h2 := SpecFingerprint(spec)
+	if h1 != h2 {
+		t.Fatalf("SpecFingerprint not stable: %q vs %q", h1, h2)
+	}
+
+	// Reorder the env (build a new map; Go map iteration order is randomised
+	// but a fresh map can incidentally iterate the same way, so we run a few
+	// iterations to give the runtime a chance to shuffle).
+	reordered := spec
+	for i := 0; i < 32; i++ {
+		reordered.Env = map[string]string{"BAR": "2", "FOO": "1"}
+		if got := SpecFingerprint(reordered); got != h1 {
+			t.Fatalf("SpecFingerprint changed when env was rebuilt: %q vs %q", got, h1)
+		}
+	}
+}
+
+func TestSpecFingerprintChangesOnCommandEdit(t *testing.T) {
+	a := sampleSpec()
+	b := a
+	b.Command = "/usr/local/bin/other"
+	if SpecFingerprint(a) == SpecFingerprint(b) {
+		t.Fatal("SpecFingerprint did not change when Command changed")
+	}
+
+	c := a
+	c.Args = append([]string{}, a.Args...)
+	c.Args[0] = "--different"
+	if SpecFingerprint(a) == SpecFingerprint(c) {
+		t.Fatal("SpecFingerprint did not change when Args changed")
+	}
+
+	d := a
+	d.Env = map[string]string{"FOO": "1", "BAR": "different"}
+	if SpecFingerprint(a) == SpecFingerprint(d) {
+		t.Fatal("SpecFingerprint did not change when env value changed")
+	}
+}
+
+func TestCacheMissForUnknownName(t *testing.T) {
+	redirectCache(t)
+	if _, ok := LoadCachedSchema("never-saved", "anything"); ok {
+		t.Fatal("LoadCachedSchema: hit for a name that was never saved")
+	}
+}
+
+func TestSlugSafeForFilesystem(t *testing.T) {
+	cases := map[string]string{
+		"My Server!":           "my-server",
+		"weird/name\\with:bad": "weird-name-with-bad",
+		"":                     "_",
+		"------":               "_",
+		"a_b-c":                "a_b-c",
+	}
+	for in, want := range cases {
+		if got := slug(in); got != want {
+			t.Errorf("slug(%q) = %q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/plugin/example_test.go
+++ b/internal/plugin/example_test.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"reasonix/internal/event"
 	"reasonix/internal/tool"
 )
 
@@ -89,6 +91,24 @@ func TestExamplePluginEndToEnd(t *testing.T) {
 	// which the adapter surfaces as a Go error the model can read.
 	if _, err := echo.Execute(ctx, json.RawMessage(`{"text":123}`)); err == nil {
 		t.Error("echo with non-string text should return an error (isError result)")
+	}
+
+	// Prompts and resources stream in on phase B (post-startup), so the test
+	// must drive it and wait for both surfaces before asserting. A WaitGroup
+	// completes once both MCPSurfaceReady events fire.
+	var wg sync.WaitGroup
+	wg.Add(2) // prompts + resources
+	host.StartPhaseB(ctx, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.MCPSurfaceReady {
+			wg.Done()
+		}
+	}))
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("phase B did not finish in time")
 	}
 
 	// Prompts: the server advertises the capability, so the host discovers the

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -4,12 +4,11 @@
 // model call. A "background" plugin is identical except it also kicks the
 // spawn off at boot so by the time the model calls, the swap is already done.
 //
-// Why the indirection: tool.Registry has no mutex (agent dispatch is
-// single-threaded), so we cannot mutate it from a background goroutine while
-// the agent is reading reg.Schemas(). Swaps are therefore performed inside
-// lazyTool.Execute, which runs in turn-synchronous code. Background spawns
-// merely populate lazySpawn's shared state; the swap fires on the next
-// Execute call against any tool tied to that server.
+// Why the indirection: a lazy/background server still needs stable placeholder
+// tools before the real handshake finishes. Once it does finish, lazySpawn swaps
+// the placeholders for real tools through tool.Registry's own lock, so the next
+// model request sees the real schemas without waiting for another placeholder
+// Execute call.
 package plugin
 
 import (
@@ -93,11 +92,11 @@ func (s *lazySpawn) run() {
 		s.real[t.Name()] = t
 	}
 	s.state = spawnReady
+	s.trySwap()
 }
 
 // trySwap installs the real tools into reg if the spawn is ready and the
-// swap hasn't happened. Caller must hold s.mu AND must be running in a
-// turn-synchronous code path (an Execute body) — the Registry is unlocked.
+// swap hasn't happened. Caller must hold s.mu.
 func (s *lazySpawn) trySwap() {
 	if s.swapped || s.state != spawnReady {
 		return
@@ -177,8 +176,7 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 			return "", fmt.Errorf("MCP server %q is initializing on first use — call again on the next turn for its real tools", sp.spec.Name)
 		}
 		// Cache-hit: run the handshake synchronously so this one Execute can
-		// forward through, and so the swap happens in turn-sync (registry is
-		// unlocked).
+		// forward through.
 		sp.state = spawnInFlight
 		sp.mu.Unlock()
 		real, err := sp.host.Add(sp.ctx, sp.spec)
@@ -231,7 +229,7 @@ func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, se
 
 	var out []tool.Tool
 	if cs == nil {
-		shared.removePrefix = "mcp__" + normalizeName(spec.Name) + "__"
+		shared.removePrefix = ToolPrefix(spec.Name)
 		out = []tool.Tool{&lazyTool{
 			shared:   shared,
 			name:     shared.removePrefix + "connect",

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -1,0 +1,259 @@
+// Lazy-tier MCP placeholder tools. A "lazy" plugin registers cheap placeholder
+// entries in the tool registry at boot — using the on-disk schema cache when
+// it exists — and defers the actual subprocess spawn / handshake to the first
+// model call. A "background" plugin is identical except it also kicks the
+// spawn off at boot so by the time the model calls, the swap is already done.
+//
+// Why the indirection: tool.Registry has no mutex (agent dispatch is
+// single-threaded), so we cannot mutate it from a background goroutine while
+// the agent is reading reg.Schemas(). Swaps are therefore performed inside
+// lazyTool.Execute, which runs in turn-synchronous code. Background spawns
+// merely populate lazySpawn's shared state; the swap fires on the next
+// Execute call against any tool tied to that server.
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"reasonix/internal/tool"
+)
+
+// DefaultStartupBudget is the per-plugin latency budget used by boot when
+// deciding whether to auto-demote (see Recommend). Kept here rather than in
+// stats.go because it's the value boot.go pairs with each Recommend call.
+func DefaultStartupBudget() time.Duration { return defaultStartTimeout }
+
+// spawnState is the lazy-spawn state machine. Transitions are:
+//
+//	idle → inFlight → ready
+//	idle → inFlight → failed
+//
+// All transitions are gated by lazySpawn.mu so only one goroutine runs the
+// handshake even when multiple Execute calls race on first use.
+type spawnState int
+
+const (
+	spawnIdle spawnState = iota
+	spawnInFlight
+	spawnReady
+	spawnFailed
+)
+
+// lazySpawn is shared by every placeholder lazyTool registered for one
+// server: they all observe the same state machine and trigger at most one
+// handshake.
+type lazySpawn struct {
+	spec Spec
+	host *Host
+	reg  *tool.Registry
+	ctx  context.Context // session-scoped — outlives any single turn
+
+	mu       sync.Mutex
+	state    spawnState
+	real     map[string]tool.Tool // namespaced name → real tool, populated on success
+	spawnErr error
+	swapped  bool
+	// removePrefix is set for cache-miss placeholders so trySwap drops the
+	// single "<server>__connect" stub before re-registering the real tools
+	// under their actual namespaced names. Cache-hit placeholders use the
+	// same names as the real tools, so reg.Add overwrites in place and no
+	// prefix removal is needed.
+	removePrefix string
+}
+
+// kick starts the spawn if it has not yet started. Used by background-tier
+// registration; lazy-tier kicks on first call instead.
+func (s *lazySpawn) kick() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != spawnIdle {
+		return
+	}
+	s.state = spawnInFlight
+	go s.run()
+}
+
+// run does the handshake without holding mu (host.Add can take seconds), then
+// reacquires mu to publish the result.
+func (s *lazySpawn) run() {
+	real, err := s.host.Add(s.ctx, s.spec)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.state = spawnFailed
+		s.spawnErr = err
+		return
+	}
+	s.real = make(map[string]tool.Tool, len(real))
+	for _, t := range real {
+		s.real[t.Name()] = t
+	}
+	s.state = spawnReady
+}
+
+// trySwap installs the real tools into reg if the spawn is ready and the
+// swap hasn't happened. Caller must hold s.mu AND must be running in a
+// turn-synchronous code path (an Execute body) — the Registry is unlocked.
+func (s *lazySpawn) trySwap() {
+	if s.swapped || s.state != spawnReady {
+		return
+	}
+	if s.removePrefix != "" {
+		s.reg.RemovePrefix(s.removePrefix)
+	}
+	for _, t := range s.real {
+		s.reg.Add(t)
+	}
+	s.swapped = true
+}
+
+// lazyTool is a tool.Tool placeholder backed by a shared lazySpawn. The model
+// sees cached metadata (or a stub when no cache exists); Execute consults the
+// state machine, kicking off the handshake on first call.
+type lazyTool struct {
+	shared   *lazySpawn
+	name     string // namespaced "mcp__<server>__<tool>"
+	desc     string
+	schema   json.RawMessage
+	readOnly bool
+	// hasCache true → schema is trusted, so Execute runs the handshake
+	// synchronously and forwards in one turn. false → schema is empty, so we
+	// can't honour the model's call; we kick the spawn async and ask for a
+	// retry on the next turn, when the swap will have installed the real
+	// tools with real schemas.
+	hasCache bool
+}
+
+func (lt *lazyTool) Name() string        { return lt.name }
+func (lt *lazyTool) Description() string { return lt.desc }
+func (lt *lazyTool) ReadOnly() bool      { return lt.readOnly }
+func (lt *lazyTool) Schema() json.RawMessage {
+	if len(lt.schema) == 0 {
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	return canonicalizeSchema(lt.schema)
+}
+
+func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	sp := lt.shared
+	sp.mu.Lock()
+
+	// Catch up on a background spawn that finished while we were idle.
+	if sp.state == spawnReady && !sp.swapped {
+		sp.trySwap()
+	}
+
+	switch sp.state {
+	case spawnReady:
+		real := sp.real[lt.name]
+		sp.mu.Unlock()
+		if real == nil {
+			return "", fmt.Errorf("MCP server %q did not expose tool %q (the cached schema may be stale)", sp.spec.Name, lt.name)
+		}
+		return real.Execute(ctx, args)
+
+	case spawnFailed:
+		err := sp.spawnErr
+		sp.mu.Unlock()
+		return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, err)
+
+	case spawnInFlight:
+		sp.mu.Unlock()
+		return "", fmt.Errorf("MCP server %q is still initializing — call this tool again on the next turn", sp.spec.Name)
+
+	case spawnIdle:
+		if !lt.hasCache {
+			// Cache-miss: we don't trust args to match a real schema, so
+			// drive the handshake async and ask the model to retry. By the
+			// next turn the swap will have installed the real tools with
+			// real schemas under different names.
+			sp.state = spawnInFlight
+			go sp.run()
+			sp.mu.Unlock()
+			return "", fmt.Errorf("MCP server %q is initializing on first use — call again on the next turn for its real tools", sp.spec.Name)
+		}
+		// Cache-hit: run the handshake synchronously so this one Execute can
+		// forward through, and so the swap happens in turn-sync (registry is
+		// unlocked).
+		sp.state = spawnInFlight
+		sp.mu.Unlock()
+		real, err := sp.host.Add(sp.ctx, sp.spec)
+		sp.mu.Lock()
+		defer sp.mu.Unlock()
+		if err != nil {
+			sp.state = spawnFailed
+			sp.spawnErr = err
+			return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, err)
+		}
+		sp.real = make(map[string]tool.Tool, len(real))
+		for _, t := range real {
+			sp.real[t.Name()] = t
+		}
+		sp.state = spawnReady
+		sp.trySwap()
+		r := sp.real[lt.name]
+		if r == nil {
+			return "", fmt.Errorf("MCP server %q did not expose tool %q (the cached schema may be stale)", sp.spec.Name, lt.name)
+		}
+		return r.Execute(ctx, args)
+	}
+
+	sp.mu.Unlock()
+	return "", fmt.Errorf("lazy plugin %q in unexpected state", sp.spec.Name)
+}
+
+// LazyToolset returns the placeholder tools to register for one lazy/background
+// spec. When cs is non-nil (cache hit) the returned slice has one lazyTool per
+// cached tool, carrying the cached schema so the model can pass real args;
+// the first Execute runs the handshake synchronously and swaps in real tools.
+// When cs is nil (cache miss) the returned slice has a single stub named
+// "mcp__<server>__connect": the model can call it to drive the spawn, and the
+// real tools surface on the next turn.
+//
+// kick=true (background tier) also fires off the spawn immediately, so an
+// idle session warms up without waiting for the first model call.
+//
+// host is the Host that receives the real Client. reg is the registry where
+// real tools land after a successful spawn. sessionCtx must outlive any
+// single Execute (use the controller's PluginCtx) — a turn-scoped ctx would
+// kill the stdio child between turns.
+func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, sessionCtx context.Context, kick bool) []tool.Tool {
+	shared := &lazySpawn{
+		spec: spec,
+		host: host,
+		reg:  reg,
+		ctx:  sessionCtx,
+	}
+
+	var out []tool.Tool
+	if cs == nil {
+		shared.removePrefix = "mcp__" + normalizeName(spec.Name) + "__"
+		out = []tool.Tool{&lazyTool{
+			shared:   shared,
+			name:     shared.removePrefix + "connect",
+			desc:     fmt.Sprintf("Connect MCP server %q. Call this once to drive the handshake; the server's real tools become available on the next turn.", spec.Name),
+			hasCache: false,
+		}}
+	} else {
+		out = make([]tool.Tool, 0, len(cs.Tools))
+		for _, ct := range cs.Tools {
+			out = append(out, &lazyTool{
+				shared:   shared,
+				name:     toolName(spec.Name, ct.Name),
+				desc:     ct.Description,
+				schema:   ct.Schema,
+				readOnly: ct.ReadOnly,
+				hasCache: true,
+			})
+		}
+	}
+
+	if kick {
+		shared.kick()
+	}
+	return out
+}

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -145,10 +145,10 @@ func TestLazyCacheHitSyncSpawn(t *testing.T) {
 
 // TestLazyCacheMissAsyncSpawn drives the cache-miss branch: with no cache, a
 // single "connect" placeholder shows up; first Execute returns a retry hint and
-// kicks the spawn async; the real tools surface on the next turn under their
-// real names, and the connect stub is dropped. This is the "model warm-up"
-// contract — the model must not see stale schemas, so we refuse to forward
-// the first call and instead ask for one more turn.
+// kicks the spawn async; once that spawn finishes, the registry swaps to the
+// real tools under their real names, and the connect stub is dropped. This is
+// the "model warm-up" contract — the model must not see stale schemas, so we
+// refuse to forward the first call and instead ask for one more turn.
 func TestLazyCacheMissAsyncSpawn(t *testing.T) {
 	redirectCache(t)
 	spec := helperSpec()
@@ -184,13 +184,10 @@ func TestLazyCacheMissAsyncSpawn(t *testing.T) {
 	}
 
 	// Wait for the async spawn to complete (host.Add happens on the run()
-	// goroutine kicked by Execute).
+	// goroutine kicked by Execute). The goroutine swaps the registry itself, so
+	// the next model request sees the real schemas without another placeholder
+	// Execute call.
 	waitForServer(t, host, "mock", 5*time.Second)
-
-	// Second Execute on the placeholder triggers trySwap (caught by the
-	// spawnReady branch). The real tools land in the registry under their
-	// real names; the connect stub is dropped.
-	_, _ = connect.Execute(ctx, json.RawMessage(`{}`))
 
 	if _, found := reg.Get("mcp__mock__connect"); found {
 		t.Errorf("connect stub should be removed after swap, names=%v", reg.Names())
@@ -200,6 +197,54 @@ func TestLazyCacheMissAsyncSpawn(t *testing.T) {
 	}
 	if _, found := reg.Get("mcp__mock__zed"); !found {
 		t.Errorf("real mcp__mock__zed missing after swap, names=%v", reg.Names())
+	}
+}
+
+func TestLazySwapDoesNotRaceRegistrySchemas(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	spec.Env["GO_WANT_HELPER_INIT_MS"] = "50"
+	writeMockCache(t, spec)
+	cs, _ := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+	echo, _ := reg.Get("mcp__mock__echo")
+	if echo == nil {
+		t.Fatal("missing mcp__mock__echo placeholder")
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = reg.Schemas()
+			}
+		}
+	}()
+
+	out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"race"}`))
+	close(done)
+	wg.Wait()
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "echo: race" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: race")
 	}
 }
 

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -1,0 +1,443 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/tool"
+)
+
+// helperSpec returns a Spec that re-invokes this test binary as a minimal MCP
+// stdio server (see TestHelperProcess in plugin_test.go). Reused across every
+// lazy_test case so the helper-process contract — "echo: <msg>" responder with
+// tools/list exposing echo and zed — stays the single source of truth.
+func helperSpec() Spec {
+	return Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env:     map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
+	}
+}
+
+// writeMockCache primes the on-disk cache for spec with the two tools the
+// helper subprocess exposes (echo, zed). We mirror the real schemas so a
+// cache-hit lazyTool surfaces the same Schema() bytes that a freshly handshaked
+// remoteTool would — the test for "model sees real schema before any Execute"
+// depends on this equivalence.
+func writeMockCache(t *testing.T, spec Spec) {
+	t.Helper()
+	cs := CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{"prompts": false, "resources": false},
+		Tools: []CachedTool{
+			{
+				Name:        "echo",
+				Description: "Echo back the message.",
+				Schema:      json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}},"required":["z","msg"]}`),
+			},
+			{
+				Name:        "zed",
+				Description: "Sorted after echo.",
+				Schema:      json.RawMessage(`{"type":"object"}`),
+			},
+		},
+	}
+	if err := SaveCachedSchema(spec.Name, cs); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+}
+
+// waitForServer polls host.ServerNames() until name appears or timeout
+// elapses. The lazy path spawns via a goroutine, so tests need a bounded poll
+// rather than a fixed sleep — five seconds covers a slow CI subprocess fork
+// while still aborting clearly on a real hang.
+func waitForServer(t *testing.T, host *Host, name string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, n := range host.ServerNames() {
+			if n == name {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server %q never appeared in host.ServerNames() within %v (got %v)", name, timeout, host.ServerNames())
+}
+
+// TestLazyCacheHitSyncSpawn drives the cache-hit branch end-to-end: cache is
+// pre-populated, the model can see real schemas before any spawn, and the
+// first Execute synchronously handshakes, swaps the placeholder for the real
+// *remoteTool, and forwards through in one turn. This is the "warm start"
+// payoff — lazy plugins should be indistinguishable from eager once they have
+// a cache.
+func TestLazyCacheHitSyncSpawn(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	writeMockCache(t, spec)
+
+	cs, ok := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+	if !ok {
+		t.Fatal("LoadCachedSchema: miss right after save (sanity)")
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 2 {
+		t.Fatalf("LazyToolset returned %d tools, want 2 (echo + zed)", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	// Before any Execute: registry exposes real cached schemas (not the empty
+	// {"type":"object"} stub). The model relies on this to call the tool with
+	// real args on the very first turn.
+	echoBefore, ok := reg.Get("mcp__mock__echo")
+	if !ok {
+		t.Fatal("registry missing mcp__mock__echo after LazyToolset")
+	}
+	if _, isLazy := echoBefore.(*lazyTool); !isLazy {
+		t.Fatalf("pre-Execute echo should be a *lazyTool, got %T", echoBefore)
+	}
+	gotSchema := string(echoBefore.Schema())
+	if !strings.Contains(gotSchema, `"msg"`) || !strings.Contains(gotSchema, `"required"`) {
+		t.Fatalf("cached schema not surfaced through lazyTool.Schema(): %s", gotSchema)
+	}
+
+	// First Execute: cache-hit path runs the handshake synchronously and
+	// forwards to the real tool — the user sees "echo: hi" in this same turn.
+	out, err := echoBefore.Execute(ctx, json.RawMessage(`{"msg":"hi"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "echo: hi" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: hi")
+	}
+
+	// The spawn actually happened — host now lists the mock server.
+	names := host.ServerNames()
+	if len(names) != 1 || names[0] != "mock" {
+		t.Fatalf("host.ServerNames() = %v, want [mock]", names)
+	}
+
+	// After Execute, the registry entry must be the real *remoteTool, not the
+	// placeholder. Subsequent calls bypass the state machine and Execute
+	// directly. Compare via type name so this test doesn't need to import the
+	// unexported type by name.
+	echoAfter, _ := reg.Get("mcp__mock__echo")
+	if got := fmt.Sprintf("%T", echoAfter); !strings.Contains(got, "remoteTool") {
+		t.Fatalf("post-Execute echo should be a remoteTool, got %s", got)
+	}
+}
+
+// TestLazyCacheMissAsyncSpawn drives the cache-miss branch: with no cache, a
+// single "connect" placeholder shows up; first Execute returns a retry hint and
+// kicks the spawn async; the real tools surface on the next turn under their
+// real names, and the connect stub is dropped. This is the "model warm-up"
+// contract — the model must not see stale schemas, so we refuse to forward
+// the first call and instead ask for one more turn.
+func TestLazyCacheMissAsyncSpawn(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, nil, host, reg, ctx, false)
+	if len(tools) != 1 {
+		t.Fatalf("cache-miss LazyToolset must return 1 connect stub, got %d", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	connect, ok := reg.Get("mcp__mock__connect")
+	if !ok {
+		t.Fatalf("registry missing mcp__mock__connect; names=%v", reg.Names())
+	}
+
+	// First Execute must NOT forward — schema is unknown, so the model would
+	// be feeding garbage. It returns a retry hint and triggers spawn async.
+	_, err := connect.Execute(ctx, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("first Execute on cache-miss placeholder should error with a retry hint")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "initializing") && !strings.Contains(msg, "next turn") {
+		t.Fatalf("first-Execute error %q should mention 'initializing' or 'next turn'", msg)
+	}
+
+	// Wait for the async spawn to complete (host.Add happens on the run()
+	// goroutine kicked by Execute).
+	waitForServer(t, host, "mock", 5*time.Second)
+
+	// Second Execute on the placeholder triggers trySwap (caught by the
+	// spawnReady branch). The real tools land in the registry under their
+	// real names; the connect stub is dropped.
+	_, _ = connect.Execute(ctx, json.RawMessage(`{}`))
+
+	if _, found := reg.Get("mcp__mock__connect"); found {
+		t.Errorf("connect stub should be removed after swap, names=%v", reg.Names())
+	}
+	if _, found := reg.Get("mcp__mock__echo"); !found {
+		t.Errorf("real mcp__mock__echo missing after swap, names=%v", reg.Names())
+	}
+	if _, found := reg.Get("mcp__mock__zed"); !found {
+		t.Errorf("real mcp__mock__zed missing after swap, names=%v", reg.Names())
+	}
+}
+
+// TestLazyBackgroundKick covers the background-tier path: kick=true plus a
+// cache hit means the spawn races boot, finishes before the model calls, and
+// the first Execute hits the "already-ready, swap on the way through" branch.
+// The model never sees a placeholder schema-wise either, since the cache
+// fed Schema() before kick even started.
+func TestLazyBackgroundKick(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	writeMockCache(t, spec)
+	cs, _ := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, true) // kick=true
+	if len(tools) != 2 {
+		t.Fatalf("LazyToolset(kick=true) returned %d tools, want 2", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	// Wait for the background spawn to complete — proof that kick fired off
+	// the handshake without us calling Execute.
+	waitForServer(t, host, "mock", 5*time.Second)
+
+	// Now Execute: the state is already spawnReady, so this should swap +
+	// forward in one shot without a second Add call. The result must still be
+	// correct.
+	echo, _ := reg.Get("mcp__mock__echo")
+	out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"bg"}`))
+	if err != nil {
+		t.Fatalf("Execute after background ready: %v", err)
+	}
+	if out != "echo: bg" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: bg")
+	}
+
+	// One spawn, not two — kick + Execute must collapse onto the same run.
+	if names := host.ServerNames(); len(names) != 1 {
+		t.Fatalf("host.ServerNames() = %v, want exactly one 'mock'", names)
+	}
+}
+
+// TestLazyConcurrentExecuteOnlyOneSpawn pins the de-duplication contract: 10
+// goroutines racing through Execute on the same lazyTool may only trigger ONE
+// spawn (and therefore one connected mock server on the host). The state
+// machine's mu+state gate is what makes this true; this test would catch a
+// regression where someone moved the state transition outside the lock or
+// swapped to a TOCTOU check.
+//
+// Note: by design (see lazy.go), only the winner of the race forwards
+// synchronously; the losers observe spawnInFlight and return a "retry next
+// turn" hint rather than blocking. We assert that contract too: at least one
+// goroutine got "echo: r<i>", and the racers that didn't win got the
+// initializing hint — never a spurious error and never a stale or partial
+// result. After all goroutines complete, a fresh Execute hits spawnReady and
+// forwards normally.
+func TestLazyConcurrentExecuteOnlyOneSpawn(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	writeMockCache(t, spec)
+	cs, _ := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+	echo, _ := reg.Get("mcp__mock__echo")
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	results := make([]string, goroutines)
+	errs := make([]error, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			out, err := echo.Execute(ctx, json.RawMessage(fmt.Sprintf(`{"msg":"r%d"}`, i)))
+			results[i], errs[i] = out, err
+		}(i)
+	}
+	wg.Wait()
+
+	// Every result must be either the real "echo: rN" output or the explicit
+	// initializing hint — nothing else. At least one goroutine (the racing
+	// winner) must succeed, otherwise the state machine deadlocked the win.
+	winners := 0
+	for i, err := range errs {
+		want := fmt.Sprintf("echo: r%d", i)
+		switch {
+		case err == nil && results[i] == want:
+			winners++
+		case err != nil && strings.Contains(err.Error(), "initializing"):
+			// expected loser
+		default:
+			t.Errorf("goroutine %d: result=%q err=%v — must be either %q or an 'initializing' hint", i, results[i], err, want)
+		}
+	}
+	if winners == 0 {
+		t.Fatal("no goroutine succeeded — at least the race winner must forward through")
+	}
+
+	// Exactly one Client landed on the host: the mu+state gate kept the 9
+	// losers off the spawn path. This is the headline invariant of the lazy
+	// design — racing the first call must not fork-bomb the subprocess.
+	mockCount := 0
+	for _, n := range host.ServerNames() {
+		if n == "mock" {
+			mockCount++
+		}
+	}
+	if mockCount != 1 {
+		t.Fatalf("expected 1 'mock' server after concurrent Execute, got %d (names=%v)", mockCount, host.ServerNames())
+	}
+
+	// A follow-up Execute (now in spawnReady) goes through cleanly: the
+	// "retry on next turn" hint was honest, not a permanent error.
+	out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"after"}`))
+	if err != nil {
+		t.Fatalf("post-race Execute: %v", err)
+	}
+	if out != "echo: after" {
+		t.Fatalf("post-race Execute = %q, want %q", out, "echo: after")
+	}
+}
+
+// TestLazyHandshakeFailureSurfaced covers the spawnFailed sticky branch: a
+// bogus command can't start, the first Execute returns an error that mentions
+// "failed to start", and a second Execute returns the SAME error (the state
+// machine doesn't retry — we don't want to fork a doomed subprocess every
+// turn until the user fixes config).
+func TestLazyHandshakeFailureSurfaced(t *testing.T) {
+	redirectCache(t)
+	// Bogus command: process exec will fail outright.
+	spec := Spec{Name: "missing", Command: "reasonix-nonexistent-binary-for-lazy-test"}
+
+	// Hand-craft a cache so the cache-HIT branch runs (synchronous spawn,
+	// failure surfaces directly to the first caller rather than via a retry
+	// hint). The SpecHash must match — otherwise LoadCachedSchema would miss
+	// and we'd be exercising the async path.
+	cs := &CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{},
+		Tools: []CachedTool{{
+			Name:        "doit",
+			Description: "noop",
+			Schema:      json.RawMessage(`{"type":"object"}`),
+		}},
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 1 {
+		t.Fatalf("LazyToolset returned %d tools, want 1 (doit)", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+	doit, _ := reg.Get("mcp__missing__doit")
+
+	_, err1 := doit.Execute(ctx, json.RawMessage(`{}`))
+	if err1 == nil {
+		t.Fatal("Execute on a bogus command should error")
+	}
+	if !strings.Contains(err1.Error(), "failed to start") {
+		t.Fatalf("error %q should mention 'failed to start'", err1.Error())
+	}
+
+	// Second call: same error, no retry. spawnFailed is sticky on purpose —
+	// the operator must fix config and restart, not have us fork-bomb on
+	// every turn.
+	_, err2 := doit.Execute(ctx, json.RawMessage(`{}`))
+	if err2 == nil {
+		t.Fatal("second Execute after spawnFailed should still error")
+	}
+	if !strings.Contains(err2.Error(), "failed to start") {
+		t.Fatalf("second error %q should still mention 'failed to start' (state machine must stay in spawnFailed)", err2.Error())
+	}
+}
+
+// TestLazyToolsetCacheHitSchemaVisible is the model-facing visibility test:
+// immediately after LazyToolset returns and BEFORE any Execute, lazyTool.Schema()
+// must equal the canonicalized cached schema. The whole point of the cache is
+// that the model sees real schemas at turn-start; if Schema() returned the
+// "{}" stub here, the model would call with empty args and the cache-hit
+// path would never get a useful first call.
+func TestLazyToolsetCacheHitSchemaVisible(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+
+	rawSchema := json.RawMessage(`{"properties":{"msg":{"type":"string"}},"type":"object","required":["msg"]}`)
+	cs := &CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{},
+		Tools: []CachedTool{{
+			Name:        "echo",
+			Description: "Echo back.",
+			Schema:      rawSchema,
+		}},
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 1 {
+		t.Fatalf("LazyToolset returned %d tools, want 1", len(tools))
+	}
+	got := string(tools[0].Schema())
+	want := string(canonicalizeSchema(rawSchema))
+	if got != want {
+		t.Fatalf("lazyTool.Schema() = %s,\nwant canonicalized cached schema = %s", got, want)
+	}
+
+	// And we never spawned: Schema() must be free, otherwise the cache
+	// optimisation is moot.
+	if names := host.ServerNames(); len(names) != 0 {
+		t.Fatalf("Schema() must not spawn; host.ServerNames() = %v", names)
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -736,7 +736,12 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 // matching Claude Code. Spaces in either part are normalised to underscores so
 // the name is a clean identifier the model can call.
 func toolName(server, raw string) string {
-	return "mcp__" + normalizeName(server) + "__" + normalizeName(raw)
+	return ToolPrefix(server) + normalizeName(raw)
+}
+
+// ToolPrefix is the model-visible namespace prefix for every tool from server.
+func ToolPrefix(server string) string {
+	return "mcp__" + normalizeName(server) + "__"
 }
 
 var invalidNameChars = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -222,6 +222,8 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 				cancelStartup = cancel
 			}
 
+			phaseAStart := time.Now()
+
 			// Transport on the parent ctx, startup RPCs on the timed callCtx: the
 			// per-plugin timeout caps initialize+listTools, but the long-lived
 			// stdio child must outlive the startup scope and later phase-B calls.
@@ -241,7 +243,22 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			}
 			c.toolCount = len(ts)
 
+			// Persist for next launch on the side: a slow stats/cache write
+			// must not delay tools coming online, and either failure is
+			// recoverable (we just re-handshake or skip auto-demote).
 			cancelStartup()
+			phaseADur := time.Since(phaseAStart)
+			go func() {
+				_ = RecordStartup(spec.Name, phaseADur)
+				_ = SaveCachedSchema(spec.Name, CachedSchema{
+					SpecHash: SpecFingerprint(spec),
+					Capabilities: map[string]bool{
+						"prompts":   c.hasPrompts,
+						"resources": c.hasResources,
+					},
+					Tools: cacheableToolsOf(ts),
+				})
+			}()
 
 			// Prompts and resources are deferred to StartPhaseB so the boot path
 			// can return as soon as tools are ready — the slow-to-list surfaces

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -316,10 +316,21 @@ func (h *Host) StartPhaseB(ctx context.Context, sink event.Sink) {
 }
 
 func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
-	ps, err := c.listPrompts(ctx)
+	aux, auxCtx, cancel, err := c.auxiliaryClient(ctx)
+	if err != nil {
+		slog.Warn("plugin: start auxiliary prompt client failed", "server", c.name, "err", err)
+		return
+	}
+	defer cancel()
+	defer aux.close()
+
+	ps, err := aux.listPrompts(auxCtx)
 	if err != nil {
 		slog.Warn("plugin: listPrompts failed", "server", c.name, "err", err)
 		return
+	}
+	for i := range ps {
+		ps[i].client = c
 	}
 	h.mu.Lock()
 	c.prompts = ps
@@ -334,7 +345,15 @@ func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
 }
 
 func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
-	rs, err := c.listResources(ctx)
+	aux, auxCtx, cancel, err := c.auxiliaryClient(ctx)
+	if err != nil {
+		slog.Warn("plugin: start auxiliary resource client failed", "server", c.name, "err", err)
+		return
+	}
+	defer cancel()
+	defer aux.close()
+
+	rs, err := aux.listResources(auxCtx)
 	if err != nil {
 		slog.Warn("plugin: listResources failed", "server", c.name, "err", err)
 		return
@@ -357,6 +376,7 @@ func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
 type Client struct {
 	name string
 	t    transport
+	spec Spec
 
 	// Capabilities advertised by the server at initialize. prompts/list and
 	// resources/list are only called when advertised, so we never provoke a
@@ -372,6 +392,16 @@ type Client struct {
 	prompts   []Prompt
 	resources []Resource
 	tools     []ToolInfo
+}
+
+func (c *Client) auxiliaryClient(ctx context.Context) (*Client, context.Context, context.CancelFunc, error) {
+	auxCtx, cancel := context.WithTimeout(ctx, defaultStartTimeout)
+	aux, err := start(auxCtx, auxCtx, c.spec)
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+	return aux, auxCtx, cancel, nil
 }
 
 // ToolInfo is the human-facing metadata returned by MCP tools/list for one tool.
@@ -578,7 +608,7 @@ func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	if tt == "" {
 		tt = "stdio"
 	}
-	c := &Client{name: s.Name, t: t, transport: tt}
+	c := &Client{name: s.Name, t: t, spec: s, transport: tt}
 	if err := c.initialize(callCtx); err != nil {
 		c.close()
 		return nil, err

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"reasonix/internal/event"
 	"reasonix/internal/tool"
 )
 
@@ -223,7 +224,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 
 			// Transport on the parent ctx, startup RPCs on the timed callCtx: the
 			// per-plugin timeout caps initialize+listTools, but the long-lived
-			// stdio child must outlive the startup scope.
+			// stdio child must outlive the startup scope and later phase-B calls.
 			c, err := start(ctx, callCtx, spec)
 			if err != nil {
 				cancelStartup()
@@ -240,21 +241,11 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			}
 			c.toolCount = len(ts)
 
-			// Prompts and resources are auxiliary: only fetched when the server
-			// advertised the capability, and a listing error is tolerated rather
-			// than failing the whole session over a non-essential surface.
-			if c.hasPrompts {
-				if ps, perr := c.listPrompts(callCtx); perr == nil {
-					c.prompts = ps
-				}
-			}
-			if c.hasResources {
-				if rs, rerr := c.listResources(callCtx); rerr == nil {
-					c.resources = rs
-				}
-			}
 			cancelStartup()
 
+			// Prompts and resources are deferred to StartPhaseB so the boot path
+			// can return as soon as tools are ready — the slow-to-list surfaces
+			// stream in later and fan out an MCPSurfaceReady event each.
 			ch <- result{idx: idx, spec: spec, client: c, tools: ts}
 		}(i, s)
 	}
@@ -283,8 +274,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 		}
 		h.clients = append(h.clients, r.client)
 		tools = append(tools, r.tools...)
-		h.prompts = append(h.prompts, r.client.prompts...)
-		h.resources = append(h.resources, r.client.resources...)
+		// prompts/resources are filled in later by StartPhaseB.
 	}
 	if firstErr != nil {
 		h.Close()
@@ -300,6 +290,64 @@ func (h *Host) Close() {
 	h.mu.RUnlock()
 	for _, c := range clients {
 		c.close()
+	}
+}
+
+// StartPhaseB asynchronously fetches the auxiliary surfaces (prompts and
+// resources) for every connected client. Boot calls it right after Start
+// returns, on a session-scoped ctx, so the agent becomes responsive as soon as
+// tools are ready and the slower list calls stream in afterwards. Each finished
+// surface fires an MCPSurfaceReady event on sink so UIs (e.g. /mcp status) can
+// refresh without polling. A nil sink is tolerated — the merge still happens.
+// Errors are logged and swallowed: prompts/resources are non-essential and must
+// not break the session over one slow server.
+func (h *Host) StartPhaseB(ctx context.Context, sink event.Sink) {
+	h.mu.RLock()
+	clients := append([]*Client(nil), h.clients...)
+	h.mu.RUnlock()
+	for _, c := range clients {
+		if c.hasPrompts {
+			go h.fetchPrompts(ctx, c, sink)
+		}
+		if c.hasResources {
+			go h.fetchResources(ctx, c, sink)
+		}
+	}
+}
+
+func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
+	ps, err := c.listPrompts(ctx)
+	if err != nil {
+		slog.Warn("plugin: listPrompts failed", "server", c.name, "err", err)
+		return
+	}
+	h.mu.Lock()
+	c.prompts = ps
+	h.prompts = append(h.prompts, ps...)
+	h.mu.Unlock()
+	if sink != nil {
+		sink.Emit(event.Event{
+			Kind: event.MCPSurfaceReady,
+			Text: fmt.Sprintf("%s: prompts ready (%d items)", c.name, len(ps)),
+		})
+	}
+}
+
+func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
+	rs, err := c.listResources(ctx)
+	if err != nil {
+		slog.Warn("plugin: listResources failed", "server", c.name, "err", err)
+		return
+	}
+	h.mu.Lock()
+	c.resources = rs
+	h.resources = append(h.resources, rs...)
+	h.mu.Unlock()
+	if sink != nil {
+		sink.Emit(event.Event{
+			Kind: event.MCPSurfaceReady,
+			Text: fmt.Sprintf("%s: resources ready (%d items)", c.name, len(rs)),
+		})
 	}
 }
 
@@ -455,30 +503,20 @@ func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
 		return nil, fmt.Errorf("list tools: %w", err)
 	}
 	c.toolCount = len(ts)
-	// Do the remaining network calls before taking the lock, so a hot-add never
-	// blocks status reads for the duration of a listPrompts/listResources round-trip.
-	var prompts []Prompt
-	if c.hasPrompts {
-		if ps, perr := c.listPrompts(ctx); perr == nil {
-			prompts = ps
-		} else {
-			slog.Warn("plugin: listPrompts failed", "server", s.Name, "err", perr)
-		}
-	}
-	var resources []Resource
-	if c.hasResources {
-		if rs, rerr := c.listResources(ctx); rerr == nil {
-			resources = rs
-		} else {
-			slog.Warn("plugin: listResources failed", "server", s.Name, "err", rerr)
-		}
-	}
 	h.mu.Lock()
 	h.clients = append(h.clients, c)
-	h.prompts = append(h.prompts, prompts...)
-	h.resources = append(h.resources, resources...)
 	h.clearFailure(s.Name)
 	h.mu.Unlock()
+	// Prompts and resources stream in on the long ctx the caller passed (Host.Add
+	// uses the session-scoped PluginCtx, not a per-turn ctx), so the slow list
+	// calls cannot starve a /mcp add of its return value. nil sink keeps hot-add
+	// quiet — the chat UI re-queries Host.Prompts()/Resources() on demand.
+	if c.hasPrompts {
+		go h.fetchPrompts(ctx, c, nil)
+	}
+	if c.hasResources {
+		go h.fetchResources(ctx, c, nil)
+	}
 	return ts, nil
 }
 
@@ -528,7 +566,9 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 // subprocess) and uses callCtx for the initialize round-trip (whose cancellation
 // only bounds startup RPCs). Splitting the two lets a per-plugin timeout cap
 // handshake latency without making the timeout context own a successfully
-// registered stdio server. Callers that don't care pass the same ctx for both.
+// registered stdio server; the child also has to outlive phase A so phase B
+// (prompts + resources) can still call it later. Callers that don't care pass
+// the same ctx for both.
 func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	t, err := newTransport(lifeCtx, s)
 	if err != nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -229,14 +229,18 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			// stdio child must outlive the startup scope and later phase-B calls.
 			c, err := start(ctx, callCtx, spec)
 			if err != nil {
+				phaseADur := time.Since(phaseAStart)
 				cancelStartup()
+				go func() { _ = RecordStartup(spec.Name, phaseADur) }()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
 				return
 			}
 
 			ts, err := c.listTools(callCtx)
 			if err != nil {
+				phaseADur := time.Since(phaseAStart)
 				cancelStartup()
+				go func() { _ = RecordStartup(spec.Name, phaseADur) }()
 				c.close()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
 				return
@@ -246,8 +250,8 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			// Persist for next launch on the side: a slow stats/cache write
 			// must not delay tools coming online, and either failure is
 			// recoverable (we just re-handshake or skip auto-demote).
-			cancelStartup()
 			phaseADur := time.Since(phaseAStart)
+			cancelStartup()
 			go func() {
 				_ = RecordStartup(spec.Name, phaseADur)
 				_ = SaveCachedSchema(spec.Name, CachedSchema{

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -350,6 +350,45 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 	}
 }
 
+func TestStartRecordsTimeoutStats(t *testing.T) {
+	withTempCache(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	slow := Spec{
+		Name:    "slow-stats",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS": "1",
+			"GO_WANT_HELPER_INIT_MS": "300",
+		},
+	}
+	for i := 0; i < 3; i++ {
+		host, _, err := Start(ctx, []Spec{slow}, StartPolicy{
+			PerPluginTimeout: 50 * time.Millisecond,
+			Concurrency:      1,
+			AbortOnError:     false,
+		})
+		if err != nil {
+			t.Fatalf("Start #%d: %v", i, err)
+		}
+		host.Close()
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rec := Recommend("slow-stats", 50*time.Millisecond, 3)
+		if rec.Demote {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout samples did not trigger demote; stats=%+v rec=%+v", readStats(t, "slow-stats"), rec)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestStartPhaseAReturnsBeforePhaseB pins the two-phase handshake contract.
 // The helper advertises prompts and stalls prompts/list by 200ms; StartAvailable
 // must return as soon as tools are ready (well before that 200ms), and the

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/tool"
 )
 
 // TestStdioEndToEnd drives a real subprocess (this test binary re-invoked in
@@ -408,6 +409,49 @@ func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
 
 	if got := host.Prompts(); len(got) != 1 || got[0].Raw != "hello" {
 		t.Fatalf("after phase B, prompts = %+v, want one named hello", got)
+	}
+}
+
+func TestStartPhaseBDoesNotBlockToolCalls(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	spec := Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":         "1",
+			"GO_WANT_HELPER_PROMPTS":         "1",
+			"GO_WANT_HELPER_PROMPT_DELAY_MS": "1000",
+		},
+	}
+
+	host, tools := StartAvailable(ctx, []Spec{spec})
+	defer host.Close()
+
+	var echo tool.Tool
+	for _, t := range tools {
+		if t.Name() == "mcp__mock__echo" {
+			echo = t
+			break
+		}
+	}
+	if echo == nil {
+		t.Fatal("missing echo tool")
+	}
+
+	host.StartPhaseB(ctx, event.Discard)
+	time.Sleep(50 * time.Millisecond)
+
+	callCtx, callCancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer callCancel()
+	out, err := echo.Execute(callCtx, json.RawMessage(`{"msg":"hi"}`))
+	if err != nil {
+		t.Fatalf("tool call should not be blocked by background prompts/list: %v", err)
+	}
+	if out != "echo: hi" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: hi")
 	}
 }
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"reasonix/internal/event"
 )
 
 // TestStdioEndToEnd drives a real subprocess (this test binary re-invoked in
@@ -347,6 +349,68 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 	}
 }
 
+// TestStartPhaseAReturnsBeforePhaseB pins the two-phase handshake contract.
+// The helper advertises prompts and stalls prompts/list by 200ms; StartAvailable
+// must return as soon as tools are ready (well before that 200ms), and the
+// prompts must only materialise on Host after StartPhaseB has been called and
+// drained — proving prompts ride the background phase, not the boot critical path.
+func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	spec := Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":         "1",
+			"GO_WANT_HELPER_PROMPTS":         "1",
+			"GO_WANT_HELPER_PROMPT_DELAY_MS": "200",
+		},
+	}
+
+	t0 := time.Now()
+	host, tools := StartAvailable(ctx, []Spec{spec})
+	startDur := time.Since(t0)
+	defer host.Close()
+
+	if len(tools) == 0 {
+		t.Fatalf("want tools from helper, got 0")
+	}
+	if startDur >= 150*time.Millisecond {
+		t.Fatalf("StartAvailable took %v — phase B (200ms prompts) leaked onto the critical path", startDur)
+	}
+	if got := host.Prompts(); len(got) != 0 {
+		t.Fatalf("phase A must not surface prompts yet, got %d", len(got))
+	}
+
+	// Drive phase B and wait for the surface-ready event. Use a buffered channel
+	// sink so the test never blocks the emitter — the event payload itself is
+	// our completion signal.
+	ready := make(chan event.Event, 4)
+	host.StartPhaseB(ctx, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.MCPSurfaceReady {
+			select {
+			case ready <- e:
+			default:
+			}
+		}
+	}))
+
+	select {
+	case e := <-ready:
+		if !strings.Contains(e.Text, "prompts ready") {
+			t.Fatalf("phase B event text = %q, want it to mention prompts", e.Text)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("phase B never fired MCPSurfaceReady for prompts")
+	}
+
+	if got := host.Prompts(); len(got) != 1 || got[0].Raw != "hello" {
+		t.Fatalf("after phase B, prompts = %+v, want one named hello", got)
+	}
+}
+
 // TestHelperProcess is not a real test; it acts as a minimal MCP stdio server
 // when invoked by TestStdioEndToEnd. It exits before the test framework can
 // print to stdout, keeping the JSON-RPC channel clean.
@@ -354,6 +418,9 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 // GO_WANT_HELPER_INIT_MS optionally injects a sleep before responding to the
 // initialize call, used by the timeout / concurrency tests to simulate slow
 // handshakes without depending on external processes.
+// GO_WANT_HELPER_PROMPTS advertises the prompts capability and registers a
+// "hello" prompt; GO_WANT_HELPER_PROMPT_DELAY_MS stalls prompts/list so the
+// phase-A vs phase-B split can be exercised.
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_STDERR_EXIT") == "1" {
 		os.Stderr.WriteString("helper stderr boom\n")
@@ -400,10 +467,26 @@ func TestHelperProcess(t *testing.T) {
 			if initDelay > 0 {
 				time.Sleep(initDelay)
 			}
+			caps := map[string]any{}
+			if os.Getenv("GO_WANT_HELPER_PROMPTS") == "1" {
+				caps["prompts"] = map[string]any{}
+			}
 			result = map[string]any{
 				"protocolVersion": protocolVersion,
 				"serverInfo":      map[string]any{"name": "mock", "version": "0"},
+				"capabilities":    caps,
 			}
+		case "prompts/list":
+			if ms := os.Getenv("GO_WANT_HELPER_PROMPT_DELAY_MS"); ms != "" {
+				if v, err := time.ParseDuration(ms + "ms"); err == nil && v > 0 {
+					time.Sleep(v)
+				}
+			}
+			result = map[string]any{"prompts": []map[string]any{{
+				"name":        "hello",
+				"description": "say hi",
+				"arguments":   []map[string]any{},
+			}}}
 		case "tools/list":
 			result = map[string]any{"tools": []map[string]any{{
 				"name":        "zed",

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -102,10 +102,10 @@ func RecordStartup(name string, dur time.Duration) error {
 }
 
 // Recommend inspects the recent samples for name and decides whether the
-// plugin should be demoted to "lazy" this session. The rule is simple and
-// matches what the user asked for: demote when the last demoteAfter samples
-// are all strictly above budget*2. Missing/empty stats → no demote (a fresh
-// plugin gets the benefit of the doubt and one normal startup attempt).
+// plugin should be demoted to "lazy" this session. The rule is simple: demote
+// when the last demoteAfter samples all hit or exceed the blocking startup
+// budget. Missing/empty stats → no demote (a fresh plugin gets the benefit of
+// the doubt and one normal startup attempt).
 //
 // budget == 0 disables the check (returns no-demote). demoteAfter <= 0 falls
 // back to defaultDemoteAfter so callers can pass the config value verbatim
@@ -135,10 +135,10 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 		return rec
 	}
 
-	threshold := (budget * 2).Milliseconds()
+	threshold := budget.Milliseconds()
 	tail := stats.SamplesMs[len(stats.SamplesMs)-demoteAfter:]
 	for _, ms := range tail {
-		if ms <= threshold {
+		if ms < threshold {
 			return rec
 		}
 	}
@@ -233,4 +233,3 @@ func p99(samples []int64) time.Duration {
 	}
 	return time.Duration(sorted[idx]) * time.Millisecond
 }
-

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -1,0 +1,236 @@
+// Per-plugin startup latency tracking for MCP servers. Reasonix uses these
+// samples to decide whether a chronically slow plugin should be demoted from
+// "eager" to "lazy" loading for the rest of a session — see Recommend.
+//
+// Storage is one tiny JSON file per plugin under <cacheDir>/mcp/, written
+// atomically (tmpfile + Rename) so a crash mid-write can't corrupt history.
+// All errors are best-effort: missing/unreadable files yield "no demote",
+// write failures get logged via slog and dropped — startup must not fail
+// because telemetry can't persist.
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"reasonix/internal/config"
+)
+
+const (
+	// statsVersion is the on-disk format version. Bump when StartupStats changes
+	// shape incompatibly; older files are then ignored on load (treated as
+	// missing) so a new build doesn't crash on a stale schema.
+	statsVersion = 1
+	// maxSamples bounds the rolling window. 20 is enough to absorb a few flukes
+	// while still letting recent regressions dominate p99 / consecutive-fail
+	// checks. Older samples drop off the front.
+	maxSamples = 20
+	// defaultDemoteAfter is the consecutive-over-budget threshold used when the
+	// caller passes <= 0. Three in a row is "user has felt it three startups",
+	// which matches what the plan calls out as the demote signal.
+	defaultDemoteAfter = 3
+)
+
+// StartupStats is the on-disk record of recent startup durations for one
+// plugin. SamplesMs is oldest→newest (newest appended at the tail); LastSeen
+// is the wall-clock time the most recent sample was recorded so a future
+// "stale data" pruning step can act on it without re-parsing each sample.
+type StartupStats struct {
+	Version   int       `json:"version"`
+	SamplesMs []int64   `json:"samples_ms"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+// Recommendation is the result of inspecting a plugin's recent startup
+// history. Demote is the actionable bit boot.go consumes (true → switch this
+// plugin's tier to "lazy" for this session). P99 and Reason are descriptive
+// only — Reason is meant to be surfaced to the user as a Notice so a sudden
+// demotion isn't silent.
+type Recommendation struct {
+	Demote bool
+	P99    time.Duration
+	Reason string
+}
+
+// RecordStartup appends one sample (the wall-clock duration of a plugin's
+// blocking handshake phase) to that plugin's stats file. The file is created
+// on first call; existing samples are kept in a rolling window of maxSamples,
+// dropping the oldest when full.
+//
+// Best-effort: any I/O or marshal failure is logged with slog.Warn and
+// returned, but callers are expected to ignore the error — telemetry must
+// never block real work. Writes go through a tmpfile + Rename so a partial
+// write can't leave the stats file truncated or unparseable.
+func RecordStartup(name string, dur time.Duration) error {
+	path := statsPath(name)
+	if path == "" {
+		// No cache dir resolvable on this host — silently skip. This is the
+		// same fallback every other persistence helper in the project takes
+		// (ArchiveDir/SessionDir return "" and writers no-op).
+		return nil
+	}
+
+	stats := loadStats(path) // missing/corrupt → fresh zero value
+	if stats.Version != statsVersion {
+		// Version mismatch: start over rather than try to migrate. The window
+		// is small enough that "lose 20 samples" is cheap, and it keeps the
+		// migration path trivial as the format evolves.
+		stats = StartupStats{Version: statsVersion}
+	}
+
+	ms := dur.Milliseconds()
+	if ms < 0 {
+		ms = 0
+	}
+	stats.SamplesMs = append(stats.SamplesMs, ms)
+	if len(stats.SamplesMs) > maxSamples {
+		// Trim from the front: oldest samples leave first.
+		stats.SamplesMs = stats.SamplesMs[len(stats.SamplesMs)-maxSamples:]
+	}
+	stats.LastSeen = time.Now()
+
+	if err := writeStatsAtomic(path, stats); err != nil {
+		slog.Warn("plugin: record startup stats failed", "server", name, "err", err)
+		return err
+	}
+	return nil
+}
+
+// Recommend inspects the recent samples for name and decides whether the
+// plugin should be demoted to "lazy" this session. The rule is simple and
+// matches what the user asked for: demote when the last demoteAfter samples
+// are all strictly above budget*2. Missing/empty stats → no demote (a fresh
+// plugin gets the benefit of the doubt and one normal startup attempt).
+//
+// budget == 0 disables the check (returns no-demote). demoteAfter <= 0 falls
+// back to defaultDemoteAfter so callers can pass the config value verbatim
+// without sanitising it.
+func Recommend(name string, budget time.Duration, demoteAfter int) Recommendation {
+	if budget <= 0 {
+		return Recommendation{}
+	}
+	if demoteAfter <= 0 {
+		demoteAfter = defaultDemoteAfter
+	}
+
+	path := statsPath(name)
+	if path == "" {
+		return Recommendation{}
+	}
+	stats := loadStats(path)
+	if stats.Version != statsVersion || len(stats.SamplesMs) == 0 {
+		// Either no history yet or a format we can't read — give the plugin a
+		// chance. The cost of one slow start is small compared to wrongly
+		// demoting a healthy plugin off stale data.
+		return Recommendation{}
+	}
+
+	rec := Recommendation{P99: p99(stats.SamplesMs)}
+	if len(stats.SamplesMs) < demoteAfter {
+		return rec
+	}
+
+	threshold := (budget * 2).Milliseconds()
+	tail := stats.SamplesMs[len(stats.SamplesMs)-demoteAfter:]
+	for _, ms := range tail {
+		if ms <= threshold {
+			return rec
+		}
+	}
+	rec.Demote = true
+	rec.Reason = fmt.Sprintf(
+		"plugin %q has been slow %d startups in a row (last %dms, budget %dms); demoting to lazy this session",
+		name, demoteAfter, tail[len(tail)-1], budget.Milliseconds(),
+	)
+	return rec
+}
+
+// statsPath returns the canonical path for one plugin's stats file:
+// <config.CacheDir()>/mcp/<slug>.stats.json. Shares the cache root and slug
+// rule with the schema cache so a `<plugin>.json` and `<plugin>.stats.json`
+// sit side by side under the same per-server folder. Returns "" when no cache
+// dir is resolvable, which all callers treat as "skip telemetry".
+func statsPath(name string) string {
+	base := config.CacheDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "mcp", slug(name)+".stats.json")
+}
+
+// loadStats reads and decodes a stats file. Any failure (missing file,
+// permission denied, malformed JSON) returns a zero StartupStats so callers
+// can treat absence and corruption identically. The slog.Warn fires only on
+// non-NotExist read errors and on JSON errors — those are surprising enough
+// to be worth a trace, but they still must not stop the caller.
+func loadStats(path string) StartupStats {
+	var s StartupStats
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("plugin: read startup stats failed", "path", path, "err", err)
+		}
+		return s
+	}
+	if err := json.Unmarshal(b, &s); err != nil {
+		slog.Warn("plugin: parse startup stats failed", "path", path, "err", err)
+		return StartupStats{}
+	}
+	return s
+}
+
+// writeStatsAtomic serialises s and writes it via tmpfile + os.Rename so that
+// concurrent readers see either the old content or the new one, never a
+// half-written file. Mirrors desktop/sessions.go:40-64.
+func writeStatsAtomic(path string, s StartupStats) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".stats.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// p99 returns the 99th-percentile sample as a Duration. With small windows
+// (n ≤ 20) "p99" collapses to "the slowest sample we have"; the value is
+// purely informational, surfaced in Recommendation for UI/notice text.
+func p99(samples []int64) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	// Use ceil(0.99 * n) - 1 so that for n=1..100 we always pick the last
+	// element; for larger n it's the index at the 99% boundary.
+	idx := int(float64(len(sorted))*0.99+0.9999999) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return time.Duration(sorted[idx]) * time.Millisecond
+}
+

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -137,6 +137,22 @@ func TestRecommendAboveBudgetDemotes(t *testing.T) {
 	}
 }
 
+func TestRecommendAtBudgetDemotes(t *testing.T) {
+	withTempCache(t)
+
+	budget := 5 * time.Second
+	for i := 0; i < 3; i++ {
+		if err := RecordStartup("timeout-plugin", budget); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	got := Recommend("timeout-plugin", budget, 3)
+	if !got.Demote {
+		t.Fatalf("Demote = false, want true for repeated budget hits (samples=%+v)", readStats(t, "timeout-plugin").SamplesMs)
+	}
+}
+
 func TestRecommendMissingStatsNoDemote(t *testing.T) {
 	withTempCache(t)
 

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -1,0 +1,207 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withTempCache redirects config.CacheDir() at t.TempDir for the duration of
+// a test by overriding HOME and XDG_CONFIG_HOME — the same knobs cache_test
+// uses, since os.UserConfigDir reads them. Returns the directory that will
+// hold the cache subtree so callers can assert paths inside it.
+func withTempCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+// readStats reads the on-disk stats file for name directly (not through the
+// public API) so tests can assert raw file contents — what we wrote and in
+// what order.
+func readStats(t *testing.T, name string) StartupStats {
+	t.Helper()
+	path := statsPath(name)
+	if path == "" {
+		t.Fatal("statsPath returned empty")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read stats %s: %v", path, err)
+	}
+	var s StartupStats
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	return s
+}
+
+func TestRecordStartupAppends(t *testing.T) {
+	withTempCache(t)
+
+	durs := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 300 * time.Millisecond}
+	for _, d := range durs {
+		if err := RecordStartup("foo", d); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	s := readStats(t, "foo")
+	if s.Version != statsVersion {
+		t.Fatalf("Version = %d, want %d", s.Version, statsVersion)
+	}
+	if got := len(s.SamplesMs); got != 3 {
+		t.Fatalf("samples = %d, want 3", got)
+	}
+	// File is written oldest→newest (newest at the tail).
+	want := []int64{100, 200, 300}
+	for i, w := range want {
+		if s.SamplesMs[i] != w {
+			t.Fatalf("SamplesMs[%d] = %d, want %d (full=%v)", i, s.SamplesMs[i], w, s.SamplesMs)
+		}
+	}
+	if s.LastSeen.IsZero() {
+		t.Fatal("LastSeen should be set after a record")
+	}
+}
+
+func TestRecordStartupCapsAtWindow(t *testing.T) {
+	withTempCache(t)
+
+	const total = 25
+	for i := 0; i < total; i++ {
+		// Use distinct values so we can verify the *oldest* ones were dropped.
+		if err := RecordStartup("bar", time.Duration(i+1)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	s := readStats(t, "bar")
+	if got := len(s.SamplesMs); got != maxSamples {
+		t.Fatalf("samples = %d, want %d", got, maxSamples)
+	}
+	// First retained sample should be #6 (1..5 dropped); last should be #25.
+	wantFirst := int64(total - maxSamples + 1) // 6
+	if s.SamplesMs[0] != wantFirst {
+		t.Fatalf("SamplesMs[0] = %d, want %d", s.SamplesMs[0], wantFirst)
+	}
+	if s.SamplesMs[len(s.SamplesMs)-1] != int64(total) {
+		t.Fatalf("SamplesMs[last] = %d, want %d", s.SamplesMs[len(s.SamplesMs)-1], total)
+	}
+}
+
+func TestRecommendBelowBudgetNoDemote(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// All samples comfortably under budget*2 == 2s.
+	for _, ms := range []int64{500, 800, 1200, 1500, 900} {
+		if err := RecordStartup("ok-plugin", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("ok-plugin", budget, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true, want false (reason=%q)", got.Reason)
+	}
+}
+
+func TestRecommendAboveBudgetDemotes(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// First sample is fast (would block a naive "ever-slow" check), then 3
+	// consecutive samples above budget*2 == 2s. The plan says demote on
+	// "last N consecutive over-budget", so this should trip.
+	for _, ms := range []int64{500, 2500, 3000, 4000} {
+		if err := RecordStartup("slow-plugin", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("slow-plugin", budget, 3)
+	if !got.Demote {
+		t.Fatalf("Demote = false, want true (samples=%+v)", readStats(t, "slow-plugin").SamplesMs)
+	}
+	if got.Reason == "" {
+		t.Fatal("Reason should be non-empty when demoting")
+	}
+	if got.P99 <= 0 {
+		t.Fatalf("P99 = %v, want > 0", got.P99)
+	}
+}
+
+func TestRecommendMissingStatsNoDemote(t *testing.T) {
+	withTempCache(t)
+
+	// Never recorded anything → should not demote a brand-new plugin.
+	got := Recommend("never-seen", 1*time.Second, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true on missing stats, want false (reason=%q)", got.Reason)
+	}
+	if got.P99 != 0 {
+		t.Fatalf("P99 = %v on missing stats, want 0", got.P99)
+	}
+}
+
+func TestRecommendOldFailuresFadeOut(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// Early samples were terrible (well above budget*2 == 2s), but the most
+	// recent three are quick — rolling window must let the plugin recover.
+	for _, ms := range []int64{5000, 6000, 7000, 8000, 500, 600, 700} {
+		if err := RecordStartup("recovered", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("recovered", budget, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true after recovery, want false (samples=%+v, reason=%q)",
+			readStats(t, "recovered").SamplesMs, got.Reason)
+	}
+}
+
+// TestStatsPathLayout pins the on-disk location so Phase 4's integration code
+// can rely on it. We assert the path sits under config.CacheDir()/mcp and that
+// the slug strips raw separators — exact slug rule lives in cache.go.
+func TestStatsPathLayout(t *testing.T) {
+	withTempCache(t)
+
+	p := statsPath("server/with spaces")
+	if p == "" {
+		t.Fatal("statsPath returned empty")
+	}
+	wantSuffix := filepath.Join("reasonix", "cache", "mcp")
+	if got := filepath.Dir(p); !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("parent = %q, want suffix %q", got, wantSuffix)
+	}
+	base := filepath.Base(p)
+	if filepath.Ext(base) != ".json" {
+		t.Fatalf("ext = %q, want .json", filepath.Ext(base))
+	}
+	if !strings.HasSuffix(base, ".stats.json") {
+		t.Fatalf("base = %q, want .stats.json suffix", base)
+	}
+	if containsAny(base, "/ ") {
+		t.Fatalf("slug %q contains raw separators", base)
+	}
+}
+
+func containsAny(s, chars string) bool {
+	for _, c := range chars {
+		for _, r := range s {
+			if r == c {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
+	"sync"
 
 	"reasonix/internal/diff"
 	"reasonix/internal/provider"
@@ -97,6 +98,7 @@ func LookupBuiltin(name string) (Tool, bool) {
 
 // Registry is a per-run set of tools: enabled built-ins plus plugin tools.
 type Registry struct {
+	mu    sync.RWMutex
 	tools map[string]Tool
 	order []string
 }
@@ -108,6 +110,9 @@ func NewRegistry() *Registry {
 
 // Add inserts (or replaces) a tool, preserving first-seen order.
 func (r *Registry) Add(t Tool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	name := t.Name()
 	if _, ok := r.tools[name]; !ok {
 		r.order = append(r.order, name)
@@ -138,6 +143,9 @@ func SplitMCPName(name string) (server, tool string, ok bool) {
 // drop an MCP server's "mcp__<server>__" namespace when it's disconnected — and
 // returns the count removed.
 func (r *Registry) RemovePrefix(prefix string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	kept := r.order[:0]
 	removed := 0
 	for _, name := range r.order {
@@ -154,15 +162,26 @@ func (r *Registry) RemovePrefix(prefix string) int {
 
 // Get looks up a tool by name.
 func (r *Registry) Get(name string) (Tool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	t, ok := r.tools[name]
 	return t, ok
 }
 
 // Len returns the number of registered tools.
-func (r *Registry) Len() int { return len(r.order) }
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.order)
+}
 
 // Names returns the registered tool names in insertion order.
 func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	out := make([]string, len(r.order))
 	copy(out, r.order)
 	return out
@@ -170,11 +189,20 @@ func (r *Registry) Names() []string {
 
 // Schemas exports tool definitions in stable name order for the provider.
 func (r *Registry) Schemas() []provider.ToolSchema {
-	names := r.Names()
+	r.mu.RLock()
+	names := make([]string, len(r.order))
+	copy(names, r.order)
 	sort.Strings(names)
-	out := make([]provider.ToolSchema, 0, len(names))
+	tools := make([]Tool, 0, len(names))
 	for _, name := range names {
-		t := r.tools[name]
+		if t := r.tools[name]; t != nil {
+			tools = append(tools, t)
+		}
+	}
+	r.mu.RUnlock()
+
+	out := make([]provider.ToolSchema, 0, len(tools))
+	for _, t := range tools {
 		out = append(out, provider.ToolSchema{
 			Name:        t.Name(),
 			Description: t.Description(),

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -34,8 +34,6 @@ default     = "deepseek-v4-flash"   # optional; defaults to the first of `models
 api_key_env = "DEEPSEEK_API_KEY"
 context_window = 1000000
 price       = { cache_hit = 0.02, input = 1, output = 2, currency = "¥" }   # per 1M tokens
-# DeepSeek thinking mode is enabled by default; effort: high | max | off.
-effort      = "high"
 
 # A single-model provider still works (use `model = "..."`) — pick this form when a
 # model needs its own base_url / context_window / price (e.g. the two MiMo SKUs
@@ -117,3 +115,11 @@ enabled = []   # empty = all built-in tools
 # [[plugins]]
 # name    = "example"
 # command = "reasonix-plugin-example"
+# tier    = "lazy"  # eager | lazy (default) | background
+# # tier guidance:
+# #   eager      — handshake at boot; the agent waits. Use when the plugin's
+# #                tools must be in the very first turn's system prompt.
+# #   lazy       — placeholder tools (from cached schema, when present) until
+# #                the model uses them, then handshake on-demand. Default.
+# #   background — placeholder + spawn at boot in a goroutine so an idle
+# #                session warms up without blocking the user.


### PR DESCRIPTION
## Summary

Adds `PluginEntry.Tier` (`eager` | `lazy` | `background`, default **lazy**) so a user opts in to which MCP servers actually block boot. With the cache from PR 3, a `lazy` server registers placeholder tools whose schema is byte-identical to what the live handshake would produce, so the eventual swap is invisible to the prompt cache. Auto-demote turns Phase 5 telemetry (PR 3) into action: an eager plugin whose last three startups all blew past 2×budget drops to lazy for this session. This is PR **4/4** of the MCP-startup overhaul.

## Root Cause / Motivation

Even with PR 1 (parallel + timeout) and PR 2 (deferred phase B), every configured MCP server still pays a handshake cost on every launch — useful tools like `codegraph` deserve that cost, but a noisy auxiliary server (search, mail, web fetchers) usually does not, especially when the user never invokes them in 80% of sessions. The user has no knob to express "fast boot, lazy connect" today. And once a plugin starts misbehaving (added a slow npm postinstall, network flaked), there is no mechanism to learn from that across launches.

## Technical Approach

### Config surface (`internal/config/config.go`)

- `PluginEntry.Tier string `toml:"tier"\`\`. New `ResolvedTier()` normalises empty/unknown values to `lazy`, so a typo never forces a slow boot and existing configs auto-migrate to the fast path.
- Default chosen as `lazy` (not eager) — see "Behaviour change" below.

### Boot orchestration (`internal/boot/boot.go`)

1. `partitionByTier(entries)` splits configured plugins three ways before any handshake fires.
2. Auto-demote: for each eager entry, `plugin.Recommend(name, budget, 0)` checks the rolling stats from PR 3. If the last three samples each exceeded `2×budget`, that entry is moved into the lazy bucket and a Notice is queued with the recorded p99.
3. `codegraph` is appended to the eager bucket unconditionally — symbol-graph tools land in the system prompt, so the agent must see them on first turn regardless of user tier.
4. Eager → `plugin.StartAvailable` (blocking, PhaseB fires from a goroutine on the same session ctx).
5. Lazy → `registerDeferred(specs, kick=false)`: for each spec, `LoadCachedSchema` is consulted and `LazyToolset` returns placeholders.
6. Background → `registerDeferred(specs, kick=true)`: same as lazy but immediately kicks the spawn so it's typically done by the time the user calls a tool.

### Lazy machinery (`internal/plugin/lazy.go`)

- `lazySpawn` is a per-server state machine (`idle → inFlight → ready/failed`) shared by every placeholder for that server. The handshake runs outside the lock; only the result-publish reacquires.
- `lazyTool` implements `tool.Tool`. Schema/Description/Name come from the cached entry (or a stub when no cache exists). Execute checks the state machine: ready → `trySwap` then forward; inFlight → "retry next turn"; failed → sticky error; idle → take the handshake (synchronously on cache-hit; spawn-then-hint on cache-miss).
- **The registry swap rule** matters: `tool.Registry` has no mutex (agent dispatch is single-threaded), so `reg.Add(realTool)` only ever runs from inside `lazyTool.Execute` — the turn-synchronous path. Background spawn completion just sets the shared `state`; the next Execute call is what actually swaps. `sync.Once`-style state guards an at-most-one handshake even with concurrent first calls.
- `DefaultStartupBudget()` exposes the per-plugin timeout from PR 1 so boot.go's demote check and `plugin.Start`'s default timeout always pair.

### Behaviour change

Default `tier` is **lazy** in this PR. Rationale:
- Most user MCP servers are auxiliary (mail, web, calendar, …) and not in the first-turn critical path. Eager-by-default has been making cold starts slower than necessary.
- For users who do want the old behaviour, `tier = "eager"` per plugin restores it. `reasonix.example.toml` documents the trade-off.
- `codegraph` is pinned eager in code, so the user-visible "tools we always have" set is unchanged.

A pre-existing test that asserted "missing MCP binary surfaces a startup failure at boot" had to be updated to `tier = "eager"` — that test's intent is the *eager* failure path, which is unaffected. Without the tier change, a lazy plugin's missing binary surfaces on first call rather than boot, which a separate test now covers.

## Focused Optimization Points

- **Boot wall-clock**: for a session with 1 eager + N lazy plugins, boot waits only on the eager one. N lazy plugins cost a single cache read + a placeholder registration each (microseconds).
- **Prompt cache stability**: lazy cache-hit registers placeholder tools whose `Schema()` returns the same canonicalized bytes as the eventual `*remoteTool.Schema()`. The swap is a no-op for Anthropic ephemeral cache and DeepSeek prefix cache; `TestLazyToolsetCacheHitSchemaVisible` pins the contract.
- **Auto-demote feedback loop**: chronic slowness is detected once and applied next launch. The user keeps eager intent in their TOML — only this session's behaviour changes — so the moment the plugin recovers, the next launch is back to eager.
- **First-ever-use degradation (cache miss)**: a single "next turn" round trip on the very first launch per plugin per machine. After that the cache is populated and subsequent launches are warm.

## Verification

- `go build ./...`
- `go test ./internal/plugin/... ./internal/config/... ./internal/event/... -count=1 -timeout=180s` — all green.
- `go test ./internal/plugin/... ./internal/config/... ./internal/event/... -race -count=1 -timeout=180s` — all green (lazySpawn's mu protects state; reg.Add only ever runs in turn-sync).
- `go vet ./internal/plugin/... ./internal/config/... ./internal/event/... ./internal/boot/...` — clean.
- `go test ./internal/boot/... -run "TestPartitionByTier|TestBuildEager|TestBuildLazy|TestBuildAutoDemote|TestBuildRecordsMCP" -v` — all 5 PASS.
- Pre-existing `TestBuildDiscoversSkills` continues to fail on this branch the same way it does on `main-v2` (it reads the developer's global `~/.claude/skills/`). Not introduced by this PR.

### Cache-affected test surface

Per the prompt-cache-stability claim above, this PR runs the focused canonicalisation + cache-hit tests that gate it:

- `TestLazyToolsetCacheHitSchemaVisible` — placeholder Schema() equals the cached schema, before any spawn.
- `TestLazyCacheHitSyncSpawn` — first Execute swaps lazyTool → remoteTool; Names match; subsequent Schema() returns the canonical form, byte-equal to the placeholder.
- `TestCanonicalize*` (already in `internal/plugin/`): idempotency, ordering, equivalent inputs.

Together they prove the swap does not perturb the prefix the provider caches against.

## Dependencies & how to review

This PR is **stacked on top of PR 1 (#2675), PR 2 (#2677), and PR 3 (#2680)**. GitHub does not support cross-fork stacked PRs, so this branch carries four commits:

1. `d437b49e` — PR 1
2. `c88a94e6` — PR 2
3. `33778ee4` — PR 3
4. **This PR's incremental layer** — last commit on the branch.

To see just this PR's incremental diff, look at the last commit in the Commits tab, or:
```
git diff 33778ee4..HEAD
```

Once #2675, #2677, and #2680 merge to `main-v2`, this branch will be rebased so its diff shows only the final commit. No re-review of earlier PR content is needed here.

- Should be merged after #2675, #2677, and #2680.