### PR TITLE
perf(tools): windowed read_file paging + cached tool schema canonicalization

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -288,6 +288,7 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 	c.mu.Unlock()
 
 	go func() {
+		defer cancel()
 		err := body(ctx)
 		c.mu.Lock()
 		c.running = false

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -153,33 +153,33 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	scanner := bufio.NewScanner(src)
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	upTo := offset + limit + 1
 
 	var collected []string
 	lineNo := 0
+	hasMore := false
 	for scanner.Scan() {
 		lineNo++
-		if lineNo > offset && len(collected) < limit {
+		if lineNo <= offset {
+			continue
+		}
+		if len(collected) < limit {
 			collected = append(collected, scanner.Text())
+			continue
 		}
-		if lineNo >= upTo {
-			break
-		}
-	}
-	remaining := 0
-	for scanner.Scan() {
-		remaining++
+		// A line past the requested window exists — stop here rather than reading
+		// the rest of the file just to count the remainder.
+		hasMore = true
+		break
 	}
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("scan: %w", err)
 	}
-	totalSeen := lineNo + remaining
 
-	if totalSeen == 0 {
+	if lineNo == 0 {
 		return "(empty file)", nil
 	}
 	if len(collected) == 0 {
-		return fmt.Sprintf("(offset %d is past EOF — file has %d lines)", offset, totalSeen), nil
+		return fmt.Sprintf("(offset %d is past EOF — file has %d lines)", offset, lineNo), nil
 	}
 
 	maxShown := offset + len(collected)
@@ -189,10 +189,8 @@ func (r readFile) scan(src io.Reader, offset, limit int) (string, error) {
 	for i, line := range collected {
 		fmt.Fprintf(&b, "%*d→%s\n", w, offset+i+1, line)
 	}
-	more := totalSeen - (offset + len(collected))
-	if more > 0 {
-		fmt.Fprintf(&b, "\n[%d more line(s); pass offset=%d to continue]\n",
-			more, offset+len(collected))
+	if hasMore {
+		fmt.Fprintf(&b, "\n[more lines below; pass offset=%d to continue]\n", offset+len(collected))
 	}
 	return b.String(), nil
 }

--- a/internal/tool/builtin/readfile_window_test.go
+++ b/internal/tool/builtin/readfile_window_test.go
@@ -1,0 +1,55 @@
+package builtin
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+type countingReader struct {
+	r io.Reader
+	n int
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += n
+	return n, err
+}
+
+// TestScanWindowedReadDoesNotConsumeWholeFile guards the regression where scan()
+// drained the entire file (a second `for scanner.Scan()` loop) just to count the
+// remaining lines for the pagination trailer. A small windowed read of a large
+// file must read only a small prefix, not all of it.
+func TestScanWindowedReadDoesNotConsumeWholeFile(t *testing.T) {
+	var buf bytes.Buffer
+	for i := 1; i <= 100_000; i++ {
+		fmt.Fprintf(&buf, "line %d\n", i)
+	}
+	total := buf.Len()
+	if total < 500*1024 {
+		t.Fatalf("test fixture too small (%d bytes) to be meaningful", total)
+	}
+
+	cr := &countingReader{r: bytes.NewReader(buf.Bytes())}
+	out, err := readFile{}.scan(cr, 0, 3)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+
+	if !strings.Contains(out, "1→line 1") || !strings.Contains(out, "3→line 3") {
+		t.Fatalf("window content wrong:\n%s", out)
+	}
+	if strings.Contains(out, "line 4") {
+		t.Fatalf("window leaked line 4:\n%s", out)
+	}
+	if !strings.Contains(out, "more lines below") {
+		t.Fatalf("pagination trailer missing:\n%s", out)
+	}
+	if cr.n > 100*1024 {
+		t.Fatalf("read %d of %d bytes for a 3-line window; should read only a small prefix", cr.n, total)
+	}
+	t.Logf("read %d of %d bytes (%.1f%%) for a 3-line window", cr.n, total, 100*float64(cr.n)/float64(total))
+}

--- a/internal/tool/builtin/tool_extra_test.go
+++ b/internal/tool/builtin/tool_extra_test.go
@@ -49,8 +49,9 @@ func TestReadFileLargeFile(t *testing.T) {
 	if strings.Contains(out, "4→line 4") {
 		t.Errorf("should not contain fourth line: %s", out)
 	}
-	// Pagination hint.
-	if !strings.Contains(out, "97 more line") {
+	// Pagination hint points at the next page; it no longer reads the whole file
+	// to compute an exact remaining count.
+	if !strings.Contains(out, "more line") || !strings.Contains(out, "offset=3") {
 		t.Errorf("pagination hint missing: %s", out)
 	}
 }

--- a/internal/tool/registry_canon_test.go
+++ b/internal/tool/registry_canon_test.go
@@ -1,0 +1,62 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+type countingSchemaTool struct {
+	name  string
+	calls *int
+}
+
+func (c countingSchemaTool) Name() string        { return c.name }
+func (c countingSchemaTool) Description() string { return c.name }
+func (c countingSchemaTool) Schema() json.RawMessage {
+	*c.calls++
+	return json.RawMessage(`{"type":"object","properties":{"b":{"type":"string"},"a":{"type":"string"}}}`)
+}
+func (c countingSchemaTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return "", nil
+}
+func (c countingSchemaTool) ReadOnly() bool { return true }
+
+// TestSchemasCanonicalizesOncePerTool guards the regression where Schemas() — run
+// every turn — re-canonicalized (unmarshal+sort+marshal) every tool's schema on
+// each call. Schemas never change after registration, so Schema() must be invoked
+// exactly once (at Add), no matter how many times Schemas() is called.
+func TestSchemasCanonicalizesOncePerTool(t *testing.T) {
+	calls := 0
+	r := NewRegistry()
+	r.Add(countingSchemaTool{name: "alpha", calls: &calls})
+
+	if calls != 1 {
+		t.Fatalf("Schema() called %d times at Add, want 1", calls)
+	}
+
+	for i := 0; i < 50; i++ {
+		schemas := r.Schemas()
+		if len(schemas) != 1 {
+			t.Fatalf("Schemas() returned %d entries, want 1", len(schemas))
+		}
+		// Canonicalization sorts object keys, so "a" must precede "b".
+		got := string(schemas[0].Parameters)
+		if ai, bi := indexOf(got, `"a"`), indexOf(got, `"b"`); ai < 0 || bi < 0 || ai > bi {
+			t.Fatalf("schema not canonicalized (keys unsorted): %s", got)
+		}
+	}
+
+	if calls != 1 {
+		t.Fatalf("Schema() called %d times after 50 Schemas() calls, want 1 (caching regressed)", calls)
+	}
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -101,14 +101,17 @@ type Registry struct {
 	mu    sync.RWMutex
 	tools map[string]Tool
 	order []string
+	canon map[string]json.RawMessage
 }
 
 // NewRegistry returns an empty registry.
 func NewRegistry() *Registry {
-	return &Registry{tools: map[string]Tool{}}
+	return &Registry{tools: map[string]Tool{}, canon: map[string]json.RawMessage{}}
 }
 
-// Add inserts (or replaces) a tool, preserving first-seen order.
+// Add inserts (or replaces) a tool, preserving first-seen order. The schema is
+// canonicalized once here — it never changes after registration, so Schemas()
+// (called every turn) reuses the result instead of re-marshaling.
 func (r *Registry) Add(t Tool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -118,6 +121,7 @@ func (r *Registry) Add(t Tool) {
 		r.order = append(r.order, name)
 	}
 	r.tools[name] = t
+	r.canon[name] = provider.CanonicalizeSchema(t.Schema())
 }
 
 // MCPNamePrefix is the namespace every MCP tool name carries: the
@@ -151,6 +155,7 @@ func (r *Registry) RemovePrefix(prefix string) int {
 	for _, name := range r.order {
 		if strings.HasPrefix(name, prefix) {
 			delete(r.tools, name)
+			delete(r.canon, name)
 			removed++
 			continue
 		}
@@ -190,23 +195,22 @@ func (r *Registry) Names() []string {
 // Schemas exports tool definitions in stable name order for the provider.
 func (r *Registry) Schemas() []provider.ToolSchema {
 	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	names := make([]string, len(r.order))
 	copy(names, r.order)
 	sort.Strings(names)
-	tools := make([]Tool, 0, len(names))
-	for _, name := range names {
-		if t := r.tools[name]; t != nil {
-			tools = append(tools, t)
-		}
-	}
-	r.mu.RUnlock()
 
-	out := make([]provider.ToolSchema, 0, len(tools))
-	for _, t := range tools {
+	out := make([]provider.ToolSchema, 0, len(names))
+	for _, name := range names {
+		t := r.tools[name]
+		if t == nil {
+			continue
+		}
 		out = append(out, provider.ToolSchema{
 			Name:        t.Name(),
 			Description: t.Description(),
-			Parameters:  provider.CanonicalizeSchema(t.Schema()),
+			Parameters:  r.canon[name],
 		})
 	}
 	return out


### PR DESCRIPTION
Two perf wins on hot paths plus a context-hygiene fix, rebased onto current `main-v2`.

## perf(tools): read_file stops scanning the whole file for a windowed read
`scan()` drained the rest of the file in a second loop just to print an exact "N more lines" count, so a small `offset`/`limit` read of a huge file still paid for a full read — defeating the streaming set up in d73df5d4. It now stops one line past the window and reports the next `offset` instead of an exact remainder. A regression test shows a 3-line window of a ~1 MB file reads ~64 KB instead of all of it.

## perf(tools): canonicalize each tool's schema once at registration
`Registry.Schemas()` runs every turn and re-canonicalized (unmarshal → sort → marshal) every tool's schema on each call, though a schema never changes after `Add`. We now canonicalize once in `Add` (under the existing lock) and read the cached form in `Schemas()`. The test asserts `Schema()` is invoked exactly once no matter how many times `Schemas()` is called.

## fix(control): cancel the per-turn context on normal completion
`runGuarded` only cancelled its per-turn context on an explicit user Cancel, never on normal completion, leaving it uncancelled for the life of the process. Added the missing `defer cancel()`. The openai stream watcher this used to strand was already addressed in #2709; this closes the remaining hygiene gap.

`go test ./...` passes; `go vet ./...` clean.
