### PR TITLE
feat(desktop): substring filter for MemoryPanel docs and facts

### DIFF
--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -1,5 +1,7 @@
+
 import { ChevronDown, ChevronRight, Search, Trash2 } from "lucide-react";
 import { useMemo, useRef, useState, type ReactNode } from "react";
+
 import { useT } from "../lib/i18n";
 import type { MemoryFact, MemoryView } from "../lib/types";
 import { ResizableDrawer } from "./ResizableDrawer";
@@ -53,12 +55,19 @@ export function MemoryPanel({
   const [editingPath, setEditingPath] = useState<string | null>(null);
   const [draft, setDraft] = useState("");
   const [busy, setBusy] = useState(false);
+
   const [highlight, setHighlight] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [typeFilter, setTypeFilter] = useState("all");
   const [expanded, setExpanded] = useState<string | null>(null);
   const [confirmForget, setConfirmForget] = useState<string | null>(null);
   const factRefs = useRef<Record<string, HTMLElement | null>>({});
+
+  // Filter input — a single substring search across docs and facts. The
+  // substring is case-insensitive and matches anywhere in the body or the
+  // path; an empty string shows everything. The filter is purely frontend
+  // (no kernel round-trip) so it's instant and reversible.
+  const [filter, setFilter] = useState("");
 
   const facts = view?.facts ?? [];
   const factNames = useMemo(() => new Set(facts.map((f) => f.name)), [facts]);
@@ -67,17 +76,22 @@ export function MemoryPanel({
     [facts],
   );
   const normalizedQuery = query.trim().toLowerCase();
+  const normalizedFilter = filter.trim().toLowerCase();
   const filteredFacts = useMemo(
     () =>
       facts.filter((f) => {
         if (typeFilter !== "all" && f.type !== typeFilter) return false;
+        if (normalizedFilter) {
+          const hay = [f.name, f.description, f.body].join(" ").toLowerCase();
+          if (!hay.includes(normalizedFilter)) return false;
+        }
         if (!normalizedQuery) return true;
         return [displayTitle(f), f.name, f.description, f.type, f.body]
           .join(" ")
           .toLowerCase()
           .includes(normalizedQuery);
       }),
-    [facts, normalizedQuery, typeFilter],
+    [facts, normalizedQuery, normalizedFilter, typeFilter],
   );
 
   const scrollToFact = (name: string) => {
@@ -142,6 +156,13 @@ export function MemoryPanel({
       setBusy(false);
     }
   };
+
+  const filteredDocs = useMemo(() => {
+    if (!view) return [];
+    const q = filter.trim().toLowerCase();
+    if (!q) return view.docs;
+    return view.docs.filter((d) => d.body.toLowerCase().includes(q) || d.path.toLowerCase().includes(q));
+  }, [view, filter]);
 
   const scopes = view?.scopes ?? [];
   // Default the scope selector to "project" when present, else the first option.
@@ -405,10 +426,18 @@ export function MemoryPanel({
             {/* Doc files — editable in place. */}
             <section className="mem-section">
               <div className="mem-section__title">{t("memory.instructionFiles")}</div>
-              {view.docs.length === 0 && (
-                <div className="mem-empty">{t("memory.noDocs")}</div>
+              <input
+                className="mem-input mem-filter"
+                placeholder={t("memory.filterPlaceholder")}
+                value={filter}
+                onChange={(e) => setFilter(e.target.value)}
+                spellCheck={false}
+                aria-label={t("memory.filterPlaceholder")}
+              />
+              {filteredDocs.length === 0 && (
+                <div className="mem-empty">{filter ? t("memory.noFilterMatch") : t("memory.noDocs")}</div>
               )}
-              {view.docs.map((d) => {
+              {filteredDocs.map((d) => {
                 const editing = editingPath === d.path;
                 return (
                   <div className="mem-doc" key={d.path}>
@@ -455,6 +484,31 @@ export function MemoryPanel({
                   </div>
                 );
               })}
+            </section>
+
+
+
+            {/* Saved auto-memories — read-only; the model owns these. */}
+            <section className="mem-section">
+              <div className="mem-section__title">{t("memory.savedMemories")}</div>
+              {filteredFacts.length === 0 ? (
+                <div className="mem-empty">{filter ? t("memory.noFilterMatch") : t("memory.noFacts")}</div>
+              ) : (
+                filteredFacts.map((f) => (
+                  <div className="mem-fact" key={f.name} title={f.body}>
+                    <span className={`badge badge--${f.type}`}>{f.type}</span>
+                    <div className="mem-fact__text">
+                      <div className="mem-fact__name">{f.name}</div>
+                      <div className="mem-fact__desc">{f.description}</div>
+                    </div>
+                  </div>
+                ))
+              )}
+              {view.storeDir && (
+                <div className="mem-hint" title={view.storeDir}>
+                  {t("memory.storedUnder", { dir: view.storeDir })}
+                </div>
+              )}
             </section>
           </div>
         )}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -304,9 +304,13 @@ export const en = {
   "memory.missingLinks": "{n} missing linked memory",
   "memory.appliesNow": "Changes apply in this session.",
   "memory.storedUnder": "stored under {dir}",
+
   "memory.forget": "Forget",
   "memory.confirmForget": "Confirm forget",
   "memory.deadLink": "No memory named “{name}”",
+
+  "memory.filterPlaceholder": "Filter docs and facts…",
+  "memory.noFilterMatch": "Nothing matches the current filter.",
 
   // settings drawer
   "settings.title": "Settings",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -305,9 +305,14 @@ export const zh: Record<DictKey, string> = {
   "memory.missingLinks": "{n} 条互链目标不存在",
   "memory.appliesNow": "变更会在当前会话生效。",
   "memory.storedUnder": "存放于 {dir}",
+
   "memory.forget": "删除",
   "memory.confirmForget": "确认删除",
   "memory.deadLink": "没有名为「{name}」的记忆",
+
+  "memory.filterPlaceholder": "筛选指令文件与记忆…",
+  "memory.noFilterMatch": "没有匹配当前筛选的内容。",
+
 
   // 设置抽屉
   "settings.title": "设置",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5541,6 +5541,7 @@ body {
   color: var(--fg);
   background: var(--hover);
 }
+
 .composer__pasted {
   display: flex;
   flex-direction: column;
@@ -5881,4 +5882,14 @@ body {
 .onboarding__skip:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+
+
+/* Memory filter input: a full-width mem-input variant that sits below
+   the section title. The existing mem-input already has a 28px height
+   and the right border tokens; this just sets margin so it doesn't
+   crowd the doc list. */
+.mem-filter {
+  margin: 4px 0 8px;
+  width: 100%;
+
 }


### PR DESCRIPTION
The memory drawer grows with usage — dozens of saved facts and nested REASONIX.md docs pile up quickly. There was no way to find a specific fact without scrolling the whole list.

Add a single full-width filter input below the 'Instruction files' section title that does case-insensitive substring matching across doc bodies and paths, and fact bodies / names / descriptions. The filter is purely frontend (no kernel round-trip) so it's instant and reversible.

The two empty-state messages are aware of the filter: 'no docs' shows when the list is genuinely empty, 'no filter match' shows when the list is non-empty but the filter prunes it.