### PR TITLE
Retry empty final answers

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -28,6 +28,7 @@ import (
 const maxToolOutputBytes = 32 * 1024
 
 const maxFinalReadinessBlocks = 3
+const maxEmptyFinalBlocks = 3
 
 // Renderer redraws the assistant's final-answer text as styled output. It is
 // applied only after a turn's text stream completes, so the user sees raw
@@ -398,6 +399,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 
 	finalReadinessBlocks := 0
+	emptyFinalBlocks := 0
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
@@ -445,8 +447,19 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				a.maybeCompact(ctx, usage)
 				continue
 			}
+			if !hasVisibleFinalAnswer(text) {
+				emptyFinalBlocks++
+				if emptyFinalBlocks >= maxEmptyFinalBlocks {
+					return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
+				}
+				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "empty final answer blocked: model returned no visible answer text; retrying"})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: emptyFinalRetryMessage()})
+				a.maybeCompact(ctx, usage)
+				continue
+			}
 			return nil // model gave a final answer
 		}
+		emptyFinalBlocks = 0
 
 		results := a.executeBatch(ctx, calls)
 		for i, call := range calls {
@@ -531,6 +544,14 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 
 func finalReadinessRetryMessage(reason string) string {
 	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
+}
+
+func hasVisibleFinalAnswer(text string) bool {
+	return strings.TrimSpace(text) != ""
+}
+
+func emptyFinalRetryMessage() string {
+	return "The previous assistant response finished without any visible answer text. Continue the same task now and provide a concise visible answer to the user. Do not send reasoning only."
 }
 
 // stream runs one completion, emitting reasoning and text deltas as typed

--- a/internal/agent/empty_final_test.go
+++ b/internal/agent/empty_final_test.go
@@ -1,0 +1,89 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestRunRetriesReasoningOnlyFinalAnswer(t *testing.T) {
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkReasoning, Text: "I should answer the user."},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "visible reply"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "answer me"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want retry after reasoning-only answer", prov.call)
+	}
+	if got := lastAssistantContent(a.session); got != "visible reply" {
+		t.Fatalf("last assistant content = %q, want visible reply", got)
+	}
+	if !sessionHasUserMessageContaining(a.session, "visible answer") {
+		t.Fatal("missing synthetic visible-answer retry message")
+	}
+}
+
+func TestRunStopsAfterRepeatedEmptyFinalAnswers(t *testing.T) {
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{{Type: provider.ChunkReasoning, Text: "thinking 1"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkReasoning, Text: "thinking 2"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkReasoning, Text: "thinking 3"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{}, event.Discard)
+
+	err := a.Run(context.Background(), "answer me")
+	if err == nil {
+		t.Fatal("expected repeated empty final answers to stop the run")
+	}
+	if !strings.Contains(err.Error(), "visible final answer") {
+		t.Fatalf("error = %v, want visible final answer", err)
+	}
+	if prov.call != 3 {
+		t.Fatalf("provider calls = %d, want three empty-answer attempts", prov.call)
+	}
+}
+
+func lastAssistantContent(s *Session) string {
+	var out string
+	for _, m := range s.Messages {
+		if m.Role == provider.RoleAssistant {
+			out = m.Content
+		}
+	}
+	return out
+}
+
+func BenchmarkHasVisibleFinalAnswer(b *testing.B) {
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"normal", "visible reply"},
+		{"leading-space", strings.Repeat(" ", 256) + "visible reply"},
+		{"all-space", strings.Repeat(" \n\t", 256)},
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			var got bool
+			for i := 0; i < b.N; i++ {
+				got = hasVisibleFinalAnswer(tc.text)
+			}
+			_ = got
+		})
+	}
+}

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -14,6 +14,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/i18n"
+	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
@@ -273,7 +274,16 @@ func renderStatuslineViewWithGitAndEffort(t *testing.T) string {
 func renderStatuslineViewWithCache(t *testing.T) string {
 	t.Helper()
 
-	prov := testutil.NewMock("deepseek-v4-flash", testutil.UsageTurn(900, 100, 50))
+	prov := testutil.NewMock("deepseek-v4-flash", testutil.Turn{
+		Text: "ok",
+		Usage: &provider.Usage{
+			CacheHitTokens:   900,
+			CacheMissTokens:  100,
+			CompletionTokens: 50,
+			PromptTokens:     1000,
+			TotalTokens:      1050,
+		},
+	})
 	exec := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{MaxSteps: 1, ContextWindow: 200_000}, event.Discard)
 	if err := exec.Run(context.Background(), "hello"); err != nil {
 		t.Fatalf("seed agent usage: %v", err)


### PR DESCRIPTION
## Summary

Fixes #3290.

- Treat a no-tool-call model turn with no visible answer text as incomplete instead of ending the user turn.
- Add a bounded retry that asks the model to continue and produce a visible answer, while preserving the existing tool-call and final-readiness gates.
- Add regression coverage for reasoning-only replies and repeated empty replies, plus a microbenchmark for the visible-answer check.
- Update the statusline cache fixture so usage seeding still uses a valid visible assistant reply.

## Validation

- `go test ./internal/agent -run "TestRun(RetriesReasoningOnlyFinalAnswer|StopsAfterRepeatedEmptyFinalAnswers)$" -count=1` (failed before the fix, passes after)
- `go test ./internal/agent -run "TestRun(RetriesReasoningOnlyFinalAnswer|StopsAfterRepeatedEmptyFinalAnswers)$" -bench BenchmarkHasVisibleFinalAnswer -benchmem -count=5`
  - normal visible answer: ~1.7-1.9 ns/op, 0 allocs/op
  - 256 leading spaces: ~90-91 ns/op, 0 allocs/op
  - all-space input: ~250-260 ns/op, 0 allocs/op
- `go test ./internal/agent -count=1`
- `go test ./internal/provider/openai ./internal/control -count=1`
- `go test ./internal/cli -run TestStatuslineKeepsCacheRatesInPrimaryDataRow -count=1`
- `go test ./... -p 1 -count=1`
- `go vet ./...`
- `go test ./... -p 1 -count=1` from `desktop/`
- `npm run build` from `desktop/frontend/` after generating local Wails bindings and refreshing local dependencies from the lockfile
- `npm run test:todo-visibility` from `desktop/frontend/` -> 200,000 checks in 0.95 ms
- `git diff --check`