### PR TITLE
fix(doctor): surface warnings at the top of the report

### DIFF
--- a/internal/doctor/report.go
+++ b/internal/doctor/report.go
@@ -205,6 +205,12 @@ func RenderText(r Report) string {
 	fmt.Fprintf(&b, "  user config  %s\n", valueOr(r.Config.UserPath, "unavailable"))
 	fmt.Fprintf(&b, "  model        %s\n", valueOr(r.Config.DefaultModel, "(none)"))
 
+	// Warnings (e.g. a config that failed to parse and fell back to defaults) go
+	// up top, not buried under the full report where they read as "all fine".
+	for _, w := range r.Warnings {
+		fmt.Fprintf(&b, "  warning: %s\n", w)
+	}
+
 	fmt.Fprintf(&b, "\nproviders\n")
 	for _, p := range r.Providers {
 		key := "missing"
@@ -266,9 +272,6 @@ func RenderText(r Report) string {
 	fmt.Fprintf(&b, "\npermissions\n")
 	fmt.Fprintf(&b, "  mode         %s\n", valueOr(r.Permission.Mode, "ask"))
 	fmt.Fprintf(&b, "  rules        allow:%d ask:%d deny:%d\n", r.Permission.AllowRules, r.Permission.AskRules, r.Permission.DenyRules)
-	for _, w := range r.Warnings {
-		fmt.Fprintf(&b, "\nwarning: %s\n", w)
-	}
 	return b.String()
 }
 

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -103,6 +103,17 @@ func TestCollectReportDoesNotRequireAPIKey(t *testing.T) {
 	}
 }
 
+func TestRenderTextSurfacesWarningsUpTop(t *testing.T) {
+	text := RenderText(Report{Warnings: []string{"config reasonix.toml: parse boom"}})
+	w := strings.Index(text, "parse boom")
+	if w < 0 {
+		t.Fatalf("warning missing from report:\n%s", text)
+	}
+	if p := strings.Index(text, "\nproviders\n"); p >= 0 && w > p {
+		t.Fatalf("warning should appear before the providers section, not buried below:\n%s", text)
+	}
+}
+
 func TestRenderTextFlagsInactiveSandbox(t *testing.T) {
 	inactive := RenderText(Report{Sandbox: SandboxReport{Bash: "enforce", Available: false}})
 	if !strings.Contains(inactive, "inactive") {


### PR DESCRIPTION
Found during the health check: a malformed `reasonix.toml` makes `doctor` fall back to defaults and record a warning, but the warning printed *last* — below the full report, whose header still reads `config reasonix.toml` / `model deepseek-flash` as if nothing's wrong. `reasonix doctor | head` or a quick glance misses it entirely.

Move warnings directly under the header. doctor still exits 0 (it's a diagnostics command meant to always run); normal commands (chat/run/mcp) already hard-fail on a malformed config. Added a render test asserting warnings appear before the providers section.