### PR TITLE
fix(desktop): 拖动窗口图标时不再崩溃 (#3573)

### DIFF
--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -294,10 +294,32 @@ export function onUpdaterProgress(cb: (p: UpdateProgress) => void): () => void {
 export function onFilesDropped(cb: (paths: string[]) => void): () => void {
   const rt = typeof window !== "undefined" ? window.runtime : undefined;
   if (!rt?.OnFileDrop) return () => {};
+
+  // Wails' internal ResolveFilePaths throws when a non-file object (e.g. the
+  // window icon) is dragged onto the webview. The error is uncaught and crashes
+  // the app. Intercept it here so only real file drops reach the callback.
+  const suppressNonFileDragError = (e: ErrorEvent) => {
+    if (e.message?.includes("additional File object is not a file on the disk")) {
+      e.preventDefault();
+    }
+  };
+  const suppressNonFileDragRejection = (e: PromiseRejectionEvent) => {
+    const msg = e.reason?.message ?? String(e.reason);
+    if (msg.includes("additional File object is not a file on the disk")) {
+      e.preventDefault();
+    }
+  };
+  window.addEventListener("error", suppressNonFileDragError);
+  window.addEventListener("unhandledrejection", suppressNonFileDragRejection);
+
   rt.OnFileDrop((_x, _y, paths) => {
     if (Array.isArray(paths) && paths.length > 0) cb(paths);
   }, true);
-  return () => rt.OnFileDropOff?.();
+  return () => {
+    rt.OnFileDropOff?.();
+    window.removeEventListener("error", suppressNonFileDragError);
+    window.removeEventListener("unhandledrejection", suppressNonFileDragRejection);
+  };
 }
 
 // onReady subscribes to the agent:ready event fired when boot.Build completes.


### PR DESCRIPTION
## Bug

拖动窗口左上角的蓝色 Reasonix 图标到窗口本身时，应用崩溃并显示：

```
[window.error]
TypeError: Failed to post a message: additional File object is not a file on the disk.
    at Object.Re [as ResolveFilePaths] (http://wails.localhost/wails/runtime.js:2:7400)
    at U (http://wails.localhost/wails/runtime.js:2:7058)
```

## 根因

`main.go` 中 `DragAndDrop: &options.DragAndDrop{EnableFileDrop: true}` 全局开启了文件拖拽。当用户拖动窗口图标（不是磁盘上的文件）时，Wails 内部的 `ResolveFilePaths` 尝试将其解析为文件路径，失败后抛出未捕获的错误，导致整个应用崩溃。

## 可选方案

### 方案 A：CSS 阻止拖拽（最简单）
给窗口图标加 `pointer-events: none` 或 `-webkit-app-region: no-drag`。
- 优点：一行 CSS
- 缺点：图标失去交互能力，可能影响其他功能

### 方案 B：关闭全局拖拽 + 局部处理（最彻底）
将 `main.go` 的 `EnableFileDrop` 改为 `false`，在 composer 区域用 HTML5 `onDrop` 自己处理文件。
- 优点：从根源解决，不再依赖 Wails 的全局拖拽
- 缺点：需要重构拖拽逻辑，改动较大，需要全面测试

### 方案 C：错误拦截（本 PR 采用，折中方案）
在 `bridge.ts` 的 `onFilesDropped` 中注册全局 `error` 和 `unhandledrejection` 拦截器，精准吞掉该错误。
- 优点：改动最小（~20 行），不影响现有逻辑，真实文件拖拽不受影响
- 缺点：治标不治本，Wails 上游如果修复了可以移除

## 修复内容

本 PR 采用方案 C。如果后续决定采用方案 B 彻底重构，这个拦截器也可以随时移除。