### PR TITLE
fix(desktop): harden Windows WebView startup

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -177,7 +177,10 @@ handled here, and what to reach for if a target misbehaves:
   release; the CSS deliberately avoids `backdrop-filter`/blur (slow & inconsistent
   there).
 - **Windows / WebView2** — `Theme: SystemDefault` follows the OS light/dark
-  setting; the runtime must be installed (bundle it for distribution).
+  setting; the installer embeds the WebView2 bootstrapper. Canary builds disable
+  WebView2 GPU acceleration by default to smoke-test blank-window reports; set
+  `REASONIX_DESKTOP_DISABLE_WEBVIEW2_GPU=1` or `0` to force the fallback on or
+  off.
 - **macOS / WebKit** — inset/hidden title bar (`TitleBarHiddenInset`); the CSS
   marks the top bar as an OS drag region (`--wails-draggable: drag`) and leaves
   room for the traffic lights.

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -10,6 +10,10 @@ import { initTextSize } from "./lib/textSize";
 import { initTheme } from "./lib/theme";
 import "./styles.css";
 
+// Install first so startup/runtime failures paint a useful error instead of a
+// featureless webview background.
+installGlobalCrashHandlers();
+
 // Apply the saved appearance (auto/light/dark) before the first paint.
 initTheme();
 initTextSize();
@@ -33,8 +37,6 @@ function prewarmFontFallbacks() {
   });
 }
 prewarmFontFallbacks();
-
-installGlobalCrashHandlers();
 
 // Inside the Wails shell, suppress the webview's default right-click menu — its
 // Reload / Back / Inspect entries are easy to hit by accident and can reset or

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -8,6 +8,8 @@ package main
 
 import (
 	"embed"
+	"os"
+	"strings"
 
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -40,6 +42,20 @@ var version = "dev"
 // `-X main.channel=canary`. Default "stable" tracks the public release; "canary"
 // tracks the opt-in pre-release line and never crosses over to stable.
 var channel = "stable"
+
+const disableWebview2GPUEnv = "REASONIX_DESKTOP_DISABLE_WEBVIEW2_GPU"
+
+func windowsWebview2GPUDisabled() bool {
+	if raw, ok := os.LookupEnv(disableWebview2GPUEnv); ok {
+		switch strings.ToLower(strings.TrimSpace(raw)) {
+		case "1", "true", "yes", "on":
+			return true
+		case "0", "false", "no", "off", "":
+			return false
+		}
+	}
+	return channel == "canary"
+}
 
 func main() {
 	app := NewApp()
@@ -96,7 +112,8 @@ func main() {
 		Windows: &windows.Options{
 			// Follow the OS theme so the title bar matches light/dark system
 			// preference instead of being locked to dark.
-			Theme: windows.SystemDefault,
+			Theme:                windows.SystemDefault,
+			WebviewGpuIsDisabled: windowsWebview2GPUDisabled(),
 		},
 		Linux: &linux.Options{
 			ProgramName: "Reasonix",

--- a/desktop/main_test.go
+++ b/desktop/main_test.go
@@ -19,3 +19,39 @@ func TestMain(m *testing.M) {
 	os.RemoveAll(dir)
 	os.Exit(code)
 }
+
+func TestWindowsWebview2GPUDisabled(t *testing.T) {
+	oldChannel := channel
+	t.Cleanup(func() {
+		channel = oldChannel
+		os.Unsetenv(disableWebview2GPUEnv)
+	})
+
+	tests := []struct {
+		name    string
+		channel string
+		env     string
+		want    bool
+	}{
+		{name: "stable default keeps gpu", channel: "stable", want: false},
+		{name: "canary default disables gpu", channel: "canary", want: true},
+		{name: "env enables fallback", channel: "stable", env: "1", want: true},
+		{name: "env disables canary fallback", channel: "canary", env: "0", want: false},
+		{name: "truthy env", channel: "stable", env: "yes", want: true},
+		{name: "falsey env", channel: "canary", env: "off", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channel = tt.channel
+			if tt.env == "" {
+				os.Unsetenv(disableWebview2GPUEnv)
+			} else {
+				os.Setenv(disableWebview2GPUEnv, tt.env)
+			}
+			if got := windowsWebview2GPUDisabled(); got != tt.want {
+				t.Fatalf("windowsWebview2GPUDisabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/desktop-build.sh
+++ b/scripts/desktop-build.sh
@@ -40,7 +40,7 @@ node -e 'const fs=require("fs"),f="wails.json",j=JSON.parse(fs.readFileSync(f,"u
 
 # NSIS installer is Windows-only (Wails requires a single windows target for -nsis).
 build_args=(-clean -platform "$PLATFORM" -ldflags "-X main.version=$VERSION -X main.channel=$CHANNEL")
-[ "$os" = windows ] && build_args+=(-nsis)
+[ "$os" = windows ] && build_args+=(-nsis -webview2 embed)
 # Link cgo against WebKitGTK 4.1: 4.0 (libwebkit2gtk-4.0.so.37) is gone on
 # Ubuntu 24.04+/Fedora 40+, while 4.1 ships from Ubuntu 22.04 onward.
 [ "$os" = linux ] && build_args+=(-tags webkit2_41)


### PR DESCRIPTION
## Summary
- embed the WebView2 bootstrapper in Windows desktop installer builds instead of relying on the default strategy
- add a Windows WebView2 GPU fallback, enabled by default for canary builds and overrideable with REASONIX_DESKTOP_DISABLE_WEBVIEW2_GPU
- install frontend crash handlers before early Wails runtime/theme calls so startup failures render an actionable overlay
- document the Windows fallback and add regression coverage for the GPU toggle

Refs #3820

## Tests
- `cd desktop && go test ./...`
- `cd desktop/frontend && pnpm typecheck`
- `bash -n scripts/desktop-build.sh`
- `cd desktop/frontend && pnpm build`