### PR TITLE
feat(agent): skip the planner pass for non-work turns in two-model mode

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -33,13 +33,17 @@ type Coordinator struct {
 	executor       *Agent
 	temperature    float64
 	sink           event.Sink
+	// shouldPlan gates the planner pass per turn; nil plans every turn. Lets a
+	// trivial, non-work turn (a question, a greeting) skip straight to the
+	// executor instead of paying a planner round on it.
+	shouldPlan func(string) bool
 }
 
 // NewCoordinator wires a planner provider (with its own session) to an executor.
 // sink receives the planner's phase/text/usage events; the executor emits its
 // own events to its own sink (the CLI wires the same sink into both). A nil
 // sink is replaced with event.Discard.
-func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerPricing *provider.Pricing, executor *Agent, temperature float64, sink event.Sink) *Coordinator {
+func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerPricing *provider.Pricing, executor *Agent, temperature float64, sink event.Sink, shouldPlan func(string) bool) *Coordinator {
 	if nilutil.IsNil(sink) {
 		sink = event.Discard
 	}
@@ -50,12 +54,17 @@ func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerP
 		executor:       executor,
 		temperature:    temperature,
 		sink:           sink,
+		shouldPlan:     shouldPlan,
 	}
 }
 
 // Run plans with the planner model, then hands the plan to the executor.
 func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})
+	if c.shouldPlan != nil && !c.shouldPlan(input) {
+		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
+		return c.executor.Run(ctx, input)
+	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.planner.Name() + " · planning"})
 	plan, err := c.plan(ctx, input)
 	if err != nil {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -52,7 +52,7 @@ func TestCoordinatorHandsPlanToExecutor(t *testing.T) {
 
 	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
 	plannerSess := NewSession("planner-sys")
-	coord := NewCoordinator(planner, plannerSess, nil, executor, 0, event.Discard)
+	coord := NewCoordinator(planner, plannerSess, nil, executor, 0, event.Discard, nil)
 
 	if err := coord.Run(context.Background(), "fix the bug"); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -68,5 +68,34 @@ func TestCoordinatorHandsPlanToExecutor(t *testing.T) {
 	// prefix grows prepend-only and stays cache-stable.
 	if n := len(plannerSess.Messages); n != 3 {
 		t.Errorf("planner session has %d messages, want 3", n)
+	}
+}
+
+// TestCoordinatorSkipsPlannerForTrivialTurn checks the gate: when shouldPlan
+// rejects the turn, the planner is never called and the executor gets the raw
+// input (no plan handoff).
+func TestCoordinatorSkipsPlannerForTrivialTurn(t *testing.T) {
+	planner := &mockProvider{name: "planner"}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "It does X."},
+		{Type: provider.ChunkDone},
+	}}
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	plannerSess := NewSession("planner-sys")
+	coord := NewCoordinator(planner, plannerSess, nil, executor, 0, event.Discard, func(string) bool { return false })
+
+	if err := coord.Run(context.Background(), "what does this function do?"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if planner.lastReq.Messages != nil {
+		t.Error("planner should not be called for a skipped turn")
+	}
+	if got := lastUser(exec.lastReq); got != "what does this function do?" {
+		t.Errorf("executor saw %q, want the raw input with no plan handoff", got)
+	}
+	if n := len(plannerSess.Messages); n != 1 { // just the system message
+		t.Errorf("planner session has %d messages, want 1 (untouched)", n)
 	}
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -452,7 +452,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				return nil, fmt.Errorf("planner %q: %w", pm, err)
 			}
 			plannerSess := agent.NewSession(agent.DefaultPlannerPrompt)
-			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, executor, cfg.Agent.Temperature, sink)
+			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, executor, cfg.Agent.Temperature, sink, control.TaskWarrantsPlanner)
 			label = entry.Model + " + planner " + pe.Model
 		}
 	}

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -166,7 +166,7 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 				return nil, fmt.Errorf("planner %q: %w", pm, err)
 			}
 			plannerSess := agent.NewSession(agent.DefaultPlannerPrompt)
-			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, executor, cfg.Agent.Temperature, p.Sink)
+			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, executor, cfg.Agent.Temperature, p.Sink, control.TaskWarrantsPlanner)
 			label = entry.Model + " + planner " + pe.Model
 		}
 	}

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -71,6 +71,18 @@ func (c *Controller) shouldAutoPlan(ctx context.Context, input string) bool {
 	return score >= 2
 }
 
+// TaskWarrantsPlanner reports whether a task turn is worth a planner pass in
+// two-model mode. Empty input, slash commands, and low-risk informational asks
+// (explain / show / what / why / 解释 / 查一下 …) skip straight to the executor;
+// anything that reads like a work request — even a terse one — still gets planned.
+func TaskWarrantsPlanner(input string) bool {
+	text := strings.TrimSpace(input)
+	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {
+		return false
+	}
+	return !isLowRiskQuestion(strings.ToLower(text))
+}
+
 func autoPlanScore(input string) int {
 	text := strings.TrimSpace(input)
 	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {

--- a/internal/control/auto_plan_test.go
+++ b/internal/control/auto_plan_test.go
@@ -1,0 +1,25 @@
+package control
+
+import "testing"
+
+func TestTaskWarrantsPlanner(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{"", false},
+		{"   ", false},
+		{"/init", false},
+		{"what does this function do?", false}, // low-risk question → executor only
+		{"why did the test fail", false},
+		{"解释一下这段代码", false},
+		{"fix the bug", true},        // terse, but a work request → still planned
+		{"add a login button", true}, // ditto
+		{"implement the new caching layer across the backend", true},
+	}
+	for _, c := range cases {
+		if got := TaskWarrantsPlanner(c.input); got != c.want {
+			t.Errorf("TaskWarrantsPlanner(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Context

A user with `agent.planner_model` configured (two-model collaboration) asked why the planner model responds on **every** turn before the executor — including plain questions and chatter. That was by design (the Coordinator planned unconditionally), but it wastes a planner round on turns that don't need one.

## Change

Gate the planner per turn on whether the input looks like real work:

- **Skip → executor only:** empty input, slash commands, and low-risk informational asks (`what/why/how/show`, `解释/查一下/说明` …).
- **Still planned:** anything that reads like a work request, even terse (`fix the bug`, `add a login button`).

Reuses the existing `auto_plan` low-risk-question heuristic (exported as `control.TaskWarrantsPlanner`) so the judgment matches plan mode. The gate is injected into the `Coordinator`; a `nil` gate preserves the always-plan behavior (tests).

## Tests

- `control.TaskWarrantsPlanner`: questions/slash/empty → false; work requests → true.
- Coordinator: skipped turn never calls the planner and hands the executor the raw input (no plan handoff); the always-plan path unchanged.
- build / gofmt / vet clean across control, agent, boot, cli.