### PR TITLE
fix(plan): clear and track approved plan todos

### DIFF
--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Check, ChevronDown, ChevronRight, Circle, CircleDot, RefreshCw, X } from "lucide-react";
 import { useT } from "../lib/i18n";
 import type { Todo } from "../lib/tools";
@@ -14,10 +14,17 @@ import { Tooltip } from "./Tooltip";
 export function TodoPanel({ todos, stale, onDismiss }: { todos: Todo[]; stale?: boolean; onDismiss: () => void }) {
   const t = useT();
   const [open, setOpen] = useState(true);
-  if (todos.length === 0) return null;
+  const currentRef = useRef<HTMLLIElement | null>(null);
 
   const done = todos.filter((t) => t.status === "completed").length;
   const current = todos.find((t) => t.status === "in_progress");
+
+  useEffect(() => {
+    if (!open) return;
+    currentRef.current?.scrollIntoView({ block: "nearest" });
+  }, [open, current?.content, current?.activeForm]);
+
+  if (todos.length === 0) return null;
 
   return (
     <div className="todobar">
@@ -50,6 +57,7 @@ export function TodoPanel({ todos, stale, onDismiss }: { todos: Todo[]; stale?: 
           {todos.map((t, i) => (
             <li
               key={i}
+              ref={t.status === "in_progress" ? currentRef : undefined}
               className={`todobar__item todobar__item--${t.status}${t.level ? " todobar__item--sub" : ""}`}
             >
               {t.status === "completed" ? (

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2242,6 +2242,13 @@ func approvalToolDetails(toolName string) (name, detail string) {
 // is truncated with a "+N more" footer so the bottom region stays compact.
 const todoPanelMaxRows = 8
 
+type todoPanelTodo struct {
+	Content    string `json:"content"`
+	Status     string `json:"status"`
+	ActiveForm string `json:"activeForm"`
+	Level      int    `json:"level"`
+}
+
 // renderTodoPanel renders the task list pinned above the input from the latest
 // todo_write call (m.todoArgs): a "Tasks done/total" header, completed items
 // dimmed/checked, the in-progress one highlighted (its activeForm if given),
@@ -2249,12 +2256,7 @@ const todoPanelMaxRows = 8
 // so the panel appears while work is outstanding and clears itself when finished.
 func (m chatTUI) renderTodoPanel() string {
 	var p struct {
-		Todos []struct {
-			Content    string `json:"content"`
-			Status     string `json:"status"`
-			ActiveForm string `json:"activeForm"`
-			Level      int    `json:"level"`
-		} `json:"todos"`
+		Todos []todoPanelTodo `json:"todos"`
 	}
 	if err := json.Unmarshal([]byte(m.todoArgs), &p); err != nil || len(p.Todos) == 0 {
 		return ""
@@ -2271,13 +2273,11 @@ func (m chatTUI) renderTodoPanel() string {
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s %s\n", accent("To-dos"), dim(fmt.Sprintf("%d/%d", done, len(p.Todos))))
-	shown := 0
-	for _, t := range p.Todos {
-		if shown >= todoPanelMaxRows {
-			b.WriteString(dim(fmt.Sprintf("  +%d more", len(p.Todos)-shown)) + "\n")
-			break
-		}
-		shown++
+	start, end := todoPanelWindow(p.Todos)
+	if start > 0 {
+		b.WriteString(dim(fmt.Sprintf("  +%d above", start)) + "\n")
+	}
+	for _, t := range p.Todos[start:end] {
 		indent := "  "
 		if t.Level >= 1 {
 			indent = "      " // sub-steps sit under their phase
@@ -2295,7 +2295,34 @@ func (m chatTUI) renderTodoPanel() string {
 			b.WriteString(indent + dim("○ "+t.Content) + "\n")
 		}
 	}
+	if end < len(p.Todos) {
+		b.WriteString(dim(fmt.Sprintf("  +%d more", len(p.Todos)-end)) + "\n")
+	}
 	return todoPanelStyle.Width(max(m.width, 10)).Render(strings.TrimRight(b.String(), "\n"))
+}
+
+func todoPanelWindow(todos []todoPanelTodo) (int, int) {
+	if len(todos) <= todoPanelMaxRows {
+		return 0, len(todos)
+	}
+	active := -1
+	for i, t := range todos {
+		if t.Status == "in_progress" {
+			active = i
+			break
+		}
+	}
+	if active < 0 {
+		return 0, todoPanelMaxRows
+	}
+	start := active - todoPanelMaxRows/2
+	if start < 0 {
+		start = 0
+	}
+	if maxStart := len(todos) - todoPanelMaxRows; start > maxStart {
+		start = maxStart
+	}
+	return start, start + todoPanelMaxRows
 }
 
 // truncateSubject trims a tool subject so the approval banner fits one line.

--- a/internal/cli/todopanel_test.go
+++ b/internal/cli/todopanel_test.go
@@ -24,3 +24,27 @@ func TestRenderTodoPanelNesting(t *testing.T) {
 		t.Fatalf("sub-step not indented under its phase:\n%s", out)
 	}
 }
+
+func TestRenderTodoPanelScrollsToInProgressTodo(t *testing.T) {
+	m := newTestChatTUI()
+	m.width = 72
+	m.todoArgs = `{"todos":[` +
+		`{"content":"Item 01","status":"completed"},` +
+		`{"content":"Item 02","status":"completed"},` +
+		`{"content":"Item 03","status":"completed"},` +
+		`{"content":"Item 04","status":"completed"},` +
+		`{"content":"Item 05","status":"completed"},` +
+		`{"content":"Item 06","status":"completed"},` +
+		`{"content":"Item 07","status":"completed"},` +
+		`{"content":"Item 08","status":"completed"},` +
+		`{"content":"Item 09","status":"in_progress","activeForm":"Working item 09"},` +
+		`{"content":"Item 10","status":"pending"}]}`
+
+	out := ansi.Strip(m.renderTodoPanel())
+	if !strings.Contains(out, "Working item 09") {
+		t.Fatalf("panel should keep the in-progress todo visible:\n%s", out)
+	}
+	if strings.Contains(out, "Item 01") {
+		t.Fatalf("panel should window around the active todo instead of pinning the first rows:\n%s", out)
+	}
+}

--- a/internal/control/auto_plan_e2e_test.go
+++ b/internal/control/auto_plan_e2e_test.go
@@ -102,6 +102,50 @@ func TestAutoPlanGateEndToEnd(t *testing.T) {
 	}
 }
 
+func TestApprovedPlanSeedClearsAfterExecutionWithoutModelTodoWrite(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("Plan:\n1. Add the config field\n2. Wire it into boot"),
+		textTurn("Done."),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+
+	approvalID := make(chan string, 1)
+	var planSeedResults []string
+	c := New(Options{
+		AutoPlan: "on",
+		Runner:   ag,
+		Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			switch e.Kind {
+			case event.ApprovalRequest:
+				approvalID <- e.Approval.ID
+			case event.ToolResult:
+				if e.Tool.ID == "plan-seed" && e.Tool.Name == "todo_write" && e.Tool.Err == "" {
+					planSeedResults = append(planSeedResults, e.Tool.Args)
+				}
+			}
+		}),
+	})
+
+	go func() { c.Approve(<-approvalID, true, false, false) }()
+
+	input := "Implement issue #2395: add config, wire boot, add tests and docs"
+	if err := c.runTurnWithRaw(context.Background(), input, input); err != nil {
+		t.Fatalf("runTurnWithRaw: %v", err)
+	}
+
+	if len(planSeedResults) != 2 {
+		t.Fatalf("plan-seed todo results = %d, want seed then completion: %#v", len(planSeedResults), planSeedResults)
+	}
+	last := planSeedResults[len(planSeedResults)-1]
+	if strings.Contains(last, `"in_progress"`) || strings.Contains(last, `"pending"`) {
+		t.Fatalf("final plan-seed todos should be completed so the panel hides: %s", last)
+	}
+	if !strings.Contains(last, `"completed"`) {
+		t.Fatalf("final plan-seed todos should contain completed items: %s", last)
+	}
+}
+
 // TestAutoPlanGateRejectionStaysInPlan proves a rejected plan keeps plan mode on
 // and never runs the execution turn: only the plan turn reached the model.
 func TestAutoPlanGateRejectionStaysInPlan(t *testing.T) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -396,7 +396,7 @@ func (c *Controller) runTurnWithRaw(ctx context.Context, input, raw string) erro
 		return nil // keep planning; plan mode stays on
 	}
 	c.SetPlanMode(false)
-	c.seedPlanTodos(proposal)
+	seededTodos := c.seedPlanTodos(proposal)
 	// The plan is the go-ahead: don't re-prompt for each write of the approved
 	// work. Auto-approve writers for the duration of this execution turn only.
 	c.mu.Lock()
@@ -407,7 +407,11 @@ func (c *Controller) runTurnWithRaw(ctx context.Context, input, raw string) erro
 		c.autoApprove = false
 		c.mu.Unlock()
 	}()
-	return c.runner.Run(ctx, planApprovedMessage)
+	if err := c.runner.Run(ctx, planApprovedMessage); err != nil {
+		return err
+	}
+	c.completePlanTodos(seededTodos)
+	return nil
 }
 
 // lastAssistantText returns the content of the most recent assistant message with
@@ -1843,14 +1847,29 @@ type seedTodo struct {
 // user approves — a structural guarantee, not a prompt the model might ignore.
 // The model still flips item status as it works (only it knows its own
 // progress); this just makes the list exist. No-op when the plan has no list.
-func (c *Controller) seedPlanTodos(plan string) {
+func (c *Controller) seedPlanTodos(plan string) string {
 	args := PlanTodosJSON(plan)
 	if args == "" {
-		return
+		return ""
 	}
 	t := event.Tool{ID: "plan-seed", Name: "todo_write", Args: args, ReadOnly: true}
 	c.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: t})
 	t.Output = "task list seeded from the approved plan"
+	c.sink.Emit(event.Event{Kind: event.ToolResult, Tool: t})
+	return args
+}
+
+func (c *Controller) completePlanTodos(args string) {
+	if args == "" {
+		return
+	}
+	done := completedPlanTodosJSON(args)
+	if done == "" {
+		return
+	}
+	t := event.Tool{ID: "plan-seed", Name: "todo_write", Args: done, ReadOnly: true}
+	c.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: t})
+	t.Output = "approved plan finished"
 	c.sink.Emit(event.Event{Kind: event.ToolResult, Tool: t})
 }
 
@@ -1865,6 +1884,23 @@ func PlanTodosJSON(plan string) string {
 		return ""
 	}
 	b, err := json.Marshal(map[string]any{"todos": items})
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func completedPlanTodosJSON(args string) string {
+	var p struct {
+		Todos []seedTodo `json:"todos"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil || len(p.Todos) == 0 {
+		return ""
+	}
+	for i := range p.Todos {
+		p.Todos[i].Status = "completed"
+	}
+	b, err := json.Marshal(map[string]any{"todos": p.Todos})
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary
- keep the CLI todo panel windowed around the current `in_progress` item instead of always pinning the first rows
- auto-complete the controller-seeded approved-plan todo list after the approved execution turn succeeds, so stale plan todos hide in CLI/desktop when the model did not issue its own `todo_write`
- auto-scroll the desktop todo panel to the current `in_progress` item while expanded

Fixes #3136.

## Verification
- `go test ./internal/cli -run 'TestRenderTodoPanelScrollsToInProgressTodo|TestRenderTodoPanelNesting' -count=1`
- `go test ./internal/control -run 'TestApprovedPlanSeedClearsAfterExecutionWithoutModelTodoWrite|TestAutoPlanGateEndToEnd|TestAutoPlanGateRejectionStaysInPlan' -count=1`
- `go test ./internal/cli -run 'TestRenderTodoPanel|TestTodoPanelKeepsLastSuccessfulTodoWrite' -count=1 -v`
- `go test ./internal/control -run 'Test.*Plan.*|TestApprovedPlanSeedClearsAfterExecutionWithoutModelTodoWrite' -count=1 -v`
- `npm run typecheck`
- `npm run build`
- `git diff --check` (only Windows LF -> CRLF warnings)

## Known unrelated failure
- `go test ./internal/cli -count=1` currently fails at `TestModelSwitchRefreshesCustomStatusline`; this branch does not touch statusline/model-switch code, and the todo-focused CLI tests pass.