### PR TITLE
fix(desktop): sidebar toggle button hidden after collapse

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -678,7 +678,7 @@ export default function App() {
         <aside className={`sidebar${sidebarCollapsed ? " sidebar--collapsed" : ""}`} aria-label={t("sidebar.navigation")}>
           <div className="sidebar__brand">
             <img src={logo} alt="" className="sidebar__logo" />
-            <span>Reasonix</span>
+            <span className="sidebar__brand-name">Reasonix</span>
             <Tooltip label={sidebarToggleTitle}>
               <button
                 className={`sidebar__toggle${sidebarExpandBlocked ? " sidebar__toggle--blocked" : ""}`}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -628,7 +628,7 @@ body {
   gap: 8px;
   padding: 0 0 12px;
 }
-.sidebar--collapsed .sidebar__brand > span {
+.sidebar--collapsed .sidebar__brand-name {
   display: none;
 }
 .sidebar--collapsed .sidebar__toggle {


### PR DESCRIPTION
The CSS rule `.sidebar--collapsed .sidebar__brand > span { display: none }` was too broad — it also hid the Tooltip wrapper `<span>` around the toggle button, making the sidebar impossible to expand once collapsed.

Fix by adding a dedicated `sidebar__brand-name` class to the brand text span and narrowing the selector accordingly.