### PR TITLE
feat(agent): cache prefix diagnostics for prompt-cache churn

### DIFF
--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -45,11 +45,24 @@ export interface WireUsage {
   cacheHitTokens: number;
   cacheMissTokens: number;
   reasoningTokens?: number;
+  cacheDiagnostics?: WireCacheDiagnostics;
   // Session-cumulative cache tokens — the status bar shows the aggregate
   // hit-rate (Σhit/Σ(hit+miss)), steadier than the single-turn cacheHitTokens.
   sessionCacheHitTokens: number;
   sessionCacheMissTokens: number;
   costUsd?: number;
+}
+
+export interface WireCacheDiagnostics {
+  prefixHash: string;
+  prefixChanged: boolean;
+  prefixChangeReasons?: string[];
+  systemHash: string;
+  toolsHash: string;
+  logRewriteVersion: number;
+  toolSchemaTokens: number;
+  cacheMissTokens: number;
+  cacheHitTokens: number;
 }
 
 export interface WireApproval {

--- a/desktop/wire.go
+++ b/desktop/wire.go
@@ -67,17 +67,30 @@ type wireTool struct {
 }
 
 type wireUsage struct {
-	PromptTokens     int `json:"promptTokens"`
-	CompletionTokens int `json:"completionTokens"`
-	TotalTokens      int `json:"totalTokens"`
-	CacheHitTokens   int `json:"cacheHitTokens"`
-	CacheMissTokens  int `json:"cacheMissTokens"`
-	ReasoningTokens  int `json:"reasoningTokens,omitempty"`
+	PromptTokens     int                   `json:"promptTokens"`
+	CompletionTokens int                   `json:"completionTokens"`
+	TotalTokens      int                   `json:"totalTokens"`
+	CacheHitTokens   int                   `json:"cacheHitTokens"`
+	CacheMissTokens  int                   `json:"cacheMissTokens"`
+	ReasoningTokens  int                   `json:"reasoningTokens,omitempty"`
+	CacheDiagnostics *wireCacheDiagnostics `json:"cacheDiagnostics,omitempty"`
 	// Session-cumulative cache tokens — the status line shows the aggregate
 	// hit-rate Σhit/Σ(hit+miss), steadier than the single-turn CacheHitTokens.
 	SessionCacheHitTokens  int     `json:"sessionCacheHitTokens"`
 	SessionCacheMissTokens int     `json:"sessionCacheMissTokens"`
 	CostUSD                float64 `json:"costUsd,omitempty"`
+}
+
+type wireCacheDiagnostics struct {
+	PrefixHash          string   `json:"prefixHash"`
+	PrefixChanged       bool     `json:"prefixChanged"`
+	PrefixChangeReasons []string `json:"prefixChangeReasons,omitempty"`
+	SystemHash          string   `json:"systemHash"`
+	ToolsHash           string   `json:"toolsHash"`
+	LogRewriteVersion   int      `json:"logRewriteVersion"`
+	ToolSchemaTokens    int      `json:"toolSchemaTokens"`
+	CacheMissTokens     int      `json:"cacheMissTokens"`
+	CacheHitTokens      int      `json:"cacheHitTokens"`
 }
 
 type wireApproval struct {
@@ -144,6 +157,9 @@ func toWire(e event.Event) wireEvent {
 				CacheMissTokens: u.CacheMissTokens, ReasoningTokens: u.ReasoningTokens,
 				SessionCacheHitTokens: e.SessionHit, SessionCacheMissTokens: e.SessionMiss,
 			}
+			if e.CacheDiagnostics != nil {
+				w.Usage.CacheDiagnostics = toWireCacheDiagnostics(e.CacheDiagnostics)
+			}
 			if e.Pricing != nil {
 				w.Usage.CostUSD = e.Pricing.Cost(u)
 			}
@@ -166,4 +182,18 @@ func toWire(e event.Event) wireEvent {
 		w.RetryMax = e.RetryMax
 	}
 	return w
+}
+
+func toWireCacheDiagnostics(d *event.CacheDiagnostics) *wireCacheDiagnostics {
+	return &wireCacheDiagnostics{
+		PrefixHash:          d.PrefixHash,
+		PrefixChanged:       d.PrefixChanged,
+		PrefixChangeReasons: append([]string(nil), d.PrefixChangeReasons...),
+		SystemHash:          d.SystemHash,
+		ToolsHash:           d.ToolsHash,
+		LogRewriteVersion:   d.LogRewriteVersion,
+		ToolSchemaTokens:    d.ToolSchemaTokens,
+		CacheMissTokens:     d.CacheMissTokens,
+		CacheHitTokens:      d.CacheHitTokens,
+	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -140,6 +140,11 @@ type Agent struct {
 	sessCacheHit  atomic.Int64
 	sessCacheMiss atomic.Int64
 
+	// lastPrefixShape records the previous provider request's cacheable prefix
+	// so usage events can explain prefix churn on the next request.
+	lastPrefixShape     PrefixShape
+	haveLastPrefixShape bool
+
 	// planMode, when true, refuses any tool call whose ReadOnly() is false.
 	// The system prompt and tool list never change with the toggle so the
 	// prompt-cache prefix stays valid; the gating happens at execute time
@@ -373,13 +378,24 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 	finalReadinessBlocks := 0
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
+		schemas := a.tools.Schemas()
+		prefixShape := a.capturePrefixShape(schemas)
+		prevPrefixShape := a.lastPrefixShape
+		if !a.haveLastPrefixShape {
+			prevPrefixShape = prefixShape
+		}
+
 		text, reasoning, signature, calls, usage, err := a.stream(ctx, step+1)
 		if err != nil {
 			return err
 		}
+		cacheDiagnostics := CompareShape(prevPrefixShape, prefixShape, usage)
+		a.lastPrefixShape = prefixShape
+		a.haveLastPrefixShape = true
 		if usage != nil && usage.TotalTokens > 0 {
 			a.sink.Emit(event.Event{Kind: event.Usage, Usage: usage, Pricing: a.pricing,
-				SessionHit: int(a.sessCacheHit.Load()), SessionMiss: int(a.sessCacheMiss.Load())})
+				CacheDiagnostics: &cacheDiagnostics,
+				SessionHit:       int(a.sessCacheHit.Load()), SessionMiss: int(a.sessCacheMiss.Load())})
 		}
 		if msg, ok := finishReasonMessage(usage); ok {
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: msg})
@@ -585,6 +601,24 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 		a.sink.Emit(event.Event{Kind: event.Message, Text: text.String(), Reasoning: display})
 	}
 	return text.String(), stored, signature, calls, usage, nil
+}
+
+func (a *Agent) capturePrefixShape(schemas []provider.ToolSchema) PrefixShape {
+	return CaptureShape(a.systemPrompt(), schemas, a.session.RewriteVersion())
+}
+
+func (a *Agent) systemPrompt() string {
+	var b strings.Builder
+	for _, m := range a.session.Messages {
+		if m.Role != provider.RoleSystem {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(m.Content)
+	}
+	return b.String()
 }
 
 // executeBatch dispatches one model turn's tool calls. A ToolDispatch event is

--- a/internal/agent/cache_diagnostics_test.go
+++ b/internal/agent/cache_diagnostics_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type cacheDiagProvider struct {
+	chunks [][]provider.Chunk
+	calls  int
+}
+
+func (p *cacheDiagProvider) Name() string { return "cache-diag" }
+
+func (p *cacheDiagProvider) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	chunks := p.chunks[p.calls]
+	p.calls++
+	ch := make(chan provider.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
+}
+
+func TestRunPopulatesCacheDiagnosticsOnUsageEvents(t *testing.T) {
+	prov := &cacheDiagProvider{chunks: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "first"},
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{
+				PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110,
+				CacheHitTokens: 0, CacheMissTokens: 100,
+			}},
+		},
+		{
+			{Type: provider.ChunkText, Text: "second"},
+			{Type: provider.ChunkUsage, Usage: &provider.Usage{
+				PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110,
+				CacheHitTokens: 80, CacheMissTokens: 20,
+			}},
+		},
+	}}
+	reg := tool.NewRegistry()
+	var diagnostics []*event.CacheDiagnostics
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Usage {
+			diagnostics = append(diagnostics, e.CacheDiagnostics)
+		}
+	})
+	session := NewSession("stable system")
+	session.IncrementRewrite()
+	a := New(prov, reg, session, Options{}, sink)
+
+	if err := a.Run(context.Background(), "one"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	if err := a.Run(context.Background(), "two"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+
+	if len(diagnostics) != 2 {
+		t.Fatalf("got %d usage diagnostics, want 2", len(diagnostics))
+	}
+	first, second := diagnostics[0], diagnostics[1]
+	if first == nil || second == nil {
+		t.Fatalf("diagnostics should be populated on every usage event: first=%v second=%v", first, second)
+	}
+	if first.PrefixChanged {
+		t.Fatalf("first usage should not report a changed prefix: %+v", first)
+	}
+	if first.CacheMissTokens != 100 || first.CacheHitTokens != 0 {
+		t.Fatalf("first cache tokens = hit %d miss %d, want hit 0 miss 100", first.CacheHitTokens, first.CacheMissTokens)
+	}
+	if !second.PrefixChanged {
+		t.Fatalf("second usage should report the tool prefix change: %+v", second)
+	}
+	if len(second.PrefixChangeReasons) != 1 || second.PrefixChangeReasons[0] != "tools" {
+		t.Fatalf("second change reasons = %v, want [tools]", second.PrefixChangeReasons)
+	}
+	if second.CacheHitTokens != 80 || second.CacheMissTokens != 20 {
+		t.Fatalf("second cache tokens = hit %d miss %d, want hit 80 miss 20", second.CacheHitTokens, second.CacheMissTokens)
+	}
+	if first.ToolsHash == second.ToolsHash {
+		t.Fatalf("tool hash should change after registering a tool: %q", first.ToolsHash)
+	}
+}

--- a/internal/agent/cache_shape.go
+++ b/internal/agent/cache_shape.go
@@ -1,0 +1,121 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// PrefixShape hashes the portions of the request prefix that influence
+// provider-side prompt-cache reuse. Comparing snapshots across turns
+// lets us explain *why* a cache miss happened.
+type PrefixShape struct {
+	SystemHash        string
+	ToolsHash         string
+	PrefixHash        string
+	LogRewriteVersion int
+	ToolSchemaTokens  int
+}
+
+// CacheDiagnostics is a type alias for event.CacheDiagnostics so the agent
+// can construct and compare diagnostics without importing event itself in
+// every call site, while still assigning to event.Event.CacheDiagnostics.
+type CacheDiagnostics = event.CacheDiagnostics
+
+func shortHash(v interface{}) string {
+	b, _ := json.Marshal(v)
+	h := sha256.Sum256(b)
+	return fmt.Sprintf("%x", h[:8])
+}
+
+// CaptureShape takes a snapshot of the current prefix state.
+func CaptureShape(systemPrompt string, schemas []provider.ToolSchema, rewriteVersion int) PrefixShape {
+	normalizedSchemas := normalizeToolSchemas(schemas)
+	toolsJSON, _ := json.Marshal(normalizedSchemas)
+	return PrefixShape{
+		SystemHash: shortHash(systemPrompt),
+		ToolsHash:  shortHash(string(toolsJSON)),
+		PrefixHash: shortHash(map[string]interface{}{
+			"system": systemPrompt,
+			"tools":  string(toolsJSON),
+		}),
+		LogRewriteVersion: rewriteVersion,
+		ToolSchemaTokens:  estimateTokens(string(toolsJSON)),
+	}
+}
+
+func normalizeToolSchemas(schemas []provider.ToolSchema) []provider.ToolSchema {
+	out := make([]provider.ToolSchema, len(schemas))
+	copy(out, schemas)
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		if out[i].Description != out[j].Description {
+			return out[i].Description < out[j].Description
+		}
+		return string(out[i].Parameters) < string(out[j].Parameters)
+	})
+	return out
+}
+
+// CompareShape returns diagnostics describing what changed between two shapes.
+func CompareShape(prev, cur PrefixShape, usage *provider.Usage) CacheDiagnostics {
+	reasons := []string{}
+	if prev.SystemHash != "" && prev.SystemHash != cur.SystemHash {
+		reasons = append(reasons, "system")
+	}
+	if prev.ToolsHash != "" && prev.ToolsHash != cur.ToolsHash {
+		reasons = append(reasons, "tools")
+	}
+	if prev.LogRewriteVersion != cur.LogRewriteVersion {
+		reasons = append(reasons, "log_rewrite")
+	}
+	var miss, hit int
+	if usage != nil {
+		miss = usage.CacheMissTokens
+		hit = usage.CacheHitTokens
+	}
+	return CacheDiagnostics{
+		PrefixHash:          cur.PrefixHash,
+		PrefixChanged:       len(reasons) > 0,
+		PrefixChangeReasons: reasons,
+		SystemHash:          cur.SystemHash,
+		ToolsHash:           cur.ToolsHash,
+		LogRewriteVersion:   cur.LogRewriteVersion,
+		ToolSchemaTokens:    cur.ToolSchemaTokens,
+		CacheMissTokens:     miss,
+		CacheHitTokens:      hit,
+	}
+}
+
+// estimateTokens gives a rough token count from byte length.
+// A proper tokenizer would be more accurate, but for diagnostic
+// purposes a byte-based estimate is sufficient and zero-alloc.
+func estimateTokens(s string) int {
+	// ~4 chars per token is a workable heuristic for code-heavy JSON.
+	if len(s) == 0 {
+		return 0
+	}
+	return len(s) / 4
+}
+
+// SchemaTokenCosts returns per-tool token cost estimates for display.
+func SchemaTokenCosts(schemas []provider.ToolSchema) []ToolSchemaCost {
+	out := make([]ToolSchemaCost, 0, len(schemas))
+	for _, s := range schemas {
+		b, _ := json.Marshal(s)
+		out = append(out, ToolSchemaCost{Name: s.Name, Tokens: estimateTokens(string(b))})
+	}
+	return out
+}
+
+// ToolSchemaCost is a per-tool token cost estimate for diagnostic display.
+type ToolSchemaCost struct {
+	Name   string
+	Tokens int
+}

--- a/internal/agent/cache_shape_test.go
+++ b/internal/agent/cache_shape_test.go
@@ -1,0 +1,37 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestCaptureShapeNormalizesToolSchemaOrder(t *testing.T) {
+	schemas := []provider.ToolSchema{
+		{
+			Name:        "write_file",
+			Description: "write a file",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+		},
+		{
+			Name:        "read_file",
+			Description: "read a file",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`),
+		},
+	}
+	reordered := []provider.ToolSchema{schemas[1], schemas[0]}
+
+	first := CaptureShape("system", schemas, 1)
+	second := CaptureShape("system", reordered, 1)
+
+	if first.ToolsHash != second.ToolsHash {
+		t.Fatalf("ToolsHash should be stable across schema order: %q != %q", first.ToolsHash, second.ToolsHash)
+	}
+	if first.PrefixHash != second.PrefixHash {
+		t.Fatalf("PrefixHash should be stable across schema order: %q != %q", first.PrefixHash, second.PrefixHash)
+	}
+	if schemas[0].Name != "write_file" || schemas[1].Name != "read_file" {
+		t.Fatalf("CaptureShape mutated caller schema order: got [%s %s]", schemas[0].Name, schemas[1].Name)
+	}
+}

--- a/internal/agent/cachehit_e2e_test.go
+++ b/internal/agent/cachehit_e2e_test.go
@@ -180,7 +180,7 @@ func TestCacheHitPrefixStable(t *testing.T) {
 		}
 		t.Logf("turn %d: prompt=%d hit=%d miss=%d → 'cache %d%%' (hit/prompt=%d%%) | %s",
 			i, u.PromptTokens, u.CacheHitTokens, u.CacheMissTokens, hitRate(u), want,
-			strings.TrimSpace(FormatUsageLine(u, nil)))
+			strings.TrimSpace(FormatUsageLine(u, nil, nil)))
 		if u.CacheHitTokens+u.CacheMissTokens != u.PromptTokens {
 			t.Errorf("display denominator mismatch: hit+miss=%d != prompt=%d (status%% would read wrong)",
 				u.CacheHitTokens+u.CacheMissTokens, u.PromptTokens)

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -146,6 +146,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string) error
 	})
 	compacted = append(compacted, msgs[start:]...)
 	a.session.Replace(compacted)
+	a.session.IncrementRewrite()
 
 	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
 		Trigger: trigger, Messages: len(region), Summary: summary, Archive: archived,

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -116,6 +116,9 @@ func TestCompactReplacesHistory(t *testing.T) {
 	if err := a.compact(context.Background(), "manual", ""); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
+	if got := sess.RewriteVersion(); got != 1 {
+		t.Fatalf("rewrite version = %d, want 1", got)
+	}
 
 	// system + summary + last 2 verbatim.
 	if got := len(sess.Messages); got != 4 {
@@ -225,6 +228,34 @@ func TestCompactInjectsFocusAndPreCompactHook(t *testing.T) {
 	}
 	if !strings.Contains(sys, "KEEP-THE-MIGRATION-PLAN") {
 		t.Errorf("summary system prompt missing the PreCompact hook output: %q", sys)
+	}
+}
+
+func TestCompactRewriteVersionFeedsCacheDiagnostics(t *testing.T) {
+	prov := &fakeProvider{reply: "- summary"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "a"},
+		{Role: provider.RoleAssistant, Content: "b"},
+		{Role: provider.RoleUser, Content: "c"},
+		{Role: provider.RoleAssistant, Content: "d"},
+		{Role: provider.RoleUser, Content: "e"},
+		{Role: provider.RoleAssistant, Content: "f"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2}, event.Discard)
+	before := CaptureShape("sys", nil, sess.RewriteVersion())
+
+	if err := a.compact(context.Background(), "auto", ""); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	after := CaptureShape("sys", nil, sess.RewriteVersion())
+	diag := CompareShape(before, after, &provider.Usage{CacheMissTokens: 10})
+	if !diag.PrefixChanged {
+		t.Fatalf("diagnostics should report prefix change: %+v", diag)
+	}
+	if len(diag.PrefixChangeReasons) != 1 || diag.PrefixChangeReasons[0] != "log_rewrite" {
+		t.Fatalf("change reasons = %v, want [log_rewrite]", diag.PrefixChangeReasons)
 	}
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -14,8 +14,9 @@ import (
 // the run-loop goroutine stay lock-free (serial with its own writes); cross-
 // goroutine access goes through Snapshot.
 type Session struct {
-	mu       sync.RWMutex
-	Messages []provider.Message
+	mu             sync.RWMutex
+	Messages       []provider.Message
+	rewriteVersion int // bumped each time the log is rewritten (compact/fold)
 }
 
 // NewSession initializes a session with an optional system prompt.
@@ -50,6 +51,12 @@ func (s *Session) Snapshot() []provider.Message {
 	defer s.mu.RUnlock()
 	return append([]provider.Message(nil), s.Messages...)
 }
+
+// RewriteVersion returns the current rewrite version.
+func (s *Session) RewriteVersion() int { return s.rewriteVersion }
+
+// IncrementRewrite bumps the rewrite version by 1.
+func (s *Session) IncrementRewrite() { s.rewriteVersion++ }
 
 // HasContent returns true when the session carries at least one user,
 // assistant, or tool message — i.e. more than just a system prompt. An

--- a/internal/agent/textsink.go
+++ b/internal/agent/textsink.go
@@ -102,7 +102,7 @@ func (s *TextSink) Emit(e event.Event) {
 			fmt.Fprintln(s.out)
 			s.textWritten = false
 		}
-		s.usageLine(e.Usage, e.Pricing)
+		s.usageLine(e.Usage, e.Pricing, e.CacheDiagnostics)
 
 	case event.Notice:
 		glyph := "·"
@@ -167,8 +167,8 @@ func (s *TextSink) closeTextStream(text, reasoning string) {
 }
 
 // usageLine writes the one-line token/cache summary; no-op when usage is unset.
-func (s *TextSink) usageLine(u *provider.Usage, p *provider.Pricing) {
-	if line := FormatUsageLine(u, p); line != "" {
+func (s *TextSink) usageLine(u *provider.Usage, p *provider.Pricing, d *event.CacheDiagnostics) {
+	if line := FormatUsageLine(u, p, d); line != "" {
 		fmt.Fprintln(s.out, line)
 		s.wroteAnything = true
 	}
@@ -182,7 +182,7 @@ func (s *TextSink) usageLine(u *provider.Usage, p *provider.Pricing) {
 // denominator just grew. Reasoning tokens (a subset of completion) show the
 // chain-of-thought cost. Shared by TextSink and the chat TUI so both frontends
 // render the line identically.
-func FormatUsageLine(u *provider.Usage, p *provider.Pricing) string {
+func FormatUsageLine(u *provider.Usage, p *provider.Pricing, d *event.CacheDiagnostics) string {
 	if u == nil || u.TotalTokens == 0 {
 		return ""
 	}
@@ -205,8 +205,16 @@ func FormatUsageLine(u *provider.Usage, p *provider.Pricing) string {
 	if p != nil {
 		cost = fmt.Sprintf(" · %s%.4f", p.Symbol(), p.Cost(u))
 	}
-	return fmt.Sprintf("  · %d tok · in %d%s · out %d%s%s",
-		u.TotalTokens, u.PromptTokens, cacheCol, u.CompletionTokens, reasoning, cost)
+	churn := ""
+	if d != nil && d.PrefixChanged {
+		reasons := strings.Join(d.PrefixChangeReasons, "+")
+		if reasons == "" {
+			reasons = "unknown"
+		}
+		churn = fmt.Sprintf(" · cache prefix changed: %s", reasons)
+	}
+	return fmt.Sprintf("  · %d tok · in %d%s · out %d%s%s%s",
+		u.TotalTokens, u.PromptTokens, cacheCol, u.CompletionTokens, reasoning, cost, churn)
 }
 
 // dimText wraps s in the ANSI dim SGR sequence so reasoning streams visually

--- a/internal/agent/usage_test.go
+++ b/internal/agent/usage_test.go
@@ -10,9 +10,13 @@ import (
 
 // renderUsage drives a Usage event through a fresh TextSink (no renderer) and
 // returns what it wrote — the usage line, exercised through the event path.
-func renderUsage(u *provider.Usage, p *provider.Pricing) string {
+func renderUsage(u *provider.Usage, p *provider.Pricing, d ...*event.CacheDiagnostics) string {
 	var b strings.Builder
-	NewTextSink(&b, nil, 80).Emit(event.Event{Kind: event.Usage, Usage: u, Pricing: p})
+	var diag *event.CacheDiagnostics
+	if len(d) > 0 {
+		diag = d[0]
+	}
+	NewTextSink(&b, nil, 80).Emit(event.Event{Kind: event.Usage, Usage: u, Pricing: p, CacheDiagnostics: diag})
 	return b.String()
 }
 
@@ -53,5 +57,16 @@ func TestUsageLineDerivesMissFromHit(t *testing.T) {
 	}
 	if out := renderUsage(u, nil); !strings.Contains(out, "1133 cached / 2407 new") {
 		t.Errorf("usage line = %q (want 1133 cached / 2407 new)", out)
+	}
+}
+
+func TestUsageLineReportsPrefixChurn(t *testing.T) {
+	u := &provider.Usage{PromptTokens: 100, CompletionTokens: 10, TotalTokens: 110}
+	d := &event.CacheDiagnostics{
+		PrefixChanged:       true,
+		PrefixChangeReasons: []string{"tools", "log_rewrite"},
+	}
+	if out := renderUsage(u, nil, d); !strings.Contains(out, "cache prefix changed: tools+log_rewrite") {
+		t.Errorf("usage line = %q (want cache prefix change reason)", out)
 	}
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2524,7 +2524,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		if e.Usage != nil {
 			m.turnTokens += e.Usage.CompletionTokens
 		}
-		if line := agent.FormatUsageLine(e.Usage, e.Pricing); line != "" {
+		if line := agent.FormatUsageLine(e.Usage, e.Pricing, e.CacheDiagnostics); line != "" {
 			m.finalizeStreamed()
 			m.commitLine(line)
 		}

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -304,6 +304,7 @@ func TestIngestEventRoutesByKind(t *testing.T) {
 		{"dispatch", event.Event{Kind: event.ToolDispatch, Tool: event.Tool{Name: "read_file", Args: `{"path":"x"}`}}, "● Read(x)"},
 		{"blocked", event.Event{Kind: event.ToolResult, Tool: event.Tool{Name: "bash", Err: "blocked by permission policy"}}, "● Bash ⊘ blocked by permission policy"},
 		{"usage", event.Event{Kind: event.Usage, Usage: &provider.Usage{PromptTokens: 1000, CompletionTokens: 200, TotalTokens: 1200, CacheHitTokens: 900, CacheMissTokens: 100}}, "  · 1200 tok"},
+		{"usage-diagnostics", event.Event{Kind: event.Usage, Usage: &provider.Usage{PromptTokens: 1000, CompletionTokens: 200, TotalTokens: 1200}, CacheDiagnostics: &event.CacheDiagnostics{PrefixChanged: true, PrefixChangeReasons: []string{"tools"}}}, "cache prefix changed: tools"},
 		{"notice-info", event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "compacted 8 messages → summary"}, "  · compacted 8 messages → summary"},
 		{"notice-warn", event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "response truncated: hit max output tokens"}, "  ! response truncated: hit max output tokens"},
 		{"phase", event.Event{Kind: event.Phase, Text: "planner · planning"}, "[planner · planning]"},

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -170,15 +170,31 @@ type AskAnswer struct {
 	Selected   []string
 }
 
+// CacheDiagnostics describes whether and why the cacheable prefix changed since
+// the last turn. It rides on the Usage event so every frontend can show
+// cache-churn attribution.
+type CacheDiagnostics struct {
+	PrefixHash          string
+	PrefixChanged       bool
+	PrefixChangeReasons []string // "system", "tools", "log_rewrite"
+	SystemHash          string
+	ToolsHash           string
+	LogRewriteVersion   int
+	ToolSchemaTokens    int
+	CacheMissTokens     int
+	CacheHitTokens      int
+}
+
 // Event is one increment in a turn's event stream. Read the field(s) documented
 // for Kind; the others are zero.
 type Event struct {
-	Kind      Kind
-	Text      string            // Reasoning / Text / Message / Notice / Phase
-	Reasoning string            // Message: the full reasoning chain
-	Tool      Tool              // ToolDispatch / ToolResult
-	Usage     *provider.Usage   // Usage
-	Pricing   *provider.Pricing // Usage: for cost display (nil = omit cost)
+	Kind             Kind
+	Text             string            // Reasoning / Text / Message / Notice / Phase
+	Reasoning        string            // Message: the full reasoning chain
+	Tool             Tool              // ToolDispatch / ToolResult
+	Usage            *provider.Usage   // Usage
+	Pricing          *provider.Pricing // Usage: for cost display (nil = omit cost)
+	CacheDiagnostics *CacheDiagnostics // Usage: cache-churn attribution (nil = N/A)
 	// SessionHit/SessionMiss carry cumulative cache tokens across the whole
 	// session (Usage events only), so a frontend can show the aggregate hit-rate
 	// — which doesn't crater on a short turn or after compaction — alongside

--- a/internal/serve/wire.go
+++ b/internal/serve/wire.go
@@ -61,17 +61,30 @@ type wireTool struct {
 }
 
 type wireUsage struct {
-	PromptTokens     int `json:"promptTokens"`
-	CompletionTokens int `json:"completionTokens"`
-	TotalTokens      int `json:"totalTokens"`
-	CacheHitTokens   int `json:"cacheHitTokens"`
-	CacheMissTokens  int `json:"cacheMissTokens"`
-	ReasoningTokens  int `json:"reasoningTokens,omitempty"`
+	PromptTokens     int                   `json:"promptTokens"`
+	CompletionTokens int                   `json:"completionTokens"`
+	TotalTokens      int                   `json:"totalTokens"`
+	CacheHitTokens   int                   `json:"cacheHitTokens"`
+	CacheMissTokens  int                   `json:"cacheMissTokens"`
+	ReasoningTokens  int                   `json:"reasoningTokens,omitempty"`
+	CacheDiagnostics *wireCacheDiagnostics `json:"cacheDiagnostics,omitempty"`
 	// Session-cumulative cache tokens — the status line shows the aggregate
 	// hit-rate Σhit/Σ(hit+miss), steadier than the single-turn CacheHitTokens.
 	SessionCacheHitTokens  int     `json:"sessionCacheHitTokens"`
 	SessionCacheMissTokens int     `json:"sessionCacheMissTokens"`
 	CostUSD                float64 `json:"costUsd,omitempty"`
+}
+
+type wireCacheDiagnostics struct {
+	PrefixHash          string   `json:"prefixHash"`
+	PrefixChanged       bool     `json:"prefixChanged"`
+	PrefixChangeReasons []string `json:"prefixChangeReasons,omitempty"`
+	SystemHash          string   `json:"systemHash"`
+	ToolsHash           string   `json:"toolsHash"`
+	LogRewriteVersion   int      `json:"logRewriteVersion"`
+	ToolSchemaTokens    int      `json:"toolSchemaTokens"`
+	CacheMissTokens     int      `json:"cacheMissTokens"`
+	CacheHitTokens      int      `json:"cacheHitTokens"`
 }
 
 type wireApproval struct {
@@ -137,6 +150,9 @@ func toWire(e event.Event) wireEvent {
 				CacheMissTokens: u.CacheMissTokens, ReasoningTokens: u.ReasoningTokens,
 				SessionCacheHitTokens: e.SessionHit, SessionCacheMissTokens: e.SessionMiss,
 			}
+			if e.CacheDiagnostics != nil {
+				w.Usage.CacheDiagnostics = toWireCacheDiagnostics(e.CacheDiagnostics)
+			}
 			if e.Pricing != nil {
 				w.Usage.CostUSD = e.Pricing.Cost(u)
 			}
@@ -156,4 +172,18 @@ func toWire(e event.Event) wireEvent {
 		}
 	}
 	return w
+}
+
+func toWireCacheDiagnostics(d *event.CacheDiagnostics) *wireCacheDiagnostics {
+	return &wireCacheDiagnostics{
+		PrefixHash:          d.PrefixHash,
+		PrefixChanged:       d.PrefixChanged,
+		PrefixChangeReasons: append([]string(nil), d.PrefixChangeReasons...),
+		SystemHash:          d.SystemHash,
+		ToolsHash:           d.ToolsHash,
+		LogRewriteVersion:   d.LogRewriteVersion,
+		ToolSchemaTokens:    d.ToolSchemaTokens,
+		CacheMissTokens:     d.CacheMissTokens,
+		CacheHitTokens:      d.CacheHitTokens,
+	}
 }

--- a/internal/serve/wire_test.go
+++ b/internal/serve/wire_test.go
@@ -21,9 +21,17 @@ func TestToWire(t *testing.T) {
 			Kind:    event.Usage,
 			Usage:   &provider.Usage{PromptTokens: 1000, CompletionTokens: 200, TotalTokens: 1200, CacheHitTokens: 900, CacheMissTokens: 100},
 			Pricing: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2},
+			CacheDiagnostics: &event.CacheDiagnostics{
+				PrefixChanged:       true,
+				PrefixChangeReasons: []string{"log_rewrite"},
+				LogRewriteVersion:   1,
+			},
 		})
 		if w.Usage == nil || w.Usage.TotalTokens != 1200 || w.Usage.CostUSD <= 0 {
 			t.Errorf("usage = %+v", w.Usage)
+		}
+		if w.Usage.CacheDiagnostics == nil || w.Usage.CacheDiagnostics.PrefixChangeReasons[0] != "log_rewrite" {
+			t.Errorf("cache diagnostics = %+v", w.Usage.CacheDiagnostics)
 		}
 	})
 


### PR DESCRIPTION
Rebase of #2405 (by @SivanCola) onto current main-v2. The branch had drifted badly; rather than replay four commits through the intermediate-state conflicts, I applied the net diff and re-merged by hand against the newer agent code.

## What it does
Each turn, hashes the prompt prefix (system / tools / combined) and, on a cache miss, attributes it to one of: system-prompt drift, tool-schema drift, a log rewrite (compaction), or an inherent tail miss. The reason is surfaced on the CLI/TUI usage line and forwarded through the serve and desktop wire so every frontend can show *why* the cache churned — directly in service of the cache-first positioning.

## Rebase notes (where main-v2 had moved on)
- Kept main-v2's mutex-safe `Session.Replace` / `Snapshot` and the `atomic.Int64` session cache counters, and threaded the new `rewriteVersion` / `RewriteVersion()` / `IncrementRewrite()` alongside them rather than reverting to the old direct-field writes.
- Left `stream()` on main-v2's signature (it still needs `turn` for the PostLLMCall hook and returns the reasoning `signature`); the prefix shape is captured from `a.tools.Schemas()` in the loop, which is what `stream` sends.
- Adapted `TestCompactRewriteVersionFeedsCacheDiagnostics` to the current 3-arg `compact(ctx, trigger, instructions)` signature.

All four review items from the original #2405 thread are already folded in (the `log_rewrite` wiring, the usage-line consumer, the `Rewite`→`Rewrite` typo, and the dead-field cleanup).

Local: `go build ./...`, `go vet`, and `go test ./internal/agent ./internal/serve ./internal/event` all green.

Closes #2405
