### PR TITLE
feat: ! prefix for direct shell execution

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -196,7 +196,10 @@ func (a *App) Submit(input string) {
 // RunShell executes a shell command directly (bypassing the model) and streams
 // output as events on eventChannel.
 func (a *App) RunShell(command string) {
-	if ctrl := a.activeCtrl(); ctrl != nil {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
 		ctrl.RunShell(command)
 	}
 }

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -193,6 +193,17 @@ func (a *App) Submit(input string) {
 	}
 }
 
+// RunShell executes a shell command directly (bypassing the model) and streams
+// output as events on eventChannel.
+func (a *App) RunShell(command string) {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.RunShell(command)
+	}
+}
+
 // SubmitDisplay runs input as a turn while recording a shorter UI-only display
 // string for the saved desktop transcript. The model still receives input.
 func (a *App) SubmitDisplay(display, input string) {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -196,10 +196,7 @@ func (a *App) Submit(input string) {
 // RunShell executes a shell command directly (bypassing the model) and streams
 // output as events on eventChannel.
 func (a *App) RunShell(command string) {
-	a.mu.RLock()
-	ctrl := a.ctrl
-	a.mu.RUnlock()
-	if ctrl != nil {
+	if ctrl := a.activeCtrl(); ctrl != nil {
 		ctrl.RunShell(command)
 	}
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -310,7 +310,12 @@ export default function App() {
       const trimmed = displayText.trim();
       // "!<cmd>" runs a shell command directly, bypassing the model.
       if (trimmed.startsWith("!")) {
-        runShell(trimmed.slice(1));
+        const cmd = trimmed.slice(1).trim();
+        if (!cmd) {
+          notice("usage: !<command>  (e.g. !ls -la)");
+          return;
+        }
+        runShell(cmd);
         return;
       }
       const model = /^\/model\s+(\S+)$/.exec(trimmed);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -138,6 +138,7 @@ export default function App() {
   const {
     state,
     send,
+    runShell,
     notice,
     cancel,
     approve,
@@ -288,6 +289,11 @@ export default function App() {
   const handleSend = useCallback(
     async (displayText: string, submitText = displayText) => {
       const trimmed = displayText.trim();
+      // "!<cmd>" runs a shell command directly, bypassing the model.
+      if (trimmed.startsWith("!")) {
+        runShell(trimmed.slice(1));
+        return;
+      }
       const model = /^\/model\s+(\S+)$/.exec(trimmed);
       if (model) {
         void switchModel(model[1]);
@@ -324,7 +330,7 @@ export default function App() {
       await syncModeToController(mode);
       send(trimmed, submitText.trim());
     },
-    [switchModel, openMemory, syncModeToController, mode, send, notice, t],
+    [switchModel, openMemory, syncModeToController, mode, send, runShell, notice, t],
   );
 
   const addToChat = useCallback((text: string) => {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+import { ShellExpandProvider, useShellExpand } from "./lib/shellExpand";
 import {
   SquarePen,
   Brain,
@@ -132,6 +133,24 @@ function sessionTitle(session: SessionMeta, fallback: string): string {
 
 function sessionTime(ms: number): string {
   return new Date(ms).toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+
+/** Global hotkey handler for shell-expand toggle (Ctrl/Cmd+B). */
+function ShellHotkeys() {
+  const shellExpand = useShellExpand();
+  useEffect(() => {
+    if (!shellExpand) return;
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "b") {
+        e.preventDefault();
+        shellExpand.toggleLast();
+      }
+    };
+    document.addEventListener("keydown", onKey as (e: globalThis.KeyboardEvent) => void);
+    return () => document.removeEventListener("keydown", onKey as (e: globalThis.KeyboardEvent) => void);
+  }, [shellExpand]);
+  return null;
 }
 
 export default function App() {
@@ -683,6 +702,8 @@ export default function App() {
       : t("sidebar.collapse");
 
   return (
+    <ShellExpandProvider>
+    <ShellHotkeys />
     <div className="app">
       <div
         className={[
@@ -1074,5 +1095,6 @@ export default function App() {
 
       {needsOnboarding && <OnboardingOverlay onComplete={() => setNeedsOnboarding(false)} />}
     </div>
+    </ShellExpandProvider>
   );
 }

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -865,12 +865,12 @@ export function Composer({
           onDoubleClick={resetComposerHeight}
         />
         <div
-          className={`composer${dragOver ? " composer--dragover" : ""}${disabled ? " composer--disabled" : ""}`}
+          className={`composer${dragOver ? " composer--dragover" : ""}${disabled ? " composer--disabled" : ""}${text.trimStart().startsWith("!") ? " composer--shell" : ""}`}
           onDrop={onDrop}
           onDragOver={onDragOver}
           onDragLeave={onDragLeave}
         >
-          <span className="composer__caret">›</span>
+          <span className="composer__caret">{text.trimStart().startsWith("!") ? "$" : "›"}</span>
           <textarea
             ref={taRef}
             className="composer__input"

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import {
   Ban,
   Check,
@@ -19,6 +19,7 @@ import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
 import { useT } from "../lib/i18n";
 import { diffsFor, subjectOf, summarize } from "../lib/tools";
+import { useShellExpand } from "../lib/shellExpand";
 import type { Item } from "../lib/useController";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
@@ -36,6 +37,9 @@ const ICONS: Record<string, LucideIcon> = {
   task: ListTree,
 };
 
+/** Lines shown by default in a shell output block before the "show all" button. */
+const SHELL_PREVIEW_LINES = 10;
+
 function pretty(json: string): string {
   try {
     return JSON.stringify(JSON.parse(json), null, 2);
@@ -49,6 +53,14 @@ function StatusGlyph({ status }: { status: ToolItem["status"] }) {
   if (status === "error") return <X className="ico ico--err" size={13} />;
   if (status === "stopped") return <Ban className="ico ico--stopped" size={13} />;
   return <Check className="ico ico--ok" size={13} />;
+}
+
+/** Returns the first n lines of text and the total line count. */
+function splitPreview(text: string, n: number): { preview: string; total: number; hasMore: boolean } {
+  const lines = text.split("\n");
+  const total = lines.length;
+  if (total <= n) return { preview: text, total, hasMore: false };
+  return { preview: lines.slice(0, n).join("\n"), total, hasMore: true };
 }
 
 // ToolCard renders one tool call. `subcalls` are sub-agent calls nested under a
@@ -72,9 +84,19 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
 
   // edit diffs are the point of the card, so they're shown inline; everything
   // else folds its args/output away by default. Nested children always show.
+  // Shell commands default to open so the output is immediately visible.
   const hasBody = diffs.length === 0 && (!!item.args || !!item.output);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(item.isShell && hasBody);
+  const [showAll, setShowAll] = useState(false);
   const expandable = hasBody;
+
+  // Register this shell card's toggle with the global ShellExpand context so
+  // Ctrl/Cmd+B can expand/collapse the most recent shell output.
+  const shellExpand = useShellExpand();
+  useEffect(() => {
+    if (!item.isShell || !shellExpand) return;
+    return shellExpand.register(item.id, () => setOpen((v) => !v));
+  }, [item.isShell, item.id, shellExpand]);
 
   // Read-only "research" calls (read/grep/ls/glob/web_fetch) are quieted to a
   // slim, borderless, dim row so a long run of them doesn't bury the few calls
@@ -82,6 +104,10 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   // full card. Uses the readOnly flag, not a tool-name list.
   const quiet =
     item.readOnly && !hasNested && item.status !== "error" && item.status !== "stopped";
+
+  // Shell output: split into preview + "show all" toggle.
+  const shellOutput = item.isShell && item.output ? item.output : null;
+  const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
 
   return (
     <div className={`tool tool--${item.status} ${quiet ? "tool--quiet" : ""}`}>
@@ -119,7 +145,21 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
         </div>
       )}
 
-      {hasBody && open && (
+      {/* Shell output: always visible (auto-open), with preview/show-all toggle */}
+      {shellPreview && open && (
+        <div className="tool__body">
+          <CodeViewer value={showAll ? shellOutput! : shellPreview.preview} maxHeight={showAll ? 480 : 260} />
+          {shellPreview.hasMore && !showAll && (
+            <button className="tool__showall" onClick={() => setShowAll(true)}>
+              {t("tool.showAllLines", { n: shellPreview.total })}
+            </button>
+          )}
+          {item.truncated && <div className="tool__note">{t("tool.truncated")}</div>}
+        </div>
+      )}
+
+      {/* Non-shell body: args + output, gated by open */}
+      {!shellPreview && hasBody && open && (
         <div className="tool__body">
           {item.args && <CodeViewer value={pretty(item.args)} language="json" maxHeight={180} />}
           {item.output && (

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -43,6 +43,7 @@ export interface AppBindings {
   Platform(): Promise<string>;
   Submit(input: string): Promise<void>;
   SubmitDisplay(display: string, input: string): Promise<void>;
+  RunShell(command: string): Promise<void>;
   Cancel(): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
   AnswerQuestion(id: string, answers: QuestionAnswer[]): Promise<void>;
@@ -513,6 +514,21 @@ function makeMockApp(): AppBindings {
     },
     async SubmitDisplay(_display, input) {
       await this.Submit(input);
+    },
+    async RunShell(command) {
+      cancelled = false;
+      emit({ kind: "turn_started" });
+      await delay(100);
+      if (cancelled) return;
+      const id = `shell-${command.slice(0, 32)}`;
+      emit({ kind: "tool_dispatch", tool: { id, name: "bash", args: JSON.stringify({ command }), readOnly: false } });
+      await delay(200);
+      if (cancelled) return;
+      emit({ kind: "tool_progress", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
+      await delay(100);
+      if (cancelled) return;
+      emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
+      emit({ kind: "turn_done" });
     },
     async Cancel() {
       cancelled = true;

--- a/desktop/frontend/src/lib/shellExpand.tsx
+++ b/desktop/frontend/src/lib/shellExpand.tsx
@@ -1,0 +1,43 @@
+import { createContext, useCallback, useContext, useMemo, useRef, type ReactNode } from "react";
+
+// Shell-expand coordination: ToolCards register their toggle callbacks, and
+// Cmd+B (from App) calls the most recent one.
+
+type ToggleFn = () => void;
+
+interface ShellExpandCtx {
+  register: (id: string, toggle: ToggleFn) => void;
+  toggleLast: () => void;
+}
+
+const Ctx = createContext<ShellExpandCtx | null>(null);
+
+export function ShellExpandProvider({ children }: { children: ReactNode }) {
+  const mapRef = useRef(new Map<string, ToggleFn>());
+  const orderRef: { current: string[] } = useRef<string[]>([]);
+
+  const register = useCallback((id: string, toggle: ToggleFn) => {
+    mapRef.current.set(id, toggle);
+    if (!orderRef.current.includes(id)) {
+      orderRef.current.push(id);
+    }
+    return () => {
+      mapRef.current.delete(id);
+      orderRef.current = orderRef.current.filter((x) => x !== id);
+    };
+  }, []);
+
+  const toggleLast = useCallback(() => {
+    const ids = orderRef.current;
+    if (ids.length === 0) return;
+    const fn = mapRef.current.get(ids[ids.length - 1]);
+    fn?.();
+  }, []);
+
+  const value = useMemo(() => ({ register, toggleLast }), [register, toggleLast]);
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useShellExpand() {
+  return useContext(Ctx);
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -54,6 +54,7 @@ export type Item =
       output?: string;
       error?: string;
       truncated?: boolean;
+      isShell?: boolean; // true for !-prefix shell commands (controls default expand)
       parentId?: string; // a sub-agent call nests under the `task` call with this id
     };
 
@@ -229,16 +230,7 @@ function applyEvent(s: State, e: WireEvent): State {
         }
         return { ...s, items: next };
       }
-      const item: Item = {
-        kind: "tool",
-        id,
-        name: t.name,
-        args: t.args ?? "",
-        readOnly: t.readOnly,
-        status: "running",
-        parentId: t.parentId,
-      };
-      return { ...s, seq: s.seq + 1, items: [...s.items, item] };
+      return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "tool", id, name: t.name, args: t.args ?? "", readOnly: t.readOnly, status: "running", isShell: id.startsWith("shell-"), parentId: t.parentId }] };
     }
 
     case "tool_result": {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -556,6 +556,11 @@ export function useController() {
     call.catch(() => {});
   }, []);
 
+  const runShell = useCallback((command: string) => {
+    dispatch({ type: "user", text: `!${command}` });
+    app.RunShell(command).catch(() => {});
+  }, []);
+
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
     dispatch({ type: "local_notice", level, text });
   }, []);
@@ -751,6 +756,7 @@ export function useController() {
   return {
     state,
     send,
+    runShell,
     notice,
     cancel,
     approve,

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -431,6 +431,7 @@ export const en = {
   "tool.stepOne": "{n} step",
   "tool.stepOther": "{n} steps",
   "tool.truncated": "output truncated",
+  "tool.showAllLines": "show all {n} lines",
   "tool.lineOne": "{n} line",
   "tool.lineOther": "{n} lines",
   "tool.matchOne": "{n} match",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -432,6 +432,7 @@ export const zh: Record<DictKey, string> = {
   "tool.stepOne": "{n} 步",
   "tool.stepOther": "{n} 步",
   "tool.truncated": "输出已截断",
+  "tool.showAllLines": "显示全部 {n} 行",
   "tool.lineOne": "{n} 行",
   "tool.lineOther": "{n} 行",
   "tool.matchOne": "{n} 处匹配",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -43,6 +43,7 @@
   --err: #e0696a;
   --danger: #e5484d;
   --danger-fg: #fff;
+  --shell-accent: #22c55e;
 
   /* component recipes */
   --list-row-height: 38px;
@@ -1458,6 +1459,21 @@ body {
   color: var(--fg-faint);
   margin-top: 3px;
 }
+.tool__showall {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  line-height: 1.6;
+}
+.tool__showall:hover {
+  background: color-mix(in srgb, var(--accent-soft) 60%, transparent);
+}
 .tool__err {
   margin: 0 11px 10px 30px;
   padding: 7px 10px;
@@ -1741,6 +1757,16 @@ body {
 .composer--disabled:focus-within {
   border-color: var(--border);
   box-shadow: none;
+}
+.composer--shell {
+  border-bottom-color: var(--shell-accent);
+}
+.composer--shell:focus-within {
+  border-bottom-color: var(--shell-accent);
+  box-shadow: 0 1px 0 0 var(--shell-accent);
+}
+.composer--shell .composer__caret {
+  color: var(--shell-accent);
 }
 .composer__caret {
   color: var(--accent);

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -898,6 +898,27 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, finalize(m, cmds)
 			}
 
+			// "!<cmd>" runs a shell command directly, bypassing the model.
+			if strings.HasPrefix(line, "!") {
+				cmd := strings.TrimPrefix(line, "!")
+				m.input.Reset()
+				m.input.SetHeight(1)
+				m.pastedBlocks = nil
+				m.state = tuiRunning
+				m.runStart = time.Now()
+				m.elapsed = 0
+				m.turnTokens = 0
+				m.pendingRestore = line
+				m.bubbleStartIdx = len(m.transcript)
+				m.commitLine("")
+				m.commitLine(renderUserBubble(line, m.width, m.planMode))
+				m.bubblePending = true
+				m.turnDiscarded = false
+				m.confirmBubbleSent() // shell events arrive instantly
+				m.ctrl.RunShell(cmd)
+				return m, tea.Batch(m.spinner.Tick, elapsedTick())
+			}
+
 			// Slash commands run locally without going through the model. A
 			// '/'-leading line that's actually a dragged file path is an attachment,
 			// not a command, so it's rewritten to an @reference instead.

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -140,6 +140,14 @@ type chatTUI struct {
 	toolTail      []string
 	toolPartial   string
 	toolLineCount int
+	// shellOutputs stores the full accumulated output of each shell command
+	// (tool IDs with "shell-" prefix), so the first 10 lines can be shown after
+	// collapse and Ctrl+B can toggle the complete output.
+	shellOutputs  map[string]string
+	shellExpanded map[string]bool
+	// shellTranscriptIdx maps a shell tool ID to the transcript index of its
+	// collapsed output block, so Ctrl+B can rewrite it in place.
+	shellTranscriptIdx map[string]int
 	// toolStreamStart / toolStreamFrame drive the "⎿ working · Ns" line shown
 	// under a dispatched tool that hasn't produced output yet, so a slow tool
 	// (e.g. codegraph_context) reads as making progress rather than frozen.
@@ -438,6 +446,9 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		pending:              &strings.Builder{},
 		pendingCommit:        &commitBuf,
 		renderer:             newMarkdownRenderer(termW),
+		shellOutputs:         make(map[string]string),
+		shellExpanded:        make(map[string]bool),
+		shellTranscriptIdx:   make(map[string]int),
 		eventCh:              eventCh,
 		history:              ctrl.History(),
 		host:                 ctrl.Host(),
@@ -850,6 +861,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, finalize(m, cmds)
 		case "ctrl+o":
 			m.toggleVerboseReasoning(m.state != tuiRunning)
+			return m, finalize(m, cmds)
+		case "ctrl+b":
+			m.toggleShellOutput()
 			return m, finalize(m, cmds)
 		case "shift+tab":
 			// Cycle auto → plan → YOLO; allowed mid-turn so the user can flip the
@@ -1352,6 +1366,10 @@ func reasoningBlock(raw string, width, maxLines int) string {
 // the live block scrolls within this window so a chatty build doesn't flood.
 const toolStreamTailLines = 8
 
+// shellPreviewLines is how many lines of shell output to show by default after
+// the command finishes. Ctrl+B toggles the full output.
+const shellPreviewLines = 10
+
 // streamToolOutput appends a chunk of a running tool's output and re-renders its
 // live block (the last toolStreamTailLines lines) under the tool card, opening
 // the block on the first chunk. Mirrors streamReasoning.
@@ -1367,6 +1385,10 @@ func (m *chatTUI) streamToolOutput(id, chunk string) {
 		m.toolLineCount = 0
 		m.toolStreamIdx = len(m.transcript)
 		m.commitLine("")
+	}
+	// Accumulate full output for shell commands so Ctrl+B can expand it.
+	if strings.HasPrefix(id, "shell-") {
+		m.shellOutputs[id] += chunk
 	}
 	// Fold completed lines into the bounded tail; keep the trailing partial.
 	data := m.toolPartial + chunk
@@ -1405,7 +1427,9 @@ func (m *chatTUI) pushToolLine(line string) {
 
 // collapseToolOutput replaces a finished tool's live block with a dim
 // "⎿ N lines" summary, so the scrollback keeps a marker of the run without the
-// full output (which the model already received). No-op when id isn't streaming.
+// full output (which the model already received). For shell commands ("shell-"
+// prefix), it shows the first shellPreviewLines with a Ctrl+B hint instead.
+// No-op when id isn't streaming.
 func (m *chatTUI) collapseToolOutput(id string) {
 	if m.toolStreamIdx < 0 || id == "" || m.toolStreamID != id {
 		return
@@ -1415,14 +1439,30 @@ func (m *chatTUI) collapseToolOutput(id string) {
 		n++
 	}
 	if n == 0 {
-		// The tool produced no streamed output (e.g. an MCP call like
-		// codegraph_context) — drop the "working" placeholder so only the card
-		// remains, rather than leaving a "0 lines" summary.
 		if m.toolStreamIdx == len(m.transcript)-1 {
 			m.transcript = m.transcript[:m.toolStreamIdx]
 		} else {
 			m.transcript[m.toolStreamIdx] = ""
 		}
+	} else if full, ok := m.shellOutputs[id]; ok {
+		// Shell command: show first N lines + hint.
+		lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
+		total := len(lines)
+		if total > shellPreviewLines {
+			preview := make([]string, shellPreviewLines+1)
+			for i := 0; i < shellPreviewLines; i++ {
+				preview[i] = dim(clampPlain(lines[i], m.width-len([]rune(connector))))
+			}
+			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", total-shellPreviewLines))
+			m.transcript[m.toolStreamIdx] = connectorBlock(preview)
+		} else {
+			rendered := make([]string, total)
+			for i, ln := range lines {
+				rendered[i] = dim(clampPlain(ln, m.width-len([]rune(connector))))
+			}
+			m.transcript[m.toolStreamIdx] = connectorBlock(rendered)
+		}
+		m.shellTranscriptIdx[id] = m.toolStreamIdx
 	} else {
 		m.transcript[m.toolStreamIdx] = connectorBlock([]string{dim(fmt.Sprintf("%d lines", n))})
 	}
@@ -1432,6 +1472,51 @@ func (m *chatTUI) collapseToolOutput(id string) {
 	m.toolTail = m.toolTail[:0]
 	m.toolPartial = ""
 	m.toolLineCount = 0
+}
+
+// toggleShellOutput expands or collapses the output of the most recent shell
+// command. When expanded, the full output replaces the preview; when collapsed,
+// only the first shellPreviewLines are shown. Called on Ctrl+B.
+func (m *chatTUI) toggleShellOutput() {
+	// Find the most recent shell output that has a transcript entry.
+	var lastID string
+	var lastIdx int
+	for id, idx := range m.shellTranscriptIdx {
+		if idx > lastIdx {
+			lastID = id
+			lastIdx = idx
+		}
+	}
+	if lastID == "" {
+		return
+	}
+	full, ok := m.shellOutputs[lastID]
+	if !ok {
+		return
+	}
+	if m.shellExpanded[lastID] {
+		// Collapse: show preview.
+		m.shellExpanded[lastID] = false
+		lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
+		if len(lines) > shellPreviewLines {
+			preview := make([]string, shellPreviewLines+1)
+			for i := 0; i < shellPreviewLines; i++ {
+				preview[i] = dim(clampPlain(lines[i], m.width-len([]rune(connector))))
+			}
+			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", len(lines)-shellPreviewLines))
+			m.transcript[lastIdx] = connectorBlock(preview)
+		}
+	} else {
+		// Expand: show full output.
+		m.shellExpanded[lastID] = true
+		lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
+		rendered := make([]string, len(lines))
+		for i, ln := range lines {
+			rendered[i] = dim(clampPlain(ln, m.width-len([]rune(connector))))
+		}
+		m.transcript[lastIdx] = connectorBlock(rendered)
+	}
+	m.transcriptDirty = true
 }
 
 // toolWorkingFrames is the braille spinner cycled once per second on the
@@ -1629,13 +1714,25 @@ func (m chatTUI) View() tea.View {
 		boxW = 10
 	}
 	hideComposer := m.hideComposer()
+	shellMode := strings.HasPrefix(strings.TrimSpace(m.input.Value()), "!")
 	var box string
 	if !hideComposer {
-		box = inputBoxStyle.Width(boxW).Render(m.input.View())
+		style := inputBoxStyle.Width(boxW)
+		if shellMode {
+			style = style.BorderForeground(lipgloss.Color(statusShellColor.hex))
+		}
+		box = style.Render(m.input.View())
 	}
 
 	var modeTag string
 	switch {
+	case shellMode:
+		modeTag = lipgloss.NewStyle().
+			Background(lipgloss.Color(statusShellColor.hex)).
+			Foreground(lipgloss.Color("#ffffff")).
+			Bold(true).
+			Padding(0, 1).
+			Render("Shell")
 	case m.ctrl.Bypass():
 		modeTag = lipgloss.NewStyle().
 			Background(lipgloss.Color(statusYoloColor.hex)).
@@ -1676,6 +1773,8 @@ func (m chatTUI) View() tea.View {
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusPlanApproval
 	case m.pendingApproval != nil:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusToolApproval
+	case shellMode:
+		status = "  " + modeTag + " · " + i18n.M.ShellModeHint
 	case m.ctrl.Bypass():
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusYoloIdle + " " + dim("("+i18n.M.ChatStatusCycleHint+")")
 	default:

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -810,6 +810,13 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.unsendPending()
 			case m.state == tuiRunning:
 				m.ctrl.Cancel()
+				// Defensive: if the controller is no longer running (cancel
+				// completed synchronously, e.g. for shell commands), transition
+				// to idle immediately instead of waiting for TurnDone.
+				if !m.ctrl.Running() {
+					m.state = tuiIdle
+					m.confirmBubbleSent()
+				}
 			case m.ctrl.Bypass():
 				m.ctrl.SetBypass(false) // back out of YOLO
 			case m.planMode:

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -599,13 +599,23 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseClickMsg:
 		// Right-click copies the active selection (Windows Terminal convention);
-		// left-press in the transcript region begins a text selection.
+		// left-press in the transcript region begins a text selection — unless
+		// the click lands on a shell-output hint line, which toggles expand.
 		if msg.Button == tea.MouseRight && m.sel.active && !m.sel.empty() {
 			text := m.selectedText()
 			m.sel = selection{}
 			return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
 		}
 		if msg.Button == tea.MouseLeft && msg.Y < m.viewport.Height() {
+			// Check if the clicked line is a shell-output hint.
+			lineIdx := m.viewport.YOffset() + msg.Y
+			if lineIdx >= 0 && lineIdx < len(m.wrappedLines) {
+				clicked := m.wrappedLines[lineIdx]
+				if strings.Contains(clicked, "more lines") && strings.Contains(clicked, "Ctrl+B") {
+					m.toggleShellOutput()
+					return m, finalize(m, cmds)
+				}
+			}
 			at := m.transcriptCaret(msg.X, msg.Y)
 			m.sel = selection{active: true, anchor: at, head: at}
 			m.autoScroll = 0
@@ -1458,7 +1468,7 @@ func (m *chatTUI) collapseToolOutput(id string) {
 			for i := 0; i < shellPreviewLines; i++ {
 				preview[i] = dim(clampPlain(lines[i], m.width-len([]rune(connector))))
 			}
-			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", total-shellPreviewLines))
+			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (click/Ctrl+B)", total-shellPreviewLines))
 			m.transcript[m.toolStreamIdx] = connectorBlock(preview)
 		} else {
 			rendered := make([]string, total)
@@ -1514,7 +1524,7 @@ func (m *chatTUI) toggleShellOutput() {
 			for i := 0; i < shellPreviewLines; i++ {
 				preview[i] = dim(clampPlain(lines[i], innerW))
 			}
-			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", total-shellPreviewLines))
+			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (click/Ctrl+B)", total-shellPreviewLines))
 			m.transcript[lastIdx] = connectorBlock(preview)
 		}
 	} else {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1370,6 +1370,11 @@ const toolStreamTailLines = 8
 // the command finishes. Ctrl+B toggles the full output.
 const shellPreviewLines = 10
 
+// shellExpandMaxLines caps how many lines Ctrl+B shows in expanded mode, so a
+// very large output (e.g. thousands of lines) doesn't hang the TUI or push the
+// input box off-screen.
+const shellExpandMaxLines = 200
+
 // streamToolOutput appends a chunk of a running tool's output and re-renders its
 // live block (the last toolStreamTailLines lines) under the tool card, opening
 // the block on the first chunk. Mirrors streamReasoning.
@@ -1475,8 +1480,8 @@ func (m *chatTUI) collapseToolOutput(id string) {
 }
 
 // toggleShellOutput expands or collapses the output of the most recent shell
-// command. When expanded, the full output replaces the preview; when collapsed,
-// only the first shellPreviewLines are shown. Called on Ctrl+B.
+// command. When expanded, up to shellExpandMaxLines lines are shown; when
+// collapsed, only the first shellPreviewLines are shown. Called on Ctrl+B.
 func (m *chatTUI) toggleShellOutput() {
 	// Find the most recent shell output that has a transcript entry.
 	var lastID string
@@ -1494,25 +1499,37 @@ func (m *chatTUI) toggleShellOutput() {
 	if !ok {
 		return
 	}
+	lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
+	total := len(lines)
+	innerW := m.width - len([]rune(connector))
+	if innerW < 10 {
+		innerW = 80
+	}
+
 	if m.shellExpanded[lastID] {
-		// Collapse: show preview.
+		// Collapse back to preview.
 		m.shellExpanded[lastID] = false
-		lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
-		if len(lines) > shellPreviewLines {
+		if total > shellPreviewLines {
 			preview := make([]string, shellPreviewLines+1)
 			for i := 0; i < shellPreviewLines; i++ {
-				preview[i] = dim(clampPlain(lines[i], m.width-len([]rune(connector))))
+				preview[i] = dim(clampPlain(lines[i], innerW))
 			}
-			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", len(lines)-shellPreviewLines))
+			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (Ctrl+B)", total-shellPreviewLines))
 			m.transcript[lastIdx] = connectorBlock(preview)
 		}
 	} else {
-		// Expand: show full output.
+		// Expand: show up to shellExpandMaxLines lines.
 		m.shellExpanded[lastID] = true
-		lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
-		rendered := make([]string, len(lines))
-		for i, ln := range lines {
-			rendered[i] = dim(clampPlain(ln, m.width-len([]rune(connector))))
+		show := total
+		if show > shellExpandMaxLines {
+			show = shellExpandMaxLines
+		}
+		rendered := make([]string, show)
+		for i := 0; i < show; i++ {
+			rendered[i] = dim(clampPlain(lines[i], innerW))
+		}
+		if total > shellExpandMaxLines {
+			rendered = append(rendered, dim(fmt.Sprintf("… %d more lines", total-shellExpandMaxLines)))
 		}
 		m.transcript[lastIdx] = connectorBlock(rendered)
 	}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -925,6 +925,13 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// "!<cmd>" runs a shell command directly, bypassing the model.
 			if strings.HasPrefix(line, "!") {
 				cmd := strings.TrimPrefix(line, "!")
+				if strings.TrimSpace(cmd) == "" {
+					m.input.Reset()
+					m.input.SetHeight(1)
+					m.pastedBlocks = nil
+					m.notice(i18n.M.ShellExecEmpty)
+					return m, finalize(m, cmds)
+				}
 				m.input.Reset()
 				m.input.SetHeight(1)
 				m.pastedBlocks = nil

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -121,9 +121,10 @@ func (m chatTUI) gitTag() string {
 }
 
 var (
-	statusAutoColor = cliColor{"#f59e0b", 214}
-	statusPlanColor = cliColor{"#2563eb", 27}
-	statusYoloColor = cliColor{"#e5484d", 167}
+	statusAutoColor  = cliColor{"#f59e0b", 214}
+	statusPlanColor  = cliColor{"#2563eb", 27}
+	statusYoloColor  = cliColor{"#e5484d", 167}
+	statusShellColor = cliColor{"#16a34a", 71} // green — shell mode indicator
 )
 
 func (m chatTUI) statusModeColor() cliColor {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -550,6 +550,10 @@ func (c *Controller) rememberProjectNote(note string) {
 // the bash tool's timeout so behaviour is consistent across invocation paths.
 const shellTimeout = 120 * time.Second
 
+// shellWaitDelay bounds how long cmd.Run() waits after context cancellation for
+// the child's pipes to drain, matching the bash tool's WaitDelay.
+const shellWaitDelay = 5 * time.Second
+
 // shellWriter forwards each chunk of shell output to a callback, so RunShell
 // can stream live progress to the frontend as the command produces output.
 type shellWriter struct{ emit func(string) }
@@ -572,13 +576,13 @@ func (c *Controller) RunShell(command string) {
 	}
 	c.runGuarded(func(ctx context.Context) error {
 		sh := sandbox.ResolveShell()
-		argv, _ := sandbox.Command(sandbox.Spec{}, sh, command)
+		argv, _ := sandbox.Command(sandbox.Spec{}, sh, command) // false = unsandboxed (user invoked)
 
-		preview := command
+		preview := []rune(command)
 		if len(preview) > 32 {
 			preview = preview[:32]
 		}
-		id := "shell-" + preview
+		id := "shell-" + string(preview)
 
 		c.sink.Emit(event.Event{
 			Kind: event.ToolDispatch,
@@ -593,6 +597,8 @@ func (c *Controller) RunShell(command string) {
 		defer cancel()
 
 		cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+		setShellKillTree(cmd)
+		cmd.WaitDelay = shellWaitDelay
 		var buf bytes.Buffer
 		w := io.MultiWriter(&buf, &shellWriter{emit: func(chunk string) {
 			c.sink.Emit(event.Event{

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -599,6 +599,7 @@ func (c *Controller) RunShell(command string) {
 		cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 		setShellKillTree(cmd)
 		cmd.WaitDelay = shellWaitDelay
+		cmd.Dir = c.cpRoot
 		var buf bytes.Buffer
 		w := io.MultiWriter(&buf, &shellWriter{emit: func(chunk string) {
 			c.sink.Emit(event.Event{

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -11,15 +11,19 @@
 package control
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/billing"
@@ -30,12 +34,14 @@ import (
 	"reasonix/internal/diff"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
+	"reasonix/internal/i18n"
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
 	"reasonix/internal/nilutil"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/sandbox"
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
@@ -434,6 +440,10 @@ func (c *Controller) Submit(input string) {
 		c.rememberProjectNote(note)
 		return
 	}
+	if strings.HasPrefix(trimmed, "!") {
+		c.RunShell(trimmed[1:])
+		return
+	}
 	switch {
 	case trimmed == "/compact" || strings.HasPrefix(trimmed, "/compact "):
 		focus := strings.TrimSpace(strings.TrimPrefix(trimmed, "/compact"))
@@ -534,6 +544,87 @@ func (c *Controller) rememberProjectNote(note string) {
 	} else {
 		c.notice("remembered → " + path)
 	}
+}
+
+// shellTimeout is the maximum time a user-invoked "!command" may run. Matches
+// the bash tool's timeout so behaviour is consistent across invocation paths.
+const shellTimeout = 120 * time.Second
+
+// shellWriter forwards each chunk of shell output to a callback, so RunShell
+// can stream live progress to the frontend as the command produces output.
+type shellWriter struct{ emit func(string) }
+
+func (w *shellWriter) Write(p []byte) (int, error) {
+	w.emit(string(p))
+	return len(p), nil
+}
+
+// RunShell executes a shell command directly (bypassing the model) and streams
+// the output as ToolDispatch/ToolProgress/ToolResult events. It uses the same
+// bash-tool infrastructure (shell resolution, timeout) and shares the runGuarded
+// lock with model turns — only one can run at a time. User-invoked "!" commands
+// run without the OS sandbox (the user typed the command explicitly).
+func (c *Controller) RunShell(command string) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		c.notice(i18n.M.ShellExecEmpty)
+		return
+	}
+	c.runGuarded(func(ctx context.Context) error {
+		sh := sandbox.ResolveShell()
+		argv, _ := sandbox.Command(sandbox.Spec{}, sh, command)
+
+		preview := command
+		if len(preview) > 32 {
+			preview = preview[:32]
+		}
+		id := "shell-" + preview
+
+		c.sink.Emit(event.Event{
+			Kind: event.ToolDispatch,
+			Tool: event.Tool{
+				ID:   id,
+				Name: "bash",
+				Args: fmt.Sprintf(`{"command":%q}`, command),
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(ctx, shellTimeout)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+		var buf bytes.Buffer
+		w := io.MultiWriter(&buf, &shellWriter{emit: func(chunk string) {
+			c.sink.Emit(event.Event{
+				Kind: event.ToolProgress,
+				Tool: event.Tool{ID: id, Output: chunk},
+			})
+		}})
+		cmd.Stdout = w
+		cmd.Stderr = w
+		err := cmd.Run()
+		out := buf.String()
+
+		if ctx.Err() == context.DeadlineExceeded {
+			c.sink.Emit(event.Event{
+				Kind: event.ToolResult,
+				Tool: event.Tool{ID: id, Name: "bash", Output: out, Err: fmt.Sprintf(i18n.M.ShellExecTimeoutFmt, shellTimeout)},
+			})
+			return nil
+		}
+		if err != nil {
+			c.sink.Emit(event.Event{
+				Kind: event.ToolResult,
+				Tool: event.Tool{ID: id, Name: "bash", Output: out, Err: fmt.Sprintf(i18n.M.ShellExecFailedFmt, err)},
+			})
+			return nil
+		}
+		c.sink.Emit(event.Event{
+			Kind: event.ToolResult,
+			Tool: event.Tool{ID: id, Name: "bash", Output: out},
+		})
+		return nil
+	})
 }
 
 // runRefTurn resolves a line's @references into a context block and starts a

--- a/internal/control/shell_kill_other.go
+++ b/internal/control/shell_kill_other.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package control
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setShellKillTree makes a cancelled shell command kill its whole process group,
+// not just the shell leader — otherwise a timed-out pipeline (e.g.
+// !find / -name foo | grep bar) orphans the children. The child gets its own
+// group (Setpgid) so the negative-pid signal reaches every descendant.
+func setShellKillTree(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/control/shell_kill_windows.go
+++ b/internal/control/shell_kill_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package control
+
+import (
+	"os/exec"
+	"strconv"
+
+	"reasonix/internal/proc"
+)
+
+// setShellKillTree hides the child's console and makes a cancelled command kill
+// its whole process tree. Windows does not cascade a kill to child processes, so
+// killing the shell leaves spawned commands running after a timeout; taskkill /T
+// walks the PID tree and /F forces it.
+func setShellKillTree(cmd *exec.Cmd) {
+	proc.HideWindow(cmd)
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		kill := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(cmd.Process.Pid))
+		proc.HideWindow(kill)
+		_ = kill.Run()
+		return cmd.Process.Kill()
+	}
+}

--- a/internal/control/shell_test.go
+++ b/internal/control/shell_test.go
@@ -1,0 +1,141 @@
+package control
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+// collectSink returns a Sink that collects events and a channel that receives
+// the TurnDone event when the turn finishes. The channel lets tests wait for
+// the runGuarded goroutine to complete.
+func collectSink() (event.Sink, chan event.Event, *[]event.Event) {
+	var events []event.Event
+	done := make(chan event.Event, 1)
+	sink := event.FuncSink(func(e event.Event) {
+		events = append(events, e)
+		if e.Kind == event.TurnDone {
+			done <- e
+		}
+	})
+	return sink, done, &events
+}
+
+func waitForDone(t *testing.T, done chan event.Event) event.Event {
+	t.Helper()
+	select {
+	case e := <-done:
+		return e
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for TurnDone")
+		return event.Event{}
+	}
+}
+
+func TestRunShell_EmitsEvents(t *testing.T) {
+	sink, done, events := collectSink()
+	ctrl := &Controller{sink: sink}
+
+	ctrl.RunShell("echo hello")
+	waitForDone(t, done)
+
+	if len(*events) < 3 {
+		t.Fatalf("expected at least 3 events, got %d: %v", len(*events), *events)
+	}
+
+	// First event: ToolDispatch
+	if (*events)[0].Kind != event.ToolDispatch {
+		t.Errorf("first event: want ToolDispatch, got %v", (*events)[0].Kind)
+	}
+	if (*events)[0].Tool.Name != "bash" {
+		t.Errorf("tool name: want bash, got %s", (*events)[0].Tool.Name)
+	}
+
+	// Last event: TurnDone
+	td := (*events)[len(*events)-1]
+	if td.Kind != event.TurnDone {
+		t.Errorf("last event: want TurnDone, got %v", td.Kind)
+	}
+
+	// Penultimate event: ToolResult
+	last := (*events)[len(*events)-2]
+	if last.Kind != event.ToolResult {
+		t.Errorf("penultimate event: want ToolResult, got %v", last.Kind)
+	}
+	if last.Tool.Err != "" {
+		t.Errorf("unexpected error: %s", last.Tool.Err)
+	}
+	if !strings.Contains(last.Tool.Output, "hello") {
+		t.Errorf("output should contain 'hello', got: %s", last.Tool.Output)
+	}
+}
+
+func TestSubmit_BangPrefix(t *testing.T) {
+	sink, done, events := collectSink()
+	ctrl := &Controller{sink: sink}
+
+	ctrl.Submit("!echo test")
+	waitForDone(t, done)
+
+	if len(*events) == 0 {
+		t.Fatal("expected events from !echo, got none")
+	}
+	if (*events)[0].Kind != event.ToolDispatch {
+		t.Errorf("first event: want ToolDispatch, got %v", (*events)[0].Kind)
+	}
+}
+
+func TestSubmit_BangEmpty(t *testing.T) {
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+
+	ctrl := &Controller{sink: sink}
+	ctrl.Submit("!")
+
+	if len(notices) == 0 {
+		t.Fatal("expected a notice for bare !")
+	}
+	if !strings.Contains(notices[0], "!") {
+		t.Errorf("notice should mention usage, got: %s", notices[0])
+	}
+}
+
+func TestSubmit_BangNotFirstChar(t *testing.T) {
+	// "! " not at position 0 should NOT trigger shell. Submit routes to
+	// runRefTurn for normal text, which needs a runner — so we test the
+	// prefix-check condition directly.
+	input := "tell me about !important"
+	trimmed := strings.TrimSpace(input)
+	if strings.HasPrefix(trimmed, "!") {
+		t.Error("trimmed input should not start with !")
+	}
+}
+
+func TestRunShell_FailingCommand(t *testing.T) {
+	sink, done, events := collectSink()
+	ctrl := &Controller{sink: sink}
+
+	ctrl.RunShell("false") // exits 1
+	waitForDone(t, done)
+
+	// Find the ToolResult
+	var result *event.Event
+	for i := range *events {
+		if (*events)[i].Kind == event.ToolResult {
+			result = &(*events)[i]
+			break
+		}
+	}
+	if result == nil {
+		t.Fatal("expected a ToolResult event")
+	}
+	if result.Tool.Err == "" {
+		t.Error("failing command should produce an error string")
+	}
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -126,9 +126,10 @@ type Messages struct {
 	CompHintFile       string // key hint footer under the @ file/resource menu
 
 	// shell execution (! prefix).
-	ShellExecEmpty     string // bare "!" with no command
-	ShellExecFailedFmt string // "shell command failed: %v"
+	ShellExecEmpty      string // bare "!" with no command
+	ShellExecFailedFmt  string // "shell command failed: %v"
 	ShellExecTimeoutFmt string // "shell command timed out (> %s)"
+	ShellModeHint       string // status line hint when input starts with !
 
 	// slash command + sub-command descriptions shown in the menu (CLI and desktop
 	// share these via i18n.M, so both frontends localize identically).

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -125,6 +125,11 @@ type Messages struct {
 	CompHintSlash      string // key hint footer under the slash-command menu
 	CompHintFile       string // key hint footer under the @ file/resource menu
 
+	// shell execution (! prefix).
+	ShellExecEmpty     string // bare "!" with no command
+	ShellExecFailedFmt string // "shell command failed: %v"
+	ShellExecTimeoutFmt string // "shell command timed out (> %s)"
+
 	// slash command + sub-command descriptions shown in the menu (CLI and desktop
 	// share these via i18n.M, so both frontends localize identically).
 	CmdNew          string // /new

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -142,6 +142,7 @@ var English = Messages{
 	ShellExecEmpty:      "usage: !<command>  (e.g. !ls -la)",
 	ShellExecFailedFmt:  "shell command failed: %v",
 	ShellExecTimeoutFmt: "shell command timed out (> %s)",
+	ShellModeHint:       "Enter runs shell · Esc cancels",
 
 	CmdNew:          "fork a fresh session",
 	CmdCompact:      "compact context",

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -139,6 +139,10 @@ var English = Messages{
 	CompHintSlash:                "↑/↓ move · Tab/Enter select · Esc close",
 	CompHintFile:                 "↑/↓ move · Tab/Enter open folder or pick file · Esc close",
 
+	ShellExecEmpty:      "usage: !<command>  (e.g. !ls -la)",
+	ShellExecFailedFmt:  "shell command failed: %v",
+	ShellExecTimeoutFmt: "shell command timed out (> %s)",
+
 	CmdNew:          "fork a fresh session",
 	CmdCompact:      "compact context",
 	CmdRewind:       "rewind to an earlier turn",

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -142,7 +142,7 @@ var English = Messages{
 	ShellExecEmpty:      "usage: !<command>  (e.g. !ls -la)",
 	ShellExecFailedFmt:  "shell command failed: %v",
 	ShellExecTimeoutFmt: "shell command timed out (> %s)",
-	ShellModeHint:       "Enter runs shell · Esc cancels",
+	ShellModeHint:       "Enter runs shell · Esc cancels · click output to expand",
 
 	CmdNew:          "fork a fresh session",
 	CmdCompact:      "compact context",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -143,7 +143,7 @@ var Chinese = Messages{
 	ShellExecEmpty:      "用法：!<命令>  （例如 !ls -la）",
 	ShellExecFailedFmt:  "Shell 命令执行失败：%v",
 	ShellExecTimeoutFmt: "Shell 命令超时（>%s）",
-	ShellModeHint:       "Enter 执行 Shell · Esc 取消",
+	ShellModeHint:       "Enter 执行 Shell · Esc 取消 · 点击输出展开",
 
 	CmdNew:          "开启新会话",
 	CmdCompact:      "压缩上下文",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -143,6 +143,7 @@ var Chinese = Messages{
 	ShellExecEmpty:      "用法：!<命令>  （例如 !ls -la）",
 	ShellExecFailedFmt:  "Shell 命令执行失败：%v",
 	ShellExecTimeoutFmt: "Shell 命令超时（>%s）",
+	ShellModeHint:       "Enter 执行 Shell · Esc 取消",
 
 	CmdNew:          "开启新会话",
 	CmdCompact:      "压缩上下文",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -140,6 +140,10 @@ var Chinese = Messages{
 	CompHintSlash:                "↑/↓ 移动 · Tab/Enter 选中 · Esc 关闭",
 	CompHintFile:                 "↑/↓ 移动 · Tab/Enter 进入文件夹或选中文件 · Esc 关闭",
 
+	ShellExecEmpty:      "用法：!<命令>  （例如 !ls -la）",
+	ShellExecFailedFmt:  "Shell 命令执行失败：%v",
+	ShellExecTimeoutFmt: "Shell 命令超时（>%s）",
+
 	CmdNew:          "开启新会话",
 	CmdCompact:      "压缩上下文",
 	CmdRewind:       "回滚到更早的一轮",


### PR DESCRIPTION
## Summary
- Add `RunShell()` to Controller — executes shell commands directly (bypassing the AI model) and streams output as ToolDispatch/ToolProgress/ToolResult events
- Intercept `!` prefix in all three frontends: TUI Enter handler, desktop `handleSend`, and Controller `Submit` (HTTP/SSE)
- Platform-specific process-tree kill on timeout (unix: Setpgid + SIGKILL group; Windows: taskkill /T)
- i18n support (EN + ZH) for error messages

## Test Plan
- [x] `go test ./internal/control/` — 18 tests pass (5 new shell tests)
- [x] `go test ./internal/i18n/` — catalog drift-guard passes
- [x] `go build ./cmd/reasonix/` — binary builds
- [x] TypeScript type-check passes (no new errors)
- [x] Manual: `!echo hello` in TUI shows tool card with output
- [x] Manual: `!ls -la` lists project directory
- [x] Manual: bare `!` shows usage notice
- [x] Manual: Esc cancels running shell command