### PR TITLE
fix(cli): persist /verbose toggle across CLI sessions (#3312)

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -2863,8 +2864,41 @@ func (m *chatTUI) cycleMode() {
 	}
 }
 
+// applyConfig seeds the TUI from a loaded config. Extracted from chatREPL so
+// the "load cfg → propagate to chatTUI" path is unit-testable without going
+// through the full bubbletea bootstrap. New chatTUI has already picked a
+// default for showReasoning (Termux native scrollback) — we use OR semantics
+// so the persisted preference never silently disables a Termux user's
+// always-on reasoning (issue #3312).
+func (m *chatTUI) applyConfig(cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	m.outputStyle = cfg.Agent.OutputStyle
+	m.statuslineCmd = cfg.Statusline.Command
+	m.cfg = cfg
+	if cfg.UI.ShowThinking {
+		m.showReasoning = true
+	}
+}
+
 func (m *chatTUI) toggleVerboseReasoning(notify bool) {
 	m.showReasoning = !m.showReasoning
+	// Persist the new preference so a future CLI session opens with the same
+	// state (issue #3312). The save runs off the bubbletea event loop to avoid
+	// stalling the UI on slow disks. We capture `show` into a local before
+	// spawning the goroutine: passing it as a function argument establishes
+	// the happens-before edge the Go memory model requires, so the save
+	// goroutine reads a stable value rather than racing the Update goroutine
+	//'s write to m.showReasoning. A missed or racing write to disk is harmless
+	// — the atomic temp+rename in SaveTo() means we either persist the new
+	// value or the previous one, never a torn file.
+	show := m.showReasoning
+	go func() {
+		if err := m.persistShowThinking(show); err != nil {
+			slog.Warn("persist show_thinking", "err", err)
+		}
+	}()
 	if !notify {
 		return
 	}
@@ -2873,6 +2907,25 @@ func (m *chatTUI) toggleVerboseReasoning(notify bool) {
 	} else {
 		m.notice("verbose off — thinking text will stay collapsed")
 	}
+}
+
+// persistShowThinking writes the supplied show-thinking preference back to
+// the user-level config. The toggle always targets the user config (not the
+// project config) because show_thinking is a personal viewing preference —
+// writing it to a project-local reasonix.toml that may be git-committed would
+// leak the user's setting to every collaborator on the repo. The user config
+// is created on first use by writeConfigFile's MkdirAll.
+//
+// `show` is passed in rather than read off m.showReasoning so the save
+// goroutine doesn't race the Update goroutine's write. Tests may call this
+// synchronously to verify the round-trip without dealing with goroutine
+// timing.
+func (m *chatTUI) persistShowThinking(show bool) error {
+	if m.cfg == nil {
+		return nil
+	}
+	m.cfg.UI.ShowThinking = show
+	return m.cfg.SaveTo(config.UserConfigPath())
 }
 
 // startTurn commits the user bubble to scrollback, resets the turn accumulator,

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -627,6 +627,105 @@ func TestEffortCommandWritesCurrentDeepSeekProvider(t *testing.T) {
 	}
 }
 
+// TestToggleVerboseReasoningPersistsShowThinking covers issue #3312 — the
+// /verbose (and Ctrl+O) toggle must round-trip through the on-disk config so
+// the next session opens with the same state. We exercise persistShowThinking
+// directly because the production toggle wraps it in a goroutine for non-
+// blocking I/O; the helper itself is the unit under test. The `show` arg is
+// passed explicitly (rather than read from m.showReasoning) to mirror how
+// toggleVerboseReasoning captures the value into a local before spawning the
+// save goroutine.
+func TestToggleVerboseReasoningPersistsShowThinking(t *testing.T) {
+	isolateUserConfig(t)
+
+	m := newTestChatTUI()
+	m.cfg = config.Default()
+	if m.cfg.UI.ShowThinking {
+		t.Fatal("precondition: default UI.ShowThinking must be false")
+	}
+
+	// First flip: on. Save and re-read the user config to confirm.
+	m.showReasoning = true
+	if err := m.persistShowThinking(m.showReasoning); err != nil {
+		t.Fatalf("persist show_thinking = on: %v", err)
+	}
+	loaded := config.LoadForEdit(config.UserConfigPath())
+	if !loaded.UI.ShowThinking {
+		t.Errorf("user config UI.ShowThinking = false, want true after toggle on")
+	}
+
+	// Second flip: off. Save and re-read — the new key must round-trip back.
+	m.showReasoning = false
+	if err := m.persistShowThinking(m.showReasoning); err != nil {
+		t.Fatalf("persist show_thinking = off: %v", err)
+	}
+	loaded = config.LoadForEdit(config.UserConfigPath())
+	if loaded.UI.ShowThinking {
+		t.Errorf("user config UI.ShowThinking = true, want false after toggle off")
+	}
+}
+
+// TestPersistShowThinkingNoConfigIsNoop proves the helper tolerates a nil cfg,
+// which is what happens in unit tests that build a chatTUI without going
+// through the full cli.go bootstrap. The production toggle relies on this
+// early-return to avoid nil-deref panics.
+func TestPersistShowThinkingNoConfigIsNoop(t *testing.T) {
+	m := newTestChatTUI()
+	if m.cfg != nil {
+		t.Fatal("newTestChatTUI must not seed cfg")
+	}
+	if err := m.persistShowThinking(true); err != nil {
+		t.Fatalf("persistShowThinking with nil cfg should be a no-op, got %v", err)
+	}
+}
+
+// TestApplyConfigRespectsShowThinking covers the boot-time half of issue
+// #3312: a user with show_thinking = true in their user config must open
+// the next session with the reasoning block already expanded. Without this
+// test, dropping the four `applyConfig` lines would leave the toggle
+// round-trip half-broken and all existing tests would still pass.
+func TestApplyConfigRespectsShowThinking(t *testing.T) {
+	m := newTestChatTUI()
+	if m.showReasoning {
+		t.Fatal("precondition: fresh chatTUI should start with showReasoning = false")
+	}
+
+	cfg := config.Default()
+	cfg.UI.ShowThinking = true
+	m.applyConfig(cfg)
+	if !m.showReasoning {
+		t.Errorf("applyConfig with cfg.UI.ShowThinking=true should turn showReasoning on")
+	}
+	if m.cfg != cfg {
+		t.Errorf("applyConfig should stash the cfg pointer for later persistence")
+	}
+}
+
+// TestApplyConfigKeepsTermuxVerboseOn is the OR-semantics check: if newChatTUI
+// already turned showReasoning on for Termux (because the live viewport
+// can't render reasoning in native scrollback), applyConfig must not stomp
+// it off when the user has no persisted preference.
+func TestApplyConfigKeepsTermuxVerboseOn(t *testing.T) {
+	m := newTestChatTUI()
+	m.showReasoning = true // simulate the newChatTUI default for Termux
+
+	m.applyConfig(config.Default()) // default cfg has ShowThinking = false
+	if !m.showReasoning {
+		t.Errorf("applyConfig with default cfg must not disable a Termux-forced showReasoning")
+	}
+}
+
+// TestApplyConfigNilIsNoop covers a defensive edge — chatREPL guards the
+// config.Load() error with an if-err-nil block, but applyConfig itself
+// should not panic if a future caller forgets.
+func TestApplyConfigNilIsNoop(t *testing.T) {
+	m := newTestChatTUI()
+	m.applyConfig(nil) // must not panic
+	if m.cfg != nil {
+		t.Errorf("applyConfig(nil) must not seed cfg")
+	}
+}
+
 func TestEffortCommandRejectsUnsupportedProvider(t *testing.T) {
 	isolateUserConfig(t)
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -469,9 +469,7 @@ func chatREPL(args []string) int {
 
 	m := newChatTUI(ctrl, missing, eventCh, termW)
 	if cfg, err := config.Load(); err == nil {
-		m.outputStyle = cfg.Agent.OutputStyle    // shown as the active entry in /output-style
-		m.statuslineCmd = cfg.Statusline.Command // custom status-line command, "" = built-in row
-		m.cfg = cfg
+		m.applyConfig(cfg)
 	}
 
 	// /model support: a pure builder the TUI calls to rebuild on a different

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,7 @@ type UIConfig struct {
 	Theme         string `toml:"theme"`          // auto|dark|light; empty resolves to auto
 	ThemeStyle    string `toml:"theme_style"`    // graphite|ember|aurora|midnight|sandstone|porcelain|linen|glacier
 	CloseBehavior string `toml:"close_behavior"` // legacy desktop close behavior; prefer desktop.close_behavior
+	ShowThinking  bool   `toml:"show_thinking"`  // CLI: expand model thinking/reasoning text in the transcript (Ctrl+O / /verbose). Default false.
 }
 
 // DesktopConfig controls desktop-only UI preferences. It is intentionally

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -63,6 +63,14 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		if strings.TrimSpace(c.UI.CloseBehavior) != "" && scope == RenderScopeProject {
 			fmt.Fprintf(&b, "close_behavior = %q   # legacy desktop close behavior; prefer [desktop].close_behavior in user config\n", c.DesktopCloseBehavior())
 		}
+		// show_thinking is only persisted when set so an unmodified config stays
+		// byte-identical; the default (false = reasoning collapsed) is the
+		// long-standing behaviour and a fresh file should not introduce a key.
+		if c.UI.ShowThinking {
+			b.WriteString("show_thinking = true   # CLI: expand model thinking/reasoning text by default; toggled at runtime with /verbose or Ctrl+O\n")
+		} else if scope == RenderScopeFull {
+			b.WriteString("# show_thinking = false   # CLI: expand model thinking/reasoning text by default; toggled at runtime with /verbose or Ctrl+O\n")
+		}
 		b.WriteString("\n")
 	}
 

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -94,6 +94,23 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	if got.UI.ThemeStyle != "glacier" {
 		t.Errorf("ui.theme_style = %q, want glacier", got.UI.ThemeStyle)
 	}
+	// show_thinking defaults to false and must survive a round-trip. Setting
+	// it true below flips the rendered key from a comment to an active entry.
+	if got.UI.ShowThinking {
+		t.Errorf("ui.show_thinking = true, want default false (backward-compatible)")
+	}
+	orig.UI.ShowThinking = true
+	rendered2 := RenderTOML(orig)
+	if !strings.Contains(rendered2, "show_thinking = true") {
+		t.Errorf("rendered TOML missing show_thinking = true:\n%s", rendered2)
+	}
+	var got2 Config
+	if _, err := toml.Decode(rendered2, &got2); err != nil {
+		t.Fatalf("rendered TOML with show_thinking does not parse: %v", err)
+	}
+	if !got2.UI.ShowThinking {
+		t.Errorf("ui.show_thinking = false after round-trip, want true")
+	}
 	if got.Desktop.Language != "en" {
 		t.Errorf("desktop.language = %q, want en", got.Desktop.Language)
 	}
@@ -367,6 +384,33 @@ func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	}
 	if !strings.Contains(project, "# system_prompt =") {
 		t.Fatalf("project render should leave a system prompt hint:\n%s", project)
+	}
+}
+
+// TestProjectRenderShowThinkingScoped covers the show_thinking render branch:
+// a default (false) config must NOT emit the key in project-scope writes
+// (avoiding noise), but a non-default (true) config must emit it so the
+// preference survives a future Load(). RenderTOMLForScope is called from
+// SaveToScope when rewriting either layer of config, so both branches need
+// explicit coverage.
+func TestProjectRenderShowThinkingScoped(t *testing.T) {
+	c := Default()
+	project := RenderTOMLForScope(c, RenderScopeProject)
+	if strings.Contains(project, "show_thinking") {
+		t.Errorf("project render with default show_thinking=false should not emit the key, got:\n%s", project)
+	}
+
+	c.UI.ShowThinking = true
+	project = RenderTOMLForScope(c, RenderScopeProject)
+	if !strings.Contains(project, "show_thinking = true") {
+		t.Errorf("project render with show_thinking=true should emit the key, got:\n%s", project)
+	}
+	var got Config
+	if _, err := toml.Decode(project, &got); err != nil {
+		t.Fatalf("project-scope TOML with show_thinking does not parse: %v", err)
+	}
+	if !got.UI.ShowThinking {
+		t.Errorf("project-scope round-trip lost show_thinking = true")
 	}
 }
 


### PR DESCRIPTION
## Summary

The `/verbose` (and Ctrl+O) toggle previously reset to off on every CLI
launch because the in-memory `showReasoning` bool was never written
back to the config. This adds an optional `ui.show_thinking` field
(default `false`, fully backward-compatible) and persists every flip
off the bubbletea event loop so the next session opens with the
reasoning block in the same state.

Fixes #3312.

## Changes

- **`internal/config/config.go`** — new `UIConfig.ShowThinking bool` with `toml:"show_thinking"`, defaults to `false`.
- **`internal/config/render.go`** — `RenderTOMLForScope` emits `show_thinking = true` only when set, with a commented-out placeholder only in `RenderScopeFull` so unmodified project configs stay byte-identical.
- **`internal/cli/cli.go`** — `chatREPL` now calls a new `m.applyConfig(cfg)` helper.
- **`internal/cli/chat_tui.go`** —
  - new `applyConfig(cfg)` method: seeds the TUI from a loaded config, using OR semantics so a persisted `ShowThinking=true` does not stomp the Termux native-scrollback default.
  - `toggleVerboseReasoning` spawns a goroutine that calls `persistShowThinking(show)`, capturing `show` into a local first so the save goroutine reads a stable value (no race with the Update goroutine's write to `m.showReasoning`).
  - new `persistShowThinking(show bool) error` method: writes the preference to the user-level config via `SaveTo(config.UserConfigPath())`.

## Design notes

**Why user config, not project config.** `show_thinking` is a personal
viewing preference; writing it to a project-local `reasonix.toml` that
may be git-committed would leak the user's setting to every
collaborator on the repo. The same rationale as `NotificationsConfig`
et al. — viewing preferences belong in `~/.config/reasonix/config.toml`.
Note: a project `reasonix.toml` with `show_thinking = false` will
silently win on the next load (project > user priority in `Load`),
which matches the long-standing merge semantics.

**Why async save.** The bubbletea `Update()` goroutine must not block
on disk I/O. `SaveTo`'s atomic temp+rename makes racing writes safe on
disk (last-writer-wins, never a torn file); a coalescer/debouncer is
left as a possible follow-up.

**Scope of the fix.** Per the issue, the `--show-thinking` flag in
non-interactive `run` mode and the desktop app's reasoning toggle
(`internal/serve/`, `desktop/`) are out of scope and explicitly
unaffected. The web/desktop frontends have their own
`TextSink.showReasoning` field.

## Tests

```
go test ./internal/config/  → ok
go test ./internal/cli/     → ok
```

New tests (all passing):

| Test | Covers |
|---|---|
| `TestToggleVerboseReasoningPersistsShowThinking` | full on→off round-trip via real disk using `isolateUserConfig` + `LoadForEdit` |
| `TestPersistShowThinkingNoConfigIsNoop` | nil cfg early-return (production toggle relies on this) |
| `TestApplyConfigRespectsShowThinking` | **boot-time load path** (the half of the bug that the round-trip test alone wouldn't catch) |
| `TestApplyConfigKeepsTermuxVerboseOn` | OR semantics — Termux default-on is not stomped by an absent preference |
| `TestApplyConfigNilIsNoop` | defensive nil guard on `applyConfig` |
| `TestProjectRenderShowThinkingScoped` | `RenderScopeProject` emits the key only when set |

The `applyConfig` extraction is the testability-driven refactor that
closes the gap identified in review: previously, deleting the four
`applyConfig` lines would still pass every existing test. The new
`TestApplyConfigRespectsShowThinking` covers that regression.

## Manual verification

1. Build: `go build ./cmd/reasonix`
2. Launch: `./reasonix chat` (or `reasonix.exe` on Windows)
3. Type `/verbose` → notice "verbose on — thinking text will be shown"
4. `/quit`
5. Reopen: reasoning block is expanded by default
6. Inspect `~/.config/reasonix/config.toml` (or `%AppData%\reasonix\config.toml` on Windows):
   ```toml
   [ui]
   show_thinking = true
   ```
7. Type `/verbose` again → notice "verbose off"
8. Reopen → reasoning block is collapsed, and the config now shows the field with the default value (commented placeholder in the full-render path).

## Out of scope

- Debouncing rapid toggles (current behavior: 10 toggles = 10 atomic writes, all safe via temp+rename).
- Surfacing a user-visible notice when `Save` fails (currently `slog.Warn`; the in-TUI notice fires regardless of save success — matches the project's existing preference-persistence pattern, e.g. `/effort`).
- The web/desktop frontends' reasoning toggles.