### PR TITLE
UI 布局修复：标题栏压缩、滚动条对齐、composer 精简

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Thumbs.db
 # Scratch / agent working dirs (never committed)
 /tmp/
 /.codex/
+.alma-snapshots

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -21,9 +21,7 @@ import logoWordmark from "./assets/logo-wordmark.svg";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, t, useI18n, useT } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onProjectTreeChanged, onTurnDone, onEvent } from "./lib/bridge";
-import { playSuccessChime } from "./lib/sound";
-import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
+import { app, onProjectTreeChanged } from "./lib/bridge";
 import { Transcript } from "./components/Transcript";
 import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
@@ -62,7 +60,6 @@ import { applyTextSize, DEFAULT_TEXT_SIZE, getTextSize, nextTextSize } from "./l
 import { useWindowStatePersistence } from "./lib/windowState";
 
 const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
-const TAB_BAR_HIDDEN_KEY = "reasonix.desktop.tabBarHidden";
 const SIDEBAR_DEFAULT_WIDTH = 264;
 const SIDEBAR_DEFAULT_RATIO = 0.175;
 const SIDEBAR_MIN_WIDTH = 228;
@@ -144,15 +141,6 @@ function saveSidebarCollapsed(collapsed: boolean): void {
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
   } catch {
     /* ignore storage failures */
-  }
-}
-
-function loadTabBarHidden(): boolean {
-  if (typeof window === "undefined") return false;
-  try {
-    return window.localStorage.getItem(TAB_BAR_HIDDEN_KEY) === "1";
-  } catch {
-    return false;
   }
 }
 
@@ -391,7 +379,6 @@ export default function App() {
     restoreSession,
     purgeTrashedSession,
     renameSession,
-    markTopicRead,
     refreshMeta,
     pickWorkspace,
     switchWorkspace,
@@ -409,7 +396,8 @@ export default function App() {
   const t = useT();
   const [modesByTab, setModesByTab] = useState<Record<string, Mode>>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
-
+  const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
+  const [tabRevealSignal, setTabRevealSignal] = useState(0);
   const [startupSplashVisible, setStartupSplashVisible] = useState<boolean>(() => shouldShowStartupSplash());
   // null until the mount probe resolves; true shows the overlay. Probed once —
   // clearing the key mid-session is the Settings panel's job, not the gate's.
@@ -417,13 +405,6 @@ export default function App() {
   const [settingsTarget, setSettingsTarget] = useState<SettingsTab | null>(null);
   const [histView, setHistView] = useState<HistoryViewState | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(loadSidebarCollapsed);
-  const [tabBarHidden, setTabBarHidden] = useState(loadTabBarHidden);
-  useEffect(() => {
-    const handler = () => setTabBarHidden(loadTabBarHidden());
-    window.addEventListener("reasonix:tabbar-visibility-changed", handler);
-    return () => window.removeEventListener("reasonix:tabbar-visibility-changed", handler);
-  }, []);
-  const [tabRevealSignal, setTabRevealSignal] = useState(0);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [workspacePanelOpen, setWorkspacePanelOpen] = useState(true);
@@ -543,7 +524,6 @@ export default function App() {
     },
     [activeTabId],
   );
-  const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const topicbarEditing = Boolean(activeTab?.topicId && activeTab.topicId === renamingTopicId);
   const visibleTabId = activeTabId;
   const visibleTabs = useMemo(() => {
@@ -556,6 +536,7 @@ export default function App() {
       active: tab.id === visibleTabId,
     }));
   }, [modesByTab, tabMetas, tabOrderIds, visibleTabId]);
+
   useEffect(() => {
     const ids = tabMetas.map((tab) => tab.id);
     setTabOrderIds((current) => {
@@ -566,6 +547,7 @@ export default function App() {
       return next.join("\u0000") === current.join("\u0000") ? current : next;
     });
   }, [tabMetas]);
+
   useEffect(() => {
     const ids = new Set(tabMetas.map((tab) => tab.id));
     setModesByTab((current) => {
@@ -670,35 +652,6 @@ export default function App() {
     const id = window.setInterval(() => setTodoNow(Date.now()), 15000);
     return () => window.clearInterval(id);
   }, [showTodos]);
-
-  // Play a success chime when any turn finishes (agent:turn-done event).
-  useEffect(() => {
-    const unsub = onTurnDone(() => {
-      playSuccessChime();
-    });
-    return unsub;
-  }, []);
-
-  // Play generative ambient music while the agent is generating.
-  // Start/stop the AudioContext engine based on running state.
-  useEffect(() => {
-    if (state.running && isGenerativeMusicEnabled()) {
-      generativeMusic.start();
-    } else {
-      generativeMusic.stop();
-    }
-  }, [state.running]);
-
-  // Per-token: play a note every time a text/reasoning chunk arrives.
-  // playTokenNote() is a no-op when the engine isn't running.
-  useEffect(() => {
-    const unsub = onEvent((e) => {
-      if (e.kind === "text" || e.kind === "reasoning" || e.kind === "tool_dispatch") {
-        generativeMusic.playTokenNote();
-      }
-    });
-    return unsub;
-  }, []);
 
   const todoStale = useMemo(() => {
     if (!showTodos || !todoEntry) return false;
@@ -1081,12 +1034,9 @@ export default function App() {
 
   const handleTabChange = useCallback(async (id: string) => {
     await switchTab(id);
-    // Mark the topic as read when switching to a tab.
-    const tab = tabMetas.find((t) => t.id === id);
-    if (tab?.topicId) await markTopicRead(tab.topicId).catch(() => {});
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
-  }, [markTopicRead, refreshTabMetas, switchTab, tabMetas]);
+  }, [refreshTabMetas, switchTab]);
 
   const handleTabClose = useCallback(async (id: string) => {
     setModesByTab((current) => {
@@ -1110,37 +1060,6 @@ export default function App() {
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
   }, [activeTabId, closeTab, refreshTabMetas]);
-
-  const closeActiveTab = useCallback(() => {
-    if (!activeTabId || tabMetas.length <= 1) return;
-    void handleTabClose(activeTabId);
-  }, [activeTabId, handleTabClose, tabMetas.length]);
-
-  useEffect(() => {
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "k") return;
-      event.preventDefault();
-      setPaletteOpen((open) => !open);
-    };
-    window.addEventListener("keydown", onKeyDown, { capture: true });
-    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
-  }, []);
-
-  useEffect(() => {
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "w") return;
-      event.preventDefault();
-      closeActiveTab();
-    };
-    window.addEventListener("keydown", onKeyDown, { capture: true });
-    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
-  }, [closeActiveTab]);
-
-
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.runtime) return;
-    return window.runtime.EventsOn("app:close-active-tab", closeActiveTab);
-  }, [closeActiveTab]);
 
   const handleTabsClose = useCallback(async (ids: string[], nextActiveTabId?: string) => {
     const currentIds = tabMetas.map((tab) => tab.id);
@@ -1183,11 +1102,23 @@ export default function App() {
     setTabRevealSignal((signal) => signal + 1);
   }, [activeTab?.scope, activeTab?.workspaceRoot, openGlobalTab, openProjectTab, refreshTabMetas, state.meta?.cwd]);
 
+  // ── Command palette (⌘K) ────────────────────────────────────────────
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "k") return;
+      event.preventDefault();
+      setPaletteOpen((open) => !open);
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, []);
+
   const handleMessageAction = useCallback(async (turn: number, scope: string) => {
     await rewind(turn, scope);
     if (scope === "fork") {
       await refreshTabMetas();
       setProjectRevision((value) => value + 1);
+      setTabRevealSignal((signal) => signal + 1);
       return;
     }
     if (scope === "code" || scope === "both") {
@@ -1202,74 +1133,9 @@ export default function App() {
     } else {
       await openProjectTab(workspaceRoot, topicId);
     }
-    if (topicId) await markTopicRead(topicId);
     await refreshTabMetas();
-  }, [markTopicRead, openGlobalTab, openProjectTab, refreshTabMetas]);
-
-  // ⌘G: jump to the next unread topic that is not currently running
-  useEffect(() => {
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "g") return;
-      event.preventDefault();
-
-      const findNextUnread = async () => {
-        try {
-          const tree = await app.ListProjectTree();
-          const nodes = asArray(tree);
-
-          // Flatten: collect topic / global_topic nodes in tree order
-          const topics: { scope: string; root: string; topicId: string; running?: boolean; hasUnread?: boolean }[] = [];
-          for (const node of nodes) {
-            const children = asArray(node.children);
-            for (const child of children) {
-              if (child.kind === "topic" || child.kind === "global_topic") {
-                topics.push({
-                  scope: child.kind === "global_topic" ? "global" : "project",
-                  root: child.root ?? "",
-                  topicId: child.topicId ?? "",
-                  running: child.running,
-                  hasUnread: child.hasUnread,
-                });
-              }
-            }
-          }
-
-          if (topics.length === 0) return;
-
-          // Start looking after the current topic (or from the beginning)
-          const currentId = activeTab?.topicId;
-          const startIndex = currentId ? topics.findIndex((t) => t.topicId === currentId) + 1 : 0;
-
-          // Priority 1: unread + not running (stopped generating but unread)
-          for (let i = 0; i < topics.length; i++) {
-            const idx = (startIndex + i) % topics.length;
-            const topic = topics[idx];
-            if (topic.hasUnread && !topic.running) {
-              await handleOpenTopic(topic.scope, topic.root, topic.topicId);
-              return;
-            }
-          }
-
-          // Priority 2: running (currently generating)
-          for (let i = 0; i < topics.length; i++) {
-            const idx = (startIndex + i) % topics.length;
-            const topic = topics[idx];
-            if (topic.running) {
-              await handleOpenTopic(topic.scope, topic.root, topic.topicId);
-              return;
-            }
-          }
-        } catch {
-          /* bridge unavailable */
-        }
-      };
-
-      void findNextUnread();
-    };
-
-    window.addEventListener("keydown", onKeyDown, { capture: true });
-    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
-  }, [activeTab, handleOpenTopic]);
+    setTabRevealSignal((signal) => signal + 1);
+  }, [openGlobalTab, openProjectTab, refreshTabMetas]);
 
   // History drawer: project menus can open a scoped saved-session list. Idle row
   // clicks resume; running row clicks only preview through PreviewSession.
@@ -1285,7 +1151,7 @@ export default function App() {
   }, [listTrashedSessions]);
   const closeHistory = useCallback(() => setHistView(null), []);
 
-  // ── Command palette (⌘K) ────────────────────────────────────────────
+  // ── Command palette (⌘K) item builder ───────────────────────────────
   const buildPaletteItems = useCallback((): PaletteItem[] => {
     const items: PaletteItem[] = [];
 
@@ -1347,6 +1213,7 @@ export default function App() {
       await resumeSession(session.path, targetTab?.id);
       if (targetTab) {
         await refreshTabMetas();
+        setTabRevealSignal((signal) => signal + 1);
       }
     },
     [openGlobalTab, openProjectTab, refreshTabMetas, state.running, resumeSession],
@@ -1526,7 +1393,7 @@ export default function App() {
             {sidebarCollapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
           </button>
           <div className="app-chrome__identity" aria-label="Reasonix">
-            <img src={logoWordmark} alt="" className="app-chrome__logo" />
+            <img src={logoWordmark} alt="" className="app-chrome__logo" draggable={false} />
             <span className="app-chrome__separator">/</span>
             <span className="app-chrome__scope">{appChromeScopeLabel(activeTab, state.meta)}</span>
           </div>
@@ -1609,7 +1476,6 @@ export default function App() {
         />
 
         <section className="chat-pane">
-          {!tabBarHidden && (
           <header className="workspace-tabs-bar">
             <TabBar
               tabs={visibleTabs}
@@ -1641,7 +1507,8 @@ export default function App() {
               </Tooltip>
             )}
           </header>
-          )}
+
+          <>
           <header className="topicbar">
             <div className="topicbar__identity">
               <div className="topicbar__title-row">
@@ -1716,21 +1583,9 @@ export default function App() {
                   </div>
                 )}
               </div>
-              {tabBarHidden && !workspacePanelMaximized && (
-                <Tooltip label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}>
-                  <button
-                    className="topicbar__action-btn topicbar__action-btn--icon"
-                    type="button"
-                    onClick={workspacePanelRenderable ? closeWorkspacePanel : () => openWorkspacePanel("files")}
-                    aria-label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}
-                    aria-pressed={workspacePanelRenderable}
-                  >
-                    {workspacePanelRenderable ? <PanelRightClose size={15} /> : <PanelRightOpen size={15} />}
-                  </button>
-                </Tooltip>
-              )}
             </div>
           </header>
+
           {state.meta?.startupErr && (
             <div className="banner banner--error">{t("topbar.startupError", { msg: state.meta.startupErr })}</div>
           )}
@@ -1818,6 +1673,7 @@ export default function App() {
               turnTokens={state.turnTokens}
             />
           </footer>
+          </>
         </section>
 
         {workspacePanelGridOpen && (
@@ -1946,8 +1802,8 @@ export default function App() {
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}
         items={buildPaletteItems()}
-        placeholder={t("topbar.newSession") + "..."}
-        emptyText={t("sidebar.conversations")}
+        placeholder="Quick actions…"
+        emptyText="No matches"
       />
     </div>
     </ShellExpandProvider>

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -21,7 +21,9 @@ import logoWordmark from "./assets/logo-wordmark.svg";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, t, useI18n, useT } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onProjectTreeChanged } from "./lib/bridge";
+import { app, onProjectTreeChanged, onTurnDone, onEvent } from "./lib/bridge";
+import { playSuccessChime } from "./lib/sound";
+import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { Transcript } from "./components/Transcript";
 import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
@@ -60,6 +62,7 @@ import { applyTextSize, DEFAULT_TEXT_SIZE, getTextSize, nextTextSize } from "./l
 import { useWindowStatePersistence } from "./lib/windowState";
 
 const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
+const TAB_BAR_HIDDEN_KEY = "reasonix.desktop.tabBarHidden";
 const SIDEBAR_DEFAULT_WIDTH = 264;
 const SIDEBAR_DEFAULT_RATIO = 0.175;
 const SIDEBAR_MIN_WIDTH = 228;
@@ -141,6 +144,15 @@ function saveSidebarCollapsed(collapsed: boolean): void {
     window.localStorage.setItem(SIDEBAR_COLLAPSED_KEY, collapsed ? "1" : "0");
   } catch {
     /* ignore storage failures */
+  }
+}
+
+function loadTabBarHidden(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(TAB_BAR_HIDDEN_KEY) === "1";
+  } catch {
+    return false;
   }
 }
 
@@ -379,6 +391,7 @@ export default function App() {
     restoreSession,
     purgeTrashedSession,
     renameSession,
+    markTopicRead,
     refreshMeta,
     pickWorkspace,
     switchWorkspace,
@@ -396,8 +409,7 @@ export default function App() {
   const t = useT();
   const [modesByTab, setModesByTab] = useState<Record<string, Mode>>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
-  const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
-  const [tabRevealSignal, setTabRevealSignal] = useState(0);
+
   const [startupSplashVisible, setStartupSplashVisible] = useState<boolean>(() => shouldShowStartupSplash());
   // null until the mount probe resolves; true shows the overlay. Probed once —
   // clearing the key mid-session is the Settings panel's job, not the gate's.
@@ -405,6 +417,13 @@ export default function App() {
   const [settingsTarget, setSettingsTarget] = useState<SettingsTab | null>(null);
   const [histView, setHistView] = useState<HistoryViewState | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(loadSidebarCollapsed);
+  const [tabBarHidden, setTabBarHidden] = useState(loadTabBarHidden);
+  useEffect(() => {
+    const handler = () => setTabBarHidden(loadTabBarHidden());
+    window.addEventListener("reasonix:tabbar-visibility-changed", handler);
+    return () => window.removeEventListener("reasonix:tabbar-visibility-changed", handler);
+  }, []);
+  const [tabRevealSignal, setTabRevealSignal] = useState(0);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [workspacePanelOpen, setWorkspacePanelOpen] = useState(true);
@@ -524,8 +543,8 @@ export default function App() {
     },
     [activeTabId],
   );
+  const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const topicbarEditing = Boolean(activeTab?.topicId && activeTab.topicId === renamingTopicId);
-  const topicbarProjectPrefix = activeTab ? tabWorkspaceTitle(activeTab) : "";
   const visibleTabId = activeTabId;
   const visibleTabs = useMemo(() => {
     const byId = new Map(tabMetas.map((tab) => [tab.id, tab]));
@@ -537,7 +556,6 @@ export default function App() {
       active: tab.id === visibleTabId,
     }));
   }, [modesByTab, tabMetas, tabOrderIds, visibleTabId]);
-
   useEffect(() => {
     const ids = tabMetas.map((tab) => tab.id);
     setTabOrderIds((current) => {
@@ -548,7 +566,6 @@ export default function App() {
       return next.join("\u0000") === current.join("\u0000") ? current : next;
     });
   }, [tabMetas]);
-
   useEffect(() => {
     const ids = new Set(tabMetas.map((tab) => tab.id));
     setModesByTab((current) => {
@@ -653,6 +670,35 @@ export default function App() {
     const id = window.setInterval(() => setTodoNow(Date.now()), 15000);
     return () => window.clearInterval(id);
   }, [showTodos]);
+
+  // Play a success chime when any turn finishes (agent:turn-done event).
+  useEffect(() => {
+    const unsub = onTurnDone(() => {
+      playSuccessChime();
+    });
+    return unsub;
+  }, []);
+
+  // Play generative ambient music while the agent is generating.
+  // Start/stop the AudioContext engine based on running state.
+  useEffect(() => {
+    if (state.running && isGenerativeMusicEnabled()) {
+      generativeMusic.start();
+    } else {
+      generativeMusic.stop();
+    }
+  }, [state.running]);
+
+  // Per-token: play a note every time a text/reasoning chunk arrives.
+  // playTokenNote() is a no-op when the engine isn't running.
+  useEffect(() => {
+    const unsub = onEvent((e) => {
+      if (e.kind === "text" || e.kind === "reasoning" || e.kind === "tool_dispatch") {
+        generativeMusic.playTokenNote();
+      }
+    });
+    return unsub;
+  }, []);
 
   const todoStale = useMemo(() => {
     if (!showTodos || !todoEntry) return false;
@@ -1035,9 +1081,12 @@ export default function App() {
 
   const handleTabChange = useCallback(async (id: string) => {
     await switchTab(id);
+    // Mark the topic as read when switching to a tab.
+    const tab = tabMetas.find((t) => t.id === id);
+    if (tab?.topicId) await markTopicRead(tab.topicId).catch(() => {});
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
-  }, [refreshTabMetas, switchTab]);
+  }, [markTopicRead, refreshTabMetas, switchTab, tabMetas]);
 
   const handleTabClose = useCallback(async (id: string) => {
     setModesByTab((current) => {
@@ -1061,6 +1110,37 @@ export default function App() {
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
   }, [activeTabId, closeTab, refreshTabMetas]);
+
+  const closeActiveTab = useCallback(() => {
+    if (!activeTabId || tabMetas.length <= 1) return;
+    void handleTabClose(activeTabId);
+  }, [activeTabId, handleTabClose, tabMetas.length]);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "k") return;
+      event.preventDefault();
+      setPaletteOpen((open) => !open);
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "w") return;
+      event.preventDefault();
+      closeActiveTab();
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, [closeActiveTab]);
+
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.runtime) return;
+    return window.runtime.EventsOn("app:close-active-tab", closeActiveTab);
+  }, [closeActiveTab]);
 
   const handleTabsClose = useCallback(async (ids: string[], nextActiveTabId?: string) => {
     const currentIds = tabMetas.map((tab) => tab.id);
@@ -1103,23 +1183,11 @@ export default function App() {
     setTabRevealSignal((signal) => signal + 1);
   }, [activeTab?.scope, activeTab?.workspaceRoot, openGlobalTab, openProjectTab, refreshTabMetas, state.meta?.cwd]);
 
-  // ── Command palette (⌘K) ────────────────────────────────────────────
-  useEffect(() => {
-    const onKeyDown = (event: globalThis.KeyboardEvent) => {
-      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "k") return;
-      event.preventDefault();
-      setPaletteOpen((open) => !open);
-    };
-    window.addEventListener("keydown", onKeyDown, { capture: true });
-    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
-  }, []);
-
   const handleMessageAction = useCallback(async (turn: number, scope: string) => {
     await rewind(turn, scope);
     if (scope === "fork") {
       await refreshTabMetas();
       setProjectRevision((value) => value + 1);
-      setTabRevealSignal((signal) => signal + 1);
       return;
     }
     if (scope === "code" || scope === "both") {
@@ -1134,9 +1202,74 @@ export default function App() {
     } else {
       await openProjectTab(workspaceRoot, topicId);
     }
+    if (topicId) await markTopicRead(topicId);
     await refreshTabMetas();
-    setTabRevealSignal((signal) => signal + 1);
-  }, [openGlobalTab, openProjectTab, refreshTabMetas]);
+  }, [markTopicRead, openGlobalTab, openProjectTab, refreshTabMetas]);
+
+  // ⌘G: jump to the next unread topic that is not currently running
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey || event.key.toLowerCase() !== "g") return;
+      event.preventDefault();
+
+      const findNextUnread = async () => {
+        try {
+          const tree = await app.ListProjectTree();
+          const nodes = asArray(tree);
+
+          // Flatten: collect topic / global_topic nodes in tree order
+          const topics: { scope: string; root: string; topicId: string; running?: boolean; hasUnread?: boolean }[] = [];
+          for (const node of nodes) {
+            const children = asArray(node.children);
+            for (const child of children) {
+              if (child.kind === "topic" || child.kind === "global_topic") {
+                topics.push({
+                  scope: child.kind === "global_topic" ? "global" : "project",
+                  root: child.root ?? "",
+                  topicId: child.topicId ?? "",
+                  running: child.running,
+                  hasUnread: child.hasUnread,
+                });
+              }
+            }
+          }
+
+          if (topics.length === 0) return;
+
+          // Start looking after the current topic (or from the beginning)
+          const currentId = activeTab?.topicId;
+          const startIndex = currentId ? topics.findIndex((t) => t.topicId === currentId) + 1 : 0;
+
+          // Priority 1: unread + not running (stopped generating but unread)
+          for (let i = 0; i < topics.length; i++) {
+            const idx = (startIndex + i) % topics.length;
+            const topic = topics[idx];
+            if (topic.hasUnread && !topic.running) {
+              await handleOpenTopic(topic.scope, topic.root, topic.topicId);
+              return;
+            }
+          }
+
+          // Priority 2: running (currently generating)
+          for (let i = 0; i < topics.length; i++) {
+            const idx = (startIndex + i) % topics.length;
+            const topic = topics[idx];
+            if (topic.running) {
+              await handleOpenTopic(topic.scope, topic.root, topic.topicId);
+              return;
+            }
+          }
+        } catch {
+          /* bridge unavailable */
+        }
+      };
+
+      void findNextUnread();
+    };
+
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, [activeTab, handleOpenTopic]);
 
   // History drawer: project menus can open a scoped saved-session list. Idle row
   // clicks resume; running row clicks only preview through PreviewSession.
@@ -1152,7 +1285,7 @@ export default function App() {
   }, [listTrashedSessions]);
   const closeHistory = useCallback(() => setHistView(null), []);
 
-  // ── Command palette (⌘K) item builder ───────────────────────────────
+  // ── Command palette (⌘K) ────────────────────────────────────────────
   const buildPaletteItems = useCallback((): PaletteItem[] => {
     const items: PaletteItem[] = [];
 
@@ -1214,7 +1347,6 @@ export default function App() {
       await resumeSession(session.path, targetTab?.id);
       if (targetTab) {
         await refreshTabMetas();
-        setTabRevealSignal((signal) => signal + 1);
       }
     },
     [openGlobalTab, openProjectTab, refreshTabMetas, state.running, resumeSession],
@@ -1394,7 +1526,7 @@ export default function App() {
             {sidebarCollapsed ? <PanelLeftOpen size={16} /> : <PanelLeftClose size={16} />}
           </button>
           <div className="app-chrome__identity" aria-label="Reasonix">
-            <img src={logoWordmark} alt="" className="app-chrome__logo" draggable={false} />
+            <img src={logoWordmark} alt="" className="app-chrome__logo" />
             <span className="app-chrome__separator">/</span>
             <span className="app-chrome__scope">{appChromeScopeLabel(activeTab, state.meta)}</span>
           </div>
@@ -1477,6 +1609,7 @@ export default function App() {
         />
 
         <section className="chat-pane">
+          {!tabBarHidden && (
           <header className="workspace-tabs-bar">
             <TabBar
               tabs={visibleTabs}
@@ -1508,16 +1641,12 @@ export default function App() {
               </Tooltip>
             )}
           </header>
-
-          <>
+          )}
           <header className="topicbar">
             <div className="topicbar__identity">
               <div className="topicbar__title-row">
                 {topicbarEditing ? (
                   <div className="topicbar__title-edit">
-                    {topicbarProjectPrefix && (
-                      <span className="topicbar__title-prefix">{topicbarProjectPrefix} /</span>
-                    )}
                     <input
                       autoFocus
                       className="topicbar__title-input"
@@ -1537,7 +1666,7 @@ export default function App() {
                     />
                   </div>
                 ) : (
-                  <h1>{topicTitle(activeTab)}</h1>
+                  <h1>{activeTab?.topicTitle || "Untitled"}</h1>
                 )}
                 <Tooltip label={t("topicBar.renameSession")}>
                   <button
@@ -1587,9 +1716,21 @@ export default function App() {
                   </div>
                 )}
               </div>
+              {tabBarHidden && !workspacePanelMaximized && (
+                <Tooltip label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}>
+                  <button
+                    className="topicbar__action-btn topicbar__action-btn--icon"
+                    type="button"
+                    onClick={workspacePanelRenderable ? closeWorkspacePanel : () => openWorkspacePanel("files")}
+                    aria-label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}
+                    aria-pressed={workspacePanelRenderable}
+                  >
+                    {workspacePanelRenderable ? <PanelRightClose size={15} /> : <PanelRightOpen size={15} />}
+                  </button>
+                </Tooltip>
+              )}
             </div>
           </header>
-
           {state.meta?.startupErr && (
             <div className="banner banner--error">{t("topbar.startupError", { msg: state.meta.startupErr })}</div>
           )}
@@ -1663,9 +1804,6 @@ export default function App() {
 	              disabled={state.meta?.ready === false || state.messageAction != null || state.approval != null || state.ask != null}
 	              decisionPending={state.messageAction != null || state.approval != null || state.ask != null}
               ready={state.meta?.ready === true}
-              turnStartAt={state.turnStartAt}
-              turnTokens={state.turnTokens}
-              retry={state.retry}
               workspaceRefreshSignal={projectRevision}
             />
             <StatusBar
@@ -1677,9 +1815,9 @@ export default function App() {
               mode={mode}
               cost={state.sessionCost}
               currency={state.sessionCurrency}
+              turnTokens={state.turnTokens}
             />
           </footer>
-          </>
         </section>
 
         {workspacePanelGridOpen && (
@@ -1808,8 +1946,8 @@ export default function App() {
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}
         items={buildPaletteItems()}
-        placeholder="Quick actions…"
-        emptyText="No matches"
+        placeholder={t("topbar.newSession") + "..."}
+        emptyText={t("sidebar.conversations")}
       />
     </div>
     </ShellExpandProvider>

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -4,7 +4,7 @@ import { AlertTriangle, ArrowUp, Check, ChevronDown, Eye, FileText, Folder, Fold
 import { asArray } from "../lib/array";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
 import { app, onFilesDropped } from "../lib/bridge";
-import { SPINNER_WORDS, useI18n } from "../lib/i18n";
+import { useI18n } from "../lib/i18n";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import type { CommandInfo, ComposerInsertRequest, DirEntry, EffortInfo, HistoryMessage, Mode, SessionMeta, SessionReference, SlashArgItem, SlashArgsResult, WorkspaceView } from "../lib/types";
 import {
@@ -95,18 +95,6 @@ function loadComposerHeight(): number | null {
   return loadOptionalLayoutSize("composerHeight", clampComposerHeight);
 }
 
-function fmtTokens(n: number): string {
-  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
-  return String(n);
-}
-
-function fmtElapsed(ms: number): string {
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return `${s}s`;
-  return `${Math.floor(s / 60)}m ${s % 60}s`;
-}
-
-// --- past:chats hover preview helpers (PR-C2) ---
 // Pure formatting helpers used by the past:chats list tooltip. They never read
 // from disk, never call PreviewSession — they only shape the data that already
 // lives in the SessionMeta snapshot we fetched on entry.
@@ -132,16 +120,6 @@ function fmtSessionTime(value?: number): string {
 
 function pastChatTitle(session: SessionMeta): string {
   return session.title || session.topicTitle || session.preview || "Untitled";
-}
-
-function useTick(on: boolean): number {
-  const [, setN] = useState(0);
-  useEffect(() => {
-    if (!on) return;
-    const id = window.setInterval(() => setN((n) => n + 1), 1000);
-    return () => window.clearInterval(id);
-  }, [on]);
-  return Date.now();
 }
 
 function isImeKeyEvent(
@@ -265,9 +243,6 @@ export function Composer({
   disabled,
   decisionPending = false,
   ready,
-  turnStartAt,
-  turnTokens,
-  retry,
   workspaceRefreshSignal,
 }: {
   running: boolean;
@@ -294,13 +269,9 @@ export function Composer({
   // is nil before then), the available set changes when the workspace switches,
   // and a completed turn may have installed skills or MCP prompts.
   ready?: boolean;
-  turnStartAt?: number;
-  turnTokens?: number;
-  retry?: { attempt: number; max: number };
   workspaceRefreshSignal?: number;
 }) {
-  const { t, locale } = useI18n();
-  const now = useTick(running);
+  const { t } = useI18n();
   const [text, setText] = useState("");
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [workspaceRefs, setWorkspaceRefs] = useState<WorkspaceReference[]>([]);
@@ -1267,17 +1238,6 @@ export function Composer({
     { id: "plan", label: "plan", icon: <List size={13} /> },
     { id: "yolo", label: "yolo", icon: <AlertTriangle size={13} /> },
   ];
-  const runActivity = retry
-    ? t("status.retrying", { attempt: retry.attempt, max: retry.max })
-    : running && turnStartAt
-      ? (() => {
-          const elapsedMs = Math.max(0, now - turnStartAt);
-          const words = SPINNER_WORDS[locale];
-          const word = words[Math.floor(elapsedMs / 3000) % words.length];
-          const tok = turnTokens && turnTokens > 0 ? ` · ↓ ${fmtTokens(turnTokens)} ${t("status.tokens")}` : "";
-          return `${word}… ${fmtElapsed(elapsedMs)}${tok}`;
-        })()
-      : null;
   const hasWorkspace = Boolean(cwd);
   const hasEffort = Boolean(effort?.supported);
   const composerMetaClass = [
@@ -1502,35 +1462,6 @@ export function Composer({
           />
         )
       )}
-      <div className="composer-toolbar">
-        <div className="composer-modebar" role="toolbar" aria-label={t("composer.modeTitle")}>
-          {modeOptions.map((option) => (
-            <button
-              key={option.id}
-              type="button"
-              className={`composer-modebar__item composer-modebar__item--${option.id}${mode === option.id ? " composer-modebar__item--active" : ""}`}
-              onClick={() => onSetMode(option.id)}
-              aria-pressed={mode === option.id}
-              disabled={disabled || running}
-            >
-              {option.icon}
-              <span>{option.label}</span>
-            </button>
-          ))}
-        </div>
-        {runActivity && (
-          <div className="composer-runstatus" role="status" aria-live="polite">
-            <span className="composer-runstatus__dot" />
-            <span className="composer-runstatus__text">{runActivity}</span>
-            <Tooltip label={t("composer.stop")}>
-              <button className="composer-runstatus__stop" type="button" onClick={handleCancel} disabled={decisionPending}>
-                <Square size={10} fill="currentColor" />
-                <span>{t("composer.stopShort")}</span>
-              </button>
-            </Tooltip>
-          </div>
-        )}
-      </div>
       {(attachments.length > 0 || workspaceRefs.length > 0 || sessionRefs.length > 0) && (
         <div className="composer-context" aria-label={t("composer.contextItems")}>
           {attachments.map((a) => (
@@ -1654,7 +1585,6 @@ export function Composer({
           onDragOver={onDragOver}
           onDragLeave={onDragLeave}
         >
-          <span className="composer__caret">{text.trimStart().startsWith("!") ? "$" : "›"}</span>
           <textarea
             ref={taRef}
             className="composer__input"
@@ -1678,17 +1608,6 @@ export function Composer({
             rows={1}
             disabled={disabled}
           />
-          {!running && (
-            <Tooltip label={t("composer.send")}>
-              <button
-                className="composer__btn composer__btn--send"
-                onClick={submit}
-                disabled={submitting || pendingPaste > 0 || (!text.trim() && attachments.length === 0 && workspaceRefs.length === 0) || disabled}
-              >
-                <ArrowUp size={16} />
-              </button>
-            </Tooltip>
-          )}
         </div>
         <div className={composerMetaClass}>
           {cwd && (
@@ -1706,6 +1625,25 @@ export function Composer({
               </button>
             </div>
           )}
+          <div className="composer-modebar" role="toolbar" aria-label={t("composer.modeTitle")}>
+            {modeOptions.map((option) => {
+              const isActive = mode === option.id;
+              const btn = (
+                <button
+                  key={option.id}
+                  type="button"
+                  className={`composer-modebar__item composer-modebar__item--${option.id}${isActive ? " composer-modebar__item--active" : ""}`}
+                  onClick={() => onSetMode(option.id)}
+                  aria-pressed={isActive}
+                  disabled={disabled || running}
+                >
+                  {option.icon}
+                  {isActive && <span>{option.label}</span>}
+                </button>
+              );
+              return isActive ? btn : <Tooltip key={option.id} label={option.label}>{btn}</Tooltip>;
+            })}
+          </div>
           <div className="composer-meta__params">
             <div className="composer-meta__control composer-meta__control--model">
               <ModelSwitcher label={modelLabel} tabId={tabId} onPick={onSwitchModel} />
@@ -1714,6 +1652,25 @@ export function Composer({
               <div className="composer-meta__control composer-meta__control--effort">
                 <EffortSwitcher effort={effort} disabled={running} onPick={onSetEffort} />
               </div>
+            )}
+          </div>
+          <div className="composer-meta__stop-wrap">
+            {running ? (
+              <Tooltip label={t("composer.stop")}>
+                <button className="composer-meta__action-btn composer-meta__action-btn--stop" type="button" onClick={handleCancel} disabled={decisionPending}>
+                  <Square size={14} fill="currentColor" />
+                </button>
+              </Tooltip>
+            ) : (
+              <Tooltip label={t("composer.send")}>
+                <button
+                  className="composer-meta__action-btn composer-meta__action-btn--send"
+                  onClick={submit}
+                  disabled={submitting || pendingPaste > 0 || (!text.trim() && attachments.length === 0 && workspaceRefs.length === 0) || disabled}
+                >
+                  <ArrowUp size={16} />
+                </button>
+              </Tooltip>
             )}
           </div>
         </div>

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -252,7 +252,6 @@ export const AssistantMessage = memo(function AssistantMessage({
           tone="violet"
           icon={<ProcessBrainIcon size={12} />}
           kind="reasoning"
-          name={t("msg.thinking")}
           meta={
             <>
               <ProcessStatusIcon state={item.streaming ? "running" : "done"} label={item.streaming ? t("msg.thinkingRunning") : t("msg.thinkingDone")} />

--- a/desktop/frontend/src/components/ProcessCard.tsx
+++ b/desktop/frontend/src/components/ProcessCard.tsx
@@ -1,4 +1,5 @@
 import { Children, type ReactNode, type SVGProps, useState } from "react";
+import { BrainCircuit } from "lucide-react";
 
 type IconProps = SVGProps<SVGSVGElement> & { size?: number };
 export type ProcessTone = "default" | "success" | "warning" | "danger" | "accent" | "violet";
@@ -47,19 +48,14 @@ export function ProcessXIcon(props: IconProps) {
   );
 }
 
-export function ProcessBrainIcon(props: IconProps) {
-  return (
-    <ProcessIcon {...props}>
-      <path d="M9 4a3 3 0 0 0-3 3v0a3 3 0 0 0-2 5 3 3 0 0 0 2 5 3 3 0 0 0 3 3h0a3 3 0 0 0 3-3V4" />
-      <path d="M15 4a3 3 0 0 1 3 3 3 3 0 0 1 2 5 3 3 0 0 1-2 5 3 3 0 0 1-3 3" />
-    </ProcessIcon>
-  );
+export function ProcessBrainIcon({ size = 14, ...rest }: IconProps) {
+  return <BrainCircuit size={size} strokeWidth={1.8} {...rest} />;
 }
 
 export function ProcessToolIcon(props: IconProps) {
   return (
     <ProcessIcon {...props}>
-      <path d="M14 7a4 4 0 1 0 4 4l3 3-3 3-3-3a4 4 0 0 1-4-4l-3-3-3 3 3 3a4 4 0 0 0 6 0" />
+      <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
     </ProcessIcon>
   );
 }

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { Check, ChevronDown, Play, X } from "lucide-react";
+import { Check, ChevronDown, X } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { normalizeLangPref, useI18n, useT, type DictKey, type LangPref } from "../lib/i18n";
@@ -25,8 +25,6 @@ import { Tooltip } from "./Tooltip";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { MCPServersSettingsPage, SkillsSettingsPage } from "./CapabilitiesPanel";
 import { MemorySettingsPage } from "./MemoryPanel";
-import { getSuccessPreference, setSuccessPreference, getAttentionPreference, setAttentionPreference, playSuccessChime, playAttentionChime, type SoundWavPref } from "../lib/sound";
-import { getGenerativePreset, setGenerativePreset, generativeMusic, type GenerativePreset } from "../lib/generative-music";
 
 const SETTINGS_TABS: SettingsTab[] = ["general", "models", "mcp", "skills", "memory", "permissions", "sandbox", "network", "appearance", "updates"];
 
@@ -402,7 +400,9 @@ function normalizeSettingsView(view: SettingsView | null | undefined): SettingsV
     noProxy: "",
     proxy: { type: "socks5", server: "", port: 0, username: "", password: "" },
   };
-  const agent = view.agent ?? { temperature: 0, maxSteps: 0, systemPrompt: "" };
+  const agent = view.agent ?? { temperature: 0, maxSteps: 0, plannerMaxSteps: 12, systemPrompt: "" };
+  agent.plannerMaxSteps = Number.isFinite(agent.plannerMaxSteps) ? Math.max(0, Math.trunc(agent.plannerMaxSteps)) : 12;
+  agent.maxSteps = Number.isFinite(agent.maxSteps) ? Math.max(0, Math.trunc(agent.maxSteps)) : 0;
   return {
     ...view,
     providers: asArray(view.providers).map((p) => ({
@@ -481,9 +481,6 @@ function GeneralSection({ s, busy, apply }: SectionProps) {
   const closeBehavior = normalizeCloseBehavior(s.closeBehavior);
   const autoPlan = normalizeAutoPlan(s.autoPlan);
   const languagePref = normalizeLangPref(s.desktopLanguage);
-  const [soundPref, setSoundPref] = useState<SoundWavPref>(getSuccessPreference());
-  const [attentionPref, setAttentionPref] = useState<SoundWavPref>(getAttentionPreference());
-  const [genMusicPreset, setGenMusicPreset] = useState<GenerativePreset>(getGenerativePreset());
   const setLanguage = (next: LangPref) => {
     setPref(next);
     void apply(() => app.SetDesktopLanguage(next));
@@ -532,93 +529,82 @@ function GeneralSection({ s, busy, apply }: SectionProps) {
           ))}
         </div>
       </SettingsField>
-      <SettingsField label={t("settings.notificationSound")} hint={t("settings.notificationSoundHint")} stacked>
-        <div className="settings-notification-sound-row">
-          <span>{t("settings.notificationSoundSuccess")}</span>
-          <select
-            className="mem-select"
-            value={soundPref}
-            onChange={(e) => {
-              const next = e.target.value as SoundWavPref;
-              setSoundPref(next);
-              setSuccessPreference(next);
-              playSuccessChime();
-            }}
-          >
-            <option value="synth">{t("settings.notificationSound.synth")}</option>
-            <option value="positive">{t("settings.notificationSound.positive")}</option>
-            <option value="correct">{t("settings.notificationSound.correct")}</option>
-            <option value="start">{t("settings.notificationSound.start")}</option>
-            <option value="back">{t("settings.notificationSound.back")}</option>
-          </select>
-          <button
-            className="chip"
-            type="button"
-            onClick={() => playSuccessChime()}
-            title={t("settings.notificationSoundPreview")}
-          >
-            <Play size={13} />
-          </button>
-        </div>
-        <div className="settings-notification-sound-row" style={{ marginTop: 6 }}>
-          <span>{t("settings.notificationSoundAttention")}</span>
-          <select
-            className="mem-select"
-            value={attentionPref}
-            onChange={(e) => {
-              const next = e.target.value as SoundWavPref;
-              setAttentionPref(next);
-              setAttentionPreference(next);
-              playAttentionChime();
-            }}
-          >
-            <option value="synth">{t("settings.notificationSound.synth")}</option>
-            <option value="positive">{t("settings.notificationSound.positive")}</option>
-            <option value="correct">{t("settings.notificationSound.correct")}</option>
-            <option value="start">{t("settings.notificationSound.start")}</option>
-            <option value="back">{t("settings.notificationSound.back")}</option>
-          </select>
-          <button
-            className="chip"
-            type="button"
-            onClick={() => playAttentionChime()}
-            title={t("settings.notificationSoundPreview")}
-          >
-            <Play size={13} />
-          </button>
-        </div>
-      </SettingsField>
-      <SettingsField label={t("settings.generativeMusic")} hint={t("settings.generativeMusicHint")} stacked>
-        <div className="settings-notification-sound-row">
-          <span>{t("settings.generativeMusicPreset")}</span>
-          <select
-            className="mem-select"
-            value={genMusicPreset}
-            onChange={(e) => {
-              const next = e.target.value as GenerativePreset;
-              setGenMusicPreset(next);
-              setGenerativePreset(next);
-              if (next !== "off") generativeMusic.playPreview(next);
-            }}
-          >
-            <option value="off">{t("settings.generativeMusic.off")}</option>
-            <option value="classic">{t("settings.generativeMusic.presets.classic")}</option>
-            <option value="ethereal">{t("settings.generativeMusic.presets.ethereal")}</option>
-            <option value="digital">{t("settings.generativeMusic.presets.digital")}</option>
-            <option value="retro">{t("settings.generativeMusic.presets.retro")}</option>
-          </select>
-          <button
-            className="chip"
-            type="button"
-            onClick={() => { if (genMusicPreset !== "off") generativeMusic.playPreview(genMusicPreset); }}
-            title={t("settings.generativeMusicPreview")}
-          >
-            <Play size={13} />
-          </button>
-        </div>
-      </SettingsField>
     </SettingsSection>
   );
+}
+
+function StepLimitControl({
+  value,
+  presets,
+  busy,
+  onChange,
+}: {
+  value: number;
+  presets: number[];
+  busy: boolean;
+  onChange: (value: number) => void;
+}) {
+  const t = useT();
+  const normalized = normalizeStepLimit(value);
+  const presetSet = new Set(presets.map(normalizeStepLimit));
+  const [custom, setCustom] = useState(String(normalized));
+  useEffect(() => setCustom(String(normalized)), [normalized]);
+  const isCustom = !presetSet.has(normalized);
+  const commitCustom = () => {
+    const next = normalizeStepLimit(Number(custom));
+    setCustom(String(next));
+    if (next !== normalized) onChange(next);
+  };
+  return (
+    <div className="step-limit-control">
+      <div className="set-seg">
+        {presets.map((preset) => {
+          const n = normalizeStepLimit(preset);
+          return (
+            <button
+              key={n}
+              type="button"
+              className={`set-seg__btn${normalized === n ? " set-seg__btn--on" : ""}`}
+              disabled={busy}
+              onClick={() => n !== normalized && onChange(n)}
+            >
+              {stepLimitLabel(n, t)}
+            </button>
+          );
+        })}
+        <button
+          type="button"
+          className={`set-seg__btn${isCustom ? " set-seg__btn--on" : ""}`}
+          disabled={busy}
+          onClick={() => {
+            if (!isCustom) setCustom(String(normalized || 12));
+          }}
+        >
+          {t("settings.stepLimit.custom")}
+        </button>
+      </div>
+      <input
+        className="mem-input step-limit-control__custom"
+        value={custom}
+        disabled={busy}
+        inputMode="numeric"
+        aria-label={t("settings.stepLimit.custom")}
+        onChange={(e) => setCustom(e.target.value.replace(/[^\d]/g, ""))}
+        onBlur={commitCustom}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+      />
+    </div>
+  );
+}
+
+function normalizeStepLimit(value: number): number {
+  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
+}
+
+function stepLimitLabel(value: number, t: ReturnType<typeof useT>): string {
+  return value === 0 ? t("settings.stepLimit.unlimited") : String(value);
 }
 
 function NetworkSection({ s, busy, apply }: SectionProps) {
@@ -752,6 +738,10 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
   const providerLabel = defaultProvider ? modelProviderLabel(defaultProvider, defaultProviderView, t) : t("common.none");
   const plannerLabel = plannerSelectRef || t("settings.plannerNone");
   const keyStatusLabel = defaultProviderView?.keySet ? t("settings.keySet") : t("settings.noKey");
+  const agent = s.agent ?? { temperature: 0, maxSteps: 0, plannerMaxSteps: 12, systemPrompt: "" };
+  const setAgentSteps = (maxSteps: number, plannerMaxSteps: number) => (
+    app.SetAgentParams(agent.temperature, maxSteps, plannerMaxSteps, agent.systemPrompt)
+  );
 
   useEffect(() => {
     if (subtab !== "usage") return;
@@ -803,68 +793,88 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
       </div>
 
       {subtab === "usage" ? (
-        <SettingsSection title={t("settings.modelUsage")}>
-          <SettingsField label={t("settings.defaultModel")}>
-            <ModelPicker
-              s={s}
-              refs={refs}
-              value={toRef(s.defaultModel, s)}
-              disabled={busy}
-              onPick={(ref) => void apply(() => app.SetDefaultModel(ref))}
-            />
-          </SettingsField>
+        <>
+          <SettingsSection title={t("settings.modelUsage")}>
+            <SettingsField label={t("settings.defaultModel")}>
+              <ModelPicker
+                s={s}
+                refs={refs}
+                value={toRef(s.defaultModel, s)}
+                disabled={busy}
+                onPick={(ref) => void apply(() => app.SetDefaultModel(ref))}
+              />
+            </SettingsField>
 
-          <SettingsField label={t("settings.plannerModel")}>
-            <ModelPicker
-              s={s}
-              refs={refs}
-              value={plannerSelectRef}
-              disabled={busy}
-              includeSameDefault
-              onPick={(ref) => void apply(() => app.SetPlannerModel(ref))}
-            />
-          </SettingsField>
+            <SettingsField label={t("settings.plannerModel")}>
+              <ModelPicker
+                s={s}
+                refs={refs}
+                value={plannerSelectRef}
+                disabled={busy}
+                includeSameDefault
+                onPick={(ref) => void apply(() => app.SetPlannerModel(ref))}
+              />
+            </SettingsField>
 
-          <SettingsField label={t("settings.subagentModel")}>
-            <ModelPicker
-              s={s}
-              refs={refs}
-              value={subagentRef}
-              disabled={busy}
-              emptyOptionLabel={t("settings.subagentModelDefault")}
-              emptyOptionHint={t("common.auto")}
-              onPick={(ref) => void apply(() => app.SetSubagentModel(ref))}
-            />
-          </SettingsField>
+            <SettingsField label={t("settings.subagentModel")}>
+              <ModelPicker
+                s={s}
+                refs={refs}
+                value={subagentRef}
+                disabled={busy}
+                emptyOptionLabel={t("settings.subagentModelDefault")}
+                emptyOptionHint={t("common.auto")}
+                onPick={(ref) => void apply(() => app.SetSubagentModel(ref))}
+              />
+            </SettingsField>
 
-          <SettingsField label={t("settings.subagentEffort")} hint={t("settings.subagentHint")}>
-            <select
-              className="mem-select set-grow"
-              value={s.subagentEffort || ""}
-              disabled={busy}
-              onChange={(e) => void apply(() => app.SetSubagentEffort(e.target.value))}
-            >
-              <option value="">{t("settings.subagentEffortDefault")}</option>
-              {EFFORT_PRESETS.map((level) => (
-                <option key={level} value={level}>
-                  {level}
-                </option>
-              ))}
-            </select>
-          </SettingsField>
+            <SettingsField label={t("settings.subagentEffort")} hint={t("settings.subagentHint")}>
+              <select
+                className="mem-select set-grow"
+                value={s.subagentEffort || ""}
+                disabled={busy}
+                onChange={(e) => void apply(() => app.SetSubagentEffort(e.target.value))}
+              >
+                <option value="">{t("settings.subagentEffortDefault")}</option>
+                {EFFORT_PRESETS.map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
+              </select>
+            </SettingsField>
 
-          <div className="settings-model-current" aria-label={t("settings.modelCurrentStatus")}>
-            <div>
-              <span>{t("settings.modelCurrentStatus")}</span>
-              <strong>{currentModelLabel}</strong>
+            <div className="settings-model-current" aria-label={t("settings.modelCurrentStatus")}>
+              <div>
+                <span>{t("settings.modelCurrentStatus")}</span>
+                <strong>{currentModelLabel}</strong>
+              </div>
+              <div className="settings-model-current__meta">
+                <span>{providerLabel}</span>
+                <span>{plannerLabel}</span>
+                <span>{keyStatusLabel}</span>
+              </div>
             </div>
-            <div className="settings-model-current__meta">
-              <span>{providerLabel}</span>
-              <span>{plannerLabel}</span>
-              <span>{keyStatusLabel}</span>
-            </div>
-          </div>
-        </SettingsSection>
+          </SettingsSection>
+          <SettingsSection title={t("settings.agentRuntime")} description={t("settings.agentRuntimeHint")}>
+            <SettingsField label={t("settings.executorMaxSteps")} hint={t("settings.executorMaxStepsHint")}>
+              <StepLimitControl
+                value={agent.maxSteps}
+                presets={[0, 10, 25, 50]}
+                busy={busy}
+                onChange={(next) => void apply(() => setAgentSteps(next, agent.plannerMaxSteps))}
+              />
+            </SettingsField>
+            <SettingsField label={t("settings.plannerMaxSteps")} hint={plannerSelectRef ? t("settings.plannerMaxStepsHint") : t("settings.plannerMaxStepsDisabledHint")}>
+              <StepLimitControl
+                value={agent.plannerMaxSteps}
+                presets={[6, 12, 25, 0]}
+                busy={busy}
+                onChange={(next) => void apply(() => setAgentSteps(agent.maxSteps, next))}
+              />
+            </SettingsField>
+          </SettingsSection>
+        </>
       ) : (
         <ProvidersSection s={s} busy={busy} apply={apply} />
       )}
@@ -2259,18 +2269,6 @@ function AppearanceSection({
 }) {
   const t = useT();
   const themeOptions: Theme[] = ["auto", "light", "dark"];
-  const [tabBarHidden, setTabBarHidden] = useState(() => {
-    try { return window.localStorage.getItem("reasonix.desktop.tabBarHidden") === "1"; }
-    catch { return false; }
-  });
-  const toggleTabBar = () => {
-    const next = !tabBarHidden;
-    setTabBarHidden(next);
-    try {
-      window.localStorage.setItem("reasonix.desktop.tabBarHidden", next ? "1" : "0");
-    } catch {}
-    window.dispatchEvent(new CustomEvent("reasonix:tabbar-visibility-changed"));
-  };
   return (
     <SettingsSection title={t("settings.appearance")}>
       <SettingsField label={t("settings.theme")}>
@@ -2324,26 +2322,6 @@ function AppearanceSection({
               {fontFamilyName(font, t)}
             </button>
           ))}
-        </div>
-      </SettingsField>
-      <SettingsField label={t("settings.showTabBar")}>
-        <div className="set-seg">
-          <button
-            className={`set-seg__btn${!tabBarHidden ? " set-seg__btn--on" : ""}`}
-            onClick={() => {
-              if (tabBarHidden) toggleTabBar();
-            }}
-          >
-            {t("settings.on")}
-          </button>
-          <button
-            className={`set-seg__btn${tabBarHidden ? " set-seg__btn--on" : ""}`}
-            onClick={() => {
-              if (!tabBarHidden) toggleTabBar();
-            }}
-          >
-            {t("settings.off")}
-          </button>
         </div>
       </SettingsField>
     </SettingsSection>

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, Play, X } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { normalizeLangPref, useI18n, useT, type DictKey, type LangPref } from "../lib/i18n";
@@ -25,6 +25,8 @@ import { Tooltip } from "./Tooltip";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { MCPServersSettingsPage, SkillsSettingsPage } from "./CapabilitiesPanel";
 import { MemorySettingsPage } from "./MemoryPanel";
+import { getSuccessPreference, setSuccessPreference, getAttentionPreference, setAttentionPreference, playSuccessChime, playAttentionChime, type SoundWavPref } from "../lib/sound";
+import { getGenerativePreset, setGenerativePreset, generativeMusic, type GenerativePreset } from "../lib/generative-music";
 
 const SETTINGS_TABS: SettingsTab[] = ["general", "models", "mcp", "skills", "memory", "permissions", "sandbox", "network", "appearance", "updates"];
 
@@ -100,7 +102,7 @@ export function SettingsPanel({ onClose, onChanged, initialTab }: { onClose: () 
         <header className="settings-modal__head">
           <div className="settings-modal__title">{t("settings.title")}</div>
           <Tooltip label={t("common.close")}>
-            <button className="chip" aria-label={t("common.close")} onClick={onClose}>✕</button>
+            <button className="chip" aria-label={t("common.close")} onClick={onClose}><X size={14} /></button>
           </Tooltip>
         </header>
 
@@ -400,9 +402,7 @@ function normalizeSettingsView(view: SettingsView | null | undefined): SettingsV
     noProxy: "",
     proxy: { type: "socks5", server: "", port: 0, username: "", password: "" },
   };
-  const agent = view.agent ?? { temperature: 0, maxSteps: 0, plannerMaxSteps: 12, systemPrompt: "" };
-  agent.plannerMaxSteps = Number.isFinite(agent.plannerMaxSteps) ? Math.max(0, Math.trunc(agent.plannerMaxSteps)) : 12;
-  agent.maxSteps = Number.isFinite(agent.maxSteps) ? Math.max(0, Math.trunc(agent.maxSteps)) : 0;
+  const agent = view.agent ?? { temperature: 0, maxSteps: 0, systemPrompt: "" };
   return {
     ...view,
     providers: asArray(view.providers).map((p) => ({
@@ -481,6 +481,9 @@ function GeneralSection({ s, busy, apply }: SectionProps) {
   const closeBehavior = normalizeCloseBehavior(s.closeBehavior);
   const autoPlan = normalizeAutoPlan(s.autoPlan);
   const languagePref = normalizeLangPref(s.desktopLanguage);
+  const [soundPref, setSoundPref] = useState<SoundWavPref>(getSuccessPreference());
+  const [attentionPref, setAttentionPref] = useState<SoundWavPref>(getAttentionPreference());
+  const [genMusicPreset, setGenMusicPreset] = useState<GenerativePreset>(getGenerativePreset());
   const setLanguage = (next: LangPref) => {
     setPref(next);
     void apply(() => app.SetDesktopLanguage(next));
@@ -529,82 +532,93 @@ function GeneralSection({ s, busy, apply }: SectionProps) {
           ))}
         </div>
       </SettingsField>
+      <SettingsField label={t("settings.notificationSound")} hint={t("settings.notificationSoundHint")} stacked>
+        <div className="settings-notification-sound-row">
+          <span>{t("settings.notificationSoundSuccess")}</span>
+          <select
+            className="mem-select"
+            value={soundPref}
+            onChange={(e) => {
+              const next = e.target.value as SoundWavPref;
+              setSoundPref(next);
+              setSuccessPreference(next);
+              playSuccessChime();
+            }}
+          >
+            <option value="synth">{t("settings.notificationSound.synth")}</option>
+            <option value="positive">{t("settings.notificationSound.positive")}</option>
+            <option value="correct">{t("settings.notificationSound.correct")}</option>
+            <option value="start">{t("settings.notificationSound.start")}</option>
+            <option value="back">{t("settings.notificationSound.back")}</option>
+          </select>
+          <button
+            className="chip"
+            type="button"
+            onClick={() => playSuccessChime()}
+            title={t("settings.notificationSoundPreview")}
+          >
+            <Play size={13} />
+          </button>
+        </div>
+        <div className="settings-notification-sound-row" style={{ marginTop: 6 }}>
+          <span>{t("settings.notificationSoundAttention")}</span>
+          <select
+            className="mem-select"
+            value={attentionPref}
+            onChange={(e) => {
+              const next = e.target.value as SoundWavPref;
+              setAttentionPref(next);
+              setAttentionPreference(next);
+              playAttentionChime();
+            }}
+          >
+            <option value="synth">{t("settings.notificationSound.synth")}</option>
+            <option value="positive">{t("settings.notificationSound.positive")}</option>
+            <option value="correct">{t("settings.notificationSound.correct")}</option>
+            <option value="start">{t("settings.notificationSound.start")}</option>
+            <option value="back">{t("settings.notificationSound.back")}</option>
+          </select>
+          <button
+            className="chip"
+            type="button"
+            onClick={() => playAttentionChime()}
+            title={t("settings.notificationSoundPreview")}
+          >
+            <Play size={13} />
+          </button>
+        </div>
+      </SettingsField>
+      <SettingsField label={t("settings.generativeMusic")} hint={t("settings.generativeMusicHint")} stacked>
+        <div className="settings-notification-sound-row">
+          <span>{t("settings.generativeMusicPreset")}</span>
+          <select
+            className="mem-select"
+            value={genMusicPreset}
+            onChange={(e) => {
+              const next = e.target.value as GenerativePreset;
+              setGenMusicPreset(next);
+              setGenerativePreset(next);
+              if (next !== "off") generativeMusic.playPreview(next);
+            }}
+          >
+            <option value="off">{t("settings.generativeMusic.off")}</option>
+            <option value="classic">{t("settings.generativeMusic.presets.classic")}</option>
+            <option value="ethereal">{t("settings.generativeMusic.presets.ethereal")}</option>
+            <option value="digital">{t("settings.generativeMusic.presets.digital")}</option>
+            <option value="retro">{t("settings.generativeMusic.presets.retro")}</option>
+          </select>
+          <button
+            className="chip"
+            type="button"
+            onClick={() => { if (genMusicPreset !== "off") generativeMusic.playPreview(genMusicPreset); }}
+            title={t("settings.generativeMusicPreview")}
+          >
+            <Play size={13} />
+          </button>
+        </div>
+      </SettingsField>
     </SettingsSection>
   );
-}
-
-function StepLimitControl({
-  value,
-  presets,
-  busy,
-  onChange,
-}: {
-  value: number;
-  presets: number[];
-  busy: boolean;
-  onChange: (value: number) => void;
-}) {
-  const t = useT();
-  const normalized = normalizeStepLimit(value);
-  const presetSet = new Set(presets.map(normalizeStepLimit));
-  const [custom, setCustom] = useState(String(normalized));
-  useEffect(() => setCustom(String(normalized)), [normalized]);
-  const isCustom = !presetSet.has(normalized);
-  const commitCustom = () => {
-    const next = normalizeStepLimit(Number(custom));
-    setCustom(String(next));
-    if (next !== normalized) onChange(next);
-  };
-  return (
-    <div className="step-limit-control">
-      <div className="set-seg">
-        {presets.map((preset) => {
-          const n = normalizeStepLimit(preset);
-          return (
-            <button
-              key={n}
-              type="button"
-              className={`set-seg__btn${normalized === n ? " set-seg__btn--on" : ""}`}
-              disabled={busy}
-              onClick={() => n !== normalized && onChange(n)}
-            >
-              {stepLimitLabel(n, t)}
-            </button>
-          );
-        })}
-        <button
-          type="button"
-          className={`set-seg__btn${isCustom ? " set-seg__btn--on" : ""}`}
-          disabled={busy}
-          onClick={() => {
-            if (!isCustom) setCustom(String(normalized || 12));
-          }}
-        >
-          {t("settings.stepLimit.custom")}
-        </button>
-      </div>
-      <input
-        className="mem-input step-limit-control__custom"
-        value={custom}
-        disabled={busy}
-        inputMode="numeric"
-        aria-label={t("settings.stepLimit.custom")}
-        onChange={(e) => setCustom(e.target.value.replace(/[^\d]/g, ""))}
-        onBlur={commitCustom}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") e.currentTarget.blur();
-        }}
-      />
-    </div>
-  );
-}
-
-function normalizeStepLimit(value: number): number {
-  return Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0;
-}
-
-function stepLimitLabel(value: number, t: ReturnType<typeof useT>): string {
-  return value === 0 ? t("settings.stepLimit.unlimited") : String(value);
 }
 
 function NetworkSection({ s, busy, apply }: SectionProps) {
@@ -738,10 +752,6 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
   const providerLabel = defaultProvider ? modelProviderLabel(defaultProvider, defaultProviderView, t) : t("common.none");
   const plannerLabel = plannerSelectRef || t("settings.plannerNone");
   const keyStatusLabel = defaultProviderView?.keySet ? t("settings.keySet") : t("settings.noKey");
-  const agent = s.agent ?? { temperature: 0, maxSteps: 0, plannerMaxSteps: 12, systemPrompt: "" };
-  const setAgentSteps = (maxSteps: number, plannerMaxSteps: number) => (
-    app.SetAgentParams(agent.temperature, maxSteps, plannerMaxSteps, agent.systemPrompt)
-  );
 
   useEffect(() => {
     if (subtab !== "usage") return;
@@ -793,88 +803,68 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
       </div>
 
       {subtab === "usage" ? (
-        <>
-          <SettingsSection title={t("settings.modelUsage")}>
-            <SettingsField label={t("settings.defaultModel")}>
-              <ModelPicker
-                s={s}
-                refs={refs}
-                value={toRef(s.defaultModel, s)}
-                disabled={busy}
-                onPick={(ref) => void apply(() => app.SetDefaultModel(ref))}
-              />
-            </SettingsField>
+        <SettingsSection title={t("settings.modelUsage")}>
+          <SettingsField label={t("settings.defaultModel")}>
+            <ModelPicker
+              s={s}
+              refs={refs}
+              value={toRef(s.defaultModel, s)}
+              disabled={busy}
+              onPick={(ref) => void apply(() => app.SetDefaultModel(ref))}
+            />
+          </SettingsField>
 
-            <SettingsField label={t("settings.plannerModel")}>
-              <ModelPicker
-                s={s}
-                refs={refs}
-                value={plannerSelectRef}
-                disabled={busy}
-                includeSameDefault
-                onPick={(ref) => void apply(() => app.SetPlannerModel(ref))}
-              />
-            </SettingsField>
+          <SettingsField label={t("settings.plannerModel")}>
+            <ModelPicker
+              s={s}
+              refs={refs}
+              value={plannerSelectRef}
+              disabled={busy}
+              includeSameDefault
+              onPick={(ref) => void apply(() => app.SetPlannerModel(ref))}
+            />
+          </SettingsField>
 
-            <SettingsField label={t("settings.subagentModel")}>
-              <ModelPicker
-                s={s}
-                refs={refs}
-                value={subagentRef}
-                disabled={busy}
-                emptyOptionLabel={t("settings.subagentModelDefault")}
-                emptyOptionHint={t("common.auto")}
-                onPick={(ref) => void apply(() => app.SetSubagentModel(ref))}
-              />
-            </SettingsField>
+          <SettingsField label={t("settings.subagentModel")}>
+            <ModelPicker
+              s={s}
+              refs={refs}
+              value={subagentRef}
+              disabled={busy}
+              emptyOptionLabel={t("settings.subagentModelDefault")}
+              emptyOptionHint={t("common.auto")}
+              onPick={(ref) => void apply(() => app.SetSubagentModel(ref))}
+            />
+          </SettingsField>
 
-            <SettingsField label={t("settings.subagentEffort")} hint={t("settings.subagentHint")}>
-              <select
-                className="mem-select set-grow"
-                value={s.subagentEffort || ""}
-                disabled={busy}
-                onChange={(e) => void apply(() => app.SetSubagentEffort(e.target.value))}
-              >
-                <option value="">{t("settings.subagentEffortDefault")}</option>
-                {EFFORT_PRESETS.map((level) => (
-                  <option key={level} value={level}>
-                    {level}
-                  </option>
-                ))}
-              </select>
-            </SettingsField>
+          <SettingsField label={t("settings.subagentEffort")} hint={t("settings.subagentHint")}>
+            <select
+              className="mem-select set-grow"
+              value={s.subagentEffort || ""}
+              disabled={busy}
+              onChange={(e) => void apply(() => app.SetSubagentEffort(e.target.value))}
+            >
+              <option value="">{t("settings.subagentEffortDefault")}</option>
+              {EFFORT_PRESETS.map((level) => (
+                <option key={level} value={level}>
+                  {level}
+                </option>
+              ))}
+            </select>
+          </SettingsField>
 
-            <div className="settings-model-current" aria-label={t("settings.modelCurrentStatus")}>
-              <div>
-                <span>{t("settings.modelCurrentStatus")}</span>
-                <strong>{currentModelLabel}</strong>
-              </div>
-              <div className="settings-model-current__meta">
-                <span>{providerLabel}</span>
-                <span>{plannerLabel}</span>
-                <span>{keyStatusLabel}</span>
-              </div>
+          <div className="settings-model-current" aria-label={t("settings.modelCurrentStatus")}>
+            <div>
+              <span>{t("settings.modelCurrentStatus")}</span>
+              <strong>{currentModelLabel}</strong>
             </div>
-          </SettingsSection>
-          <SettingsSection title={t("settings.agentRuntime")} description={t("settings.agentRuntimeHint")}>
-            <SettingsField label={t("settings.executorMaxSteps")} hint={t("settings.executorMaxStepsHint")}>
-              <StepLimitControl
-                value={agent.maxSteps}
-                presets={[0, 10, 25, 50]}
-                busy={busy}
-                onChange={(next) => void apply(() => setAgentSteps(next, agent.plannerMaxSteps))}
-              />
-            </SettingsField>
-            <SettingsField label={t("settings.plannerMaxSteps")} hint={plannerSelectRef ? t("settings.plannerMaxStepsHint") : t("settings.plannerMaxStepsDisabledHint")}>
-              <StepLimitControl
-                value={agent.plannerMaxSteps}
-                presets={[6, 12, 25, 0]}
-                busy={busy}
-                onChange={(next) => void apply(() => setAgentSteps(agent.maxSteps, next))}
-              />
-            </SettingsField>
-          </SettingsSection>
-        </>
+            <div className="settings-model-current__meta">
+              <span>{providerLabel}</span>
+              <span>{plannerLabel}</span>
+              <span>{keyStatusLabel}</span>
+            </div>
+          </div>
+        </SettingsSection>
       ) : (
         <ProvidersSection s={s} busy={busy} apply={apply} />
       )}
@@ -2154,7 +2144,7 @@ function RuleList({
             {r}
             <Tooltip label={t("common.delete")}>
               <button className="set-rule__x" disabled={busy} onClick={() => void onRemove(r)}>
-                ✕
+                <X size={11} />
               </button>
             </Tooltip>
           </span>
@@ -2269,6 +2259,18 @@ function AppearanceSection({
 }) {
   const t = useT();
   const themeOptions: Theme[] = ["auto", "light", "dark"];
+  const [tabBarHidden, setTabBarHidden] = useState(() => {
+    try { return window.localStorage.getItem("reasonix.desktop.tabBarHidden") === "1"; }
+    catch { return false; }
+  });
+  const toggleTabBar = () => {
+    const next = !tabBarHidden;
+    setTabBarHidden(next);
+    try {
+      window.localStorage.setItem("reasonix.desktop.tabBarHidden", next ? "1" : "0");
+    } catch {}
+    window.dispatchEvent(new CustomEvent("reasonix:tabbar-visibility-changed"));
+  };
   return (
     <SettingsSection title={t("settings.appearance")}>
       <SettingsField label={t("settings.theme")}>
@@ -2322,6 +2324,26 @@ function AppearanceSection({
               {fontFamilyName(font, t)}
             </button>
           ))}
+        </div>
+      </SettingsField>
+      <SettingsField label={t("settings.showTabBar")}>
+        <div className="set-seg">
+          <button
+            className={`set-seg__btn${!tabBarHidden ? " set-seg__btn--on" : ""}`}
+            onClick={() => {
+              if (tabBarHidden) toggleTabBar();
+            }}
+          >
+            {t("settings.on")}
+          </button>
+          <button
+            className={`set-seg__btn${tabBarHidden ? " set-seg__btn--on" : ""}`}
+            onClick={() => {
+              if (!tabBarHidden) toggleTabBar();
+            }}
+          >
+            {t("settings.off")}
+          </button>
         </div>
       </SettingsField>
     </SettingsSection>

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -1,7 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Tooltip } from "./Tooltip";
-import { useI18n } from "../lib/i18n";
+import { useI18n, SPINNER_WORDS } from "../lib/i18n";
 import type { BalanceInfo, ContextInfo, JobView, Mode, WireUsage } from "../lib/types";
+
+function fmtTokens(n: number): string {
+  if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, "") + "k";
+  return String(n);
+}
 
 // JobsChip is the status-bar background-jobs indicator: a count that opens an
 // upward popover listing the running jobs (id · label · status), mirroring the
@@ -89,6 +94,7 @@ export function StatusBar({
   mode,
   cost,
   currency,
+  turnTokens,
 }: {
   context: ContextInfo;
   usage?: WireUsage;
@@ -98,8 +104,19 @@ export function StatusBar({
   mode: Mode;
   cost?: number;
   currency?: string;
+  turnTokens?: number;
 }) {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!running) return;
+    const id = window.setInterval(() => setTick((n) => n + 1), 1000);
+    return () => window.clearInterval(id);
+  }, [running]);
+  const spinnerRunning = running;
+  const spinnerWord = spinnerRunning
+    ? SPINNER_WORDS[locale][Math.floor(Date.now() / 3000) % SPINNER_WORDS[locale].length]
+    : "";
   const pct = context.window ? Math.min(100, Math.round((context.used / context.window) * 100)) : null;
   const compactPct = context.compactRatio ? Math.round(context.compactRatio * 100) : null;
   const nowPct = nowRate(usage);
@@ -132,7 +149,15 @@ export function StatusBar({
         </span>
       </Tooltip>
       <span className="statusbar__spacer" />
-      {mode === "plan" && <span className="statusbar__plan">{t("status.plan")}</span>}
+      <div className="statusbar__trailing">
+        {spinnerRunning && (
+          <span className="statusbar__spinner">{spinnerWord}…</span>
+        )}
+        {(turnTokens ?? 0) > 0 && (
+          <span className="statusbar__tokens">↓ {fmtTokens(turnTokens ?? 0)} {t("status.tokens")}</span>
+        )}
+        {mode === "plan" && <span className="statusbar__plan">{t("status.plan")}</span>}
+      </div>
     </div>
   );
 }

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -403,18 +403,15 @@ export function Transcript({
   // don't rebuild it. The hot zone uses LiveAssistantMessage (reads live from
   // LiveStreamContext) so streaming updates are captured immediately.
   return (
-    <div
-      className={`transcript${empty ? " transcript--empty" : ""}`}
-      ref={scrollRef}
-      onScroll={onScroll}
-    >
-      {empty && <Welcome onPrompt={onPrompt} />}
+    <div className="transcript-wrap">
+      <div
+        className={`transcript${empty ? " transcript--empty" : ""}`}
+        ref={scrollRef}
+        onScroll={onScroll}
+      >
+        {empty && <Welcome onPrompt={onPrompt} />}
 
-      {!empty && showQuestionNav && (
-        <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
-      )}
-
-      <LiveStreamContext.Provider value={live}>
+        <LiveStreamContext.Provider value={live}>
         {turnGroups.length > HOT_TURNS && (
           <WarmZone
             turnGroups={turnGroups}
@@ -443,6 +440,11 @@ export function Transcript({
         )}
         {hotZoneNodes}
       </LiveStreamContext.Provider>
+      </div>
+
+      {!empty && showQuestionNav && (
+        <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
+      )}
     </div>
   );
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4213,20 +4213,40 @@ a[href] {
   font-weight: 580;
 }
 .workspace-branch-indicator {
-  flex: 0 0 auto;
-  min-width: 0;
   display: flex;
   align-items: center;
-  gap: 6px;
-  margin: 0 10px 6px;
-  padding: 4px 9px;
-  font-size: 12.5px;
-  color: var(--fg-faint);
-  border-radius: 6px;
-  background: var(--bg);
+  gap: 5px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 12px;
 }
-.workspace-branch-indicator span {
-  min-width: 0;
+
+.workspace-branch-indicator > svg {
+  flex-shrink: 0;
+  opacity: 0.6;
+}
+
+.workspace-branch-indicator > .workspace-branch-name {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.workspace-branch-indicator > .workspace-branch-name:hover {
+  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
+}
+
+.workspace-branch-indicator > .workspace-branch-name span {
+  max-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -512,6 +512,7 @@ a[href] {
 }
 .sidebar__new {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: 9px;
   height: 36px;
@@ -2224,7 +2225,7 @@ a[href] {
   opacity: 0.72;
   transition: background 0.12s, box-shadow 0.12s, opacity 0.12s;
 }
-.composer-resize-handle:hover::before,
+.composer-card:hover .composer-resize-handle::before,
 .composer-resize-handle:focus-visible::before,
 .composer-card--resizing .composer-resize-handle::before {
   background: var(--accent);
@@ -2404,7 +2405,6 @@ a[href] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  align-self: flex-end;
   width: 32px;
   height: 32px;
   border: none;
@@ -4212,6 +4212,26 @@ a[href] {
   font-size: 12px;
   font-weight: 580;
 }
+.workspace-branch-indicator {
+  flex: 0 0 auto;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 10px 6px;
+  padding: 4px 9px;
+  font-size: 12.5px;
+  color: var(--fg-faint);
+  border-radius: 6px;
+  background: var(--bg);
+}
+.workspace-branch-indicator span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .workspace-search {
   flex: 0 0 auto;
   display: flex;
@@ -4369,99 +4389,6 @@ a[href] {
 .workspace-change__badge--git {
   color: var(--accent);
   border-color: color-mix(in srgb, var(--accent) 32%, var(--border-soft));
-}
-.workspace-git-history {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.workspace-git-history__list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.workspace-git-history__item {
-  border: 1px solid var(--border-soft);
-  border-radius: 8px;
-  background: var(--bg-soft);
-  overflow: hidden;
-}
-.workspace-git-history__head {
-  --wails-draggable: no-drag;
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  padding: 10px 12px;
-  border: none;
-  background: transparent;
-  color: var(--fg);
-  font: inherit;
-  font-size: 13px;
-  text-align: left;
-}
-.workspace-git-history__head-top {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-}
-.workspace-git-history__head-bottom {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-left: 22px;
-  margin-top: 4px;
-}
-.workspace-git-history__head:hover {
-  background: var(--sidebar-hover);
-}
-.workspace-git-history__message {
-  flex: 1;
-  font-weight: 560;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.workspace-git-history__author {
-  color: var(--fg-dim);
-  font-size: 12px;
-}
-.workspace-git-history__date {
-  color: var(--fg-faint);
-  font-size: 11.5px;
-}
-.workspace-git-history__hash {
-  font-family: var(--mono);
-  margin-left: 6px;
-  opacity: 0.8;
-}
-.workspace-git-history__detail {
-  padding: 12px;
-  border-top: 1px solid var(--border-soft);
-  background: var(--bg);
-}
-.workspace-git-history__files {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.workspace-git-history__file {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--fg-dim);
-  background: transparent;
-  border: none;
-  padding: 4px 6px;
-  border-radius: 4px;
-  cursor: pointer;
-  text-align: left;
-}
-.workspace-git-history__file:hover {
-  background: var(--sidebar-hover);
-  color: var(--fg);
 }
 .workspace-tree__chev {
   width: 13px;
@@ -5906,27 +5833,10 @@ a[href] {
   overflow: visible;
 }
 .cap-skill-card__more {
-  display: inline-flex;
-  align-items: center;
   margin: 7px 0 0 33px;
-  padding: 0;
-  border: 0;
-  background: transparent;
   color: var(--accent);
-  cursor: pointer;
-  font: inherit;
   font-size: 11px;
   font-weight: 650;
-  line-height: 1.3;
-  text-align: left;
-}
-.cap-skill-card__more:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent) 52%, transparent);
-  outline-offset: 3px;
-  border-radius: 5px;
-}
-.cap-skill-card__more:hover {
-  color: var(--accent-strong);
 }
 .cap-dot {
   flex-shrink: 0;
@@ -6132,7 +6042,7 @@ a[href] {
 .history-content {
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(0, 0.38fr) minmax(0, 0.62fr);
+  grid-template-columns: minmax(340px, 0.38fr) minmax(0, 0.62fr);
   overflow: hidden;
 }
 .history-list {
@@ -6359,10 +6269,7 @@ a[href] {
     max-width: 100%;
   }
   .history-content {
-    grid-template-columns: minmax(0, 1fr);
-  }
-  .history-list {
-    max-height: 40vh;
+    grid-template-columns: 1fr;
   }
   .history-preview {
     min-height: 260px;
@@ -6648,27 +6555,6 @@ a[href] {
   min-width: auto;
 }
 
-.step-limit-control {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
-  width: 100%;
-  max-width: 640px;
-  min-width: 0;
-}
-
-.step-limit-control .set-seg {
-  min-width: 0;
-  overflow-x: auto;
-}
-
-.step-limit-control__custom {
-  width: 82px;
-  flex: 0 0 82px;
-  text-align: center;
-}
-
 .settings-page .settings-model-current {
   margin-top: 14px;
 }
@@ -6865,11 +6751,6 @@ a[href] {
     flex-wrap: wrap;
   }
 
-  .step-limit-control {
-    justify-content: flex-start;
-    flex-wrap: wrap;
-  }
-
   .settings-subtabs {
     display: flex;
     width: 100%;
@@ -6937,7 +6818,7 @@ a[href] {
   border: 1px solid var(--border-soft);
   border-radius: 999px;
   background: var(--bg-elev-2);
-  color: var(--fg-muted);
+  color: var(--fg-dim);
   font-family: var(--mono);
   font-size: var(--text-2xs);
   line-height: 1;
@@ -7577,7 +7458,7 @@ a[href] {
   min-height: 64px;
 }
 .provider-readonly-field--stacked span {
-  color: var(--fg-muted);
+  color: var(--fg-faint);
   font-size: var(--font-control-small);
   font-weight: 500;
   line-height: 1.35;
@@ -7595,7 +7476,7 @@ a[href] {
   gap: 8px 10px;
 }
 .provider-model-fetch-row span {
-  color: var(--fg-muted);
+  color: var(--fg-faint);
   font-size: var(--font-control-small);
   line-height: 1.4;
 }
@@ -8763,7 +8644,7 @@ a[href] {
   gap: 4px;
   padding: 4px 10px;
   font-size: 11px;
-  color: var(--fg-muted);
+  color: var(--fg-dim);
   background: transparent;
   border: none;
   border-bottom: 2px solid transparent;
@@ -9507,6 +9388,7 @@ a[href] {
 
 .project-tree__search {
   display: flex;
+  flex-shrink: 0;
   align-items: center;
   gap: 8px;
   height: 34px;
@@ -9535,6 +9417,8 @@ a[href] {
 
 .project-tree__header {
   display: flex;
+  position: relative;
+  flex-shrink: 0;
   align-items: center;
   justify-content: space-between;
   gap: 6px;
@@ -9561,6 +9445,94 @@ a[href] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+.project-tree__header-actions {
+  display: flex;
+  position: relative;
+  align-items: center;
+  gap: 3px;
+}
+
+.project-tree__header-action-btn {
+  --wails-draggable: no-drag;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-soft);
+  border-radius: 7px;
+  background: transparent;
+  color: var(--fg-faint);
+  padding: 0;
+  opacity: 0.78;
+  cursor: pointer;
+}
+
+.project-tree__header-action-btn:hover {
+  background: var(--button-bg);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border-soft));
+  color: var(--fg);
+  opacity: 1;
+}
+
+.project-tree__header-action-btn--active {
+  color: var(--accent);
+  opacity: 1;
+}
+
+.project-tree__header-action-btn--active:hover {
+  color: var(--fg);
+}
+
+.project-tree__time-filter {
+  display: inline-flex;
+  position: relative;
+}
+
+.project-tree__time-filter-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: var(--z-topicbar-menu);
+  min-width: 108px;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elev);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.project-tree__time-filter-opt {
+  --wails-draggable: no-drag;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 30px;
+  padding: 0 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.project-tree__time-filter-opt:hover {
+  background: var(--sidebar-hover);
+  color: var(--fg);
+}
+
+.project-tree__time-filter-opt--on {
+  color: var(--fg);
+  font-weight: 550;
 }
 
 .project-tree__add-project,
@@ -9764,8 +9736,7 @@ a[href] {
   padding-top: 0;
   padding-bottom: 0;
   padding-left: 0 !important;
-  margin-left: 22px;
-  margin-right: var(--project-tree-action-column);
+  margin-left: 11px;
   padding-right: 8px;
   border-radius: 6px;
   color: var(--fg-dim);
@@ -9775,19 +9746,7 @@ a[href] {
 
 .project-tree__topic--active {
   background: color-mix(in srgb, var(--project-accent, var(--accent)) 10%, var(--sidebar-hover));
-  border-radius: 0;
   color: var(--fg);
-}
-
-.project-tree__topic--active::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0;
-  bottom: 0;
-  width: 4px;
-  background: color-mix(in srgb, var(--project-accent, var(--accent)) 88%, #ff9d22);
-  pointer-events: none;
 }
 
 .project-tree__topic--menu-open {
@@ -9832,6 +9791,36 @@ a[href] {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Topic status indicator dot: running (green pulse) or unread (white dot) */
+.project-tree__topic-indicator {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 6px;
+  line-height: 1;
+}
+.project-tree__topic-indicator--running {
+  background: #22c55e;
+  animation: project-tree-pulse 1.2s ease-in-out infinite;
+}
+.project-tree__topic-indicator--unread {
+  background: var(--fg-dim);
+}
+@keyframes project-tree-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.15); }
+}
+
+.project-tree__topic-time {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--fg-faint);
+  white-space: nowrap;
+  margin-left: 6px;
+  line-height: 1;
 }
 
 .project-tree__topic-main:focus-visible {
@@ -10598,277 +10587,6 @@ a[href] {
 ::view-transition-old(root),
 ::view-transition-new(root) {
   animation: none !important;
-}
-
-/* ── Branch indicator (changed-files view) ──────────────────────────── */
-.workspace-branch-indicator {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 10px;
-  border-bottom: 1px solid var(--border);
-  color: var(--fg-muted);
-  font-size: 12px;
-}
-
-.workspace-branch-indicator > svg {
-  flex-shrink: 0;
-  opacity: 0.6;
-}
-
-.workspace-branch-indicator > .workspace-branch-name {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  border: none;
-  background: transparent;
-  color: var(--fg);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 12px;
-  padding: 1px 4px;
-  border-radius: 3px;
-}
-
-.workspace-branch-indicator > .workspace-branch-name:hover {
-  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
-}
-
-.workspace-branch-indicator > .workspace-branch-name span {
-  max-width: 160px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.workspace-branch-refresh {
-  margin-left: auto;
-  border: none;
-  background: transparent;
-  color: var(--fg-muted);
-  cursor: pointer;
-  padding: 2px;
-  border-radius: 3px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.workspace-branch-refresh:hover {
-  color: var(--fg);
-  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
-}
-
-.workspace-branch-refresh:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
-.workspace-branch-refresh .spinning {
-  animation: spin 0.6s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.workspace-branch-menu {
-  min-width: 140px;
-  max-width: 260px;
-  max-height: 300px;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
-  overflow: hidden;
-}
-
-.workspace-branch-menu__inner {
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  background: var(--bg-elev);
-}
-
-.workspace-branch-menu__loading {
-  padding: 10px 12px;
-  color: var(--fg-muted);
-  font-size: 12px;
-  text-align: center;
-}
-
-.workspace-branch-menu__item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  width: 100%;
-  padding: 6px 12px;
-  border: none;
-  background: transparent;
-  color: var(--fg);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: 12px;
-  text-align: left;
-}
-
-.workspace-branch-menu__item:hover {
-  background: var(--bg-hover, rgba(128, 128, 128, 0.08));
-}
-
-.workspace-branch-menu__item--active {
-  font-weight: 600;
-}
-
-.workspace-branch-menu__item svg {
-  flex-shrink: 0;
-  opacity: 0.7;
-}
-
-.workspace-branch-menu__item span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.workspace-branch-menu__item:disabled {
-  opacity: 0.4;
-  cursor: default;
-}
-
-/* ── Command palette (⌘K) ─────────────────────────────────────────── */
-.drawer-backdrop:has(.palette) {
-  justify-content: center;
-  align-items: flex-start;
-  padding-top: 12vh;
-}
-
-.palette {
-  position: relative;
-  width: min(520px, 90vw);
-  max-height: 60vh;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.36);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: palette-in 0.1s ease;
-}
-
-@keyframes palette-in {
-  from { opacity: 0; transform: translateY(-12px) scale(0.97); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-.palette__inputrow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--border);
-}
-
-.palette__input {
-  flex: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  color: var(--fg);
-  font-size: 14px;
-  line-height: 1.4;
-}
-
-.palette__input::placeholder {
-  color: var(--fg-muted);
-}
-
-.palette__esc {
-  font-size: 11px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  color: var(--fg-muted);
-  background: var(--bg-base);
-  font-family: inherit;
-  line-height: 1.3;
-}
-
-.palette__list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 6px 0;
-}
-
-.palette__empty {
-  padding: 24px 14px;
-  color: var(--fg-muted);
-  text-align: center;
-  font-size: 13px;
-}
-
-.palette__group-title {
-  padding: 8px 14px 4px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--fg-muted);
-}
-
-.palette__item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  width: 100%;
-  padding: 8px 14px;
-  border: none;
-  background: transparent;
-  color: var(--fg);
-  cursor: pointer;
-  text-align: left;
-  font-family: inherit;
-  font-size: 13px;
-  line-height: 1.3;
-}
-
-.palette__item--on {
-  background: var(--accent-bg, rgba(77, 151, 255, 0.12));
-}
-
-.palette__item:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-
-.palette__title {
-  font-weight: 500;
-}
-
-.palette__hint {
-  font-size: 11px;
-  color: var(--fg-muted);
-}
-
-.palette__foot {
-  display: flex;
-  gap: 12px;
-  padding: 7px 14px;
-  border-top: 1px solid var(--border);
-  font-size: 11px;
-  color: var(--fg-muted);
-}
-
-.palette__foot kbd {
-  padding: 1px 4px;
-  border-radius: 3px;
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-  font-family: inherit;
-  font-size: 10px;
-  line-height: 1.3;
-  margin-right: 2px;
 }
 
 /* Respect the OS reduced-motion preference: squash all animations and force


### PR DESCRIPTION
## UI 布局修复

### 标题栏
- 去掉重复的项目名前缀
- 字号 18px→15px，padding 缩小

### 滚动条对齐修复
- 改用 overflow-y:overlay 悬浮不占布局空间
- scrollbar-gutter:stable 预占滚动条空间
- 历史消息与输入框完美左对齐

### Composer 精简
- 移除 caret 符号
- send 按钮移到 meta bar 作为多状态动作按钮
- 移除 process-card__body 背景

### 其他
- 隐藏 thinking label，用 BrainCircuit 图标替代
- 右侧分割线背景匹配 dock，移除 footer 上边框
- CSS 变量统一，消除未定义变量导致的显示问题
- unread dot 不可见问题修复