### PR TITLE
fix(setup): collect the API key before probing /models so Pro isn't hidden

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -738,6 +738,16 @@ func selectEnabledProviders(providers []config.ProviderEntry) ([]config.Provider
 		probe := providers[famMembers[familyKey][0]]
 		famName := famInfo[familyKey].name
 
+		// Seed the probe's static list with every member of the family (e.g. the
+		// flash and pro SKUs), not just the first — so a failed /models probe
+		// falls back to the whole family instead of collapsing to one model.
+		probe.Models = familyStaticModels(providers, famMembers[familyKey])
+
+		// Collect the key before probing /models: a keyless probe 401s and the
+		// fallback would hide the live SKUs. Mirrors the custom/anthropic flows;
+		// configureKeys later sees the env var set and won't ask twice.
+		ensureProbeKey(&probe, famName)
+
 		models := fetchOrFallback(&probe, famName)
 		if len(models) == 0 {
 			fmt.Fprintf(os.Stderr, "  %s\n", dim(fmt.Sprintf(i18n.M.NoModelsAvailableFmt, famName)))
@@ -760,6 +770,39 @@ func selectEnabledProviders(providers []config.ProviderEntry) ([]config.Provider
 		enabled = append(enabled, buildFamilyEntry(probe, selected))
 	}
 	return enabled, nil
+}
+
+// familyStaticModels unions the preset model lists of every entry in the family,
+// preserving order and dropping duplicates. It is the fallback offered when the
+// live /models probe fails, so a family with separate flash/pro preset entries
+// still surfaces both rather than only the first member's model.
+func familyStaticModels(providers []config.ProviderEntry, idxs []int) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, i := range idxs {
+		for _, m := range providers[i].ModelList() {
+			if m != "" && !seen[m] {
+				seen[m] = true
+				out = append(out, m)
+			}
+		}
+	}
+	return out
+}
+
+// ensureProbeKey prompts once for the family's API key when it isn't already in
+// the environment, so the /models probe can run and return the live SKU list.
+// The value is set in the env for the probe; configureKeys persists it to .env
+// later and skips re-asking. A blank entry is fine — the static fallback covers it.
+func ensureProbeKey(probe *config.ProviderEntry, famName string) {
+	if probe.APIKeyEnv == "" || os.Getenv(probe.APIKeyEnv) != "" {
+		return
+	}
+	fmt.Printf("  %s\n", dim(fmt.Sprintf(i18n.M.FamilyKeyPromptFmt, famName)))
+	in := bufio.NewScanner(os.Stdin)
+	if key := strings.TrimSpace(ask(in, os.Stdout, "  "+probe.APIKeyEnv, "")); key != "" {
+		os.Setenv(probe.APIKeyEnv, key)
+	}
 }
 
 // fetchOrFallback tries the OpenAI-compatible GET /models endpoint

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -240,6 +240,33 @@ func TestFetchOrFallback(t *testing.T) {
 	})
 }
 
+// TestFamilyStaticModels proves the offline fallback unions every member of a
+// family (the flash + pro SKUs), not just the first — the regression that left
+// users with only flash when the live /models probe failed.
+func TestFamilyStaticModels(t *testing.T) {
+	providers := []config.ProviderEntry{
+		{Name: "deepseek-flash", Model: "deepseek-v4-flash"},
+		{Name: "deepseek-pro", Model: "deepseek-v4-pro"},
+		{Name: "mimo-flash", Model: "mimo-v2.5"},
+	}
+	got := familyStaticModels(providers, []int{0, 1})
+	want := []string{"deepseek-v4-flash", "deepseek-v4-pro"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFamilyStaticModelsDedupes(t *testing.T) {
+	providers := []config.ProviderEntry{
+		{Name: "a", Models: []string{"x", "y"}},
+		{Name: "b", Models: []string{"y", "z"}},
+	}
+	got := familyStaticModels(providers, []int{0, 1})
+	if !reflect.DeepEqual(got, []string{"x", "y", "z"}) {
+		t.Errorf("got %v, want x/y/z deduped", got)
+	}
+}
+
 // TestBuildFamilyEntry covers the three observable behaviors:
 //   - The selected models land in the entry's Models field, with Model
 //     pointed at the first one so legacy single-model lookups still work.

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -231,6 +231,7 @@ type Messages struct {
 	FetchModelsSuccessFmt      string // "Found %d models for %s"
 	FetchModelsFailedFmt       string // "Failed to fetch models for %s: %v"
 	FetchModelsUsingPresetsFmt string // "Live fetch unavailable for %s, using preset model list"
+	FamilyKeyPromptFmt         string // "Enter your %s API key to list available models (Enter to skip):"
 	SelectModelsLabel          string // "Select models to enable for %s"
 	NoModelsAvailableFmt       string // "%s: no models available, skipping"
 	CustomFetchEmpty           string // "/models returned an empty list — falling back to manual entry"

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -195,6 +195,7 @@ var English = Messages{
 	FetchModelsSuccessFmt:      "Found %d models for %s",
 	FetchModelsFailedFmt:       "Failed to fetch models for %s: %v",
 	FetchModelsUsingPresetsFmt: "Live fetch unavailable for %s, using preset model list",
+	FamilyKeyPromptFmt:         "Enter your %s API key to list available models (Enter to skip):",
 	SelectModelsLabel:          "Select models to enable for %s",
 	NoModelsAvailableFmt:       "%s: no models available, skipping",
 	CustomFetchEmpty:           "/models returned an empty list — falling back to manual entry",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -196,6 +196,7 @@ var Chinese = Messages{
 	FetchModelsSuccessFmt:      "发现 %d 个 %s 模型",
 	FetchModelsFailedFmt:       "获取 %s 模型失败: %v",
 	FetchModelsUsingPresetsFmt: "无法在线获取 %s 的模型，使用预设列表",
+	FamilyKeyPromptFmt:         "输入 %s 的 API key 以获取可用模型（回车跳过）：",
 	SelectModelsLabel:          "选择要启用的 %s 模型",
 	NoModelsAvailableFmt:       "%s: 没有可用模型，跳过",
 	CustomFetchEmpty:           "/models 返回为空，回退到手动输入",


### PR DESCRIPTION
## Problem

Many users finish setup with only `deepseek-v4-flash` available and no Pro SKU.

The setup wizard fetches each family's live model list **before** the API key is collected (`selectEnabledProviders` runs at step 2; keys are gathered by `configureKeys` at step 3). So for any user who hasn't pre-exported `DEEPSEEK_API_KEY`, the `/models` probe runs keyless, 401s, and falls back to the preset's static list. That fallback used only the **first family member** (`probe.ModelList()`), and since `deepseek-flash` and `deepseek-pro` are two single-model preset entries grouped under one `deepseek` family, the fallback collapsed to flash alone — Pro silently disappeared and got persisted out of `reasonix.toml`.

## Fix

- **Collect the family's API key before the `/models` probe** (mirrors the existing custom/anthropic flows). With a key, the probe returns the real live list — flash, pro, and whatever else the vendor exposes. `configureKeys` later sees the env var already set and won't ask twice, and still persists it to `.env`.
- **Union every family member's preset models as the offline fallback** (`familyStaticModels`), so even a blank key or an unreachable network keeps both flash and pro instead of collapsing to one.

## Validation

- `go build ./...`, `go vet`, `go test ./internal/cli ./internal/i18n` — pass.
- New tests: `TestFamilyStaticModels` (union + dedupe). Existing `TestFetchOrFallback`/`TestBuildFamilyEntry`/`TestConfigureKeys` still green.
- gofmt clean; new `FamilyKeyPromptFmt` message added to both en + zh catalogs.