### PR TITLE
fix(desktop): guard null levels and text/reasoning/args in .length calls

### DIFF
--- a/desktop/frontend/src/components/EffortSwitcher.tsx
+++ b/desktop/frontend/src/components/EffortSwitcher.tsx
@@ -14,7 +14,7 @@ export function EffortSwitcher({
 }) {
   const t = useT();
   const [open, setOpen] = useState(false);
-  if (!effort?.supported || effort.levels.length === 0) return null;
+  if (!effort?.supported || (effort.levels ?? []).length === 0) return null;
 
   const current = effort.current || "auto";
   const pick = (level: string) => {

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -12,9 +12,9 @@ function scrollVersion(items: Item[]): string {
     .map((it) => {
       switch (it.kind) {
         case "assistant":
-          return `${it.id}:a:${it.text.length}:${it.reasoning.length}:${it.streaming ? 1 : 0}`;
+          return `${it.id}:a:${it.text?.length ?? 0}:${it.reasoning?.length ?? 0}:${it.streaming ? 1 : 0}`;
         case "tool":
-          return `${it.id}:t:${it.name}:${it.status}:${it.args.length}:${it.output?.length ?? 0}:${it.error?.length ?? 0}:${it.truncated ? 1 : 0}`;
+          return `${it.id}:t:${it.name}:${it.status}:${it.args?.length ?? 0}:${it.output?.length ?? 0}:${it.error?.length ?? 0}:${it.truncated ? 1 : 0}`;
         default:
           return `${it.id}:${it.kind}`;
       }
@@ -82,7 +82,7 @@ export function Transcript({
       el.scrollTop = el.scrollHeight;
     });
     return () => cancelAnimationFrame(id);
-  }, [contentVersion, live?.text.length, live?.reasoning.length]);
+  }, [contentVersion, live?.text?.length ?? 0, live?.reasoning?.length ?? 0]);
 
   useEffect(() => {
     const el = scrollRef.current;


### PR DESCRIPTION
EffortSwitcher checked effort?.supported but then accessed effort.levels.length without a null guard — a nil []string from Go JSON serialization arrives as null and throws "Cannot read properties of null (reading 'length')".

The same class of bug existed in Transcript's scrollVersion (items may carry null text/reasoning/args from wire events) and in the useEffect dependency array where live?.text.length used single-level optional chaining.