### PR TITLE
fix(proxy): handle IPv6 literals in NO_PROXY host parsing

### DIFF
--- a/src/net/proxy.ts
+++ b/src/net/proxy.ts
@@ -81,9 +81,22 @@ export function parseNoProxy(raw: string | null | undefined): NoProxyPattern[] {
 }
 
 function buildPattern(raw: string): NoProxyPattern {
-  // Strip optional :port — we route by host only.
-  const colon = raw.lastIndexOf(":");
-  const hostPart = colon !== -1 && /^\d+$/.test(raw.slice(colon + 1)) ? raw.slice(0, colon) : raw;
+  let hostPart = raw;
+  if (raw.startsWith("[")) {
+    const end = raw.indexOf("]");
+    if (end !== -1) {
+      hostPart = raw.slice(1, end);
+    }
+  } else {
+    const colons = raw.split(":").length - 1;
+    if (colons === 1) {
+      const colon = raw.indexOf(":");
+      const port = raw.slice(colon + 1);
+      if (/^\d+$/.test(port)) {
+        hostPart = raw.slice(0, colon);
+      }
+    }
+  }
   const normalized = hostPart.toLowerCase();
   if (normalized === "*") {
     return { raw, matches: () => true };

--- a/tests/proxy.test.ts
+++ b/tests/proxy.test.ts
@@ -119,6 +119,13 @@ describe("parseNoProxy + matchesNoProxy", () => {
     expect(matchesNoProxy("api.deepseek.com", p)).toBe(true);
   });
 
+  it("handles IPv6 port stripping and bare IPv6 literals in NO_PROXY", () => {
+    expect(matchesNoProxy("::1", parseNoProxy("::1"))).toBe(true);
+    expect(matchesNoProxy("::1", parseNoProxy("[::1]:8080"))).toBe(true);
+    expect(matchesNoProxy("host", parseNoProxy("host:8080"))).toBe(true);
+    expect(matchesNoProxy("2001:db8::1", parseNoProxy("2001:db8::1"))).toBe(true);
+  });
+
   it("comma-separated entries are merged", () => {
     const p = parseNoProxy("a.com, .b.com, *.c.com, 127.0.0.1");
     expect(matchesNoProxy("a.com", p)).toBe(true);


### PR DESCRIPTION
## What

`buildPattern` strips an optional `:port` from a `NO_PROXY` segment with
`raw.lastIndexOf(":")` plus a numeric-suffix check. That breaks IPv6 literals.

For the loopback `::1`, the last colon is at index 2 and the suffix `"1"` is
numeric, so the host is truncated to `"::"`. `::1` then never matches `NO_PROXY`
and IPv6 loopback is routed **through the proxy** — even though the function
comment lists "IP literals" as supported.

## Fix

Parse the host port-aware of IPv6:

| input | host |
|-------|------|
| `::1` | `::1` (was `::`) |
| `2001:db8::1` | `2001:db8::1` |
| `[::1]:8080` | `::1` |
| `[2001:db8::1]` | `2001:db8::1` |
| `host:8080` | `host` |
| `192.168.0.1:443` | `192.168.0.1` |

- Bracketed forms take the text between `[` and `]`.
- A bare host with **exactly one** colon and a numeric suffix keeps its `:port`
  stripped.
- Anything else (a bare IPv6 literal, which has multiple colons) is left intact.

## Test

Added `NO_PROXY` cases for bare IPv6, bracketed IPv6 with a port, and the
existing `host:port` case. Verified the IPv6 case fails on the old code and
passes on the fix (53 proxy tests pass).

## Verification

`npx vitest run tests/proxy.test.ts` (53 passed); `biome check` clean on the
changed files.
