### PR TITLE
feat(site): serve v0.53 desktop downloads from R2

### DIFF
--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,8 +1,9 @@
 ---
 import Base from '../layouts/Base.astro';
-const R2 = 'https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest';
+const R2BASE = 'https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev';
+const R2 = `${R2BASE}/latest`;
 const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
-const DT053 = `${repo}/releases/download/desktop-v0.53.0`;
+const DT053 = `${R2BASE}/desktop-v0.53.0`;
 ---
 <Base
   title="Reasonix — DeepSeek-native coding agent for your terminal"


### PR DESCRIPTION
Follow-up to #2962: the stable-track (v0.53) desktop links pointed at GitHub release URLs while everything else used the R2 CDN. Point them at R2 too (`/desktop-v0.53.0/` — verified the dmg/setup.exe/AppImage all return 200), so all six downloads share one fast origin. Frontmatter-only change; `astro build` passes.