### PR TITLE
fix(css): add missing closing brace in onboarding__skip:disabled (take 2)

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7082,7 +7082,7 @@ a[href] {
 .onboarding__skip:disabled {
   opacity: 0.4;
   cursor: not-allowed;
-
+}
 
 /* Memory filter input: a full-width mem-input variant that sits below
    the section title. The existing mem-input already has a 28px height


### PR DESCRIPTION
Same root cause as PR #3418 — a merge conflict artefact between #2752 (onboarding overlay) and #3129 (InlineDiff component) left a second unclosed `.onboarding__skip:disabled` block at line 7082, about 30 lines below the first one.

The `check-css-syntax.mjs` script (added by PR #3420) now catches this in CI, which means every PR based on `main-v2` was failing the `desktop` check until this is merged upstream.

**Verification:**
- `node scripts/check-css-syntax.mjs src/styles.css` — ✅ passed
- `pnpm build` — ✅ passed