### PR TITLE
fix(macOS): reap entire codegraph process tree on exit (Setpgid + negative-PID kill)

### DIFF
--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -138,7 +138,8 @@ func EnsureInit(ctx context.Context, bin, root string) error {
 	ctx, cancel := context.WithTimeout(ctx, initTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, bin, "init", root)
-	cmd.Cancel = func() error { proc.KillTree(cmd); return nil }
+	proc.SetProcessGroupKill(cmd) // Setpgid so KillTree's negative-PID kill reaches the whole tree
+	cmd.Cancel = func() error { proc.KillTree(cmd); return nil } // on Windows, SetProcessGroupKill is a no-op so this explicit Cancel is still needed
 	cmd.WaitDelay = 3 * time.Second
 	proc.HideWindow(cmd)
 	cmd.Dir = root

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -56,6 +56,12 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	}
 	cmd := exec.CommandContext(ctx, exe, s.Args...)
 	proc.HideWindow(cmd)
+	// Place the child and all its descendants in a new process group so that
+	// KillTree (off Windows) and the Cancel handler can reap the whole tree
+	// with a single negative-pid kill — without this, a launcher shell whose
+	// managed sub-daemon (e.g. codegraph's bundled node runtime) survives
+	// the parent's death leaves orphan grandchildren behind after exit.
+	proc.SetProcessGroupKill(cmd)
 	cmd.Env = env
 	if s.Dir != "" {
 		cmd.Dir = s.Dir // pin cwd-aware servers (e.g. CodeGraph) to the project root

--- a/internal/proc/kill_other.go
+++ b/internal/proc/kill_other.go
@@ -2,18 +2,42 @@
 
 package proc
 
-import "os/exec"
+import (
+	"log/slog"
+	"os/exec"
+	"syscall"
+)
 
-// KillTree terminates cmd's process; off Windows it kills the direct child only.
+// SetProcessGroupKill configures cmd to start in its own process group so that
+// KillTree (via negative PID) can reap the whole tree on context cancellation
+// or exit. The Cancel handler catches the context-cancellation path; KillTree
+// covers the explicit-close path.
+func SetProcessGroupKill(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+}
+
+// KillTree terminates cmd's whole process group using the negative-pid trick:
+// the child was started with Setpgid so it leads its own process group, and
+// killing -PID reaches every descendant (not just the direct child). Without
+// this, a launcher shell with a managed sub-daemon (e.g. codegraph's bundled
+// node runtime) leaves orphan grandchildren alive after reasonix exits.
 func KillTree(cmd *exec.Cmd) {
 	if cmd == nil || cmd.Process == nil {
 		return
 	}
-	_ = cmd.Process.Kill()
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+		slog.Warn("proc: kill process group failed (Setpgid may be missing; the child must start its own group)", "pid", cmd.Process.Pid, "err", err)
+	}
 }
 
 // TrackTree is a no-op off Windows (returns 0); KillTracked then falls back to
-// KillTree, which is sufficient where the platform reaps the child directly.
+// KillTree, which now kills the whole process group (Setpgid + negative PID).
 func TrackTree(_ *exec.Cmd) uintptr { return 0 }
 
 // KillTracked terminates cmd's process tree; the handle is unused off Windows.

--- a/internal/proc/kill_windows.go
+++ b/internal/proc/kill_windows.go
@@ -10,6 +10,11 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// SetProcessGroupKill is a no-op on Windows: the Windows Job Object assigned by
+// TrackTree ensures the whole process tree is killed on exit, so Setpgid is
+// unnecessary and syscall.SysProcAttr.Setpgid doesn't exist on this platform.
+func SetProcessGroupKill(*exec.Cmd) {}
+
 // KillTree terminates cmd and every descendant it spawned. Process.Kill only
 // signals the direct child, so a launcher (cmd.exe → node.exe) leaves the
 // grandchild alive holding the inherited stdout/stderr pipes — which makes


### PR DESCRIPTION
## 问题

macOS/Linux 上，Reasonix 退出后 codegraph 的孙进程残留。累计 40+ 孤儿进程导致系统严重卡顿。

## 根因

`internal/proc/kill_other.go` 的 `KillTree` 只调 `cmd.Process.Kill()` — 只杀直接子进程（codegraph 的 shell launcher），不杀它启动的 node 运行时和工作进程。

对比 Windows 版：`internal/proc/kill_windows.go` 用 Job Object (`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`) + `taskkill /T` 能完整清理整个进程树，没有此问题。

## 修复

两个改动，复用代码库中已有的模式（`bash_kill_other.go` / `shell_kill_other.go`）：

1. **`internal/proc/kill_other.go`** — `KillTree` 从 `cmd.Process.Kill()` 改为 `syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)`，杀死整个进程组
2. **`internal/plugin/transport_stdio.go`** — `newStdioTransport` 中在 `cmd.Start()` 前设 `cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}` 并设 `cmd.Cancel` handler 杀进程组

这样无论正常退出还是 context 取消，codegraph 的进程树都会被完整清理。

Fixes #3734