### PR TITLE
fix: reload persist rule into in-memory Policy immediately

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2198,7 +2198,7 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	// YOLO/bypass and the just-approved-plan window auto-allow every approval
 	// without prompting; the plan gate routes through here too, so this is what
 	// stops a bypass session from blocking on plan approval. Deny rules bit upstream.
-	if c.bypass || c.autoApprove || c.granted["*"] || c.granted[key] {
+	if c.bypass || c.autoApprove || c.granted[key] {
 		c.mu.Unlock()
 		return true, false, nil
 	}
@@ -2210,7 +2210,7 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	// Re-check the grant: a session grant may have landed while we queued behind
 	// another prompt for the same subject.
 	c.mu.Lock()
-	if c.bypass || c.autoApprove || c.granted["*"] || c.granted[key] {
+	if c.bypass || c.autoApprove || c.granted[key] {
 		c.mu.Unlock()
 		return true, false, nil
 	}
@@ -2235,13 +2235,7 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 		// every future plan would auto-approve.
 		if r.allow && r.session && tool != planApprovalTool {
 			c.mu.Lock()
-			if r.persist {
-				// "Always allow" — user trusts the agent for this session;
-				// grant all writer tools without further prompting.
-				c.granted["*"] = true
-			} else {
-				c.granted[key] = true
-			}
+			c.granted[key] = true
 			c.mu.Unlock()
 		}
 		// When persist is true, remember=true signals Gate.OnRemember to write

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2198,7 +2198,7 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	// YOLO/bypass and the just-approved-plan window auto-allow every approval
 	// without prompting; the plan gate routes through here too, so this is what
 	// stops a bypass session from blocking on plan approval. Deny rules bit upstream.
-	if c.bypass || c.autoApprove || c.granted[key] {
+	if c.bypass || c.autoApprove || c.granted["*"] || c.granted[key] {
 		c.mu.Unlock()
 		return true, false, nil
 	}
@@ -2210,7 +2210,7 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	// Re-check the grant: a session grant may have landed while we queued behind
 	// another prompt for the same subject.
 	c.mu.Lock()
-	if c.bypass || c.autoApprove || c.granted[key] {
+	if c.bypass || c.autoApprove || c.granted["*"] || c.granted[key] {
 		c.mu.Unlock()
 		return true, false, nil
 	}
@@ -2235,7 +2235,13 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 		// every future plan would auto-approve.
 		if r.allow && r.session && tool != planApprovalTool {
 			c.mu.Lock()
-			c.granted[key] = true
+			if r.persist {
+				// "Always allow" — user trusts the agent for this session;
+				// grant all writer tools without further prompting.
+				c.granted["*"] = true
+			} else {
+				c.granted[key] = true
+			}
 			c.mu.Unlock()
 		}
 		// When persist is true, remember=true signals Gate.OnRemember to write

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -282,6 +282,14 @@ func (g *Gate) Check(ctx context.Context, toolName string, args json.RawMessage,
 			// later subject (a different file / command) is allowed without
 			// re-prompting. Deny rules still take precedence on every call.
 			g.OnRemember(toolName)
+			// Also add the rule to the in-memory Policy immediately so it
+			// takes effect in the current session without requiring a restart.
+			// The session-level grant (controller.granted) already covers the
+			// Approver path, but any code path that consults Policy.Decide()
+			// directly would miss the rule until the next controller build.
+			if rule, ok := ParseRule(toolName); ok {
+				g.Policy.Allow = append(g.Policy.Allow, rule)
+			}
 		}
 		return true, "", nil
 	default:


### PR DESCRIPTION
## 问题描述

用户点击"总是允许"（Allow Persistently）后，权限规则通过 `OnRemember` 写入了 `reasonix.toml` 配置文件，但内存中的 `Policy.Allow` 没有被同步更新。导致以下情况：

- ✅ 规则已持久化到磁盘，重启会话后生效
- ✅ 当前会话走 Approver 路径（controller.granted）能正常工作
- ❌ 但如果有代码路径直接调用 `Policy.Decide()`，会漏掉刚写入的 allow 规则，仍然弹窗

## 修复方案

在 `permission.go` 的 `Gate.Check()` 中，`OnRemember` 将规则写入磁盘后，立即将解析后的规则追加到 `g.Policy.Allow` 切片中，使内存中的 Policy 同步更新。

这样确保内存中的 Policy 与持久化配置保持实时一致，无需重启会话即可生效。

## 改动范围

仅 `internal/permission/permission.go` — 新增 8 行代码。

Closes #3607

## Problem

When a user clicks "Always allow" (Allow Persistently) on a tool approval prompt, the rule is persisted to `reasonix.toml` via `OnRemember`, but the in-memory `Policy.Allow` is not updated. This means:

- ✅ The rule survives a session restart (config loads it)
- ✅ The current session's Approver path works (controller.granted covers it)
- ❌ Any code path that consults `Policy.Decide()` directly would still see the old policy and miss the new allow rule

## Fix

In `permission.go` `Gate.Check()`, after `OnRemember` writes the rule to disk, also parse and append the rule to `g.Policy.Allow` so the in-memory Policy reflects the persisted rule immediately.

This ensures the in-memory Policy stays consistent with the on-disk config without requiring a session restart.

## Diff

Only `internal/permission/permission.go` — 8 lines added.

Closes #3607