### PR TITLE
fix(permission): make session/persist approval grants tool-wide

### DIFF
--- a/internal/control/approval_e2e_test.go
+++ b/internal/control/approval_e2e_test.go
@@ -1,0 +1,92 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/permission"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type recordingWriter struct {
+	mu    sync.Mutex
+	paths []string
+}
+
+func (w *recordingWriter) Name() string          { return "write_file" }
+func (w *recordingWriter) Description() string    { return "write a file" }
+func (w *recordingWriter) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)
+}
+func (w *recordingWriter) ReadOnly() bool { return false }
+func (w *recordingWriter) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var a struct {
+		Path string `json:"path"`
+	}
+	_ = json.Unmarshal(args, &a)
+	w.mu.Lock()
+	w.paths = append(w.paths, a.Path)
+	w.mu.Unlock()
+	return "ok", nil
+}
+
+func toolCallTurn(id, name, args string) []provider.Chunk {
+	return []provider.Chunk{
+		{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: id, Name: name, Arguments: args}},
+		{Type: provider.ChunkDone},
+	}
+}
+
+// TestApprovalToolWideEndToEnd drives a full agent turn through the real gate:
+// the model writes two different files, the user answers "allow for this session"
+// on the first, and the second must run without a second prompt. Regression for
+// #3498 / #3520 (a session/persist grant used to pin the exact subject, so every
+// new file/command re-prompted).
+func TestApprovalToolWideEndToEnd(t *testing.T) {
+	writer := &recordingWriter{}
+	reg := tool.NewRegistry()
+	reg.Add(writer)
+
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		toolCallTurn("c1", "write_file", `{"path":"a.txt"}`),
+		toolCallTurn("c2", "write_file", `{"path":"b.txt"}`),
+		textTurn("Done."),
+	}}
+	ag := agent.New(prov, reg, agent.NewSession(""), agent.Options{}, event.Discard)
+
+	approvalID := make(chan string, 4)
+	prompts := 0
+	c := New(Options{
+		Runner:   ag,
+		Executor: ag,
+		Policy:   permission.New("ask", nil, nil, nil), // writers ask by default
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest {
+				prompts++
+				approvalID <- e.Approval.ID
+			}
+		}),
+	})
+	c.EnableInteractiveApproval()
+
+	// Answer the first prompt with "allow for this session" (allow, session, !persist).
+	go func() { c.Approve(<-approvalID, true, true, false) }()
+
+	if err := c.runTurnWithRaw(context.Background(), "edit the files", "edit the files"); err != nil {
+		t.Fatalf("runTurnWithRaw: %v", err)
+	}
+
+	if prompts != 1 {
+		t.Errorf("approval prompts = %d, want 1 (the session grant must cover the second file too)", prompts)
+	}
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	if len(writer.paths) != 2 || writer.paths[0] != "a.txt" || writer.paths[1] != "b.txt" {
+		t.Errorf("executed writes = %v, want both a.txt and b.txt", writer.paths)
+	}
+}

--- a/internal/control/approval_e2e_test.go
+++ b/internal/control/approval_e2e_test.go
@@ -18,8 +18,8 @@ type recordingWriter struct {
 	paths []string
 }
 
-func (w *recordingWriter) Name() string          { return "write_file" }
-func (w *recordingWriter) Description() string    { return "write a file" }
+func (w *recordingWriter) Name() string        { return "write_file" }
+func (w *recordingWriter) Description() string { return "write a file" }
 func (w *recordingWriter) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -809,7 +809,7 @@ func (c *Controller) Turn() int {
 }
 
 // Approve answers a pending ApprovalRequest by ID: allow runs the call, session
-// also remembers a grant for the rest of the session so the same tool+subject
+// also remembers a tool-wide grant for the rest of the session so that tool
 // isn't re-prompted. Unknown/expired IDs are ignored.
 func (c *Controller) Approve(id string, allow, session, persist bool) {
 	c.mu.Lock()
@@ -2150,8 +2150,8 @@ func listItem(line string) (content string, level int, ok bool) {
 }
 
 // requestApproval emits an ApprovalRequest and blocks until Approve(ID, …)
-// answers or ctx is cancelled. A prior session grant for the same tool+subject
-// short-circuits. promptMu serialises outstanding prompts.
+// answers or ctx is cancelled. A prior tool-wide session grant short-circuits.
+// promptMu serialises outstanding prompts.
 // parseRewind parses the arguments after "/rewind". The user may provide:
 //
 //	/rewind              → latest checkpoint, both
@@ -2188,7 +2188,11 @@ func parseRewind(args string, cps []checkpoint.Meta) (int, RewindScope, error) {
 }
 
 func (c *Controller) requestApproval(ctx context.Context, tool, subject string) (bool, bool, error) {
-	key := tool + "\x00" + subject
+	// Session grants are tool-wide: "allow for this session" / "allow persistently"
+	// mean the user trusts this tool (write_file, bash, …), not just this one
+	// file/command, so a different subject for the same tool isn't re-prompted.
+	// Deny rules still bite upstream of here.
+	key := tool
 
 	c.mu.Lock()
 	// YOLO/bypass and the just-approved-plan window auto-allow every approval

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -249,23 +249,25 @@ func TestApprovalDeny(t *testing.T) {
 	}
 }
 
-// TestApprovalSessionGrant proves an "allow this session" answer short-circuits
-// later prompts for the same tool+subject: only the first reaches the frontend.
+// TestApprovalSessionGrant proves an "allow this session" answer is tool-wide:
+// later calls to the same tool with DIFFERENT subjects short-circuit, so only the
+// first reaches the frontend. (Regression for "I clicked allow-for-session and it
+// kept re-prompting on every new command/file" — #3498 / #3520.)
 func TestApprovalSessionGrant(t *testing.T) {
 	c, ids, prompts := approvalIDs()
-	// Only the first call reaches the frontend (the session grant short-circuits
+	// Only the first call reaches the frontend (the tool-wide grant short-circuits
 	// the rest), so a single approval is all this needs — ranging would block on
 	// a second ID that never arrives.
 	go func() { c.Approve(<-ids, true, true, false) }()
 
-	for i := 0; i < 3; i++ {
-		allow, _, err := gateApprover{c}.Approve(context.Background(), "bash", "go build", nil)
+	for _, subject := range []string{"go build", "go test ./...", "npm install"} {
+		allow, _, err := gateApprover{c}.Approve(context.Background(), "bash", subject, nil)
 		if err != nil || !allow {
-			t.Fatalf("call %d = (%v,%v), want allow", i, allow, err)
+			t.Fatalf("call %q = (%v,%v), want allow", subject, allow, err)
 		}
 	}
 	if *prompts != 1 {
-		t.Errorf("prompted %d times, want 1 (session grant should short-circuit)", *prompts)
+		t.Errorf("prompted %d times, want 1 (tool-wide session grant must short-circuit other subjects)", *prompts)
 	}
 }
 

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -278,20 +278,13 @@ func (g *Gate) Check(ctx context.Context, toolName string, args json.RawMessage,
 			return false, "the user declined this tool call — do not retry it; ask how they would like to proceed or choose another approach.", nil
 		}
 		if remember && g.OnRemember != nil {
-			g.OnRemember(rememberRule(toolName, subject))
+			// "Always allow" is tool-wide: persist the bare tool name so any
+			// later subject (a different file / command) is allowed without
+			// re-prompting. Deny rules still take precedence on every call.
+			g.OnRemember(toolName)
 		}
 		return true, "", nil
 	default:
 		return true, "", nil
 	}
-}
-
-// rememberRule builds the rule string persisted when the user picks "always
-// allow". It pins the exact subject (command / path) so the remembered grant is
-// narrow; the user can broaden it by hand later.
-func rememberRule(toolName, subject string) string {
-	if subject == "" {
-		return toolName
-	}
-	return toolName + "=" + subject
 }

--- a/internal/permission/permission_extra_test.go
+++ b/internal/permission/permission_extra_test.go
@@ -140,26 +140,6 @@ func TestSubjectPriority(t *testing.T) {
 	}
 }
 
-// --- rememberRule ---
-
-func TestRememberRuleWithSubject(t *testing.T) {
-	got := rememberRule("bash", "go test ./...")
-	if got != "bash=go test ./..." {
-		t.Errorf("rememberRule = %q", got)
-	}
-	// The literal form round-trips: ParseRule must read it back as an exact-match rule.
-	if r, ok := ParseRule(got); !ok || !r.Literal || r.Tool != "bash" || r.Subject != "go test ./..." {
-		t.Errorf("ParseRule(%q) = {%q,%q,lit=%v,ok=%v}", got, r.Tool, r.Subject, r.Literal, ok)
-	}
-}
-
-func TestRememberRuleWithoutSubject(t *testing.T) {
-	got := rememberRule("ls", "")
-	if got != "ls" {
-		t.Errorf("rememberRule = %q", got)
-	}
-}
-
 // --- New ---
 
 func TestNewPolicy(t *testing.T) {

--- a/internal/permission/permission_test.go
+++ b/internal/permission/permission_test.go
@@ -167,8 +167,10 @@ func TestGateInteractive(t *testing.T) {
 	if ap.calls != 1 {
 		t.Errorf("approver calls = %d, want 1", ap.calls)
 	}
-	if remembered != "bash=go build" {
-		t.Errorf("remembered rule = %q, want %q", remembered, "bash=go build")
+	// "Always allow" is tool-wide: the persisted rule is the bare tool name, not
+	// pinned to "go build", so any later command runs without re-prompting.
+	if remembered != "bash" {
+		t.Errorf("remembered rule = %q, want tool-wide %q", remembered, "bash")
 	}
 
 	// Decline path.


### PR DESCRIPTION
Fixes the most-reported approval complaint: clicking **"本会话内允许" / "持久允许"** (allow for session / allow persistently) kept re-prompting on every new file or command.

## Root cause
Both grants pinned the exact **subject** (file path / command):
- the session grant keyed on `tool + subject` (`requestApproval`),
- the persisted rule was `tool=subject` (literal).

So "allow write_file for this session" only suppressed re-prompts for that *one* file; the next file re-asked. Users read the labels as "trust this tool" and expected no further prompts.

## Fix (tool-wide, per maintainer decision)
- Session grant now keys on the **tool name** → any later subject of that tool short-circuits.
- Persisted rule is the **bare tool name** → tool-wide allow in config.
- **Deny rules still take precedence on every call**, so e.g. `rm -rf` on the deny list is still blocked even after "allow bash for this session".

## Tests
- Updated `TestApprovalSessionGrant` to use *different* subjects (the actual regression).
- New **full agent-turn e2e** (`TestApprovalToolWideEndToEnd`): model writes two different files, user picks "allow for session" once, second write runs with **no second prompt** — exactly one approval, both files written.
- All of permission / control / agent / boot / config green; vet clean.

Closes #3498
Closes #3520