### PR TITLE
fix(tools): preserve file encoding in write_file and delete_range

### DIFF
--- a/internal/tool/builtin/delete_range.go
+++ b/internal/tool/builtin/delete_range.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"reasonix/internal/diff"
@@ -44,7 +43,13 @@ func (d deleteRange) Execute(ctx context.Context, args json.RawMessage) (string,
 	if err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(change.Path, []byte(change.NewText), 0o644); err != nil {
+	// Re-detect the file's encoding so the rewrite preserves it (GBK/UTF-16/BOM)
+	// rather than forcing UTF-8 and corrupting a non-UTF-8 file.
+	_, enc, err := readFileEncoded(change.Path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", change.Path, err)
+	}
+	if err := writeFileEncoded(change.Path, change.NewText, enc); err != nil {
 		return "", fmt.Errorf("write %s: %w", change.Path, err)
 	}
 	return change.Diff, nil
@@ -84,11 +89,10 @@ func (d deleteRange) preview(args json.RawMessage) (diff.Change, error) {
 		return diff.Change{}, err
 	}
 
-	b, err := os.ReadFile(p.Path)
+	original, _, err := readFileEncoded(p.Path)
 	if err != nil {
 		return diff.Change{}, fmt.Errorf("read %s: %w", p.Path, err)
 	}
-	original := string(b)
 
 	// Detect line ending style so we can preserve it on write.
 	lineSep := "\n"

--- a/internal/tool/builtin/e2e_encoding_test.go
+++ b/internal/tool/builtin/e2e_encoding_test.go
@@ -87,3 +87,80 @@ func TestE2EGBKRoundTrip(t *testing.T) {
 		t.Errorf("grep did not match decoded GBK content:\n%s", grepOut)
 	}
 }
+
+func e2eArgs(m map[string]any) json.RawMessage {
+	b, _ := json.Marshal(m)
+	return json.RawMessage(b)
+}
+
+// write_file must preserve the encoding of a file it overwrites rather than
+// always writing UTF-8, which would silently corrupt a GBK file.
+func TestE2EWriteFilePreservesGBKOnOverwrite(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gbk.txt")
+	if err := os.WriteFile(path, gbkBytes(t, "原始内容\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	writeTL, _ := tool.LookupBuiltin("write_file")
+	if _, err := writeTL.Execute(context.Background(), e2eArgs(map[string]any{
+		"path":    path,
+		"content": "全新中文内容\n第二行\n",
+	})); err != nil {
+		t.Fatalf("write_file: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	if utf8.Valid(raw) {
+		t.Error("write_file rewrote an existing GBK file as UTF-8 on disk")
+	}
+	decoded, _, _ := transform.Bytes(simplifiedchinese.GB18030.NewDecoder(), raw)
+	if s := string(decoded); !strings.Contains(s, "全新中文内容") || !strings.Contains(s, "第二行") {
+		t.Errorf("write_file content wrong after GBK round-trip: %q", s)
+	}
+}
+
+// A newly created file (no existing encoding to preserve) defaults to UTF-8.
+func TestE2EWriteFileNewFileIsUTF8(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "new.txt")
+	writeTL, _ := tool.LookupBuiltin("write_file")
+	if _, err := writeTL.Execute(context.Background(), e2eArgs(map[string]any{
+		"path":    path,
+		"content": "新文件中文\n",
+	})); err != nil {
+		t.Fatalf("write_file: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	if !utf8.Valid(raw) {
+		t.Error("a newly created file should be written as UTF-8")
+	}
+	if string(raw) != "新文件中文\n" {
+		t.Errorf("new file content = %q, want UTF-8 Chinese", raw)
+	}
+}
+
+// delete_range must decode a GBK file before matching anchors (a UTF-8 anchor
+// would never match the GBK bytes otherwise) and re-encode it on write.
+func TestE2EDeleteRangePreservesGBK(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gbk.txt")
+	if err := os.WriteFile(path, gbkBytes(t, "第一行\n第二行\n第三行\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	delTL, _ := tool.LookupBuiltin("delete_range")
+	if _, err := delTL.Execute(context.Background(), e2eArgs(map[string]any{
+		"path":         path,
+		"start_anchor": "第二行",
+		"end_anchor":   "第二行",
+	})); err != nil {
+		t.Fatalf("delete_range on GBK file: %v", err)
+	}
+	raw, _ := os.ReadFile(path)
+	if utf8.Valid(raw) {
+		t.Error("delete_range rewrote a GBK file as UTF-8 on disk")
+	}
+	decoded, _, _ := transform.Bytes(simplifiedchinese.GB18030.NewDecoder(), raw)
+	s := string(decoded)
+	if strings.Contains(s, "第二行") {
+		t.Errorf("delete_range did not remove the target line: %q", s)
+	}
+	if !strings.Contains(s, "第一行") || !strings.Contains(s, "第三行") {
+		t.Errorf("delete_range removed the wrong lines: %q", s)
+	}
+}

--- a/internal/tool/builtin/writefile.go
+++ b/internal/tool/builtin/writefile.go
@@ -48,7 +48,12 @@ func (w writeFile) Execute(ctx context.Context, args json.RawMessage) (string, e
 	if err := confine(w.roots, p.Path); err != nil {
 		return "", err
 	}
-	if existing, err := os.ReadFile(p.Path); err == nil && string(existing) == p.Content {
+	// Preserve the existing file's encoding (GBK/UTF-16/BOM) on overwrite instead
+	// of always writing UTF-8, which would silently corrupt a non-UTF-8 file.
+	// readFileEncoded returns enc=UTF8 for a missing file — the right default for
+	// a newly created one.
+	existing, enc, rerr := readFileEncoded(p.Path)
+	if rerr == nil && existing == p.Content {
 		return fmt.Sprintf("%s already contains the exact content; no changes made", p.Path), nil
 	}
 	if dir := filepath.Dir(p.Path); dir != "" && dir != "." {
@@ -56,7 +61,7 @@ func (w writeFile) Execute(ctx context.Context, args json.RawMessage) (string, e
 			return "", fmt.Errorf("mkdir %s: %w", dir, err)
 		}
 	}
-	if err := os.WriteFile(p.Path, []byte(p.Content), 0o644); err != nil {
+	if err := writeFileEncoded(p.Path, p.Content, enc); err != nil {
 		return "", fmt.Errorf("write %s: %w", p.Path, err)
 	}
 	return fmt.Sprintf("wrote %d bytes to %s", len(p.Content), p.Path), nil


### PR DESCRIPTION
Fixes #3354.

## Problem
write_file, delete_range, and delete_symbol used raw os.WriteFile, always writing UTF-8 and silently corrupting GBK/GB18030/UTF-16 files. delete_range additionally read raw bytes, so a UTF-8 anchor never matched a non-UTF-8 file. edit_file / multi_edit already preserve encoding via readFileEncoded / writeFileEncoded.

## Fix
- write_file: detect an overwritten file encoding and preserve it; new files default to UTF-8.
- delete_range: decode before anchor matching, re-encode on write.
- delete_symbol: left unchanged on purpose. It does byte-level deletion by AST offset on Go (UTF-8) source; decoding would break offset alignment, and non-UTF-8 .go files fail to parse before any write.

## Tests
Added GBK round-trip e2e tests for write_file (overwrite preserves GBK, new file is UTF-8) and delete_range (decode-match + preserve GBK). Full go test ./... is green.

Note: the windows CI check is red from a pre-existing cleanup flake in the #3247 test TestBuildMigratesLegacySessionsFromConfigSessionDir, unrelated to this change.