### PR TITLE
fix(desktop): let macOS system quit bypass background close

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -89,12 +89,13 @@ func (a *App) Platform() string {
 // off the initialization in a background goroutine so the webview loads immediately.
 func (a *App) startup(ctx context.Context) {
 	a.ctx = ctx
+	installSystemQuitHook()
 
 	go a.restoreOrBuildTabs()
 }
 
 func (a *App) beforeClose(ctx context.Context) bool {
-	if a.forceQuit.Swap(false) {
+	if a.forceQuit.Swap(false) || consumeSystemQuitRequested() {
 		return false
 	}
 	cfg, _, err := a.loadDesktopUserConfigForEdit()

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -73,6 +73,28 @@ func TestEffortDefaultsBeforeStartup(t *testing.T) {
 	}
 }
 
+func TestBeforeCloseAllowsSystemQuitWhenBackgroundCloseEnabled(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	consumeSystemQuitRequested()
+	t.Cleanup(func() { consumeSystemQuitRequested() })
+
+	userCfg := config.LoadForEdit(config.UserConfigPath())
+	if err := userCfg.SetDesktopCloseBehavior("background"); err != nil {
+		t.Fatal(err)
+	}
+	if err := userCfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatal(err)
+	}
+
+	markSystemQuitRequested()
+	if prevent := NewApp().beforeClose(context.Background()); prevent {
+		t.Fatal("system quit should bypass background close-to-tray behavior")
+	}
+	if consumeSystemQuitRequested() {
+		t.Fatal("system quit marker should be consumed by beforeClose")
+	}
+}
+
 func TestEmitReadyInvokesReadyHook(t *testing.T) {
 	app := NewApp()
 	var calls int32

--- a/desktop/system_quit.go
+++ b/desktop/system_quit.go
@@ -1,0 +1,13 @@
+package main
+
+import "sync/atomic"
+
+var systemQuitRequested atomic.Bool
+
+func markSystemQuitRequested() {
+	systemQuitRequested.Store(true)
+}
+
+func consumeSystemQuitRequested() bool {
+	return systemQuitRequested.Swap(false)
+}

--- a/desktop/system_quit_darwin.go
+++ b/desktop/system_quit_darwin.go
@@ -1,0 +1,24 @@
+//go:build darwin
+
+package main
+
+/*
+#cgo darwin LDFLAGS: -framework Cocoa
+void installReasonixSystemQuitHook(void);
+*/
+import "C"
+
+import "sync"
+
+var installSystemQuitHookOnce sync.Once
+
+func installSystemQuitHook() {
+	installSystemQuitHookOnce.Do(func() {
+		C.installReasonixSystemQuitHook()
+	})
+}
+
+//export ReasonixMarkSystemQuit
+func ReasonixMarkSystemQuit() {
+	markSystemQuitRequested()
+}

--- a/desktop/system_quit_darwin.m
+++ b/desktop/system_quit_darwin.m
@@ -1,0 +1,44 @@
+//go:build darwin
+
+#import <Cocoa/Cocoa.h>
+#import <objc/runtime.h>
+
+extern void ReasonixMarkSystemQuit(void);
+
+static NSApplicationTerminateReply (*originalApplicationShouldTerminate)(id, SEL, NSApplication *);
+static void (*originalWailsContextQuit)(id, SEL);
+
+static NSApplicationTerminateReply reasonixApplicationShouldTerminate(id self, SEL _cmd, NSApplication *sender) {
+    ReasonixMarkSystemQuit();
+    if (originalApplicationShouldTerminate != NULL) {
+        return originalApplicationShouldTerminate(self, _cmd, sender);
+    }
+    return NSTerminateNow;
+}
+
+static void reasonixWailsContextQuit(id self, SEL _cmd) {
+    ReasonixMarkSystemQuit();
+    if (originalWailsContextQuit != NULL) {
+        originalWailsContextQuit(self, _cmd);
+    }
+}
+
+void installReasonixSystemQuitHook(void) {
+    Class appDelegate = NSClassFromString(@"AppDelegate");
+    SEL selector = @selector(applicationShouldTerminate:);
+    Method method = appDelegate == Nil ? NULL : class_getInstanceMethod(appDelegate, selector);
+    if (method != NULL) {
+        IMP replacement = (IMP)reasonixApplicationShouldTerminate;
+        IMP previous = method_setImplementation(method, replacement);
+        originalApplicationShouldTerminate = (NSApplicationTerminateReply (*)(id, SEL, NSApplication *))previous;
+    }
+
+    Class wailsContext = NSClassFromString(@"WailsContext");
+    SEL quitSelector = @selector(Quit);
+    Method quitMethod = wailsContext == Nil ? NULL : class_getInstanceMethod(wailsContext, quitSelector);
+    if (quitMethod != NULL) {
+        IMP replacement = (IMP)reasonixWailsContextQuit;
+        IMP previous = method_setImplementation(quitMethod, replacement);
+        originalWailsContextQuit = (void (*)(id, SEL))previous;
+    }
+}

--- a/desktop/system_quit_stub.go
+++ b/desktop/system_quit_stub.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package main
+
+func installSystemQuitHook() {}


### PR DESCRIPTION
## Summary
- mark macOS system-level Quit requests before Wails runs OnBeforeClose
- let Dock Quit, app menu Quit, and Command-Q bypass the close-to-background preference
- keep ordinary window close behavior unchanged and covered by a regression test

## Tests
- cd desktop && go test ./...