### PR TITLE
feat(run): add --resume flag for precise session file targeting / 支持精确恢复会话文件

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -205,6 +205,9 @@ func runAgent(args []string) int {
 	showThinking := fs.Bool("show-thinking", false, "show thinking text instead of the collapsed thinking marker")
 	metricsPath := fs.String("metrics", "", "write a JSON token/cache/cost summary of the run to this path")
 	dir := fs.String("dir", "", "change to this directory first (project root); config, sandbox and file tools resolve from here")
+	cont := fs.Bool("continue", false, "resume the most recent saved session")
+	fs.BoolVar(cont, "c", false, "shorthand for --continue")
+	resume := fs.String("resume", "", "resume a specific session file (non-interactive; takes precedence over --continue)")
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
@@ -252,6 +255,38 @@ func runAgent(args []string) int {
 		return 1
 	}
 	defer ctrl.Close()
+
+	// --resume: load a specific session file (non-interactive, meant for
+	// MCP/API callers that manage their own per-project session). Takes
+	// precedence over --continue.
+	// --continue: resume the most recent saved session.
+	if *resume != "" {
+		loaded, err := agent.LoadSession(*resume)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		ctrl.Resume(loaded, *resume)
+	} else if *cont {
+		sessions, err := agent.ListSessions(config.SessionDir())
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		if len(sessions) == 0 {
+			fmt.Fprintln(os.Stderr, i18n.M.NoSessionToResume)
+			return 1
+		}
+		loaded, err := agent.LoadSession(sessions[0].Path)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+		ctrl.Resume(loaded, sessions[0].Path)
+	}
+	if ctrl.SessionPath() == "" && ctrl.SessionDir() != "" {
+		ctrl.SetSessionPath(agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label()))
+	}
 
 	runErr := ctrl.Run(ctx, prompt)
 	if cfg != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -92,8 +92,11 @@ func TestMetadataCommandsDoNotProbeTerminalTheme(t *testing.T) {
 			t.Fatalf("help rc = %d, want 0", rc)
 		}
 	})
-	if !strings.Contains(out, "Usage:") {
+	if !strings.Contains(out, "Usage:") && !strings.Contains(out, "用法：") {
 		t.Fatalf("help output missing usage:\n%s", out)
+	}
+	if !strings.Contains(out, "reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] <task>") {
+		t.Fatalf("help output missing run resume flags:\n%s", out)
 	}
 }
 

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -307,7 +307,7 @@ var English = Messages{
 
 Usage:
   reasonix chat [--model NAME] [-c|--continue] [--resume]   interactive session (multi-turn; -c resumes the latest, --resume picks one)
-  reasonix run  [--model NAME] [--max-steps N] <task>   run one task and exit
+  reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] <task>   run one task and exit
   reasonix serve [--model NAME] [--addr HOST:PORT]      serve the session over HTTP+SSE (browser client at /)
   reasonix acp [--model NAME]                           serve Agent Client Protocol over stdio (also: reasonix --acp)
   reasonix setup [path]                                 interactive config wizard; writes reasonix.toml (+ .env)

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -308,7 +308,7 @@ var Chinese = Messages{
 
 用法：
   reasonix chat [--model NAME] [-c|--continue] [--resume]   交互式会话（多轮；-c 恢复最近一次，--resume 选择一个）
-  reasonix run  [--model NAME] [--max-steps N] <task>   执行单次任务后退出
+  reasonix run  [--model NAME] [--max-steps N] [-c|--continue] [--resume PATH] <task>   执行单次任务后退出
   reasonix serve [--model NAME] [--addr HOST:PORT]      通过 HTTP+SSE 提供会话（浏览器客户端在 /）
   reasonix acp [--model NAME]                           通过 stdio 提供 Agent Client Protocol（也可用：reasonix --acp）
   reasonix setup [path]                                 交互式配置向导；生成 reasonix.toml（及 .env）


### PR DESCRIPTION
## Summary
- 为 `reasonix run` 增加 `--resume <session-file>`，允许非交互调用方精确恢复指定会话文件
- 保留并补上 `--continue` / `-c`，用于恢复最近一次保存的会话
- 对 `--resume` / `--continue` 的恢复失败显式报错，避免静默新建会话
- 同步中英文 help usage，并补充 metadata 测试断言

## 说明
- 此 PR 的代码由 DeepSeek 生成
- 默认使用中文说明，方便后续审阅与追踪

## Testing
- `go test ./internal/cli -run TestMetadataCommandsDoNotProbeTerminalTheme` 通过
- `go test ./internal/cli` 未完全通过；当前 Windows 环境下仍观察到既有失败：临时目录清理时文件占用、缺失 chdir 目标、rewind 中文渲染断言不匹配、statusline 刷新断言不匹配