### PR TITLE
fix(security): resolve open code-scanning alerts (archive extraction, command injection, untrusted checkout, integer bounds)

### DIFF
--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -25,6 +25,11 @@ jobs:
       contains(github.event.comment.body, '/e2e') &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    # Running PR-head code with the provider secret is gated twice: the author_
+    # association check above, and this deployment environment. Configure the
+    # `e2e-bot` environment with required reviewers in repo settings to force a
+    # human approval per run (actions/untrusted-checkout-toctou).
+    environment: e2e-bot
     steps:
       - name: Acknowledge
         uses: actions/github-script@v9
@@ -62,7 +67,13 @@ jobs:
       - name: Check out the PR head
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr checkout ${{ github.event.issue.number }}
+        # Pin to the head commit resolved now and check it out detached, not the
+        # mutable PR ref: a force-push mid-run can't swap in different code after
+        # the trusted-author gate passed.
+        run: |
+          SHA=$(gh pr view ${{ github.event.issue.number }} --json headRefOid -q .headRefOid)
+          git fetch -q origin "$SHA"
+          git checkout -q --detach "$SHA"
 
       - name: Build the agent from the PR head
         # The whole point of the bot is to drive the PR's code, not main-v2's. Fall

--- a/internal/cli/theme.go
+++ b/internal/cli/theme.go
@@ -252,7 +252,7 @@ func parseOSC11Response(s string) (terminalRGB, bool) {
 	payload = strings.TrimSpace(payload)
 	if strings.HasPrefix(payload, "#") {
 		r, g, b, ok := parseHexColor(payload)
-		return terminalRGB{int(r), int(g), int(b)}, ok
+		return terminalRGB{r, g, b}, ok
 	}
 	for _, prefix := range []string{"rgb:", "rgba:"} {
 		if strings.HasPrefix(payload, prefix) {
@@ -318,15 +318,15 @@ func bgSGR(c cliColor) string {
 	return fmt.Sprintf("\033[48;5;%dm", c.xterm)
 }
 
-func parseHexColor(hex string) (int64, int64, int64, bool) {
+func parseHexColor(hex string) (int, int, int, bool) {
 	hex = strings.TrimPrefix(hex, "#")
 	if len(hex) != 6 {
 		return 0, 0, 0, false
 	}
-	r, errR := strconv.ParseInt(hex[0:2], 16, 64)
-	g, errG := strconv.ParseInt(hex[2:4], 16, 64)
-	b, errB := strconv.ParseInt(hex[4:6], 16, 64)
-	return r, g, b, errR == nil && errG == nil && errB == nil
+	r, errR := strconv.ParseUint(hex[0:2], 16, 8)
+	g, errG := strconv.ParseUint(hex[2:4], 16, 8)
+	b, errB := strconv.ParseUint(hex[4:6], 16, 8)
+	return int(r), int(g), int(b), errR == nil && errG == nil && errB == nil
 }
 
 func supportsTrueColor() bool {

--- a/internal/codegraph/install.go
+++ b/internal/codegraph/install.go
@@ -258,27 +258,42 @@ func sha256For(sums, name string) (string, error) {
 	return "", fmt.Errorf("codegraph: %s not listed in SHA256SUMS", name)
 }
 
-// safeJoin joins dir and a (possibly hostile) archive entry name, rejecting any
-// path that would escape dir — the zip-slip / tar-slip guard.
-func safeJoin(dir, name string) (string, error) {
-	p := filepath.Join(dir, name)
-	if p != dir && !strings.HasPrefix(p, dir+string(os.PathSeparator)) {
+// resolveWithin returns the real path to write archive entry name under root
+// (parents created), rejecting escapes. EvalSymlinks on the parent also catches
+// the symlink-redirect variant a lexical "../" check misses: a parent component
+// an earlier entry turned into a symlink, written *through* to land outside root.
+func resolveWithin(root, name string) (string, error) {
+	target := filepath.Join(root, name)
+	if target != root && !strings.HasPrefix(target, root+string(os.PathSeparator)) {
 		return "", fmt.Errorf("unsafe path %q in archive", name)
 	}
-	return p, nil
+	if target == root {
+		return root, nil
+	}
+	parent := filepath.Dir(target)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", err
+	}
+	realParent, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", err
+	}
+	if realParent != root && !strings.HasPrefix(realParent, root+string(os.PathSeparator)) {
+		return "", fmt.Errorf("unsafe path %q in archive: escapes via symlink", name)
+	}
+	return filepath.Join(realParent, filepath.Base(target)), nil
 }
 
-// safeSymlink rejects a symlink whose destination escapes dir. linkPath is the
-// symlink's own (already safeJoin'd) location; linkname is its raw target. Without
-// this a symlink to ../../etc lets a later archive entry written "through" it land
-// outside dir — the tar-slip-via-symlink the path check alone misses.
-func safeSymlink(dir, linkPath, linkname string) error {
+// symlinkWithin rejects a symlink whose target escapes root. linkPath is the
+// symlink's already-resolved real location (from resolveWithin), so a relative
+// target is judged from where the link truly lands, not its lexical archive path.
+func symlinkWithin(root, linkPath, linkname string) error {
 	dest := linkname
 	if !filepath.IsAbs(dest) {
 		dest = filepath.Join(filepath.Dir(linkPath), linkname)
 	}
 	dest = filepath.Clean(dest)
-	if dest != dir && !strings.HasPrefix(dest, dir+string(os.PathSeparator)) {
+	if dest != root && !strings.HasPrefix(dest, root+string(os.PathSeparator)) {
 		return fmt.Errorf("unsafe symlink %q -> %q in archive", linkPath, linkname)
 	}
 	return nil
@@ -290,6 +305,10 @@ func extractTarGz(data []byte, dir string) error {
 		return err
 	}
 	defer gz.Close()
+	root, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return err
+	}
 	tr := tar.NewReader(gz)
 	for {
 		hdr, err := tr.Next()
@@ -299,7 +318,7 @@ func extractTarGz(data []byte, dir string) error {
 		if err != nil {
 			return err
 		}
-		target, err := safeJoin(dir, hdr.Name)
+		target, err := resolveWithin(root, hdr.Name)
 		if err != nil {
 			return err
 		}
@@ -309,10 +328,7 @@ func extractTarGz(data []byte, dir string) error {
 				return err
 			}
 		case tar.TypeSymlink:
-			if err := safeSymlink(dir, target, hdr.Linkname); err != nil {
-				return err
-			}
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			if err := symlinkWithin(root, target, hdr.Linkname); err != nil {
 				return err
 			}
 			_ = os.Remove(target)
@@ -332,8 +348,12 @@ func extractZip(data []byte, dir string) error {
 	if err != nil {
 		return err
 	}
+	root, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return err
+	}
 	for _, f := range zr.File {
-		target, err := safeJoin(dir, f.Name)
+		target, err := resolveWithin(root, f.Name)
 		if err != nil {
 			return err
 		}
@@ -357,9 +377,6 @@ func extractZip(data []byte, dir string) error {
 }
 
 func writeFileFromReader(target string, r io.Reader, mode os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-		return err
-	}
 	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode.Perm())
 	if err != nil {
 		return err

--- a/internal/codegraph/install_test.go
+++ b/internal/codegraph/install_test.go
@@ -76,13 +76,16 @@ func TestSha256For(t *testing.T) {
 	}
 }
 
-func TestSafeJoinRejectsTraversal(t *testing.T) {
-	dir := t.TempDir()
-	if _, err := safeJoin(dir, "../escape"); err == nil {
-		t.Fatal("safeJoin should reject ../escape")
+func TestResolveWithinRejectsTraversal(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
 	}
-	if _, err := safeJoin(dir, "bin/codegraph"); err != nil {
-		t.Fatalf("safeJoin rejected a normal path: %v", err)
+	if _, err := resolveWithin(root, "../escape"); err == nil {
+		t.Fatal("resolveWithin should reject ../escape")
+	}
+	if _, err := resolveWithin(root, "bin/codegraph"); err != nil {
+		t.Fatalf("resolveWithin rejected a normal path: %v", err)
 	}
 }
 

--- a/internal/codegraph/symlink_escape_test.go
+++ b/internal/codegraph/symlink_escape_test.go
@@ -35,6 +35,46 @@ func TestExtractRejectsEscapingSymlink(t *testing.T) {
 	}
 }
 
+// tarGz builds a tar.gz from the given headers in order, each with no body.
+func tarGz(hdrs ...*tar.Header) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	for _, h := range hdrs {
+		_ = tw.WriteHeader(h)
+	}
+	tw.Close()
+	gz.Close()
+	return buf.Bytes()
+}
+
+// TestExtractRejectsSymlinkRedirectEscape covers the variant a lexical path check
+// misses: an in-bounds symlink ("real/up" -> "..", which lands on root) is made a
+// parent of a second symlink, so the second link's real location is root/escape
+// even though its archive path is real/up/escape. Resolving the parent before
+// validating the target is what catches it (go/unsafe-unzip-symlink).
+func TestExtractRejectsSymlinkRedirectEscape(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Symlink("probe-target", filepath.Join(dir, "probe-link")); err != nil {
+		t.Skipf("symlink creation is not available in this environment: %v", err)
+	}
+	_ = os.Remove(filepath.Join(dir, "probe-link"))
+	data := tarGz(
+		&tar.Header{Name: "real/", Typeflag: tar.TypeDir, Mode: 0o755},
+		&tar.Header{Name: "real/up", Typeflag: tar.TypeSymlink, Linkname: "..", Mode: 0o777},
+		&tar.Header{Name: "real/up/escape", Typeflag: tar.TypeSymlink, Linkname: "..", Mode: 0o777},
+	)
+	err := extractTarGz(data, dir)
+	if err == nil || !strings.Contains(err.Error(), "unsafe symlink") {
+		t.Fatalf("symlink-redirect escape should be rejected, got %v", err)
+	}
+	if _, err := os.Lstat(filepath.Dir(dir)); err == nil {
+		if _, err := os.Lstat(filepath.Join(filepath.Dir(dir), "escape")); err == nil {
+			t.Fatal("escape symlink was planted outside the extraction dir")
+		}
+	}
+}
+
 // TestExtractAllowsInternalSymlink keeps legitimate in-bundle symlinks working.
 func TestExtractAllowsInternalSymlink(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -154,8 +154,8 @@ func myers(a, b []string) ([]op, bool) {
 		return nil, true
 	}
 	maxD := n + m
-	if maxD > maxDiffEdits {
-		maxD = maxDiffEdits // bound the trace's O(D²) footprint
+	if maxD > maxDiffEdits || maxD < 0 {
+		maxD = maxDiffEdits // bound the trace's O(D²) footprint (and any n+m overflow)
 	}
 	offset := maxD // shift negative k into a non-negative array index
 	v := make([]int, 2*maxD+1)

--- a/scripts/backfill-issue-labels.mjs
+++ b/scripts/backfill-issue-labels.mjs
@@ -11,7 +11,7 @@
 //   --only-unlabeled   skip issues that already have an area label
 //   --limit N          process at most N issues (default 200)
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 const args = process.argv.slice(2);
 const dryRun = args.includes('--dry-run');
@@ -52,8 +52,8 @@ const SYSTEM = [
   'Reply with JSON only: {"area":[],"platform":[],"severity":[]}',
 ].join('\n');
 
-function gh(cmd) {
-  return execSync(`gh ${cmd}`, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
 }
 
 async function classify(title, body) {
@@ -76,7 +76,9 @@ async function classify(title, body) {
   return [...(parsed.area || []), ...(parsed.platform || []), ...(parsed.severity || [])].filter((l) => ALLOWED.has(l));
 }
 
-const issues = JSON.parse(gh(`issue list --state open --limit ${limit} --json number,title,body,labels`));
+const issues = JSON.parse(
+  gh(['issue', 'list', '--state', 'open', '--limit', String(limit), '--json', 'number,title,body,labels']),
+);
 console.log(`${issues.length} open issues; dryRun=${dryRun} onlyUnlabeled=${onlyUnlabeled}`);
 
 let changed = 0;
@@ -101,8 +103,7 @@ for (const it of issues) {
   if (dryRun) {
     console.log(`#${it.number}: would add ${toAdd.join(', ')}  — ${it.title.slice(0, 50)}`);
   } else {
-    const flags = toAdd.map((l) => `--add-label "${l}"`).join(' ');
-    gh(`issue edit ${it.number} ${flags}`);
+    gh(['issue', 'edit', String(it.number), ...toAdd.flatMap((l) => ['--add-label', l])]);
     console.log(`#${it.number}: +${toAdd.join(', ')}`);
   }
   changed++;


### PR DESCRIPTION
Addresses the open CodeQL code-scanning alerts on `main-v2`. The error-level alerts are three real attack surfaces; the remaining error-level open alerts are local-CLI-by-design false positives (the bash tool, `@`-file references, slugified memory names, internal session/checkpoint paths) and are dismissed separately rather than wrapped in defensive checks that would contradict our "trust non-boundary code" rule.

### Archive extraction — `internal/codegraph/install.go` (`go/zipslip`, `go/unsafe-unzip-symlink`)
The bundle is downloaded from a pinned third-party release, so extraction is a genuine boundary. The lexical `../` guard already blocked plain tar-slip, but missed the **symlink-redirect** variant: an in-bounds symlink extracted as a *parent* component lets a later entry be written through it to land outside the cache dir. Now the real parent is resolved with `EvalSymlinks` before validating, and a symlink target is judged from its resolved location. New regression test `TestExtractRejectsSymlinkRedirectEscape` constructs the exact two-link escape and proves it is refused; legitimate in-bundle symlinks still extract.

### Command injection — `scripts/backfill-issue-labels.mjs` (`js/command-line-injection`)
`execSync` built a `gh ...` shell string from interpolated values. Switched to `execFileSync('gh', [argv])` so no argument can be reparsed by a shell.

### Untrusted checkout — `.github/workflows/e2e-bot.yml` (`actions/untrusted-checkout-toctou`)
Running PR-head code with the provider secret was gated only by `author_association`. Added an `e2e-bot` deployment environment (configure required reviewers in repo settings to force per-run human approval) and pinned the checkout to the head commit resolved at trigger time, detached, so a mid-run force-push can't swap in different code.

### Integer-bound warnings — `internal/cli/theme.go`, `internal/diff/diff.go`
`parseHexColor` parses single bytes; parse them as 8-bit unsigned and return `int`, dropping the `int64`→`int` conversions at the call sites (`go/incorrect-integer-conversion`). Clamp the Myers `maxD` against a negative `n+m` overflow as well, so `make()` can never receive a wrapped size (`go/allocation-size-overflow`).

Verified: `go build ./...`, `go test ./internal/{codegraph,cli,diff}/`, `gofmt`, `node --check`, and YAML parse all pass.
