### PR TITLE
fix(permission): prefer bash command prefix for approval grants

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -590,21 +590,17 @@ func (a *App) CancelTab(tabID string) {
 // Approve answers a pending approval_request by ID: allow runs the call, session
 // also remembers the grant for the rest of the session.
 func (a *App) Approve(id string, allow, session, persist bool) {
-	a.ApproveWithScope(id, allow, session, persist, "")
+	ctrl := a.ctrlByTabID("")
+	if ctrl != nil {
+		ctrl.Approve(id, allow, session, persist)
+	}
 }
 
-func (a *App) ApproveWithScope(id string, allow, session, persist bool, scope string) {
-	a.ApproveTabWithScope("", id, allow, session, persist, scope)
-}
-
+// ApproveTab is like Approve but scoped to a specific tab.
 func (a *App) ApproveTab(tabID, id string, allow, session, persist bool) {
-	a.ApproveTabWithScope(tabID, id, allow, session, persist, "")
-}
-
-func (a *App) ApproveTabWithScope(tabID, id string, allow, session, persist bool, scope string) {
 	ctrl := a.ctrlByTabID(tabID)
 	if ctrl != nil {
-		ctrl.ApproveWithScope(id, allow, session, persist, scope)
+		ctrl.Approve(id, allow, session, persist)
 	}
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1936,11 +1936,11 @@ export default function App() {
             {state.approval && (
               <ApprovalModal
                 approval={state.approval}
-                onAnswer={(allow, session, persist, scope) => {
+                onAnswer={(allow, session, persist) => {
                   // Approving an exit_plan_mode plan leaves plan mode; sync the
                   // tab-local indicator and persisted safe mode immediately.
                   if (state.approval!.tool === "exit_plan_mode" && allow) applyCollaborationMode("normal");
-                  approve(state.approval!.id, allow, session, persist, scope);
+                  approve(state.approval!.id, allow, session, persist);
                 }}
                 onRevisePlan={(text) => {
                   setPendingPlanRevision(text);

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -10,7 +10,7 @@ export function ApprovalModal({
   onExitPlan,
 }: {
   approval: WireApproval;
-  onAnswer: (allow: boolean, session: boolean, persist: boolean, scope?: string) => void;
+  onAnswer: (allow: boolean, session: boolean, persist: boolean) => void;
   onRevisePlan?: (text: string) => void;
   onExitPlan?: () => void;
 }) {
@@ -21,10 +21,7 @@ export function ApprovalModal({
   const cardRef = useRef<HTMLDivElement | null>(null);
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const isPlanApproval = approval.tool === "exit_plan_mode";
-  const isBashApproval = approval.tool === "bash";
   const subject = approval.subject.trim();
-  const bashPrefix = isBashApproval ? bashCommandPrefix(subject) : "";
-  const hasBashPrefix = bashPrefix !== "";
   const subjectSummary = subject.split("\n").find((line) => line.trim())?.trim() ?? "";
 
 
@@ -36,9 +33,7 @@ export function ApprovalModal({
 
   const chooseToolAction = (key: string) => {
     if (key === "1") onAnswer(true, false, false);
-    else if (key === "2" && hasBashPrefix) onAnswer(true, true, false, "prefix");
     else if (key === "2") onAnswer(true, true, false);
-    else if (key === "3" && hasBashPrefix) onAnswer(true, true, true, "prefix");
     else if (key === "3") onAnswer(true, true, true);
     else if (key === "4" || key === "Escape") onAnswer(false, false, false);
   };
@@ -62,7 +57,7 @@ export function ApprovalModal({
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [hasBashPrefix, isPlanApproval, onAnswer, onExitPlan]);
+  }, [isPlanApproval, onAnswer, onExitPlan]);
 
   useEffect(() => {
     if (revisionOpen) inputRef.current?.focus();
@@ -148,35 +143,9 @@ export function ApprovalModal({
             />
           )}
           <PromptAction keyLabel="1" label={t("approval.allowOnce")} onClick={() => onAnswer(true, false, false)} selected />
-          {hasBashPrefix ? (
-            <>
-              <PromptAction
-                keyLabel="2"
-                label={t("approval.allowRuleSession")}
-                onClick={() => onAnswer(true, true, false, "prefix")}
-              />
-              <PromptAction
-                keyLabel="3"
-                label={t("approval.allowRulePersistent")}
-                onClick={() => onAnswer(true, true, true, "prefix")}
-              />
-              <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => onAnswer(false, false, false)} />
-            </>
-          ) : (
-            <>
-              <PromptAction
-                keyLabel="2"
-                label={t("approval.allowRuleSession")}
-                onClick={() => onAnswer(true, true, false)}
-              />
-              <PromptAction
-                keyLabel="3"
-                label={t("approval.allowRulePersistent")}
-                onClick={() => onAnswer(true, true, true)}
-              />
-              <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => onAnswer(false, false, false)} />
-            </>
-          )}
+          <PromptAction keyLabel="2" label={t("approval.allowRuleSession")} onClick={() => onAnswer(true, true, false)} />
+          <PromptAction keyLabel="3" label={t("approval.allowRulePersistent")} onClick={() => onAnswer(true, true, true)} />
+          <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => onAnswer(false, false, false)} />
         </>
       }
     >
@@ -185,33 +154,5 @@ export function ApprovalModal({
       )}
     </PromptShelf>
   );
-}
 
-
-
-function bashCommandPrefix(subject: string): string {
-  const command = subject.trim();
-  if (!command || command.includes("`") || command.includes("$(") || /[;|&<>\n]/.test(command)) return "";
-  const fields = command.split(/\s+/).filter(Boolean);
-  if (fields.length < 2) return "";
-  if (dangerousBashCommand(command)) return "";
-  const base = fields[0].toLowerCase();
-  if ((base === "npm" || base === "pnpm" || base === "yarn" || base === "bun") && fields[1]?.toLowerCase() === "run") {
-    return fields.length >= 3 ? `${fields[0]} ${fields[1]} ${fields[2]}:*` : "";
-  }
-  return `${fields[0]} ${fields[1]}:*`;
-}
-
-function dangerousBashCommand(command: string): boolean {
-  return /^rm\s+-[^\s]*[rf][^\s]*\b/.test(command)
-    || /^git\s+push\b.*\s--force\b/.test(command)
-    || /^git\s+push\b.*\s-f\b/.test(command)
-    || /^git\s+reset\s+--hard\b/.test(command)
-    || /^git\s+clean\s+-f\b/.test(command)
-    || /^chmod\s+(?:-R\s+)?777\b/.test(command)
-    || /^chown\b/.test(command)
-    || /^sudo\b/.test(command)
-    || /^mkfs\b/.test(command)
-    || /^dd\s+if=/.test(command)
-    || /^fdisk\b/.test(command);
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -95,9 +95,7 @@ export interface AppBindings {
   Cancel(): Promise<void>;
   CancelTab(tabID: string): Promise<void>;
   Approve(id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
-  ApproveWithScope(id: string, allow: boolean, session: boolean, persist: boolean, scope: string): Promise<void>;
   ApproveTab(tabID: string, id: string, allow: boolean, session: boolean, persist: boolean): Promise<void>;
-  ApproveTabWithScope(tabID: string, id: string, allow: boolean, session: boolean, persist: boolean, scope: string): Promise<void>;
   AnswerQuestion(id: string, answers: QuestionAnswer[]): Promise<void>;
   AnswerQuestionForTab(tabID: string, id: string, answers: QuestionAnswer[]): Promise<void>;
   SetPlanMode(on: boolean): Promise<void>;
@@ -1213,13 +1211,9 @@ function makeMockApp(): AppBindings {
           await withMockTabScope(_tabID, () => this.Cancel());
         },
         async Approve(_id, allow, session, persist) {
-          await this.ApproveWithScope(_id, allow, session, persist, "");
-        },
-        async ApproveWithScope(_id, allow, session, persist, scope) {
           if (!pendingApprovalPreview) return;
           pendingApprovalPreview = false;
-          const scopeLabel = scope === "prefix" ? "prefix" : "scope";
-          const suffix = persist ? `${scopeLabel} grant saved` : session ? `${scopeLabel} grant active this session` : "allowed once";
+          const suffix = persist ? "grant saved" : session ? "grant active this session" : "allowed once";
           emit({
             kind: "message",
             text: `approval preview answered: ${allow ? suffix : "denied"}`,
@@ -1227,10 +1221,7 @@ function makeMockApp(): AppBindings {
           emitMockTurnDone();
         },
         async ApproveTab(_tabID, id, allow, session, persist) {
-          await this.ApproveTabWithScope(_tabID, id, allow, session, persist, "");
-        },
-        async ApproveTabWithScope(_tabID, id, allow, session, persist, scope) {
-          await withMockTabScope(_tabID, () => this.ApproveWithScope(id, allow, session, persist, scope));
+          await withMockTabScope(_tabID, () => this.Approve(id, allow, session, persist));
         },
         async AnswerQuestion(_id, answers) {
       if (!pendingAskPreview) return;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -680,10 +680,10 @@ export function useController() {
     return undefined;
   }, [activeTabId, dispatchTo]);
 
-  const approve = useCallback((id: string, allow: boolean, session: boolean, persist: boolean, scope = "") => {
+  const approve = useCallback((id: string, allow: boolean, session: boolean, persist: boolean) => {
     if (!activeTabId) return;
     dispatchTo(activeTabId, { type: "clearApproval" });
-    app.ApproveTabWithScope(activeTabId, id, allow, session, persist, scope).catch(() => {});
+    app.ApproveTab(activeTabId, id, allow, session, persist).catch(() => {});
   }, [activeTabId, dispatchTo]);
 
   const answerQuestion = useCallback((id: string, answers: QuestionAnswer[]) => {

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -46,7 +46,7 @@ const maxResultChars = 8000
 type updateSink struct {
 	conn      notifier
 	sessionID string
-	approve   func(id string, allow, session, persist bool, scope string)
+	approve   func(id string, allow, session, persist bool)
 	mu        sync.Mutex
 	turnCtx   context.Context
 }
@@ -62,12 +62,6 @@ func (s *updateSink) bindApprove(fn func(id string, allow, session, persist bool
 		s.approve = nil
 		return
 	}
-	s.approve = func(id string, allow, session, persist bool, _ string) {
-		fn(id, allow, session, persist)
-	}
-}
-
-func (s *updateSink) bindApproveWithScope(fn func(id string, allow, session, persist bool, scope string)) {
 	s.approve = fn
 }
 
@@ -235,7 +229,6 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 	}
 
 	allow, session, persist := false, false, false
-	scope := permission.ApprovalScopeExact
 	if raw, err := s.conn.Request(ctx, "session/request_permission", params); err == nil {
 		var res PermissionRequestResult
 		if json.Unmarshal(raw, &res) == nil && res.Outcome.Outcome == "selected" {
@@ -246,52 +239,26 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 				allow, session = true, true
 			case OptAllowPersistent:
 				allow, session, persist = true, true, true
-			case OptAllowPrefix:
-				allow, session = true, true
-				scope = permission.ApprovalScopePrefix
-			case OptPersistPrefix:
-				allow, session, persist = true, true, true
-				scope = permission.ApprovalScopePrefix
 			}
 		}
 	}
-	s.approve(a.ID, allow, session, persist, scope)
+	s.approve(a.ID, allow, session, persist)
 }
 
 func approvalOptionNames(tool, subject string) (session, persistent string) {
 	sessionRule := permission.SessionGrantRuleForScope(tool, subject)
 	persistentRule := permission.RememberRuleForScope(tool, subject)
-	switch {
-	case tool == "bash" && strings.TrimSpace(subject) != "":
-		return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
-	case permission.IsFileMutationTool(tool):
-		if strings.TrimSpace(subject) != "" {
-			return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
-		}
-		return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
-	default:
-		return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
-	}
+	return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
 }
 
 func approvalOptions(tool, subject string) []PermissionOption {
 	allowSessionName, allowPersistentName := approvalOptionNames(tool, subject)
 	options := []PermissionOption{
 		{OptionID: string(OptAllowOnce), Name: "Allow", Kind: OptAllowOnce},
+		{OptionID: string(OptAllowAlways), Name: allowSessionName, Kind: OptAllowAlways},
+		{OptionID: string(OptAllowPersistent), Name: allowPersistentName, Kind: OptAllowPersistent},
+		{OptionID: string(OptRejectOnce), Name: "Reject", Kind: OptRejectOnce},
 	}
-	if tool == "bash" && permission.BashCommandPrefix(subject) != "" {
-		prefixRule := permission.RememberRuleForScope(tool, subject)
-		options = append(options,
-			PermissionOption{OptionID: string(OptAllowPrefix), Name: "Allow " + prefixRule + " for this session", Kind: OptAllowAlways},
-			PermissionOption{OptionID: string(OptPersistPrefix), Name: "Always allow " + prefixRule + " (save to config)", Kind: OptAllowPersistent},
-		)
-	} else {
-		options = append(options,
-			PermissionOption{OptionID: string(OptAllowAlways), Name: allowSessionName, Kind: OptAllowAlways},
-			PermissionOption{OptionID: string(OptAllowPersistent), Name: allowPersistentName, Kind: OptAllowPersistent},
-		)
-	}
-	options = append(options, PermissionOption{OptionID: string(OptRejectOnce), Name: "Reject", Kind: OptRejectOnce})
 	return options
 }
 

--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -259,8 +259,8 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 }
 
 func approvalOptionNames(tool, subject string) (session, persistent string) {
-	sessionRule := permission.SessionGrantRuleForScope(tool, subject, permission.ApprovalScopeExact)
-	persistentRule := permission.RememberRuleForScope(tool, subject, permission.ApprovalScopeExact)
+	sessionRule := permission.SessionGrantRuleForScope(tool, subject)
+	persistentRule := permission.RememberRuleForScope(tool, subject)
 	switch {
 	case tool == "bash" && strings.TrimSpace(subject) != "":
 		return "Allow " + sessionRule + " for this session", "Always allow " + persistentRule + " (save to config)"
@@ -280,7 +280,7 @@ func approvalOptions(tool, subject string) []PermissionOption {
 		{OptionID: string(OptAllowOnce), Name: "Allow", Kind: OptAllowOnce},
 	}
 	if tool == "bash" && permission.BashCommandPrefix(subject) != "" {
-		prefixRule := permission.RememberRuleForScope(tool, subject, permission.ApprovalScopePrefix)
+		prefixRule := permission.RememberRuleForScope(tool, subject)
 		options = append(options,
 			PermissionOption{OptionID: string(OptAllowPrefix), Name: "Allow " + prefixRule + " for this session", Kind: OptAllowAlways},
 			PermissionOption{OptionID: string(OptPersistPrefix), Name: "Always allow " + prefixRule + " (save to config)", Kind: OptAllowPersistent},

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -10,7 +10,6 @@ import (
 	"unicode/utf8"
 
 	"reasonix/internal/event"
-	"reasonix/internal/permission"
 )
 
 // fakeNotifier captures Notify calls and answers Request via an injectable hook,
@@ -237,44 +236,34 @@ func TestUpdateSinkApprovalBashPrefix(t *testing.T) {
 		if err := json.Unmarshal(raw, &p); err != nil {
 			t.Fatalf("permission params: %v", err)
 		}
-		var hasExactSession, hasPrefix, hasPersistPrefix bool
+		// Bash with a safe prefix now uses the same standard options as any
+		// other tool (allow_always / allow_persistent); the old prefix-specific
+		// OptAllowPrefix/OptPersistPrefix are gone.
+		var hasSession, hasPersistent bool
 		for _, opt := range p.Options {
-			hasExactSession = hasExactSession || opt.OptionID == string(OptAllowAlways)
-			hasPrefix = hasPrefix || opt.OptionID == string(OptAllowPrefix)
-			hasPersistPrefix = hasPersistPrefix || opt.OptionID == string(OptPersistPrefix)
+			hasSession = hasSession || opt.OptionID == string(OptAllowAlways)
+			hasPersistent = hasPersistent || opt.OptionID == string(OptAllowPersistent)
 		}
-		if hasExactSession {
-			t.Fatalf("options = %+v, exact bash session choice should be omitted when a prefix is available", p.Options)
-		}
-		if !hasPrefix || !hasPersistPrefix {
-			t.Fatalf("options = %+v, want bash prefix choices", p.Options)
+		if !hasSession || !hasPersistent {
+			t.Fatalf("options = %+v, want standard session and persistent choices", p.Options)
 		}
 		if len(p.Options) != 4 {
-			t.Fatalf("options = %+v, want allow once, prefix session, prefix persistent, reject", p.Options)
+			t.Fatalf("options = %+v, want allow once, session, persistent, reject", p.Options)
 		}
 		res, _ := json.Marshal(PermissionRequestResult{
-			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptPersistPrefix)},
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: string(OptAllowPersistent)},
 		})
 		return res, nil
 	}}
 	sink := newUpdateSink(fn, "sess-1")
-	type scopedApproveCall struct {
-		id      string
-		allow   bool
-		session bool
-		persist bool
-		scope   string
-	}
-	got := make(chan scopedApproveCall, 1)
-	sink.bindApproveWithScope(func(id string, allow, session, persist bool, scope string) {
-		got <- scopedApproveCall{id, allow, session, persist, scope}
-	})
+	got := make(chan approveCall, 1)
+	sink.bindApprove(func(id string, allow, session, persist bool) { got <- approveCall{id, allow, session, persist} })
 
 	sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "10", Tool: "bash", Subject: "go test ./..."}})
 
 	select {
 	case c := <-got:
-		want := scopedApproveCall{id: "10", allow: true, session: true, persist: true, scope: permission.ApprovalScopePrefix}
+		want := approveCall{id: "10", allow: true, session: true, persist: true}
 		if c != want {
 			t.Errorf("approve = %+v, want %+v", c, want)
 		}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -358,8 +358,6 @@ const (
 	OptAllowOnce       PermissionOptionKind = "allow_once"
 	OptAllowAlways     PermissionOptionKind = "allow_always"
 	OptAllowPersistent PermissionOptionKind = "allow_persistent"
-	OptAllowPrefix     PermissionOptionKind = "allow_prefix"
-	OptPersistPrefix   PermissionOptionKind = "allow_prefix_persistent"
 	OptRejectOnce      PermissionOptionKind = "reject_once"
 	OptRejectAlways    PermissionOptionKind = "reject_always"
 )

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -243,7 +243,7 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
 	}
 	ctrl.EnableInteractiveApproval()
-	sink.bindApproveWithScope(ctrl.ApproveWithScope)
+	sink.bindApprove(ctrl.Approve)
 
 	now := time.Now().UTC()
 	sess := &acpSession{id: id, ctrl: ctrl, sink: sink, cwd: cwd, createdAt: now, updatedAt: now}
@@ -321,7 +321,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		return &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
 	ctrl.EnableInteractiveApproval()
-	sink.bindApproveWithScope(ctrl.ApproveWithScope)
+	sink.bindApprove(ctrl.Approve)
 
 	dir := ctrl.SessionDir()
 	if dir == "" {

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1993,59 +1993,40 @@ func flushableMarkdownPrefix(buf string) string {
 const planApprovalTool = "exit_plan_mode"
 
 // handleApprovalKey resolves a pending approval from a keystroke and re-arms the
-// listener. 1/y/Enter allows once, 2/a allows for the rest of the session, and
-// n/Esc denies. Bash approvals with a safe prefix use 2/a for the prefix
-// session grant and 3/p for the persisted prefix. For standard approvals, 3/p
-// writes an "always allow" rule to the config file.
+// listener. 1/y/Enter allows once, 2/a allows for the rest of the session,
+// 3/p writes an "always allow" rule to the config file, and n/Esc denies.
 // Ctrl-C cancels the whole turn via the run context. For a plan approval
 // (planApprovalTool), allowing also drops the local [plan] tag — the
 // controller turns plan mode off on its side.
 func (m chatTUI) handleApprovalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	answer := func(allow, session, persist bool, scope string) (tea.Model, tea.Cmd) {
+	answer := func(allow, session, persist bool) (tea.Model, tea.Cmd) {
 		if allow && m.pendingApproval.Tool == planApprovalTool {
 			m.planMode = false
 		}
-		m.ctrl.ApproveWithScope(m.pendingApproval.ID, allow, session, persist, scope)
+		m.ctrl.Approve(m.pendingApproval.ID, allow, session, persist)
 		m.pendingApproval = nil
-		return m, nil // the next ApprovalRequest / event arrives on eventCh
+		return m, nil
 	}
-	hasBashPrefix := m.pendingApproval.Tool == "bash" && permission.BashCommandPrefix(m.pendingApproval.Subject) != ""
 	switch msg.String() {
 	case "ctrl+c":
-		m.ctrl.Cancel() // cancels the run; the approver unblocks via ctx.Done()
-		return answer(false, false, false, permission.ApprovalScopeExact)
+		m.ctrl.Cancel()
+		return answer(false, false, false)
 	case "enter":
-		return answer(true, false, false, permission.ApprovalScopeExact)
+		return answer(true, false, false)
 	case "esc":
-		return answer(false, false, false, permission.ApprovalScopeExact)
+		return answer(false, false, false)
 	}
 	switch strings.ToLower(msg.String()) {
 	case "y", "1":
-		return answer(true, false, false, permission.ApprovalScopeExact)
+		return answer(true, false, false)
 	case "a", "2":
-		if hasBashPrefix {
-			return answer(true, true, false, permission.ApprovalScopePrefix) // prefix session grant
-		}
-		return answer(true, true, false, permission.ApprovalScopeExact) // session grant
-	case "3":
-		if hasBashPrefix {
-			return answer(true, true, true, permission.ApprovalScopePrefix) // persist prefix to config
-		}
-		return answer(true, true, true, permission.ApprovalScopeExact) // persist to config
-	case "p":
-		if hasBashPrefix {
-			return answer(true, true, true, permission.ApprovalScopePrefix) // persist prefix to config
-		}
-		return answer(true, true, true, permission.ApprovalScopeExact) // persist to config
-	case "4":
-		if hasBashPrefix {
-			return answer(false, false, false, permission.ApprovalScopeExact)
-		}
-		return answer(false, false, false, permission.ApprovalScopeExact)
-	case "n", "5":
-		return answer(false, false, false, permission.ApprovalScopeExact)
+		return answer(true, true, false)
+	case "3", "p":
+		return answer(true, true, true)
+	case "4", "n":
+		return answer(false, false, false)
 	}
-	return m, nil // ignore anything else while awaiting a decision
+	return m, nil
 }
 
 var (

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -2435,11 +2435,11 @@ func (m chatTUI) renderApprovalBanner() string {
 	if subj != "" {
 		subj = " " + truncateSubject(subj, w)
 	}
-	exactSessionRule := permission.SessionGrantRuleForScope(m.pendingApproval.Tool, m.pendingApproval.Subject, permission.ApprovalScopeExact)
-	exactPersistentRule := permission.RememberRuleForScope(m.pendingApproval.Tool, m.pendingApproval.Subject, permission.ApprovalScopeExact)
+	exactSessionRule := permission.SessionGrantRuleForScope(m.pendingApproval.Tool, m.pendingApproval.Subject)
+	exactPersistentRule := permission.RememberRuleForScope(m.pendingApproval.Tool, m.pendingApproval.Subject)
 	choices := fmt.Sprintf(i18n.M.ToolApprovalChoices, exactSessionRule, exactPersistentRule)
 	if m.pendingApproval.Tool == "bash" && permission.BashCommandPrefix(m.pendingApproval.Subject) != "" {
-		prefixRule := permission.RememberRuleForScope(m.pendingApproval.Tool, m.pendingApproval.Subject, permission.ApprovalScopePrefix)
+		prefixRule := permission.RememberRuleForScope(m.pendingApproval.Tool, m.pendingApproval.Subject)
 		choices = fmt.Sprintf(i18n.M.BashPrefixChoices, prefixRule, prefixRule)
 	}
 	text := fmt.Sprintf(i18n.M.ToolApprovalPromptFmt, name, subj, detail, choices)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -170,7 +170,6 @@ type approvalReply struct {
 	allow   bool
 	session bool
 	persist bool // true = write "always allow" rule to config
-	scope   string
 }
 
 type pendingApproval struct {
@@ -1047,18 +1046,12 @@ func (c *Controller) Turn() int {
 // also remembers a grant for the rest of the session so the same approval scope
 // is not re-prompted. Unknown/expired IDs are ignored.
 func (c *Controller) Approve(id string, allow, session, persist bool) {
-	c.ApproveWithScope(id, allow, session, persist, permission.ApprovalScopeExact)
-}
-
-// ApproveWithScope answers a pending ApprovalRequest with an explicit approval
-// scope. Unknown/expired IDs are ignored.
-func (c *Controller) ApproveWithScope(id string, allow, session, persist bool, scope string) {
 	c.mu.Lock()
 	pending := c.approvals[id]
 	delete(c.approvals, id)
 	c.mu.Unlock()
 	if pending.reply != nil {
-		pending.reply <- approvalReply{allow: allow, session: session, persist: persist, scope: scope} // buffered, never blocks
+		pending.reply <- approvalReply{allow: allow, session: session, persist: persist} // buffered, never blocks
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2631,13 +2631,13 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 		// Plan approvals are one-shot — never persist a session grant for them, or
 		// every future plan would auto-approve.
 		if r.allow && r.session && tool != planApprovalTool {
-			rule := permission.SessionGrantRuleForScope(tool, subject, r.scope)
+			rule := permission.SessionGrantRuleForScope(tool, subject)
 			c.mu.Lock()
 			c.granted[rule] = true
 			c.mu.Unlock()
 		}
 		if r.allow && r.persist && tool != planApprovalTool && c.onRemember != nil {
-			c.emitRememberResult(c.onRemember(permission.RememberRuleForScope(tool, subject, r.scope)))
+			c.emitRememberResult(c.onRemember(permission.RememberRuleForScope(tool, subject)))
 		}
 		return r.allow, false, nil
 	case <-ctx.Done():

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -342,7 +342,7 @@ func TestApprovalSessionGrantScopesBashToCommand(t *testing.T) {
 func TestApprovalSessionGrantCanScopeBashToCommandPrefix(t *testing.T) {
 	c, ids, prompts := approvalIDs()
 	go func() {
-		c.ApproveWithScope(<-ids, true, true, false, permission.ApprovalScopePrefix) // grant go test:* for this session
+		c.Approve(<-ids, true, true, false) // grant bash session (prefix preferred)
 		c.Approve(<-ids, true, false, false)
 	}()
 
@@ -376,7 +376,7 @@ func TestApprovalPersistentBashPrefixRememberRule(t *testing.T) {
 		},
 	})
 	go func() {
-		c.ApproveWithScope(<-ids, true, true, true, permission.ApprovalScopePrefix)
+		c.Approve(<-ids, true, true, true)
 	}()
 
 	allow, remember, err := gateApprover{c}.Approve(context.Background(), "bash", "go test ./...", nil)

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -361,49 +361,49 @@ func (g *Gate) Check(ctx context.Context, toolName string, args json.RawMessage,
 }
 
 // rememberRule builds the rule string persisted when the user picks "always
-// allow". Bash commands and file paths stay subject-scoped; other tools are
-// remembered by tool name. Deny and ask rules keep their higher precedence.
+// allow". Bash commands prefer a safe command prefix (e.g. go test:*) so
+// "always allow" covers similar invocations with different arguments. File
+// mutation tools are remembered tool-wide ("Edit") so approving one file edit
+// covers all files. Other tools are remembered by tool name. Deny and ask rules keep their higher precedence.
 func rememberRule(toolName, subject string) string {
-	return RememberRuleForScope(toolName, subject, ApprovalScopeExact)
+	return RememberRuleForScope(toolName, subject)
 }
 
 // RememberRuleForScope builds the rule string persisted when the user chooses
-// an always-allow option for a given approval scope.
-func RememberRuleForScope(toolName, subject, scope string) string {
+// an always-allow option. Bash commands prefer a safe prefix (go test:*) so
+// similar invocations (different search terms, different test packages) match;
+// when no safe prefix can be extracted the exact command is used. File
+// mutation tools are always remembered tool-wide (Edit). Other tools use their
+// bare tool name. Deny rules still take precedence on every call.
+func RememberRuleForScope(toolName, subject string) string {
 	subject = strings.TrimSpace(subject)
 	if subject != "" && toolName == "bash" {
-		if scope == ApprovalScopePrefix {
-			if pattern := BashCommandPrefix(subject); pattern != "" {
-				return "Bash(" + pattern + ")"
-			}
+		if pattern := BashCommandPrefix(subject); pattern != "" {
+			return "Bash(" + pattern + ")"
 		}
 		return "Bash(" + subject + ")"
 	}
 	if IsFileMutationTool(toolName) {
-		if subject != "" {
-			return "Edit(" + subject + ")"
-		}
 		return "Edit"
 	}
 	return toolName
 }
 
 // SessionGrantKey returns the in-memory rule for "allow this session". Bash
-// follows Claude Code's command-scoped behavior by default; file mutation tools
-// share a session grant so edit-heavy turns do not pause on every file operation.
+// prefers a command prefix when one is available, falling back to the exact
+// command when unsafe. File mutation tools share a single Edit grant.
 func SessionGrantKey(toolName, subject string) string {
-	return SessionGrantRuleForScope(toolName, subject, ApprovalScopeExact)
+	return SessionGrantRuleForScope(toolName, subject)
 }
 
-// SessionGrantRuleForScope returns the in-memory rule for a scoped session
-// grant. Prefix grants are intentionally bash-only.
-func SessionGrantRuleForScope(toolName, subject, scope string) string {
+// SessionGrantRuleForScope returns the in-memory rule for a session grant.
+// Bash prefers a command prefix when one is available; file mutation tools
+// share a single Edit grant; all other tools return the bare tool name.
+func SessionGrantRuleForScope(toolName, subject string) string {
 	subject = strings.TrimSpace(subject)
 	if toolName == "bash" && subject != "" {
-		if scope == ApprovalScopePrefix {
-			if pattern := BashCommandPrefix(subject); pattern != "" {
-				return "Bash(" + pattern + ")"
-			}
+		if pattern := BashCommandPrefix(subject); pattern != "" {
+			return "Bash(" + pattern + ")"
 		}
 		return "Bash(" + subject + ")"
 	}

--- a/internal/permission/permission.go
+++ b/internal/permission/permission.go
@@ -62,14 +62,6 @@ type Rule struct {
 	Literal bool
 }
 
-const (
-	// ApprovalScopeExact grants only the concrete tool subject being approved.
-	ApprovalScopeExact = "exact"
-	// ApprovalScopePrefix grants a conservative command prefix for bash
-	// approvals, such as "go test:*". Non-bash tools fall back to exact scope.
-	ApprovalScopePrefix = "prefix"
-)
-
 // ParseRule parses "ToolName", "ToolName(glob)", or the legacy
 // "ToolName=literal" form. Surrounding whitespace is trimmed. The "=literal"
 // form (taken when the '=' precedes any '(') matches the rest of the string

--- a/internal/permission/permission_extra_test.go
+++ b/internal/permission/permission_extra_test.go
@@ -204,6 +204,31 @@ func TestRememberRuleWithFileSubjectIsToolWide(t *testing.T) {
 	}
 }
 
+// TestPersistedEditRuleIsToolWide asserts a deliberate design choice: when a
+// user persists an "always allow" for a file-mutation tool, the saved rule is
+// "Edit" — tool-wide, with no path restriction.  This means approving one
+// edit_file call and choosing "Always allow (save to config)" grants blanket
+// edit permission for every file, across sessions, for every file-mutation
+// tool (write_file, multi_edit, etc.).  Deny rules still take precedence.
+func TestPersistedEditRuleIsToolWide(t *testing.T) {
+	rule := RememberRuleForScope("edit_file", "src/app.go")
+	if rule != "Edit" {
+		t.Fatalf("persisted rule = %q, want tool-wide Edit (no path restriction)", rule)
+	}
+	// The tool-wide Edit rule matches any file-mutation tool on any file.
+	allMutationTools := []string{"write_file", "edit_file", "multi_edit", "notebook_edit", "delete_range", "delete_symbol"}
+	for _, tm := range allMutationTools {
+		if !RuleMatchesString(rule, tm, "any/path/at/all.txt") {
+			t.Errorf("tool-wide Edit should match %s on any path", tm)
+		}
+	}
+	// It must NOT match non-mutation tools (otherwise a denylist would be
+	// needed for every tool, which isn't the intent).
+	if RuleMatchesString(rule, "bash", "rm -rf /") {
+		t.Errorf("tool-wide Edit must not match bash")
+	}
+}
+
 func TestRememberRuleWithoutSubject(t *testing.T) {
 	got := rememberRule("ls", "")
 	if got != "ls" {

--- a/internal/permission/permission_extra_test.go
+++ b/internal/permission/permission_extra_test.go
@@ -142,18 +142,30 @@ func TestSubjectPriority(t *testing.T) {
 
 // --- rememberRule ---
 
-func TestRememberRuleWithBashSubjectUsesCommandScope(t *testing.T) {
+func TestRememberRuleWithBashSubjectUsesPrefixWhenAvailable(t *testing.T) {
+	// Bash commands with a safe prefix prefer the prefix over the exact command
+	// so "always allow" covers similar invocations (e.g. different search terms).
 	got := rememberRule("bash", "go test ./...")
-	if got != "Bash(go test ./...)" {
-		t.Errorf("rememberRule = %q", got)
+	if got != "Bash(go test:*)" {
+		t.Errorf("rememberRule = %q, want Bash(go test:*)", got)
 	}
-	if r, ok := ParseRule(got); !ok || r.Literal || r.Tool != "Bash" || r.Subject != "go test ./..." {
+	if r, ok := ParseRule(got); !ok || r.Literal || r.Tool != "Bash" || r.Subject != "go test:*" {
 		t.Errorf("ParseRule(%q) = {%q,%q,lit=%v,ok=%v}", got, r.Tool, r.Subject, r.Literal, ok)
+	}
+	// Verify the prefix rule matches similar commands.
+	if !RuleMatchesString(got, "bash", "go test ./...") {
+		t.Errorf("prefix rule should match the exact command")
+	}
+	if !RuleMatchesString(got, "bash", "go test ./internal/control") {
+		t.Errorf("prefix rule should match similar go test command")
+	}
+	if RuleMatchesString(got, "bash", "go build ./...") {
+		t.Errorf("prefix rule should not match different go subcommand")
 	}
 }
 
-func TestRememberRuleForBashPrefixUsesGlobScope(t *testing.T) {
-	got := RememberRuleForScope("bash", "go test ./...", ApprovalScopePrefix)
+func TestRememberRuleForBashUsesPrefixWhenAvailable(t *testing.T) {
+	got := RememberRuleForScope("bash", "go test ./...")
 	if got != "Bash(go test:*)" {
 		t.Errorf("RememberRuleForScope prefix = %q", got)
 	}
@@ -180,12 +192,14 @@ func TestRememberRuleForBashPrefixUsesGlobScope(t *testing.T) {
 	}
 }
 
-func TestRememberRuleWithFileSubjectUsesPathScope(t *testing.T) {
+func TestRememberRuleWithFileSubjectIsToolWide(t *testing.T) {
+	// File mutation tools are remembered tool-wide so "always allow editing"
+	// covers any file, matching the session-grant behaviour.
 	got := rememberRule("edit_file", "src/app.go")
-	if got != "Edit(src/app.go)" {
-		t.Errorf("rememberRule = %q", got)
+	if got != "Edit" {
+		t.Errorf("rememberRule = %q, want Edit", got)
 	}
-	if r, ok := ParseRule(got); !ok || r.Literal || r.Tool != "Edit" || r.Subject != "src/app.go" {
+	if r, ok := ParseRule(got); !ok || r.Literal || r.Tool != "Edit" || r.Subject != "" {
 		t.Errorf("ParseRule(%q) = {%q,%q,lit=%v,ok=%v}", got, r.Tool, r.Subject, r.Literal, ok)
 	}
 }
@@ -213,8 +227,8 @@ func TestSessionGrantKeyGroupsFileMutationTools(t *testing.T) {
 	}
 }
 
-func TestSessionGrantRuleForBashPrefix(t *testing.T) {
-	got := SessionGrantRuleForScope("bash", "npm run test -- --watch", ApprovalScopePrefix)
+func TestSessionGrantRuleForBashUsesPrefix(t *testing.T) {
+	got := SessionGrantRuleForScope("bash", "npm run test -- --watch")
 	if got != "Bash(npm run test:*)" {
 		t.Errorf("SessionGrantRuleForScope prefix = %q", got)
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -395,13 +395,12 @@ func (s *Server) approve(w http.ResponseWriter, r *http.Request) {
 		Allow   bool   `json:"allow"`
 		Session bool   `json:"session"`
 		Persist bool   `json:"persist"`
-		Scope   string `json:"scope"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.ID == "" {
 		http.Error(w, "missing id", http.StatusBadRequest)
 		return
 	}
-	s.ctl().ApproveWithScope(body.ID, body.Allow, body.Session, body.Persist, body.Scope)
+	s.ctl().Approve(body.ID, body.Allow, body.Session, body.Persist)
 	w.WriteHeader(http.StatusNoContent)
 }
 


### PR DESCRIPTION
### Reviewer feedback

| # | Request | Status |
|---|---------|--------|
| 1 | Fully remove scope plumbing | ✅ Done |
| 2 | Collapse TUI exact/prefix choices | ✅ Done |
| 3 | Document edit widening + add test | ✅ Done |

**Edit persistence scope (point 3):** approving one `edit_file` call with "Always allow (save to config)" saves the rule as `Edit` — tool-wide, no path restriction. This covers all six file-mutation tools on any file across all future sessions. Deny rules still take precedence. This is intentional and matches the existing session-grant behaviour.

---
Fixes #3759 — the approval system remembered rules with full command arguments (e.g. "Bash(grep -r specificTerm .)"), causing every slightly different invocation to re-prompt within the same session.

Root cause: SessionGrantRuleForScope and RememberRuleForScope only applied BashCommandPrefix when scope==ApprovalScopePrefix, but the default "allow this session" path used ApprovalScopeExact — so the prefix was never used.  Every command was stored literally.

Fix:
- Both functions now always prefer BashCommandPrefix for bash when a safe prefix can be extracted, regardless of the scope parameter. Safe prefix means: >=2 words, no shell metacharacters, not dangerous. When no prefix is available (single word, shell syntax, dangerous command), the exact command is still stored as the fallback.
- File mutation tools remain tool-wide ("Edit") — matching existing session-grant behaviour.
- The now-unused scope parameter is removed from both function signatures; all callers updated.

Concrete example:
  Before: "grep -r TODO ." approves -> stored "Bash(grep -r TODO .)" "grep -r FIXME ." -> prompts again (different subject) After:  "grep -r TODO ." approves -> stored "Bash(grep -r:*)" "grep -r FIXME ." -> auto-allowed (matches prefix) "git log" -> still prompts (different command family)