### PR TITLE
test: fix staticcheck SA5011 false-positive failing lint on all PRs

### DIFF
--- a/internal/control/shell_test.go
+++ b/internal/control/shell_test.go
@@ -135,8 +135,7 @@ func TestRunShell_FailingCommand(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("expected a ToolResult event")
-	}
-	if result.Tool.Err == "" {
+	} else if result.Tool.Err == "" {
 		t.Error("failing command should produce an error string")
 	}
 }

--- a/internal/provider/anthropic/anthropic_test.go
+++ b/internal/provider/anthropic/anthropic_test.go
@@ -186,16 +186,14 @@ func TestReadStream(t *testing.T) {
 	if full == nil || full.Arguments != `{"city":"Paris"}` {
 		t.Fatalf("tool full = %+v", full)
 	}
-	if usage == nil {
+	switch {
+	case usage == nil:
 		t.Fatal("expected a usage chunk")
-	}
-	if usage.PromptTokens != 150 || usage.CompletionTokens != 25 || usage.TotalTokens != 175 {
+	case usage.PromptTokens != 150 || usage.CompletionTokens != 25 || usage.TotalTokens != 175:
 		t.Fatalf("usage tokens = %+v", usage)
-	}
-	if usage.CacheHitTokens != 50 || usage.CacheMissTokens != 100 {
+	case usage.CacheHitTokens != 50 || usage.CacheMissTokens != 100:
 		t.Fatalf("usage cache = hit %d miss %d", usage.CacheHitTokens, usage.CacheMissTokens)
-	}
-	if usage.FinishReason != "tool_calls" {
+	case usage.FinishReason != "tool_calls":
 		t.Fatalf("finish reason = %q", usage.FinishReason)
 	}
 	if !done {


### PR DESCRIPTION
## What broke
Since the Dependabot cluster landed (~11:51 today), **lint fails on main-v2's PRs and every open PR** with `staticcheck SA5011` (possible nil pointer dereference):

```
internal/control/shell_test.go:136/139
internal/provider/anthropic/anthropic_test.go:189/192
```

Both sites are correctly guarded (`if x == nil { t.Fatal(...) }` then deref).

## Root cause
The **release golangci-lint v2.12.2 binary** that CI runs flags SA5011 on these guarded derefs — a staticcheck quirk in that prebuilt binary. The finding was **masked by the golangci-lint-action cache** until #3678 changed `go.sum` and invalidated it, after which it surfaced on main-v2 and every PR. A locally-built golangci-lint v2.12.2 (whole module, `GOOS=linux`, fresh GOCACHE + lint cache) does **not** reproduce it, so this is not a real defect.

> The golangci-lint-action `v7→v9` bump in #3688 is **not** the cause — v7 fails identically once the cache is cold.

## Fix
Restructure both sites with flow-based guards (`else if` / `switch`) that staticcheck always respects. No behaviour change (both were fatal — first failure stops the test) and no unreachable `return` (which a Fatal-aware analyzer would flag locally). Source/action versions untouched.

## Note
Each PR runs ci.yml from its own branch, so open PRs only need a rebase onto this once merged to go green — they don't carry these test files' fix until then. (The two files are unrelated to most PRs' changes.)