### PR TITLE
feat(plugin): tier-based MCP loading with cache-aware lazy placeholders

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -145,7 +145,34 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// Always construct a host, even with no plugins configured, so the controller's
 	// host pointer is stable for the session and `/mcp add` can hot-add into it.
 	pluginHost := plugin.NewHost()
-	specs := PluginSpecs(cfg.AutoStartPlugins())
+
+	// Partition configured plugins by tier so eager/lazy/background can each
+	// take the path that fits them. User entries default to lazy — they don't
+	// slow the next launch unless the user explicitly opts in to eager.
+	eagerEntries, lazyEntries, bgEntries := partitionByTier(cfg.AutoStartPlugins())
+
+	// Auto-demote: any eager plugin that has been chronically slow (Phase 5
+	// telemetry says p99 > 2*budget over the last few starts) drops to lazy
+	// for this session. The user keeps eager intent, just doesn't pay for it
+	// on a server that's been misbehaving. A notice surfaces the demotion.
+	var demoteMessages []string
+	budget := plugin.DefaultStartupBudget()
+	kept := eagerEntries[:0]
+	for _, e := range eagerEntries {
+		rec := plugin.Recommend(e.Name, budget, 0)
+		if rec.Demote {
+			demoteMessages = append(demoteMessages, rec.Reason)
+			lazyEntries = append(lazyEntries, e)
+			continue
+		}
+		kept = append(kept, e)
+	}
+	eagerEntries = kept
+
+	eagerSpecs := PluginSpecs(eagerEntries)
+	lazySpecs := PluginSpecs(lazyEntries)
+	bgSpecs := PluginSpecs(bgEntries)
+
 	// CodeGraph is a built-in MCP server fetched on first use. When it resolves,
 	// inject it as one more stdio plugin pinned to the project root (it is
 	// cwd-aware); EnsureInit only creates .codegraph/ (fast, size-independent),
@@ -154,6 +181,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// (one-time, ~45MB) if auto_install is on — startup still never blocks, the
 	// tools come online next session — otherwise point the user at the explicit
 	// install command. A failed init or fetch is a notice, not fatal.
+	//
+	// Codegraph stays eager regardless of user tier — symbol-graph tools land
+	// in the system prompt, so the agent must see them on first turn.
 	if cfg.Codegraph.Enabled {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
@@ -162,7 +192,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 					Text: "codegraph: init failed (" + err.Error() + ") — symbol-graph tools disabled this session"})
 			}
-			specs = append(specs, plugin.Spec{Name: "codegraph", Command: bin, Args: []string{"serve", "--mcp"}, Dir: cwd})
+			eagerSpecs = append(eagerSpecs, plugin.Spec{Name: "codegraph", Command: bin, Args: []string{"serve", "--mcp"}, Dir: cwd})
 		case cfg.Codegraph.AutoInstall:
 			notify := func(msg string) { sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg}) }
 			notify("codegraph: fetching code-intelligence runtime in the background (one-time) — symbol-graph tools available next session")
@@ -183,14 +213,23 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				Text: "codegraph: not installed — run `reasonix codegraph install` to enable symbol-graph tools"})
 		}
 	}
-	if len(specs) > 0 {
-		// Apply caller-supplied stderr override to all plugin specs.
-		if opts.Stderr != nil {
-			for i := range specs {
-				specs[i].Stderr = opts.Stderr
-			}
+
+	// Apply caller-supplied stderr override to every spec across tiers.
+	if opts.Stderr != nil {
+		for i := range eagerSpecs {
+			eagerSpecs[i].Stderr = opts.Stderr
 		}
-		host, ptools := plugin.StartAvailable(ctx, specs)
+		for i := range lazySpecs {
+			lazySpecs[i].Stderr = opts.Stderr
+		}
+		for i := range bgSpecs {
+			bgSpecs[i].Stderr = opts.Stderr
+		}
+	}
+
+	// Eager: block until handshake. Failures show up in /mcp.
+	if len(eagerSpecs) > 0 {
+		host, ptools := plugin.StartAvailable(ctx, eagerSpecs)
 		pluginHost = host
 		for _, t := range ptools {
 			reg.Add(t)
@@ -203,6 +242,26 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 		}
 	}
+
+	// Lazy / background: register placeholder tools now; the real spawn waits
+	// for either the first model call (lazy) or a goroutine kicked off here
+	// (background). Both share the same pluginHost so /mcp status, hot-add,
+	// and Close see one cohesive set of servers regardless of tier.
+	registerDeferred := func(specs []plugin.Spec, kick bool) {
+		for _, s := range specs {
+			cs, _ := plugin.LoadCachedSchema(s.Name, plugin.SpecFingerprint(s))
+			for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, kick) {
+				reg.Add(t)
+			}
+		}
+	}
+	registerDeferred(lazySpecs, false)
+	registerDeferred(bgSpecs, true)
+
+	for _, msg := range demoteMessages {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg})
+	}
+
 	cleanup := pluginHost.Close
 
 	// LSP tools resolve their servers on PATH and spawn lazily on first query, so
@@ -506,6 +565,24 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 			reg.Add(t)
 		}
 	}
+}
+
+// partitionByTier splits configured plugin entries into the three startup
+// buckets — eager (block boot until ready), lazy (placeholder until first
+// model use), background (placeholder + start spawn now). Entries with an
+// unrecognised or empty tier land in lazy (the default).
+func partitionByTier(entries []config.PluginEntry) (eager, lazy, bg []config.PluginEntry) {
+	for _, e := range entries {
+		switch e.ResolvedTier() {
+		case "eager":
+			eager = append(eager, e)
+		case "background":
+			bg = append(bg, e)
+		default:
+			lazy = append(lazy, e)
+		}
+	}
+	return eager, lazy, bg
 }
 
 // PluginSpecs maps configured plugin entries to plugin.Spec, expanding ${VAR}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -151,8 +151,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// slow the next launch unless the user explicitly opts in to eager.
 	eagerEntries, lazyEntries, bgEntries := partitionByTier(cfg.AutoStartPlugins())
 
-	// Auto-demote: any eager plugin that has been chronically slow (Phase 5
-	// telemetry says p99 > 2*budget over the last few starts) drops to lazy
+	// Auto-demote: any eager plugin that has been chronically slow (recent
+	// samples repeatedly hit the blocking startup budget) drops to lazy
 	// for this session. The user keeps eager intent, just doesn't pay for it
 	// on a server that's been misbehaving. A notice surfaces the demotion.
 	var demoteMessages []string

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1,13 +1,20 @@
 package boot
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/config"
 	"reasonix/internal/event"
+	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 
 	// Blank imports register the provider kind and built-in tools the same way
@@ -145,6 +152,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 [[plugins]]
 name = "missing"
 command = "reasonix-missing-mcp-binary"
+tier = "eager"
 `)
 	var notices []event.Event
 	ctrl, err := Build(context.Background(), Options{
@@ -276,5 +284,325 @@ func writeFile(t *testing.T, dir, name, body string) {
 	t.Helper()
 	if err := writeFileRaw(dir, name, body); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// isolateConfigHome redirects os.UserConfigDir() (and the cache subtree under
+// it) at a per-test temp dir by overriding the env vars Go's stdlib reads —
+// HOME on darwin, XDG_CONFIG_HOME on linux. Without this, Build's plugin path
+// would persist startup stats and cached schemas into the developer's real
+// ~/Library/Application Support tree and bleed state across tests. Mirrors the
+// withTempCache helper in internal/plugin/stats_test.go.
+func isolateConfigHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+// TestPartitionByTier pins the bucket assignment contract that the rest of
+// boot.go's plugin orchestration depends on: each tier string maps to its own
+// slice, the original order inside a tier is preserved (so /mcp status and
+// stats land deterministically), and a missing/unknown tier value falls into
+// lazy — the project default that keeps adding a plugin from ever slowing the
+// next launch.
+func TestPartitionByTier(t *testing.T) {
+	entries := []config.PluginEntry{
+		{Name: "e1", Tier: "eager"},
+		{Name: "l1", Tier: "lazy"},
+		{Name: "b1", Tier: "background"},
+		{Name: "default", Tier: ""}, // empty must default to lazy
+	}
+
+	eager, lazy, bg := partitionByTier(entries)
+
+	if len(eager) != 1 || eager[0].Name != "e1" {
+		t.Fatalf("eager bucket = %+v, want [e1]", eager)
+	}
+	if len(bg) != 1 || bg[0].Name != "b1" {
+		t.Fatalf("background bucket = %+v, want [b1]", bg)
+	}
+	// Lazy holds both the explicit lazy entry and the default-fallback one, in
+	// the order they appeared in the input — proves the empty-tier default
+	// flows through partition without reshuffling.
+	if len(lazy) != 2 || lazy[0].Name != "l1" || lazy[1].Name != "default" {
+		t.Fatalf("lazy bucket = %+v, want [l1, default] preserving input order", lazy)
+	}
+}
+
+// TestBuildEagerStartsAtBoot proves an eager-tier plugin actually completes
+// its handshake on the boot critical path: Host.ServerNames() must include the
+// plugin after Build returns. We point the plugin at this test binary running
+// as a stdio MCP helper (see TestHelperProcess), so the spawn is real but
+// deterministic and hermetic — no external MCP server required on PATH.
+func TestBuildEagerStartsAtBoot(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+
+[[plugins]]
+name = "eagermock"
+command = %q
+args = ["-test.run=TestHelperProcess", "--"]
+tier = "eager"
+env = { GO_WANT_HELPER_PROCESS = "1" }
+`, os.Args[0]))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	names := ctrl.Host().ServerNames()
+	found := false
+	for _, n := range names {
+		if n == "eagermock" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("eager plugin missing from Host.ServerNames() = %v — boot did not block on its handshake", names)
+	}
+	if got := ctrl.Host().Failures(); len(got) != 0 {
+		t.Fatalf("Host.Failures() = %+v, want empty for a healthy eager plugin", got)
+	}
+}
+
+// TestBuildLazyDoesNotConnectAtBoot is the inverse of the eager test: a
+// lazy-tier plugin must NOT trigger a subprocess handshake during Build, so
+// the boot critical path stays empty even with a slow-to-spawn server in
+// config. We assert through Host.ServerNames() (must not list the plugin) and
+// Host.Failures() (lazy plugins never appear here — a failure surfaces only on
+// first model use, not at boot). The placeholder tool registration itself is
+// covered by internal/plugin/lazy_test.go's TestLazy* suite; the Registry has
+// no public accessor on Controller, so at this layer we pin the load-bearing
+// boot-time invariant — no spawn — rather than re-validating the placeholder.
+func TestBuildLazyDoesNotConnectAtBoot(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+
+[[plugins]]
+name = "lazymock"
+command = %q
+args = ["-test.run=TestHelperProcess", "--"]
+tier = "lazy"
+env = { GO_WANT_HELPER_PROCESS = "1" }
+`, os.Args[0]))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, n := range ctrl.Host().ServerNames() {
+		if n == "lazymock" {
+			t.Fatalf("lazy plugin %q appeared in Host.ServerNames() — boot connected it eagerly", n)
+		}
+	}
+	if got := ctrl.Host().Failures(); len(got) != 0 {
+		t.Fatalf("Host.Failures() = %+v, want empty — lazy plugins must not even attempt a boot-time spawn", got)
+	}
+	// The configured plugin is still recognised as a configured-but-disconnected
+	// server, the same signal /mcp uses to render its "lazy, will connect on
+	// first use" line — proves the entry made it through partition into the
+	// lazy bucket rather than being dropped.
+	dconn := ctrl.DisconnectedMCPNames()
+	foundDisconnected := false
+	for _, n := range dconn {
+		if n == "lazymock" {
+			foundDisconnected = true
+			break
+		}
+	}
+	if !foundDisconnected {
+		t.Fatalf("DisconnectedMCPNames() = %v, want it to include the lazy plugin (configured but not connected)", dconn)
+	}
+}
+
+// TestBuildAutoDemoteFromStats proves the Phase 5 telemetry → Phase 4 tier
+// bridge: three consecutive over-budget startup samples must demote an
+// eager-tier plugin to lazy at the *next* boot, so the user pays for a slow
+// MCP server at most a handful of starts. We pre-seed three 30s samples for
+// "slowserver" (well above 2 * DefaultStartupBudget = 10s) via the public
+// RecordStartup API, then Build a config that declares "slowserver" eager and
+// verify (a) boot did NOT block on its handshake — the plugin is absent from
+// Host.ServerNames() — and (b) a Notice carrying the demote reason fired so
+// the user understands why their explicit "eager" was ignored this session.
+func TestBuildAutoDemoteFromStats(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// Three samples above 2*budget — the rule in stats.go's Recommend triggers
+	// when the trailing window is entirely over the threshold. Use 30s so even
+	// future budget bumps stay below the threshold.
+	for i := 0; i < 3; i++ {
+		if err := plugin.RecordStartup("slowserver", 30*time.Second); err != nil {
+			t.Fatalf("RecordStartup #%d: %v", i, err)
+		}
+	}
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+
+[[plugins]]
+name = "slowserver"
+command = "reasonix-missing-slow-mcp-binary"
+tier = "eager"
+`)
+
+	var notices []event.Event
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, n := range ctrl.Host().ServerNames() {
+		if n == "slowserver" {
+			t.Fatalf("demoted plugin %q still appeared in Host.ServerNames() — auto-demote did not move it out of the eager bucket", n)
+		}
+	}
+	// Crucially the missing-binary command never ran: a real eager attempt
+	// would have surfaced as a Failure with a spawn error. An empty failures
+	// list proves boot skipped the spawn entirely, not that it tried and
+	// silently swallowed the error.
+	if got := ctrl.Host().Failures(); len(got) != 0 {
+		t.Fatalf("Host.Failures() = %+v, want empty — demoted plugin should never have been spawned", got)
+	}
+
+	foundDemoteNotice := false
+	for _, n := range notices {
+		if strings.Contains(n.Text, "demoting to lazy") {
+			foundDemoteNotice = true
+			break
+		}
+	}
+	if !foundDemoteNotice {
+		t.Fatalf("no demote notice surfaced; got %+v", notices)
+	}
+}
+
+// TestHelperProcess is invoked as a subprocess by TestBuildEagerStartsAtBoot
+// and TestBuildLazyDoesNotConnectAtBoot. It mirrors the minimal MCP stdio
+// server in internal/plugin/plugin_test.go so the boot package can drive an
+// end-to-end handshake without depending on the plugin package's test helper
+// (Go's testing framework only re-invokes the binary of the test package
+// currently running). The helper gates on GO_WANT_HELPER_PROCESS=1 so a
+// normal `go test ./internal/boot/...` does not trip it.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
+
+	in := bufio.NewReader(os.Stdin)
+	for {
+		line, err := in.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var req struct {
+			ID     *int            `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(line, &req); err != nil {
+			continue
+		}
+		if req.ID == nil {
+			continue // notification: no response
+		}
+
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": "2024-11-05",
+				"serverInfo":      map[string]any{"name": "mock", "version": "0"},
+				"capabilities":    map[string]any{},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{{
+				"name":        "echo",
+				"description": "Echo back the message.",
+				"inputSchema": map[string]any{
+					"type":       "object",
+					"properties": map[string]any{"msg": map[string]any{"type": "string"}},
+					"required":   []string{"msg"},
+				},
+			}}}
+		}
+
+		resp := map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": result}
+		b, _ := json.Marshal(resp)
+		os.Stdout.Write(append(b, '\n'))
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -326,10 +326,34 @@ type PluginEntry struct {
 	// AutoStart controls whether the server connects during session startup.
 	// Nil preserves historical behavior: configured servers start automatically.
 	AutoStart *bool `toml:"auto_start"`
+	// Tier selects how aggressively the server is connected at boot:
+	//   "eager"      — blocks startup until the handshake completes; required for
+	//                  servers whose tools the system prompt depends on.
+	//   "lazy"       — registers placeholder tools immediately (from on-disk
+	//                  schema cache when available) and only spawns the real
+	//                  subprocess on first model use. Default for user plugins.
+	//   "background" — placeholder + spawn fired at boot but not waited on;
+	//                  swap happens once the spawn finishes.
+	// Empty defaults to "lazy" so adding a plugin never slows the next launch.
+	Tier string `toml:"tier"`
 }
 
 func (e PluginEntry) ShouldAutoStart() bool {
 	return e.AutoStart == nil || *e.AutoStart
+}
+
+// ResolvedTier returns the normalized tier ("eager"|"lazy"|"background") with
+// the project default applied. Unknown values fall back to "lazy" so a typo
+// never forces a slow boot.
+func (e PluginEntry) ResolvedTier() string {
+	switch strings.ToLower(strings.TrimSpace(e.Tier)) {
+	case "eager":
+		return "eager"
+	case "background":
+		return "background"
+	default:
+		return "lazy"
+	}
 }
 
 func (c *Config) AutoStartPlugins() []PluginEntry {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1236,6 +1236,7 @@ func (c *Controller) connectMCPSpec(s plugin.Spec) (int, error) {
 		return 0, err
 	}
 	if c.reg != nil {
+		c.reg.RemovePrefix(plugin.ToolPrefix(s.Name))
 		for _, t := range tools {
 			c.reg.Add(t)
 		}
@@ -1329,6 +1330,9 @@ func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error)
 	}
 	inConfig := cfg.RemovePlugin(name)
 	if inConfig {
+		if !disconnected && c.reg != nil {
+			c.reg.RemovePrefix(plugin.ToolPrefix(name))
+		}
 		if serr := cfg.Save(); serr != nil {
 			return disconnected, serr
 		}
@@ -1344,14 +1348,20 @@ func (c *Controller) RemoveMCPServer(name string) (disconnected bool, err error)
 // on the next session start, or now via ConnectConfiguredMCPServer (the "on").
 // Reports whether a live server was actually disconnected.
 func (c *Controller) DisconnectMCPServer(name string) bool {
-	if c.host == nil {
-		return false
+	disconnected := false
+	if c.host != nil {
+		if prefix, ok := c.host.Remove(name); ok {
+			disconnected = true
+			if c.reg != nil {
+				c.reg.RemovePrefix(prefix)
+			}
+		}
 	}
-	prefix, ok := c.host.Remove(name)
-	if ok && c.reg != nil {
-		c.reg.RemovePrefix(prefix)
+	removedPlaceholder := 0
+	if !disconnected && c.reg != nil {
+		removedPlaceholder = c.reg.RemovePrefix(plugin.ToolPrefix(name))
 	}
-	return ok
+	return disconnected || removedPlaceholder > 0
 }
 
 // Label returns the human-readable model label, e.g. "deepseek-flash".

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -2,13 +2,16 @@ package control
 
 import (
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/tool"
 )
 
 type typedNilControllerSink struct{}
@@ -23,6 +26,20 @@ func (r appendingRunner) Run(_ context.Context, input string) error {
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 	return nil
 }
+
+type fakeControlTool struct{ name string }
+
+func (t fakeControlTool) Name() string { return t.name }
+func (fakeControlTool) Description() string {
+	return "fake"
+}
+func (fakeControlTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (fakeControlTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "", nil
+}
+func (fakeControlTool) ReadOnly() bool { return true }
 
 func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
 	var sink *typedNilControllerSink
@@ -115,6 +132,19 @@ func TestSnapshotActivityRefreshesSessionActivity(t *testing.T) {
 	}
 	if !second.UpdatedAt.After(first.UpdatedAt) {
 		t.Fatalf("SnapshotActivity did not refresh activity: first=%s second=%s", first.UpdatedAt, second.UpdatedAt)
+	}
+}
+
+func TestDisconnectMCPServerRemovesLazyPlaceholder(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__mock__connect"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+
+	if ok := c.DisconnectMCPServer("mock"); !ok {
+		t.Fatal("DisconnectMCPServer returned false for a registered lazy placeholder")
+	}
+	if _, found := reg.Get("mcp__mock__connect"); found {
+		t.Fatalf("lazy placeholder still registered after disconnect; names=%v", reg.Names())
 	}
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -145,6 +146,37 @@ func TestDisconnectMCPServerRemovesLazyPlaceholder(t *testing.T) {
 	}
 	if _, found := reg.Get("mcp__mock__connect"); found {
 		t.Fatalf("lazy placeholder still registered after disconnect; names=%v", reg.Names())
+	}
+}
+
+func TestRemoveMCPServerRemovesUnconnectedLazyPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile("reasonix.toml", []byte(`
+[[plugins]]
+name = "mock"
+command = "mock-mcp"
+tier = "lazy"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__mock__connect"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+
+	disconnected, err := c.RemoveMCPServer("mock")
+	if err != nil {
+		t.Fatalf("RemoveMCPServer: %v", err)
+	}
+	if disconnected {
+		t.Fatal("RemoveMCPServer reported a live disconnect for an unconnected lazy placeholder")
+	}
+	if _, found := reg.Get("mcp__mock__connect"); found {
+		t.Fatalf("lazy placeholder still registered after remove; names=%v", reg.Names())
+	}
+	if names := c.ConfiguredMCPNames(); len(names) != 0 {
+		t.Fatalf("ConfiguredMCPNames() = %v, want empty after remove", names)
 	}
 }
 

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -4,12 +4,11 @@
 // model call. A "background" plugin is identical except it also kicks the
 // spawn off at boot so by the time the model calls, the swap is already done.
 //
-// Why the indirection: tool.Registry has no mutex (agent dispatch is
-// single-threaded), so we cannot mutate it from a background goroutine while
-// the agent is reading reg.Schemas(). Swaps are therefore performed inside
-// lazyTool.Execute, which runs in turn-synchronous code. Background spawns
-// merely populate lazySpawn's shared state; the swap fires on the next
-// Execute call against any tool tied to that server.
+// Why the indirection: a lazy/background server still needs stable placeholder
+// tools before the real handshake finishes. Once it does finish, lazySpawn swaps
+// the placeholders for real tools through tool.Registry's own lock, so the next
+// model request sees the real schemas without waiting for another placeholder
+// Execute call.
 package plugin
 
 import (
@@ -93,11 +92,11 @@ func (s *lazySpawn) run() {
 		s.real[t.Name()] = t
 	}
 	s.state = spawnReady
+	s.trySwap()
 }
 
 // trySwap installs the real tools into reg if the spawn is ready and the
-// swap hasn't happened. Caller must hold s.mu AND must be running in a
-// turn-synchronous code path (an Execute body) — the Registry is unlocked.
+// swap hasn't happened. Caller must hold s.mu.
 func (s *lazySpawn) trySwap() {
 	if s.swapped || s.state != spawnReady {
 		return
@@ -177,8 +176,7 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 			return "", fmt.Errorf("MCP server %q is initializing on first use — call again on the next turn for its real tools", sp.spec.Name)
 		}
 		// Cache-hit: run the handshake synchronously so this one Execute can
-		// forward through, and so the swap happens in turn-sync (registry is
-		// unlocked).
+		// forward through.
 		sp.state = spawnInFlight
 		sp.mu.Unlock()
 		real, err := sp.host.Add(sp.ctx, sp.spec)
@@ -231,7 +229,7 @@ func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, se
 
 	var out []tool.Tool
 	if cs == nil {
-		shared.removePrefix = "mcp__" + normalizeName(spec.Name) + "__"
+		shared.removePrefix = ToolPrefix(spec.Name)
 		out = []tool.Tool{&lazyTool{
 			shared:   shared,
 			name:     shared.removePrefix + "connect",

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -1,0 +1,259 @@
+// Lazy-tier MCP placeholder tools. A "lazy" plugin registers cheap placeholder
+// entries in the tool registry at boot — using the on-disk schema cache when
+// it exists — and defers the actual subprocess spawn / handshake to the first
+// model call. A "background" plugin is identical except it also kicks the
+// spawn off at boot so by the time the model calls, the swap is already done.
+//
+// Why the indirection: tool.Registry has no mutex (agent dispatch is
+// single-threaded), so we cannot mutate it from a background goroutine while
+// the agent is reading reg.Schemas(). Swaps are therefore performed inside
+// lazyTool.Execute, which runs in turn-synchronous code. Background spawns
+// merely populate lazySpawn's shared state; the swap fires on the next
+// Execute call against any tool tied to that server.
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"reasonix/internal/tool"
+)
+
+// DefaultStartupBudget is the per-plugin latency budget used by boot when
+// deciding whether to auto-demote (see Recommend). Kept here rather than in
+// stats.go because it's the value boot.go pairs with each Recommend call.
+func DefaultStartupBudget() time.Duration { return defaultStartTimeout }
+
+// spawnState is the lazy-spawn state machine. Transitions are:
+//
+//	idle → inFlight → ready
+//	idle → inFlight → failed
+//
+// All transitions are gated by lazySpawn.mu so only one goroutine runs the
+// handshake even when multiple Execute calls race on first use.
+type spawnState int
+
+const (
+	spawnIdle spawnState = iota
+	spawnInFlight
+	spawnReady
+	spawnFailed
+)
+
+// lazySpawn is shared by every placeholder lazyTool registered for one
+// server: they all observe the same state machine and trigger at most one
+// handshake.
+type lazySpawn struct {
+	spec Spec
+	host *Host
+	reg  *tool.Registry
+	ctx  context.Context // session-scoped — outlives any single turn
+
+	mu       sync.Mutex
+	state    spawnState
+	real     map[string]tool.Tool // namespaced name → real tool, populated on success
+	spawnErr error
+	swapped  bool
+	// removePrefix is set for cache-miss placeholders so trySwap drops the
+	// single "<server>__connect" stub before re-registering the real tools
+	// under their actual namespaced names. Cache-hit placeholders use the
+	// same names as the real tools, so reg.Add overwrites in place and no
+	// prefix removal is needed.
+	removePrefix string
+}
+
+// kick starts the spawn if it has not yet started. Used by background-tier
+// registration; lazy-tier kicks on first call instead.
+func (s *lazySpawn) kick() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state != spawnIdle {
+		return
+	}
+	s.state = spawnInFlight
+	go s.run()
+}
+
+// run does the handshake without holding mu (host.Add can take seconds), then
+// reacquires mu to publish the result.
+func (s *lazySpawn) run() {
+	real, err := s.host.Add(s.ctx, s.spec)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err != nil {
+		s.state = spawnFailed
+		s.spawnErr = err
+		return
+	}
+	s.real = make(map[string]tool.Tool, len(real))
+	for _, t := range real {
+		s.real[t.Name()] = t
+	}
+	s.state = spawnReady
+}
+
+// trySwap installs the real tools into reg if the spawn is ready and the
+// swap hasn't happened. Caller must hold s.mu AND must be running in a
+// turn-synchronous code path (an Execute body) — the Registry is unlocked.
+func (s *lazySpawn) trySwap() {
+	if s.swapped || s.state != spawnReady {
+		return
+	}
+	if s.removePrefix != "" {
+		s.reg.RemovePrefix(s.removePrefix)
+	}
+	for _, t := range s.real {
+		s.reg.Add(t)
+	}
+	s.swapped = true
+}
+
+// lazyTool is a tool.Tool placeholder backed by a shared lazySpawn. The model
+// sees cached metadata (or a stub when no cache exists); Execute consults the
+// state machine, kicking off the handshake on first call.
+type lazyTool struct {
+	shared   *lazySpawn
+	name     string // namespaced "mcp__<server>__<tool>"
+	desc     string
+	schema   json.RawMessage
+	readOnly bool
+	// hasCache true → schema is trusted, so Execute runs the handshake
+	// synchronously and forwards in one turn. false → schema is empty, so we
+	// can't honour the model's call; we kick the spawn async and ask for a
+	// retry on the next turn, when the swap will have installed the real
+	// tools with real schemas.
+	hasCache bool
+}
+
+func (lt *lazyTool) Name() string        { return lt.name }
+func (lt *lazyTool) Description() string { return lt.desc }
+func (lt *lazyTool) ReadOnly() bool      { return lt.readOnly }
+func (lt *lazyTool) Schema() json.RawMessage {
+	if len(lt.schema) == 0 {
+		return json.RawMessage(`{"type":"object"}`)
+	}
+	return canonicalizeSchema(lt.schema)
+}
+
+func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	sp := lt.shared
+	sp.mu.Lock()
+
+	// Catch up on a background spawn that finished while we were idle.
+	if sp.state == spawnReady && !sp.swapped {
+		sp.trySwap()
+	}
+
+	switch sp.state {
+	case spawnReady:
+		real := sp.real[lt.name]
+		sp.mu.Unlock()
+		if real == nil {
+			return "", fmt.Errorf("MCP server %q did not expose tool %q (the cached schema may be stale)", sp.spec.Name, lt.name)
+		}
+		return real.Execute(ctx, args)
+
+	case spawnFailed:
+		err := sp.spawnErr
+		sp.mu.Unlock()
+		return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, err)
+
+	case spawnInFlight:
+		sp.mu.Unlock()
+		return "", fmt.Errorf("MCP server %q is still initializing — call this tool again on the next turn", sp.spec.Name)
+
+	case spawnIdle:
+		if !lt.hasCache {
+			// Cache-miss: we don't trust args to match a real schema, so
+			// drive the handshake async and ask the model to retry. By the
+			// next turn the swap will have installed the real tools with
+			// real schemas under different names.
+			sp.state = spawnInFlight
+			go sp.run()
+			sp.mu.Unlock()
+			return "", fmt.Errorf("MCP server %q is initializing on first use — call again on the next turn for its real tools", sp.spec.Name)
+		}
+		// Cache-hit: run the handshake synchronously so this one Execute can
+		// forward through, and so the swap happens in turn-sync (registry is
+		// unlocked).
+		sp.state = spawnInFlight
+		sp.mu.Unlock()
+		real, err := sp.host.Add(sp.ctx, sp.spec)
+		sp.mu.Lock()
+		defer sp.mu.Unlock()
+		if err != nil {
+			sp.state = spawnFailed
+			sp.spawnErr = err
+			return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, err)
+		}
+		sp.real = make(map[string]tool.Tool, len(real))
+		for _, t := range real {
+			sp.real[t.Name()] = t
+		}
+		sp.state = spawnReady
+		sp.trySwap()
+		r := sp.real[lt.name]
+		if r == nil {
+			return "", fmt.Errorf("MCP server %q did not expose tool %q (the cached schema may be stale)", sp.spec.Name, lt.name)
+		}
+		return r.Execute(ctx, args)
+	}
+
+	sp.mu.Unlock()
+	return "", fmt.Errorf("lazy plugin %q in unexpected state", sp.spec.Name)
+}
+
+// LazyToolset returns the placeholder tools to register for one lazy/background
+// spec. When cs is non-nil (cache hit) the returned slice has one lazyTool per
+// cached tool, carrying the cached schema so the model can pass real args;
+// the first Execute runs the handshake synchronously and swaps in real tools.
+// When cs is nil (cache miss) the returned slice has a single stub named
+// "mcp__<server>__connect": the model can call it to drive the spawn, and the
+// real tools surface on the next turn.
+//
+// kick=true (background tier) also fires off the spawn immediately, so an
+// idle session warms up without waiting for the first model call.
+//
+// host is the Host that receives the real Client. reg is the registry where
+// real tools land after a successful spawn. sessionCtx must outlive any
+// single Execute (use the controller's PluginCtx) — a turn-scoped ctx would
+// kill the stdio child between turns.
+func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, sessionCtx context.Context, kick bool) []tool.Tool {
+	shared := &lazySpawn{
+		spec: spec,
+		host: host,
+		reg:  reg,
+		ctx:  sessionCtx,
+	}
+
+	var out []tool.Tool
+	if cs == nil {
+		shared.removePrefix = "mcp__" + normalizeName(spec.Name) + "__"
+		out = []tool.Tool{&lazyTool{
+			shared:   shared,
+			name:     shared.removePrefix + "connect",
+			desc:     fmt.Sprintf("Connect MCP server %q. Call this once to drive the handshake; the server's real tools become available on the next turn.", spec.Name),
+			hasCache: false,
+		}}
+	} else {
+		out = make([]tool.Tool, 0, len(cs.Tools))
+		for _, ct := range cs.Tools {
+			out = append(out, &lazyTool{
+				shared:   shared,
+				name:     toolName(spec.Name, ct.Name),
+				desc:     ct.Description,
+				schema:   ct.Schema,
+				readOnly: ct.ReadOnly,
+				hasCache: true,
+			})
+		}
+	}
+
+	if kick {
+		shared.kick()
+	}
+	return out
+}

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -145,10 +145,10 @@ func TestLazyCacheHitSyncSpawn(t *testing.T) {
 
 // TestLazyCacheMissAsyncSpawn drives the cache-miss branch: with no cache, a
 // single "connect" placeholder shows up; first Execute returns a retry hint and
-// kicks the spawn async; the real tools surface on the next turn under their
-// real names, and the connect stub is dropped. This is the "model warm-up"
-// contract — the model must not see stale schemas, so we refuse to forward
-// the first call and instead ask for one more turn.
+// kicks the spawn async; once that spawn finishes, the registry swaps to the
+// real tools under their real names, and the connect stub is dropped. This is
+// the "model warm-up" contract — the model must not see stale schemas, so we
+// refuse to forward the first call and instead ask for one more turn.
 func TestLazyCacheMissAsyncSpawn(t *testing.T) {
 	redirectCache(t)
 	spec := helperSpec()
@@ -184,13 +184,10 @@ func TestLazyCacheMissAsyncSpawn(t *testing.T) {
 	}
 
 	// Wait for the async spawn to complete (host.Add happens on the run()
-	// goroutine kicked by Execute).
+	// goroutine kicked by Execute). The goroutine swaps the registry itself, so
+	// the next model request sees the real schemas without another placeholder
+	// Execute call.
 	waitForServer(t, host, "mock", 5*time.Second)
-
-	// Second Execute on the placeholder triggers trySwap (caught by the
-	// spawnReady branch). The real tools land in the registry under their
-	// real names; the connect stub is dropped.
-	_, _ = connect.Execute(ctx, json.RawMessage(`{}`))
 
 	if _, found := reg.Get("mcp__mock__connect"); found {
 		t.Errorf("connect stub should be removed after swap, names=%v", reg.Names())
@@ -200,6 +197,54 @@ func TestLazyCacheMissAsyncSpawn(t *testing.T) {
 	}
 	if _, found := reg.Get("mcp__mock__zed"); !found {
 		t.Errorf("real mcp__mock__zed missing after swap, names=%v", reg.Names())
+	}
+}
+
+func TestLazySwapDoesNotRaceRegistrySchemas(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	spec.Env["GO_WANT_HELPER_INIT_MS"] = "50"
+	writeMockCache(t, spec)
+	cs, _ := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+	echo, _ := reg.Get("mcp__mock__echo")
+	if echo == nil {
+		t.Fatal("missing mcp__mock__echo placeholder")
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = reg.Schemas()
+			}
+		}
+	}()
+
+	out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"race"}`))
+	close(done)
+	wg.Wait()
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "echo: race" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: race")
 	}
 }
 

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -1,0 +1,443 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/tool"
+)
+
+// helperSpec returns a Spec that re-invokes this test binary as a minimal MCP
+// stdio server (see TestHelperProcess in plugin_test.go). Reused across every
+// lazy_test case so the helper-process contract — "echo: <msg>" responder with
+// tools/list exposing echo and zed — stays the single source of truth.
+func helperSpec() Spec {
+	return Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env:     map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
+	}
+}
+
+// writeMockCache primes the on-disk cache for spec with the two tools the
+// helper subprocess exposes (echo, zed). We mirror the real schemas so a
+// cache-hit lazyTool surfaces the same Schema() bytes that a freshly handshaked
+// remoteTool would — the test for "model sees real schema before any Execute"
+// depends on this equivalence.
+func writeMockCache(t *testing.T, spec Spec) {
+	t.Helper()
+	cs := CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{"prompts": false, "resources": false},
+		Tools: []CachedTool{
+			{
+				Name:        "echo",
+				Description: "Echo back the message.",
+				Schema:      json.RawMessage(`{"type":"object","properties":{"msg":{"type":"string"}},"required":["z","msg"]}`),
+			},
+			{
+				Name:        "zed",
+				Description: "Sorted after echo.",
+				Schema:      json.RawMessage(`{"type":"object"}`),
+			},
+		},
+	}
+	if err := SaveCachedSchema(spec.Name, cs); err != nil {
+		t.Fatalf("SaveCachedSchema: %v", err)
+	}
+}
+
+// waitForServer polls host.ServerNames() until name appears or timeout
+// elapses. The lazy path spawns via a goroutine, so tests need a bounded poll
+// rather than a fixed sleep — five seconds covers a slow CI subprocess fork
+// while still aborting clearly on a real hang.
+func waitForServer(t *testing.T, host *Host, name string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, n := range host.ServerNames() {
+			if n == name {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("server %q never appeared in host.ServerNames() within %v (got %v)", name, timeout, host.ServerNames())
+}
+
+// TestLazyCacheHitSyncSpawn drives the cache-hit branch end-to-end: cache is
+// pre-populated, the model can see real schemas before any spawn, and the
+// first Execute synchronously handshakes, swaps the placeholder for the real
+// *remoteTool, and forwards through in one turn. This is the "warm start"
+// payoff — lazy plugins should be indistinguishable from eager once they have
+// a cache.
+func TestLazyCacheHitSyncSpawn(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	writeMockCache(t, spec)
+
+	cs, ok := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+	if !ok {
+		t.Fatal("LoadCachedSchema: miss right after save (sanity)")
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 2 {
+		t.Fatalf("LazyToolset returned %d tools, want 2 (echo + zed)", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	// Before any Execute: registry exposes real cached schemas (not the empty
+	// {"type":"object"} stub). The model relies on this to call the tool with
+	// real args on the very first turn.
+	echoBefore, ok := reg.Get("mcp__mock__echo")
+	if !ok {
+		t.Fatal("registry missing mcp__mock__echo after LazyToolset")
+	}
+	if _, isLazy := echoBefore.(*lazyTool); !isLazy {
+		t.Fatalf("pre-Execute echo should be a *lazyTool, got %T", echoBefore)
+	}
+	gotSchema := string(echoBefore.Schema())
+	if !strings.Contains(gotSchema, `"msg"`) || !strings.Contains(gotSchema, `"required"`) {
+		t.Fatalf("cached schema not surfaced through lazyTool.Schema(): %s", gotSchema)
+	}
+
+	// First Execute: cache-hit path runs the handshake synchronously and
+	// forwards to the real tool — the user sees "echo: hi" in this same turn.
+	out, err := echoBefore.Execute(ctx, json.RawMessage(`{"msg":"hi"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out != "echo: hi" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: hi")
+	}
+
+	// The spawn actually happened — host now lists the mock server.
+	names := host.ServerNames()
+	if len(names) != 1 || names[0] != "mock" {
+		t.Fatalf("host.ServerNames() = %v, want [mock]", names)
+	}
+
+	// After Execute, the registry entry must be the real *remoteTool, not the
+	// placeholder. Subsequent calls bypass the state machine and Execute
+	// directly. Compare via type name so this test doesn't need to import the
+	// unexported type by name.
+	echoAfter, _ := reg.Get("mcp__mock__echo")
+	if got := fmt.Sprintf("%T", echoAfter); !strings.Contains(got, "remoteTool") {
+		t.Fatalf("post-Execute echo should be a remoteTool, got %s", got)
+	}
+}
+
+// TestLazyCacheMissAsyncSpawn drives the cache-miss branch: with no cache, a
+// single "connect" placeholder shows up; first Execute returns a retry hint and
+// kicks the spawn async; the real tools surface on the next turn under their
+// real names, and the connect stub is dropped. This is the "model warm-up"
+// contract — the model must not see stale schemas, so we refuse to forward
+// the first call and instead ask for one more turn.
+func TestLazyCacheMissAsyncSpawn(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, nil, host, reg, ctx, false)
+	if len(tools) != 1 {
+		t.Fatalf("cache-miss LazyToolset must return 1 connect stub, got %d", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	connect, ok := reg.Get("mcp__mock__connect")
+	if !ok {
+		t.Fatalf("registry missing mcp__mock__connect; names=%v", reg.Names())
+	}
+
+	// First Execute must NOT forward — schema is unknown, so the model would
+	// be feeding garbage. It returns a retry hint and triggers spawn async.
+	_, err := connect.Execute(ctx, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("first Execute on cache-miss placeholder should error with a retry hint")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "initializing") && !strings.Contains(msg, "next turn") {
+		t.Fatalf("first-Execute error %q should mention 'initializing' or 'next turn'", msg)
+	}
+
+	// Wait for the async spawn to complete (host.Add happens on the run()
+	// goroutine kicked by Execute).
+	waitForServer(t, host, "mock", 5*time.Second)
+
+	// Second Execute on the placeholder triggers trySwap (caught by the
+	// spawnReady branch). The real tools land in the registry under their
+	// real names; the connect stub is dropped.
+	_, _ = connect.Execute(ctx, json.RawMessage(`{}`))
+
+	if _, found := reg.Get("mcp__mock__connect"); found {
+		t.Errorf("connect stub should be removed after swap, names=%v", reg.Names())
+	}
+	if _, found := reg.Get("mcp__mock__echo"); !found {
+		t.Errorf("real mcp__mock__echo missing after swap, names=%v", reg.Names())
+	}
+	if _, found := reg.Get("mcp__mock__zed"); !found {
+		t.Errorf("real mcp__mock__zed missing after swap, names=%v", reg.Names())
+	}
+}
+
+// TestLazyBackgroundKick covers the background-tier path: kick=true plus a
+// cache hit means the spawn races boot, finishes before the model calls, and
+// the first Execute hits the "already-ready, swap on the way through" branch.
+// The model never sees a placeholder schema-wise either, since the cache
+// fed Schema() before kick even started.
+func TestLazyBackgroundKick(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	writeMockCache(t, spec)
+	cs, _ := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, true) // kick=true
+	if len(tools) != 2 {
+		t.Fatalf("LazyToolset(kick=true) returned %d tools, want 2", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	// Wait for the background spawn to complete — proof that kick fired off
+	// the handshake without us calling Execute.
+	waitForServer(t, host, "mock", 5*time.Second)
+
+	// Now Execute: the state is already spawnReady, so this should swap +
+	// forward in one shot without a second Add call. The result must still be
+	// correct.
+	echo, _ := reg.Get("mcp__mock__echo")
+	out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"bg"}`))
+	if err != nil {
+		t.Fatalf("Execute after background ready: %v", err)
+	}
+	if out != "echo: bg" {
+		t.Fatalf("Execute result = %q, want %q", out, "echo: bg")
+	}
+
+	// One spawn, not two — kick + Execute must collapse onto the same run.
+	if names := host.ServerNames(); len(names) != 1 {
+		t.Fatalf("host.ServerNames() = %v, want exactly one 'mock'", names)
+	}
+}
+
+// TestLazyConcurrentExecuteOnlyOneSpawn pins the de-duplication contract: 10
+// goroutines racing through Execute on the same lazyTool may only trigger ONE
+// spawn (and therefore one connected mock server on the host). The state
+// machine's mu+state gate is what makes this true; this test would catch a
+// regression where someone moved the state transition outside the lock or
+// swapped to a TOCTOU check.
+//
+// Note: by design (see lazy.go), only the winner of the race forwards
+// synchronously; the losers observe spawnInFlight and return a "retry next
+// turn" hint rather than blocking. We assert that contract too: at least one
+// goroutine got "echo: r<i>", and the racers that didn't win got the
+// initializing hint — never a spurious error and never a stale or partial
+// result. After all goroutines complete, a fresh Execute hits spawnReady and
+// forwards normally.
+func TestLazyConcurrentExecuteOnlyOneSpawn(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	writeMockCache(t, spec)
+	cs, _ := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+	echo, _ := reg.Get("mcp__mock__echo")
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	results := make([]string, goroutines)
+	errs := make([]error, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			out, err := echo.Execute(ctx, json.RawMessage(fmt.Sprintf(`{"msg":"r%d"}`, i)))
+			results[i], errs[i] = out, err
+		}(i)
+	}
+	wg.Wait()
+
+	// Every result must be either the real "echo: rN" output or the explicit
+	// initializing hint — nothing else. At least one goroutine (the racing
+	// winner) must succeed, otherwise the state machine deadlocked the win.
+	winners := 0
+	for i, err := range errs {
+		want := fmt.Sprintf("echo: r%d", i)
+		switch {
+		case err == nil && results[i] == want:
+			winners++
+		case err != nil && strings.Contains(err.Error(), "initializing"):
+			// expected loser
+		default:
+			t.Errorf("goroutine %d: result=%q err=%v — must be either %q or an 'initializing' hint", i, results[i], err, want)
+		}
+	}
+	if winners == 0 {
+		t.Fatal("no goroutine succeeded — at least the race winner must forward through")
+	}
+
+	// Exactly one Client landed on the host: the mu+state gate kept the 9
+	// losers off the spawn path. This is the headline invariant of the lazy
+	// design — racing the first call must not fork-bomb the subprocess.
+	mockCount := 0
+	for _, n := range host.ServerNames() {
+		if n == "mock" {
+			mockCount++
+		}
+	}
+	if mockCount != 1 {
+		t.Fatalf("expected 1 'mock' server after concurrent Execute, got %d (names=%v)", mockCount, host.ServerNames())
+	}
+
+	// A follow-up Execute (now in spawnReady) goes through cleanly: the
+	// "retry on next turn" hint was honest, not a permanent error.
+	out, err := echo.Execute(ctx, json.RawMessage(`{"msg":"after"}`))
+	if err != nil {
+		t.Fatalf("post-race Execute: %v", err)
+	}
+	if out != "echo: after" {
+		t.Fatalf("post-race Execute = %q, want %q", out, "echo: after")
+	}
+}
+
+// TestLazyHandshakeFailureSurfaced covers the spawnFailed sticky branch: a
+// bogus command can't start, the first Execute returns an error that mentions
+// "failed to start", and a second Execute returns the SAME error (the state
+// machine doesn't retry — we don't want to fork a doomed subprocess every
+// turn until the user fixes config).
+func TestLazyHandshakeFailureSurfaced(t *testing.T) {
+	redirectCache(t)
+	// Bogus command: process exec will fail outright.
+	spec := Spec{Name: "missing", Command: "reasonix-nonexistent-binary-for-lazy-test"}
+
+	// Hand-craft a cache so the cache-HIT branch runs (synchronous spawn,
+	// failure surfaces directly to the first caller rather than via a retry
+	// hint). The SpecHash must match — otherwise LoadCachedSchema would miss
+	// and we'd be exercising the async path.
+	cs := &CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{},
+		Tools: []CachedTool{{
+			Name:        "doit",
+			Description: "noop",
+			Schema:      json.RawMessage(`{"type":"object"}`),
+		}},
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 1 {
+		t.Fatalf("LazyToolset returned %d tools, want 1 (doit)", len(tools))
+	}
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+	doit, _ := reg.Get("mcp__missing__doit")
+
+	_, err1 := doit.Execute(ctx, json.RawMessage(`{}`))
+	if err1 == nil {
+		t.Fatal("Execute on a bogus command should error")
+	}
+	if !strings.Contains(err1.Error(), "failed to start") {
+		t.Fatalf("error %q should mention 'failed to start'", err1.Error())
+	}
+
+	// Second call: same error, no retry. spawnFailed is sticky on purpose —
+	// the operator must fix config and restart, not have us fork-bomb on
+	// every turn.
+	_, err2 := doit.Execute(ctx, json.RawMessage(`{}`))
+	if err2 == nil {
+		t.Fatal("second Execute after spawnFailed should still error")
+	}
+	if !strings.Contains(err2.Error(), "failed to start") {
+		t.Fatalf("second error %q should still mention 'failed to start' (state machine must stay in spawnFailed)", err2.Error())
+	}
+}
+
+// TestLazyToolsetCacheHitSchemaVisible is the model-facing visibility test:
+// immediately after LazyToolset returns and BEFORE any Execute, lazyTool.Schema()
+// must equal the canonicalized cached schema. The whole point of the cache is
+// that the model sees real schemas at turn-start; if Schema() returned the
+// "{}" stub here, the model would call with empty args and the cache-hit
+// path would never get a useful first call.
+func TestLazyToolsetCacheHitSchemaVisible(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+
+	rawSchema := json.RawMessage(`{"properties":{"msg":{"type":"string"}},"type":"object","required":["msg"]}`)
+	cs := &CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{},
+		Tools: []CachedTool{{
+			Name:        "echo",
+			Description: "Echo back.",
+			Schema:      rawSchema,
+		}},
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	if len(tools) != 1 {
+		t.Fatalf("LazyToolset returned %d tools, want 1", len(tools))
+	}
+	got := string(tools[0].Schema())
+	want := string(canonicalizeSchema(rawSchema))
+	if got != want {
+		t.Fatalf("lazyTool.Schema() = %s,\nwant canonicalized cached schema = %s", got, want)
+	}
+
+	// And we never spawned: Schema() must be free, otherwise the cache
+	// optimisation is moot.
+	if names := host.ServerNames(); len(names) != 0 {
+		t.Fatalf("Schema() must not spawn; host.ServerNames() = %v", names)
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -736,7 +736,12 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 // matching Claude Code. Spaces in either part are normalised to underscores so
 // the name is a clean identifier the model can call.
 func toolName(server, raw string) string {
-	return "mcp__" + normalizeName(server) + "__" + normalizeName(raw)
+	return ToolPrefix(server) + normalizeName(raw)
+}
+
+// ToolPrefix is the model-visible namespace prefix for every tool from server.
+func ToolPrefix(server string) string {
+	return "mcp__" + normalizeName(server) + "__"
 }
 
 var invalidNameChars = regexp.MustCompile(`[^a-zA-Z0-9_-]+`)

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"sort"
 	"strings"
+	"sync"
 
 	"reasonix/internal/diff"
 	"reasonix/internal/provider"
@@ -97,6 +98,7 @@ func LookupBuiltin(name string) (Tool, bool) {
 
 // Registry is a per-run set of tools: enabled built-ins plus plugin tools.
 type Registry struct {
+	mu    sync.RWMutex
 	tools map[string]Tool
 	order []string
 }
@@ -108,6 +110,9 @@ func NewRegistry() *Registry {
 
 // Add inserts (or replaces) a tool, preserving first-seen order.
 func (r *Registry) Add(t Tool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	name := t.Name()
 	if _, ok := r.tools[name]; !ok {
 		r.order = append(r.order, name)
@@ -138,6 +143,9 @@ func SplitMCPName(name string) (server, tool string, ok bool) {
 // drop an MCP server's "mcp__<server>__" namespace when it's disconnected — and
 // returns the count removed.
 func (r *Registry) RemovePrefix(prefix string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	kept := r.order[:0]
 	removed := 0
 	for _, name := range r.order {
@@ -154,15 +162,26 @@ func (r *Registry) RemovePrefix(prefix string) int {
 
 // Get looks up a tool by name.
 func (r *Registry) Get(name string) (Tool, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	t, ok := r.tools[name]
 	return t, ok
 }
 
 // Len returns the number of registered tools.
-func (r *Registry) Len() int { return len(r.order) }
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.order)
+}
 
 // Names returns the registered tool names in insertion order.
 func (r *Registry) Names() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	out := make([]string, len(r.order))
 	copy(out, r.order)
 	return out
@@ -170,11 +189,20 @@ func (r *Registry) Names() []string {
 
 // Schemas exports tool definitions in stable name order for the provider.
 func (r *Registry) Schemas() []provider.ToolSchema {
-	names := r.Names()
+	r.mu.RLock()
+	names := make([]string, len(r.order))
+	copy(names, r.order)
 	sort.Strings(names)
-	out := make([]provider.ToolSchema, 0, len(names))
+	tools := make([]Tool, 0, len(names))
 	for _, name := range names {
-		t := r.tools[name]
+		if t := r.tools[name]; t != nil {
+			tools = append(tools, t)
+		}
+	}
+	r.mu.RUnlock()
+
+	out := make([]provider.ToolSchema, 0, len(tools))
+	for _, t := range tools {
 		out = append(out, provider.ToolSchema{
 			Name:        t.Name(),
 			Description: t.Description(),

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -34,8 +34,6 @@ default     = "deepseek-v4-flash"   # optional; defaults to the first of `models
 api_key_env = "DEEPSEEK_API_KEY"
 context_window = 1000000
 price       = { cache_hit = 0.02, input = 1, output = 2, currency = "¥" }   # per 1M tokens
-# DeepSeek thinking mode is enabled by default; effort: high | max | off.
-effort      = "high"
 
 # A single-model provider still works (use `model = "..."`) — pick this form when a
 # model needs its own base_url / context_window / price (e.g. the two MiMo SKUs
@@ -117,3 +115,11 @@ enabled = []   # empty = all built-in tools
 # [[plugins]]
 # name    = "example"
 # command = "reasonix-plugin-example"
+# tier    = "lazy"  # eager | lazy (default) | background
+# # tier guidance:
+# #   eager      — handshake at boot; the agent waits. Use when the plugin's
+# #                tools must be in the very first turn's system prompt.
+# #   lazy       — placeholder tools (from cached schema, when present) until
+# #                the model uses them, then handshake on-demand. Default.
+# #   background — placeholder + spawn at boot in a goroutine so an idle
+# #                session warms up without blocking the user.


### PR DESCRIPTION
The PR4 layer of the MCP-startup overhaul (#2682 by @SivanCola), rebased onto current main-v2. The lower stack already merged — PR1 #2675, PR2 #2701, PR3 #2703 — so this carries only the final tier layer (the original #2682 branch still bundled stale copies of PR2/PR3, which is why it showed as conflicting).

## What it adds

`PluginEntry.Tier` (`eager` | `lazy` | `background`, **default lazy**) so users opt into which MCP servers block boot:
- **eager** — blocks startup until handshake; for servers whose tools the system prompt depends on. `codegraph` is pinned eager in code.
- **lazy** (default) — registers placeholder tools immediately (from the on-disk schema cache when present) and spawns the real subprocess on first model use. On a cache hit the placeholder `Schema()` returns the same canonicalized bytes the live tool would, so the swap is invisible to the prompt cache.
- **background** — placeholder + spawn kicked at boot, swap on completion.

Auto-demote: an eager plugin whose recent startups repeatedly blew past 2×budget drops to lazy for the session (config intent unchanged; self-heals when the plugin recovers).

## Behaviour change

Default tier is **lazy**: auxiliary MCP servers no longer slow cold starts. First-ever use of a server with no cache yet costs one `connect` + retry-next-turn round trip; subsequent launches are warm. `tier = "eager"` restores the old per-plugin behaviour; `reasonix.example.toml` documents the trade-off.

## Verification (rebased branch, run locally)

- `go build ./...`, `go vet` (plugin/boot/control/config/tool) — clean
- `go test ./...` — exit 0
- `go test -count=20` on the lazy/tier/swap/demote tests — stable
- Prompt-cache contract: `TestLazyToolsetCacheHitSchemaVisible`, `TestLazyCacheHitSyncSpawn`, `TestCanonicalize*` — all pass (proves the placeholder→real swap doesn't perturb the cached prefix)
- `-race` runs in CI (the new race job)

Closes #2682