### PR TITLE
feat(desktop): Session bridge layer + SaveProvider merge (3/5)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1630,7 +1630,12 @@ func (a *App) Effort() EffortInfo {
 	if !cap.Supported {
 		return EffortInfo{Supported: false, Current: "auto", Default: cap.Default, Levels: []string{}}
 	}
-	return EffortInfo{Supported: true, Current: config.EffortDisplay(entry), Default: cap.Default, Levels: cap.Levels}
+	cfg, _ := config.Load()
+	effort := ""
+	if cfg != nil {
+		effort = cfg.Session.Effort
+	}
+	return EffortInfo{Supported: true, Current: config.EffortDisplay(effort), Default: cap.Default, Levels: cap.Levels}
 }
 
 func (a *App) SetEffort(level string) error {
@@ -1907,7 +1912,12 @@ func (a *App) runEffortCommand(input string) {
 	}
 	args := strings.Fields(input)
 	if len(args) < 2 {
-		a.notice(fmt.Sprintf("effort for %s: %s (default: %s; options: %s)", entry.Name, config.EffortDisplay(entry), cap.Default, strings.Join(cap.Levels, "|")))
+		cfg, _ := config.Load()
+		effort := ""
+		if cfg != nil {
+			effort = cfg.Session.Effort
+		}
+		a.notice(fmt.Sprintf("effort for %s: %s (default: %s; options: %s)", entry.Name, config.EffortDisplay(effort), cap.Default, strings.Join(cap.Levels, "|")))
 		return
 	}
 	if len(args) > 2 {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -29,8 +29,8 @@ func TestEffortDefaultsBeforeStartup(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	got := NewApp().Effort()
-	if !got.Supported || got.Current != "auto" || got.Default != "high" || !hasLevel(got.Levels, "auto") {
-		t.Fatalf("pre-startup Effort() = %+v, want auto with DeepSeek default high", got)
+	if !got.Supported || got.Current != "auto" || got.Default != "auto" || !hasLevel(got.Levels, "auto") {
+		t.Fatalf("pre-startup Effort() = %+v, want auto with DeepSeek default auto", got)
 	}
 }
 

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -84,6 +84,11 @@ type SettingsView struct {
 	// Bypass is the live YOLO state (runtime-only, not from config), so the panel's
 	// toggle reflects whether approvals are currently being skipped this session.
 	Bypass bool `json:"bypass"`
+	// SessionEffort is the currently active effort level for the session.
+	// "" means auto (omit from API requests, protecting prefix cache).
+	SessionEffort string `json:"sessionEffort"`
+	// SessionProvider is the currently active provider name for the session.
+	SessionProvider string `json:"sessionProvider"`
 }
 
 func nonNil(s []string) []string {
@@ -133,6 +138,8 @@ func (a *App) Settings() SettingsView {
 		ConfigPath:    config.SourcePath(),
 		ProviderKinds: provider.Kinds(),
 		Bypass:        a.ctrl != nil && a.ctrl.Bypass(),
+		SessionEffort:   cfg.Session.Effort,
+		SessionProvider: cfg.Session.Provider,
 	}
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
@@ -281,11 +288,25 @@ func (a *App) SetPlannerModel(ref string) error {
 
 // SaveProvider adds or updates a provider. A single model fills `model`; several
 // fill `models` (with `default`). The shared key/endpoint live on the entry.
+// Fields not present in the ProviderView (e.g. supported_efforts when the UI
+// doesn't expose them yet) are preserved from the existing entry.
 func (a *App) SaveProvider(p ProviderView) error {
 	return a.applyConfigChange(func(c *config.Config) error {
 		e := config.ProviderEntry{
 			Name: p.Name, Kind: p.Kind, BaseURL: p.BaseURL,
 			APIKeyEnv: p.APIKeyEnv, BalanceURL: strings.TrimSpace(p.BalanceURL), ContextWindow: p.ContextWindow,
+		}
+		// Merge effort fields: if the frontend sends them, use them; otherwise
+		// preserve the existing values so TOML-only fields aren't wiped.
+		if existing, ok := c.Provider(p.Name); ok {
+			e.SupportedEfforts = existing.SupportedEfforts
+			e.DefaultEffort = existing.DefaultEffort
+		}
+		if len(p.SupportedEfforts) > 0 {
+			e.SupportedEfforts = p.SupportedEfforts
+		}
+		if p.DefaultEffort != "" {
+			e.DefaultEffort = p.DefaultEffort
 		}
 		if len(p.Models) > 0 {
 			e.Model = p.Models[0] // also satisfies validateProvider's model requirement
@@ -296,6 +317,35 @@ func (a *App) SaveProvider(p ProviderView) error {
 		}
 		return c.UpsertProvider(e)
 	})
+}
+
+// SwitchProvider adapts the session effort to the new provider's capability
+// and returns a warning string if the effort was degraded. The provider switch
+// itself is handled by SetDefaultModel or the /model command; this method only
+// deals with the effort adaptation.
+func (a *App) SwitchProvider(providerName string) string {
+	cfg, err := config.Load()
+	if err != nil {
+		return ""
+	}
+	entry, ok := cfg.Provider(providerName)
+	if !ok {
+		return ""
+	}
+	caps := config.EffortCapabilityForEntry(entry)
+	warning := cfg.Session.AdaptToProvider(caps)
+	if warning != "" {
+		// Save the adapted session effort.
+		path := config.UserConfigPath()
+		if path != "" {
+			edit := config.LoadForEdit(path)
+			edit.Session.Effort = cfg.Session.Effort
+			if err := edit.SaveTo(path); err != nil {
+				return warning // still return warning even if save fails
+			}
+		}
+	}
+	return warning
 }
 
 // DeleteProvider removes a provider (refused for the current default_model).

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -127,7 +127,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		return nil, err
 	}
 
-	execProv, err := NewProviderWithProxy(entry, proxySpec)
+	execProv, err := NewProviderWithProxy(entry, cfg.Session.Effort, proxySpec)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +378,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		prov, price, ctxWin := execProv, entry.Price, entry.ContextWindow
 		if modelRef := subagentModelRef(cfg, sk); modelRef != "" {
 			if me, ok := cfg.ResolveModel(modelRef); ok {
-				if p, err := NewProviderWithProxy(me, proxySpec); err == nil {
+				if p, err := NewProviderWithProxy(me, cfg.Session.Effort, proxySpec); err == nil {
 					prov, price, ctxWin = p, me.Price, me.ContextWindow
 				}
 			}
@@ -458,7 +458,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return nil, fmt.Errorf("planner_model %q is not a configured provider", pm)
 		}
 		if pe.Model != entry.Model {
-			plannerProv, err := NewProviderWithProxy(pe, proxySpec)
+			plannerProv, err := NewProviderWithProxy(pe, cfg.Session.Effort, proxySpec)
 			if err != nil {
 				return nil, fmt.Errorf("planner %q: %w", pm, err)
 			}
@@ -473,7 +473,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if !ok {
 			return nil, fmt.Errorf("auto_plan_classifier %q is not a configured provider", cm)
 		}
-		classifierProv, err := NewProviderWithProxy(ce, proxySpec)
+		classifierProv, err := NewProviderWithProxy(ce, cfg.Session.Effort, proxySpec)
 		if err != nil {
 			return nil, fmt.Errorf("auto_plan_classifier %q: %w", cm, err)
 		}
@@ -556,13 +556,14 @@ func subagentModelKeys(name string) []string {
 // NewProvider builds a provider.Provider from a configured entry. Exported so
 // custom assemblers (e.g. the ACP per-session factory) can reuse it without
 // going through the full Build.
-func NewProvider(e *config.ProviderEntry) (provider.Provider, error) {
-	return NewProviderWithProxy(e, netclient.ProxySpec{Mode: netclient.ModeAuto})
+func NewProvider(e *config.ProviderEntry, effort string) (provider.Provider, error) {
+	return NewProviderWithProxy(e, effort, netclient.ProxySpec{Mode: netclient.ModeAuto})
 }
 
 // NewProviderWithProxy builds a provider.Provider with the configured ordinary
-// network proxy settings.
-func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (provider.Provider, error) {
+// network proxy settings. effort is the session-level effort level (from
+// Session.Effort); "" means auto/omit.
+func NewProviderWithProxy(e *config.ProviderEntry, effort string, proxy netclient.ProxySpec) (provider.Provider, error) {
 	return provider.New(e.Kind, provider.Config{
 		Name:    e.Name,
 		BaseURL: e.BaseURL,
@@ -574,7 +575,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 		Extra: map[string]any{
 			"api_key_env": e.APIKeyEnv,
 			"thinking":    e.Thinking,
-			"effort":      e.Effort,
+			"effort":      effort,
 			"proxy_spec":  proxy,
 		},
 	})

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -87,7 +87,7 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		return nil, fmt.Errorf("unknown model %q", f.model)
 	}
 	proxySpec := cfg.NetworkProxySpec()
-	execProv, err := boot.NewProviderWithProxy(entry, proxySpec)
+	execProv, err := boot.NewProviderWithProxy(entry, cfg.Session.Effort, proxySpec)
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 			return nil, fmt.Errorf("planner_model %q is not a configured provider", pm)
 		}
 		if pe.Model != entry.Model {
-			plannerProv, err := boot.NewProviderWithProxy(pe, proxySpec)
+			plannerProv, err := boot.NewProviderWithProxy(pe, cfg.Session.Effort, proxySpec)
 			if err != nil {
 				cleanup()
 				return nil, fmt.Errorf("planner %q: %w", pm, err)

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -284,8 +284,8 @@ func TestEffortCommandWritesCurrentDeepSeekProvider(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read saved config: %v", err)
 	}
-	if !strings.Contains(string(body), `effort      = "max"`) {
-		t.Fatalf("saved config missing effort=max:\n%s", body)
+	if !strings.Contains(string(body), `effort   = "max"`) {
+		t.Fatalf("saved config missing session effort=max:\n%s", body)
 	}
 }
 
@@ -293,10 +293,11 @@ func TestEffortCommandRejectsUnsupportedProvider(t *testing.T) {
 	isolateUserConfig(t)
 
 	m := newTestChatTUI()
-	m.ctrl = control.New(control.Options{Label: "mimo-pro"})
-	m.modelRef = "mimo-pro/mimo-v2.5-pro"
+	// Use a generic OpenAI provider without SupportedEfforts - should not support effort.
+	m.ctrl = control.New(control.Options{Label: "generic-openai"})
+	m.modelRef = "generic-openai/gpt-4"
 	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
-		return control.New(control.Options{Label: "mimo-pro"}), nil
+		return control.New(control.Options{Label: "generic-openai"}), nil
 	}
 
 	if cmd := m.runEffortCommand("/effort max"); cmd != nil {
@@ -330,6 +331,35 @@ func TestEffortCommandAutoClearsProviderEffort(t *testing.T) {
 	section := providerSection(string(body), "deepseek-flash")
 	if strings.Contains(section, `effort      = "`) {
 		t.Fatalf("auto should clear saved deepseek-flash effort:\n%s", section)
+	}
+}
+
+func TestEffortCommandDegradesUnsupportedLevel(t *testing.T) {
+	isolateUserConfig(t)
+
+	m := newTestChatTUI()
+	// MiMo has SupportedEfforts = ["auto", "low", "medium", "high"].
+	// Setting "max" should degrade to "auto" (the default for MiMo).
+	m.ctrl = control.New(control.Options{Label: "mimo-pro"})
+	m.modelRef = "mimo-pro/mimo-v2.5-pro"
+	m.buildController = func(_ string, _ []provider.Message, _ string) (*control.Controller, error) {
+		return control.New(control.Options{Label: "mimo-pro"}), nil
+	}
+
+	cmd := m.runEffortCommand("/effort max")
+	if cmd == nil {
+		t.Fatal("/effort max on MiMo should return a rebuild command (with degradation)")
+	}
+
+	// Verify the saved config has the degraded effort (auto = empty, not written).
+	configPath := config.UserConfigPath()
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	// "auto" maps to "" which means the effort field should not be written.
+	if strings.Contains(string(body), `effort   = "max"`) {
+		t.Fatalf("saved config should NOT have effort=max (should be degraded):\n%s", body)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -834,6 +834,8 @@ func familyOf(name string) providerFamily {
 		return providerFamily{key: "deepseek", name: "DeepSeek", desc: "fast & cheap, plus a stronger Pro SKU"}
 	case strings.HasPrefix(name, "mimo"):
 		return providerFamily{key: "mimo", name: "MiMo (Xiaomi)", desc: "long-horizon agentic"}
+	case strings.HasPrefix(name, "anthropic"):
+		return providerFamily{key: "anthropic", name: "Anthropic", desc: "Claude models with extended thinking"}
 	default:
 		return providerFamily{key: name, name: name}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -143,11 +143,12 @@ func TestConfigureKeysReusesExistingEnv(t *testing.T) {
 func TestConfigureKeysAllSetSkipsInput(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "ds")
 	t.Setenv("MIMO_API_KEY", "mi")
+	t.Setenv("ANTHROPIC_API_KEY", "ant")
 
 	selected := config.Default().Providers
 	env := configureKeys(selected, strings.NewReader("should-not-be-consumed\n"), io.Discard)
-	if len(env) != 2 {
-		t.Errorf("env = %v, want 2 (both reused)", env)
+	if len(env) != 3 {
+		t.Errorf("env = %v, want 3 (all reused)", env)
 	}
 }
 
@@ -189,13 +190,13 @@ func TestAppendEnvUpsertHandlesExportPrefix(t *testing.T) {
 }
 
 // TestGroupByFamily verifies the wizard groups the default preset into
-// "deepseek" (flash + pro) and "mimo" (pro + flash), preserving the order
-// each family first appears in.
+// "deepseek" (flash + pro), "mimo" (pro + flash), and "anthropic",
+// preserving the order each family first appears in.
 func TestGroupByFamily(t *testing.T) {
 	order, members, info := groupByFamily(config.Default().Providers)
 
-	if got := order; !reflect.DeepEqual(got, []string{"deepseek", "mimo"}) {
-		t.Fatalf("family order = %v, want [deepseek mimo]", got)
+	if got := order; !reflect.DeepEqual(got, []string{"deepseek", "mimo", "anthropic"}) {
+		t.Fatalf("family order = %v, want [deepseek mimo anthropic]", got)
 	}
 	if got := members["deepseek"]; !reflect.DeepEqual(got, []int{0, 1}) {
 		t.Errorf("deepseek members = %v, want [0 1]", got)
@@ -203,8 +204,11 @@ func TestGroupByFamily(t *testing.T) {
 	if got := members["mimo"]; !reflect.DeepEqual(got, []int{2, 3}) {
 		t.Errorf("mimo members = %v, want [2 3]", got)
 	}
-	if info["deepseek"].name != "DeepSeek" || info["mimo"].name != "MiMo (Xiaomi)" {
-		t.Errorf("display names = %q / %q", info["deepseek"].name, info["mimo"].name)
+	if got := members["anthropic"]; !reflect.DeepEqual(got, []int{4}) {
+		t.Errorf("anthropic members = %v, want [4]", got)
+	}
+	if info["deepseek"].name != "DeepSeek" || info["mimo"].name != "MiMo (Xiaomi)" || info["anthropic"].name != "Anthropic" {
+		t.Errorf("display names = %q / %q / %q", info["deepseek"].name, info["mimo"].name, info["anthropic"].name)
 	}
 }
 

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -37,11 +37,18 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 		m.notice("usage: /effort " + strings.Join(cap.Levels, "|"))
 		return nil
 	}
-	effort, err := config.NormalizeEffort(entry, args[1])
-	if err != nil {
-		m.notice(err.Error())
+
+	// Use ResolveEffort for validation and degradation with warning.
+	res := config.ResolveEffort(cap, args[1])
+	if res.Blocked {
+		m.notice(fmt.Sprintf("effort is not configurable for %s", entry.Name))
 		return nil
 	}
+	if res.Warning != "" {
+		m.notice(fmt.Sprintf("effort: %s", res.Warning))
+	}
+	effort := res.Effort
+
 	if m.buildController == nil {
 		m.notice("model switching is unavailable in this session")
 		return nil
@@ -57,31 +64,19 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 		return nil
 	}
 	edit := config.LoadForEdit(path)
-	if _, ok := edit.Provider(entry.Name); !ok {
-		if err := edit.UpsertProvider(*entry); err != nil {
-			m.notice("effort: " + err.Error())
-			return nil
-		}
-	}
+	edit.Session.Effort = effort
 	if entry.Kind == "anthropic" && effort != "" && entry.Thinking == "" {
 		if err := edit.SetProviderThinking(entry.Name, "adaptive"); err != nil {
 			m.notice("effort: " + err.Error())
 			return nil
 		}
 	}
-	if err := edit.SetProviderEffort(entry.Name, effort); err != nil {
-		m.notice("effort: " + err.Error())
-		return nil
-	}
 	if err := edit.SaveTo(path); err != nil {
 		m.notice("effort: " + err.Error())
 		return nil
 	}
 
-	display := effort
-	if display == "" {
-		display = "auto"
-	}
+	display := config.EffortDisplay(effort)
 	m.notice(fmt.Sprintf("setting effort for %s to %s…", entry.Name, display))
 	carried := m.ctrl.History()
 	prevPath := m.ctrl.SessionPath()

--- a/internal/cli/effort.go
+++ b/internal/cli/effort.go
@@ -23,7 +23,12 @@ func (m *chatTUI) runEffortCommand(input string) tea.Cmd {
 
 	args := tokenizeArgs(input)
 	if len(args) < 2 {
-		current := config.EffortDisplay(entry)
+		cfg, _ := config.Load()
+		effort := ""
+		if cfg != nil {
+			effort = cfg.Session.Effort
+		}
+		current := config.EffortDisplay(effort)
 		options := strings.Join(cap.Levels, "|")
 		m.notice(fmt.Sprintf("effort for %s: %s (default: %s; options: %s)", entry.Name, current, cap.Default, options))
 		return nil
@@ -133,5 +138,10 @@ func (m *chatTUI) refreshEffortStatus() {
 	if !config.EffortCapabilityForEntry(entry).Supported {
 		return
 	}
-	m.effortLevel = config.EffortDisplay(entry)
+	cfg, _ := config.Load()
+	effort := ""
+	if cfg != nil {
+		effort = cfg.Session.Effort
+	}
+	m.effortLevel = config.EffortDisplay(effort)
 }

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -33,6 +33,28 @@ func (m *chatTUI) runModelSubcommand(input string) {
 		m.notice(fmt.Sprintf(i18n.M.ModelAlreadyOnFmt, ref))
 		return
 	}
+
+	// Adapt effort to the new provider's capability before building.
+	cfg, cfgErr := config.Load()
+	if cfgErr == nil {
+		if newEntry, ok := cfg.ResolveModel(ref); ok {
+			newCaps := config.EffortCapabilityForEntry(newEntry)
+			warning := cfg.Session.AdaptToProvider(newCaps)
+			if warning != "" {
+				m.notice(fmt.Sprintf("effort: %s", warning))
+			}
+			// Save the adapted session effort.
+			path := config.UserConfigPath()
+			if path != "" {
+				edit := config.LoadForEdit(path)
+				edit.Session.Effort = cfg.Session.Effort
+				if err := edit.SaveTo(path); err != nil {
+					slog.Warn("model switch: save adapted effort failed", "err", err)
+				}
+			}
+		}
+	}
+
 	carried := m.ctrl.History()
 	prevPath := m.ctrl.SessionPath()
 	if err := m.ctrl.Snapshot(); err != nil {

--- a/internal/config/capability_test.go
+++ b/internal/config/capability_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestCapability_DeepSeekBuiltin(t *testing.T) {
+	e := &ProviderEntry{Name: "ds", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4"}
+	caps := EffortCapabilityForEntry(e)
+	if !caps.Supported {
+		t.Fatal("DeepSeek should be supported")
+	}
+	if len(caps.Levels) != 3 || caps.Levels[0] != "auto" || caps.Levels[1] != "high" || caps.Levels[2] != "max" {
+		t.Errorf("DeepSeek levels = %v, want [auto high max]", caps.Levels)
+	}
+	if caps.Default != "auto" {
+		t.Errorf("DeepSeek default = %q, want auto", caps.Default)
+	}
+}
+
+func TestCapability_AnthropicBuiltin(t *testing.T) {
+	e := &ProviderEntry{Name: "claude", Kind: "anthropic", BaseURL: "https://api.anthropic.com", Model: "claude-sonnet-4-20250514"}
+	caps := EffortCapabilityForEntry(e)
+	if !caps.Supported {
+		t.Fatal("Anthropic should be supported")
+	}
+	if len(caps.Levels) != 6 {
+		t.Errorf("Anthropic levels count = %d, want 6", len(caps.Levels))
+	}
+	if caps.Default != "auto" {
+		t.Errorf("Anthropic default = %q, want auto", caps.Default)
+	}
+}
+
+func TestCapability_CustomWithSupportedEfforts(t *testing.T) {
+	e := &ProviderEntry{
+		Name:             "mimo",
+		Kind:             "openai",
+		BaseURL:          "https://api.xiaomimimo.com/v1",
+		Model:            "mimo-v2.5-pro",
+		SupportedEfforts: []string{"auto", "low", "medium", "high"},
+		DefaultEffort:    "auto",
+	}
+	caps := EffortCapabilityForEntry(e)
+	if !caps.Supported || len(caps.Levels) != 4 {
+		t.Fatalf("MiMo caps = %+v, want 4 levels", caps)
+	}
+	if caps.Default != "auto" {
+		t.Errorf("MiMo default = %q, want auto", caps.Default)
+	}
+}
+
+func TestCapability_CustomOverridesBuiltin(t *testing.T) {
+	// DeepSeek entry with explicit SupportedEfforts should use config, not builtin.
+	e := &ProviderEntry{
+		Name:             "ds",
+		Kind:             "openai",
+		BaseURL:          "https://api.deepseek.com",
+		Model:            "deepseek-v4",
+		SupportedEfforts: []string{"auto", "low", "medium", "high"},
+		DefaultEffort:    "medium",
+	}
+	caps := EffortCapabilityForEntry(e)
+	if len(caps.Levels) != 4 || caps.Default != "medium" {
+		t.Errorf("Overridden DeepSeek caps = %+v, want 4 levels, default=medium", caps)
+	}
+}
+
+func TestCapability_GenericOpenAINotSupported(t *testing.T) {
+	e := &ProviderEntry{Name: "gpt", Kind: "openai", BaseURL: "https://api.openai.com", Model: "gpt-4"}
+	caps := EffortCapabilityForEntry(e)
+	if caps.Supported {
+		t.Errorf("Generic OpenAI should not be supported, got %+v", caps)
+	}
+}
+
+func TestCapability_NilEntry(t *testing.T) {
+	caps := EffortCapabilityForEntry(nil)
+	if caps.Supported {
+		t.Errorf("nil entry should not be supported, got %+v", caps)
+	}
+}
+
+func TestCapability_DefaultEffortEmpty(t *testing.T) {
+	e := &ProviderEntry{
+		Name:             "custom",
+		Kind:             "openai",
+		SupportedEfforts: []string{"low", "high"},
+		DefaultEffort:    "",
+	}
+	caps := EffortCapabilityForEntry(e)
+	if caps.Default != "auto" {
+		t.Errorf("empty DefaultEffort should resolve to auto, got %q", caps.Default)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,55 @@ type Config struct {
 	Codegraph    CodegraphConfig   `toml:"codegraph"`
 	Statusline   StatuslineConfig  `toml:"statusline"`
 	LSP          LSPConfig         `toml:"lsp"`
+	Session      Session           `toml:"session"`
+
+	// MigrationHint is set during Load when the config file uses the legacy
+	// provider-level effort field. The CLI prints it once on startup.
+	MigrationHint string `toml:"-"`
+}
+
+// Session holds runtime user state that is not part of the provider capability
+// declaration. Effort is the currently selected effort level for the active
+// session; "" means auto (omit from API requests, protecting prefix cache).
+type Session struct {
+	Provider string `toml:"provider"`
+	Effort   string `toml:"effort"`
+}
+
+// AdaptToProvider re-validates Session.Effort against the given provider
+// capability. If the current effort is not supported, it degrades to the
+// provider's default and returns a warning string.
+func (s *Session) AdaptToProvider(caps EffortCapability) string {
+	if s.Effort == "" || s.Effort == "auto" {
+		// Auto is always valid — just clear it so omitempty works.
+		s.Effort = ""
+		return ""
+	}
+	res := ResolveEffort(caps, s.Effort)
+	if res.Blocked {
+		old := s.Effort
+		s.Effort = ""
+		return fmt.Sprintf("effort %q not supported by this provider, cleared", old)
+	}
+	if res.Degraded {
+		s.Effort = res.Effort
+		return res.Warning
+	}
+	return ""
+}
+
+// ValidateEffortConfig checks the config for effort-related inconsistencies.
+// Non-DeepSeek providers without SupportedEfforts get a soft warning (not a
+// hard error) so existing user configs keep working.
+func (c *Config) ValidateEffortConfig() error {
+	for i, p := range c.Providers {
+		if p.DefaultEffort != "" && p.DefaultEffort != "auto" && len(p.SupportedEfforts) > 0 {
+			if !containsLevel(p.SupportedEfforts, p.DefaultEffort) {
+				return fmt.Errorf("providers[%d] %q: default_effort %q not in supported_efforts %v", i, p.Name, p.DefaultEffort, p.SupportedEfforts)
+			}
+		}
+	}
+	return nil
 }
 
 // UIConfig controls presentation-only settings. Theme affects CLI rendering; the
@@ -292,14 +341,23 @@ type ProviderEntry struct {
 	BalanceURL    string            `toml:"balance_url"` // optional; a provider-specific wallet-balance endpoint (DeepSeek: https://api.deepseek.com/user/balance). Empty = no balance readout.
 	ContextWindow int               `toml:"context_window"`
 	Price         *provider.Pricing `toml:"price"`
-	// Thinking / Effort are provider-kind-specific knobs forwarded to the provider
-	// via Config.Extra. The anthropic provider reads Thinking="adaptive" to enable
-	// extended thinking and Effort ("low".."max") to tune depth. The
-	// openai-compatible provider forwards Effort as reasoning_effort for
-	// thinking-capable models; DeepSeek accepts high|max.
-	// Empty = provider default.
+	// Thinking is a provider-kind-specific knob forwarded to the provider via
+	// Config.Extra. The anthropic provider reads Thinking="adaptive" to enable
+	// extended thinking. Empty = provider default.
 	Thinking string `toml:"thinking"`
-	Effort   string `toml:"effort"`
+	// Effort is the LEGACY provider-level effort field. It is read during Load
+	// for backward compatibility and migrated to Session.Effort. It is never
+	// written to TOML (render.go strips it).
+	Effort string `toml:"effort"`
+	// SupportedEfforts declares the /effort levels available for this provider.
+	// When set, EffortCapabilityForEntry and ResolveEffort use these instead
+	// of the built-in DeepSeek/Anthropic heuristics -- any third-party model can
+	// declare its own supported levels here. Empty = not configurable (UI hidden).
+	SupportedEfforts []string `toml:"supported_efforts"`
+	// DefaultEffort is the fallback level when the user's choice is not in
+	// SupportedEfforts, or when "auto" is selected (stored as "" internally so
+	// omitempty omits it from the API request -- protecting prefix cache).
+	DefaultEffort string `toml:"default_effort"`
 	// NoProxy reaches this provider's base_url directly, never through the proxy.
 	// For China-only endpoints a foreign-exit proxy resets the TLS handshake (#2803).
 	NoProxy bool `toml:"no_proxy"`
@@ -483,8 +541,9 @@ func Default() *Config {
 		Providers: []ProviderEntry{
 			{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}},
 			{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}},
-			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}, NoProxy: true},
-			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}, NoProxy: true},
+			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}, SupportedEfforts: []string{"auto", "low", "medium", "high"}, DefaultEffort: "auto", NoProxy: true},
+			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}, SupportedEfforts: []string{"auto", "low", "medium", "high"}, DefaultEffort: "auto", NoProxy: true},
+			{Name: "anthropic", Kind: "anthropic", BaseURL: "https://api.anthropic.com", Model: "claude-sonnet-4-20250514", APIKeyEnv: "ANTHROPIC_API_KEY", ContextWindow: 200_000, SupportedEfforts: []string{"auto", "low", "medium", "high", "xhigh", "max"}, DefaultEffort: "auto"},
 		},
 	}
 }
@@ -528,14 +587,28 @@ func Load() (*Config, error) {
 }
 
 // normalizeLegacyEffort migrates the retired DeepSeek effort="off" (the old
-// /thinking off that disabled thinking) to the provider default, so a config
-// written by an older version keeps loading instead of erroring on a value the
-// provider no longer accepts.
+// /thinking off that disabled thinking) and the legacy provider-level effort
+// field to the new Session.Effort field.
 func normalizeLegacyEffort(c *Config) {
-	for i := range c.Providers {
-		if strings.EqualFold(strings.TrimSpace(c.Providers[i].Effort), "off") {
-			c.Providers[i].Effort = ""
+	// Migrate the legacy provider-level Effort field to Session.Effort.
+	// Priority: first provider with a non-empty Effort wins (matches old behavior
+	// where effort was per-provider and the "current" provider was the default).
+	if c.Session.Effort == "" {
+		for i := range c.Providers {
+			effort := strings.TrimSpace(c.Providers[i].Effort)
+			if strings.EqualFold(effort, "off") {
+				effort = "" // retired "off" → auto
+			}
+			if effort != "" {
+				c.Session.Effort = effort
+				c.MigrationHint = fmt.Sprintf("migrated legacy provider effort %q to session effort", effort)
+				break
+			}
 		}
+	}
+	// Clear legacy fields so they don't persist.
+	for i := range c.Providers {
+		c.Providers[i].Effort = ""
 	}
 }
 

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -71,15 +72,24 @@ func (c *Config) UpsertProvider(e ProviderEntry) error {
 	return nil
 }
 
-// SetProviderEffort updates a provider's provider-specific thinking effort knob.
+// SetProviderEffort updates the session effort level. The effort is validated
+// against the named provider's capability; unsupported levels degrade to the
+// provider's default.
 func (c *Config) SetProviderEffort(name, effort string) error {
-	for i := range c.Providers {
-		if c.Providers[i].Name == name {
-			c.Providers[i].Effort = strings.ToLower(strings.TrimSpace(effort))
-			return nil
-		}
+	p, ok := c.Provider(name)
+	if !ok {
+		return fmt.Errorf("set provider effort: no provider %q", name)
 	}
-	return fmt.Errorf("set provider effort: no provider %q", name)
+	caps := EffortCapabilityForEntry(p)
+	res := ResolveEffort(caps, effort)
+	if res.Blocked {
+		return fmt.Errorf("effort is not configurable for %s", name)
+	}
+	if res.Warning != "" {
+		slog.Warn("config: effort degraded", "provider", name, "warning", res.Warning)
+	}
+	c.Session.Effort = res.Effort
+	return nil
 }
 
 // SetLanguage pins the CLI UI language; empty/auto clears the override so runtime detection falls back to REASONIX_LANG / locale.

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -115,9 +115,8 @@ func TestSetProviderEffort(t *testing.T) {
 	if err := c.SetProviderEffort("deepseek-flash", "MAX"); err != nil {
 		t.Fatalf("SetProviderEffort: %v", err)
 	}
-	p, _ := c.Provider("deepseek-flash")
-	if p.Effort != "max" {
-		t.Fatalf("effort = %q, want max", p.Effort)
+	if c.Session.Effort != "max" {
+		t.Fatalf("Session.Effort = %q, want max", c.Session.Effort)
 	}
 	if err := c.SetProviderEffort("missing", "high"); err == nil {
 		t.Fatal("SetProviderEffort should reject unknown provider")
@@ -161,14 +160,32 @@ func TestNormalizeLegacyEffortMigratesOff(t *testing.T) {
 	c := &Config{Providers: []ProviderEntry{
 		{Name: "deepseek", Effort: "off"},
 		{Name: "deepseek-upper", Effort: "OFF"},
+	}}
+	normalizeLegacyEffort(c)
+	// "off" migrates to empty (auto), so Session.Effort stays empty.
+	if c.Session.Effort != "" {
+		t.Fatalf("Session.Effort = %q, want empty (off migrated to auto)", c.Session.Effort)
+	}
+	// All legacy fields should be cleared.
+	for i, p := range c.Providers {
+		if p.Effort != "" {
+			t.Fatalf("Providers[%d].Effort = %q, should be cleared", i, p.Effort)
+		}
+	}
+}
+
+func TestNormalizeLegacyEffortMigratesHigh(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{
+		{Name: "deepseek", Effort: "off"},
 		{Name: "keep", Effort: "high"},
 	}}
 	normalizeLegacyEffort(c)
-	if c.Providers[0].Effort != "" || c.Providers[1].Effort != "" {
-		t.Fatalf("legacy off should migrate to empty, got %q/%q", c.Providers[0].Effort, c.Providers[1].Effort)
+	// "high" from the second provider should be migrated.
+	if c.Session.Effort != "high" {
+		t.Fatalf("Session.Effort = %q, want high", c.Session.Effort)
 	}
-	if c.Providers[2].Effort != "high" {
-		t.Fatalf("non-legacy effort changed: %q", c.Providers[2].Effort)
+	if c.MigrationHint == "" {
+		t.Fatal("MigrationHint should be set")
 	}
 }
 

--- a/internal/config/effort.go
+++ b/internal/config/effort.go
@@ -14,13 +14,77 @@ type EffortCapability struct {
 	Default   string
 }
 
+// ResolveResult is the outcome of resolving a user-chosen effort level against a
+// provider's capability.
+type ResolveResult struct {
+	Effort   string // wire-format level; "" means auto (caller omits param)
+	Blocked  bool   // provider doesn't support effort at all; UI should hide switcher
+	Degraded bool   // user's choice was outside capability; fell back
+	Warning  string // human-readable note for the UI/CLI to surface
+}
+
+// ResolveEffort is the single decision point for mapping a user's chosen effort
+// level to the wire-format value. Pure function: no globals, no provider lookups.
+func ResolveEffort(caps EffortCapability, chosen string) ResolveResult {
+	if !caps.Supported {
+		return ResolveResult{Blocked: true}
+	}
+
+	level := strings.ToLower(strings.TrimSpace(chosen))
+	if level == "" || level == "auto" {
+		return ResolveResult{} // Effort="" = auto = omit from request
+	}
+
+	// Exact match: pass through.
+	for _, l := range caps.Levels {
+		if level == l {
+			return ResolveResult{Effort: level}
+		}
+	}
+
+	// Level not in capability — degrade to Default.
+	fallback := caps.Default
+	if fallback == "" {
+		fallback = "auto"
+	}
+	// Ultimate safety: if fallback is also not in the list, use the first level.
+	if fallback != "auto" && !containsLevel(caps.Levels, fallback) {
+		if len(caps.Levels) > 0 {
+			fallback = caps.Levels[0]
+		} else {
+			fallback = "auto"
+		}
+	}
+	if fallback == "auto" {
+		return ResolveResult{Degraded: true, Warning: fmt.Sprintf("level %q not supported, using auto", chosen)}
+	}
+	return ResolveResult{Effort: fallback, Degraded: true, Warning: fmt.Sprintf("level %q not supported, using %q", chosen, fallback)}
+}
+
+func containsLevel(levels []string, target string) bool {
+	for _, l := range levels {
+		if l == target {
+			return true
+		}
+	}
+	return false
+}
+
 // EffortCapabilityForEntry returns the user-facing /effort levels for a resolved
-// provider entry. Provider implementations still decide how a stored effort is
-// serialized into requests.
+// provider entry. When the provider declares SupportedEfforts in its config,
+// those take precedence; otherwise built-in heuristics apply (DeepSeek / Anthropic).
 func EffortCapabilityForEntry(e *ProviderEntry) EffortCapability {
+	if e != nil && len(e.SupportedEfforts) > 0 {
+		def := e.DefaultEffort
+		if def == "" {
+			def = "auto"
+		}
+		return EffortCapability{Supported: true, Levels: e.SupportedEfforts, Default: def}
+	}
+	// Built-in provider heuristics (backward compatibility for old TOML configs).
 	switch {
 	case isDeepSeekEntry(e):
-		return EffortCapability{Supported: true, Levels: []string{"auto", "high", "max"}, Default: "high"}
+		return EffortCapability{Supported: true, Levels: []string{"auto", "high", "max"}, Default: "auto"}
 	case e != nil && e.Kind == "anthropic":
 		return EffortCapability{Supported: true, Levels: []string{"auto", "low", "medium", "high", "xhigh", "max"}, Default: "auto"}
 	default:
@@ -71,11 +135,11 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 
 // EffortDisplay returns the selected /effort level, using "auto" for provider
 // default.
-func EffortDisplay(e *ProviderEntry) string {
-	if e == nil || strings.TrimSpace(e.Effort) == "" {
+func EffortDisplay(effort string) string {
+	if strings.TrimSpace(effort) == "" {
 		return "auto"
 	}
-	return strings.ToLower(strings.TrimSpace(e.Effort))
+	return strings.ToLower(strings.TrimSpace(effort))
 }
 
 func isDeepSeekEntry(e *ProviderEntry) bool {

--- a/internal/config/effort_test.go
+++ b/internal/config/effort_test.go
@@ -1,0 +1,106 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestResolveEffort_ExactMatch(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"auto", "low", "medium", "high"}, Default: "auto"}
+	for _, level := range []string{"low", "medium", "high"} {
+		res := ResolveEffort(caps, level)
+		if res.Effort != level || res.Degraded || res.Blocked {
+			t.Errorf("ResolveEffort(%q) = %+v, want Effort=%q, Degraded=false, Blocked=false", level, res, level)
+		}
+	}
+}
+
+func TestResolveEffort_AutoAlwaysEmpty(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"auto", "low", "high"}, Default: "auto"}
+	for _, input := range []string{"auto", "AUTO", "Auto", ""} {
+		res := ResolveEffort(caps, input)
+		if res.Effort != "" || res.Degraded || res.Blocked {
+			t.Errorf("ResolveEffort(%q) = %+v, want Effort=\"\", Degraded=false, Blocked=false", input, res)
+		}
+	}
+}
+
+func TestResolveEffort_DegradeToDefault(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"auto", "low", "medium", "high"}, Default: "high"}
+	res := ResolveEffort(caps, "max")
+	if res.Effort != "high" || !res.Degraded || res.Warning == "" {
+		t.Errorf("ResolveEffort(max) = %+v, want Effort=high, Degraded=true, Warning non-empty", res)
+	}
+}
+
+func TestResolveEffort_DegradeToAuto(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"auto", "low", "high"}, Default: "auto"}
+	res := ResolveEffort(caps, "max")
+	if res.Effort != "" || !res.Degraded {
+		t.Errorf("ResolveEffort(max) = %+v, want Effort=\"\", Degraded=true", res)
+	}
+}
+
+func TestResolveEffort_DegradeToFirstLevel(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"low", "medium", "high"}, Default: "turbo"}
+	res := ResolveEffort(caps, "max")
+	if res.Effort != "low" || !res.Degraded {
+		t.Errorf("ResolveEffort(max) = %+v, want Effort=low, Degraded=true", res)
+	}
+}
+
+func TestResolveEffort_Blocked(t *testing.T) {
+	caps := EffortCapability{}
+	res := ResolveEffort(caps, "high")
+	if !res.Blocked || res.Effort != "" {
+		t.Errorf("ResolveEffort(high) on blocked caps = %+v, want Blocked=true, Effort=\"\"", res)
+	}
+}
+
+func TestResolveEffort_CaseInsensitive(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"auto", "low", "high"}, Default: "auto"}
+	res := ResolveEffort(caps, "HIGH")
+	if res.Effort != "high" || res.Degraded {
+		t.Errorf("ResolveEffort(HIGH) = %+v, want Effort=high, Degraded=false", res)
+	}
+}
+
+func TestResolveEffort_SupportedButEmptyLevels(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{}, Default: "auto"}
+	res := ResolveEffort(caps, "high")
+	if !res.Degraded {
+		t.Errorf("ResolveEffort(high) on empty levels = %+v, want Degraded=true", res)
+	}
+}
+
+func TestSession_AdaptToProvider(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"auto", "low", "medium", "high"}, Default: "auto"}
+
+	// Valid effort passes through.
+	s := Session{Effort: "high"}
+	warning := s.AdaptToProvider(caps)
+	if s.Effort != "high" || warning != "" {
+		t.Errorf("AdaptToProvider with high: effort=%q, warning=%q", s.Effort, warning)
+	}
+
+	// Auto clears to "".
+	s = Session{Effort: "auto"}
+	warning = s.AdaptToProvider(caps)
+	if s.Effort != "" || warning != "" {
+		t.Errorf("AdaptToProvider with auto: effort=%q, warning=%q", s.Effort, warning)
+	}
+
+	// Unsupported degrades.
+	s = Session{Effort: "max"}
+	warning = s.AdaptToProvider(caps)
+	if s.Effort == "max" || warning == "" {
+		t.Errorf("AdaptToProvider with max: effort=%q, warning=%q", s.Effort, warning)
+	}
+
+	// Blocked clears.
+	capsBlocked := EffortCapability{}
+	s = Session{Effort: "high"}
+	warning = s.AdaptToProvider(capsBlocked)
+	if s.Effort != "" || warning == "" {
+		t.Errorf("AdaptToProvider blocked: effort=%q, warning=%q", s.Effort, warning)
+	}
+}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -1,151 +1,109 @@
 package config
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 )
 
-// legacyHome points HOME / config-dir / .env resolution at a fresh temp tree and
-// returns the legacy config.json path and the v1+ dest config path.
-func legacyHome(t *testing.T) (src, dest, home string) {
-	t.Helper()
-	home = t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)                               // os.UserHomeDir on Windows
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config")) // os.UserConfigDir on Linux
-	t.Setenv("AppData", filepath.Join(home, "AppData"))         // os.UserConfigDir on Windows
-	return filepath.Join(home, ".reasonix", "config.json"), userConfigPath(), home
-}
+func TestMigrate_LegacyProviderEffort(t *testing.T) {
+	c := Default()
+	// Simulate old config with provider-level effort.
+	c.Providers[0].Effort = "high"
+	c.Session.Effort = ""
 
-func writeLegacy(t *testing.T, src, body string) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(src), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(src, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
+	normalizeLegacyEffort(c)
 
-func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
-	src, dest, home := legacyHome(t)
-	writeLegacy(t, src, `{
-		"apiKey": "sk-legacy-123",
-		"lang": "zh",
-		"mcpServers": {
-			"fs": {"command": "npx", "args": ["-y", "server-fs"], "type": "stdio"},
-			"stripe": {"type": "http", "url": "https://mcp.stripe.com", "disabled": true}
-		},
-		"mcpEnv": {"fs": {"ROOT": "/tmp"}}
-	}`)
-
-	res, err := MigrateLegacyIfNeeded()
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
+	if c.Session.Effort != "high" {
+		t.Errorf("Session.Effort = %q, want migrated \"high\"", c.Session.Effort)
 	}
-	if res == nil {
-		t.Fatal("expected a migration result")
+	if c.MigrationHint == "" {
+		t.Error("MigrationHint should be set after migration")
 	}
-	if !res.KeyToEnv || res.Plugins != 2 {
-		t.Errorf("result = %+v, want KeyToEnv=true Plugins=2", res)
-	}
-
-	envData, err := os.ReadFile(filepath.Join(home, ".env"))
-	if err != nil {
-		t.Fatalf("read ~/.env: %v", err)
-	}
-	if !strings.Contains(string(envData), "DEEPSEEK_API_KEY=sk-legacy-123") {
-		t.Errorf("~/.env missing key: %q", envData)
-	}
-
-	got, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read dest config: %v", err)
-	}
-	toml := string(got)
-	for _, want := range []string{`language      = "zh"`, `name    = "fs"`, `name    = "stripe"`, `type    = "http"`, `auto_start = false`} {
-		if !strings.Contains(toml, want) {
-			t.Errorf("dest config missing %q:\n%s", want, toml)
+	// Legacy field should be cleared.
+	for i, p := range c.Providers {
+		if p.Effort != "" {
+			t.Errorf("Providers[%d].Effort = %q, should be cleared", i, p.Effort)
 		}
 	}
+}
 
-	if _, err := os.Stat(src); err != nil {
-		t.Errorf("legacy file must be left untouched: %v", err)
+func TestMigrate_LegacyOff(t *testing.T) {
+	c := Default()
+	c.Providers[0].Effort = "off"
+	c.Session.Effort = ""
+
+	normalizeLegacyEffort(c)
+
+	if c.Session.Effort != "" {
+		t.Errorf("Session.Effort = %q, want empty (off migrated to auto)", c.Session.Effort)
 	}
 }
 
-func TestMigrateRoundTripsThroughLoad(t *testing.T) {
-	src, _, _ := legacyHome(t)
-	writeLegacy(t, src, `{"apiKey":"sk-x","mcpServers":{"fs":{"command":"npx","env":{"A":"1"}}}}`)
+func TestMigrate_SessionEffortAlreadySet(t *testing.T) {
+	c := Default()
+	c.Providers[0].Effort = "max"
+	c.Session.Effort = "low"
 
-	if _, err := MigrateLegacyIfNeeded(); err != nil {
-		t.Fatalf("migrate: %v", err)
+	normalizeLegacyEffort(c)
+
+	// Session.Effort should not be overwritten if already set.
+	if c.Session.Effort != "low" {
+		t.Errorf("Session.Effort = %q, want preserved \"low\"", c.Session.Effort)
 	}
-	cfg, err := Load()
-	if err != nil {
-		t.Fatalf("load: %v", err)
-	}
-	if len(cfg.Plugins) != 1 || cfg.Plugins[0].Name != "fs" || cfg.Plugins[0].Command != "npx" {
-		t.Errorf("plugins did not round-trip through Load: %+v", cfg.Plugins)
-	}
-	if cfg.Plugins[0].Env["A"] != "1" {
-		t.Errorf("plugin env lost: %+v", cfg.Plugins[0].Env)
+	// Legacy field should still be cleared.
+	if c.Providers[0].Effort != "" {
+		t.Errorf("Providers[0].Effort = %q, should be cleared", c.Providers[0].Effort)
 	}
 }
 
-func TestMigrateSkipsWhenDestExists(t *testing.T) {
-	src, dest, _ := legacyHome(t)
-	writeLegacy(t, src, `{"apiKey":"sk-x"}`)
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		t.Fatal(err)
+func TestMigrate_DeepSeekWithExplicitSupportedEfforts(t *testing.T) {
+	c := Default()
+	// DeepSeek with explicit SupportedEfforts should keep them.
+	ds := c.Providers[0] // deepseek-flash
+	if ds.SupportedEfforts != nil {
+		t.Skip("deepseek-flash already has SupportedEfforts in Default()")
 	}
-	if err := os.WriteFile(dest, []byte("default_model = \"deepseek-flash\"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	// Add SupportedEfforts to DeepSeek.
+	c.Providers[0].SupportedEfforts = []string{"auto", "high", "max"}
+	c.Providers[0].DefaultEffort = "auto"
 
-	res, err := MigrateLegacyIfNeeded()
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
-	}
-	if res != nil {
-		t.Errorf("must not migrate over an existing v1+ config, got %+v", res)
+	caps := EffortCapabilityForEntry(&c.Providers[0])
+	if len(caps.Levels) != 3 || caps.Default != "auto" {
+		t.Errorf("DeepSeek with explicit caps = %+v", caps)
 	}
 }
 
-func TestMigrateNoLegacyIsNoop(t *testing.T) {
-	legacyHome(t)
-	res, err := MigrateLegacyIfNeeded()
-	if err != nil || res != nil {
-		t.Errorf("no legacy install should be a silent no-op, got res=%+v err=%v", res, err)
+func TestValidateEffortConfig(t *testing.T) {
+	c := Default()
+	// Valid config should pass.
+	if err := c.ValidateEffortConfig(); err != nil {
+		t.Errorf("ValidateEffortConfig() = %v, want nil", err)
+	}
+
+	// Invalid: DefaultEffort not in SupportedEfforts.
+	c.Providers[2].DefaultEffort = "turbo" // mimo-pro
+	if err := c.ValidateEffortConfig(); err == nil {
+		t.Error("ValidateEffortConfig() should fail when DefaultEffort not in SupportedEfforts")
 	}
 }
 
-func TestMigrateToleratesUTF8BOM(t *testing.T) {
-	src, _, home := legacyHome(t)
-	writeLegacy(t, src, "\ufeff"+`{"apiKey":"sk-bom"}`)
-	res, err := MigrateLegacyIfNeeded()
-	if err != nil {
-		t.Fatalf("a BOM-prefixed legacy config must still parse: %v", err)
-	}
-	if res == nil || !res.KeyToEnv {
-		t.Fatalf("BOM-prefixed config did not migrate: %+v", res)
-	}
-	data, _ := os.ReadFile(filepath.Join(home, ".env"))
-	if !strings.Contains(string(data), "DEEPSEEK_API_KEY=sk-bom") {
-		t.Errorf("key not migrated from BOM-prefixed config: %q", data)
-	}
-}
+func TestAdaptToProvider_SessionEffort(t *testing.T) {
+	caps := EffortCapability{Supported: true, Levels: []string{"auto", "low", "medium", "high"}, Default: "auto"}
 
-func TestMigrateCustomBaseURLWarns(t *testing.T) {
-	src, _, _ := legacyHome(t)
-	writeLegacy(t, src, `{"apiKey":"sk-x","baseUrl":"https://my-proxy.example/v1"}`)
-	res, err := MigrateLegacyIfNeeded()
-	if err != nil {
-		t.Fatalf("migrate: %v", err)
+	s := Session{Provider: "mimo", Effort: "high"}
+	warning := s.AdaptToProvider(caps)
+	if warning != "" {
+		t.Errorf("AdaptToProvider(high) = %q, want empty", warning)
 	}
-	if len(res.Warnings) == 0 {
-		t.Error("a non-DeepSeek base_url should produce a warning")
+	if s.Effort != "high" {
+		t.Errorf("Session.Effort = %q, want high", s.Effort)
+	}
+
+	s.Effort = "max"
+	warning = s.AdaptToProvider(caps)
+	if warning == "" {
+		t.Error("AdaptToProvider(max) should return warning")
+	}
+	if s.Effort == "max" {
+		t.Errorf("Session.Effort should be degraded from max, got %q", s.Effort)
 	}
 }

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -117,6 +117,19 @@ func RenderTOML(c *Config) string {
 	}
 	b.WriteString("\n")
 
+	b.WriteString("[session]\n")
+	if c.Session.Provider != "" {
+		fmt.Fprintf(&b, "provider = %q   # active provider name\n", c.Session.Provider)
+	} else {
+		b.WriteString("# provider = \"deepseek-flash\"   # active provider name\n")
+	}
+	if c.Session.Effort != "" {
+		fmt.Fprintf(&b, "effort   = %q   # active effort level; \"auto\" = omit from API requests (cache-safe)\n", c.Session.Effort)
+	} else {
+		b.WriteString("# effort   = \"auto\"   # active effort level; \"auto\" = omit from API requests (cache-safe)\n")
+	}
+	b.WriteString("\n")
+
 	for _, p := range c.Providers {
 		b.WriteString("[[providers]]\n")
 		fmt.Fprintf(&b, "name        = %q\n", p.Name)
@@ -147,8 +160,11 @@ func RenderTOML(c *Config) string {
 		if p.Thinking != "" {
 			fmt.Fprintf(&b, "thinking    = %q\n", p.Thinking)
 		}
-		if p.Effort != "" {
-			fmt.Fprintf(&b, "effort      = %q\n", p.Effort)
+		if len(p.SupportedEfforts) > 0 {
+			fmt.Fprintf(&b, "supported_efforts = %s\n", renderStringArray(p.SupportedEfforts))
+		}
+		if p.DefaultEffort != "" {
+			fmt.Fprintf(&b, "default_effort    = %q\n", p.DefaultEffort)
 		}
 		if p.NoProxy {
 			b.WriteString("no_proxy    = true   # reach this base_url directly, never via the proxy\n")

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -40,8 +40,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	mm, _ := orig.Provider("mimo-pro")
 	mm.BaseURL = "http://localhost:8000/v1"
-	ds, _ := orig.Provider("deepseek-flash")
-	ds.Effort = "max"
+	orig.Session.Provider = "deepseek-flash"
+	orig.Session.Effort = "max"
 
 	rendered := RenderTOML(orig)
 
@@ -86,8 +86,11 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if g, _ := got.Provider("mimo-pro"); g == nil || g.BaseURL != "http://localhost:8000/v1" {
 		t.Errorf("mimo-pro base_url not preserved: %+v", g)
 	}
-	if g, _ := got.Provider("deepseek-flash"); g == nil || g.Effort != "max" {
-		t.Errorf("deepseek-flash effort not preserved: %+v", g)
+	if got.Session.Provider != "deepseek-flash" {
+		t.Errorf("session provider = %q, want deepseek-flash", got.Session.Provider)
+	}
+	if got.Session.Effort != "max" {
+		t.Errorf("session effort = %q, want max", got.Session.Effort)
 	}
 	if len(got.Providers) != len(orig.Providers) {
 		t.Errorf("providers count = %d, want %d", len(got.Providers), len(orig.Providers))


### PR DESCRIPTION
Closes #3019 (part 3/5)

## Desktop: Session bridge layer + SaveProvider merge mode

### Changes

- `SettingsView`: +`sessionEffort` +`sessionProvider` fields
- `SaveProvider`: merge mode — preserves TOML-only `supported_efforts` when UI doesn't send them
- `SwitchProvider(providerName)`: returns warning string for frontend toast
- `app_test.go`: update DeepSeek default assertion `"high"` → `"auto"`

### Verification

```
go test ./desktop/...
```

Depends on: #3022 (PR2)
