### PR TITLE
fix(e2ebench): distinguish "suite dir missing" from "suite dir empty" in the error message

### DIFF
--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -76,7 +76,19 @@ func main() {
 		os.Exit(1)
 	}
 	if len(tasks) == 0 {
-		fmt.Fprintln(os.Stderr, "no tasks found under", filepath.Join(*suite, "tasks"))
+		// Distinguish \"suite dir is missing\" from \"suite dir is empty\"
+		// — the former is a config error (the user pointed -suite at a
+		// path that doesn't exist; -suite's default of benchmarks/e2e
+		// is missing because the bench is running from a stale
+		// checkout). The latter is \"you haven't written any tasks
+		// yet\" — both are exit-1, but the message tells the user
+		// which to fix.
+		dir := filepath.Join(*suite, "tasks")
+		if _, statErr := os.Stat(dir); statErr != nil {
+			fmt.Fprintf(os.Stderr, "no tasks found under %s: %v\n", dir, statErr)
+		} else {
+			fmt.Fprintf(os.Stderr, "no tasks found under %s (the directory exists but contains no task.toml files)\n", dir)
+		}
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary

When the suite directory has no tasks, the bench exits 1 with a single message that doesn't tell the user whether the directory is missing or just empty.

## Fix

Split the empty-tasks case into two:

* `os.Stat` fails (ENOENT for a wrong `-suite` flag, EACCES for a permissions problem) → include the underlying error.
* Dir exists but is empty (fresh checkout, no tasks added yet) → say so explicitly.

Both paths still exit 1. The shape of the change is diagnostic-only.

## Test plan

* [x] `go build ./…` passes.