### PR TITLE
fix(config): honor an explicit proxy for no_proxy providers like mimo (#3635)

### DIFF
--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -21,8 +21,7 @@ func TestBackfillDeepSeekProRestoresPro(t *testing.T) {
 	pro := hasModel(c, "deepseek-v4-pro")
 	if pro == nil {
 		t.Fatal("deepseek-v4-pro not restored")
-	}
-	if pro.Price == nil || pro.Price.Output != 6 {
+	} else if pro.Price == nil || pro.Price.Output != 6 {
 		t.Errorf("pro price not the preset: %+v", pro.Price)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,7 +271,17 @@ func (c *Config) NetworkProxySpec() netclient.ProxySpec {
 
 // directProxyHosts collects the base_url hosts of providers marked no_proxy, so
 // netclient bypasses the proxy for them without knowing any provider by name.
+//
+// Only for an auto-detected proxy (auto/env): that proxy is typically a
+// GFW-circumvention one not meant for domestic endpoints (e.g. mimo), so keep
+// them direct. An explicit proxy_mode = "custom" is the user saying "route
+// everything through this" — e.g. a mandatory corporate proxy — so honor it for
+// every provider; a custom-proxy user who wants a host direct uses
+// network.no_proxy instead (#3635).
 func (c *Config) directProxyHosts() []string {
+	if c.NetworkProxyMode() == netclient.ModeCustom {
+		return nil
+	}
 	seen := map[string]bool{}
 	var out []string
 	for _, p := range c.Providers {

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -47,8 +47,7 @@ func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
 	}
 	if res == nil {
 		t.Fatal("expected a migration result")
-	}
-	if !res.KeyToEnv || res.Plugins != 2 {
+	} else if !res.KeyToEnv || res.Plugins != 2 {
 		t.Errorf("result = %+v, want KeyToEnv=true Plugins=2", res)
 	}
 

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -17,3 +17,17 @@ func TestDirectProxyHostsFromNoProxyProviders(t *testing.T) {
 		t.Errorf("a no_proxy provider's host should land in DirectHosts, got %v", spec.DirectHosts)
 	}
 }
+
+func TestExplicitProxyOverridesProviderNoProxy(t *testing.T) {
+	// An explicit custom proxy (e.g. a mandatory corporate proxy) must apply to
+	// every provider, including no_proxy ones like mimo, so it isn't unreachable
+	// behind the proxy (#3635).
+	c := Default()
+	c.Network.ProxyMode = "custom"
+	spec := c.NetworkProxySpec()
+	for _, h := range spec.DirectHosts {
+		if h == "token-plan-cn.xiaomimimo.com" {
+			t.Fatalf("custom proxy must not force mimo direct; DirectHosts = %v", spec.DirectHosts)
+		}
+	}
+}


### PR DESCRIPTION
## Bug (#3635)
On an enterprise network where all egress must go through a corporate proxy, the `mimo` models are unreachable. Root cause (`config.go:directProxyHosts`): the built-in mimo presets set `no_proxy=true`, whose host (`token-plan-cn.xiaomimimo.com`) is added to the proxy's `DirectHosts` and **always** bypasses the proxy — so behind a mandatory proxy, mimo attempts a direct connection the firewall blocks.

`no_proxy=true` is right for an **auto-detected** system proxy (typically a GFW-circumvention proxy not meant for domestic endpoints), but wrong for an **explicitly configured** one.

## Fix
Apply the provider-level `no_proxy` bypass only for `auto`/`env` proxy modes. When `proxy_mode = "custom"` the user is saying "route everything through this proxy", so honor it for every provider (including mimo). A custom-proxy user who still wants a specific host direct uses `network.no_proxy` (which is honored for custom proxies).

## Test plan
- `internal/config`: existing `TestDirectProxyHostsFromNoProxyProviders` still passes (auto mode keeps mimo direct); new `TestExplicitProxyOverridesProviderNoProxy` asserts custom mode does NOT force mimo direct.
- `go test ./internal/config` green; vet + golangci-lint (0 issues) + gofmt clean.

Closes #3635