### PR TITLE
fix(cli): don't OSC-probe the terminal on a runtime /theme auto

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -108,10 +108,7 @@ func configureCLIThemeFromConfigForTTYOutput() {
 }
 
 func configureCLIThemeFromConfigNoProbe() {
-	prev := queryTerminalBackgroundForTheme
-	queryTerminalBackgroundForTheme = func() (terminalRGB, bool) { return terminalRGB{}, false }
-	defer func() { queryTerminalBackgroundForTheme = prev }()
-	configureCLIThemeFromConfig()
+	withoutTerminalProbe(configureCLIThemeFromConfig)
 }
 
 // setup builds a ready-to-drive Controller from config via boot.Build. It is a

--- a/internal/cli/theme.go
+++ b/internal/cli/theme.go
@@ -194,8 +194,23 @@ func defaultCLIThemeStyle(mode string) cliThemeStyle {
 	return cliThemeStyles[0]
 }
 
+// withoutTerminalProbe resolves a theme with the OSC background probe disabled —
+// for callers running while something else (the live TUI) owns stdin, where a
+// raw-mode read would fight the TUI's input reader. "auto" then falls back to the
+// COLORFGBG heuristic.
+func withoutTerminalProbe(fn func()) {
+	prev := queryTerminalBackgroundForTheme
+	queryTerminalBackgroundForTheme = func() (terminalRGB, bool) { return terminalRGB{}, false }
+	defer func() { queryTerminalBackgroundForTheme = prev }()
+	fn()
+}
+
 func setCLIThemeMode(mode string) cliPalette {
-	activeCLITheme = resolveCLIThemeWithStyle(mode, activeCLITheme.style)
+	// A runtime /theme switch runs inside the TUI, which owns stdin, so resolving
+	// "auto" must not live-probe the terminal here.
+	withoutTerminalProbe(func() {
+		activeCLITheme = resolveCLIThemeWithStyle(mode, activeCLITheme.style)
+	})
 	refreshCLIStyles()
 	return activeCLITheme
 }

--- a/internal/cli/theme_test.go
+++ b/internal/cli/theme_test.go
@@ -201,6 +201,35 @@ func TestApplyTextareaThemeClearsCursorLineBackground(t *testing.T) {
 	}
 }
 
+// TestRuntimeAutoThemeDoesNotProbeStdin guards the fix for a runtime `/theme auto`
+// that live-probed the terminal (raw-mode stdin read) while the TUI owned stdin,
+// racing bubbletea's input reader. The switch must resolve via the COLORFGBG
+// fallback instead, never invoking the probe.
+func TestRuntimeAutoThemeDoesNotProbeStdin(t *testing.T) {
+	t.Setenv("COLORTERM", "")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("REASONIX_THEME", "")
+	t.Setenv("REASONIX_THEME_STYLE", "")
+	t.Setenv("COLORFGBG", "15;0")
+	defer restoreThemeForTest(colorEnabled, activeCLITheme)
+	colorEnabled = true
+
+	prev := queryTerminalBackgroundForTheme
+	defer func() { queryTerminalBackgroundForTheme = prev }()
+	probed := false
+	queryTerminalBackgroundForTheme = func() (terminalRGB, bool) {
+		probed = true
+		return terminalRGB{}, false
+	}
+
+	if got := setCLIThemeMode("auto").name; got != "dark" {
+		t.Fatalf("auto with COLORFGBG=15;0 resolved %q, want dark", got)
+	}
+	if probed {
+		t.Fatal("runtime /theme auto probed the terminal while the TUI owns stdin")
+	}
+}
+
 func restoreThemeForTest(prevColor bool, prevTheme cliPalette) {
 	colorEnabled = prevColor
 	activeCLITheme = prevTheme


### PR DESCRIPTION
Follow-up to #2734.

The new `/theme auto` resolves the light/dark shell by querying the terminal background with an OSC 11 escape — a raw-mode read of stdin. At startup that's fine (and the no-probe paths already guard non-interactive commands), but a **runtime** `/theme auto` typed in the chat TUI runs while bubbletea owns stdin, so the probe's `MakeRaw` + `Read` races bubbletea's input reader and can steal keystrokes or corrupt terminal state.

`setCLIThemeMode` now resolves with the probe disabled (falling back to the `COLORFGBG` heuristic), via the same `withoutTerminalProbe` guard the startup no-probe paths use — which this also dedups them onto.

Test: `TestRuntimeAutoThemeDoesNotProbeStdin` asserts a runtime `/theme auto` resolves via `COLORFGBG` without invoking the probe.
