### PR TITLE
ci(e2e-bot): build with go.mod's Go version, not pinned 1.22

### DIFF
--- a/.github/workflows/e2e-bot.yml
+++ b/.github/workflows/e2e-bot.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
           cache: true
 
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## Summary
The `/e2e` bot is broken: its first step ("Build harness + fallback agent from the default branch") fails because `e2e-bot.yml` pins `go-version: '1.22'` (with setup-go's `GOTOOLCHAIN=local`) while `go.mod` now requires `go >= 1.25.0`:

```
go: go.mod requires go >= 1.25.0 (running go 1.22.12; GOTOOLCHAIN=local)
```

This aborts **every** `/e2e` run before it can build the harness/agent (observed on a `/e2e` against #3586).

## Fix
Use `go-version-file: go.mod`, exactly like `ci.yml` and the `release-*.yml` workflows already do. The bot then tracks the repo's Go version automatically and won't go stale on the next bump.

## Test plan
- 1-line value swap, indentation unchanged; mirrors the proven setup-go config used by every other workflow.
- Validation is the next `/e2e` run after merge (the bot's workflow is read from the default branch).