### PR TITLE
fix(tools): match CRLF line endings in edit_file/multi_edit

### DIFF
--- a/internal/tool/builtin/crlf_edit_test.go
+++ b/internal/tool/builtin/crlf_edit_test.go
@@ -1,0 +1,99 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/text/encoding/simplifiedchinese"
+)
+
+func encGBK(t *testing.T, s string) []byte {
+	t.Helper()
+	out, err := simplifiedchinese.GB18030.NewEncoder().String(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return []byte(out)
+}
+
+func decGBK(t *testing.T, b []byte) string {
+	t.Helper()
+	out, err := simplifiedchinese.GB18030.NewDecoder().Bytes(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+func runEdit(t *testing.T, dir, name, oldS, newS string) {
+	t.Helper()
+	b, _ := json.Marshal(map[string]any{"path": name, "old_string": oldS, "new_string": newS})
+	if _, err := (editFile{workDir: dir}).Execute(context.Background(), b); err != nil {
+		t.Fatalf("edit_file: %v", err)
+	}
+}
+
+func TestEditFileCRLFGBKPreservesEncodingAndEndings(t *testing.T) {
+	dir := t.TempDir()
+	src := "第一行 hello\r\n第二行 world\r\n第三行 done\r\n"
+	if err := os.WriteFile(filepath.Join(dir, "f.cs"), encGBK(t, src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// old/new arrive LF-only, as the model copies them out of read_file output.
+	runEdit(t, dir, "f.cs", "第一行 hello\n第二行 world", "第一行 HELLO\n第二行 WORLD")
+
+	raw, err := os.ReadFile(filepath.Join(dir, "f.cs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := decGBK(t, raw)
+	want := "第一行 HELLO\r\n第二行 WORLD\r\n第三行 done\r\n"
+	if got != want {
+		t.Fatalf("content/endings not preserved:\n got %q\nwant %q", got, want)
+	}
+	if strings.Contains(strings.ReplaceAll(got, "\r\n", ""), "\n") {
+		t.Fatalf("a bare \\n leaked into a CRLF file: %q", got)
+	}
+}
+
+func TestEditFileLFStaysLF(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("alpha\nbeta\ngamma\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runEdit(t, dir, "f.txt", "alpha\nbeta", "ALPHA\nBETA")
+	raw, _ := os.ReadFile(filepath.Join(dir, "f.txt"))
+	if strings.Contains(string(raw), "\r") {
+		t.Fatalf("CR leaked into an LF file: %q", string(raw))
+	}
+	if string(raw) != "ALPHA\nBETA\ngamma\n" {
+		t.Fatalf("unexpected result: %q", string(raw))
+	}
+}
+
+func TestMultiEditCRLF(t *testing.T) {
+	dir := t.TempDir()
+	src := "one\r\ntwo\r\nthree\r\nfour\r\n"
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := json.Marshal(map[string]any{
+		"path": "f.txt",
+		"edits": []map[string]any{
+			{"old_string": "one\ntwo", "new_string": "ONE\nTWO"},
+			{"old_string": "three", "new_string": "THREE"},
+		},
+	})
+	if _, err := (multiEdit{workDir: dir}).Execute(context.Background(), b); err != nil {
+		t.Fatalf("multi_edit: %v", err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(dir, "f.txt"))
+	if string(raw) != "ONE\r\nTWO\r\nTHREE\r\nfour\r\n" {
+		t.Fatalf("multi_edit mangled endings: %q", string(raw))
+	}
+}

--- a/internal/tool/builtin/editfile.go
+++ b/internal/tool/builtin/editfile.go
@@ -56,7 +56,8 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "", fmt.Errorf("read %s: %w", p.Path, err)
 	}
 
-	switch strings.Count(content, p.OldString) {
+	old, newStr := matchLineEndings(content, p.OldString, p.NewString)
+	switch strings.Count(content, old) {
 	case 0:
 		return "", fmt.Errorf("old_string not found in %s", p.Path)
 	case 1:
@@ -65,7 +66,7 @@ func (e editFile) Execute(ctx context.Context, args json.RawMessage) (string, er
 		return "", fmt.Errorf("old_string is not unique in %s; add more surrounding context", p.Path)
 	}
 
-	updated := strings.Replace(content, p.OldString, p.NewString, 1)
+	updated := strings.Replace(content, old, newStr, 1)
 	if err := writeFileEncoded(p.Path, updated, enc); err != nil {
 		return "", fmt.Errorf("write %s: %w", p.Path, err)
 	}

--- a/internal/tool/builtin/encoding_helpers.go
+++ b/internal/tool/builtin/encoding_helpers.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"os"
+	"strings"
 
 	fileenc "reasonix/internal/fileutil/encoding"
 )
@@ -21,4 +22,22 @@ func readFileEncoded(path string) (content string, enc fileenc.Kind, err error) 
 // writeFileEncoded encodes content back to the given encoding and writes it.
 func writeFileEncoded(path string, content string, enc fileenc.Kind) error {
 	return os.WriteFile(path, fileenc.Encode(content, enc), 0o644)
+}
+
+// matchLineEndings adapts an edit's old/new text to a CRLF file when the literal
+// old_string isn't present but its CRLF form is. read_file strips '\r' (bufio
+// ScanLines), so a model's multi-line old_string arrives LF-only while a
+// Windows/CJK source stores '\r\n'; rewriting search and replacement to the
+// file's ending fixes the match without rewriting the file's other line endings.
+func matchLineEndings(content, old, new string) (string, string) {
+	if strings.Contains(content, old) || !strings.Contains(content, "\r\n") {
+		return old, new
+	}
+	toCRLF := func(s string) string {
+		return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\n", "\r\n")
+	}
+	if strings.Contains(content, toCRLF(old)) {
+		return toCRLF(old), toCRLF(new)
+	}
+	return old, new
 }

--- a/internal/tool/builtin/multiedit.go
+++ b/internal/tool/builtin/multiedit.go
@@ -94,20 +94,21 @@ func (m multiEdit) Execute(ctx context.Context, args json.RawMessage) (string, e
 		if step.OldString == "" {
 			return "", fmt.Errorf("edit %d: old_string is required", i+1)
 		}
+		old, newStr := matchLineEndings(content, step.OldString, step.NewString)
 		if step.ReplaceAll {
-			count := strings.Count(content, step.OldString)
+			count := strings.Count(content, old)
 			if count == 0 {
 				return "", fmt.Errorf("edit %d: old_string not found", i+1)
 			}
-			content = strings.ReplaceAll(content, step.OldString, step.NewString)
+			content = strings.ReplaceAll(content, old, newStr)
 			applied += count
 			continue
 		}
-		switch strings.Count(content, step.OldString) {
+		switch strings.Count(content, old) {
 		case 0:
 			return "", fmt.Errorf("edit %d: old_string not found", i+1)
 		case 1:
-			content = strings.Replace(content, step.OldString, step.NewString, 1)
+			content = strings.Replace(content, old, newStr, 1)
 			applied++
 		default:
 			return "", fmt.Errorf("edit %d: old_string is not unique; add more surrounding context or set replace_all", i+1)


### PR DESCRIPTION
Closes #2900 — "桌面版编辑非 UTF-8 (GBK) 文件 会提示 `old_string not found`".

## Root cause

Not an encoding bug. The encoding layer already decodes GB18030/GBK correctly, and `edit_file` re-encodes on write. The real cause is **line endings**:

- `read_file` uses `bufio.Scanner` (ScanLines), which **strips `\r`**, so the model only ever sees `\n`.
- The model copies a multi-line block as its `old_string` — LF-only.
- `edit_file`/`multi_edit` match against the file's raw decoded content, which for a Windows/CJK source still has `\r\n`.
- `strings.Count(content, old) == 0` → `old_string not found`.

GBK source files (C#, C++, game scripts) are almost always CRLF on Windows, so it looked encoding-specific — but a UTF-8 CRLF file fails identically, and a GBK **LF** file works fine. Reproduced across all four combinations before the fix:

| | LF | CRLF |
|---|---|---|
| UTF-8 | ✅ | ❌ → ✅ |
| GBK | ✅ | ❌ → ✅ |

## Fix

`matchLineEndings`: when the literal `old_string` isn't present but its CRLF form is, rewrite both search and replacement to the file's ending. Only the matched region is rewritten, so the file's other line endings are preserved and LF files never gain a `\r`. Wired into both `edit_file` and `multi_edit` (`delete_range` already handled CRLF).

## Tests

- `crlf_edit_test.go`: GBK+CRLF edit preserves encoding + endings; LF stays LF; multi_edit on CRLF.
- `go build ./...`, `go vet`, `go test ./internal/tool/builtin/ ./internal/fileutil/...` — pass.
