### PR TITLE
fix(desktop): cap model switcher list height to prevent viewport over…

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3014,6 +3014,8 @@ a[href] {
   top: auto;
   bottom: auto;
   z-index: var(--z-popover);
+  max-height: min(calc(100vh - 16px), 50vh);
+  overflow-y: auto;
 }
 .modelsw__item {
   display: flex;


### PR DESCRIPTION
…flow

Add max-height (50vh) and overflow-y: auto to the portal model menu so it scrolls when there are too many models instead of overflowing the screen.

Fixes #3629