### PR TITLE
fix(build): append GOEXE so make build names the Windows binary .exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION := $(shell git describe --tags --always 2>/dev/null || echo dev)
 LDFLAGS := -s -w -X main.version=$(VERSION)
+GOEXE := $(shell go env GOEXE)
 
 # CodeGraph release pinned for the bundled MCP server / e2e test. Bump together
 # with any change to the integration in internal/codegraph.
@@ -8,8 +9,8 @@ CODEGRAPH_VERSION := v0.9.7
 .PHONY: build vet fmt test hooks cross clean e2e-codegraph
 
 build:
-	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix ./cmd/reasonix
-	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix-plugin-example ./cmd/reasonix-plugin-example
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix$(GOEXE) ./cmd/reasonix
+	CGO_ENABLED=0 go build -ldflags "$(LDFLAGS)" -o bin/reasonix-plugin-example$(GOEXE) ./cmd/reasonix-plugin-example
 
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ every [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases).
 ### Build from source
 
 ```sh
-make build      # -> bin/reasonix
+make build      # -> bin/reasonix(.exe)
 make cross      # -> dist/ (darwin|linux|windows × amd64|arm64)
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -71,7 +71,7 @@ brew install esengine/reasonix/reasonix   # macOS
 ### 从源码构建
 
 ```sh
-make build      # -> bin/reasonix
+make build      # -> bin/reasonix(.exe)
 make cross      # -> dist/（darwin|linux|windows × amd64|arm64）
 ```
 

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -33,7 +33,7 @@ each GitHub release. Or build from source:
 
 ```sh
 git clone https://github.com/esengine/DeepSeek-Reasonix   # default: main-v2 (Go)
-cd DeepSeek-Reasonix && make build                        # -> bin/reasonix
+cd DeepSeek-Reasonix && make build                        # -> bin/reasonix(.exe)
 ```
 
 Until `1.0.0` is published to npm, `npm i -g reasonix` still installs the `0.x`


### PR DESCRIPTION
`make build` hardcoded `-o bin/reasonix`, so on Windows it produced an extensionless binary that won't run. Add `GOEXE := $(shell go env GOEXE)` so the suffix is correct cross-platform, and reflect `bin/reasonix(.exe)` in the build docs (README, README.zh-CN, MIGRATING).

Extracted from #2871 by @Qxy0happy — taking the build-suffix fix; leaving the bundled Taskfile out to avoid maintaining a second build system alongside the Makefile.

Closes #2871