### PR TITLE
Fix draft goal mode handoff / 修复目标草稿模式切换

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -11,9 +11,9 @@
     "check:browser-preview": "node scripts/check-browser-preview-stability.mjs",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts",
+    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts",
     "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
-    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts"
+    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.2",

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -44,7 +44,6 @@ import {
   modeHasAutoApproveTools,
   modeHasPlan,
   modeFromAxes,
-  normalizeCollaborationMode,
   normalizeMode,
   normalizeToolApprovalMode,
   type CollaborationMode,
@@ -56,6 +55,13 @@ import {
   type TabMeta,
   type ToolApprovalMode,
 } from "./lib/types";
+import {
+  controllerCollaborationMode,
+  displayedCollaborationMode,
+  keepGoalDraftMode,
+  metaSyncedCollaborationMode,
+  tabListCollaborationMode,
+} from "./lib/goalDraftMode";
 import { loadLayoutSize, saveLayoutSize } from "./lib/layoutPreferences";
 import {
   applyTheme,
@@ -412,6 +418,7 @@ export default function App() {
   const [collaborationModesByTab, setCollaborationModesByTab] = useState<Record<string, CollaborationMode>>({});
   const [toolApprovalModesByTab, setToolApprovalModesByTab] = useState<Record<string, ToolApprovalMode>>({});
   const [goalsByTab, setGoalsByTab] = useState<Record<string, string>>({});
+  const [goalDraftModesByTab, setGoalDraftModesByTab] = useState<Record<string, boolean>>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
@@ -583,8 +590,16 @@ export default function App() {
   const startupSplashHold = state.meta?.ready !== true && !state.meta?.startupErr;
   const legacyMode = activeTabId ? modesByTab[activeTabId] ?? "normal" : "normal";
   const goal = activeTabId ? goalsByTab[activeTabId] ?? state.meta?.goal ?? activeTab?.goal ?? "" : "";
+  const goalDraftMode = activeTabId ? Boolean(goalDraftModesByTab[activeTabId]) : false;
   const collaborationMode = activeTabId
-    ? collaborationModesByTab[activeTabId] ?? normalizeCollaborationMode(state.meta?.goal ? "goal" : activeTab?.collaborationMode, goal, legacyMode)
+    ? displayedCollaborationMode({
+      goalDraftMode,
+      localMode: collaborationModesByTab[activeTabId],
+      metaGoal: state.meta?.goal,
+      tabMode: activeTab?.collaborationMode,
+      goal,
+      legacyMode,
+    })
     : "normal";
   const toolApprovalMode = activeTabId
     ? toolApprovalModesByTab[activeTabId] ?? normalizeToolApprovalMode(state.meta?.toolApprovalMode ?? activeTab?.toolApprovalMode, legacyMode, state.meta?.autoApproveTools ?? state.meta?.bypass)
@@ -602,6 +617,15 @@ export default function App() {
     },
     [activeTabId],
   );
+  const setGoalDraftModeForTab = useCallback((tabId: string, enabled: boolean) => {
+    setGoalDraftModesByTab((current) => {
+      if (Boolean(current[tabId]) === enabled) return current;
+      if (enabled) return { ...current, [tabId]: true };
+      const next = { ...current };
+      delete next[tabId];
+      return next;
+    });
+  }, []);
   const topicbarEditing = Boolean(activeTab?.topicId && activeTab.topicId === renamingTopicId);
   const visibleTabId = activeTabId;
   const visibleTabs = useMemo(() => {
@@ -612,12 +636,18 @@ export default function App() {
       ...tab,
       running: tab.id === visibleTabId ? tab.running || state.running : tab.running,
       mode: modesByTab[tab.id] ?? normalizeMode(tab.mode),
-      collaborationMode: collaborationModesByTab[tab.id] ?? normalizeCollaborationMode(tab.collaborationMode, goalsByTab[tab.id] ?? tab.goal, normalizeMode(tab.mode)),
+      collaborationMode: tabListCollaborationMode({
+        goalDraftMode: Boolean(goalDraftModesByTab[tab.id]),
+        localMode: collaborationModesByTab[tab.id],
+        tabMode: tab.collaborationMode,
+        tabGoal: goalsByTab[tab.id] ?? tab.goal,
+        legacyMode: normalizeMode(tab.mode),
+      }),
       toolApprovalMode: toolApprovalModesByTab[tab.id] ?? normalizeToolApprovalMode(tab.toolApprovalMode, normalizeMode(tab.mode), tab.toolApprovalMode === "yolo"),
       goal: goalsByTab[tab.id] ?? tab.goal ?? "",
       active: tab.id === visibleTabId,
     }));
-  }, [collaborationModesByTab, goalsByTab, modesByTab, state.running, tabMetas, tabOrderIds, toolApprovalModesByTab, visibleTabId]);
+  }, [collaborationModesByTab, goalDraftModesByTab, goalsByTab, modesByTab, state.running, tabMetas, tabOrderIds, toolApprovalModesByTab, visibleTabId]);
 
   useEffect(() => {
     const ids = tabMetas.map((tab) => tab.id);
@@ -632,6 +662,21 @@ export default function App() {
 
   useEffect(() => {
     const ids = new Set(tabMetas.map((tab) => tab.id));
+    setGoalDraftModesByTab((current) => {
+      let changed = false;
+      const next: Record<string, boolean> = {};
+      for (const tab of tabMetas) {
+        if (keepGoalDraftMode(Boolean(current[tab.id]), tab.goal)) {
+          next[tab.id] = true;
+        } else if (current[tab.id]) {
+          changed = true;
+        }
+      }
+      for (const id of Object.keys(current)) {
+        if (!ids.has(id)) changed = true;
+      }
+      return changed ? next : current;
+    });
     setModesByTab((current) => {
       let changed = false;
       const next: Record<string, Mode> = {};
@@ -649,7 +694,12 @@ export default function App() {
       let changed = false;
       const next: Record<string, CollaborationMode> = {};
       for (const tab of tabMetas) {
-        const value = normalizeCollaborationMode(tab.collaborationMode, tab.goal, normalizeMode(tab.mode));
+        const value = tabListCollaborationMode({
+          goalDraftMode: keepGoalDraftMode(Boolean(goalDraftModesByTab[tab.id]), tab.goal),
+          tabMode: tab.collaborationMode,
+          tabGoal: tab.goal,
+          legacyMode: normalizeMode(tab.mode),
+        });
         next[tab.id] = value;
         if (current[tab.id] !== value) changed = true;
       }
@@ -684,7 +734,7 @@ export default function App() {
       }
       return changed ? next : current;
     });
-  }, [tabMetas]);
+  }, [goalDraftModesByTab, tabMetas]);
 
   useEffect(() => {
     if (!renamingTopicId || activeTab?.topicId === renamingTopicId) return;
@@ -697,12 +747,13 @@ export default function App() {
   useEffect(() => {
     if (!activeTabId || !state.meta) return;
     const nextGoal = state.meta.goalStatus === "running" ? state.meta.goal ?? "" : "";
+    if (nextGoal) setGoalDraftModeForTab(activeTabId, false);
     setGoalsByTab((current) => (current[activeTabId] === nextGoal ? current : { ...current, [activeTabId]: nextGoal }));
     setCollaborationModesByTab((current) => {
-      const nextMode = nextGoal ? "goal" : normalizeCollaborationMode(undefined, "", legacyMode);
+      const nextMode = metaSyncedCollaborationMode({ nextGoal, goalDraftMode, legacyMode });
       return current[activeTabId] === nextMode ? current : { ...current, [activeTabId]: nextMode };
     });
-  }, [activeTabId, legacyMode, state.meta]);
+  }, [activeTabId, goalDraftMode, legacyMode, setGoalDraftModeForTab, state.meta]);
 
   const syncModeToController = useCallback((m: Mode) => setControllerMode(m), [setControllerMode]);
 
@@ -719,17 +770,26 @@ export default function App() {
       if (!activeTabId) return;
       const nextCollaborationMode: CollaborationMode = modeHasPlan(m) ? "plan" : "normal";
       const nextToolApprovalMode: ToolApprovalMode = modeHasAutoApproveTools(m) ? "yolo" : "ask";
+      setGoalDraftModeForTab(activeTabId, false);
       setMode(m);
       setCollaborationModesByTab((current) => (current[activeTabId] === nextCollaborationMode ? current : { ...current, [activeTabId]: nextCollaborationMode }));
       setToolApprovalModesByTab((current) => (current[activeTabId] === nextToolApprovalMode ? current : { ...current, [activeTabId]: nextToolApprovalMode }));
       setGoalsByTab((current) => (current[activeTabId] ? { ...current, [activeTabId]: "" } : current));
       void syncModeToController(m);
     },
-    [activeTabId, setMode, syncModeToController],
+    [activeTabId, setGoalDraftModeForTab, setMode, syncModeToController],
   );
   const applyCollaborationMode = useCallback(
     (m: CollaborationMode) => {
       if (!activeTabId) return;
+      if (m === "goal") {
+        setGoalDraftModeForTab(activeTabId, true);
+        setCollaborationModesByTab((current) => (current[activeTabId] === "goal" ? current : { ...current, [activeTabId]: "goal" }));
+        setMode(modeFromAxes(false, toolApprovalMode === "yolo"));
+        void setControllerCollaborationMode("normal");
+        return;
+      }
+      setGoalDraftModeForTab(activeTabId, false);
       setCollaborationModesByTab((current) => (current[activeTabId] === m ? current : { ...current, [activeTabId]: m }));
       if (m === "normal" || m === "plan") {
         setGoalsByTab((current) => (current[activeTabId] ? { ...current, [activeTabId]: "" } : current));
@@ -737,7 +797,7 @@ export default function App() {
       setMode(modeFromAxes(m === "plan", toolApprovalMode === "yolo"));
       void setControllerCollaborationMode(m);
     },
-    [activeTabId, setControllerCollaborationMode, setMode, toolApprovalMode],
+    [activeTabId, setControllerCollaborationMode, setGoalDraftModeForTab, setMode, toolApprovalMode],
   );
   const applyToolApprovalMode = useCallback(
     (m: ToolApprovalMode) => {
@@ -752,6 +812,7 @@ export default function App() {
     (nextGoal: string) => {
       if (!activeTabId) return;
       const trimmed = nextGoal.trim();
+      setGoalDraftModeForTab(activeTabId, false);
       setGoalsByTab((current) => (current[activeTabId] === trimmed ? current : { ...current, [activeTabId]: trimmed }));
       setCollaborationModesByTab((current) => {
         const nextMode = trimmed ? "goal" : "normal";
@@ -760,7 +821,7 @@ export default function App() {
       setMode(modeFromAxes(false, toolApprovalMode === "yolo"));
       void (trimmed ? setControllerGoal(trimmed) : clearControllerGoal());
     },
-    [activeTabId, clearControllerGoal, setControllerGoal, setMode, toolApprovalMode],
+    [activeTabId, clearControllerGoal, setControllerGoal, setGoalDraftModeForTab, setMode, toolApprovalMode],
   );
   const startGoal = useCallback(
     (nextGoal: string) => {
@@ -782,7 +843,7 @@ export default function App() {
   const switchModel = useCallback(
     async (name: string) => {
       await setModel(name);
-      await setControllerCollaborationMode(collaborationMode);
+      await setControllerCollaborationMode(controllerCollaborationMode({ collaborationMode, goal }));
       await setControllerToolApprovalMode(toolApprovalMode);
       if (goal.trim()) await setControllerGoal(goal);
     },
@@ -795,7 +856,7 @@ export default function App() {
   // SetBypass binding was a harmless no-op.
   useEffect(() => {
     if (!controllerReady) return;
-    void setControllerCollaborationMode(collaborationMode);
+    void setControllerCollaborationMode(controllerCollaborationMode({ collaborationMode, goal }));
     void setControllerToolApprovalMode(toolApprovalMode);
     if (goal.trim()) void setControllerGoal(goal);
   }, [collaborationMode, controllerReady, goal, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, toolApprovalMode]);

--- a/desktop/frontend/src/__tests__/goal-draft-mode.test.ts
+++ b/desktop/frontend/src/__tests__/goal-draft-mode.test.ts
@@ -1,0 +1,75 @@
+// Run: tsx src/__tests__/goal-draft-mode.test.ts
+
+import {
+  controllerCollaborationMode,
+  displayedCollaborationMode,
+  keepGoalDraftMode,
+  metaSyncedCollaborationMode,
+  tabListCollaborationMode,
+} from "../lib/goalDraftMode";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\ngoal draft mode");
+
+eq(
+  displayedCollaborationMode({ goalDraftMode: true, localMode: "normal", goal: "" }),
+  "goal",
+  "draft goal mode wins over stale local normal mode",
+);
+
+eq(
+  tabListCollaborationMode({ goalDraftMode: true, tabMode: "normal", tabGoal: "" }),
+  "goal",
+  "tab list keeps draft goal mode visible before a goal is started",
+);
+
+eq(
+  metaSyncedCollaborationMode({ nextGoal: "", goalDraftMode: true, legacyMode: "normal" }),
+  "goal",
+  "empty controller meta does not collapse a draft goal mode",
+);
+
+eq(
+  controllerCollaborationMode({ collaborationMode: "goal", goal: "" }),
+  "normal",
+  "empty draft goal syncs to the controller as normal mode",
+);
+
+eq(
+  controllerCollaborationMode({ collaborationMode: "goal", goal: "ship the fix" }),
+  "goal",
+  "started goal syncs to the controller as goal mode",
+);
+
+eq(
+  keepGoalDraftMode(true, ""),
+  true,
+  "draft flag is retained while goal text is empty",
+);
+
+eq(
+  keepGoalDraftMode(true, "ship the fix"),
+  false,
+  "draft flag clears after a real goal exists",
+);
+
+eq(
+  metaSyncedCollaborationMode({ nextGoal: "", goalDraftMode: false, legacyMode: "plan" }),
+  "plan",
+  "non-draft empty goal falls back to legacy plan mode",
+);
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
-import { ArrowUp, Eye, FileText, Folder, List, MessageSquare, Plus, Search, Shield, ShieldAlert, ShieldCheck, Square, Target, Trash2, X } from "lucide-react";
+import { ArrowUp, Eye, FileText, Folder, List, MessageSquare, Search, Shield, ShieldAlert, ShieldCheck, SlidersHorizontal, Square, Target, Trash2, X } from "lucide-react";
 import { asArray } from "../lib/array";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
 import { app, onFilesDropped } from "../lib/bridge";
@@ -1726,9 +1726,10 @@ export function Composer({
                   disabled={disabled || running}
                   aria-haspopup="menu"
                   aria-expanded={intentMenuOpen && !intentMenuClosing}
+                  aria-label={t("composer.intentMenuTitle")}
                   title={intentMenuOpen || intentMenuClosing ? undefined : t("composer.intentMenuTitle")}
                 >
-                  <Plus size={17} />
+                  <SlidersHorizontal size={17} />
                 </button>
               </Tooltip>
               {planModeOn && (

--- a/desktop/frontend/src/lib/goalDraftMode.ts
+++ b/desktop/frontend/src/lib/goalDraftMode.ts
@@ -1,0 +1,51 @@
+import {
+  normalizeCollaborationMode,
+  type CollaborationMode,
+  type Mode,
+} from "./types";
+
+export function keepGoalDraftMode(current: boolean, goal?: string): boolean {
+  return current && !(goal ?? "").trim();
+}
+
+export function displayedCollaborationMode(params: {
+  goalDraftMode: boolean;
+  localMode?: CollaborationMode;
+  metaGoal?: string;
+  tabMode?: string;
+  goal?: string;
+  legacyMode?: Mode;
+}): CollaborationMode {
+  if (params.goalDraftMode) return "goal";
+  return params.localMode ?? normalizeCollaborationMode(params.metaGoal ? "goal" : params.tabMode, params.goal, params.legacyMode);
+}
+
+export function tabListCollaborationMode(params: {
+  goalDraftMode: boolean;
+  localMode?: CollaborationMode;
+  tabMode?: string;
+  tabGoal?: string;
+  legacyMode?: Mode;
+}): CollaborationMode {
+  if (params.goalDraftMode) return "goal";
+  return params.localMode ?? normalizeCollaborationMode(params.tabMode, params.tabGoal, params.legacyMode);
+}
+
+export function metaSyncedCollaborationMode(params: {
+  nextGoal?: string;
+  goalDraftMode: boolean;
+  legacyMode?: Mode;
+}): CollaborationMode {
+  return params.nextGoal || params.goalDraftMode
+    ? "goal"
+    : normalizeCollaborationMode(undefined, "", params.legacyMode);
+}
+
+export function controllerCollaborationMode(params: {
+  collaborationMode: CollaborationMode;
+  goal?: string;
+}): CollaborationMode {
+  return params.collaborationMode === "goal" && !params.goal?.trim()
+    ? "normal"
+    : params.collaborationMode;
+}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -251,7 +251,7 @@ export const en = {
   "composer.modeYolo": "YOLO",
   "composer.modeFullAccess": "full",
   "composer.modeFullAccessTitle": "Full access skips all tool permission approvals; ask questions and plan confirmations still wait",
-  "composer.intentMenuTitle": "More actions",
+  "composer.intentMenuTitle": "Collaboration mode",
   "composer.accessMenuTitle": "Tool access",
   "composer.accessAsk": "Ask first",
   "composer.accessAskTitle": "Ask before approval-gated tool calls",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -252,7 +252,7 @@ export const zh: Record<DictKey, string> = {
   "composer.modeYolo": "Yolo",
   "composer.modeFullAccess": "完全",
   "composer.modeFullAccessTitle": "完全访问会跳过所有工具权限审批；ask 问题和计划确认仍会等待",
-  "composer.intentMenuTitle": "更多动作",
+  "composer.intentMenuTitle": "协作方式",
   "composer.accessMenuTitle": "工具权限",
   "composer.accessAsk": "需要批准",
   "composer.accessAskTitle": "工具调用前请求批准",


### PR DESCRIPTION
## Summary
- Follow-up to #3752 for fixes that landed after the merge into main-v2.
- Replace the Composer collaboration menu entry from a plus icon / generic actions label to a sliders icon / collaboration-mode label.
- Preserve draft goal mode locally while the goal text is empty, while syncing the controller as normal mode until a real goal starts.
- Extract goal draft mode decisions into small helpers and add a regression test for the flicker/disappearing capsule case.

## Verification
- wails generate module
- pnpm --dir desktop/frontend typecheck
- pnpm --dir desktop/frontend test:typecheck
- pnpm --dir desktop/frontend test
- pnpm --dir desktop/frontend check:browser-preview
- pnpm --dir desktop/frontend build

## Cache safety
- Frontend UI state, icon/copy, and tests only; no provider request serialization, tool schema, prompt prefix, or cache-sensitive surface changed.