### PR TITLE
fix(transcript): scroll to bottom on new user message and highlight latest in question jump bar

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -99,6 +99,25 @@ export function Transcript({
     if (el) stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
   };
 
+  // Track question count so we can detect when the user sends a new message.
+  const prevQuestionsLen = useRef(0);
+
+  // When the user submits a new message (questions array grows), force-scroll
+  // to the bottom regardless of the current stick state — the user's own action
+  // should reveal the new interaction.
+  useEffect(() => {
+    if (questions.length > prevQuestionsLen.current) {
+      stick.current = true;
+      const el = scrollRef.current;
+      if (el) {
+        requestAnimationFrame(() => {
+          el.scrollTop = el.scrollHeight;
+        });
+      }
+    }
+    prevQuestionsLen.current = questions.length;
+  }, [questions]);
+
   // Follow new content by setting scrollTop directly (no scrollIntoView fighting
   // the browser's scroll anchoring), and inside rAF so layout has settled first —
   // together with plain-text streaming this keeps the view from jittering. The
@@ -277,10 +296,7 @@ function QuestionJumpBar({ questions, onJump }: { questions: QuestionAnchor[]; o
 
   useEffect(() => {
     if (questions.length === 0) return;
-    setActive((cur) => {
-      if (cur !== null && questions.some((question) => question.turn === cur)) return cur;
-      return questions[questions.length - 1]?.turn ?? null;
-    });
+    setActive(questions[questions.length - 1]?.turn ?? null);
   }, [questions]);
 
   useEffect(() => {

--- a/desktop/single_instance.go
+++ b/desktop/single_instance.go
@@ -1,8 +1,17 @@
 package main
 
-import "github.com/wailsapp/wails/v2/pkg/options"
+import (
+	"os"
+
+	"github.com/wailsapp/wails/v2/pkg/options"
+)
 
 func singleInstanceLock(app *App) *options.SingleInstanceLock {
+	// Allow contributors to run a dev build alongside the installed app.
+	// Set REASONIX_DEV=1 to skip the single-instance lock.
+	if os.Getenv("REASONIX_DEV") != "" {
+		return nil
+	}
 	return &options.SingleInstanceLock{
 		UniqueId: singleInstanceID,
 		OnSecondInstanceLaunch: func(options.SecondInstanceData) {


### PR DESCRIPTION
## Summary

修复两个用户体验问题：

1. **用户滚动查看历史后发送新消息，Transcript 不会自动跳转到底部**
   之前 Transcript 的 `stick` 机制在用户手动滚动后会阻止后续内容自动追随到底部。但用户主动发送新消息时，理应跳转到底部展示新交互，而不是留在屏幕外。

2. **问题跳转栏（question jump bar）不会高亮最新消息**
   `QuestionJumpBar` 的 `active` 状态在初始化后会固定在旧位置，即使用户发送了多条新消息，高亮点也停留在最初的那一条上。改为每次 `questions` 数组变化时始终高亮最后一条。

## Changes

| File | Change |
|---|---|
| `desktop/frontend/src/components/Transcript.tsx` | 新增 `useEffect` 检测 `questions.length` 增长时强制 `stick.current = true` 并滚动到底部；`QuestionJumpBar` 的 `setActive` 改为始终指向最后一条 |
| `desktop/single_instance.go` | 添加 `REASONIX_DEV=1` 环境变量支持，允许开发者跳过单实例锁，与已安装版同时运行 |

## Testing

- `go test ./... -count=1` (desktop) — ✅ passed
- `pnpm build` (frontend) — ✅ passed
- `gofmt -l .` — ✅ clean
- `go vet ./...` — ✅ clean