### PR TITLE
Guard desktop frontend CSS syntax in CI / 在 CI 中守住桌面前端 CSS 语法

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,12 +87,21 @@ jobs:
           cache: true
           cache-dependency-path: desktop/go.sum
 
-      # The Go main package embeds frontend/dist; a placeholder lets the Go
-      # build/test resolve the embed without a full frontend build.
-      - name: Stub embedded frontend
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: desktop/frontend/pnpm-lock.yaml
+
+      - name: Install Wails CLI
         run: |
-          mkdir -p frontend/dist
-          echo '<!doctype html><title>ci</title>' > frontend/dist/index.html
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          go install github.com/wailsapp/wails/v2/cmd/wails@v2.12.0
 
       - name: gofmt
         run: |
@@ -117,6 +126,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc libgtk-3-dev libwebkit2gtk-4.0-dev
+
+      - name: Build frontend
+        run: |
+          wails generate module
+          pnpm --dir frontend install --frozen-lockfile
+          pnpm --dir frontend build
 
       - name: vet
         run: go vet ./...

--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc --noEmit && vite build",
+    "build": "node scripts/check-css-syntax.mjs src/styles.css && tsc --noEmit && vite build",
     "preview": "vite preview",
+    "check:css": "node scripts/check-css-syntax.mjs src/styles.css",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit"
   },

--- a/desktop/frontend/scripts/check-css-syntax.mjs
+++ b/desktop/frontend/scripts/check-css-syntax.mjs
@@ -1,0 +1,140 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(scriptDir, "..");
+const targets = process.argv.slice(2);
+const files = targets.length > 0 ? targets : ["src/styles.css"];
+
+let failed = false;
+
+for (const file of files) {
+  const fullPath = path.resolve(frontendRoot, file);
+  const source = fs.readFileSync(fullPath, "utf8");
+  const result = checkCssDelimiters(source);
+  if (result.ok) {
+    console.log(`CSS syntax check passed: ${file}`);
+    continue;
+  }
+
+  failed = true;
+  console.error(`CSS syntax check failed: ${file}:${result.line}:${result.column}`);
+  console.error(result.message);
+}
+
+if (failed) {
+  process.exit(1);
+}
+
+function checkCssDelimiters(source) {
+  const stack = [];
+  let state = "normal";
+  let line = 1;
+  let column = 0;
+  let tokenLine = 1;
+  let tokenColumn = 1;
+
+  for (let i = 0; i < source.length; i += 1) {
+    const char = source[i];
+    const next = source[i + 1];
+
+    if (char === "\n") {
+      line += 1;
+      column = 0;
+    } else {
+      column += 1;
+    }
+
+    if (state === "comment") {
+      if (char === "*" && next === "/") {
+        i += 1;
+        column += 1;
+        state = "normal";
+      }
+      continue;
+    }
+
+    if (state === "single" || state === "double") {
+      if (char === "\\") {
+        i += 1;
+        column += 1;
+        continue;
+      }
+      if ((state === "single" && char === "'") || (state === "double" && char === '"')) {
+        state = "normal";
+      }
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      tokenLine = line;
+      tokenColumn = column;
+      i += 1;
+      column += 1;
+      state = "comment";
+      continue;
+    }
+
+    if (char === "'") {
+      tokenLine = line;
+      tokenColumn = column;
+      state = "single";
+      continue;
+    }
+
+    if (char === '"') {
+      tokenLine = line;
+      tokenColumn = column;
+      state = "double";
+      continue;
+    }
+
+    if (char === "{") {
+      stack.push({ line, column });
+      continue;
+    }
+
+    if (char === "}") {
+      if (stack.length === 0) {
+        return {
+          ok: false,
+          line,
+          column,
+          message: "Found a closing brace without a matching opening brace.",
+        };
+      }
+      stack.pop();
+    }
+  }
+
+  if (state === "comment") {
+    return {
+      ok: false,
+      line: tokenLine,
+      column: tokenColumn,
+      message: "Found an unterminated CSS comment.",
+    };
+  }
+
+  if (state === "single" || state === "double") {
+    return {
+      ok: false,
+      line: tokenLine,
+      column: tokenColumn,
+      message: "Found an unterminated CSS string.",
+    };
+  }
+
+  if (stack.length > 0) {
+    const opener = stack[stack.length - 1];
+    return {
+      ok: false,
+      line: opener.line,
+      column: opener.column,
+      message: "Found an opening brace without a matching closing brace.",
+    };
+  }
+
+  return { ok: true };
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7048,7 +7048,7 @@ a[href] {
 .onboarding__skip:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-
+}
 
 /* InlineDiff: a compact before/after diff card. The header strip carries
    the filename, the +/- counts, and a Copy button. The body is a monospace


### PR DESCRIPTION
## Summary

- add a focused desktop frontend CSS delimiter check before TypeScript/Vite build
- run the real desktop frontend build in CI instead of stubbing `frontend/dist`
- fix the currently missing `.onboarding__skip:disabled` closing brace so the new guard is green

## Why

Vite/esbuild can emit a CSS syntax warning for an unbalanced brace while still exiting successfully. That allowed downstream desktop layout styles to be dropped without CI failing. This PR makes that failure explicit and keeps the desktop frontend build path covered in the `desktop` CI job.

## Verification

- `pnpm --dir desktop/frontend run check:css` passed
- `cd desktop && wails generate module` passed
- `pnpm --dir desktop/frontend build` passed
- `git diff --check` passed
