### PR TITLE
test(bash): widen cancel/kill timing margins to stop load flakes

### DIFF
--- a/internal/tool/builtin/bash_cancel_test.go
+++ b/internal/tool/builtin/bash_cancel_test.go
@@ -17,9 +17,9 @@ func TestBashCancelReturnsPromptly(t *testing.T) {
 	if !ok {
 		t.Fatal("bash not registered")
 	}
-	cmd := "sleep 30"
+	cmd := "sleep 120"
 	if sandbox.ResolveShell().Kind == sandbox.ShellPowerShell {
-		cmd = "Start-Sleep -Seconds 30"
+		cmd = "Start-Sleep -Seconds 120"
 	}
 	args, _ := json.Marshal(map[string]any{"command": cmd})
 
@@ -27,16 +27,26 @@ func TestBashCancelReturnsPromptly(t *testing.T) {
 	go func() { time.Sleep(300 * time.Millisecond); cancel() }()
 
 	start := time.Now()
-	_, err := bt.Execute(ctx, args)
+	done := make(chan error, 1)
+	go func() {
+		_, err := bt.Execute(ctx, args)
+		done <- err
+	}()
+
+	// The kill must land well before the 120s natural duration; the generous
+	// watchdog only trips when the cancel path is actually broken, so a loaded
+	// machine's slow process-tree teardown doesn't flake the test.
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(40 * time.Second):
+		t.Fatalf("cancel did not interrupt bash within 40s (natural duration 120s)")
+	}
 	elapsed := time.Since(start)
 
-	// Must have run until the cancel (≥ ~300ms) — not failed instantly — yet stop
-	// well before the 30s natural duration.
+	// Must have run until the cancel (≥ ~300ms) — not failed instantly.
 	if elapsed < 250*time.Millisecond {
 		t.Fatalf("command exited too fast (%v) — it didn't actually run; err=%v", elapsed, err)
-	}
-	if elapsed > 10*time.Second {
-		t.Fatalf("cancel did not interrupt bash: took %v (want < 10s vs 30s natural)", elapsed)
 	}
 	if err == nil {
 		t.Error("expected an error after cancel, got nil")

--- a/internal/tool/builtin/bgjobs_test.go
+++ b/internal/tool/builtin/bgjobs_test.go
@@ -57,7 +57,7 @@ func TestBackgroundKill(t *testing.T) {
 	defer m.Close()
 	ctx := jobs.WithManager(context.Background(), m)
 
-	if _, err := (bash{}).Execute(ctx, []byte(`{"command":"sleep 10","run_in_background":true}`)); err != nil {
+	if _, err := (bash{}).Execute(ctx, []byte(`{"command":"sleep 120","run_in_background":true}`)); err != nil {
 		t.Fatalf("bash background: %v", err)
 	}
 	id := m.Running()[0].ID
@@ -69,9 +69,12 @@ func TestBackgroundKill(t *testing.T) {
 	if !strings.Contains(kout, "Killed") {
 		t.Errorf("kill_shell = %q, want it to report Killed", kout)
 	}
-	// Windows exec can spend up to bashWaitDelay returning from a cancelled
-	// process tree while it tears down descendants and pipes.
-	res := m.Wait(ctx, []string{id}, int(bashWaitDelay.Seconds())+5)
+	// 120s natural duration keeps the job far from finishing on its own, so the
+	// reap window is the only thing this measures: a loaded machine's slow
+	// process-tree teardown (up to ~bashWaitDelay) still fits, while a genuinely
+	// broken kill trips the 40s timeout. Pairing the sleep with the timeout (as
+	// 10/10 did) raced natural completion against the reap.
+	res := m.Wait(ctx, []string{id}, 40)
 	if len(res) != 1 || res[0].Status != jobs.Killed {
 		t.Fatalf("want killed, got %+v", res)
 	}


### PR DESCRIPTION
The two bash subprocess-timing tests in `internal/tool/builtin` flake on a loaded machine because their thresholds sat too close to the job's natural duration — a slow process-tree teardown under load read as a failed kill (seen repeatedly as `TestBackgroundKill` / `TestBashCancelReturnsPromptly` on the Windows runner).

- **TestBashCancelReturnsPromptly**: was a 10s threshold against a 30s natural sleep. Now runs `Execute` under a watchdog against a 120s sleep — the test only fails if the cancel never lands within 40s, with no overlap against natural completion. Still passes in well under a second when cancel works.
- **TestBackgroundKill**: `sleep 10` with a ~10s reap timeout raced natural exit against the reap. Now `sleep 120` with a 40s reap window — clean separation.

Both still fail promptly when the cancel/kill path is genuinely broken (watchdog / reap timeout), so the regression they guard is intact — only the flaky margin is widened.

## Verification

- `go test ./internal/tool/builtin/` — pass; the two tests return in ~0.6s / ~0.02s when the kill works
- `go vet ./internal/tool/builtin/` — clean