### PR TITLE
fix(cli): refresh statusline after model switch

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -989,6 +989,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			m.notice(fmt.Sprintf(i18n.M.ModelSwitchedFmt, m.label))
 			cmds = append(cmds, fetchBalance(m.ctrl))
+			if c := m.runStatusline(); c != nil {
+				cmds = append(cmds, c)
+			}
 			// Do NOT re-issue waitForAgentEvent here — the goroutine from the
 			// last agentEventMsg handler is still blocked on the same channel.
 			// Starting a second one creates a race: two goroutines compete on

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -48,6 +48,44 @@ func TestRunStatuslineDisabled(t *testing.T) {
 	}
 }
 
+func TestModelSwitchRefreshesCustomStatusline(t *testing.T) {
+	oldCtrl := control.New(control.Options{Label: "old-model"})
+	newCtrl := control.New(control.Options{Label: "new-model"})
+	m := newChatTUI(oldCtrl, "", make(chan event.Event, 1), 80)
+	m.statuslineCmd = "cat"
+	m.statuslineOut = `{"model":"old-model"}`
+
+	_, cmd := m.Update(modelSwitchMsg{
+		ref:   "provider/new-model",
+		ctrl:  newCtrl,
+		label: "new-model",
+	})
+	if cmd == nil {
+		t.Fatal("model switch should schedule commands")
+	}
+	if !statuslineCommandHasModel(cmd, "new-model") {
+		t.Fatal("model switch did not refresh custom statusline with the new model")
+	}
+}
+
+func statuslineCommandHasModel(cmd tea.Cmd, model string) bool {
+	msg := cmd()
+	switch msg := msg.(type) {
+	case statuslineMsg:
+		return strings.Contains(msg.out, `"model":"`+model+`"`)
+	case tea.BatchMsg:
+		for _, child := range msg {
+			if child == nil {
+				continue
+			}
+			if statuslineCommandHasModel(child, model) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func TestIdleStatuslineIsCompact(t *testing.T) {
 	i18n.DetectLanguage("en")
 


### PR DESCRIPTION
修复配置了 `[statusline].command` 时，切换模型后底部 custom statusline 仍可能显示旧模型的问题。

  CLI 内置 status bar 会在渲染时直接读取当前 `m.label`，因此 model switch 成功后可以自然显示新模型。但 custom statusline 会用最近一次外部命令输出的
  `m.statuslineOut` 替换整行状态栏。如果 model switch 后不重新执行 statusline command，这个缓存输出就可能仍然来自旧模型。

  本次修改：

  - model switch 成功后重新运行 custom statusline command。
  - 保持 model switch 失败分支不刷新。
  - 增加回归测试，验证 statusline command 收到的是新模型 label。

  ## Why

  `[statusline].command` 的输入 JSON 包含 `model` 字段。model switch 改变了这个输入上下文，因此成功切换后应该触发一次刷新。

  这次改动只补充刷新时机，不改变 custom statusline 的缓存/异步执行设计。

  ## Tests

  ```bash
  go test ./internal/cli -run 'TestModelSwitchRefreshesCustomStatusline|TestRunStatuslineCmd|TestStatuslineShowsEffort|
  TestRefreshEffortStatusUsesCurrentModel'
  git diff --check