### PR TITLE
fix(skill): require relevant inline skill use, keep subagent judgment-based

### DIFF
--- a/internal/skill/index.go
+++ b/internal/skill/index.go
@@ -11,10 +11,10 @@ const IndexMaxChars = 4000
 
 const missingDescPlaceholder = `(no description — frontmatter is missing a "description:" line; tell the user to add one)`
 
-// indexHeader introduces the skills block in the system prompt: how to invoke a
-// skill, and the inline-vs-subagent distinction.
+// indexHeader introduces the skills block in the system prompt: the invocation
+// policy (mandatory for inline, judgment-based for subagent) and how to call one.
 const indexHeader = "# Skills — playbooks you can invoke\n\n" +
-	"One-liner index. Each entry is a built-in or a user-authored playbook. Call `run_skill({ name: \"<skill-name>\", arguments: \"<task>\" })` — `name` is JUST the identifier (e.g. `\"explore\"`), NOT the `[🧬 subagent]` tag that follows it. Entries tagged `[🧬 subagent]` spawn an isolated subagent — its tool calls and reasoning never enter your context, only its final answer does; use them for context-heavy work (deep exploration, multi-step research) where you only need the conclusion. Untagged skills are inlined: the body becomes a tool result you read and act on directly. The user can also invoke a skill via `/<name>`."
+	"One-liner index. Before non-trivial work, scan it: if an untagged (inline) skill is even plausibly relevant to the task, invoke it before continuing instead of pre-judging — loading one imperfect inline skill is cheap. Skills tagged `[🧬 subagent]` are the heavy path; reach for them only when the task genuinely needs context-heavy work, not on weak relevance. Each entry is a built-in or a user-authored playbook. Call `run_skill({ name: \"<skill-name>\", arguments: \"<task>\" })` — `name` is JUST the identifier (e.g. `\"explore\"`), NOT the `[🧬 subagent]` tag that follows it. Prefer the dedicated top-level tool when one exists for a built-in subagent skill. Entries tagged `[🧬 subagent]` spawn an isolated subagent — its tool calls and reasoning never enter your context, only its final answer does; use them for context-heavy work (deep exploration, multi-step research) where you only need the conclusion. Untagged skills are inlined: the body becomes a tool result you read and act on directly. The user can also invoke a skill via `/<name>`."
 
 // ApplyIndex appends the skills index to basePrompt, or returns it unchanged
 // when there are no skills. Only names + descriptions (+ a subagent tag) are

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -277,6 +277,18 @@ func TestApplyIndex(t *testing.T) {
 	}
 }
 
+func TestApplyIndexMandatesInlineButRestrainsSubagent(t *testing.T) {
+	out := ApplyIndex("BASE", []Skill{{Name: "alpha", Description: "the alpha", RunAs: RunInline}})
+
+	if !strings.Contains(out, "inline) skill is even plausibly relevant") ||
+		!strings.Contains(out, "invoke it before continuing") {
+		t.Errorf("inline skills should be mandatory on plausible relevance:\n%s", out)
+	}
+	if !strings.Contains(out, "not on weak relevance") {
+		t.Errorf("subagent skills should stay judgment-based, not mandatory:\n%s", out)
+	}
+}
+
 func TestApplyIndexTruncates(t *testing.T) {
 	var skills []Skill
 	for i := 0; i < 200; i++ {


### PR DESCRIPTION
Reworks #2666 (by @GTC2080) to address #2628 without inviting subagent spawn storms.

## What changed vs #2666

#2666 made *every* listed skill mandatory on "even plausibly relevant" — including the four `[🧬 subagent]` skills (explore/research/review/security-review), which are the context-heavy, token-expensive path. That collides with the project's cheap-first positioning and the finding that model-driven subagent spawning regresses badly.

This version scopes the mandate:
- **Inline skills**: if even plausibly relevant, invoke before continuing instead of pre-judging — loading one imperfect inline skill is cheap. (This is what #2628 actually asks for.)
- **`[🧬 subagent]` skills**: stay judgment-based — reached for only when the task genuinely needs context-heavy work, not on weak relevance.

Also restores the em-dash `# Skills —` heading (the body still uses em-dashes) and replaces the brittle full-sentence prompt assertion with one that checks the two behavioral invariants (inline mandate + subagent restraint).

## Verification

- `go test ./internal/skill ./internal/boot`
- End-to-end: ran the full `boot.Build` path (`ResolveSystemPrompt` → `skill.ApplyIndex`) in a temp project and dumped the assembled pinned prompt — inline skills carry the mandate, subagent skills are explicitly de-escalated, alongside the real built-in index.

Closes #2628
Closes #2666