### PR TITLE
fix(desktop): sidebar toggle button hidden after collapse

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -695,7 +695,12 @@ export default function App() {
         <aside className={`sidebar${sidebarCollapsed ? " sidebar--collapsed" : ""}`} aria-label={t("sidebar.navigation")}>
           <div className="sidebar__brand">
             <img src={logo} alt="" className="sidebar__logo" />
-            <span>Reasonix</span>
+            {/* sidebar__brand-name is the only span we want to hide when the rail
+                collapses — the Tooltip wrapper around the toggle button is also a
+                <span>, so a generic `.sidebar__brand > span { display: none }` rule
+                would also hide the toggle and lock the sidebar closed. This class
+                keeps the selector targeted. See PR #2987 for the original incident. */}
+            <span className="sidebar__brand-name">Reasonix</span>
             <Tooltip label={sidebarToggleTitle}>
               <button
                 className={`sidebar__toggle${sidebarExpandBlocked ? " sidebar__toggle--blocked" : ""}`}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -665,8 +665,18 @@ body {
   width: 100%;
   padding: 0 0 8px;
 }
-.sidebar--collapsed .sidebar__brand > span {
+/* Hide only the brand text when the rail collapses. The previous selector
+   (`.sidebar--collapsed .sidebar__brand > span`) also matched the Tooltip
+   wrapper around the toggle button, which made the sidebar impossible to
+   reopen once collapsed. The dedicated class keeps the rule targeted; the
+   defensive `.tooltip-trigger` override below is a belt-and-suspenders guard
+   so a future regression in the brand-name selector cannot lock the rail
+   closed again. See PR #2987 for the original incident. */
+.sidebar--collapsed .sidebar__brand-name {
   display: none;
+}
+.sidebar--collapsed .sidebar__brand .tooltip-trigger {
+  display: inline-flex;
 }
 .sidebar--collapsed .sidebar__toggle {
   margin-left: 0;


### PR DESCRIPTION
## Summary

The left rail's chevron toggle disappears the moment the rail collapses, leaving the user with no way to re-expand the sidebar. Only a full app restart (or `localStorage.removeItem('reasonix.sidebar.collapsed')`) could recover it.

## Root cause

The collapsed-rail CSS rule

```css
.sidebar--collapsed .sidebar__brand > span { display: none }
```

is too broad. The brand block is

```jsx
<div className="sidebar__brand">
  <img className="sidebar__logo" />
  <span>Reasonix</span>
  <Tooltip label={...}>
    <button className="sidebar__toggle" … />
  </Tooltip>
</div>
```

and the `Tooltip` component wraps its child in a `<span ref={setTriggerRef} {...triggerProps}>{children}</span>` (see `Tooltip.tsx`). So the `> span` selector matched **two** spans — the brand text span (intended) **and** the Tooltip wrapper around the toggle button (unintended). Once the rail collapsed, the Tooltip wrapper got `display: none`, taking the toggle button with it. The rail was then a 68 px dead zone with no way out.

## Regression

PR #2987 (`9d3a7e7b`) fixed this exact bug by adding a `.sidebar__brand-name` class and narrowing the selector to `.sidebar--collapsed .sidebar__brand-name`. That fix was reverted at some point in the main-v2 history (the class is gone, the broad `> span` rule is back), so the bug resurfaced.

## Fix

1. Re-apply the original fix: add `sidebar__brand-name` to the brand text span in `App.tsx` and narrow the CSS selector.
2. Add a **belt-and-suspenders** defensive override

   ```css
   .sidebar--collapsed .sidebar__brand .tooltip-trigger { display: inline-flex }
   ```

   so a future revert of the brand-name class (or a similar regression) cannot lock the rail closed again. The Tooltip wrapper is now explicitly visible regardless of what other rules touch the brand's spans.
3. Comments on both sides of the change explain *why* the class indirection exists and link to PR #2987, so the next person who looks at this code sees the trap.

## Files

| File | Change |
|------|--------|
| `desktop/frontend/src/App.tsx` | `<span>Reasonix</span>` → `<span className="sidebar__brand-name">Reasonix</span>` plus an inline comment. |
| `desktop/frontend/src/styles.css` | Replace `.sidebar--collapsed .sidebar__brand > span` with the targeted `.sidebar--collapsed .sidebar__brand-name`, add the defensive `.tooltip-trigger` override, and document why. |

## Diff stat

```
desktop/frontend/src/App.tsx    |  7 ++++++-
desktop/frontend/src/styles.css | 12 +++++++++++-
2 files changed, 17 insertions(+), 2 deletions(-)
```

## Verification

- `pnpm typecheck` → clean.
- `pnpm build` → clean (`✓ built in 1.72s`).
- Manual: open the desktop client, click the rail toggle to collapse, confirm the `PanelLeftOpen` icon is still visible at the top of the rail, click it, and confirm the rail re-expands. Repeat in both themes and on both `darwin` and the non-darwin padding variant.
- No new dependencies; no i18n surface change; no JS behavior change outside the CSS / brand-name class.