### PR TITLE
[desktop] 历史面板窄窗口下让预览区自适应展开

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5964,7 +5964,7 @@ a[href] {
 .history-content {
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(340px, 0.38fr) minmax(0, 0.62fr);
+  grid-template-columns: minmax(0, 0.38fr) minmax(0, 0.62fr);
   overflow: hidden;
 }
 .history-list {
@@ -6191,7 +6191,10 @@ a[href] {
     max-width: 100%;
   }
   .history-content {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .history-list {
+    max-height: 40vh;
   }
   .history-preview {
     min-height: 260px;


### PR DESCRIPTION
**问题**

历史面板在窄窗口/竖屏模式下，右侧预览区被严重压缩，没有自适应展开。根因是 .history-content 的 grid 模板用了 minmax(340px, 0.38fr) 作为列表列的下限，导致 760px 以下窗口中列表强制占 340px，预览区被挤压。

**改动**

- desktop/frontend/src/styles.css:5964 — 列表列下限从 340px 改为 