### PR TITLE
fix(desktop): surface legacy sessions in Global topics (concurrency-safe)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -599,6 +599,7 @@ type SessionMeta struct {
 	ModTime        int64  `json:"modTime"`        // compatibility alias for lastActivityAt
 	DeletedAt      int64  `json:"deletedAt,omitempty"`
 	Current        bool   `json:"current"`
+	Open           bool   `json:"open"`
 	Scope          string `json:"scope,omitempty"`
 	WorkspaceRoot  string `json:"workspaceRoot,omitempty"`
 	TopicID        string `json:"topicId,omitempty"`
@@ -622,10 +623,11 @@ func (a *App) ListSessions() []SessionMeta {
 	}
 	titles := loadSessionTitles(dir)
 	open := a.openSessionPaths(dir)
+	active := a.activeSessionPath(dir)
 	out := make([]SessionMeta, 0, len(infos))
 	for _, s := range infos {
-		_, current := open[s.Path]
-		out = append(out, sessionMetaFromInfo(s, titles[filepath.Base(s.Path)], current, 0))
+		_, isOpen := open[s.Path]
+		out = append(out, sessionMetaFromInfo(s, titles[filepath.Base(s.Path)], s.Path == active, isOpen, 0))
 	}
 	return out
 }
@@ -646,7 +648,7 @@ func (a *App) ListTrashedSessions() []SessionMeta {
 			continue
 		}
 		deletedAt := trashedSessionDeletedAt(path)
-		out = append(out, sessionMetaFromInfo(infos[0], titles[filepath.Base(path)], false, deletedAt))
+		out = append(out, sessionMetaFromInfo(infos[0], titles[filepath.Base(path)], false, false, deletedAt))
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].DeletedAt == out[j].DeletedAt {
@@ -657,7 +659,7 @@ func (a *App) ListTrashedSessions() []SessionMeta {
 	return out
 }
 
-func sessionMetaFromInfo(s agent.SessionInfo, title string, current bool, deletedAt int64) SessionMeta {
+func sessionMetaFromInfo(s agent.SessionInfo, title string, current, open bool, deletedAt int64) SessionMeta {
 	return SessionMeta{
 		Path:           s.Path,
 		Preview:        s.Preview,
@@ -668,6 +670,7 @@ func sessionMetaFromInfo(s agent.SessionInfo, title string, current bool, delete
 		ModTime:        s.LastActivityAt.UnixMilli(),
 		DeletedAt:      deletedAt,
 		Current:        current,
+		Open:           open,
 		Scope:          s.Scope,
 		WorkspaceRoot:  s.WorkspaceRoot,
 		TopicID:        s.TopicID,
@@ -709,9 +712,31 @@ func (a *App) openSessionPaths(dir string) map[string]struct{} {
 	return out
 }
 
+func (a *App) activeSessionPath(dir string) string {
+	a.mu.RLock()
+	var path string
+	if tab := a.tabs[a.activeTabID]; tab != nil && tab.Ctrl != nil {
+		path = tab.Ctrl.SessionPath()
+	}
+	a.mu.RUnlock()
+	currentPath, _, err := validateSessionPath(dir, path)
+	if err != nil {
+		return ""
+	}
+	return currentPath
+}
+
 // RestoreSession moves a trashed session back into the saved-session list.
 func (a *App) RestoreSession(path string) error {
-	return restoreTrashedSessionFile(config.SessionDir(), path)
+	dir := config.SessionDir()
+	_, key, _, err := validateTrashedSessionPath(dir, path)
+	if err != nil {
+		return err
+	}
+	if err := restoreTrashedSessionFile(dir, path); err != nil {
+		return err
+	}
+	return restoreSessionTopicIndex(dir, filepath.Join(dir, key))
 }
 
 // PurgeTrashedSession permanently removes a trashed session and its title/display

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -404,14 +404,25 @@ func TestDeleteSessionRejectsInactiveOpenTab(t *testing.T) {
 
 	sessions := app.ListSessions()
 	current := map[string]bool{}
+	open := map[string]bool{}
 	for _, s := range sessions {
 		current[filepath.Base(s.Path)] = s.Current
+		open[filepath.Base(s.Path)] = s.Open
 	}
-	if !current[filepath.Base(activePath)] || !current[filepath.Base(inactivePath)] {
-		t.Fatalf("ListSessions should mark active and inactive open sessions current, got %#v", current)
+	if !current[filepath.Base(activePath)] {
+		t.Fatalf("ListSessions should mark active session current, got %#v", current)
+	}
+	if current[filepath.Base(inactivePath)] {
+		t.Fatalf("ListSessions should not mark inactive open session current, got %#v", current)
 	}
 	if current[filepath.Base(otherPath)] {
 		t.Fatalf("ListSessions marked unopened session current, got %#v", current)
+	}
+	if !open[filepath.Base(activePath)] || !open[filepath.Base(inactivePath)] {
+		t.Fatalf("ListSessions should mark active and inactive open sessions open, got %#v", open)
+	}
+	if open[filepath.Base(otherPath)] {
+		t.Fatalf("ListSessions marked unopened session open, got %#v", open)
 	}
 }
 

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -343,6 +343,7 @@ export function HistoryPanel({
                           <div className="hist-item__preview">{sessionDisplayTitle(s, tr("history.emptySession"))}</div>
                           <div className="hist-item__meta">
                             {!isTrash && s.current && <span className="hist-item__badge">{tr("history.current")}</span>}
+                            {!isTrash && !s.current && s.open && <span className="hist-item__badge">{tr("history.open")}</span>}
                             <span>{tr(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns })}</span>
                             <span>·</span>
                             <span>{timeLabel(isTrash ? s.deletedAt || sessionActivityTime(s) : sessionActivityTime(s))}</span>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -455,10 +455,10 @@ function makeMockApp(): AppBindings {
   };
   // Mutable so delete/rename are observable in browser dev.
   const sessions: SessionMeta[] = [
-    { path: "/mock/sessions/a.jsonl", preview: "fix the login bug in auth.go", turns: 12, createdAt: t0 - 2 * day, lastActivityAt: t0 - 3_600_000, modTime: t0 - 3_600_000, current: true },
-    { path: "/mock/sessions/b.jsonl", preview: "refactor the payment module", turns: 5, createdAt: t0 - 3 * day, lastActivityAt: t0 - 6 * 3_600_000, modTime: t0 - 6 * 3_600_000, current: false },
-    { path: "/mock/sessions/c.jsonl", preview: "write the README and badges", turns: 8, createdAt: t0 - 4 * day, lastActivityAt: t0 - day - 3_600_000, modTime: t0 - day - 3_600_000, current: false },
-    { path: "/mock/sessions/d.jsonl", preview: "explain the plugin host design", turns: 3, createdAt: t0 - 5 * day, lastActivityAt: t0 - 4 * day, modTime: t0 - 4 * day, current: false },
+    { path: "/mock/sessions/a.jsonl", preview: "fix the login bug in auth.go", turns: 12, createdAt: t0 - 2 * day, lastActivityAt: t0 - 3_600_000, modTime: t0 - 3_600_000, current: true, open: true },
+    { path: "/mock/sessions/b.jsonl", preview: "refactor the payment module", turns: 5, createdAt: t0 - 3 * day, lastActivityAt: t0 - 6 * 3_600_000, modTime: t0 - 6 * 3_600_000, current: false, open: true },
+    { path: "/mock/sessions/c.jsonl", preview: "write the README and badges", turns: 8, createdAt: t0 - 4 * day, lastActivityAt: t0 - day - 3_600_000, modTime: t0 - day - 3_600_000, current: false, open: false },
+    { path: "/mock/sessions/d.jsonl", preview: "explain the plugin host design", turns: 3, createdAt: t0 - 5 * day, lastActivityAt: t0 - 4 * day, modTime: t0 - 4 * day, current: false, open: false },
   ];
   const trashedSessions: SessionMeta[] = [
     {
@@ -471,6 +471,7 @@ function makeMockApp(): AppBindings {
       modTime: t0 - 7 * day,
       deletedAt: t0 - 20 * 60_000,
       current: false,
+      open: false,
       scope: "project",
       workspaceRoot: "~/projects/joyquant-db",
       topicId: "topic_dev_standard",
@@ -486,6 +487,7 @@ function makeMockApp(): AppBindings {
       modTime: t0 - 5 * day,
       deletedAt: t0 - 2 * 3_600_000,
       current: false,
+      open: false,
       scope: "project",
       workspaceRoot: "~/projects/joyquant-sys",
       topicId: "topic_p3a_pd",
@@ -501,6 +503,7 @@ function makeMockApp(): AppBindings {
       modTime: t0 - 3 * day,
       deletedAt: t0 - day,
       current: false,
+      open: false,
       scope: "global",
       topicId: "topic_product",
       topicTitle: t("mock.trashGlobalProductTitle"),
@@ -904,6 +907,7 @@ function makeMockApp(): AppBindings {
     async ResumeSession(path: string) {
       sessions.forEach((s) => {
         s.current = s.path === path;
+        s.open = s.open || s.path === path;
       });
       return [
         { role: "user", content: `(mock) resumed ${path}` },
@@ -931,6 +935,7 @@ function makeMockApp(): AppBindings {
         trashedSessions.unshift({
           ...s,
           current: false,
+          open: false,
           path: s.path.replace("/mock/sessions/", "/mock/sessions/.trash/"),
           deletedAt: Date.now(),
         });

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -212,6 +212,7 @@ export interface SessionMeta {
   modTime: number; // compatibility alias for lastActivityAt
   deletedAt?: number; // unix milliseconds, present for trashed sessions
   current: boolean;
+  open: boolean;
   scope?: string;       // "project" | "global"; empty for legacy → treated as "global"
   workspaceRoot?: string;
   topicId?: string;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -317,6 +317,7 @@ export const en = {
   "history.namePlaceholder": "Session name…",
   "history.emptySession": "(empty session)",
   "history.current": "current",
+  "history.open": "open",
   "history.deleted": "deleted",
   "history.turnOne": "{n} turn",
   "history.turnOther": "{n} turns",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -318,6 +318,7 @@ export const zh: Record<DictKey, string> = {
   "history.namePlaceholder": "会话名称…",
   "history.emptySession": "（空会话）",
   "history.current": "当前",
+  "history.open": "已打开",
   "history.deleted": "已删除",
   "history.turnOne": "{n} 轮",
   "history.turnOther": "{n} 轮",

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1386,10 +1386,17 @@ type ProjectNode struct {
 // history panel can list them, but the project tree cannot. Give each such
 // session a deterministic Global topic so every old conversation has a direct
 // sidebar entry without guessing a project workspace.
+// legacyMigrationMu serializes the lockless load-modify-save of the projects /
+// topic-title files: this migration runs from every concurrent buildTabController
+// and from ListProjectTree, so without it parallel runs lose each other's appends.
+var legacyMigrationMu sync.Mutex
+
 func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
+	legacyMigrationMu.Lock()
+	defer legacyMigrationMu.Unlock()
 	infos, err := agent.ListSessions(dir)
 	if err != nil || len(infos) == 0 {
 		return nil
@@ -1428,6 +1435,12 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 
 		meta, err := agent.EnsureBranchMeta(info.Path)
 		if err != nil {
+			continue
+		}
+		// Only adopt genuinely-global, unscoped legacy sessions. A session that
+		// already carries a project scope or workspace root is not legacy — never
+		// strip its binding into Global.
+		if meta.Scope == "project" || strings.TrimSpace(meta.WorkspaceRoot) != "" {
 			continue
 		}
 		meta.Scope = "global"

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -21,6 +22,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/provider"
 )
 
 // --- WorkspaceTab -----------------------------------------------------------
@@ -529,6 +531,19 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 	applyTabModeToController(ctrl, tab.mode)
 
 	if dir := ctrl.SessionDir(); dir != "" {
+		migratedTopics := migrateLegacySessionsIntoGlobalTopics(dir)
+		if len(migratedTopics) > 0 {
+			a.emitProjectTreeChanged()
+		}
+		if tab.Scope == "global" && strings.TrimSpace(tab.TopicID) == "" && len(migratedTopics) > 0 {
+			topicID := migratedTopics[0]
+			topicTitle := topicTitleForTab("global", "", topicID)
+			a.mu.Lock()
+			tab.TopicID = topicID
+			tab.TopicTitle = topicTitle
+			a.saveTabsLocked()
+			a.mu.Unlock()
+		}
 		var path string
 		// When the tab has a TopicID, look for an existing session for this topic
 		// so the user continues the conversation rather than starting fresh.
@@ -1365,6 +1380,197 @@ type ProjectNode struct {
 	Children       []ProjectNode `json:"children,omitempty"`
 }
 
+// migrateLegacySessionsIntoGlobalTopics makes pre-topic desktop history visible
+// in the v2 sidebar. Imported v0.x sessions and older desktop sessions are plain
+// .jsonl files, sometimes with branch metadata but no topic metadata; the
+// history panel can list them, but the project tree cannot. Give each such
+// session a deterministic Global topic so every old conversation has a direct
+// sidebar entry without guessing a project workspace.
+func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
+	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	infos, err := agent.ListSessions(dir)
+	if err != nil || len(infos) == 0 {
+		return nil
+	}
+	titles := loadSessionTitles(dir)
+	topicTitles := loadTopicTitles("")
+	topicSources := loadTopicTitleSources("")
+	f := loadProjectsFile()
+
+	var migratedTopicIDs []string
+	for _, info := range infos {
+		if strings.TrimSpace(info.TopicID) != "" {
+			continue
+		}
+		topicID := legacySessionTopicID(info.Path)
+		if topicID == "" {
+			continue
+		}
+		title := strings.TrimSpace(titles[filepath.Base(info.Path)])
+		if title == "" {
+			title = topicTitleFromText(info.Preview)
+		} else if normalized := topicTitleFromText(title); normalized != "" {
+			title = normalized
+		}
+		if title == "" {
+			when := info.LastActivityAt
+			if when.IsZero() {
+				when = info.ModTime
+			}
+			if when.IsZero() {
+				title = "历史会话"
+			} else {
+				title = "历史会话 " + when.Local().Format("2006-01-02")
+			}
+		}
+
+		meta, err := agent.EnsureBranchMeta(info.Path)
+		if err != nil {
+			continue
+		}
+		meta.Scope = "global"
+		meta.WorkspaceRoot = ""
+		meta.TopicID = topicID
+		meta.TopicTitle = title
+		if err := agent.SaveBranchMetaPreserveUpdated(info.Path, meta); err != nil {
+			continue
+		}
+		if strings.TrimSpace(topicTitles[topicID]) == "" {
+			topicTitles[topicID] = title
+			topicSources[topicID] = topicTitleSourceManual
+		}
+		migratedTopicIDs = append(migratedTopicIDs, topicID)
+	}
+	if len(migratedTopicIDs) == 0 {
+		return nil
+	}
+	f.GlobalTopics = uniqueStrings(append(migratedTopicIDs, f.GlobalTopics...))
+	_ = saveProjectsFile(f)
+	_ = saveTopicTitles("", topicTitles)
+	_ = saveTopicTitleSources("", topicSources)
+	return migratedTopicIDs
+}
+
+func restoreSessionTopicIndex(dir, sessionPath string) error {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return nil
+	}
+	meta, ok, err := agent.LoadBranchMeta(sessionPath)
+	if err != nil {
+		return err
+	}
+	if !ok || strings.TrimSpace(meta.TopicID) == "" {
+		migrateLegacySessionsIntoGlobalTopics(dir)
+		return nil
+	}
+
+	topicID := strings.TrimSpace(meta.TopicID)
+	scope := strings.TrimSpace(meta.Scope)
+	workspaceRoot := strings.TrimSpace(meta.WorkspaceRoot)
+	if scope != "global" && scope != "project" {
+		if workspaceRoot == "" {
+			scope = "global"
+		} else {
+			scope = "project"
+		}
+	}
+	if scope == "global" {
+		workspaceRoot = ""
+	} else {
+		workspaceRoot = normalizeProjectRoot(workspaceRoot)
+		if workspaceRoot == "" {
+			scope = "global"
+		}
+	}
+
+	title := restoredSessionTopicTitle(dir, sessionPath, meta)
+	if title == "" {
+		title = defaultTopicTitle
+	}
+	if err := setTopicTitleWithSource(workspaceRoot, topicID, title, topicTitleSourceManual); err != nil {
+		return err
+	}
+
+	f := loadProjectsFile()
+	if scope == "global" {
+		f.GlobalTopics = prependUniqueString(f.GlobalTopics, topicID)
+		meta.Scope = "global"
+		meta.WorkspaceRoot = ""
+	} else {
+		found := false
+		for i, p := range f.Projects {
+			if p.Root != workspaceRoot {
+				continue
+			}
+			f.Projects[i].Topics = prependUniqueString(p.Topics, topicID)
+			found = true
+			break
+		}
+		if !found {
+			f.Projects = append(f.Projects, desktopProject{
+				Root:   workspaceRoot,
+				Topics: []string{topicID},
+			})
+		}
+		meta.Scope = "project"
+		meta.WorkspaceRoot = workspaceRoot
+	}
+	meta.TopicID = topicID
+	meta.TopicTitle = title
+	if err := saveProjectsFile(f); err != nil {
+		return err
+	}
+	return agent.SaveBranchMetaPreserveUpdated(sessionPath, meta)
+}
+
+func restoredSessionTopicTitle(dir, sessionPath string, meta agent.BranchMeta) string {
+	if title := topicTitleFromText(meta.TopicTitle); title != "" {
+		return title
+	}
+	if title := topicTitleFromText(loadSessionTitles(dir)[filepath.Base(sessionPath)]); title != "" {
+		return title
+	}
+	if s, err := agent.LoadSession(sessionPath); err == nil {
+		for _, msg := range s.Messages {
+			if msg.Role == provider.RoleUser {
+				if title := topicTitleFromText(msg.Content); title != "" {
+					return title
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func legacySessionTopicID(path string) string {
+	id := agent.BranchID(path)
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(id))
+	var b strings.Builder
+	b.WriteString("legacy_")
+	for _, r := range id {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+			b.WriteRune(r)
+		case r == '-', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	prefix := strings.TrimRight(b.String(), "_")
+	if prefix == "legacy" {
+		prefix = "legacy_session"
+	}
+	return prefix + "_" + hex.EncodeToString(sum[:])[:12]
+}
+
 // TopicMeta describes a topic for the project tree.
 type TopicMeta struct {
 	ID        string `json:"id"`
@@ -1692,6 +1898,7 @@ func (a *App) TrashTopic(topicID string) error {
 // ListProjectTree builds the sidebar tree: project folders each containing
 // their topics, plus a Global section.
 func (a *App) ListProjectTree() []ProjectNode {
+	migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
 	f := loadProjectsFile()
 	out := []ProjectNode{}
 	type topicSummary struct {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -881,5 +883,68 @@ func TestTrashTopicMovesOpenSessionToTrash(t *testing.T) {
 	}
 	if got := loadTopicTitle(projectRoot, topicID); got != "" {
 		t.Fatalf("topic title should be removed, got %q", got)
+	}
+}
+
+func TestLegacyMigrationSkipsProjectScopedSessions(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := writeLegacySession(t, dir, "scoped.jsonl", "hello", time.Now())
+	meta, err := agent.EnsureBranchMeta(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.Scope = "project"
+	meta.WorkspaceRoot = filepath.Join(t.TempDir(), "proj")
+	meta.TopicID = ""
+	if err := agent.SaveBranchMeta(path, meta); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateLegacySessionsIntoGlobalTopics(dir)
+
+	got, err := agent.EnsureBranchMeta(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Scope != "project" || got.WorkspaceRoot != meta.WorkspaceRoot {
+		t.Fatalf("project-scoped legacy session must not be forced into Global: %+v", got)
+	}
+}
+
+func TestLegacyMigrationConcurrentRunsHaveNoLostUpdates(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const n = 8
+	want := make(map[string]bool, n)
+	for i := 0; i < n; i++ {
+		p := writeLegacySession(t, dir, fmt.Sprintf("legacy-%d.jsonl", i), "hi", time.Now())
+		want[legacySessionTopicID(p)] = true
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			migrateLegacySessionsIntoGlobalTopics(dir)
+		}()
+	}
+	wg.Wait()
+
+	gotSet := map[string]bool{}
+	for _, id := range loadProjectsFile().GlobalTopics {
+		gotSet[id] = true
+	}
+	for id := range want {
+		if !gotSet[id] {
+			t.Fatalf("concurrent migration lost topic %q; GlobalTopics=%v", id, loadProjectsFile().GlobalTopics)
+		}
 	}
 }

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -26,6 +27,35 @@ func writeTopicSession(t *testing.T, dir, name, topicID, topicTitle, workspaceRo
 		TopicTitle:    topicTitle,
 	}); err != nil {
 		t.Fatalf("save branch meta: %v", err)
+	}
+	return path
+}
+
+func writeLegacySession(t *testing.T, dir, name, prompt string, modTime time.Time) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":`+strconv.Quote(prompt)+`}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write legacy session: %v", err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes legacy session: %v", err)
+	}
+	return path
+}
+
+func writeLegacyEventSession(t *testing.T, dir, name, prompt, reply string, modTime time.Time) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir legacy sessions: %v", err)
+	}
+	path := filepath.Join(dir, name)
+	body := `{"type":"user.message","id":1,"ts":"t","turn":0,"text":` + strconv.Quote(prompt) + `}` + "\n" +
+		`{"type":"model.final","id":2,"ts":"t","turn":0,"content":` + strconv.Quote(reply) + `,"toolCalls":[],"usage":{},"costUsd":0}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write legacy event session: %v", err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatalf("chtimes legacy event session: %v", err)
 	}
 	return path
 }
@@ -122,6 +152,159 @@ func TestListWorkspacesMigratesLegacyWorkspaceList(t *testing.T) {
 	projects := loadProjectsFile().Projects
 	if len(projects) != 1 || projects[0].Root != legacyRoot {
 		t.Fatalf("legacy workspace was not migrated into projects: %+v", projects)
+	}
+}
+
+func TestLegacySessionsMigrateIntoGlobalTopics(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	older := writeLegacySession(t, dir, "older.jsonl", "older imported prompt", time.Now().Add(-2*time.Hour))
+	newer := writeLegacySession(t, dir, "newer.jsonl", "newer imported prompt", time.Now().Add(-time.Hour))
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" {
+		t.Fatalf("project tree = %#v, want global folder", nodes)
+	}
+	if got := len(nodes[0].Children); got != 2 {
+		t.Fatalf("global migrated topics = %d, want 2: %#v", got, nodes[0].Children)
+	}
+	if got, want := nodes[0].Children[0].TopicID, legacySessionTopicID(newer); got != want {
+		t.Fatalf("newest topic first = %q, want %q", got, want)
+	}
+	if got, want := nodes[0].Children[1].TopicID, legacySessionTopicID(older); got != want {
+		t.Fatalf("older topic second = %q, want %q", got, want)
+	}
+
+	meta, ok, err := agent.LoadBranchMeta(newer)
+	if err != nil || !ok {
+		t.Fatalf("load migrated meta: ok=%v err=%v", ok, err)
+	}
+	if meta.Scope != "global" || meta.WorkspaceRoot != "" || meta.TopicID != legacySessionTopicID(newer) {
+		t.Fatalf("migrated meta = %+v", meta)
+	}
+
+	nodes = NewApp().ListProjectTree()
+	if got := len(nodes[0].Children); got != 2 {
+		t.Fatalf("migration should be idempotent, global topics = %d", got)
+	}
+}
+
+func TestV05LegacyEventSessionsImportIntoGlobalTopic(t *testing.T) {
+	home := isolateDesktopUserDirs(t)
+
+	legacyDir := filepath.Join(home, ".reasonix", "sessions")
+	destDir := config.SessionDir()
+	writeLegacyEventSession(t, legacyDir, "v053-chat.events.jsonl", "hello from v0.53", "hi from v0.53", time.Now().Add(-time.Hour))
+
+	imported, err := agent.MigrateLegacySessions(legacyDir, destDir)
+	if err != nil {
+		t.Fatalf("migrate legacy sessions: %v", err)
+	}
+	if imported != 1 {
+		t.Fatalf("imported legacy sessions = %d, want 1", imported)
+	}
+	migratedSession := filepath.Join(destDir, "v053-chat.jsonl")
+	if _, err := os.Stat(migratedSession); err != nil {
+		t.Fatalf("legacy v0.5 session was not imported to %s: %v", migratedSession, err)
+	}
+
+	wantTopicID := legacySessionTopicID(migratedSession)
+	migratedTopics := migrateLegacySessionsIntoGlobalTopics(destDir)
+	if len(migratedTopics) != 1 || migratedTopics[0] != wantTopicID {
+		t.Fatalf("migrated topics = %#v, want imported v0.5 topic %q", migratedTopics, wantTopicID)
+	}
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" {
+		t.Fatalf("project tree = %#v, want global folder", nodes)
+	}
+	if len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != wantTopicID {
+		t.Fatalf("global topics = %#v, want imported v0.5 topic %q", nodes[0].Children, wantTopicID)
+	}
+	meta, ok, err := agent.LoadBranchMeta(migratedSession)
+	if err != nil || !ok {
+		t.Fatalf("load imported v0.5 meta: ok=%v err=%v", ok, err)
+	}
+	if meta.Scope != "global" || meta.TopicID != wantTopicID {
+		t.Fatalf("imported v0.5 meta = %+v", meta)
+	}
+}
+
+func TestLegacySessionTopicIDsKeepNormalizedNameCollisionsDistinct(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	dotted := writeLegacySession(t, dir, "chat.1.jsonl", "dotted prompt", time.Now().Add(-2*time.Hour))
+	underscored := writeLegacySession(t, dir, "chat_1.jsonl", "underscored prompt", time.Now().Add(-time.Hour))
+
+	dottedTopic := legacySessionTopicID(dotted)
+	underscoredTopic := legacySessionTopicID(underscored)
+	if dottedTopic == underscoredTopic {
+		t.Fatalf("normalized legacy topic IDs collided: %q", dottedTopic)
+	}
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" {
+		t.Fatalf("project tree = %#v, want global folder", nodes)
+	}
+	if got := len(nodes[0].Children); got != 2 {
+		t.Fatalf("global migrated topics = %d, want 2: %#v", got, nodes[0].Children)
+	}
+	seen := map[string]bool{}
+	for _, child := range nodes[0].Children {
+		seen[child.TopicID] = true
+	}
+	if !seen[dottedTopic] || !seen[underscoredTopic] {
+		t.Fatalf("global topics = %#v, want %q and %q", nodes[0].Children, dottedTopic, underscoredTopic)
+	}
+}
+
+func TestDefaultGlobalTabGetsMigratedTopicID(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessionPath := writeLegacySession(t, dir, "legacy-tab.jsonl", "resume this legacy tab", time.Now().Add(-time.Hour))
+
+	tab := &WorkspaceTab{
+		ID:            "tab_legacy",
+		Scope:         "global",
+		WorkspaceRoot: globalTabWorkspaceRoot(),
+		Ready:         false,
+		disabledMCP:   map[string]ServerView{},
+	}
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"tab_legacy": tab},
+		tabOrder:    []string{"tab_legacy"},
+		activeTabID: "tab_legacy",
+	}
+	app.buildTabController(tab)
+	if tab.Ctrl != nil {
+		defer tab.Ctrl.Close()
+	}
+
+	wantTopicID := legacySessionTopicID(sessionPath)
+	if tab.TopicID != wantTopicID {
+		t.Fatalf("tab topicID = %q, want %q", tab.TopicID, wantTopicID)
+	}
+	if tab.Ctrl == nil {
+		t.Fatalf("tab controller was not built")
+	}
+	if tab.Ctrl.SessionPath() != sessionPath {
+		t.Fatalf("tab session path = %q, want %q", tab.Ctrl.SessionPath(), sessionPath)
+	}
+	f := loadTabsFile()
+	if len(f.Tabs) != 1 || f.Tabs[0].ID != "tab_legacy" || f.Tabs[0].TopicID != wantTopicID {
+		t.Fatalf("desktop tabs file = %+v, want tab id and migrated topic", f)
 	}
 }
 
@@ -519,6 +702,109 @@ func TestTrashTopicMovesRelatedSessionsToTrash(t *testing.T) {
 	}
 	if got := loadTopicTitle(projectRoot, topicID); got != "" {
 		t.Fatalf("topic title should be removed, got %q", got)
+	}
+}
+
+func TestRestoreGlobalTopicSessionReindexesProjectTree(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessionPath := writeLegacySession(t, dir, "restore-global.jsonl", "restore global history", time.Now().Add(-time.Hour))
+	topicID := legacySessionTopicID(sessionPath)
+	app := NewApp()
+
+	nodes := app.ListProjectTree()
+	if len(nodes) != 1 || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != topicID {
+		t.Fatalf("legacy session should start in Global, got %#v", nodes)
+	}
+	if err := app.TrashTopic(topicID); err != nil {
+		t.Fatalf("trash global topic: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, "restore-global.jsonl", "restore-global.jsonl")
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("global session should be in trash: %v", err)
+	}
+	if got := app.ListProjectTree(); len(got) != 0 {
+		t.Fatalf("trashed global topic should leave project tree, got %#v", got)
+	}
+
+	if err := app.RestoreSession(trashPath); err != nil {
+		t.Fatalf("restore global session: %v", err)
+	}
+	if got := app.ListTrashedSessions(); len(got) != 0 {
+		t.Fatalf("trash should be empty after restore, got %#v", got)
+	}
+	nodes = app.ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != topicID {
+		t.Fatalf("restored global session should reappear in Global, got %#v", nodes)
+	}
+}
+
+func TestRestoreProjectTopicSessionReindexesProjectTree(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_restore_project"
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, topicID, "Project restore"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	writeTopicSession(t, dir, "restore-project.jsonl", topicID, "Project restore", projectRoot)
+	app := NewApp()
+
+	if err := app.TrashTopic(topicID); err != nil {
+		t.Fatalf("trash project topic: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, "restore-project.jsonl", "restore-project.jsonl")
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("project session should be in trash: %v", err)
+	}
+	if got := loadTopicTitle(projectRoot, topicID); got != "" {
+		t.Fatalf("topic title should be removed while trashed, got %q", got)
+	}
+
+	if err := app.RestoreSession(trashPath); err != nil {
+		t.Fatalf("restore project session: %v", err)
+	}
+	nodes := app.ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "project" || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != topicID {
+		t.Fatalf("restored project session should reappear in project tree, got %#v", nodes)
+	}
+	if got := loadTopicTitle(projectRoot, topicID); got != "Project restore" {
+		t.Fatalf("restored topic title = %q, want Project restore", got)
+	}
+}
+
+func TestRestoreSessionWithoutTopicMetadataFallsBackToGlobal(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessionPath := writeLegacySession(t, dir, "restore-orphan.jsonl", "restore orphan history", time.Now().Add(-time.Hour))
+	topicID := legacySessionTopicID(sessionPath)
+	app := NewApp()
+	if err := app.DeleteSession(sessionPath); err != nil {
+		t.Fatalf("delete orphan session: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, "restore-orphan.jsonl", "restore-orphan.jsonl")
+
+	if err := app.RestoreSession(trashPath); err != nil {
+		t.Fatalf("restore orphan session: %v", err)
+	}
+	nodes := app.ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != topicID {
+		t.Fatalf("restored orphan session should fall back to Global, got %#v", nodes)
 	}
 }
 

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -37,6 +37,7 @@ type legacyToolCall struct {
 // one-time v0.x import has already run — so a session the user deletes after it
 // was imported doesn't reappear on the next launch.
 const legacyImportMarker = ".legacy-imported"
+const legacyEventsHomeImportMarker = ".legacy-imported.v0-events-home"
 
 // MigrateLegacySessions imports v0.x event-log sessions (<name>.events.jsonl under
 // srcDir) into the v1+ message-log format (<name>.jsonl under destDir), back-filling
@@ -46,8 +47,18 @@ const legacyImportMarker = ".legacy-imported"
 // without re-importing on every launch. Never modifies the legacy files. Returns the
 // count imported.
 func MigrateLegacySessions(srcDir, destDir string) (int, error) {
-	marker := filepath.Join(destDir, legacyImportMarker)
-	if _, err := os.Stat(marker); err == nil {
+	return migrateLegacySessions(srcDir, destDir, legacyEventsHomeImportMarker, true)
+}
+
+func migrateLegacySessions(srcDir, destDir, marker string, honorLegacyMarker bool) (int, error) {
+	if strings.TrimSpace(marker) == "" {
+		marker = legacyImportMarker
+	}
+	if importMarkerExists(destDir, marker) {
+		return 0, nil
+	}
+	if honorLegacyMarker && importMarkerExists(destDir, legacyImportMarker) {
+		writeImportMarkers(destDir, marker)
 		return 0, nil
 	}
 	entries, err := os.ReadDir(srcDir)
@@ -77,10 +88,34 @@ func MigrateLegacySessions(srcDir, destDir string) (int, error) {
 		}
 		imported++
 	}
-	if err := os.MkdirAll(destDir, 0o755); err == nil {
-		_ = os.WriteFile(marker, nil, 0o644)
-	}
+	writeImportMarkers(destDir, marker, legacyImportMarker)
 	return imported, nil
+}
+
+func importMarkerExists(destDir, marker string) bool {
+	if strings.TrimSpace(destDir) == "" || strings.TrimSpace(marker) == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(destDir, marker))
+	return err == nil
+}
+
+func writeImportMarkers(destDir string, markers ...string) {
+	if strings.TrimSpace(destDir) == "" {
+		return
+	}
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return
+	}
+	seen := map[string]bool{}
+	for _, marker := range markers {
+		marker = strings.TrimSpace(marker)
+		if marker == "" || seen[marker] {
+			continue
+		}
+		seen[marker] = true
+		_ = os.WriteFile(filepath.Join(destDir, marker), nil, 0o644)
+	}
 }
 
 // reconstructSession folds the chronological event stream into the provider

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -94,6 +94,65 @@ func TestMigrateLegacySessionsRunsOnce(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("a deleted import must not reappear after the one-time migration")
 	}
+	if _, err := os.Stat(filepath.Join(dest, legacyEventsHomeImportMarker)); err != nil {
+		t.Errorf("source-specific import marker missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, legacyImportMarker)); err != nil {
+		t.Errorf("legacy compatibility import marker missing: %v", err)
+	}
+}
+
+func TestMigrateLegacySessionsHonorsLegacyMarkerForHomeSource(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, legacyImportMarker), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := MigrateLegacySessions(src, dest)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("legacy marker should protect the home source from re-importing, got %d", n)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("legacy marker should keep deleted/imported sessions from reappearing")
+	}
+	if _, err := os.Stat(filepath.Join(dest, legacyEventsHomeImportMarker)); err != nil {
+		t.Errorf("legacy marker should be upgraded to source marker: %v", err)
+	}
+}
+
+func TestMigrateLegacySessionsSourceMarkersAreIndependent(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "appdata-chat.events.jsonl"), []byte(legacyEventLog), 0o644)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dest, legacyImportMarker), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const appDataMarker = ".legacy-imported.v0-events-appdata"
+	n, err := migrateLegacySessions(src, dest, appDataMarker, false)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("independent source marker should allow a new source import, got %d", n)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "appdata-chat.jsonl")); err != nil {
+		t.Errorf("new source session should have been imported: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, appDataMarker)); err != nil {
+		t.Errorf("new source marker missing: %v", err)
+	}
 }
 
 func TestMigrateLegacySessionsSkipsAlreadyImported(t *testing.T) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1930,9 +1930,11 @@ func listItem(line string) (content string, level int, ok bool) {
 // answers or ctx is cancelled. A prior session grant for the same tool+subject
 // short-circuits. promptMu serialises outstanding prompts.
 // parseRewind parses the arguments after "/rewind". The user may provide:
-//   /rewind              → latest checkpoint, both
-//   /rewind <turn>       → that turn, both
-//   /rewind <turn> <scope> → that turn, code|conversation|both
+//
+//	/rewind              → latest checkpoint, both
+//	/rewind <turn>       → that turn, both
+//	/rewind <turn> <scope> → that turn, code|conversation|both
+//
 // If no turn is given, the latest checkpoint is used. If no scope is given, Both is assumed.
 func parseRewind(args string, cps []checkpoint.Meta) (int, RewindScope, error) {
 	fields := strings.Fields(args)

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -263,13 +263,13 @@ func TestParseRewind(t *testing.T) {
 		wantS   RewindScope
 		wantErr bool
 	}{
-		{"", 2, RewindBoth, false},               // no args -> latest turn, both
-		{"1", 1, RewindBoth, false},              // turn only
-		{"0 code", 0, RewindCode, false},         // turn + code
+		{"", 2, RewindBoth, false},                       // no args -> latest turn, both
+		{"1", 1, RewindBoth, false},                      // turn only
+		{"0 code", 0, RewindCode, false},                 // turn + code
 		{"1 conversation", 1, RewindConversation, false}, // turn + conversation
-		{"2 both", 2, RewindBoth, false},         // turn + both
-		{"abc", 0, RewindBoth, true},             // invalid turn
-		{"0 unknown", 0, RewindBoth, true},       // unknown scope
+		{"2 both", 2, RewindBoth, false},                 // turn + both
+		{"abc", 0, RewindBoth, true},                     // invalid turn
+		{"0 unknown", 0, RewindBoth, true},               // unknown scope
 	}
 	for _, tc := range cases {
 		t.Run(tc.args, func(t *testing.T) {


### PR DESCRIPTION
Lands @SivanCola's #3188 (migrate pre-topic desktop sessions into deterministic Global topics so imported history shows in the project tree; idempotent), with two follow-up fixes that keep its behavior for genuine legacy sessions unchanged:

- **Concurrency-safe:** the migration runs from every concurrent `buildTabController` and from `ListProjectTree`; its lockless load-modify-save of the projects/topic-title files lost parallel appends. Serialized behind a package mutex (also makes the default-tab rebind deterministic). Added a `-race` concurrency test.
- **Scope-aware:** skip any session that already has a project scope / workspace root, so a topic-less project session is never force-stripped into Global (guards the edge case and the workspace-isolation direction).

Verified: `go build ./...`, `go test -race ./desktop` (incl. the new concurrency + scope-guard tests), `wails build` (tsc + Go) — all clean.

Closes #3188
