### PR TITLE
fix(desktop): convert \slashed to \not for KaTeX compatibility

### DIFF
--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -145,6 +145,12 @@ check("\\\\slashed{\\\\partial} is converted to \\not{\\\\partial}", () => {
 check("\\\\slashed in prose context", () => {
   return normalizeMath("The momentum $\\\\slashed{p}$ is conserved") === "The momentum $\\\\not{p}$ is conserved";
 });
+check("\\\\slashed\\\\epsilon(0) → \\not{\\epsilon(0)} (Greek + function)", () => {
+  return normalizeMath("$\\slashed\\epsilon(0)$") === "$\\not{\\epsilon(0)}$";
+});
+check("\\\\slashed a → \\not a (single letter)", () => {
+  return normalizeMath("$\\\\slashed a$") === "$\\\\not a$";
+});
 
 console.log("\nnormalizeMath — non-math dollar filtering");
 eq(normalizeMath("costs $5$ today"), "costs &#36;5&#36; today", "$5$ not math");

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -133,6 +133,19 @@ eq(normalizeMath("\\(x^2\\)"), "$x^2$", "\\(…\\) → $…$");
 eq(normalizeMath("\\[E=mc^2\\]"), "$$E=mc^2$$", "\\[…\\] → $$…$$");
 eq(normalizeMath("\\\\[4pt]"), "\\\\[4pt]", "\\\\[ line-break spacing protected");
 
+// ── normalizeMath — \\slashed conversion (regression) ─────────────────────────────
+// KaTeX doesn't support \\slashed (used in physics for Feynman slash notation),
+// so convert it to \\not which has a similar visual effect.
+check("\\\\slashed{p} is converted to \\not{p}", () => {
+  return normalizeMath("$\\\\slashed{p}$") === "$\\\\not{p}$";
+});
+check("\\\\slashed{\\\\partial} is converted to \\not{\\\\partial}", () => {
+  return normalizeMath("$\\\\slashed{\\\\partial}$") === "$\\\\not{\\\\partial}$";
+});
+check("\\\\slashed in prose context", () => {
+  return normalizeMath("The momentum $\\\\slashed{p}$ is conserved") === "The momentum $\\\\not{p}$ is conserved";
+});
+
 console.log("\nnormalizeMath — non-math dollar filtering");
 eq(normalizeMath("costs $5$ today"), "costs &#36;5&#36; today", "$5$ not math");
 eq(normalizeMath("env $PATH$ here"), "env &#36;PATH&#36; here", "$PATH$ not math");

--- a/desktop/frontend/src/components/latexNormalize.ts
+++ b/desktop/frontend/src/components/latexNormalize.ts
@@ -21,6 +21,12 @@ const TEXT_COMMANDS = new Set([
 ]);
 
 export function latexNormalizeForKatex(source: string): string {
+  // Convert \slashed{X} → \not{X}. KaTeX doesn't support \slashed, but
+  // \not provides a similar visual effect (slash through the character).
+  // This is commonly used in physics for Feynman slash notation (\slashed{p}).
+  // The regex handles one level of nested braces.
+  source = source.replace(/\\slashed\s*\{((?:[^{}]|\{[^{}]*\})*)\}/g, "\\not{$1}");
+
   let out = "";
   let i = 0;
 

--- a/desktop/frontend/src/components/latexNormalize.ts
+++ b/desktop/frontend/src/components/latexNormalize.ts
@@ -21,11 +21,25 @@ const TEXT_COMMANDS = new Set([
 ]);
 
 export function latexNormalizeForKatex(source: string): string {
-  // Convert \slashed{X} → \not{X}. KaTeX doesn't support \slashed, but
-  // \not provides a similar visual effect (slash through the character).
-  // This is commonly used in physics for Feynman slash notation (\slashed{p}).
-  // The regex handles one level of nested braces.
+  // Convert \slashed{X} → \not{X} and \slashed X → \not X. KaTeX doesn't
+  // support \slashed, but \not provides a similar visual effect (slash
+  // through the character). This is commonly used in physics for Feynman
+  // slash notation (\slashed{p}, \slashed{\partial}).
+  // Handles two forms:
+  //   1. Braced:    \slashed{X}     → \not{X}
+  //   2. Unbraced:  \slashed X      → \not X   (single token, no spaces)
   source = source.replace(/\\slashed\s*\{((?:[^{}]|\{[^{}]*\})*)\}/g, "\\not{$1}");
+  // Also handle unbraced forms:
+  //   \slashed\epsilon      → \not{\epsilon}
+  //   \slashed\epsilon(0)    → \not{\epsilon(0)}
+  //   \slashed a              → \not a
+  //   \slashed x              → \not x
+  // Match a backslash command (optionally followed by (...) for function calls)
+  // or a single ASCII letter. Use a function so we can add braces around
+  // function-call forms.
+  source = source.replace(/\\slashed\s*(\\[A-Za-z]+(?:\([^)]*\))?|[A-Za-z])/g, (_match, inner) => {
+    return inner.includes("(") ? `\\not{${inner}}` : `\\not ${inner}`;
+  });
 
   let out = "";
   let i = 0;


### PR DESCRIPTION
# Convert \slashed to \not for KaTeX compatibility

## Problem
KaTeX doesn't support the `\slashed` command from the LaTeX 'slashed' package, which is commonly used in physics for Feynman slash notation (`\slashed{p}`, `\slashed{\partial}`).

When the model emits these commands, Reasonix shows raw LaTeX source as red error text instead of rendering the formula.

## Solution
Convert `\slashed{X}` to `\not{X}` in `latexNormalizeForKatex`. The `\not` command provides a similar visual effect (a slash through the character) and is supported by KaTeX.

**Example:**
- Input: `$\slashed{p}$`
- After normalization: `$\not{p}$`
- Rendered: p with a slash through it (Feynman slash notation)

## Changes
- `desktop/frontend/src/components/latexNormalize.ts`: Added regex conversion
- `desktop/frontend/src/__tests__/math-golden.test.ts`: Added 3 test cases

## Tests
- 3 new test cases for `\slashed` conversion
- All tests pass (88 math-golden + 8 text-size + 6 provider-model-refresh = 102 total)

## Related
- This is a standalone fix that works with or without PR #3666
- PR #3666 has the core math pipeline improvements (classifier, code block protection, etc.)