### PR TITLE
fix: add bounded filename search for @ file references

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/fileref"
 	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/i18n"
 	"reasonix/internal/mcpdiag"
@@ -1758,6 +1759,7 @@ type WorkspaceChangesView struct {
 var atSkip = map[string]bool{".git": true, "node_modules": true, ".DS_Store": true}
 
 const filePreviewLimit = 256 * 1024
+const fileRefSearchLimit = 20
 
 func trimUTF8PartialSuffix(data []byte) []byte {
 	if utf8.Valid(data) {
@@ -1838,6 +1840,20 @@ func (a *App) ListDir(rel string) []DirEntry {
 	sort.Slice(dirs, func(i, j int) bool { return strings.ToLower(dirs[i].Name) < strings.ToLower(dirs[j].Name) })
 	sort.Slice(files, func(i, j int) bool { return strings.ToLower(files[i].Name) < strings.ToLower(files[j].Name) })
 	return append(dirs, files...)
+}
+
+// SearchFileRefs finds workspace files by basename for bare "@token" completion.
+func (a *App) SearchFileRefs(query string) []DirEntry {
+	base, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	paths := fileref.Search(base, query, fileRefSearchLimit)
+	out := make([]DirEntry, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, DirEntry{Name: path, IsDir: false})
+	}
+	return out
 }
 
 // ReadFile returns a small text preview for a file under the current workspace.

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -109,6 +109,36 @@ func TestSetEffortRejectsRunningTurn(t *testing.T) {
 	waitNotRunning(t, app.ctrl)
 }
 
+func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "frontend", "wailsjs", "runtime"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "frontend", "wailsjs", "runtime", "runtime.js"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_modules", "pkg", "runtime.js"), []byte("noise"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	got := (&App{}).SearchFileRefs("runtime.js")
+	if !hasDirEntry(got, "frontend/wailsjs/runtime/runtime.js") {
+		t.Fatalf("SearchFileRefs(runtime.js) should find nested workspace file, got %+v", got)
+	}
+	if hasDirEntry(got, "node_modules/pkg/runtime.js") {
+		t.Fatalf("SearchFileRefs should skip node_modules noise, got %+v", got)
+	}
+}
+
 func TestDeleteSessionRejectsActiveRelativePath(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
@@ -580,6 +610,15 @@ func hasLevel(levels []string, want string) bool {
 func hasCommand(cmds []CommandInfo, name string) bool {
 	for _, cmd := range cmds {
 		if cmd.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasDirEntry(entries []DirEntry, name string) bool {
+	for _, entry := range entries {
+		if entry.Name == name {
 			return true
 		}
 	}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -223,7 +223,9 @@ export function Composer({
   }, [atRaw]);
 
   const [entries, setEntries] = useState<DirEntry[]>([]);
+  const [searchEntries, setSearchEntries] = useState<DirEntry[]>([]);
   const dirCache = useRef<Record<string, DirEntry[]>>({});
+  const searchCache = useRef<Record<string, DirEntry[]>>({});
   useEffect(() => {
     if (atRaw === null) return;
     const cached = dirCache.current[atDir];
@@ -245,9 +247,42 @@ export function Composer({
     };
     // re-fetch only when the menu opens or the directory level changes
   }, [atRaw === null, atDir]);
+  useEffect(() => {
+    if (atRaw === null || atDir !== "" || atFrag === "") {
+      setSearchEntries([]);
+      return;
+    }
+    const cached = searchCache.current[atFrag];
+    if (cached) {
+      setSearchEntries(cached);
+      return;
+    }
+    setSearchEntries([]);
+    let live = true;
+    app
+      .SearchFileRefs(atFrag)
+      .then((es) => {
+        const list = es ?? [];
+        searchCache.current[atFrag] = list;
+        if (live) setSearchEntries(list);
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, [atRaw === null, atDir, atFrag]);
   const atMatches = useMemo(
-    () => (atRaw === null ? [] : entries.filter((e) => e.name.toLowerCase().includes(atFrag)).slice(0, 10)),
-    [atRaw, atFrag, entries],
+    () => {
+      if (atRaw === null) return [];
+      const local = entries.filter((e) => e.name.toLowerCase().includes(atFrag));
+      const seen = new Set(local.map((e) => e.name));
+      const searched = searchEntries.filter((e) => {
+        const basename = e.name.split("/").pop()?.toLowerCase() ?? "";
+        return basename.includes(atFrag) && !seen.has(e.name);
+      });
+      return [...local, ...searched].slice(0, 10);
+    },
+    [atRaw, atFrag, entries, searchEntries],
   );
 
   // --- which menu (if any) is open --- (slash command names win; then slash

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -99,6 +99,7 @@ export interface AppBindings {
   SetMCPServerTier(name: string, tier: string): Promise<void>;
   SlashArgs(input: string): Promise<SlashArgsResult>;
   ListDir(rel: string): Promise<DirEntry[]>;
+  SearchFileRefs(query: string): Promise<DirEntry[]>;
   ReadFile(rel: string): Promise<FilePreview>;
   WorkspaceChanges(): Promise<WorkspaceChangesView>;
   OpenWorkspacePath(rel: string): Promise<void>;
@@ -799,6 +800,12 @@ function makeMockApp(): AppBindings {
         ];
       }
       return [{ name: "file.go", isDir: false }];
+    },
+    async SearchFileRefs(query: string) {
+      const q = query.toLowerCase();
+      return ["desktop/frontend/src/lib/bridge.ts", "frontend/wailsjs/runtime/runtime.js", "internal/control/refs.go"]
+        .filter((path) => path.split("/").pop()?.toLowerCase().includes(q))
+        .map((name) => ({ name, isDir: false }));
     },
     async ReadFile(rel: string) {
       const samples: Record<string, string> = {

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"reasonix/internal/control"
+	"reasonix/internal/fileref"
 	"reasonix/internal/i18n"
 	"reasonix/internal/skill"
 )
@@ -51,6 +52,8 @@ const (
 	// pathologically large directory can't blow up the menu — we read only one
 	// level (os.ReadDir), never the whole tree.
 	maxCompItems = 200
+	// maxFileSearchItems caps basename search results for bare @tokens.
+	maxFileSearchItems = 20
 )
 
 // slashItems is the full set of slash commands offered for completion: the
@@ -298,6 +301,23 @@ func (m *chatTUI) fileItems(token string) []compItem {
 	// At the top level (still naming the first segment) MCP resources share the
 	// '@' namespace, so offer the matching ones too.
 	if !strings.Contains(token, "/") {
+		seen := map[string]bool{}
+		for _, it := range items {
+			seen[strings.TrimPrefix(it.insert, "@")] = true
+		}
+		remaining := maxCompItems - len(items)
+		if remaining > maxFileSearchItems {
+			remaining = maxFileSearchItems
+		}
+		for _, path := range fileref.Search(".", frag, remaining) {
+			if seen[path] {
+				continue
+			}
+			items = append(items, compItem{label: path, insert: "@" + path, hint: "file"})
+			if len(items) >= maxCompItems {
+				break
+			}
+		}
 		items = append(items, m.resourceItems("", token)...)
 	}
 	return items

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -158,6 +159,52 @@ func TestFileItemsOneLevel(t *testing.T) {
 		if it.label == "sub/" && !it.descend {
 			t.Error("directory entry should be a descend")
 		}
+	}
+}
+
+func TestFileItemsSearchesBasenameAtTopLevel(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	writeAt(t, dir, "frontend/wailsjs/runtime/runtime.js", "x")
+	writeAt(t, dir, "node_modules/pkg/runtime.js", "noise")
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestChatTUI()
+	items := m.fileItems("runtime.js")
+
+	if !hasLabel(items, "frontend/wailsjs/runtime/runtime.js") {
+		t.Fatalf("top-level @runtime.js should offer nested file path, got %v", labels(items))
+	}
+	if hasLabel(items, "node_modules/pkg/runtime.js") {
+		t.Fatalf("file search should skip node_modules noise, got %v", labels(items))
+	}
+}
+
+func TestFileItemsSearchRespectsMenuCap(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	for i := 0; i < maxCompItems; i++ {
+		writeAt(t, dir, filepath.Join("aa-dir-"+fmt.Sprintf("%03d", i), "file.txt"), "x")
+	}
+	writeAt(t, dir, "nested/aa-deep.js", "y")
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestChatTUI()
+	items := m.fileItems("aa")
+
+	if len(items) != maxCompItems {
+		t.Fatalf("fileItems should stay capped at %d entries, got %d", maxCompItems, len(items))
+	}
+	if hasLabel(items, "nested/aa-deep.js") {
+		t.Fatalf("search result should not exceed capped menu: %v", labels(items))
 	}
 }
 

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -1,0 +1,78 @@
+package fileref
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+var skipDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"dist":         true,
+	"build":        true,
+	".DS_Store":    true,
+}
+
+const (
+	minQueryLen    = 2
+	maxWalkEntries = 10000
+)
+
+// Search finds regular files under root whose basename contains query. It is
+// bounded by limit and skips common generated/vendor directories so interactive
+// completion stays responsive on large workspaces.
+func Search(root, query string, limit int) []string {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if len(query) < minQueryLen || strings.ContainsAny(query, `/\`) || limit <= 0 {
+		return nil
+	}
+
+	showHidden := strings.HasPrefix(query, ".")
+	var matches []string
+	visited := 0
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if path == root {
+			return nil
+		}
+		visited++
+		if visited > maxWalkEntries {
+			return filepath.SkipAll
+		}
+
+		name := d.Name()
+		if d.IsDir() {
+			if skipDirs[name] || (!showHidden && strings.HasPrefix(name, ".")) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if len(matches) >= limit {
+			return filepath.SkipAll
+		}
+		if !showHidden && strings.HasPrefix(name, ".") {
+			return nil
+		}
+		if !strings.Contains(strings.ToLower(name), query) {
+			return nil
+		}
+		if info, err := d.Info(); err != nil || !info.Mode().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		matches = append(matches, filepath.ToSlash(rel))
+		return nil
+	})
+	sort.Strings(matches)
+	return matches
+}


### PR DESCRIPTION
This change fixes @ file reference completion in the desktop app and TUI when users know a filename but not its directory. For example, typing @runtime.js can now surface candidates such as frontend/wailsjs/runtime/runtime.js without requiring users to manually navigate through frontend/wailsjs/runtime first.

To respect the original performance boundary of the existing design, this does not turn ListDir/fileItems into unbounded recursive directory completion. The existing one-level directory navigation remains unchanged, and the new filename search only runs for bare @tokens that do not contain a path separator.

The search logic is centralized in internal/fileref and reused by both desktop and TUI completion paths to keep behavior consistent. It is intentionally bounded: it requires a minimum query length, returns at most 20 results, scans at most 10000 entries, and skips high-noise or high-cost directories such as .git, node_modules, dist, build, and hidden directories.

The TUI continues to honor the existing maxCompItems completion cap by allowing search results to fill only the remaining menu capacity. On desktop, Composer merges local directory entries with filename search results, deduplicates candidates, and clears stale search state between queries to avoid leaking results across different @tokens.

The controller, serve endpoint, and ACP flow are unchanged. Submitted @references are still resolved only when they contain real existing paths, so this change only improves interactive completion and does not alter @reference resolution semantics.

Tests cover nested basename search for desktop and TUI, skipping node_modules noise, and preserving the TUI completion menu cap.



Closes #2897 