### PR TITLE
feat(cli): add /sandbox status command (#3316)

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -24,6 +24,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/command"
+	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
@@ -32,6 +33,7 @@ import (
 	"reasonix/internal/outputstyle"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/sandbox"
 	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
@@ -117,6 +119,7 @@ type chatTUI struct {
 	pendingCommit *[]string
 	renderer      *mdRenderer
 	showReasoning bool // Ctrl+O / /verbose: show raw thinking text in the CLI
+	cfg           *config.Config
 	// reasoningLineIdx is the transcript index of the live "▎ thinking…" marker
 	// while a reasoning block streams; it's rewritten to "▎ thought for Ns" when
 	// the block closes. -1 when no block is open. transcriptDirty forces a
@@ -2987,6 +2990,9 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.notice(i18n.M.SlashTodoCleared)
 	case "/verbose":
 		m.toggleVerboseReasoning(true)
+	case "/sandbox":
+		m.echoLocalCommand(input)
+		m.showSandboxStatus()
 	case "/effort":
 		return m.runEffortCommand(input)
 	case "/auto-plan":
@@ -3088,6 +3094,41 @@ func (m *chatTUI) commandNames() string {
 		names[i] = "/" + c.Name
 	}
 	return strings.Join(names, " · ")
+}
+
+// showSandboxStatus displays the current sandbox configuration and whether
+// the OS sandbox backend is available. It reads from the stored config so
+// the user can inspect sandbox state without leaving the TUI (closes #3316).
+func (m *chatTUI) showSandboxStatus() {
+	if m.cfg == nil {
+		m.notice("sandbox: config not loaded")
+		return
+	}
+	bash := m.cfg.BashMode()
+	network := m.cfg.Sandbox.Network
+	available := sandbox.Available()
+	roots := m.cfg.WriteRoots()
+
+	var b strings.Builder
+	b.WriteString("sandbox\n")
+	b.WriteString("  phase 0  file-writer confinement\n")
+	if len(roots) > 0 {
+		fmt.Fprintf(&b, "    write_roots  %s\n", strings.Join(roots, ", "))
+	}
+	if m.cfg.Sandbox.WorkspaceRoot != "" {
+		fmt.Fprintf(&b, "    workspace_root  %s\n", m.cfg.Sandbox.WorkspaceRoot)
+	}
+	if len(m.cfg.Sandbox.AllowWrite) > 0 {
+		fmt.Fprintf(&b, "    allow_write  %s\n", strings.Join(m.cfg.Sandbox.AllowWrite, ", "))
+	}
+	b.WriteString("  phase 1  OS bash sandbox\n")
+	fmt.Fprintf(&b, "    bash        %s", bash)
+	if bash == "enforce" && !available {
+		b.WriteString(" (inactive: no OS sandbox on this host — bash runs unconfined)")
+	}
+	b.WriteString("\n")
+	fmt.Fprintf(&b, "    network     %v\n", network)
+	m.notice(b.String())
 }
 
 // runMCPSubcommand handles "/mcp" (status), "/mcp add …" (connect a server live

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -435,6 +435,7 @@ func chatREPL(args []string) int {
 	if cfg, err := config.Load(); err == nil {
 		m.outputStyle = cfg.Agent.OutputStyle    // shown as the active entry in /output-style
 		m.statuslineCmd = cfg.Statusline.Command // custom status-line command, "" = built-in row
+		m.cfg = cfg
 	}
 
 	// /model support: a pure builder the TUI calls to rebuild on a different

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -74,6 +74,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
 		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},
 		{label: "/verbose", insert: "/verbose", hint: i18n.M.CmdVerbose},
+		{label: "/sandbox", insert: "/sandbox", hint: i18n.M.CmdSandbox},
 		{label: "/effort", insert: "/effort ", hint: i18n.M.CmdEffort, descend: true},
 		{label: "/auto-plan", insert: "/auto-plan ", hint: i18n.M.CmdAutoPlan, descend: true},
 		{label: "/theme", insert: "/theme ", hint: i18n.M.CmdTheme, descend: true},

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -68,6 +68,7 @@ func builtinHelpItems() []compItem {
 		{label: "/hooks", hint: i18n.M.CmdHooks},
 		{label: "/memory", hint: i18n.M.CmdMemory},
 		{label: "/output-style", hint: i18n.M.CmdOutputStyle},
+		{label: "/sandbox", hint: i18n.M.CmdSandbox},
 		{label: "/language", hint: i18n.M.CmdLanguage},
 		{label: "/auto-plan", hint: i18n.M.CmdAutoPlan},
 		{label: "/help", hint: i18n.M.CmdHelp},

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -154,6 +154,7 @@ type Messages struct {
 	CmdLanguage     string // /language
 	CmdSkill        string // /skills
 	CmdVerbose      string // /verbose
+	CmdSandbox      string // /sandbox
 	CmdEffort       string // /effort
 	CmdAutoPlan     string // /auto-plan
 	CmdHelp         string // /help

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -165,6 +165,7 @@ var English = Messages{
 	CmdLanguage:     "switch CLI language",
 	CmdSkill:        "manage skills",
 	CmdVerbose:      "toggle thinking text",
+	CmdSandbox:      "show sandbox status",
 	CmdEffort:       "set reasoning effort",
 	CmdAutoPlan:     "configure automatic plan mode",
 	CmdHelp:         "list commands",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -166,6 +166,7 @@ var Chinese = Messages{
 	CmdLanguage:     "切换 CLI 语言",
 	CmdSkill:        "管理 skills",
 	CmdVerbose:      "切换 thinking 原文显示",
+	CmdSandbox:      "查看沙箱状态",
 	CmdEffort:       "设置推理强度",
 	CmdAutoPlan:     "配置自动计划模式",
 	CmdHelp:         "查看命令列表",


### PR DESCRIPTION
Closes #3316

## Problem
The CLI has no way to inspect sandbox status. Phase 0 (file-writer confinement) never reports itself — users cannot tell whether file writes are confined or what the boundaries are. Phase 1 (OS bash sandbox) only surfaces via a single stderr warning on unsupported platforms. The desktop has a full SandboxView UI; the CLI has nothing equivalent.

## Solution
Adds a /sandbox slash command to the CLI chat TUI that displays both sandbox phases:

sandbox
  phase 0  file-writer confinement
    write_roots  /home/user/project
    workspace_root  /home/user/project
    allow_write  /tmp
  phase 1  OS bash sandbox
    bash        enforce (inactive: no OS sandbox on this host — bash runs unconfined)
    network     true

## Changes
- chat_tui.go — case /sandbox + showSandboxStatus() method, cfg *config.Config field, sandbox + config imports
- cli.go — m.cfg = cfg initialization
- complete.go — /sandbox autocomplete entry
- help_view.go — /sandbox in help items
- i18n.go — CmdSandbox field
- messages_en.go — CmdSandbox: show sandbox status
- messages_zh.go — CmdSandbox: 查看沙箱状态

## Testing
- gofmt -l — clean
- go vet ./internal/cli/... ./internal/i18n/... — clean
- go test ./internal/cli/... ./internal/i18n/... — passes