### PR TITLE
fix(desktop): remove redundant tooltips

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -679,14 +679,17 @@ export default function App() {
             </button>
           </div>
 
-          <button
-            className="sidebar__new"
-            onClick={() => void startNewSession()}
-            disabled={state.running}
-          >
-            <SquarePen size={15} />
-            <span>{t("topbar.newSession")}</span>
-          </button>
+          <Tooltip label={state.running ? t("common.busyHint") : t("topbar.newSession")} fill disabled={!sidebarCollapsed && !state.running}>
+            <button
+              className="sidebar__new"
+              onClick={() => void startNewSession()}
+              disabled={state.running}
+              aria-label={state.running ? t("common.busyHint") : t("topbar.newSession")}
+            >
+              <SquarePen size={15} />
+              <span>{t("topbar.newSession")}</span>
+            </button>
+          </Tooltip>
 
           <section className="sidebar__section">
             <div className="sidebar__section-head">

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -669,40 +669,34 @@ export default function App() {
           <div className="sidebar__brand">
             <img src={logo} alt="" className="sidebar__logo" />
             <span>Reasonix</span>
-            <Tooltip label={sidebarToggleTitle}>
-              <button
-                className={`sidebar__toggle${sidebarExpandBlocked ? " sidebar__toggle--blocked" : ""}`}
-                onClick={sidebarExpandBlocked ? undefined : toggleSidebar}
-                aria-label={sidebarToggleTitle}
-                aria-disabled={sidebarExpandBlocked}
-              >
-                {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
-              </button>
-            </Tooltip>
+            <button
+              className={`sidebar__toggle${sidebarExpandBlocked ? " sidebar__toggle--blocked" : ""}`}
+              onClick={sidebarExpandBlocked ? undefined : toggleSidebar}
+              aria-label={sidebarToggleTitle}
+              aria-disabled={sidebarExpandBlocked}
+            >
+              {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
+            </button>
           </div>
 
-          <Tooltip label={state.running ? t("common.busyHint") : t("topbar.newSession")} fill>
-            <button
-              className="sidebar__new"
-              onClick={() => void startNewSession()}
-              disabled={state.running}
-            >
-              <SquarePen size={15} />
-              <span>{t("topbar.newSession")}</span>
-            </button>
-          </Tooltip>
+          <button
+            className="sidebar__new"
+            onClick={() => void startNewSession()}
+            disabled={state.running}
+          >
+            <SquarePen size={15} />
+            <span>{t("topbar.newSession")}</span>
+          </button>
 
           <section className="sidebar__section">
             <div className="sidebar__section-head">
               <div className="sidebar__section-title">{t("sidebar.conversations")}</div>
-              <Tooltip label={t("topbar.history")}>
-                <button
-                  className="sidebar__view-all"
-                  onClick={() => void openHistory()}
-                >
-                  {t("sidebar.viewAll")}
-                </button>
-              </Tooltip>
+              <button
+                className="sidebar__view-all"
+                onClick={() => void openHistory()}
+              >
+                {t("sidebar.viewAll")}
+              </button>
             </div>
             <div className="sidebar__sessions">
               {sidebarSessions.length === 0 ? (
@@ -736,7 +730,7 @@ export default function App() {
                         >
                           <MessageSquare size={14} />
                           <span className="sidebar-session__body">
-                            <Tooltip className="sidebar-session__title" label={`${title}\n${session.path}`}>{title}</Tooltip>
+                            <span className="sidebar-session__title">{title}</span>
                             <span className="sidebar-session__meta">
                               {session.current ? t("history.current") : sessionTime(sessionActivityTime(session))}
                             </span>
@@ -799,7 +793,7 @@ export default function App() {
           </section>
 
           <nav className="sidebar__nav">
-            <Tooltip label={t("topbar.history")} fill>
+            <Tooltip label={t("topbar.history")} fill disabled={!sidebarCollapsed}>
               <button
                 className="sidebar__navitem sidebar__navitem--sessions"
                 onClick={() => void openHistory()}
@@ -808,19 +802,19 @@ export default function App() {
                 <span>{t("topbar.history")}</span>
               </button>
             </Tooltip>
-            <Tooltip label={t("topbar.memory")} fill>
+            <Tooltip label={t("topbar.memory")} fill disabled={!sidebarCollapsed}>
               <button className="sidebar__navitem" onClick={() => void openMemory()}>
                 <Brain size={15} />
                 <span>{t("topbar.memory")}</span>
               </button>
             </Tooltip>
-            <Tooltip label={t("caps.title")} fill>
+            <Tooltip label={t("caps.title")} fill disabled={!sidebarCollapsed}>
               <button className="sidebar__navitem" onClick={() => setCapsOpen(true)}>
                 <Blocks size={15} />
                 <span>{t("caps.title")}</span>
               </button>
             </Tooltip>
-            <Tooltip label={state.running ? t("common.busyHint") : t("topbar.settings")} fill>
+            <Tooltip label={state.running ? t("common.busyHint") : t("topbar.settings")} fill disabled={!sidebarCollapsed && !state.running}>
               <button
                 className="sidebar__navitem"
                 onClick={() => setSettingsOpen(true)}
@@ -854,14 +848,13 @@ export default function App() {
               <span className="topbar__model">{state.meta?.label ?? "…"}</span>
             </div>
             <div className="topbar__spacer" />
-            <Tooltip label={workspacePanelOpen ? t("workspace.close") : t("workspace.open")}>
-              <button
-                className="chip chip--icon topbar__workspace-toggle"
-                onClick={toggleWorkspacePanel}
-              >
-                {workspacePanelOpen ? <PanelRightClose size={13} /> : <PanelRightOpen size={13} />}
-              </button>
-            </Tooltip>
+            <button
+              className="chip chip--icon topbar__workspace-toggle"
+              onClick={toggleWorkspacePanel}
+              aria-label={workspacePanelOpen ? t("workspace.close") : t("workspace.open")}
+            >
+              {workspacePanelOpen ? <PanelRightClose size={13} /> : <PanelRightOpen size={13} />}
+            </button>
             <div className="topbar__actions">
               <Tooltip label={t("topbar.history")}>
                 <button

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -296,9 +296,7 @@ function SkillSources({
                   <span className={`cap-dot cap-dot--${skillRootDot(root)}`} />
                   <div className="cap-source__text">
                     <div className="cap-source__label">{skillRootLabel(root, t)}</div>
-                    <Tooltip label={root.dir} fill className="cap-source__path">
-                      {root.dir}
-                    </Tooltip>
+                    <div className="cap-source__path">{root.dir}</div>
                     <div className="cap-source__meta">
                       <span>{skillRootStatus(root, t)}</span>
                       <span>{t("caps.skillRootCount", { skills: root.skills })}</span>
@@ -627,27 +625,25 @@ function SkillRow({
   const summary = summarizeSkillDescription(skill.description);
   const canExpand = summary !== skill.description;
   return (
-    <Tooltip label={skill.description} fill>
-      <button
-        className={`cap-skill-card${expanded ? " cap-skill-card--expanded" : ""}${canExpand ? " cap-skill-card--expandable" : ""}`}
-        type="button"
-        onClick={onToggle}
-        aria-expanded={expanded}
-      >
-        <div className="cap-skill-card__head">
-          <span className="cap-skill-card__icon">/</span>
-          <span className="cap-skill-card__main">
-            <span className="cap-skill-card__command">{skill.name}</span>
-            <span className="cap-skill-card__badges">
-              <span className={`cap-skill-badge cap-skill-badge--${skill.scope}`}>{skillScopeLabel(skill.scope, t)}</span>
-              {skill.runAs === "subagent" && <span className="cap-skill-badge cap-skill-badge--run">{t("caps.subagent")}</span>}
-            </span>
+    <button
+      className={`cap-skill-card${expanded ? " cap-skill-card--expanded" : ""}${canExpand ? " cap-skill-card--expandable" : ""}`}
+      type="button"
+      onClick={onToggle}
+      aria-expanded={expanded}
+    >
+      <div className="cap-skill-card__head">
+        <span className="cap-skill-card__icon">/</span>
+        <span className="cap-skill-card__main">
+          <span className="cap-skill-card__command">{skill.name}</span>
+          <span className="cap-skill-card__badges">
+            <span className={`cap-skill-badge cap-skill-badge--${skill.scope}`}>{skillScopeLabel(skill.scope, t)}</span>
+            {skill.runAs === "subagent" && <span className="cap-skill-badge cap-skill-badge--run">{t("caps.subagent")}</span>}
           </span>
-        </div>
-        <div className="cap-skill-card__desc">{expanded ? skill.description : summary}</div>
-        {canExpand && <div className="cap-skill-card__more">{expanded ? t("common.collapse") : t("common.expand")}</div>}
-      </button>
-    </Tooltip>
+        </span>
+      </div>
+      <div className="cap-skill-card__desc">{expanded ? skill.description : summary}</div>
+      {canExpand && <div className="cap-skill-card__more">{expanded ? t("common.collapse") : t("common.expand")}</div>}
+    </button>
   );
 }
 

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -775,11 +775,9 @@ export function Composer({
                       <Eye size={14} />
                     </button>
                   </Tooltip>
-                  <Tooltip label={t("composer.pastedExpand")}>
-                    <button type="button" onClick={() => expandPastedBlock(block)}>
-                      {t("composer.pastedExpand")}
-                    </button>
-                  </Tooltip>
+                  <button type="button" onClick={() => expandPastedBlock(block)}>
+                    {t("composer.pastedExpand")}
+                  </button>
                   <Tooltip label={t("composer.pastedRemove")}>
                     <button type="button" onClick={() => removePastedBlock(block)}>
                       <Trash2 size={14} />
@@ -867,16 +865,14 @@ export function Composer({
               </Tooltip>
             </div>
           )}
-          <Tooltip label={t("composer.modeTitle")}>
-            <button
-              className={`composer__mode composer__mode--${mode}`}
-              onClick={onCycleMode}
-            >
-              <span className="composer__mode-dot" />
-              {mode === "yolo" ? t("composer.modeYolo") : mode === "plan" ? t("composer.modePlan") : t("composer.modeNormal")}
-              <span className="composer__mode-hint">{t("composer.modeHint")}</span>
-            </button>
-          </Tooltip>
+          <button
+            className={`composer__mode composer__mode--${mode}`}
+            onClick={onCycleMode}
+          >
+            <span className="composer__mode-dot" />
+            {mode === "yolo" ? t("composer.modeYolo") : mode === "plan" ? t("composer.modePlan") : t("composer.modeNormal")}
+            <span className="composer__mode-hint">{t("composer.modeHint")}</span>
+          </button>
         </div>
       </div>
     </div>

--- a/desktop/frontend/src/components/EffortSwitcher.tsx
+++ b/desktop/frontend/src/components/EffortSwitcher.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { useT } from "../lib/i18n";
 import type { EffortInfo } from "../lib/types";
-import { Tooltip } from "./Tooltip";
 
 export function EffortSwitcher({
   effort,
@@ -18,7 +17,6 @@ export function EffortSwitcher({
   if (!effort?.supported || effort.levels.length === 0) return null;
 
   const current = effort.current || "auto";
-  const title = current === "auto" ? t("status.effortAutoTitle", { def: effort.default || "auto" }) : t("status.effortTitle");
   const pick = (level: string) => {
     setOpen(false);
     if (level !== current) onPick(level);
@@ -26,16 +24,14 @@ export function EffortSwitcher({
 
   return (
     <div className="modelsw effortsw">
-      <Tooltip label={title}>
-        <button
-          className={`modelsw__trigger effortsw__trigger ${current !== "auto" ? "effortsw__trigger--explicit" : ""}`}
-          disabled={disabled}
-          onClick={() => setOpen((v) => !v)}
-        >
-          <span className="modelsw__label">{t("status.effort", { level: current })}</span>
-          <ChevronsUpDown size={11} />
-        </button>
-      </Tooltip>
+      <button
+        className={`modelsw__trigger effortsw__trigger ${current !== "auto" ? "effortsw__trigger--explicit" : ""}`}
+        disabled={disabled}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="modelsw__label">{t("status.effort", { level: current })}</span>
+        <ChevronsUpDown size={11} />
+      </button>
       {open && !disabled && (
         <>
           <div className="modelsw__backdrop" onClick={() => setOpen(false)} />

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -159,29 +159,27 @@ export function HistoryPanel({
                           placeholder={tr("history.namePlaceholder")}
                         />
                       ) : (
-                        <Tooltip label={s.path} fill>
-                          <button
-                            className="hist-item__main"
-                            onClick={() => {
-                              if (running) void loadPreview(s);
-                              else onResume(s.path);
-                            }}
-                          >
-                            <div className="hist-item__preview">{sessionDisplayTitle(s, tr("history.emptySession"))}</div>
-                            <div className="hist-item__meta">
-                              {s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
-                              <span>{tr(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns })}</span>
-                              <span>·</span>
-                              <span>{timeLabel(sessionActivityTime(s))}</span>
-                              {running && (
-                                <>
-                                  <span>·</span>
-                                  <span>{tr("history.preview")}</span>
-                                </>
-                              )}
-                            </div>
-                          </button>
-                        </Tooltip>
+                        <button
+                          className="hist-item__main"
+                          onClick={() => {
+                            if (running) void loadPreview(s);
+                            else onResume(s.path);
+                          }}
+                        >
+                          <div className="hist-item__preview">{sessionDisplayTitle(s, tr("history.emptySession"))}</div>
+                          <div className="hist-item__meta">
+                            {s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
+                            <span>{tr(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns })}</span>
+                            <span>·</span>
+                            <span>{timeLabel(sessionActivityTime(s))}</span>
+                            {running && (
+                              <>
+                                <span>·</span>
+                                <span>{tr("history.preview")}</span>
+                              </>
+                            )}
+                          </div>
+                        </button>
                       )}
 
                       {editing !== s.path && (

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -359,9 +359,7 @@ export function MemoryPanel({
                 </div>
               )}
               {view.storeDir && (
-                <Tooltip label={view.storeDir} fill block className="mem-hint">
-                  {t("memory.storedUnder", { dir: view.storeDir })}
-                </Tooltip>
+                <div className="mem-hint">{t("memory.storedUnder", { dir: view.storeDir })}</div>
               )}
             </section>
 
@@ -416,9 +414,7 @@ export function MemoryPanel({
                   <div className="mem-doc" key={d.path}>
                     <div className="mem-doc__head">
                       <span className={`badge badge--${d.scope}`}>{d.scope}</span>
-                      <Tooltip label={d.path}>
-                        <span className="mem-doc__path">{d.path}</span>
-                      </Tooltip>
+                      <span className="mem-doc__path">{d.path}</span>
                       {!editing && (
                         <button
                           className="btn btn--small"

--- a/desktop/frontend/src/components/ModelSwitcher.tsx
+++ b/desktop/frontend/src/components/ModelSwitcher.tsx
@@ -3,7 +3,6 @@ import { Check, ChevronsUpDown } from "lucide-react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import type { ModelInfo } from "../lib/types";
-import { Tooltip } from "./Tooltip";
 
 // ModelSwitcher is the bottom-of-window model picker: the status line's model
 // label becomes a button that opens a popover (upward) listing configured
@@ -26,12 +25,10 @@ export function ModelSwitcher({ label, onPick }: { label: string; onPick: (name:
 
   return (
     <div className="modelsw">
-      <Tooltip label={t("status.switchModel")}>
-        <button className="modelsw__trigger" onClick={() => setOpen((v) => !v)}>
-          <span className="modelsw__label">{label}</span>
-          <ChevronsUpDown size={11} />
-        </button>
-      </Tooltip>
+      <button className="modelsw__trigger" onClick={() => setOpen((v) => !v)}>
+        <span className="modelsw__label">{label}</span>
+        <ChevronsUpDown size={11} />
+      </button>
       {open && (
         <>
           <div className="modelsw__backdrop" onClick={() => setOpen(false)} />

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -171,12 +171,10 @@ export function StatusBar({
       {balance?.available && balance.display && (
         <>
           <span className="statusbar__sep">·</span>
-          <Tooltip label={t("status.balanceTitle")}>
-            <span className="statusbar__balance">
-              <Wallet size={11} />
-              {balance.display}
-            </span>
-          </Tooltip>
+          <span className="statusbar__balance">
+            <Wallet size={11} />
+            {balance.display}
+          </span>
         </>
       )}
       <span className="statusbar__spacer" />

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -515,31 +515,30 @@ export function WorkspacePanel({
     return changedRows.map((row) => {
       const deleted = isDeletedChange(row);
       return (
-        <Tooltip key={`${row.path}-${row.sources.join("-")}`} label={changeTitle(row)} fill>
-          <button
-            className={`workspace-change${selectedPath === row.path ? " workspace-change--active" : ""}${deleted ? " workspace-change--disabled" : ""}`}
-            draggable
-            onDragStart={(event) => startTreeDrag(event, row.path, false)}
-            onContextMenu={(event) => openTreeMenu(event, row.path, false)}
-            onClick={() => {
-              if (!deleted) selectFile(row.path);
-            }}
-            type="button"
-          >
-            <FileText size={14} className="workspace-tree__icon" />
-            <span className="workspace-change__body">
-              <span className="workspace-change__name">{basename(row.path)}</span>
-              <span className="workspace-change__path">{row.path}</span>
-              <span className="workspace-change__detail">{changeDetail(row)}</span>
-            </span>
-            <span className="workspace-change__meta">
-              {row.gitStatus && <span className="workspace-change__badge workspace-change__badge--git">{row.gitStatus}</span>}
-              {deleted && <span className="workspace-change__badge">{t("workspace.deleted")}</span>}
-              {row.sources.includes("session") && <span className="workspace-change__badge">{t("workspace.sourceSession")}</span>}
-              {row.sources.includes("git") && <span className="workspace-change__badge">{t("workspace.sourceGit")}</span>}
-            </span>
-          </button>
-        </Tooltip>
+        <button
+          key={`${row.path}-${row.sources.join("-")}`}
+          className={`workspace-change${selectedPath === row.path ? " workspace-change--active" : ""}${deleted ? " workspace-change--disabled" : ""}`}
+          draggable
+          onDragStart={(event) => startTreeDrag(event, row.path, false)}
+          onContextMenu={(event) => openTreeMenu(event, row.path, false)}
+          onClick={() => {
+            if (!deleted) selectFile(row.path);
+          }}
+          type="button"
+        >
+          <FileText size={14} className="workspace-tree__icon" />
+          <span className="workspace-change__body">
+            <span className="workspace-change__name">{basename(row.path)}</span>
+            <span className="workspace-change__path">{row.path}</span>
+            <span className="workspace-change__detail">{changeDetail(row)}</span>
+          </span>
+          <span className="workspace-change__meta">
+            {row.gitStatus && <span className="workspace-change__badge workspace-change__badge--git">{row.gitStatus}</span>}
+            {deleted && <span className="workspace-change__badge">{t("workspace.deleted")}</span>}
+            {row.sources.includes("session") && <span className="workspace-change__badge">{t("workspace.sourceSession")}</span>}
+            {row.sources.includes("git") && <span className="workspace-change__badge">{t("workspace.sourceGit")}</span>}
+          </span>
+        </button>
       );
     });
   };
@@ -551,32 +550,31 @@ export function WorkspacePanel({
       const isOpen = openDirs.has(path);
       const active = selectedPath === path;
       const row = (
-        <Tooltip key={path} label={path} fill>
-          <button
-            className={`workspace-tree__row${active ? " workspace-tree__row--active" : ""}`}
-            draggable
-            onDragStart={(event) => startTreeDrag(event, path, entry.isDir)}
-            onClick={() => (entry.isDir ? toggleDir(path) : selectFile(path))}
-            onContextMenu={(event) => openTreeMenu(event, path, entry.isDir)}
-            style={{ paddingLeft: 8 + depth * 14 }}
-          >
-            {entry.isDir ? (
-              isOpen ? (
-                <ChevronDown size={13} className="workspace-tree__chev" />
-              ) : (
-                <ChevronRight size={13} className="workspace-tree__chev" />
-              )
+        <button
+          key={path}
+          className={`workspace-tree__row${active ? " workspace-tree__row--active" : ""}`}
+          draggable
+          onDragStart={(event) => startTreeDrag(event, path, entry.isDir)}
+          onClick={() => (entry.isDir ? toggleDir(path) : selectFile(path))}
+          onContextMenu={(event) => openTreeMenu(event, path, entry.isDir)}
+          style={{ paddingLeft: 8 + depth * 14 }}
+        >
+          {entry.isDir ? (
+            isOpen ? (
+              <ChevronDown size={13} className="workspace-tree__chev" />
             ) : (
-              <span className="workspace-tree__chev" />
-            )}
-            {entry.isDir ? (
-              <Folder size={14} className="workspace-tree__icon workspace-tree__icon--dir" />
-            ) : (
-              <FileText size={14} className="workspace-tree__icon" />
-            )}
-            <span className="workspace-tree__name">{entry.name}</span>
-          </button>
-        </Tooltip>
+              <ChevronRight size={13} className="workspace-tree__chev" />
+            )
+          ) : (
+            <span className="workspace-tree__chev" />
+          )}
+          {entry.isDir ? (
+            <Folder size={14} className="workspace-tree__icon workspace-tree__icon--dir" />
+          ) : (
+            <FileText size={14} className="workspace-tree__icon" />
+          )}
+          <span className="workspace-tree__name">{entry.name}</span>
+        </button>
       );
       if (!entry.isDir || !isOpen) return [row];
       return [row, ...renderRows(path, depth + 1)];
@@ -791,28 +789,26 @@ export function WorkspacePanel({
             ? renderChangedRows()
             : flattened
             ? flattened.map(({ path, entry }) => {
-                const cleanPath = path.replace(/\/$/, "");
                 const dir = parentPath(path);
                 return (
-                  <Tooltip key={path} label={cleanPath} fill>
-                    <button
-                      className={`workspace-tree__row workspace-tree__row--search${selectedPath === path ? " workspace-tree__row--active" : ""}`}
-                      draggable
-                      onDragStart={(event) => startTreeDrag(event, path, entry.isDir)}
-                      onClick={() => (entry.isDir ? toggleDir(path) : selectFile(path))}
-                      onContextMenu={(event) => openTreeMenu(event, path, entry.isDir)}
-                    >
-                      {entry.isDir ? (
-                        <Folder size={14} className="workspace-tree__icon workspace-tree__icon--dir" />
-                      ) : (
-                        <FileText size={14} className="workspace-tree__icon" />
-                      )}
-                      <span className="workspace-tree__result">
-                        <span className="workspace-tree__result-name">{basename(path)}</span>
-                        {dir && <span className="workspace-tree__result-dir">{dir}</span>}
-                      </span>
-                    </button>
-                  </Tooltip>
+                  <button
+                    key={path}
+                    className={`workspace-tree__row workspace-tree__row--search${selectedPath === path ? " workspace-tree__row--active" : ""}`}
+                    draggable
+                    onDragStart={(event) => startTreeDrag(event, path, entry.isDir)}
+                    onClick={() => (entry.isDir ? toggleDir(path) : selectFile(path))}
+                    onContextMenu={(event) => openTreeMenu(event, path, entry.isDir)}
+                  >
+                    {entry.isDir ? (
+                      <Folder size={14} className="workspace-tree__icon workspace-tree__icon--dir" />
+                    ) : (
+                      <FileText size={14} className="workspace-tree__icon" />
+                    )}
+                    <span className="workspace-tree__result">
+                      <span className="workspace-tree__result-name">{basename(path)}</span>
+                      {dir && <span className="workspace-tree__result-dir">{dir}</span>}
+                    </span>
+                  </button>
                 );
               })
             : renderRows("", 0)}
@@ -847,12 +843,4 @@ export function WorkspacePanel({
       )}
     </aside>
   );
-}
-
-function changeTitle(row: WorkspaceChangeView): string {
-  const parts = [row.path];
-  if (row.oldPath) parts.push(`from ${row.oldPath}`);
-  if (row.gitStatus) parts.push(`git ${row.gitStatus}`);
-  if (row.turns && row.turns.length > 0) parts.push(`turns ${row.turns.join(", ")}`);
-  return parts.join(" · ");
 }


### PR DESCRIPTION
## Summary
- Remove duplicate tooltips from controls that already show clear labels, values, or inline expandable content
- Keep necessary tooltips for icon-only actions, disabled/error context, and compact items that need full-path context
- Avoid exposing internal session paths and large hover overlays in sidebar, history, skills, memory, composer, status bar, and workspace lists

## Verification
- npm run typecheck