### PR TITLE
fix(chooser): separate Enter (confirm) from Space (toggle) in multi-s…

### DIFF
--- a/internal/cli/chooser.go
+++ b/internal/cli/chooser.go
@@ -157,10 +157,10 @@ func (m chatTUI) chooserActivate(row int) (tea.Model, tea.Cmd) {
 	switch {
 	case row < len(q.Options):
 		if q.Multi {
-			c.sel[c.tab][row] = !c.sel[c.tab][row]
-			c.custom[c.tab] = ""
-			c.cursor = row
-			return m, nil
+			// Space toggles; Enter confirms current selections and advances.
+			// (Toggling is handled in handleChooserKey; we only arrive here
+			// via Enter or number keys, both of which should commit.)
+			return m.chooserAdvance()
 		}
 		c.sel[c.tab] = map[int]bool{row: true}
 		c.custom[c.tab] = ""


### PR DESCRIPTION
…elect

Multi-select mode now uses Space only for toggling individual options, while Enter (and number keys) confirms current selections and advances to the next question or submits, matching the single-select flow. Previously both keys toggled, making it impossible to commit without toggling the highlighted option.

The desktop AskCard already has this correct via explicit confirm buttons and was unaffected.