### PR TITLE
perf(providers): pool request body buffers via sync.Pool

### DIFF
--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 
 	"reasonix/internal/netclient"
 	"reasonix/internal/provider"
@@ -96,11 +97,22 @@ type client struct {
 
 func (c *client) Name() string { return c.name }
 
+// bufPool reuses byte buffers for JSON-marshalled request bodies, reducing GC
+// churn from repeated alloc/free of ~10-100KB buffers per turn.
+var bufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
 func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
-	body, err := json.Marshal(c.buildRequest(req))
-	if err != nil {
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	if err := json.NewEncoder(buf).Encode(c.buildRequest(req)); err != nil {
+		bufPool.Put(buf)
 		return nil, fmt.Errorf("%s: marshal request: %w", c.name, err)
 	}
+	body := make([]byte, buf.Len())
+	copy(body, buf.Bytes())
+	bufPool.Put(buf)
 
 	newReq := func(ctx context.Context) (*http.Request, error) {
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/messages", bytes.NewReader(body))

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/netclient"
@@ -108,11 +109,24 @@ func isDeepSeekBaseURL(baseURL string) bool {
 	return host == "api.deepseek.com" || strings.HasSuffix(host, ".deepseek.com")
 }
 
+// bufPool reuses byte buffers for JSON-marshalled request bodies. Each turn
+// allocates a buffer, marshals the request, and sends it — pooling avoids the
+// GC churn from repeated alloc/free of ~10-100KB buffers. The pool is
+// provider-level (not global) so OpenAI and Anthropic don't compete.
+var bufPool = sync.Pool{
+	New: func() any { return new(bytes.Buffer) },
+}
+
 func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provider.Chunk, error) {
-	body, err := json.Marshal(c.buildRequest(req))
-	if err != nil {
+	buf := bufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	if err := json.NewEncoder(buf).Encode(c.buildRequest(req)); err != nil {
+		bufPool.Put(buf)
 		return nil, fmt.Errorf("%s: marshal request: %w", c.name, err)
 	}
+	body := make([]byte, buf.Len())
+	copy(body, buf.Bytes())
+	bufPool.Put(buf)
 
 	newReq := func(ctx context.Context) (*http.Request, error) {
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/chat/completions", bytes.NewReader(body))


### PR DESCRIPTION
Reuse byte buffers across API calls via sync.Pool, reducing GC pressure from repeated alloc/free of ~10-100KB buffers per turn.