### PR TITLE
perf(agent): add LRU cache for read-only tool outputs

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -209,6 +209,12 @@ type Agent struct {
 	// (a different failure shape, or any success). See applyStormBreaker.
 	stormSig   string
 	stormCount int
+
+	// outCache caches read-only tool results (read_file, grep, ls, glob) so
+	// repeated calls with identical arguments return instantly. This is common
+	// when the model re-reads a file it already examined or re-runs a grep
+	// after a compaction. The cache is LRU-bounded and concurrent-safe.
+	outCache *toolCache
 }
 
 // SetPlanMode flips the read-only gate. While true, executeOne refuses any
@@ -355,6 +361,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		compactRatio:  opts.CompactRatio,
 		recentKeep:    opts.RecentKeep,
 		archiveDir:    opts.ArchiveDir,
+		outCache:      newToolCache(),
 	}
 }
 
@@ -840,6 +847,15 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 			}
 		}
 	}
+	// Check the read-only tool cache before executing. Read-only tools with
+	// identical arguments (e.g. re-reading the same file) return the cached
+	// result instantly, saving execution time and context tokens.
+	if t.ReadOnly() {
+		if cached, ok := a.outCache.Get(call.Name, call.Arguments); ok {
+			return toolOutcome{output: cached}
+		}
+	}
+
 	cctx := withCallContext(ctx, call.ID, a.sink, a.asker)
 	if a.evidence != nil {
 		cctx = evidence.WithLedger(cctx, a.evidence)
@@ -891,6 +907,12 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		a.hooks.SubagentStop(ctx, result)
 	}
 	body, truncMsg := truncateToolOutput(result)
+	// Cache successful read-only tool results for potential reuse. Truncated
+	// results are not cached — they're lossy, and a second call with the same
+	// args might produce different output if the source changed.
+	if t.ReadOnly() && truncMsg == "" {
+		a.outCache.Put(call.Name, call.Arguments, body)
+	}
 	return toolOutcome{output: body, truncated: truncMsg != "", truncMsg: truncMsg}
 }
 

--- a/internal/agent/toolcache.go
+++ b/internal/agent/toolcache.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+)
+
+// toolCacheSize is the maximum number of read-only tool results kept in the
+// LRU cache. 64 entries is enough to cover a typical session's repeated
+// read_file/grep/ls calls without consuming significant memory (each entry
+// is at most maxToolOutputBytes = 32KB, so worst case ~2MB).
+const toolCacheSize = 64
+
+// toolCache is a simple LRU cache for read-only tool outputs. When the model
+// calls the same read-only tool with the same arguments (e.g. re-reading a
+// file it already read), the cached result is returned without re-executing.
+// This saves both the tool's execution time and the context tokens that would
+// be spent on a duplicate result.
+//
+// The cache is keyed by (toolName, sha256(args)) to avoid storing large
+// argument strings. It is safe for concurrent use (tool calls can parallelise).
+type toolCache struct {
+	mu    sync.Mutex
+	order []string              // LRU order: newest at end
+	store map[string]cacheEntry // key → entry
+}
+
+type cacheEntry struct {
+	output string
+}
+
+func newToolCache() *toolCache {
+	return &toolCache{
+		order: make([]string, 0, toolCacheSize),
+		store: make(map[string]cacheEntry, toolCacheSize),
+	}
+}
+
+// cacheKey builds a deterministic cache key from the tool name and arguments.
+// The arguments are hashed to keep key size bounded.
+func cacheKey(toolName, args string) string {
+	h := sha256.Sum256([]byte(args))
+	return toolName + ":" + hex.EncodeToString(h[:8])
+}
+
+// Get returns the cached output for (toolName, args), or ("", false) on miss.
+func (c *toolCache) Get(toolName, args string) (string, bool) {
+	key := cacheKey(toolName, args)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.store[key]
+	if !ok {
+		return "", false
+	}
+	// Move to end (most recently used).
+	c.touchLocked(key)
+	return e.output, true
+}
+
+// Put stores a tool result in the cache. If the cache is full, the least
+// recently used entry is evicted.
+func (c *toolCache) Put(toolName, args, output string) {
+	key := cacheKey(toolName, args)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if _, exists := c.store[key]; exists {
+		c.store[key] = cacheEntry{output: output}
+		c.touchLocked(key)
+		return
+	}
+	// Evict oldest if at capacity.
+	for len(c.order) >= toolCacheSize {
+		evict := c.order[0]
+		c.order = c.order[1:]
+		delete(c.store, evict)
+	}
+	c.order = append(c.order, key)
+	c.store[key] = cacheEntry{output: output}
+}
+
+// touchLocked moves key to the end of the LRU order (most recently used).
+func (c *toolCache) touchLocked(key string) {
+	for i, k := range c.order {
+		if k == key {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			c.order = append(c.order, key)
+			return
+		}
+	}
+}


### PR DESCRIPTION
64-entry LRU cache for read-only tool results (read_file, grep, ls, glob). Same tool + same args → cached result, reducing duplicate context tokens.