### PR TITLE
fix(agent): reduce evidence verification false signals

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -613,39 +613,6 @@ export default function App() {
   const todos = useMemo(() => (todoItem ? parseTodos(todoItem.args) : []), [todoItem]);
   const [dismissedTodo, setDismissedTodo] = useState<string | null>(null);
   const showTodos = shouldShowTodoPanel(todoItem?.id, dismissedTodo, todos);
-  const [todoNow, setTodoNow] = useState(() => Date.now());
-  const todoSeenRef = useRef<{ id: string; at: number } | null>(null);
-
-  useEffect(() => {
-    if (!todoItem) {
-      todoSeenRef.current = null;
-      return;
-    }
-    if (todoSeenRef.current?.id !== todoItem.id) {
-      todoSeenRef.current = { id: todoItem.id, at: Date.now() };
-      setTodoNow(Date.now());
-    }
-  }, [todoItem]);
-
-  useEffect(() => {
-    if (!showTodos) return;
-    const id = window.setInterval(() => setTodoNow(Date.now()), 15000);
-    return () => window.clearInterval(id);
-  }, [showTodos]);
-
-  const todoStale = useMemo(() => {
-    if (!showTodos || !todoEntry) return false;
-    const after = state.items.slice(todoEntry.index + 1);
-    const completedToolsAfter = after.filter(
-      (it) => it.kind === "tool" && it.name !== "todo_write" && !it.parentId && (it.status === "done" || it.status === "error"),
-    ).length;
-    const finalAssistantAfter = after.some((it) => it.kind === "assistant" && !it.streaming && it.text.trim() !== "");
-    const readinessNoticeAfter = after.some(
-      (it) => it.kind === "notice" && /final-answer readiness|todo_write|complete_step/i.test(it.text),
-    );
-    const staleByTime = state.running && todoSeenRef.current?.id === todoEntry.item.id && todoNow - todoSeenRef.current.at > 90_000;
-    return completedToolsAfter >= 2 || finalAssistantAfter || readinessNoticeAfter || staleByTime;
-  }, [showTodos, state.items, state.running, todoEntry, todoNow]);
 
   // useDeferredValue lets React prioritise Composer input (high-priority) over
   // Transcript re-renders (low-priority) during streaming. When a keystroke
@@ -1595,7 +1562,7 @@ export default function App() {
           </main>
 
           <footer className="footer" ref={footerRef}>
-            {showTodos && <TodoPanel todos={todos} stale={todoStale} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
+            {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
             {state.approval && (
               <ApprovalModal
                 approval={state.approval}

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, ChevronRight, Circle, CircleDot, RefreshCw, X } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Circle, CircleDot, X } from "lucide-react";
 import { useT } from "../lib/i18n";
 import type { Todo } from "../lib/tools";
 import { Tooltip } from "./Tooltip";
@@ -11,7 +11,7 @@ import { Tooltip } from "./Tooltip";
 // shows the current item so the footer stays compact during a long run. The ✕
 // dismisses it (onDismiss) when the user abandons the task; a fresh todo_write
 // brings it back.
-export function TodoPanel({ todos, stale, onDismiss }: { todos: Todo[]; stale?: boolean; onDismiss: () => void }) {
+export function TodoPanel({ todos, onDismiss }: { todos: Todo[]; onDismiss: () => void }) {
   const t = useT();
   const [open, setOpen] = useState(true);
   const currentRef = useRef<HTMLLIElement | null>(null);
@@ -35,12 +35,6 @@ export function TodoPanel({ todos, stale, onDismiss }: { todos: Todo[]; stale?: 
           <span className="todobar__count">
             {done}/{todos.length}
           </span>
-          {stale && (
-            <span className="todobar__stale">
-              <RefreshCw size={11} />
-              {t("todo.stale")}
-            </span>
-          )}
           {!open && current && (
             <span className="todobar__current">{current.activeForm || current.content}</span>
           )}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -719,7 +719,6 @@ export const en = {
   // todo bar
   "todo.title": "To-dos",
   "todo.dismiss": "Dismiss the task list",
-  "todo.stale": "Progress may be stale",
 
   // slash menu tags
   "slash.project": "project",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -721,7 +721,6 @@ export const zh: Record<DictKey, string> = {
   // 待办栏
   "todo.title": "待办",
   "todo.dismiss": "关闭待办列表",
-  "todo.stale": "进度可能未同步",
 
   // 斜杠菜单标签
   "slash.project": "项目",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7868,21 +7868,6 @@ a[href] {
   color: var(--fg-faint);
   flex-shrink: 0;
 }
-.todobar__stale {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
-  max-width: 160px;
-  overflow: hidden;
-  color: var(--fg-faint);
-  font-size: 11px;
-  white-space: nowrap;
-}
-.todobar__stale > svg {
-  flex: 0 0 auto;
-  opacity: 0.72;
-}
 .todobar__current {
   margin-left: 4px;
   font-size: 12px;

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -543,7 +543,6 @@ type finalReadinessCheck struct {
 	applies              bool
 	reason               string
 	missingProjectChecks int
-	missingCompleteStep  bool
 	incompleteTodos      int
 }
 
@@ -552,7 +551,6 @@ func (c finalReadinessCheck) audit(result evidence.ReadinessAuditResult, recover
 		Result:                 result,
 		Recovered:              recovered,
 		MissingProjectChecks:   c.missingProjectChecks,
-		MissingCompleteStep:    c.missingCompleteStep,
 		IncompleteTodos:        c.incompleteTodos,
 		CommandMismatchMissing: c.missingProjectChecks,
 	}
@@ -594,10 +592,7 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 			missing = append(missing, fmt.Sprintf("run %q from %s after the latest write", command, finalReadinessCheckSource(check)))
 		}
 	}
-	if hasTodoReceipt && !a.evidence.HasSuccessfulCompleteStepAfter(writer) {
-		out.missingCompleteStep = true
-		missing = append(missing, "call complete_step after the latest write")
-	}
+
 	if len(missing) == 0 {
 		return out
 	}
@@ -1059,6 +1054,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	cctx := withCallContext(ctx, call.ID, a.sink, a.asker)
 	if a.evidence != nil {
 		cctx = evidence.WithLedger(cctx, a.evidence)
+		cctx = evidence.WithSessionMessages(cctx, a.session.Snapshot())
 	}
 	if len(a.projectChecks) > 0 {
 		cctx = instruction.WithChecks(cctx, a.projectChecks)

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -441,8 +441,8 @@ func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
 		t.Fatalf("readiness audit events = %d, want 3: %+v", len(sink.events), sink.events)
 	}
 	last := sink.events[len(sink.events)-1]
-	if last.Result != evidence.ReadinessErrored || !last.MissingCompleteStep {
-		t.Fatalf("terminal audit = %+v, want errored missing complete_step", last)
+	if last.Result != evidence.ReadinessErrored || last.IncompleteTodos == 0 {
+		t.Fatalf("terminal audit = %+v, want errored with incomplete todos", last)
 	}
 }
 

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -38,7 +38,7 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 		{"writer without checks or todo never gates", nil, readinessLedger(writer), true, ""},
 		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, "go test ./..."},
 		{"project check run after writer satisfies", []instruction.VerifyCheck{check}, readinessLedger(writer, checkAfter), true, ""},
-		{"todo writer without complete_step is reported", nil, readinessLedger(writer, todo), false, "complete_step"},
+		{"todo writer without complete_step is reported", nil, readinessLedger(writer, todo), false, "incomplete items"},
 		{"complete_step without final todo update is reported", nil, readinessLedger(writer, todo, completeAfter), false, "latest successful todo_write"},
 		{"todo writer with complete_step and completed todo satisfies", nil, readinessLedger(writer, todo, completeAfter, doneTodo), true, ""},
 	}

--- a/internal/cli/run_metrics.go
+++ b/internal/cli/run_metrics.go
@@ -25,7 +25,6 @@ type RunMetrics struct {
 	ReadinessRecoveries           int     `json:"readiness_recoveries"`
 	ReadinessErrors               int     `json:"readiness_errors"`
 	ReadinessMissingProjectChecks int     `json:"readiness_missing_project_checks"`
-	ReadinessMissingCompleteSteps int     `json:"readiness_missing_complete_steps"`
 	ReadinessIncompleteTodos      int     `json:"readiness_incomplete_todos"`
 	ReadinessCommandMismatches    int     `json:"readiness_command_mismatches"`
 }
@@ -76,9 +75,6 @@ func (s *metricsSink) RecordReadinessAudit(a evidence.ReadinessAudit) {
 		s.m.ReadinessRecoveries++
 	}
 	s.m.ReadinessMissingProjectChecks += a.MissingProjectChecks
-	if a.MissingCompleteStep {
-		s.m.ReadinessMissingCompleteSteps++
-	}
 	s.m.ReadinessIncompleteTodos += a.IncompleteTodos
 	s.m.ReadinessCommandMismatches += a.CommandMismatchMissing
 }

--- a/internal/cli/run_metrics_test.go
+++ b/internal/cli/run_metrics_test.go
@@ -16,7 +16,6 @@ func TestMetricsSinkAccumulatesReadinessAudit(t *testing.T) {
 	s.RecordReadinessAudit(evidence.ReadinessAudit{
 		Result:                 evidence.ReadinessBlocked,
 		MissingProjectChecks:   2,
-		MissingCompleteStep:    true,
 		IncompleteTodos:        3,
 		CommandMismatchMissing: 2,
 	})
@@ -25,8 +24,7 @@ func TestMetricsSinkAccumulatesReadinessAudit(t *testing.T) {
 		Recovered: true,
 	})
 	s.RecordReadinessAudit(evidence.ReadinessAudit{
-		Result:              evidence.ReadinessErrored,
-		MissingCompleteStep: true,
+		Result: evidence.ReadinessErrored,
 	})
 
 	if s.m.ReadinessChecks != 3 {
@@ -46,9 +44,6 @@ func TestMetricsSinkAccumulatesReadinessAudit(t *testing.T) {
 	}
 	if s.m.ReadinessMissingProjectChecks != 2 {
 		t.Fatalf("missing project checks = %d, want 2", s.m.ReadinessMissingProjectChecks)
-	}
-	if s.m.ReadinessMissingCompleteSteps != 2 {
-		t.Fatalf("missing complete_step = %d, want 2", s.m.ReadinessMissingCompleteSteps)
 	}
 	if s.m.ReadinessIncompleteTodos != 3 {
 		t.Fatalf("incomplete todos = %d, want 3", s.m.ReadinessIncompleteTodos)
@@ -72,7 +67,6 @@ func TestWriteMetricsIncludesReadinessFields(t *testing.T) {
 		ReadinessRecoveries:           1,
 		ReadinessErrors:               0,
 		ReadinessMissingProjectChecks: 0,
-		ReadinessMissingCompleteSteps: 0,
 		ReadinessIncompleteTodos:      0,
 		ReadinessCommandMismatches:    0,
 	}); err != nil {
@@ -94,7 +88,6 @@ func TestWriteMetricsIncludesReadinessFields(t *testing.T) {
 		"readiness_recoveries",
 		"readiness_errors",
 		"readiness_missing_project_checks",
-		"readiness_missing_complete_steps",
 		"readiness_incomplete_todos",
 		"readiness_command_mismatches",
 	} {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"reasonix/internal/provider"
 )
 
 // TodoItem mirrors the todo_write item shape the host needs for step matching.
@@ -325,6 +327,7 @@ func (l *Ledger) hasSuccessfulPaths(paths []string, accept func(Receipt) bool) b
 }
 
 type contextKey struct{}
+type sessionMessagesKey struct{}
 
 func WithLedger(ctx context.Context, ledger *Ledger) context.Context {
 	if ledger == nil {
@@ -336,6 +339,20 @@ func WithLedger(ctx context.Context, ledger *Ledger) context.Context {
 func FromContext(ctx context.Context) (*Ledger, bool) {
 	ledger, ok := ctx.Value(contextKey{}).(*Ledger)
 	return ledger, ok && ledger != nil
+}
+
+// WithSessionMessages attaches the full conversation history so verifyStepEvidence
+// can fall back to scanning the transcript when the per-turn ledger misses a
+// command (cross-turn references, non-bash tool calls, truncated command strings).
+func WithSessionMessages(ctx context.Context, msgs []provider.Message) context.Context {
+	return context.WithValue(ctx, sessionMessagesKey{}, msgs)
+}
+
+// SessionMessagesFromContext retrieves the conversation history attached by
+// WithSessionMessages.
+func SessionMessagesFromContext(ctx context.Context) ([]provider.Message, bool) {
+	msgs, ok := ctx.Value(sessionMessagesKey{}).([]provider.Message)
+	return msgs, ok
 }
 
 func ReceiptFromToolCall(toolName string, args json.RawMessage, success bool, readOnly bool) Receipt {

--- a/internal/evidence/readiness_audit.go
+++ b/internal/evidence/readiness_audit.go
@@ -16,7 +16,6 @@ type ReadinessAudit struct {
 	Result                 ReadinessAuditResult
 	Recovered              bool
 	MissingProjectChecks   int
-	MissingCompleteStep    bool
 	IncompleteTodos        int
 	CommandMismatchMissing int
 }

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -146,7 +146,7 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 			if command == "" {
 				return 0, 0, fmt.Errorf("evidence %d: verification command is required for host verification", i+1)
 			}
-			if !ledger.HasSuccessfulCommand(command) {
+			if !ledger.HasSuccessfulCommand(command) && !verifyCommandFromSession(ctx, command) {
 				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful bash receipt in this turn", i+1, command)
 			}
 			hostVerified++
@@ -242,4 +242,100 @@ func verifyTodoStep(ctx context.Context, step string) (evidence.TodoStepMatch, b
 	default:
 		return evidence.TodoStepMatch{}, true, fmt.Errorf("step %q matches todo %d (%q) but its status is %q; complete_step requires in_progress or completed", step, match.Index, match.Content, match.Status)
 	}
+}
+
+// verifyCommandFromSession scans the full conversation history (not just the
+// per-turn ledger) so that a complete_step can cite commands that ran in an
+// earlier turn, that used a named tool instead of bash, or that were cited
+// with a slightly different string (trailing …,
+// truncation).
+//
+// Three scenarios this covers:
+//  1. Cross-turn: command ran in a prior turn, ledger was reset — scan the
+//     session transcript for the exact bash command.
+//  2. Non-bash tool: the model used the `ls` reader tool rather than
+//     bash "ls .", but complete_step cites command="ls ." — match by tool
+//     name (the first word of the command).
+//  3. Truncated string: the actual command was
+//     `find . -type f -not -path '*/node_modules/*'` but the model wrote
+//     command="find . -type f ..." — normalize both sides (strip …,
+//     trim, collapse whitespace) and fall back to prefix matching.
+func verifyCommandFromSession(ctx context.Context, command string) bool {
+	msgs, ok := evidence.SessionMessagesFromContext(ctx)
+	if !ok {
+		return false
+	}
+	lookup := normalizeVerifyCommand(command)
+	if lookup == "" {
+		return false
+	}
+	toolName := firstWord(lookup)
+
+	for _, msg := range msgs {
+		for _, tc := range msg.ToolCalls {
+			cmd := extractCommandFromCall(tc.Name, tc.Arguments)
+			if cmd == "" {
+				continue
+			}
+			norm := normalizeVerifyCommand(cmd)
+			if norm == lookup {
+				return true
+			}
+			// Prefix match for truncated commands (scenario 3). Require the
+			// shorter side to be at least 8 chars to prevent false positives
+			// on very short fragments like "find" or "ls".
+			if len(norm) >= 8 && len(lookup) >= 8 {
+				if strings.HasPrefix(norm, lookup) || strings.HasPrefix(lookup, norm) {
+					return true
+				}
+			}
+			// Non-bash tool name match (scenario 2): the first word of the
+			// command matches a tool call name that isn't bash.
+			if toolName != "" && toolName != "bash" && tc.Name == toolName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// normalizeVerifyCommand strips trailing ellipsis,
+// trims whitespace, and collapses internal whitespace into single spaces.
+func normalizeVerifyCommand(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimSuffix(s, "...")
+	s = strings.TrimSuffix(s, "…")
+	s = strings.TrimSpace(s)
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func firstWord(s string) string {
+	s = strings.TrimSpace(s)
+	if idx := strings.IndexAny(s, " \t\n"); idx >= 0 {
+		return s[:idx]
+	}
+	return s
+}
+
+// extractCommandFromCall extracts the bash "command" argument from a tool call
+// args JSON, or returns the tool name + path for non-bash tools.
+func extractCommandFromCall(name string, argsJSON string) string {
+	if name == "bash" {
+		var args struct {
+			Command string `json:"command"`
+		}
+		if err := json.Unmarshal([]byte(argsJSON), &args); err != nil {
+			return ""
+		}
+		return strings.TrimSpace(args.Command)
+	}
+	// For non-bash tools, return "name path" so the command "ls ." can match
+	// against a tool call `ls` with path `.`.
+	var args struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(argsJSON), &args); err != nil || args.Path == "" {
+		return name
+	}
+	return name + " " + args.Path
 }


### PR DESCRIPTION
## Summary / 摘要

**EN:** Remove three false signal sources in the evidence/complete_step/todo verification system that either blocked the model's final answer incorrectly, rejected valid `complete_step` evidence, or showed a misleading UI indicator.

**CN:** 消除 evidence / complete_step / todo 验证系统中的三个虚假信号源，它们分别导致了最终答案被错误拦截、合法的 `complete_step` 证据被拒绝、以及 UI 显示误导性提示。

---

## Changes / 改动内容

### 1. Remove duplicate complete_step ordering check from finalReadinessCheck / 移除 finalReadinessCheck 中重复的 complete_step 排序检查

**EN:** `finalReadinessCheck()` used `HasSuccessfulCompleteStepAfter(writer)` to require `complete_step` at a receipt index greater than the last writer tool. But `todo_write`'s own `verifyTodoCompletionTransitions` already enforces this constraint and is **order-independent** (it searches all receipts). The duplicate was stricter, causing false positives when the model called `complete_step → write_file → todo_write(completed)`. Removed entirely.

**CN:** `finalReadinessCheck()` 用 `HasSuccessfulCompleteStepAfter(writer)` 要求 `complete_step` 必须在最后一个 writer 工具之后。但 `todo_write` 自身的 `verifyTodoCompletionTransitions` 已经是**顺序无关**的（搜索所有 receipts）。这个重复检查更严格，导致 `complete_step → write_file → todo_write(completed)` 这类正常流程被误拦截。已彻底删除。

### 2. Add session-fallback command verification in complete_step / complete_step 增加会话回退命令匹配

**EN:** The per-turn `Ledger` is reset each turn, so `complete_step` verification has three blind spots:

| Scenario | Example | Before | After |
|---|---|---|---|
| Cross-turn command | `bash("grep ...")` in turn 1, cited in turn 2 | ❌ no matching receipt | ✅ scans session transcript |
| Non-bash tool name | `ls` tool (not bash), cited as command="ls ." | ❌ no bash receipt | ✅ matches by tool name |
| Truncated command | `find . -type f ...` (real), `find . -type f ...` (cited) | ❌ string mismatch | ✅ normalized + prefix match |

Added `verifyCommandFromSession()`: normalizes both sides (strip …​, collapse whitespace), does exact match, prefix match (min 8 chars), and tool-name match. Receipt match is still the fast path — session fallback only runs when the receipt misses.

**CN:** Per-turn 的 `Ledger` 每轮会 reset，导致三个盲区：

| 场景 | 示例 | 修改前 | 修改后 |
|---|---|---|---|
| 跨轮命令 | 第1轮 bash，第2轮引用 | ❌ 找不到 receipt | ✅ 扫描全对话 |
| 非 bash 工具名 | `ls` 工具（非 bash），引用为 command="ls ." | ❌ 没有 bash receipt | ✅ 按工具名匹配 |
| 命令截断 | 真实 `find . -type f` …​，引用 `find . -type f` …​ | ❌ 字符不匹配 | ✅ 归一化 + 前缀匹配 |

新增 `verifyCommandFromSession()`：归一化（去掉 …​、折叠空白）、精确匹配、前缀匹配（最短 8 字符）、工具名匹配。receipt 匹配仍是快路径，session 回退只在前者未命中时运行。

### 3. Remove stale "Progress may be stale" indicator / 移除"进度可能未同步"提示

**EN:** The `todoStale` heuristic in the desktop `TodoPanel` checked 4 conditions (≥2 tools after last `todo_write`, final assistant message, readiness notices, 90s timeout). All except the timeout triggered false positives in normal completion flows — the model finishing its work and producing a final answer always lit the "stale" flag. Removed entirely. The todo count (`{done}/{total}`) and the transcript itself provide better progress visibility.

**CN:** Desktop `TodoPanel` 的 `todoStale` 启发式判断检查了 4 个条件（todo_write 后 ≥2 个工具、有 assistant 回复、readiness notice、90 秒超时）。除了超时，其他三个在正常完成场景下都会误报——模型做完工作给出最终答案时必然触发。已彻底删除。todo 的数字（`{done}/{total}`）和 transcript 本身已经提供了足够的进度可见性。

---

## Files / 涉及文件（13 files, +123 / -82）

| File | Δ | Change |
|---|---|---|
| `internal/agent/agent.go` | +8 -1 | Remove `HasSuccessfulCompleteStepAfter(writer)` check; add `WithSessionMessages()` injection |
| `internal/evidence/evidence.go` | +17 -0 | Add `WithSessionMessages()` / `SessionMessagesFromContext()` |
| `internal/evidence/readiness_audit.go` | -1 | Remove `MissingCompleteStep` from struct |
| `internal/tool/builtin/completestep.go` | +98 -2 | Add `verifyCommandFromSession()` as fallback |
| `internal/cli/run_metrics.go` | -4 | Remove `ReadinessMissingCompleteSteps` |
| `internal/cli/run_metrics_test.go` | -5 | Update assertion |
| `internal/agent/evidence_flow_test.go` | +2 -2 | Update assertion |
| `internal/agent/final_readiness_test.go` | +1 -1 | Update assertion |
| `desktop/frontend/src/App.tsx` | -30 | Remove `todoStale` useMemo |
| `desktop/frontend/src/components/TodoPanel.tsx` | -8 | Remove `stale` prop |
| `desktop/frontend/src/locales/en.ts` | -1 | Remove `"todo.stale"` |
| `desktop/frontend/src/locales/zh.ts` | -1 | Remove `"todo.stale"` |
| `desktop/frontend/src/styles.css` | -15 | Remove `.todobar__stale` |

---

## Testing / 测试

```
ok  internal/agent       5.520s
ok  internal/evidence    2.367s
ok  internal/tool/builtin 6.959s
ok  internal/cli         5.324s

# Cache guard tests all pass (zero cache impact):
ok  TestCacheHitPrefixStable        ✅
ok  TestCacheHitClimbsWithoutCompaction  ✅
ok  TestCompactRewriteVersionFeedsCacheDiagnostics  ✅
```

---

## Related / 关联

- Fixes #3469