### PR TITLE
Fix repeated successful writer loops

### DIFF
--- a/desktop/repeat_guard_e2e_test.go
+++ b/desktop/repeat_guard_e2e_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	agenttest "reasonix/internal/agent/testutil"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type desktopCountingTool struct {
+	name     string
+	readOnly bool
+	calls    *int32
+}
+
+func (t desktopCountingTool) Name() string        { return t.name }
+func (t desktopCountingTool) Description() string { return "test tool" }
+func (t desktopCountingTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string"}}}`)
+}
+func (t desktopCountingTool) ReadOnly() bool { return t.readOnly }
+func (t desktopCountingTool) Execute(context.Context, json.RawMessage) (string, error) {
+	atomic.AddInt32(t.calls, 1)
+	return "ok", nil
+}
+
+func TestDesktopE2EBlocksRepeatedSuccessfulBashFileWrite(t *testing.T) {
+	var calls int32
+	reg := tool.NewRegistry()
+	reg.Add(desktopCountingTool{name: "bash", calls: &calls})
+	args := `{"command":"python -c \"with open('prompt.txt', 'w') as f: f.write('hello')\""}`
+	prov := agenttest.NewMock("scripted-desktop",
+		agenttest.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "bash", Arguments: args}}},
+		agenttest.Turn{ToolCalls: []provider.ToolCall{{ID: "c2", Name: "bash", Arguments: args}}},
+		agenttest.Turn{ToolCalls: []provider.ToolCall{{ID: "c3", Name: "bash", Arguments: args}}},
+		agenttest.Turn{Text: "done"},
+	)
+	events := make(chan event.Event, 32)
+	sink := event.FuncSink(func(e event.Event) { events <- e })
+	ag := agent.New(prov, reg, agent.NewSession(""), agent.Options{}, sink)
+	ctrl := control.New(control.Options{Runner: ag, Executor: ag, Sink: sink})
+	app := NewApp()
+	app.setTestCtrl(ctrl, "scripted-desktop")
+
+	app.SubmitToTab("test", "update the prompt file")
+
+	var results []event.Event
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case e := <-events:
+			if e.Kind == event.ToolResult {
+				results = append(results, e)
+			}
+			if e.Kind == event.TurnDone {
+				if e.Err != nil {
+					t.Fatalf("turn failed: %v", e.Err)
+				}
+				if got := atomic.LoadInt32(&calls); got != 2 {
+					t.Fatalf("bash executed %d times, want 2 before the repeat guard blocks", got)
+				}
+				if len(results) != 3 {
+					t.Fatalf("tool results = %d, want 3", len(results))
+				}
+				last := results[len(results)-1].Tool.Output
+				if !strings.Contains(last, "[loop guard]") || !strings.Contains(last, "edit_file") {
+					t.Fatalf("third repeated write should nudge the model to change tools, got %q", last)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for desktop turn to finish")
+		}
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -218,6 +219,12 @@ type Agent struct {
 	// (a different failure shape, or any success). See applyStormBreaker.
 	stormSig   string
 	stormCount int
+
+	// repeatSuccessCounts tracks write-like tool calls that have already
+	// succeeded in this user turn. This catches the complementary loop shape to
+	// stormSig: a model keeps doing the same successful write, so there is no
+	// error for the failure-only storm breaker to see.
+	repeatSuccessCounts map[string]int
 }
 
 // SetPlanMode flips the read-only gate. While true, executeOne refuses any
@@ -386,6 +393,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	if a.evidence != nil {
 		a.evidence.Reset()
 	}
+	a.repeatSuccessCounts = nil
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 
@@ -753,6 +761,12 @@ func runParallel(start, end int, run func(int)) {
 // re-emits (re-worded but still over-long), truncating the same way again.
 const stormBreakThreshold = 3
 
+// repeatSuccessBreakThreshold is how many identical write-like successes the
+// agent allows before refusing another copy in the same user turn. Two gives the
+// model room for a natural self-correction; the third repeat is usually a
+// no-op/write loop and should be redirected to a different tool or final answer.
+const repeatSuccessBreakThreshold = 2
+
 // applyStormBreaker detects a run of identically-failing turns and, past the
 // threshold, rewrites the model-facing result (results[0]) into a directive to
 // change approach. It keys on each call's (tool, error) — not its args — because a
@@ -838,6 +852,13 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		return toolOutcome{
 			output: fmt.Sprintf("error: unknown tool %q", call.Name),
 			errMsg: fmt.Sprintf("unknown tool %q", call.Name),
+		}
+	}
+	if out, blocked := a.repeatedSuccessBlock(call, t); blocked {
+		return toolOutcome{
+			output:  out,
+			blocked: true,
+			errMsg:  "blocked by loop guard",
 		}
 	}
 	if a.planMode.Load() && !t.ReadOnly() {
@@ -933,6 +954,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		body, truncMsg := truncateToolOutput(fmt.Sprintf("error: %v\n%s", err, detail))
 		return toolOutcome{output: body, errMsg: firstLine(err.Error()), truncated: truncMsg != "", truncMsg: truncMsg}
 	}
+	a.recordRepeatSuccess(call, t)
 	// A foreground `task` sub-agent just finished — its result is the final answer.
 	// (A backgrounded one returns a "Started…" string and stops later in a job, so
 	// it doesn't fire here.) SubagentStop lets a hook react to delegated work.
@@ -941,6 +963,134 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	body, truncMsg := truncateToolOutput(result)
 	return toolOutcome{output: body, truncated: truncMsg != "", truncMsg: truncMsg}
+}
+
+func (a *Agent) repeatedSuccessBlock(call provider.ToolCall, t tool.Tool) (string, bool) {
+	sig, ok := repeatSuccessSignature(call, t)
+	if !ok || a.repeatSuccessCounts == nil {
+		return "", false
+	}
+	count := a.repeatSuccessCounts[sig]
+	if count < repeatSuccessBreakThreshold {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"blocked: [loop guard] %q has already succeeded %d times with the same write-like arguments in this user turn. Re-running it is unlikely to help and may burn tokens or repeat file writes. Change approach: use edit_file or multi_edit for file changes, verify with a read/test command, or explain the blocker in your final answer.",
+		call.Name, count), true
+}
+
+func (a *Agent) recordRepeatSuccess(call provider.ToolCall, t tool.Tool) {
+	sig, ok := repeatSuccessSignature(call, t)
+	if !ok {
+		return
+	}
+	if a.repeatSuccessCounts == nil {
+		a.repeatSuccessCounts = make(map[string]int)
+	}
+	a.repeatSuccessCounts[sig]++
+}
+
+func repeatSuccessSignature(call provider.ToolCall, t tool.Tool) (string, bool) {
+	if t.ReadOnly() {
+		return "", false
+	}
+	switch call.Name {
+	case "write_file", "edit_file", "multi_edit", "notebook_edit":
+		return call.Name + "\x00" + canonicalToolArgs(call.Arguments), true
+	case "bash":
+		var p struct {
+			Command         string `json:"command"`
+			RunInBackground bool   `json:"run_in_background"`
+		}
+		if err := json.Unmarshal([]byte(call.Arguments), &p); err != nil {
+			return "", false
+		}
+		if p.RunInBackground || !isShellFileWriteCommand(p.Command) {
+			return "", false
+		}
+		return "bash\x00" + normalizeShellCommand(p.Command), true
+	default:
+		return "", false
+	}
+}
+
+func canonicalToolArgs(raw string) string {
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return strings.TrimSpace(raw)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return strings.TrimSpace(raw)
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, b); err != nil {
+		return string(b)
+	}
+	return compact.String()
+}
+
+func normalizeShellCommand(command string) string {
+	return strings.Join(strings.Fields(command), " ")
+}
+
+func isShellFileWriteCommand(command string) bool {
+	lower := strings.ToLower(command)
+	switch {
+	case shellPythonOpenWrites(lower):
+		return true
+	case strings.Contains(lower, "set-content") || strings.Contains(lower, "add-content") || strings.Contains(lower, "out-file"):
+		return true
+	case strings.Contains(lower, "sed -i") || strings.Contains(lower, "perl -pi"):
+		return true
+	case hasShellWriteRedirect(command):
+		return true
+	default:
+		return false
+	}
+}
+
+func shellPythonOpenWrites(lower string) bool {
+	if !strings.Contains(lower, "open(") {
+		return false
+	}
+	if strings.Contains(lower, ".write(") {
+		return true
+	}
+	for _, marker := range []string{", 'w", `, "w`, ", 'a", `, "a`, ", 'x", `, "x`, "mode='w", `mode="w`, "mode='a", `mode="a`, "mode='x", `mode="x`} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasShellWriteRedirect(command string) bool {
+	var quote rune
+	var prev rune
+	for _, r := range command {
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			}
+			prev = r
+			continue
+		}
+		if r == '\'' || r == '"' {
+			quote = r
+			prev = r
+			continue
+		}
+		if r == '>' {
+			if prev == '2' {
+				prev = r
+				continue
+			}
+			return true
+		}
+		prev = r
+	}
+	return false
 }
 
 // isBackgroundTaskCall reports whether a `task` call set run_in_background, so a

--- a/internal/agent/repeat_guard_test.go
+++ b/internal/agent/repeat_guard_test.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestRepeatGuardBlocksRepeatedSuccessfulBashFileWrite(t *testing.T) {
+	var calls int32
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false, calls: &calls})
+	args := `{"command":"python -c \"with open('prompt.txt', 'w') as f: f.write('hello')\""}`
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "bash", args), {Type: provider.ChunkDone}},
+		{toolCallChunk("c2", "bash", args), {Type: provider.ChunkDone}},
+		{toolCallChunk("c3", "bash", args), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "update the prompt file"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("bash executed %d times, want 2 before the repeat guard blocks", got)
+	}
+	results := toolResults(a.session, "bash")
+	if len(results) != 3 {
+		t.Fatalf("tool results = %d, want 3", len(results))
+	}
+	last := results[len(results)-1]
+	if !strings.Contains(last, "[loop guard]") || !strings.Contains(last, "edit_file") {
+		t.Fatalf("third repeated write should nudge the model to change tools, got %q", last)
+	}
+}
+
+func TestRepeatGuardAllowsRepeatedNonWritingBashCommand(t *testing.T) {
+	var calls int32
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false, calls: &calls})
+	args := `{"command":"go test ./internal/agent"}`
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "bash", args), {Type: provider.ChunkDone}},
+		{toolCallChunk("c2", "bash", args), {Type: provider.ChunkDone}},
+		{toolCallChunk("c3", "bash", args), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "verify repeatedly"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Fatalf("bash executed %d times, want 3 for non-writing commands", got)
+	}
+	if last := lastToolResult(a.session, "bash"); strings.Contains(last, "[loop guard]") {
+		t.Fatalf("non-writing bash should not trip the repeat guard, got %q", last)
+	}
+}
+
+func TestRepeatGuardAllowsTwoRepeatedWriterSuccesses(t *testing.T) {
+	var calls int32
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false, calls: &calls})
+	args := `{"path":"prompt.txt","content":"hello"}`
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{toolCallChunk("c1", "write_file", args), {Type: provider.ChunkDone}},
+		{toolCallChunk("c2", "write_file", args), {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "done"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "write twice"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("writer executed %d times, want 2 before the guard threshold", got)
+	}
+	if last := lastToolResult(a.session, "write_file"); strings.Contains(last, "[loop guard]") {
+		t.Fatalf("second repeated writer call should still be allowed, got %q", last)
+	}
+}

--- a/internal/tool/builtin/write_tool_test.go
+++ b/internal/tool/builtin/write_tool_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -27,6 +28,22 @@ func TestWriteFileOverwrites(t *testing.T) {
 	got, _ := os.ReadFile(f)
 	if string(got) != "new" {
 		t.Errorf("after overwrite = %q", got)
+	}
+}
+
+func TestWriteFileSameContentNoOp(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "x.txt")
+	os.WriteFile(f, []byte("same"), 0o644)
+	out, err := writeFile{}.Execute(context.Background(), argsJSON(t, map[string]any{"path": f, "content": "same"}))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "already contains the exact content") {
+		t.Fatalf("same-content write should return a no-op signal, got %q", out)
+	}
+	got, _ := os.ReadFile(f)
+	if string(got) != "same" {
+		t.Errorf("content changed = %q", got)
 	}
 }
 

--- a/internal/tool/builtin/writefile.go
+++ b/internal/tool/builtin/writefile.go
@@ -48,6 +48,9 @@ func (w writeFile) Execute(ctx context.Context, args json.RawMessage) (string, e
 	if err := confine(w.roots, p.Path); err != nil {
 		return "", err
 	}
+	if existing, err := os.ReadFile(p.Path); err == nil && string(existing) == p.Content {
+		return fmt.Sprintf("%s already contains the exact content; no changes made", p.Path), nil
+	}
 	if dir := filepath.Dir(p.Path); dir != "" && dir != "." {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			return "", fmt.Errorf("mkdir %s: %w", dir, err)


### PR DESCRIPTION
﻿## Summary

Fixes #3157.

This adds a narrow repeat-success loop guard for write-like tool calls. When the model repeats the same successful file-writing operation more than twice in one user turn, the agent blocks the next identical call and nudges the model to switch approach, use `edit_file`/`multi_edit`, verify with a read/test command, or explain the blocker.

## Root cause

The existing storm guard only handled repeated failures. In the reported loop, each repeated `bash` write succeeded, so the agent treated every call as progress and kept feeding successful results back to the model.

## Changes

- Track identical successful write-like calls within a single user turn.
- Scope `bash` tracking to commands that appear to write files, leaving repeated read/test commands alone.
- Return an explicit `[loop guard]` tool result on the third repeated write-like success.
- Make `write_file` return a no-op signal when the target already contains the exact same content.
- Add agent-level and desktop binding-level regression coverage.

## Validation

- `go test ./internal/agent ./internal/tool/builtin -count=1`
- `go test . -run TestDesktopE2EBlocksRepeatedSuccessfulBashFileWrite -count=1 -v` from `desktop/`
- `go test . -count=1` from `desktop/`
- Copied the new desktop E2E test into a temporary `origin/main-v2` worktree and confirmed the old code fails with `bash executed 3 times, want 2 before the repeat guard blocks`.

## Notes

The desktop E2E uses a scripted provider instead of a real model so the regression is deterministic and does not require API keys, network stability, model-version behavior, or real file writes outside the fake tool.
