### PR TITLE
feat(composer): add past chats reference flow

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1080,6 +1080,15 @@ export function Composer({
     setText((prev) => removeAtToken(prev));
     setPastChatQuery("");
     setShowPastChats(false);
+    setActive(0);
+    // Return focus to textarea so the user can keep typing immediately.
+    requestAnimationFrame(() => {
+      taRef.current?.focus();
+      taRef.current?.setSelectionRange(
+        taRef.current.value.length,
+        taRef.current.value.length,
+      );
+    });
   };
 
   const removeSessionRef = (path: string) => {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -164,6 +164,7 @@ const SESSION_REF_MAX_MESSAGES = 30;
 const SESSION_REF_MAX_CHARS = 20_000;
 const SESSION_CONTEXT_HEADER = "以下是用户引用的历史会话上下文：";
 const SESSION_CONTEXT_FOOTER = "当前用户问题：";
+const PAST_CHATS_MENU_ITEM = "past:chats";
 
 // limitSessionMessages keeps the most recent useful messages within a char budget.
 // Walks from the end so the truncation is always "drop the oldest", which matches
@@ -325,6 +326,7 @@ export function Composer({
   const [loadingPastChats, setLoadingPastChats] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
+  const pastChatsItemRef = useRef<HTMLButtonElement>(null);
   const composerCardRef = useRef<HTMLDivElement>(null);
   const workspaceAnchorRef = useRef<HTMLDivElement>(null);
   const wasRunning = useRef(running);
@@ -486,7 +488,7 @@ export function Composer({
     | { kind: "pastChats" }
     | { kind: "file"; entry: DirEntry };
 
-  const includePastChatsItem = atRaw !== null && atDir === "";
+  const includePastChatsItem = atRaw !== null && atDir === "" && (atFrag === "" || PAST_CHATS_MENU_ITEM.startsWith(atFrag));
 
   const atMenuItems = useMemo<AtMenuItem[]>(
     () => [
@@ -1056,6 +1058,12 @@ export function Composer({
     setActive((prev) => (prev > maxIdx ? 0 : prev));
   }, [count]);
 
+  useEffect(() => {
+    if (menuMode === "at" && !showPastChats && includePastChatsItem && active === 0) {
+      pastChatsItemRef.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [active, includePastChatsItem, menuMode, showPastChats]);
+
   const removeAtToken = (value: string) => {
     return value.replace(/(?:^|\s)@[^\s]*$/, "").trimEnd();
   };
@@ -1412,6 +1420,7 @@ export function Composer({
           <div className="slashmenu" role="listbox">
             {includePastChatsItem && (
               <button
+                ref={pastChatsItemRef}
                 className={`slashmenu__item${active === 0 ? " slashmenu__item--active" : ""}`}
                 onMouseDown={(ev) => {
                   ev.preventDefault();
@@ -1420,7 +1429,7 @@ export function Composer({
                 onMouseMove={() => setActive(0)}
               >
                 <MessageSquare size={13} className="filemenu__icon" />
-                <span className="slashmenu__name">past:chats</span>
+                <span className="slashmenu__name">{PAST_CHATS_MENU_ITEM}</span>
               </button>
             )}
             <FileMenu

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent, ReactNode } from "react";
-import { AlertTriangle, ArrowUp, Check, ChevronDown, Eye, FileText, Folder, FolderGit2, FolderPlus, List, Search, Square, Trash2, X, Zap } from "lucide-react";
+import { AlertTriangle, ArrowUp, Check, ChevronDown, Eye, FileText, Folder, FolderGit2, FolderPlus, List, MessageSquare, Search, Square, Trash2, X, Zap } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app, onFilesDropped } from "../lib/bridge";
 import { SPINNER_WORDS, useI18n } from "../lib/i18n";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
-import type { CommandInfo, ComposerInsertRequest, DirEntry, EffortInfo, Mode, SlashArgItem, SlashArgsResult, WorkspaceView } from "../lib/types";
+import type { CommandInfo, ComposerInsertRequest, DirEntry, EffortInfo, HistoryMessage, Mode, SessionMeta, SessionReference, SlashArgItem, SlashArgsResult, WorkspaceView } from "../lib/types";
 import {
   formatWorkspaceReference,
   parseWorkspaceReference,
@@ -100,6 +100,34 @@ function fmtElapsed(ms: number): string {
   return `${Math.floor(s / 60)}m ${s % 60}s`;
 }
 
+// --- past:chats hover preview helpers (PR-C2) ---
+// Pure formatting helpers used by the past:chats list tooltip. They never read
+// from disk, never call PreviewSession — they only shape the data that already
+// lives in the SessionMeta snapshot we fetched on entry.
+const PAST_CHAT_PREVIEW_MAX = 200;
+
+function truncatePreview(value?: string, max = PAST_CHAT_PREVIEW_MAX): string {
+  const text = (value || "").trim();
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}...`;
+}
+
+function fmtSessionTime(value?: number): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mi = String(d.getMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
+}
+
+function pastChatTitle(session: SessionMeta): string {
+  return session.title || session.topicTitle || session.preview || "Untitled";
+}
+
 function useTick(on: boolean): number {
   const [, setN] = useState(0);
   useEffect(() => {
@@ -125,6 +153,90 @@ function isImeKeyEvent(
     native.keyCode === 229 ||
     Date.now() - lastCompositionEndAt < IME_CONFIRM_GRACE_MS
   );
+}
+
+// --- past:chats session reference → prompt context (PR-B) ---
+// Send-side helpers for "@past:chats" session references. PR-A wired the menu and
+// the composer-context card; this layer reads each referenced session through the
+// existing PreviewSession API and prepends a compact "user / 助手" transcript to
+// submitText so the model sees the referenced chat as background context.
+const SESSION_REF_MAX_MESSAGES = 30;
+const SESSION_REF_MAX_CHARS = 20_000;
+const SESSION_CONTEXT_HEADER = "以下是用户引用的历史会话上下文：";
+const SESSION_CONTEXT_FOOTER = "当前用户问题：";
+
+// limitSessionMessages keeps the most recent useful messages within a char budget.
+// Walks from the end so the truncation is always "drop the oldest", which matches
+// the intuition that the latest turns are the relevant ones for follow-up.
+function limitSessionMessages(
+  messages: HistoryMessage[],
+  maxMessages = SESSION_REF_MAX_MESSAGES,
+  maxChars = SESSION_REF_MAX_CHARS,
+): { messages: HistoryMessage[]; truncated: boolean } {
+  const useful = messages
+    .filter(
+      (m) =>
+        (m.role === "user" || m.role === "assistant") &&
+        typeof m.content === "string" &&
+        m.content.trim().length > 0,
+    )
+    .slice(-maxMessages);
+  const result: HistoryMessage[] = [];
+  let total = 0;
+  let truncated = useful.length >= maxMessages;
+  for (let i = useful.length - 1; i >= 0; i--) {
+    const msg = useful[i];
+    const content = msg.content.trim();
+    if (total + content.length > maxChars) {
+      truncated = true;
+      break;
+    }
+    result.unshift({ ...msg, content });
+    total += content.length;
+  }
+  if (result.length < useful.length) truncated = true;
+  return { messages: result, truncated };
+}
+
+// formatSessionContext renders one referenced session as a labelled transcript.
+// Falls back to a "no usable messages" note when filtering empties the list so
+// the model still sees that something was referenced.
+function formatSessionContext(
+  ref: SessionReference,
+  messages: HistoryMessage[],
+  truncated: boolean,
+): string {
+  const body = messages
+    .map((m) => `${m.role === "user" ? "用户" : "助手"}：${m.content.trim()}`)
+    .join("\n\n");
+  return [
+    `[会话：${ref.title}]`,
+    truncated ? "注意：该会话内容较长，以下只包含最近部分内容。" : "",
+    body || "注意：该会话没有可引用的用户/助手消息。",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+// buildSessionContext reads each referenced session, formats the most recent
+// slice, and joins them with a separator. A single failed read must not block
+// the others; the user gets a clear "读取失败" note for the bad one and the
+// remaining refs still flow through.
+async function buildSessionContext(refs: SessionReference[]): Promise<string> {
+  if (refs.length === 0) return "";
+  let context = `${SESSION_CONTEXT_HEADER}\n\n`;
+  for (const ref of refs) {
+    try {
+      const raw = await app.PreviewSession(ref.path);
+      const limited = limitSessionMessages(asArray(raw));
+      context += `${formatSessionContext(ref, limited.messages, limited.truncated)}\n\n---\n\n`;
+    } catch (error) {
+      console.error("[past:chats] failed to preview session", ref.path, error);
+      context += `[会话：${ref.title}]\n注意：该会话读取失败，已跳过。\n\n---\n\n`;
+    }
+  }
+  context += `${SESSION_CONTEXT_FOOTER}\n`;
+  return context;
 }
 
 export function Composer({
@@ -206,6 +318,11 @@ export function Composer({
   const [composerResizing, setComposerResizing] = useState(false);
   const [textareaAutoHeight, setTextareaAutoHeight] = useState<number | null>(null);
   const [textareaAutoOverflow, setTextareaAutoOverflow] = useState(false);
+  const [showPastChats, setShowPastChats] = useState(false);
+  const [pastChats, setPastChats] = useState<SessionMeta[]>([]);
+  const [pastChatQuery, setPastChatQuery] = useState("");
+  const [sessionRefs, setSessionRefs] = useState<SessionReference[]>([]);
+  const [loadingPastChats, setLoadingPastChats] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const composerCardRef = useRef<HTMLDivElement>(null);
   const workspaceAnchorRef = useRef<HTMLDivElement>(null);
@@ -455,7 +572,7 @@ export function Composer({
     return expanded;
   };
 
-  const submit = () => {
+  const submit = async () => {
     if (disabled) return;
     const t = text.trim();
     if ((!t && attachments.length === 0 && workspaceRefs.length === 0) || pendingPaste > 0) return;
@@ -464,11 +581,18 @@ export function Composer({
       ...attachments.map((a) => `@${a.path}`),
     ].join(" ");
     const displayText = [t, refs].filter(Boolean).join(t && refs ? " " : "");
-    const submitText = [expandPastedBlocks(t), refs].filter(Boolean).join(t && refs ? " " : "");
+    // PR-B: when past:chats refs are attached, prepend their formatted transcript
+    // to submitText only (displayText stays unchanged so the user still sees their
+    // original prompt in the input preview). With no refs we keep the original
+    // submitText verbatim — no header, no rewording, byte-identical to pre-PR-B.
+    const sessionContext = sessionRefs.length === 0 ? "" : await buildSessionContext(sessionRefs);
+    const baseSubmitText = [expandPastedBlocks(t), refs].filter(Boolean).join(t && refs ? " " : "");
+    const submitText = sessionContext ? `${sessionContext}${baseSubmitText}` : baseSubmitText;
     onSend(displayText, submitText);
     setText("");
     setAttachments([]);
     setWorkspaceRefs([]);
+    setSessionRefs([]);
   };
 
   const readFileAsDataURL = (file: File) =>
@@ -838,6 +962,78 @@ export function Composer({
     setTextCaretEnd(prefix + "@" + atDir + e.name + (e.isDir ? "/" : " "));
   };
 
+  // --- past:chats session reference ---
+  const openPastChats = async () => {
+    setShowPastChats(true);
+    setLoadingPastChats(true);
+    try {
+      const sessions = await app.ListSessions();
+      const sorted = asArray(sessions)
+        .filter((s) => !s.current)
+        .sort((a, b) => {
+          const at = a.lastActivityAt || a.modTime || a.createdAt || 0;
+          const bt = b.lastActivityAt || b.modTime || b.createdAt || 0;
+          return bt - at;
+        })
+        .slice(0, 50);
+      setPastChats(sorted);
+    } catch {
+      setPastChats([]);
+    } finally {
+      setLoadingPastChats(false);
+    }
+  };
+
+  // PR-C1: client-side filter for the past:chats list. Matches against the
+  // human-visible fields (title, topic, preview, path, workspace) so users
+  // can narrow long session lists without a backend round-trip. Lowercased
+  // substring match keeps the behaviour predictable across locales.
+  const filteredPastChats = useMemo(() => {
+    const q = pastChatQuery.trim().toLowerCase();
+    if (!q) return pastChats;
+    return pastChats.filter((session) =>
+      [
+        session.title,
+        session.topicTitle,
+        session.preview,
+        session.path,
+        session.workspaceRoot,
+      ]
+        .map((value) => String(value ?? "").toLowerCase())
+        .some((value) => value.includes(q)),
+    );
+  }, [pastChats, pastChatQuery]);
+
+  const removeAtToken = (value: string) => {
+    return value.replace(/(?:^|\s)@[^\s]*$/, "").trimEnd();
+  };
+
+  const pickSession = (session: SessionMeta) => {
+    setSessionRefs((prev) => {
+      if (prev.some((x) => x.path === session.path)) {
+        return prev;
+      }
+      return [
+        ...prev,
+        {
+          path: session.path,
+          title: session.title || session.topicTitle || session.preview || "Untitled",
+          preview: session.preview,
+          turns: session.turns,
+          createdAt: session.createdAt,
+          lastActivityAt: session.lastActivityAt,
+        },
+      ];
+    });
+    setText((prev) => removeAtToken(prev));
+    setPastChatQuery("");
+    setShowPastChats(false);
+  };
+
+  const removeSessionRef = (path: string) => {
+    setSessionRefs((prev) => prev.filter((ref) => ref.path !== path));
+  };
+
   // pickArg replaces just the current token with the suggestion. A "descend" item
   // (e.g. "/skill show ") ends with a space, so the effect re-fetches the next
   // level; a terminal item leaves the menu (next fetch returns nothing).
@@ -1012,7 +1208,114 @@ export function Composer({
       {menuMode === "slasharg" && argRes && (
         <ArgMenu items={argRes.items} activeIndex={active} onPick={pickArg} onHover={setActive} />
       )}
-      {menuMode === "at" && <FileMenu items={atMatches} activeIndex={active} onPick={pickEntry} onHover={setActive} />}
+      {menuMode === "at" && (
+        showPastChats ? (
+          <div className="slashmenu" role="listbox">
+            {loadingPastChats ? (
+              <div className="slashmenu__item slashmenu__item--empty">
+                <span className="slashmenu__name">正在加载历史会话...</span>
+              </div>
+            ) : pastChats.length === 0 ? (
+              <div className="slashmenu__item slashmenu__item--empty">
+                <span className="slashmenu__name">暂无历史会话</span>
+              </div>
+            ) : (
+              <>
+                {/* PR-C1: search input is only meaningful when there are sessions
+                    to filter; rendering it in the other states would be noise. */}
+                <div className="slashmenu__item slashmenu__item--search" onMouseDown={(ev) => ev.preventDefault()}>
+                  <Search size={13} className="filemenu__icon" />
+                  <input
+                    className="slashmenu__search"
+                    type="text"
+                    placeholder="搜索历史会话…"
+                    value={pastChatQuery}
+                    autoFocus
+                    onChange={(ev) => {
+                      setPastChatQuery(ev.target.value);
+                      setActive(0);
+                    }}
+                    onKeyDown={(ev) => ev.stopPropagation()}
+                  />
+                </div>
+                {filteredPastChats.length === 0 ? (
+                  <div className="slashmenu__item slashmenu__item--empty">
+                    <span className="slashmenu__name">没有匹配的历史会话</span>
+                  </div>
+                ) : (
+                  filteredPastChats.map((session, i) => {
+                    // PR-C2: hover preview uses only the SessionMeta fields we
+                    // already have on hand — no extra PreviewSession call, no
+                    // backend round-trip, no read of the full transcript.
+                    const turns = typeof session.turns === "number";
+                    const ts = session.lastActivityAt || session.modTime || session.createdAt;
+                    const preview = truncatePreview(session.preview);
+                    const pathText = session.workspaceRoot || session.path;
+                    const tooltipLabel =
+                      turns || ts || preview || pathText ? (
+                        <div className="past-chat-hover">
+                          <div className="past-chat-hover__title">{pastChatTitle(session)}</div>
+                          {preview && <div className="past-chat-hover__preview">{preview}</div>}
+                          {(turns || ts) && (
+                            <div className="past-chat-hover__meta">
+                              {turns && <span>{session.turns} 轮</span>}
+                              {ts && <span>· {fmtSessionTime(ts)}</span>}
+                            </div>
+                          )}
+                          {pathText && <div className="past-chat-hover__path">{pathText}</div>}
+                        </div>
+                      ) : null;
+                    return (
+                      <Tooltip key={session.path} block label={tooltipLabel}>
+                        <button
+                          className={`slashmenu__item ${i === active ? "slashmenu__item--active" : ""}`}
+                          onMouseDown={(ev) => {
+                            ev.preventDefault();
+                            pickSession(session);
+                          }}
+                          onMouseMove={() => setActive(i)}
+                        >
+                          <MessageSquare size={13} className="filemenu__icon" />
+                          <span className="slashmenu__name slashmenu__name--file">
+                            {pastChatTitle(session)}
+                            {turns ? ` (${session.turns} 轮)` : ""}
+                          </span>
+                        </button>
+                      </Tooltip>
+                    );
+                  })
+                )}
+              </>
+            )}
+            <button
+              className="slashmenu__item slashmenu__item--back"
+              onMouseDown={(ev) => {
+                ev.preventDefault();
+                setPastChatQuery("");
+                setShowPastChats(false);
+                setActive(0);
+              }}
+            >
+              <span className="slashmenu__name">← 返回文件列表</span>
+            </button>
+          </div>
+        ) : (
+          <div className="slashmenu" role="listbox">
+            <button
+              className="slashmenu__item slashmenu__item--special"
+              onMouseDown={(ev) => {
+                ev.preventDefault();
+                openPastChats();
+              }}
+            >
+              <MessageSquare size={13} className="filemenu__icon" />
+              <span className="slashmenu__name">past:chats</span>
+              <span className="slashmenu__desc">引用历史会话</span>
+            </button>
+            <FileMenu items={atMatches} activeIndex={active} onPick={pickEntry} onHover={setActive} />
+          </div>
+        )
+      )}
       <div className="composer-toolbar">
         <div className="composer-modebar" role="toolbar" aria-label={t("composer.modeTitle")}>
           {modeOptions.map((option) => (
@@ -1042,7 +1345,7 @@ export function Composer({
           </div>
         )}
       </div>
-      {(attachments.length > 0 || workspaceRefs.length > 0) && (
+      {(attachments.length > 0 || workspaceRefs.length > 0 || sessionRefs.length > 0) && (
         <div className="composer-context" aria-label={t("composer.contextItems")}>
           {attachments.map((a) => (
             <div
@@ -1080,6 +1383,30 @@ export function Composer({
                 <button
                   type="button"
                   onClick={() => removeWorkspaceReference(ref)}
+                >
+                  <X size={13} />
+                </button>
+              </Tooltip>
+            </div>
+          ))}
+          {sessionRefs.map((ref) => (
+            <div
+              className="composer-context__item composer-context__item--session"
+              key={ref.path}
+            >
+              <Tooltip label={ref.preview || ref.title}>
+                <span className="composer-context__label">
+                  <MessageSquare size={15} />
+                  <span>
+                    {ref.title}
+                    {typeof ref.turns === "number" ? ` (${ref.turns} 轮)` : ""}
+                  </span>
+                </span>
+              </Tooltip>
+              <Tooltip label="移除引用会话">
+                <button
+                  type="button"
+                  onClick={() => removeSessionRef(ref.path)}
                 >
                   <X size={13} />
                 </button>

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -332,6 +332,7 @@ export function Composer({
   const lastCompositionEndAt = useRef(0);
   const lastSelectionRef = useRef({ start: 0, end: 0 });
   const consumedInsertIdRef = useRef(0);
+  const submittingRef = useRef(false);
 
   useEffect(() => {
     if (wasRunning.current && !running && text.trim() === "") {
@@ -574,9 +575,10 @@ export function Composer({
   };
 
   const submit = async () => {
-    if (disabled || submitting) return;
+    if (disabled || submittingRef.current) return;
     const t = text.trim();
     if ((!t && attachments.length === 0 && workspaceRefs.length === 0) || pendingPaste > 0) return;
+    submittingRef.current = true;
     setSubmitting(true);
     try {
     const refs = [
@@ -597,6 +599,7 @@ export function Composer({
     setWorkspaceRefs([]);
     setSessionRefs([]);
     } finally {
+      submittingRef.current = false;
       setSubmitting(false);
     }
   };

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -323,6 +323,7 @@ export function Composer({
   const [pastChatQuery, setPastChatQuery] = useState("");
   const [sessionRefs, setSessionRefs] = useState<SessionReference[]>([]);
   const [loadingPastChats, setLoadingPastChats] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const composerCardRef = useRef<HTMLDivElement>(null);
   const workspaceAnchorRef = useRef<HTMLDivElement>(null);
@@ -485,16 +486,16 @@ export function Composer({
       ? "slash"
       : argRes && argRes.items.length > 0 && !dismissed
         ? "slasharg"
-        : atMatches.length > 0 && !dismissed
+        : atRaw !== null && !dismissed
           ? "at"
           : null;
-  const count =
+  const countBase =
     menuMode === "slash"
       ? slashMatches.length
       : menuMode === "slasharg"
         ? argRes!.items.length
         : menuMode === "at"
-          ? atMatches.length
+          ? atMatches.length + 1
           : 0;
 
   // Reset highlight + un-dismiss whenever the active query changes.
@@ -573,9 +574,11 @@ export function Composer({
   };
 
   const submit = async () => {
-    if (disabled) return;
+    if (disabled || submitting) return;
     const t = text.trim();
     if ((!t && attachments.length === 0 && workspaceRefs.length === 0) || pendingPaste > 0) return;
+    setSubmitting(true);
+    try {
     const refs = [
       ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
       ...attachments.map((a) => `@${a.path}`),
@@ -593,6 +596,9 @@ export function Composer({
     setAttachments([]);
     setWorkspaceRefs([]);
     setSessionRefs([]);
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const readFileAsDataURL = (file: File) =>
@@ -1004,6 +1010,12 @@ export function Composer({
     );
   }, [pastChats, pastChatQuery]);
 
+  // Final menu item count: when the past:chats list is open, count the
+  // filtered sessions instead of file entries + the "past:chats" row.
+  const count = menuMode === "at" && showPastChats
+    ? filteredPastChats.length
+    : countBase;
+
   const removeAtToken = (value: string) => {
     return value.replace(/(?:^|\s)@[^\s]*$/, "").trimEnd();
   };
@@ -1045,7 +1057,16 @@ export function Composer({
   const pickActive = () => {
     if (menuMode === "slash") pickCommand(slashMatches[active]);
     else if (menuMode === "slasharg" && argRes) pickArg(argRes.items[active]);
-    else if (menuMode === "at") pickEntry(atMatches[active]);
+    else if (menuMode === "at") {
+      if (showPastChats) {
+        const session = filteredPastChats[active];
+        if (session) pickSession(session);
+      } else if (active === 0) {
+        openPastChats();
+      } else {
+        pickEntry(atMatches[active - 1]);
+      }
+    }
   };
 
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -1060,6 +1081,14 @@ export function Composer({
       return;
     }
 
+    const target = e.target as HTMLElement;
+
+    // When the past:chats search box has focus, ArrowDown/Up/Enter/Tab/Escape
+    // should still drive menu navigation (the search box only handles typing
+    // and Backspace). Without this the keyboard is trapped in the input.
+    const inPastChatsSearch =
+      showPastChats && menuMode === "at" && target !== e.currentTarget && target.tagName === "INPUT";
+
     if (menuMode && !composing) {
       if (e.key === "ArrowDown") {
         e.preventDefault();
@@ -1072,16 +1101,28 @@ export function Composer({
         return;
       }
       if (e.key === "Enter" || e.key === "Tab") {
-        e.preventDefault();
-        pickActive();
-        return;
+        if (inPastChatsSearch || target === e.currentTarget) {
+          e.preventDefault();
+          pickActive();
+          return;
+        }
       }
       if (e.key === "Escape") {
         e.preventDefault();
-        setDismissed(true);
+        if (showPastChats) {
+          setPastChatQuery("");
+          setShowPastChats(false);
+          setActive(0);
+        } else {
+          setDismissed(true);
+        }
         return;
       }
     }
+
+    // Guard: don't handle remaining keys when focus is in a child input
+    // (e.g. the past:chats search box); let the child handle them.
+    if (target !== e.currentTarget) return;
 
     // Enter sends; Shift+Enter newline. `composing` guards IME confirms.
     if (e.key === "Enter" && !e.shiftKey && !composing) {
@@ -1221,8 +1262,6 @@ export function Composer({
               </div>
             ) : (
               <>
-                {/* PR-C1: search input is only meaningful when there are sessions
-                    to filter; rendering it in the other states would be noise. */}
                 <div className="slashmenu__item slashmenu__item--search" onMouseDown={(ev) => ev.preventDefault()}>
                   <Search size={13} className="filemenu__icon" />
                   <input
@@ -1235,7 +1274,6 @@ export function Composer({
                       setPastChatQuery(ev.target.value);
                       setActive(0);
                     }}
-                    onKeyDown={(ev) => ev.stopPropagation()}
                   />
                 </div>
                 {filteredPastChats.length === 0 ? (
@@ -1302,17 +1340,18 @@ export function Composer({
         ) : (
           <div className="slashmenu" role="listbox">
             <button
-              className="slashmenu__item slashmenu__item--special"
+              className={`slashmenu__item slashmenu__item--special${active === 0 ? " slashmenu__item--active" : ""}`}
               onMouseDown={(ev) => {
                 ev.preventDefault();
                 openPastChats();
               }}
+              onMouseMove={() => setActive(0)}
             >
               <MessageSquare size={13} className="filemenu__icon" />
               <span className="slashmenu__name">past:chats</span>
               <span className="slashmenu__desc">引用历史会话</span>
             </button>
-            <FileMenu items={atMatches} activeIndex={active} onPick={pickEntry} onHover={setActive} />
+            <FileMenu items={atMatches} activeIndex={active - 1} onPick={pickEntry} onHover={(i) => setActive(i + 1)} />
           </div>
         )
       )}
@@ -1495,7 +1534,7 @@ export function Composer({
               <button
                 className="composer__btn composer__btn--send"
                 onClick={submit}
-                disabled={pendingPaste > 0 || (!text.trim() && attachments.length === 0 && workspaceRefs.length === 0) || disabled}
+                disabled={submitting || pendingPaste > 0 || (!text.trim() && attachments.length === 0 && workspaceRefs.length === 0) || disabled}
               >
                 <ArrowUp size={16} />
               </button>

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -480,6 +480,23 @@ export function Composer({
     [atRaw, atFrag, entries, searchEntries],
   );
 
+  // Unified menu item model for the @ menu. "past:chats" is a real selectable
+  // item (kind "pastChats"), not an active===0 special case.
+  type AtMenuItem =
+    | { kind: "pastChats" }
+    | { kind: "file"; entry: DirEntry };
+
+  const includePastChatsItem = atRaw !== null && atDir === "";
+
+  const atMenuItems = useMemo<AtMenuItem[]>(
+    () => [
+      ...(includePastChatsItem ? [{ kind: "pastChats" as const }] : []),
+      ...atMatches.map((entry) => ({ kind: "file" as const, entry })),
+    ],
+    [includePastChatsItem, atMatches],
+  );
+
+
   // --- which menu (if any) is open --- (slash command names win; then slash
   // arguments; then @-refs — they're rarely valid at once)
   const menuMode: "slash" | "slasharg" | "at" | null =
@@ -496,7 +513,7 @@ export function Composer({
       : menuMode === "slasharg"
         ? argRes!.items.length
         : menuMode === "at"
-          ? atMatches.length + 1
+          ? atMenuItems.length
           : 0;
 
   // Reset highlight + un-dismiss whenever the active query changes.
@@ -504,6 +521,17 @@ export function Composer({
     setActive(0);
     setDismissed(false);
   }, [slashQuery, atRaw]);
+
+  // When the @ trigger disappears (user deleted the @), close the past:chats
+  // sub-menu and reset related state. Without this, showPastChats can outlive
+  // the @ token and leave the session list visible with no way to dismiss it.
+  useEffect(() => {
+    if (menuMode !== "at" && showPastChats) {
+      setShowPastChats(false);
+      setPastChatQuery("");
+      setActive(0);
+    }
+  }, [menuMode]);
 
   const setTextCaretEnd = (next: string) => {
     setText(next);
@@ -974,6 +1002,8 @@ export function Composer({
   // --- past:chats session reference ---
   const openPastChats = async () => {
     setShowPastChats(true);
+    setActive(0);
+    setPastChatQuery("");
     setLoadingPastChats(true);
     try {
       const sessions = await app.ListSessions();
@@ -1019,6 +1049,13 @@ export function Composer({
     ? filteredPastChats.length
     : countBase;
 
+  // Clamp active index when the menu item count changes (e.g. switching
+  // between file list and past:chats list, or filtering sessions).
+  useEffect(() => {
+    const maxIdx = Math.max(0, count - 1);
+    setActive((prev) => (prev > maxIdx ? 0 : prev));
+  }, [count]);
+
   const removeAtToken = (value: string) => {
     return value.replace(/(?:^|\s)@[^\s]*$/, "").trimEnd();
   };
@@ -1058,17 +1095,29 @@ export function Composer({
   };
 
   const pickActive = () => {
-    if (menuMode === "slash") pickCommand(slashMatches[active]);
-    else if (menuMode === "slasharg" && argRes) pickArg(argRes.items[active]);
-    else if (menuMode === "at") {
+    if (menuMode === "slash") {
+      const item = slashMatches[active];
+      if (item) pickCommand(item);
+      return;
+    }
+    if (menuMode === "slasharg" && argRes) {
+      const item = argRes.items[active];
+      if (item) pickArg(item);
+      return;
+    }
+    if (menuMode === "at") {
       if (showPastChats) {
         const session = filteredPastChats[active];
         if (session) pickSession(session);
-      } else if (active === 0) {
-        openPastChats();
-      } else {
-        pickEntry(atMatches[active - 1]);
+        return;
       }
+      const item = atMenuItems[active];
+      if (!item) return;
+      if (item.kind === "pastChats") {
+        void openPastChats();
+        return;
+      }
+      pickEntry(item.entry);
     }
   };
 
@@ -1084,31 +1133,21 @@ export function Composer({
       return;
     }
 
-    const target = e.target as HTMLElement;
-
-    // When the past:chats search box has focus, ArrowDown/Up/Enter/Tab/Escape
-    // should still drive menu navigation (the search box only handles typing
-    // and Backspace). Without this the keyboard is trapped in the input.
-    const inPastChatsSearch =
-      showPastChats && menuMode === "at" && target !== e.currentTarget && target.tagName === "INPUT";
-
     if (menuMode && !composing) {
-      if (e.key === "ArrowDown") {
+      if (e.key === "ArrowDown" && count > 0) {
         e.preventDefault();
         setActive((i) => (i + 1) % count);
         return;
       }
-      if (e.key === "ArrowUp") {
+      if (e.key === "ArrowUp" && count > 0) {
         e.preventDefault();
         setActive((i) => (i - 1 + count) % count);
         return;
       }
       if (e.key === "Enter" || e.key === "Tab") {
-        if (inPastChatsSearch || target === e.currentTarget) {
-          e.preventDefault();
-          pickActive();
-          return;
-        }
+        e.preventDefault();
+        pickActive();
+        return;
       }
       if (e.key === "Escape") {
         e.preventDefault();
@@ -1123,10 +1162,6 @@ export function Composer({
       }
     }
 
-    // Guard: don't handle remaining keys when focus is in a child input
-    // (e.g. the past:chats search box); let the child handle them.
-    if (target !== e.currentTarget) return;
-
     // Enter sends; Shift+Enter newline. `composing` guards IME confirms.
     if (e.key === "Enter" && !e.shiftKey && !composing) {
       e.preventDefault();
@@ -1137,6 +1172,29 @@ export function Composer({
     if (e.key === "Escape" && running && !decisionPending) {
       e.preventDefault();
       handleCancel();
+    }
+  };
+
+  // Keydown handler for the past:chats search <input>. The search input is a
+  // sibling of the <textarea>, so keyboard events never reach the textarea's
+  // onKeyDown. We intercept navigation keys here and delegate to the same
+  // menu logic. Regular typing keys (letters, Backspace, etc.) pass through
+  // so the user can type a search query.
+  const onPastChatSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === "Tab" || e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.key === "ArrowDown" && count > 0) {
+        setActive((i) => (i + 1) % count);
+      } else if (e.key === "ArrowUp" && count > 0) {
+        setActive((i) => (i - 1 + count) % count);
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        pickActive();
+      } else if (e.key === "Escape") {
+        setPastChatQuery("");
+        setShowPastChats(false);
+        setActive(0);
+      }
     }
   };
 
@@ -1277,6 +1335,7 @@ export function Composer({
                       setPastChatQuery(ev.target.value);
                       setActive(0);
                     }}
+                    onKeyDown={onPastChatSearchKeyDown}
                   />
                 </div>
                 {filteredPastChats.length === 0 ? (
@@ -1342,19 +1401,25 @@ export function Composer({
           </div>
         ) : (
           <div className="slashmenu" role="listbox">
-            <button
-              className={`slashmenu__item slashmenu__item--special${active === 0 ? " slashmenu__item--active" : ""}`}
-              onMouseDown={(ev) => {
-                ev.preventDefault();
-                openPastChats();
-              }}
-              onMouseMove={() => setActive(0)}
-            >
-              <MessageSquare size={13} className="filemenu__icon" />
-              <span className="slashmenu__name">past:chats</span>
-              <span className="slashmenu__desc">引用历史会话</span>
-            </button>
-            <FileMenu items={atMatches} activeIndex={active - 1} onPick={pickEntry} onHover={(i) => setActive(i + 1)} />
+            {includePastChatsItem && (
+              <button
+                className={`slashmenu__item${active === 0 ? " slashmenu__item--active" : ""}`}
+                onMouseDown={(ev) => {
+                  ev.preventDefault();
+                  void openPastChats();
+                }}
+                onMouseMove={() => setActive(0)}
+              >
+                <MessageSquare size={13} className="filemenu__icon" />
+                <span className="slashmenu__name">past:chats</span>
+              </button>
+            )}
+            <FileMenu
+              items={atMatches}
+              activeIndex={active - (includePastChatsItem ? 1 : 0)}
+              onPick={pickEntry}
+              onHover={(i) => setActive(i + (includePastChatsItem ? 1 : 0))}
+            />
           </div>
         )
       )}

--- a/desktop/frontend/src/components/FileMenu.tsx
+++ b/desktop/frontend/src/components/FileMenu.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef } from "react";
 import { Folder, FileText } from "lucide-react";
 import type { DirEntry } from "../lib/types";
 
-// FileMenu is the "@" file-reference dropdown above the composer. Like SlashMenu,
-// it's presentational — the Composer owns navigation and the one-level-at-a-time
-// descend logic. Reuses the .slashmenu container styling.
+// FileMenu is the "@" file-reference list — it renders only the items and
+// expects the caller (Composer) to wrap them in a .slashmenu container, since
+// nesting two .slashmenu absolute containers mis-positions the inner one. The
+// Composer owns navigation and the one-level-at-a-time descend logic; this
+// stays presentational.
 export function FileMenu({
   items,
   activeIndex,
@@ -22,7 +24,7 @@ export function FileMenu({
     activeRef.current?.scrollIntoView({ block: "nearest" });
   }, [activeIndex]);
   return (
-    <div className="slashmenu" role="listbox">
+    <>
       {items.map((e, i) => (
         <button
           key={(e.isDir ? "d:" : "f:") + e.name}
@@ -47,6 +49,6 @@ export function FileMenu({
           </span>
         </button>
       ))}
-    </div>
+    </>
   );
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -241,6 +241,16 @@ export interface SessionMeta {
   topicTitle?: string;
 }
 
+// SessionReference is a session selected via @ past:chats for context injection.
+export interface SessionReference {
+  path: string;
+  title: string;
+  preview?: string;
+  turns?: number;
+  createdAt?: number;
+  lastActivityAt?: number;
+}
+
 export interface WorkspaceView {
   path: string;
   name: string;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7147,7 +7147,6 @@ a[href] {
   cursor: not-allowed;
 }
 
-
 /* Memory filter input: a full-width mem-input variant that sits below
    the section title. The existing mem-input already has a 28px height
    and the right border tokens; this just sets margin so it doesn't

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3852,6 +3852,42 @@ a[href] {
   border-right: 0;
   border-top: 0;
 }
+/* past:chats hover preview (PR-C2). Inherits colors from the .tooltip container
+   (--fg / --fg-dim / --fg-faint / --border / --bg-elev) and only adjusts layout. */
+.past-chat-hover {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-width: 300px;
+}
+.past-chat-hover__title {
+  font-weight: 600;
+  color: var(--fg);
+  word-break: break-word;
+}
+.past-chat-hover__preview {
+  color: var(--fg-dim);
+  word-break: break-word;
+  max-height: 96px;
+  overflow: hidden;
+  /* fade the cut so long previews don't look amputated */
+  -webkit-mask-image: linear-gradient(to bottom, #000 70%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 70%, transparent 100%);
+}
+.past-chat-hover__meta {
+  color: var(--fg-faint);
+  font-size: 11px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.past-chat-hover__path {
+  color: var(--fg-faint);
+  font-size: 11px;
+  word-break: break-all;
+  max-height: 32px;
+  overflow: hidden;
+}
 .workspace-empty {
   padding: 18px 0;
   color: var(--fg-faint);
@@ -6736,7 +6772,34 @@ a[href] {
   color: var(--fg);
   background: var(--hover);
 }
-
+.composer-context__item--session {
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+  background: color-mix(in srgb, var(--accent) 7%, var(--panel));
+}
+.composer-context__item--session .composer-context__label > svg {
+  color: var(--accent);
+}
+.slashmenu__item--special {
+  border-bottom: 1px solid var(--border);
+  background: color-mix(in srgb, var(--accent) 5%, var(--panel));
+}
+.slashmenu__item--special:hover {
+  background: color-mix(in srgb, var(--accent) 10%, var(--panel));
+}
+.slashmenu__item--back {
+  border-top: 1px solid var(--border);
+  color: var(--fg-dim);
+}
+.slashmenu__item--back:hover {
+  background: var(--hover);
+}
+.slashmenu__item--empty {
+  color: var(--fg-faint);
+  cursor: default;
+}
+.slashmenu__item--empty:hover {
+  background: transparent;
+}
 .composer__pasted {
   display: flex;
   flex-direction: column;

--- a/docs/SESSION_REFERENCE_ARCHITECTURE.md
+++ b/docs/SESSION_REFERENCE_ARCHITECTURE.md
@@ -68,7 +68,7 @@ const menuMode: "slash" | "slasharg" | "at" | null = ...;
 interface AppBindings {
   // 会话列表
   ListSessions(): Promise<SessionMeta[]>;
-  
+
   // 会话操作（可复用读取历史）
   PreviewSession(path: string): Promise<HistoryMessage[]>;
 }
@@ -141,7 +141,7 @@ export interface SessionReference {
 interface AppBindings {
   // 新增：搜索会话
   SearchSessions(query: string): Promise<SessionMeta[]>;
-  
+
   // 已有：读取会话历史（复用）
   PreviewSession(path: string): Promise<HistoryMessage[]>;
 }
@@ -161,16 +161,16 @@ const [sessionRefs, setSessionRefs] = useState<SessionReference[]>([]);
 {menuMode === "at" && (
   showPastChats ? (
     // 显示会话列表
-    <SessionMenu 
-      items={pastChats} 
-      activeIndex={active} 
+    <SessionMenu
+      items={pastChats}
+      activeIndex={active}
       onPick={pickSession}
       onHover={setActive}
     />
   ) : (
     // 显示文件列表（原有逻辑）
     <>
-      <button 
+      <button
         className="slashmenu__item slashmenu__item--special"
         onMouseDown={() => {
           setShowPastChats(true);
@@ -197,7 +197,7 @@ const pickSession = (session: SessionMeta) => {
     createdAt: session.createdAt,
     lastActivityAt: session.lastActivityAt,
   }]);
-  
+
   // 重置状态
   setShowPastChats(false);
   setText(""); // 清空输入框
@@ -206,7 +206,7 @@ const pickSession = (session: SessionMeta) => {
 // 4. 发送时附加会话上下文
 const handleSubmit = async () => {
   let context = "";
-  
+
   if (sessionRefs.length > 0) {
     context = "以下是用户引用的历史会话上下文：\n\n";
     for (const ref of sessionRefs) {
@@ -216,7 +216,7 @@ const handleSubmit = async () => {
     }
     context += "\n\n当前用户问题：\n";
   }
-  
+
   onSubmit(context + text);
 };
 ```

--- a/docs/SESSION_REFERENCE_ARCHITECTURE.md
+++ b/docs/SESSION_REFERENCE_ARCHITECTURE.md
@@ -1,0 +1,370 @@
+# 会话引用功能架构文档
+
+> GitHub Issue: https://github.com/esengine/DeepSeek-Reasonix/issues/3185
+
+## 1. 功能需求
+
+在当前会话中使用 `@` 引用其他会话的聊天记录作为内容发送给 AI。
+
+### 1.1 用户场景
+
+- 用户在当前会话中想引用之前会话的对话内容
+- 用户想让 AI 参考之前的对话上下文
+- 用户想合并多个会话的讨论结果
+
+### 1.2 预期行为（P0-MVP）
+
+```
+输入 @
+→ 显示原有菜单（文件/目录列表）
+→ 菜单顶部新增 "past:chats" 选项
+→ 选择 past:chats
+→ 切换到历史会话列表
+→ 选择一个会话
+→ Composer 上方显示"已引用会话"
+→ 发送时把该会话历史内容附加到当前 prompt/context
+```
+
+---
+
+## 2. 现有代码结构分析
+
+### 2.1 核心文件
+
+| 文件 | 作用 |
+|------|------|
+| `desktop/frontend/src/components/Composer.tsx` | 输入框组件，包含 @ 功能 |
+| `desktop/frontend/src/components/FileMenu.tsx` | @ 文件菜单组件 |
+| `desktop/frontend/src/components/HistoryPanel.tsx` | 历史会话面板 |
+| `desktop/frontend/src/lib/bridge.ts` | 前后端通信接口 |
+| `desktop/frontend/src/lib/types.ts` | 类型定义 |
+
+### 2.2 现有 @ 功能实现
+
+**Composer.tsx 第 257-337 行** 实现了文件引用功能：
+
+```typescript
+// --- @ file references ---
+const atRaw = useMemo(() => {
+  const m = /(?:^|\s)@([^\s]*)$/.exec(text);
+  return m ? m[1] : null;
+}, [text]);
+
+// 文件匹配结果
+const atMatches = useMemo(() => {
+  // 过滤本地目录和搜索结果
+}, [atRaw, atFrag, entries, searchEntries]);
+
+// 菜单模式判断
+const menuMode: "slash" | "slasharg" | "at" | null = ...;
+
+// 渲染文件菜单
+{menuMode === "at" && <FileMenu items={atMatches} ... />}
+```
+
+### 2.3 已有的会话 API（可复用）
+
+```typescript
+interface AppBindings {
+  // 会话列表
+  ListSessions(): Promise<SessionMeta[]>;
+  
+  // 会话操作（可复用读取历史）
+  PreviewSession(path: string): Promise<HistoryMessage[]>;
+}
+```
+
+---
+
+## 3. P0-MVP 实施方案
+
+### 3.1 设计思路
+
+在现有的 `@` 菜单中添加 "past:chats" 选项，而不是创建新的 `@session:` 语法。
+
+**菜单结构：**
+```
+@
+├── 📁 past:chats        ← 新增：选择后显示历史会话列表
+├── 📁 src/
+├── 📁 docs/
+├── 📄 README.md
+└── ...
+```
+
+### 3.2 实施路线
+
+```
+第一步：后端加搜索接口
+    ↓
+第二步：前端 bridge.ts 暴露接口
+    ↓
+第三步：在 @ 菜单中添加 "past:chats" 选项
+    ↓
+第四步：选择 past:chats 后切换到会话列表
+    ↓
+第五步：选择会话后添加到引用区域
+    ↓
+第六步：发送时附加会话上下文
+```
+
+### 3.3 最小改动文件清单
+
+```
+desktop/frontend/src/lib/types.ts      — 添加 SessionReference 类型
+desktop/frontend/src/lib/bridge.ts     — 添加 SearchSessions API
+desktop/frontend/src/components/Composer.tsx — 扩展 @ 菜单逻辑
+desktop/frontend/src/components/FileMenu.tsx — 扩展菜单支持会话项
+desktop/app.go                         — 添加 SearchSessions 方法
+desktop/sessions.go                    — 实现会话搜索逻辑
+```
+
+### 3.4 类型定义
+
+```typescript
+// types.ts
+export interface SessionReference {
+  path: string;
+  title: string;
+  preview?: string;
+  turns?: number;
+  createdAt?: number;
+  lastActivityAt?: number;
+  messages?: HistoryMessage[]; // P0 先不存，发送时再拉取
+}
+```
+
+### 3.5 API 设计
+
+```typescript
+// bridge.ts
+interface AppBindings {
+  // 新增：搜索会话
+  SearchSessions(query: string): Promise<SessionMeta[]>;
+  
+  // 已有：读取会话历史（复用）
+  PreviewSession(path: string): Promise<HistoryMessage[]>;
+}
+```
+
+### 3.6 前端逻辑修改
+
+**Composer.tsx 修改：**
+
+```typescript
+// 1. 添加状态
+const [showPastChats, setShowPastChats] = useState(false);
+const [pastChats, setPastChats] = useState<SessionMeta[]>([]);
+const [sessionRefs, setSessionRefs] = useState<SessionReference[]>([]);
+
+// 2. 修改 @ 菜单渲染
+{menuMode === "at" && (
+  showPastChats ? (
+    // 显示会话列表
+    <SessionMenu 
+      items={pastChats} 
+      activeIndex={active} 
+      onPick={pickSession}
+      onHover={setActive}
+    />
+  ) : (
+    // 显示文件列表（原有逻辑）
+    <>
+      <button 
+        className="slashmenu__item slashmenu__item--special"
+        onMouseDown={() => {
+          setShowPastChats(true);
+          app.ListSessions().then(setPastChats);
+        }}
+      >
+        <MessageSquare size={13} />
+        <span className="slashmenu__name">past:chats</span>
+        <span className="slashmenu__desc">引用历史会话</span>
+      </button>
+      <FileMenu items={atMatches} ... />
+    </>
+  )
+)}
+
+// 3. 选择会话后的处理
+const pickSession = (session: SessionMeta) => {
+  // 添加到引用区域
+  setSessionRefs(prev => [...prev, {
+    path: session.path,
+    title: session.title || session.preview || "Untitled",
+    preview: session.preview,
+    turns: session.turns,
+    createdAt: session.createdAt,
+    lastActivityAt: session.lastActivityAt,
+  }]);
+  
+  // 重置状态
+  setShowPastChats(false);
+  setText(""); // 清空输入框
+};
+
+// 4. 发送时附加会话上下文
+const handleSubmit = async () => {
+  let context = "";
+  
+  if (sessionRefs.length > 0) {
+    context = "以下是用户引用的历史会话上下文：\n\n";
+    for (const ref of sessionRefs) {
+      const messages = await app.PreviewSession(ref.path);
+      const limited = limitMessages(messages, 30, 20000);
+      context += formatSessionContext(ref.title, limited);
+    }
+    context += "\n\n当前用户问题：\n";
+  }
+  
+  onSubmit(context + text);
+};
+```
+
+### 3.7 限制策略
+
+```
+最多引用最近 30 条消息
+或最多 20k 字符
+超出部分截断，并提示"已截断"
+```
+
+### 3.8 发送时的消息格式
+
+```
+以下是用户引用的历史会话上下文：
+
+[会话：修复登录 bug]
+用户：...
+助手：...
+用户：...
+
+当前用户问题：
+...
+```
+
+---
+
+## 4. 架构图
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      Composer.tsx                           │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  @ 菜单逻辑                                          │   │
+│  │  - 原有：文件/目录列表                               │   │
+│  │  - 新增：past:chats 选项（在菜单顶部）              │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                           │                                 │
+│                           ▼                                 │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  菜单渲染                                            │   │
+│  │  - showPastChats=false → FileMenu + past:chats 按钮 │   │
+│  │  - showPastChats=true  → SessionMenu (会话列表)     │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                      bridge.ts                              │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  新增 API:                                          │   │
+│  │  - SearchSessions(query): Promise<SessionMeta[]>   │   │
+│  │                                                     │   │
+│  │  复用 API:                                          │   │
+│  │  - ListSessions(): Promise<SessionMeta[]>          │   │
+│  │  - PreviewSession(path): Promise<HistoryMessage[]> │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+                           │
+                           ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    desktop/app.go                           │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  新增方法:                                          │   │
+│  │  - SearchSessions(query string) []SessionMeta      │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 5. UI 设计
+
+### 5.1 @ 菜单（showPastChats=false）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  @  ← 用户输入                                              │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  💬 past:chats        引用历史会话                   │   │
+│  ├─────────────────────────────────────────────────────┤   │
+│  │  📁 src/                                             │   │
+│  │  📁 docs/                                            │   │
+│  │  📄 README.md                                        │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                             │
+│  [输入消息...]                                    [发送]    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 会话列表（showPastChats=true）
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  @past:chats  ← 用户输入                                    │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  💬 项目架构设计讨论 - 2026-06-04                   │   │
+│  │  💬 数据处理方案 - 2026-06-03                       │   │
+│  │  💬 API 接口设计 - 2026-06-02                       │   │
+│  │  ← 返回文件列表                                     │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                             │
+│  [输入消息...]                                    [发送]    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 5.3 引用区域
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  📎 引用的会话:                                              │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  📄 项目架构设计讨论 (8 轮)               [×]       │   │
+│  └─────────────────────────────────────────────────────┘   │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  [输入消息...]                                    [发送]    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. P1 后续优化（暂不实施）
+
+- 选择单条/多条消息
+- hover 预览会话详情
+- 截断/缓存优化
+- 国际化翻译
+- 搜索会话功能
+
+---
+
+## 7. 验收标准
+
+### P0 验收
+
+- [ ] 输入 `@` 显示菜单，包含 "past:chats" 选项
+- [ ] 选择 "past:chats" 显示历史会话列表
+- [ ] 选择会话后显示在引用区域
+- [ ] 可以删除引用的会话
+- [ ] 发送时正确附加会话上下文
+- [ ] 引用内容限制在 30 条消息或 20k 字符内
+- [ ] 超出部分截断并提示
+
+### 测试用例
+
+- [ ] 无历史会话时的行为
+- [ ] 引用超大会话时的截断
+- [ ] 与现有 @ 文件引用同时使用
+- [ ] 在不同主题下的显示效果


### PR DESCRIPTION
Part of #3185
## Summary

Add `@ → past:chats` flow to the Composer, allowing users to select a historical chat session and inject its context into the current conversation.

### What's included

- **`@` menu**: New `past:chats` entry in the `@` context menu
- **Session list**: Browse recent chat sessions with title and turn count
- **Search**: Filter sessions by keyword
- **Hover preview**: Preview session content on hover before selecting
- **Context injection**: Selected session's conversation is appended to the prompt as context
- **Architecture doc**: `docs/SESSION_REFERENCE_ARCHITECTURE.md` documenting the data flow

### Files changed

| File | Change |
|---|---|
| `Composer.tsx` | `@` menu entry, session list, search, hover preview, reference card in Composer |
| `FileMenu.tsx` | Wire `past:chats` menu item |
| `types.ts` | `SessionReference` interface |
| `styles.css` | Composer reference card styles |
| `SESSION_REFERENCE_ARCHITECTURE.md` | Architecture documentation |

## Test checklist

- [ ] `@` menu shows `past:chats` option
- [ ] Clicking `past:chats` opens session list
- [ ] Search filters sessions by keyword
- [ ] Hover preview shows session content
- [ ] Selecting a session adds reference card above Composer input
- [ ] Reference card shows title, turn count, file name
- [ ] Hover on reference card shows full path
- [ ] Sending with reference: AI can reference the selected session content
- [ ] Sending without reference: normal behavior unchanged
- [ ] Deleting reference card before send: no reference injected
- [ ] `@` file references still work
- [ ] `/` command menu still works
- [ ] No regression in existing Composer behavior  