### PR TITLE
feat(ci): AI-classify issues into area/platform/severity labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,51 @@
+# Area labels auto-applied to PRs by .github/workflows/pr-auto-label.yml
+# (actions/labeler), based on the changed file paths. Keep the area set in sync
+# with issue-auto-label.yml. severity/platform are issue-only — a PR is a change,
+# not a bug report — and v1/v2 are handled by pr-version-label.yml.
+
+agent:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/agent/**'
+          - 'internal/control/**'
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/plugin/**'
+          - 'internal/codegraph/**'
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/config/**'
+          - 'internal/boot/**'
+
+provider:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/provider/**'
+
+skills:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/skill/**'
+          - 'internal/tool/**'
+
+tui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/cli/**'
+
+desktop:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'desktop/**'
+
+updater:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'desktop/cmd/sign/**'
+          - 'desktop/updater*.go'
+          - 'scripts/desktop-build.sh'
+          - '.github/workflows/release*.yml'

--- a/.github/workflows/issue-auto-label.yml
+++ b/.github/workflows/issue-auto-label.yml
@@ -1,0 +1,99 @@
+name: Auto-label issues
+
+# Classify new issues into area / platform / severity labels using the DeepSeek
+# API (the project's own model). The model is constrained to a fixed label set —
+# anything it returns outside the set is dropped — so it can't invent labels.
+# Issues it can't place into any area get `needs-triage` for a human to look at.
+# Version (v1/v2) labels are handled separately by issue-version-label.yml.
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: issue-autolabel-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        with:
+          script: |
+            const AREA = ['agent','mcp','config','updater','provider','desktop','tui','skills','rendering'];
+            const PLATFORM = ['windows','macos','linux'];
+            const SEVERITY = ['crash','data-loss','security'];
+            const ALLOWED = new Set([...AREA, ...PLATFORM, ...SEVERITY]);
+
+            const issue = context.payload.issue;
+            const title = issue.title || '';
+            const body = (issue.body || '').slice(0, 4000);
+
+            const system = [
+              'You categorize GitHub issues for Reasonix, a Go-based AI coding agent with a Wails desktop app and a terminal UI.',
+              'Pick labels ONLY from these fixed sets. Never invent labels.',
+              'area (0-2, the affected subsystem):',
+              '  agent: core agent loop / tool-calling / reasoning',
+              '  mcp: MCP servers, plugins, codegraph',
+              '  config: configuration, setup wizard, .toml/.env',
+              '  updater: auto-update, installer, release packaging',
+              '  provider: model providers, model selection/switching',
+              '  desktop: Wails desktop GUI',
+              '  tui: terminal UI / CLI',
+              '  skills: skills system',
+              '  rendering: terminal rendering / flicker / repaint',
+              'platform (only if clearly specific to one OS): windows, macos, linux',
+              'severity (only if clearly applicable):',
+              '  crash: app crashes, hangs, or freezes',
+              '  data-loss: loss of sessions, config, or history',
+              '  security: credential/secret exposure or a security flaw',
+              'Be conservative: omit a label when unsure. The issue may be in Chinese.',
+              'Reply with JSON only: {"area":[],"platform":[],"severity":[]}',
+            ].join('\n');
+
+            let labels = [];
+            try {
+              const res = await fetch('https://api.deepseek.com/chat/completions', {
+                method: 'POST',
+                headers: {
+                  'Authorization': `Bearer ${process.env.DEEPSEEK_API_KEY}`,
+                  'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                  model: 'deepseek-chat',
+                  temperature: 0,
+                  response_format: { type: 'json_object' },
+                  messages: [
+                    { role: 'system', content: system },
+                    { role: 'user', content: `Title: ${title}\n\nBody:\n${body}` },
+                  ],
+                }),
+              });
+              if (!res.ok) {
+                core.warning(`DeepSeek API ${res.status}: ${await res.text()}`);
+                return;
+              }
+              const data = await res.json();
+              const parsed = JSON.parse(data.choices[0].message.content);
+              labels = [...(parsed.area || []), ...(parsed.platform || []), ...(parsed.severity || [])]
+                .filter(l => ALLOWED.has(l));
+            } catch (e) {
+              core.warning(`Classification failed: ${e.message}`);
+              return;
+            }
+
+            if (!labels.some(l => AREA.includes(l))) labels.push('needs-triage');
+
+            if (labels.length) {
+              await github.rest.issues.addLabels({
+                ...context.repo,
+                issue_number: issue.number,
+                labels,
+              });
+              core.info(`Applied: ${labels.join(', ')}`);
+            }

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,0 +1,28 @@
+name: Auto-label PRs
+
+# Apply area labels to PRs based on changed paths (see .github/labeler.yml).
+# Complements the AI-based issue labeler (issue-auto-label.yml). Version (v1/v2)
+# labels are handled separately by pr-version-label.yml.
+#
+# pull_request_target runs in the base repo context so it has the write token
+# needed to label PRs from forks; actions/labeler only reads the diff file list
+# (it never checks out or runs PR code), so this is safe.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-autolabel-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false

--- a/scripts/backfill-issue-labels.mjs
+++ b/scripts/backfill-issue-labels.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Backfill area/platform/severity labels on existing open issues via the DeepSeek
+// API — the one-off companion to .github/workflows/issue-auto-label.yml (which
+// only fires on new issues). Keep the label sets and prompt in sync with that
+// workflow. GitHub access uses the local `gh` CLI (must be authenticated).
+//
+// Usage:
+//   DEEPSEEK_API_KEY=... node scripts/backfill-issue-labels.mjs [options]
+// Options:
+//   --dry-run          print what would change, apply nothing
+//   --only-unlabeled   skip issues that already have an area label
+//   --limit N          process at most N issues (default 200)
+
+import { execSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const onlyUnlabeled = args.includes('--only-unlabeled');
+const li = args.indexOf('--limit');
+const limit = li >= 0 ? parseInt(args[li + 1], 10) : 200;
+
+const KEY = process.env.DEEPSEEK_API_KEY;
+if (!KEY) {
+  console.error('DEEPSEEK_API_KEY is not set');
+  process.exit(1);
+}
+
+const AREA = ['agent', 'mcp', 'config', 'updater', 'provider', 'desktop', 'tui', 'skills', 'rendering'];
+const PLATFORM = ['windows', 'macos', 'linux'];
+const SEVERITY = ['crash', 'data-loss', 'security'];
+const ALLOWED = new Set([...AREA, ...PLATFORM, ...SEVERITY]);
+
+const SYSTEM = [
+  'You categorize GitHub issues for Reasonix, a Go-based AI coding agent with a Wails desktop app and a terminal UI.',
+  'Pick labels ONLY from these fixed sets. Never invent labels.',
+  'area (0-2, the affected subsystem):',
+  '  agent: core agent loop / tool-calling / reasoning',
+  '  mcp: MCP servers, plugins, codegraph',
+  '  config: configuration, setup wizard, .toml/.env',
+  '  updater: auto-update, installer, release packaging',
+  '  provider: model providers, model selection/switching',
+  '  desktop: Wails desktop GUI',
+  '  tui: terminal UI / CLI',
+  '  skills: skills system',
+  '  rendering: terminal rendering / flicker / repaint',
+  'platform (only if clearly specific to one OS): windows, macos, linux',
+  'severity (only if clearly applicable):',
+  '  crash: app crashes, hangs, or freezes',
+  '  data-loss: loss of sessions, config, or history',
+  '  security: credential/secret exposure or a security flaw',
+  'Be conservative: omit a label when unsure. The issue may be in Chinese.',
+  'Reply with JSON only: {"area":[],"platform":[],"severity":[]}',
+].join('\n');
+
+function gh(cmd) {
+  return execSync(`gh ${cmd}`, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+}
+
+async function classify(title, body) {
+  const res = await fetch('https://api.deepseek.com/chat/completions', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: 'deepseek-chat',
+      temperature: 0,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: SYSTEM },
+        { role: 'user', content: `Title: ${title}\n\nBody:\n${body}` },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`DeepSeek API ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+  const parsed = JSON.parse(data.choices[0].message.content);
+  return [...(parsed.area || []), ...(parsed.platform || []), ...(parsed.severity || [])].filter((l) => ALLOWED.has(l));
+}
+
+const issues = JSON.parse(gh(`issue list --state open --limit ${limit} --json number,title,body,labels`));
+console.log(`${issues.length} open issues; dryRun=${dryRun} onlyUnlabeled=${onlyUnlabeled}`);
+
+let changed = 0;
+for (const it of issues) {
+  const existing = it.labels.map((l) => l.name);
+  if (onlyUnlabeled && existing.some((l) => AREA.includes(l))) {
+    continue;
+  }
+  let labels;
+  try {
+    labels = await classify(it.title, (it.body || '').slice(0, 4000));
+  } catch (e) {
+    console.warn(`#${it.number}: classify failed: ${e.message}`);
+    continue;
+  }
+  if (!labels.some((l) => AREA.includes(l))) labels.push('needs-triage');
+  const toAdd = labels.filter((l) => !existing.includes(l));
+  if (!toAdd.length) {
+    console.log(`#${it.number}: nothing new`);
+    continue;
+  }
+  if (dryRun) {
+    console.log(`#${it.number}: would add ${toAdd.join(', ')}  — ${it.title.slice(0, 50)}`);
+  } else {
+    const flags = toAdd.map((l) => `--add-label "${l}"`).join(' ');
+    gh(`issue edit ${it.number} ${flags}`);
+    console.log(`#${it.number}: +${toAdd.join(', ')}`);
+  }
+  changed++;
+}
+console.log(`Done. ${changed} issue(s) ${dryRun ? 'would be' : ''} updated.`);


### PR DESCRIPTION
## What
Auto-classify GitHub issues into area/platform/severity labels via the DeepSeek API.

## Why
Only v1/v2 labels were auto-applied (read from the issue form Version dropdown); area/platform/severity were never triaged, so 170+ open issues sat with just v2 + bug/enhancement and no way to filter by subsystem or severity.

## Changes
- New labels (already created): area agent/mcp/config/updater/provider; platform windows/macos/linux; severity crash/data-loss/security; needs-triage.
- .github/workflows/issue-auto-label.yml: on issue opened/reopened, calls DeepSeek (deepseek-chat, JSON mode) to classify into the fixed label set (allowlist-validated, needs-triage fallback). Uses the existing DEEPSEEK_API_KEY secret.
- scripts/backfill-issue-labels.mjs: one-off backfill for existing open issues (--dry-run, --only-unlabeled, --limit).

## Notes
The model is constrained to a fixed allowlist so it cannot invent labels. Backfill of existing open issues was run separately.