### PR TITLE
feat(plugin): persist handshake schema & startup latency to user cache

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -526,6 +526,19 @@ func SessionDir() string {
 	return filepath.Join(dir, "reasonix", "sessions")
 }
 
+// CacheDir is the per-user cache root for derived/regenerable artefacts: MCP
+// handshake snapshots, plugin startup-latency telemetry. Lives beside the
+// existing dirs (UserConfigDir/reasonix/...) so the whole reasonix state tree
+// shares one root the user can wipe in a single rm. Empty when the OS dir is
+// unavailable — callers must tolerate that (caching is best-effort).
+func CacheDir() string {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, "reasonix", "cache")
+}
+
 // MemoryUserDir returns the reasonix user config root (…/reasonix), under which
 // the user-global REASONIX.md and the per-project auto-memory store live. Empty
 // when the user config dir can't be resolved, which disables user-scoped memory.

--- a/internal/plugin/cache.go
+++ b/internal/plugin/cache.go
@@ -1,0 +1,221 @@
+// Package-internal cache for MCP handshake results. The handshake (initialize +
+// listTools, plus optional listPrompts/listResources) costs hundreds of ms to a
+// few seconds per server on cold start. We persist the tool schema +
+// capabilities under the user cache dir keyed by a fingerprint of the load-
+// bearing Spec fields, so the next launch can register tools optimistically
+// without waiting for the network/subprocess. Caching is purely an
+// optimisation: any failure (missing dir, bad JSON, hash mismatch) silently
+// degrades to a fresh handshake.
+package plugin
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/tool"
+)
+
+// cacheableToolsOf extracts the persistable subset of remote tools so Start()
+// can hand them to SaveCachedSchema. Non-remote tools are skipped — Start
+// only feeds remote ones at the call site, but the type-assert is defensive.
+func cacheableToolsOf(tools []tool.Tool) []CachedTool {
+	out := make([]CachedTool, 0, len(tools))
+	for _, t := range tools {
+		rt, ok := t.(*remoteTool)
+		if !ok {
+			continue
+		}
+		out = append(out, CachedTool{
+			Name:        rt.rawName,
+			Description: rt.desc,
+			Schema:      rt.schema,
+			ReadOnly:    rt.readOnly,
+		})
+	}
+	return out
+}
+
+// cacheVersion bumps whenever CachedSchema shape changes incompatibly. Old
+// files with a smaller version are treated as a miss so a stale layout never
+// crashes a reader.
+const cacheVersion = 1
+
+// CachedSchema is the persisted snapshot of one server's handshake result.
+// SpecHash gates reuse — Capabilities/Tools are only trusted when the
+// caller's expectedHash (from SpecFingerprint of the current Spec) matches,
+// so renaming env vars or swapping a command never serves stale tools.
+type CachedSchema struct {
+	Version       int             `json:"version"`
+	SpecHash      string          `json:"spec_hash"`
+	Capabilities  map[string]bool `json:"capabilities"`
+	Tools         []CachedTool    `json:"tools"`
+	LastValidated time.Time       `json:"last_validated"`
+}
+
+// CachedTool mirrors the subset of an MCP tool definition we need to register
+// a placeholder before the real handshake completes: Name (raw, server-local),
+// Description (model-visible), Schema (raw JSON for input validation),
+// ReadOnly (drives confirmation prompts).
+type CachedTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Schema      json.RawMessage `json:"schema"`
+	ReadOnly    bool            `json:"read_only"`
+}
+
+// SpecFingerprint hashes the load-bearing parts of a Spec so changing the
+// command/url/args/env (not just renaming) invalidates the cache. Env map
+// keys are sorted so ordering doesn't perturb the hash — Go map iteration
+// order is randomised, so we'd otherwise get fingerprint churn on every
+// launch.
+func SpecFingerprint(s Spec) string {
+	h := sha256.New()
+	writeField(h, "type", s.Type)
+	writeField(h, "command", s.Command)
+	writeField(h, "url", s.URL)
+	writeField(h, "dir", s.Dir)
+	for _, a := range s.Args {
+		writeField(h, "arg", a)
+	}
+	writeKV(h, "env", s.Env)
+	writeKV(h, "headers", s.Headers)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// LoadCachedSchema returns the cached schema for name iff it exists, parses,
+// and matches expectedHash. Any error → (nil, false): cache is best-effort,
+// a corrupt file just means we re-handshake. Returning an error here would
+// only invite callers to log it on every launch — silence is intentional.
+func LoadCachedSchema(name, expectedHash string) (*CachedSchema, bool) {
+	p := cachePath(name)
+	if p == "" {
+		return nil, false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil, false
+	}
+	var cs CachedSchema
+	if err := json.Unmarshal(b, &cs); err != nil {
+		return nil, false
+	}
+	if cs.Version != cacheVersion {
+		return nil, false
+	}
+	if cs.SpecHash != expectedHash {
+		return nil, false
+	}
+	return &cs, true
+}
+
+// SaveCachedSchema atomically writes cs under name. Best-effort: an error
+// is logged at debug level and dropped. Uses tmpfile + os.Rename in the
+// parent dir so a crash mid-write can't leave a half-written JSON behind
+// that the next Load would mis-parse.
+func SaveCachedSchema(name string, cs CachedSchema) error {
+	p := cachePath(name)
+	if p == "" {
+		return nil
+	}
+	dir := filepath.Dir(p)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Debug("plugin cache: mkdir", "name", name, "err", err)
+		return err
+	}
+	cs.Version = cacheVersion
+	if cs.LastValidated.IsZero() {
+		cs.LastValidated = time.Now().UTC()
+	}
+	b, err := json.MarshalIndent(cs, "", "  ")
+	if err != nil {
+		slog.Debug("plugin cache: marshal", "name", name, "err", err)
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".mcp-*.tmp")
+	if err != nil {
+		slog.Debug("plugin cache: tempfile", "name", name, "err", err)
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: write", "name", name, "err", err)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: close", "name", name, "err", err)
+		return err
+	}
+	if err := os.Rename(tmpPath, p); err != nil {
+		os.Remove(tmpPath)
+		slog.Debug("plugin cache: rename", "name", name, "err", err)
+		return err
+	}
+	return nil
+}
+
+// cachePath returns "<config.CacheDir()>/mcp/<slug(name)>.json". Returns ""
+// when CacheDir is unavailable (no-op caching).
+func cachePath(name string) string {
+	base := config.CacheDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "mcp", slug(name)+".json")
+}
+
+// slugReplace strips characters that aren't safe in a filename across the
+// OSes we target. We lowercase first so the slug is stable regardless of
+// the user's display capitalisation.
+var slugReplace = regexp.MustCompile(`[^a-z0-9_-]+`)
+
+// slug sanitises name for use as a filename: lowercase, only [a-z0-9_-]. An
+// empty result (all chars stripped) falls back to "_" so cachePath stays
+// valid for any input.
+func slug(name string) string {
+	s := slugReplace.ReplaceAllString(strings.ToLower(name), "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "_"
+	}
+	return s
+}
+
+// writeField feeds a single tagged field into h with explicit separators so
+// the boundary between (key, value) and the next field can't collide via
+// concatenation (e.g. "command" + "foo" vs "comm" + "andfoo").
+func writeField(h io.Writer, key, val string) {
+	h.Write([]byte(key))
+	h.Write([]byte{0})
+	h.Write([]byte(val))
+	h.Write([]byte{1})
+}
+
+// writeKV hashes a map deterministically by sorting keys, so Go's randomised
+// map iteration doesn't churn the fingerprint between launches.
+func writeKV(h io.Writer, key string, m map[string]string) {
+	if len(m) == 0 {
+		writeField(h, key, "")
+		return
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeField(h, key+"."+k, m[k])
+	}
+}

--- a/internal/plugin/cache_test.go
+++ b/internal/plugin/cache_test.go
@@ -1,0 +1,200 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// redirectCache points config.CacheDir() at a fresh temp dir for the duration
+// of the test by overriding HOME and XDG_CONFIG_HOME — the same knobs the
+// sibling mcpjson_test uses to sandbox UserConfigDir lookups. Returns the
+// temp dir so a test can also poke into it (e.g. write a corrupted file).
+func redirectCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+func sampleSpec() Spec {
+	return Spec{
+		Name:    "my-server",
+		Type:    "stdio",
+		Command: "/usr/bin/example",
+		Args:    []string{"--flag", "x"},
+		Env:     map[string]string{"FOO": "1", "BAR": "2"},
+		Headers: map[string]string{"X-Custom": "ok"},
+		Dir:     "/work",
+	}
+}
+
+func sampleCachedSchema(hash string) CachedSchema {
+	return CachedSchema{
+		SpecHash:     hash,
+		Capabilities: map[string]bool{"prompts": true, "resources": false},
+		Tools: []CachedTool{{
+			Name:        "do_thing",
+			Description: "does a thing",
+			Schema:      json.RawMessage(`{"type":"object"}`),
+			ReadOnly:    true,
+		}},
+	}
+}
+
+func TestCacheRoundTrip(t *testing.T) {
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	cs := sampleCachedSchema(hash)
+
+	if err := SaveCachedSchema(spec.Name, cs); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+	got, ok := LoadCachedSchema(spec.Name, hash)
+	if !ok {
+		t.Fatal("LoadCachedSchema: miss after save")
+	}
+	if got.SpecHash != hash {
+		t.Errorf("SpecHash: got %q want %q", got.SpecHash, hash)
+	}
+	if len(got.Tools) != 1 || got.Tools[0].Name != "do_thing" {
+		t.Errorf("Tools: %+v", got.Tools)
+	}
+	if !got.Tools[0].ReadOnly {
+		t.Error("ReadOnly: lost across save/load")
+	}
+	if !got.Capabilities["prompts"] || got.Capabilities["resources"] {
+		t.Errorf("Capabilities: %+v", got.Capabilities)
+	}
+	if got.Version != cacheVersion {
+		t.Errorf("Version: got %d want %d", got.Version, cacheVersion)
+	}
+	if got.LastValidated.IsZero() {
+		t.Error("LastValidated: expected non-zero after save")
+	}
+}
+
+func TestCacheInvalidatesOnSpecHashMismatch(t *testing.T) {
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	if err := SaveCachedSchema(spec.Name, sampleCachedSchema(hash)); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+	if _, ok := LoadCachedSchema(spec.Name, "different-hash"); ok {
+		t.Fatal("LoadCachedSchema: hit despite mismatching expectedHash")
+	}
+}
+
+func TestCacheCorruptedFileReturnsFalse(t *testing.T) {
+	redirectCache(t)
+	p := cachePath("broken")
+	if p == "" {
+		t.Skip("cachePath unavailable in this environment")
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte("{this is not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("LoadCachedSchema panicked on corrupt file: %v", r)
+		}
+	}()
+	if _, ok := LoadCachedSchema("broken", "any"); ok {
+		t.Fatal("LoadCachedSchema: hit on corrupt file")
+	}
+}
+
+func TestCacheVersionMismatchReturnsFalse(t *testing.T) {
+	// Pin the on-disk version to one we don't recognise: a future writer must
+	// not poison an older binary's cache reads.
+	redirectCache(t)
+	spec := sampleSpec()
+	hash := SpecFingerprint(spec)
+	cs := sampleCachedSchema(hash)
+	cs.Version = cacheVersion + 99
+	p := cachePath(spec.Name)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := LoadCachedSchema(spec.Name, hash); ok {
+		t.Fatal("LoadCachedSchema: hit on future-version cache file")
+	}
+}
+
+func TestSpecFingerprintStable(t *testing.T) {
+	spec := sampleSpec()
+	h1 := SpecFingerprint(spec)
+	h2 := SpecFingerprint(spec)
+	if h1 != h2 {
+		t.Fatalf("SpecFingerprint not stable: %q vs %q", h1, h2)
+	}
+
+	// Reorder the env (build a new map; Go map iteration order is randomised
+	// but a fresh map can incidentally iterate the same way, so we run a few
+	// iterations to give the runtime a chance to shuffle).
+	reordered := spec
+	for i := 0; i < 32; i++ {
+		reordered.Env = map[string]string{"BAR": "2", "FOO": "1"}
+		if got := SpecFingerprint(reordered); got != h1 {
+			t.Fatalf("SpecFingerprint changed when env was rebuilt: %q vs %q", got, h1)
+		}
+	}
+}
+
+func TestSpecFingerprintChangesOnCommandEdit(t *testing.T) {
+	a := sampleSpec()
+	b := a
+	b.Command = "/usr/local/bin/other"
+	if SpecFingerprint(a) == SpecFingerprint(b) {
+		t.Fatal("SpecFingerprint did not change when Command changed")
+	}
+
+	c := a
+	c.Args = append([]string{}, a.Args...)
+	c.Args[0] = "--different"
+	if SpecFingerprint(a) == SpecFingerprint(c) {
+		t.Fatal("SpecFingerprint did not change when Args changed")
+	}
+
+	d := a
+	d.Env = map[string]string{"FOO": "1", "BAR": "different"}
+	if SpecFingerprint(a) == SpecFingerprint(d) {
+		t.Fatal("SpecFingerprint did not change when env value changed")
+	}
+}
+
+func TestCacheMissForUnknownName(t *testing.T) {
+	redirectCache(t)
+	if _, ok := LoadCachedSchema("never-saved", "anything"); ok {
+		t.Fatal("LoadCachedSchema: hit for a name that was never saved")
+	}
+}
+
+func TestSlugSafeForFilesystem(t *testing.T) {
+	cases := map[string]string{
+		"My Server!":           "my-server",
+		"weird/name\\with:bad": "weird-name-with-bad",
+		"":                     "_",
+		"------":               "_",
+		"a_b-c":                "a_b-c",
+	}
+	for in, want := range cases {
+		if got := slug(in); got != want {
+			t.Errorf("slug(%q) = %q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/plugin/cache_test.go
+++ b/internal/plugin/cache_test.go
@@ -8,14 +8,15 @@ import (
 )
 
 // redirectCache points config.CacheDir() at a fresh temp dir for the duration
-// of the test by overriding HOME and XDG_CONFIG_HOME — the same knobs the
-// sibling mcpjson_test uses to sandbox UserConfigDir lookups. Returns the
-// temp dir so a test can also poke into it (e.g. write a corrupted file).
+// of the test by overriding the knobs os.UserConfigDir reads: HOME/XDG_CONFIG_HOME
+// on unix, APPDATA on Windows (without it the tests write the real user cache).
+// Returns the temp dir so a test can also poke into it (e.g. write a corrupted file).
 func redirectCache(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
 	return dir
 }
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -222,6 +222,8 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 				cancelStartup = cancel
 			}
 
+			phaseAStart := time.Now()
+
 			// Transport on the parent ctx, startup RPCs on the timed callCtx: the
 			// per-plugin timeout caps initialize+listTools, but the long-lived
 			// stdio child must outlive the startup scope and later phase-B calls.
@@ -241,7 +243,22 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			}
 			c.toolCount = len(ts)
 
+			// Persist for next launch on the side: a slow stats/cache write
+			// must not delay tools coming online, and either failure is
+			// recoverable (we just re-handshake or skip auto-demote).
 			cancelStartup()
+			phaseADur := time.Since(phaseAStart)
+			go func() {
+				_ = RecordStartup(spec.Name, phaseADur)
+				_ = SaveCachedSchema(spec.Name, CachedSchema{
+					SpecHash: SpecFingerprint(spec),
+					Capabilities: map[string]bool{
+						"prompts":   c.hasPrompts,
+						"resources": c.hasResources,
+					},
+					Tools: cacheableToolsOf(ts),
+				})
+			}()
 
 			// Prompts and resources are deferred to StartPhaseB so the boot path
 			// can return as soon as tools are ready — the slow-to-list surfaces

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -229,14 +229,18 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			// stdio child must outlive the startup scope and later phase-B calls.
 			c, err := start(ctx, callCtx, spec)
 			if err != nil {
+				phaseADur := time.Since(phaseAStart)
 				cancelStartup()
+				go func() { _ = RecordStartup(spec.Name, phaseADur) }()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
 				return
 			}
 
 			ts, err := c.listTools(callCtx)
 			if err != nil {
+				phaseADur := time.Since(phaseAStart)
 				cancelStartup()
+				go func() { _ = RecordStartup(spec.Name, phaseADur) }()
 				c.close()
 				ch <- result{idx: idx, spec: spec, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
 				return
@@ -246,8 +250,8 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 			// Persist for next launch on the side: a slow stats/cache write
 			// must not delay tools coming online, and either failure is
 			// recoverable (we just re-handshake or skip auto-demote).
-			cancelStartup()
 			phaseADur := time.Since(phaseAStart)
+			cancelStartup()
 			go func() {
 				_ = RecordStartup(spec.Name, phaseADur)
 				_ = SaveCachedSchema(spec.Name, CachedSchema{

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -350,6 +350,45 @@ func TestStartPolicyPerPluginTimeout(t *testing.T) {
 	}
 }
 
+func TestStartRecordsTimeoutStats(t *testing.T) {
+	withTempCache(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	slow := Spec{
+		Name:    "slow-stats",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_HELPER_PROCESS": "1",
+			"GO_WANT_HELPER_INIT_MS": "300",
+		},
+	}
+	for i := 0; i < 3; i++ {
+		host, _, err := Start(ctx, []Spec{slow}, StartPolicy{
+			PerPluginTimeout: 50 * time.Millisecond,
+			Concurrency:      1,
+			AbortOnError:     false,
+		})
+		if err != nil {
+			t.Fatalf("Start #%d: %v", i, err)
+		}
+		host.Close()
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		rec := Recommend("slow-stats", 50*time.Millisecond, 3)
+		if rec.Demote {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout samples did not trigger demote; stats=%+v rec=%+v", readStats(t, "slow-stats"), rec)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestStartPhaseAReturnsBeforePhaseB pins the two-phase handshake contract.
 // The helper advertises prompts and stalls prompts/list by 200ms; StartAvailable
 // must return as soon as tools are ready (well before that 200ms), and the

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -102,10 +102,10 @@ func RecordStartup(name string, dur time.Duration) error {
 }
 
 // Recommend inspects the recent samples for name and decides whether the
-// plugin should be demoted to "lazy" this session. The rule is simple and
-// matches what the user asked for: demote when the last demoteAfter samples
-// are all strictly above budget*2. Missing/empty stats → no demote (a fresh
-// plugin gets the benefit of the doubt and one normal startup attempt).
+// plugin should be demoted to "lazy" this session. The rule is simple: demote
+// when the last demoteAfter samples all hit or exceed the blocking startup
+// budget. Missing/empty stats → no demote (a fresh plugin gets the benefit of
+// the doubt and one normal startup attempt).
 //
 // budget == 0 disables the check (returns no-demote). demoteAfter <= 0 falls
 // back to defaultDemoteAfter so callers can pass the config value verbatim
@@ -135,10 +135,10 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 		return rec
 	}
 
-	threshold := (budget * 2).Milliseconds()
+	threshold := budget.Milliseconds()
 	tail := stats.SamplesMs[len(stats.SamplesMs)-demoteAfter:]
 	for _, ms := range tail {
-		if ms <= threshold {
+		if ms < threshold {
 			return rec
 		}
 	}
@@ -233,4 +233,3 @@ func p99(samples []int64) time.Duration {
 	}
 	return time.Duration(sorted[idx]) * time.Millisecond
 }
-

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -1,0 +1,236 @@
+// Per-plugin startup latency tracking for MCP servers. Reasonix uses these
+// samples to decide whether a chronically slow plugin should be demoted from
+// "eager" to "lazy" loading for the rest of a session — see Recommend.
+//
+// Storage is one tiny JSON file per plugin under <cacheDir>/mcp/, written
+// atomically (tmpfile + Rename) so a crash mid-write can't corrupt history.
+// All errors are best-effort: missing/unreadable files yield "no demote",
+// write failures get logged via slog and dropped — startup must not fail
+// because telemetry can't persist.
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"reasonix/internal/config"
+)
+
+const (
+	// statsVersion is the on-disk format version. Bump when StartupStats changes
+	// shape incompatibly; older files are then ignored on load (treated as
+	// missing) so a new build doesn't crash on a stale schema.
+	statsVersion = 1
+	// maxSamples bounds the rolling window. 20 is enough to absorb a few flukes
+	// while still letting recent regressions dominate p99 / consecutive-fail
+	// checks. Older samples drop off the front.
+	maxSamples = 20
+	// defaultDemoteAfter is the consecutive-over-budget threshold used when the
+	// caller passes <= 0. Three in a row is "user has felt it three startups",
+	// which matches what the plan calls out as the demote signal.
+	defaultDemoteAfter = 3
+)
+
+// StartupStats is the on-disk record of recent startup durations for one
+// plugin. SamplesMs is oldest→newest (newest appended at the tail); LastSeen
+// is the wall-clock time the most recent sample was recorded so a future
+// "stale data" pruning step can act on it without re-parsing each sample.
+type StartupStats struct {
+	Version   int       `json:"version"`
+	SamplesMs []int64   `json:"samples_ms"`
+	LastSeen  time.Time `json:"last_seen"`
+}
+
+// Recommendation is the result of inspecting a plugin's recent startup
+// history. Demote is the actionable bit boot.go consumes (true → switch this
+// plugin's tier to "lazy" for this session). P99 and Reason are descriptive
+// only — Reason is meant to be surfaced to the user as a Notice so a sudden
+// demotion isn't silent.
+type Recommendation struct {
+	Demote bool
+	P99    time.Duration
+	Reason string
+}
+
+// RecordStartup appends one sample (the wall-clock duration of a plugin's
+// blocking handshake phase) to that plugin's stats file. The file is created
+// on first call; existing samples are kept in a rolling window of maxSamples,
+// dropping the oldest when full.
+//
+// Best-effort: any I/O or marshal failure is logged with slog.Warn and
+// returned, but callers are expected to ignore the error — telemetry must
+// never block real work. Writes go through a tmpfile + Rename so a partial
+// write can't leave the stats file truncated or unparseable.
+func RecordStartup(name string, dur time.Duration) error {
+	path := statsPath(name)
+	if path == "" {
+		// No cache dir resolvable on this host — silently skip. This is the
+		// same fallback every other persistence helper in the project takes
+		// (ArchiveDir/SessionDir return "" and writers no-op).
+		return nil
+	}
+
+	stats := loadStats(path) // missing/corrupt → fresh zero value
+	if stats.Version != statsVersion {
+		// Version mismatch: start over rather than try to migrate. The window
+		// is small enough that "lose 20 samples" is cheap, and it keeps the
+		// migration path trivial as the format evolves.
+		stats = StartupStats{Version: statsVersion}
+	}
+
+	ms := dur.Milliseconds()
+	if ms < 0 {
+		ms = 0
+	}
+	stats.SamplesMs = append(stats.SamplesMs, ms)
+	if len(stats.SamplesMs) > maxSamples {
+		// Trim from the front: oldest samples leave first.
+		stats.SamplesMs = stats.SamplesMs[len(stats.SamplesMs)-maxSamples:]
+	}
+	stats.LastSeen = time.Now()
+
+	if err := writeStatsAtomic(path, stats); err != nil {
+		slog.Warn("plugin: record startup stats failed", "server", name, "err", err)
+		return err
+	}
+	return nil
+}
+
+// Recommend inspects the recent samples for name and decides whether the
+// plugin should be demoted to "lazy" this session. The rule is simple and
+// matches what the user asked for: demote when the last demoteAfter samples
+// are all strictly above budget*2. Missing/empty stats → no demote (a fresh
+// plugin gets the benefit of the doubt and one normal startup attempt).
+//
+// budget == 0 disables the check (returns no-demote). demoteAfter <= 0 falls
+// back to defaultDemoteAfter so callers can pass the config value verbatim
+// without sanitising it.
+func Recommend(name string, budget time.Duration, demoteAfter int) Recommendation {
+	if budget <= 0 {
+		return Recommendation{}
+	}
+	if demoteAfter <= 0 {
+		demoteAfter = defaultDemoteAfter
+	}
+
+	path := statsPath(name)
+	if path == "" {
+		return Recommendation{}
+	}
+	stats := loadStats(path)
+	if stats.Version != statsVersion || len(stats.SamplesMs) == 0 {
+		// Either no history yet or a format we can't read — give the plugin a
+		// chance. The cost of one slow start is small compared to wrongly
+		// demoting a healthy plugin off stale data.
+		return Recommendation{}
+	}
+
+	rec := Recommendation{P99: p99(stats.SamplesMs)}
+	if len(stats.SamplesMs) < demoteAfter {
+		return rec
+	}
+
+	threshold := (budget * 2).Milliseconds()
+	tail := stats.SamplesMs[len(stats.SamplesMs)-demoteAfter:]
+	for _, ms := range tail {
+		if ms <= threshold {
+			return rec
+		}
+	}
+	rec.Demote = true
+	rec.Reason = fmt.Sprintf(
+		"plugin %q has been slow %d startups in a row (last %dms, budget %dms); demoting to lazy this session",
+		name, demoteAfter, tail[len(tail)-1], budget.Milliseconds(),
+	)
+	return rec
+}
+
+// statsPath returns the canonical path for one plugin's stats file:
+// <config.CacheDir()>/mcp/<slug>.stats.json. Shares the cache root and slug
+// rule with the schema cache so a `<plugin>.json` and `<plugin>.stats.json`
+// sit side by side under the same per-server folder. Returns "" when no cache
+// dir is resolvable, which all callers treat as "skip telemetry".
+func statsPath(name string) string {
+	base := config.CacheDir()
+	if base == "" {
+		return ""
+	}
+	return filepath.Join(base, "mcp", slug(name)+".stats.json")
+}
+
+// loadStats reads and decodes a stats file. Any failure (missing file,
+// permission denied, malformed JSON) returns a zero StartupStats so callers
+// can treat absence and corruption identically. The slog.Warn fires only on
+// non-NotExist read errors and on JSON errors — those are surprising enough
+// to be worth a trace, but they still must not stop the caller.
+func loadStats(path string) StartupStats {
+	var s StartupStats
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("plugin: read startup stats failed", "path", path, "err", err)
+		}
+		return s
+	}
+	if err := json.Unmarshal(b, &s); err != nil {
+		slog.Warn("plugin: parse startup stats failed", "path", path, "err", err)
+		return StartupStats{}
+	}
+	return s
+}
+
+// writeStatsAtomic serialises s and writes it via tmpfile + os.Rename so that
+// concurrent readers see either the old content or the new one, never a
+// half-written file. Mirrors desktop/sessions.go:40-64.
+func writeStatsAtomic(path string, s StartupStats) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	b, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".stats.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// p99 returns the 99th-percentile sample as a Duration. With small windows
+// (n ≤ 20) "p99" collapses to "the slowest sample we have"; the value is
+// purely informational, surfaced in Recommendation for UI/notice text.
+func p99(samples []int64) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), samples...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	// Use ceil(0.99 * n) - 1 so that for n=1..100 we always pick the last
+	// element; for larger n it's the index at the 99% boundary.
+	idx := int(float64(len(sorted))*0.99+0.9999999) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return time.Duration(sorted[idx]) * time.Millisecond
+}
+

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -137,6 +137,22 @@ func TestRecommendAboveBudgetDemotes(t *testing.T) {
 	}
 }
 
+func TestRecommendAtBudgetDemotes(t *testing.T) {
+	withTempCache(t)
+
+	budget := 5 * time.Second
+	for i := 0; i < 3; i++ {
+		if err := RecordStartup("timeout-plugin", budget); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	got := Recommend("timeout-plugin", budget, 3)
+	if !got.Demote {
+		t.Fatalf("Demote = false, want true for repeated budget hits (samples=%+v)", readStats(t, "timeout-plugin").SamplesMs)
+	}
+}
+
 func TestRecommendMissingStatsNoDemote(t *testing.T) {
 	withTempCache(t)
 

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -1,0 +1,207 @@
+package plugin
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withTempCache redirects config.CacheDir() at t.TempDir for the duration of
+// a test by overriding HOME and XDG_CONFIG_HOME — the same knobs cache_test
+// uses, since os.UserConfigDir reads them. Returns the directory that will
+// hold the cache subtree so callers can assert paths inside it.
+func withTempCache(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+// readStats reads the on-disk stats file for name directly (not through the
+// public API) so tests can assert raw file contents — what we wrote and in
+// what order.
+func readStats(t *testing.T, name string) StartupStats {
+	t.Helper()
+	path := statsPath(name)
+	if path == "" {
+		t.Fatal("statsPath returned empty")
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read stats %s: %v", path, err)
+	}
+	var s StartupStats
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("unmarshal stats: %v", err)
+	}
+	return s
+}
+
+func TestRecordStartupAppends(t *testing.T) {
+	withTempCache(t)
+
+	durs := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 300 * time.Millisecond}
+	for _, d := range durs {
+		if err := RecordStartup("foo", d); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	s := readStats(t, "foo")
+	if s.Version != statsVersion {
+		t.Fatalf("Version = %d, want %d", s.Version, statsVersion)
+	}
+	if got := len(s.SamplesMs); got != 3 {
+		t.Fatalf("samples = %d, want 3", got)
+	}
+	// File is written oldest→newest (newest at the tail).
+	want := []int64{100, 200, 300}
+	for i, w := range want {
+		if s.SamplesMs[i] != w {
+			t.Fatalf("SamplesMs[%d] = %d, want %d (full=%v)", i, s.SamplesMs[i], w, s.SamplesMs)
+		}
+	}
+	if s.LastSeen.IsZero() {
+		t.Fatal("LastSeen should be set after a record")
+	}
+}
+
+func TestRecordStartupCapsAtWindow(t *testing.T) {
+	withTempCache(t)
+
+	const total = 25
+	for i := 0; i < total; i++ {
+		// Use distinct values so we can verify the *oldest* ones were dropped.
+		if err := RecordStartup("bar", time.Duration(i+1)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	s := readStats(t, "bar")
+	if got := len(s.SamplesMs); got != maxSamples {
+		t.Fatalf("samples = %d, want %d", got, maxSamples)
+	}
+	// First retained sample should be #6 (1..5 dropped); last should be #25.
+	wantFirst := int64(total - maxSamples + 1) // 6
+	if s.SamplesMs[0] != wantFirst {
+		t.Fatalf("SamplesMs[0] = %d, want %d", s.SamplesMs[0], wantFirst)
+	}
+	if s.SamplesMs[len(s.SamplesMs)-1] != int64(total) {
+		t.Fatalf("SamplesMs[last] = %d, want %d", s.SamplesMs[len(s.SamplesMs)-1], total)
+	}
+}
+
+func TestRecommendBelowBudgetNoDemote(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// All samples comfortably under budget*2 == 2s.
+	for _, ms := range []int64{500, 800, 1200, 1500, 900} {
+		if err := RecordStartup("ok-plugin", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("ok-plugin", budget, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true, want false (reason=%q)", got.Reason)
+	}
+}
+
+func TestRecommendAboveBudgetDemotes(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// First sample is fast (would block a naive "ever-slow" check), then 3
+	// consecutive samples above budget*2 == 2s. The plan says demote on
+	// "last N consecutive over-budget", so this should trip.
+	for _, ms := range []int64{500, 2500, 3000, 4000} {
+		if err := RecordStartup("slow-plugin", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("slow-plugin", budget, 3)
+	if !got.Demote {
+		t.Fatalf("Demote = false, want true (samples=%+v)", readStats(t, "slow-plugin").SamplesMs)
+	}
+	if got.Reason == "" {
+		t.Fatal("Reason should be non-empty when demoting")
+	}
+	if got.P99 <= 0 {
+		t.Fatalf("P99 = %v, want > 0", got.P99)
+	}
+}
+
+func TestRecommendMissingStatsNoDemote(t *testing.T) {
+	withTempCache(t)
+
+	// Never recorded anything → should not demote a brand-new plugin.
+	got := Recommend("never-seen", 1*time.Second, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true on missing stats, want false (reason=%q)", got.Reason)
+	}
+	if got.P99 != 0 {
+		t.Fatalf("P99 = %v on missing stats, want 0", got.P99)
+	}
+}
+
+func TestRecommendOldFailuresFadeOut(t *testing.T) {
+	withTempCache(t)
+
+	budget := 1 * time.Second
+	// Early samples were terrible (well above budget*2 == 2s), but the most
+	// recent three are quick — rolling window must let the plugin recover.
+	for _, ms := range []int64{5000, 6000, 7000, 8000, 500, 600, 700} {
+		if err := RecordStartup("recovered", time.Duration(ms)*time.Millisecond); err != nil {
+			t.Fatalf("RecordStartup: %v", err)
+		}
+	}
+
+	got := Recommend("recovered", budget, 3)
+	if got.Demote {
+		t.Fatalf("Demote = true after recovery, want false (samples=%+v, reason=%q)",
+			readStats(t, "recovered").SamplesMs, got.Reason)
+	}
+}
+
+// TestStatsPathLayout pins the on-disk location so Phase 4's integration code
+// can rely on it. We assert the path sits under config.CacheDir()/mcp and that
+// the slug strips raw separators — exact slug rule lives in cache.go.
+func TestStatsPathLayout(t *testing.T) {
+	withTempCache(t)
+
+	p := statsPath("server/with spaces")
+	if p == "" {
+		t.Fatal("statsPath returned empty")
+	}
+	wantSuffix := filepath.Join("reasonix", "cache", "mcp")
+	if got := filepath.Dir(p); !strings.HasSuffix(got, wantSuffix) {
+		t.Fatalf("parent = %q, want suffix %q", got, wantSuffix)
+	}
+	base := filepath.Base(p)
+	if filepath.Ext(base) != ".json" {
+		t.Fatalf("ext = %q, want .json", filepath.Ext(base))
+	}
+	if !strings.HasSuffix(base, ".stats.json") {
+		t.Fatalf("base = %q, want .stats.json suffix", base)
+	}
+	if containsAny(base, "/ ") {
+		t.Fatalf("slug %q contains raw separators", base)
+	}
+}
+
+func containsAny(s, chars string) bool {
+	for _, c := range chars {
+		for _, r := range s {
+			if r == c {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/plugin/stats_test.go
+++ b/internal/plugin/stats_test.go
@@ -9,15 +9,17 @@ import (
 	"time"
 )
 
-// withTempCache redirects config.CacheDir() at t.TempDir for the duration of
-// a test by overriding HOME and XDG_CONFIG_HOME — the same knobs cache_test
-// uses, since os.UserConfigDir reads them. Returns the directory that will
-// hold the cache subtree so callers can assert paths inside it.
+// withTempCache redirects config.CacheDir() at t.TempDir for the duration of a
+// test by overriding the knobs os.UserConfigDir reads: HOME/XDG_CONFIG_HOME on
+// unix, APPDATA on Windows (without it the tests write the real user cache).
+// Returns the directory that will hold the cache subtree so callers can assert
+// paths inside it.
 func withTempCache(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
 	return dir
 }
 


### PR DESCRIPTION
PR 3/4 of the MCP-startup overhaul, rebased onto `main-v2` now that PR 1 (#2675) and PR 2 (#2701/#2677) have landed. Carries only the PR3 increment.

Adds two best-effort sidecar caches under `<UserConfigDir>/reasonix/cache/mcp/`, written from a side-goroutine after phase A so neither disk IO nor a marshal failure delays tool registration:
- `<server>.json` — handshake snapshot (capabilities + tool list with name/description/schema/readOnly), keyed by a SHA-256 `SpecFingerprint` of the load-bearing Spec fields. Stale on any spec edit (command/args/url/env/headers).
- `<server>.stats.json` — rolling window (latest 20) of phase-A durations, for the auto-demote signal.

Nothing reads these yet — they unblock PR 4. Authored by @SivanCola.

One reviewer fix on top (separate commit): `withTempCache`/`redirectCache` only overrode HOME + XDG_CONFIG_HOME, which `os.UserConfigDir` ignores on Windows (it reads %AppData%), so the cache/stats tests wrote the real user cache dir — non-hermetic on repeated local Windows runs (TestRecordStartupAppends accumulated samples) and polluting it. CI's ephemeral runners masked it. Now isolates APPDATA too.

Verified end-to-end against a real stdio MCP server: after a live handshake the side-goroutine writes both files; LoadCachedSchema hits with the live fingerprint (SpecHash + tools + readOnly + capabilities round-trip) and misses on a changed fingerprint; the startup latency sample is recorded. go vet + plugin/config tests green, and now hermetic on repeated Windows runs.

Closes #2680.