### PR TITLE
fix(diff): bound the Myers n+m sum so it can't overflow (CodeQL)

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -153,9 +153,10 @@ func myers(a, b []string) ([]op, bool) {
 	if n == 0 && m == 0 {
 		return nil, true
 	}
-	maxD := n + m
-	if maxD > maxDiffEdits || maxD < 0 {
-		maxD = maxDiffEdits // bound the trace's O(D²) footprint (and any n+m overflow)
+	// maxD = min(n+m, maxDiffEdits); take the sum only when it can't overflow int.
+	maxD := maxDiffEdits // bound the trace's O(D²) footprint
+	if n <= maxDiffEdits && m <= maxDiffEdits-n {
+		maxD = n + m
 	}
 	offset := maxD // shift negative k into a non-negative array index
 	v := make([]int, 2*maxD+1)


### PR DESCRIPTION
Resolves the two open CodeQL `go/allocation-size-overflow` (high) alerts in `internal/diff/diff.go` (the Myers line-diff).

`maxD := n + m` flows into `make([]int, 2*maxD+1)`. The value was already safe at the allocation — `maxD` is clamped to `maxDiffEdits` (2000), and a prior fix added a `maxD < 0` guard for a wrapped sum — but CodeQL flags the **addition itself** as a potential overflow, which the post-hoc clamp doesn't clear.

This restructures to `maxD = min(n+m, maxDiffEdits)`, taking the sum only when `n <= maxDiffEdits && m <= maxDiffEdits-n`, so `n + m` is evaluated only when provably within the cap. Identical bound, no overflow at the operation.

In practice the inputs are file line counts, so the sum could never overflow a real `int` anyway (you'd OOM building the slices first) — but this clears the alert cleanly rather than dismissing it.

`go build` + `go test ./internal/diff/` pass locally.
