### PR TITLE
chore: clear staticcheck findings across internal packages

### DIFF
--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -268,7 +268,7 @@ func TestServeCancel(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("prompt never started")
 	}
-	client.notify("session/cancel", SessionCancelParams{SessionID: nr.SessionID})
+	client.notify("session/cancel", SessionCancelParams(nr))
 
 	select {
 	case resp := <-promptCh:

--- a/internal/permission/bash_readonly.go
+++ b/internal/permission/bash_readonly.go
@@ -76,10 +76,7 @@ func isReadOnlyBashSubject(subject string) bool {
 
 	// Check single-word read-only commands.
 	if readOnlyBashCommands[base] {
-		if hasUnsafeReadOnlyArgs(base, fields[1:]) {
-			return false
-		}
-		return true
+		return !hasUnsafeReadOnlyArgs(base, fields[1:])
 	}
 
 	// Check prefix commands (git log, go vet, etc.).

--- a/internal/plugin/canonicalize_test.go
+++ b/internal/plugin/canonicalize_test.go
@@ -144,16 +144,3 @@ func toolNames(ts []tool.Tool) []string {
 	}
 	return names
 }
-
-func getJSONKeys(t *testing.T, raw json.RawMessage) []string {
-	t.Helper()
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -346,7 +346,7 @@ func (s *Store) Create(name string, scope Scope) (string, error) {
 // skill of the same name. Returns the written path.
 func (s *Store) CreateWithContent(name string, scope Scope, content string) (string, error) {
 	if !IsValidName(name) {
-		return "", fmt.Errorf("invalid skill name %q — use letters, digits, _, -, .", name)
+		return "", fmt.Errorf("invalid skill name %q — use letters, digits, '_', '-', '.'", name)
 	}
 	var root string
 	switch scope {

--- a/internal/tool/builtin/gitignore.go
+++ b/internal/tool/builtin/gitignore.go
@@ -162,9 +162,7 @@ func reanchorPattern(line, relDir string) string {
 		neg = "!"
 		line = line[1:]
 	}
-	if strings.HasPrefix(line, `\`) { // escaped leading '#' or '!'
-		line = line[1:]
-	}
+	line = strings.TrimPrefix(line, `\`) // escaped leading '#' or '!'
 	if relDir == "" || relDir == "." {
 		return neg + line
 	}


### PR DESCRIPTION
Clears all five staticcheck findings in the internal tree (found during an end-to-end health sweep). No behavior change; the affected packages' tests pass and `staticcheck ./internal/...` is now clean.

| Check | File | Fix |
|---|---|---|
| S1008 | `permission/bash_readonly.go` | collapse `if x { return false }; return true` to `return !x` |
| S1017 | `tool/builtin/gitignore.go` | use `strings.TrimPrefix` for the escaped-prefix strip |
| S1016 | `acp/server_test.go` | `SessionCancelParams(nr)` conversion (identical single-field structs) |
| U1000 | `plugin/canonicalize_test.go` | drop the unused `getJSONKeys` helper |
| ST1005 | `skill/skill.go` | quote the allowed name chars so the error no longer ends with `.` |

The ST1005 one was a near-false-positive: the trailing `.` was a *literal allowed character* in the name-rules message, so rather than dropping it I quoted each special char (`'_'`, `'-'`, `'.'`) — keeps the meaning and ends the string on `'`.

## Verification

- `staticcheck ./internal/...` → clean (exit 0)
- `go test ./internal/permission ./internal/tool/builtin ./internal/skill ./internal/acp ./internal/plugin`