### PR TITLE
fix(desktop): release bug-fix roundup (todo panel visibility, null-guard render crash)

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
+    "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const sourcePath = path.join(root, "src", "lib", "todoVisibility.ts");
+const source = readFileSync(sourcePath, "utf8");
+const transpiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ES2022,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString("base64")}`;
+const { shouldShowTodoPanel } = await import(moduleUrl);
+
+const completedTodos = [
+  { content: "Inspect the report", status: "completed" },
+  { content: "Ship the fix", status: "completed" },
+];
+
+assert.equal(
+  shouldShowTodoPanel("todo-final", null, completedTodos),
+  true,
+  "the final all-completed todo_write must remain visible",
+);
+assert.equal(
+  shouldShowTodoPanel("todo-active", null, [{ content: "Run tests", status: "in_progress" }]),
+  true,
+  "an active todo_write remains visible",
+);
+assert.equal(
+  shouldShowTodoPanel("todo-final", "todo-final", completedTodos),
+  false,
+  "a user dismissal still hides that exact todo list",
+);
+assert.equal(shouldShowTodoPanel(null, null, completedTodos), false, "no canonical todo item means no panel");
+assert.equal(shouldShowTodoPanel("todo-empty", null, []), false, "empty todo lists do not render a panel");
+
+const iterations = 200_000;
+const started = performance.now();
+for (let i = 0; i < iterations; i += 1) {
+  if (!shouldShowTodoPanel("todo-perf", null, completedTodos)) {
+    throw new Error("unexpected hidden todo panel during performance loop");
+  }
+}
+const elapsed = performance.now() - started;
+const perCallUs = (elapsed * 1000) / iterations;
+
+assert.ok(elapsed < 500, `todo visibility check is too slow: ${elapsed.toFixed(2)} ms`);
+console.log(
+  `todo visibility checks: ${iterations} calls in ${elapsed.toFixed(2)} ms (${perCallUs.toFixed(3)} us/call)`,
+);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -40,6 +40,7 @@ import { OnboardingOverlay } from "./components/OnboardingOverlay";
 import { TabBar } from "./components/TabBar";
 import { ProjectTree } from "./components/ProjectTree";
 import { parseTodos } from "./lib/tools";
+import { shouldShowTodoPanel } from "./lib/todoVisibility";
 import type { ComposerInsertRequest, MemoryView, Meta, Mode, SessionMeta, TabMeta } from "./lib/types";
 import { loadLayoutSize, saveLayoutSize } from "./lib/layoutPreferences";
 import {
@@ -434,10 +435,10 @@ export default function App() {
 
   // The live task list pinned above the composer comes from the most recent
   // successful top-level todo_write result; failed or still-running attempts do
-  // not advance the canonical panel state. It stays visible while work remains,
-  // clears itself once every item is completed, and can be dismissed by the user
-  // (the ✕). A dismissal is keyed to that list's id, so a fresh accepted
-  // todo_write brings the panel back.
+  // not advance the canonical panel state. It stays visible through the final
+  // all-completed update, and can be dismissed by the user (the ✕). A dismissal
+  // is keyed to that list's id, so a fresh accepted todo_write brings the panel
+  // back.
   const todoEntry = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const it = state.items[i];
@@ -450,11 +451,7 @@ export default function App() {
   const todoItem = todoEntry?.item ?? null;
   const todos = useMemo(() => (todoItem ? parseTodos(todoItem.args) : []), [todoItem]);
   const [dismissedTodo, setDismissedTodo] = useState<string | null>(null);
-  const showTodos =
-    !!todoItem &&
-    todoItem.id !== dismissedTodo &&
-    todos.length > 0 &&
-    todos.some((t) => t.status !== "completed");
+  const showTodos = shouldShowTodoPanel(todoItem?.id, dismissedTodo, todos);
   const [todoNow, setTodoNow] = useState(() => Date.now());
   const todoSeenRef = useRef<{ id: string; at: number } | null>(null);
 

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -26,9 +26,9 @@ function scrollVersion(items: Item[]): string {
     .map((it) => {
       switch (it.kind) {
         case "assistant":
-          return `${it.id}:a:${it.text.length}:${it.reasoning.length}:${it.streaming ? 1 : 0}`;
+          return `${it.id}:a:${it.text?.length ?? 0}:${it.reasoning?.length ?? 0}:${it.streaming ? 1 : 0}`;
         case "tool":
-          return `${it.id}:t:${it.name}:${it.status}:${it.args.length}:${it.output?.length ?? 0}:${it.error?.length ?? 0}:${it.truncated ? 1 : 0}`;
+          return `${it.id}:t:${it.name}:${it.status}:${it.args?.length ?? 0}:${it.output?.length ?? 0}:${it.error?.length ?? 0}:${it.truncated ? 1 : 0}`;
         default:
           return `${it.id}:${it.kind}`;
       }
@@ -116,7 +116,7 @@ export function Transcript({
       el.scrollTop = el.scrollHeight;
     });
     return () => cancelAnimationFrame(id);
-  }, [contentVersion, live?.text.length, live?.reasoning.length]);
+  }, [contentVersion, live?.text?.length ?? 0, live?.reasoning?.length ?? 0]);
 
   useEffect(() => {
     const el = scrollRef.current;

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -1,0 +1,9 @@
+import type { Todo } from "./tools";
+
+export function shouldShowTodoPanel(
+  todoId: string | null | undefined,
+  dismissedTodoId: string | null,
+  todos: Todo[],
+): boolean {
+  return !!todoId && todoId !== dismissedTodoId && todos.length > 0;
+}


### PR DESCRIPTION
Release bug-fix roundup for the desktop app. Two genuine, still-applicable fixes from contributor PRs, rebased onto current main-v2 (authorship preserved):

- **#3105** (@jiaxindeyang-a11y) — guard `null` in `.length` calls in `Transcript` (`text`/`reasoning`/`args` arrive as `null` when Go serializes a nil slice/string), preventing a render crash. EffortSwitcher's half was already covered by `asArray` on main-v2, so only the Transcript guards are carried.
- **#3016** (@GTC2080) — keep the todo panel visible through the final all-completed `todo_write` instead of hiding it on the last update; dismissal stays keyed to the list id. Logic extracted to `lib/todoVisibility.ts`.

Verified with `wails build` (frontend `tsc --noEmit` + Go compile) on Windows — clean.

Closes #3105
Closes #3016

Superseded / obsolete (closed separately, not included): #3013, #3141 (the `.sidebar__brand > span` over-match they fixed no longer exists — the brand/toggle moved into the app-chrome header) and #3083 (the `.workspace-tabs` strip was replaced by `TabBar`).
