### PR TITLE
fix(desktop): 为更新错误横幅添加关闭按钮

### DIFF
--- a/desktop/frontend/src/components/UpdateBanner.tsx
+++ b/desktop/frontend/src/components/UpdateBanner.tsx
@@ -70,7 +70,7 @@ export function UpdateBanner({ enabled = true }: { enabled?: boolean }) {
           <button className="btn btn--small btn--primary" onClick={() => void check()}>
             {t("updater.retry")}
           </button>
-          <button className="btn btn--small" onClick={reset}>
+          <button className="btn btn--small" onClick={() => void reset()}>
             {t("updater.dismiss")}
           </button>
         </div>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1927,6 +1927,9 @@ a[href] {
   font-size: var(--font-control-small);
 }
 .banner--error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   background: var(--del-bg);
   color: var(--err);
   border-bottom: 1px solid var(--border-soft);


### PR DESCRIPTION
## 问题描述

当桌面应用启动时如果没有网络连接，自动更新检查会失败并显示错误横幅。该横幅**无法关闭**——只有"重试"按钮，没有关闭/取消选项。横幅会持续显示在所有标签页和会话中，直到网络连接恢复。

## 复现步骤

1. 断开网络（或屏蔽 GitHub 访问）
2. 启动 Reasonix 桌面应用
3. 更新检查失败，显示错误横幅
4. 无法关闭横幅

## 修复方案

在 `UpdateBanner` 组件的 `error` case 中添加 dismiss 按钮，使用已有的 `reset()` 函数将状态重置为 idle。与 `available` case 中的关闭按钮行为一致。

## 改动

- `desktop/frontend/src/components/UpdateBanner.tsx`：解构时加入 `reset`，在 Retry 按钮后添加 dismiss 按钮

Fixes #3699
<img width="1511" height="183" alt="image" src="https://github.com/user-attachments/assets/bc8df925-b72b-48ff-a218-054cdfcb8911" />
