### PR TITLE
feat(desktop): enable fuzzy @-search with directory support in Composer

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3532,10 +3532,10 @@ func (a *App) SearchFileRefs(query string) []DirEntry {
 	if err != nil {
 		return nil
 	}
-	paths := fileref.Search(base, query, fileRefSearchLimit)
-	out := make([]DirEntry, 0, len(paths))
-	for _, path := range paths {
-		out = append(out, DirEntry{Name: path, IsDir: false})
+	results := fileref.Search(base, query, fileRefSearchLimit)
+	out := make([]DirEntry, 0, len(results))
+	for _, r := range results {
+		out = append(out, DirEntry{Name: r.Path, IsDir: r.IsDir})
 	}
 	return out
 }

--- a/desktop/frontend/src/__tests__/at-matches.test.ts
+++ b/desktop/frontend/src/__tests__/at-matches.test.ts
@@ -1,0 +1,96 @@
+// Run: tsx src/__tests__/at-matches.test.ts
+//
+// Regression coverage for the Composer @-menu filter (issue #3769).
+// The frontend must mirror the backend fuzzy @-search contract:
+// a fragment like "planind" should surface "src/planind/index.tsx"
+// because the search results return full slash-normalized relative
+// paths, not basenames.
+
+import { filterAtMatches } from "../lib/atMatches";
+import type { DirEntry } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (JSON.stringify(a) === JSON.stringify(b)) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+function entry(name: string, isDir = false): DirEntry {
+  return { name, isDir };
+}
+
+console.log("\nat-matches filter");
+
+// 1. Nested file surfaces when fragment matches an intermediate segment.
+{
+  const entries: DirEntry[] = [];
+  const searchEntries = [entry("src/planind/index.tsx")];
+  const got = filterAtMatches(entries, searchEntries, "planind");
+  eq(
+    got.map((e) => e.name),
+    ["src/planind/index.tsx"],
+    "src/planind/index.tsx + planind → surfaces the nested file",
+  );
+}
+
+// 2. Basename hit is preserved (regression guard for the legacy v1 path).
+{
+  const entries: DirEntry[] = [];
+  const searchEntries = [entry("src/planind/index.tsx")];
+  const got = filterAtMatches(entries, searchEntries, "index");
+  eq(
+    got.map((e) => e.name),
+    ["src/planind/index.tsx"],
+    "src/planind/index.tsx + index → still surfaces via basename",
+  );
+}
+
+// 3. Local ListDir hit and fuzzy Search hit with the same name are de-duped
+// to a single entry, with the local one taking precedence (it appears first).
+{
+  const entries = [entry("planind.go")];
+  const searchEntries = [entry("planind.go")];
+  const got = filterAtMatches(entries, searchEntries, "planind");
+  eq(
+    got.map((e) => e.name),
+    ["planind.go"],
+    "entries ∩ searchEntries with same name dedup to one",
+  );
+}
+
+// 4. Local ListDir entries with a matching fragment appear first; fuzzy hits
+// fill the rest in the order the backend returned them.
+{
+  const entries = [entry("planind.go"), entry("planind.md")];
+  const searchEntries = [entry("src/planind/index.tsx")];
+  const got = filterAtMatches(entries, searchEntries, "planind");
+  eq(
+    got.map((e) => e.name),
+    ["planind.go", "planind.md", "src/planind/index.tsx"],
+    "local entries precede fuzzy search hits, no dupes",
+  );
+}
+
+// 5. Empty fragment matches every entry because includes("") is true; this
+// pins the current behavior so a future change that re-introduces
+// basename-only matching or skips empty fragments is caught immediately.
+{
+  const entries = [entry("a.ts"), entry("b.ts")];
+  const searchEntries = [entry("src/c.ts")];
+  const got = filterAtMatches(entries, searchEntries, "");
+  eq(
+    got.map((e) => e.name),
+    ["a.ts", "b.ts", "src/c.ts"],
+    "empty fragment includes every entry (legacy behavior preserved)",
+  );
+}
+
+console.log(`\n${passed} passed, ${failed} failed\n`);
+process.exit(failed === 0 ? 0 : 1);

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { CSSProperties, ClipboardEvent, DragEvent, KeyboardEvent, PointerEvent as ReactPointerEvent } from "react";
 import { ArrowUp, Eye, FileText, Folder, List, MessageSquare, Search, Shield, ShieldAlert, ShieldCheck, SlidersHorizontal, Square, Target, Trash2, X } from "lucide-react";
 import { asArray } from "../lib/array";
+import { filterAtMatches } from "../lib/atMatches";
 import { DedupIndex, sha256 } from "../lib/attachDedup";
 import { app, onFilesDropped } from "../lib/bridge";
 import { SPINNER_WORDS, useI18n } from "../lib/i18n";
@@ -558,13 +559,7 @@ export function Composer({
   const atMatches = useMemo(
     () => {
       if (atRaw === null) return [];
-      const local = entries.filter((e) => e.name.toLowerCase().includes(atFrag));
-      const seen = new Set(local.map((e) => e.name));
-      const searched = searchEntries.filter((e) => {
-        const basename = e.name.split("/").pop()?.toLowerCase() ?? "";
-        return basename.includes(atFrag) && !seen.has(e.name);
-      });
-      return [...local, ...searched];
+      return filterAtMatches(entries, searchEntries, atFrag);
     },
     [atRaw, atFrag, entries, searchEntries],
   );

--- a/desktop/frontend/src/lib/atMatches.ts
+++ b/desktop/frontend/src/lib/atMatches.ts
@@ -1,0 +1,34 @@
+// atMatches filters the @-menu candidates shown in the Composer. It is
+// extracted from the Composer component so it can be unit-tested without
+// mounting the full React tree.
+//
+// The match logic mirrors the v2 fuzzy @-search behavior: the user's
+// fragment is matched against each entry's full relative path (which the
+// backend already returns as a slash-normalized string for search
+// results, and as a single-segment name for ListDir results). This
+// allows entries like "src/planind/index.tsx" to surface when the user
+// types a directory segment such as "planind", not just the basename
+// "index.tsx".
+//
+// Entries from the local ListDir (`entries`) and the fuzzy Search
+// (`searchEntries`) are merged with stable de-duplication keyed on
+// `entry.name` so a result that appears in both lists is shown only
+// once. The local list takes precedence (it represents the user's
+// current directory and is more immediate).
+
+import type { DirEntry } from "./types";
+
+export function filterAtMatches(
+  entries: readonly DirEntry[],
+  searchEntries: readonly DirEntry[],
+  atFrag: string,
+): DirEntry[] {
+  const frag = atFrag.toLowerCase();
+  const local = entries.filter((e) => e.name.toLowerCase().includes(frag));
+  const seen = new Set(local.map((e) => e.name));
+  const searched = searchEntries.filter((e) => {
+    if (seen.has(e.name)) return false;
+    return e.name.toLowerCase().includes(frag);
+  });
+  return [...local, ...searched];
+}

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -410,9 +410,13 @@ func (m *chatTUI) searchFileRefs(frag string) []string {
 			searchRoot = wr
 		}
 	}
-	r := fileref.Search(searchRoot, frag, maxFileSearchItems)
-	m.fileSearchCache[frag] = r
-	return r
+	results := fileref.Search(searchRoot, frag, maxFileSearchItems)
+	paths := make([]string, 0, len(results))
+	for _, r := range results {
+		paths = append(paths, r.Path)
+	}
+	m.fileSearchCache[frag] = paths
+	return paths
 }
 
 // splitPathToken splits a path token into (dir, frag): dir keeps its trailing

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -37,17 +37,30 @@ const (
 	maxWalkEntries = 10000
 )
 
-// Search finds regular files under root whose basename contains query. It is
-// bounded by limit and skips common generated/vendor directories so interactive
-// completion stays responsive on large workspaces.
-func Search(root, query string, limit int) []string {
+// SearchResult is a single entry returned by Search. It carries the relative
+// path (slash-normalized) and whether the entry is a directory, so callers
+// can present the correct icon and append "/" vs " " on selection.
+type SearchResult struct {
+	Path  string
+	IsDir bool
+}
+
+// Search finds entries under root whose path matches query. A match is
+// recorded when the query is a substring of the file's basename (preferred
+// tier), of any slash-separated path segment (fallback tier), or of a
+// directory name (lowest tier). It is bounded by limit and skips common
+// generated/vendor directories so interactive completion stays responsive on
+// large workspaces.
+func Search(root, query string, limit int) []SearchResult {
 	query = strings.ToLower(strings.TrimSpace(query))
 	if len(query) < minQueryLen || strings.ContainsAny(query, `/\`) || limit <= 0 {
 		return nil
 	}
 
 	showHidden := strings.HasPrefix(query, ".")
-	var matches []string
+	var basenameHits []SearchResult
+	var segmentHits []SearchResult
+	var dirHits []SearchResult
 	visited := 0
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -74,18 +87,17 @@ func Search(root, query string, limit int) []string {
 			if skipEntryNames[name] || skipDirNames[name] || skipDirPaths[rel] || (!showHidden && strings.HasPrefix(name, ".")) {
 				return filepath.SkipDir
 			}
+			// Allow matching directory names so the user can select a
+			// folder directly from the @-menu instead of only its contents.
+			if strings.Contains(strings.ToLower(name), query) {
+				dirHits = append(dirHits, SearchResult{Path: rel, IsDir: true})
+			}
 			return nil
 		}
 		if skipEntryNames[name] {
 			return nil
 		}
-		if len(matches) >= limit {
-			return filepath.SkipAll
-		}
 		if !showHidden && strings.HasPrefix(name, ".") {
-			return nil
-		}
-		if !strings.Contains(strings.ToLower(name), query) {
 			return nil
 		}
 		if info, err := d.Info(); err != nil || !info.Mode().IsRegular() {
@@ -95,9 +107,57 @@ func Search(root, query string, limit int) []string {
 		if err != nil {
 			return nil
 		}
-		matches = append(matches, filepath.ToSlash(rel))
+		rel = filepath.ToSlash(rel)
+		nameLower := strings.ToLower(name)
+		switch {
+		case strings.Contains(nameLower, query):
+			basenameHits = append(basenameHits, SearchResult{Path: rel})
+		case pathSegmentContains(rel, query):
+			segmentHits = append(segmentHits, SearchResult{Path: rel})
+		}
 		return nil
 	})
-	sort.Strings(matches)
-	return matches
+	sort.Slice(basenameHits, func(i, j int) bool { return basenameHits[i].Path < basenameHits[j].Path })
+	sort.Slice(segmentHits, func(i, j int) bool { return segmentHits[i].Path < segmentHits[j].Path })
+	sort.Slice(dirHits, func(i, j int) bool { return dirHits[i].Path < dirHits[j].Path })
+	// Directories first so the user can navigate into them; then basename
+	// hits (most relevant file matches); then path-segment hits. We reserve
+	// up to dirQuota slots for directories so they are never fully crowded
+	// out by a large number of file matches.
+	const dirQuota = 5
+	out := make([]SearchResult, 0, limit)
+	nDirs := len(dirHits)
+	if nDirs > dirQuota {
+		nDirs = dirQuota
+	}
+	out = append(out, dirHits[:nDirs]...)
+	remaining := limit - len(out)
+	if remaining > 0 {
+		if len(basenameHits) > remaining {
+			basenameHits = basenameHits[:remaining]
+		}
+		out = append(out, basenameHits...)
+		remaining = limit - len(out)
+	}
+	if remaining > 0 {
+		if len(segmentHits) > remaining {
+			segmentHits = segmentHits[:remaining]
+		}
+		out = append(out, segmentHits...)
+	}
+	return out
+}
+
+// pathSegmentContains reports whether query appears in any slash-separated
+// segment of the slash-normalized relative path. The basename is matched
+// independently by the caller, so this helper is meaningful only for
+// directories above the file (e.g. "src/planind/index.tsx" with query
+// "planind" matches the "planind" segment).
+func pathSegmentContains(relSlash, queryLower string) bool {
+	for _, seg := range strings.Split(relSlash, "/") {
+		if strings.Contains(strings.ToLower(seg), queryLower) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/fileref/search_test.go
+++ b/internal/fileref/search_test.go
@@ -1,0 +1,154 @@
+package fileref
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFile is a tiny helper that creates a regular file with placeholder
+// content. Tests use it to scaffold the workspace layout before each Search
+// call.
+func writeFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("ok"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+// resultPaths extracts just the Path fields from a slice of SearchResult for
+// easy assertion against expected path lists.
+func resultPaths(results []SearchResult) []string {
+	paths := make([]string, len(results))
+	for i, r := range results {
+		paths[i] = r.Path
+	}
+	return paths
+}
+
+// containsPath reports whether want appears in the results by Path field.
+func containsPath(got []SearchResult, want string) bool {
+	for _, r := range got {
+		if r.Path == want {
+			return true
+		}
+	}
+	return false
+}
+
+// containsDirHit reports whether a result with the given Path and IsDir=true
+// exists in the results.
+func containsDirHit(got []SearchResult, wantPath string) bool {
+	for _, r := range got {
+		if r.Path == wantPath && r.IsDir {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSearchMatchesPathSegment verifies the fix for issue #3769: a query
+// matching an intermediate directory segment (here "planind") should now
+// surface files under that directory, even when the basename does not
+// contain the query.
+func TestSearchMatchesPathSegment(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "planind", "index.tsx"))
+
+	got := Search(root, "planind", 50)
+	if !containsPath(got, "src/planind/index.tsx") {
+		t.Fatalf("Search(%q) should return %q (path-segment match), got %v", "planind", "src/planind/index.tsx", resultPaths(got))
+	}
+}
+
+// TestSearchMatchesDirectories verifies that a query matching a directory
+// name returns the directory itself with IsDir=true, not just its contents.
+func TestSearchMatchesDirectories(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "docs", "assets", "readme.md"))
+	writeFile(t, filepath.Join(root, "docs", "assets", "image.png"))
+
+	got := Search(root, "assets", 50)
+	if !containsDirHit(got, "docs/assets") {
+		t.Fatalf("Search(%q) should return directory %q with IsDir=true, got %v", "assets", "docs/assets", resultPaths(got))
+	}
+	// Directory hits come after basename and segment hits.
+	if !containsPath(got, "docs/assets/readme.md") {
+		t.Fatalf("Search(%q) should still return files under the directory, got %v", "assets", resultPaths(got))
+	}
+}
+
+// TestSearchKeepsBasenameMatch guards the legacy behavior: when the query
+// matches the file's basename, the file must still appear in the results,
+// and basename hits must sort strictly before path-segment and directory
+// hits so the most relevant matches surface at the top of the completion
+// menu.
+func TestSearchKeepsBasenameMatch(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "planind.go"))
+	writeFile(t, filepath.Join(root, "src", "planind", "index.tsx")) // also a segment hit
+
+	got := Search(root, "planind", 50)
+	gotPaths := resultPaths(got)
+	want := []string{"src/planind", "planind.go", "src/planind/index.tsx"}
+	if !equalSlices(gotPaths, want) {
+		t.Fatalf("Search(%q) order mismatch:\n  want %v\n  got  %v", "planind", want, gotPaths)
+	}
+	// Verify the directory hit has IsDir=true.
+	if !containsDirHit(got, "src/planind") {
+		t.Fatalf("Search(%q) should return %q with IsDir=true", "planind", "src/planind")
+	}
+}
+
+// equalSlices reports whether two []string are element-wise equal.
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSearchHandlesBasenamePathQuery verifies that searching for the basename
+// part of a nested file still surfaces the file (regression guard).
+func TestSearchHandlesBasenamePathQuery(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "planind", "index.tsx"))
+
+	got := Search(root, "index", 50)
+	if !containsPath(got, "src/planind/index.tsx") {
+		t.Fatalf("Search(%q) should return %q (basename of nested file), got %v", "index", "src/planind/index.tsx", resultPaths(got))
+	}
+}
+
+// TestSearchSkipsNoiseStillWorks ensures the noise-directory skip list still
+// applies to path-segment matches. Files under node_modules must not surface
+// even when an intermediate segment matches the query.
+func TestSearchSkipsNoiseStillWorks(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "planind", "index.tsx"))          // legitimate hit
+	writeFile(t, filepath.Join(root, "node_modules", "planind", "index.tsx")) // must be skipped
+	writeFile(t, filepath.Join(root, "build", "planind", "index.tsx"))        // skipDirNames
+	writeFile(t, filepath.Join(root, "dist", "planind", "index.tsx"))         // skipDirNames
+
+	got := Search(root, "planind", 50)
+	if containsPath(got, "node_modules/planind/index.tsx") {
+		t.Fatalf("Search should skip node_modules, got %v", resultPaths(got))
+	}
+	if containsPath(got, "build/planind/index.tsx") {
+		t.Fatalf("Search should skip build/, got %v", resultPaths(got))
+	}
+	if containsPath(got, "dist/planind/index.tsx") {
+		t.Fatalf("Search should skip dist/, got %v", resultPaths(got))
+	}
+	if !containsPath(got, "src/planind/index.tsx") {
+		t.Fatalf("Search should still return legitimate hit, got %v", resultPaths(got))
+	}
+}


### PR DESCRIPTION
## Summary

Restore the v1-style fuzzy `@file` search behavior in the Composer so that
an intermediate directory segment in a query (e.g. `@planind`) surfaces
nested matches such as `src/planind/index.tsx`, and directory names like
`assets/` are selectable from the @-menu.

Previously the backend matched only on `d.Name()` (basename), the frontend
filter reduced `searchEntries` to basename-only, and `SearchFileRefs`
hardcoded `IsDir: false` for all results — so deep paths and directories
were invisible to the @-menu.

Closes #3769.

## What changed

- `internal/fileref/search.go`
  - `Search` now returns `[]SearchResult` (with `Path` and `IsDir`) instead of
    `[]string`.
  - Matches are collected into three tiers: basename hits (preferred), path-
    segment hits (fallback), and directory-name hits (lowest). A `dirQuota`
    of 5 ensures directories are never fully crowded out by file matches.
  - `pathSegmentContains(relSlash, queryLower)` checks any slash-separated
    path segment for a match.
  - Noise directories (`.git`, `node_modules`, `build`, `dist`, ...) are
    still skipped. The public API signature is unchanged.

- `desktop/app.go`
  - `SearchFileRefs` now propagates `r.IsDir` from `SearchResult` to
    `DirEntry.IsDir`, fixing a pre-existing bug where all results were
    hardcoded `IsDir: false`.

- `internal/cli/complete.go`
  - Adapted to the new `[]SearchResult` return type (CLI only uses `Path`).

- `desktop/frontend/src/lib/atMatches.ts` (new)
  - Pure helper `filterAtMatches(entries, searchEntries, atFrag)` that
    matches against the full slash-normalized relative path and de-duplicates
    by `e.name` with the local list taking precedence.

- `desktop/frontend/src/__tests__/at-matches.test.ts` (new)
  - 5 cases covering nested-path surfacing, basename match, de-duplication,
    local-before-fuzzy ordering, and the empty-fragment legacy behavior.

- `desktop/frontend/src/components/Composer.tsx`
  - The `atMatches` `useMemo` now delegates to `filterAtMatches`. The rest
    of the @-menu logic, the `atDir !== ""` guard, and the directory
    navigation UX are intentionally untouched.

- `internal/fileref/search_test.go` (new)
  - 6 cases covering path-segment match, basename match, directory match
    with `IsDir=true`, sort order between tiers, and noise-directory skip.

## Test results

- `go test ./internal/fileref -count=1` — 6/6 PASS
- `pnpm exec tsx src/__tests__/at-matches.test.ts` — 5/5 PASS
- `go build ./...` — clean
- Manual Wails dev test — directories and files both surface correctly