### PR TITLE
fix(codegraph): mark read tools read-only (rebase of #2983)

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -244,7 +244,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
 		case ok:
-			spec := plugin.Spec{Name: "codegraph", Command: bin, Args: []string{"serve", "--mcp"}, Dir: root}
+			spec := plugin.Spec{
+				Name:              "codegraph",
+				Command:           bin,
+				Args:              []string{"serve", "--mcp"},
+				Dir:               root,
+				ReadOnlyToolNames: codegraph.ReadOnlyToolNames(),
+			}
 			warm := codegraph.Initialized(root)
 			if err := codegraph.EnsureInit(ctx, bin, root); err != nil {
 				sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,

--- a/internal/codegraph/e2e_test.go
+++ b/internal/codegraph/e2e_test.go
@@ -59,10 +59,11 @@ func TestE2ECodegraphMCP(t *testing.T) {
 	// 2) Connect through the real MCP client, pinned to the project root via Dir —
 	//    the same wiring boot uses for the built-in server.
 	host, tools, err := plugin.StartAll(ctx, []plugin.Spec{{
-		Name:    "codegraph",
-		Command: bin,
-		Args:    []string{"serve", "--mcp"},
-		Dir:     root,
+		Name:              "codegraph",
+		Command:           bin,
+		Args:              []string{"serve", "--mcp"},
+		Dir:               root,
+		ReadOnlyToolNames: ReadOnlyToolNames(),
 	}})
 	if err != nil {
 		t.Fatalf("StartAll: %v", err)
@@ -83,6 +84,9 @@ func TestE2ECodegraphMCP(t *testing.T) {
 	}
 	if search == nil {
 		t.Fatalf("no codegraph_search tool among %v", names)
+	}
+	if !search.ReadOnly() {
+		t.Fatalf("codegraph_search should be read-only under the built-in CodeGraph override; tools=%v", names)
 	}
 
 	// serve indexes in the background, so poll the search for a few seconds until

--- a/internal/codegraph/read_only.go
+++ b/internal/codegraph/read_only.go
@@ -1,0 +1,18 @@
+package codegraph
+
+// ReadOnlyToolNames returns the CodeGraph MCP tools Reasonix treats as readers
+// when older CodeGraph runtimes omit MCP annotations.readOnlyHint metadata.
+func ReadOnlyToolNames() map[string]bool {
+	return map[string]bool{
+		"codegraph_callees": true,
+		"codegraph_callers": true,
+		"codegraph_context": true,
+		"codegraph_explore": true,
+		"codegraph_files":   true,
+		"codegraph_impact":  true,
+		"codegraph_node":    true,
+		"codegraph_search":  true,
+		"codegraph_status":  true,
+		"codegraph_trace":   true,
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1387,7 +1387,13 @@ func (c *Controller) connectCodegraphMCPServer(cfg *config.Config) (int, error) 
 	if err := codegraph.EnsureInit(c.pluginCtx, bin, cwd); err != nil {
 		return 0, fmt.Errorf("codegraph init: %w", err)
 	}
-	return c.connectMCPSpec(plugin.Spec{Name: "codegraph", Command: bin, Args: []string{"serve", "--mcp"}, Dir: cwd})
+	return c.connectMCPSpec(plugin.Spec{
+		Name:              "codegraph",
+		Command:           bin,
+		Args:              []string{"serve", "--mcp"},
+		Dir:               cwd,
+		ReadOnlyToolNames: codegraph.ReadOnlyToolNames(),
+	})
 }
 
 // RemoveMCPServer disconnects a live MCP server — its tools vanish from the next

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -246,7 +246,7 @@ func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, se
 				name:     toolName(spec.Name, ct.Name),
 				desc:     ct.Description,
 				schema:   ct.Schema,
-				readOnly: ct.ReadOnly,
+				readOnly: spec.toolReadOnly(ct.Name, ct.ReadOnly),
 				hasCache: true,
 			})
 		}

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -143,6 +143,45 @@ func TestLazyCacheHitSyncSpawn(t *testing.T) {
 	}
 }
 
+func TestLazyToolsetAppliesSpecReadOnlyOverrideToCachedTools(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	cachedSpec := spec
+	writeMockCache(t, cachedSpec)
+	spec.ReadOnlyToolNames = map[string]bool{"echo": true}
+
+	cs, ok := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+	if !ok {
+		t.Fatal("LoadCachedSchema: miss right after save (sanity)")
+	}
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, cs, host, reg, ctx, false)
+	byName := map[string]tool.Tool{}
+	for _, tl := range tools {
+		byName[tl.Name()] = tl
+	}
+	echo := byName["mcp__mock__echo"]
+	if echo == nil {
+		t.Fatalf("mcp__mock__echo missing from %v", byName)
+	}
+	if !echo.ReadOnly() {
+		t.Fatal("lazy cached echo should use the spec read-only override")
+	}
+	zed := byName["mcp__mock__zed"]
+	if zed == nil {
+		t.Fatalf("mcp__mock__zed missing from %v", byName)
+	}
+	if zed.ReadOnly() {
+		t.Fatal("lazy cached zed should keep cached non-read-only status")
+	}
+}
+
 // TestLazyCacheMissAsyncSpawn drives the cache-miss branch: with no cache, a
 // single "connect" placeholder shows up; first Execute returns a retry hint and
 // kicks the spawn async; once that spawn finishes, the registry swaps to the

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -46,6 +46,10 @@ type Spec struct {
 	// captured in a bounded buffer for failure diagnostics; nil keeps it out of
 	// the terminal so child logs cannot corrupt interactive UIs.
 	Stderr io.Writer
+	// ReadOnlyToolNames marks trusted raw MCP tool names as read-only even when
+	// the server omits annotations.readOnlyHint. It is for first-party adapters
+	// with known semantics; user-configured plugins should rely on MCP metadata.
+	ReadOnlyToolNames map[string]bool
 }
 
 // transport carries JSON-RPC messages to and from one MCP server. call sends a
@@ -720,6 +724,10 @@ type mcpTool struct {
 	} `json:"annotations"`
 }
 
+func (s Spec) toolReadOnly(rawName string, hinted bool) bool {
+	return hinted || s.ReadOnlyToolNames[rawName]
+}
+
 func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 	res, err := c.call(ctx, "tools/list", map[string]any{})
 	if err != nil {
@@ -735,6 +743,7 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 	toolInfos := make([]ToolInfo, 0, len(out.Tools))
 	tools := make([]tool.Tool, 0, len(out.Tools))
 	for _, t := range out.Tools {
+		hinted := t.Annotations != nil && t.Annotations.ReadOnlyHint
 		toolInfos = append(toolInfos, ToolInfo{Name: t.Name, Description: t.Description})
 		tools = append(tools, &remoteTool{
 			client:   c,
@@ -742,7 +751,7 @@ func (c *Client) listTools(ctx context.Context) ([]tool.Tool, error) {
 			rawName:  t.Name,
 			desc:     t.Description,
 			schema:   canonicalizeSchema(t.InputSchema),
-			readOnly: t.Annotations != nil && t.Annotations.ReadOnlyHint,
+			readOnly: c.spec.toolReadOnly(t.Name, hinted),
 		})
 	}
 	sort.SliceStable(toolInfos, func(i, j int) bool { return toolInfos[i].Name < toolInfos[j].Name })
@@ -822,16 +831,15 @@ type remoteTool struct {
 	rawName  string // original name for tools/call
 	desc     string
 	schema   json.RawMessage
-	readOnly bool // from the tool's MCP readOnlyHint annotation
+	readOnly bool // from MCP readOnlyHint or trusted first-party Spec override
 }
 
 func (t *remoteTool) Name() string        { return t.name }
 func (t *remoteTool) Description() string { return t.desc }
 
-// ReadOnly reflects the tool's MCP readOnlyHint annotation. It defaults to
-// false (opaque — we can't inspect a remote tool's side effects), so plugins
-// opt into parallel-batch dispatch and the permission layer's reader-default
-// by explicitly declaring readOnlyHint: true in tools/list.
+// ReadOnly reflects MCP readOnlyHint, plus trusted first-party Spec overrides.
+// It defaults to false: opaque third-party tools must declare readOnlyHint
+// before joining reader-default permission handling or plan-mode execution.
 func (t *remoteTool) ReadOnly() bool { return t.readOnly }
 
 func (t *remoteTool) Schema() json.RawMessage {

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -55,6 +55,46 @@ func TestStdioEndToEnd(t *testing.T) {
 	}
 }
 
+func TestSpecReadOnlyToolNamesMarksUnhintedToolsReadOnly(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	spec := Spec{
+		Name:    "mock",
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestHelperProcess", "--"},
+		Env:     map[string]string{"GO_WANT_HELPER_PROCESS": "1"},
+		ReadOnlyToolNames: map[string]bool{
+			"echo": true,
+		},
+	}
+
+	host, tools, err := StartAll(ctx, []Spec{spec})
+	if err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+	defer host.Close()
+
+	byName := map[string]tool.Tool{}
+	for _, tl := range tools {
+		byName[tl.Name()] = tl
+	}
+	echo := byName["mcp__mock__echo"]
+	if echo == nil {
+		t.Fatalf("mcp__mock__echo missing from %v", byName)
+	}
+	if !echo.ReadOnly() {
+		t.Fatal("read-only override did not mark unhinted echo tool read-only")
+	}
+	zed := byName["mcp__mock__zed"]
+	if zed == nil {
+		t.Fatalf("mcp__mock__zed missing from %v", byName)
+	}
+	if zed.ReadOnly() {
+		t.Fatal("read-only override should not mark non-listed tools read-only")
+	}
+}
+
 func TestStartAvailableKeepsGoodServers(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()


### PR DESCRIPTION
Rebase of #2983 by @lizhengwu onto current `main-v2` (the original conflicted with the workspace-root rework in #2928). Original authorship preserved in the commit.

## What
First-party MCP adapters can now declare which raw tool names are read-only via `plugin.Spec.ReadOnlyToolNames`, applied as `hinted || override[name]` in both the live `listTools` path and the lazy cached-schema path. CodeGraph wires its reader tools (`codegraph_search`, `codegraph_callers`, …) through it, so they stop defaulting to `readOnly=false`.

This matters for plan mode (complements #2933): CodeGraph's read tools were opaque-by-default, so they were treated as potential writers — blocked under the read-only plan-mode gate and excluded from reader-default permission handling and parallel dispatch. Third-party plugins still rely on MCP `readOnlyHint` metadata; the override is first-party only.

## Conflict resolution
Only `internal/boot/boot.go` conflicted — kept #2928's `root` (workspace root) for `Dir`/`Initialized`/`EnsureInit` and added `ReadOnlyToolNames: codegraph.ReadOnlyToolNames()`. `internal/control/controller.go` auto-merged.

## Verification (rebased tree)
- `go build ./...`
- `REASONIX_LANG=en HOME=$(mktemp -d) go test ./internal/plugin ./internal/boot ./internal/control ./internal/codegraph -count=1` — all green
- New tests confirmed running + passing: `TestSpecReadOnlyToolNamesMarksUnhintedToolsReadOnly`, `TestLazyToolsetAppliesSpecReadOnlyOverrideToCachedTools`

Closes #2983
