### PR TITLE
fix(read): decode BOM-less UTF-16 instead of rejecting it as binary

### DIFF
--- a/internal/fileutil/encoding/encoding.go
+++ b/internal/fileutil/encoding/encoding.go
@@ -30,6 +30,12 @@ const (
 	// LossyUTF8 is not valid UTF-8 and not valid GB18030 — decoded lossily
 	// as UTF-8 with replacement characters so the model sees something.
 	LossyUTF8
+	// UTF16LENoBOM is UTF-16 Little-Endian without a BOM — common for source
+	// files saved by Windows tools. Detected heuristically from the NUL-byte
+	// pattern; written back without a BOM to preserve the original bytes.
+	UTF16LENoBOM
+	// UTF16BENoBOM is UTF-16 Big-Endian without a BOM.
+	UTF16BENoBOM
 )
 
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
@@ -44,6 +50,12 @@ func Detect(data []byte) (Kind, []byte) {
 		return UTF16LE, data
 	case len(data) >= 2 && data[0] == 0xFE && data[1] == 0xFF:
 		return UTF16BE, data
+	}
+	// BOM-less UTF-16 must be tried before utf8.Valid: its low bytes plus 0x00
+	// high bytes are all valid UTF-8 code units, so a naive check would tag a
+	// UTF-16 source file as UTF-8 and surface the embedded NULs as garbage.
+	if k, ok := DetectUTF16NoBOM(data); ok {
+		return k, data
 	}
 	if utf8.Valid(data) {
 		return UTF8, data
@@ -74,6 +86,38 @@ func DetectQuick(peek []byte) Kind {
 	return UTF8
 }
 
+// DetectUTF16NoBOM heuristically recognises BOM-less UTF-16 from the NUL-byte
+// distribution: ASCII-range text encodes one byte of payload and one 0x00 per
+// code unit, so the NULs cluster on odd offsets (LE) or even offsets (BE). It
+// requires a strong skew — one parity heavily NUL, the other almost none — so
+// genuine binary (NULs on both parities) and plain UTF-8 (no NULs) fall through.
+func DetectUTF16NoBOM(b []byte) (Kind, bool) {
+	n := len(b)
+	if n < 16 {
+		return UTF8, false
+	}
+	n &^= 1 // examine an even-length window so parity counts are comparable
+	var evenNUL, oddNUL int
+	for i := 0; i < n; i++ {
+		if b[i] != 0 {
+			continue
+		}
+		if i%2 == 0 {
+			evenNUL++
+		} else {
+			oddNUL++
+		}
+	}
+	half := n / 2
+	switch {
+	case oddNUL*10 >= half*3 && evenNUL*20 <= half:
+		return UTF16LENoBOM, true
+	case evenNUL*10 >= half*3 && oddNUL*20 <= half:
+		return UTF16BENoBOM, true
+	}
+	return UTF8, false
+}
+
 // Decode converts data from the given encoding to UTF-8 bytes.
 func Decode(data []byte, enc Kind) []byte {
 	switch enc {
@@ -83,6 +127,10 @@ func Decode(data []byte, enc Kind) []byte {
 		return decodeUTF16(data[2:], binary.LittleEndian)
 	case UTF16BE:
 		return decodeUTF16(data[2:], binary.BigEndian)
+	case UTF16LENoBOM:
+		return decodeUTF16(data, binary.LittleEndian)
+	case UTF16BENoBOM:
+		return decodeUTF16(data, binary.BigEndian)
 	case GB18030:
 		out, _, err := transform.Bytes(simplifiedchinese.GB18030.NewDecoder(), data)
 		if err != nil {
@@ -120,9 +168,13 @@ func Encode(text string, enc Kind) []byte {
 	case UTF8BOM:
 		return append(utf8BOM, []byte(text)...)
 	case UTF16LE:
-		return encodeUTF16(text, binary.LittleEndian)
+		return encodeUTF16(text, binary.LittleEndian, true)
 	case UTF16BE:
-		return encodeUTF16(text, binary.BigEndian)
+		return encodeUTF16(text, binary.BigEndian, true)
+	case UTF16LENoBOM:
+		return encodeUTF16(text, binary.LittleEndian, false)
+	case UTF16BENoBOM:
+		return encodeUTF16(text, binary.BigEndian, false)
 	case GB18030:
 		out, _, err := transform.Bytes(simplifiedchinese.GB18030.NewEncoder(), []byte(text))
 		if err != nil {
@@ -142,20 +194,21 @@ func decodeUTF16(b []byte, order binary.ByteOrder) []byte {
 	return []byte(string(utf16Decode(u)))
 }
 
-// encodeUTF16 converts a UTF-8 string to UTF-16 bytes with BOM.
-func encodeUTF16(text string, order binary.ByteOrder) []byte {
+// encodeUTF16 converts a UTF-8 string to UTF-16 bytes, with a BOM when withBOM.
+func encodeUTF16(text string, order binary.ByteOrder, withBOM bool) []byte {
 	runes := []rune(text)
 	encoded := utf16Encode(runes)
 
-	var bom [2]byte
-	if order == binary.LittleEndian {
-		bom[0], bom[1] = 0xFF, 0xFE
-	} else {
-		bom[0], bom[1] = 0xFE, 0xFF
-	}
-
 	var buf bytes.Buffer
-	buf.Write(bom[:])
+	if withBOM {
+		var bom [2]byte
+		if order == binary.LittleEndian {
+			bom[0], bom[1] = 0xFF, 0xFE
+		} else {
+			bom[0], bom[1] = 0xFE, 0xFF
+		}
+		buf.Write(bom[:])
+	}
 	for _, u := range encoded {
 		var b [2]byte
 		order.PutUint16(b[:], u)

--- a/internal/fileutil/encoding/encoding_test.go
+++ b/internal/fileutil/encoding/encoding_test.go
@@ -219,6 +219,77 @@ func TestRoundTripUTF8BOM(t *testing.T) {
 	}
 }
 
+// --- BOM-less UTF-16 ---
+
+func utf16NoBOM(t *testing.T, s string, order binary.ByteOrder) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	for _, r := range utf16.Encode([]rune(s)) {
+		_ = binary.Write(&b, order, r)
+	}
+	return b.Bytes()
+}
+
+func TestDetectUTF16LENoBOM(t *testing.T) {
+	in := utf16NoBOM(t, "// Created by 69431 on 2024/12/31\n#include \"x.h\"\n", binary.LittleEndian)
+	enc, _ := Detect(in)
+	if enc != UTF16LENoBOM {
+		t.Errorf("got %v, want UTF16LENoBOM", enc)
+	}
+}
+
+func TestDetectUTF16BENoBOM(t *testing.T) {
+	in := utf16NoBOM(t, "package main\nfunc main() {}\n", binary.BigEndian)
+	enc, _ := Detect(in)
+	if enc != UTF16BENoBOM {
+		t.Errorf("got %v, want UTF16BENoBOM", enc)
+	}
+}
+
+func TestDetectPlainUTF8NotUTF16(t *testing.T) {
+	enc, _ := Detect([]byte("the quick brown fox jumps over the lazy dog\n"))
+	if enc != UTF8 {
+		t.Errorf("ASCII text misdetected as %v", enc)
+	}
+}
+
+func TestDetectBinaryNotUTF16NoBOM(t *testing.T) {
+	// NULs on both parities — genuine binary must not look like BOM-less UTF-16.
+	bin := []byte{0x00, 0x00, 0x01, 0x00, 0x00, 0x02, 0xFF, 0x00, 0x00, 0x03, 0x00, 0x00, 0x04, 0x00, 0x00, 0x05, 0x00, 0x00}
+	if k, ok := DetectUTF16NoBOM(bin); ok {
+		t.Errorf("binary misdetected as %v", k)
+	}
+}
+
+func TestDecodeUTF16LENoBOM(t *testing.T) {
+	in := utf16NoBOM(t, "hello\nworld", binary.LittleEndian)
+	if out := string(Decode(in, UTF16LENoBOM)); out != "hello\nworld" {
+		t.Errorf("got %q", out)
+	}
+}
+
+func TestRoundTripUTF16LENoBOM(t *testing.T) {
+	original := "// c++ source\nint main() { return 0; }\n"
+	encoded := utf16NoBOM(t, original, binary.LittleEndian)
+
+	enc, _ := Detect(encoded)
+	if enc != UTF16LENoBOM {
+		t.Fatalf("detect: got %v", enc)
+	}
+	decoded := string(Decode(encoded, enc))
+	if decoded != original {
+		t.Fatalf("decode mismatch: %q", decoded)
+	}
+	edited := strings.Replace(decoded, "return 0", "return 1", 1)
+	reencoded := Encode(edited, enc)
+	if bytes.HasPrefix(reencoded, []byte{0xFF, 0xFE}) || bytes.HasPrefix(reencoded, []byte{0xFE, 0xFF}) {
+		t.Error("no-BOM re-encode leaked a BOM")
+	}
+	if redecoded := string(Decode(reencoded, enc)); redecoded != edited {
+		t.Errorf("round-trip failed: got %q, want %q", redecoded, edited)
+	}
+}
+
 // --- UTF-16 supplementary plane (surrogate pairs) ---
 
 func TestSurrogatePairRoundTrip(t *testing.T) {

--- a/internal/tool/builtin/readfile.go
+++ b/internal/tool/builtin/readfile.go
@@ -117,6 +117,18 @@ func (r readFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return r.scan(io.MultiReader(bytes.NewReader(body), f), p.Offset, p.Limit)
 	}
 
+	// BOM-less UTF-16 (Windows source files) has a NUL for every ASCII char but
+	// no BOM, so it reaches here; recognise it by its NUL pattern and decode it
+	// rather than rejecting it as binary.
+	if k, ok := fileenc.DetectUTF16NoBOM(peek); ok {
+		rest, rerr := io.ReadAll(f)
+		if rerr != nil {
+			return "", fmt.Errorf("read %s: %w", p.Path, rerr)
+		}
+		all := append(peek, rest...)
+		return r.scan(bytes.NewReader(fileenc.Decode(all, k)), p.Offset, p.Limit)
+	}
+
 	if bytes.IndexByte(peek, 0) >= 0 {
 		return "", fmt.Errorf("binary file %s (NUL byte detected); use `bash hexdump` or another tool", p.Path)
 	}

--- a/internal/tool/builtin/readfile_utf16_test.go
+++ b/internal/tool/builtin/readfile_utf16_test.go
@@ -1,0 +1,39 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+// TestReadFileBOMlessUTF16LE proves a Windows-style UTF-16 source file with no
+// BOM is decoded rather than rejected as binary on the NUL-byte check.
+func TestReadFileBOMlessUTF16LE(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CameraManagerLogLoader.cpp")
+	src := "// Created by 69431 on 2024/12/31\n#include \"alson/CameraManagerLogLoader.h\"\n"
+	var b bytes.Buffer
+	for _, u := range utf16.Encode([]rune(src)) {
+		_ = binary.Write(&b, binary.LittleEndian, u)
+	}
+	if err := os.WriteFile(path, b.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	args, _ := json.Marshal(map[string]any{"path": path})
+	out, err := readFile{}.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("read rejected BOM-less UTF-16: %v", err)
+	}
+	if !strings.Contains(out, "Created by 69431") || !strings.Contains(out, "#include") {
+		t.Fatalf("UTF-16 content not decoded:\n%s", out)
+	}
+	if strings.Contains(out, "\x00") {
+		t.Fatal("NUL bytes leaked into decoded output")
+	}
+}


### PR DESCRIPTION
## Problem

`read_file` refuses Windows source files saved as **BOM-less UTF-16** with `binary file ... (NUL byte detected)`, forcing the model into `hexdump`/`Get-Content` fallbacks. v1 read these fine.

A UTF-16 file with no BOM (e.g. a `.cpp` starting with `//` → bytes `2F 00 2F 00 …`) carries a `0x00` after every ASCII byte. `read_file` only recognised UTF-16 by its BOM (FF FE / FE FF); without one the file fell through to the NUL-byte guard and was rejected. `encoding.Detect` had the same blind spot — and worse, `utf8.Valid` returns true for those bytes (0x00 is a valid UTF-8 code unit), so editing such a file would have treated it as UTF-8.

## Fix

- `DetectUTF16NoBOM`: a NUL-distribution heuristic — BOM-less UTF-16 clusters NULs on odd offsets (LE) or even offsets (BE); it requires a strong skew (one parity heavily NUL, the other almost none) so genuine binary and plain UTF-8 fall through unchanged.
- Run it ahead of the `utf8.Valid` check in `Detect`, and ahead of the NUL-byte rejection in `read_file`.
- New `UTF16LENoBOM`/`UTF16BENoBOM` kinds decode from offset 0 and **re-encode without a BOM**, so `edit_file` round-trips the original bytes without injecting a BOM.

## Validation

- `go test ./internal/fileutil/encoding ./internal/tool/builtin` — pass
- New tests: detect/decode/round-trip for BOM-less LE+BE, a `read_file` test on a BOM-less UTF-16 `.cpp`, and negative guards (plain ASCII and NUL-on-both-parities binary stay unaffected).
- `go vet` clean, gofmt clean.