### PR TITLE
fix(desktop): remove command text from approval rule buttons, fixing layout breakage

### DIFF
--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -26,9 +26,7 @@ export function ApprovalModal({
   const bashPrefix = isBashApproval ? bashCommandPrefix(subject) : "";
   const hasBashPrefix = bashPrefix !== "";
   const subjectSummary = subject.split("\n").find((line) => line.trim())?.trim() ?? "";
-  const exactSessionRule = approvalSessionRule(approval.tool, subject);
-  const exactPersistentRule = approvalPersistentRule(approval.tool, subject);
-  const prefixRule = hasBashPrefix ? `Bash(${bashPrefix})` : "";
+
 
   const choosePlanAction = (key: string) => {
     if (key === "1") setRevisionOpen((open) => !open);
@@ -154,12 +152,12 @@ export function ApprovalModal({
             <>
               <PromptAction
                 keyLabel="2"
-                label={<RuleActionLabel label={t("approval.allowRuleSession")} rule={prefixRule} />}
+                label={t("approval.allowRuleSession")}
                 onClick={() => onAnswer(true, true, false, "prefix")}
               />
               <PromptAction
                 keyLabel="3"
-                label={<RuleActionLabel label={t("approval.allowRulePersistent")} rule={prefixRule} />}
+                label={t("approval.allowRulePersistent")}
                 onClick={() => onAnswer(true, true, true, "prefix")}
               />
               <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => onAnswer(false, false, false)} />
@@ -168,12 +166,12 @@ export function ApprovalModal({
             <>
               <PromptAction
                 keyLabel="2"
-                label={<RuleActionLabel label={t("approval.allowRuleSession")} rule={exactSessionRule} />}
+                label={t("approval.allowRuleSession")}
                 onClick={() => onAnswer(true, true, false)}
               />
               <PromptAction
                 keyLabel="3"
-                label={<RuleActionLabel label={t("approval.allowRulePersistent")} rule={exactPersistentRule} />}
+                label={t("approval.allowRulePersistent")}
                 onClick={() => onAnswer(true, true, true)}
               />
               <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => onAnswer(false, false, false)} />
@@ -189,26 +187,7 @@ export function ApprovalModal({
   );
 }
 
-function RuleActionLabel({ label, rule }: { label: string; rule: string }) {
-  return (
-    <span className="approval-rule-label">
-      <span>{label}</span>
-      <code>{rule}</code>
-    </span>
-  );
-}
 
-function approvalSessionRule(tool: string, subject: string): string {
-  if (tool === "bash" && subject) return `Bash(${subject})`;
-  if (isFileMutationTool(tool)) return "Edit";
-  return tool;
-}
-
-function approvalPersistentRule(tool: string, subject: string): string {
-  if (tool === "bash" && subject) return `Bash(${subject})`;
-  if (isFileMutationTool(tool)) return subject ? `Edit(${subject})` : "Edit";
-  return tool;
-}
 
 function bashCommandPrefix(subject: string): string {
   const command = subject.trim();
@@ -235,13 +214,4 @@ function dangerousBashCommand(command: string): boolean {
     || /^mkfs\b/.test(command)
     || /^dd\s+if=/.test(command)
     || /^fdisk\b/.test(command);
-}
-
-function isFileMutationTool(tool: string): boolean {
-  return tool === "write_file"
-    || tool === "edit_file"
-    || tool === "multi_edit"
-    || tool === "notebook_edit"
-    || tool === "delete_range"
-    || tool === "delete_symbol";
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3369,15 +3369,6 @@ a[href] {
   line-height: 1.4;
   padding-block: 1px;
 }
-.prompt-action__label:has(.approval-rule-label) {
-  overflow: visible;
-  text-overflow: clip;
-  white-space: normal;
-}
-.prompt-action:has(.approval-rule-label) {
-  height: auto;
-  padding-block: 5px;
-}
 .prompt-detail-toggle {
   flex: 0 0 auto;
   max-width: 92px;
@@ -3435,22 +3426,6 @@ a[href] {
   max-height: 150px;
   overflow: auto;
 }
-.approval-rule-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-  max-width: 100%;
-}
-.approval-rule-label code {
-  min-width: 0;
-  max-width: 24ch;
-  overflow-wrap: anywhere;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--fg);
-}
-
 /* ── ask tool: decision details ───────────────────────────────────────────── */
 .ask-shelf__crumbs {
   display: flex;


### PR DESCRIPTION
## Bug

The "Allow for session" and "Always allow" buttons in the approval modal display the full bash command as inline code (e.g. `Bash(cd "xxx" && npm run build --target production --env staging...)`). When the command is long, the button content overflows and breaks the card layout. The same root cause also triggers issue #3646 where option text pushes the card to fill the entire screen.

## Fix

The command is already visible in the card header meta area (`bash · cd "xxx" && npm run...`) and the expandable Details section. Showing it again inside the action buttons is redundant.

Removed:

- `RuleActionLabel` component (the `<span><code>` wrapper around the rule text)
- `approvalSessionRule`, `approvalPersistentRule`, `truncateSubject` helper functions
- `isFileMutationTool` function (no longer referenced)
- Unused CSS classes: `.approval-rule-label`, `.approval-rule-label code`, `.prompt-action:has(.approval-rule-label)`

## Files

| File | Δ | Change |
|---|---|---|
| `ApprovalModal.tsx` | -43 | Remove RuleActionLabel, rule helpers, and `<code>` from action button labels |
| `styles.css` | -17 | Remove .approval-rule-label and related selectors |

Fixes #3677, fixes #3646
