### PR TITLE
fix(desktop): 字体设置对加粗字符生效 (#3459)

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6949,7 +6949,6 @@ a[href] {
 }
 .settings-model-picker__option strong {
   color: var(--fg);
-  font-family: var(--mono);
   font-size: var(--font-control-small);
   font-weight: 700;
 }


### PR DESCRIPTION
## 问题

设置中选择的字体对加粗字符（bold text）无效，加粗文本仍以默认字体渲染，未跟随用户选择的字体。

## 根因

`styles.css:6953` 中 `.settings-model-picker__option strong` 强制使用了 `font-family: var(--mono)`，覆盖了用户选择的字体。

## 修复

移除 `.settings-model-picker__option strong` 中的 `font-family: var(--mono);`，让模型名称等加粗文本跟随用户选择的字体设置。

## 测试

- ✅ `npm run typecheck` 通过
- ✅ `npm run check:css` 通过

Fixes #3459