### PR TITLE
fix(config): backfill deepseek-pro for flash-only configs from the old wizard

### DIFF
--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -1,0 +1,69 @@
+package config
+
+import "testing"
+
+func hasModel(c *Config, model string) *ProviderEntry {
+	for i := range c.Providers {
+		for _, m := range c.Providers[i].ModelList() {
+			if m == model {
+				return &c.Providers[i]
+			}
+		}
+	}
+	return nil
+}
+
+func TestBackfillDeepSeekProRestoresPro(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{
+		{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY"},
+	}}
+	backfillDeepSeekPro(c)
+	pro := hasModel(c, "deepseek-v4-pro")
+	if pro == nil {
+		t.Fatal("deepseek-v4-pro not restored")
+	}
+	if pro.Price == nil || pro.Price.Output != 6 {
+		t.Errorf("pro price not the preset: %+v", pro.Price)
+	}
+}
+
+func TestBackfillDeepSeekProInheritsKeyEnv(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{
+		{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "MY_DS_KEY"},
+	}}
+	backfillDeepSeekPro(c)
+	if pro := hasModel(c, "deepseek-v4-pro"); pro == nil || pro.APIKeyEnv != "MY_DS_KEY" {
+		t.Errorf("pro should inherit the flash key env, got %+v", pro)
+	}
+}
+
+func TestBackfillDeepSeekProNoopWhenProPresent(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{
+		{Name: "deepseek-flash", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash"},
+		{Name: "deepseek-pro", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro"},
+	}}
+	backfillDeepSeekPro(c)
+	if n := len(c.Providers); n != 2 {
+		t.Errorf("providers grew to %d; should be a no-op when pro is present", n)
+	}
+}
+
+func TestBackfillDeepSeekProSkipsCustomEndpoint(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{
+		{Name: "myproxy", BaseURL: "https://proxy.example.com/v1", Model: "deepseek-v4-flash"},
+	}}
+	backfillDeepSeekPro(c)
+	if hasModel(c, "deepseek-v4-pro") != nil {
+		t.Error("must not add pro for a non-official endpoint that may not serve it")
+	}
+}
+
+func TestBackfillDeepSeekProSkipsNonDeepSeek(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{
+		{Name: "mimo-flash", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5"},
+	}}
+	backfillDeepSeekPro(c)
+	if len(c.Providers) != 1 {
+		t.Error("unrelated config must be untouched")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -579,7 +579,44 @@ func Load() (*Config, error) {
 	}
 	cfg.mergeMCPJSON(entries)
 	normalizeLegacyEffort(cfg)
+	backfillDeepSeekPro(cfg)
 	return cfg, nil
+}
+
+// backfillDeepSeekPro restores deepseek-pro for configs the pre-fix setup wizard
+// wrote with only deepseek-v4-flash: a keyless /models probe used to drop the Pro
+// SKU, leaving users unable to switch to it. In-memory only — the user's file is
+// untouched. Narrowly scoped to the official DeepSeek endpoint (which is known to
+// serve pro) so a custom flash-only deployment isn't given an entry that 404s.
+func backfillDeepSeekPro(c *Config) {
+	const flashModel, proModel = "deepseek-v4-flash", "deepseek-v4-pro"
+	var flash *ProviderEntry
+	for i := range c.Providers {
+		p := &c.Providers[i]
+		if p.Name == "deepseek-pro" {
+			return
+		}
+		for _, m := range p.ModelList() {
+			switch m {
+			case proModel:
+				return // pro already reachable
+			case flashModel:
+				if strings.Contains(p.BaseURL, "api.deepseek.com") {
+					flash = p
+				}
+			}
+		}
+	}
+	if flash == nil {
+		return
+	}
+	for _, bp := range Default().Providers {
+		if bp.Name == "deepseek-pro" {
+			bp.APIKeyEnv = flash.APIKeyEnv
+			c.Providers = append(c.Providers, bp)
+			return
+		}
+	}
 }
 
 // normalizeLegacyEffort migrates the retired DeepSeek effort="off" (the old


### PR DESCRIPTION
Self-heal for users already affected by the setup regression (#2901/#2904). Their `reasonix.toml` contains only `deepseek-v4-flash` — without re-running setup they can't switch to Pro.

On load, when the config has the official `api.deepseek.com` flash provider and no pro, `backfillDeepSeekPro` appends the `deepseek-pro` preset in memory (with its correct ¥3/¥6 pricing and balance URL, inheriting the flash provider's key env). It's a no-op when pro already exists, and scoped to the official endpoint so a custom flash-only deployment isn't handed an entry that 404s. Sits alongside the existing `normalizeLegacyEffort` load-time normalizer; the user's file is never written.

So affected users get Pro back automatically — no need to re-run `reasonix setup`.

## Validation
- `go test ./internal/config ./internal/boot ./internal/cli` — pass.
- New tests: restore, key-env inheritance, no-op when pro present, skip custom endpoint, skip non-DeepSeek.