### PR TITLE
Hide CodeGraph workspace cache from file tree / 在文件树中隐藏 CodeGraph 缓存

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2704,8 +2704,8 @@ type WorkspaceChangesView struct {
 	GitErr       string                `json:"gitErr,omitempty"`
 }
 
-// atSkip are entries the "@" menu hides as noise.
-var atSkip = map[string]bool{".git": true, "node_modules": true, ".DS_Store": true}
+// atSkip are entries the file tree and "@" menu hide as local workspace noise.
+var atSkip = map[string]bool{".git": true, ".codegraph": true, "node_modules": true, ".DS_Store": true}
 
 const filePreviewLimit = 256 * 1024
 const fileRefSearchLimit = 20

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -356,16 +356,31 @@ func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "node_modules", "pkg", "runtime.js"), []byte("noise"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(dir, ".codegraph", "cache"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".codegraph", "cache", "runtime.js"), []byte("index"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
 
-	got := (&App{}).SearchFileRefs("runtime.js")
+	app := &App{}
+	listed := app.ListDir("")
+	if hasDirEntry(listed, ".codegraph") {
+		t.Fatalf("ListDir should hide CodeGraph project index, got %+v", listed)
+	}
+
+	got := app.SearchFileRefs("runtime.js")
 	if !hasDirEntry(got, "frontend/wailsjs/runtime/runtime.js") {
 		t.Fatalf("SearchFileRefs(runtime.js) should find nested workspace file, got %+v", got)
 	}
 	if hasDirEntry(got, "node_modules/pkg/runtime.js") {
 		t.Fatalf("SearchFileRefs should skip node_modules noise, got %+v", got)
+	}
+	if hasDirEntry(got, ".codegraph/cache/runtime.js") {
+		t.Fatalf("SearchFileRefs should skip CodeGraph project index, got %+v", got)
 	}
 }
 

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -8,6 +8,7 @@ import (
 )
 
 var skipDirs = map[string]bool{
+	".codegraph":   true,
 	".git":         true,
 	"node_modules": true,
 	"dist":         true,


### PR DESCRIPTION
## Summary
- Hide the local `.codegraph/` project index from the desktop workspace file tree.
- Exclude `.codegraph/` from recursive `@file` reference search results.
- Add regression coverage for both listing and search behavior.

## Verification
- `go test ./internal/fileref ./internal/cli -run 'TestFileItemsSearchesBasenameAtTopLevel' -count=1`
- `cd desktop && go test . -run TestSearchFileRefsFindsNestedBasename -count=1`
