### PR TITLE
fix(cli): clarify TUI status rows and welcome key prompts

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1669,6 +1669,9 @@ func (m chatTUI) View() tea.View {
 	default:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusIdle + " " + dim("("+i18n.M.ChatStatusCycleHint+")")
 	}
+	if gt := m.gitTag(); gt != "" {
+		status += " · " + gt
+	}
 	// The spinning "thinking…" indicator is its own line ABOVE the input box (shown
 	// only while a turn runs); the status/data rows stay below. This mirrors Claude
 	// Code: live progress over the composer, shortcuts + stats under it.
@@ -1690,7 +1693,7 @@ func (m chatTUI) View() tea.View {
 			}
 		}
 	}
-	// Second status row: the live data (model, git, effort, context gauge, cache
+	// Second status row: the live run data (model, effort, context gauge, cache
 	// rates, jobs, balance). It lives on its own fixed row so it's always shown in
 	// full rather than being truncated off the end of the status line. Two rows is
 	// a fixed height, so unlike a wrap-when-long status it doesn't reintroduce
@@ -1698,9 +1701,6 @@ func (m chatTUI) View() tea.View {
 	var data []string
 	if mt := m.modelTag(); mt != "" {
 		data = append(data, mt)
-	}
-	if gt := m.gitTag(); gt != "" {
-		data = append(data, gt)
 	}
 	if et := m.effortTag(); et != "" {
 		data = append(data, et)
@@ -1753,7 +1753,7 @@ func (m chatTUI) View() tea.View {
 		rowsAboveBox += strings.Count(menu, "\n") + 1
 	}
 	// Layout: the working spinner (when running), then the composer when visible,
-	// then the two status rows (line 1 = mode + shortcuts/state, line 2 = live data).
+	// then the two status rows (line 1 = mode + session/worktree identity, line 2 = live run data).
 	// Each row is clamped to width independently so neither wraps; padding to full
 	// width keeps a short row from leaving stale cells from the prior frame.
 	if working != "" {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1429,9 +1429,8 @@ func readStdin() string {
 func welcome(version string) int {
 	src := config.SourcePath()
 
-	// Load early: config.Load merges the cwd-local and user-global sources, so a
-	// successful load means the user has configured before — even when run from a
-	// directory without a local reasonix.toml (SourcePath is then "").
+	// Load early for the welcome/status view. config.Load also succeeds with the
+	// built-in defaults, so SourcePath is the actual "user has configured" signal.
 	cfg, cfgErr := config.Load()
 	if cfgErr != nil {
 		cfg = config.Default()
@@ -1440,9 +1439,8 @@ func welcome(version string) int {
 	// First run on an interactive terminal: actively guide setup rather than
 	// printing a static screen and exiting. interactiveSetup owns the language
 	// prompt and welcome banner so every prompt the user sees is already
-	// localized to their choice. Only when no config loads from ANY source — not
-	// merely when the cwd lacks a local file.
-	if src == "" && cfgErr != nil && isInteractive() {
+	// localized to their choice.
+	if src == "" && isInteractive() {
 		if rc := interactiveSetup(defaultConfigTarget(), defaultEnvTarget()); rc != 0 {
 			return rc
 		}
@@ -1459,12 +1457,14 @@ func welcome(version string) int {
 		return 0
 	}
 
-	// Config loads from any source (cwd-local or user-global) on a terminal: go
-	// into chat. If any enabled provider's key isn't set yet, re-run the wizard's
-	// key-entry step inline — first run already chose language and providers, so
-	// we don't re-ask those. Skipping the prompts is still fine; the chat banner
-	// falls back to a one-line warning.
-	if cfgErr == nil && isInteractive() {
+	// A real config source exists (cwd-local or user-global) on a terminal: go into
+	// chat. If any enabled provider's key isn't set yet, re-run the wizard's key-entry
+	// step inline — first run already chose language and providers, so we don't
+	// re-ask those. Skipping the prompts is still fine; the chat banner falls back
+	// to a one-line warning. Do not do this for the built-in defaults alone: that
+	// would ask for every default provider key even though the user has not opted
+	// into those providers yet.
+	if welcomeShouldPromptMissingKeys(src, cfgErr) && isInteractive() {
 		if rc := promptMissingKeys(cfg); rc != 0 {
 			return rc
 		}
@@ -1519,6 +1519,10 @@ func welcome(version string) int {
 
 	fmt.Print(b.String())
 	return 0
+}
+
+func welcomeShouldPromptMissingKeys(src string, cfgErr error) bool {
+	return strings.TrimSpace(src) != "" && cfgErr == nil
 }
 
 func usage() {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -148,6 +149,18 @@ func TestRunMetadataCommandsDoNotMigrateLegacyConfig(t *testing.T) {
 	}
 	if _, err := os.Stat(config.UserConfigPath()); !os.IsNotExist(err) {
 		t.Fatalf("version should not migrate legacy config, stat err=%v", err)
+	}
+}
+
+func TestWelcomePromptMissingKeysRequiresConfigSource(t *testing.T) {
+	if welcomeShouldPromptMissingKeys("", nil) {
+		t.Fatal("built-in defaults without a config source should not prompt for missing provider keys")
+	}
+	if welcomeShouldPromptMissingKeys("reasonix.toml", errors.New("bad config")) {
+		t.Fatal("invalid config should not enter the missing-key prompt path")
+	}
+	if !welcomeShouldPromptMissingKeys("reasonix.toml", nil) {
+		t.Fatal("valid config source should enter the missing-key prompt path")
 	}
 }
 

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -163,6 +163,25 @@ func TestStatuslineShowsEffort(t *testing.T) {
 	}
 }
 
+func TestStatuslinePutsGitIdentityOnModeRow(t *testing.T) {
+	i18n.DetectLanguage("en")
+
+	content := renderStatuslineViewWithGitAndEffort(t)
+	lines := bottomStatusPlainLines(content)
+	if len(lines) != 2 {
+		t.Fatalf("status block lines = %d, want 2:\n%s", len(lines), strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(lines[0], "Reasonix@codex/demo (+3 -1 ?2)") {
+		t.Fatalf("mode row should include git identity:\n%s", strings.Join(lines, "\n"))
+	}
+	if strings.Contains(lines[1], "Reasonix@codex/demo") {
+		t.Fatalf("data row should not include git identity:\n%s", strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(lines[1], "deepseek-v4-flash · effort auto") {
+		t.Fatalf("data row should keep model and effort:\n%s", strings.Join(lines, "\n"))
+	}
+}
+
 func TestStatuslineExplicitEffortUsesBlue(t *testing.T) {
 	i18n.DetectLanguage("en")
 
@@ -209,6 +228,24 @@ func renderStatuslineViewWithEffort(t *testing.T, effort string) string {
 	return next.(chatTUI).View().Content
 }
 
+func renderStatuslineViewWithGitAndEffort(t *testing.T) string {
+	t.Helper()
+
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 120)
+	m.label = "deepseek-v4-flash"
+	m.effortLevel = "auto"
+	m.gitStatus = gitStatus{
+		Repo:      "Reasonix",
+		Branch:    "codex/demo",
+		Added:     3,
+		Removed:   1,
+		Untracked: 2,
+	}
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	return next.(chatTUI).View().Content
+}
+
 func renderPlanStatuslineView(t *testing.T) string {
 	t.Helper()
 
@@ -220,9 +257,13 @@ func renderPlanStatuslineView(t *testing.T) string {
 }
 
 func bottomStatusPlain(content string) string {
+	return strings.Join(bottomStatusPlainLines(content), "\n")
+}
+
+func bottomStatusPlainLines(content string) []string {
 	lines := strings.Split(ansi.Strip(content), "\n")
 	if len(lines) < 2 {
-		return strings.Join(lines, "\n")
+		return lines
 	}
-	return strings.Join(lines[len(lines)-2:], "\n")
+	return lines[len(lines)-2:]
 }


### PR DESCRIPTION
## Summary

- Move CLI TUI git/worktree identity (`repo@branch (+N -N ?N)`) from the live metrics row to the mode/session row.
- Keep the second status row focused on run data: model, effort, context, compact headroom, cache, jobs, and balance.
- Fix zero-arg `reasonix` welcome flow so built-in defaults alone do not trigger missing API key prompts such as `MIMO_API_KEY`; missing-key prompts now require a real project/user config source.

## Screenshot

![CLI TUI status layout after fix](https://gist.githubusercontent.com/SivanCola/45d5fbe5216624d461c278c7e6aa1f18/raw/303efc41ed4804fa4bc9d9e5224b8553791bbd52/reasonix-cli-tui-status-welcome.svg)

## Test plan

- `go test ./internal/cli`
