### PR TITLE
fix(desktop): eliminate perceived delay when sending messages

### DIFF
--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -241,7 +241,7 @@ function applyEvent(s: State, e: WireEvent): State {
     if (e.kind === "turn_done") return { ...s, discardTurn: false, running: false, turnActive: false, currentAssistant: undefined, live: undefined };
     return s;
   }
-  if (s.pendingUser !== undefined && e.kind !== "turn_started" && e.kind !== "turn_done") {
+  if (s.pendingUser !== undefined && e.kind !== "turn_done") {
     s = flushPendingUser(s);
   }
   if (e.kind === "retrying") {
@@ -249,8 +249,16 @@ function applyEvent(s: State, e: WireEvent): State {
   }
   if (s.retry) s = { ...s, retry: undefined };
   switch (e.kind) {
-    case "turn_started":
-      return { ...s, running: true, turnActive: true, currentAssistant: undefined, turnStartAt: Date.now(), turnTokens: 0 };
+    case "turn_started": {
+      // Flush the user message and pre-create an empty assistant bubble
+      // immediately so the user sees their message + a blinking cursor the
+      // instant the backend acknowledges the turn — no dead gap waiting for
+      // the first text/reasoning token.
+      let cur: State = s;
+      if (cur.pendingUser !== undefined) cur = flushPendingUser(cur);
+      const { items, id, seq } = ensureAssistant(cur);
+      return { ...cur, items, currentAssistant: id, seq, live: { id, text: "", reasoning: "" }, running: true, turnActive: true, turnStartAt: Date.now(), turnTokens: 0 };
+    }
     case "text":
     case "reasoning": {
       const { items, id, seq } = ensureAssistant(s);


### PR DESCRIPTION
## Problem

When the user sends a message in the desktop app, there is a noticeable delay (0.3–3 s depending on model TTFT) before anything appears in the conversation area. During this gap:

1. The Composer clears its input (the text vanishes)
2. The Transcript stays completely blank — no user message, no assistant indicator
3. Only when the backend emits the first `text` or `reasoning` token does the user message finally appear

This creates a "dead zone" where the user's message has seemingly vanished into the void.

## Root Cause

In `useController.ts`, the reducer holds the user's text in `pendingUser` and only flushes it to `items` (the rendered list) on the first **non-`turn_started`/non-`turn_done`** event:

```typescript
// Line 147 (before fix)
if (s.pendingUser !== undefined && e.kind !== "turn_started" && e.kind !== "turn_done") {
  s = flushPendingUser(s);
}
```

The `turn_started` handler never touched `pendingUser`:

```typescript
// Line 155 (before fix)
case "turn_started":
  return { ...s, running: true, turnActive: true, currentAssistant: undefined, ... };
```

So the user message only becomes visible when the first `text`/`reasoning` event arrives from the backend — which could be hundreds of milliseconds to several seconds later.

## Fix

Two changes in `applyEvent`:

1. **Flush `pendingUser` on `turn_started`** — the user message appears the instant the backend acknowledges the turn, not when the first token arrives.

2. **Pre-create an empty assistant bubble with a blinking cursor** — gives immediate visual feedback that the model is processing (similar to ChatGPT/Claude's typing indicator). The Composer's status bar already shows "thinking… 0s", and now the Transcript also shows the cursor.

```typescript
case "turn_started": {
  let cur: State = s;
  if (cur.pendingUser !== undefined) cur = flushPendingUser(cur);
  const { items, id, seq } = ensureAssistant(cur);
  return { ...cur, items, currentAssistant: id, seq, live: { id, text: "", reasoning: "" }, running: true, turnActive: true, turnStartAt: Date.now(), turnTokens: 0 };
}
```

The guard condition is simplified from `e.kind !== "turn_started" && e.kind !== "turn_done"` to just `e.kind !== "turn_done"` — the `turn_done` exclusion is kept for the cancel-before-reply edge case.

## Before / After

| Moment | Before | After |
|--------|--------|-------|
| User hits Enter | Composer clears, Transcript blank | Composer clears, **Transcript shows user message + blinking cursor** |
| Backend processes (0.3–3 s) | Blank — user wonders "did it send?" | User message visible, cursor pulsing |
| First token arrives | User message + assistant text suddenly appear | Assistant text streams into the pre-existing bubble |

## Verification

- `pnpm typecheck` ✅ clean
- `pnpm build` ✅ `built in 10.58s`
- No new dependencies
- No i18n changes
- No CSS changes (`.cursor` animation already exists at styles.css:1172)
- Diff: 1 file, +11 / −3