### PR TITLE
fix(e2ebench): parse quoted args in --test-cmd so -run "TestFoo" reaches go test

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -505,7 +505,7 @@ func failingTestNames(out string) []string {
 }
 
 func runTests(repo, testCmd string, pkgs []string) (bool, string) {
-	fields := strings.Fields(testCmd)
+	fields := splitShellFields(testCmd)
 	if len(fields) == 0 {
 		fields = []string{"go", "test"}
 	}
@@ -514,6 +514,52 @@ func runTests(repo, testCmd string, pkgs []string) (bool, string) {
 	cmd.Dir = repo
 	out, err := cmd.CombinedOutput()
 	return err == nil, string(out)
+}
+
+// splitShellFields is a small POSIX-ish shell splitter: splits on
+// whitespace, supports single- and double-quoted spans (the kind of
+// arguments a user might pass via `--test-cmd \"go test -run
+// TestFoo\"`), and strips the quotes. It's intentionally tiny — the
+// diff-mode `--test-cmd` flag is set by the workflow, not the user,
+// so we don't need shell-expansion or backticks. Quoted segments
+// preserve their internal whitespace; everything else splits on
+// runs of \t, \n, or space.
+func splitShellFields(s string) []string {
+	var out []string
+	var cur strings.Builder
+	inSingle, inDouble := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inSingle:
+			if c == '\'' {
+				inSingle = false
+			} else {
+				cur.WriteByte(c)
+			}
+		case inDouble:
+			if c == '"' {
+				inDouble = false
+			} else {
+				cur.WriteByte(c)
+			}
+		case c == '\'':
+			inSingle = true
+		case c == '"':
+			inDouble = true
+		case c == ' ' || c == '\t' || c == '\n':
+			if cur.Len() > 0 {
+				out = append(out, cur.String())
+				cur.Reset()
+			}
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	if cur.Len() > 0 {
+		out = append(out, cur.String())
+	}
+	return out
 }
 
 // changedGoFiles lists .go files changed by base...HEAD, excluding *_test.go


### PR DESCRIPTION
## Summary

The diff-mode grader's `--test-cmd` flag is split with `strings.Fields`, which treats whitespace as a separator and silently drops quote characters. A user who wires `--test-cmd="go test -run TestFoo"` ends up with `-run TestFoo` as two separate `go test` arguments — `go test` interprets `TestFoo` as a package pattern, not a regex, and the bench silently times out trying to compile a non-existent package.

## Fix

A tiny POSIX-ish shell splitter that respects single- and double-quoted spans, strips the quote characters, and falls back to whitespace splitting outside quotes. It's intentionally small (no expansion, no backticks, no $\VAR) — the flag is set by the workflow, not the user, and the previous `strings.Fields` shape was the wrong tool the moment a quoted arg showed up.

The change is one helper + one call site. The bench's existing "passes a single positional pkg" contract still works: the un-quoted `go test ./pkg/...` shape parses to `[go, test, ./pkg/...]` exactly as before. Only quoted args change behavior, and the only behavior change is "works".

## Test plan

* [x] `go build ./…` passes.