### PR TITLE
Complete ACP v1 session lifecycle / 补齐 ACP v1 会话生命周期

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -66,6 +66,12 @@ func (s *updateSink) setTurnContext(ctx context.Context) {
 	s.mu.Unlock()
 }
 
+func (s *updateSink) clearTurnContext() {
+	s.mu.Lock()
+	s.turnCtx = nil
+	s.mu.Unlock()
+}
+
 func (s *updateSink) currentTurnContext() context.Context {
 	s.mu.Lock()
 	ctx := s.turnCtx

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"unicode/utf8"
 
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
@@ -44,6 +46,8 @@ type updateSink struct {
 	conn      notifier
 	sessionID string
 	approve   func(id string, allow, session, persist bool)
+	mu        sync.Mutex
+	turnCtx   context.Context
 }
 
 func newUpdateSink(conn notifier, sessionID string) *updateSink {
@@ -54,6 +58,22 @@ func newUpdateSink(conn notifier, sessionID string) *updateSink {
 // once the controller exists (the sink is built first, to hand to the Factory).
 func (s *updateSink) bindApprove(fn func(id string, allow, session, persist bool)) {
 	s.approve = fn
+}
+
+func (s *updateSink) setTurnContext(ctx context.Context) {
+	s.mu.Lock()
+	s.turnCtx = ctx
+	s.mu.Unlock()
+}
+
+func (s *updateSink) currentTurnContext() context.Context {
+	s.mu.Lock()
+	ctx := s.turnCtx
+	s.mu.Unlock()
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
 }
 
 // Emit implements event.Sink. The agent calls it serially (see event.Sink), so no
@@ -125,7 +145,8 @@ func (s *updateSink) Emit(e event.Event) {
 		// The run loop is now blocked awaiting Approve(id, …). Do the
 		// client round-trip off the emit goroutine so Emit returns at once
 		// (the agent emits serially); the answer unblocks the loop.
-		go s.requestPermission(e.Approval)
+		turnCtx := s.currentTurnContext()
+		go s.requestPermission(turnCtx, e.Approval)
 	}
 }
 
@@ -176,7 +197,7 @@ func (s *updateSink) replay(msgs []provider.Message) {
 // session/request_permission round-trip and feeds the outcome back through
 // approve. Any transport failure or a cancelled/rejected outcome denies the call,
 // so the model gets a blocked result rather than the turn hanging.
-func (s *updateSink) requestPermission(a event.Approval) {
+func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 	if s.approve == nil {
 		return
 	}
@@ -201,9 +222,7 @@ func (s *updateSink) requestPermission(a event.Approval) {
 	}
 
 	allow, session, persist := false, false, false
-	// context.Background: Conn.Request also unblocks on connection close, so the
-	// round-trip can't outlive the wire even without a turn-scoped context here.
-	if raw, err := s.conn.Request(context.Background(), "session/request_permission", params); err == nil {
+	if raw, err := s.conn.Request(ctx, "session/request_permission", params); err == nil {
 		var res PermissionRequestResult
 		if json.Unmarshal(raw, &res) == nil && res.Outcome.Outcome == "selected" {
 			switch PermissionOptionKind(res.Outcome.OptionID) {
@@ -236,8 +255,12 @@ func clip(text string) string {
 	if len(text) <= maxResultChars {
 		return text
 	}
-	return text[:maxResultChars] + "\n…(" +
-		strconv.Itoa(len(text)-maxResultChars) + " more chars truncated)"
+	end := maxResultChars
+	for end > 0 && !utf8.ValidString(text[:end]) {
+		end--
+	}
+	return text[:end] + "\n…(" +
+		strconv.Itoa(len(text)-end) + " more chars truncated)"
 }
 
 // toolKindFor maps a tool name to the ACP tool kind the host uses to categorize

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"reasonix/internal/event"
 )
@@ -14,10 +15,11 @@ import (
 // fakeNotifier captures Notify calls and answers Request via an injectable hook,
 // standing in for *Conn in adapter unit tests.
 type fakeNotifier struct {
-	mu      sync.Mutex
-	notifs  []capturedNotif
-	onReq   func(method string, params any) (json.RawMessage, error)
-	reqSeen []capturedNotif
+	mu       sync.Mutex
+	notifs   []capturedNotif
+	onReq    func(method string, params any) (json.RawMessage, error)
+	onReqCtx func(ctx context.Context, method string, params any) (json.RawMessage, error)
+	reqSeen  []capturedNotif
 }
 
 type capturedNotif struct {
@@ -32,10 +34,13 @@ func (f *fakeNotifier) Notify(method string, params any) error {
 	return nil
 }
 
-func (f *fakeNotifier) Request(_ context.Context, method string, params any) (json.RawMessage, error) {
+func (f *fakeNotifier) Request(ctx context.Context, method string, params any) (json.RawMessage, error) {
 	f.mu.Lock()
 	f.reqSeen = append(f.reqSeen, capturedNotif{method, params})
 	f.mu.Unlock()
+	if f.onReqCtx != nil {
+		return f.onReqCtx(ctx, method, params)
+	}
 	if f.onReq != nil {
 		return f.onReq(method, params)
 	}
@@ -255,6 +260,48 @@ func TestUpdateSinkApprovalDenied(t *testing.T) {
 				t.Fatal("approve was never called")
 			}
 		})
+	}
+}
+
+func TestUpdateSinkApprovalUsesTurnContext(t *testing.T) {
+	reqStarted := make(chan struct{})
+	fn := &fakeNotifier{onReqCtx: func(ctx context.Context, _ string, _ any) (json.RawMessage, error) {
+		close(reqStarted)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}}
+	sink := newUpdateSink(fn, "sess-1")
+	turnCtx, cancel := context.WithCancel(context.Background())
+	sink.setTurnContext(turnCtx)
+	got := make(chan approveCall, 1)
+	sink.bindApprove(func(id string, allow, session, persist bool) { got <- approveCall{id, allow, session, persist} })
+
+	sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "7", Tool: "bash"}})
+	select {
+	case <-reqStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("permission request did not start")
+	}
+	cancel()
+
+	select {
+	case c := <-got:
+		if c.id != "7" || c.allow || c.session || c.persist {
+			t.Fatalf("approve after context cancel = %+v, want denied id=7", c)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("turn context cancellation did not deny permission request")
+	}
+}
+
+func TestClipKeepsValidUTF8(t *testing.T) {
+	text := strings.Repeat("a", maxResultChars-1) + "界" + strings.Repeat("b", 20)
+	got := clip(text)
+	if !utf8.ValidString(got) {
+		t.Fatalf("clip returned invalid UTF-8")
+	}
+	if strings.Contains(got, "\ufffd") {
+		t.Fatalf("clip inserted replacement characters: %q", got[len(got)-40:])
 	}
 }
 

--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -80,6 +80,8 @@ type e2eFactory struct {
 	sessionDir string
 }
 
+func (f *e2eFactory) SessionDir() string { return f.sessionDir }
+
 func (f *e2eFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
 	reg := tool.NewRegistry()
 	reg.Add(f.tool)
@@ -276,6 +278,90 @@ func TestE2ESessionLoad(t *testing.T) {
 	}
 	if kinds["tool_call"] != 1 || kinds["tool_call_update"] != 1 {
 		t.Errorf("tool replay = %v, want 1 tool_call + 1 tool_call_update", kinds)
+	}
+}
+
+func TestE2ESessionListResumeAndDelete(t *testing.T) {
+	dir := t.TempDir()
+	cwd := t.TempDir()
+	mkFactory := func() *e2eFactory {
+		return &e2eFactory{
+			prov: &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+				{{Type: provider.ChunkText, Text: "Stored answer."}, {Type: provider.ChunkDone}},
+			}},
+			tool:       fakeTool{name: "peek", ro: true, out: "unused"},
+			policy:     permission.New("ask", nil, nil, nil),
+			sessionDir: dir,
+		}
+	}
+
+	client1, stop1 := startServer(t, mkFactory())
+	client1.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client1.call(t, "session/new", SessionNewParams{Cwd: cwd})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil || nr.SessionID == "" {
+		t.Fatalf("session/new: %v (%q)", err, nr.SessionID)
+	}
+	promptCh := client1.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "remember this session"}},
+	})
+	_, promptResp := drainPrompt(t, client1, promptCh)
+	var pr SessionPromptResult
+	if err := json.Unmarshal(promptResp.Result, &pr); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if pr.TranscriptPath == nil {
+		t.Fatal("prompt did not return a transcript path")
+	}
+	transcript := *pr.TranscriptPath
+	stop1()
+
+	client2, stop2 := startServer(t, mkFactory())
+	defer stop2()
+	client2.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	listResp := client2.call(t, "session/list", SessionListParams{Cwd: cwd})
+	var lr SessionListResult
+	if err := json.Unmarshal(listResp.Result, &lr); err != nil {
+		t.Fatalf("session/list result: %v", err)
+	}
+	if len(lr.Sessions) != 1 {
+		t.Fatalf("session/list returned %d sessions, want 1: %+v", len(lr.Sessions), lr.Sessions)
+	}
+	got := lr.Sessions[0]
+	if got.SessionID != nr.SessionID || got.Cwd != cwd {
+		t.Fatalf("listed session = %+v, want id %q cwd %q", got, nr.SessionID, cwd)
+	}
+	if !strings.Contains(got.Title, "remember this session") {
+		t.Fatalf("listed title = %q, want prompt preview", got.Title)
+	}
+	if got.UpdatedAt == "" {
+		t.Fatal("listed session missing updatedAt")
+	}
+
+	resumeResp := client2.call(t, "session/resume", SessionResumeParams{SessionID: nr.SessionID, Cwd: cwd})
+	if resumeResp.Error != nil {
+		t.Fatalf("session/resume errored: %+v", resumeResp.Error)
+	}
+	select {
+	case n := <-client2.notifs:
+		t.Fatalf("session/resume replayed an unexpected notification: %+v", n)
+	default:
+	}
+
+	deleteResp := client2.call(t, "session/delete", SessionDeleteParams{SessionID: nr.SessionID})
+	if deleteResp.Error != nil {
+		t.Fatalf("session/delete errored: %+v", deleteResp.Error)
+	}
+	listResp = client2.call(t, "session/list", SessionListParams{Cwd: cwd})
+	if err := json.Unmarshal(listResp.Result, &lr); err != nil {
+		t.Fatalf("session/list after delete: %v", err)
+	}
+	if len(lr.Sessions) != 0 {
+		t.Fatalf("session/list after delete = %+v, want empty", lr.Sessions)
+	}
+	if _, err := os.Stat(transcript); !os.IsNotExist(err) {
+		t.Fatalf("transcript after delete stat err = %v, want not exist", err)
 	}
 }
 

--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -349,7 +349,7 @@ func TestE2ESessionListResumeAndDelete(t *testing.T) {
 	default:
 	}
 
-	deleteResp := client2.call(t, "session/delete", SessionDeleteParams{SessionID: nr.SessionID})
+	deleteResp := client2.call(t, "session/delete", SessionDeleteParams(nr))
 	if deleteResp.Error != nil {
 		t.Fatalf("session/delete errored: %+v", deleteResp.Error)
 	}
@@ -363,6 +363,108 @@ func TestE2ESessionListResumeAndDelete(t *testing.T) {
 	if _, err := os.Stat(transcript); !os.IsNotExist(err) {
 		t.Fatalf("transcript after delete stat err = %v, want not exist", err)
 	}
+}
+
+func TestE2ESessionListSkipsUnpromptedSessionAfterRestart(t *testing.T) {
+	dir := t.TempDir()
+	factory := &e2eFactory{
+		prov: &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+			{{Type: provider.ChunkText, Text: "unused"}, {Type: provider.ChunkDone}},
+		}},
+		tool:       fakeTool{name: "peek", ro: true, out: "unused"},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: dir,
+	}
+
+	client1, stop1 := startServer(t, factory)
+	client1.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	resp := client1.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(resp.Result, &nr); err != nil || nr.SessionID == "" {
+		t.Fatalf("session/new: %v (%q)", err, nr.SessionID)
+	}
+	stop1()
+
+	client2, stop2 := startServer(t, factory)
+	defer stop2()
+	client2.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	listResp := client2.call(t, "session/list", SessionListParams{})
+	var lr SessionListResult
+	if err := json.Unmarshal(listResp.Result, &lr); err != nil {
+		t.Fatalf("session/list result: %v", err)
+	}
+	if len(lr.Sessions) != 0 {
+		t.Fatalf("session/list returned unprompted session: %+v", lr.Sessions)
+	}
+}
+
+func TestE2EDeleteActiveSessionDoesNotRecreateFiles(t *testing.T) {
+	dir := t.TempDir()
+	releaseTool := make(chan struct{})
+	started := make(chan struct{})
+	prov := &scriptedProvider{name: "fake", responses: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "Starting."},
+			toolCallChunk("c1", "slow", `{}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "unreachable"}, {Type: provider.ChunkDone}},
+	}}
+	factory := &e2eFactory{
+		prov:       prov,
+		tool:       blockingTool{started: started, release: releaseTool},
+		policy:     permission.New("ask", nil, nil, nil),
+		sessionDir: dir,
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	sid := openSession(t, client)
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: sid,
+		Prompt:    []ContentBlock{{Type: "text", Text: "delete me while running"}},
+	})
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tool never started")
+	}
+	deleteResp := client.call(t, "session/delete", SessionDeleteParams{SessionID: sid})
+	if deleteResp.Error != nil {
+		t.Fatalf("session/delete errored: %+v", deleteResp.Error)
+	}
+
+	select {
+	case resp := <-promptCh:
+		if resp.Error != nil {
+			t.Fatalf("prompt errored after delete: %+v", resp.Error)
+		}
+		var pr SessionPromptResult
+		if err := json.Unmarshal(resp.Result, &pr); err != nil {
+			t.Fatalf("prompt result: %v", err)
+		}
+		if pr.StopReason != StopCancelled {
+			t.Fatalf("stopReason = %q, want cancelled", pr.StopReason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("prompt did not finish after delete")
+	}
+
+	listResp := client.call(t, "session/list", SessionListParams{})
+	var lr SessionListResult
+	if err := json.Unmarshal(listResp.Result, &lr); err != nil {
+		t.Fatalf("session/list result: %v", err)
+	}
+	if len(lr.Sessions) != 0 {
+		t.Fatalf("session/list after active delete = %+v, want empty", lr.Sessions)
+	}
+	for _, path := range []string{transcriptPath(dir, sid), acpMetaPath(transcriptPath(dir, sid))} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s after active delete stat err = %v, want not exist", path, err)
+		}
+	}
+	close(releaseTool)
 }
 
 // TestE2EApprovalRoundTrip drives a write tool through the gate: the policy asks,

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -16,6 +16,7 @@ package acp
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -47,10 +48,9 @@ type Implementation struct {
 	Version string `json:"version,omitempty"`
 }
 
-// InitializeResult advertises what this agent supports. The capability flags
-// match main exactly: sessions are created via session/new (no loadSession),
-// prompts may carry inline resource text (embeddedContext) but not image/audio,
-// and MCP is stdio-only (no http/sse).
+// InitializeResult advertises what this agent supports: persisted session load,
+// ACP v1 session lifecycle helpers, inline resource text (embeddedContext) but
+// not image/audio, and stdio-only MCP (no http/sse).
 type InitializeResult struct {
 	ProtocolVersion   int               `json:"protocolVersion"`
 	AgentCapabilities AgentCapabilities `json:"agentCapabilities"`
@@ -60,9 +60,21 @@ type InitializeResult struct {
 
 // AgentCapabilities is the agentCapabilities object in InitializeResult.
 type AgentCapabilities struct {
-	LoadSession        bool               `json:"loadSession"`
-	PromptCapabilities PromptCapabilities `json:"promptCapabilities"`
-	MCPCapabilities    MCPCapabilities    `json:"mcpCapabilities"`
+	LoadSession         bool                `json:"loadSession"`
+	SessionCapabilities SessionCapabilities `json:"sessionCapabilities,omitempty"`
+	PromptCapabilities  PromptCapabilities  `json:"promptCapabilities"`
+	MCPCapabilities     MCPCapabilities     `json:"mcpCapabilities"`
+}
+
+// EmptyCapability serializes to {} for ACP capability flags.
+type EmptyCapability struct{}
+
+// SessionCapabilities advertises optional session lifecycle methods.
+type SessionCapabilities struct {
+	List   *EmptyCapability `json:"list,omitempty"`
+	Resume *EmptyCapability `json:"resume,omitempty"`
+	Close  *EmptyCapability `json:"close,omitempty"`
+	Delete *EmptyCapability `json:"delete,omitempty"`
 }
 
 // PromptCapabilities reports which content-block kinds prompts may carry.
@@ -89,10 +101,48 @@ type SessionNewParams struct {
 
 // MCPServerSpec describes one stdio MCP server the client asks the agent to run.
 type MCPServerSpec struct {
-	Name    string            `json:"name"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
+	Name    string   `json:"name"`
+	Type    string   `json:"type,omitempty"`
+	Command string   `json:"command,omitempty"`
+	Args    []string `json:"args,omitempty"`
+	Env     MCPEnv   `json:"env,omitempty"`
+}
+
+// MCPEnv accepts ACP's official EnvVariable[] shape while still accepting the
+// older map shape that Reasonix v1 clients used.
+type MCPEnv map[string]string
+
+// EnvVariable is one official ACP MCP environment variable entry.
+type EnvVariable struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+func (e *MCPEnv) UnmarshalJSON(raw []byte) error {
+	if strings.TrimSpace(string(raw)) == "" || strings.TrimSpace(string(raw)) == "null" {
+		*e = nil
+		return nil
+	}
+
+	var vars []EnvVariable
+	if err := json.Unmarshal(raw, &vars); err == nil {
+		out := make(map[string]string, len(vars))
+		for i, v := range vars {
+			if strings.TrimSpace(v.Name) == "" {
+				return fmt.Errorf("env[%d].name is required", i)
+			}
+			out[v.Name] = v.Value
+		}
+		*e = out
+		return nil
+	}
+
+	var legacy map[string]string
+	if err := json.Unmarshal(raw, &legacy); err == nil {
+		*e = legacy
+		return nil
+	}
+	return fmt.Errorf("env must be an array of {name,value} objects")
 }
 
 // SessionNewResult returns the opaque id used to address the session thereafter.
@@ -115,6 +165,62 @@ type SessionLoadParams struct {
 // SessionLoadResult is the empty ack; the conversation has already arrived as a
 // burst of session/update notifications by the time it is sent.
 type SessionLoadResult struct{}
+
+// --- session/resume ---
+
+// SessionResumeParams resumes a session without replaying its transcript.
+type SessionResumeParams struct {
+	SessionID  string          `json:"sessionId"`
+	Cwd        string          `json:"cwd,omitempty"`
+	MCPServers []MCPServerSpec `json:"mcpServers,omitempty"`
+}
+
+// SessionResumeResult is the empty ack returned once the session is ready.
+type SessionResumeResult struct{}
+
+// --- session/list ---
+
+// SessionListParams lists known sessions, optionally filtered by cwd.
+type SessionListParams struct {
+	Cwd    string `json:"cwd,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+// SessionListResult is the first and only page of sessions Reasonix currently
+// returns. NextCursor is omitted because the in-process list is unpaged.
+type SessionListResult struct {
+	Sessions   []SessionInfo `json:"sessions"`
+	NextCursor string        `json:"nextCursor,omitempty"`
+}
+
+// SessionInfo is the ACP session/list item shape.
+type SessionInfo struct {
+	SessionID string         `json:"sessionId"`
+	Cwd       string         `json:"cwd"`
+	Title     string         `json:"title,omitempty"`
+	UpdatedAt string         `json:"updatedAt,omitempty"`
+	Meta      map[string]any `json:"_meta,omitempty"`
+}
+
+// --- session/close ---
+
+// SessionCloseParams closes an active session and releases its resources.
+type SessionCloseParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// SessionCloseResult is the empty close ack.
+type SessionCloseResult struct{}
+
+// --- session/delete ---
+
+// SessionDeleteParams removes a session from future session/list results.
+type SessionDeleteParams struct {
+	SessionID string `json:"sessionId"`
+}
+
+// SessionDeleteResult is the empty delete ack.
+type SessionDeleteResult struct{}
 
 // --- content blocks (inbound prompt) ---
 

--- a/internal/acp/protocol_test.go
+++ b/internal/acp/protocol_test.go
@@ -1,6 +1,8 @@
 package acp
 
 import (
+	"context"
+	"encoding/json"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -128,19 +130,22 @@ func TestNewSessionIDUnique(t *testing.T) {
 // --- mcpSpecs ---
 
 func TestMcpSpecsNil(t *testing.T) {
-	if got := mcpSpecs(nil); got != nil {
+	if got, err := mcpSpecs(nil, ""); err != nil || got != nil {
 		t.Errorf("mcpSpecs(nil) = %v, want nil", got)
 	}
-	if got := mcpSpecs([]MCPServerSpec{}); got != nil {
+	if got, err := mcpSpecs([]MCPServerSpec{}, ""); err != nil || got != nil {
 		t.Errorf("mcpSpecs([]) = %v, want nil", got)
 	}
 }
 
 func TestMcpSpecsConversion(t *testing.T) {
 	in := []MCPServerSpec{
-		{Name: "codegraph", Command: "codegraph", Args: []string{"--stdio"}, Env: map[string]string{"HOME": "/tmp"}},
+		{Name: "codegraph", Command: "codegraph", Args: []string{"--stdio"}, Env: MCPEnv{"HOME": "/tmp"}},
 	}
-	got := mcpSpecs(in)
+	got, err := mcpSpecs(in, "/workspace")
+	if err != nil {
+		t.Fatalf("mcpSpecs: %v", err)
+	}
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
@@ -152,6 +157,39 @@ func TestMcpSpecsConversion(t *testing.T) {
 	}
 	if got[0].Env["HOME"] != "/tmp" {
 		t.Errorf("env = %v", got[0].Env)
+	}
+	if got[0].Dir != "/workspace" {
+		t.Errorf("dir = %q, want /workspace", got[0].Dir)
+	}
+}
+
+func TestMCPEnvAcceptsOfficialArrayShape(t *testing.T) {
+	var p SessionNewParams
+	raw := []byte(`{
+		"cwd":"/tmp",
+		"mcpServers":[{
+			"name":"fs",
+			"command":"mcp-fs",
+			"args":["--stdio"],
+			"env":[{"name":"HOME","value":"/tmp"},{"name":"EMPTY","value":""}]
+		}]
+	}`)
+	if err := json.Unmarshal(raw, &p); err != nil {
+		t.Fatalf("unmarshal official env array: %v", err)
+	}
+	got, err := mcpSpecs(p.MCPServers, p.Cwd)
+	if err != nil {
+		t.Fatalf("mcpSpecs: %v", err)
+	}
+	if got[0].Env["HOME"] != "/tmp" || got[0].Env["EMPTY"] != "" {
+		t.Fatalf("env = %v, want HOME and EMPTY from official array", got[0].Env)
+	}
+}
+
+func TestMcpSpecsRejectsUnsupportedTransport(t *testing.T) {
+	_, err := mcpSpecs([]MCPServerSpec{{Name: "remote", Type: "http", Command: "ignored"}}, "/tmp")
+	if err == nil || !strings.Contains(err.Error(), "unsupported transport") {
+		t.Fatalf("mcpSpecs unsupported transport err = %v", err)
 	}
 }
 
@@ -196,7 +234,16 @@ func TestErrorCodes(t *testing.T) {
 func TestAcpSessionSetCancelAbort(t *testing.T) {
 	sess := &acpSession{id: "test"}
 	aborted := false
-	sess.setCancel(func() { aborted = true })
+	_, cancel, ok := sess.begin(context.Background())
+	if !ok {
+		t.Fatal("begin should succeed")
+	}
+	sess.mu.Lock()
+	sess.cancel = func() {
+		aborted = true
+		cancel()
+	}
+	sess.mu.Unlock()
 	sess.abort()
 	if !aborted {
 		t.Error("abort should call the cancel func")
@@ -210,6 +257,6 @@ func TestAcpSessionAbortNil(t *testing.T) {
 
 func TestAcpSessionSetCancelNil(t *testing.T) {
 	sess := &acpSession{id: "test"}
-	sess.setCancel(nil)
+	sess.finish()
 	sess.abort() // should not panic
 }

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -209,6 +210,12 @@ func TestServeLifecycle(t *testing.T) {
 	if !ir.AgentCapabilities.PromptCapabilities.EmbeddedContext {
 		t.Errorf("embeddedContext should be advertised")
 	}
+	if ir.AgentCapabilities.SessionCapabilities.List == nil ||
+		ir.AgentCapabilities.SessionCapabilities.Resume == nil ||
+		ir.AgentCapabilities.SessionCapabilities.Close == nil ||
+		ir.AgentCapabilities.SessionCapabilities.Delete == nil {
+		t.Errorf("sessionCapabilities = %+v, want list/resume/close/delete", ir.AgentCapabilities.SessionCapabilities)
+	}
 	if ir.AgentCapabilities.PromptCapabilities.Image {
 		t.Errorf("image must not be advertised")
 	}
@@ -279,6 +286,93 @@ func TestServeCancel(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("cancel did not end the prompt")
+	}
+}
+
+func TestServeRejectsConcurrentPromptForSameSession(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	factory := &fakeFactory{behavior: func(_ context.Context, _ event.Sink, _ string) error {
+		once.Do(func() { close(started) })
+		<-release
+		return nil
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	json.Unmarshal(newResp.Result, &nr)
+
+	first := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "first"}},
+	})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first prompt never started")
+	}
+
+	second := client.call(t, "session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "second"}},
+	})
+	if second.Error == nil {
+		t.Fatal("second concurrent prompt should return an error")
+	}
+	if second.Error.Code != ErrInvalidRequest || !strings.Contains(second.Error.Message, "active prompt") {
+		t.Fatalf("second prompt error = %+v, want active-prompt invalid request", second.Error)
+	}
+
+	close(release)
+	select {
+	case resp := <-first:
+		if resp.Error != nil {
+			t.Fatalf("first prompt errored: %+v", resp.Error)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("first prompt did not finish")
+	}
+}
+
+func TestServeSessionClose(t *testing.T) {
+	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error { return nil }}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	json.Unmarshal(newResp.Result, &nr)
+
+	closeResp := client.call(t, "session/close", SessionCloseParams{SessionID: nr.SessionID})
+	if closeResp.Error != nil {
+		t.Fatalf("session/close errored: %+v", closeResp.Error)
+	}
+
+	promptResp := client.call(t, "session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "after close"}},
+	})
+	if promptResp.Error == nil || !strings.Contains(promptResp.Error.Message, "unknown session") {
+		t.Fatalf("prompt after close error = %+v, want unknown session", promptResp.Error)
+	}
+}
+
+func TestServeRejectsPathLikeSessionID(t *testing.T) {
+	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error { return nil }}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	resp := client.call(t, "session/delete", SessionDeleteParams{SessionID: "../outside"})
+	if resp.Error == nil {
+		t.Fatal("session/delete with path-like sessionId should fail")
+	}
+	if resp.Error.Code != ErrInvalidParams || !strings.Contains(resp.Error.Message, "invalid sessionId") {
+		t.Fatalf("session/delete error = %+v, want invalid sessionId", resp.Error)
 	}
 }
 

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -220,7 +220,7 @@ func TestServeLifecycle(t *testing.T) {
 		t.Errorf("image must not be advertised")
 	}
 
-	newResp := client.call(t, "session/new", SessionNewParams{Cwd: "/tmp"})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
 	var nr SessionNewResult
 	if err := json.Unmarshal(newResp.Result, &nr); err != nil || nr.SessionID == "" {
 		t.Fatalf("session/new result: %v (%q)", err, nr.SessionID)
@@ -348,7 +348,7 @@ func TestServeSessionClose(t *testing.T) {
 	var nr SessionNewResult
 	json.Unmarshal(newResp.Result, &nr)
 
-	closeResp := client.call(t, "session/close", SessionCloseParams{SessionID: nr.SessionID})
+	closeResp := client.call(t, "session/close", SessionCloseParams(nr))
 	if closeResp.Error != nil {
 		t.Fatalf("session/close errored: %+v", closeResp.Error)
 	}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -114,28 +114,36 @@ type acpSession struct {
 
 	mu      sync.Mutex
 	cancel  context.CancelFunc
+	done    chan struct{}
 	running bool
+	deleted bool
 }
 
 func (s *acpSession) begin(ctx context.Context) (context.Context, context.CancelFunc, bool) {
 	runCtx, cancel := context.WithCancel(ctx)
 	s.mu.Lock()
-	if s.running {
+	if s.running || s.deleted {
 		s.mu.Unlock()
 		cancel()
 		return nil, nil, false
 	}
 	s.running = true
 	s.cancel = cancel
+	s.done = make(chan struct{})
 	s.mu.Unlock()
 	return runCtx, cancel, true
 }
 
 func (s *acpSession) finish() {
 	s.mu.Lock()
+	done := s.done
 	s.running = false
 	s.cancel = nil
+	s.done = nil
 	s.mu.Unlock()
+	if done != nil {
+		close(done)
+	}
 }
 
 func (s *acpSession) abort() {
@@ -144,6 +152,33 @@ func (s *acpSession) abort() {
 	s.mu.Unlock()
 	if c != nil {
 		c()
+	}
+}
+
+func (s *acpSession) abortAndWait() {
+	s.mu.Lock()
+	c := s.cancel
+	done := s.done
+	s.mu.Unlock()
+	if c != nil {
+		c()
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (s *acpSession) deleteAndWait() {
+	s.mu.Lock()
+	s.deleted = true
+	c := s.cancel
+	done := s.done
+	s.mu.Unlock()
+	if c != nil {
+		c()
+	}
+	if done != nil {
+		<-done
 	}
 }
 
@@ -218,10 +253,6 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	if dir := ctrl.SessionDir(); dir != "" {
 		sess.transcript = transcriptPath(dir, id)
 		ctrl.SetSessionPath(sess.transcript)
-		if err := saveACPMeta(sess.transcript, sess.meta()); err != nil {
-			ctrl.Close()
-			return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
-		}
 	}
 
 	s.mu.Lock()
@@ -361,7 +392,7 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	}
 	sess.sink.setTurnContext(runCtx)
 	defer func() {
-		sess.sink.setTurnContext(nil)
+		sess.sink.clearTurnContext()
 		sess.finish()
 		cancel()
 	}()
@@ -369,11 +400,7 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 
 	// Persist after the turn (best-effort) so a crash loses at most this prompt;
 	// save even on cancel/error since the partial conversation is still resumable.
-	_ = sess.ctrl.Snapshot()
-	sess.touch(text)
-	if sess.transcript != "" {
-		_ = saveACPMeta(sess.transcript, sess.meta())
-	}
+	sess.persistAfterTurn(text)
 
 	stop := StopEndTurn
 	if runErr != nil {
@@ -401,7 +428,7 @@ func (s *service) sessionClose(_ context.Context, raw json.RawMessage) (any, err
 		return nil, err
 	}
 	if sess := s.takeSession(p.SessionID); sess != nil {
-		sess.abort()
+		sess.abortAndWait()
 		sess.ctrl.Close()
 	}
 	return SessionCloseResult{}, nil
@@ -472,7 +499,7 @@ func (s *service) sessionDelete(_ context.Context, raw json.RawMessage) (any, er
 
 	path := ""
 	if sess := s.takeSession(p.SessionID); sess != nil {
-		sess.abort()
+		sess.deleteAndWait()
 		sess.ctrl.Close()
 		path = sess.transcript
 	}
@@ -589,15 +616,28 @@ func (s *service) closeAll() {
 	}
 }
 
-func (s *acpSession) touch(prompt string) {
+func (s *acpSession) persistAfterTurn(prompt string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.deleted {
+		return
+	}
+	_ = s.ctrl.Snapshot()
 	if s.title == "" {
 		s.title = previewTitle(prompt)
 	}
 	s.updatedAt = time.Now().UTC()
 	if s.createdAt.IsZero() {
 		s.createdAt = s.updatedAt
+	}
+	if s.transcript != "" && sessionFileExists(s.transcript) {
+		_ = saveACPMeta(s.transcript, acpSessionMeta{
+			SessionID: s.id,
+			Cwd:       s.cwd,
+			Title:     s.title,
+			CreatedAt: s.createdAt,
+			UpdatedAt: s.updatedAt,
+		})
 	}
 }
 
@@ -754,7 +794,11 @@ func listACPMetas(dir string) ([]acpSessionMeta, error) {
 			continue
 		}
 		id := strings.TrimSuffix(e.Name(), ".acp.json")
-		meta, ok, err := loadACPMeta(transcriptPath(dir, id))
+		sessionPath := transcriptPath(dir, id)
+		if !sessionFileExists(sessionPath) {
+			continue
+		}
+		meta, ok, err := loadACPMeta(sessionPath)
 		if err != nil || !ok {
 			continue
 		}
@@ -767,6 +811,11 @@ func listACPMetas(dir string) ([]acpSessionMeta, error) {
 		out = append(out, meta)
 	}
 	return out, nil
+}
+
+func sessionFileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 func acpMetaPath(sessionPath string) string {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -6,13 +6,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"sync"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/fileutil"
 	"reasonix/internal/plugin"
+	"reasonix/internal/provider"
 )
 
 // SessionParams is everything a Factory needs to assemble one ACP session's
@@ -42,6 +48,12 @@ type Factory interface {
 	NewSession(ctx context.Context, p SessionParams) (*control.Controller, error)
 }
 
+// SessionDirProvider lets a Factory expose the persistent session directory
+// without forcing session/list to build a controller first.
+type SessionDirProvider interface {
+	SessionDir() string
+}
+
 // AgentInfo identifies this agent to clients in the initialize reply.
 type AgentInfo struct {
 	Name    string
@@ -66,7 +78,11 @@ func Serve(ctx context.Context, r io.Reader, w io.Writer, factory Factory, info 
 	conn.Handle("initialize", svc.initialize)
 	conn.Handle("session/new", svc.sessionNew)
 	conn.Handle("session/load", svc.sessionLoad)
+	conn.Handle("session/resume", svc.sessionResume)
 	conn.Handle("session/prompt", svc.sessionPrompt)
+	conn.Handle("session/close", svc.sessionClose)
+	conn.Handle("session/list", svc.sessionList)
+	conn.Handle("session/delete", svc.sessionDelete)
 	conn.HandleNotify("session/cancel", svc.sessionCancel)
 	defer svc.closeAll()
 	return conn.Serve(ctx)
@@ -89,15 +105,36 @@ type service struct {
 type acpSession struct {
 	id         string
 	ctrl       *control.Controller
+	sink       *updateSink
 	transcript string
+	cwd        string
+	title      string
+	createdAt  time.Time
+	updatedAt  time.Time
 
-	mu     sync.Mutex
-	cancel context.CancelFunc
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	running bool
 }
 
-func (s *acpSession) setCancel(c context.CancelFunc) {
+func (s *acpSession) begin(ctx context.Context) (context.Context, context.CancelFunc, bool) {
+	runCtx, cancel := context.WithCancel(ctx)
 	s.mu.Lock()
-	s.cancel = c
+	if s.running {
+		s.mu.Unlock()
+		cancel()
+		return nil, nil, false
+	}
+	s.running = true
+	s.cancel = cancel
+	s.mu.Unlock()
+	return runCtx, cancel, true
+}
+
+func (s *acpSession) finish() {
+	s.mu.Lock()
+	s.running = false
+	s.cancel = nil
 	s.mu.Unlock()
 }
 
@@ -110,15 +147,20 @@ func (s *acpSession) abort() {
 	}
 }
 
-// initialize advertises the agent's capability set: sessions can be resumed via
-// session/load (transcripts are keyed by session id under the session dir),
-// prompts carry inline resource text (embeddedContext) but not image/audio, and
-// MCP is stdio-only (no http/sse) — the latter three matching main.
+// initialize advertises the agent's capability set: persisted load plus ACP v1
+// list/resume/close/delete lifecycle helpers, prompts carrying inline resource
+// text (embeddedContext) but not image/audio, and stdio-only MCP (no http/sse).
 func (s *service) initialize(_ context.Context, _ json.RawMessage) (any, error) {
 	return InitializeResult{
 		ProtocolVersion: ProtocolVersion,
 		AgentCapabilities: AgentCapabilities{
 			LoadSession: true,
+			SessionCapabilities: SessionCapabilities{
+				List:   &EmptyCapability{},
+				Resume: &EmptyCapability{},
+				Close:  &EmptyCapability{},
+				Delete: &EmptyCapability{},
+			},
 			PromptCapabilities: PromptCapabilities{
 				Image:           false,
 				Audio:           false,
@@ -142,6 +184,14 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 			return nil, &RPCError{Code: ErrInvalidParams, Message: "session/new: " + err.Error()}
 		}
 	}
+	cwd, err := s.resolveSessionCwd(p.Cwd, "")
+	if err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/new: " + err.Error()}
+	}
+	mcpServers, err := mcpSpecs(p.MCPServers, cwd)
+	if err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/new: " + err.Error()}
+	}
 
 	id, err := newSessionID()
 	if err != nil {
@@ -150,8 +200,8 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 
 	sink := newUpdateSink(s.conn, id)
 	ctrl, err := s.factory.NewSession(ctx, SessionParams{
-		Cwd:        p.Cwd,
-		MCPServers: mcpSpecs(p.MCPServers),
+		Cwd:        cwd,
+		MCPServers: mcpServers,
 		Sink:       sink,
 	})
 	if err != nil {
@@ -160,13 +210,18 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	ctrl.EnableInteractiveApproval()
 	sink.bindApprove(ctrl.Approve)
 
-	sess := &acpSession{id: id, ctrl: ctrl}
+	now := time.Now().UTC()
+	sess := &acpSession{id: id, ctrl: ctrl, sink: sink, cwd: cwd, createdAt: now, updatedAt: now}
 	// Pin a transcript file keyed by session id when the controller has a session
 	// dir, so every turn auto-saves there, session/prompt can hand the path back,
 	// and session/load can find it again by id across process restarts.
 	if dir := ctrl.SessionDir(); dir != "" {
 		sess.transcript = transcriptPath(dir, id)
 		ctrl.SetSessionPath(sess.transcript)
+		if err := saveACPMeta(sess.transcript, sess.meta()); err != nil {
+			ctrl.Close()
+			return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
+		}
 	}
 
 	s.mu.Lock()
@@ -186,23 +241,53 @@ func (s *service) sessionLoad(ctx context.Context, raw json.RawMessage) (any, er
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/load: " + err.Error()}
 	}
-	if p.SessionID == "" {
-		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/load: missing sessionId"}
+	if err := s.openExistingSession(ctx, "session/load", p.SessionID, p.Cwd, p.MCPServers, true); err != nil {
+		return nil, err
+	}
+	return SessionLoadResult{}, nil
+}
+
+// sessionResume restores a previously-saved session without replaying its
+// conversation history to the client.
+func (s *service) sessionResume(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p SessionResumeParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/resume: " + err.Error()}
+	}
+	if err := s.openExistingSession(ctx, "session/resume", p.SessionID, p.Cwd, p.MCPServers, false); err != nil {
+		return nil, err
+	}
+	return SessionResumeResult{}, nil
+}
+
+func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam string, servers []MCPServerSpec, replay bool) error {
+	if err := validateSessionID(method, id); err != nil {
+		return err
+	}
+	cwd, err := s.resolveSessionCwd(cwdParam, id)
+	if err != nil {
+		return &RPCError{Code: ErrInvalidParams, Message: method + ": " + err.Error()}
+	}
+	mcpServers, err := mcpSpecs(servers, cwd)
+	if err != nil {
+		return &RPCError{Code: ErrInvalidParams, Message: method + ": " + err.Error()}
 	}
 
-	if sess := s.session(p.SessionID); sess != nil {
-		newUpdateSink(s.conn, p.SessionID).replay(sess.ctrl.History())
-		return SessionLoadResult{}, nil
+	if sess := s.session(id); sess != nil {
+		if replay {
+			newUpdateSink(s.conn, id).replay(sess.ctrl.History())
+		}
+		return nil
 	}
 
-	sink := newUpdateSink(s.conn, p.SessionID)
+	sink := newUpdateSink(s.conn, id)
 	ctrl, err := s.factory.NewSession(ctx, SessionParams{
-		Cwd:        p.Cwd,
-		MCPServers: mcpSpecs(p.MCPServers),
+		Cwd:        cwd,
+		MCPServers: mcpServers,
 		Sink:       sink,
 	})
 	if err != nil {
-		return nil, &RPCError{Code: ErrInternal, Message: "session/load: " + err.Error()}
+		return &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
 	ctrl.EnableInteractiveApproval()
 	sink.bindApprove(ctrl.Approve)
@@ -210,23 +295,39 @@ func (s *service) sessionLoad(ctx context.Context, raw json.RawMessage) (any, er
 	dir := ctrl.SessionDir()
 	if dir == "" {
 		ctrl.Close()
-		return nil, &RPCError{Code: ErrInternal, Message: "session/load: persistence is disabled"}
+		return &RPCError{Code: ErrInternal, Message: method + ": persistence is disabled"}
 	}
-	path := transcriptPath(dir, p.SessionID)
+	path := transcriptPath(dir, id)
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
 		ctrl.Close()
-		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/load: unknown session " + p.SessionID}
+		return &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
 	}
 	ctrl.Resume(loaded, path)
 
-	sess := &acpSession{id: p.SessionID, ctrl: ctrl, transcript: path}
+	meta := metadataForLoadedSession(path, id, cwd, ctrl.History())
+	sess := &acpSession{
+		id:         id,
+		ctrl:       ctrl,
+		sink:       sink,
+		transcript: path,
+		cwd:        meta.Cwd,
+		title:      meta.Title,
+		createdAt:  meta.CreatedAt,
+		updatedAt:  meta.UpdatedAt,
+	}
+	if err := saveACPMeta(path, sess.meta()); err != nil {
+		ctrl.Close()
+		return &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
+	}
 	s.mu.Lock()
-	s.sessions[p.SessionID] = sess
+	s.sessions[id] = sess
 	s.mu.Unlock()
 
-	sink.replay(ctrl.History())
-	return SessionLoadResult{}, nil
+	if replay {
+		sink.replay(ctrl.History())
+	}
+	return nil
 }
 
 // transcriptPath is where a session's transcript lives — keyed by id so
@@ -254,15 +355,25 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/prompt: empty prompt"}
 	}
 
-	runCtx, cancel := context.WithCancel(ctx)
-	sess.setCancel(cancel)
-	runErr := sess.ctrl.Run(runCtx, text)
-	sess.setCancel(nil)
-	cancel()
+	runCtx, cancel, ok := sess.begin(ctx)
+	if !ok {
+		return nil, &RPCError{Code: ErrInvalidRequest, Message: "session/prompt: session already has an active prompt"}
+	}
+	sess.sink.setTurnContext(runCtx)
+	defer func() {
+		sess.sink.setTurnContext(nil)
+		sess.finish()
+		cancel()
+	}()
+	runErr := sess.ctrl.RunTurn(runCtx, text)
 
 	// Persist after the turn (best-effort) so a crash loses at most this prompt;
 	// save even on cancel/error since the partial conversation is still resumable.
 	_ = sess.ctrl.Snapshot()
+	sess.touch(text)
+	if sess.transcript != "" {
+		_ = saveACPMeta(sess.transcript, sess.meta())
+	}
 
 	stop := StopEndTurn
 	if runErr != nil {
@@ -277,6 +388,105 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		res.TranscriptPath = &sess.transcript
 	}
 	return res, nil
+}
+
+// sessionClose releases an active session. Unknown sessions are accepted as a
+// no-op because closing is an idempotent resource cleanup request.
+func (s *service) sessionClose(_ context.Context, raw json.RawMessage) (any, error) {
+	var p SessionCloseParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/close: " + err.Error()}
+	}
+	if err := validateSessionID("session/close", p.SessionID); err != nil {
+		return nil, err
+	}
+	if sess := s.takeSession(p.SessionID); sess != nil {
+		sess.abort()
+		sess.ctrl.Close()
+	}
+	return SessionCloseResult{}, nil
+}
+
+// sessionList returns ACP sessions known to this process or persisted as ACP
+// sidecars. It deliberately ignores ordinary CLI timestamp sessions.
+func (s *service) sessionList(_ context.Context, raw json.RawMessage) (any, error) {
+	var p SessionListParams
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, &RPCError{Code: ErrInvalidParams, Message: "session/list: " + err.Error()}
+		}
+	}
+	filterCwd := strings.TrimSpace(p.Cwd)
+	if filterCwd != "" && !filepath.IsAbs(filterCwd) {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/list: cwd must be an absolute path"}
+	}
+	if strings.TrimSpace(p.Cursor) != "" {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/list: unsupported cursor"}
+	}
+
+	byID := map[string]SessionInfo{}
+	if dir := s.sessionDir(); dir != "" {
+		metas, err := listACPMetas(dir)
+		if err != nil {
+			return nil, &RPCError{Code: ErrInternal, Message: "session/list: " + err.Error()}
+		}
+		for _, meta := range metas {
+			info := meta.info(nil)
+			if sessionInfoMatchesCwd(info, filterCwd) {
+				byID[info.SessionID] = info
+			}
+		}
+	}
+	for _, sess := range s.liveSessions() {
+		info := sess.info()
+		if sessionInfoMatchesCwd(info, filterCwd) {
+			byID[info.SessionID] = info
+		}
+	}
+
+	sessions := make([]SessionInfo, 0, len(byID))
+	for _, info := range byID {
+		sessions = append(sessions, info)
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		ti := parseSessionUpdatedAt(sessions[i].UpdatedAt)
+		tj := parseSessionUpdatedAt(sessions[j].UpdatedAt)
+		if ti.Equal(tj) {
+			return sessions[i].SessionID < sessions[j].SessionID
+		}
+		return ti.After(tj)
+	})
+	return SessionListResult{Sessions: sessions}, nil
+}
+
+// sessionDelete removes a session from future list results. Deleting a missing
+// session succeeds silently, matching ACP's idempotent delete guidance.
+func (s *service) sessionDelete(_ context.Context, raw json.RawMessage) (any, error) {
+	var p SessionDeleteParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/delete: " + err.Error()}
+	}
+	if err := validateSessionID("session/delete", p.SessionID); err != nil {
+		return nil, err
+	}
+
+	path := ""
+	if sess := s.takeSession(p.SessionID); sess != nil {
+		sess.abort()
+		sess.ctrl.Close()
+		path = sess.transcript
+	}
+	if path == "" {
+		if dir := s.sessionDir(); dir != "" {
+			path = transcriptPath(dir, p.SessionID)
+		}
+	}
+	if path != "" {
+		if err := deleteSessionFiles(path); err != nil {
+			return nil, &RPCError{Code: ErrInternal, Message: "session/delete: " + err.Error()}
+		}
+	}
+	return SessionDeleteResult{}, nil
 }
 
 // sessionCancel aborts a session's in-flight turn, if any. It is a notification:
@@ -297,6 +507,75 @@ func (s *service) session(id string) *acpSession {
 	return s.sessions[id]
 }
 
+func (s *service) takeSession(id string) *acpSession {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess := s.sessions[id]
+	delete(s.sessions, id)
+	return sess
+}
+
+func (s *service) liveSessions() []*acpSession {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]*acpSession, 0, len(s.sessions))
+	for _, sess := range s.sessions {
+		out = append(out, sess)
+	}
+	return out
+}
+
+func (s *service) sessionDir() string {
+	if p, ok := s.factory.(SessionDirProvider); ok {
+		if dir := strings.TrimSpace(p.SessionDir()); dir != "" {
+			return dir
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, sess := range s.sessions {
+		if dir := sess.ctrl.SessionDir(); dir != "" {
+			return dir
+		}
+	}
+	return ""
+}
+
+func (s *service) resolveSessionCwd(cwd, sessionID string) (string, error) {
+	cwd = strings.TrimSpace(cwd)
+	if cwd != "" {
+		if !filepath.IsAbs(cwd) {
+			return "", fmt.Errorf("cwd must be an absolute path")
+		}
+		return filepath.Clean(cwd), nil
+	}
+	if sessionID != "" {
+		if meta, ok := s.loadMeta(sessionID); ok && meta.Cwd != "" {
+			if !filepath.IsAbs(meta.Cwd) {
+				return "", fmt.Errorf("stored cwd must be an absolute path")
+			}
+			return filepath.Clean(meta.Cwd), nil
+		}
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("resolve cwd: %w", err)
+	}
+	return wd, nil
+}
+
+func (s *service) loadMeta(id string) (acpSessionMeta, bool) {
+	dir := s.sessionDir()
+	if dir == "" {
+		return acpSessionMeta{}, false
+	}
+	meta, ok, err := loadACPMeta(transcriptPath(dir, id))
+	if err != nil {
+		return acpSessionMeta{}, false
+	}
+	return meta, ok
+}
+
 // closeAll tears down every open session (aborting any in-flight turn and
 // stopping its MCP subprocesses) when the connection ends.
 func (s *service) closeAll() {
@@ -310,23 +589,326 @@ func (s *service) closeAll() {
 	}
 }
 
+func (s *acpSession) touch(prompt string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.title == "" {
+		s.title = previewTitle(prompt)
+	}
+	s.updatedAt = time.Now().UTC()
+	if s.createdAt.IsZero() {
+		s.createdAt = s.updatedAt
+	}
+}
+
+func (s *acpSession) meta() acpSessionMeta {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return acpSessionMeta{
+		SessionID: s.id,
+		Cwd:       s.cwd,
+		Title:     s.title,
+		CreatedAt: s.createdAt,
+		UpdatedAt: s.updatedAt,
+	}
+}
+
+func (s *acpSession) info() SessionInfo {
+	meta := s.meta()
+	extra := map[string]any{}
+	if n := len(s.ctrl.History()); n > 0 {
+		extra["messageCount"] = n
+	}
+	if len(extra) == 0 {
+		extra = nil
+	}
+	return meta.info(extra)
+}
+
+type acpSessionMeta struct {
+	SessionID string    `json:"sessionId"`
+	Cwd       string    `json:"cwd"`
+	Title     string    `json:"title,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+func (m acpSessionMeta) info(extra map[string]any) SessionInfo {
+	updatedAt := ""
+	if !m.UpdatedAt.IsZero() {
+		updatedAt = m.UpdatedAt.Format(time.RFC3339Nano)
+	}
+	return SessionInfo{
+		SessionID: m.SessionID,
+		Cwd:       m.Cwd,
+		Title:     m.Title,
+		UpdatedAt: updatedAt,
+		Meta:      extra,
+	}
+}
+
+func metadataForLoadedSession(path, id, cwd string, history []provider.Message) acpSessionMeta {
+	now := time.Now().UTC()
+	meta, ok, err := loadACPMeta(path)
+	if err != nil || !ok {
+		meta = acpSessionMeta{
+			SessionID: id,
+			Cwd:       cwd,
+			Title:     titleFromHistory(history),
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if info, statErr := os.Stat(path); statErr == nil {
+			meta.CreatedAt = info.ModTime().UTC()
+			meta.UpdatedAt = info.ModTime().UTC()
+		}
+	}
+	if meta.SessionID == "" {
+		meta.SessionID = id
+	}
+	if cwd != "" {
+		meta.Cwd = cwd
+	}
+	if meta.Title == "" {
+		meta.Title = titleFromHistory(history)
+	}
+	if meta.CreatedAt.IsZero() {
+		meta.CreatedAt = now
+	}
+	if meta.UpdatedAt.IsZero() {
+		meta.UpdatedAt = meta.CreatedAt
+	}
+	return meta
+}
+
+func loadACPMeta(sessionPath string) (acpSessionMeta, bool, error) {
+	path := acpMetaPath(sessionPath)
+	if path == "" {
+		return acpSessionMeta{}, false, nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return acpSessionMeta{}, false, nil
+		}
+		return acpSessionMeta{}, false, err
+	}
+	var meta acpSessionMeta
+	if err := json.Unmarshal(b, &meta); err != nil {
+		return acpSessionMeta{}, false, fmt.Errorf("decode ACP session metadata %s: %w", path, err)
+	}
+	return meta, true, nil
+}
+
+func saveACPMeta(sessionPath string, meta acpSessionMeta) error {
+	path := acpMetaPath(sessionPath)
+	if path == "" {
+		return nil
+	}
+	now := time.Now().UTC()
+	if meta.SessionID == "" {
+		meta.SessionID = sessionIDFromTranscript(sessionPath)
+	}
+	if meta.CreatedAt.IsZero() {
+		meta.CreatedAt = now
+	}
+	if meta.UpdatedAt.IsZero() {
+		meta.UpdatedAt = meta.CreatedAt
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".acp-session.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, path)
+}
+
+func listACPMetas(dir string) ([]acpSessionMeta, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := []acpSessionMeta{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".acp.json") {
+			continue
+		}
+		id := strings.TrimSuffix(e.Name(), ".acp.json")
+		meta, ok, err := loadACPMeta(transcriptPath(dir, id))
+		if err != nil || !ok {
+			continue
+		}
+		if meta.SessionID == "" {
+			meta.SessionID = id
+		}
+		if meta.Cwd == "" {
+			continue
+		}
+		out = append(out, meta)
+	}
+	return out, nil
+}
+
+func acpMetaPath(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return strings.TrimSuffix(sessionPath, filepath.Ext(sessionPath)) + ".acp.json"
+}
+
+func sessionIDFromTranscript(path string) string {
+	base := filepath.Base(path)
+	if ext := filepath.Ext(base); ext != "" {
+		base = strings.TrimSuffix(base, ext)
+	}
+	return base
+}
+
+func sessionInfoMatchesCwd(info SessionInfo, filter string) bool {
+	if filter == "" {
+		return true
+	}
+	return filepath.Clean(info.Cwd) == filepath.Clean(filter)
+}
+
+func titleFromHistory(history []provider.Message) string {
+	for _, m := range history {
+		if m.Role == provider.RoleUser {
+			if title := previewTitle(m.Content); title != "" {
+				return title
+			}
+		}
+	}
+	return ""
+}
+
+func previewTitle(text string) string {
+	text = strings.Join(strings.Fields(text), " ")
+	if len([]rune(text)) <= 80 {
+		return text
+	}
+	runes := []rune(text)
+	return string(runes[:77]) + "..."
+}
+
+func validateSessionID(method, id string) error {
+	trimmed := strings.TrimSpace(id)
+	if trimmed == "" {
+		return &RPCError{Code: ErrInvalidParams, Message: method + ": missing sessionId"}
+	}
+	if trimmed != id || trimmed == "." || trimmed == ".." || !isSafeSessionID(trimmed) {
+		return &RPCError{Code: ErrInvalidParams, Message: method + ": invalid sessionId"}
+	}
+	return nil
+}
+
+func isSafeSessionID(id string) bool {
+	for _, r := range id {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		if r == '-' || r == '_' || r == '.' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func parseSessionUpdatedAt(s string) time.Time {
+	t, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
+func deleteSessionFiles(sessionPath string) error {
+	paths := []string{
+		sessionPath,
+		sessionPath + ".meta",
+		acpMetaPath(sessionPath),
+	}
+	for _, path := range paths {
+		if path == "" {
+			continue
+		}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if dir := checkpointPath(sessionPath); dir != "" {
+		if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkpointPath(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return strings.TrimSuffix(sessionPath, ".jsonl") + ".ckpt"
+}
+
 // mcpSpecs converts ACP stdio MCP server declarations to plugin.Spec. ACP's
 // session/new only carries stdio servers (the agent advertises http/sse off).
-func mcpSpecs(in []MCPServerSpec) []plugin.Spec {
+func mcpSpecs(in []MCPServerSpec, cwd string) ([]plugin.Spec, error) {
 	if len(in) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]plugin.Spec, 0, len(in))
 	for _, m := range in {
+		typ := strings.ToLower(strings.TrimSpace(m.Type))
+		if typ == "" {
+			typ = "stdio"
+		}
+		if typ != "stdio" {
+			return nil, fmt.Errorf("MCP server %q uses unsupported transport %q", m.Name, m.Type)
+		}
+		if strings.TrimSpace(m.Name) == "" {
+			return nil, fmt.Errorf("MCP server name is required")
+		}
+		if strings.TrimSpace(m.Command) == "" {
+			return nil, fmt.Errorf("MCP server %q command is required", m.Name)
+		}
 		out = append(out, plugin.Spec{
 			Name:    m.Name,
-			Type:    "stdio",
+			Type:    typ,
 			Command: m.Command,
 			Args:    m.Args,
-			Env:     m.Env,
+			Env:     map[string]string(m.Env),
+			Dir:     cwd,
 		})
 	}
-	return out
+	return out, nil
 }
 
 // newSessionID returns a random RFC 4122 v4 UUID string used to address a session.

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -70,6 +70,10 @@ type Options struct {
 	// so each tab loads its own config/skills/hooks without changing the process
 	// cwd — enabling concurrent multi-project sessions.
 	WorkspaceRoot string
+	// ExtraPlugins are session-scoped MCP servers supplied by a host transport
+	// (for example ACP session/new). They are connected eagerly for this
+	// controller but are not persisted to reasonix.toml.
+	ExtraPlugins []plugin.Spec
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -302,6 +306,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				Text: "codegraph: not installed — run `reasonix codegraph install` to enable symbol-graph tools"})
 		}
 	}
+	eagerSpecs = append(eagerSpecs, opts.ExtraPlugins...)
 
 	// Apply caller-supplied stderr override to every spec across tiers.
 	if opts.Stderr != nil {

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -6,21 +6,15 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 
 	"reasonix/internal/acp"
-	"reasonix/internal/agent"
 	"reasonix/internal/boot"
-	"reasonix/internal/command"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
-	"reasonix/internal/event"
 	"reasonix/internal/i18n"
-	"reasonix/internal/instruction"
-	"reasonix/internal/memory"
 	"reasonix/internal/netclient"
-	"reasonix/internal/permission"
-	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/tool"
@@ -42,29 +36,10 @@ func acpCommand(args []string, version string) int {
 		return 2
 	}
 
-	cfg, err := config.Load()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-		return 1
-	}
-	modelName := *model
-	if modelName == "" {
-		modelName = cfg.DefaultModel
-	}
-	// Fail fast on a missing/invalid key, with stderr (never stdout) so the wire
-	// stays clean, rather than failing per-session deep inside session/new.
-	if err := cfg.Validate(modelName); err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-		return 1
-	}
-	if cfg.BashMode() == "enforce" && !sandbox.Available() {
-		fmt.Fprintln(os.Stderr, "warning: bash sandbox requested but unavailable on this platform; running bash unconfined")
-	}
-
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	factory := &acpFactory{cfg: cfg, model: modelName}
+	factory := &acpFactory{model: *model}
 	info := acp.AgentInfo{Name: "reasonix", Version: version}
 	if err := acp.Serve(ctx, os.Stdin, os.Stdout, factory, info); err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -73,139 +48,38 @@ func acpCommand(args []string, version string) int {
 	return 0
 }
 
-// acpFactory builds one control.Controller per ACP session. It mirrors setup()'s
-// assembly, with two differences that make sessions independent: the built-in
-// tools are bound to the session's cwd via builtin.Workspace (so concurrent
-// sessions have separate path roots), and the client's per-session MCP servers
-// are connected alongside the config's own plugins.
+// acpFactory builds one control.Controller per ACP session by reusing boot.Build
+// with the session cwd as WorkspaceRoot. That keeps ACP aligned with chat,
+// desktop, and serve assembly while still adding the host-supplied MCP servers
+// for this session only.
 type acpFactory struct {
-	cfg   *config.Config
 	model string
+}
+
+func (f *acpFactory) SessionDir() string {
+	return config.SessionDir()
 }
 
 // NewSession assembles the per-session controller. Resources (MCP subprocesses)
 // are released via the controller's Cleanup, run on ctrl.Close().
 func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*control.Controller, error) {
-	cfg := f.cfg
-	entry, ok := cfg.ResolveModel(f.model)
-	if !ok {
-		return nil, fmt.Errorf("unknown model %q", f.model)
-	}
-	proxySpec := cfg.NetworkProxySpec()
-	execProv, err := boot.NewProviderWithProxy(entry, proxySpec)
-	if err != nil {
-		return nil, err
-	}
-	sysPrompt, err := cfg.ResolveSystemPrompt()
-	if err != nil {
-		return nil, err
-	}
-	mem := memory.Load(memory.Options{CWD: p.Cwd, UserDir: config.MemoryUserDir()})
-	projectChecks := instruction.ExtractHostChecks(mem.Docs)
-	sysPrompt = memory.Compose(sysPrompt, mem)
-
-	// Built-ins rooted at the session cwd. Writes confine to that cwd by default
-	// (Workspace makes Dir the sole write root when WriteRoots is empty), which is
-	// the right scope for a client that opened the session on a project; an empty
-	// cwd falls back to process-cwd tools, identical to the headless run.
-	reg := tool.NewRegistry()
-	var writeRoots []string
-	if p.Cwd != "" {
-		writeRoots = []string{p.Cwd}
-	}
-	for _, t := range acpBuiltinTools(cfg, p.Cwd, writeRoots) {
-		reg.Add(t)
-	}
-
-	// MCP: the config's own plugins plus the servers the client passed in
-	// session/new, all connected for the session's lifetime.
-	cleanup := func() {}
-	var host *plugin.Host
-	specs := append(boot.PluginSpecs(cfg.AutoStartPlugins()), p.MCPServers...)
-	if len(specs) > 0 {
-		h, ptools := plugin.StartAvailable(ctx, specs)
-		host = h
-		cleanup = h.Close
-		for _, t := range ptools {
-			reg.Add(t)
-		}
-		// Mirror boot.Build: phase B (prompts + resources) is deferred to a
-		// background goroutine on the session ctx so the ACP path also sees
-		// non-empty Host.Prompts()/Resources() once the auxiliary surfaces
-		// stream in. Without this, MCPPrompt and @-ref consumers would stay
-		// empty for the session.
-		go h.StartPhaseB(ctx, p.Sink)
-		if text, ok := boot.MCPStartupNotice(h.Failures()); ok {
-			p.Sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
+	root := strings.TrimSpace(p.Cwd)
+	if root == "" {
+		if wd, err := os.Getwd(); err == nil {
+			root = wd
 		}
 	}
-
-	maxSteps := cfg.Agent.MaxSteps
-	policy := permission.New(cfg.Permissions.Mode, cfg.Permissions.Allow, cfg.Permissions.Ask, cfg.Permissions.Deny)
-	headlessGate := permission.NewGate(policy, nil)
-	taskModel, taskEffort := acpTaskProfileDefaults(cfg)
-	resolveSubagentProvider := newACPSubagentProviderResolver(cfg, entry, proxySpec)
-	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
-		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
-		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate,
-		taskModel, taskEffort, resolveSubagentProvider))
-
-	executor := agent.New(execProv, reg, agent.NewSession(sysPrompt), agent.Options{
-		MaxSteps:          maxSteps,
-		Temperature:       cfg.Agent.Temperature,
-		Pricing:           entry.Price,
-		Gate:              headlessGate,
-		ProjectChecks:     projectChecks,
-		ContextWindow:     entry.ContextWindow,
-		SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
-		CompactRatio:      cfg.Agent.CompactRatio,
-		CompactForceRatio: cfg.Agent.CompactForceRatio,
-		ArchiveDir:        config.ArchiveDir(),
-	}, p.Sink)
-
-	cmds, _ := command.Load(config.CommandDirs()...)
-
-	var runner agent.Runner = executor
-	label := entry.Model
-	if pm := cfg.Agent.PlannerModel; pm != "" {
-		pe, ok := cfg.ResolveModel(pm)
-		if !ok {
-			cleanup()
-			return nil, fmt.Errorf("planner_model %q is not a configured provider", pm)
-		}
-		if pe.Model != entry.Model {
-			plannerProv, err := boot.NewProviderWithProxy(pe, proxySpec)
-			if err != nil {
-				cleanup()
-				return nil, fmt.Errorf("planner %q: %w", pm, err)
-			}
-			plannerSess := agent.NewSession(agent.PlannerPromptWithContext(mem.Block()))
-			plannerTools := agent.PlannerToolRegistry(reg)
-			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, plannerTools, agent.Options{
-				MaxSteps:          agent.PlannerMaxSteps(maxSteps),
-				Gate:              headlessGate,
-				ContextWindow:     pe.ContextWindow,
-				SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
-				CompactRatio:      cfg.Agent.CompactRatio,
-				CompactForceRatio: cfg.Agent.CompactForceRatio,
-				ArchiveDir:        config.ArchiveDir(),
-			}, executor, cfg.Agent.Temperature, p.Sink, control.TaskWarrantsPlanner)
-			label = entry.Model + " + planner " + pe.Model
-		}
+	if root != "" && !filepath.IsAbs(root) {
+		return nil, fmt.Errorf("session cwd must be an absolute path: %s", root)
 	}
-
-	return control.New(control.Options{
-		Runner:       runner,
-		Executor:     executor,
-		Sink:         p.Sink,
-		Policy:       policy,
-		Label:        label,
-		SystemPrompt: sysPrompt,
-		SessionDir:   config.SessionDir(),
-		Host:         host,
-		Commands:     cmds,
-		Cleanup:      cleanup,
-	}), nil
+	return boot.Build(ctx, boot.Options{
+		Model:         f.model,
+		RequireKey:    true,
+		Sink:          p.Sink,
+		Stderr:        os.Stderr,
+		WorkspaceRoot: root,
+		ExtraPlugins:  p.MCPServers,
+	})
 }
 
 func acpBuiltinTools(cfg *config.Config, cwd string, writeRoots []string) []tool.Tool {

--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -2,9 +2,14 @@ package cli
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"reasonix/internal/acp"
 	"reasonix/internal/config"
+	"reasonix/internal/event"
 	"reasonix/internal/netclient"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
@@ -35,6 +40,73 @@ func TestACPBuiltinToolsKeepSessionLevelBuiltins(t *testing.T) {
 			t.Fatalf("ACP workspace tools missing %q; got %v", name, toolNames(tools))
 		}
 	}
+}
+
+func TestACPInitializesWithoutAPIKey(t *testing.T) {
+	isolateCLIConfigHome(t)
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	oldStdin := os.Stdin
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = w.WriteString(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1}}` + "\n")
+	_ = w.Close()
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = oldStdin
+		_ = r.Close()
+	})
+
+	out := captureStdout(t, func() {
+		if rc := Run([]string{"--acp"}, "test-version"); rc != 0 {
+			t.Fatalf("Run --acp initialize rc = %d, want 0", rc)
+		}
+	})
+	if !strings.Contains(out, `"protocolVersion":1`) || !strings.Contains(out, `"name":"reasonix"`) {
+		t.Fatalf("initialize output = %s", out)
+	}
+}
+
+func TestACPFactoryLoadsSessionCwdProjectConfig(t *testing.T) {
+	home := isolateCLIConfigHome(t)
+	t.Setenv("REASONIX_TEST_KEY", "test-key")
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
+default_model = "local"
+
+[[providers]]
+name = "local"
+kind = "acp-test-provider"
+base_url = "http://example.invalid"
+model = "fake-model"
+api_key_env = "REASONIX_TEST_KEY"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmdDir := filepath.Join(project, ".reasonix", "commands")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmdDir, "acp-only.md"), []byte("ACP project command"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(home); err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl, err := (&acpFactory{}).NewSession(context.Background(), acp.SessionParams{Cwd: project, Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, cmd := range ctrl.Commands() {
+		if cmd.Name == "acp-only" {
+			return
+		}
+	}
+	t.Fatalf("ACP session did not load project command from cwd; commands=%v", ctrl.Commands())
 }
 
 func TestACPTaskProfileDefaults(t *testing.T) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -44,6 +44,9 @@ func Run(args []string, version string) int {
 	if len(args) > 0 {
 		cmd = args[0]
 	}
+	if cmd == "--acp" {
+		cmd = "acp"
+	}
 	if shouldMigrateLegacyConfigForCLI(cmd) {
 		migrateLegacyConfigForCLI()
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -97,6 +97,20 @@ func TestMetadataCommandsDoNotProbeTerminalTheme(t *testing.T) {
 	}
 }
 
+func TestRunDispatchesACPLongFlagAlias(t *testing.T) {
+	errOut := captureStderr(t, func() {
+		if rc := Run([]string{"--acp", "-h"}, "test-version"); rc != 2 {
+			t.Fatalf("Run --acp -h rc = %d, want 2", rc)
+		}
+	})
+	if !strings.Contains(errOut, "Usage of acp:") {
+		t.Fatalf("--acp should dispatch to the ACP command, got stderr:\n%s", errOut)
+	}
+	if strings.Contains(errOut, "unknown command") {
+		t.Fatalf("--acp should not be treated as an unknown command:\n%s", errOut)
+	}
+}
+
 func TestRunMigratesLegacyConfigBeforeConfigOnlyCommands(t *testing.T) {
 	isolateCLIConfigHome(t)
 	legacyPath := filepath.Join(filepath.Dir(config.UserConfigPath()), "reasonix.toml")
@@ -688,4 +702,25 @@ func TestWriteDefaultConfigDisablesCodegraph(t *testing.T) {
 	if c := config.LoadForEdit(path); c.Codegraph.Enabled {
 		t.Fatal("a freshly scaffolded config left codegraph enabled; new users should start without it")
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = old }()
+
+	fn()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -45,6 +46,10 @@ import (
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
+
+// ErrTurnRunning reports that a caller tried to start a second foreground turn
+// while one is already active in the same Controller.
+var ErrTurnRunning = errors.New("turn already running")
 
 // Controller drives one chat session. Construct with New; drive with the command
 // methods; observe through the Sink passed in Options.
@@ -349,6 +354,32 @@ const planApprovedMessage = "Plan approved — plan mode is off; you're cleared 
 // `Run` path (which doesn't call this) never blocks on a prompt.
 func (c *Controller) runTurn(ctx context.Context, input string) error {
 	return c.runTurnWithRaw(ctx, input, input)
+}
+
+// RunTurn executes one foreground turn synchronously through the same lifecycle
+// used by interactive frontends: auto-plan, transient memory/background-job
+// composition, checkpoints, hooks, and plan approval. It is for transports that
+// need a blocking request/response boundary, such as ACP session/prompt.
+func (c *Controller) RunTurn(ctx context.Context, input string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	c.mu.Lock()
+	if c.running {
+		c.mu.Unlock()
+		cancel()
+		return ErrTurnRunning
+	}
+	c.cancel = cancel
+	c.running = true
+	c.mu.Unlock()
+
+	defer func() {
+		c.mu.Lock()
+		c.running = false
+		c.cancel = nil
+		c.mu.Unlock()
+		cancel()
+	}()
+	return c.runTurn(ctx, input)
 }
 
 func (c *Controller) runTurnWithRaw(ctx context.Context, input, raw string) error {

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -308,6 +308,7 @@ Usage:
   reasonix chat [--model NAME] [-c|--continue] [--resume]   interactive session (multi-turn; -c resumes the latest, --resume picks one)
   reasonix run  [--model NAME] [--max-steps N] <task>   run one task and exit
   reasonix serve [--model NAME] [--addr HOST:PORT]      serve the session over HTTP+SSE (browser client at /)
+  reasonix acp [--model NAME]                           serve Agent Client Protocol over stdio (also: reasonix --acp)
   reasonix setup [path]                                 interactive config wizard; writes reasonix.toml (+ .env)
   reasonix config auto-plan [off|on]                    configure automatic plan mode
   reasonix mcp <add|remove|list>                        manage MCP servers in reasonix.toml

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -309,6 +309,7 @@ var Chinese = Messages{
   reasonix chat [--model NAME] [-c|--continue] [--resume]   交互式会话（多轮；-c 恢复最近一次，--resume 选择一个）
   reasonix run  [--model NAME] [--max-steps N] <task>   执行单次任务后退出
   reasonix serve [--model NAME] [--addr HOST:PORT]      通过 HTTP+SSE 提供会话（浏览器客户端在 /）
+  reasonix acp [--model NAME]                           通过 stdio 提供 Agent Client Protocol（也可用：reasonix --acp）
   reasonix setup [path]                                 交互式配置向导；生成 reasonix.toml（及 .env）
   reasonix config auto-plan [off|on]                    配置自动计划模式
   reasonix mcp <add|remove|list>                        管理 reasonix.toml 里的 MCP 服务器


### PR DESCRIPTION
## Summary
- make `reasonix --acp` dispatch to the ACP subcommand and defer API-key validation until a session actually starts
- reuse `boot.Build` for ACP session assembly, including session-rooted cwd and host-supplied stdio MCP servers
- add ACP v1 `session/resume`, `session/close`, `session/list`, and `session/delete` support with sidecar metadata for list/filter/delete semantics
- accept official MCP env arrays while preserving legacy map env compatibility; tighten MCP transport and session-id validation
- fix prompt concurrency, cancellation-scoped permission requests, and UTF-8-safe ACP update clipping

## Cache impact
Low. The change does not modify provider request serialization, system prompt templates, or tool schema generation. ACP sessions now reuse `boot.Build`, so existing ACP clients may see a one-time cold cache boundary compared with the old hand-built ACP assembly, but the long-term stable prefix/tool ordering is aligned with the main session path.

## Verification
- `go test ./internal/acp ./internal/cli ./internal/control ./internal/boot`
- `go test ./...`

## Related
- Overlaps with the MCP env-array part of #3167, but keeps backward compatibility and covers the broader ACP lifecycle surface.