### PR TITLE
fix(serve): restore query helper

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -639,6 +639,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 
 
+const $ = s => document.querySelector(s);
 const $$ = s => document.querySelectorAll(s);
 const log = $('#log'), input = $('#in'), btnSend = $('#btn-send'), btnStop = $('#btn-stop');
 const statusDot = $('#status-dot-footer'), statusText = $('#status-text');

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -208,6 +208,18 @@ func TestServeIndexPage(t *testing.T) {
 	}
 }
 
+func TestServeIndexDefinesQueryHelpers(t *testing.T) {
+	html := string(indexHTML)
+	for _, want := range []string{
+		"const $ = s => document.querySelector(s);",
+		"const $$ = s => document.querySelectorAll(s);",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("serve index missing query helper %q", want)
+		}
+	}
+}
+
 func TestServeIndexPagePassesLanguagePreferenceToClient(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary
- restore the missing `$` query helper in the embedded serve-mode web UI
- add a regression test that ensures both `$` and `$$` helpers are defined before the page uses them

Fixes #3645

## Tests
- `go test ./internal/serve -run TestServeIndexDefinesQueryHelpers -count=1`
- `go test ./internal/serve -count=1`

## Notes
- local commit/push hooks currently fail because they try to run npm from the repository root where `package.json` is absent; the relevant Go tests above were run manually