### PR TITLE
test: de-flake two windows-latest timing tests

### DIFF
--- a/internal/control/shell_test.go
+++ b/internal/control/shell_test.go
@@ -26,10 +26,15 @@ func collectSink() (event.Sink, chan event.Event, *[]event.Event) {
 
 func waitForDone(t *testing.T, done chan event.Event) event.Event {
 	t.Helper()
+	return waitForDoneWithin(t, done, 5*time.Second)
+}
+
+func waitForDoneWithin(t *testing.T, done chan event.Event, d time.Duration) event.Event {
+	t.Helper()
 	select {
 	case e := <-done:
 		return e
-	case <-time.After(5 * time.Second):
+	case <-time.After(d):
 		t.Fatal("timed out waiting for TurnDone")
 		return event.Event{}
 	}
@@ -152,7 +157,12 @@ func TestRunShell_CancelStopsCommand(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	ctrl.Cancel()
 
-	e := waitForDone(t, done)
+	// Cancel kills the shell via the run context, but cmd.Wait honours
+	// shellWaitDelay (and on Windows cmd.Cancel spawns taskkill /F /T), so
+	// TurnDone can arrive almost a full shellWaitDelay after Cancel. Wait
+	// comfortably longer than that grace — a flat 5s budget equalled
+	// shellWaitDelay and lost the race on a loaded windows runner.
+	e := waitForDoneWithin(t, done, shellWaitDelay+10*time.Second)
 	if e.Kind != event.TurnDone {
 		t.Fatalf("done event kind = %v, want TurnDone", e.Kind)
 	}

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -431,7 +431,7 @@ func TestStartRecordsTimeoutStats(t *testing.T) {
 
 // TestStartPhaseAReturnsBeforePhaseB pins the two-phase handshake contract.
 // The helper advertises prompts and stalls prompts/list by 200ms; StartAvailable
-// must return as soon as tools are ready (well before that 200ms), and the
+// must return with tools ready while the prompts surface is still empty, and the
 // prompts must only materialise on Host after StartPhaseB has been called and
 // drained — proving prompts ride the background phase, not the boot critical path.
 func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
@@ -449,17 +449,17 @@ func TestStartPhaseAReturnsBeforePhaseB(t *testing.T) {
 		},
 	}
 
-	t0 := time.Now()
 	host, tools := StartAvailable(ctx, []Spec{spec})
-	startDur := time.Since(t0)
 	defer host.Close()
 
 	if len(tools) == 0 {
 		t.Fatalf("want tools from helper, got 0")
 	}
-	if startDur >= 150*time.Millisecond {
-		t.Fatalf("StartAvailable took %v — phase B (200ms prompts) leaked onto the critical path", startDur)
-	}
+	// Phase A returns with tools but the prompts surface must still be empty:
+	// StartAvailable never issues prompts/list (the helper stalls it 200ms), so
+	// prompts can only appear after StartPhaseB drains them below. We assert this
+	// deferral directly instead of timing StartAvailable — subprocess spawn plus
+	// the MCP handshake make a wall-clock threshold flaky on slow CI runners.
 	if got := host.Prompts(); len(got) != 0 {
 		t.Fatalf("phase A must not surface prompts yet, got %d", len(got))
 	}


### PR DESCRIPTION
## Summary
`windows-latest` has two distinct timing-sensitive tests that flake under CI load and intermittently block PRs (both surfaced while running CI on an unrelated branch). This de-flakes both at the root — test-only changes, no product behaviour touched.

### 1. `internal/plugin` — `TestStartPhaseAReturnsBeforePhaseB`
Asserted `StartAvailable` returns in `<150ms` while the helper stalls `prompts/list` by 200ms — a wall-clock proxy for "phase A doesn't block on the prompt fetch". But `StartAvailable` spawns a subprocess and runs the MCP `initialize` handshake, which alone can approach/exceed 150ms on a slow runner (observed **196ms**). Dropped the timing assertion; kept the deterministic deferral checks that already encode the contract (prompts empty after phase A, present only after `StartPhaseB` drains them).

### 2. `internal/control` — `TestRunShell_CancelStopsCommand`
Waited 5s for `TurnDone` after `Cancel`, but `cmd.Wait` honours `shellWaitDelay` (also 5s) — and on Windows `cmd.Cancel` spawns `taskkill /F /T` — so when the kill rides the full grace, `TurnDone` arrives at ~`shellWaitDelay` and the 5s budget loses a dead heat with it (observed **5.18s**). Now waits `shellWaitDelay + 10s` via a new `waitForDoneWithin` helper that `waitForDone` delegates to.

## Test plan
- `go test ./internal/plugin/ -run TestStartPhaseAReturnsBeforePhaseB -count=50` and `-race -count=10` → pass
- `go test ./internal/control/ -run TestRunShell_CancelStopsCommand -count=20` → pass
- `go test ./internal/plugin/ ./internal/control/` → pass
- `gofmt` / `go vet` clean