### PR TITLE
fix(desktop): refresh project tree after session changes

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -561,6 +561,7 @@ func (a *App) Fork(turn int) (TabMeta, error) {
 	meta := a.tabMeta(tab, true)
 	a.mu.Unlock()
 
+	a.emitProjectTreeChanged()
 	go a.buildTabController(tab)
 	return meta, nil
 }
@@ -689,7 +690,11 @@ func (a *App) DeleteSession(path string) error {
 	if _, ok := a.openSessionPaths(dir)[sessionPath]; ok {
 		return errActiveSession
 	}
-	return trashSessionArtifacts(dir, sessionPath, key)
+	if err := trashSessionArtifacts(dir, sessionPath, key); err != nil {
+		return err
+	}
+	a.emitProjectTreeChanged()
+	return nil
 }
 
 func (a *App) openSessionPaths(dir string) map[string]struct{} {
@@ -736,7 +741,11 @@ func (a *App) RestoreSession(path string) error {
 	if err := restoreTrashedSessionFile(dir, path); err != nil {
 		return err
 	}
-	return restoreSessionTopicIndex(dir, filepath.Join(dir, key))
+	if err := restoreSessionTopicIndex(dir, filepath.Join(dir, key)); err != nil {
+		return err
+	}
+	a.emitProjectTreeChanged()
+	return nil
 }
 
 // PurgeTrashedSession permanently removes a trashed session and its title/display
@@ -835,7 +844,11 @@ func (a *App) RemoveWorkspace(dir string) error {
 	}
 	dir = normalizeProjectRoot(dir)
 	forgetWorkspace(dir)
-	return removeProject(dir)
+	if err := removeProject(dir); err != nil {
+		return err
+	}
+	a.emitProjectTreeChanged()
+	return nil
 }
 
 func migrateLegacyWorkspacesIntoProjects() {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -721,7 +721,9 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 		a.mu.RUnlock()
 		if ctrl != nil {
 			if err := ctrl.Snapshot(); err == nil {
-				a.maybeAutoTitleTopic(tab)
+				if !a.maybeAutoTitleTopic(tab) {
+					a.emitProjectTreeChanged()
+				}
 			}
 		}
 		tab.saveMu.Lock()
@@ -736,28 +738,29 @@ func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
 	}
 }
 
-func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) {
+func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) bool {
 	if tab == nil || strings.TrimSpace(tab.TopicID) == "" || tab.Ctrl == nil {
-		return
+		return false
 	}
 	titleRoot := tab.WorkspaceRoot
 	if tab.Scope == "global" {
 		titleRoot = ""
 	}
 	if source := loadTopicTitleSource(titleRoot, tab.TopicID); source != topicTitleSourceAuto {
-		return
+		return false
 	}
 	sessionPath := tab.Ctrl.SessionPath()
 	if sessionPath == "" {
-		return
+		return false
 	}
 	nextTitle, updated := autoTitleTopicFromSession(titleRoot, tab.TopicID, sessionPath)
 	if !updated {
-		return
+		return false
 	}
 	a.updateOpenTopicTitle(tab.TopicID, nextTitle)
 	a.updateTopicSessionTitles(tab.TopicID, nextTitle)
 	a.emitProjectTreeChanged()
+	return true
 }
 
 func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath string) (string, bool) {
@@ -1627,13 +1630,18 @@ func (a *App) CreateTopic(scope, workspaceRoot, title string) (TopicMeta, error)
 			}
 		}
 	}
+	a.emitProjectTreeChanged()
 	return TopicMeta{ID: topicID, Title: trimmedTitle, CreatedAt: time.Now().UnixMilli()}, nil
 }
 
 // RenameProject updates the sidebar-only display title for a project folder.
 // Empty title clears the override and falls back to the folder name.
 func (a *App) RenameProject(workspaceRoot, title string) error {
-	return renameProject(workspaceRoot, title)
+	if err := renameProject(workspaceRoot, title); err != nil {
+		return err
+	}
+	a.emitProjectTreeChanged()
+	return nil
 }
 
 // SetProjectColor updates the project-level accent color used by project topics
@@ -1671,7 +1679,11 @@ func (a *App) ReorderProjects(workspaceRoots []string) error {
 		next = append(next, project)
 	}
 	f.Projects = next
-	return saveProjectsFile(f)
+	if err := saveProjectsFile(f); err != nil {
+		return err
+	}
+	a.emitProjectTreeChanged()
+	return nil
 }
 
 // RenameTopic updates a topic's display title.
@@ -1786,6 +1798,7 @@ func (a *App) DeleteTopic(topicID string) error {
 		}
 	}
 	_ = saveProjectsFile(f)
+	a.emitProjectTreeChanged()
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- emit project-tree refresh events after session restore/delete, workspace removal, topic/project mutations, and forked sessions
- refresh project tree metadata after successful turn snapshots so turns and last activity update without another sidebar action
- keep auto-title refreshes from double-emitting project tree change events

## Verification
- cd desktop/frontend && npm run build
- cd desktop && go test .