### PR TITLE
fix(bash): reap the process group after a command completes (#3702)

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -149,7 +149,9 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 			cmd.WaitDelay = bashWaitDelay
 			cmd.Stdout = out
 			cmd.Stderr = out
-			return "", cmd.Run()
+			runErr := cmd.Run()
+			reapTree(cmd) // reap process-group stragglers the job left running (#3702)
+			return "", runErr
 		})
 		return fmt.Sprintf("Started background job %q. It keeps running across turns; read new output with bash_output(job_id=%q), wait for it with wait, or stop it with kill_shell(job_id=%q).", job.ID, job.ID, job.ID), nil
 	}
@@ -175,6 +177,11 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	cmd.Stdout = w
 	cmd.Stderr = w
 	err := cmd.Run()
+	// A foreground command that spawned a lingering child (e.g. `bazel run`'s
+	// server) leaves it in the process group; Wait only reaped the shell leader.
+	// Kill the group so those don't accumulate into an OOM (#3702). On cancel/
+	// timeout setKillTree's Cancel already did this; this covers normal exit.
+	reapTree(cmd)
 	out := buf.String()
 
 	if errors.Is(context.Cause(runCtx), errBashTimeout) {

--- a/internal/tool/builtin/bash_kill_other.go
+++ b/internal/tool/builtin/bash_kill_other.go
@@ -20,3 +20,14 @@ func setKillTree(cmd *exec.Cmd) {
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	}
 }
+
+// reapTree kills any members the command's process group left running after it
+// returned — a foreground command that forked a daemon (e.g. `bazel run`'s
+// server) leaves it behind, and Wait only reaped the shell leader. The group id
+// is the leader's pid (Setpgid). ESRCH (empty group) is fine. See #3702.
+func reapTree(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/tool/builtin/bash_kill_windows.go
+++ b/internal/tool/builtin/bash_kill_windows.go
@@ -23,3 +23,10 @@ func setKillTree(cmd *exec.Cmd) {
 		return cmd.Process.Kill()
 	}
 }
+
+// reapTree is the post-completion process-group cleanup the POSIX build does for
+// #3702. On Windows it's a no-op: once the shell leader exits there's no live
+// parent for taskkill /T to walk, and spawning taskkill on every bash call would
+// tax the hot path for little gain — proper after-exit tree cleanup needs a Job
+// Object, which is out of scope here.
+func reapTree(*exec.Cmd) {}

--- a/internal/tool/builtin/bash_reap_test.go
+++ b/internal/tool/builtin/bash_reap_test.go
@@ -3,7 +3,10 @@
 package builtin
 
 import (
+	"context"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -14,17 +17,24 @@ import (
 // TestReapTreeKillsGroupStragglers covers #3702: a foreground command that
 // backgrounds a child (here a long sleep, standing in for `bazel run`'s server)
 // leaves it in the process group after Wait reaps the shell leader. reapTree must
-// kill it so such processes don't accumulate into an OOM.
+// kill it so such processes don't accumulate into an OOM. The child redirects its
+// fds and the pid is passed via a file so the inherited stdout can't block Wait.
 func TestReapTreeKillsGroupStragglers(t *testing.T) {
-	cmd := exec.Command("sh", "-c", "sleep 60 & echo $!")
+	pidFile := filepath.Join(t.TempDir(), "pid")
+	cmd := exec.CommandContext(context.Background(), "sh", "-c",
+		"sleep 60 >/dev/null 2>&1 & echo $! > "+pidFile)
 	setKillTree(cmd) // Setpgid — the shell leads its own group
-	out, err := cmd.Output()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		t.Fatalf("run: %v", err)
 	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+
+	data, err := os.ReadFile(pidFile)
 	if err != nil {
-		t.Fatalf("parse backgrounded pid %q: %v", out, err)
+		t.Fatalf("read pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse backgrounded pid %q: %v", data, err)
 	}
 	if err := syscall.Kill(pid, 0); err != nil {
 		t.Skipf("backgrounded child %d not alive after shell exit (%v)", pid, err)
@@ -34,7 +44,7 @@ func TestReapTreeKillsGroupStragglers(t *testing.T) {
 
 	dead := false
 	for i := 0; i < 50; i++ {
-		if err := syscall.Kill(pid, 0); err != nil {
+		if syscall.Kill(pid, 0) != nil {
 			dead = true
 			break
 		}

--- a/internal/tool/builtin/bash_reap_test.go
+++ b/internal/tool/builtin/bash_reap_test.go
@@ -1,0 +1,47 @@
+//go:build !windows
+
+package builtin
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestReapTreeKillsGroupStragglers covers #3702: a foreground command that
+// backgrounds a child (here a long sleep, standing in for `bazel run`'s server)
+// leaves it in the process group after Wait reaps the shell leader. reapTree must
+// kill it so such processes don't accumulate into an OOM.
+func TestReapTreeKillsGroupStragglers(t *testing.T) {
+	cmd := exec.Command("sh", "-c", "sleep 60 & echo $!")
+	setKillTree(cmd) // Setpgid — the shell leads its own group
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse backgrounded pid %q: %v", out, err)
+	}
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Skipf("backgrounded child %d not alive after shell exit (%v)", pid, err)
+	}
+
+	reapTree(cmd)
+
+	dead := false
+	for i := 0; i < 50; i++ {
+		if err := syscall.Kill(pid, 0); err != nil {
+			dead = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !dead {
+		_ = syscall.Kill(pid, syscall.SIGKILL) // don't leak the sleep in CI
+		t.Fatalf("backgrounded child %d survived reapTree", pid)
+	}
+}


### PR DESCRIPTION
## Problem (#3702)
A foreground bash command that forks a lingering child — e.g. `bazel run`, which starts a persistent build server — left that process alive after the command returned. `Setpgid` puts the child in the command's process group, but `cmd.Wait()` only reaps the shell leader, and `setKillTree`'s `Cancel` only kills the group on cancel/timeout. On a *normal* exit nothing cleaned the group, so each such invocation leaked a process → memory climbed until OOM (reporter saw it on ubuntu with `bazel run`).

## Fix
Kill the process group after `cmd.Run()` returns, on both the foreground and background-job paths. The group id is the shell leader's pid (`Setpgid`), so `kill(-pgid, SIGKILL)` clears any strays; an empty group is a harmless ESRCH. Cancel/timeout already did this via `setKillTree`; this covers normal completion.

POSIX-only. On Windows it's a documented no-op: once the leader exits there's no live parent for `taskkill /T` to walk, and spawning `taskkill` on every bash call would tax the hot path — proper after-exit tree cleanup there needs a Job Object (out of scope).

Note: a foreground command therefore can't leave a daemon running past its turn — intended for an agent tool; long-lived processes should use `run_in_background`.

## Tests
`TestReapTreeKillsGroupStragglers` (POSIX) runs a shell that backgrounds a `sleep 60` and exits, then asserts `reapTree` kills the stray. Runs in the ubuntu/macos CI test jobs. Build-verified on windows (no-op path) and linux (vet).

Closes #3702
