### PR TITLE
fix(tools): root glob recursive fallback at workDir; stop swallowing walk errors

### DIFF
--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -215,7 +215,10 @@ func readFileRef(path string) (content string, isDir bool, err error) {
 		var b strings.Builder
 		n := 0
 		err := filepath.WalkDir(path, func(p string, d os.DirEntry, wErr error) error {
-			if wErr != nil || n >= maxDirEntries {
+			if wErr != nil {
+				return wErr
+			}
+			if n >= maxDirEntries {
 				return filepath.SkipAll
 			}
 			if p == path {

--- a/internal/tool/builtin/glob.go
+++ b/internal/tool/builtin/glob.go
@@ -65,7 +65,7 @@ func (g globTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "", fmt.Errorf("glob %q: %w", p.Pattern, err)
 	}
 	if len(matches) == 0 && !strings.ContainsAny(rawPattern, "/\\") {
-		return globRecursive(ctx, filepath.Join("**", rawPattern))
+		return globRecursive(ctx, filepath.Join(g.workDir, "**", rawPattern))
 	}
 	if len(matches) == 0 {
 		return "(no matches)", nil

--- a/internal/tool/builtin/recursive_search_test.go
+++ b/internal/tool/builtin/recursive_search_test.go
@@ -23,7 +23,7 @@ func TestGlobBareNameFallsBackToRecursiveWithWorkDir(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "node_modules", "pkg", "target.go"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	t.Chdir(root)
+	t.Chdir(t.TempDir())
 
 	out := runTool(t, globTool{workDir: root}, map[string]any{"pattern": "target.go"})
 	if !strings.Contains(filepath.ToSlash(out), "sub/deep/target.go") {


### PR DESCRIPTION
Follow-up polish to #2915.

- **glob recursive fallback now roots at `workDir`.** The simple-filename → `**/<name>` fallback walked the process cwd, ignoring the tool's configured workspace root (the non-recursive path already honours `workDir`). Now it walks `g.workDir`. The regression test is tightened to `chdir` to an unrelated dir, so a cwd-rooted walk would fail it (verified: reverting the fix yields `(no matches)`).
- **`readFileRef` no longer swallows walk errors.** The directory listing collapsed a walk error and the entry cap into one `filepath.SkipAll`, silently dropping real errors (e.g. a mid-walk permission failure). The error now propagates; only the `maxDirEntries` cap stops the walk early.

Verification: `go build ./...`, `go vet ./internal/tool/... ./internal/control/...`, `go test ./internal/tool/builtin/ ./internal/control/` — pass.
