### PR TITLE
fix(desktop): close unterminated CSS rule breaking the real-build job

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7082,6 +7082,7 @@ a[href] {
 .onboarding__skip:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+}
 
 
 /* Memory filter input: a full-width mem-input variant that sits below


### PR DESCRIPTION
Broken-main hotfix. The desktop real-build CI job (added by #3419) fails on `styles.css:7082` with "opening brace without a matching closing brace". The `.onboarding__skip:disabled` rule lost its `}` in a text-merge against adjacent rules — same class of merge accident as the #3410 duplicate locale keys, now caught by the CSS syntax check. Added the missing `}`; `check-css-syntax` passes and braces balance 1391/1391. (The frontend job validates css+tsc+vite end-to-end.)