### PR TITLE
feat(desktop): in-app notification center (OS side is a follow-up)

### DIFF
--- a/desktop/frontend/src/components/NotificationCenter.tsx
+++ b/desktop/frontend/src/components/NotificationCenter.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react";
+import { Bell, X } from "lucide-react";
+import { clear, markAllRead, snapshot, subscribe, type Notification, unread } from "../lib/notificationCenter";
+
+// NotificationCenter is the in-app drawer of recent notifications.
+// The trigger chip sits in the topbar (a small Bell icon) and shows
+// an unread dot when unread() > 0. Opening the drawer calls
+// markAllRead() and renders the snapshot in reverse-chronological
+// order. Each entry is dismissable; a "Clear all" link at the foot
+// empties the store.
+//
+// The list is reactive: subscribe() is called once on mount, and
+// the local copy is replaced on every push. The drawer doesn't poll.
+//
+// We use real relative time formatting ('3m ago', '2h ago') without
+// a date-fns dep — the formatter is a 12-line helper that handles
+// the only two cases that matter in this UI (sub-minute and sub-day).
+export function NotificationCenter({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [list, setList] = useState<Notification[]>(snapshot());
+  useEffect(() => subscribe(setList), []);
+  // Mark all read on open; the unread dot in the trigger chip
+  // disappears immediately.
+  useEffect(() => {
+    if (open) markAllRead();
+  }, [open]);
+
+  if (!open) return null;
+  return (
+    <div className="drawer-backdrop" onClick={onClose} role="presentation">
+      <aside className="drawer" role="dialog" aria-modal="true" aria-label="Notifications" onClick={(e) => e.stopPropagation()}>
+        <header className="drawer__head">
+          <div className="drawer__title">Notifications</div>
+          <span className="drawer__spacer" />
+          {list.length > 0 && (
+            <button type="button" className="chip" onClick={() => clear()}>
+              Clear all
+            </button>
+          )}
+          <button type="button" className="chip" onClick={onClose} aria-label="Close notifications">
+            <X size={13} />
+          </button>
+        </header>
+        <div className="drawer__body notif">
+          {list.length === 0 ? (
+            <div className="notif__empty">No notifications yet.</div>
+          ) : (
+            <ul className="notif__list">
+              {list.map((n) => (
+                <li key={n.id} className={`notif__item notif__item--${n.level}`}>
+                  <div className="notif__head">
+                    <Bell size={11} aria-hidden="true" />
+                    <span className="notif__title">{n.title}</span>
+                    {n.source && <span className="notif__source">{n.source}</span>}
+                    <span className="notif__spacer" />
+                    <span className="notif__ago">{formatAgo(n.at)}</span>
+                  </div>
+                  {n.body && <div className="notif__body">{n.body}</div>}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+// NotificationBell is the topbar trigger chip. It shows an unread
+// dot when unread() > 0. Subscribes to the store so the dot updates
+// without the parent re-rendering.
+export function NotificationBell({ onClick }: { onClick: () => void }) {
+  const [n, setN] = useState<number>(unread());
+  useEffect(() => subscribe(() => setN(unread())), []);
+  return (
+    <button
+      type="button"
+      className="chip chip--icon notif-bell"
+      onClick={onClick}
+      title="Notifications"
+      aria-label={`Notifications (${n} unread)`}
+    >
+      <Bell size={13} />
+      {n > 0 && <span className="notif-bell__dot" aria-hidden="true" />}
+    </button>
+  );
+}
+
+function formatAgo(at: number): string {
+  const ms = Date.now() - at;
+  if (ms < 60_000) return "just now";
+  const m = Math.floor(ms / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}

--- a/desktop/frontend/src/lib/notificationCenter.ts
+++ b/desktop/frontend/src/lib/notificationCenter.ts
@@ -1,0 +1,106 @@
+// notificationCenter is the in-app side of the desktop's notification
+// surface. Long-running agent events (idle, plan approval needed,
+// update available, plugin hot-add, job done) deserve a visible
+// signal, and the OS notification center is the right home for them,
+// but the kernel doesn't yet expose a Notify() binding. This module
+// gives the rest of the app a single store for in-app notifications
+// so when the binding lands, the only change is "also dispatch
+// runtime.MessageDialog" alongside the in-app emit.
+//
+// The store is a tiny pub-sub on top of a plain array. We avoid
+// pulling in a state library (Zustand, Jotai) for a 60-line feature.
+// Subscribers are React components: the NotificationCenter drawer
+// subscribes on mount and unsubscribes on unmount.
+//
+// The store caps at MAX (50 by default). New notifications push
+// older ones out; the cap is high enough that a busy day of agent
+// runs (maybe 30 notifications) stays in-memory. We don't persist
+// across reloads — reloads are rare and the user can re-trigger
+// the source if they need to.
+
+export type NotificationLevel = "info" | "warn" | "error";
+
+export interface Notification {
+  id: string;
+  level: NotificationLevel;
+  title: string;
+  body: string;
+  // at is the wall-clock ms; used to display '3h ago' in the drawer.
+  at: number;
+  // source is a short label (e.g. 'agent', 'update', 'plugin') the
+  // drawer uses to group / filter. Optional.
+  source?: string;
+  // read is flipped the first time the user opens the drawer; the
+  // unread count in the topbar uses this to render a small dot.
+  read: boolean;
+}
+
+type Listener = (list: Notification[]) => void;
+
+const MAX = 50;
+let store: Notification[] = [];
+const listeners = new Set<Listener>();
+
+function emit() {
+  for (const l of listeners) l(store);
+}
+
+// push adds a notification to the store. Identical-`id` events (the
+// agent emits "agent:idle" once per turn) are deduped — the existing
+// entry's at is refreshed and read flipped back to false, so the
+// user gets a "fresh" signal but the list doesn't grow.
+export function push(n: Omit<Notification, "id" | "at" | "read"> & { id?: string }): void {
+  const id = n.id ?? `${n.source ?? "app"}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const existing = store.find((x) => x.id === id);
+  if (existing) {
+    existing.at = Date.now();
+    existing.read = false;
+    existing.body = n.body;
+  } else {
+    store = [{ ...n, id, at: Date.now(), read: false }, ...store];
+    if (store.length > MAX) store.length = MAX;
+  }
+  emit();
+}
+
+// markAllRead flips every entry's read flag; called when the user
+// opens the drawer.
+export function markAllRead(): void {
+  let changed = false;
+  for (const n of store) {
+    if (!n.read) {
+      n.read = true;
+      changed = true;
+    }
+  }
+  if (changed) emit();
+}
+
+// clear wipes the store. Useful for a 'Clear all' button in the
+// drawer; also handy for tests.
+export function clear(): void {
+  store = [];
+  emit();
+}
+
+// subscribe registers a listener. Returns the unsubscribe function.
+export function subscribe(l: Listener): () => void {
+  listeners.add(l);
+  l(store);
+  return () => {
+    listeners.delete(l);
+  };
+}
+
+// unread returns the count of unread entries. Cheap O(n) over at
+// most 50 items.
+export function unread(): number {
+  let c = 0;
+  for (const n of store) if (!n.read) c++;
+  return c;
+}
+
+// snapshot is a defensive copy; used by the drawer on each render.
+export function snapshot(): Notification[] {
+  return store.slice();
+}


### PR DESCRIPTION
Long-running agent events (idle, plan approval, update available, plugin hot-add, background job done) deserve a visible signal. The kernel doesn't yet expose a `Notify()` binding for the OS notification center, but we can stand up the in-app half of the contract now so the rest of the app has a single emit point when the binding lands.

Add `lib/notificationCenter.ts`: a tiny pub-sub on a 50-entry ring of Notification records. Identical-id events are deduped. Add `components/NotificationCenter.tsx` with a drawer and a topbar bell with an unread dot.

The follow-up is a kernel-side `App.Notify(title, body, level)` Wails binding that dispatches `runtime.MessageDialog` / OS notification alongside the in-app push.