### PR TITLE
fix(desktop): overwrite the current install on Windows update (#3217)

### DIFF
--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -248,7 +249,10 @@ func applyLinux(targz []byte) error {
 
 // applyWindows writes the downloaded NSIS installer to a temp file and launches it.
 // The per-user installer needs no admin rights and its finish page relaunches the
-// app; the caller then exits so the installer can replace the running exe.
+// app; the caller then exits so the installer can replace the running exe. The
+// installer targets the running app's own directory (issue #3217) so an update
+// overwrites in place instead of landing a second copy at the per-user default —
+// this also covers upgrades from builds that predate the registry InstallLocation.
 func applyWindows(installer []byte) error {
 	f, err := os.CreateTemp("", "reasonix-update-*.exe")
 	if err != nil {
@@ -262,7 +266,21 @@ func applyWindows(installer []byte) error {
 	if err := f.Close(); err != nil {
 		return err
 	}
-	return exec.Command(name).Start()
+	return installerCommand(name, currentInstallDir()).Start()
+}
+
+// currentInstallDir is the directory of the running executable — the location a
+// Windows update must overwrite. Empty when it can't be resolved, in which case
+// the installer falls back to its own InstallDir logic.
+func currentInstallDir() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	return filepath.Dir(exe)
 }
 
 // relaunch starts a fresh copy of the (just-replaced) executable.

--- a/desktop/updater_other.go
+++ b/desktop/updater_other.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package main
+
+import "os/exec"
+
+// installerCommand exists only so updater.go compiles off Windows; applyWindows is
+// never dispatched there (see updater_app.go).
+func installerCommand(name, _ string) *exec.Cmd {
+	return exec.Command(name)
+}

--- a/desktop/updater_windows.go
+++ b/desktop/updater_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// installerCommand runs the NSIS updater, forcing $INSTDIR to dir via /D= so the
+// update overwrites the current install in place. NSIS requires /D= to be the
+// final, unquoted token taken verbatim to the end of the line, so the raw command
+// line is set directly — exec.Command would quote a path containing spaces (e.g.
+// C:\Users\Jane Doe\...) and NSIS would then mis-parse the target directory.
+func installerCommand(name, dir string) *exec.Cmd {
+	cmd := exec.Command(name)
+	if dir != "" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: fmt.Sprintf(`"%s" /D=%s`, name, dir)}
+	}
+	return cmd
+}

--- a/desktop/updater_windows_test.go
+++ b/desktop/updater_windows_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+func TestInstallerCommandPassesUnquotedDFlagLast(t *testing.T) {
+	cmd := installerCommand(`C:\Temp\reasonix-update-1.exe`, `D:\Tools\Reasonix App`)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("expected a raw command line forcing the install dir")
+	}
+	got := cmd.SysProcAttr.CmdLine
+	want := `"C:\Temp\reasonix-update-1.exe" /D=D:\Tools\Reasonix App`
+	if got != want {
+		t.Fatalf("CmdLine = %q, want %q", got, want)
+	}
+}
+
+func TestInstallerCommandWithoutDirSkipsDFlag(t *testing.T) {
+	cmd := installerCommand(`C:\Temp\reasonix-update-1.exe`, "")
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("no dir should leave NSIS InstallDir logic intact, got CmdLine %q", cmd.SysProcAttr.CmdLine)
+	}
+}


### PR DESCRIPTION
## Problem

On Windows, a desktop self-update lands a **second copy** at the per-user default path instead of overwriting the existing install — orphaning a custom-location install (e.g. `D:\Tools\Reasonix`). Reported again on 1.2.0 (#3217); the earlier registry-based fix (#3060 / 80ce384) doesn't cover it.

## Root cause

`applyWindows` launched the downloaded NSIS installer with **no arguments**:

```go
return exec.Command(name).Start()
```

So the install directory came entirely from the installer's `InstallDirRegKey`/`InstallDir`. For anyone upgrading from a build that predates the registry `InstallLocation` (1.1.0 and earlier never wrote it), that read misses and the directory falls back to `$LOCALAPPDATA\Programs\Reasonix` — a fresh install at the default path.

## Fix

The updater already knows where it's running from. Pass the running executable's directory to the installer as `/D=<dir>` so the update overwrites **in place**, regardless of registry state — this covers upgrades from every prior version, not just ones installed by the fixed installer.

- `currentInstallDir()` = `filepath.Dir(os.Executable())` (symlink-resolved).
- NSIS requires `/D=` to be the **final, unquoted** token taken verbatim to end of line. `exec.Command` would quote a path containing spaces (`C:\Users\Jane Doe\...`) and NSIS would mis-parse it, so the raw command line is set via `SysProcAttr.CmdLine`. That field is Windows-only, so it lives in a `//go:build windows` file (`updater_windows.go`) with a no-op stub for other platforms (`updater_other.go`).
- The installer stays interactive (its finish page still relaunches the app); only the default/target directory is now correct.
- `InstallDirRegKey` in `project.nsi` is unchanged — it remains the fallback for manual/interactive installs.

## Tests

`updater_windows_test.go` locks the NSIS contract: `/D=` is the last token, unquoted, and a path with spaces is preserved verbatim; an empty dir leaves NSIS's own InstallDir logic intact.

## Verification

- `wails build` (Windows) end-to-end green.
- `go test ./...` (desktop) green, including the new Windows-tagged tests.

Closes #3217
