### PR TITLE
fix(config): skip keyless providers in ResolveModelWithFallback

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1489,7 +1489,10 @@ func (c *Config) ResolveModelWithFallback(ref string) (resolvedRef string, fallb
 	}
 	for i := range c.Providers {
 		p := &c.Providers[i]
-		if len(p.ModelList()) == 0 {
+		// Skip providers with no models or no API key: falling back onto a keyless
+		// provider just boots the tab onto something that fails on first use. Mirrors
+		// the Configured() gate the provider-removal/selection paths already apply.
+		if len(p.ModelList()) == 0 || !p.Configured() {
 			continue
 		}
 		return p.Name + "/" + p.DefaultModel(), true, true

--- a/internal/config/model_fallback_test.go
+++ b/internal/config/model_fallback_test.go
@@ -52,6 +52,22 @@ func TestResolveModelWithFallback(t *testing.T) {
 	}
 }
 
+func TestResolveModelWithFallbackSkipsKeylessProvider(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	// Make the first provider keyless. A fallback must skip it and pick the next
+	// configured provider, rather than booting a tab onto a provider with no API
+	// key (which just fails on first use).
+	c.Providers[0].APIKeyEnv = "REASONIX_TEST_EMPTY"
+
+	got, fallback, ok := c.ResolveModelWithFallback("")
+	if !ok || !fallback {
+		t.Fatalf("ResolveModelWithFallback(\"\") = (%q, %v, %v), want a fallback", got, fallback, ok)
+	}
+	if got != "prov-b/model-b1" {
+		t.Errorf("fallback = %q, want prov-b/model-b1 (prov-a is keyless and must be skipped)", got)
+	}
+}
+
 func TestModelRefsProvider(t *testing.T) {
 	if !ModelRefsProvider("deepseek-flash", "deepseek-flash") {
 		t.Fatal("bare provider ref should match provider")


### PR DESCRIPTION
Follow-up to #3421/#3437. `ResolveModelWithFallback` (the resolver used when a tab's model ref goes missing) returned the first provider with a non-empty model list **without checking `Configured()`**, so it could boot a tab onto a provider with no API key (`boot.Build(..., RequireKey:false)`), which fails on first use. The removal/selection paths already gate on `Configured()`; the resolver now matches them. One-line + a regression test (`TestResolveModelWithFallbackSkipsKeylessProvider`). Pre-existing since #3421, untouched by #3437.