### PR TITLE
fix(sandbox): don't pick the WSL bash launcher on Windows

### DIFF
--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -98,6 +98,9 @@ func TestResolveShellDecisionTable(t *testing.T) {
 	gitBash := []string{`C:\fake\Git\bin\bash.exe`}
 	always := func(string) bool { return true }
 	never := func(string) bool { return false }
+	// onPath("bash") returns C:\fake\bash.exe; treat exactly that as the WSL
+	// launcher so the exclusion is exercised without matching the Git candidate.
+	wslIsPathBash := func(p string) bool { return p == `C:\fake\bash.exe` }
 	cases := []struct {
 		name       string
 		goos       string
@@ -105,22 +108,48 @@ func TestResolveShellDecisionTable(t *testing.T) {
 		candidates []string
 		exists     func(string) bool
 		probe      func(string) bool
+		isWSL      func(string) bool
 		wantKind   ShellKind
+		wantPath   string
 	}{
-		{"bash on PATH wins", "windows", onPath("bash", "powershell"), gitBash, never, always, ShellBash},
-		{"bash on PATH but probe fails", "windows", onPath("bash", "powershell"), gitBash, never, never, ShellPowerShell},
-		{"no bash, git-bash on disk", "windows", onPath("powershell"), gitBash, always, always, ShellBash},
-		{"git-bash on disk but probe fails", "windows", onPath("powershell"), gitBash, always, never, ShellPowerShell},
-		{"no bash anywhere, pwsh", "windows", onPath("pwsh", "powershell"), gitBash, never, never, ShellPowerShell},
-		{"no bash, only powershell", "windows", onPath("powershell"), gitBash, never, never, ShellPowerShell},
-		{"windows, nothing found", "windows", onPath(), nil, never, never, ShellBash},
-		{"linux, no bash → no PS fallback", "linux", onPath("powershell"), gitBash, always, always, ShellBash},
+		{"bash on PATH wins", "windows", onPath("bash", "powershell"), gitBash, never, always, never, ShellBash, `C:\fake\bash.exe`},
+		{"bash on PATH but probe fails", "windows", onPath("bash", "powershell"), gitBash, never, never, never, ShellPowerShell, ""},
+		{"no bash, git-bash on disk", "windows", onPath("powershell"), gitBash, always, always, never, ShellBash, ""},
+		{"git-bash on disk but probe fails", "windows", onPath("powershell"), gitBash, always, never, never, ShellPowerShell, ""},
+		{"no bash anywhere, pwsh", "windows", onPath("pwsh", "powershell"), gitBash, never, never, never, ShellPowerShell, ""},
+		{"no bash, only powershell", "windows", onPath("powershell"), gitBash, never, never, never, ShellPowerShell, ""},
+		{"windows, nothing found", "windows", onPath(), nil, never, never, never, ShellBash, ""},
+		{"linux, no bash → no PS fallback", "linux", onPath("powershell"), gitBash, always, always, never, ShellBash, ""},
+		{"wsl bash on PATH skipped for git-bash", "windows", onPath("bash", "powershell"), gitBash, always, always, wslIsPathBash, ShellBash, `C:\fake\Git\bin\bash.exe`},
+		{"wsl bash on PATH, no git → powershell not wsl", "windows", onPath("bash", "powershell"), gitBash, never, always, wslIsPathBash, ShellPowerShell, ""},
 	}
 	for _, c := range cases {
-		got := resolveShell(c.goos, c.lookPath, c.exists, c.candidates, c.probe)
+		got := resolveShell(c.goos, c.lookPath, c.exists, c.candidates, c.probe, c.isWSL)
 		if got.Kind != c.wantKind {
 			t.Errorf("%s: kind = %s, want %s (path=%s)", c.name, got.Kind, c.wantKind, got.Path)
 		}
+		if c.wantPath != "" && got.Path != c.wantPath {
+			t.Errorf("%s: path = %q, want %q", c.name, got.Path, c.wantPath)
+		}
+	}
+}
+
+func TestIsWindowsWSLBash(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only path detection")
+	}
+	t.Setenv("SystemRoot", `C:\Windows`)
+	if !isWindowsWSLBash(`C:\Windows\System32\bash.exe`) {
+		t.Error("System32 bash launcher should be detected as WSL")
+	}
+	if !isWindowsWSLBash(`c:\windows\system32\BASH.EXE`) {
+		t.Error("detection should be case-insensitive")
+	}
+	if isWindowsWSLBash(`C:\Program Files\Git\bin\bash.exe`) {
+		t.Error("Git-for-Windows bash must not be flagged as WSL")
+	}
+	if isWindowsWSLBash("") {
+		t.Error("empty path is not WSL")
 	}
 }
 

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -44,15 +44,15 @@ type Shell struct {
 // is usually absent from PATH, it probes the Git-for-Windows install locations
 // and only then falls back to PowerShell so the tool still functions.
 func ResolveShell() Shell {
-	return resolveShell(runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates(), probeBash)
+	return resolveShell(runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates(), probeBash, isWindowsWSLBash)
 }
 
 // resolveShell is ResolveShell with its environment lookups injected — including
 // the Git-for-Windows bash candidates, which derive from %ProgramFiles% and so
 // are empty off Windows — so the decision table is deterministically testable on
 // any host.
-func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string, probe func(string) bool) Shell {
-	if p, err := lookPath("bash"); err == nil && probe(p) {
+func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string, probe func(string) bool, isWSL func(string) bool) Shell {
+	if p, err := lookPath("bash"); err == nil && !isWSL(p) && probe(p) {
 		return Shell{Kind: ShellBash, Path: p}
 	}
 	if goos == "windows" {
@@ -68,6 +68,27 @@ func resolveShell(goos string, lookPath func(string) (string, error), exists fun
 		}
 	}
 	return Shell{Kind: ShellBash, Path: "bash"}
+}
+
+// isWindowsWSLBash reports whether a resolved bash path is the WSL launcher
+// Windows ships under %SystemRoot% (e.g. C:\Windows\System32\bash.exe). With WSL
+// installed it runs commands inside the Linux VM — where the Windows workspace is
+// a /mnt/<drive> path — so it must never be chosen for a native Windows workspace;
+// the only bash.exe Microsoft places under the Windows dir is that launcher.
+func isWindowsWSLBash(path string) bool {
+	if runtime.GOOS != "windows" || path == "" {
+		return false
+	}
+	win := os.Getenv("SystemRoot")
+	if win == "" {
+		win = os.Getenv("windir")
+	}
+	if win == "" {
+		return false
+	}
+	p := strings.ToLower(filepath.Clean(path))
+	root := strings.ToLower(filepath.Clean(win)) + string(filepath.Separator)
+	return strings.HasPrefix(p, root)
 }
 
 // Windows ships a bash.exe launcher stub in %SystemRoot% that opens the WSL


### PR DESCRIPTION
Closes #2837

## Problem

On Windows with WSL installed, the shell tool runs every command inside WSL instead of native Windows.

`bash` on PATH resolves to the launcher Microsoft ships at `%SystemRoot%\System32\bash.exe`. `ResolveShell` probes it with `bash -c true` to weed out the "WSL not installed" stub — but once a distro **is** installed, that probe succeeds (it runs inside the Linux VM), so the launcher is accepted. From then on commands execute in WSL, where the Windows workspace is a `/mnt/<drive>` path and native paths/tools break. Asking the agent to "use Windows" didn't help because resolution kept landing on the same launcher.

## Fix

Skip any `bash` resolved under the Windows directory — the only `bash.exe` Microsoft places there is the WSL launcher. Resolution then falls through to the existing Git-for-Windows candidates, and to PowerShell when no native bash exists. WSL is never selected for a native-Windows workspace; when only PowerShell remains, the bash tool's description already steers the model to PowerShell rather than WSL.

## Tests

`internal/sandbox`: two new decision-table rows (WSL-on-PATH → Git bash; WSL-on-PATH without Git → PowerShell, asserting the resolved path) plus `TestIsWindowsWSLBash` (System32 launcher detected, case-insensitive, Git bash not flagged).
