### PR TITLE
fix(desktop): refresh checkpoints after resume

### DIFF
--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -338,6 +338,15 @@ export function useController() {
     }
   }, [bump]);
 
+  const checkpointRefreshSeq = useRef(new Map<string, number>());
+  const refreshCheckpoints = useCallback(async (tabId: string) => {
+    const seq = (checkpointRefreshSeq.current.get(tabId) ?? 0) + 1;
+    checkpointRefreshSeq.current.set(tabId, seq);
+    const checkpoints = await app.CheckpointsForTab(tabId).catch(() => undefined);
+    if (checkpointRefreshSeq.current.get(tabId) !== seq || checkpoints === undefined) return;
+    dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(checkpoints) });
+  }, [dispatchTo]);
+
   const loadSessionDataForTab = useCallback(async (tabId: string, reset = false) => {
     try {
       if (reset) dispatchTo(tabId, { type: "reset" });
@@ -346,11 +355,11 @@ export function useController() {
       dispatchTo(tabId, { type: "effort", effort: await app.EffortForTab(tabId) });
       dispatchTo(tabId, { type: "balance", balance: await app.BalanceForTab(tabId) });
       dispatchTo(tabId, { type: "jobs", jobs: asArray(await app.JobsForTab(tabId)) });
-      dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(await app.CheckpointsForTab(tabId)) });
+      await refreshCheckpoints(tabId);
       const history = asArray(await app.HistoryForTab(tabId));
       if (history && history.length) dispatchTo(tabId, { type: "history", messages: history });
     } catch { /* ignore */ }
-  }, [dispatchTo]);
+  }, [dispatchTo, refreshCheckpoints]);
 
   const activeTabFromBackend = useCallback(async (): Promise<TabMeta | undefined> => {
     const tabs = asArray(await app.ListTabs().catch(() => [] as TabMeta[]));
@@ -394,6 +403,7 @@ export function useController() {
           .catch(() => {});
         app.BalanceForTab(targetTabId).then((balance) => dispatchTo(targetTabId, { type: "balance", balance })).catch(() => {});
         app.EffortForTab(targetTabId).then((effort) => dispatchTo(targetTabId, { type: "effort", effort })).catch(() => {});
+        void refreshCheckpoints(targetTabId);
       }
       if (e.kind === "turn_done" || e.kind === "notice") {
         app.JobsForTab(targetTabId).then((jobs) => dispatchTo(targetTabId, { type: "jobs", jobs: asArray(jobs) })).catch(() => {});
@@ -489,7 +499,8 @@ export function useController() {
     dispatchTo(targetTabId, { type: "reset" });
     if (messages.length) dispatchTo(targetTabId, { type: "history", messages });
     app.ContextUsageForTab(targetTabId).then((context) => dispatchTo(targetTabId, { type: "context", context })).catch(() => {});
-  }, [activeTabId, dispatchTo, waitForTabReady]);
+    void refreshCheckpoints(targetTabId);
+  }, [activeTabId, dispatchTo, refreshCheckpoints, waitForTabReady]);
 
   const previewSession = useCallback(async (path: string): Promise<HistoryMessage[]> => asArray<HistoryMessage>(await app.PreviewSession(path).catch(() => [])), []);
   const deleteSession = useCallback((path: string) => app.DeleteSession(path).catch(() => {}), []);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -339,13 +339,17 @@ export function useController() {
   }, [bump]);
 
   const checkpointRefreshSeq = useRef(new Map<string, number>());
-  const refreshCheckpoints = useCallback(async (tabId: string) => {
+  const bumpCheckpointRefreshSeq = useCallback((tabId: string): number => {
     const seq = (checkpointRefreshSeq.current.get(tabId) ?? 0) + 1;
     checkpointRefreshSeq.current.set(tabId, seq);
+    return seq;
+  }, []);
+  const refreshCheckpoints = useCallback(async (tabId: string) => {
+    const seq = bumpCheckpointRefreshSeq(tabId);
     const checkpoints = await app.CheckpointsForTab(tabId).catch(() => undefined);
     if (checkpointRefreshSeq.current.get(tabId) !== seq || checkpoints === undefined) return;
     dispatchTo(tabId, { type: "checkpoints", checkpoints: asArray(checkpoints) });
-  }, [dispatchTo]);
+  }, [bumpCheckpointRefreshSeq, dispatchTo]);
 
   const loadSessionDataForTab = useCallback(async (tabId: string, reset = false) => {
     try {
@@ -483,9 +487,11 @@ export function useController() {
   }, [activeTabId, dispatchTo]);
 
   const newSession = useCallback(async () => {
+    const tabId = activeTabId;
+    if (tabId) bumpCheckpointRefreshSeq(tabId);
     await app.NewSession().catch(() => {});
-    if (activeTabId) dispatchTo(activeTabId, { type: "reset" });
-  }, [activeTabId, dispatchTo]);
+    if (tabId) dispatchTo(tabId, { type: "reset" });
+  }, [activeTabId, bumpCheckpointRefreshSeq, dispatchTo]);
 
   const listSessions = useCallback(async (): Promise<SessionMeta[]> => asArray<SessionMeta>(await app.ListSessions().catch(() => [])), []);
   const listTrashedSessions = useCallback(async (): Promise<SessionMeta[]> => asArray<SessionMeta>(await app.ListTrashedSessions().catch(() => [])), []);


### PR DESCRIPTION
## Summary
- refresh desktop checkpoint state after turn completion
- refresh checkpoint state after resuming a saved session
- guard checkpoint refreshes against stale async responses per tab

## Testing
- npm --prefix desktop/frontend run build
- cd desktop && go test ./...

## Notes
- Missing .ckpt directories still degrade to an empty checkpoint list and the existing disabled restore-point UI.