### PR TITLE
feat(openai): support adjusting thinking level for MiniMax-M3

### DIFF
--- a/internal/config/effort.go
+++ b/internal/config/effort.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"fmt"
-	"net/url"
 	"strings"
+
+	"reasonix/internal/provider/openai"
 )
 
 const (
@@ -66,6 +67,13 @@ func EffortCapabilityForEntry(e *ProviderEntry) EffortCapability {
 		return openAIEffortCapability()
 	}
 	switch {
+	case isMiniMaxEntry(e):
+		// MiniMax-M3 only exposes a binary thinking knob (adaptive|disabled)
+		// on its OpenAI-compatible endpoint, so /effort mirrors the API
+		// vocabulary verbatim. Default is "adaptive" because the M3 model
+		// runs with thinking on out of the box; "auto" means "don't override
+		// the model default" (== adaptive for M3).
+		return EffortCapability{Supported: true, Levels: []string{"auto", "adaptive", "disabled"}, Default: "adaptive"}
 	case e != nil && e.Kind == "anthropic":
 		return EffortCapability{Supported: true, Levels: []string{"auto", "low", "medium", "high", "xhigh", "max"}, Default: "auto"}
 	default:
@@ -114,6 +122,24 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 		}
 	}
 	switch {
+	case isMiniMaxEntry(e):
+		// The M3 knob is binary; map Anthropic / OpenAI-style levels onto the
+		// nearest valid value so a stale /effort high|low still works. "off"
+		// is a retired DeepSeek level meaning "no thinking" — on M3 that maps
+		// to "disabled" rather than the model default, since M3 actually
+		// supports a "thinking off" mode and "off" is the natural request.
+		switch level {
+		case "adaptive", "disabled":
+			return level, nil
+		case "off":
+			return "disabled", nil
+		case "low", "medium", "high":
+			return "adaptive", nil
+		case "xhigh", "max":
+			return "disabled", nil
+		default:
+			return "", fmt.Errorf("usage: /effort auto|adaptive|disabled")
+		}
 	case e != nil && e.Kind == "anthropic":
 		switch level {
 		case "low", "medium", "high", "xhigh", "max":
@@ -217,16 +243,18 @@ func normalizeReasoningProtocol(raw string) string {
 	}
 }
 
+// isDeepSeekEntry reports whether the entry points at DeepSeek's API. The
+// actual host matching lives in provider/openai so the openai package and
+// the config layer stay in lockstep when new gateways are added.
 func isDeepSeekEntry(e *ProviderEntry) bool {
-	if e == nil || e.Kind != "openai" {
-		return false
-	}
-	u, err := url.Parse(e.BaseURL)
-	if err != nil {
-		return false
-	}
-	host := strings.ToLower(u.Hostname())
-	return host == "api.deepseek.com" || strings.HasSuffix(host, ".deepseek.com")
+	return e != nil && e.Kind == "openai" && openai.IsDeepSeek(e.BaseURL)
+}
+
+// isMiniMaxEntry reports whether the entry points at MiniMax's OpenAI-compatible
+// endpoint. See openai.IsMiniMax for the host-matching rule; the entry-wrapper
+// just gates on the openai kind.
+func isMiniMaxEntry(e *ProviderEntry) bool {
+	return e != nil && e.Kind == "openai" && openai.IsMiniMax(e.BaseURL)
 }
 
 func resolvedModelReasoningCapability(e *ProviderEntry) (modelReasoningCapability, bool) {

--- a/internal/config/effort_test.go
+++ b/internal/config/effort_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsMiniMaxEntry(t *testing.T) {
+	for _, tc := range []struct {
+		baseURL string
+		want    bool
+	}{
+		{"https://api.minimaxi.com/v1", true},
+		{"https://api.minimaxi.com", true},
+		{"https://api.minimaxi.com/anthropic", true},
+		// Subdomain variants of the canonical host.
+		{"https://eu.minimaxi.com/v1", true},
+		{"https://us.minimaxi.com/v1", true},
+		// Bare apex (no api. prefix) is rejected: it would only match if
+		// the user pointed their base_url at the apex domain, which is a
+		// misconfiguration — not a path we want to silently accept.
+		{"https://minimaxi.com/v1", false},
+		{"https://minimaxi.com", false},
+		// Other vendors must not match.
+		{"https://api.deepseek.com", false},
+		{"https://api.xiaomimimo.com/v1", false},
+		{"https://api.minimax.example.com", false}, // wrong spelling — must not match
+		{"", false},
+	} {
+		e := &ProviderEntry{Kind: "openai", BaseURL: tc.baseURL}
+		if got := isMiniMaxEntry(e); got != tc.want {
+			t.Errorf("baseURL=%q: isMiniMaxEntry=%v, want %v", tc.baseURL, got, tc.want)
+		}
+	}
+}
+
+func TestEffortCapabilityMiniMax(t *testing.T) {
+	e := &ProviderEntry{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1", Model: "MiniMax-M3"}
+	cap := EffortCapabilityForEntry(e)
+	if !cap.Supported {
+		t.Fatalf("M3 entry should expose /effort, got %+v", cap)
+	}
+	wantLevels := []string{"auto", "adaptive", "disabled"}
+	if len(cap.Levels) != len(wantLevels) {
+		t.Fatalf("levels = %v, want %v", cap.Levels, wantLevels)
+	}
+	for i, l := range wantLevels {
+		if cap.Levels[i] != l {
+			t.Errorf("levels[%d] = %q, want %q", i, cap.Levels[i], l)
+		}
+	}
+	if cap.Default != "adaptive" {
+		t.Errorf("default = %q, want adaptive (M3 ships with thinking on)", cap.Default)
+	}
+}
+
+func TestNormalizeEffortMiniMax(t *testing.T) {
+	e := &ProviderEntry{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1", Model: "MiniMax-M3"}
+	cases := []struct {
+		in, want string
+	}{
+		{"auto", ""}, // auto == "leave to provider default" == empty
+		{"adaptive", "adaptive"},
+		{"disabled", "disabled"},
+		{"ADAPTIVE", "adaptive"}, // case-insensitive
+		// Stale values from other vendors still resolve to a valid M3 level
+		// rather than failing the /effort command.
+		{"off", "disabled"}, // retired DeepSeek "no thinking" → M3 actually supports "disabled"
+		{"low", "adaptive"},
+		{"medium", "adaptive"},
+		{"high", "adaptive"},
+		{"xhigh", "disabled"},
+		{"max", "disabled"},
+	}
+	for _, tc := range cases {
+		got, err := NormalizeEffort(e, tc.in)
+		if err != nil {
+			t.Errorf("NormalizeEffort(%q) returned error: %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("NormalizeEffort(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeEffortMiniMaxRejectsGarbage(t *testing.T) {
+	e := &ProviderEntry{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1", Model: "MiniMax-M3"}
+	// "turbo" and similar unrecognised inputs reach the MiniMax switch and
+	// are rejected with the MiniMax-specific usage hint. Empty input is
+	// rejected earlier with the generic hint; both are valid user-facing
+	// errors. "off" is *not* in this list — it's a retired level we now
+	// migrate to "adaptive" (tested in TestNormalizeEffortMiniMax above).
+	cases := map[string]string{
+		"turbo": "auto|adaptive|disabled",
+		"":      "auto|<level>",
+	}
+	for in, wantHint := range cases {
+		_, err := NormalizeEffort(e, in)
+		if err == nil {
+			t.Errorf("NormalizeEffort(%q) should be rejected", in)
+			continue
+		}
+		if !strings.Contains(err.Error(), wantHint) {
+			t.Errorf("NormalizeEffort(%q) error = %q, want it to mention %q", in, err.Error(), wantHint)
+		}
+	}
+}
+
+func TestEffectiveEffortMiniMax(t *testing.T) {
+	e := &ProviderEntry{Kind: "openai", BaseURL: "https://api.minimaxi.com/v1", Model: "MiniMax-M3"}
+	// unset → EffectiveEffort stays empty so the wire layer defaults to adaptive
+	if got := EffectiveEffort(e); got != "" {
+		t.Errorf("unset EffectiveEffort = %q, want \"\"", got)
+	}
+	// explicit value is preserved verbatim
+	e.Effort = "disabled"
+	if got := EffectiveEffort(e); got != "disabled" {
+		t.Errorf("explicit EffectiveEffort = %q, want disabled", got)
+	}
+}

--- a/internal/provider/openai/host.go
+++ b/internal/provider/openai/host.go
@@ -1,0 +1,46 @@
+package openai
+
+import (
+	"net/url"
+	"strings"
+)
+
+// matchesVendorHost reports whether baseURL points at one of the canonical
+// hostnames (exact match, case-insensitive) or at any subdomain of apex.
+// Returns false on any parse error or empty host.
+//
+// We take the apex separately from the canonical because they differ: the
+// canonical (e.g. api.minimaxi.com) is the specific endpoint, but regional
+// subdomains like eu.minimaxi.com or us.minimaxi.com should also match —
+// the wire shape is the same, just hosted in a different region. The bare
+// apex (e.g. minimaxi.com) is intentionally rejected: it would only happen
+// if the user pointed their base_url at the apex domain, which is a
+// misconfiguration — not a path we want to silently accept.
+func matchesVendorHost(baseURL, apex string, canonical ...string) bool {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(u.Hostname())
+	for _, c := range canonical {
+		if host == c {
+			return true
+		}
+	}
+	return strings.HasSuffix(host, "."+apex)
+}
+
+// IsDeepSeek reports whether baseURL points at DeepSeek's API
+// (api.deepseek.com or any *.deepseek.com subdomain).
+func IsDeepSeek(baseURL string) bool {
+	return matchesVendorHost(baseURL, "deepseek.com", "api.deepseek.com")
+}
+
+// IsMiniMax reports whether baseURL points at MiniMax's OpenAI-compatible
+// endpoint (api.minimaxi.com or any *.minimaxi.com subdomain).
+//
+// The host string is matched exactly — the spelling is `minimaxi`, not
+// `minimax` — to avoid clashing with any future minimax-branded gateway.
+func IsMiniMax(baseURL string) bool {
+	return matchesVendorHost(baseURL, "minimaxi.com", "api.minimaxi.com")
+}

--- a/internal/provider/openai/host_test.go
+++ b/internal/provider/openai/host_test.go
@@ -1,0 +1,72 @@
+package openai
+
+import "testing"
+
+// TestIsDeepSeek pins the host-matching rule for DeepSeek: the canonical
+// api.deepseek.com, any *.deepseek.com subdomain, but NOT the apex
+// deepseek.com (a misconfiguration we explicitly reject).
+func TestIsDeepSeek(t *testing.T) {
+	for _, tc := range []struct {
+		baseURL string
+		want    bool
+	}{
+		// Canonical
+		{"https://api.deepseek.com", true},
+		{"https://api.deepseek.com/v1", true},
+		{"https://api.deepseek.com/anthropic", true},
+		// Regional subdomains under the apex
+		{"https://eu.deepseek.com/v1", true},
+		{"https://us.deepseek.com/v1", true},
+		// Apex rejected (would require a user pointing their base_url at
+		// the apex domain, which is a misconfiguration)
+		{"https://deepseek.com/v1", false},
+		{"https://deepseek.com", false},
+		// Other vendors must not match
+		{"https://api.minimaxi.com/v1", false},
+		{"https://api.openai.com/v1", false},
+		// Wrong-spelling TLDs (e.g. "deepseek.io") must not match
+		{"https://api.deepseek.io", false},
+		{"https://deepseek.io", false},
+		// Garbage
+		{"", false},
+		{"not-a-url", false},
+	} {
+		if got := IsDeepSeek(tc.baseURL); got != tc.want {
+			t.Errorf("IsDeepSeek(%q) = %v, want %v", tc.baseURL, got, tc.want)
+		}
+	}
+}
+
+// TestIsMiniMax pins the host-matching rule for MiniMax. The spelling is
+// `minimaxi`, not `minimax` — the latter is reserved for any future
+// minimax-branded gateway so the two never collide.
+func TestIsMiniMax(t *testing.T) {
+	for _, tc := range []struct {
+		baseURL string
+		want    bool
+	}{
+		// Canonical
+		{"https://api.minimaxi.com", true},
+		{"https://api.minimaxi.com/v1", true},
+		{"https://api.minimaxi.com/anthropic", true},
+		// Regional subdomains under the apex
+		{"https://eu.minimaxi.com/v1", true},
+		{"https://us.minimaxi.com/v1", true},
+		// Apex rejected
+		{"https://minimaxi.com/v1", false},
+		{"https://minimaxi.com", false},
+		// Other vendors must not match
+		{"https://api.deepseek.com", false},
+		{"https://api.openai.com/v1", false},
+		// Wrong spelling — minimax, not minimaxi — must not match
+		{"https://api.minimax.com/v1", false},
+		{"https://api.minimax.example.com", false},
+		// Garbage
+		{"", false},
+		{"not-a-url", false},
+	} {
+		if got := IsMiniMax(tc.baseURL); got != tc.want {
+			t.Errorf("IsMiniMax(%q) = %v, want %v", tc.baseURL, got, tc.want)
+		}
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -1,6 +1,13 @@
 // Package openai implements the OpenAI-compatible /chat/completions provider.
-// It self-registers under the "openai" kind, so DeepSeek, MiMo, and any other
-// OpenAI-compatible endpoint are just config instances rather than code.
+// It self-registers under the "openai" kind, so DeepSeek, MiMo, MiniMax-M3, and
+// any other OpenAI-compatible endpoint are just config instances rather than
+// code. Each instance picks the wire shape from its base URL:
+//   - api.deepseek.com → emits thinking.type=enabled (DeepSeek-flavor CoT) plus
+//     reasoning_effort as a depth hint.
+//   - api.minimaxi.com → emits thinking.type=adaptive|disabled (M3's binary
+//     knob) instead of reasoning_effort, since M3 has no level scale.
+//   - everything else (MiMo and other OpenAI-compatible gateways) uses the
+//     vanilla reasoning_effort scale (low/medium/high).
 package openai
 
 import (
@@ -10,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -40,7 +46,8 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	effort, _ := cfg.Extra["effort"].(string)
 	protocol, _ := cfg.Extra["reasoning_protocol"].(string)
 	protocol = normalizeReasoningProtocol(protocol)
-	deepseek := protocol == "deepseek" || (protocol == "" && isDeepSeekBaseURL(cfg.BaseURL))
+	deepseek := protocol == "deepseek" || (protocol == "" && IsDeepSeek(cfg.BaseURL))
+	minimax := protocol == "" && IsMiniMax(cfg.BaseURL)
 	switch {
 	case protocol == "none":
 		effort = ""
@@ -52,6 +59,19 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		case "high", "max":
 		default:
 			return nil, fmt.Errorf("openai: provider %q uses DeepSeek thinking; effort must be high or max", name)
+		}
+	case minimax:
+		// M3's knob is binary. The config effort layer normalises user input
+		// to "adaptive", "disabled", or "" (== auto). We keep "high"/"max"
+		// (legacy DeepSeek) and "low"/"medium" (Anthropic) out — config-level
+		// NormalizeEffort remaps them to "adaptive" already, so anything
+		// reaching here is expected to be one of: "", "adaptive", "disabled".
+		effort = strings.ToLower(strings.TrimSpace(effort))
+		switch effort {
+		case "": // auto — leave empty so the wire emits thinking.type=adaptive
+		case "adaptive", "disabled":
+		default:
+			return nil, fmt.Errorf("openai: provider %q uses MiniMax thinking; effort must be adaptive or disabled", name)
 		}
 	case effort != "":
 		// Non-DeepSeek backends use OpenAI's reasoning_effort scale (low/medium/
@@ -77,6 +97,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		baseURL:  strings.TrimRight(cfg.BaseURL, "/"),
 		model:    cfg.Model,
 		deepseek: deepseek,
+		minimax:  minimax,
 		effort:   effort,
 		http:     httpClient,
 	}, nil
@@ -100,19 +121,11 @@ type client struct {
 	model    string
 	http     *http.Client
 	deepseek bool
-	effort   string // reasoning_effort forwarded to thinking-capable models; "" = omit
+	minimax  bool   // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
+	effort   string // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
 }
 
 func (c *client) Name() string { return c.name }
-
-func isDeepSeekBaseURL(baseURL string) bool {
-	u, err := url.Parse(baseURL)
-	if err != nil {
-		return false
-	}
-	host := strings.ToLower(u.Hostname())
-	return host == "api.deepseek.com" || strings.HasSuffix(host, ".deepseek.com")
-}
 
 func normalizeReasoningProtocol(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
@@ -248,8 +261,21 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		MaxTokens:       req.MaxTokens,
 		ReasoningEffort: c.effort,
 	}
-	if c.deepseek {
+	switch {
+	case c.deepseek:
+		// DeepSeek's CoT is controlled by `thinking` (always on) plus
+		// `reasoning_effort` for depth. We never disable thinking for DeepSeek.
 		out.Thinking = &thinkingMode{Type: "enabled"}
+	case c.minimax:
+		// M3 uses a single `thinking.type` field with two valid values:
+		// "adaptive" (default, thinking on) and "disabled" (off). Reasoning
+		// depth is not a knob on M3, so reasoning_effort is omitted entirely.
+		t := c.effort
+		if t == "" {
+			t = "adaptive" // /effort auto == the M3 model default
+		}
+		out.Thinking = &thinkingMode{Type: t}
+		out.ReasoningEffort = ""
 	}
 	return out
 }

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -351,6 +351,88 @@ func TestBuildRequestDeepSeekThinking(t *testing.T) {
 	}
 }
 
+// TestBuildRequestMiniMaxThinking covers the M3 wire shape: thinking.type is
+// the only knob (no reasoning_effort), and the empty-effort / auto case still
+// emits an explicit "adaptive" because that's what the M3 model default means
+// (M3 has no implicit "no thinking" mode at the wire level).
+func TestBuildRequestMiniMaxThinking(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		effort       string
+		wantThinking string
+	}{
+		{name: "auto-defaults-to-adaptive", effort: "", wantThinking: "adaptive"},
+		{name: "adaptive", effort: "adaptive", wantThinking: "adaptive"},
+		{name: "disabled", effort: "disabled", wantThinking: "disabled"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := (&client{model: "MiniMax-M3", minimax: true, effort: tc.effort}).buildRequest(provider.Request{})
+			if req.Thinking == nil || req.Thinking.Type != tc.wantThinking {
+				t.Fatalf("Thinking = %+v, want %q", req.Thinking, tc.wantThinking)
+			}
+			if req.ReasoningEffort != "" {
+				t.Fatalf("MiniMax must not send reasoning_effort, got %q", req.ReasoningEffort)
+			}
+		})
+	}
+}
+
+// TestNewMiniMaxEffortValidation locks in the boot-time validation for the
+// MiniMax path. The config effort layer remaps legacy level names, so by the
+// time effort reaches this factory it must be one of: "", "adaptive",
+// "disabled". Anything else is a config bug, surfaced now (not at request
+// time) for an actionable error.
+func TestNewMiniMaxEffortValidation(t *testing.T) {
+	base := provider.Config{Name: "m3", BaseURL: "https://api.minimaxi.com/v1", Model: "MiniMax-M3", APIKey: "k"}
+	// happy path: auto (empty effort) and both explicit values are accepted
+	for _, ok := range []string{"", "adaptive", "disabled"} {
+		if _, err := New(withEffort(base, ok)); err != nil {
+			t.Errorf("effort=%q should be accepted: %v", ok, err)
+		}
+	}
+	// unhappy: anything else is rejected up front
+	for _, bad := range []string{"high", "low", "max", "turbo"} {
+		if _, err := New(withEffort(base, bad)); err == nil {
+			t.Errorf("effort=%q should be rejected", bad)
+		}
+	}
+}
+
+// TestNewMiniMaxSetsFlag is a smoke test for base-URL detection: the factory
+// must set the `minimax` flag when the base URL points at api.minimaxi.com
+// (with or without the /v1 suffix) so buildRequest picks the right wire shape.
+func TestNewMiniMaxSetsFlag(t *testing.T) {
+	for _, baseURL := range []string{
+		"https://api.minimaxi.com/v1",
+		"https://api.minimaxi.com",
+	} {
+		p, err := New(provider.Config{Name: "m3", BaseURL: baseURL, Model: "MiniMax-M3", APIKey: "k"})
+		if err != nil {
+			t.Fatalf("New(%q): %v", baseURL, err)
+		}
+		c := p.(*client)
+		if !c.minimax {
+			t.Errorf("minimax flag not set for baseURL=%q", baseURL)
+		}
+	}
+}
+
+func withEffort(c provider.Config, effort string) provider.Config {
+	extra := c.Extra
+	if extra == nil {
+		extra = map[string]any{}
+	} else {
+		cp := make(map[string]any, len(extra)+1)
+		for k, v := range extra {
+			cp[k] = v
+		}
+		extra = cp
+	}
+	extra["effort"] = effort
+	c.Extra = extra
+	return c
+}
+
 func TestBuildRequestNonDeepSeekOmitsThinking(t *testing.T) {
 	req := (&client{model: "mimo-v2", effort: "high"}).buildRequest(provider.Request{})
 	if req.Thinking != nil {


### PR DESCRIPTION
Rebased @lightfront's #3432 onto current main-v2 and reconciled it with the reasoning-protocol refactor + the effort=auto handling that landed since it was opened (#3571).

## What it does
Teaches the openai provider to speak MiniMax-M3's binary thinking knob (`adaptive` | `disabled`) for `api.minimaxi.com` (and `*.minimaxi.com`), mirroring the existing DeepSeek wire shape:
- emits `thinking.type = adaptive|disabled` and **omits** `reasoning_effort` (M3 rejects it)
- `/effort` exposes `auto|adaptive|disabled` (default `adaptive`); stale level names from other vendors map to the nearest valid M3 value
- new `host.go` (`IsDeepSeek`/`IsMiniMax`) centralizes vendor-host detection

## Reconciliation notes (vs the original)
- Kept main-v2's `reasoning_protocol` machinery: `minimax` is gated by `protocol == ""` (like `deepseek`), so an explicit protocol override still wins.
- Adopted `IsDeepSeek` from the new `host.go` and dropped the now-redundant local `isDeepSeekBaseURL` (identical semantics).
- MiniMax routes through the `isMiniMaxEntry` fallback in `EffortCapability` / `NormalizeEffort` (it isn't a `ReasoningProtocol` value), leaving the deepseek/openai protocol paths intact.

## Testing
- `go build ./...`, `go vet`, `go test ./internal/provider/openai ./internal/config` all green (MiniMax + the existing DeepSeek/OpenAI/effort-auto tests).

Closes #3432

Original work by @lightfront.
