### PR TITLE
fix: import legacy sessions from config session dir

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -59,11 +59,12 @@ cd DeepSeek-Reasonix && make build                        # -> bin/reasonix(.exe
 
 On first launch v2 runs a one-time, **non-destructive** import: it reads a v0.x
 `~/.reasonix/config.json` (API key, base URL, language, MCP servers) and imports
-past sessions from `~/.reasonix/sessions`, leaves the old files untouched, and
-prints a boot notice when it does. Imported sessions resume with `--resume` or
-the history panel. The config import only runs when no v2 config exists yet — if
-v2 wrote its config before your `0.x` data was in place nothing is overwritten,
-so copy any missing values across by hand.
+past sessions from `~/.reasonix/sessions` and legacy event logs already located
+in the current user config session directory, leaves the old files untouched, and
+prints a boot notice when it does. Imported sessions resume with `--resume` or the
+history panel. The config import only runs when no v2 config exists yet — if v2
+wrote its config before your `0.x` data was in place nothing is overwritten, so
+copy any missing values across by hand.
 
 ## What's the same
 

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -38,6 +38,7 @@ type legacyToolCall struct {
 // was imported doesn't reappear on the next launch.
 const legacyImportMarker = ".legacy-imported"
 const legacyEventsHomeImportMarker = ".legacy-imported.v0-events-home"
+const legacyEventsConfigImportMarker = ".legacy-imported.v0-events-config"
 
 // MigrateLegacySessions imports v0.x event-log sessions (<name>.events.jsonl under
 // srcDir) into the v1+ message-log format (<name>.jsonl under destDir), back-filling
@@ -48,6 +49,14 @@ const legacyEventsHomeImportMarker = ".legacy-imported.v0-events-home"
 // count imported.
 func MigrateLegacySessions(srcDir, destDir string) (int, error) {
 	return migrateLegacySessions(srcDir, destDir, legacyEventsHomeImportMarker, true)
+}
+
+// MigrateLegacySessionsFromConfigDir imports v0.x event-log sessions found in
+// the current user config session directory. It uses an independent marker so a
+// previous ~/.reasonix import marker cannot hide sessions from a redirected
+// config root on Windows/macOS.
+func MigrateLegacySessionsFromConfigDir(srcDir, destDir string) (int, error) {
+	return migrateLegacySessions(srcDir, destDir, legacyEventsConfigImportMarker, false)
 }
 
 func migrateLegacySessions(srcDir, destDir, marker string, honorLegacyMarker bool) (int, error) {
@@ -88,7 +97,11 @@ func migrateLegacySessions(srcDir, destDir, marker string, honorLegacyMarker boo
 		}
 		imported++
 	}
-	writeImportMarkers(destDir, marker, legacyImportMarker)
+	markers := []string{marker}
+	if honorLegacyMarker {
+		markers = append(markers, legacyImportMarker)
+	}
+	writeImportMarkers(destDir, markers...)
 	return imported, nil
 }
 

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -155,6 +155,30 @@ func TestMigrateLegacySessionsSourceMarkersAreIndependent(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacyConfigSourceDoesNotBlockHomeSource(t *testing.T) {
+	configSrc := t.TempDir()
+	homeSrc := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(homeSrc, "home-chat.events.jsonl"), []byte(legacyEventLog), 0o644)
+
+	if n, err := MigrateLegacySessionsFromConfigDir(configSrc, dest); err != nil || n != 0 {
+		t.Fatalf("config source without events: n=%d err=%v, want 0 nil", n, err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, legacyEventsConfigImportMarker)); err != nil {
+		t.Fatalf("config source marker missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, legacyImportMarker)); !os.IsNotExist(err) {
+		t.Fatalf("config source must not block the home source with the generic marker, stat err=%v", err)
+	}
+
+	if n, err := MigrateLegacySessions(homeSrc, dest); err != nil || n != 1 {
+		t.Fatalf("home source after config source: n=%d err=%v, want 1 nil", n, err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "home-chat.jsonl")); err != nil {
+		t.Fatalf("home source should still import after config source marker: %v", err)
+	}
+}
+
 func TestMigrateLegacySessionsSkipsAlreadyImported(t *testing.T) {
 	src := t.TempDir()
 	dest := t.TempDir()

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -126,16 +126,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	} else if migrated != nil {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: migrated.Notice()})
 	}
-	// Back-fill v0.x sessions, independent of the config migration. This used to be
-	// nested under the (one-time) config migration above, so a v0.x user who had
-	// already opened v1 never got their old sessions imported (#2869). It is guarded
-	// by its own marker, so running every boot imports any not-yet-imported session
-	// once and is a cheap no-op afterwards.
-	if home, herr := os.UserHomeDir(); herr == nil {
-		if n, serr := agent.MigrateLegacySessions(filepath.Join(home, ".reasonix", "sessions"), config.SessionDir()); serr == nil && n > 0 {
-			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("imported %d past session(s) from ~/.reasonix/sessions — resume them with --resume or the history panel", n)})
-		}
-	}
+	migrateLegacySessionSources(sink)
 
 	// A resolvable model whose API key env is unset would otherwise build fine
 	// (RequireKey is false so the UI stays reachable) and then fail silently on the
@@ -571,6 +562,49 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		ctrlOpts.Classifier = classifier
 	}
 	return control.New(ctrlOpts), nil
+}
+
+func migrateLegacySessionSources(sink event.Sink) {
+	dest := config.SessionDir()
+	if strings.TrimSpace(dest) == "" {
+		return
+	}
+	type legacySource struct {
+		dir     string
+		label   string
+		migrate func(srcDir, destDir string) (int, error)
+	}
+	var sources []legacySource
+	if home, herr := os.UserHomeDir(); herr == nil {
+		sources = append(sources, legacySource{
+			dir:     filepath.Join(home, ".reasonix", "sessions"),
+			label:   "~/.reasonix/sessions",
+			migrate: agent.MigrateLegacySessions,
+		})
+	}
+	// Back-fill v0.x sessions from the current user config session directory as
+	// well. This covers users whose platform config root was redirected before the
+	// Go rewrite; their event logs can already live where v2 stores sessions.
+	sources = append(sources, legacySource{
+		dir:     dest,
+		label:   dest,
+		migrate: agent.MigrateLegacySessionsFromConfigDir,
+	})
+
+	seen := map[string]bool{}
+	for _, src := range sources {
+		if strings.TrimSpace(src.dir) == "" {
+			continue
+		}
+		key := filepath.Clean(src.dir)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		if n, serr := src.migrate(src.dir, dest); serr == nil && n > 0 {
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("imported %d past session(s) from %s — resume them with --resume or the history panel", n, src.label)})
+		}
+	}
 }
 
 func rememberPermissionRule(workspaceRoot, rule string) {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -549,6 +549,57 @@ func TestBuildMigratesLegacyConfigEndToEnd(t *testing.T) {
 	}
 }
 
+func TestBuildMigratesLegacySessionsFromConfigSessionDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	proj := t.TempDir()
+	t.Chdir(proj)
+	writeFile(t, proj, "reasonix.toml", "[codegraph]\nenabled = false\n")
+
+	legacyDir := config.SessionDir()
+	writeFile(t, legacyDir, "custom-root.events.jsonl",
+		`{"type":"user.message","id":1,"ts":"t","turn":0,"text":"hello from redirected config root"}`+"\n"+
+			`{"type":"model.final","id":2,"ts":"t","turn":0,"content":"hi from redirected root","toolCalls":[],"usage":{},"costUsd":0}`+"\n")
+
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+
+	ctrl, err := Build(context.Background(), Options{Sink: sink})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	sessionPath := filepath.Join(config.SessionDir(), "custom-root.jsonl")
+	data, err := os.ReadFile(sessionPath)
+	if err != nil {
+		t.Fatalf("legacy config-root session not imported to %s: %v", sessionPath, err)
+	}
+	if !strings.Contains(string(data), "hello from redirected config root") {
+		t.Fatalf("migrated session missing legacy content:\n%s", data)
+	}
+	if _, err := os.Stat(filepath.Join(config.SessionDir(), ".legacy-imported.v0-events-config")); err != nil {
+		t.Fatalf("config-root legacy import marker missing: %v", err)
+	}
+	sessionImported := false
+	for _, n := range notices {
+		if strings.Contains(n, "imported") && strings.Contains(n, "past session") && strings.Contains(n, legacyDir) {
+			sessionImported = true
+		}
+	}
+	if !sessionImported {
+		t.Errorf("no config-root session-import notice emitted; got %v", notices)
+	}
+}
+
 // isolateConfigHome redirects os.UserConfigDir() (and the cache subtree under
 // it) at a per-test temp dir by overriding the env vars Go's stdlib reads —
 // HOME on darwin, XDG_CONFIG_HOME on linux. Without this, Build's plugin path


### PR DESCRIPTION
## Summary
- import legacy v0.x event logs from the current user config session directory in addition to ~/.reasonix/sessions
- use a separate import marker for config-root session imports so source markers remain independent
- add boot and agent regression coverage, and update the migration guide

## Tests
- go test ./internal/agent -run 'TestMigrateLegacy'\n- go test ./internal/boot -run 'TestBuildMigratesLegacy(ConfigEndToEnd|SessionsFromConfigSessionDir)'\n- go test ./internal/agent ./internal/boot\n\n## Notes\n- go test ./... is blocked locally by machine state: with normal HOME, internal/control reads local MCP config; with isolated HOME/XDG/AppData, only the existing macOS sandbox confinement tests fail (internal/sandbox and internal/tool/builtin).\n