### PR TITLE
fix: stop Windows console-window flashing + surface unusable-model cause

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -74,7 +74,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	entry, ok := cfg.ResolveModel(modelName)
 	if !ok {
-		return nil, fmt.Errorf("unknown model %q (configured: %s)", modelName, providerNames(cfg))
+		return nil, fmt.Errorf("unknown model %q (configured: %s); note: defining [[providers]] replaces the built-in presets, so add a [[providers]] entry for it or use a configured name", modelName, providerNames(cfg))
 	}
 	if opts.RequireKey {
 		if err := cfg.Validate(modelName); err != nil {
@@ -87,6 +87,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// shares this synchronized sink. The job manager is session-scoped — its jobs
 	// outlive a turn and are cancelled by Controller.Close.
 	sink := event.Sync(opts.Sink)
+
+	// A resolvable model whose API key env is unset would otherwise build fine
+	// (RequireKey is false so the UI stays reachable) and then fail silently on the
+	// first request, showing as an empty/dead model. Surface the cause up front.
+	if !opts.RequireKey && entry.APIKeyEnv != "" && entry.APIKey() == "" {
+		sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
+	}
 	jm := jobs.NewManager(sink)
 
 	proxySpec := cfg.NetworkProxySpec()

--- a/internal/boot/model_error_test.go
+++ b/internal/boot/model_error_test.go
@@ -1,0 +1,90 @@
+package boot
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+
+	_ "reasonix/internal/provider/openai"
+	_ "reasonix/internal/tool/builtin"
+)
+
+// TestBuildUnknownModelErrorIsActionable: a default_model that doesn't resolve
+// (e.g. a preset name after [[providers]] replaced the built-in presets) must
+// fail with a message that names the model, lists what IS configured, and hints
+// at the [[providers]] trap — not a silent empty model.
+func TestBuildUnknownModelErrorIsActionable(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "mimo"
+
+[codegraph]
+enabled = false
+
+[[providers]]
+name = "deepseek-flash"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "deepseek-v4-flash"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	_, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err == nil {
+		t.Fatal("expected an error for an unresolvable default_model")
+	}
+	msg := err.Error()
+	for _, want := range []string{`"mimo"`, "deepseek-flash", "[[providers]]"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q should mention %q", msg, want)
+		}
+	}
+}
+
+// TestBuildNoticesMissingAPIKey: a resolvable model whose API key env is unset
+// builds fine (RequireKey is false so the UI stays reachable) but must emit a
+// notice naming the env var, instead of silently showing a dead/empty model.
+func TestBuildNoticesMissingAPIKey(t *testing.T) {
+	const keyEnv = "REASONIX_MISSING_KEY_FOR_TEST"
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "x"
+
+[codegraph]
+enabled = false
+
+[[providers]]
+name = "x"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "m"
+api_key_env = "`+keyEnv+`"
+`)
+
+	var notices []string
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e.Text)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build should succeed with RequireKey=false even without a key: %v", err)
+	}
+	defer ctrl.Close()
+
+	found := false
+	for _, n := range notices {
+		if strings.Contains(n, keyEnv) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a notice naming the unset key env %q; got %v", keyEnv, notices)
+	}
+}

--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"reasonix/internal/proc"
 )
 
 // BundleDirName is the directory, beside the reasonix executable, that the release
@@ -111,6 +113,7 @@ func EnsureInit(ctx context.Context, bin, root string) error {
 		return nil // already initialised — serve re-syncs and the watcher keeps it fresh
 	}
 	cmd := exec.CommandContext(ctx, bin, "init", root)
+	proc.HideWindow(cmd)
 	cmd.Dir = root
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("codegraph init: %w: %s", err, strings.TrimSpace(string(out)))

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"reasonix/internal/proc"
 )
 
 const maxImageAttachmentBytes = 10 * 1024 * 1024
@@ -177,7 +179,9 @@ if ($null -eq $img) { [Console]::Error.WriteLine('clipboard has no image'); exit
 $ms = New-Object System.IO.MemoryStream
 $img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
 [Convert]::ToBase64String($ms.ToArray())`
-	out, err := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script).Output()
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", script)
+	proc.HideWindow(cmd)
+	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
 			return "", fmt.Errorf("read clipboard image: %s", strings.TrimSpace(string(ee.Stderr)))

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -23,6 +23,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"reasonix/internal/proc"
 )
 
 // Event is a point in the agent loop a hook can fire at.
@@ -374,6 +376,7 @@ func DefaultSpawner(ctx context.Context, in SpawnInput) SpawnResult {
 
 	name, args := shellInvocation(in.Command)
 	cmd := exec.CommandContext(cctx, name, args...)
+	proc.HideWindow(cmd)
 	cmd.Dir = in.Cwd
 	cmd.Stdin = strings.NewReader(in.Stdin)
 	var outBuf, errBuf cappedBuffer

--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"sync"
 	"time"
+
+	"reasonix/internal/proc"
 )
 
 // docState tracks what we last sent the server for a document, so ensureSynced
@@ -42,6 +44,7 @@ type Diagnostic struct {
 
 func startClient(ctx context.Context, bin string, args []string, env map[string]string, langID, root string) (*client, error) {
 	cmd := exec.CommandContext(ctx, bin, args...)
+	proc.HideWindow(cmd)
 	cmd.Dir = root
 	cmd.Env = append(os.Environ(), envSlice(env)...)
 	cmd.Stderr = io.Discard

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"reasonix/internal/proc"
 )
 
 // stdioTransport speaks newline-delimited JSON-RPC 2.0 over a subprocess's
@@ -50,6 +52,7 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 		return nil, err
 	}
 	cmd := exec.CommandContext(ctx, exe, s.Args...)
+	proc.HideWindow(cmd)
 	cmd.Env = env
 	if s.Dir != "" {
 		cmd.Dir = s.Dir // pin cwd-aware servers (e.g. CodeGraph) to the project root
@@ -214,6 +217,7 @@ func runShellPATHCommand(parent context.Context, shell string, args []string) []
 	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, shell, args...)
+	proc.HideWindow(cmd)
 	cmd.Stdin = strings.NewReader("")
 	out, _ := cmd.CombinedOutput()
 	return out

--- a/internal/proc/hide_other.go
+++ b/internal/proc/hide_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package proc
+
+import "os/exec"
+
+// HideWindow is a no-op off Windows.
+func HideWindow(*exec.Cmd) {}

--- a/internal/proc/hide_other_test.go
+++ b/internal/proc/hide_other_test.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package proc
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestHideWindowIsNoOpOffWindows(t *testing.T) {
+	cmd := exec.Command("true")
+	HideWindow(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Fatal("HideWindow should be a no-op off Windows, but set SysProcAttr")
+	}
+}

--- a/internal/proc/hide_windows.go
+++ b/internal/proc/hide_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package proc
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const createNoWindow = 0x08000000 // CREATE_NO_WINDOW
+
+// HideWindow stops a child process from flashing a console window on Windows,
+// where a GUI parent (the desktop app) has no console of its own to inherit.
+func HideWindow(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}

--- a/internal/proc/hide_windows_test.go
+++ b/internal/proc/hide_windows_test.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package proc
+
+import (
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestHideWindowSetsCreateNoWindow(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "echo", "hi")
+	HideWindow(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil; HideWindow did not set it")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
+		t.Fatalf("CREATE_NO_WINDOW not set; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
+	}
+}
+
+func TestHideWindowPreservesExistingFlags(t *testing.T) {
+	const createNewProcessGroup = 0x00000200
+	cmd := exec.Command("cmd", "/c", "echo", "hi")
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNewProcessGroup}
+	HideWindow(cmd)
+	if cmd.SysProcAttr.CreationFlags&createNewProcessGroup == 0 {
+		t.Fatal("HideWindow clobbered a pre-existing creation flag")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
+		t.Fatal("HideWindow did not add CREATE_NO_WINDOW")
+	}
+}

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"reasonix/internal/proc"
 )
 
 // psUTF8Prologue forces PowerShell to emit UTF-8 instead of the host's OEM code
@@ -77,7 +79,9 @@ func probeBash(path string) bool {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	return exec.CommandContext(ctx, path, "-c", "true").Run() == nil
+	cmd := exec.CommandContext(ctx, path, "-c", "true")
+	proc.HideWindow(cmd)
+	return cmd.Run() == nil
 }
 
 func fileExists(p string) bool {

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/text/transform"
 
 	fileenc "reasonix/internal/fileutil/encoding"
+	"reasonix/internal/proc"
 	"reasonix/internal/tool"
 )
 
@@ -199,6 +200,7 @@ func (g grepTool) runRipgrep(ctx context.Context, pattern, path string) (string,
 	cmd := exec.CommandContext(ctx, g.rg,
 		"--no-heading", "--line-number", "--with-filename", "--color", "never",
 		"--regexp", pattern, "--", path)
+	proc.HideWindow(cmd)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Two independent Windows/desktop bugs reported together: a burst of cmd windows on startup (and again on model switch), and a model that shows empty when the default isn't usable.

## fix(windows): stop subprocesses flashing a console window
A GUI parent (the desktop app) has no console to inherit, so every child spawned via `os/exec` popped its own `cmd` window — a burst at startup (codegraph daemon, LSP, MCP stdio plugins) and **again on every model switch**, which rebuilds the controller. None of the ~spawn sites set `CREATE_NO_WINDOW`.

- New build-tagged helper `internal/proc.HideWindow` — sets `CREATE_NO_WINDOW` on Windows, no-op elsewhere.
- Applied at the console-spawning sites: codegraph `init`, LSP, MCP stdio transport (this is also how the codegraph daemon launches), the Windows `bash` probe, hooks, ripgrep, and the Windows clipboard reader.
- `bash` already hid its console via `setKillTree`; GUI launchers (explorer/open/xdg-open) don't allocate a console, so they're left alone.

Tests: `internal/proc` asserts the flag is set on Windows and the helper is a no-op elsewhere (build-tagged, so the Windows CI runner exercises the real path).

## fix(boot): surface why a model is empty instead of failing silently
Two silent failures made the default model show empty with no reason:
- `default_model` that doesn't resolve — e.g. a preset name like `mimo-pro` after you've defined `[[providers]]`, which **replaces the built-in presets**. The error now names that trap and lists the configured models.
- A resolvable model whose API key env is unset — it built fine (RequireKey is false so the UI stays reachable) and only failed on the first request. Boot now emits a notice naming the missing key env up front.

Tests: `TestBuildUnknownModelErrorIsActionable`, `TestBuildNoticesMissingAPIKey`.

`go build ./...` (native + linux cross), `go vet ./...`, and `go test ./...` pass. (One pre-existing Windows timing flake, `TestStartPhaseAReturnsBeforePhaseB`, fails on this local box on the clean base too — unrelated to this change.)
