### PR TITLE
fix(desktop): restore history reasoning and running previews

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -552,8 +552,9 @@ func (a *App) SwitchWorkspace(dir string) (string, error) {
 // HistoryMessage is one prior turn, for the frontend to repopulate its transcript
 // after a reload.
 type HistoryMessage struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+	Reasoning string `json:"reasoning,omitempty"`
 }
 
 // History returns the session's message log.
@@ -565,14 +566,21 @@ func (a *App) History() []HistoryMessage {
 		return nil
 	}
 	msgs := ctrl.History()
-	resolve := sessionDisplayResolver(config.SessionDir(), ctrl.SessionPath())
+	return historyMessages(msgs, sessionDisplayResolver(config.SessionDir(), ctrl.SessionPath()))
+}
+
+func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
 	out := make([]HistoryMessage, 0, len(msgs))
 	for _, m := range msgs {
 		content := m.Content
 		if m.Role == provider.RoleUser {
-			content = resolve(m.Content)
+			content = resolveUserContent(m.Content)
 		}
-		out = append(out, HistoryMessage{Role: string(m.Role), Content: content})
+		reasoning := ""
+		if m.Role == provider.RoleAssistant {
+			reasoning = m.ReasoningContent
+		}
+		out = append(out, HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning})
 	}
 	return out
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -98,6 +98,7 @@ export interface WireEvent {
 export interface HistoryMessage {
   role: string;
   content: string;
+  reasoning?: string;
 }
 
 // CheckpointMeta is one rewind point (a user turn) for the rewind UI.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -380,15 +380,17 @@ function reducer(s: State, a: Action): State {
     case "jobs":
       return { ...s, jobs: a.jobs };
     case "history": {
-      // Only user/assistant turns with visible text — never the system prompt or
-      // tool-result messages, and not the empty content of a tool-call-only turn.
+      // Only user/assistant turns with visible text or assistant reasoning — never
+      // the system prompt or tool-result messages.
       const visible = a.messages.filter(
-        (m) => (m.role === "user" || m.role === "assistant") && m.content.trim() !== "",
+        (m) =>
+          (m.role === "user" && m.content.trim() !== "") ||
+          (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
       );
       const items: Item[] = visible.map((m, i) =>
         m.role === "user"
           ? { kind: "user", id: `h${i}`, text: m.content }
-          : { kind: "assistant", id: `h${i}`, text: m.content, reasoning: "", streaming: false },
+          : { kind: "assistant", id: `h${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
       );
       return { ...s, items, seq: s.seq + visible.length };
     }

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "expanded prompt"},
+		{Role: provider.RoleAssistant, Content: "answer", ReasoningContent: "thinking trace"},
+		{Role: provider.RoleTool, Content: "tool output", ReasoningContent: "ignored by frontend filter"},
+		{Role: provider.RoleAssistant, ReasoningContent: "tool-call-only thinking"},
+	}
+
+	got := historyMessages(msgs, func(content string) string {
+		if content != "expanded prompt" {
+			t.Fatalf("unexpected user content passed to resolver: %q", content)
+		}
+		return "display prompt"
+	})
+
+	if len(got) != len(msgs) {
+		t.Fatalf("history length = %d, want %d", len(got), len(msgs))
+	}
+	if got[0].Content != "display prompt" {
+		t.Fatalf("user display content = %q, want display prompt", got[0].Content)
+	}
+	if got[1].Reasoning != "thinking trace" {
+		t.Fatalf("assistant reasoning = %q, want thinking trace", got[1].Reasoning)
+	}
+	if got[2].Reasoning != "" {
+		t.Fatalf("non-assistant reasoning should stay hidden, got %q", got[2].Reasoning)
+	}
+	if got[3].Reasoning != "tool-call-only thinking" {
+		t.Fatalf("empty-content assistant reasoning = %q, want tool-call-only thinking", got[3].Reasoning)
+	}
+}


### PR DESCRIPTION
## Summary
- include assistant reasoning in desktop history payloads so resumed history keeps the thinking block
- add a read-only `PreviewSession` path that loads saved sessions without snapshotting or resuming the active controller
- allow opening/searching the history drawer while a model turn is running, with running rows loading read-only previews and mutating actions disabled
- reuse the transcript renderer in history previews so reasoning stays available as a collapsed block

## Testing
- `go test ./...` from `desktop/`
- `npm run build` from `desktop/frontend/`
- Playwright check against `http://127.0.0.1:5174/`: while mock output was streaming, the history entry remained enabled, the drawer opened, read-only preview loaded, rename actions were disabled, and search was visible

## Notes
- Provider request construction is unchanged; these changes only affect desktop history display/preview payloads.