### PR TITLE
fix: allow messages starting with // to reach the model

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1080,7 +1080,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Slash commands run locally without going through the model. A
 			// '/'-leading line that's actually a dragged file path is an attachment,
 			// not a command, so it's rewritten to an @reference instead.
-			if strings.HasPrefix(line, "/") {
+			if strings.HasPrefix(line, "//") {
+				// Double-slash — common in JS comments, file:// URLs, etc.
+				// Not a command. Fall through to normal message path.
+			} else if strings.HasPrefix(line, "/") {
 				if ref, ok := control.FileRefLine(line); ok {
 					line = ref
 				} else {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -565,6 +565,10 @@ func (c *Controller) submit(input, display string) {
 			}
 			return c.runTurnWithRawDisplay(ctx, sent, sent, display)
 		})
+	case strings.HasPrefix(trimmed, "//"):
+		// Double-slash — not a command. Common in code snippets (JS
+		// comments, file:// URLs). Run as a normal turn.
+		c.runRefTurn(input, display)
 	case strings.HasPrefix(trimmed, "/"):
 		if ref, ok := FileRefLine(trimmed); ok {
 			c.runRefTurn(ref, display)


### PR DESCRIPTION
## Problem

Messages starting with `//` (e.g. JavaScript comments like `// 检查...`, `file://` URLs, multi-line console snippets) are intercepted by the `/`-command handler and never reach the model. The user sees `unknown command: //...`.

## Root cause

Both `internal/control/controller.go` and `internal/cli/chat_tui.go` check `strings.HasPrefix(input, "/")` to route slash commands, which also catches `//`.

## Fix

Add an explicit `//` check before the `/`-command handler so double-slash messages fall through to the normal turn path.

## Testing

- `go build ./internal/control/ ./internal/cli/` — ✅
- `go test ./internal/control/ ./internal/cli/` — ✅