### PR TITLE
Continue subagent transcripts

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/fileutil"
 )
 
@@ -126,6 +127,9 @@ func trashSessionArtifacts(dir, sessionPath, key string) error {
 	if err := movePathIfExists(strings.TrimSuffix(sessionPath, ".jsonl")+".ckpt", filepath.Join(itemDir, ckptName)); err != nil {
 		return err
 	}
+	if err := trashSubagentArtifacts(dir, sessionPath, itemDir); err != nil {
+		return err
+	}
 	meta := trashedSessionMeta{Key: key, DeletedAt: time.Now().UnixMilli()}
 	b, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
@@ -193,6 +197,9 @@ func restoreTrashedSessionFile(dir, path string) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
+	if err := checkRestoreSubagentConflicts(dir, itemDir); err != nil {
+		return err
+	}
 	if err := movePathIfExists(trashPath, target); err != nil {
 		return err
 	}
@@ -201,6 +208,9 @@ func restoreTrashedSessionFile(dir, path string) error {
 	}
 	ckptName := strings.TrimSuffix(key, ".jsonl") + ".ckpt"
 	if err := movePathIfExists(filepath.Join(itemDir, ckptName), filepath.Join(dir, ckptName)); err != nil {
+		return err
+	}
+	if err := restoreSubagentArtifacts(dir, itemDir); err != nil {
 		return err
 	}
 	return os.RemoveAll(itemDir)
@@ -240,6 +250,66 @@ func movePathIfExists(src, dst string) error {
 		return err
 	}
 	return os.Rename(src, dst)
+}
+
+func trashSubagentArtifacts(dir, sessionPath, itemDir string) error {
+	artifacts, err := agent.ListSubagentsByParent(dir, agent.BranchID(sessionPath))
+	if err != nil {
+		return err
+	}
+	trashSubagentDir := filepath.Join(itemDir, "subagents")
+	for _, artifact := range artifacts {
+		if err := movePathIfExists(artifact.SessionPath, filepath.Join(trashSubagentDir, filepath.Base(artifact.SessionPath))); err != nil {
+			return err
+		}
+		if err := movePathIfExists(artifact.MetaPath, filepath.Join(trashSubagentDir, filepath.Base(artifact.MetaPath))); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkRestoreSubagentConflicts(dir, itemDir string) error {
+	trashSubagentDir := filepath.Join(itemDir, "subagents")
+	entries, err := os.ReadDir(trashSubagentDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		target := filepath.Join(dir, "subagents", entry.Name())
+		if _, err := os.Stat(target); err == nil {
+			return fmt.Errorf("subagent artifact already exists: %s", entry.Name())
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func restoreSubagentArtifacts(dir, itemDir string) error {
+	trashSubagentDir := filepath.Join(itemDir, "subagents")
+	entries, err := os.ReadDir(trashSubagentDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if err := movePathIfExists(filepath.Join(trashSubagentDir, entry.Name()), filepath.Join(dir, "subagents", entry.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateSessionPath(dir, sessionPath string) (string, string, error) {

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"reasonix/internal/agent"
 )
 
 // --- loadSessionTitles ---
@@ -164,6 +166,40 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 }
 
+func TestDeleteSessionFileMovesOwnedSubagentsToTrash(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	os.WriteFile(sessionPath, []byte("data"), 0o644)
+	writeSubagentArtifact(t, dir, "sa_20260102_030405_000000000_aabbccddeeff", agent.BranchID(sessionPath))
+	writeSubagentArtifact(t, dir, "sa_20260102_030405_000000000_112233445566", "other-parent")
+
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	ownedJSONL := filepath.Join(dir, "subagents", "sa_20260102_030405_000000000_aabbccddeeff.jsonl")
+	ownedMeta := filepath.Join(dir, "subagents", "sa_20260102_030405_000000000_aabbccddeeff.meta.json")
+	if _, err := os.Stat(ownedJSONL); !os.IsNotExist(err) {
+		t.Fatalf("owned subagent jsonl should be moved out of active dir, stat err = %v", err)
+	}
+	if _, err := os.Stat(ownedMeta); !os.IsNotExist(err) {
+		t.Fatalf("owned subagent meta should be moved out of active dir, stat err = %v", err)
+	}
+	trashSubagentDir := filepath.Join(dir, sessionTrashDir, "session.jsonl", "subagents")
+	if _, err := os.Stat(filepath.Join(trashSubagentDir, "sa_20260102_030405_000000000_aabbccddeeff.jsonl")); err != nil {
+		t.Fatalf("owned subagent jsonl should be in trash: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(trashSubagentDir, "sa_20260102_030405_000000000_aabbccddeeff.meta.json")); err != nil {
+		t.Fatalf("owned subagent meta should be in trash: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subagents", "sa_20260102_030405_000000000_112233445566.jsonl")); err != nil {
+		t.Fatalf("unowned subagent jsonl should remain active: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subagents", "sa_20260102_030405_000000000_112233445566.meta.json")); err != nil {
+		t.Fatalf("unowned subagent meta should remain active: %v", err)
+	}
+}
+
 func TestDeleteSessionFileNoTitle(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "no-title.jsonl")
@@ -225,6 +261,61 @@ func TestRestoreTrashedSessionFile(t *testing.T) {
 	}
 }
 
+func TestRestoreTrashedSessionFileRestoresSubagents(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ref := "sa_20260102_030405_000000000_aabbccddeeff"
+	writeSubagentArtifact(t, dir, ref, agent.BranchID(sessionPath))
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("trash: %v", err)
+	}
+
+	trashPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl")
+	if err := restoreTrashedSessionFile(dir, trashPath); err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".jsonl")); err != nil {
+		t.Fatalf("subagent jsonl should be restored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".meta.json")); err != nil {
+		t.Fatalf("subagent meta should be restored: %v", err)
+	}
+}
+
+func TestRestoreTrashedSessionFileRejectsSubagentConflict(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ref := "sa_20260102_030405_000000000_aabbccddeeff"
+	writeSubagentArtifact(t, dir, ref, agent.BranchID(sessionPath))
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("trash: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "subagents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "subagents", ref+".jsonl"), []byte("conflict"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	trashPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl")
+	if err := restoreTrashedSessionFile(dir, trashPath); err == nil {
+		t.Fatal("restore should fail on subagent conflict")
+	}
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("trash item should remain after failed restore: %v", err)
+	}
+	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
+		t.Fatalf("parent session should not be restored after conflict, stat err = %v", err)
+	}
+}
+
 func TestPurgeTrashedSessionFile(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")
@@ -250,6 +341,24 @@ func TestPurgeTrashedSessionFile(t *testing.T) {
 	}
 	if got := resolveSessionDisplay(dir, sessionPath, "expanded prompt"); got != "expanded prompt" {
 		t.Fatalf("display sidecar should be removed after purge, got %q", got)
+	}
+}
+
+func TestPurgeTrashedSessionFileRemovesSubagents(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	os.WriteFile(sessionPath, []byte("data"), 0o644)
+	ref := "sa_20260102_030405_000000000_aabbccddeeff"
+	writeSubagentArtifact(t, dir, ref, agent.BranchID(sessionPath))
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("trash: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl")
+	if err := purgeTrashedSessionFile(dir, trashPath); err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, sessionTrashDir, "session.jsonl", "subagents", ref+".jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("trashed subagent should be removed by purge, stat err = %v", err)
 	}
 }
 
@@ -322,6 +431,31 @@ func TestDeleteSessionFileRejectsSymlinkEscape(t *testing.T) {
 	}
 	if _, err := os.Stat(outside); err != nil {
 		t.Fatalf("outside target should remain: %v", err)
+	}
+}
+
+func writeSubagentArtifact(t *testing.T, dir, ref, parentSession string) {
+	t.Helper()
+	subagentDir := filepath.Join(dir, "subagents")
+	if err := os.MkdirAll(subagentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".jsonl"), []byte(`{"role":"user","content":"sub"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := agent.SubagentMeta{
+		Ref:           ref,
+		Status:        agent.SubagentCompleted,
+		Kind:          "task",
+		Name:          "task",
+		ParentSession: parentSession,
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -907,6 +907,8 @@ func TestTrashTopicMovesRelatedSessionsToTrash(t *testing.T) {
 		t.Fatalf("mkdir sessions: %v", err)
 	}
 	sessionPath := writeTopicSession(t, dir, "trash-me.jsonl", topicID, "Trash history", projectRoot)
+	ref := "sa_20260102_030405_000000000_aabbccddeeff"
+	writeSubagentArtifact(t, dir, ref, agent.BranchID(sessionPath))
 
 	if err := NewApp().TrashTopic(topicID); err != nil {
 		t.Fatalf("trash topic: %v", err)
@@ -917,6 +919,9 @@ func TestTrashTopicMovesRelatedSessionsToTrash(t *testing.T) {
 	trashPath := filepath.Join(dir, sessionTrashDir, "trash-me.jsonl", "trash-me.jsonl")
 	if _, err := os.Stat(trashPath); err != nil {
 		t.Fatalf("topic session should be moved to trash: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, sessionTrashDir, "trash-me.jsonl", "subagents", ref+".jsonl")); err != nil {
+		t.Fatalf("topic subagent should be moved to trash: %v", err)
 	}
 	if got := loadTopicTitle(projectRoot, topicID); got != "" {
 		t.Fatalf("topic title should be removed, got %q", got)

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 )
@@ -373,6 +376,50 @@ func TestServeRejectsPathLikeSessionID(t *testing.T) {
 	}
 	if resp.Error.Code != ErrInvalidParams || !strings.Contains(resp.Error.Message, "invalid sessionId") {
 		t.Fatalf("session/delete error = %+v, want invalid sessionId", resp.Error)
+	}
+}
+
+func TestDeleteSessionFilesDeletesOwnedSubagents(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ref := "sa_20260102_030405_000000000_aabbccddeeff"
+	writeACPSubagentArtifact(t, dir, ref, agent.BranchID(sessionPath))
+
+	if err := deleteSessionFiles(sessionPath); err != nil {
+		t.Fatalf("deleteSessionFiles: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("subagent jsonl should be deleted, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".meta.json")); !os.IsNotExist(err) {
+		t.Fatalf("subagent meta should be deleted, stat err = %v", err)
+	}
+}
+
+func writeACPSubagentArtifact(t *testing.T, dir, ref, parentSession string) {
+	t.Helper()
+	subagentDir := filepath.Join(dir, "subagents")
+	if err := os.MkdirAll(subagentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".jsonl"), []byte(`{"role":"user","content":"sub"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(agent.SubagentMeta{
+		Ref:           ref,
+		Status:        agent.SubagentCompleted,
+		Kind:          "task",
+		Name:          "task",
+		ParentSession: parentSession,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -917,6 +917,9 @@ func deleteSessionFiles(sessionPath string) error {
 			return err
 		}
 	}
+	if err := agent.DeleteSubagentsByParent(filepath.Dir(sessionPath), agent.BranchID(sessionPath)); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -53,6 +53,7 @@ type Asker interface {
 
 // callContextKey carries the executing tool call's identity into Execute.
 type callContextKey struct{}
+type parentSessionContextKey struct{}
 
 // callContext is the per-call context a tool can read. parentID is the call being
 // executed and sink is the agent's event sink (the `task` tool uses both to nest
@@ -79,6 +80,18 @@ func CallContext(ctx context.Context) (parentID string, sink event.Sink, asker A
 		return "", nil, nil, false
 	}
 	return cc.parentID, cc.sink, cc.asker, true
+}
+
+// WithParentSession stamps the active parent session ID onto a turn context so
+// persisted sub-agents can record and enforce their owning conversation.
+func WithParentSession(ctx context.Context, parentSession string) context.Context {
+	return context.WithValue(ctx, parentSessionContextKey{}, strings.TrimSpace(parentSession))
+}
+
+// ParentSession returns the active parent session ID carried by a turn context.
+func ParentSession(ctx context.Context) string {
+	parentSession, _ := ctx.Value(parentSessionContextKey{}).(string)
+	return strings.TrimSpace(parentSession)
 }
 
 // Gate decides, per tool call, whether it may run. The agent consults it at

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -95,6 +95,9 @@ func (s *SubagentStore) PrepareFresh(spec SubagentSpec) (*SubagentRun, error) {
 	if s == nil {
 		return nil, fmt.Errorf("subagent transcript store is required")
 	}
+	if err := requireParentSession(spec); err != nil {
+		return nil, err
+	}
 	ref, err := s.newRef()
 	if err != nil {
 		return nil, err
@@ -112,6 +115,9 @@ func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*Subagen
 	if s == nil {
 		return nil, fmt.Errorf("subagent continuation is not available in this session")
 	}
+	if err := requireParentSession(spec); err != nil {
+		return nil, err
+	}
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return nil, fmt.Errorf("continue_from requires a subagent reference")
@@ -122,6 +128,10 @@ func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*Subagen
 	}
 	meta, err := s.LoadMeta(ref)
 	if err != nil {
+		release()
+		return nil, err
+	}
+	if err := validateContinueOwner(meta, spec); err != nil {
 		release()
 		return nil, err
 	}
@@ -143,6 +153,9 @@ func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun
 	if s == nil {
 		return nil, fmt.Errorf("subagent continuation is not available in this session")
 	}
+	if err := requireParentSession(spec); err != nil {
+		return nil, err
+	}
 	sourceRef := strings.TrimSpace(ref)
 	if sourceRef == "" {
 		return nil, fmt.Errorf("fork_from requires a subagent reference")
@@ -155,6 +168,10 @@ func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun
 	if err != nil {
 		sourceRelease()
 		return nil, err
+	}
+	if strings.TrimSpace(meta.ParentSession) == "" {
+		sourceRelease()
+		return nil, fmt.Errorf("subagent reference %q has no parent session; run a fresh subagent instead", sourceRef)
 	}
 	if err := validateMeta(meta, spec); err != nil {
 		sourceRelease()
@@ -278,6 +295,25 @@ func validateMeta(meta SubagentMeta, spec SubagentSpec) error {
 		return fmt.Errorf("subagent reference %q uses model/effort %q/%q, current run would use %q/%q", meta.Ref, meta.Model, meta.Effort, want.Model, want.Effort)
 	}
 	return nil
+}
+
+func requireParentSession(spec SubagentSpec) error {
+	if strings.TrimSpace(spec.ParentSession) == "" {
+		return fmt.Errorf("subagent transcript parent session is required")
+	}
+	return nil
+}
+
+func validateContinueOwner(meta SubagentMeta, spec SubagentSpec) error {
+	current := strings.TrimSpace(spec.ParentSession)
+	owner := strings.TrimSpace(meta.ParentSession)
+	if owner == current {
+		return nil
+	}
+	if owner == "" {
+		return fmt.Errorf("subagent reference %q has no parent session; run a fresh subagent instead", meta.Ref)
+	}
+	return fmt.Errorf("subagent reference %q belongs to parent session %q, current parent session is %q; use fork_from to copy it into this session", meta.Ref, owner, current)
 }
 
 func (s *SubagentStore) lock(ref string) (func(), error) {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -92,7 +92,7 @@ func NewSubagentStore(dir string) *SubagentStore {
 
 func (s *SubagentStore) PrepareFresh(spec SubagentSpec) (*SubagentRun, error) {
 	if s == nil {
-		return &SubagentRun{Session: NewSession(spec.SystemPrompt)}, nil
+		return nil, fmt.Errorf("subagent transcript store is required")
 	}
 	ref, err := s.newRef()
 	if err != nil {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -68,6 +68,16 @@ type SubagentRun struct {
 	release func()
 }
 
+// SubagentArtifact is a persisted sub-agent transcript and metadata pair owned
+// by a parent session. One file may be missing after a crash; lifecycle cleanup
+// should operate on the paths that exist.
+type SubagentArtifact struct {
+	Ref         string
+	SessionPath string
+	MetaPath    string
+	Meta        SubagentMeta
+}
+
 func (r *SubagentRun) Release() {
 	if r != nil && r.release != nil {
 		r.release()
@@ -89,6 +99,69 @@ func NewSubagentStore(dir string) *SubagentStore {
 		return nil
 	}
 	return &SubagentStore{dir: dir, locked: map[string]bool{}}
+}
+
+// ListSubagentsByParent returns persisted sub-agent artifacts whose metadata
+// declares the given parent session owner.
+func ListSubagentsByParent(sessionDir, parentSession string) ([]SubagentArtifact, error) {
+	parentSession = strings.TrimSpace(parentSession)
+	if strings.TrimSpace(sessionDir) == "" || parentSession == "" {
+		return nil, nil
+	}
+	dir := filepath.Join(sessionDir, "subagents")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := []SubagentArtifact{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".meta.json") {
+			continue
+		}
+		ref := strings.TrimSuffix(entry.Name(), ".meta.json")
+		if !validSubagentRef(ref) {
+			continue
+		}
+		metaPath := filepath.Join(dir, entry.Name())
+		data, err := os.ReadFile(metaPath)
+		if err != nil {
+			return nil, err
+		}
+		var meta SubagentMeta
+		if err := json.Unmarshal(data, &meta); err != nil {
+			continue
+		}
+		if strings.TrimSpace(meta.ParentSession) != parentSession {
+			continue
+		}
+		out = append(out, SubagentArtifact{
+			Ref:         ref,
+			SessionPath: filepath.Join(dir, ref+".jsonl"),
+			MetaPath:    metaPath,
+			Meta:        meta,
+		})
+	}
+	return out, nil
+}
+
+// DeleteSubagentsByParent permanently removes sub-agent artifacts owned by a
+// parent session. Missing counterpart files are ignored.
+func DeleteSubagentsByParent(sessionDir, parentSession string) error {
+	artifacts, err := ListSubagentsByParent(sessionDir, parentSession)
+	if err != nil {
+		return err
+	}
+	for _, artifact := range artifacts {
+		for _, path := range []string{artifact.SessionPath, artifact.MetaPath} {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (s *SubagentStore) PrepareFresh(spec SubagentSpec) (*SubagentRun, error) {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -85,6 +85,16 @@ func (r *SubagentRun) Release() {
 	}
 }
 
+// EphemeralSubagentRun is a non-persisted run for callers without an owning
+// parent session — e.g. headless `reasonix run`, which never mints a session
+// path. Its empty Ref makes the store's MarkRunning/SaveCompleted/SaveFailed
+// methods no-op and keeps FormatSubagentResult from emitting a transcript
+// reference, so the sub-agent behaves exactly as it did before persisted
+// transcripts existed. It holds no lock, so Release is a no-op.
+func EphemeralSubagentRun(systemPrompt string) *SubagentRun {
+	return &SubagentRun{Session: NewSession(systemPrompt)}
+}
+
 // SubagentStore persists sub-agent transcripts under config.SessionDir()/subagents.
 // Its locks are process-local; cross-process mutation is intentionally out of v1.
 type SubagentStore struct {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"reasonix/internal/fileutil"
-	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -1,0 +1,377 @@
+package agent
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/fileutil"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+type SubagentStatus string
+
+const (
+	SubagentRunning   SubagentStatus = "running"
+	SubagentCompleted SubagentStatus = "completed"
+	SubagentFailed    SubagentStatus = "failed"
+)
+
+// SubagentMeta is the sidecar for a persisted sub-agent transcript. It captures
+// the execution identity that must stay stable for continuation/fork.
+type SubagentMeta struct {
+	Ref              string         `json:"ref"`
+	CreatedAt        time.Time      `json:"createdAt"`
+	UpdatedAt        time.Time      `json:"updatedAt"`
+	Status           SubagentStatus `json:"status"`
+	Kind             string         `json:"kind"` // task | skill
+	Name             string         `json:"name"`
+	WorkspaceRoot    string         `json:"workspaceRoot"`
+	ParentSession    string         `json:"parentSession,omitempty"`
+	ParentToolCallID string         `json:"parentToolCallId,omitempty"`
+	SystemPromptHash string         `json:"systemPromptHash"`
+	ToolScope        []string       `json:"toolScope"`
+	ToolSchemaHash   string         `json:"toolSchemaHash"`
+	Model            string         `json:"model"`
+	Effort           string         `json:"effort"`
+}
+
+// SubagentSpec describes the current invocation identity.
+type SubagentSpec struct {
+	Kind             string
+	Name             string
+	WorkspaceRoot    string
+	ParentSession    string
+	ParentToolCallID string
+	SystemPrompt     string
+	Registry         *tool.Registry
+	Model            string
+	Effort           string
+}
+
+// SubagentRun is a prepared transcript run. Call Release exactly once.
+type SubagentRun struct {
+	Ref     string
+	Session *Session
+	Meta    SubagentMeta
+
+	store   *SubagentStore
+	release func()
+}
+
+func (r *SubagentRun) Release() {
+	if r != nil && r.release != nil {
+		r.release()
+		r.release = nil
+	}
+}
+
+// SubagentStore persists sub-agent transcripts under config.SessionDir()/subagents.
+// Its locks are process-local; cross-process mutation is intentionally out of v1.
+type SubagentStore struct {
+	dir string
+
+	mu     sync.Mutex
+	locked map[string]bool
+}
+
+func NewSubagentStore(dir string) *SubagentStore {
+	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	return &SubagentStore{dir: dir, locked: map[string]bool{}}
+}
+
+func (s *SubagentStore) PrepareFresh(spec SubagentSpec) (*SubagentRun, error) {
+	if s == nil {
+		return &SubagentRun{Session: NewSession(spec.SystemPrompt)}, nil
+	}
+	ref, err := s.newRef()
+	if err != nil {
+		return nil, err
+	}
+	release, err := s.lock(ref)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	meta := metaFromSpec(ref, SubagentRunning, now, now, spec)
+	return &SubagentRun{Ref: ref, Session: NewSession(spec.SystemPrompt), Meta: meta, store: s, release: release}, nil
+}
+
+func (s *SubagentStore) PrepareContinue(ref string, spec SubagentSpec) (*SubagentRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("subagent continuation is not available in this session")
+	}
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return nil, fmt.Errorf("continue_from requires a subagent reference")
+	}
+	release, err := s.lock(ref)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := s.LoadMeta(ref)
+	if err != nil {
+		release()
+		return nil, err
+	}
+	if err := validateMeta(meta, spec); err != nil {
+		release()
+		return nil, err
+	}
+	sess, err := LoadSession(s.sessionPath(ref))
+	if err != nil {
+		release()
+		return nil, fmt.Errorf("load subagent transcript %q: %w", ref, err)
+	}
+	meta.ParentSession = spec.ParentSession
+	meta.ParentToolCallID = spec.ParentToolCallID
+	return &SubagentRun{Ref: ref, Session: sess, Meta: meta, store: s, release: release}, nil
+}
+
+func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun, error) {
+	if s == nil {
+		return nil, fmt.Errorf("subagent continuation is not available in this session")
+	}
+	sourceRef := strings.TrimSpace(ref)
+	if sourceRef == "" {
+		return nil, fmt.Errorf("fork_from requires a subagent reference")
+	}
+	sourceRelease, err := s.lock(sourceRef)
+	if err != nil {
+		return nil, err
+	}
+	meta, err := s.LoadMeta(sourceRef)
+	if err != nil {
+		sourceRelease()
+		return nil, err
+	}
+	if err := validateMeta(meta, spec); err != nil {
+		sourceRelease()
+		return nil, err
+	}
+	sess, err := LoadSession(s.sessionPath(sourceRef))
+	if err != nil {
+		sourceRelease()
+		return nil, fmt.Errorf("load subagent transcript %q: %w", sourceRef, err)
+	}
+	newRef, err := s.newRef()
+	if err != nil {
+		sourceRelease()
+		return nil, err
+	}
+	newRelease, err := s.lock(newRef)
+	if err != nil {
+		sourceRelease()
+		return nil, err
+	}
+	now := time.Now().UTC()
+	newMeta := metaFromSpec(newRef, SubagentRunning, now, now, spec)
+	release := func() {
+		newRelease()
+		sourceRelease()
+	}
+	return &SubagentRun{Ref: newRef, Session: sess, Meta: newMeta, store: s, release: release}, nil
+}
+
+func (s *SubagentStore) MarkRunning(run *SubagentRun) error {
+	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	meta := run.Meta
+	meta.Status = SubagentRunning
+	meta.UpdatedAt = time.Now().UTC()
+	return s.saveMeta(meta)
+}
+
+func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
+	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	if err := run.Session.Save(s.sessionPath(run.Ref)); err != nil {
+		return err
+	}
+	meta := run.Meta
+	meta.Status = SubagentCompleted
+	meta.UpdatedAt = time.Now().UTC()
+	run.Meta = meta
+	return s.saveMeta(meta)
+}
+
+func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
+	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	meta := run.Meta
+	meta.Status = SubagentFailed
+	meta.UpdatedAt = time.Now().UTC()
+	run.Meta = meta
+	return s.saveMeta(meta)
+}
+
+func (s *SubagentStore) LoadMeta(ref string) (SubagentMeta, error) {
+	var meta SubagentMeta
+	if !validSubagentRef(ref) {
+		return meta, fmt.Errorf("invalid subagent reference %q", ref)
+	}
+	data, err := os.ReadFile(s.metaPath(ref))
+	if err != nil {
+		return meta, fmt.Errorf("load subagent metadata %q: %w", ref, err)
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return meta, fmt.Errorf("decode subagent metadata %q: %w", ref, err)
+	}
+	return meta, nil
+}
+
+func metaFromSpec(ref string, status SubagentStatus, created, updated time.Time, spec SubagentSpec) SubagentMeta {
+	scope, schemaHash := toolIdentity(spec.Registry)
+	return SubagentMeta{
+		Ref:              ref,
+		CreatedAt:        created,
+		UpdatedAt:        updated,
+		Status:           status,
+		Kind:             strings.TrimSpace(spec.Kind),
+		Name:             strings.TrimSpace(spec.Name),
+		WorkspaceRoot:    strings.TrimSpace(spec.WorkspaceRoot),
+		ParentSession:    strings.TrimSpace(spec.ParentSession),
+		ParentToolCallID: strings.TrimSpace(spec.ParentToolCallID),
+		SystemPromptHash: bytesHash([]byte(spec.SystemPrompt)),
+		ToolScope:        scope,
+		ToolSchemaHash:   schemaHash,
+		Model:            strings.TrimSpace(spec.Model),
+		Effort:           strings.TrimSpace(spec.Effort),
+	}
+}
+
+func validateMeta(meta SubagentMeta, spec SubagentSpec) error {
+	if meta.Status == SubagentRunning {
+		return fmt.Errorf("subagent reference %q is still in progress", meta.Ref)
+	}
+	if meta.Status == SubagentFailed {
+		return fmt.Errorf("subagent reference %q failed and cannot be continued", meta.Ref)
+	}
+	want := metaFromSpec(meta.Ref, meta.Status, meta.CreatedAt, meta.UpdatedAt, spec)
+	switch {
+	case meta.Kind != want.Kind:
+		return fmt.Errorf("subagent reference %q has kind %q, want %q", meta.Ref, meta.Kind, want.Kind)
+	case meta.Name != want.Name:
+		return fmt.Errorf("subagent reference %q has name %q, want %q", meta.Ref, meta.Name, want.Name)
+	case meta.WorkspaceRoot != want.WorkspaceRoot:
+		return fmt.Errorf("subagent reference %q belongs to workspace %q, current workspace is %q", meta.Ref, meta.WorkspaceRoot, want.WorkspaceRoot)
+	case meta.SystemPromptHash != want.SystemPromptHash:
+		return fmt.Errorf("subagent reference %q uses a different subagent persona; run a fresh subagent to use the current persona", meta.Ref)
+	case !sameStrings(meta.ToolScope, want.ToolScope):
+		return fmt.Errorf("subagent reference %q uses a different tool scope", meta.Ref)
+	case meta.ToolSchemaHash != want.ToolSchemaHash:
+		return fmt.Errorf("subagent reference %q uses different tool schemas", meta.Ref)
+	case meta.Model != want.Model || meta.Effort != want.Effort:
+		return fmt.Errorf("subagent reference %q uses model/effort %q/%q, current run would use %q/%q", meta.Ref, meta.Model, meta.Effort, want.Model, want.Effort)
+	}
+	return nil
+}
+
+func (s *SubagentStore) lock(ref string) (func(), error) {
+	if !validSubagentRef(ref) {
+		return nil, fmt.Errorf("invalid subagent reference %q", ref)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.locked[ref] {
+		return nil, fmt.Errorf("subagent reference %q is already running; retry after it finishes", ref)
+	}
+	s.locked[ref] = true
+	return func() {
+		s.mu.Lock()
+		delete(s.locked, ref)
+		s.mu.Unlock()
+	}, nil
+}
+
+func (s *SubagentStore) newRef() (string, error) {
+	var b [6]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "sa_" + time.Now().UTC().Format("20060102_150405_000000000") + "_" + hex.EncodeToString(b[:]), nil
+}
+
+func (s *SubagentStore) sessionPath(ref string) string { return filepath.Join(s.dir, ref+".jsonl") }
+func (s *SubagentStore) metaPath(ref string) string    { return filepath.Join(s.dir, ref+".meta.json") }
+
+func (s *SubagentStore) saveMeta(meta SubagentMeta) error {
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(s.dir, ".subagent-meta.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return fileutil.ReplaceFile(tmpPath, s.metaPath(meta.Ref))
+}
+
+func validSubagentRef(ref string) bool {
+	if !strings.HasPrefix(ref, "sa_") {
+		return false
+	}
+	for _, r := range ref {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' || r == '-' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func toolIdentity(reg *tool.Registry) ([]string, string) {
+	if reg == nil {
+		return nil, bytesHash(nil)
+	}
+	names := reg.Names()
+	sort.Strings(names)
+	schemas := normalizeToolSchemas(reg.Schemas())
+	data, _ := json.Marshal(schemas)
+	return names, bytesHash(data)
+}
+
+func bytesHash(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+func sameStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -164,23 +164,18 @@ func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun
 		sourceRelease()
 		return nil, fmt.Errorf("load subagent transcript %q: %w", sourceRef, err)
 	}
+	sourceRelease()
 	newRef, err := s.newRef()
 	if err != nil {
-		sourceRelease()
 		return nil, err
 	}
 	newRelease, err := s.lock(newRef)
 	if err != nil {
-		sourceRelease()
 		return nil, err
 	}
 	now := time.Now().UTC()
 	newMeta := metaFromSpec(newRef, SubagentRunning, now, now, spec)
-	release := func() {
-		newRelease()
-		sourceRelease()
-	}
-	return &SubagentRun{Ref: newRef, Session: sess, Meta: newMeta, store: s, release: release}, nil
+	return &SubagentRun{Ref: newRef, Session: sess, Meta: newMeta, store: s, release: newRelease}, nil
 }
 
 func (s *SubagentStore) MarkRunning(run *SubagentRun) error {

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -206,11 +207,15 @@ func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 	if s == nil || run == nil || run.Ref == "" {
 		return nil
 	}
+	var sessionErr error
+	if run.Session != nil {
+		sessionErr = run.Session.Save(s.sessionPath(run.Ref))
+	}
 	meta := run.Meta
 	meta.Status = SubagentFailed
 	meta.UpdatedAt = time.Now().UTC()
 	run.Meta = meta
-	return s.saveMeta(meta)
+	return errors.Join(sessionErr, s.saveMeta(meta))
 }
 
 func (s *SubagentStore) LoadMeta(ref string) (SubagentMeta, error) {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -127,6 +127,41 @@ func TestSubagentStoreRejectsConcurrentContinue(t *testing.T) {
 	}
 }
 
+func TestSubagentStoreSaveFailedPersistsTranscriptAndRejectsReuse(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "failed continuation"})
+	if err := store.SaveFailed(run); err != nil {
+		t.Fatalf("SaveFailed: %v", err)
+	}
+	run.Release()
+
+	loaded, err := LoadSession(store.sessionPath(run.Ref))
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if got := loaded.Snapshot(); len(got) != 2 || got[1].Content != "failed continuation" {
+		t.Fatalf("failed transcript = %+v, want persisted failed prompt", got)
+	}
+	meta, err := store.LoadMeta(run.Ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != SubagentFailed {
+		t.Fatalf("status = %q, want failed", meta.Status)
+	}
+	if _, err := store.PrepareContinue(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+		t.Fatalf("PrepareContinue error = %v, want failed ref rejection", err)
+	}
+	if _, err := store.PrepareFork(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+		t.Fatalf("PrepareFork error = %v, want failed ref rejection", err)
+	}
+}
+
 func testSubagentSpec(t *testing.T, name string) SubagentSpec {
 	t.Helper()
 	reg := tool.NewRegistry()

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -1,0 +1,118 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func TestSubagentStoreContinueLoadsSavedTranscript(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "review diff"})
+	run.Session.Add(provider.Message{Role: provider.RoleAssistant, Content: "finding A"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	continued, err := store.PrepareContinue(run.Ref, spec)
+	if err != nil {
+		t.Fatalf("PrepareContinue: %v", err)
+	}
+	defer continued.Release()
+	if continued.Ref != run.Ref {
+		t.Fatalf("continued ref = %q, want %q", continued.Ref, run.Ref)
+	}
+	if got := continued.Session.Snapshot(); len(got) != 3 || got[2].Content != "finding A" {
+		t.Fatalf("continued transcript = %+v, want saved messages", got)
+	}
+}
+
+func TestSubagentStoreForkCreatesIndependentReference(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "review diff"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	forked, err := store.PrepareFork(run.Ref, spec)
+	if err != nil {
+		t.Fatalf("PrepareFork: %v", err)
+	}
+	defer forked.Release()
+	if forked.Ref == run.Ref {
+		t.Fatalf("fork ref should be new, got %q", forked.Ref)
+	}
+	if got := forked.Session.Snapshot(); len(got) != 2 || got[1].Content != "review diff" {
+		t.Fatalf("fork transcript = %+v, want copied messages", got)
+	}
+}
+
+func TestSubagentStoreRejectsIncompatibleTranscript(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	other := spec
+	other.Name = "security-review"
+	if _, err := store.PrepareContinue(run.Ref, other); err == nil || !strings.Contains(err.Error(), "name") {
+		t.Fatalf("PrepareContinue error = %v, want incompatible name", err)
+	}
+}
+
+func TestSubagentStoreRejectsConcurrentContinue(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	first, err := store.PrepareContinue(run.Ref, spec)
+	if err != nil {
+		t.Fatalf("first PrepareContinue: %v", err)
+	}
+	defer first.Release()
+	if _, err := store.PrepareContinue(run.Ref, spec); err == nil || !strings.Contains(err.Error(), "already running") {
+		t.Fatalf("second PrepareContinue error = %v, want lock error", err)
+	}
+}
+
+func testSubagentSpec(t *testing.T, name string) SubagentSpec {
+	t.Helper()
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	return SubagentSpec{
+		Kind:          "skill",
+		Name:          name,
+		WorkspaceRoot: t.TempDir(),
+		SystemPrompt:  "review persona",
+		Registry:      reg,
+		Model:         "deepseek",
+		Effort:        "max",
+	}
+}

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -61,6 +61,31 @@ func TestSubagentStoreForkCreatesIndependentReference(t *testing.T) {
 	}
 }
 
+func TestSubagentStoreForkReleasesSourceLockAfterCopy(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "review diff"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	forked, err := store.PrepareFork(run.Ref, spec)
+	if err != nil {
+		t.Fatalf("PrepareFork: %v", err)
+	}
+	defer forked.Release()
+	continued, err := store.PrepareContinue(run.Ref, spec)
+	if err != nil {
+		t.Fatalf("source should not stay locked by fork run: %v", err)
+	}
+	continued.Release()
+}
+
 func TestSubagentStoreRejectsIncompatibleTranscript(t *testing.T) {
 	store := NewSubagentStore(t.TempDir())
 	spec := testSubagentSpec(t, "review")

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -59,6 +59,63 @@ func TestSubagentStoreForkCreatesIndependentReference(t *testing.T) {
 	if got := forked.Session.Snapshot(); len(got) != 2 || got[1].Content != "review diff" {
 		t.Fatalf("fork transcript = %+v, want copied messages", got)
 	}
+	if forked.Meta.ParentSession != spec.ParentSession {
+		t.Fatalf("fork parent session = %q, want %q", forked.Meta.ParentSession, spec.ParentSession)
+	}
+}
+
+func TestSubagentStoreRejectsContinueFromDifferentParentSession(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	other := spec
+	other.ParentSession = "other-parent"
+	if _, err := store.PrepareContinue(run.Ref, other); err == nil || !strings.Contains(err.Error(), "use fork_from") {
+		t.Fatalf("PrepareContinue error = %v, want parent ownership failure", err)
+	}
+}
+
+func TestSubagentStoreForkFromDifferentParentSessionCreatesCurrentOwner(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "review diff"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	other := spec
+	other.ParentSession = "other-parent"
+	forked, err := store.PrepareFork(run.Ref, other)
+	if err != nil {
+		t.Fatalf("PrepareFork: %v", err)
+	}
+	defer forked.Release()
+	if forked.Ref == run.Ref {
+		t.Fatalf("fork ref should be new, got %q", forked.Ref)
+	}
+	if forked.Meta.ParentSession != "other-parent" {
+		t.Fatalf("fork parent session = %q, want other-parent", forked.Meta.ParentSession)
+	}
+	sourceMeta, err := store.LoadMeta(run.Ref)
+	if err != nil {
+		t.Fatalf("LoadMeta source: %v", err)
+	}
+	if sourceMeta.ParentSession != spec.ParentSession {
+		t.Fatalf("source parent session = %q, want %q", sourceMeta.ParentSession, spec.ParentSession)
+	}
 }
 
 func TestSubagentStoreForkReleasesSourceLockAfterCopy(t *testing.T) {
@@ -170,6 +227,7 @@ func testSubagentSpec(t *testing.T, name string) SubagentSpec {
 		Kind:          "skill",
 		Name:          name,
 		WorkspaceRoot: t.TempDir(),
+		ParentSession: "parent-session",
 		SystemPrompt:  "review persona",
 		Registry:      reg,
 		Model:         "deepseek",

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -290,8 +290,15 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 	if t.transcripts == nil {
 		return nil, fmt.Errorf("subagent transcript store is required")
 	}
+	// Headless runs (e.g. `reasonix run`) never mint a session path, so there is
+	// no parent session to own a transcript. Run the sub-agent ephemerally —
+	// exactly as before persisted transcripts existed — instead of failing the
+	// call. Continuation/fork need a persisted owner, so they error here.
 	if parentSession == "" {
-		return nil, fmt.Errorf("subagent transcript parent session is required")
+		if continueFrom != "" || forkFrom != "" {
+			return nil, fmt.Errorf("continue_from/fork_from require a persisted session; none is active in this run")
+		}
+		return EphemeralSubagentRun(t.sysPrompt), nil
 	}
 	identityModel, identityEffort := t.effectiveIdentity(modelRef, effortRef)
 	spec := SubagentSpec{

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -320,6 +320,16 @@ func (t *TaskTool) runSub(ctx context.Context, prompt string, subReg *tool.Regis
 // tool registry (already filtered), and the run Options (model budget, gate).
 func RunSubAgent(ctx context.Context, prov provider.Provider, reg *tool.Registry, sysPrompt, prompt string, opts Options, sink event.Sink) (string, error) {
 	sess := NewSession(sysPrompt)
+	return RunSubAgentWithSession(ctx, prov, reg, sess, prompt, opts, sink)
+}
+
+// RunSubAgentWithSession continues an existing sub-agent session with prompt and
+// returns the latest final assistant answer. Callers use this for transcript
+// continuation; fresh sub-agents should keep using RunSubAgent.
+func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *tool.Registry, sess *Session, prompt string, opts Options, sink event.Sink) (string, error) {
+	if sess == nil {
+		return "", fmt.Errorf("sub-agent session is nil")
+	}
 	sub := New(prov, reg, sess, opts, sink)
 	if err := sub.Run(ctx, prompt); err != nil {
 		return "", fmt.Errorf("sub-agent: %w", err)

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -215,7 +215,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	subReg := t.buildSubReg(p.Tools)
 	modelRef, effortRef := t.effectiveProfile(p.Model, p.Effort)
 	parentID, parent, _, _ := CallContext(ctx)
-	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, parentID, p.ContinueFrom, p.ForkFrom)
+	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, ParentSession(ctx), parentID, p.ContinueFrom, p.ForkFrom)
 	if err != nil {
 		return "", err
 	}
@@ -280,20 +280,25 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	return answer, nil
 }
 
-func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentID, continueFrom, forkFrom string) (*SubagentRun, error) {
+func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentSession, parentID, continueFrom, forkFrom string) (*SubagentRun, error) {
 	continueFrom = strings.TrimSpace(continueFrom)
 	forkFrom = strings.TrimSpace(forkFrom)
+	parentSession = strings.TrimSpace(parentSession)
 	if continueFrom != "" && forkFrom != "" {
 		return nil, fmt.Errorf("continue_from and fork_from are mutually exclusive")
 	}
 	if t.transcripts == nil {
 		return nil, fmt.Errorf("subagent transcript store is required")
 	}
+	if parentSession == "" {
+		return nil, fmt.Errorf("subagent transcript parent session is required")
+	}
 	identityModel, identityEffort := t.effectiveIdentity(modelRef, effortRef)
 	spec := SubagentSpec{
 		Kind:             "task",
 		Name:             "task",
 		WorkspaceRoot:    t.workspaceRoot,
+		ParentSession:    parentSession,
 		ParentToolCallID: parentID,
 		SystemPrompt:     t.sysPrompt,
 		Registry:         subReg,

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -70,6 +70,7 @@ type TaskTool struct {
 	workspaceRoot     string
 	baseModel         string
 	baseEffort        string
+	identityProfile   func(modelRef, effort string) (string, string)
 }
 
 // NewTaskTool wires a task tool to the parent agent's environment so its
@@ -111,6 +112,11 @@ func (t *TaskTool) WithTranscripts(store *SubagentStore, workspaceRoot, baseMode
 	t.workspaceRoot = strings.TrimSpace(workspaceRoot)
 	t.baseModel = strings.TrimSpace(baseModel)
 	t.baseEffort = strings.TrimSpace(baseEffort)
+	return t
+}
+
+func (t *TaskTool) WithTranscriptIdentityResolver(resolve func(modelRef, effort string) (string, string)) *TaskTool {
+	t.identityProfile = resolve
 	return t
 }
 
@@ -241,13 +247,13 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, modelRef, effortRef, run.Session)
 			if err != nil {
 				_ = t.transcripts.SaveFailed(run)
-				return formatSubagentResult("", run.Ref, true), err
+				return FormatSubagentResult("", run.Ref, true), err
 			}
 			if err := t.transcripts.SaveCompleted(run); err != nil {
 				_ = t.transcripts.SaveFailed(run)
-				return formatSubagentResult("", run.Ref, true), err
+				return FormatSubagentResult("", run.Ref, true), err
 			}
-			return formatSubagentResult(answer, run.Ref, false), nil
+			return FormatSubagentResult(answer, run.Ref, false), nil
 		})
 		if run != nil && run.Ref != "" {
 			return fmt.Sprintf("Started background task %q (%s).\nSubagent reference: %s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, run.Ref), nil
@@ -265,7 +271,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		if err := t.transcripts.SaveCompleted(run); err != nil {
 			return "", err
 		}
-		return formatSubagentResult(answer, run.Ref, false), nil
+		return FormatSubagentResult(answer, run.Ref, false), nil
 	}
 	return answer, nil
 }
@@ -276,6 +282,7 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 	if continueFrom != "" && forkFrom != "" {
 		return nil, fmt.Errorf("continue_from and fork_from are mutually exclusive")
 	}
+	identityModel, identityEffort := t.effectiveIdentity(modelRef, effortRef)
 	spec := SubagentSpec{
 		Kind:             "task",
 		Name:             "task",
@@ -283,8 +290,8 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 		ParentToolCallID: parentID,
 		SystemPrompt:     t.sysPrompt,
 		Registry:         subReg,
-		Model:            t.effectiveModelIdentity(modelRef),
-		Effort:           t.effectiveEffortIdentity(effortRef),
+		Model:            identityModel,
+		Effort:           identityEffort,
 	}
 	if continueFrom != "" || forkFrom != "" {
 		if t.transcripts == nil {
@@ -299,6 +306,14 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 		return &SubagentRun{Session: NewSession(t.sysPrompt)}, nil
 	}
 	return t.transcripts.PrepareFresh(spec)
+}
+
+func (t *TaskTool) effectiveIdentity(modelRef, effort string) (string, string) {
+	if t.identityProfile != nil {
+		model, eff := t.identityProfile(modelRef, effort)
+		return strings.TrimSpace(model), strings.TrimSpace(eff)
+	}
+	return t.effectiveModelIdentity(modelRef), t.effectiveEffortIdentity(effort)
 }
 
 func (t *TaskTool) effectiveModelIdentity(modelRef string) string {
@@ -418,7 +433,7 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 	}, sink)
 }
 
-func formatSubagentResult(answer, ref string, failed bool) string {
+func FormatSubagentResult(answer, ref string, failed bool) string {
 	if ref == "" {
 		return answer
 	}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -218,6 +219,11 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	if err != nil {
 		return "", err
 	}
+	prov, pricing, ctxWin, err := t.resolveSubSessionRuntime(modelRef, effortRef)
+	if err != nil {
+		run.Release()
+		return "", fmt.Errorf("sub-agent profile: %w", err)
+	}
 
 	// Background: register a job that runs the sub-agent under the manager's
 	// session context (so it survives this turn) and return immediately. The
@@ -244,14 +250,12 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		}
 		job := jm.Start("task", label, func(jobCtx context.Context, _ io.Writer) (string, error) {
 			defer run.Release()
-			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, modelRef, effortRef, run.Session)
+			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, prov, pricing, ctxWin, run.Session)
 			if err != nil {
-				_ = t.transcripts.SaveFailed(run)
-				return FormatSubagentResult("", run.Ref, true), err
+				return FormatSubagentResult("", run.Ref, true), errors.Join(err, t.transcripts.SaveFailed(run))
 			}
 			if err := t.transcripts.SaveCompleted(run); err != nil {
-				_ = t.transcripts.SaveFailed(run)
-				return FormatSubagentResult("", run.Ref, true), err
+				return FormatSubagentResult("", run.Ref, true), errors.Join(err, t.transcripts.SaveFailed(run))
 			}
 			return FormatSubagentResult(answer, run.Ref, false), nil
 		})
@@ -263,13 +267,13 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 
 	// Foreground: run synchronously, nesting events under this call.
 	defer run.Release()
-	answer, err := t.runSubSession(ctx, p.Prompt, subReg, subSink(ctx), maxSteps, modelRef, effortRef, run.Session)
+	answer, err := t.runSubSession(ctx, p.Prompt, subReg, subSink(ctx), maxSteps, prov, pricing, ctxWin, run.Session)
 	if err != nil {
-		return "", err
+		return "", errors.Join(err, t.transcripts.SaveFailed(run))
 	}
 	if t.transcripts != nil && run.Ref != "" {
 		if err := t.transcripts.SaveCompleted(run); err != nil {
-			return "", err
+			return "", errors.Join(err, t.transcripts.SaveFailed(run))
 		}
 		return FormatSubagentResult(answer, run.Ref, false), nil
 	}
@@ -401,15 +405,19 @@ func FilterReadOnlyRegistry(parent *tool.Registry, exclude ...string) *tool.Regi
 	return sub
 }
 
-func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, modelRef, effort string, sess *Session) (string, error) {
+func (t *TaskTool) resolveSubSessionRuntime(modelRef, effort string) (provider.Provider, *provider.Pricing, int, error) {
 	prov, pricing, ctxWin := t.prov, t.pricing, t.contextWindow
 	if t.resolveProvider != nil && (modelRef != "" || effort != "") {
 		p, pr, cw, err := t.resolveProvider(modelRef, effort)
 		if err != nil {
-			return "", fmt.Errorf("sub-agent profile: %w", err)
+			return nil, nil, 0, err
 		}
 		prov, pricing, ctxWin = p, pr, cw
 	}
+	return prov, pricing, ctxWin, nil
+}
+
+func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, prov provider.Provider, pricing *provider.Pricing, ctxWin int, sess *Session) (string, error) {
 	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
 		MaxSteps:          maxSteps,
 		Temperature:       t.temperature,

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -66,6 +66,10 @@ type TaskTool struct {
 	subagentModel     string
 	subagentEffort    string
 	resolveProvider   func(modelRef, effort string) (provider.Provider, *provider.Pricing, int, error)
+	transcripts       *SubagentStore
+	workspaceRoot     string
+	baseModel         string
+	baseEffort        string
 }
 
 // NewTaskTool wires a task tool to the parent agent's environment so its
@@ -99,6 +103,17 @@ func NewTaskTool(prov provider.Provider, pricing *provider.Pricing, parentReg *t
 	}
 }
 
+// WithTranscripts enables persisted sub-agent transcript continuation for this
+// task tool. The base model/effort are the parent provider identity used when no
+// subagent override is configured.
+func (t *TaskTool) WithTranscripts(store *SubagentStore, workspaceRoot, baseModel, baseEffort string) *TaskTool {
+	t.transcripts = store
+	t.workspaceRoot = strings.TrimSpace(workspaceRoot)
+	t.baseModel = strings.TrimSpace(baseModel)
+	t.baseEffort = strings.TrimSpace(baseEffort)
+	return t
+}
+
 func (t *TaskTool) Name() string { return "task" }
 
 func (t *TaskTool) Description() string {
@@ -115,7 +130,9 @@ func (t *TaskTool) Schema() json.RawMessage {
   "max_steps":{"type":"integer","description":"Optional cap on tool-call rounds. Defaults to half the parent's cap (min 5).","minimum":1},
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."},
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},
-  "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."}
+  "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."},
+  "continue_from":{"type":"string","description":"Optional subagent transcript reference to continue in place. The current kind, prompt persona, tools, model, effort, and workspace must match the saved transcript."},
+  "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy into a new transcript before running this task. Mutually exclusive with continue_from."}
 },
 "required":["prompt"]
 }`)
@@ -163,6 +180,8 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 		RunInBackground bool     `json:"run_in_background"`
 		Model           string   `json:"model"`
 		Effort          string   `json:"effort"`
+		ContinueFrom    string   `json:"continue_from"`
+		ForkFrom        string   `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -188,6 +207,11 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 
 	subReg := t.buildSubReg(p.Tools)
 	modelRef, effortRef := t.effectiveProfile(p.Model, p.Effort)
+	parentID, parent, _, _ := CallContext(ctx)
+	run, err := t.prepareTranscriptRun(subReg, modelRef, effortRef, parentID, p.ContinueFrom, p.ForkFrom)
+	if err != nil {
+		return "", err
+	}
 
 	// Background: register a job that runs the sub-agent under the manager's
 	// session context (so it survives this turn) and return immediately. The
@@ -196,22 +220,99 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 	if p.RunInBackground {
 		jm, ok := jobs.FromContext(ctx)
 		if !ok {
+			if run != nil {
+				run.Release()
+			}
 			return "", fmt.Errorf("background execution is not available in this context")
 		}
-		parentID, parent, _, _ := CallContext(ctx)
 		nested := subSinkFor(parentID, parent)
 		label := p.Description
 		if label == "" {
 			label = "task"
 		}
+		if t.transcripts != nil && run != nil && run.Ref != "" {
+			if err := t.transcripts.MarkRunning(run); err != nil {
+				run.Release()
+				return "", err
+			}
+		}
 		job := jm.Start("task", label, func(jobCtx context.Context, _ io.Writer) (string, error) {
-			return t.runSub(jobCtx, p.Prompt, subReg, nested, maxSteps, modelRef, effortRef)
+			defer run.Release()
+			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, modelRef, effortRef, run.Session)
+			if err != nil {
+				_ = t.transcripts.SaveFailed(run)
+				return formatSubagentResult("", run.Ref, true), err
+			}
+			if err := t.transcripts.SaveCompleted(run); err != nil {
+				_ = t.transcripts.SaveFailed(run)
+				return formatSubagentResult("", run.Ref, true), err
+			}
+			return formatSubagentResult(answer, run.Ref, false), nil
 		})
+		if run != nil && run.Ref != "" {
+			return fmt.Sprintf("Started background task %q (%s).\nSubagent reference: %s\nIt runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label, run.Ref), nil
+		}
 		return fmt.Sprintf("Started background task %q (%s). It runs across turns; collect its final answer with wait (or wait will return it once done), and you'll be notified when it finishes.", job.ID, label), nil
 	}
 
 	// Foreground: run synchronously, nesting events under this call.
-	return t.runSub(ctx, p.Prompt, subReg, subSink(ctx), maxSteps, modelRef, effortRef)
+	defer run.Release()
+	answer, err := t.runSubSession(ctx, p.Prompt, subReg, subSink(ctx), maxSteps, modelRef, effortRef, run.Session)
+	if err != nil {
+		return "", err
+	}
+	if t.transcripts != nil && run.Ref != "" {
+		if err := t.transcripts.SaveCompleted(run); err != nil {
+			return "", err
+		}
+		return formatSubagentResult(answer, run.Ref, false), nil
+	}
+	return answer, nil
+}
+
+func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortRef, parentID, continueFrom, forkFrom string) (*SubagentRun, error) {
+	continueFrom = strings.TrimSpace(continueFrom)
+	forkFrom = strings.TrimSpace(forkFrom)
+	if continueFrom != "" && forkFrom != "" {
+		return nil, fmt.Errorf("continue_from and fork_from are mutually exclusive")
+	}
+	spec := SubagentSpec{
+		Kind:             "task",
+		Name:             "task",
+		WorkspaceRoot:    t.workspaceRoot,
+		ParentToolCallID: parentID,
+		SystemPrompt:     t.sysPrompt,
+		Registry:         subReg,
+		Model:            t.effectiveModelIdentity(modelRef),
+		Effort:           t.effectiveEffortIdentity(effortRef),
+	}
+	if continueFrom != "" || forkFrom != "" {
+		if t.transcripts == nil {
+			return nil, fmt.Errorf("subagent continuation is not available in this session")
+		}
+		if continueFrom != "" {
+			return t.transcripts.PrepareContinue(continueFrom, spec)
+		}
+		return t.transcripts.PrepareFork(forkFrom, spec)
+	}
+	if t.transcripts == nil {
+		return &SubagentRun{Session: NewSession(t.sysPrompt)}, nil
+	}
+	return t.transcripts.PrepareFresh(spec)
+}
+
+func (t *TaskTool) effectiveModelIdentity(modelRef string) string {
+	if strings.TrimSpace(modelRef) != "" {
+		return strings.TrimSpace(modelRef)
+	}
+	return strings.TrimSpace(t.baseModel)
+}
+
+func (t *TaskTool) effectiveEffortIdentity(effort string) string {
+	if strings.TrimSpace(effort) != "" {
+		return strings.TrimSpace(effort)
+	}
+	return strings.TrimSpace(t.baseEffort)
 }
 
 // buildSubReg returns the sub-agent's tool set: the named whitelist (minus
@@ -292,6 +393,10 @@ func FilterReadOnlyRegistry(parent *tool.Registry, exclude ...string) *tool.Regi
 // sink, and returns its final assistant answer. Shared by the foreground and
 // background paths. modelRef and effort override the parent defaults when non-empty.
 func (t *TaskTool) runSub(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, modelRef, effort string) (string, error) {
+	return t.runSubSession(ctx, prompt, subReg, sink, maxSteps, modelRef, effort, NewSession(t.sysPrompt))
+}
+
+func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, modelRef, effort string, sess *Session) (string, error) {
 	prov, pricing, ctxWin := t.prov, t.pricing, t.contextWindow
 	if t.resolveProvider != nil && (modelRef != "" || effort != "") {
 		p, pr, cw, err := t.resolveProvider(modelRef, effort)
@@ -300,7 +405,7 @@ func (t *TaskTool) runSub(ctx context.Context, prompt string, subReg *tool.Regis
 		}
 		prov, pricing, ctxWin = p, pr, cw
 	}
-	return RunSubAgent(ctx, prov, subReg, t.sysPrompt, prompt, Options{
+	return RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
 		MaxSteps:          maxSteps,
 		Temperature:       t.temperature,
 		Pricing:           pricing,
@@ -311,6 +416,19 @@ func (t *TaskTool) runSub(ctx context.Context, prompt string, subReg *tool.Regis
 		CompactForceRatio: t.compactForceRatio,
 		ArchiveDir:        t.archiveDir,
 	}, sink)
+}
+
+func formatSubagentResult(answer, ref string, failed bool) string {
+	if ref == "" {
+		return answer
+	}
+	if failed {
+		if answer == "" {
+			return "Subagent reference (failed): " + ref
+		}
+		return "Subagent reference (failed): " + ref + "\n\nFinal answer:\n" + answer
+	}
+	return "Subagent reference: " + ref + "\n\nFinal answer:\n" + answer
 }
 
 // RunSubAgent runs prompt to completion in a fresh sub-agent session over reg,

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -282,6 +282,9 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 	if continueFrom != "" && forkFrom != "" {
 		return nil, fmt.Errorf("continue_from and fork_from are mutually exclusive")
 	}
+	if t.transcripts == nil {
+		return nil, fmt.Errorf("subagent transcript store is required")
+	}
 	identityModel, identityEffort := t.effectiveIdentity(modelRef, effortRef)
 	spec := SubagentSpec{
 		Kind:             "task",
@@ -294,16 +297,10 @@ func (t *TaskTool) prepareTranscriptRun(subReg *tool.Registry, modelRef, effortR
 		Effort:           identityEffort,
 	}
 	if continueFrom != "" || forkFrom != "" {
-		if t.transcripts == nil {
-			return nil, fmt.Errorf("subagent continuation is not available in this session")
-		}
 		if continueFrom != "" {
 			return t.transcripts.PrepareContinue(continueFrom, spec)
 		}
 		return t.transcripts.PrepareFork(forkFrom, spec)
-	}
-	if t.transcripts == nil {
-		return &SubagentRun{Session: NewSession(t.sysPrompt)}, nil
 	}
 	return t.transcripts.PrepareFresh(spec)
 }
@@ -404,13 +401,6 @@ func FilterReadOnlyRegistry(parent *tool.Registry, exclude ...string) *tool.Regi
 	return sub
 }
 
-// runSub builds a sub-agent over subReg, runs prompt to completion emitting to
-// sink, and returns its final assistant answer. Shared by the foreground and
-// background paths. modelRef and effort override the parent defaults when non-empty.
-func (t *TaskTool) runSub(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, modelRef, effort string) (string, error) {
-	return t.runSubSession(ctx, prompt, subReg, sink, maxSteps, modelRef, effort, NewSession(t.sysPrompt))
-}
-
 func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *tool.Registry, sink event.Sink, maxSteps int, modelRef, effort string, sess *Session) (string, error) {
 	prov, pricing, ctxWin := t.prov, t.pricing, t.contextWindow
 	if t.resolveProvider != nil && (modelRef != "" || effort != "") {
@@ -446,19 +436,9 @@ func FormatSubagentResult(answer, ref string, failed bool) string {
 	return "Subagent reference: " + ref + "\n\nFinal answer:\n" + answer
 }
 
-// RunSubAgent runs prompt to completion in a fresh sub-agent session over reg,
-// emitting tool activity to sink, and returns the sub-agent's final assistant
-// answer. It is the shared core behind the `task` tool and subagent skills: a
-// caller supplies the system prompt (the task persona or the skill body), the
-// tool registry (already filtered), and the run Options (model budget, gate).
-func RunSubAgent(ctx context.Context, prov provider.Provider, reg *tool.Registry, sysPrompt, prompt string, opts Options, sink event.Sink) (string, error) {
-	sess := NewSession(sysPrompt)
-	return RunSubAgentWithSession(ctx, prov, reg, sess, prompt, opts, sink)
-}
-
 // RunSubAgentWithSession continues an existing sub-agent session with prompt and
-// returns the latest final assistant answer. Callers use this for transcript
-// continuation; fresh sub-agents should keep using RunSubAgent.
+// returns the latest final assistant answer. Fresh sub-agents pass a newly-created
+// session; continued sub-agents pass a loaded transcript session.
 func RunSubAgentWithSession(ctx context.Context, prov provider.Provider, reg *tool.Registry, sess *Session, prompt string, opts Options, sink event.Sink) (string, error) {
 	if sess == nil {
 		return "", fmt.Errorf("sub-agent session is nil")

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -10,6 +10,10 @@ import (
 	"reasonix/internal/tool"
 )
 
+func testTaskContext() context.Context {
+	return WithParentSession(context.Background(), "parent-session")
+}
+
 // TestTaskToolReturnsSubAgentFinalAnswer runs a task against a mock provider
 // that emits a single text turn, and verifies the tool returns that text with a
 // transcript reference — sub-agent intermediate state isn't supposed to leak.
@@ -21,7 +25,7 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 	parentReg := tool.NewRegistry()
 	task := newTestTaskTool(t, sub, parentReg, "test-sys-prompt", "", "", nil)
 
-	out, err := task.Execute(context.Background(), []byte(`{"prompt":"find callers of Foo"}`))
+	out, err := task.Execute(testTaskContext(), []byte(`{"prompt":"find callers of Foo"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -59,7 +63,7 @@ func TestTaskToolFiltersTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "research", readOnly: false})
 
 	args := []byte(`{"prompt":"x","tools":["read_file","task","write_file","run_skill","research"]}`)
-	if _, err := task.Execute(context.Background(), args); err != nil {
+	if _, err := task.Execute(testTaskContext(), args); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	// The sub-agent's tool schemas should reflect the whitelist minus meta-tools.
@@ -91,7 +95,7 @@ func TestTaskToolDefaultsToParentToolsWithoutMetaTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "security_review", readOnly: false})
 	parentReg.Add(fakeTool{name: "remember", readOnly: false})
 
-	if _, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`)); err != nil {
+	if _, err := task.Execute(testTaskContext(), []byte(`{"prompt":"x"}`)); err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
 	got := map[string]bool{}
@@ -120,7 +124,7 @@ func TestTaskToolUsesConfiguredProfileForExecution(t *testing.T) {
 	}
 	task := newTestTaskTool(t, parent, tool.NewRegistry(), "sys", "deepseek-pro", "max", resolve)
 
-	out, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`))
+	out, err := task.Execute(testTaskContext(), []byte(`{"prompt":"x"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -142,7 +146,7 @@ func TestTaskToolReturnsProfileResolutionErrors(t *testing.T) {
 	}
 	task := newTestTaskTool(t, parent, tool.NewRegistry(), "sys", "", "", resolve)
 
-	_, err := task.Execute(context.Background(), []byte(`{"prompt":"x","effort":"turbo"}`))
+	_, err := task.Execute(testTaskContext(), []byte(`{"prompt":"x","effort":"turbo"}`))
 	if err == nil || !strings.Contains(err.Error(), "bad effort") {
 		t.Fatalf("Execute error = %v, want profile resolution error", err)
 	}
@@ -155,7 +159,7 @@ func TestTaskToolRequiresTranscriptStore(t *testing.T) {
 	}}
 	task := NewTaskTool(sub, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil)
 
-	_, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`))
+	_, err := task.Execute(testTaskContext(), []byte(`{"prompt":"x"}`))
 	if err == nil || !strings.Contains(err.Error(), "transcript store is required") {
 		t.Fatalf("Execute error = %v, want transcript store requirement", err)
 	}
@@ -174,19 +178,27 @@ func TestTaskToolPersistsAndContinuesTranscript(t *testing.T) {
 	}}
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	store := NewSubagentStore(t.TempDir())
 	task := newTestTaskTool(t, sub, reg, "sys", "", "", nil).
-		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "base-effort")
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
 
-	first, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
+	first, err := task.Execute(testTaskContext(), []byte(`{"prompt":"first task"}`))
 	if err != nil {
 		t.Fatalf("first Execute: %v", err)
 	}
 	ref := subagentRefFromOutput(t, first)
+	meta, err := store.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.ParentSession != "parent-session" {
+		t.Fatalf("parent session = %q, want parent-session", meta.ParentSession)
+	}
 	if !strings.Contains(first, "first answer") {
 		t.Fatalf("first output = %q, want answer", first)
 	}
 
-	second, err := task.Execute(context.Background(), []byte(`{"prompt":"second task","continue_from":"`+ref+`"}`))
+	second, err := task.Execute(testTaskContext(), []byte(`{"prompt":"second task","continue_from":"`+ref+`"}`))
 	if err != nil {
 		t.Fatalf("second Execute: %v", err)
 	}
@@ -221,13 +233,13 @@ func TestTaskToolFailedForegroundContinuationPersistsAndRejectsReuse(t *testing.
 	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
 		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
 
-	first, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
+	first, err := task.Execute(testTaskContext(), []byte(`{"prompt":"first task"}`))
 	if err != nil {
 		t.Fatalf("first Execute: %v", err)
 	}
 	ref := subagentRefFromOutput(t, first)
 
-	_, err = task.Execute(context.Background(), []byte(`{"prompt":"second task","continue_from":"`+ref+`"}`))
+	_, err = task.Execute(testTaskContext(), []byte(`{"prompt":"second task","continue_from":"`+ref+`"}`))
 	if err == nil || !strings.Contains(err.Error(), "provider failed") {
 		t.Fatalf("second Execute error = %v, want provider failure", err)
 	}
@@ -246,7 +258,7 @@ func TestTaskToolFailedForegroundContinuationPersistsAndRejectsReuse(t *testing.
 	if len(msgs) != 4 || msgs[1].Content != "first task" || msgs[2].Content != "first answer" || msgs[3].Content != "second task" {
 		t.Fatalf("failed continuation transcript = %+v, want first task/answer plus second task", msgs)
 	}
-	if _, err := task.Execute(context.Background(), []byte(`{"prompt":"third task","continue_from":"`+ref+`"}`)); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+	if _, err := task.Execute(testTaskContext(), []byte(`{"prompt":"third task","continue_from":"`+ref+`"}`)); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
 		t.Fatalf("reuse error = %v, want failed ref rejection", err)
 	}
 }
@@ -259,12 +271,12 @@ func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 	task := newTestTaskTool(t, sub, tool.NewRegistry(), "sys", "", "", nil).
 		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "")
 
-	out, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
+	out, err := task.Execute(testTaskContext(), []byte(`{"prompt":"first task"}`))
 	if err != nil {
 		t.Fatalf("first Execute: %v", err)
 	}
 	ref := subagentRefFromOutput(t, out)
-	_, err = task.Execute(context.Background(), []byte(`{"prompt":"second task","continue_from":"`+ref+`","model":"other-model"}`))
+	_, err = task.Execute(testTaskContext(), []byte(`{"prompt":"second task","continue_from":"`+ref+`","model":"other-model"}`))
 	if err == nil || !strings.Contains(err.Error(), "model/effort") {
 		t.Fatalf("mismatched model error = %v, want compatibility failure", err)
 	}

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -11,20 +11,21 @@ import (
 )
 
 // TestTaskToolReturnsSubAgentFinalAnswer runs a task against a mock provider
-// that emits a single text turn, and verifies the tool returns exactly that
-// text — sub-agent intermediate state isn't supposed to leak.
+// that emits a single text turn, and verifies the tool returns that text with a
+// transcript reference — sub-agent intermediate state isn't supposed to leak.
 func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "found 3 callers of Foo"},
 		{Type: provider.ChunkDone},
 	}}
 	parentReg := tool.NewRegistry()
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "test-sys-prompt", nil, "", "", nil)
+	task := newTestTaskTool(t, sub, parentReg, "test-sys-prompt", "", "", nil)
 
 	out, err := task.Execute(context.Background(), []byte(`{"prompt":"find callers of Foo"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
+	_ = subagentRefFromOutput(t, out)
 	if !strings.Contains(out, "found 3 callers of Foo") {
 		t.Errorf("got %q, want sub-agent final answer", out)
 	}
@@ -52,7 +53,7 @@ func TestTaskToolFiltersTools(t *testing.T) {
 	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
 	parentReg.Add(fakeTool{name: "write_file", readOnly: false})
 	parentReg.Add(fakeTool{name: "bash", readOnly: false})
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil)
+	task := newTestTaskTool(t, sub, parentReg, "sys", "", "", nil)
 	parentReg.Add(task) // simulate the wiring in cli.setup
 	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
 	parentReg.Add(fakeTool{name: "research", readOnly: false})
@@ -81,7 +82,7 @@ func TestTaskToolDefaultsToParentToolsWithoutMetaTools(t *testing.T) {
 	parentReg := tool.NewRegistry()
 	parentReg.Add(fakeTool{name: "read_file", readOnly: true})
 	parentReg.Add(fakeTool{name: "grep", readOnly: true})
-	task := NewTaskTool(sub, nil, parentReg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil)
+	task := newTestTaskTool(t, sub, parentReg, "sys", "", "", nil)
 	parentReg.Add(task)
 	parentReg.Add(fakeTool{name: "run_skill", readOnly: false})
 	parentReg.Add(fakeTool{name: "explore", readOnly: false})
@@ -113,11 +114,11 @@ func TestTaskToolUsesConfiguredProfileForExecution(t *testing.T) {
 		{Type: provider.ChunkDone},
 	}}
 	var gotModel, gotEffort string
-	task := NewTaskTool(parent, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "deepseek-pro", "max",
-		func(model, effort string) (provider.Provider, *provider.Pricing, int, error) {
-			gotModel, gotEffort = model, effort
-			return resolved, nil, 0, nil
-		})
+	resolve := func(model, effort string) (provider.Provider, *provider.Pricing, int, error) {
+		gotModel, gotEffort = model, effort
+		return resolved, nil, 0, nil
+	}
+	task := newTestTaskTool(t, parent, tool.NewRegistry(), "sys", "deepseek-pro", "max", resolve)
 
 	out, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`))
 	if err != nil {
@@ -136,14 +137,27 @@ func TestTaskToolReturnsProfileResolutionErrors(t *testing.T) {
 		{Type: provider.ChunkText, Text: "parent answer"},
 		{Type: provider.ChunkDone},
 	}}
-	task := NewTaskTool(parent, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "",
-		func(string, string) (provider.Provider, *provider.Pricing, int, error) {
-			return nil, nil, 0, errors.New("bad effort")
-		})
+	resolve := func(string, string) (provider.Provider, *provider.Pricing, int, error) {
+		return nil, nil, 0, errors.New("bad effort")
+	}
+	task := newTestTaskTool(t, parent, tool.NewRegistry(), "sys", "", "", resolve)
 
 	_, err := task.Execute(context.Background(), []byte(`{"prompt":"x","effort":"turbo"}`))
 	if err == nil || !strings.Contains(err.Error(), "bad effort") {
 		t.Fatalf("Execute error = %v, want profile resolution error", err)
+	}
+}
+
+func TestTaskToolRequiresTranscriptStore(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "answer"},
+		{Type: provider.ChunkDone},
+	}}
+	task := NewTaskTool(sub, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil)
+
+	_, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`))
+	if err == nil || !strings.Contains(err.Error(), "transcript store is required") {
+		t.Fatalf("Execute error = %v, want transcript store requirement", err)
 	}
 }
 
@@ -160,9 +174,8 @@ func TestTaskToolPersistsAndContinuesTranscript(t *testing.T) {
 	}}
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "read_file", readOnly: true})
-	store := NewSubagentStore(t.TempDir())
-	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
-		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+	task := newTestTaskTool(t, sub, reg, "sys", "", "", nil).
+		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "base-effort")
 
 	first, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
 	if err != nil {
@@ -197,9 +210,8 @@ func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 		{Type: provider.ChunkText, Text: "answer"},
 		{Type: provider.ChunkDone},
 	}}
-	store := NewSubagentStore(t.TempDir())
-	task := NewTaskTool(sub, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
-		WithTranscripts(store, t.TempDir(), "base-model", "")
+	task := newTestTaskTool(t, sub, tool.NewRegistry(), "sys", "", "", nil).
+		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "")
 
 	out, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
 	if err != nil {
@@ -221,4 +233,10 @@ func subagentRefFromOutput(t *testing.T, out string) string {
 	}
 	t.Fatalf("no subagent reference in output:\n%s", out)
 	return ""
+}
+
+func newTestTaskTool(t *testing.T, prov provider.Provider, reg *tool.Registry, sysPrompt, subagentModel, subagentEffort string, resolve func(string, string) (provider.Provider, *provider.Pricing, int, error)) *TaskTool {
+	t.Helper()
+	return NewTaskTool(prov, nil, reg, 20, 0, 0, 0, 0, 0.0, "", sysPrompt, nil, subagentModel, subagentEffort, resolve).
+		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "base-effort")
 }

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -165,6 +165,41 @@ func TestTaskToolRequiresTranscriptStore(t *testing.T) {
 	}
 }
 
+// TestTaskToolRunsEphemerallyWithoutParentSession mirrors headless `reasonix run`:
+// the store is wired but the context carries no parent session, so the sub-agent
+// must run without persistence and return its plain answer (no transcript ref).
+func TestTaskToolRunsEphemerallyWithoutParentSession(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "headless answer"},
+		{Type: provider.ChunkDone},
+	}}
+	task := newTestTaskTool(t, sub, tool.NewRegistry(), "sys", "", "", nil)
+
+	out, err := task.Execute(context.Background(), []byte(`{"prompt":"x"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "headless answer") {
+		t.Fatalf("got %q, want sub-agent final answer", out)
+	}
+	if strings.Contains(out, "Subagent reference") {
+		t.Fatalf("ephemeral run should not emit a transcript reference: %q", out)
+	}
+}
+
+func TestTaskToolRejectsContinuationWithoutParentSession(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "answer"},
+		{Type: provider.ChunkDone},
+	}}
+	task := newTestTaskTool(t, sub, tool.NewRegistry(), "sys", "", "", nil)
+
+	_, err := task.Execute(context.Background(), []byte(`{"prompt":"x","continue_from":"sa_whatever"}`))
+	if err == nil || !strings.Contains(err.Error(), "persisted session") {
+		t.Fatalf("Execute error = %v, want persisted-session requirement", err)
+	}
+}
+
 func TestTaskToolPersistsAndContinuesTranscript(t *testing.T) {
 	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
 		{

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -146,3 +146,79 @@ func TestTaskToolReturnsProfileResolutionErrors(t *testing.T) {
 		t.Fatalf("Execute error = %v, want profile resolution error", err)
 	}
 }
+
+func TestTaskToolPersistsAndContinuesTranscript(t *testing.T) {
+	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "first answer"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "second answer"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	store := NewSubagentStore(t.TempDir())
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	first, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	ref := subagentRefFromOutput(t, first)
+	if !strings.Contains(first, "first answer") {
+		t.Fatalf("first output = %q, want answer", first)
+	}
+
+	second, err := task.Execute(context.Background(), []byte(`{"prompt":"second task","continue_from":"`+ref+`"}`))
+	if err != nil {
+		t.Fatalf("second Execute: %v", err)
+	}
+	if !strings.Contains(second, "second answer") {
+		t.Fatalf("second output = %q, want answer", second)
+	}
+	if len(sub.requests) != 2 {
+		t.Fatalf("provider requests = %d, want 2", len(sub.requests))
+	}
+	msgs := sub.requests[1].Messages
+	if len(msgs) < 4 {
+		t.Fatalf("continued request messages = %+v, want prior transcript plus new task", msgs)
+	}
+	if msgs[1].Content != "first task" || msgs[2].Content != "first answer" || lastUser(sub.requests[1]) != "second task" {
+		t.Fatalf("continued request messages = %+v, want first task/answer then second task", msgs)
+	}
+}
+
+func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "answer"},
+		{Type: provider.ChunkDone},
+	}}
+	store := NewSubagentStore(t.TempDir())
+	task := NewTaskTool(sub, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "")
+
+	out, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	ref := subagentRefFromOutput(t, out)
+	_, err = task.Execute(context.Background(), []byte(`{"prompt":"second task","continue_from":"`+ref+`","model":"other-model"}`))
+	if err == nil || !strings.Contains(err.Error(), "model/effort") {
+		t.Fatalf("mismatched model error = %v, want compatibility failure", err)
+	}
+}
+
+func subagentRefFromOutput(t *testing.T, out string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "Subagent reference: ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "Subagent reference: "))
+		}
+	}
+	t.Fatalf("no subagent reference in output:\n%s", out)
+	return ""
+}

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -205,6 +205,52 @@ func TestTaskToolPersistsAndContinuesTranscript(t *testing.T) {
 	}
 }
 
+func TestTaskToolFailedForegroundContinuationPersistsAndRejectsReuse(t *testing.T) {
+	sub := &mockProvider{name: "sub", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "first answer"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkError, Err: errors.New("provider failed")},
+		},
+	}}
+	store := NewSubagentStore(t.TempDir())
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	first, err := task.Execute(context.Background(), []byte(`{"prompt":"first task"}`))
+	if err != nil {
+		t.Fatalf("first Execute: %v", err)
+	}
+	ref := subagentRefFromOutput(t, first)
+
+	_, err = task.Execute(context.Background(), []byte(`{"prompt":"second task","continue_from":"`+ref+`"}`))
+	if err == nil || !strings.Contains(err.Error(), "provider failed") {
+		t.Fatalf("second Execute error = %v, want provider failure", err)
+	}
+	meta, err := store.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != SubagentFailed {
+		t.Fatalf("status = %q, want failed", meta.Status)
+	}
+	loaded, err := LoadSession(store.sessionPath(ref))
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	msgs := loaded.Snapshot()
+	if len(msgs) != 4 || msgs[1].Content != "first task" || msgs[2].Content != "first answer" || msgs[3].Content != "second task" {
+		t.Fatalf("failed continuation transcript = %+v, want first task/answer plus second task", msgs)
+	}
+	if _, err := task.Execute(context.Background(), []byte(`{"prompt":"third task","continue_from":"`+ref+`"}`)); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+		t.Fatalf("reuse error = %v, want failed ref rejection", err)
+	}
+}
+
 func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "answer"},

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -480,33 +480,41 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 		parentID, _, _, _ := agent.CallContext(sctx)
 		parentSession := agent.ParentSession(sctx)
-		if parentSession == "" {
-			return "", fmt.Errorf("subagent transcript parent session is required")
-		}
-		identityModel, identityEffort := subagentIdentity(modelRef, effortRef)
-		spec := agent.SubagentSpec{
-			Kind:             "skill",
-			Name:             sk.Name,
-			WorkspaceRoot:    root,
-			ParentSession:    parentSession,
-			ParentToolCallID: parentID,
-			SystemPrompt:     sk.Body,
-			Registry:         subReg,
-			Model:            identityModel,
-			Effort:           identityEffort,
-		}
 		var run *agent.SubagentRun
-		var prepErr error
-		switch {
-		case continueFrom != "":
-			run, prepErr = subagentStore.PrepareContinue(continueFrom, spec)
-		case forkFrom != "":
-			run, prepErr = subagentStore.PrepareFork(forkFrom, spec)
-		default:
-			run, prepErr = subagentStore.PrepareFresh(spec)
-		}
-		if prepErr != nil {
-			return "", prepErr
+		if subagentStore == nil || parentSession == "" {
+			// Headless runs (e.g. `reasonix run`) have no persistent session to
+			// own a transcript. Run the skill sub-agent ephemerally, as before
+			// persisted transcripts existed, instead of failing. Continuation and
+			// fork need a persisted owner, so they error here.
+			if continueFrom != "" || forkFrom != "" {
+				return "", fmt.Errorf("continue_from/fork_from require a persisted session; none is active in this run")
+			}
+			run = agent.EphemeralSubagentRun(sk.Body)
+		} else {
+			identityModel, identityEffort := subagentIdentity(modelRef, effortRef)
+			spec := agent.SubagentSpec{
+				Kind:             "skill",
+				Name:             sk.Name,
+				WorkspaceRoot:    root,
+				ParentSession:    parentSession,
+				ParentToolCallID: parentID,
+				SystemPrompt:     sk.Body,
+				Registry:         subReg,
+				Model:            identityModel,
+				Effort:           identityEffort,
+			}
+			var prepErr error
+			switch {
+			case continueFrom != "":
+				run, prepErr = subagentStore.PrepareContinue(continueFrom, spec)
+			case forkFrom != "":
+				run, prepErr = subagentStore.PrepareFork(forkFrom, spec)
+			default:
+				run, prepErr = subagentStore.PrepareFresh(spec)
+			}
+			if prepErr != nil {
+				return "", prepErr
+			}
 		}
 		defer run.Release()
 		steps := maxSteps

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -519,10 +519,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			ArchiveDir:    config.ArchiveDir(),
 		}, agent.NestedSink(sctx, event.Discard))
 		if err != nil {
-			return "", err
+			return "", errors.Join(err, subagentStore.SaveFailed(run))
 		}
 		if err := subagentStore.SaveCompleted(run); err != nil {
-			return "", err
+			return "", errors.Join(err, subagentStore.SaveFailed(run))
 		}
 		return agent.FormatSubagentResult(answer, run.Ref, false), nil
 	}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -375,6 +375,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if opts.MaxSteps > 0 {
 		maxSteps = opts.MaxSteps
 	}
+	subagentStore := agent.NewSubagentStore(filepath.Join(config.SessionDir(), "subagents"))
 
 	// Permission policy gates every tool call. The headless gate (no Approver)
 	// resolves "ask" to allow — preserving `reasonix run` autonomy — while deny
@@ -436,7 +437,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
 		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
 		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate,
-		taskModel, taskEffort, resolveSubagentProvider))
+		taskModel, taskEffort, resolveSubagentProvider).
+		WithTranscripts(subagentStore, root, modelName, entry.Effort))
 
 	// The `remember` tool lets the model persist durable facts to the project's
 	// auto-memory store; `forget` prunes ones that turn out wrong. The saved index

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -479,11 +479,16 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive")
 		}
 		parentID, _, _, _ := agent.CallContext(sctx)
+		parentSession := agent.ParentSession(sctx)
+		if parentSession == "" {
+			return "", fmt.Errorf("subagent transcript parent session is required")
+		}
 		identityModel, identityEffort := subagentIdentity(modelRef, effortRef)
 		spec := agent.SubagentSpec{
 			Kind:             "skill",
 			Name:             sk.Name,
 			WorkspaceRoot:    root,
+			ParentSession:    parentSession,
 			ParentToolCallID: parentID,
 			SystemPrompt:     sk.Body,
 			Registry:         subReg,

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -432,13 +432,34 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 		return p, me.Price, me.ContextWindow, nil
 	}
+	subagentIdentity := func(modelRef, effort string) (string, string) {
+		me := *entry
+		modelID := modelName
+		if strings.TrimSpace(modelRef) != "" {
+			if resolved, ok := cfg.ResolveModel(modelRef); ok {
+				me = *resolved
+				modelID = strings.TrimSpace(modelRef)
+			} else {
+				modelID = strings.TrimSpace(modelRef)
+			}
+		}
+		if strings.TrimSpace(effort) != "" {
+			if normalized, err := config.NormalizeEffort(&me, effort); err == nil {
+				me.Effort = normalized
+			} else {
+				me.Effort = strings.TrimSpace(effort)
+			}
+		}
+		return modelID, strings.TrimSpace(me.Effort)
+	}
 	taskModel := firstNonEmpty(cfg.Agent.SubagentModels["task"], cfg.Agent.SubagentModel)
 	taskEffort := firstNonEmpty(cfg.Agent.SubagentEfforts["task"], cfg.Agent.SubagentEffort)
 	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
 		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
 		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate,
 		taskModel, taskEffort, resolveSubagentProvider).
-		WithTranscripts(subagentStore, root, modelName, entry.Effort))
+		WithTranscripts(subagentStore, root, modelName, entry.Effort).
+		WithTranscriptIdentityResolver(subagentIdentity))
 
 	// The `remember` tool lets the model persist durable facts to the project's
 	// auto-memory store; `forget` prunes ones that turn out wrong. The saved index
@@ -458,7 +479,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// as system prompt, a tool set scoped to the skill's allowed-tools (minus the
 	// task/skill meta-tools, to bar recursion), and an optional per-skill model.
 	// Its tool activity nests under the invoking call, like `task`.
-	skillRunner := func(sctx context.Context, sk skill.Skill, task string) (string, error) {
+	skillRunner := func(sctx context.Context, sk skill.Skill, task string, runOpts skill.SubagentRunOptions) (string, error) {
 		prov, price, ctxWin := execProv, entry.Price, entry.ContextWindow
 		modelRef := subagentModelRef(cfg, sk)
 		effortRef := subagentEffortRef(cfg, sk)
@@ -470,13 +491,43 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			prov, price, ctxWin = p, pr, cw
 		}
 		subReg := agent.FilterRegistry(reg, sk.AllowedTools, agent.SubagentMetaTools()...)
+		continueFrom, forkFrom := strings.TrimSpace(runOpts.ContinueFrom), strings.TrimSpace(runOpts.ForkFrom)
+		if continueFrom != "" && forkFrom != "" {
+			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive")
+		}
+		parentID, _, _, _ := agent.CallContext(sctx)
+		identityModel, identityEffort := subagentIdentity(modelRef, effortRef)
+		spec := agent.SubagentSpec{
+			Kind:             "skill",
+			Name:             sk.Name,
+			WorkspaceRoot:    root,
+			ParentToolCallID: parentID,
+			SystemPrompt:     sk.Body,
+			Registry:         subReg,
+			Model:            identityModel,
+			Effort:           identityEffort,
+		}
+		var run *agent.SubagentRun
+		var prepErr error
+		switch {
+		case continueFrom != "":
+			run, prepErr = subagentStore.PrepareContinue(continueFrom, spec)
+		case forkFrom != "":
+			run, prepErr = subagentStore.PrepareFork(forkFrom, spec)
+		default:
+			run, prepErr = subagentStore.PrepareFresh(spec)
+		}
+		if prepErr != nil {
+			return "", prepErr
+		}
+		defer run.Release()
 		steps := maxSteps
 		if steps > 0 {
 			if steps /= 2; steps < 5 {
 				steps = 5
 			}
 		}
-		return agent.RunSubAgent(sctx, prov, subReg, sk.Body, task, agent.Options{
+		answer, err := agent.RunSubAgentWithSession(sctx, prov, subReg, run.Session, task, agent.Options{
 			MaxSteps:      steps,
 			Temperature:   cfg.Agent.Temperature,
 			Pricing:       price,
@@ -484,6 +535,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			ContextWindow: ctxWin,
 			ArchiveDir:    config.ArchiveDir(),
 		}, agent.NestedSink(sctx, event.Discard))
+		if err != nil {
+			return "", err
+		}
+		if err := subagentStore.SaveCompleted(run); err != nil {
+			return "", err
+		}
+		return agent.FormatSubagentResult(answer, run.Ref, false), nil
 	}
 	skillProfile := func(sk skill.Skill) *event.Profile {
 		model, effort := subagentModelRef(cfg, sk), subagentEffortRef(cfg, sk)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -375,7 +375,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if opts.MaxSteps > 0 {
 		maxSteps = opts.MaxSteps
 	}
-	subagentStore := agent.NewSubagentStore(filepath.Join(config.SessionDir(), "subagents"))
+	subagentStore := newSubagentStore(config.SessionDir())
 
 	// Permission policy gates every tool call. The headless gate (no Approver)
 	// resolves "ask" to allow — preserving `reasonix run` autonomy — while deny
@@ -433,24 +433,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		return p, me.Price, me.ContextWindow, nil
 	}
 	subagentIdentity := func(modelRef, effort string) (string, string) {
-		me := *entry
-		modelID := modelName
-		if strings.TrimSpace(modelRef) != "" {
-			if resolved, ok := cfg.ResolveModel(modelRef); ok {
-				me = *resolved
-				modelID = strings.TrimSpace(modelRef)
-			} else {
-				modelID = strings.TrimSpace(modelRef)
-			}
-		}
-		if strings.TrimSpace(effort) != "" {
-			if normalized, err := config.NormalizeEffort(&me, effort); err == nil {
-				me.Effort = normalized
-			} else {
-				me.Effort = strings.TrimSpace(effort)
-			}
-		}
-		return modelID, strings.TrimSpace(me.Effort)
+		return subagentEffectiveIdentity(cfg, modelName, entry, modelRef, effort)
 	}
 	taskModel := firstNonEmpty(cfg.Agent.SubagentModels["task"], cfg.Agent.SubagentModel)
 	taskEffort := firstNonEmpty(cfg.Agent.SubagentEfforts["task"], cfg.Agent.SubagentEffort)
@@ -929,6 +912,51 @@ func nearestGitRoot(start string) (string, bool) {
 func isGitMarker(path string) bool {
 	fi, err := os.Stat(path)
 	return err == nil && (fi.IsDir() || fi.Mode().IsRegular())
+}
+
+func newSubagentStore(sessionDir string) *agent.SubagentStore {
+	sessionDir = strings.TrimSpace(sessionDir)
+	if sessionDir == "" {
+		return nil
+	}
+	return agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+}
+
+func subagentEffectiveIdentity(cfg *config.Config, baseModelRef string, base *config.ProviderEntry, modelRef, effort string) (string, string) {
+	var entry config.ProviderEntry
+	if base != nil {
+		entry = *base
+	}
+	ref := strings.TrimSpace(modelRef)
+	if ref == "" {
+		ref = strings.TrimSpace(baseModelRef)
+	}
+	if cfg != nil && ref != "" {
+		if resolved, ok := cfg.ResolveModel(ref); ok {
+			entry = *resolved
+		} else if strings.TrimSpace(modelRef) != "" {
+			entry.Model = ref
+		}
+	} else if strings.TrimSpace(modelRef) != "" {
+		entry.Model = strings.TrimSpace(modelRef)
+	}
+	if rawEffort := strings.TrimSpace(effort); rawEffort != "" {
+		if normalized, err := config.NormalizeEffort(&entry, rawEffort); err == nil {
+			entry.Effort = normalized
+		} else {
+			entry.Effort = rawEffort
+		}
+	}
+	modelID := strings.TrimSpace(entry.Name)
+	model := strings.TrimSpace(entry.Model)
+	if modelID != "" && model != "" {
+		modelID += "/" + model
+	} else if model != "" {
+		modelID = model
+	} else if modelID == "" {
+		modelID = ref
+	}
+	return modelID, strings.TrimSpace(config.EffectiveEffort(&entry))
 }
 
 // NewProvider builds a provider.Provider from a configured entry. Exported so

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -243,6 +243,129 @@ func subagentRefFromHistory(t *testing.T, msgs []provider.Message) string {
 	return ""
 }
 
+// TestBuildHeadlessRunRunsTaskSubagentWithoutSessionPath reproduces headless
+// `reasonix run`: a controller built via Build with NO SetSessionPath (exactly
+// what internal/cli.runAgent does) must still be able to run a `task` sub-agent.
+// Before the ephemeral fallback this failed with "parent session is required".
+func TestBuildHeadlessRunRunsTaskSubagentWithoutSessionPath(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerHeadlessTaskTestProvider()
+	prov := &headlessTaskTestProvider{}
+	setHeadlessTaskTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-headless-test"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	// Deliberately NOT calling SetSessionPath — this is the headless run path.
+	if err := ctrl.Run(context.Background(), "use a task subagent"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := ctrl.SessionPath(); got != "" {
+		t.Fatalf("headless run should keep an empty session path, got %q", got)
+	}
+
+	var toolContent string
+	for _, msg := range ctrl.History() {
+		if msg.Role == provider.RoleTool {
+			toolContent += "\n" + msg.Content
+		}
+	}
+	if strings.Contains(toolContent, "parent session is required") {
+		t.Fatalf("task subagent failed in headless run mode: %s", toolContent)
+	}
+	if !strings.Contains(toolContent, "subagent answer") {
+		t.Fatalf("task tool result = %q, want sub-agent answer", toolContent)
+	}
+	if strings.Contains(toolContent, "Subagent reference") {
+		t.Fatalf("ephemeral headless run should not persist a transcript reference: %s", toolContent)
+	}
+}
+
+const headlessTaskTestProviderKind = "boot-headless-test"
+
+var (
+	headlessTaskTestProviderOnce    sync.Once
+	headlessTaskTestProviderCurrent *headlessTaskTestProvider
+	headlessTaskTestProviderMu      sync.Mutex
+)
+
+func registerHeadlessTaskTestProvider() {
+	headlessTaskTestProviderOnce.Do(func() {
+		provider.Register(headlessTaskTestProviderKind, func(provider.Config) (provider.Provider, error) {
+			headlessTaskTestProviderMu.Lock()
+			defer headlessTaskTestProviderMu.Unlock()
+			if headlessTaskTestProviderCurrent == nil {
+				return nil, errors.New("headless task test provider is not installed")
+			}
+			return headlessTaskTestProviderCurrent, nil
+		})
+	})
+}
+
+func setHeadlessTaskTestProvider(t *testing.T, p *headlessTaskTestProvider) {
+	t.Helper()
+	headlessTaskTestProviderMu.Lock()
+	headlessTaskTestProviderCurrent = p
+	headlessTaskTestProviderMu.Unlock()
+	t.Cleanup(func() {
+		headlessTaskTestProviderMu.Lock()
+		if headlessTaskTestProviderCurrent == p {
+			headlessTaskTestProviderCurrent = nil
+		}
+		headlessTaskTestProviderMu.Unlock()
+	})
+}
+
+type headlessTaskTestProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *headlessTaskTestProvider) Name() string { return "boot-headless-test" }
+
+func (p *headlessTaskTestProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	call := p.calls
+	p.calls++
+	p.mu.Unlock()
+
+	var chunks []provider.Chunk
+	switch call {
+	case 0:
+		chunks = []provider.Chunk{{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "task-1", Name: "task", Arguments: `{"prompt":"find callers"}`}}}
+	case 1:
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "subagent answer"}, {Type: provider.ChunkDone}}
+	default:
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "parent done"}, {Type: provider.ChunkDone}}
+	}
+	ch := make(chan provider.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
+}
+
 func TestNewProviderAppliesConfiguredDefaultEffort(t *testing.T) {
 	var gotReq map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,9 +14,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/event"
 	"reasonix/internal/netclient"
@@ -79,6 +82,160 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	if mem := ctrl.Memory(); mem == nil || len(mem.Docs) == 0 {
 		t.Fatal("controller memory set is empty after discovering REASONIX.md")
 	}
+}
+
+func TestBuildSubagentSkillFailedContinuationPersistsTranscript(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerBootSubagentTestProvider()
+	prov := &bootSubagentTestProvider{}
+	setBootSubagentTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-subagent-test"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	if err := ctrl.Run(context.Background(), "first review"); err != nil {
+		t.Fatalf("first Run: %v", err)
+	}
+	ref := subagentRefFromHistory(t, ctrl.History())
+	prov.setContinueRef(ref)
+
+	if err := ctrl.Run(context.Background(), "continue review"); err != nil {
+		t.Fatalf("second Run: %v", err)
+	}
+	store := agent.NewSubagentStore(filepath.Join(config.SessionDir(), "subagents"))
+	meta, err := store.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != agent.SubagentFailed {
+		t.Fatalf("status = %q, want failed", meta.Status)
+	}
+	sess, err := agent.LoadSession(filepath.Join(config.SessionDir(), "subagents", ref+".jsonl"))
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	msgs := sess.Snapshot()
+	if len(msgs) != 4 || msgs[1].Content != "first skill task" || msgs[2].Content != "first skill answer" || msgs[3].Content != "second skill task" {
+		t.Fatalf("failed skill transcript = %+v, want first task/answer plus second task", msgs)
+	}
+}
+
+const bootSubagentTestProviderKind = "boot-subagent-test"
+
+var (
+	bootSubagentTestProviderOnce    sync.Once
+	bootSubagentTestProviderCurrent *bootSubagentTestProvider
+	bootSubagentTestProviderMu      sync.Mutex
+)
+
+func registerBootSubagentTestProvider() {
+	bootSubagentTestProviderOnce.Do(func() {
+		provider.Register(bootSubagentTestProviderKind, func(provider.Config) (provider.Provider, error) {
+			bootSubagentTestProviderMu.Lock()
+			defer bootSubagentTestProviderMu.Unlock()
+			if bootSubagentTestProviderCurrent == nil {
+				return nil, errors.New("boot subagent test provider is not installed")
+			}
+			return bootSubagentTestProviderCurrent, nil
+		})
+	})
+}
+
+func setBootSubagentTestProvider(t *testing.T, p *bootSubagentTestProvider) {
+	t.Helper()
+	bootSubagentTestProviderMu.Lock()
+	bootSubagentTestProviderCurrent = p
+	bootSubagentTestProviderMu.Unlock()
+	t.Cleanup(func() {
+		bootSubagentTestProviderMu.Lock()
+		if bootSubagentTestProviderCurrent == p {
+			bootSubagentTestProviderCurrent = nil
+		}
+		bootSubagentTestProviderMu.Unlock()
+	})
+}
+
+type bootSubagentTestProvider struct {
+	mu          sync.Mutex
+	calls       int
+	continueRef string
+}
+
+func (p *bootSubagentTestProvider) Name() string { return "boot-subagent-test" }
+
+func (p *bootSubagentTestProvider) setContinueRef(ref string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.continueRef = ref
+}
+
+func (p *bootSubagentTestProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	call := p.calls
+	p.calls++
+	ref := p.continueRef
+	p.mu.Unlock()
+
+	var chunks []provider.Chunk
+	switch call {
+	case 0:
+		chunks = []provider.Chunk{{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "review-1", Name: "review", Arguments: `{"task":"first skill task"}`}}}
+	case 1:
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "first skill answer"}, {Type: provider.ChunkDone}}
+	case 2:
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "parent first done"}, {Type: provider.ChunkDone}}
+	case 3:
+		args, _ := json.Marshal(map[string]string{"task": "second skill task", "continue_from": ref})
+		chunks = []provider.Chunk{{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "review-2", Name: "review", Arguments: string(args)}}}
+	case 4:
+		chunks = []provider.Chunk{{Type: provider.ChunkError, Err: errors.New("subagent skill failed")}}
+	case 5:
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "parent second done"}, {Type: provider.ChunkDone}}
+	default:
+		chunks = []provider.Chunk{{Type: provider.ChunkError, Err: fmt.Errorf("unexpected provider call %d", call)}}
+	}
+	ch := make(chan provider.Chunk, len(chunks))
+	for _, chunk := range chunks {
+		ch <- chunk
+	}
+	close(ch)
+	return ch, nil
+}
+
+func subagentRefFromHistory(t *testing.T, msgs []provider.Message) string {
+	t.Helper()
+	for _, msg := range msgs {
+		if msg.Role != provider.RoleTool {
+			continue
+		}
+		for _, line := range strings.Split(msg.Content, "\n") {
+			if strings.HasPrefix(line, "Subagent reference: ") {
+				return strings.TrimSpace(strings.TrimPrefix(line, "Subagent reference: "))
+			}
+		}
+	}
+	t.Fatalf("no subagent reference in history: %+v", msgs)
+	return ""
 }
 
 func TestNewProviderAppliesConfiguredDefaultEffort(t *testing.T) {

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -112,6 +112,8 @@ model = "x"
 		t.Fatalf("Build: %v", err)
 	}
 	defer ctrl.Close()
+	sessionPath := agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label())
+	ctrl.SetSessionPath(sessionPath)
 
 	if err := ctrl.Run(context.Background(), "first review"); err != nil {
 		t.Fatalf("first Run: %v", err)
@@ -129,6 +131,9 @@ model = "x"
 	}
 	if meta.Status != agent.SubagentFailed {
 		t.Fatalf("status = %q, want failed", meta.Status)
+	}
+	if meta.ParentSession != agent.BranchID(sessionPath) {
+		t.Fatalf("parent session = %q, want %q", meta.ParentSession, agent.BranchID(sessionPath))
 	}
 	sess, err := agent.LoadSession(filepath.Join(config.SessionDir(), "subagents", ref+".jsonl"))
 	if err != nil {

--- a/internal/boot/subagent_model_test.go
+++ b/internal/boot/subagent_model_test.go
@@ -89,3 +89,38 @@ func TestSubagentEffortRefAcceptsToolNameAliases(t *testing.T) {
 		t.Fatalf("security_review alias should configure security-review effort, got %q", got)
 	}
 }
+
+func TestSubagentEffectiveIdentityUsesResolvedModelAndEffort(t *testing.T) {
+	cfg := config.Default()
+	cfg.Providers = []config.ProviderEntry{{
+		Name:             "custom",
+		Kind:             "openai",
+		Models:           []string{"alpha", "beta"},
+		Default:          "beta",
+		SupportedEfforts: []string{"low", "high"},
+		DefaultEffort:    "high",
+	}}
+	base, ok := cfg.ResolveModel("custom")
+	if !ok {
+		t.Fatal("custom provider should resolve")
+	}
+
+	model, effort := subagentEffectiveIdentity(cfg, "custom", base, "", "")
+	if model != "custom/beta" || effort != "high" {
+		t.Fatalf("identity = %q/%q, want custom/beta/high", model, effort)
+	}
+
+	model, effort = subagentEffectiveIdentity(cfg, "custom", base, "alpha", "low")
+	if model != "custom/alpha" || effort != "low" {
+		t.Fatalf("override identity = %q/%q, want custom/alpha/low", model, effort)
+	}
+}
+
+func TestNewSubagentStoreRequiresSessionDir(t *testing.T) {
+	if got := newSubagentStore(""); got != nil {
+		t.Fatalf("empty session dir should disable subagent store, got %#v", got)
+	}
+	if got := newSubagentStore(t.TempDir()); got == nil {
+		t.Fatal("non-empty session dir should create subagent store")
+	}
+}

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -90,7 +90,7 @@ func reviewCommand(args []string) int {
 
 	// 7. Run the review subagent.
 	ctx := context.Background()
-	result, err := agent.RunSubAgent(ctx, prov, reg, reviewSk.Body, task, agent.Options{
+	result, err := agent.RunSubAgentWithSession(ctx, prov, reg, agent.NewSession(reviewSk.Body), task, agent.Options{
 		MaxSteps:      12,
 		Temperature:   cfg.Agent.Temperature,
 		Pricing:       entry.Price,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -443,6 +443,7 @@ func (c *Controller) runTurnWithRaw(ctx context.Context, input, raw string) erro
 func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
+	ctx = agent.WithParentSession(ctx, c.parentSessionID())
 	input = c.Compose(input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
@@ -781,6 +782,7 @@ func (c *Controller) notice(text string) {
 // just needs the exit status — no TurnDone event, no cancel bookkeeping.
 func (c *Controller) Run(ctx context.Context, input string) error {
 	c.maybeSessionStart(ctx)
+	ctx = agent.WithParentSession(ctx, c.parentSessionID())
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	if c.hooks.Enabled() {
@@ -1403,6 +1405,10 @@ func (c *Controller) SessionPath() string {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.sessionPath
+}
+
+func (c *Controller) parentSessionID() string {
+	return agent.BranchID(c.SessionPath())
 }
 
 // History returns the executor's current message log (for repopulating a

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -888,6 +888,10 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	if err := agent.DeleteSubagentsByParent(dir, agent.BranchID(abs)); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/provider"
@@ -282,6 +283,8 @@ func TestDeleteSessionRequiresSessionNameInsideSessionDir(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
+	ref := "sa_20260102_030405_000000000_aabbccddeeff"
+	writeServeSubagentArtifact(t, dir, ref, agent.BranchID(old))
 	sibling := dir + "-other"
 	if err := os.MkdirAll(sibling, 0o755); err != nil {
 		t.Fatal(err)
@@ -321,6 +324,36 @@ func TestDeleteSessionRequiresSessionNameInsideSessionDir(t *testing.T) {
 	}
 	if _, err := os.Stat(old); !os.IsNotExist(err) {
 		t.Fatalf("old session still exists or stat failed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("old session subagent jsonl still exists or stat failed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".meta.json")); !os.IsNotExist(err) {
+		t.Fatalf("old session subagent meta still exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func writeServeSubagentArtifact(t *testing.T, dir, ref, parentSession string) {
+	t.Helper()
+	subagentDir := filepath.Join(dir, "subagents")
+	if err := os.MkdirAll(subagentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".jsonl"), []byte(`{"role":"user","content":"sub"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(agent.SubagentMeta{
+		Ref:           ref,
+		Status:        agent.SubagentCompleted,
+		Kind:          "task",
+		Name:          "task",
+		ParentSession: parentSession,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -17,7 +17,12 @@ import (
 // the final answer. boot wires this over the agent's sub-agent machinery; nil
 // means subagent skills are unavailable in this session (they error rather than
 // silently inlining, which would lose the isolation the author asked for).
-type SubagentRunner func(ctx context.Context, sk Skill, task string) (string, error)
+type SubagentRunOptions struct {
+	ContinueFrom string
+	ForkFrom     string
+}
+
+type SubagentRunner func(ctx context.Context, sk Skill, task string, opts SubagentRunOptions) (string, error)
 
 // ProfileResolver returns the model/effort profile a subagent skill will use.
 // It is optional; without one, skill frontmatter still supplies display metadata.
@@ -61,7 +66,9 @@ func (*runSkillTool) Schema() json.RawMessage {
 "type":"object",
 "properties":{
   "name":{"type":"string","description":"Skill identifier as it appears in the pinned Skills index (e.g. 'explore', 'review'). Case-sensitive. Just the identifier, not the [🧬 subagent] tag."},
-  "arguments":{"type":"string","description":"Free-form arguments. For inline skills: appended as an 'Arguments:' line; the skill's own instructions decide how to use them. For subagent skills: REQUIRED — becomes the entire task the subagent receives."}
+  "arguments":{"type":"string","description":"Free-form arguments. For inline skills: appended as an 'Arguments:' line; the skill's own instructions decide how to use them. For subagent skills: REQUIRED — becomes the entire task the subagent receives."},
+  "continue_from":{"type":"string","description":"Optional subagent transcript reference to continue in place. Only valid for runAs=subagent skills."},
+  "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Only valid for runAs=subagent skills; mutually exclusive with continue_from."}
 },
 "required":["name"]
 }`)
@@ -71,6 +78,8 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 	var p struct {
 		Name      string `json:"name"`
 		Arguments string `json:"arguments"`
+		Continue  string `json:"continue_from"`
+		Fork      string `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -84,6 +93,7 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		return "", fmt.Errorf("unknown skill %q — available: %s", name, availableNames(t.store))
 	}
 	rawArgs := strings.TrimSpace(p.Arguments)
+	opts := SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)}
 
 	if sk.RunAs == RunSubagent {
 		if t.runner == nil {
@@ -92,7 +102,10 @@ func (t *runSkillTool) Execute(ctx context.Context, args json.RawMessage) (strin
 		if rawArgs == "" {
 			return "", fmt.Errorf("run_skill: skill %q is a subagent and requires 'arguments' — the subagent has no other context, so describe the concrete task", name)
 		}
-		return t.runner(ctx, sk, rawArgs)
+		return t.runner(ctx, sk, rawArgs, opts)
+	}
+	if opts.ContinueFrom != "" || opts.ForkFrom != "" {
+		return "", fmt.Errorf("run_skill: continue_from/fork_from are only valid for runAs=subagent skills")
 	}
 	return renderInline(sk, rawArgs), nil
 }
@@ -198,12 +211,14 @@ func (t *subagentSkillTool) Description() string { return t.description }
 
 func (t *subagentSkillTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"task":{"type":"string","description":` +
-		strconv.Quote(t.taskDesc) + `}},"required":["task"]}`)
+		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Optional subagent transcript reference to continue in place."},"fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Mutually exclusive with continue_from."}},"required":["task"]}`)
 }
 
 func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
-		Task string `json:"task"`
+		Task     string `json:"task"`
+		Continue string `json:"continue_from"`
+		Fork     string `json:"fork_from"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -224,7 +239,7 @@ func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (
 	if t.runner == nil {
 		return "", fmt.Errorf("%s: no subagent runner is configured in this session", t.toolName)
 	}
-	return t.runner(ctx, sk, task)
+	return t.runner(ctx, sk, task, SubagentRunOptions{ContinueFrom: strings.TrimSpace(p.Continue), ForkFrom: strings.TrimSpace(p.Fork)})
 }
 
 func (t *subagentSkillTool) ResolveProfile(json.RawMessage) *event.Profile {

--- a/internal/skill/tools_test.go
+++ b/internal/skill/tools_test.go
@@ -49,7 +49,7 @@ func TestRunSkillSubagentRuns(t *testing.T) {
 	home := t.TempDir()
 	writeSkill(t, home, ".reasonix/skills/dig.md", "---\ndescription: dig\nrunAs: subagent\n---\nbody")
 	var gotTask string
-	runner := func(_ context.Context, sk Skill, task string) (string, error) {
+	runner := func(_ context.Context, sk Skill, task string, _ SubagentRunOptions) (string, error) {
 		gotTask = task
 		return "answer from " + sk.Name, nil
 	}
@@ -86,7 +86,9 @@ func TestRunSkillSubagentResolvesProfile(t *testing.T) {
 func TestRunSkillSubagentRequiresArgs(t *testing.T) {
 	home := t.TempDir()
 	writeSkill(t, home, ".reasonix/skills/dig.md", "---\ndescription: dig\nrunAs: subagent\n---\nbody")
-	runner := func(_ context.Context, _ Skill, _ string) (string, error) { return "x", nil }
+	runner := func(_ context.Context, _ Skill, _ string, _ SubagentRunOptions) (string, error) {
+		return "x", nil
+	}
 	tl := NewRunSkillTool(New(Options{HomeDir: home, DisableBuiltins: true}), runner)
 	if _, err := tl.Execute(context.Background(), json.RawMessage(`{"name":"dig"}`)); err == nil {
 		t.Error("subagent skill should require arguments")
@@ -111,7 +113,7 @@ func TestCleanSkillName(t *testing.T) {
 
 func TestBuiltinSubagentToolsRunner(t *testing.T) {
 	var ran string
-	runner := func(_ context.Context, sk Skill, task string) (string, error) {
+	runner := func(_ context.Context, sk Skill, task string, _ SubagentRunOptions) (string, error) {
 		ran = sk.Name + ":" + task
 		return "ok", nil
 	}
@@ -133,6 +135,34 @@ func TestBuiltinSubagentToolsRunner(t *testing.T) {
 	}
 	if ran != "explore:map the loop" {
 		t.Errorf("runner not invoked correctly: %q", ran)
+	}
+}
+
+func TestBuiltinSubagentToolsPassContinuationOptions(t *testing.T) {
+	var got SubagentRunOptions
+	runner := func(_ context.Context, _ Skill, _ string, opts SubagentRunOptions) (string, error) {
+		got = opts
+		return "ok", nil
+	}
+	tools := BuiltinSubagentTools(New(Options{HomeDir: t.TempDir()}), runner)
+	var review interface {
+		Name() string
+		Execute(context.Context, json.RawMessage) (string, error)
+	}
+	for _, tl := range tools {
+		if tl.Name() == "review" {
+			review = tl
+			break
+		}
+	}
+	if review == nil {
+		t.Fatal("review wrapper tool not built")
+	}
+	if _, err := review.Execute(context.Background(), json.RawMessage(`{"task":"again","continue_from":"sa_prev"}`)); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if got.ContinueFrom != "sa_prev" || got.ForkFrom != "" {
+		t.Fatalf("continuation opts = %+v, want continue_from sa_prev", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add persisted subagent transcript storage for task and skill subagents.
- Support continuing and forking subagent transcripts with model/effort/workspace validation.
- Adapt the review CLI to the session-based subagent runner.

## Test plan
- go test ./...