### PR TITLE
fix(desktop): stop console windows flashing on Windows during tasks

### DIFF
--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"reasonix/internal/proc"
 )
 
 type gitStatusEntry struct {
@@ -101,12 +103,15 @@ func (a *App) WorkspaceChanges() WorkspaceChangesView {
 
 func workspaceGitStatus(base string) ([]gitStatusEntry, error) {
 	cmd := exec.Command("git", "-C", base, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+	proc.HideWindow(cmd)
 	raw, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
 	entries := parseGitStatusPorcelainZ(raw)
-	topRaw, err := exec.Command("git", "-C", base, "rev-parse", "--show-toplevel").Output()
+	topCmd := exec.Command("git", "-C", base, "rev-parse", "--show-toplevel")
+	proc.HideWindow(topCmd)
+	topRaw, err := topCmd.Output()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/proc/hide_windows.go
+++ b/internal/proc/hide_windows.go
@@ -11,9 +11,12 @@ const createNoWindow = 0x08000000 // CREATE_NO_WINDOW
 
 // HideWindow stops a child process from flashing a console window on Windows,
 // where a GUI parent (the desktop app) has no console of its own to inherit.
+// CREATE_NO_WINDOW suppresses the console a console child (git, rg, a shell)
+// would otherwise pop; HideWindow guards any GUI child that shows a window.
 func HideWindow(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
+	cmd.SysProcAttr.HideWindow = true
 	cmd.SysProcAttr.CreationFlags |= createNoWindow
 }

--- a/internal/tool/builtin/bash_kill_windows.go
+++ b/internal/tool/builtin/bash_kill_windows.go
@@ -3,26 +3,22 @@ package builtin
 import (
 	"os/exec"
 	"strconv"
-	"syscall"
-)
 
-// The agent host can be a GUI process with no console of its own (the Wails
-// desktop app), so a console child like cmd.exe/powershell pops its own window
-// unless we ask for none. CREATE_NO_WINDOW isn't exported by syscall.
-const createNoWindow = 0x08000000
+	"reasonix/internal/proc"
+)
 
 // setKillTree hides the child's console and makes a cancelled command kill its
 // whole process tree. Windows does not cascade a kill to child processes, so
 // killing the shell leaves `go test` and the binaries it spawned running after an
 // Esc; taskkill /T walks the PID tree and /F forces it.
 func setKillTree(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true, CreationFlags: createNoWindow}
+	proc.HideWindow(cmd)
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil
 		}
 		kill := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(cmd.Process.Pid))
-		kill.SysProcAttr = &syscall.SysProcAttr{CreationFlags: createNoWindow}
+		proc.HideWindow(kill)
 		_ = kill.Run()
 		return cmd.Process.Kill()
 	}


### PR DESCRIPTION
## Problem

On Windows the desktop app repeatedly flashed a `cmd` window during task execution (#2846) and on new-session / session-switch / sidebar-toggle (#2831).

Root cause: the workspace "Changed" view shells out to git — `git status` + `git rev-parse` — on every turn end (and panel refresh). Those two spawns were the only subprocesses in the desktop that skipped the existing `proc.HideWindow` helper. Because the Wails app is a GUI process with no console of its own, each console child pops its own window; two git calls per refresh, once per turn, reads as constant flickering.

## Best-practice fix

The repo already had the right pattern, just split across two implementations:

- `proc.HideWindow` (used by codegraph, grep, hook, lsp, plugin, attachments) set **only** `CREATE_NO_WINDOW`.
- `bash_kill_windows.setKillTree` set **both** `HideWindow` + `CREATE_NO_WINDOW` — the more complete, widely-recommended form.

So this PR converges on **one** robust helper and uses it everywhere:

1. `proc.HideWindow` now sets `HideWindow: true` **and** `CREATE_NO_WINDOW`. `CREATE_NO_WINDOW` is the load-bearing flag that suppresses a console child's window (git, rg, a shell); `HideWindow` guards any GUI child that shows a window.
2. The two git spawns in `workspace_changes.go` route through `proc.HideWindow`.
3. `setKillTree` drops its duplicate `0x08000000` literal and calls `proc.HideWindow` for both the shell and the `taskkill` — single source of truth, no behaviour change.

## Verification

- `go build ./...`, `go vet`, `go test ./internal/proc/... ./internal/tool/builtin/...` — pass.
- desktop module `go build ./...` + `go test .` — pass.
- Built on Windows, so the `*_windows.go` files are compiled.

Closes #2846
Closes #2831
