### PR TITLE
fix(cli): clarify setup overwrite prompt

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -559,8 +559,7 @@ func setupConfig(args []string) int {
 			return 1
 		}
 		in := bufio.NewScanner(os.Stdin)
-		ans := ask(in, os.Stdout, fmt.Sprintf(i18n.M.ConfirmReconfigureFmt, path), "N")
-		if ans != "y" && ans != "Y" {
+		if !confirmReconfigureExistingConfig(path, in, os.Stdout) {
 			fmt.Println(i18n.M.KeepingExisting)
 			return 0
 		}
@@ -575,6 +574,11 @@ func setupConfig(args []string) int {
 		return rc
 	}
 	return writeDefaultConfig(t.config)
+}
+
+func confirmReconfigureExistingConfig(path string, in *bufio.Scanner, w io.Writer) bool {
+	ans := ask(in, w, fmt.Sprintf(i18n.M.ConfirmReconfigureFmt, path), "y/N")
+	return ans == "y" || ans == "Y"
 }
 
 func writeDefaultConfig(path string) int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"io"
@@ -12,6 +13,7 @@ import (
 
 	"reasonix/internal/config"
 	"reasonix/internal/event"
+	"reasonix/internal/i18n"
 	"reasonix/internal/notify"
 	"reasonix/internal/provider"
 )
@@ -269,6 +271,20 @@ func TestWithNotificationsWrapsCLISinkWithConfiguredSender(t *testing.T) {
 	}
 	if sender.messages[0].Body != "Turn finished" {
 		t.Fatalf("notification body = %q, want Turn finished", sender.messages[0].Body)
+	}
+}
+
+func TestSetupOverwritePromptShowsYNDefault(t *testing.T) {
+	t.Cleanup(func() { i18n.DetectLanguage("en") })
+	for _, lang := range []string{"en", "zh"} {
+		i18n.DetectLanguage(lang)
+		var out bytes.Buffer
+		if confirmReconfigureExistingConfig("config.toml", bufio.NewScanner(strings.NewReader("\n")), &out) {
+			t.Fatalf("%s empty overwrite answer should keep existing config", lang)
+		}
+		if !strings.Contains(out.String(), "[y/N]:") {
+			t.Fatalf("%s overwrite prompt should show explicit [y/N] default, got %q", lang, out.String())
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- show the setup overwrite confirmation as `[y/N]` instead of the ambiguous `[N]`
- keep Enter as the safe "do not overwrite" path
- add regression coverage for both English and Chinese prompt rendering

## Tests
- `go test ./internal/cli -run TestSetupOverwritePromptShowsYNDefault -count=1`
- `go test ./internal/cli -run 'TestSetupOverwritePromptShowsYNDefault|TestConfigureKeys|TestAppendEnvUpsertsExistingKey|TestConfigAutoPlanCommandWritesUserConfig|TestConfigAutoPlanLocalCreatesMinimalProjectOverride|TestWelcomePromptMissingKeysRequiresConfigSource' -count=1`
- `go test ./internal/i18n -count=1`
- `git diff --check`

## Notes
- `go test ./internal/cli -count=1` still has unrelated local failures in existing tests on this machine, including locale-sensitive English assertions and `TestModelSwitchRefreshesCustomStatusline`.