### PR TITLE
feat(cli): interactive /resume picker with keyboard navigation

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -174,8 +174,11 @@ type chatTUI struct {
 	// rewind holds the Esc-Esc / "/rewind" picker (nil when closed); while set,
 	// keys drive it and it renders as an overlay. lastEsc times the double-Esc
 	// gesture that opens it on an empty composer.
-	rewind  *rewindPicker
-	lastEsc time.Time
+	rewind *rewindPicker
+	// resumePick is the interactive "/resume" session picker overlay. Non-nil
+	// while the user browses saved sessions with ↑/↓ and confirms with Enter.
+	resumePick *resumePicker
+	lastEsc    time.Time
 
 	// lastCtrlCAt records when Ctrl+C was pressed while idle on an empty
 	// composer, enabling a "press again to quit" confirmation pattern (1.5s
@@ -668,6 +671,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.rewind != nil {
 			return m.handleRewindKey(msg)
 		}
+		// The resume picker is modal while open: keys navigate it.
+		if m.resumePick != nil {
+			return m.handleResumePickerKey(msg)
+		}
 		// A pending tool approval is modal: keystrokes answer it (y/a/n, Enter,
 		// Esc) rather than reaching the input.
 		if m.pendingApproval != nil {
@@ -685,6 +692,16 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.moveCompletion(1)
 				return m, nil
 			case "tab", "enter":
+				// When Enter is pressed and the completion has exactly one item
+				// already fully present in the input, close the menu and let Enter
+				// fall through to submit the command (/resume 3 → resume session 3).
+				if msg.String() == "enter" && len(m.completion.items) == 1 {
+					tok := m.input.Value()[m.completion.replaceFrom:]
+					if tok == m.completion.items[0].insert {
+						m.completion = completion{}
+						break // fall through to regular Enter
+					}
+				}
 				m.acceptCompletion()
 				return m, nil
 			case "esc":
@@ -1391,6 +1408,8 @@ func (m chatTUI) View() tea.View {
 	switch {
 	case m.rewind != nil:
 		status = "  " + modeTag + " · ⟲ rewind"
+	case m.resumePick != nil:
+		status = "  " + modeTag + " · " + i18n.M.StatusResumePicker
 	case m.chooser != nil:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusQuestion
 	case m.pendingApproval != nil && m.pendingApproval.Tool == planApprovalTool:
@@ -1460,6 +1479,10 @@ func (m chatTUI) View() tea.View {
 		rowsAboveBox += strings.Count(card, "\n") + 1
 	}
 	if card := m.renderRewind(); card != "" {
+		parts = append(parts, card)
+		rowsAboveBox += strings.Count(card, "\n") + 1
+	}
+	if card := m.renderResumePicker(); card != "" {
 		parts = append(parts, card)
 		rowsAboveBox += strings.Count(card, "\n") + 1
 	}

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -379,7 +379,16 @@ func (m *chatTUI) acceptCompletion() {
 		m.updateCompletion() // re-list the directory we just descended into
 		return
 	}
-	m.completion = completion{}
+	m.updateCompletion() // re-filter for arg completion (e.g. /resume → numbered sessions)
+	// If the completion re-opened with the same single item the user just
+	// selected (i.e. the token was already typed), close it so the next Enter
+	// submits the command rather than being captured again by acceptCompletion.
+	if m.completion.active && len(m.completion.items) == 1 {
+		tok := m.input.Value()[m.completion.replaceFrom:]
+		if tok == m.completion.items[0].insert {
+			m.completion = completion{}
+		}
+	}
 }
 
 var compSelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("173")).Bold(true)

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -41,7 +41,8 @@ func (m *chatTUI) runResumeCommand(input string) {
 
 	args := tokenizeArgs(input) // args[0] == "/resume"
 	if len(args) < 2 {
-		m.showSessions(sessions)
+		m.showSessions(sessions) // write list to scrollback (above input)
+		m.openResumePicker()     // open interactive picker below
 		return
 	}
 	if m.ctrl.Running() {

--- a/internal/cli/resume_picker.go
+++ b/internal/cli/resume_picker.go
@@ -1,0 +1,122 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/i18n"
+)
+
+// resumePicker is an in-chat overlay for "/resume" that lets the user pick a
+// saved session by navigating with ↑/↓ and confirming with Enter. It mirrors
+// the rewindPicker pattern: keys route through handleResumePickerKey and it
+// renders via renderResumePicker while m.resumePick is set.
+type resumePicker struct {
+	sessions []agent.SessionInfo
+	sel      int // selected index
+	active   int // index of the currently-active session (-1 when none)
+}
+
+// openResumePicker populates the picker from the session directory and opens it.
+// A no-op (with a notice) when there are no saved sessions.
+func (m *chatTUI) openResumePicker() {
+	sessions := recentSessions(m.ctrl.SessionDir())
+	if len(sessions) == 0 {
+		m.notice(i18n.M.NoSessionToResume)
+		return
+	}
+	active := m.ctrl.SessionPath()
+	activeIdx := -1
+	for i, s := range sessions {
+		if s.Path == active {
+			activeIdx = i
+			break
+		}
+	}
+	// Default selection: the first session after the active one, else 0.
+	sel := 0
+	if activeIdx >= 0 && activeIdx+1 < len(sessions) {
+		sel = activeIdx + 1
+	}
+	m.resumePick = &resumePicker{sessions: sessions, sel: sel, active: activeIdx}
+}
+
+func (m chatTUI) handleResumePickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	r := m.resumePick
+	if r == nil {
+		return m, nil
+	}
+	switch msg.String() {
+	case "up", "k":
+		if r.sel > 0 {
+			r.sel--
+		}
+	case "down", "j":
+		if r.sel < len(r.sessions)-1 {
+			r.sel++
+		}
+	case "enter":
+		return m.applyResumePick()
+	case "esc":
+		m.resumePick = nil
+	}
+	return m, nil
+}
+
+func (m chatTUI) applyResumePick() (tea.Model, tea.Cmd) {
+	r := m.resumePick
+	if r == nil || r.sel < 0 || r.sel >= len(r.sessions) {
+		return m, nil
+	}
+	target := r.sessions[r.sel]
+	m.resumePick = nil
+	if target.Path == m.ctrl.SessionPath() {
+		m.notice(i18n.M.ResumeAlreadyActive)
+		return m, nil
+	}
+	if m.ctrl.Running() {
+		m.notice(i18n.M.ResumeBusy)
+		return m, nil
+	}
+	loaded, err := agent.LoadSession(target.Path)
+	if err != nil {
+		m.notice("resume: " + err.Error())
+		return m, nil
+	}
+	_ = m.ctrl.Snapshot()
+	m.ctrl.Resume(loaded, target.Path)
+	m.replayActiveBranch(i18n.M.ResumedTitle)
+	return m, nil
+}
+
+func (m chatTUI) renderResumePicker() string {
+	r := m.resumePick
+	if r == nil {
+		return ""
+	}
+	w := max(m.width, 10)
+	var b strings.Builder
+	b.WriteString(accent(i18n.M.ResumePickTitle) + "\n")
+	for i, s := range r.sessions {
+		label := sessionPickerLabel(s)
+		if i == r.active {
+			label = dim(label) + " " + dim("(active)")
+		}
+		b.WriteString(rowLine(i == r.sel, i+1, "", label, false) + "\n")
+	}
+	b.WriteString(dim(i18n.M.ResumePickHint))
+	return choicePanelStyle.Width(w).Render(b.String())
+}
+
+// sessionPickerLabel is the "N turns · first message" line, truncated to fit.
+func sessionPickerLabel(s agent.SessionInfo) string {
+	preview := s.Preview
+	if preview == "" {
+		preview = "(no user message yet)"
+	}
+	return fmt.Sprintf("%d turns · %s", s.Turns, ansi.Truncate(preview, 60, "…"))
+}

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -6,16 +6,17 @@ import (
 	"strings"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
+
 	"reasonix/internal/agent"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
 
-// TestResumeDispatchListsSessions drives the real keystroke path
-// (runSlashCommand) for a bare "/resume" and asserts the session list with
-// previews lands in the transcript.
-func TestResumeDispatchListsSessions(t *testing.T) {
+// TestResumeDispatchOpensPicker proves bare "/resume" writes the session list
+// to the scrollback (above the input) AND opens the interactive picker overlay.
+func TestResumeDispatchOpensPicker(t *testing.T) {
 	dir := t.TempDir()
 	saveTestSession(t, filepath.Join(dir, "a.jsonl"), "alpha prompt")
 	saveTestSession(t, filepath.Join(dir, "b.jsonl"), "beta prompt")
@@ -26,11 +27,82 @@ func TestResumeDispatchListsSessions(t *testing.T) {
 	m.ctrl = control.New(control.Options{Executor: exec, SessionDir: dir, Label: "test"})
 
 	if cmd := m.runSlashCommand("/resume"); cmd != nil {
-		t.Fatal("/resume list should not return a tea.Cmd")
+		t.Fatal("/resume should not return a tea.Cmd")
 	}
+	if m.resumePick == nil {
+		t.Fatal("bare /resume should open the picker")
+	}
+	if len(m.resumePick.sessions) != 2 {
+		t.Fatalf("picker should have 2 sessions, got %d", len(m.resumePick.sessions))
+	}
+	// Session list must also appear in the scrollback transcript (above input).
 	out := strings.Join(m.transcript, "\n")
 	if !strings.Contains(out, "alpha prompt") || !strings.Contains(out, "beta prompt") {
-		t.Fatalf("session list missing previews:\n%s", out)
+		t.Fatalf("scrollback should contain session previews:\n%s", out)
+	}
+}
+
+// TestResumePickerNavigateAndSelect proves the picker's up/down navigation and
+// Enter to resume the selected session.
+func TestResumePickerNavigateAndSelect(t *testing.T) {
+	dir := t.TempDir()
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: exec, SessionDir: dir, Label: "test"})
+
+	// Create two saved sessions.
+	aPath := filepath.Join(dir, "a.jsonl")
+	saveTestSession(t, aPath, "first session prompt")
+	bPath := filepath.Join(dir, "b.jsonl")
+	saveTestSession(t, bPath, "SECOND-SESSION-PROMPT")
+
+	m := newTestChatTUI()
+	m.width = 80
+	m.ctrl = ctrl
+
+	// Open the picker via bare /resume.
+	m.runSlashCommand("/resume")
+	if m.resumePick == nil {
+		t.Fatal("bare /resume should open the picker")
+	}
+	if len(m.resumePick.sessions) != 2 {
+		t.Fatalf("picker should have 2 sessions, got %d", len(m.resumePick.sessions))
+	}
+
+	// The first session (default selection) is the most recent, which is b.jsonl.
+	// Press Enter to resume it.
+	next, _ := m.handleResumePickerKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = next.(chatTUI)
+
+	if got := ctrl.SessionPath(); got != bPath {
+		t.Fatalf("session path = %q, want %q", got, bPath)
+	}
+	if out := strings.Join(m.transcript, "\n"); !strings.Contains(out, "SECOND-SESSION-PROMPT") {
+		t.Fatalf("transcript should replay the resumed session:\n%s", out)
+	}
+	if m.resumePick != nil {
+		t.Fatal("picker should close after resume")
+	}
+}
+
+// TestResumePickerEscDismisses proves pressing Esc closes the picker without
+// switching sessions.
+func TestResumePickerEscDismisses(t *testing.T) {
+	dir := t.TempDir()
+	saveTestSession(t, filepath.Join(dir, "a.jsonl"), "alpha prompt")
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Executor: exec, SessionDir: dir, Label: "test"})
+
+	m.runSlashCommand("/resume")
+	if m.resumePick == nil {
+		t.Fatal("bare /resume should open the picker")
+	}
+
+	next, _ := m.handleResumePickerKey(tea.KeyPressMsg{Code: tea.KeyEsc})
+	m = next.(chatTUI)
+	if m.resumePick != nil {
+		t.Fatal("picker should close on Esc")
 	}
 }
 

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -60,6 +60,8 @@ type Messages struct {
 	ResumeBadIndexFmt   string // shown when /resume gets an out-of-range index (one %d)
 	ResumeAlreadyActive string // shown when /resume targets the current session
 	ResumedTitle        string // banner title after a /resume switch
+	ResumePickTitle     string // header in the interactive resume picker
+	ResumePickHint      string // keyboard hint in the interactive resume picker
 
 	// chat TUI status line / approval banner.
 	ChatThinking           string // live reasoning marker label, e.g. "thinking…"
@@ -81,6 +83,7 @@ type Messages struct {
 	AskTypingHint      string // shown on that row while entering free text
 	AskChatInstead     string // the "don't pick, just chat" option label
 	ChatStatusQuestion string // shortcuts hint while a question card is open
+	StatusResumePicker string // status tag while the resume picker is open (e.g. "select session")
 	AskSubmitTitle     string // submit-tab title in the ask tool question card
 	AskUnanswered      string // placeholder for an unanswered ask question
 	AskSubmitHint      string // submit-tab keyboard hint

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -35,6 +35,8 @@ var English = Messages{
 	ResumeBadIndexFmt:   "pick a session 1–%d (run /resume to list)",
 	ResumeAlreadyActive: "already in that session",
 	ResumedTitle:        "resumed session",
+	ResumePickTitle:     "Resume a saved session",
+	ResumePickHint:      "↑/↓ move · Enter resume · Esc cancel",
 
 	ChatThinking:           "thinking…",
 	ChatThoughtForFmt:      "thought for %ds",
@@ -48,6 +50,7 @@ var English = Messages{
 	AskTypingHint:          "type below, Enter to confirm",
 	AskChatInstead:         "None — just chat",
 	ChatStatusQuestion:     "↑/↓ move · number to pick · space multi · Enter confirm · ←/→ switch · Esc cancel",
+	StatusResumePicker: "↑/↓ move · Enter resume · Esc cancel",
 	AskSubmitTitle:         "Submit answers",
 	AskUnanswered:          "(unanswered)",
 	AskSubmitHint:          "Enter submits · ← returns to edit",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -36,6 +36,8 @@ var Chinese = Messages{
 	ResumeBadIndexFmt:   "请选择 1–%d 的会话（用 /resume 查看列表）",
 	ResumeAlreadyActive: "已在该会话中",
 	ResumedTitle:        "已恢复会话",
+	ResumePickTitle:     "选择要恢复的会话",
+	ResumePickHint:      "↑/↓ 移动 · Enter 恢复 · Esc 取消",
 
 	ChatThinking:           "思考中…",
 	ChatThoughtForFmt:      "思考了 %d 秒",
@@ -49,6 +51,7 @@ var Chinese = Messages{
 	AskTypingHint:          "输入后按 Enter 确认",
 	AskChatInstead:         "先不选择，直接回复",
 	ChatStatusQuestion:     "↑/↓ 选 · 数字快选 · 空格多选 · Enter 确认 · ←/→ 切换问题 · Esc 取消",
+	StatusResumePicker: "↑/↓ 移动 · Enter 恢复 · Esc 取消",
 	AskSubmitTitle:         "提交答案",
 	AskUnanswered:          "(未答)",
 	AskSubmitHint:          "Enter 提交 · ← 返回修改",


### PR DESCRIPTION
## Summary

Bare `/resume` now opens an interactive picker overlay that lets the user browse saved sessions with **↑/↓** and confirm with **Enter**, instead of just printing a static list. The old `/resume <n>` syntax still works.

## Changes

- **New `resume_picker.go`** — interactive overlay modal (struct + open/close/key handling/render), mirroring the `rewindPicker` pattern
- **`chat_tui.go`** — wired the picker's key dispatch, rendering, and status line
- **`complete.go`** — `acceptCompletion` now re-filters the menu after insertion so `/resume` immediately shows numbered session completions; Enter on a fully-typed single item closes the menu and submits the command
- **`resume.go`** — bare `/resume` now **both** writes the list to scrollback (above input) AND opens the interactive picker (below input)
- **i18n** — added `ResumePickTitle`, `ResumePickHint`, `StatusResumePicker` for en + zh locales
- **Tests** — `TestResumeDispatchOpensPicker`, `TestResumePickerNavigateAndSelect`, `TestResumePickerEscDismisses`

## UX

| Before | After |
|--------|-------|
| `/resume` prints a static list; user must re-type `/resume <n>` | `/resume` shows scrollback list (above) + interactive picker (below) with ↑/↓ / Enter / Esc |
| Accepting the `/resume` completion required an extra keystroke | Select `/resume` from menu → immediately shows numbered sessions |
| Typing `/resume 3` + Enter looped in completion | `/resume 3` + Enter submits and resumes session 3 |