### PR TITLE
feat(desktop): wire up ⌘K command palette

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -39,6 +39,7 @@ import { OnboardingOverlay } from "./components/OnboardingOverlay";
 import { TabBar } from "./components/TabBar";
 import { ProjectTree } from "./components/ProjectTree";
 import { CopyButton } from "./components/CopyButton";
+import { CommandPalette, type PaletteItem } from "./components/CommandPalette";
 import { parseTodos } from "./lib/tools";
 import { shouldShowTodoPanel } from "./lib/todoVisibility";
 import type { ComposerInsertRequest, Meta, Mode, SessionMeta, SettingsTab, TabMeta } from "./lib/types";
@@ -399,6 +400,7 @@ export default function App() {
   const [renamingTopicId, setRenamingTopicId] = useState<string | null>(null);
   const [topicTitleDraft, setTopicTitleDraft] = useState("");
   const [topicExportOpen, setTopicExportOpen] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
   const topicRenameSkipCommitRef = useRef(false);
   const topicRenameCommitHandledRef = useRef(false);
 
@@ -1080,6 +1082,17 @@ export default function App() {
     setTabRevealSignal((signal) => signal + 1);
   }, [activeTab?.scope, activeTab?.workspaceRoot, openGlobalTab, openProjectTab, refreshTabMetas, state.meta?.cwd]);
 
+  // ── Command palette (⌘K) ────────────────────────────────────────────
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "k") return;
+      event.preventDefault();
+      setPaletteOpen((open) => !open);
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, []);
+
   const handleMessageAction = useCallback(async (turn: number, scope: string) => {
     await rewind(turn, scope);
     if (scope === "fork") {
@@ -1117,6 +1130,55 @@ export default function App() {
     setHistView({ kind: "trash", sessions: await listTrashedSessions() });
   }, [listTrashedSessions]);
   const closeHistory = useCallback(() => setHistView(null), []);
+
+  // ── Command palette (⌘K) item builder ───────────────────────────────
+  const buildPaletteItems = useCallback((): PaletteItem[] => {
+    const items: PaletteItem[] = [];
+
+    for (const tab of tabMetas) {
+      items.push({
+        id: `tab:${tab.id}`,
+        title: tab.topicTitle || "Untitled",
+        hint: tab.scope === "global" ? "Global" : tab.workspaceName || tab.workspaceRoot,
+        group: t("sidebar.conversations"),
+        keywords: [tab.label],
+        run: () => void handleTabChange(tab.id),
+      });
+    }
+
+    items.push(
+      {
+        id: "action:new-session",
+        title: t("topbar.newSession"),
+        group: "Actions",
+        keywords: ["new", "chat", "session"],
+        run: () => void handleNewTab(),
+      },
+      {
+        id: "action:history",
+        title: t("sidebar.allHistory"),
+        group: "Actions",
+        keywords: ["history", "sessions", "past"],
+        run: () => void openAllHistory(),
+      },
+      {
+        id: "action:settings",
+        title: t("topbar.settings"),
+        group: "Actions",
+        keywords: ["preferences", "config", "options"],
+        run: () => setSettingsTarget("general"),
+      },
+      {
+        id: "action:trash",
+        title: t("sidebar.trash"),
+        group: "Actions",
+        keywords: ["deleted", "bin"],
+        run: () => void openTrash(),
+      },
+    );
+
+    return items;
+  }, [tabMetas, handleTabChange, handleNewTab, openAllHistory, openTrash, t]);
   const onResumeSession = useCallback(
     async (session: SessionMeta) => {
       if (state.running) return;
@@ -1719,6 +1781,14 @@ export default function App() {
       )}
 
       {needsOnboarding && <OnboardingOverlay onComplete={() => setNeedsOnboarding(false)} />}
+
+      <CommandPalette
+        open={paletteOpen}
+        onClose={() => setPaletteOpen(false)}
+        items={buildPaletteItems()}
+        placeholder="Quick actions…"
+        emptyText="No matches"
+      />
     </div>
     </ShellExpandProvider>
   );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10386,6 +10386,141 @@ a[href] {
   animation: none !important;
 }
 
+/* ── Command palette (⌘K) ─────────────────────────────────────────── */
+.drawer-backdrop:has(.palette) {
+  justify-content: center;
+  align-items: flex-start;
+  padding-top: 12vh;
+}
+
+.palette {
+  position: relative;
+  width: min(520px, 90vw);
+  max-height: 60vh;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.36);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: palette-in 0.1s ease;
+}
+
+@keyframes palette-in {
+  from { opacity: 0; transform: translateY(-12px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.palette__inputrow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.palette__input {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.palette__input::placeholder {
+  color: var(--fg-muted);
+}
+
+.palette__esc {
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+  background: var(--bg-base);
+  font-family: inherit;
+  line-height: 1.3;
+}
+
+.palette__list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 6px 0;
+}
+
+.palette__empty {
+  padding: 24px 14px;
+  color: var(--fg-muted);
+  text-align: center;
+  font-size: 13px;
+}
+
+.palette__group-title {
+  padding: 8px 14px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+}
+
+.palette__item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  padding: 8px 14px;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.palette__item--on {
+  background: var(--accent-bg, rgba(77, 151, 255, 0.12));
+}
+
+.palette__item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.palette__title {
+  font-weight: 500;
+}
+
+.palette__hint {
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
+.palette__foot {
+  display: flex;
+  gap: 12px;
+  padding: 7px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
+.palette__foot kbd {
+  padding: 1px 4px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  background: var(--bg-base);
+  font-family: inherit;
+  font-size: 10px;
+  line-height: 1.3;
+  margin-right: 2px;
+}
+
 /* Respect the OS reduced-motion preference: squash all animations and force
    instant scrolling so the UI feels immediate rather than web-like. */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
The `CommandPalette` component has existed in the codebase since its original PR but was never imported or rendered in the app. This change wires it up so `⌘K` / `Ctrl+K` opens a quick-action modal.

### Changes

**`desktop/frontend/src/App.tsx`** (+70)
- Import `CommandPalette` and `PaletteItem` type
- Add `paletteOpen` state with `⌘K`/`Ctrl+K` toggle listener (`keydown` capture phase)
- Add `buildPaletteItems()` generating two item groups:
  - **Chats** — each open tab as a quick-switch target
  - **Actions** — New Session, History, Settings, Trash
- Render `<CommandPalette>` below existing overlay components

**`desktop/frontend/src/styles.css`** (+135)
- `.drawer-backdrop:has(.palette)` — centered backdrop layout
- `.palette` — modal panel with rounded corners, shadow, fade+slide animation
- `.palette__inputrow` / `.palette__input` — search bar
- `.palette__list` / `.palette__group-title` / `.palette__item` — grouped fuzzy-match list
- `.palette__foot` — keyboard hints (↑↓ navigate, ↵ run, esc close)

### Verification
- [x] TypeScript compilation passes (`tsc --noEmit --pretty`)
- [x] `wails build` succeeds (darwin/arm64)
- The existing `CommandPalette.tsx` component is unchanged — no new component code needed.