### PR TITLE
feat(tui): message queue navigation with ↑/↓ during streaming

### DIFF
--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -19,6 +19,7 @@ func newTestChatTUI() chatTUI {
 		input:                ti,
 		width:                80,
 		submittedInputCursor: -1,
+		queueEditCursor:      -1,
 		nextPasteID:          1,
 		reasoningLineIdx:     -1,
 		reasoningTextIdx:     -1,

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -539,17 +539,6 @@ func (m *chatTUI) navigateQueue(delta int) bool {
 	return true
 }
 
-// commitQueueEdit writes the current input back to the queue slot being edited,
-// then resets the queue navigation cursor. Called before the input is consumed
-// (Enter or TurnDone dequeue).
-func (m *chatTUI) commitQueueEdit() {
-	if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {
-		m.pendingInterject[m.queueEditCursor] = m.input.Value()
-	}
-	m.queueEditCursor = -1
-	m.queueEditDraft = ""
-}
-
 // resetQueueNavigation resets the queue browsing cursor so the user returns to
 // normal input mode. Any in-progress edit is discarded (the queued item keeps
 // its previous value).

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -94,6 +94,13 @@ type chatTUI struct {
 	// pendingInterject queues input typed while a turn runs; each TurnDone
 	// dequeues the front and submits it as the next turn.
 	pendingInterject []string
+	// queueEditCursor tracks which queued message the user is currently
+	// browsing/editing via ↑/↓ during tuiRunning. -1 means "not browsing".
+	queueEditCursor int
+	// queueEditDraft saves the in-progress input text when the user first
+	// presses ↑ to browse the queue, so it can be restored when the cursor
+	// moves past the end.
+	queueEditDraft string
 
 	// history is a resumed session's messages, committed to scrollback once on
 	// the first WindowSizeMsg so a reopened chat shows its prior transcript.
@@ -429,6 +436,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		input:                ti,
 		spinner:              sp,
 		submittedInputCursor: -1,
+		queueEditCursor:      -1,
 		nextPasteID:          1,
 		reasoningLineIdx:     -1,
 		reasoningTextIdx:     -1,
@@ -494,6 +502,87 @@ func (m *chatTUI) recallSubmittedInput(delta int) bool {
 func (m *chatTUI) resetSubmittedInputRecall() {
 	m.submittedInputCursor = -1
 	m.submittedInputDraft = ""
+}
+
+// navigateQueue moves through the pending interject queue during tuiRunning.
+// delta < 0 means ↑ (older), delta > 0 means ↓ (newer). Returns true if the
+// input was updated.
+func (m *chatTUI) navigateQueue(delta int) bool {
+	if len(m.pendingInterject) == 0 {
+		return false
+	}
+	cursor := m.queueEditCursor
+	if cursor < 0 {
+		if delta > 0 {
+			return false // already at "new draft" — nothing newer
+		}
+		// First ↑: save the current draft and jump to the last queued item.
+		m.queueEditDraft = m.input.Value()
+		cursor = len(m.pendingInterject) - 1
+	} else {
+		cursor += delta
+	}
+
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= len(m.pendingInterject) {
+		// Past the end: restore the draft the user was composing.
+		m.queueEditCursor = -1
+		m.input.SetValue(m.queueEditDraft)
+		m.growInputToFit()
+		return true
+	}
+	m.queueEditCursor = cursor
+	m.input.SetValue(m.pendingInterject[cursor])
+	m.growInputToFit()
+	return true
+}
+
+// commitQueueEdit writes the current input back to the queue slot being edited,
+// then resets the queue navigation cursor. Called before the input is consumed
+// (Enter or TurnDone dequeue).
+func (m *chatTUI) commitQueueEdit() {
+	if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {
+		m.pendingInterject[m.queueEditCursor] = m.input.Value()
+	}
+	m.queueEditCursor = -1
+	m.queueEditDraft = ""
+}
+
+// resetQueueNavigation resets the queue browsing cursor so the user returns to
+// normal input mode. Any in-progress edit is discarded (the queued item keeps
+// its previous value).
+func (m *chatTUI) resetQueueNavigation() {
+	m.queueEditCursor = -1
+	m.queueEditDraft = ""
+}
+
+// renderQueueIndicator renders the pending-message queue as dim text to show
+// above the input box when messages are queued during a running turn.
+func (m chatTUI) renderQueueIndicator() string {
+	if m.state != tuiRunning || len(m.pendingInterject) == 0 {
+		return ""
+	}
+	queueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240")) // dim grey
+	highlightStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("250"))
+	var lines []string
+	for i, msg := range m.pendingInterject {
+		preview := msg
+		// Truncate long messages for the compact preview.
+		runes := []rune(preview)
+		if len(runes) > 50 {
+			preview = string(runes[:47]) + "…"
+		}
+		cursor := " "
+		style := queueStyle
+		if m.queueEditCursor == i {
+			cursor = "▸"
+			style = highlightStyle
+		}
+		lines = append(lines, style.Render(fmt.Sprintf("  %s [%d] %s", cursor, i+1, preview)))
+	}
+	return strings.Join(lines, "\n")
 }
 
 // prompts returns the MCP prompts discovered at startup (nil when no plugins).
@@ -770,15 +859,27 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch msg.String() {
 		case "up":
-			if m.state != tuiRunning && m.recallSubmittedInput(-1) {
+			if m.state == tuiRunning {
+				if m.navigateQueue(-1) {
+					return m, nil
+				}
+			} else if m.recallSubmittedInput(-1) {
 				return m, nil
 			}
 		case "down":
-			if m.state != tuiRunning && m.recallSubmittedInput(1) {
+			if m.state == tuiRunning {
+				if m.navigateQueue(1) {
+					return m, nil
+				}
+			} else if m.recallSubmittedInput(1) {
 				return m, nil
 			}
+		case "enter":
+			// Don't reset queue navigation — the Enter handler below needs
+			// queueEditCursor to decide whether to save an edit or enqueue.
 		default:
 			m.resetSubmittedInputRecall()
+			m.resetQueueNavigation()
 		}
 		switch msg.String() {
 		case "esc":
@@ -871,11 +972,21 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if line == "" {
 					return m, nil
 				}
-				m.pendingInterject = append(m.pendingInterject, line)
+				if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {
+					// Save the edited text back to the queue slot.
+					m.pendingInterject[m.queueEditCursor] = line
+					m.notice(fmt.Sprintf("queue [%d] updated", m.queueEditCursor+1))
+					m.queueEditCursor = -1
+					m.queueEditDraft = ""
+				} else {
+					m.pendingInterject = append(m.pendingInterject, line)
+					m.notice("feedback queued — will send when the current turn finishes")
+					m.queueEditCursor = -1
+					m.queueEditDraft = ""
+				}
 				m.input.Reset()
 				m.input.SetHeight(1)
 				m.pastedBlocks = nil
-				m.notice("feedback queued — will send when the current turn finishes")
 				return m, finalize(m, cmds)
 			}
 			if m.modelSwitchPending {
@@ -975,6 +1086,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.pendingInterject) > 0 {
 				interject := m.pendingInterject[0]
 				m.pendingInterject = m.pendingInterject[1:]
+				// Reset queue navigation — the indices shifted.
+				m.queueEditCursor = -1
+				m.queueEditDraft = ""
 				cmds = append(cmds, m.startTurn(interject, interject, interject))
 			}
 		}
@@ -1766,6 +1880,10 @@ func (m chatTUI) View() tea.View {
 	}
 	statusBlock := clampStatusLine(status, boxW) + "\n" + clampStatusLine(dataLine, boxW)
 	if !hideComposer {
+		if qi := m.renderQueueIndicator(); qi != "" {
+			parts = append(parts, qi)
+			rowsAboveBox += strings.Count(qi, "\n") + 1
+		}
 		parts = append(parts, box)
 	}
 	parts = append(parts, statusBlockStyle.Width(boxW).MaxWidth(boxW).Render(statusBlock))
@@ -2597,6 +2715,8 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		// just clear the un-sendable flag.
 		m.confirmBubbleSent()
 		m.state = tuiIdle
+		m.queueEditCursor = -1
+		m.queueEditDraft = ""
 		m.clearSubmittedPastes()
 		if e.Err != nil && e.Err.Error() != "" && !strings.Contains(e.Err.Error(), "context canceled") {
 			m.commitLine(wrapForViewport(i18n.M.ErrorPrefix+" "+e.Err.Error(), m.width, activeCLITheme.warn))

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -643,6 +643,189 @@ func TestSubmittedInputRecallWithArrowKeys(t *testing.T) {
 	}
 }
 
+func TestQueueNavigationWithArrowKeys(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"queued one", "queued two", "queued three"}
+	m.input.SetValue("my draft")
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	down := tea.KeyPressMsg{Code: tea.KeyDown}
+
+	// First ↑ should save draft and jump to last queued item.
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "queued three" {
+		t.Fatalf("first up: want %q, got %q", "queued three", got)
+	}
+	if m.queueEditCursor != 2 {
+		t.Fatalf("first up: cursor should be 2, got %d", m.queueEditCursor)
+	}
+
+	// Second ↑ should move to "queued two".
+	model, _ = m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "queued two" {
+		t.Fatalf("second up: want %q, got %q", "queued two", got)
+	}
+
+	// ↓ should move back to "queued three".
+	model, _ = m.Update(down)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "queued three" {
+		t.Fatalf("down: want %q, got %q", "queued three", got)
+	}
+
+	// ↓ past the end should restore the draft.
+	model, _ = m.Update(down)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "my draft" {
+		t.Fatalf("down past end: want %q, got %q", "my draft", got)
+	}
+	if m.queueEditCursor != -1 {
+		t.Fatalf("down past end: cursor should be -1, got %d", m.queueEditCursor)
+	}
+}
+
+func TestQueueNavigationClampAtStart(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"only item"}
+	m.input.SetValue("draft")
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	// First ↑ jumps to the only item.
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "only item" {
+		t.Fatalf("first up: want %q, got %q", "only item", got)
+	}
+	// Second ↑ should clamp at index 0 (not go negative).
+	model, _ = m.Update(up)
+	m = model.(chatTUI)
+	if m.queueEditCursor != 0 {
+		t.Fatalf("second up: cursor should clamp at 0, got %d", m.queueEditCursor)
+	}
+	if got := m.input.Value(); got != "only item" {
+		t.Fatalf("second up: value should stay %q, got %q", "only item", got)
+	}
+}
+
+func TestQueueNavigationNoOpWhenEmpty(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.input.SetValue("hello")
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "hello" {
+		t.Fatalf("empty queue: input should be unchanged, got %q", got)
+	}
+}
+
+func TestQueueEditSavesOnEnter(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"original one", "original two"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if m.queueEditCursor != 1 {
+		t.Fatalf("cursor should be 1 after up, got %d", m.queueEditCursor)
+	}
+
+	// Edit the queued message.
+	m.input.SetValue("edited two")
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	model, _ = m.Update(enter)
+	m = model.(chatTUI)
+
+	if m.pendingInterject[1] != "edited two" {
+		t.Fatalf("queue[1] should be %q, got %q", "edited two", m.pendingInterject[1])
+	}
+	if m.pendingInterject[0] != "original one" {
+		t.Fatalf("queue[0] should be unchanged, got %q", m.pendingInterject[0])
+	}
+	if m.queueEditCursor != -1 {
+		t.Fatalf("cursor should reset after enter, got %d", m.queueEditCursor)
+	}
+}
+
+func TestQueueNewMessageOnEnterDuringRunning(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"existing"}
+
+	m.input.SetValue("new message")
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	model, _ := m.Update(enter)
+	m = model.(chatTUI)
+
+	if len(m.pendingInterject) != 2 {
+		t.Fatalf("queue should have 2 items, got %d", len(m.pendingInterject))
+	}
+	if m.pendingInterject[1] != "new message" {
+		t.Fatalf("queue[1] should be %q, got %q", "new message", m.pendingInterject[1])
+	}
+}
+
+func TestQueueNavigationResetOnNonUpDownKey(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"queued"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if m.queueEditCursor != 0 {
+		t.Fatalf("cursor should be 0 after up, got %d", m.queueEditCursor)
+	}
+
+	// A regular key should reset the queue navigation cursor.
+	letter := tea.KeyPressMsg{Code: 'a'}
+	model, _ = m.Update(letter)
+	m = model.(chatTUI)
+	if m.queueEditCursor != -1 {
+		t.Fatalf("cursor should reset on non-up/down key, got %d", m.queueEditCursor)
+	}
+}
+
+func TestQueueIndicatorRendering(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"first msg", "second msg"}
+
+	qi := m.renderQueueIndicator()
+	if qi == "" {
+		t.Fatal("queue indicator should not be empty when queue has items and running")
+	}
+	if !strings.Contains(qi, "[1]") || !strings.Contains(qi, "[2]") {
+		t.Fatalf("queue indicator should contain [1] and [2], got %q", qi)
+	}
+	if !strings.Contains(qi, "first msg") || !strings.Contains(qi, "second msg") {
+		t.Fatalf("queue indicator should show message previews, got %q", qi)
+	}
+
+	// Highlight marker should appear for the browsed item.
+	m.queueEditCursor = 1
+	qi = m.renderQueueIndicator()
+	if !strings.Contains(qi, "▸") {
+		t.Fatalf("queue indicator should show ▸ for browsed item, got %q", qi)
+	}
+}
+
+func TestQueueIndicatorHiddenWhenIdle(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiIdle
+	m.pendingInterject = []string{"queued"}
+
+	if qi := m.renderQueueIndicator(); qi != "" {
+		t.Fatalf("queue indicator should be empty when idle, got %q", qi)
+	}
+}
+
 // TestViewAltScreenFillsHeight proves the switch to alt-screen: View requests
 // the alt buffer + mouse, and the frame is exactly the terminal height (the
 // transcript viewport pads to fill above the pinned bottom region).


### PR DESCRIPTION
## What

When a turn is running and the user queues messages (Enter during streaming), pressing ↑/↓ now lets them browse and edit queued messages, instead of only being able to append new ones.

## Why

Closes #2551 — during streaming, queued messages were fire-and-forget with no way to review or correct them before they were sent.

## How

- **↑/↓ during ** navigates through  queue (↑ saves the current draft, jumps to the last queued item; subsequent ↑/↓ moves through the list; past the end restores the draft)
- **Enter while browsing** saves the edited text back to the queue slot (notice: 'queue [N] updated'); Enter without browsing still queues a new message
- **Queue indicator** renders in dim grey above the input box showing  for each queued item, with ▸ marking the currently browsed entry
- **Reset guards** on any non-↑/↓ key, on Enter, on TurnDone dequeue, and on turn finish

## Tests

-  — ↑ saves draft, navigates last→first, ↓ restores draft
-  — ↑ clamps at index 0
-  — no-op when queue is empty
-  — editing a queued message saves back to the slot
-  — Enter without browsing appends as before
-  — any other key resets the browse cursor
-  /  — view correctness