### PR TITLE
fix(jobs): mark a killed job Killed synchronously

### DIFF
--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -206,6 +206,15 @@ func (m *Manager) Kill(id string) bool {
 	}
 	j.mu.Lock()
 	running := j.status == Running
+	if running {
+		// Flip to Killed synchronously so Output/Wait reflect the kill the instant
+		// it's requested, not whenever the run goroutine's cmd.Run returns (which
+		// trails by WaitDelay while a cancelled process tree tears down). The
+		// goroutine still sets Killed + records completion on return; this only
+		// fires when the job is actually Running, so a job that just finished
+		// keeps its real terminal status.
+		j.status = Killed
+	}
 	j.mu.Unlock()
 	if !running {
 		return false

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -98,6 +98,38 @@ func TestKill(t *testing.T) {
 	}
 }
 
+// Killed status is observable as soon as Kill returns, before the run goroutine
+// unwinds — otherwise a slow cancelled process tree (Windows taskkill + WaitDelay
+// drain) leaves Wait reporting Running until the goroutine finally returns, which
+// is the TestBackgroundKill flake. The job here stays blocked past ctx.Done.
+func TestKillStatusObservableBeforeGoroutineReturns(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	release := make(chan struct{})
+	j := m.Start("bash", "", func(ctx context.Context, _ io.Writer) (string, error) {
+		<-ctx.Done()
+		<-release // simulate a teardown that hasn't returned yet
+		return "", ctx.Err()
+	})
+	if !m.Kill(j.ID) {
+		t.Fatal("Kill on a running job returned false")
+	}
+
+	// Short timeout: the goroutine is still blocked, so Wait can only know the
+	// status if Kill set it synchronously.
+	res := m.Wait(context.Background(), []string{j.ID}, 1)
+	if len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("want Killed before the goroutine returns, got %+v", res)
+	}
+	if n := len(m.Running()); n != 0 {
+		t.Fatalf("a killed job should not still be Running(), got %d", n)
+	}
+
+	close(release)
+	m.Wait(context.Background(), []string{j.ID}, 5)
+}
+
 // Close cancels every still-running job.
 func TestCloseCancels(t *testing.T) {
 	m := NewManager(event.Discard)


### PR DESCRIPTION
Fixes the `TestBackgroundKill` flake on the windows-latest runner (and the user-visible lag behind it).

`Manager.Kill` only cancelled the job context; the status flipped to `Killed` later, when the run goroutine's `cmd.Run` returned. On Windows a cancelled process tree (`taskkill /F /T` + `WaitDelay` I/O drain) can take seconds to unwind, so `Wait` kept reporting `Running` until the goroutine finally returned — intermittently past the test's timeout, and a real lag for anyone scripting kill_shell + status.

Set `status = Killed` under the lock inside `Kill` (only when the job is still Running, so a job that just finished keeps its real terminal status). The run goroutine still sets Killed and records completion on return; the recordCompletion → close(done) ordering is untouched, so the drain-note invariant holds.

Added `TestKillStatusObservableBeforeGoroutineReturns` — a job that stays blocked past ctx cancellation; Wait with a short timeout must still see Killed. Verified it FAILS without the fix (reports Running, the exact flake symptom) and passes with it. jobs ×50 and TestBackgroundKill ×30 green locally.