### PR TITLE
fix(serve): sidebar resume/compact/model-switch with a race-safe controller swap

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -402,6 +402,18 @@ function setRunning(on) {
   },1000);} else {clearInterval(tickTimer);turnInfo.textContent='';}
 }
 
+function setConnState(state) {
+  // state: 'connected' | 'reconnecting' | 'disconnected'
+  const colors={connected:'var(--success)',reconnecting:'var(--warning)',disconnected:'var(--danger)'};
+  const labels={connected:'Connected',reconnecting:'Reconnecting...',disconnected:'Disconnected'};
+  if(!running){
+    statusDot.style.background=colors[state]||'';
+    statusDot.className='status__dot'+(state==='reconnecting'?' status__dot--busy':'');
+    statusText.textContent=labels[state]||state;
+  }
+  statusDotSidebar.style.background=colors[state]||'';
+}
+
 // ── messages ──
 function addUserMsg(text) { hideWelcome(); const d=el('div','msg msg--user'); d.appendChild(el('span','msg__caret','›')); d.appendChild(el('div','msg__text',text)); log.appendChild(d); scrollDown(); currentMsg=null;currentText=null;currentReasoning=null; }
 function ensureMsg() { if(!currentMsg){hideWelcome();currentMsg=el('div','msg msg--assistant');log.appendChild(currentMsg);} return currentMsg; }
@@ -579,7 +591,8 @@ function acceptSlash(){if(!slashOpen)return;const c=slashFiltered[slashIndex];if
 
 // ── SSE ──
 const es=new EventSource('/events');
-es.onmessage=ev=>{
+es.onopen=()=>{setConnState('connected');};
+es.onmessage=ev=>{setConnState('connected');
   const e=JSON.parse(ev.data);
   switch(e.kind){
     case 'turn_started': setRunning(true); finalizeMsg(); toolCards={}; break;
@@ -608,7 +621,10 @@ es.onmessage=ev=>{
     case 'turn_done': finalizeMsg(); setRunning(false); if(e.err){log.appendChild(el('div','msg--error','✗ '+e.err));scrollDown();} fetchStatus(); break;
   }
 };
-es.onerror=()=>{statusText.textContent='Disconnected';statusDot.className='status__dot';};
+es.onerror=()=>{
+  if(es.readyState===EventSource.CONNECTING){setConnState('reconnecting');}
+  else{setConnState('disconnected');}
+};
 
 // ── status polling ──
 function fetchStatus(){

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -672,7 +672,7 @@ function loadSessions(){
 loadSessions();
 
 // ── input handling ──
-function send(){ const v=input.value.trim(); if(!v)return; addUserMsg(v); post('/submit',{input:v}); input.value='';input.style.height='';closeSlashMenu(); }
+function send(){ const v=input.value.trim(); if(!v)return; addUserMsg(v); post('/submit',{input:v}).then(r=>{if(r.ok&&r.status===204){fetchStatus();loadSessions();}}); input.value='';input.style.height='';closeSlashMenu(); }
 
 input.addEventListener('input',()=>{input.style.height='auto';input.style.height=Math.min(input.scrollHeight,140)+'px';updateSlashMenu();});
 input.addEventListener('keydown',e=>{

--- a/internal/serve/modelswitch_test.go
+++ b/internal/serve/modelswitch_test.go
@@ -1,0 +1,41 @@
+package serve
+
+import (
+	"sync"
+	"testing"
+
+	"reasonix/internal/control"
+)
+
+// TestControllerAccessorIsRaceSafe guards the switchModel concurrency contract:
+// handlers read the controller through ctl() while a swap runs under the write
+// lock. With the lock removed this fails under `go test -race` (the CI race job).
+func TestControllerAccessorIsRaceSafe(t *testing.T) {
+	a, b := &control.Controller{}, &control.Controller{}
+	s := &Server{ctrl: a}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if got := s.ctl(); got != a && got != b {
+				t.Errorf("ctl() returned a pointer that was never set")
+			}
+		}()
+	}
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.mu.Lock()
+			if s.ctrl == a {
+				s.ctrl = b
+			} else {
+				s.ctrl = a
+			}
+			s.mu.Unlock()
+		}()
+	}
+	wg.Wait()
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/boot"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
@@ -67,6 +68,44 @@ func (s *Server) initTitleProvider() {
 		return
 	}
 	s.titleProv = prov
+}
+
+// switchModel rebuilds the controller with a new model, carrying over the
+// conversation history. This replicates the TUI/desktop model-switch path.
+func (s *Server) switchModel(ctx context.Context, ref string) error {
+	if s.ctrl.Running() {
+		return fmt.Errorf("cannot switch model while a turn is running")
+	}
+	// Snapshot current session so nothing is lost.
+	if err := s.ctrl.Snapshot(); err != nil {
+		slog.Warn("serve: snapshot before model switch", "err", err)
+	}
+	carried := s.ctrl.History()
+
+	newCtrl, err := boot.Build(ctx, boot.Options{
+		Model:  ref,
+		Sink:   s.bc,
+		Stderr: os.Stderr,
+	})
+	if err != nil {
+		return fmt.Errorf("switch model: %w", err)
+	}
+	// Wire session path and carry history.
+	newPath := ""
+	if dir := newCtrl.SessionDir(); dir != "" {
+		newPath = agent.NewSessionPath(dir, newCtrl.Label())
+	}
+	if len(carried) > 0 {
+		newCtrl.Resume(&agent.Session{Messages: carried}, newPath)
+	} else if newPath != "" {
+		newCtrl.SetSessionPath(newPath)
+	}
+
+	// Close old controller resources (plugins, jobs) but not the session —
+	// it was already snapshotted.
+	s.ctrl.Close()
+	s.ctrl = newCtrl
+	return nil
 }
 
 // Handler returns the HTTP routes: GET / (a minimal browser client), GET /events
@@ -216,6 +255,19 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Input == "" {
 		http.Error(w, "missing input", http.StatusBadRequest)
 		return
+	}
+	// Intercept /model <ref> for runtime model switching (the controller's
+	// Submit path only lists models — switching is frontend-specific).
+	if trimmed := strings.TrimSpace(body.Input); strings.HasPrefix(trimmed, "/model ") {
+		ref := strings.TrimSpace(strings.TrimPrefix(trimmed, "/model"))
+		if ref != "" {
+			if err := s.switchModel(r.Context(), ref); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
 	}
 	s.ctrl.Submit(body.Input)
 	w.WriteHeader(http.StatusAccepted)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/agent"
@@ -32,6 +33,7 @@ var indexHTML []byte
 // Server wires a controller to its HTTP surface. The Broadcaster must be the
 // same sink the controller was constructed with, so events reach SSE clients.
 type Server struct {
+	mu        sync.RWMutex // guards ctrl, which switchModel swaps at runtime
 	ctrl      *control.Controller
 	bc        *Broadcaster
 	titleProv provider.Provider // lightweight flash provider for session titles
@@ -43,6 +45,14 @@ func New(ctrl *control.Controller, bc *Broadcaster) *Server {
 	s := &Server{ctrl: ctrl, bc: bc, titles: newTitleCache(ctrl.SessionDir())}
 	s.initTitleProvider()
 	return s
+}
+
+// ctl returns the current controller. Handlers must read it through here, never
+// the field directly, because switchModel replaces it under the write lock.
+func (s *Server) ctl() *control.Controller {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ctrl
 }
 
 // initTitleProvider builds a lightweight flash-model provider used solely to
@@ -71,16 +81,20 @@ func (s *Server) initTitleProvider() {
 }
 
 // switchModel rebuilds the controller with a new model, carrying over the
-// conversation history. This replicates the TUI/desktop model-switch path.
+// conversation history. This replicates the TUI/desktop model-switch path. The
+// write lock is held across the whole rebuild so concurrent requests never read
+// a half-swapped controller and two switches can't run at once.
 func (s *Server) switchModel(ctx context.Context, ref string) error {
-	if s.ctrl.Running() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cur := s.ctrl
+	if cur.Running() {
 		return fmt.Errorf("cannot switch model while a turn is running")
 	}
-	// Snapshot current session so nothing is lost.
-	if err := s.ctrl.Snapshot(); err != nil {
+	if err := cur.Snapshot(); err != nil {
 		slog.Warn("serve: snapshot before model switch", "err", err)
 	}
-	carried := s.ctrl.History()
+	carried := cur.History()
 
 	newCtrl, err := boot.Build(ctx, boot.Options{
 		Model:  ref,
@@ -90,7 +104,6 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	if err != nil {
 		return fmt.Errorf("switch model: %w", err)
 	}
-	// Wire session path and carry history.
 	newPath := ""
 	if dir := newCtrl.SessionDir(); dir != "" {
 		newPath = agent.NewSessionPath(dir, newCtrl.Label())
@@ -101,10 +114,8 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 		newCtrl.SetSessionPath(newPath)
 	}
 
-	// Close old controller resources (plugins, jobs) but not the session —
-	// it was already snapshotted.
-	s.ctrl.Close()
 	s.ctrl = newCtrl
+	cur.Close()
 	return nil
 }
 
@@ -176,7 +187,7 @@ func csrfGuard(next http.Handler) http.Handler {
 // Run serves until the process is killed. Interactive approval is enabled so
 // "ask" decisions surface as approval_request events answered via POST /approve.
 func (s *Server) Run(addr string) error {
-	s.ctrl.EnableInteractiveApproval()
+	s.ctl().EnableInteractiveApproval()
 	return http.ListenAndServe(addr, s.Handler())
 }
 
@@ -184,7 +195,7 @@ func (s *Server) Run(addr string) error {
 // the provided context and drains active connections for up to 10 seconds
 // before returning.
 func (s *Server) RunGraceful(ctx context.Context, addr string) error {
-	s.ctrl.EnableInteractiveApproval()
+	s.ctl().EnableInteractiveApproval()
 	srv := &http.Server{
 		Addr:              addr,
 		Handler:           s.Handler(),
@@ -269,12 +280,12 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	s.ctrl.Submit(body.Input)
+	s.ctl().Submit(body.Input)
 	w.WriteHeader(http.StatusAccepted)
 }
 
 func (s *Server) cancel(w http.ResponseWriter, _ *http.Request) {
-	s.ctrl.Cancel()
+	s.ctl().Cancel()
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -288,7 +299,7 @@ func (s *Server) approve(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing id", http.StatusBadRequest)
 		return
 	}
-	s.ctrl.Approve(body.ID, body.Allow, body.Session)
+	s.ctl().Approve(body.ID, body.Allow, body.Session)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -300,24 +311,24 @@ func (s *Server) plan(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad body", http.StatusBadRequest)
 		return
 	}
-	s.ctrl.SetPlanMode(body.On)
+	s.ctl().SetPlanMode(body.On)
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) compact(w http.ResponseWriter, r *http.Request) {
-	if err := s.ctrl.Compact(r.Context(), ""); err != nil {
+	if err := s.ctl().Compact(r.Context(), ""); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	// Persist the compacted session to disk — ctrl.Compact() only mutates in-memory.
-	if err := s.ctrl.Snapshot(); err != nil {
+	if err := s.ctl().Snapshot(); err != nil {
 		slog.Warn("serve: snapshot after compact", "err", err)
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) newSession(w http.ResponseWriter, _ *http.Request) {
-	if err := s.ctrl.NewSession(); err != nil {
+	if err := s.ctl().NewSession(); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -332,7 +343,7 @@ func (s *Server) history(w http.ResponseWriter, _ *http.Request) {
 		Content string `json:"content"`
 	}
 	var out []msg
-	for _, m := range s.ctrl.History() {
+	for _, m := range s.ctl().History() {
 		out = append(out, msg{Role: string(m.Role), Content: m.Content})
 	}
 	writeJSON(w, out)
@@ -340,7 +351,7 @@ func (s *Server) history(w http.ResponseWriter, _ *http.Request) {
 
 // context returns the prompt-vs-window gauge numbers.
 func (s *Server) context(w http.ResponseWriter, _ *http.Request) {
-	used, window := s.ctrl.ContextSnapshot()
+	used, window := s.ctl().ContextSnapshot()
 	writeJSON(w, map[string]int{"used": used, "window": window})
 }
 
@@ -423,7 +434,7 @@ func (s *Server) rewind(w http.ResponseWriter, r *http.Request) {
 	case "conversation":
 		scope = control.RewindConversation
 	}
-	if err := s.ctrl.Rewind(body.Turn, scope); err != nil {
+	if err := s.ctl().Rewind(body.Turn, scope); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -440,7 +451,7 @@ func (s *Server) fork(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing turn", http.StatusBadRequest)
 		return
 	}
-	path, err := s.ctrl.ForkNamed(body.Turn, body.Name)
+	path, err := s.ctl().ForkNamed(body.Turn, body.Name)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -461,9 +472,9 @@ func (s *Server) summarize(w http.ResponseWriter, r *http.Request) {
 	var err error
 	switch body.Mode {
 	case "from":
-		err = s.ctrl.SummarizeFrom(r.Context(), body.Turn)
+		err = s.ctl().SummarizeFrom(r.Context(), body.Turn)
 	case "upto":
-		err = s.ctrl.SummarizeUpTo(r.Context(), body.Turn)
+		err = s.ctl().SummarizeUpTo(r.Context(), body.Turn)
 	default:
 		http.Error(w, "mode must be 'from' or 'upto'", http.StatusBadRequest)
 		return
@@ -484,7 +495,7 @@ func (s *Server) bypass(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "bad body", http.StatusBadRequest)
 		return
 	}
-	s.ctrl.SetBypass(body.On)
+	s.ctl().SetBypass(body.On)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -498,7 +509,7 @@ func (s *Server) answer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing id", http.StatusBadRequest)
 		return
 	}
-	s.ctrl.AnswerQuestion(body.ID, body.Answers)
+	s.ctl().AnswerQuestion(body.ID, body.Answers)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -512,7 +523,7 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Snapshot the current session before switching away.
-	if err := s.ctrl.Snapshot(); err != nil {
+	if err := s.ctl().Snapshot(); err != nil {
 		slog.Warn("serve: snapshot before resume", "err", err)
 	}
 	loaded, err := agent.LoadSession(body.Path)
@@ -520,7 +531,7 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "load session: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	s.ctrl.Resume(loaded, body.Path)
+	s.ctl().Resume(loaded, body.Path)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -533,7 +544,7 @@ func (s *Server) forget(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing name", http.StatusBadRequest)
 		return
 	}
-	if err := s.ctrl.ForgetMemory(body.Name); err != nil {
+	if err := s.ctl().ForgetMemory(body.Name); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -547,7 +558,7 @@ func (s *Server) checkpoints(w http.ResponseWriter, _ *http.Request) {
 		Prompt string `json:"prompt"`
 		Files  int    `json:"files"`
 	}
-	raw := s.ctrl.Checkpoints()
+	raw := s.ctl().Checkpoints()
 	out := make([]cp, len(raw))
 	for i, c := range raw {
 		out[i] = cp{Turn: c.Turn, Prompt: c.Prompt, Files: len(c.Paths)}
@@ -557,37 +568,37 @@ func (s *Server) checkpoints(w http.ResponseWriter, _ *http.Request) {
 
 // branches returns the branch list and tree text.
 func (s *Server) branches(w http.ResponseWriter, _ *http.Request) {
-	branches, err := s.ctrl.Branches()
+	branches, err := s.ctl().Branches()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	tree := s.ctrl.BranchTreeText()
+	tree := s.ctl().BranchTreeText()
 	writeJSON(w, map[string]any{"branches": branches, "tree": tree})
 }
 
 // status returns a combined status snapshot.
 func (s *Server) status(w http.ResponseWriter, r *http.Request) {
-	used, window := s.ctrl.ContextSnapshot()
-	hit, miss := s.ctrl.SessionCache()
+	used, window := s.ctl().ContextSnapshot()
+	hit, miss := s.ctl().SessionCache()
 	sess := map[string]any{
-		"label":     s.ctrl.Label(),
-		"running":   s.ctrl.Running(),
-		"plan":      s.ctrl.PlanMode(),
-		"bypass":    s.ctrl.Bypass(),
-		"cwd":       s.ctrl.SessionDir(),
+		"label":     s.ctl().Label(),
+		"running":   s.ctl().Running(),
+		"plan":      s.ctl().PlanMode(),
+		"bypass":    s.ctl().Bypass(),
+		"cwd":       s.ctl().SessionDir(),
 		"used":      used,
 		"window":    window,
 		"cacheHit":  hit,
 		"cacheMiss": miss,
 	}
-	if u := s.ctrl.LastUsage(); u != nil {
+	if u := s.ctl().LastUsage(); u != nil {
 		sess["lastUsage"] = u
 	}
-	if b, err := s.ctrl.Balance(r.Context()); err == nil && b != nil {
+	if b, err := s.ctl().Balance(r.Context()); err == nil && b != nil {
 		sess["balance"] = b
 	}
-	if j := s.ctrl.Jobs(); len(j) > 0 {
+	if j := s.ctl().Jobs(); len(j) > 0 {
 		sess["jobs"] = j
 	}
 	writeJSON(w, sess)
@@ -634,7 +645,7 @@ func (s *Server) generateTitle(ctx context.Context, firstMsg string) string {
 // sessions lists saved session files from the session directory, enriched with
 // LLM-generated titles and turn counts.
 func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
-	dir := s.ctrl.SessionDir()
+	dir := s.ctl().SessionDir()
 	if dir == "" {
 		writeJSON(w, []any{})
 		return
@@ -651,7 +662,7 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, []any{})
 		return
 	}
-	current := filepath.Clean(s.ctrl.SessionPath())
+	current := filepath.Clean(s.ctl().SessionPath())
 	var out []sessionEntry
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".jsonl") {
@@ -741,7 +752,7 @@ func (s *Server) skills(w http.ResponseWriter, _ *http.Request) {
 		Subagent    bool   `json:"subagent"`
 		Description string `json:"description"`
 	}
-	raw := s.ctrl.Skills()
+	raw := s.ctl().Skills()
 	out := make([]skillEntry, len(raw))
 	for i, sk := range raw {
 		out[i] = skillEntry{Name: sk.Name, Scope: string(sk.Scope), Subagent: sk.RunAs == "subagent", Description: sk.Description}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
@@ -256,6 +257,10 @@ func (s *Server) compact(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	// Persist the compacted session to disk — ctrl.Compact() only mutates in-memory.
+	if err := s.ctrl.Snapshot(); err != nil {
+		slog.Warn("serve: snapshot after compact", "err", err)
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -445,7 +450,7 @@ func (s *Server) answer(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// resume loads a previous session by index.
+// resume loads a previous session from a JSONL file.
 func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Path string `json:"path"`
@@ -454,9 +459,17 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing path", http.StatusBadRequest)
 		return
 	}
-	// Use Submit to handle /resume which the controller dispatches
-	s.ctrl.Submit("/resume " + body.Path)
-	w.WriteHeader(http.StatusAccepted)
+	// Snapshot the current session before switching away.
+	if err := s.ctrl.Snapshot(); err != nil {
+		slog.Warn("serve: snapshot before resume", "err", err)
+	}
+	loaded, err := agent.LoadSession(body.Path)
+	if err != nil {
+		http.Error(w, "load session: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	s.ctrl.Resume(loaded, body.Path)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // forget deletes a saved memory by name.


### PR DESCRIPTION
Lands @lanshi17's serve sidebar work from #2749 with a concurrency fix on top.

### From #2749 (verified end-to-end)
- **Session resume** — the old `Submit("/resume <path>")` had no dispatch case and silently did nothing; now `agent.LoadSession` + `ctrl.Resume`, snapshotting the current session first. Confirmed live: `POST /resume` → 204 and `/history` replays the loaded session.
- **Compact persistence** — `Snapshot()` after `Compact()`, so a compacted session survives a restart (matches `Submit("/compact")`).
- **Connection status indicator** — green/yellow/red dot driven by the EventSource state.
- **Runtime model switching** via `/model <ref>` — rebuilds the controller with carried-over history. Confirmed live: switch flips the active model and preserves `/history`.

### Added here
`switchModel` reassigned `s.ctrl` from the `/submit` goroutine while `status`, `history`, and other handlers read it concurrently — an unsynchronized data race. Added an `RWMutex`: handlers now read the controller through `ctl()` under the read lock, and `switchModel` holds the write lock across the entire rebuild, so no request can observe a half-swapped controller and two switches can't overlap. `modelswitch_test.go` exercises concurrent reads against a swap and fails under `-race` without the lock (the CI race job enforces this).

Closes #2749

Co-authored-by: lanshi <yzs20030317@gmail.com>
