### PR TITLE
refactor(net): data-driven proxy-direct hosts (supersede MiMo hardcode)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -140,15 +141,37 @@ type NetworkProxyConfig struct {
 // NetworkProxySpec returns the expanded proxy settings used by netclient.
 func (c *Config) NetworkProxySpec() netclient.ProxySpec {
 	return netclient.ProxySpec{
-		Mode:     c.Network.ProxyMode,
-		URL:      ExpandVars(c.Network.ProxyURL),
-		NoProxy:  ExpandVars(c.Network.NoProxy),
-		Type:     c.Network.Proxy.Type,
-		Server:   ExpandVars(c.Network.Proxy.Server),
-		Port:     c.Network.Proxy.Port,
-		Username: ExpandVars(c.Network.Proxy.Username),
-		Password: ExpandVars(c.Network.Proxy.Password),
+		Mode:        c.Network.ProxyMode,
+		URL:         ExpandVars(c.Network.ProxyURL),
+		NoProxy:     ExpandVars(c.Network.NoProxy),
+		Type:        c.Network.Proxy.Type,
+		Server:      ExpandVars(c.Network.Proxy.Server),
+		Port:        c.Network.Proxy.Port,
+		Username:    ExpandVars(c.Network.Proxy.Username),
+		Password:    ExpandVars(c.Network.Proxy.Password),
+		DirectHosts: c.directProxyHosts(),
 	}
+}
+
+// directProxyHosts collects the base_url hosts of providers marked no_proxy, so
+// netclient bypasses the proxy for them without knowing any provider by name.
+func (c *Config) directProxyHosts() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, p := range c.Providers {
+		if !p.NoProxy {
+			continue
+		}
+		u, err := url.Parse(strings.TrimSpace(p.BaseURL))
+		if err != nil {
+			continue
+		}
+		if h := u.Hostname(); h != "" && !seen[h] {
+			seen[h] = true
+			out = append(out, h)
+		}
+	}
+	return out
 }
 
 // NetworkProxyMode normalizes network.proxy_mode to a known value.
@@ -277,6 +300,9 @@ type ProviderEntry struct {
 	// Empty = provider default.
 	Thinking string `toml:"thinking"`
 	Effort   string `toml:"effort"`
+	// NoProxy reaches this provider's base_url directly, never through the proxy.
+	// For China-only endpoints a foreign-exit proxy resets the TLS handshake (#2803).
+	NoProxy bool `toml:"no_proxy"`
 }
 
 // ModelList returns the models this provider exposes: the explicit `models` list,
@@ -457,8 +483,8 @@ func Default() *Config {
 		Providers: []ProviderEntry{
 			{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
 			{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
-			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
-			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
+			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}, NoProxy: true},
+			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}, NoProxy: true},
 		},
 	}
 }

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -1,0 +1,19 @@
+package config
+
+import "testing"
+
+func TestDirectProxyHostsFromNoProxyProviders(t *testing.T) {
+	spec := Default().NetworkProxySpec()
+	hasMimo := false
+	for _, h := range spec.DirectHosts {
+		if h == "token-plan-cn.xiaomimimo.com" {
+			hasMimo = true
+		}
+		if h == "api.deepseek.com" {
+			t.Errorf("DeepSeek works through the proxy and must not be forced direct: %v", spec.DirectHosts)
+		}
+	}
+	if !hasMimo {
+		t.Errorf("a no_proxy provider's host should land in DirectHosts, got %v", spec.DirectHosts)
+	}
+}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -150,6 +150,9 @@ func RenderTOML(c *Config) string {
 		if p.Effort != "" {
 			fmt.Fprintf(&b, "effort      = %q\n", p.Effort)
 		}
+		if p.NoProxy {
+			b.WriteString("no_proxy    = true   # reach this base_url directly, never via the proxy\n")
+		}
 		b.WriteString("\n")
 	}
 

--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,16 +26,18 @@ const (
 
 // ProxySpec is the resolved proxy configuration used by network clients. URL is
 // an advanced override; otherwise Type/Server/Port/Credentials are composed into a
-// proxy URL. NoProxy is honored for custom proxies.
+// proxy URL. NoProxy is honored for custom proxies. DirectHosts always bypass the
+// proxy in every mode (the caller derives them, e.g. from no_proxy providers).
 type ProxySpec struct {
-	Mode     string
-	URL      string
-	NoProxy  string
-	Type     string
-	Server   string
-	Port     int
-	Username string
-	Password string
+	Mode        string
+	URL         string
+	NoProxy     string
+	Type        string
+	Server      string
+	Port        int
+	Username    string
+	Password    string
+	DirectHosts []string
 }
 
 // TransportOptions lets callers keep their existing network timeouts while
@@ -128,6 +129,14 @@ func defaultTransport() *http.Transport {
 }
 
 func proxyFunc(spec ProxySpec) (func(*http.Request) (*url.URL, error), error) {
+	base, err := baseProxyFunc(spec)
+	if err != nil {
+		return nil, err
+	}
+	return withDirectHosts(base, spec.DirectHosts), nil
+}
+
+func baseProxyFunc(spec ProxySpec) (func(*http.Request) (*url.URL, error), error) {
 	switch NormalizeMode(spec.Mode) {
 	case ModeOff:
 		return nil, nil
@@ -144,40 +153,35 @@ func proxyFunc(spec ProxySpec) (func(*http.Request) (*url.URL, error), error) {
 		pf := cfg.ProxyFunc()
 		return func(req *http.Request) (*url.URL, error) { return pf(req.URL) }, nil
 	case ModeEnv:
-		return withCNProviderDirect(environmentProxyFunc()), nil
+		return environmentProxyFunc(), nil
 	default:
-		return withCNProviderDirect(autoProxyFunc()), nil
+		return autoProxyFunc(), nil
 	}
 }
 
-// withCNProviderDirect routes the built-in China-only provider endpoints straight
-// to origin in the automatic proxy modes. Clash/v2ray-style proxies route these
-// CN hosts through a foreign exit the origin resets mid-TLS (SSL_ERROR_SYSCALL,
-// #2803); the env/system proxy still applies to every other host. Opt out with
-// REASONIX_PROXY_CN_DIRECT=0 when egress is only reachable via the proxy.
-func withCNProviderDirect(pf func(*http.Request) (*url.URL, error)) func(*http.Request) (*url.URL, error) {
-	if !cnProviderDirectEnabled() {
+// withDirectHosts makes the listed hosts (and their subdomains) bypass the proxy
+// in every mode. The caller decides which hosts are direct — netclient stays
+// provider-agnostic. A China-only endpoint reached through a foreign-exit proxy
+// resets the TLS handshake (SSL_ERROR_SYSCALL, #2803), so its provider marks it.
+func withDirectHosts(pf func(*http.Request) (*url.URL, error), hosts []string) func(*http.Request) (*url.URL, error) {
+	if pf == nil || len(hosts) == 0 {
 		return pf
 	}
+	norm := make([]string, 0, len(hosts))
+	for _, h := range hosts {
+		if h = strings.ToLower(strings.TrimSpace(h)); h != "" {
+			norm = append(norm, h)
+		}
+	}
 	return func(req *http.Request) (*url.URL, error) {
-		if builtinCNProviderHost(req.URL.Hostname()) {
-			return nil, nil
+		host := strings.ToLower(req.URL.Hostname())
+		for _, h := range norm {
+			if host == h || strings.HasSuffix(host, "."+h) {
+				return nil, nil
+			}
 		}
 		return pf(req)
 	}
-}
-
-func cnProviderDirectEnabled() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("REASONIX_PROXY_CN_DIRECT"))) {
-	case "0", "false", "no", "off":
-		return false
-	}
-	return true
-}
-
-func builtinCNProviderHost(host string) bool {
-	host = strings.ToLower(host)
-	return host == "xiaomimimo.com" || strings.HasSuffix(host, ".xiaomimimo.com")
 }
 
 func environmentProxyFunc() func(*http.Request) (*url.URL, error) {

--- a/internal/netclient/netclient_test.go
+++ b/internal/netclient/netclient_test.go
@@ -59,21 +59,20 @@ func TestCustomProxyHonorsNoProxy(t *testing.T) {
 	}
 }
 
-func TestAutoModeRoutesCNProviderDirect(t *testing.T) {
+func TestDirectHostsBypassProxy(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
 	t.Setenv("NO_PROXY", "")
-	t.Setenv("REASONIX_PROXY_CN_DIRECT", "")
-	pf, err := proxyFunc(ProxySpec{Mode: "auto"})
+	pf, err := proxyFunc(ProxySpec{Mode: "auto", DirectHosts: []string{"token-plan-cn.xiaomimimo.com"}})
 	if err != nil {
 		t.Fatalf("proxyFunc: %v", err)
 	}
 
 	got, err := pf(&http.Request{URL: mustURL("https://token-plan-cn.xiaomimimo.com/v1/chat")})
 	if err != nil {
-		t.Fatalf("mimo lookup: %v", err)
+		t.Fatalf("direct-host lookup: %v", err)
 	}
 	if got != nil {
-		t.Fatalf("MiMo (CN-only) should bypass the proxy in auto mode, got %s", got)
+		t.Fatalf("a direct host should bypass the proxy, got %s", got)
 	}
 
 	other, err := pf(&http.Request{URL: mustURL("https://example.com/x")})
@@ -81,24 +80,23 @@ func TestAutoModeRoutesCNProviderDirect(t *testing.T) {
 		t.Fatalf("other lookup: %v", err)
 	}
 	if other == nil || other.Host != "proxy.example.com:8080" {
-		t.Fatalf("non-CN host should still use the env proxy, got %v", other)
+		t.Fatalf("non-direct host should still use the env proxy, got %v", other)
 	}
 }
 
-func TestCNProviderDirectOptOut(t *testing.T) {
+func TestNoDirectHostsKeepsEveryoneProxied(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
 	t.Setenv("NO_PROXY", "")
-	t.Setenv("REASONIX_PROXY_CN_DIRECT", "0")
-	pf, err := proxyFunc(ProxySpec{Mode: "env"})
+	pf, err := proxyFunc(ProxySpec{Mode: "env"}) // no DirectHosts → nothing special-cased
 	if err != nil {
 		t.Fatalf("proxyFunc: %v", err)
 	}
 	got, err := pf(&http.Request{URL: mustURL("https://token-plan-cn.xiaomimimo.com/v1/chat")})
 	if err != nil {
-		t.Fatalf("mimo lookup: %v", err)
+		t.Fatalf("lookup: %v", err)
 	}
 	if got == nil || got.Host != "proxy.example.com:8080" {
-		t.Fatalf("opt-out should send MiMo through the proxy, got %v", got)
+		t.Fatalf("without DirectHosts the host must go through the proxy, got %v", got)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #2821.

#2821 fixed #2803 by hardcoding `xiaomimimo.com` inside `netclient` — but special-casing one provider's domain in the transport layer doesn't generalize (breaks if MiMo changes domains or another CN provider is added) and leaks provider knowledge into a generic component.

## Better approach — data-driven

- Providers carry a `no_proxy` flag (`[[providers]]`).
- `config` derives the direct-host set from the `base_url` of every `no_proxy` provider and passes it to netclient as `ProxySpec.DirectHosts`.
- `netclient` bypasses those hosts in all proxy modes and knows nothing about any provider.
- The built-in MiMo entries set `no_proxy = true`; users can flag their own CN endpoints the same way, and the direct host follows the `base_url` automatically.

Drops the `REASONIX_PROXY_CN_DIRECT` env hatch from #2821 — opting out is now `no_proxy = false` on the provider.

## Tests

- netclient: `DirectHosts` bypass + non-direct host still proxied; no `DirectHosts` → everyone proxied (proves no hardcoding).
- config: `Default().NetworkProxySpec().DirectHosts` contains MiMo's host and **not** DeepSeek's.
- build / gofmt / vet clean.