### PR TITLE
feat(cli): show a live "working · Ns" line under a running tool

### DIFF
--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -186,6 +186,33 @@ func TestToolProgressStreamsThenCollapses(t *testing.T) {
 	}
 }
 
+// TestToolWorkingLineThenClears proves a dispatched tool that streams no output
+// (e.g. codegraph_context) shows a live "working · Ns" line so it doesn't look
+// frozen, and that the line clears on the result instead of collapsing to
+// "0 lines".
+func TestToolWorkingLineThenClears(t *testing.T) {
+	m := newTestChatTUI()
+	m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "c1", Name: "codegraph_context", Args: `{"q":"x"}`}})
+
+	m.tickToolRunning() // one elapsed tick fills the placeholder
+	joined := strings.Join(m.transcript, "\n")
+	if !strings.Contains(joined, "⎿") || !strings.Contains(joined, "working") {
+		t.Fatalf("a running tool should show a 'working' progress line:\n%s", joined)
+	}
+
+	m.ingestEvent(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "c1", Name: "codegraph_context"}})
+	joined = strings.Join(m.transcript, "\n")
+	if strings.Contains(joined, "working") {
+		t.Fatalf("working line should clear after the result:\n%s", joined)
+	}
+	if strings.Contains(joined, "0 lines") {
+		t.Fatalf("a no-output tool must not collapse to '0 lines':\n%s", joined)
+	}
+	if m.toolStreamIdx != -1 {
+		t.Fatalf("tool block should be closed after the result, idx=%d", m.toolStreamIdx)
+	}
+}
+
 // TestToolProgressTailCap proves the live block only keeps the last
 // toolStreamTailLines lines so a chatty build doesn't flood scrollback.
 func TestToolProgressTailCap(t *testing.T) {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -128,11 +128,16 @@ type chatTUI struct {
 	// complete lines (toolTail) plus the in-progress one (toolPartial) — so a
 	// high-output command can't balloon memory or cost O(n²) re-splitting;
 	// toolLineCount feeds the collapse summary.
-	toolStreamIdx   int
-	toolStreamID    string
-	toolTail        []string
-	toolPartial     string
-	toolLineCount   int
+	toolStreamIdx int
+	toolStreamID  string
+	toolTail      []string
+	toolPartial   string
+	toolLineCount int
+	// toolStreamStart / toolStreamFrame drive the "⎿ working · Ns" line shown
+	// under a dispatched tool that hasn't produced output yet, so a slow tool
+	// (e.g. codegraph_context) reads as making progress rather than frozen.
+	toolStreamStart time.Time
+	toolStreamFrame int
 	transcriptDirty bool
 	eventCh         chan event.Event
 	started         bool // banner + resumed history committed once
@@ -991,6 +996,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case elapsedTickMsg:
 		if m.state == tuiRunning {
 			m.elapsed = int(time.Since(m.runStart).Seconds())
+			m.tickToolRunning()
 			cmds = append(cmds, elapsedTick())
 		}
 
@@ -1201,13 +1207,59 @@ func (m *chatTUI) collapseToolOutput(id string) {
 	if m.toolPartial != "" {
 		n++
 	}
-	m.transcript[m.toolStreamIdx] = connectorBlock([]string{dim(fmt.Sprintf("%d lines", n))})
+	if n == 0 {
+		// The tool produced no streamed output (e.g. an MCP call like
+		// codegraph_context) — drop the "working" placeholder so only the card
+		// remains, rather than leaving a "0 lines" summary.
+		if m.toolStreamIdx == len(m.transcript)-1 {
+			m.transcript = m.transcript[:m.toolStreamIdx]
+		} else {
+			m.transcript[m.toolStreamIdx] = ""
+		}
+	} else {
+		m.transcript[m.toolStreamIdx] = connectorBlock([]string{dim(fmt.Sprintf("%d lines", n))})
+	}
 	m.transcriptDirty = true
 	m.toolStreamIdx = -1
 	m.toolStreamID = ""
 	m.toolTail = m.toolTail[:0]
 	m.toolPartial = ""
 	m.toolLineCount = 0
+}
+
+// toolWorkingFrames is the braille spinner cycled once per second on the
+// "⎿ working · Ns" line of a tool that hasn't streamed output yet.
+var toolWorkingFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// beginToolRunning opens an empty live block under a just-dispatched tool card,
+// keyed by the call id. tickToolRunning fills it with a "working · Ns" line each
+// second; if the tool later streams output, streamToolOutput reuses the same
+// block; collapseToolOutput closes it on the result.
+func (m *chatTUI) beginToolRunning(id string) {
+	if id == "" {
+		return
+	}
+	m.toolStreamID = id
+	m.toolTail = m.toolTail[:0]
+	m.toolPartial = ""
+	m.toolLineCount = 0
+	m.toolStreamStart = time.Now()
+	m.toolStreamFrame = 0
+	m.toolStreamIdx = len(m.transcript)
+	m.commitLine(connectorBlock([]string{dim(fmt.Sprintf(i18n.M.ChatToolWorkingFmt, toolWorkingFrames[0], 0))}))
+}
+
+// tickToolRunning re-renders the working line of a tool that's dispatched but
+// hasn't produced output yet. A no-op once output streams in or no tool runs.
+func (m *chatTUI) tickToolRunning() {
+	if m.toolStreamIdx < 0 || m.toolLineCount != 0 || m.toolPartial != "" {
+		return
+	}
+	m.toolStreamFrame++
+	frame := toolWorkingFrames[m.toolStreamFrame%len(toolWorkingFrames)]
+	secs := int(time.Since(m.toolStreamStart).Seconds())
+	m.transcript[m.toolStreamIdx] = connectorBlock([]string{dim(fmt.Sprintf(i18n.M.ChatToolWorkingFmt, frame, secs))})
+	m.transcriptDirty = true
 }
 
 // commitReasoning closes the live thinking block: the "▎ thinking…" marker is
@@ -2231,6 +2283,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 				break
 			}
 			m.commitLine(toolCard(e.Tool.Name, e.Tool.Args, m.width))
+			m.beginToolRunning(e.Tool.ID)
 		}
 
 	case event.ToolProgress:

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -67,6 +67,7 @@ type Messages struct {
 	ChatThinking           string // live reasoning marker label, e.g. "thinking…"
 	ChatThoughtForFmt      string // collapsed reasoning summary, "%d" = elapsed s
 	ChatStatusThinkingFmt  string // "%s thinking… (%ds · <cancel hint>)" — %s = spinner, %d = elapsed s
+	ChatToolWorkingFmt     string // "%s working · %ds" under a running tool — %s = spinner, %d = elapsed s
 	ChatStatusIdle         string // shortcuts hint when idle
 	ChatStatusYoloIdle     string // shortcuts hint when idle in YOLO/bypass mode
 	ChatStatusPlanApproval string // shortcuts hint while a plan is pending

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -41,6 +41,7 @@ var English = Messages{
 	ChatThinking:           "thinking…",
 	ChatThoughtForFmt:      "thought for %ds",
 	ChatStatusThinkingFmt:  "%s thinking… (%ds · Esc cancels)",
+	ChatToolWorkingFmt:     "%s working · %ds",
 	ChatStatusIdle:         "ready",
 	ChatStatusYoloIdle:     "approvals skipped",
 	ChatStatusPlanApproval: "Enter/y approves & executes · n/Esc keeps planning · PgUp/PgDn scrolls",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -42,6 +42,7 @@ var Chinese = Messages{
 	ChatThinking:           "思考中…",
 	ChatThoughtForFmt:      "思考了 %d 秒",
 	ChatStatusThinkingFmt:  "%s 思考中… (%d 秒 · Esc 取消)",
+	ChatToolWorkingFmt:     "%s 运行中 · %d 秒",
 	ChatStatusIdle:         "就绪",
 	ChatStatusYoloIdle:     "已跳过批准",
 	ChatStatusPlanApproval: "Enter/y 批准并执行 · n/Esc 继续规划 · PgUp/PgDn 滚动",


### PR DESCRIPTION
## Problem
A dispatched tool that streams no output — MCP calls like `codegraph_context` — left a static `● codegraph_context` card with no per-tool progress. The only motion was the global "thinking Ns" line at the bottom (which doesn't name the tool), so a slow call (codegraph cold-starts its index on first use) read as **frozen**.

## Fix
On dispatch, open a `⎿ working · Ns` line directly under the tool card, refreshed once a second on the elapsed tick (rotating braille spinner + elapsed seconds) — so a slow tool visibly makes progress. It reuses the existing tool-output block, so:
- if the tool streams output (bash), the same block shows the live output (unchanged behavior);
- a no-output tool's line **clears on the result** (card remains) instead of collapsing to a meaningless `0 lines`.

Updates once per second (not per spinner frame) to keep the cost at one transcript re-render/sec.

## Tests
- New `TestToolWorkingLineThenClears`: dispatch a no-output tool → tick shows `⎿ … working`; result clears it (no `0 lines`, block closed).
- Existing `TestToolProgressStreamsThenCollapses` / `TestToolProgressTailCap` (bash streaming) still pass — the block reuse doesn't regress streamed output.
- `go build`, `go vet`, full `go test ./internal/cli ./internal/i18n` green; gofmt clean; i18n key added to en + zh.