### PR TITLE
fix(tui): 修复mintty刷新残留问题

### DIFF
--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -145,6 +145,34 @@ func TestTermuxNativeScrollbackDefaultsToExpandedReasoning(t *testing.T) {
 	}
 }
 
+// TestCompletionMenuFixedWidth verifies that the completion menu pads every
+// line (items + footer) to m.width so delta rendering always writes exactly the
+// same column count — no trailing characters for \033[K to leave behind.
+func TestCompletionMenuFixedWidth(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m.width = 80
+	m.completion.active = true
+	m.completion.items = []compItem{
+		{label: "review"},
+		{label: "clear", hint: "start fresh"},
+	}
+	m.completion.sel = 1
+	m.completion.kind = compSlash
+
+	out := m.renderCompletion()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	// items + footer = 3 lines
+	if len(lines) != 3 {
+		t.Fatalf("completion menu should have 3 lines (2 items + footer), got %d:\n%s", len(lines), out)
+	}
+	for i, line := range lines {
+		if got := ansi.StringWidth(line); got != 80 {
+			t.Errorf("line %d visual width = %d, want 80: %q", i, got, line)
+		}
+	}
+}
+
 // TestTranscriptViewportSizing proves the viewport tracks the terminal size and
 // gets the rows left over after the pinned bottom region (input box + 2 status
 // rows = 5 with an empty 1-line composer), and is fed the committed transcript.

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -173,6 +173,36 @@ func TestCompletionMenuFixedWidth(t *testing.T) {
 	}
 }
 
+// TestCompletionMenuPadsWithNonBreakingSpaces verifies the fixed-width padding
+// is not ordinary ASCII space. Ultraviolet treats trailing ASCII spaces as
+// clearable cells and may emit EL/ECH erase sequences; mintty can leave stale
+// halves of CJK glyphs when those sequences clear Chinese skill descriptions.
+func TestCompletionMenuPadsWithNonBreakingSpaces(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m.width = 80
+	m.completion.active = true
+	m.completion.items = []compItem{
+		{label: "/土壤", hint: "分析土壤墒情"},
+		{label: "/巡田", hint: "识别病虫害"},
+	}
+	m.completion.sel = 0
+	m.completion.kind = compSlash
+
+	out := m.renderCompletion()
+	for i, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if got := ansi.StringWidth(line); got != 80 {
+			t.Fatalf("line %d visual width = %d, want 80: %q", i, got, line)
+		}
+		if !strings.HasSuffix(line, "\u00a0") {
+			t.Fatalf("line %d should end with non-breaking padding, got %q", i, line)
+		}
+		if strings.HasSuffix(line, " ") {
+			t.Fatalf("line %d should not end with clearable ASCII space, got %q", i, line)
+		}
+	}
+}
+
 // TestTranscriptViewportSizing proves the viewport tracks the terminal size and
 // gets the rows left over after the pinned bottom region (input box + 2 status
 // rows = 5 with an empty 1-line composer), and is fed the committed transcript.

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -522,11 +522,26 @@ func (m *chatTUI) acceptCompletion() {
 
 var compSelStyle lipgloss.Style
 
+const completionPadCell = "\u00a0"
+
+// padCompletionLine pads completion rows with NBSPs instead of ASCII spaces.
+// Ultraviolet treats trailing ASCII spaces as clearable cells and may emit EL
+// or ECH erase sequences; mintty can leave stale CJK glyph cells after those
+// erases. NBSP is visually blank but forces the renderer to overwrite cells.
+func padCompletionLine(s string, w int) string {
+	pad := w - visibleWidth(s)
+	if pad <= 0 {
+		return s
+	}
+	return s + strings.Repeat(completionPadCell, pad)
+}
+
 // renderCompletion draws the menu above the input box: matching items, windowed
 // around the selection, the current row highlighted, hints dimmed. Every line is
-// padded to m.width so bubbletea's delta renderer always writes exactly the same
-// column count — no trailing characters for \033[K to clear, and no ghost cells
-// on terminals (mintty) with unreliable erase-to-end-of-line.
+// padded to m.width with non-clearable blank cells so bubbletea's delta renderer
+// has no ordinary trailing-space run to collapse into EL/ECH erase sequences.
+// That avoids ghost cells on terminals (mintty) with unreliable erases after
+// wide CJK glyphs.
 func (m chatTUI) renderCompletion() string {
 	if !m.completion.active || len(m.completion.items) == 0 {
 		return ""
@@ -559,7 +574,7 @@ func (m chatTUI) renderCompletion() string {
 		if it.hint != "" {
 			line += "  " + dim(it.hint)
 		}
-		b.WriteString(padRight(line, m.width))
+		b.WriteString(padCompletionLine(line, m.width))
 		b.WriteByte('\n')
 	}
 	// A key-hint footer so users discover Tab — many won't know it accepts a
@@ -568,6 +583,6 @@ func (m chatTUI) renderCompletion() string {
 	if m.completion.kind == compAt {
 		hint = i18n.M.CompHintFile
 	}
-	b.WriteString(padRight(dim(hint), m.width))
+	b.WriteString(padCompletionLine(dim(hint), m.width))
 	return b.String()
 }

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -523,7 +523,10 @@ func (m *chatTUI) acceptCompletion() {
 var compSelStyle lipgloss.Style
 
 // renderCompletion draws the menu above the input box: matching items, windowed
-// around the selection, the current row highlighted, hints dimmed.
+// around the selection, the current row highlighted, hints dimmed. Every line is
+// padded to m.width so bubbletea's delta renderer always writes exactly the same
+// column count — no trailing characters for \033[K to clear, and no ghost cells
+// on terminals (mintty) with unreliable erase-to-end-of-line.
 func (m chatTUI) renderCompletion() string {
 	if !m.completion.active || len(m.completion.items) == 0 {
 		return ""
@@ -547,14 +550,16 @@ func (m chatTUI) renderCompletion() string {
 	var b strings.Builder
 	for i := start; i < end; i++ {
 		it := items[i]
+		var line string
 		if i == m.completion.sel {
-			b.WriteString(accent("› ") + compSelStyle.Render(it.label))
+			line = accent("› ") + compSelStyle.Render(it.label)
 		} else {
-			b.WriteString("  " + it.label)
+			line = "  " + it.label
 		}
 		if it.hint != "" {
-			b.WriteString("  " + dim(it.hint))
+			line += "  " + dim(it.hint)
 		}
+		b.WriteString(padRight(line, m.width))
 		b.WriteByte('\n')
 	}
 	// A key-hint footer so users discover Tab — many won't know it accepts a
@@ -563,6 +568,6 @@ func (m chatTUI) renderCompletion() string {
 	if m.completion.kind == compAt {
 		hint = i18n.M.CompHintFile
 	}
-	b.WriteString(dim(hint))
+	b.WriteString(padRight(dim(hint), m.width))
 	return b.String()
 }


### PR DESCRIPTION
## 修复内容

修复 Git Bash/mintty 中输入 `/` 触发技能补全列表后，刷新时可能留下旧字符的问题。这个问题在技能描述包含中文等双宽字符时更容易出现。

根因是补全菜单虽然已经按固定宽度补齐，但尾部使用普通 ASCII 空格时，终端渲染器可能把这些尾随空格优化成清行/清字符控制序列。mintty 在中文双宽字符附近处理这些 erase 序列时，仍可能保留旧单元格内容。

本次改动让补全菜单行和 footer 使用 NBSP 作为不可清除式 padding：视觉上仍是空白，但会强制渲染器实际覆盖到固定宽度，而不是依赖 erase 优化。

## 主要改动

- 为补全菜单增加 `padCompletionLine`，统一按 TUI 宽度补齐。
- 使用 `completionPadCell = "\u00a0"` 避免尾部普通空格被优化成 erase 序列。
- 补充中文技能名称/描述场景的回归测试，确认补全行固定宽度且不会以普通空格结尾。

## 验证

- `gofmt -w internal/cli/complete.go internal/cli/chat_tui_test.go`
- `go test ./internal/cli -run 'TestCompletion|TestSlash|TestSkill|TestInputOwnedOverlaysKeepComposerBox|TestTranscriptViewportSizing' -count=1`
