### PR TITLE
fix(e2ebench): parse method-form test names in parseNewTests

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -464,11 +464,33 @@ func parseNewTests(diff string) []testRef {
 			continue
 		}
 		sig := strings.TrimPrefix(body, "func ")
-		paren := strings.IndexByte(sig, '(')
-		if paren <= 0 {
-			continue
+		// Function vs method: a top-level function's signature starts
+		// with its name (`TestFoo(t *testing.T) …`), so the first '('
+		// comes after the name. A method's signature starts with the
+		// receiver (`(s *Suite) TestFoo(t *testing.T) …`), so the
+		// first '(' is at position 0 — and the previous shape's
+		// `paren <= 0` guard silently dropped every method-form test
+		// on the floor. Parse the receiver out, then take the name
+		// from whatever follows the closing ')'.
+		var name string
+		if sig[0] == '(' {
+			close := strings.IndexByte(sig, ')')
+			if close < 0 {
+				continue
+			}
+			rest := strings.TrimSpace(sig[close+1:])
+			methodParen := strings.IndexByte(rest, '(')
+			if methodParen <= 0 {
+				continue
+			}
+			name = rest[:methodParen]
+		} else {
+			funcParen := strings.IndexByte(sig, '(')
+			if funcParen <= 0 {
+				continue
+			}
+			name = sig[:funcParen]
 		}
-		name := sig[:paren]
 		if strings.HasPrefix(name, "Test") || strings.HasPrefix(name, "Fuzz") || strings.HasPrefix(name, "Benchmark") {
 			refs = append(refs, testRef{name: name, pkg: pkg})
 		}


### PR DESCRIPTION
## Summary

`parseNewTests` uses `strings.IndexByte(sig, '(')` to find the boundary between the function name and the parameter list, then takes everything before the `(` as the name. For a top-level function (`func TestFoo(t *testing.T) { ... }`) that works. For a method (`func (s *Suite) TestFoo(t *testing.T) { ... }`) it does not — the signature starts with the receiver, so the first `(` is at position 0 and the method is silently dropped.

This is the most common form in suite-style tests (e.g. testify's `suite.Suite` base), and the agent is steered to write tests in the receiver style. So every suite-style test the agent wrote was treated as "not a test" — neither the differential nor the mutation gate attributed a catch to it.

## Fix

Parse the receiver out first (when present), then take the function name from the substring after the closing `)`. Top-level functions still take the old path; methods take the new one. A test that lacks both the name and a paren (a malformed `+` line) is still skipped on the same `paren <= 0` / no-closing-`)` check it was before.

## Test plan

* [x] `go build ./…` passes.