### PR TITLE
fix(doctor): report effective sandbox availability, not just mode

### DIFF
--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/codegraph"
 	"reasonix/internal/config"
 	"reasonix/internal/netclient"
+	"reasonix/internal/sandbox"
 )
 
 type Options struct {
@@ -87,6 +88,10 @@ type SandboxReport struct {
 	Bash       string   `json:"bash"`
 	Network    bool     `json:"network"`
 	WriteRoots []string `json:"write_roots,omitempty"`
+	// Available is whether an OS sandbox actually backs an "enforce" request on
+	// this host (bwrap/seatbelt present). Without it "enforce" runs unconfined —
+	// e.g. always on Windows, where there is no OS sandbox.
+	Available bool `json:"available"`
 }
 
 type NetworkReport struct {
@@ -139,6 +144,7 @@ func Collect(opts Options) Report {
 			Bash:       cfg.BashMode(),
 			Network:    cfg.Sandbox.Network,
 			WriteRoots: redactHomeAll(cfg.WriteRoots()),
+			Available:  sandbox.Available(),
 		},
 		Network: NetworkReport{
 			ProxyMode: cfg.NetworkProxyMode(),
@@ -244,7 +250,11 @@ func RenderText(r Report) string {
 	}
 
 	fmt.Fprintf(&b, "\nsandbox\n")
-	fmt.Fprintf(&b, "  bash         %s\n", r.Sandbox.Bash)
+	bashLine := r.Sandbox.Bash
+	if r.Sandbox.Bash == "enforce" && !r.Sandbox.Available {
+		bashLine += " (inactive: no OS sandbox on this host — bash runs unconfined)"
+	}
+	fmt.Fprintf(&b, "  bash         %s\n", bashLine)
 	fmt.Fprintf(&b, "  network      %v\n", r.Sandbox.Network)
 	fmt.Fprintf(&b, "  write_roots  %s\n", strings.Join(r.Sandbox.WriteRoots, ", "))
 

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -102,3 +102,15 @@ func TestCollectReportDoesNotRequireAPIKey(t *testing.T) {
 		t.Fatalf("text report should mention missing key state:\n%s", text)
 	}
 }
+
+func TestRenderTextFlagsInactiveSandbox(t *testing.T) {
+	inactive := RenderText(Report{Sandbox: SandboxReport{Bash: "enforce", Available: false}})
+	if !strings.Contains(inactive, "inactive") {
+		t.Fatalf("enforce without an OS sandbox should be flagged inactive:\n%s", inactive)
+	}
+
+	active := RenderText(Report{Sandbox: SandboxReport{Bash: "enforce", Available: true}})
+	if strings.Contains(active, "inactive") {
+		t.Fatalf("enforce with an OS sandbox should not be flagged inactive:\n%s", active)
+	}
+}


### PR DESCRIPTION
Found during the main-v2 health check. `reasonix doctor` printed the bash sandbox section straight from the configured mode (`bash enforce`) without checking `sandbox.Available()`. On a host with no OS sandbox — always Windows, or Linux without bwrap — it claimed the sandbox was enforcing while bash actually ran unconfined (writes not confined to write_roots, network not denied).

The runtime is honest (boot/acp print a one-time stderr warning when enforce is requested but unavailable), but the diagnostics command — the thing you run to check your security posture — was not. Now the report carries `available` and the text view renders `bash enforce (inactive: no OS sandbox on this host — bash runs unconfined)` when enforce isn't backed.

Verified on Windows (shows the inactive caveat) + added a render test for both states.