### PR TITLE
fix(desktop): render LLM math in chat messages

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -8,7 +8,10 @@
     "build": "tsc --noEmit && vite build",
     "preview": "vite preview",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsx src/__tests__/math-golden.test.ts",
+    "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
+    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts"
   },
   "dependencies": {
     "highlight.js": "^11.10.0",
@@ -17,15 +20,15 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
-    "rehype-katex": "^7.0.1",
-    "remark-gfm": "^4.0.0",
-    "remark-math": "^6.0.0"
+    "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@types/node": "^25.9.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
     "terser": "^5.48.0",
+    "tsx": "^4.22.4",
     "typescript": "^5.6.3",
     "vite": "^6.0.7"
   },

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -29,16 +29,13 @@ importers:
       react-markdown:
         specifier: ^9.0.1
         version: 9.1.0(@types/react@18.3.29)(react@18.3.1)
-      rehype-katex:
-        specifier: ^7.0.1
-        version: 7.0.1
       remark-gfm:
         specifier: ^4.0.0
         version: 4.0.1
-      remark-math:
-        specifier: ^6.0.0
-        version: 6.0.0
     devDependencies:
+      '@types/node':
+        specifier: ^25.9.1
+        version: 25.9.1
       '@types/react':
         specifier: ^18.3.12
         version: 18.3.29
@@ -47,16 +44,19 @@ importers:
         version: 18.3.7(@types/react@18.3.29)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(terser@5.48.0))
+        version: 4.7.0(vite@6.4.2(@types/node@25.9.1)(terser@5.48.0)(tsx@4.22.4))
       terser:
         specifier: ^5.48.0
         version: 5.48.0
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
       vite:
         specifier: ^6.0.7
-        version: 6.4.2(terser@5.48.0)
+        version: 6.4.2(@types/node@25.9.1)(terser@5.48.0)(tsx@4.22.4)
 
 packages:
 
@@ -149,8 +149,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -161,8 +173,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -173,8 +197,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -185,8 +221,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -197,8 +245,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -209,8 +269,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -221,8 +293,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -233,8 +317,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -245,8 +341,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -257,8 +365,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -269,8 +389,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -281,8 +413,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -293,8 +437,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -355,66 +511,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -470,14 +639,14 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
-  '@types/katex@0.16.8':
-    resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
-
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -582,12 +751,13 @@ packages:
   electron-to-chromium@1.5.364:
     resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
 
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
-
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -623,35 +793,11 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
-  hast-util-from-dom@5.0.1:
-    resolution: {integrity: sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==}
-
-  hast-util-from-html-isomorphic@2.0.0:
-    resolution: {integrity: sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==}
-
-  hast-util-from-html@2.0.3:
-    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
-
-  hast-util-from-parse5@8.0.3:
-    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
-
-  hast-util-is-element@3.0.0:
-    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
-
-  hast-util-parse-selector@4.0.0:
-    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
-
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
-  hast-util-to-text@4.0.2:
-    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
-
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
-
-  hastscript@9.0.1:
-    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   highlight.js@11.11.1:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
@@ -690,10 +836,6 @@ packages:
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
-    hasBin: true
-
-  katex@0.16.47:
-    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
     hasBin: true
 
   katex@0.17.0:
@@ -742,9 +884,6 @@ packages:
   mdast-util-gfm@3.1.0:
     resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
-  mdast-util-math@3.0.0:
-    resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
-
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
 
@@ -789,9 +928,6 @@ packages:
 
   micromark-extension-gfm@3.0.0:
     resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
-
-  micromark-extension-math@3.1.0:
-    resolution: {integrity: sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==}
 
   micromark-factory-destination@2.0.1:
     resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
@@ -868,9 +1004,6 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -904,14 +1037,8 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  rehype-katex@7.0.1:
-    resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
-
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
-
-  remark-math@6.0.0:
-    resolution: {integrity: sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -972,25 +1099,27 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
-
-  unist-util-find-after@5.0.0:
-    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
   unist-util-position@5.0.0:
     resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
-
-  unist-util-remove-position@5.0.0:
-    resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -1006,9 +1135,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  vfile-location@5.0.3:
-    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -1055,9 +1181,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  web-namespaces@2.0.1:
-    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1182,79 +1305,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1393,13 +1594,15 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
-  '@types/katex@0.16.8': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
+
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/prop-types@15.7.15': {}
 
@@ -1418,7 +1621,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(terser@5.48.0))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@25.9.1)(terser@5.48.0)(tsx@4.22.4))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -1426,7 +1629,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.2(terser@5.48.0)
+      vite: 6.4.2(@types/node@25.9.1)(terser@5.48.0)(tsx@4.22.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -1484,8 +1687,6 @@ snapshots:
 
   electron-to-chromium@1.5.364: {}
 
-  entities@6.0.1: {}
-
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -1515,6 +1716,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -1531,47 +1761,6 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
-
-  hast-util-from-dom@5.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      hastscript: 9.0.1
-      web-namespaces: 2.0.1
-
-  hast-util-from-html-isomorphic@2.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      hast-util-from-dom: 5.0.1
-      hast-util-from-html: 2.0.3
-      unist-util-remove-position: 5.0.0
-
-  hast-util-from-html@2.0.3:
-    dependencies:
-      '@types/hast': 3.0.4
-      devlop: 1.1.0
-      hast-util-from-parse5: 8.0.3
-      parse5: 7.3.0
-      vfile: 6.0.3
-      vfile-message: 4.0.3
-
-  hast-util-from-parse5@8.0.3:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      devlop: 1.1.0
-      hastscript: 9.0.1
-      property-information: 7.1.0
-      vfile: 6.0.3
-      vfile-location: 5.0.3
-      web-namespaces: 2.0.1
-
-  hast-util-is-element@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
-  hast-util-parse-selector@4.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
@@ -1593,24 +1782,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-text@4.0.2:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      hast-util-is-element: 3.0.0
-      unist-util-find-after: 5.0.0
-
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
-
-  hastscript@9.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      comma-separated-tokens: 2.0.3
-      hast-util-parse-selector: 4.0.0
-      property-information: 7.1.0
-      space-separated-tokens: 2.0.2
 
   highlight.js@11.11.1: {}
 
@@ -1636,10 +1810,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json5@2.2.3: {}
-
-  katex@0.16.47:
-    dependencies:
-      commander: 8.3.0
 
   katex@0.17.0:
     dependencies:
@@ -1739,18 +1909,6 @@ snapshots:
       mdast-util-gfm-table: 2.0.0
       mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
-    transitivePeerDependencies:
-      - supports-color
-
-  mdast-util-math@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      devlop: 1.1.0
-      longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-to-markdown: 2.1.2
-      unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -1903,16 +2061,6 @@ snapshots:
       micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
-  micromark-extension-math@3.1.0:
-    dependencies:
-      '@types/katex': 0.16.8
-      devlop: 1.1.0
-      katex: 0.16.47
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.2
-
   micromark-factory-destination@2.0.1:
     dependencies:
       micromark-util-character: 2.1.1
@@ -2043,10 +2191,6 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
-  parse5@7.3.0:
-    dependencies:
-      entities: 6.0.1
-
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -2089,16 +2233,6 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  rehype-katex@7.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@types/katex': 0.16.8
-      hast-util-from-html-isomorphic: 2.0.0
-      hast-util-to-text: 4.0.2
-      katex: 0.16.47
-      unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -2106,15 +2240,6 @@ snapshots:
       micromark-extension-gfm: 3.0.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  remark-math@6.0.0:
-    dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-math: 3.0.0
-      micromark-extension-math: 3.1.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -2219,7 +2344,15 @@ snapshots:
 
   trough@2.2.0: {}
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.9.3: {}
+
+  undici-types@7.24.6: {}
 
   unified@11.0.5:
     dependencies:
@@ -2231,11 +2364,6 @@ snapshots:
       trough: 2.2.0
       vfile: 6.0.3
 
-  unist-util-find-after@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
-
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -2243,11 +2371,6 @@ snapshots:
   unist-util-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-
-  unist-util-remove-position@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-visit: 5.1.0
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -2270,11 +2393,6 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vfile-location@5.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      vfile: 6.0.3
-
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -2285,7 +2403,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.2(terser@5.48.0):
+  vite@6.4.2(@types/node@25.9.1)(terser@5.48.0)(tsx@4.22.4):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2294,10 +2412,10 @@ snapshots:
       rollup: 4.60.4
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.9.1
       fsevents: 2.3.3
       terser: 5.48.0
-
-  web-namespaces@2.0.1: {}
+      tsx: 4.22.4
 
   yallist@3.1.1: {}
 

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -1,0 +1,165 @@
+// Golden-case verification for math rendering pipeline.
+// Run: tsx src/__tests__/math-golden.test.ts
+import { isInlineMathLike } from "../components/CodeOrMath";
+import { stripMathDelimiters, latexNormalizeForKatex } from "../components/latexNormalize";
+
+let passed = 0;
+let failed = 0;
+
+function check(label: string, fn: () => boolean) {
+  try {
+    if (fn()) { process.stdout.write(`  PASS  ${label}\n`); passed += 1; }
+    else      { process.stdout.write(`  FAIL  ${label}\n`); failed += 1; }
+  } catch (e) {
+    process.stdout.write(`  ERROR ${label}: ${e}\n`); failed += 1;
+  }
+}
+
+function eq(a: any, b: any, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    // prettier-ignore
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+// ── stripMathDelimiters ────────────────────────────────────────────────────────
+
+console.log("\nstripMathDelimiters");
+eq(stripMathDelimiters("\\(x+1\\)"), "x+1", "\\(...\\)");
+eq(stripMathDelimiters("\\[E=mc^2\\]"), "E=mc^2", "\\[...\\]");
+eq(stripMathDelimiters("$$\\frac{a}{b}$$"), "\\frac{a}{b}", "$$...$$");
+eq(stripMathDelimiters("$x_i^2$"), "x_i^2", "$...$");
+eq(stripMathDelimiters("plain text"), "plain text", "no delimiters");
+eq(stripMathDelimiters("$a|b$"), "a|b", "inline with pipe");
+
+// ── latexNormalizeForKatex ─────────────────────────────────────────────────────
+
+console.log("\nlatexNormalizeForKatex");
+eq(latexNormalizeForKatex("x+1"), "x+1", "plain unchanged");
+eq(latexNormalizeForKatex("\\text{baryon #}"), "\\text{baryon \\#}", "escapes # in \\text");
+eq(latexNormalizeForKatex("\\text{cost is $5}"), "\\text{cost is \\textdollar{}5}", "escapes $ in \\text");
+eq(latexNormalizeForKatex("\\text{a & b % c_d ^ e ~ f}"),
+  "\\text{a \\& b \\% c\\_d \\textasciicircum{} e \\textasciitilde{} f}",
+  "escapes & % _ ^ ~ in \\text");
+eq(latexNormalizeForKatex("\\text{already\\_escaped}"), "\\text{already\\_escaped}", "no double-escape");
+eq(latexNormalizeForKatex("\\alpha + \\beta"), "\\alpha + \\beta", "non-text commands");
+eq(latexNormalizeForKatex("a | b"), "a \\vert  b", "| to \\vert");
+eq(latexNormalizeForKatex("\\text{foo \\$ bar}"), "\\text{foo \\$ bar}", "already escaped $");
+eq(latexNormalizeForKatex("\\textrm{test #}"), "\\textrm{test \\#}", "\\textrm also handled");
+eq(latexNormalizeForKatex("\\textbf{hello world}"), "\\textbf{hello world}", "\\textbf no special chars");
+eq(latexNormalizeForKatex("\\tfrac{a}{b}"), "\\tfrac{a}{b}", "nested braces in command");
+
+// ── isInlineMathLike (CodeOrMath classifier) ───────────────────────────────────
+
+console.log("\nisInlineMathLike — math");
+check("\\text command", () => isInlineMathLike("\\text{baryon #}") === true);
+check("\\frac", () => isInlineMathLike("\\frac{a}{b}") === true);
+check("\\sqrt", () => isInlineMathLike("\\sqrt{x}") === true);
+check("\\alpha", () => isInlineMathLike("\\alpha + \\beta") === true);
+check("\\sum", () => isInlineMathLike("\\sum_{i=1}^{n}") === true);
+check("\\int", () => isInlineMathLike("\\int_0^\\infty") === true);
+check("\\begin", () => isInlineMathLike("\\begin{matrix} a & b \\end{matrix}") === true);
+check("sub/superscript x_i^2", () => isInlineMathLike("x_i^2") === true);
+check("superscript E=mc^2", () => isInlineMathLike("E=mc^2") === true);
+check("\\forall", () => isInlineMathLike("\\forall x \\in \\mathbb{R}") === true);
+check("\\(x+1\\) wrapped", () => isInlineMathLike("\\(x+1\\)") === true);
+check("$x+1$ wrapped", () => isInlineMathLike("$x+1$") === true);
+check("\\mathbf{bold}", () => isInlineMathLike("\\mathbf{x}") === true);
+check("\\mathbb{R}", () => isInlineMathLike("\\mathbb{R}") === true);
+check("a \\le b", () => isInlineMathLike("a \\le b") === true);
+
+console.log("\nisInlineMathLike — code");
+check("npm run build", () => isInlineMathLike("npm run build") === false);
+check("Markdown.tsx", () => isInlineMathLike("Markdown.tsx") === false);
+check("const x = 1", () => isInlineMathLike("const x = 1") === false);
+check("arrow =>", () => isInlineMathLike("=> x") === false);
+check("equality ==", () => isInlineMathLike("a == b") === false);
+check("strict ===", () => isInlineMathLike("a === b") === false);
+check("SQL SELECT", () => isInlineMathLike("SELECT * FROM users") === false);
+check("Go func", () => isInlineMathLike("func foo()") === false);
+check("env $PATH", () => isInlineMathLike("$PATH") === false);
+check("env $HOME", () => isInlineMathLike("$HOME") === false);
+check("docker ps", () => isInlineMathLike("docker ps") === false);
+check("git log", () => isInlineMathLike("git log") === false);
+check("ssh user@host", () => isInlineMathLike("ssh user@host") === false);
+check("curl URL", () => isInlineMathLike("curl https://example.com") === false);
+check("3 char no math", () => isInlineMathLike("abc") === false);
+check("file size 5mb", () => isInlineMathLike("5mb") === false);
+check("npx cmd", () => isInlineMathLike("npx tsx") === false);
+check("pnpm cmd", () => isInlineMathLike("pnpm install") === false);
+check("yarn cmd", () => isInlineMathLike("yarn dev") === false);
+check("import stmt", () => isInlineMathLike("import React from 'react'") === false);
+check("export stmt", () => isInlineMathLike("export default App") === false);
+check(".env filename", () => isInlineMathLike(".env") === false);
+
+// ── isLikelyInlineMath (remark plugin $...$ gate) ──────────────────────────────
+// Mirrors the isLikelyInlineMath logic from Markdown.tsx.
+
+const isLikelyInlineMath = (math: string): boolean => {
+  if (!math || math !== math.trim() || math.includes("\n")) return false;
+  if (math.includes("://") || math.includes("](")) return false;
+  if (/^\$?\d+(?:\.\d+)?%?$/.test(math)) return false;
+  if (/\\[A-Za-z]+\b/.test(math)) return true;
+  if (/[\^_{}|]/.test(math)) return true;
+  if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
+  if (/[A-Za-z]\s+[A-Za-z]/.test(math)) return false;
+  return true;
+};
+
+console.log("\nisLikelyInlineMath — math");
+check("$x$ (single var)", () => isLikelyInlineMath("x") === true);
+check("$E=mc^2$", () => isLikelyInlineMath("E=mc^2") === true);
+check("$x_i^2$", () => isLikelyInlineMath("x_i^2") === true);
+check("$\\alpha$", () => isLikelyInlineMath("\\alpha") === true);
+check("$a \\le b$", () => isLikelyInlineMath("a \\le b") === true);
+check("$\\frac{a}{b}$", () => isLikelyInlineMath("\\frac{a}{b}") === true);
+check("$f(x)$", () => isLikelyInlineMath("f(x)") === true);
+
+console.log("\nisLikelyInlineMath — currency/link (NOT math)");
+check("$5", () => isLikelyInlineMath("5") === false);
+check("$10", () => isLikelyInlineMath("10") === false);
+check("$10.50", () => isLikelyInlineMath("10.50") === false);
+check("$100%", () => isLikelyInlineMath("100%") === false);
+check("URL", () => isLikelyInlineMath("https://example.com") === false);
+check("prose text", () => isLikelyInlineMath("hello world today") === false);
+check("prose $x y z$ (spaces)", () => isLikelyInlineMath("x y z") === false);
+
+// ── looksLikeFormula (CodeBlockOrMath fenced-code classifier) ──────────────────
+// Mirrors the looksLikeFormula logic from CodeBlockOrMath.tsx.
+
+const LATEX_COMMAND_RE = /\\(?:frac|sqrt|begin|end|sum|int|prod|lim|infty|partial|nabla|alpha|beta|gamma|delta|epsilon|theta|lambda|mu|pi|sigma|tau|phi|omega|mathbf|mathrm|mathcal|mathbb|mathfrak|text|textbf|textit|widehat|widetilde|overline|underline|vec|hat|tilde|bar|dot)(?![A-Za-z])/;
+
+const looksLikeFormula = (content: string): boolean => {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+  if (!trimmed.includes("\n") && LATEX_COMMAND_RE.test(trimmed)) return true;
+  if (/\\begin\{/.test(trimmed) || /\\end\{/.test(trimmed)) return true;
+  if (/\\(?:align|equation|gather|multline|matrix|pmatrix|bmatrix|array|tabular|split|cases)\b/.test(trimmed)) return true;
+  if (trimmed.includes("\n")) return false;
+  return false;
+};
+
+console.log("\nlooksLikeFormula — formula");
+check("single-line \\frac", () => looksLikeFormula("\\frac{a}{b}") === true);
+check("single-line \\sqrt", () => looksLikeFormula("\\sqrt{x^2+1}") === true);
+check("single-line \\sum", () => looksLikeFormula("\\sum_{i=1}^{n} i") === true);
+check("single-line \\int", () => looksLikeFormula("\\int_0^\\infty e^{-x} dx") === true);
+check("multiline \\begin{aligned}", () => looksLikeFormula("\\begin{aligned}\nx &= 1 \\\\\ny &= 2\n\\end{aligned}") === true);
+check("multiline \\begin{bmatrix}", () => looksLikeFormula("\\begin{bmatrix} a & b \\\\ c & d \\end{bmatrix}") === true);
+check("multiline \\end only", () => looksLikeFormula("x = 1 \\\\\n\\end{aligned}") === true);
+check("multiline \\equation", () => looksLikeFormula("\\equation\nE = mc^2\n") === true);
+
+console.log("\nlooksLikeFormula — code");
+check("multiline no-LaTeX", () => looksLikeFormula("line one\nline two\nline three") === false);
+check("empty", () => looksLikeFormula("") === false);
+check("plain text", () => looksLikeFormula("hello world") === false);
+check("code snippet", () => looksLikeFormula("const x = 1;\nconst y = 2;") === false);
+
+// ── Summary ────────────────────────────────────────────────────────────────────
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/BlockMath.tsx
+++ b/desktop/frontend/src/components/BlockMath.tsx
@@ -1,0 +1,28 @@
+import katex from "katex";
+import { CopyButton } from "./CopyButton";
+import { latexNormalizeForKatex } from "./latexNormalize";
+
+interface BlockMathProps {
+  source: string;
+}
+
+export function BlockMath({ source }: BlockMathProps) {
+  const normalized = latexNormalizeForKatex(source);
+
+  let html: string;
+  try {
+    html = katex.renderToString(normalized, {
+      throwOnError: false,
+      displayMode: true,
+    });
+  } catch {
+    return <pre className="block-math-fallback"><code>{source}</code></pre>;
+  }
+
+  return (
+    <div className="block-math">
+      <CopyButton text={source} className="block-math__copy" />
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/CodeBlockOrMath.tsx
+++ b/desktop/frontend/src/components/CodeBlockOrMath.tsx
@@ -1,0 +1,88 @@
+import { stripMathDelimiters } from "./latexNormalize";
+import { BlockMath } from "./BlockMath";
+import { CodeViewer } from "./CodeViewer";
+
+const MATH_LANGS = new Set(["math", "latex", "tex", "katex"]);
+
+const CODE_LANGS = new Set([
+  "js", "jsx", "ts", "tsx", "go", "py", "python", "rs", "rust",
+  "java", "c", "cpp", "c++", "h", "hpp", "rb", "ruby", "swift",
+  "kt", "kotlin", "scala", "dart", "lua", "r", "jl", "julia",
+  "sh", "bash", "zsh", "fish", "ps1", "powershell", "bat", "cmd",
+  "json", "yaml", "yml", "toml", "ini", "xml", "html", "css", "scss",
+  "less", "sql", "graphql", "proto", "dockerfile", "makefile",
+  "diff", "patch", "log", "text", "plaintext",
+  "cs", "csharp", "php", "perl", "vb", "fsharp", "fs",
+]);
+
+const LATEX_COMMAND_RE = /\\(?:frac|sqrt|begin|end|sum|int|prod|lim|infty|partial|nabla|alpha|beta|gamma|delta|epsilon|theta|lambda|mu|pi|sigma|tau|phi|omega|mathbf|mathrm|mathcal|mathbb|mathfrak|text|textbf|textit|widehat|widetilde|overline|underline|vec|hat|tilde|bar|dot)(?![A-Za-z])/;
+
+function isCodeLanguage(lang: string | undefined): boolean {
+  if (!lang) return false;
+  const lc = lang.toLowerCase().trim();
+  if (MATH_LANGS.has(lc)) return false;
+  if (CODE_LANGS.has(lc)) return true;
+  return false;
+}
+
+function looksLikeFormula(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+
+  // Single-line formula with clear LaTeX command
+  if (!trimmed.includes("\n") && LATEX_COMMAND_RE.test(trimmed)) return true;
+
+  // Multi-line: only formula if it has \begin{...} or \end{...}
+  if (/\\begin\{/.test(trimmed) || /\\end\{/.test(trimmed)) return true;
+
+  // Multi-line LaTeX alignment
+  if (/\\(?:align|equation|gather|multline|matrix|pmatrix|bmatrix|array|tabular|split|cases)\b/.test(trimmed)) {
+    return true;
+  }
+
+  // Default: not a formula for multi-line content without clear signals
+  if (trimmed.includes("\n")) return false;
+
+  return false;
+}
+
+const LINE_COUNT_THRESHOLD = 50;
+const CHAR_COUNT_THRESHOLD = 10000;
+
+interface CodeBlockOrMathProps {
+  value: string;
+  language?: string;
+  maxHeight?: number;
+}
+
+/**
+ * Classify a fenced code block as display math or real code and render accordingly.
+ */
+export function CodeBlockOrMath({ value, language, maxHeight = 400 }: CodeBlockOrMathProps) {
+  const langLc = language?.toLowerCase().trim() ?? "";
+  const cleanValue = value.replace(/\n$/, "");
+
+  // Explicit math language → BlockMath
+  if (MATH_LANGS.has(langLc)) {
+    const source = stripMathDelimiters(cleanValue);
+    return <BlockMath source={source} />;
+  }
+
+  // Known code language → CodeViewer
+  if (isCodeLanguage(langLc)) {
+    return <CodeViewer value={cleanValue} language={language} maxHeight={maxHeight} />;
+  }
+
+  // No explicit language or unknown: classify by content
+  // Skip classification for very large blocks
+  if (cleanValue.length > CHAR_COUNT_THRESHOLD || cleanValue.split("\n").length > LINE_COUNT_THRESHOLD) {
+    return <CodeViewer value={cleanValue} language={language} maxHeight={maxHeight} />;
+  }
+
+  if (looksLikeFormula(cleanValue)) {
+    const source = stripMathDelimiters(cleanValue);
+    return <BlockMath source={source} />;
+  }
+
+  return <CodeViewer value={cleanValue} language={language} maxHeight={maxHeight} />;
+}

--- a/desktop/frontend/src/components/CodeOrMath.tsx
+++ b/desktop/frontend/src/components/CodeOrMath.tsx
@@ -1,0 +1,72 @@
+import { stripMathDelimiters } from "./latexNormalize";
+import { InlineMath } from "./InlineMath";
+
+const LATEX_COMMANDS = /\\(?:frac|sqrt|text|mathbf|mathit|mathrm|mathcal|mathbb|mathfrak|mathscr|alpha|beta|gamma|delta|epsilon|zeta|eta|theta|iota|kappa|lambda|mu|nu|xi|omicron|pi|rho|sigma|tau|upsilon|phi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega|sum|prod|int|iint|iiint|oint|lim|infty|partial|nabla|forall|exists|neg|in|notin|subset|subseteq|supset|supseteq|cup|cap|emptyset|varnothing|times|cdot|circ|div|pm|mp|leq|geq|ll|gg|approx|equiv|sim|simeq|propto|neq|perp|parallel|mid|angle|triangle|square|diamond|big|Big|bigg|Bigg|binom|choose|over|atop|underbrace|overbrace|widetilde|widehat|overline|underline|vec|hat|tilde|bar|dot|ddot|mathring|acute|grave|breve|check|begin|end)(?![A-Za-z])/;
+
+const CODE_TOKENS = /[{}]\s*return\b|=>|===|!==|;\s*$|;\s*\/[/*]|^[ \t]*(const|let|var|function|func|class|interface|type|enum|import|export|require|from|SELECT|INSERT|UPDATE|DELETE|CREATE|DROP|ALTER)\b|\b(?:async|await|yield)\b/;
+
+const MATH_WRAPPERS = /^(?:\\\(.*\\\)|\$.*\$)$/;
+
+const SUB_SUPER = /[a-zA-Z0-9]\^\{?[a-zA-Z0-9]|[a-zA-Z0-9]_\{?[a-zA-Z0-9]/;
+
+const CODE_LIKE = /^(?:[a-zA-Z]:[/\\]|(?:\.{1,2}[/\\])+|(?:npm|yarn|pnpm|npx|git|docker|kubectl|ssh|curl|wget|make|cmake)\s|\.(?:tsx?|jsx?|go|py|rs|java|cpp|c|h|json|yaml|yml|toml|sh|bash|zsh|env|css|html|xml|sql|md)$)/;
+
+const PATH_LIKE = /[/\\][\w.-]+(?:\.[a-z]+)?$|^\.[a-zA-Z]+$/;
+
+/**
+ * Classify inline code content as math or real code.
+ * Returns true when the content should be rendered as math.
+ */
+export function isInlineMathLike(content: string): boolean {
+  const trimmed = content.trim();
+  if (!trimmed) return false;
+
+  // If wrapped in math delimiters, it's math
+  if (MATH_WRAPPERS.test(trimmed)) return true;
+
+  // Strong LaTeX signals
+  if (LATEX_COMMANDS.test(trimmed)) return true;
+
+  // Subscript / superscript patterns
+  if (SUB_SUPER.test(trimmed)) return true;
+
+  // Contains \ followed by alpha chars (generic LaTeX detection)
+  if (/\\[A-Za-z]+/.test(trimmed) && !CODE_LIKE.test(trimmed)) return true;
+
+  // Strong code signals → keep as code
+  if (CODE_TOKENS.test(trimmed)) return false;
+  if (CODE_LIKE.test(trimmed)) return false;
+  if (PATH_LIKE.test(trimmed)) return false;
+  if (/^[$]?\d+[kmg]?b?$/i.test(trimmed)) return false; // file sizes
+
+  // Default to code for ambiguous short strings
+  if (trimmed.length < 3 && !LATEX_COMMANDS.test(trimmed)) return false;
+
+  return false;
+}
+
+interface CodeOrMathProps {
+  source: string;
+}
+
+/**
+ * Renders inline code as either InlineMath or a styled code span,
+ * classifying based on content.
+ */
+export function CodeOrMath({ source }: CodeOrMathProps) {
+  const raw = source.trim();
+
+  // If the original source is wrapped in math delimiters, treat it as math
+  // even if the inner content has no strong LaTeX signals (e.g. `\(x+1\)`).
+  if (MATH_WRAPPERS.test(raw)) {
+    return <InlineMath source={stripMathDelimiters(raw)} />;
+  }
+
+  const trimmed = stripMathDelimiters(raw);
+
+  if (isInlineMathLike(trimmed)) {
+    return <InlineMath source={trimmed} />;
+  }
+
+  return <code className="md-code">{raw}</code>;
+}

--- a/desktop/frontend/src/components/InlineMath.tsx
+++ b/desktop/frontend/src/components/InlineMath.tsx
@@ -1,0 +1,34 @@
+import katex from "katex";
+import { useState } from "react";
+import { CopyButton } from "./CopyButton";
+import { latexNormalizeForKatex } from "./latexNormalize";
+
+interface InlineMathProps {
+  source: string;
+}
+
+export function InlineMath({ source }: InlineMathProps) {
+  const [showSource, setShowSource] = useState(false);
+
+  const normalized = latexNormalizeForKatex(source);
+  const html = katex.renderToString(normalized, {
+    throwOnError: false,
+    displayMode: false,
+  });
+
+  return (
+    <span
+      className="inline-math"
+      onMouseEnter={() => setShowSource(true)}
+      onMouseLeave={() => setShowSource(false)}
+    >
+      <span dangerouslySetInnerHTML={{ __html: html }} />
+      {showSource && (
+        <span className="inline-math__source">
+          <code>{source}</code>
+          <CopyButton text={source} />
+        </span>
+      )}
+    </span>
+  );
+}

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -39,7 +39,7 @@ function inlineMathNode(value: string): any {
   return {
     type: "inlineMath",
     value,
-    data: { hName: "inline-math-node", hProperties: {} },
+    data: { hName: "inline-math-node", hProperties: { value } },
   };
 }
 
@@ -47,7 +47,7 @@ function blockMathNode(value: string): any {
   return {
     type: "math",
     value,
-    data: { hName: "block-math-node", hProperties: {} },
+    data: { hName: "block-math-node", hProperties: { value } },
   };
 }
 

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -1,75 +1,218 @@
-import { useDeferredValue } from "react";
+import { memo, useDeferredValue, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
-import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
-import { CodeViewer } from "./CodeViewer";
+import { CodeBlockOrMath } from "./CodeBlockOrMath";
+import { CodeOrMath } from "./CodeOrMath";
+import { InlineMath } from "./InlineMath";
+import { BlockMath } from "./BlockMath";
 import { openExternal } from "../lib/bridge";
 
-// Markdown rendering via react-markdown + remark-gfm (tables, task lists, strike,
-// autolinks) and remark-math + rehype-katex for $inline$/$$block$$ KaTeX math.
-// Fenced code blocks are routed through the editor seam (CodeViewer)
-// so syntax highlighting stays owned by one place; inline code is a styled <code>.
-// Links open in the system browser rather than navigating the webview.
+// ── remark plugin: LLM-LaTeX delimiters ────────────────────────────────────────
+// Handles all math delimiters that LLMs emit: $$ / \[ for display, $ / \( for
+// inline. $…$ is gated by an LLM-aware classifier to avoid $5, currency, and
+// link URLs. Produces custom HAST-passable nodes so react-markdown routes them
+// straight to our InlineMath / BlockMath components.
 
-const components: Components = {
-  // Passthrough <pre> so our code renderer fully owns block rendering (no nested
-  // <pre><pre>).
-  pre: ({ children }) => <>{children}</>,
-  code: ({ className, children }) => {
-    const text = String(children ?? "");
-    const match = /language-([\w-]+)/.exec(className ?? "");
-    const isBlock = match !== null || text.includes("\n");
-    if (isBlock) {
-      return <CodeViewer value={text.replace(/\n$/, "")} language={match?.[1]} maxHeight={360} />;
+function remarkLatexDelimiters() {
+  return (tree: any) => walkTree(tree);
+
+  function walkTree(node: any) {
+    if (!node || !Array.isArray(node.children)) return;
+    for (let i = 0; i < node.children.length; i++) {
+      const child = node.children[i];
+      if (child.type === "inlineCode" || child.type === "code") continue;
+      if (child.type === "text" && typeof child.value === "string") {
+        const replaced = splitText(child);
+        if (replaced.length > 1) {
+          node.children.splice(i, 1, ...replaced);
+          i += replaced.length - 1;
+        }
+      }
+      if (Array.isArray(child.children)) walkTree(child);
     }
-    return <code className="md-code">{children}</code>;
-  },
-  a: ({ href, children }) => (
-    <a
-      href={href}
-      onClick={(e) => {
-        e.preventDefault();
-        if (href) openExternal(href);
-      }}
-    >
-      {children}
-    </a>
-  ),
-};
-
-// LLMs emit \( \) \[ \] delimiters (remark-math only parses $/$$); convert them,
-// but protect LaTeX line-break spacing \\[ (e.g. \\[4pt]) from the rewrite, and
-// swap | for \vert inside math so remark-gfm can't read the bar as a table column.
-function normalizeMath(s: string): string {
-  const lb = "\x00LB\x00";
-  let r = s.replace(/\\\\\[/g, lb);
-  r = r
-    .replace(/\\\[/g, () => "$$")
-    .replace(/\\\]/g, () => "$$")
-    .replace(/\\\(/g, () => "$")
-    .replace(/\\\)/g, () => "$");
-  r = r.replace(/\x00LB\x00/g, "\\\\[");
-  const vert = (m: string) => m.replace(/\|/g, "\\vert ");
-  r = r.replace(/\$\$([\s\S]*?)\$\$/g, (_m, m) => `$$${vert(m)}$$`);
-  r = r.replace(/\$([^$\n]+)\$/g, (_m, m) => `$${vert(m)}$`);
-  return r;
+  }
 }
 
-export function Markdown({ text }: { text: string }) {
+function inlineMathNode(value: string): any {
+  return {
+    type: "inlineMath",
+    value,
+    data: { hName: "inline-math-node", hProperties: {} },
+  };
+}
+
+function blockMathNode(value: string): any {
+  return {
+    type: "math",
+    value,
+    data: { hName: "block-math-node", hProperties: {} },
+  };
+}
+
+function splitText(node: any): any[] {
+  const s: string = node.value;
+  const parts: any[] = [];
+  let i = 0;
+
+  while (i < s.length) {
+    // $$ ... $$ → display math (before \[ check so $$ wins for ambiguous input)
+    if (s.startsWith("$$", i) && !isMathEscaped(s, i)) {
+      const close = findTokClose(s, i + 2, "$$");
+      if (close !== -1) {
+        parts.push(blockMathNode(s.slice(i + 2, close).trim()));
+        i = close + 2;
+        continue;
+      }
+    }
+
+    // \[ ... \] → display math
+    if (s.startsWith("\\[", i) && !isMathEscaped(s, i)) {
+      const close = findSimpleClose(s, i + 2, "\\]");
+      if (close !== -1) {
+        parts.push(blockMathNode(s.slice(i + 2, close).trim()));
+        i = close + 2;
+        continue;
+      }
+    }
+
+    // \( ... \) → inline math
+    if (s.startsWith("\\(", i) && !isMathEscaped(s, i)) {
+      const close = findSimpleClose(s, i + 2, "\\)");
+      if (close !== -1) {
+        parts.push(inlineMathNode(s.slice(i + 2, close).trim()));
+        i = close + 2;
+        continue;
+      }
+    }
+
+    // $...$ → inline math (LLM-aware classifier)
+    if (s[i] === "$" && !isMathEscaped(s, i)) {
+      // Don't eat into a $$ sequence
+      if (s.startsWith("$$", i)) {
+        parts.push({ type: "text", value: s.slice(i, i + 1) });
+        i += 1;
+        continue;
+      }
+      const close = findDollarClose(s, i + 1);
+      if (close !== -1) {
+        const math = s.slice(i + 1, close).trim();
+        if (isLikelyInlineMath(math)) {
+          parts.push(inlineMathNode(math));
+          i = close + 1;
+          continue;
+        }
+        parts.push({ type: "text", value: s.slice(i, close + 1) });
+        i = close + 1;
+        continue;
+      }
+    }
+
+    // Accumulate plain text
+    let j = i + 1;
+    while (j < s.length) {
+      if (s.startsWith("$$", j) && !isMathEscaped(s, j)) break;
+      if (s.startsWith("\\[", j) && !isMathEscaped(s, j)) break;
+      if (s.startsWith("\\(", j) && !isMathEscaped(s, j)) break;
+      if (s[j] === "$" && !isMathEscaped(s, j)) break;
+      j += 1;
+    }
+    parts.push({ type: "text", value: s.slice(i, j) });
+    i = j;
+  }
+
+  return parts;
+}
+
+function findSimpleClose(s: string, start: number, target: string): number {
+  for (let i = start; i < s.length; i++) {
+    if (target === "\\)" && s[i] === "\n") return -1;
+    if (s.startsWith(target, i) && !isMathEscaped(s, i)) return i;
+  }
+  return -1;
+}
+
+function findTokClose(s: string, start: number, tok: string): number {
+  for (let i = start; i < s.length; i++) {
+    if (s.startsWith(tok, i) && !isMathEscaped(s, i)) return i;
+  }
+  return -1;
+}
+
+function findDollarClose(s: string, start: number): number {
+  for (let i = start; i < s.length; i++) {
+    if (s[i] === "\n") return -1;
+    if (s[i] === "\\") { i += 1; continue; }
+    if (s[i] === "$" && !isMathEscaped(s, i)) return i;
+  }
+  return -1;
+}
+
+function isMathEscaped(s: string, i: number): boolean {
+  let slashCount = 0;
+  for (let j = i - 1; j >= 0 && s[j] === "\\"; j -= 1) slashCount += 1;
+  return slashCount % 2 === 1;
+}
+
+function isLikelyInlineMath(math: string): boolean {
+  if (!math || math !== math.trim() || math.includes("\n")) return false;
+  if (math.includes("://") || math.includes("](")) return false;
+  if (/^\$?\d+(?:\.\d+)?%?$/.test(math)) return false;
+  if (/\\[A-Za-z]+\b/.test(math)) return true;
+  if (/[\^_{}|]/.test(math)) return true;
+  if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
+  if (/[A-Za-z]\s+[A-Za-z]/.test(math)) return false;
+  return true;
+}
+
+// ── Components ─────────────────────────────────────────────────────────────────
+
+function makeComponents(): Components & Record<string, any> {
+  return {
+    pre: ({ children }) => <>{children}</>,
+    code: ({ className, children }) => {
+      const text = String(children ?? "");
+      const match = /language-([\w-]+)/.exec(className ?? "");
+      const isBlock = match !== null || text.includes("\n");
+      if (isBlock) {
+        return <CodeBlockOrMath value={text.replace(/\n$/, "")} language={match?.[1]} />;
+      }
+      return <CodeOrMath source={text} />;
+    },
+    "inline-math-node": ({ value }: any) => (value ? <InlineMath source={value} /> : null),
+    "block-math-node": ({ value }: any) => (value ? <BlockMath source={value} /> : null),
+    a: ({ href, children }) => (
+      <a
+        href={href}
+        onClick={(e) => {
+          e.preventDefault();
+          if (href) openExternal(href);
+        }}
+      >
+        {children}
+      </a>
+    ),
+  };
+}
+
+export const Markdown = memo(function Markdown({ text }: { text: string }) {
+  const components = useMemo(() => makeComponents(), []);
   // useDeferredValue lets React prioritise the plain-text streaming frame over
   // the expensive markdown parse+render. If a new text delta arrives while the
   // markdown tree is still diffing, React can abort the in-progress render and
   // start fresh with the latest text — keeping the UI responsive during the
   // final markdown pass on long responses.
   const deferred = useDeferredValue(text);
+
   return (
     <div className="md">
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkMath]} rehypePlugins={[rehypeKatex]} components={components}>
-        {normalizeMath(deferred)}
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkLatexDelimiters]}
+        components={components}
+      >
+        {deferred}
       </ReactMarkdown>
     </div>
   );
-}
+});

--- a/desktop/frontend/src/components/latexNormalize.ts
+++ b/desktop/frontend/src/components/latexNormalize.ts
@@ -1,0 +1,124 @@
+// Normalize LaTeX source for KaTeX rendering. Only processes already-identified
+// math source — never raw Markdown text.
+//
+// Handles two things:
+// 1. LaTeX text-mode commands (\text{}, \textrm{}, etc.) where KaTeX requires
+//    escaped literal characters (#, %, &, _, $, ^, ~).
+// 2. | → \vert inside math-mode content.
+
+const TEXT_COMMANDS = new Set([
+  "emph",
+  "mbox",
+  "text",
+  "textbf",
+  "textit",
+  "textmd",
+  "textnormal",
+  "textrm",
+  "textsf",
+  "texttt",
+  "textup",
+]);
+
+export function latexNormalizeForKatex(source: string): string {
+  let out = "";
+  let i = 0;
+
+  while (i < source.length) {
+    if (source[i] === "\\") {
+      const cmd = readCommand(source, i);
+      if (cmd && TEXT_COMMANDS.has(cmd.name) && source[cmd.end] === "{") {
+        const rewritten = rewriteTextArg(source, cmd.end);
+        if (rewritten) {
+          out += source.slice(i, cmd.end + 1) + rewritten.content + "}";
+          i = rewritten.end + 1;
+          continue;
+        }
+      }
+      if (cmd) {
+        out += source.slice(i, cmd.end);
+        i = cmd.end;
+        continue;
+      }
+      out += source[i];
+      i += 1;
+      continue;
+    }
+
+    if (source[i] === "|") {
+      out += "\\vert ";
+      i += 1;
+      continue;
+    }
+
+    out += source[i];
+    i += 1;
+  }
+
+  return out;
+}
+
+function rewriteTextArg(s: string, openBrace: number): { content: string; end: number } | null {
+  let out = "";
+  let depth = 1;
+  for (let i = openBrace + 1; i < s.length; ) {
+    const ch = s[i];
+    if (ch === "\\") {
+      const cmd = readCommand(s, i);
+      const end = cmd?.end ?? i + 1;
+      out += s.slice(i, end);
+      i = end;
+      continue;
+    }
+    if (ch === "{") {
+      depth += 1;
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return { content: out, end: i };
+      out += ch;
+      i += 1;
+      continue;
+    }
+    out += escapeTextChar(ch);
+    i += 1;
+  }
+  return null;
+}
+
+function escapeTextChar(ch: string): string {
+  if (ch === "$") return "\\textdollar{}";
+  if (ch === "#" || ch === "%" || ch === "&" || ch === "_") return `\\${ch}`;
+  if (ch === "^") return "\\textasciicircum{}";
+  if (ch === "~") return "\\textasciitilde{}";
+  return ch;
+}
+
+function readCommand(s: string, slash: number): { name: string; end: number } | null {
+  if (s[slash] !== "\\" || slash + 1 >= s.length) return null;
+  let end = slash + 1;
+  while (end < s.length && /[A-Za-z]/.test(s[end])) end += 1;
+  if (end > slash + 1) return { name: s.slice(slash + 1, end), end };
+  return { name: s[slash + 1], end: slash + 2 };
+}
+
+/** Strip outer LaTeX math delimiters from already-identified math content. */
+export function stripMathDelimiters(source: string): string {
+  const trimmed = source.trim();
+  if (trimmed.startsWith("\\[") && trimmed.endsWith("\\]")) {
+    return trimmed.slice(2, -2).trim();
+  }
+  if (trimmed.startsWith("\\(") && trimmed.endsWith("\\)")) {
+    return trimmed.slice(2, -2).trim();
+  }
+  if (trimmed.startsWith("$$") && trimmed.endsWith("$$")) {
+    return trimmed.slice(2, -2).trim();
+  }
+  if (trimmed.startsWith("$") && trimmed.endsWith("$")) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1284,6 +1284,72 @@ a[href] {
   border-radius: 5px;
   padding: 1px 5px;
 }
+
+/* ── inline math (KaTeX + hover source) ─────────────────────────────────── */
+.inline-math {
+  position: relative;
+  display: inline;
+}
+.inline-math .katex {
+  font-size: 1.05em;
+}
+.inline-math__source {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  background: var(--bg-elev-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 12px;
+  z-index: 10;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.inline-math__source code {
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+/* ── display math (KaTeX + copy) ────────────────────────────────────────── */
+.block-math {
+  position: relative;
+  margin: 12px 0;
+  padding: 12px 16px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.block-math .katex-display {
+  margin: 4px 0;
+}
+.block-math__copy {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.block-math:hover .block-math__copy {
+  opacity: 1;
+}
+.block-math-fallback {
+  margin: 12px 0;
+  padding: 11px 13px;
+  background: var(--bg-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
+  font-family: var(--mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
 .md table {
   border-collapse: collapse;
   margin: 0 0 12px;

--- a/desktop/frontend/tsconfig.json
+++ b/desktop/frontend/tsconfig.json
@@ -19,5 +19,6 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src", "vite-env.d.ts"],
+  "exclude": ["src/__tests__"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/desktop/frontend/tsconfig.test.json
+++ b/desktop/frontend/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src", "vite-env.d.ts"],
+  "exclude": []
+}

--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -41,8 +41,6 @@ export default defineConfig({
           "vendor-markdown": [
             "react-markdown",
             "remark-gfm",
-            "remark-math",
-            "rehype-katex",
             "katex",
           ],
           "vendor-highlight": ["highlight.js"],


### PR DESCRIPTION
## Summary
- Replace raw-string math normalization with an LLM-aware Markdown rendering pipeline for chat messages.
- Render math-like inline/fenced code as KaTeX while preserving real code in CodeViewer/code spans.
- Normalize confirmed LaTeX math for KaTeX compatibility and keep source/copy affordances.
- Add golden-case tests and dedicated test typecheck config for math classification and normalization.

## Testing
- `pnpm run build`
- `pnpm run test:all`
- `pnpm run test:todo-visibility`

## Notes
- Removed unused `remark-math` / `rehype-katex` dependencies from the desktop frontend.
- Kept the latest `main-v2` deferred Markdown rendering behavior via `useDeferredValue`.
