### PR TITLE
refactor(desktop): apply composer gating via one atomic SetMode

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -226,6 +226,26 @@ func (a *App) SetPlanMode(on bool) {
 	}
 }
 
+// SetMode applies a composer gating mode ("plan" | "yolo" | anything else =
+// normal) in one call, so a turn submitted right after the switch can't race a
+// half-applied SetPlanMode/SetBypass pair.
+func (a *App) SetMode(mode string) {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
+		return
+	}
+	switch mode {
+	case "plan":
+		ctrl.SetMode(true, false)
+	case "yolo":
+		ctrl.SetMode(false, true)
+	default:
+		ctrl.SetMode(false, false)
+	}
+}
+
 // QuestionAnswer is the frontend's reply to one question in an ask_request.
 type QuestionAnswer struct {
 	QuestionID string   `json:"questionId"`

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -142,8 +142,7 @@ export default function App() {
     cancel,
     approve,
     answerQuestion,
-    setPlan,
-    setBypass,
+    setControllerMode,
     newSession,
     listSessions,
     resumeSession,
@@ -200,23 +199,7 @@ export default function App() {
     [effectiveSidebarWidth, viewportWidth, workspaceFileTreePanelWidth, workspacePanelWidth, workspacePreviewModeActive],
   );
 
-  const syncModeToController = useCallback(
-    async (m: Mode) => {
-      if (m === "plan") {
-        await setBypass(false);
-        await setPlan(true);
-        return;
-      }
-      if (m === "yolo") {
-        await setPlan(false);
-        await setBypass(true);
-        return;
-      }
-      await setPlan(false);
-      await setBypass(false);
-    },
-    [setPlan, setBypass],
-  );
+  const syncModeToController = useCallback((m: Mode) => setControllerMode(m), [setControllerMode]);
 
   // applyMode is the single source of truth for the input mode: it updates the
   // local pill and pushes the matching gate state to the controller (plan = read
@@ -963,8 +946,7 @@ export default function App() {
                   approve(state.approval!.id, false, false);
                 }}
                 onExitPlan={() => {
-                  setMode("normal");
-                  setPlan(false);
+                  applyMode("normal");
                   approve(state.approval!.id, false, false);
                 }}
               />

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -46,6 +46,9 @@ export interface AppBindings {
   Approve(id: string, allow: boolean, session: boolean): Promise<void>;
   AnswerQuestion(id: string, answers: QuestionAnswer[]): Promise<void>;
   SetPlanMode(on: boolean): Promise<void>;
+  // SetMode applies plan/yolo/normal gating atomically (one IPC, no half-applied
+  // window); prefer it over sequencing SetPlanMode + SetBypass from the UI.
+  SetMode(mode: string): Promise<void>;
   Compact(): Promise<void>;
   NewSession(): Promise<void>;
   History(): Promise<HistoryMessage[]>;
@@ -509,6 +512,7 @@ function makeMockApp(): AppBindings {
       emit({ kind: "turn_done" });
     },
     async SetPlanMode() {},
+    async SetMode() {},
     async Compact() {},
     async NewSession() {},
     async Checkpoints() {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -586,16 +586,14 @@ export function useController() {
     app.AnswerQuestion(id, answers).catch(() => {});
   }, []);
 
-  const setPlan = useCallback((on: boolean): Promise<void> => {
-    return app.SetPlanMode(on).catch(() => {});
-  }, []);
-
-  // setBypass toggles YOLO mode (auto-approve every tool call this session).
-  const setBypass = useCallback((on: boolean): Promise<void> => {
+  // setControllerMode pushes plan/yolo/normal to the kernel in one atomic call —
+  // the composer's single seam for gating, so it never sequences SetPlanMode +
+  // SetBypass and can't leave the backend in a half-applied mode.
+  const setControllerMode = useCallback((mode: "plan" | "yolo" | "normal"): Promise<void> => {
     return app
-      .SetBypass(on)
+      .SetMode(mode)
       .then(() => {
-        if (on) dispatch({ type: "clearApproval" });
+        if (mode === "yolo") dispatch({ type: "clearApproval" });
       })
       .catch(() => {});
   }, []);
@@ -751,8 +749,7 @@ export function useController() {
     cancel,
     approve,
     answerQuestion,
-    setPlan,
-    setBypass,
+    setControllerMode,
     newSession,
     listSessions,
     resumeSession,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1409,17 +1409,46 @@ func (c *Controller) SetBypass(on bool) {
 	c.mu.Lock()
 	c.bypass = on
 	if on {
-		pending = make([]chan approvalReply, 0, len(c.approvals))
-		for id, reply := range c.approvals {
-			delete(c.approvals, id)
-			pending = append(pending, reply)
-		}
+		pending = c.drainApprovalsLocked()
 	}
 	c.mu.Unlock()
 
 	for _, reply := range pending {
 		reply <- approvalReply{allow: true}
 	}
+}
+
+// SetMode applies plan (read-only) and bypass (auto-approve) together so a turn
+// submitted right after a composer mode switch can't observe a half-applied
+// gate. Turning bypass on drains any approval already waiting.
+func (c *Controller) SetMode(plan, bypass bool) {
+	var pending []chan approvalReply
+
+	c.mu.Lock()
+	c.planMode = plan
+	c.bypass = bypass
+	if bypass {
+		pending = c.drainApprovalsLocked()
+	}
+	c.mu.Unlock()
+
+	if c.executor != nil {
+		c.executor.SetPlanMode(plan)
+	}
+	for _, reply := range pending {
+		reply <- approvalReply{allow: true}
+	}
+}
+
+// drainApprovalsLocked removes every pending approval gate and returns their
+// reply channels; caller holds c.mu and sends {allow:true} after unlocking.
+func (c *Controller) drainApprovalsLocked() []chan approvalReply {
+	pending := make([]chan approvalReply, 0, len(c.approvals))
+	for id, reply := range c.approvals {
+		delete(c.approvals, id)
+		pending = append(pending, reply)
+	}
+	return pending
 }
 
 // Bypass reports whether YOLO/bypass mode is on, for the status-bar indicator.

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -132,3 +132,53 @@ func TestSetBypassAllowsPendingApproval(t *testing.T) {
 		t.Fatal("bypass should remain on after draining pending approvals")
 	}
 }
+
+// TestSetModeYoloDrainsPendingApproval is the SetMode-path twin of the SetBypass
+// case: applying YOLO atomically must also unblock an approval already waiting.
+func TestSetModeYoloDrainsPendingApproval(t *testing.T) {
+	c, ids, _ := approvalIDs()
+
+	done := make(chan bool, 1)
+	go func() {
+		allow, _, _ := c.requestApproval(context.Background(), "multi_edit", "/tmp/file")
+		done <- allow
+	}()
+
+	select {
+	case <-ids:
+	case <-time.After(2 * time.Second):
+		t.Fatal("approval request was not emitted")
+	}
+
+	c.SetMode(false, true)
+
+	select {
+	case allow := <-done:
+		if !allow {
+			t.Fatal("pending approval should be auto-allowed when SetMode turns YOLO on")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pending approval stayed blocked after SetMode(false, true)")
+	}
+}
+
+// TestSetModeAppliesBothGates checks SetMode sets plan and bypass together so the
+// composer never has to sequence two calls and risk a half-applied window.
+func TestSetModeAppliesBothGates(t *testing.T) {
+	c, _, _ := approvalIDs()
+
+	c.SetMode(true, false)
+	if !c.PlanMode() || c.Bypass() {
+		t.Fatalf("plan mode: plan=%v bypass=%v, want true/false", c.PlanMode(), c.Bypass())
+	}
+
+	c.SetMode(false, true)
+	if c.PlanMode() || !c.Bypass() {
+		t.Fatalf("yolo mode: plan=%v bypass=%v, want false/true", c.PlanMode(), c.Bypass())
+	}
+
+	c.SetMode(false, false)
+	if c.PlanMode() || c.Bypass() {
+		t.Fatalf("normal mode: plan=%v bypass=%v, want false/false", c.PlanMode(), c.Bypass())
+	}
+}


### PR DESCRIPTION
Follow-up to #2840.

That fix made the composer await `SetPlanMode` + `SetBypass` in sequence before submitting a turn. Correct, but it leaves two rough edges:

- a **half-applied window** between the two calls, and
- **two no-op IPCs per send** even in normal mode (the off→off path).

## Change
- Add `Controller.SetMode(plan, bypass bool)` — sets both gates under a single lock, drains any pending approval when YOLO turns on, and applies the executor's plan flag. Extracts the drain into `drainApprovalsLocked` so `SetBypass` and `SetMode` share it.
- Bind it through `App.SetMode(mode string)` and a single `setControllerMode` seam in `useController`; the composer now pushes gating in one call.
- Drop the now-dead `setPlan`/`setBypass` hook wrappers and fold the deny-side plan exit through `applyMode("normal")`.

`SetPlanMode`/`SetBypass` stay on the controller — CLI/ACP/serve still use them; only the desktop UI switches to the atomic call.

## Testing
- `go test ./internal/control -run 'Test(SetMode|SetBypass|RequestApproval|Bypass|Approval)'`
- `cd desktop && go build ./... && go vet ./...`
- `npm --prefix desktop/frontend run typecheck && npm --prefix desktop/frontend run build`

New `TestSetModeYoloDrainsPendingApproval` (the SetMode twin of the #2840 drain test) and `TestSetModeAppliesBothGates` cover the atomic path.