### PR TITLE
Refresh installed skills in active sessions / 刷新当前会话中新安装的 skills

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -170,9 +170,10 @@ export function Composer({
   insertRequest?: ComposerInsertRequest | null;
   disabled?: boolean;
   decisionPending?: boolean;
-  // ready/cwd re-trigger the command fetch: Commands() returns only built-ins
-  // until boot.Build finishes (the controller, hence skills/custom/MCP, is nil
-  // before then), and the available set changes when the workspace switches.
+  // ready/cwd/running re-trigger the command fetch: Commands() returns only
+  // built-ins until boot.Build finishes (the controller, hence skills/custom/MCP,
+  // is nil before then), the available set changes when the workspace switches,
+  // and a completed turn may have installed skills or MCP prompts.
   ready?: boolean;
   turnStartAt?: number;
   turnTokens?: number;
@@ -228,7 +229,7 @@ export function Composer({
   const [commands, setCommands] = useState<CommandInfo[]>([]);
   useEffect(() => {
     app.Commands().then((next) => setCommands(asArray(next))).catch(() => {});
-  }, [ready, cwd]);
+  }, [ready, cwd, running]);
 
   const slashQuery = useMemo(() => {
     if (!text.startsWith("/") || /\s/.test(text)) return null;

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -190,7 +190,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Stderr:        opts.Stderr,
 	})
 	skills := skillStore.List()
-	allSkills := skill.New(skill.Options{ProjectRoot: root, CustomPaths: cfg.SkillCustomPaths(), ExcludedPaths: cfg.SkillExcludedPaths(), MaxDepth: cfg.SkillMaxDepth(), Stderr: io.Discard}).List()
+	allSkillStore := skill.New(skill.Options{ProjectRoot: root, CustomPaths: cfg.SkillCustomPaths(), ExcludedPaths: cfg.SkillExcludedPaths(), MaxDepth: cfg.SkillMaxDepth(), Stderr: io.Discard})
+	allSkills := allSkillStore.List()
 	sysPrompt = skill.ApplyIndex(sysPrompt, skills)
 
 	reg := tool.NewRegistry()
@@ -665,6 +666,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Commands:      cmds,
 		Skills:        skills,
 		AllSkills:     allSkills,
+		SkillStore:    skillStore,
+		AllSkillStore: allSkillStore,
 		Hooks:         hookRunner,
 		Memory:        mem,
 		Cleanup:       cleanup,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -59,20 +59,22 @@ type Controller struct {
 	sink     event.Sink
 	policy   permission.Policy
 
-	label        string
-	systemPrompt string
-	sessionDir   string
-	host         *plugin.Host
-	commands     []command.Command
-	skills       []skill.Skill
-	allSkills    []skill.Skill
-	hooks        *hook.Runner // session hook runner; nil-safe (no hooks configured)
-	mem          *memory.Set
-	cleanup      func()
-	autoPlan     string
-	classifier   autoPlanClassifier
-	startedOnce  bool              // guards the one-shot SessionStart hook on first turn
-	onRemember   func(rule string) // set via Options; invoked when user picks "always allow"
+	label         string
+	systemPrompt  string
+	sessionDir    string
+	host          *plugin.Host
+	commands      []command.Command
+	skills        []skill.Skill
+	allSkills     []skill.Skill
+	skillStore    *skill.Store
+	allSkillStore *skill.Store
+	hooks         *hook.Runner // session hook runner; nil-safe (no hooks configured)
+	mem           *memory.Set
+	cleanup       func()
+	autoPlan      string
+	classifier    autoPlanClassifier
+	startedOnce   bool              // guards the one-shot SessionStart hook on first turn
+	onRemember    func(rule string) // set via Options; invoked when user picks "always allow"
 
 	// balanceURL/balanceKey target the active provider's optional wallet-balance
 	// endpoint (empty when the provider declares none). Captured at build so a
@@ -160,21 +162,23 @@ type approvalReply struct {
 // lets the controller mint and rotate session files; Host/Commands are surfaced
 // to frontends that resolve MCP prompts and slash commands.
 type Options struct {
-	Runner       agent.Runner
-	Executor     *agent.Agent
-	Sink         event.Sink
-	Policy       permission.Policy
-	Label        string
-	SystemPrompt string
-	SessionDir   string
-	SessionPath  string
-	Host         *plugin.Host
-	Commands     []command.Command
-	Skills       []skill.Skill
-	AllSkills    []skill.Skill
-	Hooks        *hook.Runner
-	Memory       *memory.Set
-	Cleanup      func()
+	Runner        agent.Runner
+	Executor      *agent.Agent
+	Sink          event.Sink
+	Policy        permission.Policy
+	Label         string
+	SystemPrompt  string
+	SessionDir    string
+	SessionPath   string
+	Host          *plugin.Host
+	Commands      []command.Command
+	Skills        []skill.Skill
+	AllSkills     []skill.Skill
+	SkillStore    *skill.Store
+	AllSkillStore *skill.Store
+	Hooks         *hook.Runner
+	Memory        *memory.Set
+	Cleanup       func()
 	// BalanceURL/BalanceKey wire the active provider's optional wallet-balance
 	// endpoint and bearer key; empty when the provider declares no balance_url.
 	BalanceURL    string
@@ -224,6 +228,8 @@ func New(opts Options) *Controller {
 		commands:      opts.Commands,
 		skills:        opts.Skills,
 		allSkills:     opts.AllSkills,
+		skillStore:    opts.SkillStore,
+		allSkillStore: opts.AllSkillStore,
 		hooks:         opts.Hooks,
 		mem:           opts.Memory,
 		cleanup:       opts.Cleanup,
@@ -1467,11 +1473,21 @@ func (c *Controller) Host() *plugin.Host { return c.host }
 func (c *Controller) Commands() []command.Command { return c.commands }
 
 // Skills returns the discoverable skills (for the slash menu and `/skills`).
-func (c *Controller) Skills() []skill.Skill { return c.skills }
+// When a live Store is available, scan it on demand so skills installed during
+// this session appear without rewriting the cache-stable system prompt.
+func (c *Controller) Skills() []skill.Skill {
+	if c.skillStore != nil {
+		return c.skillStore.List()
+	}
+	return c.skills
+}
 
 // AllSkills returns every discoverable skill, including disabled ones, for
 // management surfaces that need to re-enable a hidden skill.
 func (c *Controller) AllSkills() []skill.Skill {
+	if c.allSkillStore != nil {
+		return c.allSkillStore.List()
+	}
 	if len(c.allSkills) > 0 {
 		return c.allSkills
 	}

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -104,12 +104,22 @@ func (c *Controller) RunSkill(input string) (sent string, found bool) {
 		return "", false
 	}
 	name := strings.TrimPrefix(fields[0], "/")
-	for _, sk := range c.skills {
-		if sk.Name == name {
-			return skill.Render(sk, strings.Join(fields[1:], " ")), true
-		}
+	if sk, ok := c.skillByName(name); ok {
+		return skill.Render(sk, strings.Join(fields[1:], " ")), true
 	}
 	return "", false
+}
+
+func (c *Controller) skillByName(name string) (skill.Skill, bool) {
+	if c.skillStore != nil {
+		return c.skillStore.Read(name)
+	}
+	for _, sk := range c.skills {
+		if sk.Name == name {
+			return sk, true
+		}
+	}
+	return skill.Skill{}, false
 }
 
 // MCPPrompt resolves a "/mcp__server__prompt args…" line: it maps the positional

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -12,6 +12,7 @@ import (
 	"reasonix/internal/command"
 	"reasonix/internal/event"
 	"reasonix/internal/memory"
+	"reasonix/internal/skill"
 )
 
 type fakeAutoPlanClassifier struct {
@@ -46,6 +47,40 @@ func TestCustomCommandLookup(t *testing.T) {
 	}
 	if _, ok := c.CustomCommand("/missing"); ok {
 		t.Error("missing should not be found")
+	}
+}
+
+func TestSkillsReflectStoreChangesAfterControllerBuild(t *testing.T) {
+	project := t.TempDir()
+	home := t.TempDir()
+	store := skill.New(skill.Options{HomeDir: home, ProjectRoot: project, DisableBuiltins: true})
+	c := New(Options{SkillStore: store, Skills: store.List()})
+
+	if _, ok := c.RunSkill("/hot now"); ok {
+		t.Fatal("skill should not exist before it is written")
+	}
+	writeControlSkill(t, project, ".reasonix/skills/hot/SKILL.md", "---\nname: hot\ndescription: Hot install\n---\nHot body")
+
+	if skills := c.Skills(); len(skills) != 1 || skills[0].Name != "hot" {
+		t.Fatalf("Skills() = %+v, want newly installed hot skill", skills)
+	}
+	sent, ok := c.RunSkill("/hot now")
+	if !ok {
+		t.Fatal("RunSkill should find newly installed skill")
+	}
+	if !strings.Contains(sent, "Hot body") || !strings.Contains(sent, "Arguments: now") {
+		t.Fatalf("rendered skill = %q", sent)
+	}
+}
+
+func writeControlSkill(t *testing.T, root, rel, body string) {
+	t.Helper()
+	path := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Rescan the live skill stores for controller skill listings and slash skill invocation so newly installed skills are visible in the active session.
- Refetch desktop slash commands when a turn finishes so installer tools can update the composer menu without a reload.
- Add regression coverage for dynamic skill discovery after controller creation.

## Verification
- go test ./...
- cd desktop && go test ./...
- cd desktop/frontend && pnpm run check:css
- cd desktop && wails generate module, then cd frontend && pnpm run typecheck