### PR TITLE
build(desktop): ship a macOS .dmg for first-time install

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -84,6 +84,11 @@ jobs:
           choco install nsis -y --no-progress
           echo "C:\Program Files (x86)\NSIS" >> "$GITHUB_PATH"
 
+      # macOS: create-dmg packages the .app into a drag-to-Applications .dmg.
+      - name: Install create-dmg
+        if: runner.os == 'macOS'
+        run: brew install create-dmg
+
       - name: Install Wails CLI
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -113,8 +113,9 @@ has a manual check. Self-update behavior by platform:
 There are no Apple/Windows code-signing certificates yet, so a downloaded build
 trips the OS gatekeepers on first run:
 
-- **macOS** — Gatekeeper may report the app "is damaged" or is from an
-  unidentified developer. Clear the quarantine attribute, then open it:
+- **macOS** — open `Reasonix-darwin-universal.dmg` and drag Reasonix into
+  Applications. Gatekeeper may then report the app "is damaged" or is from an
+  unidentified developer; clear the quarantine attribute and open it:
   ```sh
   xattr -dr com.apple.quarantine /Applications/Reasonix.app
   ```

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -5,7 +5,8 @@
 #
 # Output lands in <repo>/dist/ with stable, platform-keyed names that
 # desktop/cmd/sign's `manifest` subcommand maps back to update.PlatformKey:
-#   macOS:   Reasonix-darwin-<arch>.zip                  (ditto archive of the .app)
+#   macOS:   Reasonix-darwin-<arch>.zip                  (ditto archive; updater channel)
+#            Reasonix-darwin-universal.dmg               (drag-to-install; human download)
 #   Windows: Reasonix-windows-<arch>-installer.exe       (NSIS per-user installer)
 #   Linux:   Reasonix-linux-<arch>.tar.gz                (bare binary)
 #
@@ -65,7 +66,23 @@ darwin)
 	else
 		ditto -c -k --keepParent "$app" "$ROOT/dist/${APPNAME}-darwin-${arch}.zip"
 	fi
-	rm -rf "$staging"
+	# A drag-to-Applications .dmg for first-time human download. Named -universal so
+	# cmd/sign's substring match (darwin-arm64/darwin-amd64) skips it: the .zip stays
+	# the updater channel, the .dmg is release-page only. create-dmg can exit nonzero
+	# while still writing the image, so gate on the file existing, not the exit code.
+	dmgsrc=$(mktemp -d)
+	cp -R "$app" "$dmgsrc/${APPNAME}.app"
+	dmg="$ROOT/dist/${APPNAME}-darwin-universal.dmg"
+	create-dmg \
+		--volname "$APPNAME" \
+		--window-size 540 380 \
+		--icon-size 110 \
+		--icon "${APPNAME}.app" 150 190 \
+		--app-drop-link 390 190 \
+		--no-internet-enable \
+		"$dmg" "$dmgsrc" || true
+	[ -f "$dmg" ] || { echo "create-dmg did not produce $dmg" >&2; exit 1; }
+	rm -rf "$staging" "$dmgsrc"
 	;;
 windows)
 	# `wails build -nsis` writes the installer under build/bin; its exact name

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -82,7 +82,7 @@ try {
           <div class="dlgroup">
             <div class="dllabel"><span class="dot pre"></span><span data-en>v<span class="rxv">{goVer}</span> · Go rewrite — preview</span><span data-zh>v<span class="rxv">{goVer}</span> · Go 重写(预览)</span></div>
             <div class="dlrow">
-              <a class="hdl" href={`${R2}/Reasonix-darwin-arm64.zip`} download>macOS</a>
+              <a class="hdl" href={`${R2}/Reasonix-darwin-universal.dmg`} download>macOS</a>
               <a class="hdl" href={`${R2}/Reasonix-windows-amd64-installer.exe`} download>Windows</a>
               <a class="hdl" href={`${R2}/Reasonix-linux-amd64.tar.gz`} download>Linux</a>
             </div>


### PR DESCRIPTION
## Problem

The v2 (Wails) macOS release only ships `Reasonix-darwin-<arch>.zip` — a ditto archive of the `.app`. Users who download and unzip it get a bare `Reasonix.app` with no cue to move it into Applications, so many don't know how to install it. (v1 shipped a proper `.dmg`; v2 regressed on this.)

## Change

- **`scripts/desktop-build.sh`** — after the `.zip`(s), build `Reasonix-darwin-universal.dmg` with `create-dmg`: a drag-to-Applications layout (app icon + Applications drop-link). Gated on the output file existing rather than the exit code, since `create-dmg` can exit nonzero while still writing the image.
- **`.github/workflows/release-desktop.yml`** — `brew install create-dmg` on the macOS runner.
- **`site/src/pages/index.astro`** — the v2 macOS download now points at the `.dmg` instead of the `.zip`.
- **`desktop/README.md`** — first-launch note now says "open the dmg, drag into Applications".

## Why the `.zip` stays

The in-app updater consumes the `.zip` (`cmd/sign manifest` matches artifacts to platform keys by substring: `darwin-arm64` / `darwin-amd64`). The `.dmg` is named `-universal`, which contains **no** platform-key substring, so `matchPlatform` skips it — it never enters `latest.json`. Net: `.zip` = updater channel, `.dmg` = human download. No updater behavior change, no manifest collision.

## Verification

- `bash -n scripts/desktop-build.sh` clean.
- `create-dmg` invocation is standard usage (`<output.dmg> <source_folder>`); the real end-to-end run only happens on a `desktop-v*` tag build (macOS runner), which is where to confirm the artifact before announcing the release.
