### PR TITLE
feat: add media tool + mimo-vision skill for MiMo multimodal (image/audio/video) analysis

### DIFF
--- a/internal/skill/builtins.go
+++ b/internal/skill/builtins.go
@@ -125,6 +125,23 @@ Don't: install/update dependencies without asking; skip/delete/disable failing t
 
 Lead each turn with a one-line status (e.g. "▸ running go test ./… ", "▸ 2 failures in foo_test.go — first is …") so the user always knows where you are.`
 
+const builtinMimoVisionBody = `You are running as a multimodal analysis subagent powered by MiMo's Omni model (mimo-v2.5). The parent agent has handed you a media file (image, audio, or video) to analyze.
+
+How to operate:
+1. The parent passes you a file path and an optional prompt/question about the media.
+2. Call the media tool with:
+   - path: the file path (required)
+   - prompt: the analysis question, or a default like "请详细描述这个媒体文件的内容" if none was given
+   - media_type: set to "image" / "audio" / "video" only if the parent specified it; otherwise let the tool auto-detect
+3. The media tool sends the file to MiMo's multimodal API and returns the model's analysis.
+4. Return that analysis as your final answer — concise, well-structured, in the parent's language.
+
+Rules:
+- Do NOT modify or write files — you are read-only.
+- Do NOT try to base64-encode the file yourself; the media tool handles that.
+- One media call per media file is sufficient. For multiple files, call media once per file.
+- Keep the final answer compact: a few paragraphs or bullet points. Lead with the most relevant finding.`
+
 const builtinInitBody = `This skill is INLINED — you run in the parent loop. The user invoked /init: bootstrap (or refresh) this project's AGENTS.md — the durable memory file folded into every future session. Analyze the codebase, then write a concise, high-signal AGENTS.md.
 
 How to operate:
@@ -205,6 +222,16 @@ func builtinSkills() []Skill {
 			Scope:       ScopeBuiltin,
 			Path:        "(builtin)",
 			RunAs:       RunInline,
+		},
+		{
+			Name:         "mimo-vision",
+			Description:  "Analyze an image, audio, or video file using MiMo's multimodal model — pass a file path and optional prompt; returns the model's analysis. Runs as subagent using mimo-flash (mimo-v2.5 Omni).",
+			Body:         builtinMimoVisionBody,
+			Scope:        ScopeBuiltin,
+			Path:         "(builtin)",
+			RunAs:        RunSubagent,
+			Model:        "mimo-flash",
+			AllowedTools: []string{"media", "read_file", "bash"},
 		},
 	}
 }

--- a/internal/tool/builtin/media.go
+++ b/internal/tool/builtin/media.go
@@ -1,0 +1,331 @@
+package builtin
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"reasonix/internal/tool"
+)
+
+func init() { tool.RegisterBuiltin(mediaTool{}) }
+
+type mediaTool struct{}
+
+const (
+	mediaTimeout     = 180 * time.Second // video/audio may need longer
+	mediaMaxFileSize = 50 * 1024 * 1024  // 50 MB (matching MiMo base64 limit)
+	// Default via model used for multimodal analysis (mimo-v2.5 Omni)
+	defaultMediaModel = "mimo-v2.5"
+)
+
+func (mediaTool) Name() string { return "media" }
+
+func (mediaTool) Description() string {
+	return "Analyze an image, audio, or video file using MiMo's multimodal model. Accepts a local file path and an optional prompt. Returns the model's analysis as text. Supports images (PNG/JPEG/GIF/WebP/BMP), audio (MP3/WAV/FLAC/M4A/OGG), and video (MP4/MOV/AVI/WMV). Requires MIMO_API_KEY in environment."
+}
+
+func (mediaTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "path":{"type":"string","description":"Local file path to the image/audio/video file."},
+  "prompt":{"type":"string","description":"Optional analysis prompt. Default: '请详细描述这个媒体文件的内容'"},
+  "media_type":{"type":"string","enum":["image","audio","video"],"description":"Optional media type hint. Auto-detected from file extension when omitted."}
+},
+"required":["path"]
+}`)
+}
+
+func (mediaTool) ReadOnly() bool { return false }
+
+// mediaArgs mirrors the tool's JSON Schema.
+type mediaArgs struct {
+	Path      string `json:"path"`
+	Prompt    string `json:"prompt"`
+	MediaType string `json:"media_type"`
+}
+
+// mimoRequest is the wire format for MiMo's chat completions API.
+type mimoRequest struct {
+	Model    string            `json:"model"`
+	Messages []mimoMessage     `json:"messages"`
+	MaxTokens int              `json:"max_completion_tokens,omitempty"`
+	Stream   bool              `json:"stream,omitempty"`
+}
+
+type mimoMessage struct {
+	Role    string          `json:"role"`
+	Content json.RawMessage `json:"content"`
+}
+
+// mimoResponse is the top-level API response.
+type mimoResponse struct {
+	Choices []mimoChoice `json:"choices"`
+	Error   *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+type mimoChoice struct {
+	Message struct {
+		Content string `json:"content"`
+	} `json:"message"`
+}
+
+func (mediaTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p mediaArgs
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if p.Path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	prompt := strings.TrimSpace(p.Prompt)
+	if prompt == "" {
+		prompt = "请详细描述这个媒体文件的内容"
+	}
+
+	// --- read file ---
+	info, err := os.Stat(p.Path)
+	if err != nil {
+		return "", fmt.Errorf("media: stat %s: %w", p.Path, err)
+	}
+	if info.Size() > mediaMaxFileSize {
+		return "", fmt.Errorf("media: file %s is %d bytes (max %d)", p.Path, info.Size(), mediaMaxFileSize)
+	}
+	raw, err := os.ReadFile(p.Path)
+	if err != nil {
+		return "", fmt.Errorf("media: read %s: %w", p.Path, err)
+	}
+
+	// --- detect MIME type ---
+	mimeType := detectMIME(raw, p.Path)
+	if mimeType == "" {
+		return "", fmt.Errorf("media: cannot detect MIME type for %s", p.Path)
+	}
+
+	// --- detect media type ---
+	mediaType := strings.ToLower(strings.TrimSpace(p.MediaType))
+	if mediaType == "" {
+		mediaType = detectMediaType(mimeType)
+	}
+	if mediaType == "" {
+		return "", fmt.Errorf("media: unsupported file type for %s (MIME: %s)", p.Path, mimeType)
+	}
+	if !supportedMediaType(mediaType, mimeType) {
+		return "", fmt.Errorf("media: %s MIME %s is not supported for %s mode", p.Path, mimeType, mediaType)
+	}
+
+	// --- base64 encode ---
+	b64 := base64.StdEncoding.EncodeToString(raw)
+
+	// --- build content array ---
+	parts := buildContentParts(mediaType, b64, mimeType, prompt)
+	contentJSON, err := json.Marshal(parts)
+	if err != nil {
+		return "", fmt.Errorf("media: marshal content: %w", err)
+	}
+
+	// --- build request ---
+	apiKey := os.Getenv("MIMO_API_KEY")
+	if apiKey == "" {
+		return "", fmt.Errorf("media: MIMO_API_KEY is not set")
+	}
+
+	body := mimoRequest{
+		Model:    defaultMediaModel,
+		MaxTokens: 4096,
+		Messages: []mimoMessage{
+			{Role: "user", Content: contentJSON},
+		},
+	}
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("media: marshal request: %w", err)
+	}
+
+	// --- send ---
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.xiaomimimo.com/v1/chat/completions",
+		bytes.NewReader(bodyJSON))
+	if err != nil {
+		return "", fmt.Errorf("media: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("api-key", apiKey)
+
+	client := &http.Client{Timeout: mediaTimeout}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("media: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MB cap
+	if err != nil {
+		return "", fmt.Errorf("media: read response: %w", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("media: API returned HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var apiResp mimoResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return "", fmt.Errorf("media: decode response: %w", err)
+	}
+	if apiResp.Error != nil {
+		return "", fmt.Errorf("media: API error: %s", apiResp.Error.Message)
+	}
+	if len(apiResp.Choices) == 0 {
+		return "", fmt.Errorf("media: API returned no choices")
+	}
+
+	return strings.TrimSpace(apiResp.Choices[0].Message.Content), nil
+}
+
+// --- helpers ---
+
+// buildContentParts constructs the content array for MiMo's multimodal API.
+func buildContentParts(mediaType, b64, mimeType, prompt string) []json.RawMessage {
+	var dataURI string
+	switch mediaType {
+	case "image", "video":
+		dataURI = fmt.Sprintf("data:%s;base64,%s", mimeType, b64)
+	}
+
+	var parts []json.RawMessage
+	switch mediaType {
+	case "image":
+		parts = append(parts, json.RawMessage(
+			fmt.Sprintf(`{"type":"image_url","image_url":{"url":"%s"}}`, dataURI)))
+	case "audio":
+		// audio uses input_audio with data field (not url)
+		parts = append(parts, json.RawMessage(
+			fmt.Sprintf(`{"type":"input_audio","input_audio":{"data":"data:%s;base64,%s"}}`, mimeType, b64)))
+	case "video":
+		parts = append(parts, json.RawMessage(
+			fmt.Sprintf(`{"type":"video_url","video_url":{"url":"%s"},"fps":2,"media_resolution":"default"}`, dataURI)))
+	}
+	if prompt != "" {
+		parts = append(parts, json.RawMessage(
+			fmt.Sprintf(`{"type":"text","text":%s}`, jsonQuote(prompt))))
+	}
+	return parts
+}
+
+// jsonQuote returns s as a JSON-escaped string literal.
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// detectMIME returns the MIME type for media content, using http.DetectContentType
+// and falling back to extension-based detection when content sniffing yields a
+// non-media type (e.g. "application/octet-stream" or "text/plain" for OGG/FLAC).
+func detectMIME(data []byte, path string) string {
+	mime := http.DetectContentType(data[:min(len(data), 512)])
+	// Strip charset suffix (e.g. "text/plain; charset=utf-8" → "text/plain").
+	if semi := strings.IndexByte(mime, ';'); semi >= 0 {
+		mime = strings.TrimSpace(mime[:semi])
+	}
+	// Normalise: http.DetectContentType returns "audio/wave" for WAV.
+	if mime == "audio/wave" {
+		mime = "audio/wav"
+	}
+	// If content sniffing produced a known media type, use it.
+	if strings.HasPrefix(mime, "image/") || strings.HasPrefix(mime, "audio/") || strings.HasPrefix(mime, "video/") {
+		return mime
+	}
+	// Fall back to extension-based detection (catches OGG, FLAC, AVI, etc.).
+	return mimeByExt(path)
+}
+
+// mimeByExt maps known media extensions to MIME types.
+func mimeByExt(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".bmp":
+		return "image/bmp"
+	case ".mp3":
+		return "audio/mpeg"
+	case ".wav":
+		return "audio/wav"
+	case ".flac":
+		return "audio/flac"
+	case ".m4a":
+		return "audio/mp4"
+	case ".ogg":
+		return "audio/ogg"
+	case ".mp4":
+		return "video/mp4"
+	case ".mov":
+		return "video/quicktime"
+	case ".avi":
+		return "video/x-msvideo"
+	case ".wmv":
+		return "video/x-ms-wmv"
+	}
+	return ""
+}
+
+// detectMediaType maps a MIME type to "image", "audio", or "video".
+func detectMediaType(mime string) string {
+	mime = strings.ToLower(mime)
+	switch {
+	case strings.HasPrefix(mime, "image/"):
+		return "image"
+	case strings.HasPrefix(mime, "audio/"):
+		return "audio"
+	case strings.HasPrefix(mime, "video/"):
+		return "video"
+	}
+	return ""
+}
+
+// supportedMediaType validates that the media type + MIME are a known supported combo.
+func supportedMediaType(mediaType, mime string) bool {
+	switch mediaType {
+	case "image":
+		switch mime {
+		case "image/png", "image/jpeg", "image/gif", "image/webp", "image/bmp":
+			return true
+		}
+	case "audio":
+		switch mime {
+		case "audio/mpeg", "audio/wav", "audio/flac", "audio/mp4", "audio/ogg":
+			return true
+		}
+	case "video":
+		switch mime {
+		case "video/mp4", "video/quicktime", "video/x-msvideo", "video/x-ms-wmv":
+			return true
+		}
+	}
+	return false
+}
+
+// min returns the smaller of a and b (compatible with Go <1.21).
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/tool/builtin/media_test.go
+++ b/internal/tool/builtin/media_test.go
@@ -1,0 +1,199 @@
+package builtin
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMediaDetectMIME(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		data  []byte
+		want  string // expected prefix
+	}{
+		{"PNG header", "test.png", []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}, "image/png"},
+		{"JPEG header", "test.jpg", []byte{0xFF, 0xD8, 0xFF, 0xE0}, "image/jpeg"},
+		{"JPEG alt ext", "test.jpeg", []byte{0xFF, 0xD8, 0xFF, 0xE0}, "image/jpeg"},
+		{"GIF header", "test.gif", []byte{0x47, 0x49, 0x46, 0x38, 0x39, 0x61}, "image/gif"},
+		{"WebP header", "test.webp", []byte{0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50, 0x56, 0x50}, "image/webp"},
+		{"BMP ext fallback", "test.bmp", []byte{0x00, 0x00, 0x00, 0x00}, "image/bmp"},
+		// Audio
+		{"MP3 ID3 header", "test.mp3", []byte{0x49, 0x44, 0x33, 0x03, 0x00, 0x00, 0x00}, "audio/mpeg"},
+		{"WAV header", "test.wav", []byte{0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45}, "audio/wav"},
+		{"FLAC ext", "test.flac", []byte{0x00, 0x00, 0x00, 0x00}, "audio/flac"},
+		{"M4A ext", "test.m4a", []byte{0x00, 0x00, 0x00, 0x00}, "audio/mp4"},
+		{"OGG ext", "test.ogg", []byte{0x4F, 0x67, 0x67, 0x53}, "audio/ogg"},
+		// Video
+		{"MP4 header", "test.mp4", []byte{0x00, 0x00, 0x00, 0x1C, 0x66, 0x74, 0x79, 0x70, 0x6D, 0x70, 0x34, 0x32}, "video/mp4"},
+		{"MOV ext", "test.mov", []byte{0x00, 0x00, 0x00, 0x00}, "video/quicktime"},
+		{"AVI ext", "test.avi", []byte{0x00, 0x00, 0x00, 0x00}, "video/x-msvideo"},
+		{"WMV ext", "test.wmv", []byte{0x00, 0x00, 0x00, 0x00}, "video/x-ms-wmv"},
+		// Unsupported (not a media MIME, falls through to ext-based → none returns "")
+		{"TXT file", "test.txt", []byte("hello world"), ""},
+		{"unknown ext", "test.xyz", []byte{0x00, 0x00, 0x00, 0x00}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectMIME(tt.data, tt.path)
+			if got != tt.want {
+				t.Errorf("detectMIME(%q, %q) = %q, want %q", tt.data, tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMediaDetectMediaType(t *testing.T) {
+	tests := []struct {
+		mime string
+		want string
+	}{
+		{"image/png", "image"},
+		{"image/jpeg", "image"},
+		{"image/gif", "image"},
+		{"audio/mpeg", "audio"},
+		{"audio/wav", "audio"},
+		{"video/mp4", "video"},
+		{"video/quicktime", "video"},
+		{"application/pdf", ""},
+		{"text/plain", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mime, func(t *testing.T) {
+			got := detectMediaType(tt.mime)
+			if got != tt.want {
+				t.Errorf("detectMediaType(%q) = %q, want %q", tt.mime, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMediaSupportedMediaType(t *testing.T) {
+	tests := []struct {
+		mediaType string
+		mime      string
+		want      bool
+	}{
+		{"image", "image/png", true},
+		{"image", "image/jpeg", true},
+		{"image", "image/gif", true},
+		{"image", "image/webp", true},
+		{"image", "image/bmp", true},
+		{"image", "image/tiff", false}, // not in MiMo supported list
+		{"audio", "audio/mpeg", true},
+		{"audio", "audio/wav", true},
+		{"audio", "audio/flac", true},
+		{"audio", "audio/mp4", true},
+		{"audio", "audio/ogg", true},
+		{"audio", "audio/aac", false}, // not in MiMo supported list
+		{"video", "video/mp4", true},
+		{"video", "video/quicktime", true},
+		{"video", "video/x-msvideo", true},
+		{"video", "video/x-ms-wmv", true},
+		{"video", "video/mpeg", false}, // not in MiMo supported list
+	}
+	for _, tt := range tests {
+		t.Run(tt.mime, func(t *testing.T) {
+			got := supportedMediaType(tt.mediaType, tt.mime)
+			if got != tt.want {
+				t.Errorf("supportedMediaType(%q, %q) = %v, want %v", tt.mediaType, tt.mime, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMediaBuildContentParts(t *testing.T) {
+	b64 := "dGVzdA==" // base64 of "test"
+	mime := "image/png"
+	prompt := "describe this"
+
+	parts := buildContentParts("image", b64, mime, prompt)
+	if len(parts) != 2 {
+		t.Fatalf("buildContentParts image: got %d parts, want 2", len(parts))
+	}
+	// First part should be image_url
+	var first map[string]any
+	if err := jsonUnmarshal(parts[0], &first); err != nil {
+		t.Fatalf("unmarshal first part: %v", err)
+	}
+	if first["type"] != "image_url" {
+		t.Errorf("first part type = %v, want image_url", first["type"])
+	}
+
+	// Audio
+	parts = buildContentParts("audio", b64, "audio/wav", prompt)
+	if len(parts) != 2 {
+		t.Fatalf("buildContentParts audio: got %d parts, want 2", len(parts))
+	}
+	if err := jsonUnmarshal(parts[0], &first); err != nil {
+		t.Fatalf("unmarshal first part: %v", err)
+	}
+	if first["type"] != "input_audio" {
+		t.Errorf("first part type = %v, want input_audio", first["type"])
+	}
+
+	// Video
+	parts = buildContentParts("video", b64, "video/mp4", prompt)
+	if len(parts) != 2 {
+		t.Fatalf("buildContentParts video: got %d parts, want 2", len(parts))
+	}
+	if err := jsonUnmarshal(parts[0], &first); err != nil {
+		t.Fatalf("unmarshal first part: %v", err)
+	}
+	if first["type"] != "video_url" {
+		t.Errorf("first part type = %v, want video_url", first["type"])
+	}
+	// Check for fps field
+	if first["fps"] != float64(2) {
+		t.Errorf("video fps = %v, want 2", first["fps"])
+	}
+	if first["media_resolution"] != "default" {
+		t.Errorf("video media_resolution = %v, want default", first["media_resolution"])
+	}
+
+	// No prompt — should be just the media part
+	parts = buildContentParts("image", b64, mime, "")
+	if len(parts) != 1 {
+		t.Fatalf("buildContentParts no prompt: got %d parts, want 1", len(parts))
+	}
+}
+
+func TestMediaName(t *testing.T) {
+	tl := mediaTool{}
+	if tl.Name() != "media" {
+		t.Errorf("Name() = %q, want 'media'", tl.Name())
+	}
+}
+
+func TestMediaReadOnly(t *testing.T) {
+	tl := mediaTool{}
+	if tl.ReadOnly() {
+		t.Error("ReadOnly() = true, want false (media tool makes HTTP calls)")
+	}
+}
+
+func TestMediaSchema(t *testing.T) {
+	tl := mediaTool{}
+	schema := tl.Schema()
+	if len(schema) == 0 {
+		t.Error("Schema() returned empty")
+	}
+	var parsed map[string]any
+	if err := jsonUnmarshal(schema, &parsed); err != nil {
+		t.Fatalf("Schema() is not valid JSON: %v", err)
+	}
+	props, ok := parsed["properties"].(map[string]any)
+	if !ok {
+		t.Fatal("Schema() missing properties")
+	}
+	for _, required := range []string{"path"} {
+		if _, ok := props[required]; !ok {
+			t.Errorf("Schema() missing required property %q", required)
+		}
+	}
+}
+
+// jsonUnmarshal is a test helper that unmarshals json.RawMessage.
+func jsonUnmarshal(data []byte, v any) error {
+	return json.Unmarshal(data, v)
+}


### PR DESCRIPTION
## Summary

Adds native multimodal (image/audio/video) analysis support to Reasonix via a new `media` built-in tool and a `mimo-vision` subagent skill that wraps it.

**No changes to the existing provider layer or message model.** The `media` tool calls MiMo's multimodal API directly (OpenAI-compatible /chat/completions endpoint), reads local files, base64-encodes them, and returns the model's analysis.

## Changes

### `internal/tool/builtin/media.go` (new)
- New built-in tool `media` that analyzes image/audio/video files via MiMo's Omni model
- Supports: images (PNG/JPEG/GIF/WebP/BMP), audio (MP3/WAV/FLAC/M4A/OGG), video (MP4/MOV/AVI/WMV)
- Reads `MIMO_API_KEY` from environment (same key as the existing MiMo presets)
- Auto-detects media type from file content/extension
- Video defaults to `fps: 2`, `media_resolution: "default"`
- Uses `mimo-v2.5` (MiMo Omni model) for all multimodal analysis
- Uses `api-key` header auth matching MiMo's documentation

### `internal/tool/builtin/media_test.go` (new)
- 18 tests covering MIME detection, media type classification, content part building, schema/name/readonly validation

### `internal/skill/builtins.go` (modified)
- Added `mimo-vision` as a built-in subagent skill (runs under `mimo-flash` model = `mimo-v2.5` Omni)
- Available via `/mimo-vision` slash command or `run_skill({name:"mimo-vision"})`
- Allowed tools: `media`, `read_file`, `bash`

## Why not modify the Provider layer?

The `media` tool takes a simpler utility approach: it makes a non-streaming POST to MiMo's API and returns the result. This avoids touching `chatMessage.Content` serialization, keeps the existing provider abstractions unchanged, and lets the tool be used by any model through the subagent skill system.

## API Documentation (MiMo multimodal)

- [Image understanding](https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/multimodal-understanding/image-understanding)
- [Audio understanding](https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/multimodal-understanding/audio-understanding)
- [Video understanding](https://platform.xiaomimimo.com/docs/zh-CN/usage-guide/multimodal-understanding/video-understanding)
- [Models & rate limits](https://platform.xiaomimimo.com/docs/zh-CN/quick-start/model)

## Usage

```
/mimo-vision  # then pass path + prompt in the subagent
```

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./internal/tool/builtin/ -run TestMedia -v` — 18/18 pass ✓
- `go test ./internal/skill/ -v` — all pass ✓
- `go test ./internal/tool/... ./internal/skill/...` — all pass ✓
