### PR TITLE
Stream workspace media previews

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3,8 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"mime"
+	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -65,12 +70,177 @@ type App struct {
 	forceQuit atomic.Bool
 	trayReady bool
 	tray      *desktopTray
+
+	mediaTokens *mediaTokenStore
+}
+
+// mediaTokenEntry holds metadata for a workspace media file served via temporary URL.
+type mediaTokenEntry struct {
+	absPath   string
+	filename  string
+	mime      string
+	kind      string
+	size      int64
+	modTime   time.Time
+	createdAt time.Time
+	expiresAt time.Time
+}
+
+// mediaTokenStore manages temporary tokens that grant access to workspace files
+// through the AssetServer middleware. Tokens expire after a fixed TTL and are
+// capped at a maximum count; creating a new token evicts the oldest entry when
+// the store is full.
+type mediaTokenStore struct {
+	mu    sync.Mutex
+	byTok map[string]*mediaTokenEntry
+	order []string // oldest first
+	maxN  int
+	ttl   time.Duration
+}
+
+const mediaTokenMax = 256
+
+func newMediaTokenStore() *mediaTokenStore {
+	return &mediaTokenStore{
+		byTok: map[string]*mediaTokenEntry{},
+		maxN:  mediaTokenMax,
+		ttl:   10 * time.Minute,
+	}
+}
+
+func (s *mediaTokenStore) cleanupLocked() {
+	now := time.Now()
+	for len(s.order) > 0 {
+		tok := s.order[0]
+		e := s.byTok[tok]
+		if e == nil {
+			s.order = s.order[1:]
+			continue
+		}
+		if !now.Before(e.expiresAt) {
+			delete(s.byTok, tok)
+			s.order = s.order[1:]
+			continue
+		}
+		break
+	}
+	for len(s.order) > s.maxN {
+		oldest := s.order[0]
+		delete(s.byTok, oldest)
+		s.order = s.order[1:]
+	}
+}
+
+func (s *mediaTokenStore) create(absPath, filename, mime, kind string, size int64, modTime time.Time) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.cleanupLocked()
+
+	tok := make([]byte, 16)
+	if _, err := rand.Read(tok); err != nil {
+		panic("crypto/rand.Read failed: " + err.Error())
+	}
+	token := hex.EncodeToString(tok)
+
+	now := time.Now()
+	s.byTok[token] = &mediaTokenEntry{
+		absPath:   absPath,
+		filename:  filename,
+		mime:      mime,
+		kind:      kind,
+		size:      size,
+		modTime:   modTime,
+		createdAt: now,
+		expiresAt: now.Add(s.ttl),
+	}
+	s.order = append(s.order, token)
+
+	// Trim oldest if the new token pushed us over the limit.
+	for len(s.order) > s.maxN {
+		oldest := s.order[0]
+		delete(s.byTok, oldest)
+		s.order = s.order[1:]
+	}
+
+	return token
+}
+
+func (s *mediaTokenStore) get(token string) *mediaTokenEntry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e := s.byTok[token]
+	if e == nil {
+		return nil
+	}
+	if time.Now().After(e.expiresAt) {
+		delete(s.byTok, token)
+		return nil
+	}
+	return e
+}
+
+func (a *App) ensureMediaTokenStore() *mediaTokenStore {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.mediaTokens == nil {
+		a.mediaTokens = newMediaTokenStore()
+	}
+	return a.mediaTokens
+}
+
+// workspaceMediaMiddleware returns an HTTP middleware that intercepts
+// /__reasonix_workspace_media/{token}/{filename} requests and serves the
+// corresponding workspace file. All other paths pass through to the Wails
+// default asset handler unchanged.
+func (a *App) workspaceMediaMiddleware() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			prefix := "/__reasonix_workspace_media/"
+			if !strings.HasPrefix(r.URL.Path, prefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if r.Method != http.MethodGet && r.Method != http.MethodHead {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+
+			rest := strings.TrimPrefix(r.URL.Path, prefix)
+			parts := strings.SplitN(rest, "/", 2)
+			if len(parts) == 0 || parts[0] == "" {
+				http.NotFound(w, r)
+				return
+			}
+			token := parts[0]
+
+			entry := a.ensureMediaTokenStore().get(token)
+			if entry == nil {
+				http.NotFound(w, r)
+				return
+			}
+
+			f, err := os.Open(entry.absPath)
+			if err != nil {
+				http.NotFound(w, r)
+				return
+			}
+			defer f.Close()
+
+			w.Header().Set("Content-Type", entry.mime)
+			w.Header().Set("Content-Disposition", mime.FormatMediaType("inline", map[string]string{"filename": entry.filename}))
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			w.Header().Set("Cache-Control", "private, max-age=600")
+			http.ServeContent(w, r, entry.filename, entry.modTime, f)
+		})
+	}
 }
 
 // NewApp constructs the bound object. Tabs are restored in startup from the
 // last session's desktop-tabs.json.
 func NewApp() *App {
-	return &App{tabs: map[string]*WorkspaceTab{}}
+	return &App{tabs: map[string]*WorkspaceTab{}, mediaTokens: newMediaTokenStore()}
 }
 
 func (a *App) bootContext() context.Context {
@@ -2447,6 +2617,9 @@ type FilePreview struct {
 	Size      int64  `json:"size"`
 	Truncated bool   `json:"truncated"`
 	Binary    bool   `json:"binary"`
+	Kind      string `json:"kind,omitempty"`
+	Mime      string `json:"mime,omitempty"`
+	URL       string `json:"url,omitempty"`
 	Err       string `json:"err,omitempty"`
 }
 
@@ -2472,6 +2645,17 @@ var atSkip = map[string]bool{".git": true, "node_modules": true, ".DS_Store": tr
 const filePreviewLimit = 256 * 1024
 const fileRefSearchLimit = 20
 
+var previewMediaMIMEs = map[string]string{
+	".bmp":  "image/bmp",
+	".gif":  "image/gif",
+	".jpeg": "image/jpeg",
+	".jpg":  "image/jpeg",
+	".pdf":  "application/pdf",
+	".png":  "image/png",
+	".svg":  "image/svg+xml",
+	".webp": "image/webp",
+}
+
 func trimUTF8PartialSuffix(data []byte) []byte {
 	if utf8.Valid(data) {
 		return data
@@ -2486,6 +2670,20 @@ func trimUTF8PartialSuffix(data []byte) []byte {
 		return data[:i]
 	}
 	return data
+}
+
+func previewMediaKind(path string) (kind string, mime string) {
+	mime = previewMediaMIMEs[strings.ToLower(filepath.Ext(path))]
+	if mime == "" {
+		return "", ""
+	}
+	if strings.HasPrefix(mime, "image/") {
+		return "image", mime
+	}
+	if mime == "application/pdf" {
+		return "pdf", mime
+	}
+	return "", ""
 }
 
 func (a *App) activeWorkspaceBase() (string, error) {
@@ -2613,6 +2811,13 @@ func (a *App) ReadFile(rel string) FilePreview {
 		return out
 	}
 	out.Size = info.Size()
+	if kind, mime := previewMediaKind(path); kind != "" {
+		token := a.ensureMediaTokenStore().create(path, info.Name(), mime, kind, info.Size(), info.ModTime())
+		out.Kind = kind
+		out.Mime = mime
+		out.URL = "/__reasonix_workspace_media/" + token + "/" + url.PathEscape(info.Name())
+		return out
+	}
 	f, err := os.Open(path)
 	if err != nil {
 		out.Err = err.Error()

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -111,6 +111,27 @@ function languageFor(path: string): string | undefined {
   return byExt[ext];
 }
 
+function renderMediaPreview(preview: FilePreview): JSX.Element | null {
+  if (!preview.url) return null;
+  if (preview.kind === "image") {
+    return (
+      <div className="workspace-media workspace-media--image">
+        <img src={preview.url} alt={basename(preview.path)} decoding="async" />
+      </div>
+    );
+  }
+  if (preview.kind === "pdf") {
+    return (
+      <iframe
+        className="workspace-media workspace-media--pdf"
+        src={preview.url}
+        title={basename(preview.path)}
+      />
+    );
+  }
+  return null;
+}
+
 function fenceFor(text: string): string {
   let longest = 0;
   for (const match of text.matchAll(/`+/g)) {
@@ -507,7 +528,7 @@ export function WorkspacePanel({
   };
 
   const openSelectionMenu = (event: ReactMouseEvent<HTMLDivElement>) => {
-    if (!selectedPath || loadingPreview || preview?.err || preview?.binary) return;
+    if (!selectedPath || loadingPreview || preview?.err || preview?.binary || preview?.kind) return;
     const text = selectedTextFromPreview();
     if (text.trim() === "") return;
     event.preventDefault();
@@ -558,7 +579,7 @@ export function WorkspacePanel({
     setTreeMenu(null);
     try {
       const file = await app.ReadFile(target.path);
-      if (file.err || file.binary) {
+      if (file.err || file.binary || file.kind) {
         onAddToChat?.(formatWorkspaceReference(target.path, false));
         return;
       }
@@ -777,6 +798,8 @@ export function WorkspacePanel({
             <div className="workspace-empty">{t("workspace.loading")}</div>
           ) : preview?.err ? (
             <div className="workspace-empty workspace-empty--error">{preview.err}</div>
+          ) : preview?.kind ? (
+            renderMediaPreview(preview)
           ) : preview?.binary ? (
             <div className="workspace-empty">{t("workspace.binary")}</div>
           ) : preview ? (

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -269,6 +269,9 @@ export interface FilePreview {
   size: number;
   truncated: boolean;
   binary: boolean;
+  kind?: "image" | "pdf";
+  mime?: string;
+  url?: string;
   err?: string;
 }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3368,6 +3368,29 @@ a[href] {
 .workspace-preview__body .code {
   min-width: 0;
 }
+.workspace-media {
+  box-sizing: border-box;
+  width: 100%;
+}
+.workspace-media--image {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 100%;
+}
+.workspace-media--image img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+}
+.workspace-media--pdf {
+  display: block;
+  height: 100%;
+  min-height: 520px;
+  border: 0;
+  background: var(--bg);
+}
 .workspace-note {
   margin-bottom: 10px;
   padding: 6px 9px;

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -59,7 +59,7 @@ func main() {
 		// Match the dark UI shell so the initial webview background doesn't flash
 		// white before CSS loads — particularly visible on WebKitGTK.
 		BackgroundColour:   &options.RGBA{R: 26, G: 26, B: 46, A: 255},
-		AssetServer:        &assetserver.Options{Assets: assets},
+		AssetServer:        &assetserver.Options{Assets: assets, Middleware: app.workspaceMediaMiddleware()},
 		OnStartup:          app.startup,
 		OnDomReady:         app.domReady,
 		OnBeforeClose:      app.beforeClose,

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -1,11 +1,15 @@
 package main
 
 import (
+	"mime"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"golang.org/x/text/encoding/simplifiedchinese"
 )
@@ -138,6 +142,365 @@ func TestReadFilePreviewBinaryClassification(t *testing.T) {
 	}
 	if !strings.ContainsRune(p.Body, '�') {
 		t.Errorf("lossy decode should mark undecodable bytes with U+FFFD, got %q", p.Body)
+	}
+}
+
+func TestReadFileMediaPreview(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	png := []byte("\x89PNG\r\n\x1a\npreview")
+	if err := os.WriteFile("shot.PNG", png, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var app App
+	image := app.ReadFile("shot.PNG")
+	if image.Err != "" {
+		t.Fatalf("ReadFile png err = %q", image.Err)
+	}
+	if image.Binary || image.Kind != "image" || image.Mime != "image/png" {
+		t.Fatalf("ReadFile png = %+v, want image preview", image)
+	}
+	if image.Body != "" {
+		t.Fatalf("media preview should have empty body, got %q", image.Body)
+	}
+	if !strings.HasPrefix(image.URL, "/__reasonix_workspace_media/") || !strings.HasSuffix(image.URL, "/shot.PNG") {
+		t.Fatalf("unexpected media URL: %q", image.URL)
+	}
+
+	if err := os.WriteFile("report.pdf", []byte("%PDF-1.4\npreview"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pdf := app.ReadFile("report.pdf")
+	if pdf.Err != "" {
+		t.Fatalf("ReadFile pdf err = %q", pdf.Err)
+	}
+	if pdf.Binary || pdf.Kind != "pdf" || pdf.Mime != "application/pdf" {
+		t.Fatalf("ReadFile pdf = %+v, want pdf preview", pdf)
+	}
+	if pdf.Body != "" {
+		t.Fatalf("media preview should have empty body, got %q", pdf.Body)
+	}
+	if !strings.HasPrefix(pdf.URL, "/__reasonix_workspace_media/") || !strings.HasSuffix(pdf.URL, "/report.pdf") {
+		t.Fatalf("unexpected media URL: %q", pdf.URL)
+	}
+}
+
+func TestMediaTokenHandlerServesFile(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	png := []byte("\x89PNG\r\n\x1a\npreview-data")
+	if err := os.WriteFile("shot.PNG", png, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	preview := app.ReadFile("shot.PNG")
+	if preview.URL == "" {
+		t.Fatal("expected URL in media preview")
+	}
+
+	mw := app.workspaceMediaMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("fallback handler should not be called for media URLs")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, preview.URL, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+		t.Fatalf("expected Content-Type image/png, got %q", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "inline") {
+		t.Fatalf("expected inline Content-Disposition, got %q", cd)
+	}
+	if rec.Body.String() != string(png) {
+		t.Fatalf("body mismatch, got %q", rec.Body.String())
+	}
+}
+
+func TestMediaTokenHandlerEscapedFilename(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	name := `weird "file" name.png`
+	if err := os.WriteFile(name, []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	preview := app.ReadFile(name)
+	if strings.Contains(preview.URL, " ") || strings.Contains(preview.URL, `"`) {
+		t.Fatalf("media URL should path-escape filename, got %q", preview.URL)
+	}
+
+	handler := app.workspaceMediaMiddleware()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("fallback handler should not be called")
+	}))
+	req := httptest.NewRequest(http.MethodGet, preview.URL, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	disposition, params, err := mime.ParseMediaType(rec.Header().Get("Content-Disposition"))
+	if err != nil {
+		t.Fatalf("Content-Disposition should parse: %v", err)
+	}
+	if disposition != "inline" || params["filename"] != name {
+		t.Fatalf("Content-Disposition = %q %#v, want inline filename %q", disposition, params, name)
+	}
+}
+
+func TestMediaTokenHandlerHead(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile("doc.pdf", []byte("%PDF-test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	preview := app.ReadFile("doc.pdf")
+
+	mw := app.workspaceMediaMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("fallback handler should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodHead, preview.URL, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/pdf" {
+		t.Fatalf("expected Content-Type application/pdf, got %q", ct)
+	}
+}
+
+func TestMediaTokenHandlerRangeRequest(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	data := []byte("0123456789ABCDEF")
+	if err := os.WriteFile("data.png", data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	preview := app.ReadFile("data.png")
+
+	mw := app.workspaceMediaMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("fallback should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, preview.URL, nil)
+	req.Header.Set("Range", "bytes=0-4")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("expected 206, got %d", rec.Code)
+	}
+	if rec.Body.String() != "01234" {
+		t.Fatalf("expected '01234', got %q", rec.Body.String())
+	}
+}
+
+func TestMediaTokenHandlerBadToken(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	mw := app.workspaceMediaMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/__reasonix_workspace_media/deadbeef/fake.png", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for bad token, got %d", rec.Code)
+	}
+}
+
+func TestMediaTokenHandlerNonGetHead(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile("test.png", []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	preview := app.ReadFile("test.png")
+
+	mw := app.workspaceMediaMiddleware()
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("fallback should not be called")
+	}))
+
+	req := httptest.NewRequest(http.MethodPost, preview.URL, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for POST, got %d", rec.Code)
+	}
+}
+
+func TestMediaTokenHandlerPassesUnrelatedPaths(t *testing.T) {
+	app := NewApp()
+	mw := app.workspaceMediaMiddleware()
+
+	fallbackCalled := false
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/index.html", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !fallbackCalled {
+		t.Fatal("expected fallback handler for non-media path")
+	}
+}
+
+func TestMediaTokenMaxEviction(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile("test.png", []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	store := app.mediaTokens
+
+	// Fill beyond max to trigger eviction of oldest.
+	var oldestToken string
+	for i := 0; i < mediaTokenMax+1; i++ {
+		tok := store.create(dir+"/test.png", "test.png", "image/png", "image", 4, time.Time{})
+		if i == 0 {
+			oldestToken = tok
+		}
+	}
+
+	if store.get(oldestToken) != nil {
+		t.Fatal("oldest token should have been evicted")
+	}
+	if len(store.order) != mediaTokenMax {
+		t.Fatalf("expected %d tokens, got %d", mediaTokenMax, len(store.order))
+	}
+}
+
+func TestMediaTokenExpiry(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile("test.png", []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	store := app.mediaTokens
+	tok := store.create(dir+"/test.png", "test.png", "image/png", "image", 4, time.Time{})
+
+	// Force expiry by rolling back the clock on the entry.
+	store.mu.Lock()
+	store.byTok[tok].expiresAt = time.Now().Add(-1 * time.Second)
+	store.mu.Unlock()
+
+	if e := store.get(tok); e != nil {
+		t.Fatal("expired token should return nil")
+	}
+	next := store.create(dir+"/test.png", "test.png", "image/png", "image", 4, time.Time{})
+	if next == "" || store.get(next) == nil {
+		t.Fatal("store should create and read a fresh token after expired get cleanup")
+	}
+}
+
+func TestReadFileTextUnchanged(t *testing.T) {
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile("hello.txt", []byte("hello world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	preview := app.ReadFile("hello.txt")
+	if preview.Err != "" {
+		t.Fatalf("ReadFile text err = %q", preview.Err)
+	}
+	if preview.Body != "hello world" {
+		t.Fatalf("expected text body, got %q", preview.Body)
+	}
+	if preview.Kind != "" || preview.Mime != "" || preview.URL != "" {
+		t.Fatalf("text preview should not have media fields")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Serve workspace image/PDF previews through short-lived AssetServer token URLs instead of base64 data URLs.
- Add token expiry/eviction, range-friendly `http.ServeContent`, escaped filenames, and inline media headers.
- Render workspace media previews from URLs while preserving Composer clipboard data URL handling.

## Tests
- `cd desktop/frontend && pnpm build`
- `cd desktop && go test . -run 'Test(ReadFile|MediaToken)'`
- `cd desktop && go test . -run TestLegacyMigrationConcurrentRunsHaveNoLostUpdates -count=1`

## Notes
- `cd desktop && go test ./...` was attempted and repeatedly hit `TestLegacyMigrationConcurrentRunsHaveNoLostUpdates` TempDir cleanup (`sessions: directory not empty`); the same test passes when run in isolation.
