### PR TITLE
fix(cli): persist /theme selection to user config so it survives restart

### DIFF
--- a/internal/cli/theme.go
+++ b/internal/cli/theme.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"image/color"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"charm.land/bubbles/v2/textarea"
 	"charm.land/lipgloss/v2"
 
+	"reasonix/internal/config"
 	"reasonix/internal/i18n"
 )
 
@@ -461,6 +463,28 @@ func (m *chatTUI) runThemeSubcommand(input string) {
 	}
 	m.refreshRuntimeTheme()
 	m.notice(fmt.Sprintf(i18n.M.ThemeChangedFmt, theme.name, theme.style))
+
+	// Persist to user config so the choice survives restart.
+	m.persistTheme(name)
+}
+
+func (m *chatTUI) persistTheme(inputName string) {
+	path := config.UserConfigPath()
+	if path == "" {
+		return
+	}
+	edit := config.LoadForEdit(path)
+	switch inputName {
+	case "auto", "light", "dark":
+		edit.UI.Theme = inputName
+		edit.UI.ThemeStyle = activeCLITheme.style
+	default:
+		edit.UI.Theme = activeCLITheme.name
+		edit.UI.ThemeStyle = inputName
+	}
+	if err := edit.SaveTo(path); err != nil {
+		slog.Warn("theme: failed to persist", "path", path, "err", err)
+	}
 }
 
 func (m *chatTUI) refreshRuntimeTheme() {


### PR DESCRIPTION
## Problem

The `/theme` command (e.g. `/theme light`) only modified the runtime `activeCLITheme` variable and refreshed the UI, but **never wrote the choice to `~/.config/reasonix/config.toml`**. On next startup the config loader read the old value and the theme was lost — the user's theme preference reverted to the default.

## Fix

Added a `persistTheme` method called after every successful `/theme` switch, following the same pattern used by `/effort` and `/language` (which already persist to config).

| User input | Written to `~/.config/reasonix/config.toml` |
|---|---|
| `/theme light` / `/theme dark` / `/theme auto` | `theme = "..."` + current `theme_style` |
| `/theme aurora` (any style name) | `theme = "dark"` / `"light"` + `theme_style = "aurora"` |

## Verification

- `go build ./...` — passes
- `go test ./internal/cli/ -run Theme` — all theme tests pass
- `go test ./internal/config/ -run TestRenderTOML` — passes (config round-trip unaffected)