### PR TITLE
Fix skill detail expand button / 修复技能详情展开按钮

### DIFF
--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -1219,7 +1219,11 @@ function SkillRow({
         </Tooltip>
       </div>
       <div className="cap-skill-card__desc">{expanded ? skill.description : summary}</div>
-      {canExpand && <div className="cap-skill-card__more">{expanded ? t("common.collapse") : t("common.expand")}</div>}
+      {canExpand && (
+        <button className="cap-skill-card__more" type="button" onClick={onToggle} aria-expanded={expanded}>
+          {expanded ? t("common.collapse") : t("common.expand")}
+        </button>
+      )}
     </div>
   );
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5701,10 +5701,27 @@ a[href] {
   overflow: visible;
 }
 .cap-skill-card__more {
+  display: inline-flex;
+  align-items: center;
   margin: 7px 0 0 33px;
+  padding: 0;
+  border: 0;
+  background: transparent;
   color: var(--accent);
+  cursor: pointer;
+  font: inherit;
   font-size: 11px;
   font-weight: 650;
+  line-height: 1.3;
+  text-align: left;
+}
+.cap-skill-card__more:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 52%, transparent);
+  outline-offset: 3px;
+  border-radius: 5px;
+}
+.cap-skill-card__more:hover {
+  color: var(--accent-strong);
 }
 .cap-dot {
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- make the skill card's lower expand/collapse affordance a real button
- wire that button to the same detail toggle handler as the skill card header
- preserve the existing visual treatment while adding hover and keyboard focus states

## Root cause
The visible "Expand" text under long skill descriptions was rendered as a plain `div`, so clicking it did not call the skill detail toggle handler. Only the card header button actually toggled the expanded state.

## Validation
- `pnpm --dir desktop/frontend build` passed after generating local Wails bindings

Fixes #3460
