### PR TITLE
fix(config): 过滤聊天候选中的非聊天模型

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2737,7 +2737,7 @@ func (a *App) ModelsForTab(tabID string) []ModelInfo {
 		if !modelProviderAccessAllowed(access, p.Name) || !p.Configured() {
 			continue
 		}
-		for _, m := range p.ModelList() {
+		for _, m := range p.ChatModelList() {
 			ref := p.Name + "/" + m
 			out = append(out, ModelInfo{Ref: ref, Provider: p.Name, Model: m, Current: ref == curModel})
 		}

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -183,7 +183,7 @@ func removeProviderAccess(c *config.Config, names ...string) {
 func providerViewFromEntry(p config.ProviderEntry, builtIn, added bool) ProviderView {
 	return ProviderView{
 		Name: p.Name, BuiltIn: builtIn, Added: added, Kind: p.Kind, BaseURL: p.BaseURL,
-		Models: nonNil(p.ModelList()), ModelsURL: p.ModelsURL, Default: p.DefaultModel(),
+		Models: nonNil(p.ChatModelList()), ModelsURL: p.ModelsURL, Default: p.DefaultModel(),
 		APIKeyEnv:         p.APIKeyEnv,
 		KeySet:            p.APIKeyEnv != "" && os.Getenv(p.APIKeyEnv) != "",
 		BalanceURL:        p.BalanceURL,

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"reflect"
 	"testing"
 
+	"reasonix/internal/config"
 	"reasonix/internal/provider"
 )
 
@@ -36,5 +38,21 @@ func TestWithFreshSystemPromptPrependsMissingSystemMessage(t *testing.T) {
 	}
 	if got[1].Content != "hello" {
 		t.Fatalf("existing user message changed: %+v", got[1])
+	}
+}
+
+func TestProviderViewFromEntry_FiltersNonChatModels(t *testing.T) {
+	p := config.ProviderEntry{
+		Name: "mimo-api",
+		Models: []string{
+			"mimo-v2", "mimo-v2-pro",
+			"mimo-v2-asr", "mimo-v2-tts",
+			"mimo-v2-tts-voiceclone", "mimo-v2-tts-voicedesign",
+		},
+	}
+	view := providerViewFromEntry(p, true, false)
+	want := []string{"mimo-v2", "mimo-v2-pro"}
+	if !reflect.DeepEqual(view.Models, want) {
+		t.Errorf("ProviderView.Models = %v, want %v", view.Models, want)
 	}
 }

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -87,7 +87,7 @@ func (m *chatTUI) showModels() {
 		if !p.Configured() {
 			continue
 		}
-		for _, model := range p.ModelList() {
+		for _, model := range p.ChatModelList() {
 			refs = append(refs, p.Name+"/"+model)
 		}
 	}
@@ -106,7 +106,7 @@ func modelRefs() []string {
 		if !p.Configured() {
 			continue
 		}
-		for _, model := range p.ModelList() {
+		for _, model := range p.ChatModelList() {
 			out = append(out, p.Name+"/"+model)
 		}
 	}

--- a/internal/config/chat_model_test.go
+++ b/internal/config/chat_model_test.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// ── IsLikelyChatModel ──────────────────────────────────────────────────────────
+
+func TestIsLikelyChatModel_RejectsEmptyInput(t *testing.T) {
+	for _, model := range []string{"", "   ", "\t"} {
+		if IsLikelyChatModel(model) {
+			t.Errorf("IsLikelyChatModel(%q) = true, want false", model)
+		}
+	}
+}
+
+func TestIsLikelyChatModel_AllowsKnownChatModels(t *testing.T) {
+	for _, model := range []string{
+		"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-pro", "mimo-v2-omni",
+		"deepseek-v4-flash", "deepseek-v4-pro",
+		"gpt-4o", "gpt-4o-mini",
+		"claude-3.5-sonnet", "qwen-max",
+	} {
+		if !IsLikelyChatModel(model) {
+			t.Errorf("IsLikelyChatModel(%q) = false, want true", model)
+		}
+	}
+}
+
+func TestIsLikelyChatModel_FiltersAudioModels(t *testing.T) {
+	// Real-world samples from #3483.
+	for _, model := range []string{
+		"mimo-v2.5-asr", "mimo-v2.5-tts", "mimo-v2.5-tts-voice",
+		"mimo-v2-tts-voiceclone", "mimo-v2-tts-voicedesign",
+		"tts-1",
+	} {
+		if IsLikelyChatModel(model) {
+			t.Errorf("IsLikelyChatModel(%q) = true, want false", model)
+		}
+	}
+}
+
+func TestIsLikelyChatModel_FiltersNonChatKeywords(t *testing.T) {
+	for _, model := range []string{
+		"whisper-1",
+		"text-embedding-3-small", "text-embedding-ada-002",
+		"text-moderation-stable",
+		"rerank-v1",
+		"dall-e-3",
+		"text-to-speech-v1", "speech-to-text-v2",
+	} {
+		if IsLikelyChatModel(model) {
+			t.Errorf("IsLikelyChatModel(%q) = true, want false", model)
+		}
+	}
+}
+
+func TestIsLikelyChatModel_DoesNotFilterVoiceAlone(t *testing.T) {
+	for _, model := range []string{
+		"voice-chat-model", "gpt-4o-voice",
+	} {
+		if !IsLikelyChatModel(model) {
+			t.Errorf("IsLikelyChatModel(%q) = false, want true", model)
+		}
+	}
+}
+
+// ── ModelList / ChatModelList ──────────────────────────────────────────────────
+
+func TestModelList_ReturnsRawList(t *testing.T) {
+	p := ProviderEntry{
+		Models: []string{
+			"mimo-v2.5", "mimo-v2.5-pro",
+			"mimo-v2.5-asr", "mimo-v2.5-tts", "mimo-v2.5-tts-voice",
+		},
+	}
+	got := p.ModelList()
+	want := []string{
+		"mimo-v2.5", "mimo-v2.5-pro",
+		"mimo-v2.5-asr", "mimo-v2.5-tts", "mimo-v2.5-tts-voice",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ModelList() = %v, want %v", got, want)
+	}
+}
+
+func TestChatModelList_FiltersNonChatModels(t *testing.T) {
+	p := ProviderEntry{
+		Models: []string{
+			"mimo-v2.5", "mimo-v2.5-pro",
+			"mimo-v2.5-asr", "mimo-v2.5-tts", "mimo-v2.5-tts-voice",
+			"mimo-v2-tts-voiceclone", "mimo-v2-tts-voicedesign",
+		},
+	}
+	got := p.ChatModelList()
+	want := []string{"mimo-v2.5", "mimo-v2.5-pro"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ChatModelList() = %v, want %v", got, want)
+	}
+}
+
+func TestChatModelList_AllNonChat(t *testing.T) {
+	p := ProviderEntry{
+		Models: []string{"mimo-v2.5-tts", "mimo-v2.5-asr"},
+	}
+	got := p.ChatModelList()
+	if len(got) != 0 {
+		t.Errorf("ChatModelList() = %v, want empty", got)
+	}
+}
+
+func TestChatModelList_AllChat(t *testing.T) {
+	p := ProviderEntry{
+		Models: []string{"gpt-4o", "gpt-4o-mini"},
+	}
+	got := p.ChatModelList()
+	want := []string{"gpt-4o", "gpt-4o-mini"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ChatModelList() = %v, want %v", got, want)
+	}
+}
+
+func TestChatModelList_EmptyModels(t *testing.T) {
+	p := ProviderEntry{}
+	if got := p.ChatModelList(); got != nil {
+		t.Errorf("ChatModelList() = %v, want nil", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -535,6 +535,74 @@ func (e *ProviderEntry) ModelList() []string {
 	return nil
 }
 
+// IsLikelyChatModel reports whether a model ID looks like a chat/completion
+// model rather than a specialised audio/vision/embedding model. It applies a
+// conservative name-based heuristic — the OpenAI-compatible /models API does
+// not return capability/modality metadata, so this is the most reliable
+// fallback until providers add such fields.
+//
+// The heuristic works in two passes:
+//  1. Multi-word substring check for compound terms that span separators
+//     (e.g. "text-embedding", "text-to-speech").
+//  2. Token-level check: the model ID is split on common separators (- _ . / :)
+//     and each token is compared against a set of known non-chat keywords.
+//
+// "voice" is intentionally absent from the non-chat set because it is too
+// broad — legitimate future chat models may include it in their name.
+func IsLikelyChatModel(model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	lower := strings.ToLower(model)
+
+	// Pass 1: compound terms that span separator boundaries.
+	var compoundNonChat = []string{
+		"text-embedding", "text-to-speech", "speech-to-text",
+	}
+	for _, c := range compoundNonChat {
+		if strings.Contains(lower, c) {
+			return false
+		}
+	}
+
+	// Pass 2: token-level check.
+	tokens := strings.FieldsFunc(lower, func(r rune) bool {
+		return r == '-' || r == '_' || r == '.' || r == '/' || r == ':'
+	})
+	var nonChatTokens = map[string]bool{
+		"asr": true, "stt": true, "tts": true,
+		"whisper": true, "embedding": true,
+		"moderation": true, "rerank": true, "dall": true,
+		"transcription": true,
+	}
+	for _, tok := range tokens {
+		if nonChatTokens[tok] {
+			return false
+		}
+	}
+	return true
+}
+
+// ChatModelList returns ModelList filtered to likely chat/completion models.
+// Non-chat models (TTS, STT, ASR, embedding, etc.) are excluded so they do
+// not appear in the chat model picker. Use ModelList() only when the full
+// raw provider model list is needed, such as config serialization, provider
+// diagnostics, or model-fetch editing.
+func (e *ProviderEntry) ChatModelList() []string {
+	raw := e.ModelList()
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, m := range raw {
+		if IsLikelyChatModel(m) {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
 // DefaultModel returns the provider's default model: the explicit `default`, else
 // the first of ModelList.
 func (e *ProviderEntry) DefaultModel() string {

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -371,7 +371,7 @@ func (c *Controller) modelListText() string {
 		if !p.Configured() {
 			continue
 		}
-		for _, m := range p.ModelList() {
+		for _, m := range p.ChatModelList() {
 			fmt.Fprintf(&b, "  %s/%s\n", p.Name, m)
 		}
 	}


### PR DESCRIPTION
## 概述

修复 #3483。

TTS/STT/ASR 等非聊天模型会出现在 Desktop 和 CLI 的聊天模型候选列表中。用户误选这类模型作为聊天模型后，请求仍按 Chat messages 格式发送，可能触发 Provider 400 错误，例如：

`messages[0] system role is not allowed for TTS model`

本 PR 在共享配置层新增聊天模型候选过滤，避免非聊天模型进入 Desktop / Settings / CLI 的聊天模型选择路径。

## 改动内容

- 新增 `config.IsLikelyChatModel()`，使用通用 token-based heuristic 过滤明显非聊天模型
- 新增 `ProviderEntry.ChatModelList()`，保留 `ModelList()` 原始语义不变
- Desktop ModelSwitcher 改用 `ChatModelList()`
- Desktop Settings 模型列表改用 `ChatModelList()`
- CLI `/model` 列表改用 `ChatModelList()`
- CLI `/model` Tab 补全改用 `ChatModelList()`
- control 层 `modelListText()` 改用 `ChatModelList()`

## 设计说明

`ModelList()` 仍然返回 provider 原始模型列表，用于配置保存、诊断、模型解析、迁移等内部路径。

`ChatModelList()` 只用于聊天模型候选展示路径，避免前端局部过滤导致 Desktop 和 CLI 行为不一致。

## Known limitation

如果用户历史配置中已经把默认模型设置为 TTS/ASR 等非聊天模型，`DefaultModel()` 仍可能解析到该模型。这个属于已有坏配置的回退问题，建议后续单独 follow-up 处理，避免本 PR 扩大到模型解析和配置迁移逻辑。

## 验证

- `git diff --check` 通过
- `go test ./internal/config/ -v` 通过
- `go test ./desktop/ -run "TestProviderViewFromEntry|TestSaveProvider|TestWithFresh" -v` 通过
- `go test ./internal/control/` 通过
- Desktop 手测通过：
  - 聊天模型下拉框不再显示 TTS/ASR 模型
  - Settings 模型列表不再显示 TTS/ASR 模型
  - 正常聊天模型仍然显示
- CLI 手测通过：
  - `/model` 列表不再显示 TTS/ASR 模型
  - `/model` Tab 补全不再显示 TTS/ASR 模型
  - 正常聊天模型仍然可见并可切换

Fixes #3483