### PR TITLE
fix(memory): scope import-cycle detection to the current path (diamonds aren't cycles)

### DIFF
--- a/internal/memory/doc.go
+++ b/internal/memory/doc.go
@@ -221,6 +221,7 @@ func resolveImports(body, baseDir string, seen map[string]bool, depth int) strin
 		}
 		seen[abs] = true
 		lines[i] = resolveImports(strings.TrimSpace(string(b)), filepath.Dir(path), seen, depth+1)
+		delete(seen, abs)
 	}
 	return strings.Join(lines, "\n")
 }

--- a/internal/memory/memory_test.go
+++ b/internal/memory/memory_test.go
@@ -138,3 +138,42 @@ func mustWrite(t *testing.T, path, body string) {
 		t.Fatal(err)
 	}
 }
+
+func TestImportDiamondAndCycle(t *testing.T) {
+	proj := t.TempDir()
+	mustMkdir(t, filepath.Join(proj, ".git"))
+
+	mustWrite(t, filepath.Join(proj, "shared.md"), "SHARED CONTENT")
+	mustWrite(t, filepath.Join(proj, "a.md"), "A\n@shared.md")
+	mustWrite(t, filepath.Join(proj, "b.md"), "B\n@shared.md")
+	mustWrite(t, filepath.Join(proj, "REASONIX.md"), "@a.md\n@b.md")
+
+	set := Load(Options{CWD: proj})
+	if len(set.Docs) != 1 {
+		t.Fatalf("want 1 doc, got %d", len(set.Docs))
+	}
+	body := set.Docs[0].Body
+
+	count := strings.Count(body, "SHARED CONTENT")
+	if count != 2 {
+		t.Errorf("expected 'SHARED CONTENT' to appear twice, got %d times. Body:\n%s", count, body)
+	}
+	if strings.Contains(body, "skipped: import cycle") {
+		t.Errorf("body contains incorrect import cycle message:\n%s", body)
+	}
+
+	projCycle := t.TempDir()
+	mustMkdir(t, filepath.Join(projCycle, ".git"))
+	mustWrite(t, filepath.Join(projCycle, "cycle1.md"), "CYCLE1\n@cycle2.md")
+	mustWrite(t, filepath.Join(projCycle, "cycle2.md"), "CYCLE2\n@cycle1.md")
+	mustWrite(t, filepath.Join(projCycle, "REASONIX.md"), "@cycle1.md")
+
+	setCycle := Load(Options{CWD: projCycle})
+	if len(setCycle.Docs) != 1 {
+		t.Fatalf("want 1 doc, got %d", len(setCycle.Docs))
+	}
+	bodyCycle := setCycle.Docs[0].Body
+	if !strings.Contains(bodyCycle, "skipped: import cycle") {
+		t.Errorf("expected import cycle to be detected and reported. Body:\n%s", bodyCycle)
+	}
+}


### PR DESCRIPTION
## What

`resolveImports` is documented as performing *"cycle detection via seen"*, but
`seen` is a single shared map that is marked (`seen[abs] = true`) and **never
un-marked**. A *diamond* import — two sibling files importing one common helper
— is a DAG, not a cycle, yet the second import was replaced with:

```
@shared.md  <!-- skipped: import cycle -->
```

and the helper's content was dropped. Real memory fragments shared between two
`REASONIX.md` includes silently vanish, with a misleading "cycle" message.

## Repro

```
REASONIX.md:  @a.md  @b.md
a.md:         @shared.md
b.md:         @shared.md
shared.md:    HELPER
```

Before: `HELPER` then `@shared.md  <!-- skipped: import cycle -->`.
After: `HELPER` twice.

## Fix

`delete(seen, abs)` after the recursive call returns, making it proper
path-scoped (DFS) cycle detection. An ancestor still on the current path is a
real cycle and is still caught; sibling branches can each import a common file.

## Test

`TestImportDiamondAndCycle` (via `Load`): the diamond inlines the helper twice
with no "cycle" comment, and a true `a → b → a` cycle is still detected and
labeled. Verified it fails on the old code and passes on the fix.

## Verification

`go test ./internal/memory/`, `go build ./...`, `go vet`, `gofmt -l` all clean.
