### PR TITLE
fix(desktop): don't start the system tray on macOS (#3223)

### DIFF
--- a/desktop/tray_supported_darwin.go
+++ b/desktop/tray_supported_darwin.go
@@ -2,4 +2,7 @@
 
 package main
 
-func traySupported() bool { return true }
+// systray creates the NSStatusItem (an NSWindow) on the calling goroutine, but
+// Cocoa demands the main thread — which Wails owns — so the tray crashes the app
+// at launch (#3223). macOS backgrounds via runtime.Hide + the Dock instead.
+func traySupported() bool { return false }


### PR DESCRIPTION
## Problem

Desktop **v1.2.0 crashes at launch on macOS** (every Mac, reported on Intel/macOS 15.7 in #3223):

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException',
    reason: 'NSWindow should only be instantiated on the main thread!'
  -[NSStatusBarWindow initForStatusItem:]
  fyne.io/systray.nativeStart
  main.startDesktopTray (tray_loop_external.go)
  main.(*App).startTray (tray.go)
  main.(*App).startup (app.go)
```

## Root cause

`startup()` calls `startTray()` unconditionally, and `traySupported()` returned `true` on darwin. `fyne.io/systray` creates its `NSStatusItem` (an `NSWindow`) on whatever goroutine starts it — but Wails runs `startup` on a worker goroutine, and Cocoa requires `NSWindow` on the main thread. So the status item creation aborts the process. The close-to-tray feature was only viable on Windows/Linux.

## Fix

`traySupported()` returns `false` on macOS. The close-to-background path there already hides via `runtime.Hide` and restores from the Dock (plus the system-quit hook handles Cmd-Q), so the menu-bar item is redundant and nothing is lost. `startTray()` early-returns; the systray code is never invoked on darwin.

A real macOS menu-bar item would need the status item created on the main thread (Wails doesn't cleanly expose that) and is out of scope for this crash fix.

## Note

This needs a **desktop-v1.2.1** patch — macOS doesn't self-update, and the crash is at startup, so affected users must download the fixed build manually.

Closes #3223