### PR TITLE
ci: suppress staticcheck SA5011 false positives in test files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,15 @@ linters:
       - path: _test\.go
         linters:
           - errcheck
+      # The pinned golangci-lint binary's staticcheck reports SA5011 false
+      # positives on `if x == nil { t.Fatal(...) }`-guarded derefs in tests (it
+      # doesn't treat t.Fatal as terminating); the same code is clean under a
+      # locally-built golangci-lint. Scope the suppression to tests so SA5011
+      # still guards production code.
+      - path: _test\.go
+        linters:
+          - staticcheck
+        text: SA5011
 
 issues:
   max-issues-per-linter: 0


### PR DESCRIPTION
## Why
The pinned golangci-lint binary CI runs reports `SA5011` (possible nil pointer dereference) on correct `if x == nil { t.Fatal(...) }`-guarded derefs in **test** files — its staticcheck doesn't treat `t.Fatal` as terminating. A locally-built golangci-lint (same v2.12.2) reports 0 issues on the same code, and the finding is masked by the golangci-lint-action cache until a `go.sum` change cold-busts it — so it surfaces **per package** and has repeatedly failed lint on otherwise-correct PRs (patched ad hoc in #3706 and #3714, with more packages still to hit).

## Fix
Add a test-only exclusion for SA5011 in `.golangci.yml`. SA5011 still runs on production code; only `_test.go` guarded-deref false positives are suppressed. This stops the whack-a-mole instead of guarding each new test site by hand.

## Verification
- `golangci-lint config verify` passes (v2.12.2, the CI version).
- `golangci-lint run` clean locally.