### PR TITLE
fix(checkpoint): create the .ckpt dir lazily, not on every New (rebase of #2972)

### DIFF
--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -72,9 +72,6 @@ type Store struct {
 func New(dir, root string) *Store {
 	s := &Store{dir: dir, root: root, seen: map[string]bool{}}
 	if dir != "" {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			slog.Warn("checkpoint: create dir failed, persistence disabled", "dir", dir, "err", err)
-		}
 		s.load()
 	}
 	return s
@@ -176,6 +173,10 @@ func (s *Store) persist(c *Checkpoint) {
 	}
 	b, err := json.Marshal(c)
 	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		slog.Warn("checkpoint: create dir failed", "dir", s.dir, "err", err)
 		return
 	}
 	if err := os.WriteFile(filepath.Join(s.dir, fmt.Sprintf("turn-%d.json", c.Turn)), b, 0o644); err != nil {

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -276,3 +276,24 @@ func BenchmarkRestoreGB18030Encoding(b *testing.B) {
 		}
 	}
 }
+
+func TestLazyDirectoryCreation(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(t.TempDir(), "lazy-sess.ckpt")
+
+	s := New(dir, root)
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("directory should not exist yet: %v", err)
+	}
+
+	s.Begin(0, "lazy", 0)
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("directory should now exist: %v", err)
+	}
+	turnPath := filepath.Join(dir, "turn-0.json")
+	if _, err := os.Stat(turnPath); err != nil {
+		t.Fatalf("turn file should now exist: %v", err)
+	}
+}


### PR DESCRIPTION
Rebase of #2972 by @Tatlatat onto current main-v2 (conflicted with the checkpoint encoding fix #2967). Authorship preserved on the commit.

Conflict was test-only — both #2967's `BenchmarkRestoreGB18030Encoding` and #2972's `TestLazyDirectoryCreation` were added at the same spot; kept both. Also stripped the four AAA-scaffolding comments from the new test per the repo comment rule.

Verified on the rebased tree: `go build ./...` + `go test ./internal/checkpoint` green.

Closes #2972