### PR TITLE
feat(tui): clear composer on single Ctrl+C when input is non-empty

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -174,8 +174,9 @@ type chatTUI struct {
 	rewind  *rewindPicker
 	lastEsc time.Time
 
-	// lastCtrlCAt records when Ctrl+C was pressed while idle, enabling a
-	// "press again to quit" confirmation pattern (1.5s window).
+	// lastCtrlCAt records when Ctrl+C was pressed while idle on an empty
+	// composer, enabling a "press again to quit" confirmation pattern (1.5s
+	// window). Reset when Ctrl+C clears non-empty input instead.
 	lastCtrlCAt time.Time
 
 	// host is the running MCP servers (nil when no plugins). The TUI reads
@@ -670,7 +671,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			return m, nil
-		case "ctrl+c":
+		case "ctrl+c", "super+c", "meta+c":
 			if m.state == tuiRunning {
 				if m.bubblePending {
 					m.unsendPending() // server not yet replied — restore text, leave no trace
@@ -679,7 +680,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				return m, nil
 			}
-			// Idle: require double-press within 1.5s to prevent accidental exits.
+			// Idle: if the composer has text, a single press clears it (like Esc).
+			// On an empty composer, require double-press within 1.5s to quit.
+			if strings.TrimSpace(m.input.Value()) != "" {
+				m.input.Reset()
+				m.pastedBlocks = nil
+				m.lastCtrlCAt = time.Time{}
+				return m, nil
+			}
 			if !m.lastCtrlCAt.IsZero() && time.Since(m.lastCtrlCAt) < 1500*time.Millisecond {
 				return m, tea.Quit
 			}

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -448,6 +448,53 @@ func TestDoubleCtrlCQuit(t *testing.T) {
 	}
 }
 
+// TestCtrlCClearsInput verifies that a single Ctrl+C while idle with non-empty
+// input clears the composer without arming the double-press quit gesture.
+func TestCtrlCClearsInput(t *testing.T) {
+	m := newTestChatTUI()
+	m.input.SetValue("hello world")
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: 4}
+
+	out, _ := m.Update(ctrlC)
+	m2 := out.(chatTUI)
+
+	if strings.TrimSpace(m2.input.Value()) != "" {
+		t.Errorf("Ctrl+C should clear non-empty input, got %q", m2.input.Value())
+	}
+	if !m2.lastCtrlCAt.IsZero() {
+		t.Error("Ctrl+C on non-empty input should not arm the quit gesture")
+	}
+}
+
+// TestCtrlCClearsThenDoublePressQuits verifies the full user flow: Ctrl+C on
+// non-empty input clears it, then two more presses on the empty composer quit.
+func TestCtrlCClearsThenDoublePressQuits(t *testing.T) {
+	m := newTestChatTUI()
+	m.input.SetValue("draft text")
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: 4}
+
+	// First press: clear input.
+	out, _ := m.Update(ctrlC)
+	m2 := out.(chatTUI)
+	if strings.TrimSpace(m2.input.Value()) != "" {
+		t.Fatal("first Ctrl+C should clear input")
+	}
+
+	// Second press (on empty): arm quit.
+	out2, _ := m2.Update(ctrlC)
+	m3 := out2.(chatTUI)
+	if m3.lastCtrlCAt.IsZero() {
+		t.Error("Ctrl+C on empty input should arm quit")
+	}
+
+	// Third press (within window): quit.
+	out3, cmd := m3.Update(ctrlC)
+	if cmd == nil {
+		t.Error("double Ctrl+C on empty input should quit")
+	}
+	_ = out3
+}
+
 // TestAgentEventCoalescesBurst proves one update drains the buffered event burst
 // behind the delivered event, so a flood collapses into a single re-render.
 func TestAgentEventCoalescesBurst(t *testing.T) {


### PR DESCRIPTION
## Summary

Single Ctrl+C (or Cmd+C on macOS) now clears the input composer when it has content, instead of arming the double-press quit gesture. The quit flow is preserved for an empty composer with the existing 1.5s window.

## Motivation

Users often type a long prompt and want to discard it quickly. Currently Ctrl+C on non-empty input shows a "press again to quit" hint, which is surprising — the natural expectation is to clear the input. This matches the existing Esc behavior on non-empty input.

## Changes

- **`internal/cli/chat_tui.go`**: In the idle Ctrl+C handler, check if the composer has text before arming the quit gesture. If non-empty, clear input (matching Esc's existing behavior). Also add `super+c`/`meta+c` key bindings for macOS Cmd+C support.
- **`internal/cli/chat_tui_test.go`**: Add `TestCtrlCClearsInput` and `TestCtrlCClearsThenDoublePressQuits` to cover the new clear path and the full clear→quit flow.

## Behavior

| State | Input | Action |
|-------|-------|--------|
| Idle | Non-empty | Single press clears input |
| Idle | Empty | Double-press (1.5s) to quit |
| Running | — | Cancel turn / unsend pending (unchanged) |
