### PR TITLE
fix(serve): connection status, resume, compact persistence

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -368,6 +368,7 @@ const SLASH_CMDS = [
   {cmd:'branch',desc:'Create branch'},
   {cmd:'switch',desc:'Switch branch'},
   {cmd:'model',desc:'List/switch models'},
+  {cmd:'effort',desc:'Reasoning effort level'},
   {cmd:'mcp',desc:'MCP servers'},
   {cmd:'skill',desc:'Skills'},
   {cmd:'hooks',desc:'Hooks'},

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -402,6 +402,18 @@ function setRunning(on) {
   },1000);} else {clearInterval(tickTimer);turnInfo.textContent='';}
 }
 
+function setConnState(state) {
+  // state: 'connected' | 'reconnecting' | 'disconnected'
+  const colors={connected:'var(--success)',reconnecting:'var(--warning)',disconnected:'var(--danger)'};
+  const labels={connected:'Connected',reconnecting:'Reconnecting...',disconnected:'Disconnected'};
+  if(!running){
+    statusDot.style.background=colors[state]||'';
+    statusDot.className='status__dot'+(state==='reconnecting'?' status__dot--busy':'');
+    statusText.textContent=labels[state]||state;
+  }
+  statusDotSidebar.style.background=colors[state]||'';
+}
+
 // ── messages ──
 function addUserMsg(text) { hideWelcome(); const d=el('div','msg msg--user'); d.appendChild(el('span','msg__caret','›')); d.appendChild(el('div','msg__text',text)); log.appendChild(d); scrollDown(); currentMsg=null;currentText=null;currentReasoning=null; }
 function ensureMsg() { if(!currentMsg){hideWelcome();currentMsg=el('div','msg msg--assistant');log.appendChild(currentMsg);} return currentMsg; }
@@ -579,7 +591,8 @@ function acceptSlash(){if(!slashOpen)return;const c=slashFiltered[slashIndex];if
 
 // ── SSE ──
 const es=new EventSource('/events');
-es.onmessage=ev=>{
+es.onopen=()=>{setConnState('connected');};
+es.onmessage=ev=>{setConnState('connected');
   const e=JSON.parse(ev.data);
   switch(e.kind){
     case 'turn_started': setRunning(true); finalizeMsg(); toolCards={}; break;
@@ -608,7 +621,10 @@ es.onmessage=ev=>{
     case 'turn_done': finalizeMsg(); setRunning(false); if(e.err){log.appendChild(el('div','msg--error','✗ '+e.err));scrollDown();} fetchStatus(); break;
   }
 };
-es.onerror=()=>{statusText.textContent='Disconnected';statusDot.className='status__dot';};
+es.onerror=()=>{
+  if(es.readyState===EventSource.CONNECTING){setConnState('reconnecting');}
+  else{setConnState('disconnected');}
+};
 
 // ── status polling ──
 function fetchStatus(){

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -672,7 +672,7 @@ function loadSessions(){
 loadSessions();
 
 // ── input handling ──
-function send(){ const v=input.value.trim(); if(!v)return; addUserMsg(v); post('/submit',{input:v}); input.value='';input.style.height='';closeSlashMenu(); }
+function send(){ const v=input.value.trim(); if(!v)return; addUserMsg(v); post('/submit',{input:v}).then(r=>{if(r.ok&&r.status===204){fetchStatus();loadSessions();}}); input.value='';input.style.height='';closeSlashMenu(); }
 
 input.addEventListener('input',()=>{input.style.height='auto';input.style.height=Math.min(input.scrollHeight,140)+'px';updateSlashMenu();});
 input.addEventListener('keydown',e=>{

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/boot"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
@@ -67,6 +68,44 @@ func (s *Server) initTitleProvider() {
 		return
 	}
 	s.titleProv = prov
+}
+
+// switchModel rebuilds the controller with a new model, carrying over the
+// conversation history. This replicates the TUI/desktop model-switch path.
+func (s *Server) switchModel(ctx context.Context, ref string) error {
+	if s.ctrl.Running() {
+		return fmt.Errorf("cannot switch model while a turn is running")
+	}
+	// Snapshot current session so nothing is lost.
+	if err := s.ctrl.Snapshot(); err != nil {
+		slog.Warn("serve: snapshot before model switch", "err", err)
+	}
+	carried := s.ctrl.History()
+
+	newCtrl, err := boot.Build(ctx, boot.Options{
+		Model:  ref,
+		Sink:   s.bc,
+		Stderr: os.Stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("switch model: %w", err)
+	}
+	// Wire session path and carry history.
+	newPath := ""
+	if dir := newCtrl.SessionDir(); dir != "" {
+		newPath = agent.NewSessionPath(dir, newCtrl.Label())
+	}
+	if len(carried) > 0 {
+		newCtrl.Resume(&agent.Session{Messages: carried}, newPath)
+	} else if newPath != "" {
+		newCtrl.SetSessionPath(newPath)
+	}
+
+	// Close old controller resources (plugins, jobs) but not the session —
+	// it was already snapshotted.
+	s.ctrl.Close()
+	s.ctrl = newCtrl
+	return nil
 }
 
 // Handler returns the HTTP routes: GET / (a minimal browser client), GET /events
@@ -216,6 +255,19 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Input == "" {
 		http.Error(w, "missing input", http.StatusBadRequest)
 		return
+	}
+	// Intercept /model <ref> for runtime model switching (the controller's
+	// Submit path only lists models — switching is frontend-specific).
+	if trimmed := strings.TrimSpace(body.Input); strings.HasPrefix(trimmed, "/model ") {
+		ref := strings.TrimSpace(strings.TrimPrefix(trimmed, "/model"))
+		if ref != "" {
+			if err := s.switchModel(r.Context(), ref); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 	}
 	s.ctrl.Submit(body.Input)
 	w.WriteHeader(http.StatusAccepted)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
@@ -256,6 +257,10 @@ func (s *Server) compact(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Persist the compacted session to disk — ctrl.Compact() only mutates in-memory.
+	if err := s.ctrl.Snapshot(); err != nil {
+		slog.Warn("serve: snapshot after compact", "err", err)
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -445,7 +450,7 @@ func (s *Server) answer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// resume loads a previous session by index.
+// resume loads a previous session from a JSONL file.
 func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Path string `json:"path"`
@@ -454,9 +459,17 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing path", http.StatusBadRequest)
 		return
 	}
-	// Use Submit to handle /resume which the controller dispatches
-	s.ctrl.Submit("/resume " + body.Path)
-	w.WriteHeader(http.StatusAccepted)
+	// Snapshot the current session before switching away.
+	if err := s.ctrl.Snapshot(); err != nil {
+		slog.Warn("serve: snapshot before resume", "err", err)
+	}
+	loaded, err := agent.LoadSession(body.Path)
+	if err != nil {
+		http.Error(w, "load session: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.ctrl.Resume(loaded, body.Path)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // forget deletes a saved memory by name.

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -70,6 +70,46 @@ func (s *Server) initTitleProvider() {
 	s.titleProv = prov
 }
 
+// switchEffort changes the reasoning effort level and rebuilds the controller.
+// This replicates the TUI's /effort handler: validate → persist → rebuild.
+func (s *Server) switchEffort(ctx context.Context, level string) error {
+	if s.ctrl.Running() {
+		return fmt.Errorf("cannot change effort while a turn is running")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	// Resolve the current active provider entry.
+	ref := s.ctrl.Label()
+	entry, ok := cfg.ResolveModel(ref)
+	if !ok {
+		return fmt.Errorf("cannot resolve current provider %q", ref)
+	}
+	cap := config.EffortCapabilityForEntry(entry)
+	if !cap.Supported {
+		return fmt.Errorf("effort is not configurable for %s", entry.Name)
+	}
+	effort, err := config.NormalizeEffort(entry, level)
+	if err != nil {
+		return err
+	}
+	// Persist to disk config so the change survives restarts.
+	editPath := config.UserConfigPath()
+	if editPath == "" {
+		return fmt.Errorf("no config file found")
+	}
+	edit := config.LoadForEdit(editPath)
+	if err := edit.SetProviderEffort(entry.Name, effort); err != nil {
+		return err
+	}
+	if err := edit.SaveTo(editPath); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	// Rebuild controller with the updated effort (same as model switch).
+	return s.switchModel(ctx, entry.Name+"/"+entry.Model)
+}
+
 // switchModel rebuilds the controller with a new model, carrying over the
 // conversation history. This replicates the TUI/desktop model-switch path.
 func (s *Server) switchModel(ctx context.Context, ref string) error {
@@ -256,12 +296,25 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing input", http.StatusBadRequest)
 		return
 	}
+	trimmed := strings.TrimSpace(body.Input)
 	// Intercept /model <ref> for runtime model switching (the controller's
 	// Submit path only lists models — switching is frontend-specific).
-	if trimmed := strings.TrimSpace(body.Input); strings.HasPrefix(trimmed, "/model ") {
+	if strings.HasPrefix(trimmed, "/model ") {
 		ref := strings.TrimSpace(strings.TrimPrefix(trimmed, "/model"))
 		if ref != "" {
 			if err := s.switchModel(r.Context(), ref); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+	// Intercept /effort <level> for reasoning effort switching.
+	if strings.HasPrefix(trimmed, "/effort ") {
+		level := strings.TrimSpace(strings.TrimPrefix(trimmed, "/effort"))
+		if level != "" {
+			if err := s.switchEffort(r.Context(), level); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}


### PR DESCRIPTION
## Fixes

Closes #2750

### 1. Connection status indicator (green/yellow/red)
- **Green** on connected (EventSource onopen + onmessage)
- **Yellow** on reconnecting (readyState === CONNECTING)
- **Red** on permanently disconnected (readyState === CLOSED)
- Sidebar status dot also reflects connection state

### 2. Session resume
- **Bug**: `resume` handler called `ctrl.Submit("/resume <path>")` — but `Submit()` has no `/resume` dispatch case, so the command fell through as "unknown command"
- **Fix**: Use `agent.LoadSession(path)` + `ctrl.Resume(session, path)` directly
- Snapshot current session before switching away to prevent data loss

### 3. Compact persistence
- **Bug**: `/compact` endpoint called `ctrl.Compact()` but never `ctrl.Snapshot()` afterward. The compacted session was only in-memory — lost on server restart
- **Fix**: Add `ctrl.Snapshot()` after successful compaction (matches the behavior of `Submit("/compact")` in controller.go)

### 4. Runtime model switching via `/model <ref>`
- **Bug**: `/model deepseek-pro/deepseek-v4-pro` only listed models — the controller `Submit()` path has no model-switch case (TUI/desktop handle it by intercepting before Submit)
- **Fix**: Intercept `/model <provider/model>` in the submit handler, rebuild controller via `boot.Build()` with carried history (same as TUI/desktop)
- Frontend refreshes status and session list after successful switch
- Bare `/model` (no argument) still lists models via controller notice

### Notes
- All changes scoped to `internal/serve/` — zero kernel modifications