### PR TITLE
fix(test): make Windows statusline and symlink tests portable

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -300,7 +300,7 @@ func runStatuslineCmd(cmd, stdinPayload string) string {
 	})
 	out := strings.TrimSpace(res.Stdout)
 	if i := strings.IndexByte(out, '\n'); i >= 0 {
-		out = out[:i]
+		out = strings.TrimSpace(out[:i])
 	}
 	return out
 }

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -15,16 +16,25 @@ import (
 // TestRunStatuslineCmd checks the custom status-line runner: it returns the
 // first stdout line and forwards the JSON payload on stdin.
 func TestRunStatuslineCmd(t *testing.T) {
+	firstLineCmd := "printf 'row-one\\nrow-two\\n'"
+	stdinCmd := "cat"
+	failCmd := "exit 3"
+	if runtime.GOOS == "windows" {
+		firstLineCmd = "echo row-one & echo row-two"
+		stdinCmd = "more"
+		failCmd = "exit /b 3"
+	}
+
 	// Multi-line output collapses to the first row.
-	if got := runStatuslineCmd("printf 'row-one\\nrow-two\\n'", "{}"); got != "row-one" {
+	if got := runStatuslineCmd(firstLineCmd, "{}"); got != "row-one" {
 		t.Errorf("multi-line output should collapse to the first row, got %q", got)
 	}
 	// The JSON payload is delivered on stdin.
-	if got := runStatuslineCmd("cat", `{"model":"deepseek"}`); got != `{"model":"deepseek"}` {
+	if got := runStatuslineCmd(stdinCmd, `{"model":"deepseek"}`); got != `{"model":"deepseek"}` {
 		t.Errorf("stdin payload not forwarded, got %q", got)
 	}
 	// A failing command yields an empty line, not an error.
-	if got := runStatuslineCmd("exit 3", "{}"); got != "" {
+	if got := runStatuslineCmd(failCmd, "{}"); got != "" {
 		t.Errorf("failed command should yield empty, got %q", got)
 	}
 }

--- a/internal/codegraph/symlink_escape_test.go
+++ b/internal/codegraph/symlink_escape_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -36,6 +38,11 @@ func TestExtractRejectsEscapingSymlink(t *testing.T) {
 // TestExtractAllowsInternalSymlink keeps legitimate in-bundle symlinks working.
 func TestExtractAllowsInternalSymlink(t *testing.T) {
 	dir := t.TempDir()
+	probe := filepath.Join(dir, "probe-link")
+	if err := os.Symlink("probe-target", probe); err != nil {
+		t.Skipf("symlink creation is not available in this environment: %v", err)
+	}
+	_ = os.Remove(probe)
 	for _, dest := range []string{"bin/codegraph", "./node", "sub/dir/../tool"} {
 		if err := extractTarGz(tarGzWithSymlink("link", dest), dir); err != nil {
 			t.Errorf("internal symlink -> %q should be allowed, got %v", dest, err)


### PR DESCRIPTION
﻿## What

- Make the custom statusline command test use shell commands that work on Windows and Unix.
- Trim the first captured statusline row after splitting on `\n`, so CRLF output does not leave a trailing `\r`.
- Skip the CodeGraph internal-symlink extraction test when the current Windows environment cannot create symlinks.

## Why

On a regular Windows checkout, `go test ./cmd/... ./internal/...` can fail even when the product code is otherwise healthy:

- `TestRunStatuslineCmd` uses Unix-only commands (`printf`, `cat`, `exit 3`).
- Windows command output can include `\r\n`, and `runStatuslineCmd` trimmed before splitting but not after taking the first row.
- `TestExtractAllowsInternalSymlink` assumes `os.Symlink` is available, but many Windows developer machines require Developer Mode or elevated privileges.

## Validation

- `go test ./internal/cli ./internal/codegraph -count=1`
- `go test ./cmd/... ./internal/...`
