### PR TITLE
fix(e2ebench): cap post-cancel wait with WaitDelay so a wedged child can't wedge the bench

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -82,6 +82,12 @@ func runOnce(o diffOpts, srcFiles, pkgs []string, prompt string) diffReport {
 	cmd.Dir = o.repo
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
+	// Same WaitDelay contract as runTask in main.go: when the diff-mode
+	// ctx times out, exec.WaitDelay bounds how long we wait for the child
+	// to honour the cancel signal before the I/O pipes are force-closed
+	// and Wait() returns. Without it, a wedged child would block the
+	// bench forever. See main.go for the rationale.
+	cmd.WaitDelay = 10 * time.Second
 	runErr := cmd.Run()
 
 	// The agent's new files are untracked, so `git diff HEAD` would miss them;

--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -182,6 +182,17 @@ func runTask(bin, model string, t task) result {
 	cmd.Dir = work
 	cmd.Stdout = os.Stderr // stream the run to the job log, keep stdout clean for the report
 	cmd.Stderr = os.Stderr
+	// When the bench's per-task ctx times out, Go's exec sends the cancel
+	// signal (SIGKILL on Unix by default) and then waits for the child to
+	// exit. Without WaitDelay, that wait is unbounded: a stuck child
+	// (deep syscall, MCP stdio server wedged on a write to a closed pipe,
+	// AV scanner holding the binary open on Windows) blocks the bench
+	// indefinitely. After WaitDelay, exec closes the child's I/O pipes,
+	// which unblocks any stdio-bound wait in the child even when the
+	// signal is ignored. 10s is the same shape bash.go uses for its
+	// 120s foreground timeout — long enough for a graceful exit, short
+	// enough that the bench never wedges.
+	cmd.WaitDelay = 10 * time.Second
 	runErr := cmd.Run()
 
 	if m, err := readMetrics(metricsPath); err == nil {


### PR DESCRIPTION
## Summary

Both `runTask` (suite mode) and `runOnce` (diff mode) launch the `reasonix` binary with `exec.CommandContext` but no `WaitDelay`. When the bench's per-task ctx times out, Go's exec sends the cancel signal and then `Wait()`s for the child to exit. Without `WaitDelay`, that wait is unbounded: a wedged child can keep the bench hung indefinitely.

## Problem

The shape of a wedge:

* A child deep in an unresponsive syscall (e.g. an unlinked `fs.read()` on a network mount that just went away).
* An MCP stdio server blocked on `write` to a closed pipe — the child's read of its own stdin unblocks, but a goroutine in the harness doing `io.Copy(stdout, pipe)` is hung on the write side, so the process can't exit.
* On Windows, an AV scanner holding the binary open for a few hundred ms after the cancel signal lands.

In all three cases the bench reaches the timeout, the cancel signal fires, and `cmd.Wait()` blocks forever because the child still has open file descriptors pointing at the parent's pipe.

## Fix

`cmd.WaitDelay = 10 * time.Second` on both call sites. After WaitDelay, exec closes the child's I/O pipes, which unblocks any stdio-bound wait in the child even when the signal was ignored. `Wait` then returns `ErrWaitDelay`, which surfaces as a non-nil `runErr` — handled identically to any other non-zero exit by the rest of the bench.

10s is the same shape `bash.go` uses for its 120s foreground timeout: long enough for a graceful exit, short enough that the bench never wedges.

## Scope

This affects only the e2e benchmark harness (`cmd/e2ebench`), not the production chat path. The chat TUI and the desktop serve path already have their own command-context wiring (and use `setKillTree` / `proc.KillTree` for the actual child processes, which is the right answer there).

## Test plan

* [x] `go build ./…` passes.
* [x] `go test ./cmd/e2ebench/ -count=1` passes (no test changes; the harness has no current test coverage of the run loop itself, only the metric reader).