### PR TITLE
feat(tui): empty enter scrolls viewport to bottom

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1041,6 +1041,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			line := strings.TrimSpace(m.input.Value())
 
 			if line == "" {
+				m.viewport.GotoBottom()
 				return m, nil
 			}
 			if line == "exit" || line == "quit" || line == ":q" {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1017,6 +1017,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == tuiRunning {
 				line := strings.TrimSpace(m.input.Value())
 				if line == "" {
+					m.viewport.GotoBottom()
 					return m, nil
 				}
 				if m.queueEditCursor >= 0 && m.queueEditCursor < len(m.pendingInterject) {

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1101,6 +1101,54 @@ func TestTranscriptTailFollow(t *testing.T) {
 	}
 }
 
+// TestEmptyEnterScrollsToBottom proves that pressing Enter with an empty composer
+// scrolls the viewport to the bottom in both idle and running states, so the user
+// can quickly tail-follow after scrolling up to read history.
+func TestEmptyEnterScrollsToBottom(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	// --- idle state ---
+	t.Run("idle", func(t *testing.T) {
+		cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 8})
+		for i := 0; i < 12; i++ {
+			cur = adv(cur, notice)
+		}
+		// Scroll up to leave the bottom.
+		cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+		if cur.viewport.AtBottom() {
+			t.Fatal("wheel-up should break the bottom pin")
+		}
+		// Empty enter → should snap back to bottom.
+		cur = adv(cur, tea.KeyPressMsg{Code: tea.KeyEnter})
+		if !cur.viewport.AtBottom() {
+			t.Error("empty enter while idle should scroll viewport to bottom")
+		}
+	})
+
+	// --- running state ---
+	t.Run("running", func(t *testing.T) {
+		cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 8})
+		for i := 0; i < 12; i++ {
+			cur = adv(cur, notice)
+		}
+		cur.state = tuiRunning
+		cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+		if cur.viewport.AtBottom() {
+			t.Fatal("wheel-up should break the bottom pin")
+		}
+		cur = adv(cur, tea.KeyPressMsg{Code: tea.KeyEnter})
+		if !cur.viewport.AtBottom() {
+			t.Error("empty enter while running should scroll viewport to bottom")
+		}
+	})
+}
+
 func TestFoldedPasteUsesPlaceholderAndExpandsOnSend(t *testing.T) {
 	m := newTestChatTUI()
 	pasted := "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3,\n  \"d\": 4\n}"


### PR DESCRIPTION
小改动：在 TUI 中，输入框为空时按 Enter 不再是无操作，而是自动将 viewport 滚到最底部（tail-follow）。

之前空输入按 Enter 直接 return，改了之后加了一行 `m.viewport.GotoBottom()`。

Closes #3550