### PR TITLE
Fix workspace builtin tool assembly

### DIFF
--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -20,12 +20,13 @@ import (
 	"reasonix/internal/event"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/sandbox"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
 
-	// Blank imports register the provider kind and built-in tools the same way
-	// cmd/reasonix's main does; without them Build sees an empty provider
-	// registry and a bare tool set.
+	// Blank import registers the provider kind the same way cmd/reasonix's main
+	// does; importing builtin above registers the built-in tools.
 	_ "reasonix/internal/provider/openai"
-	_ "reasonix/internal/tool/builtin"
 )
 
 // TestBuildFoldsProjectMemoryIntoSystemPrompt is the end-to-end proof of the
@@ -169,6 +170,24 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 	if !strings.Contains(sys, "projskill") || !strings.Contains(sys, "explore") {
 		t.Fatalf("skill names missing from index:\n%s", sys)
+	}
+}
+
+func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
+	reg := tool.NewRegistry()
+	var stderr bytes.Buffer
+	addBuiltins(reg, nil, []string{t.TempDir()}, sandbox.Spec{}, builtin.SearchSpec{}, &stderr, t.TempDir())
+	for _, name := range []string{
+		"todo_write",
+		"complete_step",
+		"bash_output",
+		"kill_shell",
+		"wait",
+		"notebook_edit",
+	} {
+		if _, ok := reg.Get(name); !ok {
+			t.Fatalf("workspace builtins missing %q; got %v", name, reg.Names())
+		}
 	}
 }
 

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -105,9 +105,7 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 	if p.Cwd != "" {
 		writeRoots = []string{p.Cwd}
 	}
-	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: writeRoots, Network: cfg.Sandbox.Network}
-	ws := builtin.Workspace{Dir: p.Cwd, WriteRoots: writeRoots, Bash: bashSpec, Search: builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, nil)}
-	for _, t := range ws.Tools(cfg.Tools.Enabled...) {
+	for _, t := range acpBuiltinTools(cfg, p.Cwd, writeRoots) {
 		reg.Add(t)
 	}
 
@@ -187,4 +185,15 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		Commands:     cmds,
 		Cleanup:      cleanup,
 	}), nil
+}
+
+func acpBuiltinTools(cfg *config.Config, cwd string, writeRoots []string) []tool.Tool {
+	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: writeRoots, Network: cfg.Sandbox.Network}
+	ws := builtin.Workspace{
+		Dir:        cwd,
+		WriteRoots: writeRoots,
+		Bash:       bashSpec,
+		Search:     builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, nil),
+	}
+	return ws.Tools(cfg.Tools.Enabled...)
 }

--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/tool"
+
+	_ "reasonix/internal/tool/builtin"
+)
+
+func TestACPBuiltinToolsKeepSessionLevelBuiltins(t *testing.T) {
+	dir := t.TempDir()
+	tools := toolMap(acpBuiltinTools(&config.Config{}, dir, []string{dir}))
+	for _, name := range []string{
+		"todo_write",
+		"complete_step",
+		"bash_output",
+		"kill_shell",
+		"wait",
+		"notebook_edit",
+	} {
+		if tools[name] == nil {
+			t.Fatalf("ACP workspace tools missing %q; got %v", name, toolNames(tools))
+		}
+	}
+}
+
+func toolMap(tools []tool.Tool) map[string]tool.Tool {
+	out := make(map[string]tool.Tool, len(tools))
+	for _, t := range tools {
+		out[t.Name()] = t
+	}
+	return out
+}
+
+func toolNames(tools map[string]tool.Tool) []string {
+	out := make([]string, 0, len(tools))
+	for name := range tools {
+		out = append(out, name)
+	}
+	return out
+}

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -37,20 +37,27 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 	}
 	roots := realRoots(writeRoots)
 
-	all := []tool.Tool{
-		readFile{workDir: w.Dir},
-		writeFile{workDir: w.Dir, roots: roots},
-		editFile{workDir: w.Dir, roots: roots},
-		multiEdit{workDir: w.Dir, roots: roots},
-		deleteRange{workDir: w.Dir, roots: roots},
-		deleteSymbol{workDir: w.Dir, roots: roots},
-		bash{workDir: w.Dir, sb: w.Bash},
-		listDir{workDir: w.Dir},
-		globTool{workDir: w.Dir},
-		grepTool{workDir: w.Dir, rg: w.Search.RgPath},
-		webFetch{},
+	overrides := map[string]tool.Tool{
+		"read_file":     readFile{workDir: w.Dir},
+		"write_file":    writeFile{workDir: w.Dir, roots: roots},
+		"edit_file":     editFile{workDir: w.Dir, roots: roots},
+		"multi_edit":    multiEdit{workDir: w.Dir, roots: roots},
+		"notebook_edit": notebookEdit{workDir: w.Dir, roots: roots},
+		"delete_range":  deleteRange{workDir: w.Dir, roots: roots},
+		"delete_symbol": deleteSymbol{workDir: w.Dir, roots: roots},
+		"bash":          bash{workDir: w.Dir, sb: w.Bash},
+		"ls":            listDir{workDir: w.Dir},
+		"glob":          globTool{workDir: w.Dir},
+		"grep":          grepTool{workDir: w.Dir, rg: w.Search.RgPath},
+		"web_fetch":     webFetch{},
 	}
+	all := tool.Builtins()
 	if len(enabled) == 0 {
+		for i, t := range all {
+			if bound, ok := overrides[t.Name()]; ok {
+				all[i] = bound
+			}
+		}
 		return all
 	}
 	want := make(map[string]bool, len(enabled))
@@ -60,6 +67,9 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 	out := make([]tool.Tool, 0, len(enabled))
 	for _, t := range all {
 		if want[t.Name()] {
+			if bound, ok := overrides[t.Name()]; ok {
+				t = bound
+			}
 			out = append(out, t)
 		}
 	}

--- a/internal/tool/builtin/workspace_test.go
+++ b/internal/tool/builtin/workspace_test.go
@@ -2,6 +2,7 @@ package builtin
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -130,6 +131,21 @@ func TestWorkspacePreservesSessionLevelBuiltins(t *testing.T) {
 	}
 }
 
+func TestWorkspaceToolSchemasStableAcrossRoots(t *testing.T) {
+	firstRoot := t.TempDir()
+	secondRoot := t.TempDir()
+
+	first := workspaceSchemasJSON(t, firstRoot)
+	second := workspaceSchemasJSON(t, secondRoot)
+
+	if first != second {
+		t.Fatalf("workspace tool schemas should not depend on workspace root:\nfirst=%s\nsecond=%s", first, second)
+	}
+	if strings.Contains(first, firstRoot) || strings.Contains(first, secondRoot) {
+		t.Fatalf("workspace paths must not leak into tool schemas: %s", first)
+	}
+}
+
 // TestWorkspaceEmptyDirUnchanged confirms a zero-Dir workspace yields tools that
 // behave exactly like the process-cwd built-ins (relative path unchanged).
 func TestWorkspaceEmptyDirUnchanged(t *testing.T) {
@@ -160,4 +176,17 @@ func keys(m map[string]tool.Tool) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+func workspaceSchemasJSON(t *testing.T, dir string) string {
+	t.Helper()
+	reg := tool.NewRegistry()
+	for _, tt := range (Workspace{Dir: dir}).Tools() {
+		reg.Add(tt)
+	}
+	b, err := json.Marshal(reg.Schemas())
+	if err != nil {
+		t.Fatalf("marshal schemas: %v", err)
+	}
+	return string(b)
 }

--- a/internal/tool/builtin/workspace_test.go
+++ b/internal/tool/builtin/workspace_test.go
@@ -108,9 +108,25 @@ func TestWorkspacePreviewBinds(t *testing.T) {
 
 // TestWorkspaceEnabledFilter checks the enabled whitelist.
 func TestWorkspaceEnabledFilter(t *testing.T) {
-	got := byName(Workspace{Dir: t.TempDir()}.Tools("read_file", "bash"))
-	if len(got) != 2 || got["read_file"] == nil || got["bash"] == nil {
+	got := byName(Workspace{Dir: t.TempDir()}.Tools("read_file", "bash", "todo_write", "wait"))
+	if len(got) != 4 || got["read_file"] == nil || got["bash"] == nil || got["todo_write"] == nil || got["wait"] == nil {
 		t.Fatalf("enabled filter returned %d tools: %v", len(got), keys(got))
+	}
+}
+
+func TestWorkspacePreservesSessionLevelBuiltins(t *testing.T) {
+	got := byName(Workspace{Dir: t.TempDir()}.Tools())
+	for _, name := range []string{
+		"todo_write",
+		"complete_step",
+		"bash_output",
+		"kill_shell",
+		"wait",
+		"notebook_edit",
+	} {
+		if got[name] == nil {
+			t.Fatalf("workspace tools missing %q; got %v", name, keys(got))
+		}
 	}
 }
 


### PR DESCRIPTION
﻿## Summary

Fixes #3218.

Workspace-bound sessions now preserve the full built-in tool surface instead of only exposing path-bound workspace tools. This prevents normal CLI/desktop/ACP sessions from prompting the model toward tools that are missing from the runtime registry.

Related: #3197, #3165.

## Root cause

`boot.addBuiltins` used `builtin.Workspace.Tools(...)` whenever a workspace root was set. `Workspace.Tools` only returned workspace/path-bound tools such as `read_file`, `write_file`, `bash`, `grep`, and `glob`, so session-level builtins were dropped even though the prompt and tool schemas mention them.

The missing tools included:

- `todo_write`
- `complete_step`
- `bash_output`
- `kill_shell`
- `wait`
- `notebook_edit`

ACP also called `Workspace.Tools(...)` directly, so it had the same missing-tool risk and could drift from the shared boot assembly.

## Changes

- Make `Workspace.Tools` start from the complete builtin set and override only workspace-aware tools.
- Preserve explicit `tools.enabled` filtering while allowing session-level builtins through when enabled.
- Add boot-level coverage for workspace-root builtin assembly.
- Add ACP-level coverage for workspace builtin assembly.

## Validation

- `go test ./internal/tool/builtin -run "TestWorkspace(PreservesSessionLevelBuiltins|EnabledFilter|BindsReadAndWrite|WriteConfinement|PreviewBinds)" -count=1 -v`
- `go test ./internal/boot -run TestAddBuiltinsWithWorkspaceRootKeepsSessionTools -count=1 -v`
- `go test ./internal/cli -run TestACPBuiltinToolsKeepSessionLevelBuiltins -count=1 -v`
- `go test ./internal/tool/builtin ./internal/boot -count=1`
- `git diff --check`

Note: a broader CLI run including the pre-existing `TestModelSwitchRefreshesCustomStatusline` still fails with `model switch did not refresh custom statusline with the new model`; this is unrelated to this change.
