### PR TITLE
Harden CodeGraph runtime bootstrap / 强化 CodeGraph 运行时启动可靠性

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,52 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  mirror-codegraph:
+    name: mirror CodeGraph runtime to R2
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'esengine' }}
+    env:
+      HAS_R2: ${{ secrets.R2_ACCESS_KEY_ID != '' && secrets.R2_SECRET_ACCESS_KEY != '' && secrets.R2_ACCOUNT_ID != '' && secrets.R2_BUCKET != '' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download CodeGraph release assets
+        if: env.HAS_R2 == 'true'
+        run: |
+          version="$(awk '/^CODEGRAPH_VERSION[[:space:]]*:=/ { print $3; exit }' Makefile)"
+          [ -n "$version" ] || { echo "CODEGRAPH_VERSION not found" >&2; exit 1; }
+          base="https://github.com/colbymchenry/codegraph/releases/download/${version}"
+          mkdir -p codegraph-assets
+          curl -fsSL "$base/SHA256SUMS" -o codegraph-assets/SHA256SUMS
+          for asset in \
+            codegraph-darwin-arm64.tar.gz \
+            codegraph-darwin-x64.tar.gz \
+            codegraph-linux-arm64.tar.gz \
+            codegraph-linux-x64.tar.gz \
+            codegraph-win32-arm64.zip \
+            codegraph-win32-x64.zip
+          do
+            curl -fsSL "$base/$asset" -o "codegraph-assets/$asset"
+            want="$(awk -v name="$asset" '$2 == name { print $1 }' codegraph-assets/SHA256SUMS)"
+            got="$(shasum -a 256 "codegraph-assets/$asset" | awk '{ print $1 }')"
+            [ "$got" = "$want" ] || { echo "checksum mismatch for $asset" >&2; exit 1; }
+          done
+          echo "CODEGRAPH_VERSION=$version" >> "$GITHUB_ENV"
+
+      - name: Configure AWS CLI for R2
+        if: env.HAS_R2 == 'true'
+        run: |
+          aws configure set aws_access_key_id "${{ secrets.R2_ACCESS_KEY_ID }}"
+          aws configure set aws_secret_access_key "${{ secrets.R2_SECRET_ACCESS_KEY }}"
+          aws configure set region auto
+
+      - name: Mirror CodeGraph to R2
+        if: env.HAS_R2 == 'true'
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          ENDPOINT="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          aws s3 cp codegraph-assets/ "s3://${R2_BUCKET}/codegraph/${CODEGRAPH_VERSION}/" --recursive --endpoint-url "$ENDPOINT"

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1841,12 +1841,7 @@ func (a *App) Capabilities() CapabilitiesView {
 		if loadedCfg != nil && !seen["codegraph"] {
 			status := "disabled"
 			if loadedCfg.Codegraph.Enabled {
-				switch loadedCfg.Codegraph.ResolvedTier() {
-				case "background", "eager":
-					status = "initializing"
-				default:
-					status = "deferred"
-				}
+				status = "initializing"
 			}
 			if s, ok := disabled["codegraph"]; ok {
 				s.Status = "disabled"
@@ -2353,8 +2348,8 @@ func (a *App) connectConfiguredMCPServerForTab(tab *WorkspaceTab, name string) (
 }
 
 // SetMCPServerTier is kept for old desktop bindings. New config writes drop the
-// retired tier field, so this only affects the active session before the next
-// config reload.
+// retired tier field; for CodeGraph this now means "enable and start in the
+// background".
 func (a *App) SetMCPServerTier(name, tier string) error {
 	if name == "codegraph" {
 		return a.setCodegraphTier(tier)
@@ -2429,14 +2424,13 @@ func (a *App) setCodegraphEnabled(enabled bool) error {
 	return nil
 }
 
-func (a *App) setCodegraphTier(tier string) error {
-	tier = normalizeMCPTier(tier)
+func (a *App) setCodegraphTier(_ string) error {
 	cfg, path, err := a.loadDesktopUserConfigForEdit()
 	if err != nil {
 		return err
 	}
 	cfg.Codegraph.Enabled = true
-	cfg.Codegraph.Tier = tier
+	cfg.Codegraph.Tier = ""
 	if err := cfg.SaveTo(path); err != nil {
 		return err
 	}
@@ -2450,7 +2444,7 @@ func (a *App) setCodegraphTier(tier string) error {
 	a.mu.Lock()
 	delete(tab.disabledMCP, "codegraph")
 	a.mu.Unlock()
-	if tier != "lazy" && !mcpConnected(tab.Ctrl, "codegraph") {
+	if !mcpConnected(tab.Ctrl, "codegraph") {
 		if _, err := tab.Ctrl.ConnectCodegraphMCPServer(cfg); err != nil {
 			recordCodegraphFailure(tab.Ctrl, cfg.Codegraph, err)
 			return nil

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1773,7 +1773,7 @@ tier = "lazy"
 	t.Fatalf("broken MCP missing from Capabilities: %+v", view.Servers)
 }
 
-func TestSetMCPServerTierPersistsCodegraphConfig(t *testing.T) {
+func TestSetMCPServerTierEnablesCodegraphAndIgnoresLegacyTier(t *testing.T) {
 	t.Setenv("HOME", robustTempDir(t))
 	t.Setenv("USERPROFILE", robustTempDir(t))
 	t.Setenv("XDG_CONFIG_HOME", robustTempDir(t))
@@ -1794,7 +1794,7 @@ auto_install = true
 	app.setTestCtrl(control.New(control.Options{Host: plugin.NewHost()}), "")
 	defer app.activeCtrl().Close()
 
-	if err := app.SetMCPServerTier("codegraph", "background"); err != nil {
+	if err := app.SetMCPServerTier("codegraph", "eager"); err != nil {
 		t.Fatalf("SetMCPServerTier(codegraph): %v", err)
 	}
 	cfg, err := config.Load()
@@ -1802,17 +1802,17 @@ auto_install = true
 		t.Fatal(err)
 	}
 	if !cfg.Codegraph.Enabled {
-		t.Fatal("codegraph enabled = false, want true after selecting a startup tier")
+		t.Fatal("codegraph enabled = false, want true after legacy tier update")
 	}
 	if got := cfg.Codegraph.Tier; got != "" {
-		t.Fatalf("codegraph tier = %q, want migrated empty", got)
+		t.Fatalf("codegraph tier = %q, want ignored legacy tier", got)
 	}
 	userCfg := config.LoadForEdit(config.UserConfigPath())
 	if !userCfg.Codegraph.Enabled {
-		t.Fatal("user codegraph enabled = false, want true after selecting a startup tier")
+		t.Fatal("user codegraph enabled = false, want true after legacy tier update")
 	}
 	if got := userCfg.Codegraph.Tier; got != "" {
-		t.Fatalf("user codegraph tier = %q, want migrated empty", got)
+		t.Fatalf("user codegraph tier = %q, want ignored legacy tier", got)
 	}
 	if !mcpFailed(app.activeCtrl(), "codegraph") {
 		t.Fatalf("Host.Failures() = %+v, want codegraph failure recorded for missing runtime", app.activeCtrl().Host().Failures())

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -77,8 +77,8 @@ and DeepSeek prefix-cache–oriented design.
 - **Code intelligence**: embedding semantic search is replaced by **CodeGraph**
   (`codegraph_*` tools) — a tree-sitter symbol/call graph, no embedding service or
   API cost. New (first-run) configs start with it off; existing configs keep it
-  on across upgrades. Toggle `[codegraph]` in the MCP manager or config, and set
-  `[codegraph].tier` to choose lazy, background, or eager startup.
+  on across upgrades. Toggle `[codegraph]` in the MCP manager or config; when
+  enabled it starts in the background so chat startup is never blocked.
 - **Plan mode** + `complete_step` (evidence-backed step sign-off).
 - **No web dashboard** — the v2 line is terminal + desktop (Wails), by design.
 - Some granular v1 tools are intentionally consolidated (e.g. file-management ops

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -87,12 +87,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if stderr == nil {
 		stderr = os.Stderr
 	}
-	root := opts.WorkspaceRoot
-	if root == "" {
-		if wd, err := os.Getwd(); err == nil {
-			root = wd
-		}
-	}
+	root := resolveWorkspaceRoot(opts.WorkspaceRoot)
 	// One-time import of v1/v0.5 legacy config — runs before Load so the freshly
 	// written config + ~/.env are picked up this same boot. CLI Run also calls this
 	// before config-only commands; this call stays as the shared frontend fallback.
@@ -245,11 +240,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// tools come online next session — otherwise point the user at the explicit
 	// install command. A failed init or fetch is a notice, not fatal.
 	//
-	// CodeGraph follows the same user-selectable tier model as ordinary MCP
-	// servers when a tier is set. EnsureInit only creates .codegraph/ (fast,
-	// size-independent). With no explicit tier — an upgraded config that predates
-	// the setting — it keeps the historical startup: warm projects eager so
-	// symbol tools are ready on the first turn, cold projects in the background.
+	// CodeGraph is fixed to background startup. Legacy tier values are ignored so
+	// enabling it never blocks chat startup.
 	if cfg.Codegraph.Enabled {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
@@ -274,24 +266,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 						Text: "codegraph: preparing code-intelligence tools in the background — tools will appear when ready"})
 				}
 			}
-			if strings.TrimSpace(cfg.Codegraph.Tier) == "" {
-				if warm {
-					eagerSpecs = append(eagerSpecs, spec)
-				} else {
-					bgSpecs = append(bgSpecs, spec)
-					bgNotice()
-				}
-				break
-			}
-			switch cfg.Codegraph.ResolvedTier() {
-			case "eager":
-				eagerSpecs = append(eagerSpecs, spec)
-			case "background":
-				bgSpecs = append(bgSpecs, spec)
-				bgNotice()
-			default:
-				lazySpecs = append(lazySpecs, spec)
-			}
+			bgSpecs = append(bgSpecs, spec)
+			bgNotice()
 		case cfg.Codegraph.AutoInstall:
 			notify := func(msg string) { sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg}) }
 			notify("codegraph: fetching code-intelligence runtime in the background (one-time) — symbol-graph tools available next session")
@@ -825,6 +801,42 @@ func subagentModelKeys(name string) []string {
 		}
 	}
 	return keys
+}
+
+func resolveWorkspaceRoot(explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	if root, ok := nearestGitRoot(wd); ok {
+		return root
+	}
+	return wd
+}
+
+func nearestGitRoot(start string) (string, bool) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		dir = filepath.Clean(start)
+	}
+	for {
+		if isGitMarker(filepath.Join(dir, ".git")) {
+			return dir, true
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			return "", false
+		}
+		dir = next
+	}
+}
+
+func isGitMarker(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && (fi.IsDir() || fi.Mode().IsRegular())
 }
 
 // NewProvider builds a provider.Provider from a configured entry. Exported so

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -844,6 +844,85 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 }
 
+func TestBuildWarmCodegraphIgnoresLegacyEagerTier(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake launcher is a POSIX-sh script")
+	}
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	if err := os.Mkdir(filepath.Join(dir, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	launcher := filepath.Join(dir, "slow-codegraph")
+	writeFile(t, dir, "slow-codegraph", "#!/bin/sh\nif [ \"$1\" = serve ]; then sleep 5; fi\n")
+	if err := os.Chmod(launcher, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = true
+path = %q
+tier = "eager"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`, launcher))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{})
+	if err != nil {
+		t.Fatalf("Build should not block on warm codegraph with legacy eager tier: %v", err)
+	}
+	defer ctrl.Close()
+}
+
+func TestBuildDefaultsToNearestGitRoot(t *testing.T) {
+	isolateConfigHome(t)
+	root := robustTempDir(t)
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	subdir := filepath.Join(root, "cmd", "tool")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, root, "reasonix.toml", `
+default_model = "root-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "root-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+	t.Chdir(subdir)
+
+	ctrl, err := Build(context.Background(), Options{Model: "root-model"})
+	if err != nil {
+		t.Fatalf("Build should load config from nearest git root: %v", err)
+	}
+	defer ctrl.Close()
+}
+
 func TestBuildMigratesLegacyEagerBeforeStatsDemotion(t *testing.T) {
 	isolateConfigHome(t)
 	dir := robustTempDir(t)

--- a/internal/cli/codegraph.go
+++ b/internal/cli/codegraph.go
@@ -60,7 +60,7 @@ func codegraphStatus() int {
 	}
 	fmt.Printf("%-13s %v\n", "enabled:", cfg.Codegraph.Enabled)
 	fmt.Printf("%-13s %v\n", "auto_install:", cfg.Codegraph.AutoInstall)
-	fmt.Printf("%-13s %s\n", "tier:", cfg.Codegraph.ResolvedTier())
+	fmt.Printf("%-13s %s\n", "startup:", cfg.Codegraph.ResolvedTier())
 	fmt.Printf("%-13s %s\n", "version:", codegraph.Version)
 	fmt.Printf("%-13s %s\n", "cache:", codegraph.CacheDir())
 	if p, ok := codegraph.Resolve(cfg.Codegraph.Path); ok {

--- a/internal/cli/mcp_manager.go
+++ b/internal/cli/mcp_manager.go
@@ -364,8 +364,6 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 		status := "initializing"
 		if m.mcpDisabled["codegraph"] || !loadedCfg.Codegraph.Enabled {
 			status = "disabled"
-		} else if loadedCfg.Codegraph.ResolvedTier() == "lazy" {
-			status = "deferred"
 		}
 		snap.servers = append(snap.servers, withMCPCodegraphConfig(mcpServerView{
 			Name: "codegraph", Status: status,

--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -171,7 +171,7 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 	}
 	if v.BuiltIn && v.Name == "codegraph" {
 		cfg.Codegraph.Enabled = true
-		cfg.Codegraph.Tier = normalizeMCPTierForCLI(tier)
+		cfg.Codegraph.Tier = ""
 		if err := cfg.Save(); err != nil {
 			m.notice("mcp mode: " + err.Error())
 			return m, nil
@@ -179,7 +179,7 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 		if m.mcpDisabled != nil {
 			delete(m.mcpDisabled, v.Name)
 		}
-		if tier != "lazy" && m.ctrl != nil && !mcpConnected(m.ctrl, v.Name) {
+		if m.ctrl != nil && !mcpConnected(m.ctrl, v.Name) {
 			if _, err := m.ctrl.ConnectConfiguredMCPServer(v.Name); err != nil {
 				recordMCPModeCodegraphFailure(m.ctrl, cfg.Codegraph, err)
 				m.notice("saved connection mode, but connect failed: " + err.Error())

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -459,7 +459,7 @@ func TestApplyMCPModeRecordsCodegraphConnectFailure(t *testing.T) {
 	t.Setenv("REASONIX_CACHE_DIR", t.TempDir())
 	cfg := config.Default()
 	cfg.Codegraph.Enabled = false
-	cfg.Codegraph.Tier = "lazy"
+	cfg.Codegraph.Tier = "eager"
 	if err := cfg.SaveTo("reasonix.toml"); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
@@ -472,11 +472,11 @@ func TestApplyMCPModeRecordsCodegraphConnectFailure(t *testing.T) {
 		stage: mcpStageMode,
 		name:  "codegraph",
 		snapshot: mcpSnapshot{configPath: "reasonix.toml", servers: []mcpServerView{{
-			Name: "codegraph", Transport: "stdio", Status: "disabled", BuiltIn: true, Configured: true, Tier: "lazy",
+			Name: "codegraph", Transport: "stdio", Status: "disabled", BuiltIn: true, Configured: true, Tier: "background",
 		}}},
 	}
 
-	_, _ = m.applyMCPMode("background")
+	_, _ = m.applyMCPMode("eager")
 
 	failures := m.ctrl.Host().Failures()
 	if len(failures) != 1 || failures[0].Name != "codegraph" {

--- a/internal/codegraph/checksums.go
+++ b/internal/codegraph/checksums.go
@@ -1,0 +1,14 @@
+package codegraph
+
+// releaseAssetSHA256 holds the upstream SHA256SUMS values for Version. These
+// are baked into the reasonix binary so downloaded CodeGraph archives are
+// verified against trusted metadata instead of trusting whichever mirror served
+// the bytes.
+var releaseAssetSHA256 = map[string]string{
+	"codegraph-darwin-arm64.tar.gz": "83a3b90bc334ab2a34240e29e9fab7ff273ab6381794aa6f3cba428397c916b5",
+	"codegraph-darwin-x64.tar.gz":   "74d2331161a317fa6164285a61ec480ce7893be46c1677a4b5a2932e35586b9d",
+	"codegraph-linux-arm64.tar.gz":  "7b4225f90ca5285cccfec099323129348c2753bcbc9910281f9b61db88fa5f37",
+	"codegraph-linux-x64.tar.gz":    "61805e3c9b4052db53c71241b800859095fea4f2cbd2a1844a6c2b9594b9f84a",
+	"codegraph-win32-arm64.zip":     "c728ada3d42701213dde26d8e94ded3ed1c7d4b568124210649ce8f9f938a31a",
+	"codegraph-win32-x64.zip":       "a5571d3ee54cc1caac76bf09e0f7cb350fc4dd6788a5437217eac33b71fa7a15",
+}

--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -40,17 +40,18 @@ You have codegraph tools for symbol-level code intelligence. For architecture qu
 - codegraph_files — project file tree with symbol counts
 Use grep/read_file for content search (comments, strings, config values) and when codegraph is not available.`
 
-// BundleDirName is the directory, beside the reasonix executable, that the release
-// archive unpacks the CodeGraph bundle into. Its launcher lives at
-// <BundleDirName>/bin/codegraph, with the bundled node runtime and lib/ beside it;
-// the launcher resolves those relative to itself, so the bundle is relocatable.
+// BundleDirName is the optional directory, beside the reasonix executable, where
+// an operator can place an unpacked CodeGraph bundle for offline use. Its
+// launcher lives at <BundleDirName>/bin/codegraph, with the bundled node runtime
+// and lib/ beside it; the launcher resolves those relative to itself, so the
+// bundle is relocatable.
 const BundleDirName = "codegraph"
 
 // Resolve returns the absolute path to the CodeGraph launcher. Search order:
 //  1. override — an explicit [codegraph].path from config (~ and ${VAR} expanded);
-//  2. the per-version cache populated by Install (the normal case);
+//  2. the per-version cache populated by Install;
 //  3. a system-installed `codegraph` on PATH;
-//  4. a bundle placed beside the reasonix executable (fallback for manual setups).
+//  4. a bundle placed beside the executable (manual/offline fallback).
 //
 // ok is false when none resolves — the caller then triggers Install (or skips the
 // feature), so the codegraph_* tools come online once the cache is populated.
@@ -76,6 +77,19 @@ func Resolve(override string) (string, bool) {
 // The executable path is symlink-resolved first so a launcher installed via a
 // symlink (e.g. a package manager's bin shim) still points at the real bundle.
 func bundled() (string, bool) {
+	base, ok := bundledBaseDir()
+	if !ok {
+		return "", false
+	}
+	for _, rel := range launcherNames() {
+		if p := filepath.Join(base, rel); isExec(p) {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+func bundledBaseDir() (string, bool) {
 	exe, err := os.Executable()
 	if err != nil {
 		return "", false
@@ -83,13 +97,7 @@ func bundled() (string, bool) {
 	if real, err := filepath.EvalSymlinks(exe); err == nil {
 		exe = real
 	}
-	base := filepath.Join(filepath.Dir(exe), BundleDirName)
-	for _, rel := range launcherNames() {
-		if p := filepath.Join(base, rel); isExec(p) {
-			return p, true
-		}
-	}
-	return "", false
+	return filepath.Join(filepath.Dir(exe), BundleDirName), true
 }
 
 // launcherNames are the bundle-relative launcher paths to try, per OS. The unix

--- a/internal/codegraph/install.go
+++ b/internal/codegraph/install.go
@@ -7,7 +7,6 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -23,6 +22,10 @@ const (
 	// with CODEGRAPH_VERSION in the Makefile and .github/workflows.
 	Version = "v0.9.7"
 	cgRepo  = "colbymchenry/codegraph"
+
+	officialMirrorBase         = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/codegraph"
+	officialMainlandMirrorBase = ""
+	perSourceDownloadTimeout   = 15 * time.Second
 
 	renameAttempts = 5
 	renameBackoff  = 200 * time.Millisecond
@@ -79,7 +82,8 @@ func assetName() string {
 }
 
 // Install downloads and unpacks the CodeGraph bundle into CacheDir on first use,
-// verifying it against the release's SHA256SUMS, then returns the launcher path.
+// verifying it against the checksum baked into the reasonix binary, then returns
+// the launcher path.
 // It is idempotent: a present cache is returned untouched. log, if non-nil,
 // receives a couple of progress lines. The extraction is staged in a temp dir and
 // atomically renamed into place, so a cancelled or failed run leaves no partial
@@ -104,21 +108,9 @@ func InstallWithClient(ctx context.Context, client *http.Client, log func(string
 	asset := assetName()
 	logf(log, "codegraph: downloading %s (%s, one-time)…", asset, Version)
 
-	base := fmt.Sprintf("https://github.com/%s/releases/download/%s", cgRepo, Version)
-	sums, err := httpGet(ctx, client, base+"/SHA256SUMS")
-	if err != nil {
-		return "", fmt.Errorf("codegraph: fetch checksums: %w", err)
-	}
-	want, err := sha256For(string(sums), asset)
+	data, err := downloadAsset(ctx, client, asset, log)
 	if err != nil {
 		return "", err
-	}
-	data, err := httpGet(ctx, client, base+"/"+asset)
-	if err != nil {
-		return "", fmt.Errorf("codegraph: download %s: %w", asset, err)
-	}
-	if got := sha256.Sum256(data); hex.EncodeToString(got[:]) != want {
-		return "", fmt.Errorf("codegraph: checksum mismatch for %s", asset)
 	}
 
 	parent := filepath.Dir(dir)
@@ -160,6 +152,65 @@ func InstallWithClient(ctx context.Context, client *http.Client, log func(string
 	}
 	logf(log, "codegraph: installed to %s", dir)
 	return p, nil
+}
+
+func downloadAsset(ctx context.Context, client *http.Client, asset string, log func(string)) ([]byte, error) {
+	want := expectedAssetSHA256(asset)
+	if want == "" {
+		return nil, fmt.Errorf("codegraph: no embedded checksum for %s (%s)", asset, Version)
+	}
+	return downloadAssetFromBases(ctx, client, asset, want, downloadBases(), log)
+}
+
+func downloadAssetFromBases(ctx context.Context, client *http.Client, asset, want string, bases []string, log func(string)) ([]byte, error) {
+	var errs []string
+	for _, base := range bases {
+		url := strings.TrimRight(base, "/") + "/" + asset
+		getCtx := ctx
+		cancel := func() {}
+		if perSourceDownloadTimeout > 0 {
+			getCtx, cancel = context.WithTimeout(ctx, perSourceDownloadTimeout)
+		}
+		data, err := httpGet(getCtx, client, url)
+		cancel()
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", base, err))
+			continue
+		}
+		got := fmt.Sprintf("%x", sha256.Sum256(data))
+		if got != want {
+			errs = append(errs, fmt.Sprintf("%s: checksum mismatch for %s", base, asset))
+			continue
+		}
+		logf(log, "codegraph: downloaded from %s", base)
+		return data, nil
+	}
+	return nil, fmt.Errorf("codegraph: download %s failed (%s)", asset, strings.Join(errs, "; "))
+}
+
+func expectedAssetSHA256(asset string) string {
+	return releaseAssetSHA256[asset]
+}
+
+func downloadBases() []string {
+	bases := []string{officialMirrorBase + "/" + Version}
+	if strings.TrimSpace(officialMainlandMirrorBase) != "" {
+		bases = append(bases, strings.TrimRight(officialMainlandMirrorBase, "/")+"/"+Version)
+	}
+	bases = append(bases, fmt.Sprintf("https://github.com/%s/releases/download/%s", cgRepo, Version))
+	return dedupeStrings(bases)
+}
+
+func dedupeStrings(values []string) []string {
+	var out []string
+	seen := make(map[string]bool, len(values))
+	for _, v := range values {
+		if !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // promote moves the freshly extracted bundle (root) into its versioned home

--- a/internal/codegraph/install_test.go
+++ b/internal/codegraph/install_test.go
@@ -5,7 +5,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -166,6 +168,79 @@ func TestInstallReturnsCachedWithoutNetwork(t *testing.T) {
 	// Resolve should also find it (no override, cache wins).
 	if p, ok := Resolve(""); !ok || p != launcher {
 		t.Fatalf("Resolve = %q, %v; want %q", p, ok, launcher)
+	}
+}
+
+func TestDownloadAssetUsesEmbeddedChecksumAndMirrorFallback(t *testing.T) {
+	asset := assetName()
+	body := []byte("verified codegraph payload")
+	sum := sha256.Sum256(body)
+	prev, hadPrev := releaseAssetSHA256[asset]
+	releaseAssetSHA256[asset] = fmt.Sprintf("%x", sum)
+	t.Cleanup(func() {
+		if hadPrev {
+			releaseAssetSHA256[asset] = prev
+		} else {
+			delete(releaseAssetSHA256, asset)
+		}
+	})
+
+	bad := httptest.NewServer(http.NotFoundHandler())
+	defer bad.Close()
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/"+asset) {
+			t.Fatalf("download path = %q, want asset suffix", r.URL.Path)
+		}
+		w.Write(body)
+	}))
+	defer good.Close()
+
+	got, err := downloadAssetFromBases(context.Background(), http.DefaultClient, asset, fmt.Sprintf("%x", sum), []string{bad.URL, good.URL}, nil)
+	if err != nil {
+		t.Fatalf("downloadAsset: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("downloadAsset body = %q, want %q", got, body)
+	}
+}
+
+func TestDownloadAssetRejectsMirrorChecksumMismatch(t *testing.T) {
+	asset := assetName()
+	prev, hadPrev := releaseAssetSHA256[asset]
+	releaseAssetSHA256[asset] = strings.Repeat("0", 64)
+	t.Cleanup(func() {
+		if hadPrev {
+			releaseAssetSHA256[asset] = prev
+		} else {
+			delete(releaseAssetSHA256, asset)
+		}
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("tampered"))
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if _, err := downloadAssetFromBases(ctx, http.DefaultClient, asset, strings.Repeat("0", 64), []string{srv.URL}, nil); err == nil {
+		t.Fatal("downloadAsset accepted a checksum mismatch")
+	}
+}
+
+func TestDownloadBasesUseOfficialSourcesBeforeGitHub(t *testing.T) {
+	got := downloadBases()
+	want := []string{
+		officialMirrorBase + "/" + Version,
+		fmt.Sprintf("https://github.com/%s/releases/download/%s", cgRepo, Version),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("downloadBases = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("downloadBases[%d] = %q, want %q (all=%#v)", i, got[i], want[i], got)
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,9 +211,8 @@ type StatuslineConfig struct {
 // enabled but missing; set false to require an explicit `reasonix codegraph
 // install` (e.g. for air-gapped or headless runs). Path overrides binary
 // resolution; empty resolves the cache, then a `codegraph` on PATH, then a
-// bundle beside the executable. Tier matches ordinary MCP servers (lazy,
-// background, eager); when unset it preserves the historical warm→eager /
-// cold→background startup.
+// bundle beside the executable. CodeGraph always starts in the background when
+// enabled; legacy tier values are ignored and removed during config load.
 type CodegraphConfig struct {
 	Enabled     bool   `toml:"enabled"`
 	AutoInstall bool   `toml:"auto_install"`
@@ -226,7 +225,7 @@ func (c CodegraphConfig) ShouldAutoStart() bool {
 }
 
 func (c CodegraphConfig) ResolvedTier() string {
-	return resolvedMCPTier(c.Tier)
+	return "background"
 }
 
 // NetworkConfig controls outbound HTTP proxy settings. web_fetch reuses these

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -539,7 +539,7 @@ func TestCodegraphDefaultEnabledForUpgrades(t *testing.T) {
 		t.Fatal("default codegraph auto_install = false, want true")
 	}
 	if c.Codegraph.Tier != "" {
-		t.Fatalf("default codegraph tier = %q, want unset (boot then preserves warm→eager/cold→background)", c.Codegraph.Tier)
+		t.Fatalf("default codegraph tier = %q, want unset (background by default)", c.Codegraph.Tier)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the main package light by downloading CodeGraph on demand, with official R2 first and GitHub release fallback
- verify downloaded CodeGraph archives against SHA256 values embedded in Reasonix instead of trusting mirror-provided checksums
- start built-in CodeGraph only in the background, ignoring legacy eager/lazy tier values so chat startup is never blocked
- default boot workspace discovery to the nearest git root when no explicit workspace root is provided
- add the release workflow step that mirrors upstream CodeGraph assets into R2 after checksum verification

## Verification
- `go test ./internal/codegraph ./internal/boot ./internal/config ./internal/cli`
- `go test -run 'Codegraph|MCPServer|Capabilities' -count=1 -v` in the desktop module
- `go run github.com/goreleaser/goreleaser/v2@latest check`
