### PR TITLE
fix(search): emit the search_files truncation notice once and stop walking

### DIFF
--- a/src/tools/fs/search.ts
+++ b/src/tools/fs/search.ts
@@ -36,7 +36,9 @@ export async function searchFiles(
   }
   const matches: string[] = [];
   let totalBytes = 0;
+  let truncated = false;
   const walk = async (dir: string): Promise<void> => {
+    if (truncated) return;
     throwIfAborted(args.signal);
     let entries: import("node:fs").Dirent[];
     try {
@@ -45,6 +47,7 @@ export async function searchFiles(
       return;
     }
     for (const e of entries) {
+      if (truncated) return;
       throwIfAborted(args.signal);
       const full = pathMod.join(dir, e.name);
       const lower = e.name.toLowerCase();
@@ -52,7 +55,10 @@ export async function searchFiles(
       if (hit) {
         const rel = displayRel(ctx.rootDir, full);
         if (totalBytes + rel.length + 1 > ctx.maxListBytes) {
-          matches.push("[… search truncated — refine pattern …]");
+          if (!truncated) {
+            matches.push("[… search truncated — refine pattern …]");
+            truncated = true;
+          }
           return;
         }
         matches.push(rel);

--- a/tests/filesystem-tools.test.ts
+++ b/tests/filesystem-tools.test.ts
@@ -419,6 +419,23 @@ describe("filesystem tools (built-in, sandbox-enforced)", () => {
         spy.mockRestore();
       }
     });
+
+    it("reports search truncated notice exactly once and stops walk", async () => {
+      const localTools = new ToolRegistry();
+      registerFilesystemTools(localTools, { rootDir: root, maxListBytes: 15 });
+
+      await fs.mkdir(join(root, "dirA"), { recursive: true });
+      await fs.mkdir(join(root, "dirB"), { recursive: true });
+      await fs.writeFile(join(root, "dirA", "match1.ts"), "x");
+      await fs.writeFile(join(root, "dirA", "match2.ts"), "x");
+      await fs.writeFile(join(root, "dirB", "match3.ts"), "x");
+
+      const out = await localTools.dispatch("search_files", JSON.stringify({ pattern: "match" }));
+      expect(out).toContain("[… search truncated — refine pattern …]");
+
+      const occurrences = out.split("[… search truncated — refine pattern …]").length - 1;
+      expect(occurrences).toBe(1);
+    });
   });
 
   describe("search_content", () => {


### PR DESCRIPTION
## What

`searchFiles` pushes `[… search truncated — refine pattern …]` and `return`s
when the byte budget is exceeded. But `return` only unwinds the **current**
recursive `walk` frame — the parent loop keeps visiting sibling entries and
other directories. A later match while still over budget pushes the notice
**again**, so the output ends with duplicate truncation lines, and the walk
wastes I/O.

The sibling `searchContent` in the same file already guards this with a
`truncated` flag.

## Repro

A workspace where matches span multiple directories and `maxListBytes` is small
enough to truncate after the first directory → output contains the truncation
notice **twice**.

## Fix

Mirror `searchContent`: add a `truncated` flag, bail at the top of `walk` and
before each entry once it's set, and push the notice only on the first overflow.
Result: a single truncation notice and no wasted traversal.

## Test

A `search_files` case asserting the truncation notice appears **exactly once**
across multiple directories. Verified it fails on the old code (two notices) and
passes on the fix.

## Verification

`npx vitest run tests/filesystem-tools.test.ts` (123 passed); `biome check`
clean on the changed files.
