### PR TITLE
feat(desktop): mid-turn steer injection and tool-call details in history

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -941,9 +941,14 @@ func (a *App) SwitchWorkspace(dir string) (string, error) {
 // HistoryMessage is one prior turn, for the frontend to repopulate its transcript
 // after a reload.
 type HistoryMessage struct {
-	Role      string `json:"role"`
-	Content   string `json:"content"`
-	Reasoning string `json:"reasoning,omitempty"`
+	Role          string `json:"role"`
+	Content       string `json:"content"`
+	Reasoning     string `json:"reasoning,omitempty"`
+	ToolName      string `json:"toolName,omitempty"`
+	ToolArgs      string `json:"toolArgs,omitempty"`
+	ToolOutput    string `json:"toolOutput,omitempty"`
+	ToolID        string `json:"toolId,omitempty"`
+	ToolTruncated bool   `json:"toolTruncated,omitempty"`
 }
 
 // History returns the session's message log.
@@ -961,6 +966,14 @@ func (a *App) HistoryForTab(tabID string) []HistoryMessage {
 }
 
 func historyMessages(msgs []provider.Message, resolveUserContent func(string) string) []HistoryMessage {
+	toolCallByID := make(map[string]provider.ToolCall, 4)
+	for _, m := range msgs {
+		if m.Role == provider.RoleAssistant {
+			for _, tc := range m.ToolCalls {
+				toolCallByID[tc.ID] = tc
+			}
+		}
+	}
 	out := make([]HistoryMessage, 0, len(msgs))
 	for _, m := range msgs {
 		content := m.Content
@@ -971,7 +984,20 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 		if m.Role == provider.RoleAssistant {
 			reasoning = m.ReasoningContent
 		}
-		out = append(out, HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning})
+		hm := HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning}
+		if m.Role == provider.RoleTool {
+			hm.ToolName = m.Name
+			hm.ToolOutput = m.Content
+			hm.ToolID = m.ToolCallID
+			hm.Content = ""
+			if tc, ok := toolCallByID[m.ToolCallID]; ok {
+				hm.ToolArgs = tc.Arguments
+				if hm.ToolName == "" {
+					hm.ToolName = tc.Name
+				}
+			}
+		}
+		out = append(out, hm)
 	}
 	return out
 }
@@ -1117,6 +1143,16 @@ func (a *App) SetBypass(on bool) {
 		return
 	}
 	a.SetModeForTab("", "normal")
+}
+
+// Steer sends mid-turn guidance to the agent without interrupting the in-flight request.
+func (a *App) Steer(text string) {
+	a.mu.RLock()
+	ctrl := a.ctrlByTabID("")
+	a.mu.RUnlock()
+	if ctrl != nil {
+		ctrl.Steer(text)
+	}
 }
 
 // CommandInfo describes one available slash command for the composer's "/" menu.

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -233,6 +233,7 @@ export default function App() {
     activeTabId,
     send,
     runShell,
+    steer,
     notice,
     cancel,
     approve,
@@ -334,6 +335,7 @@ export default function App() {
   const [footerHeight, setFooterHeight] = useState(0);
   const layoutRef = useRef<HTMLDivElement>(null);
   const footerRef = useRef<HTMLElement>(null);
+  const runningRef = useRef(state.running);
   const [layoutWidth, setLayoutWidth] = useState(0);
   const preferredWorkspacePanelWidth =
     rightDockMode === "context"
@@ -523,6 +525,12 @@ export default function App() {
     send(text);
   }, [pendingPlanRevision, send, state.running]);
 
+  // Keep runningRef in sync so handleSend sees the latest running value
+  // even inside a stale closure.
+  useEffect(() => {
+    runningRef.current = state.running;
+  }, [state.running]);
+
   // Memory drawer: opening fetches a fresh snapshot; writes re-fetch so the
   // panel reflects what landed on disk.
   const openMemory = useCallback(async () => {
@@ -585,10 +593,11 @@ export default function App() {
         notice(t("settings.themeUnknown", { name: arg }), "warn");
         return;
       }
+      if (runningRef.current) { steer(submitText.trim()); return; }
       await syncModeToController(mode);
       send(trimmed, submitText.trim());
     },
-    [switchModel, openMemory, syncModeToController, mode, send, runShell, notice, t],
+    [switchModel, openMemory, syncModeToController, mode, send, steer, runShell, notice, t],
   );
 
   const refreshTabMetas = useCallback(async (): Promise<TabMeta[]> => {

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -439,11 +439,22 @@ function previewMessagesToItems(messages: HistoryMessage[]): Item[] {
     .filter(
       (m) =>
         (m.role === "user" && m.content.trim() !== "") ||
-        (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
+        (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")) ||
+        (m.role === "tool" && (m.toolName ?? "").trim() !== ""),
     )
-    .map((m, i) =>
-      m.role === "user"
-        ? { kind: "user", id: `hp${i}`, text: m.content }
-        : { kind: "assistant", id: `hp${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
-    );
+    .map((m, i) => {
+      if (m.role === "user") return { kind: "user", id: `hp${i}`, text: m.content };
+      if (m.role === "tool")
+        return {
+          kind: "tool",
+          id: m.toolId || `hp${i}`,
+          name: m.toolName || "",
+          args: m.toolArgs || "",
+          readOnly: false,
+          status: "done" as const,
+          output: m.toolOutput,
+          truncated: m.toolTruncated,
+        };
+      return { kind: "assistant", id: `hp${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false };
+    });
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -82,6 +82,7 @@ export interface AppBindings {
   SubmitDisplay(display: string, input: string): Promise<void>;
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
   RunShell(command: string): Promise<void>;
+  Steer(text: string): Promise<void>;
   Cancel(): Promise<void>;
   CancelTab(tabID: string): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
@@ -825,6 +826,12 @@ function makeMockApp(): AppBindings {
           if (cancelled) return;
           emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
           emit({ kind: "turn_done" });
+        },
+        async Steer(_text) {
+          // Mock: emit a steer event as confirmation in the transcript
+          emit({ kind: "steer", text: _text });
+          // In the real app, steer is fire-and-forget to the agent queue.
+          // In the mock, simulate it being consumed immediately.
         },
         async Cancel() {
           cancelled = true;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -17,7 +17,8 @@ export type EventKind =
   | "turn_done"
   | "compaction_started"
   | "compaction_done"
-  | "retrying";
+  | "retrying"
+  | "steer";
 
 export interface WireCompaction {
   trigger?: string; // "auto" | "manual"
@@ -189,6 +190,11 @@ export interface HistoryMessage {
   role: string;
   content: string;
   reasoning?: string;
+  toolName?: string;
+  toolArgs?: string;
+  toolOutput?: string;
+  toolId?: string;
+  toolTruncated?: boolean;
 }
 
 // CheckpointMeta is one rewind point (a user turn) for the rewind UI.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -267,15 +267,29 @@ function reducer(s: State, a: Action): State {
     case "message_action_start": return { ...s, messageAction: a.action };
     case "message_action_done": return { ...s, messageAction: undefined };
     case "history": {
+      // User, assistant, and tool-result messages. Tool messages need
+      // toolName set by the backend before rendering as ToolCard.
       const visible = a.messages.filter(
-        (m) => (m.role === "user" && m.content.trim() !== "") ||
-               (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
+        (m) =>
+          (m.role === "user" && m.content.trim() !== "") ||
+          (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")) ||
+          (m.role === "tool" && (m.toolName ?? "").trim() !== ""),
       );
-      const items: Item[] = visible.map((m, i) =>
-        m.role === "user"
-          ? { kind: "user", id: `h${i}`, text: m.content }
-          : { kind: "assistant", id: `h${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
-      );
+      const items: Item[] = visible.map((m, i) => {
+        if (m.role === "user") return { kind: "user", id: `h${i}`, text: m.content };
+        if (m.role === "tool")
+          return {
+            kind: "tool",
+            id: m.toolId || `h${i}`,
+            name: m.toolName || "",
+            args: m.toolArgs || "",
+            readOnly: false,
+            status: "done" as const,
+            output: m.toolOutput,
+            truncated: m.toolTruncated,
+          };
+        return { kind: "assistant", id: `h${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false };
+      });
       return { ...s, items, seq: s.seq + visible.length };
     }
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
@@ -431,6 +445,12 @@ export function useController() {
     if (!activeTabId) return;
     dispatchTo(activeTabId, { type: "user", text: `!${command}` });
     app.RunShell(command).catch(() => {});
+  }, [activeTabId, dispatchTo]);
+
+  const steer = useCallback((text: string) => {
+    if (!activeTabId) return;
+    dispatchTo(activeTabId, { type: "user", text });
+    app.Steer(text).catch(() => {});
   }, [activeTabId, dispatchTo]);
 
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
@@ -631,7 +651,7 @@ export function useController() {
   return {
     state: activeState,
     activeTabId,
-    send, runShell, notice, cancel, approve, answerQuestion, setControllerMode,
+    send, runShell, steer, notice, cancel, approve, answerQuestion, setControllerMode,
     newSession, listSessions, listTrashedSessions, resumeSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, setModel, setEffort,
     fetchMemory, remember, forget, saveDoc,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -178,6 +178,13 @@ type Agent struct {
 	// reach it. nil leaves those tools to degrade gracefully.
 	jobs *jobs.Manager
 
+	// steerQueue holds mid-turn user messages queued while the agent is
+	// running. Each is consumed once per loop iteration, persisted to the
+	// session, and remains visible for the rest of the turn.
+	steerMu       sync.Mutex
+	steerQueue    []string
+	steerConsumed bool
+
 	// evidence is a per-user-turn ledger of host-observed tool receipts. It lets
 	// complete_step validate that cited evidence happened before the claim.
 	evidence *evidence.Ledger
@@ -292,6 +299,53 @@ func (a *Agent) SessionCache() (hit, miss int) {
 // means compaction is disabled for this agent.
 func (a *Agent) ContextWindow() int { return a.contextWindow }
 
+// mid-turn steer marker.
+const midTurnSteerPrefix = "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]"
+
+func midTurnSteerMessage(text string) string {
+	return midTurnSteerPrefix + "\n" + text
+}
+
+// Steer queues a message for mid-turn injection.
+func (a *Agent) Steer(text string) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = append(a.steerQueue, text)
+	a.steerConsumed = false
+}
+
+// SteerConsumed returns true when the steer queue became empty.
+func (a *Agent) SteerConsumed() bool {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return a.steerConsumed
+}
+
+func (a *Agent) consumeSteer() (string, bool) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	if len(a.steerQueue) == 0 {
+		return "", false
+	}
+	t := a.steerQueue[0]
+	a.steerQueue = a.steerQueue[1:]
+	a.steerConsumed = len(a.steerQueue) == 0
+	return t, true
+}
+
+func (a *Agent) clearSteerQueue() {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = nil
+	a.steerConsumed = false
+}
+
+func (a *Agent) steerQueueLen() int {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return len(a.steerQueue)
+}
+
 // CompactRatio returns the fraction of the window at which auto-compaction
 // fires (e.g. 0.8). The status line uses it to show headroom to the next compact.
 func (a *Agent) CompactRatio() float64 { return a.compactRatio }
@@ -390,6 +444,10 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 // a round count. A positive maxSteps imposes an optional hard guard, surfaced as
 // a resumable notice when hit.
 func (a *Agent) Run(ctx context.Context, input string) error {
+	defer a.clearSteerQueue()
+	a.steerMu.Lock()
+	a.steerConsumed = false
+	a.steerMu.Unlock()
 	if a.evidence != nil {
 		a.evidence.Reset()
 	}
@@ -399,6 +457,11 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 	finalReadinessBlocks := 0
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
+		// Consume a queued steer and persist it to the session.
+		if text, ok := a.consumeSteer(); ok {
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: midTurnSteerMessage(text)})
+			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
+		}
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
 		prevPrefixShape := a.lastPrefixShape
@@ -443,6 +506,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + reason})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: finalReadinessRetryMessage(reason)})
 				a.maybeCompact(ctx, usage)
+				continue
+			}
+			if a.steerQueueLen() > 0 {
 				continue
 			}
 			return nil // model gave a final answer

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -739,6 +739,27 @@ func (c *Controller) EnableInteractiveApproval() {
 	}
 }
 
+// Steer queues mid-turn guidance without interrupting the in-flight request.
+func (c *Controller) Steer(text string) {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		exec.Steer(text)
+	}
+}
+
+// SteerConsumed returns true when the steer queue is empty after the last consume.
+func (c *Controller) SteerConsumed() bool {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		return exec.SteerConsumed()
+	}
+	return true
+}
+
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -79,6 +79,11 @@ const (
 	// event — or TurnDone — clears. Appended last to keep the Kind values before
 	// it wire-stable.
 	Retrying
+	// Steer fires when a mid-turn steer message is consumed from the queue and
+	// injected as a user message. Text carries the raw steer content (without the
+	// wrapper prefix), so a frontend can display it to the user as confirmation.
+	// Frontends use Steer to know a queued message has been delivered.
+	Steer
 )
 
 // Level classifies a Notice so sinks can style or filter it.


### PR DESCRIPTION
Fix two core desktop features:
1. Model dialogue mid-turn steer: when the model is running, user input is now injected as mid-turn guidance via a steer queue instead of being silently dropped by runGuarded. A runningRef replaces the stale state.running closure in handleSend, and the steer flows through App.Steer -> Controller.Steer -> Agent.Steer into a FIFO queue consumed each iteration of the agent loop, persisted to the session so it remains visible for subsequent API calls. A Steer event confirms delivery to the frontend.

2. History tool-call details: HistoryMessage now carries ToolName, ToolArgs, ToolOutput, ToolID, and ToolTruncated fields mapped from the provider's tool-call records. The history reducer and HistoryPanel's previewMessagesToItems render tool messages as ToolCard items, so switching between saved sessions shows full tool invocation details.

Changes:
- internal/event/event.go: add Steer event kind
- internal/agent/agent.go: add steerQueue, Steer/consumeSteer/ SteerConsumed/clearSteerQueue/steerQueueLen, midTurnSteerPrefix, and steer consumption/peristence in Run loop
- internal/control/controller.go: add Steer/SteerConsumed methods
- desktop/app.go: add App.Steer, expand HistoryMessage struct with tool fields, map tool messages in historyMessages via toolCallByID
- desktop/frontend/src/lib/bridge.ts: add Steer to AppBindings and mock
- desktop/frontend/src/lib/types.ts: add steer event kind, tool fields to HistoryMessage
- desktop/frontend/src/lib/useController.ts: add steer callback, update history reducer for tool messages
- desktop/frontend/src/App.tsx: add runningRef + steer in handleSend
- desktop/frontend/src/components/HistoryPanel.tsx: update previewMessagesToItems for tool messages