### PR TITLE
refactor(desktop): share sessionActivityTime helper

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { CapabilitiesPanel } from "./components/CapabilitiesPanel";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { WorkspacePanel } from "./components/WorkspacePanel";
 import { parseTodos } from "./lib/tools";
+import { sessionActivityTime } from "./lib/session";
 import type { MemoryView, Mode, SessionMeta } from "./lib/types";
 import { loadLayoutSize, saveLayoutSize } from "./lib/layoutPreferences";
 
@@ -119,10 +120,6 @@ function sessionTitle(session: SessionMeta, fallback: string): string {
 
 function sessionTime(ms: number): string {
   return new Date(ms).toLocaleDateString([], { month: "short", day: "numeric" });
-}
-
-function sessionActivityTime(session: SessionMeta): number {
-  return session.lastActivityAt ?? session.modTime;
 }
 
 export default function App() {

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Pencil, Trash2, Check, X } from "lucide-react";
 import { t, useT } from "../lib/i18n";
+import { sessionActivityTime } from "../lib/session";
 import type { SessionMeta } from "../lib/types";
 import { ResizableDrawer } from "./ResizableDrawer";
 
@@ -130,10 +131,6 @@ export function HistoryPanel({
         </div>
     </ResizableDrawer>
   );
-}
-
-function sessionActivityTime(session: SessionMeta): number {
-  return session.lastActivityAt ?? session.modTime;
 }
 
 // dayLabel buckets a timestamp into "Today", "Yesterday", or a locale date. It's

--- a/desktop/frontend/src/lib/session.ts
+++ b/desktop/frontend/src/lib/session.ts
@@ -1,0 +1,5 @@
+import type { SessionMeta } from "./types";
+
+export function sessionActivityTime(session: SessionMeta): number {
+  return session.lastActivityAt ?? session.modTime;
+}


### PR DESCRIPTION
## Summary

Follow-up cleanup on the merged session-ordering fix (#2697).

`App.tsx` and `HistoryPanel.tsx` each carried an identical `sessionActivityTime` helper (`lastActivityAt ?? modTime`). Move it to `lib/session.ts` and import it in both so there is one source of truth.

## Verification

- `npm run typecheck` in `desktop/frontend`
- `npm run build` in `desktop/frontend`