### PR TITLE
fix(desktop): suppress hover highlight on the active tab

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6843,7 +6843,7 @@ a[href] {
   transition: background 0.12s;
 }
 
-.tabbar__tab:hover {
+.tabbar__tab:not(.tabbar__tab--active):hover {
   background: color-mix(in srgb, var(--bg-elev-2) 42%, transparent);
 }
 


### PR DESCRIPTION
## Problem

When hovering over the currently-selected tab in the tab bar, its background changes to the hover color (`--bg-elev-2`), making it look like the tab is **not** selected.  This is confusing — the active tab should visually remain stable regardless of mouse position.

## Root Cause

The hover rule applies to all `.tabbar__tab` elements unconditionally:

```css
.tabbar__tab:hover {
  background: color-mix(in srgb, var(--bg-elev-2) 42%, transparent);
}
```

The active tab's background (`--chat-bg`) is overridden by this hover mixin because both selectors have the same specificity and the hover rule comes first in source order — but `:hover` adds a pseudo-class specificity bump that wins.

## Fix

Add `:not(.tabbar__tab--active)` to the hover selector:

```css
.tabbar__tab:not(.tabbar__tab--active):hover {
  background: color-mix(in srgb, var(--bg-elev-2) 42%, transparent);
}
```

The close button inside the active tab is unaffected — its visibility is controlled by a separate rule (`.tabbar__tab--active .tabbar__tab-close`).

## Verification

- `pnpm typecheck` ✅ clean
- `pnpm build` ✅ `built in 5.00s`
- No new dependencies
- No i18n changes
- Diff: 1 file, +1 / −1