### PR TITLE
fix(control): auto-answer ask prompts in YOLO mode

### DIFF
--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -102,9 +103,15 @@ func TestScheduleSnapshotCoalesces(t *testing.T) {
 	a, tab := appWithTab(t, path)
 	_ = a
 
+	var wg sync.WaitGroup
 	for i := 0; i < 64; i++ {
-		go tab.sink.Emit(event.Event{Kind: event.TurnDone})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tab.sink.Emit(event.Event{Kind: event.TurnDone})
+		}()
 	}
+	wg.Wait()
 
 	waitForFile(t, path, "acknowledged")
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -739,15 +739,16 @@ func (c *Controller) EnableInteractiveApproval() {
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.
 func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
-	c.mu.Lock()
-	bypass := c.bypass
-	c.mu.Unlock()
-	if bypass {
+	if c.bypassEnabled() {
 		return recommendedAskAnswers(questions), nil
 	}
 
 	c.promptMu.Lock()
 	defer c.promptMu.Unlock()
+
+	if c.bypassEnabled() {
+		return recommendedAskAnswers(questions), nil
+	}
 
 	c.mu.Lock()
 	c.nextID++
@@ -767,6 +768,12 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 		c.mu.Unlock()
 		return nil, ctx.Err()
 	}
+}
+
+func (c *Controller) bypassEnabled() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.bypass
 }
 
 func recommendedAskAnswers(questions []event.AskQuestion) []event.AskAnswer {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -739,6 +739,13 @@ func (c *Controller) EnableInteractiveApproval() {
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.
 func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
+	c.mu.Lock()
+	bypass := c.bypass
+	c.mu.Unlock()
+	if bypass {
+		return recommendedAskAnswers(questions), nil
+	}
+
 	c.promptMu.Lock()
 	defer c.promptMu.Unlock()
 
@@ -760,6 +767,17 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 		c.mu.Unlock()
 		return nil, ctx.Err()
 	}
+}
+
+func recommendedAskAnswers(questions []event.AskQuestion) []event.AskAnswer {
+	out := make([]event.AskAnswer, len(questions))
+	for i, q := range questions {
+		out[i] = event.AskAnswer{QuestionID: q.ID}
+		if len(q.Options) > 0 {
+			out[i].Selected = []string{q.Options[0].Label}
+		}
+	}
+	return out
 }
 
 // AnswerQuestion resolves a pending AskRequest by ID with the user's selections.
@@ -1930,9 +1948,11 @@ func listItem(line string) (content string, level int, ok bool) {
 // answers or ctx is cancelled. A prior session grant for the same tool+subject
 // short-circuits. promptMu serialises outstanding prompts.
 // parseRewind parses the arguments after "/rewind". The user may provide:
-//   /rewind              → latest checkpoint, both
-//   /rewind <turn>       → that turn, both
-//   /rewind <turn> <scope> → that turn, code|conversation|both
+//
+//	/rewind              → latest checkpoint, both
+//	/rewind <turn>       → that turn, both
+//	/rewind <turn> <scope> → that turn, code|conversation|both
+//
 // If no turn is given, the latest checkpoint is used. If no scope is given, Both is assumed.
 func parseRewind(args string, cps []checkpoint.Meta) (int, RewindScope, error) {
 	fields := strings.Fields(args)

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -263,13 +263,13 @@ func TestParseRewind(t *testing.T) {
 		wantS   RewindScope
 		wantErr bool
 	}{
-		{"", 2, RewindBoth, false},               // no args -> latest turn, both
-		{"1", 1, RewindBoth, false},              // turn only
-		{"0 code", 0, RewindCode, false},         // turn + code
+		{"", 2, RewindBoth, false},                       // no args -> latest turn, both
+		{"1", 1, RewindBoth, false},                      // turn only
+		{"0 code", 0, RewindCode, false},                 // turn + code
 		{"1 conversation", 1, RewindConversation, false}, // turn + conversation
-		{"2 both", 2, RewindBoth, false},         // turn + both
-		{"abc", 0, RewindBoth, true},             // invalid turn
-		{"0 unknown", 0, RewindBoth, true},       // unknown scope
+		{"2 both", 2, RewindBoth, false},                 // turn + both
+		{"abc", 0, RewindBoth, true},                     // invalid turn
+		{"0 unknown", 0, RewindBoth, true},               // unknown scope
 	}
 	for _, tc := range cases {
 		t.Run(tc.args, func(t *testing.T) {

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -182,3 +182,55 @@ func TestSetModeAppliesBothGates(t *testing.T) {
 		t.Fatalf("normal mode: plan=%v bypass=%v, want false/false", c.PlanMode(), c.Bypass())
 	}
 }
+
+func TestBypassAutoAnswersAskWithRecommendedOptions(t *testing.T) {
+	var askRequested bool
+	c := New(Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.AskRequest {
+				askRequested = true
+			}
+		}),
+	})
+	c.SetBypass(true)
+
+	answers, err := c.Ask(context.Background(), []event.AskQuestion{
+		{
+			ID:     "approach",
+			Header: "Approach",
+			Prompt: "Which path?",
+			Options: []event.AskOption{
+				{Label: "Recommended path"},
+				{Label: "Alternative path"},
+			},
+		},
+		{
+			ID:     "scope",
+			Header: "Scope",
+			Prompt: "How broad?",
+			Options: []event.AskOption{
+				{Label: "Minimal"},
+				{Label: "Broad"},
+			},
+			Multi: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if askRequested {
+		t.Fatal("bypass must not emit an AskRequest event")
+	}
+	want := []event.AskAnswer{
+		{QuestionID: "approach", Selected: []string{"Recommended path"}},
+		{QuestionID: "scope", Selected: []string{"Minimal"}},
+	}
+	if len(answers) != len(want) {
+		t.Fatalf("answers len = %d, want %d: %#v", len(answers), len(want), answers)
+	}
+	for i := range want {
+		if answers[i].QuestionID != want[i].QuestionID || len(answers[i].Selected) != 1 || answers[i].Selected[0] != want[i].Selected[0] {
+			t.Fatalf("answers[%d] = %#v, want %#v", i, answers[i], want[i])
+		}
+	}
+}

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -232,5 +233,62 @@ func TestBypassAutoAnswersAskWithRecommendedOptions(t *testing.T) {
 		if answers[i].QuestionID != want[i].QuestionID || len(answers[i].Selected) != 1 || answers[i].Selected[0] != want[i].Selected[0] {
 			t.Fatalf("answers[%d] = %#v, want %#v", i, answers[i], want[i])
 		}
+	}
+}
+
+func TestBypassRecheckedForAskAfterPromptLock(t *testing.T) {
+	askRequests := make(chan struct{}, 1)
+	c := New(Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.AskRequest {
+				askRequests <- struct{}{}
+			}
+		}),
+	})
+	questions := []event.AskQuestion{{
+		ID:     "q1",
+		Header: "Choice",
+		Prompt: "Which path?",
+		Options: []event.AskOption{
+			{Label: "Recommended"},
+			{Label: "Alternative"},
+		},
+	}}
+
+	c.promptMu.Lock()
+	started := make(chan struct{})
+	done := make(chan []event.AskAnswer, 1)
+	errs := make(chan error, 1)
+	var once sync.Once
+	go func() {
+		once.Do(func() { close(started) })
+		answers, err := c.Ask(context.Background(), questions)
+		if err != nil {
+			errs <- err
+			return
+		}
+		done <- answers
+	}()
+	<-started
+	time.Sleep(20 * time.Millisecond)
+
+	c.SetBypass(true)
+	c.promptMu.Unlock()
+
+	select {
+	case err := <-errs:
+		t.Fatalf("Ask: %v", err)
+	case answers := <-done:
+		if len(answers) != 1 || answers[0].QuestionID != "q1" || len(answers[0].Selected) != 1 || answers[0].Selected[0] != "Recommended" {
+			t.Fatalf("answers = %#v, want recommended option", answers)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask stayed blocked after bypass turned on while queued behind promptMu")
+	}
+
+	select {
+	case <-askRequests:
+		t.Fatal("bypass must not emit AskRequest after acquiring promptMu")
+	default:
 	}
 }


### PR DESCRIPTION
## Summary
- auto-answer `ask` prompts in YOLO/bypass mode without emitting an `AskRequest`
- choose each question's first option, matching the existing recommended-option convention
- add regression coverage for YOLO auto-answer behavior

## Tests
- `HOME="$(mktemp -d)" go test ./internal/control -run 'Test(BypassSkipsAutoPlan|RequestApprovalHonorsBypass|SetBypassAllowsPendingApproval|SetModeYoloDrainsPendingApproval|SetModeAppliesBothGates|BypassAutoAnswersAskWithRecommendedOptions)'`\n- `git diff --check`