### PR TITLE
fix(diff): clamp Myers edit-distance operands to clear the allocation overflow alert

### DIFF
--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -153,10 +153,18 @@ func myers(a, b []string) ([]op, bool) {
 	if n == 0 && m == 0 {
 		return nil, true
 	}
-	// maxD = min(n+m, maxDiffEdits); take the sum only when it can't overflow int.
-	maxD := maxDiffEdits // bound the trace's O(D²) footprint
-	if n <= maxDiffEdits && m <= maxDiffEdits-n {
-		maxD = n + m
+	// Clamp each side to the cap before summing so neither n+m nor the 2*maxD
+	// allocation can overflow int; maxD stays min(n+m, maxDiffEdits).
+	cn, cm := n, m
+	if cn > maxDiffEdits {
+		cn = maxDiffEdits
+	}
+	if cm > maxDiffEdits {
+		cm = maxDiffEdits
+	}
+	maxD := cn + cm
+	if maxD > maxDiffEdits {
+		maxD = maxDiffEdits // bound the trace's O(D²) footprint
 	}
 	offset := maxD // shift negative k into a non-negative array index
 	v := make([]int, 2*maxD+1)


### PR DESCRIPTION
Follow-up to #3773 to clear the remaining CodeQL `go/allocation-size-overflow` alert.

#3773 cleared the `n + m` addition alert, but CodeQL kept flagging the `make([]int, 2*maxD+1)` allocation: it doesn't propagate `maxD`'s upper bound through the guarded sum, so it can't prove `2*maxD` won't overflow.

This clamps each line count to `maxDiffEdits` before summing (`cn`, `cm`), so both the sum and the `2*maxD` allocation have operands bounded by a constant — the canonical barrier CodeQL recognizes. `maxD` stays `min(n+m, maxDiffEdits)`, identical behavior.

`go build` + `go test ./internal/diff/` pass locally.
