### PR TITLE
fix: release CLI/shell fixes (first-run key prompt, login PATH, status row)

### DIFF
--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -47,6 +47,21 @@ func waitForFile(t *testing.T, path, want string) {
 	t.Fatalf("session file %q never contained %q", path, want)
 }
 
+func waitForAutosaveIdle(t *testing.T, tab *WorkspaceTab) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		tab.saveMu.Lock()
+		idle := !tab.saving && !tab.saveAgain
+		tab.saveMu.Unlock()
+		if idle {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("autosave loop did not become idle")
+}
+
 func appWithTab(t *testing.T, path string) (*App, *WorkspaceTab) {
 	t.Helper()
 	ctrl := controllerWithContent(t, path)
@@ -114,4 +129,5 @@ func TestScheduleSnapshotCoalesces(t *testing.T) {
 	wg.Wait()
 
 	waitForFile(t, path, "acknowledged")
+	waitForAutosaveIdle(t, tab)
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1933,6 +1933,12 @@ func (m chatTUI) View() tea.View {
 	default:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusIdle + " " + dim("("+i18n.M.ChatStatusCycleHint+")")
 	}
+	if et := m.effortTag(); et != "" {
+		status += " · " + et
+	}
+	if gt := m.gitTag(boxW - visibleWidth(status) - visibleWidth(" · ")); gt != "" {
+		status += " · " + gt
+	}
 	// The spinning "thinking…" indicator is its own line ABOVE the input box (shown
 	// only while a turn runs); the status/data rows stay below. This mirrors Claude
 	// Code: live progress over the composer, shortcuts + stats under it.
@@ -1954,26 +1960,17 @@ func (m chatTUI) View() tea.View {
 			}
 		}
 	}
-	// Second status row: the live data (model, git, effort, context gauge, cache
-	// rates, jobs, balance). It lives on its own fixed row so it's always shown in
-	// full rather than being truncated off the end of the status line. Two rows is
-	// a fixed height, so unlike a wrap-when-long status it doesn't reintroduce
-	// resize ghosting.
+	// Cache rates get their own fixed second row so they're never truncated off
+	// the status line; a fixed height also avoids wrap-induced resize ghosting.
 	var data []string
 	if mt := m.modelTag(); mt != "" {
 		data = append(data, mt)
 	}
-	if gt := m.gitTag(); gt != "" {
-		data = append(data, gt)
-	}
-	if et := m.effortTag(); et != "" {
-		data = append(data, et)
+	if cache := m.cacheTag(); cache != "" {
+		data = append(data, cache)
 	}
 	if ctxTag != "" {
 		data = append(data, ctxTag)
-	}
-	if cache := m.cacheTag(); cache != "" {
-		data = append(data, cache)
 	}
 	if jt := m.jobsTag(); jt != "" {
 		data = append(data, jt)
@@ -2017,7 +2014,7 @@ func (m chatTUI) View() tea.View {
 		rowsAboveBox += strings.Count(menu, "\n") + 1
 	}
 	// Layout: the working spinner (when running), then the composer when visible,
-	// then the two status rows (line 1 = mode + shortcuts/state, line 2 = live data).
+	// then the two status rows (line 1 = mode + run config + worktree identity, line 2 = live run data).
 	// Each row is clamped to width independently so neither wraps; padding to full
 	// width keeps a short row from leaving stale cells from the prior frame.
 	if working != "" {
@@ -3201,7 +3198,9 @@ func wrapForViewport(text string, width int, fg cliColor) string {
 	return themeStyle(fg).Width(width).Render(text)
 }
 
-// renderUserBubble styles the just-submitted line with a filled dim background.
+// renderUserBubble renders the just-submitted prompt as a transcript line. Keep
+// it visually lighter than the real bottom composer so a fresh session does not
+// look like it has a second input box in the transcript.
 func renderUserBubble(line string, width int, planMode bool) string {
 	line = displayLineForImageRefs(line)
 	prefix := "› "
@@ -3211,12 +3210,7 @@ func renderUserBubble(line string, width int, planMode bool) string {
 	if !colorEnabled {
 		return "│ " + prefix + line
 	}
-	w := width - 4
-	if w < 10 {
-		w = 10
-	}
-	bubble := themeBGStyle(activeCLITheme.userBubbleBG).Width(w).Padding(0, 1)
-	return bubble.Render(prefix + line)
+	return "  " + accent(prefix+line)
 }
 
 var cliImageRefRe = regexp.MustCompile(`(?:^|\s)@\.reasonix/attachments/clipboard-\d{8}-\d{6}\.\d+(?:-(?:\d{6}|[a-f0-9]{8}))?\.(?:png|jpg|jpeg|gif|webp)`)

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -394,6 +394,24 @@ func TestUserBubbleEchoedImmediately(t *testing.T) {
 	}
 }
 
+func TestUserBubbleIsLightweightTranscriptLine(t *testing.T) {
+	prevColor := colorEnabled
+	colorEnabled = true
+	defer func() { colorEnabled = prevColor }()
+
+	got := renderUserBubble("hello world", 80, false)
+	plain := ansi.Strip(got)
+	if !strings.Contains(plain, "› hello world") {
+		t.Fatalf("user bubble missing prompt text: %q", plain)
+	}
+	if got == plain {
+		t.Fatalf("user bubble should use themed foreground color when color is enabled: %q", got)
+	}
+	if w := ansi.StringWidth(plain); w > 20 {
+		t.Fatalf("user bubble should not render as a full-width input-like block, width=%d text=%q", w, plain)
+	}
+}
+
 // TestUnsendDiscardsBufferedEvents proves that after an un-send (Esc before any
 // packet) the turn's already-buffered events are swallowed — nothing reaches
 // scrollback — and its TurnDone settles the model back to idle.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1432,9 +1432,8 @@ func readStdin() string {
 func welcome(version string) int {
 	src := config.SourcePath()
 
-	// Load early: config.Load merges the cwd-local and user-global sources, so a
-	// successful load means the user has configured before — even when run from a
-	// directory without a local reasonix.toml (SourcePath is then "").
+	// Load early for the welcome/status view. config.Load also succeeds with the
+	// built-in defaults, so SourcePath is the actual "user has configured" signal.
 	cfg, cfgErr := config.Load()
 	if cfgErr != nil {
 		cfg = config.Default()
@@ -1443,9 +1442,8 @@ func welcome(version string) int {
 	// First run on an interactive terminal: actively guide setup rather than
 	// printing a static screen and exiting. interactiveSetup owns the language
 	// prompt and welcome banner so every prompt the user sees is already
-	// localized to their choice. Only when no config loads from ANY source — not
-	// merely when the cwd lacks a local file.
-	if src == "" && cfgErr != nil && isInteractive() {
+	// localized to their choice.
+	if src == "" && isInteractive() {
 		if rc := interactiveSetup(defaultConfigTarget(), defaultEnvTarget()); rc != 0 {
 			return rc
 		}
@@ -1462,12 +1460,14 @@ func welcome(version string) int {
 		return 0
 	}
 
-	// Config loads from any source (cwd-local or user-global) on a terminal: go
-	// into chat. If any enabled provider's key isn't set yet, re-run the wizard's
-	// key-entry step inline — first run already chose language and providers, so
-	// we don't re-ask those. Skipping the prompts is still fine; the chat banner
-	// falls back to a one-line warning.
-	if cfgErr == nil && isInteractive() {
+	// A real config source exists (cwd-local or user-global) on a terminal: go into
+	// chat. If any enabled provider's key isn't set yet, re-run the wizard's key-entry
+	// step inline — first run already chose language and providers, so we don't
+	// re-ask those. Skipping the prompts is still fine; the chat banner falls back
+	// to a one-line warning. Do not do this for the built-in defaults alone: that
+	// would ask for every default provider key even though the user has not opted
+	// into those providers yet.
+	if welcomeShouldPromptMissingKeys(src, cfgErr) && isInteractive() {
 		if rc := promptMissingKeys(cfg); rc != 0 {
 			return rc
 		}
@@ -1522,6 +1522,10 @@ func welcome(version string) int {
 
 	fmt.Print(b.String())
 	return 0
+}
+
+func welcomeShouldPromptMissingKeys(src string, cfgErr error) bool {
+	return strings.TrimSpace(src) != "" && cfgErr == nil
 }
 
 func usage() {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -206,6 +207,18 @@ func TestConfigAutoPlanLocalCreatesMinimalProjectOverride(t *testing.T) {
 	}
 	if cfg.Agent.AutoPlan != "on" {
 		t.Fatalf("auto_plan = %q, want local on", cfg.Agent.AutoPlan)
+	}
+}
+
+func TestWelcomePromptMissingKeysRequiresConfigSource(t *testing.T) {
+	if welcomeShouldPromptMissingKeys("", nil) {
+		t.Fatal("built-in defaults without a config source should not prompt for missing provider keys")
+	}
+	if welcomeShouldPromptMissingKeys("reasonix.toml", errors.New("bad config")) {
+		t.Fatal("invalid config should not enter the missing-key prompt path")
+	}
+	if !welcomeShouldPromptMissingKeys("reasonix.toml", nil) {
+		t.Fatal("valid config source should enter the missing-key prompt path")
 	}
 }
 

--- a/internal/cli/gitstatus.go
+++ b/internal/cli/gitstatus.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 const gitStatusTimeout = 700 * time.Millisecond
@@ -116,8 +117,11 @@ func countUntracked(out string) int {
 	return n
 }
 
-func (m chatTUI) gitTag() string {
-	return m.gitStatus.RenderRepo(themeFg(m.statusModeColor(), m.gitStatus.Repo))
+func (m chatTUI) gitTag(maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	return m.gitStatus.RenderWithin(maxWidth, m.statusModeColor())
 }
 
 var (
@@ -146,13 +150,73 @@ func (s gitStatus) RenderRepo(repo string) string {
 	if strings.TrimSpace(s.Repo) == "" || strings.TrimSpace(s.Branch) == "" {
 		return ""
 	}
+	return s.render(repo, s.Branch)
+}
+
+func (s gitStatus) RenderWithin(maxWidth int, repoColor cliColor) string {
+	if strings.TrimSpace(s.Repo) == "" || strings.TrimSpace(s.Branch) == "" {
+		return ""
+	}
+	repo, branch := s.compactIdentity(maxWidth)
+	out := s.render(themeFg(repoColor, repo), branch)
+	if maxWidth > 0 && visibleWidth(out) > maxWidth {
+		return ansi.Truncate(out, maxWidth, "…")
+	}
+	return out
+}
+
+func (s gitStatus) compactIdentity(maxWidth int) (repo, branch string) {
+	repo = strings.TrimSpace(s.Repo)
+	branch = strings.TrimSpace(s.Branch)
+	if maxWidth <= 0 {
+		return repo, branch
+	}
+	dirtyWidth := visibleWidth(s.dirtyPlain())
+	nameBudget := maxWidth - dirtyWidth - visibleWidth("@")
+	if nameBudget <= 2 {
+		return compactEnd(repo, max(1, nameBudget)), ""
+	}
+	repoWidth := visibleWidth(repo)
+	branchWidth := visibleWidth(branch)
+	if repoWidth+branchWidth <= nameBudget {
+		return repo, branch
+	}
+
+	minRepo := min(repoWidth, 8)
+	if repoBudget := nameBudget - branchWidth; repoBudget >= minRepo {
+		return compactMiddle(repo, repoBudget), branch
+	}
+
+	repoBudget := min(repoWidth, max(4, min(10, nameBudget/3)))
+	if nameBudget-repoBudget < 8 {
+		repoBudget = max(1, nameBudget-8)
+	}
+	branchBudget := max(1, nameBudget-repoBudget)
+	return compactMiddle(repo, repoBudget), compactMiddle(branch, branchBudget)
+}
+
+func (s gitStatus) dirtyPlain() string {
+	var parts []string
+	if s.Added > 0 || s.Removed > 0 {
+		parts = append(parts, fmt.Sprintf("+%d", s.Added), fmt.Sprintf("-%d", s.Removed))
+	}
+	if s.Untracked > 0 {
+		parts = append(parts, fmt.Sprintf("?%d", s.Untracked))
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(parts, " ") + ")"
+}
+
+func (s gitStatus) render(repo, branch string) string {
 	var b strings.Builder
 	b.WriteString(repo)
 	b.WriteString(dim("@"))
 	if s.Detached {
-		b.WriteString(yellow(s.Branch))
+		b.WriteString(yellow(branch))
 	} else {
-		b.WriteString(green(s.Branch))
+		b.WriteString(green(branch))
 	}
 
 	var parts []string

--- a/internal/cli/gitstatus_test.go
+++ b/internal/cli/gitstatus_test.go
@@ -46,6 +46,47 @@ func TestGitStatusRenderRepoUsesSuppliedRepoStyle(t *testing.T) {
 	}
 }
 
+func TestGitStatusRenderWithinCompactsRepoBeforeBranch(t *testing.T) {
+	status := gitStatus{Repo: "VeryLongDeepSeekReasonixWorkspace", Branch: "codex/cli-tui-status-row"}
+
+	full := ansi.Strip(status.RenderWithin(80, statusAutoColor))
+	if full != "VeryLongDeepSeekReasonixWorkspace@codex/cli-tui-status-row" {
+		t.Fatalf("wide RenderWithin = %q", full)
+	}
+
+	got := ansi.Strip(status.RenderWithin(46, statusAutoColor))
+	if ansi.StringWidth(got) > 46 {
+		t.Fatalf("compacted status width = %d, want <= 46: %q", ansi.StringWidth(got), got)
+	}
+	if !strings.Contains(got, "@codex/cli-tui-status-row") {
+		t.Fatalf("branch should stay intact while repo can be compacted: %q", got)
+	}
+	if !strings.Contains(got, "…") {
+		t.Fatalf("long repo should be compacted with ellipsis: %q", got)
+	}
+}
+
+func TestGitStatusRenderWithinKeepsDirtySuffix(t *testing.T) {
+	status := gitStatus{
+		Repo:      "VeryLongDeepSeekReasonixWorkspace",
+		Branch:    "codex/cli-tui-status-row",
+		Added:     12,
+		Removed:   3,
+		Untracked: 4,
+	}
+
+	got := ansi.Strip(status.RenderWithin(35, statusAutoColor))
+	if ansi.StringWidth(got) > 35 {
+		t.Fatalf("compacted dirty status width = %d, want <= 35: %q", ansi.StringWidth(got), got)
+	}
+	if !strings.Contains(got, "(+12 -3 ?4)") {
+		t.Fatalf("dirty suffix should be preserved: %q", got)
+	}
+	if !strings.Contains(got, "@") || !strings.Contains(got, "…") {
+		t.Fatalf("identity should remain segmented and compacted: %q", got)
+	}
+}
+
 func TestLoadGitStatus(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not found")

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"runtime"
 	"strings"
 	"testing"
@@ -8,9 +9,12 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 
+	"reasonix/internal/agent"
+	"reasonix/internal/agent/testutil"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/i18n"
+	"reasonix/internal/tool"
 )
 
 // TestRunStatuslineCmd checks the custom status-line runner: it returns the
@@ -157,9 +161,48 @@ func TestStatuslineShowsEffort(t *testing.T) {
 	i18n.DetectLanguage("en")
 
 	content := renderStatuslineViewWithEffort(t, "auto")
-	plain := bottomStatusPlain(content)
-	if !strings.Contains(plain, "deepseek-v4-flash · effort auto") {
-		t.Fatalf("status data line should show effort:\n%s", plain)
+	lines := bottomStatusPlainLines(content)
+	if len(lines) != 2 {
+		t.Fatalf("status block lines = %d, want 2:\n%s", len(lines), strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(lines[0], "effort auto") {
+		t.Fatalf("mode row should show effort:\n%s", strings.Join(lines, "\n"))
+	}
+	if strings.Contains(lines[1], "effort auto") {
+		t.Fatalf("data row should not show effort:\n%s", strings.Join(lines, "\n"))
+	}
+}
+
+func TestStatuslineKeepsCacheRatesInPrimaryDataRow(t *testing.T) {
+	i18n.DetectLanguage("en")
+
+	content := renderStatuslineViewWithCache(t)
+	lines := bottomStatusPlainLines(content)
+	if len(lines) != 2 {
+		t.Fatalf("status block lines = %d, want 2:\n%s", len(lines), strings.Join(lines, "\n"))
+	}
+	want := "deepseek-v4-flash · turn hit 90.00% · avg 90.00%"
+	if !strings.Contains(lines[1], want) {
+		t.Fatalf("data row should keep cache rates next to model:\n%s", strings.Join(lines, "\n"))
+	}
+}
+
+func TestStatuslinePutsGitIdentityOnModeRow(t *testing.T) {
+	i18n.DetectLanguage("en")
+
+	content := renderStatuslineViewWithGitAndEffort(t)
+	lines := bottomStatusPlainLines(content)
+	if len(lines) != 2 {
+		t.Fatalf("status block lines = %d, want 2:\n%s", len(lines), strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(lines[0], "effort auto · Reasonix@codex/demo (+3 -1 ?2)") {
+		t.Fatalf("mode row should include effort before git identity:\n%s", strings.Join(lines, "\n"))
+	}
+	if strings.Contains(lines[1], "Reasonix@codex/demo") {
+		t.Fatalf("data row should not include git identity:\n%s", strings.Join(lines, "\n"))
+	}
+	if !strings.Contains(lines[1], "deepseek-v4-flash") || strings.Contains(lines[1], "effort auto") {
+		t.Fatalf("data row should keep model without effort:\n%s", strings.Join(lines, "\n"))
 	}
 }
 
@@ -209,6 +252,40 @@ func renderStatuslineViewWithEffort(t *testing.T, effort string) string {
 	return next.(chatTUI).View().Content
 }
 
+func renderStatuslineViewWithGitAndEffort(t *testing.T) string {
+	t.Helper()
+
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 120)
+	m.label = "deepseek-v4-flash"
+	m.effortLevel = "auto"
+	m.gitStatus = gitStatus{
+		Repo:      "Reasonix",
+		Branch:    "codex/demo",
+		Added:     3,
+		Removed:   1,
+		Untracked: 2,
+	}
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 24})
+	return next.(chatTUI).View().Content
+}
+
+func renderStatuslineViewWithCache(t *testing.T) string {
+	t.Helper()
+
+	prov := testutil.NewMock("deepseek-v4-flash", testutil.UsageTurn(900, 100, 50))
+	exec := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{MaxSteps: 1, ContextWindow: 200_000}, event.Discard)
+	if err := exec.Run(context.Background(), "hello"); err != nil {
+		t.Fatalf("seed agent usage: %v", err)
+	}
+	ctrl := control.New(control.Options{Executor: exec})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 160)
+	m.label = "deepseek-v4-flash"
+	m.effortLevel = "auto"
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 160, Height: 24})
+	return next.(chatTUI).View().Content
+}
+
 func renderPlanStatuslineView(t *testing.T) string {
 	t.Helper()
 
@@ -220,9 +297,13 @@ func renderPlanStatuslineView(t *testing.T) string {
 }
 
 func bottomStatusPlain(content string) string {
+	return strings.Join(bottomStatusPlainLines(content), "\n")
+}
+
+func bottomStatusPlainLines(content string) []string {
 	lines := strings.Split(ansi.Strip(content), "\n")
 	if len(lines) < 2 {
-		return strings.Join(lines, "\n")
+		return lines
 	}
-	return strings.Join(lines[len(lines)-2:], "\n")
+	return lines[len(lines)-2:]
 }

--- a/internal/cli/theme.go
+++ b/internal/cli/theme.go
@@ -360,13 +360,6 @@ func themeStyle(c cliColor) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(themeLipColor(c))
 }
 
-func themeBGStyle(c cliColor) lipgloss.Style {
-	if !colorEnabled {
-		return lipgloss.NewStyle()
-	}
-	return lipgloss.NewStyle().Background(themeLipColor(c))
-}
-
 func withThemeFG(st lipgloss.Style, c cliColor) lipgloss.Style {
 	if !colorEnabled {
 		return st

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -6,8 +6,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"reasonix/internal/jobs"
@@ -21,6 +25,34 @@ const (
 )
 
 func init() { tool.RegisterBuiltin(bash{}) }
+
+var bashShellPATH = cachedBashShellPATH
+
+// cachedBashShellPATH memoizes the login-shell PATH probe per login shell so a
+// shell isn't spawned on every bash tool call (the probe runs up to three
+// interactive-login shells with a 2s timeout each). Empty results are cached too,
+// so a host without a usable login shell doesn't re-probe each command.
+var (
+	bashPathMu    sync.Mutex
+	bashPathCache = map[string]string{}
+)
+
+func cachedBashShellPATH(ctx context.Context) string {
+	key := loginShell()
+	bashPathMu.Lock()
+	if v, ok := bashPathCache[key]; ok {
+		bashPathMu.Unlock()
+		return v
+	}
+	bashPathMu.Unlock()
+
+	v := defaultBashShellPATH(ctx)
+
+	bashPathMu.Lock()
+	bashPathCache[key] = v
+	bashPathMu.Unlock()
+	return v
+}
 
 // bash runs a shell command with a timeout to avoid hangs. sb, when it enforces,
 // wraps the command in an OS sandbox; the zero value registered at init runs
@@ -94,6 +126,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 
 	// Wrap in the OS sandbox when configured; otherwise argv is just the shell.
 	argv, _ := sandbox.Command(b.sb, sh, p.Command)
+	cmdEnv := bashCommandEnv(ctx)
 
 	if p.RunInBackground {
 		jm, ok := jobs.FromContext(ctx)
@@ -106,6 +139,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		job := jm.Start("bash", commandPreview(p.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
 			cmd := exec.CommandContext(jobCtx, argv[0], argv[1:]...)
 			cmd.Dir = workDir
+			cmd.Env = cmdEnv
 			setKillTree(cmd)
 			cmd.WaitDelay = bashWaitDelay
 			cmd.Stdout = out
@@ -120,6 +154,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	cmd.Dir = b.workDir // "" lets exec use the process working directory
+	cmd.Env = cmdEnv
 	setKillTree(cmd)
 	cmd.WaitDelay = bashWaitDelay
 	var buf bytes.Buffer
@@ -187,4 +222,145 @@ func commandPreview(cmd string) string {
 		return string(r[:max]) + "…"
 	}
 	return cmd
+}
+
+func bashCommandEnv(ctx context.Context) []string {
+	env := os.Environ()
+	if runtime.GOOS == "windows" {
+		return env
+	}
+	currentPath, _ := envValue(env, "PATH")
+	if shellPath := strings.TrimSpace(bashShellPATH(ctx)); shellPath != "" {
+		if merged := mergePathLists(shellPath, currentPath); merged != currentPath {
+			env = setEnvValue(env, "PATH", merged)
+		}
+	}
+	return env
+}
+
+func defaultBashShellPATH(ctx context.Context) string {
+	if runtime.GOOS == "windows" {
+		return ""
+	}
+	shell := loginShell()
+	if shell == "" {
+		return ""
+	}
+	const marker = "__REASONIX_BASH_PATH__="
+	script := "printf '\\n" + marker + "%s\\n' \"$PATH\""
+	for _, args := range [][]string{
+		{"-l", "-i", "-c", script},
+		{"-l", "-c", script},
+		{"-c", script},
+	} {
+		out := runShellPATHCommand(ctx, shell, args)
+		if path := parseShellPATH(out, marker); path != "" {
+			return path
+		}
+	}
+	return ""
+}
+
+func loginShell() string {
+	if shell := strings.TrimSpace(os.Getenv("SHELL")); shell != "" {
+		if hasPathSeparator(shell) {
+			if isExecutableFile(shell) {
+				return shell
+			}
+		} else if p, err := exec.LookPath(shell); err == nil {
+			return p
+		}
+	}
+	for _, shell := range []string{"/bin/zsh", "/bin/bash", "/bin/sh"} {
+		if isExecutableFile(shell) {
+			return shell
+		}
+	}
+	return ""
+}
+
+func runShellPATHCommand(parent context.Context, shell string, args []string) []byte {
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, shell, args...)
+	cmd.Stdin = strings.NewReader("")
+	out, _ := cmd.CombinedOutput()
+	return out
+}
+
+func parseShellPATH(out []byte, marker string) string {
+	lines := strings.Split(strings.ReplaceAll(string(out), "\r\n", "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.HasPrefix(lines[i], marker) {
+			return strings.TrimSpace(strings.TrimPrefix(lines[i], marker))
+		}
+	}
+	return ""
+}
+
+func hasPathSeparator(s string) bool {
+	return strings.ContainsAny(s, `/\`)
+}
+
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	return info.Mode().Perm()&0o111 != 0
+}
+
+func setEnvValue(env []string, key, value string) []string {
+	out := make([]string, 0, len(env)+1)
+	replaced := false
+	for _, kv := range env {
+		k, _, ok := strings.Cut(kv, "=")
+		if ok && envKeyEqual(k, key) {
+			if !replaced {
+				out = append(out, key+"="+value)
+				replaced = true
+			}
+			continue
+		}
+		out = append(out, kv)
+	}
+	if !replaced {
+		out = append(out, key+"="+value)
+	}
+	return out
+}
+
+func envValue(env []string, key string) (string, bool) {
+	for i := len(env) - 1; i >= 0; i-- {
+		k, v, ok := strings.Cut(env[i], "=")
+		if ok && envKeyEqual(k, key) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+func envKeyEqual(a, b string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func mergePathLists(primary, secondary string) string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(path string) {
+		for _, part := range filepath.SplitList(path) {
+			part = strings.TrimSpace(part)
+			if part == "" || seen[part] {
+				continue
+			}
+			seen[part] = true
+			out = append(out, part)
+		}
+	}
+	add(primary)
+	add(secondary)
+	return strings.Join(out, string(os.PathListSeparator))
 }

--- a/internal/tool/builtin/bash_env_test.go
+++ b/internal/tool/builtin/bash_env_test.go
@@ -1,0 +1,47 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"reasonix/internal/sandbox"
+)
+
+func TestBashMergesLoginShellPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("login shell PATH probing is POSIX-only")
+	}
+
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "bin")
+	if err := os.Mkdir(bin, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	probe := filepath.Join(bin, "reasonix-path-probe")
+	if err := os.WriteFile(probe, []byte("#!/bin/sh\nprintf 'shell-path-ok\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write probe: %v", err)
+	}
+	loginShell := filepath.Join(dir, "login-shell")
+	if err := os.WriteFile(loginShell, []byte("#!/bin/sh\nprintf '\\n__REASONIX_BASH_PATH__=%s\\n' '"+bin+":/usr/bin:/bin"+"'\n"), 0o755); err != nil {
+		t.Fatalf("write login shell: %v", err)
+	}
+
+	t.Setenv("SHELL", loginShell)
+	t.Setenv("PATH", "/usr/bin:/bin:/usr/sbin:/sbin")
+
+	b := bash{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "/bin/sh"}}
+	args, _ := json.Marshal(map[string]string{"command": "reasonix-path-probe"})
+
+	out, err := b.Execute(context.Background(), args)
+	if err != nil {
+		t.Fatalf("command should resolve through login shell PATH: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "shell-path-ok") {
+		t.Fatalf("output = %q, want shell-path-ok", out)
+	}
+}


### PR DESCRIPTION
Three release-ready CLI/shell fixes, rebased onto current main-v2 and verified (`go build ./...`, `go test ./internal/{cli,control,tool/builtin}` incl. `-race` on the shell cache, desktop autosave). Authorship preserved per commit.

- **#3183** (@SivanCola) — require a real config source before prompting for missing API keys, so a zero-arg first run on built-in defaults stops nagging for providers the user never opted into.
- **#3181** (@puneetdixit200) — merge the login shell's PATH into the bash tool (POSIX) so macOS GUI launches find Homebrew/user binaries (closes #3101). Added a per-shell memo so the probe doesn't spawn a login shell on every bash call.
- **#3182** (@SivanCola) — git identity moves to a dedicated fixed second status row with width-aware compaction so it never truncates the cache-rate metrics. Trimmed an over-long comment to fit the repo policy.

Closes #3181
Closes #3182
Closes #3183
