### PR TITLE
fix(provider): time out a stalled SSE stream instead of hanging (#3374)

### DIFF
--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -32,11 +32,12 @@ import (
 	"reasonix/internal/provider"
 )
 
-// streamIdleTimeout caps how long a started SSE stream may go silent before it's
-// treated as a dropped connection — a half-open TCP connection (proxy switched
+// defaultStreamIdleTimeout caps how long a started SSE stream may go silent before
+// it's treated as a dropped connection — a half-open TCP connection (proxy switched
 // mid-stream) sends no RST, so scanner.Scan() would block forever. Generous on
-// purpose; live streams emit far more often. A var so tests can override it.
-var streamIdleTimeout = 120 * time.Second
+// purpose; live streams emit far more often. Stored per-client (client.idleTimeout)
+// so a test can shorten it without a shared global that races other watchdogs.
+const defaultStreamIdleTimeout = 120 * time.Second
 
 const (
 	// anthropicVersion is the required API version header value.
@@ -91,14 +92,15 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		root = defaultBaseURL
 	}
 	return &client{
-		name:     name,
-		apiKey:   cfg.APIKey,
-		keyEnv:   keyEnv,
-		baseURL:  root,
-		model:    cfg.Model,
-		thinking: thinking,
-		effort:   effort,
-		http:     httpClient, // no overall timeout; lifecycle is ctx-driven
+		name:        name,
+		apiKey:      cfg.APIKey,
+		keyEnv:      keyEnv,
+		baseURL:     root,
+		model:       cfg.Model,
+		thinking:    thinking,
+		effort:      effort,
+		http:        httpClient, // no overall timeout; lifecycle is ctx-driven
+		idleTimeout: defaultStreamIdleTimeout,
 	}, nil
 }
 
@@ -108,14 +110,15 @@ func newHTTPClient(cfg provider.Config) (*http.Client, error) {
 }
 
 type client struct {
-	name     string
-	apiKey   string
-	keyEnv   string // api_key_env name, surfaced in auth errors
-	baseURL  string
-	model    string
-	thinking string // "adaptive" enables extended thinking; "" = off (config-driven)
-	effort   string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
-	http     *http.Client
+	name        string
+	apiKey      string
+	keyEnv      string // api_key_env name, surfaced in auth errors
+	baseURL     string
+	model       string
+	thinking    string // "adaptive" enables extended thinking; "" = off (config-driven)
+	effort      string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
+	http        *http.Client
+	idleTimeout time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
 }
 
 func (c *client) Name() string { return c.name }
@@ -277,16 +280,20 @@ func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
 	defer resp.Body.Close()
 	defer close(out)
 
-	// Close the body if the stream stalls past streamIdleTimeout so scanner.Scan()
+	// Close the body if the stream stalls past c.idleTimeout so scanner.Scan()
 	// unblocks instead of hanging on a half-open connection. The watchdog owns the
 	// timer; the read loop only pings the buffered activity channel (no Timer.Reset
 	// race). A context cancel already unblocks the scan via the transport.
+	idleTimeout := c.idleTimeout
+	if idleTimeout <= 0 { // zero-value client (constructed without New)
+		idleTimeout = defaultStreamIdleTimeout
+	}
 	done := make(chan struct{})
 	defer close(done)
 	activity := make(chan struct{}, 1)
 	var stalled atomic.Bool
 	go func() {
-		idle := time.NewTimer(streamIdleTimeout)
+		idle := time.NewTimer(idleTimeout)
 		defer idle.Stop()
 		for {
 			select {
@@ -301,7 +308,7 @@ func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
 					default:
 					}
 				}
-				idle.Reset(streamIdleTimeout)
+				idle.Reset(idleTimeout)
 			case <-done:
 				return
 			}
@@ -400,7 +407,7 @@ func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
 	}
 
 	if stalled.Load() {
-		out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, streamIdleTimeout)}
+		out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout)}
 		return
 	}
 	if err := scanner.Err(); err != nil {

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -25,10 +25,18 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"reasonix/internal/netclient"
 	"reasonix/internal/provider"
 )
+
+// streamIdleTimeout caps how long a started SSE stream may go silent before it's
+// treated as a dropped connection — a half-open TCP connection (proxy switched
+// mid-stream) sends no RST, so scanner.Scan() would block forever. Generous on
+// purpose; live streams emit far more often. A var so tests can override it.
+var streamIdleTimeout = 120 * time.Second
 
 const (
 	// anthropicVersion is the required API version header value.
@@ -269,6 +277,37 @@ func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
 	defer resp.Body.Close()
 	defer close(out)
 
+	// Close the body if the stream stalls past streamIdleTimeout so scanner.Scan()
+	// unblocks instead of hanging on a half-open connection. The watchdog owns the
+	// timer; the read loop only pings the buffered activity channel (no Timer.Reset
+	// race). A context cancel already unblocks the scan via the transport.
+	done := make(chan struct{})
+	defer close(done)
+	activity := make(chan struct{}, 1)
+	var stalled atomic.Bool
+	go func() {
+		idle := time.NewTimer(streamIdleTimeout)
+		defer idle.Stop()
+		for {
+			select {
+			case <-idle.C:
+				stalled.Store(true)
+				resp.Body.Close()
+				return
+			case <-activity:
+				if !idle.Stop() {
+					select {
+					case <-idle.C:
+					default:
+					}
+				}
+				idle.Reset(streamIdleTimeout)
+			case <-done:
+				return
+			}
+		}
+	}()
+
 	tools := map[int]*provider.ToolCall{} // tool_use blocks, keyed by content index
 	var inTok, outTok, cacheCreate, cacheRead int
 	var stopReason string
@@ -278,6 +317,10 @@ func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	for scanner.Scan() {
+		select { // ping the idle watchdog; non-blocking so a full buffer is fine
+		case activity <- struct{}{}:
+		default:
+		}
 		line := strings.TrimSpace(scanner.Text())
 		// SSE carries `event:` and `data:` lines; the data JSON's own `type` field
 		// is authoritative, so we only need the data payloads.
@@ -356,6 +399,10 @@ func (c *client) readStream(resp *http.Response, out chan<- provider.Chunk) {
 		}
 	}
 
+	if stalled.Load() {
+		out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, streamIdleTimeout)}
+		return
+	}
 	if err := scanner.Err(); err != nil {
 		out <- provider.Chunk{Type: provider.ChunkError, Err: fmt.Errorf("%s: read stream: %w", c.name, err)}
 		return

--- a/internal/provider/anthropic/stall_test.go
+++ b/internal/provider/anthropic/stall_test.go
@@ -1,0 +1,68 @@
+package anthropic
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// TestStreamStallTimesOut covers issue #3374 for the Anthropic provider: a
+// half-open connection sends the SSE head then goes silent without an RST, which
+// would hang scanner.Scan() forever. The idle watchdog must surface a stall error.
+func TestStreamStallTimesOut(t *testing.T) {
+	old := streamIdleTimeout
+	streamIdleTimeout = 150 * time.Millisecond
+	defer func() { streamIdleTimeout = old }()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		_, _ = io.WriteString(w, ": ping\n\n")
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-release // stall: never send data, never close
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	p, err := New(provider.Config{Name: "claude", BaseURL: srv.URL, Model: "claude-opus-4-8", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages:  []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+		MaxTokens: 16,
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case chunk, ok := <-ch:
+			if !ok {
+				t.Fatal("stream closed without surfacing a stall error")
+			}
+			if chunk.Type == provider.ChunkError {
+				if !strings.Contains(chunk.Err.Error(), "stalled") {
+					t.Fatalf("error = %v, want a 'stalled' error", chunk.Err)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("stream did not time out on a stalled connection — it hung")
+		}
+	}
+}

--- a/internal/provider/anthropic/stall_test.go
+++ b/internal/provider/anthropic/stall_test.go
@@ -16,10 +16,6 @@ import (
 // half-open connection sends the SSE head then goes silent without an RST, which
 // would hang scanner.Scan() forever. The idle watchdog must surface a stall error.
 func TestStreamStallTimesOut(t *testing.T) {
-	old := streamIdleTimeout
-	streamIdleTimeout = 150 * time.Millisecond
-	defer func() { streamIdleTimeout = old }()
-
 	release := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -40,6 +36,7 @@ func TestStreamStallTimesOut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	p.(*client).idleTimeout = 150 * time.Millisecond
 	ch, err := p.Stream(context.Background(), provider.Request{
 		Messages:  []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
 		MaxTokens: 16,

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -27,12 +27,14 @@ import (
 	"reasonix/internal/provider"
 )
 
-// streamIdleTimeout caps how long a started SSE stream may go without any bytes
-// before it's treated as a dropped connection. A half-open TCP connection (e.g. a
-// proxy switched mid-stream) sends no RST, so scanner.Scan() would block forever;
-// this turns that hang into a recoverable error. Generous on purpose — live
-// streams emit tokens/keepalives far more often than this. A var so tests override it.
-var streamIdleTimeout = 120 * time.Second
+// defaultStreamIdleTimeout caps how long a started SSE stream may go without any
+// bytes before it's treated as a dropped connection. A half-open TCP connection
+// (e.g. a proxy switched mid-stream) sends no RST, so scanner.Scan() would block
+// forever; this turns that hang into a recoverable error. Generous on purpose —
+// live streams emit tokens/keepalives far more often. Stored per-client
+// (client.idleTimeout) so a test can shorten it without a shared global that
+// would race other streams' watchdogs.
+const defaultStreamIdleTimeout = 120 * time.Second
 
 func init() {
 	provider.Register("openai", New)
@@ -101,15 +103,16 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		return nil, fmt.Errorf("openai: network: %w", err)
 	}
 	return &client{
-		name:     name,
-		apiKey:   cfg.APIKey,
-		keyEnv:   keyEnv,
-		baseURL:  strings.TrimRight(cfg.BaseURL, "/"),
-		model:    cfg.Model,
-		deepseek: deepseek,
-		minimax:  minimax,
-		effort:   effort,
-		http:     httpClient,
+		name:        name,
+		apiKey:      cfg.APIKey,
+		keyEnv:      keyEnv,
+		baseURL:     strings.TrimRight(cfg.BaseURL, "/"),
+		model:       cfg.Model,
+		deepseek:    deepseek,
+		minimax:     minimax,
+		effort:      effort,
+		http:        httpClient,
+		idleTimeout: defaultStreamIdleTimeout,
 	}, nil
 }
 
@@ -124,15 +127,16 @@ func newHTTPClient(cfg provider.Config) (*http.Client, error) {
 }
 
 type client struct {
-	name     string
-	apiKey   string
-	keyEnv   string // api_key_env name, surfaced in auth errors
-	baseURL  string
-	model    string
-	http     *http.Client
-	deepseek bool
-	minimax  bool   // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
-	effort   string // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
+	name        string
+	apiKey      string
+	keyEnv      string // api_key_env name, surfaced in auth errors
+	baseURL     string
+	model       string
+	http        *http.Client
+	deepseek    bool
+	minimax     bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
+	effort      string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
+	idleTimeout time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
 }
 
 func (c *client) Name() string { return c.name }
@@ -299,17 +303,21 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	defer resp.Body.Close()
 
 	// Close the response body when the context is canceled (user interrupt) or the
-	// stream stalls past streamIdleTimeout, so scanner.Scan() unblocks instead of
+	// stream stalls past c.idleTimeout, so scanner.Scan() unblocks instead of
 	// hanging on a half-open connection. done lets the watchdog exit on a normal
 	// return — otherwise it outlives the call and blocks forever on a non-cancellable
 	// context whose Done() is nil. The watchdog owns the timer; the read loop only
 	// pings the buffered activity channel, so there's no Timer.Reset race.
+	idleTimeout := c.idleTimeout
+	if idleTimeout <= 0 { // zero-value client (constructed without New)
+		idleTimeout = defaultStreamIdleTimeout
+	}
 	done := make(chan struct{})
 	defer close(done)
 	activity := make(chan struct{}, 1)
 	var stalled atomic.Bool
 	go func() {
-		idle := time.NewTimer(streamIdleTimeout)
+		idle := time.NewTimer(idleTimeout)
 		defer idle.Stop()
 		for {
 			select {
@@ -327,7 +335,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 					default:
 					}
 				}
-				idle.Reset(streamIdleTimeout)
+				idle.Reset(idleTimeout)
 			case <-done:
 				return
 			}
@@ -419,7 +427,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	}
 
 	if stalled.Load() {
-		return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, streamIdleTimeout)
+		return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout)
 	}
 	if err := scanner.Err(); err != nil {
 		return emitted, fmt.Errorf("%s: read stream: %w", c.name, err)

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -20,11 +20,19 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"reasonix/internal/netclient"
 	"reasonix/internal/provider"
 )
+
+// streamIdleTimeout caps how long a started SSE stream may go without any bytes
+// before it's treated as a dropped connection. A half-open TCP connection (e.g. a
+// proxy switched mid-stream) sends no RST, so scanner.Scan() would block forever;
+// this turns that hang into a recoverable error. Generous on purpose — live
+// streams emit tokens/keepalives far more often than this. A var so tests override it.
+var streamIdleTimeout = 120 * time.Second
 
 func init() {
 	provider.Register("openai", New)
@@ -290,17 +298,39 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<- provider.Chunk) (emitted bool, _ error) {
 	defer resp.Body.Close()
 
-	// Close the response body when the context is canceled so scanner.Scan()
-	// unblocks instead of hanging on a stalled connection. done lets the goroutine
-	// exit when readStream returns normally — otherwise it outlives the call, and
-	// blocks forever on a non-cancellable context whose Done() is nil.
+	// Close the response body when the context is canceled (user interrupt) or the
+	// stream stalls past streamIdleTimeout, so scanner.Scan() unblocks instead of
+	// hanging on a half-open connection. done lets the watchdog exit on a normal
+	// return — otherwise it outlives the call and blocks forever on a non-cancellable
+	// context whose Done() is nil. The watchdog owns the timer; the read loop only
+	// pings the buffered activity channel, so there's no Timer.Reset race.
 	done := make(chan struct{})
 	defer close(done)
+	activity := make(chan struct{}, 1)
+	var stalled atomic.Bool
 	go func() {
-		select {
-		case <-ctx.Done():
-			resp.Body.Close()
-		case <-done:
+		idle := time.NewTimer(streamIdleTimeout)
+		defer idle.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				resp.Body.Close()
+				return
+			case <-idle.C:
+				stalled.Store(true)
+				resp.Body.Close()
+				return
+			case <-activity:
+				if !idle.Stop() {
+					select {
+					case <-idle.C:
+					default:
+					}
+				}
+				idle.Reset(streamIdleTimeout)
+			case <-done:
+				return
+			}
 		}
 	}()
 
@@ -314,6 +344,10 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 	for scanner.Scan() {
+		select { // ping the idle watchdog; non-blocking so a full buffer is fine
+		case activity <- struct{}{}:
+		default:
+		}
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || !strings.HasPrefix(line, "data:") {
 			continue
@@ -384,6 +418,9 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		}
 	}
 
+	if stalled.Load() {
+		return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, streamIdleTimeout)
+	}
 	if err := scanner.Err(); err != nil {
 		return emitted, fmt.Errorf("%s: read stream: %w", c.name, err)
 	}

--- a/internal/provider/openai/stall_test.go
+++ b/internal/provider/openai/stall_test.go
@@ -1,0 +1,68 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// TestStreamStallTimesOut covers issue #3374: a half-open connection (a proxy
+// switched mid-stream) sends the SSE head then goes silent without an RST, so
+// scanner.Scan() would block forever and Ctrl+C-less sessions hang until kill -9.
+// The idle watchdog must surface a stall error instead of hanging.
+func TestStreamStallTimesOut(t *testing.T) {
+	old := streamIdleTimeout
+	streamIdleTimeout = 150 * time.Millisecond
+	defer func() { streamIdleTimeout = old }()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flush(w)
+		_, _ = io.WriteString(w, ": keep-alive\n\n") // one comment, resets the watchdog once
+		flush(w)
+		<-release // then stall: never send data, never close — half-open connection
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case chunk, ok := <-ch:
+			if !ok {
+				t.Fatal("stream closed without surfacing a stall error")
+			}
+			if chunk.Type == provider.ChunkError {
+				if !strings.Contains(chunk.Err.Error(), "stalled") {
+					t.Fatalf("error = %v, want a 'stalled' error", chunk.Err)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("stream did not time out on a stalled connection — it hung")
+		}
+	}
+}
+
+func flush(w http.ResponseWriter) {
+	if f, ok := w.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/internal/provider/openai/stall_test.go
+++ b/internal/provider/openai/stall_test.go
@@ -17,10 +17,6 @@ import (
 // scanner.Scan() would block forever and Ctrl+C-less sessions hang until kill -9.
 // The idle watchdog must surface a stall error instead of hanging.
 func TestStreamStallTimesOut(t *testing.T) {
-	old := streamIdleTimeout
-	streamIdleTimeout = 150 * time.Millisecond
-	defer func() { streamIdleTimeout = old }()
-
 	release := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -37,6 +33,7 @@ func TestStreamStallTimesOut(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	p.(*client).idleTimeout = 150 * time.Millisecond
 	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
 	if err != nil {
 		t.Fatalf("Stream: %v", err)


### PR DESCRIPTION
## Problem (#3374)
When an API stream stalls on a half-open connection — a proxy switched mid-stream, so the TCP connection is dead but sends no RST — `scanner.Scan()` blocks forever. The UI sits on "thinking", and because the read goroutine never returns, the session can only be killed with `kill -9`. The reporter captured all threads parked in `futex_wait` with no active sockets.

## Fix
Both stream readers (openai-compatible and anthropic) now run an idle watchdog: if a *started* stream goes silent past `streamIdleTimeout` (120s), the response body is closed, `scanner.Scan()` unblocks, and a clear `stream stalled — connection likely dropped` error surfaces, returning the session to the input prompt instead of hanging.

- The watchdog owns the timer; the read loop only does a non-blocking send on a buffered channel, so there's no `Timer.Reset` race.
- 120s is generous on purpose — live streams emit tokens/keepalives far more often, so a normal slow reasoner is never cut. Time-to-first-token is still covered separately by `ResponseHeaderTimeout`.
- The openai idempotent-replay path (#3148) is untouched: a stall surfaces as a normal (non-`IsConnReset`) error, so it doesn't trigger a replay loop on a persistently bad connection.

Note: the in-flight Ctrl+C interrupt half of the report (SIGINT should cancel the turn, not exit) is already handled on `main-v2` — the chat TUI maps Ctrl+C while running to `ctrl.Cancel()`. This PR closes the remaining "hangs forever with no key working" half.

## Tests
`TestStreamStallTimesOut` in each provider: a mock server sends the SSE head then stalls; with the watchdog the stream surfaces a stall error in ~150ms (test override), where before it hung to the test deadline. Existing reconnect/streaming tests still pass.

Closes #3374
