### PR TITLE
chore(npm): publish v2 (1.x) under `next`, keep 0.x as latest

### DIFF
--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -98,7 +98,11 @@ if (!publish) {
   process.exit(0);
 }
 
-const distTag = version.includes("-") ? "next" : "latest";
+// Only the v0.x stable line is the promoted default (`latest`). The v2 (1.x) line
+// and every prerelease ship under `next` so a bare `npm i reasonix` keeps resolving
+// 0.53.x; opt in with `npm i reasonix@next`. (npm rejects `v2` as a tag — it parses
+// as a SemVer range.) Promote v2 with a manual `npm dist-tag add reasonix@<ver> latest`.
+const distTag = version.startsWith("0.") && !version.includes("-") ? "latest" : "next";
 const publishArgs = ["publish", "--access", "public", "--tag", distTag];
 
 for (const sub of subPackages) {


### PR DESCRIPTION
Keeps `npm i reasonix` on the v0.x line until v2 is ready to be promoted.

## Problem
`npm/build.mjs` published every stable release with `--tag latest`, so each v2 (1.x) release re-claims the `latest` dist-tag — upgrading bare `npm i reasonix` users off the proven 0.53.x line, and stealing `latest` back even after it's moved manually.

## Fix
Only **0.x stable** publishes to `latest`; the **1.x line and all prereleases** go to **`next`**:

```js
const distTag = version.startsWith("0.") && !version.includes("-") ? "latest" : "next";
```

| version | tag |
|---|---|
| 0.53.2 / 0.54.2 | latest |
| 1.0.0 / 1.0.1 / 1.0.0-rc1 | next |

`npm i reasonix` → 0.53.x; `npm i reasonix@next` (or `@1.0.0`) → v2. (npm rejects `v2` as a tag name — it parses as a SemVer range — so `next` is the opt-in channel.) Promoting v2 to the default stays a deliberate `npm dist-tag add reasonix@<ver> latest`.

The live dist-tags have already been set to match: `latest: 0.53.2`, `next: 1.0.0`.

`node --check` passes; tag derivation verified across sample versions.
