### PR TITLE
fix(cli): restore mid-turn interject feedback

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -91,6 +91,11 @@ type chatTUI struct {
 	// untouched.
 	planMode bool
 
+	// pendingInterject holds user input queued while a turn is running. When the
+	// turn completes (TurnDone), this text is automatically submitted as the next
+	// turn — letting the user interject mid-execution without waiting.
+	pendingInterject string
+
 	// history is a resumed session's messages, committed to scrollback once on
 	// the first WindowSizeMsg so a reopened chat shows its prior transcript.
 	history []provider.Message
@@ -854,7 +859,16 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "enter":
 			if m.state == tuiRunning {
-				return m, nil // ignore Enter while a turn is in flight
+				line := strings.TrimSpace(m.input.Value())
+				if line == "" {
+					return m, nil
+				}
+				m.pendingInterject = line
+				m.input.Reset()
+				m.input.SetHeight(1)
+				m.pastedBlocks = nil
+				m.notice("feedback queued — will send when the current turn finishes")
+				return m, finalize(m, cmds)
 			}
 			if m.modelSwitchPending {
 				return m, nil // ignore Enter while /model switch is building
@@ -949,6 +963,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, fetchBalance(m.ctrl))
 			if c := m.runStatusline(); c != nil {
 				cmds = append(cmds, c)
+			}
+			if m.pendingInterject != "" {
+				interject := m.pendingInterject
+				m.pendingInterject = ""
+				cmds = append(cmds, m.startTurn(interject, interject, interject))
 			}
 		}
 		if turnDone || gitMaybeChanged {
@@ -1653,6 +1672,9 @@ func (m chatTUI) View() tea.View {
 			working = fmt.Sprintf("  "+i18n.M.ChatStatusThinkingFmt, m.spinner.View(), m.elapsed)
 			if m.turnTokens > 0 {
 				working += " · ↓" + shortTokens(m.turnTokens)
+			}
+			if m.pendingInterject != "" {
+				working += dim(" · ✎ feedback queued")
 			}
 		}
 	}
@@ -2926,3 +2948,4 @@ type eventSink struct {
 }
 
 func (s *eventSink) Emit(e event.Event) { s.ch <- e }
+

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -91,10 +91,9 @@ type chatTUI struct {
 	// untouched.
 	planMode bool
 
-	// pendingInterject holds user input queued while a turn is running. When the
-	// turn completes (TurnDone), this text is automatically submitted as the next
-	// turn — letting the user interject mid-execution without waiting.
-	pendingInterject string
+	// pendingInterject queues input typed while a turn runs; each TurnDone
+	// dequeues the front and submits it as the next turn.
+	pendingInterject []string
 
 	// history is a resumed session's messages, committed to scrollback once on
 	// the first WindowSizeMsg so a reopened chat shows its prior transcript.
@@ -863,7 +862,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if line == "" {
 					return m, nil
 				}
-				m.pendingInterject = line
+				m.pendingInterject = append(m.pendingInterject, line)
 				m.input.Reset()
 				m.input.SetHeight(1)
 				m.pastedBlocks = nil
@@ -964,9 +963,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if c := m.runStatusline(); c != nil {
 				cmds = append(cmds, c)
 			}
-			if m.pendingInterject != "" {
-				interject := m.pendingInterject
-				m.pendingInterject = ""
+			if len(m.pendingInterject) > 0 {
+				interject := m.pendingInterject[0]
+				m.pendingInterject = m.pendingInterject[1:]
 				cmds = append(cmds, m.startTurn(interject, interject, interject))
 			}
 		}
@@ -1673,8 +1672,12 @@ func (m chatTUI) View() tea.View {
 			if m.turnTokens > 0 {
 				working += " · ↓" + shortTokens(m.turnTokens)
 			}
-			if m.pendingInterject != "" {
-				working += dim(" · ✎ feedback queued")
+			if n := len(m.pendingInterject); n > 0 {
+				if n == 1 {
+					working += dim(" · ✎ feedback queued")
+				} else {
+					working += dim(fmt.Sprintf(" · ✎ %d queued", n))
+				}
 			}
 		}
 	}
@@ -2948,4 +2951,3 @@ type eventSink struct {
 }
 
 func (s *eventSink) Emit(e event.Event) { s.ch <- e }
-

--- a/internal/cli/interject_test.go
+++ b/internal/cli/interject_test.go
@@ -1,0 +1,50 @@
+package cli
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func TestInterjectQueuesWhileRunningWithoutOverwrite(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+
+	m.input.SetValue("first")
+	m0, _ := m.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = m0.(chatTUI)
+
+	m.input.SetValue("second")
+	m0, _ = m.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = m0.(chatTUI)
+
+	m.input.SetValue("")
+	m0, _ = m.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = m0.(chatTUI)
+
+	if want := []string{"first", "second"}; len(m.pendingInterject) != len(want) ||
+		m.pendingInterject[0] != want[0] || m.pendingInterject[1] != want[1] {
+		t.Fatalf("pendingInterject = %v, want %v (second must not overwrite first; empty must not queue)", m.pendingInterject, want)
+	}
+	if m.state != tuiRunning {
+		t.Fatalf("queuing input must not change state; got %v", m.state)
+	}
+}
+
+func TestInterjectDequeuesFrontOnTurnDone(t *testing.T) {
+	r := &blockingTurnRunner{started: make(chan struct{})}
+	ctrl := control.New(control.Options{Runner: r, Sink: event.Discard, SessionDir: t.TempDir(), Label: "test"})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 8), 80)
+	m.state = tuiRunning
+	m.pendingInterject = []string{"first", "second"}
+
+	m0, _ := m.update(agentEventMsg(event.Event{Kind: event.TurnDone}))
+	m = m0.(chatTUI)
+
+	if len(m.pendingInterject) != 1 || m.pendingInterject[0] != "second" {
+		t.Fatalf("TurnDone should dequeue only the front; got %v", m.pendingInterject)
+	}
+}


### PR DESCRIPTION
Extracts and hardens the interject restore from #2877 by @Qxy0Happy (original commit preserved). Drops the other two concerns from that PR: the CodeGraph-prompt change (unconditional ~70 tokens on every request even when codegraph is disabled — against the cheapness positioning; better injected only when those tools are registered) and the unrelated Taskfile/Windows-build commit.

## What
Post-Go-rewrite, pressing Enter while a turn was running was ignored. Now the input is queued and auto-submitted when the current turn finishes (TurnDone), restoring the iterative-feedback loop.

Hardening on top of the original:
- **FIFO queue, not a single string** — the original held one `pendingInterject string`, so a second mid-turn Enter silently dropped the first. Now a `[]string` queue: append on Enter, dequeue the front on each TurnDone, status line shows the count when >1 is pending.
- Dropped a stray EOF blank line (would fail `gofmt`/`git diff --check`).
- Added tests: queue-without-overwrite, empty-not-queued, dequeue-front-on-TurnDone.

## Verification
- `gofmt` clean, `git diff --check` clean
- `REASONIX_LANG=en HOME=$(mktemp -d) go test ./internal/cli -count=1` green
- New `TestInterjectQueuesWhileRunningWithoutOverwrite` + `TestInterjectDequeuesFrontOnTurnDone` pass

Closes #2877