### PR TITLE
fix(shell): merge login shell PATH for bash tool

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -6,7 +6,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -21,6 +24,8 @@ const (
 )
 
 func init() { tool.RegisterBuiltin(bash{}) }
+
+var bashShellPATH = defaultBashShellPATH
 
 // bash runs a shell command with a timeout to avoid hangs. sb, when it enforces,
 // wraps the command in an OS sandbox; the zero value registered at init runs
@@ -94,6 +99,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 
 	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
 	argv, _ := sandbox.Command(b.sb, sh, p.Command)
+	cmdEnv := bashCommandEnv(ctx)
 
 	if p.RunInBackground {
 		jm, ok := jobs.FromContext(ctx)
@@ -106,6 +112,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		job := jm.Start("bash", commandPreview(p.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
 			cmd := exec.CommandContext(jobCtx, argv[0], argv[1:]...)
 			cmd.Dir = workDir
+			cmd.Env = cmdEnv
 			setKillTree(cmd)
 			cmd.WaitDelay = bashWaitDelay
 			cmd.Stdout = out
@@ -120,6 +127,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Dir = b.workDir // "" lets exec use the process working directory
+	cmd.Env = cmdEnv
 	setKillTree(cmd)
 	cmd.WaitDelay = bashWaitDelay
 	var buf bytes.Buffer
@@ -187,4 +195,145 @@ func commandPreview(cmd string) string {
 		return string(r[:max]) + "…"
 	}
 	return cmd
+}
+
+func bashCommandEnv(ctx context.Context) []string {
+	env := os.Environ()
+	if runtime.GOOS == "windows" {
+		return env
+	}
+	currentPath, _ := envValue(env, "PATH")
+	if shellPath := strings.TrimSpace(bashShellPATH(ctx)); shellPath != "" {
+		if merged := mergePathLists(shellPath, currentPath); merged != currentPath {
+			env = setEnvValue(env, "PATH", merged)
+		}
+	}
+	return env
+}
+
+func defaultBashShellPATH(ctx context.Context) string {
+	if runtime.GOOS == "windows" {
+		return ""
+	}
+	shell := loginShell()
+	if shell == "" {
+		return ""
+	}
+	const marker = "__REASONIX_BASH_PATH__="
+	script := "printf '\\n" + marker + "%s\\n' \"$PATH\""
+	for _, args := range [][]string{
+		{"-l", "-i", "-c", script},
+		{"-l", "-c", script},
+		{"-c", script},
+	} {
+		out := runShellPATHCommand(ctx, shell, args)
+		if path := parseShellPATH(out, marker); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func loginShell() string {
+	if shell := strings.TrimSpace(os.Getenv("SHELL")); shell != "" {
+		if hasPathSeparator(shell) {
+			if isExecutableFile(shell) {
+				return shell
+			}
+		} else if p, err := exec.LookPath(shell); err == nil {
+			return p
+		}
+	}
+	for _, shell := range []string{"/bin/zsh", "/bin/bash", "/bin/sh"} {
+		if isExecutableFile(shell) {
+			return shell
+		}
+	}
+	return ""
+}
+
+func runShellPATHCommand(parent context.Context, shell string, args []string) []byte {
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, shell, args...)
+	cmd.Stdin = strings.NewReader("")
+	out, _ := cmd.CombinedOutput()
+	return out
+}
+
+func parseShellPATH(out []byte, marker string) string {
+	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.HasPrefix(lines[i], marker) {
+			return strings.TrimSpace(strings.TrimPrefix(lines[i], marker))
+		}
+	}
+	return ""
+}
+
+func hasPathSeparator(s string) bool {
+	return strings.ContainsAny(s, `/\`)
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+func setEnvValue(env []string, key, value string) []string {
+	out := make([]string, 0, len(env)+1)
+	replaced := false
+	for _, kv := range env {
+		k, _, ok := strings.Cut(kv, "=")
+		if ok && envKeyEqual(k, key) {
+			if !replaced {
+				out = append(out, key+"="+value)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !replaced {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func envValue(env []string, key string) (string, bool) {
+	for i := len(env) - 1; i >= 0; i-- {
+		k, v, ok := strings.Cut(env[i], "=")
+		if ok && envKeyEqual(k, key) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func envKeyEqual(a, b string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func mergePathLists(primary, secondary string) string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(path string) {
+		for _, part := range filepath.SplitList(path) {
+			part = strings.TrimSpace(part)
+			if part == "" || seen[part] {
+				continue
+			}
+			seen[part] = true
+			out = append(out, part)
+		}
+	}
+	add(primary)
+	add(secondary)
+	return strings.Join(out, string(os.PathListSeparator))
 }

--- a/internal/tool/builtin/bash_env_test.go
+++ b/internal/tool/builtin/bash_env_test.go
@@ -1,0 +1,47 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"reasonix/internal/sandbox"
+)
+
+func TestBashMergesLoginShellPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("login shell PATH probing is POSIX-only")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	probe := filepath.Join(bin, "reasonix-path-probe")
+	if err := os.WriteFile(probe, []byte("#!/bin/sh\nprintf 'shell-path-ok\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write probe: %v", err)
+	}
+	loginShell := filepath.Join(dir, "login-shell")
+	if err := os.WriteFile(loginShell, []byte("#!/bin/sh\nprintf '\\n__REASONIX_BASH_PATH__=%s\\n' '"+bin+":/usr/bin:/bin"+"'\n"), 0o755); err != nil {
+		t.Fatalf("write login shell: %v", err)
+	}
+
+	t.Setenv("SHELL", loginShell)
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+
+	b := bash{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "/bin/sh"}}
+	args, _ := json.Marshal(map[string]string{"command": "reasonix-path-probe"})
+
+	out, err := b.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("command should resolve through login shell PATH: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "shell-path-ok") {
+		t.Fatalf("output = %q, want shell-path-ok", out)
+	}
+}


### PR DESCRIPTION
Fixes esengine/DeepSeek-Reasonix#3101.

Desktop launches on macOS can inherit only the system default PATH, so the Bash tool and commands it starts cannot find user-installed binaries such as Homebrew tools or project CLIs. The MCP stdio path already has a login-shell PATH fallback, but the Bash tool itself still ran with the stripped process environment.

This patch probes the user login shell for PATH on POSIX hosts, merges that PATH ahead of the current process PATH, and passes the merged environment to both foreground and background Bash tool commands. Windows behavior is unchanged.

Verification:

- `GOTOOLCHAIN=local go test ./internal/tool/builtin -run TestBashMergesLoginShellPath -count=1` failed before the fix with `reasonix-path-probe: command not found`, then passed after the fix
- `GOTOOLCHAIN=local go test ./internal/tool/builtin -count=1`
- `GOTOOLCHAIN=local go test ./internal/sandbox ./internal/plugin ./internal/tool/builtin -count=1`
- `git diff --check`
