### PR TITLE
fix(desktop): align balance currency with usage

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1444,9 +1444,15 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 // and is "" when the active provider declares no balance_url — the frontend then
 // omits the readout. Err carries a fetch failure for an optional tooltip.
 type BalanceInfo struct {
-	Available bool   `json:"available"`
-	Display   string `json:"display"`
-	Err       string `json:"err,omitempty"`
+	Available bool            `json:"available"`
+	Display   string          `json:"display"`
+	Balances  []BalanceAmount `json:"balances,omitempty"`
+	Err       string          `json:"err,omitempty"`
+}
+
+type BalanceAmount struct {
+	Currency string `json:"currency"`
+	Amount   string `json:"amount"`
 }
 
 // Balance queries the active provider's wallet balance (a network call). It
@@ -1469,7 +1475,11 @@ func (a *App) BalanceForTab(tabID string) BalanceInfo {
 	if b == nil {
 		return BalanceInfo{} // provider declares no balance endpoint
 	}
-	return BalanceInfo{Available: true, Display: b.Display()}
+	info := BalanceInfo{Available: true, Display: b.Display()}
+	for _, bi := range b.Infos {
+		info.Balances = append(info.Balances, BalanceAmount{Currency: bi.Currency, Amount: bi.TotalBalance})
+	}
+	return info
 }
 
 // JobView is one running background job (bash/task started with

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -80,6 +80,21 @@ function formatMoney(amount?: number, currency?: string): string {
   return `${symbol}${amount < 1 ? amount.toFixed(4) : amount.toFixed(2)}`;
 }
 
+function currencyMatches(value: string | undefined, wanted: string): boolean {
+  const symbol = currencySymbol(wanted);
+  const normalized = (value || "").trim();
+  if (!normalized) return false;
+  if (currencySymbol(normalized) === symbol) return true;
+  return normalized.toUpperCase() === wanted.trim().toUpperCase();
+}
+
+function balanceLabel(balance?: BalanceInfo, currency?: string): string {
+  if (!balance?.available) return "-";
+  const preferred = currency ? balance.balances?.find((b) => currencyMatches(b.currency, currency)) : undefined;
+  if (preferred) return `${currencySymbol(preferred.currency)}${preferred.amount.trim()}`;
+  return balance.display || "-";
+}
+
 export function StatusBar({
   context,
   usage,
@@ -106,6 +121,7 @@ export function StatusBar({
   const avgPct = avgRate(usage);
   const jobsList = jobs ?? [];
   const costLabel = formatMoney(cost, currency);
+  const balanceAmount = balanceLabel(balance, currency);
 
   return (
     <div className="statusbar">
@@ -128,7 +144,7 @@ export function StatusBar({
       <span className="statusbar__sep">·</span>
       <Tooltip label={t("status.balanceTitle")}>
         <span className="statusbar__item statusbar__balance">
-          {t("status.balance", { amount: balance?.available && balance.display ? balance.display : "-" })}
+          {t("status.balance", { amount: balanceAmount })}
         </span>
       </Tooltip>
       <span className="statusbar__spacer" />

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -474,9 +474,15 @@ export interface ProviderView {
 // BalanceInfo is the wallet-balance readout (desktop/app.go Balance). available
 // is false when the provider declares no balanceUrl or a fetch failed; display is
 // the formatted amount (e.g. "¥110.00").
+export interface BalanceAmount {
+  currency: string;
+  amount: string;
+}
+
 export interface BalanceInfo {
   available: boolean;
   display: string;
+  balances?: BalanceAmount[];
   err?: string;
 }
 


### PR DESCRIPTION
## Summary
- expose wallet balance currency amounts to the desktop frontend while keeping the existing display field for compatibility
- show the status-bar balance in the same currency as the current usage/cost when that currency is available
- fall back to the legacy balance display when the provider does not return a matching currency

Fixes #3527

## Verification
- git diff --check
- npm --prefix desktop/frontend run build
- go test ./internal/billing
- cd desktop && go test . -run 'TestPreviewSession|TestListSessions|TestHistory|TestSession'
