### PR TITLE
refactor(desktop): validate session path once on delete

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -407,7 +407,7 @@ func (a *App) ListSessions() []SessionMeta {
 // file on the next turn; start a new session first to retire it.
 func (a *App) DeleteSession(path string) error {
 	dir := config.SessionDir()
-	sessionPath, _, err := validateSessionPath(dir, path)
+	sessionPath, key, err := validateSessionPath(dir, path)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func (a *App) DeleteSession(path string) error {
 			return errActiveSession
 		}
 	}
-	return deleteSessionFile(dir, sessionPath)
+	return removeSessionArtifacts(dir, sessionPath, key)
 }
 
 // RenameSession sets a custom display name for a session (empty clears it back to

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -87,6 +87,10 @@ func deleteSessionFile(dir, sessionPath string) error {
 	if err != nil {
 		return err
 	}
+	return removeSessionArtifacts(dir, sessionPath, key)
+}
+
+func removeSessionArtifacts(dir, sessionPath, key string) error {
 	if err := os.Remove(sessionPath); err != nil && !os.IsNotExist(err) {
 		return err
 	}


### PR DESCRIPTION
## Summary
Follow-up cleanup on #2746. The desktop delete path validated the session path twice.

`DeleteSession` validates the target once to normalize it for the active-session guard, then handed the already-normalized absolute path to `deleteSessionFile`, which validated it a second time — repeating the `os.Lstat` + `EvalSymlinks` filesystem calls for no behavioral gain.

## Change
- Split the delete body into a no-revalidate core `removeSessionArtifacts(dir, sessionPath, key)`.
- `DeleteSession` now calls the core directly after its single validation.
- `deleteSessionFile` stays as the self-validating primitive (it still owns the `.jsonl`/containment/symlink-escape guard), so the existing security tests — outside-dir, non-jsonl, symlink-escape, sidecar cleanup — keep exercising it unchanged.

No behavior change; one fewer filesystem stat round-trip per delete.

## Verification
- `go vet ./` and `go test ./` in `desktop` pass.
