### PR TITLE
fix(serve): cache session titles and match current session on Windows

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -32,11 +33,12 @@ type Server struct {
 	ctrl      *control.Controller
 	bc        *Broadcaster
 	titleProv provider.Provider // lightweight flash provider for session titles
+	titles    *titleCache
 }
 
 // New builds a Server. bc must be the controller's event sink.
 func New(ctrl *control.Controller, bc *Broadcaster) *Server {
-	s := &Server{ctrl: ctrl, bc: bc}
+	s := &Server{ctrl: ctrl, bc: bc, titles: newTitleCache(ctrl.SessionDir())}
 	s.initTitleProvider()
 	return s
 }
@@ -584,28 +586,18 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, []any{})
 		return
 	}
-	current := s.ctrl.SessionPath()
+	current := filepath.Clean(s.ctrl.SessionPath())
 	var out []sessionEntry
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
 			continue
 		}
-		path := dir + "/" + e.Name()
+		path := filepath.Join(dir, e.Name())
 		name := strings.TrimSuffix(e.Name(), ".jsonl")
-		entry := sessionEntry{Name: name, Path: path, Current: path == current}
-		// Read first user message for title generation and turn count.
+		entry := sessionEntry{Name: name, Path: path, Current: filepath.Clean(path) == current}
 		if first, turns := previewSessionFile(path); turns > 0 {
 			entry.Turns = turns
-			if title := s.generateTitle(r.Context(), first); title != "" {
-				entry.Title = title
-			} else if first != "" {
-				// Fallback: truncate the first message as a preview.
-				if r := []rune(first); len(r) > 50 {
-					entry.Title = string(r[:47]) + "..."
-				} else {
-					entry.Title = first
-				}
-			}
+			entry.Title = s.sessionTitle(r.Context(), e.Name(), first, fileModNano(e))
 		}
 		out = append(out, entry)
 	}
@@ -617,6 +609,35 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 		out = []sessionEntry{}
 	}
 	writeJSON(w, out)
+}
+
+// sessionTitle returns a title for a session: the cached flash-generated title
+// when it matches the file's mtime, otherwise a freshly generated one (cached
+// for next time), falling back to a truncated preview when generation is off.
+func (s *Server) sessionTitle(ctx context.Context, name, first string, mod int64) string {
+	if cached, ok := s.titles.get(name, mod); ok {
+		return cached
+	}
+	if title := s.generateTitle(ctx, first); title != "" {
+		s.titles.put(name, title, mod)
+		return title
+	}
+	return previewTitle(first)
+}
+
+func previewTitle(first string) string {
+	if r := []rune(first); len(r) > 50 {
+		return string(r[:47]) + "..."
+	}
+	return first
+}
+
+func fileModNano(e os.DirEntry) int64 {
+	info, err := e.Info()
+	if err != nil {
+		return 0
+	}
+	return info.ModTime().UnixNano()
 }
 
 // previewSessionFile reads the first user message and turn count from a JSONL session file.

--- a/internal/serve/titlecache.go
+++ b/internal/serve/titlecache.go
@@ -1,0 +1,58 @@
+package serve
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// titleCache persists generated session titles to <dir>/.session-titles.json,
+// keyed by file name and invalidated by mtime, so the flash model is queried
+// once per session rather than on every sidebar refresh. Persistence is
+// best-effort: a missing or unreadable cache just regenerates.
+type titleCache struct {
+	mu      sync.Mutex
+	dir     string
+	loaded  bool
+	entries map[string]titleEntry
+}
+
+type titleEntry struct {
+	Title string `json:"title"`
+	Mod   int64  `json:"mod"`
+}
+
+func newTitleCache(dir string) *titleCache {
+	return &titleCache{dir: dir, entries: map[string]titleEntry{}}
+}
+
+func (c *titleCache) load() {
+	if c.loaded {
+		return
+	}
+	c.loaded = true
+	if data, err := os.ReadFile(filepath.Join(c.dir, ".session-titles.json")); err == nil {
+		json.Unmarshal(data, &c.entries)
+	}
+}
+
+func (c *titleCache) get(name string, mod int64) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.load()
+	if e, ok := c.entries[name]; ok && e.Mod == mod {
+		return e.Title, true
+	}
+	return "", false
+}
+
+func (c *titleCache) put(name, title string, mod int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.load()
+	c.entries[name] = titleEntry{Title: title, Mod: mod}
+	if data, err := json.Marshal(c.entries); err == nil {
+		os.WriteFile(filepath.Join(c.dir, ".session-titles.json"), data, 0o644)
+	}
+}

--- a/internal/serve/titlecache_test.go
+++ b/internal/serve/titlecache_test.go
@@ -1,0 +1,36 @@
+package serve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTitleCacheReusesUntilMtimeChanges(t *testing.T) {
+	dir := t.TempDir()
+	c := newTitleCache(dir)
+
+	if _, ok := c.get("a.jsonl", 100); ok {
+		t.Fatal("empty cache should miss")
+	}
+
+	c.put("a.jsonl", "First Title", 100)
+	if got, ok := c.get("a.jsonl", 100); !ok || got != "First Title" {
+		t.Fatalf("hit on matching mtime = %q,%v, want First Title,true", got, ok)
+	}
+	if _, ok := c.get("a.jsonl", 200); ok {
+		t.Fatal("changed mtime should invalidate the cached title")
+	}
+}
+
+func TestTitleCachePersistsAcrossInstances(t *testing.T) {
+	dir := t.TempDir()
+	newTitleCache(dir).put("a.jsonl", "Persisted", 7)
+
+	if _, err := os.Stat(filepath.Join(dir, ".session-titles.json")); err != nil {
+		t.Fatalf("cache file not written: %v", err)
+	}
+	if got, ok := newTitleCache(dir).get("a.jsonl", 7); !ok || got != "Persisted" {
+		t.Fatalf("fresh instance get = %q,%v, want Persisted,true", got, ok)
+	}
+}


### PR DESCRIPTION
Follow-up to #2742.

### Session titles were regenerated on every request
`GET /sessions` called the flash model for every session file on every fetch — one LLM round-trip per session, repeated each time the sidebar refreshed. For a directory of N sessions that's N flash calls per load, with no reuse.

Titles are now persisted to `<sessionDir>/.session-titles.json`, keyed by file name and invalidated by mtime. A session is titled once and reused across refreshes and restarts; only a session whose first message actually changes is re-titled. The fallback preview (when the flash provider is off) is not cached, so titles upgrade automatically once a flash model is configured. The cache lives in its own `titlecache.go` to keep `serve.go` from growing.

### Current-session highlight never matched on Windows
The listing built paths as `dir + "/" + name` and compared them to `SessionPath()`, which comes from `filepath.Join` (backslashes on Windows). The string compare could never be true there, so the active session was never highlighted. Paths are now built with `filepath.Join` and compared via `filepath.Clean` on both sides.

Adds `titlecache_test.go` covering cache hit, mtime invalidation, and persistence across instances.
