### PR TITLE
fix(cli): chain into argument menu right after accepting a command

### DIFF
--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -363,9 +363,9 @@ func (m *chatTUI) moveCompletion(delta int) {
 	m.completion.sel = ((m.completion.sel+delta)%n + n) % n
 }
 
-// acceptCompletion applies the selected item to the input. A directory descends
-// (the input is filled and the menu re-opens one level deeper); anything else
-// completes and closes the menu.
+// acceptCompletion applies the selected item to the input, then recomputes the
+// menu from the new value: it re-opens one level deeper (a descended directory
+// or a freshly completed command's arguments) or closes when nothing applies.
 func (m *chatTUI) acceptCompletion() {
 	if m.completion.sel >= len(m.completion.items) {
 		m.completion = completion{}
@@ -379,8 +379,8 @@ func (m *chatTUI) acceptCompletion() {
 	}
 	m.input.SetValue(val[:rf] + it.insert)
 	m.input.CursorEnd()
-	if it.descend {
-		m.updateCompletion() // re-list the directory we just descended into
+	if it.descend || strings.HasSuffix(it.insert, " ") {
+		m.updateCompletion()
 		return
 	}
 	m.updateCompletion() // re-filter for arg completion (e.g. /resume → numbered sessions)

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -189,6 +189,28 @@ func TestResumeArgCompletionListsSessions(t *testing.T) {
 	}
 }
 
+// TestResumeAcceptChainsIntoSessionMenu proves accepting "/resume" (a
+// non-descend command that still takes arguments) immediately opens the session
+// menu, rather than waiting for the next keystroke.
+func TestResumeAcceptChainsIntoSessionMenu(t *testing.T) {
+	dir := t.TempDir()
+	saveTestSession(t, filepath.Join(dir, "a.jsonl"), "first")
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Executor: exec, SessionDir: dir, Label: "test"})
+
+	m.input.SetValue("/resu")
+	m.updateCompletion()
+	m.acceptCompletion()
+	if got := m.input.Value(); got != "/resume " {
+		t.Fatalf("accepting /resume should fill %q, got %q", "/resume ", got)
+	}
+	if !m.completion.active || m.completion.kind != compSlashArg {
+		t.Fatalf("accepting /resume should chain into the session menu: %+v", m.completion)
+	}
+}
+
 // TestRunResumeSwitchesSession proves "/resume <n>" repoints the running
 // controller to the chosen saved session and loads its history.
 func TestRunResumeSwitchesSession(t *testing.T) {


### PR DESCRIPTION
Accepting a slash command that takes arguments but does not descend (e.g. `/resume`) filled the input to `/resume ` but immediately closed the menu, so the subcommand hints only reappeared on the next keystroke. In practice the user had to delete the trailing space and retype it before the session list showed up.

The cause is in `acceptCompletion()`: only descend commands (`/mcp`, `/model`, …) recomputed the menu after acceptance; everything else just cleared it.

Now the menu is recomputed whenever the accepted insert leaves the command word complete (descend, or an insert ending in a space — i.e. we're now in argument territory). Argument-less commands (`/rewind`, `/quit`, … whose insert has no trailing space) still close as before, so the menu never re-matches the command back onto itself.

Adds the regression test `TestResumeAcceptChainsIntoSessionMenu` covering this path.
