### PR TITLE
feat(site): dual-track landing — stable v0.53 default, v1.0.0 preview

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/Base.astro';
 const R2 = 'https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest';
 const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
+const DT053 = `${repo}/releases/download/desktop-v0.53.0`;
 ---
 <Base
   title="Reasonix — DeepSeek-native coding agent for your terminal"
@@ -25,14 +26,14 @@ const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
 
   <a id="top"></a>
   <header class="hero wrap">
-    <div class="kicker"><span class="dot"></span><span data-en>v1.0.0 — a ground-up rewrite in Go · MIT</span><span data-zh>v1.0.0 — Go 全新重写 · MIT</span></div>
+    <div class="kicker"><span class="dot"></span><span data-en>Stable v0.53 on npm · v1.0.0 Go rewrite — preview · MIT</span><span data-zh>npm 稳定版 v0.53 · v1.0.0 Go 重写(预览)· MIT</span></div>
     <h1>
       <span data-en>A <em>DeepSeek</em>-native agent for your terminal.</span>
       <span data-zh><em>DeepSeek</em> 原生的终端编码 Agent。</span>
     </h1>
     <p class="lede">
-      <span data-en>The loop is append-only, aligned to DeepSeek's byte-stable prefix cache — so long sessions hold <b>90%+ cache hit</b> and input-token cost collapses to <b>~1/5</b>. One Go binary. Terminal-first.</span>
-      <span data-zh>运行循环 append-only,对齐 DeepSeek 字节稳定的 prefix-cache —— 长会话缓存命中 <b>90%+</b>,输入 token 成本降到 <b>约 1/5</b>。单个 Go 二进制,终端优先。</span>
+      <span data-en>The loop is append-only, aligned to DeepSeek's byte-stable prefix cache — so long sessions hold <b>90%+ cache hit</b> and input-token cost collapses to <b>~1/5</b>. Terminal-first.</span>
+      <span data-zh>运行循环 append-only,对齐 DeepSeek 字节稳定的 prefix-cache —— 长会话缓存命中 <b>90%+</b>,输入 token 成本降到 <b>约 1/5</b>。终端优先。</span>
     </p>
     <div class="hi">
       <div class="hi-tabs">
@@ -41,15 +42,49 @@ const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
         <button class="htab" data-h="dl"><span data-en>Download</span><span data-zh>下载</span></button>
       </div>
       <div class="hi-body">
-        <div class="hpanel on" data-h="npm"><span class="hcmd"><span class="p">$ </span>npm i -g reasonix</span><button class="cp" data-copy="npm i -g reasonix"><span data-en>Copy</span><span data-zh>复制</span></button></div>
-        <div class="hpanel" data-h="brew"><span class="hcmd"><span class="p">$ </span>brew install esengine/reasonix/reasonix</span><button class="cp" data-copy="brew install esengine/reasonix/reasonix"><span data-en>Copy</span><span data-zh>复制</span></button></div>
+        <div class="hpanel on" data-h="npm">
+          <div class="cmdgroup">
+            <div class="cmdtag ok">latest · v0.53</div>
+            <div class="cmdrow"><span class="hcmd"><span class="p">$ </span>npm i -g reasonix</span><button class="cp" data-copy="npm i -g reasonix"><span data-en>Copy</span><span data-zh>复制</span></button></div>
+            <div class="cmdrow"><span class="hcmd"><span class="p">$ </span>reasonix code</span><button class="cp" data-copy="reasonix code"><span data-en>Copy</span><span data-zh>复制</span></button></div>
+          </div>
+          <div class="cmdgroup">
+            <div class="cmdtag pre">next · v1.0.0</div>
+            <div class="cmdrow"><span class="hcmd"><span class="p">$ </span>npm i -g reasonix@next</span><button class="cp" data-copy="npm i -g reasonix@next"><span data-en>Copy</span><span data-zh>复制</span></button></div>
+            <div class="cmdrow"><span class="hcmd"><span class="p">$ </span>reasonix</span><button class="cp" data-copy="reasonix"><span data-en>Copy</span><span data-zh>复制</span></button></div>
+          </div>
+        </div>
+        <div class="hpanel" data-h="brew">
+          <div class="cmdgroup">
+            <div class="cmdtag pre"><span data-en>v1.0.0 only</span><span data-zh>仅 v1.0.0</span></div>
+            <div class="cmdrow"><span class="hcmd"><span class="p">$ </span>brew install esengine/reasonix/reasonix</span><button class="cp" data-copy="brew install esengine/reasonix/reasonix"><span data-en>Copy</span><span data-zh>复制</span></button></div>
+            <div class="cmdrow"><span class="hcmd"><span class="p">$ </span>reasonix</span><button class="cp" data-copy="reasonix"><span data-en>Copy</span><span data-zh>复制</span></button></div>
+          </div>
+        </div>
         <div class="hpanel" data-h="dl">
-          <a class="hdl" href={`${R2}/Reasonix-darwin-arm64.zip`} download>macOS</a>
-          <a class="hdl" href={`${R2}/Reasonix-windows-amd64-installer.exe`} download>Windows</a>
-          <a class="hdl" href={`${R2}/Reasonix-linux-amd64.tar.gz`} download>Linux</a>
+          <div class="dlgroup">
+            <div class="dllabel"><span class="dot ok"></span><span data-en>Stable · v0.53</span><span data-zh>稳定版 · v0.53</span></div>
+            <div class="dlrow">
+              <a class="hdl" href={`${DT053}/Reasonix_0.53.0_universal.dmg`}>macOS</a>
+              <a class="hdl" href={`${DT053}/Reasonix_0.53.0_x64-setup.exe`}>Windows</a>
+              <a class="hdl" href={`${DT053}/Reasonix_0.53.0_amd64.AppImage`}>Linux</a>
+            </div>
+          </div>
+          <div class="dlgroup">
+            <div class="dllabel"><span class="dot pre"></span><span data-en>v1.0.0 · Go rewrite — preview</span><span data-zh>v1.0.0 · Go 重写(预览)</span></div>
+            <div class="dlrow">
+              <a class="hdl" href={`${R2}/Reasonix-darwin-arm64.zip`} download>macOS</a>
+              <a class="hdl" href={`${R2}/Reasonix-windows-amd64-installer.exe`} download>Windows</a>
+              <a class="hdl" href={`${R2}/Reasonix-linux-amd64.tar.gz`} download>Linux</a>
+            </div>
+          </div>
         </div>
       </div>
     </div>
+    <p class="hnote">
+      <span data-en><b>v0.53</b> — the stable line, runs on Node. <b>v1.0.0</b> — the Go rewrite, one binary, no Node, in preview. <a href={`${repo}/releases/tag/v1.0.0`}>v1.0.0 release notes →</a></span>
+      <span data-zh><b>v0.53</b> —— 稳定线,基于 Node。<b>v1.0.0</b> —— Go 重写、单二进制、无需 Node,预览中。<a href={`${repo}/releases/tag/v1.0.0`}>v1.0.0 更新说明 →</a></span>
+    </p>
     <a class="ghlink" href={repo}><span data-en>★ Star on GitHub</span><span data-zh>★ 在 GitHub 点星</span></a>
 
     <div class="term" id="term">

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -80,10 +80,28 @@ h1 em{font-style:italic;font-family:var(--serif);font-weight:500;color:var(--acc
 .hi .cp{background:var(--ink);border-color:var(--ink);color:#fff;font-weight:500;padding:9px 16px;font-size:13px}
 .hi .cp:hover{background:#000}
 .hi .cp.ok{background:var(--ok);border-color:var(--ok);color:#fff}
-.hpanel[data-h="dl"].on{gap:8px}
+.hpanel[data-h="dl"].on{flex-direction:column;align-items:stretch;gap:14px}
+.dlgroup{display:flex;flex-direction:column;gap:8px}
+.dllabel{display:flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11.5px;letter-spacing:.02em;color:var(--muted);text-align:left}
+.dllabel .dot{width:6px;height:6px;border-radius:50%}
+.dllabel .dot.ok{background:var(--ok)}
+.dllabel .dot.pre{background:var(--accent)}
+.dlrow{display:flex;gap:8px}
+.hpanel[data-h="npm"].on,.hpanel[data-h="brew"].on{flex-direction:column;align-items:stretch;gap:16px}
+.cmdgroup{display:flex;flex-direction:column;gap:8px}
+.cmdrow{display:flex;align-items:center;gap:10px;min-width:0}
+.cmdrow .hcmd{flex:1}
+.cmdtag{align-self:flex-start;font-family:var(--mono);font-size:10.5px;font-weight:600;letter-spacing:.02em;padding:3px 9px;border-radius:999px;white-space:nowrap}
+.cmdtag.ok{color:var(--ok);background:rgba(28,154,99,.1)}
+.cmdtag.pre{color:var(--accent);background:var(--accent-soft)}
 .hdl{flex:1;text-align:center;font-size:13.5px;font-weight:600;color:var(--ink);background:var(--bg);
   border:1px solid var(--line-2);border-radius:10px;padding:12px 8px;transition:.15s}
 .hdl:hover{border-color:var(--ink);background:#fff}
+.hnote{margin:16px auto 0;max-width:600px;font-size:13px;line-height:1.65;color:var(--muted)}
+.hnote b{color:var(--ink);font-weight:600}
+.hnote code{font-family:var(--mono);font-size:12px;color:var(--ink);background:var(--bg);border:1px solid var(--line);border-radius:6px;padding:1px 6px}
+.hnote a{color:var(--ink);font-weight:600;text-decoration:none;border-bottom:1px solid var(--line-2)}
+.hnote a:hover{border-color:var(--ink)}
 .ghlink{display:inline-block;margin-top:22px;color:var(--muted);font-size:14.5px;transition:.15s}
 .ghlink:hover{color:var(--ink)}
 


### PR DESCRIPTION
Aligns Reasonix.app with the new npm dist-tags (`latest` → v0.53, `next` → 1.0.0).

## Why
npm `latest` now resolves to the stable v0.53 line, but the homepage still presented v1.0.0 as the default — and `npm i -g reasonix` (which now installs v0.53, a Node CLI) sat under a "single Go binary, no Node" pitch. This makes the two tracks explicit.

## Changes (`site/src/pages/index.astro` + `global.css`)
- **Install widget**
  - **npm**: two labelled groups — 🟢 `latest · v0.53` (`npm i -g reasonix` → run `reasonix code`) and 🔵 `next · v1.0.0` (`npm i -g reasonix@next` → run `reasonix`). The v0.53 CLI needs the `code` subcommand; v1.0.0 doesn't.
  - **Homebrew**: tagged 🔵 `v1.0.0 only` (the tap ships the Go build).
  - **Download**: 🟢 stable v0.53 desktop (the `desktop-v0.53.0` Tauri builds — dmg / x64-setup.exe / AppImage) and 🔵 v1.0.0 desktop (the Wails R2 builds).
- **Kicker** + a one-line note: v0.53 = stable (Node), v1.0.0 = the Go rewrite (one binary, no Node) in preview, linking the v1.0.0 release notes. Dropped the lede's "One Go binary" claim (it described v1.0.0, not the default).

Built locally with `astro build`; reviewed in `astro dev`.

Deploys to Reasonix.app via `pages.yml` on merge.
