### PR TITLE
fix(desktop): preserve tool details in history

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -941,9 +941,18 @@ func (a *App) SwitchWorkspace(dir string) (string, error) {
 // HistoryMessage is one prior turn, for the frontend to repopulate its transcript
 // after a reload.
 type HistoryMessage struct {
-	Role      string `json:"role"`
-	Content   string `json:"content"`
-	Reasoning string `json:"reasoning,omitempty"`
+	Role       string            `json:"role"`
+	Content    string            `json:"content"`
+	Reasoning  string            `json:"reasoning,omitempty"`
+	ToolCalls  []HistoryToolCall `json:"toolCalls,omitempty"`
+	ToolCallID string            `json:"toolCallId,omitempty"`
+	ToolName   string            `json:"toolName,omitempty"`
+}
+
+type HistoryToolCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
 }
 
 // History returns the session's message log.
@@ -971,7 +980,18 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 		if m.Role == provider.RoleAssistant {
 			reasoning = m.ReasoningContent
 		}
-		out = append(out, HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning})
+		hm := HistoryMessage{Role: string(m.Role), Content: content, Reasoning: reasoning}
+		if m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
+			hm.ToolCalls = make([]HistoryToolCall, len(m.ToolCalls))
+			for i, tc := range m.ToolCalls {
+				hm.ToolCalls[i] = HistoryToolCall{ID: tc.ID, Name: tc.Name, Arguments: tc.Arguments}
+			}
+		}
+		if m.Role == provider.RoleTool {
+			hm.ToolCallID = m.ToolCallID
+			hm.ToolName = m.Name
+		}
+		out = append(out, hm)
 	}
 	return out
 }

--- a/desktop/frontend/src/components/HistoryPanel.tsx
+++ b/desktop/frontend/src/components/HistoryPanel.tsx
@@ -4,7 +4,7 @@ import { Archive, Pencil, Search, Trash2, RotateCcw } from "lucide-react";
 import { t, useT } from "../lib/i18n";
 import { sessionActivityTime } from "../lib/session";
 import type { HistoryMessage, SessionMeta } from "../lib/types";
-import type { Item } from "../lib/useController";
+import { historyMessagesToItems, type Item } from "../lib/useController";
 import { ResizableDrawer } from "./ResizableDrawer";
 import { Tooltip } from "./Tooltip";
 import { Transcript } from "./Transcript";
@@ -435,15 +435,5 @@ function sessionMetaLine(s: SessionMeta, tr: ReturnType<typeof useT>, isTrash = 
 }
 
 function previewMessagesToItems(messages: HistoryMessage[]): Item[] {
-  return messages
-    .filter(
-      (m) =>
-        (m.role === "user" && m.content.trim() !== "") ||
-        (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
-    )
-    .map((m, i) =>
-      m.role === "user"
-        ? { kind: "user", id: `hp${i}`, text: m.content }
-        : { kind: "assistant", id: `hp${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
-    );
+  return historyMessagesToItems(messages, "hp").items;
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -189,6 +189,15 @@ export interface HistoryMessage {
   role: string;
   content: string;
   reasoning?: string;
+  toolCalls?: HistoryToolCall[];
+  toolCallId?: string;
+  toolName?: string;
+}
+
+export interface HistoryToolCall {
+  id: string;
+  name: string;
+  arguments: string;
 }
 
 // CheckpointMeta is one rewind point (a user turn) for the rewind UI.

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -119,6 +119,72 @@ type Action =
 
 // ---- reducer helpers (unchanged logic) ----
 
+export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: string, startSeq = 0): { items: Item[]; seq: number } {
+  const resultByID = new Map<string, HistoryMessage>();
+  for (const m of messages) {
+    if (m.role === "tool" && m.toolCallId && !resultByID.has(m.toolCallId)) {
+      resultByID.set(m.toolCallId, m);
+    }
+  }
+
+  const items: Item[] = [];
+  let seq = startSeq;
+  const consumedToolIDs = new Set<string>();
+  for (const m of messages) {
+    if (m.role === "system") continue;
+    if (m.role === "user") {
+      if (m.content.trim() === "") continue;
+      items.push({ kind: "user", id: `${idPrefix}${seq}`, text: m.content });
+      seq++;
+      continue;
+    }
+    if (m.role === "assistant") {
+      const hasText = m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "";
+      if (hasText) {
+        items.push({ kind: "assistant", id: `${idPrefix}${seq}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false });
+        seq++;
+      }
+      for (const tc of m.toolCalls ?? []) {
+        const result = resultByID.get(tc.id);
+        if (tc.id) consumedToolIDs.add(tc.id);
+        const output = result?.content ?? "";
+        const error = output.startsWith("[error") || output.startsWith("Error:") ? output : undefined;
+        items.push({
+          kind: "tool",
+          id: tc.id || `${idPrefix}tool${seq}`,
+          name: tc.name,
+          args: tc.arguments ?? "",
+          readOnly: false,
+          status: error ? "error" : "done",
+          output,
+          error,
+          isShell: (tc.id || "").startsWith("shell-"),
+        });
+        seq++;
+      }
+      continue;
+    }
+    if (m.role === "tool") {
+      if (m.toolCallId && consumedToolIDs.has(m.toolCallId)) continue;
+      const output = m.content;
+      const error = output.startsWith("[error") || output.startsWith("Error:") ? output : undefined;
+      items.push({
+        kind: "tool",
+        id: m.toolCallId || `${idPrefix}tool${seq}`,
+        name: m.toolName || "tool",
+        args: "",
+        readOnly: false,
+        status: error ? "error" : "done",
+        output,
+        error,
+        isShell: (m.toolCallId || "").startsWith("shell-"),
+      });
+      seq++;
+    }
+  }
+  return { items, seq };
+}
+
 function ensureAssistant(s: State): { items: Item[]; id: string; seq: number } {
   if (s.currentAssistant) {
     const exists = s.items.some((it) => it.id === s.currentAssistant && it.kind === "assistant");
@@ -267,16 +333,8 @@ function reducer(s: State, a: Action): State {
     case "message_action_start": return { ...s, messageAction: a.action };
     case "message_action_done": return { ...s, messageAction: undefined };
     case "history": {
-      const visible = a.messages.filter(
-        (m) => (m.role === "user" && m.content.trim() !== "") ||
-               (m.role === "assistant" && (m.content.trim() !== "" || (m.reasoning ?? "").trim() !== "")),
-      );
-      const items: Item[] = visible.map((m, i) =>
-        m.role === "user"
-          ? { kind: "user", id: `h${i}`, text: m.content }
-          : { kind: "assistant", id: `h${i}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false },
-      );
-      return { ...s, items, seq: s.seq + visible.length };
+      const { items, seq } = historyMessagesToItems(a.messages, "h", s.seq);
+      return { ...s, items, seq };
     }
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": return { ...s, approval: undefined };

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -15,8 +15,10 @@ import (
 func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	msgs := []provider.Message{
 		{Role: provider.RoleUser, Content: "expanded prompt"},
-		{Role: provider.RoleAssistant, Content: "answer", ReasoningContent: "thinking trace"},
-		{Role: provider.RoleTool, Content: "tool output", ReasoningContent: "ignored by frontend filter"},
+		{Role: provider.RoleAssistant, Content: "answer", ReasoningContent: "thinking trace", ToolCalls: []provider.ToolCall{{
+			ID: "call_1", Name: "bash", Arguments: `{"command":"pwd"}`,
+		}}},
+		{Role: provider.RoleTool, Name: "bash", ToolCallID: "call_1", Content: "tool output", ReasoningContent: "ignored by frontend filter"},
 		{Role: provider.RoleAssistant, ReasoningContent: "tool-call-only thinking"},
 	}
 
@@ -35,6 +37,12 @@ func TestHistoryMessagesIncludeAssistantReasoning(t *testing.T) {
 	}
 	if got[1].Reasoning != "thinking trace" {
 		t.Fatalf("assistant reasoning = %q, want thinking trace", got[1].Reasoning)
+	}
+	if len(got[1].ToolCalls) != 1 || got[1].ToolCalls[0].ID != "call_1" || got[1].ToolCalls[0].Name != "bash" || got[1].ToolCalls[0].Arguments != `{"command":"pwd"}` {
+		t.Fatalf("assistant tool calls not preserved: %+v", got[1].ToolCalls)
+	}
+	if got[2].ToolCallID != "call_1" || got[2].ToolName != "bash" || got[2].Content != "tool output" {
+		t.Fatalf("tool result details not preserved: %+v", got[2])
 	}
 	if got[2].Reasoning != "" {
 		t.Fatalf("non-assistant reasoning should stay hidden, got %q", got[2].Reasoning)

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -650,11 +650,39 @@ function fetchStatus(){
 setInterval(fetchStatus,30000);
 
 // ── history ──
-fetch('/history').then(r=>r.json()).then(ms=>{
-  if(!ms||ms.length===0)return; hideWelcome();
-  ms.forEach(m=>{if(!m.content)return; if(m.role==='user'){addUserMsg(m.content);}else{const d=el('div','msg msg--assistant');d.appendChild(el('div','msg__text',m.content));log.appendChild(d);}});
+function renderHistoryMessages(ms){
+  if(!ms||ms.length===0)return;
+  hideWelcome(); toolCards={};
+  const resultById=new Map();
+  ms.forEach(m=>{if(m.role==='tool'&&m.toolCallId&&!resultById.has(m.toolCallId))resultById.set(m.toolCallId,m);});
+  const consumed=new Set();
+  let seq=0;
+  ms.forEach(m=>{
+    if(m.role==='system')return;
+    if(m.role==='user'){if(m.content)addUserMsg(m.content);return;}
+    if(m.role==='assistant'){
+      if(m.reasoning)appendReasoning(m.reasoning);
+      if(m.content)appendText(m.content);
+      if(m.content||m.reasoning)finalizeMsg();
+      (m.toolCalls||[]).forEach(tc=>{
+        const id=tc.id||'hist-tool-'+(seq++);
+        renderToolDispatch({id,name:tc.name,args:tc.arguments||'',readOnly:false});
+        const result=resultById.get(tc.id);
+        if(tc.id)consumed.add(tc.id);
+        if(result)renderToolResult({id,name:tc.name,output:result.content||''});
+      });
+      return;
+    }
+    if(m.role==='tool'){
+      if(m.toolCallId&&consumed.has(m.toolCallId))return;
+      const id=m.toolCallId||'hist-tool-'+(seq++);
+      renderToolDispatch({id,name:m.toolName||'tool',args:'',readOnly:false});
+      renderToolResult({id,name:m.toolName||'tool',output:m.content||''});
+    }
+  });
   currentMsg=null;currentText=null;currentReasoning=null; scrollDown();
-}).catch(()=>{});
+}
+fetch('/history').then(r=>r.json()).then(renderHistoryMessages).catch(()=>{});
 
 // ── session list ──
 function loadSessions(){
@@ -668,7 +696,7 @@ function loadSessions(){
       const title=s.title||name.replace(/^\w+-/,'').replace(/T/,' ').replace(/[-_]/g,' ').slice(0,30);
       const meta=s.turns?s.turns+' turns':'';
       item.innerHTML='<svg class="session-item__icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg><div class="session-item__body"><div class="session-item__title">'+escHtml(title)+'</div><div class="session-item__meta">'+escHtml(meta)+'</div></div>';
-      item.onclick=()=>{if(running||s.current)return;post('/resume',{path:s.path}).then(()=>{log.innerHTML='';log.appendChild(welcome);welcome.style.display='';loadSessions();setTimeout(()=>fetch('/history').then(r=>r.json()).then(ms=>{if(!ms||ms.length===0)return;hideWelcome();ms.forEach(m=>{if(!m.content)return;if(m.role==='user')addUserMsg(m.content);else{const d=el('div','msg msg--assistant');d.appendChild(el('div','msg__text',m.content));log.appendChild(d);}});currentMsg=null;scrollDown();}),300);});};
+      item.onclick=()=>{if(running||s.current)return;post('/resume',{path:s.path}).then(()=>{log.innerHTML='';log.appendChild(welcome);welcome.style.display='';loadSessions();setTimeout(()=>fetch('/history').then(r=>r.json()).then(renderHistoryMessages),300);});};
       list.appendChild(item);
     });
   }).catch(()=>{const list=$('#session-list');if(list)list.innerHTML='<div style="padding:10px;color:var(--muted-2);font-size:12px">Error loading</div>';});

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -425,20 +425,49 @@ func (s *Server) newSession(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// history returns the session's message log as {role, content} pairs so a
-// reconnecting client can repopulate its transcript. Supports ETag caching:
+type historyToolCall struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+}
+
+type historyMessage struct {
+	Role       string            `json:"role"`
+	Content    string            `json:"content"`
+	Reasoning  string            `json:"reasoning,omitempty"`
+	ToolCalls  []historyToolCall `json:"toolCalls,omitempty"`
+	ToolCallID string            `json:"toolCallId,omitempty"`
+	ToolName   string            `json:"toolName,omitempty"`
+}
+
+func historyMessages(msgs []provider.Message) []historyMessage {
+	out := make([]historyMessage, 0, len(msgs))
+	for _, m := range msgs {
+		hm := historyMessage{Role: string(m.Role), Content: m.Content}
+		if m.Role == provider.RoleAssistant {
+			hm.Reasoning = m.ReasoningContent
+			if len(m.ToolCalls) > 0 {
+				hm.ToolCalls = make([]historyToolCall, len(m.ToolCalls))
+				for i, tc := range m.ToolCalls {
+					hm.ToolCalls[i] = historyToolCall{ID: tc.ID, Name: tc.Name, Arguments: tc.Arguments}
+				}
+			}
+		}
+		if m.Role == provider.RoleTool {
+			hm.ToolCallID = m.ToolCallID
+			hm.ToolName = m.Name
+		}
+		out = append(out, hm)
+	}
+	return out
+}
+
+// history returns the session's message log so a reconnecting client can
+// repopulate its transcript, including historical tool cards. Supports ETag caching:
 // if the client sends If-None-Match with the current ETag, the server returns
 // 304 Not Modified with no body, saving bandwidth on reconnects.
 func (s *Server) history(w http.ResponseWriter, r *http.Request) {
-	type msg struct {
-		Role    string `json:"role"`
-		Content string `json:"content"`
-	}
-	var out []msg
-	for _, m := range s.ctl().History() {
-		out = append(out, msg{Role: string(m.Role), Content: m.Content})
-	}
-	writeJSONCached(w, r, out)
+	writeJSONCached(w, r, historyMessages(s.ctl().History()))
 }
 
 // context returns the prompt-vs-window gauge numbers. Supports ETag caching

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"reasonix/internal/control"
+	"reasonix/internal/provider"
 )
 
 // fakeRunner stands in for an agent.Runner: it records the composed input and
@@ -85,6 +86,29 @@ func TestServeEndpoints(t *testing.T) {
 
 	if resp, _ := http.Post(srv.URL+"/submit", "application/json", strings.NewReader(`{}`)); resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("empty submit should be 400, got %d", resp.StatusCode)
+	}
+}
+
+func TestHistoryMessagesPreserveToolDetails(t *testing.T) {
+	got := historyMessages([]provider.Message{
+		{Role: provider.RoleUser, Content: "run command"},
+		{Role: provider.RoleAssistant, Content: "checking", ReasoningContent: "think", ToolCalls: []provider.ToolCall{{
+			ID: "call_1", Name: "bash", Arguments: `{"command":"pwd"}`,
+		}}},
+		{Role: provider.RoleTool, Name: "bash", ToolCallID: "call_1", Content: "/tmp/project\n"},
+	})
+
+	if len(got) != 3 {
+		t.Fatalf("history length = %d, want 3", len(got))
+	}
+	if got[1].Reasoning != "think" {
+		t.Fatalf("assistant reasoning = %q, want think", got[1].Reasoning)
+	}
+	if len(got[1].ToolCalls) != 1 || got[1].ToolCalls[0].ID != "call_1" || got[1].ToolCalls[0].Name != "bash" || got[1].ToolCalls[0].Arguments != `{"command":"pwd"}` {
+		t.Fatalf("assistant tool calls not preserved: %+v", got[1].ToolCalls)
+	}
+	if got[2].ToolCallID != "call_1" || got[2].ToolName != "bash" || got[2].Content != "/tmp/project\n" {
+		t.Fatalf("tool result details not preserved: %+v", got[2])
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve assistant tool calls and tool-result linkage in desktop history payloads
- rebuild historical ToolCard entries for desktop History, Preview, and Resume flows
- preserve and replay tool cards from `reasonix serve` `/history`

## Related
- Fixes #3268
- Related #3195

## Verification
- `go test ./internal/serve -count=1`
- `go test . -run 'TestHistoryMessages|TestPreviewSessionMessages' -count=1` from `desktop/`\n- `git diff --check`\n\nNote: frontend `npm run typecheck` is blocked in this worktree by missing generated Wails bindings (`wailsjs/go/main/App` and `wailsjs/runtime/runtime`), unrelated to this change.