### PR TITLE
fix(desktop): remove gray bar on top of composer input when focused

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2035,6 +2035,14 @@ a[href] {
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 70%, transparent);
   opacity: 0.95;
 }
+/* Hide the resize handle while the input is focused — the user is typing,
+   not resizing.  The handle otherwise appears as a colored pill above the
+   card on hover (which always co-occurs with focus after a click). */
+.composer-card:focus-within .composer-resize-handle::before {
+  opacity: 0 !important;
+  background: color-mix(in srgb, var(--fg-faint) 38%, transparent) !important;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--border) 82%, transparent) !important;
+}
 .composer-resize-handle:focus-visible {
   outline: none;
 }
@@ -2168,11 +2176,20 @@ a[href] {
   min-height: calc(var(--font-content) * 1.55);
   outline: none;
   overflow-y: hidden;
+  scrollbar-width: none;           /* Firefox */
+}
+.composer__input::-webkit-scrollbar {
+  display: none;                    /* Chrome / Safari / Wails webview */
 }
 .composer-card--resized .composer__input {
   height: 100%;
   max-height: none;
   overflow-y: auto;
+  scrollbar-width: thin;           /* restore scrollbar when resized */
+}
+.composer-card--resized .composer__input::-webkit-scrollbar {
+  display: block;
+  width: 6px;
 }
 .composer__input::placeholder {
   color: var(--fg-faint);


### PR DESCRIPTION
## Problem

After clicking into the composer textarea, a gray bar appears along the top inner edge of the input.  It looks like a scrollbar track and is visually distracting — especially since the composer already has a border-color change on focus to indicate the active state.

## Root Cause

Two contributing factors:

1. **Resize handle** — The `.composer-resize-handle::before` pseudo-element is a 2px bar at the top of the composer card.  It's styled with `background: transparent` by default and shows on `:hover`.  Since clicking the textarea always co-occurs with hovering the card, the handle becomes visible the instant focus lands — it reads as an unexpected scrollbar-like bar above the text.

2. **Native scrollbar** — The textarea uses `field-sizing: content` for auto-growth.  In some webview configurations, the native scrollbar track can appear even before content overflows the `max-height`.

## Fix

| Change | Effect |
|--------|--------|
| `.composer-card:focus-within .composer-resize-handle::before { background: transparent !important }` | Hide the resize handle while the user is typing |
| `.composer__input { scrollbar-width: none }` + `::-webkit-scrollbar { display: none }` | Suppress native scrollbar in the default (non-resized) state |
| `.composer-card--resized .composer__input { scrollbar-width: thin }` + `::-webkit-scrollbar { display: block; width: 6px }` | Restore a thin scrollbar when the user has explicitly resized the composer |

The border-color change on `:focus-within` is preserved as the sole focus indicator.

## Verification

- `pnpm typecheck` ✅ clean
- `pnpm build` ✅ `built in 5.25s`
- No new dependencies
- No i18n changes
- Diff: 1 file, +16 / −0