### PR TITLE
ci(release): split npm onto its own tag line, decoupled from brew

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,53 @@
+name: Release npm
+
+# npm line. Tag namespace `npm-v<semver>` triggers this — plain `v<semver>` tags
+# are the CLI binary + Homebrew release (release.yml) and intentionally do NOT
+# trigger here (GitHub glob `npm-v*` does not match `v*`). Splitting npm onto its
+# own tag lets a prerelease ship to npm's `next` channel without touching the
+# stable Homebrew cask (and lets a stable cask ship without forcing npm to leave
+# its rc). Bump with:
+#   git tag npm-vX.Y.Z          # stable  -> publishes under `next`
+#   git tag npm-vX.Y.Z-rc.N     # prerelease -> publishes under `next`
+#   git push origin <tag>
+#
+# build.mjs decides the dist-tag: only the 0.x stable line is `latest`; the 1.x
+# line and every prerelease ship under `next`. Promote a 1.x stable to the default
+# install with a manual `npm dist-tag add reasonix@X.Y.Z latest`.
+on:
+  push:
+    tags: ['npm-v*']
+
+permissions:
+  contents: read
+
+jobs:
+  cache-guard:
+    name: cache hit guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - run: ./scripts/cache-guard.sh
+
+  npm:
+    name: publish npm packages
+    needs: cache-guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+      # build.mjs strips the leading `npm-`/`v`, so it derives the bare semver from
+      # the `npm-v*` tag (e.g. npm-v1.3.0-rc.1 -> 1.3.0-rc.1).
+      - run: node npm/build.mjs "${GITHUB_REF_NAME}" --publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,12 @@
 name: Release
 
+# CLI binary line. Tag namespace `v<semver>` triggers this — it builds the
+# release archives + checksums, publishes the GitHub release, and updates the
+# Homebrew cask. npm is a SEPARATE line (release-npm.yml, `npm-v*`) so an npm
+# prerelease can ship without forcing the stable cask, and vice versa; desktop is
+# `desktop-v*` (release-desktop.yml). A prerelease `v*-rc*` still builds archives
+# and a prerelease GitHub release, but goreleaser auto-skips the cask upload
+# (brew has no prerelease channel — see .goreleaser.yaml).
 on:
   push:
     tags: ['v*']
@@ -38,21 +45,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-
-  npm:
-    name: publish npm packages
-    needs: cache-guard
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-      - run: node npm/build.mjs "${GITHUB_REF_NAME}" --publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,8 @@ homebrew_casks:
     ids: [reasonix]
     # Prereleases (v*-rc*) must not update the stable tap; brew has no separate
     # prerelease channel, so a pushed rc cask becomes the default `brew install`.
+    # npm is a separate line (release-npm.yml, `npm-v*`), so an npm prerelease no
+    # longer drags brew along — a stable `v*` cask can ship while npm stays on rc.
     skip_upload: "auto"
     repository:
       owner: esengine

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -18,10 +18,11 @@ const TARGETS = [
 
 const tag = process.argv[2] ?? process.env.GITHUB_REF_NAME;
 if (!tag) {
-  console.error("usage: node npm/build.mjs <tag>   (e.g. v1.0.0)");
+  console.error("usage: node npm/build.mjs <tag>   (e.g. v1.0.0 or npm-v1.0.0)");
   process.exit(1);
 }
-const version = tag.replace(/^v/, "");
+// npm ships on its own `npm-v*` tag (release-npm.yml); also accept a bare `v*`.
+const version = tag.replace(/^(npm-)?v/, "");
 const publish = process.argv.includes("--publish");
 
 rmSync(STAGE, { recursive: true, force: true });


### PR DESCRIPTION
## Why

The CLI release was driven by a single `v*` tag that ran goreleaser (archives + GitHub release + Homebrew cask) **and** published npm together. goreleaser auto-skips the cask on prereleases (brew has no prerelease channel), so:

- a `v*-rc*` tag could publish an npm rc, but **never** a stable cask, and
- a stable `v*` forced npm to leave its rc.

The two channels could not move independently — which blocks shipping an npm rc while brew goes stable in the same cycle.

## What

Give npm its own tag namespace, mirroring the desktop line:

| Tag | Workflow | Produces |
|---|---|---|
| `v*` | `release.yml` | archives + checksums + GitHub release + Homebrew cask |
| `npm-v*` | `release-npm.yml` (**new**) | npm publish only (own `cache-guard` gate) |
| `desktop-v*` | `release-desktop.yml` (unchanged) | desktop |

- `build.mjs` now strips `^(npm-)?v`, so `npm-v1.3.0-rc.1` → `1.3.0-rc.1` (dist-tag stays `next` for the 1.x line and every prerelease).
- A normal stable release now needs **both** `v1.3.0` and `npm-v1.3.0` tags (the cost of decoupling).

## Verification (local)

- `actionlint` on both workflows → exit 0
- `goreleaser check` → config valid; `goreleaser release --snapshot` → 6 targets + archives + cask
- `node npm/build.mjs npm-v1.3.0-rc.1` → staged `1.3.0-rc.1`, dist-tag `next`
- `go test ./...` (English locale) → all green; release cache guard passes

> Note: this must merge to `main-v2` **before** pushing any `npm-v*` tag — tag-triggered runs read the workflow from the tagged commit.