### PR TITLE
fix(rewind): fail loudly past a compacted boundary (#3598) + suffix-scan CanCode (#3438)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -741,6 +741,16 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 			CanConversation: ctrl.CheckpointHasBoundary(m.Turn),
 		})
 	}
+	// RestoreCode(turn) reverts every file touched in this turn or any later one, so
+	// a turn can rewind code even when it changed no files itself — as long as a
+	// later turn did. Propagate CanCode backwards over the oldest-first list.
+	hasCodeAfter := false
+	for i := len(out) - 1; i >= 0; i-- {
+		if len(out[i].Files) > 0 {
+			hasCodeAfter = true
+		}
+		out[i].CanCode = hasCodeAfter
+	}
 	return out
 }
 

--- a/desktop/checkpoints_cancode_test.go
+++ b/desktop/checkpoints_cancode_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/checkpoint"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func seedCheckpoint(t *testing.T, ckptDir string, c checkpoint.Checkpoint) {
+	t.Helper()
+	b, err := json.Marshal(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ckptDir, "turn-"+strconv.Itoa(c.Turn)+".json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCheckpointsCanCodePropagatesToEarlierTurns covers #3438: RestoreCode(turn)
+// reverts files touched in that turn or any later one, so a turn with no file
+// changes of its own can still rewind code when a later turn changed files. The
+// desktop CanCode flag must reflect that suffix capability, not just the turn's
+// own paths.
+func TestCheckpointsCanCodePropagatesToEarlierTurns(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "s.jsonl")
+	ckptDir := sessionPath[:len(sessionPath)-len(".jsonl")] + ".ckpt"
+	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "old"
+	now := time.Now()
+	seedCheckpoint(t, ckptDir, checkpoint.Checkpoint{Turn: 0, Time: now, Prompt: "ask only", MsgIndex: 0})
+	seedCheckpoint(t, ckptDir, checkpoint.Checkpoint{Turn: 1, Time: now, Prompt: "edit a file", MsgIndex: 2,
+		Files: []checkpoint.FileSnap{{Path: "a.txt", Content: &content}}})
+	seedCheckpoint(t, ckptDir, checkpoint.Checkpoint{Turn: 2, Time: now, Prompt: "ask again", MsgIndex: 4})
+
+	ag := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: ag, SessionDir: dir, Label: "test"})
+	ctrl.SetSessionPath(sessionPath)
+
+	app := &App{}
+	app.setTestCtrl(ctrl, "test")
+
+	metas := app.CheckpointsForTab("test")
+	if len(metas) != 3 {
+		t.Fatalf("checkpoints = %d, want 3", len(metas))
+	}
+	got := map[int]bool{}
+	for _, m := range metas {
+		got[m.Turn] = m.CanCode
+	}
+	if !got[0] {
+		t.Error("turn 0 (no files of its own) should allow code rewind — turn 1 changed files")
+	}
+	if !got[1] {
+		t.Error("turn 1 changed files, should allow code rewind")
+	}
+	if got[2] {
+		t.Error("turn 2 is after the last file-bearing turn, should NOT allow code rewind")
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1050,19 +1050,23 @@ func (c *Controller) Rewind(turn int, scope RewindScope) error {
 			return c.rewindFail(fmt.Errorf("conversation rewind unavailable for turn %d (resumed session)", turn))
 		}
 		s := c.executor.Session()
-		if boundary <= len(s.Messages) {
-			s.Messages = s.Messages[:boundary]
-			c.mu.Lock()
-			c.cpTurn = turn // renumber future turns from here; later turns are gone
-			for k := range c.cpBound {
-				if k >= turn {
-					delete(c.cpBound, k)
-				}
+		// boundary is the message-log index at turn start; compaction shrinks the
+		// log without rewriting boundaries, so a stale boundary past the end means
+		// the turn was compacted away — fail loudly instead of skipping silently.
+		if boundary > len(s.Messages) {
+			return c.rewindFail(fmt.Errorf("conversation rewind unavailable for turn %d: the conversation was compacted past this point", turn))
+		}
+		s.Messages = s.Messages[:boundary]
+		c.mu.Lock()
+		c.cpTurn = turn // renumber future turns from here; later turns are gone
+		for k := range c.cpBound {
+			if k >= turn {
+				delete(c.cpBound, k)
 			}
-			c.mu.Unlock()
-			if err := c.Snapshot(); err != nil {
-				slog.Warn("controller: snapshot after rewind", "err", err)
-			}
+		}
+		c.mu.Unlock()
+		if err := c.Snapshot(); err != nil {
+			slog.Warn("controller: snapshot after rewind", "err", err)
 		}
 		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 			Text: fmt.Sprintf("rewound conversation to turn %d", turn)})

--- a/internal/control/rewind_e2e_test.go
+++ b/internal/control/rewind_e2e_test.go
@@ -1,0 +1,101 @@
+package control
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func runTwoTurns(t *testing.T) (*Controller, *agent.Agent, *[]event.Event) {
+	t.Helper()
+	dir := t.TempDir()
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("first answer"),
+		textTurn("second answer"),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession("sys"), agent.Options{}, event.Discard)
+	var events []event.Event
+	c := New(Options{
+		Runner:     ag,
+		Executor:   ag,
+		SessionDir: dir,
+		Label:      "test",
+		Sink:       event.FuncSink(func(e event.Event) { events = append(events, e) }),
+	})
+	c.SetSessionPath(agent.NewSessionPath(dir, "test"))
+	if err := c.runTurnWithRaw(context.Background(), "first prompt", "first prompt"); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if err := c.runTurnWithRaw(context.Background(), "second prompt", "second prompt"); err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	return c, ag, &events
+}
+
+// TestRewindConversationFailsLoudlyAfterCompaction reproduces #3598: once
+// compaction shrinks the message log below a turn's recorded boundary, a
+// conversation/both rewind to that turn skipped the truncation but still emitted
+// a success notice — code rolled back, conversation silently did not.
+func TestRewindConversationFailsLoudlyAfterCompaction(t *testing.T) {
+	c, ag, events := runTwoTurns(t)
+
+	c.mu.Lock()
+	lastTurn := c.cpTurn - 1
+	boundary := c.cpBound[lastTurn]
+	c.mu.Unlock()
+	if boundary <= 1 {
+		t.Fatalf("expected the latest turn's boundary above 1, got cpBound=%v", c.cpBound)
+	}
+
+	// Auto-compaction replaces the prefix with a summary, shrinking the log below
+	// the recorded boundary; compaction does not rewrite checkpoint boundaries.
+	sess := ag.Session()
+	sess.Messages = []provider.Message{{Role: provider.RoleUser, Content: "summary"}}
+
+	*events = nil
+	err := c.Rewind(lastTurn, RewindBoth)
+	if err == nil || !strings.Contains(err.Error(), "compacted") {
+		t.Fatalf("Rewind after compaction error = %v, want a 'compacted past' failure", err)
+	}
+	for _, e := range *events {
+		if e.Kind == event.Notice && strings.Contains(e.Text, "rewound conversation") {
+			t.Fatalf("emitted a false conversation-rewind success after skipping truncation: %q", e.Text)
+		}
+	}
+	if got := len(ag.Session().Messages); got != 1 {
+		t.Fatalf("session messages = %d, want the compacted log left intact at 1", got)
+	}
+}
+
+// TestRewindConversationSucceedsWithLiveBoundary is the companion happy path: a
+// boundary still within the log truncates the conversation and reports success.
+func TestRewindConversationSucceedsWithLiveBoundary(t *testing.T) {
+	c, ag, events := runTwoTurns(t)
+
+	c.mu.Lock()
+	lastTurn := c.cpTurn - 1
+	boundary := c.cpBound[lastTurn]
+	c.mu.Unlock()
+
+	*events = nil
+	if err := c.Rewind(lastTurn, RewindConversation); err != nil {
+		t.Fatalf("Rewind with a live boundary: %v", err)
+	}
+	if got := len(ag.Session().Messages); got != boundary {
+		t.Fatalf("session truncated to %d messages, want boundary %d", got, boundary)
+	}
+	ok := false
+	for _, e := range *events {
+		if e.Kind == event.Notice && strings.Contains(e.Text, "rewound conversation") {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Fatal("expected a conversation-rewind success notice")
+	}
+}


### PR DESCRIPTION
## Summary

Two rewind-correctness fixes from issue triage.

### 1. Conversation rewind silently no-ops after compaction (#3598)
A turn's conversation-rewind boundary is the message-log index recorded at turn start. Compaction shrinks `Session.Messages` **without** rewriting checkpoint boundaries, so once a turn has been compacted away its boundary exceeds `len(Messages)`. `Controller.Rewind` tested `boundary <= len(s.Messages)` and, when that was false, **skipped the truncation but still emitted a "rewound conversation to turn N" success notice**. For `RewindBoth` the code was rolled back while the conversation silently was not — the data-loss in #3598 ("code rolled back but conversation is not").

Now it returns a clear `conversation rewind unavailable … the conversation was compacted past this point` failure (surfaced as a Warn notice via the existing `rewindFail` path) and only reports success when the log was actually truncated.

### 2. CanCode ignores later turns' file changes (#3438)
`RestoreCode(turn)` reverts every file touched in that turn **or any later one**, so a turn that changed no files of its own can still rewind code when a later turn did. The desktop `CanCode` flag only checked the turn's own `Paths`, disabling the code/both buttons for such turns. It now propagates backwards over the oldest-first checkpoint list so the UI matches backend capability.

> Note: this addresses the `CanCode` sub-bug called out in #3438. The broader frontend turn-number divergence in #3438/#3640 (synthetic user messages from stream-recovery/retries/plan-approval shift the frontend turn counter relative to backend checkpoint turns) is a separate, larger fix that needs end-to-end desktop verification and is tracked separately.

## Test plan (end-to-end)
- `internal/control/rewind_e2e_test.go` — drives two real turns through a real agent + controller + checkpoint store, simulates compaction by shrinking the log below the recorded boundary, and asserts `RewindBoth` now returns a `compacted`-past failure, emits no false success notice, and leaves the log intact; companion test asserts a live boundary still truncates + reports success.
- `desktop/checkpoints_cancode_test.go` — seeds a real checkpoint store (turn 0 no files, turn 1 with a file, turn 2 no files) and asserts `CheckpointsForTab` returns CanCode `[true, true, false]`.
- `go test ./internal/control ./internal/checkpoint` green; `go vet` + gofmt clean on changed files. (Two pre-existing desktop failures on Windows — `TestMediaTokenHandlerEscapedFilename`, `TestAddSkillPathRestoresConventionRootWithoutCustomPath` — reproduce without this change and are platform/env-specific.)