### PR TITLE
fix(agent): degrade gracefully instead of looping on unmet readiness (#3664)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -414,6 +414,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 
 	finalReadinessBlocks := 0
+	lastReadinessReason := ""
 	emptyFinalBlocks := 0
 	handoffNudges := 0
 	usedAnyTool := false
@@ -477,14 +478,20 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		if len(calls) == 0 {
 			readiness := a.finalReadinessCheck()
 			if readiness.reason != "" {
+				// Nudging only helps while the model is resolving the gap. Stop and
+				// accept the answer once the same reason recurs (it's thrashing — e.g.
+				// re-running a check that still won't match) or the retry budget is
+				// spent, so an unsatisfiable gate degrades gracefully instead of
+				// burning rounds and then discarding the turn's work.
+				repeatedReason := finalReadinessBlocks > 0 && readiness.reason == lastReadinessReason
 				finalReadinessBlocks++
-				result := evidence.ReadinessBlocked
-				if finalReadinessBlocks >= maxFinalReadinessBlocks {
-					result = evidence.ReadinessErrored
-					event.RecordReadinessAudit(a.sink, readiness.audit(result, false))
-					return fmt.Errorf("final-answer readiness failed %d times: %s", finalReadinessBlocks, readiness.reason)
+				if repeatedReason || finalReadinessBlocks >= maxFinalReadinessBlocks {
+					event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessErrored, false))
+					a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "proceeding without confirmed readiness: " + readiness.reason})
+					return nil
 				}
-				event.RecordReadinessAudit(a.sink, readiness.audit(result, false))
+				lastReadinessReason = readiness.reason
+				event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessBlocked, false))
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + readiness.reason})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: finalReadinessRetryMessage(readiness.reason)})
 				a.maybeCompact(ctx, usage)
@@ -582,6 +589,14 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 		return finalReadinessCheck{}
 	}
 	out.applies = true
+	// A finished step that changed files must be signed off with complete_step.
+	// Only enforced once there is a writer this turn — no-write flows (research,
+	// Q&A) keep todo sign-off advisory to avoid gating trivial lists.
+	if !a.planMode.Load() {
+		if unsigned, hasTodos := a.evidence.CompletedTodosMissingReceipt(); hasTodos && len(unsigned) > 0 {
+			missing = append(missing, finalReadinessUnsignedTodos(unsigned))
+		}
+	}
 	for _, check := range a.projectChecks {
 		command := strings.TrimSpace(check.Command)
 		if command == "" {
@@ -598,6 +613,18 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	}
 	out.reason = strings.Join(missing, "; ")
 	return out
+}
+
+func finalReadinessUnsignedTodos(items []evidence.TodoStepMatch) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		label := strings.TrimSpace(item.Content)
+		if label == "" {
+			label = fmt.Sprintf("todo %d", item.Index)
+		}
+		parts = append(parts, label)
+	}
+	return "completed todos lack a matching complete_step receipt: " + strings.Join(parts, ", ")
 }
 
 func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -79,10 +79,15 @@ func sessionHasUserMessageContaining(s *Session, needle string) bool {
 }
 
 type readinessAuditSink struct {
-	events []evidence.ReadinessAudit
+	events  []evidence.ReadinessAudit
+	notices []string
 }
 
-func (s *readinessAuditSink) Emit(event.Event) {}
+func (s *readinessAuditSink) Emit(e event.Event) {
+	if e.Kind == event.Notice {
+		s.notices = append(s.notices, e.Text)
+	}
+}
 
 func (s *readinessAuditSink) RecordReadinessAudit(a evidence.ReadinessAudit) {
 	s.events = append(s.events, a)
@@ -380,39 +385,12 @@ func TestFinalReadinessRequiresCompleteStepAfterWriterWhenTodoSeen(t *testing.T)
 	}
 }
 
-func TestFinalReadinessStopsAfterRepeatedBlocks(t *testing.T) {
-	todoWrite, ok := tool.LookupBuiltin("todo_write")
-	if !ok {
-		t.Fatal("todo_write builtin not registered")
-	}
-	reg := tool.NewRegistry()
-	reg.Add(fakeTool{name: "write_file", readOnly: false})
-	reg.Add(todoWrite)
-	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
-		{
-			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
-			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
-			{Type: provider.ChunkDone},
-		},
-		{{Type: provider.ChunkText, Text: "premature 1"}, {Type: provider.ChunkDone}},
-		{{Type: provider.ChunkText, Text: "premature 2"}, {Type: provider.ChunkDone}},
-		{{Type: provider.ChunkText, Text: "premature 3"}, {Type: provider.ChunkDone}},
-	}}
-	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
-
-	err := a.Run(context.Background(), "edit with todo and never sign off")
-	if err == nil {
-		t.Fatal("expected repeated readiness blocks to stop the run")
-	}
-	if !strings.Contains(err.Error(), "final-answer readiness") {
-		t.Fatalf("error = %v, want final-answer readiness", err)
-	}
-	if prov.call != 4 {
-		t.Fatalf("provider calls = %d, want three blocked final answers after writer turn", prov.call)
-	}
-}
-
-func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
+// TestFinalReadinessDegradesOnRepeatedReason is the #3664 regression: an
+// unsatisfiable readiness gate must not loop-and-abort. When the same block
+// reason recurs (here the in_progress todo is never signed off), the turn
+// degrades — the answer is accepted with a visible warning rather than burning
+// the full retry budget and then discarding the turn's work with an error.
+func TestFinalReadinessDegradesOnRepeatedReason(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {
 		t.Fatal("todo_write builtin not registered")
@@ -433,16 +411,87 @@ func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
 	sink := &readinessAuditSink{}
 	a := New(prov, reg, NewSession(""), Options{}, sink)
 
-	err := a.Run(context.Background(), "edit with todo and never sign off")
-	if err == nil {
-		t.Fatal("expected repeated readiness blocks to stop the run")
+	if err := a.Run(context.Background(), "edit with todo and never sign off"); err != nil {
+		t.Fatalf("unsatisfiable readiness must degrade gracefully, not error: %v", err)
 	}
-	if len(sink.events) != 3 {
-		t.Fatalf("readiness audit events = %d, want 3: %+v", len(sink.events), sink.events)
+	if prov.call != 3 {
+		t.Fatalf("provider calls = %d, want early-exit on the repeated reason (one nudge, then degrade)", prov.call)
 	}
-	last := sink.events[len(sink.events)-1]
-	if last.Result != evidence.ReadinessErrored || last.IncompleteTodos == 0 {
-		t.Fatalf("terminal audit = %+v, want errored with incomplete todos", last)
+	foundWarn := false
+	for _, n := range sink.notices {
+		if strings.Contains(n, "proceeding without confirmed readiness") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Fatalf("degrade must emit a visible warning (not silent); notices = %v", sink.notices)
+	}
+	if len(sink.events) != 2 || sink.events[len(sink.events)-1].Result != evidence.ReadinessErrored {
+		t.Fatalf("audits = %+v, want one block then an errored degrade", sink.events)
+	}
+}
+
+// TestFinalReadinessNeverLoopsUnbounded locks the anti-deadloop guarantee: no
+// matter how many premature answers the model would emit, the gate caps the
+// rounds and terminates. The provider scripts 20 premature turns; the run must
+// still stop at the early-exit (3 provider calls) and return.
+func TestFinalReadinessNeverLoopsUnbounded(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(todoWrite)
+	turns := [][]provider.Chunk{{
+		toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+		toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Edit code","status":"in_progress"}]}`),
+		{Type: provider.ChunkDone},
+	}}
+	for i := 0; i < 20; i++ {
+		turns = append(turns, []provider.Chunk{{Type: provider.ChunkText, Text: "premature"}, {Type: provider.ChunkDone}})
+	}
+	prov := &scriptedProvider{name: "p", turns: turns}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "never sign off"); err != nil {
+		t.Fatalf("Run must terminate gracefully, got %v", err)
+	}
+	if prov.call > maxFinalReadinessBlocks+1 {
+		t.Fatalf("provider calls = %d, want bounded at %d — the loop is not capped", prov.call, maxFinalReadinessBlocks+1)
+	}
+}
+
+// TestFinalReadinessEnforcesUnsignedCompletionThenDegrades proves the evidence
+// guarantee moved intact to the single readiness gate: a completed todo with a
+// writer but no complete_step receipt is still caught (the block names the
+// missing receipt), and then degrades gracefully instead of looping.
+func TestFinalReadinessEnforcesUnsignedCompletionThenDegrades(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "write_file", `{"path":"changed.go","content":"package main"}`),
+			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Edit code","status":"completed"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "claiming done without sign-off"}, {Type: provider.ChunkDone}},
+		{{Type: provider.ChunkText, Text: "still no sign-off"}, {Type: provider.ChunkDone}},
+	}}
+	sink := &readinessAuditSink{}
+	a := New(prov, reg, NewSession(""), Options{}, sink)
+
+	if err := a.Run(context.Background(), "edit, mark done, but never sign off"); err != nil {
+		t.Fatalf("must degrade gracefully, not error: %v", err)
+	}
+	joined := strings.Join(sink.notices, "\n")
+	if !strings.Contains(joined, "complete_step receipt") {
+		t.Fatalf("readiness must enforce the moved guarantee (name the missing complete_step receipt); notices = %v", sink.notices)
 	}
 }
 

--- a/internal/boot/readiness_e2e_test.go
+++ b/internal/boot/readiness_e2e_test.go
@@ -1,0 +1,148 @@
+package boot
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+const readinessE2EKind = "readiness-e2e-test"
+
+var (
+	readinessE2EOnce    sync.Once
+	readinessE2EMu      sync.Mutex
+	readinessE2ECurrent *readinessE2EProvider
+)
+
+func installReadinessE2EProvider(t *testing.T, p *readinessE2EProvider) {
+	t.Helper()
+	readinessE2EOnce.Do(func() {
+		provider.Register(readinessE2EKind, func(provider.Config) (provider.Provider, error) {
+			readinessE2EMu.Lock()
+			defer readinessE2EMu.Unlock()
+			if readinessE2ECurrent == nil {
+				return nil, errors.New("readiness e2e provider not installed")
+			}
+			return readinessE2ECurrent, nil
+		})
+	})
+	readinessE2EMu.Lock()
+	readinessE2ECurrent = p
+	readinessE2EMu.Unlock()
+	t.Cleanup(func() {
+		readinessE2EMu.Lock()
+		if readinessE2ECurrent == p {
+			readinessE2ECurrent = nil
+		}
+		readinessE2EMu.Unlock()
+	})
+}
+
+// readinessE2EProvider scripts the #3664 shape: change a file and mark the step
+// in_progress, then keep answering without ever signing it off.
+type readinessE2EProvider struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (p *readinessE2EProvider) Name() string { return "readiness-e2e" }
+
+func (p *readinessE2EProvider) Stream(_ context.Context, _ provider.Request) (<-chan provider.Chunk, error) {
+	p.mu.Lock()
+	call := p.calls
+	p.calls++
+	p.mu.Unlock()
+
+	var chunks []provider.Chunk
+	switch call {
+	case 0:
+		chunks = []provider.Chunk{
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "w1", Name: "write_file", Arguments: `{"path":"changed.go","content":"package main\n"}`}},
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "t1", Name: "todo_write", Arguments: `{"todos":[{"content":"Edit code","status":"in_progress"}]}`}},
+			{Type: provider.ChunkDone},
+		}
+	default:
+		chunks = []provider.Chunk{{Type: provider.ChunkText, Text: "all done (prematurely)"}, {Type: provider.ChunkDone}}
+	}
+	ch := make(chan provider.Chunk, len(chunks))
+	for _, c := range chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch, nil
+}
+
+func (p *readinessE2EProvider) callCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+// TestReadinessGateDegradesEndToEnd exercises the whole real stack — boot.Build,
+// the Controller, the agent loop, the builtin write_file/todo_write, the evidence
+// ledger and the readiness gate — for #3664. A model that edits a file, marks the
+// step in_progress, then keeps answering without signing off must not loop or
+// abort: the turn degrades, the answer is delivered with a visible warning, and
+// the real write actually lands in the workspace.
+func TestReadinessGateDegradesEndToEnd(t *testing.T) {
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	prov := &readinessE2EProvider{}
+	installReadinessE2EProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[[providers]]
+name = "test-model"
+kind = "readiness-e2e-test"
+model = "x"
+`)
+
+	var mu sync.Mutex
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			mu.Lock()
+			notices = append(notices, e.Text)
+			mu.Unlock()
+		}
+	})
+
+	ctrl, err := Build(context.Background(), Options{Sink: sink, WorkspaceRoot: dir})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := ctrl.Run(ctx, "edit changed.go and report"); err != nil {
+		t.Fatalf("turn must degrade gracefully end-to-end, got error: %v", err)
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("turn did not terminate — possible deadloop: %v", ctx.Err())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "changed.go")); err != nil {
+		t.Fatalf("write_file did not run end-to-end: %v", err)
+	}
+	mu.Lock()
+	joined := strings.Join(notices, "\n")
+	mu.Unlock()
+	if !strings.Contains(joined, "proceeding without confirmed readiness") {
+		t.Fatalf("want a visible readiness-degrade warning (not silent, not an error); notices = %v", notices)
+	}
+	if c := prov.callCount(); c > 4 {
+		t.Fatalf("provider calls = %d, want bounded — the gate must cap the rounds", c)
+	}
+}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -304,6 +304,47 @@ func (l *Ledger) UnverifiedCompletedTodos(current []TodoItem) (missing []TodoSte
 	return missing, true
 }
 
+// CompletedTodosMissingReceipt returns the completed todos in the latest
+// successful todo_write that lack a matching successful complete_step receipt.
+// Enforcement moved here from todo_write (which now only warns), so this is the
+// single place that verifies a finished step was actually signed off with
+// evidence. Unlike UnverifiedCompletedTodos it does not skip earlier-completed
+// items: todo_write no longer rejects them, so "already completed" no longer
+// implies "already verified".
+func (l *Ledger) CompletedTodosMissingReceipt() (missing []TodoStepMatch, hasTodos bool) {
+	if l == nil {
+		return nil, false
+	}
+	l.mu.Lock()
+	receipts := append([]Receipt(nil), l.receipts...)
+	l.mu.Unlock()
+
+	var latest []TodoItem
+	for i := len(receipts) - 1; i >= 0; i-- {
+		r := receipts[i]
+		if !r.Success || r.ToolName != "todo_write" {
+			continue
+		}
+		latest = r.Todos
+		hasTodos = true
+		break
+	}
+	if !hasTodos {
+		return nil, false
+	}
+	for i, t := range latest {
+		if todoStatus(t.Status) != "completed" {
+			continue
+		}
+		index := i + 1
+		if hasSuccessfulCompleteStepForTodo(receipts, index, latest) {
+			continue
+		}
+		missing = append(missing, TodoStepMatch{Found: true, Index: index, Content: t.Content, Status: "completed", ActiveForm: t.ActiveForm})
+	}
+	return missing, true
+}
+
 func (l *Ledger) hasSuccessfulPaths(paths []string, accept func(Receipt) bool) bool {
 	wanted := pathSet(normalizePaths(paths))
 	if l == nil || len(wanted) == 0 {

--- a/internal/tool/builtin/todo.go
+++ b/internal/tool/builtin/todo.go
@@ -85,27 +85,32 @@ func (todoWrite) Execute(ctx context.Context, args json.RawMessage) (string, err
 			return "", fmt.Errorf("todo %d: invalid status %q (want pending|in_progress|completed)", i+1, t.Status)
 		}
 	}
-	if err := verifyTodoCompletionTransitions(ctx, p.Todos); err != nil {
-		return "", err
+	ack := fmt.Sprintf("Todos updated: %d total — %d completed, %d in progress, %d pending.",
+		len(p.Todos), done, active, pending)
+	if warn := unverifiedCompletionWarning(ctx, p.Todos); warn != "" {
+		ack += "\n" + warn
 	}
-	return fmt.Sprintf("Todos updated: %d total — %d completed, %d in progress, %d pending.",
-		len(p.Todos), done, active, pending), nil
+	return ack, nil
 }
 
-func verifyTodoCompletionTransitions(ctx context.Context, todos []todoItem) error {
+// unverifiedCompletionWarning flags todos flipped to completed without a matching
+// complete_step receipt. It is advisory, not blocking: todo_write only tracks
+// progress, so it must never fail the model mid-flow — the final-answer readiness
+// gate is the single enforcement point. The warning keeps the nudge immediate.
+func unverifiedCompletionWarning(ctx context.Context, todos []todoItem) string {
 	ledger, ok := evidence.FromContext(ctx)
 	if !ok {
-		return nil
+		return ""
 	}
 	missing, hasBaseline := ledger.UnverifiedCompletedTodos(toEvidenceTodos(todos))
 	if !hasBaseline || len(missing) == 0 {
-		return nil
+		return ""
 	}
 	if len(missing) == 1 {
 		m := missing[0]
-		return fmt.Errorf("todo %d %q is newly completed but has no matching successful complete_step receipt in this turn", m.Index, m.Content)
+		return fmt.Sprintf("⚠ todo %d %q is marked completed without a matching complete_step receipt; sign it off with complete_step before finishing.", m.Index, m.Content)
 	}
-	return fmt.Errorf("%d todos are newly completed but have no matching successful complete_step receipts in this turn", len(missing))
+	return fmt.Sprintf("⚠ %d todos are marked completed without matching complete_step receipts; sign each off with complete_step before finishing.", len(missing))
 }
 
 func toEvidenceTodos(todos []todoItem) []evidence.TodoItem {

--- a/internal/tool/builtin/todo_test.go
+++ b/internal/tool/builtin/todo_test.go
@@ -26,7 +26,7 @@ func TestTodoWriteRejectsBadLevel(t *testing.T) {
 	}
 }
 
-func TestTodoWriteRejectsNewCompletedWithoutCompleteStepReceipt(t *testing.T) {
+func TestTodoWriteWarnsOnNewCompletedWithoutCompleteStepReceipt(t *testing.T) {
 	ledger := evidence.NewLedger()
 	ledger.Record(evidence.Receipt{
 		ToolName: "todo_write",
@@ -36,9 +36,12 @@ func TestTodoWriteRejectsNewCompletedWithoutCompleteStepReceipt(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("new completion without complete_step should be rejected, got %v", err)
+	out, err := (todoWrite{}).Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("todo_write must not fail mid-flow; it only warns: %v", err)
+	}
+	if !strings.Contains(out, "complete_step") {
+		t.Fatalf("completion without complete_step should warn, got %q", out)
 	}
 }
 
@@ -78,8 +81,11 @@ func TestTodoWriteIgnoresFailedCompleteStepReceipt(t *testing.T) {
 	ctx := evidence.WithLedger(context.Background(), ledger)
 	args := json.RawMessage(`{"todos":[{"content":"Add parser","status":"completed"}]}`)
 
-	_, err := (todoWrite{}).Execute(ctx, args)
-	if err == nil || !strings.Contains(err.Error(), "complete_step") {
-		t.Fatalf("failed complete_step should not authorize new completion, got %v", err)
+	out, err := (todoWrite{}).Execute(ctx, args)
+	if err != nil {
+		t.Fatalf("todo_write must not fail mid-flow; it only warns: %v", err)
+	}
+	if !strings.Contains(out, "complete_step") {
+		t.Fatalf("a failed complete_step should still warn (not authorize) the completion, got %q", out)
 	}
 }


### PR DESCRIPTION
## Problem (#3664)
The final-answer readiness gate could trap weaker planner/executor models in a costly cycle: `todo_write` hard-rejected a completion lacking a `complete_step` receipt, so the model thrashed re-running compile/test, and after the retry budget the turn **hard-errored — discarding its work**. Users reported "several rounds of compile+test, then it dies".

## Approach
Follow how agent harnesses bound verification (LangChain `early_stopping`, Claude Code's loop-guarded Stop hook): **nudge, then degrade** — never trap or discard.

- `todo_write` no longer fails mid-flow; it only **warns** on an unsigned completion (progress tracking must not block).
- The completion-evidence guarantee **moves to the single final-answer readiness gate** (`CompletedTodosMissingReceipt`), enforced only once files were changed so no-write flows aren't gated.
- When the **same block reason recurs** (thrashing) or the retry budget is spent, the turn **accepts the answer with a visible `proceeding without confirmed readiness` warning** + an errored audit, instead of erroring and losing work.

## Test plan
- Unit/loop E2E (`internal/agent`): graceful degrade on repeated reason; the moved guarantee still caught; **unbounded-input bound check** (20 premature answers → still capped). Passing under `-count=10`, no hang.
- **Real end-to-end** (`internal/boot`): drives `boot.Build` → `Controller.Run` → agent loop → builtin `write_file`/`todo_write` → evidence ledger → readiness gate with a scripted provider that never signs off; asserts the turn degrades (no error, terminates within timeout), emits the warning, and the real write lands. Passing under `-count=10`.
- `internal/control` + `internal/cli` green; gofmt/vet clean.

Closes #3664