### PR TITLE
fix(web_fetch): reuse network proxy resolution

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -204,8 +204,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	searchSpec := builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, stderr)
 	bashTimeout := time.Duration(cfg.BashTimeoutSeconds()) * time.Second
-	proxyURL := netclient.ResolveProxyURL(proxySpec)
-	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRootsForRoot(root), bashSpec, bashTimeout, searchSpec, stderr, root, proxyURL)
+	addBuiltins(reg, cfg.Tools.Enabled, cfg.WriteRootsForRoot(root), bashSpec, bashTimeout, searchSpec, stderr, root, proxySpec)
 	// Always construct a host, even with no plugins configured, so the controller's
 	// host pointer is stable for the session and `/mcp add` can hot-add into it.
 	pluginHost := plugin.NewHost()
@@ -862,12 +861,12 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 // instance bound to writeRoots (preserving registry order).
 // When workDir is non-empty, tools resolve relative paths against it instead of
 // the process cwd, enabling concurrent multi-project sessions.
-func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxyURL string) {
+func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sandbox.Spec, bashTimeout time.Duration, searchSpec builtin.SearchSpec, stderr io.Writer, workDir string, proxySpec netclient.ProxySpec) {
 	// If a workspace directory is set, use workspace-bound tools that resolve
 	// paths relative to that directory. Otherwise fall back to the process-cwd
 	// compile-time builtins.
 	if workDir != "" {
-		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxyURL: proxyURL}
+		ws := builtin.Workspace{Dir: workDir, WriteRoots: writeRoots, Bash: bashSpec, BashTimeout: bashTimeout, Search: searchSpec, ProxySpec: proxySpec}
 		for _, t := range ws.Tools(enabled...) {
 			reg.Add(t)
 		}
@@ -890,7 +889,7 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 	// Replace the unconfined defaults with confined instances (registry order is
 	// preserved on replace): file-writers bound to the workspace, bash to the OS
 	// sandbox, web_fetch to the proxy. Only replace tools actually enabled/present.
-	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec, bashTimeout), builtin.ConfineSearch(searchSpec), builtin.ConfineWebFetch(proxyURL))
+	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec, bashTimeout), builtin.ConfineSearch(searchSpec), builtin.ConfineWebFetch(proxySpec))
 	for _, t := range confined {
 		if _, ok := reg.Get(t.Name()); ok {
 			reg.Add(t)

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -18,6 +18,7 @@ import (
 
 	"reasonix/internal/config"
 	"reasonix/internal/event"
+	"reasonix/internal/netclient"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
@@ -216,7 +217,7 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 func TestAddBuiltinsWithWorkspaceRootKeepsSessionTools(t *testing.T) {
 	reg := tool.NewRegistry()
 	var stderr bytes.Buffer
-	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), "")
+	addBuiltins(reg, nil, []string{robustTempDir(t)}, sandbox.Spec{}, 120*time.Second, builtin.SearchSpec{}, &stderr, robustTempDir(t), netclient.ProxySpec{})
 	for _, name := range []string{
 		"todo_write",
 		"complete_step",

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -91,6 +91,7 @@ func acpBuiltinTools(cfg *config.Config, cwd string, writeRoots []string) []tool
 		Bash:        bashSpec,
 		BashTimeout: time.Duration(cfg.BashTimeoutSeconds()) * time.Second,
 		Search:      builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, nil),
+		ProxySpec:   cfg.NetworkProxySpec(),
 	}
 	return ws.Tools(cfg.Tools.Enabled...)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -229,9 +229,8 @@ func (c CodegraphConfig) ResolvedTier() string {
 	return resolvedMCPTier(c.Tier)
 }
 
-// NetworkConfig controls ordinary outbound HTTP traffic such as model providers,
-// wallet-balance lookups, updater checks, and CodeGraph downloads. It intentionally
-// does not apply to web_fetch, which keeps its own SSRF-guarded dialer.
+// NetworkConfig controls outbound HTTP proxy settings. web_fetch reuses these
+// proxy settings while keeping its own SSRF-guarded dialer.
 type NetworkConfig struct {
 	// ProxyMode is "auto" (default; environment proxy for now), "env", "custom",
 	// or "off". auto leaves room for OS proxy detection later without changing the

--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -1,6 +1,6 @@
-// Package netclient builds HTTP clients that share Reasonix's user-facing proxy
-// settings. It is intentionally not used by web_fetch, whose dial-time SSRF guard
-// has a different security boundary from ordinary provider/update traffic.
+// Package netclient builds HTTP clients and proxy resolvers that share Reasonix's
+// user-facing proxy settings. web_fetch reuses the resolver while keeping its own
+// dial-time SSRF guard.
 package netclient
 
 import (
@@ -69,6 +69,11 @@ func NormalizeMode(mode string) string {
 func Validate(spec ProxySpec) error {
 	_, err := proxyFunc(spec)
 	return err
+}
+
+// ProxyFunc returns the per-request proxy resolver for spec.
+func ProxyFunc(spec ProxySpec) (func(*http.Request) (*url.URL, error), error) {
+	return proxyFunc(spec)
 }
 
 // NewHTTPClient returns an HTTP client with Reasonix proxy settings applied.
@@ -251,38 +256,6 @@ func validateProxyURL(u *url.URL) error {
 		return fmt.Errorf("network proxy_url host is required")
 	}
 	return nil
-}
-
-// ResolveProxyURL resolves the ProxySpec into a usable proxy URL string
-// (e.g. "http://127.0.0.1:7897"). Returns "" when the mode is off or when
-// auto/env mode has no environment proxy configured. Exported so web_fetch
-// can apply the same proxy settings as the rest of Reasonix.
-func ResolveProxyURL(spec ProxySpec) string {
-	switch NormalizeMode(spec.Mode) {
-	case ModeOff:
-		return ""
-	case ModeCustom:
-		u, err := customProxyURL(spec)
-		if err != nil {
-			return ""
-		}
-		return u.String()
-	case ModeEnv:
-		cfg := httpproxy.FromEnvironment()
-		if cfg.HTTPSProxy != "" {
-			return cfg.HTTPSProxy
-		}
-		return cfg.HTTPProxy
-	default: // auto
-		cfg := httpproxy.FromEnvironment()
-		if cfg.HTTPSProxy != "" {
-			return cfg.HTTPSProxy
-		}
-		if cfg.HTTPProxy != "" {
-			return cfg.HTTPProxy
-		}
-		return ""
-	}
 }
 
 func redactURL(u *url.URL) string {

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/netclient"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/tool"
 )
@@ -21,11 +22,10 @@ func ConfineBash(spec sandbox.Spec, timeout ...time.Duration) tool.Tool {
 	return b
 }
 
-// ConfineWebFetch returns the web_fetch built-in bound to a proxy URL,
-// overriding the unconfined instance registered at init. An empty proxyURL
-// yields the unconfined behavior (direct connection with SSRF guard).
-func ConfineWebFetch(proxyURL string) tool.Tool {
-	return webFetch{proxyURL: proxyURL}
+// ConfineWebFetch returns the web_fetch built-in bound to Reasonix proxy
+// settings while preserving its SSRF-guarded dialer.
+func ConfineWebFetch(proxySpec netclient.ProxySpec) tool.Tool {
+	return webFetch{proxySpec: proxySpec}
 }
 
 // ConfineWriters returns the file-writing built-ins (write_file, edit_file,

--- a/internal/tool/builtin/web_fetch_proxy_test.go
+++ b/internal/tool/builtin/web_fetch_proxy_test.go
@@ -10,8 +10,11 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"reasonix/internal/netclient"
 )
 
 func startCONNECTProxy(t *testing.T) string {
@@ -52,6 +55,75 @@ func startCONNECTProxy(t *testing.T) string {
 	return fmt.Sprintf("http://%s", listener.Addr().String())
 }
 
+func startRespondingCONNECTProxy(t *testing.T, respond func(hit int32, req *http.Request) *http.Response) (string, *int32) {
+	t.Helper()
+	var hits int32
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				br := bufio.NewReader(c)
+				req, err := http.ReadRequest(br)
+				if err != nil || req.Method != http.MethodConnect {
+					return
+				}
+				hit := atomic.AddInt32(&hits, 1)
+				c.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+				req, err = http.ReadRequest(br)
+				if err != nil {
+					return
+				}
+				_ = respond(hit, req).Write(c)
+			}(conn)
+		}
+	}()
+	return fmt.Sprintf("http://%s", listener.Addr().String()), &hits
+}
+
+func textProxyResponse(req *http.Request, statusCode int, status string, body string) *http.Response {
+	resp := &http.Response{
+		StatusCode: statusCode,
+		Status:     status,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    req,
+	}
+	resp.Header.Set("Content-Type", "text/plain")
+	resp.ContentLength = int64(len(body))
+	return resp
+}
+
+func startInterceptingCONNECTProxy(t *testing.T, body string) (string, *int32) {
+	t.Helper()
+	return startRespondingCONNECTProxy(t, func(_ int32, req *http.Request) *http.Response {
+		return textProxyResponse(req, http.StatusOK, "200 OK", body)
+	})
+}
+
+func startRedirectingCONNECTProxy(t *testing.T, location string) (string, *int32) {
+	t.Helper()
+	return startRespondingCONNECTProxy(t, func(hit int32, req *http.Request) *http.Response {
+		if hit == 1 {
+			resp := textProxyResponse(req, http.StatusFound, "302 Found", "")
+			resp.Header.Set("Location", location)
+			return resp
+		}
+		return textProxyResponse(req, http.StatusOK, "200 OK", "proxied after redirect")
+	})
+}
+
 func startTestHTTPServer(t *testing.T, body string) string {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -70,12 +142,101 @@ func startTestHTTPServer(t *testing.T, body string) string {
 	return u
 }
 
+func TestWebFetchUsesEnvProxyAtRequestTime(t *testing.T) {
+	t.Setenv("http_proxy", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("https_proxy", "")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	proxyURL, proxyHits := startInterceptingCONNECTProxy(t, "from env proxy")
+	wf := webFetch{proxySpec: netclient.ProxySpec{Mode: netclient.ModeEnv}}
+	t.Setenv("HTTP_PROXY", proxyURL)
+
+	args, _ := json.Marshal(map[string]string{"url": "http://service.test/resource"})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := wf.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("webFetch.Execute through env proxy: %v", err)
+	}
+	if !strings.Contains(result, "from env proxy") {
+		t.Fatalf("expected env proxy response, got: %s", result)
+	}
+	if got := atomic.LoadInt32(proxyHits); got != 1 {
+		t.Fatalf("proxy hits = %d, want 1", got)
+	}
+}
+
+func TestWebFetchProxySpecHonorsNoProxy(t *testing.T) {
+	targetURL := startTestHTTPServer(t, "direct no_proxy")
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		t.Fatalf("parse target URL: %v", err)
+	}
+	proxyURL, proxyHits := startInterceptingCONNECTProxy(t, "from proxy")
+	wf := webFetch{
+		proxySpec: netclient.ProxySpec{
+			Mode:    netclient.ModeCustom,
+			URL:     proxyURL,
+			NoProxy: target.Hostname(),
+		},
+	}
+	args, _ := json.Marshal(map[string]string{"url": targetURL})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := wf.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("webFetch.Execute with no_proxy: %v", err)
+	}
+	if !strings.Contains(result, "direct no_proxy") {
+		t.Fatalf("expected direct response, got: %s", result)
+	}
+	if got := atomic.LoadInt32(proxyHits); got != 0 {
+		t.Fatalf("proxy hits = %d, want 0", got)
+	}
+}
+
+func TestWebFetchRechecksProxySpecAfterRedirect(t *testing.T) {
+	targetURL := startTestHTTPServer(t, "redirect target direct")
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		t.Fatalf("parse target URL: %v", err)
+	}
+	proxyURL, proxyHits := startRedirectingCONNECTProxy(t, targetURL)
+	wf := webFetch{
+		proxySpec: netclient.ProxySpec{
+			Mode:    netclient.ModeCustom,
+			URL:     proxyURL,
+			NoProxy: target.Hostname(),
+		},
+	}
+	args, _ := json.Marshal(map[string]string{"url": "http://service.test/start"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := wf.Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("webFetch.Execute with redirect: %v", err)
+	}
+	if !strings.Contains(result, "redirect target direct") {
+		t.Fatalf("expected redirected request to bypass proxy, got: %s", result)
+	}
+	if got := atomic.LoadInt32(proxyHits); got != 1 {
+		t.Fatalf("proxy hits = %d, want 1", got)
+	}
+}
+
 func TestWebFetchThroughCONNECTProxy(t *testing.T) {
 	targetURL := startTestHTTPServer(t, "hello from target")
 	proxyURL := startCONNECTProxy(t)
 	t.Logf("proxy: %s  target: %s", proxyURL, targetURL)
 
-	wf := webFetch{proxyURL: proxyURL}
+	wf := webFetch{proxySpec: netclient.ProxySpec{Mode: netclient.ModeCustom, URL: proxyURL}}
 	args, _ := json.Marshal(map[string]string{"url": targetURL})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -92,7 +253,7 @@ func TestWebFetchThroughCONNECTProxy(t *testing.T) {
 
 func TestWebFetchWithoutProxy(t *testing.T) {
 	targetURL := startTestHTTPServer(t, "direct fetch OK")
-	wf := webFetch{proxyURL: ""}
+	wf := webFetch{proxySpec: netclient.ProxySpec{Mode: netclient.ModeOff}}
 	args, _ := json.Marshal(map[string]string{"url": targetURL})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -109,7 +270,7 @@ func TestWebFetchWithoutProxy(t *testing.T) {
 
 func TestSSRFStillBlocksPrivateThroughProxy(t *testing.T) {
 	proxyURL := startCONNECTProxy(t)
-	wf := webFetch{proxyURL: proxyURL}
+	wf := webFetch{proxySpec: netclient.ProxySpec{Mode: netclient.ModeCustom, URL: proxyURL}}
 
 	blocked := []string{
 		"http://169.254.169.254/latest/meta-data",
@@ -146,7 +307,7 @@ func TestProxyBasicAuthURLParsing(t *testing.T) {
 }
 
 func TestWebFetchSOCKS5Proxy(t *testing.T) {
-	wf := webFetch{proxyURL: "socks5://127.0.0.1:1"}
+	wf := webFetch{proxySpec: netclient.ProxySpec{Mode: netclient.ModeCustom, URL: "socks5://127.0.0.1:1"}}
 	args, _ := json.Marshal(map[string]string{"url": "https://example.com"})
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -159,7 +320,7 @@ func TestWebFetchSOCKS5Proxy(t *testing.T) {
 }
 
 func TestSSRFBlocksPrivateTargetThroughSOCKS5(t *testing.T) {
-	wf := webFetch{proxyURL: "socks5://127.0.0.1:1080"}
+	wf := webFetch{proxySpec: netclient.ProxySpec{Mode: netclient.ModeCustom, URL: "socks5://127.0.0.1:1080"}}
 	for _, u := range []string{"http://169.254.169.254/latest/meta-data", "http://10.0.0.1/", "http://192.168.1.1/"} {
 		t.Run(u, func(t *testing.T) {
 			args, _ := json.Marshal(map[string]string{"url": u})
@@ -177,7 +338,7 @@ func TestSOCKS5ProxyOnPrivateAddressNotSSRFBlocked(t *testing.T) {
 	// A SOCKS proxy commonly lives on a private/LAN address; the SSRF guard must
 	// not reject the proxy itself. Reaching the (absent) proxy fails, but never
 	// with an SSRF "internal address" error.
-	wf := webFetch{proxyURL: "socks5://10.0.0.1:1080"}
+	wf := webFetch{proxySpec: netclient.ProxySpec{Mode: netclient.ModeCustom, URL: "socks5://10.0.0.1:1080"}}
 	args, _ := json.Marshal(map[string]string{"url": "https://example.com"})
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()

--- a/internal/tool/builtin/webfetch.go
+++ b/internal/tool/builtin/webfetch.go
@@ -16,15 +16,14 @@ import (
 
 	"golang.org/x/net/proxy"
 
+	"reasonix/internal/netclient"
 	"reasonix/internal/tool"
 )
 
 func init() { tool.RegisterBuiltin(webFetch{}) }
 
 type webFetch struct {
-	// proxyURL is resolved from config [network] settings. When non-empty,
-	// outbound requests tunnel through this proxy while preserving SSRF guard.
-	proxyURL string
+	proxySpec netclient.ProxySpec
 }
 
 const (
@@ -50,13 +49,13 @@ func (webFetch) Schema() json.RawMessage {
 
 func (webFetch) ReadOnly() bool { return true }
 
-// ssrfGuardedClient is an HTTP client whose dialer refuses to connect to private,
-// link-local, or unspecified addresses — the SSRF surface a prompt-injected fetch
-// would aim at (cloud metadata at 169.254.169.254, RFC1918 internal services).
-// Loopback is allowed: the agent can already reach localhost via bash, so a local
-// dev server stays fetchable. The check runs at dial time on the resolved IP, so a
-// public host that redirects or DNS-rebinds to an internal address is caught too.
-func ssrfGuardedClient(proxyURL string) *http.Client {
+// ssrfGuardedTransport refuses to connect to private, link-local, or unspecified
+// addresses — the SSRF surface a prompt-injected fetch would aim at (cloud
+// metadata at 169.254.169.254, RFC1918 internal services). Loopback is allowed:
+// the agent can already reach localhost via bash, so a local dev server stays
+// fetchable. The check runs at dial time on the resolved IP, so a public host
+// that redirects or DNS-rebinds to an internal address is caught too.
+func ssrfGuardedTransport(proxyURL string) *http.Transport {
 	dialer := &net.Dialer{Timeout: webFetchTimeout}
 
 	// directDialContext handles SSRF-protected direct connection (no proxy).
@@ -177,9 +176,25 @@ func ssrfGuardedClient(proxyURL string) *http.Client {
 		}
 	}
 
+	return tr
+}
+
+type webFetchRoundTripper struct {
+	proxyURLFor func(*http.Request) (string, error)
+}
+
+func (rt webFetchRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	proxyURL, err := rt.proxyURLFor(req)
+	if err != nil {
+		return nil, fmt.Errorf("resolve proxy: %w", err)
+	}
+	return ssrfGuardedTransport(proxyURL).RoundTrip(req)
+}
+
+func ssrfGuardedClient(proxyURLFor func(*http.Request) (string, error)) *http.Client {
 	return &http.Client{
 		Timeout:   webFetchTimeout,
-		Transport: tr,
+		Transport: webFetchRoundTripper{proxyURLFor: proxyURLFor},
 	}
 }
 
@@ -203,6 +218,21 @@ func blockedFetchIP(ip net.IP) bool {
 		ip.IsLinkLocalMulticast() ||
 		ip.IsUnspecified() || // 0.0.0.0 / ::
 		cgnatRange.Contains(ip) // 100.64.0.0/10 (incl. Alibaba Cloud metadata)
+}
+
+func (wf webFetch) proxyURLFor(req *http.Request) (string, error) {
+	pf, err := netclient.ProxyFunc(wf.proxySpec)
+	if err != nil {
+		return "", err
+	}
+	if pf == nil {
+		return "", nil
+	}
+	u, err := pf(req)
+	if err != nil || u == nil {
+		return "", err
+	}
+	return u.String(), nil
 }
 
 func (wf webFetch) Execute(ctx context.Context, args json.RawMessage) (string, error) {
@@ -231,7 +261,7 @@ func (wf webFetch) Execute(ctx context.Context, args json.RawMessage) (string, e
 	req.Header.Set("User-Agent", "reasonix-web-fetch/1.0")
 	req.Header.Set("Accept", "text/html,text/plain,text/markdown,application/json,*/*;q=0.5")
 
-	resp, err := ssrfGuardedClient(wf.proxyURL).Do(req)
+	resp, err := ssrfGuardedClient(wf.proxyURLFor).Do(req)
 	if err != nil {
 		return "", fmt.Errorf("fetch %s: %w", p.URL, err)
 	}

--- a/internal/tool/builtin/workspace.go
+++ b/internal/tool/builtin/workspace.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"reasonix/internal/netclient"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/tool"
 )
@@ -25,7 +26,7 @@ type Workspace struct {
 	Bash        sandbox.Spec
 	BashTimeout time.Duration
 	Search      SearchSpec
-	ProxyURL    string // resolved proxy URL for web_fetch
+	ProxySpec   netclient.ProxySpec
 }
 
 // Tools returns the built-in tools bound to the workspace, ready to Add to a
@@ -52,7 +53,7 @@ func (w Workspace) Tools(enabled ...string) []tool.Tool {
 		"ls":            listDir{workDir: w.Dir},
 		"glob":          globTool{workDir: w.Dir},
 		"grep":          grepTool{workDir: w.Dir, rg: w.Search.RgPath},
-		"web_fetch":     webFetch{proxyURL: w.ProxyURL},
+		"web_fetch":     webFetch{proxySpec: w.ProxySpec},
 	}
 	all := tool.Builtins()
 	if len(enabled) == 0 {


### PR DESCRIPTION
## Summary
This updates `web_fetch` to reuse Reasonix's shared network proxy resolver instead of using a static proxy URL resolved during boot.

Before this change:
- `web_fetch` received a flattened proxy URL from `netclient.ResolveProxyURL`.
- It did not share the same per-request behavior as provider/update traffic.
- `no_proxy`, env/auto/custom proxy behavior, and redirect boundaries could diverge from `netclient`.
- Windows system proxy fallback in `auto` mode could not be reused by `web_fetch`.

After this change:
- `web_fetch` carries the full `netclient.ProxySpec`.
- It calls the shared per-request proxy resolver for every fetch round trip, including redirects.
- `env`, `auto`, `custom`, `no_proxy`, and `DirectHosts` now follow the same resolver path as other network clients.
- The existing SSRF guard remains in `web_fetch`: direct dials still vet resolved IPs, and proxied IP-literal targets are still blocked.

## Issues
Fixes #3610
Fixes #3510

## Implementation notes
- Exported `netclient.ProxyFunc` as a thin wrapper around the existing resolver.
- Replaced `web_fetch`'s static `proxyURL` field with `netclient.ProxySpec`.
- Kept the existing HTTP CONNECT / SOCKS proxy handling and SSRF boundary in `web_fetch`.
- Removed the now-unused static `ResolveProxyURL` helper.
- Wired the proxy spec through normal boot, workspace-bound tools, and ACP tool setup.
- Updated config comments so they no longer say network proxy settings exclude `web_fetch`.

## Tests
- `go test ./internal/tool/builtin -run 'TestWebFetchUsesEnvProxyAtRequestTime|TestWebFetchProxySpecHonorsNoProxy|TestWebFetchRechecksProxySpecAfterRedirect'`
- `go test ./internal/tool/builtin ./internal/netclient ./internal/boot ./internal/cli`
- `git ls-files '*.go' | xargs ../.tools/go/bin/gofmt -l`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `go test -race ./...`
