### PR TITLE
Restore mid-turn interject feedback + add CodeGraph prompt guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION := $(shell git describe --tags --always 2>/dev/null || echo dev)
 LDFLAGS := -s -w -X main.version=$(VERSION)
+GOEXE := $(shell go env GOEXE)
 
 # CodeGraph release pinned for the bundled MCP server / e2e test. Bump together
 # with any change to the integration in internal/codegraph.
@@ -8,8 +9,8 @@ CODEGRAPH_VERSION := v0.9.7
 .PHONY: build vet fmt test hooks cross clean e2e-codegraph
 
 build:
-	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix ./cmd/reasonix
-	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix-plugin-example ./cmd/reasonix-plugin-example
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix$(GOEXE) ./cmd/reasonix
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix-plugin-example$(GOEXE) ./cmd/reasonix-plugin-example
 
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ every [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases).
 ### Build from source
 
 ```sh
-make build      # -> bin/reasonix
+make build      # -> bin/reasonix(.exe)
 make cross      # -> dist/ (darwin|linux|windows × amd64|arm64)
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,7 +71,7 @@ brew install esengine/reasonix/reasonix   # macOS
 ### 从源码构建
 
 ```sh
-make build      # -> bin/reasonix
+make build      # -> bin/reasonix(.exe)
 make cross      # -> dist/（darwin|linux|windows × amd64|arm64）
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,96 @@
+version: '3'
+
+vars:
+  VERSION:
+    sh: git describe --tags --always 2>/dev/null || echo dev
+  LDFLAGS: '-s -w -X main.version={{.VERSION}}'
+  EXE_EXT:
+    sh: go env GOEXE
+  # CodeGraph release pinned for the bundled MCP server / e2e test. Bump
+  # together with any change to the integration in internal/codegraph.
+  CODEGRAPH_VERSION: v0.9.7
+
+tasks:
+  default:
+    desc: Build reasonix and the plugin example (default task)
+    cmds:
+      - task: build
+
+  build:
+    desc: Build reasonix and the plugin example
+    cmds:
+      - CGO_ENABLED=0 go build -ldflags '{{.LDFLAGS}}' -o bin/reasonix{{.EXE_EXT}} ./cmd/reasonix
+      - CGO_ENABLED=0 go build -ldflags '{{.LDFLAGS}}' -o bin/reasonix-plugin-example{{.EXE_EXT}} ./cmd/reasonix-plugin-example
+
+  install:
+    desc: Install reasonix via go install
+    cmds:
+      - CGO_ENABLED=0 go install -ldflags '{{.LDFLAGS}}' ./cmd/reasonix
+
+  vet:
+    desc: Run go vet ./...
+    cmds:
+      - go vet ./...
+
+  fmt:
+    desc: Format Go source code with gofmt
+    cmds:
+      - gofmt -w .
+
+  test:
+    desc: Run all tests (go test ./...)
+    cmds:
+      - go test ./...
+
+  hooks:
+    desc: Install git hooks (core.hooksPath -> .githooks)
+    cmds:
+      - 'git config core.hooksPath .githooks'
+      - 'echo "installed: core.hooksPath -> .githooks (pre-push runs go vet)"'
+    silent: true
+
+  cross:
+    desc: Cross-compile for darwin/amd64, darwin/arm64, linux/amd64, linux/arm64, windows/amd64, windows/arm64
+    cmds:
+      - |
+        mkdir -p dist
+        for p in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64; do
+          os=${p%/*}
+          arch=${p#*/}
+          ext=
+          [ "$os" = "windows" ] && ext=.exe
+          echo "build $os/$arch"
+          CGO_ENABLED=0 GOOS=$os GOARCH=$arch go build -ldflags '{{.LDFLAGS}}' -o dist/reasonix-$os-$arch$ext ./cmd/reasonix
+        done
+    silent: true
+
+  clean:
+    desc: Remove build output (bin/ dist/)
+    cmds:
+      - rm -rf bin dist
+
+  # Fetch the matching CodeGraph bundle into bin/codegraph/ (the distribution
+  # layout: launcher at bin/codegraph/bin/codegraph beside bin/reasonix) and
+  # run the gated MCP end-to-end test against it. Requires `gh`. Windows:
+  # install via the upstream install.ps1 and run the test with
+  # REASONIX_CODEGRAPH_BIN set.
+  e2e-codegraph:
+    desc: Fetch pinned CodeGraph release and run gated MCP e2e test
+    cmds:
+      - |
+        os=$(uname -s | tr 'A-Z' 'a-z')
+        arch=$(uname -m)
+        case $arch in
+          arm64|aarch64) arch=arm64 ;;
+          x86_64|amd64) arch=x64 ;;
+          *) echo "unsupported arch $arch"; exit 1 ;;
+        esac
+        asset=codegraph-$os-$arch.tar.gz
+        dest=bin/codegraph
+        echo "fetching $asset ({{.CODEGRAPH_VERSION}}) -> $dest"
+        rm -rf "$dest" && mkdir -p "$dest"
+        gh release download {{.CODEGRAPH_VERSION}} -R colbymchenry/codegraph -p "$asset" -O /tmp/$asset
+        tar -xzf /tmp/$asset -C "$dest" --strip-components=1
+        REASONIX_CODEGRAPH_E2E=1 REASONIX_CODEGRAPH_BIN=$PWD/$dest/bin/codegraph \
+          go test ./internal/codegraph/ -run E2E -v -count=1
+    silent: true

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -33,7 +33,7 @@ each GitHub release. Or build from source:
 
 ```sh
 git clone https://github.com/esengine/DeepSeek-Reasonix   # default: main-v2 (Go)
-cd DeepSeek-Reasonix && make build                        # -> bin/reasonix
+cd DeepSeek-Reasonix && make build                        # -> bin/reasonix(.exe)
 ```
 
 Until `1.0.0` is published to npm, `npm i -g reasonix` still installs the `0.x`

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -91,6 +91,11 @@ type chatTUI struct {
 	// untouched.
 	planMode bool
 
+	// pendingInterject holds user input queued while a turn is running. When the
+	// turn completes (TurnDone), this text is automatically submitted as the next
+	// turn — letting the user interject mid-execution without waiting.
+	pendingInterject string
+
 	// history is a resumed session's messages, committed to scrollback once on
 	// the first WindowSizeMsg so a reopened chat shows its prior transcript.
 	history []provider.Message
@@ -815,7 +820,16 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "enter":
 			if m.state == tuiRunning {
-				return m, nil // ignore Enter while a turn is in flight
+				line := strings.TrimSpace(m.input.Value())
+				if line == "" {
+					return m, nil
+				}
+				m.pendingInterject = line
+				m.input.Reset()
+				m.input.SetHeight(1)
+				m.pastedBlocks = nil
+				m.notice("feedback queued — will send when the current turn finishes")
+				return m, finalize(m, cmds)
 			}
 			if m.modelSwitchPending {
 				return m, nil // ignore Enter while /model switch is building
@@ -906,6 +920,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, fetchBalance(m.ctrl))
 			if c := m.runStatusline(); c != nil {
 				cmds = append(cmds, c)
+			}
+			if m.pendingInterject != "" {
+				interject := m.pendingInterject
+				m.pendingInterject = ""
+				cmds = append(cmds, m.startTurn(interject, interject, interject))
 			}
 		}
 
@@ -1482,6 +1501,9 @@ func (m chatTUI) View() tea.View {
 			working = fmt.Sprintf("  "+i18n.M.ChatStatusThinkingFmt, m.spinner.View(), m.elapsed)
 			if m.turnTokens > 0 {
 				working += " · ↓" + shortTokens(m.turnTokens)
+			}
+			if m.pendingInterject != "" {
+				working += dim(" · ✎ feedback queued")
 			}
 		}
 	}
@@ -2717,3 +2739,4 @@ type eventSink struct {
 }
 
 func (s *eventSink) Emit(e event.Event) { s.ch <- e }
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -438,7 +438,11 @@ keep exactly one in_progress, and flip each to completed as you finish it — up
 the list as you go, not just at the end.
 In plan mode the harness blocks writer tools: do read-only research, then write a
 concise plan as your reply and stop. The user is asked to approve before anything
-is changed; once approved, work through the steps, updating the task list as you go.`
+is changed; once approved, work through the steps, updating the task list as you go.
+CodeGraph code-intelligence tools (codegraph_explore, codegraph_search,
+codegraph_node, codegraph_callers, codegraph_callees, codegraph_impact,
+codegraph_files) understand your codebase at the AST level — prefer them over
+grep/read_file for code understanding.`
 
 // LanguagePolicy is the auto fallback appended to the system prompt when no
 // concrete UI language is resolved. It is static English text, so it stays part


### PR DESCRIPTION
## 变更内容

### 1. 恢复 turn 运行中的 interject 反馈（主要）

**问题：** Go 重写后，turn 运行期间按 Enter 直接被忽略（\eturn m, nil\），用户只能等当前 turn 跑完才能输入下一轮反馈。

**修复：** Enter 在 turn 运行中不再忽略，而是将输入排入 \pendingInterject\ 队列。当前 turn 完成后（TurnDone 事件），队列中的文本自动作为下一轮输入提交。

**改动文件：** \internal/cli/chat_tui.go\
- 新增 \pendingInterject string\ 字段
- Enter 处理：turn 运行中将输入排队，显示 \eedback queued\ 提示
- 状态栏：显示 \✎ feedback queued\ 指示器
- TurnDone：消费 \pendingInterject\ 并自动调用 \startTurn\

### 2. 默认 System Prompt 添加 CodeGraph 引导

在 \DefaultSystemPrompt\ 末尾添加段落，提示模型优先使用 codegraph_* 工具进行 AST 级别的代码理解。