### PR TITLE
feat(desktop): attach files dropped onto the composer

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1726,6 +1726,67 @@ func (a *App) AttachmentDataURL(path string) (string, error) {
 	return control.ImageDataURL(path)
 }
 
+// DroppedItem is one OS-dropped file resolved into a composer context entry: an
+// in-tree file becomes a workspace @reference (read in place, no copy), while an
+// image or out-of-tree file is copied into .reasonix/attachments.
+type DroppedItem struct {
+	Kind       string `json:"kind"` // "workspace" | "attachment"
+	Path       string `json:"path"`
+	IsDir      bool   `json:"isDir,omitempty"`
+	PreviewURL string `json:"previewUrl,omitempty"`
+}
+
+// AttachDropped turns an absolute path from the native file-drop bridge into a
+// composer context entry. Images are stored as attachments so the chip shows a
+// thumbnail; other in-workspace files are referenced relatively (no copy); files
+// outside the workspace are copied into .reasonix/attachments.
+func (a *App) AttachDropped(path string) (DroppedItem, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return DroppedItem{}, err
+	}
+	if isImageExt(path) {
+		if rel, err := control.SaveImageFile(path); err == nil {
+			preview, _ := control.ImageDataURL(rel)
+			return DroppedItem{Kind: "attachment", Path: rel, PreviewURL: preview}, nil
+		}
+	}
+	if rel, ok := workspaceRelative(path); ok {
+		return DroppedItem{Kind: "workspace", Path: rel, IsDir: info.IsDir()}, nil
+	}
+	if info.IsDir() {
+		return DroppedItem{}, fmt.Errorf("can only attach files from outside the workspace")
+	}
+	rel, err := control.SaveAttachmentFile(path)
+	if err != nil {
+		return DroppedItem{}, err
+	}
+	return DroppedItem{Kind: "attachment", Path: rel}, nil
+}
+
+func isImageExt(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp":
+		return true
+	}
+	return false
+}
+
+func workspaceRelative(path string) (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(cwd, path)
+	if err != nil {
+		return "", false
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
 // --- memory panel (frontend ⇄ controller) ---
 
 // MemoryDoc is one loaded doc-memory file for the panel: path, scope, and body.

--- a/desktop/attach_dropped_test.go
+++ b/desktop/attach_dropped_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceRelative(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	cwd, _ := os.Getwd()
+
+	if rel, ok := workspaceRelative(filepath.Join(cwd, "sub", "file.go")); !ok || rel != "sub/file.go" {
+		t.Fatalf("in-tree = (%q, %v), want (sub/file.go, true)", rel, ok)
+	}
+	if _, ok := workspaceRelative(filepath.Join(filepath.Dir(cwd), "sibling.txt")); ok {
+		t.Fatal("a path above the workspace must not resolve as in-tree")
+	}
+}
+
+func TestIsImageExt(t *testing.T) {
+	for _, p := range []string{"a.png", "A.PNG", "b.jpeg", "c.webp"} {
+		if !isImageExt(p) {
+			t.Errorf("%q should be an image extension", p)
+		}
+	}
+	for _, p := range []string{"notes.pdf", "main.go", "noext"} {
+		if isImageExt(p) {
+			t.Errorf("%q should not be an image extension", p)
+		}
+	}
+}
+
+func TestAttachDroppedInWorkspaceReferencesInPlace(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	cwd, _ := os.Getwd()
+	if err := os.MkdirAll(filepath.Join(cwd, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(cwd, "sub", "notes.txt")
+	if err := os.WriteFile(target, []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (&App{}).AttachDropped(target)
+	if err != nil {
+		t.Fatalf("AttachDropped: %v", err)
+	}
+	if got.Kind != "workspace" || got.Path != "sub/notes.txt" {
+		t.Fatalf("got %+v, want workspace ref sub/notes.txt", got)
+	}
+}
+
+func TestAttachDroppedOutsideWorkspaceCopiesToAttachments(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	outside := filepath.Join(t.TempDir(), "report.pdf")
+	if err := os.WriteFile(outside, []byte("%PDF body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (&App{}).AttachDropped(outside)
+	if err != nil {
+		t.Fatalf("AttachDropped: %v", err)
+	}
+	if got.Kind != "attachment" || !strings.HasPrefix(got.Path, ".reasonix/attachments/") || !strings.HasSuffix(got.Path, ".pdf") {
+		t.Fatalf("got %+v, want copied pdf attachment", got)
+	}
+}
+
+func TestAttachDroppedImageStoresThumbnail(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	root := t.TempDir()
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	cwd, _ := os.Getwd()
+	png := append([]byte("\x89PNG\r\n\x1a\n"), make([]byte, 64)...)
+	if err := os.WriteFile(filepath.Join(cwd, "shot.png"), png, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := (&App{}).AttachDropped(filepath.Join(cwd, "shot.png"))
+	if err != nil {
+		t.Fatalf("AttachDropped: %v", err)
+	}
+	if got.Kind != "attachment" || !strings.HasSuffix(got.Path, ".png") {
+		t.Fatalf("got %+v, want png attachment", got)
+	}
+	if !strings.HasPrefix(got.PreviewURL, "data:image/png;base64,") {
+		t.Fatalf("preview = %q, want png data URL", got.PreviewURL)
+	}
+}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
 import { ArrowUp, Check, ChevronDown, Eye, FileText, Folder, FolderGit2, FolderPlus, Search, Square, Trash2, X } from "lucide-react";
-import { app } from "../lib/bridge";
+import { app, onFilesDropped } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import type { CommandInfo, ComposerInsertRequest, DirEntry, Mode, SlashArgItem, SlashArgsResult, WorkspaceView } from "../lib/types";
@@ -386,8 +386,8 @@ export function Composer({
     }
   };
 
-  // Non-image drops (PDFs, docs): the browser hands us bytes, not a path, so the
-  // kernel stores them and we reference the saved path — attached, not ignored.
+  // Non-image pastes (PDFs, docs): the clipboard hands us bytes, not a path, so
+  // the kernel stores them and we reference the saved path — attached, not ignored.
   const attachOtherFiles = async (files: File[]) => {
     const others = files.filter((f) => !f.type.startsWith("image/"));
     if (others.length === 0) return;
@@ -409,6 +409,30 @@ export function Composer({
     void attachImageFiles(files);
     void attachOtherFiles(files);
   };
+
+  // OS file drops arrive as absolute paths through the native bridge (the webview
+  // withholds them from the HTML drop event); the kernel resolves each into a
+  // workspace @reference or a stored attachment.
+  const attachDroppedPaths = async (paths: string[]) => {
+    setDragOver(false);
+    for (const path of paths) {
+      setPendingPaste((n) => n + 1);
+      try {
+        const item = await app.AttachDropped(path);
+        if (item.kind === "workspace") {
+          addWorkspaceReference({ path: item.path, isDir: item.isDir });
+        } else {
+          setAttachments((prev) => [...prev, { path: item.path, previewUrl: item.previewUrl }]);
+        }
+      } catch {
+        // non-fatal: a failed drop attach must not block normal text input
+      } finally {
+        setPendingPaste((n) => Math.max(0, n - 1));
+      }
+    }
+  };
+
+  useEffect(() => onFilesDropped((paths) => void attachDroppedPaths(paths)), []);
 
   const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
     const files = Array.from(e.clipboardData.files);
@@ -458,11 +482,9 @@ export function Composer({
       return;
     }
 
-    const files = Array.from(e.dataTransfer.files);
-    if (files.length === 0) return;
-    e.preventDefault();
-    setDragOver(false);
-    attachFiles(files);
+    // OS file drops deliver no usable bytes/paths here; the native bridge
+    // (onFilesDropped → AttachDropped) handles them. Just clear the hover state.
+    if (hasFileDrag(e.dataTransfer)) setDragOver(false);
   };
 
   const onDragOver = (e: DragEvent<HTMLDivElement>) => {
@@ -669,7 +691,7 @@ export function Composer({
   const composerCardStyle = composerHeight === null ? undefined : ({ "--composer-height": `${composerHeight}px` } as CSSProperties);
 
   return (
-    <div className="composer-wrap">
+    <div className="composer-wrap" style={{ "--wails-drop-target": "drop" } as CSSProperties}>
       {workspaceMenuOpen && cwd && (
         <div className="workspace-switcher" ref={workspaceMenuRef}>
           <label className="workspace-switcher__search">

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -12,6 +12,7 @@ import type {
   CommandInfo,
   ContextInfo,
   DirEntry,
+  DroppedItem,
   EffortInfo,
   FilePreview,
   HistoryMessage,
@@ -98,6 +99,9 @@ export interface AppBindings {
   RevealWorkspacePath(rel: string): Promise<void>;
   SavePastedImage(dataUrl: string): Promise<string>;
   SavePastedFile(name: string, dataUrl: string): Promise<string>;
+  // AttachDropped resolves an OS-dropped absolute path (from the native file-drop
+  // bridge) into a composer context entry — a workspace ref or a stored attachment.
+  AttachDropped(path: string): Promise<DroppedItem>;
   AttachmentDataURL(path: string): Promise<string>;
   Models(): Promise<ModelInfo[]>;
   SetModel(name: string): Promise<void>;
@@ -143,6 +147,10 @@ export interface AppBindings {
 interface WailsRuntime {
   EventsOn(name: string, cb: (...data: unknown[]) => void): () => void;
   BrowserOpenURL(url: string): void;
+  // Native OS file drop (desktop only); useDropTarget gates delivery to elements
+  // carrying the --wails-drop-target CSS property. Absent in the browser dev mock.
+  OnFileDrop?(cb: (x: number, y: number, paths: string[]) => void, useDropTarget: boolean): void;
+  OnFileDropOff?(): void;
 }
 
 declare global {
@@ -188,6 +196,18 @@ export function onUpdaterProgress(cb: (p: UpdateProgress) => void): () => void {
   return () => {
     updaterListeners.delete(cb);
   };
+}
+
+// onFilesDropped subscribes to native OS file drops landing on the composer (the
+// --wails-drop-target element); the callback gets the dropped files' absolute
+// paths. No-op in the browser dev mock, where the runtime is absent.
+export function onFilesDropped(cb: (paths: string[]) => void): () => void {
+  const rt = typeof window !== "undefined" ? window.runtime : undefined;
+  if (!rt?.OnFileDrop) return () => {};
+  rt.OnFileDrop((_x, _y, paths) => {
+    if (Array.isArray(paths) && paths.length > 0) cb(paths);
+  }, true);
+  return () => rt.OnFileDropOff?.();
 }
 
 // onReady subscribes to the agent:ready event fired when boot.Build completes.
@@ -703,6 +723,10 @@ function makeMockApp(): AppBindings {
     },
     async SavePastedFile(name: string, _dataUrl: string) {
       return `.reasonix/attachments/mock-${name}`;
+    },
+    async AttachDropped(path: string) {
+      const name = path.split(/[/\\]/).filter(Boolean).pop() ?? path;
+      return { kind: "attachment" as const, path: `.reasonix/attachments/mock-${name}` };
     },
     async AttachmentDataURL(_path: string) {
       return "data:image/png;base64,iVBORw0KGgo=";

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -160,6 +160,13 @@ export interface DirEntry {
   isDir: boolean;
 }
 
+export interface DroppedItem {
+  kind: "workspace" | "attachment";
+  path: string;
+  isDir?: boolean;
+  previewUrl?: string;
+}
+
 export interface FilePreview {
   path: string;
   body: string;

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -54,6 +54,11 @@ func main() {
 		OnShutdown:       app.shutdown,
 		Bind:             []any{app},
 
+		// Native OS file drops: the webview withholds dropped files' paths from the
+		// HTML drop event, so the frontend (composer) reads them via runtime.OnFileDrop
+		// against the --wails-drop-target element instead.
+		DragAndDrop: &options.DragAndDrop{EnableFileDrop: true},
+
 		// --- per-platform adaptation (see desktop/README.md for the rationale) ---
 		Mac: &mac.Options{
 			// Inset traffic-lights over a frameless-feeling header; the frontend

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -156,6 +156,64 @@ func SaveImageFile(path string) (string, error) {
 	return SaveImageBytes("", raw)
 }
 
+func SaveAttachmentFile(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("attachment path must not be a symlink")
+	}
+	if info.IsDir() || info.Size() <= 0 || info.Size() > maxFileAttachmentBytes {
+		return "", fmt.Errorf("attachment must be between 1 byte and 25 MB")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	opened, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+	if !os.SameFile(info, opened) {
+		return "", fmt.Errorf("attachment changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(f, maxFileAttachmentBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(raw) == 0 || len(raw) > maxFileAttachmentBytes {
+		return "", fmt.Errorf("attachment must be between 1 byte and 25 MB")
+	}
+	if after, err := f.Stat(); err != nil {
+		return "", err
+	} else if !os.SameFile(opened, after) || after.Size() != opened.Size() {
+		return "", fmt.Errorf("attachment changed while reading")
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	if !safeAttachmentExt.MatchString(ext) {
+		ext = ".bin"
+	}
+	if err := ensureAttachmentRoot(); err != nil {
+		return "", err
+	}
+	rel, dst, err := createAttachmentFile(ext)
+	if err != nil {
+		return "", err
+	}
+	if _, err := dst.Write(raw); err != nil {
+		_ = dst.Close()
+		_ = os.Remove(rel)
+		return "", err
+	}
+	if err := dst.Close(); err != nil {
+		_ = os.Remove(rel)
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
 func SaveClipboardImage() (string, error) {
 	switch runtime.GOOS {
 	case "darwin":

--- a/internal/control/attachments_test.go
+++ b/internal/control/attachments_test.go
@@ -102,6 +102,66 @@ func TestSaveImageFile(t *testing.T) {
 	}
 }
 
+func TestSaveAttachmentFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("notes.pdf", []byte("%PDF-1.4 body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := SaveAttachmentFile("notes.pdf")
+	if err != nil {
+		t.Fatalf("SaveAttachmentFile: %v", err)
+	}
+	if !strings.HasPrefix(got, ".reasonix/attachments/clipboard-") || !strings.HasSuffix(got, ".pdf") {
+		t.Fatalf("path = %q, want attachment pdf path", got)
+	}
+	if data, err := os.ReadFile(got); err != nil || string(data) != "%PDF-1.4 body" {
+		t.Fatalf("stored bytes = %q (err %v), want original", data, err)
+	}
+}
+
+func TestSaveAttachmentFileRejectsEmptyAndDir(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("empty.txt", nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SaveAttachmentFile("empty.txt"); err == nil {
+		t.Fatal("empty file should fail")
+	}
+	if err := os.Mkdir("adir", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SaveAttachmentFile("adir"); err == nil {
+		t.Fatal("directory should fail")
+	}
+}
+
+func TestSaveAttachmentFileSanitizesExtension(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("payload.weird-ext-here", []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := SaveAttachmentFile("payload.weird-ext-here")
+	if err != nil {
+		t.Fatalf("SaveAttachmentFile: %v", err)
+	}
+	if !strings.HasSuffix(got, ".bin") {
+		t.Fatalf("path = %q, want .bin fallback for unsafe extension", got)
+	}
+}
+
+func TestSaveAttachmentFileRejectsSymlink(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if err := os.WriteFile("source.bin", []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("source.bin", "link.bin"); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if _, err := SaveAttachmentFile("link.bin"); err == nil {
+		t.Fatal("symlink attachment path should fail")
+	}
+}
+
 func TestSaveImageFileRejectsSymlink(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if err := os.WriteFile("source.png", mustBase64(t, tinyPNG), 0o644); err != nil {


### PR DESCRIPTION
## What

Drag a file from the OS file manager onto the composer and it attaches — same as paste, but for drops.

Wails leaves native file drop disabled by default, so the webview never hands the dropped files' paths to the HTML `drop` event; the composer's existing handler only saw in-app reference drags and clipboard pastes. This enables Wails' native file drop and bridges the resolved absolute paths to the composer via `runtime.OnFileDrop`, gated to the `--wails-drop-target` input region.

## How drops resolve

Each dropped path is resolved in the kernel (`AttachDropped`):

- **In-workspace file** → relative `@reference`, read in place (no copy).
- **Image** (anywhere) → copied into `.reasonix/attachments` with a thumbnail chip.
- **Out-of-tree file** → copied into `.reasonix/attachments`.

The old HTML-drop byte path is removed so a single drop never attaches twice.

## Tests

- `internal/control`: `SaveAttachmentFile` (size/dir/symlink/extension-sanitize edges).
- `desktop`: `workspaceRelative` in/out-of-tree boundary, `isImageExt`, and `AttachDropped`'s three branches (in-tree ref / external copy / image thumbnail).

Go build+vet (root + desktop) and frontend `tsc --noEmit` are green. End-to-end drop behavior needs a real desktop build to eyeball.
