### PR TITLE
docs: split usage guide out of README, add a docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   &nbsp;·&nbsp;
   <a href="./README.zh-CN.md">简体中文</a>
   &nbsp;·&nbsp;
+  <a href="./docs/GUIDE.md">Guide</a>
+  &nbsp;·&nbsp;
   <a href="./docs/SPEC.md">Spec</a>
   &nbsp;·&nbsp;
   <a href="https://esengine.github.io/DeepSeek-Reasonix/">Website</a>
@@ -97,22 +99,10 @@ echo "explain this code" | reasonix run
 
 ## Configuration
 
-Resolution order: **flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` >
-built-in defaults**. Secrets come from the environment via `api_key_env` and are
-never stored in config files.
+A minimal `reasonix.toml` — one provider and a default model — is enough to start:
 
 ```toml
-default_model = "deepseek-flash"   # executor; set [agent].planner_model to add a planner
-# language    = "zh"               # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
-
-[agent]
-max_steps = 0                    # executor tool-call rounds; 0 = no limit
-planner_max_steps = 12           # planner read-only tool-call rounds; 0 = no limit
-# planner_model = "mimo-pro"          # optional low-frequency planner
-# subagent_model = "deepseek-pro"     # optional default for runAs=subagent skills
-# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
-auto_plan = "off"                  # off|on; off keeps plan mode manual
-# auto_plan_classifier = "deepseek-flash"   # optional; only borderline tasks call it
+default_model = "deepseek-flash"
 
 [[providers]]
 name        = "deepseek-flash"
@@ -120,211 +110,24 @@ kind        = "openai"
 base_url    = "https://api.deepseek.com"
 model       = "deepseek-v4-flash"
 api_key_env = "DEEPSEEK_API_KEY"
-# also preset: deepseek-pro, mimo-pro (mimo-v2.5-pro), mimo-flash (mimo-v2-flash) @ api.xiaomimimo.com/v1
-
-[tools]
-enabled = []   # omit/empty = all built-ins
-bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
-
-[skills]
-# paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
-# excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
-# disabled_skills = ["review"]                  # hide skills until /skill enable <name>
-
-[permissions]
-mode  = "ask"                                # writer fallback when no rule matches: ask|allow|deny
-deny  = ["Bash(rm -rf*)", "Bash(git push*)"] # hard-blocked in every mode
-allow = ["Bash(go test:*)"]                  # never prompted
-
-[sandbox]
-# workspace_root = ""          # file-writers confined here; empty = current dir
-# allow_write    = ["/tmp"]    # extra dirs write_file/edit_file/multi_edit may touch
-
-[[plugins]]
-name    = "example"
-command = "reasonix-plugin-example"
 ```
 
-Permissions gate each tool call: `deny` > `ask` > `allow` > fallback. Bash and
-file mutation tools require approval by default; read-only tools generally do
-not. Approvals are stored and matched as permission rules, not button labels:
-for example `Bash(npm run build)`, `Bash(npm run test:*)`, and `Edit(docs/**)`.
-`reasonix chat` can grant Bash as an exact command or as a conservative command
-prefix (for example `Bash(go test:*)`), while file-editing tools share session
-edit grants and persist path-scoped rules such as `Edit(src/app.go)`.
-`reasonix run` stays autonomous but still honours `deny`. See
-[`docs/SPEC.md`](docs/SPEC.md) for the full schema and contract.
+Resolution order is **flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` >
+built-in defaults**; secrets come from the environment via `api_key_env` and are
+never written to config files. Permissions, the sandbox, plugins (MCP), slash
+commands, `@` references, and two-model setup are all in the
+**[Guide](./docs/GUIDE.md)**.
 
-Permissions are *policy* (which calls to allow / prompt). The **sandbox** is
-*enforcement*: the file-writers (`write_file` / `edit_file` / `multi_edit`)
-refuse any path outside `[sandbox] workspace_root` (default: the current dir, so
-edits stay in the project), resolving symlinks and `..` so a link can't tunnel
-out. Reads are unrestricted. `bash` is itself jailed on macOS by default
-(`[sandbox] bash`, Seatbelt): commands may write only those same roots (plus
-temp and toolchain caches) and reach the network only when `[sandbox] network`
-is set. Other platforms fall back to running unconfined for now (see
-`docs/SPEC.md` §9 for the escape-prompt and Linux support still to come).
+## Documentation
 
-### Plugins (MCP)
-
-Reasonix is an MCP client. A `[[plugins]]` entry's `type` selects the transport:
-`stdio` (default) launches a local subprocess (`command`/`args`/`env`); `http`
-(Streamable HTTP) connects to a remote `url` with optional static `headers`
-(`${VAR}` / `${VAR:-default}` expanded from the environment, so tokens stay out
-of the file). Tools surface to the model as `mcp__<server>__<tool>`; a tool
-declaring MCP's `readOnlyHint: true` joins parallel dispatch and the permission
-reader-default.
-
-A server's **prompts** surface as `/mcp__<server>__<prompt>` slash commands
-(positional args after the command); its **resources** are pulled in by writing
-`@<server>:<uri>` in a message; `/mcp` lists connected servers and what each
-exposes. `make build` also produces `bin/reasonix-plugin-example` — a runnable
-reference stdio server (`echo`, `wordcount`, a `review` prompt, a style-guide
-resource) you can copy.
-
-```toml
-[[plugins]]                       # local stdio server
-name    = "example"
-command = "reasonix-plugin-example"
-
-[[plugins]]                       # remote server over Streamable HTTP
-name    = "stripe"
-type    = "http"
-url     = "https://mcp.stripe.com"
-headers = { Authorization = "Bearer ${STRIPE_KEY}" }
-```
-
-Enabled MCP servers start connecting automatically in the background after a
-session begins, so chat stays usable while tools come online. Use `/mcp` or the
-desktop MCP panel to refresh status, reconnect a server, inspect failures, or
-disable a server for the current session.
-
-**Already have an `.mcp.json`?** Drop it in the project root and Reasonix
-reads it as-is — the `mcpServers` spec (`command`/`args`/`env`, `type`/`url`/
-`headers`, `${VAR}` expansion) maps field-for-field onto `[[plugins]]`. Both
-sources are merged; on a name collision `reasonix.toml` wins.
-
-```json
-{
-  "mcpServers": {
-    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"] },
-    "stripe": { "type": "http", "url": "https://mcp.stripe.com", "headers": { "Authorization": "Bearer ${STRIPE_KEY}" } }
-  }
-}
-```
-
-**Upgrading from `0.x`?** Your old `~/.reasonix/config.json` is still read for its
-`mcpServers` (honouring `mcpDisabled`) as a lowest-priority source, so MCP servers
-keep working — move them into `reasonix.toml`'s `[[plugins]]` or a `.mcp.json` when
-convenient.
-
-### Slash commands
-
-In `reasonix chat`, built-in commands (`/compact`, `/new`, `/clear`, `/rewind`, `/tree`,
-`/branch`, `/switch`, `/todo`, `/model`, `/effort`, `/mcp`, `/memory`, `/help`) run locally.
-`/new` starts a new session while saving the previous transcript for
-history/resume; `/clear` asks for confirmation, then discards the current context
-without saving it.
-`/tree` shows saved conversation branches, `/branch [name]` forks the current
-conversation tip, `/branch <turn> [name]` forks from an earlier checkpointed turn,
-and `/switch <id|name>` loads another branch. **Custom commands** are Markdown files under
-`.reasonix/commands/` (project) or `~/.config/reasonix/commands/` (user) —
-`review.md` becomes `/review`, a subdirectory namespaces it (`git/commit.md` →
-`/git:commit`). The body is a prompt template; invoking the command sends it as a
-turn.
-
-```markdown
----
-description: Review the staged diff
-argument-hint: [focus-area]
----
-Review the staged diff. Focus on $ARGUMENTS, list bugs with file:line.
-```
-
-`$ARGUMENTS` expands to all space-separated args, `$1`…`$N` to positional ones.
-MCP prompts also appear here as `/mcp__<server>__<prompt>`.
-
-### @ references
-
-Embed `@` references in a message and Reasonix resolves them before sending, as
-tagged context blocks: `@path/to/file` (or `@dir`) injects a local file's
-contents (or a directory listing), and `@<server>:<uri>` injects an MCP
-resource. A local path is only treated as a reference when it actually exists,
-so ordinary `@mentions` stay literal. Typing `/` or `@` opens an autocomplete
-menu — slash commands, or hierarchical file navigation (one directory level at a
-time, descend into folders) plus MCP resources.
-
-### Two-model collaboration (optional)
-
-`reasonix setup` keeps first-run minimal: pick provider → keys (every SKU of a
-chosen provider is enabled). Running two models together (executor + planner,
-separate cache-stable sessions) is a one-line edit afterwards — set
-`planner_model` to any other enabled provider:
-
-```toml
-[agent]
-planner_model = "deepseek-pro"   # used as the low-frequency planner
-planner_max_steps = 12           # read-only tool-call rounds before pausing
-```
-
-The planner sees loaded `REASONIX.md` / `AGENTS.md` memory and a small read-only
-research tool set, so it can inspect relevant files before handing a plan to the
-executor. Writer and workflow tools remain executor-only. `max_steps` limits the
-executor; `planner_max_steps` limits only the planner, and either can be set to
-`0` for no round limit.
-
-Keep personal step-limit preferences in the user config. Add them to a project's
-`./reasonix.toml` only when that repository needs a shared override, such as a
-larger planner limit for a very large codebase.
-
-Subagent skills inherit the executor model by default. Set `subagent_model` to
-run them on another configured model, or use `subagent_models` to override only
-specific skills such as `review` or `security_review`.
-
-For interactive frontends, plan mode is manual by default. Set
-`agent.auto_plan = "on"` to make complex-looking tasks enter plan mode
-automatically: Reasonix first drafts a read-only plan, then waits for approval
-before editing or running side-effecting commands. `auto_plan_classifier` can
-name a cheap provider such as `deepseek-flash`; it is only called for borderline
-inputs and falls back to the heuristic if classification fails. Use
-`/auto-plan off|on` in `reasonix chat` to change the user-level setting, or
-`reasonix config auto-plan off|on` from a shell/script. Pass `--local` to the
-shell command only when you intentionally want a project-local override.
-
-## Architecture
-
-Three tiers of extensibility, all behind registries the core resolves by name:
-
-1. **Registry** — `Provider` and `Tool` are interfaces; the core has no
-   `switch model`.
-2. **Compile-time built-ins** — providers (`provider/openai`) and tools
-   (`tool/builtin`) self-register via `init()`; `main` blank-imports them.
-   Adding a built-in is one file plus one import.
-3. **Runtime plugins** — executables declared in config, spoken to over
-   newline-delimited JSON-RPC 2.0 on stdin/stdout (the MCP stdio convention).
-   Each remote tool is adapted to the `Tool` interface.
-
-## Status
-
-Done: registry-based providers/tools, OpenAI-compatible streaming with tool
-calls (bounded retry on 429/5xx), built-in tools (read_file, write_file,
-edit_file, multi_edit, bash, ls, glob, grep, web_fetch, task, todo_write, ask),
-TOML config, an interactive `reasonix setup` wizard, two-model collaboration
-(executor + planner in separate, cache-stable sessions), low-frequency context
-compaction, sub-agents (`task`), a bubbletea chat TUI (markdown, plan mode with
-controller-driven approval, live token/activity readout, pinned task list,
-`ask` question chooser, `/compact` `/new` `/tree` `/branch` `/switch` `/todo`), session persistence + resume,
-per-call **permissions** (allow/ask/deny rules; chat prompts before writers, deny
-rules hard-block everywhere), a **workspace sandbox** confining file-writers to
-the project (symlink/`..`-safe), an MCP client — **stdio + Streamable HTTP**
-transports, tools (`mcp__server__tool`, `readOnlyHint`-aware), prompts (slash
-commands), resources (`@`-references), and `/mcp`, configured via `[[plugins]]`
-or a project `.mcp.json` — custom slash commands (`.reasonix/commands/*.md`),
-`@file` / `@resource` references, plus a runnable reference plugin
-(`cmd/reasonix-plugin-example`), the harness loop, and CLI. A Wails desktop
-client (`desktop/`) drives the same kernel. Next: an OS-level sandbox for `bash`
-(macOS Seatbelt / Linux bubblewrap), an Anthropic-native provider, MCP OAuth +
-legacy SSE. See `docs/SPEC.md` §9.
+- **[Guide](./docs/GUIDE.md)** — configuration, permissions & sandbox, plugins
+  (MCP), slash commands, `@` references, two-model collaboration.
+- **[Spec](./docs/SPEC.md)** — engineering contract: architecture, registries,
+  data types, and roadmap.
+- **[Migrating from 0.x](./docs/MIGRATING.md)** — moving from the legacy
+  TypeScript releases to the 1.0 Go rewrite.
+- **[Checkpoints & rewind](./docs/CHECKPOINTS.md)** — the snapshot-based edit
+  safety net (Esc-Esc / `/rewind`).
 
 <br/>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,6 +7,8 @@
   &nbsp;·&nbsp;
   <strong>简体中文</strong>
   &nbsp;·&nbsp;
+  <a href="./docs/GUIDE.zh-CN.md">指南</a>
+  &nbsp;·&nbsp;
   <a href="./docs/SPEC.md">规格</a>
   &nbsp;·&nbsp;
   <a href="https://esengine.github.io/DeepSeek-Reasonix/">官方网站</a>
@@ -93,21 +95,10 @@ echo "解释这段代码" | reasonix run
 
 ## 配置
 
-优先级：**flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` > 内置默认值**。
-密钥经环境变量通过 `api_key_env` 注入，绝不写入配置文件。
+一个最小的 `reasonix.toml`——一个 provider 加一个默认模型——就够跑起来:
 
 ```toml
-default_model = "deepseek-flash"   # 执行器；设 [agent].planner_model 可加规划器
-# language    = "zh"               # 界面语言；为空则按 $LANG / $REASONIX_LANG 自动检测
-
-[agent]
-max_steps = 0                    # 执行器工具调用轮数；0 表示不限
-planner_max_steps = 12           # 规划器只读工具调用轮数；0 表示不限
-# planner_model = "mimo-pro"          # 可选的低频规划器
-# subagent_model = "deepseek-pro"     # runAs=subagent skill 的默认模型
-# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
-auto_plan = "off"                  # off|on；off 表示计划模式仅手动开启
-# auto_plan_classifier = "deepseek-flash"   # 可选；只在边界任务上调用
+default_model = "deepseek-flash"
 
 [[providers]]
 name        = "deepseek-flash"
@@ -115,175 +106,20 @@ kind        = "openai"
 base_url    = "https://api.deepseek.com"
 model       = "deepseek-v4-flash"
 api_key_env = "DEEPSEEK_API_KEY"
-# 还有预设：deepseek-pro、mimo-pro（mimo-v2.5-pro）、mimo-flash（mimo-v2-flash） @ api.xiaomimimo.com/v1
-
-[tools]
-enabled = []   # 省略/为空 = 全部内置工具
-bash_timeout_seconds = 120   # 前台安全上限；设为 0 表示不设工具层超时
-
-[skills]
-# paths = ["~/my-skills", "../shared/skills"]   # 额外的自定义技能目录
-# excluded_paths = ["~/.agents/skills"]         # 隐藏约定来源，不删除目录
-# disabled_skills = ["review"]                  # 隐藏技能，直到 /skill enable <name>
-
-[permissions]
-mode  = "ask"                                # 无规则命中时 writer 的兜底：ask|allow|deny
-deny  = ["Bash(rm -rf*)", "Bash(git push*)"] # 任何模式下都硬阻断
-allow = ["Bash(go test:*)"]                  # 从不询问
-
-[sandbox]
-# workspace_root = ""          # 文件写工具被限制在此目录；留空 = 当前目录
-# allow_write    = ["/tmp"]    # write_file/edit_file/multi_edit 额外可写的目录
-
-[[plugins]]
-name    = "example"
-command = "reasonix-plugin-example"
 ```
 
-权限逐次调用把关：`deny` > `ask` > `allow` > 兜底。Bash 和文件修改都要审核；
-只读工具一般不需要。审核规则不是按“按钮文案”存，而是按权限规则匹配，比如
-`Bash(npm run build)`、`Bash(npm run test:*)`、`Edit(docs/**)` 这种形式。
-`reasonix chat` 会在 writer 调用前征求同意（普通工具为 `1` 本次 · `2` 本会话允许此范围 · `3` 总是允许此范围（保存） · `4` 拒绝；Bash 可额外选择命令前缀授权）；
-其中 Bash 默认按具体命令记，也可按安全推导出的命令前缀记（如 `Bash(go test:*)`）；文件编辑类工具的本会话授权按编辑能力记，持久授权则写入 `Edit(<path>)` 文件路径规则；
-`reasonix run` 保持自主运行但仍然遵守 `deny`。完整 schema 与契约见
-[`docs/SPEC.md`](docs/SPEC.md)。
+优先级为 **flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` > 内置默认值**;
+密钥经环境变量通过 `api_key_env` 注入,绝不写入配置文件。权限、沙盒、插件(MCP)、
+斜杠命令、`@` 引用与双模型设置,全部在 **[指南](./docs/GUIDE.zh-CN.md)** 里。
 
-权限是**策略**（哪些调用放行/询问），**沙盒**是**强制**：文件写工具
-（`write_file` / `edit_file` / `multi_edit`）拒绝 `[sandbox] workspace_root`
-之外的任何路径（默认当前目录，编辑不出项目），并解析符号链接与 `..`，使链接无法
-打洞越界。读不受限。`bash` 本身在 macOS 默认进沙盒（`[sandbox] bash`，Seatbelt）：
-命令只能写这些 root（外加临时目录与工具链缓存），`[sandbox] network` 为真时才能联网；
-其它平台暂回退为不沙盒运行（越界问一次与 Linux 支持见 `docs/SPEC.md` §9）。
+## 文档
 
-### 插件（MCP）
-
-Reasonix 是一个 MCP 客户端。`[[plugins]]` 的 `type` 选择传输：`stdio`（默认）启动本地子进
-程（`command`/`args`/`env`）；`http`（Streamable HTTP）连接远程 `url`，可带静态
-`headers`（`${VAR}` / `${VAR:-default}` 从环境展开，密钥不入文件）。工具以
-`mcp__<server>__<tool>` 暴露给模型，与 Claude Code 一致；声明 MCP `readOnlyHint: true`
-的工具会参与并行调度并命中权限层的只读默认放行。
-
-服务器的 **prompts** 会暴露成 `/mcp__<server>__<prompt>` 斜杠命令（命令后空格分隔参
-数）；**resources** 通过在消息里写 `@<server>:<uri>` 拉入；`/mcp` 列出已连接服务器及
-各自暴露的内容。`make build` 还会产出 `bin/reasonix-plugin-example`——一个可直接运行的
-stdio 参考实现（`echo`、`wordcount`、一个 `review` prompt、一个 style-guide 资源），
-可照抄。
-
-```toml
-[[plugins]]                       # 本地 stdio 服务器
-name    = "example"
-command = "reasonix-plugin-example"
-
-[[plugins]]                       # 远程 Streamable HTTP 服务器
-name    = "stripe"
-type    = "http"
-url     = "https://mcp.stripe.com"
-headers = { Authorization = "Bearer ${STRIPE_KEY}" }
-```
-
-**已有 Claude Code 的 `.mcp.json`？** 直接放到项目根目录，Reasonix 会原样读取——其
-`mcpServers` 规范（`command`/`args`/`env`、`type`/`url`/`headers`、`${VAR}` 展开）
-与 `[[plugins]]` 字段一一对应。两处来源会合并加载；同名时以 `reasonix.toml` 为准。
-
-```json
-{
-  "mcpServers": {
-    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"] },
-    "stripe": { "type": "http", "url": "https://mcp.stripe.com", "headers": { "Authorization": "Bearer ${STRIPE_KEY}" } }
-  }
-}
-```
-
-**从 `0.x` 升级？** 旧的 `~/.reasonix/config.json` 仍会被读取(读其 `mcpServers`、并遵从
-`mcpDisabled`),作为最低优先级来源——所以 MCP 服务器照常可用;方便时再把它们挪进
-`reasonix.toml` 的 `[[plugins]]` 或 `.mcp.json`。
-
-### 斜杠命令
-
-`reasonix chat` 里,内置命令(`/compact`、`/new`、`/clear`、`/rewind`、`/tree`、`/branch`、`/switch`、`/todo`、`/model`、`/effort`、`/mcp`、`/help`)在本地执行。
-`/new` 会开启新会话,同时保存之前的 transcript 供历史记录和恢复使用;`/clear` 会二次确认,确认后丢弃当前上下文且不保存。
-`/tree` 查看已保存的对话分支,`/branch [name]` 从当前对话末端分支,`/branch <turn> [name]`
-从较早的 checkpoint 轮次分支,`/switch <id|name>` 切换到另一个分支。**自定义命令**
-是放在 `.reasonix/commands/`(项目)或 `~/.config/reasonix/commands/`(用户)下的 Markdown 文件——
-`review.md` 即 `/review`,子目录构成命名空间(`git/commit.md` → `/git:commit`)。文件正文
-是 prompt 模板,调用即作为一轮对话发出。
-
-```markdown
----
-description: Review the staged diff
-argument-hint: [focus-area]
----
-Review the staged diff. Focus on $ARGUMENTS, list bugs with file:line.
-```
-
-`$ARGUMENTS` 展开为全部空格分隔参数,`$1`…`$N` 为位置参数。MCP prompts 也以
-`/mcp__<server>__<prompt>` 形式出现在这里。
-
-### @ 引用
-
-在消息里写 `@` 引用,Reasonix 会在发送前解析成带标签的上下文块:`@path/to/file`(或
-`@dir`)注入本地文件内容(或目录清单),`@<server>:<uri>` 注入 MCP 资源。本地路径**只有
-真实存在**时才当作引用,普通 `@mention` 保持原文。敲 `/` 或 `@` 会弹出补全菜单——斜杠
-命令,或**逐层**的文件导航(一次只列当前一层目录、可下钻进子目录)外加 MCP 资源。
-
-### 双模型协同（可选）
-
-`reasonix setup` 刻意保持首次体验极简：选 provider → 输入 key（所选 provider 的所有
-SKU 都会启用）。若要让两个模型协同（执行器 + 规划器，各自独立、缓存稳定的
-session），向导后手动在 `reasonix.toml` 加一行即可：
-
-```toml
-[agent]
-planner_model = "deepseek-pro"   # 作为低频规划器
-planner_max_steps = 12           # 暂停前允许的只读工具调用轮数
-```
-
-Planner 会看到已加载的 `REASONIX.md` / `AGENTS.md` 记忆，并拿到一小组只读研究工具，
-因此可以先检查相关文件再把计划交给执行器。写入类和流程类工具仍只给执行器使用。
-`max_steps` 限制执行器；`planner_max_steps` 只限制规划器，两者都可设为 `0` 表示不限。
-
-个人偏好的轮数上限建议放在用户级配置。只有当某个仓库确实需要团队共享覆盖时，
-再写进项目的 `./reasonix.toml`，例如超大代码库需要更高的 planner 上限。
-
-Subagent skills 默认继承执行器模型。设置 `subagent_model` 可让它们统一走另一个已配置
-模型；设置 `subagent_models` 则只覆盖 `review`、`security_review` 等指定 skill。
-
-交互式前端中，计划模式默认手动开启。设置 `agent.auto_plan = "on"` 后，看起来复杂
-的任务会自动进入 plan mode：Reasonix 先只读生成计划，待用户批准后才
-编辑文件或执行有副作用的命令。`auto_plan_classifier` 可以指定便宜的 provider，例如
-`deepseek-flash`；它只在边界输入上调用，分类失败会回退到启发式规则。也可以用
-`reasonix chat` 里的 `/auto-plan off|on` 修改用户级设置，或在 shell/脚本里用
-`reasonix config auto-plan off|on`。只有明确想写项目级覆盖时，才给 shell 命令加
-`--local`。
-
-## 架构
-
-三层可扩展性，全部藏在内核按名解析的 registry 之后：
-
-1. **Registry**：`Provider` 与 `Tool` 是接口；内核没有 `switch model`。
-2. **编译期内置**：provider（`provider/openai`）和 tool（`tool/builtin`）通过
-   `init()` 自注册，`main` 用 blank import 拉入。新增内置 = 一个文件 + 一行 import。
-3. **运行时插件**：配置里声明的可执行文件，通过 stdin/stdout 上的
-   newline-delimited JSON-RPC 2.0（MCP stdio 约定）通信，每个远程 tool 适配成
-   `Tool` 接口。
-
-## 状态
-
-已完成：基于 registry 的 provider/tool、OpenAI 兼容流式 + 工具调用（429/5xx 有界重
-试）、九个内置工具（read_file、write_file、edit_file、multi_edit、bash、ls、glob、
-grep、web_fetch）、TOML 配置、交互式 `reasonix setup` 向导、双模型协同（执行器 + 规划器，
-各自独立、缓存稳定的 session）、低频上下文压缩、子 agent（`task`）、bubbletea 聊天
-TUI（markdown、plan mode、上下文仪表盘、`/compact` `/new` `/tree` `/branch` `/switch`）、会话持久化 + 恢复、
-逐次调用**权限**（allow/ask/deny 规则；chat 在 writer 前询问，deny 在各模式硬阻断）、
-**工作区沙盒**（把文件写工具限制在项目内，符号链接/`..` 安全）、
-MCP 客户端——**stdio + Streamable HTTP** 传输、工具（`mcp__server__tool`,支持
-`readOnlyHint`）、prompts（斜杠命令）、resources（`@` 引用）、`/mcp`，可经
-`[[plugins]]` 或 Claude 风格的项目 `.mcp.json` 配置——自定义斜杠命令
-（`.reasonix/commands/*.md`）、`@file` / `@resource` 引用、外加可运行的参考插件
-（`cmd/reasonix-plugin-example`）、harness 主循环、CLI。chat 在终端普通缓冲区运行(原生
-scrollback)并带 `/` 与 `@` 输入补全。后续:给 `bash` 套 OS 级沙盒（macOS Seatbelt /
-Linux bubblewrap，"盒子里放行、边界上询问"）、Anthropic 原生 provider、MCP OAuth +
-legacy SSE。见 `docs/SPEC.md` §9。
+- **[指南](./docs/GUIDE.zh-CN.md)** —— 配置、权限与沙盒、插件(MCP)、斜杠命令、
+  `@` 引用、双模型协同。
+- **[规格](./docs/SPEC.md)** —— 工程契约:架构、registry、数据类型与路线图。
+- **[从 0.x 迁移](./docs/MIGRATING.md)** —— 从 legacy TypeScript 版本迁到 1.0 Go 重写版。
+- **[Checkpoints 与 rewind](./docs/CHECKPOINTS.md)** —— 基于快照的编辑安全网
+  (Esc-Esc / `/rewind`)。
 
 <br/>
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,0 +1,222 @@
+# Reasonix Guide
+
+<a href="../README.md">README</a>
+&nbsp;·&nbsp;
+<a href="./GUIDE.zh-CN.md">简体中文</a>
+&nbsp;·&nbsp;
+<a href="./SPEC.md">Spec</a>
+
+> Day-to-day configuration and usage. For the engineering contract and internals
+> (data types, registries, package layout, roadmap), see the **[Spec](./SPEC.md)**.
+
+## Contents
+
+- [Configuration](#configuration)
+- [Permissions & sandbox](#permissions--sandbox)
+- [Plugins (MCP)](#plugins-mcp)
+- [Slash commands](#slash-commands)
+- [@ references](#-references)
+- [Two-model collaboration](#two-model-collaboration)
+
+## Configuration
+
+Resolution order: **flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` >
+built-in defaults**. Secrets come from the environment via `api_key_env` and are
+never stored in config files.
+
+```toml
+default_model = "deepseek-flash"   # executor; set [agent].planner_model to add a planner
+# language    = "zh"               # ui language; empty = auto-detect from $LANG / $REASONIX_LANG
+
+[agent]
+max_steps = 0                    # executor tool-call rounds; 0 = no limit
+planner_max_steps = 12           # planner read-only tool-call rounds; 0 = no limit
+# planner_model = "mimo-pro"          # optional low-frequency planner
+# subagent_model = "deepseek-pro"     # optional default for runAs=subagent skills
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
+auto_plan = "off"                  # off|on; off keeps plan mode manual
+# auto_plan_classifier = "deepseek-flash"   # optional; only borderline tasks call it
+
+[[providers]]
+name        = "deepseek-flash"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+# also preset: deepseek-pro, mimo-pro (mimo-v2.5-pro), mimo-flash (mimo-v2.5) @ token-plan-cn.xiaomimimo.com/v1
+
+[tools]
+enabled = []   # omit/empty = all built-ins
+bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
+
+[skills]
+# paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
+# excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders
+# disabled_skills = ["review"]                  # hide skills until /skill enable <name>
+
+[permissions]
+mode  = "ask"                                # writer fallback when no rule matches: ask|allow|deny
+deny  = ["Bash(rm -rf*)", "Bash(git push*)"] # hard-blocked in every mode
+allow = ["Bash(go test:*)"]                  # never prompted
+
+[sandbox]
+# workspace_root = ""          # file-writers confined here; empty = current dir
+# allow_write    = ["/tmp"]    # extra dirs write_file/edit_file/multi_edit may touch
+
+[[plugins]]
+name    = "example"
+command = "reasonix-plugin-example"
+```
+
+For the full schema and every field's contract, see [`SPEC.md` §5](./SPEC.md#5-configuration-toml).
+
+## Permissions & sandbox
+
+Permissions gate each tool call: `deny` > `ask` > `allow` > fallback. Bash and
+file mutation tools require approval by default; read-only tools generally do
+not. Approvals are stored and matched as permission rules, not button labels:
+for example `Bash(npm run build)`, `Bash(npm run test:*)`, and `Edit(docs/**)`.
+`reasonix chat` can grant Bash as an exact command or as a conservative command
+prefix (for example `Bash(go test:*)`), while file-editing tools share session
+edit grants and persist path-scoped rules such as `Edit(src/app.go)`.
+`reasonix run` stays autonomous but still honours `deny`.
+
+Permissions are *policy* (which calls to allow / prompt). The **sandbox** is
+*enforcement*: the file-writers (`write_file` / `edit_file` / `multi_edit`)
+refuse any path outside `[sandbox] workspace_root` (default: the current dir, so
+edits stay in the project), resolving symlinks and `..` so a link can't tunnel
+out. Reads are unrestricted. `bash` is itself jailed on macOS by default
+(`[sandbox] bash`, Seatbelt): commands may write only those same roots (plus
+temp and toolchain caches) and reach the network only when `[sandbox] network`
+is set. Other platforms fall back to running unconfined for now (see
+[`SPEC.md` §9](./SPEC.md#9-roadmap-not-in-current-scope) for the escape-prompt and
+Linux support still to come).
+
+## Plugins (MCP)
+
+Reasonix is an MCP client. A `[[plugins]]` entry's `type` selects the transport:
+`stdio` (default) launches a local subprocess (`command`/`args`/`env`); `http`
+(Streamable HTTP) connects to a remote `url` with optional static `headers`
+(`${VAR}` / `${VAR:-default}` expanded from the environment, so tokens stay out
+of the file). Tools surface to the model as `mcp__<server>__<tool>`; a tool
+declaring MCP's `readOnlyHint: true` joins parallel dispatch and the permission
+reader-default.
+
+A server's **prompts** surface as `/mcp__<server>__<prompt>` slash commands
+(positional args after the command); its **resources** are pulled in by writing
+`@<server>:<uri>` in a message; `/mcp` lists connected servers and what each
+exposes. `make build` also produces `bin/reasonix-plugin-example` — a runnable
+reference stdio server (`echo`, `wordcount`, a `review` prompt, a style-guide
+resource) you can copy.
+
+```toml
+[[plugins]]                       # local stdio server
+name    = "example"
+command = "reasonix-plugin-example"
+
+[[plugins]]                       # remote server over Streamable HTTP
+name    = "stripe"
+type    = "http"
+url     = "https://mcp.stripe.com"
+headers = { Authorization = "Bearer ${STRIPE_KEY}" }
+```
+
+Enabled MCP servers start connecting automatically in the background after a
+session begins, so chat stays usable while tools come online. Use `/mcp` or the
+desktop MCP panel to refresh status, reconnect a server, inspect failures, or
+disable a server for the current session.
+
+**Already have an `.mcp.json`?** Drop it in the project root and Reasonix
+reads it as-is — the `mcpServers` spec (`command`/`args`/`env`, `type`/`url`/
+`headers`, `${VAR}` expansion) maps field-for-field onto `[[plugins]]`. Both
+sources are merged; on a name collision `reasonix.toml` wins.
+
+```json
+{
+  "mcpServers": {
+    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"] },
+    "stripe": { "type": "http", "url": "https://mcp.stripe.com", "headers": { "Authorization": "Bearer ${STRIPE_KEY}" } }
+  }
+}
+```
+
+**Upgrading from `0.x`?** Your old `~/.reasonix/config.json` is still read for its
+`mcpServers` (honouring `mcpDisabled`) as a lowest-priority source, so MCP servers
+keep working — move them into `reasonix.toml`'s `[[plugins]]` or a `.mcp.json` when
+convenient.
+
+## Slash commands
+
+In `reasonix chat`, built-in commands (`/compact`, `/new`, `/clear`, `/rewind`,
+`/tree`, `/branch`, `/switch`, `/todo`, `/model`, `/mcp`, `/skills`, `/hooks`,
+`/memory`, `/output-style`, `/sandbox`, `/language`, `/auto-plan`, `/help`) run
+locally — `/help` lists them all. `/new` starts a new session while saving the
+previous transcript for history/resume; `/clear` asks for confirmation, then
+discards the current context without saving it. `/tree` shows saved conversation
+branches, `/branch [name]` forks the current conversation tip, `/branch <turn>
+[name]` forks from an earlier checkpointed turn, and `/switch <id|name>` loads
+another branch. **Custom commands** are Markdown files under `.reasonix/commands/`
+(project) or `~/.config/reasonix/commands/` (user) — `review.md` becomes
+`/review`, a subdirectory namespaces it (`git/commit.md` → `/git:commit`). The
+body is a prompt template; invoking the command sends it as a turn.
+
+```markdown
+---
+description: Review the staged diff
+argument-hint: [focus-area]
+---
+Review the staged diff. Focus on $ARGUMENTS, list bugs with file:line.
+```
+
+`$ARGUMENTS` expands to all space-separated args, `$1`…`$N` to positional ones.
+MCP prompts also appear here as `/mcp__<server>__<prompt>`.
+
+## @ references
+
+Embed `@` references in a message and Reasonix resolves them before sending, as
+tagged context blocks: `@path/to/file` (or `@dir`) injects a local file's
+contents (or a directory listing), and `@<server>:<uri>` injects an MCP
+resource. A local path is only treated as a reference when it actually exists,
+so ordinary `@mentions` stay literal. Typing `/` or `@` opens an autocomplete
+menu — slash commands, or hierarchical file navigation (one directory level at a
+time, descend into folders) plus MCP resources.
+
+## Two-model collaboration
+
+`reasonix setup` keeps first-run minimal: pick provider → keys (every SKU of a
+chosen provider is enabled). Running two models together (executor + planner,
+separate cache-stable sessions) is a one-line edit afterwards — set
+`planner_model` to any other enabled provider:
+
+```toml
+[agent]
+planner_model = "deepseek-pro"   # used as the low-frequency planner
+planner_max_steps = 12           # read-only tool-call rounds before pausing
+```
+
+The planner sees loaded `REASONIX.md` / `AGENTS.md` memory and a small read-only
+research tool set, so it can inspect relevant files before handing a plan to the
+executor. Writer and workflow tools remain executor-only. `max_steps` limits the
+executor; `planner_max_steps` limits only the planner, and either can be set to
+`0` for no round limit.
+
+Keep personal step-limit preferences in the user config. Add them to a project's
+`./reasonix.toml` only when that repository needs a shared override, such as a
+larger planner limit for a very large codebase.
+
+Subagent skills inherit the executor model by default. Set `subagent_model` to
+run them on another configured model, or use `subagent_models` to override only
+specific skills such as `review` or `security_review`.
+
+For interactive frontends, plan mode is manual by default. Set
+`agent.auto_plan = "on"` to make complex-looking tasks enter plan mode
+automatically: Reasonix first drafts a read-only plan, then waits for approval
+before editing or running side-effecting commands. `auto_plan_classifier` can
+name a cheap provider such as `deepseek-flash`; it is only called for borderline
+inputs and falls back to the heuristic if classification fails. Use
+`/auto-plan off|on` in `reasonix chat` to change the user-level setting, or
+`reasonix config auto-plan off|on` from a shell/script. Pass `--local` to the
+shell command only when you intentionally want a project-local override.
+
+The why behind separate sessions (keeping each model's prefix cache-stable) is in
+[`SPEC.md` §3.5](./SPEC.md#35-two-model-collaboration-coordinator).

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -1,0 +1,194 @@
+# Reasonix 使用指南
+
+<a href="../README.zh-CN.md">README</a>
+&nbsp;·&nbsp;
+<a href="./GUIDE.md">English</a>
+&nbsp;·&nbsp;
+<a href="./SPEC.md">规格</a>
+
+> 日常配置与使用。工程契约与内部实现（数据类型、registry、包结构、路线图）见
+> **[规格 SPEC.md](./SPEC.md)**。
+
+## 目录
+
+- [配置](#配置)
+- [权限与沙盒](#权限与沙盒)
+- [插件（MCP）](#插件mcp)
+- [斜杠命令](#斜杠命令)
+- [@ 引用](#-引用)
+- [双模型协同](#双模型协同)
+
+## 配置
+
+优先级：**flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` > 内置默认值**。
+密钥经环境变量通过 `api_key_env` 注入，绝不写入配置文件。
+
+```toml
+default_model = "deepseek-flash"   # 执行器；设 [agent].planner_model 可加规划器
+# language    = "zh"               # 界面语言；为空则按 $LANG / $REASONIX_LANG 自动检测
+
+[agent]
+max_steps = 0                    # 执行器工具调用轮数；0 表示不限
+planner_max_steps = 12           # 规划器只读工具调用轮数；0 表示不限
+# planner_model = "mimo-pro"          # 可选的低频规划器
+# subagent_model = "deepseek-pro"     # runAs=subagent skill 的默认模型
+# subagent_models = { review = "deepseek-pro", security_review = "deepseek-pro" }
+auto_plan = "off"                  # off|on；off 表示计划模式仅手动开启
+# auto_plan_classifier = "deepseek-flash"   # 可选；只在边界任务上调用
+
+[[providers]]
+name        = "deepseek-flash"
+kind        = "openai"
+base_url    = "https://api.deepseek.com"
+model       = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+# 还有预设：deepseek-pro、mimo-pro（mimo-v2.5-pro）、mimo-flash（mimo-v2.5） @ token-plan-cn.xiaomimimo.com/v1
+
+[tools]
+enabled = []   # 省略/为空 = 全部内置工具
+bash_timeout_seconds = 120   # 前台安全上限；设为 0 表示不设工具层超时
+
+[skills]
+# paths = ["~/my-skills", "../shared/skills"]   # 额外的自定义技能目录
+# excluded_paths = ["~/.agents/skills"]         # 隐藏约定来源，不删除目录
+# disabled_skills = ["review"]                  # 隐藏技能，直到 /skill enable <name>
+
+[permissions]
+mode  = "ask"                                # 无规则命中时 writer 的兜底：ask|allow|deny
+deny  = ["Bash(rm -rf*)", "Bash(git push*)"] # 任何模式下都硬阻断
+allow = ["Bash(go test:*)"]                  # 从不询问
+
+[sandbox]
+# workspace_root = ""          # 文件写工具被限制在此目录；留空 = 当前目录
+# allow_write    = ["/tmp"]    # write_file/edit_file/multi_edit 额外可写的目录
+
+[[plugins]]
+name    = "example"
+command = "reasonix-plugin-example"
+```
+
+完整 schema 与每个字段的契约见 [`SPEC.md` §5](./SPEC.md#5-configuration-toml)。
+
+## 权限与沙盒
+
+权限逐次调用把关：`deny` > `ask` > `allow` > 兜底。Bash 和文件修改都要审核；
+只读工具一般不需要。审核规则不是按“按钮文案”存，而是按权限规则匹配，比如
+`Bash(npm run build)`、`Bash(npm run test:*)`、`Edit(docs/**)` 这种形式。
+`reasonix chat` 会在 writer 调用前征求同意（普通工具为 `1` 本次 · `2` 本会话允许此范围 · `3` 总是允许此范围（保存） · `4` 拒绝；Bash 可额外选择命令前缀授权）；
+其中 Bash 默认按具体命令记，也可按安全推导出的命令前缀记（如 `Bash(go test:*)`）；文件编辑类工具的本会话授权按编辑能力记，持久授权则写入 `Edit(<path>)` 文件路径规则；
+`reasonix run` 保持自主运行但仍然遵守 `deny`。
+
+权限是**策略**（哪些调用放行/询问），**沙盒**是**强制**：文件写工具
+（`write_file` / `edit_file` / `multi_edit`）拒绝 `[sandbox] workspace_root`
+之外的任何路径（默认当前目录，编辑不出项目），并解析符号链接与 `..`，使链接无法
+打洞越界。读不受限。`bash` 本身在 macOS 默认进沙盒（`[sandbox] bash`，Seatbelt）：
+命令只能写这些 root（外加临时目录与工具链缓存），`[sandbox] network` 为真时才能联网；
+其它平台暂回退为不沙盒运行（越界问一次与 Linux 支持见
+[`SPEC.md` §9](./SPEC.md#9-roadmap-not-in-current-scope)）。
+
+## 插件（MCP）
+
+Reasonix 是一个 MCP 客户端。`[[plugins]]` 的 `type` 选择传输：`stdio`（默认）启动本地子进
+程（`command`/`args`/`env`）；`http`（Streamable HTTP）连接远程 `url`，可带静态
+`headers`（`${VAR}` / `${VAR:-default}` 从环境展开，密钥不入文件）。工具以
+`mcp__<server>__<tool>` 暴露给模型，与 Claude Code 一致；声明 MCP `readOnlyHint: true`
+的工具会参与并行调度并命中权限层的只读默认放行。
+
+服务器的 **prompts** 会暴露成 `/mcp__<server>__<prompt>` 斜杠命令（命令后空格分隔参
+数）；**resources** 通过在消息里写 `@<server>:<uri>` 拉入；`/mcp` 列出已连接服务器及
+各自暴露的内容。`make build` 还会产出 `bin/reasonix-plugin-example`——一个可直接运行的
+stdio 参考实现（`echo`、`wordcount`、一个 `review` prompt、一个 style-guide 资源），
+可照抄。
+
+```toml
+[[plugins]]                       # 本地 stdio 服务器
+name    = "example"
+command = "reasonix-plugin-example"
+
+[[plugins]]                       # 远程 Streamable HTTP 服务器
+name    = "stripe"
+type    = "http"
+url     = "https://mcp.stripe.com"
+headers = { Authorization = "Bearer ${STRIPE_KEY}" }
+```
+
+启用的 MCP 服务器会在会话开始后于后台自动连接，因此工具上线期间聊天仍可正常使用。
+用 `/mcp` 或桌面端 MCP 面板可刷新状态、重连服务器、查看失败原因，或在当前会话内禁用某个服务器。
+
+**已有 Claude Code 的 `.mcp.json`？** 直接放到项目根目录，Reasonix 会原样读取——其
+`mcpServers` 规范（`command`/`args`/`env`、`type`/`url`/`headers`、`${VAR}` 展开）
+与 `[[plugins]]` 字段一一对应。两处来源会合并加载；同名时以 `reasonix.toml` 为准。
+
+```json
+{
+  "mcpServers": {
+    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path"] },
+    "stripe": { "type": "http", "url": "https://mcp.stripe.com", "headers": { "Authorization": "Bearer ${STRIPE_KEY}" } }
+  }
+}
+```
+
+**从 `0.x` 升级？** 旧的 `~/.reasonix/config.json` 仍会被读取（读其 `mcpServers`、并遵从
+`mcpDisabled`），作为最低优先级来源——所以 MCP 服务器照常可用；方便时再把它们挪进
+`reasonix.toml` 的 `[[plugins]]` 或 `.mcp.json`。
+
+## 斜杠命令
+
+`reasonix chat` 里，内置命令（`/compact`、`/new`、`/clear`、`/rewind`、`/tree`、`/branch`、`/switch`、`/todo`、`/model`、`/mcp`、`/skills`、`/hooks`、`/memory`、`/output-style`、`/sandbox`、`/language`、`/auto-plan`、`/help`）在本地执行——`/help` 可列出全部。
+`/new` 会开启新会话，同时保存之前的 transcript 供历史记录和恢复使用；`/clear` 会二次确认，确认后丢弃当前上下文且不保存。
+`/tree` 查看已保存的对话分支，`/branch [name]` 从当前对话末端分支，`/branch <turn> [name]`
+从较早的 checkpoint 轮次分支，`/switch <id|name>` 切换到另一个分支。**自定义命令**
+是放在 `.reasonix/commands/`（项目）或 `~/.config/reasonix/commands/`（用户）下的 Markdown 文件——
+`review.md` 即 `/review`，子目录构成命名空间（`git/commit.md` → `/git:commit`）。文件正文
+是 prompt 模板，调用即作为一轮对话发出。
+
+```markdown
+---
+description: Review the staged diff
+argument-hint: [focus-area]
+---
+Review the staged diff. Focus on $ARGUMENTS, list bugs with file:line.
+```
+
+`$ARGUMENTS` 展开为全部空格分隔参数，`$1`…`$N` 为位置参数。MCP prompts 也以
+`/mcp__<server>__<prompt>` 形式出现在这里。
+
+## @ 引用
+
+在消息里写 `@` 引用，Reasonix 会在发送前解析成带标签的上下文块：`@path/to/file`（或
+`@dir`）注入本地文件内容（或目录清单），`@<server>:<uri>` 注入 MCP 资源。本地路径**只有
+真实存在**时才当作引用，普通 `@mention` 保持原文。敲 `/` 或 `@` 会弹出补全菜单——斜杠
+命令，或**逐层**的文件导航（一次只列当前一层目录、可下钻进子目录）外加 MCP 资源。
+
+## 双模型协同
+
+`reasonix setup` 刻意保持首次体验极简：选 provider → 输入 key（所选 provider 的所有
+SKU 都会启用）。若要让两个模型协同（执行器 + 规划器，各自独立、缓存稳定的
+session），向导后手动在 `reasonix.toml` 加一行即可：
+
+```toml
+[agent]
+planner_model = "deepseek-pro"   # 作为低频规划器
+planner_max_steps = 12           # 暂停前允许的只读工具调用轮数
+```
+
+Planner 会看到已加载的 `REASONIX.md` / `AGENTS.md` 记忆，并拿到一小组只读研究工具，
+因此可以先检查相关文件再把计划交给执行器。写入类和流程类工具仍只给执行器使用。
+`max_steps` 限制执行器；`planner_max_steps` 只限制规划器，两者都可设为 `0` 表示不限。
+
+个人偏好的轮数上限建议放在用户级配置。只有当某个仓库确实需要团队共享覆盖时，
+再写进项目的 `./reasonix.toml`，例如超大代码库需要更高的 planner 上限。
+
+Subagent skills 默认继承执行器模型。设置 `subagent_model` 可让它们统一走另一个已配置
+模型；设置 `subagent_models` 则只覆盖 `review`、`security_review` 等指定 skill。
+
+交互式前端中，计划模式默认手动开启。设置 `agent.auto_plan = "on"` 后，看起来复杂
+的任务会自动进入 plan mode：Reasonix 先只读生成计划，待用户批准后才
+编辑文件或执行有副作用的命令。`auto_plan_classifier` 可以指定便宜的 provider，例如
+`deepseek-flash`；它只在边界输入上调用，分类失败会回退到启发式规则。也可以用
+`reasonix chat` 里的 `/auto-plan off|on` 修改用户级设置，或在 shell/脚本里用
+`reasonix config auto-plan off|on`。只有明确想写项目级覆盖时，才给 shell 命令加
+`--local`。
+
+分离 session（让各模型前缀缓存稳定）背后的取舍见
+[`SPEC.md` §3.5](./SPEC.md#35-two-model-collaboration-coordinator)。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -429,15 +429,15 @@ context_window = 1000000   # tokens; harness compacts older history near this li
 [[providers]]
 name        = "mimo-pro"
 kind        = "openai"
-base_url    = "https://api.xiaomimimo.com/v1"
+base_url    = "https://token-plan-cn.xiaomimimo.com/v1"
 model       = "mimo-v2.5-pro"
 api_key_env = "MIMO_API_KEY"
 
 [[providers]]
 name        = "mimo-flash"
 kind        = "openai"
-base_url    = "https://api.xiaomimimo.com/v1"
-model       = "mimo-v2-flash"
+base_url    = "https://token-plan-cn.xiaomimimo.com/v1"
+model       = "mimo-v2.5"
 api_key_env = "MIMO_API_KEY"
 
 [tools]


### PR DESCRIPTION
## What

Restructure the README into a lean landing page and move the detailed how-to into a dedicated, bilingual guide.

- `README.md` / `README.zh-CN.md`: intro, install, quick start, a minimal `reasonix.toml`, and a new **Documentation** index. The exhaustive configuration, permissions/sandbox, plugins (MCP), slash commands, `@`-references, and two-model sections move out (~390 → ~190 lines).
- `docs/GUIDE.md` + `docs/GUIDE.zh-CN.md` (new): the user-facing guide those sections moved into. `SPEC.md` stays the contributor contract; the guide cross-links to it for the full schema and roadmap.

## Fixes (verified against `config.Default()`)

- MiMo preset endpoint is `token-plan-cn.xiaomimimo.com/v1` (was `api.xiaomimimo.com/v1`) and the `mimo-flash` model is `mimo-v2.5` (was `mimo-v2-flash`) — corrected in the guide and `SPEC.md` §5.
- The guide's built-in slash-command list now mirrors what `/help` prints.

All recent additions to these files (code signing, `max_steps` / `planner_max_steps`, `bash_timeout_seconds`, `excluded_paths`, the rule-based permission model, MCP background auto-connect, `/clear`, `auto_plan = off|on`, `/auto-plan`) are preserved — just relocated into the guide.

No code changes.
