### PR TITLE
refactor(config): share skill-path canonicalization, fold case on Windows

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -934,17 +934,17 @@ func skillRootsView() []SkillRootView {
 	st := skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, DisableBuiltins: true, Stderr: io.Discard})
 	counts := map[string]int{}
 	for _, sk := range st.List() {
-		counts[cleanAbsPath(filepath.Dir(skillRootPath(sk.Path)))]++
+		counts[config.CanonicalSkillPath(filepath.Dir(skillRootPath(sk.Path)))]++
 	}
 	userConfigured := map[string]bool{}
 	if userCfg != nil {
 		for _, p := range userCfg.Skills.Paths {
-			userConfigured[cleanAbsPath(p)] = true
+			userConfigured[config.CanonicalSkillPath(p)] = true
 		}
 	}
 	var out []SkillRootView
 	for _, r := range st.Roots() {
-		dir := cleanAbsPath(r.Dir)
+		dir := config.CanonicalSkillPath(r.Dir)
 		view := SkillRootView{
 			Dir:        r.Dir,
 			Scope:      string(r.Scope),
@@ -973,9 +973,9 @@ func skillRootsView() []SkillRootView {
 }
 
 func rootActive(roots []SkillRootView, path string) bool {
-	want := cleanAbsPath(path)
+	want := config.CanonicalSkillPath(path)
 	for _, r := range roots {
-		if r.Scope == string(skill.ScopeCustom) && cleanAbsPath(r.Dir) == want {
+		if r.Scope == string(skill.ScopeCustom) && config.CanonicalSkillPath(r.Dir) == want {
 			return true
 		}
 	}
@@ -1063,23 +1063,6 @@ func skillRootPath(path string) string {
 		return filepath.Dir(path)
 	}
 	return path
-}
-
-func cleanAbsPath(path string) string {
-	path = config.ExpandVars(strings.TrimSpace(path))
-	if path == "~" || strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
-		if home, err := os.UserHomeDir(); err == nil {
-			if path == "~" {
-				path = home
-			} else {
-				path = filepath.Join(home, path[2:])
-			}
-		}
-	}
-	if abs, err := filepath.Abs(path); err == nil {
-		path = abs
-	}
-	return filepath.Clean(path)
 }
 
 // MCPServerInput is the drawer's "add server" form. Transport is "stdio" (Command

--- a/desktop/skills_app_test.go
+++ b/desktop/skills_app_test.go
@@ -102,5 +102,5 @@ func realTestPath(path string) string {
 	if p, err := filepath.EvalSymlinks(path); err == nil {
 		path = p
 	}
-	return cleanAbsPath(path)
+	return config.CanonicalSkillPath(path)
 }

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"reasonix/internal/fileutil"
@@ -193,9 +194,9 @@ func (c *Config) AddSkillPath(path string) error {
 	if path == "" {
 		return fmt.Errorf("skill path: empty path")
 	}
-	want := canonicalSkillPath(path)
+	want := CanonicalSkillPath(path)
 	for _, existing := range c.Skills.Paths {
-		if canonicalSkillPath(existing) == want {
+		if CanonicalSkillPath(existing) == want {
 			return nil
 		}
 	}
@@ -210,9 +211,9 @@ func (c *Config) RemoveSkillPath(path string) (bool, error) {
 	if path == "" {
 		return false, fmt.Errorf("skill path: empty path")
 	}
-	want := canonicalSkillPath(path)
+	want := CanonicalSkillPath(path)
 	for i, existing := range c.Skills.Paths {
-		if canonicalSkillPath(existing) == want {
+		if CanonicalSkillPath(existing) == want {
 			c.Skills.Paths = append(c.Skills.Paths[:i], c.Skills.Paths[i+1:]...)
 			return true, nil
 		}
@@ -220,7 +221,10 @@ func (c *Config) RemoveSkillPath(path string) (bool, error) {
 	return false, nil
 }
 
-func canonicalSkillPath(path string) string {
+// CanonicalSkillPath expands env vars, ~ and relative segments to an absolute
+// cleaned path for comparing skill roots. On Windows it folds case so paths that
+// differ only in casing dedupe. Use only for comparison, never as stored config.
+func CanonicalSkillPath(path string) string {
 	path = ExpandVars(strings.TrimSpace(path))
 	if strings.HasPrefix(path, "~/") || strings.HasPrefix(path, `~\`) {
 		if home, err := os.UserHomeDir(); err == nil {
@@ -234,7 +238,11 @@ func canonicalSkillPath(path string) string {
 	if abs, err := filepath.Abs(path); err == nil {
 		path = abs
 	}
-	return filepath.Clean(path)
+	path = filepath.Clean(path)
+	if runtime.GOOS == "windows" {
+		return strings.ToLower(path)
+	}
+	return path
 }
 
 // UpsertPlugin adds e, or replaces an MCP server with the same name (preserving


### PR DESCRIPTION
## Summary

Follow-up cleanup on the merged Agent Skill Sources work (#2692).

- **Dedupe canonicalization.** The desktop drawer (`cleanAbsPath`) and config (`canonicalSkillPath`) carried near-identical `~`/env/abs/clean path logic. Export it once as `config.CanonicalSkillPath` and reuse it from the desktop side so the skill-root dedup lives in a single place.
- **Windows case-folding.** Dedup compared paths byte-for-byte, so `C:\Foo` and `c:\foo` were stored as two distinct custom roots on Windows. The canonical form now lowercases on Windows; it is comparison-only, so the stored config spelling is untouched.

## Verification

- `go test ./internal/config ./internal/boot`
- `go test .` from `desktop` (covers `skills_app_test.go`)
- `gofmt -l` clean