### PR TITLE
fix(agent): prevent executor handoff role confusion / 防止执行器交接角色混淆

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -31,6 +31,7 @@ const maxToolOutputBytes = 32 * 1024
 const maxFinalReadinessBlocks = 3
 const maxEmptyFinalBlocks = 3
 const maxStreamRecoveries = 1
+const maxExecutorHandoffConfusionBlocks = 2
 
 // Renderer redraws the assistant's final-answer text as styled output. It is
 // applied only after a turn's text stream completes, so the user sees raw
@@ -122,8 +123,11 @@ type Agent struct {
 	sessMu      sync.Mutex // guards the session pointer for external Session()/SetSession
 	maxSteps    int
 	maxStepsKey string
-	temperature float64
-	pricing     *provider.Pricing
+	// executorHandoffGuard is enabled by Coordinator for the executor agent. The
+	// per-turn marker check in Run keeps ordinary single-model turns unaffected.
+	executorHandoffGuard bool
+	temperature          float64
+	pricing              *provider.Pricing
 
 	// sink receives the turn's typed event stream (reasoning/text deltas, tool
 	// dispatch/results, usage, notices). The agent no longer formats output
@@ -411,7 +415,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 	finalReadinessBlocks := 0
 	emptyFinalBlocks := 0
+	handoffConfusionBlocks := 0
 	streamRecoveries := 0
+	executorHandoff := a.executorHandoffGuard && strings.Contains(input, executorHandoffMarker)
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
 		schemas := a.tools.Schemas()
 		prefixShape := a.capturePrefixShape(schemas)
@@ -490,6 +496,16 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				}
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "empty final answer blocked: model returned no visible answer text; retrying"})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: emptyFinalRetryMessage()})
+				a.maybeCompact(ctx, usage)
+				continue
+			}
+			if executorHandoff && finalAnswerConfusesExecutorWithPlanner(text) {
+				handoffConfusionBlocks++
+				if handoffConfusionBlocks >= maxExecutorHandoffConfusionBlocks {
+					return fmt.Errorf("executor handoff failed: model kept responding as the planner instead of executing")
+				}
+				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor handoff blocked: model responded as planner instead of executing; retrying with explicit executor instructions"})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: executorHandoffRetryMessage()})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
@@ -615,6 +631,55 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 
 func finalReadinessRetryMessage(reason string) string {
 	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
+}
+
+func finalAnswerConfusesExecutorWithPlanner(text string) bool {
+	s := strings.ToLower(strings.TrimSpace(text))
+	if s == "" {
+		return false
+	}
+	patterns := []string{
+		"我是 planner",
+		"我是planner",
+		"我是规划器",
+		"我只是 planner",
+		"我只是planner",
+		"我只能读不能写",
+		"只有只读工具",
+		"没有写入权限",
+		"没有执行权限",
+		"交给 executor",
+		"触发 executor",
+		"如何触发 executor",
+		"需要 executor",
+		"i am planner",
+		"i am the planner",
+		"i'm planner",
+		"i'm the planner",
+		"as the planner",
+		"only have read-only tools",
+		"read-only tools only",
+		"cannot write",
+		"can't write",
+		"no write access",
+		"hand off to executor",
+		"handoff to executor",
+		"trigger the executor",
+		"need the executor",
+	}
+	for _, pattern := range patterns {
+		if strings.Contains(s, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func executorHandoffRetryMessage() string {
+	return `You are already in the executor phase. The planner's read-only limitations do not apply to you.
+
+Do not answer as the planner and do not ask how to trigger the executor.
+Use your available tools now to carry out the task. If a write or command is blocked by permissions or workspace boundaries, state that specific blocker and ask for the needed approval/path.`
 }
 
 func hasVisibleFinalAnswer(text string) bool {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -638,16 +638,16 @@ func finalAnswerConfusesExecutorWithPlanner(text string) bool {
 	if s == "" {
 		return false
 	}
+	// Role-identity phrases only. Bare permission claims ("no write access",
+	// "没有写入权限") are excluded — a correctly-executing model uses that exact
+	// vocabulary to report a genuine blocker, which is the desired behavior.
 	patterns := []string{
 		"我是 planner",
 		"我是planner",
 		"我是规划器",
 		"我只是 planner",
 		"我只是planner",
-		"我只能读不能写",
 		"只有只读工具",
-		"没有写入权限",
-		"没有执行权限",
 		"交给 executor",
 		"触发 executor",
 		"如何触发 executor",
@@ -659,9 +659,6 @@ func finalAnswerConfusesExecutorWithPlanner(text string) bool {
 		"as the planner",
 		"only have read-only tools",
 		"read-only tools only",
-		"cannot write",
-		"can't write",
-		"no write access",
 		"hand off to executor",
 		"handoff to executor",
 		"trigger the executor",

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -31,7 +31,7 @@ const maxToolOutputBytes = 32 * 1024
 const maxFinalReadinessBlocks = 3
 const maxEmptyFinalBlocks = 3
 const maxStreamRecoveries = 1
-const maxExecutorHandoffConfusionBlocks = 2
+const maxExecutorHandoffNudges = 1
 
 // Renderer redraws the assistant's final-answer text as styled output. It is
 // applied only after a turn's text stream completes, so the user sees raw
@@ -415,7 +415,8 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 	finalReadinessBlocks := 0
 	emptyFinalBlocks := 0
-	handoffConfusionBlocks := 0
+	handoffNudges := 0
+	usedAnyTool := false
 	streamRecoveries := 0
 	executorHandoff := a.executorHandoffGuard && strings.Contains(input, executorHandoffMarker)
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
@@ -499,12 +500,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				a.maybeCompact(ctx, usage)
 				continue
 			}
-			if executorHandoff && finalAnswerConfusesExecutorWithPlanner(text) {
-				handoffConfusionBlocks++
-				if handoffConfusionBlocks >= maxExecutorHandoffConfusionBlocks {
-					return fmt.Errorf("executor handoff failed: model kept responding as the planner instead of executing")
-				}
-				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor handoff blocked: model responded as planner instead of executing; retrying with explicit executor instructions"})
+			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges {
+				handoffNudges++
+				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor answered without taking any action; nudging it to use its tools"})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: executorHandoffRetryMessage()})
 				a.maybeCompact(ctx, usage)
 				continue
@@ -515,6 +513,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 			return nil // model gave a final answer
 		}
 		emptyFinalBlocks = 0
+		usedAnyTool = true
 
 		results := a.executeBatch(ctx, calls)
 		for i, call := range calls {
@@ -631,45 +630,6 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 
 func finalReadinessRetryMessage(reason string) string {
 	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
-}
-
-func finalAnswerConfusesExecutorWithPlanner(text string) bool {
-	s := strings.ToLower(strings.TrimSpace(text))
-	if s == "" {
-		return false
-	}
-	// Role-identity phrases only. Bare permission claims ("no write access",
-	// "没有写入权限") are excluded — a correctly-executing model uses that exact
-	// vocabulary to report a genuine blocker, which is the desired behavior.
-	patterns := []string{
-		"我是 planner",
-		"我是planner",
-		"我是规划器",
-		"我只是 planner",
-		"我只是planner",
-		"只有只读工具",
-		"交给 executor",
-		"触发 executor",
-		"如何触发 executor",
-		"需要 executor",
-		"i am planner",
-		"i am the planner",
-		"i'm planner",
-		"i'm the planner",
-		"as the planner",
-		"only have read-only tools",
-		"read-only tools only",
-		"hand off to executor",
-		"handoff to executor",
-		"trigger the executor",
-		"need the executor",
-	}
-	for _, pattern := range patterns {
-		if strings.Contains(s, pattern) {
-			return true
-		}
-	}
-	return false
 }
 
 func executorHandoffRetryMessage() string {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -23,8 +23,12 @@ Given a task, produce a concise, ordered plan for the executor model to carry ou
 Use the read-only tools available to you when the task needs context from the
 workspace, user rules, or docs; keep that research targeted and stop once you
 have enough evidence. Do not write full implementations or attempt side effects.
-Outline the steps, which files to touch, and the key decisions. Keep it short and
+Do not ask the user how to trigger the executor and do not say you are waiting
+for the executor. Output executor-ready instructions: what to do, which files or
+commands are relevant, expected blockers, and key decisions. Keep it short and
 actionable.`
+
+const executorHandoffMarker = "Reasonix executor handoff"
 
 // PlannerPromptWithContext appends cache-stable standing context, such as loaded
 // REASONIX.md / AGENTS.md memory, to the planner's smaller system prompt.
@@ -67,6 +71,9 @@ func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerP
 		plannerOptions.Temperature = temperature
 		plannerOptions.Pricing = plannerPricing
 		plannerAgent = New(planner, plannerTools, plannerSession, plannerOptions, plannerSink(sink))
+	}
+	if executor != nil {
+		executor.executorHandoffGuard = true
 	}
 	return &Coordinator{
 		planner:        planner,
@@ -166,5 +173,22 @@ func plannerSink(sink event.Sink) event.Sink {
 }
 
 func formatHandoff(task, plan string) string {
-	return fmt.Sprintf("Task: %s\n\nA planner proposed this approach:\n%s\n\nCarry it out, adapting as needed.", task, plan)
+	return fmt.Sprintf(`# %s
+
+You are the executor now. Use your available tools to execute the task.
+
+Original task:
+%s
+
+Planner output:
+%s
+
+Executor instructions:
+- Treat the planner output as context, not as your role or capability set.
+- Ignore any planner statement such as "I cannot write", "I only have read-only tools", or "hand this to the executor"; those limitations apply to the planner, not to you.
+- Do not ask the user how to trigger the executor. You are already in the executor phase.
+- If the task requires changes, call the appropriate tools (for example write/edit/bash) instead of only restating the plan.
+- If a target path is outside the writable workspace or otherwise blocked, explain that specific blocker and ask for the needed path/approval.
+
+Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, plan)
 }

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -74,7 +74,7 @@ func TestCoordinatorHandsPlanToExecutor(t *testing.T) {
 	if got := lastUser(planner.lastReq); !strings.Contains(got, "fix the bug") {
 		t.Errorf("planner saw user %q, want it to contain the task", got)
 	}
-	if got := lastUser(exec.lastReq); !strings.Contains(got, "read main.go") || !strings.Contains(got, "fix the bug") {
+	if got := lastUser(exec.lastReq); !strings.Contains(got, "read main.go") || !strings.Contains(got, "fix the bug") || !strings.Contains(got, "You are the executor now") {
 		t.Errorf("executor saw user %q, want task + plan", got)
 	}
 	// planner session must accumulate (system, user, assistant-plan) so its
@@ -251,6 +251,45 @@ func TestCoordinatorPlannerMaxStepsZeroIsUnlimited(t *testing.T) {
 	}
 	if got := lastUser(exec.lastReq); !strings.Contains(got, "use both files") {
 		t.Fatalf("executor did not receive planner output: %q", got)
+	}
+}
+
+func TestCoordinatorRetriesExecutorWhenItAnswersAsPlanner(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Write the requested skill file."},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "我是 Planner，只有只读工具，需要交给 Executor 执行。"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "write_file", Arguments: `{"path":"kan-tu.md"}`}},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "Done."},
+			{Type: provider.ChunkDone},
+		},
+	}}
+
+	execReg := tool.NewRegistry()
+	execReg.Add(coordinatorTestTool{name: "write_file", readOnly: false, output: "wrote file"})
+	executor := New(exec, execReg, NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "install the skill"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 3 {
+		t.Fatalf("executor requests = %d, want original confusion, retry tool call, final answer", got)
+	}
+	if got := lastUser(exec.requests[1]); !strings.Contains(got, "already in the executor phase") {
+		t.Fatalf("second executor request missing handoff retry message: %q", got)
+	}
+	if len(exec.requests[1].Messages) == 0 {
+		t.Fatal("executor request should contain messages")
 	}
 }
 

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -329,3 +329,26 @@ func BenchmarkPlannerToolRegistry(b *testing.B) {
 		}
 	}
 }
+
+func TestHandoffConfusionDetectionExcludesLegitBlockers(t *testing.T) {
+	confused := []string{
+		"我是 Planner，只有只读工具，需要交给 Executor 执行。",
+		"As the planner I only have read-only tools, hand off to executor.",
+	}
+	legit := []string{
+		"I cannot write to /etc/hosts because it is outside the writable workspace. Please grant access.",
+		"我没有写入权限去修改 /etc/hosts，该路径在工作区之外，请提供工作区内的路径。",
+		"The deploy step failed: no write access to the production bucket.",
+		"Done. I edited main.go and added the missing return.",
+	}
+	for _, s := range confused {
+		if !finalAnswerConfusesExecutorWithPlanner(s) {
+			t.Errorf("want confusion=true for %q", s)
+		}
+	}
+	for _, s := range legit {
+		if finalAnswerConfusesExecutorWithPlanner(s) {
+			t.Errorf("want confusion=false for %q", s)
+		}
+	}
+}

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -74,7 +74,7 @@ func TestCoordinatorHandsPlanToExecutor(t *testing.T) {
 	if got := lastUser(planner.lastReq); !strings.Contains(got, "fix the bug") {
 		t.Errorf("planner saw user %q, want it to contain the task", got)
 	}
-	if got := lastUser(exec.lastReq); !strings.Contains(got, "read main.go") || !strings.Contains(got, "fix the bug") || !strings.Contains(got, "You are the executor now") {
+	if got := lastUser(exec.requests[0]); !strings.Contains(got, "read main.go") || !strings.Contains(got, "fix the bug") || !strings.Contains(got, "You are the executor now") {
 		t.Errorf("executor saw user %q, want task + plan", got)
 	}
 	// planner session must accumulate (system, user, assistant-plan) so its
@@ -170,7 +170,7 @@ func TestCoordinatorPlannerUsesReadOnlyResearchTools(t *testing.T) {
 			t.Fatalf("planner tools = %v, must not include %s", tools, forbidden)
 		}
 	}
-	if got := lastUser(exec.lastReq); !strings.Contains(got, "follow the loaded rule") || !strings.Contains(got, "fix the bug") {
+	if got := lastUser(exec.requests[0]); !strings.Contains(got, "follow the loaded rule") || !strings.Contains(got, "fix the bug") {
 		t.Errorf("executor saw user %q, want task + planner plan", got)
 	}
 	if got := plannerSess.Messages[0].Content; !strings.Contains(got, "Rule: keep changes narrow.") {
@@ -249,19 +249,21 @@ func TestCoordinatorPlannerMaxStepsZeroIsUnlimited(t *testing.T) {
 	if got := len(planner.requests); got != 3 {
 		t.Fatalf("planner requests = %d, want all 3 scripted planner turns", got)
 	}
-	if got := lastUser(exec.lastReq); !strings.Contains(got, "use both files") {
+	if got := lastUser(exec.requests[0]); !strings.Contains(got, "use both files") {
 		t.Fatalf("executor did not receive planner output: %q", got)
 	}
 }
 
-func TestCoordinatorRetriesExecutorWhenItAnswersAsPlanner(t *testing.T) {
+func TestCoordinatorNudgesExecutorThatAnswersWithoutActing(t *testing.T) {
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "Write the requested skill file."},
 		{Type: provider.ChunkDone},
 	}}
+	// The first turn is a plain final answer with no tool call and no
+	// planner-vocabulary — the nudge must fire on the missing action, not on words.
 	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
 		{
-			{Type: provider.ChunkText, Text: "我是 Planner，只有只读工具，需要交给 Executor 执行。"},
+			{Type: provider.ChunkText, Text: "这个计划看起来没问题,应该很好实现。"},
 			{Type: provider.ChunkDone},
 		},
 		{
@@ -283,13 +285,45 @@ func TestCoordinatorRetriesExecutorWhenItAnswersAsPlanner(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	if got := len(exec.requests); got != 3 {
-		t.Fatalf("executor requests = %d, want original confusion, retry tool call, final answer", got)
+		t.Fatalf("executor requests = %d, want answer-without-acting, nudge tool call, final answer", got)
 	}
-	if got := lastUser(exec.requests[1]); !strings.Contains(got, "already in the executor phase") {
-		t.Fatalf("second executor request missing handoff retry message: %q", got)
+	if got := lastUser(exec.requests[1]); !strings.Contains(got, "Use your available tools now to carry out the task") {
+		t.Fatalf("second executor request missing handoff nudge message: %q", got)
 	}
-	if len(exec.requests[1].Messages) == 0 {
-		t.Fatal("executor request should contain messages")
+}
+
+func TestCoordinatorDoesNotNudgeExecutorThatActs(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Write the requested skill file."},
+		{Type: provider.ChunkDone},
+	}}
+	// Executor calls a tool on its first turn, then answers — no nudge expected.
+	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "write_file", Arguments: `{"path":"kan-tu.md"}`}},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "Done."},
+			{Type: provider.ChunkDone},
+		},
+	}}
+
+	execReg := tool.NewRegistry()
+	execReg.Add(coordinatorTestTool{name: "write_file", readOnly: false, output: "wrote file"})
+	executor := New(exec, execReg, NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "install the skill"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 2 {
+		t.Fatalf("executor requests = %d, want tool call + final answer with no nudge", got)
+	}
+	for i, req := range exec.requests {
+		if strings.Contains(lastUser(req), "Use your available tools now to carry out the task") {
+			t.Fatalf("request %d unexpectedly received a handoff nudge", i)
+		}
 	}
 }
 
@@ -326,29 +360,6 @@ func BenchmarkPlannerToolRegistry(b *testing.B) {
 		reg := PlannerToolRegistry(parentReg)
 		if reg.Len() == 0 {
 			b.Fatal("planner registry should retain read-only research tools")
-		}
-	}
-}
-
-func TestHandoffConfusionDetectionExcludesLegitBlockers(t *testing.T) {
-	confused := []string{
-		"我是 Planner，只有只读工具，需要交给 Executor 执行。",
-		"As the planner I only have read-only tools, hand off to executor.",
-	}
-	legit := []string{
-		"I cannot write to /etc/hosts because it is outside the writable workspace. Please grant access.",
-		"我没有写入权限去修改 /etc/hosts，该路径在工作区之外，请提供工作区内的路径。",
-		"The deploy step failed: no write access to the production bucket.",
-		"Done. I edited main.go and added the missing return.",
-	}
-	for _, s := range confused {
-		if !finalAnswerConfusesExecutorWithPlanner(s) {
-			t.Errorf("want confusion=true for %q", s)
-		}
-	}
-	for _, s := range legit {
-		if finalAnswerConfusesExecutorWithPlanner(s) {
-			t.Errorf("want confusion=false for %q", s)
 		}
 	}
 }


### PR DESCRIPTION
Refs #3490

## Summary
- strengthen the planner-to-executor handoff so executor models ignore planner-only limitations
- add an executor handoff guard that retries when the executor answers as the planner instead of using tools
- cover the Chinese planner-style confusion case with a coordinator regression test

## Testing
- `go test ./internal/agent ./internal/boot ./internal/config ./internal/cli`
- `cd desktop && go test . -run 'TestSettings|TestSetAgent|Test.*Settings|TestProviderViewFromEntry'`
- `npm run check:css && npm run test:typecheck`
