### PR TITLE
feat: Claude Code parity roundup (/rewind, ! shell, queue navigation)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -292,6 +292,17 @@ func (a *App) SubmitToTab(tabID, input string) {
 	}
 }
 
+// RunShell executes a shell command directly (bypassing the model) and streams
+// output as events on eventChannel.
+func (a *App) RunShell(command string) {
+	a.mu.RLock()
+	ctrl := a.ctrl
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.RunShell(command)
+	}
+}
+
 // SubmitDisplay runs input as a turn while recording a shorter UI-only display
 // string for the saved desktop transcript. The model still receives input.
 func (a *App) SubmitDisplay(display, input string) {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -295,10 +295,7 @@ func (a *App) SubmitToTab(tabID, input string) {
 // RunShell executes a shell command directly (bypassing the model) and streams
 // output as events on eventChannel.
 func (a *App) RunShell(command string) {
-	a.mu.RLock()
-	ctrl := a.ctrl
-	a.mu.RUnlock()
-	if ctrl != nil {
+	if ctrl := a.activeCtrl(); ctrl != nil {
 		ctrl.RunShell(command)
 	}
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
+import { ShellExpandProvider, useShellExpand } from "./lib/shellExpand";
 import {
   SquarePen,
   Brain,
@@ -208,11 +209,30 @@ function workspaceDisplayName(path?: string): string {
   return parts.length > 0 ? parts[parts.length - 1] : path;
 }
 
+
+/** Global hotkey handler for shell-expand toggle (Ctrl/Cmd+B). */
+function ShellHotkeys() {
+  const shellExpand = useShellExpand();
+  useEffect(() => {
+    if (!shellExpand) return;
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "b") {
+        e.preventDefault();
+        shellExpand.toggleLast();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [shellExpand]);
+  return null;
+}
+
 export default function App() {
   const {
     state,
     activeTabId,
     send,
+    runShell,
     notice,
     cancel,
     approve,
@@ -510,6 +530,16 @@ export default function App() {
   const handleSend = useCallback(
     async (displayText: string, submitText = displayText) => {
       const trimmed = displayText.trim();
+      // "!<cmd>" runs a shell command directly, bypassing the model.
+      if (trimmed.startsWith("!")) {
+        const cmd = trimmed.slice(1).trim();
+        if (!cmd) {
+          notice("usage: !<command>  (e.g. !ls -la)");
+          return;
+        }
+        runShell(cmd);
+        return;
+      }
       const model = /^\/model\s+(\S+)$/.exec(trimmed);
       if (model) {
         void switchModel(model[1]);
@@ -548,7 +578,7 @@ export default function App() {
       await syncModeToController(mode);
       send(trimmed, submitText.trim());
     },
-    [switchModel, openMemory, syncModeToController, mode, send, notice, t],
+    [switchModel, openMemory, syncModeToController, mode, send, runShell, notice, t],
   );
 
   const refreshTabMetas = useCallback(async (): Promise<TabMeta[]> => {
@@ -1091,6 +1121,8 @@ export default function App() {
   const workspacePanelMaxWidth = workspacePreviewActive ? RIGHT_DOCK_MAX_WIDTH : RIGHT_DOCK_TREE_MAX_WIDTH;
 
   return (
+    <ShellExpandProvider>
+    <ShellHotkeys />
     <div className="app">
       <div
         ref={layoutRef}
@@ -1524,5 +1556,6 @@ export default function App() {
 
       {needsOnboarding && <OnboardingOverlay onComplete={() => setNeedsOnboarding(false)} />}
     </div>
+    </ShellExpandProvider>
   );
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -215,7 +215,7 @@ function ShellHotkeys() {
   const shellExpand = useShellExpand();
   useEffect(() => {
     if (!shellExpand) return;
-    const onKey = (e: KeyboardEvent) => {
+    const onKey = (e: globalThis.KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && e.key === "b") {
         e.preventDefault();
         shellExpand.toggleLast();

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -982,12 +982,12 @@ export function Composer({
           onDoubleClick={resetComposerHeight}
         />
         <div
-          className={`composer${dragOver ? " composer--dragover" : ""}${disabled ? " composer--disabled" : ""}`}
+          className={`composer${dragOver ? " composer--dragover" : ""}${disabled ? " composer--disabled" : ""}${text.trimStart().startsWith("!") ? " composer--shell" : ""}`}
           onDrop={onDrop}
           onDragOver={onDragOver}
           onDragLeave={onDragLeave}
         >
-          <span className="composer__caret">›</span>
+          <span className="composer__caret">{text.trimStart().startsWith("!") ? "$" : "›"}</span>
           <textarea
             ref={taRef}
             className="composer__input"

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import {
   Ban,
   Check,
@@ -19,6 +19,7 @@ import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
 import { useT } from "../lib/i18n";
 import { diffsFor, subjectOf, summarize } from "../lib/tools";
+import { useShellExpand } from "../lib/shellExpand";
 import type { Item } from "../lib/useController";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
@@ -36,6 +37,9 @@ const ICONS: Record<string, LucideIcon> = {
   task: ListTree,
 };
 
+/** Lines shown by default in a shell output block before the "show all" button. */
+const SHELL_PREVIEW_LINES = 10;
+
 function pretty(json: string): string {
   try {
     return JSON.stringify(JSON.parse(json), null, 2);
@@ -49,6 +53,14 @@ function StatusGlyph({ status }: { status: ToolItem["status"] }) {
   if (status === "error") return <X className="ico ico--err" size={13} />;
   if (status === "stopped") return <Ban className="ico ico--stopped" size={13} />;
   return <Check className="ico ico--ok" size={13} />;
+}
+
+/** Returns the first n lines of text and the total line count. */
+function splitPreview(text: string, n: number): { preview: string; total: number; hasMore: boolean } {
+  const lines = text.split("\n");
+  const total = lines.length;
+  if (total <= n) return { preview: text, total, hasMore: false };
+  return { preview: lines.slice(0, n).join("\n"), total, hasMore: true };
 }
 
 // ToolCard renders one tool call. `subcalls` are sub-agent calls nested under a
@@ -72,9 +84,19 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
 
   // edit diffs are the point of the card, so they're shown inline; everything
   // else folds its args/output away by default. Nested children always show.
+  // Shell commands default to open so the output is immediately visible.
   const hasBody = diffs.length === 0 && (!!item.args || !!item.output);
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(item.isShell && hasBody);
+  const [showAll, setShowAll] = useState(false);
   const expandable = hasBody;
+
+  // Register this shell card's toggle with the global ShellExpand context so
+  // Ctrl/Cmd+B can expand/collapse the most recent shell output.
+  const shellExpand = useShellExpand();
+  useEffect(() => {
+    if (!item.isShell || !shellExpand) return;
+    return shellExpand.register(item.id, () => setOpen((v) => !v));
+  }, [item.isShell, item.id, shellExpand]);
 
   // Read-only "research" calls (read/grep/ls/glob/web_fetch) are quieted to a
   // slim, borderless, dim row so a long run of them doesn't bury the few calls
@@ -82,6 +104,10 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   // full card. Uses the readOnly flag, not a tool-name list.
   const quiet =
     item.readOnly && !hasNested && item.status !== "error" && item.status !== "stopped";
+
+  // Shell output: split into preview + "show all" toggle.
+  const shellOutput = item.isShell && item.output ? item.output : null;
+  const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
 
   return (
     <div className={`tool tool--${item.status} ${quiet ? "tool--quiet" : ""}`}>
@@ -119,7 +145,21 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
         </div>
       )}
 
-      {hasBody && open && (
+      {/* Shell output: always visible (auto-open), with preview/show-all toggle */}
+      {shellPreview && open && (
+        <div className="tool__body">
+          <CodeViewer value={showAll ? shellOutput! : shellPreview.preview} maxHeight={showAll ? 480 : 260} />
+          {shellPreview.hasMore && !showAll && (
+            <button className="tool__showall" onClick={() => setShowAll(true)}>
+              {t("tool.showAllLines", { n: shellPreview.total })}
+            </button>
+          )}
+          {item.truncated && <div className="tool__note">{t("tool.truncated")}</div>}
+        </div>
+      )}
+
+      {/* Non-shell body: args + output, gated by open */}
+      {!shellPreview && hasBody && open && (
         <div className="tool__body">
           {item.args && <CodeViewer value={pretty(item.args)} language="json" maxHeight={180} />}
           {item.output && (

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -81,6 +81,7 @@ export interface AppBindings {
   SubmitToTab(tabID: string, input: string): Promise<void>;
   SubmitDisplay(display: string, input: string): Promise<void>;
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
+  RunShell(command: string): Promise<void>;
   Cancel(): Promise<void>;
   CancelTab(tabID: string): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
@@ -802,6 +803,21 @@ function makeMockApp(): AppBindings {
         async SubmitDisplayToTab(_tabID, display, input) {
           await this.SubmitDisplay(display, input);
         },
+        async RunShell(command) {
+          cancelled = false;
+          emit({ kind: "turn_started" });
+          await delay(100);
+          if (cancelled) return;
+          const id = `shell-${command.slice(0, 32)}`;
+          emit({ kind: "tool_dispatch", tool: { id, name: "bash", args: JSON.stringify({ command }), readOnly: false } });
+          await delay(200);
+          if (cancelled) return;
+          emit({ kind: "tool_progress", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
+          await delay(100);
+          if (cancelled) return;
+          emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
+          emit({ kind: "turn_done" });
+        },
         async Cancel() {
           cancelled = true;
           emit({ kind: "turn_done" });
@@ -810,7 +826,7 @@ function makeMockApp(): AppBindings {
           await this.Cancel();
         },
         async Approve(_id, allow, session, persist) {
-      if (!pendingApprovalPreview) return;
+          if (!pendingApprovalPreview) return;
       pendingApprovalPreview = false;
       const suffix = persist ? "persisted" : session ? "allowed for session" : "allowed once";
       emit({

--- a/desktop/frontend/src/lib/shellExpand.tsx
+++ b/desktop/frontend/src/lib/shellExpand.tsx
@@ -1,0 +1,43 @@
+import { createContext, useCallback, useContext, useMemo, useRef, type ReactNode } from "react";
+
+// Shell-expand coordination: ToolCards register their toggle callbacks, and
+// Cmd+B (from App) calls the most recent one.
+
+type ToggleFn = () => void;
+
+interface ShellExpandCtx {
+  register: (id: string, toggle: ToggleFn) => void;
+  toggleLast: () => void;
+}
+
+const Ctx = createContext<ShellExpandCtx | null>(null);
+
+export function ShellExpandProvider({ children }: { children: ReactNode }) {
+  const mapRef = useRef(new Map<string, ToggleFn>());
+  const orderRef: { current: string[] } = useRef<string[]>([]);
+
+  const register = useCallback((id: string, toggle: ToggleFn) => {
+    mapRef.current.set(id, toggle);
+    if (!orderRef.current.includes(id)) {
+      orderRef.current.push(id);
+    }
+    return () => {
+      mapRef.current.delete(id);
+      orderRef.current = orderRef.current.filter((x) => x !== id);
+    };
+  }, []);
+
+  const toggleLast = useCallback(() => {
+    const ids = orderRef.current;
+    if (ids.length === 0) return;
+    const fn = mapRef.current.get(ids[ids.length - 1]);
+    fn?.();
+  }, []);
+
+  const value = useMemo(() => ({ register, toggleLast }), [register, toggleLast]);
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useShellExpand() {
+  return useContext(Ctx);
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -55,7 +55,8 @@ export type Item =
       output?: string;
       error?: string;
       truncated?: boolean;
-      parentId?: string;
+      isShell?: boolean; // true for !-prefix shell commands (controls default expand)
+      parentId?: string; // a sub-agent call nests under the `task` call with this id
     };
 
 interface State {
@@ -181,7 +182,7 @@ function applyEvent(s: State, e: WireEvent): State {
         if (it.kind === "tool") next[idx] = { ...it, name: t.name, args: t.args ? t.args : it.args, readOnly: t.readOnly };
         return { ...s, items: next };
       }
-      return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "tool", id, name: t.name, args: t.args ?? "", readOnly: t.readOnly, status: "running", parentId: t.parentId }] };
+      return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "tool", id, name: t.name, args: t.args ?? "", readOnly: t.readOnly, status: "running", isShell: id.startsWith("shell-"), parentId: t.parentId }] };
     }
     case "tool_result": {
       const t = e.tool;
@@ -426,6 +427,11 @@ export function useController() {
     (display !== submit ? app.SubmitDisplayToTab(activeTabId, display, submit) : app.SubmitToTab(activeTabId, submit)).catch(() => {});
   }, [activeTabId, dispatchTo]);
 
+  const runShell = useCallback((command: string) => {
+    dispatch({ type: "user", text: `!${command}` });
+    app.RunShell(command).catch(() => {});
+  }, []);
+
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
     if (!activeTabId) return;
     dispatchTo(activeTabId, { type: "local_notice", level, text });
@@ -624,7 +630,7 @@ export function useController() {
   return {
     state: activeState,
     activeTabId,
-    send, notice, cancel, approve, answerQuestion, setControllerMode,
+    send, runShell, notice, cancel, approve, answerQuestion, setControllerMode,
     newSession, listSessions, listTrashedSessions, resumeSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, setModel, setEffort,
     fetchMemory, remember, forget, saveDoc,

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -428,9 +428,10 @@ export function useController() {
   }, [activeTabId, dispatchTo]);
 
   const runShell = useCallback((command: string) => {
-    dispatch({ type: "user", text: `!${command}` });
+    if (!activeTabId) return;
+    dispatchTo(activeTabId, { type: "user", text: `!${command}` });
     app.RunShell(command).catch(() => {});
-  }, []);
+  }, [activeTabId, dispatchTo]);
 
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
     if (!activeTabId) return;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -557,6 +557,7 @@ export const en = {
   "tool.stepOne": "{n} step",
   "tool.stepOther": "{n} steps",
   "tool.truncated": "output truncated",
+  "tool.showAllLines": "show all {n} lines",
   "tool.lineOne": "{n} line",
   "tool.lineOther": "{n} lines",
   "tool.matchOne": "{n} match",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -558,6 +558,7 @@ export const zh: Record<DictKey, string> = {
   "tool.stepOne": "{n} 步",
   "tool.stepOther": "{n} 步",
   "tool.truncated": "输出已截断",
+  "tool.showAllLines": "显示全部 {n} 行",
   "tool.lineOne": "{n} 行",
   "tool.lineOther": "{n} 行",
   "tool.matchOne": "{n} 处匹配",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -51,6 +51,7 @@
   --err: #e0696a;
   --danger: #e5484d;
   --danger-fg: #fff;
+  --shell-accent: #22c55e;
 
   /* component recipes */
   --list-row-height: 38px;
@@ -1474,6 +1475,21 @@ a[href] {
   color: var(--fg-faint);
   margin-top: 3px;
 }
+.tool__showall {
+  display: inline-block;
+  margin-top: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  line-height: 1.6;
+}
+.tool__showall:hover {
+  background: color-mix(in srgb, var(--accent-soft) 60%, transparent);
+}
 .tool__err {
   margin: 0 11px 10px 30px;
   padding: 7px 10px;
@@ -1756,6 +1772,16 @@ a[href] {
 .composer--disabled:focus-within {
   border-color: var(--border);
   box-shadow: none;
+}
+.composer--shell {
+  border-bottom-color: var(--shell-accent);
+}
+.composer--shell:focus-within {
+  border-bottom-color: var(--shell-accent);
+  box-shadow: 0 1px 0 0 var(--shell-accent);
+}
+.composer--shell .composer__caret {
+  color: var(--shell-accent);
 }
 .composer__caret {
   color: var(--accent);

--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -19,6 +19,7 @@ func newTestChatTUI() chatTUI {
 		input:                ti,
 		width:                80,
 		submittedInputCursor: -1,
+		queueEditCursor:      -1,
 		nextPasteID:          1,
 		reasoningLineIdx:     -1,
 		reasoningTextIdx:     -1,

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -140,6 +140,14 @@ type chatTUI struct {
 	toolTail      []string
 	toolPartial   string
 	toolLineCount int
+	// shellOutputs stores the full accumulated output of each shell command
+	// (tool IDs with "shell-" prefix), so the first 10 lines can be shown after
+	// collapse and Ctrl+B can toggle the complete output.
+	shellOutputs  map[string]string
+	shellExpanded map[string]bool
+	// shellTranscriptIdx maps a shell tool ID to the transcript index of its
+	// collapsed output block, so Ctrl+B can rewrite it in place.
+	shellTranscriptIdx map[string]int
 	// toolStreamStart / toolStreamFrame drive the "⎿ working · Ns" line shown
 	// under a dispatched tool that hasn't produced output yet, so a slow tool
 	// (e.g. codegraph_context) reads as making progress rather than frozen.
@@ -438,6 +446,9 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		pending:              &strings.Builder{},
 		pendingCommit:        &commitBuf,
 		renderer:             newMarkdownRenderer(termW),
+		shellOutputs:         make(map[string]string),
+		shellExpanded:        make(map[string]bool),
+		shellTranscriptIdx:   make(map[string]int),
 		eventCh:              eventCh,
 		history:              ctrl.History(),
 		host:                 ctrl.Host(),
@@ -588,13 +599,23 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.MouseClickMsg:
 		// Right-click copies the active selection (Windows Terminal convention);
-		// left-press in the transcript region begins a text selection.
+		// left-press in the transcript region begins a text selection — unless
+		// the click lands on a shell-output hint line, which toggles expand.
 		if msg.Button == tea.MouseRight && m.sel.active && !m.sel.empty() {
 			text := m.selectedText()
 			m.sel = selection{}
 			return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
 		}
 		if msg.Button == tea.MouseLeft && msg.Y < m.viewport.Height() {
+			// Check if the clicked line is a shell-output hint.
+			lineIdx := m.viewport.YOffset() + msg.Y
+			if lineIdx >= 0 && lineIdx < len(m.wrappedLines) {
+				clicked := m.wrappedLines[lineIdx]
+				if strings.Contains(clicked, "more lines") && strings.Contains(clicked, "Ctrl+B") {
+					m.toggleShellOutput()
+					return m, finalize(m, cmds)
+				}
+			}
 			at := m.transcriptCaret(msg.X, msg.Y)
 			m.sel = selection{active: true, anchor: at, head: at}
 			m.autoScroll = 0
@@ -792,6 +813,13 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.unsendPending()
 			case m.state == tuiRunning:
 				m.ctrl.Cancel()
+				// Defensive: if the controller is no longer running (cancel
+				// completed synchronously, e.g. for shell commands), transition
+				// to idle immediately instead of waiting for TurnDone.
+				if !m.ctrl.Running() {
+					m.state = tuiIdle
+					m.confirmBubbleSent()
+				}
 			case m.planMode:
 				m.planMode = false
 				m.ctrl.SetPlanMode(false)
@@ -860,6 +888,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+o":
 			m.toggleVerboseReasoning(m.state != tuiRunning)
 			return m, finalize(m, cmds)
+		case "ctrl+b":
+			m.toggleShellOutput()
+			return m, finalize(m, cmds)
 		case "shift+tab":
 			// Cycle auto → plan → YOLO; allowed mid-turn so the user can flip the
 			// gate while a run is in flight (the controller's mode is atomic).
@@ -905,6 +936,34 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.notice(fmt.Sprintf(i18n.M.QuickRememberDoneFmt, path))
 				}
 				return m, finalize(m, cmds)
+			}
+
+			// "!<cmd>" runs a shell command directly, bypassing the model.
+			if strings.HasPrefix(line, "!") {
+				cmd := strings.TrimPrefix(line, "!")
+				if strings.TrimSpace(cmd) == "" {
+					m.input.Reset()
+					m.input.SetHeight(1)
+					m.pastedBlocks = nil
+					m.notice(i18n.M.ShellExecEmpty)
+					return m, finalize(m, cmds)
+				}
+				m.input.Reset()
+				m.input.SetHeight(1)
+				m.pastedBlocks = nil
+				m.state = tuiRunning
+				m.runStart = time.Now()
+				m.elapsed = 0
+				m.turnTokens = 0
+				m.pendingRestore = line
+				m.bubbleStartIdx = len(m.transcript)
+				m.commitLine("")
+				m.commitLine(renderUserBubble(line, m.width, m.planMode))
+				m.bubblePending = true
+				m.turnDiscarded = false
+				m.confirmBubbleSent() // shell events arrive instantly
+				m.ctrl.RunShell(cmd)
+				return m, tea.Batch(m.spinner.Tick, elapsedTick())
 			}
 
 			// Slash commands run locally without going through the model. A
@@ -1340,6 +1399,15 @@ func reasoningBlock(raw string, width, maxLines int) string {
 // the live block scrolls within this window so a chatty build doesn't flood.
 const toolStreamTailLines = 8
 
+// shellPreviewLines is how many lines of shell output to show by default after
+// the command finishes. Ctrl+B toggles the full output.
+const shellPreviewLines = 10
+
+// shellExpandMaxLines caps how many lines Ctrl+B shows in expanded mode, so a
+// very large output (e.g. thousands of lines) doesn't hang the TUI or push the
+// input box off-screen.
+const shellExpandMaxLines = 200
+
 // streamToolOutput appends a chunk of a running tool's output and re-renders its
 // live block (the last toolStreamTailLines lines) under the tool card, opening
 // the block on the first chunk. Mirrors streamReasoning.
@@ -1355,6 +1423,10 @@ func (m *chatTUI) streamToolOutput(id, chunk string) {
 		m.toolLineCount = 0
 		m.toolStreamIdx = len(m.transcript)
 		m.commitLine("")
+	}
+	// Accumulate full output for shell commands so Ctrl+B can expand it.
+	if strings.HasPrefix(id, "shell-") {
+		m.shellOutputs[id] += chunk
 	}
 	// Fold completed lines into the bounded tail; keep the trailing partial.
 	data := m.toolPartial + chunk
@@ -1393,7 +1465,9 @@ func (m *chatTUI) pushToolLine(line string) {
 
 // collapseToolOutput replaces a finished tool's live block with a dim
 // "⎿ N lines" summary, so the scrollback keeps a marker of the run without the
-// full output (which the model already received). No-op when id isn't streaming.
+// full output (which the model already received). For shell commands ("shell-"
+// prefix), it shows the first shellPreviewLines with a Ctrl+B hint instead.
+// No-op when id isn't streaming.
 func (m *chatTUI) collapseToolOutput(id string) {
 	if m.toolStreamIdx < 0 || id == "" || m.toolStreamID != id {
 		return
@@ -1403,14 +1477,30 @@ func (m *chatTUI) collapseToolOutput(id string) {
 		n++
 	}
 	if n == 0 {
-		// The tool produced no streamed output (e.g. an MCP call like
-		// codegraph_context) — drop the "working" placeholder so only the card
-		// remains, rather than leaving a "0 lines" summary.
 		if m.toolStreamIdx == len(m.transcript)-1 {
 			m.transcript = m.transcript[:m.toolStreamIdx]
 		} else {
 			m.transcript[m.toolStreamIdx] = ""
 		}
+	} else if full, ok := m.shellOutputs[id]; ok {
+		// Shell command: show first N lines + hint.
+		lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
+		total := len(lines)
+		if total > shellPreviewLines {
+			preview := make([]string, shellPreviewLines+1)
+			for i := 0; i < shellPreviewLines; i++ {
+				preview[i] = dim(clampPlain(lines[i], m.width-len([]rune(connector))))
+			}
+			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (click/Ctrl+B)", total-shellPreviewLines))
+			m.transcript[m.toolStreamIdx] = connectorBlock(preview)
+		} else {
+			rendered := make([]string, total)
+			for i, ln := range lines {
+				rendered[i] = dim(clampPlain(ln, m.width-len([]rune(connector))))
+			}
+			m.transcript[m.toolStreamIdx] = connectorBlock(rendered)
+		}
+		m.shellTranscriptIdx[id] = m.toolStreamIdx
 	} else {
 		m.transcript[m.toolStreamIdx] = connectorBlock([]string{dim(fmt.Sprintf("%d lines", n))})
 	}
@@ -1420,6 +1510,63 @@ func (m *chatTUI) collapseToolOutput(id string) {
 	m.toolTail = m.toolTail[:0]
 	m.toolPartial = ""
 	m.toolLineCount = 0
+}
+
+// toggleShellOutput expands or collapses the output of the most recent shell
+// command. When expanded, up to shellExpandMaxLines lines are shown; when
+// collapsed, only the first shellPreviewLines are shown. Called on Ctrl+B.
+func (m *chatTUI) toggleShellOutput() {
+	// Find the most recent shell output that has a transcript entry.
+	var lastID string
+	var lastIdx int
+	for id, idx := range m.shellTranscriptIdx {
+		if idx > lastIdx {
+			lastID = id
+			lastIdx = idx
+		}
+	}
+	if lastID == "" {
+		return
+	}
+	full, ok := m.shellOutputs[lastID]
+	if !ok {
+		return
+	}
+	lines := strings.Split(strings.TrimRight(full, "\n"), "\n")
+	total := len(lines)
+	innerW := m.width - len([]rune(connector))
+	if innerW < 10 {
+		innerW = 80
+	}
+
+	if m.shellExpanded[lastID] {
+		// Collapse back to preview.
+		m.shellExpanded[lastID] = false
+		if total > shellPreviewLines {
+			preview := make([]string, shellPreviewLines+1)
+			for i := 0; i < shellPreviewLines; i++ {
+				preview[i] = dim(clampPlain(lines[i], innerW))
+			}
+			preview[shellPreviewLines] = dim(fmt.Sprintf("… %d more lines (click/Ctrl+B)", total-shellPreviewLines))
+			m.transcript[lastIdx] = connectorBlock(preview)
+		}
+	} else {
+		// Expand: show up to shellExpandMaxLines lines.
+		m.shellExpanded[lastID] = true
+		show := total
+		if show > shellExpandMaxLines {
+			show = shellExpandMaxLines
+		}
+		rendered := make([]string, show)
+		for i := 0; i < show; i++ {
+			rendered[i] = dim(clampPlain(lines[i], innerW))
+		}
+		if total > shellExpandMaxLines {
+			rendered = append(rendered, dim(fmt.Sprintf("… %d more lines", total-shellExpandMaxLines)))
+		}
+		m.transcript[lastIdx] = connectorBlock(rendered)
+	}
+	m.transcriptDirty = true
 }
 
 // toolWorkingFrames is the braille spinner cycled once per second on the
@@ -1617,13 +1764,25 @@ func (m chatTUI) View() tea.View {
 		boxW = 10
 	}
 	hideComposer := m.hideComposer()
+	shellMode := strings.HasPrefix(strings.TrimSpace(m.input.Value()), "!")
 	var box string
 	if !hideComposer {
-		box = inputBoxStyle.Width(boxW).Render(m.input.View())
+		style := inputBoxStyle.Width(boxW)
+		if shellMode {
+			style = style.BorderForeground(lipgloss.Color(statusShellColor.hex))
+		}
+		box = style.Render(m.input.View())
 	}
 
 	var modeTag string
 	switch {
+	case shellMode:
+		modeTag = lipgloss.NewStyle().
+			Background(lipgloss.Color(statusShellColor.hex)).
+			Foreground(lipgloss.Color("#ffffff")).
+			Bold(true).
+			Padding(0, 1).
+			Render("Shell")
 	case m.ctrl.Bypass():
 		modeTag = lipgloss.NewStyle().
 			Background(lipgloss.Color(statusYoloColor.hex)).
@@ -1664,6 +1823,8 @@ func (m chatTUI) View() tea.View {
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusPlanApproval
 	case m.pendingApproval != nil:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusToolApproval
+	case shellMode:
+		status = "  " + modeTag + " · " + i18n.M.ShellModeHint
 	case m.ctrl.Bypass():
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusYoloIdle + " " + dim("("+i18n.M.ChatStatusCycleHint+")")
 	default:

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -94,6 +94,13 @@ type chatTUI struct {
 	// pendingInterject queues input typed while a turn runs; each TurnDone
 	// dequeues the front and submits it as the next turn.
 	pendingInterject []string
+	// queueEditCursor tracks which queued message the user is currently
+	// browsing/editing via ↑/↓ during tuiRunning. -1 means "not browsing".
+	queueEditCursor int
+	// queueEditDraft saves the in-progress input text when the user first
+	// presses ↑ to browse the queue, so it can be restored when the cursor
+	// moves past the end.
+	queueEditDraft string
 
 	// history is a resumed session's messages, committed to scrollback once on
 	// the first WindowSizeMsg so a reopened chat shows its prior transcript.
@@ -437,6 +444,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		input:                ti,
 		spinner:              sp,
 		submittedInputCursor: -1,
+		queueEditCursor:      -1,
 		nextPasteID:          1,
 		reasoningLineIdx:     -1,
 		reasoningTextIdx:     -1,
@@ -505,6 +513,76 @@ func (m *chatTUI) recallSubmittedInput(delta int) bool {
 func (m *chatTUI) resetSubmittedInputRecall() {
 	m.submittedInputCursor = -1
 	m.submittedInputDraft = ""
+}
+
+// navigateQueue moves through the pending interject queue during tuiRunning.
+// delta < 0 means ↑ (older), delta > 0 means ↓ (newer). Returns true if the
+// input was updated.
+func (m *chatTUI) navigateQueue(delta int) bool {
+	if len(m.pendingInterject) == 0 {
+		return false
+	}
+	cursor := m.queueEditCursor
+	if cursor < 0 {
+		if delta > 0 {
+			return false // already at "new draft" — nothing newer
+		}
+		// First ↑: save the current draft and jump to the last queued item.
+		m.queueEditDraft = m.input.Value()
+		cursor = len(m.pendingInterject) - 1
+	} else {
+		cursor += delta
+	}
+
+	if cursor < 0 {
+		cursor = 0
+	}
+	if cursor >= len(m.pendingInterject) {
+		// Past the end: restore the draft the user was composing.
+		m.queueEditCursor = -1
+		m.input.SetValue(m.queueEditDraft)
+		m.growInputToFit()
+		return true
+	}
+	m.queueEditCursor = cursor
+	m.input.SetValue(m.pendingInterject[cursor])
+	m.growInputToFit()
+	return true
+}
+
+// resetQueueNavigation resets the queue browsing cursor so the user returns to
+// normal input mode. Any in-progress edit is discarded (the queued item keeps
+// its previous value).
+func (m *chatTUI) resetQueueNavigation() {
+	m.queueEditCursor = -1
+	m.queueEditDraft = ""
+}
+
+// renderQueueIndicator renders the pending-message queue as dim text to show
+// above the input box when messages are queued during a running turn.
+func (m chatTUI) renderQueueIndicator() string {
+	if m.state != tuiRunning || len(m.pendingInterject) == 0 {
+		return ""
+	}
+	queueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("240")) // dim grey
+	highlightStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("250"))
+	var lines []string
+	for i, msg := range m.pendingInterject {
+		preview := msg
+		// Truncate long messages for the compact preview.
+		runes := []rune(preview)
+		if len(runes) > 50 {
+			preview = string(runes[:47]) + "…"
+		}
+		cursor := " "
+		style := queueStyle
+		if m.queueEditCursor == i {
+			cursor = "▸"
+			style = highlightStyle
+		}
+		lines = append(lines, style.Render(fmt.Sprintf("  %s [%d] %s", cursor, i+1, preview)))
+	}
+	return strings.Join(lines, "\n")
 }
 
 // prompts returns the MCP prompts discovered at startup (nil when no plugins).
@@ -791,15 +869,27 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch msg.String() {
 		case "up":
-			if m.state != tuiRunning && m.recallSubmittedInput(-1) {
+			if m.state == tuiRunning {
+				if m.navigateQueue(-1) {
+					return m, nil
+				}
+			} else if m.recallSubmittedInput(-1) {
 				return m, nil
 			}
 		case "down":
-			if m.state != tuiRunning && m.recallSubmittedInput(1) {
+			if m.state == tuiRunning {
+				if m.navigateQueue(1) {
+					return m, nil
+				}
+			} else if m.recallSubmittedInput(1) {
 				return m, nil
 			}
+		case "enter":
+			// Don't reset queue navigation — the Enter handler below needs
+			// queueEditCursor to decide whether to save an edit or enqueue.
 		default:
 			m.resetSubmittedInputRecall()
+			m.resetQueueNavigation()
 		}
 		switch msg.String() {
 		case "esc":
@@ -902,11 +992,21 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if line == "" {
 					return m, nil
 				}
-				m.pendingInterject = append(m.pendingInterject, line)
+				if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {
+					// Save the edited text back to the queue slot.
+					m.pendingInterject[m.queueEditCursor] = line
+					m.notice(fmt.Sprintf("queue [%d] updated", m.queueEditCursor+1))
+					m.queueEditCursor = -1
+					m.queueEditDraft = ""
+				} else {
+					m.pendingInterject = append(m.pendingInterject, line)
+					m.notice("feedback queued — will send when the current turn finishes")
+					m.queueEditCursor = -1
+					m.queueEditDraft = ""
+				}
 				m.input.Reset()
 				m.input.SetHeight(1)
 				m.pastedBlocks = nil
-				m.notice("feedback queued — will send when the current turn finishes")
 				return m, finalize(m, cmds)
 			}
 			if m.modelSwitchPending {
@@ -1034,6 +1134,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.pendingInterject) > 0 {
 				interject := m.pendingInterject[0]
 				m.pendingInterject = m.pendingInterject[1:]
+				// Reset queue navigation — the indices shifted.
+				m.queueEditCursor = -1
+				m.queueEditDraft = ""
 				cmds = append(cmds, m.startTurn(interject, interject, interject))
 			}
 		}
@@ -1927,6 +2030,10 @@ func (m chatTUI) View() tea.View {
 	}
 	statusBlock := clampStatusLine(status, boxW) + "\n" + clampStatusLine(dataLine, boxW)
 	if !hideComposer {
+		if qi := m.renderQueueIndicator(); qi != "" {
+			parts = append(parts, qi)
+			rowsAboveBox += strings.Count(qi, "\n") + 1
+		}
 		parts = append(parts, box)
 	}
 	parts = append(parts, statusBlockStyle.Width(boxW).MaxWidth(boxW).Render(statusBlock))
@@ -2763,6 +2870,8 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		// just clear the un-sendable flag.
 		m.confirmBubbleSent()
 		m.state = tuiIdle
+		m.queueEditCursor = -1
+		m.queueEditDraft = ""
 		m.clearSubmittedPastes()
 		if e.Err != nil && e.Err.Error() != "" && !strings.Contains(e.Err.Error(), "context canceled") {
 			m.commitLine(wrapForViewport(i18n.M.ErrorPrefix+" "+e.Err.Error(), m.width, activeCLITheme.warn))

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -643,6 +643,189 @@ func TestSubmittedInputRecallWithArrowKeys(t *testing.T) {
 	}
 }
 
+func TestQueueNavigationWithArrowKeys(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"queued one", "queued two", "queued three"}
+	m.input.SetValue("my draft")
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	down := tea.KeyPressMsg{Code: tea.KeyDown}
+
+	// First ↑ should save draft and jump to last queued item.
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "queued three" {
+		t.Fatalf("first up: want %q, got %q", "queued three", got)
+	}
+	if m.queueEditCursor != 2 {
+		t.Fatalf("first up: cursor should be 2, got %d", m.queueEditCursor)
+	}
+
+	// Second ↑ should move to "queued two".
+	model, _ = m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "queued two" {
+		t.Fatalf("second up: want %q, got %q", "queued two", got)
+	}
+
+	// ↓ should move back to "queued three".
+	model, _ = m.Update(down)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "queued three" {
+		t.Fatalf("down: want %q, got %q", "queued three", got)
+	}
+
+	// ↓ past the end should restore the draft.
+	model, _ = m.Update(down)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "my draft" {
+		t.Fatalf("down past end: want %q, got %q", "my draft", got)
+	}
+	if m.queueEditCursor != -1 {
+		t.Fatalf("down past end: cursor should be -1, got %d", m.queueEditCursor)
+	}
+}
+
+func TestQueueNavigationClampAtStart(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"only item"}
+	m.input.SetValue("draft")
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	// First ↑ jumps to the only item.
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "only item" {
+		t.Fatalf("first up: want %q, got %q", "only item", got)
+	}
+	// Second ↑ should clamp at index 0 (not go negative).
+	model, _ = m.Update(up)
+	m = model.(chatTUI)
+	if m.queueEditCursor != 0 {
+		t.Fatalf("second up: cursor should clamp at 0, got %d", m.queueEditCursor)
+	}
+	if got := m.input.Value(); got != "only item" {
+		t.Fatalf("second up: value should stay %q, got %q", "only item", got)
+	}
+}
+
+func TestQueueNavigationNoOpWhenEmpty(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.input.SetValue("hello")
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if got := m.input.Value(); got != "hello" {
+		t.Fatalf("empty queue: input should be unchanged, got %q", got)
+	}
+}
+
+func TestQueueEditSavesOnEnter(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"original one", "original two"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if m.queueEditCursor != 1 {
+		t.Fatalf("cursor should be 1 after up, got %d", m.queueEditCursor)
+	}
+
+	// Edit the queued message.
+	m.input.SetValue("edited two")
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	model, _ = m.Update(enter)
+	m = model.(chatTUI)
+
+	if m.pendingInterject[1] != "edited two" {
+		t.Fatalf("queue[1] should be %q, got %q", "edited two", m.pendingInterject[1])
+	}
+	if m.pendingInterject[0] != "original one" {
+		t.Fatalf("queue[0] should be unchanged, got %q", m.pendingInterject[0])
+	}
+	if m.queueEditCursor != -1 {
+		t.Fatalf("cursor should reset after enter, got %d", m.queueEditCursor)
+	}
+}
+
+func TestQueueNewMessageOnEnterDuringRunning(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"existing"}
+
+	m.input.SetValue("new message")
+	enter := tea.KeyPressMsg{Code: tea.KeyEnter}
+	model, _ := m.Update(enter)
+	m = model.(chatTUI)
+
+	if len(m.pendingInterject) != 2 {
+		t.Fatalf("queue should have 2 items, got %d", len(m.pendingInterject))
+	}
+	if m.pendingInterject[1] != "new message" {
+		t.Fatalf("queue[1] should be %q, got %q", "new message", m.pendingInterject[1])
+	}
+}
+
+func TestQueueNavigationResetOnNonUpDownKey(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"queued"}
+
+	up := tea.KeyPressMsg{Code: tea.KeyUp}
+	model, _ := m.Update(up)
+	m = model.(chatTUI)
+	if m.queueEditCursor != 0 {
+		t.Fatalf("cursor should be 0 after up, got %d", m.queueEditCursor)
+	}
+
+	// A regular key should reset the queue navigation cursor.
+	letter := tea.KeyPressMsg{Code: 'a'}
+	model, _ = m.Update(letter)
+	m = model.(chatTUI)
+	if m.queueEditCursor != -1 {
+		t.Fatalf("cursor should reset on non-up/down key, got %d", m.queueEditCursor)
+	}
+}
+
+func TestQueueIndicatorRendering(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiRunning
+	m.pendingInterject = []string{"first msg", "second msg"}
+
+	qi := m.renderQueueIndicator()
+	if qi == "" {
+		t.Fatal("queue indicator should not be empty when queue has items and running")
+	}
+	if !strings.Contains(qi, "[1]") || !strings.Contains(qi, "[2]") {
+		t.Fatalf("queue indicator should contain [1] and [2], got %q", qi)
+	}
+	if !strings.Contains(qi, "first msg") || !strings.Contains(qi, "second msg") {
+		t.Fatalf("queue indicator should show message previews, got %q", qi)
+	}
+
+	// Highlight marker should appear for the browsed item.
+	m.queueEditCursor = 1
+	qi = m.renderQueueIndicator()
+	if !strings.Contains(qi, "▸") {
+		t.Fatalf("queue indicator should show ▸ for browsed item, got %q", qi)
+	}
+}
+
+func TestQueueIndicatorHiddenWhenIdle(t *testing.T) {
+	m := newTestChatTUI()
+	m.state = tuiIdle
+	m.pendingInterject = []string{"queued"}
+
+	if qi := m.renderQueueIndicator(); qi != "" {
+		t.Fatalf("queue indicator should be empty when idle, got %q", qi)
+	}
+}
+
 // TestViewAltScreenFillsHeight proves the switch to alt-screen: View requests
 // the alt buffer + mouse, and the frame is exactly the terminal height (the
 // transcript viewport pads to fill above the pinned bottom region).

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -121,9 +121,10 @@ func (m chatTUI) gitTag() string {
 }
 
 var (
-	statusAutoColor = cliColor{"#f59e0b", 214}
-	statusPlanColor = cliColor{"#2563eb", 27}
-	statusYoloColor = cliColor{"#e5484d", 167}
+	statusAutoColor  = cliColor{"#f59e0b", 214}
+	statusPlanColor  = cliColor{"#2563eb", 27}
+	statusYoloColor  = cliColor{"#e5484d", 167}
+	statusShellColor = cliColor{"#16a34a", 71} // green — shell mode indicator
 )
 
 func (m chatTUI) statusModeColor() cliColor {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -11,12 +11,15 @@
 package control
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,12 +34,14 @@ import (
 	"reasonix/internal/diff"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
+	"reasonix/internal/i18n"
 	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
 	"reasonix/internal/nilutil"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/sandbox"
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
@@ -435,6 +440,10 @@ func (c *Controller) Submit(input string) {
 		c.rememberProjectNote(note)
 		return
 	}
+	if strings.HasPrefix(trimmed, "!") {
+		c.RunShell(trimmed[1:])
+		return
+	}
 	switch {
 	case trimmed == "/compact" || strings.HasPrefix(trimmed, "/compact "):
 		focus := strings.TrimSpace(strings.TrimPrefix(trimmed, "/compact"))
@@ -546,6 +555,94 @@ func (c *Controller) rememberProjectNote(note string) {
 	} else {
 		c.notice("remembered → " + path)
 	}
+}
+
+// shellTimeout is the maximum time a user-invoked "!command" may run. Matches
+// the bash tool's timeout so behaviour is consistent across invocation paths.
+const shellTimeout = 120 * time.Second
+
+// shellWaitDelay bounds how long cmd.Run() waits after context cancellation for
+// the child's pipes to drain, matching the bash tool's WaitDelay.
+const shellWaitDelay = 5 * time.Second
+
+// shellWriter forwards each chunk of shell output to a callback, so RunShell
+// can stream live progress to the frontend as the command produces output.
+type shellWriter struct{ emit func(string) }
+
+func (w *shellWriter) Write(p []byte) (int, error) {
+	w.emit(string(p))
+	return len(p), nil
+}
+
+// RunShell executes a shell command directly (bypassing the model) and streams
+// the output as ToolDispatch/ToolProgress/ToolResult events. It uses the same
+// bash-tool infrastructure (shell resolution, timeout) and shares the runGuarded
+// lock with model turns — only one can run at a time. User-invoked "!" commands
+// run without the OS sandbox (the user typed the command explicitly).
+func (c *Controller) RunShell(command string) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		c.notice(i18n.M.ShellExecEmpty)
+		return
+	}
+	c.runGuarded(func(ctx context.Context) error {
+		sh := sandbox.ResolveShell()
+		argv, _ := sandbox.Command(sandbox.Spec{}, sh, command) // false = unsandboxed (user invoked)
+
+		preview := []rune(command)
+		if len(preview) > 32 {
+			preview = preview[:32]
+		}
+		id := "shell-" + string(preview)
+
+		c.sink.Emit(event.Event{
+			Kind: event.ToolDispatch,
+			Tool: event.Tool{
+				ID:   id,
+				Name: "bash",
+				Args: fmt.Sprintf(`{"command":%q}`, command),
+			},
+		})
+
+		ctx, cancel := context.WithTimeout(ctx, shellTimeout)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
+		setShellKillTree(cmd)
+		cmd.WaitDelay = shellWaitDelay
+		cmd.Dir = c.cpRoot
+		var buf bytes.Buffer
+		w := io.MultiWriter(&buf, &shellWriter{emit: func(chunk string) {
+			c.sink.Emit(event.Event{
+				Kind: event.ToolProgress,
+				Tool: event.Tool{ID: id, Output: chunk},
+			})
+		}})
+		cmd.Stdout = w
+		cmd.Stderr = w
+		err := cmd.Run()
+		out := buf.String()
+
+		if ctx.Err() == context.DeadlineExceeded {
+			c.sink.Emit(event.Event{
+				Kind: event.ToolResult,
+				Tool: event.Tool{ID: id, Name: "bash", Output: out, Err: fmt.Sprintf(i18n.M.ShellExecTimeoutFmt, shellTimeout)},
+			})
+			return nil
+		}
+		if err != nil {
+			c.sink.Emit(event.Event{
+				Kind: event.ToolResult,
+				Tool: event.Tool{ID: id, Name: "bash", Output: out, Err: fmt.Sprintf(i18n.M.ShellExecFailedFmt, err)},
+			})
+			return nil
+		}
+		c.sink.Emit(event.Event{
+			Kind: event.ToolResult,
+			Tool: event.Tool{ID: id, Name: "bash", Output: out},
+		})
+		return nil
+	})
 }
 
 // runRefTurn resolves a line's @references into a context block and starts a

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -501,6 +501,17 @@ func (c *Controller) Submit(input string) {
 				c.notice(err.Error())
 			}
 			return
+		case "/rewind":
+			args := strings.TrimSpace(strings.TrimPrefix(trimmed, fields[0]))
+			turn, scope, err := parseRewind(args, c.Checkpoints())
+			if err != nil {
+				c.notice("usage: /rewind [turn] [code|conversation|both]")
+				return
+			}
+			if err := c.Rewind(turn, scope); err != nil {
+				c.notice(err.Error())
+			}
+			return
 		}
 		if c.managementNotice(trimmed) {
 			return
@@ -1821,6 +1832,39 @@ func listItem(line string) (content string, level int, ok bool) {
 // requestApproval emits an ApprovalRequest and blocks until Approve(ID, …)
 // answers or ctx is cancelled. A prior session grant for the same tool+subject
 // short-circuits. promptMu serialises outstanding prompts.
+// parseRewind parses the arguments after "/rewind". The user may provide:
+//   /rewind              → latest checkpoint, both
+//   /rewind <turn>       → that turn, both
+//   /rewind <turn> <scope> → that turn, code|conversation|both
+// If no turn is given, the latest checkpoint is used. If no scope is given, Both is assumed.
+func parseRewind(args string, cps []checkpoint.Meta) (int, RewindScope, error) {
+	fields := strings.Fields(args)
+	if len(fields) == 0 {
+		if len(cps) == 0 {
+			return 0, RewindBoth, fmt.Errorf("no checkpoints available")
+		}
+		return cps[len(cps)-1].Turn, RewindBoth, nil
+	}
+	turn, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0, RewindBoth, fmt.Errorf("invalid turn: %w", err)
+	}
+	scope := RewindBoth
+	if len(fields) >= 2 {
+		switch strings.ToLower(fields[1]) {
+		case "code":
+			scope = RewindCode
+		case "conversation":
+			scope = RewindConversation
+		case "both":
+			scope = RewindBoth
+		default:
+			return 0, RewindBoth, fmt.Errorf("unknown scope %q", fields[1])
+		}
+	}
+	return turn, scope, nil
+}
+
 func (c *Controller) requestApproval(ctx context.Context, tool, subject string) (bool, bool, error) {
 	key := tool + "\x00" + subject
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/checkpoint"
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -247,5 +248,48 @@ func TestApprovalCtxCancel(t *testing.T) {
 	allow, _, err := gateApprover{c}.Approve(ctx, "bash", "x", nil)
 	if err == nil || allow {
 		t.Fatalf("Approve on cancelled ctx = (%v,%v), want (false, error)", allow, err)
+	}
+}
+
+func TestParseRewind(t *testing.T) {
+	cps := []checkpoint.Meta{
+		{Turn: 0, Prompt: "first"},
+		{Turn: 1, Prompt: "second"},
+		{Turn: 2, Prompt: "third"},
+	}
+	cases := []struct {
+		args    string
+		wantT   int
+		wantS   RewindScope
+		wantErr bool
+	}{
+		{"", 2, RewindBoth, false},               // no args -> latest turn, both
+		{"1", 1, RewindBoth, false},              // turn only
+		{"0 code", 0, RewindCode, false},         // turn + code
+		{"1 conversation", 1, RewindConversation, false}, // turn + conversation
+		{"2 both", 2, RewindBoth, false},         // turn + both
+		{"abc", 0, RewindBoth, true},             // invalid turn
+		{"0 unknown", 0, RewindBoth, true},       // unknown scope
+	}
+	for _, tc := range cases {
+		t.Run(tc.args, func(t *testing.T) {
+			gotT, gotS, err := parseRewind(tc.args, cps)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseRewind(%q) err=%v, wantErr=%v", tc.args, err, tc.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if gotT != tc.wantT || gotS != tc.wantS {
+				t.Fatalf("parseRewind(%q) = (%d,%d), want (%d,%d)", tc.args, gotT, gotS, tc.wantT, tc.wantS)
+			}
+		})
+	}
+}
+
+func TestParseRewindEmptyCheckpoints(t *testing.T) {
+	_, _, err := parseRewind("", nil)
+	if err == nil {
+		t.Fatal("expected error when no checkpoints")
 	}
 }

--- a/internal/control/shell_kill_other.go
+++ b/internal/control/shell_kill_other.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package control
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setShellKillTree makes a cancelled shell command kill its whole process group,
+// not just the shell leader — otherwise a timed-out pipeline (e.g.
+// !find / -name foo | grep bar) orphans the children. The child gets its own
+// group (Setpgid) so the negative-pid signal reaches every descendant.
+func setShellKillTree(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}

--- a/internal/control/shell_kill_windows.go
+++ b/internal/control/shell_kill_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package control
+
+import (
+	"os/exec"
+	"strconv"
+
+	"reasonix/internal/proc"
+)
+
+// setShellKillTree hides the child's console and makes a cancelled command kill
+// its whole process tree. Windows does not cascade a kill to child processes, so
+// killing the shell leaves spawned commands running after a timeout; taskkill /T
+// walks the PID tree and /F forces it.
+func setShellKillTree(cmd *exec.Cmd) {
+	proc.HideWindow(cmd)
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		kill := exec.Command("taskkill", "/F", "/T", "/PID", strconv.Itoa(cmd.Process.Pid))
+		proc.HideWindow(kill)
+		_ = kill.Run()
+		return cmd.Process.Kill()
+	}
+}

--- a/internal/control/shell_test.go
+++ b/internal/control/shell_test.go
@@ -1,0 +1,141 @@
+package control
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+// collectSink returns a Sink that collects events and a channel that receives
+// the TurnDone event when the turn finishes. The channel lets tests wait for
+// the runGuarded goroutine to complete.
+func collectSink() (event.Sink, chan event.Event, *[]event.Event) {
+	var events []event.Event
+	done := make(chan event.Event, 1)
+	sink := event.FuncSink(func(e event.Event) {
+		events = append(events, e)
+		if e.Kind == event.TurnDone {
+			done <- e
+		}
+	})
+	return sink, done, &events
+}
+
+func waitForDone(t *testing.T, done chan event.Event) event.Event {
+	t.Helper()
+	select {
+	case e := <-done:
+		return e
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for TurnDone")
+		return event.Event{}
+	}
+}
+
+func TestRunShell_EmitsEvents(t *testing.T) {
+	sink, done, events := collectSink()
+	ctrl := &Controller{sink: sink}
+
+	ctrl.RunShell("echo hello")
+	waitForDone(t, done)
+
+	if len(*events) < 3 {
+		t.Fatalf("expected at least 3 events, got %d: %v", len(*events), *events)
+	}
+
+	// First event: ToolDispatch
+	if (*events)[0].Kind != event.ToolDispatch {
+		t.Errorf("first event: want ToolDispatch, got %v", (*events)[0].Kind)
+	}
+	if (*events)[0].Tool.Name != "bash" {
+		t.Errorf("tool name: want bash, got %s", (*events)[0].Tool.Name)
+	}
+
+	// Last event: TurnDone
+	td := (*events)[len(*events)-1]
+	if td.Kind != event.TurnDone {
+		t.Errorf("last event: want TurnDone, got %v", td.Kind)
+	}
+
+	// Penultimate event: ToolResult
+	last := (*events)[len(*events)-2]
+	if last.Kind != event.ToolResult {
+		t.Errorf("penultimate event: want ToolResult, got %v", last.Kind)
+	}
+	if last.Tool.Err != "" {
+		t.Errorf("unexpected error: %s", last.Tool.Err)
+	}
+	if !strings.Contains(last.Tool.Output, "hello") {
+		t.Errorf("output should contain 'hello', got: %s", last.Tool.Output)
+	}
+}
+
+func TestSubmit_BangPrefix(t *testing.T) {
+	sink, done, events := collectSink()
+	ctrl := &Controller{sink: sink}
+
+	ctrl.Submit("!echo test")
+	waitForDone(t, done)
+
+	if len(*events) == 0 {
+		t.Fatal("expected events from !echo, got none")
+	}
+	if (*events)[0].Kind != event.ToolDispatch {
+		t.Errorf("first event: want ToolDispatch, got %v", (*events)[0].Kind)
+	}
+}
+
+func TestSubmit_BangEmpty(t *testing.T) {
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+
+	ctrl := &Controller{sink: sink}
+	ctrl.Submit("!")
+
+	if len(notices) == 0 {
+		t.Fatal("expected a notice for bare !")
+	}
+	if !strings.Contains(notices[0], "!") {
+		t.Errorf("notice should mention usage, got: %s", notices[0])
+	}
+}
+
+func TestSubmit_BangNotFirstChar(t *testing.T) {
+	// "! " not at position 0 should NOT trigger shell. Submit routes to
+	// runRefTurn for normal text, which needs a runner — so we test the
+	// prefix-check condition directly.
+	input := "tell me about !important"
+	trimmed := strings.TrimSpace(input)
+	if strings.HasPrefix(trimmed, "!") {
+		t.Error("trimmed input should not start with !")
+	}
+}
+
+func TestRunShell_FailingCommand(t *testing.T) {
+	sink, done, events := collectSink()
+	ctrl := &Controller{sink: sink}
+
+	ctrl.RunShell("false") // exits 1
+	waitForDone(t, done)
+
+	// Find the ToolResult
+	var result *event.Event
+	for i := range *events {
+		if (*events)[i].Kind == event.ToolResult {
+			result = &(*events)[i]
+			break
+		}
+	}
+	if result == nil {
+		t.Fatal("expected a ToolResult event")
+	}
+	if result.Tool.Err == "" {
+		t.Error("failing command should produce an error string")
+	}
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -127,6 +127,12 @@ type Messages struct {
 	CompHintSlash      string // key hint footer under the slash-command menu
 	CompHintFile       string // key hint footer under the @ file/resource menu
 
+	// shell execution (! prefix).
+	ShellExecEmpty      string // bare "!" with no command
+	ShellExecFailedFmt  string // "shell command failed: %v"
+	ShellExecTimeoutFmt string // "shell command timed out (> %s)"
+	ShellModeHint       string // status line hint when input starts with !
+
 	// slash command + sub-command descriptions shown in the menu (CLI and desktop
 	// share these via i18n.M, so both frontends localize identically).
 	CmdNew          string // /new

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -141,6 +141,11 @@ var English = Messages{
 	CompHintSlash:                "↑/↓ move · Tab/Enter select · Esc close",
 	CompHintFile:                 "↑/↓ move · Tab/Enter open folder or pick file · Esc close",
 
+	ShellExecEmpty:      "usage: !<command>  (e.g. !ls -la)",
+	ShellExecFailedFmt:  "shell command failed: %v",
+	ShellExecTimeoutFmt: "shell command timed out (> %s)",
+	ShellModeHint:       "Enter runs shell · Esc cancels · click output to expand",
+
 	CmdNew:          "fork a fresh session",
 	CmdCompact:      "compact context",
 	CmdRewind:       "rewind to an earlier turn",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -142,6 +142,11 @@ var Chinese = Messages{
 	CompHintSlash:                "↑/↓ 移动 · Tab/Enter 选中 · Esc 关闭",
 	CompHintFile:                 "↑/↓ 移动 · Tab/Enter 进入文件夹或选中文件 · Esc 关闭",
 
+	ShellExecEmpty:      "用法：!<命令>  （例如 !ls -la）",
+	ShellExecFailedFmt:  "Shell 命令执行失败：%v",
+	ShellExecTimeoutFmt: "Shell 命令超时（>%s）",
+	ShellModeHint:       "Enter 执行 Shell · Esc 取消 · 点击输出展开",
+
 	CmdNew:          "开启新会话",
 	CmdCompact:      "压缩上下文",
 	CmdRewind:       "回滚到更早的一轮",


### PR DESCRIPTION
Parity-feature roundup bringing the CLI/desktop closer to Claude Code, rebased onto current main-v2 and verified end-to-end (`go build ./...`, `go test` root+desktop, `wails build` tsc+Go). Authorship preserved per commit.

- **#3164** (@dzy) — `/rewind [turn] [code|conversation|both]` slash command, mirroring Claude Code's `/rewind`; reuses the existing checkpoint machinery.
- **#2993** (@lanshi17) — `!<cmd>` runs a shell command directly (bypassing the model), like Claude Code's bang prefix; streams output as a collapsible tool card across TUI + desktop, process-group kill on timeout. Adapted to the per-project tab model (a.ctrl → activeCtrl, dispatch → dispatchTo) + DOM KeyboardEvent typing.
- **#3143** (@lanshi17) — ↑/↓ browse + edit the pending-message queue while a turn streams (Claude Code's queued-messages UX). Closes #2551.

Verification: shell exec (`TestRunShell_*`), `/rewind` parse (`TestParseRewind*`), and queue-nav (`TestQueue*`/`TestInterject*`) tests pass; desktop `wails build` clean.

Closes #3164
Closes #2993
Closes #3143

Not included this round: #3070 (reveal-in-file-manager) is already in main-v2; #3144 / #3125 / #3030 (text-size / shortcuts / close-to-tray) conflict heavily in the reworked styles/settings and are deferred to a clean follow-up rebase.
