### PR TITLE
fix(desktop): keep the NSIS installer script ASCII

### DIFF
--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -7,12 +7,12 @@ Unicode true
 ## untouched and only regenerates wails_tools.nsh). The two customizations vs.
 ## Wails' default template:
 ##
-##   1. REQUEST_EXECUTION_LEVEL "user" + InstallDir under $LOCALAPPDATA — install
+##   1. REQUEST_EXECUTION_LEVEL "user" + InstallDir under $LOCALAPPDATA - install
 ##      without administrator rights. This is what lets the auto-updater re-run a
 ##      freshly downloaded installer silently (`/S`) with no UAC prompt.
 ##   2. Uninstall registry under HKCU (not HKLM). Wails' wails.writeUninstaller /
 ##      wails.deleteUninstaller macros hard-code HKLM, which a non-admin install
-##      cannot write — so we inline HKCU versions below instead.
+##      cannot write - so we inline HKCU versions below instead.
 ##
 ## Everything else mirrors Wails' generated default. Defines below override the
 ## ProjectInfo values that wails_tools.nsh would otherwise populate.


### PR DESCRIPTION
## Problem

Found running a full `scripts/desktop-build.sh windows/amd64` locally — the NSIS
step aborted:

```
Processing script file: "project.nsi" (ACP)
Error in script "project.nsi" on line 10 -- aborting creation process
```

`makensis` picks source encoding from a BOM. `project.nsi` is UTF-8 **without** a
BOM, so on a non-UTF-8 ANSI codepage (this box is CP936) makensis reads it as ACP
and the two em-dashes in the header comment turn into invalid bytes — the parse
dies on line 10. GitHub's en-US runners (CP1252) happen to tolerate the garbage
inside a comment, which is why the v2 Wails installer has never failed in CI (no
`desktop-v*` Wails release has shipped yet).

## Fix

Replace the two em-dashes with ASCII hyphens — there's no reason for non-ASCII in
a build script, and this is locale-proof without depending on a BOM surviving
edits.

## Verified

`scripts/desktop-build.sh windows/amd64 v1.0.0` now produces
`dist/Reasonix-windows-amd64-installer.exe`, and the installer's version
properties read correctly (ProductName `Reasonix`, version `1.0.0`, company,
copyright) — confirming the wails.json info block from #2779 flows through to the
NSIS `INFO_*` defines too.
