### PR TITLE
refactor(desktop): drop dead codegraph-disabled loop in Capabilities

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -992,19 +992,6 @@ func (a *App) Capabilities() CapabilitiesView {
 			seen["codegraph"] = true
 		}
 	}
-	for name, s := range disabled {
-		if seen[name] {
-			continue
-		}
-		if name != "codegraph" || !codegraphConfigured {
-			continue
-		}
-		s.Status = "disabled"
-		s.BuiltIn = true
-		s.Error = ""
-		out.Servers = append(out.Servers, s)
-		retainedDisabled[name] = s
-	}
 	out.Servers = orderServerViews(out.Servers, order)
 
 	a.mu.Lock()


### PR DESCRIPTION
Small follow-up to #2834.

That PR added a codegraph special-case block in `Capabilities()` which renders the disabled built-in **and** marks it `seen` (deleting it from the `disabled` map). That made the trailing `for name, s := range disabled` loop dead: its only branch is `name == "codegraph" && codegraphConfigured`, but

- when `codegraphConfigured` is true, the block above already ran and set `seen["codegraph"]`, so the loop `continue`s, and
- when it's false, the loop's own `!codegraphConfigured` guard skips every entry.

So the loop can never append anything. Removing it drops 13 lines and leaves a single place that decides codegraph's drawer state.

No behaviour change. `go build`/`go vet`/`go test ./...` (desktop module) pass.
