### PR TITLE
feat(desktop): mid-turn steer injection with tab-scoped routing and position-aware tool-result pairing

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -533,6 +533,18 @@ func (a *App) CancelTab(tabID string) {
 	}
 }
 
+// Steer sends mid-turn guidance to the agent without interrupting the in-flight request.
+func (a *App) Steer(text string) {
+	a.SteerForTab("", text)
+}
+
+// SteerForTab sends mid-turn guidance to a specific tab's agent.
+func (a *App) SteerForTab(tabID, text string) {
+	if ctrl := a.ctrlByTabID(tabID); ctrl != nil {
+		ctrl.Steer(text)
+	}
+}
+
 // Approve answers a pending approval_request by ID: allow runs the call, session
 // also remembers the grant for the rest of the session.
 func (a *App) Approve(id string, allow, session, persist bool) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1190,6 +1190,37 @@ func (r *blockingRunner) Run(ctx context.Context, _ string) error {
 	}
 }
 
+func TestSteerForTabNoPanic(t *testing.T) {
+	dir := t.TempDir()
+	path := agent.NewSessionPath(dir, "steer-test")
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+
+	ctrl := control.New(control.Options{
+		Executor:    exec,
+		Sink:        event.Discard,
+		SessionDir:  dir,
+		SessionPath: path,
+		Label:       "steer-tab",
+	})
+	defer ctrl.Close()
+
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{
+		"tab-a": {ID: "tab-a", Scope: "global", Ready: true, Ctrl: ctrl, model: "test"},
+	}
+	app.activeTabID = "tab-a"
+
+	// SteerForTab with valid tab — should not panic.
+	app.SteerForTab("tab-a", "guidance")
+
+	// SteerForTab with non-existent tab — should not panic.
+	app.SteerForTab("nonexistent", "should not panic")
+
+	// App.Steer (legacy, no tab ID) — no panic.
+	app.Steer("fallback guidance")
+}
+
 func waitNotRunning(t *testing.T, ctrl *control.Controller) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -232,6 +232,7 @@ export default function App() {
     activeTabId,
     send,
     runShell,
+    steer,
     notice,
     cancel,
     approve,
@@ -333,6 +334,7 @@ export default function App() {
   const [footerHeight, setFooterHeight] = useState(0);
   const layoutRef = useRef<HTMLDivElement>(null);
   const footerRef = useRef<HTMLElement>(null);
+  const runningRef = useRef(state.running);
   const [layoutWidth, setLayoutWidth] = useState(0);
   const preferredWorkspacePanelWidth =
     rightDockMode === "context"
@@ -528,6 +530,12 @@ export default function App() {
     send(text);
   }, [pendingPlanRevision, send, state.running]);
 
+  // Keep runningRef in sync so handleSend sees the latest running value
+  // even inside a stale closure.
+  useEffect(() => {
+    runningRef.current = state.running;
+  }, [state.running]);
+
   // Memory drawer: opening fetches a fresh snapshot; writes re-fetch so the
   // panel reflects what landed on disk.
   const openMemory = useCallback(async () => {
@@ -590,10 +598,11 @@ export default function App() {
         notice(t("settings.themeUnknown", { name: arg }), "warn");
         return;
       }
+      if (runningRef.current) { steer(submitText.trim()); return; }
       await syncModeToController(mode);
       send(trimmed, submitText.trim());
     },
-    [switchModel, openMemory, syncModeToController, mode, send, runShell, notice, t],
+    [switchModel, openMemory, syncModeToController, mode, send, steer, runShell, notice, t],
   );
 
   const refreshTabMetas = useCallback(async (): Promise<TabMeta[]> => {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -82,6 +82,8 @@ export interface AppBindings {
   SubmitDisplay(display: string, input: string): Promise<void>;
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
   RunShell(command: string): Promise<void>;
+  Steer(text: string): Promise<void>;
+  SteerForTab(tabID: string, text: string): Promise<void>;
   Cancel(): Promise<void>;
   CancelTab(tabID: string): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
@@ -829,6 +831,13 @@ function makeMockApp(): AppBindings {
           if (cancelled) return;
           emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
           emit({ kind: "turn_done" });
+        },
+        async Steer(_text) {
+          // Mock: emit a steer event as confirmation in the transcript.
+          emit({ kind: "steer", text: _text });
+        },
+        async SteerForTab(_tabID, _text) {
+          await this.Steer(_text);
         },
         async Cancel() {
           cancelled = true;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -17,7 +17,8 @@ export type EventKind =
   | "turn_done"
   | "compaction_started"
   | "compaction_done"
-  | "retrying";
+  | "retrying"
+  | "steer";
 
 export interface WireCompaction {
   trigger?: string; // "auto" | "manual"

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -121,17 +121,11 @@ type Action =
 // ---- reducer helpers (unchanged logic) ----
 
 export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: string, startSeq = 0): { items: Item[]; seq: number } {
-  const resultByID = new Map<string, HistoryMessage>();
-  for (const m of messages) {
-    if (m.role === "tool" && m.toolCallId && !resultByID.has(m.toolCallId)) {
-      resultByID.set(m.toolCallId, m);
-    }
-  }
-
   const items: Item[] = [];
   let seq = startSeq;
   const consumedToolIDs = new Set<string>();
-  for (const m of messages) {
+  for (let i = 0; i < messages.length; i++) {
+    const m = messages[i];
     if (m.role === "system") continue;
     if (m.role === "user") {
       if (m.content.trim() === "") continue;
@@ -145,8 +139,11 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
         items.push({ kind: "assistant", id: `${idPrefix}${seq}`, text: m.content, reasoning: m.reasoning ?? "", streaming: false });
         seq++;
       }
+      // Position-aware: collect tool results only up to the next user or
+      // assistant message, matching SanitizeToolPairing's turn scoping.
+      const toolResults = collectToolResultsAfter(messages, i);
       for (const tc of m.toolCalls ?? []) {
-        const result = resultByID.get(tc.id);
+        const result = toolResults.get(tc.id);
         if (tc.id) consumedToolIDs.add(tc.id);
         const output = result?.content ?? "";
         const error = output.startsWith("[error") || output.startsWith("Error:") ? output : undefined;
@@ -184,6 +181,23 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
     }
   }
   return { items, seq };
+}
+
+// collectToolResultsAfter scans forward from the assistant message at
+// assistantIndex, collecting tool results until the next user or assistant
+// message (exclusive). Returns a Map keyed by toolCallId. When duplicate IDs
+// exist within a turn the first result wins — matching pairToolResults'
+// idDistinct behaviour in internal/provider/provider.go.
+function collectToolResultsAfter(messages: HistoryMessage[], assistantIndex: number): Map<string, HistoryMessage> {
+  const results = new Map<string, HistoryMessage>();
+  for (let j = assistantIndex + 1; j < messages.length; j++) {
+    const m = messages[j];
+    if (m.role === "user" || m.role === "assistant") break;
+    if (m.role === "tool" && m.toolCallId && !results.has(m.toolCallId)) {
+      results.set(m.toolCallId, m);
+    }
+  }
+  return results;
 }
 
 function ensureAssistant(s: State): { items: Item[]; id: string; seq: number } {
@@ -286,6 +300,9 @@ function applyEvent(s: State, e: WireEvent): State {
       const sessionCurrency = e.usage?.currency || s.sessionCurrency || "¥";
       return { ...s, usage: e.usage, context: { ...s.context, used }, turnTokens, sessionCost, sessionCurrency };
     }
+    case "steer":
+      // Show a compact guidance notice when the backend confirms delivery.
+      return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `s${s.seq}`, level: "info", text: `\u2192 ${e.text ?? ""}` }] };
     case "notice":
       return { ...s, running: s.turnActive ? s.running : false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: e.level ?? "info", text: e.text ?? "" }] };
     case "phase":
@@ -506,6 +523,15 @@ export function useController() {
     app.RunShell(command).catch(() => {});
   }, [activeTabId, dispatchTo]);
 
+  const steer = useCallback((text: string) => {
+    if (!activeTabId) return;
+    // Steer is queued to the agent and persisted to session for history
+    // replay. We do NOT dispatch a user bubble here — instead the backend
+    // Steer event drives a compact guidance notice in the transcript,
+    // visually distinct from a full conversation turn.
+    app.SteerForTab(activeTabId, text).catch(() => {});
+  }, [activeTabId]);
+
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
     if (!activeTabId) return;
     dispatchTo(activeTabId, { type: "local_notice", level, text });
@@ -707,7 +733,7 @@ export function useController() {
   return {
     state: activeState,
     activeTabId,
-    send, runShell, notice, cancel, approve, answerQuestion, setControllerMode,
+    send, runShell, steer, notice, cancel, approve, answerQuestion, setControllerMode,
     newSession, listSessions, listTrashedSessions, resumeSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, setModel, setEffort,
     fetchMemory, remember, forget, saveDoc,

--- a/desktop/wire.go
+++ b/desktop/wire.go
@@ -126,7 +126,9 @@ var kindNames = map[event.Kind]string{
 	event.CompactionStarted: "compaction_started",
 	event.CompactionDone:    "compaction_done",
 	event.ToolProgress:      "tool_progress",
+	event.MCPSurfaceReady:   "mcp_surface_ready",
 	event.Retrying:          "retrying",
+	event.Steer:             "steer",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -165,10 +165,18 @@ func TestToWireTurnDoneNoError(t *testing.T) {
 
 // --- kindNames completeness ---
 
+func TestToWireSteer(t *testing.T) {
+	e := event.Event{Kind: event.Steer, Text: "please use smaller diffs"}
+	w := toWire(e)
+	if w.Kind != "steer" || w.Text != "please use smaller diffs" {
+		t.Errorf("steer wire = %+v", w)
+	}
+}
+
 func TestKindNamesComplete(t *testing.T) {
-	// ToolProgress is the last Kind; every value through it must have a wire name,
+	// Steer is the last Kind; every value through it must have a wire name,
 	// or toWire emits kind:"" and the frontend reducer falls through to undefined.
-	for k := event.Kind(0); k <= event.ToolProgress; k++ {
+	for k := event.Kind(0); k <= event.Steer; k++ {
 		if kindNames[k] == "" {
 			t.Errorf("kind %d has no wire name — toWire would emit kind:\"\"", k)
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -179,6 +179,15 @@ type Agent struct {
 	// reach it. nil leaves those tools to degrade gracefully.
 	jobs *jobs.Manager
 
+	// steerQueue holds mid-turn user messages queued while the agent is
+	// running. Each is consumed once per loop iteration, persisted to the
+	// session for history replay, and sent to the model as guidance (not a
+	// new task). Cache miss for the next API call is unavoidable but limited
+	// to one call — the prefix stays stable otherwise.
+	steerMu       sync.Mutex
+	steerQueue    []string
+	steerConsumed bool
+
 	// evidence is a per-user-turn ledger of host-observed tool receipts. It lets
 	// complete_step validate that cited evidence happened before the claim.
 	evidence *evidence.Ledger
@@ -293,6 +302,53 @@ func (a *Agent) SessionCache() (hit, miss int) {
 // means compaction is disabled for this agent.
 func (a *Agent) ContextWindow() int { return a.contextWindow }
 
+// mid-turn steer marker.
+const midTurnSteerPrefix = "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]"
+
+func midTurnSteerMessage(text string) string {
+	return midTurnSteerPrefix + "\n" + text
+}
+
+// Steer queues a message for mid-turn injection.
+func (a *Agent) Steer(text string) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = append(a.steerQueue, text)
+	a.steerConsumed = false
+}
+
+// SteerConsumed returns true when the steer queue became empty after the last consume.
+func (a *Agent) SteerConsumed() bool {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return a.steerConsumed
+}
+
+func (a *Agent) consumeSteer() (string, bool) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	if len(a.steerQueue) == 0 {
+		return "", false
+	}
+	t := a.steerQueue[0]
+	a.steerQueue = a.steerQueue[1:]
+	a.steerConsumed = len(a.steerQueue) == 0
+	return t, true
+}
+
+func (a *Agent) clearSteerQueue() {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = nil
+	a.steerConsumed = false
+}
+
+func (a *Agent) steerQueueLen() int {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return len(a.steerQueue)
+}
+
 // CompactRatio returns the fraction of the window at which auto-compaction
 // fires (e.g. 0.8). The status line uses it to show headroom to the next compact.
 func (a *Agent) CompactRatio() float64 { return a.compactRatio }
@@ -391,6 +447,10 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 // a round count. A positive maxSteps imposes an optional hard guard, surfaced as
 // a resumable notice when hit.
 func (a *Agent) Run(ctx context.Context, input string) error {
+	defer a.clearSteerQueue()
+	a.steerMu.Lock()
+	a.steerConsumed = false
+	a.steerMu.Unlock()
 	if a.evidence != nil {
 		a.evidence.Reset()
 	}
@@ -401,6 +461,14 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	finalReadinessBlocks := 0
 	emptyFinalBlocks := 0
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
+		// Consume a queued steer and persist it to the session so it
+		// survives tab switches and history replay. The model sees it as
+		// guidance (with a prefix), not a new task. One cache miss per
+		// steer is unavoidable — the model must see the new instruction.
+		if text, ok := a.consumeSteer(); ok {
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: midTurnSteerMessage(text)})
+			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
+		}
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
 		prevPrefixShape := a.lastPrefixShape
@@ -464,6 +532,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 			}
 			if readiness.applies {
 				event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessAllowed, finalReadinessBlocks > 0))
+			}
+			if a.steerQueueLen() > 0 {
+				continue
 			}
 			return nil // model gave a final answer
 		}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -739,6 +739,27 @@ func (c *Controller) EnableInteractiveApproval() {
 	}
 }
 
+// Steer queues mid-turn guidance without interrupting the in-flight request.
+func (c *Controller) Steer(text string) {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		exec.Steer(text)
+	}
+}
+
+// SteerConsumed returns true when the steer queue is empty after the last consume.
+func (c *Controller) SteerConsumed() bool {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		return exec.SteerConsumed()
+	}
+	return true
+}
+
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -83,6 +83,11 @@ const (
 	// event — or TurnDone — clears. Appended last to keep the Kind values before
 	// it wire-stable.
 	Retrying
+	// Steer fires when a mid-turn steer message is consumed from the queue and
+	// injected as a user message. Text carries the raw steer content (without the
+	// wrapper prefix), so a frontend can display it to the user as confirmation.
+	// Frontends use Steer to know a queued message has been delivered.
+	Steer
 )
 
 // Level classifies a Notice so sinks can style or filter it.

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -653,33 +653,40 @@ setInterval(fetchStatus,30000);
 function renderHistoryMessages(ms){
   if(!ms||ms.length===0)return;
   hideWelcome(); toolCards={};
-  const resultById=new Map();
-  ms.forEach(m=>{if(m.role==='tool'&&m.toolCallId&&!resultById.has(m.toolCallId))resultById.set(m.toolCallId,m);});
   const consumed=new Set();
   let seq=0;
-  ms.forEach(m=>{
-    if(m.role==='system')return;
-    if(m.role==='user'){if(m.content)addUserMsg(m.content);return;}
+  for(let i=0;i<ms.length;i++){
+    const m=ms[i];
+    if(m.role==='system')continue;
+    if(m.role==='user'){if(m.content)addUserMsg(m.content);continue;}
     if(m.role==='assistant'){
       if(m.reasoning)appendReasoning(m.reasoning);
       if(m.content)appendText(m.content);
       if(m.content||m.reasoning)finalizeMsg();
+      // Position-aware: collect tool results only up to the next user or
+      // assistant message, matching SanitizeToolPairing's turn scoping.
+      const results=new Map();
+      for(let j=i+1;j<ms.length;j++){
+        const n=ms[j];
+        if(n.role==='user'||n.role==='assistant')break;
+        if(n.role==='tool'&&n.toolCallId&&!results.has(n.toolCallId))results.set(n.toolCallId,n);
+      }
       (m.toolCalls||[]).forEach(tc=>{
         const id=tc.id||'hist-tool-'+(seq++);
         renderToolDispatch({id,name:tc.name,args:tc.arguments||'',readOnly:false});
-        const result=resultById.get(tc.id);
+        const result=results.get(tc.id);
         if(tc.id)consumed.add(tc.id);
         if(result)renderToolResult({id,name:tc.name,output:result.content||''});
       });
-      return;
+      continue;
     }
     if(m.role==='tool'){
-      if(m.toolCallId&&consumed.has(m.toolCallId))return;
+      if(m.toolCallId&&consumed.has(m.toolCallId))continue;
       const id=m.toolCallId||'hist-tool-'+(seq++);
       renderToolDispatch({id,name:m.toolName||'tool',args:'',readOnly:false});
       renderToolResult({id,name:m.toolName||'tool',output:m.content||''});
     }
-  });
+  }
   currentMsg=null;currentText=null;currentReasoning=null; scrollDown();
 }
 fetch('/history').then(r=>r.json()).then(renderHistoryMessages).catch(()=>{});

--- a/internal/serve/wire.go
+++ b/internal/serve/wire.go
@@ -120,6 +120,8 @@ var kindNames = map[event.Kind]string{
 	event.CompactionStarted: "compaction_started",
 	event.CompactionDone:    "compaction_done",
 	event.ToolProgress:      "tool_progress",
+	event.MCPSurfaceReady:   "mcp_surface_ready",
+	event.Steer:             "steer",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.

--- a/internal/serve/wire_test.go
+++ b/internal/serve/wire_test.go
@@ -65,4 +65,11 @@ func TestToWire(t *testing.T) {
 			t.Errorf("turn_done = %+v", w)
 		}
 	})
+
+	t.Run("steer", func(t *testing.T) {
+		w := toWire(event.Event{Kind: event.Steer, Text: "mid-turn guidance"})
+		if w.Kind != "steer" || w.Text != "mid-turn guidance" {
+			t.Errorf("steer = %+v", w)
+		}
+	})
 }


### PR DESCRIPTION

## Summary

This PR implements mid-turn steer injection for the desktop app, addressing all reviewer feedback from #3263, and fixes a cross-turn tool-result shadowing bug in the history display introduced by #3286.

## Changes

### 1. Mid-turn steer injection (reviewer feedback from #3263)

- **internal/event/event.go**: Add ` + "Steer" + @" event kind
- **internal/agent/agent.go**: Add ` + "steerQueue" + @" with ` + "Steer" + @"/` + "consumeSteer" + @"/` + "SteerConsumed" + @"/` + "clearSteerQueue" + @"/` + "steerQueueLen" + @" and mid-turn injection in the Run loop: each queued steer is persisted to the session and emitted as a ` + "Steer" + @" event
- **internal/control/controller.go**: Add ` + "Steer" + @"/` + "SteerConsumed" + @" methods delegating to the current executor
- **desktop/app.go**: Add ` + "App.Steer" + @"/` + "App.SteerForTab" + @" with per-tab routing, matching the ` + "SubmitForTab" + @"/` + "CancelForTab" + @" pattern
- **Wire mappings**: ` + "desktop/wire.go" + @" and ` + "internal/serve/wire.go" + @" map ` + "event.Steer" + @" ? ` + "" + @"steer" + @"" + @"` + "" + @" with regression tests in both packages
- **Frontend**: ` + "Steer" + @"/` + "SteerForTab" + @" bindings, ` + "useController" + @" steer callback routed with ` + "ctiveTabId" + @", ` + "unningRef" + @" + steer dispatch in ` + "App.handleSend" + @"

### 2. Position-aware tool-result pairing fix

The ` + "historyMessagesToItems" + @" function (introduced in #3286) used a global ` + "esultByID" + @" Map that collected the *first* tool result for each ` + "	oolCallId" + @" across the entire session. When a gateway synthesizes IDs like ` + "call_0" + @" (see ` + "internal/provider/openai/openai.go:354" + @"), consecutive turns produce colliding IDs, causing later turns to display the wrong tool output.

**Fix**: Replace the global Map with ` + "collectToolResultsAfter" + @", which scans forward from each assistant message only until the next user or assistant message - matching ` + "SanitizeToolPairing" + @"'s turn-scoped behaviour in ` + "internal/provider/provider.go" + @".

- **desktop/frontend/src/lib/useController.ts**: ` + "historyMessagesToItems" + @" now uses position-aware pairing
- **internal/serve/index.html**: ` + "enderHistoryMessages" + @" applies the same fix

## Related

- Closes #3263 (steer feature, reviewer feedback addressed)
- Fixes a pairing bug in #3286 (` + "ix(desktop): preserve tool details in history" + @")

## Verification

- ` + "go test ./internal/serve -run 'TestToWire|TestHistory' -count=1" + @" ?
- ` + "go test ./desktop -run 'TestToWireSteer|TestKindNamesComplete' -count=1" + @" ?
- ` + "
px tsc --noEmit" + @" in ` + "desktop/frontend" + @" ?