### PR TITLE
Fix desktop image drag crash / 修复桌面图片拖拽崩溃

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1372,7 +1372,7 @@ export default function App() {
             {sidebarCollapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
           </button>
           <div className="app-chrome__identity" aria-label="Reasonix">
-            <img src={logoWordmark} alt="" className="app-chrome__logo" />
+            <img src={logoWordmark} alt="" className="app-chrome__logo" draggable={false} />
             <span className="app-chrome__separator">/</span>
             <span className="app-chrome__scope">{appChromeScopeLabel(activeTab, state.meta)}</span>
           </div>

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1480,7 +1480,7 @@ export function Composer({
             >
               <Tooltip label={a.path}>
                 <span className="composer-context__label">
-                  {a.previewUrl ? <img src={a.previewUrl} alt="" /> : <FileText size={15} />}
+                  {a.previewUrl ? <img src={a.previewUrl} alt="" draggable={false} /> : <FileText size={15} />}
                   <span>{a.path.split("/").pop()}</span>
                 </span>
               </Tooltip>

--- a/desktop/frontend/src/components/OnboardingOverlay.tsx
+++ b/desktop/frontend/src/components/OnboardingOverlay.tsx
@@ -43,7 +43,7 @@ export function OnboardingOverlay({ onComplete }: { onComplete: () => void }) {
   return (
     <div className="onboarding">
       <div className="onboarding__card">
-        <img src={logo} className="onboarding__logo" alt="Reasonix" />
+        <img src={logo} className="onboarding__logo" alt="Reasonix" draggable={false} />
         <div className="onboarding__title">{t("onboarding.title")}</div>
         <div className="onboarding__tag">{t("onboarding.tagline")}</div>
 

--- a/desktop/frontend/src/components/StartupSplash.tsx
+++ b/desktop/frontend/src/components/StartupSplash.tsx
@@ -69,7 +69,7 @@ export function StartupSplash({ hold, onDone }: { hold: boolean; onDone: () => v
     <div className="startup-splash" data-leaving={leaving} onClick={() => finish(true)}>
       <div className="startup-splash__card">
         <div className="startup-splash__mark" aria-hidden="true">
-          <img src={logoSymbol} alt="" />
+          <img src={logoSymbol} alt="" draggable={false} />
         </div>
         <div className="startup-splash__name">Reasonix</div>
         <div className="startup-splash__sub">{t("app.splashSubtitle")}</div>

--- a/desktop/frontend/src/components/Welcome.tsx
+++ b/desktop/frontend/src/components/Welcome.tsx
@@ -10,7 +10,7 @@ export function Welcome({ onPrompt }: { onPrompt: (text: string) => void }) {
   const examples = [t("welcome.ex1"), t("welcome.ex2"), t("welcome.ex3")];
   return (
     <div className="welcome">
-      <img src={logoWordmark} className="welcome__logo" alt="Reasonix" />
+      <img src={logoWordmark} className="welcome__logo" alt="Reasonix" draggable={false} />
       <div className="welcome__tag">{t("welcome.tagline")}</div>
 
       <div className="welcome__hints">

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -117,7 +117,7 @@ function renderMediaPreview(preview: FilePreview): JSX.Element | null {
   if (preview.kind === "image") {
     return (
       <div className="workspace-media workspace-media--image">
-        <img src={preview.url} alt={basename(preview.path)} decoding="async" />
+        <img src={preview.url} alt={basename(preview.path)} decoding="async" draggable={false} />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- mark internal desktop images as non-draggable so dragging the empty-state logo does not start a browser image drag
- cover adjacent internal image previews/logos to keep Wails file-drop handling reserved for real file drops

Fixes #3543

## Verification
- pnpm --dir desktop/frontend check:css
- pnpm --dir desktop/frontend typecheck
- pnpm --dir desktop/frontend build
- rg -n "<img(?![^>]*draggable=)" desktop/frontend/src -S -P; test $? -eq 1