### PR TITLE
feat(desktop): surface crashes instead of blanking to a white screen

### DIFF
--- a/desktop/frontend/src/components/ErrorBoundary.tsx
+++ b/desktop/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,18 @@
+import { Component, type ReactNode } from "react";
+import { reportCrash } from "../lib/crash";
+
+export class ErrorBoundary extends Component<{ children: ReactNode }, { crashed: boolean }> {
+  state = { crashed: false };
+
+  static getDerivedStateFromError() {
+    return { crashed: true };
+  }
+
+  componentDidCatch(error: unknown, info: { componentStack?: string | null }) {
+    reportCrash("react", error, info.componentStack ?? undefined);
+  }
+
+  render() {
+    return this.state.crashed ? null : this.props.children;
+  }
+}

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -1,0 +1,37 @@
+// Last-resort crash surface: a React render error with no boundary unmounts the
+// whole tree (blank window), and global errors/rejections leave no trace either.
+
+function paint(text: string) {
+  let host = document.getElementById("crash-overlay");
+  if (!host) {
+    host = document.createElement("div");
+    host.id = "crash-overlay";
+    document.body.appendChild(host);
+  }
+  const title = document.createElement("div");
+  title.className = "crash-overlay__title";
+  title.textContent = "Reasonix hit an error — screenshot this and send it over";
+  const body = document.createElement("pre");
+  body.className = "crash-overlay__body";
+  body.textContent = text;
+  const copy = document.createElement("button");
+  copy.className = "crash-overlay__copy";
+  copy.textContent = "Copy";
+  copy.onclick = () => void navigator.clipboard?.writeText(text);
+  host.replaceChildren(title, body, copy);
+}
+
+function format(label: string, err: unknown, extra?: string): string {
+  const e = err as { message?: string; stack?: string } | null;
+  const detail = e?.stack || e?.message || String(err);
+  return [`[${label}]`, detail, extra?.trim()].filter(Boolean).join("\n\n");
+}
+
+export function reportCrash(label: string, err: unknown, extra?: string) {
+  paint(format(label, err, extra));
+}
+
+export function installGlobalCrashHandlers() {
+  window.addEventListener("error", (e) => reportCrash("window.error", e.error ?? e.message));
+  window.addEventListener("unhandledrejection", (e) => reportCrash("unhandledrejection", e.reason));
+}

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -1,12 +1,15 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import { installGlobalCrashHandlers } from "./lib/crash";
 import { LocaleProvider } from "./lib/i18n";
 import { initTheme } from "./lib/theme";
 import "./styles.css";
 
 // Apply the saved appearance (auto/light/dark) before the first paint.
 initTheme();
+installGlobalCrashHandlers();
 
 // Inside the Wails shell, suppress the webview's default right-click menu — its
 // Reload / Back / Inspect entries are easy to hit by accident and can reset or
@@ -24,8 +27,10 @@ if (!root) throw new Error("missing #root");
 
 createRoot(root).render(
   <StrictMode>
-    <LocaleProvider>
-      <App />
-    </LocaleProvider>
+    <ErrorBoundary>
+      <LocaleProvider>
+        <App />
+      </LocaleProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4424,3 +4424,38 @@ body {
     justify-content: center;
   }
 }
+
+#crash-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99999;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  background: #1a1a2e;
+  color: #e6e6f0;
+  overflow: auto;
+}
+.crash-overlay__title {
+  color: #ff6b6b;
+  font-size: 15px;
+  font-weight: 700;
+}
+.crash-overlay__body {
+  margin: 0;
+  font-family: var(--mono, monospace);
+  font-size: 12.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.crash-overlay__copy {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border: 1px solid #444;
+  border-radius: 6px;
+  background: #2a2a40;
+  color: inherit;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Why

The desktop frontend had no error boundary. A render error therefore unmounted the entire React tree — the window just went white — and global `error` / `unhandledrejection` events left nothing behind either. That's exactly the "app goes blank after running a plan" report, with no way to see what actually threw.

## What

- `ErrorBoundary` around the app: a render error now paints the message + component stack instead of a blank tree.
- Global `window.error` / `unhandledrejection` handlers for failures outside React's render path (async work, event handlers).
- Both route through a tiny DOM overlay (`crash.ts`) that does not depend on React still being mounted, so it shows even when the tree is gone. It has a Copy button and is screenshot-friendly.

## How to read a crash now

Instead of a white window you get a dark error page with the stack. Screenshot it (or hit Copy) and the failing site is right there — no DevTools needed.

## DevTools / F12

Separately: the WebView2 DevTools (F12, right-click → Inspect) are only compiled in for debug builds. To get F12 in a build, run `wails build -devtools` (or `wails dev`). A plain `wails build` ships with them disabled, which is why F12 did nothing.

## Scope

This catches frontend (JS) crashes — the common "window still there but white" case. If a blank screen still reproduces with no overlay, the failure is below the JS layer (WebView2 render process or a Go-side panic with no `recover()` around the agent goroutine); that's a separate follow-up.

## Validation

- `npm run typecheck` + `npm run build` in `desktop/frontend`