### PR TITLE
fix(desktop): classify attachments by real file type

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, GitBranch, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
 import { ProcessBrainIcon, ProcessCard, ProcessStatusIcon } from "./ProcessCard";
+import { replaceAttachmentRefsForDisplay } from "../lib/attachmentDisplay";
 import { useT } from "../lib/i18n";
 import type { Item, MessageActionScope } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
@@ -19,7 +20,7 @@ export function UserMessage({
   turn?: number;
   anchorId?: string;
 }) {
-  const displayText = text.replace(/@\.reasonix\/attachments\/[^\s]+/g, "[image]");
+  const displayText = replaceAttachmentRefsForDisplay(text);
   return (
     <div className="msg msg--user" id={anchorId} data-question-anchor={anchorId} data-turn={turn}>
       <div className="msg__body">

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -2,6 +2,7 @@ import { createContext, memo, type CSSProperties, type MouseEvent as ReactMouseE
 import type { Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
 import { useT } from "../lib/i18n";
+import { replaceAttachmentRefsForDisplay } from "../lib/attachmentDisplay";
 import { AssistantMessage, TurnActions, UserMessage } from "./Message";
 import { ProcessCard, ProcessCompactIcon, ProcessInfoIcon, ProcessPhaseIcon, ProcessStatusIcon } from "./ProcessCard";
 import { ToolCard } from "./ToolCard";
@@ -46,7 +47,7 @@ function questionAnchorId(id: string): string {
 }
 
 function compactQuestionText(text: string): string {
-  const cleaned = text.replace(/@\.reasonix\/attachments\/[^\s]+/g, "[image]").replace(/\s+/g, " ").trim();
+  const cleaned = replaceAttachmentRefsForDisplay(text).replace(/\s+/g, " ").trim();
   if (cleaned.length <= 80) return cleaned;
   return cleaned.slice(0, 80);
 }
@@ -84,7 +85,7 @@ function repinIfWasPinned(
 
 // Summarise a warm turn for its compact card.
 function warmUserPreview(text: string): string {
-  const cleaned = text.replace(/@\.reasonix\/attachments\/[^\s]+/g, "[image]").replace(/\s+/g, " ").trim();
+  const cleaned = replaceAttachmentRefsForDisplay(text).replace(/\s+/g, " ").trim();
   return cleaned.length <= 80 ? cleaned : cleaned.slice(0, 77) + "...";
 }
 

--- a/desktop/frontend/src/lib/attachmentDisplay.ts
+++ b/desktop/frontend/src/lib/attachmentDisplay.ts
@@ -1,0 +1,45 @@
+const attachmentRefRe = /@(\.reasonix\/attachments\/[^\s]+)/g;
+const trailingPunctuationRe = /[.,;!?)\]}]+$/;
+
+function splitTrailingPunctuation(token: string): { core: string; suffix: string } {
+  const m = token.match(trailingPunctuationRe);
+  if (!m || m.index === undefined) return { core: token, suffix: "" };
+  return { core: token.slice(0, m.index), suffix: m[0] };
+}
+
+function baseName(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+function isImageAttachmentRef(path: string): boolean {
+  const ext = (() => {
+    const name = baseName(path).toLowerCase();
+    const dot = name.lastIndexOf(".");
+    return dot >= 0 ? name.slice(dot) : "";
+  })();
+  switch (ext) {
+    case ".png":
+    case ".jpg":
+    case ".jpeg":
+    case ".gif":
+    case ".webp":
+    case ".bmp":
+    case ".svg":
+    case ".tif":
+    case ".tiff":
+      return true;
+    default:
+      return false;
+  }
+}
+
+export function replaceAttachmentRefsForDisplay(text: string): string {
+  return text.replace(attachmentRefRe, (_full, token: string) => {
+    const { core, suffix } = splitTrailingPunctuation(token);
+    if (!core) return _full;
+    if (isImageAttachmentRef(core)) return `[image]${suffix}`;
+    const name = baseName(core) || "attachment";
+    return `[file:${name}]${suffix}`;
+  });
+}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -62,13 +62,28 @@ func classifyRef(token string, known map[string]bool, exists func(string) bool) 
 	if i := strings.Index(token, ":"); i > 0 && i+1 < len(token) && known[token[:i]] {
 		return ref{kind: refResource, server: token[:i], uri: token[i+1:], raw: token}, true
 	}
-	if strings.HasPrefix(filepath.ToSlash(token), ".reasonix/attachments/") && exists(token) {
-		return ref{kind: refImage, path: token, raw: token}, true
+	if isAttachmentRef(token) && exists(token) {
+		if isImageAttachmentRef(token) {
+			return ref{kind: refImage, path: token, raw: token}, true
+		}
+		return ref{kind: refFile, path: token, raw: token}, true
 	}
 	if exists(token) {
 		return ref{kind: refFile, path: token, raw: token}, true
 	}
 	return ref{}, false
+}
+
+func isAttachmentRef(token string) bool {
+	return strings.HasPrefix(filepath.ToSlash(token), ".reasonix/attachments/")
+}
+
+func isImageAttachmentRef(token string) bool {
+	switch strings.ToLower(filepath.Ext(token)) {
+	case ".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".svg", ".tif", ".tiff":
+		return true
+	}
+	return false
 }
 
 // detectRefs finds the @references in a line: MCP resources for connected

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -56,7 +57,13 @@ func TestParseRefTokens(t *testing.T) {
 
 func TestClassifyRef(t *testing.T) {
 	known := map[string]bool{"docs": true}
-	files := map[string]bool{"src/main.go": true, "README.md": true, ".reasonix/attachments/clipboard-20260601-010203.000000.png": true}
+	files := map[string]bool{
+		"src/main.go": true,
+		"README.md":   true,
+		".reasonix/attachments/clipboard-20260601-010203.000000.png": true,
+		".reasonix/attachments/clipboard-20260601-010203.000000.yml": true,
+		".reasonix/attachments/clipboard-20260601-010203.000000.zip": true,
+	}
 	exists := func(p string) bool { return files[p] }
 
 	cases := []struct {
@@ -68,6 +75,8 @@ func TestClassifyRef(t *testing.T) {
 		{"src/main.go", true, refFile},          // existing file
 		{"README.md", true, refFile},            // existing file
 		{".reasonix/attachments/clipboard-20260601-010203.000000.png", true, refImage},
+		{".reasonix/attachments/clipboard-20260601-010203.000000.yml", true, refFile},
+		{".reasonix/attachments/clipboard-20260601-010203.000000.zip", true, refFile},
 		{"ghost:issue://1", false, 0}, // unknown server, no such file
 		{"missing.go", false, 0},      // nonexistent path → not a ref
 		{"docs:", false, 0},           // empty uri → not a resource, no file
@@ -81,6 +90,54 @@ func TestClassifyRef(t *testing.T) {
 		if ok && r.kind != c.wantKnd {
 			t.Errorf("classifyRef(%q) kind = %v, want %v", c.token, r.kind, c.wantKnd)
 		}
+	}
+}
+
+func TestResolveRefsAttachmentKinds(t *testing.T) {
+	temp := t.TempDir()
+	attachmentsDir := filepath.Join(temp, ".reasonix", "attachments")
+	if err := os.MkdirAll(attachmentsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ymlRef := filepath.ToSlash(".reasonix/attachments/config.yml")
+	zipRef := filepath.ToSlash(".reasonix/attachments/archive.zip")
+	pngRef := filepath.ToSlash(".reasonix/attachments/shot.png")
+	if err := os.WriteFile(filepath.Join(temp, filepath.FromSlash(ymlRef)), []byte("name: reasonix\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temp, filepath.FromSlash(zipRef)), []byte{'P', 'K', 0x03, 0x04, 0x00}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temp, filepath.FromSlash(pngRef)), []byte("\x89PNG\r\n\x1a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(temp); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Error(err)
+		}
+	})
+
+	line := "check @" + ymlRef + " @" + zipRef + " @" + pngRef
+	block, errs := (&Controller{}).ResolveRefs(context.Background(), line)
+	if len(errs) != 0 {
+		t.Fatalf("ResolveRefs errors = %v", errs)
+	}
+	if !strings.Contains(block, `<file path="`+ymlRef+`">`) || !strings.Contains(block, "name: reasonix") {
+		t.Fatalf("expected yml attachment to resolve as file content, got: %s", block)
+	}
+	if !strings.Contains(block, `<file path="`+zipRef+`">`) || !strings.Contains(block, "[binary file "+zipRef) {
+		t.Fatalf("expected zip attachment to resolve as binary file note, got: %s", block)
+	}
+	if !strings.Contains(block, `<image path="`+pngRef+`">`) {
+		t.Fatalf("expected png attachment to resolve as image block, got: %s", block)
 	}
 }
 


### PR DESCRIPTION
## Summary
- classify `.reasonix/attachments/*` refs as `refImage` only for real image extensions, so `.yml/.zip` now resolve as normal file refs
- add control-layer regression tests for png/yml/zip attachment classification and `ResolveRefs` behavior
- update transcript/user-message replacement so image attachments render as `[image]` and non-image attachments as `[file:<name>]`

Fixes #3452.

## Test plan
- [x] `go test ./internal/control`
- [x] `npm run typecheck` (in `desktop/frontend`)