### PR TITLE
fix(desktop): restore maximized window from tray

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -318,15 +318,30 @@ func showFromBackground(ctx context.Context, wasMaximised bool) {
 	if backgroundCloseUsesApplicationHide(goruntime.GOOS) {
 		runtime.Show(ctx)
 	}
-	runtime.WindowShow(ctx)
-	runtime.WindowUnminimise(ctx)
-	if backgroundRestoreShouldMaximise(goruntime.GOOS, wasMaximised) {
+	plan := backgroundRestorePlanFor(goruntime.GOOS, wasMaximised)
+	if plan.maximiseBeforeShow {
 		runtime.WindowMaximise(ctx)
+	}
+	runtime.WindowShow(ctx)
+	if plan.unminimiseAfterShow {
+		runtime.WindowUnminimise(ctx)
 	}
 }
 
 func backgroundCloseUsesApplicationHide(goos string) bool {
 	return goos == "darwin"
+}
+
+type backgroundRestorePlan struct {
+	maximiseBeforeShow  bool
+	unminimiseAfterShow bool
+}
+
+func backgroundRestorePlanFor(goos string, wasMaximised bool) backgroundRestorePlan {
+	if backgroundRestoreShouldMaximise(goos, wasMaximised) {
+		return backgroundRestorePlan{maximiseBeforeShow: true}
+	}
+	return backgroundRestorePlan{unminimiseAfterShow: true}
 }
 
 func backgroundRestoreShouldMaximise(goos string, wasMaximised bool) bool {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -69,9 +69,10 @@ type App struct {
 	activeTabID string
 	readyHook   func()
 
-	forceQuit atomic.Bool
-	trayReady bool
-	tray      *desktopTray
+	forceQuit           atomic.Bool
+	backgroundMaximised atomic.Bool
+	trayReady           bool
+	tray                *desktopTray
 
 	mediaTokens *mediaTokenStore
 }
@@ -278,6 +279,7 @@ func (a *App) beforeClose(ctx context.Context) bool {
 		cfg = config.LoadForEdit(config.UserConfigPath())
 	}
 	if cfg.DesktopCloseBehavior() == "background" {
+		a.backgroundMaximised.Store(runtime.WindowIsMaximised(ctx))
 		a.saveWindowStateSync()
 		a.snapshotAllTabs()
 		hideForBackground(ctx)
@@ -288,7 +290,7 @@ func (a *App) beforeClose(ctx context.Context) bool {
 
 func (a *App) showMainWindow() {
 	if a.ctx != nil {
-		showFromBackground(a.ctx)
+		showFromBackground(a.ctx, a.backgroundMaximised.Swap(false))
 	}
 }
 
@@ -312,16 +314,23 @@ func hideForBackground(ctx context.Context) {
 	runtime.WindowHide(ctx)
 }
 
-func showFromBackground(ctx context.Context) {
+func showFromBackground(ctx context.Context, wasMaximised bool) {
 	if backgroundCloseUsesApplicationHide(goruntime.GOOS) {
 		runtime.Show(ctx)
 	}
 	runtime.WindowShow(ctx)
 	runtime.WindowUnminimise(ctx)
+	if backgroundRestoreShouldMaximise(goruntime.GOOS, wasMaximised) {
+		runtime.WindowMaximise(ctx)
+	}
 }
 
 func backgroundCloseUsesApplicationHide(goos string) bool {
 	return goos == "darwin"
+}
+
+func backgroundRestoreShouldMaximise(goos string, wasMaximised bool) bool {
+	return wasMaximised && !backgroundCloseUsesApplicationHide(goos)
 }
 
 // restoreOrBuildTabs restores the tabs from the last session, or creates a

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -129,6 +129,24 @@ func TestBackgroundCloseHideStrategyByPlatform(t *testing.T) {
 	}
 }
 
+func TestBackgroundRestoreMaximiseStrategy(t *testing.T) {
+	tests := []struct {
+		goos      string
+		maximised bool
+		want      bool
+	}{
+		{goos: "windows", maximised: true, want: true},
+		{goos: "linux", maximised: true, want: true},
+		{goos: "darwin", maximised: true, want: false},
+		{goos: "windows", maximised: false, want: false},
+	}
+	for _, tt := range tests {
+		if got := backgroundRestoreShouldMaximise(tt.goos, tt.maximised); got != tt.want {
+			t.Fatalf("backgroundRestoreShouldMaximise(%q, %v) = %v, want %v", tt.goos, tt.maximised, got, tt.want)
+		}
+	}
+}
+
 func TestEmitReadyInvokesReadyHook(t *testing.T) {
 	app := NewApp()
 	var calls int32

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -144,6 +145,36 @@ func TestBackgroundRestoreMaximiseStrategy(t *testing.T) {
 		if got := backgroundRestoreShouldMaximise(tt.goos, tt.maximised); got != tt.want {
 			t.Fatalf("backgroundRestoreShouldMaximise(%q, %v) = %v, want %v", tt.goos, tt.maximised, got, tt.want)
 		}
+	}
+}
+
+func TestBackgroundRestorePlanAvoidsNormalWindowFlash(t *testing.T) {
+	tests := []struct {
+		name      string
+		goos      string
+		maximised bool
+		want      backgroundRestorePlan
+	}{
+		{
+			name:      "maximised Windows window",
+			goos:      "windows",
+			maximised: true,
+			want:      backgroundRestorePlan{maximiseBeforeShow: true},
+		},
+		{
+			name:      "normal Windows window",
+			goos:      "windows",
+			maximised: false,
+			want:      backgroundRestorePlan{unminimiseAfterShow: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := backgroundRestorePlanFor(tt.goos, tt.maximised)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("backgroundRestorePlanFor(%q, %v) = %v, want %v", tt.goos, tt.maximised, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -92,11 +92,7 @@ func (a *App) trayLocale() string {
 }
 
 func (a *App) showFromTray() {
-	ctx := a.ctx
-	if ctx == nil {
-		return
-	}
-	showFromBackground(ctx)
+	a.showMainWindow()
 }
 
 func (a *App) quitFromTray() {


### PR DESCRIPTION
## What

Restore a maximized desktop window to its maximized state after it is hidden to the system tray.

Fixes #3475.

## Why

The normal startup path restores `WindowState.Maximised`, but the tray restore path only called `WindowShow` and `WindowUnminimise`. On Windows, closing a maximized window to the tray and reopening it therefore restored a non-maximized window.

## How

- Record whether the window was maximized immediately before background hide.
- Consume that one-shot state when the window is reopened.
- Re-maximize after show/unminimise on Windows and Linux.
- Keep macOS application-level hide/show behavior unchanged.
- Route tray open through the existing main-window restore path.

## Testing

- `go test . -run 'TestBackground(CloseHideStrategyByPlatform|RestoreMaximiseStrategy)|TestTrayMenuLabelsFollowLocale|TestBeforeCloseAllowsSystemQuitWhenBackgroundCloseEnabled' -count=1`
- `wails build` (Windows amd64)

`go test ./...` still has three unrelated existing Windows failures: a locked TempDir cleanup, skill path state, and a test filename containing a double quote that Windows rejects.
