### PR TITLE
fix(desktop): restore full-path hover on workspace tree rows

### DIFF
--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -550,31 +550,32 @@ export function WorkspacePanel({
       const isOpen = openDirs.has(path);
       const active = selectedPath === path;
       const row = (
-        <button
-          key={path}
-          className={`workspace-tree__row${active ? " workspace-tree__row--active" : ""}`}
-          draggable
-          onDragStart={(event) => startTreeDrag(event, path, entry.isDir)}
-          onClick={() => (entry.isDir ? toggleDir(path) : selectFile(path))}
-          onContextMenu={(event) => openTreeMenu(event, path, entry.isDir)}
-          style={{ paddingLeft: 8 + depth * 14 }}
-        >
-          {entry.isDir ? (
-            isOpen ? (
-              <ChevronDown size={13} className="workspace-tree__chev" />
+        <Tooltip key={path} label={path} fill>
+          <button
+            className={`workspace-tree__row${active ? " workspace-tree__row--active" : ""}`}
+            draggable
+            onDragStart={(event) => startTreeDrag(event, path, entry.isDir)}
+            onClick={() => (entry.isDir ? toggleDir(path) : selectFile(path))}
+            onContextMenu={(event) => openTreeMenu(event, path, entry.isDir)}
+            style={{ paddingLeft: 8 + depth * 14 }}
+          >
+            {entry.isDir ? (
+              isOpen ? (
+                <ChevronDown size={13} className="workspace-tree__chev" />
+              ) : (
+                <ChevronRight size={13} className="workspace-tree__chev" />
+              )
             ) : (
-              <ChevronRight size={13} className="workspace-tree__chev" />
-            )
-          ) : (
-            <span className="workspace-tree__chev" />
-          )}
-          {entry.isDir ? (
-            <Folder size={14} className="workspace-tree__icon workspace-tree__icon--dir" />
-          ) : (
-            <FileText size={14} className="workspace-tree__icon" />
-          )}
-          <span className="workspace-tree__name">{entry.name}</span>
-        </button>
+              <span className="workspace-tree__chev" />
+            )}
+            {entry.isDir ? (
+              <Folder size={14} className="workspace-tree__icon workspace-tree__icon--dir" />
+            ) : (
+              <FileText size={14} className="workspace-tree__icon" />
+            )}
+            <span className="workspace-tree__name">{entry.name}</span>
+          </button>
+        </Tooltip>
       );
       if (!entry.isDir || !isOpen) return [row];
       return [row, ...renderRows(path, depth + 1)];


### PR DESCRIPTION
Follow-up to #2769.

That PR removed redundant tooltips across the desktop UI — correct in almost every spot. The one place it over-trimmed was the **workspace file tree rows**: those render only the bare filename (indented by depth, no inline path), so two same-named files in different directories became indistinguishable on hover, and long names that truncate were no longer readable in full.

This restores `label={path}` on the tree rows only. Search-result rows (which already show the directory inline) and change rows (which show the full path inline) keep the leaner no-tooltip treatment from #2769.

## Verification
- npm run typecheck
