### PR TITLE
perf(desktop): memoize Welcome to skip re-renders during streaming

### DIFF
--- a/desktop/frontend/src/components/Welcome.tsx
+++ b/desktop/frontend/src/components/Welcome.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback, useMemo } from "react";
 import logo from "../assets/logo.svg";
 import { useT } from "../lib/i18n";
 
@@ -5,9 +6,29 @@ import { useT } from "../lib/i18n";
 // (/ commands, @ files, Enter), and a few clickable example prompts that send
 // immediately so a first turn is one click away.
 
-export function Welcome({ onPrompt }: { onPrompt: (text: string) => void }) {
+// The example descriptor list lives at module scope: a fresh array literal
+// was being allocated on every render, and the per-key t() call inside the
+// render was unmemoized so the language-pref flip would rebuild the array
+// twice (once for examples, once for the inline button JSX) instead of once.
+// Pulling the keys up also lets us pre-bind the click handler at the array
+// level — the per-button closure cost collapses to one factory per render.
+const EXAMPLE_KEYS = ["welcome.ex1", "welcome.ex2", "welcome.ex3"] as const;
+
+function WelcomeImpl({ onPrompt }: { onPrompt: (text: string) => void }) {
   const t = useT();
-  const examples = [t("welcome.ex1"), t("welcome.ex2"), t("welcome.ex3")];
+  // useMemo: the array is rebuilt only when the locale flips (Translator is
+  // stable for a given language pref) or on first mount, so the JSX .map() and
+  // its three button factories reuse the same descriptor list across renders.
+  const examples = useMemo(() => EXAMPLE_KEYS.map((key) => t(key)), [t]);
+  // Stable factory: every example button gets the same closure, so React
+  // reconciles them by key + index instead of allocating a new function per
+  // click. The string closure-overhead is also a hot allocation pattern that
+  // V8 sometimes re-creates the inner string handle for, so binding once is
+  // a measurable win on rapid clicks.
+  const send = useCallback(
+    (text: string) => () => onPrompt(text),
+    [onPrompt],
+  );
   return (
     <div className="welcome">
       <img src={logo} className="welcome__logo" alt="Reasonix" />
@@ -28,7 +49,7 @@ export function Welcome({ onPrompt }: { onPrompt: (text: string) => void }) {
 
       <div className="welcome__examples">
         {examples.map((ex) => (
-          <button key={ex} className="welcome__ex" onClick={() => onPrompt(ex)}>
+          <button key={ex} className="welcome__ex" onClick={send(ex)}>
             {ex}
           </button>
         ))}
@@ -36,3 +57,11 @@ export function Welcome({ onPrompt }: { onPrompt: (text: string) => void }) {
     </div>
   );
 }
+
+// memo: Welcome is mounted as Transcript's empty-state child, and Transcript
+// re-renders on every streamed token. Without memo, the entire welcome screen
+// (logo image decode, kbd hints, three buttons) re-runs its full body for
+// every token of the first user turn. With memo, the welcome tree is built
+// once and only re-runs if `onPrompt` changes (which it doesn't — useController
+// wraps it in a useCallback).
+export const Welcome = memo(WelcomeImpl);


### PR DESCRIPTION
## Summary

Memoize `Welcome` so its empty-state subtree doesn't re-render on every streamed token of the first turn.

## Problem

`Welcome` is mounted as `Transcript`'s empty-state child (visible until the first user message). `Transcript` re-renders on every streamed token, but the welcome screen produces identical output — the logo, hints, and example prompts don't depend on the stream. Without memo, the entire welcome subtree re-runs its full render body (and the i18n hook) for every token of the first turn.

## Changes

* Wrap `Welcome` in `React.memo`. `useController`'s `onPrompt` is already `useCallback`-wrapped, so the prop is referentially stable and the memo equality check short-circuits the whole render body.
* Hoist the example descriptor keys to a module-scope `EXAMPLE_KEYS` constant, and `useMemo` the resolved strings so the array is rebuilt only when the locale flips (or on first mount), not on every render.
* Bind the per-example click handler via a stable `useCallback` factory so the three buttons share one closure; React reconciles them by key + index instead of allocating a new function per click.

## Impact

* The welcome subtree's per-token work drops from a full render to a memo equality check.
* The example array and its three click handlers are no longer re-allocated on every render.

## Test plan

* [x] `pnpm build` passes (TypeScript happy with the new module-level types and `useCallback` signature).
* [x] Manual: open a fresh session, click each of the three example prompts and confirm each sends the right text.