### PR TITLE
docs(changelog): mark 1.0.0 released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Go line (Reasonix 1.0+) are recorded here. The legacy
 `0.x` TypeScript history lives on the [`v1`](https://github.com/esengine/DeepSeek-Reasonix/tree/v1)
 branch.
 
-## [1.0.0] — unreleased
+## [1.0.0] — 2026-06-03
 
 First stable release — a **ground-up rewrite in Go**. Not an upgrade of the `0.x`
 TypeScript line; a new codebase that becomes the default (`main-v2`).


### PR DESCRIPTION
Stamp the 1.0.0 release date ahead of tagging the stable release.