### PR TITLE
fix(e2ebench): truncate on a UTF-8 rune boundary in truncateFor

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type diffOpts struct {
@@ -561,10 +562,19 @@ func gitOut(repo string, args ...string) string {
 func truncate(s string) string { return truncateFor(s, 12000) }
 
 func truncateFor(s string, max int) string {
-	if len(s) <= max {
+	if max <= 0 || len(s) <= max {
 		return s
 	}
-	return s[:max] + "\n…(truncated)…"
+	// Avoid splitting a multi-byte UTF-8 rune — `s[:max]` would otherwise
+	// drop the last 1–3 bytes of a rune and corrupt the surrounding
+	// characters when the markdown report is rendered with the same
+	// font. `utf8.RuneStart` returns true only on the first byte of a
+	// rune, so walk back until the cut lands on one.
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "\n…(truncated)…"
 }
 
 func tail(s string, n int) string {


### PR DESCRIPTION
## Summary

`truncateFor` is the e2e bench's "cap a long output at N bytes and add a `…(truncated)…` marker" helper. The old shape did `s[:max]` blindly, which can drop the last 1–3 bytes of a multi-byte UTF-8 rune.

A test failure that ends in a CJK character (e.g. a Go identifier, a file path with non-ASCII, or a log message) would land mid-rune in the truncated slice. The markdown renderer then sees invalid UTF-8 and either substitutes replacement characters or refuses to render the line entirely — a cosmetic glitch that hides the last meaningful line of the test output.

## Fix

Walk back from `max` until the cut lands on a rune-start byte. `utf8.RuneStart` returns true only on the first byte of a UTF-8 sequence, so a single backward scan is all that's needed.

Also guard against `max <= 0` — the old shape returned `s[:max]` for negative max, which is the entire string, silently swallowing the "truncate" intent.

## Test plan

* [x] `go build ./…` passes.