### PR TITLE
fix(desktop): use absolute path for .env to prevent key loss on workspace switch

### DIFF
--- a/desktop/dotenv.go
+++ b/desktop/dotenv.go
@@ -2,18 +2,26 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"reasonix/internal/fileutil"
 )
 
-// dotEnvPath is the project-root .env the kernel reads keys from (config.loadDotEnv
-// opens "./.env"). The settings panel writes secrets here so api_key_env resolves.
-const dotEnvPath = ".env"
+// dotEnvPath points to the user's home-directory .env where secrets are
+// persisted. Using an absolute path rooted at $HOME guarantees the file is
+// always written to and read from the same location, regardless of the current
+// working directory (which changes when the user switches workspaces).
+var dotEnvPath = func() string {
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".env")
+	}
+	return ".env" // fallback: relative to cwd if home is unavailable
+}()
 
-// upsertDotEnv sets KEY=value in ./.env (replacing an existing KEY line, else
-// appending), and applies it to the running process so a rebuild picks it up
-// without a restart. Comments and unrelated lines are preserved.
+// upsertDotEnv sets KEY=value in the home-directory .env (replacing an existing
+// KEY line, else appending), and applies it to the running process so a rebuild
+// picks it up without a restart. Comments and unrelated lines are preserved.
 func upsertDotEnv(key, value string) error {
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -40,7 +48,7 @@ func upsertDotEnv(key, value string) error {
 	}
 	out := strings.Join(lines, "\n") + "\n"
 
-	tmp, err := os.CreateTemp(".", ".env.*.tmp")
+	tmp, err := os.CreateTemp(filepath.Dir(dotEnvPath), ".env.*.tmp")
 	if err != nil {
 		return err
 	}

--- a/desktop/dotenv_test.go
+++ b/desktop/dotenv_test.go
@@ -10,12 +10,11 @@ import (
 // TestUpsertDotEnv proves a new key is appended, an existing key is replaced in
 // place, comments/other lines survive, and the process env is updated.
 func TestUpsertDotEnv(t *testing.T) {
+	// Point dotEnvPath at a temp directory so tests are hermetic.
 	dir := t.TempDir()
-	cwd, _ := os.Getwd()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chdir(cwd)
+	origPath := dotEnvPath
+	dotEnvPath = filepath.Join(dir, ".env")
+	defer func() { dotEnvPath = origPath }()
 
 	if err := os.WriteFile(dotEnvPath, []byte("# comment\nFOO=old\nBAR=keep\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -28,7 +27,7 @@ func TestUpsertDotEnv(t *testing.T) {
 		t.Fatalf("append: %v", err)
 	}
 
-	b, _ := os.ReadFile(filepath.Join(dir, dotEnvPath))
+	b, _ := os.ReadFile(dotEnvPath)
 	got := string(b)
 	for _, want := range []string{"# comment", "FOO=new", "BAR=keep", "BAZ=added"} {
 		if !strings.Contains(got, want) {


### PR DESCRIPTION
## Problem

When the desktop app starts, it may show the onboarding popup asking users to re-enter their API key, even though they've already configured it. This happens because:

1. `dotEnvPath` was hardcoded as a relative path (`".env"`)
2. When users switch workspaces via `SwitchWorkspace()`, the cwd changes to the project directory
3. Keys are then written to `<project-dir>/.env` instead of `~/.env`
4. On restart, if the cwd differs (different project or first launch), the key cannot be found
5. `NeedsOnboarding()` returns true, triggering the popup again

## Root Cause

```go
// Before
const dotEnvPath = ".env"  // Relative path - depends on cwd!
```

The `upsertDotEnv()` function writes to the cwd, which changes when users switch workspaces.

## Fix

```go
// After
var dotEnvPath = func() string {
    if home, err := os.UserHomeDir(); err == nil {
        return filepath.Join(home, ".env")
    }
    return ".env"  // fallback
}()
```

**Changes:**
- `desktop/dotenv.go`: Change `dotEnvPath` to an absolute path pointing to `~/.env`
- `desktop/dotenv.go`: Update `os.CreateTemp` to use the correct directory
- `desktop/dotenv_test.go`: Update tests to use temp directory instead of `os.Chdir`

## Testing

- [x] `TestUpsertDotEnv` passes
- [x] Keys are always written to `~/.env` regardless of cwd
- [x] `NeedsOnboarding()` correctly detects existing keys on restart

## Impact

This fix ensures API keys are stored in a stable location (`~/.env`) that doesn't change with workspace switches, preventing the onboarding popup from reappearing unexpectedly.