### PR TITLE
feat(desktop): add branch switcher dropdown in changes panel

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2983,6 +2983,7 @@ type WorkspaceChangesView struct {
 	Files        []WorkspaceChangeView `json:"files"`
 	GitAvailable bool                  `json:"gitAvailable"`
 	GitErr       string                `json:"gitErr,omitempty"`
+	GitBranch    string                `json:"gitBranch,omitempty"`
 }
 
 // workspaceNoiseNames are local cache/vendor entries hidden from the file tree

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -13,6 +13,7 @@ import {
   Folder,
   FolderTree,
   FolderX,
+  Check,
   GitBranch,
   Maximize2,
   MessageSquarePlus,
@@ -221,6 +222,10 @@ export function WorkspacePanel({
   const [treeResizing, setTreeResizing] = useState(false);
   const [recentOpen, setRecentOpen] = useState(false);
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
+  const [branchMenuOpen, setBranchMenuOpen] = useState(false);
+  const [branchList, setBranchList] = useState<string[]>([]);
+  const [switchingBranch, setSwitchingBranch] = useState(false);
+  const branchBtnRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
 
   useEffect(() => {
@@ -247,6 +252,33 @@ export function WorkspacePanel({
       if (changesRequestRef.current === requestId) setLoadingChanges(false);
     }
   }, []);
+
+  const openBranchMenu = useCallback(async () => {
+    try {
+      const branches = await app.GitBranches();
+      setBranchList(branches);
+    } catch {
+      setBranchList([]);
+    }
+    setBranchMenuOpen((prev) => !prev);
+  }, []);
+
+  const switchBranch = useCallback(
+    async (branch: string) => {
+      if (branch === changes?.gitBranch) return;
+      setSwitchingBranch(true);
+      try {
+        await app.GitCheckout(branch);
+        await loadChanges();
+      } catch {
+        // Error message shown via the changes view
+      } finally {
+        setSwitchingBranch(false);
+        setBranchMenuOpen(false);
+      }
+    },
+    [changes?.gitBranch, loadChanges],
+  );
 
   const selectFile = useCallback(
     (path: string) => {
@@ -902,6 +934,56 @@ export function WorkspacePanel({
                 </button>
               </Tooltip>
             )}
+          </div>
+        )}
+
+        {viewMode === "changed" && changes?.gitBranch && (
+          <div className="workspace-branch-indicator">
+            <GitBranch size={13} />
+            <button
+              ref={branchBtnRef}
+              className="workspace-branch-name"
+              onClick={openBranchMenu}
+            >
+              <span>{changes.gitBranch}</span>
+              <ChevronDown size={11} />
+            </button>
+            <AnchoredPopover
+              open={branchMenuOpen}
+              anchorRef={branchBtnRef}
+              onClose={() => setBranchMenuOpen(false)}
+              className="workspace-branch-menu"
+              placement="bottom"
+              align="start"
+              offset={4}
+            >
+              <div className="workspace-branch-menu__inner">
+                {branchList.length === 0 ? (
+                  <div className="workspace-branch-menu__loading">{t("workspace.loading")}</div>
+                ) : (
+                  branchList.map((b) => (
+                    <button
+                      key={b}
+                      type="button"
+                      className={`workspace-branch-menu__item${b === changes.gitBranch ? " workspace-branch-menu__item--active" : ""}`}
+                      onClick={() => switchBranch(b)}
+                      disabled={switchingBranch}
+                    >
+                      {b === changes.gitBranch && <Check size={13} />}
+                      <span>{b}</span>
+                    </button>
+                  ))
+                )}
+              </div>
+            </AnchoredPopover>
+            <button
+              className="workspace-branch-refresh"
+              onClick={loadChanges}
+              disabled={loadingChanges}
+              title={t("workspace.refreshChanges")}
+            >
+              <RefreshCw size={12} className={loadingChanges ? "spinning" : ""} />
+            </button>
           </div>
         )}
 

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -142,6 +142,8 @@ export interface AppBindings {
   SearchFileRefs(query: string): Promise<DirEntry[]>;
   ReadFile(rel: string): Promise<FilePreview>;
   WorkspaceChanges(): Promise<WorkspaceChangesView>;
+  GitBranches(): Promise<string[]>;
+  GitCheckout(branch: string): Promise<void>;
   OpenWorkspacePath(rel: string): Promise<void>;
   RevealWorkspacePath(rel: string): Promise<void>;
   RevealPath(path: string): Promise<void>;
@@ -1328,6 +1330,7 @@ function makeMockApp(): AppBindings {
     async WorkspaceChanges() {
       return {
         gitAvailable: true,
+        gitBranch: "main",
         files: [
           {
             path: "desktop/frontend/src/components/WorkspacePanel.tsx",
@@ -1341,6 +1344,12 @@ function makeMockApp(): AppBindings {
           { path: "internal/control/controller.go", sources: ["session"], turns: [1], latestTime: Date.now() - 120_000 },
         ],
       };
+    },
+    async GitBranches() {
+      return ["main", "dev", "feature/branch-switcher"];
+    },
+    async GitCheckout(_branch: string) {
+      console.info("mock GitCheckout", _branch);
     },
     async OpenWorkspacePath(rel: string) {
       console.info("mock OpenWorkspacePath", rel);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -321,6 +321,7 @@ export interface WorkspaceChangesView {
   files: WorkspaceChangeView[];
   gitAvailable: boolean;
   gitErr?: string;
+  gitBranch?: string;
 }
 
 export interface ComposerInsertRequest {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10461,13 +10461,19 @@ a[href] {
 .workspace-branch-menu {
   min-width: 140px;
   max-width: 260px;
-  max-height: 240px;
+  max-height: 300px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+  overflow: hidden;
 }
 
 .workspace-branch-menu__inner {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  background: var(--bg-elev);
 }
 
 .workspace-branch-menu__loading {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10386,6 +10386,136 @@ a[href] {
   animation: none !important;
 }
 
+/* ── Branch indicator (changed-files view) ──────────────────────────── */
+.workspace-branch-indicator {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+
+.workspace-branch-indicator > svg {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.workspace-branch-indicator > .workspace-branch-name {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.workspace-branch-indicator > .workspace-branch-name:hover {
+  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
+}
+
+.workspace-branch-indicator > .workspace-branch-name span {
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-branch-refresh {
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.workspace-branch-refresh:hover {
+  color: var(--fg);
+  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
+}
+
+.workspace-branch-refresh:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.workspace-branch-refresh .spinning {
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.workspace-branch-menu {
+  min-width: 140px;
+  max-width: 260px;
+  max-height: 240px;
+}
+
+.workspace-branch-menu__inner {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.workspace-branch-menu__loading {
+  padding: 10px 12px;
+  color: var(--fg-muted);
+  font-size: 12px;
+  text-align: center;
+}
+
+.workspace-branch-menu__item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 12px;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  text-align: left;
+}
+
+.workspace-branch-menu__item:hover {
+  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
+}
+
+.workspace-branch-menu__item--active {
+  font-weight: 600;
+}
+
+.workspace-branch-menu__item svg {
+  flex-shrink: 0;
+  opacity: 0.7;
+}
+
+.workspace-branch-menu__item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-branch-menu__item:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* Respect the OS reduced-motion preference: squash all animations and force
    instant scrolling so the UI feels immediate rather than web-like. */
 @media (prefers-reduced-motion: reduce) {

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -30,6 +31,8 @@ func (a *App) WorkspaceChanges() WorkspaceChangesView {
 		out.GitErr = err.Error()
 		return out
 	}
+
+	out.GitBranch = workspaceGitBranch(base)
 
 	changes := map[string]*workspaceChangeAccumulator{}
 	add := func(path string) *workspaceChangeAccumulator {
@@ -176,4 +179,66 @@ func workspaceRelPathFromGitStatus(repoRoot, base, path string) string {
 		path = filepath.Join(repoRoot, filepath.FromSlash(path))
 	}
 	return normalizeWorkspaceRelPath(base, path)
+}
+
+// workspaceGitBranch returns the current git branch name for the repo rooted
+// at base, or an empty string when base is not inside a git repository or when
+// git is unavailable.
+func workspaceGitBranch(base string) string {
+	cmd := exec.Command("git", "-C", base, "branch", "--show-current")
+	proc.HideWindowDetached(cmd)
+	raw, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	if branch := strings.TrimSpace(string(raw)); branch != "" {
+		return branch
+	}
+
+	headCmd := exec.Command("git", "-C", base, "rev-parse", "--short", "HEAD")
+	proc.HideWindowDetached(headCmd)
+	raw, err = headCmd.Output()
+	if err != nil {
+		return ""
+	}
+	short := strings.TrimSpace(string(raw))
+	if short == "" {
+		return ""
+	}
+	return "@" + short
+}
+
+// GitBranches returns all local git branches for the active workspace's repo.
+func (a *App) GitBranches() ([]string, error) {
+	base, err := a.activeWorkspaceBase()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command("git", "-C", base, "branch", "--format=%(refname:short)")
+	proc.HideWindowDetached(cmd)
+	raw, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	branches := strings.FieldsFunc(strings.TrimSpace(string(raw)), func(r rune) bool { return r == '\n' })
+	return branches, nil
+}
+
+// GitCheckout switches the active workspace's git branch and returns the
+// current branch name, or an error when git is unavailable.
+func (a *App) GitCheckout(branch string) error {
+	base, err := a.activeWorkspaceBase()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("git", "-C", base, "checkout", branch)
+	proc.HideWindowDetached(cmd)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if len(out) > 0 {
+			return fmt.Errorf("git checkout: %s", strings.TrimSpace(string(out)))
+		}
+		return err
+	}
+	return nil
 }

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -612,6 +612,7 @@ func TestWorkspaceChangesGitStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 	runGit(t, "init")
+	runGit(t, "checkout", "-b", "feature/test")
 	if err := os.WriteFile("tracked.txt", []byte("v1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -626,6 +627,9 @@ func TestWorkspaceChangesGitStatus(t *testing.T) {
 	got := (&App{}).WorkspaceChanges()
 	if !got.GitAvailable {
 		t.Fatalf("git unavailable: %s", got.GitErr)
+	}
+	if got.GitBranch != "feature/test" {
+		t.Fatalf("git branch = %q, want feature/test", got.GitBranch)
 	}
 	byPath := map[string]WorkspaceChangeView{}
 	for _, file := range got.Files {
@@ -725,6 +729,37 @@ func TestWorkspaceChangesUntrackedDirectoryListsFiles(t *testing.T) {
 	}
 }
 
+func TestWorkspaceChangesGitBranchDetachedHead(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "init")
+	runGit(t, "config", "user.email", "test@example.com")
+	runGit(t, "config", "user.name", "Test User")
+	if err := os.WriteFile("tracked.txt", []byte("v1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "add", "tracked.txt")
+	runGit(t, "commit", "-m", "init")
+	short := gitOutput(t, "rev-parse", "--short", "HEAD")
+	runGit(t, "checkout", "--detach", "HEAD")
+
+	got := (&App{}).WorkspaceChanges()
+	if !got.GitAvailable {
+		t.Fatalf("git unavailable: %s", got.GitErr)
+	}
+	if got.GitBranch != "@"+short {
+		t.Fatalf("git branch = %q, want @%s", got.GitBranch, short)
+	}
+}
+
 func runGit(t *testing.T, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -732,6 +767,16 @@ func runGit(t *testing.T, args ...string) {
 	if err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
+}
+
+func gitOutput(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // --- settings_app.go helpers ---


### PR DESCRIPTION
Show the current Git branch name in the Changed-files view with a dropdown to switch branches and a refresh button to reload changes.

### Backend
- Add `GitBranch` field to `WorkspaceChangesView` struct
- Add `workspaceGitBranch()` helper (supports named branch and detached HEAD)
- Add `GitBranches()` and `GitCheckout()` app bindings

### Frontend
- **WorkspacePanel**: branch indicator bar with branch name button, dropdown menu listing all local branches, and a refresh button with spinning animation
- **Types**: add `gitBranch?: string` to `WorkspaceChangesView`
- **Bridge**: add `GitBranches()` and `GitCheckout()` to `AppBindings` + mock implementations
- **CSS**: `.workspace-branch-indicator`, `.workspace-branch-menu` (with background, border, shadow), `.workspace-branch-refresh` with `spin` animation

### Tests
- Assert `GitBranch` in existing `TestWorkspaceChangesGitStatus`
- Add `TestWorkspaceChangesGitBranchDetachedHead` for detached HEAD scenario
- Add `gitOutput()` test helper

### Verification
- [x] Go build passes
- [x] TypeScript compilation passes
- [x] `wails build` succeeds (darwin/arm64)
- [x] Branch dropdown renders with correct background, border, shadow, and adequate height