### PR TITLE
docs: note Windows code signing via SignPath Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ brew install esengine/reasonix/reasonix   # macOS
 Prebuilt archives (`darwin|linux|windows × amd64|arm64`) and `SHA256SUMS` are on
 every [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases).
 
+### Code signing
+
+Windows builds are code-signed with a free certificate provided by the
+[SignPath Foundation](https://signpath.org/), with signing through
+[SignPath.io](https://signpath.io/).
+
 ### Build from source
 
 ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,6 +68,11 @@ brew install esengine/reasonix/reasonix   # macOS
 预编译归档(`darwin|linux|windows × amd64|arm64`)和 `SHA256SUMS` 见每个
 [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases)。
 
+### 代码签名
+
+Windows 构建使用 [SignPath 基金会](https://signpath.org/) 提供的免费代码签名证书,
+通过 [SignPath.io](https://signpath.io/) 完成签名。
+
 ### 从源码构建
 
 ```sh


### PR DESCRIPTION
Adds a short code-signing note to README (EN + zh-CN). This satisfies the SignPath Foundation open-source program requirement that the download/about page mention the project uses SignPath for code signing. Signing gets wired into the desktop release workflow once the certificate is granted.