### PR TITLE
fix(config): migrate legacy API key into the global credentials store, not ~/.env

### DIFF
--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -468,8 +468,11 @@ func TestBuildMigratesLegacyConfigEndToEnd(t *testing.T) {
 		t.Errorf("DEEPSEEK_API_KEY not pinned into env after migration: %q", got)
 	}
 
-	if data, err := os.ReadFile(filepath.Join(home, ".env")); err != nil || !strings.Contains(string(data), "DEEPSEEK_API_KEY=sk-e2e") {
-		t.Errorf("~/.env missing migrated key: %q (err %v)", data, err)
+	if data, err := os.ReadFile(config.UserCredentialsPath()); err != nil || !strings.Contains(string(data), "DEEPSEEK_API_KEY=sk-e2e") {
+		t.Errorf("credentials store missing migrated key: %q (err %v)", data, err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".env")); !os.IsNotExist(err) {
+		t.Errorf("migration must not write the user's ~/.env, stat err=%v", err)
 	}
 
 	sessionImported := false

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -50,7 +50,7 @@ func (r *MigrationResult) Notice() string {
 		fmt.Fprintf(&b, " (%d MCP server(s))", r.Plugins)
 	}
 	if r.KeyToEnv {
-		b.WriteString("; API key written to ~/.env")
+		b.WriteString("; API key saved to reasonix's credentials store")
 	}
 	b.WriteString(". The old files were left untouched.")
 	for _, w := range r.Warnings {
@@ -117,8 +117,8 @@ func MigrateLegacyIfNeeded() (*MigrationResult, error) {
 		return nil, fmt.Errorf("write %s: %w", dest, err)
 	}
 	if len(envLines) > 0 {
-		if err := writeHomeEnv(home, envLines); err != nil {
-			return res, fmt.Errorf("write ~/.env: %w", err)
+		if err := writeCredentialsEnv(home, envLines); err != nil {
+			return res, fmt.Errorf("write credentials: %w", err)
 		}
 	}
 	return res, nil
@@ -241,11 +241,20 @@ func mergeEnv(base, overlay map[string]string) map[string]string {
 	return out
 }
 
-// writeHomeEnv merges lines into ~/.env, replacing any existing assignment of the
-// same key, and pins them into the current process env so the just-built session
-// resolves the key without a restart.
-func writeHomeEnv(home string, lines []string) error {
-	path := filepath.Join(home, ".env")
+// writeCredentialsEnv merges lines into the reasonix-owned global credentials
+// file (UserCredentialsPath, e.g. %AppData%\reasonix\credentials), replacing any
+// existing assignment of the same key, and pins them into the current process env
+// so the just-built session resolves the key without a restart. Falls back to
+// ~/.env only when the user config dir can't be resolved — never a project .env,
+// so a migration keeps secrets out of the user's project tree.
+func writeCredentialsEnv(home string, lines []string) error {
+	path := UserCredentialsPath()
+	if path == "" {
+		path = filepath.Join(home, ".env")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
 	target := make(map[string]bool, len(lines))
 	for _, l := range lines {
 		if k, _, ok := strings.Cut(l, "="); ok {

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -52,12 +52,15 @@ func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
 		t.Errorf("result = %+v, want KeyToEnv=true Plugins=2", res)
 	}
 
-	envData, err := os.ReadFile(filepath.Join(home, ".env"))
+	envData, err := os.ReadFile(UserCredentialsPath())
 	if err != nil {
-		t.Fatalf("read ~/.env: %v", err)
+		t.Fatalf("read credentials: %v", err)
 	}
 	if !strings.Contains(string(envData), "DEEPSEEK_API_KEY=sk-legacy-123") {
-		t.Errorf("~/.env missing key: %q", envData)
+		t.Errorf("credentials missing key: %q", envData)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".env")); !os.IsNotExist(err) {
+		t.Errorf("migration must not write the user's ~/.env, stat err=%v", err)
 	}
 
 	got, err := os.ReadFile(dest)
@@ -115,7 +118,7 @@ func TestMigrateSkipsWhenDestExists(t *testing.T) {
 }
 
 func TestMigrateImportsLegacyV1TOMLBeforeJSON(t *testing.T) {
-	srcJSON, dest, home := legacyHome(t)
+	srcJSON, dest, _ := legacyHome(t)
 	legacyTOML := filepath.Join(filepath.Dir(dest), "reasonix.toml")
 	if err := os.MkdirAll(filepath.Dir(legacyTOML), 0o755); err != nil {
 		t.Fatal(err)
@@ -155,8 +158,8 @@ command = "legacy-bin"
 			t.Fatalf("migrated TOML missing %q:\n%s", want, text)
 		}
 	}
-	if _, err := os.Stat(filepath.Join(home, ".env")); !os.IsNotExist(err) {
-		t.Fatalf("v1 TOML migration should not import lower-priority JSON key, env stat err=%v", err)
+	if _, err := os.Stat(UserCredentialsPath()); !os.IsNotExist(err) {
+		t.Fatalf("v1 TOML migration should not import lower-priority JSON key, credentials stat err=%v", err)
 	}
 }
 
@@ -207,7 +210,7 @@ func TestMigrateNoLegacyIsNoop(t *testing.T) {
 }
 
 func TestMigrateToleratesUTF8BOM(t *testing.T) {
-	src, _, home := legacyHome(t)
+	src, _, _ := legacyHome(t)
 	writeLegacy(t, src, "\ufeff"+`{"apiKey":"sk-bom"}`)
 	res, err := MigrateLegacyIfNeeded()
 	if err != nil {
@@ -216,7 +219,7 @@ func TestMigrateToleratesUTF8BOM(t *testing.T) {
 	if res == nil || !res.KeyToEnv {
 		t.Fatalf("BOM-prefixed config did not migrate: %+v", res)
 	}
-	data, _ := os.ReadFile(filepath.Join(home, ".env"))
+	data, _ := os.ReadFile(UserCredentialsPath())
 	if !strings.Contains(string(data), "DEEPSEEK_API_KEY=sk-bom") {
 		t.Errorf("key not migrated from BOM-prefixed config: %q", data)
 	}


### PR DESCRIPTION
## Problem
The one-time v0/v1 legacy config import wrote the carried-over `DEEPSEEK_API_KEY` to `~/.env` (`writeHomeEnv`), polluting the user's home dotenv with a secret.

## Fix
Write the migrated key to the reasonix-owned global credentials file (`UserCredentialsPath()`, e.g. `%AppData%\reasonix\credentials`) — the same global secrets store the desktop settings panel and `reasonix setup` already use. This keeps secrets out of the user's project/home `.env` and lets the key resolve from any workspace root. Falls back to `~/.env` only when the user config dir can't be resolved.

The boot-time migration notice now says "API key saved to reasonix's credentials store" instead of "written to ~/.env".

## Tests
Updated `migrate_test.go` and `boot_test.go` to assert the key lands in the credentials store and that `~/.env` is *not* written. `go test ./internal/config ./internal/boot` green.
