### PR TITLE
fix(cli): prevent bang shell commands from grabbing the TUI

### DIFF
--- a/internal/control/shell_kill_other.go
+++ b/internal/control/shell_kill_other.go
@@ -7,12 +7,11 @@ import (
 	"syscall"
 )
 
-// setShellKillTree makes a cancelled shell command kill its whole process group,
-// not just the shell leader — otherwise a timed-out pipeline (e.g.
-// !find / -name foo | grep bar) orphans the children. The child gets its own
-// group (Setpgid) so the negative-pid signal reaches every descendant.
+// setShellKillTree makes cancellation kill the whole shell tree. Running the
+// child in a new session also keeps interactive prompts from grabbing the TUI's
+// controlling terminal.
 func setShellKillTree(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {
 			return nil

--- a/internal/control/shell_kill_other_test.go
+++ b/internal/control/shell_kill_other_test.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package control
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestSetShellKillTreeDetachesControllingTerminal(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "true")
+	setShellKillTree(cmd)
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil")
+	}
+	if !cmd.SysProcAttr.Setsid {
+		t.Fatal("shell commands should run in a new session so interactive prompts cannot grab the TUI terminal")
+	}
+}

--- a/internal/control/shell_test.go
+++ b/internal/control/shell_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"reasonix/internal/event"
+	"reasonix/internal/sandbox"
 )
 
 // collectSink returns a Sink that collects events and a channel that receives
@@ -137,5 +138,23 @@ func TestRunShell_FailingCommand(t *testing.T) {
 	}
 	if result.Tool.Err == "" {
 		t.Error("failing command should produce an error string")
+	}
+}
+
+func TestRunShell_CancelStopsCommand(t *testing.T) {
+	sink, done, _ := collectSink()
+	ctrl := &Controller{sink: sink}
+
+	command := "sleep 30"
+	if sandbox.ResolveShell().Kind == sandbox.ShellPowerShell {
+		command = "Start-Sleep -Seconds 30"
+	}
+	ctrl.RunShell(command)
+	time.Sleep(100 * time.Millisecond)
+	ctrl.Cancel()
+
+	e := waitForDone(t, done)
+	if e.Kind != event.TurnDone {
+		t.Fatalf("done event kind = %v, want TurnDone", e.Kind)
 	}
 }


### PR DESCRIPTION
## Summary
- Run user-invoked `!` shell commands in a new POSIX session so interactive tools such as `sudo` cannot grab the TUI controlling terminal.
- Keep cancellation killing the whole shell process group.
- Add coverage for shell cancellation and the POSIX session-detach contract.

## Root cause
`!sudo ls` can make sudo open `/dev/tty` for password input instead of reading from the captured stdin/stdout pipes. In the chat TUI that steals the terminal from Bubble Tea, so the turn appears stuck and Esc/Ctrl+C cannot be handled reliably until the shell timeout.

## Validation
- `go test ./internal/control -count=1`
- `GOOS=darwin GOARCH=amd64 go test -c ./internal/control`
- `go test ./internal/cli -run Test.*(Shell|Bang|Cancel|Esc|Ctrl|ToolProgress|ToolResult) -count=1`

Note: `go test ./internal/cli ./internal/control -count=1` still hits the existing unrelated `TestModelSwitchRefreshesCustomStatusline` failure in `internal/cli`.

Closes #3229