### PR TITLE
Fix desktop display replay for composed prompts / 修复组合提示词的桌面历史显示

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -495,7 +495,7 @@ func (a *App) SubmitToTab(tabID, input string) {
 		return
 	}
 	if ctrl := a.ctrlByTabID(tabID); ctrl != nil {
-		ctrl.Submit(input)
+		ctrl.SubmitDisplay(input, input)
 	}
 }
 
@@ -518,8 +518,20 @@ func (a *App) SubmitDisplayToTab(tabID, display, input string) {
 	if ctrl == nil {
 		return
 	}
-	_ = recordSessionDisplay(config.SessionDir(), ctrl.SessionPath(), input, display)
-	ctrl.Submit(input)
+	ctrl.SubmitDisplay(display, input)
+}
+
+func (a *App) bindControllerDisplayRecorder(ctrl *control.Controller) {
+	if ctrl == nil {
+		return
+	}
+	ctrl.SetDisplayRecorder(func(content, display string) {
+		dir := ctrl.SessionDir()
+		if dir == "" {
+			dir = config.SessionDir()
+		}
+		_ = recordSessionDisplay(dir, ctrl.SessionPath(), content, display)
+	})
 }
 
 // Cancel aborts the in-flight turn.
@@ -2545,6 +2557,7 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	if err != nil {
 		return err
 	}
+	a.bindControllerDisplayRecorder(newCtrl)
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
 	tab.model = name
@@ -2634,6 +2647,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	if err != nil {
 		return err
 	}
+	a.bindControllerDisplayRecorder(newCtrl)
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
 	tab.effort = &effort

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -33,6 +33,7 @@ func (a *App) setTestCtrl(ctrl *control.Controller, model string) {
 	}
 	tab := a.tabs["test"]
 	tab.Ctrl = ctrl
+	a.bindControllerDisplayRecorder(ctrl)
 	tab.model = model
 }
 
@@ -511,6 +512,54 @@ func (r *appendingDesktopRunner) Run(_ context.Context, input string) error {
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 	r.session.Add(provider.Message{Role: provider.RoleAssistant, Content: "ok"})
 	return nil
+}
+
+func TestSubmitToTabHistoryDisplaysRawInputAfterMemoryCompose(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "memory-display.jsonl")
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	runner := &appendingDesktopRunner{session: sess, started: make(chan string, 1)}
+	ctrl := control.New(control.Options{
+		Runner:      runner,
+		Executor:    exec,
+		Sink:        event.Discard,
+		SessionDir:  dir,
+		SessionPath: path,
+		Label:       "test",
+	})
+	defer ctrl.Close()
+
+	app := NewApp()
+	app.setTestCtrl(ctrl, "deepseek/test")
+	ctrl.QueueMemory(`Saved memory "reasonix-contributions": contribution count updated`)
+
+	const prompt = "不要，删了"
+	app.SubmitToTab("test", prompt)
+	composed := <-runner.started
+	waitNotRunning(t, ctrl)
+
+	if !strings.Contains(composed, "<memory-update>") || !strings.HasSuffix(composed, prompt) {
+		t.Fatalf("model input should include memory update followed by prompt, got %q", composed)
+	}
+	got := app.HistoryForTab("test")
+	if len(got) < 2 {
+		t.Fatalf("history length = %d, want user + assistant", len(got))
+	}
+	if got[0].Role != "system" || got[1].Role != "user" {
+		t.Fatalf("history roles = %+v, want system then user", got[:min(len(got), 2)])
+	}
+	if got[1].Content != prompt {
+		t.Fatalf("displayed user content = %q, want %q", got[1].Content, prompt)
+	}
+	if strings.Contains(got[1].Content, "<memory-update>") {
+		t.Fatalf("displayed user content leaked memory update: %q", got[1].Content)
+	}
 }
 
 func TestForkCreatesActiveTabWithoutSwitchingSourceController(t *testing.T) {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -310,6 +310,7 @@ func (a *App) rebuild() error {
 		a.emitReady(a.ctx)
 		return err
 	}
+	a.bindControllerDisplayRecorder(ctrl)
 	a.mu.Lock()
 	tab.Ctrl = ctrl
 	tab.model = model

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -527,6 +527,7 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 		return
 	}
 
+	a.bindControllerDisplayRecorder(ctrl)
 	ctrl.EnableInteractiveApproval()
 	applyTabModeToController(ctrl, tab.mode)
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -141,6 +141,8 @@ type Controller struct {
 	// a fresh memory takes effect this session without busting the prompt cache;
 	// it joins the prefix naturally on the next session.
 	pendingMemory []string
+
+	displayRecorder func(content, display string)
 }
 
 type approvalReply struct {
@@ -245,6 +247,26 @@ func New(opts Options) *Controller {
 		c.executor.SetMemoryQueue(c)
 	}
 	return c
+}
+
+// SetDisplayRecorder installs an optional hook used by frontends that persist a
+// shorter user-facing transcript than the fully composed model prompt.
+func (c *Controller) SetDisplayRecorder(fn func(content, display string)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.displayRecorder = fn
+}
+
+func (c *Controller) recordDisplay(content, display string) {
+	if strings.TrimSpace(display) == "" || content == display {
+		return
+	}
+	c.mu.Lock()
+	record := c.displayRecorder
+	c.mu.Unlock()
+	if record != nil {
+		record(content, display)
+	}
 }
 
 // ckptDir derives a session's checkpoint directory from its file path
@@ -352,6 +374,10 @@ func (c *Controller) runTurn(ctx context.Context, input string) error {
 }
 
 func (c *Controller) runTurnWithRaw(ctx context.Context, input, raw string) error {
+	return c.runTurnWithRawDisplay(ctx, input, raw, "")
+}
+
+func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
 	input = c.Compose(input)
@@ -373,6 +399,7 @@ func (c *Controller) runTurnWithRaw(ctx context.Context, input, raw string) erro
 		}
 		defer func() { c.hooks.Stop(ctx, lastAssistantText(c.History()), turn) }()
 	}
+	c.recordDisplay(input, display)
 	if err := c.runner.Run(ctx, input); err != nil {
 		return err
 	}
@@ -435,6 +462,16 @@ func lastAssistantText(msgs []provider.Message) string {
 // resolve to a turn; an unknown slash emits a Notice. Anything else is a normal
 // turn with its @-references resolved first.
 func (c *Controller) Submit(input string) {
+	c.submit(input, "")
+}
+
+// SubmitDisplay runs input as a turn while remembering the user-facing display
+// text for transcript replay when controller-side composition expands input.
+func (c *Controller) SubmitDisplay(display, input string) {
+	c.submit(input, display)
+}
+
+func (c *Controller) submit(input, display string) {
 	trimmed := strings.TrimSpace(input)
 	if note, ok := MemoryQuickAddNote(trimmed); ok {
 		c.rememberProjectNote(note)
@@ -479,11 +516,11 @@ func (c *Controller) Submit(input string) {
 				c.notice("unknown command: " + trimmed)
 				return nil
 			}
-			return c.runTurnWithRaw(ctx, sent, sent)
+			return c.runTurnWithRawDisplay(ctx, sent, sent, display)
 		})
 	case strings.HasPrefix(trimmed, "/"):
 		if ref, ok := FileRefLine(trimmed); ok {
-			c.runRefTurn(ref)
+			c.runRefTurn(ref, display)
 			return
 		}
 		// Read-only management verbs (/model /memory /skills /hooks /mcp) emit a
@@ -533,19 +570,19 @@ func (c *Controller) Submit(input string) {
 		// turn. (Built-in slash verbs like /compact are handled above.)
 		if sent, ok := c.CustomCommand(trimmed); ok {
 			c.runGuarded(func(ctx context.Context) error {
-				return c.runTurnWithRaw(ctx, sent, sent)
+				return c.runTurnWithRawDisplay(ctx, sent, sent, display)
 			})
 			return
 		}
 		if sent, ok := c.RunSkill(trimmed); ok {
 			c.runGuarded(func(ctx context.Context) error {
-				return c.runTurnWithRaw(ctx, sent, sent)
+				return c.runTurnWithRawDisplay(ctx, sent, sent, display)
 			})
 			return
 		}
 		c.notice("unknown command: " + trimmed)
 	default:
-		c.runRefTurn(input)
+		c.runRefTurn(input, display)
 	}
 }
 
@@ -651,7 +688,7 @@ func (c *Controller) RunShell(command string) {
 
 // runRefTurn resolves a line's @references into a context block and starts a
 // turn with it prepended (or the raw line when nothing resolved).
-func (c *Controller) runRefTurn(input string) {
+func (c *Controller) runRefTurn(input, display string) {
 	c.runGuarded(func(ctx context.Context) error {
 		block, errs := c.ResolveRefs(ctx, input)
 		for _, e := range errs {
@@ -661,7 +698,7 @@ func (c *Controller) runRefTurn(input string) {
 		if block != "" {
 			sent = "Referenced context:\n\n" + block + "\n\n" + input
 		}
-		return c.runTurnWithRaw(ctx, sent, input)
+		return c.runTurnWithRawDisplay(ctx, sent, input, display)
 	})
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -269,6 +269,22 @@ func (c *Controller) recordDisplay(content, display string) {
 	}
 }
 
+func (c *Controller) recordDisplayForNewUser(startMessages int, display string) {
+	if strings.TrimSpace(display) == "" {
+		return
+	}
+	msgs := c.History()
+	if startMessages > len(msgs) {
+		startMessages = len(msgs)
+	}
+	for _, m := range msgs[startMessages:] {
+		if m.Role == provider.RoleUser {
+			c.recordDisplay(m.Content, display)
+			return
+		}
+	}
+}
+
 // ckptDir derives a session's checkpoint directory from its file path
 // (…/<id>.jsonl → …/<id>.ckpt). Empty path → empty (in-memory checkpoints).
 func ckptDir(sessionPath string) string {
@@ -383,6 +399,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	input = c.Compose(input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
+	defer c.recordDisplayForNewUser(startMessages, display)
 	// Open a checkpoint for this turn before the user message is appended, so the
 	// recorded message boundary precedes it and pre-edit snapshots land here.
 	c.beginCheckpoint(input)
@@ -399,7 +416,6 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		}
 		defer func() { c.hooks.Stop(ctx, lastAssistantText(c.History()), turn) }()
 	}
-	c.recordDisplay(input, display)
 	if err := c.runner.Run(ctx, input); err != nil {
 		return err
 	}

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -29,6 +29,15 @@ func (r appendingRunner) Run(_ context.Context, input string) error {
 	return nil
 }
 
+type handoffRunner struct {
+	session *agent.Session
+}
+
+func (r handoffRunner) Run(_ context.Context, input string) error {
+	r.session.Add(provider.Message{Role: provider.RoleUser, Content: "handoff: " + input})
+	return nil
+}
+
 type fakeControlTool struct{ name string }
 
 func (t fakeControlTool) Name() string { return t.name }
@@ -74,6 +83,28 @@ func TestRunTurnSnapshotsActivityWhenTranscriptChanges(t *testing.T) {
 	}
 	if meta.UpdatedAt.IsZero() {
 		t.Fatal("activity meta should be marked")
+	}
+}
+
+func TestRunTurnRecordsDisplayForPersistedUserMessage(t *testing.T) {
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Runner: handoffRunner{session: sess}, Executor: exec})
+	var gotContent, gotDisplay string
+	c.SetDisplayRecorder(func(content, display string) {
+		gotContent = content
+		gotDisplay = display
+	})
+
+	if err := c.runTurnWithRawDisplay(context.Background(), "expanded prompt", "raw prompt", "visible prompt"); err != nil {
+		t.Fatal(err)
+	}
+
+	if gotContent != "handoff: expanded prompt" {
+		t.Fatalf("display recorded against %q, want persisted user message", gotContent)
+	}
+	if gotDisplay != "visible prompt" {
+		t.Fatalf("display = %q, want visible prompt", gotDisplay)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix desktop transcript replay so composed internal prompt blocks stay hidden from the user bubble.
- Add a controller display-recorder hook that records the final composed prompt to the visible user text after memory, plan, background-job, or reference framing is applied.
- Bind the recorder across desktop controller startup and rebuild paths, and add a regression test for memory-update replay.

## Root Cause
Desktop display sidecars were keyed before controller-side `Compose` expanded the user input. When memory updates were queued, the saved session contained the composed `<memory-update>` block, but history replay could not find the display mapping and rendered the internal prompt as a user message.

## Validation
- `go test ./internal/control`
- `npm run build`
- `cd desktop && go test ./...`
- `go test ./...`

Fixes #3391.
