### PR TITLE
fix(tools): skip macOS TCC-protected dirs in recursive glob/grep walks

### DIFF
--- a/internal/tool/builtin/gitignore.go
+++ b/internal/tool/builtin/gitignore.go
@@ -91,7 +91,7 @@ func (ig *walkIgnorer) skip(path, name string, isDir bool) bool {
 	if isHiddenName(name) {
 		return true
 	}
-	if isDir && vendorDirs[name] {
+	if isDir && (vendorDirs[name] || isProtectedDir(abs)) {
 		return true
 	}
 	return ig.ignored(abs, isDir)

--- a/internal/tool/builtin/protected_dirs_darwin.go
+++ b/internal/tool/builtin/protected_dirs_darwin.go
@@ -1,0 +1,23 @@
+package builtin
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// macOS TCC-protected user dirs: an opendir trips a privacy consent prompt
+// ("wants to access Apple Music / media library"), so recursive glob/grep prune
+// them. Matched by absolute path, not basename, so a project's own dir is safe.
+var protectedDirs = func() map[string]bool {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return nil
+	}
+	m := make(map[string]bool, 4)
+	for _, d := range []string{"Music", "Pictures", "Movies", "Library"} {
+		m[filepath.Clean(filepath.Join(home, d))] = true
+	}
+	return m
+}()
+
+func isProtectedDir(abs string) bool { return protectedDirs[abs] }

--- a/internal/tool/builtin/protected_dirs_darwin_test.go
+++ b/internal/tool/builtin/protected_dirs_darwin_test.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package builtin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProtectedDirsArePruned(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("no home dir")
+	}
+	for _, name := range []string{"Music", "Pictures", "Movies", "Library"} {
+		abs := filepath.Join(home, name)
+		if !isProtectedDir(abs) {
+			t.Errorf("isProtectedDir(%q) = false, want true", abs)
+		}
+		if skipWalkDir(home, abs, name) != true {
+			t.Errorf("skipWalkDir did not prune protected %q", abs)
+		}
+	}
+}
+
+func TestProtectedMatchIsByAbsPathNotBasename(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("no home dir")
+	}
+	root := filepath.Join(home, "code", "proj")
+	projMusic := filepath.Join(root, "Music")
+	if isProtectedDir(projMusic) {
+		t.Errorf("a project's own Music dir %q must not be protected", projMusic)
+	}
+	if skipWalkDir(root, projMusic, "Music") {
+		t.Errorf("skipWalkDir wrongly pruned a project dir named Music")
+	}
+}
+
+func TestProtectedRootItselfIsNotPruned(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		t.Skip("no home dir")
+	}
+	music := filepath.Join(home, "Music")
+	if skipWalkDir(music, music, "Music") {
+		t.Error("explicitly targeting ~/Music as the walk root must not be pruned")
+	}
+}

--- a/internal/tool/builtin/protected_dirs_other.go
+++ b/internal/tool/builtin/protected_dirs_other.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package builtin
+
+func isProtectedDir(string) bool { return false }

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -101,5 +101,8 @@ var vendorDirs = map[string]bool{
 // rooted at root. The root itself is never pruned, so explicitly targeting a
 // vendor dir still works.
 func skipWalkDir(root, path, name string) bool {
-	return path != root && vendorDirs[name]
+	if path == root {
+		return false
+	}
+	return vendorDirs[name] || isProtectedDir(absClean(path))
 }


### PR DESCRIPTION
## What

Recursive `glob`/`grep` walk into macOS TCC-protected user directories — `~/Music`, `~/Pictures`, `~/Movies`, `~/Library` — trips a privacy consent prompt ("reasonix-desktop wants to access Apple Music / your media library") on a plain `opendir`, before a single byte is read. The desktop process pops it mid-search whenever a walk root's subtree includes one of these dirs.

## Fix

Prune those paths from both walkers:

- New `protected_dirs_darwin.go` builds the protected set once from `$HOME`; `protected_dirs_other.go` is a no-op stub on every other OS (zero overhead, no `runtime.GOOS` branches in the hot path).
- Matched by **absolute path**, not basename, so a project's own `Music`/`Library` directory is still searched.
- Walk root is exempt, so explicitly pointing grep at `~/Music` still works — same rule as the existing vendor-dir pruning.

## Test

`protected_dirs_darwin_test.go` (darwin-gated) covers: the four dirs are pruned, matching is by abs path (a project `Music` dir is not), and the root itself is never pruned. `glob`/`grep`/walk suites stay green; `GOOS=darwin` build + test compile verified.