### PR TITLE
fix(release): don't push the Homebrew cask for prereleases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -34,6 +34,9 @@ checksum:
 homebrew_casks:
   - name: reasonix
     ids: [reasonix]
+    # Prereleases (v*-rc*) must not update the stable tap; brew has no separate
+    # prerelease channel, so a pushed rc cask becomes the default `brew install`.
+    skip_upload: "auto"
     repository:
       owner: esengine
       name: homebrew-reasonix


### PR DESCRIPTION
The `v1.0.0-rc1` RC pushed an rc cask to `esengine/homebrew-reasonix`, so `brew install esengine/reasonix/reasonix` would have served a prerelease as the default — Homebrew has no separate prerelease channel. (Already reverted the rc cask from the tap by hand.)

`skip_upload: "auto"` skips the tap update when the version is a prerelease; stable tags still publish. Validated with `goreleaser check`.