### PR TITLE
fix(control): don't draft or gate on a plan in bypass/YOLO mode

### DIFF
--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -45,8 +45,11 @@ func (c *Controller) shouldAutoPlan(ctx context.Context, input string) bool {
 	mode := c.autoPlan
 	plan := c.planMode
 	classifier := c.classifier
+	bypass := c.bypass
 	c.mu.Unlock()
-	if mode == autoPlanOff || plan {
+	// YOLO/bypass means "don't stop to ask" — entering plan mode would draft a
+	// plan and gate on approval, the opposite of what the user opted into.
+	if mode == autoPlanOff || plan || bypass {
 		return false
 	}
 	score := autoPlanScore(input)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1661,7 +1661,10 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	key := tool + "\x00" + subject
 
 	c.mu.Lock()
-	if c.granted[key] {
+	// YOLO/bypass and the just-approved-plan window auto-allow every approval
+	// without prompting; the plan gate routes through here too, so this is what
+	// stops a bypass session from blocking on plan approval. Deny rules bit upstream.
+	if c.bypass || c.autoApprove || c.granted[key] {
 		c.mu.Unlock()
 		return true, false, nil
 	}

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -1,0 +1,93 @@
+package control
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// TestBypassSkipsAutoPlan drives the same complex request that
+// TestAutoPlanGateEndToEnd uses to enter plan mode, but with YOLO/bypass on. It
+// must NOT enter plan mode, NOT prefix the plan marker, NOT emit an approval, and
+// run a single execution turn — proving bypass suppresses the auto-plan gate.
+func TestBypassSkipsAutoPlan(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("Done — implemented directly."),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+
+	var approvalRequested bool
+	c := New(Options{
+		AutoPlan: "on",
+		Runner:   ag,
+		Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest {
+				approvalRequested = true
+			}
+		}),
+	})
+	c.SetBypass(true)
+
+	input := "实现 issue #2395：新增配置项、自动判断复杂任务、补测试和文档"
+	if err := c.runTurnWithRaw(context.Background(), input, input); err != nil {
+		t.Fatalf("runTurnWithRaw: %v", err)
+	}
+
+	if c.PlanMode() {
+		t.Fatal("bypass must not enter plan mode")
+	}
+	if approvalRequested {
+		t.Fatal("bypass must not emit an approval request")
+	}
+	if got := firstUserMessage(ag.Session().Messages); strings.HasPrefix(got, PlanModeMarker) {
+		t.Fatalf("bypass must not prefix the auto-plan marker; got %q", got)
+	}
+	if prov.call != 1 {
+		t.Fatalf("provider called %d times, want 1 (no plan turn, just execution)", prov.call)
+	}
+}
+
+// TestRequestApprovalHonorsBypass guards the underlying gate: the plan-approval
+// path routes through requestApproval, which used to emit an ApprovalRequest and
+// block even in bypass. Under bypass it must return allow immediately without
+// emitting anything — otherwise a YOLO session stalls on plan approval.
+func TestRequestApprovalHonorsBypass(t *testing.T) {
+	var approvalRequested bool
+	c := New(Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest {
+				approvalRequested = true
+			}
+		}),
+	})
+	c.SetBypass(true)
+
+	done := make(chan bool, 1)
+	go func() {
+		allow, _, err := c.requestApproval(context.Background(), planApprovalTool, "")
+		if err != nil {
+			t.Errorf("requestApproval: %v", err)
+		}
+		done <- allow
+	}()
+
+	select {
+	case allow := <-done:
+		if !allow {
+			t.Fatal("bypass should auto-allow the approval")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("requestApproval blocked under bypass; it must auto-allow without prompting")
+	}
+
+	if approvalRequested {
+		t.Fatal("bypass must not emit an ApprovalRequest event")
+	}
+}


### PR DESCRIPTION
Bypass ("YOLO", `--dangerously-skip-permissions`) means "don't stop to ask," but two paths ignored it, so a YOLO session would draft a plan and then **stall waiting for plan approval**:

- `shouldAutoPlan` never checked `bypass`, so a complex request still auto-entered plan mode (an extra read-only planning round-trip).
- `requestApproval` — which the plan gate routes through — emitted an `ApprovalRequest` and blocked regardless of mode. Only the tool-call approver (`gateApprover`) honored `bypass`, so the plan gate stayed a hard stop even in YOLO.

This matches how the other agents behave: Claude Code makes plan and bypass mutually-exclusive permission modes (no auto-plan; bypass has no plan phase), and Codex's plan is a non-blocking inline tracker. Neither inserts an auto-triggered, blocking plan gate into full-auto.

## Fixes
1. `shouldAutoPlan` returns false when `bypass` is on — YOLO skips the plan-first turn entirely.
2. `requestApproval` auto-allows under `bypass`/`autoApprove` — no approval path can block in YOLO (defensive backstop). Deny rules still bite (resolved upstream).

## Tests
- `TestBypassSkipsAutoPlan` (e2e): the same complex request that enters plan mode normally runs a single execution turn under bypass — no plan mode, no marker, no approval event.
- `TestRequestApprovalHonorsBypass`: the plan gate returns allow immediately under bypass without emitting an `ApprovalRequest` (guards against re-introducing the stall).

`go test ./...` passes; `go vet ./...` clean. Existing non-bypass auto-plan gate tests still pass.
