### PR TITLE
fix(cli): setup always offers the built-in provider catalog (DeepSeek + MiMo)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -622,6 +622,7 @@ func selectEnabledProviders(providers []config.ProviderEntry) ([]config.Provider
 	for _, s := range stale {
 		fmt.Fprintf(os.Stderr, "  %s\n", dim(fmt.Sprintf(i18n.M.SkipStaleCustomEntryFmt, s.Name, s.BaseURL)))
 	}
+	providers = withBuiltinFamilies(providers)
 
 	famOrder, famMembers, famInfo := groupByFamily(providers)
 
@@ -1042,6 +1043,25 @@ func groupByFamily(providers []config.ProviderEntry) ([]string, map[string][]int
 		members[f.key] = append(members[f.key], i)
 	}
 	return order, members, info
+}
+
+// withBuiltinFamilies guarantees the wizard always offers the built-in provider
+// families (DeepSeek, MiMo) even when the loaded config replaced them — a
+// reasonix.toml that defines only [[providers]] for deepseek otherwise hides
+// MiMo from setup, since [[providers]] replaces the presets wholesale. Families
+// already present are left untouched (the user's customizations win); only the
+// missing built-in families get their default entries appended.
+func withBuiltinFamilies(providers []config.ProviderEntry) []config.ProviderEntry {
+	have := map[string]bool{}
+	for _, p := range providers {
+		have[familyOf(p.Name).key] = true
+	}
+	for _, bp := range config.Default().Providers {
+		if k := familyOf(bp.Name).key; !have[k] {
+			providers = append(providers, bp)
+		}
+	}
+	return providers
 }
 
 // promptMissingKeys re-runs the wizard's key-entry step for any enabled

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -344,3 +344,28 @@ func TestFilterStaleCustomEntries(t *testing.T) {
 		}
 	})
 }
+
+func TestWithBuiltinFamiliesAddsMissingMiMo(t *testing.T) {
+	// The user's case: a reasonix.toml that defines only deepseek providers.
+	cfg := []config.ProviderEntry{
+		{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com"},
+		{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com"},
+	}
+	order, _, info := groupByFamily(withBuiltinFamilies(cfg))
+	seen := map[string]bool{}
+	for _, k := range order {
+		seen[info[k].name] = true
+	}
+	if !seen["DeepSeek"] || !seen["MiMo (Xiaomi)"] {
+		t.Fatalf("wizard families = %v, want both DeepSeek and MiMo", order)
+	}
+	// A user's customized deepseek must not be duplicated.
+	if n := len(groupByFamilyKeys(withBuiltinFamilies(cfg), "deepseek")); n != 2 {
+		t.Fatalf("deepseek members = %d, want the user's 2 (no injected duplicate)", n)
+	}
+}
+
+func groupByFamilyKeys(ps []config.ProviderEntry, key string) []int {
+	_, members, _ := groupByFamily(ps)
+	return members[key]
+}


### PR DESCRIPTION
## Problem

`reasonix setup` listed only the providers already in your config. Because a `reasonix.toml` with `[[providers]]` replaces the built-in presets wholesale, a user whose config defined only `deepseek-*` entries saw **only DeepSeek** in the wizard — MiMo was gone and there was no way to add it back through setup. (Reported: "I want not just DeepSeek but MiMo and custom too.")

## Fix

`withBuiltinFamilies` injects the missing built-in families (DeepSeek, MiMo from `config.Default()`) into the wizard menu before grouping. Families already present are left untouched — the user's customizations win and nothing is duplicated; only **missing** built-in families get their default entries appended. Custom + Anthropic are appended as before.

So setup now always offers DeepSeek + MiMo + 自定义 + Anthropic regardless of the current config, and selecting a built-in still writes only what the user picks.

## Verification

- `go test ./internal/cli` — pass (existing wizard tests unchanged)
- New `TestWithBuiltinFamiliesAddsMissingMiMo` — a deepseek-only config yields both DeepSeek and MiMo families, no deepseek duplication
- E2E with the exact reported config (a `reasonix.toml` with only two deepseek `[[providers]]`): wizard families = `[DeepSeek, MiMo (Xiaomi)]` + 自定义模型 + Anthropic