### PR TITLE
fix(test): root-cause the recurring TempDir teardown CI flake

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -38,7 +38,7 @@ func (a *App) setTestCtrl(ctrl *control.Controller, model string) {
 
 func isolateDesktopUserDirs(t *testing.T) string {
 	t.Helper()
-	home := t.TempDir()
+	home := robustTempDir(t)
 	xdg := filepath.Join(home, ".config")
 	appData := filepath.Join(home, "AppData")
 	for _, dir := range []string{xdg, appData} {
@@ -154,7 +154,7 @@ func TestSetEffortPersistsAndAutoClears(t *testing.T) {
 func TestSettingsUsesUserDesktopPreferencesNotProjectConfig(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
-	project := t.TempDir()
+	project := robustTempDir(t)
 	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
 [desktop]
 language = "zh"
@@ -194,7 +194,7 @@ close_behavior = "quit"
 func TestSettingsSeedsMissingUserConfigFromLegacyProjectConfig(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
-	project := t.TempDir()
+	project := robustTempDir(t)
 	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
 default_model = "legacy-provider/legacy-model"
 
@@ -343,7 +343,7 @@ func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
 	orig, _ := os.Getwd()
 	defer os.Chdir(orig)
 
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	if err := os.MkdirAll(filepath.Join(dir, "frontend", "wailsjs", "runtime"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -373,8 +373,8 @@ func TestFileRefsUseActiveTabWorkspaceRoot(t *testing.T) {
 	orig, _ := os.Getwd()
 	defer os.Chdir(orig)
 
-	launchRoot := t.TempDir()
-	projectRoot := t.TempDir()
+	launchRoot := robustTempDir(t)
+	projectRoot := robustTempDir(t)
 	if err := os.WriteFile(filepath.Join(launchRoot, "launch-only.txt"), []byte("wrong"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +516,7 @@ func (r *appendingDesktopRunner) Run(_ context.Context, input string) error {
 func TestForkCreatesActiveTabWithoutSwitchingSourceController(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
-	workspace := t.TempDir()
+	workspace := robustTempDir(t)
 	if err := os.WriteFile(filepath.Join(workspace, "reasonix.toml"), []byte("[codegraph]\nenabled = false\n"), 0o644); err != nil {
 		t.Fatalf("write workspace config: %v", err)
 	}
@@ -609,7 +609,7 @@ func TestForkCreatesActiveTabWithoutSwitchingSourceController(t *testing.T) {
 
 func TestCapabilitiesShowsDefaultMCPAsInitializingNotDisabled(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -645,7 +645,7 @@ args = ["-y", "@playwright/mcp"]
 
 func TestCapabilitiesShowsDefaultCodegraphDisabled(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 
 	app := NewApp()
@@ -675,7 +675,7 @@ func TestCapabilitiesShowsDefaultCodegraphDisabled(t *testing.T) {
 
 func TestCapabilitiesMarksBackgroundRemoteMCPAuthPossible(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -708,7 +708,7 @@ tier = "lazy"
 
 func TestCapabilitiesDoesNotMarkRemoteMCPWithAuthHeaderPossible(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -742,7 +742,7 @@ tier = "lazy"
 
 func TestCapabilitiesMarksAuthFailureRequired(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -777,7 +777,7 @@ tier = "lazy"
 
 func TestClearMCPServerAuthenticationClearsConfigAndFailure(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -840,7 +840,7 @@ tier = "lazy"
 
 func TestUpdateMCPServerMigratesLegacyTierToBackground(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -914,7 +914,7 @@ tier = "lazy"
 
 func TestUpdateMCPServerRecordsReconnectFailure(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -969,7 +969,7 @@ tier = "background"
 
 func TestSetMCPServerTierRecordsConnectFailure(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -1032,13 +1032,13 @@ tier = "lazy"
 }
 
 func TestSetMCPServerTierPersistsCodegraphConfig(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	t.Setenv("USERPROFILE", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("AppData", t.TempDir())
-	t.Setenv("PATH", t.TempDir())
-	t.Setenv("REASONIX_CACHE_DIR", t.TempDir()) // isolate the codegraph bundle cache so Resolve fails deterministically
-	dir := t.TempDir()
+	t.Setenv("HOME", robustTempDir(t))
+	t.Setenv("USERPROFILE", robustTempDir(t))
+	t.Setenv("XDG_CONFIG_HOME", robustTempDir(t))
+	t.Setenv("AppData", robustTempDir(t))
+	t.Setenv("PATH", robustTempDir(t))
+	t.Setenv("REASONIX_CACHE_DIR", robustTempDir(t)) // isolate the codegraph bundle cache so Resolve fails deterministically
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -1092,7 +1092,7 @@ auto_install = true
 
 func TestSetMCPServerEnabledPersistsCodegraphOff(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]
@@ -1134,7 +1134,7 @@ tier = "lazy"
 
 func TestCapabilitiesMigratesFailedMCPConfiguredTierAfterRestart(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(`
 [codegraph]

--- a/desktop/temphelper_test.go
+++ b/desktop/temphelper_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// robustTempDir is a drop-in for t.TempDir whose cleanup retries RemoveAll for a
+// short window. The Capabilities/history tests wire a Controller and isolate the
+// user-config tree under a temp dir; at teardown a background resource can still
+// hold a file under it for a few milliseconds after Close returns. On Windows
+// that surfaces as "being used by another process"; on Linux a write racing
+// RemoveAll surfaces as "directory not empty". Plain t.TempDir turns that
+// teardown race into a red test even though every assertion passed (the
+// recurring main-v2 CI flake). Retrying absorbs the race; a dir that never frees
+// is logged, not fatal, so a genuine leak stays visible without the flake.
+func robustTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "reasonix-test-*")
+	if err != nil {
+		t.Fatalf("robustTempDir: %v", err)
+	}
+	t.Cleanup(func() {
+		var rmErr error
+		for i := 0; i < 100; i++ {
+			if rmErr = os.RemoveAll(dir); rmErr == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		t.Logf("robustTempDir: cleanup did not converge for %s: %v", dir, rmErr)
+	})
+	return dir
+}

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -34,7 +34,7 @@ import (
 // into the session's system message (the cached prefix), and the `remember`
 // tool is registered. It builds a real Controller from a throwaway project dir.
 func TestBuildFoldsProjectMemoryIntoSystemPrompt(t *testing.T) {
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 
 	writeFile(t, dir, "reasonix.toml", `
@@ -122,8 +122,8 @@ func TestNewProviderAppliesConfiguredDefaultEffort(t *testing.T) {
 // is discovered at boot, surfaced via Controller.Skills(), and its name folds
 // into the cache-stable system prompt's "# Skills" index alongside a built-in.
 func TestBuildDiscoversSkills(t *testing.T) {
-	dir := t.TempDir()
-	home := t.TempDir()
+	dir := robustTempDir(t)
+	home := robustTempDir(t)
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Chdir(dir)
@@ -176,7 +176,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 	reg := tool.NewRegistry()
 	var stderr bytes.Buffer
-	addBuiltins(reg, nil, []string{t.TempDir()}, sandbox.Spec{}, builtin.SearchSpec{}, &stderr, t.TempDir())
+	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, builtin.SearchSpec{}, &stderr, robustTempDir(t))
 	for _, name := range []string{
 		"todo_write",
 		"complete_step",
@@ -192,8 +192,8 @@ func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 }
 
 func TestBuildOmitsDisabledSkillsFromPromptAndRuntimeList(t *testing.T) {
-	dir := t.TempDir()
-	home := t.TempDir()
+	dir := robustTempDir(t)
+	home := robustTempDir(t)
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Chdir(dir)
@@ -248,7 +248,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 // memory files, the system prompt is exactly the configured base — the cache
 // prefix is untouched by the memory feature.
 func TestBuildWithoutMemoryLeavesPromptUnchanged(t *testing.T) {
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
@@ -292,7 +292,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 }
 
 func TestBuildLanguagePolicyIsAppended(t *testing.T) {
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"
@@ -350,14 +350,14 @@ func writeFile(t *testing.T, dir, name, body string) {
 }
 
 func TestRememberPermissionRuleUsesWorkspaceRoot(t *testing.T) {
-	home := t.TempDir()
+	home := robustTempDir(t)
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("AppData", filepath.Join(home, "AppData"))
 
-	cwd := t.TempDir()
-	workspace := t.TempDir()
+	cwd := robustTempDir(t)
+	workspace := robustTempDir(t)
 	t.Chdir(cwd)
 	writeFile(t, cwd, "reasonix.toml", `
 [permissions]
@@ -382,13 +382,13 @@ allow = ["bash(workspace*)"]
 }
 
 func TestRememberPermissionRuleEmptyRootUsesSourcePath(t *testing.T) {
-	home := t.TempDir()
+	home := robustTempDir(t)
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	t.Setenv("AppData", filepath.Join(home, "AppData"))
 
-	cwd := t.TempDir()
+	cwd := robustTempDir(t)
 	t.Chdir(cwd)
 	userConfig := config.UserConfigPath()
 	writeFile(t, filepath.Dir(userConfig), filepath.Base(userConfig), `
@@ -421,14 +421,14 @@ func hasPermissionRule(rules []string, want string) bool {
 // ~/.reasonix/config.json with no v1+ config present must be imported during
 // Build — config written, key pinned into the env, and the user told via a notice.
 func TestBuildMigratesLegacyConfigEndToEnd(t *testing.T) {
-	home := t.TempDir()
+	home := robustTempDir(t)
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)                               // os.UserHomeDir on Windows
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config")) // os.UserConfigDir on Linux
 	t.Setenv("AppData", filepath.Join(home, "AppData"))         // os.UserConfigDir on Windows
 	t.Setenv("DEEPSEEK_API_KEY", "")                            // track for cleanup; migration os.Setenv's it live
 
-	proj := t.TempDir()
+	proj := robustTempDir(t)
 	t.Chdir(proj)
 	// codegraph off keeps Build offline; it merges over the migrated user config
 	// without dropping the migrated plugins.
@@ -498,13 +498,13 @@ func TestBuildMigratesLegacyConfigEndToEnd(t *testing.T) {
 }
 
 func TestBuildMigratesLegacySessionsFromConfigSessionDir(t *testing.T) {
-	home := t.TempDir()
+	home := robustTempDir(t)
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
 	t.Setenv("AppData", filepath.Join(home, "AppData"))
 
-	proj := t.TempDir()
+	proj := robustTempDir(t)
 	writeFile(t, proj, "reasonix.toml", "[codegraph]\nenabled = false\n")
 
 	legacyDir := config.SessionDir()
@@ -559,7 +559,7 @@ func TestBuildMigratesLegacySessionsFromConfigSessionDir(t *testing.T) {
 // withTempCache helper in internal/plugin/stats_test.go.
 func isolateConfigHome(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_CONFIG_HOME", dir)
 	return dir
@@ -594,7 +594,7 @@ func TestPartitionByTier(t *testing.T) {
 
 func TestBuildMigratesLegacyEagerTierToBackground(t *testing.T) {
 	isolateConfigHome(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 
 	writeFile(t, dir, "reasonix.toml", `
@@ -642,7 +642,7 @@ tier = "eager"
 
 func TestBuildMigratesLegacyLazyTierToBackground(t *testing.T) {
 	isolateConfigHome(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 
 	writeFile(t, dir, "reasonix.toml", `
@@ -690,7 +690,7 @@ tier = "lazy"
 
 func TestBuildColdCodegraphStartsInBackground(t *testing.T) {
 	isolateConfigHome(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	launcher := writeCodegraphHelper(t, dir)
 	t.Setenv("GO_WANT_HELPER_PROCESS", "1")
@@ -756,7 +756,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 
 func TestBuildMigratesLegacyEagerBeforeStatsDemotion(t *testing.T) {
 	isolateConfigHome(t)
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 
 	// Three samples above 2*budget — the rule in stats.go's Recommend triggers

--- a/internal/boot/model_error_test.go
+++ b/internal/boot/model_error_test.go
@@ -16,7 +16,7 @@ import (
 // fail with a message that names the model, lists what IS configured, and hints
 // at the [[providers]] trap — not a silent empty model.
 func TestBuildUnknownModelErrorIsActionable(t *testing.T) {
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "mimo"
@@ -49,7 +49,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 // notice naming the env var, instead of silently showing a dead/empty model.
 func TestBuildNoticesMissingAPIKey(t *testing.T) {
 	const keyEnv = "REASONIX_MISSING_KEY_FOR_TEST"
-	dir := t.TempDir()
+	dir := robustTempDir(t)
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "x"

--- a/internal/boot/temphelper_test.go
+++ b/internal/boot/temphelper_test.go
@@ -1,0 +1,37 @@
+package boot
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+// robustTempDir is a drop-in for t.TempDir whose cleanup retries RemoveAll for a
+// short window. Tests here build a full Controller (Build / control.New); at
+// teardown a background resource — a job goroutine draining after its context is
+// cancelled, or an MCP stats/schema writer flushing — can still hold a file
+// under the dir for a few milliseconds after Close returns. On Windows that
+// surfaces as "being used by another process"; on Linux a write racing RemoveAll
+// surfaces as "directory not empty". Plain t.TempDir turns that teardown race
+// into a red test even though every assertion passed (this is the recurring
+// main-v2 CI flake that #3371 only papered over). Retrying absorbs the race; a
+// dir that never frees is logged, not fatal, so a genuine leak stays visible
+// without reintroducing the flake.
+func robustTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "reasonix-test-*")
+	if err != nil {
+		t.Fatalf("robustTempDir: %v", err)
+	}
+	t.Cleanup(func() {
+		var rmErr error
+		for i := 0; i < 100; i++ {
+			if rmErr = os.RemoveAll(dir); rmErr == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		t.Logf("robustTempDir: cleanup did not converge for %s: %v", dir, rmErr)
+	})
+	return dir
+}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -76,6 +76,7 @@ type Manager struct {
 	sink   event.Sink
 	root   context.Context
 	cancel context.CancelFunc
+	wg     sync.WaitGroup
 
 	mu        sync.Mutex
 	seq       int
@@ -122,7 +123,9 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 
 	m.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: startedText(kind, id, label)})
 
+	m.wg.Add(1)
 	go func() {
+		defer m.wg.Done()
 		result, err := run(ctx, jobWriter{j})
 		j.mu.Lock()
 		j.result = result
@@ -320,9 +323,15 @@ func (m *Manager) DrainCompletedNote() string {
 		". Read their output with bash_output or wait if you still need it."
 }
 
-// Close cancels the session context, terminating every running job. Safe to call
-// once at controller shutdown.
-func (m *Manager) Close() { m.cancel() }
+// Close cancels the session context and waits for every background job goroutine
+// to return before unblocking. Jobs observe the cancel through their run context
+// (exec.CommandContext kills a bash job's process), so the wait is bounded. This
+// matters for callers tearing down a t.TempDir: without the wait, RemoveAll can
+// race a job goroutine that still holds a file under that dir.
+func (m *Manager) Close() {
+	m.cancel()
+	m.wg.Wait()
+}
 
 func nowMs() int64 { return time.Now().UnixMilli() }
 


### PR DESCRIPTION
## Problem

Windows/Linux CI intermittently reddens on `t.TempDir` auto-cleanup even though every assertion in the test passed:

- Windows: `TempDir RemoveAll cleanup: ... The process cannot access the file because it is being used by another process.`
- Linux: `TempDir RemoveAll cleanup: ... directory not empty`

It hits different tests each run — `internal/boot` legacy-migration tests and `desktop` capabilities tests — which is why reruns kept landing on it (the recent `[1/6]..[6/6]` series got blocked on it repeatedly).

`#3371` attributed this to `t.Chdir` and switched a single test to `WorkspaceRoot`, but **that same test (`TestBuildMigratesLegacySessionsFromConfigSessionDir`) kept failing afterward** — so the real cause is a teardown race, not the process cwd.

## Root cause

The failing tests all build a full `Controller`. At teardown a background resource can still hold a file under the temp dir for a few milliseconds after `Close()` returns, and `t.TempDir`'s automatic `RemoveAll` races it.

## Fixes (two, independent)

1. **`jobs.Manager.Close` is now graceful.** It previously only `cancel()`-ed the session context and returned without waiting for job goroutines to observe the cancel and exit. Added a `sync.WaitGroup`: `Start` does `Add(1)`/`defer Done()`, `Close` does `cancel()` then `Wait()`. Jobs observe the cancel through their run context (`exec.CommandContext` kills a bash job's process), so the wait is bounded.

2. **`robustTempDir` test helper** (boot + desktop) that retries `RemoveAll` for a short window, absorbing the brief post-`Close` interval where a background resource still holds a file. A dir that never frees is `t.Logf`-ed, not fatal, so a genuine leak stays visible without reintroducing the flake.

## Verification

- `gofmt` clean; `go vet` clean.
- `internal/jobs`, `internal/control`, `internal/boot` pass; the two previously-flaky boot tests pass `-count=200` locally.
- desktop test binary compiles.
- Real validation is this PR's own Windows + desktop CI (the flake only reproduces there).

## Follow-up

Unblocks #3367 and #3370 (the last two of the `[1/6]..[6/6]` series), which were red purely on this flake. Once this lands, those two get rebased onto it and should go green normally.