### PR TITLE
[desktop] fix: 修复超链接中键点击硬控 GUI (#3505)

### DIFF
--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -37,6 +37,13 @@ const components: Components = {
         e.preventDefault();
         if (href) openExternal(href);
       }}
+      onAuxClick={(e) => {
+        e.preventDefault();
+        if (href) openExternal(href);
+      }}
+      onMouseDown={(e) => {
+        if (e.button === 1) e.preventDefault();
+      }}
     >
       {children}
     </a>


### PR DESCRIPTION
## 修复内容

修复 AI 回复中的超链接被鼠标中键点击时，会导致整个 webview 被导航走（界面硬控）的问题。

## 根因

\Markdown.tsx\ 中的 \<a>\ 组件只处理了 \onClick\ 事件，但鼠标中键触发的是 \uxclick\ 事件，未被拦截，导致浏览器默认行为执行（在 webview 中直接导航）。

## 修复方案

- 添加 \onAuxClick\ 处理，拦截中键点击并通过 \openExternal()\ 在系统浏览器打开
- 添加 \onMouseDown\ 阻止中键默认行为（兼容某些边缘情况）

## 测试

- ✅ \
pm run typecheck\ 通过
- ✅ \
pm run check:css\ 通过

Fixes #3505