### PR TITLE
fix(agent): allow plan-mode todos in final readiness

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -436,8 +436,10 @@ func (a *Agent) finalReadinessFailure() string {
 		return ""
 	}
 	var missing []string
-	if incomplete, hasTodos := a.evidence.IncompleteLatestTodos(); hasTodos && len(incomplete) > 0 {
-		missing = append(missing, finalReadinessIncompleteTodos(incomplete))
+	if !a.planMode.Load() {
+		if incomplete, hasTodos := a.evidence.IncompleteLatestTodos(); hasTodos && len(incomplete) > 0 {
+			missing = append(missing, finalReadinessIncompleteTodos(incomplete))
+		}
 	}
 	writer, hasWriter := a.evidence.LatestSuccessfulWriterIndex()
 	if !hasWriter {

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -61,3 +61,13 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 		})
 	}
 }
+
+func TestFinalReadinessAllowsIncompleteTodosInPlanMode(t *testing.T) {
+	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "draft implementation plan", Status: "pending"}}}
+	a := &Agent{evidence: readinessLedger(todo)}
+	a.SetPlanMode(true)
+
+	if got := a.finalReadinessFailure(); got != "" {
+		t.Fatalf("finalReadinessFailure() = %q, want empty in plan mode", got)
+	}
+}


### PR DESCRIPTION
  这是 #2917 / #2920 的后续补充修复。

  #2920 已经修复了执行流程里的核心问题：当 latest successful `todo_write` 里仍有 `pending` / `in_progress` 任务时，agent 不应该直接给出“已完成”的最终回答。

  这次 PR 补充的是 plan mode 的边界：plan mode 下 `todo_write` 是 read-only，它更像是在表达“待用户批准后要执行的计划”，而不是“已经完成的执行进度”。因此，plan
  mode 下存在 `pending` todo 是合理状态，不应该被 execution final-readiness gate 阻止。

  本次修改：
  - 在 plan mode 下跳过 incomplete todo 的 final-readiness block。
  - 增加回归测试，证明 plan mode 里 pending todo 不会阻止最终计划输出。
  - 保持 normal / yolo 执行模式下的原有 gate 行为不变。

  为什么需要这样做：
  - 执行模式里，`pending` / `in_progress` todo 表示工作未完成，应该阻止最终完成报告。
  - plan mode 里，`pending` todo 表示计划中的待执行事项，正是等待用户批准后执行的内容。
  - 如果 plan mode 也被这个 gate 阻止，模型可能为了通过 readiness 检查而把未执行的计划项标记成 `completed`，反而制造错误的完成状态。

  Tests:
  - `go test ./internal/agent`
  - `git diff --check`