### PR TITLE
fix(desktop): wire up tool_progress so live bash output doesn't blank the app

### DIFF
--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -8,6 +8,7 @@ export type EventKind =
   | "message"
   | "tool_dispatch"
   | "tool_result"
+  | "tool_progress"
   | "usage"
   | "notice"
   | "phase"

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -242,6 +242,17 @@ function applyEvent(s: State, e: WireEvent): State {
       return { ...s, items: next };
     }
 
+    case "tool_progress": {
+      const t = e.tool;
+      if (!t?.id) return s;
+      const idx = s.items.findIndex((it) => it.kind === "tool" && it.id === t.id);
+      if (idx < 0) return s;
+      const next = [...s.items];
+      const it = next[idx];
+      if (it.kind === "tool") next[idx] = { ...it, output: (it.output ?? "") + (t.output ?? "") };
+      return { ...s, items: next };
+    }
+
     case "usage": {
       const used = e.usage && s.context.window ? e.usage.promptTokens : s.context.used;
       // Usage arrives once per model step; sum the output across steps for the
@@ -335,6 +346,10 @@ function applyEvent(s: State, e: WireEvent): State {
         : finalized;
       return { ...s, items, running: false, turnActive: false, currentAssistant: undefined, approval: undefined, ask: undefined, seq: s.seq + 1 };
     }
+    // An unrecognized event kind (e.g. one the kernel added but this build's wire
+    // map doesn't name yet) must not collapse state to undefined — ignore it.
+    default:
+      return s;
   }
 }
 
@@ -387,6 +402,8 @@ function reducer(s: State, a: Action): State {
       return { ...initialState, meta: s.meta, context: { ...s.context, used: 0 }, balance: s.balance, jobs: s.jobs };
     case "event":
       return applyEvent(s, a.e);
+    default:
+      return s;
   }
 }
 

--- a/desktop/wire.go
+++ b/desktop/wire.go
@@ -100,6 +100,7 @@ var kindNames = map[event.Kind]string{
 	event.TurnDone:          "turn_done",
 	event.CompactionStarted: "compaction_started",
 	event.CompactionDone:    "compaction_done",
+	event.ToolProgress:      "tool_progress",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.
@@ -125,7 +126,7 @@ func toWire(e event.Event) wireEvent {
 		} else {
 			w.Level = "info"
 		}
-	case event.ToolDispatch, event.ToolResult:
+	case event.ToolDispatch, event.ToolResult, event.ToolProgress:
 		w.Tool = &wireTool{
 			ID: e.Tool.ID, Name: e.Tool.Name, Args: e.Tool.Args,
 			Output: e.Tool.Output, Err: e.Tool.Err,

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -59,6 +59,14 @@ func TestToWireToolResult(t *testing.T) {
 	}
 }
 
+func TestToWireToolProgress(t *testing.T) {
+	e := event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: "1", Output: "chunk"}}
+	w := toWire(e)
+	if w.Kind != "tool_progress" || w.Tool == nil || w.Tool.Output != "chunk" {
+		t.Errorf("tool progress = kind:%q tool:%+v", w.Kind, w.Tool)
+	}
+}
+
 func TestToWireUsage(t *testing.T) {
 	e := event.Event{
 		Kind:        event.Usage,
@@ -128,14 +136,11 @@ func TestToWireTurnDoneNoError(t *testing.T) {
 // --- kindNames completeness ---
 
 func TestKindNamesComplete(t *testing.T) {
-	allKinds := []event.Kind{
-		event.TurnStarted, event.Reasoning, event.Text, event.Message,
-		event.ToolDispatch, event.ToolResult, event.Usage, event.Notice,
-		event.Phase, event.ApprovalRequest, event.AskRequest, event.TurnDone,
-	}
-	for _, k := range allKinds {
-		if _, ok := kindNames[k]; !ok {
-			t.Errorf("kind %d not in kindNames", k)
+	// ToolProgress is the last Kind; every value through it must have a wire name,
+	// or toWire emits kind:"" and the frontend reducer falls through to undefined.
+	for k := event.Kind(0); k <= event.ToolProgress; k++ {
+		if kindNames[k] == "" {
+			t.Errorf("kind %d has no wire name — toWire would emit kind:\"\"", k)
 		}
 	}
 }


### PR DESCRIPTION
## Root cause of the white screen

`ToolProgress` was appended to the `event.Kind` enum (to keep earlier Kind values wire-stable) but never added to the desktop wire map or the frontend. So when bash streams live output mid-turn:

1. `kindNames[event.ToolProgress]` misses → Go returns the zero value `""`.
2. `toWire` emits `kind: ""`.
3. The frontend `applyEvent` has no `case` for it **and no `default`** → returns `undefined`.
4. `reducer` returns `undefined` → the whole `useReducer` state becomes `undefined`.
5. Next render: `todoItem` reads `state.items` off `undefined` → `TypeError: Cannot read properties of undefined (reading 'items')` → tree unmounts → **white screen**.

Caught via the new crash overlay (#2691); the `[react]` stack pointed straight at the `todoItem` memo. This is **independent of the cmd-window popup (#2686)** — both just happen while bash runs, which is why hiding the popup didn't stop the blanking.

## Fix

- Map `ToolProgress → "tool_progress"` in `kindNames` + `toWire`, add it to `EventKind`, and handle it in `applyEvent` (append the chunk to the tool's output, so live progress now actually renders).
- Add `default: return s` to **both** `applyEvent` and the reducer — an event kind a newer kernel emits but this build doesn't name yet is now ignored, never fatal.
- Tighten `TestKindNamesComplete` to walk every Kind through `ToolProgress` (the old hand-listed set had missed `ToolProgress` too, so it stayed green), plus a `toWire(ToolProgress)` test.

## Validation

- `gofmt` / `go vet` / `go build` / `go test ./...` in `desktop/` — pass (the tightened completeness test now fails if any Kind is unmapped)
- `npm run typecheck` + `npm run build` in `desktop/frontend`