### PR TITLE
fix(cli): prompt before reusing setup API keys

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1296,17 +1296,12 @@ func providersWithMissingKeys(cfg *config.Config) []config.ProviderEntry {
 }
 
 // configureKeys reconciles each enabled provider's API key with the
-// environment. For every distinct api_key_env: if the variable is already
-// set — either by loadDotEnv from .env, or by an earlier wizard step that
-// called os.Setenv (the URL-fetch flow asks for the key once so it can call
-// /models) — the existing value is reused and a single-line confirmation is
-// printed so the user can see why no prompt appeared. Otherwise the user is
-// asked once per env var (deduped across providers that share one, e.g.
-// both DeepSeek models). Returns KEY=value lines to append to .env: any
-// env var that was already set in the process goes through too, so a
-// re-run of `reasonix setup` re-pins the current value into .env (a
-// loadDotEnv is first-wins, so without re-pinning, an old .env line would
-// shadow the fresh value).
+// environment. For every distinct api_key_env: if the variable is already set,
+// setup asks whether to re-enter it; Enter keeps and re-pins the existing value.
+// Otherwise the user is asked once per env var (deduped across providers that
+// share one, e.g. both DeepSeek models). Returns KEY=value lines to append to
+// .env. Re-pinning matters because loadDotEnv is first-wins, so a stale key left
+// earlier in the credentials file would otherwise keep shadowing the fresh value.
 func configureKeys(selected []config.ProviderEntry, r io.Reader, w io.Writer) []string {
 	in := bufio.NewScanner(r)
 	fmt.Fprintln(w, "\n"+i18n.M.EnterAPIKeysHeader)
@@ -1319,11 +1314,14 @@ func configureKeys(selected []config.ProviderEntry, r io.Reader, w io.Writer) []
 		}
 		seen[p.APIKeyEnv] = true
 
-		// Reuse any value the wizard or .env already set. The URL-fetch
-		// flow (promptCustomProviderFromURL) calls os.Setenv(keyEnv, apiKey)
-		// before the /models probe; that value is the user's "real" key
-		// and we'd be wrong to discard it by asking again.
 		if cur := os.Getenv(p.APIKeyEnv); cur != "" {
+			reset := ask(in, w, "  "+fmt.Sprintf(i18n.M.APIKeyResetPromptFmt, p.APIKeyEnv), "y/N")
+			if reset == "y" || reset == "Y" {
+				if key := ask(in, w, "  "+p.APIKeyEnv, ""); key != "" {
+					envLines = append(envLines, p.APIKeyEnv+"="+key)
+					continue
+				}
+			}
 			fmt.Fprintf(w, "  %s %s\n", green("✓"), fmt.Sprintf(i18n.M.APIKeyAlreadySetFmt, p.APIKeyEnv))
 			envLines = append(envLines, p.APIKeyEnv+"="+cur)
 			continue

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -262,7 +262,7 @@ func TestConfigureKeysReusesExistingEnv(t *testing.T) {
 
 	selected := config.Default().Providers
 	var output bytes.Buffer
-	env := configureKeys(selected, strings.NewReader("mi-key-from-input\n"), &output)
+	env := configureKeys(selected, strings.NewReader("\nmi-key-from-input\n"), &output)
 
 	if len(env) != 2 {
 		t.Fatalf("env = %v (want 2: DeepSeek reused + MiMo entered)", env)
@@ -278,16 +278,36 @@ func TestConfigureKeysReusesExistingEnv(t *testing.T) {
 	}
 }
 
-// TestConfigureKeysAllSetSkipsInput ensures that when every env var is
-// already populated, configureKeys returns without reading anything from
-// the input — critical for the first-time-setup flow, where the URL-fetch
-// step has already collected all keys and configureKeys is a no-op.
-func TestConfigureKeysAllSetSkipsInput(t *testing.T) {
+func TestConfigureKeysCanResetExistingEnv(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "stale-ds-key")
+	t.Setenv("MIMO_API_KEY", "") // ask for this one normally
+
+	selected := config.Default().Providers
+	var output bytes.Buffer
+	env := configureKeys(selected, strings.NewReader("y\nfresh-ds-key\nmi-key\n"), &output)
+
+	if len(env) != 2 {
+		t.Fatalf("env = %v (want 2: DeepSeek reset + MiMo entered)", env)
+	}
+	if env[0] != "DEEPSEEK_API_KEY=fresh-ds-key" {
+		t.Errorf("env[0] = %q, want freshly entered value", env[0])
+	}
+	if env[1] != "MIMO_API_KEY=mi-key" {
+		t.Errorf("env[1] = %q, want typed MiMo value", env[1])
+	}
+	if !strings.Contains(output.String(), "[y/N]:") || !strings.Contains(output.String(), "DEEPSEEK_API_KEY") {
+		t.Errorf("expected a reset confirmation for DEEPSEEK_API_KEY, got:\n%s", output.String())
+	}
+}
+
+// TestConfigureKeysAllSetDefaultsToReusingInput ensures that when every env var
+// is already populated, pressing Enter at each confirmation keeps the values.
+func TestConfigureKeysAllSetDefaultsToReusingInput(t *testing.T) {
 	t.Setenv("DEEPSEEK_API_KEY", "ds")
 	t.Setenv("MIMO_API_KEY", "mi")
 
 	selected := config.Default().Providers
-	env := configureKeys(selected, strings.NewReader("should-not-be-consumed\n"), io.Discard)
+	env := configureKeys(selected, strings.NewReader("\n\n"), io.Discard)
 	if len(env) != 2 {
 		t.Errorf("env = %v, want 2 (both reused)", env)
 	}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -293,6 +293,7 @@ type Messages struct {
 	AnthropicFetchEmpty        string // "/models returned an empty list — Anthropic-compatible providers usually don't expose one, falling back to manual entry"
 	SkipStaleCustomEntryFmt    string // "skipping stale %q entry from reasonix.toml (pointing at %s) — please remove it"
 	APIKeyAlreadySetFmt        string // "reusing existing value for %s"
+	APIKeyResetPromptFmt       string // "Re-enter %s?"
 
 	// custom provider
 	CustomProviderLabel  string // "Custom Model"

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -255,6 +255,7 @@ var English = Messages{
 	AnthropicFetchEmpty:        "/models returned an empty list — Anthropic-compatible providers usually don't expose one, falling back to manual entry",
 	SkipStaleCustomEntryFmt:    "skipping stale %q entry from reasonix.toml (pointing at %s) — please remove it from [[providers]]",
 	APIKeyAlreadySetFmt:        "reusing existing value for %s",
+	APIKeyResetPromptFmt:       "Re-enter %s?",
 
 	// custom provider
 	CustomProviderLabel:  "Custom Model",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -256,6 +256,7 @@ var Chinese = Messages{
 	AnthropicFetchEmpty:        "/models 返回为空 — Anthropic 兼容服务通常不提供此端点，回退到手动输入",
 	SkipStaleCustomEntryFmt:    "跳过 reasonix.toml 里的旧 %q 条目（指向 %s）— 请手动从 [[providers]] 里删除",
 	APIKeyAlreadySetFmt:        "复用已设置的 %s",
+	APIKeyResetPromptFmt:       "重新输入 %s？",
 
 	// custom provider
 	CustomProviderLabel:  "自定义模型",


### PR DESCRIPTION
## Summary
- prompt during `reasonix setup` before reusing an already-set provider API key
- keep Enter as the safe default that reuses and re-pins the existing value
- allow `y` to re-enter the key so stale credentials can be replaced without manually editing the credentials file
- add localized English/Chinese prompt text and regression coverage for reuse and reset paths

## Tests
- `go test ./internal/cli -run 'TestConfigureKeys|TestAppendEnvUpsertReplacesExistingKey|TestAppendEnvUpsertHandlesExportPrefix' -count=1`
- `go test ./internal/i18n -count=1`
- `git diff --check`

## Notes
- `go test ./internal/cli -count=1` still has unrelated local failures on this machine, including locale-sensitive assertions from the user config and `TestModelSwitchRefreshesCustomStatusline`.