### PR TITLE
fix(desktop): build a universal macOS app, drop the Intel runner

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -44,8 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runner: macos-14, platform: darwin/arm64, name: darwin-arm64 }
-          - { runner: macos-13, platform: darwin/amd64, name: darwin-amd64 }
+          # One universal macOS build (Intel + Apple Silicon) on a single arm64
+          # runner — avoids the scarce/slow macos-13 Intel runner.
+          - { runner: macos-14, platform: darwin/universal, name: darwin-universal }
           - { runner: windows-latest, platform: windows/amd64, name: windows-amd64 }
           - { runner: ubuntu-22.04, platform: linux/amd64, name: linux-amd64 }
     runs-on: ${{ matrix.runner }}

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -53,7 +53,15 @@ darwin)
 	app="$staging/${APPNAME}.app"
 	cp -R "build/bin/reasonix-desktop.app" "$app"
 	codesign --force --deep -s - "$app"
-	ditto -c -k --keepParent "$app" "$ROOT/dist/${APPNAME}-darwin-${arch}.zip"
+	if [ "$arch" = universal ]; then
+		# One universal .app covers Intel + Apple Silicon; publish it under both
+		# manifest keys so the updater's darwin-arm64/darwin-amd64 lookup finds it
+		# (avoids a scarce macos-13 Intel runner).
+		ditto -c -k --keepParent "$app" "$ROOT/dist/${APPNAME}-darwin-arm64.zip"
+		ditto -c -k --keepParent "$app" "$ROOT/dist/${APPNAME}-darwin-amd64.zip"
+	else
+		ditto -c -k --keepParent "$app" "$ROOT/dist/${APPNAME}-darwin-${arch}.zip"
+	fi
 	rm -rf "$staging"
 	;;
 windows)


### PR DESCRIPTION
The macos-13 Intel runner is scarce and repeatedly stalled the desktop RC for a long time waiting for allocation. Switch to a single `darwin/universal` build on the macos-14 (arm64) runner — it carries both Intel + Apple Silicon slices, so one runner covers both Macs and the slow Intel leg is gone. No regression vs the previous two-runner setup (Intel Macs still supported).

The one universal .app is published under both `Reasonix-darwin-arm64.zip` and `Reasonix-darwin-amd64.zip`, so the existing manifest keys and the updater's `darwin-<arch>` lookup resolve unchanged — **no updater/sign/Go changes**.

Matrix goes 4 → 3 jobs. Can't build a macOS app on Windows, so the universal build itself verifies on the macos-14 runner in this PR's release dry-run.