### PR TITLE
fix(openai): clamp effort=max to high for non-DeepSeek backends (MiMo 400)

### DIFF
--- a/internal/provider/openai/effort_test.go
+++ b/internal/provider/openai/effort_test.go
@@ -1,0 +1,55 @@
+package openai
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func newClient(t *testing.T, baseURL, effort string) *client {
+	t.Helper()
+	extra := map[string]any{}
+	if effort != "" {
+		extra["effort"] = effort
+	}
+	p, err := New(provider.Config{Name: "p", BaseURL: baseURL, Model: "m", APIKey: "k", Extra: extra})
+	if err != nil {
+		t.Fatalf("New(%q, effort=%q): %v", baseURL, effort, err)
+	}
+	return p.(*client)
+}
+
+func TestEffortNormalization(t *testing.T) {
+	const mimo = "https://api.xiaomimimo.com/v1"
+	const deepseek = "https://api.deepseek.com/v1"
+
+	tests := []struct {
+		base, effort, want string
+	}{
+		{mimo, "max", "high"}, // DeepSeek-ism clamped to the OpenAI ceiling — MiMo 400s on "max"
+		{mimo, "high", "high"},
+		{mimo, "medium", "medium"},
+		{mimo, "low", "low"},
+		{mimo, "MAX", "high"}, // case-insensitive
+		{mimo, "", ""},        // unset stays omitted
+		{deepseek, "max", "max"},
+		{deepseek, "high", "high"},
+		{deepseek, "", "high"}, // DeepSeek default depth
+	}
+	for _, tc := range tests {
+		if got := newClient(t, tc.base, tc.effort).effort; got != tc.want {
+			t.Errorf("base=%s effort=%q: got %q, want %q", tc.base, tc.effort, got, tc.want)
+		}
+	}
+}
+
+func TestEffortInvalidRejected(t *testing.T) {
+	_, err := New(provider.Config{
+		Name: "p", BaseURL: "https://api.xiaomimimo.com/v1", Model: "m", APIKey: "k",
+		Extra: map[string]any{"effort": "turbo"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "low, medium, or high") {
+		t.Fatalf("expected a low/medium/high validation error, got: %v", err)
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -47,6 +47,18 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		default:
 			return nil, fmt.Errorf("openai: provider %q uses DeepSeek thinking; effort must be high or max", name)
 		}
+	} else if effort != "" {
+		// Non-DeepSeek backends use OpenAI's reasoning_effort scale (low/medium/
+		// high); "max" is a DeepSeek-ism MiMo et al. reject with 400, so clamp it
+		// to the OpenAI ceiling and reject other values at boot, not at request time.
+		effort = strings.ToLower(strings.TrimSpace(effort))
+		switch effort {
+		case "max":
+			effort = "high"
+		case "low", "medium", "high":
+		default:
+			return nil, fmt.Errorf("openai: provider %q: effort must be low, medium, or high", name)
+		}
 	}
 	httpClient, err := newHTTPClient(cfg)
 	if err != nil {


### PR DESCRIPTION
## What MiMo users hit

A MiMo provider with `effort = "max"` returns **400 on every request**:

```
"Input should be 'low', 'medium' or 'high'", input: 'max'  (loc: body.reasoning_effort)
```

## Root cause

`effort` was only validated/normalized on the **DeepSeek** path. DeepSeek's reasoning scale is `high|max`; the OpenAI scale that MiMo (and other openai-compatible endpoints) follow is `low|medium|high`. A non-DeepSeek provider forwarded `effort` verbatim as `reasoning_effort`, so the DeepSeek-ism `"max"` reached MiMo and was rejected — and the example config's DeepSeek block literally shows `effort = "max"`, so it's an easy mistake to copy onto a MiMo provider.

## Fix

Normalize `effort` for non-DeepSeek providers too: map `"max"` → the OpenAI ceiling `"high"`, accept `low/medium/high`, and reject anything else **at boot** with a clear message instead of a per-request 400.

## How it was found

End-to-end probed the real MiMo endpoint (`api.xiaomimimo.com`, both `mimo-v2.5-pro` and `mimo-v2-flash`) by bisecting the request shape one field at a time. Everything Reasonix sends by default — full real built-in tool set, parallel tool calls, `content:""` on tool-call turns, `stream_options`, replayed `reasoning_content` — returns **200**. The only 400s were `reasoning_effort:"max"` (this fix) and `max_tokens` above the model's 131072 completion cap (not sent on the normal agent path).

Verified: with the fix, a client configured `effort="max"` sends `reasoning_effort="high"` and the request succeeds 200 against real MiMo.

`go build ./...`, `go vet ./internal/provider/...`, `go test ./internal/provider/...` — pass.
