### PR TITLE
fix(io): copy-fallback for atomic writes on cross-device (EXDEV) rename

### DIFF
--- a/desktop/dotenv.go
+++ b/desktop/dotenv.go
@@ -3,6 +3,8 @@ package main
 import (
 	"os"
 	"strings"
+
+	"reasonix/internal/fileutil"
 )
 
 // dotEnvPath is the project-root .env the kernel reads keys from (config.loadDotEnv
@@ -52,7 +54,7 @@ func upsertDotEnv(key, value string) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	if err := os.Rename(tmpPath, dotEnvPath); err != nil {
+	if err := fileutil.ReplaceFile(tmpPath, dotEnvPath); err != nil {
 		os.Remove(tmpPath)
 		return err
 	}

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"reasonix/internal/fileutil"
 )
 
 // errActiveSession is returned when a delete targets the session in use.
@@ -60,7 +62,7 @@ func saveSessionTitles(dir string, m map[string]string) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, sessionTitlesPath(dir))
+	return fileutil.ReplaceFile(tmpPath, sessionTitlesPath(dir))
 }
 
 // setSessionTitle sets (or, with an empty title, clears) a session's custom name.
@@ -135,7 +137,7 @@ func saveSessionDisplays(dir string, m sessionDisplayMap) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, sessionDisplayPath(dir))
+	return fileutil.ReplaceFile(tmpPath, sessionDisplayPath(dir))
 }
 
 func recordSessionDisplay(dir, sessionPath, content, display string) error {

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -8,6 +8,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"reasonix/internal/fileutil"
 )
 
 // BranchMeta is the small sidecar record that turns flat session files into a
@@ -108,7 +110,7 @@ func SaveBranchMeta(sessionPath string, m BranchMeta) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, metaPath)
+	return fileutil.ReplaceFile(tmpPath, metaPath)
 }
 
 func EnsureBranchMeta(sessionPath string) (BranchMeta, error) {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/fileutil"
 	"reasonix/internal/provider"
 )
 
@@ -45,7 +46,7 @@ func (s *Session) Save(path string) error {
 		os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, path)
+	return fileutil.ReplaceFile(tmpPath, path)
 }
 
 // LoadSession reads a JSONL file written by Save into a fresh Session value.

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"reasonix/internal/fileutil"
 	"reasonix/internal/permission"
 )
 
@@ -259,7 +260,7 @@ func (c *Config) SaveTo(path string) error {
 		os.Remove(tmpPath)
 		return fmt.Errorf("save: close temp: %w", err)
 	}
-	return os.Rename(tmpPath, path)
+	return fileutil.ReplaceFile(tmpPath, path)
 }
 
 // Save writes the configuration back to the file it was loaded from

--- a/internal/fileutil/atomicwrite.go
+++ b/internal/fileutil/atomicwrite.go
@@ -1,0 +1,34 @@
+package fileutil
+
+import "os"
+
+// ReplaceFile renames tmp onto dest, falling back to a copy when the rename
+// fails — Windows encryption-software filter drivers report a cross-device link
+// (EXDEV) for a same-dir rename. The rename error surfaces only if the copy also fails.
+func ReplaceFile(tmp, dest string) error {
+	if err := os.Rename(tmp, dest); err != nil {
+		if copyErr := copyOnto(tmp, dest); copyErr != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func copyOnto(tmp, dest string) error {
+	info, err := os.Stat(tmp)
+	if err != nil {
+		return err
+	}
+	data, err := os.ReadFile(tmp)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(dest, data, info.Mode().Perm()); err != nil {
+		return err
+	}
+	// WriteFile keeps an existing dest's mode, so re-apply tmp's mode to match
+	// what the rename would have done (a 0600 config tmp must not widen to 0644).
+	_ = os.Chmod(dest, info.Mode().Perm())
+	_ = os.Remove(tmp)
+	return nil
+}

--- a/internal/fileutil/atomicwrite_test.go
+++ b/internal/fileutil/atomicwrite_test.go
@@ -1,0 +1,50 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplaceFileRenamesInPlace(t *testing.T) {
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "x.tmp")
+	dest := filepath.Join(dir, "x.txt")
+	if err := os.WriteFile(tmp, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReplaceFile(tmp, dest); err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := os.ReadFile(dest); string(b) != "hello" {
+		t.Errorf("dest = %q, want hello", b)
+	}
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Error("tmp should be gone after ReplaceFile")
+	}
+}
+
+func TestCopyOntoOverwritesAndPreservesMode(t *testing.T) {
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "x.tmp")
+	dest := filepath.Join(dir, "x.txt")
+	if err := os.WriteFile(tmp, []byte("new"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("old-and-longer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyOnto(tmp, dest); err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := os.ReadFile(dest); string(b) != "new" {
+		t.Errorf("dest = %q, want new (fully overwritten)", b)
+	}
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Error("tmp should be removed after copyOnto")
+	}
+	// Mode preservation is meaningful on Unix; Windows only tracks the read-only bit.
+	if info, err := os.Stat(dest); err == nil && info.Mode().Perm() != 0o600 {
+		t.Logf("dest mode = %o (want 0600 on Unix)", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
Closes #2694

## What

Make atomic file writes survive Windows encryption-software filter drivers (亿赛通/Esafenet and similar), which reject the temp-file → target `rename` with a cross-device link error (`EXDEV`) even when both paths are in the same directory.

## Why

The session save, conversation-branch metadata, config save (`reasonix setup` / `/mcp add` / `/thinking`), and the desktop `.env` / session-title / display saves all write to a sibling temp file and then `os.Rename` it onto the destination. On machines with these drivers that rename fails, so the save fails.

Note on #2694: the report's `/apply` "edit blocks" trace is from the v1 (Node) line — its `EXDEV: ... rename` string and `write-file-atomic` temp names are libuv's. In v2 the `write_file` / `edit_file` / `multi_edit` tools already write **in place** (`os.WriteFile`), so the edit path was never affected. The same failure mode does exist in v2's rename-based atomic *saves*, which this fixes.

## How

New `fileutil.ReplaceFile(tmp, dest)`: renames as before, and only if the rename fails, copies the temp file's bytes onto the destination (re-applying the temp's mode so a `0600` config temp doesn't widen) and removes the temp — the copy path the drivers permit. The original rename error is surfaced only if the copy fallback also fails, so genuine failures aren't masked. Routed the five rename sites (`agent/save.go`, `agent/branch.go`, `config/edit.go`, `desktop/dotenv.go`, `desktop/sessions.go`) through it.

`codegraph/install.go` also renames, but that's a *directory* move during install (a different, recursive case) and out of scope here.

## Tests

`internal/fileutil` unit tests cover the rename happy path and the copy fallback (full overwrite of a longer destination + temp removal + mode). Runs on all three OS legs including windows-latest. Desktop module builds and its session tests pass.
