### PR TITLE
fix: custom provider model list overflow and add /provider command

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1614,6 +1614,7 @@ func (a *App) Commands() []CommandInfo {
 		{Name: "new", Description: i18n.M.CmdNew, Kind: "builtin"},
 		{Name: "compact", Description: i18n.M.CmdCompact, Kind: "builtin"},
 		{Name: "model", Description: i18n.M.CmdModel, Kind: "builtin"},
+		{Name: "provider", Description: i18n.M.CmdProvider, Kind: "builtin"},
 		{Name: "effort", Description: i18n.M.CmdEffort, Kind: "builtin"},
 		{Name: "memory", Description: i18n.M.CmdMemory, Kind: "builtin"},
 		{Name: "remember", Description: i18n.M.CmdRemember, Kind: "builtin"},
@@ -1684,8 +1685,16 @@ func (a *App) SlashArgs(input string) SlashArgsResult {
 		DisconnectedMCP: ctrl.DisconnectedMCPNames(),
 		CurrentModel:    model,
 	}
+	seen := map[string]bool{}
 	for _, m := range a.Models() {
 		data.ModelRefs = append(data.ModelRefs, m.Ref)
+		if m.Provider != "" && !seen[m.Provider] {
+			seen[m.Provider] = true
+			data.ProviderNames = append(data.ProviderNames, m.Provider)
+		}
+		if m.Current {
+			data.CurrentProvider = m.Provider
+		}
 	}
 	if h := ctrl.Host(); h != nil {
 		data.ServerNames = h.ServerNames()

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3214,6 +3214,12 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		if m.pendingModelSwitch != nil {
 			return m.pendingModelSwitch
 		}
+	case "/provider":
+		m.echoLocalCommand(input)
+		m.runProviderCommand(input)
+		if m.pendingModelSwitch != nil {
+			return m.pendingModelSwitch
+		}
 	case "/skill", "/skills":
 		m.echoLocalCommand(input)
 		m.runSkillSubcommand(input)

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -70,6 +70,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/switch", insert: "/switch ", hint: i18n.M.CmdSwitchBranch},
 		{label: "/mcp", insert: "/mcp", hint: i18n.M.CmdMcp},
 		{label: "/model", insert: "/model ", hint: i18n.M.CmdModel, descend: true},
+		{label: "/provider", insert: "/provider ", hint: i18n.M.CmdProvider, descend: true},
 		{label: "/skills", insert: "/skills", hint: i18n.M.CmdSkill},
 		{label: "/hooks", insert: "/hooks ", hint: i18n.M.CmdHooks, descend: true},
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
@@ -169,10 +170,16 @@ func (m *chatTUI) slashArgItems(val string) ([]compItem, int, bool) {
 }
 
 func (m *chatTUI) slashArgData() control.ArgData {
+	curProvider := ""
+	if parts := strings.SplitN(m.modelRef, "/", 2); len(parts) == 2 {
+		curProvider = parts[0]
+	}
 	data := control.ArgData{
-		Skills:       m.skills,
-		ModelRefs:    modelRefs(),
-		CurrentModel: m.modelRef,
+		Skills:          m.skills,
+		ModelRefs:       modelRefs(),
+		CurrentModel:    m.modelRef,
+		ProviderNames:   providerNames(),
+		CurrentProvider: curProvider,
 	}
 	if m.ctrl != nil {
 		data.DisabledSkills = m.ctrl.DisabledSkills()

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -64,6 +64,7 @@ func builtinHelpItems() []compItem {
 		{label: "/switch", hint: i18n.M.CmdSwitchBranch},
 		{label: "/todo", hint: i18n.M.CmdTodo},
 		{label: "/model", hint: i18n.M.CmdModel},
+		{label: "/provider", hint: i18n.M.CmdProvider},
 		{label: "/mcp", hint: i18n.M.CmdMcp},
 		{label: "/skills", hint: i18n.M.CmdSkill},
 		{label: "/hooks", hint: i18n.M.CmdHooks},

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -141,3 +141,20 @@ func modelRefs() []string {
 	}
 	return out
 }
+
+// providerNames returns the names of configured providers for slash completion.
+func providerNames() []string {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
+		out = append(out, p.Name)
+	}
+	return out
+}

--- a/internal/cli/provider.go
+++ b/internal/cli/provider.go
@@ -44,24 +44,20 @@ func (m *chatTUI) showProviders() {
 		if !p.Configured() {
 			continue
 		}
+		// Prefer chat models for display; fall back to the full model list
+		// (which includes non-chat models like embeddings) for count/label.
 		models := p.ChatModelList()
-		modelCount := len(models)
-		if modelCount == 0 {
-			modelCount = len(p.ModelList())
+		if len(models) == 0 {
+			models = p.ModelList()
 		}
 
 		status := ""
 		if p.Name == curProvider {
 			status = "  " + viewStatus("active")
 		}
-		modelLabel := fmt.Sprintf("%d models", modelCount)
-		if modelCount == 1 {
+		modelLabel := fmt.Sprintf("%d models", len(models))
+		if len(models) == 1 {
 			modelLabel = models[0]
-			if modelLabel == "" {
-				if l := p.ModelList(); len(l) > 0 {
-					modelLabel = l[0]
-				}
-			}
 		}
 		line := fmt.Sprintf("  %-16s  %-20s  %s%s", p.Name, modelLabel, dim(p.Kind), status)
 		lines = append(lines, line)

--- a/internal/cli/provider.go
+++ b/internal/cli/provider.go
@@ -1,0 +1,139 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/config"
+	"reasonix/internal/i18n"
+)
+
+// runProviderCommand handles "/provider": with no argument it lists the configured
+// providers and marks the active one; "/provider <name>" switches to that
+// provider's default model (or prompts the user to pick one when multiple models
+// are configured).
+func (m *chatTUI) runProviderCommand(input string) {
+	args := tokenizeArgs(input) // args[0] == "/provider"
+	if len(args) < 2 {
+		m.showProviders()
+		return
+	}
+	name := args[1]
+	m.switchToProvider(name)
+}
+
+// showProviders lists all configured providers, marking the one backing the
+// current model.
+func (m *chatTUI) showProviders() {
+	cfg, err := config.Load()
+	if err != nil {
+		m.notice("provider: " + err.Error())
+		return
+	}
+	var lines []string
+	lines = append(lines, viewHeader("%s", i18n.M.ProviderListHeader))
+
+	// Determine the current provider name from m.modelRef ("provider/model").
+	curProvider := ""
+	if parts := strings.SplitN(m.modelRef, "/", 2); len(parts) == 2 {
+		curProvider = parts[0]
+	}
+
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
+		models := p.ChatModelList()
+		modelCount := len(models)
+		if modelCount == 0 {
+			modelCount = len(p.ModelList())
+		}
+
+		status := ""
+		if p.Name == curProvider {
+			status = "  " + viewStatus("active")
+		}
+		modelLabel := fmt.Sprintf("%d models", modelCount)
+		if modelCount == 1 {
+			modelLabel = models[0]
+			if modelLabel == "" {
+				if l := p.ModelList(); len(l) > 0 {
+					modelLabel = l[0]
+				}
+			}
+		}
+		line := fmt.Sprintf("  %-16s  %-20s  %s%s", p.Name, modelLabel, dim(p.Kind), status)
+		lines = append(lines, line)
+	}
+	lines = append(lines, viewHint(viewCompactText("switch with /provider <name>", m.width)))
+	m.commitLine(strings.Join(lines, "\n"))
+}
+
+// switchToProvider switches the session to the named provider's default model.
+// If the provider has multiple models, it shows an interactive picker (in the
+// setup/CLI style) if running in a TTY, or falls back to a notice listing
+// available models.
+func (m *chatTUI) switchToProvider(name string) {
+	cfg, err := config.Load()
+	if err != nil {
+		m.notice("provider: " + err.Error())
+		return
+	}
+	var entry *config.ProviderEntry
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if p.Name == name && p.Configured() {
+			entry = p
+			break
+		}
+	}
+	if entry == nil {
+		m.notice(fmt.Sprintf(i18n.M.ProviderUnknownFmt, name))
+		return
+	}
+
+	// Determine current provider.
+	curProvider := ""
+	if parts := strings.SplitN(m.modelRef, "/", 2); len(parts) == 2 {
+		curProvider = parts[0]
+	}
+
+	models := entry.ChatModelList()
+	if len(models) == 0 {
+		models = entry.ModelList()
+	}
+	if len(models) == 0 {
+		m.notice(fmt.Sprintf(i18n.M.ProviderNoModelsFmt, name))
+		return
+	}
+
+	// If only one model, switch directly.
+	if len(models) == 1 {
+		ref := entry.Name + "/" + models[0]
+		if entry.Name == curProvider && models[0] == "" {
+			m.notice(fmt.Sprintf(i18n.M.ProviderAlreadyOnFmt, name))
+			return
+		}
+		m.runModelSubcommand("/model " + ref)
+		return
+	}
+
+	// If already on this provider, just notify.
+	if entry.Name == curProvider {
+		m.notice(fmt.Sprintf(i18n.M.ProviderAlreadyOnFmt, name))
+		return
+	}
+
+	// Multiple models — use the TUI notice to list them and tell the user to
+	// pick one with /model. We don't launch raw-mode selectOne from inside the
+	// bubbletea event loop because it would conflict with bubbletea's terminal
+	// management. Instead, we show the available models and suggest /model.
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\n", viewHeader("%s", fmt.Sprintf(i18n.M.ProviderPickLabel, name)))
+	for _, model := range models {
+		fmt.Fprintf(&b, "  %s\n", model)
+	}
+	fmt.Fprintf(&b, "%s", viewHint(viewCompactText(fmt.Sprintf("switch with /model %s/<model>", entry.Name), m.width)))
+	m.commitLine(strings.TrimRight(b.String(), "\n"))
+}

--- a/internal/cli/select.go
+++ b/internal/cli/select.go
@@ -28,12 +28,23 @@ func termHeight(fd int) int {
 	return h
 }
 
-// maxViewport calculates how many menu rows fit in the terminal after subtracting
-// the header (2 lines) and the hint/footer (1 line), leaving at least 5 rows.
-func maxViewport(totalItems, termRows int) int {
-	avail := termRows - 3 // header + blank + footer
-	if avail < 5 {
-		avail = 5
+// fixedLines returns the number of non-item lines rendered each frame:
+// header label, blank separator, scroll-up indicator, scroll-down indicator.
+// When searching is true the search bar adds one more line.
+func fixedLines(searching bool) int {
+	n := 4 // header + blank + scroll-up + scroll-down
+	if searching {
+		n++ // search bar
+	}
+	return n
+}
+
+// maxViewport calculates how many menu item rows fit after subtracting the
+// fixed lines from the available terminal rows, leaving at least 1 row.
+func maxViewport(totalItems, termRows int, searching bool) int {
+	avail := termRows - fixedLines(searching)
+	if avail < 1 {
+		avail = 1
 	}
 	if totalItems < avail {
 		return totalItems
@@ -81,22 +92,19 @@ func selectOne(label string, items []menuItem) (int, error) {
 	// search state
 	searching := false
 	searchQuery := ""
-	filtered := items                    // indices into original items
-	filterIdx := make([]int, len(items)) // maps filtered position → original index
+	filtered := items
+	filterIdx := make([]int, len(items))
 	for i := range items {
 		filterIdx[i] = i
 	}
 
 	sel := 0
 	scroll := 0
+	prevLines := 0 // lines printed in the previous frame; 0 = first frame
 
 	render := func() {
 		n := len(filtered)
-		if n == 0 {
-			return
-		}
-		// clamp viewport
-		vp := maxViewport(n, th)
+		vp := maxViewport(n, th, searching)
 		// adjust scroll to keep sel visible
 		if sel < scroll {
 			scroll = sel
@@ -108,8 +116,8 @@ func selectOne(label string, items []menuItem) (int, error) {
 			scroll = 0
 		}
 
-		// scroll-up indicator
-		if scroll > 0 {
+		// scroll-up indicator (always 1 line)
+		if n > 0 && scroll > 0 {
 			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreAboveFmt, scroll)))
 		} else {
 			fmt.Fprintf(w, "\r\033[K\r\n")
@@ -129,16 +137,20 @@ func selectOne(label string, items []menuItem) (int, error) {
 				fmt.Fprintf(w, "\r\033[K   %s %s\r\n", name, dim(it.desc))
 			}
 		}
+		// if fewer items than viewport, pad with blank lines so the frame
+		// height stays constant
+		for i := end - scroll; i < vp; i++ {
+			fmt.Fprintf(w, "\r\033[K\r\n")
+		}
 
-		// scroll-down indicator
-		if end < n {
+		// scroll-down indicator (always 1 line)
+		if n > 0 && end < n {
 			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreBelowFmt, n-end)))
 		} else {
 			fmt.Fprintf(w, "\r\033[K\r\n")
 		}
 	}
 
-	// initial header + search bar area
 	drawHeader := func() {
 		if searching {
 			fmt.Fprintf(w, "\r\033[K%s %s  %s\r\n\r\n", accent("▌"), bold(label), dim(i18n.M.SelectSearchHint))
@@ -148,18 +160,19 @@ func selectOne(label string, items []menuItem) (int, error) {
 		}
 	}
 
-	// total lines to move up for redraw: header(2) + searchbar(if searching)(1) + viewport items + scroll indicators
-	totalLines := func() int {
-		vp := maxViewport(len(filtered), th)
-		lines := 2 + vp + 2 // header + blank + items + top/bottom scroll indicators
-		if searching {
-			lines++ // search bar
+	redraw := func() {
+		if prevLines > 0 {
+			fmt.Fprintf(w, "\033[%dA", prevLines)
 		}
-		return lines
+		drawHeader()
+		render()
+		// Clear everything below the current frame so stale rows from a taller
+		// previous frame don't linger.
+		fmt.Fprint(w, "\033[J")
+		prevLines = fixedLines(searching) + maxViewport(len(filtered), th, searching)
 	}
 
-	drawHeader()
-	render()
+	redraw() // initial draw
 
 	buf := make([]byte, 8)
 	for {
@@ -181,10 +194,7 @@ func selectOne(label string, items []menuItem) (int, error) {
 				}
 				sel = 0
 				scroll = 0
-				// redraw: move up and redraw everything
-				fmt.Fprintf(w, "\033[%dA", totalLines())
-				drawHeader()
-				render()
+				redraw()
 			case k[0] == '\r' || k[0] == '\n':
 				if len(filtered) > 0 {
 					fmt.Fprint(w, "\r\n")
@@ -197,9 +207,7 @@ func selectOne(label string, items []menuItem) (int, error) {
 					filterIdx = filterIndices(items, searchQuery)
 					sel = 0
 					scroll = 0
-					fmt.Fprintf(w, "\033[%dA", totalLines())
-					drawHeader()
-					render()
+					redraw()
 				}
 			case k[0] == 3: // Ctrl-C
 				fmt.Fprint(w, "\r\n")
@@ -210,9 +218,7 @@ func selectOne(label string, items []menuItem) (int, error) {
 				filterIdx = filterIndices(items, searchQuery)
 				sel = 0
 				scroll = 0
-				fmt.Fprintf(w, "\033[%dA", totalLines())
-				drawHeader()
-				render()
+				redraw()
 			default:
 				continue
 			}
@@ -229,9 +235,7 @@ func selectOne(label string, items []menuItem) (int, error) {
 		case k[0] == '/': // enter search mode
 			searching = true
 			searchQuery = ""
-			fmt.Fprintf(w, "\033[%dA", totalLines())
-			drawHeader()
-			render()
+			redraw()
 		case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'A': // up
 			if sel > 0 {
 				sel--
@@ -251,9 +255,7 @@ func selectOne(label string, items []menuItem) (int, error) {
 		default:
 			continue // ignore other keys, no redraw
 		}
-		fmt.Fprintf(w, "\033[%dA", totalLines())
-		drawHeader()
-		render()
+		redraw()
 	}
 }
 
@@ -285,13 +287,11 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 	cur := 0
 	checked := make([]bool, len(items))
 	scroll := 0
+	prevLines := 0
 
 	render := func() {
 		n := len(filtered)
-		if n == 0 {
-			return
-		}
-		vp := maxViewport(n, th)
+		vp := maxViewport(n, th, searching)
 		if cur < scroll {
 			scroll = cur
 		}
@@ -302,7 +302,7 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 			scroll = 0
 		}
 
-		if scroll > 0 {
+		if n > 0 && scroll > 0 {
 			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreAboveFmt, scroll)))
 		} else {
 			fmt.Fprintf(w, "\r\033[K\r\n")
@@ -326,21 +326,15 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 				fmt.Fprintf(w, "\r\033[K   %s %s %s\r\n", box, name, dim(it.desc))
 			}
 		}
+		for i := end - scroll; i < vp; i++ {
+			fmt.Fprintf(w, "\r\033[K\r\n")
+		}
 
-		if end < n {
+		if n > 0 && end < n {
 			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreBelowFmt, n-end)))
 		} else {
 			fmt.Fprintf(w, "\r\033[K\r\n")
 		}
-	}
-
-	totalLines := func() int {
-		vp := maxViewport(len(filtered), th)
-		lines := 2 + vp + 2
-		if searching {
-			lines++
-		}
-		return lines
 	}
 
 	drawHeader := func() {
@@ -352,8 +346,17 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 		}
 	}
 
-	drawHeader()
-	render()
+	redraw := func() {
+		if prevLines > 0 {
+			fmt.Fprintf(w, "\033[%dA", prevLines)
+		}
+		drawHeader()
+		render()
+		fmt.Fprint(w, "\033[J")
+		prevLines = fixedLines(searching) + maxViewport(len(filtered), th, searching)
+	}
+
+	redraw()
 
 	buf := make([]byte, 8)
 	for {
@@ -375,9 +378,7 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 				}
 				cur = 0
 				scroll = 0
-				fmt.Fprintf(w, "\033[%dA", totalLines())
-				drawHeader()
-				render()
+				redraw()
 			case k[0] == '\r' || k[0] == '\n':
 				var out []int
 				for i, c := range checked {
@@ -402,9 +403,7 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 					filterIdx = filterIndices(items, searchQuery)
 					cur = 0
 					scroll = 0
-					fmt.Fprintf(w, "\033[%dA", totalLines())
-					drawHeader()
-					render()
+					redraw()
 				}
 			case k[0] == 3: // Ctrl-C
 				fmt.Fprint(w, "\r\n")
@@ -415,9 +414,7 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 				filterIdx = filterIndices(items, searchQuery)
 				cur = 0
 				scroll = 0
-				fmt.Fprintf(w, "\033[%dA", totalLines())
-				drawHeader()
-				render()
+				redraw()
 			case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'A':
 				if cur > 0 {
 					cur--
@@ -437,9 +434,7 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 			default:
 				continue
 			}
-			fmt.Fprintf(w, "\033[%dA", totalLines())
-			drawHeader()
-			render()
+			redraw()
 			continue
 		}
 
@@ -462,9 +457,7 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 		case k[0] == '/': // enter search mode
 			searching = true
 			searchQuery = ""
-			fmt.Fprintf(w, "\033[%dA", totalLines())
-			drawHeader()
-			render()
+			redraw()
 		case k[0] == ' ':
 			if len(filtered) > 0 {
 				origIdx := filterIdx[cur]
@@ -489,9 +482,7 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 		default:
 			continue
 		}
-		fmt.Fprintf(w, "\033[%dA", totalLines())
-		drawHeader()
-		render()
+		redraw()
 	}
 }
 
@@ -512,4 +503,10 @@ func filterIndices(items []menuItem, query string) []int {
 		}
 	}
 	return out
+}
+
+// FrameLines is exported for testing. It returns the total number of terminal
+// lines that selectOne/selectMany will print for the given state.
+func FrameLines(filteredLen, termRows int, searching bool) int {
+	return fixedLines(searching) + maxViewport(filteredLen, termRows, searching)
 }

--- a/internal/cli/select.go
+++ b/internal/cli/select.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"golang.org/x/term"
 
@@ -18,9 +19,54 @@ type menuItem struct {
 	desc string
 }
 
+// termHeight returns the terminal's row count, falling back to 24 on error.
+func termHeight(fd int) int {
+	_, h, err := term.GetSize(fd)
+	if err != nil || h <= 0 {
+		return 24
+	}
+	return h
+}
+
+// maxViewport calculates how many menu rows fit in the terminal after subtracting
+// the header (2 lines) and the hint/footer (1 line), leaving at least 5 rows.
+func maxViewport(totalItems, termRows int) int {
+	avail := termRows - 3 // header + blank + footer
+	if avail < 5 {
+		avail = 5
+	}
+	if totalItems < avail {
+		return totalItems
+	}
+	return avail
+}
+
+// renderSearchBar draws the search input line when searching is active.
+func renderSearchBar(w *os.File, query string) {
+	fmt.Fprintf(w, "\r\033[K%s %s\n", accent("🔍"), query+"_")
+}
+
+// filterMenuItems returns items whose name or desc contain the query (case-insensitive).
+func filterMenuItems(items []menuItem, query string) []menuItem {
+	if query == "" {
+		return items
+	}
+	lq := strings.ToLower(query)
+	var out []menuItem
+	for _, it := range items {
+		if strings.Contains(strings.ToLower(it.name), lq) || strings.Contains(strings.ToLower(it.desc), lq) {
+			out = append(out, it)
+		}
+	}
+	return out
+}
+
 // selectOne renders an interactive single-choice menu navigated with the arrow
 // keys (or j/k), confirmed with Enter, aborted with q or Ctrl-C. It puts the
 // terminal in raw mode, so it requires a TTY (callers gate on isInteractive).
+// When the item list exceeds the terminal height, only a viewport-sized window
+// is shown, with scroll indicators. Pressing '/' enters search mode to filter
+// items by keyword.
 func selectOne(label string, items []menuItem) (int, error) {
 	fd := int(os.Stdin.Fd())
 	old, err := term.MakeRaw(fd)
@@ -30,11 +76,52 @@ func selectOne(label string, items []menuItem) (int, error) {
 	defer term.Restore(fd, old)
 
 	w := os.Stdout
-	fmt.Fprintf(w, "%s %s  %s\r\n\r\n", accent("▌"), bold(label), dim(i18n.M.SelectOneHint))
+	th := termHeight(fd)
+
+	// search state
+	searching := false
+	searchQuery := ""
+	filtered := items                    // indices into original items
+	filterIdx := make([]int, len(items)) // maps filtered position → original index
+	for i := range items {
+		filterIdx[i] = i
+	}
 
 	sel := 0
+	scroll := 0
+
 	render := func() {
-		for i, it := range items {
+		n := len(filtered)
+		if n == 0 {
+			return
+		}
+		// clamp viewport
+		vp := maxViewport(n, th)
+		// adjust scroll to keep sel visible
+		if sel < scroll {
+			scroll = sel
+		}
+		if sel >= scroll+vp {
+			scroll = sel - vp + 1
+		}
+		if scroll < 0 {
+			scroll = 0
+		}
+
+		// scroll-up indicator
+		if scroll > 0 {
+			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreAboveFmt, scroll)))
+		} else {
+			fmt.Fprintf(w, "\r\033[K\r\n")
+		}
+
+		// menu rows
+		end := scroll + vp
+		if end > n {
+			end = n
+		}
+		for i := scroll; i < end; i++ {
+			it := filtered[i]
 			name := fmt.Sprintf("%-10s", it.name)
 			if i == sel {
 				fmt.Fprintf(w, "\r\033[K%s\r\n", reverse(fmt.Sprintf(" ❯ %s %s ", name, it.desc)))
@@ -42,7 +129,36 @@ func selectOne(label string, items []menuItem) (int, error) {
 				fmt.Fprintf(w, "\r\033[K   %s %s\r\n", name, dim(it.desc))
 			}
 		}
+
+		// scroll-down indicator
+		if end < n {
+			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreBelowFmt, n-end)))
+		} else {
+			fmt.Fprintf(w, "\r\033[K\r\n")
+		}
 	}
+
+	// initial header + search bar area
+	drawHeader := func() {
+		if searching {
+			fmt.Fprintf(w, "\r\033[K%s %s  %s\r\n\r\n", accent("▌"), bold(label), dim(i18n.M.SelectSearchHint))
+			renderSearchBar(w, searchQuery)
+		} else {
+			fmt.Fprintf(w, "\r\033[K%s %s  %s\r\n\r\n", accent("▌"), bold(label), dim(i18n.M.SelectOneHint))
+		}
+	}
+
+	// total lines to move up for redraw: header(2) + searchbar(if searching)(1) + viewport items + scroll indicators
+	totalLines := func() int {
+		vp := maxViewport(len(filtered), th)
+		lines := 2 + vp + 2 // header + blank + items + top/bottom scroll indicators
+		if searching {
+			lines++ // search bar
+		}
+		return lines
+	}
+
+	drawHeader()
 	render()
 
 	buf := make([]byte, 8)
@@ -52,19 +168,76 @@ func selectOne(label string, items []menuItem) (int, error) {
 			return 0, err
 		}
 		k := buf[:n]
+
+		if searching {
+			switch {
+			case k[0] == 27: // Esc — exit search
+				searching = false
+				searchQuery = ""
+				filtered = items
+				filterIdx = make([]int, len(items))
+				for i := range items {
+					filterIdx[i] = i
+				}
+				sel = 0
+				scroll = 0
+				// redraw: move up and redraw everything
+				fmt.Fprintf(w, "\033[%dA", totalLines())
+				drawHeader()
+				render()
+			case k[0] == '\r' || k[0] == '\n':
+				if len(filtered) > 0 {
+					fmt.Fprint(w, "\r\n")
+					return filterIdx[sel], nil
+				}
+			case k[0] == 127 || k[0] == 8: // backspace
+				if len(searchQuery) > 0 {
+					searchQuery = searchQuery[:len(searchQuery)-1]
+					filtered = filterMenuItems(items, searchQuery)
+					filterIdx = filterIndices(items, searchQuery)
+					sel = 0
+					scroll = 0
+					fmt.Fprintf(w, "\033[%dA", totalLines())
+					drawHeader()
+					render()
+				}
+			case k[0] == 3: // Ctrl-C
+				fmt.Fprint(w, "\r\n")
+				return 0, errCancelled
+			case k[0] >= 32 && k[0] < 127: // printable
+				searchQuery += string(k[0])
+				filtered = filterMenuItems(items, searchQuery)
+				filterIdx = filterIndices(items, searchQuery)
+				sel = 0
+				scroll = 0
+				fmt.Fprintf(w, "\033[%dA", totalLines())
+				drawHeader()
+				render()
+			default:
+				continue
+			}
+			continue
+		}
+
 		switch {
 		case k[0] == '\r' || k[0] == '\n':
 			fmt.Fprint(w, "\r\n")
-			return sel, nil
+			return filterIdx[sel], nil
 		case k[0] == 3 || k[0] == 'q': // Ctrl-C or q
 			fmt.Fprint(w, "\r\n")
 			return 0, errCancelled
+		case k[0] == '/': // enter search mode
+			searching = true
+			searchQuery = ""
+			fmt.Fprintf(w, "\033[%dA", totalLines())
+			drawHeader()
+			render()
 		case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'A': // up
 			if sel > 0 {
 				sel--
 			}
 		case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'B': // down
-			if sel < len(items)-1 {
+			if sel < len(filtered)-1 {
 				sel++
 			}
 		case k[0] == 'k':
@@ -72,20 +245,23 @@ func selectOne(label string, items []menuItem) (int, error) {
 				sel--
 			}
 		case k[0] == 'j':
-			if sel < len(items)-1 {
+			if sel < len(filtered)-1 {
 				sel++
 			}
 		default:
 			continue // ignore other keys, no redraw
 		}
-		fmt.Fprintf(w, "\033[%dA", len(items)) // move back up to the first item
+		fmt.Fprintf(w, "\033[%dA", totalLines())
+		drawHeader()
 		render()
 	}
 }
 
 // selectMany renders an interactive multi-choice menu: arrow keys (or j/k) move,
 // Space toggles, Enter confirms (at least one required), q/Ctrl-C aborts. It
-// returns the checked indices in order and requires a TTY.
+// returns the checked indices in order and requires a TTY. When the item list
+// exceeds the terminal height, only a viewport-sized window is shown. Pressing
+// '/' enters search mode to filter items by keyword.
 func selectMany(label string, items []menuItem) ([]int, error) {
 	fd := int(os.Stdin.Fd())
 	old, err := term.MakeRaw(fd)
@@ -95,14 +271,52 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 	defer term.Restore(fd, old)
 
 	w := os.Stdout
-	fmt.Fprintf(w, "%s %s  %s\r\n\r\n", accent("▌"), bold(label), dim(i18n.M.SelectManyHint))
+	th := termHeight(fd)
+
+	// search state
+	searching := false
+	searchQuery := ""
+	filtered := items
+	filterIdx := make([]int, len(items))
+	for i := range items {
+		filterIdx[i] = i
+	}
 
 	cur := 0
 	checked := make([]bool, len(items))
+	scroll := 0
+
 	render := func() {
-		for i, it := range items {
+		n := len(filtered)
+		if n == 0 {
+			return
+		}
+		vp := maxViewport(n, th)
+		if cur < scroll {
+			scroll = cur
+		}
+		if cur >= scroll+vp {
+			scroll = cur - vp + 1
+		}
+		if scroll < 0 {
+			scroll = 0
+		}
+
+		if scroll > 0 {
+			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreAboveFmt, scroll)))
+		} else {
+			fmt.Fprintf(w, "\r\033[K\r\n")
+		}
+
+		end := scroll + vp
+		if end > n {
+			end = n
+		}
+		for i := scroll; i < end; i++ {
+			it := filtered[i]
+			origIdx := filterIdx[i]
 			box := "[ ]"
-			if checked[i] {
+			if checked[origIdx] {
 				box = "[x]"
 			}
 			name := fmt.Sprintf("%-14s", it.name)
@@ -112,7 +326,33 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 				fmt.Fprintf(w, "\r\033[K   %s %s %s\r\n", box, name, dim(it.desc))
 			}
 		}
+
+		if end < n {
+			fmt.Fprintf(w, "\r\033[K%s\n", dim(fmt.Sprintf(i18n.M.SelectMoreBelowFmt, n-end)))
+		} else {
+			fmt.Fprintf(w, "\r\033[K\r\n")
+		}
 	}
+
+	totalLines := func() int {
+		vp := maxViewport(len(filtered), th)
+		lines := 2 + vp + 2
+		if searching {
+			lines++
+		}
+		return lines
+	}
+
+	drawHeader := func() {
+		if searching {
+			fmt.Fprintf(w, "\r\033[K%s %s  %s\r\n\r\n", accent("▌"), bold(label), dim(i18n.M.SelectSearchHint))
+			renderSearchBar(w, searchQuery)
+		} else {
+			fmt.Fprintf(w, "\r\033[K%s %s  %s\r\n\r\n", accent("▌"), bold(label), dim(i18n.M.SelectManyHint))
+		}
+	}
+
+	drawHeader()
 	render()
 
 	buf := make([]byte, 8)
@@ -122,6 +362,87 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 			return nil, err
 		}
 		k := buf[:n]
+
+		if searching {
+			switch {
+			case k[0] == 27: // Esc — exit search
+				searching = false
+				searchQuery = ""
+				filtered = items
+				filterIdx = make([]int, len(items))
+				for i := range items {
+					filterIdx[i] = i
+				}
+				cur = 0
+				scroll = 0
+				fmt.Fprintf(w, "\033[%dA", totalLines())
+				drawHeader()
+				render()
+			case k[0] == '\r' || k[0] == '\n':
+				var out []int
+				for i, c := range checked {
+					if c {
+						out = append(out, i)
+					}
+				}
+				if len(out) == 0 {
+					continue
+				}
+				fmt.Fprint(w, "\r\n")
+				return out, nil
+			case k[0] == ' ':
+				if len(filtered) > 0 {
+					origIdx := filterIdx[cur]
+					checked[origIdx] = !checked[origIdx]
+				}
+			case k[0] == 127 || k[0] == 8: // backspace
+				if len(searchQuery) > 0 {
+					searchQuery = searchQuery[:len(searchQuery)-1]
+					filtered = filterMenuItems(items, searchQuery)
+					filterIdx = filterIndices(items, searchQuery)
+					cur = 0
+					scroll = 0
+					fmt.Fprintf(w, "\033[%dA", totalLines())
+					drawHeader()
+					render()
+				}
+			case k[0] == 3: // Ctrl-C
+				fmt.Fprint(w, "\r\n")
+				return nil, errCancelled
+			case k[0] >= 32 && k[0] < 127:
+				searchQuery += string(k[0])
+				filtered = filterMenuItems(items, searchQuery)
+				filterIdx = filterIndices(items, searchQuery)
+				cur = 0
+				scroll = 0
+				fmt.Fprintf(w, "\033[%dA", totalLines())
+				drawHeader()
+				render()
+			case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'A':
+				if cur > 0 {
+					cur--
+				}
+			case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'B':
+				if cur < len(filtered)-1 {
+					cur++
+				}
+			case k[0] == 'k':
+				if cur > 0 {
+					cur--
+				}
+			case k[0] == 'j':
+				if cur < len(filtered)-1 {
+					cur++
+				}
+			default:
+				continue
+			}
+			fmt.Fprintf(w, "\033[%dA", totalLines())
+			drawHeader()
+			render()
+			continue
+		}
+
 		switch {
 		case k[0] == '\r' || k[0] == '\n':
 			var out []int
@@ -138,14 +459,23 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 		case k[0] == 3 || k[0] == 'q':
 			fmt.Fprint(w, "\r\n")
 			return nil, errCancelled
+		case k[0] == '/': // enter search mode
+			searching = true
+			searchQuery = ""
+			fmt.Fprintf(w, "\033[%dA", totalLines())
+			drawHeader()
+			render()
 		case k[0] == ' ':
-			checked[cur] = !checked[cur]
+			if len(filtered) > 0 {
+				origIdx := filterIdx[cur]
+				checked[origIdx] = !checked[origIdx]
+			}
 		case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'A':
 			if cur > 0 {
 				cur--
 			}
 		case len(k) >= 3 && k[0] == 27 && k[1] == '[' && k[2] == 'B':
-			if cur < len(items)-1 {
+			if cur < len(filtered)-1 {
 				cur++
 			}
 		case k[0] == 'k':
@@ -153,13 +483,33 @@ func selectMany(label string, items []menuItem) ([]int, error) {
 				cur--
 			}
 		case k[0] == 'j':
-			if cur < len(items)-1 {
+			if cur < len(filtered)-1 {
 				cur++
 			}
 		default:
 			continue
 		}
-		fmt.Fprintf(w, "\033[%dA", len(items))
+		fmt.Fprintf(w, "\033[%dA", totalLines())
+		drawHeader()
 		render()
 	}
+}
+
+// filterIndices returns the original indices of items matching query.
+func filterIndices(items []menuItem, query string) []int {
+	if query == "" {
+		out := make([]int, len(items))
+		for i := range items {
+			out[i] = i
+		}
+		return out
+	}
+	lq := strings.ToLower(query)
+	var out []int
+	for i, it := range items {
+		if strings.Contains(strings.ToLower(it.name), lq) || strings.Contains(strings.ToLower(it.desc), lq) {
+			out = append(out, i)
+		}
+	}
+	return out
 }

--- a/internal/cli/select_test.go
+++ b/internal/cli/select_test.go
@@ -1,0 +1,126 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestFrameLines(t *testing.T) {
+	tests := []struct {
+		name      string
+		filtered  int
+		termRows  int
+		searching bool
+		wantLines int
+	}{
+		{
+			name:      "small list no search",
+			filtered:  5,
+			termRows:  24,
+			searching: false,
+			wantLines: 4 + 5, // fixed(4) + items(5)
+		},
+		{
+			name:      "small list with search",
+			filtered:  5,
+			termRows:  24,
+			searching: true,
+			wantLines: 5 + 5, // fixed(5 search) + items(5)
+		},
+		{
+			name:      "list exceeds terminal height",
+			filtered:  100,
+			termRows:  24,
+			searching: false,
+			wantLines: 4 + 20, // fixed(4) + viewport(24-4=20)
+		},
+		{
+			name:      "list exceeds terminal with search",
+			filtered:  100,
+			termRows:  24,
+			searching: true,
+			wantLines: 5 + 19, // fixed(5) + viewport(24-5=19)
+		},
+		{
+			name:      "empty list",
+			filtered:  0,
+			termRows:  24,
+			searching: false,
+			wantLines: 4 + 0, // fixed(4) + viewport(0 items)
+		},
+		{
+			name:      "tiny terminal",
+			filtered:  10,
+			termRows:  8,
+			searching: false,
+			wantLines: 4 + 4, // fixed(4) + viewport(8-4=4)
+		},
+		{
+			name:      "tiny terminal with search",
+			filtered:  10,
+			termRows:  8,
+			searching: true,
+			wantLines: 5 + 3, // fixed(5) + viewport(8-5=3)
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FrameLines(tt.filtered, tt.termRows, tt.searching)
+			if got != tt.wantLines {
+				t.Errorf("FrameLines(%d, %d, %v) = %d, want %d",
+					tt.filtered, tt.termRows, tt.searching, got, tt.wantLines)
+			}
+		})
+	}
+}
+
+func TestFrameLinesNeverExceedsTerminal(t *testing.T) {
+	// The frame must never print more lines than the terminal has rows.
+	// Otherwise the terminal scrolls and cursor repositioning drifts.
+	termRows := 24
+	for _, searching := range []bool{false, true} {
+		for n := 0; n <= 200; n++ {
+			lines := FrameLines(n, termRows, searching)
+			if lines > termRows {
+				t.Errorf("FrameLines(%d, %d, searching=%v) = %d, exceeds terminal",
+					n, termRows, searching, lines)
+			}
+		}
+	}
+}
+
+func TestMaxViewportBounds(t *testing.T) {
+	// Viewport must be at least 1 even on impossibly small terminals.
+	vp := maxViewport(10, 3, false)
+	if vp < 1 {
+		t.Errorf("maxViewport(10, 3, false) = %d, want >= 1", vp)
+	}
+	// When items < available rows, viewport equals items.
+	vp = maxViewport(3, 24, false)
+	if vp != 3 {
+		t.Errorf("maxViewport(3, 24, false) = %d, want 3", vp)
+	}
+}
+
+func TestFilterMenuItems(t *testing.T) {
+	items := []menuItem{
+		{name: "deepseek-v4", desc: "DeepSeek V4"},
+		{name: "gpt-4o", desc: "OpenAI GPT-4o"},
+		{name: "mimo-pro", desc: "MiMo Pro"},
+	}
+	// Empty query returns all.
+	if got := filterMenuItems(items, ""); len(got) != 3 {
+		t.Errorf("empty query: got %d, want 3", len(got))
+	}
+	// Case-insensitive match on name.
+	if got := filterMenuItems(items, "GPT"); len(got) != 1 || got[0].name != "gpt-4o" {
+		t.Errorf("GPT: got %v", got)
+	}
+	// Case-insensitive match on desc.
+	if got := filterMenuItems(items, "mimo"); len(got) != 1 || got[0].name != "mimo-pro" {
+		t.Errorf("mimo: got %v", got)
+	}
+	// No match.
+	if got := filterMenuItems(items, "claude"); len(got) != 0 {
+		t.Errorf("claude: got %d, want 0", len(got))
+	}
+}

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -340,6 +340,12 @@ func (c *Controller) managementNotice(trimmed string) bool {
 	switch fields[0] {
 	case "/model":
 		c.notice(c.modelListText())
+	case "/provider":
+		if len(fields) >= 2 {
+			c.notice(c.providerSwitchText(fields[1]))
+		} else {
+			c.notice(c.providerListText())
+		}
 	case "/memory":
 		c.notice(c.memoryListText())
 	case "/skill", "/skills":
@@ -396,6 +402,66 @@ func (c *Controller) modelListText() string {
 	}
 	b.WriteString(i18n.M.ListModelsHint)
 	return strings.TrimRight(b.String(), "\n")
+}
+
+func (c *Controller) providerListText() string {
+	cfg, err := config.Load()
+	if err != nil {
+		return "provider: " + err.Error()
+	}
+	curProvider := ""
+	if parts := strings.Fields(c.label); len(parts) > 0 {
+		curProvider = parts[0]
+	}
+	var b strings.Builder
+	b.WriteString(i18n.M.ProviderListHeader + "\n")
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
+		models := p.ChatModelList()
+		if len(models) == 0 {
+			models = p.ModelList()
+		}
+		suffix := ""
+		if p.Name == curProvider {
+			suffix = " (active)"
+		}
+		fmt.Fprintf(&b, "  %s — %d models%s\n", p.Name, len(models), suffix)
+	}
+	b.WriteString("switch with /provider <name>")
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (c *Controller) providerSwitchText(name string) string {
+	cfg, err := config.Load()
+	if err != nil {
+		return "provider: " + err.Error()
+	}
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if p.Name == name && p.Configured() {
+			models := p.ChatModelList()
+			if len(models) == 0 {
+				models = p.ModelList()
+			}
+			if len(models) == 0 {
+				return fmt.Sprintf(i18n.M.ProviderNoModelsFmt, name)
+			}
+			if len(models) == 1 {
+				return fmt.Sprintf("provider %s — model: %s (switch with /model %s/%s)", name, models[0], name, models[0])
+			}
+			var b strings.Builder
+			fmt.Fprintf(&b, "provider %s — %d models:\n", name, len(models))
+			for _, m := range models {
+				fmt.Fprintf(&b, "  %s/%s\n", name, m)
+			}
+			b.WriteString(fmt.Sprintf("switch with /model %s/<model>", name))
+			return strings.TrimRight(b.String(), "\n")
+		}
+	}
+	return fmt.Sprintf(i18n.M.ProviderUnknownFmt, name)
 }
 
 func (c *Controller) memoryListText() string {

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -32,6 +32,8 @@ type ArgData struct {
 	DisconnectedMCP []string
 	ModelRefs       []string
 	CurrentModel    string
+	ProviderNames   []string
+	CurrentProvider string
 }
 
 // SlashArgItems completes the arguments of a management slash command
@@ -54,6 +56,8 @@ func SlashArgItems(line string, d ArgData) ([]SlashItem, int) {
 		raw = mcpArgItems(prior, cur, d)
 	case "/model":
 		raw = modelArgItems(prior, d)
+	case "/provider":
+		raw = providerArgItems(prior, d)
 	case "/skill", "/skills":
 		raw = skillArgItems(prior, d)
 	case "/hooks":
@@ -239,6 +243,21 @@ func modelArgItems(prior []string, d ArgData) []SlashItem {
 			hint = i18n.M.ArgModelCurrent
 		}
 		items = append(items, SlashItem{Label: ref, Insert: ref, Hint: hint})
+	}
+	return items
+}
+
+func providerArgItems(prior []string, d ArgData) []SlashItem {
+	if len(prior) != 1 { // the single name arg is already placed
+		return nil
+	}
+	var items []SlashItem
+	for _, name := range d.ProviderNames {
+		hint := ""
+		if name == d.CurrentProvider {
+			hint = i18n.M.ArgModelCurrent
+		}
+		items = append(items, SlashItem{Label: name, Insert: name, Hint: hint})
 	}
 	return items
 }

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -457,7 +457,7 @@ func (c *Controller) providerSwitchText(name string) string {
 			for _, m := range models {
 				fmt.Fprintf(&b, "  %s/%s\n", name, m)
 			}
-			b.WriteString(fmt.Sprintf("switch with /model %s/<model>", name))
+			fmt.Fprintf(&b, "switch with /model %s/<model>", name)
 			return strings.TrimRight(b.String(), "\n")
 		}
 	}

--- a/internal/control/slash_test.go
+++ b/internal/control/slash_test.go
@@ -32,6 +32,8 @@ func TestSlashArgItems(t *testing.T) {
 		DisconnectedMCP: []string{"optional"},
 		ModelRefs:       []string{"deepseek-flash/deepseek-v4-flash", "deepseek-pro/deepseek-v4-pro"},
 		CurrentModel:    "deepseek-flash/deepseek-v4-flash",
+		ProviderNames:   []string{"deepseek-flash", "deepseek-pro", "custom"},
+		CurrentProvider: "deepseek-flash",
 	}
 
 	// /skills subcommands
@@ -105,6 +107,21 @@ func TestSlashArgItems(t *testing.T) {
 		if it.Label == data.CurrentModel && it.Hint != "current" {
 			t.Errorf("active model should be hinted 'current', got %q", it.Hint)
 		}
+	}
+	// /provider → provider names, current marked
+	items, _ = SlashArgItems("/provider ", data)
+	if !has(items, "deepseek-pro") || !has(items, "custom") {
+		t.Errorf("/provider should list provider names; got %v", labelsOf(items))
+	}
+	for _, it := range items {
+		if it.Label == data.CurrentProvider && it.Hint != "current" {
+			t.Errorf("active provider should be hinted 'current', got %q", it.Hint)
+		}
+	}
+	// /provider de → filter to deepseek-*
+	items, _ = SlashArgItems("/provider de", data)
+	if len(items) != 2 {
+		t.Errorf("/provider de should filter to 2 deepseek providers; got %v", labelsOf(items))
 	}
 	// /hooks
 	items, _ = SlashArgItems("/hooks ", data)

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -356,8 +356,6 @@ type Messages struct {
 	// /provider command
 	CmdProvider          string // /provider
 	ProviderListHeader   string // header for /provider list
-	ProviderSwitchingFmt string // switching to provider
-	ProviderSwitchedFmt  string // switched to provider
 	ProviderAlreadyOnFmt string // already on provider
 	ProviderUnknownFmt   string // unknown provider
 	ProviderPickLabel    string // label for provider model picker

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -347,8 +347,21 @@ type Messages struct {
 	ProviderErrServerBusy          string // 503
 
 	// selection menus
-	SelectOneHint  string // "(↑/↓ · Enter · q to cancel)"
-	SelectManyHint string // "(↑/↓ · Space · Enter · q)"
+	SelectOneHint      string // "(↑/↓ · Enter · q to cancel)"
+	SelectManyHint     string // "(↑/↓ · Space · Enter · q)"
+	SelectMoreAboveFmt string // "↑ %d more above"
+	SelectMoreBelowFmt string // "↓ %d more below"
+	SelectSearchHint   string // "/ to search · Esc to cancel"
+
+	// /provider command
+	CmdProvider          string // /provider
+	ProviderListHeader   string // header for /provider list
+	ProviderSwitchingFmt string // switching to provider
+	ProviderSwitchedFmt  string // switched to provider
+	ProviderAlreadyOnFmt string // already on provider
+	ProviderUnknownFmt   string // unknown provider
+	ProviderPickLabel    string // label for provider model picker
+	ProviderNoModelsFmt  string // provider has no models
 
 	// usage / help
 	UsageBody string // full multi-line help text

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -306,8 +306,21 @@ var English = Messages{
 	ProviderErrServer:              "Server error (HTTP 500): the provider hit an internal fault. Retried with backoff; if it keeps failing, try again later.",
 	ProviderErrServerBusy:          "Server busy (HTTP 503): the provider is overloaded. Retried with backoff; please try again shortly.",
 
-	SelectOneHint:  "(↑/↓ · Enter · q to cancel)",
-	SelectManyHint: "(↑/↓ · Space · Enter · q)",
+	SelectOneHint:  "(↑/↓ · Enter · q to cancel; / to search)",
+	SelectManyHint: "(↑/↓ · Space · Enter · q; / to search)",
+
+	SelectMoreAboveFmt: "  ↑ %d more above",
+	SelectMoreBelowFmt: "  ↓ %d more below",
+	SelectSearchHint:   "/ to search · type to filter · Esc cancel search",
+
+	CmdProvider:          "switch provider",
+	ProviderListHeader:   "providers (/provider <name> to switch)",
+	ProviderSwitchingFmt: "switching to provider %s…",
+	ProviderSwitchedFmt:  "switched to provider %s",
+	ProviderAlreadyOnFmt: "already using provider %s",
+	ProviderUnknownFmt:   "unknown provider %q",
+	ProviderPickLabel:    "Select a model from %s",
+	ProviderNoModelsFmt:  "provider %s has no configured models",
 
 	UsageBody: `reasonix — a config- and plugin-driven coding agent (multi-model)
 

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -315,8 +315,6 @@ var English = Messages{
 
 	CmdProvider:          "switch provider",
 	ProviderListHeader:   "providers (/provider <name> to switch)",
-	ProviderSwitchingFmt: "switching to provider %s…",
-	ProviderSwitchedFmt:  "switched to provider %s",
 	ProviderAlreadyOnFmt: "already using provider %s",
 	ProviderUnknownFmt:   "unknown provider %q",
 	ProviderPickLabel:    "Select a model from %s",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -316,8 +316,6 @@ var Chinese = Messages{
 
 	CmdProvider:          "切换供应商",
 	ProviderListHeader:   "供应商（/provider <名称> 切换）",
-	ProviderSwitchingFmt: "正在切换到供应商 %s…",
-	ProviderSwitchedFmt:  "已切换到供应商 %s",
 	ProviderAlreadyOnFmt: "已经在使用供应商 %s",
 	ProviderUnknownFmt:   "未知供应商 %q",
 	ProviderPickLabel:    "选择 %s 的一个模型",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -307,8 +307,21 @@ var Chinese = Messages{
 	ProviderErrServer:              "服务器故障 (HTTP 500)：服务端内部错误。已退避重试；若持续失败请稍后再试。",
 	ProviderErrServerBusy:          "服务器繁忙 (HTTP 503)：服务端负载过高。已退避重试，请稍后再试。",
 
-	SelectOneHint:  "(↑/↓ · Enter · q 取消)",
-	SelectManyHint: "(↑/↓ · Space · Enter · q)",
+	SelectOneHint:  "(↑/↓ · Enter · q 取消；/ 搜索)",
+	SelectManyHint: "(↑/↓ · Space · Enter · q；/ 搜索)",
+
+	SelectMoreAboveFmt: "  ↑ 上方还有 %d 个",
+	SelectMoreBelowFmt: "  ↓ 下方还有 %d 个",
+	SelectSearchHint:   "/ 搜索 · 输入关键词过滤 · Esc 取消搜索",
+
+	CmdProvider:          "切换供应商",
+	ProviderListHeader:   "供应商（/provider <名称> 切换）",
+	ProviderSwitchingFmt: "正在切换到供应商 %s…",
+	ProviderSwitchedFmt:  "已切换到供应商 %s",
+	ProviderAlreadyOnFmt: "已经在使用供应商 %s",
+	ProviderUnknownFmt:   "未知供应商 %q",
+	ProviderPickLabel:    "选择 %s 的一个模型",
+	ProviderNoModelsFmt:  "供应商 %s 没有已配置的模型",
 
 	UsageBody: `reasonix — 由配置和插件驱动的 coding agent（多模型）
 


### PR DESCRIPTION
## Summary

Fixes #3765

Two improvements to the CLI TUI:

### Bug Fix: Model list overflow in terminal selection menus

When a custom provider returns a large model list (100+ models), `selectOne`/`selectMany` menus rendered all items without viewport windowing — items beyond the terminal height were invisible and unreachable.

**Changes to `internal/cli/select.go`:**
- Added terminal height detection via `term.GetSize(fd)`
- Implemented viewport windowing: only shows items that fit in the terminal
- Added scroll indicators: "↑ N more above" / "↓ N more below"
- Added `/` key to enter keyword search mode (case-insensitive filter on name + desc)
- `Esc` exits search and restores the full list
- Works for both `selectOne` (single-choice) and `selectMany` (multi-choice) menus

### New Feature: `/provider` slash command

Added a `/provider` command to switch providers from the CLI chat interface:

- `/provider` — lists all configured providers with model counts, marks active
- `/provider <name>` — switches to that provider's default model (or lists models when multiple are configured)
- Tab autocomplete for provider names
- Bilingual i18n support (en/zh)

## Files Changed

| File | Change |
|------|--------|
| `internal/cli/select.go` | Viewport scrolling + search mode |
| `internal/cli/provider.go` | New `/provider` command (new file) |
| `internal/cli/chat_tui.go` | Register `/provider` in slash handler |
| `internal/cli/complete.go` | `/provider` autocomplete + provider data |
| `internal/cli/help_view.go` | `/provider` in help listing |
| `internal/cli/model.go` | `providerNames()` helper |
| `internal/control/slash.go` | `/provider` arg completion + `ProviderNames` in `ArgData` |
| `internal/control/slash_test.go` | Test coverage for `/provider` completion |
| `internal/i18n/i18n.go` | New message fields |
| `internal/i18n/messages_en.go` | English translations |
| `internal/i18n/messages_zh.go` | Chinese translations |

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./internal/i18n/...` — passes (drift guard confirms en/zh parity)
- `go test ./internal/control/...` — passes (includes new `/provider` test cases)
- `go test ./internal/config/...` — passes