### PR TITLE
feat: add opt-in canary update channel (desktop + CLI)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -9,14 +9,29 @@ name: Release desktop
 # runner per platform. Artifacts are minisign-signed (MINISIGN_* secrets), a
 # latest.json manifest is generated, and everything is published to a GitHub
 # release and mirrored to R2 (the updater reads R2 first, GitHub as fallback).
+#
+# The same build/sign/manifest pipeline serves two channels. A `desktop-v*` tag
+# (or manual stable dispatch) publishes the stable line and moves R2's latest/
+# pointer. A manual `channel: canary` dispatch builds with -X main.channel=canary,
+# publishes a rolling `desktop-canary` pre-release, and moves only the canary/
+# pointer — it never touches latest/, so stable installs can't update onto it.
 on:
   push:
     tags: ["desktop-v*"]
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Release channel"
+        type: choice
+        options: [stable, canary]
+        default: stable
       tag:
-        description: "Tag to publish (e.g. desktop-v1.1.0). Required when run manually."
-        required: true
+        description: "stable: tag to publish (e.g. desktop-v1.1.0)"
+        required: false
+        type: string
+      base_version:
+        description: "canary: intended next stable version, e.g. 1.5.0"
+        required: false
         type: string
 
 permissions:
@@ -94,13 +109,17 @@ jobs:
 
       - name: Resolve version
         id: ver
-        run: |
-          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=${TAG#desktop-}" >> "$GITHUB_OUTPUT"
+        run: bash scripts/resolve-desktop-release.sh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IN_CHANNEL: ${{ inputs.channel }}
+          IN_TAG: ${{ inputs.tag }}
+          IN_BASE_VERSION: ${{ inputs.base_version }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_NUMBER: ${{ github.run_number }}
 
       - name: Build and package
-        run: scripts/desktop-build.sh "${{ matrix.platform }}" "${{ steps.ver.outputs.version }}"
+        run: scripts/desktop-build.sh "${{ matrix.platform }}" "${{ steps.ver.outputs.version }}" "${{ steps.ver.outputs.channel }}"
 
       - name: Sign artifacts (minisign)
         working-directory: desktop
@@ -136,13 +155,14 @@ jobs:
 
       - name: Resolve version
         id: ver
-        run: |
-          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
-          VERSION="${TAG#desktop-}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          # A version with a suffix (v1.0.0-rc1) is a prerelease.
-          case "$VERSION" in *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT";; *) echo "prerelease=false" >> "$GITHUB_OUTPUT";; esac
+        run: bash scripts/resolve-desktop-release.sh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IN_CHANNEL: ${{ inputs.channel }}
+          IN_TAG: ${{ inputs.tag }}
+          IN_BASE_VERSION: ${{ inputs.base_version }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_NUMBER: ${{ github.run_number }}
 
       # Generate latest.json with GitHub release download URLs; the mirror step
       # rewrites them to R2 afterwards. GITHUB_REPOSITORY is provided by the runner.
@@ -154,9 +174,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes)
-          [ "${{ steps.ver.outputs.prerelease }}" = "true" ] && args+=(--prerelease)
-          gh release create "${{ steps.ver.outputs.tag }}" dist/* "${args[@]}"
+          if [ "${{ steps.ver.outputs.channel }}" = "canary" ]; then
+            # Rolling channel: replace the previous desktop-canary release+tag so it
+            # always holds exactly the latest canary build.
+            gh release delete "${{ steps.ver.outputs.tag }}" --cleanup-tag --yes 2>/dev/null || true
+            gh release create "${{ steps.ver.outputs.tag }}" dist/* \
+              --target "${{ github.sha }}" \
+              --title "Reasonix Desktop ${{ steps.ver.outputs.version }} (canary)" \
+              --notes "Opt-in canary build for testers. Not a stable release. Built from ${{ github.sha }}." \
+              --prerelease
+          else
+            args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes)
+            [ "${{ steps.ver.outputs.prerelease }}" = "true" ] && args+=(--prerelease)
+            gh release create "${{ steps.ver.outputs.tag }}" dist/* "${args[@]}"
+          fi
 
   mirror:
     name: mirror to R2
@@ -167,12 +198,18 @@ jobs:
     env:
       HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' && secrets.R2_SECRET_ACCESS_KEY != '' && secrets.R2_ACCOUNT_ID != '' && secrets.R2_BUCKET != '' }}
     steps:
-      - name: Resolve tag
+      - uses: actions/checkout@v4
+
+      - name: Resolve version
         id: ver
-        run: |
-          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          case "${TAG#desktop-}" in *-*) echo "prerelease=true" >> "$GITHUB_OUTPUT";; *) echo "prerelease=false" >> "$GITHUB_OUTPUT";; esac
+        run: bash scripts/resolve-desktop-release.sh
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          IN_CHANNEL: ${{ inputs.channel }}
+          IN_TAG: ${{ inputs.tag }}
+          IN_BASE_VERSION: ${{ inputs.base_version }}
+          REF_NAME: ${{ github.ref_name }}
+          RUN_NUMBER: ${{ github.run_number }}
 
       - name: Download release assets
         if: env.HAS_R2 == 'true'
@@ -216,9 +253,11 @@ jobs:
         run: |
           ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           aws s3 cp assets/ "s3://${R2_BUCKET}/${TAG}/" --recursive --endpoint-url "$ENDPOINT"
-          # Prereleases publish to their own tag prefix but must not move the
-          # updater's latest/ pointer; stable releases do.
-          if [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then
+          # The pointer a release moves is its channel's alone: canary writes
+          # canary/, stable writes latest/. A stable prerelease (rc) moves neither.
+          if [ "${{ steps.ver.outputs.channel }}" = "canary" ]; then
+            aws s3 cp assets/ "s3://${R2_BUCKET}/canary/" --recursive --endpoint-url "$ENDPOINT"
+          elif [ "${{ steps.ver.outputs.prerelease }}" = "true" ]; then
             echo "prerelease — leaving R2 latest/ untouched"
           else
             aws s3 cp assets/ "s3://${R2_BUCKET}/latest/" --recursive --endpoint-url "$ENDPOINT"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -10,12 +10,20 @@ name: Release npm
 #   git tag npm-vX.Y.Z-rc.N     # prerelease -> publishes under `next`
 #   git push origin <tag>
 #
-# build.mjs decides the dist-tag: only the 0.x stable line is `latest`; the 1.x
-# line and every prerelease ship under `next`. Promote a 1.x stable to the default
-# install with a manual `npm dist-tag add reasonix@X.Y.Z latest`.
+# A manual workflow_dispatch with base_version publishes an opt-in canary to the
+# `canary` dist-tag (npm i reasonix@canary) from the current ref; it never moves
+# `next`/`latest`. build.mjs decides the dist-tag: 0.x stable is `latest`; a
+# `-canary.` build is `canary`; the 1.x line and rc prereleases are `next`. Promote
+# a 1.x stable to the default install with `npm dist-tag add reasonix@X.Y.Z latest`.
 on:
   push:
     tags: ['npm-v*']
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: "canary: intended next stable version, e.g. 1.5.0"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -46,8 +54,17 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      # build.mjs strips the leading `npm-`/`v`, so it derives the bare semver from
-      # the `npm-v*` tag (e.g. npm-v1.3.0-rc.1 -> 1.3.0-rc.1).
-      - run: node npm/build.mjs "${GITHUB_REF_NAME}" --publish
+      # Tag push uses the npm-v* tag; a canary dispatch synthesizes a
+      # <base>-canary.<run_number> version. build.mjs strips the leading `npm-`/`v`.
+      - name: Resolve version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            base="${{ inputs.base_version }}"; base="${base#v}"
+            echo "arg=v${base}-canary.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "arg=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+      - run: node npm/build.mjs "${{ steps.ver.outputs.arg }}" --publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -36,6 +36,11 @@ var assets embed.FS
 // prompts to update.
 var version = "dev"
 
+// channel selects which updater pointer this build polls, injected via
+// `-X main.channel=canary`. Default "stable" tracks the public release; "canary"
+// tracks the opt-in pre-release line and never crosses over to stable.
+var channel = "stable"
+
 func main() {
 	app := NewApp()
 

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -32,13 +32,37 @@ import (
 // the thin Wails binding that wires these into App methods and progress events.
 
 // Manifest endpoints — R2 CDN first (fast, especially in CN), GitHub releases as
-// fallback. Mirrors the v1 desktop's two-endpoint scheme.
+// fallback. The build channel picks the rolling pointer so a canary build polls
+// the canary line and a stable build polls latest; the two never cross.
 const (
-	manifestPrimary     = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/latest.json"
-	manifestFallback    = "https://github.com/esengine/reasonix/releases/latest/download/latest.json"
-	defaultDownloadPage = "https://github.com/esengine/reasonix/releases/latest"
-	httpTimeout         = 15 * time.Second
+	r2Base         = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev"
+	ghReleasesBase = "https://github.com/esengine/reasonix/releases"
+	httpTimeout    = 15 * time.Second
 )
+
+// manifestEndpoints returns the primary (R2) then fallback (GitHub) manifest URLs
+// for the running build's channel.
+func manifestEndpoints() []string {
+	if channel == "canary" {
+		return []string{
+			r2Base + "/canary/latest.json",
+			ghReleasesBase + "/download/desktop-canary/latest.json",
+		}
+	}
+	return []string{
+		r2Base + "/latest/latest.json",
+		ghReleasesBase + "/latest/download/latest.json",
+	}
+}
+
+// downloadPage is the human-facing releases page shown when self-update is
+// unavailable (macOS) or the manifest omits its own link.
+func downloadPage() string {
+	if channel == "canary" {
+		return ghReleasesBase // lists pre-releases too
+	}
+	return ghReleasesBase + "/latest"
+}
 
 // UpdateInfo is the CheckUpdate result that drives the frontend's update banner.
 type UpdateInfo struct {
@@ -95,7 +119,7 @@ func normalizeVersion(v string) (string, bool) {
 // and decodes it.
 func fetchManifest(ctx context.Context, c *http.Client) (*update.Manifest, error) {
 	var lastErr error
-	for _, url := range []string{manifestPrimary, manifestFallback} {
+	for _, url := range manifestEndpoints() {
 		b, err := fetchBytes(ctx, c, url)
 		if err != nil {
 			lastErr = err
@@ -116,7 +140,7 @@ func fetchManifest(ctx context.Context, c *http.Client) (*update.Manifest, error
 func evaluate(current string, m *update.Manifest) UpdateInfo {
 	page := m.DownloadPage
 	if page == "" {
-		page = defaultDownloadPage
+		page = downloadPage()
 	}
 	info := UpdateInfo{
 		Current:       current,

--- a/desktop/updater_app.go
+++ b/desktop/updater_app.go
@@ -30,7 +30,7 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 		return &UpdateInfo{
 			Current:       version,
 			CanSelfUpdate: canSelfUpdate(),
-			DownloadURL:   defaultDownloadPage,
+			DownloadURL:   downloadPage(),
 			Err:           err.Error(),
 		}, nil
 	}
@@ -41,7 +41,7 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 		return &UpdateInfo{
 			Current:       version,
 			CanSelfUpdate: canSelfUpdate(),
-			DownloadURL:   defaultDownloadPage,
+			DownloadURL:   downloadPage(),
 			Err:           err.Error(),
 		}, nil
 	}
@@ -52,7 +52,7 @@ func (a *App) CheckUpdate() (*UpdateInfo, error) {
 // OpenDownloadPage opens the releases page in the browser — the macOS manual-update
 // path and a fallback link elsewhere.
 func (a *App) OpenDownloadPage() {
-	page := defaultDownloadPage
+	page := downloadPage()
 	if c, err := httpClient(); err == nil {
 		ctx, cancel := context.WithTimeout(a.reqCtx(), httpTimeout)
 		defer cancel()

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"runtime"
+	"strings"
 	"testing"
 
 	"reasonix/desktop/internal/update"
@@ -66,6 +67,36 @@ func TestEvaluate(t *testing.T) {
 	}
 	if full.CanSelfUpdate != (runtime.GOOS != "darwin") {
 		t.Errorf("CanSelfUpdate = %v on %s", full.CanSelfUpdate, runtime.GOOS)
+	}
+}
+
+func TestChannelSelectsDistinctPointers(t *testing.T) {
+	orig := channel
+	t.Cleanup(func() { channel = orig })
+
+	channel = "stable"
+	stable := manifestEndpoints()
+	channel = "canary"
+	canary := manifestEndpoints()
+
+	for _, u := range stable {
+		if strings.Contains(u, "canary") {
+			t.Errorf("stable endpoint leaks into canary: %q", u)
+		}
+	}
+	if !strings.Contains(stable[0], "/latest/latest.json") {
+		t.Errorf("stable primary = %q, want the latest/ pointer", stable[0])
+	}
+	for _, u := range canary {
+		if strings.Contains(u, "/latest/") {
+			t.Errorf("canary endpoint hits the stable latest/ pointer: %q", u)
+		}
+	}
+	if !strings.Contains(canary[0], "/canary/latest.json") {
+		t.Errorf("canary primary = %q, want the canary/ pointer", canary[0])
+	}
+	if downloadPage() == (ghReleasesBase + "/latest") {
+		t.Error("canary download page should not be the stable latest releases page")
 	}
 }
 

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -99,11 +99,16 @@ if (!publish) {
   process.exit(0);
 }
 
-// Only the v0.x stable line is the promoted default (`latest`). The v2 (1.x) line
-// and every prerelease ship under `next` so a bare `npm i reasonix` keeps resolving
-// 0.53.x; opt in with `npm i reasonix@next`. (npm rejects `v2` as a tag — it parses
-// as a SemVer range.) Promote v2 with a manual `npm dist-tag add reasonix@<ver> latest`.
-const distTag = version.startsWith("0.") && !version.includes("-") ? "latest" : "next";
+// Three independent dist-tags: 0.x stable is the promoted default (`latest`); a
+// `-canary.` build is the opt-in tester channel (`canary`); everything else — the
+// 1.x line and rc prereleases — ships under `next`. Only a `--tag canary` publish
+// moves canary, so `next`/`latest` users never resolve a canary. Promote a 1.x
+// stable to default with a manual `npm dist-tag add reasonix@<ver> latest`.
+const distTag = version.includes("-canary.")
+  ? "canary"
+  : version.startsWith("0.") && !version.includes("-")
+    ? "latest"
+    : "next";
 const publishArgs = ["publish", "--access", "public", "--tag", distTag];
 
 for (const sub of subPackages) {

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -11,12 +11,14 @@
 #            Reasonix-windows-<arch>.zip                 (portable human download)
 #   Linux:   Reasonix-linux-<arch>.tar.gz                (bare binary)
 #
-# Usage: scripts/desktop-build.sh <os/arch> <version>
+# Usage: scripts/desktop-build.sh <os/arch> <version> [channel]
 #   e.g. scripts/desktop-build.sh darwin/arm64 v1.1.0
+#        scripts/desktop-build.sh darwin/arm64 v1.5.0-canary.20260608.42 canary
 set -euo pipefail
 
-PLATFORM="${1:?usage: desktop-build.sh <os/arch> <version>}"
-VERSION="${2:?usage: desktop-build.sh <os/arch> <version>}"
+PLATFORM="${1:?usage: desktop-build.sh <os/arch> <version> [channel]}"
+VERSION="${2:?usage: desktop-build.sh <os/arch> <version> [channel]}"
+CHANNEL="${3:-stable}"
 
 os="${PLATFORM%/*}"
 arch="${PLATFORM#*/}"
@@ -36,7 +38,7 @@ numver="${VERSION#v}"; numver="${numver%%-*}"
 node -e 'const fs=require("fs"),f="wails.json",j=JSON.parse(fs.readFileSync(f,"utf8"));j.info.productVersion=process.argv[1];fs.writeFileSync(f,JSON.stringify(j,null,2)+"\n")' "$numver"
 
 # NSIS installer is Windows-only (Wails requires a single windows target for -nsis).
-build_args=(-clean -platform "$PLATFORM" -ldflags "-X main.version=$VERSION")
+build_args=(-clean -platform "$PLATFORM" -ldflags "-X main.version=$VERSION -X main.channel=$CHANNEL")
 [ "$os" = windows ] && build_args+=(-nsis)
 # Link cgo against WebKitGTK 4.1: 4.0 (libwebkit2gtk-4.0.so.37) is gone on
 # Ubuntu 24.04+/Fedora 40+, while 4.1 ships from Ubuntu 22.04 onward.

--- a/scripts/resolve-desktop-release.sh
+++ b/scripts/resolve-desktop-release.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Resolve tag/version/channel/prerelease for one desktop release run, shared by the
+# build, publish, and mirror jobs so they agree on a single value. Reads the run's
+# context from env and writes the four outputs to $GITHUB_OUTPUT.
+#
+#   stable: from a desktop-v* tag push, or a manual dispatch with `tag`.
+#   canary: a manual dispatch with channel=canary; version is synthesized from
+#           base_version + the monotonic run_number, tag is the rolling
+#           `desktop-canary`, and it is always a prerelease.
+set -euo pipefail
+
+if [ "${EVENT_NAME:-}" = "workflow_dispatch" ] && [ "${IN_CHANNEL:-stable}" = "canary" ]; then
+	base="${IN_BASE_VERSION:?canary dispatch requires base_version}"
+	base="${base#v}"
+	base="${base#desktop-v}"
+	version="v${base}-canary.${RUN_NUMBER}"
+	tag="desktop-canary"
+	channel="canary"
+	prerelease="true"
+else
+	if [ "${EVENT_NAME:-}" = "workflow_dispatch" ]; then
+		tag="${IN_TAG:?stable dispatch requires tag}"
+	else
+		tag="${REF_NAME}"
+	fi
+	version="${tag#desktop-}"
+	channel="stable"
+	case "$version" in
+	*-*) prerelease="true" ;;
+	*) prerelease="false" ;;
+	esac
+fi
+
+{
+	echo "tag=$tag"
+	echo "version=$version"
+	echo "channel=$channel"
+	echo "prerelease=$prerelease"
+} >>"$GITHUB_OUTPUT"
+
+echo "resolved: tag=$tag version=$version channel=$channel prerelease=$prerelease"


### PR DESCRIPTION
Adds an opt-in **canary** channel — desktop **and** CLI — so testers shake out bugs on a pre-release line before a real release, instead of the stable release doubling as the beta.

## Desktop
- A build carries its channel via `-X main.channel=canary`; the updater then polls R2's `canary/latest.json` pointer instead of `latest/`, so the channels never cross.
- Folded into `release-desktop.yml` (not a new file): **build/sign/manifest are shared jobs**; only version/publish/mirror branch on channel. The stable `desktop-v*` tag path is unchanged.
- Cut one: **Actions → Release desktop → Run workflow → channel: canary, base_version: 1.5.0**. Builds main-v2 HEAD, publishes a rolling `desktop-canary` pre-release, mirrors to R2 `canary/`.
- `mirror` moves only the channel's own pointer — canary writes `canary/`, stable writes `latest/`, an rc moves neither. `TestChannelSelectsDistinctPointers` pins the URL isolation.

## CLI
- npm dist-tags are independent pointers. A version containing `-canary.` publishes to a **new `canary` tag** (`npm i reasonix@canary`); it **never moves `next` or `latest`**, so 1.x-on-`next` and 0.x-on-`latest` users are untouched.
- `release-npm.yml` gains a `workflow_dispatch` canary mode: **Actions → Release npm → Run workflow → base_version: 1.5.0** builds the current ref as `<base>-canary.<run_number>` and publishes it `--tag canary`. Tag-push (`npm-v*`) behaviour is unchanged.
- Verified routing: `0.53.1→latest`, `0.53.1-beta→next`, `1.5.0→next`, `1.5.0-rc.1→next`, `1.5.0-canary.42→canary`.

## Why both
The stable release currently doubles as the beta on both surfaces. CLI was the gap I'd missed first: `next` is the *live* channel for all 1.x users, not a test buffer, so testers on `@next` get production. The separate `canary` tag is the actual buffer.

## Verified
- `go build` / `go vet` / desktop unit tests green (incl. channel-isolation test)
- `node --check` on build.mjs; dist-tag routing exercised across all version shapes
- both workflow YAMLs valid; `resolve-desktop-release.sh` exercised across tag-push / stable-dispatch / canary-dispatch / rc cases
- shell scripts stored LF

## Needs a live run to fully validate
The R2 `canary/` write + rolling `desktop-canary` release, and the npm `--tag canary` publish, can only be confirmed by dispatching once each — recommend a test dispatch of both after merge.
