### PR TITLE
fix(composer): refresh @ mention picker on workspace/project switch (#3601)

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -341,6 +341,10 @@ export function Composer({
   const lastSelectionRef = useRef({ start: 0, end: 0 });
   const consumedInsertIdRef = useRef(0);
   const submittingRef = useRef(false);
+  // Snapshot of the current cwd so async callbacks (openPastChats) can detect
+  // workspace switches and discard stale responses (issue #3601).
+  const cwdRef = useRef(cwd);
+  cwdRef.current = cwd;
   const attachmentDedupRef = useRef(new DedupIndex());
   const attachmentDedupKeysRef = useRef<Record<string, AttachmentDedupKey>>({});
 
@@ -431,6 +435,27 @@ export function Composer({
   const [searchEntries, setSearchEntries] = useState<DirEntry[]>([]);
   const dirCache = useRef<Record<string, DirEntry[]>>({});
   const searchCache = useRef<Record<string, DirEntry[]>>({});
+
+  // When the workspace/project changes (cwd prop), invalidate all @ mention
+  // state so the picker reloads candidates for the new project. Without this,
+  // dirCache/searchCache retain entries from the old project and the picker
+  // shows stale results (issue #3601).
+  const prevCwdRef = useRef(cwd);
+  useEffect(() => {
+    if (prevCwdRef.current === cwd) return; // skip mount — state already initial
+    prevCwdRef.current = cwd;
+    dirCache.current = {};
+    searchCache.current = {};
+    setEntries([]);
+    setSearchEntries([]);
+    setShowPastChats(false);
+    setPastChats([]);
+    setPastChatQuery("");
+    setLoadingPastChats(false);
+    setActive(0);
+    setDismissed(false);
+  }, [cwd]);
+
   useEffect(() => {
     if (atRaw === null) return;
     const cached = dirCache.current[atDir];
@@ -450,8 +475,8 @@ export function Composer({
     return () => {
       live = false;
     };
-    // re-fetch only when the menu opens or the directory level changes
-  }, [atRaw === null, atDir]);
+    // re-fetch when the menu opens or the directory level changes
+  }, [atRaw === null, atDir, cwd]);
   useEffect(() => {
     if (atRaw === null || atDir !== "" || atFrag === "") {
       setSearchEntries([]);
@@ -475,7 +500,7 @@ export function Composer({
     return () => {
       live = false;
     };
-  }, [atRaw === null, atDir, atFrag]);
+  }, [atRaw === null, atDir, atFrag, cwd]);
   const atMatches = useMemo(
     () => {
       if (atRaw === null) return [];
@@ -1050,12 +1075,15 @@ export function Composer({
 
   // --- past:chats session reference ---
   const openPastChats = async () => {
+    const snapshotCwd = cwdRef.current;
     setShowPastChats(true);
     setActive(0);
     setPastChatQuery("");
     setLoadingPastChats(true);
     try {
       const sessions = await app.ListSessions();
+      // Discard stale response if workspace changed while the request was in-flight.
+      if (cwdRef.current !== snapshotCwd) return;
       const sorted = asArray(sessions)
         .filter((s) => !s.current)
         .sort((a, b) => {
@@ -1066,9 +1094,10 @@ export function Composer({
         .slice(0, 50);
       setPastChats(sorted);
     } catch {
+      if (cwdRef.current !== snapshotCwd) return;
       setPastChats([]);
     } finally {
-      setLoadingPastChats(false);
+      if (cwdRef.current === snapshotCwd) setLoadingPastChats(false);
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes #3601 — @ mention picker not refreshing when switching between projects.

### Problem
When switching from project A to project B, the @ mention picker still showed project A's file candidates because:
1. `dirCache`/`searchCache` keys didn't include workspace context — switching projects hit stale cache entries
2. `ListDir`/`SearchFileRefs` effect dependencies didn't include `cwd` — no re-fetch on workspace switch
3. `openPastChats` had no race condition protection — stale async responses could overwrite new workspace state

### Reproduction
1. Open project A, type `@` → see A's files
2. Switch to project B, type `@` → **Bug**: still shows A's files
3. **Expected**: shows B's files only

### Changes (1 file: `Composer.tsx`)
- **`cwdRef` snapshot pattern**: Detect workspace switches in async `openPastChats`, discard stale `ListSessions` responses
- **`useEffect([cwd])`**: Invalidate all @ mention state (caches, entries, past chats, loading, active index) when cwd changes
- **`prevCwdRef`**: Skip the effect on initial mount, avoiding unnecessary re-renders
- **Add `cwd` to effect deps**: `ListDir` and `SearchFileRefs` effects re-fetch when workspace changes while menu is open
- **Conditional `finally`**: Only reset `loadingPastChats` when cwd hasn't changed, preventing stale async from overwriting new state

### Verification
- [x] A project: `@` shows A-only files
- [x] Switch to B project: `@` shows B-only files, no A files
- [x] `@` open while switching: candidates auto-refresh to new project
- [x] `@past:chats` entry still present and functional
- [x] TypeScript compilation passes
- [x] Security review: no vulnerabilities found (change is security-enhancing)
- [x] Code review: 2 minor issues found and fixed (mount re-render, effect optimization)

### Security Review
No exploitable issues found. The change is security-enhancing — prevents cross-project data leakage by invalidating caches on workspace switch.
