### PR TITLE
fix(desktop): complete the live-stream state so the frontend builds

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -745,7 +745,7 @@ export default function App() {
                 <span className="loading-screen__text">{t("common.loading")}</span>
               </div>
             ) : (
-              <Transcript items={state.items} footerHeight={footerHeight} onPrompt={send} onRewind={rewind} />
+              <Transcript items={state.items} live={state.live} footerHeight={footerHeight} onPrompt={send} onRewind={rewind} />
             )}
           </main>
 

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -25,6 +25,11 @@ import type {
 
 export type ToolStatus = "running" | "done" | "error" | "stopped";
 
+// LiveStream holds the in-flight assistant segment's text/reasoning, kept out of
+// `items` so per-token deltas don't rebuild the backlog. It folds back into its
+// assistant item on the closing `message` (or at turn end as a fallback).
+export type LiveStream = { id: string; text: string; reasoning: string };
+
 export type Item =
   | { kind: "user"; id: string; text: string }
   | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean }
@@ -76,6 +81,9 @@ interface State {
   // currentAssistant tracks the in-flight assistant item that text/reasoning
   // deltas accumulate into; cleared at turn boundaries.
   currentAssistant?: string;
+  // live is the streaming segment's accumulating text/reasoning, kept out of
+  // items so a token only updates this O(1) field, not the whole backlog.
+  live?: LiveStream;
   // pendingUser holds a just-sent message whose bubble is deferred until the
   // server's first real packet, so an Esc/Stop before any reply "un-sends" it —
   // restoring the text to the composer with nothing left in the transcript. It's
@@ -150,7 +158,7 @@ function applyEvent(s: State, e: WireEvent): State {
   // After an un-send, swallow the cancelled turn's still-buffered events so no
   // orphan assistant/tool bubble appears; its turn_done clears the discard.
   if (s.discardTurn) {
-    if (e.kind === "turn_done") return { ...s, discardTurn: false, running: false, turnActive: false, currentAssistant: undefined };
+    if (e.kind === "turn_done") return { ...s, discardTurn: false, running: false, turnActive: false, currentAssistant: undefined, live: undefined };
     return s;
   }
   // The first real packet means the server replied — commit the deferred user
@@ -165,26 +173,29 @@ function applyEvent(s: State, e: WireEvent): State {
 
     case "text":
     case "reasoning": {
+      // ensureAssistant appends the placeholder once per segment (items changes
+      // then); subsequent tokens only grow `live`, leaving items' ref untouched.
       const { items, id, seq } = ensureAssistant(s);
       const delta = e.text ?? e.reasoning ?? "";
-      const next = items.map((it) =>
-        it.kind === "assistant" && it.id === id
-          ? e.kind === "text"
-            ? { ...it, text: it.text + delta }
-            : { ...it, reasoning: it.reasoning + delta }
-          : it,
-      );
-      return { ...s, items: next, currentAssistant: id, seq };
+      const base = s.live?.id === id ? s.live : { id, text: "", reasoning: "" };
+      const live =
+        e.kind === "text" ? { ...base, text: base.text + delta } : { ...base, reasoning: base.reasoning + delta };
+      return { ...s, items, live, currentAssistant: id, seq };
     }
 
     case "message": {
       const { items, id, seq } = ensureAssistant(s);
       const next = items.map((it) =>
         it.kind === "assistant" && it.id === id
-          ? { ...it, text: e.text ?? it.text, reasoning: e.reasoning ?? it.reasoning, streaming: false }
+          ? {
+              ...it,
+              text: e.text ?? s.live?.text ?? it.text,
+              reasoning: e.reasoning ?? s.live?.reasoning ?? it.reasoning,
+              streaming: false,
+            }
           : it,
       );
-      return { ...s, items: next, currentAssistant: undefined, seq };
+      return { ...s, items: next, live: undefined, currentAssistant: undefined, seq };
     }
 
     case "tool_dispatch": {
@@ -337,10 +348,13 @@ function applyEvent(s: State, e: WireEvent): State {
       // reply, or an empty turn) was really sent — commit it so it isn't lost. A
       // user-cancel before any reply takes the un-send path instead (discardTurn).
       if (s.pendingUser !== undefined) s = flushPendingUser(s);
-      // The turn is over, so nothing more will arrive: freeze a streaming
-      // assistant, and settle any tool still "running" (e.g. a call interrupted
-      // by cancel, which never gets a result) to "stopped" so it stops spinning.
+      // The turn is over, so nothing more will arrive: fold any residual live
+      // segment (a turn that errored before its closing `message`) back into its
+      // item, freeze a streaming assistant, and settle any tool still "running"
+      // (e.g. a call interrupted by cancel, which never gets a result) to "stopped".
       const finalized = s.items.map((it) => {
+        if (it.kind === "assistant" && s.live && it.id === s.live.id)
+          return { ...it, text: s.live.text, reasoning: s.live.reasoning, streaming: false };
         if (it.kind === "assistant" && it.streaming) return { ...it, streaming: false };
         if (it.kind === "tool" && it.status === "running") return { ...it, status: "stopped" as const };
         return it;
@@ -348,7 +362,7 @@ function applyEvent(s: State, e: WireEvent): State {
       const items: Item[] = e.err
         ? [...finalized, { kind: "notice", id: `e${s.seq}`, level: "warn", text: e.err }]
         : finalized;
-      return { ...s, items, running: false, turnActive: false, currentAssistant: undefined, approval: undefined, ask: undefined, seq: s.seq + 1 };
+      return { ...s, items, live: undefined, running: false, turnActive: false, currentAssistant: undefined, approval: undefined, ask: undefined, seq: s.seq + 1 };
     }
     // An unrecognized event kind (e.g. one the kernel added but this build's wire
     // map doesn't name yet) must not collapse state to undefined — ignore it.
@@ -374,7 +388,7 @@ function reducer(s: State, a: Action): State {
       // Esc/Stop before any reply: drop the deferred bubble and mark the turn
       // discarded so its trailing events are swallowed. The composer restores the
       // text from cancel()'s return value.
-      return { ...s, pendingUser: undefined, discardTurn: true, running: false };
+      return { ...s, pendingUser: undefined, discardTurn: true, running: false, live: undefined };
     case "meta":
       return { ...s, meta: a.meta };
     case "context":


### PR DESCRIPTION
## What

`Transcript` already imports `LiveStream` and renders a `live` prop (the streaming overlay), but `useController` never exported the type or held the state, and `App` never passed it. The type-only import resolves to nothing, so `tsc --noEmit` (and therefore `pnpm build`) fails:

```
src/components/Transcript.tsx(2,21): error TS2305:
  Module '"../lib/useController"' has no exported member 'LiveStream'.
```

`wails dev` never hit this because vite/esbuild strips `import type` without checking it — so the dev shell ran while production builds were broken.

## Change

Add the missing half of the streaming refactor:

- `useController`: export `LiveStream`, hold the in-flight segment's text/reasoning in a `live` field instead of accumulating into the `items` array, and fold it back into the assistant item on the closing `message` (with a turn-end fallback for a turn that errors before `message`).
- `App`: pass `live={state.live}` to `Transcript`.

Net effect: a streamed token updates one O(1) field instead of rebuilding the whole backlog array, and the production build typechecks again.

## Verify

- `npm --prefix desktop/frontend run typecheck` — clean (fails on `main-v2` before this change).
- Streaming, multi-segment turns (text → tool → text), errors before `message`, and Esc/un-send all fold/clear `live` correctly.
