### PR TITLE
fix(desktop): keep Windows tray loop on locked thread

### DIFF
--- a/desktop/tray_loop_windows.go
+++ b/desktop/tray_loop_windows.go
@@ -2,9 +2,21 @@
 
 package main
 
-import "fyne.io/systray"
+import (
+	"runtime"
+
+	"fyne.io/systray"
+)
 
 func startDesktopTray(onReady, onExit func()) func() {
-	go systray.Run(onReady, onExit)
+	go runDesktopTrayLoop(func() {
+		systray.Run(onReady, onExit)
+	})
 	return systray.Quit
+}
+
+func runDesktopTrayLoop(run func()) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	run()
 }

--- a/desktop/tray_loop_windows_test.go
+++ b/desktop/tray_loop_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+func TestDesktopTrayLoopRunsOnLockedOSThread(t *testing.T) {
+	done := make(chan struct{})
+	runDesktopTrayLoop(func() {
+		first := windows.GetCurrentThreadId()
+		for i := 0; i < 100; i++ {
+			runtime.Gosched()
+		}
+		if got := windows.GetCurrentThreadId(); got != first {
+			t.Fatalf("tray loop moved OS threads: first=%d got=%d", first, got)
+		}
+		close(done)
+	})
+
+	select {
+	case <-done:
+	default:
+		t.Fatal("tray loop did not run")
+	}
+}


### PR DESCRIPTION
## What

Keep the Windows systray event loop on a locked OS thread.

Fixes #3516.

Also addresses the tray right-click/menu responsiveness symptoms reported in #3394 and the tray portion of #3548. The MCP orphan-process note in #3548 is a separate issue and is intentionally out of scope for this PR.

## Why

We caught a live repro on Windows with desktop v1.4.0 where the tray icon stopped responding to right click while the app was hidden:

- `reasonix-desktop.exe` was still alive and `Responding=True`.
- The main Wails window was hidden but not hung.
- The systray hidden window (`SystrayClass`) still existed but `IsHungAppWindow(SystrayClass) == true`.
- The Wails window (`wailsWindow`) reported `IsHungAppWindow(...) == false`.

That points to the systray Win32 message loop becoming stuck independently of the main Wails window. `fyne.io/systray` relies on Win32 hidden-window messages on Windows, so the tray loop should stay pinned to one OS thread.

## How

- Wrap the Windows systray loop in a helper that calls `runtime.LockOSThread()` before `systray.Run(...)`.
- Add a Windows-only regression test that verifies the helper does not move OS threads across scheduler yields.

## Testing

- `go test . -run 'TestDesktopTrayLoopRunsOnLockedOSThread|TestTrayMenuLabelsFollowLocale|TestBeforeCloseAllowsSystemQuitWhenBackgroundCloseEnabled' -count=1`
- `wails build`
- Windows manual test passed locally: launch the built desktop app, enable close-to-tray/background behavior, close to tray, repeatedly use the tray right-click menu, and confirm Open/Quit remain responsive.
