### PR TITLE
fix(desktop): stamp the release version into the build

### DIFF
--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -10,7 +10,10 @@
     "name": "esengine"
   },
   "info": {
+    "companyName": "Reasonix",
     "productName": "Reasonix",
+    "productVersion": "0.0.0",
+    "copyright": "Copyright © 2026 Reasonix Contributors",
     "comments": "Reasonix desktop — a Wails shell around the Go kernel."
   }
 }

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -25,6 +25,12 @@ BINNAME="reasonix-desktop"    # wails.json outputfilename -> linux binary name
 
 cd "$ROOT/desktop"
 
+# Stamp the version resource (Windows file properties, macOS CFBundleVersion) from
+# the tag. Wails reads info.productVersion from wails.json; goversioninfo needs it
+# numeric, so a leading "v" must go or the whole version block is silently dropped.
+numver="${VERSION#v}"
+node -e 'const fs=require("fs"),f="wails.json",j=JSON.parse(fs.readFileSync(f,"utf8"));j.info.productVersion=process.argv[1];fs.writeFileSync(f,JSON.stringify(j,null,2)+"\n")' "$numver"
+
 # NSIS installer is Windows-only (Wails requires a single windows target for -nsis).
 build_args=(-clean -platform "$PLATFORM" -ldflags "-X main.version=$VERSION")
 [ "$os" = windows ] && build_args+=(-nsis)


### PR DESCRIPTION
## What

Found while test-building the desktop package locally: the produced `.exe` had a
**blank "File version"** in its Windows properties. `wails.json`'s `info` block
defined no `productVersion`, so Wails' generated versioninfo template resolved
`{{.Info.ProductVersion}}` to empty and the binary shipped with no usable file
version (and no company/copyright).

- Fill `wails.json` `info` with `companyName` / `productVersion` / `copyright`.
- `desktop-build.sh` stamps `productVersion` from the tag before `wails build`
  (numeric — a leading `v` breaks goversioninfo's fixed-version parse). The same
  value feeds the macOS bundle version.

## Verified locally

`wails build` with a `v1.0.0` stamp → the exe's `FileVersionRaw` reads `1.0.0.0`
(was `0.0.0`/blank). The brand icon from the prior PR is embedded correctly.

## Known limitation (not fixed here)

The version **string** fields (Product name, Company, Copyright) are present in
the binary under the canonical `040904b0` block with a matching Translation, but
Windows `VerQueryValue` (and so .NET `FileVersionInfo` / Explorer's "Product
name" line) still reads them blank — a goversioninfo/Wails string-table
serialization quirk independent of this change. The numeric **File version** —
the field installers and update checks key on — is correct. Tracking the
string-field display as a separate follow-up.
