### PR TITLE
feat: migrate v0.x ~/.reasonix install on upgrade (config, key, MCP, sessions) + legacy `code` alias

### DIFF
--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// legacyEvent is the subset of the v0.x typed event stream (<name>.events.jsonl)
+// needed to rebuild the conversation: user input, assistant turns (text + tool
+// calls), and tool results. All other event types (UI, plan, checkpoint, …) are
+// presentation and carry no message state.
+type legacyEvent struct {
+	Type             string           `json:"type"`
+	Text             string           `json:"text"`             // user.message
+	Content          string           `json:"content"`          // model.final
+	ReasoningContent string           `json:"reasoningContent"` // model.final
+	ToolCalls        []legacyToolCall `json:"toolCalls"`        // model.final
+	CallID           string           `json:"callId"`           // tool.result
+	Output           string           `json:"output"`           // tool.result
+}
+
+type legacyToolCall struct {
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// MigrateLegacySessions imports v0.x event-log sessions (<name>.events.jsonl under
+// srcDir) into the v1+ message-log format (<name>.jsonl under destDir). It is a
+// no-op when destDir already holds sessions (so it never imports twice) or srcDir
+// has none, and never modifies the legacy files. Returns the count imported.
+func MigrateLegacySessions(srcDir, destDir string) (int, error) {
+	if hasSessions(destDir) {
+		return 0, nil
+	}
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return 0, nil
+	}
+	imported := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".events.jsonl") {
+			continue
+		}
+		msgs, err := reconstructSession(filepath.Join(srcDir, name))
+		if err != nil || len(msgs) == 0 {
+			continue
+		}
+		dest := filepath.Join(destDir, strings.TrimSuffix(name, ".events.jsonl")+".jsonl")
+		s := &Session{Messages: msgs}
+		if err := s.Save(dest); err != nil {
+			return imported, err
+		}
+		if info, err := e.Info(); err == nil {
+			os.Chtimes(dest, info.ModTime(), info.ModTime()) // preserve resume ordering
+		}
+		imported++
+	}
+	return imported, nil
+}
+
+func hasSessions(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".jsonl" {
+			return true
+		}
+	}
+	return false
+}
+
+// reconstructSession folds the chronological event stream into the provider
+// message sequence. Tool results inherit their tool name from the assistant turn
+// that issued the call (the v0.x result event carries only the call id).
+func reconstructSession(path string) ([]provider.Message, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var msgs []provider.Message
+	toolName := map[string]string{}
+	dec := json.NewDecoder(f)
+	for {
+		var e legacyEvent
+		if err := dec.Decode(&e); err != nil {
+			if !errors.Is(err, io.EOF) {
+				return msgs, nil // malformed tail — keep what parsed cleanly
+			}
+			break
+		}
+		switch e.Type {
+		case "user.message":
+			if e.Text != "" {
+				msgs = append(msgs, provider.Message{Role: provider.RoleUser, Content: e.Text})
+			}
+		case "model.final":
+			m := provider.Message{Role: provider.RoleAssistant, Content: e.Content, ReasoningContent: e.ReasoningContent}
+			for _, tc := range e.ToolCalls {
+				m.ToolCalls = append(m.ToolCalls, provider.ToolCall{ID: tc.ID, Name: tc.Function.Name, Arguments: tc.Function.Arguments})
+				toolName[tc.ID] = tc.Function.Name
+			}
+			msgs = append(msgs, m)
+		case "tool.result":
+			msgs = append(msgs, provider.Message{Role: provider.RoleTool, ToolCallID: e.CallID, Name: toolName[e.CallID], Content: e.Output})
+		}
+	}
+	return msgs, nil
+}

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -1,0 +1,95 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+const legacyEventLog = `{"type":"model.turn.started","id":1,"ts":"t","turn":0,"model":"deepseek"}
+{"type":"user.message","id":2,"ts":"t","turn":0,"text":"list the files"}
+{"type":"model.delta","id":3,"ts":"t","turn":0,"channel":"content","text":"sure"}
+{"type":"model.final","id":4,"ts":"t","turn":0,"content":"On it.","toolCalls":[{"id":"call_1","type":"function","function":{"name":"ls","arguments":"{\"path\":\".\"}"}}],"usage":{},"costUsd":0}
+{"type":"tool.result","id":5,"ts":"t","turn":0,"callId":"call_1","ok":true,"output":"a.go\nb.go","durationMs":3}
+{"type":"model.final","id":6,"ts":"t","turn":0,"content":"There are two files.","toolCalls":[],"usage":{},"costUsd":0}
+`
+
+func TestMigrateLegacySessionsReconstructsConversation(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := MigrateLegacySessions(src, dest)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d sessions, want 1", n)
+	}
+
+	loaded, err := LoadSession(filepath.Join(dest, "chat-1.jsonl"))
+	if err != nil {
+		t.Fatalf("reload migrated session: %v", err)
+	}
+	got := loaded.Messages
+	if len(got) != 4 {
+		t.Fatalf("message count = %d, want 4 (user, assistant+toolcall, tool, assistant):\n%+v", len(got), got)
+	}
+	if got[0].Role != provider.RoleUser || got[0].Content != "list the files" {
+		t.Errorf("msg0 = %+v, want user 'list the files'", got[0])
+	}
+	if got[1].Role != provider.RoleAssistant || len(got[1].ToolCalls) != 1 ||
+		got[1].ToolCalls[0].ID != "call_1" || got[1].ToolCalls[0].Name != "ls" {
+		t.Errorf("msg1 = %+v, want assistant with ls tool call call_1", got[1])
+	}
+	if got[2].Role != provider.RoleTool || got[2].ToolCallID != "call_1" ||
+		got[2].Name != "ls" || got[2].Content != "a.go\nb.go" {
+		t.Errorf("msg2 = %+v, want tool result for call_1 named ls", got[2])
+	}
+	if got[3].Role != provider.RoleAssistant || got[3].Content != "There are two files." {
+		t.Errorf("msg3 = %+v, want final assistant text", got[3])
+	}
+}
+
+func TestMigrateLegacySessionsSkipsWhenDestHasSessions(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
+	os.WriteFile(filepath.Join(dest, "existing.jsonl"), []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644)
+
+	n, err := MigrateLegacySessions(src, dest)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("must not import over an existing v1+ session dir, imported %d", n)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("legacy session should not have been written when dest already has sessions")
+	}
+}
+
+func TestMigrateLegacySessionsNoSrcIsNoop(t *testing.T) {
+	n, err := MigrateLegacySessions(filepath.Join(t.TempDir(), "nope"), t.TempDir())
+	if err != nil || n != 0 {
+		t.Errorf("missing legacy session dir should be a silent no-op, got n=%d err=%v", n, err)
+	}
+}
+
+func TestMigrateLegacySessionsSkipsEmptyLog(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "empty.events.jsonl"), []byte(`{"type":"model.turn.started","id":1,"ts":"t","turn":0}`+"\n"), 0o644)
+
+	n, err := MigrateLegacySessions(src, dest)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("a log with no user/assistant/tool messages should not produce a session, imported %d", n)
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -71,6 +72,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if stderr == nil {
 		stderr = os.Stderr
 	}
+	// One-time import of a v0.x (~/.reasonix/config.json) install — runs before
+	// Load so the freshly written config + ~/.env are picked up this same boot.
+	migrated, migErr := config.MigrateLegacyIfNeeded()
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, err
@@ -94,6 +98,17 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// shares this synchronized sink. The job manager is session-scoped — its jobs
 	// outlive a turn and are cancelled by Controller.Close.
 	sink := event.Sync(opts.Sink)
+
+	if migErr != nil {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "config migration from ~/.reasonix failed: " + migErr.Error()})
+	} else if migrated != nil {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: migrated.Notice()})
+		if home, herr := os.UserHomeDir(); herr == nil {
+			if n, serr := agent.MigrateLegacySessions(filepath.Join(home, ".reasonix", "sessions"), config.SessionDir()); serr == nil && n > 0 {
+				sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("imported %d past session(s) from ~/.reasonix/sessions — resume them with --resume or the history panel", n)})
+			}
+		}
+	}
 
 	// A resolvable model whose API key env is unset would otherwise build fine
 	// (RequireKey is false so the UI stays reachable) and then fail silently on the

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -287,6 +287,83 @@ func writeFile(t *testing.T, dir, name, body string) {
 	}
 }
 
+// TestBuildMigratesLegacyConfigEndToEnd drives the real boot path: a v0.x
+// ~/.reasonix/config.json with no v1+ config present must be imported during
+// Build — config written, key pinned into the env, and the user told via a notice.
+func TestBuildMigratesLegacyConfigEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)                               // os.UserHomeDir on Windows
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config")) // os.UserConfigDir on Linux
+	t.Setenv("AppData", filepath.Join(home, "AppData"))         // os.UserConfigDir on Windows
+	t.Setenv("DEEPSEEK_API_KEY", "")                            // track for cleanup; migration os.Setenv's it live
+
+	proj := t.TempDir()
+	t.Chdir(proj)
+	// codegraph off keeps Build offline; it merges over the migrated user config
+	// without dropping the migrated plugins.
+	writeFile(t, proj, "reasonix.toml", "[codegraph]\nenabled = false\n")
+	writeFile(t, filepath.Join(home, ".reasonix"), "config.json",
+		`{"apiKey":"sk-e2e","lang":"zh","mcpServers":{"fs":{"command":"npx","args":["-y","server-fs"]}}}`)
+	writeFile(t, filepath.Join(home, ".reasonix", "sessions"), "chat-1.events.jsonl",
+		`{"type":"user.message","id":1,"ts":"t","turn":0,"text":"hello from v0.x"}`+"\n"+
+			`{"type":"model.final","id":2,"ts":"t","turn":0,"content":"hi","toolCalls":[],"usage":{},"costUsd":0}`+"\n")
+
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+
+	ctrl, err := Build(context.Background(), Options{Sink: sink})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	migrated := false
+	for _, n := range notices {
+		if strings.Contains(n, "migrated your previous configuration") {
+			migrated = true
+		}
+	}
+	if !migrated {
+		t.Fatalf("no migration notice emitted; got %v", notices)
+	}
+
+	dest := config.UserConfigPath()
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("v2 config not written to %s: %v", dest, err)
+	}
+	if !strings.Contains(string(data), `name    = "fs"`) || !strings.Contains(string(data), `language      = "zh"`) {
+		t.Errorf("migrated config missing plugin/lang:\n%s", data)
+	}
+
+	if got := os.Getenv("DEEPSEEK_API_KEY"); got != "sk-e2e" {
+		t.Errorf("DEEPSEEK_API_KEY not pinned into env after migration: %q", got)
+	}
+
+	if data, err := os.ReadFile(filepath.Join(home, ".env")); err != nil || !strings.Contains(string(data), "DEEPSEEK_API_KEY=sk-e2e") {
+		t.Errorf("~/.env missing migrated key: %q (err %v)", data, err)
+	}
+
+	sessionImported := false
+	for _, n := range notices {
+		if strings.Contains(n, "imported") && strings.Contains(n, "past session") {
+			sessionImported = true
+		}
+	}
+	if !sessionImported {
+		t.Errorf("no session-import notice emitted; got %v", notices)
+	}
+	migratedSession := filepath.Join(config.SessionDir(), "chat-1.jsonl")
+	if _, err := os.Stat(migratedSession); err != nil {
+		t.Errorf("legacy session not imported to %s: %v", migratedSession, err)
+	}
+}
+
 // isolateConfigHome redirects os.UserConfigDir() (and the cache subtree under
 // it) at a per-test temp dir by overriding the env vars Go's stdlib reads —
 // HOME on darwin, XDG_CONFIG_HOME on linux. Without this, Build's plugin path

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -53,7 +53,7 @@ func Run(args []string, version string) int {
 	switch cmd {
 	case "run":
 		return runAgent(rest)
-	case "chat":
+	case "chat", "code": // "code" is the v0.x name for the interactive session
 		return chatREPL(rest)
 	case "serve":
 		return runServe(rest)

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -1,0 +1,230 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// legacyConfig is the subset of the v0.x (~/.reasonix/config.json) schema this
+// import carries forward. Fields absent here are dropped on purpose: desktop tab
+// state is frontend-owned, and skills already live in the shared ~/.reasonix/skills
+// root that v1+ also scans, so they need no migration.
+type legacyConfig struct {
+	APIKey      string                       `json:"apiKey"`
+	BaseURL     string                       `json:"baseUrl"`
+	Lang        string                       `json:"lang"`
+	MCPServers  map[string]legacyMCPServer   `json:"mcpServers"`
+	MCPEnv      map[string]map[string]string `json:"mcpEnv"`
+	MCPDisabled []string                     `json:"mcpDisabled"`
+}
+
+type legacyMCPServer struct {
+	Command   string            `json:"command"`
+	Args      []string          `json:"args"`
+	Env       map[string]string `json:"env"`
+	Transport string            `json:"transport"`
+	Type      string            `json:"type"`
+	URL       string            `json:"url"`
+	Headers   map[string]string `json:"headers"`
+	Disabled  bool              `json:"disabled"`
+}
+
+// MigrationResult summarizes a one-time legacy import for the boot-time notice.
+type MigrationResult struct {
+	From     string
+	To       string
+	KeyToEnv bool
+	Plugins  int
+	Warnings []string
+}
+
+func (r *MigrationResult) Notice() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "migrated your previous configuration: %s → %s", r.From, r.To)
+	if r.Plugins > 0 {
+		fmt.Fprintf(&b, " (%d MCP server(s))", r.Plugins)
+	}
+	if r.KeyToEnv {
+		b.WriteString("; API key written to ~/.env")
+	}
+	b.WriteString(". The old files were left untouched.")
+	for _, w := range r.Warnings {
+		b.WriteString("\n  note: " + w)
+	}
+	return b.String()
+}
+
+// MigrateLegacyIfNeeded performs a one-time, non-destructive import of a v0.x
+// install (~/.reasonix/config.json) into the v1+ user config when the latter does
+// not exist yet. It never modifies or deletes the legacy files. Returns nil when
+// there is nothing to migrate (no legacy install, or a v1+ config already present).
+func MigrateLegacyIfNeeded() (*MigrationResult, error) {
+	dest := userConfigPath()
+	if dest == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(dest); err == nil {
+		return nil, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, nil
+	}
+	src := filepath.Join(home, ".reasonix", "config.json")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return nil, nil
+	}
+	var legacy legacyConfig
+	data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF}) // tolerate a UTF-8 BOM (some editors add one)
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return nil, fmt.Errorf("parse legacy config %s: %w", src, err)
+	}
+
+	cfg := Default()
+	res := &MigrationResult{From: src, To: dest}
+	if legacy.Lang != "" {
+		cfg.Language = legacy.Lang
+	}
+	cfg.Plugins = legacyPlugins(legacy)
+	res.Plugins = len(cfg.Plugins)
+
+	var envLines []string
+	if key := strings.TrimSpace(legacy.APIKey); key != "" {
+		envLines = append(envLines, "DEEPSEEK_API_KEY="+key)
+		res.KeyToEnv = true
+		if base := strings.TrimSpace(legacy.BaseURL); base != "" && !strings.Contains(base, "deepseek.com") {
+			res.Warnings = append(res.Warnings, "your previous base_url was "+base+
+				" — add a [[providers]] entry pointing at it; the key was saved as DEEPSEEK_API_KEY")
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return nil, fmt.Errorf("create config dir: %w", err)
+	}
+	if err := cfg.WriteFile(dest); err != nil {
+		return nil, fmt.Errorf("write %s: %w", dest, err)
+	}
+	if len(envLines) > 0 {
+		if err := writeHomeEnv(home, envLines); err != nil {
+			return res, fmt.Errorf("write ~/.env: %w", err)
+		}
+	}
+	return res, nil
+}
+
+func legacyPlugins(legacy legacyConfig) []PluginEntry {
+	if len(legacy.MCPServers) == 0 {
+		return nil
+	}
+	disabled := make(map[string]bool, len(legacy.MCPDisabled))
+	for _, n := range legacy.MCPDisabled {
+		disabled[n] = true
+	}
+	names := make([]string, 0, len(legacy.MCPServers))
+	for n := range legacy.MCPServers {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	out := make([]PluginEntry, 0, len(names))
+	for _, name := range names {
+		s := legacy.MCPServers[name]
+		pe := PluginEntry{
+			Name:    name,
+			Type:    normalizeTransport(firstNonEmpty(s.Type, s.Transport)),
+			Command: s.Command,
+			Args:    s.Args,
+			Env:     mergeEnv(s.Env, legacy.MCPEnv[name]),
+			URL:     s.URL,
+			Headers: s.Headers,
+		}
+		if s.Disabled || disabled[name] {
+			off := false
+			pe.AutoStart = &off
+		}
+		out = append(out, pe)
+	}
+	return out
+}
+
+// normalizeTransport maps the v0.x transport names to v1+ plugin types. stdio is
+// the default, so it returns "" (RenderTOML then omits the field).
+func normalizeTransport(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "http", "streamable-http":
+		return "http"
+	case "sse":
+		return "sse"
+	default:
+		return ""
+	}
+}
+
+func firstNonEmpty(a, b string) string {
+	if strings.TrimSpace(a) != "" {
+		return a
+	}
+	return b
+}
+
+// mergeEnv overlays the per-server env map onto the spec's own env (overlay wins,
+// matching v0.x mcpEnv precedence). Returns nil when both are empty.
+func mergeEnv(base, overlay map[string]string) map[string]string {
+	if len(base) == 0 && len(overlay) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(base)+len(overlay))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overlay {
+		out[k] = v
+	}
+	return out
+}
+
+// writeHomeEnv merges lines into ~/.env, replacing any existing assignment of the
+// same key, and pins them into the current process env so the just-built session
+// resolves the key without a restart.
+func writeHomeEnv(home string, lines []string) error {
+	path := filepath.Join(home, ".env")
+	target := make(map[string]bool, len(lines))
+	for _, l := range lines {
+		if k, _, ok := strings.Cut(l, "="); ok {
+			target[strings.TrimSpace(k)] = true
+		}
+	}
+	var kept []string
+	if data, err := os.ReadFile(path); err == nil {
+		for _, raw := range strings.Split(string(data), "\n") {
+			check := strings.TrimPrefix(strings.TrimSpace(raw), "export ")
+			if k, _, ok := strings.Cut(check, "="); ok && target[strings.TrimSpace(k)] {
+				continue
+			}
+			kept = append(kept, raw)
+		}
+		if n := len(kept); n > 0 && kept[n-1] == "" {
+			kept = kept[:n-1]
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	var b strings.Builder
+	for _, l := range kept {
+		b.WriteString(l)
+		b.WriteByte('\n')
+	}
+	for _, l := range lines {
+		b.WriteString(l)
+		b.WriteByte('\n')
+		if k, v, ok := strings.Cut(l, "="); ok {
+			os.Setenv(strings.TrimSpace(k), v)
+		}
+	}
+	return os.WriteFile(path, []byte(b.String()), 0o600)
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// legacyHome points HOME / config-dir / .env resolution at a fresh temp tree and
+// returns the legacy config.json path and the v1+ dest config path.
+func legacyHome(t *testing.T) (src, dest, home string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)                               // os.UserHomeDir on Windows
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config")) // os.UserConfigDir on Linux
+	t.Setenv("AppData", filepath.Join(home, "AppData"))         // os.UserConfigDir on Windows
+	return filepath.Join(home, ".reasonix", "config.json"), userConfigPath(), home
+}
+
+func writeLegacy(t *testing.T, src, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
+	src, dest, home := legacyHome(t)
+	writeLegacy(t, src, `{
+		"apiKey": "sk-legacy-123",
+		"lang": "zh",
+		"mcpServers": {
+			"fs": {"command": "npx", "args": ["-y", "server-fs"], "type": "stdio"},
+			"stripe": {"type": "http", "url": "https://mcp.stripe.com", "disabled": true}
+		},
+		"mcpEnv": {"fs": {"ROOT": "/tmp"}}
+	}`)
+
+	res, err := MigrateLegacyIfNeeded()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if res == nil {
+		t.Fatal("expected a migration result")
+	}
+	if !res.KeyToEnv || res.Plugins != 2 {
+		t.Errorf("result = %+v, want KeyToEnv=true Plugins=2", res)
+	}
+
+	envData, err := os.ReadFile(filepath.Join(home, ".env"))
+	if err != nil {
+		t.Fatalf("read ~/.env: %v", err)
+	}
+	if !strings.Contains(string(envData), "DEEPSEEK_API_KEY=sk-legacy-123") {
+		t.Errorf("~/.env missing key: %q", envData)
+	}
+
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest config: %v", err)
+	}
+	toml := string(got)
+	for _, want := range []string{`language      = "zh"`, `name    = "fs"`, `name    = "stripe"`, `type    = "http"`, `auto_start = false`} {
+		if !strings.Contains(toml, want) {
+			t.Errorf("dest config missing %q:\n%s", want, toml)
+		}
+	}
+
+	if _, err := os.Stat(src); err != nil {
+		t.Errorf("legacy file must be left untouched: %v", err)
+	}
+}
+
+func TestMigrateRoundTripsThroughLoad(t *testing.T) {
+	src, _, _ := legacyHome(t)
+	writeLegacy(t, src, `{"apiKey":"sk-x","mcpServers":{"fs":{"command":"npx","env":{"A":"1"}}}}`)
+
+	if _, err := MigrateLegacyIfNeeded(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(cfg.Plugins) != 1 || cfg.Plugins[0].Name != "fs" || cfg.Plugins[0].Command != "npx" {
+		t.Errorf("plugins did not round-trip through Load: %+v", cfg.Plugins)
+	}
+	if cfg.Plugins[0].Env["A"] != "1" {
+		t.Errorf("plugin env lost: %+v", cfg.Plugins[0].Env)
+	}
+}
+
+func TestMigrateSkipsWhenDestExists(t *testing.T) {
+	src, dest, _ := legacyHome(t)
+	writeLegacy(t, src, `{"apiKey":"sk-x"}`)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("default_model = \"deepseek-flash\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := MigrateLegacyIfNeeded()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if res != nil {
+		t.Errorf("must not migrate over an existing v1+ config, got %+v", res)
+	}
+}
+
+func TestMigrateNoLegacyIsNoop(t *testing.T) {
+	legacyHome(t)
+	res, err := MigrateLegacyIfNeeded()
+	if err != nil || res != nil {
+		t.Errorf("no legacy install should be a silent no-op, got res=%+v err=%v", res, err)
+	}
+}
+
+func TestMigrateToleratesUTF8BOM(t *testing.T) {
+	src, _, home := legacyHome(t)
+	writeLegacy(t, src, "\ufeff"+`{"apiKey":"sk-bom"}`)
+	res, err := MigrateLegacyIfNeeded()
+	if err != nil {
+		t.Fatalf("a BOM-prefixed legacy config must still parse: %v", err)
+	}
+	if res == nil || !res.KeyToEnv {
+		t.Fatalf("BOM-prefixed config did not migrate: %+v", res)
+	}
+	data, _ := os.ReadFile(filepath.Join(home, ".env"))
+	if !strings.Contains(string(data), "DEEPSEEK_API_KEY=sk-bom") {
+		t.Errorf("key not migrated from BOM-prefixed config: %q", data)
+	}
+}
+
+func TestMigrateCustomBaseURLWarns(t *testing.T) {
+	src, _, _ := legacyHome(t)
+	writeLegacy(t, src, `{"apiKey":"sk-x","baseUrl":"https://my-proxy.example/v1"}`)
+	res, err := MigrateLegacyIfNeeded()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if len(res.Warnings) == 0 {
+		t.Error("a non-DeepSeek base_url should produce a warning")
+	}
+}

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -17,10 +18,14 @@ func explainError(err error) error {
 	}
 	var apiErr *provider.APIError
 	if errors.As(err, &apiErr) {
-		if msg := i18n.M.ProviderStatusMessage(apiErr.Status); msg != "" {
-			return errors.New(msg)
+		msg := i18n.M.ProviderStatusMessage(apiErr.Status)
+		if msg == "" {
+			return err
 		}
-		return err
+		if reason := requestErrorReason(apiErr); reason != "" {
+			return fmt.Errorf("%s\n%s", msg, reason)
+		}
+		return errors.New(msg)
 	}
 	var authErr *provider.AuthError
 	if errors.As(err, &authErr) {
@@ -34,4 +39,39 @@ func explainError(err error) error {
 		return errors.New(msg)
 	}
 	return err
+}
+
+// requestErrorReason returns the provider's verbatim reason for request-shaped
+// 4xx (400/422) — the localized line names the category, the body names the
+// actual cause (context-length exceeded, unpaired tool_calls). Empty otherwise.
+func requestErrorReason(e *provider.APIError) string {
+	if e.Status != 400 && e.Status != 422 {
+		return ""
+	}
+	return providerBodyReason(e.Body)
+}
+
+// providerBodyReason pulls the human reason from an OpenAI/Anthropic-shaped error
+// body ({"error":{"message":…}}), falling back to the trimmed raw body.
+func providerBodyReason(body string) string {
+	if body == "" {
+		return ""
+	}
+	var parsed struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if json.Unmarshal([]byte(body), &parsed) == nil && parsed.Error.Message != "" {
+		return clampRunes(parsed.Error.Message, 800)
+	}
+	return clampRunes(body, 800)
+}
+
+func clampRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
 }

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -31,6 +31,21 @@ func TestExplainError(t *testing.T) {
 		}
 	}
 
+	jsonBody := explainError(&provider.APIError{Provider: "deepseek", Status: 400, Body: `{"error":{"message":"This model's maximum context length is 65536 tokens.","type":"invalid_request_error"}}`})
+	if !strings.Contains(jsonBody.Error(), i18n.M.ProviderErrBadRequest) || !strings.Contains(jsonBody.Error(), "maximum context length") {
+		t.Errorf("400 should append the provider reason from a JSON body, got %q", jsonBody.Error())
+	}
+
+	rawBody := explainError(&provider.APIError{Provider: "deepseek", Status: 422, Body: "some unparseable detail"})
+	if !strings.Contains(rawBody.Error(), "some unparseable detail") {
+		t.Errorf("422 should fall back to the raw body, got %q", rawBody.Error())
+	}
+
+	noLeak := explainError(&provider.APIError{Provider: "deepseek", Status: 429, Body: `{"error":{"message":"slow down"}}`})
+	if noLeak.Error() != i18n.M.ProviderErrRateLimited {
+		t.Errorf("429 body must not leak into the message, got %q", noLeak.Error())
+	}
+
 	plain := errors.New("some other failure")
 	if explainError(plain) != plain {
 		t.Error("unknown errors should pass through unchanged")


### PR DESCRIPTION
## Why

Upgrading from v0.x (Ink/TS, `0.53.0`) to the v1 Go rewrite silently dropped everything: config, API key, MCP servers, skills and chat history, with no prompt (#2802). The rewrite moved and reshaped all of it:

| | v0.x | v1+ |
|---|---|---|
| user config | `~/.reasonix/config.json` | OS config dir `reasonix/config.toml` (macOS: `~/Library/Application Support/...`) |
| format | JSON | TOML |
| API key | in `config.json` (`apiKey`) | env via `api_key_env` (`.env` / shell) |
| MCP | `mcpServers{}` | `[[plugins]]` |
| sessions | `~/.reasonix/sessions/*.events.jsonl` (event log) | `<config>/reasonix/sessions/*.jsonl` (message log) |

The data was never deleted — v1 just looked in a new place. This adds the missing bridge.

## What

A one-time, **non-destructive** import wired into `boot.Build` (so both the CLI and the desktop app get it), gated on "no v1+ config present but `~/.reasonix/config.json` exists":

- **config** → language + MCP servers (`mcpServers`/`mcpEnv`/`mcpDisabled`, transports normalized, disabled servers kept as `auto_start = false`) into `config.toml`.
- **API key** → written to `~/.env` as `DEEPSEEK_API_KEY` and pinned into the live process so the very first boot resolves it.
- **sessions** → the v0.x typed event stream is replayed into the v1+ `provider.Message` log (`user.message`/`model.final`+tool calls/`tool.result`), preserving mtime for resume ordering.
- The legacy `~/.reasonix` files are never modified or deleted, and the user is told what happened via a boot notice (the "no prompt" complaint).
- Skills need no migration: `~/.reasonix/skills` is already a v1+ global skill root.

Also: `reasonix code` (the v0.x name for the interactive session) is now an alias for `chat`, so upgrading users who type it get in instead of hitting unknown-command.

A bad-request 400/422 now also appends the provider's actual reason (previously collapsed into one generic line), which is what made diagnosing the migration-era failures hard in the first place.

## Tests

- `internal/config`: key/MCP/lang import, round-trip through `Load`, BOM tolerance, skip-when-config-exists, custom-base_url warning.
- `internal/agent`: event-stream → message-log reconstruction, skip-when-dest-has-sessions, empty-log skip.
- `internal/boot`: end-to-end through the real `Build` — notice emitted, `config.toml` + `~/.env` + session `.jsonl` written.
- Verified end-to-end with the real binary against a simulated v0.x install.

Closes #2802
