### PR TITLE
refactor(cli): split skill picker view, strip restating comments

### DIFF
--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -23,22 +23,12 @@ type BranchMeta struct {
 	ForkMessageIndex int       `json:"fork_message_index,omitempty"`
 	CreatedAt        time.Time `json:"created_at"`
 	UpdatedAt        time.Time `json:"updated_at"`
-	// Scope distinguishes project-level from global sessions.
-	// "project" means this session belongs to a project workspace;
-	// "global" (the default for legacy sessions) means it's a global conversation.
-	Scope string `json:"scope,omitempty"`
-	// WorkspaceRoot is the project's root directory for project-scoped sessions.
-	WorkspaceRoot string `json:"workspace_root,omitempty"`
-	// TopicID links this session to a topic within a project.
-	TopicID string `json:"topic_id,omitempty"`
-	// TopicTitle is the user-visible topic name. May differ from a
-	// separately-stored title (which can be renamed independently).
-	TopicTitle string `json:"topic_title,omitempty"`
+	Scope            string    `json:"scope,omitempty"`
+	WorkspaceRoot    string    `json:"workspace_root,omitempty"`
+	TopicID          string    `json:"topic_id,omitempty"`
+	TopicTitle       string    `json:"topic_title,omitempty"`
 }
 
-// DefaultScope returns the effective scope, treating empty/"global" as "global"
-// and "project" as "project". Legacy sessions without a scope field default to
-// "global" so they appear in the Global / 未归档 group rather than being orphaned.
 func (m BranchMeta) DefaultScope() string {
 	switch m.Scope {
 	case "project":

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -88,15 +88,10 @@ type SessionInfo struct {
 	ModTime        time.Time // compatibility alias for LastActivityAt
 	Preview        string
 	Turns          int
-	// Scope is the session's workspace scope ("project" | "global").
-	// Empty for legacy sessions (treated as "global").
-	Scope string
-	// WorkspaceRoot is the project root for project-scoped sessions.
-	WorkspaceRoot string
-	// TopicID is the topic this session belongs to (project-scoped only).
-	TopicID string
-	// TopicTitle is the topic's display name.
-	TopicTitle string
+	Scope          string
+	WorkspaceRoot  string
+	TopicID        string
+	TopicTitle     string
 }
 
 // ListSessions returns every *.jsonl session under dir, most-recently-active

--- a/internal/cli/skill_hooks.go
+++ b/internal/cli/skill_hooks.go
@@ -13,14 +13,8 @@ import (
 	"reasonix/internal/skill"
 )
 
-// runSkillSubcommand handles "/skills" (and the legacy "/skill" alias): list
-// the discoverable skills, open the manager, show one's body, scaffold a new
-// one, or inspect the discovery paths.
-// "/skills <name> [args]" with no recognised subcommand falls through to invoking
-// the skill (handled by runSlashCommand's default branch), so this only owns the
-// management verbs.
 func (m *chatTUI) runSkillSubcommand(input string) {
-	args := tokenizeArgs(input) // args[0] == "/skills" or legacy "/skill"
+	args := tokenizeArgs(input)
 	sub := ""
 	if len(args) > 1 {
 		sub = strings.ToLower(args[1])
@@ -54,7 +48,6 @@ func (m *chatTUI) runSkillSubcommand(input string) {
 	case "paths":
 		m.skillPaths()
 	default:
-		// /skills is management-only; a skill is invoked directly as /<name>.
 		hint := ""
 		if _, ok := m.ctrl.RunSkill("/" + args[1]); ok {
 			hint = " (to run it, type /" + args[1] + ")"
@@ -230,8 +223,6 @@ func (m *chatTUI) skillPaths() {
 	m.commitLine(renderSkillPaths(m.width, st.Roots()))
 }
 
-// skillStore builds a Store reflecting this session's project root + configured
-// custom paths, for the management verbs that need to write or enumerate roots.
 func (m *chatTUI) skillStore() *skill.Store {
 	cwd, _ := os.Getwd()
 	var custom []string
@@ -241,10 +232,8 @@ func (m *chatTUI) skillStore() *skill.Store {
 	return skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom})
 }
 
-// runHooksSubcommand handles "/hooks": list the active hooks and the project's
-// trust state, or trust the current project so its hooks load next session.
 func (m *chatTUI) runHooksSubcommand(input string) {
-	args := tokenizeArgs(input) // args[0] == "/hooks"
+	args := tokenizeArgs(input)
 	sub := ""
 	if len(args) > 1 {
 		sub = strings.ToLower(args[1])
@@ -270,7 +259,6 @@ func (m *chatTUI) hooksList(cwd string) {
 	m.commitLine(renderHooks(m.width, active, trusted, hook.ProjectDefinesHooks(cwd)))
 }
 
-// containsArg reports whether flag appears in args.
 func containsArg(args []string, flag string) bool {
 	for _, a := range args {
 		if a == flag {

--- a/internal/cli/skill_picker.go
+++ b/internal/cli/skill_picker.go
@@ -13,9 +13,6 @@ import (
 	"reasonix/internal/skill"
 )
 
-// scopePriority orders skills by usefulness: project-level skills first,
-// then custom paths, global, and builtins last. Within each tier,
-// alphabetical order keeps the list scannable.
 var scopePriority = map[skill.Scope]int{
 	skill.ScopeProject: 0,
 	skill.ScopeCustom:  1,
@@ -33,9 +30,6 @@ const (
 	pickerConfirmDelete skillPickerMode = "confirm-delete"
 )
 
-// skillPicker is the in-chat overlay for /skills manage. It lists discoverable
-// skills with search, detail, and source views, following the same modal pattern
-// as rewindPicker and resumePicker.
 type skillPicker struct {
 	mode            skillPickerMode
 	skills          []skill.Skill
@@ -55,7 +49,6 @@ type skillPicker struct {
 	deleteSkill     skill.Skill
 }
 
-// skillRootLine is a CLI view model for one skill discovery root.
 type skillRootLine struct {
 	dir        string
 	scope      skill.Scope
@@ -65,9 +58,6 @@ type skillRootLine struct {
 	diagnostic bool
 }
 
-// openSkillPicker populates the picker from m.skills and opens it. A no-op
-// (with a notice) when there are no skills. Skills are sorted by scope
-// priority (project > custom > global > builtin) then name.
 func (m *chatTUI) openSkillPicker() {
 	st := m.skillStore()
 	skills := st.List()
@@ -102,7 +92,6 @@ func (m chatTUI) handleSkillPickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 	}
 
-	// Search mode: typed chars build the query; Esc exits search.
 	if p.searchActive {
 		switch msg.String() {
 		case "esc":
@@ -128,7 +117,6 @@ func (m chatTUI) handleSkillPickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 			}
 			return m, nil
 		default:
-			// Append typed characters to the query.
 			if t := msg.Text; t != "" {
 				p.query += t
 			} else if s := msg.String(); len(s) == 1 && s[0] >= 32 && s[0] < 127 {
@@ -139,7 +127,6 @@ func (m chatTUI) handleSkillPickerKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) 
 		}
 	}
 
-	// Non-search mode: route by current picker mode.
 	switch p.mode {
 	case pickerSkills:
 		return m.handleSkillPickerSkillsKey(msg)
@@ -345,7 +332,6 @@ func (m chatTUI) deleteSkillPick(sk skill.Skill) (tea.Model, tea.Cmd) {
 		delete(p.originalEnabled, sk.Name)
 		p.mode = pickerSkills
 		p.detailAction = 0
-		p.confirm = 1
 	}
 	m.notice(fmt.Sprintf(i18n.M.SkillPickerDeletedFmt, sk.Name))
 	m.refreshSkillPickerData()
@@ -353,7 +339,6 @@ func (m chatTUI) deleteSkillPick(sk skill.Skill) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-// rescanSkills rebuilds the skill store and refreshes the picker data.
 func (m *chatTUI) rescanSkills() {
 	m.refreshSkillPickerData()
 	m.notice(i18n.M.SkillPickerRescanned)
@@ -378,8 +363,6 @@ func (m *chatTUI) refreshSkillPickerData() {
 	}
 }
 
-// filteredSkills returns skills matching the current query (case-insensitive
-// substring match on name and description).
 func (p *skillPicker) filteredSkills() []skill.Skill {
 	if p.query == "" {
 		return p.skills
@@ -395,7 +378,6 @@ func (p *skillPicker) filteredSkills() []skill.Skill {
 	return out
 }
 
-// visibleRoots returns roots to display based on showDiagnostics.
 func (p *skillPicker) visibleRoots() []skillRootLine {
 	if p.showDiagnostics {
 		return p.roots
@@ -539,8 +521,6 @@ func skillInRoot(sk skill.Skill, root skillRootLine) bool {
 	return cleanPath == cleanRoot || strings.HasPrefix(cleanPath, prefix)
 }
 
-// skillRootLines builds the view-model list of discovery roots with per-root
-// skill counts computed by path-prefix matching. Builtins get a virtual root.
 func skillRootLines(st *skill.Store, skills []skill.Skill) []skillRootLine {
 	storeRoots := st.Roots()
 	lines := make([]skillRootLine, len(storeRoots))
@@ -551,9 +531,6 @@ func skillRootLines(st *skill.Store, skills []skill.Skill) []skillRootLine {
 			status: r.Status,
 		}
 	}
-	// Count skills per root by directory-boundary path match. Using
-	// filepath.Clean + a trailing separator avoids /skills matching
-	// /skills-extra.
 	for _, s := range skills {
 		if s.Scope == skill.ScopeBuiltin {
 			continue
@@ -563,6 +540,7 @@ func skillRootLines(st *skill.Store, skills []skill.Skill) []skillRootLine {
 			if lines[i].scope != s.Scope {
 				continue
 			}
+			// Trailing separator: directory-boundary match so /skills can't match /skills-extra.
 			prefix := filepath.Clean(lines[i].dir) + string(filepath.Separator)
 			if strings.HasPrefix(cleanPath, prefix) {
 				lines[i].skills++
@@ -570,7 +548,6 @@ func skillRootLines(st *skill.Store, skills []skill.Skill) []skillRootLine {
 			}
 		}
 	}
-	// Mark custom paths as configured; convention dirs as diagnostic.
 	for i := range lines {
 		if lines[i].scope == skill.ScopeCustom {
 			lines[i].configured = true
@@ -578,7 +555,6 @@ func skillRootLines(st *skill.Store, skills []skill.Skill) []skillRootLine {
 			lines[i].diagnostic = true
 		}
 	}
-	// Count builtins and append a virtual root.
 	builtinCount := 0
 	for _, s := range skills {
 		if s.Scope == skill.ScopeBuiltin {
@@ -595,421 +571,6 @@ func skillRootLines(st *skill.Store, skills []skill.Skill) []skillRootLine {
 		})
 	}
 	return lines
-}
-
-// -- rendering --
-
-const (
-	skillDialogMinRows = 8
-	skillDialogMaxRows = 18
-)
-
-func (m chatTUI) renderSkillPicker() string {
-	p := m.skillPick
-	if p == nil {
-		return ""
-	}
-	w := max(viewWidth(m.width), 40)
-	switch p.mode {
-	case pickerSkills:
-		return managerContentPanelStyle(w).Render(m.renderSkillPickerSkills())
-	case pickerSources:
-		return managerContentPanelStyle(w).Render(m.renderSkillPickerSources())
-	case pickerSourceSkills:
-		return managerContentPanelStyle(w).Render(m.renderSkillPickerSourceSkills())
-	case pickerDetail:
-		return managerContentPanelStyle(w).Render(m.renderSkillPickerDetail())
-	case pickerConfirmDelete:
-		return managerContentPanelStyle(w).Render(m.renderSkillPickerConfirmDelete())
-	}
-	return ""
-}
-
-func (m chatTUI) skillPickerFooterHint() string {
-	if m.skillPick == nil {
-		return ""
-	}
-	switch m.skillPick.mode {
-	case pickerSkills:
-		return i18n.M.SkillPickerHint
-	case pickerSources:
-		return i18n.M.SkillPickerSourceHint
-	case pickerSourceSkills:
-		return i18n.M.SkillPickerSourceSkillsHint
-	case pickerDetail:
-		return i18n.M.SkillPickerDetailHint
-	case pickerConfirmDelete:
-		return i18n.M.SkillPickerDeleteHint
-	default:
-		return ""
-	}
-}
-
-func (m chatTUI) renderSkillPickerSkills() string {
-	p := m.skillPick
-	w := max(viewWidth(m.width), 40)
-	var b strings.Builder
-
-	fmt.Fprintf(&b, "%s\n", viewHeader("Manage skills"))
-	if summary := skillPickerSummary(p); summary != "" {
-		fmt.Fprintf(&b, "%s\n", viewMeta(summary))
-	}
-	b.WriteByte('\n')
-	b.WriteString(renderSkillSearchBox(p.query, p.searchActive, w))
-	b.WriteByte('\n')
-
-	skills := p.skills
-	if p.searchActive && p.query != "" {
-		skills = p.filteredSkills()
-	}
-
-	if len(skills) == 0 {
-		b.WriteString(viewMeta(i18n.M.SkillPickerSearchEmpty))
-		b.WriteByte('\n')
-	} else {
-		start, end := skillListWindow(p.sel, len(skills), m.skillPickerVisibleRows())
-		if start > 0 {
-			b.WriteString(viewMeta(fmt.Sprintf(i18n.M.SkillPickerMoreAboveFmt, start)))
-			b.WriteByte('\n')
-		}
-		lastGroup := ""
-		for i := start; i < end; i++ {
-			group := skillGroupLabel(skills[i].Scope)
-			if group != lastGroup {
-				if lastGroup != "" {
-					b.WriteByte('\n')
-				}
-				fmt.Fprintf(&b, "  %s\n", bold(group))
-				lastGroup = group
-			}
-			b.WriteString(renderSkillRow(i+1, i == p.sel, skills[i], p.skillEnabled(skills[i].Name), w))
-			b.WriteByte('\n')
-		}
-		if end < len(skills) {
-			b.WriteString(viewMeta(fmt.Sprintf(i18n.M.SkillPickerMoreBelowFmt, len(skills)-end)))
-			b.WriteByte('\n')
-		}
-	}
-
-	return strings.TrimRight(b.String(), "\n")
-}
-
-func (m chatTUI) skillPickerVisibleRows() int {
-	if m.height <= 0 {
-		return skillDialogMaxRows
-	}
-	return min(skillDialogMaxRows, max(skillDialogMinRows, m.height-14))
-}
-
-func skillListWindow(sel, total, limit int) (int, int) {
-	if total <= 0 {
-		return 0, 0
-	}
-	if limit <= 0 || limit >= total {
-		return 0, total
-	}
-	if sel < 0 {
-		sel = 0
-	}
-	if sel >= total {
-		sel = total - 1
-	}
-	start := sel - limit/2
-	if start < 0 {
-		start = 0
-	}
-	if start+limit > total {
-		start = total - limit
-	}
-	return start, start + limit
-}
-
-func renderSkillSearchBox(query string, active bool, w int) string {
-	boxWidth := max(8, w-4)
-	innerWidth := max(1, boxWidth-4)
-	text := "/ " + i18n.M.SkillPickerSearchPlaceholder
-	if active || query != "" {
-		text = "/ " + query
-	}
-	text = padRight(viewCompactText(text, innerWidth), innerWidth)
-	var b strings.Builder
-	b.WriteString(dim("  ╭" + strings.Repeat("─", boxWidth-2) + "╮"))
-	b.WriteByte('\n')
-	b.WriteString(dim("  │ " + text + " │"))
-	b.WriteByte('\n')
-	b.WriteString(dim("  ╰" + strings.Repeat("─", boxWidth-2) + "╯"))
-	b.WriteByte('\n')
-	return b.String()
-}
-
-func (m chatTUI) renderSkillPickerSources() string {
-	p := m.skillPick
-	var b strings.Builder
-
-	b.WriteString(accent(i18n.M.SkillPickerSourceTitle))
-	summary := skillSourceSummary(p.roots)
-	if summary != "" {
-		b.WriteString("  " + dim(summary))
-	}
-	b.WriteByte('\n')
-
-	roots := p.visibleRoots()
-	for i, r := range roots {
-		label := sourceRowLabel(r, m.width)
-		b.WriteString(rowLine(i == p.sourceSel, i+1, "", label, false))
-		b.WriteByte('\n')
-	}
-
-	// Diagnostics toggle hint.
-	if p.showDiagnostics {
-		b.WriteString(dim("  " + i18n.M.SkillPickerDiagShown))
-	} else {
-		b.WriteString(dim("  " + i18n.M.SkillPickerDiagHidden))
-	}
-	return b.String()
-}
-
-func (m chatTUI) renderSkillPickerSourceSkills() string {
-	p := m.skillPick
-	var b strings.Builder
-	root, ok := p.selectedRoot()
-	if !ok {
-		p.mode = pickerSources
-		return m.renderSkillPickerSources()
-	}
-	skills := p.selectedRootSkills()
-	b.WriteString(accent(i18n.M.SkillPickerSourceTitle))
-	b.WriteString("  " + dim(viewCompactPath(root.dir, max(8, m.width-18))))
-	b.WriteByte('\n')
-	b.WriteByte('\n')
-	if len(skills) == 0 {
-		b.WriteString(dim("  " + i18n.M.SkillPickerSourceSkillsEmpty))
-		b.WriteByte('\n')
-		return b.String()
-	}
-	start, end := skillListWindow(p.sourceSkillSel, len(skills), m.skillPickerVisibleRows())
-	if start > 0 {
-		b.WriteString(dim("  " + fmt.Sprintf(i18n.M.SkillPickerMoreAboveFmt, start)))
-		b.WriteByte('\n')
-	}
-	for i := start; i < end; i++ {
-		b.WriteString(renderSkillRow(i+1, i == p.sourceSkillSel, skills[i], p.skillEnabled(skills[i].Name), m.width))
-		b.WriteByte('\n')
-	}
-	if end < len(skills) {
-		b.WriteString(dim("  " + fmt.Sprintf(i18n.M.SkillPickerMoreBelowFmt, len(skills)-end)))
-		b.WriteByte('\n')
-	}
-	return b.String()
-}
-
-func (m chatTUI) renderSkillPickerDetail() string {
-	p := m.skillPick
-	var b strings.Builder
-	b.WriteString(renderSkillDetailHeader(p.detailSkill, m.width))
-	b.WriteByte('\n')
-	b.WriteByte('\n')
-	enabled := i18n.M.SkillPickerDisabledLabel
-	if p.skillEnabled(p.detailSkill.Name) {
-		enabled = i18n.M.SkillPickerAvailableLabel
-	}
-	b.WriteString(dim("  " + i18n.M.SkillPickerStatusLabel + ": " + enabled))
-	b.WriteByte('\n')
-	actions := skillActionsFor(p.detailSkill)
-	for i, action := range actions {
-		b.WriteString(rowLine(i == p.detailAction, i+1, "", action.label, false))
-		b.WriteByte('\n')
-	}
-	if body := renderSkillBodyPreview(p.detailSkill, m.width, 6); body != "" {
-		b.WriteByte('\n')
-		b.WriteString(body)
-	}
-	return b.String()
-}
-
-func (m chatTUI) renderSkillPickerConfirmDelete() string {
-	p := m.skillPick
-	var b strings.Builder
-	b.WriteString(accent(fmt.Sprintf(i18n.M.SkillPickerDeleteTitleFmt, p.deleteSkill.Name)))
-	b.WriteByte('\n')
-	path := skillDeleteTargetLabel(p.deleteSkill)
-	if path != "" {
-		b.WriteString(dim("  " + viewCompactPath(path, max(8, m.width-4))))
-		b.WriteByte('\n')
-	}
-	b.WriteByte('\n')
-	b.WriteString(rowLine(p.confirm == 0, 1, "", i18n.M.SkillPickerDeleteConfirm, false))
-	b.WriteByte('\n')
-	b.WriteString(rowLine(p.confirm == 1, 2, "", i18n.M.SkillPickerDeleteCancel, false))
-	return b.String()
-}
-
-// renderSkillRow renders one skill as a single-line picker row:
-//
-//  12. ✓ 可用  brand-guidelines       · 全局 · ~80 tok
-//
-// The selected row gets full reverse-video highlighting.
-func renderSkillRow(num int, selected bool, s skill.Skill, enabled bool, w int) string {
-	prefix := "    "
-	if selected {
-		prefix = accent("  › ")
-	}
-	nameWidth := min(30, max(14, w/3))
-	name := compactMiddle(s.Name, nameWidth)
-	if selected {
-		name = bold(name)
-	}
-	name = padRight(name, nameWidth)
-	status := "✓ " + i18n.M.SkillPickerAvailableLabel
-	if enabled {
-		status = viewStatus(status)
-	} else {
-		status = viewMeta("○ " + i18n.M.SkillPickerDisabledLabel)
-	}
-	meta := skillRowMeta(s)
-	number := fmt.Sprintf("%2d. ", num)
-	line := fmt.Sprintf("%s%s%s · %s · %s", prefix, number, name, status, viewMeta(meta))
-	if visibleWidth(line) > w {
-		line = viewCompactText(line, w)
-	}
-
-	if selected {
-		return reverse(padRight(line, w))
-	}
-	return line
-}
-
-func skillGroupLabel(sc skill.Scope) string {
-	return titleText(scopeLabel(sc)) + " skills"
-}
-
-func skillRowMeta(s skill.Skill) string {
-	parts := []string{scopeLabel(s.Scope)}
-	if s.RunAs == skill.RunSubagent {
-		parts = append(parts, i18n.M.SkillPickerSubagent)
-	}
-	parts = append(parts, fmt.Sprintf(i18n.M.SkillPickerTokenFmt, approxSkillTokens(s)))
-	return strings.Join(parts, " · ")
-}
-
-func approxSkillTokens(s skill.Skill) int {
-	text := strings.TrimSpace(s.Body)
-	if text == "" {
-		text = strings.TrimSpace(s.Description)
-	}
-	if text == "" {
-		return 0
-	}
-	estimate := max(len([]rune(text))/4, len(strings.Fields(text)))
-	if estimate <= 10 {
-		return 10
-	}
-	return ((estimate + 9) / 10) * 10
-}
-
-// sourceRowLabel formats one root as "path  scope  status  N skills".
-func sourceRowLabel(r skillRootLine, w int) string {
-	path := viewCompactPath(r.dir, max(8, w-40))
-	scope := dim(scopeLabel(r.scope))
-	status := statusLabel(r.status)
-	if r.status == skill.StatusOK {
-		status = accent(status)
-	} else {
-		status = dim(status)
-	}
-	skills := dim(fmt.Sprintf("%d %s", r.skills, i18n.M.SkillPickerSkillsUnit))
-	return fmt.Sprintf("%s  %s  %s  %s", path, scope, status, skills)
-}
-
-// skillPickerSummary builds the summary line for the skills header. When
-// searching it shows "N matching · total M"; otherwise "N available · X
-// project · Y builtin" with only non-zero scopes.
-func skillPickerSummary(p *skillPicker) string {
-	if len(p.skills) == 0 {
-		return ""
-	}
-	if p.searchActive && p.query != "" {
-		filtered := p.filteredSkills()
-		return fmt.Sprintf(i18n.M.SkillPickerMatchingFmt, len(filtered), len(p.skills))
-	}
-	counts := map[skill.Scope]int{}
-	for _, s := range p.skills {
-		counts[s.Scope]++
-	}
-	var parts []string
-	parts = append(parts, fmt.Sprintf(i18n.M.SkillPickerAvailableFmt, len(p.skills)))
-	for _, sc := range []skill.Scope{skill.ScopeProject, skill.ScopeCustom, skill.ScopeGlobal, skill.ScopeBuiltin} {
-		if n, ok := counts[sc]; ok && n > 0 {
-			parts = append(parts, fmt.Sprintf("%d %s", n, scopeLabel(sc)))
-		}
-	}
-	return strings.Join(parts, " · ")
-}
-
-// skillSourceSummary builds the "N active" line for the source view.
-func skillSourceSummary(roots []skillRootLine) string {
-	active := 0
-	for _, r := range roots {
-		if r.skills > 0 {
-			active++
-		}
-	}
-	if active == 0 {
-		return ""
-	}
-	return fmt.Sprintf(i18n.M.SkillPickerSourceActiveFmt, active)
-}
-
-// renderSkillDetail renders the detail pane for one skill.
-func renderSkillDetail(s skill.Skill, w int) string {
-	var b strings.Builder
-	b.WriteString(renderSkillDetailHeader(s, w))
-	if body := renderSkillBodyPreview(s, w, 12); body != "" {
-		b.WriteByte('\n')
-		b.WriteString(body)
-	}
-	return b.String()
-}
-
-func renderSkillDetailHeader(s skill.Skill, w int) string {
-	var b strings.Builder
-	b.WriteString(accent("/" + s.Name))
-	b.WriteByte('\n')
-
-	// Scope + RunAs.
-	meta := fmt.Sprintf(i18n.M.SkillPickerDetailMetaFmt, scopeLabel(s.Scope), string(s.RunAs))
-	b.WriteString(dim("  " + meta))
-	b.WriteByte('\n')
-
-	// Path.
-	if s.Path != "" && s.Scope != skill.ScopeBuiltin {
-		b.WriteString(dim("  " + viewCompactPath(s.Path, max(8, w-4))))
-		b.WriteByte('\n')
-	}
-
-	// Description.
-	if strings.TrimSpace(s.Description) != "" {
-		b.WriteByte('\n')
-		b.WriteString(viewCompactText(s.Description, max(8, w-4)))
-		b.WriteByte('\n')
-	}
-
-	return b.String()
-}
-
-func renderSkillBodyPreview(s skill.Skill, w, maxLines int) string {
-	body, extra := viewBodyPreview(s.Body, maxLines)
-	if body == "" {
-		return ""
-	}
-	var b strings.Builder
-	b.WriteString(dim(viewProtectLines(body, w)))
-	b.WriteByte('\n')
-	if extra > 0 {
-		b.WriteString(viewMore(extra, i18n.M.SkillPickerLinesUnit))
-		b.WriteByte('\n')
-	}
-	return b.String()
 }
 
 type skillActionKind string
@@ -1088,38 +649,6 @@ func skillDeleteTargetLabel(s skill.Skill) string {
 	return target
 }
 
-func scopeLabel(sc skill.Scope) string {
-	switch sc {
-	case skill.ScopeProject:
-		return i18n.M.SkillPickerScopeProject
-	case skill.ScopeCustom:
-		return i18n.M.SkillPickerScopeCustom
-	case skill.ScopeGlobal:
-		return i18n.M.SkillPickerScopeGlobal
-	case skill.ScopeBuiltin:
-		return i18n.M.SkillPickerScopeBuiltin
-	default:
-		return string(sc)
-	}
-}
-
-func statusLabel(st skill.PathStatus) string {
-	switch st {
-	case skill.StatusOK:
-		return i18n.M.SkillPickerStatusOK
-	case skill.StatusMissing:
-		return i18n.M.SkillPickerStatusMissing
-	case skill.StatusNotDirectory:
-		return i18n.M.SkillPickerStatusNotDir
-	case skill.StatusUnreadable:
-		return i18n.M.SkillPickerStatusUnreadable
-	default:
-		return string(st)
-	}
-}
-
-// sortedSkills returns a copy of skills sorted by scope priority (project >
-// custom > global > builtin) then alphabetically by name.
 func sortedSkills(skills []skill.Skill) []skill.Skill {
 	sorted := make([]skill.Skill, len(skills))
 	copy(sorted, skills)

--- a/internal/cli/skill_picker_view.go
+++ b/internal/cli/skill_picker_view.go
@@ -1,0 +1,437 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/i18n"
+	"reasonix/internal/skill"
+)
+
+const (
+	skillDialogMinRows = 8
+	skillDialogMaxRows = 18
+)
+
+func (m chatTUI) renderSkillPicker() string {
+	p := m.skillPick
+	if p == nil {
+		return ""
+	}
+	w := max(viewWidth(m.width), 40)
+	switch p.mode {
+	case pickerSkills:
+		return managerContentPanelStyle(w).Render(m.renderSkillPickerSkills())
+	case pickerSources:
+		return managerContentPanelStyle(w).Render(m.renderSkillPickerSources())
+	case pickerSourceSkills:
+		return managerContentPanelStyle(w).Render(m.renderSkillPickerSourceSkills())
+	case pickerDetail:
+		return managerContentPanelStyle(w).Render(m.renderSkillPickerDetail())
+	case pickerConfirmDelete:
+		return managerContentPanelStyle(w).Render(m.renderSkillPickerConfirmDelete())
+	}
+	return ""
+}
+
+func (m chatTUI) skillPickerFooterHint() string {
+	if m.skillPick == nil {
+		return ""
+	}
+	switch m.skillPick.mode {
+	case pickerSkills:
+		return i18n.M.SkillPickerHint
+	case pickerSources:
+		return i18n.M.SkillPickerSourceHint
+	case pickerSourceSkills:
+		return i18n.M.SkillPickerSourceSkillsHint
+	case pickerDetail:
+		return i18n.M.SkillPickerDetailHint
+	case pickerConfirmDelete:
+		return i18n.M.SkillPickerDeleteHint
+	default:
+		return ""
+	}
+}
+
+func (m chatTUI) renderSkillPickerSkills() string {
+	p := m.skillPick
+	w := max(viewWidth(m.width), 40)
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s\n", viewHeader("Manage skills"))
+	if summary := skillPickerSummary(p); summary != "" {
+		fmt.Fprintf(&b, "%s\n", viewMeta(summary))
+	}
+	b.WriteByte('\n')
+	b.WriteString(renderSkillSearchBox(p.query, p.searchActive, w))
+	b.WriteByte('\n')
+
+	skills := p.skills
+	if p.searchActive && p.query != "" {
+		skills = p.filteredSkills()
+	}
+
+	if len(skills) == 0 {
+		b.WriteString(viewMeta(i18n.M.SkillPickerSearchEmpty))
+		b.WriteByte('\n')
+	} else {
+		start, end := skillListWindow(p.sel, len(skills), m.skillPickerVisibleRows())
+		if start > 0 {
+			b.WriteString(viewMeta(fmt.Sprintf(i18n.M.SkillPickerMoreAboveFmt, start)))
+			b.WriteByte('\n')
+		}
+		lastGroup := ""
+		for i := start; i < end; i++ {
+			group := skillGroupLabel(skills[i].Scope)
+			if group != lastGroup {
+				if lastGroup != "" {
+					b.WriteByte('\n')
+				}
+				fmt.Fprintf(&b, "  %s\n", bold(group))
+				lastGroup = group
+			}
+			b.WriteString(renderSkillRow(i+1, i == p.sel, skills[i], p.skillEnabled(skills[i].Name), w))
+			b.WriteByte('\n')
+		}
+		if end < len(skills) {
+			b.WriteString(viewMeta(fmt.Sprintf(i18n.M.SkillPickerMoreBelowFmt, len(skills)-end)))
+			b.WriteByte('\n')
+		}
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (m chatTUI) skillPickerVisibleRows() int {
+	if m.height <= 0 {
+		return skillDialogMaxRows
+	}
+	return min(skillDialogMaxRows, max(skillDialogMinRows, m.height-14))
+}
+
+func skillListWindow(sel, total, limit int) (int, int) {
+	if total <= 0 {
+		return 0, 0
+	}
+	if limit <= 0 || limit >= total {
+		return 0, total
+	}
+	if sel < 0 {
+		sel = 0
+	}
+	if sel >= total {
+		sel = total - 1
+	}
+	start := sel - limit/2
+	if start < 0 {
+		start = 0
+	}
+	if start+limit > total {
+		start = total - limit
+	}
+	return start, start + limit
+}
+
+func renderSkillSearchBox(query string, active bool, w int) string {
+	boxWidth := max(8, w-4)
+	innerWidth := max(1, boxWidth-4)
+	text := "/ " + i18n.M.SkillPickerSearchPlaceholder
+	if active || query != "" {
+		text = "/ " + query
+	}
+	text = padRight(viewCompactText(text, innerWidth), innerWidth)
+	var b strings.Builder
+	b.WriteString(dim("  ╭" + strings.Repeat("─", boxWidth-2) + "╮"))
+	b.WriteByte('\n')
+	b.WriteString(dim("  │ " + text + " │"))
+	b.WriteByte('\n')
+	b.WriteString(dim("  ╰" + strings.Repeat("─", boxWidth-2) + "╯"))
+	b.WriteByte('\n')
+	return b.String()
+}
+
+func (m chatTUI) renderSkillPickerSources() string {
+	p := m.skillPick
+	var b strings.Builder
+
+	b.WriteString(accent(i18n.M.SkillPickerSourceTitle))
+	summary := skillSourceSummary(p.roots)
+	if summary != "" {
+		b.WriteString("  " + dim(summary))
+	}
+	b.WriteByte('\n')
+
+	roots := p.visibleRoots()
+	for i, r := range roots {
+		label := sourceRowLabel(r, m.width)
+		b.WriteString(rowLine(i == p.sourceSel, i+1, "", label, false))
+		b.WriteByte('\n')
+	}
+
+	if p.showDiagnostics {
+		b.WriteString(dim("  " + i18n.M.SkillPickerDiagShown))
+	} else {
+		b.WriteString(dim("  " + i18n.M.SkillPickerDiagHidden))
+	}
+	return b.String()
+}
+
+func (m chatTUI) renderSkillPickerSourceSkills() string {
+	p := m.skillPick
+	var b strings.Builder
+	root, ok := p.selectedRoot()
+	if !ok {
+		p.mode = pickerSources
+		return m.renderSkillPickerSources()
+	}
+	skills := p.selectedRootSkills()
+	b.WriteString(accent(i18n.M.SkillPickerSourceTitle))
+	b.WriteString("  " + dim(viewCompactPath(root.dir, max(8, m.width-18))))
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+	if len(skills) == 0 {
+		b.WriteString(dim("  " + i18n.M.SkillPickerSourceSkillsEmpty))
+		b.WriteByte('\n')
+		return b.String()
+	}
+	start, end := skillListWindow(p.sourceSkillSel, len(skills), m.skillPickerVisibleRows())
+	if start > 0 {
+		b.WriteString(dim("  " + fmt.Sprintf(i18n.M.SkillPickerMoreAboveFmt, start)))
+		b.WriteByte('\n')
+	}
+	for i := start; i < end; i++ {
+		b.WriteString(renderSkillRow(i+1, i == p.sourceSkillSel, skills[i], p.skillEnabled(skills[i].Name), m.width))
+		b.WriteByte('\n')
+	}
+	if end < len(skills) {
+		b.WriteString(dim("  " + fmt.Sprintf(i18n.M.SkillPickerMoreBelowFmt, len(skills)-end)))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func (m chatTUI) renderSkillPickerDetail() string {
+	p := m.skillPick
+	var b strings.Builder
+	b.WriteString(renderSkillDetailHeader(p.detailSkill, m.width))
+	b.WriteByte('\n')
+	b.WriteByte('\n')
+	enabled := i18n.M.SkillPickerDisabledLabel
+	if p.skillEnabled(p.detailSkill.Name) {
+		enabled = i18n.M.SkillPickerAvailableLabel
+	}
+	b.WriteString(dim("  " + i18n.M.SkillPickerStatusLabel + ": " + enabled))
+	b.WriteByte('\n')
+	actions := skillActionsFor(p.detailSkill)
+	for i, action := range actions {
+		b.WriteString(rowLine(i == p.detailAction, i+1, "", action.label, false))
+		b.WriteByte('\n')
+	}
+	if body := renderSkillBodyPreview(p.detailSkill, m.width, 6); body != "" {
+		b.WriteByte('\n')
+		b.WriteString(body)
+	}
+	return b.String()
+}
+
+func (m chatTUI) renderSkillPickerConfirmDelete() string {
+	p := m.skillPick
+	var b strings.Builder
+	b.WriteString(accent(fmt.Sprintf(i18n.M.SkillPickerDeleteTitleFmt, p.deleteSkill.Name)))
+	b.WriteByte('\n')
+	path := skillDeleteTargetLabel(p.deleteSkill)
+	if path != "" {
+		b.WriteString(dim("  " + viewCompactPath(path, max(8, m.width-4))))
+		b.WriteByte('\n')
+	}
+	b.WriteByte('\n')
+	b.WriteString(rowLine(p.confirm == 0, 1, "", i18n.M.SkillPickerDeleteConfirm, false))
+	b.WriteByte('\n')
+	b.WriteString(rowLine(p.confirm == 1, 2, "", i18n.M.SkillPickerDeleteCancel, false))
+	return b.String()
+}
+
+func renderSkillRow(num int, selected bool, s skill.Skill, enabled bool, w int) string {
+	prefix := "    "
+	if selected {
+		prefix = accent("  › ")
+	}
+	nameWidth := min(30, max(14, w/3))
+	name := compactMiddle(s.Name, nameWidth)
+	if selected {
+		name = bold(name)
+	}
+	name = padRight(name, nameWidth)
+	status := "✓ " + i18n.M.SkillPickerAvailableLabel
+	if enabled {
+		status = viewStatus(status)
+	} else {
+		status = viewMeta("○ " + i18n.M.SkillPickerDisabledLabel)
+	}
+	meta := skillRowMeta(s)
+	number := fmt.Sprintf("%2d. ", num)
+	line := fmt.Sprintf("%s%s%s · %s · %s", prefix, number, name, status, viewMeta(meta))
+	if visibleWidth(line) > w {
+		line = viewCompactText(line, w)
+	}
+
+	if selected {
+		return reverse(padRight(line, w))
+	}
+	return line
+}
+
+func skillGroupLabel(sc skill.Scope) string {
+	return titleText(scopeLabel(sc)) + " skills"
+}
+
+func skillRowMeta(s skill.Skill) string {
+	parts := []string{scopeLabel(s.Scope)}
+	if s.RunAs == skill.RunSubagent {
+		parts = append(parts, i18n.M.SkillPickerSubagent)
+	}
+	parts = append(parts, fmt.Sprintf(i18n.M.SkillPickerTokenFmt, approxSkillTokens(s)))
+	return strings.Join(parts, " · ")
+}
+
+func approxSkillTokens(s skill.Skill) int {
+	text := strings.TrimSpace(s.Body)
+	if text == "" {
+		text = strings.TrimSpace(s.Description)
+	}
+	if text == "" {
+		return 0
+	}
+	estimate := max(len([]rune(text))/4, len(strings.Fields(text)))
+	if estimate <= 10 {
+		return 10
+	}
+	return ((estimate + 9) / 10) * 10
+}
+
+func sourceRowLabel(r skillRootLine, w int) string {
+	path := viewCompactPath(r.dir, max(8, w-40))
+	scope := dim(scopeLabel(r.scope))
+	status := statusLabel(r.status)
+	if r.status == skill.StatusOK {
+		status = accent(status)
+	} else {
+		status = dim(status)
+	}
+	skills := dim(fmt.Sprintf("%d %s", r.skills, i18n.M.SkillPickerSkillsUnit))
+	return fmt.Sprintf("%s  %s  %s  %s", path, scope, status, skills)
+}
+
+func skillPickerSummary(p *skillPicker) string {
+	if len(p.skills) == 0 {
+		return ""
+	}
+	if p.searchActive && p.query != "" {
+		filtered := p.filteredSkills()
+		return fmt.Sprintf(i18n.M.SkillPickerMatchingFmt, len(filtered), len(p.skills))
+	}
+	counts := map[skill.Scope]int{}
+	for _, s := range p.skills {
+		counts[s.Scope]++
+	}
+	var parts []string
+	parts = append(parts, fmt.Sprintf(i18n.M.SkillPickerAvailableFmt, len(p.skills)))
+	for _, sc := range []skill.Scope{skill.ScopeProject, skill.ScopeCustom, skill.ScopeGlobal, skill.ScopeBuiltin} {
+		if n, ok := counts[sc]; ok && n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, scopeLabel(sc)))
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func skillSourceSummary(roots []skillRootLine) string {
+	active := 0
+	for _, r := range roots {
+		if r.skills > 0 {
+			active++
+		}
+	}
+	if active == 0 {
+		return ""
+	}
+	return fmt.Sprintf(i18n.M.SkillPickerSourceActiveFmt, active)
+}
+
+func renderSkillDetail(s skill.Skill, w int) string {
+	var b strings.Builder
+	b.WriteString(renderSkillDetailHeader(s, w))
+	if body := renderSkillBodyPreview(s, w, 12); body != "" {
+		b.WriteByte('\n')
+		b.WriteString(body)
+	}
+	return b.String()
+}
+
+func renderSkillDetailHeader(s skill.Skill, w int) string {
+	var b strings.Builder
+	b.WriteString(accent("/" + s.Name))
+	b.WriteByte('\n')
+
+	meta := fmt.Sprintf(i18n.M.SkillPickerDetailMetaFmt, scopeLabel(s.Scope), string(s.RunAs))
+	b.WriteString(dim("  " + meta))
+	b.WriteByte('\n')
+
+	if s.Path != "" && s.Scope != skill.ScopeBuiltin {
+		b.WriteString(dim("  " + viewCompactPath(s.Path, max(8, w-4))))
+		b.WriteByte('\n')
+	}
+
+	if strings.TrimSpace(s.Description) != "" {
+		b.WriteByte('\n')
+		b.WriteString(viewCompactText(s.Description, max(8, w-4)))
+		b.WriteByte('\n')
+	}
+
+	return b.String()
+}
+
+func renderSkillBodyPreview(s skill.Skill, w, maxLines int) string {
+	body, extra := viewBodyPreview(s.Body, maxLines)
+	if body == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString(dim(viewProtectLines(body, w)))
+	b.WriteByte('\n')
+	if extra > 0 {
+		b.WriteString(viewMore(extra, i18n.M.SkillPickerLinesUnit))
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func scopeLabel(sc skill.Scope) string {
+	switch sc {
+	case skill.ScopeProject:
+		return i18n.M.SkillPickerScopeProject
+	case skill.ScopeCustom:
+		return i18n.M.SkillPickerScopeCustom
+	case skill.ScopeGlobal:
+		return i18n.M.SkillPickerScopeGlobal
+	case skill.ScopeBuiltin:
+		return i18n.M.SkillPickerScopeBuiltin
+	default:
+		return string(sc)
+	}
+}
+
+func statusLabel(st skill.PathStatus) string {
+	switch st {
+	case skill.StatusOK:
+		return i18n.M.SkillPickerStatusOK
+	case skill.StatusMissing:
+		return i18n.M.SkillPickerStatusMissing
+	case skill.StatusNotDirectory:
+		return i18n.M.SkillPickerStatusNotDir
+	case skill.StatusUnreadable:
+		return i18n.M.SkillPickerStatusUnreadable
+	default:
+		return string(st)
+	}
+}


### PR DESCRIPTION
Follow-up cleanup on the just-merged #2928 to bring the new skills code in line with the repo rules.

## What
- Split `skill_picker.go` (1161 lines, over the 800-line hard ceiling) into state/handlers (`skill_picker.go`, 690) and rendering (`skill_picker_view.go`, 437).
- Strip the what-restating doc comments, section banner (`// -- rendering --`), and the ASCII-art row example the merged code carried, plus the per-field "what" comments on the new `BranchMeta`/`SessionInfo` fields and the function-doc essays in `skill_hooks.go`. Kept the one genuinely load-bearing note (the `/skills` vs `/skills-extra` directory-boundary match).
- Drop a dead `p.confirm = 1` write in `deleteSkillPick` (`confirm` is unused in skills mode).

Pure cleanup — no behavior change.

## Verification
- `gofmt` clean, `go vet ./internal/cli/... ./internal/agent/...`
- `REASONIX_LANG=en HOME=$(mktemp -d) go test ./internal/cli ./internal/agent ./internal/control ./internal/skill -count=1`
