### PR TITLE
fix(bash): suppress the console window for shell commands on Windows

### DIFF
--- a/internal/tool/builtin/bash_kill_windows.go
+++ b/internal/tool/builtin/bash_kill_windows.go
@@ -3,18 +3,27 @@ package builtin
 import (
 	"os/exec"
 	"strconv"
+	"syscall"
 )
 
-// setKillTree makes a cancelled command kill its whole process tree. Windows does
-// not cascade a kill to child processes, so killing the shell leaves `go test`
-// and the test binaries it spawned running after an Esc; taskkill /T walks the
-// PID tree and /F forces it.
+// The agent host can be a GUI process with no console of its own (the Wails
+// desktop app), so a console child like cmd.exe/powershell pops its own window
+// unless we ask for none. CREATE_NO_WINDOW isn't exported by syscall.
+const createNoWindow = 0x08000000
+
+// setKillTree hides the child's console and makes a cancelled command kill its
+// whole process tree. Windows does not cascade a kill to child processes, so
+// killing the shell leaves `go test` and the binaries it spawned running after an
+// Esc; taskkill /T walks the PID tree and /F forces it.
 func setKillTree(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil
 		}
-		_ = exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(cmd.Process.Pid)).Run()
+		kill := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(cmd.Process.Pid))
+		kill.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+		_ = kill.Run()
 		return cmd.Process.Kill()
 	}
 }


### PR DESCRIPTION
## Symptom

On Windows, when the desktop app executes a plan, a small console (cmd) window pops up the moment a shell command runs — and users report the app going blank (white) right after.

## Root cause

`setKillTree` in `bash_kill_windows.go` set `cmd.Cancel` but never set `cmd.SysProcAttr` (the non-Windows build sets `Setpgid`). The Wails desktop host is a GUI process with no console of its own, so every `cmd.exe`/`powershell` child the bash tool spawns gets a fresh console window. Both the foreground path (`bash.go:118`) and the background-job path (`bash.go:104`) go through `setKillTree`, so one fix covers both.

## Fix

Set `CREATE_NO_WINDOW + HideWindow` on the spawned child, and `CREATE_NO_WINDOW` on the `taskkill` used to tear down the tree on cancel. No more window flashing mid-turn.

## On the white screen

The blank-app report is very likely a side effect of the same popup: the new console steals the foreground, and WebView2 is prone to pausing compositing when its window is occluded and not repainting when it returns. Removing the popup should remove that trigger. If a blank screen still reproduces after this, it's a separate crash-isolation gap (the desktop backend has no `recover()` around the agent goroutine and the frontend has no error boundary) — tracked separately.

## Why e2e didn't catch it

The `benchmarks/e2e` suite runs the agent core on Linux CI with `bash` = `/bin/sh`; it never spawns a Windows console child and never starts the Wails webview, so this path is structurally outside its coverage.

## Validation

- `gofmt` / `go vet` / `go build` on Windows
- `go test ./internal/tool/builtin/` (incl. cancel + powershell regressions) — pass