### PR TITLE
fix(setup): keep each family model in its own entry to preserve pricing

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -767,7 +767,11 @@ func selectEnabledProviders(providers []config.ProviderEntry) ([]config.Provider
 		for _, idx := range idxs {
 			selected = append(selected, models[idx])
 		}
-		enabled = append(enabled, buildFamilyEntry(probe, selected))
+		members := make([]config.ProviderEntry, 0, len(famMembers[familyKey]))
+		for _, idx := range famMembers[familyKey] {
+			members = append(members, providers[idx])
+		}
+		enabled = append(enabled, buildFamilyEntries(probe, members, selected)...)
 	}
 	return enabled, nil
 }
@@ -835,6 +839,41 @@ func fetchOrFallback(probe *config.ProviderEntry, famName string) []string {
 // vary per vendor but not per model. The Default pointer is reset to the
 // first selected model if it would otherwise reference a model the user
 // didn't pick (or was empty).
+// buildFamilyEntries splits the user's selection back across the family's preset
+// members so each model keeps its own entry — and therefore its own pricing,
+// context window, and balance URL. A family like DeepSeek ships flash and pro as
+// separate presets with different prices; collapsing them into one entry would
+// bill pro at flash's rate. Models the live /models list returned that match no
+// preset (a new SKU) fall under the probe entry. Member order is preserved;
+// within a member, selection order is preserved.
+func buildFamilyEntries(probe config.ProviderEntry, members []config.ProviderEntry, selected []string) []config.ProviderEntry {
+	tmpl := map[string]config.ProviderEntry{probe.Name: probe}
+	ownerName := map[string]string{}
+	for _, m := range members {
+		tmpl[m.Name] = m
+		for _, id := range m.ModelList() {
+			ownerName[id] = m.Name
+		}
+	}
+	var order []string
+	groups := map[string][]string{}
+	for _, sm := range selected {
+		name, ok := ownerName[sm]
+		if !ok {
+			name = probe.Name
+		}
+		if _, seen := groups[name]; !seen {
+			order = append(order, name)
+		}
+		groups[name] = append(groups[name], sm)
+	}
+	out := make([]config.ProviderEntry, 0, len(order))
+	for _, name := range order {
+		out = append(out, buildFamilyEntry(tmpl[name], groups[name]))
+	}
+	return out
+}
+
 func buildFamilyEntry(probe config.ProviderEntry, selected []string) config.ProviderEntry {
 	entry := probe
 	entry.Models = selected

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"reasonix/internal/config"
+	"reasonix/internal/provider"
 )
 
 func TestChdirTo(t *testing.T) {
@@ -264,6 +265,41 @@ func TestFamilyStaticModelsDedupes(t *testing.T) {
 	got := familyStaticModels(providers, []int{0, 1})
 	if !reflect.DeepEqual(got, []string{"x", "y", "z"}) {
 		t.Errorf("got %v, want x/y/z deduped", got)
+	}
+}
+
+// TestBuildFamilyEntriesSplitsPricing proves flash and pro land in separate
+// entries carrying their own price, rather than collapsing into one entry that
+// would bill pro at flash's rate.
+func TestBuildFamilyEntriesSplitsPricing(t *testing.T) {
+	flash := config.ProviderEntry{Name: "deepseek-flash", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", Price: &provider.Pricing{Input: 1, Output: 2}}
+	pro := config.ProviderEntry{Name: "deepseek-pro", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", Price: &provider.Pricing{Input: 3, Output: 6}}
+	got := buildFamilyEntries(flash, []config.ProviderEntry{flash, pro}, []string{"deepseek-v4-flash", "deepseek-v4-pro"})
+	if len(got) != 2 {
+		t.Fatalf("got %d entries, want 2", len(got))
+	}
+	byName := map[string]config.ProviderEntry{}
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if e := byName["deepseek-flash"]; e.Model != "deepseek-v4-flash" || e.Price == nil || e.Price.Output != 2 {
+		t.Errorf("flash entry wrong: %+v (price %+v)", e, e.Price)
+	}
+	if e := byName["deepseek-pro"]; e.Model != "deepseek-v4-pro" || e.Price == nil || e.Price.Output != 6 {
+		t.Errorf("pro entry wrong: %+v (price %+v)", e, e.Price)
+	}
+}
+
+// TestBuildFamilyEntriesUnknownModelUsesProbe puts a live-only SKU (no matching
+// preset) under the probe entry rather than dropping it.
+func TestBuildFamilyEntriesUnknownModelUsesProbe(t *testing.T) {
+	flash := config.ProviderEntry{Name: "deepseek-flash", Model: "deepseek-v4-flash", Price: &provider.Pricing{Input: 1}}
+	got := buildFamilyEntries(flash, []config.ProviderEntry{flash}, []string{"deepseek-v4-flash", "deepseek-v9-experimental"})
+	if len(got) != 1 || got[0].Name != "deepseek-flash" {
+		t.Fatalf("got %+v, want one deepseek-flash entry", got)
+	}
+	if !reflect.DeepEqual(got[0].Models, []string{"deepseek-v4-flash", "deepseek-v9-experimental"}) {
+		t.Errorf("Models = %v, want both under the probe entry", got[0].Models)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #2901. When a family's selection spans members with different pricing — DeepSeek ships `deepseek-flash` (¥1/¥2) and `deepseek-pro` (¥3/¥6) as separate presets — `buildFamilyEntry` collapsed them into one `ProviderEntry` carrying the probe's single `Price`, so pro was billed at flash's rate.

`buildFamilyEntries` now splits the selection back across the preset members so each model keeps its own price, context window, and balance URL (matching the shape `config.Default()` already uses). Models the live `/models` list returned that match no preset fall under the probe entry.

## Validation
- `go build ./...`, `go vet ./internal/cli`, `go test ./internal/cli` — pass.
- New tests: `TestBuildFamilyEntriesSplitsPricing` (flash ¥2 / pro ¥6 stay separate) and `TestBuildFamilyEntriesUnknownModelUsesProbe` (live-only SKU falls under the probe). Existing `TestBuildFamilyEntry` unchanged.