### PR TITLE
fix(e2ebench): surface JSON marshal + write errors instead of silently dropping them

### DIFF
--- a/cmd/e2ebench/main.go
+++ b/cmd/e2ebench/main.go
@@ -102,8 +102,15 @@ func main() {
 		fmt.Print(report)
 	}
 	if *outJSON != "" {
-		b, _ := json.MarshalIndent(results, "", "  ")
-		_ = os.WriteFile(*outJSON, b, 0o644)
+		b, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "marshal json:", err)
+			os.Exit(1)
+		}
+		if err := os.WriteFile(*outJSON, b, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, "write json:", err)
+			os.Exit(1)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The bench's `-json` write path uses `json.MarshalIndent` + `os.WriteFile` and discards both errors. A marshal failure or a write failure is silently swallowed: the bench exits 0, the markdown report goes out, and the JSON file is either missing or contains `null`.

## Fix

Surface both errors on stderr and exit 1, matching the markdown-report write path.

## Test plan

* [x] `go build ./…` passes.