### PR TITLE
fix(cli): show fractional K in compact token counts

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1792,13 +1792,13 @@ func (m chatTUI) effortTag() string {
 	return dim(body)
 }
 
-// shortTokens prints token counts compactly: 142_000 → "142K", 1_000_000 → "1M".
+// shortTokens prints token counts compactly: 1_500 → "1.5K", 142_000 → "142.0K", 1_000_000 → "1.0M".
 func shortTokens(n int) string {
 	switch {
-	case n >= 1_000_000:
+	case n >= 999_950:
 		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
 	case n >= 1_000:
-		return fmt.Sprintf("%dK", n/1_000)
+		return fmt.Sprintf("%.1fK", float64(n)/1_000)
 	default:
 		return fmt.Sprintf("%d", n)
 	}

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -863,5 +864,31 @@ func TestAgentEventCoalescesBurst(t *testing.T) {
 	}
 	if len(m.eventCh) != 0 {
 		t.Errorf("channel should be fully drained, %d left", len(m.eventCh))
+	}
+}
+
+func TestShortTokens(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1.0K"},
+		{1500, "1.5K"},
+		{1999, "2.0K"},
+		{9999, "10.0K"},
+		{142000, "142.0K"},
+		{999999, "1.0M"},
+		{1000000, "1.0M"},
+		{1500000, "1.5M"},
+	}
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("n=%d", tc.n), func(t *testing.T) {
+			got := shortTokens(tc.n)
+			if got != tc.want {
+				t.Errorf("shortTokens(%d) = %q, want %q", tc.n, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

`shortTokens` (the status-panel token counter) used integer division for the
thousands branch, truncating the fractional part — and its doc comment
disagreed with the actual output.

```go
case n >= 1_000:
    return fmt.Sprintf("%dK", n/1_000)   // 1_999 → "1K", 9_999 → "9K"
```

The millions branch already used `%.1f`, so the format was inconsistent:
`1_500_000` correctly showed `1.5M`, but `1_500` wrongly showed `1K`. The doc
comment also promised `1_000_000 → "1M"` while the code produced `"1.0M"`.

## Before / After

| tokens  | before | after    |
|---------|--------|----------|
| 1_500   | `1K`   | `1.5K`   |
| 1_999   | `1K`   | `2.0K`   |
| 9_999   | `9K`   | `10.0K`  |
| 142_000 | `142K` | `142.0K` |
| 999_999 | `999K` | `1.0M`   |

This counter is shown in the live `… ctx (N%)` / `↓<tokens>` status, so the
truncation under-reported usage by up to ~49%.

## Fix

- Use `%.1fK` to match the millions branch.
- Lower the M threshold to `999_950` so values that round to `1.0M`
  (e.g. `999_999`) render as `1.0M` instead of `1000.0K`.
- Update the doc comment to match real output.
- Add table-driven `TestShortTokens` (was 0% coverage) covering the sub-K,
  fractional-K, and M-rounding boundaries.

## Verification

`go test ./internal/cli/`, `go build ./...`, `go vet ./internal/cli/`, and
`gofmt -l` all clean.
