### PR TITLE
fix(e2ebench): preserve source file mode in copyFile

### DIFF
--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -347,11 +347,23 @@ func copyFile(src, dst string) error {
 		return err
 	}
 	defer in.Close()
-	out, err := os.Create(dst)
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, info.Mode().Perm())
 	if err != nil {
 		return err
 	}
 	defer out.Close()
-	_, err = io.Copy(out, in)
-	return err
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	// os.Create / O_CREATE default to 0666 (umask'd). A read-only seed
+	// (e.g. a fixture 0400 marker file) would otherwise become writable
+	// in the workdir, which then looks like a permissions change to
+	// `git status` even though we never wrote to it. Mirror the source
+	// mode explicitly so a seed's executable bit / read-only bit
+	// survive the copy.
+	return os.Chmod(dst, info.Mode().Perm())
 }


### PR DESCRIPTION
## Summary

The seed workdir the bench copies into a per-task temp dir sometimes carries intentional permissions — a read-only fixture marker, an executable bit on a shell script, a 0600 secret. The old `copyFile` shape used `os.Create` (which sets `O_CREATE|O_WRONLY|O_TRUNC`, defaulting to mode 0666 umask'd) and never touched the mode again.

A seed 0400 file copied into the workdir would become 0644, looking like a permission change to `git status` even though we never wrote to it. A 0600 secret would silently widen to 0644, which then leaks to any `go test` child process inheriting the workdir.

## Fix

`os.OpenFile` with `info.Mode().Perm()` so the destination's mode is exact, and re-apply the mode via `os.Chmod` as a belt-and-suspenders.

No behavior change for seeds with default mode; strictly a permission-preservation guarantee for non-default modes.

## Test plan

* [x] `go build ./…` passes.