### PR TITLE
Follow up desktop UI fixes after PR #3752 merge / 补入 #3752 合并后的桌面 UI 修复

### DIFF
--- a/desktop/frontend/scripts/check-browser-preview-stability.mjs
+++ b/desktop/frontend/scripts/check-browser-preview-stability.mjs
@@ -26,6 +26,12 @@ function mustContain(rel, source, needle, reason) {
   }
 }
 
+function mustNotMatch(rel, source, pattern, reason) {
+  if (pattern.test(source)) {
+    fail(`${rel}: matched forbidden pattern ${pattern} (${reason})`);
+  }
+}
+
 const anchoredPopover = read("src/components/AnchoredPopover.tsx");
 mustNotContain(
   "src/components/AnchoredPopover.tsx",
@@ -97,6 +103,14 @@ mustContain(
   "composer-modebar--approval",
   "tool approval must use a direct segmented control",
 );
+for (const mode of ["ask", "auto", "yolo"]) {
+  mustNotMatch(
+    "src/components/Composer.tsx",
+    composer,
+    new RegExp(`composer-modebar__item--${mode}[\\s\\S]{0,320}disabled=\\{disabled \\|\\| running\\}`),
+    "approval mode must remain switchable while a model turn is running",
+  );
+}
 mustNotContain(
   "src/components/Composer.tsx",
   composer,

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -412,6 +412,7 @@ export default function App() {
   const [collaborationModesByTab, setCollaborationModesByTab] = useState<Record<string, CollaborationMode>>({});
   const [toolApprovalModesByTab, setToolApprovalModesByTab] = useState<Record<string, ToolApprovalMode>>({});
   const [goalsByTab, setGoalsByTab] = useState<Record<string, string>>({});
+  const [goalDraftModesByTab, setGoalDraftModesByTab] = useState<Record<string, boolean>>({});
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
@@ -583,8 +584,9 @@ export default function App() {
   const startupSplashHold = state.meta?.ready !== true && !state.meta?.startupErr;
   const legacyMode = activeTabId ? modesByTab[activeTabId] ?? "normal" : "normal";
   const goal = activeTabId ? goalsByTab[activeTabId] ?? state.meta?.goal ?? activeTab?.goal ?? "" : "";
+  const goalDraftMode = activeTabId ? Boolean(goalDraftModesByTab[activeTabId]) : false;
   const collaborationMode = activeTabId
-    ? collaborationModesByTab[activeTabId] ?? normalizeCollaborationMode(state.meta?.goal ? "goal" : activeTab?.collaborationMode, goal, legacyMode)
+    ? goalDraftMode ? "goal" : collaborationModesByTab[activeTabId] ?? normalizeCollaborationMode(state.meta?.goal ? "goal" : activeTab?.collaborationMode, goal, legacyMode)
     : "normal";
   const toolApprovalMode = activeTabId
     ? toolApprovalModesByTab[activeTabId] ?? normalizeToolApprovalMode(state.meta?.toolApprovalMode ?? activeTab?.toolApprovalMode, legacyMode, state.meta?.autoApproveTools ?? state.meta?.bypass)
@@ -602,6 +604,15 @@ export default function App() {
     },
     [activeTabId],
   );
+  const setGoalDraftModeForTab = useCallback((tabId: string, enabled: boolean) => {
+    setGoalDraftModesByTab((current) => {
+      if (Boolean(current[tabId]) === enabled) return current;
+      if (enabled) return { ...current, [tabId]: true };
+      const next = { ...current };
+      delete next[tabId];
+      return next;
+    });
+  }, []);
   const topicbarEditing = Boolean(activeTab?.topicId && activeTab.topicId === renamingTopicId);
   const visibleTabId = activeTabId;
   const visibleTabs = useMemo(() => {
@@ -612,12 +623,12 @@ export default function App() {
       ...tab,
       running: tab.id === visibleTabId ? tab.running || state.running : tab.running,
       mode: modesByTab[tab.id] ?? normalizeMode(tab.mode),
-      collaborationMode: collaborationModesByTab[tab.id] ?? normalizeCollaborationMode(tab.collaborationMode, goalsByTab[tab.id] ?? tab.goal, normalizeMode(tab.mode)),
+      collaborationMode: goalDraftModesByTab[tab.id] ? "goal" : collaborationModesByTab[tab.id] ?? normalizeCollaborationMode(tab.collaborationMode, goalsByTab[tab.id] ?? tab.goal, normalizeMode(tab.mode)),
       toolApprovalMode: toolApprovalModesByTab[tab.id] ?? normalizeToolApprovalMode(tab.toolApprovalMode, normalizeMode(tab.mode), tab.toolApprovalMode === "yolo"),
       goal: goalsByTab[tab.id] ?? tab.goal ?? "",
       active: tab.id === visibleTabId,
     }));
-  }, [collaborationModesByTab, goalsByTab, modesByTab, state.running, tabMetas, tabOrderIds, toolApprovalModesByTab, visibleTabId]);
+  }, [collaborationModesByTab, goalDraftModesByTab, goalsByTab, modesByTab, state.running, tabMetas, tabOrderIds, toolApprovalModesByTab, visibleTabId]);
 
   useEffect(() => {
     const ids = tabMetas.map((tab) => tab.id);
@@ -632,6 +643,21 @@ export default function App() {
 
   useEffect(() => {
     const ids = new Set(tabMetas.map((tab) => tab.id));
+    setGoalDraftModesByTab((current) => {
+      let changed = false;
+      const next: Record<string, boolean> = {};
+      for (const tab of tabMetas) {
+        if (current[tab.id] && !(tab.goal ?? "").trim()) {
+          next[tab.id] = true;
+        } else if (current[tab.id]) {
+          changed = true;
+        }
+      }
+      for (const id of Object.keys(current)) {
+        if (!ids.has(id)) changed = true;
+      }
+      return changed ? next : current;
+    });
     setModesByTab((current) => {
       let changed = false;
       const next: Record<string, Mode> = {};
@@ -649,7 +675,9 @@ export default function App() {
       let changed = false;
       const next: Record<string, CollaborationMode> = {};
       for (const tab of tabMetas) {
-        const value = normalizeCollaborationMode(tab.collaborationMode, tab.goal, normalizeMode(tab.mode));
+        const value = goalDraftModesByTab[tab.id] && !(tab.goal ?? "").trim()
+          ? "goal"
+          : normalizeCollaborationMode(tab.collaborationMode, tab.goal, normalizeMode(tab.mode));
         next[tab.id] = value;
         if (current[tab.id] !== value) changed = true;
       }
@@ -684,7 +712,7 @@ export default function App() {
       }
       return changed ? next : current;
     });
-  }, [tabMetas]);
+  }, [goalDraftModesByTab, tabMetas]);
 
   useEffect(() => {
     if (!renamingTopicId || activeTab?.topicId === renamingTopicId) return;
@@ -697,12 +725,13 @@ export default function App() {
   useEffect(() => {
     if (!activeTabId || !state.meta) return;
     const nextGoal = state.meta.goalStatus === "running" ? state.meta.goal ?? "" : "";
+    if (nextGoal) setGoalDraftModeForTab(activeTabId, false);
     setGoalsByTab((current) => (current[activeTabId] === nextGoal ? current : { ...current, [activeTabId]: nextGoal }));
     setCollaborationModesByTab((current) => {
-      const nextMode = nextGoal ? "goal" : normalizeCollaborationMode(undefined, "", legacyMode);
+      const nextMode = nextGoal || goalDraftMode ? "goal" : normalizeCollaborationMode(undefined, "", legacyMode);
       return current[activeTabId] === nextMode ? current : { ...current, [activeTabId]: nextMode };
     });
-  }, [activeTabId, legacyMode, state.meta]);
+  }, [activeTabId, goalDraftMode, legacyMode, setGoalDraftModeForTab, state.meta]);
 
   const syncModeToController = useCallback((m: Mode) => setControllerMode(m), [setControllerMode]);
 
@@ -719,17 +748,26 @@ export default function App() {
       if (!activeTabId) return;
       const nextCollaborationMode: CollaborationMode = modeHasPlan(m) ? "plan" : "normal";
       const nextToolApprovalMode: ToolApprovalMode = modeHasAutoApproveTools(m) ? "yolo" : "ask";
+      setGoalDraftModeForTab(activeTabId, false);
       setMode(m);
       setCollaborationModesByTab((current) => (current[activeTabId] === nextCollaborationMode ? current : { ...current, [activeTabId]: nextCollaborationMode }));
       setToolApprovalModesByTab((current) => (current[activeTabId] === nextToolApprovalMode ? current : { ...current, [activeTabId]: nextToolApprovalMode }));
       setGoalsByTab((current) => (current[activeTabId] ? { ...current, [activeTabId]: "" } : current));
       void syncModeToController(m);
     },
-    [activeTabId, setMode, syncModeToController],
+    [activeTabId, setGoalDraftModeForTab, setMode, syncModeToController],
   );
   const applyCollaborationMode = useCallback(
     (m: CollaborationMode) => {
       if (!activeTabId) return;
+      if (m === "goal") {
+        setGoalDraftModeForTab(activeTabId, true);
+        setCollaborationModesByTab((current) => (current[activeTabId] === "goal" ? current : { ...current, [activeTabId]: "goal" }));
+        setMode(modeFromAxes(false, toolApprovalMode === "yolo"));
+        void setControllerCollaborationMode("normal");
+        return;
+      }
+      setGoalDraftModeForTab(activeTabId, false);
       setCollaborationModesByTab((current) => (current[activeTabId] === m ? current : { ...current, [activeTabId]: m }));
       if (m === "normal" || m === "plan") {
         setGoalsByTab((current) => (current[activeTabId] ? { ...current, [activeTabId]: "" } : current));
@@ -737,7 +775,7 @@ export default function App() {
       setMode(modeFromAxes(m === "plan", toolApprovalMode === "yolo"));
       void setControllerCollaborationMode(m);
     },
-    [activeTabId, setControllerCollaborationMode, setMode, toolApprovalMode],
+    [activeTabId, setControllerCollaborationMode, setGoalDraftModeForTab, setMode, toolApprovalMode],
   );
   const applyToolApprovalMode = useCallback(
     (m: ToolApprovalMode) => {
@@ -752,6 +790,7 @@ export default function App() {
     (nextGoal: string) => {
       if (!activeTabId) return;
       const trimmed = nextGoal.trim();
+      setGoalDraftModeForTab(activeTabId, false);
       setGoalsByTab((current) => (current[activeTabId] === trimmed ? current : { ...current, [activeTabId]: trimmed }));
       setCollaborationModesByTab((current) => {
         const nextMode = trimmed ? "goal" : "normal";
@@ -760,7 +799,7 @@ export default function App() {
       setMode(modeFromAxes(false, toolApprovalMode === "yolo"));
       void (trimmed ? setControllerGoal(trimmed) : clearControllerGoal());
     },
-    [activeTabId, clearControllerGoal, setControllerGoal, setMode, toolApprovalMode],
+    [activeTabId, clearControllerGoal, setControllerGoal, setGoalDraftModeForTab, setMode, toolApprovalMode],
   );
   const startGoal = useCallback(
     (nextGoal: string) => {
@@ -782,7 +821,8 @@ export default function App() {
   const switchModel = useCallback(
     async (name: string) => {
       await setModel(name);
-      await setControllerCollaborationMode(collaborationMode);
+      const controllerCollaborationMode = collaborationMode === "goal" && !goal.trim() ? "normal" : collaborationMode;
+      await setControllerCollaborationMode(controllerCollaborationMode);
       await setControllerToolApprovalMode(toolApprovalMode);
       if (goal.trim()) await setControllerGoal(goal);
     },
@@ -795,7 +835,8 @@ export default function App() {
   // SetBypass binding was a harmless no-op.
   useEffect(() => {
     if (!controllerReady) return;
-    void setControllerCollaborationMode(collaborationMode);
+    const controllerCollaborationMode = collaborationMode === "goal" && !goal.trim() ? "normal" : collaborationMode;
+    void setControllerCollaborationMode(controllerCollaborationMode);
     void setControllerToolApprovalMode(toolApprovalMode);
     if (goal.trim()) void setControllerGoal(goal);
   }, [collaborationMode, controllerReady, goal, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, toolApprovalMode]);

--- a/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
+++ b/desktop/frontend/src/__tests__/provider-model-refresh.test.ts
@@ -36,6 +36,12 @@ eq(
 );
 
 eq(
+  mergedFetchedProviderModels(["mimo-v2.5-pro"], ["mimo-v2-flash", "mimo-v2-omni", "mimo-v2.5-pro"], { preserveCurated: true }),
+  ["mimo-v2.5-pro"],
+  "manual access refresh preserves selected MiMo model instead of importing provider catalog",
+);
+
+eq(
   mergedFetchedProviderModels([], ["coding-pro", "chat"], { preserveCurated: true }),
   ["coding-pro", "chat"],
   "background refresh can populate an empty model list",

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
-import { ArrowUp, Eye, FileText, Folder, List, MessageSquare, Plus, Search, Shield, ShieldAlert, ShieldCheck, Square, Target, Trash2, X } from "lucide-react";
+import { ArrowUp, Eye, FileText, Folder, List, MessageSquare, Search, Shield, ShieldAlert, ShieldCheck, SlidersHorizontal, Square, Target, Trash2, X } from "lucide-react";
 import { asArray } from "../lib/array";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
 import { app, onFilesDropped } from "../lib/bridge";
@@ -1726,9 +1726,10 @@ export function Composer({
                   disabled={disabled || running}
                   aria-haspopup="menu"
                   aria-expanded={intentMenuOpen && !intentMenuClosing}
+                  aria-label={t("composer.intentMenuTitle")}
                   title={intentMenuOpen || intentMenuClosing ? undefined : t("composer.intentMenuTitle")}
                 >
-                  <Plus size={17} />
+                  <SlidersHorizontal size={17} />
                 </button>
               </Tooltip>
               {planModeOn && (

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1780,7 +1780,7 @@ export function Composer({
                   type="button"
                   className={`composer-modebar__item composer-modebar__item--ask${toolApprovalMode === "ask" ? " composer-modebar__item--active" : ""}`}
                   onClick={() => chooseApprovalMode("ask")}
-                  disabled={disabled || running}
+                  disabled={disabled}
                   aria-pressed={toolApprovalMode === "ask"}
                   title={t("composer.accessAskTitle")}
                 >
@@ -1791,7 +1791,7 @@ export function Composer({
                   type="button"
                   className={`composer-modebar__item composer-modebar__item--auto${toolApprovalMode === "auto" ? " composer-modebar__item--active" : ""}`}
                   onClick={() => chooseApprovalMode("auto")}
-                  disabled={disabled || running}
+                  disabled={disabled}
                   aria-pressed={toolApprovalMode === "auto"}
                   title={t("composer.accessAutoTitle")}
                 >
@@ -1802,7 +1802,7 @@ export function Composer({
                   type="button"
                   className={`composer-modebar__item composer-modebar__item--yolo${toolApprovalMode === "yolo" ? " composer-modebar__item--active" : ""}`}
                   onClick={() => chooseApprovalMode("yolo")}
-                  disabled={disabled || running}
+                  disabled={disabled}
                   aria-pressed={toolApprovalMode === "yolo"}
                   title={t("composer.accessYoloTitle")}
                 >

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1946,7 +1946,7 @@ function ProvidersSection({ s, busy, apply }: SectionProps) {
           });
           return;
         }
-        const models = mergedFetchedProviderModels(p.models, fetched);
+        const models = mergedFetchedProviderModels(p.models, fetched, { preserveCurated: true });
         const currentDefault = providerDefaultModel(p.default, models);
         await app.SaveProvider({ ...p, models, default: currentDefault });
         setGroupFetchResult(group.id, {

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -251,7 +251,7 @@ export const en = {
   "composer.modeYolo": "YOLO",
   "composer.modeFullAccess": "full",
   "composer.modeFullAccessTitle": "Full access skips all tool permission approvals; ask questions and plan confirmations still wait",
-  "composer.intentMenuTitle": "More actions",
+  "composer.intentMenuTitle": "Collaboration mode",
   "composer.accessMenuTitle": "Tool access",
   "composer.accessAsk": "Ask first",
   "composer.accessAskTitle": "Ask before approval-gated tool calls",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -252,7 +252,7 @@ export const zh: Record<DictKey, string> = {
   "composer.modeYolo": "Yolo",
   "composer.modeFullAccess": "完全",
   "composer.modeFullAccessTitle": "完全访问会跳过所有工具权限审批；ask 问题和计划确认仍会等待",
-  "composer.intentMenuTitle": "更多动作",
+  "composer.intentMenuTitle": "协作方式",
   "composer.accessMenuTitle": "工具权限",
   "composer.accessAsk": "需要批准",
   "composer.accessAskTitle": "工具调用前请求批准",


### PR DESCRIPTION
## Summary
- Follow up #3752 with fixes that were pushed to the old PR head after it had already merged.
- Preserve curated provider model lists during refresh.
- Clarify the composer collaboration entry, keep draft goal mode stable, and allow approval mode changes while a turn is running.

## Verification
- `wails generate module`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend test`
- `pnpm --dir desktop/frontend check:browser-preview`