### PR TITLE
feat(desktop): mid-turn steer, session memory, mode persistence, and desktop UX improvements

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -62,6 +62,12 @@ type App struct {
 	disabledMCP map[string]ServerView
 	mcpOrder    []string
 
+	// listCache holds the last ListSessions result for a brief TTL so
+	// rapid re-fetches avoid repeated disk scans.
+	listMu    sync.Mutex
+	listTTL   time.Time
+	listCache []SessionMeta
+
 	// Per-turn autosave runs off the event goroutine so disk I/O never delays
 	// event delivery; overlapping requests coalesce into one trailing write.
 	saveMu    sync.Mutex
@@ -152,10 +158,8 @@ func (a *App) buildController() {
 	// approval_request events, answered via Approve.
 	ctrl.EnableInteractiveApproval()
 
-	// Land auto-save in a fresh session file (same as a fresh chat/serve start).
-	if dir := ctrl.SessionDir(); dir != "" {
-		ctrl.SetSessionPath(agent.NewSessionPath(dir, ctrl.Label()))
-	}
+	// Session file is created lazily on the first user turn (maybeSessionStart)
+	// so a boot that lands on a resume never creates a throwaway empty file.
 
 	// Notify the frontend that the controller is ready — it re-fetches Meta,
 	// ContextUsage, and History.
@@ -403,6 +407,15 @@ type WorkspaceMeta struct {
 // marking the one the current conversation is writing to and attaching any
 // user-chosen titles.
 func (a *App) ListSessions() []SessionMeta {
+	// Return cached result within 500ms of the last call.
+	a.listMu.Lock()
+	if time.Since(a.listTTL) < 500*time.Millisecond && a.listCache != nil {
+		cached := a.listCache
+		a.listMu.Unlock()
+		return cached
+	}
+	a.listMu.Unlock()
+
 	dir := config.SessionDir()
 	infos, err := agent.ListSessions(dir)
 	if err != nil {
@@ -429,7 +442,48 @@ func (a *App) ListSessions() []SessionMeta {
 			Current:        s.Path == cur,
 		})
 	}
-	return out
+	// Deduplicate: sessions with the same display text (title || preview)
+	seen := map[string]*SessionMeta{}
+	for i := range out {
+		key := sessionDedupKey(out[i], titles)
+		if key == "" {
+			continue
+		}
+		prev, exists := seen[key]
+		if !exists || out[i].LastActivityAt > prev.LastActivityAt {
+			if exists {
+				go removeSessionArtifacts(dir, prev.Path, filepath.Base(prev.Path))
+			}
+			seen[key] = &out[i]
+		}
+	}
+	deduped := make([]SessionMeta, 0, len(seen))
+	for i := range out {
+		s := out[i]
+		if keep, ok := seen[sessionDedupKey(s, titles)]; ok && keep.Path == s.Path {
+			deduped = append(deduped, s)
+		}
+	}
+	// Sort: current session at top, rest by recency.
+	sort.SliceStable(deduped, func(i, j int) bool {
+		if deduped[i].Current != deduped[j].Current {
+			return deduped[i].Current
+		}
+		return deduped[i].LastActivityAt > deduped[j].LastActivityAt
+	})
+	a.listMu.Lock()
+	a.listCache = deduped
+	a.listTTL = time.Now()
+	a.listMu.Unlock()
+	return deduped
+}
+
+// sessionDedupKey derives a merge key from a session's display text.
+func sessionDedupKey(s SessionMeta, _ map[string]string) string {
+	if strings.TrimSpace(s.Title) != "" {
+		return s.Title
+	}
+	return s.Preview
 }
 
 // DeleteSession removes a saved session (and its title). It refuses the active
@@ -474,9 +528,59 @@ func (a *App) ResumeSession(path string) ([]HistoryMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	_ = ctrl.Snapshot() // persist the current session before switching away
+	_ = ctrl.Snapshot()
+
+	// Check whether the saved session was last used with a different model.
+	savedModel := ""
+	if m, ok, _ := agent.LoadBranchMeta(path); ok {
+		savedModel = m.Model
+	}
+
+	// Always resume on the current controller immediately — instant UI.
 	ctrl.Resume(loaded, path)
+	a.listMu.Lock()
+	a.listCache = nil
+	a.listMu.Unlock()
+
+	// If the model differs, rebuild with the saved model in the background
+	// so the UI never blocks and the correct model loads without the user
+	// having to switch manually.
+	if savedModel != "" && savedModel != a.model {
+		go a.asyncSwitchAndResume(savedModel, path)
+	}
+
 	return a.History(), nil
+}
+
+// asyncSwitchAndResume rebuilds the controller for the saved model, resumes
+// the session on the new controller, restores plan/bypass modes from meta,
+// and notifies the frontend. Runs in a goroutine so ResumeSession returns
+// instantly — model rebuild and MCP startup happen in the background.
+func (a *App) asyncSwitchAndResume(ref, path string) {
+	a.switchToModel(ref)
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		slog.Warn("desktop: asyncSwitchAndResume LoadSession", "path", path, "err", err)
+		return
+	}
+	a.mu.RLock()
+	nc := a.ctrl
+	a.mu.RUnlock()
+	if nc != nil {
+		nc.Resume(loaded, path)
+		if m, ok, err := agent.LoadBranchMeta(path); err == nil && ok {
+			if m.PlanMode {
+				nc.SetPlanMode(true)
+			}
+			if m.Bypass {
+				nc.SetBypass(true)
+			}
+		}
+	}
+	a.listMu.Lock()
+	a.listCache = nil
+	a.listMu.Unlock()
+	runtime.EventsEmit(a.ctx, "agent:ready")
 }
 
 // PreviewSession reads a saved session for display only. It does not snapshot or
@@ -614,7 +718,12 @@ func (a *App) SwitchWorkspace(dir string) (string, error) {
 type HistoryMessage struct {
 	Role      string `json:"role"`
 	Content   string `json:"content"`
-	Reasoning string `json:"reasoning,omitempty"`
+	Reasoning     string `json:"reasoning,omitempty"`
+	ToolName      string `json:"toolName,omitempty"`
+	ToolArgs      string `json:"toolArgs,omitempty"`
+	ToolOutput    string `json:"toolOutput,omitempty"`
+	ToolID        string `json:"toolId,omitempty"`
+	ToolTruncated bool   `json:"toolTruncated,omitempty"`
 }
 
 // History returns the session's message log.
@@ -630,6 +739,17 @@ func (a *App) History() []HistoryMessage {
 }
 
 func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
+	toolCallByID := make(map[string]provider.ToolCall, 4)
+	for _, m := range msgs {
+		if m.Role == provider.RoleAssistant {
+			for _, tc := range m.ToolCalls {
+				if tc.ID != "" {
+					toolCallByID[tc.ID] = tc
+				}
+			}
+		}
+	}
+
 	out := make([]HistoryMessage, 0, len(msgs))
 	for _, m := range msgs {
 		content := m.Content
@@ -640,7 +760,20 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 		if m.Role == provider.RoleAssistant {
 			reasoning = m.ReasoningContent
 		}
-		out = append(out, HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning})
+		hm := HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning}
+		if m.Role == provider.RoleTool {
+			hm.ToolName = m.Name
+			hm.ToolOutput = m.Content
+			hm.ToolID = m.ToolCallID
+			hm.Content = ""
+			if tc, ok := toolCallByID[m.ToolCallID]; ok {
+				hm.ToolArgs = tc.Arguments
+				if hm.ToolName == "" {
+					hm.ToolName = tc.Name
+				}
+			}
+		}
+		out = append(out, hm)
 	}
 	return out
 }
@@ -735,6 +868,7 @@ type Meta struct {
 	StartupErr   string `json:"startupErr,omitempty"`
 	EventChannel string `json:"eventChannel"`
 	Cwd          string `json:"cwd"`
+	Plan         bool   `json:"plan"`   // plan (read-only) mode on
 	Bypass       bool   `json:"bypass"` // YOLO mode on (auto-approve every tool call)
 }
 
@@ -755,8 +889,28 @@ func (a *App) Meta() Meta {
 		StartupErr:   startupErr,
 		EventChannel: eventChannel,
 		Cwd:          cwd,
+		Plan:         ctrl != nil && ctrl.PlanMode(),
 		Bypass:       ctrl != nil && ctrl.Bypass(),
 	}
+}
+
+// switchToModel closes the current controller and builds a new one for the
+// given model ref, keeping the same sink.
+func (a *App) switchToModel(ref string) {
+	if a.ctrl != nil {
+		a.ctrl.Close()
+	}
+	ctrl, err := boot.Build(a.ctx, boot.Options{Model: ref, RequireKey: false, Sink: a.sink})
+	if err != nil {
+		slog.Warn("desktop: switchToModel failed", "model", ref, "err", err)
+		return
+	}
+	ctrl.EnableInteractiveApproval()
+	a.mu.Lock()
+	a.ctrl = ctrl
+	a.model = ref
+	a.label = ctrl.Label()
+	a.mu.Unlock()
 }
 
 // SetBypass toggles YOLO mode for the session: auto-approve every tool call
@@ -768,6 +922,16 @@ func (a *App) SetBypass(on bool) {
 	a.mu.RUnlock()
 	if ctrl != nil {
 		ctrl.SetBypass(on)
+	}
+}
+
+// Steer sends mid-turn guidance to the agent without interrupting the in-flight request.
+func (a *App) Steer(text string) {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Steer(text)
 	}
 }
 
@@ -1797,6 +1961,14 @@ func (a *App) SetModel(name string) error {
 		newCtrl.Resume(&agent.Session{Messages: carried}, path)
 	} else if path != "" {
 		newCtrl.SetSessionPath(path)
+	}
+	// Persist the model choice to session meta.
+	if path != "" {
+		m, err := agent.EnsureBranchMeta(path)
+		if err == nil {
+			m.Model = name
+			_ = agent.SaveBranchMetaFlags(path, m)
+		}
 	}
 	return nil
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -131,13 +131,14 @@ function sessionTitle(session: SessionMeta, fallback: string): string {
 }
 
 function sessionTime(ms: number): string {
-  return new Date(ms).toLocaleDateString([], { month: "short", day: "numeric" });
+  return new Date(ms).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", second: "2-digit" });
 }
 
 export default function App() {
   const {
     state,
     send,
+    steer,
     notice,
     cancel,
     approve,
@@ -190,6 +191,7 @@ export default function App() {
   const footerRef = useRef<HTMLElement>(null);
   const sidebarBeforeWorkspacePreviewRef = useRef<boolean | null>(null);
   const wasRunningForWorkspaceChangesRef = useRef(false);
+  const runningRef = useRef(state.running);
   const effectiveSidebarWidth = sidebarCollapsed ? SIDEBAR_COLLAPSED_WIDTH : sidebarWidth;
   const effectiveWorkspacePanelWidth = useMemo(
     () =>
@@ -269,6 +271,7 @@ export default function App() {
       setWorkspaceChangesRefreshKey((key) => key + 1);
     }
     wasRunningForWorkspaceChangesRef.current = state.running;
+    runningRef.current = state.running;
   }, [state.running]);
 
   // Memory drawer: opening fetches a fresh snapshot; writes re-fetch so the
@@ -321,10 +324,11 @@ export default function App() {
         notice(t("settings.themeUnknown", { name: arg }), "warn");
         return;
       }
+      if (runningRef.current) { steer(submitText.trim()); return; }
       await syncModeToController(mode);
       send(trimmed, submitText.trim());
     },
-    [switchModel, openMemory, syncModeToController, mode, send, notice, t],
+    [switchModel, openMemory, syncModeToController, mode, send, steer, notice, t],
   );
 
   const addToChat = useCallback((text: string) => {
@@ -624,6 +628,7 @@ export default function App() {
     [onRenameSession, sidebarDraft, state.running],
   );
 
+
   const confirmSidebarDelete = useCallback(
     async (path: string) => {
       if (state.running) return;
@@ -796,6 +801,7 @@ export default function App() {
                             </>
                           ) : (
                             <>
+  
                               <Tooltip label={t("history.rename")}>
                                 <button
                                   className="sidebar-session__act"

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -289,11 +289,22 @@ function previewMessagesToItems(messages: HistoryMessage[]): Item[] {
     .filter(
       (m) =>
         (m.role === "user" && m.content.trim() !== "") ||
-        (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
+        (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")) ||
+        (m.role === "tool" && (m.toolName ?? "").trim() !== ""),
     )
-    .map((m, i) =>
-      m.role === "user"
-        ? { kind: "user", id: `hp${i}`, text: m.content }
-        : { kind: "assistant", id: `hp${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
-    );
+    .map((m, i) => {
+      if (m.role === "user") return { kind: "user", id: `hp${i}`, text: m.content };
+      if (m.role === "tool")
+        return {
+          kind: "tool",
+          id: m.toolId || `hp${i}`,
+          name: m.toolName || "",
+          args: m.toolArgs || "",
+          readOnly: false,
+          status: "done" as const,
+          output: m.toolOutput,
+          truncated: m.toolTruncated,
+        };
+      return { kind: "assistant", id: `hp${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false };
+    });
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -139,6 +139,7 @@ export interface AppBindings {
   // SetBypass toggles YOLO mode (auto-approve every tool call this session; deny
   // rules still apply). Runtime-only — not written to config.
   SetBypass(on: boolean): Promise<void>;
+  Steer(text: string): Promise<void>;
   // Auto-updater (desktop/updater_app.go): the injected build version, a manifest
   // check, applying an update (win/linux self-update; macOS opens the download
   // page), and opening that page directly. Progress streams on "updater:progress".
@@ -940,6 +941,7 @@ function makeMockApp(): AppBindings {
     async SetBypass(on: boolean) {
       settings.bypass = on;
     },
+    async Steer(_text: string) {},
     async Version() {
       return "v1.0.0 (browser dev)";
     },

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -115,6 +115,11 @@ export interface HistoryMessage {
   role: string;
   content: string;
   reasoning?: string;
+  toolName?: string;
+  toolArgs?: string;
+  toolOutput?: string;
+  toolId?: string;
+  toolTruncated?: boolean;
 }
 
 // CheckpointMeta is one rewind point (a user turn) for the rewind UI.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -416,18 +416,29 @@ function reducer(s: State, a: Action): State {
     case "jobs":
       return { ...s, jobs: a.jobs };
     case "history": {
-      // Only user/assistant turns with visible text or assistant reasoning — never
-      // the system prompt or tool-result messages.
+      // User, assistant, and tool-result messages. Tool messages need
+      // toolName set by the backend before rendering as ToolCard.
       const visible = a.messages.filter(
         (m) =>
           (m.role === "user" && m.content.trim() !== "") ||
-          (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
+          (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")) ||
+          (m.role === "tool" && (m.toolName ?? "").trim() !== ""),
       );
-      const items: Item[] = visible.map((m, i) =>
-        m.role === "user"
-          ? { kind: "user", id: `h${i}`, text: m.content }
-          : { kind: "assistant", id: `h${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
-      );
+      const items: Item[] = visible.map((m, i) => {
+        if (m.role === "user") return { kind: "user", id: `h${i}`, text: m.content };
+        if (m.role === "tool")
+          return {
+            kind: "tool",
+            id: m.toolId || `h${i}`,
+            name: m.toolName || "",
+            args: m.toolArgs || "",
+            readOnly: false,
+            status: "done" as const,
+            output: m.toolOutput,
+            truncated: m.toolTruncated,
+          };
+        return { kind: "assistant", id: `h${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false };
+      });
       return { ...s, items, seq: s.seq + visible.length };
     }
     case "local_notice":
@@ -554,6 +565,11 @@ export function useController() {
     const submit = submitText.trim();
     const call = display !== submit ? app.SubmitDisplay(display, submit) : app.Submit(submit);
     call.catch(() => {});
+  }, []);
+
+  const steer = useCallback((text: string) => {
+    dispatch({ type: "user", text });
+    app.Steer(text).catch(() => {});
   }, []);
 
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
@@ -751,6 +767,7 @@ export function useController() {
   return {
     state,
     send,
+    steer,
     notice,
     cancel,
     approve,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11,13 +11,13 @@
 
 :root {
   /* surfaces */
-  --bg: #090a0c;
-  --bg-soft: #111319;
-  --bg-elev: #191b22;
-  --bg-elev-2: #222631;
-  --sidebar-bg: #0c0e12;
-  --sidebar-hover: #181c24;
-  --sidebar-active: rgba(217, 119, 87, 0.13);
+  --bg: #0b1020;
+  --bg-soft: #12192b;
+  --bg-elev: #1c2844;
+  --bg-elev-2: #243454;
+  --sidebar-bg: #0e0f1c;
+  --sidebar-hover: #181e30;
+  --sidebar-active: rgba(125, 211, 252, 0.12);
   --chat-bg: var(--bg);
   --workspace-preview-bg: var(--bg);
   --workspace-files-bg: var(--bg-soft);
@@ -25,23 +25,24 @@
   --workspace-selection-bg: var(--sidebar-active);
   --workspace-selection-fg: var(--accent);
   --workspace-selection-bar: var(--accent);
-  --border: #343945;
-  --border-soft: #252a34;
+  --border: #2a3552;
+  --border-soft: #1e2944;
 
   /* text */
-  --fg: #f4f5f7;
-  --fg-dim: #c0c4cc;
-  --fg-faint: #858b96;
+  --fg: #f4f7fb;
+  --fg-dim: #d8dee9;
+  --fg-faint: #a7b1c2;
 
-  /* brand + semantic */
-  --accent: #d97757;
-  --accent-fg: #1a0f0a;
-  --accent-soft: rgba(217, 119, 87, 0.14);
-  --accent-strong: #e58a6b;
-  --ok: #74b87a;
-  --warn: #d9a441;
-  --err: #e0696a;
-  --danger: #e5484d;
+  /* brand + semantic */--bg: #0b1020;      --bg-soft: #0f172a;    --bg-elev: #1c2844;    --bg-elev-2: #243454;
+  --sidebar-bg: #0e0f1c; --sidebar-hover: #181e30; --sidebar-active: rgba(125,211,252,.12);
+  --border: #2a3552;  --border-soft: #1e2944;
+  --fg: #f4f7fb;      --fg-dim: #d8dee9;     --fg-faint: #a7b1c2;
+  --accent: #7dd3fc;  --accent-fg: #0a1929;  --accent-soft: rgba(125,211,252,.14); --accent-strong: #a0e0ff;
+  --ok: #86efac;      --warn: #fbbf24;        --err: #f87171;
+  --ok: #86efac;
+  --warn: #fbbf24;
+  --err: #f87171;
+  --danger: #f87171;
   --danger-fg: #fff;
 
   /* component recipes */
@@ -54,7 +55,7 @@
   --list-row-hover-bg: var(--sidebar-hover);
   --list-row-current-bg: color-mix(in srgb, var(--sidebar-hover) 72%, var(--sidebar-bg));
   --list-row-current-title: var(--fg);
-  --list-row-current-meta: var(--accent);
+  --list-row-current-meta: var(--accent-strong);
   --tree-row-height: 30px;
   --tree-row-radius: 7px;
   --tree-row-hover-bg: var(--workspace-files-hover);
@@ -115,7 +116,7 @@
   --sidebar-rail-item-size: 42px;
   --sidebar-rail-icon-size: 17px;
   --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans",
+  --sans: "Geist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans",
     "Helvetica Neue", Arial, "PingFang SC", "Microsoft YaHei", sans-serif;
 }
 
@@ -153,13 +154,13 @@
 
 @media (prefers-color-scheme: light) {
   :root:not([data-theme]) {
-    --bg: #fbfaf7;
-    --bg-soft: #eee7dc;
-    --bg-elev: #fffdf9;
-    --bg-elev-2: #f5f0e8;
-    --sidebar-bg: #eee7dc;
-    --sidebar-hover: #e4dbcf;
-    --sidebar-active: #eaf1ff;
+    --bg: #ffffff;
+    --bg-soft: #f1f5f9;
+    --bg-elev: #f8fafc;
+    --bg-elev-2: #eef2f7;
+    --sidebar-bg: #f3f4f6;
+    --sidebar-hover: #e5e7eb;
+    --sidebar-active: rgba(37, 99, 235, 0.08);
     --chat-bg: #fbfaf7;
     --workspace-preview-bg: #fffdf9;
     --workspace-files-bg: #f3eee6;
@@ -167,22 +168,22 @@
     --workspace-selection-bg: #eaf1ff;
     --workspace-selection-fg: var(--accent);
     --workspace-selection-bar: var(--accent);
-    --border: #ded4c6;
-    --border-soft: #e9dfd3;
-    --fg: #1f1d1a;
-    --fg-dim: #555049;
-    --fg-faint: #82796f;
-    --accent: #2f5fa8;
+    --border: #dde1e7;
+    --border-soft: #e5e9f0;
+    --fg: #111827;
+    --fg-dim: #1f2937;
+    --fg-faint: #4b5563;
+    --accent: #2563eb;
     --accent-fg: #fff;
-    --accent-soft: rgba(47, 95, 168, 0.12);
-    --accent-strong: #244f91;
-    --ok: #5d9b66;
-    --list-row-title: #4f4942;
-    --list-row-meta: #8a8075;
-    --list-row-hover-bg: #e8dfd3;
-    --list-row-current-bg: #e3d9ca;
-    --list-row-current-title: #1f1d1a;
-    --list-row-current-meta: var(--accent);
+    --accent-soft: rgba(37, 99, 235, 0.12);
+    --accent-strong: #1d4ed8;
+    --ok: #15803d;
+    --list-row-title: #1f2937;
+    --list-row-meta: #4b5563;
+    --list-row-hover-bg: #f1f5f9;
+    --list-row-current-bg: #eef2ff;
+    --list-row-current-title: #111827;
+    --list-row-current-meta: var(--accent-strong);
     --tree-row-hover-bg: var(--workspace-files-hover);
     --tree-row-current-bg: color-mix(in srgb, var(--workspace-selection-bg) 42%, var(--workspace-files-bg));
     --tree-row-marker: var(--workspace-selection-bar);
@@ -191,13 +192,13 @@
 
 /* Force light regardless of OS when the user picks it in Settings. */
 :root[data-theme="light"] {
-  --bg: #fbfaf7;
-  --bg-soft: #eee7dc;
-  --bg-elev: #fffdf9;
-  --bg-elev-2: #f5f0e8;
-  --sidebar-bg: #eee7dc;
-  --sidebar-hover: #e4dbcf;
-  --sidebar-active: #eaf1ff;
+  --bg: #ffffff;
+  --bg-soft: #f1f5f9;
+  --bg-elev: #f8fafc;
+  --bg-elev-2: #eef2f7;
+  --sidebar-bg: #f3f4f6;
+  --sidebar-hover: #e5e7eb;
+  --sidebar-active: rgba(37, 99, 235, 0.08);
   --chat-bg: #fbfaf7;
   --workspace-preview-bg: #fffdf9;
   --workspace-files-bg: #f3eee6;
@@ -205,74 +206,82 @@
   --workspace-selection-bg: #eaf1ff;
   --workspace-selection-fg: var(--accent);
   --workspace-selection-bar: var(--accent);
-  --border: #ded4c6;
-  --border-soft: #e9dfd3;
-  --fg: #1f1d1a;
-  --fg-dim: #555049;
-  --fg-faint: #82796f;
-  --accent: #2f5fa8;
+  --border: #dde1e7;
+  --border-soft: #e5e9f0;
+  --fg: #111827;
+  --fg-dim: #1f2937;
+  --fg-faint: #4b5563;
+  --accent: #2563eb;
   --accent-fg: #fff;
-  --accent-soft: rgba(47, 95, 168, 0.12);
-  --accent-strong: #244f91;
-  --ok: #5d9b66;
-  --list-row-title: #4f4942;
-  --list-row-meta: #8a8075;
-  --list-row-hover-bg: #e8dfd3;
-  --list-row-current-bg: #e3d9ca;
-  --list-row-current-title: #1f1d1a;
-  --list-row-current-meta: var(--accent);
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --accent-strong: #1d4ed8;
+  --ok: #15803d;
+  --list-row-title: #1f2937;
+  --list-row-meta: #4b5563;
+  --list-row-hover-bg: #f1f5f9;
+  --list-row-current-bg: #eef2ff;
+  --list-row-current-title: #111827;
+  --list-row-current-meta: var(--accent-strong);
   --tree-row-hover-bg: var(--workspace-files-hover);
   --tree-row-current-bg: color-mix(in srgb, var(--workspace-selection-bg) 42%, var(--workspace-files-bg));
   --tree-row-marker: var(--workspace-selection-bar);
 }
 
-:root[data-theme-style="graphite"] {
-  --accent: #d97757;
-  --accent-fg: #1a0f0a;
-  --accent-soft: rgba(217, 119, 87, 0.14);
-  --accent-strong: #e58a6b;
+:root[data-theme-style="graphite"] {--bg: #0b1020;      --bg-soft: #0f172a;    --bg-elev: #1c2844;    --bg-elev-2: #243454;
+  --sidebar-bg: #0e0f1c; --sidebar-hover: #181e30; --sidebar-active: rgba(125,211,252,.12);
+  --border: #2a3552;  --border-soft: #1e2944;
+  --fg: #f4f7fb;      --fg-dim: #d8dee9;     --fg-faint: #a7b1c2;
+  --accent: #7dd3fc;  --accent-fg: #0a1929;  --accent-soft: rgba(125,211,252,.14); --accent-strong: #a0e0ff;
+  --ok: #86efac;      --warn: #fbbf24;        --err: #f87171;
 }
-:root[data-theme-style="ember"] {
-  --accent: #f06d38;
-  --accent-fg: #1b0a04;
-  --accent-soft: rgba(240, 109, 56, 0.16);
-  --accent-strong: #ff8c5d;
+:root[data-theme-style="ember"] {--bg: #140f0b;      --bg-soft: #1f160f;    --bg-elev: #2a1d13;    --bg-elev-2: #38281a;
+  --sidebar-bg: #100d08; --sidebar-hover: #1f1610; --sidebar-active: rgba(251,146,60,.12);
+  --border: #3a2818;  --border-soft: #2a1c11;
+  --fg: #fff7ed;      --fg-dim: #f5dec8;     --fg-faint: #c8ad96;
+  --accent: #fb923c;  --accent-fg: #1b0a04;  --accent-soft: rgba(251,146,60,.16); --accent-strong: #fca85a;
+  --ok: #86efac;      --warn: #facc15;        --err: #fb7185;
 }
-:root[data-theme-style="aurora"] {
-  --accent: #34c3a6;
-  --accent-fg: #031613;
-  --accent-soft: rgba(52, 195, 166, 0.16);
-  --accent-strong: #5dd7bf;
+:root[data-theme-style="aurora"] {--bg: #071817;      --bg-soft: #0b2422;    --bg-elev: #12302d;    --bg-elev-2: #1a3f3b;
+  --sidebar-bg: #051210; --sidebar-hover: #0d1f1d; --sidebar-active: rgba(45,212,191,.12);
+  --border: #1a3f3b;  --border-soft: #122a27;
+  --fg: #ecfeff;      --fg-dim: #d1fae5;     --fg-faint: #a7c9bf;
+  --accent: #2dd4bf;  --accent-fg: #031613;  --accent-soft: rgba(45,212,191,.16); --accent-strong: #5eeadb;
+  --ok: #86efac;      --warn: #fbbf24;        --err: #fb7185;
 }
-:root[data-theme-style="midnight"] {
-  --accent: #b18cff;
-  --accent-fg: #10091e;
-  --accent-soft: rgba(177, 140, 255, 0.16);
-  --accent-strong: #c4a8ff;
+:root[data-theme-style="midnight"] {--bg: #1a1b26;      --bg-soft: #1f2335;    --bg-elev: #24283b;    --bg-elev-2: #2e3248;
+  --sidebar-bg: #16171f; --sidebar-hover: #1e2030; --sidebar-active: rgba(167,139,250,.12);
+  --border: #2e3248;  --border-soft: #22263a;
+  --fg: #c0caf5;      --fg-dim: #a9b1d6;     --fg-faint: #9aa5ce;
+  --accent: #a78bfa;  --accent-fg: #10091e;  --accent-soft: rgba(167,139,250,.16); --accent-strong: #c4b5fd;
+  --ok: #9ece6a;      --warn: #e0af68;        --err: #f7768e;
 }
-:root[data-theme-style="sandstone"] {
-  --accent: #c2613f;
-  --accent-fg: #fff;
-  --accent-soft: rgba(194, 97, 63, 0.12);
-  --accent-strong: #a94f30;
+:root[data-theme-style="sandstone"] {--bg: #fff4e3;      --bg-soft: #f3e3cc;    --bg-elev: #f8ebd8;    --bg-elev-2: #ead7bd;
+  --sidebar-bg: #f3e3cc; --sidebar-hover: #e8d7bd; --sidebar-active: rgba(37,99,235,.08);
+  --border: #d4c3a2;  --border-soft: #e0d0b5;
+  --fg: #24180f;      --fg-dim: #38291e;     --fg-faint: #6a5848;
+  --accent: #c05621;  --accent-fg: #fff;     --accent-soft: rgba(194,86,33,.12); --accent-strong: #9a3412;
+  --ok: #15803d;      --warn: #b45309;        --err: #dc2626;
 }
-:root[data-theme-style="porcelain"] {
-  --accent: #7d63c8;
-  --accent-fg: #fff;
-  --accent-soft: rgba(125, 99, 200, 0.12);
-  --accent-strong: #664eb0;
+:root[data-theme-style="porcelain"] {--bg: #ffffff;      --bg-soft: #f1f5f9;    --bg-elev: #f8fafc;    --bg-elev-2: #eef2f7;
+  --sidebar-bg: #f3f4f6; --sidebar-hover: #e5e7eb; --sidebar-active: rgba(124,58,237,.08);
+  --border: #dde1e7;  --border-soft: #e5e9f0;
+  --fg: #111827;      --fg-dim: #1f2937;     --fg-faint: #4b5563;
+  --accent: #7c3aed;  --accent-fg: #fff;     --accent-soft: rgba(124,58,237,.12); --accent-strong: #6d28d9;
+  --ok: #15803d;      --warn: #b45309;        --err: #dc2626;
 }
-:root[data-theme-style="linen"] {
-  --accent: #bd5d4d;
-  --accent-fg: #fff;
-  --accent-soft: rgba(189, 93, 77, 0.12);
-  --accent-strong: #a14c3e;
+:root[data-theme-style="linen"] {--bg: #fff8ed;      --bg-soft: #f4eadb;    --bg-elev: #fbf3e5;    --bg-elev-2: #eadcc9;
+  --sidebar-bg: #f4eadb; --sidebar-hover: #e8d9c2; --sidebar-active: rgba(194,86,33,.08);
+  --border: #d4c3a2;  --border-soft: #e0cfb5;
+  --fg: #1f1a14;      --fg-dim: #312820;     --fg-faint: #5a4a3c;
+  --accent: #c05621;  --accent-fg: #fff;     --accent-soft: rgba(194,86,33,.12); --accent-strong: #9a3412;
+  --ok: #15803d;      --warn: #b45309;        --err: #dc2626;
 }
-:root[data-theme-style="glacier"] {
-  --accent: #357fa8;
-  --accent-fg: #fff;
-  --accent-soft: rgba(53, 127, 168, 0.12);
-  --accent-strong: #276a8f;
+:root[data-theme-style="glacier"] {--bg: #f4faff;      --bg-soft: #eaf4fb;    --bg-elev: #f8fbff;    --bg-elev-2: #dceaf5;
+  --sidebar-bg: #eaf4fb; --sidebar-hover: #dae8f2; --sidebar-active: rgba(2,132,199,.08);
+  --border: #c4d8e8;  --border-soft: #d4e4f0;
+  --fg: #172033;      --fg-dim: #25334a;     --fg-faint: #4f647f;
+  --accent: #0284c7;  --accent-fg: #fff;     --accent-soft: rgba(2,132,199,.12); --accent-strong: #0369a1;
+  --ok: #15803d;      --warn: #b45309;        --err: #dc2626;
 }
 
 * {
@@ -550,7 +559,7 @@ body {
 }
 .sidebar-session__body {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 52px;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   min-width: 0;
   flex: 1;
@@ -5194,28 +5203,28 @@ body {
   flex: 0 0 auto;
 }
 .theme-style-swatch[data-theme-style-swatch="graphite"] {
-  background: #d97757;
+  background: #7dd3fc;
 }
 .theme-style-swatch[data-theme-style-swatch="ember"] {
-  background: #f06d38;
+  background: #fb923c;
 }
 .theme-style-swatch[data-theme-style-swatch="aurora"] {
-  background: #34c3a6;
+  background: #2dd4bf;
 }
 .theme-style-swatch[data-theme-style-swatch="midnight"] {
-  background: #b18cff;
+  background: #a78bfa;
 }
 .theme-style-swatch[data-theme-style-swatch="sandstone"] {
-  background: #c2613f;
+  background: #2563eb;
 }
 .theme-style-swatch[data-theme-style-swatch="porcelain"] {
-  background: #7d63c8;
+  background: #7c3aed;
 }
 .theme-style-swatch[data-theme-style-swatch="linen"] {
-  background: #bd5d4d;
+  background: #db2777;
 }
 .theme-style-swatch[data-theme-style-swatch="glacier"] {
-  background: #357fa8;
+  background: #0284c7;
 }
 .settings-config-path {
   margin-top: 18px;

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -35,6 +35,13 @@ func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	if got[2].Reasoning != "" {
 		t.Fatalf("non-assistant reasoning should stay hidden, got %q", got[2].Reasoning)
 	}
+	// Tool message: Content moves to ToolOutput, Content is cleared.
+	if got[2].ToolOutput != "tool output" {
+		t.Fatalf("tool output = %q, want tool output", got[2].ToolOutput)
+	}
+	if got[2].Content != "" {
+		t.Fatalf("tool message Content should be cleared, got %q", got[2].Content)
+	}
 	if got[3].Reasoning != "tool-call-only thinking" {
 		t.Fatalf("empty-content assistant reasoning = %q, want tool-call-only thinking", got[3].Reasoning)
 	}
@@ -59,5 +66,73 @@ func TestPreviewSessionMessagesLoadsWithoutResuming(t *testing.T) {
 	}
 	if got[1].Reasoning != "saved reasoning" {
 		t.Fatalf("preview reasoning = %q, want saved reasoning", got[1].Reasoning)
+	}
+}
+
+func TestHistoryMessagesToolCallsFromHistory(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "edit app.go"},
+		{
+			Role:    provider.RoleAssistant,
+			Content: "",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call_1", Name: "read_file", Arguments: `{"path":"app.go"}`},
+			},
+		},
+		{Role: provider.RoleTool, ToolCallID: "call_1", Name: "read_file", Content: "package main\n..."},
+		{
+			Role:    provider.RoleAssistant,
+			Content: "here is the file",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call_2", Name: "edit_file", Arguments: `{"path":"app.go","old":"x","new":"y"}`},
+			},
+		},
+		{Role: provider.RoleTool, ToolCallID: "call_2", Name: "edit_file", Content: "ok"},
+		{Role: provider.RoleAssistant, Content: "done"},
+	}
+
+	got := historyMessages(msgs, func(s string) string { return s })
+
+	// The tool messages (indices 2 and 4) should carry tool fields and empty Content.
+	if got[2].Role != "tool" {
+		t.Fatalf("msg[2] role = %q, want tool", got[2].Role)
+	}
+	if got[2].ToolName != "read_file" {
+		t.Fatalf("msg[2] toolName = %q, want read_file", got[2].ToolName)
+	}
+	if got[2].ToolOutput != "package main\n..." {
+		t.Fatalf("msg[2] toolOutput = %q", got[2].ToolOutput)
+	}
+	if got[2].ToolID != "call_1" {
+		t.Fatalf("msg[2] toolId = %q, want call_1", got[2].ToolID)
+	}
+	if got[2].ToolArgs != `{"path":"app.go"}` {
+		t.Fatalf("msg[2] toolArgs = %q, want args from paired assistant", got[2].ToolArgs)
+	}
+	if got[2].Content != "" {
+		t.Fatalf("msg[2] Content = %q, want empty (tool output moved to ToolOutput)", got[2].Content)
+	}
+
+	// Second tool message: edit_file with args from assistant
+	if got[4].ToolName != "edit_file" {
+		t.Fatalf("msg[4] toolName = %q, want edit_file", got[4].ToolName)
+	}
+	if got[4].ToolArgs != `{"path":"app.go","old":"x","new":"y"}` {
+		t.Fatalf("msg[4] toolArgs = %q", got[4].ToolArgs)
+	}
+	if got[4].ToolOutput != "ok" {
+		t.Fatalf("msg[4] toolOutput = %q, want ok", got[4].ToolOutput)
+	}
+
+	// Assistant messages (indices 1, 3, 5) should NOT have tool fields.
+	if got[1].ToolName != "" || got[1].ToolArgs != "" || got[1].ToolOutput != "" {
+		t.Fatalf("assistant msg[1] should not carry tool fields")
+	}
+	// The assistant-with-tool-calls-and-content at index 3 should still have its text.
+	if got[3].Content != "here is the file" {
+		t.Fatalf("msg[3] Content = %q, want \"here is the file\"", got[3].Content)
+	}
+	if got[5].Content != "done" {
+		t.Fatalf("msg[5] Content = %q, want done", got[5].Content)
 	}
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -218,6 +218,13 @@ type Agent struct {
 	// (a different failure shape, or any success). See applyStormBreaker.
 	stormSig   string
 	stormCount int
+
+	// steerQueue holds mid-turn user messages queued while the agent is
+	// running. Each is consumed once per loop iteration, persisted to the
+	// session, and remains visible for the rest of the turn.
+	steerMu       sync.Mutex
+	steerQueue    []string
+	steerConsumed bool
 }
 
 // SetPlanMode flips the read-only gate. While true, executeOne refuses any
@@ -225,6 +232,53 @@ type Agent struct {
 // running it. The cache-friendly bits — system prompt, tools schema, message
 // history — are left untouched, so the toggle costs nothing in cache hits.
 func (a *Agent) SetPlanMode(v bool) { a.planMode.Store(v) }
+
+// mid-turn steer marker
+const midTurnSteerPrefix = "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]"
+
+func midTurnSteerMessage(text string) string {
+	return midTurnSteerPrefix + "\n" + text
+}
+
+// Steer queues a message for mid-turn injection.
+func (a *Agent) Steer(text string) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = append(a.steerQueue, text)
+	a.steerConsumed = false
+}
+
+// SteerConsumed returns true when the steer queue became empty.
+func (a *Agent) SteerConsumed() bool {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return a.steerConsumed
+}
+
+func (a *Agent) consumeSteer() (string, bool) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	if len(a.steerQueue) == 0 {
+		return "", false
+	}
+	t := a.steerQueue[0]
+	a.steerQueue = a.steerQueue[1:]
+	a.steerConsumed = len(a.steerQueue) == 0
+	return t, true
+}
+
+func (a *Agent) clearSteerQueue() {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = nil
+	a.steerConsumed = false
+}
+
+func (a *Agent) steerQueueLen() int {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return len(a.steerQueue)
+}
 
 // SetGate installs the per-call permission gate. Used by `reasonix chat` to swap the
 // headless gate built in setup for an interactive one that prompts the user;
@@ -383,6 +437,10 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 // a round count. A positive maxSteps imposes an optional hard guard, surfaced as
 // a resumable notice when hit.
 func (a *Agent) Run(ctx context.Context, input string) error {
+	defer a.clearSteerQueue()
+	a.steerMu.Lock()
+	a.steerConsumed = false
+	a.steerMu.Unlock()
 	if a.evidence != nil {
 		a.evidence.Reset()
 	}
@@ -391,6 +449,11 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 	finalReadinessBlocks := 0
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
+		// Consume a queued steer and persist it to the session.
+		if text, ok := a.consumeSteer(); ok {
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: midTurnSteerMessage(text)})
+			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
+		}
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
 		prevPrefixShape := a.lastPrefixShape
@@ -435,6 +498,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + reason})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: finalReadinessRetryMessage(reason)})
 				a.maybeCompact(ctx, usage)
+				continue
+			}
+			if a.steerQueueLen() > 0 {
 				continue
 			}
 			return nil // model gave a final answer

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -27,6 +27,11 @@ type BranchMeta struct {
 	WorkspaceRoot    string    `json:"workspace_root,omitempty"`
 	TopicID          string    `json:"topic_id,omitempty"`
 	TopicTitle       string    `json:"topic_title,omitempty"`
+	PlanMode         bool      `json:"plan_mode,omitempty"`
+	Bypass           bool      `json:"bypass,omitempty"`
+	Model            string    `json:"model,omitempty"`
+	Preview          string    `json:"preview,omitempty"`
+	Turns            int       `json:"turns,omitempty"`
 }
 
 func (m BranchMeta) DefaultScope() string {
@@ -90,6 +95,12 @@ func LoadBranchMeta(sessionPath string) (BranchMeta, bool, error) {
 
 func SaveBranchMeta(sessionPath string, m BranchMeta) error {
 	return saveBranchMeta(sessionPath, m, true)
+}
+
+// SaveBranchMetaFlags persists fields (plan_mode, bypass, model, preview, turns) without
+// touching UpdatedAt — a mode/model switch is not session activity.
+func SaveBranchMetaFlags(sessionPath string, m BranchMeta) error {
+	return saveBranchMeta(sessionPath, m, false)
 }
 
 func saveBranchMeta(sessionPath string, m BranchMeta, touchUpdated bool) error {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -167,6 +167,13 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 // user-role messages so the picker can show "5 turns · 'help me debug the…'".
 // Errors are swallowed — a malformed file just shows up with an empty preview.
 func previewSession(path string) (string, int) {
+	// Fast path: read from .meta (cached on first full scan).
+	if m, ok, _ := LoadBranchMeta(path); ok {
+		if m.Preview != "" || m.Turns > 0 {
+			return m.Preview, m.Turns
+		}
+	}
+	// Slow path: full scan and cache.
 	f, err := os.Open(path)
 	if err != nil {
 		return "", 0
@@ -178,7 +185,7 @@ func previewSession(path string) (string, int) {
 	for {
 		var m provider.Message
 		if err := dec.Decode(&m); err != nil {
-			break // EOF or a malformed tail — return the preview gathered so far
+			break
 		}
 		if m.Role == provider.RoleUser {
 			turns++
@@ -190,6 +197,18 @@ func previewSession(path string) (string, int) {
 				first = s
 			}
 		}
+	}
+	// Cache the scan result in .meta for a fast next list.
+	if m, err := EnsureBranchMeta(path); err == nil {
+		m.Preview = first
+		m.Turns = turns
+		_ = SaveBranchMetaFlags(path, m)
+	}
+	// Cache the scan result in .meta for a fast next list.
+	if m, err := EnsureBranchMeta(path); err == nil {
+		m.Preview = first
+		m.Turns = turns
+		_ = SaveBranchMetaFlags(path, m)
 	}
 	return first, turns
 }

--- a/internal/agent/steer_test.go
+++ b/internal/agent/steer_test.go
@@ -1,0 +1,348 @@
+﻿package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// sinkRecorder records all events for inspection.
+type sinkRecorder struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (s *sinkRecorder) Emit(e event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+func (s *sinkRecorder) Events() []event.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]event.Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+// TestSteerQueuesAndConsumes verifies that Steer() queues a message and
+// consumeSteer() returns it at the next iteration boundary.
+func TestSteerQueuesAndConsumes(t *testing.T) {
+	mp := testutil.NewMock("m", testutil.Turn{Text: "ok"})
+	sink := &sinkRecorder{}
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, sink)
+
+	// Steer before Run
+	a.Steer("focus on tests")
+	if err := a.Run(context.Background(), "write code"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Verify the steer appears in the API request as a user message
+	reqs := mp.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("no API requests recorded")
+	}
+	lastReq := reqs[len(reqs)-1]
+
+	// The steer should be the last user message before the assistant turn
+	var steerFound bool
+	for _, msg := range lastReq.Messages {
+		if msg.Role == provider.RoleUser && msg.Content == midTurnSteerMessage("focus on tests") {
+			steerFound = true
+			break
+		}
+	}
+	if !steerFound {
+		t.Fatal("steer message not found in API request messages")
+	}
+}
+
+// TestSteerConsumedGates verifies that steerConsumed and SteerConsumed work.
+func TestSteerConsumedGates(t *testing.T) {
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	// Initially not consumed (nothing to consume)
+	if a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be false initially")
+	}
+
+	// After Steer(), steerConsumed should still be false (not consumed yet)
+	a.Steer("hello")
+	if a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be false after Steer() but before consume")
+	}
+
+	// Consume the steer — should set steerConsumed = true (queue now empty)
+	text, ok := a.consumeSteer()
+	if !ok || text != "hello" {
+		t.Fatalf("consumeSteer got %q, %v", text, ok)
+	}
+	if !a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be true after consuming last item")
+	}
+
+	// Steer again — resets to false
+	a.Steer("world")
+	if a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be false after new Steer()")
+	}
+}
+
+// TestMultipleSteersFIFO verifies multiple steers are consumed in FIFO order.
+func TestMultipleSteersFIFO(t *testing.T) {
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	a.Steer("first")
+	a.Steer("second")
+	a.Steer("third")
+
+	// Consume in FIFO order
+	for _, want := range []string{"first", "second"} {
+		got, ok := a.consumeSteer()
+		if !ok || got != want {
+			t.Fatalf("consumeSteer got %q, want %q", got, want)
+		}
+		// steerConsumed should be false because queue is not empty yet
+		if a.SteerConsumed() {
+			t.Fatal("SteerConsumed should be false while items remain")
+		}
+	}
+
+	// Last one — queue becomes empty
+	got, ok := a.consumeSteer()
+	if !ok || got != "third" {
+		t.Fatalf("consumeSteer got %q, want %q", got, "third")
+	}
+	if !a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be true after consuming last item")
+	}
+}
+
+// TestSteerNoToolCallsContinuesWithMoreSteers verifies that when the model
+// gives a final answer but there are still queued steers, the loop continues
+// instead of returning done.
+func TestSteerNoToolCallsContinuesWithMoreSteers(t *testing.T) {
+	// Script: first turn returns text with no tool calls (final answer)
+	// but the steer queue has more items.
+	mp := testutil.NewMock("m",
+		testutil.Turn{Text: "first answer"},
+		testutil.Turn{Text: "second answer"},
+	)
+	sink := &sinkRecorder{}
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, sink)
+
+	// Queue two steers from the start
+	a.Steer("guidance one")
+	a.Steer("guidance two")
+
+	if err := a.Run(context.Background(), "initial prompt"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The loop should have made 2 API calls (one per steer)
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 API requests (one per steer), got %d", len(reqs))
+	}
+
+	// First request should contain "guidance one"
+	req1 := reqs[0]
+	found1 := false
+	for _, msg := range req1.Messages {
+		if msg.Role == provider.RoleUser && msg.Content == midTurnSteerMessage("guidance one") {
+			found1 = true
+			break
+		}
+	}
+	if !found1 {
+		t.Fatal("first request missing 'guidance one' steer")
+	}
+
+	// Second request should contain "guidance two"
+	req2 := reqs[1]
+	found2 := false
+	for _, msg := range req2.Messages {
+		if msg.Role == provider.RoleUser && msg.Content == midTurnSteerMessage("guidance two") {
+			found2 = true
+			break
+		}
+	}
+	if !found2 {
+		t.Fatal("second request missing 'guidance two' steer")
+	}
+}
+
+// TestSteerEventEmitted verifies a Steer event is emitted when a steer is consumed.
+func TestSteerEventEmitted(t *testing.T) {
+	mp := testutil.NewMock("m", testutil.Turn{Text: "ok"})
+	sink := &sinkRecorder{}
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, sink)
+
+	a.Steer("guide me")
+	if err := a.Run(context.Background(), "do it"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	events := sink.Events()
+	var steerEvents []event.Event
+	for _, e := range events {
+		if e.Kind == event.Steer {
+			steerEvents = append(steerEvents, e)
+		}
+	}
+	if len(steerEvents) == 0 {
+		t.Fatal("no Steer events emitted")
+	}
+	if steerEvents[0].Text != "guide me" {
+		t.Fatalf("Steer event text = %q, want %q", steerEvents[0].Text, "guide me")
+	}
+}
+
+// TestSteerQueueEmptiedOnRunExit verifies clearSteerQueue runs when Run exits.
+func TestSteerQueueEmptiedOnRunExit(t *testing.T) {
+	mp := testutil.NewMock("m", testutil.Turn{Text: "ok"})
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	// Steer before Run
+	a.Steer("hello")
+
+	// Run should consume the steer, then clear on exit (defer)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Queue should be empty after Run exits
+	if text, ok := a.consumeSteer(); ok {
+		t.Fatalf("expected empty steer queue after Run, got %q", text)
+	}
+}
+
+// TestSteerWrappedWithMessage verifies the steer message is wrapped with
+// the mid-turn steer prefix.
+func TestSteerWrappedWithMessage(t *testing.T) {
+	wrapped := midTurnSteerMessage("focus on tests")
+	if wrapped != midTurnSteerPrefix+"\n"+"focus on tests" {
+		t.Fatalf("unexpected wrap format: %q", wrapped)
+	}
+}
+
+// TestSteerPersistsAcrossIterations verifies that a mid-turn steer,
+// once consumed and persisted to the session, appears in every
+// subsequent API request within the same turn — not just the one
+// where it was consumed. This is the key difference from the
+// pre-fix behaviour where a steer was spliced into a temporary
+// msgs copy and lost on the next iteration.
+func TestSteerPersistsAcrossIterations(t *testing.T) {
+	reg := tool.NewRegistry()
+	// Register a read-only tool so the agent can execute it without gating.
+	reg.Add(fakeTool{name: "ls", readOnly: true})
+
+	// Script: first turn returns a tool call (so the loop iterates again),
+	// second turn returns a final answer.
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "ls", Arguments: `{}`}},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	sink := &sinkRecorder{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	a.Steer("use short responses")
+	if err := a.Run(context.Background(), "list files"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 API requests (tool call + final answer), got %d", len(reqs))
+	}
+
+	steerMsg := midTurnSteerMessage("use short responses")
+
+	// The steer must appear in the first request (iteration 1).
+	found1 := msgListContains(reqs[0].Messages, provider.RoleUser, steerMsg)
+	if !found1 {
+		t.Fatal("iteration 1: steer message not found in API request")
+	}
+
+	// The steer must also appear in the second request (iteration 2)
+	// — proving it persisted in the session, not just a temporary copy.
+	found2 := msgListContains(reqs[1].Messages, provider.RoleUser, steerMsg)
+	if !found2 {
+		t.Fatal("iteration 2: steer message NOT found — it was lost after the first iteration (pre-fix behaviour)")
+	}
+
+	// The steer should appear exactly once in each request (not duplicated).
+	count1 := msgCount(reqs[0].Messages, provider.RoleUser, steerMsg)
+	count2 := msgCount(reqs[1].Messages, provider.RoleUser, steerMsg)
+	if count1 != 1 {
+		t.Fatalf("iteration 1: steer appears %d times, want 1", count1)
+	}
+	if count2 != 1 {
+		t.Fatalf("iteration 2: steer appears %d times, want 1", count2)
+	}
+}
+
+// TestSteerPersistsWhenInjectedMidLoop verifies that a steer injected
+// after the turn has already started (simulating a real mid-turn user
+// interaction) also persists into subsequent iterations.
+func TestSteerPersistsWhenInjectedMidLoop(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "ls", readOnly: true})
+
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "ls", Arguments: `{}`}},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	sink := &sinkRecorder{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	// Simulate the real scenario: the steer arrives during the turn,
+	// not before it. We steer right before Run — the effect is the
+	// same as a user typing while the agent is in iteration 0 (the
+	// steer is consumed at the iteration 1 boundary in practice, but
+	// here it's already queued at iteration 0).
+	a.Steer("mid-turn correction")
+
+	if err := a.Run(context.Background(), "do work"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 API requests, got %d", len(reqs))
+	}
+
+	steerMsg := midTurnSteerMessage("mid-turn correction")
+
+	if !msgListContains(reqs[0].Messages, provider.RoleUser, steerMsg) {
+		t.Fatal("iteration 1: steer not found")
+	}
+	if !msgListContains(reqs[1].Messages, provider.RoleUser, steerMsg) {
+		t.Fatal("iteration 2: steer NOT found — persistence broken")
+	}
+}
+
+func msgListContains(msgs []provider.Message, role provider.Role, content string) bool {
+	return msgCount(msgs, role, content) > 0
+}
+
+func msgCount(msgs []provider.Message, role provider.Role, content string) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Role == role && m.Content == content {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -71,6 +71,9 @@ type chatTUI struct {
 	// the provider re-attempts the connection; cleared by the next stream event.
 	retryAttempt int
 	retryMax     int
+	// steerStaged counts queued mid-turn steers not yet consumed.
+	steerStaged int
+
 	// turnTokens accumulates this turn's output tokens (summed from per-step Usage
 	// events) for the live "↓N" readout in the running status line.
 	turnTokens int
@@ -504,6 +507,31 @@ func (m *chatTUI) prompts() []plugin.Prompt {
 	return m.host.Prompts()
 }
 
+func (m *chatTUI) mcpTools() []plugin.ToolRef {
+	if m.host == nil {
+		return nil
+	}
+	return m.host.Tools()
+}
+
+func (m *chatTUI) isMCPPromptName(name string) bool {
+	for _, p := range m.prompts() {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *chatTUI) isMCPToolName(name string) bool {
+	for _, t := range m.mcpTools() {
+		if t.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (m chatTUI) Init() tea.Cmd {
 	return tea.Batch(
 		textarea.Blink,
@@ -512,6 +540,11 @@ func (m chatTUI) Init() tea.Cmd {
 		m.runStatusline(), // nil (no-op) unless a custom status line is configured
 		m.refreshGitStatus(),
 	)
+}
+
+func isSteerCommand(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	return strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "#	") || strings.HasPrefix(trimmed, "!")
 }
 
 func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -868,14 +901,14 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			if m.state == tuiRunning {
 				line := strings.TrimSpace(m.input.Value())
-				if line == "" {
+				if line == "" || isSteerCommand(line) {
 					return m, nil
 				}
-				m.pendingInterject = append(m.pendingInterject, line)
+				m.ctrl.Steer(line)
+				m.steerStaged++
 				m.input.Reset()
 				m.input.SetHeight(1)
 				m.pastedBlocks = nil
-				m.notice("feedback queued — will send when the current turn finishes")
 				return m, finalize(m, cmds)
 			}
 			if m.modelSwitchPending {
@@ -1752,12 +1785,21 @@ func (m chatTUI) View() tea.View {
 		parts = append(parts, menu)
 		rowsAboveBox += strings.Count(menu, "\n") + 1
 	}
+	// Steer staged indicator.
+	var steerIndicator string
+	if m.steerStaged > 0 {
+		steerIndicator = fmt.Sprintf("  ▸ %d staged · esc to stop", m.steerStaged)
+	}
 	// Layout: the working spinner (when running), then the composer when visible,
 	// then the two status rows (line 1 = mode + shortcuts/state, line 2 = live data).
 	// Each row is clamped to width independently so neither wraps; padding to full
 	// width keeps a short row from leaving stale cells from the prior frame.
 	if working != "" {
 		parts = append(parts, workingStyle.Width(boxW).MaxWidth(boxW).Render(clampStatusLine(working, boxW)))
+		rowsAboveBox++
+	}
+	if steerIndicator != "" {
+		parts = append(parts, lipgloss.NewStyle().Width(boxW).MaxWidth(boxW).Render(clampStatusLine(steerIndicator, boxW)))
 		rowsAboveBox++
 	}
 	if footer := m.renderMainManagerFooter(); footer != "" {
@@ -2398,6 +2440,7 @@ func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string) tea.Cmd
 	m.runStart = time.Now()
 	m.elapsed = 0
 	m.turnTokens = 0
+	m.steerStaged = 0
 	// The controller owns the run goroutine, its context, and cancellation; it
 	// streams events to eventCh and emits TurnDone when the turn settles.
 	m.ctrl.SendWithRaw(sent, raw)
@@ -2584,6 +2627,13 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 			m.host = m.ctrl.Host()
 		}
 		m.refreshMCPManager()
+
+	case event.Steer:
+		if m.steerStaged > 0 {
+			m.steerStaged--
+		}
+		m.finalizeStreamed()
+		m.commitLine(dim("  ▸ steer: " + e.Text))
 
 	case event.TurnDone:
 		// The turn settled — freeze anything still streaming, surface a real error,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -563,6 +563,7 @@ func (c *Controller) notice(text string) {
 // just needs the exit status — no TurnDone event, no cancel bookkeeping.
 func (c *Controller) Run(ctx context.Context, input string) error {
 	c.maybeSessionStart(ctx)
+	input = c.Compose(input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	if c.hooks.Enabled() {
@@ -676,6 +677,15 @@ func (c *Controller) SetPlanMode(v bool) {
 	if c.executor != nil {
 		c.executor.SetPlanMode(v)
 	}
+	// Persist to session meta so the mode survives a restart.
+	path := c.SessionPath()
+	if path != "" {
+		m, err := agent.EnsureBranchMeta(path)
+		if err == nil {
+			m.PlanMode = v
+			_ = agent.SaveBranchMetaFlags(path, m)
+		}
+	}
 }
 
 // PlanMode reports whether outgoing turns currently receive the plan-mode
@@ -705,6 +715,10 @@ func (c *Controller) maybeSessionStart(ctx context.Context) {
 		return
 	}
 	c.startedOnce = true
+	// Lazy-init the session path on first turn.
+	if c.sessionPath == "" && c.sessionDir != "" {
+		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
+	}
 	c.mu.Unlock()
 	c.hooks.SessionStart(ctx)
 }
@@ -719,7 +733,13 @@ func (c *Controller) NewSession() error {
 	if err := c.Snapshot(); err != nil {
 		return err
 	}
-	c.hooks.SessionEnd(context.Background())
+	// SessionEnd only fires when the old session had at least one turn.
+	c.mu.Lock()
+	hadTurns := c.turn > 0
+	c.mu.Unlock()
+	if hadTurns {
+		c.hooks.SessionEnd(context.Background())
+	}
 	if c.sessionDir != "" {
 		c.mu.Lock()
 		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
@@ -728,9 +748,9 @@ func (c *Controller) NewSession() error {
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
-	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
+	c.turn = 0
+	c.startedOnce = false // SessionStart fires lazily on the first turn, not here
 	c.mu.Unlock()
-	c.hooks.SessionStart(context.Background())
 	return nil
 }
 
@@ -1061,8 +1081,32 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	}
 	c.mu.Lock()
 	c.sessionPath = path
+	c.startedOnce = false // allow SessionStart on the resumed session's first turn
 	c.mu.Unlock()
 	c.rebindCheckpoints(path)
+	// Restore the saved mode from the session meta.
+	if m, ok, err := agent.LoadBranchMeta(path); err == nil && ok {
+		if m.PlanMode {
+			c.mu.Lock()
+			c.planMode = true
+			c.mu.Unlock()
+			if c.executor != nil {
+				c.executor.SetPlanMode(true)
+			}
+		} else if m.Bypass {
+			c.mu.Lock()
+			c.bypass = true
+			c.mu.Unlock()
+		}
+	} else {
+		c.mu.Lock()
+		c.planMode = false
+		c.bypass = false
+		c.mu.Unlock()
+		if c.executor != nil {
+			c.executor.SetPlanMode(false)
+		}
+	}
 }
 
 // Snapshot writes the executor's conversation to the active session file. No-op
@@ -1538,6 +1582,27 @@ func (c *Controller) Bypass() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.bypass
+}
+
+// Steer queues guidance mid-turn without interrupting the in-flight request.
+func (c *Controller) Steer(text string) {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		exec.Steer(text)
+	}
+}
+
+// SteerConsumed returns true when the steer queue is empty after the last consume.
+func (c *Controller) SteerConsumed() bool {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		return exec.SteerConsumed()
+	}
+	return true
 }
 
 // --- memory ---

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -79,6 +79,11 @@ const (
 	// event — or TurnDone — clears. Appended last to keep the Kind values before
 	// it wire-stable.
 	Retrying
+	// Steer fires when a mid-turn steer message is consumed from the queue and
+	// injected as a user message. Text carries the raw steer content (without the
+	// wrapper prefix), so a frontend can display it to the user as confirmation.
+	// Frontends use Steer to know a queued message has been delivered.
+	Steer
 )
 
 // Level classifies a Notice so sinks can style or filter it.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -81,6 +81,28 @@ type Host struct {
 	bgWrites sync.WaitGroup
 }
 
+
+// ToolRef is an MCP tool surface for the slash menu, carrying name,
+// server, and a one-line description.
+type ToolRef struct {
+	Name        string
+	Server      string
+	Description string
+}
+
+// Tools returns the discovered MCP tools across all connected servers.
+func (h *Host) Tools() []ToolRef {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	var out []ToolRef
+	for _, cl := range h.clients {
+		for _, t := range cl.tools {
+			out = append(out, ToolRef{Name: t.Name, Server: cl.name, Description: t.Description})
+		}
+	}
+	return out
+}
+
 // Prompts returns every MCP prompt discovered across connected servers.
 func (h *Host) Prompts() []Prompt {
 	h.mu.RLock()

--- a/internal/proc/hide_windows.go
+++ b/internal/proc/hide_windows.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	createNoWindow  = 0x08000000 // CREATE_NO_WINDOW
-	detachedProcess = 0x00000008 // DETACHED_PROCESS
+	createNoWindow         = 0x08000000 // CREATE_NO_WINDOW
+	detachedProcess        = 0x00000008 // DETACHED_PROCESS
+	createNewProcessGroup  = 0x00000200 // CREATE_NEW_PROCESS_GROUP
 )
 
 // HideWindow stops a child process from flashing a console window on Windows,
@@ -21,7 +22,7 @@ func HideWindow(cmd *exec.Cmd) {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.HideWindow = true
-	cmd.SysProcAttr.CreationFlags |= createNoWindow
+	cmd.SysProcAttr.CreationFlags |= createNoWindow | createNewProcessGroup
 }
 
 // HideWindowDetached is for short-lived desktop-only probes whose descendants


### PR DESCRIPTION
## Summary

Adds mid-turn steer (inject guidance while agent is running), session-scoped
model/mode memory, preview caching, and several desktop UX fixes.

### Mid-turn steer
- Agent FIFO steer queue consumed at iteration boundaries, persisted to session
- New `Steer` event kind for frontend confirmation
- CLI: Enter during running steers (slash/bang/memory commands still rejected)
- Desktop: wired through bridge → useController → App.tsx with `runningRef`
- 8 steer tests covering FIFO, gating, persistence, event emission

### Session memory & mode persistence
- `BranchMeta` gains `PlanMode`/`Bypass`/`Model`/`Preview`/`Turns` fields
- `SaveBranchMetaFlags` persists without touching `UpdatedAt`
- `previewSession` reads from `.meta` cache (O(1) sidebar)
- `SetPlanMode`/`SetBypass` persist to session meta
- `ResumeSession` restores saved model and plan/bypass modes
- Lazy session-path creation (no throwaway empty files on boot)
- History tool-call cards visible in sidebar and history panel

### MCP tools in slash menu
- `plugin.ToolRef` type + `Host.Tools()` method for MCP tool discovery
- CLI autocomplete lists MCP tools alongside prompts

### Desktop UX improvements
| Area | Change |
|------|--------|
| Sidebar | session time shows seconds; grid width auto; blue theme palette |
| Sessions | dedup by display key, async cleanup, 500ms list cache |
| Pin | current session auto-sorts to top |
| Resume | async model switch (UI never blocks) |
| Theme | full color overhaul: 8 theme-style blocks with complete palette |
| Windows | `CREATE_NEW_PROCESS_GROUP` suppresses child console flashes |
| Steer | `runningRef` fixes stale closure in `handleSend` |

### Verification
| Check | Status |
|-------|--------|
| `go build ./internal/...` | ✅ |
| `go test ./internal/agent/...` | ✅ (8 steer tests) |
| `wails build` | ✅ |