### PR TITLE
fix: improve macOS window chrome layout and drag area

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -62,6 +62,12 @@ func NewApp() *App {
 	return &App{tabs: map[string]*WorkspaceTab{}}
 }
 
+// Platform exposes the native OS to the frontend so chrome/layout affordances can
+// stay platform-scoped instead of relying on browser user-agent guesses.
+func (a *App) Platform() string {
+	return goruntime.GOOS
+}
+
 // startup runs once the webview process is up, before the frontend can issue any
 // bound call. It captures the Wails context (needed for EventsEmit), then kicks
 // off the initialization in a background goroutine so the webview loads immediately.

--- a/desktop/app_platform_test.go
+++ b/desktop/app_platform_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestAppPlatformReturnsRuntimeGOOS(t *testing.T) {
+	app := NewApp()
+
+	if got := app.Platform(); got != runtime.GOOS {
+		t.Fatalf("Platform() = %q, want %q", got, runtime.GOOS)
+	}
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -341,6 +341,22 @@ export default function App() {
   useEffect(() => {
     let cancelled = false;
     (async () => {
+      const platform = await app.Platform().catch(() => "");
+      if (cancelled || typeof document === "undefined") return;
+      if (platform) {
+        document.documentElement.dataset.platform = platform;
+      } else {
+        delete document.documentElement.dataset.platform;
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
       try {
         const needs = await app.NeedsOnboarding();
         if (!cancelled) setNeedsOnboarding(needs);
@@ -654,6 +670,7 @@ export default function App() {
           .join(" ")}
         style={layoutStyle}
       >
+        <div className="mac-window-chrome" aria-hidden="true" />
         <aside className={`sidebar${sidebarCollapsed ? " sidebar--collapsed" : ""}`} aria-label={t("sidebar.navigation")}>
           <div className="sidebar__brand">
             <img src={logo} alt="" className="sidebar__logo" />

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -44,6 +44,7 @@ import type {
 // AppBindings mirrors desktop/app.go's exported method set. Keep in sync by hand
 // (or regenerate with `wails generate module` and import wailsjs instead).
 export interface AppBindings {
+  Platform(): Promise<string>;
   Submit(input: string): Promise<void>;
   SubmitDisplay(display: string, input: string): Promise<void>;
   Cancel(): Promise<void>;
@@ -413,6 +414,9 @@ function makeMockApp(): AppBindings {
     bypass: false,
   };
   return {
+    async Platform() {
+      return "browser";
+    },
     async Submit(input) {
       cancelled = false;
       emit({ kind: "turn_started" });

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -111,9 +111,14 @@
 
   --radius: 9px;
   --maxw: 820px;
+  --mac-window-chrome-height: 0px;
   --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans",
     "Helvetica Neue", Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
+}
+
+:root[data-platform="darwin"] {
+  --mac-window-chrome-height: 52px;
 }
 
 @media (prefers-color-scheme: light) {
@@ -6179,6 +6184,38 @@ body {
 .workspace-tabs-bar .tabbar,
 .workspace-tabs-bar .tabbar * {
   --wails-draggable: no-drag;
+}
+
+.mac-window-chrome {
+  display: none;
+}
+
+:root[data-platform="darwin"] .layout {
+  padding-top: var(--mac-window-chrome-height);
+}
+
+:root[data-platform="darwin"] .mac-window-chrome {
+  display: block;
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 11;
+  height: var(--mac-window-chrome-height);
+  background: var(--chat-bg);
+  border-bottom: 1px solid var(--border-soft);
+  --wails-draggable: drag;
+}
+
+:root[data-platform="darwin"] .workspace-tabs-bar {
+  background: color-mix(in srgb, var(--bg-soft) 78%, var(--chat-bg));
+}
+
+:root[data-platform="darwin"] .sidebar {
+  padding-top: 12px;
+}
+
+:root[data-platform="darwin"] .sidebar-resizer,
+:root[data-platform="darwin"] .workspace-panel-resizer {
+  top: var(--mac-window-chrome-height);
 }
 
 .topicbar {


### PR DESCRIPTION
Problem:
The macOS traffic light controls were visually cramped against the custom desktop layout, and the first chrome pass used a pseudo-element for the top drag region, which Wails did not recognize as a native draggable area.

Solution:
Add a platform API so the frontend can scope layout changes to macOS only, render a real macOS chrome DOM layer for the draggable title area, and apply darwin-only CSS spacing/background adjustments without affecting Windows, Linux, or browser dev.

【Before】

<img width="1240" height="720" alt="0778fe65-b14a-4d8b-9e93-038bd3d27591" src="https://github.com/user-attachments/assets/5a4daa1e-68af-4bdc-8737-2ac85d64ce57" />

【Now】
<img width="1240" height="720" alt="5cb5d647-cf67-430d-a48e-c58d808a93f4" src="https://github.com/user-attachments/assets/847e5192-da8d-4e00-a9f9-0c70eff8d6e0" />
