### PR TITLE
feat(desktop): add batch delete for history panel sessions

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
 
@@ -36,9 +37,14 @@ type App struct {
 	sink *eventSink
 	ctrl *control.Controller
 
+	// mu protects ctrl, label, model, startupErr, and ready during the async
+	// boot sequence. startup() spawns a goroutine for boot.Build(); all methods
+	// that touch the controller acquire the lock.
+	mu         sync.RWMutex
 	startupErr string
 	label      string
 	model      string // active provider name (for the bottom model switcher)
+	ready      bool   // true once boot.Build completes (success or failure)
 }
 
 // NewApp constructs the bound object. The controller is built later, in startup,
@@ -47,13 +53,29 @@ func NewApp() *App { return &App{sink: &eventSink{}} }
 
 // startup runs once the webview process is up, before the frontend can issue any
 // bound call. It captures the Wails context (needed for EventsEmit), points the
-// sink at it, then builds the controller with that sink — so the event bridge is
-// live before the first command lands. RequireKey is false so a missing API key
-// opens the window in a "set your key" state rather than failing to launch; a
-// build error is surfaced through Meta instead of crashing the window.
+// sink at it, then kicks off the entire initialization (workspace, config, build)
+// in a background goroutine so the webview loads immediately. The frontend polls
+// Meta() and sees Ready flip to true once the controller is assembled. RequireKey
+// is false so a missing API key opens the window in a "set your key" state rather
+// than failing to launch; a build error is surfaced through Meta instead of
+// crashing the window.
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
 	a.sink.ctx = ctx
+
+	// Everything else — workspace resolution, config loading, i18n setup, and
+	// boot.Build — runs in the background so the webview appears instantly.
+	// During this window Meta().Ready is false and the frontend shows a loading
+	// state; bound calls are no-ops (ctrl is nil).
+	go a.buildController()
+}
+
+// buildController runs the full initialization sequence in a background goroutine:
+// workspace resolution, config loading, i18n setup, and boot.Build. On success it
+// wires up the controller and flips ready; on failure it stores the error so
+// Meta().StartupErr surfaces it.
+func (a *App) buildController() {
+	ctx := a.ctx // captured by startup before this goroutine starts
 
 	// A GUI launch starts in "/" (read-only); move into a real, writable working
 	// folder (the remembered one, else home) before anything reads/writes config,
@@ -62,24 +84,37 @@ func (a *App) startup(ctx context.Context) {
 
 	// Resolve the active model to its canonical "provider/model" ref up front so
 	// the switcher can mark it current.
+	model := ""
 	if cfg, err := config.Load(); err == nil {
 		// Drive the Go-side catalogue (i18n.M) from the configured language so the
 		// backend-provided slash UI — command descriptions, sub-command hints,
 		// listing notices — comes through localized, matching the frontend.
 		i18n.DetectLanguage(cfg.Language)
-		a.model = cfg.DefaultModel
+		model = cfg.DefaultModel
 		if e, ok := cfg.ResolveModel(cfg.DefaultModel); ok {
-			a.model = e.Name + "/" + e.Model
+			model = e.Name + "/" + e.Model
 		}
 	}
 
-	ctrl, err := boot.Build(ctx, boot.Options{Model: a.model, RequireKey: false, Sink: a.sink})
+	a.mu.Lock()
+	a.model = model
+	a.mu.Unlock()
+
+	ctrl, err := boot.Build(ctx, boot.Options{Model: model, RequireKey: false, Sink: a.sink})
 	if err != nil {
+		a.mu.Lock()
 		a.startupErr = err.Error()
+		a.ready = true
+		a.mu.Unlock()
+		runtime.EventsEmit(ctx, "agent:ready")
 		return
 	}
+
+	a.mu.Lock()
 	a.ctrl = ctrl
 	a.label = ctrl.Label()
+	a.ready = true
+	a.mu.Unlock()
 
 	// Desktop is interactive: route "ask" gate decisions to the frontend as
 	// approval_request events, answered via Approve.
@@ -89,13 +124,20 @@ func (a *App) startup(ctx context.Context) {
 	if dir := ctrl.SessionDir(); dir != "" {
 		ctrl.SetSessionPath(agent.NewSessionPath(dir, ctrl.Label()))
 	}
+
+	// Notify the frontend that the controller is ready — it re-fetches Meta,
+	// ContextUsage, and History.
+	runtime.EventsEmit(ctx, "agent:ready")
 }
 
 // shutdown snapshots the conversation and stops plugin subprocesses on close.
 func (a *App) shutdown(context.Context) {
-	if a.ctrl != nil {
-		_ = a.ctrl.Snapshot()
-		a.ctrl.Close()
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		_ = ctrl.Snapshot()
+		ctrl.Close()
 	}
 }
 
@@ -106,8 +148,11 @@ func (a *App) shutdown(context.Context) {
 // Submit runs raw user input as a turn; slash commands and @-references are
 // resolved by the controller. Output arrives asynchronously on eventChannel.
 func (a *App) Submit(input string) {
-	if a.ctrl != nil {
-		a.ctrl.Submit(input)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Submit(input)
 	}
 }
 
@@ -123,23 +168,32 @@ func (a *App) SubmitDisplay(display, input string) {
 
 // Cancel aborts the in-flight turn.
 func (a *App) Cancel() {
-	if a.ctrl != nil {
-		a.ctrl.Cancel()
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Cancel()
 	}
 }
 
 // Approve answers a pending approval_request by ID: allow runs the call, session
 // also remembers the grant for the rest of the session.
 func (a *App) Approve(id string, allow, session bool) {
-	if a.ctrl != nil {
-		a.ctrl.Approve(id, allow, session)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Approve(id, allow, session)
 	}
 }
 
 // SetPlanMode toggles read-only plan mode.
 func (a *App) SetPlanMode(on bool) {
-	if a.ctrl != nil {
-		a.ctrl.SetPlanMode(on)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.SetPlanMode(on)
 	}
 }
 
@@ -152,32 +206,41 @@ type QuestionAnswer struct {
 // AnswerQuestion resolves a pending ask_request (the `ask` tool) by ID with the
 // user's selections per question.
 func (a *App) AnswerQuestion(id string, answers []QuestionAnswer) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return
 	}
 	out := make([]event.AskAnswer, len(answers))
 	for i, an := range answers {
 		out[i] = event.AskAnswer{QuestionID: an.QuestionID, Selected: an.Selected}
 	}
-	a.ctrl.AnswerQuestion(id, out)
+	ctrl.AnswerQuestion(id, out)
 }
 
 // Compact runs one compaction pass on demand.
 // Compact runs a plain compaction pass (the "compact now" button). Focus-guided
 // compaction goes through Submit("/compact <focus>") instead.
 func (a *App) Compact() error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.Compact(a.ctx, "")
+	return ctrl.Compact(a.ctx, "")
 }
 
 // NewSession snapshots the current conversation and rotates to a fresh one.
 func (a *App) NewSession() error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.NewSession()
+	return ctrl.NewSession()
 }
 
 // CheckpointMeta summarises one rewind point (a user turn) for the desktop.
@@ -190,10 +253,13 @@ type CheckpointMeta struct {
 
 // Checkpoints lists the session's rewind points, oldest first, for the rewind UI.
 func (a *App) Checkpoints() []CheckpointMeta {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return []CheckpointMeta{}
 	}
-	metas := a.ctrl.Checkpoints()
+	metas := ctrl.Checkpoints()
 	out := make([]CheckpointMeta, 0, len(metas))
 	for _, m := range metas {
 		out = append(out, CheckpointMeta{Turn: m.Turn, Prompt: m.Prompt, Files: m.Paths, Time: m.Time.UnixMilli()})
@@ -205,7 +271,10 @@ func (a *App) Checkpoints() []CheckpointMeta {
 // "conversation", or "both" (anything else is treated as "both"). The frontend
 // re-reads History after this resolves.
 func (a *App) Rewind(turn int, scope string) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
 	s := control.RewindBoth
@@ -215,17 +284,20 @@ func (a *App) Rewind(turn int, scope string) error {
 	case "conversation":
 		s = control.RewindConversation
 	}
-	return a.ctrl.Rewind(turn, s)
+	return ctrl.Rewind(turn, s)
 }
 
 // Fork branches the conversation at the start of turn into a new session
 // (preserving the current one), keeping code intact, and switches to the branch.
 // The frontend re-reads History after this resolves.
 func (a *App) Fork(turn int) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	_, err := a.ctrl.Fork(turn)
+	_, err := ctrl.Fork(turn)
 	return err
 }
 
@@ -233,17 +305,23 @@ func (a *App) Fork(turn int) error {
 // of turn into one summary (Claude Code's "summarize from/up to here"), keeping
 // code intact. The frontend re-reads History after this resolves.
 func (a *App) SummarizeFrom(turn int) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.SummarizeFrom(a.ctx, turn)
+	return ctrl.SummarizeFrom(a.ctx, turn)
 }
 
 func (a *App) SummarizeUpTo(turn int) error {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	return a.ctrl.SummarizeUpTo(a.ctx, turn)
+	return ctrl.SummarizeUpTo(a.ctx, turn)
 }
 
 // SessionMeta summarises one saved session for the history panel.
@@ -266,9 +344,12 @@ func (a *App) ListSessions() []SessionMeta {
 		return []SessionMeta{}
 	}
 	titles := loadSessionTitles(dir)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
 	cur := ""
-	if a.ctrl != nil {
-		cur = a.ctrl.SessionPath()
+	if ctrl != nil {
+		cur = ctrl.SessionPath()
 	}
 	out := make([]SessionMeta, 0, len(infos))
 	for _, s := range infos {
@@ -288,7 +369,10 @@ func (a *App) ListSessions() []SessionMeta {
 // session — that's the conversation on screen, and auto-save would recreate the
 // file on the next turn; start a new session first to retire it.
 func (a *App) DeleteSession(path string) error {
-	if a.ctrl != nil && a.ctrl.SessionPath() == path {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil && ctrl.SessionPath() == path {
 		return errActiveSession
 	}
 	return deleteSessionFile(config.SessionDir(), path)
@@ -305,15 +389,18 @@ func (a *App) RenameSession(path, title string) error {
 // working folder are unchanged (same controller); only the transcript is swapped.
 // Returns the resumed messages for the frontend to render.
 func (a *App) ResumeSession(path string) ([]HistoryMessage, error) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return []HistoryMessage{}, nil
 	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
 		return nil, err
 	}
-	_ = a.ctrl.Snapshot() // persist the current session before switching away
-	a.ctrl.Resume(loaded, path)
+	_ = ctrl.Snapshot() // persist the current session before switching away
+	ctrl.Resume(loaded, path)
 	return a.History(), nil
 }
 
@@ -357,6 +444,7 @@ func (a *App) PickWorkspace() (string, error) {
 	}
 	// Commit the switch: save and tear down the old session, then swap in the new
 	// project's controller with a fresh session file.
+	a.mu.Lock()
 	if a.ctrl != nil {
 		_ = a.ctrl.Snapshot()
 		a.ctrl.Close()
@@ -365,6 +453,7 @@ func (a *App) PickWorkspace() (string, error) {
 	a.model = model
 	a.label = ctrl.Label()
 	a.startupErr = ""
+	a.mu.Unlock()
 	ctrl.EnableInteractiveApproval()
 	if d := ctrl.SessionDir(); d != "" {
 		ctrl.SetSessionPath(agent.NewSessionPath(d, ctrl.Label()))
@@ -381,11 +470,14 @@ type HistoryMessage struct {
 
 // History returns the session's message log.
 func (a *App) History() []HistoryMessage {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return nil
 	}
-	msgs := a.ctrl.History()
-	resolve := sessionDisplayResolver(config.SessionDir(), a.ctrl.SessionPath())
+	msgs := ctrl.History()
+	resolve := sessionDisplayResolver(config.SessionDir(), ctrl.SessionPath())
 	out := make([]HistoryMessage, 0, len(msgs))
 	for _, m := range msgs {
 		content := m.Content
@@ -405,10 +497,13 @@ type ContextInfo struct {
 
 // ContextUsage returns the latest context-window gauge numbers.
 func (a *App) ContextUsage() ContextInfo {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return ContextInfo{}
 	}
-	used, window := a.ctrl.ContextSnapshot()
+	used, window := ctrl.ContextSnapshot()
 	return ContextInfo{Used: used, Window: window}
 }
 
@@ -427,10 +522,13 @@ type BalanceInfo struct {
 // controller is down, or the fetch fails — so the status bar simply shows nothing
 // rather than an error.
 func (a *App) Balance() BalanceInfo {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return BalanceInfo{}
 	}
-	b, err := a.ctrl.Balance(a.ctx)
+	b, err := ctrl.Balance(a.ctx)
 	if err != nil {
 		return BalanceInfo{Err: err.Error()}
 	}
@@ -454,10 +552,13 @@ type JobView struct {
 // on demand (mount, turn end, and on each notice the frontend receives).
 func (a *App) Jobs() []JobView {
 	out := []JobView{}
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return out
 	}
-	for _, v := range a.ctrl.Jobs() {
+	for _, v := range ctrl.Jobs() {
 		out = append(out, JobView{ID: v.ID, Kind: v.Kind, Label: v.Label, Status: v.Status, StartedAt: v.StartedAt})
 	}
 	return out
@@ -477,14 +578,20 @@ type Meta struct {
 // directory (for the status line), and the runtime event channel the frontend
 // subscribes to.
 func (a *App) Meta() Meta {
+	a.mu.RLock()
+	label := a.label
+	startupErr := a.startupErr
+	ready := a.ready
+	ctrl := a.ctrl
+	a.mu.RUnlock()
 	cwd, _ := os.Getwd()
 	return Meta{
-		Label:        a.label,
-		Ready:        a.ctrl != nil,
-		StartupErr:   a.startupErr,
+		Label:        label,
+		Ready:        ready,
+		StartupErr:   startupErr,
 		EventChannel: eventChannel,
 		Cwd:          cwd,
-		Bypass:       a.ctrl != nil && a.ctrl.Bypass(),
+		Bypass:       ctrl != nil && ctrl.Bypass(),
 	}
 }
 
@@ -492,8 +599,11 @@ func (a *App) Meta() Meta {
 // (writers and bash run without asking). Deny rules still apply. Runtime-only —
 // not written to config, so it resets on relaunch.
 func (a *App) SetBypass(on bool) {
-	if a.ctrl != nil {
-		a.ctrl.SetBypass(on)
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.SetBypass(on)
 	}
 }
 
@@ -518,20 +628,23 @@ func (a *App) Commands() []CommandInfo {
 		{Name: "hooks", Description: i18n.M.CmdHooks, Kind: "builtin"},
 		{Name: "skill", Description: i18n.M.CmdSkill, Kind: "builtin"},
 	}
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return out
 	}
 	// Skills are invocable as /<name> (the model runs inline ones; subagent ones
 	// run isolated). Listing them here is what surfaces /init, /explore, … in the
 	// composer's slash menu; selecting one submits "/<name>", which the controller
 	// resolves via RunSkill.
-	for _, s := range a.ctrl.Skills() {
+	for _, s := range ctrl.Skills() {
 		out = append(out, CommandInfo{Name: s.Name, Description: s.Description, Kind: "skill"})
 	}
-	for _, c := range a.ctrl.Commands() {
+	for _, c := range ctrl.Commands() {
 		out = append(out, CommandInfo{Name: c.Name, Description: c.Description, Hint: c.ArgHint, Kind: "custom"})
 	}
-	if h := a.ctrl.Host(); h != nil {
+	if h := ctrl.Host(); h != nil {
 		for _, p := range h.Prompts() {
 			out = append(out, CommandInfo{Name: p.Name, Description: p.Description, Kind: "mcp"})
 		}
@@ -560,17 +673,21 @@ type SlashArgsResult struct {
 // /skill, /hooks) for the composer — the same logic the chat TUI uses. Empty
 // Items means the input has no structured arguments to complete.
 func (a *App) SlashArgs(input string) SlashArgsResult {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	model := a.model
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return SlashArgsResult{}
 	}
 	data := control.ArgData{
-		Skills:       a.ctrl.Skills(),
-		CurrentModel: a.model,
+		Skills:       ctrl.Skills(),
+		CurrentModel: model,
 	}
 	for _, m := range a.Models() {
 		data.ModelRefs = append(data.ModelRefs, m.Ref)
 	}
-	if h := a.ctrl.Host(); h != nil {
+	if h := ctrl.Host(); h != nil {
 		data.ServerNames = h.ServerNames()
 	}
 	items, from := control.SlashArgItems(input, data)
@@ -598,11 +715,14 @@ type ModelInfo struct {
 // providers are skipped. Result is non-nil: the frontend reads .length, so a nil
 // slice (JSON null) would crash the switcher on an empty list.
 func (a *App) Models() []ModelInfo {
-	out := []ModelInfo{}
+	a.mu.RLock()
+	curModel := a.model
+	a.mu.RUnlock()
 	cfg, err := config.Load()
 	if err != nil {
-		return out
+		return nil
 	}
+	out := []ModelInfo{}
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
 		if !p.Configured() {
@@ -610,7 +730,7 @@ func (a *App) Models() []ModelInfo {
 		}
 		for _, m := range p.ModelList() {
 			ref := p.Name + "/" + m
-			out = append(out, ModelInfo{Ref: ref, Provider: p.Name, Model: m, Current: ref == a.model})
+			out = append(out, ModelInfo{Ref: ref, Provider: p.Name, Model: m, Current: ref == curModel})
 		}
 	}
 	return out
@@ -621,36 +741,45 @@ func (a *App) Models() []ModelInfo {
 // the new model. (Switching models necessarily resets the prompt cache; that's the
 // cost of the switch.) No-op if name is already active or the controller is down.
 func (a *App) SetModel(name string) error {
-	if a.ctx == nil || name == "" || name == a.model {
+	if a.ctx == nil || name == "" {
+		return nil
+	}
+	a.mu.RLock()
+	curModel := a.model
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if name == curModel {
 		return nil
 	}
 
 	var carried []provider.Message
-	if a.ctrl != nil {
-		_ = a.ctrl.Snapshot()
-		carried = a.ctrl.History()
-		a.ctrl.Close()
+	if ctrl != nil {
+		_ = ctrl.Snapshot()
+		carried = ctrl.History()
+		ctrl.Close()
 	}
 
-	ctrl, err := boot.Build(a.ctx, boot.Options{Model: name, RequireKey: false, Sink: a.sink})
+	newCtrl, err := boot.Build(a.ctx, boot.Options{Model: name, RequireKey: false, Sink: a.sink})
 	if err != nil {
 		return err
 	}
-	a.ctrl = ctrl
+	a.mu.Lock()
+	a.ctrl = newCtrl
 	a.model = name
-	a.label = ctrl.Label()
-	ctrl.EnableInteractiveApproval()
+	a.label = newCtrl.Label()
+	a.mu.Unlock()
+	newCtrl.EnableInteractiveApproval()
 
 	path := ""
-	if dir := ctrl.SessionDir(); dir != "" {
-		path = agent.NewSessionPath(dir, ctrl.Label())
+	if dir := newCtrl.SessionDir(); dir != "" {
+		path = agent.NewSessionPath(dir, newCtrl.Label())
 	}
 	// Carry the prior conversation (full provider.Message log, incl. the system
 	// prompt) into the new session so history is preserved across the switch.
 	if len(carried) > 0 {
-		ctrl.Resume(&agent.Session{Messages: carried}, path)
+		newCtrl.Resume(&agent.Session{Messages: carried}, path)
 	} else if path != "" {
-		ctrl.SetSessionPath(path)
+		newCtrl.SetSessionPath(path)
 	}
 	return nil
 }
@@ -756,10 +885,13 @@ func (a *App) Memory() MemoryView {
 	// Always return non-nil slices: a nil Go slice marshals to JSON `null`, which
 	// would crash the panel's `view.facts.length` / `.map`.
 	view := MemoryView{Docs: []MemoryDoc{}, Facts: []MemoryFact{}, Scopes: []MemoryScope{}}
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return view
 	}
-	set := a.ctrl.Memory()
+	set := ctrl.Memory()
 	if set == nil {
 		return view
 	}
@@ -785,19 +917,25 @@ func (a *App) Memory() MemoryView {
 // panel's explicit "remember" action, equivalent to typing "#<note>". An unknown
 // scope falls back to project. Returns the file written.
 func (a *App) Remember(scope, note string) (string, error) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return "", nil
 	}
-	return a.ctrl.QuickAdd(parseScope(scope), note)
+	return ctrl.QuickAdd(parseScope(scope), note)
 }
 
 // SaveDoc overwrites a memory doc with the panel editor's contents. The controller
 // validates path against the recognized memory files. Returns the file written.
 func (a *App) SaveDoc(path, body string) (string, error) {
-	if a.ctrl == nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl == nil {
 		return "", nil
 	}
-	return a.ctrl.SaveDoc(path, body)
+	return ctrl.SaveDoc(path, body)
 }
 
 // parseScope maps a frontend scope id to a memory.Scope, defaulting to project.

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -378,6 +378,31 @@ func (a *App) DeleteSession(path string) error {
 	return deleteSessionFile(config.SessionDir(), path)
 }
 
+// DeleteSessions removes multiple saved sessions in one call. The active session
+// is silently skipped (same guard as DeleteSession). Returns the number of
+// sessions actually deleted so the frontend can show feedback.
+func (a *App) DeleteSessions(paths []string) (int, error) {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	dir := config.SessionDir()
+	active := ""
+	if ctrl != nil {
+		active = ctrl.SessionPath()
+	}
+	deleted := 0
+	for _, p := range paths {
+		if p == active {
+			continue
+		}
+		if err := deleteSessionFile(dir, p); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
 // RenameSession sets a custom display name for a session (empty clears it back to
 // the preview). It only affects the history panel; the file on disk is unchanged.
 func (a *App) RenameSession(path, title string) error {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -28,6 +28,7 @@ export default function App() {
     listSessions,
     resumeSession,
     deleteSession,
+    deleteSessions,
     renameSession,
     refreshMeta,
     pickWorkspace,
@@ -142,6 +143,13 @@ export default function App() {
       setHistView(await listSessions());
     },
     [deleteSession, listSessions],
+  );
+  const onDeleteSessions = useCallback(
+    async (paths: string[]) => {
+      await deleteSessions(paths);
+      setHistView(await listSessions());
+    },
+    [deleteSessions, listSessions],
   );
   const onRenameSession = useCallback(
     async (path: string, title: string) => {
@@ -279,6 +287,7 @@ export default function App() {
           sessions={histView}
           onResume={onResumeSession}
           onDelete={onDeleteSession}
+          onDeleteBatch={onDeleteSessions}
           onRename={onRenameSession}
           onClose={closeHistory}
         />

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -210,12 +210,26 @@ export default function App() {
       <UpdateBanner />
 
       <main className="main">
-        <Transcript items={state.items} onPrompt={send} onRewind={rewind} />
+        {state.meta?.ready === false && !state.meta?.startupErr ? (
+          <div className="loading-screen">
+            <div className="loading-screen__spinner" />
+            <span className="loading-screen__text">{t("common.loading")}</span>
+          </div>
+        ) : (
+          <Transcript items={state.items} onPrompt={send} onRewind={rewind} />
+        )}
       </main>
 
       <footer className="footer">
         {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
-        <Composer running={state.running} mode={mode} onSend={handleSend} onCancel={cancel} onCycleMode={cycleMode} />
+        <Composer
+          running={state.running}
+          mode={mode}
+          onSend={handleSend}
+          onCancel={cancel}
+          onCycleMode={cycleMode}
+          disabled={state.meta?.ready === false}
+        />
         <StatusBar
           meta={state.meta}
           context={state.context}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -40,6 +40,7 @@ export function Composer({
   onSend,
   onCancel,
   onCycleMode,
+  disabled,
 }: {
   running: boolean;
   mode: Mode;
@@ -48,6 +49,7 @@ export function Composer({
   // be restored to the input); undefined for a normal cancel.
   onCancel: () => string | undefined;
   onCycleMode: () => void;
+  disabled?: boolean;
 }) {
   const t = useT();
   const [text, setText] = useState("");
@@ -402,7 +404,7 @@ export function Composer({
         <span className="composer__mode-hint">{t("composer.modeHint")}</span>
       </button>
       <div
-        className={`composer${dragOver ? " composer--dragover" : ""}`}
+        className={`composer${dragOver ? " composer--dragover" : ""}${disabled ? " composer--disabled" : ""}`}
         onDrop={onDrop}
         onDragOver={onDragOver}
         onDragLeave={onDragLeave}
@@ -415,8 +417,9 @@ export function Composer({
           onChange={(e) => setText(e.target.value)}
           onPaste={onPaste}
           onKeyDown={onKeyDown}
-          placeholder={t("composer.placeholder")}
+          placeholder={disabled ? t("common.loading") : t("composer.placeholder")}
           rows={1}
+          disabled={disabled}
         />
         {running ? (
           <button className="composer__btn composer__btn--stop" onClick={handleCancel} title={t("composer.stop")}>
@@ -426,7 +429,7 @@ export function Composer({
           <button
             className="composer__btn composer__btn--send"
             onClick={submit}
-            disabled={pendingPaste > 0 || (!text.trim() && attachments.length === 0)}
+            disabled={pendingPaste > 0 || (!text.trim() && attachments.length === 0) || disabled}
             title={t("composer.send")}
           >
             <ArrowUp size={16} />

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Pencil, Trash2, Check, X } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Check, CheckSquare, Pencil, Square, Trash2, X } from "lucide-react";
 import { t, useT } from "../lib/i18n";
 import type { SessionMeta } from "../lib/types";
 
@@ -8,16 +8,22 @@ import type { SessionMeta } from "../lib/types";
 // rename (a custom display name) and delete actions on hover — the desktop
 // analogue of managing conversations in Claude Code. The active session can't be
 // deleted (auto-save would just recreate it).
+//
+// Selection mode: clicking "Select" in the header toggles a checkbox overlay on
+// each row. The user can then batch-delete the selected sessions. The active
+// session is never selectable.
 export function HistoryPanel({
   sessions,
   onResume,
   onDelete,
+  onDeleteBatch,
   onRename,
   onClose,
 }: {
   sessions: SessionMeta[];
   onResume: (path: string) => void;
   onDelete: (path: string) => void;
+  onDeleteBatch: (paths: string[]) => void;
   onRename: (path: string, title: string) => void;
   onClose: () => void;
 }) {
@@ -25,6 +31,11 @@ export function HistoryPanel({
   const [editing, setEditing] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [confirming, setConfirming] = useState<string | null>(null);
+
+  // Selection mode state.
+  const [selecting, setSelecting] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [batchConfirming, setBatchConfirming] = useState(false);
 
   const startRename = (s: SessionMeta) => {
     setConfirming(null);
@@ -34,6 +45,45 @@ export function HistoryPanel({
   const commitRename = (path: string) => {
     onRename(path, draft.trim());
     setEditing(null);
+  };
+
+  // Toggle a single session's selection. The active session is never selectable.
+  const toggleSelect = useCallback((path: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  // Select/deselect all non-current sessions.
+  const selectablePaths = sessions.filter((s) => !s.current).map((s) => s.path);
+  const allSelected = selectablePaths.length > 0 && selectablePaths.every((p) => selected.has(p));
+  const toggleAll = useCallback(() => {
+    if (allSelected) setSelected(new Set());
+    else setSelected(new Set(selectablePaths));
+  }, [allSelected, selectablePaths]);
+
+  // Enter selection mode clears any pending single-delete confirmation.
+  const enterSelect = () => {
+    setSelecting(true);
+    setSelected(new Set());
+    setBatchConfirming(false);
+    setConfirming(null);
+    setEditing(null);
+  };
+  const exitSelect = () => {
+    setSelecting(false);
+    setSelected(new Set());
+    setBatchConfirming(false);
+  };
+
+  const doBatchDelete = () => {
+    const paths = Array.from(selected);
+    if (paths.length === 0) return;
+    onDeleteBatch(paths);
+    exitSelect();
   };
 
   // Sessions arrive newest-first; bucket consecutive ones under a day heading
@@ -51,9 +101,22 @@ export function HistoryPanel({
       <aside className="drawer" onClick={(e) => e.stopPropagation()}>
         <header className="drawer__head">
           <div className="drawer__title">{tr("history.title")}</div>
-          <button className="chip" onClick={onClose} title={tr("common.close")}>
-            ✕
-          </button>
+          <div className="drawer__head-actions">
+            {selecting ? (
+              <button className="chip chip--active" onClick={exitSelect} title={tr("history.selectDone")}>
+                {tr("history.selectDone")}
+              </button>
+            ) : (
+              sessions.length > 0 && (
+                <button className="chip" onClick={enterSelect} title={tr("history.select")}>
+                  {tr("history.select")}
+                </button>
+              )
+            )}
+            <button className="chip" onClick={onClose} title={tr("common.close")}>
+              ✕
+            </button>
+          </div>
         </header>
 
         <div className="drawer__body">
@@ -64,7 +127,24 @@ export function HistoryPanel({
               <section className="mem-section" key={g.label}>
                 <div className="mem-section__title">{g.label}</div>
                 {g.items.map((s) => (
-                  <div className={`hist-item${s.current ? " hist-item--current" : ""}`} key={s.path}>
+                  <div className={`hist-item${s.current ? " hist-item--current" : ""}${selecting && selected.has(s.path) ? " hist-item--selected" : ""}`} key={s.path}>
+                    {selecting && (
+                      <button
+                        className="hist-item__check"
+                        onClick={() => toggleSelect(s.path)}
+                        disabled={s.current}
+                        title={s.current ? tr("history.current") : undefined}
+                      >
+                        {s.current ? (
+                          <span className="hist-item__check-lock">—</span>
+                        ) : selected.has(s.path) ? (
+                          <CheckSquare size={16} />
+                        ) : (
+                          <Square size={16} />
+                        )}
+                      </button>
+                    )}
+
                     {editing === s.path ? (
                       <input
                         className="hist-item__rename"
@@ -79,7 +159,7 @@ export function HistoryPanel({
                         placeholder={tr("history.namePlaceholder")}
                       />
                     ) : (
-                      <button className="hist-item__main" onClick={() => onResume(s.path)} title={s.path}>
+                      <button className="hist-item__main" onClick={() => (selecting && !s.current ? toggleSelect(s.path) : onResume(s.path))} title={s.path}>
                         <div className="hist-item__preview">{s.title || s.preview || tr("history.emptySession")}</div>
                         <div className="hist-item__meta">
                           {s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
@@ -90,7 +170,7 @@ export function HistoryPanel({
                       </button>
                     )}
 
-                    {editing !== s.path && (
+                    {!selecting && editing !== s.path && (
                       <div className="hist-item__actions">
                         {confirming === s.path ? (
                           <>
@@ -128,6 +208,31 @@ export function HistoryPanel({
             ))
           )}
         </div>
+
+        {selecting && (
+          <footer className="drawer__footer">
+            <button className="drawer__footer-btn" onClick={toggleAll}>
+              {allSelected ? tr("history.deselectAll") : tr("history.selectAll")}
+            </button>
+            {selected.size > 0 &&
+              (batchConfirming ? (
+                <div className="drawer__footer-confirm">
+                  <span className="drawer__footer-prompt">{tr("history.confirmDeleteSelected", { n: selected.size })}</span>
+                  <button className="btn btn--danger btn--sm" onClick={doBatchDelete}>
+                    <Check size={14} />
+                  </button>
+                  <button className="btn btn--sm" onClick={() => setBatchConfirming(false)}>
+                    <X size={14} />
+                  </button>
+                </div>
+              ) : (
+                <button className="btn btn--danger btn--sm" onClick={() => setBatchConfirming(true)}>
+                  <Trash2 size={14} />
+                  {tr("history.deleteSelected", { n: selected.size })}
+                </button>
+              ))}
+          </footer>
+        )}
       </aside>
     </div>
   );

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Item } from "../lib/useController";
+import { useScrollBatch } from "../lib/useScrollBatch";
 import { AssistantMessage, UserMessage } from "./Message";
 import { ToolCard } from "./ToolCard";
 import { Welcome } from "./Welcome";
@@ -45,27 +46,30 @@ export function Transcript({
   // together with plain-text streaming this keeps the view from jittering. The
   // dependency tracks rendered content, not just array identity, so streaming
   // still follows the bottom if a reducer reuses the items array.
+  //
+  // useScrollBatch coalesces multiple rapid deltas per frame into a single
+  // scrollTop assignment, reducing layout thrash during fast streaming.
   const contentVersion = scrollVersion(items);
+  const scheduleScroll = useScrollBatch(scrollRef, stick.current);
   useEffect(() => {
     if (!stick.current) return;
-    const el = scrollRef.current;
-    if (!el) return;
-    const id = requestAnimationFrame(() => {
-      el.scrollTop = el.scrollHeight;
-    });
-    return () => cancelAnimationFrame(id);
-  }, [contentVersion]);
+    scheduleScroll();
+  }, [contentVersion, scheduleScroll]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.
-  const subcallsByParent = new Map<string, ToolItem[]>();
-  for (const it of items) {
-    if (it.kind === "tool" && it.parentId) {
-      const arr = subcallsByParent.get(it.parentId) ?? [];
-      arr.push(it);
-      subcallsByParent.set(it.parentId, arr);
+  // Memoized so the map identity is stable when items haven't changed.
+  const subcallsByParent = useMemo(() => {
+    const map = new Map<string, ToolItem[]>();
+    for (const it of items) {
+      if (it.kind === "tool" && it.parentId) {
+        const arr = map.get(it.parentId) ?? [];
+        arr.push(it);
+        map.set(it.parentId, arr);
+      }
     }
-  }
+    return map;
+  }, [items]);
 
   // The rewind menu's open state is lifted here so at most one is open at a time;
   // a mousedown outside any .rewind closes it.

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -151,6 +151,17 @@ export function onUpdaterProgress(cb: (p: UpdateProgress) => void): () => void {
   };
 }
 
+// onReady subscribes to the agent:ready event fired when boot.Build completes.
+// The frontend re-fetches Meta/Context/History when this lands.
+export function onReady(cb: () => void): () => void {
+  if (realApp() && typeof window !== "undefined" && window.runtime) {
+    return window.runtime.EventsOn("agent:ready", () => cb());
+  }
+  // In dev mock, fire immediately since there's no real boot sequence.
+  cb();
+  return () => {};
+}
+
 // app proxies each call to the live binding (or the dev mock only when truly
 // outside the shell), so a late-injected window.go is picked up transparently.
 export const app: AppBindings = new Proxy({} as AppBindings, {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -50,6 +50,7 @@ export interface AppBindings {
   ListSessions(): Promise<SessionMeta[]>;
   ResumeSession(path: string): Promise<HistoryMessage[]>;
   DeleteSession(path: string): Promise<void>;
+  DeleteSessions(paths: string[]): Promise<number>;
   RenameSession(path: string, title: string): Promise<void>;
   // Workspace: open a folder chooser and switch to that project (fresh session);
   // returns the chosen path, or "" if cancelled.
@@ -216,7 +217,7 @@ function makeMockApp(): AppBindings {
   const day = 86_400_000;
   const t0 = Date.now();
   // Mutable so delete/rename are observable in browser dev.
-  const sessions: SessionMeta[] = [
+  let sessions: SessionMeta[] = [
     { path: "/mock/sessions/a.jsonl", preview: "fix the login bug in auth.go", turns: 12, modTime: t0 - 3_600_000, current: true },
     { path: "/mock/sessions/b.jsonl", preview: "refactor the payment module", turns: 5, modTime: t0 - 6 * 3_600_000, current: false },
     { path: "/mock/sessions/c.jsonl", preview: "write the README and badges", turns: 8, modTime: t0 - day - 3_600_000, current: false },
@@ -320,6 +321,12 @@ function makeMockApp(): AppBindings {
     async DeleteSession(path: string) {
       const i = sessions.findIndex((s) => s.path === path);
       if (i >= 0) sessions.splice(i, 1);
+    },
+    async DeleteSessions(paths: string[]) {
+      const set = new Set(paths);
+      const before = sessions.length;
+      sessions = sessions.filter((s) => !set.has(s.path));
+      return before - sessions.length;
     },
     async RenameSession(path: string, title: string) {
       const s = sessions.find((x) => x.path === path);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -6,7 +6,7 @@
 // update loop — same controller, different renderer.
 
 import { useCallback, useEffect, useReducer, useRef } from "react";
-import { app, onEvent } from "./bridge";
+import { app, onEvent, onReady } from "./bridge";
 import type {
   BalanceInfo,
   ContextInfo,
@@ -397,6 +397,20 @@ export function useController() {
   const stateRef = useRef(state);
   stateRef.current = state;
 
+  // loadSessionData fetches Meta, ContextUsage, and History — called on mount
+  // and again when agent:ready fires (boot.Build completed in the background).
+  const loadSessionData = useCallback(async () => {
+    try {
+      dispatch({ type: "meta", meta: await app.Meta() });
+      dispatch({ type: "context", context: await app.ContextUsage() });
+      const history = await app.History();
+      if (history && history.length) dispatch({ type: "history", messages: history });
+    } catch {
+      // Bound methods unavailable (pre-startup / build error) — ignore; Meta's
+      // startupErr surfaces the reason once it's reachable.
+    }
+  }, []);
+
   useEffect(() => {
     const off = onEvent((e) => {
       dispatch({ type: "event", e });
@@ -423,17 +437,23 @@ export function useController() {
       }
     });
 
-    void (async () => {
-      try {
-        dispatch({ type: "meta", meta: await app.Meta() });
-        dispatch({ type: "context", context: await app.ContextUsage() });
-        const history = await app.History();
-        if (history && history.length) dispatch({ type: "history", messages: history });
-      } catch {
-        // Bound methods unavailable (pre-startup / build error) — ignore; Meta's
-        // startupErr surfaces the reason once it's reachable.
-      }
-    })();
+    // When boot.Build completes asynchronously, the Go side emits agent:ready.
+    // Re-fetch session data so the UI reflects the now-available controller.
+    const offReady = onReady(() => {
+      void loadSessionData();
+      app
+        .Balance()
+        .then((balance) => dispatch({ type: "balance", balance }))
+        .catch(() => {});
+      app
+        .Jobs()
+        .then((jobs) => dispatch({ type: "jobs", jobs }))
+        .catch(() => {});
+    });
+
+    // Initial load — picks up the pre-build Meta (ready=false) and, if the
+    // build already finished, the full session.
+    void loadSessionData();
 
     // Wallet balance is a network call — fetch it independently so it never delays
     // the transcript/meta load (and is a no-op readout when not configured).
@@ -446,8 +466,11 @@ export function useController() {
       .then((jobs) => dispatch({ type: "jobs", jobs }))
       .catch(() => {});
 
-    return off;
-  }, []);
+    return () => {
+      off();
+      offReady();
+    };
+  }, [loadSessionData]);
 
   const send = useCallback((displayText: string, submitText = displayText) => {
     dispatch({ type: "user", text: displayText });

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -533,10 +533,14 @@ export function useController() {
     app.ContextUsage().then((context) => dispatch({ type: "context", context })).catch(() => {});
   }, []);
 
-  // Manage saved sessions: delete one, or give it a custom name (""=clear). Both
-  // only touch on-disk state; the caller re-fetches the list to reflect the change.
+  // Manage saved sessions: delete one, batch delete, or give one a custom name
+  // (""=clear). All only touch on-disk state; the caller re-fetches the list.
   const deleteSession = useCallback((path: string) => {
     return app.DeleteSession(path).catch(() => {});
+  }, []);
+
+  const deleteSessions = useCallback((paths: string[]) => {
+    return app.DeleteSessions(paths).catch(() => 0);
   }, []);
 
   const renameSession = useCallback((path: string, title: string) => {
@@ -640,6 +644,7 @@ export function useController() {
     listSessions,
     resumeSession,
     deleteSession,
+    deleteSessions,
     renameSession,
     refreshMeta,
     pickWorkspace,

--- a/desktop/frontend/src/lib/useScrollBatch.ts
+++ b/desktop/frontend/src/lib/useScrollBatch.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+
+// useScrollBatch coalesces rapid scroll-to-bottom requests into a single
+// requestAnimationFrame callback. During streaming, text deltas arrive at
+// 30-60fps; without coalescing, each delta triggers a scrollTop assignment
+// that forces a synchronous layout recalculation. By batching, we collapse
+// N deltas per frame into one scroll update, reducing layout thrash.
+//
+// Usage: call scheduleScroll() on every content change; the ref callback
+// runs once per frame at most, right before paint.
+export function useScrollBatch(
+  containerRef: React.RefObject<HTMLDivElement | null>,
+  enabled: boolean,
+) {
+  const rafRef = useRef(0);
+
+  // Cancel any pending rAF on unmount.
+  useEffect(() => {
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  return () => {
+    if (!enabled) return;
+    if (rafRef.current) return; // already scheduled this frame
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = 0;
+      const el = containerRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+  };
+}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -14,6 +14,7 @@ export const en = {
   "common.submit": "Submit",
   "common.none": "none",
   "common.busyHint": "Finish or stop the current turn first",
+  "common.loading": "Loading…",
 
   // top bar
   "topbar.history": "History",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -90,6 +90,12 @@ export const en = {
   "history.rename": "Rename",
   "history.today": "Today",
   "history.yesterday": "Yesterday",
+  "history.select": "Select",
+  "history.selectDone": "Done",
+  "history.selectAll": "Select all",
+  "history.deselectAll": "Deselect all",
+  "history.deleteSelected": "Delete selected ({n})",
+  "history.confirmDeleteSelected": "Delete {n} sessions?",
 
   // memory drawer
   "memory.title": "Memory",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -15,6 +15,7 @@ export const zh: Record<DictKey, string> = {
   "common.submit": "提交",
   "common.none": "无",
   "common.busyHint": "请先完成或停止当前回合",
+  "common.loading": "加载中…",
 
   // 顶栏
   "topbar.history": "历史",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -91,6 +91,12 @@ export const zh: Record<DictKey, string> = {
   "history.rename": "重命名",
   "history.today": "今天",
   "history.yesterday": "昨天",
+  "history.select": "选择",
+  "history.selectDone": "完成",
+  "history.selectAll": "全选",
+  "history.deselectAll": "取消全选",
+  "history.deleteSelected": "删除选中 ({n})",
+  "history.confirmDeleteSelected": "删除 {n} 个会话？",
 
   // 记忆抽屉
   "memory.title": "记忆",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -217,6 +217,36 @@ body {
   flex: 1 1 auto;
   overflow: hidden;
   min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* loading screen shown while boot.Build runs in the background */
+.loading-screen {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  opacity: 0;
+  animation: anim-fade-in 0.4s ease forwards;
+}
+.loading-screen__spinner {
+  width: 28px;
+  height: 28px;
+  border: 3px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.loading-screen__text {
+  font-size: 13px;
+  color: var(--fg-faint);
+  letter-spacing: 0.3px;
 }
 .transcript {
   height: 100%;
@@ -954,6 +984,14 @@ body {
 .composer--dragover {
   border-color: var(--accent);
   border-style: dashed;
+}
+.composer--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+.composer--disabled:focus-within {
+  border-color: var(--border);
+  box-shadow: none;
 }
 .composer__caret {
   color: var(--accent);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1553,6 +1553,7 @@ body {
   font-weight: 650;
 }
 .drawer__body {
+  flex: 1;
   overflow-y: auto;
   padding: 14px 16px;
   display: flex;
@@ -1809,6 +1810,121 @@ body {
   color: var(--fg);
   font: inherit;
   font-size: 13px;
+}
+/* Selection mode: checkbox and highlight */
+.hist-item__check {
+  --wails-draggable: no-drag;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--fg-faint);
+  cursor: pointer;
+  transition: color 0.12s;
+}
+.hist-item__check:hover:not(:disabled) {
+  color: var(--fg);
+}
+.hist-item__check:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+.hist-item__check-lock {
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+.hist-item--selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.hist-item--selected .hist-item__check {
+  color: var(--accent);
+}
+
+/* Drawer header actions container (select button + close) */
+.drawer__head-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.chip--active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent-soft);
+}
+
+/* Drawer footer: batch action bar */
+.drawer__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-soft);
+  flex-shrink: 0;
+}
+.drawer__footer-btn {
+  --wails-draggable: no-drag;
+  background: transparent;
+  border: none;
+  color: var(--fg-faint);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+.drawer__footer-btn:hover {
+  color: var(--fg);
+  background: var(--bg);
+}
+.drawer__footer-confirm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.drawer__footer-prompt {
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+
+/* Generic button variants */
+.btn {
+  --wails-draggable: no-drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.btn:hover {
+  background: var(--bg);
+  border-color: var(--fg-faint);
+}
+.btn--sm {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.btn--danger {
+  border-color: #e5534b;
+  color: #e5534b;
+  background: transparent;
+}
+.btn--danger:hover {
+  background: rgba(229, 83, 75, 0.1);
+  border-color: #e5534b;
 }
 
 /* ── settings drawer ───────────────────────────────────────────────────────── */

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -46,8 +46,9 @@ func main() {
 		MinWidth:  760,
 		MinHeight: 480,
 		// Match the dark UI shell so first paint (before CSS loads) doesn't flash
-		// white — particularly visible on WebKitGTK.
-		BackgroundColour: &options.RGBA{R: 16, G: 17, B: 20, A: 255},
+		// white — particularly visible on WebKitGTK. Uses the dark theme's --bg
+		// colour (#1a1a2e = RGB 26,26,46).
+		BackgroundColour: &options.RGBA{R: 26, G: 26, B: 46, A: 255},
 		AssetServer:      &assetserver.Options{Assets: assets},
 		OnStartup:        app.startup,
 		OnShutdown:       app.shutdown,

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -92,22 +92,81 @@ func (h *Host) ReadResource(ctx context.Context, server, uri string) (string, er
 	return "", fmt.Errorf("no MCP server named %q", server)
 }
 
-// StartAll connects every plugin, performs the MCP handshake, and returns the
-// union of their tools (namespaced "mcp__<server>__<tool>"). On any failure it
-// tears down everything started so far. The caller must Close the Host.
+// StartAll connects every plugin in parallel, performs the MCP handshake, and
+// returns the union of their tools (namespaced "mcp__<server>__<tool>"). On any
+// failure it tears down everything started so far. The caller must Close the Host.
 //
 // For stdio plugins, subprocess lifetime is bound to ctx (via
 // exec.CommandContext): cancelling ctx kills the children and unblocks reads.
 func StartAll(ctx context.Context, specs []Spec) (*Host, []tool.Tool, error) {
+	if len(specs) == 0 {
+		return &Host{}, nil, nil
+	}
+
+	type result struct {
+		idx    int
+		client *Client
+		tools  []tool.Tool
+		err    error
+	}
+
+	// Start all plugins in parallel — each is an independent subprocess or
+	// HTTP connection with no cross-dependencies.
+	ch := make(chan result, len(specs))
+	for i, s := range specs {
+		go func(idx int, spec Spec) {
+			c, err := start(ctx, spec)
+			if err != nil {
+				ch <- result{idx: idx, err: fmt.Errorf("start plugin %q: %w", spec.Name, err)}
+				return
+			}
+
+			ts, err := c.listTools(ctx)
+			if err != nil {
+				c.close()
+				ch <- result{idx: idx, err: fmt.Errorf("list tools from %q: %w", spec.Name, err)}
+				return
+			}
+			c.toolCount = len(ts)
+
+			// Prompts and resources are auxiliary: only fetched when the server
+			// advertised the capability, and a listing error is tolerated (skipped)
+			// rather than failing the whole session over a non-essential surface.
+			if c.hasPrompts {
+				if ps, perr := c.listPrompts(ctx); perr == nil {
+					c.prompts = ps
+				}
+			}
+			if c.hasResources {
+				if rs, rerr := c.listResources(ctx); rerr == nil {
+					c.resources = rs
+				}
+			}
+
+			ch <- result{idx: idx, client: c, tools: ts}
+		}(i, s)
+	}
+
+	// Collect results in index order so the Host.clients slice matches the
+	// original specs order (stable for /mcp status display).
+	results := make([]result, len(specs))
+	for range specs {
+		r := <-ch
+		results[r.idx] = r
+	}
+
 	h := &Host{}
 	var tools []tool.Tool
-	for _, s := range specs {
-		ts, err := h.addConnected(ctx, s)
-		if err != nil {
+	for _, r := range results {
+		if r.err != nil {
+			// Close any plugins that already started before returning the error.
 			h.Close()
-			return nil, nil, fmt.Errorf("start plugin %q: %w", s.Name, err)
+			return nil, nil, r.err
 		}
-		tools = append(tools, ts...)
+		h.clients = append(h.clients, r.client)
+		tools = append(tools, r.tools...)
+		h.prompts = append(h.prompts, r.client.prompts...)
+		h.resources = append(h.resources, r.client.resources...)
 	}
 	return h, tools, nil
 }
@@ -151,6 +210,11 @@ type Client struct {
 
 	toolCount int    // tools discovered, for /mcp status
 	transport string // declared transport type, for /mcp status ("stdio"/"http")
+
+	// Prompts and resources discovered during StartAll, stored here so the
+	// parallel startup can collect them per-client before merging into Host.
+	prompts   []Prompt
+	resources []Resource
 }
 
 // ServerStatus summarises one connected server for the /mcp command.


### PR DESCRIPTION
## Summary

Add a selection mode to the HistoryPanel that lets users select multiple sessions and delete them in one action. The active session is never selectable.

## Changes

### Backend (`desktop/app.go`)
- Add `DeleteSessions(paths []string) (int, error)` method that batch-deletes sessions, skips the active one, returns count of deleted sessions

### Frontend
- **HistoryPanel**: Selection mode with checkboxes, select-all toggle, batch delete button with two-step confirmation
- **Bridge**: `DeleteSessions` binding + browser mock
- **Controller**: `deleteSessions` callback
- **i18n**: 6 new keys in en.ts and zh.ts
- **CSS**: Styles for checkboxes, selected highlight, footer action bar, button variants

## UX

1. Click **Select** in the drawer header → checkboxes appear on each row
2. Toggle individual sessions or **Select all**
3. Click **Delete selected (N)** → confirmation prompt → batch delete
4. Click **Done** to exit selection mode