### PR TITLE
fix(desktop): keep Windows tray interactive after close

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -108,10 +108,7 @@ func (a *App) beforeClose(ctx context.Context) bool {
 	if cfg.DesktopCloseBehavior() == "background" {
 		a.saveWindowStateSync()
 		a.snapshotAllTabs()
-		// Hide the application, not just the window, so macOS can restore it
-		// from the Dock/menu using the normal app activation path. On tray-capable
-		// platforms, the tray menu provides an additional Open/Quit entry point.
-		runtime.Hide(ctx)
+		hideForBackground(ctx)
 		return true
 	}
 	return false
@@ -119,8 +116,7 @@ func (a *App) beforeClose(ctx context.Context) bool {
 
 func (a *App) showMainWindow() {
 	if a.ctx != nil {
-		runtime.Show(a.ctx)
-		runtime.WindowShow(a.ctx)
+		showFromBackground(a.ctx)
 	}
 }
 
@@ -134,6 +130,26 @@ func (a *App) quitApp() {
 	}
 	a.forceQuit.Store(true)
 	runtime.Quit(a.ctx)
+}
+
+func hideForBackground(ctx context.Context) {
+	if backgroundCloseUsesApplicationHide(goruntime.GOOS) {
+		runtime.Hide(ctx)
+		return
+	}
+	runtime.WindowHide(ctx)
+}
+
+func showFromBackground(ctx context.Context) {
+	if backgroundCloseUsesApplicationHide(goruntime.GOOS) {
+		runtime.Show(ctx)
+	}
+	runtime.WindowShow(ctx)
+	runtime.WindowUnminimise(ctx)
+}
+
+func backgroundCloseUsesApplicationHide(goos string) bool {
+	return goos == "darwin"
 }
 
 // restoreOrBuildTabs restores the tabs from the last session, or creates a

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -95,6 +95,23 @@ func TestBeforeCloseAllowsSystemQuitWhenBackgroundCloseEnabled(t *testing.T) {
 	}
 }
 
+func TestBackgroundCloseHideStrategyByPlatform(t *testing.T) {
+	tests := []struct {
+		goos string
+		want bool
+	}{
+		{goos: "darwin", want: true},
+		{goos: "windows", want: false},
+		{goos: "linux", want: false},
+		{goos: "freebsd", want: false},
+	}
+	for _, tt := range tests {
+		if got := backgroundCloseUsesApplicationHide(tt.goos); got != tt.want {
+			t.Fatalf("backgroundCloseUsesApplicationHide(%q) = %v, want %v", tt.goos, got, tt.want)
+		}
+	}
+}
+
 func TestEmitReadyInvokesReadyHook(t *testing.T) {
 	app := NewApp()
 	var calls int32

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -4,7 +4,6 @@ import (
 	"sync"
 
 	"fyne.io/systray"
-	wruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 )
 
 type desktopTray struct {
@@ -32,6 +31,8 @@ func (a *App) startTray() {
 		systray.SetTitle("Reasonix")
 		systray.SetTooltip("Reasonix")
 		systray.SetOnTapped(func() { a.showFromTray() })
+		// Keep secondary/right-click on systray's native menu path.
+		systray.SetOnSecondaryTapped(nil)
 
 		labels := trayMenuLabels(a.trayLocale())
 		t.openItem = systray.AddMenuItem(labels.openTitle, labels.openTooltip)
@@ -95,9 +96,7 @@ func (a *App) showFromTray() {
 	if ctx == nil {
 		return
 	}
-	wruntime.Show(ctx)
-	wruntime.WindowShow(ctx)
-	wruntime.WindowUnminimise(ctx)
+	showFromBackground(ctx)
 }
 
 func (a *App) quitFromTray() {


### PR DESCRIPTION
## Summary
- use window-level hide on tray platforms so Windows/Linux tray icons remain interactive after closing to background
- keep macOS on application-level hide for Dock restoration
- preserve native tray right-click menu behavior and reuse the shared restore path for tray/second-instance opens

Fixes #3227

## Verification
- corepack pnpm build
- go test -run 'TestBackgroundCloseHideStrategyByPlatform|TestBeforeCloseAllowsSystemQuitWhenBackgroundCloseEnabled|TestTrayMenuLabelsFollowLocale' .\n- GOOS=windows GOARCH=amd64 go test -exec /usr/bin/true ./...\n- go test ./cmd/sign ./internal/update\n\nNote: full `go test ./...` in `desktop/` still hits the existing intermittent `TestLegacyMigrationConcurrentRunsHaveNoLostUpdates` TempDir cleanup race; the test passes when run directly and is unrelated to this tray change.