### PR TITLE
fix(cli): validate prune-sessions --days as a real positive integer

### DIFF
--- a/src/cli/commands/prune-sessions.ts
+++ b/src/cli/commands/prune-sessions.ts
@@ -8,7 +8,7 @@ export interface PruneSessionsOptions {
 
 export function pruneSessionsCommand(opts: PruneSessionsOptions): void {
   const days = opts.days ?? 90;
-  if (!Number.isFinite(days) || days < 1) {
+  if (!Number.isInteger(days) || days < 1) {
     console.error(t("sessions.daysInvalid", { days }));
     process.exit(1);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -509,7 +509,7 @@ program
 program
   .command("prune-sessions")
   .description(t("cli.pruneSessions"))
-  .option("--days <n>", t("ui.pruneDaysHint"), (v) => Number.parseInt(v, 10))
+  .option("--days <n>", t("ui.pruneDaysHint"), (v) => Number(v))
   .option("--dry-run", t("ui.pruneDryRunHint"))
   .action(async (opts) => {
     const { pruneSessionsCommand } = await import("./commands/prune-sessions.js");

--- a/tests/prune-days-validation.test.ts
+++ b/tests/prune-days-validation.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { pruneSessionsCommand } from "../src/cli/commands/prune-sessions.js";
+import * as sessionModule from "../src/memory/session.js";
+
+// Replicated coercer from src/cli/index.ts
+const coerceDays = (v: string) => Number(v);
+
+// Replicated guard check from src/cli/commands/prune-sessions.ts
+const isValidDays = (days: any) => Number.isInteger(days) && days >= 1;
+
+describe("prune-sessions --days validation", () => {
+  describe("replicated logic", () => {
+    it("should reject 1.5", () => {
+      const parsed = coerceDays("1.5");
+      expect(parsed).toBe(1.5);
+      expect(isValidDays(parsed)).toBe(false);
+    });
+
+    it("should accept 1e2 and yield 100", () => {
+      const parsed = coerceDays("1e2");
+      expect(parsed).toBe(100);
+      expect(isValidDays(parsed)).toBe(true);
+    });
+
+    it("should reject abc", () => {
+      const parsed = coerceDays("abc");
+      expect(Number.isNaN(parsed)).toBe(true);
+      expect(isValidDays(parsed)).toBe(false);
+    });
+
+    it("should accept 5", () => {
+      const parsed = coerceDays("5");
+      expect(parsed).toBe(5);
+      expect(isValidDays(parsed)).toBe(true);
+    });
+  });
+
+  describe("pruneSessionsCommand integration", () => {
+    let exitSpy: any;
+    let errorSpy: any;
+
+    beforeEach(() => {
+      exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+        throw new Error("process.exit");
+      }) as any);
+      errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(sessionModule, "listSessions").mockReturnValue([]);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("errors and exits on 1.5", () => {
+      expect(() => pruneSessionsCommand({ days: coerceDays("1.5"), dryRun: true })).toThrow(
+        "process.exit",
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it("works (does not exit) on 1e2", () => {
+      pruneSessionsCommand({ days: coerceDays("1e2"), dryRun: true });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("errors and exits on abc", () => {
+      expect(() => pruneSessionsCommand({ days: coerceDays("abc"), dryRun: true })).toThrow(
+        "process.exit",
+      );
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errorSpy).toHaveBeenCalled();
+    });
+
+    it("works (does not exit) on 5", () => {
+      pruneSessionsCommand({ days: coerceDays("5"), dryRun: true });
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## What

`prune-sessions --days` coerced its value with `Number.parseInt(v, 10)`, which
silently truncates and accepts trailing garbage:

| input | parsed as | intended |
|-------|-----------|----------|
| `1.5` | `1` | reject |
| `3abc`| `3` | reject |
| `1e2` | `1` | **100** |

The last one is a data-loss trap: `--days 1e2` means "100 days" to a user but
prunes with a **1-day** cutoff, deleting almost every saved session. The guard
in `prune-sessions.ts` used `Number.isFinite` (not `isInteger`), and `parseInt`
had already coerced the value to an integer before the guard ran — so invalid
input slipped through despite the "must be a positive integer" error message.

## Fix

- Coerce with `Number(v)` so the real value reaches validation
  (`1.5`→`1.5`, `1e2`→`100`, `abc`→`NaN`).
- Tighten the guard to `Number.isInteger(days) || days < 1`.

Now `--days 1.5` and `--days abc` are rejected, `--days 1e2` correctly means
100, and the default of 90 still passes. (The port-number parser elsewhere in
`index.ts` already uses `Number.isInteger` — this aligns `--days` with it.)

## Test

`tests/prune-days-validation.test.ts` covers the coercer + guard and adds a
`pruneSessionsCommand` integration case asserting it `process.exit(1)`s on a
non-integer. Verified the integration test fails on the old code and passes on
the fix.

## Verification

`npx vitest run tests/prune-days-validation.test.ts` (8 passed); `biome check`
clean on the changed files.
