### PR TITLE
fix: ContextPanel token breakdown uses mismatched units (snapshot vs cumulative)

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2879,6 +2879,16 @@ func (a *App) ContextPanel(tabID string) ContextPanelInfo {
 		used, window := ctrl.ContextSnapshot()
 		info.UsedTokens = used
 		info.WindowTokens = window
+		// Per-turn token breakdown from LastUsage (same snapshot as UsedTokens)
+		// so the donut segments are proportional to the current context fill,
+		// not inflated by cumulative session totals.
+		if u := ctrl.LastUsage(); u != nil {
+			info.PromptTokens = u.PromptTokens
+			info.CompletionTokens = u.CompletionTokens
+			info.ReasoningTokens = u.ReasoningTokens
+			info.CacheHitTokens = u.CacheHitTokens
+			info.CacheMissTokens = u.CacheMissTokens
+		}
 	}
 
 	telemetry := tab.telemetrySnapshot()
@@ -2886,11 +2896,6 @@ func (a *App) ContextPanel(tabID string) ContextPanelInfo {
 		info.ReadFiles = records
 	}
 	usage := telemetry.Usage
-	info.PromptTokens = usage.PromptTokens
-	info.CompletionTokens = usage.CompletionTokens
-	info.ReasoningTokens = usage.ReasoningTokens
-	info.CacheHitTokens = usage.CacheHitTokens
-	info.CacheMissTokens = usage.CacheMissTokens
 	info.RequestCount = usage.RequestCount
 	info.ElapsedMs = usage.ElapsedMs
 	info.SessionCost = usage.SessionCost


### PR DESCRIPTION
The workspace overview donut chart shows broken segment proportions after turn 1 because `UsedTokens` comes from `ContextSnapshot()` (per-turn snapshot) but `PromptTokens`/`CompletionTokens`/`ReasoningTokens` came from `sessionUsageStats` (cumulative across all turns). After the first turn, cumulative >> snapshot, making "other" always 0 and segment percentages wildly inflated.

Fix: read `PromptTokens`/`CompletionTokens`/`ReasoningTokens`/`CacheHitTokens`/`CacheMissTokens` from `ctrl.LastUsage()` — the same per-turn snapshot `UsedTokens` already uses. Cumulative fields (`RequestCount`, `ElapsedMs`, `SessionCost`) stay on `telemetry.Usage`.

- **Files:** `desktop/tabs.go` (+10/-5)