### PR TITLE
fix(desktop): 修复右侧文件/Git栏分割线缝隙 (#3443)

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -644,8 +644,9 @@ a[href] {
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 0;
+  left: 50%;
   width: 1px;
+  transform: translateX(-50%);
   background: var(--border-soft);
   transition: background 0.12s, box-shadow 0.12s;
 }


### PR DESCRIPTION
## 问题

右侧「文件与 Git」栏和对话窗口之间的分割线与侧边栏之间存在明显缝隙。

## 根因

`workspace-panel-resizer` 的 `::after` 线定位在 `left: 0`（最左边），但 resizer 本身有 8px 宽，导致右边 7px 是空白区域，视觉上形成"缝隙"。

对比 `sidebar-resizer` 的线在 `left: 50%; transform: translateX(-50%)`（居中），所以没有缝隙感。

## 修复

将 `workspace-panel-resizer::after` 的线居中显示：

```css
left: 50%;
transform: translateX(-50%);
```

## 测试

- ✅ `npm run typecheck` 通过
- ✅ `npm run check:css` 通过

Fixes #3443