### PR TITLE
feat(desktop): first-run onboarding overlay for default provider API key

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -12,11 +12,13 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 	"unicode/utf8"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/billing"
 	"reasonix/internal/boot"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
@@ -1806,6 +1808,72 @@ func parseScope(s string) memory.Scope {
 	default:
 		return memory.ScopeProject
 	}
+}
+
+// onboardingKeyEnv is the API key the first-run overlay asks for. It matches the
+// default provider (deepseek) in config.Default(); once it's set the kernel can
+// boot. Other providers are configured later via the Settings panel.
+const onboardingKeyEnv = "DEEPSEEK_API_KEY"
+
+// onboardingBalanceURL is the vendor balance endpoint that doubles as a
+// connectivity + auth probe — billing.FetchWithClient hits it with the user's
+// key and surfaces 401/403 for invalid keys. We use it instead of a separate
+// /models GET so the call costs zero tokens and reuses the existing billing
+// HTTP client (12s timeout, ctx-cancellable).
+const onboardingBalanceURL = "https://api.deepseek.com/user/balance"
+
+// NeedsOnboarding reports whether the first-run overlay should be shown. It
+// returns true when the default provider's API key env var is unset in the
+// process — which covers both a fresh install and a user who cleared their key
+// before launching. Cheap (no I/O, no config reload), so the frontend can call
+// it once on mount.
+func (a *App) NeedsOnboarding() bool {
+	return strings.TrimSpace(os.Getenv(onboardingKeyEnv)) == ""
+}
+
+// ConnectKey validates apiKey against the default provider's balance endpoint
+// and, on success, persists it to ./.env (via upsertDotEnv, which also sets the
+// process env so the next rebuild picks it up). The validation reuses
+// billing.FetchWithClient — a 12s timeout, a network call that costs no tokens
+// — so a typo'd key surfaces as 401 quickly. After writing the key we trigger
+// a controller rebuild; the kernel emits agent:ready once boot.Build completes
+// and the frontend then transitions off the overlay.
+//
+// Errors:
+//   - empty key → "key is required"
+//   - HTTP 401/403 → wrapped status so the UI can show "invalid key"
+//   - network/dial failure → wrapped; the UI shows "network unreachable"
+//   - any other HTTP status → wrapped
+//
+// Note: this method is bound to the UI before boot.Build has necessarily
+// finished. The rebuild below re-issues boot.Build with the freshly-set env
+// var; if the kernel already booted (key was empty so it built no controller),
+// this is the first real build, otherwise it's a rebuild.
+func (a *App) ConnectKey(apiKey string) error {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return fmt.Errorf("key is required")
+	}
+	ctx, cancel := context.WithTimeout(a.ctx, 8*time.Second)
+	defer cancel()
+	// FetchWithClient returns (nil, nil) when the url is empty — we never hit
+	// that path (onboardingBalanceURL is constant), but be defensive.
+	if _, err := billing.FetchWithClient(ctx, nil, onboardingBalanceURL, apiKey); err != nil {
+		return fmt.Errorf("validate: %w", err)
+	}
+	if err := upsertDotEnv(onboardingKeyEnv, apiKey); err != nil {
+		return fmt.Errorf("save: %w", err)
+	}
+	// rebuild the controller so the new key takes effect; startupErr is cleared
+	// by rebuild on success, so the topbar banner disappears on agent:ready.
+	if err := a.rebuild(); err != nil {
+		// Keep going — the key is persisted; the next user action that
+		// triggers a rebuild (e.g. /model switch) will load it.
+		a.mu.Lock()
+		a.startupErr = err.Error()
+		a.mu.Unlock()
+	}
+	return nil
 }
 
 // eventSink is the controller's event.Sink in desktop mode: it forwards every

--- a/desktop/frontend/pnpm-workspace.yaml
+++ b/desktop/frontend/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import logo from "./assets/logo.svg";
 import { useT } from "./lib/i18n";
 import { useController } from "./lib/useController";
+import { app } from "./lib/bridge";
 import { Transcript } from "./components/Transcript";
 import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
@@ -27,6 +28,7 @@ import { SettingsPanel } from "./components/SettingsPanel";
 import { CapabilitiesPanel } from "./components/CapabilitiesPanel";
 import { UpdateBanner } from "./components/UpdateBanner";
 import { WorkspacePanel } from "./components/WorkspacePanel";
+import { OnboardingOverlay } from "./components/OnboardingOverlay";
 import { parseTodos } from "./lib/tools";
 import { sessionActivityTime } from "./lib/session";
 import type { MemoryView, Mode, SessionMeta } from "./lib/types";
@@ -150,6 +152,11 @@ export default function App() {
   } = useController();
   const t = useT();
   const [mode, setMode] = useState<Mode>("normal");
+  // Onboarding gate. null = not yet checked (show the regular loading screen),
+  // true = show the overlay, false = past onboarding, render the main UI.
+  // Probed exactly once on mount; the user clearing their key mid-session
+  // won't re-trigger the overlay (that's what the Settings panel is for).
+  const [needsOnboarding, setNeedsOnboarding] = useState<boolean | null>(null);
   const [memView, setMemView] = useState<MemoryView | null>(null);
   const [histView, setHistView] = useState<SessionMeta[] | null>(null);
   const [sidebarSessions, setSidebarSessions] = useState<SessionMeta[]>([]);
@@ -273,6 +280,30 @@ export default function App() {
   useEffect(() => {
     void refreshSessions();
   }, [refreshSessions]);
+
+  // Probe the Go side for missing API key exactly once. We don't re-probe on
+  // meta changes because the only path that "adds a key" is the Settings
+  // panel, which calls SetProviderKey and a rebuild — the kernel then emits
+  // agent:ready and the regular UI is already mounted.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const needs = await app.NeedsOnboarding();
+        if (!cancelled) setNeedsOnboarding(needs);
+      } catch {
+        // Bridge unavailable (browser dev mock missing the method, or
+        // pre-startup) — fall through to the regular UI; if the kernel
+        // can't load it, the existing topbar.startupError banner surfaces
+        // the reason. Treat as "no onboarding" so the user can still poke
+        // at the Settings panel.
+        if (!cancelled) setNeedsOnboarding(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     const onResize = () => setViewportWidth(window.innerWidth);
@@ -833,6 +864,12 @@ export default function App() {
       {settingsOpen && <SettingsPanel onClose={() => setSettingsOpen(false)} onChanged={() => void refreshMeta()} />}
 
       {capsOpen && <CapabilitiesPanel onClose={() => setCapsOpen(false)} />}
+
+      {/* First-run gate: covers the whole app until the default provider's API
+          key is in place. onComplete fires after ConnectKey succeeds; the
+          kernel is already rebuilding in the background and will emit
+          agent:ready once the new controller is up. */}
+      {needsOnboarding && <OnboardingOverlay onComplete={() => setNeedsOnboarding(false)} />}
     </div>
   );
 }

--- a/desktop/frontend/src/components/OnboardingOverlay.tsx
+++ b/desktop/frontend/src/components/OnboardingOverlay.tsx
@@ -1,0 +1,140 @@
+import { useCallback, useRef, useState } from "react";
+import logo from "../assets/logo.svg";
+import { useT } from "../lib/i18n";
+import { app, openExternal } from "../lib/bridge";
+
+// OnboardingOverlay is the full-window first-run gate. Shown by App when
+// NeedsOnboarding() returns true (the default provider's API key is unset).
+// It validates the pasted key against the provider's balance endpoint, writes
+// it to ./.env via Go, and triggers a controller rebuild — the overlay stays
+// up until App's useController hook picks up agent:ready and the parent
+// drops needsOnboarding back to false. Three states the UI walks through:
+//
+//   idle        → paste a key, click "Connect & start"
+//   validating  → button shows a spinner, the input is locked
+//   error       → red banner with the kernel's reason; user can retry
+//
+// We deliberately don't auto-focus the input on mount: the user may be reading
+// the privacy / "where to get a key" copy first, and yanking focus before
+// they've decided feels pushy.
+export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
+  const t = useT();
+  const [value, setValue] = useState("");
+  const [state, setState] = useState<"idle" | "validating" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const submit = useCallback(async () => {
+    const key = value.trim();
+    if (!key) {
+      setError(t("onboarding.error.empty"));
+      setState("error");
+      inputRef.current?.focus();
+      return;
+    }
+    setState("validating");
+    setError(null);
+    try {
+      await app.ConnectKey(key);
+      // The Go side rebuilds the controller and emits agent:ready; the
+      // parent's useController hook will pick that up and refresh Meta/
+      // History. We just need to unmount ourselves so the main UI takes over.
+      // If the rebuild throws the key is still persisted and the next
+      // controller rebuild will pick it up, so leaving the overlay showing
+      // on error is the safer behavior.
+      onComplete();
+    } catch (e) {
+      // The kernel returns human-readable errors for the common cases
+      // (401 → "invalid key", dial failure → "network unreachable"). Map the
+      // 401/403 status text to a friendlier i18n key when we recognize it.
+      const msg = e instanceof Error ? e.message : String(e);
+      if (/status\s*401|status\s*403|invalid/i.test(msg)) {
+        setError(t("onboarding.error.invalid"));
+      } else if (/network|unreachable|timeout|dial/i.test(msg)) {
+        setError(t("onboarding.error.network"));
+      } else {
+        setError(msg || t("onboarding.error.unknown"));
+      }
+      setState("error");
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [t, value, onComplete]);
+
+  return (
+    <div className="onboarding">
+      <div className="onboarding__card">
+        <img src={logo} className="onboarding__logo" alt="Reasonix" />
+        <div className="onboarding__title">{t("onboarding.title")}</div>
+        <div className="onboarding__tag">{t("onboarding.tagline")}</div>
+
+        <label className="onboarding__label" htmlFor="onboarding-key">
+          {t("onboarding.inputLabel")}
+        </label>
+        <input
+          id="onboarding-key"
+          ref={inputRef}
+          className="onboarding__input"
+          type="password"
+          autoComplete="off"
+          spellCheck={false}
+          placeholder={t("onboarding.inputPlaceholder")}
+          value={value}
+          onChange={(e) => {
+            setValue(e.target.value);
+            if (state === "error") setState("idle");
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && state !== "validating") {
+              e.preventDefault();
+              void submit();
+            }
+          }}
+          disabled={state === "validating"}
+        />
+
+        {state === "error" && error && (
+          <div className="onboarding__error" role="alert">
+            {error}
+          </div>
+        )}
+
+        <button
+          className="onboarding__submit"
+          onClick={() => void submit()}
+          disabled={state === "validating"}
+        >
+          {state === "validating" ? (
+            <>
+              <span className="onboarding__spinner" />
+              {t("onboarding.validating")}
+            </>
+          ) : (
+            t("onboarding.submit")
+          )}
+        </button>
+
+        <div className="onboarding__links">
+          <button
+            type="button"
+            className="onboarding__link"
+            onClick={() => openExternal("https://platform.deepseek.com/api_keys")}
+          >
+            {t("onboarding.getKey")}
+          </button>
+          <span className="onboarding__sep">·</span>
+          <span className="onboarding__privacy">{t("onboarding.privacy")}</span>
+        </div>
+
+        <button
+          type="button"
+          className="onboarding__skip"
+          onClick={onComplete}
+          disabled={state === "validating"}
+        >
+          {t("onboarding.skip")}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -132,6 +132,13 @@ export interface AppBindings {
   CheckUpdate(): Promise<UpdateInfo | null>;
   ApplyUpdate(): Promise<void>;
   OpenDownloadPage(): Promise<void>;
+  // Onboarding: first-run overlay for the default provider's API key.
+  // NeedsOnboarding is true when DEEPSEEK_API_KEY (or whatever the default
+  // provider's key env is) is unset in the process. ConnectKey validates the
+  // key against the balance endpoint, persists it to ./.env, and rebuilds the
+  // controller — the frontend then transitions off the overlay on agent:ready.
+  NeedsOnboarding(): Promise<boolean>;
+  ConnectKey(apiKey: string): Promise<void>;
 }
 
 interface WailsRuntime {
@@ -732,6 +739,19 @@ function makeMockApp(): AppBindings {
       if (typeof window !== "undefined") {
         window.open("https://github.com/esengine/reasonix/releases/latest", "_blank", "noopener");
       }
+    },
+    // Onboarding mock: pretend the key is missing until the user "connects" so
+    // the overlay flow is exercisable in the browser dev seam. The real Wails
+    // shell overrides this and the overlay never appears once a key is set.
+    async NeedsOnboarding() {
+      return !settings.providers.find((p) => p.name === "deepseek-flash")?.keySet;
+    },
+    async ConnectKey(apiKey: string) {
+      if (!apiKey.trim()) throw new Error("key is required");
+      settings.providers.forEach((p) => {
+        if (p.apiKeyEnv === "DEEPSEEK_API_KEY") p.keySet = true;
+      });
+      await delay(300);
     },
   };
 }

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -384,6 +384,23 @@ export const en = {
   "updater.failed": "Update failed: {msg}",
   "updater.retry": "Retry",
   "updater.dismiss": "Later",
+
+  // onboarding — first-run overlay shown when the default provider's API key
+  // is unset. The user pastes a key; we validate it against the vendor's
+  // balance endpoint (no tokens spent) and persist it to ./.env.
+  "onboarding.title": "Connect Reasonix",
+  "onboarding.tagline": "Paste a DeepSeek API key to start. Stored locally in .env, never sent anywhere else.",
+  "onboarding.inputLabel": "API key",
+  "onboarding.inputPlaceholder": "sk-…",
+  "onboarding.submit": "Connect & start",
+  "onboarding.validating": "Validating…",
+  "onboarding.getKey": "How do I get a key?",
+  "onboarding.privacy": "Stored only in this app's .env",
+  "onboarding.error.empty": "Please paste a key first.",
+  "onboarding.error.invalid": "That key didn't work — double-check it's active and has billing set up.",
+  "onboarding.error.network": "Couldn't reach DeepSeek — check your network and try again.",
+  "onboarding.error.unknown": "Something went wrong: {msg}",
+  "onboarding.skip": "Skip for now",
 };
 
 export type DictKey = keyof typeof en;

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -385,4 +385,20 @@ export const zh: Record<DictKey, string> = {
   "updater.failed": "更新失败：{msg}",
   "updater.retry": "重试",
   "updater.dismiss": "稍后",
+
+  // 首次启动引导：默认 provider 的 API key 未设置时显示。用户粘贴 key 后，
+  // 我们用 vendor 的余额接口做零 token 校验，然后写入 ./.env。
+  "onboarding.title": "连接 Reasonix",
+  "onboarding.tagline": "粘贴一个 DeepSeek API key 即可开始。密钥仅存于本机的 .env，不会发往任何地方。",
+  "onboarding.inputLabel": "API 密钥",
+  "onboarding.inputPlaceholder": "sk-…",
+  "onboarding.submit": "连接并开始",
+  "onboarding.validating": "校验中…",
+  "onboarding.getKey": "如何获取 API key？",
+  "onboarding.privacy": "仅保存在本应用的 .env",
+  "onboarding.error.empty": "请先粘贴密钥。",
+  "onboarding.error.invalid": "这个 key 无法使用 —— 检查一下是否已激活、是否开通了计费。",
+  "onboarding.error.network": "无法连接 DeepSeek —— 检查网络后再试。",
+  "onboarding.error.unknown": "出错啦：{msg}",
+  "onboarding.skip": "稍后设置",
 };

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4916,3 +4916,174 @@ body {
   color: inherit;
   cursor: pointer;
 }
+
+/* onboarding — first-run gate covering the whole window. Sits above every
+   other layer; the card is centered, terminal-styled, with a faint scanline
+   accent so it reads as "stop and paste a key" rather than a generic modal. */
+.onboarding {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(
+      ellipse at top,
+      rgba(217, 119, 87, 0.06) 0%,
+      transparent 60%
+    ),
+    rgba(7, 8, 10, 0.92);
+  backdrop-filter: none;
+  --wails-draggable: drag;
+}
+.onboarding__card {
+  --wails-draggable: no-drag;
+  width: min(440px, calc(100vw - 48px));
+  padding: 32px 32px 28px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55), 0 0 0 1px rgba(217, 119, 87, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.onboarding__logo {
+  width: 36px;
+  height: 36px;
+  align-self: flex-start;
+  margin-bottom: 4px;
+}
+.onboarding__title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  color: var(--fg);
+}
+.onboarding__tag {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--fg-dim);
+  margin-bottom: 6px;
+}
+.onboarding__label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+.onboarding__input {
+  font-family: var(--mono);
+  font-size: 13px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  outline: none;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+.onboarding__input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(217, 119, 87, 0.18);
+}
+.onboarding__input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.onboarding__error {
+  font-size: 12px;
+  line-height: 1.5;
+  color: #ff8b7a;
+  background: rgba(255, 70, 70, 0.08);
+  border: 1px solid rgba(255, 70, 70, 0.25);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+.onboarding__submit {
+  margin-top: 4px;
+  padding: 10px 14px;
+  background: var(--accent);
+  color: #1a0e08;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background 120ms ease, transform 80ms ease;
+}
+.onboarding__submit:hover:not(:disabled) {
+  background: #e08868;
+}
+.onboarding__submit:active:not(:disabled) {
+  transform: translateY(1px);
+}
+.onboarding__submit:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+.onboarding__spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(26, 14, 8, 0.3);
+  border-top-color: #1a0e08;
+  border-radius: 50%;
+  animation: onboarding-spin 0.7s linear infinite;
+}
+@keyframes onboarding-spin {
+  to { transform: rotate(360deg); }
+}
+.onboarding__links {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--fg-dim);
+  margin-top: 4px;
+}
+.onboarding__link {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.onboarding__link:hover {
+  color: #e08868;
+}
+.onboarding__sep {
+  opacity: 0.5;
+}
+.onboarding__privacy {
+  opacity: 0.8;
+}
+.onboarding__skip {
+  background: none;
+  border: none;
+  padding: 4px 0;
+  margin-top: 2px;
+  color: var(--fg-dim);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: center;
+  transition: color 120ms ease;
+}
+.onboarding__skip:hover:not(:disabled) {
+  color: var(--fg);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.onboarding__skip:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary

Adds a first-run gate in the desktop app: when the default provider's
API key (DEEPSEEK_API_KEY, matching `Default()` in internal/config) is
unset in the process, the user sees a full-window overlay asking them
to paste a `sk-...` key. The submit button validates the key against
the vendor's balance endpoint, persists it to `./.env`, and rebuilds
the controller. The overlay stays up until the kernel emits
`agent:ready` and the main UI takes over.

Closes the "what does the user do when they download the desktop app
and launch it for the first time" gap — currently the chat composer
just shows a topbar error and the user has to dig into Settings to
find the API key field.

## Changes (3 commits)

1. **`chore(desktop): allow esbuild postinstall in pnpm workspace`**
   pnpm 11+ refuses to run build scripts unless explicitly approved.
   `wails dev` would exit 1 on a fresh clone with
   `ERR_PNPM_IGNORED_BUILDS`. Project-scope `esbuild: true` so it
   travels with the repo.

2. **`feat(desktop): add NeedsOnboarding/ConnectKey bindings`**
   Two new methods on `*App`:
   - `NeedsOnboarding() bool` — true when DEEPSEEK_API_KEY is empty
     in the process. Cheap, no I/O.
   - `ConnectKey(apiKey string) error` — validates via
     `billing.FetchWithClient` (zero-token, 8s timeout), persists via
     `upsertDotEnv` (writes to `./.env` and `os.Setenv`s the key so
     the next rebuild picks it up), then triggers a controller
     rebuild. Returns "key is required" / "status 401" /
     "network: ..." for the UI to map.

3. **`feat(desktop): add first-run OnboardingOverlay`**
   - `desktop/frontend/src/components/OnboardingOverlay.tsx` —
     full-window modal with logo, paste field, submit button (with
     spinner), "How do I get a key?" link (opens
     `platform.deepseek.com/api_keys` in the system browser), and a
     small "Skip for now" footer link.
   - `desktop/frontend/src/App.tsx` — one-shot `NeedsOnboarding()`
     probe on mount; gates the entire app on the result. Probe is
     `useEffect([])` so Settings panel changes don't re-trigger.
   - `desktop/frontend/src/lib/bridge.ts` — adds both methods to
     `AppBindings`; browser dev mock returns true when no provider
     has its key set, so the overlay flow is exercisable in
     `pnpm dev` outside the Wails shell.
   - `desktop/frontend/src/styles.css` — `.onboarding*` classes
     (dark `--bg-elev` card, `--accent` CTA, mono input, spinner
     animation). Terminal-hacker aesthetic, matches the rest of
     the theme.
   - `desktop/frontend/src/locales/{en,zh}.ts` — 13 i18n keys each
     (title, tagline, input label/placeholder, submit, validating,
     get-key link, privacy, three error states, unknown, skip).

## UX flow

1. Fresh install / cleared key → app launches → overlay covers the
   window. Composer is hidden; no chat possible without a key.
2. User pastes a key, hits Enter (or clicks "Connect & start").
   Button shows a spinner; input locks.
3. Go side validates → 401 → "That key didn't work — check it's
   active and has billing set up." Network fail → "Couldn't reach
   DeepSeek — check your network and try again." Other → raw message.
4. Success → key written to `./.env` (or `desktop/.env` in wails
   dev), process env updated, controller rebuilt. Frontend unmounts
   the overlay; agent:ready → main UI.
5. "Skip for now" → overlay dismisses, user can poke around the
   empty state. Trying to chat surfaces the topbar `startupError`
   banner; Settings panel is the path back.

## i18n

Auto-detects from `navigator.language` (WebView2 reflects the system
locale on Windows). User override in Settings → Language. All 13
new keys present in both `en.ts` and `zh.ts`; `translate()` falls
back to English on missing keys, so partial translations degrade
gracefully.

## Test plan

- [x] `go build ./...` — clean
- [x] `tsc --noEmit` — clean
- [x] `vite build` — clean
- [x] `go test ./...` in `desktop/` — all pass
- [x] Local wails dev: rename `.env` → `.env.bak`, clear
      `DEEPSEEK_API_KEY` from User env, restart wails dev → overlay
      appears. Paste valid key → overlay dismisses, `desktop/.env`
      has the new key, restart wails dev → no overlay.
- [x] Click "Skip for now" → main UI loads, topbar shows
      `startupError`, Settings panel accepts a key and the chat
      resumes after the kernel rebuilds.
- [x] i18n: switch Settings → Language to 中文, restart wails dev,
      overlay text flips to Chinese (title: 连接 Reasonix, submit:
      连接并开始, skip: 稍后设置, etc.).

## Notes

- No new dependencies. Reuses `billing.FetchWithClient`,
  `upsertDotEnv`, `a.rebuild()`. Adds one log line in
  `ConnectKey` for save failures (will be added in a follow-up if
  reviewers want).
- Doesn't touch `main.go` / `startup()` / `buildController()`.
  Onboarding is purely a frontend gate; if the user skips, the
  existing topbar error path takes over.
- Bridge mock returns `true` from `NeedsOnboarding()` when no
  provider has its key set, so pure browser dev (`pnpm dev`)
  exercises the overlay without rebuilding the Go side.
- The `desktop/frontend/pnpm-workspace.yaml` is unrelated to the
  feature itself but blocks `wails dev` on a fresh clone; committing
  it here saves the next contributor the 10-minute debug session.
