### PR TITLE
fix(e2ebench): use digit-only cut when parsing the hunk-header new-side start line

### DIFF
--- a/cmd/e2ebench/diff.go
+++ b/cmd/e2ebench/diff.go
@@ -409,12 +409,17 @@ func changedLineSet(repo, base string, srcFiles []string) map[string]map[int]boo
 			out[file] = map[int]bool{}
 		case strings.HasPrefix(ln, "@@"):
 			// @@ -a,b +c,d @@ — start collecting at new-side line c.
+			// Digit-only cut: malformed headers (e.g. `@@ +abc @@`) fail closed.
 			if plus := strings.Index(ln, "+"); plus >= 0 {
 				num := ln[plus+1:]
-				if sp := strings.IndexAny(num, ", "); sp >= 0 {
-					num = num[:sp]
+				end := len(num)
+				for i := 0; i < len(num); i++ {
+					if num[i] < '0' || num[i] > '9' {
+						end = i
+						break
+					}
 				}
-				_, _ = fmt.Sscanf(num, "%d", &newLine)
+				_, _ = fmt.Sscanf(num[:end], "%d", &newLine)
 			}
 		case strings.HasPrefix(ln, "+") && !strings.HasPrefix(ln, "+++"):
 			if file != "" {


### PR DESCRIPTION
## Summary

`changedLineSet` parses the `@@ -a,b +c,d @@` hunk header to learn the new-side starting line. The old shape used a comma-OR-space cut that silently mis-parses malformed headers — the next `+` line then registers under line 0, which is invalid.

## Fix

Replace the comma-OR-space cut with a digit-only cut. Malformed headers now fail closed (previous newLine kept, no invalid line 0 attribution). The happy paths produce the same integer they did before; the fix is strictly for the malformed case.

## Test plan

* [x] `go build ./…` passes.