### PR TITLE
fix(cli): disable codegraph in ACP session config test

### DIFF
--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -75,6 +75,9 @@ func TestACPFactoryLoadsSessionCwdProjectConfig(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
 default_model = "local"
 
+[codegraph]
+enabled = false
+
 [[providers]]
 name = "local"
 kind = "acp-test-provider"


### PR DESCRIPTION
## Summary
`TestACPFactoryLoadsSessionCwdProjectConfig` fails deterministically on any machine that has the codegraph binary installed (and intermittently on others). It builds a full controller through `boot.Build` with the default config, which starts the `codegraph serve --mcp` daemon. The daemon opens `<workspaceRoot>/.codegraph/codegraph.db`, and on Windows that handle outlives `ctrl.Close()`, so the `t.TempDir` cleanup of the workspace root fails with `unlinkat ... The process cannot access the file because it is being used by another process`.

The test only verifies that an ACP session loads project commands from cwd — codegraph is irrelevant to it. Disable codegraph in the test's `reasonix.toml`, matching the convention the boot tests already use.

## Test plan
- Repro confirmed: `go test ./internal/cli -run '^TestACPFactoryLoadsSessionCwdProjectConfig$' -count=5` -> 5/5 FAIL (db lock) before; `-count=10` -> 10/10 pass after, ~0.86s (no daemon).
- `go test ./internal/cli` green.