### PR TITLE
feat(control): add /rewind slash command for session rollback

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -501,6 +501,17 @@ func (c *Controller) Submit(input string) {
 				c.notice(err.Error())
 			}
 			return
+		case "/rewind":
+			args := strings.TrimSpace(strings.TrimPrefix(trimmed, fields[0]))
+			turn, scope, err := parseRewind(args, c.Checkpoints())
+			if err != nil {
+				c.notice("usage: /rewind [turn] [code|conversation|both]")
+				return
+			}
+			if err := c.Rewind(turn, scope); err != nil {
+				c.notice(err.Error())
+			}
+			return
 		}
 		if c.managementNotice(trimmed) {
 			return
@@ -1787,6 +1798,39 @@ func listItem(line string) (content string, level int, ok bool) {
 // requestApproval emits an ApprovalRequest and blocks until Approve(ID, …)
 // answers or ctx is cancelled. A prior session grant for the same tool+subject
 // short-circuits. promptMu serialises outstanding prompts.
+// parseRewind parses the arguments after "/rewind". The user may provide:
+//   /rewind              → latest checkpoint, both
+//   /rewind <turn>       → that turn, both
+//   /rewind <turn> <scope> → that turn, code|conversation|both
+// If no turn is given, the latest checkpoint is used. If no scope is given, Both is assumed.
+func parseRewind(args string, cps []checkpoint.Meta) (int, RewindScope, error) {
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
+		if len(cps) == 0 {
+			return 0, RewindBoth, fmt.Errorf("no checkpoints available")
+		}
+		return cps[len(cps)-1].Turn, RewindBoth, nil
+	}
+	turn, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, RewindBoth, fmt.Errorf("invalid turn: %w", err)
+	}
+	scope := RewindBoth
+	if len(fields) >= 2 {
+		switch strings.ToLower(fields[1]) {
+		case "code":
+			scope = RewindCode
+		case "conversation":
+			scope = RewindConversation
+		case "both":
+			scope = RewindBoth
+		default:
+			return 0, RewindBoth, fmt.Errorf("unknown scope %q", fields[1])
+		}
+	}
+	return turn, scope, nil
+}
+
 func (c *Controller) requestApproval(ctx context.Context, tool, subject string) (bool, bool, error) {
 	key := tool + "\x00" + subject
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/checkpoint"
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -247,5 +248,48 @@ func TestApprovalCtxCancel(t *testing.T) {
 	allow, _, err := gateApprover{c}.Approve(ctx, "bash", "x", nil)
 	if err == nil || allow {
 		t.Fatalf("Approve on cancelled ctx = (%v,%v), want (false, error)", allow, err)
+	}
+}
+
+func TestParseRewind(t *testing.T) {
+	cps := []checkpoint.Meta{
+		{Turn: 0, Prompt: "first"},
+		{Turn: 1, Prompt: "second"},
+		{Turn: 2, Prompt: "third"},
+	}
+	cases := []struct {
+		args    string
+		wantT   int
+		wantS   RewindScope
+		wantErr bool
+	}{
+		{"", 2, RewindBoth, false},               // no args -> latest turn, both
+		{"1", 1, RewindBoth, false},              // turn only
+		{"0 code", 0, RewindCode, false},         // turn + code
+		{"1 conversation", 1, RewindConversation, false}, // turn + conversation
+		{"2 both", 2, RewindBoth, false},         // turn + both
+		{"abc", 0, RewindBoth, true},             // invalid turn
+		{"0 unknown", 0, RewindBoth, true},       // unknown scope
+	}
+	for _, tc := range cases {
+		t.Run(tc.args, func(t *testing.T) {
+			gotT, gotS, err := parseRewind(tc.args, cps)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseRewind(%q) err=%v, wantErr=%v", tc.args, err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if gotT != tc.wantT || gotS != tc.wantS {
+				t.Fatalf("parseRewind(%q) = (%d,%d), want (%d,%d)", tc.args, gotT, gotS, tc.wantT, tc.wantS)
+			}
+		})
+	}
+}
+
+func TestParseRewindEmptyCheckpoints(t *testing.T) {
+	_, _, err := parseRewind("", nil)
+	if err == nil {
+		t.Fatal("expected error when no checkpoints")
 	}
 }


### PR DESCRIPTION
## Summary

Add `/rewind` slash command support to `Controller.Submit()` so all frontends 
(TUI, desktop webview, HTTP/SSE server) can trigger checkpoint-based rollback 
without relying solely on the Esc-Esc picker.

## Usage

- `/rewind` — rewind to latest checkpoint (both code + conversation)
- `/rewind <turn>` — rewind to a specific turn (both)
- `/rewind <turn> <scope>` — rewind with explicit scope
  - `scope` = `code` | `conversation` | `both`

## Changes

- `internal/control/controller.go`: wire `/rewind` into `Submit()`, add `parseRewind()` helper
- `internal/control/controller_test.go`: add `TestParseRewind` + `TestParseRewindEmptyCheckpoints`

## Test Plan

- [x] `go test ./internal/control/...` passes
- [x] `go build ./cmd/reasonix` succeeds
- [x] `/rewind` without args picks latest checkpoint
- [x] `/rewind <turn>` defaults to `RewindBoth`
- [x] `/rewind <turn> <scope>` respects explicit scope
- [x] Invalid turn / unknown scope return usage hint