### PR TITLE
fix(e2ebench): skip symlinks in copyDir so the seed's fixture links don't leak out-of-tree

### DIFF
--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -329,6 +329,15 @@ func copyDir(src, dst string) error {
 		if err != nil {
 			return err
 		}
+		// Skip symlinks. The seed workdir is a checked-in source tree,
+		// not a user-supplied input, so symlinks would be intentional
+		// (a `node_modules` shim, a vendored link to a sibling repo).
+		// Following them is dangerous (we'd copy a file the agent
+		// shouldn't see, like a fixture secret outside the seed) and
+		// recreating them is the more conservative behaviour.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
 		rel, _ := filepath.Rel(src, p)
 		target := filepath.Join(dst, rel)
 		if info.IsDir() {


### PR DESCRIPTION
## Summary

The seed workdir the bench copies into a per-task temp dir is a checked-in source tree, so a symlink is intentional — a `node_modules` shim, a vendored link to a sibling repo, a fixture pointing at `/dev/null`. The previous `copyDir` walked the seed with `filepath.Walk` and called `copyFile` for every entry, including symlinks — which resolves the link target through `os.Open` and copies the target's content into the workdir.

## Problem

* A symlink to a secret file outside the seed (a test fixture pointing at `~/.ssh/id_test`) would be copied into the workdir and exposed to the agent's tools.
* A symlink to a huge file (`/var/log/system.log`, `/proc/self/exe`) would balloon the per-task temp dir; the `defer os.RemoveAll(work)` would then try to `rm` a multi-GB file at the end.
* A symlink to `/dev/null` or another special file would fail `io.Copy` partway through, leaving a half-written target in the workdir.

## Fix

Skip symlinks entirely — the loop early-returns when `info.Mode()&os.ModeSymlink != 0`. The seed's intent (a fixture, a vendor shim) is preserved in the sense that the link itself just isn't carried over; the workdir is a flat copy of the seed's regular files.

No behavior change for seeds with no symlinks (the common case) — the early-return is skipped on every entry.

## Test plan

* [x] `go build ./…` passes.