### PR TITLE
refactor(desktop): extract goal-draft collaboration-mode helpers

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -11,9 +11,9 @@
     "check:browser-preview": "node scripts/check-browser-preview-stability.mjs",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts",
+    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts",
     "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
-    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts"
+    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.2",

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -44,7 +44,6 @@ import {
   modeHasAutoApproveTools,
   modeHasPlan,
   modeFromAxes,
-  normalizeCollaborationMode,
   normalizeMode,
   normalizeToolApprovalMode,
   type CollaborationMode,
@@ -56,6 +55,13 @@ import {
   type TabMeta,
   type ToolApprovalMode,
 } from "./lib/types";
+import {
+  controllerCollaborationMode,
+  displayedCollaborationMode,
+  keepGoalDraftMode,
+  metaSyncedCollaborationMode,
+  tabListCollaborationMode,
+} from "./lib/goalDraftMode";
 import { loadLayoutSize, saveLayoutSize } from "./lib/layoutPreferences";
 import {
   applyTheme,
@@ -586,7 +592,14 @@ export default function App() {
   const goal = activeTabId ? goalsByTab[activeTabId] ?? state.meta?.goal ?? activeTab?.goal ?? "" : "";
   const goalDraftMode = activeTabId ? Boolean(goalDraftModesByTab[activeTabId]) : false;
   const collaborationMode = activeTabId
-    ? goalDraftMode ? "goal" : collaborationModesByTab[activeTabId] ?? normalizeCollaborationMode(state.meta?.goal ? "goal" : activeTab?.collaborationMode, goal, legacyMode)
+    ? displayedCollaborationMode({
+        goalDraftMode,
+        localMode: collaborationModesByTab[activeTabId],
+        metaGoal: state.meta?.goal,
+        tabMode: activeTab?.collaborationMode,
+        goal,
+        legacyMode,
+      })
     : "normal";
   const toolApprovalMode = activeTabId
     ? toolApprovalModesByTab[activeTabId] ?? normalizeToolApprovalMode(state.meta?.toolApprovalMode ?? activeTab?.toolApprovalMode, legacyMode, state.meta?.autoApproveTools ?? state.meta?.bypass)
@@ -623,7 +636,13 @@ export default function App() {
       ...tab,
       running: tab.id === visibleTabId ? tab.running || state.running : tab.running,
       mode: modesByTab[tab.id] ?? normalizeMode(tab.mode),
-      collaborationMode: goalDraftModesByTab[tab.id] ? "goal" : collaborationModesByTab[tab.id] ?? normalizeCollaborationMode(tab.collaborationMode, goalsByTab[tab.id] ?? tab.goal, normalizeMode(tab.mode)),
+      collaborationMode: tabListCollaborationMode({
+        goalDraftMode: Boolean(goalDraftModesByTab[tab.id]),
+        localMode: collaborationModesByTab[tab.id],
+        tabMode: tab.collaborationMode,
+        tabGoal: goalsByTab[tab.id] ?? tab.goal,
+        legacyMode: normalizeMode(tab.mode),
+      }),
       toolApprovalMode: toolApprovalModesByTab[tab.id] ?? normalizeToolApprovalMode(tab.toolApprovalMode, normalizeMode(tab.mode), tab.toolApprovalMode === "yolo"),
       goal: goalsByTab[tab.id] ?? tab.goal ?? "",
       active: tab.id === visibleTabId,
@@ -647,7 +666,7 @@ export default function App() {
       let changed = false;
       const next: Record<string, boolean> = {};
       for (const tab of tabMetas) {
-        if (current[tab.id] && !(tab.goal ?? "").trim()) {
+        if (keepGoalDraftMode(Boolean(current[tab.id]), tab.goal)) {
           next[tab.id] = true;
         } else if (current[tab.id]) {
           changed = true;
@@ -675,9 +694,12 @@ export default function App() {
       let changed = false;
       const next: Record<string, CollaborationMode> = {};
       for (const tab of tabMetas) {
-        const value = goalDraftModesByTab[tab.id] && !(tab.goal ?? "").trim()
-          ? "goal"
-          : normalizeCollaborationMode(tab.collaborationMode, tab.goal, normalizeMode(tab.mode));
+        const value = tabListCollaborationMode({
+          goalDraftMode: keepGoalDraftMode(Boolean(goalDraftModesByTab[tab.id]), tab.goal),
+          tabMode: tab.collaborationMode,
+          tabGoal: tab.goal,
+          legacyMode: normalizeMode(tab.mode),
+        });
         next[tab.id] = value;
         if (current[tab.id] !== value) changed = true;
       }
@@ -728,7 +750,7 @@ export default function App() {
     if (nextGoal) setGoalDraftModeForTab(activeTabId, false);
     setGoalsByTab((current) => (current[activeTabId] === nextGoal ? current : { ...current, [activeTabId]: nextGoal }));
     setCollaborationModesByTab((current) => {
-      const nextMode = nextGoal || goalDraftMode ? "goal" : normalizeCollaborationMode(undefined, "", legacyMode);
+      const nextMode = metaSyncedCollaborationMode({ nextGoal, goalDraftMode, legacyMode });
       return current[activeTabId] === nextMode ? current : { ...current, [activeTabId]: nextMode };
     });
   }, [activeTabId, goalDraftMode, legacyMode, setGoalDraftModeForTab, state.meta]);
@@ -821,8 +843,7 @@ export default function App() {
   const switchModel = useCallback(
     async (name: string) => {
       await setModel(name);
-      const controllerCollaborationMode = collaborationMode === "goal" && !goal.trim() ? "normal" : collaborationMode;
-      await setControllerCollaborationMode(controllerCollaborationMode);
+      await setControllerCollaborationMode(controllerCollaborationMode({ collaborationMode, goal }));
       await setControllerToolApprovalMode(toolApprovalMode);
       if (goal.trim()) await setControllerGoal(goal);
     },
@@ -835,8 +856,7 @@ export default function App() {
   // SetBypass binding was a harmless no-op.
   useEffect(() => {
     if (!controllerReady) return;
-    const controllerCollaborationMode = collaborationMode === "goal" && !goal.trim() ? "normal" : collaborationMode;
-    void setControllerCollaborationMode(controllerCollaborationMode);
+    void setControllerCollaborationMode(controllerCollaborationMode({ collaborationMode, goal }));
     void setControllerToolApprovalMode(toolApprovalMode);
     if (goal.trim()) void setControllerGoal(goal);
   }, [collaborationMode, controllerReady, goal, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, toolApprovalMode]);

--- a/desktop/frontend/src/__tests__/goal-draft-mode.test.ts
+++ b/desktop/frontend/src/__tests__/goal-draft-mode.test.ts
@@ -1,0 +1,75 @@
+// Run: tsx src/__tests__/goal-draft-mode.test.ts
+
+import {
+  controllerCollaborationMode,
+  displayedCollaborationMode,
+  keepGoalDraftMode,
+  metaSyncedCollaborationMode,
+  tabListCollaborationMode,
+} from "../lib/goalDraftMode";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\ngoal draft mode");
+
+eq(
+  displayedCollaborationMode({ goalDraftMode: true, localMode: "normal", goal: "" }),
+  "goal",
+  "draft goal mode wins over stale local normal mode",
+);
+
+eq(
+  tabListCollaborationMode({ goalDraftMode: true, tabMode: "normal", tabGoal: "" }),
+  "goal",
+  "tab list keeps draft goal mode visible before a goal is started",
+);
+
+eq(
+  metaSyncedCollaborationMode({ nextGoal: "", goalDraftMode: true, legacyMode: "normal" }),
+  "goal",
+  "empty controller meta does not collapse a draft goal mode",
+);
+
+eq(
+  controllerCollaborationMode({ collaborationMode: "goal", goal: "" }),
+  "normal",
+  "empty draft goal syncs to the controller as normal mode",
+);
+
+eq(
+  controllerCollaborationMode({ collaborationMode: "goal", goal: "ship the fix" }),
+  "goal",
+  "started goal syncs to the controller as goal mode",
+);
+
+eq(
+  keepGoalDraftMode(true, ""),
+  true,
+  "draft flag is retained while goal text is empty",
+);
+
+eq(
+  keepGoalDraftMode(true, "ship the fix"),
+  false,
+  "draft flag clears after a real goal exists",
+);
+
+eq(
+  metaSyncedCollaborationMode({ nextGoal: "", goalDraftMode: false, legacyMode: "plan" }),
+  "plan",
+  "non-draft empty goal falls back to legacy plan mode",
+);
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/goalDraftMode.ts
+++ b/desktop/frontend/src/lib/goalDraftMode.ts
@@ -1,0 +1,51 @@
+import {
+  normalizeCollaborationMode,
+  type CollaborationMode,
+  type Mode,
+} from "./types";
+
+export function keepGoalDraftMode(current: boolean, goal?: string): boolean {
+  return current && !(goal ?? "").trim();
+}
+
+export function displayedCollaborationMode(params: {
+  goalDraftMode: boolean;
+  localMode?: CollaborationMode;
+  metaGoal?: string;
+  tabMode?: string;
+  goal?: string;
+  legacyMode?: Mode;
+}): CollaborationMode {
+  if (params.goalDraftMode) return "goal";
+  return params.localMode ?? normalizeCollaborationMode(params.metaGoal ? "goal" : params.tabMode, params.goal, params.legacyMode);
+}
+
+export function tabListCollaborationMode(params: {
+  goalDraftMode: boolean;
+  localMode?: CollaborationMode;
+  tabMode?: string;
+  tabGoal?: string;
+  legacyMode?: Mode;
+}): CollaborationMode {
+  if (params.goalDraftMode) return "goal";
+  return params.localMode ?? normalizeCollaborationMode(params.tabMode, params.tabGoal, params.legacyMode);
+}
+
+export function metaSyncedCollaborationMode(params: {
+  nextGoal?: string;
+  goalDraftMode: boolean;
+  legacyMode?: Mode;
+}): CollaborationMode {
+  return params.nextGoal || params.goalDraftMode
+    ? "goal"
+    : normalizeCollaborationMode(undefined, "", params.legacyMode);
+}
+
+export function controllerCollaborationMode(params: {
+  collaborationMode: CollaborationMode;
+  goal?: string;
+}): CollaborationMode {
+  return params.collaborationMode === "goal" && !params.goal?.trim()
+    ? "normal"
+    : params.collaborationMode;
+}


### PR DESCRIPTION
The goal-draft collaboration-mode decision was inlined at seven call
sites in `App.tsx` (active tab, tab list, controller sync, model switch).
This pulls the rule into `src/lib/goalDraftMode.ts` as five small pure
functions and adds unit coverage in `goal-draft-mode.test.ts`.

No behavior change — the helpers are equivalent to the inline form
merged in #3795. The point is to keep the decision in one place and make
it testable.

The helper extraction and tests were originally proposed by @SivanCola
in #3794 (co-authored here). The handoff fix itself already landed
inline via #3795, so this PR carries only the refactor + tests.
