### PR TITLE
desktop: per-turn autosave + transcript render perf

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,11 +57,21 @@ type App struct {
 	ready       bool   // true once boot.Build completes (success or failure)
 	disabledMCP map[string]ServerView
 	mcpOrder    []string
+
+	// Per-turn autosave runs off the event goroutine so disk I/O never delays
+	// event delivery; overlapping requests coalesce into one trailing write.
+	saveMu    sync.Mutex
+	saving    bool
+	saveAgain bool
 }
 
 // NewApp constructs the bound object. The controller is built later, in startup,
 // once the Wails context exists.
-func NewApp() *App { return &App{sink: &eventSink{}, disabledMCP: map[string]ServerView{}} }
+func NewApp() *App {
+	a := &App{sink: &eventSink{}, disabledMCP: map[string]ServerView{}}
+	a.sink.app = a
+	return a
+}
 
 // startup runs once the webview process is up, before the frontend can issue any
 // bound call. It captures the Wails context (needed for EventsEmit), points the
@@ -1814,11 +1825,54 @@ func parseScope(s string) memory.Scope {
 // — Emit must not be exposed to JS. Emit runs on the agent goroutine;
 // runtime.EventsEmit is goroutine-safe, and the ctx guard covers the brief window
 // before startup assigns it.
-type eventSink struct{ ctx context.Context }
+type eventSink struct {
+	ctx context.Context
+	app *App
+}
 
 func (s *eventSink) Emit(e event.Event) {
-	if s.ctx == nil {
+	if s.ctx != nil {
+		runtime.EventsEmit(s.ctx, eventChannel, toWire(e))
+	}
+	// Persist after each turn so a force-kill of a long session loses at most the
+	// in-flight prompt, not every turn back to the last workspace switch.
+	if e.Kind == event.TurnDone && s.app != nil {
+		s.app.scheduleSnapshot()
+	}
+}
+
+// scheduleSnapshot kicks a single-flight background save of the active session;
+// a request arriving while one runs sets a trailing pass so the final state lands.
+func (a *App) scheduleSnapshot() {
+	a.saveMu.Lock()
+	if a.saving {
+		a.saveAgain = true
+		a.saveMu.Unlock()
 		return
 	}
-	runtime.EventsEmit(s.ctx, eventChannel, toWire(e))
+	a.saving = true
+	a.saveMu.Unlock()
+	go a.snapshotLoop()
+}
+
+func (a *App) snapshotLoop() {
+	for {
+		a.mu.RLock()
+		ctrl := a.ctrl
+		a.mu.RUnlock()
+		if ctrl != nil {
+			if err := ctrl.Snapshot(); err != nil {
+				slog.Warn("desktop: per-turn snapshot", "err", err)
+			}
+		}
+		a.saveMu.Lock()
+		if a.saveAgain {
+			a.saveAgain = false
+			a.saveMu.Unlock()
+			continue
+		}
+		a.saving = false
+		a.saveMu.Unlock()
+		return
+	}
 }

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type stubProvider struct{}
+
+func (stubProvider) Name() string { return "stub" }
+
+func (stubProvider) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	ch := make(chan provider.Chunk, 1)
+	close(ch)
+	return ch, nil
+}
+
+func controllerWithContent(t *testing.T, path string) *control.Controller {
+	t.Helper()
+	sess := agent.NewSession("system")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "remember this turn"})
+	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "acknowledged"})
+	ag := agent.New(stubProvider{}, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
+	return control.New(control.Options{Executor: ag, SessionPath: path, Sink: event.Discard})
+}
+
+func waitForFile(t *testing.T, path, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(path); err == nil && strings.Contains(string(b), want) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("session file %q never contained %q", path, want)
+}
+
+// TestTurnDonePersistsSession proves a completed turn is written to disk without
+// any explicit Snapshot call — the desktop autosave the data-loss fix adds. A
+// nil sink ctx (no webview) must not disable persistence.
+func TestTurnDonePersistsSession(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	a := &App{ctrl: controllerWithContent(t, path)}
+	a.sink = &eventSink{app: a}
+
+	a.sink.Emit(event.Event{Kind: event.TurnDone})
+
+	waitForFile(t, path, "remember this turn")
+}
+
+// TestNonTurnDoneDoesNotPersist confirms only TurnDone triggers a save, so the
+// per-token event storm doesn't thrash the disk.
+func TestNonTurnDoneDoesNotPersist(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	a := &App{ctrl: controllerWithContent(t, path)}
+	a.sink = &eventSink{app: a}
+
+	a.sink.Emit(event.Event{Kind: event.Text, Text: "tok"})
+
+	time.Sleep(50 * time.Millisecond)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("a non-TurnDone event wrote the session file (err=%v)", err)
+	}
+}
+
+// TestScheduleSnapshotCoalesces hammers the scheduler concurrently to prove the
+// single-flight loop neither panics nor drops the final write.
+func TestScheduleSnapshotCoalesces(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	a := &App{ctrl: controllerWithContent(t, path)}
+	a.sink = &eventSink{app: a}
+
+	for i := 0; i < 64; i++ {
+		go a.scheduleSnapshot()
+	}
+
+	waitForFile(t, path, "acknowledged")
+}

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
@@ -49,7 +49,10 @@ export function UserMessage({
   );
 }
 
-export function AssistantMessage({ item }: { item: AssistantItem }) {
+// memo: an unchanged message keeps a stable `item` ref across a streaming turn's
+// per-token re-renders, so only the live bubble re-parses markdown, not the whole
+// backlog.
+export const AssistantMessage = memo(function AssistantMessage({ item }: { item: AssistantItem }) {
   const t = useT();
   const [open, setOpen] = useState(false);
   return (
@@ -86,4 +89,4 @@ export function AssistantMessage({ item }: { item: AssistantItem }) {
       )}
     </div>
   );
-}
+});

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import {
   Ban,
   Check,
@@ -54,7 +54,7 @@ function StatusGlyph({ status }: { status: ToolItem["status"] }) {
 // ToolCard renders one tool call. `subcalls` are sub-agent calls nested under a
 // `task` card (their ParentID points at this call); they render inline, live, so
 // the sub-agent's work is visible as it happens.
-export function ToolCard({ item, subcalls }: { item: ToolItem; subcalls?: ToolItem[] }) {
+export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolItem; subcalls?: ToolItem[] }) {
   const t = useT();
   const diffs = diffsFor(item.name, item.args);
   const subject = subjectOf(item.name, item.args);
@@ -134,4 +134,4 @@ export function ToolCard({ item, subcalls }: { item: ToolItem; subcalls?: ToolIt
       {item.error && <div className="tool__err">{item.error}</div>}
     </div>
   );
-}
+});

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState } from "react";
-import type { Item } from "../lib/useController";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Item, LiveStream } from "../lib/useController";
 import { useT } from "../lib/i18n";
 import { AssistantMessage, UserMessage } from "./Message";
 import { ToolCard } from "./ToolCard";
@@ -41,11 +41,13 @@ function repinIfWasPinned(
 
 export function Transcript({
   items,
+  live,
   footerHeight = 0,
   onPrompt,
   onRewind,
 }: {
   items: Item[];
+  live?: LiveStream;
   footerHeight?: number;
   onPrompt: (text: string) => void;
   onRewind?: (turn: number, scope: string) => void;
@@ -68,7 +70,10 @@ export function Transcript({
   // together with plain-text streaming this keeps the view from jittering. The
   // dependency tracks rendered content, not just array identity, so streaming
   // still follows the bottom if a reducer reuses the items array.
-  const contentVersion = scrollVersion(items);
+  // scrollVersion is O(items); recompute only when the backlog changes, not on
+  // every streamed token. The live bubble's growth drives follow-to-bottom via
+  // its length added to the effect deps below.
+  const contentVersion = useMemo(() => scrollVersion(items), [items]);
   useEffect(() => {
     if (!stick.current) return;
     const el = scrollRef.current;
@@ -77,7 +82,7 @@ export function Transcript({
       el.scrollTop = el.scrollHeight;
     });
     return () => cancelAnimationFrame(id);
-  }, [contentVersion]);
+  }, [contentVersion, live?.text.length, live?.reasoning.length]);
 
   useEffect(() => {
     const el = scrollRef.current;
@@ -114,14 +119,19 @@ export function Transcript({
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.
-  const subcallsByParent = new Map<string, ToolItem[]>();
-  for (const it of items) {
-    if (it.kind === "tool" && it.parentId) {
-      const arr = subcallsByParent.get(it.parentId) ?? [];
-      arr.push(it);
-      subcallsByParent.set(it.parentId, arr);
+  // Memoized so a `task` card's `subcalls` ref stays stable and its memo holds
+  // across a streaming turn's per-token re-renders.
+  const subcallsByParent = useMemo(() => {
+    const m = new Map<string, ToolItem[]>();
+    for (const it of items) {
+      if (it.kind === "tool" && it.parentId) {
+        const arr = m.get(it.parentId) ?? [];
+        arr.push(it);
+        m.set(it.parentId, arr);
+      }
     }
-  }
+    return m;
+  }, [items]);
 
   // The rewind menu's open state is lifted here so at most one is open at a time;
   // a mousedown outside any .rewind closes it.
@@ -166,8 +176,12 @@ export function Transcript({
               />
             );
           }
-          case "assistant":
-            return <AssistantMessage key={it.id} item={it} />;
+          case "assistant": {
+            // The streaming segment's text lives in `live`, not in items, so the
+            // backlog ref stays stable per token; overlay it only on its own item.
+            const shown = live && live.id === it.id ? { ...it, text: live.text, reasoning: live.reasoning, streaming: true } : it;
+            return <AssistantMessage key={it.id} item={shown} />;
+          }
           case "tool":
             if (it.parentId) return null; // rendered nested under its parent
             if (it.name === "todo_write") return null; // shown live in the pinned TodoPanel


### PR DESCRIPTION
Two desktop improvements.

## feat(desktop): autosave the session after each turn
A force-kill of a long desktop session lost every turn back to the last workspace switch — snapshots only ran on shutdown/switch. The session now saves after each `TurnDone` on a single-flight background goroutine, so disk I/O never delays event delivery and overlapping turns coalesce into one trailing write.

## perf(desktop): stop re-rendering the whole transcript on every streamed token
`memo` on `AssistantMessage` and `ToolCard`, and `useMemo` for `scrollVersion` and the subcall grouping in `Transcript`, so a streaming turn's per-token re-renders touch only the live bubble instead of re-parsing the entire backlog. Scroll-to-bottom now also tracks the live stream's length.

Desktop Go tests pass (incl. the new autosave test). Frontend typecheck/build is exercised by the `desktop` CI job.
