### PR TITLE
style(desktop): add builtin badge variant on skill source rows

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4154,6 +4154,11 @@ body {
   background: color-mix(in srgb, var(--err) 7%, var(--bg-soft));
   color: var(--err);
 }
+.cap-source-badge--builtin {
+  border-color: color-mix(in srgb, var(--accent) 22%, var(--border));
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-soft));
+  color: color-mix(in srgb, var(--accent) 70%, var(--fg-dim));
+}
 .cap-source__meta {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Follow-up to #2874. The builtin-path source badge used a `--builtin` tone that had no matching CSS rule, so it fell back to the base badge style and looked identical to the `--scope` badge. Adds the missing variant with a subtle accent tint to distinguish built-in paths from configured/missing ones.