### PR TITLE
Add desktop dev port wrapper / 新增桌面开发端口脚本

### DIFF
--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 
+const devPort = Number(process.env.REASONIX_DESKTOP_VITE_PORT || "5173");
+
 // On macOS ≤ 12 (Safari 15 WebKit) a crossorigin module/stylesheet fetched over the
 // wails:// scheme is CORS-blocked (no Access-Control-Allow-Origin from the handler),
 // so the bundle never loads and the window paints blank; newer WebKit tolerates it.
@@ -57,7 +59,7 @@ export default defineConfig({
     // Bind IPv4 — unset host listens on ::1, and the Wails dev proxy's [::1]
     // dial fails on Windows hosts where IPv6 loopback is filtered.
     host: "127.0.0.1",
-    port: 5173,
+    port: devPort,
     strictPort: true,
   },
 });

--- a/dev
+++ b/dev
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(git rev-parse --show-toplevel)"
+desktop_dir="$root/desktop"
+
+vite_port="${REASONIX_DESKTOP_VITE_PORT:-}"
+if [[ $# -gt 0 && "$1" =~ ^[0-9]+$ ]]; then
+  vite_port="$1"
+  shift
+fi
+
+if [[ -z "$vite_port" ]]; then
+  branch="$(git -C "$root" branch --show-current || true)"
+  if [[ -z "$branch" ]]; then
+    branch="$(git -C "$root" rev-parse --short HEAD)"
+  fi
+  key="$root:$branch"
+  hash="$(printf "%s" "$key" | cksum | awk '{print $1}')"
+  vite_port=$((5173 + (hash % 100)))
+fi
+
+if (( vite_port < 1024 || vite_port > 36000 )); then
+  echo "dev: Vite port must be between 1024 and 36000, got $vite_port" >&2
+  exit 2
+fi
+
+wails_port="${REASONIX_DESKTOP_WAILS_PORT:-$((vite_port + 29000))}"
+
+export REASONIX_DESKTOP_VITE_PORT="$vite_port"
+
+echo "Reasonix desktop dev"
+echo "  worktree: $root"
+echo "  vite:     http://127.0.0.1:$vite_port"
+echo "  wails:    127.0.0.1:$wails_port"
+
+cd "$desktop_dir"
+exec wails dev -nosyncgomod -devserver "127.0.0.1:$wails_port" "$@"


### PR DESCRIPTION
## Summary
- add a root `./dev` wrapper that runs desktop Wails dev from any repo location
- allow `./dev 5120` to set the Vite port and derive the Wails dev server port
- make Vite read `REASONIX_DESKTOP_VITE_PORT` while preserving the default 5173 port

## Verification
- `bash -n dev`
- `./dev 5120 -help`
- `(cd desktop && wails build -clean -nosyncgomod)`