### PR TITLE
[desktop] fix model selector dropdown scroll and truncated name tooltip

### DIFF
--- a/desktop/frontend/src/components/ModelSwitcher.tsx
+++ b/desktop/frontend/src/components/ModelSwitcher.tsx
@@ -86,8 +86,8 @@ export function ModelSwitcher({ label, tabId, onPick }: { label: string; tabId?:
               onClick={() => pick(m.ref)}
             >
               <span className="modelsw__copy">
-                <span className="modelsw__model">{m.model}</span>
-                <span className="modelsw__provider">{providerLabel(m.provider, t)}</span>
+                <span className="modelsw__model" title={m.model}>{m.model}</span>
+                <span className="modelsw__provider" title={providerLabel(m.provider, t)}>{providerLabel(m.provider, t)}</span>
               </span>
               {m.current && <Check size={13} className="modelsw__check" />}
             </button>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4401,11 +4401,29 @@ a[href] {
   z-index: var(--z-local-popover);
   min-width: 200px;
   max-width: 320px;
+  max-height: 280px;
+  overflow-y: auto;
   background: var(--bg-elev);
   border: 1px solid var(--border);
   border-radius: 9px;
   padding: 5px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+.modelsw__menu::-webkit-scrollbar {
+  width: 6px;
+}
+.modelsw__menu::-webkit-scrollbar-track {
+  background: transparent;
+  border-radius: 3px;
+}
+.modelsw__menu::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 3px;
+}
+.modelsw__menu::-webkit-scrollbar-thumb:hover {
+  background: var(--fg-faint);
 }
 .modelsw__menu--portal {
   position: fixed;


### PR DESCRIPTION
## 问题

1. **模型名称显示不全** (#3628)：当模型名称较长时（如 siliconflow 平台的模型带前缀），下拉列表中会被截断显示为 "deepseek-v4-..."，用户无法确认完整名称。

2. **模型列表无法滚动** (#3629)：当配置的模型数量较多时，下拉列表没有滚动条，超出屏幕的模型无法选择。

## 修复

### 1. 添加滚动支持
给 `.modelsw__menu` 添加：
- `max-height: 280px` — 限制下拉列表最大高度
- `overflow-y: auto` — 超出时显示滚动条

### 2. 添加 Tooltip 显示完整名称
给模型名称和提供商名称添加 `title` 属性，鼠标悬停时显示完整文本：
- `<span className="modelsw__model" title={m.model}>`
- `<span className="modelsw__provider" title={providerLabel(...)}>`

## 验证
- ✅ `npm run typecheck` 通过
- ✅ `npm run check:css` 通过
- ✅ `npm test` 通过（93 tests）

## 截图
修复前：模型名称被截断，长列表无法滚动
修复后：鼠标悬停显示完整名称，列表可滚动
