### PR TITLE
feat(cli): show git status in default status line

### DIFF
--- a/docs/assets/cli-git-statusline-preview.svg
+++ b/docs/assets/cli-git-statusline-preview.svg
@@ -1,0 +1,25 @@
+<svg width="1320" height="310" viewBox="0 0 1320 310" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Reasonix CLI git status line preview</title>
+  <desc id="desc">Terminal preview showing the built-in Reasonix status line with repository, branch, changed line counts, and untracked file count.</desc>
+  <rect width="1320" height="310" rx="18" fill="#1f2430"/>
+  <rect x="22" y="22" width="1276" height="266" rx="12" fill="#272b38" stroke="#3f4558"/>
+  <line x1="22" y1="96" x2="1298" y2="96" stroke="#666b7d"/>
+  <line x1="22" y1="184" x2="1298" y2="184" stroke="#666b7d"/>
+  <text x="48" y="66" fill="#c8d3ff" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="32">&gt; </text>
+  <rect x="86" y="39" width="13" height="38" rx="2" fill="#c8d3ff"/>
+  <text x="48" y="148" fill="#e5e7eb" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="28">Implement default git status in the built-in CLI status line</text>
+  <text x="48" y="238" fill="#1596ff" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">deepseek-v4-pro[1m]</text>
+  <text x="322" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">|</text>
+  <rect x="350" y="205" width="606" height="52" rx="8" fill="#202637" stroke="#f97316" stroke-width="3"/>
+  <text x="372" y="238" fill="#1aa3a3" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">DeepSeek-Reasonix</text>
+  <text x="630" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">@</text>
+  <text x="648" y="238" fill="#22c55e" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">main-v2</text>
+  <text x="760" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26"> (</text>
+  <text x="795" y="238" fill="#22c55e" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">+15</text>
+  <text x="852" y="238" fill="#ef4444" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">-0</text>
+  <text x="897" y="238" fill="#f59e0b" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">?1</text>
+  <text x="932" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">)</text>
+  <text x="980" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">| effort: max | 5h - | 7d -</text>
+  <text x="48" y="274" fill="#ff6b8a" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="24">Auto ready</text>
+  <text x="184" y="274" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="24">(shift+tab to cycle)</text>
+</svg>

--- a/docs/assets/cli-git-statusline-preview.svg
+++ b/docs/assets/cli-git-statusline-preview.svg
@@ -11,7 +11,7 @@
   <text x="48" y="238" fill="#1596ff" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">deepseek-v4-pro[1m]</text>
   <text x="322" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">|</text>
   <rect x="350" y="205" width="606" height="52" rx="8" fill="#202637" stroke="#f97316" stroke-width="3"/>
-  <text x="372" y="238" fill="#1aa3a3" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">DeepSeek-Reasonix</text>
+  <text x="372" y="238" fill="#f59e0b" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">DeepSeek-Reasonix</text>
   <text x="630" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">@</text>
   <text x="648" y="238" fill="#22c55e" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26">main-v2</text>
   <text x="760" y="238" fill="#8b90a0" font-family="SFMono-Regular, Menlo, Consolas, monospace" font-size="26"> (</text>

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1508,21 +1508,21 @@ func (m chatTUI) View() tea.View {
 	switch {
 	case m.ctrl.Bypass():
 		modeTag = lipgloss.NewStyle().
-			Background(lipgloss.Color("#e5484d")).
+			Background(lipgloss.Color(statusYoloColor.hex)).
 			Foreground(lipgloss.Color("#ffffff")).
 			Bold(true).
 			Padding(0, 1).
 			Render("YOLO")
 	case m.planMode:
 		modeTag = lipgloss.NewStyle().
-			Background(lipgloss.Color("#2563eb")).
+			Background(lipgloss.Color(statusPlanColor.hex)).
 			Foreground(lipgloss.Color("#ffffff")).
 			Bold(true).
 			Padding(0, 1).
 			Render("Plan")
 	default:
 		modeTag = lipgloss.NewStyle().
-			Background(lipgloss.Color("#f59e0b")).
+			Background(lipgloss.Color(statusAutoColor.hex)).
 			Foreground(lipgloss.Color("#111827")).
 			Bold(true).
 			Padding(0, 1).

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -232,6 +232,7 @@ type chatTUI struct {
 	// place of the built-in data row.
 	statuslineCmd string
 	statuslineOut string
+	gitStatus     gitStatus
 
 	// modelSwitchPending is true while an async /model build is in flight.
 	modelSwitchPending bool
@@ -279,6 +280,10 @@ type balanceMsg struct{ text string }
 // when none/failed).
 type statuslineMsg struct{ out string }
 
+// gitStatusMsg carries the latest lightweight git readout for the built-in
+// status line. Empty means "not a git worktree" or "git unavailable".
+type gitStatusMsg struct{ status gitStatus }
+
 // runStatusline runs the user's custom status-line command off the event loop,
 // feeding it a small JSON context on stdin and returning its first stdout line.
 // A no-op (nil) when no command is configured. Tight timeout so a slow script
@@ -289,10 +294,12 @@ func (m chatTUI) runStatusline() tea.Cmd {
 		return nil
 	}
 	used, window := m.ctrl.ContextSnapshot()
+	cwd, _ := os.Getwd()
 	payload, _ := json.Marshal(map[string]any{
 		"model":         m.label,
 		"contextUsed":   used,
 		"contextWindow": window,
+		"cwd":           cwd,
 	})
 	return func() tea.Msg { return statuslineMsg{out: runStatuslineCmd(cmd, string(payload))} }
 }
@@ -311,6 +318,13 @@ func runStatuslineCmd(cmd, stdinPayload string) string {
 		out = strings.TrimSpace(out[:i])
 	}
 	return out
+}
+
+func (m chatTUI) refreshGitStatus() tea.Cmd {
+	if m.statuslineCmd != "" {
+		return nil
+	}
+	return fetchGitStatus()
 }
 
 // modelSwitchMsg carries the result of an async /model switch. A nil err means
@@ -486,6 +500,7 @@ func (m chatTUI) Init() tea.Cmd {
 		waitForAgentEvent(m.eventCh),
 		fetchBalance(m.ctrl),
 		m.runStatusline(), // nil (no-op) unless a custom status line is configured
+		m.refreshGitStatus(),
 	)
 }
 
@@ -895,6 +910,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		e := event.Event(msg)
 		m.ingestEvent(e)
 		turnDone := e.Kind == event.TurnDone
+		gitMaybeChanged := e.Kind == event.ToolResult && !e.Tool.ReadOnly
 		// Coalesce a burst: the goroutine that produced this event has already
 		// exited (a Cmd reads the channel once), so it's safe to drain the events
 		// already buffered and ingest them now. One re-wrap then covers the whole
@@ -909,6 +925,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if e2.Kind == event.TurnDone {
 					turnDone = true
 				}
+				if e2.Kind == event.ToolResult && !e2.Tool.ReadOnly {
+					gitMaybeChanged = true
+				}
 			default:
 				break drain
 			}
@@ -922,12 +941,20 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, c)
 			}
 		}
+		if turnDone || gitMaybeChanged {
+			if c := m.refreshGitStatus(); c != nil {
+				cmds = append(cmds, c)
+			}
+		}
 
 	case balanceMsg:
 		m.balance = msg.text
 
 	case statuslineMsg:
 		m.statuslineOut = msg.out
+
+	case gitStatusMsg:
+		m.gitStatus = msg.status
 
 	case compactDoneMsg:
 		if msg.err != nil {
@@ -1536,14 +1563,17 @@ func (m chatTUI) View() tea.View {
 			}
 		}
 	}
-	// Second status row: the live data (model, effort, context gauge, cache rates,
-	// jobs, balance). It lives on its own fixed row so it's always shown in full
-	// rather than being truncated off the end of the status line. Two rows is a
-	// fixed height, so unlike a wrap-when-long status it doesn't reintroduce
+	// Second status row: the live data (model, git, effort, context gauge, cache
+	// rates, jobs, balance). It lives on its own fixed row so it's always shown in
+	// full rather than being truncated off the end of the status line. Two rows is
+	// a fixed height, so unlike a wrap-when-long status it doesn't reintroduce
 	// resize ghosting.
 	var data []string
 	if mt := m.modelTag(); mt != "" {
 		data = append(data, mt)
+	}
+	if gt := m.gitTag(); gt != "" {
+		data = append(data, gt)
 	}
 	if et := m.effortTag(); et != "" {
 		data = append(data, et)

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -117,15 +117,36 @@ func countUntracked(out string) int {
 }
 
 func (m chatTUI) gitTag() string {
-	return m.gitStatus.Render()
+	return m.gitStatus.RenderRepo(themeFg(m.statusModeColor(), m.gitStatus.Repo))
+}
+
+var (
+	statusAutoColor = cliColor{"#f59e0b", 214}
+	statusPlanColor = cliColor{"#2563eb", 27}
+	statusYoloColor = cliColor{"#e5484d", 167}
+)
+
+func (m chatTUI) statusModeColor() cliColor {
+	switch {
+	case m.ctrl != nil && m.ctrl.Bypass():
+		return statusYoloColor
+	case m.planMode:
+		return statusPlanColor
+	default:
+		return statusAutoColor
+	}
 }
 
 func (s gitStatus) Render() string {
+	return s.RenderRepo(accent(s.Repo))
+}
+
+func (s gitStatus) RenderRepo(repo string) string {
 	if strings.TrimSpace(s.Repo) == "" || strings.TrimSpace(s.Branch) == "" {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString(accent(s.Repo))
+	b.WriteString(repo)
 	b.WriteString(dim("@"))
 	if s.Detached {
 		b.WriteString(yellow(s.Branch))

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -1,0 +1,147 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const gitStatusTimeout = 700 * time.Millisecond
+
+type gitStatus struct {
+	Repo      string
+	Branch    string
+	Detached  bool
+	Added     int
+	Removed   int
+	Untracked int
+}
+
+func fetchGitStatus() tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), gitStatusTimeout)
+		defer cancel()
+		status, err := loadGitStatus(ctx, "")
+		if err != nil {
+			return gitStatusMsg{}
+		}
+		return gitStatusMsg{status: status}
+	}
+}
+
+func loadGitStatus(ctx context.Context, cwd string) (gitStatus, error) {
+	root, err := runGit(ctx, cwd, "rev-parse", "--show-toplevel")
+	if err != nil {
+		return gitStatus{}, err
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return gitStatus{}, errors.New("empty git root")
+	}
+
+	status := gitStatus{Repo: filepath.Base(root)}
+	if branch, err := runGit(ctx, root, "symbolic-ref", "--quiet", "--short", "HEAD"); err == nil && strings.TrimSpace(branch) != "" {
+		status.Branch = strings.TrimSpace(branch)
+	} else if sha, err := runGit(ctx, root, "rev-parse", "--short", "HEAD"); err == nil && strings.TrimSpace(sha) != "" {
+		status.Branch = strings.TrimSpace(sha)
+		status.Detached = true
+	} else if ref, err := runGit(ctx, root, "symbolic-ref", "--short", "HEAD"); err == nil && strings.TrimSpace(ref) != "" {
+		status.Branch = strings.TrimSpace(ref)
+	}
+	if status.Branch == "" {
+		status.Branch = "HEAD"
+		status.Detached = true
+	}
+
+	if out, err := runGit(ctx, root, "diff", "--numstat", "HEAD", "--"); err == nil {
+		status.Added, status.Removed = parseGitNumstat(out)
+	}
+	if out, err := runGit(ctx, root, "status", "--porcelain=v1", "--untracked-files=normal"); err == nil {
+		status.Untracked = countUntracked(out)
+	}
+	return status, nil
+}
+
+func runGit(ctx context.Context, cwd string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if cwd != "" {
+		cmd.Dir = cwd
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func parseGitNumstat(out string) (added int, removed int) {
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] != "-" {
+			if n, err := strconv.Atoi(fields[0]); err == nil {
+				added += n
+			}
+		}
+		if fields[1] != "-" {
+			if n, err := strconv.Atoi(fields[1]); err == nil {
+				removed += n
+			}
+		}
+	}
+	return added, removed
+}
+
+func countUntracked(out string) int {
+	n := 0
+	for _, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if strings.HasPrefix(line, "?? ") {
+			n++
+		}
+	}
+	return n
+}
+
+func (m chatTUI) gitTag() string {
+	return m.gitStatus.Render()
+}
+
+func (s gitStatus) Render() string {
+	if strings.TrimSpace(s.Repo) == "" || strings.TrimSpace(s.Branch) == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(accent(s.Repo))
+	b.WriteString(dim("@"))
+	if s.Detached {
+		b.WriteString(yellow(s.Branch))
+	} else {
+		b.WriteString(green(s.Branch))
+	}
+
+	var parts []string
+	if s.Added > 0 || s.Removed > 0 {
+		parts = append(parts, green(fmt.Sprintf("+%d", s.Added)), red(fmt.Sprintf("-%d", s.Removed)))
+	}
+	if s.Untracked > 0 {
+		parts = append(parts, yellow(fmt.Sprintf("?%d", s.Untracked)))
+	}
+	if len(parts) > 0 {
+		b.WriteString(dim(" ("))
+		b.WriteString(strings.Join(parts, " "))
+		b.WriteString(dim(")"))
+	}
+	return b.String()
+}

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -74,6 +75,7 @@ func runGit(ctx context.Context, cwd string, args ...string) (string, error) {
 	if cwd != "" {
 		cmd.Dir = cwd
 	}
+	cmd.Env = append(os.Environ(), "GIT_OPTIONAL_LOCKS=0")
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/internal/cli/gitstatus_test.go
+++ b/internal/cli/gitstatus_test.go
@@ -39,6 +39,13 @@ func TestGitStatusRender(t *testing.T) {
 	}
 }
 
+func TestGitStatusRenderRepoUsesSuppliedRepoStyle(t *testing.T) {
+	got := ansi.Strip(gitStatus{Repo: "repo", Branch: "main"}.RenderRepo("[repo]"))
+	if got != "[repo]@main" {
+		t.Fatalf("RenderRepo = %q, want styled repo name only", got)
+	}
+}
+
 func TestLoadGitStatus(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")

--- a/internal/cli/gitstatus_test.go
+++ b/internal/cli/gitstatus_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+func TestParseGitNumstat(t *testing.T) {
+	added, removed := parseGitNumstat("10\t2\ta.go\n-\t-\tasset.bin\n3\t0\tpath with spaces.go\n")
+	if added != 13 || removed != 2 {
+		t.Fatalf("parseGitNumstat = (+%d -%d), want (+13 -2)", added, removed)
+	}
+}
+
+func TestCountUntracked(t *testing.T) {
+	got := countUntracked(" M tracked.go\n?? new.go\n?? nested/\n")
+	if got != 2 {
+		t.Fatalf("countUntracked = %d, want 2", got)
+	}
+}
+
+func TestGitStatusRender(t *testing.T) {
+	got := ansi.Strip(gitStatus{Repo: "mySkills", Branch: "main", Added: 15}.Render())
+	if got != "mySkills@main (+15 -0)" {
+		t.Fatalf("Render = %q", got)
+	}
+
+	got = ansi.Strip(gitStatus{Repo: "repo", Branch: "abc1234", Detached: true, Untracked: 2}.Render())
+	if got != "repo@abc1234 (?2)" {
+		t.Fatalf("detached Render = %q", got)
+	}
+}
+
+func TestLoadGitStatus(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found")
+	}
+
+	root := t.TempDir()
+	runGitForTest(t, root, "init")
+	runGitForTest(t, root, "config", "user.email", "reasonix@example.invalid")
+	runGitForTest(t, root, "config", "user.name", "Reasonix Test")
+	writeFileForTest(t, filepath.Join(root, "tracked.txt"), "one\ntwo\n")
+	runGitForTest(t, root, "add", "tracked.txt")
+	runGitForTest(t, root, "commit", "-m", "initial")
+	runGitForTest(t, root, "branch", "-M", "main")
+
+	writeFileForTest(t, filepath.Join(root, "tracked.txt"), "one\nchanged\nthree\n")
+	writeFileForTest(t, filepath.Join(root, "new.txt"), "untracked\n")
+	if err := os.Mkdir(filepath.Join(root, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	status, err := loadGitStatus(ctx, filepath.Join(root, "subdir"))
+	if err != nil {
+		t.Fatalf("loadGitStatus: %v", err)
+	}
+	if status.Repo != filepath.Base(root) || status.Branch != "main" || status.Detached {
+		t.Fatalf("status identity = %+v", status)
+	}
+	if status.Added != 2 || status.Removed != 1 || status.Untracked != 1 {
+		t.Fatalf("status changes = (+%d -%d ?%d), want (+2 -1 ?1)", status.Added, status.Removed, status.Untracked)
+	}
+	if plain := ansi.Strip(status.Render()); !strings.Contains(plain, filepath.Base(root)+"@main") || !strings.Contains(plain, "+2 -1 ?1") {
+		t.Fatalf("rendered status = %q", plain)
+	}
+}
+
+func runGitForTest(t *testing.T, cwd string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = cwd
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeFileForTest(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/cli/gitstatus_test.go
+++ b/internal/cli/gitstatus_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -72,6 +73,30 @@ func TestLoadGitStatus(t *testing.T) {
 	}
 	if plain := ansi.Strip(status.Render()); !strings.Contains(plain, filepath.Base(root)+"@main") || !strings.Contains(plain, "+2 -1 ?1") {
 		t.Fatalf("rendered status = %q", plain)
+	}
+}
+
+func TestRunGitDisablesOptionalLocks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell script fake git")
+	}
+
+	bin := filepath.Join(t.TempDir(), "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeGit := filepath.Join(bin, "git")
+	if err := os.WriteFile(fakeGit, []byte("#!/bin/sh\nprintf '%s' \"$GIT_OPTIONAL_LOCKS\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := runGit(context.Background(), "", "status")
+	if err != nil {
+		t.Fatalf("runGit: %v", err)
+	}
+	if out != "0" {
+		t.Fatalf("GIT_OPTIONAL_LOCKS = %q, want 0", out)
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -212,7 +212,7 @@ func RenderTOML(c *Config) string {
 
 	b.WriteString("[statusline]\n")
 	b.WriteString("# A custom status line: a command whose first stdout line replaces the built-in\n")
-	b.WriteString("# data row. It receives {\"model\",\"contextUsed\",\"contextWindow\"} as JSON on stdin.\n")
+	b.WriteString("# data row. It receives {\"model\",\"contextUsed\",\"contextWindow\",\"cwd\"} as JSON on stdin.\n")
 	if c.Statusline.Command != "" {
 		fmt.Fprintf(&b, "command = %q\n", c.Statusline.Command)
 	} else {


### PR DESCRIPTION
## Summary
- Add a built-in async git status readout to the CLI data row.
- Render `repo@branch` with tracked line deltas and untracked file count when available.
- Keep custom `[statusline].command` behavior as an override, and include `cwd` in its JSON stdin payload.
- Add focused parser/rendering tests plus a preview asset for the PR.

## Preview
![Reasonix CLI git status line preview](https://raw.githubusercontent.com/SivanCola/DeepSeek-Reasonix/codex/default-git-statusline/docs/assets/cli-git-statusline-preview.svg)

## Tests
- `xmllint --noout docs/assets/cli-git-statusline-preview.svg`
- `HOME=$(mktemp -d) XDG_CONFIG_HOME=$(mktemp -d) go test ./internal/cli ./internal/config`

Note: `go test ./...` was also run locally and failed only in the existing macOS sandbox confinement checks for `internal/sandbox` and `internal/tool/builtin`, where outside-root writes were not denied in this environment.