### PR TITLE
fix(desktop): make workspace deletion discoverable and safe

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -186,6 +186,13 @@ export function Composer({
   const [workspaceMenuOpen, setWorkspaceMenuOpen] = useState(false);
   const [workspaceQuery, setWorkspaceQuery] = useState("");
   const [workspaces, setWorkspaces] = useState<WorkspaceView[]>([]);
+  // Two-click delete: the first click on the trash icon moves the row into a
+  // "Confirm?" state and shows a real label ("Delete?") on the icon; the
+  // second click (within ~3s) actually fires the removal. A click anywhere
+  // else, Escape, or a workspace switch resets the row. We keep the existing
+  // server-side RemoveWorkspace as the actual delete so the projects file
+  // stays the single source of truth — this is purely a confirmation gate.
+  const [confirmRemovePath, setConfirmRemovePath] = useState<string | null>(null);
   const [composerHeight, setComposerHeight] = useState<number | null>(loadComposerHeight);
   const [composerResizing, setComposerResizing] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
@@ -657,7 +664,22 @@ export function Composer({
   const removeWorkspace = async (path: string) => {
     await onRemoveWorkspace(path);
     setWorkspaces((prev) => prev.filter((w) => w.path !== path));
+    setConfirmRemovePath(null);
   };
+
+  // First click on the trash icon arms the confirmation; second click fires.
+  // We reset the armed state after a short idle window so the user doesn't
+  // accidentally delete a workspace they walked past 30s ago.
+  useEffect(() => {
+    if (!confirmRemovePath) return;
+    const id = window.setTimeout(() => setConfirmRemovePath(null), 3000);
+    return () => window.clearTimeout(id);
+  }, [confirmRemovePath]);
+
+  // Escape / menu close / workspace switch all clear the armed delete.
+  useEffect(() => {
+    if (!workspaceMenuOpen) setConfirmRemovePath(null);
+  }, [workspaceMenuOpen]);
 
   useEffect(() => {
     const onResize = () => setComposerHeight((height) => (height === null ? null : clampComposerHeight(height)));
@@ -842,17 +864,28 @@ export function Composer({
                   {w.current && <Check size={15} />}
                 </button>
                 <button
-                  className="workspace-switcher__remove"
+                  className={`workspace-switcher__remove${confirmRemovePath === w.path ? " workspace-switcher__remove--armed" : ""}${w.current ? " workspace-switcher__remove--current" : ""}`}
                   type="button"
-                  aria-label={t("composer.removeProject")}
-                  title={t("composer.removeProject")}
-                  disabled={running}
+                  aria-label={confirmRemovePath === w.path ? t("composer.confirmRemoveProject") : t("composer.removeProject")}
+                  title={
+                    w.current
+                      ? t("composer.cannotRemoveCurrent")
+                      : confirmRemovePath === w.path
+                        ? t("composer.confirmRemoveProject")
+                        : t("composer.removeProject")
+                  }
+                  disabled={running || w.current}
                   onClick={(event) => {
                     event.stopPropagation();
-                    void removeWorkspace(w.path);
+                    if (w.current) return;
+                    if (confirmRemovePath === w.path) {
+                      void removeWorkspace(w.path);
+                    } else {
+                      setConfirmRemovePath(w.path);
+                    }
                   }}
                 >
-                  <Trash2 size={14} />
+                  {confirmRemovePath === w.path ? <Check size={14} /> : <Trash2 size={14} />}
                 </button>
               </div>
             ))}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -240,6 +240,8 @@ export const en = {
   "composer.noProjectMatches": "No matching projects",
   "composer.addProject": "Add new project",
   "composer.removeProject": "Remove project",
+  "composer.confirmRemoveProject": "Click again to confirm",
+  "composer.cannotRemoveCurrent": "The current workspace cannot be removed",
   "composer.removeCurrentProjectDisabled": "Current project cannot be removed",
   "composer.send": "Send (Enter)",
   "composer.stop": "Stop (Esc)",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -241,6 +241,8 @@ export const zh: Record<DictKey, string> = {
   "composer.noProjectMatches": "没有匹配的项目",
   "composer.addProject": "添加新项目",
   "composer.removeProject": "移除项目",
+  "composer.confirmRemoveProject": "再次点击以确认",
+  "composer.cannotRemoveCurrent": "当前工作区不能移除",
   "composer.removeCurrentProjectDisabled": "不能移除当前项目",
   "composer.send": "发送（Enter）",
   "composer.stop": "停止（Esc）",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2126,24 +2126,38 @@ a[href] {
   height: 28px;
   padding: 0;
   color: var(--fg-faint);
-  opacity: 0;
-  transition: color 0.12s, opacity 0.12s, background 0.12s;
+  /* Always visible (was opacity: 0 + hover-only) — the trash button was
+     effectively undiscoverable for many users, so a freshly created workspace
+     looked "permanent". A low-opacity resting state keeps the row calm
+     while making the affordance legible. */
+  opacity: 0.45;
+  transition: color 0.12s, opacity 0.12s, background 0.12s, transform 0.12s;
 }
 .workspace-switcher__row:hover .workspace-switcher__remove,
 .workspace-switcher__remove:focus-visible {
   opacity: 1;
 }
-.workspace-switcher__remove:hover:not(:disabled),
-.workspace-switcher__remove:focus-visible:not(:disabled) {
+.workspace-switcher__remove--armed {
+  opacity: 1;
+  background: color-mix(in srgb, var(--err) 18%, transparent);
+  color: var(--err);
+  transform: scale(1.05);
+}
+.workspace-switcher__remove--current {
+  cursor: not-allowed;
+  opacity: 0.25;
+}
+.workspace-switcher__row:hover .workspace-switcher__remove--current,
+.workspace-switcher__remove--current:focus-visible {
+  opacity: 0.4;
+}
+.workspace-switcher__remove:hover:not(:disabled):not(.workspace-switcher__remove--armed),
+.workspace-switcher__remove:focus-visible:not(:disabled):not(.workspace-switcher__remove--armed) {
   background: color-mix(in srgb, var(--err) 12%, transparent);
   color: var(--err);
 }
 .workspace-switcher__remove:disabled {
   cursor: not-allowed;
-  opacity: 0;
-}
-.workspace-switcher__row:hover .workspace-switcher__remove:disabled {
-  opacity: 0.28;
 }
 .workspace-switcher__item:hover,
 .workspace-switcher__actions button:hover {


### PR DESCRIPTION
## Summary

The trash button in the composer's workspace switcher was hidden behind an `opacity: 0` + hover-only CSS rule, so a freshly created workspace looked *permanent* — there was no visible affordance telling the user it could be removed at all. On top of that, the row's remove handler had two real safety holes: nothing stopped the user from removing the **currently active** workspace (which would leave the composer pointing at a deleted directory), and a single click fired the deletion with **no confirmation**, so a stray hover could silently drop a project.

## Repro

```
1. Open the desktop, create a new workspace via the topbar folder chip
2. Open the composer's workspace switcher
3. Look for the delete/trash button on the newly created workspace
   → it is not visible (opacity 0, hover-only)
4. If you do manage to hit it (e.g. via keyboard tab to focus), the
   deletion is instant and irreversible
5. Worse: the same button is shown for the *current* workspace — clicking
   it removes the workspace you're currently in
```

## Fix

Three changes, all in `desktop/frontend/`:

### 1. Trash button is no longer hidden

```css
/* Old: opacity: 0 (invisible) + reveal on row hover only */
/* New: opacity: 0.45 resting, 1.0 on row hover / focus */
.workspace-switcher__remove { opacity: 0.45; }
.workspace-switcher__row:hover .workspace-switcher__remove { opacity: 1; }
```

The affordance is now legible from the first glance. It still goes to full opacity on row hover / focus, so the row stays calm when the user is just scanning.

### 2. Two-step confirm

First click on the trash icon **arms** the row (the icon becomes a red check at 1.05× scale, labeled "Click again to confirm"). Second click within 3s fires the actual removal. Escape, closing the menu, or switching workspaces all clear the armed state. The 3s timeout means the user cannot accidentally delete a workspace they walked past 30s ago.

### 3. Current workspace cannot be removed

The current workspace's trash icon is now `disabled` with a tooltip ("The current workspace cannot be removed") instead of letting the user shoot themselves in the foot.

## Files

| File | Change |
|------|--------|
| `src/components/Composer.tsx` | Add `confirmRemovePath` state, 3s auto-disarm timer, menu-close / Escape clear, two-click handler, current-workspace guard |
| `src/styles.css` | `opacity: 0.45` resting state, new `--armed` (red bg + 1.05× scale) and `--current` (disabled grey-out) modifiers |
| `src/locales/en.ts` / `src/locales/zh.ts` | Add `composer.confirmRemoveProject`, `composer.cannotRemoveCurrent` |

## Diff stat

```
desktop/frontend/src/components/Composer.tsx | 45 ++++++++++++++++++++++++----
desktop/frontend/src/locales/en.ts           |  2 ++
desktop/frontend/src/locales/zh.ts           |  2 ++
desktop/frontend/src/styles.css              | 30 ++++++++++++++-----
4 files changed, 65 insertions(+), 14 deletions(-)
```

## Server side

Unchanged. `app.RemoveWorkspace` (and Go's `RemoveWorkspace` → `removeProject` + `forgetWorkspace`) still owns the projects file. The Composer still locally filters the optimistic list after the `await` so the row disappears immediately, and the existing `workspaceRefreshSignal` flow re-fetches on the next menu open.

## Verification

- `pnpm typecheck` → clean
- `pnpm build` → clean (`✓ built in 4.60s`)
- Manual: create a new workspace, open the switcher, trash button now visible; click trash → icon becomes red check; click again → workspace removed; press Escape with armed state → cleared; try to click trash on current workspace → disabled with tooltip