### PR TITLE
fix(cli): prevent welcome() from re-triggering setup when global config exists

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1255,11 +1255,20 @@ func readStdin() string {
 func welcome(version string) int {
 	src := config.SourcePath()
 
+	// Try loading config early — it merges user-global + cwd-local sources.
+	// A valid load means the user has configured before (possibly in another
+	// directory), so we should NOT re-trigger the setup wizard.
+	cfg, cfgErr := config.Load()
+	if cfgErr != nil {
+		cfg = config.Default()
+	}
+
 	// First run on an interactive terminal: actively guide setup rather than
 	// printing a static screen and exiting. interactiveSetup owns the language
 	// prompt and welcome banner so every prompt the user sees is already
-	// localized to their choice.
-	if src == "" && isInteractive() {
+	// localized to their choice. Only trigger when no config loads from ANY
+	// source (neither cwd-local nor user-global).
+	if src == "" && cfgErr != nil && isInteractive() {
 		if rc := interactiveSetup("reasonix.toml"); rc != 0 {
 			return rc
 		}
@@ -1276,17 +1285,12 @@ func welcome(version string) int {
 		return 0
 	}
 
-	cfg, cfgErr := config.Load()
-	if cfgErr != nil {
-		cfg = config.Default()
-	}
-
-	// reasonix.toml exists and parses on a terminal: go into chat. If any enabled
-	// provider's key isn't set yet, re-run the wizard's key-entry step inline
-	// — first run already chose language and providers, so we don't re-ask
-	// those. Skipping the prompts is still fine; the chat banner falls back to
-	// a one-line warning.
-	if src != "" && cfgErr == nil && isInteractive() {
+	// Config loads successfully (from any source) on a terminal: go into chat.
+	// If any enabled provider's key isn't set yet, re-run the wizard's key-entry
+	// step inline — first run already chose language and providers, so we don't
+	// re-ask those. Skipping the prompts is still fine; the chat banner falls
+	// back to a one-line warning.
+	if cfgErr == nil && isInteractive() {
 		if rc := promptMissingKeys(cfg); rc != 0 {
 			return rc
 		}


### PR DESCRIPTION
## Problem

When running `reasonix` without arguments from a directory that lacks `reasonix.toml`, the setup wizard is re-triggered even though a valid global config (`~/.config/reasonix/config.toml`) exists and loads successfully.

## Root Cause

In `welcome()` (internal/cli/cli.go), the setup trigger condition was:

```go
if src == "" && isInteractive() {   // src = config.SourcePath()
    interactiveSetup("reasonix.toml")  // ← triggers setup wizard
}
```

`SourcePath()` checks for `reasonix.toml` in cwd first, then falls back to the global user config. When the user runs `reasonix` from a different directory (e.g., after `cd`), ``SourcePath()` returns `""` because there's no cwd-local file — **even though `config.Load()` would succeed** from the global path.

The chat entry path also unnecessarily required `src != ""`:

```go
if src != "" && cfgErr == nil && isInteractive() {  // ← blocks chat when src is empty
    return chatREPL(nil)
}
```

## Fix

1. Move `config.Load()` **before** the setup-trigger check
2. Change trigger condition from `src == ""` to `src == "" && cfgErr != nil` — wizard only runs when no config loads from ANY source
3. Remove redundant `src != ""` guard on chat entry — `cfgErr == nil` is sufficient

```go
// Before: always triggered setup when no cwd-local file
if src == "" && isInteractive() {

// After: only triggers setup when config.Load() also fails
if src == "" && cfgErr != nil && isInteractive() {
```

## Testing

- `go build ./...` — compiles successfully
- `go test ./internal/config/` — all tests pass
- `go test ./internal/cli/` — 5 pre-existing i18n test failures unrelated to this change

Closes #2856