### PR TITLE
fix(cli): copy via OSC 52 when the platform clipboard tool fails (tmux/SSH)

### DIFF
--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -22,10 +22,22 @@ func wrapTranscript(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }
 
-// copyToClipboard writes text to the system clipboard off the event loop.
+// clipboardWriteAll is the platform clipboard writer; a var so tests can force
+// the failure path (the tmux / SSH scenario) without a real display server.
+var clipboardWriteAll = clipboard.WriteAll
+
+// copyToClipboard writes text to the system clipboard. It first tries the
+// platform tool (xclip / xsel / wl-copy / pbcopy) via atotto; when that fails —
+// typically inside tmux or over SSH where the display server is unreachable — it
+// falls back to OSC 52, which tmux and modern terminals forward to the host
+// clipboard. tea.SetClipboard's command is *run* here so the message it yields
+// (handled by the runtime) reaches the event loop; returning the command itself
+// would be dropped as an unrecognized message and emit nothing.
 func copyToClipboard(text string) tea.Cmd {
 	return func() tea.Msg {
-		_ = clipboard.WriteAll(text)
+		if err := clipboardWriteAll(text); err != nil {
+			return tea.SetClipboard(text)()
+		}
 		return nil
 	}
 }

--- a/internal/cli/transcript_test.go
+++ b/internal/cli/transcript_test.go
@@ -1,6 +1,12 @@
 package cli
 
-import "testing"
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
 
 func TestScrollbarThumb(t *testing.T) {
 	if _, size := scrollbarThumb(10, 0, 5); size != 0 {
@@ -61,5 +67,32 @@ func TestSelectedTextMultiLine(t *testing.T) {
 	m.sel = selection{active: true, anchor: selPos{line: 0, col: 3}, head: selPos{line: 0, col: 3}}
 	if got := m.selectedText(); got != "" {
 		t.Errorf("empty selection should yield no text, got %q", got)
+	}
+}
+
+func TestCopyToClipboardPlatformSuccess(t *testing.T) {
+	defer func(fn func(string) error) { clipboardWriteAll = fn }(clipboardWriteAll)
+	var got string
+	clipboardWriteAll = func(s string) error { got = s; return nil }
+
+	if msg := copyToClipboard("hello")(); msg != nil {
+		t.Errorf("platform write succeeded; want nil msg (no OSC 52 fallback), got %#v", msg)
+	}
+	if got != "hello" {
+		t.Errorf("clipboardWriteAll got %q, want %q", got, "hello")
+	}
+}
+
+func TestCopyToClipboardOSC52Fallback(t *testing.T) {
+	defer func(fn func(string) error) { clipboardWriteAll = fn }(clipboardWriteAll)
+	clipboardWriteAll = func(string) error { return errors.New("no display (tmux/ssh)") }
+
+	// On failure the command must return the *message* tea.SetClipboard yields —
+	// the runtime handles it by emitting OSC 52 (bubbletea tea.go: setClipboardMsg
+	// -> ansi.SetSystemClipboard). Returning the command itself would be dropped.
+	got := copyToClipboard("copied text")()
+	want := tea.SetClipboard("copied text")()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("fallback msg = %#v (%T), want the runtime-handled setClipboardMsg %#v (%T)", got, got, want, want)
 	}
 }


### PR DESCRIPTION
Closes #2716. Supersedes #2717 (same root cause + direction — credit to @lanshi17 for the diagnosis — but its fallback never actually emitted OSC 52; see below).

## Root cause
`copyToClipboard` discarded the atotto error (`_ = clipboard.WriteAll`). Inside tmux / over SSH, xclip/xsel/wl-copy can't reach the display server, so the copy silently failed.

## Fix
On atotto failure, fall back to OSC 52 (tmux + modern terminals forward it to the host clipboard) via bubbletea v2's built-in `tea.SetClipboard`.

The subtlety that #2717 missed: the fallback must return `tea.SetClipboard(text)()` — the **message**, executed here — not `tea.SetClipboard(text)`/`tea.Printf(...)` (a command). A `tea.Cmd` returned as a `tea.Msg` matches no case in the runtime's dispatch (tea.go event loop) nor in the model's Update, so it's silently dropped and emits nothing. The message (`setClipboardMsg`) is handled by the runtime at tea.go (`p.execute(ansi.SetSystemClipboard(...))`), which writes the escape to the terminal.

## Verification
- Unit: `TestCopyToClipboardPlatformSuccess` (success → nil, no fallback) and `TestCopyToClipboardOSC52Fallback` (failure → msg `reflect.DeepEqual` to `tea.SetClipboard(text)()`, i.e. the runtime-handled message, not a dropped command).
- End-to-end: ran a real `tea.Program` with output captured to a buffer; `tea.SetClipboard("foo")` produces `\x1b]52;c;Zm9v…` (OSC 52 + base64) in the terminal output. The #2717 form produced nothing (the command was dropped) — confirmed by type: `tea.Printf(...)` is a `tea.Cmd`, `tea.SetClipboard(x)()` is the handled `setClipboardMsg`.
- Kept #2717's `clipboardWriteAll` var seam for testing the failure path without a display server. Full `go test ./internal/cli` green.