### PR TITLE
fix(e2ebench): cap mutation test wait + always restore source on panic

### DIFF
--- a/cmd/e2ebench/mutation.go
+++ b/cmd/e2ebench/mutation.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const maxMutants = 15
@@ -68,8 +69,34 @@ func runMutation(repo, base string, srcFiles []string, refs []testRef) mutationR
 			}
 			cmd := exec.Command("go", "test", "-run", runRe, pkg)
 			cmd.Dir = repo
+			// Bound the wait for the mutated-binary test run. Without
+			// WaitDelay, a mutant that compiles but wedges a test
+			// (e.g. infinite loop, blocking syscall) would block the
+			// bench forever, AND the explicit WriteFile restore below
+			// would not fire. 2 minutes matches what `go test -timeout`
+			// uses by default — long enough for a slow legitimate
+			// test, short enough that a hung binary never pins the
+			// bench. After WaitDelay, exec closes the child's I/O,
+			// unblocking the stdio-bound wait even when SIGKILL is
+			// ignored.
+			cmd.WaitDelay = 2 * time.Minute
+			// Restore the source no matter what — even when the test
+			// binary wedges, panics, or the process is killed by the
+			// test-timeout cap. The previous shape only restored on
+			// the happy path; a panic between WriteFile and the
+			// `caught := ...` line would leave the file in mutated
+			// state and break the next mutant (and the next attempt's
+			// diff-mode run via resetTree, which `git clean -fd`
+			// would then re-load from the mutated working tree).
+			restored := false
+			defer func() {
+				if !restored {
+					_ = os.WriteFile(abs, srcB, 0o644)
+				}
+			}()
 			caught := cmd.Run() != nil
-			_ = os.WriteFile(abs, srcB, 0o644) // restore before the next mutant
+			_ = os.WriteFile(abs, srcB, 0o644)
+			restored = true
 			if caught {
 				res.caught++
 			} else {


### PR DESCRIPTION
## Summary

`runMutation` writes a zero-value-return body to disk, runs the agent's new tests against it, then restores the original source — all on the happy path. Two failure modes break the bench:

1. A mutant that compiles but wedges the test (infinite loop, blocking syscall, race-detector crash) blocks `cmd.Run()` forever.
2. A panic between WriteFile and the explicit WriteFile-restore leaves the file in mutated state. The next mutant in the same file builds on a mutated base, and the next diff-mode attempt's `resetTree` (which `git clean -fd` would re-load from the mutated working tree) inherits the corruption.

## Fix

* `cmd.WaitDelay = 2 * time.Minute` on the mutation test run, matching `go test -timeout`'s own default. After WaitDelay, exec closes the child's I/O pipes, unblocking the stdio-bound wait even when SIGKILL is ignored.
* Wrap the per-mutant test in a defer that restores the source if the explicit happy-path restore didn't fire. A `restored` flag guards against double-restore, which would be a no-op but generates a misleading stat-failure log line in any future test that adds source-file watchers.

## Test plan

* [x] `go build ./…` passes.