### PR TITLE
feat(desktop): mid-turn steer injection

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -587,6 +587,18 @@ func (a *App) CancelTab(tabID string) {
 	}
 }
 
+// Steer sends mid-turn guidance to the agent without interrupting the in-flight request.
+func (a *App) Steer(text string) {
+	a.SteerForTab("", text)
+}
+
+// SteerForTab sends mid-turn guidance to a specific tab's agent.
+func (a *App) SteerForTab(tabID, text string) {
+	if ctrl := a.ctrlByTabID(tabID); ctrl != nil {
+		ctrl.Steer(text)
+	}
+}
+
 // Approve answers a pending approval_request by ID: allow runs the call, session
 // also remembers the grant for the rest of the session.
 func (a *App) Approve(id string, allow, session, persist bool) {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -381,6 +381,7 @@ export default function App() {
     activeTabId,
     send,
     runShell,
+    steer,
     notice,
     cancel,
     approve,
@@ -573,6 +574,7 @@ export default function App() {
   const [footerHeight, setFooterHeight] = useState(0);
   const footerHeightRef = useRef(0);
   const footerRef = useRef<HTMLElement>(null);
+  const runningRef = useRef(state.running);
   const rightDockDetailActive = rightDockMode === "context" ? contextDetailActive : workspacePreviewActive;
   const preferredWorkspacePanelWidth = rightDockDetailActive ? rightDockPreviewWidth : rightDockTreeWidth;
   const workspacePanelMinWidth = rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH;
@@ -941,6 +943,12 @@ export default function App() {
     }
   }, [clearSession, notice, t]);
 
+  // Keep runningRef in sync so handleSend sees the latest running value
+  // even inside a stale closure.
+  useEffect(() => {
+    runningRef.current = state.running;
+  }, [state.running]);
+
   // handleSend intercepts slash commands that need a desktop-native action before
   // they reach the backend: "/model <ref>" rebuilds on that model, "/memory"
   // opens Settings, and "/clear" shows an in-app confirmation card. Everything else — skills (/init, …),
@@ -1016,12 +1024,13 @@ export default function App() {
         notice(t("settings.themeUnknown", { name: arg }), "warn");
         return;
       }
+      if (runningRef.current) { steer(submitText.trim()); return; }
       await setControllerCollaborationMode(collaborationMode);
       await setControllerToolApprovalMode(toolApprovalMode);
       if (goal.trim()) await setControllerGoal(goal);
       send(trimmed, submitText.trim());
     },
-    [applyGoal, closeTransientOverlays, collaborationMode, goal, send, runShell, notice, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, switchModel, t, toolApprovalMode],
+    [applyGoal, closeTransientOverlays, collaborationMode, goal, send, runShell, notice, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, steer, switchModel, t, toolApprovalMode],
   );
 
   const refreshTabMetas = useCallback(async (): Promise<TabMeta[]> => {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -92,6 +92,8 @@ export interface AppBindings {
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
   RunShell(command: string): Promise<void>;
   RunShellForTab(tabID: string, command: string): Promise<void>;
+  Steer(text: string): Promise<void>;
+  SteerForTab(tabID: string, text: string): Promise<void>;
   Cancel(): Promise<void>;
   CancelTab(tabID: string): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
@@ -1204,6 +1206,13 @@ function makeMockApp(): AppBindings {
         },
         async RunShellForTab(_tabID, command) {
           await withMockTabScope(_tabID, () => this.RunShell(command));
+        },
+        async Steer(_text) {
+          // Mock: emit a steer event as confirmation in the transcript.
+          emit({ kind: "steer", text: _text });
+        },
+        async SteerForTab(_tabID, _text) {
+          await this.Steer(_text);
         },
         async Cancel() {
           cancelled = true;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -17,7 +17,8 @@ export type EventKind =
   | "turn_done"
   | "compaction_started"
   | "compaction_done"
-  | "retrying";
+  | "retrying"
+  | "steer";
 
 export interface WireCompaction {
   trigger?: string; // "auto" | "manual"

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -368,6 +368,8 @@ function applyEvent(s: State, e: WireEvent): State {
       const items = at < 0 ? [...s.items, filled] : s.items.map((it, i) => (i === at ? filled : it));
       return { ...s, running: s.turnActive ? s.running : false, seq: s.seq + 1, items };
     }
+    case "steer":
+      return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `s${s.seq}`, level: "info", text: `↪ ${e.text ?? ""}` }] };
     case "approval_request": return { ...s, approval: e.approval };
     case "ask_request": return { ...s, ask: e.ask };
     case "turn_done": {
@@ -660,6 +662,14 @@ export function useController() {
     app.RunShellForTab(activeTabId, command).catch(() => {});
   }, [activeTabId, dispatchTo]);
 
+  const steer = useCallback((text: string) => {
+    if (!activeTabId) return;
+    // Steer is queued to the agent and persisted to session for history
+    dispatchTo(activeTabId, { type: "user", text, seq: getOrCreateState(statesRef.current, activeTabId).seq });
+    // Steer event drives a compact guidance notice in the transcript,
+    app.SteerForTab(activeTabId, text).catch(() => {});
+  }, [activeTabId, dispatchTo]);
+
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
     if (!activeTabId) return;
     dispatchTo(activeTabId, { type: "local_notice", level, text });
@@ -900,7 +910,7 @@ export function useController() {
   return {
     state: activeState,
     activeTabId,
-    send, runShell, notice, cancel, approve, answerQuestion, setControllerMode, setCollaborationMode, setToolApprovalMode, setGoal, clearGoal,
+    send, runShell, steer, notice, cancel, approve, answerQuestion, setControllerMode, setCollaborationMode, setToolApprovalMode, setGoal, clearGoal,
     newSession, clearSession, listSessions, listTrashedSessions, resumeSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, setModel, setEffort,
     fetchMemory, remember, forget, saveDoc,

--- a/desktop/wire.go
+++ b/desktop/wire.go
@@ -127,7 +127,9 @@ var kindNames = map[event.Kind]string{
 	event.CompactionStarted: "compaction_started",
 	event.CompactionDone:    "compaction_done",
 	event.ToolProgress:      "tool_progress",
+	event.MCPSurfaceReady:   "mcp_surface_ready",
 	event.Retrying:          "retrying",
+	event.Steer:             "steer",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -165,10 +165,18 @@ func TestToWireTurnDoneNoError(t *testing.T) {
 
 // --- kindNames completeness ---
 
+func TestToWireSteer(t *testing.T) {
+	e := event.Event{Kind: event.Steer, Text: "please use smaller diffs"}
+	w := toWire(e)
+	if w.Kind != "steer" || w.Text != "please use smaller diffs" {
+		t.Errorf("steer wire = %+v", w)
+	}
+}
+
 func TestKindNamesComplete(t *testing.T) {
-	// ToolProgress is the last Kind; every value through it must have a wire name,
+	// Steer is the last Kind; every value through it must have a wire name,
 	// or toWire emits kind:"" and the frontend reducer falls through to undefined.
-	for k := event.Kind(0); k <= event.ToolProgress; k++ {
+	for k := event.Kind(0); k <= event.Steer; k++ {
 		if kindNames[k] == "" {
 			t.Errorf("kind %d has no wire name — toWire would emit kind:\"\"", k)
 		}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -199,6 +199,15 @@ type Agent struct {
 	// reach it. nil leaves those tools to degrade gracefully.
 	jobs *jobs.Manager
 
+	// steerQueue holds mid-turn user messages queued while the agent is
+	// running. Each is consumed once per loop iteration, persisted to the
+	// session for history replay, and sent to the model as guidance (not a
+	// new task). Cache miss for the next API call is unavoidable but limited
+	// to one call — the prefix stays stable otherwise.
+	steerMu       sync.Mutex
+	steerQueue    []string
+	steerConsumed bool
+
 	// evidence is a per-user-turn ledger of host-observed tool receipts. It lets
 	// complete_step validate that cited evidence happened before the claim.
 	evidence *evidence.Ledger
@@ -313,6 +322,53 @@ func (a *Agent) SessionCache() (hit, miss int) {
 // means compaction is disabled for this agent.
 func (a *Agent) ContextWindow() int { return a.contextWindow }
 
+// mid-turn steer marker.
+const midTurnSteerPrefix = "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]"
+
+func midTurnSteerMessage(text string) string {
+	return midTurnSteerPrefix + "\n" + text
+}
+
+// Steer queues a message for mid-turn injection.
+func (a *Agent) Steer(text string) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = append(a.steerQueue, text)
+	a.steerConsumed = false
+}
+
+// SteerConsumed returns true when the steer queue became empty after the last consume.
+func (a *Agent) SteerConsumed() bool {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return a.steerConsumed
+}
+
+func (a *Agent) consumeSteer() (string, bool) {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	if len(a.steerQueue) == 0 {
+		return "", false
+	}
+	t := a.steerQueue[0]
+	a.steerQueue = a.steerQueue[1:]
+	a.steerConsumed = len(a.steerQueue) == 0
+	return t, true
+}
+
+func (a *Agent) clearSteerQueue() {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	a.steerQueue = nil
+	a.steerConsumed = false
+}
+
+func (a *Agent) steerQueueLen() int {
+	a.steerMu.Lock()
+	defer a.steerMu.Unlock()
+	return len(a.steerQueue)
+}
+
 // CompactRatio returns the fraction of the window at which auto-compaction
 // fires (e.g. 0.8). The status line uses it to show headroom to the next compact.
 func (a *Agent) CompactRatio() float64 { return a.compactRatio }
@@ -419,6 +475,10 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 // a round count. A positive maxSteps imposes an optional hard guard, surfaced as
 // a resumable notice when hit.
 func (a *Agent) Run(ctx context.Context, input string) error {
+	defer a.clearSteerQueue()
+	a.steerMu.Lock()
+	a.steerConsumed = false
+	a.steerMu.Unlock()
 	if a.evidence != nil {
 		a.evidence.Reset()
 	}
@@ -433,6 +493,14 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	streamRecoveries := 0
 	executorHandoff := a.executorHandoffGuard && strings.Contains(input, executorHandoffMarker)
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
+		// Consume a queued steer and persist it to the session so it
+		// survives tab switches and history replay. The model sees it as
+		// guidance (with a prefix), not a new task. One cache miss per
+		// steer is unavoidable — the model must see the new instruction.
+		if text, ok := a.consumeSteer(); ok {
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: midTurnSteerMessage(text)})
+			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
+		}
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
 		prevPrefixShape := a.lastPrefixShape
@@ -522,6 +590,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 			}
 			if readiness.applies {
 				event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessAllowed, finalReadinessBlocks > 0))
+			}
+			if a.steerQueueLen() > 0 {
+				continue
 			}
 			return nil // model gave a final answer
 		}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1111,6 +1111,35 @@ func (c *Controller) refreshInteractiveGate() {
 	}
 }
 
+// Steer queues mid-turn guidance without interrupting the in-flight request.
+func (c *Controller) Steer(text string) {
+	c.mu.Lock()
+	exec := c.executor
+	running := c.running
+	c.mu.Unlock()
+	if exec == nil {
+		return
+	}
+	if running {
+		exec.Steer(text)
+		return
+	}
+	// Agent not running — frontend's runningRef was stale.
+	// Convert to a new turn so the user gets a response.
+	go func() { c.SubmitDisplay(text, text) }()
+}
+
+// SteerConsumed returns true when the steer queue is empty after the last consume.
+func (c *Controller) SteerConsumed() bool {
+	c.mu.Lock()
+	exec := c.executor
+	c.mu.Unlock()
+	if exec != nil {
+		return exec.SteerConsumed()
+	}
+	return true
+}
+
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -83,6 +83,11 @@ const (
 	// event — or TurnDone — clears. Appended last to keep the Kind values before
 	// it wire-stable.
 	Retrying
+	// Steer fires when a mid-turn steer message is consumed from the queue and
+	// injected as a user message. Text carries the raw steer content (without the
+	// wrapper prefix), so a frontend can display it to the user as confirmation.
+	// Frontends use Steer to know a queued message has been delivered.
+	Steer
 )
 
 // Level classifies a Notice so sinks can style or filter it.

--- a/internal/serve/wire.go
+++ b/internal/serve/wire.go
@@ -121,6 +121,8 @@ var kindNames = map[event.Kind]string{
 	event.CompactionStarted: "compaction_started",
 	event.CompactionDone:    "compaction_done",
 	event.ToolProgress:      "tool_progress",
+	event.MCPSurfaceReady:   "mcp_surface_ready",
+	event.Steer:             "steer",
 }
 
 // toWireAsk converts an event.Ask into its JSON wire form.

--- a/internal/serve/wire_test.go
+++ b/internal/serve/wire_test.go
@@ -72,4 +72,11 @@ func TestToWire(t *testing.T) {
 			t.Errorf("turn_done = %+v", w)
 		}
 	})
+
+	t.Run("steer", func(t *testing.T) {
+		w := toWire(event.Event{Kind: event.Steer, Text: "mid-turn guidance"})
+		if w.Kind != "steer" || w.Text != "mid-turn guidance" {
+			t.Errorf("steer = %+v", w)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Implement mid-turn steer injection with tab-scoped routing, addressing reviewer feedback from #3263 (wire mappings + `SteerForTab`).
- Align `historyMessagesToItems` tool-result lookup with `SanitizeToolPairing`'s turn-scoped pairing: position-aware scan instead of a session-global Map to avoid cross-turn ID collisions with synthesized `call_%d` IDs.

## Changes

**Steer (#3263)**
- `internal/event/event.go`: `Steer` event kind
- `internal/agent/agent.go`: `steerQueue` + Run-loop injection + persistence
- `internal/control/controller.go`: `Steer`/`SteerConsumed`
- `desktop/app.go`: `App.Steer`/`App.SteerForTab`
- Wire mappings in `desktop/wire.go` + `internal/serve/wire.go` with tests
- Frontend: bindings, `runningRef` + steer dispatch in `handleSend`

**Tool-result pairing alignment (#3286)**
- `useController.ts`: global `resultByID` Map → `collectToolResultsAfter`
- `internal/serve/index.html`: same

## Related

Closes #3263