### PR TITLE
ci: add a -race job and run the prompt-cache prefix guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,30 @@ jobs:
         run: go build ./...
 
       - name: test
+        env:
+          # Run the prompt-cache prefix-stability guard (TestCacheHit*) in CI: a
+          # regression there silently tanks the cache hit rate the project is
+          # built around.
+          REASONIX_RELEASE_CACHE_GUARD: "1"
         run: go test ./...
+
+  race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      # The matrix never runs -race (it needs cgo); the project's concurrency
+      # (plugin fan-out, background phase B, jobs Kill/Wait) would otherwise
+      # ship without race coverage.
+      - name: test -race
+        env:
+          REASONIX_RELEASE_CACHE_GUARD: "1"
+        run: go test -race ./...
 
   desktop:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Two CI coverage gaps surfaced by an end-to-end health check of main-v2:

1. **No race coverage.** The matrix only runs `go test ./...` without `-race` (it needs cgo). The project's concurrency — plugin start fan-out, background phase B + auxiliary clients, jobs Kill/Wait, the TUI event drain — has never been exercised under the race detector. Adds a dedicated `race` job on ubuntu-latest running `go test -race ./...`.
2. **Prefix-stability guard dormant.** `TestCacheHit*` (the guard that proves the durable system-prompt prefix stays byte-stable so DeepSeek's prefix cache keeps hitting — the whole cost story) is gated behind `REASONIX_RELEASE_CACHE_GUARD` and CI never set it, so a regression that tanks the cache hit rate would go uncaught. Sets the env on the test steps.

No production code change. If the new race job flags anything, that's a real find to fix before merge.