### PR TITLE
Fix legacy desktop provider access inference / 修复旧版桌面供应商接入推断

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2936,6 +2936,14 @@ func (a *App) applyProviderEffortConfig(entry *config.ProviderEntry, effort stri
 				return err
 			}
 		}
+		canonicalName := config.CanonicalDesktopOfficialProviderName(entry.Name)
+		if canonicalName != entry.Name {
+			if _, ok := cfg.Provider(canonicalName); ok {
+				if err := cfg.SetProviderEffort(canonicalName, effort); err != nil {
+					return err
+				}
+			}
+		}
 		return cfg.SetProviderEffort(entry.Name, effort)
 	})
 }

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -304,6 +304,7 @@ func TestSettingsSurfacesOfficialProviderTemplatesSeparately(t *testing.T) {
 
 func TestSettingsRepairsLegacyOfficialProviderWithoutModel(t *testing.T) {
 	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
@@ -321,15 +322,124 @@ api_key_env = "DEEPSEEK_API_KEY"
 
 	got := NewApp().Settings()
 	for _, p := range got.Providers {
-		if p.Name != "deepseek-flash" {
+		if p.Name != "deepseek" {
 			continue
 		}
-		if len(p.Models) != 1 || p.Models[0] != "deepseek-v4-flash" || p.Default != "deepseek-v4-flash" {
-			t.Fatalf("deepseek-flash provider = %+v, want repaired flash model", p)
+		if !p.Added || !p.KeySet || len(p.Models) != 2 || p.Models[0] != "deepseek-v4-flash" || p.Models[1] != "deepseek-v4-pro" || p.Default != "deepseek-v4-flash" {
+			t.Fatalf("deepseek provider = %+v, want added repaired official model list", p)
+		}
+		if got.DefaultModel != "deepseek/deepseek-v4-flash" {
+			t.Fatalf("default_model = %q, want deepseek/deepseek-v4-flash", got.DefaultModel)
 		}
 		return
 	}
-	t.Fatalf("settings providers missing deepseek-flash: %+v", got.Providers)
+	t.Fatalf("settings providers missing deepseek: %+v", got.Providers)
+}
+
+func TestSettingsInfersLegacyProviderAccessWhenMissing(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	t.Setenv("MIMO_API_KEY", "sk-test")
+	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserConfigPath(), []byte(`
+default_model = "deepseek-flash/deepseek-v4-pro"
+
+[[providers]]
+name = "deepseek-flash"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+models = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+
+[[providers]]
+name = "mimo-pro"
+kind = "openai"
+base_url = "https://token-plan-cn.xiaomimimo.com/v1"
+model = "mimo-v2.5-pro"
+api_key_env = "MIMO_API_KEY"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got := NewApp().Settings()
+	providers := map[string]ProviderView{}
+	for _, p := range got.Providers {
+		providers[p.Name] = p
+	}
+	if !providers["deepseek"].Added || !providers["deepseek"].KeySet {
+		t.Fatalf("deepseek provider = %+v, want inferred added key-set provider", providers["deepseek"])
+	}
+	if !providers["mimo-token-plan"].Added || !providers["mimo-token-plan"].KeySet {
+		t.Fatalf("mimo-token-plan provider = %+v, want inferred added key-set provider", providers["mimo-token-plan"])
+	}
+	if got.DefaultModel != "deepseek/deepseek-v4-pro" {
+		t.Fatalf("default_model = %q, want deepseek/deepseek-v4-pro", got.DefaultModel)
+	}
+}
+
+func TestSettingsDoesNotInferProviderAccessWhenExplicitlyEmpty(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserConfigPath(), []byte(`
+default_model = "deepseek-flash/deepseek-v4-flash"
+
+[desktop]
+provider_access = []
+
+[[providers]]
+name = "deepseek-flash"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+models = ["deepseek-v4-flash"]
+default = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got := NewApp().Settings()
+	for _, p := range got.Providers {
+		if p.Added {
+			t.Fatalf("provider %+v should not be inferred as added when provider_access is explicit empty", p)
+		}
+	}
+}
+
+func TestSettingsInfersConfiguredBuiltInsWithoutConfigFile(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	t.Setenv("MIMO_API_KEY", "sk-test")
+
+	got := NewApp().Settings()
+	providers := map[string]ProviderView{}
+	for _, p := range got.Providers {
+		providers[p.Name] = p
+	}
+	if !providers["deepseek"].Added || !providers["deepseek"].KeySet {
+		t.Fatalf("deepseek provider = %+v, want inferred added provider from configured key", providers["deepseek"])
+	}
+	if !providers["mimo-token-plan"].Added || !providers["mimo-token-plan"].KeySet {
+		t.Fatalf("mimo-token-plan provider = %+v, want inferred added provider from configured key", providers["mimo-token-plan"])
+	}
+}
+
+func TestSettingsDoesNotInferBuiltInsWithoutKeys(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	t.Setenv("MIMO_API_KEY", "")
+
+	got := NewApp().Settings()
+	for _, p := range got.Providers {
+		if p.Added {
+			t.Fatalf("provider %+v should not be inferred as added without a configured key", p)
+		}
+	}
 }
 
 func TestAddOfficialProviderAccessReplacesLegacyProviderWithoutModel(t *testing.T) {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -327,16 +327,48 @@ func (a *App) loadDesktopUserConfigForEdit() (*config.Config, string, error) {
 		return nil, "", fmt.Errorf("cannot resolve user config directory")
 	}
 	if _, err := os.Stat(userPath); err == nil {
-		return config.LoadForEdit(userPath), userPath, nil
+		cfg := config.LoadForEdit(userPath)
+		normalizeLegacyDesktopProviderAccessForSettings(cfg, userPath)
+		return cfg, userPath, nil
 	}
 	cfg := config.LoadForEdit(userPath)
 	legacyPath := config.SourcePathForRoot(a.activeWorkspaceRoot())
 	if legacyPath == "" || sameConfigPath(legacyPath, userPath) {
+		normalizeLegacyDesktopProviderAccessForSettings(cfg, userPath)
 		return cfg, userPath, nil
 	}
 	legacyCfg := config.LoadForEdit(legacyPath)
+	normalizeLegacyDesktopProviderAccessForSettings(legacyCfg, legacyPath)
 	legacyCfg.ConfigVersion = config.Default().ConfigVersion
 	return legacyCfg, userPath, nil
+}
+
+func normalizeLegacyDesktopProviderAccessForSettings(cfg *config.Config, path string) {
+	if cfg == nil || len(cfg.Desktop.ProviderAccess) > 0 || configDeclaresProviderAccess(path) {
+		return
+	}
+	config.NormalizeLegacyDesktopProviderAccess(cfg)
+}
+
+func configDeclaresProviderAccess(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(body), "\n") {
+		if before, _, ok := strings.Cut(line, "#"); ok {
+			line = before
+		}
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "provider_access") {
+			rest := strings.TrimSpace(strings.TrimPrefix(line, "provider_access"))
+			return strings.HasPrefix(rest, "=")
+		}
+	}
+	return false
 }
 
 func (a *App) activeWorkspaceRoot() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1073,6 +1073,52 @@ func normalizeDesktopOfficialProviderAccess(c *Config) {
 	retargetDesktopOfficialRefs(c, seen)
 }
 
+// NormalizeLegacyDesktopProviderAccess seeds the desktop provider-access list
+// for configs written before Settings tracked explicit provider access. Callers
+// should only use this when they know the TOML did not declare provider_access;
+// an explicit empty list means the user removed all access entries.
+func NormalizeLegacyDesktopProviderAccess(c *Config) {
+	if c == nil || len(c.Desktop.ProviderAccess) > 0 {
+		return
+	}
+	seen := desktopProviderAccessMap(nil)
+	var access []string
+	add := func(name string) {
+		name = canonicalDesktopOfficialProviderName(name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		access = append(access, name)
+	}
+	addRef := func(ref string) {
+		if entry, ok := c.ResolveModel(ref); ok {
+			if !entry.Configured() {
+				return
+			}
+			add(entry.Name)
+		}
+	}
+	addRef(c.DefaultModel)
+	addRef(c.Agent.PlannerModel)
+	addRef(c.Agent.SubagentModel)
+	addRef(c.Agent.AutoPlanClassifier)
+	for _, ref := range c.Agent.SubagentModels {
+		addRef(ref)
+	}
+	for i := range c.Providers {
+		p := &c.Providers[i]
+		if p.Configured() {
+			add(p.Name)
+		}
+	}
+	if len(access) == 0 {
+		return
+	}
+	c.Desktop.ProviderAccess = access
+	normalizeDesktopOfficialProviderAccess(c)
+}
+
 func canonicalDesktopOfficialProviderName(name string) string {
 	switch strings.TrimSpace(name) {
 	case "deepseek-flash", "deepseek-pro":
@@ -1084,6 +1130,12 @@ func canonicalDesktopOfficialProviderName(name string) string {
 	default:
 		return strings.TrimSpace(name)
 	}
+}
+
+// CanonicalDesktopOfficialProviderName returns the Settings Center provider ID
+// for built-in official provider aliases.
+func CanonicalDesktopOfficialProviderName(name string) string {
+	return canonicalDesktopOfficialProviderName(name)
 }
 
 func desktopProviderAccessMap(names []string) map[string]bool {


### PR DESCRIPTION
## Summary
- Infer desktop provider access for legacy Settings configs that predate `desktop.provider_access`, so Settings > Model shows the same configured providers as the bottom model switcher.
- Treat explicit `provider_access = []` as an intentional empty access list and do not auto-add providers.
- Infer built-in official providers from configured keys when no config file exists, covering upgrades that preserved credentials but not the new access list.
- Keep `/effort auto` aligned with canonical official provider IDs when legacy aliases are migrated.

## Verification
- `go test ./...` (initial run hit a transient `internal/cli TestLoadGitStatus` git-status identity failure; `go test ./internal/cli` passed on rerun)
- `go test ./...` in `desktop`
- `pnpm build` in `desktop/frontend`
- `git diff --check`