### PR TITLE
fix(tui): submit exact completion on enter

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -869,15 +869,12 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.completion = completion{}
 					break // fall through to regular Enter and submit the command
 				}
-				// When Enter is pressed and the completion has exactly one item
-				// already fully present in the input, close the menu and let Enter
-				// fall through to submit the command (/resume 3 → resume session 3).
-				if msg.String() == "enter" && len(m.completion.items) == 1 {
-					tok := m.input.Value()[m.completion.replaceFrom:]
-					if tok == m.completion.items[0].insert {
-						m.completion = completion{}
-						break // fall through to regular Enter
-					}
+				// When Enter is pressed and the selected completion is already fully
+				// present in the input, close the menu and submit instead of accepting
+				// the same item again (/resume 1 still has /resume 10 as a prefix match).
+				if msg.String() == "enter" && m.completionSelectedInsertPresent() {
+					m.completion = completion{}
+					break // fall through to regular Enter
 				}
 				m.acceptCompletion()
 				return m, nil

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -475,6 +475,17 @@ func (m *chatTUI) completionBareOverlayCommand() bool {
 	}
 }
 
+func (m *chatTUI) completionSelectedInsertPresent() bool {
+	if !m.completion.active || m.completion.sel >= len(m.completion.items) {
+		return false
+	}
+	val := m.input.Value()
+	if m.completion.replaceFrom > len(val) {
+		return false
+	}
+	return val[m.completion.replaceFrom:] == m.completion.items[m.completion.sel].insert
+}
+
 // acceptCompletion applies the selected item to the input, then recomputes the
 // menu from the new value: it re-opens one level deeper (a descended directory
 // or a freshly completed command's arguments) or closes when nothing applies.

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -330,6 +330,28 @@ func TestEnterOnMCPWithTrailingSpaceSubmitsManager(t *testing.T) {
 	}
 }
 
+func TestEnterOnExactSlashArgSubmitsWhenPrefixAlsoMatches(t *testing.T) {
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{SessionDir: t.TempDir()})
+	m.input.SetValue("/resume 1")
+	m.completion = completion{
+		active:      true,
+		kind:        compSlashArg,
+		items:       []compItem{{label: "1", insert: "1"}, {label: "10", insert: "10"}},
+		sel:         0,
+		replaceFrom: len("/resume "),
+	}
+
+	got, _ := m.update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	next := got.(chatTUI)
+	if next.completion.active {
+		t.Fatalf("Enter on exact selected arg should close completion: %+v", next.completion)
+	}
+	if got := next.input.Value(); got != "" {
+		t.Fatalf("Enter on exact selected arg should submit command, input=%q", got)
+	}
+}
+
 // TestSlashArgCompletionRemoveNoHost proves "/mcp remove " stays closed when no
 // servers are connected (nothing to suggest), rather than showing an empty box.
 func TestSlashArgCompletionRemoveNoHost(t *testing.T) {


### PR DESCRIPTION
## Summary

  Fixes #3592

  Fix terminal TUI autocomplete so Enter submits when the currently selected completion item is already fully present in the
  input token.

  This fixes `/resume 1` when both `1` and `10` remain in the completion list. Previously, Enter was captured by the
  completion menu and kept accepting the already-inserted `1`, so the command did not submit.

  ## Changes

  - Add `completionSelectedInsertPresent()` to detect when the selected completion insert already matches the current token.
  - Let Enter close the completion menu and fall through to normal submission in that exact-match case.
  - Add a regression test for `/resume 1` with both `1` and `10` present.

  ## Scope

  This is limited to TUI autocomplete Enter handling. Tab behavior is unchanged.

  The fix is intentionally generic for exact selected inserts, so it also avoids the same stuck-Enter behavior for other
  completion menus where the selected item is already fully typed but other prefix matches remain.

  ## Tests

  - `go test ./internal/cli -run 'TestSlashCompletion|TestSlashArgCompletion|TestEnterOnExactMCPSubmitsManager|
  TestEnterOnMCPWithTrailingSpaceSubmitsManager|TestEnterOnExactSlashArgSubmitsWhenPrefixAlsoMatches|
  TestCompletionClosesOnSpaceAndNonMatch|TestActiveAtToken|TestMoveCompletionWraps' -count=1`
  - `go test ./internal/cli -count=1`
  - `env GOCACHE=/private/tmp/reasonix-gocache go build -o /tmp/reasonix-test ./cmd/reasonix`
  - `git diff --check`