### PR TITLE
fix(desktop): strip controller-injected prefixes from chat display (#3720)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1293,6 +1293,9 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 		content := m.Content
 		if m.Role == provider.RoleUser {
 			content = resolveUserContent(m.Content)
+			if control.IsSyntheticUserMessage(content) {
+				continue
+			}
 		}
 		reasoning := ""
 		if m.Role == provider.RoleAssistant {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"reasonix/internal/control"
 	"reasonix/internal/fileutil"
 )
 
@@ -401,7 +402,7 @@ func sessionDisplayResolver(dir, sessionPath string) func(content string) string
 				return display
 			}
 		}
-		return content
+		return control.StripComposePrefixes(content)
 	}
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3448,7 +3448,7 @@ func replaySectionsFor(history []provider.Message, width int, renderer *mdRender
 	for _, m := range history {
 		switch m.Role {
 		case provider.RoleUser:
-			content := strings.TrimPrefix(m.Content, control.PlanModeMarker+"\n\n")
+			content := control.StripComposePrefixes(m.Content)
 			out = append(out, renderUserBubble(content, width, false)+"\n\n")
 		case provider.RoleAssistant:
 			body := strings.TrimSpace(m.Content)

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -2,15 +2,73 @@ package control
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	"reasonix/internal/skill"
 )
 
+var reComposeBlock = regexp.MustCompile(`(?s)^\s*<(?:memory-update|background-jobs)>.*?</(?:memory-update|background-jobs)>\s*\n`)
+
 // PlanModeMarker is prepended to every user turn while plan mode is on. It rides
 // in the user message (not the system prompt or tools), so the cache-stable
 // prompt prefix is left untouched and the toggle costs nothing in cache hits.
 const PlanModeMarker = "[Plan mode — read-only. Explore the codebase first (read_file, ls, grep, glob, web_fetch, task are available; writers are refused by the harness), then present a LAYERED plan as your reply and stop — do not write files, edit, or run side-effecting bash. Structure the plan as a two-level markdown list so it becomes a layered task list: each PHASE is a top-level numbered list item (a coherent milestone, e.g. \"1. Add the config loader\"), and each phase's concrete, verifiable sub-steps are bullets indented beneath it (e.g. \"   - parse the TOML into Config\"). Use plain numbered list items for phases — do NOT write phases as markdown headings (##, ###) — so both levels parse. Keep phases few (about 2-6). The user will be asked to approve before any changes are made.]"
+
+// StripComposePrefixes removes controller-injected prefixes from a composed
+// user message so that the display text matches what the user actually typed.
+// It strips the PlanModeMarker, <memory-update>…</memory-update>, and
+// <background-jobs>…</background-jobs> blocks that Compose prepends to user
+// turns. This is used as a fallback when no .display.json sidecar recording
+// exists (e.g. sessions created before the display-recording feature, or
+// synthetic user messages injected by the controller).
+func StripComposePrefixes(content string) string {
+	s := content
+	for {
+		next := reComposeBlock.ReplaceAllStringFunc(s, func(match string) string {
+			return ""
+		})
+		if next == s {
+			break
+		}
+		s = next
+	}
+	s = strings.TrimPrefix(s, PlanModeMarker+"\n\n")
+	s = strings.TrimPrefix(s, PlanModeMarker)
+	s = strings.TrimSpace(s)
+	return s
+}
+
+// IsSyntheticUserMessage returns true if the content matches one of the known
+// synthetic user messages injected by the controller or agent loop (plan
+// approval, stream recovery, readiness retry, etc.). These should not be shown
+// in the chat UI.
+func IsSyntheticUserMessage(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == planApprovedMessage {
+		return true
+	}
+	for _, prefix := range syntheticPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// syntheticPrefixes must be kept in sync with the synthetic user messages
+// injected by the controller (planApprovedMessage) and agent loop
+// (streamRecoveryMessage, finalReadinessRetryMessage, emptyFinalRetryMessage,
+// executorHandoffRetryMessage in internal/agent/agent.go).
+var syntheticPrefixes = []string{
+	"Plan approved — plan mode is off",
+	"Host final-answer readiness check failed",
+	"You are already in the executor phase",
+	"The previous assistant response was interrupted while a tool call",
+	"The previous assistant response was interrupted during streaming",
+	"The previous assistant response was interrupted before visible",
+	"The previous assistant response finished without any visible answer",
+}
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,
 // returning the message to actually send to the model. The frontend keeps

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -371,3 +371,127 @@ func TestRunTurnAutoPlanScoresRawPromptNotResolvedRefs(t *testing.T) {
 		t.Fatal("controller plan mode should remain off")
 	}
 }
+
+func TestStripComposePrefixes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain user message unchanged",
+			input: "explain this function",
+			want:  "explain this function",
+		},
+		{
+			name:  "plan mode marker stripped",
+			input: PlanModeMarker + "\n\nexplain this function",
+			want:  "explain this function",
+		},
+		{
+			name:  "plan mode marker without trailing newlines",
+			input: PlanModeMarker,
+			want:  "",
+		},
+		{
+			name:  "memory update block stripped",
+			input: "<memory-update>\nThe following project-memory changes were just made and apply from now on:\n- Saved memory \"rmb\": user balance\n</memory-update>\n\nexplain this",
+			want:  "explain this",
+		},
+		{
+			name:  "background jobs block stripped",
+			input: "<background-jobs>\n1 completed\n</background-jobs>\n\nexplain this",
+			want:  "explain this",
+		},
+		{
+			name:  "memory and plan marker both stripped",
+			input: "<memory-update>\n- note\n</memory-update>\n\n" + PlanModeMarker + "\n\nexplain this",
+			want:  "explain this",
+		},
+		{
+			name:  "empty after stripping",
+			input: PlanModeMarker + "\n\n",
+			want:  "",
+		},
+		{
+			name:  "memory update only no user text",
+			input: "<memory-update>\n- note\n</memory-update>\n\n",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripComposePrefixes(tt.input)
+			if got != tt.want {
+				t.Errorf("StripComposePrefixes() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSyntheticUserMessage(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "plan approved message",
+			input: planApprovedMessage,
+			want:  true,
+		},
+		{
+			name:  "stream recovery interrupted tool",
+			input: "The previous assistant response was interrupted while a tool call was streaming. Continue the same task now.",
+			want:  true,
+		},
+		{
+			name:  "stream recovery interrupted text",
+			input: "The previous assistant response was interrupted during streaming. Continue the same task from immediately after the partial assistant message above.",
+			want:  true,
+		},
+		{
+			name:  "empty final retry",
+			input: "The previous assistant response finished without any visible answer text. Continue the same task now and provide a concise visible answer.",
+			want:  true,
+		},
+		{
+			name:  "readiness retry",
+			input: "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: missing evidence.",
+			want:  true,
+		},
+		{
+			name:  "executor handoff",
+			input: "You are already in the executor phase. The planner's read-only limitations do not apply to you.",
+			want:  true,
+		},
+		{
+			name:  "regular user message",
+			input: "explain this function",
+			want:  false,
+		},
+		{
+			name:  "plan mode marker in message",
+			input: PlanModeMarker + "\n\nexplain this",
+			want:  false,
+		},
+		{
+			name:  "stream recovery interrupted before visible",
+			input: "The previous assistant response was interrupted during streaming before visible answer text was completed. Continue the same task now.",
+			want:  true,
+		},
+		{
+			name:  "user quoting interrupted response not synthetic",
+			input: "The previous assistant response was interrupted by my VPN, can you retry?",
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsSyntheticUserMessage(tt.input)
+			if got != tt.want {
+				t.Errorf("IsSyntheticUserMessage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Rebases @ashishexee's #3738 onto current main-v2. The only conflict was a trivial import merge in `desktop/sessions.go` (main-v2 added `internal/agent`, the PR added `internal/control`) — both are used, so both imports are kept.

Strips controller-injected prefixes (`[Plan mode — read-only…]` marker, `<memory-update>`, `<background-jobs>` blocks) and synthetic `Role: "user"` messages from the chat display, so agent-mode internals no longer leak into the desktop/TUI transcript.

### Verification
- `control.StripComposePrefixes` covered by `TestStripComposePrefixes` (8 sub-cases: plan marker, memory-update, background-jobs, combined, empty-after-strip) — all pass
- Root module `go build ./...`, `internal/control` and `internal/cli` tests, and the desktop module `go build ./...` all green after the merge

Closes #3738

Credit: @ashishexee
