### PR TITLE
Allow removing skill convention sources / 支持移除技能约定来源

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ enabled = []   # omit/empty = all built-ins
 
 [skills]
 # paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
+# excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
 # disabled_skills = ["review"]                  # hide skills until /skill enable <name>
 
 [permissions]

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,6 +115,7 @@ enabled = []   # 省略/为空 = 全部内置工具
 
 [skills]
 # paths = ["~/my-skills", "../shared/skills"]   # 额外的自定义技能目录
+# excluded_paths = ["~/.agents/skills"]         # 隐藏约定来源，不删除目录
 # disabled_skills = ["review"]                  # 隐藏技能，直到 /skill enable <name>
 
 [permissions]

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1702,6 +1702,7 @@ type SkillRootView struct {
 	Priority   int                  `json:"priority"`
 	Status     string               `json:"status"`
 	Configured bool                 `json:"configured"`
+	Removable  bool                 `json:"removable"`
 	Skills     int                  `json:"skills"`
 	SkillItems []SkillRootSkillView `json:"skillItems,omitempty"`
 	Warning    string               `json:"warning,omitempty"`
@@ -1886,12 +1887,14 @@ func skillRootsView() []SkillRootView {
 	cfg, _ := config.Load()
 	userCfg := config.LoadForEdit(config.UserConfigPath())
 	var custom []string
+	var excluded []string
 	maxDepth := 3
 	if cfg != nil {
 		custom = cfg.SkillCustomPaths()
+		excluded = cfg.SkillExcludedPaths()
 		maxDepth = cfg.SkillMaxDepth()
 	}
-	st := skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, MaxDepth: maxDepth, DisableBuiltins: true, Stderr: io.Discard})
+	st := skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, ExcludedPaths: excluded, MaxDepth: maxDepth, DisableBuiltins: true, Stderr: io.Discard})
 	counts := map[string]int{}
 	skillItems := map[string][]SkillRootSkillView{}
 	roots := st.Roots()
@@ -1925,6 +1928,7 @@ func skillRootsView() []SkillRootView {
 			Priority:   r.Priority + 1,
 			Status:     string(r.Status),
 			Configured: r.Scope == skill.ScopeCustom && userConfigured[dir],
+			Removable:  true,
 			Skills:     counts[dir],
 			SkillItems: skillItems[dir],
 		}
@@ -1940,6 +1944,7 @@ func skillRootsView() []SkillRootView {
 				Scope:      string(skill.ScopeCustom),
 				Status:     "inactive",
 				Configured: true,
+				Removable:  true,
 				Warning:    "configured in user config but not active in this workspace; project [skills].paths may override it",
 			})
 		}
@@ -1978,17 +1983,25 @@ func (a *App) PickSkillFolder() (string, error) {
 // controller so the skills index and slash menu reflect it immediately.
 func (a *App) AddSkillPath(path string) error {
 	path = normalizeSkillPath(path)
+	workspaceRoot := a.activeWorkspaceRoot()
 	return a.applyConfigChange(func(c *config.Config) error {
+		if isConventionSkillRoot(path, workspaceRoot) {
+			return c.RestoreSkillPath(path)
+		}
 		return c.AddSkillPath(path)
 	})
 }
 
-// RemoveSkillPath removes a custom skill root from the user config and rebuilds.
+// RemoveSkillPath removes a skill source from the user config and rebuilds. For
+// convention roots, it records a pseudo-delete in excluded_paths.
 func (a *App) RemoveSkillPath(path string) error {
 	path = normalizeSkillPath(path)
 	return a.applyConfigChange(func(c *config.Config) error {
-		_, err := c.RemoveSkillPath(path)
-		return err
+		removed, err := c.RemoveSkillPath(path)
+		if err != nil || removed {
+			return err
+		}
+		return c.ExcludeSkillPath(path)
 	})
 }
 
@@ -2039,6 +2052,29 @@ func normalizeSkillPath(path string) string {
 		}
 	}
 	return filepath.Clean(path)
+}
+
+func isConventionSkillRoot(path, workspaceRoot string) bool {
+	want := config.CanonicalSkillPath(path)
+	if want == "" {
+		return false
+	}
+	bases := []string{workspaceRoot}
+	if home, err := os.UserHomeDir(); err == nil {
+		bases = append(bases, home)
+	}
+	for _, base := range bases {
+		base = strings.TrimSpace(base)
+		if base == "" {
+			continue
+		}
+		for _, dir := range config.ConventionDirs {
+			if want == config.CanonicalSkillPath(filepath.Join(base, dir, skill.SkillsDirname)) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func skillRootPath(path string) string {

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -288,6 +288,7 @@ function normalizeCapabilitiesView(view: CapabilitiesView | null | undefined): C
     skills: asArray(view?.skills),
     skillRoots: asArray(view?.skillRoots).map((root) => ({
       ...root,
+      removable: Boolean(root.removable),
       skillItems: asArray(root.skillItems),
     })),
   };
@@ -434,7 +435,7 @@ function SkillSources({
                 const rootSkillsExpanded = expandedRootSkills.has(key);
                 const rootSkillsFull = fullRootSkills.has(key);
                 const canShowRootSkills = rootSkills.length > 0;
-                const canRemoveRoot = root.scope === "custom" && root.configured;
+                const canRemoveRoot = root.removable;
                 return (
                   <div className={`cap-source cap-source--${skillRootTone(root)}`} key={key}>
                     <span className={`cap-dot cap-dot--${skillRootDot(root)}`} />

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -429,13 +429,14 @@ function makeMockApp(): AppBindings {
     { name: "init", description: "Scaffold a REASONIX.md for this repo", scope: "builtin", runAs: "inline", enabled: true },
   ];
   let capSkillRoots: SkillRootView[] = [
-    { dir: "~/projects/reasonix/.reasonix/skills", scope: "project", priority: 1, status: "missing", configured: false, skills: 0 },
+    { dir: "~/projects/reasonix/.reasonix/skills", scope: "project", priority: 1, status: "missing", configured: false, removable: true, skills: 0 },
     {
       dir: "~/my-skills",
       scope: "custom",
       priority: 5,
       status: "ok",
       configured: true,
+      removable: true,
       skills: 1,
       skillItems: [{ name: "review", description: "Review the staged diff", scope: "custom", runAs: "inline" }],
     },
@@ -445,6 +446,7 @@ function makeMockApp(): AppBindings {
       priority: 6,
       status: "ok",
       configured: false,
+      removable: true,
       skills: 2,
       skillItems: [
         { name: "explore", description: "Investigate the codebase in an isolated subagent", scope: "global", runAs: "subagent" },
@@ -1185,6 +1187,7 @@ function makeMockApp(): AppBindings {
           priority: capSkillRoots.length + 1,
           status: "ok",
           configured: true,
+          removable: true,
           skills: 1,
           skillItems: [{ name: "local-dev", description: "Local custom development workflow", scope: "custom", runAs: "inline" }],
         });
@@ -1194,7 +1197,7 @@ function makeMockApp(): AppBindings {
       }
     },
     async RemoveSkillPath(path: string) {
-      capSkillRoots = capSkillRoots.filter((r) => !(r.scope === "custom" && r.dir === path));
+      capSkillRoots = capSkillRoots.filter((r) => r.dir !== path);
       if (!capSkillRoots.some((r) => r.scope === "custom")) {
         const idx = capSkills.findIndex((s) => s.name === "local-dev");
         if (idx >= 0) capSkills.splice(idx, 1);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -364,6 +364,7 @@ export interface SkillRootView {
   priority: number;
   status: string;
   configured: boolean;
+  removable: boolean;
   skills: number;
   skillItems?: SkillRootSkillView[];
   warning?: string;

--- a/desktop/skills_app_test.go
+++ b/desktop/skills_app_test.go
@@ -108,6 +108,88 @@ func TestSkillRootsViewMarksEnvConfiguredCustomRoot(t *testing.T) {
 	t.Fatalf("custom skill root %q not found in %+v", root, roots)
 }
 
+func TestSkillRootsViewOmitsExcludedConventionRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	project := t.TempDir()
+	root := filepath.Join(home, ".agents", "skills")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "noisy.md"), []byte("---\ndescription: noisy\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := config.UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("[skills]\nexcluded_paths = [\"~/.agents/skills\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(wd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	roots := skillRootsView()
+	want := realTestPath(root)
+	for _, r := range roots {
+		if realTestPath(r.Dir) == want {
+			t.Fatalf("excluded convention root should be hidden, got %+v in %+v", r, roots)
+		}
+	}
+}
+
+func TestRemoveSkillPathPseudoDeletesConventionRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	path := filepath.Join(home, ".agents", "skills")
+	app := NewApp()
+
+	if err := app.RemoveSkillPath(path); err != nil {
+		t.Fatalf("RemoveSkillPath: %v", err)
+	}
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if len(cfg.Skills.ExcludedPaths) != 1 || realTestPath(cfg.Skills.ExcludedPaths[0]) != realTestPath(path) {
+		t.Fatalf("excluded paths = %v, want %q", cfg.Skills.ExcludedPaths, path)
+	}
+}
+
+func TestAddSkillPathRestoresConventionRootWithoutCustomPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	path := filepath.Join(home, ".agents", "skills")
+	cfgPath := config.UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("[skills]\nexcluded_paths = [\"~/.agents/skills\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp()
+
+	if err := app.AddSkillPath(path); err != nil {
+		t.Fatalf("AddSkillPath: %v", err)
+	}
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if len(cfg.Skills.ExcludedPaths) != 0 {
+		t.Fatalf("excluded paths after restore = %v, want empty", cfg.Skills.ExcludedPaths)
+	}
+	if len(cfg.Skills.Paths) != 0 {
+		t.Fatalf("restored convention root should not become custom path: %v", cfg.Skills.Paths)
+	}
+}
+
 func TestCapabilitiesIncludesDisabledSkills(t *testing.T) {
 	a := NewApp()
 	a.setTestCtrl(control.New(control.Options{

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -388,6 +388,7 @@ enabled = []   # omit/empty = all built-ins
 
 [skills]
 # paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
+# excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
 # disabled_skills = ["review"]                  # hidden from prompt, slash invocation, and skill tools
 
 [permissions]

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -182,12 +182,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	skillStore := skill.New(skill.Options{
 		ProjectRoot:   root,
 		CustomPaths:   cfg.SkillCustomPaths(),
+		ExcludedPaths: cfg.SkillExcludedPaths(),
 		DisabledNames: cfg.DisabledSkillNames(),
 		MaxDepth:      cfg.SkillMaxDepth(),
 		Stderr:        opts.Stderr,
 	})
 	skills := skillStore.List()
-	allSkills := skill.New(skill.Options{ProjectRoot: root, CustomPaths: cfg.SkillCustomPaths(), MaxDepth: cfg.SkillMaxDepth(), Stderr: io.Discard}).List()
+	allSkills := skill.New(skill.Options{ProjectRoot: root, CustomPaths: cfg.SkillCustomPaths(), ExcludedPaths: cfg.SkillExcludedPaths(), MaxDepth: cfg.SkillMaxDepth(), Stderr: io.Discard}).List()
 	sysPrompt = skill.ApplyIndex(sysPrompt, skills)
 
 	reg := tool.NewRegistry()

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -244,6 +244,55 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 }
 
+func TestBuildOmitsExcludedSkillRootsFromPromptAndRuntimeList(t *testing.T) {
+	dir := robustTempDir(t)
+	home := robustTempDir(t)
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Chdir(dir)
+	excluded := filepath.Join(home, ".agents", "skills")
+	writeFile(t, home, ".reasonix/skills/keep.md", "---\ndescription: keep\n---\nplaybook")
+	writeFile(t, home, ".agents/skills/noisy.md", "---\ndescription: noisy\n---\nplaybook")
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[skills]
+excluded_paths = [%q]
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`, excluded))
+
+	ctrl, err := Build(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	for _, s := range ctrl.Skills() {
+		if s.Name == "noisy" {
+			t.Fatalf("excluded skill should not be executable: %v", ctrl.Skills())
+		}
+	}
+	sys := systemMessage(ctrl.History())
+	if strings.Contains(sys, "noisy") {
+		t.Fatalf("excluded skill name should be omitted from system prompt:\n%s", sys)
+	}
+	if !strings.Contains(sys, "keep") {
+		t.Fatalf("non-excluded skill should remain in system prompt:\n%s", sys)
+	}
+}
+
 // TestBuildWithoutMemoryLeavesPromptUnchanged is the inverse invariant: with no
 // memory files, the system prompt is exactly the configured base — the cache
 // prefix is untouched by the memory feature.

--- a/internal/cli/skill_hooks.go
+++ b/internal/cli/skill_hooks.go
@@ -226,12 +226,14 @@ func (m *chatTUI) skillPaths() {
 func (m *chatTUI) skillStore() *skill.Store {
 	cwd, _ := os.Getwd()
 	var custom []string
+	var excluded []string
 	maxDepth := 3
 	if cfg, err := config.Load(); err == nil {
 		custom = cfg.SkillCustomPaths()
+		excluded = cfg.SkillExcludedPaths()
 		maxDepth = cfg.SkillMaxDepth()
 	}
-	return skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, MaxDepth: maxDepth})
+	return skill.New(skill.Options{ProjectRoot: cwd, CustomPaths: custom, ExcludedPaths: excluded, MaxDepth: maxDepth})
 }
 
 func (m *chatTUI) runHooksSubcommand(input string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -298,12 +298,14 @@ func (c *Config) NetworkProxyMode() string {
 
 // SkillsConfig configures skill discovery. Paths adds extra "custom"-scope skill
 // roots — each a directory of SKILL.md / <name>.md playbooks — scanned between
-// the project roots (.reasonix/.agents/.claude under the workspace) and the
-// global roots (the same three under the home dir). ~ and relative paths and
-// ${VAR} expansion are supported. DisabledSkills hides named skills from the
-// agent prompt, slash invocation, and skill tools while keeping them manageable.
+// the project roots (.reasonix/.agents/.agent/.claude under the workspace) and
+// the global roots. ExcludedPaths hides matching discovery roots without deleting
+// folders. ~, relative paths, and ${VAR} expansion are supported. DisabledSkills
+// hides named skills from the agent prompt, slash invocation, and skill tools
+// while keeping them manageable.
 type SkillsConfig struct {
 	Paths          []string `toml:"paths"`
+	ExcludedPaths  []string `toml:"excluded_paths"`
 	DisabledSkills []string `toml:"disabled_skills"`
 	MaxDepth       int      `toml:"max_depth"`
 }
@@ -313,6 +315,18 @@ type SkillsConfig struct {
 func (c *Config) SkillCustomPaths() []string {
 	var out []string
 	for _, p := range c.Skills.Paths {
+		if p = ExpandVars(p); strings.TrimSpace(p) != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// SkillExcludedPaths returns configured skill roots that should be hidden from
+// discovery, with ${VAR} expanded and empty entries dropped.
+func (c *Config) SkillExcludedPaths() []string {
+	var out []string
+	for _, p := range c.Skills.ExcludedPaths {
 		if p = ExpandVars(p); strings.TrimSpace(p) != "" {
 			out = append(out, p)
 		}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -314,6 +314,7 @@ func (c *Config) AddSkillPath(path string) error {
 		return fmt.Errorf("skill path: empty path")
 	}
 	want := CanonicalSkillPath(path)
+	c.removeExcludedSkillPath(want)
 	for _, existing := range c.Skills.Paths {
 		if CanonicalSkillPath(existing) == want {
 			return nil
@@ -338,6 +339,50 @@ func (c *Config) RemoveSkillPath(path string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// RestoreSkillPath removes a pseudo-deleted skill source from excluded_paths.
+func (c *Config) RestoreSkillPath(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("skill path: empty path")
+	}
+	want := CanonicalSkillPath(path)
+	if want == "" {
+		return fmt.Errorf("skill path: empty path")
+	}
+	c.removeExcludedSkillPath(want)
+	return nil
+}
+
+// ExcludeSkillPath hides any skill discovery root matching path. This is used by
+// UI "remove source" actions for convention roots that are not stored in paths.
+func (c *Config) ExcludeSkillPath(path string) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return fmt.Errorf("skill path: empty path")
+	}
+	want := CanonicalSkillPath(path)
+	if want == "" {
+		return fmt.Errorf("skill path: empty path")
+	}
+	for _, existing := range c.Skills.ExcludedPaths {
+		if CanonicalSkillPath(existing) == want {
+			return nil
+		}
+	}
+	c.Skills.ExcludedPaths = append(c.Skills.ExcludedPaths, path)
+	return nil
+}
+
+func (c *Config) removeExcludedSkillPath(want string) {
+	next := c.Skills.ExcludedPaths[:0]
+	for _, existing := range c.Skills.ExcludedPaths {
+		if CanonicalSkillPath(existing) != want {
+			next = append(next, existing)
+		}
+	}
+	c.Skills.ExcludedPaths = next
 }
 
 // SetSkillEnabled persists a per-skill enable/disable preference. Skills are

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -382,8 +382,14 @@ func TestPermissionMutators(t *testing.T) {
 func TestSkillPathMutators(t *testing.T) {
 	c := Default()
 	root := t.TempDir()
+	if err := c.ExcludeSkillPath(root); err != nil {
+		t.Fatalf("exclude skill path: %v", err)
+	}
 	if err := c.AddSkillPath(root); err != nil {
 		t.Fatalf("add skill path: %v", err)
+	}
+	if len(c.Skills.ExcludedPaths) != 0 {
+		t.Fatalf("add skill path should restore excluded path, got %v", c.Skills.ExcludedPaths)
 	}
 	if err := c.AddSkillPath(filepath.Join(root, ".")); err != nil {
 		t.Fatalf("duplicate skill path: %v", err)
@@ -403,6 +409,27 @@ func TestSkillPathMutators(t *testing.T) {
 	}
 	if removed, err := c.RemoveSkillPath(root); err != nil || removed {
 		t.Fatalf("remove absent: removed=%v err=%v", removed, err)
+	}
+	if err := c.ExcludeSkillPath(filepath.Join(root, ".")); err != nil {
+		t.Fatalf("exclude skill path: %v", err)
+	}
+	if err := c.ExcludeSkillPath(root); err != nil {
+		t.Fatalf("duplicate exclude skill path: %v", err)
+	}
+	if len(c.Skills.ExcludedPaths) != 1 {
+		t.Fatalf("excluded paths = %v, want one deduped entry", c.Skills.ExcludedPaths)
+	}
+	if err := c.ExcludeSkillPath(" "); err == nil {
+		t.Fatal("empty excluded skill path should error")
+	}
+	if err := c.RestoreSkillPath(root); err != nil {
+		t.Fatalf("restore skill path: %v", err)
+	}
+	if len(c.Skills.ExcludedPaths) != 0 {
+		t.Fatalf("excluded paths after restore = %v, want empty", c.Skills.ExcludedPaths)
+	}
+	if err := c.RestoreSkillPath(" "); err == nil {
+		t.Fatal("empty restored skill path should error")
 	}
 }
 

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -272,6 +272,11 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	} else {
 		b.WriteString("# paths = [\"~/my-skills\", \"../shared/skills\"]   # extra custom skill roots\n")
 	}
+	if len(c.Skills.ExcludedPaths) > 0 {
+		fmt.Fprintf(&b, "excluded_paths = %s   # skill roots hidden from discovery\n", renderStringArray(c.Skills.ExcludedPaths))
+	} else {
+		b.WriteString("# excluded_paths = [\"~/.agents/skills\"]   # hide convention roots without deleting folders\n")
+	}
 	if c.Skills.MaxDepth != 0 {
 		fmt.Fprintf(&b, "max_depth = %d   # nested scan depth; default 3, set 1 for legacy root-only discovery\n", c.SkillMaxDepth())
 	} else {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -43,6 +43,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 		},
 	}
 	orig.Skills.Paths = []string{"~/my-skills", "../shared/skills"}
+	orig.Skills.ExcludedPaths = []string{"~/.agents/skills"}
 	orig.Skills.DisabledSkills = []string{"review", "explore"}
 	orig.Skills.MaxDepth = 2
 	orig.Codegraph = CodegraphConfig{Enabled: true, AutoInstall: false, Path: "/opt/codegraph", Tier: "background"}
@@ -157,6 +158,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if len(got.Skills.Paths) != 2 || got.Skills.Paths[0] != "~/my-skills" {
 		t.Errorf("skills.paths = %v", got.Skills.Paths)
+	}
+	if len(got.Skills.ExcludedPaths) != 1 || got.Skills.ExcludedPaths[0] != "~/.agents/skills" {
+		t.Errorf("skills.excluded_paths = %v", got.Skills.ExcludedPaths)
 	}
 	if len(got.Skills.DisabledSkills) != 2 || got.Skills.DisabledSkills[0] != "review" || got.Skills.DisabledSkills[1] != "explore" {
 		t.Errorf("skills.disabled_skills = %v", got.Skills.DisabledSkills)

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -74,6 +74,7 @@ type Options struct {
 	HomeDir         string
 	ProjectRoot     string
 	CustomPaths     []string
+	ExcludedPaths   []string
 	DisabledNames   []string
 	MaxDepth        int
 	DisableBuiltins bool // suppress shipped built-ins (test-only knob)
@@ -88,6 +89,7 @@ type Store struct {
 	homeDir         string
 	projectRoot     string
 	customPaths     []string
+	excludedPaths   map[string]bool
 	disabled        map[string]bool
 	maxDepth        int
 	disableBuiltins bool
@@ -116,6 +118,10 @@ func New(opts Options) *Store {
 		}
 	}
 	custom := dedupePaths(resolveCustomPaths(opts.CustomPaths, base, home))
+	excluded := map[string]bool{}
+	for _, p := range dedupePaths(resolveCustomPaths(opts.ExcludedPaths, base, home)) {
+		excluded[config.CanonicalSkillPath(p)] = true
+	}
 	stderr := opts.Stderr
 	if stderr == nil {
 		stderr = os.Stderr
@@ -124,6 +130,7 @@ func New(opts Options) *Store {
 		homeDir:         home,
 		projectRoot:     root,
 		customPaths:     custom,
+		excludedPaths:   excluded,
 		disabled:        disabledNameSet(opts.DisabledNames),
 		maxDepth:        normalizeMaxDepth(opts.MaxDepth),
 		disableBuiltins: opts.DisableBuiltins,
@@ -173,9 +180,12 @@ func (s *Store) roots() []Root {
 	for _, c := range config.ConventionDirs {
 		dirs = append(dirs, de{filepath.Join(s.homeDir, c, SkillsDirname), ScopeGlobal})
 	}
-	out := make([]Root, len(dirs))
-	for i, d := range dirs {
-		out[i] = Root{Dir: d.dir, Scope: d.scope, Priority: i, Status: pathStatus(d.dir)}
+	out := make([]Root, 0, len(dirs))
+	for _, d := range dirs {
+		if s.excludedPaths[config.CanonicalSkillPath(d.dir)] {
+			continue
+		}
+		out = append(out, Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir)})
 	}
 	return out
 }

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"reasonix/internal/config"
 )
 
 func writeSkill(t *testing.T, base, rel, content string) string {
@@ -148,6 +150,26 @@ func TestConventionDirsDiscovered(t *testing.T) {
 	for _, name := range []string{"fromclaude", "fromagents", "fromagent"} {
 		if _, ok := find(list, name); !ok {
 			t.Errorf("convention dir for %q not scanned", name)
+		}
+	}
+}
+
+func TestExcludedPathsHideConventionRoots(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/keep.md", "---\ndescription: keep\n---\nb")
+	writeSkill(t, home, ".agents/skills/noisy.md", "---\ndescription: noisy\n---\nb")
+	excluded := filepath.Join(home, ".agents", "skills")
+	st := New(Options{HomeDir: home, ExcludedPaths: []string{excluded}, DisableBuiltins: true})
+
+	if _, ok := find(st.List(), "keep"); !ok {
+		t.Fatal("non-excluded skill should be listed")
+	}
+	if _, ok := find(st.List(), "noisy"); ok {
+		t.Fatal("excluded skill should not be listed")
+	}
+	for _, root := range st.Roots() {
+		if config.CanonicalSkillPath(root.Dir) == config.CanonicalSkillPath(excluded) {
+			t.Fatalf("excluded root should be hidden from Roots: %+v", st.Roots())
 		}
 	}
 }

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -123,6 +123,7 @@ enabled = []   # empty = all built-in tools
 # invoke them via /<name>. Manage with /skill (list, show, enable, disable, new, paths).
 # [skills]
 # paths = ["~/my-skills", "../shared/skills"]   # extra "custom"-scope skill roots
+# excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
 # disabled_skills = ["review"]                  # hide from prompt, slash invocation, and skill tools
 
 # Hooks run shell commands around the loop (PreToolUse / PostToolUse /


### PR DESCRIPTION
## Summary
- Add `[skills].excluded_paths` so users can hide skill discovery roots without deleting folders.
- Let the desktop Sources panel pseudo-delete convention roots such as `~/.agents/skills`; re-adding the same convention root restores it instead of adding a duplicate custom path.
- Thread excluded paths through boot, `/skills paths`, and desktop capabilities so hidden sources stay out of the runtime skill index and prompt.

## Tests
- `go test ./internal/config ./internal/skill ./internal/boot ./internal/cli`
- `(cd desktop && go test ./...)`
- `(cd desktop/frontend && npm run build)`
- Browser dev check: skill Sources shows remove/confirm controls for convention roots.

Fixes #3422