### PR TITLE
fix(serve): keep SSE /events warm with periodic ping so proxies don't drop the idle stream

### DIFF
--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -279,6 +279,15 @@ func (s *Server) index(w http.ResponseWriter, _ *http.Request) {
 	_, _ = w.Write(indexHTML)
 }
 
+// sseKeepaliveInterval is how often the /events handler emits a `: ping`
+// SSE comment. Most reverse proxies (nginx, ALB, Cloudflare) close idle
+// upstream connections after 30–60 s; a long quiet turn (the agent
+// thinking, the model generating a single long response) easily hits
+// that window. The comment is one byte on the wire and is dropped by
+// the EventSource client, so it's a no-op for the consumer while it
+// keeps the TCP socket warm for the proxy.
+const sseKeepaliveInterval = 15 * time.Second
+
 // events streams the controller's event flow as SSE until the client
 // disconnects. Each event is one `data:` frame of the JSON wire form.
 func (s *Server) events(w http.ResponseWriter, r *http.Request) {
@@ -297,6 +306,9 @@ func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, ": connected\n\n") // open the stream immediately
 	flusher.Flush()
 
+	keepalive := time.NewTicker(sseKeepaliveInterval)
+	defer keepalive.Stop()
+
 	for {
 		select {
 		case data, ok := <-ch:
@@ -304,6 +316,15 @@ func (s *Server) events(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+		case <-keepalive.C:
+			// SSE comment lines start with `:` and are ignored by the
+			// client. Emit one every sseKeepaliveInterval so the
+			// upstream socket stays warm; without this, a long quiet
+			// turn (e.g. a model thinking) lets a proxy like nginx
+			// or an ALB close the idle connection and the next
+			// event arrives on a half-closed stream.
+			fmt.Fprint(w, ": ping\n\n")
 			flusher.Flush()
 		case <-r.Context().Done():
 			return


### PR DESCRIPTION
## Summary

When the desktop frontend sits behind a reverse proxy (nginx, Cloudflare, ALB), the proxy's default 30-60s idle-timeout can close an `/events` SSE connection that's just been quiet (the agent thinking, or between text deltas during a long response). The proxy drops the half-closed socket on its side; the next event arrives on a stream the EventSource client has already given up on, and the user sees the connection die mid-turn.

## Fix

Emit a `: ping` SSE comment every 15 seconds. SSE comment lines start with `:` and are dropped by the EventSource client (per the spec), so it's a no-op for the consumer. On the wire it's 8 bytes (": ping\n\n") that arrive just often enough to keep the upstream TCP socket warm, so nginx/ALB/Cloudflare never hit their idle timer.

15s is well under the tightest common proxy timeout (nginx default 60s) with comfortable headroom for jitter. Too long and a quiet 45s turn could still be cut; too short and we add traffic without benefit.

## Test plan

* [x] `go build ./…` passes.
* [x] `go test ./internal/serve/ -count=1 -run TestServer -v` passes (no behavior change on the unit-test path).