### PR TITLE
fix(session): keep carried conversations in one file across rebuilds

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1350,7 +1350,9 @@ func (a *App) SetModel(name string) error {
 	}
 
 	var carried []provider.Message
+	prevPath := ""
 	if ctrl != nil {
+		prevPath = ctrl.SessionPath()
 		_ = ctrl.Snapshot()
 		carried = ctrl.History()
 		ctrl.Close()
@@ -1367,12 +1369,10 @@ func (a *App) SetModel(name string) error {
 	a.mu.Unlock()
 	newCtrl.EnableInteractiveApproval()
 
-	path := ""
-	if dir := newCtrl.SessionDir(); dir != "" {
-		path = agent.NewSessionPath(dir, newCtrl.Label())
-	}
 	// Carry the prior conversation (full provider.Message log, incl. the system
-	// prompt) into the new session so history is preserved across the switch.
+	// prompt) into the new session so history is preserved across the switch, and
+	// keep it in its existing file so the switch doesn't orphan a duplicate (#2807).
+	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if len(carried) > 0 {
 		newCtrl.Resume(&agent.Session{Messages: carried}, path)
 	} else if path != "" {

--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func carryingController(carried []provider.Message, path string) *control.Controller {
+	sess := &agent.Session{}
+	sess.Replace(carried)
+	ag := agent.New(stubProvider{}, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
+	return control.New(control.Options{Executor: ag, SessionPath: path, Sink: event.Discard})
+}
+
+// TestCarriedRebuildsKeepOneSession reproduces issue #2807: a model switch or any
+// config change rebuilds the controller and carries the conversation forward. Each
+// rebuild must keep writing to the same file, so a run of them leaves exactly one
+// history entry — not a new identical duplicate per rebuild.
+func TestCarriedRebuildsKeepOneSession(t *testing.T) {
+	dir := t.TempDir()
+	path := agent.NewSessionPath(dir, "model-a")
+	ctrl := controllerWithContent(t, path)
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 5; i++ {
+		prevPath := ctrl.SessionPath()
+		carried := ctrl.History()
+		ctrl.Close()
+
+		newPath := agent.ContinueSessionPath(prevPath, dir, "model-b")
+		ctrl = carryingController(carried, newPath)
+		if err := ctrl.Snapshot(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctrl.Close()
+
+	infos, err := agent.ListSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(infos) != 1 {
+		paths := make([]string, len(infos))
+		for i, s := range infos {
+			paths[i] = filepath.Base(s.Path)
+		}
+		t.Fatalf("after 5 carried rebuilds the history shows %d sessions, want 1: %v", len(infos), paths)
+	}
+}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -184,7 +184,9 @@ func (a *App) rebuild() error {
 		return nil
 	}
 	var carried []provider.Message
+	prevPath := ""
 	if a.ctrl != nil {
+		prevPath = a.ctrl.SessionPath()
 		_ = a.ctrl.Snapshot()
 		carried = a.ctrl.History()
 		a.ctrl.Close()
@@ -209,10 +211,7 @@ func (a *App) rebuild() error {
 	a.label = ctrl.Label()
 	a.startupErr = ""
 	ctrl.EnableInteractiveApproval()
-	path := ""
-	if dir := ctrl.SessionDir(); dir != "" {
-		path = agent.NewSessionPath(dir, ctrl.Label())
-	}
+	path := agent.ContinueSessionPath(prevPath, ctrl.SessionDir(), ctrl.Label())
 	if len(carried) > 0 {
 		carried = withFreshSystemPrompt(carried, systemPromptFrom(ctrl.History()))
 		ctrl.Resume(&agent.Session{Messages: carried}, path)

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -178,6 +178,21 @@ func previewSession(path string) (string, int) {
 	return first, turns
 }
 
+// ContinueSessionPath returns where a conversation carried into a rebuilt
+// controller (model switch, config change) should keep auto-saving: its existing
+// file when it has one, so the continued session stays a single file instead of
+// the old one being orphaned as an identical duplicate (#2807). A session with no
+// file yet gets a fresh path; "" when persistence is disabled.
+func ContinueSessionPath(prevPath, dir, model string) string {
+	if prevPath != "" {
+		return prevPath
+	}
+	if dir == "" {
+		return ""
+	}
+	return NewSessionPath(dir, model)
+}
+
 // NewSessionPath returns the path to use for a fresh session, namespaced by
 // the model so the filename hints at what the conversation was with. dir is
 // typically config.SessionDir().

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -180,6 +180,27 @@ func writeBranchMeta(t *testing.T, path string, createdAt, updatedAt time.Time) 
 	}
 }
 
+func TestContinueSessionPathReusesPriorFile(t *testing.T) {
+	prev := filepath.Join("sessions", "20260602-120000.000000000-deepseek.jsonl")
+	if got := ContinueSessionPath(prev, "sessions", "other-model"); got != prev {
+		t.Fatalf("carried conversation should keep its file %q, got %q", prev, got)
+	}
+}
+
+func TestContinueSessionPathMintsFreshWhenNoPrior(t *testing.T) {
+	dir := t.TempDir()
+	got := ContinueSessionPath("", dir, "deepseek")
+	if filepath.Dir(got) != dir || !strings.HasSuffix(got, ".jsonl") {
+		t.Fatalf("fresh path = %q, want a .jsonl under %q", got, dir)
+	}
+}
+
+func TestContinueSessionPathNoPersistence(t *testing.T) {
+	if got := ContinueSessionPath("", "", "deepseek"); got != "" {
+		t.Fatalf("no session dir should disable persistence, got %q", got)
+	}
+}
+
 // TestListSessionsMissingDir returns nil + no error so callers can fall
 // through to a fresh session without special-casing.
 func TestListSessionsMissingDir(t *testing.T) {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -207,10 +207,12 @@ type chatTUI struct {
 	skills []skill.Skill
 
 	// buildController builds a fresh controller on a model ref, carrying prior
-	// history across (set by chatREPL; it must NOT touch this model — the swap
-	// happens in runModelSubcommand on the running copy). nil disables /model.
-	// modelRef is the active "provider/model" ref, marked current in the picker.
-	buildController func(ref string, carry []provider.Message) (*control.Controller, error)
+	// history across and pinning auto-save to resumePath so the continued
+	// conversation stays in one file (set by chatREPL; it must NOT touch this
+	// model — the swap happens in runModelSubcommand on the running copy). nil
+	// disables /model. modelRef is the active "provider/model" ref, marked
+	// current in the picker.
+	buildController func(ref string, carry []provider.Message, resumePath string) (*control.Controller, error)
 	modelRef        string
 	effortLevel     string // "" when the current provider/model has no configurable effort
 

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -270,7 +270,7 @@ func TestEffortCommandWritesCurrentDeepSeekProvider(t *testing.T) {
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{Label: "deepseek-flash"})
 	m.modelRef = "deepseek-flash/deepseek-v4-flash"
-	m.buildController = func(_ string, _ []provider.Message) (*control.Controller, error) {
+	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
 		return control.New(control.Options{Label: "deepseek-flash"}), nil
 	}
 
@@ -295,7 +295,7 @@ func TestEffortCommandRejectsUnsupportedProvider(t *testing.T) {
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{Label: "mimo-pro"})
 	m.modelRef = "mimo-pro/mimo-v2.5-pro"
-	m.buildController = func(_ string, _ []provider.Message) (*control.Controller, error) {
+	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
 		return control.New(control.Options{Label: "mimo-pro"}), nil
 	}
 
@@ -313,7 +313,7 @@ func TestEffortCommandAutoClearsProviderEffort(t *testing.T) {
 	m := newTestChatTUI()
 	m.ctrl = control.New(control.Options{Label: "deepseek-flash"})
 	m.modelRef = "deepseek-flash/deepseek-v4-flash"
-	m.buildController = func(_ string, _ []provider.Message) (*control.Controller, error) {
+	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
 		return control.New(control.Options{Label: "deepseek-flash"}), nil
 	}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -368,15 +368,14 @@ func chatREPL(args []string) int {
 	// model (carrying the conversation). It must NOT touch the running model —
 	// runModelSubcommand performs the swap on the live copy. The same stable sink
 	// feeds the new controller, so events keep flowing to this TUI.
-	m.buildController = func(ref string, carry []provider.Message) (*control.Controller, error) {
+	m.buildController = func(ref string, carry []provider.Message, resumePath string) (*control.Controller, error) {
 		c, err := setupQuiet(ctx, ref, *maxSteps, false, sink)
 		if err != nil {
 			return nil, err
 		}
-		path := ""
-		if dir := c.SessionDir(); dir != "" {
-			path = agent.NewSessionPath(dir, c.Label())
-		}
+		// Keep the carried conversation in its existing file so the switch doesn't
+		// orphan a duplicate (#2807).
+		path := agent.ContinueSessionPath(resumePath, c.SessionDir(), c.Label())
 		if len(carry) > 0 {
 			c.Resume(&agent.Session{Messages: carry}, path)
 		} else if path != "" {

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -79,6 +79,7 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 	}
 	m.notice(fmt.Sprintf("setting effort for %s to %s…", entry.Name, display))
 	carried := m.ctrl.History()
+	prevPath := m.ctrl.SessionPath()
 	if err := m.ctrl.Snapshot(); err != nil {
 		m.notice("effort: snapshot: " + err.Error())
 	}
@@ -86,7 +87,7 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 	build := m.buildController
 	m.modelSwitchPending = true
 	m.pendingModelSwitch = func() tea.Msg {
-		c, err := build(ref, carried)
+		c, err := build(ref, carried, prevPath)
 		if err != nil {
 			return modelSwitchMsg{ref: ref, err: err}
 		}

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -34,6 +34,7 @@ func (m *chatTUI) runModelSubcommand(input string) {
 		return
 	}
 	carried := m.ctrl.History()
+	prevPath := m.ctrl.SessionPath()
 	if err := m.ctrl.Snapshot(); err != nil {
 		slog.Warn("model switch: snapshot failed", "err", err)
 	}
@@ -51,7 +52,7 @@ func (m *chatTUI) runModelSubcommand(input string) {
 	// must happen here, before we hand the new controller back.
 	m.modelSwitchPending = true
 	m.pendingModelSwitch = func() tea.Msg {
-		c, err := build(ref, carried)
+		c, err := build(ref, carried, prevPath)
 		if err != nil {
 			return modelSwitchMsg{ref: ref, err: err}
 		}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -91,6 +91,7 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	if cur.Running() {
 		return fmt.Errorf("cannot switch model while a turn is running")
 	}
+	prevPath := cur.SessionPath()
 	if err := cur.Snapshot(); err != nil {
 		slog.Warn("serve: snapshot before model switch", "err", err)
 	}
@@ -104,10 +105,9 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	if err != nil {
 		return fmt.Errorf("switch model: %w", err)
 	}
-	newPath := ""
-	if dir := newCtrl.SessionDir(); dir != "" {
-		newPath = agent.NewSessionPath(dir, newCtrl.Label())
-	}
+	// Keep the carried conversation in its existing file so the switch doesn't
+	// orphan a duplicate (#2807).
+	newPath := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())
 	if len(carried) > 0 {
 		newCtrl.Resume(&agent.Session{Messages: carried}, newPath)
 	} else if newPath != "" {


### PR DESCRIPTION
## Problem

Session history fills with **identical duplicate conversations** (issue #2807). The user deletes them, restarts, and after a while more copies reappear — same content, no deliberate action.

## Root cause

Every controller rebuild that **carries the conversation forward** — a model switch, `/effort` change, or any config-driven rebuild (provider/skill/MCP/permission edits, key connect) — re-pinned auto-save to a freshly minted `agent.NewSessionPath(...)` while the previous file stayed on disk. The continued conversation is one logical thread, but each rebuild wrote it to a new file and orphaned the old one as an exact copy. Frequent (and often invisible) settings rebuilds therefore pile up duplicates.

The same flaw was duplicated across all four frontends: desktop `SetModel` + `rebuild`, serve `switchModel`, and CLI `/model` + `/effort`.

## Fix

Add one tested helper, `agent.ContinueSessionPath(prevPath, dir, model)`: a carried conversation keeps its existing file; only a session with no file yet gets a fresh path. All four carry-forward sites now route through it, capturing the prior `SessionPath()` before tearing down the old controller. Paths that intentionally start a fresh session (boot, new chat, workspace switch) are unchanged.

## Tests

- `internal/agent`: unit tests for the helper (reuse prior file / mint fresh / persistence disabled).
- `desktop`: end-to-end regression — 5 consecutive carried rebuilds must leave exactly **one** history entry. Reverting the fix makes it report 6, reproducing the bug.

`go build`, `go vet`, `gofmt`, and the affected package tests pass on both the root and desktop modules.
