### PR TITLE
style(memory): drop redundant docSeen.add comment

### DIFF
--- a/internal/memory/doc.go
+++ b/internal/memory/doc.go
@@ -142,7 +142,6 @@ type docSeen struct {
 	infos []os.FileInfo
 }
 
-// add records info and reports whether it was new.
 func (s *docSeen) add(info os.FileInfo) bool {
 	for _, prev := range s.infos {
 		if os.SameFile(prev, info) {


### PR DESCRIPTION
Follow-up to #2688. The `docSeen.add` doc comment only restated the method name + signature, which the repo comment policy bans ("restating code"). Drop it; the readDoc/docSeen comments that explain the symlink-identity *why* stay.

No behavior change.