### PR TITLE
Split /new and /clear session flows / 区分 /new 与 /clear 会话流程

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,11 @@ convenient.
 
 ### Slash commands
 
-In `reasonix chat`, built-in commands (`/compact`, `/new`/`/clear`, `/rewind`, `/tree`,
+In `reasonix chat`, built-in commands (`/compact`, `/new`, `/clear`, `/rewind`, `/tree`,
 `/branch`, `/switch`, `/todo`, `/model`, `/effort`, `/mcp`, `/memory`, `/help`) run locally.
-`/new` starts a fresh model context while saving the previous transcript for
-history/resume; `/clear` is the Claude Code-compatible alias.
+`/new` starts a new session while saving the previous transcript for
+history/resume; `/clear` asks for confirmation, then discards the current context
+without saving it.
 `/tree` shows saved conversation branches, `/branch [name]` forks the current
 conversation tip, `/branch <turn> [name]` forks from an earlier checkpointed turn,
 and `/switch <id|name>` loads another branch. **Custom commands** are Markdown files under

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -200,8 +200,8 @@ headers = { Authorization = "Bearer ${STRIPE_KEY}" }
 
 ### 斜杠命令
 
-`reasonix chat` 里,内置命令(`/compact`、`/new`（`/clear`）、`/rewind`、`/tree`、`/branch`、`/switch`、`/todo`、`/model`、`/effort`、`/mcp`、`/help`)在本地执行。
-`/new` 会开启干净的模型上下文,同时保存之前的 transcript 供历史记录和恢复使用;`/clear` 是兼容 Claude Code 习惯的同义命令。
+`reasonix chat` 里,内置命令(`/compact`、`/new`、`/clear`、`/rewind`、`/tree`、`/branch`、`/switch`、`/todo`、`/model`、`/effort`、`/mcp`、`/help`)在本地执行。
+`/new` 会开启新会话,同时保存之前的 transcript 供历史记录和恢复使用;`/clear` 会二次确认,确认后丢弃当前上下文且不保存。
 `/tree` 查看已保存的对话分支,`/branch [name]` 从当前对话末端分支,`/branch <turn> [name]`
 从较早的 checkpoint 轮次分支,`/switch <id|name>` 切换到另一个分支。**自定义命令**
 是放在 `.reasonix/commands/`(项目)或 `~/.config/reasonix/commands/`(用户)下的 Markdown 文件——

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -792,6 +792,22 @@ func (a *App) NewSession() error {
 	return nil
 }
 
+// ClearSession discards the current conversation and rotates to a fresh unsaved one.
+func (a *App) ClearSession() error {
+	a.mu.RLock()
+	tab := a.activeTabLocked()
+	ctrl := a.activeCtrlLocked()
+	a.mu.RUnlock()
+	if ctrl == nil {
+		return nil
+	}
+	if err := ctrl.ClearSession(); err != nil {
+		return err
+	}
+	a.persistTabSessionPath(tab, ctrl.SessionPath())
+	return nil
+}
+
 // CheckpointMeta summarises one rewind point (a user turn) for the desktop.
 type CheckpointMeta struct {
 	Turn            int      `json:"turn"`
@@ -1789,6 +1805,7 @@ type CommandInfo struct {
 func (a *App) Commands() []CommandInfo {
 	out := []CommandInfo{
 		{Name: "new", Description: i18n.M.CmdNew, Kind: "builtin"},
+		{Name: "clear", Description: i18n.M.CmdClear, Kind: "builtin"},
 		{Name: "compact", Description: i18n.M.CmdCompact, Kind: "builtin"},
 		{Name: "model", Description: i18n.M.CmdModel, Kind: "builtin"},
 		{Name: "effort", Description: i18n.M.CmdEffort, Kind: "builtin"},

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
 import { ApprovalModal } from "./components/ApprovalModal";
 import { AskCard } from "./components/AskCard";
+import { ClearContextCard } from "./components/ClearContextCard";
 import { StatusBar } from "./components/StatusBar";
 import { HistoryPanel } from "./components/HistoryPanel";
 import { CommandPalette, type PaletteItem } from "./components/CommandPalette";
@@ -383,6 +384,7 @@ export default function App() {
     setToolApprovalMode: setControllerToolApprovalMode,
     setGoal: setControllerGoal,
     clearGoal: clearControllerGoal,
+    clearSession,
     listSessions,
     listTrashedSessions,
     resumeSession,
@@ -444,6 +446,7 @@ export default function App() {
   const [sidebarTogglePressed, setSidebarTogglePressed] = useState(false);
   const [workspaceTogglePressed, setWorkspaceTogglePressed] = useState(false);
   const [savedTopicTurnCount, setSavedTopicTurnCount] = useState<number | undefined>(undefined);
+  const [clearContextPending, setClearContextPending] = useState(false);
   const topicRenameSkipCommitRef = useRef(false);
   const topicRenameCommitHandledRef = useRef(false);
   const appRef = useRef<HTMLDivElement>(null);
@@ -857,9 +860,28 @@ export default function App() {
     send(text);
   }, [pendingPlanRevision, send, state.running]);
 
-  // handleSend intercepts the slash commands that need a desktop-native action
-  // before they reach the backend: "/model <ref>" rebuilds on that model, and
-  // "/memory" opens the Memory tab in the settings centre. Everything else — skills (/init, …),
+  useEffect(() => {
+    setClearContextPending(false);
+  }, [activeTabId]);
+
+  const cancelClearContext = useCallback(() => {
+    setClearContextPending(false);
+  }, []);
+
+  const confirmClearContext = useCallback(async () => {
+    setClearContextPending(false);
+    try {
+      await clearSession();
+      notice(t("clearContext.done"));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      notice(msg || t("clearContext.failed"), "warn");
+    }
+  }, [clearSession, notice, t]);
+
+  // handleSend intercepts slash commands that need a desktop-native action before
+  // they reach the backend: "/model <ref>" rebuilds on that model, "/memory"
+  // opens Settings, and "/clear" shows an in-app confirmation card. Everything else — skills (/init, …),
   // custom commands, bare /model and the other read-only management verbs
   // (/skill, /hooks, /mcp) — goes straight to Submit, which the controller
   // resolves (a turn, or a listing Notice).
@@ -884,6 +906,10 @@ export default function App() {
       if (trimmed === "/memory") {
         closeTransientOverlays();
         setSettingsTarget("memory");
+        return;
+      }
+      if (trimmed === "/clear") {
+        setClearContextPending(true);
         return;
       }
       const goalCommand = /^\/goal(?:\s+(.*))?$/.exec(trimmed);
@@ -1834,7 +1860,7 @@ export default function App() {
                 onRewind={handleMessageAction}
                 checkpoints={state.checkpoints}
                 actionPending={state.messageAction != null}
-                rewindDisabled={state.running || state.messageAction != null || state.approval != null || state.ask != null}
+                rewindDisabled={state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
               />
             )}
           </main>
@@ -1867,6 +1893,14 @@ export default function App() {
                 onDismiss={() => answerQuestion(state.ask!.id, [])}
               />
             )}
+            {clearContextPending && (
+              <ClearContextCard
+                onCancel={cancelClearContext}
+                onConfirm={() => {
+                  void confirmClearContext();
+                }}
+              />
+            )}
             <Composer
               running={state.running}
               collaborationMode={collaborationMode}
@@ -1887,8 +1921,8 @@ export default function App() {
               onSwitchModel={switchModel}
               onSetEffort={setEffort}
               insertRequest={composerInsertRequest}
-              disabled={state.meta?.ready === false || state.messageAction != null || state.approval != null || state.ask != null}
-              decisionPending={state.messageAction != null || state.approval != null || state.ask != null}
+              disabled={state.meta?.ready === false || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+              decisionPending={state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
               ready={state.meta?.ready === true}
               turnStartAt={state.turnStartAt}
               turnTokens={state.turnTokens}

--- a/desktop/frontend/src/components/ClearContextCard.tsx
+++ b/desktop/frontend/src/components/ClearContextCard.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useRef } from "react";
+import { useT } from "../lib/i18n";
+import { PromptAction, PromptBadge, PromptShelf } from "./PromptShelf";
+
+export function ClearContextCard({
+  onCancel,
+  onConfirm,
+}: {
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const t = useT();
+  const shelfRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    shelfRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const tag = target?.tagName.toLowerCase();
+      if (tag === "input" || tag === "textarea" || target?.isContentEditable) return;
+
+      if (event.key === "Escape" || event.key === "1") {
+        event.preventDefault();
+        onCancel();
+        return;
+      }
+      if (event.key === "2" || event.key.toLowerCase() === "y") {
+        event.preventDefault();
+        onConfirm();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onCancel, onConfirm]);
+
+  return (
+    <PromptShelf
+      barRef={shelfRef}
+      titleId="clear-context-shelf-title"
+      title={t("clearContext.title")}
+      badges={<PromptBadge>{t("clearContext.badge")}</PromptBadge>}
+      meta={t("clearContext.prompt")}
+      actions={
+        <>
+          <PromptAction keyLabel="1" label={t("common.cancel")} selected onClick={onCancel} />
+          <PromptAction keyLabel="2" label={t("clearContext.clear")} onClick={onConfirm} />
+        </>
+      }
+    >
+      <div className="ask-shelf__detail-list">
+        <div className="ask-shelf__detail clear-context-card__detail">
+          <span className="ask-shelf__detail-desc">{t("clearContext.detail")}</span>
+        </div>
+      </div>
+    </PromptShelf>
+  );
+}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -114,6 +114,7 @@ export interface AppBindings {
   ClearGoalForTab(tabID: string): Promise<void>;
   Compact(): Promise<void>;
   NewSession(): Promise<void>;
+  ClearSession(): Promise<void>;
   History(): Promise<HistoryMessage[]>;
   HistoryForTab(tabID: string): Promise<HistoryMessage[]>;
   Checkpoints(): Promise<CheckpointMeta[]>;
@@ -1327,6 +1328,7 @@ function makeMockApp(): AppBindings {
         },
         async Compact() {},
         async NewSession() {},
+        async ClearSession() {},
     async Checkpoints() {
       return [
         { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], time: Date.now() - 30_000, canCode: true, canConversation: true },
@@ -1504,7 +1506,8 @@ function makeMockApp(): AppBindings {
         },
     async Commands() {
       return [
-        { name: "new", description: "Start a new session", kind: "builtin" as const },
+        { name: "new", description: "start new session; save transcript", kind: "builtin" as const },
+        { name: "clear", description: "discard current context", kind: "builtin" as const },
         { name: "compact", description: "Summarize older history to free up context", kind: "builtin" as const },
         { name: "model", description: "Switch model", kind: "builtin" as const },
         { name: "effort", description: "Set reasoning effort", kind: "builtin" as const },

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -731,6 +731,13 @@ export function useController() {
     if (tabId) dispatchTo(tabId, { type: "reset" });
   }, [activeTabId, bumpCheckpointRefreshSeq, dispatchTo]);
 
+  const clearSession = useCallback(async () => {
+    const tabId = activeTabId;
+    if (tabId) bumpCheckpointRefreshSeq(tabId);
+    await app.ClearSession();
+    if (tabId) dispatchTo(tabId, { type: "reset" });
+  }, [activeTabId, bumpCheckpointRefreshSeq, dispatchTo]);
+
   const listSessions = useCallback(async (): Promise<SessionMeta[]> => asArray<SessionMeta>(await app.ListSessions().catch(() => [])), []);
   const listTrashedSessions = useCallback(async (): Promise<SessionMeta[]> => asArray<SessionMeta>(await app.ListTrashedSessions().catch(() => [])), []);
   const resumeSession = useCallback(async (path: string, tabId?: string) => {
@@ -885,7 +892,7 @@ export function useController() {
     state: activeState,
     activeTabId,
     send, runShell, notice, cancel, approve, answerQuestion, setControllerMode, setCollaborationMode, setToolApprovalMode, setGoal, clearGoal,
-    newSession, listSessions, listTrashedSessions, resumeSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
+    newSession, clearSession, listSessions, listTrashedSessions, resumeSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, setModel, setEffort,
     fetchMemory, remember, forget, saveDoc,
     switchTab, openProjectTab, openGlobalTab, closeTab, reorderTabs,

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -358,6 +358,15 @@ export const en = {
   "ask.customPlaceholder": "Type your own answer…",
   "ask.justChat": "Just chat",
 
+  // clear context confirmation
+  "clearContext.title": "Clear current context",
+  "clearContext.badge": "local only",
+  "clearContext.prompt": "Clear current context without saving?",
+  "clearContext.detail": "This deletes the current transcript from local history and keeps only the system prompt.",
+  "clearContext.clear": "Clear",
+  "clearContext.done": "Current context cleared",
+  "clearContext.failed": "Could not clear current context",
+
   // history drawer
   "history.title": "History",
   "history.trashTitle": "Trash",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -359,6 +359,15 @@ export const zh: Record<DictKey, string> = {
   "ask.customPlaceholder": "输入你自己的答案…",
   "ask.justChat": "只是聊聊",
 
+  // 清空上下文确认
+  "clearContext.title": "清空当前上下文",
+  "clearContext.badge": "仅本地",
+  "clearContext.prompt": "清空当前上下文且不保存？",
+  "clearContext.detail": "会从本地历史中删除当前 transcript，只保留 system prompt。",
+  "clearContext.clear": "清空",
+  "clearContext.done": "已清空当前上下文",
+  "clearContext.failed": "清空当前上下文失败",
+
   // 历史抽屉
   "history.title": "历史",
   "history.trashTitle": "回收站",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4877,6 +4877,9 @@ a[href] {
   font-size: 12px;
   line-height: 1.35;
 }
+.clear-context-card__detail {
+  grid-template-columns: 1fr;
+}
 .ask-shelf__custom-row {
   display: flex;
   align-items: center;

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -294,10 +294,11 @@ each writer/bash call. `deny` rules harden both modes.
 
 The chat TUI accepts `/command` input. Three kinds share one dispatch:
 
-- **Built-in actions** (`/compact`, `/new`/`/clear`, `/effort`, `/mcp`, `/help`) manipulate session
-  state locally and never reach the model. `/new` and its Claude Code-compatible
-  alias `/clear` start a fresh model context while saving the previous transcript
-  for resume/history; they do not delete persisted history or project memory.
+- **Built-in actions** (`/compact`, `/new`, `/clear`, `/effort`, `/mcp`, `/help`) manipulate session
+  state locally and never reach the model. `/new` starts a new session while
+  saving the previous transcript for resume/history. `/clear` requires
+  confirmation, then discards the current context without saving it; it does not
+  delete project memory.
 - **Custom commands** are Markdown files under `.reasonix/commands/` (project) and
   `~/.config/reasonix/commands/` (user); the project dir overrides the user dir on a
   name clash. A file `review.md` becomes `/review`; a subdirectory namespaces it

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -216,6 +216,10 @@ type chatTUI struct {
 	mcp         *mcpManager
 	mcpDisabled map[string]bool
 
+	// clearConfirm is the destructive "/clear" confirmation overlay. It is separate
+	// from /new because /clear discards the current transcript instead of saving it.
+	clearConfirm *clearConfirm
+
 	// lastCtrlCAt records when Ctrl+C was pressed while idle on an empty
 	// composer, enabling a "press again to quit" confirmation pattern (1.5s
 	// window). Reset when Ctrl+C clears non-empty input instead.
@@ -786,7 +790,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateCompletion()
 			return m, finalize(m, cmds)
 		}
-		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.mcpImport == nil && m.skillPick == nil && m.shouldFoldPaste(msg.Content) {
+		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.clearConfirm == nil && m.mcpImport == nil && m.skillPick == nil && m.shouldFoldPaste(msg.Content) {
 			m.insertFoldedPaste(msg.Content)
 			m.growInputToFit()
 			m.updateCompletion()
@@ -853,6 +857,10 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The MCP manager is modal while open: keys navigate it.
 		if m.mcp != nil {
 			return m.handleMCPManagerKey(msg)
+		}
+		// The destructive /clear confirmation is modal while open.
+		if m.clearConfirm != nil {
+			return m.handleClearConfirmKey(msg)
 		}
 		// The skill picker is modal while open: keys navigate it.
 		if m.skillPick != nil {
@@ -1447,7 +1455,7 @@ func (m chatTUI) bottomRows() int {
 // reserve rows for a composer that cannot receive input, leaving a confusing
 // blank/bordered area at the bottom of the TUI.
 func (m chatTUI) hideComposer() bool {
-	if m.mcp != nil || m.mcpImport != nil || m.skillPick != nil || m.resumePick != nil || m.rewind != nil || m.pendingApproval != nil {
+	if m.mcp != nil || m.clearConfirm != nil || m.mcpImport != nil || m.skillPick != nil || m.resumePick != nil || m.rewind != nil || m.pendingApproval != nil {
 		return true
 	}
 	return m.chooser != nil && !m.chooser.typing
@@ -1464,6 +1472,9 @@ func (m chatTUI) transcriptHeight() int {
 
 func (m chatTUI) renderMainManager() string {
 	if card := m.renderMCPManager(); card != "" {
+		return card
+	}
+	if card := m.renderClearConfirm(); card != "" {
 		return card
 	}
 	return m.renderSkillPicker()
@@ -1486,6 +1497,8 @@ func (m chatTUI) renderMainManagerFooter() string {
 	switch {
 	case m.mcp != nil:
 		hint = m.mcp.footerHint()
+	case m.clearConfirm != nil:
+		hint = "Enter confirm · y clear · n/Esc cancel"
 	case m.skillPick != nil:
 		hint = m.skillPickerFooterHint()
 	}
@@ -3167,21 +3180,18 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		// guidance steering what the summary keeps.
 		focus := strings.TrimSpace(strings.TrimPrefix(input, cmd))
 		return func() tea.Msg { return compactDoneMsg{err: m.ctrl.Compact(context.Background(), focus)} }
-	case "/new", "/clear":
+	case "/new":
 		m.echoLocalCommand(input)
 		if err := m.ctrl.NewSession(); err != nil {
 			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashNewFailed, err))
 			return nil
 		}
-		// Native scrollback keeps the old transcript; mark the fork with a fresh
-		// banner and reset live state.
-		m.pending.Reset()
-		m.reasoning.Reset()
-		m.todoArgs = ""
-		m.chooser = nil
-		m.commitLine("")
-		m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
+		// Native scrollback keeps the old transcript; mark the fork with a fresh banner.
+		m.resetFreshContextView(false)
 		m.notice(i18n.M.SlashNewDone)
+	case "/clear":
+		m.echoLocalCommand(input)
+		m.clearConfirm = &clearConfirm{confirm: 1}
 	case "/resume":
 		m.runResumeCommand(input)
 	case "/todo":

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -257,6 +257,77 @@ func TestMCPManagerHidesComposerBox(t *testing.T) {
 	}
 }
 
+func TestClearCommandRequiresConfirmationAndDiscardsSession(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "old context"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	path := filepath.Join(dir, "session.jsonl")
+	ctrl := control.New(control.Options{Executor: exec, SystemPrompt: "sys", SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+
+	if cmd := m.runSlashCommand("/clear"); cmd != nil {
+		t.Fatal("/clear should open a local confirmation without returning a command")
+	}
+	if m.clearConfirm == nil {
+		t.Fatal("/clear should open a confirmation prompt")
+	}
+	if m.clearConfirm.confirm != 1 {
+		t.Fatalf("/clear confirmation should default to cancel, got %d", m.clearConfirm.confirm)
+	}
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	m = m0.(chatTUI)
+	footerRows := strings.Count(m.renderMainManagerFooter(), "\n") + 1
+	if got, want := m.bottomRows(), footerRows+2; got != want {
+		t.Fatalf("bottomRows with /clear confirmation = %d, want %d (footer + status rows; confirmation renders in main area)", got, want)
+	}
+	if !m.hideComposer() {
+		t.Fatal("/clear confirmation should hide the composer")
+	}
+	content := ansi.Strip(m.View().Content)
+	if !strings.Contains(content, "Clear current context without saving?") {
+		t.Fatalf("/clear confirmation prompt missing from view:\n%s", content)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("session should still exist before confirmation: %v", err)
+	}
+	if current := exec.Session().Snapshot(); len(current) != 2 {
+		t.Fatalf("context changed before confirmation: %+v", current)
+	}
+
+	next, _ := m.handleClearConfirmKey(tea.KeyPressMsg{Code: tea.KeyEnter})
+	m = next.(chatTUI)
+	if m.clearConfirm != nil {
+		t.Fatal("Enter on default cancel should close the confirmation")
+	}
+	if ctrl.SessionPath() != path {
+		t.Fatal("cancelled /clear should not rotate the session path")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("cancelled /clear should keep the session file: %v", err)
+	}
+
+	m.runSlashCommand("/clear")
+	next, _ = m.handleClearConfirmKey(tea.KeyPressMsg{Code: 'y'})
+	m = next.(chatTUI)
+	if ctrl.SessionPath() == path {
+		t.Fatal("confirmed /clear should rotate to a fresh session path")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("confirmed /clear should remove the old transcript, stat err=%v", err)
+	}
+	current := exec.Session().Snapshot()
+	if len(current) != 1 || current[0].Role != provider.RoleSystem || current[0].Content != "sys" {
+		t.Fatalf("cleared context = %+v, want only system prompt", current)
+	}
+	if len(m.transcript) == 0 || strings.Contains(strings.Join(m.transcript, "\n"), "old context") {
+		t.Fatalf("TUI transcript was not reset after /clear: %+v", m.transcript)
+	}
+}
+
 func TestMainManagerFollowsTranscriptWithoutTopPadding(t *testing.T) {
 	ctrl := control.New(control.Options{})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"reasonix/internal/i18n"
+)
+
+type clearConfirm struct {
+	confirm int // 0 = clear, 1 = cancel
+}
+
+func (m chatTUI) handleClearConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "down", "left", "right", "j", "k", "tab", "shift+tab":
+		if m.clearConfirm.confirm == 0 {
+			m.clearConfirm.confirm = 1
+		} else {
+			m.clearConfirm.confirm = 0
+		}
+	case "y", "Y":
+		return m.confirmClearContext()
+	case "n", "N", "esc", "ctrl+c":
+		m.clearConfirm = nil
+	case "enter":
+		if m.clearConfirm.confirm == 0 {
+			return m.confirmClearContext()
+		}
+		m.clearConfirm = nil
+	}
+	return m, nil
+}
+
+func (m chatTUI) confirmClearContext() (tea.Model, tea.Cmd) {
+	m.clearConfirm = nil
+	if err := m.ctrl.ClearSession(); err != nil {
+		m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashClearFailed, err))
+		return m, nil
+	}
+	m.resetFreshContextView(true)
+	m.notice(i18n.M.SlashClearDone)
+	return m, tea.ClearScreen
+}
+
+func (m *chatTUI) resetFreshContextView(clearTranscript bool) {
+	m.finalizeStreamed()
+	m.pending.Reset()
+	m.reasoning.Reset()
+	m.todoArgs = ""
+	m.chooser = nil
+	m.pendingApproval = nil
+	m.bubblePending = false
+	m.turnDiscarded = false
+	if clearTranscript {
+		m.transcript = nil
+		m.wrappedLines = nil
+		m.viewport.SetContent("")
+	} else {
+		m.commitLine("")
+	}
+	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
+	m.transcriptDirty = true
+}
+
+func (m chatTUI) renderClearConfirm() string {
+	if m.clearConfirm == nil {
+		return ""
+	}
+	w := max(viewWidth(m.width), 40)
+	var b strings.Builder
+	b.WriteString(i18n.M.SlashClearPrompt + "\n")
+	b.WriteString(viewMeta("This deletes the current transcript from local history and keeps only the system prompt.") + "\n\n")
+	b.WriteString(rowLine(m.clearConfirm.confirm == 0, 1, "", "Clear", false) + "\n")
+	b.WriteString(rowLine(m.clearConfirm.confirm == 1, 2, "", "Cancel", false))
+	return choicePanelStyle.Width(w).Render(b.String())
+}

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -62,7 +62,7 @@ func (m *chatTUI) slashItems() []compItem {
 	items := []compItem{
 		{label: "/compact", insert: "/compact ", hint: i18n.M.CmdCompact},
 		{label: "/new", insert: "/new ", hint: i18n.M.CmdNew},
-		{label: "/clear", insert: "/clear", hint: i18n.M.CmdNew},
+		{label: "/clear", insert: "/clear", hint: i18n.M.CmdClear},
 		{label: "/resume", insert: "/resume ", hint: i18n.M.CmdResume},
 		{label: "/rewind", insert: "/rewind", hint: i18n.M.CmdRewind},
 		{label: "/tree", insert: "/tree", hint: i18n.M.CmdTree},

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -57,7 +57,7 @@ func builtinHelpItems() []compItem {
 	return []compItem{
 		{label: "/compact", hint: i18n.M.CmdCompact},
 		{label: "/new", hint: i18n.M.CmdNew},
-		{label: "/clear", hint: i18n.M.CmdNew},
+		{label: "/clear", hint: i18n.M.CmdClear},
 		{label: "/rewind", hint: i18n.M.CmdRewind},
 		{label: "/tree", hint: i18n.M.CmdTree},
 		{label: "/branch", hint: i18n.M.CmdBranch},

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -694,7 +694,7 @@ func lastAssistantText(msgs []provider.Message) string {
 // composition — emitting all output as events. The HTTP/SSE server uses this so
 // a browser client only POSTs the typed line.
 //
-// Slash commands route to the matching primitive: /compact and /new (or /clear)
+// Slash commands route to the matching primitive: /compact, /new, and /clear
 // run their session op and emit a Notice; /mcp__server__prompt and custom /commands
 // resolve to a turn; an unknown slash emits a Notice. Anything else is a normal
 // turn with its @-references resolved first.
@@ -738,12 +738,20 @@ func (c *Controller) submit(input, display string) {
 				}
 			}
 		}()
-	case trimmed == "/new" || trimmed == "/clear":
+	case trimmed == "/new":
 		go func() {
 			if err := c.NewSession(); err != nil {
 				c.notice("new session failed: " + err.Error())
 			} else {
 				c.notice("new session")
+			}
+		}()
+	case trimmed == "/clear":
+		go func() {
+			if err := c.ClearSession(); err != nil {
+				c.notice("clear context failed: " + err.Error())
+			} else {
+				c.notice("context cleared")
 			}
 		}()
 	case strings.HasPrefix(trimmed, "/mcp__"):
@@ -1264,6 +1272,57 @@ func (c *Controller) NewSession() error {
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
 	c.mu.Unlock()
 	c.hooks.SessionStart(context.Background())
+	return nil
+}
+
+// ClearSession discards the current conversation without preserving it in
+// resume/history, then rotates to a clean session carrying the same system prompt.
+func (c *Controller) ClearSession() error {
+	if c.executor == nil {
+		return nil
+	}
+	c.mu.Lock()
+	running := c.running
+	oldPath := c.sessionPath
+	c.mu.Unlock()
+	if running {
+		return fmt.Errorf("cannot clear while a turn is running")
+	}
+	if err := removeSessionArtifacts(oldPath); err != nil {
+		return err
+	}
+	c.hooks.SessionEnd(context.Background())
+	if c.sessionDir != "" {
+		c.mu.Lock()
+		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
+		c.mu.Unlock()
+	}
+	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.rebindCheckpoints(c.SessionPath())
+	c.mu.Lock()
+	c.startedOnce = true
+	c.mu.Unlock()
+	c.hooks.SessionStart(context.Background())
+	return nil
+}
+
+func removeSessionArtifacts(path string) error {
+	if path == "" {
+		return nil
+	}
+	for _, p := range []string{path, agent.BranchMetaPath(path)} {
+		if p == "" {
+			continue
+		}
+		if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if dir := ckptDir(path); dir != "" {
+		if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -170,7 +170,7 @@ func TestSnapshotActivityRefreshesSessionActivity(t *testing.T) {
 	}
 }
 
-func TestSubmitClearAliasStartsFreshContextAndSavesTranscript(t *testing.T) {
+func TestNewSessionStartsFreshContextAndSavesTranscript(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "old context"})
@@ -178,13 +178,11 @@ func TestSubmitClearAliasStartsFreshContextAndSavesTranscript(t *testing.T) {
 	path := filepath.Join(dir, "session.jsonl")
 	c := New(Options{Executor: exec, SystemPrompt: "sys", SessionDir: dir, SessionPath: path, Label: "test"})
 
-	c.submit("/clear", "")
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) && c.SessionPath() == path {
-		time.Sleep(time.Millisecond)
+	if err := c.NewSession(); err != nil {
+		t.Fatal(err)
 	}
 	if c.SessionPath() == path {
-		t.Fatal("/clear did not rotate to a fresh session path")
+		t.Fatal("/new did not rotate to a fresh session path")
 	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
@@ -196,6 +194,46 @@ func TestSubmitClearAliasStartsFreshContextAndSavesTranscript(t *testing.T) {
 	current := exec.Session().Snapshot()
 	if len(current) != 1 || current[0].Role != provider.RoleSystem || current[0].Content != "sys" {
 		t.Fatalf("fresh context = %+v, want only system prompt", current)
+	}
+}
+
+func TestSubmitClearDiscardsCurrentContextWithoutSavingTranscript(t *testing.T) {
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "old context"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	path := filepath.Join(dir, "session.jsonl")
+	c := New(Options{Executor: exec, SystemPrompt: "sys", SessionDir: dir, SessionPath: path, Label: "test"})
+	if err := c.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+	ckpt := ckptDir(path)
+	if err := os.MkdirAll(ckpt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ckpt, "turn-0.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c.submit("/clear", "")
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) && c.SessionPath() == path {
+		time.Sleep(time.Millisecond)
+	}
+	if c.SessionPath() == path {
+		t.Fatal("/clear did not rotate to a fresh session path")
+	}
+	for _, p := range []string{path, agent.BranchMetaPath(path), ckpt} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("discarded artifact %s still exists or stat failed with %v", p, err)
+		}
+	}
+	if _, err := os.Stat(c.SessionPath()); !os.IsNotExist(err) {
+		t.Fatalf("fresh empty session should not be saved yet; stat err=%v", err)
+	}
+	current := exec.Session().Snapshot()
+	if len(current) != 1 || current[0].Role != provider.RoleSystem || current[0].Content != "sys" {
+		t.Fatalf("cleared context = %+v, want only system prompt", current)
 	}
 }
 

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -120,8 +120,11 @@ type Messages struct {
 	// chat TUI slash commands.
 	SlashCompactDone   string // "/compact" succeeded
 	SlashCompactFailed string // "/compact" errored, prefixed before the underlying error
-	SlashNewDone       string // "/new" or "/clear" succeeded
-	SlashNewFailed     string // "/new" or "/clear" errored
+	SlashNewDone       string // "/new" succeeded
+	SlashNewFailed     string // "/new" errored
+	SlashClearPrompt   string // "/clear" destructive confirmation prompt
+	SlashClearDone     string // "/clear" succeeded
+	SlashClearFailed   string // "/clear" errored
 	SlashTodoCleared   string // "/todo" dismissed the pinned task list
 	SlashUnavailable   string // the command is configured off (no callback wired)
 	SlashUnknown       string // shown when the user types an unrecognised "/cmd"
@@ -140,7 +143,8 @@ type Messages struct {
 
 	// slash command + sub-command descriptions shown in the menu (CLI and desktop
 	// share these via i18n.M, so both frontends localize identically).
-	CmdNew          string // /new, /clear
+	CmdNew          string // /new
+	CmdClear        string // /clear
 	CmdCompact      string // /compact
 	CmdRewind       string // /rewind
 	CmdTree         string // /tree

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -89,12 +89,15 @@ var English = Messages{
 
 	SlashCompactDone:   "session compacted — older middle replaced by a summary, recent turns kept",
 	SlashCompactFailed: "compaction failed",
-	SlashNewDone:       "fresh context started — previous transcript saved",
+	SlashNewDone:       "new session started — previous transcript saved",
 	SlashNewFailed:     "could not start a new session",
+	SlashClearPrompt:   "Clear current context without saving?",
+	SlashClearDone:     "current context cleared",
+	SlashClearFailed:   "could not clear current context",
 	SlashUnavailable:   "command unavailable in this build",
 	SlashUnknown:       "unknown command",
 	SlashTodoCleared:   "task list dismissed",
-	SlashHelp:          "commands: /compact · /new (/clear) · /resume · /rewind · /tree · /branch · /switch · /todo · /verbose · /model (switch model) · /effort · /theme · /language · /mcp · /skills · /hooks · /paste-image · /memory · /goal · /remember · /quit · /help · plus skills (/init, /explore, …)",
+	SlashHelp:          "commands: /compact · /new · /clear · /resume · /rewind · /tree · /branch · /switch · /todo · /verbose · /model (switch model) · /effort · /theme · /language · /mcp · /skills · /hooks · /paste-image · /memory · /goal · /remember · /quit · /help · plus skills (/init, /explore, …)",
 
 	SkillPickerTitle:             "Skills",
 	SkillPickerAvailableFmt:      "%d available",
@@ -151,7 +154,8 @@ var English = Messages{
 	ShellExecTimeoutFmt: "shell command timed out (> %s)",
 	ShellModeHint:       "Enter runs shell · Esc cancels · click output to expand",
 
-	CmdNew:          "start fresh context; save transcript",
+	CmdNew:          "start new session; save transcript",
+	CmdClear:        "discard current context",
 	CmdCompact:      "compact context",
 	CmdRewind:       "rewind to an earlier turn",
 	CmdTree:         "show conversation branches",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -90,12 +90,15 @@ var Chinese = Messages{
 
 	SlashCompactDone:   "已压缩 — 旧的中段换成一段摘要，最近几轮保留原样",
 	SlashCompactFailed: "压缩失败",
-	SlashNewDone:       "已开启新上下文 — 之前的对话已存档",
+	SlashNewDone:       "已开启新会话 — 之前的对话已存档",
 	SlashNewFailed:     "新建会话失败",
+	SlashClearPrompt:   "清空当前上下文且不保存？",
+	SlashClearDone:     "已清空当前上下文",
+	SlashClearFailed:   "清空当前上下文失败",
 	SlashUnavailable:   "当前构建不支持该命令",
 	SlashUnknown:       "未知命令",
 	SlashTodoCleared:   "已清除任务清单",
-	SlashHelp:          "命令：/compact · /new（/clear）· /resume · /rewind · /tree · /branch · /switch · /todo · /verbose · /model（切换模型）· /effort · /theme · /language · /mcp · /skills · /hooks · /paste-image · /memory · /goal · /remember · /quit · /help · 以及 skills（/init、/explore …）",
+	SlashHelp:          "命令：/compact · /new · /clear · /resume · /rewind · /tree · /branch · /switch · /todo · /verbose · /model（切换模型）· /effort · /theme · /language · /mcp · /skills · /hooks · /paste-image · /memory · /goal · /remember · /quit · /help · 以及 skills（/init、/explore …）",
 
 	SkillPickerTitle:             "Skills",
 	SkillPickerAvailableFmt:      "%d 个可用",
@@ -152,7 +155,8 @@ var Chinese = Messages{
 	ShellExecTimeoutFmt: "Shell 命令超时（>%s）",
 	ShellModeHint:       "Enter 执行 Shell · Esc 取消 · 点击输出展开",
 
-	CmdNew:          "清空上下文并保存历史",
+	CmdNew:          "开启新会话并保存历史",
+	CmdClear:        "丢弃当前上下文",
 	CmdCompact:      "压缩上下文",
 	CmdRewind:       "回滚到更早的一轮",
 	CmdTree:         "查看对话分支树",


### PR DESCRIPTION
## Summary
- Split `/new` and `/clear` semantics: `/new` starts a new session and saves the transcript, while `/clear` discards the current context.
- Add two-step `/clear` confirmation in the CLI TUI and an ASK-style in-app confirmation card in desktop.
- Update desktop state reset, command help, docs, and regression coverage for the new session/context behavior.

## Verification
- `pnpm --dir desktop/frontend build`
- isolated config run of `go test ./internal/control ./internal/cli`
- `go test ./...` from `desktop/`
- `git diff --check origin/main-v2...HEAD`
