### PR TITLE
refactor(desktop): trim onboarding comments, fix stale timeout note

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1830,45 +1830,19 @@ func parseScope(s string) memory.Scope {
 	}
 }
 
-// onboardingKeyEnv is the API key the first-run overlay asks for. It matches the
-// default provider (deepseek) in config.Default(); once it's set the kernel can
-// boot. Other providers are configured later via the Settings panel.
+// onboardingKeyEnv is the default provider (deepseek) key from config.Default().
 const onboardingKeyEnv = "DEEPSEEK_API_KEY"
 
-// onboardingBalanceURL is the vendor balance endpoint that doubles as a
-// connectivity + auth probe — billing.FetchWithClient hits it with the user's
-// key and surfaces 401/403 for invalid keys. We use it instead of a separate
-// /models GET so the call costs zero tokens and reuses the existing billing
-// HTTP client (12s timeout, ctx-cancellable).
+// onboardingBalanceURL doubles as a zero-token connectivity + auth probe:
+// billing.FetchWithClient surfaces 401/403 for a bad key.
 const onboardingBalanceURL = "https://api.deepseek.com/user/balance"
 
-// NeedsOnboarding reports whether the first-run overlay should be shown. It
-// returns true when the default provider's API key env var is unset in the
-// process — which covers both a fresh install and a user who cleared their key
-// before launching. Cheap (no I/O, no config reload), so the frontend can call
-// it once on mount.
 func (a *App) NeedsOnboarding() bool {
 	return strings.TrimSpace(os.Getenv(onboardingKeyEnv)) == ""
 }
 
-// ConnectKey validates apiKey against the default provider's balance endpoint
-// and, on success, persists it to ./.env (via upsertDotEnv, which also sets the
-// process env so the next rebuild picks it up). The validation reuses
-// billing.FetchWithClient — a 12s timeout, a network call that costs no tokens
-// — so a typo'd key surfaces as 401 quickly. After writing the key we trigger
-// a controller rebuild; the kernel emits agent:ready once boot.Build completes
-// and the frontend then transitions off the overlay.
-//
-// Errors:
-//   - empty key → "key is required"
-//   - HTTP 401/403 → wrapped status so the UI can show "invalid key"
-//   - network/dial failure → wrapped; the UI shows "network unreachable"
-//   - any other HTTP status → wrapped
-//
-// Note: this method is bound to the UI before boot.Build has necessarily
-// finished. The rebuild below re-issues boot.Build with the freshly-set env
-// var; if the kernel already booted (key was empty so it built no controller),
-// this is the first real build, otherwise it's a rebuild.
+// ConnectKey validates apiKey against the balance endpoint, persists it to
+// ./.env, and rebuilds the controller so the new key takes effect.
 func (a *App) ConnectKey(apiKey string) error {
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
@@ -1876,19 +1850,14 @@ func (a *App) ConnectKey(apiKey string) error {
 	}
 	ctx, cancel := context.WithTimeout(a.ctx, 8*time.Second)
 	defer cancel()
-	// FetchWithClient returns (nil, nil) when the url is empty — we never hit
-	// that path (onboardingBalanceURL is constant), but be defensive.
 	if _, err := billing.FetchWithClient(ctx, nil, onboardingBalanceURL, apiKey); err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
 	if err := upsertDotEnv(onboardingKeyEnv, apiKey); err != nil {
 		return fmt.Errorf("save: %w", err)
 	}
-	// rebuild the controller so the new key takes effect; startupErr is cleared
-	// by rebuild on success, so the topbar banner disappears on agent:ready.
 	if err := a.rebuild(); err != nil {
-		// Keep going — the key is persisted; the next user action that
-		// triggers a rebuild (e.g. /model switch) will load it.
+		// Key is persisted; surface the failure but let the next rebuild load it.
 		a.mu.Lock()
 		a.startupErr = err.Error()
 		a.mu.Unlock()

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -162,10 +162,8 @@ export default function App() {
   } = useController();
   const t = useT();
   const [mode, setMode] = useState<Mode>("normal");
-  // Onboarding gate. null = not yet checked (show the regular loading screen),
-  // true = show the overlay, false = past onboarding, render the main UI.
-  // Probed exactly once on mount; the user clearing their key mid-session
-  // won't re-trigger the overlay (that's what the Settings panel is for).
+  // null until the mount probe resolves; true shows the overlay. Probed once —
+  // clearing the key mid-session is the Settings panel's job, not the gate's.
   const [needsOnboarding, setNeedsOnboarding] = useState<boolean | null>(null);
   const [memView, setMemView] = useState<MemoryView | null>(null);
   const [histView, setHistView] = useState<SessionMeta[] | null>(null);
@@ -318,10 +316,6 @@ export default function App() {
     void refreshSessions();
   }, [refreshSessions]);
 
-  // Probe the Go side for missing API key exactly once. We don't re-probe on
-  // meta changes because the only path that "adds a key" is the Settings
-  // panel, which calls SetProviderKey and a rebuild — the kernel then emits
-  // agent:ready and the regular UI is already mounted.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -329,11 +323,8 @@ export default function App() {
         const needs = await app.NeedsOnboarding();
         if (!cancelled) setNeedsOnboarding(needs);
       } catch {
-        // Bridge unavailable (browser dev mock missing the method, or
-        // pre-startup) — fall through to the regular UI; if the kernel
-        // can't load it, the existing topbar.startupError banner surfaces
-        // the reason. Treat as "no onboarding" so the user can still poke
-        // at the Settings panel.
+        // Bridge unavailable (browser dev seam) — skip the gate; a real key
+        // failure still surfaces via the topbar startupError banner.
         if (!cancelled) setNeedsOnboarding(false);
       }
     })();
@@ -994,10 +985,6 @@ export default function App() {
 
       {capsOpen && <CapabilitiesPanel onClose={() => setCapsOpen(false)} />}
 
-      {/* First-run gate: covers the whole app until the default provider's API
-          key is in place. onComplete fires after ConnectKey succeeds; the
-          kernel is already rebuilding in the background and will emit
-          agent:ready once the new controller is up. */}
       {needsOnboarding && <OnboardingOverlay onComplete={() => setNeedsOnboarding(false)} />}
     </div>
   );

--- a/desktop/frontend/src/components/OnboardingOverlay.tsx
+++ b/desktop/frontend/src/components/OnboardingOverlay.tsx
@@ -3,20 +3,8 @@ import logo from "../assets/logo.svg";
 import { useT } from "../lib/i18n";
 import { app, openExternal } from "../lib/bridge";
 
-// OnboardingOverlay is the full-window first-run gate. Shown by App when
-// NeedsOnboarding() returns true (the default provider's API key is unset).
-// It validates the pasted key against the provider's balance endpoint, writes
-// it to ./.env via Go, and triggers a controller rebuild — the overlay stays
-// up until App's useController hook picks up agent:ready and the parent
-// drops needsOnboarding back to false. Three states the UI walks through:
-//
-//   idle        → paste a key, click "Connect & start"
-//   validating  → button shows a spinner, the input is locked
-//   error       → red banner with the kernel's reason; user can retry
-//
-// We deliberately don't auto-focus the input on mount: the user may be reading
-// the privacy / "where to get a key" copy first, and yanking focus before
-// they've decided feels pushy.
+// Full-window first-run gate: validate a pasted key via Go, then onComplete
+// unmounts us so the rebuilt controller's main UI takes over.
 export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
   const t = useT();
   const [value, setValue] = useState("");
@@ -36,17 +24,8 @@ export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
     setError(null);
     try {
       await app.ConnectKey(key);
-      // The Go side rebuilds the controller and emits agent:ready; the
-      // parent's useController hook will pick that up and refresh Meta/
-      // History. We just need to unmount ourselves so the main UI takes over.
-      // If the rebuild throws the key is still persisted and the next
-      // controller rebuild will pick it up, so leaving the overlay showing
-      // on error is the safer behavior.
       onComplete();
     } catch (e) {
-      // The kernel returns human-readable errors for the common cases
-      // (401 → "invalid key", dial failure → "network unreachable"). Map the
-      // 401/403 status text to a friendlier i18n key when we recognize it.
       const msg = e instanceof Error ? e.message : String(e);
       if (/status\s*401|status\s*403|invalid/i.test(msg)) {
         setError(t("onboarding.error.invalid"));

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -132,11 +132,8 @@ export interface AppBindings {
   CheckUpdate(): Promise<UpdateInfo | null>;
   ApplyUpdate(): Promise<void>;
   OpenDownloadPage(): Promise<void>;
-  // Onboarding: first-run overlay for the default provider's API key.
-  // NeedsOnboarding is true when DEEPSEEK_API_KEY (or whatever the default
-  // provider's key env is) is unset in the process. ConnectKey validates the
-  // key against the balance endpoint, persists it to ./.env, and rebuilds the
-  // controller — the frontend then transitions off the overlay on agent:ready.
+  // First-run overlay: NeedsOnboarding is true when the default provider key is
+  // unset; ConnectKey validates, persists to ./.env, and rebuilds the controller.
   NeedsOnboarding(): Promise<boolean>;
   ConnectKey(apiKey: string): Promise<void>;
 }
@@ -740,11 +737,10 @@ function makeMockApp(): AppBindings {
         window.open("https://github.com/esengine/reasonix/releases/latest", "_blank", "noopener");
       }
     },
-    // Onboarding mock: pretend the key is missing until the user "connects" so
-    // the overlay flow is exercisable in the browser dev seam. The real Wails
-    // shell overrides this and the overlay never appears once a key is set.
+    // Dev seam: drives the overlay flow in the browser until ConnectKey sets the
+    // key. Matches ConnectKey on apiKeyEnv so the two stay in sync.
     async NeedsOnboarding() {
-      return !settings.providers.find((p) => p.name === "deepseek-flash")?.keySet;
+      return !settings.providers.find((p) => p.apiKeyEnv === "DEEPSEEK_API_KEY")?.keySet;
     },
     async ConnectKey(apiKey: string) {
       if (!apiKey.trim()) throw new Error("key is required");

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -389,9 +389,7 @@ export const en = {
   "updater.retry": "Retry",
   "updater.dismiss": "Later",
 
-  // onboarding — first-run overlay shown when the default provider's API key
-  // is unset. The user pastes a key; we validate it against the vendor's
-  // balance endpoint (no tokens spent) and persist it to ./.env.
+  // onboarding — first-run API-key overlay
   "onboarding.title": "Connect Reasonix",
   "onboarding.tagline": "Paste a DeepSeek API key to start. Stored locally in .env, never sent anywhere else.",
   "onboarding.inputLabel": "API key",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -390,8 +390,7 @@ export const zh: Record<DictKey, string> = {
   "updater.retry": "重试",
   "updater.dismiss": "稍后",
 
-  // 首次启动引导：默认 provider 的 API key 未设置时显示。用户粘贴 key 后，
-  // 我们用 vendor 的余额接口做零 token 校验，然后写入 ./.env。
+  // onboarding — first-run API-key overlay
   "onboarding.title": "连接 Reasonix",
   "onboarding.tagline": "粘贴一个 DeepSeek API key 即可开始。密钥仅存于本机的 .env，不会发往任何地方。",
   "onboarding.inputLabel": "API 密钥",


### PR DESCRIPTION
## Summary
Follow-up cleanup on #2752 (first-run onboarding overlay). Comment-only, plus one stale-fact fix and a dev-mock alignment — no behavior change.

## Changes
- **`ConnectKey` doc fixed**: it claimed a "12s timeout" twice, but the validation call runs under an 8s `context.WithTimeout` (the 12s is `billing.httpClient`'s default, which the ctx pre-empts). Dropped the misleading number.
- **Trimmed restated comments** the code already states: the `Errors:` list / `Note:` paragraph on `ConnectKey`, the three-state header essay and inline narration in `OnboardingOverlay`, the probe-`useEffect` catch essay in `App.tsx`, and the multi-line locale headers (the zh one bordered on a translator note).
- **Bridge dev mock aligned**: `NeedsOnboarding` matched the provider by `name === "deepseek-flash"` while `ConnectKey` matched by `apiKeyEnv === "DEEPSEEK_API_KEY"`. Both now key off `apiKeyEnv` so the dev seam stays consistent.

Net −72 lines, all comments except the two-line mock change.

## Verification
- `go vet ./` and `go test ./` in `desktop` pass.
- `npm run typecheck` (tsc --noEmit) in `desktop/frontend` clean.
