### PR TITLE
fix(desktop): prevent context menu and popover flash-close during streaming generation

### DIFF
--- a/desktop/frontend/src/components/AnchoredPopover.tsx
+++ b/desktop/frontend/src/components/AnchoredPopover.tsx
@@ -73,26 +73,19 @@ export function AnchoredPopover({
     if (!anchor || !menu) return;
     const next = calculatePosition(anchor, menu, align, offset, placement);
     setPosition((current) => (samePosition(current, next) ? current : next));
-  });
+  }, [open, align, offset, placement]);
 
   useEffect(() => {
     if (!open) return;
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
-    const closeOnScroll = (event: Event) => {
-      const target = event.target;
-      if (target instanceof Node && popoverRef.current?.contains(target)) return;
-      onClose();
-    };
     const closeOnViewportChange = () => onClose();
     window.addEventListener("keydown", closeOnEscape);
     window.addEventListener("resize", closeOnViewportChange);
-    window.addEventListener("scroll", closeOnScroll, true);
     return () => {
       window.removeEventListener("keydown", closeOnEscape);
       window.removeEventListener("resize", closeOnViewportChange);
-      window.removeEventListener("scroll", closeOnScroll, true);
     };
   }, [onClose, open]);
 

--- a/desktop/frontend/src/components/ContextMenu.tsx
+++ b/desktop/frontend/src/components/ContextMenu.tsx
@@ -75,22 +75,15 @@ export function ContextMenu({
       onClose();
     };
     const close = () => onClose();
-    const closeOnScroll = (event: Event) => {
-      const target = event.target;
-      if (target instanceof Node && menuRef.current?.contains(target)) return;
-      onClose();
-    };
     const closeOnEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") onClose();
     };
     window.addEventListener("pointerdown", closeOnOutsidePointerDown, true);
     window.addEventListener("resize", close);
-    window.addEventListener("scroll", closeOnScroll, true);
     window.addEventListener("keydown", closeOnEscape);
     return () => {
       window.removeEventListener("pointerdown", closeOnOutsidePointerDown, true);
       window.removeEventListener("resize", close);
-      window.removeEventListener("scroll", closeOnScroll, true);
       window.removeEventListener("keydown", closeOnEscape);
     };
   }, [open, onClose]);


### PR DESCRIPTION
## Problem

During AI streaming generation, right-click context menus and popover dropdowns (branch selector, recent files menu, etc.) flash open and immediately close, making them unreadable and unclickable.

## Root Cause

Both `AnchoredPopover` and `ContextMenu` listen for `scroll` events on `window` to close themselves. During streaming, the transcript area auto-scrolls on every incoming token (`Transcript.tsx:218-226`), which fires window `scroll` events that instantly close any open menu.

## Fix

1. **`AnchoredPopover.tsx`** — Remove the `closeOnScroll` listener. The popover still closes on Escape key, window resize, and backdrop click. Also fixed `useLayoutEffect` missing dependency array `[open, align, offset, placement]` to reduce unnecessary layout recalculations during streaming re-renders.

2. **`ContextMenu.tsx`** — Remove the `closeOnScroll` listener. The menu still closes on Escape key, window resize, and click-outside (via `pointerdown`).

## Impact

- All right-click menus (TabBar, ProjectTree, HistoryPanel, WorkspacePanel tree rows)
- All `AnchoredPopover` instances (branch selector, recent files menu)
- `/` slash command menu and `@` file menu are **not affected** (they never had global scroll listeners)

Closes #TBD