### PR TITLE
chore: add CODEOWNERS scaffolding for core-path review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,3 @@
-# Code owners — governs required review on core paths.
-#
-# Takes effect once a main-v2 ruleset enables "Require review from Code Owners".
-# Paths not listed here have no required owner, so the maintainers can merge them
-# freely; the core-architecture paths below require the repo owner's review.
-
-# --- Maintainers: paste the two GitHub usernames to auto-request them on every PR ---
-# *                     @USERNAME1 @USERNAME2
-
-# --- Core architecture — owner review required ---
-/internal/agent/        @esengine
-/internal/provider/     @esengine
-/internal/netclient/    @esengine
-/internal/serve/        @esengine
-/internal/config/       @esengine
-/cmd/e2ebench/          @esengine
-/.github/               @esengine
+# Every pull request requires review from the maintainer.
+# The repo owner is optional (can review anything, but is not required).
+* @SivanCola

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Code owners — governs required review on core paths.
+#
+# Takes effect once a main-v2 ruleset enables "Require review from Code Owners".
+# Paths not listed here have no required owner, so the maintainers can merge them
+# freely; the core-architecture paths below require the repo owner's review.
+
+# --- Maintainers: paste the two GitHub usernames to auto-request them on every PR ---
+# *                     @USERNAME1 @USERNAME2
+
+# --- Core architecture — owner review required ---
+/internal/agent/        @esengine
+/internal/provider/     @esengine
+/internal/netclient/    @esengine
+/internal/serve/        @esengine
+/internal/config/       @esengine
+/cmd/e2ebench/          @esengine
+/.github/               @esengine


### PR DESCRIPTION
Scaffolding for the maintainer hand-off. Two parts:

- **`v*` tag ruleset** — already created (ruleset id 17270315, active). Only repo admins can create/update/delete `v*` tags, so releases stay with the owner even though the new maintainers get Write.
- **`.github/CODEOWNERS`** (this PR) — core architecture paths (`internal/agent`, `internal/provider`, `internal/netclient`, `internal/serve`, `internal/config`, `cmd/e2ebench`, `.github`) require owner review. Everything else has no required owner, so the maintainers merge freely.

**To finish:** paste the two maintainers' GitHub usernames into the commented `*` line (so they're auto-requested on every PR), then merge.

Note: CODEOWNERS only *enforces* once a `main-v2` ruleset has **Require review from Code Owners** enabled (plus Require PR + status checks). Say the word and I'll add that branch ruleset too.
