### PR TITLE
fix(katex): convert aligned→align when \tag is present

### DIFF
--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -63,6 +63,19 @@ eq(latexNormalizeForKatex("\\tfrac{a}{b}"), "\\tfrac{a}{b}", "nested braces in c
 eq(latexNormalizeForKatex("\\|x\\|"), "\\|x\\|", "\\| is left alone (readCommand handles \\|, not | branch)");
 eq(latexNormalizeForKatex("\\\\|x|"), "\\\\\\vert x\\vert", "\\\\| line break + pipe: both | → \\vert");
 
+// ── latexNormalizeForKatex — \tag → align conversion (regression for KaTeX "Multiple \tag") ──
+eq(latexNormalizeForKatex("a = b \\tag{10}"), "a = b \\tag{10}", "\\tag without aligned passes through");
+eq(latexNormalizeForKatex("\\begin{aligned} a &= b \\\\ \\end{aligned}"),
+  "\\begin{aligned} a &= b \\\\ \\end{aligned}", "aligned without \\tag unchanged");
+eq(latexNormalizeForKatex("\\begin{aligned} a &= b \\tag{10}\\\\ c &= d \\end{aligned}"),
+  "\\begin{align} a &= b \\tag{10}\\\\ c &= d \\end{align}", "aligned with \\tag → align");
+eq(latexNormalizeForKatex("\\begin{aligned} a &= b \\tag{10}\\\\ c &= d \\tag{11} \\end{aligned}"),
+  "\\begin{align} a &= b \\tag{10}\\\\ c &= d \\tag{11} \\end{align}", "aligned with multiple \\tag → align");
+eq(latexNormalizeForKatex("\\boxed{\\begin{aligned} a &= b \\tag{10}\\\\ c &= d \\end{aligned}}"),
+  "\\boxed{\\begin{align} a &= b \\tag{10}\\\\ c &= d \\end{align}}", "boxed aligned with \\tag → boxed align");
+eq(latexNormalizeForKatex("\\begin{gathered} a = b \\tag{10}\\\\ c = d \\end{gathered}"),
+  "\\begin{gather} a = b \\tag{10}\\\\ c = d \\end{gather}", "gathered with \\tag → gather");
+
 // ── isLikelyInlineMath (mathClassify) ──────────────────────────────────────────
 
 console.log("\nisLikelyInlineMath — math");
@@ -238,6 +251,9 @@ const e2e: Array<[string, string]> = [
   ["\\(\\alpha\\)", "LLM-native inline delimiter"],
   ["\\[\\sum_{i=1}^n i\\]", "LLM-native display delimiter"],
   ["$$ |a| = |b| $$", "display with absolute values"],
+  ["$$\\boxed{\\begin{aligned}\nr_A E_\\pi(k;0) &= B(k^2) \\\\\nF_R(k;0) + 2r_A F_\\pi(k;0) &= A(k^2)\n\\end{aligned}}$$", "boxed aligned (no \\tag)"],
+  ["$$\\boxed{\\begin{aligned}\nr_A E_\\pi(k;0) &= B(k^2) \\tag{10}\\\\\nF_R(k;0) + 2r_A F_\\pi(k;0) &= A(k^2) \\tag{11}\n\\end{aligned}}$$", "boxed aligned with \\tag → align (no error)"],
+  ["\\[\\boxed{\\begin{aligned}\nx &= 1 \\\\\ny &= 2\n\\end{aligned}}\\]", "LLM-native boxed aligned"],
 ];
 for (const [src, label] of e2e) {
   check(`${label}: ${src}`, () => katexOf(normalizeMath(src), false));

--- a/desktop/frontend/src/components/latexNormalize.ts
+++ b/desktop/frontend/src/components/latexNormalize.ts
@@ -41,6 +41,22 @@ export function latexNormalizeForKatex(source: string): string {
     return inner.includes("(") ? `\\not{${inner}}` : `\\not ${inner}`;
   });
 
+  // When \tag is present, convert aligned/gathered/alignedat environments
+  // to align/gather/alignat.  KaTeX's aligned/gathered treat the entire
+  // block as one equation and only permit a single \tag (parse error
+  // "Multiple \tag" on older versions), while align/gather support \tag
+  // on every row natively.  We only convert when \tag exists so that
+  // plain aligned blocks keep their un-numbered behaviour.
+  if (/\\tag\*?\s*\{/.test(source)) {
+    source = source
+      .replace(/\\begin\{alignedat\}\{(\d+)\}/g, "\\begin{alignat}{$1}")
+      .replace(/\\end\{alignedat\}/g, "\\end{alignat}")
+      .replace(/\\begin\{aligned\}/g, "\\begin{align}")
+      .replace(/\\end\{aligned\}/g, "\\end{align}")
+      .replace(/\\begin\{gathered\}/g, "\\begin{gather}")
+      .replace(/\\end\{gathered\}/g, "\\end{gather}");
+  }
+
   let out = "";
   let i = 0;
 


### PR DESCRIPTION
## Problem

KaTeX`s `aligned`/`gathered` environments treat the entire block as one
equation and only permit a single `\tag` per block (parse error "Multiple
\tag"). When LLMs emit `\tag{...}` inside `aligned` — as in:

```latex
$$
\boxed{\begin{aligned}
r_A E_\pi(k;0) &= B(k^2) \tag{10}\\
F_R(k;0) + 2r_A F_\pi(k;0) &= A(k^2) \tag{11}
\end{aligned}}
$$
```

KaTeX throws `KaTeX parse error: Multiple \tag`, which `rehype-katex`
renders as `<span class="katex-error" style="color:#cc0000">` —
showing red error text in the web UI.

## Fix

Instead of stripping `\tag` commands (which loses equation numbers),
convert the environments when `\tag` is present:

- `\begin{aligned}` → `\begin{align}`
- `\begin{gathered}` → `\begin{gather}`
- `\begin{alignedat}{N}` → `\begin{alignat}{N}`

KaTeX's `align`/`gather`/`alignat` support `\tag` on every row
natively. Plain `aligned` blocks without `\tag` are left unchanged
so they keep their un-numbered behaviour. The conversion is only
applied when `\tag` is detected in the math source.

```ts
if (/\\tag\*?\s*\{/.test(source)) {
  source = source
    .replace(/\\begin\{alignedat\}\{(\d+)\}/g, "\\begin{alignat}{$1}")
    .replace(/\\end\{alignedat\}/g, "\\end{alignat}")
    .replace(/\\begin\{aligned\}/g, "\\begin{align}")
    .replace(/\\end\{aligned\}/g, "\\end{align}")
    .replace(/\\begin\{gathered\}/g, "\\begin{gather}")
    .replace(/\\end\{gathered\}/g, "\\end{gather}");
}
```

## Files changed

- `desktop/frontend/src/components/latexNormalize.ts` — aligned→align
  conversion when `\tag` is present
- `desktop/frontend/src/__tests__/math-golden.test.ts` — 6 new unit
  tests + 1 updated e2e test

## Testing

All 99 golden tests pass (`npx tsx src/__tests__/math-golden.test.ts`).