### PR TITLE
fix(desktop): anchor send button to bottom-right of composer

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2181,6 +2181,7 @@ a[href] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  align-self: flex-end;
   width: 32px;
   height: 32px;
   border: none;


### PR DESCRIPTION
## Problem

The send button uses the default flex alignment (`center`), so it floats vertically centred in the composer.  As the textarea grows to 2, 3, 4+ lines, the button drifts downward with each new line — the muscle memory target keeps moving.

## Fix

Add `align-self: flex-end` to `.composer__btn`:

```css
.composer__btn {
  ...
  align-self: flex-end;
  ...
}
```

This pins the button to the bottom-right corner of the flex container regardless of how tall the input is.  The caret (`›`) keeps the default `align-items: center` so it stays visually anchored to the first line of text.

## Before / After

| Lines | Before (button position) | After (button position) |
|-------|--------------------------|-------------------------|
| 1 line | Centred ✓ | Bottom ✓ |
| 3 lines | Drifted down ✗ | Bottom (same spot) ✓ |
| 5 lines | Near bottom ✗ | Bottom (same spot) ✓ |

## Verification

- `pnpm typecheck` ✅ clean
- `pnpm build` ✅ `built in 12.75s`
- No new dependencies
- No i18n changes
- Diff: 1 file, +1 / −0