### PR TITLE
fix(sessions): back-fill v0.x sessions even after v1 has been used

### DIFF
--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -33,12 +33,21 @@ type legacyToolCall struct {
 	} `json:"function"`
 }
 
+// legacyImportMarker, once present in the v1+ session dir, records that the
+// one-time v0.x import has already run — so a session the user deletes after it
+// was imported doesn't reappear on the next launch.
+const legacyImportMarker = ".legacy-imported"
+
 // MigrateLegacySessions imports v0.x event-log sessions (<name>.events.jsonl under
-// srcDir) into the v1+ message-log format (<name>.jsonl under destDir). It is a
-// no-op when destDir already holds sessions (so it never imports twice) or srcDir
-// has none, and never modifies the legacy files. Returns the count imported.
+// srcDir) into the v1+ message-log format (<name>.jsonl under destDir), back-filling
+// any whose .jsonl isn't already present. It runs once — guarded by a marker file in
+// destDir — so it still imports when destDir already holds v1+ sessions (the old
+// all-or-nothing skip hid a v0.x user's history the moment they opened v1, #2869)
+// without re-importing on every launch. Never modifies the legacy files. Returns the
+// count imported.
 func MigrateLegacySessions(srcDir, destDir string) (int, error) {
-	if hasSessions(destDir) {
+	marker := filepath.Join(destDir, legacyImportMarker)
+	if _, err := os.Stat(marker); err == nil {
 		return 0, nil
 	}
 	entries, err := os.ReadDir(srcDir)
@@ -51,11 +60,14 @@ func MigrateLegacySessions(srcDir, destDir string) (int, error) {
 		if e.IsDir() || !strings.HasSuffix(name, ".events.jsonl") {
 			continue
 		}
+		dest := filepath.Join(destDir, strings.TrimSuffix(name, ".events.jsonl")+".jsonl")
+		if _, err := os.Stat(dest); err == nil {
+			continue // already imported, or a v1+ session of the same name
+		}
 		msgs, err := reconstructSession(filepath.Join(srcDir, name))
 		if err != nil || len(msgs) == 0 {
 			continue
 		}
-		dest := filepath.Join(destDir, strings.TrimSuffix(name, ".events.jsonl")+".jsonl")
 		s := &Session{Messages: msgs}
 		if err := s.Save(dest); err != nil {
 			return imported, err
@@ -65,20 +77,10 @@ func MigrateLegacySessions(srcDir, destDir string) (int, error) {
 		}
 		imported++
 	}
+	if err := os.MkdirAll(destDir, 0o755); err == nil {
+		os.WriteFile(marker, nil, 0o644)
+	}
 	return imported, nil
-}
-
-func hasSessions(dir string) bool {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && filepath.Ext(e.Name()) == ".jsonl" {
-			return true
-		}
-	}
-	return false
 }
 
 // reconstructSession folds the chronological event stream into the provider

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -55,7 +55,7 @@ func TestMigrateLegacySessionsReconstructsConversation(t *testing.T) {
 	}
 }
 
-func TestMigrateLegacySessionsSkipsWhenDestHasSessions(t *testing.T) {
+func TestMigrateLegacySessionsBackfillsAlongsideExisting(t *testing.T) {
 	src := t.TempDir()
 	dest := t.TempDir()
 	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
@@ -65,11 +65,56 @@ func TestMigrateLegacySessionsSkipsWhenDestHasSessions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	if n != 0 {
-		t.Errorf("must not import over an existing v1+ session dir, imported %d", n)
+	if n != 1 {
+		t.Errorf("should back-fill the legacy session even when dest has others, imported %d", n)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); err != nil {
+		t.Errorf("legacy session should have been imported: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "existing.jsonl")); err != nil {
+		t.Errorf("pre-existing v1+ session must be left intact: %v", err)
+	}
+}
+
+func TestMigrateLegacySessionsRunsOnce(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
+
+	if n, err := MigrateLegacySessions(src, dest); err != nil || n != 1 {
+		t.Fatalf("first run: n=%d err=%v, want 1", n, err)
+	}
+	// User deletes the imported session, then a second launch happens.
+	if err := os.Remove(filepath.Join(dest, "chat-1.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := MigrateLegacySessions(src, dest); err != nil || n != 0 {
+		t.Fatalf("second run must be a no-op (marker present): n=%d err=%v", n, err)
 	}
 	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); !os.IsNotExist(err) {
-		t.Errorf("legacy session should not have been written when dest already has sessions")
+		t.Errorf("a deleted import must not reappear after the one-time migration")
+	}
+}
+
+func TestMigrateLegacySessionsSkipsAlreadyImported(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
+	os.WriteFile(filepath.Join(dest, "chat-1.jsonl"), []byte(`{"role":"user","content":"edited"}`+"\n"), 0o644)
+
+	n, err := MigrateLegacySessions(src, dest)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("a same-named existing session must not be overwritten, imported %d", n)
+	}
+	loaded, err := LoadSession(filepath.Join(dest, "chat-1.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Messages) != 1 || loaded.Messages[0].Content != "edited" {
+		t.Errorf("existing same-named session was clobbered: %+v", loaded.Messages)
 	}
 }
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -104,10 +104,15 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "config migration from ~/.reasonix failed: " + migErr.Error()})
 	} else if migrated != nil {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: migrated.Notice()})
-		if home, herr := os.UserHomeDir(); herr == nil {
-			if n, serr := agent.MigrateLegacySessions(filepath.Join(home, ".reasonix", "sessions"), config.SessionDir()); serr == nil && n > 0 {
-				sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("imported %d past session(s) from ~/.reasonix/sessions — resume them with --resume or the history panel", n)})
-			}
+	}
+	// Back-fill v0.x sessions, independent of the config migration. This used to be
+	// nested under the (one-time) config migration above, so a v0.x user who had
+	// already opened v1 never got their old sessions imported (#2869). It is guarded
+	// by its own marker, so running every boot imports any not-yet-imported session
+	// once and is a cheap no-op afterwards.
+	if home, herr := os.UserHomeDir(); herr == nil {
+		if n, serr := agent.MigrateLegacySessions(filepath.Join(home, ".reasonix", "sessions"), config.SessionDir()); serr == nil && n > 0 {
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("imported %d past session(s) from ~/.reasonix/sessions — resume them with --resume or the history panel", n)})
 		}
 	}
 


### PR DESCRIPTION
Answers "what about users who already used v1 and still want their 0.53 sessions?" from #2869.

## Problem

The v0.x → v1 session import had two issues that together hid old history:

1. It skipped entirely once the v1 session dir held *any* session (`hasSessions(destDir)` → all-or-nothing), so a user who opened v1 first never got their 0.53 sessions.
2. It was only called nested under the one-time **config** migration, so on every later boot it didn't run at all — there was no way to trigger it.

## Fix

- **Back-fill**: import any v0.x `*.events.jsonl` whose `.jsonl` isn't already present, instead of bailing when the dir is non-empty. A same-named existing session is left untouched.
- **One-time marker** (`.legacy-imported` in the session dir) so the import runs once and a session the user later deletes doesn't reappear next launch.
- **Runs on every boot, independent of the config migration**, so existing v1 installs back-fill on their next launch (cheap no-op once the marker is set).

The legacy files under `~/.reasonix/sessions` are never modified; imported sessions are resumable via `--resume` or the history panel.

## Tests

`internal/agent/migrate_test.go`: back-fill alongside existing sessions, one-time semantics (deleted import doesn't reappear), and same-named sessions not clobbered. `go build ./...`, `go vet`, `go test ./internal/agent/ ./internal/boot/` — pass.

Refs #2869
