### PR TITLE
docs(migrating): explain latest/next dist-tags and v0.x auto-import

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -11,7 +11,7 @@ changed and how to move over.
 | Language | TypeScript / Node | Go |
 | Branch | [`v1`](https://github.com/esengine/DeepSeek-Reasonix/tree/v1) (maintenance only) | `main-v2` (default, active) |
 | Versions | `0.x` (up to v0.54.x) | `1.0.0`+ |
-| Install | `npm i -g reasonix` (npm ships the TS build) | `npm i -g reasonix` too — the package wraps the Go binary; or a release archive / `go build` |
+| Install | `npm i -g reasonix` (the `latest` tag, stays on `0.x`) | `npm i -g reasonix@next` — `latest` deliberately stays on `0.x`; or a release archive / `go build` |
 | Code intelligence | embedding semantic search | bundled [CodeGraph](https://github.com/colbymchenry/codegraph) (symbol/call graph) |
 
 "v1" and "v2" are **codebase generations**, not semver: the v1 line never reached
@@ -23,21 +23,30 @@ changed and how to move over.
 same way esbuild/biome ship native binaries via npm). The binary itself is a
 standalone Go executable; npm is only the installer, not a runtime dependency.
 
+**`npm i -g reasonix` deliberately still installs `0.x`.** A bare install — and
+`npx reasonix`, and 0.53's own `update` — follows npm's `latest` tag, which we
+keep pinned to the `0.x` line so existing users aren't pulled into the rewrite
+without asking. v1.x (Go) ships under the `next` tag; opt in explicitly:
+
 ```sh
-npm i -g reasonix      # 1.0.0+ delivers the Go binary; 0.x is the legacy TS build
+npm i -g reasonix@next     # or pin a version: reasonix@1.1.0
 reasonix chat
 ```
 
-Prebuilt archives (`reasonix-<os>-<arch>.tar.gz` / `.zip`) are also attached to
-each GitHub release. Or build from source:
+`latest` will stay on `0.x` for the foreseeable future, so installing or
+updating v2 always means `@next` (or a pinned `1.x`).
+
+Prebuilt archives (`reasonix-<os>-<arch>.tar.gz` / `.zip`) and the desktop
+installer are attached to each GitHub release. These are a **separate channel**
+from npm: the installer drops a standalone desktop/binary build and does not
+touch a CLI you installed with `npm i -g`, so the two coexist — an npm `0.53` in
+your shell alongside a `1.x` desktop app is expected, not a conflict. Or build
+from source:
 
 ```sh
 git clone https://github.com/esengine/DeepSeek-Reasonix   # default: main-v2 (Go)
 cd DeepSeek-Reasonix && make build                        # -> bin/reasonix(.exe)
 ```
-
-Until `1.0.0` is published to npm, `npm i -g reasonix` still installs the `0.x`
-TypeScript build — build from source (above) for the Go version meanwhile.
 
 ## Configuration
 
@@ -47,6 +56,14 @@ TypeScript build — build from source (above) for the Go version meanwhile.
 | env / API keys | `.env` or the environment (`DEEPSEEK_API_KEY`, `MIMO_API_KEY`, …) via `api_key_env` |
 | project memory | `REASONIX.md` (+ auto-memory), Claude-Code-compatible |
 | MCP servers | `[[plugins]]` in `reasonix.toml`, or a Claude-Code `.mcp.json` (read as-is) |
+
+On first launch v2 runs a one-time, **non-destructive** import: it reads a v0.x
+`~/.reasonix/config.json` (API key, base URL, language, MCP servers) and imports
+past sessions from `~/.reasonix/sessions`, leaves the old files untouched, and
+prints a boot notice when it does. Imported sessions resume with `--resume` or
+the history panel. The config import only runs when no v2 config exists yet — if
+v2 wrote its config before your `0.x` data was in place nothing is overwritten,
+so copy any missing values across by hand.
 
 ## What's the same
 


### PR DESCRIPTION
`MIGRATING.md` read more like a v1-vs-v2 comparison than a migration path, and its install section was stale — it claimed a bare `npm i -g reasonix` delivers the Go binary. It doesn't, and that mismatch is what surfaced in #3163.

This rewrites the install + config sections to state the actual distribution policy:

- **`latest` is deliberately pinned to `0.x`.** `npm i -g reasonix`, `npx reasonix`, and 0.53's own `update` all follow `latest`, so existing users stay on 0.53 on purpose — nobody is auto-upgraded into the rewrite. v1.x ships under `next`; installing/updating v2 means `@next` (or a pinned `1.x`).
- **The desktop/release installer is a separate channel from the npm CLI.** It drops a standalone build and doesn't touch a `npm i -g` install, so an npm `0.53` shell CLI alongside a `1.x` desktop app is expected, not a conflict.
- **First v2 launch does a one-time, non-destructive import** of `~/.reasonix/config.json` and `~/.reasonix/sessions`, leaving the old files untouched and printing a boot notice. Notes the "config import only runs when no v2 config exists yet" gotcha that makes it look like nothing carried over.

Docs only; no code change.

Closes #3163
