### PR TITLE
Manage Recent Sessions from the Desktop Sidebar

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -406,13 +406,21 @@ func (a *App) ListSessions() []SessionMeta {
 // session — that's the conversation on screen, and auto-save would recreate the
 // file on the next turn; start a new session first to retire it.
 func (a *App) DeleteSession(path string) error {
+	dir := config.SessionDir()
+	sessionPath, _, err := validateSessionPath(dir, path)
+	if err != nil {
+		return err
+	}
 	a.mu.RLock()
 	ctrl := a.ctrl
 	a.mu.RUnlock()
-	if ctrl != nil && ctrl.SessionPath() == path {
-		return errActiveSession
+	if ctrl != nil {
+		currentPath, _, err := validateSessionPath(dir, ctrl.SessionPath())
+		if err == nil && currentPath == sessionPath {
+			return errActiveSession
+		}
 	}
-	return deleteSessionFile(config.SessionDir(), path)
+	return deleteSessionFile(dir, sessionPath)
 }
 
 // RenameSession sets a custom display name for a session (empty clears it back to

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -104,6 +105,31 @@ func TestSetEffortRejectsRunningTurn(t *testing.T) {
 
 	close(runner.release)
 	waitNotRunning(t, app.ctrl)
+}
+
+func TestDeleteSessionRejectsActiveRelativePath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "active.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	app := NewApp()
+	app.ctrl = control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "test"})
+	defer app.ctrl.Close()
+
+	if err := app.DeleteSession(filepath.Base(path)); err != errActiveSession {
+		t.Fatalf("DeleteSession(active basename) error = %v, want errActiveSession", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("active session should remain: %v", err)
+	}
 }
 
 type blockingRunner struct {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -7,10 +7,14 @@ import {
   History,
   Settings as SettingsIcon,
   MessageSquare,
+  Pencil,
   PanelLeftClose,
   PanelLeftOpen,
   PanelRightClose,
   PanelRightOpen,
+  Check,
+  Trash2,
+  X,
 } from "lucide-react";
 import logo from "./assets/logo.svg";
 import { useT } from "./lib/i18n";
@@ -159,6 +163,9 @@ export default function App() {
   const [memView, setMemView] = useState<MemoryView | null>(null);
   const [histView, setHistView] = useState<SessionMeta[] | null>(null);
   const [sidebarSessions, setSidebarSessions] = useState<SessionMeta[]>([]);
+  const [sidebarEditing, setSidebarEditing] = useState<string | null>(null);
+  const [sidebarDraft, setSidebarDraft] = useState("");
+  const [sidebarConfirming, setSidebarConfirming] = useState<string | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(loadSidebarCollapsed);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
@@ -520,7 +527,8 @@ export default function App() {
     async (path: string) => {
       if (state.running) return;
       await deleteSession(path);
-      setHistView(await refreshSessions());
+      const sessions = await refreshSessions();
+      setHistView((cur) => (cur === null ? null : sessions));
     },
     [state.running, deleteSession, refreshSessions],
   );
@@ -528,9 +536,36 @@ export default function App() {
     async (path: string, title: string) => {
       if (state.running) return;
       await renameSession(path, title);
-      setHistView(await refreshSessions());
+      const sessions = await refreshSessions();
+      setHistView((cur) => (cur === null ? null : sessions));
     },
     [state.running, renameSession, refreshSessions],
+  );
+
+  const startSidebarRename = useCallback((session: SessionMeta) => {
+    if (state.running) return;
+    setSidebarConfirming(null);
+    setSidebarEditing(session.path);
+    setSidebarDraft(session.title || session.preview || "");
+  }, [state.running]);
+
+  const commitSidebarRename = useCallback(
+    async (path: string) => {
+      if (state.running) return;
+      const title = sidebarDraft.trim();
+      setSidebarEditing(null);
+      await onRenameSession(path, title);
+    },
+    [onRenameSession, sidebarDraft, state.running],
+  );
+
+  const confirmSidebarDelete = useCallback(
+    async (path: string) => {
+      if (state.running) return;
+      setSidebarConfirming(null);
+      await onDeleteSession(path);
+    },
+    [onDeleteSession, state.running],
   );
 
   // Workspace: open the folder chooser and switch projects. The hook resets the
@@ -625,21 +660,85 @@ export default function App() {
                 <div className="sidebar__empty">{t("sidebar.noRecent")}</div>
               ) : (
                 sidebarSessions.map((session) => (
-                  <button
+                  <div
                     className={`sidebar-session${session.current ? " sidebar-session--current" : ""}`}
                     key={session.path}
-                    onClick={() => void onResumeSession(session.path)}
-                    disabled={state.running || session.current}
                     title={session.path}
                   >
-                    <MessageSquare size={14} />
-                    <span className="sidebar-session__body">
-                      <span className="sidebar-session__title">{sessionTitle(session, t("history.emptySession"))}</span>
-                      <span className="sidebar-session__meta">
-                        {session.current ? t("history.current") : sessionTime(sessionActivityTime(session))}
+                    {sidebarEditing === session.path ? (
+                      <input
+                        className="sidebar-session__rename"
+                        autoFocus
+                        value={sidebarDraft}
+                        onChange={(e) => setSidebarDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") void commitSidebarRename(session.path);
+                          if (e.key === "Escape") setSidebarEditing(null);
+                        }}
+                        onBlur={() => void commitSidebarRename(session.path)}
+                        placeholder={t("history.namePlaceholder")}
+                      />
+                    ) : (
+                      <button
+                        className="sidebar-session__main"
+                        onClick={() => void onResumeSession(session.path)}
+                        disabled={state.running || session.current}
+                        title={session.path}
+                      >
+                        <MessageSquare size={14} />
+                        <span className="sidebar-session__body">
+                          <span className="sidebar-session__title">{sessionTitle(session, t("history.emptySession"))}</span>
+                          <span className="sidebar-session__meta">
+                            {session.current ? t("history.current") : sessionTime(sessionActivityTime(session))}
+                          </span>
+                        </span>
+                      </button>
+                    )}
+                    {sidebarEditing !== session.path && (
+                      <span className="sidebar-session__actions">
+                        {sidebarConfirming === session.path ? (
+                          <>
+                            <button
+                              className="sidebar-session__act sidebar-session__act--danger"
+                              title={t("history.confirmDelete")}
+                              disabled={state.running}
+                              onClick={() => void confirmSidebarDelete(session.path)}
+                            >
+                              <Check size={13} />
+                            </button>
+                            <button
+                              className="sidebar-session__act"
+                              title={t("common.cancel")}
+                              onClick={() => setSidebarConfirming(null)}
+                            >
+                              <X size={13} />
+                            </button>
+                          </>
+                        ) : (
+                          <>
+                            <button
+                              className="sidebar-session__act"
+                              title={t("history.rename")}
+                              disabled={state.running}
+                              onClick={() => startSidebarRename(session)}
+                            >
+                              <Pencil size={12} />
+                            </button>
+                            {!session.current && (
+                              <button
+                                className="sidebar-session__act"
+                                title={t("common.delete")}
+                                disabled={state.running}
+                                onClick={() => setSidebarConfirming(session.path)}
+                              >
+                                <Trash2 size={12} />
+                              </button>
+                            )}
+                          </>
+                        )}
                       </span>
-                    </span>
-                  </button>
+                    )}
+                  </div>
                 ))
               )}
             </div>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -476,17 +476,40 @@ body {
 .sidebar-session {
   display: flex;
   align-items: center;
-  gap: var(--list-row-gap);
+  gap: 4px;
   height: var(--list-row-height);
-  padding: 0 var(--list-row-px);
+  padding: 0 4px 0 var(--list-row-px);
   margin-bottom: 2px;
   border-radius: var(--list-row-radius);
+  cursor: default;
 }
 .sidebar-session:hover {
   background: var(--list-row-hover-bg);
 }
 .sidebar-session svg {
   display: none;
+}
+.sidebar-session__main {
+  --wails-draggable: no-drag;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--list-row-gap);
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.sidebar-session__main:disabled {
+  cursor: default;
+}
+.sidebar-session__main:disabled:hover {
+  color: inherit;
 }
 .sidebar-session__body {
   display: flex;
@@ -511,6 +534,65 @@ body {
   color: var(--list-row-meta);
   font-size: 11px;
   line-height: 1;
+}
+.sidebar-session__actions {
+  --wails-draggable: no-drag;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.sidebar-session:hover .sidebar-session__actions,
+.sidebar-session:focus-within .sidebar-session__actions {
+  opacity: 1;
+}
+.sidebar-session__act {
+  --wails-draggable: no-drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-faint);
+  cursor: pointer;
+}
+.sidebar-session__act svg {
+  display: block;
+}
+.sidebar-session__act:hover {
+  color: var(--fg);
+  background: var(--bg);
+}
+.sidebar-session__act:disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+.sidebar-session__act:disabled:hover {
+  color: var(--fg-faint);
+  background: transparent;
+}
+.sidebar-session__act--danger,
+.sidebar-session__act--danger:hover {
+  color: #e5534b;
+}
+.sidebar-session__rename {
+  --wails-draggable: no-drag;
+  flex: 1;
+  min-width: 0;
+  height: 26px;
+  padding: 0 8px;
+  border: 1px solid var(--accent-soft);
+  border-radius: 7px;
+  background: var(--bg-elev);
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  outline: none;
 }
 .sidebar-session--current {
   background: var(--list-row-current-bg);

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -67,6 +67,10 @@ func saveSessionTitles(dir string, m map[string]string) error {
 
 // setSessionTitle sets (or, with an empty title, clears) a session's custom name.
 func setSessionTitle(dir, sessionPath, title string) error {
+	sessionPath, _, err := validateSessionPath(dir, sessionPath)
+	if err != nil {
+		return err
+	}
 	m := loadSessionTitles(dir)
 	key := filepath.Base(sessionPath)
 	if strings.TrimSpace(title) == "" {
@@ -77,25 +81,80 @@ func setSessionTitle(dir, sessionPath, title string) error {
 	return saveSessionTitles(dir, m)
 }
 
-// deleteSessionFile removes a session's .jsonl and its title entry.
+// deleteSessionFile removes a session's .jsonl and its sidecar state.
 func deleteSessionFile(dir, sessionPath string) error {
+	sessionPath, key, err := validateSessionPath(dir, sessionPath)
+	if err != nil {
+		return err
+	}
 	if err := os.Remove(sessionPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	if err := os.Remove(sessionPath + ".meta"); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.RemoveAll(strings.TrimSuffix(sessionPath, ".jsonl") + ".ckpt"); err != nil {
+		return err
+	}
 	m := loadSessionTitles(dir)
-	if _, ok := m[filepath.Base(sessionPath)]; ok {
-		delete(m, filepath.Base(sessionPath))
+	if _, ok := m[key]; ok {
+		delete(m, key)
 		if err := saveSessionTitles(dir, m); err != nil {
 			return err
 		}
 	}
-	if dm := loadSessionDisplays(dir); dm[filepath.Base(sessionPath)] != nil {
-		delete(dm, filepath.Base(sessionPath))
+	if dm := loadSessionDisplays(dir); dm[key] != nil {
+		delete(dm, key)
 		if err := saveSessionDisplays(dir, dm); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func validateSessionPath(dir, sessionPath string) (string, string, error) {
+	if strings.TrimSpace(sessionPath) == "" {
+		return "", "", fmt.Errorf("empty session path")
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", "", err
+	}
+	path := sessionPath
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(absDir, path)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", err
+	}
+	if filepath.Ext(absPath) != ".jsonl" {
+		return "", "", fmt.Errorf("not a session file: %s", sessionPath)
+	}
+	rel, err := filepath.Rel(absDir, absPath)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+		return "", "", fmt.Errorf("session path outside session dir: %s", sessionPath)
+	}
+	if info, err := os.Lstat(absPath); err == nil {
+		if info.IsDir() {
+			return "", "", fmt.Errorf("not a session file: %s", sessionPath)
+		}
+		realDir, dirErr := filepath.EvalSymlinks(absDir)
+		if dirErr != nil {
+			realDir = absDir
+		}
+		realPath, err := filepath.EvalSymlinks(absPath)
+		if err != nil {
+			return "", "", err
+		}
+		rel, err := filepath.Rel(realDir, realPath)
+		if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." || filepath.IsAbs(rel) {
+			return "", "", fmt.Errorf("session path escapes session dir: %s", sessionPath)
+		}
+	} else if !os.IsNotExist(err) {
+		return "", "", err
+	}
+	return absPath, filepath.Base(absPath), nil
 }
 
 type sessionDisplayMap map[string]map[string]string

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -114,6 +114,13 @@ func TestDeleteSessionFile(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")
 	os.WriteFile(sessionPath, []byte("data"), 0o644)
+	metaPath := sessionPath + ".meta"
+	os.WriteFile(metaPath, []byte("{}"), 0o644)
+	ckptDir := filepath.Join(dir, "session.ckpt")
+	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
+		t.Fatalf("mkdir ckpt: %v", err)
+	}
+	os.WriteFile(filepath.Join(ckptDir, "1.json"), []byte("{}"), 0o644)
 
 	// Set a title first.
 	setSessionTitle(dir, sessionPath, "My Title")
@@ -127,6 +134,12 @@ func TestDeleteSessionFile(t *testing.T) {
 	// File should be gone.
 	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
 		t.Error("session file should be deleted")
+	}
+	if _, err := os.Stat(metaPath); !os.IsNotExist(err) {
+		t.Error("session meta should be deleted")
+	}
+	if _, err := os.Stat(ckptDir); !os.IsNotExist(err) {
+		t.Error("session checkpoints should be deleted")
 	}
 	// Title should be gone.
 	m := loadSessionTitles(dir)
@@ -156,6 +169,49 @@ func TestDeleteSessionFileMissing(t *testing.T) {
 	// Deleting a non-existent file should not error.
 	if err := deleteSessionFile(dir, filepath.Join(dir, "missing.jsonl")); err != nil {
 		t.Fatalf("delete missing: %v", err)
+	}
+}
+
+func TestDeleteSessionFileRejectsOutsideDir(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.jsonl")
+	os.WriteFile(outside, []byte("data"), 0o644)
+
+	if err := deleteSessionFile(dir, outside); err == nil {
+		t.Fatal("delete outside dir should fail")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside file should remain: %v", err)
+	}
+}
+
+func TestDeleteSessionFileRejectsNonJSONL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.meta")
+	os.WriteFile(path, []byte("data"), 0o644)
+
+	if err := deleteSessionFile(dir, path); err == nil {
+		t.Fatal("delete non-jsonl should fail")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("non-jsonl file should remain: %v", err)
+	}
+}
+
+func TestDeleteSessionFileRejectsSymlinkEscape(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.jsonl")
+	os.WriteFile(outside, []byte("data"), 0o644)
+	link := filepath.Join(dir, "link.jsonl")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if err := deleteSessionFile(dir, link); err == nil {
+		t.Fatal("delete symlink escape should fail")
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Fatalf("outside target should remain: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds inline rename and delete controls to the desktop sidebar's recent-session list.
- Hardens desktop session rename/delete APIs so they only operate on valid `.jsonl` session files under the configured session directory.
- Deletes session sidecar state together with the transcript, including title/display metadata, branch metadata, and checkpoint directories.

## Root Cause
Recent sessions could only be managed from the full history drawer, even though the sidebar is the primary place users see and switch between recent conversations. The backend delete path also trusted the frontend-provided path too much and only removed part of the session's persisted sidecar state.

## Technical Approach
- Reworked sidebar session rows so the main row remains the resume target while compact action buttons appear on hover/focus.
- Added inline rename input and two-step delete confirmation to match the existing history drawer behavior.
- Added session path validation before rename/delete, including directory containment, `.jsonl` extension checks, and symlink escape rejection.
- Extended delete cleanup to remove `.meta`, `.ckpt`, title sidecar, and display sidecar entries.

## Focused Optimization Points
- Keeps the current session protected from deletion while still allowing rename.
- Avoids changing session filenames, preserving stable resume/checkpoint identifiers.
- Refreshes sidebar/history data after mutations without opening the history drawer when actions originate from the sidebar.
- Keeps controls compact and hidden until hover/focus so existing title/date scanability is preserved.

## Verification
- `npm run build` in `desktop/frontend` passed. Vite reported the existing large chunk warning.
- `go test ./...` in `desktop` passed.
- `git diff --check` passed.
- In-app browser verification on `http://127.0.0.1:5173/`: sidebar rename updated the row title, delete confirmation removed the row from the recent-session list.
