### PR TITLE
Fix add project flow on macOS / 修复 macOS 添加项目无响应

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1013,12 +1013,54 @@ func (a *App) PickWorkspace() (string, error) {
 	a.mu.RUnlock()
 	dir, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
 		Title:            "Choose working folder",
-		DefaultDirectory: cur,
+		DefaultDirectory: dialogDefaultDirectory(cur),
 	})
 	if err != nil || dir == "" {
 		return "", err
 	}
 	return a.SwitchWorkspace(dir)
+}
+
+func dialogDefaultDirectory(preferred string) string {
+	if dir := nearestExistingDirectory(preferred); dir != "" {
+		return dir
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		if dir := nearestExistingDirectory(cwd); dir != "" {
+			return dir
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		if dir := nearestExistingDirectory(home); dir != "" {
+			return dir
+		}
+	}
+	return ""
+}
+
+func nearestExistingDirectory(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	for {
+		info, err := os.Stat(path)
+		if err == nil {
+			if info.IsDir() {
+				return path
+			}
+			path = filepath.Dir(path)
+			continue
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return ""
+		}
+		path = parent
+	}
 }
 
 func (a *App) ListWorkspaces() []WorkspaceMeta {
@@ -1753,7 +1795,7 @@ func (a *App) PickSkillFolder() (string, error) {
 	cur, _ := os.Getwd()
 	dir, err := runtime.OpenDirectoryDialog(a.ctx, runtime.OpenDialogOptions{
 		Title:            "Choose skills folder",
-		DefaultDirectory: cur,
+		DefaultDirectory: dialogDefaultDirectory(cur),
 	})
 	if err != nil || dir == "" {
 		return "", err

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -892,7 +892,7 @@ export function Composer({
             {filteredWorkspaces.length === 0 && <div className="workspace-switcher__empty">{t("composer.noProjectMatches")}</div>}
           </div>
           <div className="workspace-switcher__actions">
-            <button onClick={() => void chooseWorkspace()}>
+            <button type="button" onClick={() => void chooseWorkspace()}>
               <FolderPlus size={15} />
               <span>{t("composer.addProject")}</span>
             </button>

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -763,7 +763,18 @@ export function ProjectTree({
           query.trim() ? (
             <div className="project-tree__empty">{t("projectTree.emptyNoMatch")}</div>
           ) : (
-            <div className="project-tree__empty project-tree__empty--subtle">{t("projectTree.emptyNoProjects")}</div>
+            <div className="project-tree__empty-state">
+              <div className="project-tree__empty project-tree__empty--subtle">{t("projectTree.emptyNoProjects")}</div>
+              <button
+                type="button"
+                className="project-tree__empty-primary"
+                onClick={() => void handleAddProject()}
+                disabled={addingProject}
+              >
+                <FolderPlus size={14} />
+                <span>{t("projectTree.addProjectTooltip")}</span>
+              </button>
+            </div>
           )
         ) : (
           visibleTree.map((node) => renderNode(node, 0))

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -359,13 +359,20 @@ function baseName(path: string): string {
   return path.replace(/[/\\]+$/, "").split(/[/\\]/).filter(Boolean).pop() ?? path;
 }
 
+function mockScenario(): "demo" | "fresh" {
+  if (typeof window === "undefined") return "demo";
+  const value = new URLSearchParams(window.location.search).get("mock")?.trim().toLowerCase();
+  return value === "fresh" || value === "empty" || value === "first-run" ? "fresh" : "demo";
+}
+
 function makeMockApp(): AppBindings {
+  const freshMock = mockScenario() === "fresh";
   let cancelled = false;
   let pendingAskPreview = false;
   let pendingApprovalPreview = false;
-  let cwd = "~/projects/joyquant-db"; // mutable so PickWorkspace is visible in dev
   const globalWorkspaceRoot = "~/Library/Application Support/reasonix/global-workspace";
-  let workspaces = ["~/projects/joyquant-db", "~/projects/joyquant-sys", "~/projects/reasonix", "~/projects/blade"];
+  let cwd = freshMock ? globalWorkspaceRoot : "~/projects/joyquant-db"; // mutable so PickWorkspace is visible in dev
+  let workspaces = freshMock ? [] : ["~/projects/joyquant-db", "~/projects/joyquant-sys", "~/projects/reasonix", "~/projects/blade"];
   let mockEffort = "auto";
   const day = 86_400_000;
   const t0 = Date.now();
@@ -515,6 +522,10 @@ function makeMockApp(): AppBindings {
       topicTitle: t("mock.trashGlobalProductTitle"),
     },
   ];
+  if (freshMock) {
+    sessions.splice(0);
+    trashedSessions.splice(0);
+  }
   // Mutable settings so the Settings panel's edits are observable in browser dev.
   const settings: SettingsView = {
     defaultModel: "deepseek-flash",
@@ -543,7 +554,13 @@ function makeMockApp(): AppBindings {
     providerKinds: ["openai"],
     bypass: false,
   };
-  const mockProjectTree: ProjectNode[] = [
+  settings.providers = settings.providers.map((provider) =>
+    provider.apiKeyEnv === "DEEPSEEK_API_KEY" ? { ...provider, keySet: !freshMock } : provider,
+  );
+  if (freshMock) {
+    settings.configPath = "~/.config/reasonix/config.toml";
+  }
+  const mockProjectTree: ProjectNode[] = freshMock ? [] : [
     {
       key: "project_~/projects/joyquant-db",
       kind: "project",
@@ -600,7 +617,22 @@ function makeMockApp(): AppBindings {
   const setMockActiveTab = (tabId: string) => {
     mockTabs = mockTabs.map((tab) => ({ ...tab, active: tab.id === tabId }));
   };
-  let mockTabs: TabMeta[] = [
+  let mockTabs: TabMeta[] = freshMock ? [
+    {
+      id: "tab_global",
+      scope: "global",
+      workspaceRoot: globalWorkspaceRoot,
+      workspaceName: "Global",
+      topicId: "",
+      topicTitle: "Global",
+      label: "DeepSeek-R1",
+      ready: true,
+      running: false,
+      mode: "normal",
+      active: true,
+      cwd: globalWorkspaceRoot,
+    },
+  ] : [
     {
       id: "tab_joyquant_db",
       scope: "project",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7579,6 +7579,40 @@ a[href] {
   font-size: 12px;
 }
 
+.project-tree__empty-state {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 2px 0 0;
+}
+
+.project-tree__empty-primary {
+  --wails-draggable: no-drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  height: 32px;
+  margin: 0 8px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-elev));
+  color: var(--accent-strong);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 620;
+}
+
+.project-tree__empty-primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 21%, var(--bg-elev));
+  color: var(--fg);
+}
+
+.project-tree__empty-primary:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
 .context-inspector,
 .workbench-dock {
   grid-row: 2;

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -64,6 +64,27 @@ func TestSaveWorkspaceOnlyRemembersLastWorkspace(t *testing.T) {
 	}
 }
 
+func TestDialogDefaultDirectoryFallsBackFromMissingWorkspace(t *testing.T) {
+	parent := t.TempDir()
+	missing := filepath.Join(parent, "deleted", "project")
+
+	if got := dialogDefaultDirectory(missing); got != parent {
+		t.Fatalf("dialogDefaultDirectory(%q) = %q, want %q", missing, got, parent)
+	}
+}
+
+func TestDialogDefaultDirectoryUsesFileParent(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "reasonix.toml")
+	if err := os.WriteFile(file, []byte("default_model = \"x\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := dialogDefaultDirectory(file); got != dir {
+		t.Fatalf("dialogDefaultDirectory(file) = %q, want %q", got, dir)
+	}
+}
+
 // --- cwdWritable ---
 
 func TestCwdWritable(t *testing.T) {


### PR DESCRIPTION
## Summary
- fall back to an existing directory before opening the native folder picker
- restore a visible empty-project add button and make composer add-project a plain button
- add a browser dev `?mock=fresh` mode for first-run visual checks

Fixes #3254

## Verification
- `corepack pnpm@10 build` with the bundled Node runtime
- `go test ./...` in `desktop/`