### PR TITLE
fix(desktop): link Linux release against WebKitGTK 4.1

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -69,12 +69,13 @@ jobs:
         with:
           version: 10
 
-      # Linux: WebKitGTK 4.0 toolchain (pinned to ubuntu-22.04; no webkit2_41 tag).
+      # Linux: WebKitGTK 4.1 toolchain (-tags webkit2_41 in desktop-build.sh).
+      # 4.1 ships from ubuntu-22.04 on and is the only one present on 24.04+/Fedora 40+.
       - name: Install Linux build deps
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.0-dev
+          sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.1-dev
 
       # Windows: NSIS provides makensis for `wails build -nsis`.
       - name: Install NSIS

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -90,6 +90,8 @@ tags are the CLI release). Pushing one triggers `.github/workflows/release-deskt
 which builds on a native runner per platform (Wails can't cross-compile a
 CGO/WebKit binary), packages each artifact, signs it with minisign, generates a
 `latest.json` manifest, publishes a GitHub release, and mirrors everything to R2.
+The Linux artifact links against WebKitGTK 4.1 (`-tags webkit2_41`), so it needs
+`libwebkit2gtk-4.1-0` at runtime — present by default on Ubuntu 22.04+, Fedora 40+.
 
 ```sh
 git tag desktop-v1.1.0 && git push origin desktop-v1.1.0

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -36,6 +36,9 @@ node -e 'const fs=require("fs"),f="wails.json",j=JSON.parse(fs.readFileSync(f,"u
 # NSIS installer is Windows-only (Wails requires a single windows target for -nsis).
 build_args=(-clean -platform "$PLATFORM" -ldflags "-X main.version=$VERSION")
 [ "$os" = windows ] && build_args+=(-nsis)
+# Link cgo against WebKitGTK 4.1: 4.0 (libwebkit2gtk-4.0.so.37) is gone on
+# Ubuntu 24.04+/Fedora 40+, while 4.1 ships from Ubuntu 22.04 onward.
+[ "$os" = linux ] && build_args+=(-tags webkit2_41)
 
 echo "==> wails build ${build_args[*]}"
 wails build "${build_args[@]}"


### PR DESCRIPTION
## Problem

The shipped Linux build fails to launch on Ubuntu 24.04+ / 25.10 (and Fedora 40+, Arch):

```
./reasonix-desktop: error while loading shared libraries:
libwebkit2gtk-4.0.so.37: cannot open shared object file: No such file or directory
```

The release build linked against **WebKitGTK 4.0**, which those distros have dropped entirely — they ship only **4.1** (`libwebkit2gtk-4.1.so.0`). Notably `desktop/README.md` already documented the `webkit2_41` build tag for local builds, but the release pipeline never passed it, so the official artifact stayed pinned to 4.0.

## Fix

- `scripts/desktop-build.sh` — pass `-tags webkit2_41` on Linux so cgo links against 4.1.
- `.github/workflows/release-desktop.yml` — install `libwebkit2gtk-4.1-dev` instead of `-4.0-dev`.
- `desktop/README.md` — note the released Linux binary now needs `libwebkit2gtk-4.1-0` at runtime.

## Compatibility

WebKitGTK 4.1 is available from **Ubuntu 22.04** onward and on Fedora 40+/Arch, so the `ubuntu-22.04` build runner is unchanged and the new binary runs across 22.04 → 25.10. Distros that only have 4.0 (Ubuntu 20.04 and older) lose support, but 4.0 is being removed upstream everywhere and a single binary can't link both.

Closes #3154
