### PR TITLE
fix(glob): match the pattern relative to the path base dir, not the project root

### DIFF
--- a/src/tools/fs/glob.ts
+++ b/src/tools/fs/glob.ts
@@ -51,7 +51,8 @@ export async function globFiles(
       }
       if (!e.isFile() && !e.isSymbolicLink()) continue;
       const rel = displayRel(ctx.rootDir, full);
-      if (!isMatch(rel)) continue;
+      const matchRel = displayRel(startAbs, full);
+      if (!isMatch(matchRel)) continue;
       let mtimeMs = 0;
       if (sortBy === "mtime") {
         try {

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -1315,6 +1315,27 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(out).toContain("src/index.ts");
       expect(out).not.toContain("(no matches)");
     });
+
+    it("matches relative to an absolute path argument", async () => {
+      const absDir = join(root, "absdir");
+      await fs.mkdir(absDir, { recursive: true });
+      await fs.writeFile(join(absDir, "testfile.ts"), "export const a = 1;");
+      const out = await tools.dispatch("glob", JSON.stringify({ path: absDir, pattern: "*.ts" }));
+      expect(out).toContain("absdir/testfile.ts");
+      expect(out).not.toContain("(no matches)");
+    });
+
+    it("matches relative to dot path '.' and does not recurse unless requested", async () => {
+      await fs.writeFile(join(root, "top.ts"), "x");
+      await fs.mkdir(join(root, "sub"), { recursive: true });
+      await fs.writeFile(join(root, "sub", "a.ts"), "y");
+
+      const out = await tools.dispatch("glob", JSON.stringify({ path: ".", pattern: "*.ts" }));
+      const lines = out.split("\n").filter((l) => l.trim());
+      expect(lines).toContain("top.ts");
+      expect(lines).not.toContain("sub/a.ts");
+      expect(lines).not.toContain("src/index.ts");
+    });
   });
 
   describe("search_content — context lines (-A/-B/-C semantics)", () => {

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -1309,6 +1309,12 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
       expect(lines.length).toBe(3);
       expect(lines[lines.length - 1]).toMatch(/3 more matches/);
     });
+
+    it("matches relative to a custom path base directory", async () => {
+      const out = await tools.dispatch("glob", JSON.stringify({ path: "src", pattern: "*.ts" }));
+      expect(out).toContain("src/index.ts");
+      expect(out).not.toContain("(no matches)");
+    });
   });
 
   describe("search_content — context lines (-A/-B/-C semantics)", () => {


### PR DESCRIPTION
## What

The `glob` tool documents its `path` argument as *"Base directory to walk … The
pattern matches relative to this path."* But `globFiles` walked from `startAbs`
while testing the pattern against the path relative to `ctx.rootDir` (project
root).

So `glob(path: "src", pattern: "*.ts")` compared `"src/index.ts"` against
`"*.ts"`, matched nothing, and returned `(no matches)` — even though `index.ts`
matches `*.ts` relative to `src`.

## Fix

Match against a path relative to `startAbs` (the walk root), while keeping the
**displayed** result relative to `rootDir` so output still shows `src/index.ts`:

```ts
const rel = displayRel(ctx.rootDir, full);      // for display (unchanged)
const matchRel = displayRel(startAbs, full);     // for matching (new)
if (!isMatch(matchRel)) continue;
```

When no `path` is given (`startAbs == rootDir`) behavior is unchanged.

## Test

Added a case: globbing `*.ts` under `path: "src"` finds `src/index.ts` and does
not return `(no matches)`. Verified it fails on the old code and passes on the
fix (123 filesystem-tool tests pass).

## Verification

`npx vitest run tests/filesystem-tools.test.ts` (123 passed); `biome check`
clean on the changed files.
