### PR TITLE
fix(tui): ESC no longer exits YOLO; Ctrl+C copies selection to clipboard

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -667,7 +667,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.KeyPressMsg:
-		// Any keystroke dismisses a finished selection (copy is a right-click).
+		// Any keystroke dismisses a finished selection (copy is a right-click),
+		// except Ctrl+C/Super+C/Meta+C which may copy the selection to clipboard.
+		sel := m.sel
 		m.sel = selection{}
 		// Transcript scroll keys work in any state (PgUp/PgDn are never text).
 		switch msg.String() {
@@ -782,15 +784,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "esc":
 			// "Back out" of the most specific in-progress state: un-send a just-sent
 			// turn (server not yet replied), cancel a streaming turn, turn plan mode
-			// off, or clear typed-but-unsent input. Scrollback is the terminal's now,
-			// so there's no viewport to dismiss.
+			// off, or clear typed-but-unsent input. YOLO mode is only exited via
+			// Shift+Tab cycle (/plan → YOLO → normal) or --yolo flag. Scrollback is
+			// the terminal's now, so there's no viewport to dismiss.
 			switch {
 			case m.state == tuiRunning && m.bubblePending:
 				m.unsendPending()
 			case m.state == tuiRunning:
 				m.ctrl.Cancel()
-			case m.ctrl.Bypass():
-				m.ctrl.SetBypass(false) // back out of YOLO
 			case m.planMode:
 				m.planMode = false
 				m.ctrl.SetPlanMode(false)
@@ -821,12 +822,20 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			// Idle: if the composer has text, a single press clears it (like Esc).
-			// On an empty composer, require double-press within 1.5s to quit.
+			// On an empty composer: if there's an active text selection, copy to
+			// clipboard (standard terminal convention); otherwise require double-press
+			// within 1.5s to quit.
 			if strings.TrimSpace(m.input.Value()) != "" {
 				m.input.Reset()
 				m.pastedBlocks = nil
 				m.lastCtrlCAt = time.Time{}
 				return m, nil
+			}
+			if sel.active && !sel.empty() {
+				m.sel = sel // restore so selectedText() can read it
+				text := m.selectedText()
+				m.sel = selection{}
+				return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
 			}
 			if !m.lastCtrlCAt.IsZero() && time.Since(m.lastCtrlCAt) < 1500*time.Millisecond {
 				return m, tea.Quit

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/x/ansi"
 
 	"reasonix/internal/agent"
@@ -874,6 +875,57 @@ func TestCtrlCClearsThenDoublePressQuits(t *testing.T) {
 		t.Error("double Ctrl+C on empty input should quit")
 	}
 	_ = out3
+}
+
+// TestCtrlCCopySelection verifies that Ctrl+C while idle on an empty composer
+// with an active text selection copies the selected text to clipboard instead
+// of arming the double-press quit gesture.
+func TestCtrlCCopySelection(t *testing.T) {
+	var copied string
+	clipboardWriteAll = func(text string) error { copied = text; return nil }
+	defer func() { clipboardWriteAll = clipboard.WriteAll }()
+
+	m := newTestChatTUI()
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: 4}
+
+	// Set up an active selection: anchor < head so there's something to copy.
+	// selection uses content-line coordinates; transcript needs at least one line.
+	m.transcript = []string{"hello world"}
+	m.wrappedLines = []string{"hello world"}
+	m.sel = selection{active: true, anchor: selPos{line: 0, col: 0}, head: selPos{line: 0, col: 5}}
+
+	out, cmd := m.Update(ctrlC)
+	m2, ok := out.(chatTUI)
+	if !ok {
+		t.Fatalf("Update returned %T, want chatTUI", out)
+	}
+
+	// Selection should be cleared after copy.
+	if m2.sel.active {
+		t.Error("selection should be cleared after Ctrl+C copy")
+	}
+
+	// Should NOT arm the quit gesture.
+	if !m2.lastCtrlCAt.IsZero() {
+		t.Error("Ctrl+C on active selection should not arm the quit gesture")
+	}
+
+	// Should return a command (clipboard copy + finalize).
+	if cmd == nil {
+		t.Fatal("Ctrl+C on selection should return a cmd (clipboard + finalize)")
+	}
+
+	// Execute the command — it should trigger the clipboard stub.
+	cmd()
+	if copied != "hello" {
+		t.Errorf("clipboard should contain selected text %q, got %q", "hello", copied)
+	}
+
+	// Second Ctrl+C should now arm quit (selection is gone).
+	_, cmd2 := m2.Update(ctrlC)
+	if cmd2 == nil {
+		t.Error("Ctrl+C after copy should arm quit (return a finalize cmd)")
+	}
 }
 
 // TestAgentEventCoalescesBurst proves one update drains the buffered event burst


### PR DESCRIPTION
## 问题

### 1. ESC 意外退出 YOLO 模式
空闲时按 ESC 会调用 `SetBypass(false)`，将 YOLO 模式（`--dangerously-skip-permissions`）静默还原为 auto。用户仅想清空输入或双击 ESC 呼出回滚选择器时，却丢失了 YOLO 状态。

### 2. Ctrl+C 无法复制选中文本
空闲时用鼠标选中文本后按 Ctrl+C，触发的却是"再按一次退出"序列，而不是复制到剪贴板。Ctrl+C 复制是标准终端约定。

## 修复

### ESC → YOLO
删除了 ESC 处理中的 `case m.ctrl.Bypass()` 分支。YOLO 模式现在**仅**通过 `Shift+Tab` 循环（normal → plan → YOLO → normal）退出。

**修改文件**: `internal/cli/chat_tui.go` — ESC switch 分支（删除了 `case m.ctrl.Bypass(): m.ctrl.SetBypass(false)`）

### Ctrl+C → 复制选中文本
在通用按键清除选中状态之前保存它；Ctrl+C 处理中先检查是否有选中文本，有则复制到剪贴板，不触发退出序列。

**修改文件**: `internal/cli/chat_tui.go` — 在 KeyPress 入口处保存 `sel := m.sel`，Ctrl+C 分支新增选中文本检测+复制逻辑

### 测试
新增 `TestCtrlCCopySelection` — 验证选中+Ctrl+C 复制、清除选中、不启动退出、后续 Ctrl+C 正常退出。

Closes: N/A (无对应 issue)