### PR TITLE
fix(desktop): list the whole directory level in the @ file menu

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -241,7 +241,7 @@ export function Composer({
     // re-fetch only when the menu opens or the directory level changes
   }, [atRaw === null, atDir]);
   const atMatches = useMemo(
-    () => (atRaw === null ? [] : entries.filter((e) => e.name.toLowerCase().includes(atFrag)).slice(0, 10)),
+    () => (atRaw === null ? [] : entries.filter((e) => e.name.toLowerCase().includes(atFrag))),
     [atRaw, atFrag, entries],
   );
 


### PR DESCRIPTION
Fixes #2800 — the `@` file-reference menu listed an incomplete set of directories/files.

**Cause:** `Composer.tsx` capped the matched entries with a fixed `.slice()`, so a directory with more entries than the cap was truncated (the reporter's project had ~25 entries at the top level; the menu stopped at `controller/`).

**Fix:** drop the cap entirely. A fixed cap just moves the same bug to a larger directory. `ListDir` returns one level (never recursive) and `FileMenu` already scrolls in a 280px container, so the full level lists and scrolls.

Verified `tsc --noEmit` passes.

Closes #2800