### PR TITLE
style(desktop): right-align user messages as chat bubbles

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1060,12 +1060,18 @@ a[href] {
 }
 .msg--user {
   display: flex;
-  gap: 10px;
-  align-items: baseline;
+  gap: 8px;
+  align-items: flex-start;
   color: var(--fg);
+  background: var(--accent-soft);
+  border-radius: 14px 14px 4px 14px;
+  padding: 10px 14px;
+  margin-left: auto;
+  margin-right: 0;
+  max-width: 75%;
+  width: fit-content;
 }
 .rewind {
-  margin-left: auto;
   flex-shrink: 0;
   position: relative;
 }
@@ -1167,15 +1173,14 @@ a[href] {
   background: color-mix(in srgb, var(--danger) 12%, transparent);
 }
 .msg__caret {
-  color: var(--accent);
-  font-family: var(--mono);
-  font-weight: 600;
-  flex-shrink: 0;
+  display: none;
 }
 .msg--user .msg__text {
   white-space: pre-wrap;
   word-break: break-word;
   font-weight: 450;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .msg--assistant {
   color: var(--fg);


### PR DESCRIPTION
## Problem

User messages and AI responses are both left-aligned, making it hard to quickly locate user messages when scrolling through long conversations. User inputs are typically 1-2 lines while AI outputs are dozens of lines — with everything stacked on the left, user messages get visually buried.

This differs from the classic chat layout used by ChatGPT, Claude Desktop, iMessage, WeChat, Slack, etc., where user messages are right-aligned and AI messages are left-aligned.

## Solution

Right-align user messages as chat bubbles with a subtle `accent-soft` background. AI messages remain left-aligned. Pure CSS change — no component logic modified.

### Before
```
› User message text here...
Assistant response that is very long...
› Another user message...
Another long assistant response...
```

### After
```
                              [User message text here...]
Assistant response that is very long...
                              [Another user message...]
Another long assistant response...
```

## Changes (1 file, +12/-7 lines)

`desktop/frontend/src/styles.css`:
- `.msg--user`: right-align with `margin-left: auto`, add `accent-soft` background bubble with `border-radius: 14px 14px 4px 14px`, `max-width: 75%`, `width: fit-content`
- `.msg__caret`: hidden (redundant in bubble layout)
- `.rewind`: remove `margin-left: auto` (now flows inside bubble)
- `.msg--user .msg__text`: `flex: 1 1 auto; min-width: 0` for proper text wrapping

## Theme compatibility

Uses the existing `--accent-soft` CSS variable, which is already defined for every theme variant (dark, light, graphite, ember, aurora, midnight, sandstone, porcelain, linen, glacier). All themes are automatically supported with no extra work.
