### PR TITLE
fix(cli): measure approval-banner subject by display width, not rune count (rebase of #2968)

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2000,11 +2000,7 @@ func truncateSubject(s string, width int) string {
 	if max < 16 {
 		max = 16
 	}
-	r := []rune(s)
-	if len(r) > max {
-		return string(r[:max]) + "…"
-	}
-	return s
+	return ansi.Truncate(s, max, "…")
 }
 
 // clampStatusLine truncates a status line to `width` visible columns, ANSI-aware,

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -921,3 +921,29 @@ func TestShortTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestTruncateSubject(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		width int
+	}{
+		{"short ASCII", "rm file", 60},
+		{"long ASCII", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 60},
+		{"CJK at 60", "日本語の文章は通常、表示幅が広いため、端末の横幅を超えてしまうことがあります。", 60},
+		{"CJK at 30", "日本語の文章は通常、表示幅が広いため、端末の横幅を超えてしまうことがあります。", 30},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateSubject(tc.input, tc.width)
+			wantMax := tc.width - 28
+			if wantMax < 16 {
+				wantMax = 16
+			}
+			w := ansi.StringWidth(got)
+			if w > wantMax {
+				t.Errorf("truncateSubject(%q, %d) = %q (width %d), want visible width <= %d", tc.input, tc.width, got, w, wantMax)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Rebase of #2968 by @Tatlatat onto current main-v2, with the failing test assertion corrected. Authorship preserved on the commit.

The production fix is right as-is: `truncateSubject` now uses the project's existing `ansi.Truncate` (no hand-rolled width table), matching lipgloss's own width model — fixes CJK banner overflow.

The original test red-barred CI because it measured the result with `go-runewidth` (counts `…` as width 2) while the code/renderer use `x/ansi` (width 1), disagreeing by one column on long ASCII. Switched the assertion to `ansi.StringWidth` (the same width model the code uses) and dropped the now-unused `go-runewidth` import. Conflict on rebase was test-only (#2966's `TestShortTokens` added at the same spot — kept both).

Verified on the rebased tree: `go build ./...` + full `go test ./internal/cli` green; `TestTruncateSubject` (incl. the previously-failing long-ASCII case) and `TestShortTokens` pass.

Closes #2968