### PR TITLE
fix(agent): echo tool schema on invalid-JSON tool args

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -858,7 +858,15 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		a.hooks.PostToolUse(ctx, call.Name, json.RawMessage(call.Arguments), result)
 	}
 	if err != nil {
-		body, truncMsg := truncateToolOutput(fmt.Sprintf("error: %v\n%s", err, result))
+		detail := result
+		// Malformed-args failures are a transient model JSON glitch (e.g. options
+		// written as ["a":"b"] → "invalid character ':' after array element"). The
+		// args can't be safely re-parsed, but echoing the tool's schema makes the
+		// retry land valid instead of repeating the same broken shape.
+		if !json.Valid([]byte(call.Arguments)) {
+			detail = strings.TrimRight(detail, "\n") + "\nThe arguments were not valid JSON. Re-emit them exactly per this schema:\n" + string(t.Schema())
+		}
+		body, truncMsg := truncateToolOutput(fmt.Sprintf("error: %v\n%s", err, detail))
 		return toolOutcome{output: body, errMsg: firstLine(err.Error()), truncated: truncMsg != "", truncMsg: truncMsg}
 	}
 	// A foreground `task` sub-agent just finished — its result is the final answer.

--- a/internal/agent/argserror_test.go
+++ b/internal/agent/argserror_test.go
@@ -1,0 +1,54 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// A model that emits structurally-invalid JSON for a tool's args should get the
+// tool's schema echoed back, so the retry lands a valid shape instead of
+// repeating the same broken one (the "invalid character ':' after array element"
+// case from the ask tool).
+func TestMalformedToolArgsEchoSchema(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(NewAskTool())
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "ask", `{"questions":["q":1]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "ask me"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := toolResult(a.session, "ask")
+	if !strings.Contains(got, "not valid JSON") || !strings.Contains(got, `"options"`) {
+		t.Fatalf("malformed-args result should echo the schema, got %q", got)
+	}
+}
+
+// A valid-JSON arg that fails the tool's own validation must surface that error
+// as-is, without the schema hint (the shape was fine; the values weren't).
+func TestValidArgsErrorOmitsSchema(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(NewAskTool())
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "ask", `{"questions":[{"question":"q","header":"h","options":[{"label":"a"}]}]}`), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "ask me"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	got := toolResult(a.session, "ask")
+	if strings.Contains(got, "not valid JSON") {
+		t.Fatalf("a valid-JSON arg error must not get the schema hint, got %q", got)
+	}
+	if !strings.Contains(got, "two options") {
+		t.Fatalf("expected the real validation error, got %q", got)
+	}
+}


### PR DESCRIPTION
## What happened

A transcript showed `ask ⊘ invalid args: invalid character ':' after array element`. The model emitted structurally-invalid JSON for the `ask` tool's arguments (options written like `["a":"b"]`), `json.Unmarshal` rejected it, and the tool errored.

## Fix

Invalid JSON can't be safely re-parsed (guessing the intended structure is risky), and the agent already recovers by retrying — but with nothing to anchor on, the retry can repeat the same broken shape. So when a tool call's args fail `json.Valid`, append the tool's own schema to the error fed back to the model, so the retry lands a valid shape in one cheap round.

Scoped tightly: only triggers when the args are *not valid JSON*. Valid-JSON args that fail a tool's value validation (e.g. ask with <2 options) surface their real error unchanged, no schema noise.

## Tests

- malformed-args (`{"questions":["q":1]}`) → result echoes the schema + "not valid JSON".
- valid-JSON-but-invalid-values → real validation error, no schema hint.
- build / vet / agent suite green.