### PR TITLE
fix(config): disable auto plan by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ default_model = "deepseek-flash"   # executor; set [agent].planner_model to add 
 # planner_model = "mimo-pro"          # optional low-frequency planner
 # subagent_model = "deepseek-pro"     # optional default for runAs=subagent skills
 # subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
-auto_plan = "ask"                  # off|ask|on; complex chat tasks start in plan mode
+auto_plan = "off"                  # off|ask|on; ask/on auto-enter plan mode for complex chat tasks
 # auto_plan_classifier = "deepseek-flash"   # optional; only borderline tasks call it
 
 [[providers]]
@@ -247,9 +247,10 @@ Subagent skills inherit the executor model by default. Set `subagent_model` to
 run them on another configured model, or use `subagent_models` to override only
 specific skills such as `review` or `security_review`.
 
-For interactive frontends, `agent.auto_plan = "ask"` makes complex-looking tasks
-enter plan mode automatically: Reasonix first drafts a read-only plan, then waits
-for approval before editing or running side-effecting commands. `auto_plan_classifier`
+For interactive frontends, `agent.auto_plan = "off"` keeps plan mode user-driven
+by default. Set it to `ask` or `on` if you want complex-looking tasks to enter
+plan mode automatically: Reasonix first drafts a read-only plan, then waits for
+approval before editing or running side-effecting commands. `auto_plan_classifier`
 can name a cheap provider such as `deepseek-flash`; it is only called for
 borderline inputs and falls back to the heuristic if classification fails.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ default_model = "deepseek-flash"   # 执行器；设 [agent].planner_model 可�
 # planner_model = "mimo-pro"          # 可选的低频规划器
 # subagent_model = "deepseek-pro"     # runAs=subagent skill 的默认模型
 # subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
-auto_plan = "ask"                  # off|ask|on；复杂聊天任务自动进入计划模式
+auto_plan = "off"                  # off|ask|on；ask/on 让复杂聊天任务自动进入计划模式
 # auto_plan_classifier = "deepseek-flash"   # 可选；只在边界任务上调用
 
 [[providers]]
@@ -227,8 +227,9 @@ planner_model = "deepseek-pro"   # 作为低频规划器
 Subagent skills 默认继承执行器模型。设置 `subagent_model` 可让它们统一走另一个已配置
 模型；设置 `subagent_models` 则只覆盖 `review`、`security_review` 等指定 skill。
 
-交互式前端中，`agent.auto_plan = "ask"` 会让看起来复杂的任务自动进入 plan
-mode：Reasonix 先只读生成计划，待用户批准后才编辑文件或执行有副作用的命令。
+交互式前端中，`agent.auto_plan = "off"` 会让计划模式默认保持用户手动触发。
+如果设为 `ask` 或 `on`，看起来复杂的任务会自动进入 plan mode：Reasonix
+先只读生成计划，待用户批准后才编辑文件或执行有副作用的命令。
 `auto_plan_classifier` 可以指定便宜的 provider，例如 `deepseek-flash`；它只在边界输入上调用，分类失败会回退到启发式规则。
 
 ## 架构

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -546,7 +546,7 @@ func Default() *Config {
 			// compaction, not by a round count. Set a positive agent.max_steps only
 			// if you want a hard guard against runaway.
 			MaxSteps:          0,
-			AutoPlan:          "ask",
+			AutoPlan:          "off",
 			SoftCompactRatio:  0.5,
 			CompactRatio:      0.8,
 			CompactForceRatio: 0.9,

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -1,0 +1,9 @@
+package config
+
+import "testing"
+
+func TestDefaultAutoPlanOff(t *testing.T) {
+	if got := Default().Agent.AutoPlan; got != "off" {
+		t.Fatalf("default auto_plan = %q, want off", got)
+	}
+}

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -87,9 +87,9 @@ func RenderTOML(c *Config) string {
 	fmt.Fprintf(&b, "temperature = %s\n", formatFloat(c.Agent.Temperature))
 	autoPlan := c.Agent.AutoPlan
 	if autoPlan == "" {
-		autoPlan = "ask"
+		autoPlan = "off"
 	}
-	fmt.Fprintf(&b, "auto_plan   = %q   # off|ask|on; ask/on auto-enter plan mode for complex tasks\n", autoPlan)
+	fmt.Fprintf(&b, "auto_plan   = %q   # off|ask|on; off by default, ask/on auto-enter plan mode for complex tasks\n", autoPlan)
 	if c.Agent.AutoPlanClassifier != "" {
 		fmt.Fprintf(&b, "auto_plan_classifier = %q   # optional provider/model for borderline auto-plan decisions\n", c.Agent.AutoPlanClassifier)
 	} else {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -70,8 +70,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if got.Agent.Temperature != orig.Agent.Temperature {
 		t.Errorf("temperature = %v, want %v", got.Agent.Temperature, orig.Agent.Temperature)
 	}
-	if got.Agent.AutoPlan != "ask" {
-		t.Errorf("auto_plan = %q, want ask", got.Agent.AutoPlan)
+	if got.Agent.AutoPlan != "off" {
+		t.Errorf("auto_plan = %q, want off", got.Agent.AutoPlan)
 	}
 	if got.Agent.AutoPlanClassifier != "deepseek-flash" {
 		t.Errorf("auto_plan_classifier = %q, want deepseek-flash", got.Agent.AutoPlanClassifier)

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -18,7 +18,7 @@ guessing; keep changes minimal and correct; briefly summarize what you did."""
 # system_prompt_file = "prompts/system.md"   # overrides system_prompt when set
 max_steps   = 25
 temperature = 0.0
-auto_plan   = "ask"   # off|ask|on; ask/on auto-enter plan mode for complex tasks
+auto_plan   = "off"   # off|ask|on; ask/on auto-enter plan mode for complex tasks
 # auto_plan_classifier = "deepseek-flash"   # optional; only used for borderline tasks
 soft_compact_ratio  = 0.5   # notice only; keeps the cache-first prefix intact
 compact_ratio       = 0.8   # try compacting when prompt reaches this fraction


### PR DESCRIPTION
﻿## Summary

- disable automatic plan mode by default (`agent.auto_plan = "off"`)
- keep `ask` / `on` available for users who explicitly opt into auto-plan
- update English/Chinese docs and the example config to reflect the safer default
- add a default-config regression test so the default does not silently flip back

## Why

`auto_plan = "ask"` currently behaves like an automatic heuristic gate: simple prompts can still be pulled into plan mode because of prompt length or words inside quoted/source text. That makes plan mode feel surprising and difficult to avoid for non-mutating tasks such as translation, summarization, rewriting, or ordinary Q&A.

This PR takes the conservative path for #3137: keep plan mode user-driven by default, while preserving the existing opt-in behavior for users who want automatic planning.

## Validation

- `go test ./internal/config ./internal/control -count=1`
- `git diff --check`
