### PR TITLE
feat(net): exponential-backoff retry with clear error UX

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -963,6 +963,7 @@ export default function App() {
               mode={mode}
               turnStartAt={state.turnStartAt}
 	      turnTokens={state.turnTokens}
+	      retry={state.retry}
 	      onSwitchModel={switchModel}
 	      onSetEffort={setEffort}
 	    />

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -94,6 +94,7 @@ export function StatusBar({
   mode,
   turnStartAt,
   turnTokens,
+  retry,
   onSwitchModel,
   onSetEffort,
 }: {
@@ -107,6 +108,7 @@ export function StatusBar({
   mode: Mode;
   turnStartAt: number;
   turnTokens: number;
+  retry?: { attempt: number; max: number };
   onSwitchModel: (name: string) => void;
   onSetEffort: (level: string) => void;
 }) {
@@ -119,7 +121,9 @@ export function StatusBar({
   // While a turn runs, the status line shows live activity (word · elapsed ·
   // tokens) in place of the static context gauge.
   let activity: string | null = null;
-  if (running && turnStartAt) {
+  if (retry) {
+    activity = t("status.retrying", { attempt: retry.attempt, max: retry.max });
+  } else if (running && turnStartAt) {
     const elapsedMs = Math.max(0, now - turnStartAt);
     const words = SPINNER_WORDS[locale];
     const word = words[Math.floor(elapsedMs / 3000) % words.length];

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -16,7 +16,8 @@ export type EventKind =
   | "ask_request"
   | "turn_done"
   | "compaction_started"
-  | "compaction_done";
+  | "compaction_done"
+  | "retrying";
 
 export interface WireCompaction {
   trigger?: string; // "auto" | "manual"
@@ -92,6 +93,8 @@ export interface WireEvent {
   ask?: WireAsk;
   compaction?: WireCompaction;
   err?: string;
+  retryAttempt?: number;
+  retryMax?: number;
 }
 
 // Bound-method payloads (desktop/app.go).

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -98,6 +98,9 @@ interface State {
   // frontend-observed harness state; no model cooperation needed.
   turnStartAt: number;
   turnTokens: number;
+  // retry drives the transient "retrying (n/m)" indicator while the provider
+  // re-attempts the connection; cleared by the next stream event or turn end.
+  retry?: { attempt: number; max: number };
   // seq is a monotonic id source so React keys stay stable across re-renders.
   seq: number;
 }
@@ -166,6 +169,13 @@ function applyEvent(s: State, e: WireEvent): State {
   // request) and turn_done is handled in its own case, so neither commits.
   if (s.pendingUser !== undefined && e.kind !== "turn_started" && e.kind !== "turn_done") {
     s = flushPendingUser(s);
+  }
+  if (e.kind === "retrying") {
+    return { ...s, retry: { attempt: e.retryAttempt ?? 0, max: e.retryMax ?? 0 } };
+  }
+  // Any other event got past the retry window (or ended the turn): clear it.
+  if (s.retry) {
+    s = { ...s, retry: undefined };
   }
   switch (e.kind) {
     case "turn_started":

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -179,6 +179,7 @@ export const en = {
   "status.effortAutoTitle": "Reasoning effort: auto (model default: {def})",
   "status.switchFolder": "{cwd}\nClick to switch project folder",
   "status.tokens": "tokens",
+  "status.retrying": "retrying ({attempt}/{max})…",
   "status.cache": "cache {pct}%",
   "status.cacheAvg": "avg {pct}%",
   "status.balanceTitle": "Wallet balance",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -180,6 +180,7 @@ export const zh: Record<DictKey, string> = {
   "status.effortAutoTitle": "推理力度：auto（模型默认：{def}）",
   "status.switchFolder": "{cwd}\n点击切换项目目录",
   "status.tokens": "tokens",
+  "status.retrying": "正在重试 ({attempt}/{max})…",
   "status.cache": "缓存 {pct}%",
   "status.cacheAvg": "平均 {pct}%",
   "status.balanceTitle": "钱包余额",

--- a/desktop/wire.go
+++ b/desktop/wire.go
@@ -12,16 +12,18 @@ import "reasonix/internal/event"
 // may diverge later; if they don't, this is the obvious thing to lift into a
 // shared event.ToWire.)
 type wireEvent struct {
-	Kind       string          `json:"kind"`
-	Text       string          `json:"text,omitempty"`
-	Reasoning  string          `json:"reasoning,omitempty"`
-	Level      string          `json:"level,omitempty"`
-	Tool       *wireTool       `json:"tool,omitempty"`
-	Usage      *wireUsage      `json:"usage,omitempty"`
-	Approval   *wireApproval   `json:"approval,omitempty"`
-	Ask        *wireAsk        `json:"ask,omitempty"`
-	Compaction *wireCompaction `json:"compaction,omitempty"`
-	Err        string          `json:"err,omitempty"`
+	Kind         string          `json:"kind"`
+	Text         string          `json:"text,omitempty"`
+	Reasoning    string          `json:"reasoning,omitempty"`
+	Level        string          `json:"level,omitempty"`
+	Tool         *wireTool       `json:"tool,omitempty"`
+	Usage        *wireUsage      `json:"usage,omitempty"`
+	Approval     *wireApproval   `json:"approval,omitempty"`
+	Ask          *wireAsk        `json:"ask,omitempty"`
+	Compaction   *wireCompaction `json:"compaction,omitempty"`
+	Err          string          `json:"err,omitempty"`
+	RetryAttempt int             `json:"retryAttempt,omitempty"`
+	RetryMax     int             `json:"retryMax,omitempty"`
 }
 
 // wireCompaction is the JSON form of an event.Compaction. On a compaction_started
@@ -101,6 +103,7 @@ var kindNames = map[event.Kind]string{
 	event.CompactionStarted: "compaction_started",
 	event.CompactionDone:    "compaction_done",
 	event.ToolProgress:      "tool_progress",
+	event.Retrying:          "retrying",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.
@@ -158,6 +161,9 @@ func toWire(e event.Event) wireEvent {
 		if e.Err != nil {
 			w.Err = e.Err.Error()
 		}
+	case event.Retrying:
+		w.RetryAttempt = e.RetryAttempt
+		w.RetryMax = e.RetryMax
 	}
 	return w
 }

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"reasonix/internal/event"
@@ -40,6 +41,21 @@ func TestToWireNoticeWarn(t *testing.T) {
 	w := toWire(e)
 	if w.Level != "warn" {
 		t.Errorf("notice warn level = %q", w.Level)
+	}
+}
+
+func TestToWireRetrying(t *testing.T) {
+	e := event.Event{Kind: event.Retrying, RetryAttempt: 3, RetryMax: 10}
+	w := toWire(e)
+	if w.Kind != "retrying" || w.RetryAttempt != 3 || w.RetryMax != 10 {
+		t.Errorf("retrying wire = %+v", w)
+	}
+	b, err := json.Marshal(w)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if s := string(b); !strings.Contains(s, `"retryAttempt":3`) || !strings.Contains(s, `"retryMax":10`) {
+		t.Errorf("retrying JSON = %s", s)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -424,6 +424,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 // accumulated text and reasoning are also returned so the caller can round-trip
 // reasoning on the next turn.
 func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, []provider.ToolCall, *provider.Usage, error) {
+	ctx = provider.WithRetryNotify(ctx, func(info provider.RetryInfo) {
+		a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: info.Attempt, RetryMax: info.Max})
+	})
 	ch, err := a.prov.Stream(ctx, provider.Request{
 		Messages:    a.session.Messages,
 		Tools:       a.tools.Schemas(),

--- a/internal/agent/retry_e2e_test.go
+++ b/internal/agent/retry_e2e_test.go
@@ -1,0 +1,85 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/provider/openai"
+	"reasonix/internal/tool"
+)
+
+type recordSink struct {
+	mu  sync.Mutex
+	evs []event.Event
+}
+
+func (s *recordSink) Emit(e event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.evs = append(s.evs, e)
+}
+
+func (s *recordSink) kinds(k event.Kind) []event.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []event.Event
+	for _, e := range s.evs {
+		if e.Kind == k {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// TestAgentEmitsRetryingThenStreams drives the whole chain end-to-end: a real
+// OpenAI-compatible provider hits an httptest server that returns 503 twice then
+// a valid SSE stream. The agent must emit a Retrying event per backoff (so the
+// composer can show "retrying n/m") and still deliver the streamed answer.
+func TestAgentEmitsRetryingThenStreams(t *testing.T) {
+	var reqs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		if reqs <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"overloaded"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"hi there\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	prov, err := openai.New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New provider: %v", err)
+	}
+
+	sink := &recordSink{}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, sink)
+	if err := a.Run(context.Background(), "hi"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	retries := sink.kinds(event.Retrying)
+	if len(retries) != 2 || retries[0].RetryAttempt != 1 || retries[1].RetryAttempt != 2 {
+		t.Fatalf("want two Retrying events (1,2), got %+v", retries)
+	}
+	if retries[0].RetryMax != provider.MaxRetries {
+		t.Errorf("RetryMax = %d, want %d", retries[0].RetryMax, provider.MaxRetries)
+	}
+
+	var answer strings.Builder
+	for _, e := range sink.kinds(event.Text) {
+		answer.WriteString(e.Text)
+	}
+	if !strings.Contains(answer.String(), "hi there") {
+		t.Errorf("streamed answer = %q, want it to contain %q", answer.String(), "hi there")
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -67,6 +67,10 @@ type chatTUI struct {
 	state    tuiState
 	runStart time.Time
 	elapsed  int
+	// retryAttempt/retryMax drive the transient "retrying (n/m)" indicator while
+	// the provider re-attempts the connection; cleared by the next stream event.
+	retryAttempt int
+	retryMax     int
 	// turnTokens accumulates this turn's output tokens (summed from per-step Usage
 	// events) for the live "↓N" readout in the running status line.
 	turnTokens int
@@ -1471,9 +1475,13 @@ func (m chatTUI) View() tea.View {
 	// Code: live progress over the composer, shortcuts + stats under it.
 	var working string
 	if m.state == tuiRunning {
-		working = fmt.Sprintf("  "+i18n.M.ChatStatusThinkingFmt, m.spinner.View(), m.elapsed)
-		if m.turnTokens > 0 {
-			working += " · ↓" + shortTokens(m.turnTokens)
+		if m.retryAttempt > 0 {
+			working = fmt.Sprintf("  "+i18n.M.ChatStatusRetryingFmt, m.spinner.View(), m.retryAttempt, m.retryMax)
+		} else {
+			working = fmt.Sprintf("  "+i18n.M.ChatStatusThinkingFmt, m.spinner.View(), m.elapsed)
+			if m.turnTokens > 0 {
+				working += " · ↓" + shortTokens(m.turnTokens)
+			}
 		}
 	}
 	// Second status row: the live data (model, effort, context gauge, cache rates,
@@ -2212,6 +2220,15 @@ func (m *chatTUI) unsendPending() {
 // preserving order. Switching on the event Kind replaces the old prefix-sniffing
 // of a flattened byte stream: the structure is now explicit.
 func (m *chatTUI) ingestEvent(e event.Event) {
+	if e.Kind == event.Retrying {
+		m.retryAttempt = e.RetryAttempt
+		m.retryMax = e.RetryMax
+		return
+	}
+	// Any other event means the connection got past the retry window (or the turn
+	// ended), so the transient "retrying" indicator clears.
+	m.retryAttempt = 0
+	m.retryMax = 0
 	if m.turnDiscarded {
 		// The turn was un-sent (Esc before any packet); swallow whatever was already
 		// buffered for it until it settles, so nothing lands in scrollback.

--- a/internal/cli/retry_indicator_test.go
+++ b/internal/cli/retry_indicator_test.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/i18n"
+)
+
+// TestRetryIndicatorShowsAndClears proves a Retrying event sets the transient
+// retry fields the composer renders from, and that the next stream event clears
+// them back to the normal thinking line.
+func TestRetryIndicatorShowsAndClears(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+
+	m.ingestEvent(event.Event{Kind: event.Retrying, RetryAttempt: 3, RetryMax: 10})
+	if m.retryAttempt != 3 || m.retryMax != 10 {
+		t.Fatalf("retry fields = %d/%d, want 3/10", m.retryAttempt, m.retryMax)
+	}
+
+	m.ingestEvent(event.Event{Kind: event.Text, Text: "answer"})
+	if m.retryAttempt != 0 || m.retryMax != 0 {
+		t.Fatalf("a stream event should clear the retry indicator, got %d/%d", m.retryAttempt, m.retryMax)
+	}
+}
+
+// TestRetryIndicatorText guards the composer's retry line wording — the same
+// format string View() renders when retryAttempt > 0.
+func TestRetryIndicatorText(t *testing.T) {
+	line := fmt.Sprintf(i18n.English.ChatStatusRetryingFmt, "⠋", 3, 10)
+	if !strings.Contains(line, "retrying (3/10)") {
+		t.Errorf("EN retry line = %q, want it to contain 'retrying (3/10)'", line)
+	}
+	zh := fmt.Sprintf(i18n.Chinese.ChatStatusRetryingFmt, "⠋", 3, 10)
+	if !strings.Contains(zh, "正在重试 (3/10)") {
+		t.Errorf("ZH retry line = %q, want it to contain '正在重试 (3/10)'", zh)
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -294,7 +294,7 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 		c.running = false
 		c.cancel = nil
 		c.mu.Unlock()
-		c.sink.Emit(event.Event{Kind: event.TurnDone, Err: err})
+		c.sink.Emit(event.Event{Kind: event.TurnDone, Err: explainError(err)})
 	}()
 }
 

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -1,0 +1,37 @@
+package control
+
+import (
+	"errors"
+	"fmt"
+
+	"reasonix/internal/i18n"
+	"reasonix/internal/provider"
+)
+
+// explainError maps a provider HTTP failure to an actionable, localized message
+// so the turn-done error the UI shows is never a bare status code or silent
+// failure. Unknown errors (and nil) pass through unchanged.
+func explainError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *provider.APIError
+	if errors.As(err, &apiErr) {
+		if msg := i18n.M.ProviderStatusMessage(apiErr.Status); msg != "" {
+			return errors.New(msg)
+		}
+		return err
+	}
+	var authErr *provider.AuthError
+	if errors.As(err, &authErr) {
+		msg := i18n.M.ProviderStatusMessage(authErr.Status)
+		if msg == "" {
+			return err
+		}
+		if authErr.KeyEnv != "" {
+			return fmt.Errorf("%s (%s)", msg, authErr.KeyEnv)
+		}
+		return errors.New(msg)
+	}
+	return err
+}

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -1,0 +1,38 @@
+package control
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"reasonix/internal/i18n"
+	"reasonix/internal/provider"
+)
+
+func TestExplainError(t *testing.T) {
+	if explainError(nil) != nil {
+		t.Error("nil should stay nil")
+	}
+
+	bal := explainError(&provider.APIError{Provider: "deepseek", Status: 402, Body: "Insufficient Balance"})
+	if bal.Error() != i18n.M.ProviderErrInsufficientBalance {
+		t.Errorf("402 = %q, want the insufficient-balance message", bal.Error())
+	}
+
+	auth := explainError(&provider.AuthError{Provider: "deepseek", KeyEnv: "DEEPSEEK_API_KEY", Status: 401})
+	if !strings.Contains(auth.Error(), "DEEPSEEK_API_KEY") {
+		t.Errorf("401 should name the key env: %q", auth.Error())
+	}
+
+	for _, status := range []int{400, 422, 429, 500, 503} {
+		got := explainError(&provider.APIError{Provider: "p", Status: status})
+		if got.Error() == "" || got.Error() == (&provider.APIError{Provider: "p", Status: status}).Error() {
+			t.Errorf("status %d should map to a localized message, got %q", status, got.Error())
+		}
+	}
+
+	plain := errors.New("some other failure")
+	if explainError(plain) != plain {
+		t.Error("unknown errors should pass through unchanged")
+	}
+}

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -73,6 +73,12 @@ const (
 	// status without polling. Text carries "<server>: <surface> ready (<count>
 	// items)". Appended last to keep the Kind values before it wire-stable.
 	MCPSurfaceReady
+	// Retrying fires before each backoff sleep while the provider re-attempts the
+	// connection+header phase after a transient failure (RetryAttempt of RetryMax).
+	// A frontend shows a transient "retrying (n/m)" indicator that the next stream
+	// event — or TurnDone — clears. Appended last to keep the Kind values before
+	// it wire-stable.
+	Retrying
 )
 
 // Level classifies a Notice so sinks can style or filter it.
@@ -177,13 +183,15 @@ type Event struct {
 	// session (Usage events only), so a frontend can show the aggregate hit-rate
 	// — which doesn't crater on a short turn or after compaction — alongside
 	// Usage's single-turn numbers.
-	SessionHit  int        // Usage: cumulative cache-hit prompt tokens this session
-	SessionMiss int        // Usage: cumulative cache-miss prompt tokens this session
-	Level       Level      // Notice
-	Approval    Approval   // ApprovalRequest
-	Ask         Ask        // AskRequest
-	Err         error      // TurnDone: non-nil on failure
-	Compaction  Compaction // Compaction
+	SessionHit   int        // Usage: cumulative cache-hit prompt tokens this session
+	SessionMiss  int        // Usage: cumulative cache-miss prompt tokens this session
+	Level        Level      // Notice
+	Approval     Approval   // ApprovalRequest
+	Ask          Ask        // AskRequest
+	Err          error      // TurnDone: non-nil on failure
+	Compaction   Compaction // Compaction
+	RetryAttempt int        // Retrying: 1-based attempt about to be made
+	RetryMax     int        // Retrying: total attempts before giving up
 }
 
 // Sink consumes a turn's events. The agent calls Emit serially from its run

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -68,6 +68,7 @@ type Messages struct {
 	ChatThoughtForFmt      string // collapsed reasoning summary, "%d" = elapsed s
 	ChatStatusThinkingFmt  string // "%s thinking… (%ds · <cancel hint>)" — %s = spinner, %d = elapsed s
 	ChatToolWorkingFmt     string // "%s working · %ds" under a running tool — %s = spinner, %d = elapsed s
+	ChatStatusRetryingFmt  string // "%s retrying (%d/%d)…" — %s = spinner, %d/%d = attempt/max
 	ChatStatusIdle         string // shortcuts hint when idle
 	ChatStatusYoloIdle     string // shortcuts hint when idle in YOLO/bypass mode
 	ChatStatusCycleHint    string // mode-cycle shortcut hint shown when no modal prompt owns the status row
@@ -272,12 +273,43 @@ type Messages struct {
 	WriteConfigErr            string // "write config:" — prefix for write failure
 	WriteEnvErr               string // "write .env:" — prefix for env-write failure
 
+	// provider HTTP error explanations — actionable, reason + fix per status code
+	ProviderErrBadRequest          string // 400
+	ProviderErrAuth                string // 401
+	ProviderErrInsufficientBalance string // 402
+	ProviderErrUnprocessable       string // 422
+	ProviderErrRateLimited         string // 429
+	ProviderErrServer              string // 500
+	ProviderErrServerBusy          string // 503
+
 	// selection menus
 	SelectOneHint  string // "(↑/↓ · Enter · q to cancel)"
 	SelectManyHint string // "(↑/↓ · Space · Enter · q)"
 
 	// usage / help
 	UsageBody string // full multi-line help text
+}
+
+// ProviderStatusMessage returns an actionable explanation for a known provider
+// HTTP status, or "" when the status has no specific guidance.
+func (m Messages) ProviderStatusMessage(status int) string {
+	switch status {
+	case 400:
+		return m.ProviderErrBadRequest
+	case 401, 403:
+		return m.ProviderErrAuth
+	case 402:
+		return m.ProviderErrInsufficientBalance
+	case 422:
+		return m.ProviderErrUnprocessable
+	case 429:
+		return m.ProviderErrRateLimited
+	case 500:
+		return m.ProviderErrServer
+	case 503:
+		return m.ProviderErrServerBusy
+	}
+	return ""
 }
 
 // M is the active catalogue. DetectLanguage replaces it; English is the

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -42,6 +42,7 @@ var English = Messages{
 	ChatThoughtForFmt:      "thought for %ds",
 	ChatStatusThinkingFmt:  "%s thinking… (%ds · Esc cancels)",
 	ChatToolWorkingFmt:     "%s working · %ds",
+	ChatStatusRetryingFmt:  "%s retrying (%d/%d)… (Esc cancels)",
 	ChatStatusIdle:         "ready",
 	ChatStatusYoloIdle:     "approvals skipped",
 	ChatStatusCycleHint:    "shift+tab to cycle",
@@ -234,6 +235,14 @@ var English = Messages{
 	ReconfigureOnUnknownModel: "Configured model is no longer available — re-running setup.",
 	WriteConfigErr:            "write config:",
 	WriteEnvErr:               "write .env:",
+
+	ProviderErrBadRequest:          "Malformed request (HTTP 400): the request body was rejected. This is likely a bug — please report it if it persists.",
+	ProviderErrAuth:                "Authentication failed (HTTP 401): your API key is missing, wrong, or expired. Check the key in .env or run `reasonix setup`.",
+	ProviderErrInsufficientBalance: "Insufficient balance (HTTP 402): your account is out of credit. Top up your account, then retry.",
+	ProviderErrUnprocessable:       "Invalid parameters (HTTP 422): a request parameter was rejected. This is likely a bug — please report it if it persists.",
+	ProviderErrRateLimited:         "Rate limit reached (HTTP 429): too many requests (TPM/RPM). Retried with backoff — slow down or try again shortly.",
+	ProviderErrServer:              "Server error (HTTP 500): the provider hit an internal fault. Retried with backoff; if it keeps failing, try again later.",
+	ProviderErrServerBusy:          "Server busy (HTTP 503): the provider is overloaded. Retried with backoff; please try again shortly.",
 
 	SelectOneHint:  "(↑/↓ · Enter · q to cancel)",
 	SelectManyHint: "(↑/↓ · Space · Enter · q)",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -43,6 +43,7 @@ var Chinese = Messages{
 	ChatThoughtForFmt:      "思考了 %d 秒",
 	ChatStatusThinkingFmt:  "%s 思考中… (%d 秒 · Esc 取消)",
 	ChatToolWorkingFmt:     "%s 运行中 · %d 秒",
+	ChatStatusRetryingFmt:  "%s 正在重试 (%d/%d)… (Esc 取消)",
 	ChatStatusIdle:         "就绪",
 	ChatStatusYoloIdle:     "已跳过批准",
 	ChatStatusCycleHint:    "shift+tab 循环切换",
@@ -235,6 +236,14 @@ var Chinese = Messages{
 	ReconfigureOnUnknownModel: "配置的模型已不可用 —— 重新运行引导配置。",
 	WriteConfigErr:            "写入配置失败：",
 	WriteEnvErr:               "写入 .env 失败：",
+
+	ProviderErrBadRequest:          "请求格式错误 (HTTP 400)：请求体被拒绝，通常是程序缺陷。若持续出现请反馈。",
+	ProviderErrAuth:                "认证失败 (HTTP 401)：API key 缺失、错误或已过期。请检查 .env 中的密钥，或运行 `reasonix setup`。",
+	ProviderErrInsufficientBalance: "余额不足 (HTTP 402)：账户余额不足，请前往充值后重试。",
+	ProviderErrUnprocessable:       "参数错误 (HTTP 422)：某个请求参数被拒绝，通常是程序缺陷。若持续出现请反馈。",
+	ProviderErrRateLimited:         "请求速率达到上限 (HTTP 429)：请求过于频繁 (TPM/RPM)。已退避重试，请放慢速率或稍后再试。",
+	ProviderErrServer:              "服务器故障 (HTTP 500)：服务端内部错误。已退避重试；若持续失败请稍后再试。",
+	ProviderErrServerBusy:          "服务器繁忙 (HTTP 503)：服务端负载过高。已退避重试，请稍后再试。",
 
 	SelectOneHint:  "(↑/↓ · Enter · q 取消)",
 	SelectManyHint: "(↑/↓ · Space · Enter · q)",

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -21,13 +21,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"math/rand"
 	"net/http"
 	"strings"
-	"time"
 
 	"reasonix/internal/netclient"
 	"reasonix/internal/provider"
@@ -106,7 +102,18 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 		return nil, fmt.Errorf("%s: marshal request: %w", c.name, err)
 	}
 
-	resp, err := c.sendWithRetry(ctx, body)
+	newReq := func(ctx context.Context) (*http.Request, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Accept", "text/event-stream")
+		httpReq.Header.Set("x-api-key", c.apiKey)
+		httpReq.Header.Set("anthropic-version", anthropicVersion)
+		return httpReq, nil
+	}
+	resp, err := provider.SendWithRetry(ctx, c.http, c.name, c.keyEnv, newReq)
 	if err != nil {
 		return nil, err
 	}
@@ -114,76 +121,6 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 	out := make(chan provider.Chunk)
 	go c.readStream(resp, out)
 	return out, nil
-}
-
-// sendWithRetry POSTs the request and returns the streaming response, retrying the
-// connection+header phase on transient errors and retryable statuses (408, 429,
-// 5xx — which covers Anthropic's 529 overloaded) with exponential backoff + jitter.
-// Mid-stream failures are not retried (the model has already emitted tokens).
-func (c *client) sendWithRetry(ctx context.Context, body []byte) (*http.Response, error) {
-	const maxAttempts = 3
-	var lastErr error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		if attempt > 0 {
-			delay := time.Duration(1<<(attempt-1))*500*time.Millisecond + time.Duration(rand.Intn(250))*time.Millisecond
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(delay):
-			}
-		}
-
-		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("%s: build request: %w", c.name, err)
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("Accept", "text/event-stream")
-		httpReq.Header.Set("x-api-key", c.apiKey)
-		httpReq.Header.Set("anthropic-version", anthropicVersion)
-
-		resp, err := c.http.Do(httpReq)
-		if err != nil {
-			if !isTransientErr(err) {
-				return nil, fmt.Errorf("%s: request failed: %w", c.name, err)
-			}
-			lastErr = fmt.Errorf("%s: request failed: %w", c.name, err)
-			continue
-		}
-		if resp.StatusCode == http.StatusOK {
-			return resp, nil
-		}
-		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		// A rejected key is a configuration problem, not a transient one.
-		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-			return nil, &provider.AuthError{Provider: c.name, KeyEnv: c.keyEnv, Status: resp.StatusCode}
-		}
-		statusErr := fmt.Errorf("%s: status %d: %s", c.name, resp.StatusCode, strings.TrimSpace(string(msg)))
-		if !isRetryableStatus(resp.StatusCode) {
-			return nil, statusErr
-		}
-		lastErr = statusErr
-	}
-	return nil, lastErr
-}
-
-// isRetryableStatus matches 408, 429, and 5xx (incl. Anthropic's 529 overloaded).
-func isRetryableStatus(s int) bool {
-	return s == http.StatusRequestTimeout || s == http.StatusTooManyRequests || (s >= 500 && s <= 599)
-}
-
-// isTransientErr never retries ctx cancellation/deadline (caller intent); retries
-// everything else (DNS, connection reset, abrupt EOF).
-func isTransientErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-	return true
 }
 
 // buildRequest converts the transport-agnostic Request into the Messages API shape:

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -8,10 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"sort"
@@ -105,7 +102,17 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 		return nil, fmt.Errorf("%s: marshal request: %w", c.name, err)
 	}
 
-	resp, err := c.sendWithRetry(ctx, body)
+	newReq := func(ctx context.Context) (*http.Request, error) {
+		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+		httpReq.Header.Set("Accept", "text/event-stream")
+		return httpReq, nil
+	}
+	resp, err := provider.SendWithRetry(ctx, c.http, c.name, c.keyEnv, newReq)
 	if err != nil {
 		return nil, err
 	}
@@ -113,87 +120,6 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 	out := make(chan provider.Chunk)
 	go c.readStream(ctx, resp, out)
 	return out, nil
-}
-
-// sendWithRetry POSTs the request body and returns the streaming response,
-// retrying on transient network errors and retryable HTTP statuses (408, 429,
-// 5xx) with exponential backoff + jitter. Retries only cover the connection +
-// header phase; once we hand the response to readStream, mid-stream failures
-// surface as ChunkError without retry, since the model has already started
-// emitting tokens we'd otherwise duplicate.
-func (c *client) sendWithRetry(ctx context.Context, body []byte) (*http.Response, error) {
-	const maxAttempts = 3
-	var lastErr error
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		if attempt > 0 {
-			delay := time.Duration(1<<(attempt-1))*500*time.Millisecond + time.Duration(rand.Intn(250))*time.Millisecond
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(delay):
-			}
-		}
-
-		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))
-		if err != nil {
-			return nil, fmt.Errorf("%s: build request: %w", c.name, err)
-		}
-		httpReq.Header.Set("Content-Type", "application/json")
-		httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
-		httpReq.Header.Set("Accept", "text/event-stream")
-
-		resp, err := c.http.Do(httpReq)
-		if err != nil {
-			if !isTransientErr(err) {
-				return nil, fmt.Errorf("%s: request failed: %w", c.name, err)
-			}
-			lastErr = fmt.Errorf("%s: request failed: %w", c.name, err)
-			continue
-		}
-		if resp.StatusCode == http.StatusOK {
-			return resp, nil
-		}
-		msg, readErr := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		if readErr != nil {
-			msg = []byte(fmt.Sprintf("(could not read error body: %v)", readErr))
-		}
-		// Drain any remaining body so the HTTP connection can be reused by the
-		// transport pool, then close.
-		_, _ = io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-		// A rejected key is a configuration problem, not a transient one — give
-		// an actionable error instead of dumping the raw status body.
-		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-			return nil, &provider.AuthError{Provider: c.name, KeyEnv: c.keyEnv, Status: resp.StatusCode}
-		}
-		statusErr := fmt.Errorf("%s: status %d: %s", c.name, resp.StatusCode, strings.TrimSpace(string(msg)))
-		if !isRetryableStatus(resp.StatusCode) {
-			return nil, statusErr
-		}
-		lastErr = statusErr
-	}
-	return nil, lastErr
-}
-
-// isRetryableStatus returns true for HTTP status codes a transient backoff can
-// reasonably recover from: 408 (request timeout), 429 (rate limit), and 5xx.
-// 4xx other than 408/429 (auth, validation, not-found) are caller bugs and
-// won't fix themselves on retry.
-func isRetryableStatus(s int) bool {
-	return s == http.StatusRequestTimeout || s == http.StatusTooManyRequests || (s >= 500 && s <= 599)
-}
-
-// isTransientErr classifies HTTP client errors. ctx cancellation and deadline
-// expiry are caller intent — never retry those. Everything else (DNS failures,
-// connection resets, abrupt EOF, etc.) gets one more shot.
-func isTransientErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-	return true
 }
 
 func (c *client) buildRequest(req provider.Request) chatRequest {

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -13,36 +13,80 @@ import (
 	"reasonix/internal/provider"
 )
 
-// TestIsRetryableStatus covers the boundary: 408/429/5xx retry, other 4xx don't.
-func TestIsRetryableStatus(t *testing.T) {
-	retry := []int{408, 429, 500, 502, 503, 504, 599}
-	noRetry := []int{200, 400, 401, 403, 404, 422}
-	for _, s := range retry {
-		if !isRetryableStatus(s) {
-			t.Errorf("status %d should be retryable", s)
+// TestStreamRetriesThenSucceeds drives the real retry path end-to-end: the
+// server returns 503 twice, then a valid SSE stream. The provider must back off,
+// fire the retry-notify callback for each attempt, and ultimately stream the answer.
+func TestStreamRetriesThenSucceeds(t *testing.T) {
+	var reqs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		if reqs <= 2 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"overloaded"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"hi there\"}}]}\n\ndata: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	var attempts []int
+	ctx := provider.WithRetryNotify(context.Background(), func(i provider.RetryInfo) {
+		attempts = append(attempts, i.Attempt)
+		if i.Max != provider.MaxRetries {
+			t.Errorf("RetryInfo.Max = %d, want %d", i.Max, provider.MaxRetries)
+		}
+	})
+
+	ch, err := p.Stream(ctx, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream after retries: %v", err)
+	}
+	var got strings.Builder
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("unexpected stream error: %v", chunk.Err)
+		}
+		if chunk.Type == provider.ChunkText {
+			got.WriteString(chunk.Text)
 		}
 	}
-	for _, s := range noRetry {
-		if isRetryableStatus(s) {
-			t.Errorf("status %d should not be retryable", s)
-		}
+	if got.String() != "hi there" {
+		t.Errorf("streamed text = %q, want %q", got.String(), "hi there")
+	}
+	if reqs != 3 {
+		t.Errorf("server saw %d requests, want 3 (2 failures + 1 success)", reqs)
+	}
+	if len(attempts) != 2 || attempts[0] != 1 || attempts[1] != 2 {
+		t.Errorf("retry-notify attempts = %v, want [1 2]", attempts)
 	}
 }
 
-// TestIsTransientErr keeps user-intent errors (ctx cancel / deadline) out of
-// the retry path while letting network-level failures through.
-func TestIsTransientErr(t *testing.T) {
-	if isTransientErr(nil) {
-		t.Error("nil error should not be transient")
+// TestStreamInsufficientBalance verifies a 402 fails fast (no retry) as a typed
+// *provider.APIError carrying the status, so the display layer can explain it.
+func TestStreamInsufficientBalance(t *testing.T) {
+	var reqs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		w.WriteHeader(http.StatusPaymentRequired)
+		_, _ = w.Write([]byte(`{"error":"Insufficient Balance"}`))
+	}))
+	defer srv.Close()
+
+	p, _ := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	_, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	var apiErr *provider.APIError
+	if !errors.As(err, &apiErr) || apiErr.Status != 402 {
+		t.Fatalf("want *provider.APIError{Status:402}, got %T: %v", err, err)
 	}
-	if isTransientErr(context.Canceled) {
-		t.Error("ctx canceled should not be transient")
-	}
-	if isTransientErr(context.DeadlineExceeded) {
-		t.Error("ctx deadline should not be transient")
-	}
-	if !isTransientErr(errors.New("connection reset")) {
-		t.Error("generic network-ish error should be transient")
+	if reqs != 1 {
+		t.Errorf("402 should not retry, server saw %d requests", reqs)
 	}
 }
 

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -1,0 +1,163 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MaxRetries is the number of times SendWithRetry re-attempts the connection +
+// header phase after the initial try (so up to MaxRetries+1 total attempts).
+const MaxRetries = 10
+
+const maxBackoff = 15 * time.Second
+
+// RetryInfo describes a backoff about to happen: Attempt is the 1-based retry
+// number (of Max) and Delay is how long SendWithRetry will wait before it.
+type RetryInfo struct {
+	Attempt int
+	Max     int
+	Delay   time.Duration
+	Err     error
+}
+
+type RetryNotify func(RetryInfo)
+
+type retryNotifyKey struct{}
+
+// WithRetryNotify attaches a callback that SendWithRetry invokes before each
+// backoff sleep, so the agent can surface a transient "retrying (n/m)" status.
+func WithRetryNotify(ctx context.Context, fn RetryNotify) context.Context {
+	if fn == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, retryNotifyKey{}, fn)
+}
+
+func retryNotifyFromContext(ctx context.Context) RetryNotify {
+	fn, _ := ctx.Value(retryNotifyKey{}).(RetryNotify)
+	return fn
+}
+
+// APIError reports a non-OK HTTP status that isn't an auth failure. Status
+// carries the code so the display layer can map it to an actionable, localized
+// message; Body is a trimmed snippet of the response.
+type APIError struct {
+	Provider string
+	Status   int
+	Body     string
+}
+
+func (e *APIError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("%s: status %d", e.Provider, e.Status)
+	}
+	return fmt.Sprintf("%s: status %d: %s", e.Provider, e.Status, e.Body)
+}
+
+// RetryableStatus reports whether a backoff can plausibly recover from status s:
+// 408 (request timeout), 429 (rate limit) and 5xx (incl. Anthropic's 529). Other
+// 4xx (400/401/402/422, …) are caller/config problems retrying can't fix.
+func RetryableStatus(s int) bool {
+	return s == http.StatusRequestTimeout || s == http.StatusTooManyRequests || (s >= 500 && s <= 599)
+}
+
+func transientErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return true
+}
+
+func backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if retryAfter > maxBackoff {
+			return maxBackoff
+		}
+		return retryAfter
+	}
+	d := time.Duration(1<<(attempt-1)) * 500 * time.Millisecond
+	if d > maxBackoff {
+		d = maxBackoff
+	}
+	return d + time.Duration(rand.Intn(250))*time.Millisecond
+}
+
+func parseRetryAfter(resp *http.Response) time.Duration {
+	v := strings.TrimSpace(resp.Header.Get("Retry-After"))
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	return 0
+}
+
+// SendWithRetry POSTs a streaming request built by newReq and returns the OK
+// response. It retries the connection+header phase up to MaxRetries times on
+// transient network errors and retryable statuses with capped exponential
+// backoff + jitter, honoring Retry-After. 401/403 become *AuthError; other
+// non-OK statuses become *APIError. A RetryNotify in ctx fires before each
+// sleep. Retries cover only the header phase — once the body streams, mid-stream
+// failures are not retried (the model has already emitted tokens).
+func SendWithRetry(ctx context.Context, httpClient *http.Client, provName, keyEnv string, newReq func(context.Context) (*http.Request, error)) (*http.Response, error) {
+	notify := retryNotifyFromContext(ctx)
+	var lastErr error
+	var retryAfter time.Duration
+
+	for attempt := 0; attempt <= MaxRetries; attempt++ {
+		if attempt > 0 {
+			delay := backoffDelay(attempt, retryAfter)
+			if notify != nil {
+				notify(RetryInfo{Attempt: attempt, Max: MaxRetries, Delay: delay, Err: lastErr})
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		retryAfter = 0
+
+		req, err := newReq(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("%s: build request: %w", provName, err)
+		}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			if !transientErr(err) {
+				return nil, fmt.Errorf("%s: request failed: %w", provName, err)
+			}
+			lastErr = fmt.Errorf("%s: request failed: %w", provName, err)
+			continue
+		}
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		retryAfter = parseRetryAfter(resp)
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return nil, &AuthError{Provider: provName, KeyEnv: keyEnv, Status: resp.StatusCode}
+		}
+		apiErr := &APIError{Provider: provName, Status: resp.StatusCode, Body: strings.TrimSpace(string(msg))}
+		if !RetryableStatus(resp.StatusCode) {
+			return nil, apiErr
+		}
+		lastErr = apiErr
+	}
+	return nil, lastErr
+}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -1,0 +1,125 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func statusResp(status int, hdr map[string]string) *http.Response {
+	h := http.Header{}
+	for k, v := range hdr {
+		h.Set(k, v)
+	}
+	return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader("body")), Header: h}
+}
+
+func newDummyReq(ctx context.Context) (*http.Request, error) {
+	return http.NewRequestWithContext(ctx, http.MethodPost, "http://x/y", nil)
+}
+
+func TestRetryableStatus(t *testing.T) {
+	for _, s := range []int{408, 429, 500, 502, 503, 504, 529, 599} {
+		if !RetryableStatus(s) {
+			t.Errorf("status %d should be retryable", s)
+		}
+	}
+	for _, s := range []int{200, 400, 401, 402, 403, 404, 422} {
+		if RetryableStatus(s) {
+			t.Errorf("status %d should not be retryable", s)
+		}
+	}
+}
+
+func TestTransientErr(t *testing.T) {
+	if transientErr(nil) {
+		t.Error("nil should not be transient")
+	}
+	if transientErr(context.Canceled) || transientErr(context.DeadlineExceeded) {
+		t.Error("ctx cancel/deadline should not be transient")
+	}
+	if !transientErr(errors.New("connection reset")) {
+		t.Error("network-ish error should be transient")
+	}
+}
+
+func TestBackoffDelay(t *testing.T) {
+	if d := backoffDelay(1, 0); d < 500*time.Millisecond || d >= 750*time.Millisecond {
+		t.Errorf("attempt 1 base delay = %v, want [500ms,750ms)", d)
+	}
+	if d := backoffDelay(20, 0); d > maxBackoff+250*time.Millisecond {
+		t.Errorf("delay %v exceeds cap+jitter", d)
+	}
+	if d := backoffDelay(5, 3*time.Second); d != 3*time.Second {
+		t.Errorf("Retry-After should win: %v", d)
+	}
+	if d := backoffDelay(1, time.Hour); d != maxBackoff {
+		t.Errorf("Retry-After should be capped to %v, got %v", maxBackoff, d)
+	}
+}
+
+func TestSendWithRetryFailsFastOnClientErrors(t *testing.T) {
+	for _, status := range []int{400, 402, 422} {
+		calls := 0
+		cl := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+			calls++
+			return statusResp(status, nil), nil
+		})}
+		_, err := SendWithRetry(context.Background(), cl, "p", "KEY", newDummyReq)
+		if calls != 1 {
+			t.Errorf("status %d retried (%d calls), should fail fast", status, calls)
+		}
+		var apiErr *APIError
+		if !errors.As(err, &apiErr) || apiErr.Status != status {
+			t.Errorf("status %d: want *APIError with Status=%d, got %v", status, status, err)
+		}
+	}
+}
+
+func TestSendWithRetryAuthError(t *testing.T) {
+	calls := 0
+	cl := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return statusResp(401, nil), nil
+	})}
+	_, err := SendWithRetry(context.Background(), cl, "deepseek", "DEEPSEEK_API_KEY", newDummyReq)
+	if calls != 1 {
+		t.Errorf("401 retried (%d calls), should fail fast", calls)
+	}
+	var authErr *AuthError
+	if !errors.As(err, &authErr) || authErr.KeyEnv != "DEEPSEEK_API_KEY" {
+		t.Errorf("want *AuthError naming the key env, got %v", err)
+	}
+}
+
+func TestSendWithRetryRecoversAndNotifies(t *testing.T) {
+	calls := 0
+	cl := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls == 1 {
+			return statusResp(503, nil), nil
+		}
+		return statusResp(200, nil), nil
+	})}
+	var infos []RetryInfo
+	ctx := WithRetryNotify(context.Background(), func(i RetryInfo) { infos = append(infos, i) })
+
+	resp, err := SendWithRetry(ctx, cl, "p", "KEY", newDummyReq)
+	if err != nil {
+		t.Fatalf("should recover after one retry: %v", err)
+	}
+	if resp.StatusCode != 200 || calls != 2 {
+		t.Fatalf("status=%d calls=%d, want 200 after 2 calls", resp.StatusCode, calls)
+	}
+	if len(infos) != 1 || infos[0].Attempt != 1 || infos[0].Max != MaxRetries {
+		t.Fatalf("retry notify = %#v, want one Attempt 1/%d", infos, MaxRetries)
+	}
+}


### PR DESCRIPTION
Network failures used to give up after 3 silent retries, and non-OK HTTP statuses surfaced as a bare `status 4xx: <body>` (or nothing). This makes the retry policy robust and gives the user clear, actionable feedback.

## Retry (exponential backoff, up to 10)
- A shared `provider.SendWithRetry` replaces the duplicated per-provider loops (openai/deepseek + anthropic). Up to 10 retries, capped exponential backoff (≤ 15s) with jitter, honoring `Retry-After`.
- **Retryable:** 408 / 429 / 5xx (incl. Anthropic 529) + network errors. **Fail fast:** 400 / 401 / 402 / 422 — retrying can't fix them.

## Clear errors (no more silent / bare status)
- New `provider.APIError{Status}` (401/403 stay `AuthError`). The controller maps them to actionable, localized (en/zh) messages at the `TurnDone` boundary: 400 malformed, 401 auth, 402 insufficient balance → top up, 422 bad params, 429 rate limit, 500 server fault, 503 server busy.

## "retrying (n/m)" indicator
- New `event.Retrying{attempt,max}`; the agent injects a `WithRetryNotify` callback so providers stay UI-agnostic.
- **CLI:** transient line above the composer (reuses the thinking row), cleared by the next stream event.
- **Desktop:** `state.retry` → status bar, same self-clearing. Wired through `wire.go` → `useController` → `StatusBar`.

## Tests (end-to-end)
- `provider`: real httptest 503×2→200 SSE recovers + fires retry-notify; 402 fails fast as `*APIError`; backoff cap / Retry-After / classification boundaries.
- `agent`: real OpenAI-compatible provider against httptest (503×2→200) — asserts the agent emits `Retrying(1/10),(2/10)` then streams the answer.
- `control`: status→message mapping (402, 401+keyenv, passthrough). `cli`: indicator set/clear + en/zh wording. `desktop`: wire serialization.

Verified on the post-merge tree: `go build ./...`, full `go test ./internal/...`, desktop Go build+test, and `tsc --noEmit` all green.
