### PR TITLE
test(desktop): use single-backslash inputs in the slashed golden tests

### DIFF
--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -133,24 +133,13 @@ eq(normalizeMath("\\(x^2\\)"), "$x^2$", "\\(…\\) → $…$");
 eq(normalizeMath("\\[E=mc^2\\]"), "$$E=mc^2$$", "\\[…\\] → $$…$$");
 eq(normalizeMath("\\\\[4pt]"), "\\\\[4pt]", "\\\\[ line-break spacing protected");
 
-// ── normalizeMath — \\slashed conversion (regression) ─────────────────────────────
-// KaTeX doesn't support \\slashed (used in physics for Feynman slash notation),
-// so convert it to \\not which has a similar visual effect.
-check("\\\\slashed{p} is converted to \\not{p}", () => {
-  return normalizeMath("$\\\\slashed{p}$") === "$\\\\not{p}$";
-});
-check("\\\\slashed{\\\\partial} is converted to \\not{\\\\partial}", () => {
-  return normalizeMath("$\\\\slashed{\\\\partial}$") === "$\\\\not{\\\\partial}$";
-});
-check("\\\\slashed in prose context", () => {
-  return normalizeMath("The momentum $\\\\slashed{p}$ is conserved") === "The momentum $\\\\not{p}$ is conserved";
-});
-check("\\\\slashed\\\\epsilon(0) → \\not{\\epsilon(0)} (Greek + function)", () => {
-  return normalizeMath("$\\slashed\\epsilon(0)$") === "$\\not{\\epsilon(0)}$";
-});
-check("\\\\slashed a → \\not a (single letter)", () => {
-  return normalizeMath("$\\\\slashed a$") === "$\\\\not a$";
-});
+// ── normalizeMath — \slashed conversion (regression) ──────────────────────────
+// KaTeX has no \slashed (Feynman slash notation); it is rewritten to \not.
+eq(normalizeMath("$\\slashed{p}$"), "$\\not{p}$", "\\slashed{p} → \\not{p}");
+eq(normalizeMath("$\\slashed{\\partial}$"), "$\\not{\\partial}$", "\\slashed{\\partial} → \\not{\\partial}");
+eq(normalizeMath("The momentum $\\slashed{p}$ is conserved"), "The momentum $\\not{p}$ is conserved", "\\slashed in prose");
+eq(normalizeMath("$\\slashed\\epsilon(0)$"), "$\\not{\\epsilon(0)}$", "\\slashed\\epsilon(0) → \\not{\\epsilon(0)} (unbraced fn)");
+eq(normalizeMath("$\\slashed a$"), "$\\not a$", "\\slashed a → \\not a (unbraced letter)");
 
 console.log("\nnormalizeMath — non-math dollar filtering");
 eq(normalizeMath("costs $5$ today"), "costs &#36;5&#36; today", "$5$ not math");


### PR DESCRIPTION
Follow-up to #3750 (test-only).

The `\slashed -> \not` golden cases wrote their braced inputs with a double backslash (`\slashed{p}`), while real model output is a single one (`\slashed{p}`). The conversion regex matched either way, so the tests passed — but they asserted a form the model never emits and left the production single-backslash braced form uncovered.

This switches those cases to single-backslash inputs and to the `eq()` helper the surrounding golden tests already use (the unbraced `\slashed\epsilon(0)` / `\slashed a` cases were already single-backslash). No production code changes; `npm --prefix desktop/frontend test` stays green (90/90).
