### PR TITLE
fix: grow TUI composer for wrapped input

### DIFF
--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -14,6 +14,7 @@ import (
 func newTestChatTUI() chatTUI {
 	commit := []string{}
 	ti := textarea.New()
+	configureChatTextarea(&ti)
 	ti.SetWidth(80)
 	return chatTUI{
 		input:                ti,

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -419,18 +419,7 @@ type clipboardPasteMsg struct {
 // the controller, so a resumed session pre-populates scrollback.
 func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Event, termW int) chatTUI {
 	ti := textarea.New()
-	ti.Prompt = ""
-	ti.CharLimit = 16384
-	ti.SetHeight(1)
-	ti.ShowLineNumbers = false
-	applyTextareaTheme(&ti)
-	// Use the real terminal cursor (not a styled virtual one) so View can place
-	// it at the insertion point and IME candidate windows anchor to the input.
-	ti.SetVirtualCursor(false)
-	// Plain Enter submits (the chatTUI handler intercepts it), so the textarea's
-	// own InsertNewline binding moves to Alt+Enter / Ctrl+J / Shift+Enter.
-	ti.KeyMap.InsertNewline = key.NewBinding(key.WithKeys("alt+enter", "ctrl+j", "shift+enter"))
-	ti.Focus()
+	configureChatTextarea(&ti)
 
 	sp := spinner.New()
 	sp.Spinner = spinner.Dot
@@ -464,6 +453,25 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		skills:               ctrl.Skills(),
 		viewport:             viewport.New(viewport.WithWidth(termW)),
 	}
+}
+
+func configureChatTextarea(ti *textarea.Model) {
+	ti.Prompt = ""
+	ti.CharLimit = 16384
+	ti.DynamicHeight = true
+	ti.MinHeight = 1
+	ti.MaxHeight = maxInputRows
+	ti.MaxContentHeight = ti.CharLimit
+	ti.SetHeight(1)
+	ti.ShowLineNumbers = false
+	applyTextareaTheme(ti)
+	// Use the real terminal cursor (not a styled virtual one) so View can place
+	// it at the insertion point and IME candidate windows anchor to the input.
+	ti.SetVirtualCursor(false)
+	// Plain Enter submits (the chatTUI handler intercepts it), so the textarea's
+	// own InsertNewline binding moves to Alt+Enter / Ctrl+J / Shift+Enter.
+	ti.KeyMap.InsertNewline = key.NewBinding(key.WithKeys("alt+enter", "ctrl+j", "shift+enter"))
+	ti.Focus()
 }
 
 func (m *chatTUI) rememberSubmittedInput(input string) {
@@ -788,7 +796,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "enter":
 					val := strings.TrimSpace(m.input.Value())
 					m.input.Reset()
-					m.input.SetHeight(1)
 					m.chooser.typing = false
 					if val == "" {
 						return m, finalize(m, cmds)
@@ -799,7 +806,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				case "esc":
 					m.chooser.typing = false
 					m.input.Reset()
-					m.input.SetHeight(1)
 					return m, finalize(m, cmds)
 				}
 				var ic tea.Cmd
@@ -1005,7 +1011,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.queueEditDraft = ""
 				}
 				m.input.Reset()
-				m.input.SetHeight(1)
 				m.pastedBlocks = nil
 				return m, finalize(m, cmds)
 			}
@@ -1026,7 +1031,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// space keeps "#7" / "#issue" prompts from being swallowed.
 			if note, ok := control.MemoryQuickAddNote(line); ok {
 				m.input.Reset()
-				m.input.SetHeight(1)
 				m.pastedBlocks = nil
 				if note == "" {
 					m.notice(i18n.M.QuickRememberEmpty)
@@ -1043,13 +1047,11 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmd := strings.TrimPrefix(line, "!")
 				if strings.TrimSpace(cmd) == "" {
 					m.input.Reset()
-					m.input.SetHeight(1)
 					m.pastedBlocks = nil
 					m.notice(i18n.M.ShellExecEmpty)
 					return m, finalize(m, cmds)
 				}
 				m.input.Reset()
-				m.input.SetHeight(1)
 				m.pastedBlocks = nil
 				m.state = tuiRunning
 				m.runStart = time.Now()
@@ -1074,7 +1076,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					line = ref
 				} else {
 					m.input.Reset()
-					m.input.SetHeight(1)
 					m.pastedBlocks = nil
 					cmds = append(cmds, m.runSlashCommand(line))
 					return m, finalize(m, cmds)
@@ -1083,7 +1084,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			sentLine := m.expandPastedBlocks(line)
 			m.input.Reset()
-			m.input.SetHeight(1)
 
 			// @references (local files / MCP resources, including inline image
 			// attachments) are resolved off the event loop by the controller; the turn
@@ -2448,6 +2448,9 @@ func (m *chatTUI) clearSubmittedPastes() {
 }
 
 func (m *chatTUI) growInputToFit() {
+	if m.input.DynamicHeight {
+		return
+	}
 	lines := strings.Count(m.input.Value(), "\n") + 1
 	if lines < 1 {
 		lines = 1

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -122,6 +122,65 @@ func TestTranscriptViewportSizing(t *testing.T) {
 	}
 }
 
+func TestManualNewlineGrowsComposerWithoutHidingFirstLine(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 40)
+
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 12})
+	m = m0.(chatTUI)
+	m.input.SetValue("first line")
+
+	m0, _ = m.Update(tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl})
+	m = m0.(chatTUI)
+
+	if got := m.input.Height(); got != 2 {
+		t.Fatalf("input height after Ctrl+J = %d, want 2", got)
+	}
+	if got := m.input.ScrollYOffset(); got != 0 {
+		t.Fatalf("input scroll offset after Ctrl+J = %d, want 0 so the first line remains visible", got)
+	}
+}
+
+func TestManualNewlineCanExceedVisibleComposerRows(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 40)
+
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 40, Height: 12})
+	m = m0.(chatTUI)
+	m.input.SetValue("first line")
+
+	for range maxInputRows + 1 {
+		m0, _ = m.Update(tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl})
+		m = m0.(chatTUI)
+	}
+
+	if got, want := strings.Count(m.input.Value(), "\n"), maxInputRows+1; got != want {
+		t.Fatalf("manual newlines preserved = %d, want %d", got, want)
+	}
+	if got := m.input.Height(); got != maxInputRows {
+		t.Fatalf("visible input height = %d, want capped at %d", got, maxInputRows)
+	}
+}
+
+func TestSoftWrappedInputGrowsComposerAndShrinksTranscript(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 24)
+
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 24, Height: 12})
+	m = m0.(chatTUI)
+	initialViewportHeight := m.viewport.Height()
+
+	m0, _ = m.Update(tea.PasteMsg{Content: strings.Repeat("x", 60)})
+	m = m0.(chatTUI)
+
+	if got := m.input.Height(); got <= 1 {
+		t.Fatalf("input height after soft-wrapped paste = %d, want > 1", got)
+	}
+	if got := m.viewport.Height(); got >= initialViewportHeight {
+		t.Fatalf("viewport height after composer growth = %d, want less than initial %d", got, initialViewportHeight)
+	}
+}
+
 func TestMCPManagerHidesComposerBox(t *testing.T) {
 	ctrl := control.New(control.Options{})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)


### PR DESCRIPTION
 ## 摘要

  修复 chat TUI 输入框在多行输入场景下不会正确动态增高的问题。

  本次修复覆盖两个相关现象：

  - 使用 `Ctrl+J` 手工换行时，输入框虽然插入了新行，但第一行可能被顶出可视区域。
  - 粘贴较长文本后，内容会发生软换行，但输入框仍保持一行高度，上方 transcript 区域也不会相应缩短。

  ## 改动内容

  - 将 chat textarea 初始化逻辑集中到 `configureChatTextarea`。
  - 启用 textarea 自带动态高度：
    - 最小高度：1 行
    - 最大可见高度：5 行
    - 内容高度上限与可见高度解耦，避免超过 5 行后无法继续输入换行
  - 移除清空输入后的手动 `SetHeight(1)`。
  - 保留现有换行快捷键绑定：
    - `Ctrl+J`
    - `Alt+Enter`
    - `Shift+Enter`
  - 当动态高度启用时，让 `growInputToFit` 不再手动覆盖 textarea 高度，避免和组件内部滚动状态冲突。

  ## 背景与原因

  之前的实现通过手动统计 `\n` 来调整输入框高度：

  ```go
  strings.Count(input, "\n") + 1
  ```
  这个方式有两个问题：

  1. 只能识别显式换行，无法识别因为终端宽度不足产生的软换行。
  2. 在 Ctrl+J 首次换行时，textarea
  会先按一行高度调整内部滚动位置，随后外层再手动增高，导致第一行被滚出可视区域。

  改为使用 textarea 自带的 DynamicHeight 后，高度计算由组件按 visual lines
  完成，可以同时覆盖手工换行和软换行。

  回归测试

  新增测试覆盖：

  - Ctrl+J 后输入框增高，且第一行不会被隐藏。
  - 手工换行可以超过输入框最大可见高度，输入内容不会被 5 行可见高度限制。
  - 粘贴长文本触发软换行后，输入框会增高，上方 transcript viewport 会相应缩短。

  测试计划

  - go test ./internal/cli -run 'TestManualNewlineGrowsComposerWithoutHidingFirstLine|TestManualNewlineCanExc
  eedVisibleComposerRows|TestSoftWrappedInputGrowsComposerAndShrinksTranscript'
  - go test ./internal/cli -run 'TestTranscriptViewportSizing|TestManualNewlineGrowsComposerWithoutHidingFirs
  tLine|TestManualNewlineCanExceedVisibleComposerRows|TestSoftWrappedInputGrowsComposerAndShrinksTranscript|T
  estPasteMsgFoldsBeforeTextareaConsumesNewlines|TestModalPanelsHideComposerBox|TestMCPManagerHidesComposerBo
  x|Test.*Completion|Test.*Paste|Test.*Input|Test.*Viewport|Test.*Render'
  - go test ./internal/cli
  - git diff --check


