### PR TITLE
fix(desktop): isolate user config dir in tests; SearchFileRefs non-nil

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1969,7 +1969,7 @@ func (a *App) ListDir(rel string) []DirEntry {
 func (a *App) SearchFileRefs(query string) []DirEntry {
 	base, err := os.Getwd()
 	if err != nil {
-		return nil
+		return []DirEntry{}
 	}
 	paths := fileref.Search(base, query, fileRefSearchLimit)
 	out := make([]DirEntry, 0, len(paths))

--- a/desktop/main_test.go
+++ b/desktop/main_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain isolates os.UserConfigDir() for the whole package. On Windows it
+// reads %AppData%, which the per-test HOME / XDG_CONFIG_HOME overrides do not
+// cover — without this, tests that persist desktop state (saveWorkspace,
+// session/cache writes) leak into the developer's real Reasonix config dir.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "reasonix-desktop-test")
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Setenv("AppData", dir)
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}


### PR DESCRIPTION
## Symptom
A user's desktop launched into a config-parse error (`reasonix.toml ... sandbox.allow_write ... bool vs slice`) and a React white-screen (`Cannot read properties of null (reading 'length')`). Two root causes behind it:

## 1. Tests pollute the real user config on Windows (the actual trigger)
The desktop's active workspace had been overwritten with a deleted **test temp dir** (`...\Temp\TestSaveWorkspaceRemembersRecentWorkspaces...`). Cause: desktop tests isolate via `HOME` / `XDG_CONFIG_HOME`, but on Windows `os.UserConfigDir()` reads **%AppData%**, which no test overrides. So `go test ./desktop/...` on Windows wrote `saveWorkspace` state into the developer's real `%AppData%\reasonix\desktop-workspaces.json`, and the next desktop launch tried to open a long-gone test dir.

Fix: a package `TestMain` that points `AppData` at a temp dir, isolating `os.UserConfigDir()` on every OS. One place; protects current and future tests.

## 2. A bound slice method returned nil → frontend crash
`SearchFileRefs` returned `nil` on a getwd error; Wails marshals a Go nil slice to JS `null`, so the frontend's `.length`/`.map` throws. (`Models`/`History`/`Checkpoints`/`ListSessions` already return empty slices — this was the last holdout.) Now returns `[]DirEntry{}`.

Note: the white-screen itself is already mitigated on current main-v2 — `Models()`/`History()`/`Meta()`/`ContextUsage()` all return non-null, so a config error now degrades to the error banner instead of crashing. This PR closes the remaining nil-returner and stops the test pollution that put the user in the bad state.

## Verification
- `gofmt` clean, `git diff --check` clean
- `go build ./...` + full `go test ./...` (desktop module) green
- `pnpm run typecheck` clean