### PR TITLE
feat(agent): enforce project instruction receipts

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -12,6 +12,7 @@ import (
 	"reasonix/internal/diff"
 	"reasonix/internal/event"
 	"reasonix/internal/evidence"
+	"reasonix/internal/instruction"
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
 	"reasonix/internal/nilutil"
@@ -173,6 +174,10 @@ type Agent struct {
 	// complete_step validate that cited evidence happened before the claim.
 	evidence *evidence.Ledger
 
+	// projectChecks are structured project instructions that complete_step can
+	// verify against same-turn bash receipts after a write-backed completion.
+	projectChecks []instruction.VerifyCheck
+
 	// memQueue, when non-nil, lets the remember/forget tools fold a turn-tail note
 	// about a just-made memory change into the next turn, so it applies this
 	// session without touching the cache-stable prefix. Set via SetMemoryQueue.
@@ -297,6 +302,9 @@ type Options struct {
 	// Jobs is the session's background-job manager (nil disables background tools).
 	Jobs *jobs.Manager
 
+	// ProjectChecks are host-observable structured checks extracted during boot.
+	ProjectChecks []instruction.VerifyCheck
+
 	// Context management. ContextWindow <= 0 disables compaction. CompactRatio
 	// is the trigger fraction; RecentKeep is the minimum recent messages kept
 	// verbatim (the tail is otherwise token-bounded). Both fall back to defaults.
@@ -340,6 +348,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		hooks:         hooks,
 		jobs:          opts.Jobs,
 		evidence:      evidence.NewLedger(),
+		projectChecks: append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
 		contextWindow: opts.ContextWindow,
 		compactRatio:  opts.CompactRatio,
 		recentKeep:    opts.RecentKeep,
@@ -755,6 +764,9 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	cctx := withCallContext(ctx, call.ID, a.sink, a.asker)
 	if a.evidence != nil {
 		cctx = evidence.WithLedger(cctx, a.evidence)
+	}
+	if len(a.projectChecks) > 0 {
+		cctx = instruction.WithChecks(cctx, a.projectChecks)
 	}
 	if a.jobs != nil {
 		cctx = jobs.WithManager(cctx, a.jobs)

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"reasonix/internal/event"
+	"reasonix/internal/instruction"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -89,6 +90,43 @@ func TestEvidenceFlowEndToEnd(t *testing.T) {
 
 	if got := toolResult(a.session, "complete_step"); !strings.Contains(got, "host-verified 1") {
 		t.Fatalf("complete_step result = %q, want it host-verified from the bash receipt", got)
+	}
+}
+
+func TestEvidenceFlowEnforcesProjectChecksAfterWrite(t *testing.T) {
+	completeStep, ok := tool.LookupBuiltin("complete_step")
+	if !ok {
+		t.Fatal("complete_step builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(completeStep)
+
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("c2", "bash", `{"command":"go test ./..."}`),
+			toolCallChunk("c3", "complete_step", `{
+				"step":"Edit code",
+				"result":"changed.go updated",
+				"evidence":[{"kind":"diff","summary":"updated code","paths":["changed.go"]}]
+			}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+
+	a := New(prov, reg, NewSession(""), Options{
+		ProjectChecks: []instruction.VerifyCheck{{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3}},
+	}, event.Discard)
+	if err := a.Run(context.Background(), "edit and verify"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	got := toolResult(a.session, "complete_step")
+	if !strings.Contains(got, "project checks 1") {
+		t.Fatalf("complete_step result = %q, want project check verified from same batch", got)
 	}
 }
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
+	"reasonix/internal/instruction"
 	"reasonix/internal/jobs"
 	"reasonix/internal/lsp"
 	"reasonix/internal/memory"
@@ -134,6 +135,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// turn. Mid-session changes never touch this prefix — they ride the
 	// controller's transient turn-injection and fold in on the next session.
 	mem := memory.Load(memory.Options{CWD: ".", UserDir: config.MemoryUserDir()})
+	projectChecks := instruction.ExtractHostChecks(mem.Docs)
 	sysPrompt = memory.Compose(sysPrompt, mem)
 
 	// Skills: discover playbooks (built-in + project/custom/global) and fold their
@@ -385,6 +387,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Gate:          headlessGate,
 		Hooks:         hookRunner,
 		Jobs:          jm,
+		ProjectChecks: projectChecks,
 		ContextWindow: entry.ContextWindow,
 		ArchiveDir:    config.ArchiveDir(),
 	}, sink)

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -102,12 +102,56 @@ func (l *Ledger) HasSuccessfulCommand(command string) bool {
 	return false
 }
 
+func (l *Ledger) HasSuccessfulCommandAfter(command string, after int) bool {
+	command = strings.TrimSpace(command)
+	if l == nil || command == "" {
+		return false
+	}
+	start := after + 1
+	if start < 0 {
+		start = 0
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := start; i < len(l.receipts); i++ {
+		r := l.receipts[i]
+		if r.Success && r.ToolName == "bash" && r.Command == command {
+			return true
+		}
+	}
+	return false
+}
+
 func (l *Ledger) HasSuccessfulWrite(paths []string) bool {
 	return l.hasSuccessfulPaths(paths, func(r Receipt) bool { return r.Write })
 }
 
 func (l *Ledger) HasSuccessfulReadOrWrite(paths []string) bool {
 	return l.hasSuccessfulPaths(paths, func(r Receipt) bool { return r.Read || r.Write })
+}
+
+func (l *Ledger) LatestSuccessfulWriteIndex(paths []string) (int, bool) {
+	wanted := pathSet(normalizePaths(paths))
+	if l == nil || len(wanted) == 0 {
+		return 0, false
+	}
+	latest := -1
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, r := range l.receipts {
+		if !r.Success || !r.Write {
+			continue
+		}
+		for _, p := range r.Paths {
+			if wanted[p] {
+				latest = i
+				break
+			}
+		}
+	}
+	return latest, latest >= 0
 }
 
 func (l *Ledger) MatchLatestTodoStep(step string) (TodoStepMatch, bool) {

--- a/internal/instruction/instruction.go
+++ b/internal/instruction/instruction.go
@@ -1,0 +1,96 @@
+package instruction
+
+import (
+	"context"
+	"strings"
+
+	"reasonix/internal/memory"
+)
+
+// VerifyCheck is a host-observable project check extracted from structured
+// project memory. It is runtime-only and is not serialized into prompts.
+type VerifyCheck struct {
+	Command    string
+	SourcePath string
+	Line       int
+}
+
+type contextKey struct{}
+
+func WithChecks(ctx context.Context, checks []VerifyCheck) context.Context {
+	if len(checks) == 0 {
+		return ctx
+	}
+	cp := append([]VerifyCheck(nil), checks...)
+	return context.WithValue(ctx, contextKey{}, cp)
+}
+
+func FromContext(ctx context.Context) []VerifyCheck {
+	checks, ok := ctx.Value(contextKey{}).([]VerifyCheck)
+	if !ok || len(checks) == 0 {
+		return nil
+	}
+	return append([]VerifyCheck(nil), checks...)
+}
+
+// ExtractHostChecks reads only the structured "Reasonix host checks" section.
+// Ordinary project instructions remain guidance and do not become hard gates.
+func ExtractHostChecks(docs []memory.Source) []VerifyCheck {
+	seen := map[string]bool{}
+	var checks []VerifyCheck
+	for _, doc := range docs {
+		inSection := false
+		for i, raw := range strings.Split(doc.Body, "\n") {
+			line := strings.TrimRight(raw, "\r")
+			if heading, ok := markdownHeading(line); ok {
+				inSection = strings.EqualFold(heading, "Reasonix host checks")
+				continue
+			}
+			if !inSection {
+				continue
+			}
+			command, ok := verifyBullet(line)
+			if !ok || seen[command] {
+				continue
+			}
+			seen[command] = true
+			checks = append(checks, VerifyCheck{
+				Command:    command,
+				SourcePath: doc.Path,
+				Line:       i + 1,
+			})
+		}
+	}
+	return checks
+}
+
+func markdownHeading(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "#") {
+		return "", false
+	}
+	i := 0
+	for i < len(line) && line[i] == '#' {
+		i++
+	}
+	if i == 0 || i >= len(line) || line[i] != ' ' {
+		return "", false
+	}
+	heading := strings.TrimSpace(line[i+1:])
+	heading = strings.TrimSpace(strings.TrimRight(heading, "#"))
+	return heading, heading != ""
+}
+
+func verifyBullet(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if len(line) < 2 || (line[:2] != "- " && line[:2] != "* ") {
+		return "", false
+	}
+	body := strings.TrimSpace(line[2:])
+	const prefix = "verify:"
+	if len(body) < len(prefix) || !strings.EqualFold(body[:len(prefix)], prefix) {
+		return "", false
+	}
+	command := strings.TrimSpace(body[len(prefix):])
+	return command, command != ""
+}

--- a/internal/instruction/instruction_test.go
+++ b/internal/instruction/instruction_test.go
@@ -1,0 +1,59 @@
+package instruction
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/memory"
+)
+
+func TestExtractHostChecksFromStructuredSection(t *testing.T) {
+	docs := []memory.Source{{
+		Path:  "AGENTS.md",
+		Scope: memory.ScopeProject,
+		Body: strings.Join([]string{
+			"# Project rules",
+			"## Reasonix host checks",
+			"- verify: go test ./internal/...",
+			"* verify: git diff --check",
+			"- verify: go test ./internal/...",
+			"- note: ignored",
+			"## Other",
+			"- verify: ignored after section",
+		}, "\n"),
+	}}
+
+	checks := ExtractHostChecks(docs)
+	if len(checks) != 2 {
+		t.Fatalf("checks len = %d, want 2: %#v", len(checks), checks)
+	}
+	if checks[0].Command != "go test ./internal/..." || checks[0].SourcePath != "AGENTS.md" || checks[0].Line != 3 {
+		t.Fatalf("first check = %#v", checks[0])
+	}
+	if checks[1].Command != "git diff --check" || checks[1].SourcePath != "AGENTS.md" || checks[1].Line != 4 {
+		t.Fatalf("second check = %#v", checks[1])
+	}
+}
+
+func TestExtractHostChecksIgnoresOrdinaryGuidance(t *testing.T) {
+	docs := []memory.Source{{
+		Path: "REASONIX.md",
+		Body: "Always run go test before committing.\n\n- verify: go test ./...",
+	}}
+
+	if checks := ExtractHostChecks(docs); len(checks) != 0 {
+		t.Fatalf("ordinary guidance should not create hard checks: %#v", checks)
+	}
+}
+
+func TestExtractHostChecksIsCaseInsensitive(t *testing.T) {
+	docs := []memory.Source{{
+		Path: "REASONIX.md",
+		Body: "## reasonix HOST checks\n- verify: go test ./...",
+	}}
+
+	checks := ExtractHostChecks(docs)
+	if len(checks) != 1 || checks[0].Command != "go test ./..." {
+		t.Fatalf("case-insensitive heading not extracted: %#v", checks)
+	}
+}

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"reasonix/internal/evidence"
+	"reasonix/internal/instruction"
 	"reasonix/internal/tool"
 )
 
@@ -113,6 +114,10 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 	if err != nil {
 		return "", err
 	}
+	projectVerified, err := verifyProjectChecks(ctx, p.Evidence)
+	if err != nil {
+		return "", err
+	}
 	hostStatus := ""
 	if _, ok := evidence.FromContext(ctx); ok {
 		hostStatus = fmt.Sprintf(" Host evidence: host-verified %d, manual/unverified %d.", hostVerified, manualUnverified)
@@ -121,8 +126,12 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 	if hasTodo {
 		todoStatus = fmt.Sprintf(" Todo step: todo-matched %d.", todoMatch.Index)
 	}
+	projectStatus := ""
+	if projectVerified > 0 {
+		projectStatus = fmt.Sprintf(" Project checks: project checks %d.", projectVerified)
+	}
 	return fmt.Sprintf("Step %q signed off with %d evidence item(s) [%s].%s Move the next step to in_progress with todo_write.",
-		p.Step, len(p.Evidence), strings.Join(kinds, ", "), hostStatus+todoStatus), nil
+		p.Step, len(p.Evidence), strings.Join(kinds, ", "), hostStatus+todoStatus+projectStatus), nil
 }
 
 func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified int, manualUnverified int, err error) {
@@ -162,6 +171,55 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 		}
 	}
 	return hostVerified, manualUnverified, nil
+}
+
+func verifyProjectChecks(ctx context.Context, items []stepEvidence) (int, error) {
+	checks := instruction.FromContext(ctx)
+	if len(checks) == 0 {
+		return 0, nil
+	}
+	ledger, ok := evidence.FromContext(ctx)
+	if !ok {
+		return 0, nil
+	}
+	after, ok := latestWriteBackedEvidenceIndex(ledger, items)
+	if !ok {
+		return 0, nil
+	}
+	for _, check := range checks {
+		command := strings.TrimSpace(check.Command)
+		if command == "" {
+			continue
+		}
+		if !ledger.HasSuccessfulCommandAfter(command, after) {
+			return 0, fmt.Errorf("project check %q from %s has no matching successful bash receipt after the latest matching write in this turn", command, checkSource(check))
+		}
+	}
+	return len(checks), nil
+}
+
+func latestWriteBackedEvidenceIndex(ledger *evidence.Ledger, items []stepEvidence) (int, bool) {
+	latest := -1
+	for _, item := range items {
+		switch item.Kind {
+		case "diff", "files":
+			if i, ok := ledger.LatestSuccessfulWriteIndex(item.Paths); ok && i > latest {
+				latest = i
+			}
+		}
+	}
+	return latest, latest >= 0
+}
+
+func checkSource(check instruction.VerifyCheck) string {
+	source := strings.TrimSpace(check.SourcePath)
+	if source == "" {
+		source = "project memory"
+	}
+	if check.Line > 0 {
+		return fmt.Sprintf("%s:%d", source, check.Line)
+	}
+	return source
 }
 
 func verifyTodoStep(ctx context.Context, step string) (evidence.TodoStepMatch, bool, error) {

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"reasonix/internal/evidence"
+	"reasonix/internal/instruction"
 )
 
 func TestCompleteStepRejectsMissingEvidence(t *testing.T) {
@@ -160,6 +161,87 @@ func TestCompleteStepAllowsManualAsUnverified(t *testing.T) {
 	}
 	if !strings.Contains(out, "manual/unverified 1") {
 		t.Fatalf("manual evidence should be marked unverified, got %q", out)
+	}
+}
+
+func TestCompleteStepRejectsMissingProjectCheckAfterWrite(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "write_file", Success: true, Paths: []string{"changed.go"}, Write: true})
+	ctx := instruction.WithChecks(evidence.WithLedger(context.Background(), ledger), []instruction.VerifyCheck{
+		{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3},
+	})
+
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"Edit code",
+		"result":"code changed",
+		"evidence":[{"kind":"diff","summary":"changed code","paths":["changed.go"]}]
+	}`))
+	if err == nil {
+		t.Fatal("write-backed completion should require project verify checks")
+	}
+	for _, want := range []string{"project check", "go test ./...", "AGENTS.md:3"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
+	}
+}
+
+func TestCompleteStepRejectsProjectCheckBeforeWrite(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
+	ledger.Record(evidence.Receipt{ToolName: "write_file", Success: true, Paths: []string{"changed.go"}, Write: true})
+	ctx := instruction.WithChecks(evidence.WithLedger(context.Background(), ledger), []instruction.VerifyCheck{
+		{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3},
+	})
+
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"Edit code",
+		"result":"code changed",
+		"evidence":[{"kind":"diff","summary":"changed code","paths":["changed.go"]}]
+	}`))
+	if err == nil || !strings.Contains(err.Error(), "after the latest matching write") {
+		t.Fatalf("check before write should be rejected, got %v", err)
+	}
+}
+
+func TestCompleteStepAcceptsProjectChecksAfterWrite(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "write_file", Success: true, Paths: []string{"changed.go"}, Write: true})
+	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
+	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "git diff --check"})
+	ctx := instruction.WithChecks(evidence.WithLedger(context.Background(), ledger), []instruction.VerifyCheck{
+		{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3},
+		{Command: "git diff --check", SourcePath: "AGENTS.md", Line: 4},
+	})
+
+	out, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"Edit code",
+		"result":"code changed",
+		"evidence":[{"kind":"diff","summary":"changed code","paths":["changed.go"]}]
+	}`))
+	if err != nil {
+		t.Fatalf("project checks after write should pass: %v", err)
+	}
+	if !strings.Contains(out, "project checks 2") {
+		t.Fatalf("ack should mention project checks, got %q", out)
+	}
+}
+
+func TestCompleteStepProjectChecksOnlyGateWriteBackedCompletions(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "read_file", Success: true, Paths: []string{"notes.md"}, Read: true})
+	ctx := instruction.WithChecks(evidence.WithLedger(context.Background(), ledger), []instruction.VerifyCheck{
+		{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3},
+	})
+
+	cases := []string{
+		`{"step":"Manual","result":"checked","evidence":[{"kind":"manual","summary":"operator checked"}]}`,
+		`{"step":"Inspect","result":"read file","evidence":[{"kind":"files","summary":"inspected file","paths":["notes.md"]}]}`,
+	}
+	for _, body := range cases {
+		if _, err := (completeStep{}).Execute(ctx, json.RawMessage(body)); err != nil {
+			t.Fatalf("non-write-backed completion should not require project checks: %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Related to #2751.

Background: #2628, #2704.

- Adds a small `internal/instruction` parser for structured `Reasonix host checks` sections in loaded project memory docs.
- Carries extracted verify checks through runtime-only agent context.
- Requires write-backed `complete_step` sign-offs to have same-turn successful bash receipts for every configured verify check after the latest matching writer receipt.

## Scope

- No UI changes; screenshots not applicable.
- No performance claims; cache hit rate/token/runtime metrics are not claimed.
- No prompt or tool schema changes.
- No MCP/worktree/subagent/cache/auto-memory/daily-summary changes.
- RFC labels requested: `rfc`, `v2`, `enhancement`; applying labels requires maintainer permissions from this account.

## Test Plan

- `D:\Go\go\bin\go.exe test ./internal/instruction ./internal/evidence ./internal/tool/builtin ./internal/agent ./internal/boot` - PASS
- `D:\Go\go\bin\go.exe test ./internal/...` - PASS
- `git diff --check` - PASS

## E2E

- Not triggered from this account; maintainer trigger requested: `/e2e diff x3`.
