### PR TITLE
fix(codegraph): stop leaking detached MCP daemons and indexing the whole drive (#3747)

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -245,6 +245,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if cfg.Codegraph.Enabled {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
+		case ok && !codegraph.IndexableRoot(root):
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
+				Text: "codegraph: project root is a filesystem root — skipped to avoid indexing the whole volume"})
 		case ok:
 			spec := plugin.Spec{
 				Name:              "codegraph",

--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -159,6 +159,24 @@ func Initialized(root string) bool {
 	return err == nil && fi.IsDir()
 }
 
+// IndexableRoot reports whether root is a real project directory CodeGraph can
+// safely be pinned to. A filesystem root (a Windows drive root like C:\, a UNC
+// share root, or the unix /) is rejected: serve --mcp walks its working
+// directory, so a root cwd makes it index the whole volume — C:\Windows,
+// C:\Program Files, everything — pinning gigabytes of RAM (#3747). An empty
+// root is rejected too: there is nothing to pin a cwd-aware server to.
+func IndexableRoot(root string) bool {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return false
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	return filepath.Dir(abs) != abs // a filesystem root is its own parent
+}
+
 func expand(p string) string {
 	p = os.ExpandEnv(p)
 	if strings.HasPrefix(p, "~/") {

--- a/internal/codegraph/codegraph_test.go
+++ b/internal/codegraph/codegraph_test.go
@@ -91,3 +91,25 @@ func TestEnsureInitPropagatesFailure(t *testing.T) {
 		t.Fatal("EnsureInit should return the init failure")
 	}
 }
+
+func TestIndexableRootRejectsFilesystemRoots(t *testing.T) {
+	if got := IndexableRoot(t.TempDir()); !got {
+		t.Fatal("a real project dir must be indexable")
+	}
+	for _, root := range []string{"", "   "} {
+		if IndexableRoot(root) {
+			t.Fatalf("IndexableRoot(%q) = true; want false", root)
+		}
+	}
+	var roots []string
+	if runtime.GOOS == "windows" {
+		roots = []string{`C:\`, `c:\`, `\\server\share`}
+	} else {
+		roots = []string{"/"}
+	}
+	for _, root := range roots {
+		if IndexableRoot(root) {
+			t.Fatalf("IndexableRoot(%q) = true; want false (filesystem root)", root)
+		}
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1728,6 +1728,9 @@ func (c *Controller) connectCodegraphMCPServer(cfg *config.Config) (int, error) 
 	if err != nil {
 		return 0, err
 	}
+	if !codegraph.IndexableRoot(cwd) {
+		return 0, fmt.Errorf("codegraph: refusing to index %q — a filesystem root would index the whole volume", cwd)
+	}
 	if err := codegraph.EnsureInit(c.pluginCtx, bin, cwd); err != nil {
 		return 0, fmt.Errorf("codegraph init: %w", err)
 	}

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -74,13 +74,14 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := cmd.Start(); err != nil {
+	job, err := proc.StartTracked(cmd)
+	if err != nil {
 		return nil, err
 	}
 	t := &stdioTransport{
 		name:    s.Name,
 		cmd:     cmd,
-		job:     proc.TrackTree(cmd),
+		job:     job,
 		stdin:   stdin,
 		stdout:  bufio.NewReader(stdout),
 		stderr:  stderr,

--- a/internal/proc/kill_other.go
+++ b/internal/proc/kill_other.go
@@ -12,9 +12,12 @@ func KillTree(cmd *exec.Cmd) {
 	_ = cmd.Process.Kill()
 }
 
-// TrackTree is a no-op off Windows (returns 0); KillTracked then falls back to
-// KillTree, which is sufficient where the platform reaps the child directly.
-func TrackTree(_ *exec.Cmd) uintptr { return 0 }
+// StartTracked starts cmd. Off Windows there is no Job Object to track it in —
+// the platform reaps the child directly — so it just starts and returns a 0
+// handle, and KillTracked falls back to KillTree.
+func StartTracked(cmd *exec.Cmd) (uintptr, error) {
+	return 0, cmd.Start()
+}
 
 // KillTracked terminates cmd's process tree; the handle is unused off Windows.
 func KillTracked(cmd *exec.Cmd, _ uintptr) { KillTree(cmd) }

--- a/internal/proc/kill_other_test.go
+++ b/internal/proc/kill_other_test.go
@@ -26,15 +26,16 @@ func TestKillTreeTerminatesChild(t *testing.T) {
 }
 
 func TestKillTrackedTerminatesChild(t *testing.T) {
-	if TrackTree(nil) != 0 {
-		t.Fatal("TrackTree is a no-op off Windows; want 0")
-	}
 	cmd := exec.Command("sleep", "30")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
+	job, err := StartTracked(cmd)
+	if err != nil {
+		t.Fatalf("StartTracked: %v", err)
+	}
+	if job != 0 {
+		t.Fatalf("StartTracked job = %d off Windows; want 0", job)
 	}
 
-	KillTracked(cmd, 0)
+	KillTracked(cmd, job)
 
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()

--- a/internal/proc/kill_windows.go
+++ b/internal/proc/kill_windows.go
@@ -5,6 +5,7 @@ package proc
 import (
 	"os/exec"
 	"strconv"
+	"syscall"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -24,14 +25,29 @@ func KillTree(cmd *exec.Cmd) {
 	_ = cmd.Process.Kill()
 }
 
-// TrackTree assigns cmd to a new Job Object set to terminate every process in
-// it when the job handle is closed. A launcher's detached grandchild (e.g. the
-// CodeGraph node daemon, which re-parents itself away from the launcher) stays
-// in the job even though it leaves cmd's live child tree, so KillTracked — and,
-// crucially, an abrupt reasonix exit, which closes the handle — still reaps it,
-// where taskkill /T would miss it. Returns 0 on failure; the caller then relies
-// on KillTree alone.
-func TrackTree(cmd *exec.Cmd) uintptr {
+// StartTracked starts cmd inside a new Job Object whose KILL_ON_JOB_CLOSE flag
+// fells the whole tree — including a launcher's detached grandchild (cmd.exe →
+// node.exe, as the CodeGraph daemon re-parents itself off the launcher) — when
+// the handle closes via KillTracked or an abrupt reasonix exit. The child is
+// created suspended and assigned to the job before it runs, so a fast shim can
+// no longer exec its grandchild and exit before assignment, orphaning a node
+// the job never captured (#3747). It is always resumed before returning, even
+// when job assignment fails, so a child is never left wedged suspended. Returns
+// the job handle, 0 if it could not be created — then KillTracked relies on
+// KillTree alone.
+func StartTracked(cmd *exec.Cmd) (uintptr, error) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= windows.CREATE_SUSPENDED
+	if err := cmd.Start(); err != nil {
+		return 0, err
+	}
+	defer resumeProcess(uint32(cmd.Process.Pid))
+	return assignJob(cmd), nil
+}
+
+func assignJob(cmd *exec.Cmd) uintptr {
 	if cmd == nil || cmd.Process == nil {
 		return 0
 	}
@@ -62,8 +78,31 @@ func TrackTree(cmd *exec.Cmd) uintptr {
 	return uintptr(job)
 }
 
-// KillTracked terminates cmd's whole process tree. When job (from TrackTree) is
-// non-zero, terminating it kills even detached descendants; the KillTree pass
+// resumeProcess resumes every thread of pid. A CREATE_SUSPENDED process has a
+// single suspended primary thread, so this releases it once the job is assigned.
+func resumeProcess(pid uint32) {
+	snap, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPTHREAD, 0)
+	if err != nil {
+		return
+	}
+	defer func() { _ = windows.CloseHandle(snap) }()
+	var te windows.ThreadEntry32
+	te.Size = uint32(unsafe.Sizeof(te))
+	for err := windows.Thread32First(snap, &te); err == nil; err = windows.Thread32Next(snap, &te) {
+		if te.OwnerProcessID != pid {
+			continue
+		}
+		th, err := windows.OpenThread(windows.THREAD_SUSPEND_RESUME, false, te.ThreadID)
+		if err != nil {
+			continue
+		}
+		_, _ = windows.ResumeThread(th)
+		_ = windows.CloseHandle(th)
+	}
+}
+
+// KillTracked terminates cmd's whole process tree. When job (from StartTracked)
+// is non-zero, terminating it kills even detached descendants; the KillTree pass
 // then catches anything spawned in the gap before the job was assigned.
 func KillTracked(cmd *exec.Cmd, job uintptr) {
 	if job != 0 {

--- a/internal/proc/kill_windows_test.go
+++ b/internal/proc/kill_windows_test.go
@@ -3,6 +3,7 @@
 package proc
 
 import (
+	"errors"
 	"io"
 	"os/exec"
 	"testing"
@@ -37,7 +38,7 @@ func TestKillTreeUnblocksWaitOnSurvivingGrandchild(t *testing.T) {
 	}
 }
 
-// TrackTree must create a Job Object for a started process, and KillTracked
+// StartTracked must create a Job Object for the started process, and KillTracked
 // must take the whole tracked tree down (the job reaps even descendants a plain
 // taskkill /T would miss — see the codegraph daemon leak this guards against).
 func TestKillTrackedReapsTrackedTree(t *testing.T) {
@@ -47,15 +48,14 @@ func TestKillTrackedReapsTrackedTree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StdoutPipe: %v", err)
 	}
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("Start: %v", err)
+	job, err := StartTracked(cmd)
+	if err != nil {
+		t.Fatalf("StartTracked: %v", err)
+	}
+	if job == 0 {
+		t.Fatal("StartTracked returned 0 — job object not created")
 	}
 	go func() { _, _ = io.Copy(io.Discard, stdout) }()
-
-	job := TrackTree(cmd)
-	if job == 0 {
-		t.Fatal("TrackTree returned 0 — job object not created")
-	}
 	time.Sleep(500 * time.Millisecond) // let cmd.exe exec the ping grandchild into the job
 
 	KillTracked(cmd, job)
@@ -66,5 +66,28 @@ func TestKillTrackedReapsTrackedTree(t *testing.T) {
 	case <-done:
 	case <-time.After(8 * time.Second):
 		t.Fatal("cmd.Wait blocked after KillTracked — tracked tree survived")
+	}
+}
+
+// StartTracked creates the child suspended to win the job-assignment race, so it
+// must resume it or the process hangs forever. A child that exits with a known
+// code proves the resume fired: Wait returns that code instead of timing out.
+func TestStartTrackedResumesSuspendedChild(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "exit", "7")
+	HideWindow(cmd)
+	if _, err := StartTracked(cmd); err != nil {
+		t.Fatalf("StartTracked: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		var ee *exec.ExitError
+		if !errors.As(err, &ee) || ee.ExitCode() != 7 {
+			t.Fatalf("exit = %v, want exit status 7", err)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("cmd.Wait blocked — StartTracked left the child suspended")
 	}
 }


### PR DESCRIPTION
## Problem

#3747: after a session, dozens of orphaned `codegraph serve --mcp` node processes survived (~1.7 GB), and one instance launched with cwd `C:\` indexed the entire system drive (~1 GB).

Two independent Reasonix-side root causes.

### 1. The job object lost the race against the launcher

Each stdio MCP server starts as `cmd.exe -> node.exe`; CodeGraph's shim re-parents the node daemon off the launcher. `TrackTree` assigned the process to its kill-on-close Job Object **after** `cmd.Start()` returned — but a fast `.cmd` shim can exec node and exit before that assignment lands, leaving `node.exe` orphaned in no job. `KillTracked` (and an abrupt reasonix exit, which relies on the job handle closing) then can't reap it, so every failed/closed handshake leaks a daemon.

**Fix:** `proc.StartTracked` creates the child suspended, assigns it to the job while it is still frozen, then resumes it — so the launcher and every descendant it spawns are captured before any code runs. The process is always resumed (even if assignment fails) so a child can never be left wedged suspended.

### 2. A filesystem-root cwd indexed the whole volume

CodeGraph is cwd-aware; when the project root resolved to `C:\` it walked the entire drive. `codegraph.IndexableRoot` now rejects drive roots, UNC share roots, `/`, and an empty root — checked at both spawn sites (boot and the `/codegraph` connect path) before launching `serve`.

## Tests

- `proc`: job assignment + reap through `StartTracked`; a deterministic resume check (a suspended child that must run to exit 7, so a missed resume fails instead of hanging).
- `codegraph`: `IndexableRoot` rejects `C:\`, `\server\share`, `/`, and `""`.

Verified locally on Windows 11: `golangci-lint` clean, `go vet`, and the proc / codegraph / plugin / boot / control package tests pass.

## Not in this PR

Dedup of concurrent codegraph spawns and an idle-timeout watchdog (#3747 items 2-3) are follow-ups. With reaping now reliable, leaked handles are felled on close and on exit, which removes the surviving-orphan harm; dedup/idle-timeout are an optimization on top.

Closes #3747
