### PR TITLE
fix(desktop): prevent workspace git console flashes on Windows

### DIFF
--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -103,14 +103,14 @@ func (a *App) WorkspaceChanges() WorkspaceChangesView {
 
 func workspaceGitStatus(base string) ([]gitStatusEntry, error) {
 	cmd := exec.Command("git", "-C", base, "status", "--porcelain=v1", "-z", "--untracked-files=all")
-	proc.HideWindow(cmd)
+	proc.HideWindowDetached(cmd)
 	raw, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
 	entries := parseGitStatusPorcelainZ(raw)
 	topCmd := exec.Command("git", "-C", base, "rev-parse", "--show-toplevel")
-	proc.HideWindow(topCmd)
+	proc.HideWindowDetached(topCmd)
 	topRaw, err := topCmd.Output()
 	if err != nil {
 		return nil, err

--- a/internal/proc/hide_other.go
+++ b/internal/proc/hide_other.go
@@ -6,3 +6,6 @@ import "os/exec"
 
 // HideWindow is a no-op off Windows.
 func HideWindow(*exec.Cmd) {}
+
+// HideWindowDetached is a no-op off Windows.
+func HideWindowDetached(*exec.Cmd) {}

--- a/internal/proc/hide_windows.go
+++ b/internal/proc/hide_windows.go
@@ -7,7 +7,10 @@ import (
 	"syscall"
 )
 
-const createNoWindow = 0x08000000 // CREATE_NO_WINDOW
+const (
+	createNoWindow  = 0x08000000 // CREATE_NO_WINDOW
+	detachedProcess = 0x00000008 // DETACHED_PROCESS
+)
 
 // HideWindow stops a child process from flashing a console window on Windows,
 // where a GUI parent (the desktop app) has no console of its own to inherit.
@@ -19,4 +22,15 @@ func HideWindow(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.HideWindow = true
 	cmd.SysProcAttr.CreationFlags |= createNoWindow
+}
+
+// HideWindowDetached is for short-lived desktop-only probes whose descendants
+// have been observed to flash their own console windows. Do not use it for tools
+// that rely on console-program stdout/stderr capture, such as PowerShell.
+func HideWindowDetached(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.HideWindow = true
+	cmd.SysProcAttr.CreationFlags |= detachedProcess
 }

--- a/internal/proc/hide_windows_test.go
+++ b/internal/proc/hide_windows_test.go
@@ -4,6 +4,7 @@ package proc
 
 import (
 	"os/exec"
+	"strings"
 	"syscall"
 	"testing"
 )
@@ -17,6 +18,9 @@ func TestHideWindowSetsCreateNoWindow(t *testing.T) {
 	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
 		t.Fatalf("CREATE_NO_WINDOW not set; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
 	}
+	if cmd.SysProcAttr.CreationFlags&detachedProcess != 0 {
+		t.Fatalf("DETACHED_PROCESS should not be set by HideWindow; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
+	}
 }
 
 func TestHideWindowPreservesExistingFlags(t *testing.T) {
@@ -29,5 +33,34 @@ func TestHideWindowPreservesExistingFlags(t *testing.T) {
 	}
 	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
 		t.Fatal("HideWindow did not add CREATE_NO_WINDOW")
+	}
+}
+
+func TestHideWindowDetachedSetsDetachedProcess(t *testing.T) {
+	cmd := exec.Command("git", "status")
+	HideWindowDetached(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil; HideWindowDetached did not set it")
+	}
+	if !cmd.SysProcAttr.HideWindow {
+		t.Fatal("HideWindowDetached did not set HideWindow")
+	}
+	if cmd.SysProcAttr.CreationFlags&createNoWindow != 0 {
+		t.Fatalf("CREATE_NO_WINDOW should not be combined with DETACHED_PROCESS; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
+	}
+	if cmd.SysProcAttr.CreationFlags&detachedProcess == 0 {
+		t.Fatalf("DETACHED_PROCESS not set; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
+	}
+}
+
+func TestHideWindowPreservesStdoutCapture(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "echo", "reasonix-ok")
+	HideWindow(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("command failed: %v", err)
+	}
+	if !strings.Contains(string(out), "reasonix-ok") {
+		t.Fatalf("output = %q, want it to contain reasonix-ok", out)
 	}
 }


### PR DESCRIPTION
Fixes the Windows desktop workspace panel flashing console windows when it runs
git status probes.

This keeps the shared `proc.HideWindow` helper on `CREATE_NO_WINDOW` only, so
shell tools such as PowerShell keep stdout/stderr capture working. The detached
process behavior is scoped to the desktop workspace git probes via a Windows-only
`proc.HideWindowDetached` helper, with a non-Windows no-op stub.

Also adds proc-level regression coverage that `HideWindow` still captures child
stdout.

Closes #2930