### PR TITLE
fix(desktop): mid-turn steer and tool-call cards in history view

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -941,9 +941,14 @@ func (a *App) SwitchWorkspace(dir string) (string, error) {
 // HistoryMessage is one prior turn, for the frontend to repopulate its transcript
 // after a reload.
 type HistoryMessage struct {
-	Role      string `json:"role"`
-	Content   string `json:"content"`
-	Reasoning string `json:"reasoning,omitempty"`
+	Role          string `json:"role"`
+	Content       string `json:"content"`
+	Reasoning     string `json:"reasoning,omitempty"`
+	ToolName      string `json:"toolName,omitempty"`
+	ToolArgs      string `json:"toolArgs,omitempty"`
+	ToolOutput    string `json:"toolOutput,omitempty"`
+	ToolId        string `json:"toolId,omitempty"`
+	ToolTruncated bool   `json:"toolTruncated,omitempty"`
 }
 
 // History returns the session's message log.
@@ -961,6 +966,18 @@ func (a *App) HistoryForTab(tabID string) []HistoryMessage {
 }
 
 func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
+	// First pass: build a lookup from tool-call ID to its metadata.
+	toolCallByID := make(map[string]provider.ToolCall, 4)
+	for _, m := range msgs {
+		if m.Role == provider.RoleAssistant {
+			for _, tc := range m.ToolCalls {
+				if tc.ID != "" {
+					toolCallByID[tc.ID] = tc
+				}
+			}
+		}
+	}
+
 	out := make([]HistoryMessage, 0, len(msgs))
 	for _, m := range msgs {
 		content := m.Content
@@ -971,7 +988,20 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 		if m.Role == provider.RoleAssistant {
 			reasoning = m.ReasoningContent
 		}
-		out = append(out, HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning})
+		hm := HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning}
+		if m.Role == provider.RoleTool {
+			hm.ToolName = m.Name
+			hm.ToolOutput = m.Content
+			hm.Content = ""
+			if tc, ok := toolCallByID[m.ToolCallID]; ok {
+				hm.ToolArgs = tc.Arguments
+				if hm.ToolName == "" {
+					hm.ToolName = tc.Name
+				}
+				hm.ToolId = tc.ID
+			}
+		}
+		out = append(out, hm)
 	}
 	return out
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -189,6 +189,11 @@ export interface HistoryMessage {
   role: string;
   content: string;
   reasoning?: string;
+  toolName?: string;
+  toolArgs?: string;
+  toolOutput?: string;
+  toolId?: string;
+  toolTruncated?: boolean;
 }
 
 // CheckpointMeta is one rewind point (a user turn) for the rewind UI.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -225,6 +225,13 @@ type Agent struct {
 	// stormSig: a model keeps doing the same successful write, so there is no
 	// error for the failure-only storm breaker to see.
 	repeatSuccessCounts map[string]int
+
+	// steerQueue holds mid-turn user messages queued while the agent is
+	// running. Each is consumed once per loop iteration, persisted to the
+	// session, and remains visible for the rest of the turn.
+	steerMu       sync.Mutex
+	steerQueue    []string
+	steerConsumed bool
 }
 
 // SetPlanMode flips the read-only gate. While true, executeOne refuses any
@@ -232,6 +239,53 @@ type Agent struct {
 // running it. The cache-friendly bits — system prompt, tools schema, message
 // history — are left untouched, so the toggle costs nothing in cache hits.
 func (a *Agent) SetPlanMode(v bool) { a.planMode.Store(v) }
+
+// mid-turn steer marker
+const midTurnSteerPrefix = "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]"
+
+func midTurnSteerMessage(text string) string {
+	return midTurnSteerPrefix + "\n" + text
+}
+
+// Steer queues a message for mid-turn injection.
+func (a *Agent) Steer(text string) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = append(a.steerQueue, text)
+	a.steerConsumed = false
+}
+
+// SteerConsumed returns true when the steer queue became empty.
+func (a *Agent) SteerConsumed() bool {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return a.steerConsumed
+}
+
+func (a *Agent) consumeSteer() (string, bool) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	if len(a.steerQueue) == 0 {
+		return "", false
+	}
+	t := a.steerQueue[0]
+	a.steerQueue = a.steerQueue[1:]
+	a.steerConsumed = len(a.steerQueue) == 0
+	return t, true
+}
+
+func (a *Agent) clearSteerQueue() {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = nil
+	a.steerConsumed = false
+}
+
+func (a *Agent) steerQueueLen() int {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return len(a.steerQueue)
+}
 
 // SetGate installs the per-call permission gate. Used by `reasonix chat` to swap the
 // headless gate built in setup for an interactive one that prompts the user;
@@ -390,6 +444,10 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 // a round count. A positive maxSteps imposes an optional hard guard, surfaced as
 // a resumable notice when hit.
 func (a *Agent) Run(ctx context.Context, input string) error {
+	defer a.clearSteerQueue()
+	a.steerMu.Lock()
+	a.steerConsumed = false
+	a.steerMu.Unlock()
 	if a.evidence != nil {
 		a.evidence.Reset()
 	}
@@ -399,6 +457,11 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 	finalReadinessBlocks := 0
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
+		// Consume a queued steer and persist it to the session.
+		if text, ok := a.consumeSteer(); ok {
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: midTurnSteerMessage(text)})
+			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
+		}
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
 		prevPrefixShape := a.lastPrefixShape
@@ -443,6 +506,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + reason})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: finalReadinessRetryMessage(reason)})
 				a.maybeCompact(ctx, usage)
+				continue
+			}
+			if a.steerQueueLen() > 0 {
 				continue
 			}
 			return nil // model gave a final answer

--- a/internal/agent/steer_test.go
+++ b/internal/agent/steer_test.go
@@ -1,0 +1,348 @@
+﻿package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// sinkRecorder records all events for inspection.
+type sinkRecorder struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (s *sinkRecorder) Emit(e event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, e)
+}
+
+func (s *sinkRecorder) Events() []event.Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]event.Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+// TestSteerQueuesAndConsumes verifies that Steer() queues a message and
+// consumeSteer() returns it at the next iteration boundary.
+func TestSteerQueuesAndConsumes(t *testing.T) {
+	mp := testutil.NewMock("m", testutil.Turn{Text: "ok"})
+	sink := &sinkRecorder{}
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, sink)
+
+	// Steer before Run
+	a.Steer("focus on tests")
+	if err := a.Run(context.Background(), "write code"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Verify the steer appears in the API request as a user message
+	reqs := mp.Requests()
+	if len(reqs) == 0 {
+		t.Fatal("no API requests recorded")
+	}
+	lastReq := reqs[len(reqs)-1]
+
+	// The steer should be the last user message before the assistant turn
+	var steerFound bool
+	for _, msg := range lastReq.Messages {
+		if msg.Role == provider.RoleUser && msg.Content == midTurnSteerMessage("focus on tests") {
+			steerFound = true
+			break
+		}
+	}
+	if !steerFound {
+		t.Fatal("steer message not found in API request messages")
+	}
+}
+
+// TestSteerConsumedGates verifies that steerConsumed and SteerConsumed work.
+func TestSteerConsumedGates(t *testing.T) {
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	// Initially not consumed (nothing to consume)
+	if a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be false initially")
+	}
+
+	// After Steer(), steerConsumed should still be false (not consumed yet)
+	a.Steer("hello")
+	if a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be false after Steer() but before consume")
+	}
+
+	// Consume the steer — should set steerConsumed = true (queue now empty)
+	text, ok := a.consumeSteer()
+	if !ok || text != "hello" {
+		t.Fatalf("consumeSteer got %q, %v", text, ok)
+	}
+	if !a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be true after consuming last item")
+	}
+
+	// Steer again — resets to false
+	a.Steer("world")
+	if a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be false after new Steer()")
+	}
+}
+
+// TestMultipleSteersFIFO verifies multiple steers are consumed in FIFO order.
+func TestMultipleSteersFIFO(t *testing.T) {
+	a := New(nil, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	a.Steer("first")
+	a.Steer("second")
+	a.Steer("third")
+
+	// Consume in FIFO order
+	for _, want := range []string{"first", "second"} {
+		got, ok := a.consumeSteer()
+		if !ok || got != want {
+			t.Fatalf("consumeSteer got %q, want %q", got, want)
+		}
+		// steerConsumed should be false because queue is not empty yet
+		if a.SteerConsumed() {
+			t.Fatal("SteerConsumed should be false while items remain")
+		}
+	}
+
+	// Last one — queue becomes empty
+	got, ok := a.consumeSteer()
+	if !ok || got != "third" {
+		t.Fatalf("consumeSteer got %q, want %q", got, "third")
+	}
+	if !a.SteerConsumed() {
+		t.Fatal("SteerConsumed should be true after consuming last item")
+	}
+}
+
+// TestSteerNoToolCallsContinuesWithMoreSteers verifies that when the model
+// gives a final answer but there are still queued steers, the loop continues
+// instead of returning done.
+func TestSteerNoToolCallsContinuesWithMoreSteers(t *testing.T) {
+	// Script: first turn returns text with no tool calls (final answer)
+	// but the steer queue has more items.
+	mp := testutil.NewMock("m",
+		testutil.Turn{Text: "first answer"},
+		testutil.Turn{Text: "second answer"},
+	)
+	sink := &sinkRecorder{}
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, sink)
+
+	// Queue two steers from the start
+	a.Steer("guidance one")
+	a.Steer("guidance two")
+
+	if err := a.Run(context.Background(), "initial prompt"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// The loop should have made 2 API calls (one per steer)
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 API requests (one per steer), got %d", len(reqs))
+	}
+
+	// First request should contain "guidance one"
+	req1 := reqs[0]
+	found1 := false
+	for _, msg := range req1.Messages {
+		if msg.Role == provider.RoleUser && msg.Content == midTurnSteerMessage("guidance one") {
+			found1 = true
+			break
+		}
+	}
+	if !found1 {
+		t.Fatal("first request missing 'guidance one' steer")
+	}
+
+	// Second request should contain "guidance two"
+	req2 := reqs[1]
+	found2 := false
+	for _, msg := range req2.Messages {
+		if msg.Role == provider.RoleUser && msg.Content == midTurnSteerMessage("guidance two") {
+			found2 = true
+			break
+		}
+	}
+	if !found2 {
+		t.Fatal("second request missing 'guidance two' steer")
+	}
+}
+
+// TestSteerEventEmitted verifies a Steer event is emitted when a steer is consumed.
+func TestSteerEventEmitted(t *testing.T) {
+	mp := testutil.NewMock("m", testutil.Turn{Text: "ok"})
+	sink := &sinkRecorder{}
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, sink)
+
+	a.Steer("guide me")
+	if err := a.Run(context.Background(), "do it"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	events := sink.Events()
+	var steerEvents []event.Event
+	for _, e := range events {
+		if e.Kind == event.Steer {
+			steerEvents = append(steerEvents, e)
+		}
+	}
+	if len(steerEvents) == 0 {
+		t.Fatal("no Steer events emitted")
+	}
+	if steerEvents[0].Text != "guide me" {
+		t.Fatalf("Steer event text = %q, want %q", steerEvents[0].Text, "guide me")
+	}
+}
+
+// TestSteerQueueEmptiedOnRunExit verifies clearSteerQueue runs when Run exits.
+func TestSteerQueueEmptiedOnRunExit(t *testing.T) {
+	mp := testutil.NewMock("m", testutil.Turn{Text: "ok"})
+	a := New(mp, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	// Steer before Run
+	a.Steer("hello")
+
+	// Run should consume the steer, then clear on exit (defer)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Queue should be empty after Run exits
+	if text, ok := a.consumeSteer(); ok {
+		t.Fatalf("expected empty steer queue after Run, got %q", text)
+	}
+}
+
+// TestSteerWrappedWithMessage verifies the steer message is wrapped with
+// the mid-turn steer prefix.
+func TestSteerWrappedWithMessage(t *testing.T) {
+	wrapped := midTurnSteerMessage("focus on tests")
+	if wrapped != midTurnSteerPrefix+"\n"+"focus on tests" {
+		t.Fatalf("unexpected wrap format: %q", wrapped)
+	}
+}
+
+// TestSteerPersistsAcrossIterations verifies that a mid-turn steer,
+// once consumed and persisted to the session, appears in every
+// subsequent API request within the same turn — not just the one
+// where it was consumed. This is the key difference from the
+// pre-fix behaviour where a steer was spliced into a temporary
+// msgs copy and lost on the next iteration.
+func TestSteerPersistsAcrossIterations(t *testing.T) {
+	reg := tool.NewRegistry()
+	// Register a read-only tool so the agent can execute it without gating.
+	reg.Add(fakeTool{name: "ls", readOnly: true})
+
+	// Script: first turn returns a tool call (so the loop iterates again),
+	// second turn returns a final answer.
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "ls", Arguments: `{}`}},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	sink := &sinkRecorder{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	a.Steer("use short responses")
+	if err := a.Run(context.Background(), "list files"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 API requests (tool call + final answer), got %d", len(reqs))
+	}
+
+	steerMsg := midTurnSteerMessage("use short responses")
+
+	// The steer must appear in the first request (iteration 1).
+	found1 := msgListContains(reqs[0].Messages, provider.RoleUser, steerMsg)
+	if !found1 {
+		t.Fatal("iteration 1: steer message not found in API request")
+	}
+
+	// The steer must also appear in the second request (iteration 2)
+	// — proving it persisted in the session, not just a temporary copy.
+	found2 := msgListContains(reqs[1].Messages, provider.RoleUser, steerMsg)
+	if !found2 {
+		t.Fatal("iteration 2: steer message NOT found — it was lost after the first iteration (pre-fix behaviour)")
+	}
+
+	// The steer should appear exactly once in each request (not duplicated).
+	count1 := msgCount(reqs[0].Messages, provider.RoleUser, steerMsg)
+	count2 := msgCount(reqs[1].Messages, provider.RoleUser, steerMsg)
+	if count1 != 1 {
+		t.Fatalf("iteration 1: steer appears %d times, want 1", count1)
+	}
+	if count2 != 1 {
+		t.Fatalf("iteration 2: steer appears %d times, want 1", count2)
+	}
+}
+
+// TestSteerPersistsWhenInjectedMidLoop verifies that a steer injected
+// after the turn has already started (simulating a real mid-turn user
+// interaction) also persists into subsequent iterations.
+func TestSteerPersistsWhenInjectedMidLoop(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "ls", readOnly: true})
+
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			ToolCalls: []provider.ToolCall{{ID: "call_1", Name: "ls", Arguments: `{}`}},
+		},
+		testutil.Turn{Text: "done"},
+	)
+	sink := &sinkRecorder{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	// Simulate the real scenario: the steer arrives during the turn,
+	// not before it. We steer right before Run — the effect is the
+	// same as a user typing while the agent is in iteration 0 (the
+	// steer is consumed at the iteration 1 boundary in practice, but
+	// here it's already queued at iteration 0).
+	a.Steer("mid-turn correction")
+
+	if err := a.Run(context.Background(), "do work"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 API requests, got %d", len(reqs))
+	}
+
+	steerMsg := midTurnSteerMessage("mid-turn correction")
+
+	if !msgListContains(reqs[0].Messages, provider.RoleUser, steerMsg) {
+		t.Fatal("iteration 1: steer not found")
+	}
+	if !msgListContains(reqs[1].Messages, provider.RoleUser, steerMsg) {
+		t.Fatal("iteration 2: steer NOT found — persistence broken")
+	}
+}
+
+func msgListContains(msgs []provider.Message, role provider.Role, content string) bool {
+	return msgCount(msgs, role, content) > 0
+}
+
+func msgCount(msgs []provider.Message, role provider.Role, content string) int {
+	n := 0
+	for _, m := range msgs {
+		if m.Role == role && m.Content == content {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -71,6 +71,8 @@ type chatTUI struct {
 	// the provider re-attempts the connection; cleared by the next stream event.
 	retryAttempt int
 	retryMax     int
+	// steerStaged counts queued mid-turn steers not yet consumed.
+	steerStaged int
 	// turnTokens accumulates this turn's output tokens (summed from per-step Usage
 	// events) for the live "↓N" readout in the running status line.
 	turnTokens int
@@ -513,6 +515,12 @@ func (m *chatTUI) recallSubmittedInput(delta int) bool {
 func (m *chatTUI) resetSubmittedInputRecall() {
 	m.submittedInputCursor = -1
 	m.submittedInputDraft = ""
+}
+
+// isSteerCommand rejects slash commands and bang-prefixed inputs during steer.
+func isSteerCommand(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	return strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "#\t") || strings.HasPrefix(trimmed, "!")
 }
 
 // navigateQueue moves through the pending interject queue during tuiRunning.
@@ -989,21 +997,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			if m.state == tuiRunning {
 				line := strings.TrimSpace(m.input.Value())
-				if line == "" {
+				if line == "" || isSteerCommand(line) {
 					return m, nil
 				}
-				if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {
-					// Save the edited text back to the queue slot.
-					m.pendingInterject[m.queueEditCursor] = line
-					m.notice(fmt.Sprintf("queue [%d] updated", m.queueEditCursor+1))
-					m.queueEditCursor = -1
-					m.queueEditDraft = ""
-				} else {
-					m.pendingInterject = append(m.pendingInterject, line)
-					m.notice("feedback queued — will send when the current turn finishes")
-					m.queueEditCursor = -1
-					m.queueEditDraft = ""
-				}
+				m.ctrl.Steer(line)
+				m.steerStaged++
 				m.input.Reset()
 				m.input.SetHeight(1)
 				m.pastedBlocks = nil
@@ -1055,6 +1053,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.runStart = time.Now()
 				m.elapsed = 0
 				m.turnTokens = 0
+				m.steerStaged = 0
 				m.pendingRestore = line
 				m.bubbleStartIdx = len(m.transcript)
 				m.commitLine("")
@@ -1951,12 +1950,8 @@ func (m chatTUI) View() tea.View {
 			if m.turnTokens > 0 {
 				working += " · ↓" + shortTokens(m.turnTokens)
 			}
-			if n := len(m.pendingInterject); n > 0 {
-				if n == 1 {
-					working += dim(" · ✎ feedback queued")
-				} else {
-					working += dim(fmt.Sprintf(" · ✎ %d queued", n))
-				}
+			if m.steerStaged > 0 {
+				working += fmt.Sprintf(" · ▸ %d staged", m.steerStaged)
 			}
 		}
 	}
@@ -2695,6 +2690,7 @@ func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string) tea.Cmd
 	m.runStart = time.Now()
 	m.elapsed = 0
 	m.turnTokens = 0
+	m.steerStaged = 0
 	// The controller owns the run goroutine, its context, and cancellation; it
 	// streams events to eventCh and emits TurnDone when the turn settles.
 	m.ctrl.SendWithRaw(sent, raw)
@@ -2882,6 +2878,13 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		}
 		m.refreshMCPManager()
 
+	case event.Steer:
+		if m.steerStaged > 0 {
+			m.steerStaged--
+		}
+		m.finalizeStreamed()
+		m.commitLine("  ▸ steer: " + e.Text)
+
 	case event.TurnDone:
 		// The turn settled — freeze anything still streaming, surface a real error,
 		// and gate a plan-mode proposal on the user's approval. Autosave already
@@ -2894,6 +2897,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 		// just clear the un-sendable flag.
 		m.confirmBubbleSent()
 		m.state = tuiIdle
+		m.steerStaged = 0
 		m.queueEditCursor = -1
 		m.queueEditDraft = ""
 		m.clearSubmittedPastes()

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1718,6 +1718,27 @@ func (c *Controller) Bypass() bool {
 	return c.bypass
 }
 
+// Steer queues guidance mid-turn without interrupting the in-flight request.
+func (c *Controller) Steer(text string) {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		exec.Steer(text)
+	}
+}
+
+// SteerConsumed returns true when the steer queue is empty after the last consume.
+func (c *Controller) SteerConsumed() bool {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		return exec.SteerConsumed()
+	}
+	return true
+}
+
 // --- memory ---
 //
 // c.mem is treated as an immutable snapshot guarded by c.mu: reads take the lock

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -79,6 +79,10 @@ const (
 	// event — or TurnDone — clears. Appended last to keep the Kind values before
 	// it wire-stable.
 	Retrying
+	// Steer fires when a mid-turn steer message is consumed from the queue and
+	// injected as a user message. Text carries the raw steer content (without the
+	// wrapper prefix), so a frontend can display it to the user as confirmation.
+	Steer
 )
 
 // Level classifies a Notice so sinks can style or filter it.


### PR DESCRIPTION
Mid-turn steer:
- Agent: FIFO steer queue consumed per loop iteration, persisted to session
- Event: new Steer kind for frontend confirmation
- Controller: Steer()/SteerConsumed() delegated to executor
- CLI/TUI: Enter during running calls Steer() for non-command text; steerStaged indicator in status line; event.Steer renders confirm line

Tool-call cards in history:
- HistoryMessage (Go + TS): add toolName/toolArgs/toolOutput/toolId/toolTruncated
- historyMessages: build toolCallByID map from assistant ToolCalls, populate tool fields on RoleTool messages for history/preview panels