### PR TITLE
fix(cli): let Esc cancel a running turn even with the completion menu open

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -711,6 +711,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			case "esc":
 				m.completion = completion{}
+				if m.state == tuiRunning {
+					break // a turn is running — also cancel it via the main Esc handler
+				}
 				return m, nil
 			}
 		}

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +15,40 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
 )
+
+type blockingTurnRunner struct{ started chan struct{} }
+
+func (r *blockingTurnRunner) Run(ctx context.Context, _ string) error {
+	close(r.started)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestEscCancelsRunningTurnWithCompletionOpen reproduces the report that Esc
+// (unlike Ctrl+C) did not stop a running turn: an active completion menu
+// captured Esc to close itself and returned before reaching the running-turn
+// cancel branch, while Ctrl+C — not in the completion switch — fell through.
+func TestEscCancelsRunningTurnWithCompletionOpen(t *testing.T) {
+	r := &blockingTurnRunner{started: make(chan struct{})}
+	ctrl := control.New(control.Options{Runner: r, Sink: event.Discard, SessionDir: t.TempDir(), Label: "test"})
+	ctrl.Send("hi")
+	<-r.started // the turn is in flight and cancellable
+
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+	m.state = tuiRunning
+	m.completion.active = true // e.g. a "/" typed into the composer while waiting
+
+	_, _ = m.update(tea.KeyPressMsg{Code: tea.KeyEscape})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for ctrl.Running() {
+		if time.Now().After(deadline) {
+			t.Fatal("Esc did not cancel the running turn (completion menu swallowed it)")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
 
 // TestTranscriptMirrorsCommits proves the alt-screen migration's foundation:
 // every line commitLine sends to native scrollback is also captured in the


### PR DESCRIPTION
## Report
Esc didn't stop a running task — but Ctrl+C did.

## Root cause
That divergence is the tell. During a turn, the key router checks the modal overlays in order; the autocomplete-menu block (`if m.completion.active`) has a `case "esc": close menu; return` that fires **before** the main `case "esc": … m.ctrl.Cancel()`. Ctrl+C isn't in the completion switch, so it falls through to cancel — Esc gets swallowed (silently closing a possibly empty/stale menu). The other overlays (rewind/approval/chooser) intercept Esc *and* Ctrl+C, so they're ruled out by the fact that Ctrl+C worked.

## Fix
When a turn is running, the completion-Esc case closes the menu and then **falls through** to the main Esc handler (which cancels), instead of returning. Idle behaviour is unchanged (Esc just closes the menu).

## Repro / test
`TestEscCancelsRunningTurnWithCompletionOpen`: start a turn on a blocking runner, set `completion.active`, feed Esc, assert the turn cancels. **Fails on the old code** ("completion menu swallowed it"), passes with the fix. Full `go test ./internal/cli` green; gofmt + vet clean.