### PR TITLE
netclient: remove Client.Timeout from NewHTTPClient, delegate to context

### DIFF
--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -65,7 +65,7 @@ func httpClient() (*http.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return netclient.NewHTTPClient(cfg.NetworkProxySpec(), httpTimeout, netclient.TransportOptions{})
+	return netclient.NewHTTPClient(cfg.NetworkProxySpec(), netclient.TransportOptions{})
 }
 
 // canSelfUpdate reports whether in-place update is possible. macOS is excluded:

--- a/desktop/updater_app.go
+++ b/desktop/updater_app.go
@@ -34,7 +34,9 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 			Err:           err.Error(),
 		}, nil
 	}
-	m, err := fetchManifest(a.reqCtx(), c)
+	ctx, cancel := context.WithTimeout(a.reqCtx(), httpTimeout)
+	defer cancel()
+	m, err := fetchManifest(ctx, c)
 	if err != nil {
 		return &UpdateInfo{
 			Current:       version,
@@ -52,7 +54,9 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 func (a *App) OpenDownloadPage() {
 	page := defaultDownloadPage
 	if c, err := httpClient(); err == nil {
-		if m, err := fetchManifest(a.reqCtx(), c); err == nil && m.DownloadPage != "" {
+		ctx, cancel := context.WithTimeout(a.reqCtx(), httpTimeout)
+		defer cancel()
+		if m, err := fetchManifest(ctx, c); err == nil && m.DownloadPage != "" {
 			page = m.DownloadPage
 		}
 	}
@@ -73,7 +77,9 @@ func (a *App) ApplyUpdate() error {
 	if err != nil {
 		return a.failUpdate(err)
 	}
-	m, err := fetchManifest(a.reqCtx(), c)
+	ctx, cancel := context.WithTimeout(a.reqCtx(), httpTimeout)
+	defer cancel()
+	m, err := fetchManifest(ctx, c)
 	if err != nil {
 		return a.failUpdate(err)
 	}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/codegraph"
@@ -140,7 +139,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if err := netclient.Validate(proxySpec); err != nil {
 		return nil, err
 	}
-	balanceClient, err := netclient.NewHTTPClient(proxySpec, 12*time.Second, netclient.TransportOptions{})
+	balanceClient, err := netclient.NewHTTPClient(proxySpec, netclient.TransportOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +283,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		case cfg.Codegraph.AutoInstall:
 			notify := func(msg string) { sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg}) }
 			notify("codegraph: fetching code-intelligence runtime in the background (one-time) — symbol-graph tools available next session")
-			codegraphClient, err := netclient.NewHTTPClient(proxySpec, 0, netclient.TransportOptions{})
+			codegraphClient, err := netclient.NewHTTPClient(proxySpec, netclient.TransportOptions{})
 			if err != nil {
 				notify("codegraph: install skipped (" + err.Error() + ")")
 			} else {

--- a/internal/cli/codegraph.go
+++ b/internal/cli/codegraph.go
@@ -38,7 +38,7 @@ func codegraphInstall() int {
 		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
-	client, err := netclient.NewHTTPClient(cfg.NetworkProxySpec(), 0, netclient.TransportOptions{})
+	client, err := netclient.NewHTTPClient(cfg.NetworkProxySpec(), netclient.TransportOptions{})
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		return 1

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/billing"
@@ -1199,6 +1200,8 @@ func (c *Controller) Balance(ctx context.Context) (*billing.Balance, error) {
 	if strings.TrimSpace(c.balanceURL) == "" {
 		return nil, nil
 	}
+	ctx, cancel := context.WithTimeout(ctx, 12*time.Second)
+	defer cancel()
 	return billing.FetchWithClient(ctx, c.balanceClient, c.balanceURL, c.balanceKey)
 }
 

--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -72,12 +72,12 @@ func Validate(spec ProxySpec) error {
 }
 
 // NewHTTPClient returns an HTTP client with Reasonix proxy settings applied.
-func NewHTTPClient(spec ProxySpec, timeout time.Duration, opts TransportOptions) (*http.Client, error) {
+func NewHTTPClient(spec ProxySpec, opts TransportOptions) (*http.Client, error) {
 	tr, err := NewTransport(spec, opts)
 	if err != nil {
 		return nil, err
 	}
-	return &http.Client{Timeout: timeout, Transport: tr}, nil
+	return &http.Client{Transport: tr}, nil
 }
 
 // NewTransport clones net/http's default transport and overlays the requested

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -80,7 +80,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 
 func newHTTPClient(cfg provider.Config) (*http.Client, error) {
 	spec, _ := cfg.Extra["proxy_spec"].(netclient.ProxySpec)
-	return netclient.NewHTTPClient(spec, 0, netclient.TransportOptions{})
+	return netclient.NewHTTPClient(spec, netclient.TransportOptions{})
 }
 
 type client struct {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -78,7 +78,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 
 func newHTTPClient(cfg provider.Config) (*http.Client, error) {
 	spec, _ := cfg.Extra["proxy_spec"].(netclient.ProxySpec)
-	return netclient.NewHTTPClient(spec, 0, netclient.TransportOptions{
+	return netclient.NewHTTPClient(spec, netclient.TransportOptions{
 		DialTimeout:           30 * time.Second,
 		KeepAlive:             30 * time.Second,
 		TLSHandshakeTimeout:   15 * time.Second,


### PR DESCRIPTION
http.Client.Timeout is an end-to-end deadline that includes reading the entire response body — a blunt instrument unsuitable for both large downloads and long-lived streaming requests. Remove both the field and the parameter from the shared factory; let each call site express its deadline via context.Context.

### Changes

| File | Change |
|------|--------|
| `internal/netclient/netclient.go` | Removed `timeout time.Duration` parameter and `Client.Timeout` field |
| `desktop/updater.go` | Dropped `httpTimeout` argument from call |
| `desktop/updater_app.go` | Wrapped manifest fetches with `context.WithTimeout(ctx, 15s)`; download/signature left unbounded |
| `internal/control/controller.go` | Wrapped Balance query with `context.WithTimeout(ctx, 12s)` |
| `internal/boot/boot.go` | Dropped timeout arguments from 2 call sites, removed unused `"time"` import |
| `internal/cli/codegraph.go` | Dropped `0` argument |
| `internal/provider/openai/openai.go` | Dropped `0` argument |
| `internal/provider/anthropic/anthropic.go` | Dropped `0` argument |

### Why this is the right fix

- **LLM providers are untouched in behaviour** — they already pass `0` (no Client.Timeout) and rely on context for lifecycle. Dropping the argument changes nothing.
- **The updater bug is fixed** — large installer downloads are no longer cut off at 15s.
- **Deadlines are explicit at the call site** — each caller expresses its own time budget, rather than inheriting a one-size-fits-all value from the shared factory.

Closes #3028
