### PR TITLE
fix(control): don't auto-answer the ask tool in YOLO mode (#3624)

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -885,12 +885,6 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	}
 }
 
-func (c *Controller) bypassEnabled() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.bypass
-}
-
 // AnswerQuestion resolves a pending AskRequest by ID with the user's selections.
 // Unknown/expired IDs are ignored.
 func (c *Controller) AnswerQuestion(id string, answers []event.AskAnswer) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -858,17 +858,12 @@ func (c *Controller) EnableInteractiveApproval() {
 // Ask implements agent.Asker: it emits an AskRequest and blocks until
 // AnswerQuestion(ID, …) answers or ctx is cancelled. promptMu serialises it
 // against tool-approval prompts so at most one user prompt is outstanding.
+// Unlike tool-approval gates, Ask is NOT bypassed in YOLO mode — the `ask`
+// tool exists to get a genuine user decision, and YOLO only auto-approves
+// tool calls; it must not answer the user's questions for them.
 func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
-	if c.bypassEnabled() {
-		return recommendedAskAnswers(questions), nil
-	}
-
 	c.promptMu.Lock()
 	defer c.promptMu.Unlock()
-
-	if c.bypassEnabled() {
-		return recommendedAskAnswers(questions), nil
-	}
 
 	c.mu.Lock()
 	c.nextID++
@@ -894,17 +889,6 @@ func (c *Controller) bypassEnabled() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.bypass
-}
-
-func recommendedAskAnswers(questions []event.AskQuestion) []event.AskAnswer {
-	out := make([]event.AskAnswer, len(questions))
-	for i, q := range questions {
-		out[i] = event.AskAnswer{QuestionID: q.ID}
-		if len(q.Options) > 0 {
-			out[i].Selected = []string{q.Options[0].Label}
-		}
-	}
-	return out
 }
 
 // AnswerQuestion resolves a pending AskRequest by ID with the user's selections.

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -3,7 +3,6 @@ package control
 import (
 	"context"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -184,18 +183,18 @@ func TestSetModeAppliesBothGates(t *testing.T) {
 	}
 }
 
-func TestBypassAutoAnswersAskWithRecommendedOptions(t *testing.T) {
-	var askRequested bool
+func TestBypassDoesNotAutoAnswerAsk(t *testing.T) {
+	askCh := make(chan event.Ask, 1)
 	c := New(Options{
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.AskRequest {
-				askRequested = true
+				askCh <- e.Ask
 			}
 		}),
 	})
 	c.SetBypass(true)
 
-	answers, err := c.Ask(context.Background(), []event.AskQuestion{
+	questions := []event.AskQuestion{
 		{
 			ID:     "approach",
 			Header: "Approach",
@@ -215,33 +214,69 @@ func TestBypassAutoAnswersAskWithRecommendedOptions(t *testing.T) {
 			},
 			Multi: true,
 		},
+	}
+
+	done := make(chan struct {
+		answers []event.AskAnswer
+		err     error
+	}, 1)
+	go func() {
+		answers, err := c.Ask(context.Background(), questions)
+		done <- struct {
+			answers []event.AskAnswer
+			err     error
+		}{answers, err}
+	}()
+
+	// Even with bypass on, Ask must emit an AskRequest and wait for the user.
+	var ask event.Ask
+	select {
+	case ask = <-askCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask did not emit AskRequest under bypass; bypass should not auto-answer ask")
+	}
+
+	// Answer with NON-recommended options to prove the user was consulted.
+	c.AnswerQuestion(ask.ID, []event.AskAnswer{
+		{QuestionID: "approach", Selected: []string{"Alternative path"}},
+		{QuestionID: "scope", Selected: []string{"Broad"}},
 	})
-	if err != nil {
-		t.Fatalf("Ask: %v", err)
+
+	var result struct {
+		answers []event.AskAnswer
+		err     error
 	}
-	if askRequested {
-		t.Fatal("bypass must not emit an AskRequest event")
+	select {
+	case result = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask stayed blocked after AnswerQuestion")
 	}
-	want := []event.AskAnswer{
-		{QuestionID: "approach", Selected: []string{"Recommended path"}},
-		{QuestionID: "scope", Selected: []string{"Minimal"}},
+	if result.err != nil {
+		t.Fatalf("Ask: %v", result.err)
 	}
-	if len(answers) != len(want) {
-		t.Fatalf("answers len = %d, want %d: %#v", len(answers), len(want), answers)
+
+	wantAnswers := []event.AskAnswer{
+		{QuestionID: "approach", Selected: []string{"Alternative path"}},
+		{QuestionID: "scope", Selected: []string{"Broad"}},
 	}
-	for i := range want {
-		if answers[i].QuestionID != want[i].QuestionID || len(answers[i].Selected) != 1 || answers[i].Selected[0] != want[i].Selected[0] {
-			t.Fatalf("answers[%d] = %#v, want %#v", i, answers[i], want[i])
+	if len(result.answers) != len(wantAnswers) {
+		t.Fatalf("answers len = %d, want %d: %#v", len(result.answers), len(wantAnswers), result.answers)
+	}
+	for i := range wantAnswers {
+		if result.answers[i].QuestionID != wantAnswers[i].QuestionID ||
+			len(result.answers[i].Selected) != 1 ||
+			result.answers[i].Selected[0] != wantAnswers[i].Selected[0] {
+			t.Fatalf("answers[%d] = %#v, want %#v", i, result.answers[i], wantAnswers[i])
 		}
 	}
 }
 
-func TestBypassRecheckedForAskAfterPromptLock(t *testing.T) {
-	askRequests := make(chan struct{}, 1)
+func TestAskSerializesBehindPromptLockEvenWithBypass(t *testing.T) {
+	askCh := make(chan event.Ask, 1)
 	c := New(Options{
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.AskRequest {
-				askRequests <- struct{}{}
+				askCh <- e.Ask
 			}
 		}),
 	})
@@ -256,12 +291,9 @@ func TestBypassRecheckedForAskAfterPromptLock(t *testing.T) {
 	}}
 
 	c.promptMu.Lock()
-	started := make(chan struct{})
 	done := make(chan []event.AskAnswer, 1)
 	errs := make(chan error, 1)
-	var once sync.Once
 	go func() {
-		once.Do(func() { close(started) })
 		answers, err := c.Ask(context.Background(), questions)
 		if err != nil {
 			errs <- err
@@ -269,26 +301,42 @@ func TestBypassRecheckedForAskAfterPromptLock(t *testing.T) {
 		}
 		done <- answers
 	}()
-	<-started
+	// Give the goroutine time to block on promptMu.
 	time.Sleep(20 * time.Millisecond)
 
-	c.SetBypass(true)
-	c.promptMu.Unlock()
-
+	// Pre-unlock assertion: while promptMu is still held, Ask must NOT have
+	// emitted AskRequest — proving it truly serialized behind the lock.
 	select {
-	case err := <-errs:
-		t.Fatalf("Ask: %v", err)
-	case answers := <-done:
-		if len(answers) != 1 || answers[0].QuestionID != "q1" || len(answers[0].Selected) != 1 || answers[0].Selected[0] != "Recommended" {
-			t.Fatalf("answers = %#v, want recommended option", answers)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Ask stayed blocked after bypass turned on while queued behind promptMu")
+	case <-askCh:
+		t.Fatal("Ask emitted AskRequest before acquiring promptMu; it did not serialize behind the lock")
+	default:
 	}
 
+	// Enable bypass while Ask is queued behind promptMu.
+	c.SetBypass(true)
+	// Release the lock — Ask proceeds but must still emit an AskRequest.
+	c.promptMu.Unlock()
+
+	// Post-unlock assertion: Ask must emit AskRequest now that it holds the lock.
+	var ask event.Ask
 	select {
-	case <-askRequests:
-		t.Fatal("bypass must not emit AskRequest after acquiring promptMu")
-	default:
+	case ask = <-askCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask did not emit AskRequest after acquiring promptMu with bypass on; bypass should not suppress ask")
+	}
+
+	// Answer and verify we get the user's choice.
+	c.AnswerQuestion(ask.ID, []event.AskAnswer{
+		{QuestionID: "q1", Selected: []string{"Alternative"}},
+	})
+
+	var answers []event.AskAnswer
+	select {
+	case answers = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Ask stayed blocked after AnswerQuestion")
+	}
+	if len(answers) != 1 || answers[0].QuestionID != "q1" || len(answers[0].Selected) != 1 || answers[0].Selected[0] != "Alternative" {
+		t.Fatalf("answers = %#v, want Alternative (user's choice, not auto-recommended)", answers)
 	}
 }


### PR DESCRIPTION
## Bug (#3624)
In YOLO/bypass mode, when the agent calls the `ask` tool to get a user decision, no prompt appears and the agent silently receives the first option. Bypass is meant to skip **tool-approval** gates, not to answer the user's genuine questions — so `ask` was being defeated.

## Fix
`Controller.Ask` removed both `bypassEnabled()` short-circuits (and the now-unused `recommendedAskAnswers` helper). Ask always emits an `AskRequest` and waits for `AnswerQuestion`, even under bypass.

## Provenance — combining the two open PRs for this issue
Two PRs targeted #3624; neither was mergeable alone:
- **#3709** (@CVEngineer66): the correct, minimal controller.go fix — but it didn't update the existing tests, so CI went red (the old tests asserted the auto-answer behavior and `Ask` now blocks).
- **#3638** (@warvyvr): the same fix **plus** the updated behavior tests (green CI) — but it also committed unrelated files (`wow.md`, `README.md`, `.gitignore`).

This PR takes #3709's clean fix and #3638's behavior tests (`TestBypassDoesNotAutoAnswerAsk`, `TestAskSerializesBehindPromptLockEvenWithBypass`), dropping the stray files. Credit to both authors via Co-authored-by.

## Test plan
- `go test ./internal/control` green; both new tests pass; gofmt/vet clean.