### PR TITLE
fix(acp)!: change MCPServerSpec.Env from map to ordered name/value array

### DIFF
--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -87,12 +87,18 @@ type SessionNewParams struct {
 	MCPServers []MCPServerSpec `json:"mcpServers,omitempty"`
 }
 
+// EnvVariable represents a single environment variable with a name and value.
+type EnvVariable struct {
+	Name string `json:"name"`
+	Value string `json:"value"`
+}
+
 // MCPServerSpec describes one stdio MCP server the client asks the agent to run.
 type MCPServerSpec struct {
-	Name    string            `json:"name"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
+	Name    string   `json:"name"`
+	Command string   `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	Env     []EnvVariable `json:"env,omitempty"`
 }
 
 // SessionNewResult returns the opaque id used to address the session thereafter.

--- a/internal/acp/protocol_test.go
+++ b/internal/acp/protocol_test.go
@@ -138,7 +138,7 @@ func TestMcpSpecsNil(t *testing.T) {
 
 func TestMcpSpecsConversion(t *testing.T) {
 	in := []MCPServerSpec{
-		{Name: "codegraph", Command: "codegraph", Args: []string{"--stdio"}, Env: map[string]string{"HOME": "/tmp"}},
+		{Name: "codegraph", Command: "codegraph", Args: []string{"--stdio"}, Env: []EnvVariable{{Name:"HOME", Value: "/tmp"}}},
 	}
 	got := mcpSpecs(in)
 	if len(got) != 1 {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -318,12 +318,16 @@ func mcpSpecs(in []MCPServerSpec) []plugin.Spec {
 	}
 	out := make([]plugin.Spec, 0, len(in))
 	for _, m := range in {
+		env := make(map[string]string)
+		for _, variable := range m.Env {
+			env[variable.Name] = variable.Value
+		}
 		out = append(out, plugin.Spec{
 			Name:    m.Name,
 			Type:    "stdio",
 			Command: m.Command,
 			Args:    m.Args,
-			Env:     m.Env,
+			Env:     env,
 		})
 	}
 	return out


### PR DESCRIPTION
The ACP wire format for MCPServerSpec.Env changes from a JSON object (map[string]string) to a JSON array of name/value pairs ([]EnvVariable). 

Reference: https://agentclientprotocol.com/protocol/v1/session-setup#param-env

Breaking: old ACP clients sending {"env":{"KEY":"val"}} will no longer unmarshal. Clients must switch to the array format {"env":[{"name":"KEY","value":"val"}]}.