### PR TITLE
fix(desktop): 修复粘贴附件保存到错误的工作区目录

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3402,16 +3402,32 @@ func (a *App) currentProviderEntryForTab(tabID string) (*config.ProviderEntry, e
 	return entry, nil
 }
 
-// SavePastedImage stores a browser clipboard image data URL under
-// .reasonix/attachments and returns the relative @-reference path.
+// SavePastedImage stores a browser clipboard image data URL under the active
+// tab's workspace .reasonix/attachments and returns the relative @-reference path.
 func (a *App) SavePastedImage(dataURL string) (string, error) {
+	root := a.activeWorkspaceRoot()
+	if root != "" && root != "." {
+		if prev, err := os.Getwd(); err == nil {
+			if err := os.Chdir(root); err == nil {
+				defer func() { _ = os.Chdir(prev) }()
+			}
+		}
+	}
 	return control.SaveImageDataURL(dataURL)
 }
 
 // SavePastedFile stores a dropped non-image file (the browser exposes its bytes
-// as a data URL but not a real path) under .reasonix/attachments and returns the
-// relative @-reference path.
+// as a data URL but not a real path) under the active tab's workspace
+// .reasonix/attachments and returns the relative @-reference path.
 func (a *App) SavePastedFile(name, dataURL string) (string, error) {
+	root := a.activeWorkspaceRoot()
+	if root != "" && root != "." {
+		if prev, err := os.Getwd(); err == nil {
+			if err := os.Chdir(root); err == nil {
+				defer func() { _ = os.Chdir(prev) }()
+			}
+		}
+	}
 	return control.SaveAttachmentDataURL(name, dataURL)
 }
 


### PR DESCRIPTION
\, \attachments\, name)\)。cwd 在启动时从 \desktop-workspace\ 设置一次，当用户切换到不同项目的标签页时不会更新。

当前活动标签页的正确工作区根目录可以通过 \App.activeWorkspaceRoot()\ 获取（已被 \LoadConfig\ 等多个方法使用），但这两个方法没有使用它。

## 修复方案

在写入附件前，先 \os.Chdir\ 到活动标签页的 \WorkspaceRoot\，然后通过 defer 恢复原始 cwd。有优雅降级处理——如果 \ctiveWorkspaceRoot()\ 返回 \\\\ 或 \\.\\，或者 chdir 失败，会保留原有行为。