### PR TITLE
fix(agent): block final answers with incomplete todos

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -237,14 +237,15 @@ export default function App() {
   }, [state.meta, mode, syncModeToController]);
 
   // The live task list pinned above the composer comes from the most recent
-  // top-level todo_write call; it stays visible while work remains, clears itself
-  // once every item is completed, and can be dismissed by the user (the ✕). A
-  // dismissal is keyed to that list's id, so a fresh todo_write (a new task)
-  // brings the panel back.
+  // successful top-level todo_write result; failed or still-running attempts do
+  // not advance the canonical panel state. It stays visible while work remains,
+  // clears itself once every item is completed, and can be dismissed by the user
+  // (the ✕). A dismissal is keyed to that list's id, so a fresh accepted
+  // todo_write brings the panel back.
   const todoItem = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const it = state.items[i];
-      if (it.kind === "tool" && it.name === "todo_write" && !it.parentId) return it;
+      if (it.kind === "tool" && it.name === "todo_write" && !it.parentId && it.status === "done" && !it.error) return it;
     }
     return null;
   }, [state.items]);

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -435,17 +435,20 @@ func (a *Agent) finalReadinessFailure() string {
 	if a.evidence == nil {
 		return ""
 	}
+	var missing []string
+	if incomplete, hasTodos := a.evidence.IncompleteLatestTodos(); hasTodos && len(incomplete) > 0 {
+		missing = append(missing, finalReadinessIncompleteTodos(incomplete))
+	}
 	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
 	if !hasWriter {
-		return ""
+		return strings.Join(missing, "; ")
 	}
 	hasProjectChecks := len(a.projectChecks) > 0
 	hasTodoReceipt := a.evidence.HasSuccessfulTodoWrite()
-	if !hasProjectChecks && !hasTodoReceipt {
+	if !hasProjectChecks && !hasTodoReceipt && len(missing) == 0 {
 		return ""
 	}
 
-	var missing []string
 	for _, check := range a.projectChecks {
 		command := strings.TrimSpace(check.Command)
 		if command == "" {
@@ -462,6 +465,18 @@ func (a *Agent) finalReadinessFailure() string {
 		return ""
 	}
 	return strings.Join(missing, "; ")
+}
+
+func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		label := strings.TrimSpace(item.Content)
+		if label == "" {
+			label = fmt.Sprintf("todo %d", item.Index)
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", label, item.Status))
+	}
+	return "latest successful todo_write still has incomplete items: " + strings.Join(parts, ", ")
 }
 
 func finalReadinessCheckSource(check instruction.VerifyCheck) string {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -58,6 +58,16 @@ func lastToolResult(s *Session, name string) string {
 	return result
 }
 
+func toolResults(s *Session, name string) []string {
+	var results []string
+	for _, m := range s.Messages {
+		if m.Role == provider.RoleTool && m.Name == name {
+			results = append(results, m.Content)
+		}
+	}
+	return results
+}
+
 func sessionHasUserMessageContaining(s *Session, needle string) bool {
 	for _, m := range s.Messages {
 		if m.Role == provider.RoleUser && strings.Contains(m.Content, needle) {
@@ -264,6 +274,7 @@ func TestFinalReadinessRequiresCompleteStepAfterWriterWhenTodoSeen(t *testing.T)
 				"result":"changed.go updated",
 				"evidence":[{"kind":"diff","summary":"updated code","paths":["changed.go"]}]
 			}`),
+			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Edit code","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "signed off done"}, {Type: provider.ChunkDone}},
@@ -372,6 +383,12 @@ func TestEvidenceFlowRejectsStepMissingFromTodoWrite(t *testing.T) {
 				"result":"step is complete",
 				"evidence":[{"kind":"manual","summary":"checked manually"}]
 			}`),
+			toolCallChunk("c3", "complete_step", `{
+				"step":"Add parser",
+				"result":"parser added",
+				"evidence":[{"kind":"manual","summary":"checked manually"}]
+			}`),
+			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
@@ -430,13 +447,24 @@ func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
 	if !ok {
 		t.Fatal("todo_write builtin not registered")
 	}
+	completeStep, ok := tool.LookupBuiltin("complete_step")
+	if !ok {
+		t.Fatal("complete_step builtin not registered")
+	}
 	reg := tool.NewRegistry()
 	reg.Add(todoWrite)
+	reg.Add(completeStep)
 
 	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
 		{
 			toolCallChunk("c1", "todo_write", `{"todos":[{"content":"Add parser","status":"in_progress"}]}`),
 			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
+			toolCallChunk("c3", "complete_step", `{
+				"step":"Add parser",
+				"result":"parser added",
+				"evidence":[{"kind":"manual","summary":"checked manually"}]
+			}`),
+			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
@@ -447,9 +475,13 @@ func TestEvidenceFlowRejectsTodoCompletionWithoutCompleteStep(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	got := lastToolResult(a.session, "todo_write")
+	results := toolResults(a.session, "todo_write")
+	if len(results) < 2 {
+		t.Fatalf("todo_write results = %v, want the rejected completion result", results)
+	}
+	got := results[1]
 	if !strings.Contains(got, "complete_step") {
-		t.Fatalf("final todo_write result = %q, want completion rejected until complete_step", got)
+		t.Fatalf("todo_write result = %q, want completion rejected until complete_step", got)
 	}
 }
 
@@ -475,6 +507,12 @@ func TestEvidenceFlowFailedCompleteStepDoesNotAuthorizeTodoCompletion(t *testing
 				"evidence":[{"kind":"manual","summary":"checked manually"}]
 			}`),
 			toolCallChunk("c3", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
+			toolCallChunk("c4", "complete_step", `{
+				"step":"Add parser",
+				"result":"parser added",
+				"evidence":[{"kind":"manual","summary":"checked manually"}]
+			}`),
+			toolCallChunk("c5", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
@@ -485,9 +523,13 @@ func TestEvidenceFlowFailedCompleteStepDoesNotAuthorizeTodoCompletion(t *testing
 		t.Fatalf("Run: %v", err)
 	}
 
-	got := lastToolResult(a.session, "todo_write")
+	results := toolResults(a.session, "todo_write")
+	if len(results) < 2 {
+		t.Fatalf("todo_write results = %v, want the rejected completion result", results)
+	}
+	got := results[1]
 	if !strings.Contains(got, "complete_step") {
-		t.Fatalf("final todo_write result = %q, want failed complete_step not to authorize completion", got)
+		t.Fatalf("todo_write result = %q, want failed complete_step not to authorize completion", got)
 	}
 }
 
@@ -513,6 +555,7 @@ func TestEvidenceFlowRejectsReplacedTodoAfterNumericCompleteStep(t *testing.T) {
 				"evidence":[{"kind":"manual","summary":"checked manually"}]
 			}`),
 			toolCallChunk("c3", "todo_write", `{"todos":[{"content":"Ship parser","status":"completed"}]}`),
+			toolCallChunk("c4", "todo_write", `{"todos":[{"content":"Add parser","status":"completed"}]}`),
 			{Type: provider.ChunkDone},
 		},
 		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
@@ -523,9 +566,13 @@ func TestEvidenceFlowRejectsReplacedTodoAfterNumericCompleteStep(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	got := lastToolResult(a.session, "todo_write")
+	results := toolResults(a.session, "todo_write")
+	if len(results) < 2 {
+		t.Fatalf("todo_write results = %v, want the rejected replacement result", results)
+	}
+	got := results[1]
 	if !strings.Contains(got, "Ship parser") || !strings.Contains(got, "complete_step") {
-		t.Fatalf("final todo_write result = %q, want replaced todo rejected", got)
+		t.Fatalf("todo_write result = %q, want replaced todo rejected", got)
 	}
 }
 
@@ -555,6 +602,19 @@ func TestEvidenceFlowAcceptsReorderedTodoAfterNumericCompleteStep(t *testing.T) 
 			}`),
 			toolCallChunk("c3", "todo_write", `{"todos":[
 				{"content":"Write tests","status":"pending"},
+				{"content":"Add parser","status":"completed"}
+			]}`),
+			toolCallChunk("c4", "todo_write", `{"todos":[
+				{"content":"Write tests","status":"in_progress"},
+				{"content":"Add parser","status":"completed"}
+			]}`),
+			toolCallChunk("c5", "complete_step", `{
+				"step":"Write tests",
+				"result":"tests written",
+				"evidence":[{"kind":"manual","summary":"checked manually"}]
+			}`),
+			toolCallChunk("c6", "todo_write", `{"todos":[
+				{"content":"Write tests","status":"completed"},
 				{"content":"Add parser","status":"completed"}
 			]}`),
 			{Type: provider.ChunkDone},

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -22,6 +22,7 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 	checkAfter := evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."}
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	completeAfter := evidence.Receipt{ToolName: "complete_step", Success: true, Step: "edit"}
+	doneTodo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "completed"}}}
 
 	cases := []struct {
 		name        string
@@ -32,11 +33,14 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 	}{
 		{"nil evidence never gates", []instruction.VerifyCheck{check}, nil, true, ""},
 		{"no writer never gates", []instruction.VerifyCheck{check}, readinessLedger(checkAfter), true, ""},
+		{"incomplete todo without writer is reported", nil, readinessLedger(todo), false, "latest successful todo_write"},
+		{"completed todo without writer satisfies", nil, readinessLedger(doneTodo), true, ""},
 		{"writer without checks or todo never gates", nil, readinessLedger(writer), true, ""},
 		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, "go test ./..."},
 		{"project check run after writer satisfies", []instruction.VerifyCheck{check}, readinessLedger(writer, checkAfter), true, ""},
 		{"todo writer without complete_step is reported", nil, readinessLedger(writer, todo), false, "complete_step"},
-		{"todo writer with complete_step after satisfies", nil, readinessLedger(writer, todo, completeAfter), true, ""},
+		{"complete_step without final todo update is reported", nil, readinessLedger(writer, todo, completeAfter), false, "latest successful todo_write"},
+		{"todo writer with complete_step and completed todo satisfies", nil, readinessLedger(writer, todo, completeAfter, doneTodo), true, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -213,6 +213,24 @@ func TestToolWorkingLineThenClears(t *testing.T) {
 	}
 }
 
+func TestTodoPanelKeepsLastSuccessfulTodoWrite(t *testing.T) {
+	m := newTestChatTUI()
+	initial := `{"todos":[{"content":"Sync main-v2","status":"in_progress"},{"content":"Push origin","status":"pending"}]}`
+	failed := `{"todos":[{"content":"Sync main-v2","status":"completed"},{"content":"Push origin","status":"in_progress"}]}`
+
+	m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "todo-1", Name: "todo_write", Args: initial}})
+	m.ingestEvent(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "todo-1", Name: "todo_write", Args: initial, Output: "Todos updated"}})
+	if m.todoArgs != initial {
+		t.Fatalf("todoArgs after successful result = %q, want initial args", m.todoArgs)
+	}
+
+	m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "todo-2", Name: "todo_write", Args: failed}})
+	m.ingestEvent(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "todo-2", Name: "todo_write", Args: failed, Err: "missing complete_step"}})
+	if m.todoArgs != initial {
+		t.Fatalf("failed todo_write must not replace the panel: got %q, want %q", m.todoArgs, initial)
+	}
+}
+
 // TestToolProgressTailCap proves the live block only keeps the last
 // toolStreamTailLines lines so a chatty build doesn't flood scrollback.
 func TestToolProgressTailCap(t *testing.T) {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2373,9 +2373,8 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		m.finalizeStreamed()
 		switch e.Tool.Name {
 		case "todo_write":
-			// Drive the pinned task list above the input (renderTodoPanel) rather
-			// than printing a tool line; it updates in place as the list evolves.
-			m.todoArgs = e.Tool.Args
+			// The result decides whether this list becomes canonical; dispatch only
+			// means the model asked for an update.
 		case planApprovalTool:
 			// No longer a tool, but guard anyway: the plan is the assistant's reply.
 		default:
@@ -2398,6 +2397,9 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		// call surfaces a red "⏺ Verb ⊘ <reason>" card. A live-output block (bash)
 		// collapses to a one-line "⎿ N lines" summary first.
 		m.collapseToolOutput(e.Tool.ID)
+		if e.Tool.Name == "todo_write" && e.Tool.Err == "" {
+			m.todoArgs = e.Tool.Args
+		}
 		if e.Tool.Err != "" {
 			m.finalizeStreamed()
 			m.commitLine("  " + red("●") + " " + bold(toolDisplayName(e.Tool.Name)) + " " + red("⊘ "+e.Tool.Err))

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -157,6 +157,36 @@ func (l *Ledger) HasSuccessfulTodoWrite() bool {
 	return false
 }
 
+func (l *Ledger) IncompleteLatestTodos() ([]TodoStepMatch, bool) {
+	if l == nil {
+		return nil, false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := len(l.receipts) - 1; i >= 0; i-- {
+		r := l.receipts[i]
+		if !r.Success || r.ToolName != "todo_write" {
+			continue
+		}
+		incomplete := make([]TodoStepMatch, 0)
+		for j, t := range r.Todos {
+			status := todoStatus(t.Status)
+			if status == "completed" {
+				continue
+			}
+			incomplete = append(incomplete, TodoStepMatch{
+				Found:      true,
+				Index:      j + 1,
+				Content:    t.Content,
+				Status:     status,
+				ActiveForm: t.ActiveForm,
+			})
+		}
+		return incomplete, true
+	}
+	return nil, false
+}
+
 func (l *Ledger) HasSuccessfulWrite(paths []string) bool {
 	return l.hasSuccessfulPaths(paths, func(r Receipt) bool { return r.Write })
 }


### PR DESCRIPTION
Fixes #2917

## Summary
- gate final-answer readiness on the latest successful todo_write list, even in pure bash/todo flows with no writer receipt
- keep final answers blocked until the latest successful todo list has no pending or in_progress items
- make CLI and Desktop todo panels advance only from successful todo_write results, so failed attempts do not become canonical UI state

## Validation
- D:\Go\go\bin\go.exe test ./internal/agent -run "TestFinalReadinessFailureBranches"
- D:\Go\go\bin\go.exe test ./internal/cli -run "TestTodoPanelKeepsLastSuccessfulTodoWrite"
- D:\Go\go\bin\go.exe test ./internal/agent
- D:\Go\go\bin\go.exe test ./internal/evidence
- D:\Go\go\bin\go.exe test ./internal/cli
- D:\Go\go\bin\go.exe test ./...
- pnpm --dir desktop/frontend typecheck
- pnpm --dir desktop/frontend build
- git diff --check

No screenshot is attached because the UI layout and styling are unchanged; the change is state acceptance behavior for todo_write results.
