### PR TITLE
feat(agent): gate final answer readiness

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -26,6 +26,8 @@ import (
 // window before the next compaction runs.
 const maxToolOutputBytes = 32 * 1024
 
+const maxFinalReadinessBlocks = 3
+
 // Renderer redraws the assistant's final-answer text as styled output. It is
 // applied only after a turn's text stream completes, so the user sees raw
 // markdown stream live, then a single redraw replaces it with formatted
@@ -369,6 +371,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 
+	finalReadinessBlocks := 0
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
 		text, reasoning, signature, calls, usage, err := a.stream(ctx, step+1)
 		if err != nil {
@@ -395,6 +398,16 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		})
 
 		if len(calls) == 0 {
+			if reason := a.finalReadinessFailure(); reason != "" {
+				finalReadinessBlocks++
+				if finalReadinessBlocks >= maxFinalReadinessBlocks {
+					return fmt.Errorf("final-answer readiness failed %d times: %s", finalReadinessBlocks, reason)
+				}
+				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + reason})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: finalReadinessRetryMessage(reason)})
+				a.maybeCompact(ctx, usage)
+				continue
+			}
 			return nil // model gave a final answer
 		}
 
@@ -416,6 +429,54 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	// is already in the session, so the user can just send another message to pick
 	// up where it left off.
 	return fmt.Errorf("paused after %d tool-call rounds (agent.max_steps) — the work so far is saved; send another message to continue, or set max_steps higher or to 0 for no limit", a.maxSteps)
+}
+
+func (a *Agent) finalReadinessFailure() string {
+	if a.evidence == nil {
+		return ""
+	}
+	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
+	if !hasWriter {
+		return ""
+	}
+	hasProjectChecks := len(a.projectChecks) > 0
+	hasTodoReceipt := a.evidence.HasSuccessfulTodoWrite()
+	if !hasProjectChecks && !hasTodoReceipt {
+		return ""
+	}
+
+	var missing []string
+	for _, check := range a.projectChecks {
+		command := strings.TrimSpace(check.Command)
+		if command == "" {
+			continue
+		}
+		if !a.evidence.HasSuccessfulCommandAfter(command, writer) {
+			missing = append(missing, fmt.Sprintf("run %q from %s after the latest write", command, finalReadinessCheckSource(check)))
+		}
+	}
+	if hasTodoReceipt && !a.evidence.HasSuccessfulCompleteStepAfter(writer) {
+		missing = append(missing, "call complete_step after the latest write")
+	}
+	if len(missing) == 0 {
+		return ""
+	}
+	return strings.Join(missing, "; ")
+}
+
+func finalReadinessCheckSource(check instruction.VerifyCheck) string {
+	source := strings.TrimSpace(check.SourcePath)
+	if source == "" {
+		source = "project memory"
+	}
+	if check.Line > 0 {
+		return fmt.Sprintf("%s:%d", source, check.Line)
+	}
+	return source
+}
+
+func finalReadinessRetryMessage(reason string) string {
+	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
 }
 
 // stream runs one completion, emitting reasoning and text deltas as typed

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -58,6 +58,15 @@ func lastToolResult(s *Session, name string) string {
 	return result
 }
 
+func sessionHasUserMessageContaining(s *Session, needle string) bool {
+	for _, m := range s.Messages {
+		if m.Role == provider.RoleUser && strings.Contains(m.Content, needle) {
+			return true
+		}
+	}
+	return false
+}
+
 // TestEvidenceFlowEndToEnd drives a full Run(): turn 1 runs bash then signs the
 // step off citing that exact command; complete_step must see the host receipt
 // recorded earlier in the same batch and report it host-verified.
@@ -127,6 +136,180 @@ func TestEvidenceFlowEnforcesProjectChecksAfterWrite(t *testing.T) {
 	got := toolResult(a.session, "complete_step")
 	if !strings.Contains(got, "project checks 1") {
 		t.Fatalf("complete_step result = %q, want project check verified from same batch", got)
+	}
+}
+
+func TestFinalReadinessAllowsFinalAnswerWithoutWriter(t *testing.T) {
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{
+		ProjectChecks: []instruction.VerifyCheck{{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3}},
+	}, event.Discard)
+
+	if err := a.Run(context.Background(), "inspect only"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 1 {
+		t.Fatalf("provider calls = %d, want 1", prov.call)
+	}
+}
+
+func TestFinalReadinessAllowsWriterWithoutChecksOrTodos(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "simple edit"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want 2", prov.call)
+	}
+}
+
+func TestFinalReadinessBlocksUntilProjectCheckRunsAfterWriter(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "premature"}, {Type: provider.ChunkDone}},
+		{
+			toolCallChunk("c2", "bash", `{"command":"go test ./..."}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "verified done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{
+		ProjectChecks: []instruction.VerifyCheck{{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3}},
+	}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit and finish"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want final answer to be retried after readiness block", prov.call)
+	}
+	if !sessionHasUserMessageContaining(a.session, "final-answer readiness") {
+		t.Fatal("missing synthetic readiness retry message")
+	}
+	if got := lastToolResult(a.session, "bash"); !strings.Contains(got, "bash done") {
+		t.Fatalf("bash tool result = %q, want command rerun after block", got)
+	}
+}
+
+func TestFinalReadinessRejectsProjectCheckBeforeWriter(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "bash", `{"command":"go test ./..."}`),
+			toolCallChunk("c2", "write_file", `{"path":"changed.go","content":"package main"}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "premature"}, {Type: provider.ChunkDone}},
+		{
+			toolCallChunk("c3", "bash", `{"command":"go test ./..."}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "verified done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{
+		ProjectChecks: []instruction.VerifyCheck{{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3}},
+	}, event.Discard)
+
+	if err := a.Run(context.Background(), "verify before edit, then finish"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want pre-write check rejected and retried", prov.call)
+	}
+}
+
+func TestFinalReadinessRequiresCompleteStepAfterWriterWhenTodoSeen(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	completeStep, ok := tool.LookupBuiltin("complete_step")
+	if !ok {
+		t.Fatal("complete_step builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(todoWrite)
+	reg.Add(completeStep)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "premature"}, {Type: provider.ChunkDone}},
+		{
+			toolCallChunk("c3", "complete_step", `{
+				"step":"Edit code",
+				"result":"changed.go updated",
+				"evidence":[{"kind":"diff","summary":"updated code","paths":["changed.go"]}]
+			}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "signed off done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit with todo and finish"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want final answer to wait for complete_step", prov.call)
+	}
+	if got := lastToolResult(a.session, "complete_step"); !strings.Contains(got, "signed off") {
+		t.Fatalf("complete_step result = %q, want successful sign-off", got)
+	}
+}
+
+func TestFinalReadinessStopsAfterRepeatedBlocks(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "premature 1"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "premature 2"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "premature 3"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	err := a.Run(context.Background(), "edit with todo and never sign off")
+	if err == nil {
+		t.Fatal("expected repeated readiness blocks to stop the run")
+	}
+	if !strings.Contains(err.Error(), "final-answer readiness") {
+		t.Fatalf("error = %v, want final-answer readiness", err)
+	}
+	if prov.call != 4 {
+		t.Fatalf("provider calls = %d, want three blocked final answers after writer turn", prov.call)
 	}
 }
 

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -123,6 +123,40 @@ func (l *Ledger) HasSuccessfulCommandAfter(command string, after int) bool {
 	return false
 }
 
+func (l *Ledger) HasSuccessfulCompleteStepAfter(after int) bool {
+	if l == nil {
+		return false
+	}
+	start := after + 1
+	if start < 0 {
+		start = 0
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := start; i < len(l.receipts); i++ {
+		r := l.receipts[i]
+		if r.Success && r.ToolName == "complete_step" {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *Ledger) HasSuccessfulTodoWrite() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.receipts {
+		if r.Success && r.ToolName == "todo_write" {
+			return true
+		}
+	}
+	return false
+}
+
 func (l *Ledger) HasSuccessfulWrite(paths []string) bool {
 	return l.hasSuccessfulPaths(paths, func(r Receipt) bool { return r.Write })
 }
@@ -149,6 +183,22 @@ func (l *Ledger) LatestSuccessfulWriteIndex(paths []string) (int, bool) {
 				latest = i
 				break
 			}
+		}
+	}
+	return latest, latest >= 0
+}
+
+func (l *Ledger) LatestSuccessfulWriterIndex() (int, bool) {
+	if l == nil {
+		return 0, false
+	}
+	latest := -1
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i, r := range l.receipts {
+		if r.Success && r.Write {
+			latest = i
 		}
 	}
 	return latest, latest >= 0

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -46,6 +46,40 @@ func TestLedgerMatchesFileReadAndWriteReceipts(t *testing.T) {
 	}
 }
 
+func TestLedgerReportsFinalReadinessReceiptsAfterWriter(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Record(Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})
+	ledger.Record(Receipt{ToolName: "write_file", Success: true, Paths: []string{"changed.go"}, Write: true})
+	ledger.Record(Receipt{ToolName: "bash", Success: false, Command: "git diff --check"})
+	ledger.Record(Receipt{ToolName: "todo_write", Success: true, Todos: []TodoItem{{Content: "Edit code", Status: "in_progress"}}})
+
+	writer, ok := ledger.LatestSuccessfulWriterIndex()
+	if !ok {
+		t.Fatal("expected latest successful writer")
+	}
+	if ledger.HasSuccessfulCommandAfter("go test ./...", writer) {
+		t.Fatal("command before latest writer must not satisfy final readiness")
+	}
+	if ledger.HasSuccessfulCommandAfter("git diff --check", writer) {
+		t.Fatal("failed command must not satisfy final readiness")
+	}
+	if ledger.HasSuccessfulCompleteStepAfter(writer) {
+		t.Fatal("missing complete_step must not satisfy final readiness")
+	}
+	if !ledger.HasSuccessfulTodoWrite() {
+		t.Fatal("successful todo_write receipt should be reported")
+	}
+
+	ledger.Record(Receipt{ToolName: "bash", Success: true, Command: "git diff --check"})
+	ledger.Record(Receipt{ToolName: "complete_step", Success: true, Step: "Edit code"})
+	if !ledger.HasSuccessfulCommandAfter("git diff --check", writer) {
+		t.Fatal("command after latest writer should satisfy final readiness")
+	}
+	if !ledger.HasSuccessfulCompleteStepAfter(writer) {
+		t.Fatal("complete_step after latest writer should satisfy final readiness")
+	}
+}
+
 func TestLedgerResetClearsTurnReceipts(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(Receipt{ToolName: "bash", Success: true, Command: "go test ./..."})


### PR DESCRIPTION
## Summary

Related to #2764.

Background: #2753.

- Adds runtime-only final-answer readiness checks before accepting a no-tool-call final answer.
- Uses conservative triggering: only successful writer turns with project checks or successful `todo_write` receipts are gated.
- Re-prompts the agent to provide missing post-write receipts instead of ending the turn prematurely.

## Scope

- No UI changes; screenshots not applicable.
- No performance claims; cache hit rate/token/runtime metrics are not claimed.
- No prompt or tool schema changes.
- No MCP/worktree/subagent/cache/auto-memory/desktop changes.
- RFC labels requested: `rfc`, `v2`, `enhancement`; applying labels requires maintainer permissions from this account.

## Test Plan

- `D:\Go\go\bin\go.exe test ./internal/evidence ./internal/agent ./internal/tool/builtin` - PASS
- `D:\Go\go\bin\go.exe test ./internal/...` - PASS
- `git diff --check` - PASS

## E2E

- Not triggered from this account; maintainer trigger requested: `/e2e diff x3`.
