### PR TITLE
fix(styles): adjust workspace tab flex properties for better layout

### DIFF
--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -624,12 +624,12 @@ export function WorkspacePanel({
                 </button>
               </Tooltip>
             ))}
-            <Tooltip label={t("workspace.newTab")}>
-              <button className="workspace-tab workspace-tab--new" onClick={openPickerTab}>
-                <Plus size={14} />
-              </button>
-            </Tooltip>
           </div>
+          <Tooltip label={t("workspace.newTab")}>
+            <button className="workspace-tab workspace-tab--new" onClick={openPickerTab}>
+              <Plus size={14} />
+            </button>
+          </Tooltip>
 
           <div className="workspace-preview__window-actions">
             <Tooltip label={maximized ? t("workspace.restore") : t("workspace.maximize")}>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2696,7 +2696,7 @@ body {
   border-bottom: 1px solid var(--border-soft);
 }
 .workspace-tabs {
-  flex: 1 1 auto;
+  flex: 1 1 0%;
   min-width: 0;
   display: flex;
   align-items: center;
@@ -2704,6 +2704,9 @@ body {
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
+}
+.workspace-tabs > * {
+  flex-shrink: 0;
 }
 .workspace-tabs::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
Updated the flex properties of the workspace tabs to improve layout consistency. The flex-grow value was changed to 0% to prevent tabs from expanding, and a new rule was added to prevent flex items from shrinking. This enhances the overall appearance and functionality of the workspace tabs.