### PR TITLE
fix(config): preserve LSP settings on config save

### DIFF
--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -273,6 +273,8 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	}
 	b.WriteString("\n")
 
+	renderLSPConfig(&b, c.LSP)
+
 	b.WriteString("[skills]\n")
 	if len(c.Skills.Paths) > 0 {
 		fmt.Fprintf(&b, "paths = %s   # extra custom skill roots\n", renderStringArray(c.Skills.Paths))
@@ -413,6 +415,68 @@ func shouldRenderSystemPrompt(c, defaults *Config, scope RenderScope) bool {
 		return true
 	}
 	return strings.TrimSpace(c.Agent.SystemPrompt) != "" && c.Agent.SystemPrompt != defaults.Agent.SystemPrompt
+}
+
+func renderLSPConfig(b *strings.Builder, cfg LSPConfig) {
+	b.WriteString("[lsp]\n")
+	fmt.Fprintf(b, "enabled = %v   # language server tools; servers launch lazily when used\n", cfg.Enabled)
+	if len(cfg.Servers) == 0 {
+		b.WriteString("# [lsp.servers.go]\n")
+		b.WriteString("# command = \"gopls\"\n")
+		b.WriteString("# args = []\n")
+		b.WriteString("# extensions = [\".go\"]\n\n")
+		return
+	}
+	b.WriteString("\n")
+
+	langs := make([]string, 0, len(cfg.Servers))
+	for lang := range cfg.Servers {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+	for _, lang := range langs {
+		srv := cfg.Servers[lang]
+		fmt.Fprintf(b, "[lsp.servers.%s]\n", renderTOMLKeyPart(lang))
+		if srv.Command != "" {
+			fmt.Fprintf(b, "command = %q\n", srv.Command)
+		}
+		if len(srv.Args) > 0 {
+			fmt.Fprintf(b, "args = %s\n", renderStringArray(srv.Args))
+		}
+		if len(srv.Env) > 0 {
+			fmt.Fprintf(b, "env = %s\n", renderStringMap(srv.Env))
+		}
+		if srv.LanguageID != "" {
+			fmt.Fprintf(b, "language_id = %q\n", srv.LanguageID)
+		}
+		if len(srv.Extensions) > 0 {
+			fmt.Fprintf(b, "extensions = %s\n", renderStringArray(srv.Extensions))
+		}
+		if srv.InstallHint != "" {
+			fmt.Fprintf(b, "install_hint = %q\n", srv.InstallHint)
+		}
+		b.WriteString("\n")
+	}
+}
+
+func renderTOMLKeyPart(key string) string {
+	if isBareTOMLKey(key) {
+		return key
+	}
+	return strconv.Quote(key)
+}
+
+func isBareTOMLKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, r := range key {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // renderStringArray renders a []string as a TOML inline array.

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -48,6 +49,19 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Skills.DisabledSkills = []string{"review", "explore"}
 	orig.Skills.MaxDepth = 2
 	orig.Codegraph = CodegraphConfig{Enabled: true, AutoInstall: false, Path: "/opt/codegraph", Tier: "background"}
+	orig.LSP = LSPConfig{
+		Enabled: true,
+		Servers: map[string]LSPServer{
+			"lua": {
+				Command:     "lua-language-server",
+				Args:        []string{"--stdio"},
+				Env:         map[string]string{"LUA_PATH": "./?.lua"},
+				LanguageID:  "lua",
+				Extensions:  []string{".lua", ".script", ".gui_script"},
+				InstallHint: "install lua-language-server",
+			},
+		},
+	}
 	orig.Plugins = []PluginEntry{
 		{Name: "example", Command: "reasonix-plugin-example"},
 		{Name: "stripe", Type: "http", URL: "https://mcp.stripe.com", Headers: map[string]string{"Authorization": "Bearer x"}, AutoStart: boolPtr(false), Tier: "background"},
@@ -131,6 +145,22 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if got.Codegraph.Tier != "" {
 		t.Errorf("codegraph.tier = %q, want migrated empty", got.Codegraph.Tier)
 	}
+	if !got.LSP.Enabled {
+		t.Error("lsp.enabled = false, want true")
+	}
+	lua := got.LSP.Servers["lua"]
+	if lua.Command != "lua-language-server" || lua.LanguageID != "lua" || lua.InstallHint != "install lua-language-server" {
+		t.Errorf("lsp.servers.lua scalar fields not preserved: %+v", lua)
+	}
+	if len(lua.Args) != 1 || lua.Args[0] != "--stdio" {
+		t.Errorf("lsp.servers.lua.args = %v, want [--stdio]", lua.Args)
+	}
+	if lua.Env["LUA_PATH"] != "./?.lua" {
+		t.Errorf("lsp.servers.lua.env = %v, want LUA_PATH", lua.Env)
+	}
+	if len(lua.Extensions) != 3 || lua.Extensions[2] != ".gui_script" {
+		t.Errorf("lsp.servers.lua.extensions = %v", lua.Extensions)
+	}
 	if got.Agent.SubagentModel != "mimo-pro" {
 		t.Errorf("subagent_model = %q, want mimo-pro", got.Agent.SubagentModel)
 	}
@@ -191,6 +221,103 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if strings.Contains(rendered, "\ntier") {
 		t.Errorf("rendered config should not contain MCP tier fields:\n%s", rendered)
+	}
+}
+
+func TestScopedRenderPreservesLSPConfig(t *testing.T) {
+	const src = `
+config_version = 2
+default_model = "mimo"
+
+[lsp]
+enabled = true
+
+[lsp.servers.lua]
+command = "lua-language-server"
+args = ["--stdio"]
+env = { LUA_PATH = "./?.lua" }
+language_id = "lua"
+extensions = [".lua", ".script", ".gui_script"]
+install_hint = "install lua-language-server"
+
+[lsp.servers."c++"]
+command = "clangd"
+extensions = [".cc", ".cpp", ".hpp"]
+`
+
+	var cfg Config
+	if _, err := toml.Decode(src, &cfg); err != nil {
+		t.Fatalf("decode source TOML: %v", err)
+	}
+
+	for _, scope := range []RenderScope{RenderScopeFull, RenderScopeUser, RenderScopeProject} {
+		t.Run(string(scope), func(t *testing.T) {
+			rendered := RenderTOMLForScope(&cfg, scope)
+			if !strings.Contains(rendered, "[lsp]") {
+				t.Fatalf("render missing [lsp]:\n%s", rendered)
+			}
+			if !strings.Contains(rendered, "[lsp.servers.lua]") {
+				t.Fatalf("render missing [lsp.servers.lua]:\n%s", rendered)
+			}
+			if !strings.Contains(rendered, `[lsp.servers."c++"]`) {
+				t.Fatalf("render missing quoted c++ server key:\n%s", rendered)
+			}
+
+			var got Config
+			if _, err := toml.Decode(rendered, &got); err != nil {
+				t.Fatalf("decode rendered TOML: %v\n---\n%s", err, rendered)
+			}
+			if !got.LSP.Enabled {
+				t.Fatalf("lsp.enabled = false, want true")
+			}
+			lua, ok := got.LSP.Servers["lua"]
+			if !ok {
+				t.Fatalf("lsp.servers.lua missing after round-trip: %+v", got.LSP.Servers)
+			}
+			if lua.Command != "lua-language-server" || lua.LanguageID != "lua" || lua.InstallHint != "install lua-language-server" {
+				t.Fatalf("lsp.servers.lua scalar fields not preserved: %+v", lua)
+			}
+			if len(lua.Args) != 1 || lua.Args[0] != "--stdio" {
+				t.Fatalf("lsp.servers.lua.args = %v, want [--stdio]", lua.Args)
+			}
+			if lua.Env["LUA_PATH"] != "./?.lua" {
+				t.Fatalf("lsp.servers.lua.env = %v, want LUA_PATH", lua.Env)
+			}
+			if len(lua.Extensions) != 3 || lua.Extensions[0] != ".lua" || lua.Extensions[2] != ".gui_script" {
+				t.Fatalf("lsp.servers.lua.extensions = %v", lua.Extensions)
+			}
+			cpp, ok := got.LSP.Servers["c++"]
+			if !ok {
+				t.Fatalf("lsp.servers.c++ missing after round-trip: %+v", got.LSP.Servers)
+			}
+			if cpp.Command != "clangd" || len(cpp.Extensions) != 3 || cpp.Extensions[1] != ".cpp" {
+				t.Fatalf("lsp.servers.c++ not preserved: %+v", cpp)
+			}
+		})
+	}
+}
+
+func BenchmarkRenderTOMLWithLSPServers(b *testing.B) {
+	cfg := Default()
+	cfg.LSP.Servers = make(map[string]LSPServer, 64)
+	for i := 0; i < 64; i++ {
+		lang := "lang" + strconv.Itoa(i)
+		cfg.LSP.Servers[lang] = LSPServer{
+			Command:     "server-" + strconv.Itoa(i),
+			Args:        []string{"--stdio", "--flag"},
+			Env:         map[string]string{"SERVER_MODE": "stdio", "SERVER_ROOT": "."},
+			LanguageID:  lang,
+			Extensions:  []string{"." + lang, "." + lang + "x"},
+			InstallHint: "install server-" + strconv.Itoa(i),
+		}
+	}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		rendered := RenderTOML(cfg)
+		if len(rendered) == 0 {
+			b.Fatal("empty render")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Render `[lsp]` and `[lsp.servers.<lang>]` in `RenderTOMLForScope` so `SaveTo` preserves user LSP overrides.
- Sort LSP server keys and quote non-bare language ids such as `c++` for deterministic, valid TOML.
- Add round-trip coverage for full, user, and project scoped renders.

## Root cause
`Config.LSP` was loaded correctly, but the annotated TOML renderer never serialized it back out. Any save operation rewrote the config without the LSP section.

## Validation
- `go test ./internal/config -count=1`
- `go test ./internal/config -run ^$ -bench BenchmarkRenderTOMLWithLSPServers -benchmem -count=5`
  - 64-server render: 132-153 us/op on Windows amd64 / i9-12900H
- `go vet ./...`
- `go test ./... -p 1 -count=1`
  - Local Windows note: all reached non-CLI packages passed; `internal/cli/TestACPFactoryLoadsSessionCwdProjectConfig` still fails at TempDir cleanup with a file-in-use error outside this render path.
- `go test ./desktop/... -count=1`
  - Local Windows note: unrelated desktop failures were observed in TempDir cleanup, skill path restoration, and escaped filename handling.

Closes #3464