### PR TITLE
feat(desktop): add keyboard shortcuts for text size

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -10,9 +10,9 @@
     "check:css": "node scripts/check-css-syntax.mjs src/styles.css && node scripts/check-z-index-tokens.mjs src/styles.css",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/__tests__/math-golden.test.ts",
+    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts",
     "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
-    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts"
+    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts"
   },
   "dependencies": {
     "highlight.js": "^11.10.0",

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -56,6 +56,7 @@ import {
   themeForStyle,
   type Theme,
 } from "./lib/theme";
+import { applyTextSize, DEFAULT_TEXT_SIZE, getTextSize, nextTextSize } from "./lib/textSize";
 import { useWindowStatePersistence } from "./lib/windowState";
 
 const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
@@ -335,6 +336,26 @@ function ShellHotkeys() {
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [shellExpand]);
+  return null;
+}
+
+/** Global hotkey handler for text-size shortcuts (Ctrl/Cmd + Plus/Minus/0). */
+function TextSizeHotkeys() {
+  useEffect(() => {
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (!(e.ctrlKey || e.metaKey)) return;
+      if (e.key !== "+" && e.key !== "=" && e.key !== "-" && e.key !== "0") return;
+
+      e.preventDefault();
+      if (e.key === "0") {
+        applyTextSize(DEFAULT_TEXT_SIZE);
+        return;
+      }
+      applyTextSize(nextTextSize(getTextSize(), e.key === "-" ? -1 : 1));
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
   return null;
 }
 
@@ -1340,6 +1361,7 @@ export default function App() {
   return (
     <ShellExpandProvider>
     <ShellHotkeys />
+    <TextSizeHotkeys />
     <div className={`app app--${desktopPlatform}`}>
       <div
         ref={layoutRef}

--- a/desktop/frontend/src/__tests__/text-size.test.ts
+++ b/desktop/frontend/src/__tests__/text-size.test.ts
@@ -1,0 +1,29 @@
+// Run: tsx src/__tests__/text-size.test.ts
+
+import { DEFAULT_TEXT_SIZE, nextTextSize } from "../lib/textSize";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\ntext size shortcuts");
+eq(nextTextSize("small", 1), DEFAULT_TEXT_SIZE, "increase from small");
+eq(nextTextSize("default", 1), "large", "increase from default");
+eq(nextTextSize("large", 1), "xlarge", "increase from large");
+eq(nextTextSize("xlarge", 1), "xlarge", "increase clamps at largest");
+eq(nextTextSize("xlarge", -1), "large", "decrease from xlarge");
+eq(nextTextSize("large", -1), DEFAULT_TEXT_SIZE, "decrease from large");
+eq(nextTextSize("default", -1), "small", "decrease from default");
+eq(nextTextSize("small", -1), "small", "decrease clamps at smallest");
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/textSize.ts
+++ b/desktop/frontend/src/lib/textSize.ts
@@ -10,6 +10,12 @@ export function isTextSize(value: unknown): value is TextSize {
   return typeof value === "string" && (TEXT_SIZES as readonly string[]).includes(value);
 }
 
+export function nextTextSize(current: TextSize, delta: -1 | 1): TextSize {
+  const index = TEXT_SIZES.indexOf(current);
+  const nextIndex = Math.min(TEXT_SIZES.length - 1, Math.max(0, index + delta));
+  return TEXT_SIZES[nextIndex];
+}
+
 export function getTextSize(): TextSize {
   const stored = typeof localStorage !== "undefined" ? localStorage.getItem(TEXT_SIZE_KEY) : null;
   return isTextSize(stored) ? stored : DEFAULT_TEXT_SIZE;


### PR DESCRIPTION
## What
Add desktop keyboard shortcuts for changing text size:
- Ctrl/Cmd + Plus: increase text size
- Ctrl/Cmd + Minus: decrease text size
- Ctrl/Cmd + 0: reset text size

## Why
Fixes #3562. The desktop app already has text-size presets in Settings -> Appearance, but users did not have a quick keyboard shortcut to adjust them.

## Testing
- `npm.cmd run test:all`
- `npx.cmd tsc --noEmit -p tsconfig.test.json`

Note: full frontend `typecheck` requires generated Wails bindings (`desktop/frontend/wailsjs`). On this machine, `go` and `wails` are not installed, so I could not run the CI-equivalent `wails generate module` step locally.