### PR TITLE
fix(net): route built-in CN providers direct in auto/env proxy modes (#2803)

### DIFF
--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -143,10 +144,40 @@ func proxyFunc(spec ProxySpec) (func(*http.Request) (*url.URL, error), error) {
 		pf := cfg.ProxyFunc()
 		return func(req *http.Request) (*url.URL, error) { return pf(req.URL) }, nil
 	case ModeEnv:
-		return environmentProxyFunc(), nil
+		return withCNProviderDirect(environmentProxyFunc()), nil
 	default:
-		return autoProxyFunc(), nil
+		return withCNProviderDirect(autoProxyFunc()), nil
 	}
+}
+
+// withCNProviderDirect routes the built-in China-only provider endpoints straight
+// to origin in the automatic proxy modes. Clash/v2ray-style proxies route these
+// CN hosts through a foreign exit the origin resets mid-TLS (SSL_ERROR_SYSCALL,
+// #2803); the env/system proxy still applies to every other host. Opt out with
+// REASONIX_PROXY_CN_DIRECT=0 when egress is only reachable via the proxy.
+func withCNProviderDirect(pf func(*http.Request) (*url.URL, error)) func(*http.Request) (*url.URL, error) {
+	if !cnProviderDirectEnabled() {
+		return pf
+	}
+	return func(req *http.Request) (*url.URL, error) {
+		if builtinCNProviderHost(req.URL.Hostname()) {
+			return nil, nil
+		}
+		return pf(req)
+	}
+}
+
+func cnProviderDirectEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("REASONIX_PROXY_CN_DIRECT"))) {
+	case "0", "false", "no", "off":
+		return false
+	}
+	return true
+}
+
+func builtinCNProviderHost(host string) bool {
+	host = strings.ToLower(host)
+	return host == "xiaomimimo.com" || strings.HasSuffix(host, ".xiaomimimo.com")
 }
 
 func environmentProxyFunc() func(*http.Request) (*url.URL, error) {

--- a/internal/netclient/netclient_test.go
+++ b/internal/netclient/netclient_test.go
@@ -59,6 +59,49 @@ func TestCustomProxyHonorsNoProxy(t *testing.T) {
 	}
 }
 
+func TestAutoModeRoutesCNProviderDirect(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("REASONIX_PROXY_CN_DIRECT", "")
+	pf, err := proxyFunc(ProxySpec{Mode: "auto"})
+	if err != nil {
+		t.Fatalf("proxyFunc: %v", err)
+	}
+
+	got, err := pf(&http.Request{URL: mustURL("https://token-plan-cn.xiaomimimo.com/v1/chat")})
+	if err != nil {
+		t.Fatalf("mimo lookup: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("MiMo (CN-only) should bypass the proxy in auto mode, got %s", got)
+	}
+
+	other, err := pf(&http.Request{URL: mustURL("https://example.com/x")})
+	if err != nil {
+		t.Fatalf("other lookup: %v", err)
+	}
+	if other == nil || other.Host != "proxy.example.com:8080" {
+		t.Fatalf("non-CN host should still use the env proxy, got %v", other)
+	}
+}
+
+func TestCNProviderDirectOptOut(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("REASONIX_PROXY_CN_DIRECT", "0")
+	pf, err := proxyFunc(ProxySpec{Mode: "env"})
+	if err != nil {
+		t.Fatalf("proxyFunc: %v", err)
+	}
+	got, err := pf(&http.Request{URL: mustURL("https://token-plan-cn.xiaomimimo.com/v1/chat")})
+	if err != nil {
+		t.Fatalf("mimo lookup: %v", err)
+	}
+	if got == nil || got.Host != "proxy.example.com:8080" {
+		t.Fatalf("opt-out should send MiMo through the proxy, got %v", got)
+	}
+}
+
 func TestOffProxyDisablesProxy(t *testing.T) {
 	pf, err := proxyFunc(ProxySpec{Mode: "off"})
 	if err != nil {


### PR DESCRIPTION
## Why

With `proxy_mode=auto` and a system HTTPS proxy (Clash), connecting to MiMo (`token-plan-cn.xiaomimimo.com`) fails the TLS handshake with `SSL_ERROR_SYSCALL`, while DeepSeek works through the same proxy (#2803). The reporter confirmed plain `curl` through the proxy fails the same way and direct works — so the proxy routes this CN-only endpoint through a foreign exit the origin resets; it is the proxy path, not our HTTP client.

The automatic proxy modes (`auto`/`env`) had no built-in direct list — every host went through whatever the env/system proxy said.

## What

Route the built-in China-only provider hosts (`*.xiaomimimo.com`) straight to origin in `auto`/`env` modes. Every other host still honors the env/system proxy, and `custom`/`off` are untouched (the user controls routing there).

Escape hatch: `REASONIX_PROXY_CN_DIRECT=0` forces them back through the proxy, for networks where egress is only reachable via the proxy.

## Tests

- auto mode routes MiMo direct despite `HTTPS_PROXY` set, while a normal host still uses the proxy
- `REASONIX_PROXY_CN_DIRECT=0` sends MiMo back through the proxy
- `go test ./internal/netclient`, gofmt, vet clean

Closes #2803