### PR TITLE
fix(codegraph): make install + init robust on Windows (Access-denied, hung init)

### DIFF
--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -21,9 +21,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"reasonix/internal/proc"
 )
+
+const initTimeout = 30 * time.Second
 
 // BundleDirName is the directory, beside the reasonix executable, that the release
 // archive unpacks the CodeGraph bundle into. Its launcher lives at
@@ -112,7 +115,11 @@ func EnsureInit(ctx context.Context, bin, root string) error {
 	if Initialized(root) {
 		return nil // already initialised — serve re-syncs and the watcher keeps it fresh
 	}
+	ctx, cancel := context.WithTimeout(ctx, initTimeout)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, "init", root)
+	cmd.Cancel = func() error { proc.KillTree(cmd); return nil }
+	cmd.WaitDelay = 3 * time.Second
 	proc.HideWindow(cmd)
 	cmd.Dir = root
 	if out, err := cmd.CombinedOutput(); err != nil {

--- a/internal/codegraph/install.go
+++ b/internal/codegraph/install.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 const (
@@ -22,6 +23,9 @@ const (
 	// with CODEGRAPH_VERSION in the Makefile and .github/workflows.
 	Version = "v0.9.7"
 	cgRepo  = "colbymchenry/codegraph"
+
+	renameAttempts = 5
+	renameBackoff  = 200 * time.Millisecond
 )
 
 // CacheDir is where the CodeGraph bundle is unpacked on first use:
@@ -141,12 +145,14 @@ func InstallWithClient(ctx context.Context, client *http.Client, log func(string
 	if err != nil {
 		return "", err
 	}
-	if err := os.Rename(root, dir); err != nil {
-		// A concurrent session may have won the race; accept its install.
+	if p, ok := cached(); ok {
+		return p, nil // a concurrent session already populated dir
+	}
+	if err := promote(root, dir); err != nil {
 		if p, ok := cached(); ok {
-			return p, nil
+			return p, nil // a concurrent winner landed during our retries
 		}
-		return "", err
+		return "", fmt.Errorf("codegraph: install to %s failed: %w — the cache directory may be read-only or locked by antivirus; set REASONIX_CACHE_DIR to a writable location to relocate it", dir, err)
 	}
 	p, ok := cached()
 	if !ok {
@@ -154,6 +160,23 @@ func InstallWithClient(ctx context.Context, client *http.Client, log func(string
 	}
 	logf(log, "codegraph: installed to %s", dir)
 	return p, nil
+}
+
+// promote moves the freshly extracted bundle (root) into its versioned home
+// (dir). On Windows os.Rename onto an existing directory fails with "Access is
+// denied", so a stale/partial dest from an earlier interrupted install (cached()
+// already reported it incomplete) is cleared first; a just-extracted .exe can
+// also stay briefly locked by an AV scanner, so the move is retried.
+func promote(root, dir string) error {
+	_ = os.RemoveAll(dir)
+	var err error
+	for i := 0; i < renameAttempts; i++ {
+		if err = os.Rename(root, dir); err == nil {
+			return nil
+		}
+		time.Sleep(renameBackoff)
+	}
+	return err
 }
 
 func httpGet(ctx context.Context, client *http.Client, url string) ([]byte, error) {

--- a/internal/codegraph/install_test.go
+++ b/internal/codegraph/install_test.go
@@ -31,6 +31,38 @@ func TestAssetNameForCurrentPlatform(t *testing.T) {
 	}
 }
 
+func TestPromoteReplacesStalePartialDest(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, ".dl-x", "codegraph-x64")
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bin", "codegraph"), []byte("new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(parent, "v0.9.7")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "stale.txt"), []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := promote(root, dir); err != nil {
+		t.Fatalf("promote over a stale dest: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(dir, "bin", "codegraph")); err != nil || string(got) != "new" {
+		t.Fatalf("dest missing promoted bundle: %q %v", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatal("stale dest content survived promote")
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Fatal("root should have been moved into dir")
+	}
+}
+
 func TestSha256For(t *testing.T) {
 	sums := "abc123  codegraph-linux-x64.tar.gz\ndef456  codegraph-darwin-arm64.tar.gz\n"
 	got, err := sha256For(sums, "codegraph-darwin-arm64.tar.gz")


### PR DESCRIPTION
## Problem

On Windows the codegraph background install could fail at the final step with

```
codegraph: install failed (rename ...\.dl-xxx\codegraph-win32-x64 ...\v0.9.7: Access is denied)
```

`os.Rename` onto an **existing** `v<ver>` directory fails with *Access denied* on Windows, so once a partial/interrupted install left a stale `v<ver>` behind, every subsequent launch re-hit the same rename and never recovered — it just degraded to grep/glob and retried forever. A freshly-extracted `.exe` briefly locked by an AV scanner produces the same failure transiently.

Separately, `EnsureInit` ran `codegraph init` **unbounded** (ctx = app lifetime). A broken/partial launcher could hang it, and since the `cmd → node` tree isn't killed as a unit on Windows, that could wedge boot.

## Fix

- **`install.go`** — `promote()` clears a stale (incomplete) destination before the move and retries to ride out a transient AV lock. On a genuine permission failure the error now points at `REASONIX_CACHE_DIR` so users on a locked-down or read-only install location can relocate the cache.
- **`codegraph.go`** — `EnsureInit` now caps `codegraph init` with a timeout and tree-kills the process tree on cancel (reusing `proc.KillTree`), so a hung init can't hold up startup.

## Tests

- `TestPromoteReplacesStalePartialDest` — a non-empty stale dest (the exact Access-denied repro; plain `os.Rename` onto it fails on every OS) is replaced cleanly.

## Notes

Builds on the stdio tree-kill fix already on main-v2 — together these make codegraph never able to wedge boot or loop on a failed install. codegraph remains optional: when it can't install, the agent degrades to grep/glob and the app stays fully usable.
