### PR TITLE
fix(desktop): only highlight composer resize grip on direct hover (#3461)

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2159,7 +2159,7 @@ a[href] {
   opacity: 0.72;
   transition: background 0.12s, box-shadow 0.12s, opacity 0.12s;
 }
-.composer-card:hover .composer-resize-handle::before,
+.composer-resize-handle:hover::before,
 .composer-resize-handle:focus-visible::before,
 .composer-card--resizing .composer-resize-handle::before {
   background: var(--accent);


### PR DESCRIPTION
## Summary

- Fix resize grip incorrectly highlighting with theme color when hovering other parts of the multi-line composer input
- Change CSS trigger from `.composer-card:hover` to `.composer-resize-handle:hover` so only direct handle hover activates the accent highlight

Closes #3461

## Test plan

- [ ] Enter multi-line input mode (drag resize or type multiple lines)
- [ ] Hover over textarea body — grip stays default gray
- [ ] Hover over top resize grip — grip highlights with theme color
- [ ] Click input to focus — grip remains hidden/dimmed while typing

Made with [Cursor](https://cursor.com)