### PR TITLE
fix(provider): replay an SSE stream cut before any token

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -144,8 +144,37 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 	}
 
 	out := make(chan provider.Chunk)
-	go c.readStream(ctx, resp, out)
+	go c.streamWithReconnect(ctx, resp, newReq, out)
 	return out, nil
+}
+
+// maxStreamReconnects bounds how many times a mid-stream connection drop is
+// replayed from scratch before the error is surfaced — each replay re-runs the
+// whole request (cheap under prompt caching, but not free).
+const maxStreamReconnects = 3
+
+// streamWithReconnect drives readStream and, when the connection is cut before
+// any model output has been forwarded, replays the request rather than failing
+// the turn. Once a token (reasoning/text/tool-call) has been emitted, a replay
+// would duplicate output, so the error is surfaced instead.
+func (c *client) streamWithReconnect(ctx context.Context, resp *http.Response, newReq func(context.Context) (*http.Request, error), out chan<- provider.Chunk) {
+	defer close(out)
+	for attempt := 0; ; attempt++ {
+		emitted, err := c.readStream(ctx, resp, out)
+		if err == nil {
+			return
+		}
+		if emitted || attempt >= maxStreamReconnects || !provider.IsConnReset(err) {
+			out <- provider.Chunk{Type: provider.ChunkError, Err: err}
+			return
+		}
+		next, rerr := provider.SendWithRetry(ctx, c.http, c.name, c.keyEnv, newReq)
+		if rerr != nil {
+			out <- provider.Chunk{Type: provider.ChunkError, Err: rerr}
+			return
+		}
+		resp = next
+	}
 }
 
 func (c *client) buildRequest(req provider.Request) chatRequest {
@@ -200,13 +229,13 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 	return out
 }
 
-// readStream parses the SSE stream, emits text deltas live, accumulates tool-call
-// fragments internally, and emits complete ToolCalls (by index) when done. Each
-// call also gets a ChunkToolCallStart the moment its name is known, so a frontend
-// can show the tool card while the arguments are still streaming.
-func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<- provider.Chunk) {
+// readStream parses one SSE response into chunks: text deltas stream live,
+// tool-call fragments accumulate by index and emit complete on [DONE], and a
+// ChunkToolCallStart fires the moment a call's name is known. It returns whether
+// any model output was forwarded (so the caller can decide a replay is safe) and
+// the first fatal error — a nil error means the stream reached [DONE].
+func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<- provider.Chunk) (emitted bool, _ error) {
 	defer resp.Body.Close()
-	defer close(out)
 
 	// Close the response body when the context is canceled so scanner.Scan()
 	// unblocks instead of hanging on a stalled connection. done lets the goroutine
@@ -243,12 +272,10 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 
 		var sr streamResponse
 		if err := json.Unmarshal([]byte(data), &sr); err != nil {
-			out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: decode stream: %w", c.name, err)}
-			return
+			return emitted, fmt.Errorf("%s: decode stream: %w", c.name, err)
 		}
 		if sr.Error != nil {
-			out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: %s", c.name, sr.Error.Message)}
-			return
+			return emitted, fmt.Errorf("%s: %s", c.name, sr.Error.Message)
 		}
 		if len(sr.Choices) > 0 && sr.Choices[0].FinishReason != nil && *sr.Choices[0].FinishReason != "" {
 			lastFinishReason = *sr.Choices[0].FinishReason
@@ -256,6 +283,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		if sr.Usage != nil {
 			u := normaliseUsage(sr.Usage)
 			u.FinishReason = lastFinishReason
+			emitted = true
 			out <- provider.Chunk{Type: provider.ChunkUsage, Usage: u}
 		}
 		if len(sr.Choices) == 0 {
@@ -264,14 +292,17 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 
 		delta := sr.Choices[0].Delta
 		if delta.ReasoningContent != "" {
+			emitted = true
 			out <- provider.Chunk{Type: provider.ChunkReasoning, Text: delta.ReasoningContent}
 		}
 		if delta.Content != "" {
 			r, txt := think.push(delta.Content)
 			if r != "" {
+				emitted = true
 				out <- provider.Chunk{Type: provider.ChunkReasoning, Text: r}
 			}
 			if txt != "" {
+				emitted = true
 				out <- provider.Chunk{Type: provider.ChunkText, Text: txt}
 			}
 		}
@@ -294,14 +325,14 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 			// (possibly large) arguments finish streaming.
 			if !started[tc.Index] && cur.Name != "" {
 				started[tc.Index] = true
+				emitted = true
 				out <- provider.Chunk{Type: provider.ChunkToolCallStart, ToolCall: &provider.ToolCall{ID: cur.ID, Name: cur.Name}}
 			}
 		}
 	}
 
 	if err := scanner.Err(); err != nil {
-		out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: read stream: %w", c.name, err)}
-		return
+		return emitted, fmt.Errorf("%s: read stream: %w", c.name, err)
 	}
 
 	if r, txt := think.flush(); r != "" || txt != "" {
@@ -325,6 +356,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		out <- provider.Chunk{Type: provider.ChunkToolCall, ToolCall: tc}
 	}
 	out <- provider.Chunk{Type: provider.ChunkDone}
+	return emitted, nil
 }
 
 // normaliseUsage folds the two cache-hit shapes the OpenAI-compatible ecosystem

--- a/internal/provider/openai/reconnect_test.go
+++ b/internal/provider/openai/reconnect_test.go
@@ -1,0 +1,120 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+// rstAfter writes a 200 SSE head plus the given prelude, then forces a TCP RST
+// (SetLinger(0) + Close) so the client read fails like a proxy that idle-drops
+// the long-lived connection (wsarecv: forcibly closed), not a clean EOF.
+func rstAfter(t *testing.T, w http.ResponseWriter, prelude string) {
+	t.Helper()
+	hj, ok := w.(http.Hijacker)
+	if !ok {
+		t.Fatal("ResponseWriter is not a Hijacker")
+	}
+	conn, buf, err := hj.Hijack()
+	if err != nil {
+		t.Fatalf("hijack: %v", err)
+	}
+	_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\n\r\n")
+	_, _ = buf.WriteString(prelude)
+	_ = buf.Flush()
+	if tcp, ok := conn.(*net.TCPConn); ok {
+		_ = tcp.SetLinger(0)
+	}
+	_ = conn.Close()
+}
+
+// TestStreamReconnectsOnEarlyConnReset reproduces issue #3148: a local proxy
+// (v2rayN/sing-box) forcibly closes the idle SSE connection during a reasoner's
+// first-token gap, before any token is emitted. The drop must be replayed
+// transparently — the caller sees one clean stream, never an error.
+func TestStreamReconnectsOnEarlyConnReset(t *testing.T) {
+	var reqs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		if reqs == 1 {
+			rstAfter(t, w, ": keep-alive\n\n") // a comment line, zero model output
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"recovered\"}}]}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var text strings.Builder
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("early conn reset should be replayed, not surfaced: %v", chunk.Err)
+		}
+		if chunk.Type == provider.ChunkText {
+			text.WriteString(chunk.Text)
+		}
+	}
+	if text.String() != "recovered" {
+		t.Errorf("text = %q, want %q", text.String(), "recovered")
+	}
+	if reqs != 2 {
+		t.Errorf("server saw %d requests, want 2 (one reset + one replay)", reqs)
+	}
+}
+
+// TestStreamDoesNotReplayAfterOutput guards against duplicated output: once a
+// token has streamed, a mid-stream reset must surface as an error rather than
+// replaying the request (which would re-emit the already-shown text).
+func TestStreamDoesNotReplayAfterOutput(t *testing.T) {
+	var reqs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		rstAfter(t, w, "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var text strings.Builder
+	var gotErr bool
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkText:
+			text.WriteString(chunk.Text)
+		case provider.ChunkError:
+			gotErr = true
+		}
+	}
+	if text.String() != "partial" {
+		t.Errorf("text = %q, want %q (the one delta that streamed)", text.String(), "partial")
+	}
+	if !gotErr {
+		t.Error("a reset after output should surface a ChunkError")
+	}
+	if reqs != 1 {
+		t.Errorf("server saw %d requests, want 1 (no replay after output)", reqs)
+	}
+}

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -76,6 +78,27 @@ func transientErr(err error) bool {
 		return false
 	}
 	return true
+}
+
+// IsConnReset reports whether err is a connection-level drop (peer reset,
+// truncated body, closed socket) as opposed to a protocol or caller error. A
+// stream cut this way mid-body can be replayed from scratch, unlike a decode or
+// 4xx error. The common trigger is a local proxy (v2rayN/sing-box) idle-closing
+// the long-lived SSE connection during a reasoner's first-token gap.
+func IsConnReset(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, io.EOF) ||
+		errors.Is(err, net.ErrClosed) ||
+		errors.Is(err, syscall.ECONNRESET) || errors.Is(err, syscall.ECONNABORTED) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 func backoffDelay(attempt int, retryAfter time.Duration) time.Duration {

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -3,9 +3,12 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -48,6 +51,27 @@ func TestTransientErr(t *testing.T) {
 	}
 	if !transientErr(errors.New("connection reset")) {
 		t.Error("network-ish error should be transient")
+	}
+}
+
+func TestIsConnReset(t *testing.T) {
+	if IsConnReset(nil) {
+		t.Error("nil is not a conn reset")
+	}
+	if IsConnReset(context.Canceled) || IsConnReset(context.DeadlineExceeded) {
+		t.Error("ctx cancel/deadline must not look like a recoverable reset")
+	}
+	if IsConnReset(errors.New("decode stream: invalid character")) {
+		t.Error("a plain protocol error must not be treated as a conn reset")
+	}
+	for _, err := range []error{
+		io.ErrUnexpectedEOF,
+		&net.OpError{Op: "read", Err: syscall.ECONNRESET},
+		fmt.Errorf("read stream: %w", &net.OpError{Op: "read", Err: errors.New("wsarecv: forcibly closed")}),
+	} {
+		if !IsConnReset(err) {
+			t.Errorf("want conn reset for %v", err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

With a local proxy in front of the API (v2rayN / sing-box core), a streaming turn dies mid-flight:

```
deepseek-flash: read stream: read tcp 127.0.0.1:7442->127.0.0.1:10808:
wsarecv: An existing connection was forcibly closed by the remote host.
```

The dominant trigger: a reasoner has a long time-to-first-token (prefill + thinking) during which **no bytes flow**, so the proxy treats the long-lived SSE connection as idle and forcibly closes (RST) it — before any token reaches us. `SendWithRetry` only covers the connect + header phase; once the body streams, a drop was surfaced as a hard error, failing the whole turn.

## Fix

The OpenAI provider (which DeepSeek uses) now drives the stream through `streamWithReconnect`:

- If the connection resets **before any model output has been forwarded**, the request is replayed from scratch. That window is exactly the idle-prefill case the proxy kills, and a replay is idempotent — under prompt caching the resent prefix is a cache hit, so recovery is cheap.
- Once a token (reasoning / text / tool-call) has streamed, a reset is surfaced as an error instead — replaying would duplicate already-visible output.
- Bounded at `maxStreamReconnects` (3); each replay still gets `SendWithRetry`'s header-phase backoff.

`provider.IsConnReset` gates the decision strictly on connection-level errors (peer reset, truncated EOF, closed socket via `net.Error` / `ECONNRESET` / `io.ErrUnexpectedEOF`), so decode errors and 4xx still fail fast — no silent masking.

`readStream` was refactored to return `(emitted bool, err error)` rather than emitting the terminal error itself, so the reconnect wrapper owns the replay-or-surface decision and channel lifecycle.

## Tests

- `TestIsConnReset` — only connection-level drops count; ctx-cancel and protocol errors don't.
- `TestStreamReconnectsOnEarlyConnReset` — a mock that force-RSTs the first SSE connection (zero tokens) then serves a full stream; the caller sees one clean stream, server takes 2 requests.
- `TestStreamDoesNotReplayAfterOutput` — a reset *after* a token surfaces a `ChunkError`, no replay (server takes 1 request).

## End-to-end verification

Built the real `reasonix` CLI and ran `reasonix run` against a mock DeepSeek endpoint that force-RSTs the first stream connection mid-flight (before any token), then serves the answer on retry. Full stack (boot → controller → provider):

```
$ reasonix run "Reply with the recovery token"
E2E_OK_RECOVERED
  · 10 tok · in 7 (0 cached / 7 new) · out 3
exit 0
```

The answer is only served on the **second** (reconnected) attempt — the turn recovered transparently with no error, exit 0.

Scope: this lands on the OpenAI provider (the one DeepSeek uses, and the one in the report). The Anthropic provider has the same `readStream` shape and can take the same treatment in a follow-up.

Closes #3148
