### PR TITLE
feat(web_fetch): proxy support with SSRF-safe HTTP CONNECT / SOCKS5 tunnelling

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -204,7 +204,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	searchSpec := builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, stderr)
 	bashTimeout := time.Duration(cfg.BashTimeoutSeconds()) * time.Second
-	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRootsForRoot(root), bashSpec, bashTimeout, searchSpec, stderr, root)
+	proxyURL := netclient.ResolveProxyURL(proxySpec)
+	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRootsForRoot(root), bashSpec, bashTimeout, searchSpec, stderr, root, proxyURL)
 	// Always construct a host, even with no plugins configured, so the controller's
 	// host pointer is stable for the session and `/mcp add` can hot-add into it.
 	pluginHost := plugin.NewHost()
@@ -861,12 +862,12 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 // instance bound to writeRoots (preserving registry order).
 // When workDir is non-empty, tools resolve relative paths against it instead of
 // the process cwd, enabling concurrent multi-project sessions.
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string) {
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxyURL string) {
 	// If a workspace directory is set, use workspace-bound tools that resolve
 	// paths relative to that directory. Otherwise fall back to the process-cwd
 	// compile-time builtins.
 	if workDir != "" {
-		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec}
+		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxyURL: proxyURL}
 		for _, t := range ws.Tools(enabled...) {
 			reg.Add(t)
 		}
@@ -888,8 +889,8 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 	}
 	// Replace the unconfined defaults with confined instances (registry order is
 	// preserved on replace): file-writers bound to the workspace, bash to the OS
-	// sandbox. Only replace tools actually enabled/present.
-	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec, bashTimeout), builtin.ConfineSearch(searchSpec))
+	// sandbox, web_fetch to the proxy. Only replace tools actually enabled/present.
+	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec, bashTimeout), builtin.ConfineSearch(searchSpec), builtin.ConfineWebFetch(proxyURL))
 	for _, t := range confined {
 		if _, ok := reg.Get(t.Name()); ok {
 			reg.Add(t)

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -216,7 +216,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 	reg := tool.NewRegistry()
 	var stderr bytes.Buffer
-	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t))
+	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), "")
 	for _, name := range []string{
 		"todo_write",
 		"complete_step",

--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -253,6 +253,38 @@ func validateProxyURL(u *url.URL) error {
 	return nil
 }
 
+// ResolveProxyURL resolves the ProxySpec into a usable proxy URL string
+// (e.g. "http://127.0.0.1:7897"). Returns "" when the mode is off or when
+// auto/env mode has no environment proxy configured. Exported so web_fetch
+// can apply the same proxy settings as the rest of Reasonix.
+func ResolveProxyURL(spec ProxySpec) string {
+	switch NormalizeMode(spec.Mode) {
+	case ModeOff:
+		return ""
+	case ModeCustom:
+		u, err := customProxyURL(spec)
+		if err != nil {
+			return ""
+		}
+		return u.String()
+	case ModeEnv:
+		cfg := httpproxy.FromEnvironment()
+		if cfg.HTTPSProxy != "" {
+			return cfg.HTTPSProxy
+		}
+		return cfg.HTTPProxy
+	default: // auto
+		cfg := httpproxy.FromEnvironment()
+		if cfg.HTTPSProxy != "" {
+			return cfg.HTTPSProxy
+		}
+		if cfg.HTTPProxy != "" {
+			return cfg.HTTPProxy
+		}
+		return ""
+	}
+}
+
 func redactURL(u *url.URL) string {
 	cp := *u
 	if cp.User != nil {

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -21,6 +21,13 @@ func ConfineBash(spec sandbox.Spec, timeout ...time.Duration) tool.Tool {
 	return b
 }
 
+// ConfineWebFetch returns the web_fetch built-in bound to a proxy URL,
+// overriding the unconfined instance registered at init. An empty proxyURL
+// yields the unconfined behavior (direct connection with SSRF guard).
+func ConfineWebFetch(proxyURL string) tool.Tool {
+	return webFetch{proxyURL: proxyURL}
+}
+
 // ConfineWriters returns the file-writing built-ins (write_file, edit_file,
 // multi_edit, notebook_edit) bound to roots — the only directories they may
 // modify. The composition root adds these to the per-run registry to override

--- a/internal/tool/builtin/web_fetch_proxy_test.go
+++ b/internal/tool/builtin/web_fetch_proxy_test.go
@@ -157,3 +157,32 @@ func TestWebFetchSOCKS5Proxy(t *testing.T) {
 		t.Logf("expected error (no SOCKS5 server): %v", err)
 	}
 }
+
+func TestSSRFBlocksPrivateTargetThroughSOCKS5(t *testing.T) {
+	wf := webFetch{proxyURL: "socks5://127.0.0.1:1080"}
+	for _, u := range []string{"http://169.254.169.254/latest/meta-data", "http://10.0.0.1/", "http://192.168.1.1/"} {
+		t.Run(u, func(t *testing.T) {
+			args, _ := json.Marshal(map[string]string{"url": u})
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			_, err := wf.Execute(ctx, args)
+			if err == nil || !strings.Contains(err.Error(), "refusing to fetch internal address") {
+				t.Errorf("want SSRF block for %s, got %v", u, err)
+			}
+		})
+	}
+}
+
+func TestSOCKS5ProxyOnPrivateAddressNotSSRFBlocked(t *testing.T) {
+	// A SOCKS proxy commonly lives on a private/LAN address; the SSRF guard must
+	// not reject the proxy itself. Reaching the (absent) proxy fails, but never
+	// with an SSRF "internal address" error.
+	wf := webFetch{proxyURL: "socks5://10.0.0.1:1080"}
+	args, _ := json.Marshal(map[string]string{"url": "https://example.com"})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, err := wf.Execute(ctx, args)
+	if err != nil && strings.Contains(err.Error(), "refusing to fetch internal address") {
+		t.Fatalf("proxy on private address was SSRF-blocked: %v", err)
+	}
+}

--- a/internal/tool/builtin/web_fetch_proxy_test.go
+++ b/internal/tool/builtin/web_fetch_proxy_test.go
@@ -1,0 +1,159 @@
+package builtin
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func startCONNECTProxy(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				req, err := http.ReadRequest(br)
+				if err != nil {
+					return
+				}
+				if req.Method != http.MethodConnect {
+					return
+				}
+				targetConn, err := net.DialTimeout("tcp", req.Host, 5*time.Second)
+				if err != nil {
+					c.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))
+					return
+				}
+				defer targetConn.Close()
+				c.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+				go func() { io.Copy(targetConn, c) }()
+				io.Copy(c, targetConn)
+			}(conn)
+		}
+	}()
+	return fmt.Sprintf("http://%s", listener.Addr().String())
+}
+
+func startTestHTTPServer(t *testing.T, body string) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := fmt.Sprintf("http://%s/", listener.Addr().String())
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(body))
+	})
+	server := &http.Server{Handler: mux}
+	t.Cleanup(func() { server.Close() })
+	go server.Serve(listener)
+	return u
+}
+
+func TestWebFetchThroughCONNECTProxy(t *testing.T) {
+	targetURL := startTestHTTPServer(t, "hello from target")
+	proxyURL := startCONNECTProxy(t)
+	t.Logf("proxy: %s  target: %s", proxyURL, targetURL)
+
+	wf := webFetch{proxyURL: proxyURL}
+	args, _ := json.Marshal(map[string]string{"url": targetURL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := wf.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("webFetch.Execute through proxy: %v", err)
+	}
+	if !strings.Contains(result, "hello from target") {
+		t.Errorf("expected 'hello from target', got: %s", result)
+	}
+}
+
+func TestWebFetchWithoutProxy(t *testing.T) {
+	targetURL := startTestHTTPServer(t, "direct fetch OK")
+	wf := webFetch{proxyURL: ""}
+	args, _ := json.Marshal(map[string]string{"url": targetURL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := wf.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("webFetch without proxy: %v", err)
+	}
+	if !strings.Contains(result, "direct fetch OK") {
+		t.Errorf("expected 'direct fetch OK', got: %s", result)
+	}
+}
+
+func TestSSRFStillBlocksPrivateThroughProxy(t *testing.T) {
+	proxyURL := startCONNECTProxy(t)
+	wf := webFetch{proxyURL: proxyURL}
+
+	blocked := []string{
+		"http://169.254.169.254/latest/meta-data",
+		"http://10.0.0.1/",
+		"http://192.168.1.1/",
+	}
+	for _, u := range blocked {
+		t.Run(u, func(t *testing.T) {
+			args, _ := json.Marshal(map[string]string{"url": u})
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err := wf.Execute(ctx, args)
+			if err == nil {
+				t.Error("expected SSRF error, got nil")
+			} else {
+				t.Logf("blocked: %v", err)
+			}
+		})
+	}
+}
+
+func TestProxyBasicAuthURLParsing(t *testing.T) {
+	u, _ := url.Parse("http://user:pass@127.0.0.1:7897")
+	if u.User == nil {
+		t.Fatal("expected user info")
+	}
+	if u.User.Username() != "user" {
+		t.Errorf("username = %q", u.User.Username())
+	}
+	pass, _ := u.User.Password()
+	if pass != "pass" {
+		t.Errorf("password = %q", pass)
+	}
+}
+
+func TestWebFetchSOCKS5Proxy(t *testing.T) {
+	wf := webFetch{proxyURL: "socks5://127.0.0.1:1"}
+	args, _ := json.Marshal(map[string]string{"url": "https://example.com"})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, err := wf.Execute(ctx, args)
+	if err == nil {
+		t.Log("unexpected success (no SOCKS5 running)")
+	} else {
+		t.Logf("expected error (no SOCKS5 server): %v", err)
+	}
+}

--- a/internal/tool/builtin/webfetch.go
+++ b/internal/tool/builtin/webfetch.go
@@ -1,7 +1,9 @@
 package builtin
 
 import (
+	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,7 +19,11 @@ import (
 
 func init() { tool.RegisterBuiltin(webFetch{}) }
 
-type webFetch struct{}
+type webFetch struct {
+	// proxyURL is resolved from config [network] settings. When non-empty,
+	// outbound requests tunnel through this proxy while preserving SSRF guard.
+	proxyURL string
+}
 
 const (
 	webFetchTimeout = 15 * time.Second
@@ -48,30 +54,106 @@ func (webFetch) ReadOnly() bool { return true }
 // Loopback is allowed: the agent can already reach localhost via bash, so a local
 // dev server stays fetchable. The check runs at dial time on the resolved IP, so a
 // public host that redirects or DNS-rebinds to an internal address is caught too.
-func ssrfGuardedClient() *http.Client {
+func ssrfGuardedClient(proxyURL string) *http.Client {
 	dialer := &net.Dialer{Timeout: webFetchTimeout}
-	return &http.Client{
-		Timeout: webFetchTimeout,
-		Transport: &http.Transport{
-			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				host, port, err := net.SplitHostPort(addr)
-				if err != nil {
-					return nil, err
-				}
-				ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-				if err != nil {
-					return nil, err
-				}
-				for _, ip := range ips {
-					if blockedFetchIP(ip.IP) {
-						return nil, fmt.Errorf("refusing to fetch internal address %s (resolves to %s)", host, ip.IP)
+
+	// directDialContext handles SSRF-protected direct connection (no proxy).
+	// It resolves DNS locally, checks resolved IPs against the SSRF blocklist,
+	// then dials the vetted IP directly to prevent DNS rebinding.
+	directDialContext := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		ips, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+		for _, ip := range ips {
+			if blockedFetchIP(ip.IP) {
+				return nil, fmt.Errorf("refusing to fetch internal address %s (resolves to %s)", host, ip.IP)
+			}
+		}
+		return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
+	}
+
+	tr := &http.Transport{
+		DialContext: directDialContext,
+	}
+
+	if proxyURL != "" {
+		pu, err := url.Parse(proxyURL)
+		if err == nil && pu.Host != "" {
+			switch pu.Scheme {
+			case "http", "https":
+				// HTTP CONNECT: dial proxy → send CONNECT with the ORIGINAL
+				// hostname (not a locally-resolved IP) so the proxy handles DNS.
+				// This is essential for users whose local DNS is blocked (GFW).
+				// SSRF protection: IP literals are checked directly; domain names
+				// go through the trusted proxy which resolves them.
+				proxyDialer := dialer
+				tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+					host, port, err := net.SplitHostPort(addr)
+					if err != nil {
+						return nil, err
 					}
+					// SSRF check on IP literals only — domain names go through
+					// the trusted proxy which resolves them on the remote side.
+					if ip := net.ParseIP(host); ip != nil {
+						if blockedFetchIP(ip) {
+							return nil, fmt.Errorf("refusing to fetch internal address %s (resolves to %s)", host, ip)
+						}
+					}
+					// Dial the proxy (proxy address is never an SSRF target — the
+					// user configured it, and it's almost certainly an IP or a
+					// resolvable hostname reachable from the local network).
+					proxyConn, err := proxyDialer.DialContext(ctx, "tcp", pu.Host)
+					if err != nil {
+						return nil, fmt.Errorf("connect to proxy %s: %w", pu.Host, err)
+					}
+					// CONNECT the ORIGINAL hostname through the proxy, letting
+					// the proxy resolve DNS on the remote side. If this is an IP
+					// literal we already vetted it above.
+					targetAddr := net.JoinHostPort(host, port)
+					connectReq := &http.Request{
+						Method: http.MethodConnect,
+						URL:    &url.URL{Host: targetAddr},
+						Host:   targetAddr,
+						Header: make(http.Header),
+					}
+					if pu.User != nil {
+						user := pu.User.Username()
+						pass, _ := pu.User.Password()
+						auth := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+						connectReq.Header.Set("Proxy-Authorization", "Basic "+auth)
+					}
+					if err := connectReq.Write(proxyConn); err != nil {
+						proxyConn.Close()
+						return nil, fmt.Errorf("write CONNECT to proxy: %w", err)
+					}
+					br := bufio.NewReader(proxyConn)
+					resp, err := http.ReadResponse(br, connectReq)
+					if err != nil {
+						proxyConn.Close()
+						return nil, fmt.Errorf("read CONNECT response: %w", err)
+					}
+					if resp.StatusCode != http.StatusOK {
+						proxyConn.Close()
+						return nil, fmt.Errorf("proxy CONNECT failed: %s", resp.Status)
+					}
+					return proxyConn, nil
 				}
-				// Dial the IP we just vetted, not the hostname, so the connection
-				// can't re-resolve to a different (internal) address (DNS rebinding).
-				return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].IP.String(), port))
-			},
-		},
+				tr.Proxy = nil
+
+			case "socks5", "socks5h":
+				tr.Proxy = http.ProxyURL(pu)
+			}
+		}
+	}
+
+	return &http.Client{
+		Timeout:   webFetchTimeout,
+		Transport: tr,
 	}
 }
 
@@ -97,7 +179,7 @@ func blockedFetchIP(ip net.IP) bool {
 		cgnatRange.Contains(ip) // 100.64.0.0/10 (incl. Alibaba Cloud metadata)
 }
 
-func (webFetch) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+func (wf webFetch) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
 		URL string `json:"url"`
 	}
@@ -123,7 +205,7 @@ func (webFetch) Execute(ctx context.Context, args json.RawMessage) (string, erro
 	req.Header.Set("User-Agent", "reasonix-web-fetch/1.0")
 	req.Header.Set("Accept", "text/html,text/plain,text/markdown,application/json,*/*;q=0.5")
 
-	resp, err := ssrfGuardedClient().Do(req)
+	resp, err := ssrfGuardedClient(wf.proxyURL).Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetch %s: %w", p.URL, err)
 	}

--- a/internal/tool/builtin/webfetch.go
+++ b/internal/tool/builtin/webfetch.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/net/proxy"
+
 	"reasonix/internal/tool"
 )
 
@@ -146,7 +148,31 @@ func ssrfGuardedClient(proxyURL string) *http.Client {
 				tr.Proxy = nil
 
 			case "socks5", "socks5h":
-				tr.Proxy = http.ProxyURL(pu)
+				// Tunnel through SOCKS5. Dial the trusted proxy with a plain
+				// dialer (a proxy on a private/LAN address must not be rejected
+				// by the SSRF guard), then route the target through it. IP-literal
+				// targets are still SSRF-checked; hostnames are resolved by the
+				// proxy — the same boundary as the HTTP CONNECT path above.
+				var auth *proxy.Auth
+				if pu.User != nil {
+					pass, _ := pu.User.Password()
+					auth = &proxy.Auth{User: pu.User.Username(), Password: pass}
+				}
+				if sd, err := proxy.SOCKS5("tcp", pu.Host, auth, dialer); err == nil {
+					if cd, ok := sd.(proxy.ContextDialer); ok {
+						tr.Proxy = nil
+						tr.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+							host, _, err := net.SplitHostPort(addr)
+							if err != nil {
+								return nil, err
+							}
+							if ip := net.ParseIP(host); ip != nil && blockedFetchIP(ip) {
+								return nil, fmt.Errorf("refusing to fetch internal address %s (resolves to %s)", host, ip)
+							}
+							return cd.DialContext(ctx, network, addr)
+						}
+					}
+				}
 			}
 		}
 	}

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -25,6 +25,7 @@ type Workspace struct {
 	Bash        sandbox.Spec
 	BashTimeout time.Duration
 	Search      SearchSpec
+	ProxyURL    string // resolved proxy URL for web_fetch
 }
 
 // Tools returns the built-in tools bound to the workspace, ready to Add to a
@@ -51,7 +52,7 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		"ls":            listDir{workDir: w.Dir},
 		"glob":          globTool{workDir: w.Dir},
 		"grep":          grepTool{workDir: w.Dir, rg: w.Search.RgPath},
-		"web_fetch":     webFetch{},
+		"web_fetch":     webFetch{proxyURL: w.ProxyURL},
 	}
 	all := tool.Builtins()
 	if len(enabled) == 0 {


### PR DESCRIPTION
Rebased @ningqipeng's #3357 onto current main-v2 (resolving the boot/workspace conflicts from the bash-timeout changes) and fixed the SOCKS5 branch.

## What it does
Wires `web_fetch` to the `[network]` proxy config while preserving the SSRF guard:
- **HTTP/HTTPS proxy** → dial proxy, `CONNECT` with the original hostname (proxy resolves DNS — needed behind the GFW). IP-literal targets stay SSRF-checked.
- **SOCKS5/5h** → tunnel via the proxy; IP-literal targets SSRF-checked, hostnames resolved by the proxy.
- **No proxy** → unchanged dial-time SSRF guard (resolve locally, block internal IPs, dial the vetted IP to defeat rebinding).

## Fix on top of the original
The original SOCKS branch only set `Transport.Proxy`, so the proxy itself was dialed through the SSRF-checking `directDialContext` — a SOCKS proxy on a private/LAN address (common; anything but loopback) was refused by the guard. This routes SOCKS through `golang.org/x/net/proxy` with a plain dialer to the trusted proxy and keeps the IP-literal target check in a wrapping `DialContext`, mirroring the HTTP CONNECT path. Added tests for both the preserved block and the proxy-not-blocked case.

## Testing
- `go test ./internal/tool/builtin ./internal/boot ./internal/netclient` green
- New: `TestSSRFBlocksPrivateTargetThroughSOCKS5`, `TestSOCKS5ProxyOnPrivateAddressNotSSRFBlocked`

Closes #3357

Original work by @ningqipeng.
