### PR TITLE
Preserve file encoding during checkpoint restore

### DIFF
--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -22,13 +22,15 @@ import (
 	"time"
 
 	"reasonix/internal/diff"
+	fileenc "reasonix/internal/fileutil/encoding"
 )
 
 // FileSnap is one file's state at the moment it was first touched in a turn.
 // Content == nil means the file did not exist then, so a restore deletes it.
 type FileSnap struct {
-	Path    string  `json:"path"`
-	Content *string `json:"content"`
+	Path     string        `json:"path"`
+	Content  *string       `json:"content"`
+	Encoding *fileenc.Kind `json:"encoding,omitempty"`
 }
 
 // Checkpoint anchors the pre-edit state of every distinct file touched during one
@@ -132,9 +134,17 @@ func (s *Store) Bounds() map[int]int {
 // Only the first touch of a path in the current turn is kept (that is its
 // turn-start content). A no-op before the first Begin.
 func (s *Store) Snapshot(ch diff.Change) {
+	if ch.Path == "" {
+		return
+	}
+	var enc *fileenc.Kind
+	if ch.Kind != diff.Create {
+		enc = s.detectEncoding(ch.Path)
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.cur == nil || ch.Path == "" || s.seen[ch.Path] {
+	if s.cur == nil || s.seen[ch.Path] {
 		return
 	}
 	s.seen[ch.Path] = true
@@ -143,8 +153,21 @@ func (s *Store) Snapshot(ch diff.Change) {
 		old := ch.OldText
 		content = &old
 	}
-	s.cur.Files = append(s.cur.Files, FileSnap{Path: ch.Path, Content: content})
+	s.cur.Files = append(s.cur.Files, FileSnap{Path: ch.Path, Content: content, Encoding: enc})
 	s.persist(s.cur)
+}
+
+func (s *Store) detectEncoding(p string) *fileenc.Kind {
+	abs, err := safePath(s.root, p)
+	if err != nil {
+		return nil
+	}
+	b, err := os.ReadFile(abs)
+	if err != nil {
+		return nil
+	}
+	enc, _ := fileenc.Detect(b)
+	return &enc
 }
 
 func (s *Store) persist(c *Checkpoint) {
@@ -210,7 +233,7 @@ func (s *Store) all() []*Checkpoint {
 func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error) {
 	s.mu.Lock()
 	// earliest snapshot per path across checkpoints >= fromTurn (turn order → first wins).
-	earliest := map[string]*string{}
+	earliest := map[string]FileSnap{}
 	order := []string{}
 	for _, c := range s.all() {
 		if c.Turn < fromTurn {
@@ -220,7 +243,7 @@ func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error)
 			if _, ok := earliest[f.Path]; ok {
 				continue
 			}
-			earliest[f.Path] = f.Content
+			earliest[f.Path] = f
 			order = append(order, f.Path)
 		}
 	}
@@ -233,8 +256,8 @@ func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error)
 			err = gerr
 			continue
 		}
-		content := earliest[p]
-		if content == nil {
+		snap := earliest[p]
+		if snap.Content == nil {
 			if rmErr := os.Remove(abs); rmErr == nil {
 				deleted = append(deleted, p)
 			} else if !os.IsNotExist(rmErr) {
@@ -246,13 +269,28 @@ func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error)
 			err = mkErr
 			continue
 		}
-		if wErr := os.WriteFile(abs, []byte(*content), 0o644); wErr != nil {
+		enc := fileenc.UTF8
+		if snap.Encoding != nil {
+			enc = *snap.Encoding
+		} else if current := detectCurrentEncoding(abs); current != nil {
+			enc = *current
+		}
+		if wErr := os.WriteFile(abs, fileenc.Encode(*snap.Content, enc), 0o644); wErr != nil {
 			err = wErr
 			continue
 		}
 		written = append(written, p)
 	}
 	return written, deleted, err
+}
+
+func detectCurrentEncoding(path string) *fileenc.Kind {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	enc, _ := fileenc.Detect(b)
+	return &enc
 }
 
 // safePath resolves p against root and rejects anything escaping it — restore

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -1,11 +1,17 @@
 package checkpoint
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+	"unicode/utf8"
 
 	"reasonix/internal/diff"
+	fileenc "reasonix/internal/fileutil/encoding"
 )
 
 func write(t *testing.T, p, s string) {
@@ -24,6 +30,14 @@ func read(t *testing.T, p string) string {
 		t.Fatal(err)
 	}
 	return string(b)
+}
+func readBytes(t *testing.T, p string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
 }
 
 // Two turns edit a.txt and create b.txt; rewinding restores each file to its
@@ -74,6 +88,103 @@ func TestRestoreToTurnZero(t *testing.T) {
 	}
 	if got := read(t, a); got != "v0" {
 		t.Fatalf("a = %q, want v0 (earliest snapshot)", got)
+	}
+}
+
+func TestRestorePreservesGB18030Encoding(t *testing.T) {
+	root := t.TempDir()
+	a := filepath.Join(root, "gbk.txt")
+	original := "\u4f60\u597d\n\u65e7\u884c\n"
+	edited := "\u4f60\u597d\n\u65b0\u884c\n"
+	originalRaw := fileenc.Encode(original, fileenc.GB18030)
+	if err := os.WriteFile(a, originalRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New("", root)
+	s.Begin(0, "edit gbk", 0)
+	s.Snapshot(diff.Change{Path: a, Kind: diff.Modify, OldText: original})
+	if err := os.WriteFile(a, fileenc.Encode(edited, fileenc.GB18030), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := s.RestoreCode(0); err != nil {
+		t.Fatal(err)
+	}
+	gotRaw := readBytes(t, a)
+	if utf8.Valid(gotRaw) {
+		t.Fatalf("restored GB18030 file became valid UTF-8 bytes: % x", gotRaw)
+	}
+	if !bytes.Equal(gotRaw, originalRaw) {
+		t.Fatalf("restored bytes = % x, want original GB18030 bytes % x", gotRaw, originalRaw)
+	}
+}
+
+func TestRestorePreservesGB18030EncodingAfterPersistence(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(t.TempDir(), "sess.ckpt")
+	a := filepath.Join(root, "gbk.txt")
+	original := "\u4f60\u597d\n\u65e7\u884c\n"
+	edited := "\u4f60\u597d\n\u65b0\u884c\n"
+	originalRaw := fileenc.Encode(original, fileenc.GB18030)
+	if err := os.WriteFile(a, originalRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(dir, root)
+	s.Begin(0, "edit gbk", 0)
+	s.Snapshot(diff.Change{Path: a, Kind: diff.Modify, OldText: original})
+
+	resumed := New(dir, root)
+	if err := os.WriteFile(a, fileenc.Encode(edited, fileenc.GB18030), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := resumed.RestoreCode(0); err != nil {
+		t.Fatal(err)
+	}
+	if gotRaw := readBytes(t, a); !bytes.Equal(gotRaw, originalRaw) {
+		t.Fatalf("restored bytes after persistence = % x, want original GB18030 bytes % x", gotRaw, originalRaw)
+	}
+}
+
+func TestRestoreLegacySnapshotFallsBackToCurrentEncoding(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(t.TempDir(), "sess.ckpt")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	a := filepath.Join(root, "gbk.txt")
+	original := "\u4f60\u597d\n\u65e7\u884c\n"
+	edited := "\u4f60\u597d\n\u65b0\u884c\n"
+	originalRaw := fileenc.Encode(original, fileenc.GB18030)
+	if err := os.WriteFile(a, fileenc.Encode(edited, fileenc.GB18030), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	legacy := Checkpoint{
+		Turn:     0,
+		Time:     time.Now(),
+		Prompt:   "legacy",
+		MsgIndex: 0,
+		Files: []FileSnap{{
+			Path:    a,
+			Content: &original,
+		}},
+	}
+	b, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "turn-0.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	resumed := New(dir, root)
+	if _, _, err := resumed.RestoreCode(0); err != nil {
+		t.Fatal(err)
+	}
+	if gotRaw := readBytes(t, a); !bytes.Equal(gotRaw, originalRaw) {
+		t.Fatalf("legacy restored bytes = % x, want original GB18030 bytes % x", gotRaw, originalRaw)
 	}
 }
 
@@ -135,5 +246,33 @@ func TestPersistenceRoundTrip(t *testing.T) {
 	}
 	if s2.NextTurn() != 2 {
 		t.Fatalf("NextTurn = %d, want 2", s2.NextTurn())
+	}
+}
+
+func BenchmarkRestoreGB18030Encoding(b *testing.B) {
+	root := b.TempDir()
+	a := filepath.Join(root, "gbk.txt")
+	original := strings.Repeat("\u4f60\u597d\u4e16\u754c\n\u65e7\u884c\n", 8192)
+	edited := strings.Repeat("\u4f60\u597d\u4e16\u754c\n\u65b0\u884c\n", 8192)
+	originalRaw := fileenc.Encode(original, fileenc.GB18030)
+	editedRaw := fileenc.Encode(edited, fileenc.GB18030)
+	if err := os.WriteFile(a, originalRaw, 0o644); err != nil {
+		b.Fatal(err)
+	}
+
+	s := New("", root)
+	s.Begin(0, "edit gbk", 0)
+	s.Snapshot(diff.Change{Path: a, Kind: diff.Modify, OldText: original})
+
+	b.SetBytes(int64(len(originalRaw)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := os.WriteFile(a, editedRaw, 0o644); err != nil {
+			b.Fatal(err)
+		}
+		if _, _, err := s.RestoreCode(0); err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #2964.

## Summary
- Record each checkpoint snapshot's original file encoding when a text file is captured.
- Re-encode restored checkpoint content back to that encoding instead of always writing UTF-8.
- Keep legacy checkpoint files compatible by falling back to the current on-disk encoding when old snapshots have no encoding metadata.

## Verification
- Reproduced the reported bug on current main-v2: GB18030 content restored as valid UTF-8 bytes before the fix.
- `D:\Go\go\bin\go.exe test ./internal/checkpoint -count=1 -v`
- `D:\Go\go\bin\go.exe test ./internal/checkpoint -run ^$ -bench BenchmarkRestoreGB18030Encoding -benchmem -count=3`
  - Windows amd64, i9-12900H: 0.876-0.891 ms/op, 128.78-130.81 MB/s, 16 allocs/op.
- `D:\Go\go\bin\go.exe test -count=1 ./...`
- `D:\Go\go\bin\go.exe vet ./...`
- Desktop module with isolated user config env: `D:\Go\go\bin\go.exe test -count=1 ./...`
- Desktop module with isolated user config env: `D:\Go\go\bin\go.exe vet ./...`