### PR TITLE
feat(cli): add a --dir flag to run and chat

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -141,14 +141,32 @@ func setupQuiet(ctx context.Context, modelName string, maxStepsOverride int, req
 	})
 }
 
+// chdirTo honours --dir: it switches the working directory before anything reads
+// it, so config discovery, the sandbox root, and file tools all resolve from the
+// chosen project root. Returns 2 (already reported) on failure, 0 otherwise.
+func chdirTo(dir string) int {
+	if dir == "" {
+		return 0
+	}
+	if err := os.Chdir(dir); err != nil {
+		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+		return 2
+	}
+	return 0
+}
+
 func runAgent(args []string) int {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	model := fs.String("model", "", "provider name (default: config default_model)")
 	maxSteps := fs.Int("max-steps", 0, "max tool-call rounds (0 = use config/default)")
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
 	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
+	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	if rc := chdirTo(*dir); rc != 0 {
+		return rc
 	}
 	configureCLIThemeFromConfigForTTYOutput()
 
@@ -261,8 +279,12 @@ func chatREPL(args []string) int {
 	resume := fs.Bool("resume", false, "list saved sessions and pick one to resume")
 	yolo := fs.Bool("dangerously-skip-permissions", false, "YOLO: auto-approve every tool call this session (deny rules still apply)")
 	fs.BoolVar(yolo, "yolo", false, "alias for --dangerously-skip-permissions")
+	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
 	if err := fs.Parse(args); err != nil {
 		return 2
+	}
+	if rc := chdirTo(*dir); rc != 0 {
+		return rc
 	}
 	if cfg, err := config.Load(); err == nil {
 		configureCLIThemeWithStyle(cfg.UITheme(), cfg.UIThemeStyle())

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -12,6 +12,46 @@ import (
 	"reasonix/internal/config"
 )
 
+func TestChdirTo(t *testing.T) {
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if rc := chdirTo(""); rc != 0 {
+		t.Fatalf(`chdirTo("") = %d, want 0`, rc)
+	}
+	if cwd, _ := os.Getwd(); cwd != orig {
+		t.Fatalf(`chdirTo("") moved cwd to %q`, cwd)
+	}
+
+	tmp := t.TempDir()
+	// Restore CWD before TempDir's RemoveAll runs (LIFO ordering): Windows can't
+	// delete a directory that is still the process working directory.
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if rc := chdirTo(tmp); rc != 0 {
+		t.Fatalf("chdirTo(tmp) = %d, want 0", rc)
+	}
+	got, _ := filepath.EvalSymlinks(mustGetwd(t))
+	want, _ := filepath.EvalSymlinks(tmp)
+	if got != want {
+		t.Fatalf("cwd = %q, want %q", got, want)
+	}
+
+	if rc := chdirTo(filepath.Join(tmp, "does-not-exist")); rc != 2 {
+		t.Fatalf("chdirTo(missing) = %d, want 2", rc)
+	}
+}
+
+func mustGetwd(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cwd
+}
+
 func TestMetadataCommandsDoNotProbeTerminalTheme(t *testing.T) {
 	defer func(prev func() (terminalRGB, bool)) {
 		queryTerminalBackgroundForTheme = prev


### PR DESCRIPTION
Addresses the CLI part of #2795.

`reasonix run` / `reasonix chat` (alias `code`) only worked on the process cwd — a user trying `reasonix code --dir <path>` hit an unknown-flag error because `--dir` didn't exist. Add it to both commands: it `os.Chdir`s right after flag parsing, before anything reads the cwd, so **config discovery, the sandbox root, and file tools all resolve from the chosen project root**.

`chdirTo` returns a clean exit code 2 (with a message) on a bad path. Unit-tested (empty = no-op, valid dir, missing dir).

**On the other two parts of #2795 (not changed here):**
- *MCP config format* — the README is already correct: `mcpServers` JSON goes in a project-root `.mcp.json` (maps field-for-field onto `[[plugins]]`); `reasonix.toml` uses `[[plugins]]`. The `mcp[]` the reporter saw is the TOML array, not a bug.
- *Desktop/CLI MCP not in sync* — both chdir + `boot.Build` the same config, and the desktop rebuilds its controller (and MCP host) on workspace switch, so this looks like a *configured-vs-connected* display difference rather than a config mismatch. Needs a concrete repro to pin down.