### PR TITLE
为 CLI `reasonix chat` / `reasonix run` 增加可选系统通知。默认关闭，用户在配置中开启后，可在任务完成、等待工具批准、等待用户回答时收到系统通知。feat(cli): add desktop notifications

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/i18n"
+	"reasonix/internal/notify"
 	"reasonix/internal/provider"
 	"reasonix/internal/provider/openai"
 	"reasonix/internal/serve"
@@ -181,6 +182,16 @@ func chdirTo(dir string) int {
 	return 0
 }
 
+var newNotificationSender = func() notify.Sender { return notify.NewPlatformSender() }
+
+// withNotifications adds system notifications to CLI event streams when configured.
+func withNotifications(sink event.Sink, cfg *config.Config) event.Sink {
+	if cfg == nil || !cfg.Notifications.Enabled {
+		return sink
+	}
+	return notify.NewSink(sink, newNotificationSender(), cfg.Notifications)
+}
+
 func runAgent(args []string) int {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	model := fs.String("model", "", "provider name (default: config default_model)")
@@ -194,6 +205,7 @@ func runAgent(args []string) int {
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc
 	}
+	cfg, _ := config.Load()
 	configureCLIThemeFromConfigForTTYOutput()
 
 	prompt := strings.TrimSpace(strings.Join(fs.Args(), " "))
@@ -227,6 +239,7 @@ func runAgent(args []string) int {
 		metrics = &metricsSink{inner: textSink}
 		sink = metrics
 	}
+	sink = withNotifications(sink, cfg)
 	ctrl, err := setup(ctx, *model, *maxSteps, true, sink)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -235,6 +248,9 @@ func runAgent(args []string) int {
 	defer ctrl.Close()
 
 	runErr := ctrl.Run(ctx, prompt)
+	if cfg != nil {
+		notify.SendEvent(newNotificationSender(), cfg.Notifications, event.Event{Kind: event.TurnDone, Err: runErr})
+	}
 	if metrics != nil {
 		if err := writeMetrics(*metricsPath, metrics.m); err != nil {
 			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -312,7 +328,8 @@ func chatREPL(args []string) int {
 	if rc := chdirTo(*dir); rc != 0 {
 		return rc
 	}
-	if cfg, err := config.Load(); err == nil {
+	cfg, err := config.Load()
+	if err == nil {
 		configureCLIThemeWithStyle(cfg.UITheme(), cfg.UIThemeStyle())
 	}
 
@@ -347,7 +364,8 @@ func chatREPL(args []string) int {
 	// agent goroutine.
 	eventCh := make(chan event.Event, 1024)
 
-	sink := &eventSink{ch: eventCh}
+	var sink event.Sink = &eventSink{ch: eventCh}
+	sink = withNotifications(sink, cfg)
 	ctrl, err := setup(ctx, *model, *maxSteps, false, sink)
 	if err != nil && errors.Is(err, boot.ErrUnknownModel) && isInteractive() && config.SourcePath() == "" {
 		// True first run whose default model can't resolve: guide setup, then retry.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"reasonix/internal/config"
+	"reasonix/internal/event"
+	"reasonix/internal/notify"
 	"reasonix/internal/provider"
 )
 
@@ -219,6 +221,54 @@ func TestWelcomePromptMissingKeysRequiresConfigSource(t *testing.T) {
 	}
 	if !welcomeShouldPromptMissingKeys("reasonix.toml", nil) {
 		t.Fatal("valid config source should enter the missing-key prompt path")
+	}
+}
+
+type cliRecordSink struct {
+	events []event.Kind
+}
+
+func (s *cliRecordSink) Emit(e event.Event) {
+	s.events = append(s.events, e.Kind)
+}
+
+type cliRecordSender struct {
+	messages []notify.Message
+}
+
+func (s *cliRecordSender) Send(m notify.Message) error {
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func TestWithNotificationsWrapsCLISinkWithConfiguredSender(t *testing.T) {
+	inner := &cliRecordSink{}
+	sender := &cliRecordSender{}
+	calls := 0
+	prev := newNotificationSender
+	newNotificationSender = func() notify.Sender {
+		calls++
+		return sender
+	}
+	t.Cleanup(func() { newNotificationSender = prev })
+
+	cfg := config.Default()
+	cfg.Notifications.Enabled = true
+
+	wrapped := withNotifications(inner, cfg)
+	wrapped.Emit(event.Event{Kind: event.TurnDone})
+
+	if calls != 1 {
+		t.Fatalf("newNotificationSender calls = %d, want 1", calls)
+	}
+	if len(inner.events) != 1 || inner.events[0] != event.TurnDone {
+		t.Fatalf("forwarded events = %v, want [TurnDone]", inner.events)
+	}
+	if len(sender.messages) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(sender.messages))
+	}
+	if sender.messages[0].Body != "Turn finished" {
+		t.Fatalf("notification body = %q, want Turn finished", sender.messages[0].Body)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,22 +39,23 @@ func SkillNameKey(name string) string {
 
 // Config is Reasonix's runtime configuration.
 type Config struct {
-	ConfigVersion int               `toml:"config_version"`
-	DefaultModel  string            `toml:"default_model"`
-	Language      string            `toml:"language"` // ui/model language tag (e.g. "zh"); empty = auto-detect from $LANG / $REASONIX_LANG
-	UI            UIConfig          `toml:"ui"`
-	Desktop       DesktopConfig     `toml:"desktop"`
-	Agent         AgentConfig       `toml:"agent"`
-	Providers     []ProviderEntry   `toml:"providers"`
-	Tools         ToolsConfig       `toml:"tools"`
-	Permissions   PermissionsConfig `toml:"permissions"`
-	Sandbox       SandboxConfig     `toml:"sandbox"`
-	Network       NetworkConfig     `toml:"network"`
-	Plugins       []PluginEntry     `toml:"plugins"`
-	Skills        SkillsConfig      `toml:"skills"`
-	Codegraph     CodegraphConfig   `toml:"codegraph"`
-	Statusline    StatuslineConfig  `toml:"statusline"`
-	LSP           LSPConfig         `toml:"lsp"`
+	ConfigVersion int                 `toml:"config_version"`
+	DefaultModel  string              `toml:"default_model"`
+	Language      string              `toml:"language"` // ui/model language tag (e.g. "zh"); empty = auto-detect from $LANG / $REASONIX_LANG
+	UI            UIConfig            `toml:"ui"`
+	Desktop       DesktopConfig       `toml:"desktop"`
+	Notifications NotificationsConfig `toml:"notifications"`
+	Agent         AgentConfig         `toml:"agent"`
+	Providers     []ProviderEntry     `toml:"providers"`
+	Tools         ToolsConfig         `toml:"tools"`
+	Permissions   PermissionsConfig   `toml:"permissions"`
+	Sandbox       SandboxConfig       `toml:"sandbox"`
+	Network       NetworkConfig       `toml:"network"`
+	Plugins       []PluginEntry       `toml:"plugins"`
+	Skills        SkillsConfig        `toml:"skills"`
+	Codegraph     CodegraphConfig     `toml:"codegraph"`
+	Statusline    StatuslineConfig    `toml:"statusline"`
+	LSP           LSPConfig           `toml:"lsp"`
 }
 
 // UIConfig controls CLI presentation-only settings. Desktop appearance is kept in
@@ -73,6 +74,14 @@ type DesktopConfig struct {
 	Theme         string `toml:"theme"`          // auto|dark|light; empty resolves to dark
 	ThemeStyle    string `toml:"theme_style"`    // graphite|ember|aurora|midnight|sandstone|porcelain|linen|glacier
 	CloseBehavior string `toml:"close_behavior"` // quit|background; desktop window close behavior
+}
+
+// NotificationsConfig controls optional system notifications for CLI chat/run.
+type NotificationsConfig struct {
+	Enabled         bool `toml:"enabled"`
+	TurnDone        bool `toml:"turn_done"`
+	ApprovalRequest bool `toml:"approval_request"`
+	AskRequest      bool `toml:"ask_request"`
 }
 
 // UITheme normalizes ui.theme to a supported value.
@@ -626,6 +635,12 @@ func Default() *Config {
 		ConfigVersion: 2,
 		DefaultModel:  "deepseek-flash",
 		UI:            UIConfig{Theme: "auto"},
+		Notifications: NotificationsConfig{
+			Enabled:         false,
+			TurnDone:        true,
+			ApprovalRequest: true,
+			AskRequest:      true,
+		},
 		Agent: AgentConfig{
 			SystemPrompt: DefaultSystemPrompt,
 			// 0 = no step cap: the agent loops until the model gives a final answer,

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -81,6 +81,13 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		}
 		fmt.Fprintf(&b, "close_behavior = %q   # desktop: quit|background when the window close button is clicked\n", c.DesktopCloseBehavior())
 		b.WriteString("\n")
+
+		b.WriteString("[notifications]\n")
+		fmt.Fprintf(&b, "enabled = %v   # system notifications for CLI chat/run; default off\n", c.Notifications.Enabled)
+		fmt.Fprintf(&b, "turn_done = %v   # notify when a turn finishes\n", c.Notifications.TurnDone)
+		fmt.Fprintf(&b, "approval_request = %v   # notify when a tool approval is waiting\n", c.Notifications.ApprovalRequest)
+		fmt.Fprintf(&b, "ask_request = %v   # notify when a question is waiting\n", c.Notifications.AskRequest)
+		b.WriteString("\n")
 	}
 
 	if shouldRenderNetwork(c, defaults, scope) {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -19,6 +19,10 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Desktop.Theme = "dark"
 	orig.Desktop.ThemeStyle = "graphite"
 	orig.Desktop.CloseBehavior = "background"
+	orig.Notifications.Enabled = true
+	orig.Notifications.TurnDone = true
+	orig.Notifications.ApprovalRequest = true
+	orig.Notifications.AskRequest = true
 	orig.Agent.AutoPlanClassifier = "deepseek-flash"
 	orig.Agent.SubagentModel = "mimo-pro"
 	orig.Agent.SubagentModels = map[string]string{"review": "deepseek-pro"}
@@ -83,6 +87,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Desktop.CloseBehavior != "background" {
 		t.Errorf("desktop.close_behavior = %q, want background", got.Desktop.CloseBehavior)
+	}
+	if !got.Notifications.Enabled || !got.Notifications.TurnDone || !got.Notifications.ApprovalRequest || !got.Notifications.AskRequest {
+		t.Errorf("notifications not preserved: %+v", got.Notifications)
 	}
 	if got.Agent.MaxSteps != orig.Agent.MaxSteps {
 		t.Errorf("max_steps = %d, want %d", got.Agent.MaxSteps, orig.Agent.MaxSteps)
@@ -171,6 +178,23 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 }
 
+func TestNotificationsDefaultsKeepEventSwitchesEnabled(t *testing.T) {
+	cfg := Default()
+	if cfg.Notifications.Enabled {
+		t.Fatal("notifications.enabled default = true, want false")
+	}
+	if !cfg.Notifications.TurnDone || !cfg.Notifications.ApprovalRequest || !cfg.Notifications.AskRequest {
+		t.Fatalf("notification event switches default off: %+v", cfg.Notifications)
+	}
+
+	if _, err := toml.Decode("[notifications]\nenabled = true\n", cfg); err != nil {
+		t.Fatalf("decode notifications: %v", err)
+	}
+	if !cfg.Notifications.Enabled || !cfg.Notifications.TurnDone || !cfg.Notifications.ApprovalRequest || !cfg.Notifications.AskRequest {
+		t.Fatalf("enabled-only config should keep event switches on: %+v", cfg.Notifications)
+	}
+}
+
 func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	c := Default()
 	c.Language = "zh"
@@ -180,14 +204,14 @@ func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	c.Desktop.CloseBehavior = "background"
 
 	user := RenderTOMLForScope(c, RenderScopeUser)
-	for _, want := range []string{"config_version = 2", "[desktop]", `theme = "dark"`, `close_behavior = "background"`} {
+	for _, want := range []string{"config_version = 2", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, "[notifications]"} {
 		if !strings.Contains(user, want) {
 			t.Fatalf("user render missing %q:\n%s", want, user)
 		}
 	}
 
 	project := RenderTOMLForScope(c, RenderScopeProject)
-	for _, forbidden := range []string{"[desktop]", "close_behavior ="} {
+	for _, forbidden := range []string{"[desktop]", "[notifications]", "close_behavior ="} {
 		if strings.Contains(project, forbidden) {
 			t.Fatalf("project render should not contain %q:\n%s", forbidden, project)
 		}

--- a/internal/notify/sender_darwin.go
+++ b/internal/notify/sender_darwin.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+package notify
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// PlatformSender delivers notifications through the host OS.
+type PlatformSender struct{}
+
+// NewPlatformSender returns the best-effort sender for the current platform.
+func NewPlatformSender() PlatformSender { return PlatformSender{} }
+
+func (PlatformSender) Send(m Message) error {
+	script := `display notification "` + appleScriptString(m.Body) + `" with title "` + appleScriptString(m.Title) + `"`
+	cmd := exec.Command("osascript", "-e", script)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() { _ = cmd.Wait() }()
+	return nil
+}
+
+func appleScriptString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	return strings.ReplaceAll(s, `"`, `\"`)
+}

--- a/internal/notify/sender_linux.go
+++ b/internal/notify/sender_linux.go
@@ -1,0 +1,20 @@
+//go:build linux
+
+package notify
+
+import "os/exec"
+
+// PlatformSender delivers notifications through the host OS.
+type PlatformSender struct{}
+
+// NewPlatformSender returns the best-effort sender for the current platform.
+func NewPlatformSender() PlatformSender { return PlatformSender{} }
+
+func (PlatformSender) Send(m Message) error {
+	cmd := exec.Command("notify-send", m.Title, m.Body)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() { _ = cmd.Wait() }()
+	return nil
+}

--- a/internal/notify/sender_other.go
+++ b/internal/notify/sender_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux && !windows
+
+package notify
+
+// PlatformSender delivers notifications through the host OS.
+type PlatformSender struct{}
+
+// NewPlatformSender returns the best-effort sender for the current platform.
+func NewPlatformSender() PlatformSender { return PlatformSender{} }
+
+func (PlatformSender) Send(Message) error { return nil }

--- a/internal/notify/sender_windows.go
+++ b/internal/notify/sender_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package notify
+
+import "os/exec"
+
+// PlatformSender delivers notifications through the host OS.
+type PlatformSender struct{}
+
+// NewPlatformSender returns the best-effort sender for the current platform.
+func NewPlatformSender() PlatformSender { return PlatformSender{} }
+
+func (PlatformSender) Send(m Message) error {
+	cmd := exec.Command("powershell", "-NoProfile", "-Command", `
+if (Get-Command New-BurntToastNotification -ErrorAction SilentlyContinue) {
+  New-BurntToastNotification -Text $args[0], $args[1]
+} elseif (Get-Command msg -ErrorAction SilentlyContinue) {
+  msg $env:USERNAME ($args[0] + ': ' + $args[1])
+}
+`, m.Title, m.Body)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	go func() { _ = cmd.Wait() }()
+	return nil
+}

--- a/internal/notify/sink.go
+++ b/internal/notify/sink.go
@@ -1,0 +1,68 @@
+package notify
+
+import (
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+)
+
+// Message is the user-visible payload sent to the platform notifier.
+type Message struct {
+	Title string
+	Body  string
+}
+
+// Sender delivers a notification without taking ownership of event routing.
+type Sender interface {
+	Send(Message) error
+}
+
+// Sink forwards every event to inner and mirrors configured attention events to sender.
+type Sink struct {
+	inner  event.Sink
+	sender Sender
+	cfg    config.NotificationsConfig
+}
+
+// NewSink wraps an existing event sink with best-effort notification delivery.
+func NewSink(inner event.Sink, sender Sender, cfg config.NotificationsConfig) *Sink {
+	return &Sink{inner: inner, sender: sender, cfg: cfg}
+}
+
+// Emit preserves the underlying event stream before attempting notification side effects.
+func (s *Sink) Emit(e event.Event) {
+	if s.inner != nil {
+		s.inner.Emit(e)
+	}
+	SendEvent(s.sender, s.cfg, e)
+}
+
+// SendEvent applies the same notification rules for paths that do not emit through Sink.
+func SendEvent(sender Sender, cfg config.NotificationsConfig, e event.Event) {
+	if !cfg.Enabled || sender == nil {
+		return
+	}
+	if msg, ok := message(cfg, e); ok {
+		_ = sender.Send(msg)
+	}
+}
+
+func message(cfg config.NotificationsConfig, e event.Event) (Message, bool) {
+	switch e.Kind {
+	case event.TurnDone:
+		if cfg.TurnDone {
+			if e.Err != nil {
+				return Message{Title: "Reasonix", Body: "Turn failed"}, true
+			}
+			return Message{Title: "Reasonix", Body: "Turn finished"}, true
+		}
+	case event.ApprovalRequest:
+		if cfg.ApprovalRequest {
+			return Message{Title: "Reasonix", Body: "Approval needed"}, true
+		}
+	case event.AskRequest:
+		if cfg.AskRequest {
+			return Message{Title: "Reasonix", Body: "Question needs your answer"}, true
+		}
+	}
+	return Message{}, false
+}

--- a/internal/notify/sink_test.go
+++ b/internal/notify/sink_test.go
@@ -1,0 +1,126 @@
+package notify
+
+import (
+	"errors"
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+)
+
+var errTestFailure = errors.New("failed")
+
+type recordSink struct {
+	events []event.Kind
+}
+
+func (s *recordSink) Emit(e event.Event) {
+	s.events = append(s.events, e.Kind)
+}
+
+type recordSender struct {
+	messages []Message
+}
+
+func (s *recordSender) Send(m Message) error {
+	s.messages = append(s.messages, m)
+	return nil
+}
+
+func TestSinkForwardsEventsAndSendsConfiguredNotifications(t *testing.T) {
+	inner := &recordSink{}
+	sender := &recordSender{}
+	sink := NewSink(inner, sender, config.NotificationsConfig{
+		Enabled:         true,
+		TurnDone:        true,
+		ApprovalRequest: true,
+		AskRequest:      true,
+	})
+
+	sink.Emit(event.Event{Kind: event.ApprovalRequest})
+	sink.Emit(event.Event{Kind: event.AskRequest})
+	sink.Emit(event.Event{Kind: event.TurnDone})
+
+	if len(inner.events) != 3 {
+		t.Fatalf("forwarded events = %d, want 3", len(inner.events))
+	}
+	if len(sender.messages) != 3 {
+		t.Fatalf("notifications = %d, want 3", len(sender.messages))
+	}
+	if sender.messages[0].Body != "Approval needed" {
+		t.Errorf("approval notification body = %q", sender.messages[0].Body)
+	}
+	if sender.messages[1].Body != "Question needs your answer" {
+		t.Errorf("ask notification body = %q", sender.messages[1].Body)
+	}
+	if sender.messages[2].Body != "Turn finished" {
+		t.Errorf("turn notification body = %q", sender.messages[2].Body)
+	}
+}
+
+func TestSinkSkipsNotificationsWhenDisabled(t *testing.T) {
+	inner := &recordSink{}
+	sender := &recordSender{}
+	sink := NewSink(inner, sender, config.NotificationsConfig{
+		Enabled:         false,
+		TurnDone:        true,
+		ApprovalRequest: true,
+		AskRequest:      true,
+	})
+
+	sink.Emit(event.Event{Kind: event.TurnDone})
+
+	if len(inner.events) != 1 {
+		t.Fatalf("forwarded events = %d, want 1", len(inner.events))
+	}
+	if len(sender.messages) != 0 {
+		t.Fatalf("notifications = %d, want 0", len(sender.messages))
+	}
+}
+
+func TestSendEventUsesSameNotificationRules(t *testing.T) {
+	sender := &recordSender{}
+
+	SendEvent(sender, config.NotificationsConfig{Enabled: true, TurnDone: true}, event.Event{Kind: event.TurnDone})
+
+	if len(sender.messages) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(sender.messages))
+	}
+	if sender.messages[0].Body != "Turn finished" {
+		t.Errorf("notification body = %q", sender.messages[0].Body)
+	}
+}
+
+func TestTurnDoneWithErrorSendsFailureNotification(t *testing.T) {
+	sender := &recordSender{}
+
+	SendEvent(sender, config.NotificationsConfig{Enabled: true, TurnDone: true}, event.Event{Kind: event.TurnDone, Err: errTestFailure})
+
+	if len(sender.messages) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(sender.messages))
+	}
+	if sender.messages[0].Body != "Turn failed" {
+		t.Errorf("notification body = %q", sender.messages[0].Body)
+	}
+}
+
+func TestSinkHonorsPerEventConfig(t *testing.T) {
+	sender := &recordSender{}
+	sink := NewSink(&recordSink{}, sender, config.NotificationsConfig{
+		Enabled:         true,
+		TurnDone:        false,
+		ApprovalRequest: true,
+		AskRequest:      false,
+	})
+
+	sink.Emit(event.Event{Kind: event.TurnDone})
+	sink.Emit(event.Event{Kind: event.ApprovalRequest})
+	sink.Emit(event.Event{Kind: event.AskRequest})
+
+	if len(sender.messages) != 1 {
+		t.Fatalf("notifications = %d, want 1", len(sender.messages))
+	}
+	if sender.messages[0].Body != "Approval needed" {
+		t.Errorf("notification body = %q", sender.messages[0].Body)
+	}
+}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -9,6 +9,12 @@ default_model = "deepseek"   # a provider name (→ its default model) or "provi
 theme = "auto"   # auto|dark|light; controls CLI colors only; REASONIX_THEME can override per run
 # theme_style = "graphite"   # graphite|ember|aurora|midnight|sandstone|porcelain|linen|glacier
 
+[notifications]
+enabled = false   # system notifications for CLI chat/run; default off
+turn_done = true   # notify when a turn finishes
+approval_request = true   # notify when a tool approval is waiting
+ask_request = true   # notify when a question is waiting
+
 [agent]
 system_prompt = """
 You are Reasonix, a coding agent focused on executing code tasks.


### PR DESCRIPTION
为 CLI `reasonix chat` / `reasonix run` 增加可选系统通知。默认关闭，用户显式配置后，在任务完成、等待工具批准、等待用户回答时发送系统通知。 
Closes #3190 
## 问题

  在 VS Code 终端或普通终端中使用 `reasonix chat/run`
  时，任务可能运行较久，或者中途阻塞在用户输入上。当前终端内会有状态变化，但没有外部提醒，用户必须一直盯着终端才能及时知道：

  - 任务已经完成
  - 工具调用正在等待批准
  - `ask` 问题正在等待回答

  这类问题不需要改变 agent 推理逻辑，本质上是 CLI/TUI 的注意力提醒能力缺失。

  ## 设计判断

  Reasonix 已经有完整的事件流，相关语义也已经存在：

  - `TurnDone`：一轮任务结束
  - `ApprovalRequest`：等待用户批准工具调用
  - `AskRequest`：等待用户回答结构化问题

  所以这个 PR 没有新增 agent 核心状态，也没有改变 controller 的事件语义，而是在 CLI 边界把已有事件转成系统通知。

  这样做的好处是：

  - 复用现有 `event.Sink` 机制，改动集中在 CLI 边界
  - 默认关闭，不改变现有用户体验
  - 配置开启后，`chat` 和 `run` 都能获得一致的提醒能力
  - hooks 仍然保留给高级用户做自定义通知、声音、Webhook 等扩展

  ## 改动

  新增用户级配置：

  ```toml
  [notifications]
  enabled = false   # system notifications for CLI chat/run; default off
  turn_done = true
  approval_request = true
  ask_request = true
  ```
  说明：

  - enabled = false 保持默认无感。
  - 只配置 enabled = true 时，三类通知默认开启。
  - [notifications] 不写入 project-scope 配置，因为这是用户机器上的提醒偏好，不是项目行为。

  新增 internal/notify：

  - Sink 包装已有 event.Sink
  - 先转发原事件，再按配置发送系统通知
  - 通知发送 best-effort，失败不会影响主流程

  平台实现：

  - macOS：osascript display notification
  - Linux：notify-send
  - Windows：best-effort New-BurntToastNotification / msg
  - 其他平台：no-op

  chat 和 run 的差异

  reasonix chat 是异步 TUI 流程，controller 本身会 emit TurnDone，所以通知 sink 可以直接从事件流中处理：

  - TurnDone
  - ApprovalRequest
  - AskRequest

  reasonix run 是同步执行流程。当前 Controller.Run(...) 的语义是返回 exit status，不 emit TurnDone。因此：

  - ApprovalRequest / AskRequest 仍通过 sink 处理
  - run 结束后的完成/失败通知由 runAgent 显式发送

  这样保留了 Controller.Run 的既有语义，没有为了通知功能改动核心 controller 行为。

  不影响 desktop app

  desktop app 也会消费 agent 事件，但它有自己的 Wails/webview 事件通道和应用内 notice/card 展示。本 PR 没有接入 desktop app 的 event sink，也没有改变
  desktop 的通知行为。

  因此这个改动只影响 CLI reasonix chat/run。

  测试

  补充并运行了相关测试：

  go test ./internal/notify ./internal/config ./internal/cli

  覆盖点包括：

  - 通知 sink 会转发原事件
  - enabled = false 时不通知
  - 单个事件开关可以独立关闭
  - TurnDone 成功/失败分别通知
  - 只配置 enabled = true 时，三类事件开关仍默认开启
  - user-scope config 会渲染 [notifications]
  - project-scope config 不渲染 [notifications]

  同时运行：

  git diff --check

  无空白问题。


