### PR TITLE
chore(ci): drop /npm/reasonix from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,12 +40,6 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
 
-  - package-ecosystem: "npm"
-    directory: "/npm/reasonix"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Follow-up to #3676. The `/npm/reasonix` package.json only declares this project's own `@reasonix/cli-*` platform binaries as `optionalDependencies` (versioned by the release pipeline via npm/build.mjs), with no third-party deps. Dependabot opened five useless `0.0.0 -> 1.0.0` self-bump PRs (#3679/#3681/#3682/#3683/#3685, now closed); removing the ecosystem entry so they don't reopen.

go/desktop/site/frontend npm + gomod + github-actions ecosystems are unaffected.