### PR TITLE
[4/6] Restore v0.53 process cards / 迁移 0.53 风格过程卡片

### DIFF
--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  mdast-util-gfm-autolink-literal: 2.0.0
+
 importers:
 
   .:

--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  mdast-util-gfm-autolink-literal: 2.0.0
-
 importers:
 
   .:

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,20 +1,39 @@
 import { memo, useState } from "react";
-import { ChevronRight, MoreHorizontal } from "lucide-react";
+import { ChevronDown, GitBranch, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
-import { Tooltip } from "./Tooltip";
+import { ProcessBrainIcon, ProcessCard, ProcessStatusIcon } from "./ProcessCard";
 import { useT } from "../lib/i18n";
-import type { Item } from "../lib/useController";
+import type { Item, MessageActionScope } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
 
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
+export type TurnActionMenu = "summary" | "rewind";
 
 export function UserMessage({
   text,
   turn,
   anchorId,
-  open,
-  onToggle,
+}: {
+  text: string;
+  turn?: number;
+  anchorId?: string;
+}) {
+  const displayText = text.replace(/@\.reasonix\/attachments\/[^\s]+/g, "[image]");
+  return (
+    <div className="msg msg--user" id={anchorId} data-question-anchor={anchorId} data-turn={turn}>
+      <div className="msg__body">
+        <div className="msg__text">{displayText}</div>
+      </div>
+    </div>
+  );
+}
+
+export function TurnActions({
+  text,
+  turn,
+  openMenu,
+  onOpenMenu,
   onRewind,
   checkpoint,
   actionPending = false,
@@ -22,17 +41,16 @@ export function UserMessage({
 }: {
   text: string;
   turn?: number;
-  anchorId?: string;
-  open?: boolean; // whether this message's rewind menu is the open one (lifted to Transcript)
-  onToggle?: () => void;
-  onRewind?: (turn: number, scope: string) => void;
+  openMenu?: TurnActionMenu | null;
+  onOpenMenu?: (menu: TurnActionMenu | null) => void;
+  onRewind?: (turn: number, scope: MessageActionScope) => void;
   checkpoint?: CheckpointMeta;
   actionPending?: boolean;
   rewindDisabled?: boolean;
 }) {
   const t = useT();
-  const [confirmScope, setConfirmScope] = useState<string | null>(null);
-  const canRewind = onRewind != null && turn != null;
+  const [confirmScope, setConfirmScope] = useState<MessageActionScope | null>(null);
+  const canAct = onRewind != null && turn != null;
   const actionDisabledReason = (scope: string): string => {
     if (rewindDisabled || actionPending) return t("rewind.disabledRunning");
     if (!checkpoint) return t("rewind.disabledNoCheckpoint");
@@ -50,7 +68,7 @@ export function UserMessage({
     }
     return "";
   };
-  const actionLabel = (scope: string): string => {
+  const actionLabel = (scope: MessageActionScope): string => {
     if (confirmScope !== scope) {
       switch (scope) {
         case "fork":
@@ -82,17 +100,18 @@ export function UserMessage({
         return t("rewind.confirmBoth");
     }
   };
-  const actionMeta = (scope: string): string => {
+  const actionMeta = (scope: MessageActionScope): string => {
     if ((scope === "code" || scope === "both") && checkpoint?.files?.length) {
       return t("rewind.filesChanged", { count: checkpoint.files.length });
     }
     return "";
   };
-  const runAction = (scope: string) => {
+  const runAction = (scope: MessageActionScope) => {
     setConfirmScope(null);
+    onOpenMenu?.(null);
     onRewind?.(turn as number, scope);
   };
-  const selectRewind = (scope: string) => {
+  const selectRewind = (scope: MessageActionScope) => {
     if (actionDisabledReason(scope)) return;
     if (confirmScope !== scope) {
       setConfirmScope(scope);
@@ -100,7 +119,7 @@ export function UserMessage({
     }
     runAction(scope);
   };
-  const renderAction = (scope: string, danger = false) => {
+  const renderAction = (scope: MessageActionScope, danger = false) => {
     const disabledReason = actionDisabledReason(scope);
     const meta = actionMeta(scope);
     return (
@@ -120,83 +139,117 @@ export function UserMessage({
       </button>
     );
   };
-  const displayText = text.replace(/@\.reasonix\/attachments\/[^\s]+/g, "[image]");
+  const forkDisabledReason = canAct ? actionDisabledReason("fork") : "";
+  const toggleMenu = (menu: TurnActionMenu) => {
+    setConfirmScope(null);
+    onOpenMenu?.(openMenu === menu ? null : menu);
+  };
+
   return (
-    <div className="msg msg--user" id={anchorId} data-question-anchor={anchorId} data-turn={turn}>
-      <span className="msg__caret">›</span>
-      <div className="msg__text">{displayText}</div>
-      {canRewind && (
-        <div className={`rewind${open ? " rewind--open" : ""}`}>
-          <Tooltip label={t("rewind.label")}>
+    <div className="turn-actions">
+      <CopyButton text={text} label={t("msg.copy")} />
+      {canAct && (
+        <>
+          <button
+            className={`turn-actions__btn${confirmScope === "fork" ? " turn-actions__btn--confirm" : ""}`}
+            type="button"
+            disabled={Boolean(forkDisabledReason)}
+            title={forkDisabledReason || undefined}
+            onClick={() => selectRewind("fork")}
+          >
+            <GitBranch size={13} />
+            <span>{actionLabel("fork")}</span>
+          </button>
+          <div className={`turn-actions__group${openMenu === "summary" ? " turn-actions__group--open" : ""}`}>
             <button
-              className="rewind__btn"
+              className="turn-actions__btn"
               type="button"
-              aria-label={t("rewind.label")}
-              aria-expanded={Boolean(open)}
-              onClick={() => {
-                setConfirmScope(null);
-                onToggle?.();
-              }}
+              aria-haspopup="menu"
+              aria-expanded={openMenu === "summary"}
+              onClick={() => toggleMenu("summary")}
             >
-              <MoreHorizontal size={15} />
+              <ScrollText size={13} />
+              <span>{t("turnActions.summary")}</span>
+              <ChevronDown size={12} />
             </button>
-          </Tooltip>
-          {open && (
-            <div className="rewind__menu">
-              {rewindDisabled && <div className="rewind__menu-hint">{t("rewind.disabledRunning")}</div>}
-              {!rewindDisabled && !checkpoint && <div className="rewind__menu-hint">{t("rewind.disabledNoCheckpoint")}</div>}
-              {renderAction("fork")}
-              <div className="rewind__menu-separator" />
-              {renderAction("summ-from")}
-              {renderAction("summ-upto")}
-              <div className="rewind__menu-separator" />
-              {renderAction("conversation")}
-              {renderAction("code")}
-              {renderAction("both", true)}
-            </div>
-          )}
-        </div>
+            {openMenu === "summary" && (
+              <div className="rewind__menu turn-actions__menu" role="menu">
+                {rewindDisabled && <div className="rewind__menu-hint">{t("rewind.disabledRunning")}</div>}
+                {!rewindDisabled && !checkpoint && <div className="rewind__menu-hint">{t("rewind.disabledNoCheckpoint")}</div>}
+                {renderAction("summ-from")}
+                {renderAction("summ-upto")}
+              </div>
+            )}
+          </div>
+          <div className={`turn-actions__group${openMenu === "rewind" ? " turn-actions__group--open" : ""}`}>
+            <button
+              className="turn-actions__btn"
+              type="button"
+              aria-haspopup="menu"
+              aria-expanded={openMenu === "rewind"}
+              onClick={() => toggleMenu("rewind")}
+            >
+              <RotateCcw size={13} />
+              <span>{t("turnActions.rewind")}</span>
+              <ChevronDown size={12} />
+            </button>
+            {openMenu === "rewind" && (
+              <div className="rewind__menu turn-actions__menu" role="menu">
+                {rewindDisabled && <div className="rewind__menu-hint">{t("rewind.disabledRunning")}</div>}
+                {!rewindDisabled && !checkpoint && <div className="rewind__menu-hint">{t("rewind.disabledNoCheckpoint")}</div>}
+                {renderAction("conversation")}
+                {renderAction("code")}
+                {renderAction("both", true)}
+              </div>
+            )}
+          </div>
+        </>
       )}
     </div>
   );
 }
 
-// memo: an unchanged message keeps a stable `item` ref across a streaming turn's
-// per-token re-renders, so only the live bubble re-parses markdown, not the whole
-// backlog.
-export const AssistantMessage = memo(function AssistantMessage({ item }: { item: AssistantItem }) {
+export const AssistantMessage = memo(function AssistantMessage({
+  item,
+}: {
+  item: AssistantItem;
+}) {
   const t = useT();
-  const [open, setOpen] = useState(false);
+  const hasText = item.streaming || item.text.trim() !== "";
+  const processOnly = Boolean(item.reasoning) && !hasText;
+  const processWithText = Boolean(item.reasoning) && hasText;
   return (
-    <div className="msg msg--assistant">
+    <div className={`msg msg--assistant${processOnly ? " msg--process-only" : ""}${processWithText ? " msg--process-with-text" : ""}`}>
       {item.reasoning && (
-        <div className="reasoning">
-          <button className="reasoning__toggle" onClick={() => setOpen((v) => !v)}>
-            <ChevronRight
-              className={`reasoning__chevron ${open ? "reasoning__chevron--open" : ""}`}
-              size={12}
-            />
-            {t("msg.thinking")}
-          </button>
-          {open && <div className="reasoning__body">{item.reasoning}</div>}
-        </div>
+        <ProcessCard
+          tone="violet"
+          icon={<ProcessBrainIcon size={12} />}
+          kind="reasoning"
+          name={t("msg.thinking")}
+          meta={
+            <>
+              <ProcessStatusIcon state={item.streaming ? "running" : "done"} label={item.streaming ? t("msg.thinkingRunning") : t("msg.thinkingDone")} />
+              <span>{item.streaming ? t("msg.thinkingRunning") : t("msg.thinkingDone")}</span>
+            </>
+          }
+          defaultOpen={item.streaming}
+        >
+          <div className="reasoning__body">{item.reasoning}</div>
+        </ProcessCard>
       )}
-      <div className="msg__body">
-        {item.streaming ? (
-          // While streaming, render raw text (stable, monospace-free) instead of
-          // re-parsing markdown on every token — partial markdown reflows the
-          // layout and makes the view jitter. Markdown renders once, on completion.
-          <div className="msg__stream">
-            {item.text}
-            <span className="cursor" />
-          </div>
-        ) : (
-          <Markdown text={item.text} />
-        )}
-      </div>
-      {!item.streaming && item.text && (
-        <div className="msg__actions">
-          <CopyButton text={item.text} label={t("msg.copy")} />
+      {hasText && (
+        <div className="msg__body">
+          {item.streaming ? (
+            // While streaming, render raw text (stable, monospace-free) instead of
+            // re-parsing markdown on every token — partial markdown reflows the
+            // layout and makes the view jitter. Markdown renders once, on completion.
+            <div className="msg__stream">
+              {item.text}
+              <span className="cursor" />
+            </div>
+          ) : (
+            <Markdown text={item.text} />
+          )}
         </div>
       )}
     </div>

--- a/desktop/frontend/src/components/ProcessCard.tsx
+++ b/desktop/frontend/src/components/ProcessCard.tsx
@@ -1,0 +1,161 @@
+import { Children, type ReactNode, type SVGProps, useState } from "react";
+
+type IconProps = SVGProps<SVGSVGElement> & { size?: number };
+export type ProcessTone = "default" | "success" | "warning" | "danger" | "accent" | "violet";
+export type ProcessState = "running" | "done" | "failed" | "waiting" | "stopped";
+
+function ProcessIcon({ size = 14, children, ...rest }: IconProps & { children: ReactNode }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...rest}
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function ProcessChevronIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <path d="m6 9 6 6 6-6" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessCheckIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <path d="m5 12 5 5L20 7" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessXIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <path d="M6 6l12 12M18 6 6 18" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessBrainIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <path d="M9 4a3 3 0 0 0-3 3v0a3 3 0 0 0-2 5 3 3 0 0 0 2 5 3 3 0 0 0 3 3h0a3 3 0 0 0 3-3V4" />
+      <path d="M15 4a3 3 0 0 1 3 3 3 3 0 0 1 2 5 3 3 0 0 1-2 5 3 3 0 0 1-3 3" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessToolIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <path d="M14 7a4 4 0 1 0 4 4l3 3-3 3-3-3a4 4 0 0 1-4-4l-3-3-3 3 3 3a4 4 0 0 0 6 0" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessInfoIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 16v-4" />
+      <path d="M12 8h.01" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessPhaseIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <path d="M4 7h9" />
+      <path d="M4 12h13" />
+      <path d="M4 17h7" />
+      <path d="m17 7 3 3-3 3" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessCompactIcon(props: IconProps) {
+  return (
+    <ProcessIcon {...props}>
+      <path d="M8 4h8" />
+      <path d="M6 8h12" />
+      <rect x="4" y="12" width="16" height="8" rx="2" />
+      <path d="M8 16h8" />
+    </ProcessIcon>
+  );
+}
+
+export function ProcessStatusIcon({ state, label }: { state: ProcessState; label: string }) {
+  if (state === "running") return <span className="process-card__spin" role="img" aria-label={label} title={label} />;
+  if (state === "done") return <ProcessCheckIcon className="process-card__status process-card__status--done" size={12} aria-label={label} />;
+  if (state === "failed") return <ProcessXIcon className="process-card__status process-card__status--failed" size={12} aria-label={label} />;
+  return <span className={`process-card__dot process-card__dot--${state}`} role="img" aria-label={label} title={label} />;
+}
+
+export function ProcessCard({
+  tone = "default",
+  icon,
+  kind,
+  name,
+  meta,
+  defaultOpen = false,
+  open,
+  onOpenChange,
+  children,
+  className,
+}: {
+  tone?: ProcessTone;
+  icon: ReactNode;
+  kind: ReactNode;
+  name?: ReactNode;
+  meta?: ReactNode;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children?: ReactNode;
+  className?: string;
+}) {
+  const [internalOpen, setInternalOpen] = useState(defaultOpen);
+  const actualOpen = open ?? internalOpen;
+  const hasBody = Children.count(children) > 0;
+  const toggle = () => {
+    if (!hasBody) return;
+    const next = !actualOpen;
+    if (open === undefined) setInternalOpen(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    <div className={`process-card${className ? ` ${className}` : ""}`} data-tone={tone} data-open={actualOpen} data-has-body={hasBody}>
+      <button
+        type="button"
+        className="process-card__head"
+        onClick={toggle}
+        aria-expanded={hasBody ? actualOpen : undefined}
+      >
+        <span className="process-card__icon">{icon}</span>
+        <span className="process-card__kind">{kind}</span>
+        {name && <span className="process-card__name">{name}</span>}
+        <span className="process-card__grow" />
+        {meta && <span className="process-card__meta">{meta}</span>}
+        {hasBody && (
+          <span className="process-card__chevron">
+            <ProcessChevronIcon size={12} />
+          </span>
+        )}
+      </button>
+      {hasBody && actualOpen && <div className="process-card__body">{children}</div>}
+    </div>
+  );
+}

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -1,22 +1,7 @@
 import { memo, useEffect, useState } from "react";
-import {
-  Ban,
-  Check,
-  ChevronRight,
-  FilePen,
-  FileText,
-  FolderOpen,
-  Globe,
-  Loader2,
-  ListTree,
-  Search,
-  SquareTerminal,
-  Wrench,
-  X,
-  type LucideIcon,
-} from "lucide-react";
 import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
+import { ProcessCard, ProcessStatusIcon, ProcessToolIcon, type ProcessState, type ProcessTone } from "./ProcessCard";
 import { useT } from "../lib/i18n";
 import { diffsFor, subjectOf, summarize } from "../lib/tools";
 import { useShellExpand } from "../lib/shellExpand";
@@ -25,19 +10,6 @@ import type { Item } from "../lib/useController";
 type ToolItem = Extract<Item, { kind: "tool" }>;
 
 const SUBAGENT_TOOLS = new Set(["task", "run_skill", "explore", "research", "review", "security_review"]);
-
-const ICONS: Record<string, LucideIcon> = {
-  edit_file: FilePen,
-  multi_edit: FilePen,
-  write_file: FilePen,
-  read_file: FileText,
-  bash: SquareTerminal,
-  ls: FolderOpen,
-  glob: Search,
-  grep: Search,
-  web_fetch: Globe,
-  task: ListTree,
-};
 
 /** Lines shown by default in a shell output block before the "show all" button. */
 const SHELL_PREVIEW_LINES = 10;
@@ -50,11 +22,23 @@ function pretty(json: string): string {
   }
 }
 
-function StatusGlyph({ status }: { status: ToolItem["status"] }) {
-  if (status === "running") return <Loader2 className="ico spin" size={13} />;
-  if (status === "error") return <X className="ico ico--err" size={13} />;
-  if (status === "stopped") return <Ban className="ico ico--stopped" size={13} />;
-  return <Check className="ico ico--ok" size={13} />;
+function processState(status: ToolItem["status"]): ProcessState {
+  if (status === "running") return "running";
+  if (status === "error") return "failed";
+  if (status === "stopped") return "stopped";
+  return "done";
+}
+
+function processTone(status: ToolItem["status"]): ProcessTone {
+  if (status === "error") return "danger";
+  if (status === "stopped") return "warning";
+  if (status === "done") return "success";
+  return "default";
+}
+
+function formatDuration(ms?: number): string {
+  if (typeof ms !== "number" || !Number.isFinite(ms) || ms < 0) return "";
+  return `${Math.round(ms)} ms`;
 }
 
 /** Returns the first n lines of text and the total line count. */
@@ -72,7 +56,6 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   const t = useT();
   const diffs = diffsFor(item.name, item.args);
   const subject = subjectOf(item.name, item.args);
-  const Icon = ICONS[item.name] ?? Wrench;
   const nested = subcalls ?? [];
   const hasNested = nested.length > 0;
   const profileText =
@@ -91,10 +74,9 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   // edit diffs are the point of the card, so they're shown inline; everything
   // else folds its args/output away by default. Nested children always show.
   // Shell commands default to open so the output is immediately visible.
-  const hasBody = diffs.length === 0 && (!!item.args || !!item.output);
-  const [open, setOpen] = useState(item.isShell && hasBody);
+  const hasArgsOrOutput = diffs.length === 0 && (!!item.args || !!item.output);
+  const [open, setOpen] = useState(item.isShell && hasArgsOrOutput);
   const [showAll, setShowAll] = useState(false);
-  const expandable = hasBody;
 
   // Register this shell card's toggle with the global ShellExpand context so
   // Ctrl/Cmd+B can expand/collapse the most recent shell output.
@@ -114,26 +96,32 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   // Shell output: split into preview + "show all" toggle.
   const shellOutput = item.isShell && item.output ? item.output : null;
   const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
+  const hasProcessBody = Boolean(summary || diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error);
+  const duration = item.status === "running" ? "" : formatDuration(item.durationMs);
 
   return (
-    <div className={`tool tool--${item.status} ${quiet ? "tool--quiet" : ""}`}>
-      <div
-        className={`tool__row ${expandable ? "tool__row--clickable" : ""}`}
-        onClick={expandable ? () => setOpen((v) => !v) : undefined}
-      >
-        {expandable ? (
-          <ChevronRight className={`tool__chevron ${open ? "tool__chevron--open" : ""}`} size={13} />
-        ) : (
-          <span className="tool__chevron tool__chevron--placeholder" />
-        )}
-        <Icon className="tool__icon" size={14} />
-        <span className="tool__name">{item.name}</span>
-        {subject && <span className="tool__subject">{subject}</span>}
-        {profileText && <span className="tool__profile">{profileText}</span>}
-        <span className="tool__meta">
-          <StatusGlyph status={item.status} />
-        </span>
-      </div>
+    <ProcessCard
+      tone={processTone(item.status)}
+      icon={<ProcessToolIcon size={12} />}
+      kind="tool"
+      name={
+        <>
+          <span className="tool__name">{item.name}</span>
+          {subject && <span className="tool__subject">{subject}</span>}
+          {profileText && <span className="tool__profile">{profileText}</span>}
+        </>
+      }
+      meta={
+        <>
+          <ProcessStatusIcon state={processState(item.status)} label={item.status} />
+          {duration && <span className="tool__duration">{duration}</span>}
+        </>
+      }
+      open={hasProcessBody ? open : undefined}
+      onOpenChange={hasProcessBody ? setOpen : undefined}
+      defaultOpen={item.isShell && hasArgsOrOutput}
+      className={`tool tool--${item.status}${quiet ? " tool--quiet" : ""}`}
+    >
 
       {summary && <div className="tool__summary">{summary}</div>}
 
@@ -153,7 +141,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
       )}
 
       {/* Shell output: always visible (auto-open), with preview/show-all toggle */}
-      {shellPreview && open && (
+      {shellPreview && (
         <div className="tool__body">
           <CodeViewer value={showAll ? shellOutput! : shellPreview.preview} maxHeight={showAll ? 480 : 260} />
           {shellPreview.hasMore && !showAll && (
@@ -166,7 +154,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
       )}
 
       {/* Non-shell body: args + output, gated by open */}
-      {!shellPreview && hasBody && open && (
+      {!shellPreview && hasArgsOrOutput && (
         <div className="tool__body">
           {item.args && <CodeViewer value={pretty(item.args)} language="json" maxHeight={180} />}
           {item.output && (
@@ -179,6 +167,6 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
       )}
 
       {item.error && <div className="tool__err">{item.error}</div>}
-    </div>
+    </ProcessCard>
   );
 });

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -2,11 +2,13 @@ import { type CSSProperties, type MouseEvent as ReactMouseEvent, useEffect, useM
 import type { Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
 import { useT } from "../lib/i18n";
-import { AssistantMessage, UserMessage } from "./Message";
+import { AssistantMessage, TurnActions, UserMessage } from "./Message";
+import { ProcessCard, ProcessCompactIcon, ProcessInfoIcon, ProcessPhaseIcon, ProcessStatusIcon } from "./ProcessCard";
 import { ToolCard } from "./ToolCard";
 import { Welcome } from "./Welcome";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
+type OpenTurnAction = { turn: number; menu: "summary" | "rewind" };
 type QuestionAnchor = { id: string; text: string; turn: number };
 
 const QUESTION_NAV_MIN_COUNT = 2;
@@ -186,18 +188,17 @@ export function Transcript({
     return m;
   }, [items]);
 
-  // The rewind menu's open state is lifted here so at most one is open at a time;
-  // a mousedown outside any .rewind closes it.
-  const [openTurn, setOpenTurn] = useState<number | null>(null);
+  // The turn action menu's open state is lifted here so at most one is open.
+  const [openAction, setOpenAction] = useState<OpenTurnAction | null>(null);
   useEffect(() => {
-    if (openTurn === null) return;
+    if (openAction === null) return;
     const onDown = (e: MouseEvent) => {
       const el = e.target as Element | null;
-      if (!el || !el.closest(".rewind")) setOpenTurn(null);
+      if (!el || !el.closest(".turn-actions")) setOpenAction(null);
     };
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
-  }, [openTurn]);
+  }, [openAction]);
 
   // Each user message's turn = its ordinal among user messages, so a rewind
   // targets the matching checkpoint.
@@ -220,6 +221,87 @@ export function Transcript({
   };
 
   const empty = items.length === 0;
+  let activeTurn: number | undefined;
+  let actionText = "";
+  let actionReady = false;
+  const renderedItems = [];
+  const pushTurnActions = () => {
+    if (activeTurn == null || !actionReady || actionText.trim() === "") return;
+    const turn = activeTurn;
+    const openMenu = openAction && openAction.turn === turn ? openAction.menu : null;
+    renderedItems.push(
+      <TurnActions
+        key={`turn-actions-${turn}`}
+        text={actionText}
+        turn={turn}
+        openMenu={openMenu}
+        onOpenMenu={(menu) => setOpenAction(menu ? { turn, menu } : null)}
+        checkpoint={checkpointsByTurn.get(turn)}
+        actionPending={actionPending}
+        rewindDisabled={rewindDisabled}
+        onRewind={(targetTurn, scope) => {
+          onRewind?.(targetTurn, scope);
+          setOpenAction(null);
+        }}
+      />,
+    );
+    actionText = "";
+    actionReady = false;
+  };
+  for (const it of items) {
+    switch (it.kind) {
+      case "user": {
+        pushTurnActions();
+        const tn = userTurn.get(it.id);
+        activeTurn = tn;
+        renderedItems.push(
+          <UserMessage
+            key={it.id}
+            text={it.text}
+            turn={tn}
+            anchorId={questionAnchorId(it.id)}
+          />,
+        );
+        break;
+      }
+      case "assistant": {
+        // The streaming segment's text lives in `live`, not in items, so the
+        // backlog ref stays stable per token; overlay it only on its own item.
+        const shown = live && live.id === it.id ? { ...it, text: live.text, reasoning: live.reasoning, streaming: true } : it;
+        renderedItems.push(
+          <AssistantMessage
+            key={it.id}
+            item={shown}
+          />,
+        );
+        if (!shown.streaming && shown.text.trim() !== "") {
+          actionText = shown.text;
+          actionReady = true;
+        }
+        break;
+      }
+      case "tool": {
+        if (it.parentId) break; // rendered nested under its parent
+        if (it.name === "todo_write") break; // shown live in the pinned TodoPanel
+        if (it.name === "exit_plan_mode") break; // the plan was shown in the approval card
+        renderedItems.push(<ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />);
+        break;
+      }
+      case "phase": {
+        renderedItems.push(<PhaseCard key={it.id} text={it.text} />);
+        break;
+      }
+      case "notice": {
+        renderedItems.push(<NoticeCard key={it.id} level={it.level} text={it.text} />);
+        break;
+      }
+      case "compaction": {
+        renderedItems.push(<CompactionCard key={it.id} item={it} />);
+        break;
+      }
+    }
+  }
+  pushTurnActions();
 
   return (
     <div
@@ -233,55 +315,7 @@ export function Transcript({
         <QuestionJumpBar questions={questions} onJump={jumpToQuestion} />
       )}
 
-      {items.map((it) => {
-        switch (it.kind) {
-          case "user": {
-            const tn = userTurn.get(it.id);
-            return (
-              <UserMessage
-                key={it.id}
-                text={it.text}
-                turn={tn}
-                anchorId={questionAnchorId(it.id)}
-	                open={tn != null && openTurn === tn}
-	                onToggle={() => setOpenTurn((cur) => (cur === tn ? null : (tn ?? null)))}
-	                checkpoint={tn != null ? checkpointsByTurn.get(tn) : undefined}
-	                actionPending={actionPending}
-	                rewindDisabled={rewindDisabled}
-	                onRewind={(turn, scope) => {
-                  onRewind?.(turn, scope);
-                  setOpenTurn(null);
-                }}
-              />
-            );
-          }
-          case "assistant": {
-            // The streaming segment's text lives in `live`, not in items, so the
-            // backlog ref stays stable per token; overlay it only on its own item.
-            const shown = live && live.id === it.id ? { ...it, text: live.text, reasoning: live.reasoning, streaming: true } : it;
-            return <AssistantMessage key={it.id} item={shown} />;
-          }
-          case "tool":
-            if (it.parentId) return null; // rendered nested under its parent
-            if (it.name === "todo_write") return null; // shown live in the pinned TodoPanel
-            if (it.name === "exit_plan_mode") return null; // the plan was shown in the approval card
-            return <ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />;
-          case "phase":
-            return (
-              <div key={it.id} className="phase">
-                {it.text}
-              </div>
-            );
-          case "notice":
-            return (
-              <div key={it.id} className={`notice notice--${it.level}`}>
-                {it.text}
-              </div>
-            );
-          case "compaction":
-            return <CompactionCard key={it.id} item={it} />;
-        }
-      })}
+      {renderedItems}
     </div>
   );
 }
@@ -415,6 +449,37 @@ function QuestionJumpBar({ questions, onJump }: { questions: QuestionAnchor[]; o
 }
 
 type CompactionItem = Extract<Item, { kind: "compaction" }>;
+type NoticeItem = Extract<Item, { kind: "notice" }>;
+
+function PhaseCard({ text }: { text: string }) {
+  return (
+    <ProcessCard
+      tone="accent"
+      icon={<ProcessPhaseIcon size={12} />}
+      kind="phase"
+      name={text}
+      className="phase process-card--phase"
+    />
+  );
+}
+
+function NoticeCard({ level, text }: { level: NoticeItem["level"]; text: string }) {
+  const t = useT();
+  const warning = level === "warn";
+  return (
+    <ProcessCard
+      tone={warning ? "warning" : "default"}
+      icon={<ProcessInfoIcon size={12} />}
+      kind="notice"
+      name={t(warning ? "notice.warning" : "notice.info")}
+      meta={warning ? <ProcessStatusIcon state="waiting" label={t("notice.warning")} /> : undefined}
+      defaultOpen
+      className={`notice notice--${level}`}
+    >
+      <div className="notice__body">{text}</div>
+    </ProcessCard>
+  );
+}
 
 // CompactionCard marks a context-compaction boundary in the transcript. While
 // the pass runs it shows a "compacting…" placeholder; once done it shows the
@@ -422,25 +487,28 @@ type CompactionItem = Extract<Item, { kind: "compaction" }>;
 // summary is the new context base, so it's available but doesn't flood the view).
 function CompactionCard({ item }: { item: CompactionItem }) {
   const t = useT();
-  const [open, setOpen] = useState(false);
   if (item.pending) {
     return (
-      <div className="compaction compaction--pending">
-        <span className="compaction__spinner">⋯</span> {t("compaction.working")}
-      </div>
+      <ProcessCard
+        tone="accent"
+        icon={<ProcessCompactIcon size={12} />}
+        kind="context"
+        name={t("compaction.working")}
+        meta={<ProcessStatusIcon state="running" label={t("compaction.working")} />}
+        className="compaction compaction--pending"
+      />
     );
   }
   return (
-    <div className="compaction">
-      <button className="compaction__head" onClick={() => setOpen((v) => !v)}>
-        <span className="compaction__icon">◆</span>
-        <span className="compaction__title">{t("compaction.title")}</span>
-        <span className="compaction__meta">
-          {t("compaction.messages", { n: item.messages })} · {item.trigger}
-        </span>
-        <span className="compaction__toggle">{open ? t("compaction.hideSummary") : t("compaction.showSummary")}</span>
-      </button>
-      {open && <pre className="compaction__summary">{item.summary}</pre>}
-    </div>
+    <ProcessCard
+      tone="accent"
+      icon={<ProcessCompactIcon size={12} />}
+      kind="context"
+      name={t("compaction.title")}
+      meta={`${t("compaction.messages", { n: item.messages })}${item.trigger ? ` · ${item.trigger}` : ""}`}
+      className="compaction"
+    >
+      <pre className="compaction__summary">{item.summary}</pre>
+    </ProcessCard>
   );
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -757,8 +757,32 @@ function makeMockApp(): AppBindings {
             }),
             output: "todo list updated",
             readOnly: false,
+            durationMs: 150,
           },
         });
+        emit({ kind: "turn_done" });
+        return;
+      }
+      if (trimmedInput === "/process-preview" || trimmedInput === "process preview" || trimmedInput === "过程预览") {
+        await delay(200);
+        if (cancelled) return;
+        emit({ kind: "phase", text: "Preparing context" });
+        await delay(120);
+        emit({ kind: "notice", level: "info", text: "Loaded project instructions from AGENTS.md." });
+        await delay(120);
+        emit({ kind: "notice", level: "warn", text: "Network access is enabled; external results may change over time." });
+        await delay(120);
+        emit({ kind: "compaction_started", compaction: { trigger: "manual" } });
+        await delay(320);
+        emit({
+          kind: "compaction_done",
+          compaction: {
+            trigger: "manual",
+            messages: 6,
+            summary: "Preserved the active task, relevant files, and UI decisions while trimming earlier exploratory context.",
+          },
+        });
+        emit({ kind: "message", text: "Process card preview complete." });
         emit({ kind: "turn_done" });
         return;
       }
@@ -790,7 +814,7 @@ function makeMockApp(): AppBindings {
       await delay(350);
       emit({
         kind: "tool_result",
-        tool: { id: "t1", name: "edit_file", output: "edited main.go", readOnly: false },
+        tool: { id: "t1", name: "edit_file", output: "edited main.go", readOnly: false, durationMs: 350 },
       });
       emit({
         kind: "usage",
@@ -827,7 +851,7 @@ function makeMockApp(): AppBindings {
           emit({ kind: "tool_progress", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
           await delay(100);
           if (cancelled) return;
-          emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false } });
+          emit({ kind: "tool_result", tool: { id, name: "bash", output: `$ ${command}\n(mock output)\n`, readOnly: false, durationMs: 300 } });
           emit({ kind: "turn_done" });
         },
         async Cancel() {
@@ -930,11 +954,14 @@ function makeMockApp(): AppBindings {
       const s = sessions.find((x) => x.path === path) ?? trashedSessions.find((x) => x.path === path);
       return [
         { role: "user", content: s?.preview || `(mock) preview ${path}` },
+        { role: "phase", content: "Preparing read-only preview" },
         {
           role: "assistant",
           content: "This is a read-only mock preview. The active conversation is unchanged.",
           reasoning: "Preview reads the saved session without resuming it.",
         },
+        { role: "notice", level: "info", content: "Preview mode keeps the active conversation untouched." },
+        { role: "compaction", content: "", trigger: "manual", messages: 3, summary: "Mock preview preserved the latest task, tool result, and answer summary." },
       ];
     },
     async DeleteSession(path: string) {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -39,6 +39,7 @@ export interface WireTool {
   err?: string;
   readOnly: boolean;
   truncated?: boolean;
+  durationMs?: number;
   partial?: boolean; // an early dispatch (name only) — a full one with args follows
   parentId?: string; // set on a sub-agent's calls — the parent `task` call's id
   profile?: WireProfile; // subagent model/effort resolved for this call
@@ -195,9 +196,15 @@ export interface HistoryMessage {
   role: string;
   content: string;
   reasoning?: string;
+  level?: "info" | "warn";
   toolCalls?: HistoryToolCall[];
   toolCallId?: string;
   toolName?: string;
+  pending?: boolean;
+  trigger?: string;
+  messages?: number;
+  summary?: string;
+  archive?: string;
 }
 
 export interface HistoryToolCall {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -55,6 +55,7 @@ export type Item =
       output?: string;
       error?: string;
       truncated?: boolean;
+      durationMs?: number;
       isShell?: boolean; // true for !-prefix shell commands (controls default expand)
       parentId?: string; // a sub-agent call nests under the `task` call with this id
       profile?: { model?: string; effort?: string }; // subagent model/effort from tool event
@@ -133,6 +134,33 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
   const consumedToolIDs = new Set<string>();
   for (const m of messages) {
     if (m.role === "system") continue;
+    if (m.role === "phase") {
+      if (m.content.trim() !== "") {
+        items.push({ kind: "phase", id: `${idPrefix}${seq}`, text: m.content });
+        seq++;
+      }
+      continue;
+    }
+    if (m.role === "notice") {
+      if (m.content.trim() !== "") {
+        items.push({ kind: "notice", id: `${idPrefix}${seq}`, level: m.level === "warn" ? "warn" : "info", text: m.content });
+        seq++;
+      }
+      continue;
+    }
+    if (m.role === "compaction") {
+      items.push({
+        kind: "compaction",
+        id: `${idPrefix}${seq}`,
+        pending: Boolean(m.pending),
+        trigger: m.trigger ?? "",
+        messages: m.messages ?? 0,
+        summary: m.summary ?? "",
+        archive: m.archive ?? "",
+      });
+      seq++;
+      continue;
+    }
     if (m.role === "user") {
       if (m.content.trim() === "") continue;
       items.push({ kind: "user", id: `${idPrefix}${seq}`, text: m.content });
@@ -264,7 +292,7 @@ function applyEvent(s: State, e: WireEvent): State {
       }
       if (idx >= 0) {
         const it = next[idx];
-        if (it.kind === "tool") next[idx] = { ...it, status: t.err ? "error" : "done", output: t.output, error: t.err, truncated: t.truncated };
+        if (it.kind === "tool") next[idx] = { ...it, status: t.err ? "error" : "done", output: t.output, error: t.err, truncated: t.truncated, durationMs: t.durationMs };
       }
       return { ...s, items: next };
     }

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -524,7 +524,13 @@ export const en = {
 
   // assistant message
   "msg.thinking": "thinking",
+  "msg.thinkingRunning": "thinking…",
+  "msg.thinkingDone": "done",
   "msg.copy": "Copy",
+  "turnActions.summary": "Summary",
+  "turnActions.rewind": "Rewind",
+  "notice.info": "Notice",
+  "notice.warning": "Warning",
   "questionNav.label": "Question navigation",
   "questionNav.progress": "Question {current} / {total}",
   "questionNav.jump": "Jump to question {n}",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -525,7 +525,13 @@ export const zh: Record<DictKey, string> = {
 
   // 助手消息
   "msg.thinking": "思考过程",
+  "msg.thinkingRunning": "思考中…",
+  "msg.thinkingDone": "已完成",
   "msg.copy": "复制",
+  "turnActions.summary": "总结",
+  "turnActions.rewind": "回溯",
+  "notice.info": "提示",
+  "notice.warning": "警告",
   "questionNav.label": "问题导航",
   "questionNav.progress": "问题 {current} / {total}",
   "questionNav.jump": "跳转到问题 {n}",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1060,35 +1060,41 @@ a[href] {
 }
 .msg--user {
   display: flex;
-  gap: 10px;
-  align-items: baseline;
+  justify-content: flex-end;
   color: var(--fg);
 }
-.rewind {
-  margin-left: auto;
-  flex-shrink: 0;
+.msg--user .msg__body {
+  max-width: 82%;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border-soft);
+  border-radius: 14px;
+  padding: 10px 16px;
   position: relative;
 }
+.rewind {
+  position: absolute;
+  bottom: -8px;
+  right: -8px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+.msg--user .msg__body:hover .rewind,
+.rewind--open {
+  opacity: 1;
+}
 .rewind__btn {
-  opacity: 0.62;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
-  background: color-mix(in srgb, var(--button-bg) 36%, transparent);
-  border: 1px solid color-mix(in srgb, var(--button-border) 42%, transparent);
+  width: 22px;
+  height: 22px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
   border-radius: 6px;
-  color: var(--button-muted-fg);
+  color: var(--fg-dim);
   padding: 0;
-  transition: opacity 120ms ease, background 120ms ease, border-color 120ms ease, color 120ms ease;
-}
-.msg--user:hover .rewind__btn,
-.msg--user:focus-within .rewind__btn,
-.rewind--open .rewind__btn {
-  opacity: 0.86;
-  background: color-mix(in srgb, var(--button-bg) 58%, transparent);
-  border-color: color-mix(in srgb, var(--button-border) 70%, transparent);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+  transition: background 120ms ease, border-color 120ms ease;
 }
 .rewind__btn:hover,
 .rewind__btn:focus-visible,
@@ -1100,8 +1106,9 @@ a[href] {
 }
 .rewind__menu {
   position: absolute;
-  top: 100%;
+  bottom: 100%;
   right: 0;
+  margin-bottom: 4px;
   z-index: 20;
   display: flex;
   flex-direction: column;
@@ -1166,50 +1173,185 @@ a[href] {
   color: var(--danger);
   background: color-mix(in srgb, var(--danger) 12%, transparent);
 }
-.msg__caret {
-  color: var(--accent);
-  font-family: var(--mono);
-  font-weight: 600;
-  flex-shrink: 0;
-}
 .msg--user .msg__text {
   white-space: pre-wrap;
   word-break: break-word;
   font-weight: 450;
+  line-height: 1.65;
 }
 .msg--assistant {
   color: var(--fg);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.msg--process-only {
+  margin-top: 6px;
+  margin-bottom: 6px;
+}
+.msg--assistant > .process-card {
+  align-self: stretch;
+  margin-left: 0;
+  margin-right: 0;
+}
+.msg--process-only > .process-card {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+.process-card.tool + .msg--process-with-text {
+  margin-top: 6px;
+}
+.process-card.tool + .msg--process-with-text > .process-card:first-child {
+  margin-top: 0;
 }
 
-.reasoning {
-  margin-bottom: 8px;
+.process-card {
+  --process-tone: var(--fg-dim);
+  --process-tone-soft: color-mix(in srgb, var(--fg-dim) 12%, transparent);
+  box-sizing: border-box;
+  width: 100%;
+  margin: 6px auto;
+  border: 1px solid var(--border-soft);
+  border-radius: 12px;
+  background: var(--bg-elev);
+  overflow: hidden;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.02);
 }
-.reasoning__toggle {
-  display: inline-flex;
+.process-card[data-tone="success"] {
+  --process-tone: var(--ok);
+  --process-tone-soft: color-mix(in srgb, var(--ok) 16%, transparent);
+}
+.process-card[data-tone="warning"] {
+  --process-tone: var(--warn);
+  --process-tone-soft: color-mix(in srgb, var(--warn) 16%, transparent);
+}
+.process-card[data-tone="danger"] {
+  --process-tone: var(--err);
+  --process-tone-soft: color-mix(in srgb, var(--err) 16%, transparent);
+}
+.process-card[data-tone="accent"] {
+  --process-tone: var(--accent);
+  --process-tone-soft: var(--accent-soft);
+}
+.process-card[data-tone="violet"] {
+  --process-tone: #a78bfa;
+  --process-tone-soft: rgba(167, 139, 250, 0.16);
+}
+.process-card__head {
+  box-sizing: border-box;
+  display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 9px;
+  width: 100%;
+  min-height: 44px;
   background: none;
   border: none;
-  color: var(--fg-faint);
+  color: inherit;
   font: inherit;
-  font-size: 12px;
-  padding: 2px 0;
+  font-size: 13px;
+  padding: 8px 14px;
+  text-align: left;
+  cursor: pointer;
+  user-select: none;
 }
-.reasoning__toggle:hover {
-  color: var(--fg-dim);
+.process-card__head:hover {
+  background: var(--bg-elev-2);
 }
-.reasoning__chevron {
-  transition: transform 0.15s;
+.process-card[data-has-body="false"] .process-card__head {
+  cursor: default;
 }
-.reasoning__chevron--open {
-  transform: rotate(90deg);
+.process-card[data-has-body="false"] .process-card__head:hover {
+  background: none;
+}
+.process-card__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  background: var(--process-tone-soft);
+  color: var(--process-tone);
+  flex-shrink: 0;
+}
+.process-card__kind {
+  color: var(--fg-faint);
+  font-size: var(--font-control);
+  letter-spacing: 0.02em;
+  text-transform: lowercase;
+}
+.process-card__name {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+  color: var(--fg);
+  font-size: var(--font-control);
+  font-weight: 650;
+}
+.process-card__grow {
+  flex: 1 1 auto;
+  min-width: 10px;
+}
+.process-card__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--fg-faint);
+  font-size: var(--font-caption);
+  flex-shrink: 0;
+}
+.process-card__chevron {
+  display: inline-flex;
+  color: var(--fg-faint);
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+}
+.process-card[data-open="false"] .process-card__chevron {
+  transform: rotate(-90deg);
+}
+.process-card__body {
+  box-sizing: border-box;
+  border-top: 1px solid var(--border-soft);
+  background: var(--bg-soft);
+}
+.process-card__status {
+  flex-shrink: 0;
+}
+.process-card__status--done {
+  color: var(--ok);
+}
+.process-card__status--failed {
+  color: var(--err);
+}
+.process-card__spin {
+  width: 10px;
+  height: 10px;
+  border: 2px solid color-mix(in srgb, var(--process-tone) 24%, transparent);
+  border-top-color: var(--process-tone);
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 0.9s linear infinite;
+}
+.process-card__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  display: inline-block;
+  background: var(--process-tone);
+}
+.process-card__dot--stopped {
+  color: var(--fg-faint);
+  background: var(--fg-faint);
 }
 .reasoning__body {
-  margin-top: 6px;
-  padding: 8px 12px;
-  border-left: 2px solid var(--border);
+  margin: 12px 16px 14px;
+  padding-left: 16px;
+  border-left: 3px solid color-mix(in srgb, var(--process-tone) 56%, transparent);
   color: var(--fg-dim);
-  font-size: var(--font-content);
+  font-size: 13.5px;
+  font-style: italic;
+  line-height: 1.7;
   white-space: pre-wrap;
 }
 
@@ -1373,13 +1515,56 @@ a[href] {
 .code-block:hover .code-block__copy {
   opacity: 1;
 }
-.msg__actions {
-  margin-top: 6px;
-  opacity: 0;
-  transition: opacity 0.12s;
+.msg--assistant .msg__body {
+  line-height: 1.68;
 }
-.msg--assistant:hover .msg__actions {
-  opacity: 1;
+.turn-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 4px;
+  min-height: 26px;
+}
+.turn-actions__group {
+  position: relative;
+  display: inline-flex;
+}
+.turn-actions__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border);
+  color: var(--fg-faint);
+  border-radius: 6px;
+  padding: 3px 7px;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1.25;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.turn-actions__btn:hover:not(:disabled),
+.turn-actions__btn:focus-visible:not(:disabled),
+.turn-actions__group--open .turn-actions__btn {
+  color: var(--fg);
+  border-color: var(--fg-faint);
+  background: var(--bg-elev);
+}
+.turn-actions__btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+.turn-actions__btn--confirm {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border));
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-elev-2));
+}
+.turn-actions__menu {
+  bottom: calc(100% + 5px);
+  right: auto;
+  left: 0;
 }
 
 /* ── diff ────────────────────────────────────────────────────────────────── */
@@ -1422,26 +1607,24 @@ a[href] {
   font-family: var(--mono);
 }
 
-/* ── tool cards (compact rows) ───────────────────────────────────────────── */
+/* ── process cards: reasoning and tool calls share the same shell ─────────── */
 .tool {
-  margin: 8px auto;
+  margin: 6px auto;
   border: 1px solid var(--border-soft);
-  border-radius: 8px;
-  background: var(--bg-soft);
+  border-radius: 12px;
+  background: var(--bg-elev);
   overflow: hidden;
 }
 .tool--running {
   border-color: var(--accent-soft);
 }
-/* read-only "research" calls: a slim, borderless, muted row instead of a boxed
-   card, so a long run of reads/greps reads as a quiet log. */
+/* Read-only research calls keep the same process-card shell, but their content
+   is visually quieter than write/shell/sub-agent calls. */
 .tool--quiet {
-  margin: 1px auto;
-  background: none;
-  border-color: transparent;
+  border-color: var(--border-soft);
 }
 .tool--quiet .tool__row {
-  padding: 2px 11px;
+  color: var(--fg-dim);
 }
 .tool--quiet .tool__name {
   color: var(--fg-dim);
@@ -1449,21 +1632,19 @@ a[href] {
 }
 .tool--quiet .tool__icon {
   color: var(--fg-faint);
-  opacity: 0.78;
 }
 .tool--quiet .tool__row--clickable:hover {
-  background: var(--bg-soft);
-  border-radius: 6px;
+  background: var(--bg-elev-2);
 }
 .tool--quiet .tool__summary {
-  padding-top: 0;
-  padding-bottom: 3px;
+  color: var(--fg-faint);
 }
 .tool__row {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 7px 11px;
+  min-height: 42px;
+  padding: 9px 14px;
   width: 100%;
   background: none;
   border: none;
@@ -1474,7 +1655,7 @@ a[href] {
 .tool__row--clickable {
 }
 .tool__row--clickable:hover {
-  background: var(--bg-elev);
+  background: var(--bg-elev-2);
 }
 .tool__chevron {
   flex-shrink: 0;
@@ -1499,6 +1680,14 @@ a[href] {
   font-weight: 600;
   color: var(--accent);
   flex-shrink: 0;
+}
+.process-card__name .tool__name {
+  color: var(--fg);
+}
+.tool__duration {
+  color: var(--fg-faint);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 .tool__subject {
   font-family: var(--mono);
@@ -1589,84 +1778,35 @@ a[href] {
   }
 }
 
-/* ── notices / phase ─────────────────────────────────────────────────────── */
-.notice {
-  margin: 8px auto;
-  font-size: 12.5px;
+/* ── process variants: notices, phases, and compaction ───────────────────── */
+.process-card.notice,
+.process-card.compaction,
+.process-card.phase {
+  margin: 6px auto;
+}
+.process-card.phase {
+  opacity: 0.82;
+}
+.process-card.phase .process-card__head {
+  min-height: 36px;
+  padding-block: 7px;
+}
+.notice__body {
+  margin: 11px 16px 13px;
+  padding-left: 14px;
+  border-left: 3px solid color-mix(in srgb, var(--process-tone) 50%, transparent);
   color: var(--fg-dim);
-  padding: 5px 11px;
-  border-left: 2px solid var(--border);
-  /* Listings (/skill, /hooks, /mcp, /memory, /model) are multi-line with leading
-     spaces; preserve them so the output isn't crammed onto one line. Monospace
-     keeps the indented entries aligned, like the CLI. */
-  white-space: pre-wrap;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: var(--font-caption);
+  line-height: 1.65;
+  white-space: pre-wrap;
 }
-.notice--warn {
-  color: var(--warn);
-  border-left-color: var(--warn);
-}
-.phase {
-  margin: 14px auto;
-  text-align: center;
-  font-size: 11px;
-  letter-spacing: 0.5px;
-  text-transform: uppercase;
-  color: var(--fg-faint);
-}
-
-/* ── compaction card ─────────────────────────────────────────────────────── */
-.compaction {
-  margin: 12px auto;
-  border: 1px solid var(--accent-soft, var(--border));
-  border-radius: var(--radius, 6px);
-  background: var(--bg-soft);
-  overflow: hidden;
-}
-.compaction--pending {
-  padding: 7px 12px;
-  font-size: 12.5px;
-  color: var(--fg-dim);
-  border-style: dashed;
-}
-.compaction__spinner {
-  color: var(--accent);
-}
-.compaction__head {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 7px 12px;
-  background: none;
-  border: none;
-  font: inherit;
-  font-size: 12.5px;
-  color: var(--fg);
-  text-align: left;
-}
-.compaction__head:hover {
-  background: var(--bg-elev);
-}
-.compaction__icon {
-  color: var(--accent);
-}
-.compaction__title {
-  font-weight: 600;
-}
-.compaction__meta {
-  color: var(--fg-dim);
-}
-.compaction__toggle {
-  margin-left: auto;
-  color: var(--clickable, var(--accent));
-  font-size: 11.5px;
+.notice--warn .notice__body {
+  color: color-mix(in srgb, var(--warn) 78%, var(--fg));
 }
 .compaction__summary {
   margin: 0;
-  padding: 10px 12px;
-  border-top: 1px solid var(--border);
-  background: var(--bg);
+  padding: 12px 16px;
   color: var(--fg-dim);
   font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   font-size: 12px;
@@ -2286,7 +2426,7 @@ a[href] {
   align-items: center;
   gap: 6px;
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--fg-faint);
   /* One line, always: without this a narrow window squeezes the flex items and
      CJK text breaks one character per line. The metric chips keep their width
@@ -2370,7 +2510,7 @@ a[href] {
   padding: 0;
   font: inherit;
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: inherit;
   color: var(--fg-dim);
 }
 .statusbar__jobs:hover {
@@ -2382,7 +2522,7 @@ a[href] {
 }
 .jobsmenu__head {
   padding: 2px 9px 6px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--fg-faint);
 }
 .jobsmenu__item {
@@ -2390,7 +2530,7 @@ a[href] {
   align-items: baseline;
   gap: 8px;
   padding: 4px 9px;
-  font-size: 12px;
+  font-size: var(--font-control-small);
 }
 .jobsmenu__id {
   color: var(--accent);
@@ -2427,7 +2567,7 @@ a[href] {
   color: var(--fg-dim);
   font: inherit;
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: inherit;
   padding: 0;
   white-space: nowrap;
   min-width: 0; /* let the label ellipsize when the status bar is tight */
@@ -5284,25 +5424,112 @@ a[href] {
   opacity: 0.5;
 }
 
-/* ── history drawer: click-to-resume rows with read-only preview ────────────── */
-.history-drawer {
-  min-height: 0;
+/* ── management modals: shared shell for settings, history, and trash ───────── */
+.management-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(0, 0, 0, 0.48);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 }
-.history-drawer--preview {
+
+.management-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(1360px, calc(100vw - 96px));
+  height: min(900px, calc(100vh - 80px));
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
+  overflow: hidden;
+}
+
+.management-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elev);
+  flex: 0 0 auto;
+}
+
+.management-modal__title {
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: var(--fg);
+}
+
+.management-modal__summary {
+  margin-top: 3px;
+  color: var(--fg-faint);
+  font-size: var(--text-xs);
+}
+
+.management-modal__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* ── history manager: searchable list with preview and actions ─────────────── */
+.history-manager {
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(220px, 0.44fr) minmax(0, 0.56fr);
-  gap: 12px;
+  grid-template-rows: auto minmax(0, 1fr);
+  overflow: hidden;
+}
+.history-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.history-content {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(340px, 0.38fr) minmax(0, 0.62fr);
   overflow: hidden;
 }
 .history-list {
   min-width: 0;
   overflow-y: auto;
-  padding-right: 2px;
+  padding: 14px 14px 16px;
+  border-right: 1px solid var(--border);
 }
 .history-search {
-  margin-bottom: 12px;
+  flex: 1 1 360px;
+  max-width: 520px;
+  margin: 0;
+}
+.history-filter-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  flex: 0 0 auto;
+  color: var(--fg-dim);
+  font-size: var(--font-caption);
+}
+.history-filter-select select {
+  --wails-draggable: no-drag;
+  min-width: 118px;
+  height: 34px;
+  padding: 0 28px 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-control-small);
 }
 .history-clear {
   height: 30px;
@@ -5318,19 +5545,24 @@ a[href] {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border);
-  border-radius: 8px;
   background: var(--bg);
 }
 .history-preview__head {
-  padding: 10px 12px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 14px 16px;
   border-bottom: 1px solid var(--border-soft);
   background: var(--bg-soft);
+}
+.history-preview__copy {
+  min-width: 0;
 }
 .history-preview__title {
   overflow: hidden;
   color: var(--fg);
-  font-size: 13px;
+  font-size: var(--font-control);
   font-weight: 650;
   line-height: 1.35;
   text-overflow: ellipsis;
@@ -5339,12 +5571,28 @@ a[href] {
 .history-preview__meta {
   margin-top: 3px;
   color: var(--fg-faint);
-  font-size: 11px;
+  font-size: var(--font-caption);
+}
+.history-preview__actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  max-width: 48%;
 }
 .history-preview__body {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+}
+.history-preview--empty {
+  display: grid;
+  place-items: center;
+}
+.history-preview__empty {
+  color: var(--fg-faint);
+  font-size: var(--font-control);
 }
 .history-preview__body .transcript {
   padding: 14px 14px 18px;
@@ -5398,8 +5646,16 @@ a[href] {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
   font-size: 11px;
   color: var(--fg-faint);
+}
+.hist-item__scope {
+  max-width: 46%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-dim);
 }
 .hist-item__badge {
   color: var(--accent);
@@ -5824,10 +6080,6 @@ a[href] {
   .drawer--wide {
     width: min(620px, 96vw);
   }
-  .history-drawer--preview {
-    grid-template-columns: 1fr;
-    grid-template-rows: minmax(180px, 0.42fr) minmax(0, 0.58fr);
-  }
   .settings-shell {
     grid-template-columns: 1fr;
     grid-template-rows: auto minmax(0, 1fr);
@@ -5856,9 +6108,12 @@ a[href] {
 
 /* ── tool card extras: outcome line, nested sub-agent, multi-edit labels ───── */
 .tool__summary {
-  padding: 1px 11px 8px 30px;
+  margin: 0 0 12px 14px;
+  padding: 10px 16px 0;
+  border-left: 3px solid color-mix(in srgb, var(--ok) 45%, transparent);
   font-family: var(--mono);
-  font-size: 11.5px;
+  font-size: 12.5px;
+  line-height: 1.65;
   color: var(--fg-faint);
 }
 .tool__summary::before {
@@ -6886,6 +7141,83 @@ a[href] {
   display: flex;
   align-items: center;
   gap: 8px;
+  position: relative;
+  --wails-draggable: no-drag;
+}
+
+.topicbar__action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elev);
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+
+.topicbar__action-btn:hover:not(:disabled),
+.topicbar__action-btn:focus-visible:not(:disabled),
+.topicbar__export--open .topicbar__action-btn {
+  color: var(--fg);
+  border-color: var(--fg-faint);
+  background: var(--bg-elev-2);
+}
+
+.topicbar__action-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.topicbar__action-btn--icon {
+  width: 34px;
+  min-width: 34px;
+  padding: 0;
+}
+
+.topicbar__export {
+  position: relative;
+  display: inline-flex;
+}
+
+.topicbar__export-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 7px);
+  z-index: 70;
+  min-width: 172px;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elev);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.34);
+}
+
+.topicbar__export-menu button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 9px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 12.5px;
+  text-align: left;
+}
+
+.topicbar__export-menu button:hover,
+.topicbar__export-menu button:focus-visible {
+  color: var(--fg);
+  background: var(--button-bg);
 }
 
 .topicbar__icon-btn {


### PR DESCRIPTION
Summary / 摘要
- Restore the v0.53-style process-card presentation for reasoning, tool calls, phases, notices, and compaction events.
- Introduce a shared ProcessCard/Toner-style abstraction with migrated icons and color treatments.
- Adapt the process cards to the newer chat layout and streaming states.

Validation / 验证
- npm run typecheck && npm run build
- go test . -run 'TestPreviewSessionMessages|TestHistoryMessages|TestToWireTool' (desktop)\n- go test ./internal/event ./internal/serve ./internal/agent ./internal/control\n- git diff --check