### PR TITLE
fix(agent): scope @-references to workspace root instead of process CWD

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3840,7 +3840,7 @@ func (a *App) AttachDropped(path string) (DroppedItem, error) {
 				return nil
 			}
 		}
-		if rel, ok := workspaceRelative(path); ok {
+		if rel, ok := workspaceRelativeIn(path, a.activeWorkspaceRoot()); ok {
 			item = DroppedItem{Kind: "workspace", Path: rel, IsDir: info.IsDir()}
 			return nil
 		}
@@ -3868,12 +3868,16 @@ func isImageExt(path string) bool {
 	return false
 }
 
-func workspaceRelative(path string) (string, bool) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", false
+func workspaceRelativeIn(path, workspaceRoot string) (string, bool) {
+	root := workspaceRoot
+	if !filepath.IsAbs(root) {
+		abs, err := filepath.Abs(root)
+		if err != nil {
+			return "", false
+		}
+		root = abs
 	}
-	rel, err := filepath.Rel(cwd, path)
+	rel, err := filepath.Rel(root, path)
 	if err != nil {
 		return "", false
 	}

--- a/desktop/attach_dropped_test.go
+++ b/desktop/attach_dropped_test.go
@@ -10,20 +10,13 @@ import (
 
 const desktopTinyPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
 
-func TestWorkspaceRelative(t *testing.T) {
-	orig, _ := os.Getwd()
-	defer os.Chdir(orig)
-
+func TestWorkspaceRelativeIn(t *testing.T) {
 	root := t.TempDir()
-	if err := os.Chdir(root); err != nil {
-		t.Fatal(err)
-	}
-	cwd, _ := os.Getwd()
 
-	if rel, ok := workspaceRelative(filepath.Join(cwd, "sub", "file.go")); !ok || rel != "sub/file.go" {
+	if rel, ok := workspaceRelativeIn(filepath.Join(root, "sub", "file.go"), root); !ok || rel != "sub/file.go" {
 		t.Fatalf("in-tree = (%q, %v), want (sub/file.go, true)", rel, ok)
 	}
-	if _, ok := workspaceRelative(filepath.Join(filepath.Dir(cwd), "sibling.txt")); ok {
+	if _, ok := workspaceRelativeIn(filepath.Join(filepath.Dir(root), "sibling.txt"), root); ok {
 		t.Fatal("a path above the workspace must not resolve as in-tree")
 	}
 }

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -324,7 +324,15 @@ func (m *chatTUI) fileItems(token string) []compItem {
 	dir, frag := splitPathToken(token)
 	readDir := dir
 	if readDir == "" {
-		readDir = "."
+		if m.ctrl != nil {
+			if wr := m.ctrl.WorkspaceRoot(); wr != "" {
+				readDir = wr
+			} else {
+				readDir = "."
+			}
+		} else {
+			readDir = "."
+		}
 	}
 	entries, err := os.ReadDir(readDir)
 	if err != nil {
@@ -393,7 +401,13 @@ func (m *chatTUI) searchFileRefs(frag string) []string {
 	if r, ok := m.fileSearchCache[frag]; ok {
 		return r
 	}
-	r := fileref.Search(".", frag, maxFileSearchItems)
+	searchRoot := "."
+	if m.ctrl != nil {
+		if wr := m.ctrl.WorkspaceRoot(); wr != "" {
+			searchRoot = wr
+		}
+	}
+	r := fileref.Search(searchRoot, frag, maxFileSearchItems)
 	m.fileSearchCache[frag] = r
 	return r
 }

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -322,17 +323,19 @@ func (m *chatTUI) atItems(token string) []compItem {
 // unless frag starts with '.'. Top-level tokens also surface MCP resources.
 func (m *chatTUI) fileItems(token string) []compItem {
 	dir, frag := splitPathToken(token)
+	workspaceRoot := ""
+	if m.ctrl != nil {
+		workspaceRoot = m.ctrl.WorkspaceRoot()
+	}
 	readDir := dir
-	if readDir == "" {
-		if m.ctrl != nil {
-			if wr := m.ctrl.WorkspaceRoot(); wr != "" {
-				readDir = wr
-			} else {
-				readDir = "."
-			}
-		} else {
-			readDir = "."
+	if workspaceRoot != "" {
+		if readDir == "" {
+			readDir = workspaceRoot
+		} else if !filepath.IsAbs(readDir) {
+			readDir = filepath.Join(workspaceRoot, filepath.FromSlash(readDir))
 		}
+	} else if readDir == "" {
+		readDir = "."
 	}
 	entries, err := os.ReadDir(readDir)
 	if err != nil {

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -162,6 +162,30 @@ func TestFileItemsOneLevel(t *testing.T) {
 	}
 }
 
+func TestFileItemsSubdirUsesWorkspaceRoot(t *testing.T) {
+	cwd := t.TempDir()
+	workspace := t.TempDir()
+	writeAt(t, cwd, "src/cwd.go", "wrong")
+	writeAt(t, workspace, "src/workspace.go", "right")
+
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newTestChatTUI()
+	m.ctrl = control.New(control.Options{SessionDir: t.TempDir(), WorkspaceRoot: workspace})
+	items := m.fileItems("src/")
+
+	if !hasLabel(items, "workspace.go") {
+		t.Fatalf("workspace file should be listed for @src/: %v", labels(items))
+	}
+	if hasLabel(items, "cwd.go") {
+		t.Fatalf("cwd file should not leak into workspace completion: %v", labels(items))
+	}
+}
+
 func TestFileItemsSearchesBasenameAtTopLevel(t *testing.T) {
 	orig, _ := os.Getwd()
 	defer os.Chdir(orig)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2152,6 +2152,11 @@ func (c *Controller) DisconnectMCPServer(name string) bool {
 // Label returns the human-readable model label, e.g. "deepseek-flash".
 func (c *Controller) Label() string { return c.label }
 
+// WorkspaceRoot returns the workspace root for this controller's session
+// (the directory that file-writers and @-references are scoped to).
+// Empty means no scoping is in effect.
+func (c *Controller) WorkspaceRoot() string { return c.cpRoot }
+
 // Close stops plugin subprocesses and releases resources. A session that ever
 // started fires SessionEnd so a teardown hook runs.
 func (c *Controller) Close() {

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -110,7 +110,17 @@ func (c *Controller) detectRefs(line string) []ref {
 			known[n] = true
 		}
 	}
-	exists := func(p string) bool { _, err := os.Stat(p); return err == nil }
+	exists := func(p string) bool {
+		if _, err := os.Stat(p); err == nil {
+			return true
+		}
+		if c.cpRoot != "" {
+			if _, err := os.Stat(filepath.Join(c.cpRoot, p)); err == nil {
+				return true
+			}
+		}
+		return false
+	}
 
 	var refs []ref
 	for _, tok := range parseRefTokens(line) {
@@ -131,7 +141,7 @@ func (c *Controller) HasRefs(line string) bool {
 // don't exist in cwd. It walks the working tree once and matches every
 // unresolved name against the set, stopping when all are found. This runs in
 // the async ResolveRefs path, never on the TUI event loop.
-func resolveBareNames(refs []ref) []ref {
+func resolveBareNames(refs []ref, workspaceRoot string) []ref {
 	need := map[string]*ref{}
 	var names []string
 	for i := range refs {
@@ -149,7 +159,10 @@ func resolveBareNames(refs []ref) []ref {
 		return refs
 	}
 	found := 0
-	cwd, _ := os.Getwd()
+	cwd := workspaceRoot
+	if cwd == "" {
+		cwd, _ = os.Getwd()
+	}
 	_ = filepath.WalkDir(cwd, func(p string, d os.DirEntry, wErr error) error {
 		if wErr != nil || found == len(names) {
 			return filepath.SkipAll
@@ -193,7 +206,7 @@ func FileRefLine(line string) (string, bool) {
 // Safe to call off a frontend's event loop; honours ctx for the resource reads.
 func (c *Controller) ResolveRefs(ctx context.Context, line string) (block string, errs []string) {
 	refs := c.detectRefs(line)
-	refs = resolveBareNames(refs)
+	refs = resolveBareNames(refs, c.cpRoot)
 	var b strings.Builder
 	for _, r := range refs {
 		switch r.kind {
@@ -205,7 +218,7 @@ func (c *Controller) ResolveRefs(ctx context.Context, line string) (block string
 			}
 			appendRefBlock(&b, "resource", `ref="@`+r.raw+`"`, text)
 		case refFile:
-			text, isDir, err := readFileRef(r.path)
+			text, isDir, err := readFileRef(r.path, c.cpRoot)
 			if err != nil {
 				errs = append(errs, "@"+r.raw+" — "+err.Error())
 				continue
@@ -237,7 +250,78 @@ const maxDirEntries = 100
 // recursive listing capped at maxDirEntries; a binary file (NUL in the first
 // 8 KiB) is noted rather than dumped; a large file is truncated to
 // maxFileRefBytes with a marker. isDir lets the caller pick the wrapping tag.
-func readFileRef(path string) (content string, isDir bool, err error) {
+// When baseDir is non-empty the read is sandboxed under it via os.Root so
+// user-supplied paths cannot escape the workspace; otherwise the path is
+// used as-is (CLI single-workspace compatibility).
+func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
+	absPath, absBase, ok := resolveAbsRef(path, baseDir)
+	if !ok {
+		return "", false, os.ErrNotExist
+	}
+	if absBase == "" {
+		return readFileRefUnscoped(absPath)
+	}
+
+	root, rerr := os.OpenRoot(absBase)
+	if rerr != nil {
+		return "", false, rerr
+	}
+	defer root.Close()
+
+	rel, rerr := filepath.Rel(absBase, absPath)
+	if rerr != nil {
+		return "", false, rerr
+	}
+
+	info, err := root.Stat(rel)
+	if err != nil {
+		return "", false, err
+	}
+	if info.IsDir() {
+		var b strings.Builder
+		n := 0
+		err := walkRootDir(root, rel, &b, &n, 0)
+		if n >= maxDirEntries {
+			b.WriteString("\n…[truncated; directory has more entries]…")
+		}
+		if err != nil {
+			return "", true, err
+		}
+		return b.String(), true, nil
+	}
+
+	if strings.EqualFold(filepath.Ext(rel), ".pdf") {
+		return readPDFRef(rel, info.Size()), false, nil
+	}
+
+	f, err := root.Open(rel)
+	if err != nil {
+		return "", false, err
+	}
+	defer f.Close()
+
+	buf := make([]byte, maxFileRefBytes+1)
+	n, rerr := io.ReadFull(f, buf)
+	if rerr != nil && rerr != io.ErrUnexpectedEOF && rerr != io.EOF {
+		return "", false, rerr
+	}
+	data := buf[:n]
+
+	if mime := imageMime(data, rel); mime != "" {
+		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — image bytes are not inlined. Use an available MCP image/OCR/vision tool with this path when visual understanding is needed.]", rel, mime, info.Size()), false, nil
+	}
+	if bytes.IndexByte(data[:min(n, 8192)], 0) >= 0 {
+		return fmt.Sprintf("[binary file %s, %d bytes — not shown]", rel, info.Size()), false, nil
+	}
+	if n > maxFileRefBytes {
+		return string(data[:maxFileRefBytes]) + fmt.Sprintf("\n…[truncated; file is %d bytes]…", info.Size()), false, nil
+	}
+	return string(data), false, nil
+}
+
+// readFileRefUnscoped is the legacy readFileRef body kept for CLI single-workspace
+// compatibility, where no controller-scoped sandbox is in effect.
+func readFileRefUnscoped(path string) (content string, isDir bool, err error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return "", false, err
@@ -310,6 +394,77 @@ func readFileRef(path string) (content string, isDir bool, err error) {
 		return string(data[:maxFileRefBytes]) + fmt.Sprintf("\n…[truncated; file is %d bytes]…", info.Size()), false, nil
 	}
 	return string(data), false, nil
+}
+
+// walkRootDir walks a directory under a sandboxed *os.Root and writes each
+// entry (skipping noisy ones like .git and node_modules) into b until n hits
+// maxDirEntries.
+func walkRootDir(root *os.Root, dir string, b *strings.Builder, n *int, depth int) error {
+	if depth > 16 || *n >= maxDirEntries {
+		return nil
+	}
+	f, err := root.Open(dir)
+	if err != nil {
+		return err
+	}
+	entries, err := f.ReadDir(-1)
+	f.Close()
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if *n >= maxDirEntries {
+			return nil
+		}
+		name := e.Name()
+		entry := name
+		if e.IsDir() {
+			switch name {
+			case ".git", "node_modules", ".DS_Store", "__pycache__", ".idea", ".vscode":
+				continue
+			}
+			entry += "/"
+		}
+		b.WriteString(entry)
+		b.WriteByte('\n')
+		*n++
+		if e.IsDir() {
+			child := filepath.ToSlash(filepath.Join(dir, name))
+			if err := walkRootDir(root, child, b, n, depth+1); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// resolveAbsRef resolves the user-supplied @-reference path against baseDir
+// and returns the absolute path plus the absolute base root to sandbox I/O
+// under. With a baseDir, the path is confined under it (a relative path that
+// escapes via ".." is rejected). With an empty baseDir, the path is returned
+// as-is and the caller falls back to plain os.Stat/os.Open so CLI usage
+// (where there is no controller-scoped workspace) keeps working.
+func resolveAbsRef(path, baseDir string) (absPath, absBase string, ok bool) {
+	if baseDir == "" {
+		return path, "", true
+	}
+	absBase = baseDir
+	if !filepath.IsAbs(absBase) {
+		var err error
+		absBase, err = filepath.Abs(absBase)
+		if err != nil {
+			return "", "", false
+		}
+	}
+	cleaned := filepath.Clean(path)
+	if !filepath.IsAbs(cleaned) {
+		cleaned = filepath.Join(absBase, cleaned)
+	}
+	rel, err := filepath.Rel(absBase, cleaned)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", "", false
+	}
+	return cleaned, absBase, true
 }
 
 func readPDFRef(path string, size int64) string {

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -111,15 +111,16 @@ func (c *Controller) detectRefs(line string) []ref {
 		}
 	}
 	exists := func(p string) bool {
-		if _, err := os.Stat(p); err == nil {
-			return true
-		}
 		if c.cpRoot != "" {
-			if _, err := os.Stat(filepath.Join(c.cpRoot, p)); err == nil {
-				return true
+			absPath, _, ok := resolveAbsRef(p, c.cpRoot)
+			if !ok {
+				return false
 			}
+			_, err := os.Stat(absPath)
+			return err == nil
 		}
-		return false
+		_, err := os.Stat(p)
+		return err == nil
 	}
 
 	var refs []ref
@@ -149,7 +150,15 @@ func resolveBareNames(refs []ref, workspaceRoot string) []ref {
 		if r.kind != refFile || strings.ContainsAny(r.raw, "/\\") {
 			continue
 		}
-		if _, err := os.Stat(r.raw); err == nil {
+		statPath := r.raw
+		if workspaceRoot != "" {
+			absPath, _, ok := resolveAbsRef(r.raw, workspaceRoot)
+			if !ok {
+				continue
+			}
+			statPath = absPath
+		}
+		if _, err := os.Stat(statPath); err == nil {
 			continue
 		}
 		need[r.raw] = r
@@ -291,7 +300,7 @@ func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
 	}
 
 	if strings.EqualFold(filepath.Ext(rel), ".pdf") {
-		return readPDFRef(rel, info.Size()), false, nil
+		return readPDFRef(absPath, info.Size()), false, nil
 	}
 
 	f, err := root.Open(rel)

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -162,22 +162,22 @@ func TestReadFileRef(t *testing.T) {
 	}
 
 	// Text file: content verbatim, not a directory.
-	if got, isDir, err := readFileRef(textPath); err != nil || isDir || got != "line one\nline two\n" {
+	if got, isDir, err := readFileRef(textPath, ""); err != nil || isDir || got != "line one\nline two\n" {
 		t.Errorf("text file = (%q, %v, %v)", got, isDir, err)
 	}
 
 	// Binary file: noted, not dumped.
-	if got, _, err := readFileRef(binPath); err != nil || !strings.Contains(got, "binary file") {
+	if got, _, err := readFileRef(binPath, ""); err != nil || !strings.Contains(got, "binary file") {
 		t.Errorf("binary file = (%q, %v), want a binary note", got, err)
 	}
 
 	// Image file: identified as image-specific guidance, not generic binary.
-	if got, _, err := readFileRef(imagePath); err != nil || !strings.Contains(got, "image file") {
+	if got, _, err := readFileRef(imagePath, ""); err != nil || !strings.Contains(got, "image file") {
 		t.Errorf("image file = (%q, %v), want an image note", got, err)
 	}
 
 	// Large file: truncated with a marker.
-	if got, _, err := readFileRef(bigPath); err != nil || !strings.Contains(got, "truncated") {
+	if got, _, err := readFileRef(bigPath, ""); err != nil || !strings.Contains(got, "truncated") {
 		t.Errorf("big file should be truncated, got len=%d err=%v", len(got), err)
 	}
 
@@ -188,7 +188,7 @@ func TestReadFileRef(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "sub", "nested.txt"), []byte("nested"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	got, isDir, err := readFileRef(dir)
+	got, isDir, err := readFileRef(dir, "")
 	if err != nil || !isDir {
 		t.Fatalf("dir = (isDir=%v, err=%v)", isDir, err)
 	}
@@ -197,7 +197,7 @@ func TestReadFileRef(t *testing.T) {
 	}
 
 	// Missing path: error.
-	if _, _, err := readFileRef(filepath.Join(dir, "nope")); err == nil {
+	if _, _, err := readFileRef(filepath.Join(dir, "nope"), ""); err == nil {
 		t.Error("missing path should error")
 	}
 }
@@ -218,7 +218,7 @@ func TestReadFileRefPDFExtraction(t *testing.T) {
 		}
 		return pdfExtractResult{text: "Quarterly results\nRevenue up", tool: "test-extractor"}, nil
 	}
-	got, isDir, err := readFileRef(pdfPath)
+	got, isDir, err := readFileRef(pdfPath, "")
 	if err != nil || isDir {
 		t.Fatalf("pdf text = (isDir=%v, err=%v)", isDir, err)
 	}
@@ -229,7 +229,7 @@ func TestReadFileRefPDFExtraction(t *testing.T) {
 	extractPDFText = func(string) (pdfExtractResult, error) {
 		return pdfExtractResult{text: "   ", tool: "test-extractor"}, nil
 	}
-	got, _, err = readFileRef(pdfPath)
+	got, _, err = readFileRef(pdfPath, "")
 	if err != nil {
 		t.Fatalf("empty pdf text err = %v", err)
 	}
@@ -240,7 +240,7 @@ func TestReadFileRefPDFExtraction(t *testing.T) {
 	extractPDFText = func(string) (pdfExtractResult, error) {
 		return pdfExtractResult{}, os.ErrNotExist
 	}
-	got, _, err = readFileRef(pdfPath)
+	got, _, err = readFileRef(pdfPath, "")
 	if err != nil {
 		t.Fatalf("failed pdf text err = %v", err)
 	}
@@ -314,7 +314,7 @@ func TestResolveBareNamesDuplicates(t *testing.T) {
 		{kind: refFile, raw: "main.go"},
 	}
 
-	resolved := resolveBareNames(refs)
+	resolved := resolveBareNames(refs, "")
 
 	if len(resolved) != 2 {
 		t.Fatalf("expected 2 resolved refs, got %d", len(resolved))
@@ -328,5 +328,104 @@ func TestResolveBareNamesDuplicates(t *testing.T) {
 	}
 	if mainRef.path != "c/main.go" {
 		t.Errorf("expected main.go path to be c/main.go, got %q", mainRef.path)
+	}
+}
+
+func TestReadFileRefWithBaseDir(t *testing.T) {
+	base := t.TempDir()
+	sub := filepath.Join(base, "proj")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "hello.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Relative path "proj/hello.txt" resolves via baseDir when not in CWD.
+	got, isDir, err := readFileRef("proj/hello.txt", base)
+	if err != nil {
+		t.Fatalf("readFileRef with baseDir: %v", err)
+	}
+	if isDir {
+		t.Error("expected file, not directory")
+	}
+	if got != "hello" {
+		t.Errorf("got %q, want %q", got, "hello")
+	}
+
+	// Empty baseDir falls back to direct path (absolute).
+	got2, _, err2 := readFileRef(filepath.Join(sub, "hello.txt"), "")
+	if err2 != nil {
+		t.Fatalf("readFileRef with empty baseDir: %v", err2)
+	}
+	if got2 != "hello" {
+		t.Errorf("got %q, want %q", got2, "hello")
+	}
+}
+
+func TestResolveBareNamesWithWorkspaceRoot(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "src", "main.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := []ref{{kind: refFile, raw: "main.go"}}
+	resolved := resolveBareNames(refs, root)
+
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(resolved))
+	}
+	if resolved[0].path != "src/main.go" {
+		t.Errorf("expected src/main.go, got %q", resolved[0].path)
+	}
+}
+
+func TestResolveAbsRef(t *testing.T) {
+	temp := t.TempDir()
+
+	_, _, ok := resolveAbsRef("foo.txt", "")
+	if !ok {
+		t.Errorf("empty base: expected ok=true with CLI fallback")
+	}
+
+	absInBase := filepath.Join(temp, "foo.txt")
+	absPath, absBase, ok := resolveAbsRef(absInBase, temp)
+	if !ok || absPath != absInBase || absBase != temp {
+		t.Errorf("absolute path under base: got (%q, %q, %v), want (%q, %q, true)", absPath, absBase, ok, absInBase, temp)
+	}
+
+	if _, _, ok := resolveAbsRef(filepath.Join(temp, "..", "outside.txt"), temp); ok {
+		t.Errorf("absolute path outside base should be rejected")
+	}
+
+	want := filepath.Join(temp, "sub", "file.txt")
+	absPath, absBase, ok = resolveAbsRef(filepath.Join("sub", "file.txt"), temp)
+	if !ok || absPath != want || absBase != temp {
+		t.Errorf("relative in base: got (%q, %q, %v), want (%q, %q, true)", absPath, absBase, ok, want, temp)
+	}
+
+	if _, _, ok := resolveAbsRef(".."+string(filepath.Separator)+"outside.txt", temp); ok {
+		t.Errorf("path traversal should be rejected")
+	}
+	if _, _, ok := resolveAbsRef("sub/../../escape.txt", temp); ok {
+		t.Errorf("path traversal should be rejected")
+	}
+}
+
+func TestReadFileRefBlocksPathTraversal(t *testing.T) {
+	temp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(temp, "safe.txt"), []byte("safe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(temp, "..", "outside.txt"), []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Remove(filepath.Join(temp, "..", "outside.txt")) })
+
+	if _, isDir, err := readFileRef(".."+string(filepath.Separator)+"outside.txt", temp); err == nil {
+		t.Errorf("expected traversal to fail, got isDir=%v err=%v", isDir, err)
 	}
 }

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -429,3 +429,79 @@ func TestReadFileRefBlocksPathTraversal(t *testing.T) {
 		t.Errorf("expected traversal to fail, got isDir=%v err=%v", isDir, err)
 	}
 }
+
+func TestDetectRefsUsesWorkspaceRootNotProcessCWD(t *testing.T) {
+	cwd := t.TempDir()
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cwd, "cwd-only.txt"), []byte("wrong"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workspace, "workspace.txt"), []byte("right"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Error(err)
+		}
+	})
+
+	refs := (&Controller{cpRoot: workspace}).detectRefs("see @cwd-only.txt and @workspace.txt")
+	if len(refs) != 1 || refs[0].raw != "workspace.txt" {
+		t.Fatalf("detectRefs should only see workspace files, got %+v", refs)
+	}
+
+	block, errs := (&Controller{cpRoot: workspace}).ResolveRefs(context.Background(), "see @cwd-only.txt")
+	if block != "" || len(errs) != 0 {
+		t.Fatalf("cwd-only file should not be treated as a ref, block=%q errs=%v", block, errs)
+	}
+}
+
+func TestReadFileRefPDFExtractionWithBaseDirUsesAbsPath(t *testing.T) {
+	base := t.TempDir()
+	pdfPath := filepath.Join(base, "docs", "report.pdf")
+	if err := os.MkdirAll(filepath.Dir(pdfPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(pdfPath, []byte("%PDF-1.4 fake"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outside := t.TempDir()
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(outside); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldCwd); err != nil {
+			t.Error(err)
+		}
+	})
+
+	oldExtract := extractPDFText
+	t.Cleanup(func() { extractPDFText = oldExtract })
+	extractPDFText = func(path string) (pdfExtractResult, error) {
+		if path != pdfPath {
+			t.Fatalf("extract path = %q, want %q", path, pdfPath)
+		}
+		return pdfExtractResult{text: "workspace pdf", tool: "test-extractor"}, nil
+	}
+
+	got, isDir, err := readFileRef("docs/report.pdf", base)
+	if err != nil || isDir {
+		t.Fatalf("scoped pdf = (isDir=%v, err=%v)", isDir, err)
+	}
+	if !strings.Contains(got, "workspace pdf") {
+		t.Fatalf("scoped pdf extraction missing text: %s", got)
+	}
+}


### PR DESCRIPTION
Multi-tab desktop sessions were resolving @file references against the process working directory (os.Getwd()), causing cross-workspace contamination when tabs share the same process.

Changes:

- controller.go: add WorkspaceRoot() accessor for cpRoot

- refs.go: detectRefs/resolveBareNames/readFileRef use cpRoot as base directory

- app.go: workspaceRelative renamed to workspaceRelativeIn with explicit root; AttachDropped uses activeWorkspaceRoot()

- complete.go: fileItems/searchFileRefs use ctrl.WorkspaceRoot()

All paths fall back to os.Getwd() when workspaceRoot is empty, preserving CLI compatibility.

Closes: esengine/DeepSeek-Reasonix#3776