### PR TITLE
fix(agent): stop bypassing ask tool in YOLO mode

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -858,17 +858,11 @@ func (c *Controller) EnableInteractiveApproval() {
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.
+// Unlike tool-approval gates, Ask is NOT bypassed in YOLO mode — the ask
+// tool exists to get a user decision, and YOLO only skips tool approvals.
 func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
-	if c.bypassEnabled() {
-		return recommendedAskAnswers(questions), nil
-	}
-
 	c.promptMu.Lock()
 	defer c.promptMu.Unlock()
-
-	if c.bypassEnabled() {
-		return recommendedAskAnswers(questions), nil
-	}
 
 	c.mu.Lock()
 	c.nextID++
@@ -894,17 +888,6 @@ func (c *Controller) bypassEnabled() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.bypass
-}
-
-func recommendedAskAnswers(questions []event.AskQuestion) []event.AskAnswer {
-	out := make([]event.AskAnswer, len(questions))
-	for i, q := range questions {
-		out[i] = event.AskAnswer{QuestionID: q.ID}
-		if len(q.Options) > 0 {
-			out[i].Selected = []string{q.Options[0].Label}
-		}
-	}
-	return out
 }
 
 // AnswerQuestion resolves a pending AskRequest by ID with the user's selections.


### PR DESCRIPTION
## Bug

In YOLO mode, when the agent calls the `ask` tool to get a user decision, no prompt UI appears and the agent receives a fake answer (the first option is automatically selected). This defeats the purpose of the `ask` tool, which exists specifically for cases where the model needs genuine user input.

## Root Cause

`Controller.Ask()` (which implements `agent.Asker`) checked `bypassEnabled()` before emitting the `AskRequest` event:

```go
func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
    if c.bypassEnabled() {
        return recommendedAskAnswers(questions), nil  // ← silently picks first option
    }
    // ... normal flow: emit AskRequest, block for user ...
}
```

The same check appeared twice — once before `promptMu.Lock()` and once after — both returning `recommendedAskAnswers()` which always selects `q.Options[0].Label`.

## Logic Error

YOLO mode (`c.bypass = true`) was designed to **skip tool-approval gates** (the `requestApproval()` method), allowing autonomous execution without manual approval of each tool call. The `ask` tool is semantically different:

| Operation | YOLO mode expected behavior | Previous behavior |
|---|---|---|
| Tool call approval (`requestApproval`) | ✅ Auto-allow (skip prompt) | ✅ Correct |
| `ask` tool (user decision) | ✅ Show prompt, wait for real input | ❌ Silently returned first option |

The `ask` tool exists precisely for cases where the model cannot decide on its own — treating it the same as a tool approval gate undermines its purpose.

## Fix

Removed both `bypassEnabled()` checks from `Controller.Ask()`, so the `ask` tool always emits an `AskRequest` event and waits for the user to respond, regardless of mode.

Also removed the now-unused `recommendedAskAnswers()` helper function.

## Testing

- `go build ./internal/...` — clean
- `go test ./internal/agent/ -run TestAsk` — all 4 ask tool tests pass
- Manual verification: YOLO mode now shows the ask prompt UI and waits for user input

Fixes #3696