### PR TITLE
fix(desktop): stop auto-populating empty model lists from provider API

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -759,6 +759,10 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
 
     void backgroundApply(async () => {
       for (const { provider } of candidates) {
+        // Background auto-refresh only protects a user-curated model list.
+        // If the user hasn't specified any models, don't silently populate
+        // the provider with every model from the API.
+        if (!provider.models || provider.models.length === 0) continue;
         try {
           const fetched = await app.FetchProviderModels(provider);
           if (fetched.length === 0) continue;


### PR DESCRIPTION
## Summary / 摘要

**EN:** Background auto-refresh calls `FetchProviderModels` for every configured provider and merges the result via `mergedFetchedProviderModels()`. When the user left the models list empty (common for custom providers), `preserveCurated: true` had no effect because `saved.length === 0`, causing every model from the API to be written into the config and polluting the model dropdown.

Now the background refresh skips providers whose models list is empty, preventing silent pollution of the model dropdown. Users can still manually fetch models via the "Refresh Models" button.

**CN:** 后台自动刷新会对每个配置了 API key 的 provider 调用 `FetchProviderModels`，然后将结果通过 `mergedFetchedProviderModels()` 合并到配置中。当用户未填写具体模型列表时（自定义 provider 的常见做法），`preserveCurated: true` 的保护条件因 `saved.length === 0` 而不生效，导致所有 API 返回的模型被写入配置，污染模型下拉框。

现在后台刷新会跳过模型列表为空的 provider，防止静默污染。用户仍然可以通过"刷新模型"按钮手动获取可用模型。

## Root Cause

In `SettingsPanel.tsx` background auto-refresh (line 760-773):

\`\`\`typescript
const models = mergedFetchedProviderModels(provider.models, fetched, { preserveCurated: true });
\`\`\`

In `mergedFetchedProviderModels()` (\`providerModels.ts:1-5\`):

\`\`\`typescript
if (options.preserveCurated && saved.length > 0) return saved;
return uniqueStrings([...saved, ...fetched]);
\`\`\`

When \`saved.length === 0\` (user never filled in models), \`preserveCurated\` is a no-op and every API model enters the config.

## Fix

Added early skip at the start of the auto-refresh loop:

\`\`\`typescript
if (!provider.models || provider.models.length === 0) continue;
\`\`\`

## Testing

- \`npx tsc --noEmit\` — clean
- \`pnpm build\` — clean
- Manual: empty model list no longer triggers auto-refresh write

Fixes #3705