### PR TITLE
fix(desktop): extend diff row background on horizontal scroll

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1934,6 +1934,7 @@ a[href] {
   gap: 8px;
   padding: 0 12px;
   white-space: pre;
+  min-width: min-content;
 }
 .diff__row--add {
   background: var(--add-bg);
@@ -8720,6 +8721,7 @@ a[href] {
   display: flex;
   gap: 6px;
   padding: 0 8px;
+  min-width: min-content;
 }
 .inline-diff__row--add {
   background: var(--add-bg);


### PR DESCRIPTION
Add min-width: min-content to .diff__row and .inline-diff__row so background colors cover the full line width when horizontal scrolling is active.

Fixes #3599