### PR TITLE
fix: auto-allow pending approvals in YOLO mode

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -200,16 +200,33 @@ export default function App() {
     [effectiveSidebarWidth, viewportWidth, workspaceFileTreePanelWidth, workspacePanelWidth, workspacePreviewModeActive],
   );
 
+  const syncModeToController = useCallback(
+    async (m: Mode) => {
+      if (m === "plan") {
+        await setBypass(false);
+        await setPlan(true);
+        return;
+      }
+      if (m === "yolo") {
+        await setPlan(false);
+        await setBypass(true);
+        return;
+      }
+      await setPlan(false);
+      await setBypass(false);
+    },
+    [setPlan, setBypass],
+  );
+
   // applyMode is the single source of truth for the input mode: it updates the
   // local pill and pushes the matching gate state to the controller (plan = read
   // only; yolo = auto-approve every tool call). normal clears both.
   const applyMode = useCallback(
     (m: Mode) => {
       setMode(m);
-      setPlan(m === "plan");
-      setBypass(m === "yolo");
+      void syncModeToController(m);
     },
-    [setPlan, setBypass],
+    [syncModeToController],
   );
   // Shift+Tab cycles normal → plan → yolo → normal.
   const cycleMode = useCallback(() => {
@@ -222,11 +239,19 @@ export default function App() {
   const switchModel = useCallback(
     async (name: string) => {
       await setModel(name);
-      if (mode === "plan") setPlan(true);
-      else if (mode === "yolo") setBypass(true);
+      await syncModeToController(mode);
     },
-    [setModel, mode, setPlan, setBypass],
+    [setModel, mode, syncModeToController],
   );
+
+  // Startup and workspace/model rebuilds create a fresh controller in normal
+  // mode. Re-apply the UI mode once the controller is ready, including the case
+  // where the user picked YOLO while boot was still loading and SetBypass was a
+  // harmless no-op.
+  useEffect(() => {
+    if (state.meta?.ready !== true || mode === "normal") return;
+    void syncModeToController(mode);
+  }, [state.meta, mode, syncModeToController]);
 
   // The live task list pinned above the composer comes from the most recent
   // top-level todo_write call; it stays visible while work remains, clears itself
@@ -277,7 +302,7 @@ export default function App() {
   // (/skill, /hooks, /mcp) — goes straight to Submit, which the controller
   // resolves (a turn, or a listing Notice).
   const handleSend = useCallback(
-    (displayText: string, submitText = displayText) => {
+    async (displayText: string, submitText = displayText) => {
       const trimmed = displayText.trim();
       const model = /^\/model\s+(\S+)$/.exec(trimmed);
       if (model) {
@@ -312,9 +337,10 @@ export default function App() {
         notice(t("settings.themeUnknown", { name: arg }), "warn");
         return;
       }
+      await syncModeToController(mode);
       send(trimmed, submitText.trim());
     },
-    [switchModel, openMemory, send, notice, t],
+    [switchModel, openMemory, syncModeToController, mode, send, notice, t],
   );
 
   const addToChat = useCallback((text: string) => {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -586,13 +586,18 @@ export function useController() {
     app.AnswerQuestion(id, answers).catch(() => {});
   }, []);
 
-  const setPlan = useCallback((on: boolean) => {
-    app.SetPlanMode(on).catch(() => {});
+  const setPlan = useCallback((on: boolean): Promise<void> => {
+    return app.SetPlanMode(on).catch(() => {});
   }, []);
 
   // setBypass toggles YOLO mode (auto-approve every tool call this session).
-  const setBypass = useCallback((on: boolean) => {
-    app.SetBypass(on).catch(() => {});
+  const setBypass = useCallback((on: boolean): Promise<void> => {
+    return app
+      .SetBypass(on)
+      .then(() => {
+        if (on) dispatch({ type: "clearApproval" });
+      })
+      .catch(() => {});
   }, []);
 
   const newSession = useCallback(async () => {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1404,9 +1404,22 @@ func (c *Controller) Jobs() []jobs.View {
 // approval prompt is auto-allowed (writers and bash run without asking). Deny
 // rules still block. Runtime-only — never written to config.
 func (c *Controller) SetBypass(on bool) {
+	var pending []chan approvalReply
+
 	c.mu.Lock()
 	c.bypass = on
+	if on {
+		pending = make([]chan approvalReply, 0, len(c.approvals))
+		for id, reply := range c.approvals {
+			delete(c.approvals, id)
+			pending = append(pending, reply)
+		}
+	}
 	c.mu.Unlock()
+
+	for _, reply := range pending {
+		reply <- approvalReply{allow: true}
+	}
 }
 
 // Bypass reports whether YOLO/bypass mode is on, for the status-bar indicator.
@@ -1682,7 +1695,7 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	// Re-check the grant: a session grant may have landed while we queued behind
 	// another prompt for the same subject.
 	c.mu.Lock()
-	if c.granted[key] {
+	if c.bypass || c.autoApprove || c.granted[key] {
 		c.mu.Unlock()
 		return true, false, nil
 	}

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -91,3 +91,44 @@ func TestRequestApprovalHonorsBypass(t *testing.T) {
 		t.Fatal("bypass must not emit an ApprovalRequest event")
 	}
 }
+
+// TestSetBypassAllowsPendingApproval covers the desktop case where the approval
+// card is already visible, then the user switches to YOLO. Turning bypass on must
+// unblock that pending gate too; otherwise the backend keeps waiting while the UI
+// says approvals should be skipped.
+func TestSetBypassAllowsPendingApproval(t *testing.T) {
+	c, ids, _ := approvalIDs()
+
+	done := make(chan bool, 1)
+	errs := make(chan error, 1)
+	go func() {
+		allow, _, err := c.requestApproval(context.Background(), "multi_edit", "/tmp/file")
+		if err != nil {
+			errs <- err
+			return
+		}
+		done <- allow
+	}()
+
+	select {
+	case <-ids:
+	case <-time.After(2 * time.Second):
+		t.Fatal("approval request was not emitted")
+	}
+
+	c.SetBypass(true)
+
+	select {
+	case err := <-errs:
+		t.Fatalf("requestApproval: %v", err)
+	case allow := <-done:
+		if !allow {
+			t.Fatal("pending approval should be auto-allowed when bypass turns on")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending approval stayed blocked after bypass turned on")
+	}
+	if !c.Bypass() {
+		t.Fatal("bypass should remain on after draining pending approvals")
+	}
+}

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -672,7 +672,11 @@ function loadSessions(){
 loadSessions();
 
 // ── input handling ──
-function send(){ const v=input.value.trim(); if(!v)return; addUserMsg(v); post('/submit',{input:v}).then(r=>{if(r.ok&&r.status===204){fetchStatus();loadSessions();}}); input.value='';input.style.height='';closeSlashMenu(); }
+async function syncModeBeforeSubmit(){
+  if(planMode){ await post('/bypass',{on:false}); await post('/plan',{on:true}); }
+  else if(bypassMode){ await post('/plan',{on:false}); await post('/bypass',{on:true}); }
+}
+async function send(){ const v=input.value.trim(); if(!v)return; await syncModeBeforeSubmit(); addUserMsg(v); post('/submit',{input:v}).then(r=>{if(r.ok&&r.status===204){fetchStatus();loadSessions();}}); input.value='';input.style.height='';closeSlashMenu(); }
 
 input.addEventListener('input',()=>{input.style.height='auto';input.style.height=Math.min(input.scrollHeight,140)+'px';updateSlashMenu();});
 input.addEventListener('keydown',e=>{
@@ -705,17 +709,17 @@ function updateModeButtons(){
   $('#btn-plan').classList.toggle('toolbar__btn--active',planMode);
   $('#btn-bypass').classList.toggle('toolbar__btn--danger',bypassMode);
 }
-function setPlan(on){planMode=on;if(on){bypassMode=false;post('/bypass',{on:false});}post('/plan',{on});updateModeButtons();}
-function setBypass(on){bypassMode=on;if(on){planMode=false;post('/plan',{on:false});}post('/bypass',{on});updateModeButtons();}
-function cycleMode(){if(!planMode&&!bypassMode)setPlan(true);else if(planMode){setPlan(false);setBypass(true);}else setBypass(false);setTimeout(fetchStatus,200);}
-function setMode(m){if(m==='auto'){if(planMode)setPlan(false);if(bypassMode)setBypass(false);}else if(m==='plan'){setPlan(true);}else if(m==='yolo'){setBypass(true);}}
+async function setPlan(on){planMode=on;if(on){bypassMode=false;}updateModeButtons();if(on){await post('/bypass',{on:false});}await post('/plan',{on});}
+async function setBypass(on){bypassMode=on;if(on){planMode=false;}updateModeButtons();if(on){await post('/plan',{on:false});}await post('/bypass',{on});}
+async function cycleMode(){if(!planMode&&!bypassMode)await setPlan(true);else if(planMode){await setPlan(false);await setBypass(true);}else await setBypass(false);setTimeout(fetchStatus,200);}
+async function setMode(m){if(m==='auto'){if(planMode)await setPlan(false);if(bypassMode)await setBypass(false);}else if(m==='plan'){await setPlan(true);}else if(m==='yolo'){await setBypass(true);}}
 
 // toolbar buttons
-btnSend.onclick=send;
+btnSend.onclick=()=>void send();
 btnStop.onclick=()=>post('/cancel');
-$('#btn-auto').onclick=()=>setMode('auto');
-$('#btn-plan').onclick=()=>setPlan(!planMode);
-$('#btn-bypass').onclick=()=>setBypass(!bypassMode);
+$('#btn-auto').onclick=()=>void setMode('auto');
+$('#btn-plan').onclick=()=>void setPlan(!planMode);
+$('#btn-bypass').onclick=()=>void setBypass(!bypassMode);
 $('#btn-new').onclick=()=>{if(running)return;post('/new').then(()=>{log.innerHTML='';log.appendChild(welcome);welcome.style.display='';loadSessions();});};
 $('#btn-compact').onclick=()=>{if(!running)post('/compact');};
 $('#btn-rewind').onclick=()=>openRewindPicker();


### PR DESCRIPTION
## Summary
- Auto-allow already pending approval requests when YOLO/bypass mode is enabled.
- Re-check bypass state after the serialized approval queue before emitting a new prompt.
- Make desktop mode changes awaitable and re-apply the UI mode after controller ready/rebuild so startup-time YOLO/plan selections are not dropped.
- Sync the current desktop mode before submitting an agent turn, closing the race where `Submit` could arrive before `SetBypass(true)` / `SetPlanMode(true)`.
- Apply the same submit-before-mode-sync guard to the lightweight `reasonix serve` web UI.

## Testing
- `go test ./internal/control -run 'Test(Bypass|RequestApproval|SetBypass|Approval)'`
- `go test ./internal/serve ./internal/control -run 'Test(Bypass|RequestApproval|SetBypass|Approval|CSRF|Wire|Serve|Status)'`
- `HOME=$(mktemp -d) XDG_CONFIG_HOME=$HOME/.config go test ./internal/control`
- `npm run typecheck`
- `npm run build`