### PR TITLE
fix: isolate desktop sessions by workspace

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -978,11 +978,42 @@ type WorkspaceMeta struct {
 	Current bool   `json:"current"`
 }
 
+func controllerSessionDir(ctrl *control.Controller) string {
+	if ctrl != nil {
+		if dir := ctrl.SessionDir(); dir != "" {
+			return dir
+		}
+	}
+	return desktopSessionDir("")
+}
+
+func tabSessionDir(tab *WorkspaceTab) string {
+	if tab != nil {
+		if tab.Ctrl != nil {
+			if dir := tab.Ctrl.SessionDir(); dir != "" {
+				return dir
+			}
+		}
+		if tab.WorkspaceRoot != "" {
+			return desktopSessionDir(tab.WorkspaceRoot)
+		}
+	}
+	return desktopSessionDir("")
+}
+
+func (a *App) activeSessionDir() string {
+	a.mu.RLock()
+	tab := a.activeTabLocked()
+	dir := tabSessionDir(tab)
+	a.mu.RUnlock()
+	return dir
+}
+
 // ListSessions returns the saved sessions newest-first for the history panel,
 // marking the one the current conversation is writing to and attaching any
 // user-chosen titles.
 func (a *App) ListSessions() []SessionMeta {
-	dir := config.SessionDir()
+	dir := a.activeSessionDir()
 	infos, err := agent.ListSessions(dir)
 	if err != nil {
 		return []SessionMeta{}
@@ -1001,20 +1032,21 @@ func (a *App) ListSessions() []SessionMeta {
 // ListTrashedSessions returns sessions that were moved to the local trash,
 // newest-deleted first. These can be previewed, restored, or permanently purged.
 func (a *App) ListTrashedSessions() []SessionMeta {
-	dir := config.SessionDir()
-	paths, err := listTrashedSessionFiles(dir)
-	if err != nil {
-		return []SessionMeta{}
-	}
-	titles := loadSessionTitles(dir)
-	out := make([]SessionMeta, 0, len(paths))
-	for _, path := range paths {
-		infos, err := agent.ListSessions(filepath.Dir(path))
-		if err != nil || len(infos) == 0 {
+	out := []SessionMeta{}
+	for _, dir := range a.knownSessionDirs() {
+		paths, err := listTrashedSessionFiles(dir)
+		if err != nil {
 			continue
 		}
-		deletedAt := trashedSessionDeletedAt(path)
-		out = append(out, sessionMetaFromInfo(infos[0], titles[filepath.Base(path)], false, false, deletedAt))
+		titles := loadSessionTitles(dir)
+		for _, path := range paths {
+			infos, err := agent.ListSessions(filepath.Dir(path))
+			if err != nil || len(infos) == 0 {
+				continue
+			}
+			deletedAt := trashedSessionDeletedAt(path)
+			out = append(out, sessionMetaFromInfo(infos[0], titles[filepath.Base(path)], false, false, deletedAt))
+		}
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].DeletedAt == out[j].DeletedAt {
@@ -1023,6 +1055,25 @@ func (a *App) ListTrashedSessions() []SessionMeta {
 		return out[i].DeletedAt > out[j].DeletedAt
 	})
 	return out
+}
+
+func (a *App) trashedSessionDir(path string) (string, error) {
+	for _, dir := range a.knownSessionDirs() {
+		if _, _, _, err := validateTrashedSessionPath(dir, path); err == nil {
+			return dir, nil
+		}
+	}
+	return "", fmt.Errorf("trashed session path outside known session dirs: %s", path)
+}
+
+func (a *App) sessionDirForPath(path string) (string, string, error) {
+	for _, dir := range a.knownSessionDirs() {
+		sessionPath, _, err := validateSessionPath(dir, path)
+		if err == nil {
+			return dir, sessionPath, nil
+		}
+	}
+	return "", "", fmt.Errorf("session path outside known session dirs: %s", path)
 }
 
 func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, deletedAt int64) SessionMeta {
@@ -1047,7 +1098,7 @@ func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, 
 // DeleteSession moves a saved session to the local trash. It refuses any open
 // session because tab auto-save would recreate or append to the file later.
 func (a *App) DeleteSession(path string) error {
-	dir := config.SessionDir()
+	dir := a.activeSessionDir()
 	sessionPath, key, err := validateSessionPath(dir, path)
 	if err != nil {
 		return err
@@ -1098,7 +1149,10 @@ func (a *App) activeSessionPath(dir string) string {
 
 // RestoreSession moves a trashed session back into the saved-session list.
 func (a *App) RestoreSession(path string) error {
-	dir := config.SessionDir()
+	dir, err := a.trashedSessionDir(path)
+	if err != nil {
+		return err
+	}
 	_, key, _, err := validateTrashedSessionPath(dir, path)
 	if err != nil {
 		return err
@@ -1116,13 +1170,17 @@ func (a *App) RestoreSession(path string) error {
 // PurgeTrashedSession permanently removes a trashed session and its title/display
 // sidecars.
 func (a *App) PurgeTrashedSession(path string) error {
-	return purgeTrashedSessionFile(config.SessionDir(), path)
+	dir, err := a.trashedSessionDir(path)
+	if err != nil {
+		return err
+	}
+	return purgeTrashedSessionFile(dir, path)
 }
 
 // RenameSession sets a custom display name for a session (empty clears it back to
 // the preview). It only affects the history panel; the file on disk is unchanged.
 func (a *App) RenameSession(path, title string) error {
-	return setSessionTitle(config.SessionDir(), path, title)
+	return setSessionTitle(a.activeSessionDir(), path, title)
 }
 
 // ResumeSession snapshots the current conversation, then loads the session at
@@ -1143,20 +1201,28 @@ func (a *App) ResumeSessionForTab(tabID, path string) ([]HistoryMessage, error) 
 		return []HistoryMessage{}, fmt.Errorf("tab is not ready")
 	}
 	ctrl := tab.Ctrl
-	loaded, err := agent.LoadSession(path)
+	sessionPath, _, err := validateSessionPath(controllerSessionDir(ctrl), path)
+	if err != nil {
+		return nil, err
+	}
+	loaded, err := agent.LoadSession(sessionPath)
 	if err != nil {
 		return nil, err
 	}
 	_ = ctrl.Snapshot() // persist the current session before switching away
-	ctrl.Resume(loaded, path)
-	a.rememberTabSessionPath(tab, path)
+	ctrl.Resume(loaded, sessionPath)
+	a.rememberTabSessionPath(tab, sessionPath)
 	return a.HistoryForTab(tabID), nil
 }
 
 // PreviewSession reads a saved session for display only. It does not snapshot or
 // swap the active controller, so the history drawer can call it while a turn runs.
 func (a *App) PreviewSession(path string) ([]HistoryMessage, error) {
-	return previewSessionMessages(config.SessionDir(), path)
+	sessionDir, sessionPath, err := a.sessionDirForPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return previewSessionMessages(sessionDir, sessionPath)
 }
 
 // PickWorkspace opens a folder chooser and, on a pick, opens a new project tab
@@ -1371,7 +1437,7 @@ func (a *App) HistoryForTab(tabID string) []HistoryMessage {
 		return []HistoryMessage{}
 	}
 	msgs := ctrl.History()
-	return historyMessages(msgs, sessionDisplayResolver(config.SessionDir(), ctrl.SessionPath()))
+	return historyMessages(msgs, sessionDisplayResolver(controllerSessionDir(ctrl), ctrl.SessionPath()))
 }
 
 func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
@@ -1405,14 +1471,18 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 }
 
 func previewSessionMessages(sessionDir, path string) ([]HistoryMessage, error) {
-	if out, ok, err := previewEventSessionMessages(path); ok || err != nil {
-		return out, err
-	}
-	loaded, err := agent.LoadSession(path)
+	sessionPath, _, err := validateSessionPath(sessionDir, path)
 	if err != nil {
 		return nil, err
 	}
-	return historyMessages(loaded.Snapshot(), sessionDisplayResolver(sessionDir, path)), nil
+	if out, ok, err := previewEventSessionMessages(sessionPath); ok || err != nil {
+		return out, err
+	}
+	loaded, err := agent.LoadSession(sessionPath)
+	if err != nil {
+		return nil, err
+	}
+	return historyMessages(loaded.Snapshot(), sessionDisplayResolver(sessionDir, sessionPath)), nil
 }
 
 type previewEventRecord struct {
@@ -3036,6 +3106,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 		RequireKey:     false,
 		Sink:           tab.sink,
 		WorkspaceRoot:  tab.WorkspaceRoot,
+		SessionDir:     tabSessionDir(tab),
 		EffortOverride: cloneStringPtr(effortOverride),
 	})
 	if err != nil {
@@ -3129,6 +3200,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		RequireKey:     false,
 		Sink:           tab.sink,
 		WorkspaceRoot:  tab.WorkspaceRoot,
+		SessionDir:     tabSessionDir(tab),
 		EffortOverride: &effort,
 	})
 	if err != nil {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1152,6 +1153,98 @@ func TestDeleteSessionRejectsInactiveOpenTab(t *testing.T) {
 	}
 	if open[filepath.Base(otherPath)] {
 		t.Fatalf("ListSessions marked unopened session open, got %#v", open)
+	}
+}
+
+func TestDesktopSessionAPIsUseControllerSessionDir(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dirA := filepath.Join(t.TempDir(), "workspace-a-sessions")
+	dirB := filepath.Join(t.TempDir(), "workspace-b-sessions")
+	if err := os.MkdirAll(dirA, 0o755); err != nil {
+		t.Fatalf("mkdir dirA: %v", err)
+	}
+	if err := os.MkdirAll(dirB, 0o755); err != nil {
+		t.Fatalf("mkdir dirB: %v", err)
+	}
+	pathA := filepath.Join(dirA, "a.jsonl")
+	pathB := filepath.Join(dirB, "b.jsonl")
+	if err := os.WriteFile(pathA, []byte(`{"role":"user","content":"workspace A"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write pathA: %v", err)
+	}
+	if err := os.WriteFile(pathB, []byte(`{"role":"user","content":"workspace B"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write pathB: %v", err)
+	}
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{SessionDir: dirA, SessionPath: pathA, Label: "test"}), "")
+	defer app.activeCtrl().Close()
+
+	sessions := app.ListSessions()
+	if len(sessions) != 1 || sessions[0].Path != pathA || sessions[0].Preview != "workspace A" {
+		t.Fatalf("ListSessions should read the active controller session dir only, got %+v", sessions)
+	}
+	if err := app.RenameSession(pathA, "A title"); err != nil {
+		t.Fatalf("RenameSession in active session dir: %v", err)
+	}
+	if titles := loadSessionTitles(dirA); titles["a.jsonl"] != "A title" {
+		t.Fatalf("title should be written beside the active session, got %+v", titles)
+	}
+	if titles := loadSessionTitles(dirB); len(titles) != 0 {
+		t.Fatalf("inactive workspace title sidecar should remain untouched, got %+v", titles)
+	}
+}
+
+func TestResumeSessionRejectsPathOutsideControllerSessionDir(t *testing.T) {
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	activePath := filepath.Join(dirA, "active.jsonl")
+	outsidePath := filepath.Join(dirB, "outside.jsonl")
+	for _, path := range []string{activePath, outsidePath} {
+		if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{SessionDir: dirA, SessionPath: activePath, Label: "test"}), "")
+	defer app.activeCtrl().Close()
+
+	if _, err := app.ResumeSession(outsidePath); err == nil {
+		t.Fatal("ResumeSession should reject a transcript outside the active session dir")
+	}
+	if _, err := app.PreviewSession(outsidePath); err == nil {
+		t.Fatal("PreviewSession should reject a transcript outside the active session dir")
+	}
+}
+
+func BenchmarkDesktopListSessionsScoped(b *testing.B) {
+	dirA := filepath.Join(b.TempDir(), "workspace-a-sessions")
+	dirB := filepath.Join(b.TempDir(), "workspace-b-sessions")
+	for _, dir := range []string{dirA, dirB} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			b.Fatalf("mkdir %s: %v", dir, err)
+		}
+		for i := 0; i < 120; i++ {
+			path := filepath.Join(dir, fmt.Sprintf("session-%03d.jsonl", i))
+			body := fmt.Sprintf(`{"role":"user","content":"session %03d"}`+"\n", i)
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				b.Fatalf("write session: %v", err)
+			}
+		}
+	}
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{SessionDir: dirA, SessionPath: filepath.Join(dirA, "session-000.jsonl"), Label: "test"}), "")
+	defer app.activeCtrl().Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sessions := app.ListSessions()
+		if len(sessions) != 120 {
+			b.Fatalf("ListSessions len = %d, want 120", len(sessions))
+		}
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/fileutil"
 )
@@ -33,6 +34,29 @@ const sessionTrashMetaFile = ".trash-meta.json"
 func sessionTitlesPath(dir string) string  { return filepath.Join(dir, sessionTitlesFile) }
 func sessionDisplayPath(dir string) string { return filepath.Join(dir, sessionDisplayFile) }
 func sessionTrashPath(dir string) string   { return filepath.Join(dir, sessionTrashDir) }
+
+func desktopSessionDir(root string) string {
+	base := config.MemoryUserDir()
+	if base == "" {
+		return config.SessionDir()
+	}
+	root = strings.TrimSpace(root)
+	if root == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return config.SessionDir()
+		}
+		root = cwd
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	return filepath.Join(base, "projects", desktopWorkspaceSlug(root), "sessions")
+}
+
+func desktopWorkspaceSlug(absPath string) string {
+	return strings.NewReplacer(string(os.PathSeparator), "-", "/", "-", "\\", "-", ":", "-").Replace(absPath)
+}
 
 // loadSessionTitles reads the basename→title map (missing/corrupt → empty).
 func loadSessionTitles(dir string) map[string]string {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -477,6 +477,7 @@ func (a *App) rebuild() error {
 		Model: model, RequireKey: false,
 		Sink:           tab.sink,
 		WorkspaceRoot:  tab.WorkspaceRoot,
+		SessionDir:     tabSessionDir(tab),
 		EffortOverride: cloneStringPtr(tab.effort),
 	})
 	if err != nil {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -721,11 +721,39 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 		tab.sink.ctx = wailsCtx
 	}
 
+	sessionDir := desktopSessionDir(root)
+	topicID := strings.TrimSpace(tab.TopicID)
+	if tab.Scope == "global" {
+		migratedTopics := migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
+		if len(migratedTopics) > 0 {
+			a.emitProjectTreeChanged()
+		}
+		if topicID == "" && len(migratedTopics) > 0 {
+			topicID = migratedTopics[0]
+			topicTitle := topicTitleForTab("global", "", topicID)
+			a.mu.Lock()
+			if strings.TrimSpace(tab.TopicID) == "" {
+				tab.TopicID = topicID
+				tab.TopicTitle = topicTitle
+				a.saveTabsLocked()
+			} else {
+				topicID = strings.TrimSpace(tab.TopicID)
+			}
+			a.mu.Unlock()
+		}
+	}
+	if topicID != "" {
+		if _, dir := a.findKnownTopicSession(topicID); dir != "" {
+			sessionDir = dir
+		}
+	}
+
 	ctrl, err := boot.Build(buildCtx, boot.Options{
 		Model:          model,
 		RequireKey:     false,
 		Sink:           tab.sink,
 		WorkspaceRoot:  root,
+		SessionDir:     sessionDir,
 		EffortOverride: cloneStringPtr(tab.effort),
 	})
 	if err != nil {
@@ -2288,20 +2316,22 @@ func (a *App) updateTopicSessionTitles(topicID, title string) {
 	if strings.TrimSpace(topicID) == "" || strings.TrimSpace(title) == "" {
 		return
 	}
-	infos, err := agent.ListSessions(config.SessionDir())
-	if err != nil {
-		return
-	}
-	for _, info := range infos {
-		if info.TopicID != topicID {
+	for _, dir := range a.knownSessionDirs() {
+		infos, err := agent.ListSessions(dir)
+		if err != nil {
 			continue
 		}
-		meta, ok, err := agent.LoadBranchMeta(info.Path)
-		if err != nil || !ok {
-			continue
+		for _, info := range infos {
+			if info.TopicID != topicID {
+				continue
+			}
+			meta, ok, err := agent.LoadBranchMeta(info.Path)
+			if err != nil || !ok {
+				continue
+			}
+			meta.TopicTitle = title
+			_ = agent.SaveBranchMetaPreserveUpdated(info.Path, meta)
 		}
-		meta.TopicTitle = title
-		_ = agent.SaveBranchMetaPreserveUpdated(info.Path, meta)
 	}
 }
 
@@ -2381,7 +2411,6 @@ func (a *App) TrashTopic(topicID string) error {
 	if strings.TrimSpace(topicID) == "" {
 		return fmt.Errorf("topicID is required")
 	}
-	dir := config.SessionDir()
 
 	type topicTab struct {
 		id            string
@@ -2452,20 +2481,22 @@ func (a *App) TrashTopic(topicID string) error {
 		a.mu.Unlock()
 	}
 
-	infos, err := agent.ListSessions(dir)
-	if err != nil {
-		return err
-	}
-	for _, info := range infos {
-		if info.TopicID != topicID {
-			continue
-		}
-		sessionPath, _, err := validateSessionPath(dir, info.Path)
+	for _, dir := range a.knownSessionDirs() {
+		infos, err := agent.ListSessions(dir)
 		if err != nil {
 			return err
 		}
-		if err := deleteSessionFile(dir, sessionPath); err != nil {
-			return err
+		for _, info := range infos {
+			if info.TopicID != topicID {
+				continue
+			}
+			sessionPath, _, err := validateSessionPath(dir, info.Path)
+			if err != nil {
+				return err
+			}
+			if err := deleteSessionFile(dir, sessionPath); err != nil {
+				return err
+			}
 		}
 	}
 	if err := a.DeleteTopic(topicID); err != nil {
@@ -2503,7 +2534,11 @@ func (a *App) ListProjectTree() []ProjectNode {
 		lastActivityAt int64
 	}
 	topicSummaries := map[string]topicSummary{}
-	if infos, err := agent.ListSessions(config.SessionDir()); err == nil {
+	for _, dir := range a.knownSessionDirs() {
+		infos, err := agent.ListSessions(dir)
+		if err != nil {
+			continue
+		}
 		for _, info := range infos {
 			if strings.TrimSpace(info.TopicID) == "" {
 				continue
@@ -2980,6 +3015,36 @@ func (a *App) persistTabSessionPath(tab *WorkspaceTab, path string) {
 	a.rememberTabSessionPath(tab, path)
 }
 
+func (a *App) knownSessionDirs() []string {
+	seen := map[string]bool{}
+	out := []string{}
+	add := func(dir string) {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			return
+		}
+		if abs, err := filepath.Abs(dir); err == nil {
+			dir = abs
+		}
+		if seen[dir] {
+			return
+		}
+		seen[dir] = true
+		out = append(out, dir)
+	}
+	add(config.SessionDir()) // legacy/global sessions from earlier desktop builds
+	add(desktopSessionDir(globalWorkspaceRoot()))
+	for _, project := range loadProjectsFile().Projects {
+		add(desktopSessionDir(project.Root))
+	}
+	a.mu.RLock()
+	for _, tab := range a.tabs {
+		add(tabSessionDir(tab))
+	}
+	a.mu.RUnlock()
+	return out
+}
+
 // findTopicSession scans the session directory for a .jsonl file whose .meta
 // carries the given topicID. Returns the most recently updated match, or ""
 // if no session exists for this topic.
@@ -3011,4 +3076,13 @@ func findTopicSession(dir, topicID string) string {
 		}
 	}
 	return bestPath
+}
+
+func (a *App) findKnownTopicSession(topicID string) (string, string) {
+	for _, dir := range a.knownSessionDirs() {
+		if path := findTopicSession(dir, topicID); path != "" {
+			return path, dir
+		}
+	}
+	return "", ""
 }

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -12,6 +12,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
+	"reasonix/internal/control"
 )
 
 func waitForTabReady(t *testing.T, app *App, tabID string) *WorkspaceTab {
@@ -1078,6 +1079,9 @@ func TestRestoreSessionWithoutTopicMetadataFallsBackToGlobal(t *testing.T) {
 	sessionPath := writeLegacySession(t, dir, "restore-orphan.jsonl", "restore orphan history", time.Now().Add(-time.Hour))
 	topicID := legacySessionTopicID(sessionPath)
 	app := NewApp()
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: filepath.Join(dir, "active.jsonl"), Label: "test"})
+	app.setTestCtrl(ctrl, "")
+	defer ctrl.Close()
 	if err := app.DeleteSession(sessionPath); err != nil {
 		t.Fatalf("delete orphan session: %v", err)
 	}
@@ -1163,9 +1167,25 @@ func TestTrashTopicMovesOpenSessionToTrash(t *testing.T) {
 	if len(trashed) != 1 || trashed[0].Path != trashPath {
 		t.Fatalf("trashed sessions = %#v, want %q", trashed, trashPath)
 	}
+	preview, err := app.PreviewSession(trashPath)
+	if err != nil {
+		t.Fatalf("preview trashed session: %v", err)
+	}
+	if !hasHistoryContent(preview, "remember this turn") {
+		t.Fatalf("preview trashed session = %#v, want remembered turn", preview)
+	}
 	if got := loadTopicTitle(projectRoot, topicID); got != "" {
 		t.Fatalf("topic title should be removed, got %q", got)
 	}
+}
+
+func hasHistoryContent(messages []HistoryMessage, content string) bool {
+	for _, m := range messages {
+		if m.Content == content {
+			return true
+		}
+	}
+	return false
 }
 
 func TestLegacyMigrationSkipsProjectScopedSessions(t *testing.T) {

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -7,11 +7,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"golang.org/x/text/encoding/simplifiedchinese"
+	"reasonix/internal/config"
 )
 
 // --- workspaceStatePath ---
@@ -82,6 +84,50 @@ func TestDialogDefaultDirectoryUsesFileParent(t *testing.T) {
 
 	if got := dialogDefaultDirectory(file); got != dir {
 		t.Fatalf("dialogDefaultDirectory(file) = %q, want %q", got, dir)
+	}
+}
+
+func TestDesktopSessionDirIsScopedByWorkspace(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	rootA := filepath.Join(t.TempDir(), "project-a")
+	rootB := filepath.Join(t.TempDir(), "project-b")
+	if err := os.MkdirAll(rootA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rootB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dirA := desktopSessionDir(rootA)
+	dirB := desktopSessionDir(rootB)
+	if dirA == "" || dirB == "" {
+		t.Fatalf("desktop session dirs should resolve: A=%q B=%q", dirA, dirB)
+	}
+	if dirA == dirB {
+		t.Fatalf("different workspaces must not share a desktop session dir: %q", dirA)
+	}
+	if dirA == config.SessionDir() || dirB == config.SessionDir() {
+		t.Fatalf("desktop workspace sessions should not use the global CLI session dir: A=%q B=%q global=%q", dirA, dirB, config.SessionDir())
+	}
+	wantPrefix := filepath.Join(config.MemoryUserDir(), "projects") + string(filepath.Separator)
+	if !strings.HasPrefix(dirA, wantPrefix) || filepath.Base(dirA) != "sessions" {
+		t.Fatalf("workspace session dir should live under the project state tree, got %q", dirA)
+	}
+}
+
+func BenchmarkDesktopSessionDir(b *testing.B) {
+	root := filepath.Join(b.TempDir(), "project")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if desktopSessionDir(root) == "" {
+			b.Fatal("empty session dir")
+		}
 	}
 }
 
@@ -265,14 +311,21 @@ func TestMediaTokenHandlerEscapedFilename(t *testing.T) {
 	}
 
 	name := `weird "file" name.png`
+	rawURLChars := []string{" ", `"`}
+	if runtime.GOOS == "windows" {
+		name = "weird #file name.png"
+		rawURLChars = []string{" ", "#"}
+	}
 	if err := os.WriteFile(name, []byte("png"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	app := NewApp()
 	preview := app.ReadFile(name)
-	if strings.Contains(preview.URL, " ") || strings.Contains(preview.URL, `"`) {
-		t.Fatalf("media URL should path-escape filename, got %q", preview.URL)
+	for _, raw := range rawURLChars {
+		if strings.Contains(preview.URL, raw) {
+			t.Fatalf("media URL should path-escape %q in filename, got %q", raw, preview.URL)
+		}
 	}
 
 	handler := app.workspaceMediaMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -76,6 +76,9 @@ type Options struct {
 	// (for example ACP session/new). They are connected eagerly for this
 	// controller but are not persisted to reasonix.toml.
 	ExtraPlugins []plugin.Spec
+	// SessionDir overrides where persisted chat transcripts are written. When
+	// empty, the shared CLI/global session directory is used.
+	SessionDir string
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -691,6 +694,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		classifier = control.NewProviderAutoPlanClassifier(classifierProv)
 	}
 
+	sessionDir := opts.SessionDir
+	if sessionDir == "" {
+		sessionDir = config.SessionDir()
+	}
+
 	ctrlOpts := control.Options{
 		Runner:        runner,
 		Executor:      executor,
@@ -698,7 +706,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Policy:        policy,
 		Label:         label,
 		SystemPrompt:  sysPrompt,
-		SessionDir:    config.SessionDir(),
+		SessionDir:    sessionDir,
 		Host:          pluginHost,
 		Commands:      cmds,
 		Skills:        skills,

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -444,6 +444,40 @@ func TestNewProviderAppliesModelReasoningProtocol(t *testing.T) {
 	}
 }
 
+func TestBuildHonorsSessionDirOverride(t *testing.T) {
+	dir := t.TempDir()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	sessionDir := filepath.Join(t.TempDir(), "desktop-workspace-sessions")
+	ctrl, err := Build(context.Background(), Options{SessionDir: sessionDir})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	if got := ctrl.SessionDir(); got != sessionDir {
+		t.Fatalf("SessionDir() = %q, want override %q", got, sessionDir)
+	}
+}
+
 // TestBuildDiscoversSkills proves the skill wiring end-to-end: a project skill
 // is discovered at boot, surfaced via Controller.Skills(), and its name folds
 // into the cache-stable system prompt's "# Skills" index alongside a built-in.

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -73,8 +73,16 @@ func (s *lazySpawn) kick() {
 	if s.state != spawnIdle {
 		return
 	}
+	if !s.host.beginDeferredSpawn() {
+		s.state = spawnFailed
+		s.spawnErr = fmt.Errorf("plugin host is closed")
+		return
+	}
 	s.state = spawnInFlight
-	go s.run()
+	go func() {
+		defer s.host.endDeferredSpawn()
+		s.run()
+	}()
 }
 
 // run does the handshake without holding mu (host.Add can take seconds), then
@@ -172,8 +180,17 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 			// drive the handshake async and ask the model to retry. By the
 			// next turn the swap will have installed the real tools with
 			// real schemas under different names.
+			if !sp.host.beginDeferredSpawn() {
+				sp.state = spawnFailed
+				sp.spawnErr = fmt.Errorf("plugin host is closed")
+				sp.mu.Unlock()
+				return "", fmt.Errorf("MCP server %q failed to start: %w", sp.spec.Name, sp.spawnErr)
+			}
 			sp.state = spawnInFlight
-			go sp.run()
+			go func() {
+				defer sp.host.endDeferredSpawn()
+				sp.run()
+			}()
 			sp.mu.Unlock()
 			return "", fmt.Errorf("MCP server %q is initializing on first use — call again on the next turn for its real tools", sp.spec.Name)
 		}
@@ -223,11 +240,13 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 // single Execute (use the controller's PluginCtx) — a turn-scoped ctx would
 // kill the stdio child between turns.
 func LazyToolset(spec Spec, cs *CachedSchema, host *Host, reg *tool.Registry, sessionCtx context.Context, kick bool) []tool.Tool {
+	spawnCtx, cancel := context.WithCancel(sessionCtx)
+	host.registerDeferredCancel(cancel)
 	shared := &lazySpawn{
 		spec: spec,
 		host: host,
 		reg:  reg,
-		ctx:  sessionCtx,
+		ctx:  spawnCtx,
 	}
 
 	var out []tool.Tool

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -334,6 +334,38 @@ func TestLazyBackgroundKick(t *testing.T) {
 	}
 }
 
+func TestLazyBackgroundCloseCancelsInFlightKick(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+	spec.Name = "slow"
+	spec.Env["GO_WANT_HELPER_INIT_MS"] = "5000"
+	writeMockCache(t, spec)
+	cs, _ := LoadCachedSchema(spec.Name, SpecFingerprint(spec))
+
+	host := NewHost()
+	reg := tool.NewRegistry()
+
+	tools := LazyToolset(spec, cs, host, reg, context.Background(), true)
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		host.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Host.Close did not cancel the in-flight background lazy spawn")
+	}
+
+	if names := host.ServerNames(); len(names) != 0 {
+		t.Fatalf("closed host retained connected servers: %v", names)
+	}
+}
+
 // TestLazyConcurrentExecuteOnlyOneSpawn pins the de-duplication contract: 10
 // goroutines racing through Execute on the same lazyTool may only trigger ONE
 // spawn (and therefore one connected mock server on the host). The state

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -81,6 +81,14 @@ type Host struct {
 	prompts   []Prompt
 	resources []Resource
 	failures  []Failure
+	closed    bool
+
+	// Lazy/background servers may still be handshaking when a session closes.
+	// Close cancels those startup contexts and waits for their goroutines before
+	// taking the client snapshot, so a just-connected stdio child cannot escape
+	// teardown and keep a Windows workspace directory locked.
+	deferredCancels []context.CancelFunc
+	deferredWG      sync.WaitGroup
 
 	// Detached stats/schema-cache writers from Start; off the boot path but
 	// drained by Close so cleanup can't race a still-open cache file.
@@ -326,6 +334,20 @@ func Start(ctx context.Context, specs []Spec, p StartPolicy) (*Host, []tool.Tool
 
 // Close terminates all plugin connections.
 func (h *Host) Close() {
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return
+	}
+	h.closed = true
+	cancels := append([]context.CancelFunc(nil), h.deferredCancels...)
+	h.mu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
+	h.deferredWG.Wait()
+
 	h.mu.RLock()
 	clients := append([]*Client(nil), h.clients...) // snapshot; close outside the lock
 	h.mu.RUnlock()
@@ -547,6 +569,30 @@ func (h *Host) clearFailure(name string) {
 // command), which keeps the controller's host pointer stable for the session.
 func NewHost() *Host { return &Host{} }
 
+func (h *Host) registerDeferredCancel(cancel context.CancelFunc) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		cancel()
+		return
+	}
+	h.deferredCancels = append(h.deferredCancels, cancel)
+}
+
+func (h *Host) beginDeferredSpawn() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		return false
+	}
+	h.deferredWG.Add(1)
+	return true
+}
+
+func (h *Host) endDeferredSpawn() {
+	h.deferredWG.Done()
+}
+
 // has reports whether a server with this name is already connected.
 func (h *Host) has(name string) bool {
 	h.mu.RLock()
@@ -572,6 +618,13 @@ func (h *Host) Add(ctx context.Context, s Spec) ([]tool.Tool, error) {
 }
 
 func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
+	h.mu.RLock()
+	if h.closed {
+		h.mu.RUnlock()
+		return nil, fmt.Errorf("plugin host is closed")
+	}
+	h.mu.RUnlock()
+
 	c, err := start(ctx, ctx, s)
 	if err != nil {
 		return nil, err
@@ -583,6 +636,11 @@ func (h *Host) addConnected(ctx context.Context, s Spec) ([]tool.Tool, error) {
 	}
 	c.toolCount = len(ts)
 	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		c.close()
+		return nil, fmt.Errorf("plugin host is closed")
+	}
 	h.clients = append(h.clients, c)
 	h.clearFailure(s.Name)
 	h.mu.Unlock()


### PR DESCRIPTION
## Summary
- Store desktop session history under per-workspace project state instead of the shared global session directory.
- Pass the desktop session directory through startup, workspace switches, model switches, and settings rebuilds so new sessions, history actions, and display sidecars stay scoped.
- Reject resume paths outside the active workspace session directory.

Fixes #2813

## Validation
- `D:\Go\go\bin\go.exe test ./...`
- `D:\Go\go\bin\go.exe test ./...` from `desktop/`
- `D:\Go\go\bin\go.exe vet ./...`
- `D:\Go\go\bin\go.exe vet ./...` from `desktop/`
- `D:\Go\go\bin\go.exe test . -run ^$ -bench "BenchmarkDesktop(SessionDir|ListSessionsScoped)$" -benchmem -benchtime=2s -count=3` from `desktop/`

Performance benchmark on Windows 10-class desktop path:
- `BenchmarkDesktopListSessionsScoped`: 7.53-8.54 ms/op for 120 current-workspace sessions while another workspace also had 120 sessions.
- `BenchmarkDesktopSessionDir`: 1.86-2.09 us/op.

No screenshots: this changes desktop session storage and backend path validation only; no UI surface changed.