### PR TITLE
feat(desktop): settings search input (section-level filter)

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -400,6 +400,8 @@ export const en = {
   "settings.language": "Language",
   "settings.langAuto": "Auto (system)",
   "settings.config": "config: {path}",
+  "settings.searchPlaceholder": "Filter settings…",
+  "settings.noSectionMatch": "No setting matches “{q}”.",
 
   // todo bar
   "todo.title": "To-dos",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -401,6 +401,8 @@ export const zh: Record<DictKey, string> = {
   "settings.language": "语言",
   "settings.langAuto": "自动（跟随系统）",
   "settings.config": "配置文件：{path}",
+  "settings.searchPlaceholder": "筛选设置…",
+  "settings.noSectionMatch": "没有匹配 “{q}” 的设置。",
 
   // 待办栏
   "todo.title": "待办",


### PR DESCRIPTION
The settings drawer has grown to six sections (Models / Permissions / Sandbox / Agent / Appearance / Updates). Finding a specific field meant scrolling the whole list. Add a search input below the drawer header that hides sections whose title doesn't match the query.

The match is section-level (case-insensitive substring). Per-field matching is a follow-up: it needs a section schema exporting its search text, which the section components don't yet expose.

When the query hides every section, an empty-state message names the query so the user knows the filter is the reason (not a broken config).