### PR TITLE
fix(desktop): improve Windows install updates and portable release

### DIFF
--- a/desktop/build/windows/installer/project.nsi
+++ b/desktop/build/windows/installer/project.nsi
@@ -14,11 +14,13 @@ Unicode true
 ##      wails.deleteUninstaller macros hard-code HKLM, which a non-admin install
 ##      cannot write - so we inline HKCU versions below instead.
 ##   3. InstallDir is remembered across updates via InstallDirRegKey +
-##      InstallLocation (HKCU\...\Uninstall\InstallLocation). Without this, every
-##      release forces the user back to %LOCALAPPDATA%\Programs\Reasonix even if
-##      they had moved the install to a different drive (e.g. D:\Tools\Reasonix);
-##      the silent auto-updater would re-run with /S into the wrong dir, leaving
-##      the old install orphaned.
+##      InstallLocation (HKCU\...\Uninstall\InstallLocation). When upgrading from
+##      a build that did not write InstallLocation yet, .onInit falls back to the
+##      old DisplayIcon path before using the default. Without this, every release
+##      forces the user back to %LOCALAPPDATA%\Programs\Reasonix even if they had
+##      moved the install to a different drive (e.g. D:\Tools\Reasonix); the silent
+##      auto-updater would re-run with /S into the wrong dir, leaving the old
+##      install orphaned.
 ##
 ## Everything else mirrors Wails' generated default. Defines below override the
 ## ProjectInfo values that wails_tools.nsh would otherwise populate.
@@ -33,6 +35,7 @@ Unicode true
 ## wails.* macros used below).
 ####
 !include "wails_tools.nsh"
+!include "FileFunc.nsh"
 
 # The version information for this two must consist of 4 parts
 VIProductVersion "${INFO_PRODUCTVERSION}.0"
@@ -111,12 +114,20 @@ ShowInstDetails show # This will always show the installation details.
 Function .onInit
    !insertmacro wails.checkArchitecture
 
-   ; InstallDirRegKey leaves $INSTDIR empty when the InstallLocation value
-   ; is missing (first install, or the user wiped the uninstaller registry).
-   ; Fall back to the per-user default so the directory page lands on a
-   ; usable path instead of crashing the install with "InstallDir empty".
-   StrCmp $INSTDIR "" 0 +2
+   ; InstallDirRegKey leaves $INSTDIR empty when the InstallLocation value is
+   ; missing. Older installers still wrote DisplayIcon, so use its parent folder
+   ; as a compatibility bridge before falling back to the per-user default.
+   StrCmp $INSTDIR "" 0 done
+   ClearErrors
+   ReadRegStr $0 HKCU "${UNINST_KEY}" "DisplayIcon"
+   IfErrors fallback
+   StrCmp $0 "" fallback
+   ${GetParent} "$0" $INSTDIR
+   StrCmp $INSTDIR "" fallback done
+
+fallback:
    StrCpy $INSTDIR "${REASONIX_DEFAULT_INSTALLDIR}"
+done:
 FunctionEnd
 
 Section

--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -207,6 +207,9 @@ func genManifest(dir, version, tag string) error {
 
 // matchPlatform returns the platform key embedded in a file name, or "" if none.
 func matchPlatform(name string) string {
+	if strings.Contains(name, "windows-amd64") && !strings.HasSuffix(name, "-installer.exe") {
+		return ""
+	}
 	for _, p := range platforms {
 		if strings.Contains(name, p) {
 			return p

--- a/desktop/cmd/sign/main_test.go
+++ b/desktop/cmd/sign/main_test.go
@@ -55,6 +55,7 @@ func TestGenManifest(t *testing.T) {
 		"Reasonix-darwin-arm64.zip",
 		"Reasonix-darwin-amd64.zip",
 		"Reasonix-windows-amd64-installer.exe",
+		"Reasonix-windows-amd64.zip", // portable download, not the updater channel
 		"Reasonix-linux-amd64.tar.gz",
 		"Reasonix-linux-amd64.tar.gz.minisig", // must be skipped
 		"README.txt",                          // unmatched, must be skipped

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -7,7 +7,8 @@
 # desktop/cmd/sign's `manifest` subcommand maps back to update.PlatformKey:
 #   macOS:   Reasonix-darwin-<arch>.zip                  (ditto archive; updater channel)
 #            Reasonix-darwin-universal.dmg               (drag-to-install; human download)
-#   Windows: Reasonix-windows-<arch>-installer.exe       (NSIS per-user installer)
+#   Windows: Reasonix-windows-<arch>-installer.exe       (NSIS per-user installer; updater channel)
+#            Reasonix-windows-<arch>.zip                 (portable human download)
 #   Linux:   Reasonix-linux-<arch>.tar.gz                (bare binary)
 #
 # Usage: scripts/desktop-build.sh <os/arch> <version>
@@ -90,6 +91,14 @@ windows)
 	installer=$(ls build/bin/*installer*.exe 2>/dev/null | head -n1 || true)
 	[ -n "$installer" ] || { echo "no NSIS installer found in build/bin" >&2; exit 1; }
 	cp "$installer" "$ROOT/dist/${APPNAME}-windows-${arch}-installer.exe"
+	portable=$(find build/bin -maxdepth 1 -type f -name "*.exe" ! -name "*installer*.exe" | head -n1 || true)
+	[ -n "$portable" ] || { echo "no portable Windows exe found in build/bin" >&2; exit 1; }
+	staging=$(mktemp -d)
+	cp "$portable" "$staging/${APPNAME}.exe"
+	src_win=$(cygpath -w "$staging/${APPNAME}.exe")
+	zip_win=$(cygpath -w "$ROOT/dist/${APPNAME}-windows-${arch}.zip")
+	powershell.exe -NoProfile -Command "Compress-Archive -Force -LiteralPath '$src_win' -DestinationPath '$zip_win'"
+	rm -rf "$staging"
 	;;
 linux)
 	tar -czf "$ROOT/dist/${APPNAME}-linux-${arch}.tar.gz" -C build/bin "$BINNAME"


### PR DESCRIPTION
## Summary

- fall back from missing `InstallLocation` to the previous `DisplayIcon` path so manual Windows installer upgrades can keep the old install folder
- publish a Windows portable zip alongside the NSIS installer for users who do not want the installer flow
- keep the updater manifest pinned to the NSIS installer so portable zip assets do not become the auto-update channel

Closes #3274

## Tests

- `bash -n scripts/desktop-build.sh`
- `git diff --check`
- `go test ./cmd/sign ./internal/update`

## Notes

- Full `go test ./...` under `desktop/` still requires built frontend assets; without `frontend/dist`, the package setup fails before tests run.
- NSIS compilation and the Windows zip packaging path are expected to be covered by the Windows release runner.
