### PR TITLE
feat(proxy): auto-detect the Windows system proxy (PAC/WPAD/IE)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/yuin/goldmark v1.8.2
 	golang.org/x/net v0.35.0
+	golang.org/x/sys v0.44.0
 	golang.org/x/term v0.43.0
 	golang.org/x/text v0.24.0
 )
@@ -32,5 +33,4 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 )

--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/net/http/httpproxy"
+
+	"reasonix/internal/sysproxy"
 )
 
 const (
@@ -140,8 +142,10 @@ func proxyFunc(spec ProxySpec) (func(*http.Request) (*url.URL, error), error) {
 		}
 		pf := cfg.ProxyFunc()
 		return func(req *http.Request) (*url.URL, error) { return pf(req.URL) }, nil
-	default:
+	case ModeEnv:
 		return environmentProxyFunc(), nil
+	default:
+		return autoProxyFunc(), nil
 	}
 }
 
@@ -149,6 +153,19 @@ func environmentProxyFunc() func(*http.Request) (*url.URL, error) {
 	cfg := httpproxy.FromEnvironment()
 	pf := cfg.ProxyFunc()
 	return func(req *http.Request) (*url.URL, error) { return pf(req.URL) }
+}
+
+// autoProxyFunc honors environment proxy vars first, then falls back to the OS
+// system proxy (Windows IE/PAC/WPAD) so corporate Windows machines work without
+// any manual HTTP_PROXY setup. Non-Windows resolves to env-only.
+func autoProxyFunc() func(*http.Request) (*url.URL, error) {
+	pf := httpproxy.FromEnvironment().ProxyFunc()
+	return func(req *http.Request) (*url.URL, error) {
+		if u, err := pf(req.URL); err != nil || u != nil {
+			return u, err
+		}
+		return sysproxy.ForURL(req.URL)
+	}
 }
 
 func customProxyURL(spec ProxySpec) (*url.URL, error) {

--- a/internal/sysproxy/sysproxy.go
+++ b/internal/sysproxy/sysproxy.go
@@ -1,0 +1,72 @@
+// Package sysproxy resolves the OS-level proxy (Windows system/PAC settings)
+// for a target URL. ForURL returns nil on platforms without system-proxy
+// support or when no proxy applies, so callers fall back to direct/env.
+package sysproxy
+
+import (
+	"net/url"
+	"strings"
+)
+
+func splitList(s string) []string {
+	return strings.FieldsFunc(s, func(r rune) bool {
+		return r == ';' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+}
+
+// parseProxyList picks a proxy from a WinHTTP/IE proxy string for scheme. The
+// string is either "host:port" (all protocols) or "http=h:p;https=h:p" form.
+func parseProxyList(list, scheme string) *url.URL {
+	var fallback string
+	for _, f := range splitList(list) {
+		if i := strings.IndexByte(f, '='); i >= 0 {
+			if strings.EqualFold(f[:i], scheme) {
+				return hostProxyURL(f[i+1:])
+			}
+			continue
+		}
+		if fallback == "" {
+			fallback = f
+		}
+	}
+	if fallback != "" {
+		return hostProxyURL(fallback)
+	}
+	return nil
+}
+
+func hostProxyURL(hostport string) *url.URL {
+	hostport = strings.TrimSpace(hostport)
+	if i := strings.Index(hostport, "://"); i >= 0 {
+		hostport = hostport[i+3:]
+	}
+	if hostport == "" {
+		return nil
+	}
+	return &url.URL{Scheme: "http", Host: hostport}
+}
+
+// bypassed reports whether host matches a WinINET proxy-bypass entry. "<local>"
+// matches dotless (intranet) hosts; a leading "*" is a suffix wildcard.
+func bypassed(host, bypass string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	if host == "" {
+		return false
+	}
+	for _, e := range splitList(bypass) {
+		e = strings.ToLower(e)
+		switch {
+		case e == "<local>":
+			if !strings.Contains(host, ".") {
+				return true
+			}
+		case strings.HasPrefix(e, "*"):
+			if strings.HasSuffix(host, strings.TrimPrefix(e, "*")) {
+				return true
+			}
+		case host == e:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/sysproxy/sysproxy_test.go
+++ b/internal/sysproxy/sysproxy_test.go
@@ -1,0 +1,49 @@
+package sysproxy
+
+import "testing"
+
+func TestParseProxyList(t *testing.T) {
+	for _, tc := range []struct {
+		name, list, scheme, want string
+	}{
+		{"single all-protocol", "proxy.example.com:8080", "https", "http://proxy.example.com:8080"},
+		{"per-protocol https", "http=p1:80;https=p2:443", "https", "http://p2:443"},
+		{"per-protocol http", "http=p1:80;https=p2:443", "http", "http://p1:80"},
+		{"scheme miss falls back to bare", "p0:3128;ftp=p1:21", "https", "http://p0:3128"},
+		{"strips scheme prefix", "http://p:8080", "https", "http://p:8080"},
+		{"empty", "", "https", ""},
+		{"only other protocol, no bare", "ftp=p:21", "https", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseProxyList(tc.list, tc.scheme)
+			if tc.want == "" {
+				if got != nil {
+					t.Fatalf("got %v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.String() != tc.want {
+				t.Fatalf("got %v, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBypassed(t *testing.T) {
+	for _, tc := range []struct {
+		host, bypass string
+		want         bool
+	}{
+		{"api.deepseek.com", "<local>", false},
+		{"intranet", "<local>", true},
+		{"host.corp.local", "*.corp.local", true},
+		{"api.deepseek.com", "*.corp.local;<local>", false},
+		{"api.deepseek.com", "api.deepseek.com", true},
+		{"API.DeepSeek.com", "api.deepseek.com", true},
+		{"api.deepseek.com", "", false},
+	} {
+		if got := bypassed(tc.host, tc.bypass); got != tc.want {
+			t.Errorf("bypassed(%q, %q) = %v, want %v", tc.host, tc.bypass, got, tc.want)
+		}
+	}
+}

--- a/internal/sysproxy/system_other.go
+++ b/internal/sysproxy/system_other.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package sysproxy
+
+import "net/url"
+
+// ForURL has no OS proxy source outside Windows; env/direct handling stays with
+// the caller. The unused list/bypass helpers keep one cross-platform file.
+func ForURL(*url.URL) (*url.URL, error) {
+	_ = parseProxyList
+	_ = bypassed
+	return nil, nil
+}

--- a/internal/sysproxy/system_windows.go
+++ b/internal/sysproxy/system_windows.go
@@ -1,0 +1,134 @@
+//go:build windows
+
+package sysproxy
+
+import (
+	"net/url"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	winhttp              = windows.NewLazySystemDLL("winhttp.dll")
+	procGetIEProxyConfig = winhttp.NewProc("WinHttpGetIEProxyConfigForCurrentUser")
+	procOpen             = winhttp.NewProc("WinHttpOpen")
+	procGetProxyForURL   = winhttp.NewProc("WinHttpGetProxyForUrl")
+	procCloseHandle      = winhttp.NewProc("WinHttpCloseHandle")
+
+	kernel32       = windows.NewLazySystemDLL("kernel32.dll")
+	procGlobalFree = kernel32.NewProc("GlobalFree")
+)
+
+type ieProxyConfig struct {
+	fAutoDetect       int32
+	lpszAutoConfigURL *uint16
+	lpszProxy         *uint16
+	lpszProxyBypass   *uint16
+}
+
+type autoproxyOptions struct {
+	dwFlags                uint32
+	dwAutoDetectFlags      uint32
+	lpszAutoConfigURL      *uint16
+	lpvReserved            uintptr
+	dwReserved             uint32
+	fAutoLogonIfChallenged int32
+}
+
+type proxyInfo struct {
+	dwAccessType    uint32
+	lpszProxy       *uint16
+	lpszProxyBypass *uint16
+}
+
+const (
+	fAutoDetect       = 0x00000001
+	fConfigURL        = 0x00000002
+	detectTypeDHCP    = 0x00000001
+	detectTypeDNSA    = 0x00000002
+	accessTypeNoProxy = 1
+)
+
+// ForURL resolves the Windows system proxy (static IE proxy, PAC autoconfig URL,
+// or WPAD auto-detect) for target. Returns nil when the system is set to direct
+// or no proxy applies; callers then fall back to env/direct.
+func ForURL(target *url.URL) (*url.URL, error) {
+	if target == nil {
+		return nil, nil
+	}
+	var ie ieProxyConfig
+	if r, _, _ := procGetIEProxyConfig.Call(uintptr(unsafe.Pointer(&ie))); r == 0 {
+		return nil, nil
+	}
+	defer globalFree(ie.lpszProxy)
+	defer globalFree(ie.lpszProxyBypass)
+	defer globalFree(ie.lpszAutoConfigURL)
+
+	scheme := strings.ToLower(target.Scheme)
+	if scheme == "" {
+		scheme = "http"
+	}
+
+	if ie.lpszProxy != nil {
+		bypass := ptrToString(ie.lpszProxyBypass)
+		if !bypassed(target.Hostname(), bypass) {
+			if u := parseProxyList(ptrToString(ie.lpszProxy), scheme); u != nil {
+				return u, nil
+			}
+		}
+	}
+	if ie.fAutoDetect != 0 || ie.lpszAutoConfigURL != nil {
+		if u := pacProxy(target, ie.lpszAutoConfigURL, scheme); u != nil {
+			return u, nil
+		}
+	}
+	return nil, nil
+}
+
+func pacProxy(target *url.URL, autoConfigURL *uint16, scheme string) *url.URL {
+	session, _, _ := procOpen.Call(0, accessTypeNoProxy, 0, 0, 0)
+	if session == 0 {
+		return nil
+	}
+	defer procCloseHandle.Call(session)
+
+	opts := autoproxyOptions{fAutoLogonIfChallenged: 1}
+	if autoConfigURL != nil {
+		opts.dwFlags = fConfigURL
+		opts.lpszAutoConfigURL = autoConfigURL
+	} else {
+		opts.dwFlags = fAutoDetect
+		opts.dwAutoDetectFlags = detectTypeDHCP | detectTypeDNSA
+	}
+
+	urlPtr, err := windows.UTF16PtrFromString(target.String())
+	if err != nil {
+		return nil
+	}
+	var info proxyInfo
+	r, _, _ := procGetProxyForURL.Call(session, uintptr(unsafe.Pointer(urlPtr)), uintptr(unsafe.Pointer(&opts)), uintptr(unsafe.Pointer(&info)))
+	if r == 0 {
+		return nil
+	}
+	defer globalFree(info.lpszProxy)
+	defer globalFree(info.lpszProxyBypass)
+	if info.lpszProxy == nil {
+		return nil
+	}
+	return parseProxyList(ptrToString(info.lpszProxy), scheme)
+}
+
+func ptrToString(p *uint16) string {
+	if p == nil {
+		return ""
+	}
+	return windows.UTF16PtrToString(p)
+}
+
+func globalFree(p *uint16) {
+	if p != nil {
+		_, _, _ = procGlobalFree.Call(uintptr(unsafe.Pointer(p)))
+	}
+}


### PR DESCRIPTION
Closes #2672

## What

`auto` proxy mode now auto-detects the **Windows system proxy** — static IE/WinINET proxy, PAC autoconfig URL, and WPAD auto-detect — so corporate Windows machines work out of the box without anyone setting `HTTP_PROXY` by hand. This is the core ask of #2672 (#2690 only added a manual config path).

## Why

`auto` previously resolved through `httpproxy.FromEnvironment()` only — env vars. Go's `net/http` has no notion of the Windows system proxy, so on machines where the proxy is delivered via a system PAC file or IE setting (typical enterprise setup), the first request just fails with `failed to fetch`. Every other major runtime (browsers, Node, .NET) reads the system proxy automatically.

## How

- New `internal/sysproxy`:
  - `system_windows.go` calls `WinHttpGetIEProxyConfigForCurrentUser`; for a static proxy it parses/bypasses directly, and for a PAC URL or WPAD it calls `WinHttpGetProxyForUrl` to resolve the proxy **per target URL**. Pure-Go via `golang.org/x/sys/windows` lazy DLL — no cgo.
  - `system_other.go` is a no-op on non-Windows.
- `netclient` `auto` mode: environment proxy first, then the system proxy fallback. `env` / `custom` / `off` are unchanged.
- CLI and desktop both build their outbound clients through `netclient.NewHTTPClient(cfg.NetworkProxySpec())`, so both pick this up with no per-surface change.

## Testing

- Unit tests for the proxy-string parser and bypass matching (cross-platform, run on the windows-latest leg too).
- **End-to-end on real Windows** with the built binary in `auto` mode and no `HTTP_PROXY`:
  - Static system proxy (`ProxyEnable=1`, `ProxyServer=127.0.0.1:P`) → `reasonix run` routes the provider request through `127.0.0.1:P` (verified at a logging proxy).
  - PAC (`AutoConfigURL` → a PAC returning `PROXY 127.0.0.1:P`) → WinHTTP fetches and executes the PAC, and the request routes through the resolved proxy.

## Note / limitation

Resolution is per-request via WinHTTP, which maintains its own PAC cache. No change to how proxies are configured in `reasonix.toml` / desktop settings — `auto` just got smarter on Windows.
