### PR TITLE
fix(desktop): strip crossorigin from built assets so macOS 12 webview loads

### DIFF
--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -1,10 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+
+// On macOS ≤ 12 (Safari 15 WebKit) a crossorigin module/stylesheet fetched over the
+// wails:// scheme is CORS-blocked (no Access-Control-Allow-Origin from the handler),
+// so the bundle never loads and the window paints blank; newer WebKit tolerates it.
+function stripCrossorigin(): Plugin {
+  return {
+    name: "strip-crossorigin",
+    enforce: "post",
+    transformIndexHtml: (html) => html.replace(/\s+crossorigin(?==["']|[\s/>])/g, ""),
+  };
+}
 
 // base: "./" so built asset URLs are relative. Wails serves the embedded dist from
 // the app root over the wails:// scheme, where absolute "/assets/..." URLs 404.
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), stripCrossorigin()],
   base: "./",
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Problem

Users on **macOS 12.6 Intel** report the downloaded desktop app launches to a **black screen**, while `wails dev` / `pnpm dev` runs fine on the same machine.

## Root cause

Vite emits the entry script and stylesheet with a `crossorigin` attribute:

```html
<script type="module" crossorigin src="./assets/index-*.js"></script>
<link rel="stylesheet" crossorigin href="./assets/index-*.css">
```

- In **dev**, assets are served from `http://127.0.0.1:5173` (a normal http origin), so the CORS-mode fetch the `crossorigin` attribute forces is satisfied.
- In the **packaged** app, assets are served by Wails over the `wails://` scheme. On the older WebKit shipped with macOS ≤ 12 (Safari 15), the `crossorigin` fetch over a custom scheme is treated as cross-origin and the scheme handler returns no `Access-Control-Allow-Origin`, so the request is blocked — the bundle never runs and only the dark window background paints, which reads as a black screen. Ventura+ WebKit tolerates it, so it only reproduces on macOS ≤ 12.

The window itself opens (hence a *dark* screen, not a crash or a Gatekeeper 'damaged' error), and the binary is universal + ad-hoc signed without hardened runtime, so architecture and JIT entitlements are not involved.

## Fix

A tiny `transformIndexHtml` plugin strips the `crossorigin` attribute from the built `index.html`. Wails serves everything same-origin, so CORS is not needed and the same-origin module/stylesheet load normally.

## Validation

- `tsc --noEmit` + `vite build` clean; built `index.html` no longer carries `crossorigin`.
- Needs a final confirmation on a macOS 12.6 machine (couldn't reproduce the old-WebKit path in CI).