### PR TITLE
fix(config): merge [[plugins]] across config files instead of replacing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -364,14 +364,25 @@ func Load() (*Config, error) {
 	loadDotEnv()
 	cfg := Default()
 
+	var tomlSources []string
 	if uc := userConfigPath(); uc != "" {
-		if err := mergeFile(cfg, uc); err != nil {
+		tomlSources = append(tomlSources, uc)
+	}
+	tomlSources = append(tomlSources, "reasonix.toml")
+	for _, path := range tomlSources {
+		if err := mergeFile(cfg, path); err != nil {
 			return nil, err
 		}
 	}
-	if err := mergeFile(cfg, "reasonix.toml"); err != nil {
+	// toml.DecodeFile replaces [[plugins]] wholesale, so cfg.Plugins now holds
+	// only the last file's. Re-merge by name across all sources (later wins) so a
+	// project reasonix.toml doesn't drop the global config's MCP servers.
+	plugins, err := mergeTOMLPlugins(tomlSources)
+	if err != nil {
 		return nil, err
 	}
+	cfg.Plugins = plugins
+
 	// Claude Code's .mcp.json (project root) is read last and merged into
 	// [[plugins]], so a server configured for Claude works here unchanged.
 	// reasonix.toml wins on a name collision (see mergeMCPJSON).
@@ -381,6 +392,30 @@ func Load() (*Config, error) {
 	}
 	cfg.mergeMCPJSON(entries)
 	return cfg, nil
+}
+
+// mergeTOMLPlugins merges [[plugins]] across TOML sources by name (later source wins).
+func mergeTOMLPlugins(paths []string) ([]PluginEntry, error) {
+	var merged []PluginEntry
+	index := map[string]int{}
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		var f Config
+		if _, err := toml.DecodeFile(path, &f); err != nil {
+			return nil, fmt.Errorf("config %s: %w", path, err)
+		}
+		for _, p := range f.Plugins {
+			if i, ok := index[p.Name]; ok {
+				merged[i] = p
+				continue
+			}
+			index[p.Name] = len(merged)
+			merged = append(merged, p)
+		}
+	}
+	return merged, nil
 }
 
 // LoadForEdit returns a config to seed the `reasonix setup` wizard when reconfiguring:

--- a/internal/config/mcpjson_test.go
+++ b/internal/config/mcpjson_test.go
@@ -110,6 +110,40 @@ command = "local-bin"
 	}
 }
 
+func TestLoadMergesPluginsAcrossTOMLSources(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "xdg"))
+	t.Setenv("AppData", filepath.Join(root, "AppData")) // os.UserConfigDir reads AppData on Windows
+	t.Chdir(t.TempDir())
+
+	gpath := UserConfigPath()
+	if gpath == "" {
+		t.Fatal("UserConfigPath empty under isolated env")
+	}
+	if err := os.MkdirAll(filepath.Dir(gpath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gpath, []byte("[[plugins]]\nname = \"globalmcp\"\ncommand = \"global-bin\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("reasonix.toml", []byte("[[plugins]]\nname = \"projectmcp\"\ncommand = \"project-bin\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names := map[string]bool{}
+	for _, p := range cfg.Plugins {
+		names[p.Name] = true
+	}
+	if !names["globalmcp"] || !names["projectmcp"] {
+		t.Fatalf("a project reasonix.toml [[plugins]] dropped the global config's server; got %+v", cfg.Plugins)
+	}
+}
+
 func TestMergeMCPJSONPrecedence(t *testing.T) {
 	// reasonix.toml already declares "shared" (stdio); .mcp.json offers a colliding
 	// "shared" (http) plus a fresh "extra". reasonix.toml must win on the collision;


### PR DESCRIPTION
## What

Fix MCP servers configured in the global config silently disappearing when the project's `reasonix.toml` also declares any `[[plugins]]`.

## Why

`config.Load()` decodes the global `config.toml` and then the project `reasonix.toml` onto the **same** struct. `toml.DecodeFile` *replaces* array fields rather than appending, so the project file's `[[plugins]]` overwrote the whole slice — every MCP server from the global config was dropped. The server then never started, so the model had no tools from it and never called it. This reads to users as both "the config file isn't being read" and "it won't call MCP."

`.mcp.json` was already merged additively (`mergeMCPJSON`), so the intent was always for plugins to accumulate — only the TOML-to-TOML path missed it.

## How

Re-merge `[[plugins]]` by name across all TOML sources (global, then project), later source winning on a name collision — same precedence model as `.mcp.json`. Other fields keep their existing override semantics.

## Verification

- New regression test `TestLoadMergesPluginsAcrossTOMLSources` (cross-platform isolated, so it also runs on the windows-latest leg): global + project each declare a server, both must survive `Load()`. Confirmed red without the fix, green with it.
- End-to-end with the built binary: `reasonix mcp list` with a global `config.toml` server + a project `reasonix.toml` server now lists both (previously only the project one).
