### PR TITLE
feat(agent): structured, economical compaction (soft/force ratios + fold economics)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -195,9 +195,13 @@ type Agent struct {
 	// tail verbatim (recentKeep is the message floor) and archiving the originals
 	// under archiveDir. compactStuck latches when compaction can't get the prompt
 	// under the window (consecutiveCompacts crosses the limit), so auto-compaction
-	// pauses instead of looping.
+	// pauses instead of looping. softCompactNoticed gates the one-shot soft-ratio
+	// notice so it fires once per approach, not every turn.
 	contextWindow       int
+	softCompactRatio    float64
 	compactRatio        float64
+	compactForceRatio   float64
+	softCompactNoticed  bool
 	recentKeep          int
 	archiveDir          string
 	compactStuck        bool
@@ -290,7 +294,7 @@ func (a *Agent) CompactRatio() float64 { return a.compactRatio }
 // TUI's `/compact` command so the user can reset the prefix before it
 // naturally fills up.
 func (a *Agent) CompactNow(ctx context.Context, instructions string) error {
-	return a.compact(ctx, "manual", instructions)
+	return a.compact(ctx, "manual", instructions, true)
 }
 
 // Options configures an Agent.
@@ -302,6 +306,15 @@ type Options struct {
 	// Gate is the per-call permission gate. nil disables gating.
 	Gate Gate
 
+	// Context management. ContextWindow <= 0 disables compaction. Ratios and
+	// RecentKeep fall back to defaults when unset.
+	ContextWindow     int
+	SoftCompactRatio  float64
+	CompactRatio      float64
+	CompactForceRatio float64
+	RecentKeep        int
+	ArchiveDir        string
+
 	// Hooks fires PreToolUse / PostToolUse shell hooks around tool calls. nil
 	// disables hook firing.
 	Hooks ToolHooks
@@ -311,14 +324,6 @@ type Options struct {
 
 	// ProjectChecks are host-observable structured checks extracted during boot.
 	ProjectChecks []instruction.VerifyCheck
-
-	// Context management. ContextWindow <= 0 disables compaction. CompactRatio
-	// is the trigger fraction; RecentKeep is the minimum recent messages kept
-	// verbatim (the tail is otherwise token-bounded). Both fall back to defaults.
-	ContextWindow int
-	CompactRatio  float64
-	RecentKeep    int
-	ArchiveDir    string
 }
 
 // New constructs an Agent. MaxSteps <= 0 means no cap — the run loop continues
@@ -326,8 +331,14 @@ type Options struct {
 // provider errors (compaction keeps the context bounded). A nil sink is replaced
 // with event.Discard so the agent can always emit unconditionally.
 func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Options, sink event.Sink) *Agent {
+	if opts.SoftCompactRatio <= 0 {
+		opts.SoftCompactRatio = defaultSoftCompactRatio
+	}
 	if opts.CompactRatio <= 0 {
 		opts.CompactRatio = defaultCompactRatio
+	}
+	if opts.CompactForceRatio <= 0 {
+		opts.CompactForceRatio = defaultCompactForceRatio
 	}
 	if opts.RecentKeep <= 0 {
 		opts.RecentKeep = minRecentKeep
@@ -344,22 +355,24 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		hooks = nil
 	}
 	return &Agent{
-		prov:          prov,
-		tools:         tools,
-		session:       session,
-		maxSteps:      opts.MaxSteps,
-		temperature:   opts.Temperature,
-		pricing:       opts.Pricing,
-		sink:          sink,
-		gate:          gate,
-		hooks:         hooks,
-		jobs:          opts.Jobs,
-		evidence:      evidence.NewLedger(),
-		projectChecks: append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
-		contextWindow: opts.ContextWindow,
-		compactRatio:  opts.CompactRatio,
-		recentKeep:    opts.RecentKeep,
-		archiveDir:    opts.ArchiveDir,
+		prov:              prov,
+		tools:             tools,
+		session:           session,
+		maxSteps:          opts.MaxSteps,
+		temperature:       opts.Temperature,
+		pricing:           opts.Pricing,
+		sink:              sink,
+		gate:              gate,
+		hooks:             hooks,
+		jobs:              opts.Jobs,
+		evidence:          evidence.NewLedger(),
+		projectChecks:     append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
+		contextWindow:     opts.ContextWindow,
+		softCompactRatio:  opts.SoftCompactRatio,
+		compactRatio:      opts.CompactRatio,
+		compactForceRatio: opts.CompactForceRatio,
+		recentKeep:        opts.RecentKeep,
+		archiveDir:        opts.ArchiveDir,
 	}
 }
 

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -19,12 +20,21 @@ import (
 // fraction of the window, so a huge window still compacts rarely while a small
 // one still lands below the trigger (which is what stops the re-compaction loop).
 const (
-	defaultCompactRatio  = 0.8   // trigger: prompt at this fraction of the window compacts
-	defaultCompactTarget = 0.5   // safety cap: the kept tail never exceeds this fraction of the window
-	defaultTailTokens    = 16384 // verbatim recent-tail budget, in tokens
-	minRecentKeep        = 2     // never keep fewer recent messages than this
-	minCompactMessages   = 2     // skip compaction below this many compactable messages
-	fallbackTokPerChar   = 0.25  // ~4 chars/token, used before any usage is available to calibrate
+	defaultSoftCompactRatio  = 0.5   // report growing context here, but keep the cache-stable prefix intact
+	defaultCompactRatio      = 0.8   // trigger: prompt at this fraction of the window compacts
+	defaultCompactForceRatio = 0.9   // force compaction at this high-water mark even for low-value folds
+	defaultCompactTarget     = 0.5   // safety cap: the kept tail never exceeds this fraction of the window
+	defaultTailTokens        = 16384 // verbatim recent-tail budget, in tokens
+	minRecentKeep            = 2     // never keep fewer recent messages than this
+	minCompactMessages       = 2     // skip compaction below this many compactable messages
+	fallbackTokPerChar       = 0.25  // ~4 chars/token, used before any usage is available to calibrate
+)
+
+// summaryTag wraps the compaction summary so the model can distinguish it from
+// live user input and later strip or skip it when reasoning about the current turn.
+const (
+	summaryTagOpen  = "<compaction-summary>"
+	summaryTagClose = "</compaction-summary>"
 )
 
 // summarySystemPrompt steers the executor to distill older history into a
@@ -65,17 +75,28 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 		return
 	}
 	high := int(float64(a.contextWindow) * a.compactRatio)
+	soft := int(float64(a.contextWindow) * a.softCompactRatio)
+	// Between the soft ratio and the trigger, report growing context once without
+	// rewriting the prefix — a compaction here would needlessly crater the cache.
+	if u.PromptTokens >= soft && u.PromptTokens < high && !a.softCompactNoticed {
+		a.softCompactNoticed = true
+		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("context reached %.0f%% of window; keeping cache-first prefix until compact threshold %.0f%%", a.softCompactRatio*100, a.compactRatio*100)})
+		return
+	}
 	if u.PromptTokens < high {
 		// A turn that sits under the trigger is the breathing room a healthy
-		// compaction buys; it clears the stuck latch and the run counter.
+		// compaction buys; it clears the stuck latch, the run counter, and the
+		// one-shot soft notice.
 		a.consecutiveCompacts = 0
 		a.compactStuck = false
+		a.softCompactNoticed = false
 		return
 	}
 	if a.compactStuck {
 		return
 	}
-	if err := a.compact(ctx, "auto", ""); err != nil {
+	force := u.PromptTokens >= int(float64(a.contextWindow)*a.compactForceRatio)
+	if err := a.compact(ctx, "auto", "", force); err != nil {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("compaction skipped: %v", err)})
 		return
 	}
@@ -93,21 +114,77 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	}
 }
 
+// foldEconomics estimates whether compacting the given region saves enough
+// tokens to justify the summarization API call. It returns false when the
+// region is too small for the savings to outweigh the extra round-trip cost
+// and latency of calling the summarizer.
+func foldEconomics(region []provider.Message) bool {
+	const minFoldTokens = 400
+	return estimateMessagesTokens(region) >= minFoldTokens
+}
+
+func estimateMessagesTokens(msgs []provider.Message) int {
+	total := 0
+	for _, m := range msgs {
+		total += 4 // chat-message framing overhead
+		total += estimateTextTokens(m.Content)
+		total += estimateTextTokens(m.ReasoningContent)
+		total += estimateTextTokens(m.Name)
+		total += estimateTextTokens(m.ToolCallID)
+		for _, tc := range m.ToolCalls {
+			total += 8
+			total += estimateTextTokens(tc.ID)
+			total += estimateTextTokens(tc.Name)
+			total += estimateTextTokens(tc.Arguments)
+		}
+	}
+	return total
+}
+
+func estimateTextTokens(s string) int {
+	if s == "" {
+		return 0
+	}
+	// A conservative cross-language approximation: English-ish text trends near
+	// four bytes per token, while CJK-heavy text is closer to one rune per token.
+	bytes := len(s)
+	runes := utf8.RuneCountInString(s)
+	byBytes := (bytes + 3) / 4
+	if runes > byBytes {
+		return runes
+	}
+	return byBytes
+}
+
 // compact summarizes the older middle of the session and replaces it in place:
 // the session becomes system + summary + recent tail. The dropped originals are
 // archived first, so the full history stays traceable. trigger is "auto" (the
 // window threshold) or "manual" (/compact); it rides the Compaction events so a
 // frontend can label the card. instructions is optional extra summary guidance
-// (the user's `/compact <focus>` text); a PreCompact hook can contribute more. A
-// Started event is emitted before the (network) summarize so the UI can show a
-// "compacting…" placeholder, and a Done event (carrying the summary) replaces it.
-func (a *Agent) compact(ctx context.Context, trigger, instructions string) error {
+// (the user's `/compact <focus>` text); a PreCompact hook can contribute more.
+// force bypasses the fold-economics skip (manual /compact and the force-ratio
+// high-water mark always compact). A Started event is emitted before the (network)
+// summarize so the UI can show a "compacting…" placeholder, and a Done event
+// (carrying the summary) replaces it.
+func (a *Agent) compact(ctx context.Context, trigger, instructions string, force bool) error {
 	msgs := a.session.Messages
-	head, start, ok := a.planCompaction(msgs)
+	head, start, ok := a.planCompaction(msgs, minCompactMessages)
+	if !ok {
+		// A single huge message can still be worth folding. Keep the normal
+		// message-count guard for small histories, but let content size decide
+		// whether a one-message region has real compaction value.
+		head, start, ok = a.planCompaction(msgs, 1)
+	}
 	if !ok {
 		return nil // recent tail already covers everything worth keeping
 	}
 	region := msgs[head:start]
+
+	// Economic check: skip if the region is too small to justify the summarizer
+	// call, unless force (manual /compact or the force-ratio ceiling) demands it.
+	if !force && !foldEconomics(region) {
+		return nil
+	}
 
 	a.sink.Emit(event.Event{Kind: event.CompactionStarted, Compaction: event.Compaction{Trigger: trigger}})
 
@@ -141,8 +218,11 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string) error
 	compacted := make([]provider.Message, 0, head+1+len(msgs)-start)
 	compacted = append(compacted, msgs[:head]...)
 	compacted = append(compacted, provider.Message{
-		Role:    provider.RoleUser,
-		Content: "Summary of earlier conversation (older messages were compacted to save context):\n" + summary,
+		Role: provider.RoleUser,
+		Content: summaryTagOpen + "\n" +
+			"Summary of earlier conversation (older messages were compacted to save context):\n" +
+			summary + "\n" +
+			summaryTagClose,
 	})
 	compacted = append(compacted, msgs[start:]...)
 	a.session.Replace(compacted)
@@ -230,7 +310,7 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 // bounded by a token budget (not a message count), so a few large tool outputs
 // can't keep it above the trigger and re-fire compaction every turn. ok is false
 // when there is too little to compact.
-func (a *Agent) planCompaction(msgs []provider.Message) (head, start int, ok bool) {
+func (a *Agent) planCompaction(msgs []provider.Message, min int) (head, start int, ok bool) {
 	if len(msgs) > 0 && msgs[0].Role == provider.RoleSystem {
 		head = 1
 	}
@@ -251,7 +331,7 @@ func (a *Agent) planCompaction(msgs []provider.Message) (head, start int, ok boo
 	if start < head {
 		start = head
 	}
-	if start-head < minCompactMessages {
+	if start-head < min {
 		return head, start, false
 	}
 	return head, start, true

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -101,9 +101,10 @@ func TestTailStartSmallSession(t *testing.T) {
 
 func TestCompactReplacesHistory(t *testing.T) {
 	prov := &fakeProvider{reply: "- goal: do X\n- changed file Y"}
+	bigStep := strings.Repeat("important implementation detail ", 80)
 	sess := &Session{Messages: []provider.Message{
 		{Role: provider.RoleSystem, Content: "sys"},
-		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleUser, Content: "task " + bigStep},
 		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "read_file", Arguments: "{}"}}},
 		{Role: provider.RoleTool, ToolCallID: "1", Name: "read_file", Content: "file contents"},
 		{Role: provider.RoleAssistant, Content: "did a step"},
@@ -113,7 +114,7 @@ func TestCompactReplacesHistory(t *testing.T) {
 	dir := t.TempDir()
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: dir}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", ""); err != nil {
+	if err := a.compact(context.Background(), "manual", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if got := sess.RewriteVersion(); got != 1 {
@@ -170,7 +171,7 @@ func TestCompactEmitsEvents(t *testing.T) {
 	sink := event.FuncSink(func(e event.Event) { got = append(got, e) })
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2}, sink)
 
-	if err := a.compact(context.Background(), "auto", ""); err != nil {
+	if err := a.compact(context.Background(), "auto", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -216,7 +217,7 @@ func TestCompactInjectsFocusAndPreCompactHook(t *testing.T) {
 	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, Hooks: &stubHooks{preCompactOut: "KEEP-THE-MIGRATION-PLAN"}}, event.Discard)
 
-	if err := a.compact(context.Background(), "manual", "focus on the auth refactor"); err != nil {
+	if err := a.compact(context.Background(), "manual", "focus on the auth refactor", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 	if len(prov.got) == 0 || prov.got[0].Role != provider.RoleSystem {
@@ -245,7 +246,7 @@ func TestCompactRewriteVersionFeedsCacheDiagnostics(t *testing.T) {
 	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2}, event.Discard)
 	before := CaptureShape("sys", nil, sess.RewriteVersion())
 
-	if err := a.compact(context.Background(), "auto", ""); err != nil {
+	if err := a.compact(context.Background(), "auto", "", true); err != nil {
 		t.Fatalf("compact: %v", err)
 	}
 
@@ -259,37 +260,107 @@ func TestCompactRewriteVersionFeedsCacheDiagnostics(t *testing.T) {
 	}
 }
 
+func TestCompactFoldsSingleLargeMessage(t *testing.T) {
+	prov := &fakeProvider{reply: "- captured the large file contents"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "read_file", Content: strings.Repeat("large output line\n", 500)},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	if err := a.compact(context.Background(), "auto", "", false); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if got := len(sess.Messages); got != 4 {
+		t.Fatalf("len = %d, want 4: %+v", got, sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[1].Content, "large file contents") {
+		t.Fatalf("single large message was not summarized: %+v", sess.Messages)
+	}
+	if len(prov.got) == 0 || !strings.Contains(prov.got[1].Content, "large output line") {
+		t.Fatalf("summarizer did not receive the large message: %+v", prov.got)
+	}
+}
+
+func TestCompactSkipsSingleSmallMessage(t *testing.T) {
+	prov := &fakeProvider{reply: "- should not be called"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "tiny"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	if err := a.compact(context.Background(), "auto", "", false); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if got := len(sess.Messages); got != 4 {
+		t.Fatalf("small single message should not compact, len = %d", got)
+	}
+	if len(prov.got) != 0 {
+		t.Fatalf("summarizer was called for tiny region: %+v", prov.got)
+	}
+}
+
 func TestMaybeCompactThreshold(t *testing.T) {
-	// 40-char contents → ~10 tokens each at the fallback ratio; with a 20-token
-	// window the tail budget (10) keeps only the last couple, leaving a region to
-	// compact once the trigger is crossed.
-	body := strings.Repeat("x", 40)
+	// A large early user message gives the fold real value; with a 100-token window
+	// the soft (50%), trigger (80%), and force (90%) thresholds are easy to hit.
 	newSess := func() *Session {
 		return &Session{Messages: []provider.Message{
-			{Role: provider.RoleSystem, Content: body},
-			{Role: provider.RoleUser, Content: body},
-			{Role: provider.RoleAssistant, Content: body},
-			{Role: provider.RoleUser, Content: body},
-			{Role: provider.RoleAssistant, Content: body},
-			{Role: provider.RoleUser, Content: body},
-			{Role: provider.RoleAssistant, Content: body},
+			{Role: provider.RoleSystem, Content: "sys"},
+			{Role: provider.RoleUser, Content: strings.Repeat("a ", 500)},
+			{Role: provider.RoleAssistant, Content: "b"},
+			{Role: provider.RoleUser, Content: "c"},
+			{Role: provider.RoleAssistant, Content: "d"},
+			{Role: provider.RoleUser, Content: "e"},
+			{Role: provider.RoleAssistant, Content: "f"},
 		}}
 	}
 
-	// Below 80% of the window: untouched.
+	// Below 50% of the window: untouched.
 	sess := newSess()
-	a := New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 20, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 8})
+	a := New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 49})
 	if len(sess.Messages) != 7 {
 		t.Errorf("below threshold should not compact, len = %d", len(sess.Messages))
 	}
 
-	// At/above 80%: compacts.
+	// At/above 50% only emits a soft notice; it does not rewrite the cache prefix.
 	sess = newSess()
-	a = New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 20, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
-	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 18})
-	if len(sess.Messages) >= 7 {
-		t.Errorf("above threshold should compact, len = %d", len(sess.Messages))
+	prov := &fakeProvider{reply: "s"}
+	var notices []event.Event
+	a = New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e)
+		}
+	}))
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 50})
+	if len(sess.Messages) != 7 {
+		t.Errorf("soft threshold should not compact, len = %d", len(sess.Messages))
+	}
+	if len(prov.got) != 0 {
+		t.Fatalf("soft threshold called summarizer: %+v", prov.got)
+	}
+	if len(notices) != 1 || !strings.Contains(notices[0].Text, "context reached 50%") {
+		t.Fatalf("soft threshold notice = %+v", notices)
+	}
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 60})
+	if len(notices) != 1 {
+		t.Fatalf("soft threshold notice should only emit once, got %d", len(notices))
+	}
+
+	// At/above 80%: compacts when the fold is economically worthwhile. The
+	// token-budgeted tail keeps the small recent messages, so the large early
+	// message is the only foldable region — folding it installs a summary at
+	// index 1 (the count is unchanged because one message becomes one summary).
+	sess = newSess()
+	a = New(&fakeProvider{reply: "s"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
+	if !strings.Contains(sess.Messages[1].Content, "Summary of earlier") {
+		t.Errorf("compact threshold should fold the large early message, got: %+v", sess.Messages[1])
 	}
 
 	// No context window: compaction disabled.
@@ -298,5 +369,69 @@ func TestMaybeCompactThreshold(t *testing.T) {
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 1 << 30})
 	if len(sess.Messages) != 7 {
 		t.Errorf("no window should disable compaction, len = %d", len(sess.Messages))
+	}
+}
+
+func TestMaybeCompactForceCeilingBypassesEconomics(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "small old request"},
+		{Role: provider.RoleAssistant, Content: "small old answer"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	prov := &fakeProvider{reply: "forced summary"}
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 90})
+	// The token-budgeted tail keeps "small old answer", next, ok, so only the
+	// single early message folds — force bypasses the economics skip and installs
+	// a summary at index 1, leaving the count at 5.
+	if got := len(sess.Messages); got != 5 {
+		t.Fatalf("len = %d, want 5 after forced single-message fold: %+v", got, sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[1].Content, "forced summary") {
+		t.Fatalf("forced compact did not install summary: %+v", sess.Messages)
+	}
+	if len(prov.got) == 0 {
+		t.Fatalf("summarizer was not called at force ceiling")
+	}
+}
+
+func TestMaybeCompactSkipsLowValueRegionBeforeForceCeiling(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "small old request"},
+		{Role: provider.RoleAssistant, Content: "small old answer"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	prov := &fakeProvider{reply: "should not summarize"}
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
+	if got := len(sess.Messages); got != 5 {
+		t.Fatalf("low-value region should not compact before force ceiling, len = %d", got)
+	}
+	if len(prov.got) != 0 {
+		t.Fatalf("summarizer was called for low-value non-forced region: %+v", prov.got)
+	}
+}
+
+func TestMaybeCompactFoldsSingleLargeMessageAtThreshold(t *testing.T) {
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: strings.Repeat("large prompt chunk ", 500)},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(&fakeProvider{reply: "single large summary"}, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 80})
+	if got := len(sess.Messages); got != 4 {
+		t.Fatalf("len = %d, want 4: %+v", got, sess.Messages)
+	}
+	if !strings.Contains(sess.Messages[1].Content, "single large summary") {
+		t.Fatalf("single large message was not compacted at threshold: %+v", sess.Messages)
 	}
 }

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -49,15 +49,18 @@ func SubagentMetaTools() []string {
 // parallel research across independent areas (the parallel-dispatch path picks
 // these up only when readOnly, which task is not).
 type TaskTool struct {
-	prov          provider.Provider
-	pricing       *provider.Pricing
-	parentReg     *tool.Registry
-	maxSteps      int
-	contextWindow int
-	temperature   float64
-	archiveDir    string
-	sysPrompt     string
-	gate          Gate
+	prov              provider.Provider
+	pricing           *provider.Pricing
+	parentReg         *tool.Registry
+	maxSteps          int
+	contextWindow     int
+	softCompactRatio  float64
+	compactRatio      float64
+	compactForceRatio float64
+	temperature       float64
+	archiveDir        string
+	sysPrompt         string
+	gate              Gate
 }
 
 // NewTaskTool wires a task tool to the parent agent's environment so its
@@ -67,20 +70,23 @@ type TaskTool struct {
 // deny rules still bite while autonomous sub-agents are never blocked on an
 // interactive prompt (there is no UI to answer one).
 func NewTaskTool(prov provider.Provider, pricing *provider.Pricing, parentReg *tool.Registry,
-	maxSteps, contextWindow int, temperature float64, archiveDir, sysPrompt string, gate Gate) *TaskTool {
+	maxSteps, contextWindow int, softCompactRatio, compactRatio, compactForceRatio, temperature float64, archiveDir, sysPrompt string, gate Gate) *TaskTool {
 	if sysPrompt == "" {
 		sysPrompt = DefaultTaskSystemPrompt
 	}
 	return &TaskTool{
-		prov:          prov,
-		pricing:       pricing,
-		parentReg:     parentReg,
-		maxSteps:      maxSteps,
-		contextWindow: contextWindow,
-		temperature:   temperature,
-		archiveDir:    archiveDir,
-		sysPrompt:     sysPrompt,
-		gate:          gate,
+		prov:              prov,
+		pricing:           pricing,
+		parentReg:         parentReg,
+		maxSteps:          maxSteps,
+		contextWindow:     contextWindow,
+		softCompactRatio:  softCompactRatio,
+		compactRatio:      compactRatio,
+		compactForceRatio: compactForceRatio,
+		temperature:       temperature,
+		archiveDir:        archiveDir,
+		sysPrompt:         sysPrompt,
+		gate:              gate,
 	}
 }
 
@@ -203,12 +209,15 @@ func FilterRegistry(parent *tool.Registry, names []string, exclude ...string) *t
 // background paths.
 func (t *TaskTool) runSub(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int) (string, error) {
 	return RunSubAgent(ctx, t.prov, subReg, t.sysPrompt, prompt, Options{
-		MaxSteps:      maxSteps,
-		Temperature:   t.temperature,
-		Pricing:       t.pricing,
-		Gate:          t.gate,
-		ContextWindow: t.contextWindow,
-		ArchiveDir:    t.archiveDir,
+		MaxSteps:          maxSteps,
+		Temperature:       t.temperature,
+		Pricing:           t.pricing,
+		Gate:              t.gate,
+		ContextWindow:     t.contextWindow,
+		SoftCompactRatio:  t.softCompactRatio,
+		CompactRatio:      t.compactRatio,
+		CompactForceRatio: t.compactForceRatio,
+		ArchiveDir:        t.archiveDir,
 	}, sink)
 }
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -18,7 +18,7 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 		{Type: provider.ChunkDone},
 	}}
 	parentReg := tool.NewRegistry()
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "test-sys-prompt", nil)
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "test-sys-prompt", nil)
 
 	out, err := task.Execute(context.Background(), []byte(`{"prompt":"find callers of Foo"}`))
 	if err != nil {
@@ -51,7 +51,7 @@ func TestTaskToolFiltersTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
 	parentReg.Add(fakeTool{name: "write_file", readOnly: false})
 	parentReg.Add(fakeTool{name: "bash", readOnly: false})
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task) // simulate the wiring in cli.setup
 	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
 	parentReg.Add(fakeTool{name: "research", readOnly: false})
@@ -80,7 +80,7 @@ func TestTaskToolDefaultsToParentToolsWithoutMetaTools(t *testing.T) {
 	parentReg := tool.NewRegistry()
 	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
 	parentReg.Add(fakeTool{name: "grep", readOnly: true})
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0.0, "", "sys", nil)
+	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil)
 	parentReg.Add(task)
 	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
 	parentReg.Add(fakeTool{name: "explore", readOnly: false})

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -401,7 +401,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// nesting out of the picture). It registers into the same reg the
 	// executor uses, so the model surfaces it like any other tool.
 	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
-		entry.ContextWindow, cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
+		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
+		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
 
 	// The `remember` tool lets the model persist durable facts to the project's
 	// auto-memory store; `forget` prunes ones that turn out wrong. The saved index
@@ -454,15 +455,18 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 
 	execSess := agent.NewSession(sysPrompt)
 	executor := agent.New(execProv, reg, execSess, agent.Options{
-		MaxSteps:      maxSteps,
-		Temperature:   cfg.Agent.Temperature,
-		Pricing:       entry.Price,
-		Gate:          headlessGate,
-		Hooks:         hookRunner,
-		Jobs:          jm,
-		ProjectChecks: projectChecks,
-		ContextWindow: entry.ContextWindow,
-		ArchiveDir:    config.ArchiveDir(),
+		MaxSteps:          maxSteps,
+		Temperature:       cfg.Agent.Temperature,
+		Pricing:           entry.Price,
+		Gate:              headlessGate,
+		Hooks:             hookRunner,
+		Jobs:              jm,
+		ProjectChecks:     projectChecks,
+		ContextWindow:     entry.ContextWindow,
+		SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
+		CompactRatio:      cfg.Agent.CompactRatio,
+		CompactForceRatio: cfg.Agent.CompactForceRatio,
+		ArchiveDir:        config.ArchiveDir(),
 	}, sink)
 
 	// Custom slash commands (.reasonix/commands + user dir). Best-effort: a malformed

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -138,15 +138,19 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 	policy := permission.New(cfg.Permissions.Mode, cfg.Permissions.Allow, cfg.Permissions.Ask, cfg.Permissions.Deny)
 	headlessGate := permission.NewGate(policy, nil)
 	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
-		entry.ContextWindow, cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
+		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
+		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate))
 
 	executor := agent.New(execProv, reg, agent.NewSession(sysPrompt), agent.Options{
-		MaxSteps:      maxSteps,
-		Temperature:   cfg.Agent.Temperature,
-		Pricing:       entry.Price,
-		Gate:          headlessGate,
-		ContextWindow: entry.ContextWindow,
-		ArchiveDir:    config.ArchiveDir(),
+		MaxSteps:          maxSteps,
+		Temperature:       cfg.Agent.Temperature,
+		Pricing:           entry.Price,
+		Gate:              headlessGate,
+		ContextWindow:     entry.ContextWindow,
+		SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
+		CompactRatio:      cfg.Agent.CompactRatio,
+		CompactForceRatio: cfg.Agent.CompactForceRatio,
+		ArchiveDir:        config.ArchiveDir(),
 	}, p.Sink)
 
 	cmds, _ := command.Load(config.CommandDirs()...)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -353,6 +353,10 @@ type AgentConfig struct {
 	// AutoPlanClassifier optionally names a provider/model used to classify
 	// borderline auto-plan decisions. Empty keeps the zero-cost heuristic path.
 	AutoPlanClassifier string `toml:"auto_plan_classifier"`
+	// Compaction window fractions: soft = notice only, compact = trigger, force = hard ceiling.
+	SoftCompactRatio  float64 `toml:"soft_compact_ratio"`
+	CompactRatio      float64 `toml:"compact_ratio"`
+	CompactForceRatio float64 `toml:"compact_force_ratio"`
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's
@@ -541,8 +545,11 @@ func Default() *Config {
 			// the user cancels, or the provider errors. Context stays bounded by
 			// compaction, not by a round count. Set a positive agent.max_steps only
 			// if you want a hard guard against runaway.
-			MaxSteps: 0,
-			AutoPlan: "ask",
+			MaxSteps:          0,
+			AutoPlan:          "ask",
+			SoftCompactRatio:  0.5,
+			CompactRatio:      0.8,
+			CompactForceRatio: 0.9,
 		},
 		// Mode "ask" with no rules keeps `reasonix run` autonomous (no TTY → ask
 		// resolves to allow) while `reasonix chat` prompts before writers. Users add

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -95,6 +95,9 @@ func RenderTOML(c *Config) string {
 	} else {
 		b.WriteString("# auto_plan_classifier = \"deepseek-flash\"   # optional; only used for borderline tasks\n")
 	}
+	fmt.Fprintf(&b, "soft_compact_ratio  = %s   # notice only; keeps cache-first prefix intact\n", formatFloat(c.Agent.SoftCompactRatio))
+	fmt.Fprintf(&b, "compact_ratio       = %s   # try compacting when prompt reaches this fraction\n", formatFloat(c.Agent.CompactRatio))
+	fmt.Fprintf(&b, "compact_force_ratio = %s   # force compacting at this high-water mark\n", formatFloat(c.Agent.CompactForceRatio))
 	if c.Agent.PlannerModel != "" {
 		fmt.Fprintf(&b, "planner_model = %q   # low-frequency planner (two-model collaboration)\n", c.Agent.PlannerModel)
 	} else {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -76,6 +76,15 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if got.Agent.AutoPlanClassifier != "deepseek-flash" {
 		t.Errorf("auto_plan_classifier = %q, want deepseek-flash", got.Agent.AutoPlanClassifier)
 	}
+	if got.Agent.SoftCompactRatio != orig.Agent.SoftCompactRatio {
+		t.Errorf("soft_compact_ratio = %v, want %v", got.Agent.SoftCompactRatio, orig.Agent.SoftCompactRatio)
+	}
+	if got.Agent.CompactRatio != orig.Agent.CompactRatio {
+		t.Errorf("compact_ratio = %v, want %v", got.Agent.CompactRatio, orig.Agent.CompactRatio)
+	}
+	if got.Agent.CompactForceRatio != orig.Agent.CompactForceRatio {
+		t.Errorf("compact_force_ratio = %v, want %v", got.Agent.CompactForceRatio, orig.Agent.CompactForceRatio)
+	}
 	if got.Agent.SystemPrompt != orig.Agent.SystemPrompt {
 		t.Errorf("system_prompt mismatch:\n got %q\nwant %q", got.Agent.SystemPrompt, orig.Agent.SystemPrompt)
 	}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -20,6 +20,9 @@ max_steps   = 25
 temperature = 0.0
 auto_plan   = "ask"   # off|ask|on; ask/on auto-enter plan mode for complex tasks
 # auto_plan_classifier = "deepseek-flash"   # optional; only used for borderline tasks
+soft_compact_ratio  = 0.5   # notice only; keeps the cache-first prefix intact
+compact_ratio       = 0.8   # try compacting when prompt reaches this fraction
+compact_force_ratio = 0.9   # force compacting at this high-water mark
 # planner_model = "mimo-pro"   # optional: enable two-model collaboration
 # subagent_model = "deepseek-pro"   # optional default for runAs=subagent skills
 # subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }   # per-skill overrides


### PR DESCRIPTION
Rebase of #2406 (by @SivanCola) onto current main-v2 (after #3050/#3057 landed). The branch had drifted; I applied the net diff and re-merged the compaction core by hand, since `compact()` had diverged on both sides.

## What it does
- **Soft ratio (0.5)** — between the soft mark and the trigger, emit a one-shot notice instead of compacting, so the cache-stable prefix is kept intact while the user is warned.
- **Force ratio (0.9)** — a high-water mark that compacts even a low-value region.
- **Fold economics** — skip the summarizer round-trip when the foldable region is too small to pay for the extra latency/cost (bypassed by `force` and by manual `/compact`).

## Rebase notes (signature reconciliation)
- main-v2 had `compact(ctx, trigger, instructions)`; this PR had `compact(ctx, force bool)`. Unified to **`compact(ctx, trigger, instructions, force)`** so the force flag coexists with the existing `/compact <focus>` text + PreCompact-hook path and the cache-diagnostics rewrite tracking from #3057.
- Kept main-v2's **token-budgeted tail** (`planCompaction`, parameterized with a min-message count for the single-large-message fallback) rather than reverting to the PR's message-count tail, and kept main-v2's more detailed summary prompt.
- `maybeCompact` now layers the soft-notice and force logic on top of main-v2's anti-re-compaction `compactStuck` latch.
- Adapted the threshold tests to the token-budgeted tail (a single large old message folds 1→1: the summary is installed but the message count is unchanged).

Local: `go build ./...`, `go vet`, and `go test ./internal/agent ./internal/config ./internal/boot ./internal/cli ./internal/control` all green.

Closes #2406
