### PR TITLE
fix(css): add missing closing brace that broke esbuild CSS compilation

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7048,7 +7048,7 @@ a[href] {
 .onboarding__skip:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-
+}
 
 /* InlineDiff: a compact before/after diff card. The header strip carries
    the filename, the +/- counts, and a Copy button. The body is a monospace


### PR DESCRIPTION
The `.onboarding__skip:disabled` block was missing its closing `}`, causing esbuild (Vite dev mode CSS compiler) to abort at line 7049. All rules after that point — ~1900 lines including `.workbench-dock`, `.context-panel`, `.context-inspector` layout positioning — were silently discarded, breaking the right-side dock layout.

Introduced as a merge conflict artefact between #2752 (onboarding overlay) and #3129 (InlineDiff component).

**Verification:**
- `pnpm build` — no more `Expected "}" to go with "{"` warning
- Build output now includes `.context-inspector,.workbench-dock{grid-row:2;grid-column:4;...}`