### PR TITLE
fix(desktop): show skills/custom/MCP in the slash picker (#2815)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -960,6 +960,7 @@ export default function App() {
               onPickFolder={switchFolder}
               insertRequest={composerInsertRequest}
               disabled={state.meta?.ready === false || state.approval != null || state.ask != null}
+              ready={state.meta?.ready === true}
             />
             <StatusBar
               meta={state.meta}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -103,6 +103,7 @@ export function Composer({
   onPickFolder,
   insertRequest,
   disabled,
+  ready,
 }: {
   running: boolean;
   mode: Mode;
@@ -115,6 +116,10 @@ export function Composer({
   onPickFolder: (path?: string) => Promise<string>;
   insertRequest?: ComposerInsertRequest | null;
   disabled?: boolean;
+  // ready/cwd re-trigger the command fetch: Commands() returns only built-ins
+  // until boot.Build finishes (the controller, hence skills/custom/MCP, is nil
+  // before then), and the available set changes when the workspace switches.
+  ready?: boolean;
 }) {
   const t = useT();
   const [text, setText] = useState("");
@@ -156,7 +161,7 @@ export function Composer({
   const [commands, setCommands] = useState<CommandInfo[]>([]);
   useEffect(() => {
     app.Commands().then(setCommands).catch(() => {});
-  }, []);
+  }, [ready, cwd]);
 
   const slashQuery = useMemo(() => {
     if (!text.startsWith("/") || /\s/.test(text)) return null;
@@ -241,7 +246,7 @@ export function Composer({
     // re-fetch only when the menu opens or the directory level changes
   }, [atRaw === null, atDir]);
   const atMatches = useMemo(
-    () => (atRaw === null ? [] : entries.filter((e) => e.name.toLowerCase().includes(atFrag))),
+    () => (atRaw === null ? [] : entries.filter((e) => e.name.toLowerCase().includes(atFrag)).slice(0, 10)),
     [atRaw, atFrag, entries],
   );
 
@@ -775,9 +780,11 @@ export function Composer({
                       <Eye size={14} />
                     </button>
                   </Tooltip>
-                  <button type="button" onClick={() => expandPastedBlock(block)}>
-                    {t("composer.pastedExpand")}
-                  </button>
+                  <Tooltip label={t("composer.pastedExpand")}>
+                    <button type="button" onClick={() => expandPastedBlock(block)}>
+                      {t("composer.pastedExpand")}
+                    </button>
+                  </Tooltip>
                   <Tooltip label={t("composer.pastedRemove")}>
                     <button type="button" onClick={() => removePastedBlock(block)}>
                       <Trash2 size={14} />
@@ -865,14 +872,16 @@ export function Composer({
               </Tooltip>
             </div>
           )}
-          <button
-            className={`composer__mode composer__mode--${mode}`}
-            onClick={onCycleMode}
-          >
-            <span className="composer__mode-dot" />
-            {mode === "yolo" ? t("composer.modeYolo") : mode === "plan" ? t("composer.modePlan") : t("composer.modeNormal")}
-            <span className="composer__mode-hint">{t("composer.modeHint")}</span>
-          </button>
+          <Tooltip label={t("composer.modeTitle")}>
+            <button
+              className={`composer__mode composer__mode--${mode}`}
+              onClick={onCycleMode}
+            >
+              <span className="composer__mode-dot" />
+              {mode === "yolo" ? t("composer.modeYolo") : mode === "plan" ? t("composer.modePlan") : t("composer.modeNormal")}
+              <span className="composer__mode-hint">{t("composer.modeHint")}</span>
+            </button>
+          </Tooltip>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Why

In the desktop app, typing `/` only listed the built-in verbs — installed skills (`/init`, `/explore`, a user's `/frontend-design`, …), custom commands and MCP prompts never appeared, and a typed `/<skill>` couldn't match (#2815). The CLI works because its picker reads the resolved command set.

## Root cause

`Composer` fetched `app.Commands()` once on mount with empty deps. The desktop boots the controller asynchronously (the webview paints immediately, `boot.Build` runs in the background), so at mount `a.ctrl` is nil and `Commands()` hits the `if ctrl == nil { return out }` early-return — only the 9 built-ins, never re-fetched.

## Fix

Re-fetch `Commands()` when readiness flips and when the workspace changes (a new `ready` prop, plus `cwd` which populates on ready and changes on switch). Skills/custom/MCP now appear in the picker as soon as boot finishes.

Closes #2815