### PR TITLE
fix(desktop): reduce sidebar visual noise by removing separator lines

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -489,7 +489,6 @@ a[href] {
   min-width: 0;
   padding: 12px 10px;
   background: var(--sidebar-bg);
-  border-right: 1px solid var(--border-soft);
   --wails-draggable: drag;
   user-select: none;
   overflow: hidden;
@@ -548,7 +547,6 @@ a[href] {
   gap: 2px;
   flex: 0 0 auto;
   padding: 10px 0 8px;
-  border-top: 1px solid var(--border-soft);
 }
 .sidebar__navitem {
   display: flex;
@@ -9801,8 +9799,9 @@ a[href] {
   left: 0;
   top: 0;
   bottom: 0;
-  width: 4px;
-  background: color-mix(in srgb, var(--project-accent, var(--accent)) 88%, #ff9d22);
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: color-mix(in srgb, var(--project-accent, var(--accent)) 70%, #ff9d22);
   pointer-events: none;
 }
 


### PR DESCRIPTION
## What

Remove visual separator lines inside the sidebar to make the UI feel less fragmented.

## Changes

1. **Remove sidebar right border** — sidebar and main content area now blend together without a vertical divider
2. **Remove sidebar__nav top border** — no horizontal line between navigation and project tree
3. **Soften active topic indicator** — 4px → 3px width, added border-radius, reduced opacity for a gentler accent bar

## Why

The sidebar had too many separator lines (border-right, border-top, active indicator bar) which made the layout feel visually割裂. When a session is selected, the sidebar should feel like a natural extension of the main content area, not a separate panel.