### PR TITLE
feat(serve): runtime effort switching via /effort <level>

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -368,6 +368,7 @@ const SLASH_CMDS = [
   {cmd:'branch',desc:'Create branch'},
   {cmd:'switch',desc:'Switch branch'},
   {cmd:'model',desc:'List/switch models'},
+  {cmd:'effort',desc:'Reasoning effort level'},
   {cmd:'mcp',desc:'MCP servers'},
   {cmd:'skill',desc:'Skills'},
   {cmd:'hooks',desc:'Hooks'},

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -84,6 +84,45 @@ func (s *Server) initTitleProvider() {
 // conversation history. This replicates the TUI/desktop model-switch path. The
 // write lock is held across the whole rebuild so concurrent requests never read
 // a half-swapped controller and two switches can't run at once.
+// switchEffort changes the reasoning effort level and rebuilds the controller.
+// Config is persisted to disk first, then switchModel handles the rebuild.
+func (s *Server) switchEffort(ctx context.Context, level string) error {
+	cur := s.ctl()
+	if cur.Running() {
+		return fmt.Errorf("cannot change effort while a turn is running")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	ref := cur.Label()
+	entry, ok := cfg.ResolveModel(ref)
+	if !ok {
+		return fmt.Errorf("cannot resolve current provider %q", ref)
+	}
+	cap := config.EffortCapabilityForEntry(entry)
+	if !cap.Supported {
+		return fmt.Errorf("effort is not configurable for %s", entry.Name)
+	}
+	effort, err := config.NormalizeEffort(entry, level)
+	if err != nil {
+		return err
+	}
+	editPath := config.UserConfigPath()
+	if editPath == "" {
+		return fmt.Errorf("no config file found")
+	}
+	edit := config.LoadForEdit(editPath)
+	if err := edit.SetProviderEffort(entry.Name, effort); err != nil {
+		return err
+	}
+	if err := edit.SaveTo(editPath); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	// Rebuild controller with updated effort — switchModel handles the lock.
+	return s.switchModel(ctx, entry.Name+"/"+entry.Model)
+}
+
 func (s *Server) switchModel(ctx context.Context, ref string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -267,12 +306,25 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing input", http.StatusBadRequest)
 		return
 	}
+	trimmed := strings.TrimSpace(body.Input)
 	// Intercept /model <ref> for runtime model switching (the controller's
 	// Submit path only lists models — switching is frontend-specific).
-	if trimmed := strings.TrimSpace(body.Input); strings.HasPrefix(trimmed, "/model ") {
+	if strings.HasPrefix(trimmed, "/model ") {
 		ref := strings.TrimSpace(strings.TrimPrefix(trimmed, "/model"))
 		if ref != "" {
 			if err := s.switchModel(r.Context(), ref); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+	// Intercept /effort <level> for reasoning effort switching.
+	if strings.HasPrefix(trimmed, "/effort ") {
+		level := strings.TrimSpace(strings.TrimPrefix(trimmed, "/effort"))
+		if level != "" {
+			if err := s.switchEffort(r.Context(), level); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}


### PR DESCRIPTION
## Summary

Adds `/effort <level>` slash command to the HTTP SSE frontend for runtime reasoning effort switching.

### How it works

1. Intercept `/effort <level>` in the submit handler (before `ctrl.Submit()`)
2. `switchEffort()`: load config → resolve current provider → normalize effort level → persist to disk config
3. Delegate to `switchModel()` for thread-safe controller rebuild with carried history

### Supported levels

| Provider | Levels | Notes |
|----------|--------|-------|
| DeepSeek | `auto`, `high`, `max` | `low`/`medium` → `high`, `xhigh` → `max` |
| Anthropic | `auto`, `low`, `medium`, `high`, `xhigh`, `max` | |

### Changes

- `internal/serve/serve.go`: +53 lines (switchEffort method, /effort intercept)
- `internal/serve/index.html`: +1 line (/effort in slash menu)

All changes scoped to `internal/serve/` — zero kernel modifications.