### PR TITLE
fix(cli): stop config overwrite when the default model can't resolve

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -324,9 +324,10 @@ func chatREPL(args []string) int {
 
 	sink := &eventSink{ch: eventCh}
 	ctrl, err := setup(ctx, *model, *maxSteps, false, sink)
-	if err != nil && errors.Is(err, boot.ErrUnknownModel) && isInteractive() {
-		// The configured model no longer resolves (e.g. a renamed/removed
-		// provider). Re-run the wizard instead of dead-ending, then retry.
+	if err != nil && errors.Is(err, boot.ErrUnknownModel) && isInteractive() && config.SourcePath() == "" {
+		// True first run whose default model can't resolve: guide setup, then retry.
+		// With a config present, fall through to the descriptive error — re-running
+		// the wizard would overwrite the user's config (#2856).
 		fmt.Fprintln(os.Stderr, i18n.M.ReconfigureOnUnknownModel)
 		if rc := interactiveSetup(defaultConfigTarget(), defaultEnvTarget()); rc != 0 {
 			return rc


### PR DESCRIPTION
## Problem

`chatREPL`'s `ErrUnknownModel` recovery re-ran the setup wizard whenever the configured default model failed to resolve (e.g. a renamed/removed provider) — *even when a config file already existed*. `interactiveSetup` then wrote over the user's config, one of the overwrite paths flagged in #2856.

The first-run onboarding rework already landed on `main-v2` (setup writes to the user-global config, and `welcome()` only auto-launches the wizard when no config resolves from any source), so #2856's main cause is fixed. This closes the one remaining overwrite path.

## Fix

Gate the recovery on `config.SourcePath() == ""` (a true first run with no config anywhere). When a config exists but its model can't resolve, fall through to the existing descriptive error, which already tells the user to run `reasonix setup`.

## Verification

- `go build ./...`, `go vet ./internal/cli/...`, `go test ./internal/cli/...` — pass.

Refs #2856. Supersedes #2858 (whose `welcome()` change conflicts with the first-run rework already on `main-v2`).
