### PR TITLE
feat(cli): render LaTeX math as Unicode in chat output

### DIFF
--- a/internal/cli/latex.go
+++ b/internal/cli/latex.go
@@ -1,0 +1,405 @@
+package cli
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// latexToUnicode renders a LaTeX math expression as a best-effort Unicode
+// approximation suitable for a terminal: Greek letters, operators/relations,
+// super/subscripts, \frac, \sqrt and accents map to real glyphs; anything it
+// can't represent degrades to a readable plain-text form. There is no Go
+// library for this, so the symbol table below is maintained by hand.
+func latexToUnicode(expr string) string {
+	return convertMath([]rune(expr))
+}
+
+func convertMath(rs []rune) string {
+	var b strings.Builder
+	b.Grow(len(rs))
+	for i := 0; i < len(rs); {
+		switch r := rs[i]; {
+		case r == '\\':
+			i = convertCommand(&b, rs, i)
+		case r == '^':
+			arg, ni := readAtom(rs, i+1, false)
+			b.WriteString(superscript(convertMath([]rune(arg))))
+			i = ni
+		case r == '_':
+			arg, ni := readAtom(rs, i+1, false)
+			b.WriteString(subscript(convertMath([]rune(arg))))
+			i = ni
+		case r == '{' || r == '}':
+			i++
+		case r == '&' || r == '~':
+			b.WriteByte(' ')
+			i++
+		case r == '$':
+			i++
+		default:
+			b.WriteRune(r)
+			i++
+		}
+	}
+	return b.String()
+}
+
+// convertCommand consumes the backslash command starting at rs[i] and writes
+// its rendering; it returns the index just past everything it consumed.
+func convertCommand(b *strings.Builder, rs []rune, i int) int {
+	j := i + 1
+	if j >= len(rs) {
+		return j
+	}
+	if !isASCIILetter(rs[j]) {
+		switch ch := rs[j]; ch {
+		case '\\':
+			b.WriteString("  ")
+		case ',', ';', ':', '!', ' ':
+			b.WriteByte(' ')
+		default:
+			b.WriteRune(ch)
+		}
+		return j + 1
+	}
+
+	k := j
+	for k < len(rs) && isASCIILetter(rs[k]) {
+		k++
+	}
+	cmd := string(rs[j:k])
+
+	switch cmd {
+	case "frac", "tfrac", "dfrac":
+		num, k2 := readAtom(rs, k, true)
+		den, k3 := readAtom(rs, k2, true)
+		b.WriteString(renderFrac(convertMath([]rune(num)), convertMath([]rune(den))))
+		return k3
+	case "sqrt":
+		idx := ""
+		if k < len(rs) && rs[k] == '[' {
+			idx, k = readBracket(rs, k)
+		}
+		arg, k2 := readAtom(rs, k, true)
+		b.WriteString(renderSqrt(idx, convertMath([]rune(arg))))
+		return k2
+	case "text", "textrm", "textbf", "textit", "mathrm", "mathsf", "mathtt", "mathit", "mathbf", "mathcal", "operatorname":
+		arg, k2 := readAtom(rs, k, true)
+		b.WriteString(arg)
+		return k2
+	case "mathbb":
+		arg, k2 := readAtom(rs, k, true)
+		b.WriteString(blackboard(arg))
+		return k2
+	case "left", "right", "big", "Big", "bigg", "Bigg", "bigl", "bigr", "Bigl", "Bigr", "displaystyle", "textstyle", "limits", "nolimits":
+		return k
+	case "begin", "end":
+		_, k2 := readAtom(rs, k, true)
+		return k2
+	}
+
+	if combining, ok := accents[cmd]; ok {
+		arg, k2 := readAtom(rs, k, true)
+		b.WriteString(applyCombining(convertMath([]rune(arg)), combining))
+		return k2
+	}
+	if sym, ok := symbols[cmd]; ok {
+		b.WriteString(sym)
+		return k
+	}
+	b.WriteString(cmd)
+	return k
+}
+
+// readAtom reads the argument of a command or script: a {balanced group}, a
+// \command, or a single rune. Returns the inner text (no surrounding braces)
+// and the index just past it.
+func readAtom(rs []rune, i int, skipSpaces bool) (string, int) {
+	if skipSpaces {
+		for i < len(rs) && rs[i] == ' ' {
+			i++
+		}
+	}
+	if i >= len(rs) {
+		return "", i
+	}
+	switch rs[i] {
+	case '{':
+		depth := 0
+		start := i + 1
+		for j := i; j < len(rs); j++ {
+			switch rs[j] {
+			case '{':
+				depth++
+			case '}':
+				depth--
+				if depth == 0 {
+					return string(rs[start:j]), j + 1
+				}
+			}
+		}
+		return string(rs[start:]), len(rs)
+	case '\\':
+		k := i + 1
+		if k < len(rs) && !isASCIILetter(rs[k]) {
+			return string(rs[i : k+1]), k + 1
+		}
+		for k < len(rs) && isASCIILetter(rs[k]) {
+			k++
+		}
+		return string(rs[i:k]), k
+	default:
+		return string(rs[i]), i + 1
+	}
+}
+
+func readBracket(rs []rune, i int) (string, int) {
+	start := i + 1
+	for j := start; j < len(rs); j++ {
+		if rs[j] == ']' {
+			return string(rs[start:j]), j + 1
+		}
+	}
+	return "", len(rs)
+}
+
+func renderFrac(num, den string) string {
+	return wrapIfCompound(num) + "/" + wrapIfCompound(den)
+}
+
+func renderSqrt(idx, arg string) string {
+	if utf8.RuneCountInString(arg) > 1 {
+		arg = "(" + arg + ")"
+	}
+	switch idx {
+	case "", "2":
+		return "√" + arg
+	case "3":
+		return "∛" + arg
+	case "4":
+		return "∜" + arg
+	}
+	return superscript(idx) + "√" + arg
+}
+
+func wrapIfCompound(s string) string {
+	if utf8.RuneCountInString(s) > 1 {
+		return "(" + s + ")"
+	}
+	return s
+}
+
+func applyCombining(s string, mark rune) string {
+	rs := []rune(s)
+	if len(rs) == 0 {
+		return string(mark)
+	}
+	return string(rs[0]) + string(mark) + string(rs[1:])
+}
+
+func blackboard(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if bb, ok := blackboardCaps[r]; ok {
+			b.WriteRune(bb)
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func superscript(s string) string {
+	if t, ok := mapAll(s, superMap); ok {
+		return t
+	}
+	if utf8.RuneCountInString(s) == 1 {
+		return "^" + s
+	}
+	return "^(" + s + ")"
+}
+
+func subscript(s string) string {
+	if t, ok := mapAll(s, subMap); ok {
+		return t
+	}
+	if utf8.RuneCountInString(s) == 1 {
+		return "_" + s
+	}
+	return "_(" + s + ")"
+}
+
+func mapAll(s string, m map[rune]rune) (string, bool) {
+	if s == "" {
+		return "", true
+	}
+	var b strings.Builder
+	for _, r := range s {
+		c, ok := m[r]
+		if !ok {
+			return "", false
+		}
+		b.WriteRune(c)
+	}
+	return b.String(), true
+}
+
+func isASCIILetter(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}
+
+// normalizeMath rewrites the alternate math delimiters \(..\) and \[..\] to
+// $..$ / $$..$$ and collapses newlines inside a $$ display block onto one line
+// so the inline math parser sees a single contiguous run. It tracks fenced and
+// inline code so literal delimiters inside code are never rewritten.
+func normalizeMath(s string) string {
+	rs := []rune(s)
+	n := len(rs)
+	var b strings.Builder
+	b.Grow(len(s))
+
+	inFenced, inCode, inDisplay := false, false, false
+
+	for i := 0; i < n; {
+		r := rs[i]
+
+		if r == '`' && i+2 < n && rs[i+1] == '`' && rs[i+2] == '`' {
+			inFenced = !inFenced
+			b.WriteString("```")
+			i += 3
+			continue
+		}
+		if r == '`' && !inFenced {
+			inCode = !inCode
+			b.WriteRune(r)
+			i++
+			continue
+		}
+		if inFenced || inCode {
+			b.WriteRune(r)
+			i++
+			continue
+		}
+
+		if r == '\\' && i+1 < n {
+			switch rs[i+1] {
+			case '\\':
+				b.WriteString("\\\\")
+				i += 2
+				continue
+			case '[':
+				b.WriteString("$$")
+				inDisplay = true
+				i += 2
+				continue
+			case ']':
+				b.WriteString("$$")
+				inDisplay = false
+				i += 2
+				continue
+			case '(':
+				b.WriteString("$")
+				i += 2
+				continue
+			case ')':
+				b.WriteString("$")
+				i += 2
+				continue
+			}
+		}
+		if r == '$' && i+1 < n && rs[i+1] == '$' {
+			b.WriteString("$$")
+			inDisplay = !inDisplay
+			i += 2
+			continue
+		}
+		if r == '\n' && inDisplay {
+			b.WriteByte(' ')
+			i++
+			continue
+		}
+
+		b.WriteRune(r)
+		i++
+	}
+	return b.String()
+}
+
+var symbols = map[string]string{
+	"alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ", "epsilon": "ε",
+	"varepsilon": "ε", "zeta": "ζ", "eta": "η", "theta": "θ", "vartheta": "ϑ",
+	"iota": "ι", "kappa": "κ", "lambda": "λ", "mu": "μ", "nu": "ν", "xi": "ξ",
+	"omicron": "ο", "pi": "π", "varpi": "ϖ", "rho": "ρ", "varrho": "ϱ",
+	"sigma": "σ", "varsigma": "ς", "tau": "τ", "upsilon": "υ", "phi": "φ",
+	"varphi": "ϕ", "chi": "χ", "psi": "ψ", "omega": "ω",
+	"Gamma": "Γ", "Delta": "Δ", "Theta": "Θ", "Lambda": "Λ", "Xi": "Ξ",
+	"Pi": "Π", "Sigma": "Σ", "Upsilon": "Υ", "Phi": "Φ", "Psi": "Ψ", "Omega": "Ω",
+
+	"times": "×", "div": "÷", "cdot": "·", "ast": "∗", "star": "⋆",
+	"pm": "±", "mp": "∓", "oplus": "⊕", "ominus": "⊖", "otimes": "⊗",
+	"oslash": "⊘", "odot": "⊙", "circ": "∘", "bullet": "•", "setminus": "∖",
+
+	"leq": "≤", "le": "≤", "geq": "≥", "ge": "≥", "neq": "≠", "ne": "≠",
+	"equiv": "≡", "approx": "≈", "cong": "≅", "sim": "∼", "simeq": "≃",
+	"propto": "∝", "ll": "≪", "gg": "≫", "doteq": "≐", "asymp": "≍",
+
+	"leftarrow": "←", "rightarrow": "→", "to": "→", "gets": "←",
+	"leftrightarrow": "↔", "Leftarrow": "⇐", "Rightarrow": "⇒",
+	"Leftrightarrow": "⇔", "implies": "⇒", "iff": "⇔", "mapsto": "↦",
+	"uparrow": "↑", "downarrow": "↓", "longrightarrow": "⟶", "longleftarrow": "⟵",
+
+	"sum": "∑", "prod": "∏", "coprod": "∐", "int": "∫", "iint": "∬",
+	"iiint": "∭", "oint": "∮", "nabla": "∇", "partial": "∂",
+	"infty": "∞", "sqrt": "√", "surd": "√",
+
+	"in": "∈", "notin": "∉", "ni": "∋", "subset": "⊂", "supset": "⊃",
+	"subseteq": "⊆", "supseteq": "⊇", "cup": "∪", "cap": "∩",
+	"emptyset": "∅", "varnothing": "∅", "forall": "∀", "exists": "∃",
+	"nexists": "∄", "neg": "¬", "lnot": "¬", "land": "∧", "wedge": "∧",
+	"lor": "∨", "vee": "∨",
+
+	"angle": "∠", "perp": "⊥", "parallel": "∥", "mid": "∣", "nmid": "∤",
+	"triangle": "△", "square": "□", "diamond": "◇", "top": "⊤", "bot": "⊥",
+	"vdash": "⊢", "models": "⊨", "therefore": "∴", "because": "∵",
+
+	"ldots": "…", "dots": "…", "cdots": "⋯", "vdots": "⋮", "ddots": "⋱",
+	"prime": "′", "degree": "°", "deg": "°", "hbar": "ℏ", "ell": "ℓ",
+	"Re": "ℜ", "Im": "ℑ", "aleph": "ℵ", "wp": "℘",
+	"langle": "⟨", "rangle": "⟩", "lceil": "⌈", "rceil": "⌉",
+	"lfloor": "⌊", "rfloor": "⌋", "backslash": "\\",
+
+	"quad": "  ", "qquad": "    ", "space": " ", "thinspace": " ",
+	"lim": "lim", "sin": "sin", "cos": "cos", "tan": "tan", "log": "log",
+	"ln": "ln", "exp": "exp", "min": "min", "max": "max", "det": "det",
+	"gcd": "gcd", "dim": "dim", "ker": "ker",
+}
+
+var accents = map[string]rune{
+	"hat": '̂', "widehat": '̂', "bar": '̄', "overline": '̄',
+	"vec": '⃗', "dot": '̇', "ddot": '̈', "tilde": '̃',
+	"widetilde": '̃', "acute": '́', "grave": '̀', "check": '̌',
+}
+
+var superMap = map[rune]rune{
+	'0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴', '5': '⁵', '6': '⁶',
+	'7': '⁷', '8': '⁸', '9': '⁹', '+': '⁺', '-': '⁻', '=': '⁼', '(': '⁽',
+	')': '⁾', 'a': 'ᵃ', 'b': 'ᵇ', 'c': 'ᶜ', 'd': 'ᵈ', 'e': 'ᵉ', 'f': 'ᶠ',
+	'g': 'ᵍ', 'h': 'ʰ', 'i': 'ⁱ', 'j': 'ʲ', 'k': 'ᵏ', 'l': 'ˡ', 'm': 'ᵐ',
+	'n': 'ⁿ', 'o': 'ᵒ', 'p': 'ᵖ', 'r': 'ʳ', 's': 'ˢ', 't': 'ᵗ', 'u': 'ᵘ',
+	'v': 'ᵛ', 'w': 'ʷ', 'x': 'ˣ', 'y': 'ʸ', 'z': 'ᶻ',
+}
+
+var subMap = map[rune]rune{
+	'0': '₀', '1': '₁', '2': '₂', '3': '₃', '4': '₄', '5': '₅', '6': '₆',
+	'7': '₇', '8': '₈', '9': '₉', '+': '₊', '-': '₋', '=': '₌', '(': '₍',
+	')': '₎', 'a': 'ₐ', 'e': 'ₑ', 'h': 'ₕ', 'i': 'ᵢ', 'j': 'ⱼ', 'k': 'ₖ',
+	'l': 'ₗ', 'm': 'ₘ', 'n': 'ₙ', 'o': 'ₒ', 'p': 'ₚ', 'r': 'ᵣ', 's': 'ₛ',
+	't': 'ₜ', 'u': 'ᵤ', 'v': 'ᵥ', 'x': 'ₓ',
+}
+
+var blackboardCaps = map[rune]rune{
+	'A': '𝔸', 'B': '𝔹', 'C': 'ℂ', 'D': '𝔻', 'E': '𝔼', 'F': '𝔽', 'G': '𝔾',
+	'H': 'ℍ', 'I': '𝕀', 'J': '𝕁', 'K': '𝕂', 'L': '𝕃', 'M': '𝕄', 'N': 'ℕ',
+	'O': '𝕆', 'P': 'ℙ', 'Q': 'ℚ', 'R': 'ℝ', 'S': '𝕊', 'T': '𝕋', 'U': '𝕌',
+	'V': '𝕍', 'W': '𝕎', 'X': '𝕏', 'Y': '𝕐', 'Z': 'ℤ',
+}

--- a/internal/cli/latex_test.go
+++ b/internal/cli/latex_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLatexToUnicode(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`E = mc^2`, "E = mc²"},
+		{`x^{n+1}`, "xⁿ⁺¹"},
+		{`H_2O`, "H₂O"},
+		{`x_i^2`, "xᵢ²"},
+		{`\alpha + \beta = \gamma`, "α + β = γ"},
+		{`\sum_{i=1}^{n} i`, "∑ᵢ₌₁ⁿ i"},
+		{`\int_0^1 x\,dx`, "∫₀¹ x dx"},
+		{`\frac{1}{2}`, "1/2"},
+		{`\frac{x+1}{2}`, "(x+1)/2"},
+		{`\sqrt{2}`, "√2"},
+		{`\sqrt{x+y}`, "√(x+y)"},
+		{`\sqrt[3]{x}`, "∛x"},
+		{`a \leq b \neq c`, "a ≤ b ≠ c"},
+		{`\mathbb{R}^n`, "ℝⁿ"},
+		{`\text{if } x > 0`, "if  x > 0"},
+		{`\vec{v}`, "v⃗"},
+		{`a^q`, "a^q"},
+		{`f(x) = x^{2y}`, "f(x) = x²ʸ"},
+	}
+	for _, c := range cases {
+		if got := latexToUnicode(c.in); got != c.want {
+			t.Errorf("latexToUnicode(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNormalizeMath(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{`\(x+1\)`, "$x+1$"},
+		{`\[x+1\]`, "$$x+1$$"},
+		{"$$\nE = mc^2\n$$", "$$ E = mc^2 $$"},
+		{"`\\(literal\\)`", "`\\(literal\\)`"},
+		{"```\n\\[code\\]\n```", "```\n\\[code\\]\n```"},
+	}
+	for _, c := range cases {
+		if got := normalizeMath(c.in); got != c.want {
+			t.Errorf("normalizeMath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRenderInlineMath(t *testing.T) {
+	colorEnabled = false
+	r := newMarkdownRenderer(80)
+
+	out := r.Render(`The mass-energy relation is $E = mc^2$ exactly.`)
+	if !strings.Contains(out, "E = mc²") {
+		t.Errorf("inline math not rendered: %q", out)
+	}
+
+	out = r.Render(`It costs $5 and then $10 total.`)
+	if !strings.Contains(out, "$5 and then $10") {
+		t.Errorf("currency wrongly parsed as math: %q", out)
+	}
+
+	out = r.Render("$$\n\\int_0^1 x\\,dx = \\frac{1}{2}\n$$")
+	if !strings.Contains(out, "∫₀¹ x dx = 1/2") {
+		t.Errorf("display math not rendered: %q", out)
+	}
+
+	out = r.Render("Code stays literal: `$x^2$` here.")
+	if !strings.Contains(out, "$x^2$") {
+		t.Errorf("math inside code span was converted: %q", out)
+	}
+}

--- a/internal/cli/math_e2e_test.go
+++ b/internal/cli/math_e2e_test.go
@@ -1,0 +1,69 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"reasonix/internal/event"
+)
+
+// TestMathStreamingEndToEnd drives the real streaming path (ingestEvent →
+// streamAnswer/flushableMarkdownPrefix → renderer.Render → commitPending) with
+// the math chunked mid-formula across event.Text boundaries, the way a model
+// actually streams tokens. It proves a half-written $...$ / $$...$$ is never
+// flushed as raw LaTeX and the committed transcript shows finished Unicode.
+func TestMathStreamingEndToEnd(t *testing.T) {
+	colorEnabled = false
+	m := newTestChatTUI()
+
+	chunks := []string{
+		`Euler's identity is $e^{i\`,
+		"pi} + 1 = 0$, a classic.\n\nThe Basel sum:\n$$\\sum_{n=1}",
+		`}^{\infty} \frac{1}{n^2}`,
+		" = \\frac{\\pi^2}{6}$$\n\nThat is all.",
+	}
+	for _, c := range chunks {
+		m.ingestEvent(event.Event{Kind: event.Text, Text: c})
+		mid := strings.Join(m.transcript, "\n")
+		for _, leak := range []string{`\pi`, `\sum`, `\frac`, `\infty`, `$e^{`, `$$\`} {
+			if strings.Contains(mid, leak) {
+				t.Fatalf("raw LaTeX %q leaked into a mid-stream flush: %q", leak, mid)
+			}
+		}
+	}
+
+	m.ingestEvent(event.Event{Kind: event.Message})
+
+	out := strings.Join(m.transcript, "\n")
+	for _, want := range []string{"e^(iπ) + 1 = 0", "∑", "1/(n²)", "(π²)/6", "That is all."} {
+		if !strings.Contains(out, want) {
+			t.Errorf("final transcript missing %q:\n%s", want, out)
+		}
+	}
+	for _, leak := range []string{`\`, "$$", "$e"} {
+		if strings.Contains(out, leak) {
+			t.Errorf("final transcript still contains raw %q:\n%s", leak, out)
+		}
+	}
+}
+
+// TestMathStreamingStyledPath repeats the commit with colour on so the real
+// ANSI-styled output is exercised, then asserts the Unicode survives a strip.
+func TestMathStreamingStyledPath(t *testing.T) {
+	colorEnabled = true
+	defer func() { colorEnabled = false }()
+	m := newTestChatTUI()
+
+	m.ingestEvent(event.Event{Kind: event.Text, Text: `The relation $a^2 + b^2 = c^2$ holds.`})
+	m.ingestEvent(event.Event{Kind: event.Message})
+
+	out := strings.Join(m.transcript, "\n")
+	if !strings.Contains(out, "\x1b[") {
+		t.Errorf("expected ANSI escapes in coloured output, got %q", out)
+	}
+	if stripped := ansi.Strip(out); !strings.Contains(stripped, "a² + b² = c²") {
+		t.Errorf("math missing after ANSI strip: %q", stripped)
+	}
+}

--- a/internal/cli/mathnode.go
+++ b/internal/cli/mathnode.go
@@ -1,0 +1,66 @@
+package cli
+
+import (
+	"bytes"
+
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+var kindMath = ast.NewNodeKind("Math")
+
+type mathNode struct {
+	ast.BaseInline
+	value   string
+	display bool
+}
+
+func (n *mathNode) Kind() ast.NodeKind         { return kindMath }
+func (n *mathNode) Dump(src []byte, level int) { ast.DumpHelper(n, src, level, nil, nil) }
+
+type mathParser struct{}
+
+func (p *mathParser) Trigger() []byte { return []byte{'$'} }
+
+func (p *mathParser) Parse(parent ast.Node, block text.Reader, pc parser.Context) ast.Node {
+	line, _ := block.PeekLine()
+	if len(line) == 0 || line[0] != '$' {
+		return nil
+	}
+	display := len(line) >= 2 && line[1] == '$'
+	delim := 1
+	if display {
+		delim = 2
+	}
+
+	rest := line[delim:]
+	var closeAt int
+	if display {
+		closeAt = bytes.Index(rest, []byte("$$"))
+	} else {
+		closeAt = bytes.IndexByte(rest, '$')
+	}
+	if closeAt < 0 {
+		return nil
+	}
+	inner := rest[:closeAt]
+	if len(bytes.TrimSpace(inner)) == 0 {
+		return nil
+	}
+
+	// Currency guard (markdown-it-texmath rule): a single-$ span only counts as
+	// math when the open isn't followed by space, the close isn't preceded by
+	// space, and the char after the close isn't a digit — so "$5 and $10" stays
+	// prose. Display $$ is unambiguous and skips the check.
+	if !display {
+		after := closeAt + 1
+		if inner[0] == ' ' || inner[len(inner)-1] == ' ' ||
+			(after < len(rest) && rest[after] >= '0' && rest[after] <= '9') {
+			return nil
+		}
+	}
+
+	block.Advance(delim + closeAt + delim)
+	return &mathNode{value: latexToUnicode(string(bytes.TrimSpace(inner))), display: display}
+}

--- a/internal/cli/md.go
+++ b/internal/cli/md.go
@@ -10,7 +10,9 @@ import (
 	"github.com/yuin/goldmark/ast"
 	"github.com/yuin/goldmark/extension"
 	extast "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
 )
 
 // mdRenderer turns the model's markdown answer into ANSI-styled terminal text
@@ -31,7 +33,12 @@ func newMarkdownRenderer(width int) *mdRenderer {
 	// Enable the GFM table extension so | header | rows | get parsed into
 	// a Table node rather than falling through as a literal text block.
 	return &mdRenderer{
-		md:    goldmark.New(goldmark.WithExtensions(extension.Table)),
+		md: goldmark.New(
+			goldmark.WithExtensions(extension.Table),
+			goldmark.WithParserOptions(
+				parser.WithInlineParsers(util.Prioritized(&mathParser{}, 150)),
+			),
+		),
 		width: width,
 	}
 }
@@ -50,7 +57,7 @@ func (r *mdRenderer) Render(input string) string {
 	if strings.TrimSpace(input) == "" {
 		return ""
 	}
-	input = fixCJKEmphasis(input)
+	input = fixCJKEmphasis(normalizeMath(input))
 	src := []byte(input)
 	doc := r.md.Parser().Parse(text.NewReader(src))
 	var buf strings.Builder
@@ -338,6 +345,8 @@ func (r *mdRenderer) appendInline(b *strings.Builder, n ast.Node, src []byte) {
 			b.WriteString(string(v.URL(src)))
 		case *ast.RawHTML:
 			// drop — rare in chat output and would print as literal escapes
+		case *mathNode:
+			b.WriteString(italic(v.value))
 		case *ast.String:
 			b.Write(v.Value)
 		default:


### PR DESCRIPTION
Model answers regularly include `$...$` / `$$...$$` (and `\(..\)`, `\[..\]`) math that until now printed as raw `\frac`, `\sum`, `\alpha` … in the terminal. This wires a goldmark inline parser into the existing markdown renderer and converts math to a Unicode approximation.

## What renders now
- Greek letters, operators/relations/arrows, set notation
- Super/subscripts (`x^2` → x², `H_2O` → H₂O, `\sum_{i=1}^{n}` → ∑ᵢ₌₁ⁿ), with a graceful `^( )` fallback when no Unicode glyph exists
- `\frac`, `\sqrt[n]`, `\mathbb`, accents (`\hat`, `\vec`, …)
- `\(..\)` / `\[..\]` normalised to `$` / `$$`; multi-line display blocks collapsed onto one line

## Safety
- Currency guard — `it costs $5 and $10` stays prose
- Code spans / fenced blocks pass through untouched
- Tokens split mid-formula never flush half-rendered LaTeX (flush stays on blank-line boundaries)

## Tests
Unit coverage for the converter + delimiter normalisation, plus an end-to-end streaming test that chunks a formula across `event.Text` boundaries and asserts no raw LaTeX leaks while the committed transcript shows finished Unicode.
