### PR TITLE
fix(desktop): keep the live controller when a model switch fails

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1768,7 +1768,6 @@ func (a *App) SetModel(name string) error {
 		prevPath = tab.Ctrl.SessionPath()
 		_ = tab.Ctrl.Snapshot()
 		carried = tab.Ctrl.History()
-		tab.Ctrl.Close()
 	}
 
 	newCtrl, err := boot.Build(a.ctx, boot.Options{
@@ -1776,15 +1775,20 @@ func (a *App) SetModel(name string) error {
 		RequireKey:    false,
 		Sink:          tab.sink,
 		WorkspaceRoot: tab.WorkspaceRoot,
+		Stderr:        io.Discard,
 	})
 	if err != nil {
 		return err
 	}
+	old := tab.Ctrl
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
 	tab.model = name
 	tab.Label = newCtrl.Label()
 	a.mu.Unlock()
+	if old != nil {
+		old.Close()
+	}
 	newCtrl.EnableInteractiveApproval()
 
 	path := agent.ContinueSessionPath(prevPath, newCtrl.SessionDir(), newCtrl.Label())

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -458,7 +458,15 @@ export function useController() {
   const compact = useCallback(() => { app.Compact().catch(() => {}); }, []);
 
   const setModel = useCallback(async (name: string) => {
-    await app.SetModel(name).catch(() => {});
+    try {
+      await app.SetModel(name);
+    } catch (e) {
+      if (activeTabId) {
+        const text = `Model switch failed: ${e instanceof Error ? e.message : String(e)}`;
+        dispatchTo(activeTabId, { type: "local_notice", level: "warn", text });
+      }
+      return;
+    }
     if (!activeTabId) return;
     try {
       dispatchTo(activeTabId, { type: "meta", meta: await app.Meta() });

--- a/desktop/setmodel_test.go
+++ b/desktop/setmodel_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSetModelFailureLeavesTabStateIntact(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "reasonix.toml"), []byte(`
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	tab := app.createTabEntryWithID("project", workspace, "", "tab1")
+	app.tabs[tab.ID] = tab
+	app.activeTabID = tab.ID
+	app.buildTabController(tab)
+	if tab.Ctrl == nil {
+		t.Fatalf("tab controller failed to build: %s", tab.StartupErr)
+	}
+	defer tab.Ctrl.Close()
+
+	oldCtrl := tab.Ctrl
+	oldModel := tab.model
+
+	if err := app.SetModel("no-such-provider/no-such-model"); err == nil {
+		t.Fatal("SetModel with an unknown model should return an error")
+	}
+	if tab.Ctrl != oldCtrl {
+		t.Fatal("a failed model switch must keep the existing controller, not replace/close it")
+	}
+	if tab.model != oldModel {
+		t.Fatalf("tab.model changed to %q on a failed switch, want %q", tab.model, oldModel)
+	}
+}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -204,7 +205,6 @@ func (a *App) rebuild() error {
 		prevPath = tab.Ctrl.SessionPath()
 		_ = tab.Ctrl.Snapshot()
 		carried = tab.Ctrl.History()
-		tab.Ctrl.Close()
 	}
 	model := tab.model
 	if cfg, err := config.Load(); err == nil {
@@ -219,6 +219,7 @@ func (a *App) rebuild() error {
 		Model: model, RequireKey: false,
 		Sink:          tab.sink,
 		WorkspaceRoot: tab.WorkspaceRoot,
+		Stderr:        io.Discard,
 	})
 	if err != nil {
 		a.mu.Lock()
@@ -226,12 +227,16 @@ func (a *App) rebuild() error {
 		a.mu.Unlock()
 		return err
 	}
+	old := tab.Ctrl
 	a.mu.Lock()
 	tab.Ctrl = ctrl
 	tab.model = model
 	tab.Label = ctrl.Label()
 	tab.StartupErr = ""
 	a.mu.Unlock()
+	if old != nil {
+		old.Close()
+	}
 	ctrl.EnableInteractiveApproval()
 	path := agent.ContinueSessionPath(prevPath, ctrl.SessionDir(), ctrl.Label())
 	if len(carried) > 0 {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -416,6 +417,7 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 		RequireKey:    false,
 		Sink:          tab.sink,
 		WorkspaceRoot: root,
+		Stderr:        io.Discard,
 	})
 	if err != nil {
 		a.mu.Lock()


### PR DESCRIPTION
Re-implementation of #2768 by @paradoxSCH (Closes #2644) against current main-v2 — the original couldn't be rebased because #2928's multi-tab refactor moved every field it touched (`a.ctrl`→`tab.Ctrl` etc.), so I re-applied the load-bearing fixes against the new `WorkspaceTab` model.

## The bug (still live on main-v2)
`SetModel` (desktop/app.go) and `rebuild` (desktop/settings_app.go) both did `tab.Ctrl.Close()` **before** `boot.Build`. A failed build — e.g. switching to an unknown/misconfigured model — returned the error but left the tab pointing at a **closed** controller, killing the conversation. The frontend then swallowed the error (`SetModel(...).catch(() => {})`), so the user saw nothing.

## Fix
- **Build → swap → close on success only.** On a failed `boot.Build`, the existing controller is left untouched and still usable. (both `SetModel` and `rebuild`)
- **Surface the failure** in `useController.ts` via `local_notice` instead of dropping it.
- **Quiet boot diagnostics on the desktop** — pass `Stderr: io.Discard` to the three desktop `boot.Build` sites (`SetModel`, `rebuild`, initial tab build) so bash-sandbox warnings stop leaking to the Windows desktop console during rebuilds.

Scoped to the correctness fixes; left out the original PR's unrelated bits (dist placeholder, a JSX→ReactElement type tweak) which aren't bugs.

## Verification
- `gofmt` clean; `go build ./...` (desktop) + full `go test ./...` (desktop module) green
- `pnpm run typecheck` (frontend) clean
- Added `TestSetModelFailureLeavesTabStateIntact` (failed switch returns an error and leaves tab controller/model unmutated)

Closes #2768
Closes #2644