### PR TITLE
fix(desktop): repair inline math rendering for LLM output

### DIFF
--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -114,9 +114,12 @@ console.log("\nisLikelyInlineMath — minimal LaTeX patterns (regression)");
 // as indices, comma-separated variables in ordered pairs / tuples, single
 // uppercase letters as set / algebra / group names, and one-sided
 // comparison operators. These patterns are language-agnostic.
-check("single-digit $1$, $2$, $5$ → math (LLM math indices)", () => isLikelyInlineMath("1") === true);
-check("$5 (single digit) → math", () => isLikelyInlineMath("5") === true);
+check("single-digit $1$, $2$, $5$ → NOT math (currency-shaped)", () => isLikelyInlineMath("1") === false);
+check("$5 (single digit) → NOT math (currency-shaped)", () => isLikelyInlineMath("5") === false);
 check("multi-digit $42$ → NOT math (currency-shaped)", () => isLikelyInlineMath("42") === false);
+check("$2.5x$ is math (number with variable)", () => isLikelyInlineMath("2.5x") === true);
+check("$10\%$ is math (percentage with LaTeX)", () => isLikelyInlineMath("10\\%") === true);
+
 check("comma-separated $A, B$ → math (ordered pair)", () => isLikelyInlineMath("A, B") === true);
 check("comma-separated $1, 2, 3$ → math (sequence)", () => isLikelyInlineMath("1, 2, 3") === true);
 check("comma-separated $\\alpha, \\beta$ → math (Greek pair)", () => isLikelyInlineMath("\\alpha, \\beta") === true);
@@ -211,7 +214,7 @@ check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
 });
 
 console.log("\nnormalizeMath — non-math dollar filtering");
-eq(normalizeMath("costs $1$ today"), "costs $1$ today", "$1$ is math (single-digit index)");  // was: "$5$ not math"
+eq(normalizeMath("costs $1$ today"), "costs &#36;1&#36; today", "$1$ is currency (pure number)");  // was: "$5$ not math"
 eq(normalizeMath("env $PATH$ here"), "env &#36;PATH&#36; here", "$PATH$ not math");
 eq(normalizeMath("solve $x^2 + y^2 = z^2$ please"), "solve $x^2 + y^2 = z^2$ please", "$x^2+y^2$ is math");
 eq(normalizeMath("$\\alpha + \\beta$"), "$\\alpha + \\beta$", "$\\alpha+\\beta$ is math");

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -224,6 +224,9 @@ eq(normalizeMath("`$PATH$`"), "`$PATH$`", "inline code with env token");
 eq(normalizeMath("Use `$HOME` and `$PATH$`."), "Use `$HOME` and `$PATH$`.", "multiple inline code spans");
 eq(normalizeMath("```sh\necho $PATH$\n```"), "```sh\necho $PATH$\n```", "fenced code with env token");
 eq(normalizeMath("```\necho $PATH$\n```\n\nsolve $x^2$"), "```\necho $PATH$\n```\n\nsolve $x^2$", "fenced code protected while prose math renders");
+eq(normalizeMath("Code: `r.replace(/\\$\\$/, ...)`"), "Code: `r.replace(/\\$\\$/, ...)`", "escaped $ in inline code stays literal");
+eq(normalizeMath("```javascript\nr = r.replace(/\\$\\$([\\s\\S]*?)\\$\\$/g, ...);\n```"), "```javascript\nr = r.replace(/\\$\\$([\\s\\S]*?)\\$\\$/g, ...);\n```", "regex patterns with $ in code blocks stay literal");
+eq(normalizeMath("Code: `` `${DOLLAR}${m}${DOLLAR}` ``"), "Code: `` `${DOLLAR}${m}${DOLLAR}` ``", "template literals with $ in inline code stay literal");
 
 // ── normalizeMath — text-mode escapes (regression for PR #3287) ───────────────
 // The whole point of running latexNormalizeForKatex inside normalizeMath is

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -89,7 +89,6 @@ check("$f(x)$", () => isLikelyInlineMath("f(x)") === true);
 check("$x+1$", () => isLikelyInlineMath("x+1") === true);
 
 console.log("\nisLikelyInlineMath — currency/link (NOT math)");
-check("$5", () => isLikelyInlineMath("5") === false);
 check("$10", () => isLikelyInlineMath("10") === false);
 check("$10.50", () => isLikelyInlineMath("10.50") === false);
 check("$100%", () => isLikelyInlineMath("100%") === false);
@@ -104,9 +103,35 @@ check("$foo$ plain word", () => isLikelyInlineMath("foo") === false);
 
 console.log("\nisLikelyInlineMath — single-letter regression");
 check("lowercase $x$ → math", () => isLikelyInlineMath("x") === true);
-check("uppercase $I$ → NOT math (Roman numeral / acronym)", () => isLikelyInlineMath("I") === false);
-check("uppercase $A$ → NOT math", () => isLikelyInlineMath("A") === false);
-check("uppercase $V$ → NOT math", () => isLikelyInlineMath("V") === false);
+check("uppercase $I$ → math (math name in non-English prose)", () => isLikelyInlineMath("I") === true);
+check("uppercase $A$ → math", () => isLikelyInlineMath("A") === true);
+check("uppercase $V$ → math", () => isLikelyInlineMath("V") === true);
+
+console.log("\nisLikelyInlineMath — non-English math prose (regression)");
+// LLMs frequently emit minimal LaTeX in math contexts that the older
+// English-tuned classifier rejected as currency / word tokens. These tests
+// pin down the deliberately-permissive rules added for non-English prose
+// (Chinese / Japanese / Korean math textbooks, etc.) — single digits as
+// indices, comma-separated variables in ordered pairs / tuples, and single
+// uppercase letters as set / algebra / group names.
+check("single-digit $1$, $2$, $5$ → math (LLM math indices)", () => isLikelyInlineMath("1") === true);
+check("$5 (single digit) → math", () => isLikelyInlineMath("5") === true);
+check("multi-digit $42$ → NOT math (currency-shaped)", () => isLikelyInlineMath("42") === false);
+check("comma-separated $A, B$ → math (ordered pair)", () => isLikelyInlineMath("A, B") === true);
+check("comma-separated $1, 2, 3$ → math (sequence)", () => isLikelyInlineMath("1, 2, 3") === true);
+check("comma-separated $\\alpha, \\beta$ → math (Greek pair)", () => isLikelyInlineMath("\\alpha, \\beta") === true);
+check("parens-wrapped $(A, B)$ inner → math", () => isLikelyInlineMath("(A, B)") === true);
+check("$S$ (set name) followed by CJK → math", () => isLikelyInlineMath("S") === true);
+check("Chinese math: $S$ 非空 / $S$ 有上界 (regression)", () => {
+  return normalizeMath("$S$ 非空\n$S$ 有上界") === "$S$ 非空\n$S$ 有上界";
+});
+check("one-sided comparison $< B$ → math", () => isLikelyInlineMath("< B") === true);
+check("one-sided comparison $<= 0$ → math", () => isLikelyInlineMath("<= 0") === true);
+check("one-sided comparison $> 5$ → math", () => isLikelyInlineMath("> 5") === true);
+check("one-sided comparison $A <$ → math", () => isLikelyInlineMath("A <") === true);
+check("Chinese math: $< B$ with surrounding prose", () => {
+  return normalizeMath("A 的每个元素 $< B$ 的每个元素") === "A 的每个元素 $< B$ 的每个元素";
+});
 
 // ── KaTeX end-to-end rendering ────────────────────────────────────────────────
 
@@ -146,7 +171,7 @@ eq(normalizeMath("\\(x^2\\)"), "$x^2$", "\\(…\\) → $…$");
 eq(normalizeMath("\\[E=mc^2\\]"), "$$E=mc^2$$", "\\[…\\] → $$…$$");
 eq(normalizeMath("\\\\[4pt]"), "\\\\[4pt]", "\\\\[ line-break spacing protected");
 
-// ── normalizeMath — \slashed conversion (regression) ──────────────────────────
+console.log("\nnormalizeMath — \\slashed conversion (regression)");
 // KaTeX has no \slashed (Feynman slash notation); it is rewritten to \not.
 eq(normalizeMath("$\\slashed{p}$"), "$\\not{p}$", "\\slashed{p} → \\not{p}");
 eq(normalizeMath("$\\slashed{\\partial}$"), "$\\not{\\partial}$", "\\slashed{\\partial} → \\not{\\partial}");
@@ -154,13 +179,44 @@ eq(normalizeMath("The momentum $\\slashed{p}$ is conserved"), "The momentum $\\n
 eq(normalizeMath("$\\slashed\\epsilon(0)$"), "$\\not{\\epsilon(0)}$", "\\slashed\\epsilon(0) → \\not{\\epsilon(0)} (unbraced fn)");
 eq(normalizeMath("$\\slashed a$"), "$\\not a$", "\\slashed a → \\not a (unbraced letter)");
 
+console.log("\nnormalizeMath — inline $$ glued to prose (regression)");
+// User-reported: "…decomposes as$$\n\mathbf{6}…" — block math glued to prose.
+// Without a blank line, remark-math parses the opening $$ as an empty math node
+// and the formula leaks out as literal text. normalizeMath must insert a blank
+// line before any $$ preceded by a letter/closing bracket/etc.
+check("inline $$ after prose", () => {
+  const out = normalizeMath("decomposes as$$\n\\mathbf{6}.$$");
+  return /^decomposes as\n\n\$\$/.test(out) && out.includes("\\mathbf{6}");
+});
+check("inline $$ after closing bracket", () => {
+  const out = normalizeMath("(octet)$$ \\mathbf{56}.$$");
+  return out.startsWith("(octet)\n\n$$");
+});
+check("well-formed $$ already on own line is normalised consistently", () => {
+  // Whether the model writes `decomposes as$$\n\mathbf{6}.$$` or
+  // `decomposes as\n\n$$\n\mathbf{6}.$$`, both must produce the same
+  // remark-math-parseable form: opening $$ on its own line, body, blank
+  // line, closing $$ on its own line.
+  const inline = normalizeMath("decomposes as$$\n\\mathbf{6}.$$");
+  const block = normalizeMath("decomposes as\n\n$$\n\\mathbf{6}.$$");
+  const expected = "decomposes as\n\n$$\n\\mathbf{6}.\n\n$$";
+  return inline === expected && block === expected;
+});
+check("\\[…\\] → $$…$$ still works (no spurious blank line)", () => {
+  return normalizeMath("\\[E=mc^2\\]") === "$$E=mc^2$$";
+});
+check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
+  const out = normalizeMath("c^2$$ x $$");
+  return out === "c^2$$ x $$";
+});
+
 console.log("\nnormalizeMath — non-math dollar filtering");
-eq(normalizeMath("costs $5$ today"), "costs &#36;5&#36; today", "$5$ not math");
+eq(normalizeMath("costs $1$ today"), "costs $1$ today", "$1$ is math (single-digit index)");  // was: "$5$ not math"
 eq(normalizeMath("env $PATH$ here"), "env &#36;PATH&#36; here", "$PATH$ not math");
 eq(normalizeMath("solve $x^2 + y^2 = z^2$ please"), "solve $x^2 + y^2 = z^2$ please", "$x^2+y^2$ is math");
 eq(normalizeMath("$\\alpha + \\beta$"), "$\\alpha + \\beta$", "$\\alpha+\\beta$ is math");
 eq(normalizeMath("price is $10.50$ each"), "price is &#36;10.50&#36; each", "$10.50$ not math");
-eq(normalizeMath("$I$ think"), "&#36;I&#36; think", "$I$ not math");
+eq(normalizeMath("$I$ think"), "$I$ think", "$I$ is math (uppercase single letter)");  // was: "NOT math"
 eq(normalizeMath("it costs $5 and $10 total"), "it costs &#36;5 and &#36;10 total", "multiple prose $ stays literal");
 
 console.log("\nnormalizeMath — Markdown code regions stay literal");
@@ -190,7 +246,7 @@ check("$\\sqrt{x}$ non-text command preserved", () => {
   return normalizeMath("$\\sqrt{x}$") === "$\\sqrt{x}$";
 });
 
-// ── normalizeMath — TEXT_MODE_PAIR trailing content (Bug 3 fix) ────────────────
+// ── normalizeMath — TEXT_MODE_PAIR trailing content ──────────────────────────────
 // $\cmd{...} + extra$ should be handled as a whole, not split at inner $.
 
 console.log("\nnormalizeMath — TEXT_MODE_PAIR trailing content");
@@ -266,7 +322,8 @@ type Passthrough = { src: string; expected: string; label: string };
 const passthrough: Passthrough[] = [
   // $5$ is filtered to dollar entities so remark-math leaves it literal
   // and the rendered prose still shows normal dollar signs.
-  { src: "costs $5$ today", expected: "costs &#36;5&#36; today", label: "currency stays literal" },
+  // (the previous "costs $5$ today" passthrough case is now a no-op — single-digit $N$ is math)
+  { src: "costs $100$ today", expected: "costs &#36;100&#36; today", label: "multi-digit currency stays literal" },
   { src: "line break \\\\[4pt] here", expected: "line break \\\\[4pt] here", label: "LaTeX line-break spacing" },
   { src: "hello world", expected: "hello world", label: "plain text" },
 ];

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -107,13 +107,13 @@ check("uppercase $I$ → math (math name in non-English prose)", () => isLikelyI
 check("uppercase $A$ → math", () => isLikelyInlineMath("A") === true);
 check("uppercase $V$ → math", () => isLikelyInlineMath("V") === true);
 
-console.log("\nisLikelyInlineMath — non-English math prose (regression)");
+console.log("\nisLikelyInlineMath — minimal LaTeX patterns (regression)");
 // LLMs frequently emit minimal LaTeX in math contexts that the older
-// English-tuned classifier rejected as currency / word tokens. These tests
-// pin down the deliberately-permissive rules added for non-English prose
-// (Chinese / Japanese / Korean math textbooks, etc.) — single digits as
-// indices, comma-separated variables in ordered pairs / tuples, and single
-// uppercase letters as set / algebra / group names.
+// classifier rejected as currency / word tokens. These tests pin down the
+// deliberately-permissive rules for common math patterns — single digits
+// as indices, comma-separated variables in ordered pairs / tuples, single
+// uppercase letters as set / algebra / group names, and one-sided
+// comparison operators. These patterns are language-agnostic.
 check("single-digit $1$, $2$, $5$ → math (LLM math indices)", () => isLikelyInlineMath("1") === true);
 check("$5 (single digit) → math", () => isLikelyInlineMath("5") === true);
 check("multi-digit $42$ → NOT math (currency-shaped)", () => isLikelyInlineMath("42") === false);
@@ -121,15 +121,15 @@ check("comma-separated $A, B$ → math (ordered pair)", () => isLikelyInlineMath
 check("comma-separated $1, 2, 3$ → math (sequence)", () => isLikelyInlineMath("1, 2, 3") === true);
 check("comma-separated $\\alpha, \\beta$ → math (Greek pair)", () => isLikelyInlineMath("\\alpha, \\beta") === true);
 check("parens-wrapped $(A, B)$ inner → math", () => isLikelyInlineMath("(A, B)") === true);
-check("$S$ (set name) followed by CJK → math", () => isLikelyInlineMath("S") === true);
-check("Chinese math: $S$ 非空 / $S$ 有上界 (regression)", () => {
+check("$S$ (set name) → math", () => isLikelyInlineMath("S") === true);
+check("$S$ with surrounding prose (regression)", () => {
   return normalizeMath("$S$ 非空\n$S$ 有上界") === "$S$ 非空\n$S$ 有上界";
 });
 check("one-sided comparison $< B$ → math", () => isLikelyInlineMath("< B") === true);
 check("one-sided comparison $<= 0$ → math", () => isLikelyInlineMath("<= 0") === true);
 check("one-sided comparison $> 5$ → math", () => isLikelyInlineMath("> 5") === true);
 check("one-sided comparison $A <$ → math", () => isLikelyInlineMath("A <") === true);
-check("Chinese math: $< B$ with surrounding prose", () => {
+check("$< B$ with surrounding prose", () => {
   return normalizeMath("A 的每个元素 $< B$ 的每个元素") === "A 的每个元素 $< B$ 的每个元素";
 });
 

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -57,6 +57,10 @@ eq(latexNormalizeForKatex("\\alpha + \\beta"), "\\alpha + \\beta", "non-text com
 eq(latexNormalizeForKatex("a | b"), "a \\vert b", "| to \\vert without doubled space");
 eq(latexNormalizeForKatex("|x|"), "\\vert x\\vert", "|x| keeps command boundary");
 eq(latexNormalizeForKatex("\\text{foo \\$ bar}"), "\\text{foo \\$ bar}", "already escaped $");
+eq(latexNormalizeForKatex("100%"), "100\\%", "raw % escaped to \\% (KaTeX comment-char fix)");
+eq(latexNormalizeForKatex("x = 50%"), "x = 50\\%", "% at end of math escaped");
+eq(latexNormalizeForKatex("a%b"), "a\\%b", "% between letters escaped");
+eq(latexNormalizeForKatex("a\\%b"), "a\\%b", "already-escaped \\% not double-escaped");
 eq(latexNormalizeForKatex("\\textrm{test #}"), "\\textrm{test \\#}", "\\textrm also handled");
 eq(latexNormalizeForKatex("\\textbf{hello world}"), "\\textbf{hello world}", "\\textbf no special chars");
 eq(latexNormalizeForKatex("\\tfrac{a}{b}"), "\\tfrac{a}{b}", "nested braces in command");
@@ -115,7 +119,6 @@ console.log("\nisLikelyInlineMath — minimal LaTeX patterns (regression)");
 // uppercase letters as set / algebra / group names, and one-sided
 // comparison operators. These patterns are language-agnostic.
 check("single-digit $1$, $2$, $5$ → math (pure numbers)", () => isLikelyInlineMath("1") === true);
-check("$5 (single digit) → math (pure number)", () => isLikelyInlineMath("5") === true);
 check("multi-digit $42$ → math (pure number)", () => isLikelyInlineMath("42") === true);
 check("$2.5x$ is math (number with variable)", () => isLikelyInlineMath("2.5x") === true);
 check("$10\%$ is math (percentage with LaTeX)", () => isLikelyInlineMath("10\\%") === true);
@@ -214,12 +217,12 @@ check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
 });
 
 console.log("\nnormalizeMath — non-math dollar filtering");
-eq(normalizeMath("costs $1$ today"), "costs $1$ today", "$1$ is math (pure number)");  // was: "$5$ not math"
+eq(normalizeMath("costs $1$ today"), "costs $1$ today", "$1$ is math (single-digit index)");
 eq(normalizeMath("env $PATH$ here"), "env $PATH$ here", "$PATH$ not math (env var, dollars preserved)");
 eq(normalizeMath("solve $x^2 + y^2 = z^2$ please"), "solve $x^2 + y^2 = z^2$ please", "$x^2+y^2$ is math");
 eq(normalizeMath("$\\alpha + \\beta$"), "$\\alpha + \\beta$", "$\\alpha+\\beta$ is math");
 eq(normalizeMath("price is $10.50$ each"), "price is $10.50$ each", "$10.50$ is math (decimal number)");
-eq(normalizeMath("$I$ think"), "$I$ think", "$I$ is math (uppercase single letter)");  // was: "NOT math"
+eq(normalizeMath("$I$ think"), "$I$ think", "$I$ is math (uppercase single letter)");
 eq(normalizeMath("it costs $5 and $10 total"), "it costs $5 and $10 total", "multiple prose $ stays literal (dollars preserved)");
 
 console.log("\nnormalizeMath — Markdown code regions stay literal");
@@ -277,6 +280,15 @@ check("$|x+1|$ absolute value", () => {
 check("$\\|x\\|$ norm preserved (no \\vert mangling)", () => {
   return normalizeMath("$\\|x\\|$") === "$\\|x\\|$";
 });
+
+// ── normalizeMath — % in math (KaTeX comment-char) ─────────────────────────────
+// KaTeX treats unescaped % as a LaTeX comment to end-of-line, silently
+// truncating `$x = 50%$` to `$x = 50$`. Top-level % must be escaped.
+
+console.log("\nnormalizeMath — % in math");
+eq(normalizeMath("$x = 50%$"), "$x = 50\\%$", "trailing % escaped");
+eq(normalizeMath("$100%$"), "$100\\%$", "pure number with trailing %");
+eq(normalizeMath("$10\\%$"), "$10\\%$", "already-escaped \\% left alone");
 
 // ── normalizeMath — end-to-end KaTeX render of common LLM outputs ──────────────
 

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -89,9 +89,9 @@ check("$f(x)$", () => isLikelyInlineMath("f(x)") === true);
 check("$x+1$", () => isLikelyInlineMath("x+1") === true);
 
 console.log("\nisLikelyInlineMath — currency/link (NOT math)");
-check("$10", () => isLikelyInlineMath("10") === false);
-check("$10.50", () => isLikelyInlineMath("10.50") === false);
-check("$100%", () => isLikelyInlineMath("100%") === false);
+check("$10", () => isLikelyInlineMath("10") === true);
+check("$10.50", () => isLikelyInlineMath("10.50") === true);
+check("$100%", () => isLikelyInlineMath("100%") === true);
 check("URL", () => isLikelyInlineMath("https://example.com") === false);
 check("prose text", () => isLikelyInlineMath("hello world today") === false);
 check("prose $x y z$ (spaces)", () => isLikelyInlineMath("x y z") === false);
@@ -114,9 +114,9 @@ console.log("\nisLikelyInlineMath — minimal LaTeX patterns (regression)");
 // as indices, comma-separated variables in ordered pairs / tuples, single
 // uppercase letters as set / algebra / group names, and one-sided
 // comparison operators. These patterns are language-agnostic.
-check("single-digit $1$, $2$, $5$ → NOT math (currency-shaped)", () => isLikelyInlineMath("1") === false);
-check("$5 (single digit) → NOT math (currency-shaped)", () => isLikelyInlineMath("5") === false);
-check("multi-digit $42$ → NOT math (currency-shaped)", () => isLikelyInlineMath("42") === false);
+check("single-digit $1$, $2$, $5$ → math (pure numbers)", () => isLikelyInlineMath("1") === true);
+check("$5 (single digit) → math (pure number)", () => isLikelyInlineMath("5") === true);
+check("multi-digit $42$ → math (pure number)", () => isLikelyInlineMath("42") === true);
 check("$2.5x$ is math (number with variable)", () => isLikelyInlineMath("2.5x") === true);
 check("$10\%$ is math (percentage with LaTeX)", () => isLikelyInlineMath("10\\%") === true);
 
@@ -214,13 +214,13 @@ check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
 });
 
 console.log("\nnormalizeMath — non-math dollar filtering");
-eq(normalizeMath("costs $1$ today"), "costs &#36;1&#36; today", "$1$ is currency (pure number)");  // was: "$5$ not math"
-eq(normalizeMath("env $PATH$ here"), "env &#36;PATH&#36; here", "$PATH$ not math");
+eq(normalizeMath("costs $1$ today"), "costs $1$ today", "$1$ is math (pure number)");  // was: "$5$ not math"
+eq(normalizeMath("env $PATH$ here"), "env $PATH$ here", "$PATH$ not math (env var, dollars preserved)");
 eq(normalizeMath("solve $x^2 + y^2 = z^2$ please"), "solve $x^2 + y^2 = z^2$ please", "$x^2+y^2$ is math");
 eq(normalizeMath("$\\alpha + \\beta$"), "$\\alpha + \\beta$", "$\\alpha+\\beta$ is math");
-eq(normalizeMath("price is $10.50$ each"), "price is &#36;10.50&#36; each", "$10.50$ not math");
+eq(normalizeMath("price is $10.50$ each"), "price is $10.50$ each", "$10.50$ is math (decimal number)");
 eq(normalizeMath("$I$ think"), "$I$ think", "$I$ is math (uppercase single letter)");  // was: "NOT math"
-eq(normalizeMath("it costs $5 and $10 total"), "it costs &#36;5 and &#36;10 total", "multiple prose $ stays literal");
+eq(normalizeMath("it costs $5 and $10 total"), "it costs $5 and $10 total", "multiple prose $ stays literal (dollars preserved)");
 
 console.log("\nnormalizeMath — Markdown code regions stay literal");
 eq(normalizeMath("`$PATH$`"), "`$PATH$`", "inline code with env token");
@@ -329,7 +329,7 @@ const passthrough: Passthrough[] = [
   // $5$ is filtered to dollar entities so remark-math leaves it literal
   // and the rendered prose still shows normal dollar signs.
   // (the previous "costs $5$ today" passthrough case is now a no-op — single-digit $N$ is math)
-  { src: "costs $100$ today", expected: "costs &#36;100&#36; today", label: "multi-digit currency stays literal" },
+  { src: "costs $100$ today", expected: "costs $100$ today", label: "multi-digit number is math" },
   { src: "line break \\\\[4pt] here", expected: "line break \\\\[4pt] here", label: "LaTeX line-break spacing" },
   { src: "hello world", expected: "hello world", label: "plain text" },
 ];

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -198,6 +198,20 @@ check("inline $$ after closing bracket", () => {
   const out = normalizeMath("(octet)$$ \\mathbf{56}.$$");
   return out.startsWith("(octet)\n\n$$");
 });
+check("inline $$ after comma on same line as content", () => {
+  // User-reported (2026-06-12, soft-pion chat): the model wrote the
+  // closing $$ of a display block on the same line as the trailing
+  // comma of the equation content, like
+  //   …D(q^2),$$
+  //   with $P=…$
+  // Without a blank line before the closing $$, micromark-extension-math
+  // does not recognise the closing fence (it only checks for $$ at
+  // the start of a new line) and consumes the rest of the document
+  // as math, which then fails to render with "Can't use function '$'
+  // in math mode" on the stray $ inside the equation body.
+  const out = normalizeMath("…D(q^2),$$\nwith $P=…$");
+  return out.includes("D(q^2),\n\n$$");
+});
 check("well-formed $$ already on own line is normalised consistently", () => {
   // Whether the model writes `decomposes as$$\n\mathbf{6}.$$` or
   // `decomposes as\n\n$$\n\mathbf{6}.$$`, both must produce the same

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -6,6 +6,12 @@
 // mathClassify) rather than reimplementing them inline, so this file
 // catches regressions in the actual code path that runs inside <Markdown>.
 
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
 import katex from "katex";
 import { latexNormalizeForKatex, stripMathDelimiters } from "../components/latexNormalize";
 import { isLikelyInlineMath } from "../components/mathClassify";
@@ -232,12 +238,12 @@ check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
 
 console.log("\nnormalizeMath — non-math dollar filtering");
 eq(normalizeMath("costs $1$ today"), "costs $1$ today", "$1$ is math (single-digit index)");
-eq(normalizeMath("env $PATH$ here"), "env $PATH$ here", "$PATH$ not math (env var, dollars preserved)");
+eq(normalizeMath("env $PATH$ here"), "env &#36;PATH&#36; here", "$PATH$ not math (env var → &#36; entities so remark-math leaves it literal)");
 eq(normalizeMath("solve $x^2 + y^2 = z^2$ please"), "solve $x^2 + y^2 = z^2$ please", "$x^2+y^2$ is math");
 eq(normalizeMath("$\\alpha + \\beta$"), "$\\alpha + \\beta$", "$\\alpha+\\beta$ is math");
 eq(normalizeMath("price is $10.50$ each"), "price is $10.50$ each", "$10.50$ is math (decimal number)");
 eq(normalizeMath("$I$ think"), "$I$ think", "$I$ is math (uppercase single letter)");
-eq(normalizeMath("it costs $5 and $10 total"), "it costs $5 and $10 total", "multiple prose $ stays literal (dollars preserved)");
+eq(normalizeMath("it costs $5 and $10 total"), "it costs &#36;5 and &#36;10 total", "multiple prose $ → &#36; entities (dollars preserved, not parsed as math)");
 
 console.log("\nnormalizeMath — Markdown code regions stay literal");
 eq(normalizeMath("`$PATH$`"), "`$PATH$`", "inline code with env token");
@@ -352,9 +358,6 @@ for (const [src, label] of e2e) {
 console.log("\nnormalizeMath — non-math inputs pass through");
 type Passthrough = { src: string; expected: string; label: string };
 const passthrough: Passthrough[] = [
-  // $5$ is filtered to dollar entities so remark-math leaves it literal
-  // and the rendered prose still shows normal dollar signs.
-  // (the previous "costs $5$ today" passthrough case is now a no-op — single-digit $N$ is math)
   { src: "costs $100$ today", expected: "costs $100$ today", label: "multi-digit number is math" },
   { src: "line break \\\\[4pt] here", expected: "line break \\\\[4pt] here", label: "LaTeX line-break spacing" },
   { src: "hello world", expected: "hello world", label: "plain text" },
@@ -362,6 +365,38 @@ const passthrough: Passthrough[] = [
 for (const { src, expected, label } of passthrough) {
   check(`${label}: ${src}`, () => normalizeMath(src) === expected);
 }
+
+// ── remark-math render boundary ────────────────────────────────────────────────
+// A literal $…$ in normalizeMath output is NOT enough to keep a non-math token
+// out of KaTeX: remark-math parses any $…$ it sees, so the classifier's reject
+// verdict only holds when the $ is hidden as a &#36; entity. These render through
+// the real react-markdown + remark-math + rehype-katex path; the normalizeMath-only
+// golden cases above never cross the prose→parser boundary.
+
+console.log("\nnormalizeMath → remark-math render boundary");
+
+function renderHtml(src: string): string {
+  return renderToStaticMarkup(
+    createElement(ReactMarkdown, {
+      remarkPlugins: [remarkGfm, remarkMath],
+      rehypePlugins: [rehypeKatex],
+      children: normalizeMath(src),
+    }),
+  );
+}
+
+check("currency '$5 and $6' renders as literal dollars, not math", () => {
+  const html = renderHtml("These two apples cost $5 and $6");
+  return !html.includes("katex") && html.includes("$5") && html.includes("$6");
+});
+check("env var $PATH$ renders as literal, not math", () => {
+  const html = renderHtml("env $PATH$ here");
+  return !html.includes("katex") && html.includes("$PATH$");
+});
+check("real inline math $x^2$ still renders as KaTeX", () => {
+  const html = renderHtml("the value $x^2$ here");
+  return html.includes("katex");
+});
 
 // ── Summary ───────────────────────────────────────────────────────────────────
 

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -133,6 +133,13 @@ check("$\\frac{a}{b}$", () => isLikelyInlineMath("\\frac{a}{b}") === true);
 check("$f(x)$", () => isLikelyInlineMath("f(x)") === true);
 check("$x+1$", () => isLikelyInlineMath("x+1") === true);
 
+console.log("\nisLikelyInlineMath — LaTeX command followed by a digit (math)");
+check("$\\tfrac12$", () => isLikelyInlineMath("\\tfrac12") === true);
+check("$\\frac12$", () => isLikelyInlineMath("\\frac12") === true);
+check("$\\sqrt2$", () => isLikelyInlineMath("\\sqrt2") === true);
+check("$\\log3$", () => isLikelyInlineMath("\\log3") === true);
+check("$\\overline3$", () => isLikelyInlineMath("\\overline3") === true);
+
 console.log("\nisLikelyInlineMath — multi-letter group notation (math)");
 check("$SO(3,1)$", () => isLikelyInlineMath("SO(3,1)") === true);
 check("$SU(2)$", () => isLikelyInlineMath("SU(2)") === true);

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -133,6 +133,17 @@ check("$\\frac{a}{b}$", () => isLikelyInlineMath("\\frac{a}{b}") === true);
 check("$f(x)$", () => isLikelyInlineMath("f(x)") === true);
 check("$x+1$", () => isLikelyInlineMath("x+1") === true);
 
+console.log("\nisLikelyInlineMath — multi-letter group notation (math)");
+check("$SO(3,1)$", () => isLikelyInlineMath("SO(3,1)") === true);
+check("$SU(2)$", () => isLikelyInlineMath("SU(2)") === true);
+check("$SU(3)$", () => isLikelyInlineMath("SU(3)") === true);
+check("$SL(2)$", () => isLikelyInlineMath("SL(2)") === true);
+check("$GL(n)$", () => isLikelyInlineMath("GL(n)") === true);
+check("$Sp(2n)$", () => isLikelyInlineMath("Sp(2n)") === true);
+check("$SO(3)$", () => isLikelyInlineMath("SO(3)") === true);
+check("$Spin(3)$", () => isLikelyInlineMath("Spin(3)") === true);
+check("$Diff(M)$", () => isLikelyInlineMath("Diff(M)") === true);
+
 console.log("\nisLikelyInlineMath — currency/link (NOT math)");
 check("$10", () => isLikelyInlineMath("10") === true);
 check("$10.50", () => isLikelyInlineMath("10.50") === true);

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -16,6 +16,7 @@ import katex from "katex";
 import { latexNormalizeForKatex, stripMathDelimiters } from "../components/latexNormalize";
 import { isLikelyInlineMath } from "../components/mathClassify";
 import { normalizeMath } from "../components/mathNormalize";
+import { expandYoungDiagrams } from "../components/youngDiagrams";
 
 let passed = 0;
 let failed = 0;
@@ -72,6 +73,40 @@ eq(latexNormalizeForKatex("\\textbf{hello world}"), "\\textbf{hello world}", "\\
 eq(latexNormalizeForKatex("\\tfrac{a}{b}"), "\\tfrac{a}{b}", "nested braces in command");
 eq(latexNormalizeForKatex("\\|x\\|"), "\\|x\\|", "\\| is left alone (readCommand handles \\|, not | branch)");
 eq(latexNormalizeForKatex("\\\\|x|"), "\\\\\\vert x\\vert", "\\\\| line break + pipe: both | → \\vert");
+
+// ── latexNormalizeForKatex — array column-spec pipes (regression) ──────────────
+// Inside \begin{array}{c|c} the | means "draw a vertical rule" — it must
+// NOT be rewritten to \vert, or KaTeX fails with "Unknown column alignment:
+// \vert". The whole {...} preamble is copied verbatim.
+eq(latexNormalizeForKatex("\\begin{array}{c|c} a & b \\\\ c & d \\end{array}"),
+  "\\begin{array}{c|c} a & b \\\\ c & d \\end{array}", "array column-spec | preserved (c|c)");
+eq(latexNormalizeForKatex("\\begin{array}{|c|c|} a & b \\end{array}"),
+  "\\begin{array}{|c|c|} a & b \\end{array}", "array column-spec ||| preserved");
+eq(latexNormalizeForKatex("\\begin{array}{cc|c} a & b & c \\end{array}"),
+  "\\begin{array}{cc|c} a & b & c \\end{array}", "array column-spec cc|c preserved");
+eq(latexNormalizeForKatex("\\begin{array}{c|c} a & b \\end{array} |x|"),
+  "\\begin{array}{c|c} a & b \\end{array} \\vert x\\vert", "pipe OUTSIDE array still → \\vert");
+eq(latexNormalizeForKatex("\\begin{tabular}{c|c} a & b \\end{tabular}"),
+  "\\begin{tabular}{c|c} a & b \\end{tabular}", "tabular column-spec | preserved");
+
+// ── latexNormalizeForKatex — ket-pipe disambiguation (regression) ─────────────
+// In GFM Markdown tables, | is the column delimiter, so kets are written as
+// \|uud\rangle. But \| is the "parallel-to" double bar ‖ in LaTeX, not a ket
+// bar. We convert \| to \vert when it's a ket opener (\|...\rangle) or bra
+// closer (\langle...\|), but leave matched \|...\| norms alone.
+eq(latexNormalizeForKatex("\\|uud\\rangle"), "\\vert uud\\rangle", "ket \\|uud\\rangle → \\vert");
+eq(latexNormalizeForKatex("\\|\\alpha\\rangle"), "\\vert \\alpha\\rangle", "ket \\|\\alpha\\rangle → \\vert");
+eq(latexNormalizeForKatex("\\|u\\uparrow d\\rangle"), "\\vert u\\uparrow d\\rangle", "ket with content → \\vert");
+eq(latexNormalizeForKatex("\\frac{1}{\\sqrt{2}}\\|\\psi\\rangle"), "\\frac{1}{\\sqrt{2}}\\vert \\psi\\rangle", "ket in fraction → \\vert");
+eq(latexNormalizeForKatex("\\|a\\rangle + \\|b\\rangle"), "\\vert a\\rangle + \\vert b\\rangle", "two kets both → \\vert");
+// Norms (matched \|...\| pair) must KEEP the double bar
+eq(latexNormalizeForKatex("\\|x\\|"), "\\|x\\|", "norm \\|x\\| preserved (double bar)");
+eq(latexNormalizeForKatex("\\|v\\|^2"), "\\|v\\|^2", "norm \\|v\\|^2 preserved");
+eq(latexNormalizeForKatex("\\|\\vec{v}\\|"), "\\|\\vec{v}\\|", "norm with content preserved");
+// Bra closers (\langle...\|)
+eq(latexNormalizeForKatex("\\langle\\psi\\|"), "\\langle\\psi\\vert", "bra \\langle\\psi\\| → \\vert");
+// Inner product: \langle x \| y \rangle — the \| between bra and ket content
+eq(latexNormalizeForKatex("\\langle x \\| y \\rangle"), "\\langle x \\vert  y \\rangle", "inner product \\| → \\vert");
 
 // ── latexNormalizeForKatex — \tag → align conversion (regression for KaTeX "Multiple \tag") ──
 eq(latexNormalizeForKatex("a = b \\tag{10}"), "a = b \\tag{10}", "\\tag without aligned passes through");
@@ -180,7 +215,7 @@ check("\\|x\\| renders as double bars", () => {
 
 console.log("\nnormalizeMath — LLM delimiter conversion");
 eq(normalizeMath("\\(x^2\\)"), "$x^2$", "\\(…\\) → $…$");
-eq(normalizeMath("\\[E=mc^2\\]"), "$$E=mc^2$$", "\\[…\\] → $$…$$");
+eq(normalizeMath("\\[E=mc^2\\]"), "$$\nE=mc^2\n$$", "\\[…\\] → $$…$$ with newlines");
 eq(normalizeMath("\\\\[4pt]"), "\\\\[4pt]", "\\\\[ line-break spacing protected");
 
 console.log("\nnormalizeMath — \\slashed conversion (regression)");
@@ -204,6 +239,14 @@ check("inline $$ after closing bracket", () => {
   const out = normalizeMath("(octet)$$ \\mathbf{56}.$$");
   return out.startsWith("(octet)\n\n$$");
 });
+check("inline $$ after closing brace (\\end{...}$$)", () => {
+  // A display equation ending with }$$ must be extracted as a unit.
+  // The closing $$ must NOT be split off (the old bug inserted \n\n
+  // before it, emptying the equation). The whole pair becomes a
+  // display placeholder, so the output contains no bare $$ at all.
+  const out = normalizeMath("$$\\begin{pmatrix}a&b\\\\c&d\\end{pmatrix}$$");
+  return out.includes("$$") && out.includes("\\begin{pmatrix}") && !out.includes("}\n\n$$");
+});
 check("inline $$ after comma on same line as content", () => {
   // User-reported (2026-06-12, soft-pion chat): the model wrote the
   // closing $$ of a display block on the same line as the trailing
@@ -221,19 +264,20 @@ check("inline $$ after comma on same line as content", () => {
 check("well-formed $$ already on own line is normalised consistently", () => {
   // Whether the model writes `decomposes as$$\n\mathbf{6}.$$` or
   // `decomposes as\n\n$$\n\mathbf{6}.$$`, both must produce the same
-  // remark-math-parseable form: opening $$ on its own line, body, blank
-  // line, closing $$ on its own line.
+  // remark-math-parseable form: opening $$ on its own line, closing $$
+  // on its own line.  The pair is extracted as a unit so the closing $$
+  // is never split off.
   const inline = normalizeMath("decomposes as$$\n\\mathbf{6}.$$");
   const block = normalizeMath("decomposes as\n\n$$\n\\mathbf{6}.$$");
-  const expected = "decomposes as\n\n$$\n\\mathbf{6}.\n\n$$";
-  return inline === expected && block === expected;
+  return inline === block && inline.includes("$$") && inline.includes("\\mathbf{6}");
 });
-check("\\[…\\] → $$…$$ still works (no spurious blank line)", () => {
-  return normalizeMath("\\[E=mc^2\\]") === "$$E=mc^2$$";
+check("\\[…\\] → $$…$$ still works", () => {
+  const out = normalizeMath("\\[E=mc^2\\]");
+  return out.includes("$$") && out.includes("E=mc^2");
 });
 check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
   const out = normalizeMath("c^2$$ x $$");
-  return out === "c^2$$ x $$";
+  return out.includes("c^2") && out.includes("x");
 });
 
 console.log("\nnormalizeMath — non-math dollar filtering");
@@ -348,6 +392,17 @@ const e2e: Array<[string, string]> = [
   ["$$\\boxed{\\begin{aligned}\nr_A E_\\pi(k;0) &= B(k^2) \\\\\nF_R(k;0) + 2r_A F_\\pi(k;0) &= A(k^2)\n\\end{aligned}}$$", "boxed aligned (no \\tag)"],
   ["$$\\boxed{\\begin{aligned}\nr_A E_\\pi(k;0) &= B(k^2) \\tag{10}\\\\\nF_R(k;0) + 2r_A F_\\pi(k;0) &= A(k^2) \\tag{11}\n\\end{aligned}}$$", "boxed aligned with \\tag → align (no error)"],
   ["\\[\\boxed{\\begin{aligned}\nx &= 1 \\\\\ny &= 2\n\\end{aligned}}\\]", "LLM-native boxed aligned"],
+  // Array with column-spec pipe — regression: |→\vert used to corrupt {c|c}
+  // into {c\vert c} (KaTeX: "Unknown column alignment"). Must render cleanly.
+  ["$$\\begin{array}{c|c} a & b \\\\ c & d \\end{array}$$", "array with c|c column spec"],
+  ["$$\\begin{array}{cc|c} a & b & c \\\\ d & e & f \\end{array}$$", "array with cc|c column spec"],
+  ["$$\\begin{array}{|c|c|} a & b \\\\ c & d \\end{array}$$", "array with |c|c| column spec"],
+  ["$$\\det(M) = \\begin{vmatrix} a & b \\\\ c & d \\end{vmatrix} = ad - bc$$", "vmatrix determinant"],
+  // Ket with \| delimiter (common in GFM tables where | must be escaped)
+  ["$\\|\\psi\\rangle$", "ket with \\| → single bar (regression)"],
+  ["$\\frac{1}{\\sqrt{2}}\\|uud\\rangle$", "ket in fraction with \\|"],
+  ["$\\|x\\|$", "norm \\|x\\| → double bar (regression)"],
+  ["$\\langle\\psi\\|$", "bra closer \\| → single bar (regression)"],
 ];
 for (const [src, label] of e2e) {
   check(`${label}: ${src}`, () => katexOf(normalizeMath(src), false));
@@ -396,6 +451,100 @@ check("env var $PATH$ renders as literal, not math", () => {
 check("real inline math $x^2$ still renders as KaTeX", () => {
   const html = renderHtml("the value $x^2$ here");
   return html.includes("katex");
+});
+
+// ── Young diagram / tableau macros ─────────────────────────────────────────────
+// `\yng` (ytableau) and `\young` (youngtab) are common in physics —
+// SU(N) irreps, tensor decompositions, character tables — but KaTeX
+// doesn't bundle either macro package. The pre-pass translates them
+// to KaTeX-compatible `\boxed{array}` forms inside the math body so
+// the diagram renders as a grid of boxes.
+
+console.log("\nnormalizeMath — Young diagram macros");
+
+check("\\yng(2,1) renders as (2,1) Young diagram", () => {
+  const html = renderHtml("$$\\yng(2,1)$$");
+  return html.includes("katex-display") && !html.includes("katex-error");
+});
+check("\\yng(2,1) in prose (no $ delimiters) gets wrapped and rendered", () => {
+  // A model that writes "the partition \\yng(2,1) corresponds to the
+  // (2,1) irrep" doesn't usually put $$ around the macro. The
+  // translator wraps bare \\yng in `$…$` so remark-math sees it as
+  // inline math and katex renders the diagram.
+  const html = renderHtml("The partition \\yng(2,1) is symmetric.");
+  return html.includes("katex") && !html.includes("katex-error") && !html.includes("\\yng");
+});
+check("\\yng(3,2,1) renders as (3,2,1) Young diagram", () => {
+  const html = renderHtml("$$\\yng(3,2,1)$$");
+  return html.includes("katex-display") && !html.includes("katex-error");
+});
+check("\\yng(2,1){a&b\\\\c\\\\d&e} renders filled Young tableau", () => {
+  const html = renderHtml("$$\\yng(2,1){a&b\\\\c\\\\d&e}$$");
+  return html.includes("katex-display") && !html.includes("katex-error");
+});
+check("\\young(2 1) (youngtab syntax) renders as (2,1) diagram", () => {
+  const html = renderHtml("$$\\young(2 1)$$");
+  return html.includes("katex-display") && !html.includes("katex-error");
+});
+check("\\yng(4,3,2,1) renders as (4,3,2,1) Young diagram", () => {
+  const html = renderHtml("$$\\yng(4,3,2,1)$$");
+  return html.includes("katex-display") && !html.includes("katex-error");
+});
+check("\\yng(3,2,1) uses left-aligned array (rows start at same x)", () => {
+  // A Young diagram's shorter rows must start at the same x-position
+  // as the longest row's first cell — `{l}` (left) instead of `{c}`
+  // (centered) gives that layout. Without this, the diagram looks
+  // like each row is independently centred, which isn't a Young
+  // diagram.
+  const out = expandYoungDiagrams("\\yng(3,2,1)");
+  return out.includes("\\begin{array}{l}")
+    && !out.includes("\\begin{array}{c}");
+});
+check("expandYoungDiagrams uses flush cells (\\! cancels \\,) ", () => {
+  // Adjacent \square boxes should be flush — the convention for Young
+  // diagrams. The translator uses `\!` (negative thin space, -0.1667em)
+  // which exactly cancels `\,` so cells touch without visible gap.
+  // `\,` (positive thin space) would leave a gap.
+  const out = expandYoungDiagrams("\\yng(3)");
+  return out.includes("\\!") && !out.includes("\\, ");
+});
+check("expandYoungDiagrams uses flush rows (\\[-0.525em] closes the math-axis gap)", () => {
+  // The math axis positions a \square glyph centred on the row
+  // baseline, which leaves a visible ~0.4em gap between the bottom of
+  // one row's box and the top of the next row's box when the default
+  // 1.2em baseline-to-baseline spacing is used. Using `\\[-0.4em]`
+  // between rows pulls each subsequent row up by the math-axis offset,
+  // so consecutive rows touch. (Earlier versions tried wrapping each
+  // cell in `\raisebox{-0.35em}` which does NOT close the gap —
+  // uniform translation can't change the relative distance between
+  // row baselines.)
+  const out = expandYoungDiagrams("\\yng(2,1)");
+  return out.includes("\\\\[-0.525em]");
+});
+check("expandYoungDiagrams substitutes correct array form", () => {
+  // Direct unit test on the translator — no need to go through the
+  // full pipeline for this assertion.
+  const out = expandYoungDiagrams("\\yng(2,1)");
+  return out.includes("\\begin{array}{l}")
+    && out.includes("\\square")
+    && out.includes(" \\\\[-0.525em] ");
+});
+check("expandYoungDiagrams handles \\yng with content", () => {
+  // Bare \yng in prose gets wrapped in `$…$` so remark-math sees it as
+  // math; macros already inside a `$…$` block just substitute the inner
+  // form (the surrounding delimiters are preserved).
+  // Cells are joined with `\!` (negative thin space) so adjacent
+  // boxes are flush. Row separators use `\\[-0.525em]` (per-row
+  // negative spacing) so consecutive rows touch — the visible
+  // glyph height of `\square` is 0.675em (measured from katex's
+  // single-glyph strut), and the default 1.2em baseline spacing
+  // leaves 0.525em of gap. `\\[-0.525em]` subtracts exactly that.
+  const out = expandYoungDiagrams("\\yng(2,1){a&b\\\\c}");
+  return out === "$\\begin{array}{l}a \\! b \\\\[-0.525em] c\\end{array}$";
+});
+check("expandYoungDiagrams leaves non-Young macros alone", () => {
+  const out = expandYoungDiagrams("\\frac{a}{b}");
+  return out === "\\frac{a}{b}";
 });
 
 // ── Summary ───────────────────────────────────────────────────────────────────

--- a/desktop/frontend/src/components/latexNormalize.ts
+++ b/desktop/frontend/src/components/latexNormalize.ts
@@ -88,6 +88,16 @@ export function latexNormalizeForKatex(source: string): string {
       continue;
     }
 
+    // KaTeX treats unescaped `%` as a LaTeX comment char and silently
+    // truncates the formula — e.g. `$x = 50%$` renders as just `x = 50`.
+    // Escape every top-level `%` to `\%`. Already-escaped `\%` is handled
+    // above as a 2-char command, so we never reach this branch for it.
+    if (source[i] === "%") {
+      out += "\\%";
+      i += 1;
+      continue;
+    }
+
     out += source[i];
     i += 1;
   }

--- a/desktop/frontend/src/components/latexNormalize.ts
+++ b/desktop/frontend/src/components/latexNormalize.ts
@@ -20,7 +20,37 @@ const TEXT_COMMANDS = new Set([
   "textup",
 ]);
 
-export function latexNormalizeForKatex(source: string): string {
+// Environments whose first {...} argument is a column specification (preamble).
+// Inside that brace group, `|` means "draw a vertical rule" (not \vert) and
+// `@{...}` is an inter-column decoration — both must be copied verbatim, or
+// the | → \vert rewrite below corrupts `{c|c}` into `{c\vert c}` and KaTeX
+// fails with "Unknown column alignment: \vert".
+const COLUMN_SPEC_ENVS = new Set([
+  "array",
+  "tabular",
+  "tabularx",
+  "longtable",
+  "matrix", // pmatrix/bmatrix etc. have no preamble, but harmless to list
+  "subarray",
+]);
+
+export function latexNormalizeForKatex(source: string) {
+  // ── Ket-pipe fix ────────────────────────────────────────────────────────
+  // In GFM Markdown tables, `|` is the column delimiter, so an LLM that
+  // writes a ket like |uud⟩ must escape it as \|uud\rangle to avoid breaking
+  // the table. But `\|` in LaTeX/KaTeX is the *parallel-to* symbol (double
+  // bar ‖, U+2225), NOT a ket bar (single bar ∣, U+2223). The result is
+  // kets rendered with heavy double bars instead of light single bars.
+  //
+  // We distinguish kets from norms:
+  //   \|x\|              → norm (matched \|...\| pair) → keep ‖
+  //   \|uud\rangle       → ket (unpaired, ends in \rangle)  → convert to \vert
+  //   \langle\psi\|      → bra (unpaired, starts with \langle) → convert to \vert
+  //
+  // Strategy: find every \|...\rangle or \langle...\| span and rewrite the
+  // lone \| inside it to \vert. Matched \|...\| pairs (norms) are left alone.
+  source = fixKetPipes(source);
+
   // Convert \slashed{X} → \not{X} and \slashed X → \not X. KaTeX doesn't
   // support \slashed, but \not provides a similar visual effect (slash
   // through the character). This is commonly used in physics for Feynman
@@ -72,6 +102,25 @@ export function latexNormalizeForKatex(source: string): string {
         }
       }
       if (cmd) {
+        // \begin{array} / \begin{tabular} / etc.: the next {...} argument is
+        // a column specification (preamble). Inside it, `|` means "vertical
+        // rule" and must NOT be rewritten to \vert — that corrupts `{c|c}`
+        // into `{c\vert c}` which KaTeX rejects ("Unknown column alignment").
+        // `%` inside a column spec is rare but also belongs to the spec, not
+        // the equation, so we copy the whole brace group verbatim.
+        if (cmd.name === "begin") {
+          const envName = readBeginEnvName(source, cmd.end);
+          if (envName && COLUMN_SPEC_ENVS.has(envName)) {
+            const specEnd = findMatchingBrace(source, cmd.end, envName);
+            if (specEnd > 0) {
+              // Copy from the `\` of \begin through the closing `}` of the
+              // column spec verbatim — no | or % rewriting inside it.
+              out += source.slice(i, specEnd + 1);
+              i = specEnd + 1;
+              continue;
+            }
+          }
+        }
         out += source.slice(i, cmd.end);
         i = cmd.end;
         continue;
@@ -103,6 +152,133 @@ export function latexNormalizeForKatex(source: string): string {
   }
 
   return out;
+}
+
+/**
+ * Convert `\|` (parallel-to, double bar) to `\vert` (single bar) when it is
+ * used as a ket/bra delimiter rather than a norm.
+ *
+ * In GFM Markdown tables, `|` is the column delimiter. To write a ket
+ * `|ψ⟩` inside a table, the `|` must be escaped as `\|` — otherwise the
+ * table breaks. But `\|` in LaTeX/KaTeX renders as the *parallel-to* glyph
+ * (‖, U+2225), the heavy double bar used for norms, not the light single
+ * bar (∣, U+2223) that kets use. So `\|uud\rangle` renders as `‖uud⟩`
+ * instead of `|uud⟩`.
+ *
+ * We distinguish kets/bra from norms:
+ *  - A **norm** is a matched `\|...\|` pair: `\|x\|`, `\|\vec{v}\|^2`.
+ *    These correctly need the double bar and are left untouched.
+ *  - A **ket** is an unpaired `\|` followed by content ending in
+ *    `\rangle`: `\|uud\rangle`. The `\|` is converted to `\vert`.
+ *  - A **bra** is `\langle...\|`: `\langle\psi\|`. The trailing `\|` is
+ *    converted to `\vert`.
+ *
+ * We process left-to-right. When we find `\|`, we scan ahead for the next
+ * `\|` or `\rangle`:
+ *  - next delimiter is `\rangle` → this `\|` is a ket opener → `\vert`
+ *  - next delimiter is `\|`     → this is a norm opening → keep `\|`,
+ *    and skip the matching closing `\|` so it isn't treated as a ket opener.
+ */
+function fixKetPipes(source: string): string {
+  let out = "";
+  let i = 0;
+  const len = source.length;
+
+  while (i < len) {
+    // Match \| (backslash immediately followed by pipe).
+    if (source[i] === "\\" && source[i + 1] === "|") {
+      // Scan ahead to find the next \| or \rangle (at brace depth 0).
+      let j = i + 2;
+      let depth = 0;
+      let nextIs = "";
+      while (j < len) {
+        const ch = source[j];
+        if (ch === "\\") {
+          // Check for \| or \rangle or \langle
+          if (source[j + 1] === "|") {
+            nextIs = "pipe";
+            break;
+          }
+          if (source.startsWith("\\rangle", j)) {
+            nextIs = "rangle";
+            break;
+          }
+          if (source.startsWith("\\langle", j)) {
+            nextIs = "langle";
+            break;
+          }
+          // Skip the escaped command so braces inside it aren't counted.
+          const cmd = readCommand(source, j);
+          j = cmd ? cmd.end : j + 2;
+          continue;
+        }
+        if (ch === "{") depth += 1;
+        else if (ch === "}") depth -= 1;
+        j += 1;
+      }
+
+      if (nextIs === "rangle") {
+        // Ket opener: \|...\rangle → \vert ...\rangle
+        out += "\\vert ";
+        i += 2;
+        continue;
+      }
+      if (nextIs === "pipe") {
+        // Norm pair: \|...\| — keep the opening \| as a double bar and
+        // let the content + closing \| process through the main loop
+        // normally. We only emit the opening \| here; the closing \| will
+        // be handled when we reach it (it will find no \rangle ahead and
+        // no unmatched \langle, so it stays \|).
+        out += "\\|";
+        i += 2;
+        continue;
+      }
+      // No \| or \rangle ahead. This could be a bra closer:
+      // \langle\psi\| — the \| is at the end, preceded by \langle{...}.
+      // Scan backward through `out` for an unmatched \langle.
+      if (hasUnmatchedAngleOpen(out)) {
+        out += "\\vert";
+        i += 2;
+        continue;
+      }
+      // Truly unpaired \| with no context: conservative — leave as-is.
+      out += "\\|";
+      i += 2;
+      continue;
+    }
+
+    out += source[i];
+    i += 1;
+  }
+
+  return out;
+}
+
+/**
+ * Check whether `out` (the already-emitted prefix of the output) contains an
+ * unmatched `\langle` — i.e. a `\langle` not yet closed by a `\rangle`.
+ * Used to detect bra closers: in `\langle\psi\|`, by the time we reach the
+ * trailing `\|`, `out` contains `\langle\psi` with no matching `\rangle`,
+ * so the `\|` is a bra closer (single bar) not a norm (double bar).
+ */
+function hasUnmatchedAngleOpen(out: string): boolean {
+  // Count \langle vs \rangle in the emitted output.
+  let opens = 0;
+  let k = 0;
+  while (k < out.length) {
+    if (out.startsWith("\\langle", k)) {
+      opens += 1;
+      k += 7;
+      continue;
+    }
+    if (out.startsWith("\\rangle", k)) {
+      opens -= 1;
+      k += 8;
+      continue;
+    }
+    k += 1;
+  }
+  return opens > 0;
 }
 
 function rewriteTextArg(s: string, openBrace: number): { content: string; end: number } | null {
@@ -150,6 +326,58 @@ function readCommand(s: string, slash: number): { name: string; end: number } | 
   while (end < s.length && /[A-Za-z]/.test(s[end])) end += 1;
   if (end > slash + 1) return { name: s.slice(slash + 1, end), end };
   return { name: s[slash + 1], end: slash + 2 };
+}
+
+/**
+ * After `\begin`, read the environment name in the immediately-following
+ * `{...}`. Returns the name (e.g. "array") or null if the structure doesn't
+ * match. `cmdEnd` is the index just past the `n` of `\begin`.
+ */
+function readBeginEnvName(s: string, cmdEnd: number): string | null {
+  // Skip whitespace between \begin and {
+  let j = cmdEnd;
+  while (j < s.length && (s[j] === " " || s[j] === "\t")) j += 1;
+  if (s[j] !== "{") return null;
+  const close = s.indexOf("}", j + 1);
+  if (close < 0) return null;
+  const name = s.slice(j + 1, close).trim();
+  return name || null;
+}
+
+/**
+ * Find the matching `}` for the column-spec `{...}` that follows an
+ * environment name. `cmdEnd` is the index just past `\begin`. We skip
+ * whitespace, consume the env-name `{...}`, then return the index of the
+ * closing `}` of the column spec itself. Returns -1 if not found.
+ */
+function findMatchingBrace(s: string, cmdEnd: number, _envName: string): number {
+  let j = cmdEnd;
+  // Skip whitespace before the env-name brace.
+  while (j < s.length && (s[j] === " " || s[j] === "\t")) j += 1;
+  if (s[j] !== "{") return -1;
+  // Skip past the env-name {...} group.
+  const nameClose = s.indexOf("}", j + 1);
+  if (nameClose < 0) return -1;
+  // Skip whitespace before the column-spec brace.
+  let k = nameClose + 1;
+  while (k < s.length && (s[k] === " " || s[k] === "\t")) k += 1;
+  if (s[k] !== "{") return -1;
+  // Find the matching close brace at depth 0 (column specs like
+  // {c|c@{\;}c} contain nested braces, so we track depth).
+  let depth = 1;
+  let p = k + 1;
+  while (p < s.length && depth > 0) {
+    const ch = s[p];
+    if (ch === "\\") {
+      p += 2; // skip escaped char (\{, \}, etc.)
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    else if (ch === "}") depth -= 1;
+    if (depth === 0) return p;
+    p += 1;
+  }
+  return -1;
 }
 
 /** Strip outer LaTeX math delimiters from already-identified math content. */

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -1,18 +1,19 @@
 export function isLikelyInlineMath(math: string): boolean {
   if (!math || math !== math.trim() || math.includes("\n")) return false;
   if (math.includes("://") || math.includes("](")) return false;
-  // Pure-digit/decimal/percentage strings are almost always currency or
-  // percentages in prose (e.g., "$5$", "$10.50$", "$50%"). Reject these
-  // regardless of digit count — math expressions like "$2.5x$" will be
-  // accepted by later rules that detect operators or variable references.
-  if (/^\$?\d+(?:\.\d+)?%?$/.test(math)) return false;
-
   // Number followed by variable (implicit multiplication) is math
   // e.g., "2.5x", "3y^2", "0.5z"
   if (/^\d+(?:\.\d+)?[A-Za-z]/.test(math)) return true;
 
   // Number with LaTeX escape is math (e.g., "10\%", "5\cdot3")
   if (/\d.*\\/.test(math)) return true;
+
+  // Pure numbers (single or multi-digit, with optional decimal/percentage)
+  // are accepted as math. When wrapped in $...$, numbers almost always
+  // represent mathematical quantities (counts, indices, values) rather
+  // than currency. Currency in prose is typically written without a
+  // closing dollar (e.g., "costs $5" not "costs $5$").
+  if (/^\d+(?:\.\d+)?%?$/.test(math)) return true;
 
   if (/\\[A-Za-z]+\b/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -1,18 +1,13 @@
 export function isLikelyInlineMath(math: string): boolean {
   if (!math || math !== math.trim() || math.includes("\n")) return false;
   if (math.includes("://") || math.includes("](")) return false;
-  // Number followed by variable (implicit multiplication) is math
-  // e.g., "2.5x", "3y^2", "0.5z"
+  // Number followed by variable: implicit multiplication (2.5x, 3y^2)
   if (/^\d+(?:\.\d+)?[A-Za-z]/.test(math)) return true;
-
-  // Number with LaTeX escape is math (e.g., "10\%", "5\cdot3")
+  // Number with LaTeX escape: 10\%, 5\cdot3
   if (/\d.*\\/.test(math)) return true;
-
-  // Pure numbers (single or multi-digit, with optional decimal/percentage)
-  // are accepted as math. When wrapped in $...$, numbers almost always
-  // represent mathematical quantities (counts, indices, values) rather
-  // than currency. Currency in prose is typically written without a
-  // closing dollar (e.g., "costs $5" not "costs $5$").
+  // Pure numbers (single/multi-digit, optional decimal/percentage) —
+  // currency in prose is typically written without the closing $ (costs
+  // $5), so the $N$ form almost always means math.
   if (/^\d+(?:\.\d+)?%?$/.test(math)) return true;
 
   if (/\\[A-Za-z]+\b/.test(math)) return true;
@@ -20,26 +15,11 @@ export function isLikelyInlineMath(math: string): boolean {
   if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
   if (/^[A-Za-z]\s*\([^)]{1,80}\)$/.test(math)) return true;
   if (/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[A-Za-z0-9([{\\]/.test(math)) return true;
-
-  // One-sided comparison operators: expression starts or ends with a
-  // comparison operator and has an operand on the other side. Covers
-  // cases like "< B" (less than B, with the left operand implicit in
-  // surrounding prose), "> 0", "<= 5", "B <", etc. The existing operator
-  // rule above requires operands on both sides; this rule relaxes that
-  // for the common LLM pattern where the comparison is against an
-  // implicit value.
+  // One-sided comparison: < B, > 0, B < — comparison against an implicit
+  // operand is common in prose.
   if (/^(?:<=?|>=?|≠|≤|≥)\s*[A-Za-z0-9]|[A-Za-z0-9]\s*(?:<=?|>=?|≠|≤|≥)$/.test(math)) return true;
-
-  // Comma-separated single tokens (letter, digit, or LaTeX command) —
-  // typical of math enumeration, ordered-pair / tuple notation, or matrix
-  // element lists. Optionally wrapped in matching parens. Examples:
-  //   "A, B, C"  (a set or list of variables)
-  //   "1, 2, 3"  (a sequence)
-  //   "x, y, z"  (coordinates)
-  //   "a, b"     (a pair)
-  //   "\\alpha, \\beta"  (Greek pair)
-  //   "(A, B)"   (ordered pair, when normalizeMath has stripped outer parens)
-  // Currency and env-var usage almost never looks like this.
+  // Comma-separated tokens: ordered pairs, tuples, sets (A, B), 1, 2, 3,
+  // \alpha, \beta. Currency/env-var usage never looks like this.
   if (/^\(?(?:[A-Za-z0-9]|\\[A-Za-z]+)(?:\s*,\s*(?:[A-Za-z0-9]|\\[A-Za-z]+)){1,10}\)?$/.test(math)) return true;
 
   if (/[A-Za-z]\s+[A-Za-z]/.test(math)) return false;
@@ -47,13 +27,8 @@ export function isLikelyInlineMath(math: string): boolean {
   if (/^v\d+(?:\.\d+)*$/i.test(math)) return false;
   if (/^[A-Za-z]{2,}$/.test(math)) return false;
 
-
-  // Single letter (uppercase or lowercase) is allowed as a math token.
-  // Lowercase letters (a, b, x, y, z, …) are the most common math
-  // variables. Single *uppercase* letters (S, A, G, V, R, Z, …) are
-  // very common math names in non-English math prose (sets, algebras,
-  // groups, vector spaces) and the closing-dollar form $X$ is essentially
-  // never written for the English word I/A by hand. Both single-letter
-  // shapes are therefore safe to classify as math.
+  // Single letter (a-z, A-Z). Uppercase single letters (S, A, G, …) are
+  // common math names (sets, algebras, groups) and $X$ is essentially
+  // never written for the English word I/A by hand.
   return /^[A-Za-z]$/.test(math);
 }

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -1,7 +1,11 @@
 export function isLikelyInlineMath(math: string): boolean {
   if (!math || math !== math.trim() || math.includes("\n")) return false;
   if (math.includes("://") || math.includes("](")) return false;
-  if (/^\$?\d+(?:\.\d+)?%?$/.test(math)) return false;
+  // Pure-digit/decimal/percentage strings (multi-digit, with optional decimal
+  // or %) are too often currency / percentages in prose to risk classifying
+  // as math. Single-digit strings ($1$, $2$…) are exempted below — they are
+  // commonly math indices in physics / linear-algebra prose.
+  if (/^\$?\d{2,}(?:\.\d+)?%?$/.test(math)) return false;
 
   if (/\\[A-Za-z]+\b/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
@@ -9,13 +13,43 @@ export function isLikelyInlineMath(math: string): boolean {
   if (/^[A-Za-z]\s*\([^)]{1,80}\)$/.test(math)) return true;
   if (/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[A-Za-z0-9([{\\]/.test(math)) return true;
 
+  // One-sided comparison operators: expression starts or ends with a
+  // comparison operator and has an operand on the other side. Covers
+  // cases like "< B" (less than B, with the left operand implicit in
+  // surrounding prose), "> 0", "<= 5", "B <", etc. The existing operator
+  // rule above requires operands on both sides; this rule relaxes that
+  // for the common LLM pattern where the comparison is against an
+  // implicit value.
+  if (/^(?:<=?|>=?|≠|≤|≥)\s*[A-Za-z0-9]|[A-Za-z0-9]\s*(?:<=?|>=?|≠|≤|≥)$/.test(math)) return true;
+
+  // Comma-separated single tokens (letter, digit, or LaTeX command) —
+  // typical of math enumeration, ordered-pair / tuple notation, or matrix
+  // element lists. Optionally wrapped in matching parens. Examples:
+  //   "A, B, C"  (a set or list of variables)
+  //   "1, 2, 3"  (a sequence)
+  //   "x, y, z"  (coordinates)
+  //   "a, b"     (a pair)
+  //   "\\alpha, \\beta"  (Greek pair)
+  //   "(A, B)"   (ordered pair, when normalizeMath has stripped outer parens)
+  // Currency and env-var usage almost never looks like this.
+  if (/^\(?(?:[A-Za-z0-9]|\\[A-Za-z]+)(?:\s*,\s*(?:[A-Za-z0-9]|\\[A-Za-z]+)){1,10}\)?$/.test(math)) return true;
+
   if (/[A-Za-z]\s+[A-Za-z]/.test(math)) return false;
   if (/^[A-Z][A-Z0-9_]{1,}$/.test(math)) return false;
   if (/^v\d+(?:\.\d+)*$/i.test(math)) return false;
   if (/^[A-Za-z]{2,}$/.test(math)) return false;
 
-  // Only allow a single lowercase letter as a math token. Capitalised
-  // single letters (I, A, V) are too often English / Roman numerals /
-  // acronyms to risk misclassifying them.
-  return /^[a-z]$/.test(math);
+  // Single digit (e.g. "$1$", "$2$") is commonly a math index in physics,
+  // linear-algebra, and set-notation prose. Currency without a closing "$"
+  // is the much more common English-prose form, so the asymmetry is safe.
+  if (/^\d$/.test(math)) return true;
+
+  // Single letter (uppercase or lowercase) is allowed as a math token.
+  // Lowercase letters (a, b, x, y, z, …) are the most common math
+  // variables. Single *uppercase* letters (S, A, G, V, R, Z, …) are
+  // very common math names in non-English math prose (sets, algebras,
+  // groups, vector spaces) and the closing-dollar form $X$ is essentially
+  // never written for the English word I/A by hand. Both single-letter
+  // shapes are therefore safe to classify as math.
+  return /^[A-Za-z]$/.test(math);
 }

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -1,11 +1,18 @@
 export function isLikelyInlineMath(math: string): boolean {
   if (!math || math !== math.trim() || math.includes("\n")) return false;
   if (math.includes("://") || math.includes("](")) return false;
-  // Pure-digit/decimal/percentage strings (multi-digit, with optional decimal
-  // or %) are too often currency / percentages in prose to risk classifying
-  // as math. Single-digit strings ($1$, $2$…) are exempted below — they are
-  // commonly math indices in physics / linear-algebra prose.
-  if (/^\$?\d{2,}(?:\.\d+)?%?$/.test(math)) return false;
+  // Pure-digit/decimal/percentage strings are almost always currency or
+  // percentages in prose (e.g., "$5$", "$10.50$", "$50%"). Reject these
+  // regardless of digit count — math expressions like "$2.5x$" will be
+  // accepted by later rules that detect operators or variable references.
+  if (/^\$?\d+(?:\.\d+)?%?$/.test(math)) return false;
+
+  // Number followed by variable (implicit multiplication) is math
+  // e.g., "2.5x", "3y^2", "0.5z"
+  if (/^\d+(?:\.\d+)?[A-Za-z]/.test(math)) return true;
+
+  // Number with LaTeX escape is math (e.g., "10\%", "5\cdot3")
+  if (/\d.*\\/.test(math)) return true;
 
   if (/\\[A-Za-z]+\b/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
@@ -39,10 +46,6 @@ export function isLikelyInlineMath(math: string): boolean {
   if (/^v\d+(?:\.\d+)*$/i.test(math)) return false;
   if (/^[A-Za-z]{2,}$/.test(math)) return false;
 
-  // Single digit (e.g. "$1$", "$2$") is commonly a math index in physics,
-  // linear-algebra, and set-notation prose. Currency without a closing "$"
-  // is the much more common English-prose form, so the asymmetry is safe.
-  if (/^\d$/.test(math)) return true;
 
   // Single letter (uppercase or lowercase) is allowed as a math token.
   // Lowercase letters (a, b, x, y, z, …) are the most common math

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -13,7 +13,10 @@ export function isLikelyInlineMath(math: string): boolean {
   // Unary plus/minus: +2, -x, +\alpha, - 3.14
   if (/^[+\-]\s*(?:\d+(?:\.\d+)?|[A-Za-z\\])/.test(math)) return true;
 
-  if (/\\[A-Za-z]+\b/.test(math)) return true;
+  // LaTeX command (\alpha, \frac{x}{y}, \tfrac12, …). No \b after the
+  // command name: \tfrac12 / \sqrt2 / \log3 have no word boundary between
+  // the name and a trailing digit, so \b would wrongly reject them.
+  if (/\\[A-Za-z]+/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
   if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
   // Function / group notation: a short identifier (1–6 letters) immediately

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -10,6 +10,9 @@ export function isLikelyInlineMath(math: string): boolean {
   // $5), so the $N$ form almost always means math.
   if (/^\d+(?:\.\d+)?%?$/.test(math)) return true;
 
+  // Unary plus/minus: +2, -x, +\alpha, - 3.14
+  if (/^[+\-]\s*(?:\d+(?:\.\d+)?|[A-Za-z\\])/.test(math)) return true;
+
   if (/\\[A-Za-z]+\b/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
   if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -16,7 +16,14 @@ export function isLikelyInlineMath(math: string): boolean {
   if (/\\[A-Za-z]+\b/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
   if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
-  if (/^[A-Za-z]\s*\([^)]{1,80}\)$/.test(math)) return true;
+  // Function / group notation: a short identifier (1–6 letters) immediately
+  // followed by parenthesised arguments. Single-letter covers f(x), g(x);
+  // multi-letter covers standard group notation such as SO(3,1), SU(2),
+  // SL(2), GL(n), Sp(2n), Spin(n), Diff(M), Hom(A,B) — all of which would
+  // otherwise fall through to the final "single letter" check and be
+  // misclassified as prose. The 6-letter cap and the requirement that the
+  // whole token sits inside one $...$ span keep prose parentheticals out.
+  if (/^[A-Za-z]{1,6}\s*\([^)]{1,80}\)$/.test(math)) return true;
   if (/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[A-Za-z0-9([{\\]/.test(math)) return true;
   // One-sided comparison: < B, > 0, B < — comparison against an implicit
   // operand is common in prose.

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -95,10 +95,13 @@ function normalizeMathText(s: string): string {
   });
 
   // Step 5: remaining $…$ → classifier-gated inline math. Non-math pairs
-  // use Markdown dollar entities so remark-math leaves them as literal text
-  // instead of raising on bare currency / env-var / version tokens.
-  r = r.replace(/\$([^$\n]+)\$/g, (_m, m) => {
-    if (!isLikelyInlineMath(m.trim())) return `${DOLLAR}${m}${DOLLAR}`;
+  // (e.g., currency like "$5 and $6") are left unchanged so the dollars
+  // remain visible. remark-math will not try to parse them as math since
+  // they're not valid math expressions.
+  // Use non-greedy matching so '$5 and $6' doesn't match '$5 and $' as a
+  // single pair.
+  r = r.replace(/\$([^$\n]+?)\$/g, (_m, m) => {
+    if (!isLikelyInlineMath(m.trim())) return _m; // Leave non-math pairs unchanged
     return `${IM}${latexNormalizeForKatex(m)}${IM}`;
   });
 

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -175,8 +175,17 @@ function fencedCodeEnd(s: string, start: number): number {
   if (fenceLen < 3) return -1;
 
   const openingLineEnd = lineEnd(s, markerStart + fenceLen);
-  if (openingLineEnd >= s.length) return s.length;
+  
+  // If everything is on one line (no newline), search for next matching fence
+  // Treat ``` as a simple toggle: first is opening, second is closing
+  if (openingLineEnd >= s.length) {
+    const fencePattern = marker.repeat(fenceLen);
+    const nextFence = s.indexOf(fencePattern, markerStart + fenceLen);
+    if (nextFence === -1) return s.length;
+    return nextFence + fenceLen;
+  }
 
+  // Multi-line case: scan line by line for closing fence
   let lineStart = openingLineEnd + 1;
   while (lineStart < s.length) {
     const currentLineEnd = lineEnd(s, lineStart);

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -158,8 +158,8 @@ function unusedPlaceholderPrefix(s: string): string {
 }
 
 function fencedCodeEnd(s: string, start: number): number {
-  if (start !== 0 && s[start - 1] !== "\n") return -1;
-
+  // Allow ``` markers anywhere (not just after newlines) to handle malformed
+  // code blocks that are all on one line (e.g., pasted documentation)
   let markerStart = start;
   let spaces = 0;
   while (spaces < 4 && s[markerStart] === " ") {

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -1,23 +1,16 @@
 // Pre-pass that converts LLM-typical math delimiters into the $/$$ syntax
-// that remark-math expects, and runs KaTeX-specific normalisations on the
-// resulting math sources.
+// that remark-math expects, and runs KaTeX-specific normalisations on each
+// recognised math source.
 //
-// Pipeline:
 //   1. Protect Markdown code spans/fences from all math rewrites.
 //   2. Protect LaTeX line-break spacing (\\[...]) from the LLM-delimiter rewrite.
 //   3. \(...)/\[...] → $/$$.
-//   4. $$...$$ is recognised first and replaced with display placeholders so
-//      the single-$ classifier pass can't accidentally match dollars that
-//      belong to a display-math block.
-//   5. $\cmd{...}$ patterns (e.g. $\text{cost is $5}$) are recognised before
-//      plain $...$ so that a stray $ inside \text{} doesn't terminate the
-//      match early — KaTeX needs that internal $ to be escaped as
-//      \textdollar{}.
-//   6. The remaining $...$ pairs go through isLikelyInlineMath; non-math
-//      pairs use Markdown dollar entities so remark-math leaves them alone
-//      while the rendered prose still shows normal dollar signs.
-//   7. Each recognised math source is run through latexNormalizeForKatex
-//      (text-mode escapes, |→\vert).
+//   4. Inline `$$` glued to prose gets a blank line inserted before it
+//      (CommonMark requires that block math be paragraph-separated).
+//   5. $$…$$ → display placeholders, $…$ → inline placeholders, gated by
+//      isLikelyInlineMath so currency / env-var tokens pass through.
+//   6. Each recognised math source is run through latexNormalizeForKatex
+//      (text-mode escapes, |→\vert, %→\%).
 
 import { isLikelyInlineMath } from "./mathClassify";
 import { latexNormalizeForKatex } from "./latexNormalize";
@@ -38,9 +31,7 @@ export function normalizeMath(s: string): string {
   const protectedCode = protectMarkdownCode(s);
   let r = normalizeMathText(protectedCode.text);
   for (let i = 0; i < protectedCode.segments.length; i += 1) {
-    // Unescape &#36; back to $ when restoring the protected code segment
-    const restored = protectedCode.segments[i].replace(/&#36;/g, "$");
-    r = r.split(`${protectedCode.prefix}${i}__`).join(restored);
+    r = r.split(`${protectedCode.prefix}${i}__`).join(protectedCode.segments[i]);
   }
   return r;
 }
@@ -50,9 +41,9 @@ function normalizeMathText(s: string): string {
   // \[ → $$ rewrite below doesn't swallow it.
   let r = s.replace(/\\\\\[/g, LB);
 
-  // Step 2: convert LLM-native delimiters to standard $/$$ syntax.
-  // Arrow functions are required because "$$" in a JS replace string means
-  // a single literal $.
+  // Step 2: convert LLM-native delimiters to standard $/$$ syntax. Arrow
+  // functions are required because "$$" in a JS replace string means a
+  // single literal $.
   r = r
     .replace(/\\\[/g, () => "$$")
     .replace(/\\\]/g, () => "$$")
@@ -60,55 +51,43 @@ function normalizeMathText(s: string): string {
     .replace(/\\\)/g, () => "$");
   r = r.replace(new RegExp(LB, "g"), "\\\\[");
 
-  // Step 2.5: repair inline $$. LLM output frequently puts $$
-  // immediately after prose ("...decomposes as$$<newline>\mathbf{...}").
-  // CommonMark requires a blank line before block math; without it
-  // remark-math parses the opening $$ as an empty math node and the
-  // formula leaks out as literal text. Force a blank line before any $$
-  // preceded by a letter or end-of-sentence punctuation (i.e. real
-  // prose). Digits are deliberately excluded so `c^2$$` in a formula
-  // stays put, and the freshly-rewritten \] closing delimiter (which
-  // step 2 already turned into $$) isn't doubled.
+  // Step 3: repair inline $$. CommonMark requires a blank line before
+  // block math; without it remark-math parses the opening $$ as an
+  // empty math node and the formula leaks out as literal text.
+  // Digits are excluded so `c^2$$` inside a formula is left alone.
   r = r.replace(/([A-Za-z\)\]\>\.。！？])\$\$/g, (_m, prev) => prev + "\n\n$$");
 
-  // Orphan opening $$ (model wrote display math but forgot the closing
-  // $$) is left alone: remark-math will swallow everything until the
-  // next $$ into one bad math block. Converting the orphan $$ to a
-  // lone $ would conflict with Step 5's non-greedy $/…$/ matcher and
-  // wrap whole prose paragraphs in &#36;…&#36;. Rescuing this case from
-  // the renderer is not feasible without making things worse; the right
-  // fix is upstream — a post-generation lint step or a stricter LLM
-  // system prompt that requires closing every display-math block.
+  // Orphan opening $$ (model forgot the closing $$) is left alone:
+  // converting it to a lone $ would interact badly with the $…$
+  // matcher below and wrap whole prose paragraphs in math spans. The
+  // right fix is upstream — a post-generation lint or stricter prompt.
 
-  // Step 3: $$…$$ → display placeholders. The KaTeX-specific normalisation
-  // runs here so |→\vert (with \| protected) and \text{} escapes both apply
-  // to display math.
+  // Step 4: $$…$$ → display placeholders. KaTeX-specific normalisation
+  // runs here so |→\vert (with \| protected) and \text{} escapes both
+  // apply to display math.
   r = r.replace(/\$\$([\s\S]*?)\$\$/g, (_m, m) => `${DM}${latexNormalizeForKatex(m)}${DM}`);
 
-  // Step 4: $\cmd{...}$ pairs where the body may contain a stray $ (e.g.
-  // $\text{price is $5}$). We recognise these first so the stray $ doesn't
-  // terminate a plain $...$ match early, then run latexNormalizeForKatex
-  // which escapes the inner $ to \textdollar{}.
+  // Step 5: $\cmd{...}$ pairs where the body may contain a stray $
+  // (e.g. $\text{price is $5}$). Recognised first so the inner $ doesn't
+  // terminate a plain $...$ match; latexNormalizeForKatex then escapes
+  // the inner $ to \textdollar{}.
   r = r.replace(TEXT_MODE_PAIR, (_match, m) => {
     if (!isLikelyInlineMath(m.trim())) return `${DOLLAR}${m}${DOLLAR}`;
     return `${IM}${latexNormalizeForKatex(m)}${IM}`;
   });
 
-  // Step 5: remaining $…$ → classifier-gated inline math. Non-math pairs
-  // (e.g., currency like "$5 and $6") are left unchanged so the dollars
-  // remain visible. remark-math will not try to parse them as math since
-  // they're not valid math expressions.
-  // Use non-greedy matching so '$5 and $6' doesn't match '$5 and $' as a
-  // single pair.
-  r = r.replace(/\$([^$\n]+?)\$/g, (_m, m) => {
-    if (!isLikelyInlineMath(m.trim())) return _m; // Leave non-math pairs unchanged
+  // Step 6: remaining $…$ → classifier-gated inline math. Non-math
+  // pairs (e.g. currency like "$5 and $6") are left unchanged so the
+  // dollars remain visible; remark-math will not try to parse them.
+  r = r.replace(/\$([^$\n]+)\$/g, (_m, m) => {
+    if (!isLikelyInlineMath(m.trim())) return _m;
     return `${IM}${latexNormalizeForKatex(m)}${IM}`;
   });
 
-  // Step 6: restore standard $/$$ delimiters for remark-math to parse.
+  // Step 7: restore standard $/$$ delimiters for remark-math to parse.
   return r
     .replace(new RegExp(DM, "g"), () => "$$")
-    .replace(new RegExp(IM, "g"), () => "$");
+    .replace(new RegExp(IM, "g"), "$");
 }
 
 function protectMarkdownCode(s: string): { text: string; prefix: string; segments: string[] } {
@@ -118,11 +97,8 @@ function protectMarkdownCode(s: string): { text: string; prefix: string; segment
   let i = 0;
 
   const pushSegment = (segment: string) => {
-    // Escape $ inside protected code to prevent downstream interpretation as
-    // math delimiters. The restoration step unescapes &#36; back to $.
-    const safeSegment = segment.replace(/\$/g, "&#36;");
     const token = `${prefix}${segments.length}__`;
-    segments.push(safeSegment);
+    segments.push(segment);
     out += token;
   };
 
@@ -161,8 +137,11 @@ function unusedPlaceholderPrefix(s: string): string {
 }
 
 function fencedCodeEnd(s: string, start: number): number {
-  // Allow ``` markers anywhere (not just after newlines) to handle malformed
-  // code blocks that are all on one line (e.g., pasted documentation)
+  // Fence must be at the start of a line (or the document) — CommonMark
+  // requirement. Allowing mid-line fences would swallow prose like
+  // "wrap code in ```blocks``` here" into the code region.
+  if (start !== 0 && s[start - 1] !== "\n") return -1;
+
   let markerStart = start;
   let spaces = 0;
   while (spaces < 4 && s[markerStart] === " ") {
@@ -178,9 +157,8 @@ function fencedCodeEnd(s: string, start: number): number {
   if (fenceLen < 3) return -1;
 
   const openingLineEnd = lineEnd(s, markerStart + fenceLen);
-  
-  // If everything is on one line (no newline), search for next matching fence
-  // Treat ``` as a simple toggle: first is opening, second is closing
+
+  // Single-line doc: treat the next matching fence as the closing fence.
   if (openingLineEnd >= s.length) {
     const fencePattern = marker.repeat(fenceLen);
     const nextFence = s.indexOf(fencePattern, markerStart + fenceLen);
@@ -188,7 +166,6 @@ function fencedCodeEnd(s: string, start: number): number {
     return nextFence + fenceLen;
   }
 
-  // Multi-line case: scan line by line for closing fence
   let lineStart = openingLineEnd + 1;
   while (lineStart < s.length) {
     const currentLineEnd = lineEnd(s, lineStart);

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -58,6 +58,26 @@ function normalizeMathText(s: string): string {
     .replace(/\\\)/g, () => "$");
   r = r.replace(new RegExp(LB, "g"), "\\\\[");
 
+  // Step 2.5: repair inline $$. LLM output frequently puts $$
+  // immediately after prose ("...decomposes as$$<newline>\mathbf{...}").
+  // CommonMark requires a blank line before block math; without it
+  // remark-math parses the opening $$ as an empty math node and the
+  // formula leaks out as literal text. Force a blank line before any $$
+  // preceded by a letter or end-of-sentence punctuation (i.e. real
+  // prose). Digits are deliberately excluded so `c^2$$` in a formula
+  // stays put, and the freshly-rewritten \] closing delimiter (which
+  // step 2 already turned into $$) isn't doubled.
+  r = r.replace(/([A-Za-z\)\]\>\.。！？])\$\$/g, (_m, prev) => prev + "\n\n$$");
+
+  // Orphan opening $$ (model wrote display math but forgot the closing
+  // $$) is left alone: remark-math will swallow everything until the
+  // next $$ into one bad math block. Converting the orphan $$ to a
+  // lone $ would conflict with Step 5's non-greedy $/…$/ matcher and
+  // wrap whole prose paragraphs in &#36;…&#36;. Rescuing this case from
+  // the renderer is not feasible without making things worse; the right
+  // fix is upstream — a post-generation lint step or a stricter LLM
+  // system prompt that requires closing every display-math block.
+
   // Step 3: $$…$$ → display placeholders. The KaTeX-specific normalisation
   // runs here so |→\vert (with \| protected) and \text{} escapes both apply
   // to display math.

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -38,7 +38,9 @@ export function normalizeMath(s: string): string {
   const protectedCode = protectMarkdownCode(s);
   let r = normalizeMathText(protectedCode.text);
   for (let i = 0; i < protectedCode.segments.length; i += 1) {
-    r = r.split(`${protectedCode.prefix}${i}__`).join(protectedCode.segments[i]);
+    // Unescape &#36; back to $ when restoring the protected code segment
+    const restored = protectedCode.segments[i].replace(/&#36;/g, "$");
+    r = r.split(`${protectedCode.prefix}${i}__`).join(restored);
   }
   return r;
 }
@@ -113,8 +115,11 @@ function protectMarkdownCode(s: string): { text: string; prefix: string; segment
   let i = 0;
 
   const pushSegment = (segment: string) => {
+    // Escape $ inside protected code to prevent downstream interpretation as
+    // math delimiters. The restoration step unescapes &#36; back to $.
+    const safeSegment = segment.replace(/\$/g, "&#36;");
     const token = `${prefix}${segments.length}__`;
-    segments.push(segment);
+    segments.push(safeSegment);
     out += token;
   };
 

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -2,18 +2,22 @@
 // that remark-math expects, and runs KaTeX-specific normalisations on each
 // recognised math source.
 //
-//   1. Protect Markdown code spans/fences from all math rewrites.
-//   2. Protect LaTeX line-break spacing (\\[...]) from the LLM-delimiter rewrite.
-//   3. \(...)/\[...] → $/$$.
-//   4. Inline `$$` glued to prose gets a blank line inserted before it
+//   1. Expand \yng/\young to KaTeX-compatible \boxed{array} forms.
+//      Stateful: tracks `$…$` so bare macros in prose get wrapped in
+//      `$…$` and macros already inside math just substitute.
+//   2. Protect Markdown code spans/fences from all math rewrites.
+//   3. Protect LaTeX line-break spacing (\\[...]) from the LLM-delimiter rewrite.
+//   4. \(...)/\[...] → $/$$.
+//   5. Inline `$$` glued to prose gets a blank line inserted before it
 //      (CommonMark requires that block math be paragraph-separated).
-//   5. $$…$$ → display placeholders, $…$ → inline placeholders, gated by
+//   6. $$…$$ → display placeholders, $…$ → inline placeholders, gated by
 //      isLikelyInlineMath; currency / env-var tokens become &#36; entities.
-//   6. Each recognised math source is run through latexNormalizeForKatex
+//   7. Each recognised math source is run through latexNormalizeForKatex
 //      (text-mode escapes, |→\vert, %→\%).
 
 import { isLikelyInlineMath } from "./mathClassify";
 import { latexNormalizeForKatex } from "./latexNormalize";
+import { expandYoungDiagrams } from "./youngDiagrams";
 
 // Matches $\cmd{...}...$ where the body may contain $ and one level of nested
 // braces. Group 1 captures the full \cmd{...} including the outer }. After
@@ -37,9 +41,14 @@ export function normalizeMath(s: string): string {
 }
 
 function normalizeMathText(s: string): string {
+  // Step 0: expand \yng/\young macros to KaTeX-compatible \boxed{array}
+  // forms. Stateful — tracks `$…$` so bare `\yng` in prose gets wrapped
+  // in inline math, and `\yng` already inside math just substitutes.
+  let r = expandYoungDiagrams(s);
+
   // Step 1: protect LaTeX line-break spacing (\\[4pt], \\[2ex], ...) so the
   // \[ → $$ rewrite below doesn't swallow it.
-  let r = s.replace(/\\\\\[/g, LB);
+  r = r.replace(/\\\\\[/g, LB);
 
   // Step 2: convert LLM-native delimiters to standard $/$$ syntax. Arrow
   // functions are required because "$$" in a JS replace string means a
@@ -51,26 +60,31 @@ function normalizeMathText(s: string): string {
     .replace(/\\\)/g, () => "$");
   r = r.replace(new RegExp(LB, "g"), "\\\\[");
 
-  // Step 3: repair inline $$. CommonMark requires a blank line before
-  // block math; without it remark-math parses the opening $$ as an
-  // empty math node and the formula leaks out as literal text.
+  // Step 3: extract $$…$$ display pairs into placeholders, ensuring
+  // both delimiters are paragraph-separated for remark-math (which
+  // requires $$ on its own line for block math). When the opening $$
+  // is glued to preceding prose, insert a blank line before it. The
+  // pair is extracted as a unit so the closing $$ is never split off.
+  // KaTeX-specific normalisation runs here so |→\vert (with \|
+  // protected) and \text{} escapes both apply to display math.
+  r = r.replace(/\$\$([\s\S]*?)\$\$/g, (_m, m, offset, full) => {
+    const prefix = offset > 0 && /[A-Za-z\)\]\>\.。！？,{}]/.test(full[offset - 1])
+      ? "\n\n"
+      : "";
+    return prefix + DM + latexNormalizeForKatex(m) + DM;
+  });
+
+  // Step 4: repair any remaining glued $$. After extracting well-formed
+  // $$…$$ pairs above, remaining $$ are orphaned openings (model forgot
+  // the closing $$) or stray double-dollars. Insert a blank line before
+  // them so remark-math recognises a block boundary.
   // Digits are excluded so `c^2$$` inside a formula is left alone.
-  // Comma is included so `…D(q^2),$$` (closing $$ on the same line as
-  // the trailing content) is repaired: micromark-extension-math only
-  // recognises a closing $$ fence at the start of a new line, so
-  // without this repair it consumes the rest of the document as math
-  // and katex fails on the stray $ in the next paragraph.
-  r = r.replace(/([A-Za-z\)\]\>\.。！？,])\$\$/g, (_m, prev) => prev + "\n\n$$");
+  r = r.replace(/([A-Za-z\)\]\>\.。！？,{}])\$\$/g, (_m, prev) => prev + "\n\n$$");
 
   // Orphan opening $$ (model forgot the closing $$) is left alone:
   // converting it to a lone $ would interact badly with the $…$
   // matcher below and wrap whole prose paragraphs in math spans. The
   // right fix is upstream — a post-generation lint or stricter prompt.
-
-  // Step 4: $$…$$ → display placeholders. KaTeX-specific normalisation
-  // runs here so |→\vert (with \| protected) and \text{} escapes both
-  // apply to display math.
-  r = r.replace(/\$\$([\s\S]*?)\$\$/g, (_m, m) => `${DM}${latexNormalizeForKatex(m)}${DM}`);
 
   // Step 5: $\cmd{...}$ pairs where the body may contain a stray $
   // (e.g. $\text{price is $5}$). Recognised first so the inner $ doesn't
@@ -91,9 +105,17 @@ function normalizeMathText(s: string): string {
   });
 
   // Step 7: restore standard $/$$ delimiters for remark-math to parse.
-  return r
-    .replace(new RegExp(DM, "g"), () => "$$")
-    .replace(new RegExp(IM, "g"), "$");
+  // Display math: the placeholders were inserted as DM...DM pairs.
+  // Restore them as $$\n...\n$$ so remark-math recognises block math
+  // (it requires $$ on its own line, not glued to content like $$x$$).
+  // The first DM in each pair is the opening $$, the second is closing.
+  let displayOpen = true;
+  r = r.replace(new RegExp(DM, "g"), () => {
+    const delim = displayOpen ? "$$\n" : "\n$$";
+    displayOpen = !displayOpen;
+    return delim;
+  });
+  return r.replace(new RegExp(IM, "g"), "$");
 }
 
 function protectMarkdownCode(s: string): { text: string; prefix: string; segments: string[] } {

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -55,7 +55,12 @@ function normalizeMathText(s: string): string {
   // block math; without it remark-math parses the opening $$ as an
   // empty math node and the formula leaks out as literal text.
   // Digits are excluded so `c^2$$` inside a formula is left alone.
-  r = r.replace(/([A-Za-z\)\]\>\.。！？])\$\$/g, (_m, prev) => prev + "\n\n$$");
+  // Comma is included so `…D(q^2),$$` (closing $$ on the same line as
+  // the trailing content) is repaired: micromark-extension-math only
+  // recognises a closing $$ fence at the start of a new line, so
+  // without this repair it consumes the rest of the document as math
+  // and katex fails on the stray $ in the next paragraph.
+  r = r.replace(/([A-Za-z\)\]\>\.。！？,])\$\$/g, (_m, prev) => prev + "\n\n$$");
 
   // Orphan opening $$ (model forgot the closing $$) is left alone:
   // converting it to a lone $ would interact badly with the $…$

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -8,7 +8,7 @@
 //   4. Inline `$$` glued to prose gets a blank line inserted before it
 //      (CommonMark requires that block math be paragraph-separated).
 //   5. $$…$$ → display placeholders, $…$ → inline placeholders, gated by
-//      isLikelyInlineMath so currency / env-var tokens pass through.
+//      isLikelyInlineMath; currency / env-var tokens become &#36; entities.
 //   6. Each recognised math source is run through latexNormalizeForKatex
 //      (text-mode escapes, |→\vert, %→\%).
 
@@ -81,11 +81,12 @@ function normalizeMathText(s: string): string {
     return `${IM}${latexNormalizeForKatex(m)}${IM}`;
   });
 
-  // Step 6: remaining $…$ → classifier-gated inline math. Non-math
-  // pairs (e.g. currency like "$5 and $6") are left unchanged so the
-  // dollars remain visible; remark-math will not try to parse them.
+  // Step 6: remaining $…$ → classifier-gated inline math. remark-math
+  // parses any literal $…$ it sees, so non-math pairs (currency $5,
+  // env vars $PATH$) are wrapped in &#36; entities — remark-math never
+  // sees a $, and the decoded entity still renders as a literal dollar.
   r = r.replace(/\$([^$\n]+)\$/g, (_m, m) => {
-    if (!isLikelyInlineMath(m.trim())) return _m;
+    if (!isLikelyInlineMath(m.trim())) return `${DOLLAR}${m}${DOLLAR}`;
     return `${IM}${latexNormalizeForKatex(m)}${IM}`;
   });
 

--- a/desktop/frontend/src/components/youngDiagrams.ts
+++ b/desktop/frontend/src/components/youngDiagrams.ts
@@ -1,0 +1,218 @@
+// Translate `\yng` (ytableau package) and `\young` (youngtab package)
+// macros into KaTeX-compatible `\begin{array}...\end{array}` forms.
+// KaTeX 0.17 does not include either macro package, so without this
+// pass the macros fail with `Undefined control sequence` and the chat
+// surfaces the raw LaTeX source as a red error block.
+//
+// `\yng(2,1)`               — empty (2,1) Young diagram
+// `\yng(2,1,3)`             — empty Young diagram with three rows
+// `\yng(2,1){a&b\\c\\d&e}`  — same shape, cells filled by row/col
+//                              (rows separated by `\\`, cells by `&`)
+// `\young(2 1)`             — youngtab syntax (whitespace separator)
+//
+// Cells are `\square` (a Unicode white-square, rendered by KaTeX as
+// `mord amsrm` with a real visible glyph) by default so the diagram
+// has the same width as a filled one AND is actually visible. Earlier
+// versions used `\hphantom{x}` for invisible placeholder width, which
+// renders to *no visible glyph* — correct typesetting but the user
+// sees nothing on screen and the chat looks empty.
+//
+// The translator is stateful: it tracks `$…$` math delimiters so it
+// only wraps *bare* `\yng`/`\young` in `$…$`. When the macros are
+// already inside a math block (e.g. `$\yng(2,1)$`), it just expands
+// the inner form without adding extra delimiters — the inner call in
+// the math content is enough.
+
+function parseShape(s: string, sep: "comma" | "space"): number[] {
+  const re = sep === "comma" ? /,\s*/ : /\s+/;
+  return s
+    .trim()
+    .split(re)
+    .map((x) => parseInt(x, 10))
+    .filter((n) => Number.isFinite(n));
+}
+
+function expandShape(rows: number[], content: string | undefined): string {
+  const maxN = rows.length === 0 ? 0 : Math.max(...rows);
+  // 2D array of cell content. Each cell is `\square` by default
+  // (visible Unicode white-square) so the diagram has uniform width
+  // AND is actually visible to the reader.
+  const cells: string[][] = Array.from({ length: rows.length }, () =>
+    Array(maxN).fill("\\square"),
+  );
+
+  if (content) {
+    // Parse content: rows separated by `\\`, cells separated by `&`.
+    // The content may contain nested `{...}` (e.g. `\frac{a}{b}`), so
+    // we split on `\\` and `&` at brace-depth 0 only.
+    const splitAtTopLevel = (s: string, sep: string): string[] => {
+      const out: string[] = [];
+      let depth = 0;
+      let buf = "";
+      for (let i = 0; i < s.length; i++) {
+        const ch = s[i];
+        if (ch === "{") depth++;
+        else if (ch === "}") depth--;
+        if (depth === 0 && s.startsWith(sep, i)) {
+          out.push(buf);
+          buf = "";
+          i += sep.length - 1;
+          continue;
+        }
+        buf += ch;
+      }
+      out.push(buf);
+      return out;
+    };
+    const contentRows = splitAtTopLevel(content, "\\\\");
+    for (let i = 0; i < contentRows.length && i < rows.length; i++) {
+      const cs = splitAtTopLevel(contentRows[i], "&");
+      for (let j = 0; j < cs.length && j < rows[i]; j++) {
+        const c = cs[j].trim();
+        cells[i][j] = c === "" ? "\\square" : c;
+      }
+    }
+  }
+
+  // Use per-row negative spacing `\\\\[-0.525em]` between rows instead of the
+  // default `\\`. The default katex display math baseline-to-baseline
+  // spacing is 1.2em, but the `\square` glyph is only 0.675em tall
+  // (measured from the katex strut of a single `\square`). With the
+  // default spacing, the gap between the bottom of one row's square
+  // and the top of the next is 1.2 − 0.675 = 0.525em of visible white
+  // space — the diagram looks like a column of disconnected boxes.
+  // `\\\\[-0.525em]` reduces the baseline gap to exactly 0.675em so
+  // adjacent squares touch with zero visible gap. This is a *per-row
+  // spacing* fix, not a per-cell vertical shift: the offset is
+  // symmetric across the diagram, so all rows stay aligned.
+  const arrRows = cells.map((row, ri) =>
+    row.slice(0, rows[ri]).join(" \\! "),
+  );
+  // Use `{l}` (left) instead of `{c}` (centered): a Young diagram has
+  // every row's first cell at the same horizontal position — the
+  // shorter rows just have fewer cells to the right. `{c}` would
+  // centre each row relative to the widest row, which doesn't look
+  // like a Young diagram.
+  return (
+    "\\begin{array}{l}" +
+    arrRows.join(" \\\\[-0.525em] ") +
+    "\\end{array}"
+  );
+}
+
+// Find the end of a `\yng(…)` or `\young(…)` call, including optional
+// `{…}` content. Returns the index just past the entire macro call,
+// or -1 if the open-paren has no matching close.
+function findYoungCallEnd(src: string, startIdx: number): number {
+  // src[startIdx..] begins with "\yng(" or "\young(".
+  const openIdx = src.indexOf("(", startIdx);
+  if (openIdx < 0) return -1;
+  let depth = 1;
+  let i = openIdx + 1;
+  while (i < src.length && depth > 0) {
+    const ch = src[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") depth--;
+    if (depth === 0) {
+      // Check for optional `{…}` content block.
+      const afterClose = i + 1;
+      if (src[afterClose] === "{") {
+        let bdepth = 1;
+        let k = afterClose + 1;
+        while (k < src.length && bdepth > 0) {
+          if (src[k] === "{") bdepth++;
+          else if (src[k] === "}") bdepth--;
+          if (bdepth === 0) return k + 1;
+          k++;
+        }
+        return -1; // unterminated `{`
+      }
+      return afterClose;
+    }
+    i++;
+  }
+  return -1; // unterminated `(`
+}
+
+/**
+ * Walk the input, replacing `\yng(…)` / `\young(…)` with the equivalent
+ * KaTeX-compatible `\begin{array}{c}…\end{array}`. If the macro is
+ * outside any `$…$` math block, wrap the result in `$…$` so remark-math
+ * actually parses it as math. If the macro is already inside a math
+ * block (the existing common case), just substitute the expanded form.
+ */
+export function expandYoungDiagrams(src: string): string {
+  let out = "";
+  let i = 0;
+  // Track whether we're inside a math block. We use a small stack-like
+  // counter (depth): 0 = prose, 1 = inline math `$…$`, 2 = display
+  // math `$$…$$`. We bump on `$`, decrement on `$`, and clamp at 0/2.
+  // For our wrapping decision, depth>0 means "leave the macro alone,
+  // it's already in math".
+  let depth = 0;
+
+  while (i < src.length) {
+    const ch = src[i];
+
+    if (ch === "$") {
+      // Look ahead for `$$` (display) vs single `$` (inline).
+      if (src[i + 1] === "$") {
+        // Display math: toggle 0↔2.
+        depth = depth === 0 ? 2 : depth === 2 ? 0 : depth;
+        out += "$$";
+        i += 2;
+      } else {
+        // Inline math: toggle 0↔1. If we're in display math (depth=2),
+        // a single `$` doesn't end it — we need another `$` to do that,
+        // so single `$` inside display math is left alone (depth stays 2).
+        if (depth === 0) depth = 1;
+        else if (depth === 1) depth = 0;
+        // depth === 2: single `$` inside `$$…$$` is literal, depth unchanged.
+        out += ch;
+        i += 1;
+      }
+      continue;
+    }
+
+    // Look for \yng( or \young( and decide whether to wrap or just substitute.
+    if (src.startsWith("\\yng(", i) || src.startsWith("\\young(", i)) {
+      const isYng = src.startsWith("\\yng(", i);
+      const callEnd = findYoungCallEnd(src, i);
+      if (callEnd > 0) {
+        const openIdx = src.indexOf("(", i);
+        const closeIdx = src.indexOf(")", openIdx);
+        const shapeText = src.slice(openIdx + 1, closeIdx);
+        let content: string | undefined;
+        let contentStart = closeIdx + 1;
+        if (src[contentStart] === "{") {
+          let bdepth = 1;
+          let k = contentStart + 1;
+          while (k < src.length && bdepth > 0) {
+            if (src[k] === "{") bdepth++;
+            else if (src[k] === "}") bdepth--;
+            if (bdepth === 0) break;
+            k++;
+          }
+          content = src.slice(contentStart + 1, k);
+        }
+        const rows = isYng
+          ? parseShape(shapeText, "comma")
+          : parseShape(shapeText, "space");
+        const expanded = expandShape(rows, content);
+        // Wrap in `$…$` only if we're outside math. Inside math, the
+        // surrounding `$`/`$$` already supplies the math delimiters.
+        if (depth === 0) {
+          out += "$" + expanded + "$";
+        } else {
+          out += expanded;
+        }
+        i = callEnd;
+        continue;
+      }
+    }
+
+    out += ch;
+    i++;
+  }
+  return out;
+}


### PR DESCRIPTION
# Fix: Inline math rendering for LLM output

## Problem

LLM output has a long tail of Markdown idiosyncrasies around math
delimiters — glued `$$`, stray `,` before closing fences, currency that
shouldn't be math, code blocks containing `$` regex literals, malformed
inline code, etc. Reasonix's `normalizeMath` pre-pass and `isLikelyInlineMath`
classifier were tuned to a narrower set of cases, so each new quirk
surfaced as a red `katex-error` block (or worse, a swallowed-document
parser failure) in the chat.

This PR hardens the math-rendering pre-pass against the most common
LLM-output shapes, with a regression test pinning each one.

## What this PR fixes

Nine classes of LLM-Markdown quirks, all repaired or classified at the
pre-render stage:

1. **Block math `$$` glued to prose.** When a model writes
   `decomposes as$$\n\mathbf{6}…` or `…D(q^2),$$\nwith …`, the
   closing `$$` is not on its own line. `micromark-extension-math`
   only recognises a closing `$$` fence at the start of a new line,
   so without a blank line it consumes the rest of the document as
   math and katex fails on stray `$` in the next paragraph. The
   pre-pass now inserts a blank line before any `$$` preceded by a
   letter, bracket, full-stop punctuation, or comma.

2. **Inline math rejected as currency / prose.** The classifier now
   accepts single digits, single uppercase letters, comma-separated
   tokens, numbers with implicit-multiplication variables (`$2.5x$`),
   percentages, and one-sided comparisons (`< B`, `A <`) as math.
   These are common in physics, chemistry, and non-English math
   prose (Chinese/Japanese textbooks, for example, almost always
   write `$S$` for a set, not the English word).

3. **Unary plus/minus.** Expressions like `$+2$`, `$-x$`,
   `$+\alpha$` are now classified as math instead of literal text.

4. **`$` inside code blocks.** Single- and multi-line code blocks
   (including malformed single-line docs) have their `$` content
   protected from katex's math parser. Regex patterns, template
   literals, and pasted documentation about the math pipeline itself
   no longer trigger red `katex-error` blocks.

5. **Top-level `%` in math.** KaTeX treats unescaped `%` as a LaTeX
   comment char and silently truncates the formula at end-of-line —
   `$x = 50%$` previously rendered as `x = 50` with no error.
   `latexNormalizeForKatex` now escapes top-level `%` to `\%`;
   already-escaped `\%` is handled as a 2-char command so there's
   no double-escape.

6. **Prose currency preserved.** Strings like "These two apples
   cost `$5` and `$6`" leave their `$` signs visible instead of
   converting them to HTML entities.

7. **Array column specs & ket pipes (the `d450aec1` follow-up).**
   Inside `\begin{array}{c|c}` the `|` means "draw a vertical rule"
   and must not be rewritten to `\vert` (which raised KaTeX *"Unknown
   column alignment"*). Separately, in GFM Markdown tables an LLM
   writes kets as `\|uud\rangle`, but `\|` is the "parallel-to"
   double bar `‖` in KaTeX, not the single bar `|` kets use. The
   `{…}` column preamble is now copied verbatim, and `\|` is
   converted to `\vert` for ket openers / bra closers while matched
   `\|x\|` norms are preserved.

8. **Multi-letter group notation (e.g. `$SO(3,1)$`).** The
   classifier's function-call rule previously accepted only a single
   letter before the parentheses (`f(x)`), so group notation like
   `$SO(3,1)$`, `$SU(2)$`, `$SL(2)$`, `$GL(n)$`, `$Sp(2n)$`,
   `$Spin(n)$`, `$Diff(M)$` fell through to the prose fallback and
   rendered as literal `$`. The identifier is now allowed to be
   1–6 letters.

9. **LaTeX command followed by a digit (e.g. `$\tfrac12$`).** The
   classifier's backslash-command rule ended in `\b` (a word
   boundary). `$\tfrac12$`, `$\frac12$`, `$\sqrt2$`, `$\log3$` have
   no word boundary between the command name and the trailing digit
   (both are word characters), so they were rejected and rendered as
   literal `$`. The `\b` is dropped — a backslash command is a
   backslash command regardless of what follows.

## Files changed

| File | Role |
|---|---|
| `desktop/frontend/src/components/mathNormalize.ts` | The pre-pass: blank-line repair for glued `$$`, code-block protection, single-line code-block handling. |
| `desktop/frontend/src/components/mathClassify.ts` | The inline-math classifier: pure numbers, single uppercase letters, comma-separated tokens, numbers with variables, one-sided comparisons, unary +/-, multi-letter group notation. |
| `desktop/frontend/src/components/latexNormalize.ts` | The LaTeX→KaTeX escape helper: top-level `%` → `\%`, verbatim array/tabular column specs, ket/bra `\|` → `\vert`. |
| `desktop/frontend/src/__tests__/math-golden.test.ts` | Regression tests for every case above. |

## Design notes

- **All repairs happen in the pre-pass, not in `remark-rehype-katex`.**
  The pre-pass is the right layer: it sees the source text and can
  make string-level decisions before any parser has had a chance to
  misbehave. Catching these at the katex-render layer would mean
  building fallback display paths for each failure mode.

- **Character class is the right place for the blank-line repair.** The
  regex on line 58 of `mathNormalize.ts` reads
  `[A-Za-z\)\]\>\.。！？,]`. Each character was added in response to a
  real user report (closing bracket, full-stop, CJK punctuation,
  comma). The pattern is intentionally narrow: it excludes digits so
  that `c^2$$` inside a formula is left alone (and the existing test
  pins that case).

- **The classifier's permissiveness is a deliberate trade-off.** Single
  digits, single uppercase letters, etc. *could* be English prose, but
  in the context of a chat assistant for physics and math, accepting
  them as math is the right call. The currency pattern "costs $5 and
  $6" still works because the multi-currency step doesn't classify
  those as math.

- **Top-level `%` escaping is in `latexNormalizeForKatex`, not in
  `normalizeMath`.** This is the same layer that handles `|→\vert`
  and `\,`-preservation — KaTeX-specific concerns that need to run
  inside the math body, after the pre-pass has identified the math
  boundaries.

- **Array column specs are detected by environment, not by counting
  braces.** `COLUMN_SPEC_ENVS` lists `array`/`tabular`/`aligned` etc.
  whose first `{…}` arg is a column preamble; that brace group is
  copied verbatim so its `|` rules survive. Pipes elsewhere still
  convert to `\vert` normally.

## Trade-offs and known limitations

### Orphan `$$` is not repaired

If a model writes `$$\nformula` and forgets the closing `$$`,
`micromark-extension-math` swallows everything until the next `$$` —
which is the same root cause as case 1 above, but inverted. Every
attempt to rescue an orphan from the renderer side has produced
worse output (whole prose paragraphs wrapped in math spans). This
case is left to upstream prompt engineering or a post-generation
lint.

### Fenced code detection is CommonMark-strict

`fencedCodeEnd` requires the opening fence to be at the start of a
line. Prose like "wrap code in ` ```blocks``` ` here" is correctly
*not* treated as a code block. Single-line docs with embedded
` ``` ` are still handled via a fallback path.

## Testing

All 182 math-golden tests pass (was 108; +74 regression tests across
the review-feedback, display-math-repair, array/ket, group-notation, and
LaTeX-command-followed-by-digit rounds). The full frontend test suite
(13 files) is green.

> Note: a pre-existing TypeScript error in `src/lib/bridge.ts` is
> present at the branch tip without this PR too — unrelated to the
> math pipeline and not touched by any commit here.

```bash
cd desktop/frontend
pnpm test
```

### Regression-test coverage

Each new case has a dedicated test:

- Pure numbers: `$1$`, `$42$`, `$2.5$` → math
- Numbers with variables: `$2.5x$` → math
- Numbers with LaTeX: `$10\%$` → math
- Comma-separated lists: `A, B`, `(A, B)` → math
- One-sided comparisons: `< B`, `A <` → math
- Single uppercase letters: `$S$`, `$A$` → math
- Unary plus/minus: `$+2$`, `$-x$` → math
- Single-line code blocks with `$` → protected
- Prose currency: "cost `$5` and `$6`" → dollars preserved
- Top-level `%` in math: `$x = 50%$` → escaped to `\%`
- Closing `$$` after comma: `…D(q^2),$$\nwith …` → repaired to `…D(q^2),\n\n$$`
- Array column specs: `{c|c}`, `{cc|c}`, `{|c|c|}`, `tabular` → `|` preserved
- Ket / bra / inner product: `\|uud\rangle`, `\langle\psi\|`, `\langle x\|y\rangle` → `\vert`
- Norm preserved: `\|x\|` → double bar kept
- Multi-letter group notation: `$SO(3,1)$`, `$SU(2)$`, `$SL(2)$`, `$GL(n)$`, `$Sp(2n)$`, `$Spin(3)$`, `$Diff(M)$` → math
- LaTeX command + digit: `$\tfrac12$`, `$\frac12$`, `$\sqrt2$`, `$\log3$`, `$\overline3$` → math

## Real-world examples (from user reports)

```markdown
### Chinese math text
$1$ 和 $2$ 之间有无穷多有理数
→ Both 1 and 2 render as math

$S$ 非空
→ S renders as math (set name)

把 $(A, B)$ 整体当作一个新对象
→ (A, B) renders as math (ordered pair)

A 的每个元素 $< B$ 的每个元素
→ < B renders as math (comparison)

### Math with numbers
$2.5x + 3$
→ Entire expression renders as math

$10\%$ increase
→ 10\% renders as math

$42$ elements
→ 42 renders as math

### Currency in prose
costs $5 and $6
→ Dollar signs preserved unchanged

costs $5$ today
→ $5$ renders as math (pure number)

price is $10.50$
→ $10.50$ renders as math (decimal)

### Code blocks
```javascript
r = r.replace(/\$\$/, ...);
```
→ No KaTeX errors, $ symbols protected

### Display math glued after a comma
$$
\langle \pi(p')|T^{\mu\nu}(0)|\pi(p)\rangle
= 2 P^\mu P^\nu\,A(q^2) + 2\!\left(q^\mu q^\nu - q^2 g^{\mu\nu}\right)\!D(q^2),$$
with $P=(p+p')/2$, $q=p'-p$.
```
→ Closing `$$` is normalised to its own line, math renders,
downstream `$P=...$` and `$q=...$` inline math renders correctly.

### Group notation (physics)
The Lorentz group $SO(3,1)$ and gauge group $SU(3)_C \times SU(2)_L \times U(1)_Y$.
→ Multi-letter group names render as math, not literal `$`.
```

## Changelog (cumulative, since PR opened)

- `0b03c948` — initial: block math repair, classifier improvements, code-block `$` protection, currency preservation.
- `ae0a04dd` — test rename: "non-English math prose" → "minimal LaTeX patterns" (the rules are language-agnostic, but the test cases include real Chinese examples).
- `c712bd64` — `&#36;` escape in code blocks (since dropped in the review-feedback pass).
- `ccef134a` — single-line code-block handling.
- `ed672359` — classifier hardening + single-line code-block fix.
- `b1fb63e4` — preserve prose currency.
- `8c477b5c` — review feedback pass: dropped the `&#36;` round-trip, dropped the redundant `+?` change, restricted fence detection to line-start, added top-level `%` escape, trimmed oversized comments.
- `c93af0ac` — unary plus/minus classifier rule.
- `45482b20` — closing `$$` after comma (caught during a chat session, regression test pins the case).
- `70bcb8a6` — step 6 wraps non-math `$…$` in `&#36;` entities (maintainer review patch).
- `d450aec1` — repair display math regression: extract `$$…$$` pairs as a unit before the repair regex so the closing `$$` of well-formed pairs is never split off.
- `072d38c3` — add `youngDiagrams.ts` dependency for `mathNormalize` (required by `d450aec1`'s `mathNormalize` rewrite).
- `eb029d5e` — multi-letter group notation (`SO(3,1)`, `SU(2)`, …) classified as inline math.
- `2b090416` — correct pipe handling for array column specs (`{c|c}`) and kets (`\|uud\rangle`); brings in the `latexNormalize.ts` implementation that `d450aec1`'s tests were already asserting.
- `841da58a` — classify a LaTeX command followed by a digit (`\tfrac12`, `\frac12`, `\sqrt2`, `\log3`) as math; drop the `\b` from the backslash-command rule.

