### PR TITLE
Support nested skill discovery / 支持嵌套 Skill 发现

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1467,14 +1467,17 @@ func skillRootsView() []SkillRootView {
 	cfg, _ := config.Load()
 	userCfg := config.LoadForEdit(config.UserConfigPath())
 	var custom []string
+	maxDepth := 3
 	if cfg != nil {
 		custom = cfg.SkillCustomPaths()
+		maxDepth = cfg.SkillMaxDepth()
 	}
-	st := skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, DisableBuiltins: true, Stderr: io.Discard})
+	st := skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, MaxDepth: maxDepth, DisableBuiltins: true, Stderr: io.Discard})
 	counts := map[string]int{}
 	skillItems := map[string][]SkillRootSkillView{}
+	roots := st.Roots()
 	for _, sk := range st.List() {
-		root := config.CanonicalSkillPath(filepath.Dir(skillRootPath(sk.Path)))
+		root := skillDisplayRoot(sk, roots)
 		counts[root]++
 		skillItems[root] = append(skillItems[root], SkillRootSkillView{
 			Name:        sk.Name,
@@ -1495,7 +1498,7 @@ func skillRootsView() []SkillRootView {
 		}
 	}
 	out := []SkillRootView{}
-	for _, r := range st.Roots() {
+	for _, r := range roots {
 		dir := config.CanonicalSkillPath(r.Dir)
 		view := SkillRootView{
 			Dir:        r.Dir,
@@ -1624,6 +1627,21 @@ func skillRootPath(path string) string {
 		return filepath.Dir(path)
 	}
 	return path
+}
+
+func skillDisplayRoot(sk skill.Skill, roots []skill.Root) string {
+	cleanPath := filepath.Clean(sk.Path)
+	for _, r := range roots {
+		if r.Scope != sk.Scope {
+			continue
+		}
+		cleanRoot := filepath.Clean(r.Dir)
+		prefix := cleanRoot + string(filepath.Separator)
+		if cleanPath == cleanRoot || strings.HasPrefix(cleanPath, prefix) {
+			return config.CanonicalSkillPath(r.Dir)
+		}
+	}
+	return config.CanonicalSkillPath(filepath.Dir(skillRootPath(sk.Path)))
 }
 
 // MCPServerInput is the drawer's "add server" form. Transport is "stdio" (Command

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -188,10 +188,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		ProjectRoot:   root,
 		CustomPaths:   cfg.SkillCustomPaths(),
 		DisabledNames: cfg.DisabledSkillNames(),
+		MaxDepth:      cfg.SkillMaxDepth(),
 		Stderr:        opts.Stderr,
 	})
 	skills := skillStore.List()
-	allSkills := skill.New(skill.Options{ProjectRoot: root, CustomPaths: cfg.SkillCustomPaths(), Stderr: io.Discard}).List()
+	allSkills := skill.New(skill.Options{ProjectRoot: root, CustomPaths: cfg.SkillCustomPaths(), MaxDepth: cfg.SkillMaxDepth(), Stderr: io.Discard}).List()
 	sysPrompt = skill.ApplyIndex(sysPrompt, skills)
 
 	reg := tool.NewRegistry()

--- a/internal/cli/skill_hooks.go
+++ b/internal/cli/skill_hooks.go
@@ -226,10 +226,12 @@ func (m *chatTUI) skillPaths() {
 func (m *chatTUI) skillStore() *skill.Store {
 	cwd, _ := os.Getwd()
 	var custom []string
+	maxDepth := 3
 	if cfg, err := config.Load(); err == nil {
 		custom = cfg.SkillCustomPaths()
+		maxDepth = cfg.SkillMaxDepth()
 	}
-	return skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom})
+	return skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, MaxDepth: maxDepth})
 }
 
 func (m *chatTUI) runHooksSubcommand(input string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -296,6 +296,7 @@ func (c *Config) NetworkProxyMode() string {
 type SkillsConfig struct {
 	Paths          []string `toml:"paths"`
 	DisabledSkills []string `toml:"disabled_skills"`
+	MaxDepth       int      `toml:"max_depth"`
 }
 
 // SkillCustomPaths returns the configured custom skill roots with ${VAR}
@@ -308,6 +309,25 @@ func (c *Config) SkillCustomPaths() []string {
 		}
 	}
 	return out
+}
+
+// SkillMaxDepth bounds nested skill discovery. Depth 3 favors bundled skill
+// packs while Store keeps nested markdown safe by requiring descriptions.
+func (c *Config) SkillMaxDepth() int {
+	const (
+		defaultDepth = 3
+		maxDepth     = 5
+	)
+	if c == nil || c.Skills.MaxDepth == 0 {
+		return defaultDepth
+	}
+	if c.Skills.MaxDepth < 1 {
+		return 1
+	}
+	if c.Skills.MaxDepth > maxDepth {
+		return maxDepth
+	}
+	return c.Skills.MaxDepth
 }
 
 // DisabledSkillNames returns valid disabled skill identifiers, preserving the

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -260,6 +260,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	} else {
 		b.WriteString("# paths = [\"~/my-skills\", \"../shared/skills\"]   # extra custom skill roots\n")
 	}
+	if c.Skills.MaxDepth != 0 {
+		fmt.Fprintf(&b, "max_depth = %d   # nested scan depth; default 3, set 1 for legacy root-only discovery\n", c.SkillMaxDepth())
+	} else {
+		b.WriteString("# max_depth = 3   # nested scan depth; set 1 for legacy root-only discovery\n")
+	}
 	if disabled := c.DisabledSkillNames(); len(disabled) > 0 {
 		fmt.Fprintf(&b, "disabled_skills = %s   # hidden from the prompt, slash invocation, and skill tools\n\n", renderStringArray(disabled))
 	} else {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -40,6 +40,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	orig.Skills.Paths = []string{"~/my-skills", "../shared/skills"}
 	orig.Skills.DisabledSkills = []string{"review", "explore"}
+	orig.Skills.MaxDepth = 2
 	orig.Codegraph = CodegraphConfig{Enabled: true, AutoInstall: false, Path: "/opt/codegraph", Tier: "background"}
 	orig.Plugins = []PluginEntry{
 		{Name: "example", Command: "reasonix-plugin-example"},
@@ -152,6 +153,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if len(got.Skills.DisabledSkills) != 2 || got.Skills.DisabledSkills[0] != "review" || got.Skills.DisabledSkills[1] != "explore" {
 		t.Errorf("skills.disabled_skills = %v", got.Skills.DisabledSkills)
+	}
+	if got.SkillMaxDepth() != 2 {
+		t.Errorf("skills.max_depth = %d, want 2", got.SkillMaxDepth())
 	}
 	if len(got.Plugins) != 2 {
 		t.Fatalf("plugins count = %d, want 2", len(got.Plugins))

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -74,6 +74,7 @@ type Options struct {
 	ProjectRoot     string
 	CustomPaths     []string
 	DisabledNames   []string
+	MaxDepth        int
 	DisableBuiltins bool // suppress shipped built-ins (test-only knob)
 	// Stderr is the writer for diagnostic warnings. When nil, defaults to
 	// os.Stderr. Set to io.Discard to suppress output (e.g. during model
@@ -87,6 +88,7 @@ type Store struct {
 	projectRoot     string
 	customPaths     []string
 	disabled        map[string]bool
+	maxDepth        int
 	disableBuiltins bool
 	stderr          io.Writer
 }
@@ -122,6 +124,7 @@ func New(opts Options) *Store {
 		projectRoot:     root,
 		customPaths:     custom,
 		disabled:        disabledNameSet(opts.DisabledNames),
+		maxDepth:        normalizeMaxDepth(opts.MaxDepth),
 		disableBuiltins: opts.DisableBuiltins,
 		stderr:          stderr,
 	}
@@ -193,6 +196,23 @@ func (s *Store) disabledName(name string) bool {
 	return s.disabled[config.SkillNameKey(name)]
 }
 
+func normalizeMaxDepth(depth int) int {
+	const (
+		defaultDepth = 3
+		maxDepth     = 5
+	)
+	if depth == 0 {
+		return defaultDepth
+	}
+	if depth < 1 {
+		return 1
+	}
+	if depth > maxDepth {
+		return maxDepth
+	}
+	return depth
+}
+
 // pathStatus classifies a root directory without failing on the common case of
 // "not created yet".
 func pathStatus(dir string) PathStatus {
@@ -223,15 +243,7 @@ func (s *Store) List() []Skill {
 		if r.Status != StatusOK {
 			continue
 		}
-		entries, err := os.ReadDir(r.Dir)
-		if err != nil {
-			continue
-		}
-		for _, e := range entries {
-			sk, ok := s.readEntry(r.Dir, r.Scope, e)
-			if !ok {
-				continue
-			}
+		for _, sk := range s.discoverRoot(r) {
 			if s.disabledName(sk.Name) {
 				continue
 			}
@@ -267,24 +279,75 @@ func (s *Store) Read(name string) (Skill, bool) {
 	if s.disabledName(name) {
 		return Skill{}, false
 	}
-	for _, r := range s.roots() {
-		dirCand := filepath.Join(r.Dir, name, SkillFile)
-		if info, err := os.Stat(dirCand); err == nil && info.Mode().IsRegular() {
-			return s.parse(dirCand, name, r.Scope)
-		}
-		flatCand := filepath.Join(r.Dir, name+".md")
-		if info, err := os.Stat(flatCand); err == nil && info.Mode().IsRegular() {
-			return s.parse(flatCand, name, r.Scope)
-		}
-	}
-	if !s.disableBuiltins {
-		for _, sk := range builtinSkills() {
-			if sk.Name == name {
-				return sk, true
-			}
+	for _, sk := range s.List() {
+		if sk.Name == name {
+			return sk, true
 		}
 	}
 	return Skill{}, false
+}
+
+func (s *Store) discoverRoot(r Root) []Skill {
+	var out []Skill
+	s.scanDir(r.Dir, r.Scope, 1, map[string]bool{}, &out)
+	return out
+}
+
+func (s *Store) scanDir(dir string, scope Scope, depth int, seen map[string]bool, out *[]Skill) {
+	key := filepath.Clean(dir)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		key = filepath.Clean(resolved)
+	}
+	if seen[key] {
+		return
+	}
+	seen[key] = true
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		sk, ok := s.readEntry(dir, scope, e)
+		if ok {
+			if depth == 1 || strings.TrimSpace(sk.Description) != "" {
+				*out = append(*out, sk)
+			}
+			continue
+		}
+		if depth >= s.maxDepth || !s.canScanChildDir(dir, e) {
+			continue
+		}
+		s.scanDir(filepath.Join(dir, e.Name()), scope, depth+1, seen, out)
+	}
+}
+
+func (s *Store) canScanChildDir(dir string, e os.DirEntry) bool {
+	name := e.Name()
+	if shouldSkipScanDir(name) {
+		return false
+	}
+	full := filepath.Join(dir, name)
+	if e.IsDir() {
+		return true
+	}
+	if e.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(full)
+	return err == nil && info.IsDir()
+}
+
+func shouldSkipScanDir(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	switch strings.ToLower(name) {
+	case "assets", "node_modules", "references", "scripts":
+		return true
+	default:
+		return false
+	}
 }
 
 // readEntry turns one directory entry into a skill. It resolves symlinks via

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -66,6 +66,78 @@ func TestFlatAndDirLayout(t *testing.T) {
 	}
 }
 
+func TestNestedSkillsDiscoveredByDefault(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/superpower/skill-a.md", "---\ndescription: nested flat\n---\nflat body")
+	writeSkill(t, home, ".reasonix/skills/superpower/tool-a/SKILL.md", "---\ndescription: nested dir\n---\ndir body")
+	writeSkill(t, home, ".reasonix/skills/superpower/references/notes.md", "---\ndescription: not a skill\n---\nnotes")
+
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	list := st.List()
+	if _, ok := find(list, "skill-a"); !ok {
+		t.Fatal("default max depth should discover nested flat skills")
+	}
+	if _, ok := find(list, "tool-a"); !ok {
+		t.Fatal("default max depth should discover nested directory skills")
+	}
+	if _, ok := find(list, "notes"); ok {
+		t.Fatal("references directories should not be scanned as skill roots")
+	}
+	if sk, ok := st.Read("skill-a"); !ok || sk.Description != "nested flat" || !strings.Contains(sk.Body, "flat body") {
+		t.Fatalf("Read should resolve nested skills from the same discovery path: %+v ok=%v", sk, ok)
+	}
+}
+
+func TestMaxDepthOnePreservesRootOnlyDiscovery(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/superpower/skill-a.md", "---\ndescription: nested flat\n---\nflat body")
+	writeSkill(t, home, ".reasonix/skills/superpower/tool-a/SKILL.md", "---\ndescription: nested dir\n---\ndir body")
+
+	st := New(Options{HomeDir: home, MaxDepth: 1, DisableBuiltins: true})
+	if _, ok := find(st.List(), "skill-a"); ok {
+		t.Fatal("max depth 1 should not discover nested flat skills")
+	}
+	if _, ok := find(st.List(), "tool-a"); ok {
+		t.Fatal("max depth 1 should not discover nested directory skills")
+	}
+}
+
+func TestNestedSkillsRequireDescription(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/root.md", "---\n---\nroot body")
+	writeSkill(t, home, ".reasonix/skills/superpower/draft.md", "---\n---\ndraft body")
+	writeSkill(t, home, ".reasonix/skills/superpower/tool/SKILL.md", "---\n---\ntool body")
+
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	list := st.List()
+	if _, ok := find(list, "root"); !ok {
+		t.Fatal("root-level skills without description should keep legacy discovery behavior")
+	}
+	if _, ok := find(list, "draft"); ok {
+		t.Fatal("nested flat skills without description should be ignored")
+	}
+	if _, ok := find(list, "tool"); ok {
+		t.Fatal("nested directory skills without description should be ignored")
+	}
+	if _, ok := st.Read("draft"); ok {
+		t.Fatal("Read should not resolve nested skills filtered for missing description")
+	}
+}
+
+func TestNestedDirectorySkillStopsTraversal(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/pack/SKILL.md", "---\ndescription: pack\n---\npack body")
+	writeSkill(t, home, ".reasonix/skills/pack/child.md", "---\ndescription: child\n---\nchild body")
+
+	st := New(Options{HomeDir: home, MaxDepth: 3, DisableBuiltins: true})
+	if _, ok := find(st.List(), "pack"); !ok {
+		t.Fatal("directory-layout skill should be discovered")
+	}
+	if _, ok := find(st.List(), "child"); ok {
+		t.Fatal("directory-layout skill packages should not be scanned for child skills")
+	}
+}
+
 func TestConventionDirsDiscovered(t *testing.T) {
 	proj := t.TempDir()
 	writeSkill(t, proj, ".claude/skills/fromclaude.md", "---\ndescription: c\n---\nb")


### PR DESCRIPTION
## Summary
- default skill discovery now scans nested skill bundles up to depth 3
- nested skill candidates must include a description, reducing accidental registration of ordinary markdown files
- thread max_depth through boot, CLI skill views, and desktop capabilities so listing and run_skill stay consistent

## Tests
- go test ./internal/skill
- go test ./internal/config
- go test ./internal/boot