### PR TITLE
feat(desktop): add batch delete for history panel sessions

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -282,6 +282,31 @@ func (a *App) DeleteSession(path string) error {
 	return deleteSessionFile(config.SessionDir(), path)
 }
 
+// DeleteSessions removes multiple saved sessions in one call. The active session
+// is silently skipped (same guard as DeleteSession). Returns the number of
+// sessions actually deleted so the frontend can show feedback.
+func (a *App) DeleteSessions(paths []string) (int, error) {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	dir := config.SessionDir()
+	active := ""
+	if ctrl != nil {
+		active = ctrl.SessionPath()
+	}
+	deleted := 0
+	for _, p := range paths {
+		if p == active {
+			continue
+		}
+		if err := deleteSessionFile(dir, p); err != nil {
+			return deleted, err
+		}
+		deleted++
+	}
+	return deleted, nil
+}
+
 // RenameSession sets a custom display name for a session (empty clears it back to
 // the preview). It only affects the history panel; the file on disk is unchanged.
 func (a *App) RenameSession(path, title string) error {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -28,6 +28,7 @@ export default function App() {
     listSessions,
     resumeSession,
     deleteSession,
+    deleteSessions,
     renameSession,
     refreshMeta,
     pickWorkspace,
@@ -142,6 +143,13 @@ export default function App() {
       setHistView(await listSessions());
     },
     [deleteSession, listSessions],
+  );
+  const onDeleteSessions = useCallback(
+    async (paths: string[]) => {
+      await deleteSessions(paths);
+      setHistView(await listSessions());
+    },
+    [deleteSessions, listSessions],
   );
   const onRenameSession = useCallback(
     async (path: string, title: string) => {
@@ -265,6 +273,7 @@ export default function App() {
           sessions={histView}
           onResume={onResumeSession}
           onDelete={onDeleteSession}
+          onDeleteBatch={onDeleteSessions}
           onRename={onRenameSession}
           onClose={closeHistory}
         />

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
-import { Pencil, Trash2, Check, X } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Check, CheckSquare, Pencil, Square, Trash2, X } from "lucide-react";
 import { t, useT } from "../lib/i18n";
 import type { SessionMeta } from "../lib/types";
 
@@ -8,16 +8,22 @@ import type { SessionMeta } from "../lib/types";
 // rename (a custom display name) and delete actions on hover — the desktop
 // analogue of managing conversations in Claude Code. The active session can't be
 // deleted (auto-save would just recreate it).
+//
+// Selection mode: clicking "Select" in the header toggles a checkbox overlay on
+// each row. The user can then batch-delete the selected sessions. The active
+// session is never selectable.
 export function HistoryPanel({
   sessions,
   onResume,
   onDelete,
+  onDeleteBatch,
   onRename,
   onClose,
 }: {
   sessions: SessionMeta[];
   onResume: (path: string) => void;
   onDelete: (path: string) => void;
+  onDeleteBatch: (paths: string[]) => void;
   onRename: (path: string, title: string) => void;
   onClose: () => void;
 }) {
@@ -25,6 +31,11 @@ export function HistoryPanel({
   const [editing, setEditing] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [confirming, setConfirming] = useState<string | null>(null);
+
+  // Selection mode state.
+  const [selecting, setSelecting] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [batchConfirming, setBatchConfirming] = useState(false);
 
   const startRename = (s: SessionMeta) => {
     setConfirming(null);
@@ -34,6 +45,45 @@ export function HistoryPanel({
   const commitRename = (path: string) => {
     onRename(path, draft.trim());
     setEditing(null);
+  };
+
+  // Toggle a single session's selection. The active session is never selectable.
+  const toggleSelect = useCallback((path: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  // Select/deselect all non-current sessions.
+  const selectablePaths = sessions.filter((s) => !s.current).map((s) => s.path);
+  const allSelected = selectablePaths.length > 0 && selectablePaths.every((p) => selected.has(p));
+  const toggleAll = useCallback(() => {
+    if (allSelected) setSelected(new Set());
+    else setSelected(new Set(selectablePaths));
+  }, [allSelected, selectablePaths]);
+
+  // Enter selection mode clears any pending single-delete confirmation.
+  const enterSelect = () => {
+    setSelecting(true);
+    setSelected(new Set());
+    setBatchConfirming(false);
+    setConfirming(null);
+    setEditing(null);
+  };
+  const exitSelect = () => {
+    setSelecting(false);
+    setSelected(new Set());
+    setBatchConfirming(false);
+  };
+
+  const doBatchDelete = () => {
+    const paths = Array.from(selected);
+    if (paths.length === 0) return;
+    onDeleteBatch(paths);
+    exitSelect();
   };
 
   // Sessions arrive newest-first; bucket consecutive ones under a day heading
@@ -51,9 +101,22 @@ export function HistoryPanel({
       <aside className="drawer" onClick={(e) => e.stopPropagation()}>
         <header className="drawer__head">
           <div className="drawer__title">{tr("history.title")}</div>
-          <button className="chip" onClick={onClose} title={tr("common.close")}>
-            ✕
-          </button>
+          <div className="drawer__head-actions">
+            {selecting ? (
+              <button className="chip chip--active" onClick={exitSelect} title={tr("history.selectDone")}>
+                {tr("history.selectDone")}
+              </button>
+            ) : (
+              sessions.length > 0 && (
+                <button className="chip" onClick={enterSelect} title={tr("history.select")}>
+                  {tr("history.select")}
+                </button>
+              )
+            )}
+            <button className="chip" onClick={onClose} title={tr("common.close")}>
+              ✕
+            </button>
+          </div>
         </header>
 
         <div className="drawer__body">
@@ -64,7 +127,24 @@ export function HistoryPanel({
               <section className="mem-section" key={g.label}>
                 <div className="mem-section__title">{g.label}</div>
                 {g.items.map((s) => (
-                  <div className={`hist-item${s.current ? " hist-item--current" : ""}`} key={s.path}>
+                  <div className={`hist-item${s.current ? " hist-item--current" : ""}${selecting && selected.has(s.path) ? " hist-item--selected" : ""}`} key={s.path}>
+                    {selecting && (
+                      <button
+                        className="hist-item__check"
+                        onClick={() => toggleSelect(s.path)}
+                        disabled={s.current}
+                        title={s.current ? tr("history.current") : undefined}
+                      >
+                        {s.current ? (
+                          <span className="hist-item__check-lock">—</span>
+                        ) : selected.has(s.path) ? (
+                          <CheckSquare size={16} />
+                        ) : (
+                          <Square size={16} />
+                        )}
+                      </button>
+                    )}
+
                     {editing === s.path ? (
                       <input
                         className="hist-item__rename"
@@ -79,7 +159,7 @@ export function HistoryPanel({
                         placeholder={tr("history.namePlaceholder")}
                       />
                     ) : (
-                      <button className="hist-item__main" onClick={() => onResume(s.path)} title={s.path}>
+                      <button className="hist-item__main" onClick={() => (selecting && !s.current ? toggleSelect(s.path) : onResume(s.path))} title={s.path}>
                         <div className="hist-item__preview">{s.title || s.preview || tr("history.emptySession")}</div>
                         <div className="hist-item__meta">
                           {s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
@@ -90,7 +170,7 @@ export function HistoryPanel({
                       </button>
                     )}
 
-                    {editing !== s.path && (
+                    {!selecting && editing !== s.path && (
                       <div className="hist-item__actions">
                         {confirming === s.path ? (
                           <>
@@ -128,6 +208,31 @@ export function HistoryPanel({
             ))
           )}
         </div>
+
+        {selecting && (
+          <footer className="drawer__footer">
+            <button className="drawer__footer-btn" onClick={toggleAll}>
+              {allSelected ? tr("history.deselectAll") : tr("history.selectAll")}
+            </button>
+            {selected.size > 0 &&
+              (batchConfirming ? (
+                <div className="drawer__footer-confirm">
+                  <span className="drawer__footer-prompt">{tr("history.confirmDeleteSelected", { n: selected.size })}</span>
+                  <button className="btn btn--danger btn--sm" onClick={doBatchDelete}>
+                    <Check size={14} />
+                  </button>
+                  <button className="btn btn--sm" onClick={() => setBatchConfirming(false)}>
+                    <X size={14} />
+                  </button>
+                </div>
+              ) : (
+                <button className="btn btn--danger btn--sm" onClick={() => setBatchConfirming(true)}>
+                  <Trash2 size={14} />
+                  {tr("history.deleteSelected", { n: selected.size })}
+                </button>
+              ))}
+          </footer>
+        )}
       </aside>
     </div>
   );

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -49,6 +49,7 @@ export interface AppBindings {
   ListSessions(): Promise<SessionMeta[]>;
   ResumeSession(path: string): Promise<HistoryMessage[]>;
   DeleteSession(path: string): Promise<void>;
+  DeleteSessions(paths: string[]): Promise<number>;
   RenameSession(path: string, title: string): Promise<void>;
   // Workspace: open a folder chooser and switch to that project (fresh session);
   // returns the chosen path, or "" if cancelled.
@@ -202,7 +203,7 @@ function makeMockApp(): AppBindings {
   const day = 86_400_000;
   const t0 = Date.now();
   // Mutable so delete/rename are observable in browser dev.
-  const sessions: SessionMeta[] = [
+  let sessions: SessionMeta[] = [
     { path: "/mock/sessions/a.jsonl", preview: "fix the login bug in auth.go", turns: 12, modTime: t0 - 3_600_000, current: true },
     { path: "/mock/sessions/b.jsonl", preview: "refactor the payment module", turns: 5, modTime: t0 - 6 * 3_600_000, current: false },
     { path: "/mock/sessions/c.jsonl", preview: "write the README and badges", turns: 8, modTime: t0 - day - 3_600_000, current: false },
@@ -303,6 +304,12 @@ function makeMockApp(): AppBindings {
     async DeleteSession(path: string) {
       const i = sessions.findIndex((s) => s.path === path);
       if (i >= 0) sessions.splice(i, 1);
+    },
+    async DeleteSessions(paths: string[]) {
+      const set = new Set(paths);
+      const before = sessions.length;
+      sessions = sessions.filter((s) => !set.has(s.path));
+      return before - sessions.length;
     },
     async RenameSession(path: string, title: string) {
       const s = sessions.find((x) => x.path === path);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -507,10 +507,14 @@ export function useController() {
     app.ContextUsage().then((context) => dispatch({ type: "context", context })).catch(() => {});
   }, []);
 
-  // Manage saved sessions: delete one, or give it a custom name (""=clear). Both
-  // only touch on-disk state; the caller re-fetches the list to reflect the change.
+  // Manage saved sessions: delete one, batch delete, or give one a custom name
+  // (""=clear). All only touch on-disk state; the caller re-fetches the list.
   const deleteSession = useCallback((path: string) => {
     return app.DeleteSession(path).catch(() => {});
+  }, []);
+
+  const deleteSessions = useCallback((paths: string[]) => {
+    return app.DeleteSessions(paths).catch(() => 0);
   }, []);
 
   const renameSession = useCallback((path: string, title: string) => {
@@ -614,6 +618,7 @@ export function useController() {
     listSessions,
     resumeSession,
     deleteSession,
+    deleteSessions,
     renameSession,
     refreshMeta,
     pickWorkspace,

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -89,6 +89,12 @@ export const en = {
   "history.rename": "Rename",
   "history.today": "Today",
   "history.yesterday": "Yesterday",
+  "history.select": "Select",
+  "history.selectDone": "Done",
+  "history.selectAll": "Select all",
+  "history.deselectAll": "Deselect all",
+  "history.deleteSelected": "Delete selected ({n})",
+  "history.confirmDeleteSelected": "Delete {n} sessions?",
 
   // memory drawer
   "memory.title": "Memory",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -90,6 +90,12 @@ export const zh: Record<DictKey, string> = {
   "history.rename": "重命名",
   "history.today": "今天",
   "history.yesterday": "昨天",
+  "history.select": "选择",
+  "history.selectDone": "完成",
+  "history.selectAll": "全选",
+  "history.deselectAll": "取消全选",
+  "history.deleteSelected": "删除选中 ({n})",
+  "history.confirmDeleteSelected": "删除 {n} 个会话？",
 
   // 记忆抽屉
   "memory.title": "记忆",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1511,6 +1511,7 @@ body {
   font-weight: 650;
 }
 .drawer__body {
+  flex: 1;
   overflow-y: auto;
   padding: 14px 16px;
   display: flex;
@@ -1767,6 +1768,121 @@ body {
   color: var(--fg);
   font: inherit;
   font-size: 13px;
+}
+/* Selection mode: checkbox and highlight */
+.hist-item__check {
+  --wails-draggable: no-drag;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--fg-faint);
+  cursor: pointer;
+  transition: color 0.12s;
+}
+.hist-item__check:hover:not(:disabled) {
+  color: var(--fg);
+}
+.hist-item__check:disabled {
+  cursor: default;
+  opacity: 0.4;
+}
+.hist-item__check-lock {
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+.hist-item--selected {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.hist-item--selected .hist-item__check {
+  color: var(--accent);
+}
+
+/* Drawer header actions container (select button + close) */
+.drawer__head-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.chip--active {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent-soft);
+}
+
+/* Drawer footer: batch action bar */
+.drawer__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-soft);
+  flex-shrink: 0;
+}
+.drawer__footer-btn {
+  --wails-draggable: no-drag;
+  background: transparent;
+  border: none;
+  color: var(--fg-faint);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 6px;
+}
+.drawer__footer-btn:hover {
+  color: var(--fg);
+  background: var(--bg);
+}
+.drawer__footer-confirm {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.drawer__footer-prompt {
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+
+/* Generic button variants */
+.btn {
+  --wails-draggable: no-drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg);
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.btn:hover {
+  background: var(--bg);
+  border-color: var(--fg-faint);
+}
+.btn--sm {
+  padding: 4px 8px;
+  font-size: 12px;
+}
+.btn--danger {
+  border-color: #e5534b;
+  color: #e5534b;
+  background: transparent;
+}
+.btn--danger:hover {
+  background: rgba(229, 83, 75, 0.1);
+  border-color: #e5534b;
 }
 
 /* ── settings drawer ───────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Add a selection mode to the HistoryPanel that lets users select multiple sessions and delete them in one action. The active session is never selectable.

## Changes

### Backend (`desktop/app.go`)
- Add `DeleteSessions(paths []string) (int, error)` method that batch-deletes sessions, skips the active one, returns count of deleted sessions

### Frontend
- **HistoryPanel**: Selection mode with checkboxes, select-all toggle, batch delete button with two-step confirmation
- **Bridge**: `DeleteSessions` binding + browser mock
- **Controller**: `deleteSessions` callback
- **i18n**: 6 new keys in en.ts and zh.ts
- **CSS**: Styles for checkboxes, selected highlight, footer action bar, button variants

## UX

1. Click **Select** in the drawer header → checkboxes appear on each row
2. Toggle individual sessions or **Select all**
3. Click **Delete selected (N)** → confirmation prompt → batch delete
4. Click **Done** to exit selection mode