### PR TITLE
fix(desktop): unify font family for model names and UI labels

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -745,7 +745,7 @@ a[href] {
   font-weight: 600;
 }
 .topbar__model {
-  font-family: var(--mono);
+  font-family: inherit;
   font-size: 11px;
   color: var(--fg-dim);
   overflow: hidden;
@@ -6480,7 +6480,7 @@ a[href] {
 .settings-center__navitem small {
   color: var(--fg-dim);
   font-size: var(--text-2xs);
-  font-family: var(--mono);
+  font-family: inherit;
 }
 
 .settings-center__content {
@@ -6922,7 +6922,7 @@ a[href] {
   font-size: var(--text-base);
   font-weight: 700;
   color: var(--fg);
-  font-family: var(--mono);
+  font-family: inherit;
 }
 .settings-model-current__meta {
   display: flex;
@@ -6938,7 +6938,7 @@ a[href] {
   border-radius: 999px;
   background: var(--bg-elev-2);
   color: var(--fg-muted);
-  font-family: var(--mono);
+  font-family: inherit;
   font-size: var(--text-2xs);
   line-height: 1;
   padding: 5px 8px;
@@ -6994,7 +6994,7 @@ a[href] {
 }
 .settings-model-picker__selected span {
   color: var(--fg);
-  font-family: var(--mono);
+  font-family: inherit;
   font-size: var(--font-control);
   font-weight: 650;
 }


### PR DESCRIPTION
## 问题

桌面端多处 UI 元素（模型名称、导航栏副标题、当前状态标签等）硬编码了 \ont-family: var(--mono)\，导致用户切换字体后这些元素仍然使用等宽字体，与整体字体不一致。

关联 issue: #3468

## 修复

将以下 5 处硬编码的 \ar(--mono)\ 改为 \inherit\，使其跟随用户选择的字体：

- \.topbar__model\ — 顶部状态栏模型名
- \.settings-center__navitem small\ — 设置导航栏副标题（如模型名）
- \.settings-model-current strong\ — 当前状态模型名
- \.settings-model-current__meta span\ — 当前状态元信息标签
- \.settings-model-picker__selected span\ — 模型选择器显示名

## 验证

- [x] \wails dev\ 桌面端实测，切换字体后所有模型名称和标签跟随变化