### PR TITLE
test(boot): fix Windows TempDir cleanup in legacy-session migration test

### DIFF
--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -505,7 +505,6 @@ func TestBuildMigratesLegacySessionsFromConfigSessionDir(t *testing.T) {
 	t.Setenv("AppData", filepath.Join(home, "AppData"))
 
 	proj := t.TempDir()
-	t.Chdir(proj)
 	writeFile(t, proj, "reasonix.toml", "[codegraph]\nenabled = false\n")
 
 	legacyDir := config.SessionDir()
@@ -520,7 +519,11 @@ func TestBuildMigratesLegacySessionsFromConfigSessionDir(t *testing.T) {
 		}
 	})
 
-	ctrl, err := Build(context.Background(), Options{Sink: sink})
+	// Pass the project root via WorkspaceRoot instead of t.Chdir: changing the
+	// process cwd into a t.TempDir makes Windows refuse to remove that dir during
+	// test cleanup (the cwd counts as "in use"), which is the only thing this test
+	// failed on. WorkspaceRoot loads the same config without touching the cwd.
+	ctrl, err := Build(context.Background(), Options{Sink: sink, WorkspaceRoot: proj})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}


### PR DESCRIPTION
Fixes the Windows CI regression from #3247.

## Problem
TestBuildMigratesLegacySessionsFromConfigSessionDir used t.Chdir(proj) to point Build at a temp project dir, which makes that dir the process cwd. On Windows a cwd directory cannot be removed, so t.TempDir cleanup failed (being used by another process) even though all assertions passed — reddening the main-v2 Windows CI for every Go PR.

## Fix
Use Build’s WorkspaceRoot option (added for desktop multi-project sessions) instead of t.Chdir. It loads the same project config without changing the process cwd, so the temp dir is removable on cleanup. The migration assertions are unchanged. Verified on macOS; the Windows CI on this PR confirms the cleanup.