### PR TITLE
fix(desktop): bump CI pnpm to 10 for the frontend build

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -66,7 +66,7 @@ jobs:
           node-version: "22"
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
 
       # Linux: WebKitGTK 4.0 toolchain (pinned to ubuntu-22.04; no webkit2_41 tag).
       - name: Install Linux build deps


### PR DESCRIPTION
First run of the v2 Wails desktop release (`desktop-v1.0.0-rc1`) failed on all platforms at `wails build` → `pnpm install`:

```
Installing frontend dependencies: ERROR  packages field missing or empty
```

`desktop/frontend/pnpm-workspace.yaml` is pnpm-10-style (holds `allowBuilds` config, no `packages:` field). pnpm 9 — which `release-desktop.yml` pinned — still treats pnpm-workspace.yaml as workspace-only and requires `packages:`, so it errors. The frontend is developed on pnpm 10 (local builds fine), so match the release runner to it.

Found dry-running the desktop RC; the build never reached publish/mirror, so nothing was released.