### PR TITLE
feat(serve): runtime effort switching via /effort <level>

### DIFF
--- a/internal/serve/effort_test.go
+++ b/internal/serve/effort_test.go
@@ -1,0 +1,54 @@
+package serve
+
+import (
+	"testing"
+
+	"reasonix/internal/config"
+)
+
+func TestApplyEffortEditUpsertsMissingProvider(t *testing.T) {
+	edit := &config.Config{}
+	entry := &config.ProviderEntry{Name: "deepseek", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4"}
+
+	if err := applyEffortEdit(edit, entry, "high"); err != nil {
+		t.Fatalf("applyEffortEdit: %v", err)
+	}
+	got, ok := edit.Provider("deepseek")
+	if !ok {
+		t.Fatal("provider absent from user config should be upserted so the effort edit lands")
+	}
+	if got.Effort != "high" {
+		t.Fatalf("effort = %q, want high", got.Effort)
+	}
+}
+
+func TestApplyEffortEditEnablesAnthropicThinking(t *testing.T) {
+	edit := &config.Config{}
+	entry := &config.ProviderEntry{Name: "anthropic", Kind: "anthropic", BaseURL: "https://api.anthropic.com", Model: "claude-opus-4-8"}
+
+	if err := applyEffortEdit(edit, entry, "max"); err != nil {
+		t.Fatalf("applyEffortEdit: %v", err)
+	}
+	got, _ := edit.Provider("anthropic")
+	if got.Thinking != "adaptive" {
+		t.Fatalf("thinking = %q, want adaptive (effort needs extended thinking to engage)", got.Thinking)
+	}
+	if got.Effort != "max" {
+		t.Fatalf("effort = %q, want max", got.Effort)
+	}
+}
+
+func TestApplyEffortEditKeepsExistingAnthropicThinking(t *testing.T) {
+	edit := &config.Config{Providers: []config.ProviderEntry{
+		{Name: "anthropic", Kind: "anthropic", Model: "claude-opus-4-8", Thinking: "always"},
+	}}
+	entry := &config.ProviderEntry{Name: "anthropic", Kind: "anthropic", Model: "claude-opus-4-8", Thinking: "always"}
+
+	if err := applyEffortEdit(edit, entry, "low"); err != nil {
+		t.Fatalf("applyEffortEdit: %v", err)
+	}
+	got, _ := edit.Provider("anthropic")
+	if got.Thinking != "always" {
+		t.Fatalf("thinking = %q, want it left untouched", got.Thinking)
+	}
+}

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -368,6 +368,7 @@ const SLASH_CMDS = [
   {cmd:'branch',desc:'Create branch'},
   {cmd:'switch',desc:'Switch branch'},
   {cmd:'model',desc:'List/switch models'},
+  {cmd:'effort',desc:'Reasoning effort level'},
   {cmd:'mcp',desc:'MCP servers'},
   {cmd:'skill',desc:'Skills'},
   {cmd:'hooks',desc:'Hooks'},

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -84,6 +84,45 @@ func (s *Server) initTitleProvider() {
 // conversation history. This replicates the TUI/desktop model-switch path. The
 // write lock is held across the whole rebuild so concurrent requests never read
 // a half-swapped controller and two switches can't run at once.
+// switchEffort changes the reasoning effort level and rebuilds the controller.
+// Config is persisted to disk first, then switchModel handles the rebuild.
+func (s *Server) switchEffort(ctx context.Context, level string) error {
+	cur := s.ctl()
+	if cur.Running() {
+		return fmt.Errorf("cannot change effort while a turn is running")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	ref := cur.Label()
+	entry, ok := cfg.ResolveModel(ref)
+	if !ok {
+		return fmt.Errorf("cannot resolve current provider %q", ref)
+	}
+	cap := config.EffortCapabilityForEntry(entry)
+	if !cap.Supported {
+		return fmt.Errorf("effort is not configurable for %s", entry.Name)
+	}
+	effort, err := config.NormalizeEffort(entry, level)
+	if err != nil {
+		return err
+	}
+	editPath := config.UserConfigPath()
+	if editPath == "" {
+		return fmt.Errorf("no config file found")
+	}
+	edit := config.LoadForEdit(editPath)
+	if err := edit.SetProviderEffort(entry.Name, effort); err != nil {
+		return err
+	}
+	if err := edit.SaveTo(editPath); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	// Rebuild controller with updated effort — switchModel handles the lock.
+	return s.switchModel(ctx, entry.Name+"/"+entry.Model)
+}
+
 func (s *Server) switchModel(ctx context.Context, ref string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -267,12 +306,25 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing input", http.StatusBadRequest)
 		return
 	}
+	trimmed := strings.TrimSpace(body.Input)
 	// Intercept /model <ref> for runtime model switching (the controller's
 	// Submit path only lists models — switching is frontend-specific).
-	if trimmed := strings.TrimSpace(body.Input); strings.HasPrefix(trimmed, "/model ") {
+	if strings.HasPrefix(trimmed, "/model ") {
 		ref := strings.TrimSpace(strings.TrimPrefix(trimmed, "/model"))
 		if ref != "" {
 			if err := s.switchModel(r.Context(), ref); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+	}
+	// Intercept /effort <level> for reasoning effort switching.
+	if strings.HasPrefix(trimmed, "/effort ") {
+		level := strings.TrimSpace(strings.TrimPrefix(trimmed, "/effort"))
+		if level != "" {
+			if err := s.switchEffort(r.Context(), level); err != nil {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -84,45 +84,6 @@ func (s *Server) initTitleProvider() {
 // conversation history. This replicates the TUI/desktop model-switch path. The
 // write lock is held across the whole rebuild so concurrent requests never read
 // a half-swapped controller and two switches can't run at once.
-// switchEffort changes the reasoning effort level and rebuilds the controller.
-// Config is persisted to disk first, then switchModel handles the rebuild.
-func (s *Server) switchEffort(ctx context.Context, level string) error {
-	cur := s.ctl()
-	if cur.Running() {
-		return fmt.Errorf("cannot change effort while a turn is running")
-	}
-	cfg, err := config.Load()
-	if err != nil {
-		return fmt.Errorf("load config: %w", err)
-	}
-	ref := cur.Label()
-	entry, ok := cfg.ResolveModel(ref)
-	if !ok {
-		return fmt.Errorf("cannot resolve current provider %q", ref)
-	}
-	cap := config.EffortCapabilityForEntry(entry)
-	if !cap.Supported {
-		return fmt.Errorf("effort is not configurable for %s", entry.Name)
-	}
-	effort, err := config.NormalizeEffort(entry, level)
-	if err != nil {
-		return err
-	}
-	editPath := config.UserConfigPath()
-	if editPath == "" {
-		return fmt.Errorf("no config file found")
-	}
-	edit := config.LoadForEdit(editPath)
-	if err := edit.SetProviderEffort(entry.Name, effort); err != nil {
-		return err
-	}
-	if err := edit.SaveTo(editPath); err != nil {
-		return fmt.Errorf("save config: %w", err)
-	}
-	// Rebuild controller with updated effort — switchModel handles the lock.
-	return s.switchModel(ctx, entry.Name+"/"+entry.Model)
-}
-
 func (s *Server) switchModel(ctx context.Context, ref string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -156,6 +117,60 @@ func (s *Server) switchModel(ctx context.Context, ref string) error {
 	s.ctrl = newCtrl
 	cur.Close()
 	return nil
+}
+
+// switchEffort persists a new reasoning-effort level for the active provider and
+// rebuilds via switchModel (which takes the write lock).
+func (s *Server) switchEffort(ctx context.Context, level string) error {
+	cur := s.ctl()
+	if cur.Running() {
+		return fmt.Errorf("cannot change effort while a turn is running")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+	ref := cur.Label()
+	entry, ok := cfg.ResolveModel(ref)
+	if !ok {
+		return fmt.Errorf("cannot resolve current provider %q", ref)
+	}
+	if !config.EffortCapabilityForEntry(entry).Supported {
+		return fmt.Errorf("effort is not configurable for %s", entry.Name)
+	}
+	effort, err := config.NormalizeEffort(entry, level)
+	if err != nil {
+		return err
+	}
+	editPath := config.UserConfigPath()
+	if editPath == "" {
+		return fmt.Errorf("no config file found")
+	}
+	edit := config.LoadForEdit(editPath)
+	if err := applyEffortEdit(edit, entry, effort); err != nil {
+		return err
+	}
+	if err := edit.SaveTo(editPath); err != nil {
+		return fmt.Errorf("save config: %w", err)
+	}
+	return s.switchModel(ctx, entry.Name+"/"+entry.Model)
+}
+
+// applyEffortEdit writes effort onto entry within edit, mirroring CLI/desktop
+// SetEffort: upsert the provider when the user config has no block for it yet, and
+// enable adaptive thinking for Anthropic so the effort knob actually engages.
+func applyEffortEdit(edit *config.Config, entry *config.ProviderEntry, effort string) error {
+	if _, ok := edit.Provider(entry.Name); !ok {
+		if err := edit.UpsertProvider(*entry); err != nil {
+			return err
+		}
+	}
+	if entry.Kind == "anthropic" && effort != "" && entry.Thinking == "" {
+		if err := edit.SetProviderThinking(entry.Name, "adaptive"); err != nil {
+			return err
+		}
+	}
+	return edit.SetProviderEffort(entry.Name, effort)
 }
 
 // Handler returns the HTTP routes: GET / (a minimal browser client), GET /events


### PR DESCRIPTION
Picks up @lanshi17's `/effort <level>` for the HTTP SSE frontend (#2770) and lands it with the correctness gaps fixed.

## What #2770 added
`/effort <level>` in the serve submit handler + slash menu, persisting the effort knob and rebuilding the controller via `switchModel` — scoped entirely to `internal/serve/`.

## Fixes on top
The original `switchEffort` diverged from the canonical CLI (`internal/cli/effort.go`) and desktop (`App.SetEffort`) paths in two ways:

- **Missing provider upsert.** It wrote effort straight to the user config via `SetProviderEffort`, which errors with `no provider` whenever the active provider has no `[[providers]]` block there yet — the common default-DeepSeek case. `/effort` would just 500.
- **Missing Anthropic `thinking=adaptive`.** Without it the effort levels the PR advertises for Anthropic never engage.

Both are now handled by `applyEffortEdit` (upsert-if-absent + Anthropic adaptive thinking), the same sequence CLI/desktop already use. Also moved `switchEffort` below `switchModel` so `switchModel` keeps its own doc comment (the insertion had orphaned it), and added unit coverage for the upsert and Anthropic-thinking branches.

Credit to @lanshi17 for the feature and the clean serve-only scoping.

Closes #2770