### PR TITLE
ci: enforce golangci-lint, add govulncheck + coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,56 @@ jobs:
 
       - name: test
         run: go test ./...
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12.2
+          args: --timeout=5m
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    continue-on-error: true # informational — stdlib vulns need a Go patch release
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: govulncheck
+        run: govulncheck ./...
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: test with coverage
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.out
+          retention-days: 7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,37 @@ version: "2"
 linters:
   enable:
     - errcheck
-    - staticcheck
-    - unused
     - govet
     - ineffassign
+    - staticcheck
+    - unused
+  settings:
+    errcheck:
+      check-type-assertions: false
+      exclude-functions:
+        - (*os.File).Close
+        - (io.Closer).Close
+        - (*net/http.Response).Body.Close
+        - golang.org/x/term.Restore
+    staticcheck:
+      checks:
+        - all
+        - -ST1005 # error strings ending with punctuation — too strict for initial adoption
+        - -ST1018 # Unicode format characters — intentional in TUI code
+        - -QF1001 # De Morgan's law — readability preference
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Setup/teardown in tests routinely ignores cleanup errors.
+      - path: _test\.go
+        linters:
+          - errcheck
 
 issues:
-  # Only report issues introduced by the PR, not pre-existing code.
-  new-from-rev: main-v2
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -401,6 +401,8 @@ func changedLineSet(repo, base string, srcFiles []string) map[string]map[int]boo
 	file := ""
 	newLine := 0
 	for _, ln := range strings.Split(diff, "\n") {
+		// '-' (deletion) lines are intentionally unhandled: they don't advance the
+		// new-side line counter, so they fall through with no case.
 		switch {
 		case strings.HasPrefix(ln, "+++ b/"):
 			file = strings.TrimPrefix(ln, "+++ b/")
@@ -412,15 +414,13 @@ func changedLineSet(repo, base string, srcFiles []string) map[string]map[int]boo
 				if sp := strings.IndexAny(num, ", "); sp >= 0 {
 					num = num[:sp]
 				}
-				fmt.Sscanf(num, "%d", &newLine)
+				_, _ = fmt.Sscanf(num, "%d", &newLine)
 			}
 		case strings.HasPrefix(ln, "+") && !strings.HasPrefix(ln, "+++"):
 			if file != "" {
 				out[file][newLine] = true
 			}
 			newLine++
-		case strings.HasPrefix(ln, "-"):
-			// deletion: does not advance the new-side counter
 		}
 	}
 	return out

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -73,12 +73,12 @@ func MigrateLegacySessions(srcDir, destDir string) (int, error) {
 			return imported, err
 		}
 		if info, err := e.Info(); err == nil {
-			os.Chtimes(dest, info.ModTime(), info.ModTime()) // preserve resume ordering
+			_ = os.Chtimes(dest, info.ModTime(), info.ModTime()) // preserve resume ordering
 		}
 		imported++
 	}
 	if err := os.MkdirAll(destDir, 0o755); err == nil {
-		os.WriteFile(marker, nil, 0o644)
+		_ = os.WriteFile(marker, nil, 0o644)
 	}
 	return imported, nil
 }

--- a/internal/cli/latex.go
+++ b/internal/cli/latex.go
@@ -18,23 +18,23 @@ func convertMath(rs []rune) string {
 	var b strings.Builder
 	b.Grow(len(rs))
 	for i := 0; i < len(rs); {
-		switch r := rs[i]; {
-		case r == '\\':
+		switch r := rs[i]; r {
+		case '\\':
 			i = convertCommand(&b, rs, i)
-		case r == '^':
+		case '^':
 			arg, ni := readAtom(rs, i+1, false)
 			b.WriteString(superscript(convertMath([]rune(arg))))
 			i = ni
-		case r == '_':
+		case '_':
 			arg, ni := readAtom(rs, i+1, false)
 			b.WriteString(subscript(convertMath([]rune(arg))))
 			i = ni
-		case r == '{' || r == '}':
+		case '{', '}':
 			i++
-		case r == '&' || r == '~':
+		case '&', '~':
 			b.WriteByte(' ')
 			i++
-		case r == '$':
+		case '$':
 			i++
 		default:
 			b.WriteRune(r)

--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -387,14 +387,6 @@ type mcpEditConfigLaunch struct {
 	systemDefault bool
 }
 
-func mcpEditConfigCommand(path string) (*exec.Cmd, error) {
-	launch, err := mcpEditConfigLaunchCommand(path, exec.LookPath)
-	if err != nil {
-		return nil, err
-	}
-	return launch.cmd, nil
-}
-
 func mcpEditConfigLaunchCommand(path string, lookPath func(string) (string, error)) (mcpEditConfigLaunch, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {

--- a/internal/cli/theme_osc_unix.go
+++ b/internal/cli/theme_osc_unix.go
@@ -39,7 +39,7 @@ func queryTerminalBackground() (terminalRGB, bool) {
 	if err := unix.SetNonblock(inFd, true); err != nil {
 		return terminalRGB{}, false
 	}
-	defer unix.FcntlInt(uintptr(inFd), unix.F_SETFL, flags)
+	defer func() { _, _ = unix.FcntlInt(uintptr(inFd), unix.F_SETFL, flags) }()
 
 	if _, err := os.Stdout.Write([]byte("\x1b]11;?\x07")); err != nil {
 		return terminalRGB{}, false

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -120,7 +120,7 @@ func resolveBareNames(refs []ref) []ref {
 	}
 	found := 0
 	cwd, _ := os.Getwd()
-	filepath.WalkDir(cwd, func(p string, d os.DirEntry, wErr error) error {
+	_ = filepath.WalkDir(cwd, func(p string, d os.DirEntry, wErr error) error {
 		if wErr != nil || found == len(names) {
 			return filepath.SkipAll
 		}

--- a/internal/plugin/cache.go
+++ b/internal/plugin/cache.go
@@ -197,10 +197,10 @@ func slug(name string) string {
 // the boundary between (key, value) and the next field can't collide via
 // concatenation (e.g. "command" + "foo" vs "comm" + "andfoo").
 func writeField(h io.Writer, key, val string) {
-	h.Write([]byte(key))
-	h.Write([]byte{0})
-	h.Write([]byte(val))
-	h.Write([]byte{1})
+	_, _ = h.Write([]byte(key))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(val))
+	_, _ = h.Write([]byte{1})
 }
 
 // writeKV hashes a map deterministically by sorting keys, so Go's randomised

--- a/internal/proc/kill_windows.go
+++ b/internal/proc/kill_windows.go
@@ -54,7 +54,7 @@ func TrackTree(cmd *exec.Cmd) uintptr {
 		_ = windows.CloseHandle(job)
 		return 0
 	}
-	defer windows.CloseHandle(h)
+	defer func() { _ = windows.CloseHandle(h) }()
 	if err := windows.AssignProcessToJobObject(job, h); err != nil {
 		_ = windows.CloseHandle(job)
 		return 0

--- a/internal/serve/titlecache.go
+++ b/internal/serve/titlecache.go
@@ -33,7 +33,7 @@ func (c *titleCache) load() {
 	}
 	c.loaded = true
 	if data, err := os.ReadFile(filepath.Join(c.dir, ".session-titles.json")); err == nil {
-		json.Unmarshal(data, &c.entries)
+		_ = json.Unmarshal(data, &c.entries)
 	}
 }
 
@@ -53,6 +53,6 @@ func (c *titleCache) put(name, title string, mod int64) {
 	c.load()
 	c.entries[name] = titleEntry{Title: title, Mod: mod}
 	if data, err := json.Marshal(c.entries); err == nil {
-		os.WriteFile(filepath.Join(c.dir, ".session-titles.json"), data, 0o644)
+		_ = os.WriteFile(filepath.Join(c.dir, ".session-titles.json"), data, 0o644)
 	}
 }

--- a/internal/sysproxy/system_windows.go
+++ b/internal/sysproxy/system_windows.go
@@ -92,7 +92,7 @@ func pacProxy(target *url.URL, autoConfigURL *uint16, scheme string) *url.URL {
 	if session == 0 {
 		return nil
 	}
-	defer procCloseHandle.Call(session)
+	defer func() { _, _, _ = procCloseHandle.Call(session) }()
 
 	opts := autoproxyOptions{fAutoLogonIfChallenged: 1}
 	if autoConfigURL != nil {

--- a/internal/tool/builtin/delete_symbol.go
+++ b/internal/tool/builtin/delete_symbol.go
@@ -188,11 +188,11 @@ func (d deleteSymbol) findSymbol(path, name, kind, parent string) (symbolMatch, 
 
 	if len(filtered) > 1 {
 		var b strings.Builder
-		b.WriteString(fmt.Sprintf("Multiple matches for %q — disambiguate with kind/parent:\n", name))
+		fmt.Fprintf(&b, "Multiple matches for %q — disambiguate with kind/parent:\n", name)
 		for _, m := range filtered {
-			b.WriteString(fmt.Sprintf("  line %d: %s %s", m.line, m.kind, m.name))
+			fmt.Fprintf(&b, "  line %d: %s %s", m.line, m.kind, m.name)
 			if m.parent != "" {
-				b.WriteString(fmt.Sprintf(" (on %s)", m.parent))
+				fmt.Fprintf(&b, " (on %s)", m.parent)
 			}
 			b.WriteString("\n")
 		}

--- a/internal/tool/builtin/grep.go
+++ b/internal/tool/builtin/grep.go
@@ -119,7 +119,7 @@ func (g grepTool) Execute(ctx context.Context, args json.RawMessage) (string, er
 			if dec != nil {
 				pr, pw := io.Pipe()
 				go func() {
-					pw.Write(peek)
+					_, _ = pw.Write(peek)
 					io.Copy(pw, f) //nolint:errcheck
 					pw.Close()
 				}()


### PR DESCRIPTION
Rebase of #2424 by @HUQIANTAO onto current `main-v2`, made actually mergeable.

## Why the original couldn't merge

1. **Regressed the workflow.** The PR rewrote `ci.yml` from an older revision — it would have dropped the `windows-latest` test leg, the `race` job, and the `REASONIX_RELEASE_CACHE_GUARD` that `main-v2` has since added. This version *appends* the three new jobs instead.
2. **Broken config version.** It paired `golangci-lint-action@v7` (→ golangci-lint **v2**) with a **v1-format** `.golangci.yml`. v2 rejects it outright: `can't load config: unsupported version of the configuration ""`. Verified locally. Migrated to v2 and pinned the linter to `v2.12.2` for reproducibility.
3. **Red gate.** Even with a valid config, a full-tree run had **21 pre-existing findings**, so the lint job would have failed on every PR.

## What this does

- **lint** (enforced), **govulncheck** (`continue-on-error` — stdlib advisories need a Go release), **coverage** (artifact upload) — appended to the existing `test` / `race` / `desktop` jobs.
- Replaces `main-v2`'s unused `.golangci.yml` (it had `new-from-rev` and was never wired to CI) with a full-gate v2 config, and **fixes all 21 findings** so the gate is green tree-wide rather than diff-only:
  - **errcheck** — acknowledge ignored returns on best-effort writes/cleanup (hash writes, title-cache load/save, deferred `Restore`/`CloseHandle`/`Fcntl`, the session-import marker write, `WalkDir`).
  - **staticcheck SA4017** (real smell) — drop the empty, pure-condition `-` case in the diff parser (it was already a no-op; the explanatory comment moves above the switch).
  - **staticcheck QF1002 / QF1012** — tagged switch in `latex.go`; `fmt.Fprintf` over `WriteString(fmt.Sprintf(...))` in `delete_symbol.go`.
  - **unused** — remove the orphaned `mcpEditConfigCommand` wrapper (its only reference was itself; the real `mcpEditConfigLaunchCommand` stays).

## Verification

- `golangci-lint v2.12.2 run ./...` — **exit 0** on both the default and `GOOS=linux` (CI target) runs.
- `go build ./...`, `go vet ./...`, `go test` on every touched package — pass.

Closes #2424
