### PR TITLE
refactor(complete): memoize @token file search, drop dead skip entry

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -247,6 +247,9 @@ type chatTUI struct {
 
 	// completion is the live autocomplete menu (slash commands; @-refs later).
 	completion completion
+	// fileSearchCache memoizes fileref.Search by query so the bounded walk runs
+	// once per @token fragment, not on every keystroke that re-renders the menu.
+	fileSearchCache map[string][]string
 }
 
 type tuiState int

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -310,7 +310,11 @@ func (m *chatTUI) fileItems(token string) []compItem {
 		if remaining > maxFileSearchItems {
 			remaining = maxFileSearchItems
 		}
-		for _, path := range fileref.Search(".", frag, remaining) {
+		results := m.searchFileRefs(frag)
+		if len(results) > remaining {
+			results = results[:remaining]
+		}
+		for _, path := range results {
 			if seen[path] {
 				continue
 			}
@@ -322,6 +326,20 @@ func (m *chatTUI) fileItems(token string) []compItem {
 		items = append(items, m.resourceItems("", token)...)
 	}
 	return items
+}
+
+// searchFileRefs memoizes the bounded basename walk so re-rendering the menu
+// for an unchanged @token fragment doesn't re-walk the workspace each keystroke.
+func (m *chatTUI) searchFileRefs(frag string) []string {
+	if m.fileSearchCache == nil {
+		m.fileSearchCache = map[string][]string{}
+	}
+	if r, ok := m.fileSearchCache[frag]; ok {
+		return r
+	}
+	r := fileref.Search(".", frag, maxFileSearchItems)
+	m.fileSearchCache[frag] = r
+	return r
 }
 
 // splitPathToken splits a path token into (dir, frag): dir keeps its trailing

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -12,7 +12,6 @@ var skipDirs = map[string]bool{
 	"node_modules": true,
 	"dist":         true,
 	"build":        true,
-	".DS_Store":    true,
 }
 
 const (


### PR DESCRIPTION
Follow-up cleanup on the bounded @-reference file search landed in #2910.

- **Memoize the TUI walk.** `fileref.Search` was invoked on every keystroke that re-rendered the @-completion menu. Cache it by fragment on `chatTUI` so an unchanged token walks the workspace once — matching what the desktop Composer already does with its `searchCache`. The `maxCompItems` cap is preserved (search still fills only the remaining menu capacity).
- **Drop `.DS_Store` from `skipDirs`.** That map only guards directory names; a `.DS_Store` *file* is already filtered by the hidden-entry check, so the entry was dead.

No behavior change to completion results or @reference resolution. Existing `internal/cli` and `desktop` tests cover the paths; build + vet clean.