### PR TITLE
fix(desktop): prevent step limit segmented buttons from wrapping on narrow screens

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6867,7 +6867,10 @@ a[href] {
 
   .step-limit-control {
     justify-content: flex-start;
-    flex-wrap: wrap;
+  }
+
+  .step-limit-control .set-seg {
+    flex-shrink: 0;
   }
 
   .settings-subtabs {
@@ -7735,6 +7738,7 @@ a[href] {
   font-size: var(--font-control-small);
   padding: 5px 13px;
   text-transform: capitalize;
+  white-space: nowrap;
 }
 .set-seg__btn--on {
   background: var(--accent-soft);


### PR DESCRIPTION
## 问题

设置页面中「执行轮数上限」和「规划轮数上限」的 segmented 按钮组在竖屏/窄窗口下，\lex-wrap: wrap\ 导致按钮换行，「自定义」等文字被截断或布局错乱。

## 修复

- 移除 \.step-limit-control\ 的 \lex-wrap: wrap\，改为横向滚动
- 给 \.step-limit-control .set-seg\ 加 \lex-shrink: 0\ 防止被压缩
- 给 \.set-seg__btn\ 加 \white-space: nowrap\ 防止按钮内文字换行

## 验证

- [x] \wails dev\ 桌面端实测，竖屏窄窗口下按钮组横向滚动，不再换行