### PR TITLE
fix(desktop): 文件面板右键新增「显示文件所在位置」

### DIFF
--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRight,
   FileText,
   Folder,
+  FolderOpen,
   FolderTree,
   FolderX,
   GitBranch,
@@ -41,8 +42,9 @@ const WORKSPACE_PREVIEW_MIN_WIDTH = 360;
 const WORKSPACE_PREVIEW_TARGET_WIDTH = 360;
 const WORKSPACE_DUAL_PANEL_MIN_WIDTH = WORKSPACE_TREE_MIN_WIDTH + WORKSPACE_PREVIEW_MIN_WIDTH;
 const WORKSPACE_DUAL_PANEL_TARGET_WIDTH = WORKSPACE_TREE_DEFAULT_WIDTH + WORKSPACE_PREVIEW_TARGET_WIDTH;
-const WORKSPACE_CONTEXT_MENU_FILE_HEIGHT = 92;
-const WORKSPACE_CONTEXT_MENU_REF_HEIGHT = 48;
+const WORKSPACE_CONTEXT_MENU_FILE_HEIGHT = 136;
+const WORKSPACE_CONTEXT_MENU_REF_HEIGHT = 92;
+const WORKSPACE_CONTEXT_MENU_SELECTION_HEIGHT = 48;
 const WORKSPACE_MAX_PREVIEW_TABS = 5;
 
 function clampWorkspaceTreeWidth(width: number, panelWidth?: number): number {
@@ -641,6 +643,12 @@ export function WorkspacePanel({
     }
   };
 
+  const revealInFileManager = () => {
+    if (!treeMenu) return;
+    setTreeMenu(null);
+    void app.RevealWorkspacePath(treeMenu.path);
+  };
+
   const renderRows = (dir: string, depth: number): JSX.Element[] => {
     const entries = entriesByDir[dir] ?? [];
     return entries.flatMap((entry) => {
@@ -937,7 +945,7 @@ export function WorkspacePanel({
             </>
           ) : null}
           {selectionMenu && (
-            <FloatingMenu x={selectionMenu.x} y={selectionMenu.y} estimatedHeight={WORKSPACE_CONTEXT_MENU_REF_HEIGHT}>
+            <FloatingMenu x={selectionMenu.x} y={selectionMenu.y} estimatedHeight={WORKSPACE_CONTEXT_MENU_SELECTION_HEIGHT}>
               <FloatingMenuItems
                 items={[
                   {
@@ -1094,6 +1102,11 @@ export function WorkspacePanel({
                       onSelect: () => void addTreeFileToChat(),
                     },
                   ]),
+              {
+                icon: <FolderOpen size={14} />,
+                label: t("workspace.revealInFileManager"),
+                onSelect: revealInFileManager,
+              },
             ]}
           />
         </FloatingMenu>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -109,6 +109,7 @@ export const en = {
   "workspace.sourceSession": "Session",
   "workspace.sourceGit": "Git",
   "workspace.deleted": "Deleted",
+  "workspace.revealInFileManager": "Show in file manager",
 
   // mcp & skills drawer
   "caps.title": "MCP & Skills",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -110,6 +110,7 @@ export const zh: Record<DictKey, string> = {
   "workspace.sourceSession": "会话",
   "workspace.sourceGit": "Git",
   "workspace.deleted": "已删除",
+  "workspace.revealInFileManager": "在文件管理器中显示",
 
   // MCP 与技能抽屉
   "caps.title": "MCP 与技能",


### PR DESCRIPTION
## 问题

当前文件面板右键菜单只有「添加文件引用」和「添加文件内容」，无法快速定位文件在系统中的位置。用户需要手动打开资源管理器再导航到对应目录。

关联 issue: #3539

## 修复

在 WorkspacePanel 的文件/文件夹右键菜单中新增「显示文件所在位置」选项，调用已有的 \pp.RevealWorkspacePath()\ Go 绑定：
- Windows → \xplorer /select\ 定位文件
- macOS → \open -R\ 在 Finder 中显示
- Linux → 调用系统文件管理器

## 改动

- \WorkspacePanel.tsx\: 新增 \evealInFileManager\ 函数 + 菜单项 + 更新 estimatedHeight 常量
- \locales/zh.ts\: 新增 \workspace.revealInFileManager\
- \locales/en.ts\: 新增 \workspace.revealInFileManager\

## 验证

- [x] \
pm run typecheck\ 通过
- [x] \
pm run check:css\ 通过
- [x] \
pm test\ 通过
- [x] \wails dev\ 桌面端实测右键菜单 → 资源管理器正确定位