### PR TITLE
feat: make codegraph MCP configurable

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -948,11 +948,11 @@ func (a *App) Capabilities() CapabilitiesView {
 	seen := map[string]bool{}
 	connected := map[string]bool{}
 	retainedDisabled := map[string]ServerView{}
-	codegraphConfigured := false
+	var loadedCfg *config.Config
 	configured := map[string]config.PluginEntry{}
 	var configuredEntries []config.PluginEntry
 	if cfg, err := config.Load(); err == nil {
-		codegraphConfigured = cfg.Codegraph.Enabled
+		loadedCfg = cfg
 		configuredEntries = append(configuredEntries, cfg.Plugins...)
 		for _, p := range configuredEntries {
 			configured[p.Name] = p
@@ -970,6 +970,8 @@ func (a *App) Capabilities() CapabilitiesView {
 			}
 			if p, ok := configured[s.Name]; ok {
 				view = withPluginConfig(view, p)
+			} else if s.Name == "codegraph" && loadedCfg != nil {
+				view = withCodegraphConfig(view, loadedCfg.Codegraph)
 			}
 			out.Servers = append(out.Servers, view)
 		}
@@ -980,13 +982,15 @@ func (a *App) Capabilities() CapabilitiesView {
 			}
 			if p, ok := configured[f.Name]; ok {
 				view = withPluginConfig(view, p)
+			} else if f.Name == "codegraph" && loadedCfg != nil {
+				view = withCodegraphConfig(view, loadedCfg.Codegraph)
 			}
 			out.Servers = append(out.Servers, view)
 		}
 	}
 	// Configured servers that are neither connected nor failed are either lazy
 	// (deferred), background/eager (initializing), or toggled off this session.
-	if len(configuredEntries) > 0 || codegraphConfigured {
+	if len(configuredEntries) > 0 || loadedCfg != nil {
 		for _, p := range configuredEntries {
 			if seen[p.Name] {
 				continue
@@ -1013,17 +1017,27 @@ func (a *App) Capabilities() CapabilitiesView {
 			out.Servers = append(out.Servers, withPluginConfig(ServerView{Name: p.Name, Status: status}, p))
 			seen[p.Name] = true
 		}
-		if codegraphConfigured && !seen["codegraph"] {
+		if loadedCfg != nil && !seen["codegraph"] {
+			status := "disabled"
+			if loadedCfg.Codegraph.Enabled {
+				switch loadedCfg.Codegraph.ResolvedTier() {
+				case "background", "eager":
+					status = "initializing"
+				default:
+					status = "deferred"
+				}
+			}
 			if s, ok := disabled["codegraph"]; ok {
 				s.Status = "disabled"
 				s.Transport = "stdio"
 				s.BuiltIn = true
+				s = withCodegraphConfig(s, loadedCfg.Codegraph)
 				s.Error = ""
 				out.Servers = append(out.Servers, s)
 				retainedDisabled["codegraph"] = s
 				delete(disabled, "codegraph")
 			} else {
-				out.Servers = append(out.Servers, ServerView{Name: "codegraph", Transport: "stdio", Status: "initializing", BuiltIn: true})
+				out.Servers = append(out.Servers, withCodegraphConfig(ServerView{Name: "codegraph", Status: status}, loadedCfg.Codegraph))
 			}
 			seen["codegraph"] = true
 		}
@@ -1072,6 +1086,17 @@ func withPluginConfig(v ServerView, p config.PluginEntry) ServerView {
 	auth := mcpdiag.DiagnoseAuth(v.Transport, v.Status, v.Error, v.URL, v.AuthConfigured)
 	v.AuthStatus = auth.Status
 	v.AuthURL = auth.URL
+	return v
+}
+
+func withCodegraphConfig(v ServerView, c config.CodegraphConfig) ServerView {
+	v.Name = "codegraph"
+	v.Transport = "stdio"
+	v.BuiltIn = true
+	v.Configured = true
+	v.AutoStart = c.ShouldAutoStart()
+	v.Tier = c.ResolvedTier()
+	v.AuthStatus = mcpdiag.AuthNone
 	return v
 }
 
@@ -1337,6 +1362,9 @@ func (a *App) UpdateMCPServer(name string, in MCPServerInput) error {
 
 // RemoveMCPServer disconnects a live server and drops it from config (the row's ✕).
 func (a *App) RemoveMCPServer(name string) error {
+	if name == "codegraph" {
+		return fmt.Errorf("codegraph is built in; it cannot be removed")
+	}
 	if a.ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
@@ -1387,6 +1415,9 @@ func (a *App) SetMCPServerEnabled(name string, enabled bool) error {
 	if a.ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
+	if name == "codegraph" {
+		return a.setCodegraphEnabled(enabled)
+	}
 	if enabled {
 		_, err := a.ctrl.ConnectConfiguredMCPServer(name)
 		if err == nil {
@@ -1416,7 +1447,7 @@ func (a *App) SetMCPServerEnabled(name string, enabled bool) error {
 // "connect now" remain separate controls.
 func (a *App) SetMCPServerTier(name, tier string) error {
 	if name == "codegraph" {
-		return fmt.Errorf("codegraph is built in; configure it with [codegraph]")
+		return a.setCodegraphTier(tier)
 	}
 	tier = normalizeMCPTier(tier)
 	cfg, err := config.Load()
@@ -1428,6 +1459,10 @@ func (a *App) SetMCPServerTier(name, tier string) error {
 	for i := range cfg.Plugins {
 		if cfg.Plugins[i].Name == name {
 			cfg.Plugins[i].Tier = tier
+			if !cfg.Plugins[i].ShouldAutoStart() {
+				on := true
+				cfg.Plugins[i].AutoStart = &on
+			}
 			updated = cfg.Plugins[i]
 			found = true
 			break
@@ -1447,6 +1482,66 @@ func (a *App) SetMCPServerTier(name, tier string) error {
 		a.mu.Lock()
 		delete(a.disabledMCP, name)
 		a.mu.Unlock()
+	}
+	return nil
+}
+
+func (a *App) setCodegraphEnabled(enabled bool) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	cfg.Codegraph.Enabled = enabled
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	if enabled {
+		a.mu.Lock()
+		delete(a.disabledMCP, "codegraph")
+		a.mu.Unlock()
+		if _, err := a.ctrl.ConnectConfiguredMCPServer("codegraph"); err != nil {
+			recordCodegraphFailure(a.ctrl, cfg.Codegraph, err)
+			return nil
+		}
+		return nil
+	}
+	if h := a.ctrl.Host(); h != nil {
+		h.ClearFailure("codegraph")
+	}
+	a.ctrl.DisconnectMCPServer("codegraph")
+	s := withCodegraphConfig(ServerView{Name: "codegraph", Status: "disabled"}, cfg.Codegraph)
+	a.mu.Lock()
+	if a.disabledMCP == nil {
+		a.disabledMCP = map[string]ServerView{}
+	}
+	a.disabledMCP["codegraph"] = s
+	a.mcpOrder = mergeServerOrder(a.mcpOrder, []ServerView{s})
+	a.mu.Unlock()
+	return nil
+}
+
+func (a *App) setCodegraphTier(tier string) error {
+	tier = normalizeMCPTier(tier)
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	cfg.Codegraph.Enabled = true
+	cfg.Codegraph.Tier = tier
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+	if a.ctrl == nil {
+		return nil
+	}
+	a.mu.Lock()
+	delete(a.disabledMCP, "codegraph")
+	a.mu.Unlock()
+	if tier != "lazy" && !mcpConnected(a.ctrl, "codegraph") {
+		if _, err := a.ctrl.ConnectConfiguredMCPServer("codegraph"); err != nil {
+			recordCodegraphFailure(a.ctrl, cfg.Codegraph, err)
+			return nil
+		}
 	}
 	return nil
 }
@@ -1510,6 +1605,22 @@ func recordMCPFailure(ctrl *control.Controller, e config.PluginEntry, err error)
 		Env:     exp.Env,
 		URL:     exp.URL,
 		Headers: exp.Headers,
+	}, err)
+}
+
+func recordCodegraphFailure(ctrl *control.Controller, c config.CodegraphConfig, err error) {
+	if ctrl == nil || ctrl.Host() == nil || err == nil {
+		return
+	}
+	cmd := strings.TrimSpace(c.Path)
+	if cmd == "" {
+		cmd = "codegraph"
+	}
+	ctrl.Host().RecordFailure(plugin.Spec{
+		Name:    "codegraph",
+		Type:    "stdio",
+		Command: cmd,
+		Args:    []string{"serve", "--mcp"},
 	}, err)
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -167,6 +167,37 @@ args = ["-y", "@playwright/mcp"]
 	t.Fatalf("playwright MCP missing from Capabilities: %+v", view.Servers)
 }
 
+func TestCapabilitiesShowsDefaultCodegraphDisabled(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	app := NewApp()
+	app.ctrl = control.New(control.Options{Host: plugin.NewHost()})
+	defer app.ctrl.Close()
+
+	view := app.Capabilities()
+	for _, s := range view.Servers {
+		if s.Name == "codegraph" {
+			if s.Status != "disabled" {
+				t.Fatalf("codegraph status = %q, want disabled; server = %+v", s.Status, s)
+			}
+			if !s.BuiltIn || !s.Configured {
+				t.Fatalf("codegraph builtIn/configured = %v/%v, want true/true; server = %+v", s.BuiltIn, s.Configured, s)
+			}
+			if s.AutoStart {
+				t.Fatalf("codegraph autoStart = true, want false; server = %+v", s)
+			}
+			if s.Tier != "lazy" {
+				t.Fatalf("codegraph tier = %q, want lazy; server = %+v", s.Tier, s)
+			}
+			return
+		}
+	}
+	t.Fatalf("codegraph missing from Capabilities: %+v", view.Servers)
+}
+
 func TestCapabilitiesMarksDeferredRemoteMCPAuthPossible(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -496,6 +527,94 @@ tier = "lazy"
 		}
 	}
 	t.Fatalf("broken MCP missing from Capabilities: %+v", view.Servers)
+}
+
+func TestSetMCPServerTierPersistsCodegraphConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
+[codegraph]
+enabled = false
+auto_install = true
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.ctrl = control.New(control.Options{Host: plugin.NewHost()})
+	defer app.ctrl.Close()
+
+	if err := app.SetMCPServerTier("codegraph", "background"); err != nil {
+		t.Fatalf("SetMCPServerTier(codegraph): %v", err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Codegraph.Enabled {
+		t.Fatal("codegraph enabled = false, want true after selecting a startup tier")
+	}
+	if got := cfg.Codegraph.Tier; got != "background" {
+		t.Fatalf("codegraph tier = %q, want background", got)
+	}
+	if !mcpFailed(app.ctrl, "codegraph") {
+		t.Fatalf("Host.Failures() = %+v, want codegraph failure recorded for missing runtime", app.ctrl.Host().Failures())
+	}
+	view := app.Capabilities()
+	for _, s := range view.Servers {
+		if s.Name == "codegraph" {
+			if s.Status != "failed" {
+				t.Fatalf("codegraph status = %q, want failed; server = %+v", s.Status, s)
+			}
+			if !s.BuiltIn || !s.Configured || s.Tier != "background" || !s.AutoStart {
+				t.Fatalf("codegraph view did not preserve built-in config: %+v", s)
+			}
+			return
+		}
+	}
+	t.Fatalf("codegraph missing from Capabilities: %+v", view.Servers)
+}
+
+func TestSetMCPServerEnabledPersistsCodegraphOff(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
+[codegraph]
+enabled = true
+tier = "lazy"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.ctrl = control.New(control.Options{Host: plugin.NewHost()})
+	defer app.ctrl.Close()
+
+	if err := app.SetMCPServerEnabled("codegraph", false); err != nil {
+		t.Fatalf("SetMCPServerEnabled(codegraph,false): %v", err)
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Codegraph.Enabled {
+		t.Fatal("codegraph enabled = true, want false after disabling")
+	}
+	view := app.Capabilities()
+	for _, s := range view.Servers {
+		if s.Name == "codegraph" {
+			if s.Status != "disabled" || s.AutoStart {
+				t.Fatalf("codegraph disabled view = %+v, want disabled with autoStart=false", s)
+			}
+			return
+		}
+	}
+	t.Fatalf("codegraph missing from Capabilities: %+v", view.Servers)
 }
 
 func TestCapabilitiesKeepsFailedMCPConfiguredTierAfterRestart(t *testing.T) {

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -728,7 +728,7 @@ function FailedServersNotice({
           const open = expanded.has(s.name);
           const error = s.error || t("caps.failed");
           const actionLabel = serverActionLabel(s, t);
-          const canConfigure = s.configured && !s.builtIn;
+          const canConfigure = s.configured;
           const handlePrimaryAction = () => {
             if (shouldOpenAuth(s)) {
               openExternal((s.authUrl || "").trim());
@@ -900,6 +900,7 @@ function ServerRow({
             <div className="cap-row__head">
               <span className="cap-row__name">{s.name}</span>
               <span className="cap-row__transport">{s.transport}</span>
+              {s.builtIn && <span className="cap-row__builtin">{t("caps.builtIn")}</span>}
             </div>
             <div className="cap-row__sub">{sub}</div>
           </div>
@@ -921,14 +922,6 @@ function ServerRow({
                   </button>
                 ) : s.status === "initializing" ? (
                   <span className="cap-row__pending">{t("caps.initializingShort")}</span>
-                ) : s.builtIn ? (
-                  s.status === "disabled" ? (
-                    <button className="btn btn--small" disabled={busy} onClick={() => onToggle(true)}>
-                      {t("caps.enable")}
-                    </button>
-                  ) : (
-                    <span className="cap-row__builtin">{t("caps.builtIn")}</span>
-                  )
                 ) : (
                   <Tooltip label={enabled ? t("caps.disable") : t("caps.enable")}>
                     <label className="cap-switch">
@@ -1017,12 +1010,13 @@ function ServerDetails({
 }) {
   const t = useT();
   const command = serverCommand(s);
-  const canConfigure = s.configured && !s.builtIn;
-  const canConnectNow = !s.builtIn && (s.status === "deferred" || s.status === "disabled");
+  const canConfigure = s.configured;
+  const canEditConfig = s.configured && !s.builtIn;
+  const canConnectNow = s.status === "deferred" || s.status === "disabled";
   const canShowTools = (s.tools ?? 0) > 0 || (tools?.length ?? 0) > 0;
   const showClearAuth = canClearAuth(s);
   const authLabel = serverAuthLabel(s, t);
-  if (editing && canConfigure) {
+  if (editing && canEditConfig) {
     return (
       <div className="cap-server-details">
         <EditServerForm s={s} busy={busy} onCancel={onCancelEdit} onSave={onUpdate} />
@@ -1090,12 +1084,12 @@ function ServerDetails({
                 {t("caps.clearAuth")}
               </button>
             )}
-            {canConfigure && (
+            {canEditConfig && (
               <button className="btn btn--small" disabled={busy} onClick={onEdit}>
                 {t("caps.editConfig")}
               </button>
             )}
-            {canConfigure &&
+            {canEditConfig &&
               (confirming ? (
                 <>
                   <button className="btn btn--small" disabled={busy} onClick={onRemove}>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -290,14 +290,14 @@ function makeMockApp(): AppBindings {
     {
       name: "codegraph",
       transport: "stdio",
-      status: "connected",
+      status: "disabled",
       builtIn: true,
       configured: true,
-      autoStart: true,
-      tier: "background",
-      tools: 4,
+      autoStart: false,
+      tier: "lazy",
+      tools: 0,
       prompts: 0,
-      resources: 1,
+      resources: 0,
       toolList: [
         { name: "search", description: "Search symbols, files, and text in the workspace." },
         { name: "context", description: "Fetch surrounding source context for a symbol or file." },
@@ -739,6 +739,7 @@ function makeMockApp(): AppBindings {
           ? {
               ...s,
               status: enabled ? "connected" : "disabled",
+              autoStart: s.builtIn ? enabled : s.autoStart,
               tools: enabled ? s.tools || 4 : 0,
               error: undefined,
               authStatus: !enabled && s.transport !== "stdio" ? "possible" : undefined,
@@ -750,9 +751,9 @@ function makeMockApp(): AppBindings {
     async SetMCPServerTier(name: string, tier: string) {
       capServers = capServers.map((s) => {
         if (s.name !== name) return s;
-        if (tier === "lazy") return { ...s, tier };
+        if (tier === "lazy") return { ...s, tier, autoStart: true };
         const tools = s.tools || (s.transport === "stdio" ? 3 : 5);
-        return { ...s, tier, status: "connected", tools, error: undefined, authStatus: undefined, authUrl: undefined };
+        return { ...s, tier, autoStart: true, status: "connected", tools, error: undefined, authStatus: undefined, authUrl: undefined };
       });
     },
     async SlashArgs(input: string) {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4585,9 +4585,16 @@ body {
   color: var(--fg-faint);
 }
 .cap-row__builtin {
-  font-size: 11px;
-  font-weight: 650;
-  color: var(--fg-faint);
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 6%, var(--bg-soft));
+  color: color-mix(in srgb, var(--accent) 70%, var(--fg-dim));
+  font-size: 10px;
+  font-weight: 550;
+  letter-spacing: 0;
+  line-height: 1.35;
 }
 .cap-row--skill {
   align-items: center;

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -58,8 +58,9 @@ and DeepSeek prefix-cache–oriented design.
 
 - **Code intelligence**: embedding semantic search is replaced by **CodeGraph**
   (`codegraph_*` tools) — a tree-sitter symbol/call graph, no embedding service or
-  API cost. Fetched into a local cache on first use (or `reasonix codegraph
-  install`); set `[codegraph].enabled = false` to opt out.
+  API cost. It is off by default for first-run sessions; enable `[codegraph]` in
+  the MCP manager or config, and set `[codegraph].tier` to choose lazy,
+  background, or eager startup.
 - **Plan mode** + `complete_step` (evidence-backed step sign-off).
 - **No web dashboard** — the v2 line is terminal + desktop (Wails), by design.
 - Some granular v1 tools are intentionally consolidated (e.g. file-management ops

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -219,10 +219,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// tools come online next session — otherwise point the user at the explicit
 	// install command. A failed init or fetch is a notice, not fatal.
 	//
-	// Warm CodeGraph projects stay eager because the agent benefits from seeing
-	// symbol-graph tools on the first turn. Cold projects start in the background:
-	// the first .codegraph/ creation and daemon warmup should not be reported as
-	// a startup failure just because they exceeded the generic MCP budget.
+	// CodeGraph now follows the same user-selectable tier model as ordinary MCP
+	// servers. EnsureInit only creates .codegraph/ (fast, size-independent);
+	// lazy still avoids connecting until first use, background starts without
+	// blocking chat, and eager waits for the MCP handshake.
 	if cfg.Codegraph.Enabled {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
@@ -234,12 +234,17 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 					Text: "codegraph: init failed (" + err.Error() + ") — symbol-graph tools disabled this session"})
 				break
 			}
-			if warm {
+			switch cfg.Codegraph.ResolvedTier() {
+			case "eager":
 				eagerSpecs = append(eagerSpecs, spec)
-			} else {
+			case "background":
 				bgSpecs = append(bgSpecs, spec)
-				sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
-					Text: "codegraph: preparing code-intelligence tools in the background — tools will appear when ready"})
+				if !warm {
+					sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
+						Text: "codegraph: preparing code-intelligence tools in the background — tools will appear when ready"})
+				}
+			default:
+				lazySpecs = append(lazySpecs, spec)
 			}
 		case cfg.Codegraph.AutoInstall:
 			notify := func(msg string) { sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg}) }

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -605,6 +605,7 @@ default_model = "test-model"
 [codegraph]
 enabled = true
 path = %q
+tier = "background"
 
 [agent]
 system_prompt = "BASE"
@@ -654,6 +655,43 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 	if !foundNotice {
 		t.Fatalf("missing background warmup notice; got %+v", notices)
+	}
+}
+
+func TestBuildDefaultDoesNotStartCodegraph(t *testing.T) {
+	isolateConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, name := range ctrl.Host().ServerNames() {
+		if name == "codegraph" {
+			t.Fatalf("default config started codegraph; servers=%v", ctrl.Host().ServerNames())
+		}
+	}
+	if got := ctrl.Host().Failures(); len(got) != 0 {
+		t.Fatalf("Host.Failures() = %+v, want empty with codegraph disabled by default", got)
 	}
 }
 

--- a/internal/cli/codegraph.go
+++ b/internal/cli/codegraph.go
@@ -60,6 +60,7 @@ func codegraphStatus() int {
 	}
 	fmt.Printf("%-13s %v\n", "enabled:", cfg.Codegraph.Enabled)
 	fmt.Printf("%-13s %v\n", "auto_install:", cfg.Codegraph.AutoInstall)
+	fmt.Printf("%-13s %s\n", "tier:", cfg.Codegraph.ResolvedTier())
 	fmt.Printf("%-13s %s\n", "version:", codegraph.Version)
 	fmt.Printf("%-13s %s\n", "cache:", codegraph.CacheDir())
 	if p, ok := codegraph.Resolve(cfg.Codegraph.Path); ok {

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -181,17 +181,19 @@ func mcpList() int {
 	}
 	listed := 0
 	// CodeGraph is a built-in server injected by boot, not a [[plugins]] entry, so
-	// report its resolved status here too — otherwise `mcp list` looks empty even
-	// when codegraph will load. This doubles as a headless preflight: it shows
-	// whether the binary resolves before you enter a session.
-	if cfg.Codegraph.Enabled {
-		if bin, ok := codegraph.Resolve(cfg.Codegraph.Path); ok {
-			fmt.Printf("%-16s (stdio, built-in)  %s serve --mcp\n", "codegraph", bin)
-		} else {
-			fmt.Printf("%-16s (built-in, not installed)  run `reasonix codegraph install` (or it auto-installs on first use)\n", "codegraph")
+	// report its resolved status here too. It is listed even when disabled, matching
+	// the MCP manager where the user can enable it and choose a startup tier.
+	codegraphMeta := fmt.Sprintf(" [auto_start=%v tier=%s]", cfg.Codegraph.Enabled, cfg.Codegraph.ResolvedTier())
+	if bin, ok := codegraph.Resolve(cfg.Codegraph.Path); ok {
+		fmt.Printf("%-16s (stdio, built-in)%s  %s serve --mcp\n", "codegraph", codegraphMeta, bin)
+	} else {
+		fmt.Printf("%-16s (built-in, not installed)%s  run `reasonix codegraph install`", "codegraph", codegraphMeta)
+		if cfg.Codegraph.Enabled && cfg.Codegraph.AutoInstall {
+			fmt.Print(" (or let auto_install fetch it on next startup)")
 		}
-		listed++
+		fmt.Println()
 	}
+	listed++
 	for _, p := range cfg.Plugins {
 		typ := p.Type
 		if typ == "" {

--- a/internal/cli/mcp_manager.go
+++ b/internal/cli/mcp_manager.go
@@ -309,9 +309,9 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 	}
 	configured := map[string]config.PluginEntry{}
 	var configuredEntries []config.PluginEntry
-	codegraphEnabled := false
+	var loadedCfg *config.Config
 	if cfg != nil {
-		codegraphEnabled = cfg.Codegraph.Enabled
+		loadedCfg = cfg
 		configuredEntries = append(configuredEntries, cfg.Plugins...)
 		for _, p := range configuredEntries {
 			configured[p.Name] = p
@@ -328,6 +328,8 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 			}
 			if p, ok := configured[s.Name]; ok {
 				v = withMCPPluginConfig(v, p)
+			} else if s.Name == "codegraph" && loadedCfg != nil {
+				v = withMCPCodegraphConfig(v, loadedCfg.Codegraph)
 			}
 			snap.servers = append(snap.servers, v)
 			seen[s.Name] = true
@@ -340,6 +342,8 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 			}
 			if p, ok := configured[f.Name]; ok {
 				v = withMCPPluginConfig(v, p)
+			} else if f.Name == "codegraph" && loadedCfg != nil {
+				v = withMCPCodegraphConfig(v, loadedCfg.Codegraph)
 			}
 			snap.servers = append(snap.servers, v)
 			seen[f.Name] = true
@@ -362,14 +366,16 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 		snap.servers = append(snap.servers, v)
 		seen[p.Name] = true
 	}
-	if codegraphEnabled && !seen["codegraph"] {
+	if loadedCfg != nil && !seen["codegraph"] {
 		status := "initializing"
-		if m.mcpDisabled["codegraph"] {
+		if m.mcpDisabled["codegraph"] || !loadedCfg.Codegraph.Enabled {
 			status = "disabled"
+		} else if loadedCfg.Codegraph.ResolvedTier() == "lazy" {
+			status = "deferred"
 		}
-		snap.servers = append(snap.servers, mcpServerView{
-			Name: "codegraph", Transport: "stdio", Status: status, BuiltIn: true,
-		})
+		snap.servers = append(snap.servers, withMCPCodegraphConfig(mcpServerView{
+			Name: "codegraph", Status: status,
+		}, loadedCfg.Codegraph))
 	}
 	return snap
 }
@@ -397,6 +403,17 @@ func withMCPPluginConfig(v mcpServerView, p config.PluginEntry) mcpServerView {
 	auth := mcpdiag.DiagnoseAuth(v.Transport, v.Status, v.Error, v.URL, v.authConfigured)
 	v.AuthStatus = auth.Status
 	v.AuthURL = auth.URL
+	return v
+}
+
+func withMCPCodegraphConfig(v mcpServerView, c config.CodegraphConfig) mcpServerView {
+	v.Name = "codegraph"
+	v.Transport = "stdio"
+	v.BuiltIn = true
+	v.Configured = true
+	v.AutoStart = c.ShouldAutoStart()
+	v.Tier = c.ResolvedTier()
+	v.AuthStatus = mcpdiag.AuthNone
 	return v
 }
 

--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -15,6 +15,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/mcpdiag"
+	"reasonix/internal/plugin"
 )
 
 func (m chatTUI) applyMCPAction(v mcpServerView, action mcpAction) (tea.Model, tea.Cmd) {
@@ -49,6 +50,20 @@ func (m chatTUI) connectSelectedMCP(v mcpServerView) (tea.Model, tea.Cmd) {
 		m.notice("mcp: no active session")
 		return m, nil
 	}
+	if v.BuiltIn && v.Name == "codegraph" {
+		cfg, err := config.Load()
+		if err != nil {
+			m.notice("mcp connect: " + err.Error())
+			return m, nil
+		}
+		if !cfg.Codegraph.Enabled {
+			cfg.Codegraph.Enabled = true
+			if err := cfg.Save(); err != nil {
+				m.notice("mcp connect: " + err.Error())
+				return m, nil
+			}
+		}
+	}
 	if v.Status == "connected" {
 		m.ctrl.DisconnectMCPServer(v.Name)
 	}
@@ -75,6 +90,23 @@ func (m chatTUI) disableSelectedMCP(v mcpServerView) (tea.Model, tea.Cmd) {
 		m.notice("mcp: no active session")
 		return m, nil
 	}
+	persisted := false
+	if v.BuiltIn && v.Name == "codegraph" {
+		cfg, err := config.Load()
+		if err != nil {
+			m.notice("mcp disable: " + err.Error())
+			return m, nil
+		}
+		cfg.Codegraph.Enabled = false
+		if err := cfg.Save(); err != nil {
+			m.notice("mcp disable: " + err.Error())
+			return m, nil
+		}
+		persisted = true
+		if h := m.ctrl.Host(); h != nil {
+			h.ClearFailure(v.Name)
+		}
+	}
 	if m.mcpDisabled == nil {
 		m.mcpDisabled = map[string]bool{}
 	}
@@ -86,7 +118,11 @@ func (m chatTUI) disableSelectedMCP(v mcpServerView) (tea.Model, tea.Cmd) {
 		m.mcp.stage = mcpStageDetail
 		m.mcp.selectName(v.Name)
 	}
-	m.notice("disabled " + v.Name + " for this session")
+	if persisted {
+		m.notice("disabled " + v.Name)
+	} else {
+		m.notice("disabled " + v.Name + " for this session")
+	}
 	return m, nil
 }
 
@@ -128,22 +164,45 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 	if !ok {
 		return m, nil
 	}
-	if v.BuiltIn {
-		m.notice("codegraph is built in; configure it with [codegraph]")
-		return m, nil
-	}
 	cfg, err := config.Load()
 	if err != nil {
 		m.notice("mcp mode: " + err.Error())
 		return m, nil
 	}
+	if v.BuiltIn && v.Name == "codegraph" {
+		cfg.Codegraph.Enabled = true
+		cfg.Codegraph.Tier = normalizeMCPTierForCLI(tier)
+		if err := cfg.Save(); err != nil {
+			m.notice("mcp mode: " + err.Error())
+			return m, nil
+		}
+		if m.mcpDisabled != nil {
+			delete(m.mcpDisabled, v.Name)
+		}
+		if tier != "lazy" && m.ctrl != nil && !mcpConnected(m.ctrl, v.Name) {
+			if _, err := m.ctrl.ConnectConfiguredMCPServer(v.Name); err != nil {
+				recordMCPModeCodegraphFailure(m.ctrl, cfg.Codegraph, err)
+				m.notice("saved connection mode, but connect failed: " + err.Error())
+			}
+			m.host = m.ctrl.Host()
+		}
+		m.refreshMCPManager()
+		if m.mcp != nil {
+			m.mcp.stage = mcpStageDetail
+			m.mcp.selectName(v.Name)
+		}
+		m.notice("updated connection mode for " + v.Name)
+		return m, nil
+	}
 	found := false
+	var selected config.PluginEntry
 	for i := range cfg.Plugins {
 		if cfg.Plugins[i].Name == v.Name {
 			cfg.Plugins[i].Tier = normalizeMCPTierForCLI(tier)
 			if !cfg.Plugins[i].ShouldAutoStart() {
 				cfg.Plugins[i].AutoStart = mcpBoolPtr(true)
 			}
+			selected = cfg.Plugins[i]
 			found = true
 			break
 		}
@@ -161,6 +220,7 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 	}
 	if tier != "lazy" && m.ctrl != nil && !mcpConnected(m.ctrl, v.Name) {
 		if _, err := m.ctrl.ConnectConfiguredMCPServer(v.Name); err != nil {
+			recordMCPModePluginFailure(m.ctrl, selected, err)
 			m.notice("saved connection mode, but connect failed: " + err.Error())
 		}
 		m.host = m.ctrl.Host()
@@ -172,6 +232,38 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 	}
 	m.notice("updated connection mode for " + v.Name)
 	return m, nil
+}
+
+func recordMCPModePluginFailure(ctrl *control.Controller, e config.PluginEntry, err error) {
+	if ctrl == nil || ctrl.Host() == nil || err == nil {
+		return
+	}
+	exp := e.ExpandedPlugin()
+	ctrl.Host().RecordFailure(plugin.Spec{
+		Name:    exp.Name,
+		Type:    exp.Type,
+		Command: exp.Command,
+		Args:    exp.Args,
+		Env:     exp.Env,
+		URL:     exp.URL,
+		Headers: exp.Headers,
+	}, err)
+}
+
+func recordMCPModeCodegraphFailure(ctrl *control.Controller, c config.CodegraphConfig, err error) {
+	if ctrl == nil || ctrl.Host() == nil || err == nil {
+		return
+	}
+	cmd := strings.TrimSpace(c.Path)
+	if cmd == "" {
+		cmd = "codegraph"
+	}
+	ctrl.Host().RecordFailure(plugin.Spec{
+		Name:    "codegraph",
+		Type:    "stdio",
+		Command: cmd,
+		Args:    []string{"serve", "--mcp"},
+	}, err)
 }
 
 func (m chatTUI) openMCPConfig() (tea.Model, tea.Cmd) {

--- a/internal/cli/mcp_manager_view.go
+++ b/internal/cli/mcp_manager_view.go
@@ -275,7 +275,11 @@ func mcpActionsFor(v mcpServerView, configPath string) []mcpActionItem {
 		out = append(out, mcpActionItem{mcpActionClearAuth, "Clear authentication"})
 	}
 	if v.Status != "disabled" {
-		out = append(out, mcpActionItem{mcpActionDisable, "Disable for this session"})
+		label := "Disable for this session"
+		if v.BuiltIn && v.Name == "codegraph" {
+			label = "Disable"
+		}
+		out = append(out, mcpActionItem{mcpActionDisable, label})
 	}
 	if !v.BuiltIn {
 		out = append(out, mcpActionItem{mcpActionRemove, "Remove server"})
@@ -289,7 +293,11 @@ func appendMCPFailureSecondaryActions(out []mcpActionItem, v mcpServerView, conf
 	}
 	out = appendMCPConfigActions(out, v, configPath)
 	if v.Status != "disabled" {
-		out = append(out, mcpActionItem{mcpActionDisable, "Disable for this session"})
+		label := "Disable for this session"
+		if v.BuiltIn && v.Name == "codegraph" {
+			label = "Disable"
+		}
+		out = append(out, mcpActionItem{mcpActionDisable, label})
 	}
 	if !v.BuiltIn {
 		out = append(out, mcpActionItem{mcpActionRemove, "Remove server"})
@@ -298,9 +306,9 @@ func appendMCPFailureSecondaryActions(out []mcpActionItem, v mcpServerView, conf
 }
 
 func appendMCPConfigActions(out []mcpActionItem, v mcpServerView, configPath string) []mcpActionItem {
-	if v.Configured && !v.BuiltIn {
+	if v.Configured {
 		out = append(out, mcpActionItem{mcpActionMode, "Change connection mode"})
-		if configPath != "" {
+		if !v.BuiltIn && configPath != "" {
 			out = append(out, mcpActionItem{mcpActionEdit, "Edit config"})
 		}
 	}

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -9,6 +9,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 
 	"reasonix/internal/config"
+	"reasonix/internal/control"
 	"reasonix/internal/plugin"
 )
 
@@ -403,6 +404,114 @@ func TestApplyMCPModePersistsTier(t *testing.T) {
 	}
 	if len(loaded.Plugins) != 1 || loaded.Plugins[0].Tier != "background" {
 		t.Fatalf("tier not persisted, plugins=%+v", loaded.Plugins)
+	}
+}
+
+func TestApplyMCPModeRecordsPluginConnectFailure(t *testing.T) {
+	isolateUserConfig(t)
+	t.Setenv("PATH", "")
+	cfg := config.Default()
+	cfg.Plugins = []config.PluginEntry{{Name: "broken", Command: "definitely-missing-reasonix-mcp", Tier: "lazy"}}
+	if err := cfg.SaveTo("reasonix.toml"); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Host: plugin.NewHost()})
+	defer m.ctrl.Close()
+	m.host = m.ctrl.Host()
+	m.mcp = &mcpManager{
+		stage: mcpStageMode,
+		name:  "broken",
+		snapshot: mcpSnapshot{configPath: "reasonix.toml", servers: []mcpServerView{{
+			Name: "broken", Transport: "stdio", Status: "deferred", Configured: true, Tier: "lazy",
+		}}},
+	}
+
+	_, _ = m.applyMCPMode("background")
+
+	failures := m.ctrl.Host().Failures()
+	if len(failures) != 1 || failures[0].Name != "broken" {
+		t.Fatalf("Host.Failures() = %+v, want broken failure", failures)
+	}
+	v, ok := m.mcp.selectedServer()
+	if !ok {
+		t.Fatal("selected server missing after refresh")
+	}
+	if v.Status != "failed" {
+		t.Fatalf("server status = %q, want failed; server = %+v", v.Status, v)
+	}
+}
+
+func TestApplyMCPModeRecordsCodegraphConnectFailure(t *testing.T) {
+	isolateUserConfig(t)
+	t.Setenv("PATH", "")
+	t.Setenv("REASONIX_CACHE_DIR", t.TempDir())
+	cfg := config.Default()
+	cfg.Codegraph.Enabled = false
+	cfg.Codegraph.Tier = "lazy"
+	if err := cfg.SaveTo("reasonix.toml"); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Host: plugin.NewHost()})
+	defer m.ctrl.Close()
+	m.host = m.ctrl.Host()
+	m.mcp = &mcpManager{
+		stage: mcpStageMode,
+		name:  "codegraph",
+		snapshot: mcpSnapshot{configPath: "reasonix.toml", servers: []mcpServerView{{
+			Name: "codegraph", Transport: "stdio", Status: "disabled", BuiltIn: true, Configured: true, Tier: "lazy",
+		}}},
+	}
+
+	_, _ = m.applyMCPMode("background")
+
+	failures := m.ctrl.Host().Failures()
+	if len(failures) != 1 || failures[0].Name != "codegraph" {
+		t.Fatalf("Host.Failures() = %+v, want codegraph failure", failures)
+	}
+	if !strings.Contains(failures[0].Error, "not installed") {
+		t.Fatalf("codegraph failure error = %q, want not installed", failures[0].Error)
+	}
+	v, ok := m.mcp.selectedServer()
+	if !ok {
+		t.Fatal("selected server missing after refresh")
+	}
+	if v.Status != "failed" {
+		t.Fatalf("codegraph status = %q, want failed; server = %+v", v.Status, v)
+	}
+}
+
+func TestDisableCodegraphPersistsEnabledFalse(t *testing.T) {
+	isolateUserConfig(t)
+	cfg := config.Default()
+	cfg.Codegraph.Enabled = true
+	cfg.Codegraph.Tier = "background"
+	if err := cfg.SaveTo("reasonix.toml"); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{Host: plugin.NewHost()})
+	defer m.ctrl.Close()
+	m.mcp = &mcpManager{
+		stage: mcpStageDetail,
+		name:  "codegraph",
+		snapshot: mcpSnapshot{configPath: "reasonix.toml", servers: []mcpServerView{{
+			Name: "codegraph", Transport: "stdio", Status: "connected", BuiltIn: true, Configured: true, AutoStart: true, Tier: "background",
+		}}},
+	}
+
+	_, _ = m.disableSelectedMCP(m.mcp.snapshot.servers[0])
+
+	loaded, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if loaded.Codegraph.Enabled {
+		t.Fatalf("codegraph enabled = true, want false")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,16 +118,27 @@ type StatuslineConfig struct {
 
 // CodegraphConfig governs the built-in CodeGraph MCP server — symbol/call-graph
 // code intelligence (tree-sitter + SQLite) that gives the agent codegraph_*
-// search / context / explore / trace / node tools. Enabled defaults to true; set
-// enabled = false to drop those tools and fall back to grep/glob. AutoInstall
-// (default true) lets reasonix fetch the CodeGraph runtime into its cache on first
-// use; set false to require an explicit `reasonix codegraph install` (e.g. for
-// air-gapped or headless runs). Path overrides binary resolution; empty resolves
-// the cache, then a `codegraph` on PATH, then a bundle beside the executable.
+// search / context / explore / trace / node tools. Enabled defaults to false so
+// first-run sessions do not start CodeGraph until the user opts in. AutoInstall
+// (default true) lets reasonix fetch the CodeGraph runtime into its cache when
+// CodeGraph is enabled but missing; set false to require an explicit
+// `reasonix codegraph install` (e.g. for air-gapped or headless runs). Path
+// overrides binary resolution; empty resolves the cache, then a `codegraph` on
+// PATH, then a bundle beside the executable. Tier matches ordinary MCP servers:
+// lazy, background, or eager.
 type CodegraphConfig struct {
 	Enabled     bool   `toml:"enabled"`
 	AutoInstall bool   `toml:"auto_install"`
 	Path        string `toml:"path"`
+	Tier        string `toml:"tier"`
+}
+
+func (c CodegraphConfig) ShouldAutoStart() bool {
+	return c.Enabled
+}
+
+func (c CodegraphConfig) ResolvedTier() string {
+	return resolvedMCPTier(c.Tier)
 }
 
 // NetworkConfig controls ordinary outbound HTTP traffic such as model providers,
@@ -459,7 +470,11 @@ func (e PluginEntry) ShouldAutoStart() bool {
 // the project default applied. Unknown values fall back to "lazy" so a typo
 // never forces a slow boot.
 func (e PluginEntry) ResolvedTier() string {
-	switch strings.ToLower(strings.TrimSpace(e.Tier)) {
+	return resolvedMCPTier(e.Tier)
+}
+
+func resolvedMCPTier(tier string) string {
+	switch strings.ToLower(strings.TrimSpace(tier)) {
 	case "eager":
 		return "eager"
 	case "background":
@@ -526,11 +541,10 @@ func Default() *Config {
 		// so an absent [sandbox] in a user's file keeps egress (zero value would
 		// wrongly deny it).
 		Sandbox: SandboxConfig{Bash: "enforce", Network: true},
-		// CodeGraph code-intelligence on by default: when it resolves it is injected
-		// as a built-in MCP server, and AutoInstall fetches it into the cache on
-		// first use. Set enabled = false to opt out, or auto_install = false to
-		// require an explicit `reasonix codegraph install`.
-		Codegraph: CodegraphConfig{Enabled: true, AutoInstall: true},
+		// CodeGraph code-intelligence is available as a built-in MCP server, but
+		// first-run sessions keep it off until the user enables it. AutoInstall
+		// fetches it into the cache once enabled and missing.
+		Codegraph: CodegraphConfig{Enabled: false, AutoInstall: true},
 		// LSP tools on by default, but dormant until a language server is on PATH;
 		// a missing server yields an install hint rather than an error.
 		LSP:     LSPConfig{Enabled: true},

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -379,6 +379,19 @@ func TestAutoStartPlugins(t *testing.T) {
 	}
 }
 
+func TestCodegraphDefaultsDisabledLazy(t *testing.T) {
+	c := Default()
+	if c.Codegraph.Enabled {
+		t.Fatal("default codegraph enabled = true, want false")
+	}
+	if !c.Codegraph.AutoInstall {
+		t.Fatal("default codegraph auto_install = false, want true")
+	}
+	if got := c.Codegraph.ResolvedTier(); got != "lazy" {
+		t.Fatalf("default codegraph tier = %q, want lazy", got)
+	}
+}
+
 func TestPluginResolvedTierDefaultsToLazy(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -170,6 +170,21 @@ func RenderTOML(c *Config) string {
 		b.WriteString("]\n\n")
 	}
 
+	b.WriteString("[codegraph]\n")
+	fmt.Fprintf(&b, "enabled      = %v   # built-in MCP server; off by default for first-run sessions\n", c.Codegraph.Enabled)
+	fmt.Fprintf(&b, "auto_install = %v   # fetch the runtime when CodeGraph is enabled but missing\n", c.Codegraph.AutoInstall)
+	if c.Codegraph.Path != "" {
+		fmt.Fprintf(&b, "path         = %q   # optional launcher override\n", c.Codegraph.Path)
+	} else {
+		b.WriteString("# path       = \"\"   # empty = cache, then PATH, then a bundle beside reasonix\n")
+	}
+	if strings.TrimSpace(c.Codegraph.Tier) != "" {
+		fmt.Fprintf(&b, "tier         = %q   # lazy|background|eager\n", c.Codegraph.ResolvedTier())
+	} else {
+		b.WriteString("# tier       = \"lazy\"   # lazy|background|eager\n")
+	}
+	b.WriteString("\n")
+
 	b.WriteString("[skills]\n")
 	if len(c.Skills.Paths) > 0 {
 		fmt.Fprintf(&b, "paths = %s   # extra custom skill roots\n", renderStringArray(c.Skills.Paths))

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -35,6 +35,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	orig.Skills.Paths = []string{"~/my-skills", "../shared/skills"}
 	orig.Skills.DisabledSkills = []string{"review", "explore"}
+	orig.Codegraph = CodegraphConfig{Enabled: true, AutoInstall: false, Path: "/opt/codegraph", Tier: "background"}
 	orig.Plugins = []PluginEntry{
 		{Name: "example", Command: "reasonix-plugin-example"},
 		{Name: "stripe", Type: "http", URL: "https://mcp.stripe.com", Headers: map[string]string{"Authorization": "Bearer x"}, AutoStart: boolPtr(false), Tier: "background"},
@@ -77,6 +78,18 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Agent.SystemPrompt != orig.Agent.SystemPrompt {
 		t.Errorf("system_prompt mismatch:\n got %q\nwant %q", got.Agent.SystemPrompt, orig.Agent.SystemPrompt)
+	}
+	if !got.Codegraph.Enabled {
+		t.Error("codegraph.enabled = false, want true")
+	}
+	if got.Codegraph.AutoInstall {
+		t.Error("codegraph.auto_install = true, want false")
+	}
+	if got.Codegraph.Path != "/opt/codegraph" {
+		t.Errorf("codegraph.path = %q, want /opt/codegraph", got.Codegraph.Path)
+	}
+	if got.Codegraph.Tier != "background" {
+		t.Errorf("codegraph.tier = %q, want background", got.Codegraph.Tier)
 	}
 	if got.Agent.SubagentModel != "mimo-pro" {
 		t.Errorf("subagent_model = %q, want mimo-pro", got.Agent.SubagentModel)

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -83,15 +83,15 @@ enabled = []   # empty = all built-in tools
 
 # CodeGraph code intelligence (symbol/call-graph search via tree-sitter + SQLite),
 # a built-in MCP server giving the agent codegraph_* search / context / explore /
-# trace / node tools. On by default. The runtime is fetched into a per-version
-# cache on first use (auto_install); .codegraph/ is then initialised (fast) and
-# CodeGraph's daemon indexes in the background, so installs and startup stay fast
-# even on a large repo. Disable to fall back to grep/glob, turn off auto_install
-# to require an explicit `reasonix codegraph install`, or point `path` at a launcher.
+# trace / node tools. Off by default for first-run sessions. Once enabled, the
+# runtime is fetched into a per-version cache when missing (auto_install);
+# .codegraph/ is then initialised (fast) and CodeGraph's daemon indexes in the
+# background. Choose tier the same way as ordinary MCP servers.
 # [codegraph]
-# enabled      = true
+# enabled      = false
 # auto_install = true
 # path         = ""   # empty = cache, then PATH, then a bundle beside reasonix
+# tier         = "lazy"   # lazy | background | eager
 
 # Skills are invokable playbooks (SKILL.md / <name>.md with frontmatter), found
 # under .reasonix/skills, .agents/skills, .agent/skills, .claude/skills (project)


### PR DESCRIPTION
## Summary
- Stop treating CodeGraph as an always-on built-in MCP. First-run config now defaults it to disabled, and startup only happens after the user enables it.
- Persist CodeGraph enablement and startup tier so desktop and CLI keep the user setting across sessions.
- Show built-in MCPs in the same MCP controls as other servers: enable/disable toggle and lazy/background/eager startup selection, while hiding delete/edit-config actions for CodeGraph.
- Record CLI background/eager connect failures in `Host.Failures` so failed CodeGraph/configured MCP starts render as failed instead of initializing forever.
- Update config rendering, examples, migration docs, frontend mock data, and tests for the new CodeGraph enabled/auto_install/tier behavior.

## Testing
- `go test ./internal/config ./internal/boot ./internal/cli -run "TestCodegraph|TestBuildDefaultDoesNotStartCodegraph|TestBuildColdCodegraphStartsInBackground|TestMCP|TestApplyMCPMode|TestDisableCodegraph"`
- isolated `go test ./internal/cli`
- `npm run build` from `desktop/frontend/`