### PR TITLE
Stabilize sidebar and appearance layouts / 稳定侧栏与外观布局

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -80,7 +80,7 @@ import logoWordmark from "./assets/logo-wordmark.svg";
 
 const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
 const SIDEBAR_DEFAULT_WIDTH = 264;
-const SIDEBAR_MIN_WIDTH = 248;
+const SIDEBAR_MIN_WIDTH = 264;
 const SIDEBAR_MAX_WIDTH = 300;
 const SIDEBAR_VIEWPORT_RATIO = 0.18;
 const CHAT_MIN_WIDTH = 400;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1445,7 +1445,7 @@ a[href] {
 }
 
 .layout {
-  --sidebar-width: var(--sidebar-expanded-width, clamp(248px, 18vw, 300px));
+  --sidebar-width: var(--sidebar-expanded-width, clamp(264px, 18vw, 300px));
   --chat-min-width: 760px;
   --chat-docked-min-width: 640px;
   --workspace-width: 420px;
@@ -1520,6 +1520,7 @@ a[href] {
 }
 
 .sidebar {
+  --sidebar-entry-content-inset: 12px;
   grid-row: 2;
   grid-column: 1;
   display: flex;
@@ -1561,18 +1562,21 @@ a[href] {
 }
 .sidebar__new {
   display: flex;
+  flex: 0 0 44px;
   align-items: center;
-  gap: 12px;
-  height: 52px;
-  padding: 0 18px;
-  margin-bottom: 14px;
+  gap: 9px;
+  height: 44px;
+  min-height: 44px;
+  padding: 0 var(--sidebar-entry-content-inset);
+  margin-bottom: 10px;
   background: var(--grad);
   border: 0;
   border-radius: 12px;
   color: var(--accent-text);
-  font-size: 15px;
-  font-weight: 650;
+  font-size: 13px;
+  font-weight: 600;
   box-shadow: 0 6px 18px -6px var(--accent), var(--shadow-1);
+  /* Logo, CTA icon, and search icon share the same content inset; CTA stays visually stronger. */
   transition:
     color var(--dur-fast),
     background var(--dur-fast),
@@ -1662,7 +1666,9 @@ a[href] {
 }
 
 .app--darwin .sidebar--collapsed .sidebar__new {
+  flex-basis: 36px;
   height: 36px;
+  min-height: 36px;
   border-radius: 8px;
 }
 
@@ -1690,7 +1696,9 @@ a[href] {
   gap: 0;
 }
 .sidebar--collapsed .sidebar__new {
+  flex-basis: 40px;
   height: 40px;
+  min-height: 40px;
   border-radius: 10px;
 }
 .sidebar--collapsed .sidebar__new span,
@@ -10089,7 +10097,7 @@ a[href] {
 }
 .theme-card-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 190px), 1fr));
   gap: 10px;
   width: 100%;
 }
@@ -10098,6 +10106,8 @@ a[href] {
   display: flex;
   flex-direction: column;
   gap: 9px;
+  min-width: 0;
+  overflow: hidden;
   border: 1.5px solid var(--border);
   border-radius: 12px;
   background: var(--surface, var(--bg));
@@ -10118,11 +10128,20 @@ a[href] {
 }
 .theme-card__head {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
+  flex-wrap: wrap;
   gap: 8px;
+  min-width: 0;
+}
+.theme-card--on .theme-card__head {
+  padding-right: 24px;
 }
 .theme-card__name {
+  flex: 1 1 120px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 13.5px;
   font-weight: 700;
   white-space: nowrap;
@@ -10134,7 +10153,10 @@ a[href] {
   margin-left: 2px;
 }
 .theme-card__tag {
-  flex: 0 0 auto;
+  flex: 0 1 auto;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-size: 10.5px;
   font-weight: 600;
   color: var(--fg-dim);
@@ -10147,17 +10169,23 @@ a[href] {
 .theme-card__swatches {
   display: flex;
   gap: 6px;
+  min-width: 0;
 }
 .theme-card__swatch {
   flex: 1;
+  min-width: 28px;
   height: 30px;
   border-radius: 7px;
   box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--fg-faint) 30%, transparent);
 }
 .theme-card__desc {
+  display: -webkit-box;
+  overflow: hidden;
   font-size: 11.5px;
   line-height: 1.55;
   color: var(--fg-dim);
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
 }
 .theme-card__check {
   position: absolute;
@@ -10178,9 +10206,9 @@ a[href] {
   opacity: 1;
   transform: scale(1);
 }
-/* The tag chip would otherwise sit under the check badge when selected. */
+/* The check badge owns the selected state; the note chip remains inside the card layout. */
 .theme-card--on .theme-card__tag {
-  visibility: hidden;
+  margin-right: 24px;
 }
 
 /* Per-direction preview swatches (dark variant is the default). */
@@ -12623,14 +12651,16 @@ a[href] {
 
 .project-tree__search {
   display: flex;
+  flex: 0 0 40px;
   align-items: center;
-  gap: 8px;
-  height: 34px;
+  gap: 9px;
+  height: 40px;
+  min-height: 40px;
   margin: 0 var(--project-tree-edge-gap);
-  padding: 0 10px;
+  padding: 0 12px;
   border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--bg-elev);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-elev) 72%, var(--bg-soft));
   color: var(--fg-faint);
 }
 
@@ -14390,26 +14420,30 @@ a[href] {
 
 .sidebar__brand {
   display: flex;
+  flex: 0 0 36px;
   align-items: center;
-  min-height: 38px;
-  padding: 3px 8px 11px;
+  min-height: 36px;
+  padding: 2px var(--sidebar-entry-content-inset);
+  margin-bottom: 10px;
   color: var(--fg);
 }
 
 .sidebar__brand-logo {
   flex: 0 0 auto;
   display: block;
-  width: 126px;
-  height: 29px;
+  width: 136px;
+  height: 32px;
   object-fit: contain;
   object-position: left center;
 }
 
 .sidebar__new {
   display: flex;
-  height: 52px;
-  margin-bottom: 14px;
-  padding: 0 18px;
+  flex: 0 0 44px;
+  height: 44px;
+  min-height: 44px;
+  margin-bottom: 10px;
+  padding: 0 var(--sidebar-entry-content-inset);
   border-radius: 12px;
   color: var(--accent-text);
   background: var(--grad);
@@ -14453,10 +14487,13 @@ a[href] {
 }
 
 .project-tree__search {
-  height: 32px;
+  flex-basis: 40px;
+  height: 40px;
+  min-height: 40px;
   margin: 0;
-  border-radius: 8px;
-  background: transparent;
+  padding: 0 var(--sidebar-entry-content-inset);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-elev) 72%, var(--bg-soft));
 }
 
 .project-tree__header {
@@ -15302,14 +15339,15 @@ a[href] {
 }
 
 :root[data-theme-style="graphite"] .sidebar__brand {
-  min-height: 38px;
-  padding: 3px 6px 9px;
+  flex: 0 0 36px;
+  min-height: 36px;
+  padding: 2px var(--sidebar-entry-content-inset);
   margin-bottom: 10px;
 }
 
 :root[data-theme-style="graphite"] .sidebar__brand-logo {
-  width: 128px;
-  height: 30px;
+  width: 136px;
+  height: 32px;
 }
 
 :root[data-theme-style="graphite"] .topicbar__subtitle {
@@ -15320,9 +15358,11 @@ a[href] {
 
 :root[data-theme-style="graphite"] .sidebar__new {
   display: flex;
-  height: 52px;
-  margin-bottom: 14px;
-  padding: 0 18px;
+  flex: 0 0 44px;
+  height: 44px;
+  min-height: 44px;
+  margin-bottom: 10px;
+  padding: 0 var(--sidebar-entry-content-inset);
   border: 0;
   border-radius: 12px;
   color: var(--accent-text);
@@ -15353,13 +15393,15 @@ a[href] {
 }
 
 :root[data-theme-style="graphite"] .project-tree__search {
-  height: 39px;
+  flex-basis: 40px;
+  height: 40px;
+  min-height: 40px;
   margin: 0;
-  padding: 9px 12px;
+  padding: 0 var(--sidebar-entry-content-inset);
   gap: 9px;
   border: 1px solid transparent;
-  border-radius: 8px;
-  background: var(--bg-soft);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--bg-soft) 82%, var(--bg-elev));
   color: var(--fg-faint);
   font-size: 13px;
   line-height: 1.45;


### PR DESCRIPTION
## Summary
- Restore the expanded sidebar minimum width to the redesign baseline.
- Keep the logo, new-session CTA, and search control on a compact shared content inset so they cannot drift or flex-shrink.
- Make the Appearance visual-style cards responsive with a readable minimum width, wrapped in-card tags, capped descriptions, and automatic column reduction under narrow widths.

## Verification
- pnpm --dir desktop/frontend build
- Browser DOM check: sidebar logo/CTA/search share the same content line.
- Browser DOM check: compressed Appearance visual-style cards drop to one column with no horizontal overflow.