### PR TITLE
Hide generated workspace noise from file references / 隐藏工作区生成物噪音

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2921,8 +2921,31 @@ type WorkspaceChangesView struct {
 	GitErr       string                `json:"gitErr,omitempty"`
 }
 
-// atSkip are entries the file tree and "@" menu hide as local workspace noise.
-var atSkip = map[string]bool{".git": true, ".codegraph": true, "node_modules": true, ".DS_Store": true}
+// workspaceNoiseNames are local cache/vendor entries hidden from the file tree
+// and "@" menu regardless of where they appear.
+var workspaceNoiseNames = map[string]bool{
+	".codex":       true,
+	".codegraph":   true,
+	".DS_Store":    true,
+	".git":         true,
+	".npm":         true,
+	".pnpm-store":  true,
+	"node_modules": true,
+	"Thumbs.db":    true,
+}
+
+var workspaceNoiseDirs = map[string]bool{
+	"bin":                      true,
+	"desktop/build":            true,
+	"desktop/frontend/dist":    true,
+	"desktop/frontend/wailsjs": true,
+	"dist":                     true,
+	"npm/.stage":               true,
+	"site/.astro":              true,
+	"site/dist":                true,
+	"stage":                    true,
+	"tmp":                      true,
+}
 
 const filePreviewLimit = 256 * 1024
 const fileRefSearchLimit = 20
@@ -2966,6 +2989,21 @@ func previewMediaKind(path string) (kind string, mime string) {
 		return "pdf", mime
 	}
 	return "", ""
+}
+
+func workspaceEntryRel(rel, name string) string {
+	rel = strings.Trim(filepath.ToSlash(rel), "/")
+	if rel == "" || rel == "." {
+		return name
+	}
+	return rel + "/" + name
+}
+
+func skipWorkspaceEntry(rel, name string, isDir bool) bool {
+	if workspaceNoiseNames[name] {
+		return true
+	}
+	return isDir && workspaceNoiseDirs[workspaceEntryRel(rel, name)]
 }
 
 func (a *App) activeWorkspaceBase() (string, error) {
@@ -3039,7 +3077,7 @@ func (a *App) ListDir(rel string) []DirEntry {
 	dirs, files := []DirEntry{}, []DirEntry{}
 	for _, e := range es {
 		name := e.Name()
-		if atSkip[name] {
+		if skipWorkspaceEntry(rel, name, e.IsDir()) {
 			continue
 		}
 		if e.IsDir() {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -351,6 +351,12 @@ func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "frontend", "wailsjs", "runtime", "runtime.js"), []byte("x"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.WriteFile(filepath.Join(dir, "frontend", "Thumbs.db"), []byte("noise"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "frontend", ".DS_Store"), []byte("noise"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(filepath.Join(dir, "node_modules", "pkg"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -398,6 +404,12 @@ func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
 	if hasDirEntry(desktopFrontend, "wailsjs") {
 		t.Fatalf("ListDir should hide generated Wails bindings, got %+v", desktopFrontend)
 	}
+	frontendEntries := app.ListDir("frontend")
+	for _, hidden := range []string{".DS_Store", "Thumbs.db"} {
+		if hasDirEntry(frontendEntries, hidden) {
+			t.Fatalf("ListDir should hide local noise file %q, got %+v", hidden, frontendEntries)
+		}
+	}
 
 	got := app.SearchFileRefs("runtime.js")
 	if !hasDirEntry(got, "frontend/wailsjs/runtime/runtime.js") {
@@ -423,6 +435,12 @@ func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
 		if hasDirEntry(got, hidden) {
 			t.Fatalf("SearchFileRefs should skip local noise %q, got %+v", hidden, got)
 		}
+	}
+	if noise := app.SearchFileRefs("Thumbs"); hasDirEntry(noise, "frontend/Thumbs.db") {
+		t.Fatalf("SearchFileRefs should skip Thumbs.db noise, got %+v", noise)
+	}
+	if noise := app.SearchFileRefs(".DS"); hasDirEntry(noise, "frontend/.DS_Store") {
+		t.Fatalf("SearchFileRefs should skip .DS_Store noise even for dot-prefixed search, got %+v", noise)
 	}
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -363,25 +363,66 @@ func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, ".codegraph", "cache", "runtime.js"), []byte("index"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	for _, noise := range []string{".codex", ".npm", ".pnpm-store", "bin", "dist", "stage", "tmp"} {
+		if err := os.MkdirAll(filepath.Join(dir, noise), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, noise, "runtime.js"), []byte("noise"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "desktop", "frontend", "wailsjs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "desktop", "frontend", "wailsjs", "runtime.js"), []byte("generated"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "product", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "product", "bin", "runtime.js"), []byte("real"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.Chdir(dir); err != nil {
 		t.Fatal(err)
 	}
 
 	app := &App{}
 	listed := app.ListDir("")
-	if hasDirEntry(listed, ".codegraph") {
-		t.Fatalf("ListDir should hide CodeGraph project index, got %+v", listed)
+	for _, hidden := range []string{".codex", ".codegraph", ".npm", ".pnpm-store", "bin", "dist", "stage", "tmp"} {
+		if hasDirEntry(listed, hidden) {
+			t.Fatalf("ListDir should hide local noise %q, got %+v", hidden, listed)
+		}
+	}
+	desktopFrontend := app.ListDir("desktop/frontend")
+	if hasDirEntry(desktopFrontend, "wailsjs") {
+		t.Fatalf("ListDir should hide generated Wails bindings, got %+v", desktopFrontend)
 	}
 
 	got := app.SearchFileRefs("runtime.js")
 	if !hasDirEntry(got, "frontend/wailsjs/runtime/runtime.js") {
 		t.Fatalf("SearchFileRefs(runtime.js) should find nested workspace file, got %+v", got)
 	}
+	if !hasDirEntry(got, "product/bin/runtime.js") {
+		t.Fatalf("SearchFileRefs should keep non-root bin directories searchable, got %+v", got)
+	}
 	if hasDirEntry(got, "node_modules/pkg/runtime.js") {
 		t.Fatalf("SearchFileRefs should skip node_modules noise, got %+v", got)
 	}
-	if hasDirEntry(got, ".codegraph/cache/runtime.js") {
-		t.Fatalf("SearchFileRefs should skip CodeGraph project index, got %+v", got)
+	for _, hidden := range []string{
+		".codex/runtime.js",
+		".codegraph/cache/runtime.js",
+		".npm/runtime.js",
+		".pnpm-store/runtime.js",
+		"bin/runtime.js",
+		"desktop/frontend/wailsjs/runtime.js",
+		"dist/runtime.js",
+		"stage/runtime.js",
+		"tmp/runtime.js",
+	} {
+		if hasDirEntry(got, hidden) {
+			t.Fatalf("SearchFileRefs should skip local noise %q, got %+v", hidden, got)
+		}
 	}
 }
 

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -7,15 +7,20 @@ import (
 	"strings"
 )
 
-var skipDirNames = map[string]bool{
+var skipEntryNames = map[string]bool{
 	".codex":       true,
 	".codegraph":   true,
+	".DS_Store":    true,
 	".git":         true,
 	".npm":         true,
 	".pnpm-store":  true,
-	"build":        true,
-	"dist":         true,
 	"node_modules": true,
+	"Thumbs.db":    true,
+}
+
+var skipDirNames = map[string]bool{
+	"build": true,
+	"dist":  true,
 }
 
 var skipDirPaths = map[string]bool{
@@ -66,9 +71,12 @@ func Search(root, query string, limit int) []string {
 				return filepath.SkipDir
 			}
 			rel = filepath.ToSlash(rel)
-			if skipDirNames[name] || skipDirPaths[rel] || (!showHidden && strings.HasPrefix(name, ".")) {
+			if skipEntryNames[name] || skipDirNames[name] || skipDirPaths[rel] || (!showHidden && strings.HasPrefix(name, ".")) {
 				return filepath.SkipDir
 			}
+			return nil
+		}
+		if skipEntryNames[name] {
 			return nil
 		}
 		if len(matches) >= limit {

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -7,12 +7,24 @@ import (
 	"strings"
 )
 
-var skipDirs = map[string]bool{
+var skipDirNames = map[string]bool{
+	".codex":       true,
 	".codegraph":   true,
 	".git":         true,
-	"node_modules": true,
-	"dist":         true,
+	".npm":         true,
+	".pnpm-store":  true,
 	"build":        true,
+	"dist":         true,
+	"node_modules": true,
+}
+
+var skipDirPaths = map[string]bool{
+	"bin":                      true,
+	"desktop/frontend/wailsjs": true,
+	"npm/.stage":               true,
+	"site/.astro":              true,
+	"stage":                    true,
+	"tmp":                      true,
 }
 
 const (
@@ -49,7 +61,12 @@ func Search(root, query string, limit int) []string {
 
 		name := d.Name()
 		if d.IsDir() {
-			if skipDirs[name] || (!showHidden && strings.HasPrefix(name, ".")) {
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return filepath.SkipDir
+			}
+			rel = filepath.ToSlash(rel)
+			if skipDirNames[name] || skipDirPaths[rel] || (!showHidden && strings.HasPrefix(name, ".")) {
 				return filepath.SkipDir
 			}
 			return nil


### PR DESCRIPTION
## Summary
- Hide local cache/vendor entries from the desktop workspace file tree, including `.codex/`, `.npm/`, `.pnpm-store/`, and `node_modules/`.
- Hide path-specific generated/build directories such as root `bin/`, `dist/`, `stage/`, `tmp/`, `desktop/frontend/wailsjs/`, and Astro/npm build output.
- Apply matching skips to recursive `@file` reference search while keeping ordinary nested directories such as `product/bin/` searchable.
- Add regression coverage for listing, search, and the non-root `bin/` case.

## Verification
- `go test ./internal/fileref ./internal/cli -run 'TestFileItemsSearchesBasenameAtTopLevel' -count=1`
- `cd desktop && go test . -run TestSearchFileRefsFindsNestedBasename -count=1`
