### PR TITLE
Fix workspace panel resizer hover / 修复右侧文件面板拖拽提示色

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -573,6 +573,8 @@ a[href] {
   background: var(--border-soft);
   transition: background 0.12s, box-shadow 0.12s;
 }
+.workspace-panel-resizer:hover::after,
+.workspace-panel-resizer:focus-visible::after,
 .layout--workspace-resizing .workspace-panel-resizer::after {
   background: var(--accent);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent);


### PR DESCRIPTION
## Summary

- Add hover and focus-visible accent styling to the right workspace panel resizer.
- Align the "Files & Git" dock resize affordance with the left sidebar, drawers, and inner workspace tree resizer.

## Root Cause

The outer workspace panel resizer only applied the accent color while actively resizing. Unlike the other resize handles, it did not include `:hover` or `:focus-visible` selectors, so users did not get a theme-color hint before dragging.

## Validation

- `pnpm --ignore-workspace run build`
- Browser hover check on the Vite dev page: the resizer changed from `rgb(37, 42, 52)` to the accent `rgb(217, 119, 87)` and applied the hover shadow.
- `git diff --check`

Fixes #3390