### PR TITLE
Fix session list jumping on resume

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -337,12 +337,14 @@ func (a *App) SummarizeUpTo(turn int) error {
 
 // SessionMeta summarises one saved session for the history panel.
 type SessionMeta struct {
-	Path    string `json:"path"`
-	Preview string `json:"preview"`         // first user message
-	Title   string `json:"title,omitempty"` // user-chosen name, when set (overrides preview)
-	Turns   int    `json:"turns"`
-	ModTime int64  `json:"modTime"` // unix milliseconds, for the frontend to group/format
-	Current bool   `json:"current"`
+	Path           string `json:"path"`
+	Preview        string `json:"preview"`         // first user message
+	Title          string `json:"title,omitempty"` // user-chosen name, when set (overrides preview)
+	Turns          int    `json:"turns"`
+	CreatedAt      int64  `json:"createdAt"`      // unix milliseconds
+	LastActivityAt int64  `json:"lastActivityAt"` // unix milliseconds
+	ModTime        int64  `json:"modTime"`        // compatibility alias for lastActivityAt
+	Current        bool   `json:"current"`
 }
 
 type WorkspaceMeta struct {
@@ -371,12 +373,14 @@ func (a *App) ListSessions() []SessionMeta {
 	out := make([]SessionMeta, 0, len(infos))
 	for _, s := range infos {
 		out = append(out, SessionMeta{
-			Path:    s.Path,
-			Preview: s.Preview,
-			Title:   titles[filepath.Base(s.Path)],
-			Turns:   s.Turns,
-			ModTime: s.ModTime.UnixMilli(),
-			Current: s.Path == cur,
+			Path:           s.Path,
+			Preview:        s.Preview,
+			Title:          titles[filepath.Base(s.Path)],
+			Turns:          s.Turns,
+			CreatedAt:      s.CreatedAt.UnixMilli(),
+			LastActivityAt: s.LastActivityAt.UnixMilli(),
+			ModTime:        s.LastActivityAt.UnixMilli(),
+			Current:        s.Path == cur,
 		})
 	}
 	return out

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -121,6 +121,10 @@ function sessionTime(ms: number): string {
   return new Date(ms).toLocaleDateString([], { month: "short", day: "numeric" });
 }
 
+function sessionActivityTime(session: SessionMeta): number {
+  return session.lastActivityAt ?? session.modTime;
+}
+
 export default function App() {
   const {
     state,
@@ -605,7 +609,7 @@ export default function App() {
                     <span className="sidebar-session__body">
                       <span className="sidebar-session__title">{sessionTitle(session, t("history.emptySession"))}</span>
                       <span className="sidebar-session__meta">
-                        {session.current ? t("history.current") : sessionTime(session.modTime)}
+                        {session.current ? t("history.current") : sessionTime(sessionActivityTime(session))}
                       </span>
                     </span>
                   </button>

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -41,7 +41,7 @@ export function HistoryPanel({
   // (Today / Yesterday / a date) while preserving that order.
   const groups: { label: string; items: SessionMeta[] }[] = [];
   for (const s of sessions) {
-    const label = dayLabel(s.modTime);
+    const label = dayLabel(sessionActivityTime(s));
     const last = groups[groups.length - 1];
     if (last && last.label === label) last.items.push(s);
     else groups.push({ label, items: [s] });
@@ -85,7 +85,7 @@ export function HistoryPanel({
                           {s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
                           <span>{tr(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns })}</span>
                           <span>·</span>
-                          <span>{timeLabel(s.modTime)}</span>
+                          <span>{timeLabel(sessionActivityTime(s))}</span>
                         </div>
                       </button>
                     )}
@@ -130,6 +130,10 @@ export function HistoryPanel({
         </div>
     </ResizableDrawer>
   );
+}
+
+function sessionActivityTime(session: SessionMeta): number {
+  return session.lastActivityAt ?? session.modTime;
 }
 
 // dayLabel buckets a timestamp into "Today", "Yesterday", or a locale date. It's

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -280,10 +280,10 @@ function makeMockApp(): AppBindings {
   };
   // Mutable so delete/rename are observable in browser dev.
   const sessions: SessionMeta[] = [
-    { path: "/mock/sessions/a.jsonl", preview: "fix the login bug in auth.go", turns: 12, modTime: t0 - 3_600_000, current: true },
-    { path: "/mock/sessions/b.jsonl", preview: "refactor the payment module", turns: 5, modTime: t0 - 6 * 3_600_000, current: false },
-    { path: "/mock/sessions/c.jsonl", preview: "write the README and badges", turns: 8, modTime: t0 - day - 3_600_000, current: false },
-    { path: "/mock/sessions/d.jsonl", preview: "explain the plugin host design", turns: 3, modTime: t0 - 4 * day, current: false },
+    { path: "/mock/sessions/a.jsonl", preview: "fix the login bug in auth.go", turns: 12, createdAt: t0 - 2 * day, lastActivityAt: t0 - 3_600_000, modTime: t0 - 3_600_000, current: true },
+    { path: "/mock/sessions/b.jsonl", preview: "refactor the payment module", turns: 5, createdAt: t0 - 3 * day, lastActivityAt: t0 - 6 * 3_600_000, modTime: t0 - 6 * 3_600_000, current: false },
+    { path: "/mock/sessions/c.jsonl", preview: "write the README and badges", turns: 8, createdAt: t0 - 4 * day, lastActivityAt: t0 - day - 3_600_000, modTime: t0 - day - 3_600_000, current: false },
+    { path: "/mock/sessions/d.jsonl", preview: "explain the plugin host design", turns: 3, createdAt: t0 - 5 * day, lastActivityAt: t0 - 4 * day, modTime: t0 - 4 * day, current: false },
   ];
   // Mutable settings so the Settings panel's edits are observable in browser dev.
   const settings: SettingsView = {
@@ -374,6 +374,9 @@ function makeMockApp(): AppBindings {
       return sessions.map((s) => ({ ...s }));
     },
     async ResumeSession(path: string) {
+      sessions.forEach((s) => {
+        s.current = s.path === path;
+      });
       return [
         { role: "user", content: `(mock) resumed ${path}` },
         { role: "assistant", content: "This is a mock resumed transcript — the real one comes from the kernel." },

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -114,7 +114,9 @@ export interface SessionMeta {
   preview: string;
   title?: string; // user-chosen name; falls back to preview when empty
   turns: number;
-  modTime: number; // unix milliseconds
+  createdAt?: number; // unix milliseconds
+  lastActivityAt?: number; // unix milliseconds
+  modTime: number; // compatibility alias for lastActivityAt
   current: boolean;
 }
 

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -76,6 +76,10 @@ func LoadBranchMeta(sessionPath string) (BranchMeta, bool, error) {
 }
 
 func SaveBranchMeta(sessionPath string, m BranchMeta) error {
+	return saveBranchMeta(sessionPath, m, true)
+}
+
+func saveBranchMeta(sessionPath string, m BranchMeta, touchUpdated bool) error {
 	metaPath := BranchMetaPath(sessionPath)
 	if metaPath == "" {
 		return fmt.Errorf("empty session path")
@@ -87,7 +91,9 @@ func SaveBranchMeta(sessionPath string, m BranchMeta) error {
 	if m.CreatedAt.IsZero() {
 		m.CreatedAt = now
 	}
-	m.UpdatedAt = now
+	if touchUpdated || m.UpdatedAt.IsZero() {
+		m.UpdatedAt = now
+	}
 	if err := os.MkdirAll(filepath.Dir(metaPath), 0o755); err != nil {
 		return err
 	}
@@ -120,13 +126,16 @@ func EnsureBranchMeta(sessionPath string) (BranchMeta, error) {
 	if m, ok, err := LoadBranchMeta(sessionPath); err != nil || ok {
 		return m, err
 	}
-	now := time.Now().UTC()
+	when := time.Now().UTC()
+	if info, err := os.Stat(sessionPath); err == nil {
+		when = info.ModTime().UTC()
+	}
 	m := BranchMeta{
 		ID:        BranchID(sessionPath),
-		CreatedAt: now,
-		UpdatedAt: now,
+		CreatedAt: when,
+		UpdatedAt: when,
 	}
-	return m, SaveBranchMeta(sessionPath, m)
+	return m, saveBranchMeta(sessionPath, m, false)
 }
 
 func TouchBranchMeta(sessionPath string) error {
@@ -134,7 +143,8 @@ func TouchBranchMeta(sessionPath string) error {
 	if err != nil {
 		return err
 	}
-	return SaveBranchMeta(sessionPath, m)
+	m.UpdatedAt = time.Now().UTC()
+	return saveBranchMeta(sessionPath, m, false)
 }
 
 func ListBranches(dir string) ([]BranchInfo, error) {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -78,20 +78,22 @@ func LoadSession(path string) (*Session, error) {
 	return s, nil
 }
 
-// SessionInfo summarises a saved session for the --resume picker: where it
-// is on disk, when it was last touched, the first user message as a preview,
-// and a rough turn count.
+// SessionInfo summarises a saved session for the --resume picker: where it is on
+// disk, when it was created/last active, the first user message as a preview, and
+// a rough turn count.
 type SessionInfo struct {
-	Path    string
-	ModTime time.Time
-	Preview string
-	Turns   int
+	Path           string
+	CreatedAt      time.Time
+	LastActivityAt time.Time
+	ModTime        time.Time // compatibility alias for LastActivityAt
+	Preview        string
+	Turns          int
 }
 
-// ListSessions returns every *.jsonl session under dir, newest first, each
-// with a preview line so the picker can show something the user recognises.
-// A missing directory is not an error — it just means there's nothing to
-// resume yet.
+// ListSessions returns every *.jsonl session under dir, most-recently-active
+// first, each with a preview line so the picker can show something the user
+// recognises. A missing directory is not an error — it just means there's
+// nothing to resume yet.
 func ListSessions(dir string) ([]SessionInfo, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -117,15 +119,30 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 			// or the resume picker.
 			continue
 		}
+		createdAt := info.ModTime()
+		lastActivityAt := info.ModTime()
+		if meta, ok, err := LoadBranchMeta(full); err == nil && ok {
+			if !meta.CreatedAt.IsZero() {
+				createdAt = meta.CreatedAt
+			}
+			if !meta.UpdatedAt.IsZero() {
+				lastActivityAt = meta.UpdatedAt
+			}
+		}
 		out = append(out, SessionInfo{
-			Path:    full,
-			ModTime: info.ModTime(),
-			Preview: preview,
-			Turns:   turns,
+			Path:           full,
+			CreatedAt:      createdAt,
+			LastActivityAt: lastActivityAt,
+			ModTime:        lastActivityAt,
+			Preview:        preview,
+			Turns:          turns,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return out[i].ModTime.After(out[j].ModTime)
+		if out[i].LastActivityAt.Equal(out[j].LastActivityAt) {
+			return out[i].Path < out[j].Path
+		}
+		return out[i].LastActivityAt.After(out[j].LastActivityAt)
 	})
 	return out, nil
 }

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,6 +122,61 @@ func TestListSessionsOrdersByMTime(t *testing.T) {
 	}
 	if got[0].Turns != 1 || got[0].Preview != "preview for b.jsonl" {
 		t.Errorf("preview/turns wrong on newest: turns=%d preview=%q", got[0].Turns, got[0].Preview)
+	}
+}
+
+func TestListSessionsOrdersByLastActivityMeta(t *testing.T) {
+	dir := t.TempDir()
+	aPath := filepath.Join(dir, "a.jsonl")
+	bPath := filepath.Join(dir, "b.jsonl")
+	for _, path := range []string{aPath, bPath} {
+		s := NewSession("")
+		s.Add(provider.Message{Role: provider.RoleUser, Content: "preview for " + filepath.Base(path)})
+		if err := s.Save(path); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Now().UTC()
+	olderActivity := now.Add(-2 * time.Hour)
+	newerActivity := now.Add(-1 * time.Hour)
+	writeBranchMeta(t, aPath, now.Add(-24*time.Hour), newerActivity)
+	writeBranchMeta(t, bPath, now.Add(-24*time.Hour), olderActivity)
+	if err := touch(aPath, now.Add(-3*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := touch(bPath, now); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ListSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
+	}
+	if got[0].Path != aPath {
+		t.Fatalf("first entry = %s, want activity-newer a.jsonl despite older file mtime", got[0].Path)
+	}
+	if !got[0].LastActivityAt.Equal(newerActivity) || !got[0].ModTime.Equal(newerActivity) {
+		t.Fatalf("activity fields = %s / %s, want %s", got[0].LastActivityAt, got[0].ModTime, newerActivity)
+	}
+}
+
+func writeBranchMeta(t *testing.T, path string, createdAt, updatedAt time.Time) {
+	t.Helper()
+	meta := BranchMeta{
+		ID:        BranchID(path),
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(BranchMetaPath(path), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2161,8 +2161,10 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		m.chooser = newChooser(e.Ask)
 
 	case event.TurnDone:
-		// The turn settled — freeze anything still streaming, autosave, surface a
-		// real error, and gate a plan-mode proposal on the user's approval.
+		// The turn settled — freeze anything still streaming, surface a real error,
+		// and gate a plan-mode proposal on the user's approval. Autosave already
+		// happened in Controller so every frontend shares the same activity-time
+		// semantics.
 		m.commitReasoning()
 		m.commitPending()
 		// The bubble was echoed on Enter and an un-sent turn is swallowed above
@@ -2171,7 +2173,6 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		m.confirmBubbleSent()
 		m.state = tuiIdle
 		m.clearSubmittedPastes()
-		_ = m.ctrl.Snapshot() // best-effort; never the user's problem mid-chat
 		if e.Err != nil && e.Err.Error() != "" && !strings.Contains(e.Err.Error(), "context canceled") {
 			m.commitLine(wrapForViewport(i18n.M.ErrorPrefix+" "+e.Err.Error(), m.width, lipgloss.Color("3")))
 		}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -334,6 +334,8 @@ func (c *Controller) runTurnWithRaw(ctx context.Context, input, raw string) erro
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
 	input = c.Compose(input)
+	startMessages := c.messageCount()
+	defer c.snapshotActivityIfChanged(startMessages)
 	// Open a checkpoint for this turn before the user message is appended, so the
 	// recorded message boundary precedes it and pre-edit snapshots land here.
 	c.beginCheckpoint(input)
@@ -539,6 +541,8 @@ func (c *Controller) notice(text string) {
 // just needs the exit status — no TurnDone event, no cancel bookkeeping.
 func (c *Controller) Run(ctx context.Context, input string) error {
 	c.maybeSessionStart(ctx)
+	startMessages := c.messageCount()
+	defer c.snapshotActivityIfChanged(startMessages)
 	if c.hooks.Enabled() {
 		c.turn++
 		if block, _ := c.hooks.PromptSubmit(ctx, input, c.turn); block {
@@ -1033,6 +1037,18 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 // interaction). Called after every turn so a crash loses at most one in-flight
 // prompt.
 func (c *Controller) Snapshot() error {
+	return c.snapshot(false)
+}
+
+// SnapshotActivity writes the active conversation and marks the session as
+// recently active. Use it only after a real user/model turn changes the
+// transcript; switch/close snapshots should call Snapshot so they do not reorder
+// recent-session pickers.
+func (c *Controller) SnapshotActivity() error {
+	return c.snapshot(true)
+}
+
+func (c *Controller) snapshot(markActivity bool) error {
 	c.mu.Lock()
 	path := c.sessionPath
 	c.mu.Unlock()
@@ -1043,10 +1059,34 @@ func (c *Controller) Snapshot() error {
 	if !s.HasContent() {
 		return nil
 	}
+	if !markActivity {
+		if _, err := agent.EnsureBranchMeta(path); err != nil {
+			return err
+		}
+	}
 	if err := s.Save(path); err != nil {
 		return err
 	}
-	return agent.TouchBranchMeta(path)
+	if markActivity {
+		return agent.TouchBranchMeta(path)
+	}
+	return nil
+}
+
+func (c *Controller) messageCount() int {
+	if c.executor == nil {
+		return 0
+	}
+	return len(c.executor.Session().Snapshot())
+}
+
+func (c *Controller) snapshotActivityIfChanged(startMessages int) {
+	if c.messageCount() <= startMessages {
+		return
+	}
+	if err := c.SnapshotActivity(); err != nil {
+		slog.Warn("controller: activity snapshot", "err", err)
+	}
 }
 
 // SetSessionPath pins where auto-save lands (a fresh session file minted by the

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -2,20 +2,120 @@ package control
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/provider"
 )
 
 type typedNilControllerSink struct{}
 
 func (*typedNilControllerSink) Emit(event.Event) {}
 
+type appendingRunner struct {
+	session *agent.Session
+}
+
+func (r appendingRunner) Run(_ context.Context, input string) error {
+	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
+	return nil
+}
+
 func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
 	var sink *typedNilControllerSink
 	c := New(Options{Sink: sink})
 
 	c.notice("typed nil sink should not panic")
+}
+
+func TestRunTurnSnapshotsActivityWhenTranscriptChanges(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	path := filepath.Join(dir, "session.jsonl")
+	c := New(Options{Runner: appendingRunner{session: sess}, Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	if err := c.runTurn(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Messages) != 2 {
+		t.Fatalf("saved messages = %d, want system + user", len(loaded.Messages))
+	}
+	meta, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("load activity meta ok=%v err=%v", ok, err)
+	}
+	if meta.UpdatedAt.IsZero() {
+		t.Fatal("activity meta should be marked")
+	}
+}
+
+func TestSnapshotDoesNotRefreshSessionActivity(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.SetSessionPath(filepath.Join(dir, "session.jsonl"))
+
+	if err := c.SnapshotActivity(); err != nil {
+		t.Fatal(err)
+	}
+	first, ok, err := agent.LoadBranchMeta(c.SessionPath())
+	if err != nil || !ok {
+		t.Fatalf("load initial meta ok=%v err=%v", ok, err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "saved without activity"})
+	if err := c.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+	second, ok, err := agent.LoadBranchMeta(c.SessionPath())
+	if err != nil || !ok {
+		t.Fatalf("load second meta ok=%v err=%v", ok, err)
+	}
+	if !second.UpdatedAt.Equal(first.UpdatedAt) {
+		t.Fatalf("Snapshot refreshed activity: first=%s second=%s", first.UpdatedAt, second.UpdatedAt)
+	}
+}
+
+func TestSnapshotActivityRefreshesSessionActivity(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.SetSessionPath(filepath.Join(dir, "session.jsonl"))
+
+	if err := c.SnapshotActivity(); err != nil {
+		t.Fatal(err)
+	}
+	first, _, err := agent.LoadBranchMeta(c.SessionPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "activity"})
+	if err := c.SnapshotActivity(); err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := agent.LoadBranchMeta(c.SessionPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.UpdatedAt.After(first.UpdatedAt) {
+		t.Fatalf("SnapshotActivity did not refresh activity: first=%s second=%s", first.UpdatedAt, second.UpdatedAt)
+	}
 }
 
 // approvalIDs returns a Controller whose Sink forwards each ApprovalRequest's ID


### PR DESCRIPTION
## Summary

Fixes #2681 by keeping the desktop recent-session list ordered by real conversation activity instead of file rewrite time. Switching sessions now updates only the current marker unless a real turn changes the transcript.

## Root Cause

The session list used the JSONL file modification time as the recency signal. Resuming another session snapshots the session being left, which rewrites that JSONL file and refreshes its mtime. The sidebar then re-fetched sessions, sorted by that refreshed mtime, and visually shuffled rows under the cursor.

## Technical Approach

- Reuse the existing session sidecar metadata as the source for `createdAt` and `lastActivityAt`.
- Keep `Snapshot()` for persistence-only saves without refreshing activity time.
- Add `SnapshotActivity()` and call it automatically when a real controller turn grows the transcript.
- Sort `agent.ListSessions` by `lastActivityAt`, with `modTime` retained as a compatibility alias.
- Update desktop session metadata and UI displays to consume `lastActivityAt` while preserving old clients.

## Focused Optimization Points

- Keeps the fix in the shared controller/session layer so desktop, CLI, and serve paths share consistent autosave semantics.
- Avoids changing provider-visible prompts, messages, tool schemas, or cache-sensitive request bytes.
- Adds regression tests for activity-based ordering and for the difference between persistence snapshots and activity snapshots.

## Verification

- `go test ./internal/agent ./internal/control ./internal/cli`
- `npm run build` in `desktop/frontend`
- `go test ./...` in `desktop`
- `git diff --check`
- Attempted root full suite with isolated HOME: `tmp_home=$(mktemp -d) && HOME="$tmp_home" go test ./...`. `internal/boot` passed under isolated HOME; the remaining local failures were the pre-existing sandbox enforcement tests in `internal/sandbox` and `internal/tool/builtin`, where this local environment did not deny writes outside the workspace.