### PR TITLE
feat(plugin): defer prompts/resources to a background phase

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -195,6 +195,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		for _, t := range ptools {
 			reg.Add(t)
 		}
+		// PhaseB (prompts + resources) runs on the boot ctx — which is the
+		// controller's session-scoped PluginCtx — so the auxiliary surfaces
+		// keep streaming in after Start returns without holding up the agent.
+		go host.StartPhaseB(ctx, sink)
 		if text, ok := MCPStartupNotice(host.Failures()); ok {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -123,6 +123,12 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		for _, t := range ptools {
 			reg.Add(t)
 		}
+		// Mirror boot.Build: phase B (prompts + resources) is deferred to a
+		// background goroutine on the session ctx so the ACP path also sees
+		// non-empty Host.Prompts()/Resources() once the auxiliary surfaces
+		// stream in. Without this, MCPPrompt and @-ref consumers would stay
+		// empty for the session.
+		go h.StartPhaseB(ctx, p.Sink)
 		if text, ok := boot.MCPStartupNotice(h.Failures()); ok {
 			p.Sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -68,6 +68,11 @@ const (
 	// ToolResult for long tools like bash so a frontend can show live progress.
 	// Appended last to keep the Kind values before it wire-stable.
 	ToolProgress
+	// MCPSurfaceReady fires once per server when its background-loaded surface
+	// (prompts or resources) finishes after startup. Lets UIs refresh /mcp
+	// status without polling. Text carries "<server>: <surface> ready (<count>
+	// items)". Appended last to keep the Kind values before it wire-stable.
+	MCPSurfaceReady
 )
 
 // Level classifies a Notice so sinks can style or filter it.

--- a/internal/plugin/example_test.go
+++ b/internal/plugin/example_test.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"reasonix/internal/event"
 	"reasonix/internal/tool"
 )
 
@@ -89,6 +91,24 @@ func TestExamplePluginEndToEnd(t *testing.T) {
 	// which the adapter surfaces as a Go error the model can read.
 	if _, err := echo.Execute(ctx, json.RawMessage(`{"text":123}`)); err == nil {
 		t.Error("echo with non-string text should return an error (isError result)")
+	}
+
+	// Prompts and resources stream in on phase B (post-startup), so the test
+	// must drive it and wait for both surfaces before asserting. A WaitGroup
+	// completes once both MCPSurfaceReady events fire.
+	var wg sync.WaitGroup
+	wg.Add(2) // prompts + resources
+	host.StartPhaseB(ctx, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.MCPSurfaceReady {
+			wg.Done()
+		}
+	}))
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("phase B did not finish in time")
 	}
 
 	// Prompts: the server advertises the capability, so the host discovers the

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -316,10 +316,21 @@ func (h *Host) StartPhaseB(ctx context.Context, sink event.Sink) {
 }
 
 func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
-	ps, err := c.listPrompts(ctx)
+	aux, auxCtx, cancel, err := c.auxiliaryClient(ctx)
+	if err != nil {
+		slog.Warn("plugin: start auxiliary prompt client failed", "server", c.name, "err", err)
+		return
+	}
+	defer cancel()
+	defer aux.close()
+
+	ps, err := aux.listPrompts(auxCtx)
 	if err != nil {
 		slog.Warn("plugin: listPrompts failed", "server", c.name, "err", err)
 		return
+	}
+	for i := range ps {
+		ps[i].client = c
 	}
 	h.mu.Lock()
 	c.prompts = ps
@@ -334,7 +345,15 @@ func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
 }
 
 func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
-	rs, err := c.listResources(ctx)
+	aux, auxCtx, cancel, err := c.auxiliaryClient(ctx)
+	if err != nil {
+		slog.Warn("plugin: start auxiliary resource client failed", "server", c.name, "err", err)
+		return
+	}
+	defer cancel()
+	defer aux.close()
+
+	rs, err := aux.listResources(auxCtx)
 	if err != nil {
 		slog.Warn("plugin: listResources failed", "server", c.name, "err", err)
 		return
@@ -357,6 +376,7 @@ func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
 type Client struct {
 	name string
 	t    transport
+	spec Spec
 
 	// Capabilities advertised by the server at initialize. prompts/list and
 	// resources/list are only called when advertised, so we never provoke a
@@ -372,6 +392,16 @@ type Client struct {
 	prompts   []Prompt
 	resources []Resource
 	tools     []ToolInfo
+}
+
+func (c *Client) auxiliaryClient(ctx context.Context) (*Client, context.Context, context.CancelFunc, error) {
+	auxCtx, cancel := context.WithTimeout(ctx, defaultStartTimeout)
+	aux, err := start(auxCtx, auxCtx, c.spec)
+	if err != nil {
+		cancel()
+		return nil, nil, nil, err
+	}
+	return aux, auxCtx, cancel, nil
 }
 
 // ToolInfo is the human-facing metadata returned by MCP tools/list for one tool.
@@ -578,7 +608,7 @@ func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	if tt == "" {
 		tt = "stdio"
 	}
-	c := &Client{name: s.Name, t: t, transport: tt}
+	c := &Client{name: s.Name, t: t, spec: s, transport: tt}
 	if err := c.initialize(callCtx); err != nil {
 		c.close()
 		return nil, err

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"reasonix/internal/event"
 	"reasonix/internal/tool"
 )
 
@@ -223,7 +224,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 
 			// Transport on the parent ctx, startup RPCs on the timed callCtx: the
 			// per-plugin timeout caps initialize+listTools, but the long-lived
-			// stdio child must outlive the startup scope.
+			// stdio child must outlive the startup scope and later phase-B calls.
 			c, err := start(ctx, callCtx, spec)
 			if err != nil {
 				cancelStartup()
@@ -240,21 +241,11 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			}
 			c.toolCount = len(ts)
 
-			// Prompts and resources are auxiliary: only fetched when the server
-			// advertised the capability, and a listing error is tolerated rather
-			// than failing the whole session over a non-essential surface.
-			if c.hasPrompts {
-				if ps, perr := c.listPrompts(callCtx); perr == nil {
-					c.prompts = ps
-				}
-			}
-			if c.hasResources {
-				if rs, rerr := c.listResources(callCtx); rerr == nil {
-					c.resources = rs
-				}
-			}
 			cancelStartup()
 
+			// Prompts and resources are deferred to StartPhaseB so the boot path
+			// can return as soon as tools are ready — the slow-to-list surfaces
+			// stream in later and fan out an MCPSurfaceReady event each.
 			ch <- result{idx: idx, spec: spec, client: c, tools: ts}
 		}(i, s)
 	}
@@ -283,8 +274,7 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 		}
 		h.clients = append(h.clients, r.client)
 		tools = append(tools, r.tools...)
-		h.prompts = append(h.prompts, r.client.prompts...)
-		h.resources = append(h.resources, r.client.resources...)
+		// prompts/resources are filled in later by StartPhaseB.
 	}
 	if firstErr != nil {
 		h.Close()
@@ -300,6 +290,64 @@ func (h *Host) Close() {
 	h.mu.RUnlock()
 	for _, c := range clients {
 		c.close()
+	}
+}
+
+// StartPhaseB asynchronously fetches the auxiliary surfaces (prompts and
+// resources) for every connected client. Boot calls it right after Start
+// returns, on a session-scoped ctx, so the agent becomes responsive as soon as
+// tools are ready and the slower list calls stream in afterwards. Each finished
+// surface fires an MCPSurfaceReady event on sink so UIs (e.g. /mcp status) can
+// refresh without polling. A nil sink is tolerated — the merge still happens.
+// Errors are logged and swallowed: prompts/resources are non-essential and must
+// not break the session over one slow server.
+func (h *Host) StartPhaseB(ctx context.Context, sink event.Sink) {
+	h.mu.RLock()
+	clients := append([]*Client(nil), h.clients...)
+	h.mu.RUnlock()
+	for _, c := range clients {
+		if c.hasPrompts {
+			go h.fetchPrompts(ctx, c, sink)
+		}
+		if c.hasResources {
+			go h.fetchResources(ctx, c, sink)
+		}
+	}
+}
+
+func (h *Host) fetchPrompts(ctx context.Context, c *Client, sink event.Sink) {
+	ps, err := c.listPrompts(ctx)
+	if err != nil {
+		slog.Warn("plugin: listPrompts failed", "server", c.name, "err", err)
+		return
+	}
+	h.mu.Lock()
+	c.prompts = ps
+	h.prompts = append(h.prompts, ps...)
+	h.mu.Unlock()
+	if sink != nil {
+		sink.Emit(event.Event{
+			Kind: event.MCPSurfaceReady,
+			Text: fmt.Sprintf("%s: prompts ready (%d items)", c.name, len(ps)),
+		})
+	}
+}
+
+func (h *Host) fetchResources(ctx context.Context, c *Client, sink event.Sink) {
+	rs, err := c.listResources(ctx)
+	if err != nil {
+		slog.Warn("plugin: listResources failed", "server", c.name, "err", err)
+		return
+	}
+	h.mu.Lock()
+	c.resources = rs
+	h.resources = append(h.resources, rs...)
+	h.mu.Unlock()
+	if sink != nil {
+		sink.Emit(event.Event{
+			Kind: event.MCPSurfaceReady,
+			Text: fmt.Sprintf("%s: resources ready (%d items)", c.name, len(rs)),
+		})
 	}
 }
 
@@ -455,30 +503,20 @@ func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
 		return nil, fmt.Errorf("list tools: %w", err)
 	}
 	c.toolCount = len(ts)
-	// Do the remaining network calls before taking the lock, so a hot-add never
-	// blocks status reads for the duration of a listPrompts/listResources round-trip.
-	var prompts []Prompt
-	if c.hasPrompts {
-		if ps, perr := c.listPrompts(ctx); perr == nil {
-			prompts = ps
-		} else {
-			slog.Warn("plugin: listPrompts failed", "server", s.Name, "err", perr)
-		}
-	}
-	var resources []Resource
-	if c.hasResources {
-		if rs, rerr := c.listResources(ctx); rerr == nil {
-			resources = rs
-		} else {
-			slog.Warn("plugin: listResources failed", "server", s.Name, "err", rerr)
-		}
-	}
 	h.mu.Lock()
 	h.clients = append(h.clients, c)
-	h.prompts = append(h.prompts, prompts...)
-	h.resources = append(h.resources, resources...)
 	h.clearFailure(s.Name)
 	h.mu.Unlock()
+	// Prompts and resources stream in on the long ctx the caller passed (Host.Add
+	// uses the session-scoped PluginCtx, not a per-turn ctx), so the slow list
+	// calls cannot starve a /mcp add of its return value. nil sink keeps hot-add
+	// quiet — the chat UI re-queries Host.Prompts()/Resources() on demand.
+	if c.hasPrompts {
+		go h.fetchPrompts(ctx, c, nil)
+	}
+	if c.hasResources {
+		go h.fetchResources(ctx, c, nil)
+	}
 	return ts, nil
 }
 
@@ -528,7 +566,9 @@ func (h *Host) Remove(name string) (toolPrefix string, found bool) {
 // subprocess) and uses callCtx for the initialize round-trip (whose cancellation
 // only bounds startup RPCs). Splitting the two lets a per-plugin timeout cap
 // handshake latency without making the timeout context own a successfully
-// registered stdio server. Callers that don't care pass the same ctx for both.
+// registered stdio server; the child also has to outlive phase A so phase B
+// (prompts + resources) can still call it later. Callers that don't care pass
+// the same ctx for both.
 func start(lifeCtx, callCtx context.Context, s Spec) (*Client, error) {
 	t, err := newTransport(lifeCtx, s)
 	if err != nil {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/tool"
 )
 
 // TestStdioEndToEnd drives a real subprocess (this test binary re-invoked in
@@ -408,6 +409,49 @@ func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
 
 	if got := host.Prompts(); len(got) != 1 || got[0].Raw != "hello" {
 		t.Fatalf("after phase B, prompts = %+v, want one named hello", got)
+	}
+}
+
+func TestStartPhaseBDoesNotBlockToolCalls(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	spec := Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":         "1",
+			"GO_WANT_HELPER_PROMPTS":         "1",
+			"GO_WANT_HELPER_PROMPT_DELAY_MS": "1000",
+		},
+	}
+
+	host, tools := StartAvailable(ctx, []Spec{spec})
+	defer host.Close()
+
+	var echo tool.Tool
+	for _, t := range tools {
+		if t.Name() == "mcp__mock__echo" {
+			echo = t
+			break
+		}
+	}
+	if echo == nil {
+		t.Fatal("missing echo tool")
+	}
+
+	host.StartPhaseB(ctx, event.Discard)
+	time.Sleep(50 * time.Millisecond)
+
+	callCtx, callCancel := context.WithTimeout(ctx, 150*time.Millisecond)
+	defer callCancel()
+	out, err := echo.Execute(callCtx, json.RawMessage(`{"msg":"hi"}`))
+	if err != nil {
+		t.Fatalf("tool call should not be blocked by background prompts/list: %v", err)
+	}
+	if out != "echo: hi" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: hi")
 	}
 }
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"reasonix/internal/event"
 )
 
 // TestStdioEndToEnd drives a real subprocess (this test binary re-invoked in
@@ -347,6 +349,68 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 	}
 }
 
+// TestStartPhaseAReturnsBeforePhaseB pins the two-phase handshake contract.
+// The helper advertises prompts and stalls prompts/list by 200ms; StartAvailable
+// must return as soon as tools are ready (well before that 200ms), and the
+// prompts must only materialise on Host after StartPhaseB has been called and
+// drained — proving prompts ride the background phase, not the boot critical path.
+func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	spec := Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS":         "1",
+			"GO_WANT_HELPER_PROMPTS":         "1",
+			"GO_WANT_HELPER_PROMPT_DELAY_MS": "200",
+		},
+	}
+
+	t0 := time.Now()
+	host, tools := StartAvailable(ctx, []Spec{spec})
+	startDur := time.Since(t0)
+	defer host.Close()
+
+	if len(tools) == 0 {
+		t.Fatalf("want tools from helper, got 0")
+	}
+	if startDur >= 150*time.Millisecond {
+		t.Fatalf("StartAvailable took %v — phase B (200ms prompts) leaked onto the critical path", startDur)
+	}
+	if got := host.Prompts(); len(got) != 0 {
+		t.Fatalf("phase A must not surface prompts yet, got %d", len(got))
+	}
+
+	// Drive phase B and wait for the surface-ready event. Use a buffered channel
+	// sink so the test never blocks the emitter — the event payload itself is
+	// our completion signal.
+	ready := make(chan event.Event, 4)
+	host.StartPhaseB(ctx, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.MCPSurfaceReady {
+			select {
+			case ready <- e:
+			default:
+			}
+		}
+	}))
+
+	select {
+	case e := <-ready:
+		if !strings.Contains(e.Text, "prompts ready") {
+			t.Fatalf("phase B event text = %q, want it to mention prompts", e.Text)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("phase B never fired MCPSurfaceReady for prompts")
+	}
+
+	if got := host.Prompts(); len(got) != 1 || got[0].Raw != "hello" {
+		t.Fatalf("after phase B, prompts = %+v, want one named hello", got)
+	}
+}
+
 // TestHelperProcess is not a real test; it acts as a minimal MCP stdio server
 // when invoked by TestStdioEndToEnd. It exits before the test framework can
 // print to stdout, keeping the JSON-RPC channel clean.
@@ -354,6 +418,9 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 // GO_WANT_HELPER_INIT_MS optionally injects a sleep before responding to the
 // initialize call, used by the timeout / concurrency tests to simulate slow
 // handshakes without depending on external processes.
+// GO_WANT_HELPER_PROMPTS advertises the prompts capability and registers a
+// "hello" prompt; GO_WANT_HELPER_PROMPT_DELAY_MS stalls prompts/list so the
+// phase-A vs phase-B split can be exercised.
 func TestHelperProcess(t *testing.T) {
 	if os.Getenv("GO_WANT_HELPER_STDERR_EXIT") == "1" {
 		os.Stderr.WriteString("helper stderr boom\n")
@@ -400,10 +467,26 @@ func TestHelperProcess(t *testing.T) {
 			if initDelay > 0 {
 				time.Sleep(initDelay)
 			}
+			caps := map[string]any{}
+			if os.Getenv("GO_WANT_HELPER_PROMPTS") == "1" {
+				caps["prompts"] = map[string]any{}
+			}
 			result = map[string]any{
 				"protocolVersion": protocolVersion,
 				"serverInfo":      map[string]any{"name": "mock", "version": "0"},
+				"capabilities":    caps,
 			}
+		case "prompts/list":
+			if ms := os.Getenv("GO_WANT_HELPER_PROMPT_DELAY_MS"); ms != "" {
+				if v, err := time.ParseDuration(ms + "ms"); err == nil && v > 0 {
+					time.Sleep(v)
+				}
+			}
+			result = map[string]any{"prompts": []map[string]any{{
+				"name":        "hello",
+				"description": "say hi",
+				"arguments":   []map[string]any{},
+			}}}
 		case "tools/list":
 			result = map[string]any{"tools": []map[string]any{{
 				"name":        "zed",


### PR DESCRIPTION
PR 2/4 of the MCP-startup overhaul, rebased onto `main-v2` now that PR 1 (#2675) has landed. Carries only the phase-A/B increment — the PR1 commits drop out as already-upstream.

Splits the MCP handshake into phase A (initialize + listTools, blocking) and phase B (listPrompts + listResources, deferred to a background goroutine on the session ctx). Boot becomes responsive as soon as tools are ready; the slower auxiliary surfaces stream in afterward and fan out an `MCPSurfaceReady` event per server so /mcp status refreshes without polling. ACP sessions get the same phase-B wiring.

Authored by @SivanCola — this is the rebased continuation of #2677 (which carried the pre-squash PR1 commits and would have conflicted on merge). Closes #2677.

Verified end-to-end against a real stdio MCP server: phase A returns with tools while a deliberately-slow listing is still pending (prompts/resources empty), phase B then populates both and emits the two MCPSurfaceReady events, and a deferred prompt is invocable through the surviving primary connection. go vet + plugin/boot/event tests green.