### PR TITLE
fix(desktop): simplify empty project state

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1191,7 +1191,6 @@ export default function App() {
               activeScope={activeTab?.scope}
               activeWorkspaceRoot={activeTab?.workspaceRoot}
               activeTopicId={activeTab?.topicId}
-              currentWorkspaceName={workspaceDisplayName(state.meta?.cwd)}
               onOpenTopic={handleOpenTopic}
               onOpenProjectHistory={openProjectHistory}
               onTopicsChanged={refreshProjectsAndTabs}
@@ -1200,9 +1199,6 @@ export default function App() {
               onAddProject={async () => {
                 await switchFolder();
               }}
-              onUseCurrentProject={state.meta?.cwd ? async () => {
-                await switchFolder(state.meta?.cwd);
-              } : undefined}
             />
           </section>
 

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -4,7 +4,7 @@
 // new topic.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { Archive, ChevronRight, ChevronDown, Pencil, Plus, Folder, FolderGit2, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check } from "lucide-react";
+import { Archive, ChevronRight, ChevronDown, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import type { ProjectNode } from "../lib/types";
@@ -17,11 +17,9 @@ interface ProjectTreeProps {
   activeScope?: string;
   activeWorkspaceRoot?: string;
   activeTopicId?: string;
-  currentWorkspaceName?: string;
   onOpenTopic: (scope: string, workspaceRoot: string, topicId: string) => Promise<void> | void;
   onOpenProjectHistory: (scope: "global" | "project", workspaceRoot: string) => Promise<void> | void;
   onAddProject: () => Promise<void>;
-  onUseCurrentProject?: () => Promise<void>;
   onRenameTopic?: (topicId: string, title: string) => Promise<void> | void;
   onTopicsChanged?: () => Promise<void> | void;
   refreshSignal?: number;
@@ -133,11 +131,9 @@ export function ProjectTree({
   activeScope,
   activeWorkspaceRoot,
   activeTopicId,
-  currentWorkspaceName,
   onOpenTopic,
   onOpenProjectHistory,
   onAddProject,
-  onUseCurrentProject,
   onRenameTopic,
   onTopicsChanged,
   refreshSignal,
@@ -767,40 +763,7 @@ export function ProjectTree({
           query.trim() ? (
             <div className="project-tree__empty">{t("projectTree.emptyNoMatch")}</div>
           ) : (
-            <div className="project-tree__empty-state">
-              <div className="project-tree__empty-icon">
-                <FolderPlus size={18} />
-              </div>
-              <div className="project-tree__empty-copy">
-                <strong>{t("projectTree.emptyNoProjects")}</strong>
-                <span>{t("projectTree.emptyNoProjectsDesc")}</span>
-              </div>
-              <div className="project-tree__empty-actions">
-                <button
-                  type="button"
-                  className="project-tree__empty-primary"
-                  onClick={() => void handleAddProject()}
-                  disabled={addingProject}
-                >
-                  <FolderPlus size={14} />
-                  <span>{t("projectTree.emptyAddProject")}</span>
-                </button>
-                {onUseCurrentProject && currentWorkspaceName && (
-                  <button
-                    type="button"
-                    className="project-tree__empty-secondary"
-                    onClick={async () => {
-                      await onUseCurrentProject();
-                      await refresh();
-                    }}
-                  >
-                    <FolderGit2 size={14} />
-                    <span>{t("projectTree.emptyUseCurrentDir")}</span>
-                  </button>
-                )}
-              </div>
-              {currentWorkspaceName && <div className="project-tree__empty-current">{t("projectTree.emptyCurrentDir", { dir: currentWorkspaceName })}</div>}
-            </div>
+            <div className="project-tree__empty project-tree__empty--subtle">{t("projectTree.emptyNoProjects")}</div>
           )
         ) : (
           visibleTree.map((node) => renderNode(node, 0))

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -370,10 +370,6 @@ export const en = {
   "projectTree.colorPink": "Pink",
   "projectTree.emptyNoMatch": "No matching projects or sessions",
   "projectTree.emptyNoProjects": "No projects yet",
-  "projectTree.emptyNoProjectsDesc": "Add projects to organize sessions, files, and context.",
-  "projectTree.emptyAddProject": "Add new project",
-  "projectTree.emptyUseCurrentDir": "Use current directory",
-  "projectTree.emptyCurrentDir": "Current directory: {dir}",
   "projectTree.newTopicTooltip": "New session",
   "projectTree.addProjectTooltip": "Add new project",
 

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -371,10 +371,6 @@ export const zh: Record<DictKey, string> = {
   "projectTree.colorPink": "粉色",
   "projectTree.emptyNoMatch": "没有匹配的项目或会话",
   "projectTree.emptyNoProjects": "还没有项目",
-  "projectTree.emptyNoProjectsDesc": "添加项目后，可以按项目管理会话、文件和上下文。",
-  "projectTree.emptyAddProject": "添加新项目",
-  "projectTree.emptyUseCurrentDir": "使用当前目录",
-  "projectTree.emptyCurrentDir": "当前目录：{dir}",
   "projectTree.newTopicTooltip": "新建会话",
   "projectTree.addProjectTooltip": "添加新项目",
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7511,84 +7511,9 @@ a[href] {
   font-size: 13px;
 }
 
-.project-tree__empty-state {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 14px 8px;
-  color: var(--fg-dim);
-}
-
-.project-tree__empty-icon {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 34px;
-  height: 34px;
-  border: 1px solid var(--border-soft);
-  border-radius: 8px;
-  background: var(--bg);
-  color: var(--accent);
-}
-
-.project-tree__empty-copy {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-
-.project-tree__empty-copy strong {
-  color: var(--fg);
-  font-size: 14px;
-  line-height: 1.2;
-}
-
-.project-tree__empty-copy span,
-.project-tree__empty-current {
-  color: var(--fg-faint);
+.project-tree__empty--subtle {
+  padding: 8px 12px;
   font-size: 12px;
-  line-height: 1.45;
-}
-
-.project-tree__empty-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-}
-
-.project-tree__empty-actions button {
-  --wails-draggable: no-drag;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  height: 32px;
-  border-radius: 7px;
-  font: inherit;
-  font-size: 12.5px;
-}
-
-.project-tree__empty-primary {
-  border: 1px solid color-mix(in srgb, var(--accent) 52%, var(--border));
-  background: color-mix(in srgb, var(--accent) 18%, var(--bg-elev));
-  color: var(--accent-strong);
-  font-weight: 620;
-}
-
-.project-tree__empty-primary:hover {
-  background: color-mix(in srgb, var(--accent) 24%, var(--bg-elev));
-  color: var(--fg);
-}
-
-.project-tree__empty-secondary {
-  border: 1px solid var(--border-soft);
-  background: var(--bg);
-  color: var(--fg-dim);
-}
-
-.project-tree__empty-secondary:hover {
-  background: var(--bg-hover);
-  color: var(--fg);
 }
 
 .context-inspector,


### PR DESCRIPTION
## Summary
- Replace the large empty project workspace card with a single subtle empty row.
- Remove the empty-state current-directory action so the internal Global workspace is not suggested as a project.
- Drop unused empty-state styles and locale strings.

## Testing
- git diff --check
- pnpm typecheck (blocked: current worktree is missing Wails-generated desktop/wailsjs bindings)
- pnpm exec vite build (blocked: current worktree is missing Wails-generated desktop/wailsjs runtime imports)
- wails generate module (blocked: current worktree is missing frontend/dist for the embedded asset pattern)