### PR TITLE
Fix workspace title clipping / 修复工作区名称裁切

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6721,7 +6721,7 @@ a[href] {
   padding-right: 16px;
   color: var(--fg-dim);
   font-size: 15px;
-  line-height: 1;
+  line-height: 1.35;
   white-space: nowrap;
 }
 
@@ -6769,6 +6769,7 @@ a[href] {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 1.35;
 }
 
 .app-chrome__spacer {


### PR DESCRIPTION
## Summary
- Increase the app chrome workspace label line-height so Windows font descenders are not clipped.
- Preserve the existing ellipsis behavior and 38px titlebar height.

## Root cause
The top app chrome identity row used `line-height: 1` while the workspace label also clipped overflow for ellipsis. On Windows/Segoe UI at 1080p, descenders in letters such as `g`, `p`, and `q` could be cut off.

## Verification
- `npm run build`
- `git diff --check`
- Chrome DevTools at 1920x1080 with `global workspace gpqy`; `.app-chrome__scope` computed to 20.25px line-height with vertical clearance inside the 38px chrome.

Closes #3389