### PR TITLE
fix(control): bare @ref resolution drops files when a name exists in multiple dirs

### DIFF
--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -134,6 +134,7 @@ func resolveBareNames(refs []ref) []ref {
 		if r, ok := need[d.Name()]; ok {
 			rel, _ := filepath.Rel(cwd, p)
 			r.path = filepath.ToSlash(rel)
+			delete(need, d.Name())
 			found++
 		}
 		return nil

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -144,3 +144,61 @@ func TestReadFileRef(t *testing.T) {
 		t.Error("missing path should error")
 	}
 }
+
+func TestResolveBareNamesDuplicates(t *testing.T) {
+	temp := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(temp, "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(temp, "b"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(temp, "c"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(temp, "a", "helper.go"), []byte("package a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temp, "b", "helper.go"), []byte("package b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temp, "c", "main.go"), []byte("package c"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(temp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Error(err)
+		}
+	})
+
+	refs := []ref{
+		{kind: refFile, raw: "helper.go"},
+		{kind: refFile, raw: "main.go"},
+	}
+
+	resolved := resolveBareNames(refs)
+
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved refs, got %d", len(resolved))
+	}
+
+	helperRef := resolved[0]
+	mainRef := resolved[1]
+
+	if helperRef.path != "a/helper.go" && helperRef.path != "b/helper.go" {
+		t.Errorf("expected helper.go path to be a/helper.go or b/helper.go, got %q", helperRef.path)
+	}
+	if mainRef.path != "c/main.go" {
+		t.Errorf("expected main.go path to be c/main.go, got %q", mainRef.path)
+	}
+}


### PR DESCRIPTION
## What

`resolveBareNames` walks the project tree to resolve bare `@filename`
references, incrementing `found` per match and stopping (`filepath.SkipAll`)
once `found == len(names)`. But a matched name was never removed from `need`, so
a filename present in **several directories** incremented `found` on every
occurrence and overwrote its resolved path.

With `@helper.go` and `@main.go`, where `helper.go` exists in two directories:
`found` reaches the target after matching `helper.go` twice and the walk stops
**before reaching `main.go`** — leaving `main.go` unresolved and pinning
`helper.go` to the second copy.

## Fix

`delete(need, d.Name())` after the first match, so `found` counts **distinct**
names and duplicate files are ignored.

## Test

`TestResolveBareNamesDuplicates`: a temp tree with `a/helper.go`, `b/helper.go`,
`c/main.go`; resolves `@helper.go` + `@main.go` and asserts **both** resolve
(`main.go` → `c/main.go`). Verified it fails on the old code and passes on the
fix.

## Verification

`go test ./internal/control/`, `go build ./...`, `go vet`, `gofmt -l` all clean.
