### PR TITLE
fix(openai): harden request building for strict OpenAI-compatible backends

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -214,7 +214,6 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		// still keeps it (for display/archive); we just don't pay to re-upload it.
 		cm := chatMessage{
 			Role:       string(m.Role),
-			Content:    m.Content,
 			ToolCallID: m.ToolCallID,
 			Name:       m.Name,
 		}
@@ -223,6 +222,10 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 			wire.Function.Name = tc.Name
 			wire.Function.Arguments = tc.Arguments
 			cm.ToolCalls = append(cm.ToolCalls, wire)
+		}
+		if m.Role != provider.RoleAssistant || len(cm.ToolCalls) == 0 || m.Content != "" {
+			content := m.Content
+			cm.Content = &content
 		}
 		msgs[i] = cm
 	}
@@ -433,13 +436,12 @@ type streamOptions struct {
 
 type chatMessage struct {
 	Role string `json:"role"`
-	// content is always serialized, even when empty: an assistant turn that is
-	// pure tool_calls (no preamble text) has empty content, and DeepSeek's
-	// strict deserializer rejects a message missing the field ("missing field
-	// `content`"). An empty string satisfies presence and is accepted by every
-	// OpenAI-compatible backend for all roles (unlike null, which some reject
-	// for a tool message).
-	Content    string         `json:"content"`
+	// content is always present (never omitted): DeepSeek's strict deserializer
+	// rejects a message missing the field. A pure tool_calls assistant turn
+	// serializes as null (OpenAI-spec, and what strict clones expect); every
+	// other role/message serializes as a string, empty included — null is
+	// rejected by some backends for a tool message.
+	Content    *string        `json:"content"`
 	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
 	ToolCallID string         `json:"tool_call_id,omitempty"`
 	Name       string         `json:"name,omitempty"`

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -126,9 +126,10 @@ func TestStreamAuthError(t *testing.T) {
 }
 
 // TestBuildRequestAlwaysSerializesContent guards the DeepSeek 400 regression:
-// an assistant turn that is pure tool_calls (no preamble text) has empty
-// content, and DeepSeek rejects a message missing the `content` field. Every
-// message — including that one — must serialize a content field.
+// DeepSeek rejects a message missing the `content` field, so every message must
+// serialize one. A pure tool_calls assistant turn carries null (OpenAI-spec,
+// and accepted by DeepSeek — verified against a live multi-tool session); other
+// roles serialize a string. The field must never be absent.
 func TestBuildRequestAlwaysSerializesContent(t *testing.T) {
 	c := &client{model: "deepseek-v4"}
 	req := c.buildRequest(provider.Request{
@@ -156,9 +157,9 @@ func TestBuildRequestAlwaysSerializesContent(t *testing.T) {
 			t.Errorf("messages[%d] is missing the content field: %s", i, b)
 		}
 	}
-	// The tool-call-only assistant message must carry content:"" and its tool_calls.
-	if got := string(raw[1]["content"]); got != `""` {
-		t.Errorf("assistant content = %s, want \"\"", got)
+	// The tool-call-only assistant message must carry content:null and its tool_calls.
+	if got := string(raw[1]["content"]); got != `null` {
+		t.Errorf("assistant content = %s, want null", got)
 	}
 	if _, ok := raw[1]["tool_calls"]; !ok {
 		t.Errorf("assistant message lost its tool_calls: %s", b)
@@ -424,8 +425,8 @@ func TestBuildRequestPreservesEmptyIDToolResults(t *testing.T) {
 	})
 	var toolContents []string
 	for _, m := range req.Messages {
-		if m.Role == string(provider.RoleTool) {
-			toolContents = append(toolContents, m.Content)
+		if m.Role == string(provider.RoleTool) && m.Content != nil {
+			toolContents = append(toolContents, *m.Content)
 		}
 	}
 	if len(toolContents) != 2 {
@@ -471,5 +472,37 @@ func TestStreamSynthesizesMissingToolCallIDs(t *testing.T) {
 	}
 	if ids[0] == ids[1] {
 		t.Errorf("synthesized ids must be distinct, got %v", ids)
+	}
+}
+
+func TestBuildRequestContentNullForAssistantToolCalls(t *testing.T) {
+	c := &client{name: "x", model: "m", baseURL: "https://api.example.com/v1"}
+	req := provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleAssistant, Content: "", ToolCalls: []provider.ToolCall{{ID: "c1", Name: "ls", Arguments: `{}`}}},
+			{Role: provider.RoleTool, Content: "", ToolCallID: "c1", Name: "ls"},
+			{Role: provider.RoleAssistant, Content: "all done"},
+		},
+		Tools: []provider.ToolSchema{{Name: "noargs", Parameters: provider.CanonicalizeSchema(nil)}},
+	}
+	body, err := json.Marshal(c.buildRequest(req))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !json.Valid(body) {
+		t.Fatalf("invalid JSON body: %s", body)
+	}
+	s := string(body)
+	if !strings.Contains(s, `"tool_calls"`) || !strings.Contains(s, `"content":null`) {
+		t.Errorf("assistant tool_calls turn should carry null content: %s", s)
+	}
+	if !strings.Contains(s, `{"role":"tool","content":""`) {
+		t.Errorf("tool message should keep empty-string content, not null: %s", s)
+	}
+	if !strings.Contains(s, `"content":"all done"`) {
+		t.Errorf("text assistant turn should keep its string content: %s", s)
+	}
+	if !strings.Contains(s, `"parameters":{"type":"object"}`) {
+		t.Errorf("no-param tool should serialize a valid empty-object schema: %s", s)
 	}
 }

--- a/internal/provider/schema_canonicalize.go
+++ b/internal/provider/schema_canonicalize.go
@@ -9,7 +9,11 @@ import (
 // schema always produces the same byte representation.
 func CanonicalizeSchema(raw json.RawMessage) json.RawMessage {
 	if len(raw) == 0 {
-		return raw
+		// A tool with no parameters (common for MCP tools) yields an empty
+		// schema. An empty json.RawMessage makes json.Marshal of the enclosing
+		// request fail ("unexpected end of JSON input") and bricks the whole
+		// provider; emit a valid empty-object schema instead.
+		return json.RawMessage(`{"type":"object"}`)
 	}
 	var v any
 	if err := json.Unmarshal(raw, &v); err != nil {


### PR DESCRIPTION
## Summary

Two robustness/compat fixes for OpenAI-compatible providers, surfaced while investigating #3526 (switching to a strict OpenAI-compatible backend mid-session → `HTTP 400 "Expecting ',' delimiter"`).

### 1. `fix(provider)`: valid schema for no-param tools
A tool with no parameters (common for MCP tools) produces an empty schema. An empty `json.RawMessage` makes `json.Marshal` of the **whole** chat request fail with `unexpected end of JSON input` — so a single no-arg tool bricks the entire provider for every request, with a cryptic error. `CanonicalizeSchema` now maps empty → `{"type":"object"}`.

### 2. `fix(openai)`: null content for pure tool-call assistant turns
A pure-`tool_calls` assistant turn previously serialized `"content":""`. Strict OpenAI-compatible backends can reject that. `null` is the OpenAI-spec form for a tool-call turn; we now emit `null` for that one case and keep the string form (empty included) for every other role/message.

## On #3526 specifically

I verified our request serialization is **not** the cause: a mid-session request (assistant `tool_calls` + `tool` results) marshals to **valid JSON** (`json.Valid == true`), and Go's `json.Marshal` either produces valid JSON or errors — it never emits malformed JSON. So the `Expecting ',' delimiter` 400 is the Agnes/Sapiens server rejecting valid JSON.

Change #2 is a **spec-aligned compatibility attempt** for that server (the `content:""` → `null` shape is the most likely thing a strict clone trips on). It is **verified non-regressive on DeepSeek** (a live multi-tool session, whose history carries the tool-call turns as `content:null`, completed with no 400). I could not test it against Agnes/Sapiens directly — @reporter, please try a build with this change and confirm.

## Testing
- `go test ./internal/provider/...` green
- Live DeepSeek multi-tool run completes (3 tool rounds, history serialized with `content:null`, no 400)

Refs #3526
