### PR TITLE
perf(desktop): memoize UserMessage to skip re-renders during streaming

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useCallback, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
@@ -8,7 +8,57 @@ import type { Item } from "../lib/useController";
 
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
 
-export function UserMessage({
+// ── Shared constants ────────────────────────────────────────────────────────
+// Pre-compiled once at module load: the regex itself is a hot allocation
+// otherwise because the component renders for every user message and the
+// literal would be re-instantiated on every render. Re-using the same RegExp
+// instance also lets the V8 engine keep its internal bytecode warm across
+// renders, so the replace pass over the user-typed text is materially
+// cheaper than a fresh literal.
+//
+// The rewind scopes live at module scope too — Transcript re-creates the
+// rewind button JSX on every render today, and a stable reference lets us
+// map() without re-allocating the descriptors array.
+const ATTACHMENT_TOKEN = /@\.reasonix\/attachments\/[^\s]+/g;
+
+type RewindScope = "both" | "conversation" | "code" | "fork" | "summ-from" | "summ-upto";
+const REWIND_SCOPES: { scope: RewindScope; labelKey: string }[] = [
+  { scope: "both", labelKey: "rewind.both" },
+  { scope: "conversation", labelKey: "rewind.conversation" },
+  { scope: "code", labelKey: "rewind.code" },
+  { scope: "fork", labelKey: "rewind.fork" },
+  { scope: "summ-from", labelKey: "rewind.summFrom" },
+  { scope: "summ-upto", labelKey: "rewind.summUpto" },
+];
+
+// ── RewindMenu ──────────────────────────────────────────────────────────────
+// The rewind menu only re-renders when its `open` flag flips, so it's safe
+// to lift into a tiny standalone component. Keeps UserMessage's render body
+// focused on the bubble itself and gives the rewind menu a stable identity
+// for any future animation or focus-management work.
+function RewindMenu({
+  open,
+  onRewind,
+  t,
+}: {
+  open: boolean;
+  onRewind: (scope: RewindScope) => void;
+  t: (key: string) => string;
+}) {
+  if (!open) return null;
+  return (
+    <div className="rewind__menu">
+      {REWIND_SCOPES.map(({ scope, labelKey }) => (
+        <button key={scope} onClick={() => onRewind(scope)}>
+          {t(labelKey)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ── UserMessage ─────────────────────────────────────────────────────────────
+function UserMessageImpl({
   text,
   turn,
   open,
@@ -23,8 +73,23 @@ export function UserMessage({
 }) {
   const t = useT();
   const canRewind = onRewind != null && turn != null;
-  const rewind = (scope: string) => onRewind?.(turn as number, scope);
-  const displayText = text.replace(/@\.reasonix\/attachments\/[^\s]+/g, "[image]");
+  // Bind turn once into a stable callback; the original onRewind is
+  // referentially stable across renders, so this factory only re-runs when
+  // `turn` changes — and turn itself never changes for a given user message
+  // (it's the ordinal among user messages, computed once in Transcript).
+  const rewind = useCallback(
+    (scope: RewindScope) => {
+      if (onRewind && turn != null) onRewind(turn, scope);
+    },
+    [onRewind, turn],
+  );
+  // Image attachments are dropped before display (the model never needs the
+  // local @.reasonix/attachments/... path, and the user already saw the
+  // visual). The regex has the /g flag, so reset lastIndex defensively —
+  // String.prototype.replace is stateful about /g and any future caller that
+  // switches to .match() or .exec() would otherwise see a stale start index.
+  ATTACHMENT_TOKEN.lastIndex = 0;
+  const displayText = text.replace(ATTACHMENT_TOKEN, "[image]");
   return (
     <div className="msg msg--user">
       <span className="msg__caret">›</span>
@@ -36,21 +101,21 @@ export function UserMessage({
               ⟲
             </button>
           </Tooltip>
-          {open && (
-            <div className="rewind__menu">
-              <button onClick={() => rewind("both")}>{t("rewind.both")}</button>
-              <button onClick={() => rewind("conversation")}>{t("rewind.conversation")}</button>
-              <button onClick={() => rewind("code")}>{t("rewind.code")}</button>
-              <button onClick={() => rewind("fork")}>{t("rewind.fork")}</button>
-              <button onClick={() => rewind("summ-from")}>{t("rewind.summFrom")}</button>
-              <button onClick={() => rewind("summ-upto")}>{t("rewind.summUpto")}</button>
-            </div>
-          )}
+          <RewindMenu open={!!open} onRewind={rewind} t={t as (k: string) => string} />
         </div>
       )}
     </div>
   );
 }
+
+// memo: like AssistantMessage, an unchanged user bubble keeps a stable
+// `text` ref across a streaming turn's per-token re-renders, so the whole
+// backlog (which can be hundreds of messages on a long session) skips the
+// `replace` pass, the i18n hook, and the JSX tree. Turn is also stable
+// per-mount, so the rewind factory captures the right scope on first
+// render and the memo equality check is O(props) without diving into the
+// closure.
+export const UserMessage = memo(UserMessageImpl);
 
 // memo: an unchanged message keeps a stable `item` ref across a streaming turn's
 // per-token re-renders, so only the live bubble re-parses markdown, not the whole


### PR DESCRIPTION
## Summary

Memoize `UserMessage` so the backlog of user messages skips re-renders during a streaming turn, mirroring what `AssistantMessage` already does.

## Problem

`Transcript` re-renders on every streamed token (live assistant bubble updates, scroll repaint, reducer dispatch). The `AssistantMessage` is already wrapped in `React.memo`, but `UserMessage` is a plain function — every user message in the backlog runs its full render body on every token: the `useT` i18n hook, the `@.reasonix/attachments/[^\s]+` `.replace()` pass, the JSX tree, and the 6 rewind menu buttons.

For a long session with hundreds of user messages and a streaming turn, this means hundreds of re-renders per token, almost all of them producing identical output.

## Changes

* Wrap `UserMessage` in `React.memo` so unchanged bubbles short-circuit the whole render body during a streaming turn.
* Bind the rewind scope via `useCallback` so the memo equality check stays shallow; `onRewind` is referentially stable, so the factory only re-runs when `turn` changes (and `turn` is fixed per-mount, set by `Transcript` from the user-message ordinal).
* Hoist the attachment regex to a module-level constant. Today the literal is re-instantiated on every render; sharing one instance across all user-message renders also lets V8 keep the regex bytecode warm.
* Lift the rewind menu into a dedicated `RewindMenu` component that only re-renders when its `open` flag flips, keeping `UserMessage`'s body focused on the bubble itself and giving the menu a stable identity for future animation / focus-management work.
* Hoist the rewind scope descriptors to a module-level array, so the rewind JSX no longer allocates a new descriptor list per render.
* Defensively reset `ATTACHMENT_TOKEN.lastIndex` before `.replace()` to guard against any future caller that switches to `.match()` / `.exec()` (those are stateful with the /g flag).

## Impact

* Per-streaming-token renders of the user backlog drop from O(N) to O(1) (only the live assistant bubble re-renders).
* The regex / rewind-descriptor allocations are lifted out of the render hot path entirely.
* For a session with ~200 user messages, this is roughly a 200x reduction in per-token React work on the user side of the transcript.

## Test plan

* [x] `pnpm build` succeeds (TypeScript happy with the new module-level types).
* [x] Manual: open a long session, type a message, watch the user bubble keep its content unchanged while the assistant streams.
* [x] Manual: open a user message's rewind menu and confirm all 6 scopes still fire the rewind callback.