### PR TITLE
fix(lru): actually evict stale entries from TtlLruCache on lookup

### DIFF
--- a/src/core/lru.ts
+++ b/src/core/lru.ts
@@ -28,6 +28,10 @@ export class LruCache<K, V> {
   clear(): void {
     this.map.clear();
   }
+
+  delete(key: K): void {
+    this.map.delete(key);
+  }
 }
 
 /** LruCache with a per-entry TTL — a stale hit is treated as a miss and evicted. */
@@ -43,7 +47,10 @@ export class TtlLruCache<K, V> {
   get(key: K): V | undefined {
     const e = this.inner.get(key);
     if (!e) return undefined;
-    if (e.expiresAt <= Date.now()) return undefined;
+    if (e.expiresAt <= Date.now()) {
+      this.inner.delete(key);
+      return undefined;
+    }
     return e.v;
   }
 

--- a/tests/lru.test.ts
+++ b/tests/lru.test.ts
@@ -94,4 +94,26 @@ describe("TtlLruCache", () => {
     expect(c.get("b")).toBe(2);
     expect(c.get("c")).toBe(3);
   });
+
+  it("evicts a stale entry on lookup and prevents it from surviving eviction", () => {
+    const c = new TtlLruCache<string, number>(2, 1000);
+    c.set("a", 1);
+    c.set("b", 2);
+    vi.advanceTimersByTime(1500);
+
+    // Stale lookup on "a". Should return undefined and evict "a".
+    expect(c.get("a")).toBeUndefined();
+
+    // Verify "a" was actually evicted from the underlying cache store
+    expect((c as any).inner.get("a")).toBeUndefined();
+    expect((c as any).inner.size).toBe(1);
+
+    // Set new keys to verify correct eviction behavior
+    c.set("c", 3); // size becomes 2: {"b", "c"}
+    c.set("d", 4); // oldest ("b") gets evicted: {"c", "d"}
+
+    expect((c as any).inner.get("c")).not.toBeUndefined();
+    expect((c as any).inner.get("d")).not.toBeUndefined();
+    expect((c as any).inner.get("b")).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## What

`TtlLruCache` is documented as *"a stale hit is treated as a miss **and
evicted**"*, but `get()` didn't evict:

```ts
get(key: K): V | undefined {
  const e = this.inner.get(key);            // already promotes the entry to MRU
  if (!e) return undefined;
  if (e.expiresAt <= Date.now()) return undefined;  // miss — but entry stays
  return e.v;
}
```

Two problems for an expired key:
1. It is **never removed** — it lingers in the underlying map.
2. The preceding `this.inner.get(key)` has already re-inserted it as
   most-recently-used, so the stale entry *outlives* fresher ones during
   eviction.

`TtlLruCache` backs the gitignore cache and the directory-listing cache (both
5s TTL), which are hit on hot file-operation paths — so stale entries
accumulate and skew eviction under load.

## Fix

- Add a public `delete(key)` to `LruCache`.
- In `TtlLruCache.get`, call `this.inner.delete(key)` when the entry is expired
  before returning `undefined`, so it is evicted immediately as documented.

## Test

Appended a `TtlLruCache` case (fake timers): after the TTL elapses, a lookup
returns `undefined`, the key is gone from the underlying store, and it no longer
survives subsequent evictions. Verified it fails on the old code and passes on
the fix.

## Verification

`npx vitest run tests/lru.test.ts` (11 passed); `biome check` clean on the
changed files.
