### PR TITLE
fix(desktop): allow read-only history preview while running

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -425,6 +425,12 @@ func (a *App) ResumeSession(path string) ([]HistoryMessage, error) {
 	return a.History(), nil
 }
 
+// PreviewSession reads a saved session for display only. It does not snapshot or
+// swap the active controller, so the history drawer can call it while a turn runs.
+func (a *App) PreviewSession(path string) ([]HistoryMessage, error) {
+	return previewSessionMessages(config.SessionDir(), path)
+}
+
 // PickWorkspace opens a folder chooser and, on a pick, switches the agent to that
 // project: it re-roots the process there, rebuilds the controller from that
 // folder's reasonix.toml + REASONIX.md, and starts a fresh session — the desktop
@@ -583,6 +589,14 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 		out = append(out, HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning})
 	}
 	return out
+}
+
+func previewSessionMessages(sessionDir, path string) ([]HistoryMessage, error) {
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		return nil, err
+	}
+	return historyMessages(loaded.Snapshot(), sessionDisplayResolver(sessionDir, path)), nil
 }
 
 // ContextInfo is the prompt-vs-window gauge payload. Both zero means no data yet.

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -134,6 +134,7 @@ export default function App() {
     newSession,
     listSessions,
     resumeSession,
+    previewSession,
     deleteSession,
     renameSession,
     refreshMeta,
@@ -468,34 +469,37 @@ export default function App() {
     });
   }, []);
 
-  // History drawer: opening fetches the saved-session list; picking one resumes it
-  // (the transcript swaps in; the model/folder are unchanged).
+  // History drawer: opening fetches the saved-session list. Idle row clicks resume;
+  // running row clicks only preview through PreviewSession.
   const openHistory = useCallback(async () => {
     setHistView(await refreshSessions());
   }, [refreshSessions]);
   const closeHistory = useCallback(() => setHistView(null), []);
   const onResumeSession = useCallback(
     async (path: string) => {
+      if (state.running) return;
       setHistView(null);
       await resumeSession(path);
       await refreshSessions();
     },
-    [resumeSession, refreshSessions],
+    [state.running, resumeSession, refreshSessions],
   );
   // Delete / rename act on disk, then re-fetch so the panel reflects the change.
   const onDeleteSession = useCallback(
     async (path: string) => {
+      if (state.running) return;
       await deleteSession(path);
       setHistView(await refreshSessions());
     },
-    [deleteSession, refreshSessions],
+    [state.running, deleteSession, refreshSessions],
   );
   const onRenameSession = useCallback(
     async (path: string, title: string) => {
+      if (state.running) return;
       await renameSession(path, title);
       setHistView(await refreshSessions());
     },
-    [renameSession, refreshSessions],
+    [state.running, renameSession, refreshSessions],
   );
 
   // Workspace: open the folder chooser and switch projects. The hook resets the
@@ -581,12 +585,7 @@ export default function App() {
           <section className="sidebar__section">
             <div className="sidebar__section-head">
               <div className="sidebar__section-title">{t("sidebar.conversations")}</div>
-              <button
-                className="sidebar__view-all"
-                onClick={() => void openHistory()}
-                disabled={state.running}
-                title={state.running ? t("common.busyHint") : t("topbar.history")}
-              >
+              <button className="sidebar__view-all" onClick={() => void openHistory()} title={t("topbar.history")}>
                 {t("sidebar.viewAll")}
               </button>
             </div>
@@ -619,8 +618,7 @@ export default function App() {
             <button
               className="sidebar__navitem sidebar__navitem--sessions"
               onClick={() => void openHistory()}
-              disabled={state.running}
-              title={state.running ? t("common.busyHint") : t("topbar.history")}
+              title={t("topbar.history")}
             >
               <History size={15} />
               <span>{t("topbar.history")}</span>
@@ -675,12 +673,7 @@ export default function App() {
               {workspacePanelOpen ? <PanelRightClose size={13} /> : <PanelRightOpen size={13} />}
             </button>
             <div className="topbar__actions">
-              <button
-                className="chip chip--icon"
-                onClick={() => void openHistory()}
-                disabled={state.running}
-                title={state.running ? t("common.busyHint") : t("topbar.history")}
-              >
+              <button className="chip chip--icon" onClick={() => void openHistory()} title={t("topbar.history")}>
                 <History size={13} />
               </button>
               <button className="chip chip--icon" onClick={() => void openMemory()} title={t("topbar.memory")}>
@@ -825,7 +818,9 @@ export default function App() {
       {histView !== null && (
         <HistoryPanel
           sessions={histView}
+          running={state.running}
           onResume={onResumeSession}
+          onPreview={previewSession}
           onDelete={onDeleteSession}
           onRename={onRenameSession}
           onClose={closeHistory}

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -1,24 +1,28 @@
-import { useState } from "react";
-import { Pencil, Trash2, Check, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Pencil, Search, Trash2, Check, X } from "lucide-react";
 import { t, useT } from "../lib/i18n";
 import { sessionActivityTime } from "../lib/session";
-import type { SessionMeta } from "../lib/types";
+import type { HistoryMessage, SessionMeta } from "../lib/types";
+import type { Item } from "../lib/useController";
 import { ResizableDrawer } from "./ResizableDrawer";
+import { Transcript } from "./Transcript";
 
-// HistoryPanel is the desktop session switcher: a right-side drawer listing saved
-// sessions newest-first, grouped by day. Each row resumes on click, and carries
-// rename (a custom display name) and delete actions on hover — the desktop
-// analogue of managing conversations in Claude Code. The active session can't be
-// deleted (auto-save would just recreate it).
+// HistoryPanel lists saved sessions newest-first. Idle clicks resume a session;
+// running clicks load a read-only preview so the active stream keeps writing to
+// the current controller/session.
 export function HistoryPanel({
   sessions,
+  running,
   onResume,
+  onPreview,
   onDelete,
   onRename,
   onClose,
 }: {
   sessions: SessionMeta[];
+  running: boolean;
   onResume: (path: string) => void;
+  onPreview: (path: string) => Promise<HistoryMessage[]>;
   onDelete: (path: string) => void;
   onRename: (path: string, title: string) => void;
   onClose: () => void;
@@ -27,108 +31,225 @@ export function HistoryPanel({
   const [editing, setEditing] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [confirming, setConfirming] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  const [preview, setPreview] = useState<{
+    path: string;
+    title: string;
+    meta: string;
+    messages: HistoryMessage[];
+    loading: boolean;
+  } | null>(null);
+  const previewSeq = useRef(0);
 
   const startRename = (s: SessionMeta) => {
+    if (running) return;
     setConfirming(null);
     setEditing(s.path);
     setDraft(s.title || s.preview || "");
   };
   const commitRename = (path: string) => {
+    if (running) return;
     onRename(path, draft.trim());
     setEditing(null);
   };
+  const loadPreview = useCallback(
+    async (s: SessionMeta) => {
+      const seq = ++previewSeq.current;
+      setEditing(null);
+      setConfirming(null);
+      setPreview({
+        path: s.path,
+        title: sessionDisplayTitle(s, tr("history.emptySession")),
+        meta: sessionMetaLine(s, tr),
+        messages: [],
+        loading: true,
+      });
+      const messages = await onPreview(s.path);
+      if (seq === previewSeq.current) {
+        setPreview((cur) => (cur?.path === s.path ? { ...cur, messages, loading: false } : cur));
+      }
+    },
+    [onPreview, tr],
+  );
+
+  const filteredSessions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sessions;
+    return sessions.filter((s) =>
+      [s.title, s.preview, s.path].some((part) => (part ?? "").toLowerCase().includes(q)),
+    );
+  }, [query, sessions]);
 
   // Sessions arrive newest-first; bucket consecutive ones under a day heading
   // (Today / Yesterday / a date) while preserving that order.
   const groups: { label: string; items: SessionMeta[] }[] = [];
-  for (const s of sessions) {
+  for (const s of filteredSessions) {
     const label = dayLabel(sessionActivityTime(s));
     const last = groups[groups.length - 1];
     if (last && last.label === label) last.items.push(s);
     else groups.push({ label, items: [s] });
   }
 
-  return (
-    <ResizableDrawer onClose={onClose}>
-        <header className="drawer__head">
-          <div className="drawer__title">{tr("history.title")}</div>
-          <button className="chip" onClick={onClose} title={tr("common.close")}>
-            ✕
-          </button>
-        </header>
+  useEffect(() => {
+    if (!preview) return;
+    if (!filteredSessions.some((s) => s.path === preview.path)) setPreview(null);
+  }, [filteredSessions, preview]);
 
-        <div className="drawer__body">
+  useEffect(() => {
+    if (!running) return;
+    setEditing(null);
+    setConfirming(null);
+    if (preview || filteredSessions.length === 0) return;
+    const first = filteredSessions.find((s) => !s.current) ?? filteredSessions[0];
+    void loadPreview(first);
+  }, [filteredSessions, loadPreview, preview, running]);
+
+  const previewItems = useMemo(() => previewMessagesToItems(preview?.messages ?? []), [preview?.messages]);
+  const showPreview = preview !== null;
+
+  return (
+    <ResizableDrawer onClose={onClose} wide={showPreview || running}>
+      <header className="drawer__head">
+        <div>
+          <div className="drawer__title">{tr("history.title")}</div>
+          {running && <div className="drawer__summary">{tr("history.readOnlyHint")}</div>}
+        </div>
+        <button className="chip" onClick={onClose} title={tr("common.close")}>
+          ✕
+        </button>
+      </header>
+
+      <div className={`drawer__body history-drawer${showPreview ? " history-drawer--preview" : ""}`}>
+        <div className="history-list">
+          {sessions.length > 0 && (
+            <label className="mem-search history-search">
+              <Search size={13} />
+              <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder={tr("history.searchPlaceholder")} />
+            </label>
+          )}
           {sessions.length === 0 ? (
             <div className="mem-empty">{tr("history.empty")}</div>
+          ) : filteredSessions.length === 0 ? (
+            <div className="mem-empty">{tr("history.noResults")}</div>
           ) : (
             groups.map((g) => (
               <section className="mem-section" key={g.label}>
                 <div className="mem-section__title">{g.label}</div>
-                {g.items.map((s) => (
-                  <div className={`hist-item${s.current ? " hist-item--current" : ""}`} key={s.path}>
-                    {editing === s.path ? (
-                      <input
-                        className="hist-item__rename"
-                        autoFocus
-                        value={draft}
-                        onChange={(e) => setDraft(e.target.value)}
-                        onKeyDown={(e) => {
-                          if (e.key === "Enter") commitRename(s.path);
-                          if (e.key === "Escape") setEditing(null);
-                        }}
-                        onBlur={() => commitRename(s.path)}
-                        placeholder={tr("history.namePlaceholder")}
-                      />
-                    ) : (
-                      <button className="hist-item__main" onClick={() => onResume(s.path)} title={s.path}>
-                        <div className="hist-item__preview">{s.title || s.preview || tr("history.emptySession")}</div>
-                        <div className="hist-item__meta">
-                          {s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
-                          <span>{tr(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns })}</span>
-                          <span>·</span>
-                          <span>{timeLabel(sessionActivityTime(s))}</span>
-                        </div>
-                      </button>
-                    )}
-
-                    {editing !== s.path && (
-                      <div className="hist-item__actions">
-                        {confirming === s.path ? (
-                          <>
-                            <button
-                              className="hist-act hist-act--danger"
-                              title={tr("history.confirmDelete")}
-                              onClick={() => {
-                                onDelete(s.path);
-                                setConfirming(null);
-                              }}
-                            >
-                              <Check size={14} />
-                            </button>
-                            <button className="hist-act" title={tr("common.cancel")} onClick={() => setConfirming(null)}>
-                              <X size={14} />
-                            </button>
-                          </>
-                        ) : (
-                          <>
-                            <button className="hist-act" title={tr("history.rename")} onClick={() => startRename(s)}>
-                              <Pencil size={13} />
-                            </button>
-                            {!s.current && (
-                              <button className="hist-act" title={tr("common.delete")} onClick={() => setConfirming(s.path)}>
-                                <Trash2 size={13} />
-                              </button>
+                {g.items.map((s) => {
+                  const selected = preview?.path === s.path;
+                  return (
+                    <div
+                      className={`hist-item${s.current ? " hist-item--current" : ""}${selected ? " hist-item--selected" : ""}`}
+                      key={s.path}
+                    >
+                      {editing === s.path ? (
+                        <input
+                          className="hist-item__rename"
+                          autoFocus
+                          value={draft}
+                          onChange={(e) => setDraft(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") commitRename(s.path);
+                            if (e.key === "Escape") setEditing(null);
+                          }}
+                          onBlur={() => commitRename(s.path)}
+                          placeholder={tr("history.namePlaceholder")}
+                        />
+                      ) : (
+                        <button
+                          className="hist-item__main"
+                          onClick={() => {
+                            if (running) void loadPreview(s);
+                            else onResume(s.path);
+                          }}
+                          title={s.path}
+                        >
+                          <div className="hist-item__preview">{sessionDisplayTitle(s, tr("history.emptySession"))}</div>
+                          <div className="hist-item__meta">
+                            {s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
+                            <span>{tr(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns })}</span>
+                            <span>·</span>
+                            <span>{timeLabel(sessionActivityTime(s))}</span>
+                            {running && (
+                              <>
+                                <span>·</span>
+                                <span>{tr("history.preview")}</span>
+                              </>
                             )}
-                          </>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                ))}
+                          </div>
+                        </button>
+                      )}
+
+                      {editing !== s.path && (
+                        <div className="hist-item__actions">
+                          {confirming === s.path ? (
+                            <>
+                              <button
+                                className="hist-act hist-act--danger"
+                                title={tr("history.confirmDelete")}
+                                disabled={running}
+                                onClick={() => {
+                                  if (running) return;
+                                  onDelete(s.path);
+                                  setConfirming(null);
+                                }}
+                              >
+                                <Check size={14} />
+                              </button>
+                              <button className="hist-act" title={tr("common.cancel")} onClick={() => setConfirming(null)}>
+                                <X size={14} />
+                              </button>
+                            </>
+                          ) : (
+                            <>
+                              <button
+                                className="hist-act"
+                                title={tr("history.rename")}
+                                disabled={running}
+                                onClick={() => startRename(s)}
+                              >
+                                <Pencil size={13} />
+                              </button>
+                              {!s.current && (
+                                <button
+                                  className="hist-act"
+                                  title={tr("common.delete")}
+                                  disabled={running}
+                                  onClick={() => setConfirming(s.path)}
+                                >
+                                  <Trash2 size={13} />
+                                </button>
+                              )}
+                            </>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
               </section>
             ))
           )}
         </div>
+
+        {showPreview && (
+          <section className="history-preview">
+            <div className="history-preview__head">
+              <div className="history-preview__title">{preview.title}</div>
+              <div className="history-preview__meta">{preview.meta}</div>
+            </div>
+            <div className="history-preview__body">
+              {preview.loading ? (
+                <div className="mem-empty">{tr("common.loading")}</div>
+              ) : previewItems.length === 0 ? (
+                <div className="mem-empty">{tr("history.previewEmpty")}</div>
+              ) : (
+                <Transcript items={previewItems} onPrompt={() => {}} />
+              )}
+            </div>
+          </section>
+        )}
+      </div>
     </ResizableDrawer>
   );
 }
@@ -146,4 +267,26 @@ function dayLabel(ms: number): string {
 
 function timeLabel(ms: number): string {
   return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function sessionDisplayTitle(s: SessionMeta, fallback: string): string {
+  return s.title || s.preview || fallback;
+}
+
+function sessionMetaLine(s: SessionMeta, tr: ReturnType<typeof useT>): string {
+  return `${tr(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns })} · ${timeLabel(sessionActivityTime(s))}`;
+}
+
+function previewMessagesToItems(messages: HistoryMessage[]): Item[] {
+  return messages
+    .filter(
+      (m) =>
+        (m.role === "user" && m.content.trim() !== "") ||
+        (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
+    )
+    .map((m, i) =>
+      m.role === "user"
+        ? { kind: "user", id: `hp${i}`, text: m.content }
+        : { kind: "assistant", id: `hp${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
+    );
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -54,9 +54,10 @@ export interface AppBindings {
   SummarizeFrom(turn: number): Promise<void>;
   SummarizeUpTo(turn: number): Promise<void>;
   // Session history: list saved sessions, resume one (returns its transcript),
-  // delete one, or give one a custom display name ("" clears it).
+  // preview one read-only, delete one, or give one a custom display name ("" clears it).
   ListSessions(): Promise<SessionMeta[]>;
   ResumeSession(path: string): Promise<HistoryMessage[]>;
+  PreviewSession(path: string): Promise<HistoryMessage[]>;
   DeleteSession(path: string): Promise<void>;
   RenameSession(path: string, title: string): Promise<void>;
   // Workspace: open a folder chooser and switch to that project (fresh session);
@@ -388,6 +389,17 @@ function makeMockApp(): AppBindings {
       return [
         { role: "user", content: `(mock) resumed ${path}` },
         { role: "assistant", content: "This is a mock resumed transcript — the real one comes from the kernel." },
+      ];
+    },
+    async PreviewSession(path: string) {
+      const s = sessions.find((x) => x.path === path);
+      return [
+        { role: "user", content: s?.preview || `(mock) preview ${path}` },
+        {
+          role: "assistant",
+          content: "This is a read-only mock preview. The active conversation is unchanged.",
+          reasoning: "Preview reads the saved session without resuming it.",
+        },
       ];
     },
     async DeleteSession(path: string) {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -552,6 +552,10 @@ export function useController() {
     app.ContextUsage().then((context) => dispatch({ type: "context", context })).catch(() => {});
   }, []);
 
+  const previewSession = useCallback((path: string): Promise<HistoryMessage[]> => {
+    return app.PreviewSession(path).catch(() => []);
+  }, []);
+
   // Manage saved sessions: delete one, or give it a custom name (""=clear). Both
   // only touch on-disk state; the caller re-fetches the list to reflect the change.
   const deleteSession = useCallback((path: string) => {
@@ -671,6 +675,7 @@ export function useController() {
     newSession,
     listSessions,
     resumeSession,
+    previewSession,
     deleteSession,
     renameSession,
     refreshMeta,

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -196,6 +196,11 @@ export const en = {
   "history.turnOther": "{n} turns",
   "history.confirmDelete": "Confirm delete",
   "history.rename": "Rename",
+  "history.preview": "preview",
+  "history.previewEmpty": "No visible messages in this session.",
+  "history.readOnlyHint": "Model output is running. History is read-only until the turn finishes.",
+  "history.searchPlaceholder": "Search sessions…",
+  "history.noResults": "No matching sessions.",
   "history.today": "Today",
   "history.yesterday": "Yesterday",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -197,6 +197,11 @@ export const zh: Record<DictKey, string> = {
   "history.turnOther": "{n} 轮",
   "history.confirmDelete": "确认删除",
   "history.rename": "重命名",
+  "history.preview": "预览",
+  "history.previewEmpty": "这个会话没有可见消息。",
+  "history.readOnlyHint": "模型正在输出，历史仅可查看，暂不能切换或修改会话。",
+  "history.searchPlaceholder": "搜索会话…",
+  "history.noResults": "没有匹配的会话。",
   "history.today": "今天",
   "history.yesterday": "昨天",
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3890,7 +3890,66 @@ body {
   opacity: 0.5;
 }
 
-/* ── history drawer: click-to-resume rows with rename/delete actions ────────── */
+/* ── history drawer: click-to-resume rows with read-only preview ────────────── */
+.history-drawer {
+  min-height: 0;
+}
+.history-drawer--preview {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(220px, 0.44fr) minmax(0, 0.56fr);
+  gap: 12px;
+  overflow: hidden;
+}
+.history-list {
+  min-width: 0;
+  overflow-y: auto;
+  padding-right: 2px;
+}
+.history-search {
+  margin-bottom: 12px;
+}
+.history-preview {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+.history-preview__head {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-soft);
+  background: var(--bg-soft);
+}
+.history-preview__title {
+  overflow: hidden;
+  color: var(--fg);
+  font-size: 13px;
+  font-weight: 650;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-preview__meta {
+  margin-top: 3px;
+  color: var(--fg-faint);
+  font-size: 11px;
+}
+.history-preview__body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.history-preview__body .transcript {
+  padding: 14px 14px 18px;
+}
+.history-preview__body .transcript > * {
+  max-width: none;
+}
 .hist-item {
   display: flex;
   align-items: stretch;
@@ -3907,6 +3966,10 @@ body {
 }
 .hist-item--current {
   border-color: var(--accent-soft);
+}
+.hist-item--selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent-soft);
 }
 .hist-item__main {
   --wails-draggable: no-drag;
@@ -3971,6 +4034,14 @@ body {
 .hist-act:hover {
   color: var(--fg);
   background: var(--bg);
+}
+.hist-act:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+.hist-act:disabled:hover {
+  color: var(--fg-faint);
+  background: transparent;
 }
 .hist-act--danger,
 .hist-act--danger:hover {
@@ -4330,6 +4401,10 @@ body {
 @media (max-width: 760px) {
   .drawer--wide {
     width: min(620px, 96vw);
+  }
+  .history-drawer--preview {
+    grid-template-columns: 1fr;
+    grid-template-rows: minmax(180px, 0.42fr) minmax(0, 0.58fr);
   }
   .settings-shell {
     grid-template-columns: 1fr;

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/provider"
 )
 
@@ -35,5 +37,27 @@ func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	}
 	if got[3].Reasoning != "tool-call-only thinking" {
 		t.Fatalf("empty-content assistant reasoning = %q, want tool-call-only thinking", got[3].Reasoning)
+	}
+}
+
+func TestPreviewSessionMessagesLoadsWithoutResuming(t *testing.T) {
+	dir := t.TempDir()
+	session := agent.NewSession("")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "show history"})
+	session.Add(provider.Message{Role: provider.RoleAssistant, Content: "answer", ReasoningContent: "saved reasoning"})
+	path := filepath.Join(dir, "session.jsonl")
+	if err := session.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := previewSessionMessages(dir, path)
+	if err != nil {
+		t.Fatalf("previewSessionMessages: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("preview history length = %d, want 2", len(got))
+	}
+	if got[1].Reasoning != "saved reasoning" {
+		t.Fatalf("preview reasoning = %q, want saved reasoning", got[1].Reasoning)
 	}
 }


### PR DESCRIPTION
## Summary
- add a read-only `PreviewSession` backend path that loads saved sessions without snapshotting or resuming the active controller
- keep history drawer entry points enabled while a model turn is running
- make running history rows load read-only transcript previews while disabling resume/rename/delete mutations
- add session search and reuse the existing transcript renderer so reasoning remains available as a collapsed block

## Testing
- `go test ./...` from `desktop/`
- `npm run build` from `desktop/frontend/`
- Playwright check against `http://127.0.0.1:5174/`: while mock output was streaming, the history entry remained enabled, the drawer opened, read-only preview loaded, rename actions were disabled, and search was visible

## Notes
- This builds on #2705, which already restored assistant reasoning in desktop history payloads.
- Provider request construction is unchanged; this only affects desktop history display/preview payloads.