### PR TITLE
ci(release): keep canary off the GitHub releases page (R2-only)

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -11,10 +11,10 @@ name: Release desktop
 # release and mirrored to R2 (the updater reads R2 first, GitHub as fallback).
 #
 # The same build/sign/manifest pipeline serves two channels. A `desktop-v*` tag
-# (or manual stable dispatch) publishes the stable line and moves R2's latest/
-# pointer. A manual `channel: canary` dispatch builds with -X main.channel=canary,
-# publishes a rolling `desktop-canary` pre-release, and moves only the canary/
-# pointer — it never touches latest/, so stable installs can't update onto it.
+# (or manual stable dispatch) publishes a GitHub release and moves R2's latest/
+# pointer. A manual `channel: canary` dispatch builds with -X main.channel=canary
+# and uploads only to R2's canary/ pointer — no GitHub release, so canary never
+# shows on the releases page and never touches latest/.
 on:
   push:
     tags: ["desktop-v*"]
@@ -173,24 +173,25 @@ jobs:
         working-directory: desktop
         run: go run ./cmd/sign manifest ../dist "${{ steps.ver.outputs.version }}" "${{ steps.ver.outputs.tag }}"
 
+      # Canary is R2-only and never appears on the GitHub releases page; the mirror
+      # job picks up the signed dist via the canary-dist artifact below. Stable
+      # publishes a GitHub release as usual.
       - name: Publish GitHub release
+        if: steps.ver.outputs.channel != 'canary'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          if [ "${{ steps.ver.outputs.channel }}" = "canary" ]; then
-            # Rolling channel: replace the previous desktop-canary release+tag so it
-            # always holds exactly the latest canary build.
-            gh release delete "${{ steps.ver.outputs.tag }}" --cleanup-tag --yes 2>/dev/null || true
-            gh release create "${{ steps.ver.outputs.tag }}" dist/* \
-              --target "${{ github.sha }}" \
-              --title "Reasonix Desktop ${{ steps.ver.outputs.version }} (canary)" \
-              --notes "Opt-in canary build for testers. Not a stable release. Built from ${{ github.sha }}." \
-              --prerelease
-          else
-            args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes)
-            [ "${{ steps.ver.outputs.prerelease }}" = "true" ] && args+=(--prerelease)
-            gh release create "${{ steps.ver.outputs.tag }}" dist/* "${args[@]}"
-          fi
+          args=(--title "Reasonix Desktop ${{ steps.ver.outputs.version }}" --generate-notes)
+          [ "${{ steps.ver.outputs.prerelease }}" = "true" ] && args+=(--prerelease)
+          gh release create "${{ steps.ver.outputs.tag }}" dist/* "${args[@]}"
+
+      - name: Upload canary dist for mirror
+        if: steps.ver.outputs.channel == 'canary'
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-dist
+          path: dist/*
+          if-no-files-found: error
 
   mirror:
     name: mirror to R2
@@ -214,8 +215,17 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
           RUN_NUMBER: ${{ github.run_number }}
 
+      # Canary has no GitHub release — pull the signed dist from the workflow
+      # artifact. Stable pulls from the published release.
+      - name: Download canary dist
+        if: env.HAS_R2 == 'true' && steps.ver.outputs.channel == 'canary'
+        uses: actions/download-artifact@v4
+        with:
+          name: canary-dist
+          path: assets
+
       - name: Download release assets
-        if: env.HAS_R2 == 'true'
+        if: env.HAS_R2 == 'true' && steps.ver.outputs.channel != 'canary'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -44,10 +44,9 @@ const (
 // for the running build's channel.
 func manifestEndpoints() []string {
 	if channel == "canary" {
-		return []string{
-			r2Base + "/canary/latest.json",
-			ghReleasesBase + "/download/desktop-canary/latest.json",
-		}
+		// Canary publishes only to R2 (no GitHub release), so there is no
+		// GitHub fallback for this channel.
+		return []string{r2Base + "/canary/latest.json"}
 	}
 	return []string{
 		r2Base + "/latest/latest.json",

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,7 +18,7 @@ provides the pre-release buffer instead of a long-lived branch.
 | Surface | Stable | Pre-release buffer |
 |---|---|---|
 | npm | `latest` (0.x), `next` (1.x) | `canary` (`npm i reasonix@canary`) |
-| Desktop | R2 `latest/` pointer | R2 `canary/` pointer (rolling `desktop-canary` release) |
+| Desktop | R2 `latest/` pointer | R2 `canary/` pointer (R2-only — never on the GitHub releases page) |
 
 A canary build is isolated: it **never** moves `latest` / `next` / desktop `latest/`.
 Testers opt in explicitly. (Desktop builds carry `-X main.channel=canary`; npm versions
@@ -46,9 +46,9 @@ the `release` environment deployment.
 2. **Cut a canary** before the intended release (e.g. heading for `1.4.0`):
    - Desktop: Actions → **Release desktop** → `channel: canary`, `base_version: 1.4.0`
    - CLI: Actions → **Release npm** → `base_version: 1.4.0`
-   - Publishes `1.4.0-canary.N` to the desktop `canary/` pointer and npm `@canary`.
-3. **Test** — testers install `reasonix@canary` (CLI) or download the `desktop-canary`
-   pre-release, and report bugs.
+   - Publishes `1.4.0-canary.N` to the desktop R2 `canary/` pointer (no GitHub release) and npm `@canary`.
+3. **Test** — testers install `reasonix@canary` (CLI) or grab the desktop canary
+   build from its R2 link, and report bugs.
 4. **Fix** on `main-v2` via PRs; re-cut the canary as needed (`canary.N` bumps).
 5. **Ship stable** when the canary is clean — push the three tags:
    ```sh
@@ -68,5 +68,5 @@ the `release` environment deployment.
 - Canary version numbers use the workflow `run_number`, so the desktop and CLI canary
   numbers differ (e.g. `canary.11` vs `canary.2`). Only monotonicity per channel matters.
 - A stable `-rc` tag (e.g. `npm-v1.4.0-rc.1`) still ships under `next`, not `canary`.
-- macOS canary self-update is manual (no notarization); testers download from the
-  `desktop-canary` release page.
+- macOS canary self-update is manual (no notarization); testers download the canary
+  build from its R2 link (canary is not on the GitHub releases page).


### PR DESCRIPTION
The canary acceptance builds published a `desktop-canary` GitHub pre-release titled `v1.4.0-canary.N`, which showed up on the public releases page and read like a 1.4 stable was out. It wasn't — but it's confusing.

This makes desktop canary **R2-only**:
- Canary skips the GitHub release entirely; `publish` uploads the signed dist as a `canary-dist` artifact, `mirror` pulls that artifact and pushes to R2 (`canary/` + `desktop-canary/`) as before.
- Updater's canary channel is now R2-only (no GitHub fallback, since there's no release).
- Stable is **unchanged** — still a normal GitHub release + R2 `latest/`.

Result: canary never appears on the releases page; testers get the desktop canary from its R2 link. The already-published `desktop-canary` release was deleted manually.

Verified: `go build`/channel test green, YAML valid.