### PR TITLE
fix: recursive file search in glob/ls + @-ref resolution

### DIFF
--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -97,6 +97,50 @@ func (c *Controller) HasRefs(line string) bool {
 	return len(c.detectRefs(line)) > 0
 }
 
+// resolveBareNames batch-resolves simple filenames (no path separator) that
+// don't exist in cwd. It walks the working tree once and matches every
+// unresolved name against the set, stopping when all are found. This runs in
+// the async ResolveRefs path, never on the TUI event loop.
+func resolveBareNames(refs []ref) []ref {
+	need := map[string]*ref{}
+	var names []string
+	for i := range refs {
+		r := &refs[i]
+		if r.kind != refFile || strings.ContainsAny(r.raw, "/\\") {
+			continue
+		}
+		if _, err := os.Stat(r.raw); err == nil {
+			continue
+		}
+		need[r.raw] = r
+		names = append(names, r.raw)
+	}
+	if len(names) == 0 {
+		return refs
+	}
+	found := 0
+	cwd, _ := os.Getwd()
+	filepath.WalkDir(cwd, func(p string, d os.DirEntry, wErr error) error {
+		if wErr != nil || found == len(names) {
+			return filepath.SkipAll
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if r, ok := need[d.Name()]; ok {
+			rel, _ := filepath.Rel(cwd, p)
+			r.path = filepath.ToSlash(rel)
+			found++
+		}
+		return nil
+	})
+	return refs
+}
+
 // FileRefLine reports whether a submitted line is nothing but a path to an
 // existing file — a dragged or pasted file lands as its bare path, which on
 // POSIX starts with '/' and would otherwise be misread as a slash command. The
@@ -117,8 +161,10 @@ func FileRefLine(line string) (string, bool) {
 // strings for any that failed. An empty block means no references resolved.
 // Safe to call off a frontend's event loop; honours ctx for the resource reads.
 func (c *Controller) ResolveRefs(ctx context.Context, line string) (block string, errs []string) {
+	refs := c.detectRefs(line)
+	refs = resolveBareNames(refs)
 	var b strings.Builder
-	for _, r := range c.detectRefs(line) {
+	for _, r := range refs {
 		switch r.kind {
 		case refResource:
 			text, err := c.host.ReadResource(ctx, r.server, r.uri)
@@ -152,12 +198,14 @@ func appendRefBlock(b *strings.Builder, tag, attr, body string) {
 	fmt.Fprintf(b, "<%s %s>\n%s\n</%s>", tag, attr, body, tag)
 }
 
+// maxDirEntries caps how many directory entries are injected so @some-huge-dir
+// can't blow the context window.
+const maxDirEntries = 100
+
 // readFileRef reads an @-referenced path for injection. A directory yields a
-// recursive listing (walked depth-first so the model sees the full tree); a
-// binary file (NUL in the first 8 KiB) is noted rather than dumped; a large file
-// is truncated to maxFileRefBytes with a marker. isDir lets the caller pick the
-// wrapping tag. Common noise directories (.git, node_modules, .DS_Store) are
-// skipped during the walk.
+// recursive listing capped at maxDirEntries; a binary file (NUL in the first
+// 8 KiB) is noted rather than dumped; a large file is truncated to
+// maxFileRefBytes with a marker. isDir lets the caller pick the wrapping tag.
 func readFileRef(path string) (content string, isDir bool, err error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -165,25 +213,20 @@ func readFileRef(path string) (content string, isDir bool, err error) {
 	}
 	if info.IsDir() {
 		var b strings.Builder
+		n := 0
 		err := filepath.WalkDir(path, func(p string, d os.DirEntry, wErr error) error {
-			if wErr != nil {
-				return wErr
+			if wErr != nil || n >= maxDirEntries {
+				return filepath.SkipAll
 			}
-			// Skip the root itself — we only list its children.
 			if p == path {
 				return nil
 			}
-			name := d.Name()
-			// Skip common noise directories.
 			if d.IsDir() {
-				switch name {
+				switch d.Name() {
 				case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
 					return filepath.SkipDir
 				}
 			}
-			// Render the path relative to the referenced directory so the
-			// listing is concise and unambiguous. Use forward slashes for
-			// cross-platform consistency.
 			rel, rErr := filepath.Rel(path, p)
 			if rErr != nil {
 				rel = p
@@ -194,8 +237,12 @@ func readFileRef(path string) (content string, isDir bool, err error) {
 			}
 			b.WriteString(rel)
 			b.WriteByte('\n')
+			n++
 			return nil
 		})
+		if n >= maxDirEntries {
+			b.WriteString("\n…[truncated; directory has more entries]…")
+		}
 		if err != nil {
 			return "", true, err
 		}

--- a/internal/memory/doc.go
+++ b/internal/memory/doc.go
@@ -249,7 +249,8 @@ func importTarget(line string) (string, bool) {
 func resolvePath(p, baseDir string) string {
 	if strings.HasPrefix(p, "~") {
 		if home, err := os.UserHomeDir(); err == nil {
-			return filepath.Join(home, strings.TrimPrefix(p[1:], "/"))
+			rest := strings.TrimLeft(p[1:], "/\\")
+			return filepath.Join(home, rest)
 		}
 	}
 	if filepath.IsAbs(p) {

--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -42,6 +42,10 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if p.Pattern == "" {
 		return "", fmt.Errorf("pattern is required")
 	}
+	// Save the original pattern before resolveIn prepends workDir, so the
+	// simple-filename recursive-fallback check below works on the raw input
+	// — not the already-joined absolute path that always contains separators.
+	rawPattern := p.Pattern
 	p.Pattern = resolveIn(g.workDir, p.Pattern)
 	p.Pattern = filepath.FromSlash(p.Pattern) // models emit "/" (see Description); WalkDir/Match compare OS-native paths
 
@@ -54,13 +58,14 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 	// found and the pattern is a simple filename (no path separator), retry
 	// with a recursive walk (equivalent to "**/<pattern>") so the tool finds
 	// files anywhere in the tree — the common case where the model only knows
-	// a filename but not its exact location.
+	// a filename but not its exact location. Uses the raw pattern (before
+	// resolveIn) so a workspace root doesn't mask a simple "*.go".
 	matches, err := filepath.Glob(p.Pattern)
 	if err != nil {
 		return "", fmt.Errorf("glob %q: %w", p.Pattern, err)
 	}
-	if len(matches) == 0 && !strings.ContainsAny(p.Pattern, "/\\") {
-		return globRecursive(ctx, filepath.Join("**", p.Pattern))
+	if len(matches) == 0 && !strings.ContainsAny(rawPattern, "/\\") {
+		return globRecursive(ctx, filepath.Join("**", rawPattern))
 	}
 	if len(matches) == 0 {
 		return "(no matches)", nil
@@ -74,7 +79,8 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 
 // globRecursive handles patterns containing ** by walking the filesystem.
 // It splits the pattern at ** to get a root prefix and a suffix to match
-// against each file path found during the walk.
+// against each file path found during the walk. Accepts a context so the
+// walk can be interrupted on cancellation.
 func globRecursive(ctx context.Context, pattern string) (string, error) {
 	// Split on ** to find the root directory and the remaining pattern.
 	parts := strings.SplitN(pattern, "**", 2)

--- a/internal/tool/builtin/ls.go
+++ b/internal/tool/builtin/ls.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"reasonix/internal/tool"
@@ -19,18 +20,19 @@ type listDir struct{ workDir string }
 func (listDir) Name() string { return "ls" }
 
 func (listDir) Description() string {
-	return "List the entries of a directory. Directories are shown with a trailing slash; files show their byte size."
+	return "List the entries of a directory. Directories are shown with a trailing slash; files show their byte size. Set recursive=true to list all nested files depth-first (skips .git/node_modules)."
 }
 
 func (listDir) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Directory path (default \".\")"}}}`)
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string","description":"Directory path (default \".\")"},"recursive":{"type":"boolean","description":"When true, recursively list all nested files (default false)"}}}`)
 }
 
 func (listDir) ReadOnly() bool { return true }
 
 func (l listDir) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	p := struct {
-		Path string `json:"path"`
+		Path      string `json:"path"`
+		Recursive bool   `json:"recursive"`
 	}{Path: "."}
 	if len(args) > 0 {
 		if err := json.Unmarshal(args, &p); err != nil {
@@ -41,6 +43,11 @@ func (l listDir) Execute(ctx context.Context, args json.RawMessage) (string, err
 		p.Path = "."
 	}
 	p.Path = resolveIn(l.workDir, p.Path)
+
+	// Recursive mode: walk the whole tree depth-first.
+	if p.Recursive {
+		return l.listRecursive(p.Path)
+	}
 
 	entries, err := os.ReadDir(p.Path)
 	if err != nil {
@@ -61,6 +68,52 @@ func (l listDir) Execute(ctx context.Context, args json.RawMessage) (string, err
 	}
 	if b.Len() == 0 {
 		return "(empty directory)", nil
+	}
+	return b.String(), nil
+}
+
+// listRecursive walks a directory tree depth-first, skipping noise dirs.
+// Depth is capped to guard against symlink loops.
+func (l listDir) listRecursive(root string) (string, error) {
+	var b strings.Builder
+	err := filepath.WalkDir(root, func(p string, d os.DirEntry, wErr error) error {
+		if wErr != nil {
+			return wErr
+		}
+		if p == root {
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
+				return filepath.SkipDir
+			}
+		}
+		rel, rErr := filepath.Rel(root, p)
+		if rErr != nil {
+			rel = p
+		}
+		// Guard against excessive depth.
+		if strings.Count(rel, string(os.PathSeparator)) > 50 {
+			if d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		if d.IsDir() {
+			rel += "/"
+		} else if info, iErr := d.Info(); iErr == nil {
+			rel += fmt.Sprintf("\t%d", info.Size())
+		}
+		b.WriteString(rel + "\n")
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("ls -R %s: %w", root, err)
+	}
+	if b.Len() == 0 {
+		return "(empty directory tree)", nil
 	}
 	return b.String(), nil
 }

--- a/internal/tool/builtin/recursive_search_test.go
+++ b/internal/tool/builtin/recursive_search_test.go
@@ -1,0 +1,73 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGlobBareNameFallsBackToRecursiveWithWorkDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub", "deep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "deep", "target.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "node_modules", "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "node_modules", "pkg", "target.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(root)
+
+	out := runTool(t, globTool{workDir: root}, map[string]any{"pattern": "target.go"})
+	if !strings.Contains(filepath.ToSlash(out), "sub/deep/target.go") {
+		t.Fatalf("bare filename should fall back to a recursive walk; got:\n%s", out)
+	}
+	if strings.Contains(out, "node_modules") {
+		t.Fatalf("recursive fallback should skip node_modules; got:\n%s", out)
+	}
+}
+
+func TestLsRecursive(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a", "b", "nested.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git", "HEAD"), []byte("ref"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := listDir{workDir: root}
+
+	flat := runTool(t, l, map[string]any{"path": "."})
+	if strings.Contains(flat, "nested.txt") {
+		t.Fatalf("flat ls must not recurse; got:\n%s", flat)
+	}
+
+	rec, err := l.Execute(context.Background(), json.RawMessage(`{"path":".","recursive":true}`))
+	if err != nil {
+		t.Fatalf("recursive ls: %v", err)
+	}
+	s := filepath.ToSlash(rec)
+	if !strings.Contains(s, "a/b/nested.txt") {
+		t.Fatalf("recursive ls should list nested files; got:\n%s", rec)
+	}
+	if strings.Contains(rec, "HEAD") {
+		t.Fatalf("recursive ls should skip .git; got:\n%s", rec)
+	}
+}


### PR DESCRIPTION
Rebased #2643 by @xinrenH onto current `main-v2`, plus a regression test.

## What this fixes

- **glob recursive fallback was dead code.** The "simple filename → retry as `**/<name>`" fallback tested `p.Pattern` *after* `resolveIn` had prepended `workDir`, so the `!ContainsAny("/\\")` guard was always false when a workspace root was set — the fallback never ran. Now it checks the raw pattern, so `glob "foo.go"` finds the file anywhere in the tree.
- **`ls` gains `recursive`** — depth-first listing of nested files, skipping `.git`/`node_modules`/etc., with a depth cap against symlink loops.
- **`@dir` listings are capped** at `maxDirEntries` (100) so referencing a huge directory can't blow the context window.
- **Bare `@filename` refs resolve tree-wide** via a single async walk in `ResolveRefs` (off the event loop).
- **`~\path` handling** trims both `/` and `\`, fixing Windows-style home paths in memory imports.

## Testing

- New `recursive_search_test.go` pins the glob fallback (the previously-uncovered path) and `ls recursive=true`, including the noise-dir skip.
- E2E-verified the `@dir` cap and bare-name resolution against a real temp tree.
- `go build ./...`, `go vet ./internal/...`, `go test ./internal/tool/... ./internal/control/ ./internal/memory/` — pass.

Co-authored work by @xinrenH (original #2643).

Closes #2643
