### PR TITLE
style(desktop): trim dotEnvPath comment to one line

### DIFF
--- a/desktop/dotenv.go
+++ b/desktop/dotenv.go
@@ -8,10 +8,8 @@ import (
 	"reasonix/internal/fileutil"
 )
 
-// dotEnvPath points to the user's home-directory .env where secrets are
-// persisted. Using an absolute path rooted at $HOME guarantees the file is
-// always written to and read from the same location, regardless of the current
-// working directory (which changes when the user switches workspaces).
+// dotEnvPath is ~/.env (absolute, so a workspace switch — which changes cwd —
+// can't scatter or lose the key).
 var dotEnvPath = func() string {
 	if home, err := os.UserHomeDir(); err == nil {
 		return filepath.Join(home, ".env")


### PR DESCRIPTION
Follow-up to #2853. The `dotEnvPath` doc comment ran to four lines; the why (an absolute `~/.env` survives the cwd change a workspace switch causes) fits in one, and the fallback is self-evident from the code. Comment-only, no behavior change.