### PR TITLE
Fix desktop in-memory file drops / 修复桌面内存文件拖拽

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -45,6 +45,10 @@ type PastedBlock = {
   text: string;
 };
 
+type WebkitFileEntry = {
+  isDirectory?: boolean;
+};
+
 function lineCount(s: string): number {
   if (s === "") return 0;
   return s.split(/\r\n|\r|\n/).length;
@@ -573,6 +577,34 @@ export function Composer({
   const hasFileDrag = (dataTransfer: DataTransfer): boolean =>
     Array.from(dataTransfer.items).some((it) => it.kind === "file") || dataTransfer.files.length > 0;
 
+  const getWebkitFileEntry = (item: DataTransferItem): WebkitFileEntry | null => {
+    const getAsEntry = (item as DataTransferItem & { webkitGetAsEntry?: () => WebkitFileEntry | null }).webkitGetAsEntry;
+    return typeof getAsEntry === "function" ? getAsEntry.call(item) : null;
+  };
+
+  const hasDirectoryDrop = (dataTransfer: DataTransfer): boolean =>
+    Array.from(dataTransfer.items).some((item) => item.kind === "file" && getWebkitFileEntry(item)?.isDirectory === true);
+
+  const clearWailsDropTarget = () => {
+    document.querySelectorAll(".wails-drop-target-active").forEach((el) => el.classList.remove("wails-drop-target-active"));
+  };
+
+  const stopNativeFileDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    e.nativeEvent.stopImmediatePropagation();
+    clearWailsDropTarget();
+  };
+
+  const onFileDropCapture = (e: DragEvent<HTMLDivElement>) => {
+    if (hasWorkspaceReferenceDrag(e.dataTransfer) || !hasFileDrag(e.dataTransfer) || hasDirectoryDrop(e.dataTransfer)) return;
+    const files = Array.from(e.dataTransfer.files);
+    if (files.length === 0) return;
+    stopNativeFileDrop(e);
+    setDragOver(false);
+    attachFiles(files);
+  };
+
   const onDrop = (e: DragEvent<HTMLDivElement>) => {
     const droppedWorkspaceRef = readWorkspaceReferenceDrag(e.dataTransfer);
     if (droppedWorkspaceRef) {
@@ -826,6 +858,7 @@ export function Composer({
     <div
       className={`composer-wrap${decisionPending ? " composer-wrap--decision-pending" : ""}`}
       style={{ "--wails-drop-target": "drop" } as CSSProperties}
+      onDropCapture={onFileDropCapture}
     >
       <AnchoredPopover
         open={workspaceMenuOpen && !!cwd}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -577,13 +577,19 @@ export function Composer({
   const hasFileDrag = (dataTransfer: DataTransfer): boolean =>
     Array.from(dataTransfer.items).some((it) => it.kind === "file") || dataTransfer.files.length > 0;
 
+  const fileDragItems = (dataTransfer: DataTransfer): DataTransferItem[] =>
+    Array.from(dataTransfer.items).filter((item) => item.kind === "file");
+
   const getWebkitFileEntry = (item: DataTransferItem): WebkitFileEntry | null => {
     const getAsEntry = (item as DataTransferItem & { webkitGetAsEntry?: () => WebkitFileEntry | null }).webkitGetAsEntry;
     return typeof getAsEntry === "function" ? getAsEntry.call(item) : null;
   };
 
-  const hasDirectoryDrop = (dataTransfer: DataTransfer): boolean =>
-    Array.from(dataTransfer.items).some((item) => item.kind === "file" && getWebkitFileEntry(item)?.isDirectory === true);
+  const hasPathlessFileDrop = (dataTransfer: DataTransfer): boolean => {
+    const items = fileDragItems(dataTransfer);
+    if (items.length === 0) return dataTransfer.files.length > 0;
+    return items.some((item) => getWebkitFileEntry(item) === null);
+  };
 
   const clearWailsDropTarget = () => {
     document.querySelectorAll(".wails-drop-target-active").forEach((el) => el.classList.remove("wails-drop-target-active"));
@@ -597,7 +603,7 @@ export function Composer({
   };
 
   const onFileDropCapture = (e: DragEvent<HTMLDivElement>) => {
-    if (hasWorkspaceReferenceDrag(e.dataTransfer) || !hasFileDrag(e.dataTransfer) || hasDirectoryDrop(e.dataTransfer)) return;
+    if (hasWorkspaceReferenceDrag(e.dataTransfer) || !hasFileDrag(e.dataTransfer) || !hasPathlessFileDrop(e.dataTransfer)) return;
     const files = Array.from(e.dataTransfer.files);
     if (files.length === 0) return;
     stopNativeFileDrop(e);


### PR DESCRIPTION
## Summary
- intercept ordinary file drops in the desktop composer before Wails tries to resolve them as disk-backed files
- save dropped in-memory files through the existing pasted-file attachment path
- preserve workspace reference drags and directory drops for the existing native path flow

## Verification
- `pnpm build` with the bundled Node runtime
- `go test ./...` from `desktop/`
- `go test ./internal/control` from repo root