### PR TITLE
fix(cli): measure approval-banner subject by display width, not rune count

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1909,11 +1909,7 @@ func truncateSubject(s string, width int) string {
 	if max < 16 {
 		max = 16
 	}
-	r := []rune(s)
-	if len(r) > max {
-		return string(r[:max]) + "…"
-	}
-	return s
+	return ansi.Truncate(s, max, "…")
 }
 
 // clampStatusLine truncates a status line to `width` visible columns, ANSI-aware,

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -10,6 +10,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/mattn/go-runewidth"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
@@ -863,5 +864,31 @@ func TestAgentEventCoalescesBurst(t *testing.T) {
 	}
 	if len(m.eventCh) != 0 {
 		t.Errorf("channel should be fully drained, %d left", len(m.eventCh))
+	}
+}
+
+func TestTruncateSubject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		width int
+	}{
+		{"short ASCII", "rm file", 60},
+		{"long ASCII", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 60},
+		{"CJK at 60", "日本語の文章は通常、表示幅が広いため、端末の横幅を超えてしまうことがあります。", 60},
+		{"CJK at 30", "日本語の文章は通常、表示幅が広いため、端末の横幅を超えてしまうことがあります。", 30},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateSubject(tc.input, tc.width)
+			wantMax := tc.width - 28
+			if wantMax < 16 {
+				wantMax = 16
+			}
+			w := runewidth.StringWidth(got)
+			if w > wantMax {
+				t.Errorf("truncateSubject(%q, %d) = %q (width %d), want visible width <= %d", tc.input, tc.width, got, w, wantMax)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

`truncateSubject` trims a tool subject so the approval banner stays one line.
It sliced by **rune count**:

```go
r := []rune(s)
if len(r) > max {
    return string(r[:max]) + "…"
}
```

Wide CJK characters are 2 display columns each, so a subject of `max` CJK runes
renders ~`2*max` columns — overflowing the banner and wrapping to a second row.
That strands the input-box borders in scrollback, which is the exact failure the
neighbouring `clampStatusLine` documents and avoids with `ansi.Truncate`.

## Repro (measured)

For a 44-char CJK subject at banner width 60 (max ≈ 32 cols):

| | visible width |
|---|---|
| before | **65** (overflows, wraps) |
| after  | **31** (fits) |

ASCII is unaffected (32 vs 33 — same one-line result).

## Fix

Replace the rune-slicing body with `ansi.Truncate(s, max, "…")` — ANSI-aware,
counts display columns, and already used by `clampStatusLine` plus four other
call sites in this package. The `max := width - 28` floor-at-16 logic is kept.

Add `TestTruncateSubject` asserting the visible width stays within bounds for
ASCII and CJK at both the normal and floor widths. (Verified the test fails on
the old implementation and passes on the new one.)

## Verification

`go test ./internal/cli/`, `go build ./...`, `go vet ./internal/cli/`, and
`gofmt -l` all clean.
