### PR TITLE
fix(desktop): make the frontend typecheck under TypeScript 6 (unblocks #3691)

### DIFF
--- a/desktop/frontend/src/components/AnchoredPopover.tsx
+++ b/desktop/frontend/src/components/AnchoredPopover.tsx
@@ -54,7 +54,7 @@ export function AnchoredPopover({
   closing = false,
 }: {
   open: boolean;
-  anchorRef: RefObject<HTMLElement>;
+  anchorRef: RefObject<HTMLElement | null>;
   onClose: () => void;
   className: string;
   children: ReactNode;

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -381,7 +381,7 @@ export function Composer({
   // by 120ms so rapid typing doesn't flood the backend with IPC calls — the
   // menu only updates after the user pauses.
   const [argRes, setArgRes] = useState<SlashArgsResult | null>(null);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => {
     if (!text.startsWith("/") || !/\s/.test(text)) {
       setArgRes(null);

--- a/desktop/frontend/src/components/PromptShelf.tsx
+++ b/desktop/frontend/src/components/PromptShelf.tsx
@@ -21,7 +21,7 @@ export function PromptShelf({
   children?: ReactNode;
   crumbs?: ReactNode;
   quickActions?: ReactNode;
-  barRef?: RefObject<HTMLDivElement>;
+  barRef?: RefObject<HTMLDivElement | null>;
   actionsWrap?: boolean;
 }) {
   return (

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   CSSProperties,
   DragEvent as ReactDragEvent,
+  JSX,
   KeyboardEvent,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,


### PR DESCRIPTION
Unblocks the TypeScript 6 bump (#3691). The `@types/react` 19 bump (#3690) tightened ref nullability and dropped the global `JSX` namespace; TypeScript 6 enforces both, so the frontend typecheck fails under #3691 even though it passes under 5.9.

Fixes (no behavior change, all valid under the current TS 5.9 too):
- `AnchoredPopover` / `PromptShelf`: shared ref props typed `RefObject<T | null>` to match what `useRef(null)` actually returns.
- `WorkspacePanel`: import the `JSX` namespace from `react` instead of relying on the removed global.
- `Composer`: give the debounce `useRef` an explicit `undefined` initial value.

Verified locally: with `typescript@6.0.3`, the 12 errors #3691 hit are gone (only the wails-generated bindings, which CI generates, remain); under the locked TS 5.9 the changed files add no new errors. Once this lands, #3691 should go green on rebase.
