### PR TITLE
Fix official provider display for proxy endpoints / 修复代理端点误显示为官方供应商

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2949,16 +2949,46 @@ func (a *App) applyProviderEffortConfig(entry *config.ProviderEntry, effort stri
 				return err
 			}
 		}
-		canonicalName := config.CanonicalDesktopOfficialProviderName(entry.Name)
-		if canonicalName != entry.Name {
-			if _, ok := cfg.Provider(canonicalName); ok {
-				if err := cfg.SetProviderEffort(canonicalName, effort); err != nil {
-					return err
-				}
+		for _, name := range providerEffortTargetNames(cfg, entry) {
+			if err := cfg.SetProviderEffort(name, effort); err != nil {
+				return err
 			}
 		}
-		return cfg.SetProviderEffort(entry.Name, effort)
+		return nil
 	})
+}
+
+func providerEffortTargetNames(cfg *config.Config, entry *config.ProviderEntry) []string {
+	if cfg == nil || entry == nil {
+		return nil
+	}
+	out := []string{entry.Name}
+	seen := map[string]bool{entry.Name: true}
+	kind := officialProviderKindFromEntry(*entry)
+	if kind == "" {
+		return out
+	}
+	var family []string
+	switch kind {
+	case "deepseek":
+		family = []string{"deepseek", "deepseek-flash", "deepseek-pro"}
+	case "mimo-token-plan":
+		family = []string{"mimo-token-plan", "mimo-pro", "mimo-flash"}
+	case "mimo-api":
+		family = []string{"mimo-api"}
+	}
+	for _, name := range family {
+		if seen[name] {
+			continue
+		}
+		p, ok := cfg.Provider(name)
+		if !ok || officialProviderKindFromEntry(*p) != kind {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out
 }
 
 // DirEntry is one entry in the "@" file-reference menu.

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -325,6 +325,9 @@ api_key_env = "DEEPSEEK_API_KEY"
 		if p.Name != "deepseek" {
 			continue
 		}
+		if !p.BuiltIn {
+			t.Fatalf("deepseek provider should be marked built-in for official endpoint: %+v", p)
+		}
 		if !p.Added || !p.KeySet || len(p.Models) != 2 || p.Models[0] != "deepseek-v4-flash" || p.Models[1] != "deepseek-v4-pro" || p.Default != "deepseek-v4-flash" {
 			t.Fatalf("deepseek provider = %+v, want added repaired official model list", p)
 		}
@@ -334,6 +337,53 @@ api_key_env = "DEEPSEEK_API_KEY"
 		return
 	}
 	t.Fatalf("settings providers missing deepseek: %+v", got.Providers)
+}
+
+func TestSettingsTreatsReservedProviderNameWithExternalEndpointAsCustom(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserConfigPath(), []byte(`
+default_model = "deepseek/deepseek-v4-Flash"
+
+[desktop]
+provider_access = ["deepseek"]
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://opencode.ai/zen/go/v1"
+models = ["deepseek-v4-Flash", "deepseek-v4-pro", "glm-5"]
+default = "deepseek-v4-Flash"
+api_key_env = "DEEPSEEK_API_KEY"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	got := NewApp().Settings()
+	var custom *ProviderView
+	for i := range got.Providers {
+		if got.Providers[i].Name == "deepseek" {
+			custom = &got.Providers[i]
+			break
+		}
+	}
+	if custom == nil {
+		t.Fatalf("settings providers missing deepseek: %+v", got.Providers)
+	}
+	if custom.BuiltIn {
+		t.Fatalf("external deepseek endpoint should be custom, got built-in provider: %+v", *custom)
+	}
+	if !custom.Added || !custom.KeySet || custom.BaseURL != "https://opencode.ai/zen/go/v1" {
+		t.Fatalf("external deepseek provider = %+v, want added key-set custom opencode endpoint", *custom)
+	}
+	for _, p := range got.OfficialProviders {
+		if p.Name == "deepseek" && p.Added {
+			t.Fatalf("official DeepSeek template should not be marked added by external endpoint: %+v", p)
+		}
+	}
 }
 
 func TestSettingsInfersLegacyProviderAccessWhenMissing(t *testing.T) {

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1579,6 +1579,7 @@ function providerAccessGroups(providers: ProviderView[], t: ReturnType<typeof us
   const groups = new Map<string, ProviderAccessGroup>();
   for (const p of providers) {
     const id = providerGroupID(p);
+    const builtIn = id.startsWith("builtin:");
     const existing = groups.get(id);
     if (existing) {
       existing.providers.push(p);
@@ -1590,7 +1591,7 @@ function providerAccessGroups(providers: ProviderView[], t: ReturnType<typeof us
       id,
       label: providerGroupLabel(p, t),
       description: providerGroupDescription(p, t),
-      builtIn: p.builtIn,
+      builtIn,
       providers: [p],
       apiKeyEnv: p.apiKeyEnv,
       keySet: p.keySet,
@@ -1602,13 +1603,45 @@ function providerAccessGroups(providers: ProviderView[], t: ReturnType<typeof us
   return Array.from(groups.values());
 }
 
+function providerBaseHost(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function canonicalOfficialProviderName(name: string): string {
+  switch (name.trim()) {
+    case "deepseek-flash":
+    case "deepseek-pro":
+      return "deepseek";
+    case "mimo":
+    case "xiaomi-mimo":
+    case "xiaomi_mimo":
+      return "mimo-api";
+    case "mimo-pro":
+    case "mimo-flash":
+      return "mimo-token-plan";
+    default:
+      return name.trim();
+  }
+}
+
+function officialProviderKind(p: ProviderView): string {
+  if (!p.builtIn) return "";
+  const name = canonicalOfficialProviderName(p.name);
+  const host = providerBaseHost(p.baseUrl);
+  if (name === "deepseek" && host === "api.deepseek.com") return "deepseek";
+  if (name === "mimo-token-plan" && host === "token-plan-cn.xiaomimimo.com") return "mimo-token-plan";
+  if (name === "mimo-api" && host === "api.xiaomimimo.com") return "mimo-api";
+  return "";
+}
+
 function providerGroupID(p: ProviderView): string {
-  if (!p.builtIn) return `custom:${p.name}`;
-  const base = p.baseUrl.toLowerCase();
-  if (p.apiKeyEnv === "DEEPSEEK_API_KEY" || base.includes("deepseek")) return "builtin:deepseek";
-  if (base.includes("token-plan-cn.xiaomimimo.com")) return "builtin:mimo-token-plan";
-  if (base.includes("api.xiaomimimo.com") || base.includes("mimo") || base.includes("xiaomimimo")) return "builtin:mimo-api";
-  return `builtin:${p.name}`;
+  const official = officialProviderKind(p);
+  if (official) return `builtin:${official}`;
+  return `custom:${p.name}`;
 }
 
 function providerGroupLabel(p: ProviderView, t?: ReturnType<typeof useT>): string {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,15 +134,35 @@ func desktopModelRefsProvider(c *config.Config, ref, name string) bool {
 	return false
 }
 
-func builtInProviderNames() map[string]bool {
-	out := map[string]bool{}
-	for _, p := range config.Default().Providers {
-		out[p.Name] = true
+func officialProviderHost(baseURL string) string {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return ""
 	}
-	for _, name := range []string{"deepseek", "deepseek-flash", "mimo-api", "mimo-token-plan", "mimo-pro"} {
-		out[name] = true
+	return strings.ToLower(u.Hostname())
+}
+
+func officialProviderKindFromEntry(p config.ProviderEntry) string {
+	host := officialProviderHost(p.BaseURL)
+	switch config.CanonicalDesktopOfficialProviderName(p.Name) {
+	case "deepseek":
+		if host == "api.deepseek.com" {
+			return "deepseek"
+		}
+	case "mimo-api":
+		if host == "api.xiaomimimo.com" {
+			return "mimo-api"
+		}
+	case "mimo-token-plan":
+		if host == "token-plan-cn.xiaomimimo.com" {
+			return "mimo-token-plan"
+		}
 	}
-	return out
+	return ""
+}
+
+func isOfficialBuiltInProvider(p config.ProviderEntry) bool {
+	return officialProviderKindFromEntry(p) != ""
 }
 
 func providerAccessSet(names []string) map[string]bool {
@@ -204,6 +225,24 @@ func officialProviderViews(added map[string]bool) []ProviderView {
 		}
 		for _, entry := range entries {
 			out = append(out, providerViewFromEntry(entry, true, added[entry.Name]))
+		}
+	}
+	return out
+}
+
+func officialProviderAddedSet(cfg *config.Config) map[string]bool {
+	out := map[string]bool{}
+	if cfg == nil {
+		return out
+	}
+	access := providerAccessSet(cfg.Desktop.ProviderAccess)
+	for i := range cfg.Providers {
+		p := cfg.Providers[i]
+		if !access[p.Name] {
+			continue
+		}
+		if kind := officialProviderKindFromEntry(p); kind != "" {
+			out[kind] = true
 		}
 	}
 	return out
@@ -275,12 +314,11 @@ func (a *App) Settings() SettingsView {
 		ProviderKinds:     nonNil(provider.Kinds()),
 		Bypass:            ctrl != nil && ctrl.Bypass(),
 	}
-	builtIns := builtInProviderNames()
 	added := providerAccessSet(cfg.Desktop.ProviderAccess)
-	v.OfficialProviders = officialProviderViews(added)
+	v.OfficialProviders = officialProviderViews(officialProviderAddedSet(cfg))
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
-		v.Providers = append(v.Providers, providerViewFromEntry(*p, builtIns[p.Name], added[p.Name]))
+		v.Providers = append(v.Providers, providerViewFromEntry(*p, isOfficialBuiltInProvider(*p), added[p.Name]))
 	}
 	return v
 }
@@ -742,7 +780,11 @@ func (a *App) RemoveProviderAccess(name string) error {
 	if name == "" {
 		return fmt.Errorf("remove provider access: empty provider name")
 	}
-	if builtInProviderNames()[name] {
+	cfg, _, err := a.loadDesktopUserConfigForEdit()
+	if err != nil {
+		return err
+	}
+	if p, ok := cfg.Provider(name); ok && isOfficialBuiltInProvider(*p) {
 		return a.removeBuiltInProviderAccessAndRetargetTabs(name)
 	}
 	return a.deleteProviderAndRetargetTabs(name)

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -92,7 +92,7 @@ func (c *Config) UpsertProvider(e ProviderEntry) error {
 func (c *Config) SetProviderEffort(name, effort string) error {
 	for i := range c.Providers {
 		if c.Providers[i].Name == name {
-			c.Providers[i].Effort = strings.ToLower(strings.TrimSpace(effort))
+			c.Providers[i].Effort = normalizeStoredEffort(effort)
 			return nil
 		}
 	}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -275,18 +275,21 @@ func TestNormalizeEffortDeepSeek(t *testing.T) {
 	}
 }
 
-func TestNormalizeLegacyEffortMigratesOff(t *testing.T) {
+func TestNormalizeLegacyEffortMigratesProviderDefaults(t *testing.T) {
 	c := &Config{Providers: []ProviderEntry{
 		{Name: "deepseek", Effort: "off"},
 		{Name: "deepseek-upper", Effort: "OFF"},
+		{Name: "deepseek-auto", Effort: "auto"},
+		{Name: "deepseek-auto-upper", Effort: "AUTO"},
 		{Name: "keep", Effort: "high"},
 	}}
 	normalizeLegacyEffort(c)
-	if c.Providers[0].Effort != "" || c.Providers[1].Effort != "" {
-		t.Fatalf("legacy off should migrate to empty, got %q/%q", c.Providers[0].Effort, c.Providers[1].Effort)
+	normalizeEffortConfig(c)
+	if c.Providers[0].Effort != "" || c.Providers[1].Effort != "" || c.Providers[2].Effort != "" || c.Providers[3].Effort != "" {
+		t.Fatalf("provider default efforts should migrate to empty, got %q/%q/%q/%q", c.Providers[0].Effort, c.Providers[1].Effort, c.Providers[2].Effort, c.Providers[3].Effort)
 	}
-	if c.Providers[2].Effort != "high" {
-		t.Fatalf("non-legacy effort changed: %q", c.Providers[2].Effort)
+	if c.Providers[4].Effort != "high" {
+		t.Fatalf("non-legacy effort changed: %q", c.Providers[4].Effort)
 	}
 }
 
@@ -874,6 +877,10 @@ func TestNormalizeEffortCustomDefaultEffort(t *testing.T) {
 	// /effort auto still maps to "" regardless of DefaultEffort.
 	if got, err := NormalizeEffort(e, "auto"); err != nil || got != "" {
 		t.Fatalf("NormalizeEffort(auto) = %q/%v, want empty/nil", got, err)
+	}
+	e.Effort = "auto"
+	if got := EffectiveEffort(e); got != "low" {
+		t.Fatalf("stored auto should fall through to default_effort, got %q", got)
 	}
 	e.Effort = "high"
 	if got := EffectiveEffort(e); got != "high" {

--- a/internal/config/effort.go
+++ b/internal/config/effort.go
@@ -143,7 +143,7 @@ func EffectiveEffort(e *ProviderEntry) string {
 	if e == nil {
 		return ""
 	}
-	if effort := normalizeEffortLevel(e.Effort); effort != "" {
+	if effort := normalizeStoredEffort(e.Effort); effort != "" {
 		return effort
 	}
 	supported := normalizedSupportedEfforts(e)
@@ -170,13 +170,18 @@ func normalizeProviderEffortFields(e *ProviderEntry) {
 	if e == nil {
 		return
 	}
-	e.Effort = normalizeEffortLevel(e.Effort)
-	if e.Effort == "off" {
-		e.Effort = ""
-	}
+	e.Effort = normalizeStoredEffort(e.Effort)
 	e.ReasoningProtocol = normalizeReasoningProtocol(e.ReasoningProtocol)
 	e.DefaultEffort = normalizeEffortLevel(e.DefaultEffort)
 	e.SupportedEfforts = normalizedSupportedEfforts(e)
+}
+
+func normalizeStoredEffort(raw string) string {
+	level := normalizeEffortLevel(raw)
+	if level == "auto" || level == "off" {
+		return ""
+	}
+	return level
 }
 
 // ReasoningProtocolForEntry resolves the provider request shape for reasoning

--- a/internal/provider/openai/effort_test.go
+++ b/internal/provider/openai/effort_test.go
@@ -32,9 +32,11 @@ func TestEffortNormalization(t *testing.T) {
 		{mimo, "medium", "medium"},
 		{mimo, "low", "low"},
 		{mimo, "MAX", "high"}, // case-insensitive
+		{mimo, "auto", ""},    // UI/config auto means omit provider-specific effort
 		{mimo, "", ""},        // unset stays omitted
 		{deepseek, "max", "max"},
 		{deepseek, "high", "high"},
+		{deepseek, "auto", "high"},
 		{deepseek, "", "high"}, // DeepSeek default depth
 	}
 	for _, tc := range tests {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -38,6 +38,10 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
 	effort, _ := cfg.Extra["effort"].(string)
+	effort = strings.ToLower(strings.TrimSpace(effort))
+	if effort == "auto" {
+		effort = ""
+	}
 	protocol, _ := cfg.Extra["reasoning_protocol"].(string)
 	protocol = normalizeReasoningProtocol(protocol)
 	deepseek := protocol == "deepseek" || (protocol == "" && isDeepSeekBaseURL(cfg.BaseURL))
@@ -45,7 +49,6 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	case protocol == "none":
 		effort = ""
 	case deepseek:
-		effort = strings.ToLower(strings.TrimSpace(effort))
 		switch effort {
 		case "", "off": // "off" is a retired level (disabled thinking); fall back to the default depth
 			effort = "high"
@@ -57,7 +60,6 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		// Non-DeepSeek backends use OpenAI's reasoning_effort scale (low/medium/
 		// high); "max" is a DeepSeek-ism MiMo et al. reject with 400, so clamp it
 		// to the OpenAI ceiling and reject other values at boot, not at request time.
-		effort = strings.ToLower(strings.TrimSpace(effort))
 		switch effort {
 		case "max":
 			effort = "high"


### PR DESCRIPTION
## Summary
- require built-in provider cards to match the official endpoint host before labeling them as official access
- keep proxy endpoints named `deepseek` or `mimo-*` visible as custom provider access instead of official presets
- treat stored `effort = "auto"` as provider default and harden OpenAI-compatible provider startup against stale auto effort values

Fixes #3561

## Testing
- `go test ./internal/config ./internal/provider/openai`
- `(cd desktop && go test ./...)`
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend build`