### PR TITLE
fix(desktop): unblock settings/new-session mid-run, restore cost readout, blend Windows title bar

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -669,22 +669,25 @@ export default function App() {
           <div className="sidebar__brand">
             <img src={logo} alt="" className="sidebar__logo" />
             <span>Reasonix</span>
-            <button
-              className={`sidebar__toggle${sidebarExpandBlocked ? " sidebar__toggle--blocked" : ""}`}
-              onClick={sidebarExpandBlocked ? undefined : toggleSidebar}
-              aria-label={sidebarToggleTitle}
-              aria-disabled={sidebarExpandBlocked}
-            >
-              {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
-            </button>
+            <Tooltip label={sidebarToggleTitle}>
+              <button
+                className={`sidebar__toggle${sidebarExpandBlocked ? " sidebar__toggle--blocked" : ""}`}
+                onClick={sidebarExpandBlocked ? undefined : toggleSidebar}
+                aria-label={sidebarToggleTitle}
+                aria-disabled={sidebarExpandBlocked}
+              >
+                {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
+              </button>
+            </Tooltip>
           </div>
 
-          <Tooltip label={state.running ? t("common.busyHint") : t("topbar.newSession")} fill disabled={!sidebarCollapsed && !state.running}>
+          <Tooltip label={t("topbar.newSession")} fill>
             <button
               className="sidebar__new"
-              onClick={() => void startNewSession()}
-              disabled={state.running}
-              aria-label={state.running ? t("common.busyHint") : t("topbar.newSession")}
+              onClick={() => {
+                if (state.running) cancel();
+                void startNewSession();
+              }}
             >
               <SquarePen size={15} />
               <span>{t("topbar.newSession")}</span>
@@ -694,12 +697,14 @@ export default function App() {
           <section className="sidebar__section">
             <div className="sidebar__section-head">
               <div className="sidebar__section-title">{t("sidebar.conversations")}</div>
-              <button
-                className="sidebar__view-all"
-                onClick={() => void openHistory()}
-              >
-                {t("sidebar.viewAll")}
-              </button>
+              <Tooltip label={t("topbar.history")}>
+                <button
+                  className="sidebar__view-all"
+                  onClick={() => void openHistory()}
+                >
+                  {t("sidebar.viewAll")}
+                </button>
+              </Tooltip>
             </div>
             <div className="sidebar__sessions">
               {sidebarSessions.length === 0 ? (
@@ -733,7 +738,7 @@ export default function App() {
                         >
                           <MessageSquare size={14} />
                           <span className="sidebar-session__body">
-                            <span className="sidebar-session__title">{title}</span>
+                            <Tooltip className="sidebar-session__title" label={`${title}\n${session.path}`}>{title}</Tooltip>
                             <span className="sidebar-session__meta">
                               {session.current ? t("history.current") : sessionTime(sessionActivityTime(session))}
                             </span>
@@ -796,7 +801,7 @@ export default function App() {
           </section>
 
           <nav className="sidebar__nav">
-            <Tooltip label={t("topbar.history")} fill disabled={!sidebarCollapsed}>
+            <Tooltip label={t("topbar.history")} fill>
               <button
                 className="sidebar__navitem sidebar__navitem--sessions"
                 onClick={() => void openHistory()}
@@ -805,23 +810,22 @@ export default function App() {
                 <span>{t("topbar.history")}</span>
               </button>
             </Tooltip>
-            <Tooltip label={t("topbar.memory")} fill disabled={!sidebarCollapsed}>
+            <Tooltip label={t("topbar.memory")} fill>
               <button className="sidebar__navitem" onClick={() => void openMemory()}>
                 <Brain size={15} />
                 <span>{t("topbar.memory")}</span>
               </button>
             </Tooltip>
-            <Tooltip label={t("caps.title")} fill disabled={!sidebarCollapsed}>
+            <Tooltip label={t("caps.title")} fill>
               <button className="sidebar__navitem" onClick={() => setCapsOpen(true)}>
                 <Blocks size={15} />
                 <span>{t("caps.title")}</span>
               </button>
             </Tooltip>
-            <Tooltip label={state.running ? t("common.busyHint") : t("topbar.settings")} fill disabled={!sidebarCollapsed && !state.running}>
+            <Tooltip label={t("topbar.settings")} fill>
               <button
                 className="sidebar__navitem"
                 onClick={() => setSettingsOpen(true)}
-                disabled={state.running}
               >
                 <SettingsIcon size={15} />
                 <span>{t("topbar.settings")}</span>
@@ -851,13 +855,14 @@ export default function App() {
               <span className="topbar__model">{state.meta?.label ?? "…"}</span>
             </div>
             <div className="topbar__spacer" />
-            <button
-              className="chip chip--icon topbar__workspace-toggle"
-              onClick={toggleWorkspacePanel}
-              aria-label={workspacePanelOpen ? t("workspace.close") : t("workspace.open")}
-            >
-              {workspacePanelOpen ? <PanelRightClose size={13} /> : <PanelRightOpen size={13} />}
-            </button>
+            <Tooltip label={workspacePanelOpen ? t("workspace.close") : t("workspace.open")}>
+              <button
+                className="chip chip--icon topbar__workspace-toggle"
+                onClick={toggleWorkspacePanel}
+              >
+                {workspacePanelOpen ? <PanelRightClose size={13} /> : <PanelRightOpen size={13} />}
+              </button>
+            </Tooltip>
             <div className="topbar__actions">
               <Tooltip label={t("topbar.history")}>
                 <button
@@ -877,20 +882,21 @@ export default function App() {
                   <Blocks size={13} />
                 </button>
               </Tooltip>
-              <Tooltip label={state.running ? t("common.busyHint") : t("topbar.settings")}>
+              <Tooltip label={t("topbar.settings")}>
                 <button
                   className="chip chip--icon"
                   onClick={() => setSettingsOpen(true)}
-                  disabled={state.running}
                 >
                   <SettingsIcon size={13} />
                 </button>
               </Tooltip>
-              <Tooltip label={state.running ? t("common.busyHint") : t("topbar.newSession")}>
+              <Tooltip label={t("topbar.newSession")}>
                 <button
                   className="chip chip--icon"
-                  onClick={() => void startNewSession()}
-                  disabled={state.running}
+                  onClick={() => {
+                    if (state.running) cancel();
+                    void startNewSession();
+                  }}
                 >
                   <SquarePen size={13} />
                 </button>
@@ -958,6 +964,7 @@ export default function App() {
               running={state.running}
               mode={mode}
               turnStartAt={state.turnStartAt}
+              cost={state.sessionCostUsd}
 	      turnTokens={state.turnTokens}
 	      retry={state.retry}
 	      onSwitchModel={switchModel}

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Cpu, Wallet } from "lucide-react";
+import { Coins, Cpu, Wallet } from "lucide-react";
 import { EffortSwitcher } from "./EffortSwitcher";
 import { ModelSwitcher } from "./ModelSwitcher";
 import { Tooltip } from "./Tooltip";
@@ -94,6 +94,7 @@ export function StatusBar({
   mode,
   turnStartAt,
   turnTokens,
+  cost,
   retry,
   onSwitchModel,
   onSetEffort,
@@ -108,6 +109,7 @@ export function StatusBar({
   mode: Mode;
   turnStartAt: number;
   turnTokens: number;
+  cost?: number;
   retry?: { attempt: number; max: number };
   onSwitchModel: (name: string) => void;
   onSetEffort: (level: string) => void;
@@ -172,13 +174,26 @@ export function StatusBar({
           <JobsChip jobs={jobs} />
         </>
       )}
+      {typeof cost === "number" && cost > 0 && (
+        <>
+          <span className="statusbar__sep">·</span>
+          <Tooltip label={t("status.spendTitle")}>
+            <span className="statusbar__balance statusbar__cost">
+              <Coins size={11} />
+              {`¥${cost < 1 ? cost.toFixed(4) : cost.toFixed(2)}`}
+            </span>
+          </Tooltip>
+        </>
+      )}
       {balance?.available && balance.display && (
         <>
           <span className="statusbar__sep">·</span>
-          <span className="statusbar__balance">
-            <Wallet size={11} />
-            {balance.display}
-          </span>
+          <Tooltip label={t("status.balanceTitle")}>
+            <span className="statusbar__balance">
+              <Wallet size={11} />
+              {balance.display}
+            </span>
+          </Tooltip>
         </>
       )}
       <span className="statusbar__spacer" />

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -98,6 +98,10 @@ interface State {
   // frontend-observed harness state; no model cooperation needed.
   turnStartAt: number;
   turnTokens: number;
+  // sessionCostUsd is the running spend for this session — each turn's estimated
+  // cost (provider currency, despite the wire field name) summed so the status bar
+  // can show what the conversation has cost. Reset with the session.
+  sessionCostUsd: number;
   // retry drives the transient "retrying (n/m)" indicator while the provider
   // re-attempts the connection; cleared by the next stream event or turn end.
   retry?: { attempt: number; max: number };
@@ -113,6 +117,7 @@ const initialState: State = {
   jobs: [],
   turnStartAt: 0,
   turnTokens: 0,
+  sessionCostUsd: 0,
   seq: 0,
 };
 
@@ -283,7 +288,8 @@ function applyEvent(s: State, e: WireEvent): State {
       // Usage arrives once per model step; sum the output across steps for the
       // turn's running token tally.
       const turnTokens = s.turnTokens + (e.usage?.completionTokens ?? 0);
-      return { ...s, usage: e.usage, context: { ...s.context, used }, turnTokens };
+      const sessionCostUsd = s.sessionCostUsd + (e.usage?.costUsd ?? 0);
+      return { ...s, usage: e.usage, context: { ...s.context, used }, turnTokens, sessionCostUsd };
     }
 
     case "notice":

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -183,6 +183,7 @@ export const en = {
   "status.cache": "cache {pct}%",
   "status.cacheAvg": "avg {pct}%",
   "status.balanceTitle": "Wallet balance",
+  "status.spendTitle": "Spent this session",
   "status.jobs": "{n} running",
   "status.jobsTitle": "Background jobs",
   "status.yolo": "YOLO",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -184,6 +184,7 @@ export const zh: Record<DictKey, string> = {
   "status.cache": "缓存 {pct}%",
   "status.cacheAvg": "平均 {pct}%",
   "status.balanceTitle": "钱包余额",
+  "status.spendTitle": "本会话花费",
   "status.jobs": "{n} 个运行中",
   "status.jobsTitle": "后台作业",
   "status.yolo": "YOLO",

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -62,9 +62,18 @@ func main() {
 			Appearance: mac.NSAppearanceNameDarkAqua,
 		},
 		Windows: &windows.Options{
-			// Follow the OS light/dark setting; the frontend also honors
-			// prefers-color-scheme so the two stay in sync.
-			Theme: windows.SystemDefault,
+			// Paint the OS title bar with the app's dark shell colour instead of the
+			// default light caption that clashed against the dark UI on light-mode
+			// Windows (#2793). Both modes use the shell colour so it always blends.
+			Theme: windows.Dark,
+			CustomTheme: &windows.ThemeSettings{
+				DarkModeTitleBar:   windows.RGB(26, 26, 46),
+				DarkModeTitleText:  windows.RGB(228, 228, 238),
+				DarkModeBorder:     windows.RGB(26, 26, 46),
+				LightModeTitleBar:  windows.RGB(26, 26, 46),
+				LightModeTitleText: windows.RGB(228, 228, 238),
+				LightModeBorder:    windows.RGB(26, 26, 46),
+			},
 		},
 		Linux: &linux.Options{
 			ProgramName: "Reasonix",


### PR DESCRIPTION
## Why

The v1 desktop got a wave of UX complaints in #2793. This is the first, low-risk pass at the concrete regressions people actually named — not the full visual redesign (that's tracked separately).

## What

- **Settings / New session no longer hard-disabled while a turn runs.** Several users read the disabled buttons as "one window per task." Both work mid-run now; New session cancels the in-flight turn first.
- **Bottom cost readout is back.** The status bar lost the spend figure people relied on. We already compute per-turn cost on the wire (`Pricing.Cost`), so this accumulates it across the session and shows `¥…` next to the balance (resets with the session).
- **Windows title bar blends with the dark shell.** On light-mode Windows the default light caption clashed against the dark UI; it's now painted the shell colour.

## Not in this pass (follow-ups for #2793)

- Settings entry de-duplication + consistent drawer side
- Input echo latency / transcript virtualization ("typed command doesn't show", slowdown on long sessions)
- Broader alignment + visual-design pass (the agreed direction is to produce layout mocks first)

## Verification

- `tsc --noEmit` clean; `go vet ./...` clean; `wails build` succeeds; ran the built app and confirmed the title bar, the unblocked buttons, and the cost chip.

Addresses #2793 (partial).
