### PR TITLE
feat(hooks): add PermissionRequest hook

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -396,7 +396,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// project hooks run arbitrary shell commands, so cloning a repo must not
 	// silently execute them). Non-blocking hook output is surfaced to the user as
 	// a Notice through the shared sink. The runner fires PreToolUse/PostToolUse in
-	// the agent loop and UserPromptSubmit/Stop at the controller's turn boundary.
+	// the agent loop and PermissionRequest/UserPromptSubmit/Stop at the controller
+	// boundary.
 	hooksTrusted := hook.IsTrusted(root, "")
 	hookRunner := hook.NewRunner(
 		hook.Load(hook.LoadOptions{ProjectRoot: root, Trusted: hooksTrusted}),

--- a/internal/cli/hooks_view.go
+++ b/internal/cli/hooks_view.go
@@ -12,7 +12,7 @@ func renderHooks(width int, hooks []hook.ResolvedHook, trusted bool, projectDefi
 	fmt.Fprintf(&b, "%s\n", viewHeader("hooks (%d active)", len(hooks)))
 	for _, h := range hooks {
 		match := h.Match
-		if h.Event == hook.PreToolUse || h.Event == hook.PostToolUse {
+		if h.Event == hook.PreToolUse || h.Event == hook.PostToolUse || h.Event == hook.PermissionRequest {
 			if match == "" {
 				match = "*"
 			}

--- a/internal/cli/view_helpers_test.go
+++ b/internal/cli/view_helpers_test.go
@@ -115,6 +115,21 @@ func TestRenderHooksUsesSharedVisualLanguage(t *testing.T) {
 	assertLinesWithin(t, got, width)
 }
 
+func TestRenderHooksShowsPermissionRequestMatch(t *testing.T) {
+	width := 72
+	got := renderHooks(width, []hook.ResolvedHook{{
+		HookConfig: hook.HookConfig{Command: "notify", Match: "bash"},
+		Event:      hook.PermissionRequest,
+		Scope:      hook.ScopeGlobal,
+	}}, true, true)
+	for _, want := range []string{"PermissionRequest", "global", "bash", "notify"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("hooks view missing %q:\n%s", want, got)
+		}
+	}
+	assertLinesWithin(t, got, width)
+}
+
 func TestRenderHelpGroupsCommands(t *testing.T) {
 	width := 72
 	got := renderHelp(width,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -526,7 +526,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	}
 	// The plan is already visible as the assistant's answer, so the request
 	// carries no subject — it's purely the gate.
-	allow, _, err := c.requestApproval(ctx, planApprovalTool, "")
+	allow, _, err := c.requestApproval(ctx, planApprovalTool, "", nil)
 	if err != nil {
 		return err
 	}
@@ -2391,7 +2391,7 @@ func (g gateApprover) Approve(ctx context.Context, tool, subject string, args js
 	if auto {
 		return true, false, nil
 	}
-	return g.c.requestApproval(ctx, tool, subject)
+	return g.c.requestApproval(ctx, tool, subject, args)
 }
 
 type seedTodo struct {
@@ -2590,7 +2590,7 @@ func parseRewind(args string, cps []checkpoint.Meta) (int, RewindScope, error) {
 // requestApproval emits an ApprovalRequest and blocks until Approve(ID, …)
 // answers or ctx is cancelled. A prior session grant for the same approval scope
 // short-circuits. promptMu serialises outstanding prompts.
-func (c *Controller) requestApproval(ctx context.Context, tool, subject string) (bool, bool, error) {
+func (c *Controller) requestApproval(ctx context.Context, tool, subject string, args json.RawMessage) (bool, bool, error) {
 	c.mu.Lock()
 	// YOLO/full access and the just-approved-plan execution window auto-allow
 	// approval-gated tools without prompting. Plan approval is a user decision,
@@ -2618,6 +2618,9 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string) 
 	c.mu.Unlock()
 
 	c.sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: id, Tool: tool, Subject: subject}})
+	if tool != planApprovalTool {
+		go c.hooks.PermissionRequest(ctx, tool, subject, args)
+	}
 	// The agent now needs the user's attention; a Notification hook can ping an
 	// external channel (desktop notice, phone) while the run blocks on the reply.
 	if subject != "" {

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/event"
+	"reasonix/internal/hook"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -295,6 +296,64 @@ func approvalIDs() (*Controller, chan string, *int) {
 	return c, ids, &prompts
 }
 
+func permissionHookController(t *testing.T, match string) (*Controller, chan string, chan hook.Payload) {
+	t.Helper()
+	ids := make(chan string, 8)
+	payloads := make(chan hook.Payload, 8)
+	spawner := func(_ context.Context, in hook.SpawnInput) hook.SpawnResult {
+		var payload hook.Payload
+		if err := json.Unmarshal([]byte(in.Stdin), &payload); err != nil {
+			t.Errorf("permission hook payload json: %v", err)
+		}
+		payloads <- payload
+		return hook.SpawnResult{ExitCode: 0}
+	}
+	c := New(Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.ApprovalRequest {
+				ids <- e.Approval.ID
+			}
+		}),
+		Hooks: hook.NewRunner([]hook.ResolvedHook{{
+			HookConfig: hook.HookConfig{Command: "notify", Match: match},
+			Event:      hook.PermissionRequest,
+			Scope:      hook.ScopeGlobal,
+		}}, "/tmp", spawner, nil),
+	})
+	return c, ids, payloads
+}
+
+func waitApprovalID(t *testing.T, ids <-chan string) string {
+	t.Helper()
+	select {
+	case id := <-ids:
+		return id
+	case <-time.After(2 * time.Second):
+		t.Fatal("ApprovalRequest was not emitted")
+	}
+	return ""
+}
+
+func waitPermissionHook(t *testing.T, payloads <-chan hook.Payload) hook.Payload {
+	t.Helper()
+	select {
+	case payload := <-payloads:
+		return payload
+	case <-time.After(2 * time.Second):
+		t.Fatal("PermissionRequest hook did not fire")
+	}
+	return hook.Payload{}
+}
+
+func assertNoPermissionHook(t *testing.T, payloads <-chan hook.Payload) {
+	t.Helper()
+	select {
+	case payload := <-payloads:
+		t.Fatalf("PermissionRequest hook fired unexpectedly: %+v", payload)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 // TestApprovalAllowOnce drives the happy path: the gate emits an ApprovalRequest,
 // the (fake) frontend answers allow, and the gate returns allow with no grant.
 func TestApprovalAllowOnce(t *testing.T) {
@@ -304,6 +363,110 @@ func TestApprovalAllowOnce(t *testing.T) {
 	allow, remember, err := gateApprover{c}.Approve(context.Background(), "bash", "go test", nil)
 	if err != nil || !allow || remember {
 		t.Fatalf("Approve = (%v,%v,%v), want allow once", allow, remember, err)
+	}
+}
+
+func TestPermissionRequestHookFiresForToolApproval(t *testing.T) {
+	c, ids, payloads := permissionHookController(t, "bash")
+	args := json.RawMessage(`{"command":"go test ./..."}`)
+	type approveResult struct {
+		allow    bool
+		remember bool
+		err      error
+	}
+	done := make(chan approveResult, 1)
+	go func() {
+		allow, remember, err := gateApprover{c}.Approve(context.Background(), "bash", "go test ./...", args)
+		done <- approveResult{allow: allow, remember: remember, err: err}
+	}()
+
+	id := waitApprovalID(t, ids)
+	payload := waitPermissionHook(t, payloads)
+	if payload.Event != hook.PermissionRequest {
+		t.Fatalf("payload event = %q, want PermissionRequest", payload.Event)
+	}
+	if payload.ToolName != "bash" {
+		t.Fatalf("payload tool = %q, want bash", payload.ToolName)
+	}
+	if payload.Subject != "go test ./..." {
+		t.Fatalf("payload subject = %q, want command subject", payload.Subject)
+	}
+	if string(payload.ToolArgs) != string(args) {
+		t.Fatalf("payload args = %s, want %s", payload.ToolArgs, args)
+	}
+
+	c.Approve(id, true, false, false)
+	select {
+	case got := <-done:
+		if got.err != nil || !got.allow || got.remember {
+			t.Fatalf("Approve = (%v,%v,%v), want allow once", got.allow, got.remember, got.err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("approval stayed blocked")
+	}
+}
+
+func TestPermissionRequestHookDoesNotFireForPolicyAllow(t *testing.T) {
+	c, _, payloads := permissionHookController(t, "bash")
+	g := permission.NewGate(permission.New("ask", []string{"bash(go test*)"}, nil, nil), gateApprover{c})
+
+	allow, _, err := g.Check(context.Background(), "bash", json.RawMessage(`{"command":"go test ./..."}`), false)
+	if err != nil || !allow {
+		t.Fatalf("allow-listed call = (%v,%v), want allowed", allow, err)
+	}
+	assertNoPermissionHook(t, payloads)
+}
+
+func TestPermissionRequestHookDoesNotFireForSessionGrant(t *testing.T) {
+	c, _, payloads := permissionHookController(t, "bash")
+	c.mu.Lock()
+	c.granted[permission.SessionGrantRuleForScope("bash", "go test ./...", permission.ApprovalScopeExact)] = true
+	c.mu.Unlock()
+
+	allow, _, err := c.requestApproval(context.Background(), "bash", "go test ./...", nil)
+	if err != nil || !allow {
+		t.Fatalf("session-granted approval = (%v,%v), want allowed", allow, err)
+	}
+	assertNoPermissionHook(t, payloads)
+}
+
+func TestPermissionRequestHookDoesNotFireForYolo(t *testing.T) {
+	c, _, payloads := permissionHookController(t, "bash")
+	c.SetToolApprovalMode(ToolApprovalYolo)
+
+	allow, _, err := c.requestApproval(context.Background(), "bash", "go test ./...", nil)
+	if err != nil || !allow {
+		t.Fatalf("YOLO approval = (%v,%v), want allowed", allow, err)
+	}
+	assertNoPermissionHook(t, payloads)
+}
+
+func TestPermissionRequestHookDoesNotFireForPlanApproval(t *testing.T) {
+	c, ids, payloads := permissionHookController(t, ".*")
+	done := make(chan bool, 1)
+	errs := make(chan error, 1)
+	go func() {
+		allow, _, err := c.requestApproval(context.Background(), planApprovalTool, "", nil)
+		if err != nil {
+			errs <- err
+			return
+		}
+		done <- allow
+	}()
+
+	id := waitApprovalID(t, ids)
+	assertNoPermissionHook(t, payloads)
+	c.Approve(id, true, false, false)
+
+	select {
+	case err := <-errs:
+		t.Fatalf("plan approval: %v", err)
+	case allow := <-done:
+		if !allow {
+			t.Fatal("manual plan approval should allow")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("plan approval stayed blocked")
 	}
 }
 

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -104,7 +104,7 @@ func TestRequestApprovalHonorsAutoApproveTools(t *testing.T) {
 
 	done := make(chan bool, 1)
 	go func() {
-		allow, _, err := c.requestApproval(context.Background(), "multi_edit", "/tmp/file")
+		allow, _, err := c.requestApproval(context.Background(), "multi_edit", "/tmp/file", nil)
 		if err != nil {
 			t.Errorf("requestApproval: %v", err)
 		}
@@ -160,7 +160,7 @@ func TestToolApprovalModeAutoDrainsPendingFallbackApproval(t *testing.T) {
 	done := make(chan bool, 1)
 	errs := make(chan error, 1)
 	go func() {
-		allow, _, err := c.requestApproval(context.Background(), "multi_edit", "/tmp/file")
+		allow, _, err := c.requestApproval(context.Background(), "multi_edit", "/tmp/file", nil)
 		if err != nil {
 			errs <- err
 			return
@@ -205,7 +205,7 @@ func TestToolApprovalModeAutoDoesNotDrainPendingExplicitAsk(t *testing.T) {
 	done := make(chan bool, 1)
 	errs := make(chan error, 1)
 	go func() {
-		allow, _, err := c.requestApproval(context.Background(), "bash", "git commit -m x")
+		allow, _, err := c.requestApproval(context.Background(), "bash", "git commit -m x", nil)
 		if err != nil {
 			errs <- err
 			return
@@ -250,7 +250,7 @@ func TestToolApprovalModeYoloBypassesApprovalPrompts(t *testing.T) {
 	if !c.AutoApproveTools() {
 		t.Fatal("YOLO mode should satisfy legacy AutoApproveTools")
 	}
-	allow, remember, err := c.requestApproval(context.Background(), "bash", "go test ./...")
+	allow, remember, err := c.requestApproval(context.Background(), "bash", "go test ./...", nil)
 	if err != nil || !allow || remember {
 		t.Fatalf("requestApproval in YOLO = (%v,%v,%v), want allow without remember", allow, remember, err)
 	}
@@ -270,7 +270,7 @@ func TestPlanApprovalIgnoresAutoApproveTools(t *testing.T) {
 	done := make(chan bool, 1)
 	errs := make(chan error, 1)
 	go func() {
-		allow, _, err := c.requestApproval(context.Background(), planApprovalTool, "")
+		allow, _, err := c.requestApproval(context.Background(), planApprovalTool, "", nil)
 		if err != nil {
 			errs <- err
 			return
@@ -318,7 +318,7 @@ func TestSetAutoApproveToolsAllowsPendingApproval(t *testing.T) {
 	done := make(chan bool, 1)
 	errs := make(chan error, 1)
 	go func() {
-		allow, _, err := c.requestApproval(context.Background(), "multi_edit", "/tmp/file")
+		allow, _, err := c.requestApproval(context.Background(), "multi_edit", "/tmp/file", nil)
 		if err != nil {
 			errs <- err
 			return
@@ -362,7 +362,7 @@ func TestSetAutoApproveToolsDoesNotDrainPendingPlanApproval(t *testing.T) {
 	done := make(chan bool, 1)
 	errs := make(chan error, 1)
 	go func() {
-		allow, _, err := c.requestApproval(context.Background(), planApprovalTool, "")
+		allow, _, err := c.requestApproval(context.Background(), planApprovalTool, "", nil)
 		if err != nil {
 			errs <- err
 			return
@@ -412,7 +412,7 @@ func TestSetModeYoloDrainsPendingApproval(t *testing.T) {
 
 	done := make(chan bool, 1)
 	go func() {
-		allow, _, _ := c.requestApproval(context.Background(), "multi_edit", "/tmp/file")
+		allow, _, _ := c.requestApproval(context.Background(), "multi_edit", "/tmp/file", nil)
 		done <- allow
 	}()
 

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1,6 +1,7 @@
 // Package hook runs user-configured shell-command hooks around the agent loop:
-// PreToolUse / PostToolUse fire around each tool call, UserPromptSubmit before a
-// turn, Stop after it. Hooks come from settings.json — a project
+// PreToolUse / PostToolUse fire around each tool call, PermissionRequest fires
+// before a tool approval prompt is shown, UserPromptSubmit before a turn, Stop
+// after it. Hooks come from settings.json — a project
 // (.reasonix/settings.json, only when the project is trusted) and a global
 // (~/.reasonix/settings.json) file. A hook's exit
 // code is its verdict: 0 = pass, 2 = block (only on the gating events), other =
@@ -31,10 +32,11 @@ import (
 type Event string
 
 const (
-	PreToolUse       Event = "PreToolUse"
-	PostToolUse      Event = "PostToolUse"
-	UserPromptSubmit Event = "UserPromptSubmit"
-	Stop             Event = "Stop"
+	PreToolUse        Event = "PreToolUse"
+	PostToolUse       Event = "PostToolUse"
+	PermissionRequest Event = "PermissionRequest"
+	UserPromptSubmit  Event = "UserPromptSubmit"
+	Stop              Event = "Stop"
 	// PostLLMCall fires after every model turn completes (streaming finishes) but
 	// before the reasoning_content is stored in the session. The hook receives the
 	// raw reasoning text in the payload; its stdout, if non-empty on exit 0,
@@ -55,7 +57,7 @@ const (
 
 // Events is every event, in a stable order — drives loading and `/hooks`.
 var Events = []Event{
-	PreToolUse, PostToolUse, UserPromptSubmit, Stop,
+	PreToolUse, PostToolUse, PermissionRequest, UserPromptSubmit, Stop,
 	PostLLMCall,
 	SessionStart, SessionEnd, SubagentStop, Notification, PreCompact,
 }
@@ -69,7 +71,7 @@ func IsBlocking(e Event) bool { return e == PreToolUse || e == UserPromptSubmit 
 // hooks gate progress, so they're tight; post/stop hooks get more room.
 func defaultTimeout(e Event) time.Duration {
 	switch e {
-	case PreToolUse, UserPromptSubmit:
+	case PreToolUse, PermissionRequest, UserPromptSubmit:
 		return 5 * time.Second
 	default:
 		return 30 * time.Second
@@ -87,8 +89,9 @@ const (
 
 // HookConfig is one hook as written in settings.json.
 type HookConfig struct {
-	// Match is an anchored regex selecting tools (Pre/PostToolUse only); "" or
-	// "*" = every tool. Anchored: "file" won't match "read_file" — use ".*file".
+	// Match is an anchored regex selecting tools (Pre/PostToolUse and
+	// PermissionRequest only); "" or "*" = every tool. Anchored: "file" won't
+	// match "read_file" — use ".*file".
 	Match string `json:"match,omitempty"`
 	// Command is the shell command to run (spawned through the platform shell).
 	Command string `json:"command"`
@@ -210,7 +213,7 @@ func appendResolved(out *[]ResolvedHook, s *Settings, scope Scope, source string
 // anchored regex; non-tool events always match. A malformed regex never fires
 // (safer than firing on everything).
 func MatchesTool(h ResolvedHook, toolName string) bool {
-	if h.Event != PreToolUse && h.Event != PostToolUse {
+	if h.Event != PreToolUse && h.Event != PostToolUse && h.Event != PermissionRequest {
 		return true
 	}
 	m := h.Match
@@ -230,6 +233,7 @@ type Payload struct {
 	Cwd           string          `json:"cwd"`
 	ToolName      string          `json:"toolName,omitempty"`
 	ToolArgs      json.RawMessage `json:"toolArgs,omitempty"`
+	Subject       string          `json:"subject,omitempty"`
 	ToolResult    string          `json:"toolResult,omitempty"`
 	Prompt        string          `json:"prompt,omitempty"`
 	LastAssistant string          `json:"lastAssistantText,omitempty"`

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -43,6 +43,19 @@ func TestLoadTrustGating(t *testing.T) {
 	}
 }
 
+func TestLoadPermissionRequestHook(t *testing.T) {
+	home := t.TempDir()
+	writeSettings(t, home, `{"hooks":{"PermissionRequest":[{"match":"bash","command":"notify"}]}}`)
+
+	got := Load(LoadOptions{HomeDir: home})
+	if len(got) != 1 {
+		t.Fatalf("hooks count = %d, want 1", len(got))
+	}
+	if got[0].Event != PermissionRequest || got[0].Match != "bash" || got[0].Command != "notify" {
+		t.Fatalf("loaded hook = %+v, want PermissionRequest/bash/notify", got[0])
+	}
+}
+
 func TestProjectDefinesHooks(t *testing.T) {
 	proj := t.TempDir()
 	if ProjectDefinesHooks(proj) {
@@ -81,6 +94,18 @@ func TestMatchesTool(t *testing.T) {
 	if MatchesTool(pre("["), "bash") {
 		t.Error("malformed regex should not fire")
 	}
+	perm := func(match string) ResolvedHook {
+		return ResolvedHook{HookConfig: HookConfig{Match: match}, Event: PermissionRequest}
+	}
+	if !MatchesTool(perm("bash"), "bash") {
+		t.Error(`PermissionRequest "bash" should match "bash"`)
+	}
+	if MatchesTool(perm("bash"), "read_file") {
+		t.Error(`PermissionRequest "bash" must not match "read_file"`)
+	}
+	if MatchesTool(perm("["), "bash") {
+		t.Error("malformed PermissionRequest regex should not fire")
+	}
 	// Non-tool events always match regardless of the match field.
 	prompt := ResolvedHook{HookConfig: HookConfig{Match: "bash"}, Event: UserPromptSubmit}
 	if !MatchesTool(prompt, "") {
@@ -98,8 +123,10 @@ func TestDecideOutcome(t *testing.T) {
 		{"pass", PreToolUse, SpawnResult{ExitCode: 0}, DecisionPass},
 		{"block-exit2", PreToolUse, SpawnResult{ExitCode: 2}, DecisionBlock},
 		{"exit2-nonblocking-warns", PostToolUse, SpawnResult{ExitCode: 2}, DecisionWarn},
+		{"permission-exit2-warns", PermissionRequest, SpawnResult{ExitCode: 2}, DecisionWarn},
 		{"other-nonzero-warns", PreToolUse, SpawnResult{ExitCode: 1}, DecisionWarn},
 		{"timeout-blocking", UserPromptSubmit, SpawnResult{TimedOut: true}, DecisionBlock},
+		{"permission-timeout-warns", PermissionRequest, SpawnResult{TimedOut: true}, DecisionWarn},
 		{"timeout-nonblocking", Stop, SpawnResult{TimedOut: true}, DecisionWarn},
 		{"spawn-error", PreToolUse, SpawnResult{SpawnErr: os.ErrNotExist}, DecisionError},
 	}
@@ -143,6 +170,23 @@ func TestRunFiltersByEventAndTool(t *testing.T) {
 	Run(context.Background(), Payload{Event: PreToolUse, ToolName: "bash"}, hooks, spawner)
 	if len(ran) != 1 || ran[0] != "a" {
 		t.Errorf("only the matching PreToolUse hook should run, got %v", ran)
+	}
+}
+
+func TestRunFiltersPermissionRequestByTool(t *testing.T) {
+	hooks := []ResolvedHook{
+		{HookConfig: HookConfig{Command: "a", Match: "bash"}, Event: PermissionRequest},
+		{HookConfig: HookConfig{Command: "b", Match: "read_file"}, Event: PermissionRequest},
+		{HookConfig: HookConfig{Command: "c"}, Event: Notification},
+	}
+	var ran []string
+	spawner := func(_ context.Context, in SpawnInput) SpawnResult {
+		ran = append(ran, in.Command)
+		return SpawnResult{ExitCode: 0}
+	}
+	Run(context.Background(), Payload{Event: PermissionRequest, ToolName: "bash"}, hooks, spawner)
+	if len(ran) != 1 || ran[0] != "a" {
+		t.Errorf("only the matching PermissionRequest hook should run, got %v", ran)
 	}
 }
 

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -75,6 +75,16 @@ func (r *Runner) PostToolUse(ctx context.Context, name string, args json.RawMess
 	r.handle(rep)
 }
 
+// PermissionRequest fires before a tool approval prompt is shown. It can't
+// block; non-pass outcomes are surfaced to the user via notify.
+func (r *Runner) PermissionRequest(ctx context.Context, name, subject string, args json.RawMessage) {
+	if !r.Enabled() {
+		return
+	}
+	rep := Run(ctx, Payload{Event: PermissionRequest, Cwd: r.cwd, ToolName: name, ToolArgs: args, Subject: subject}, r.hooks, r.spawner)
+	r.handle(rep)
+}
+
 // PromptSubmit fires before a turn starts. block=true aborts the turn; message
 // is the reason.
 func (r *Runner) PromptSubmit(ctx context.Context, prompt string, turn int) (block bool, message string) {

--- a/internal/hook/runner_test.go
+++ b/internal/hook/runner_test.go
@@ -109,6 +109,52 @@ func TestRunnerPostToolUseWarn(t *testing.T) {
 	}
 }
 
+// --- Runner.PermissionRequest ---
+
+func TestRunnerPermissionRequestPayload(t *testing.T) {
+	hooks := []ResolvedHook{
+		{HookConfig: HookConfig{Command: "notify", Match: "bash"}, Event: PermissionRequest},
+	}
+	var got Payload
+	spawner := func(_ context.Context, in SpawnInput) SpawnResult {
+		if err := json.Unmarshal([]byte(in.Stdin), &got); err != nil {
+			t.Fatalf("payload json: %v", err)
+		}
+		return SpawnResult{ExitCode: 0}
+	}
+	args := json.RawMessage(`{"command":"go test ./..."}`)
+	r := NewRunner(hooks, "/tmp", spawner, nil)
+	r.PermissionRequest(context.Background(), "bash", "go test ./...", args)
+
+	if got.Event != PermissionRequest {
+		t.Errorf("Event = %q, want PermissionRequest", got.Event)
+	}
+	if got.ToolName != "bash" {
+		t.Errorf("ToolName = %q, want bash", got.ToolName)
+	}
+	if got.Subject != "go test ./..." {
+		t.Errorf("Subject = %q, want command subject", got.Subject)
+	}
+	if string(got.ToolArgs) != string(args) {
+		t.Errorf("ToolArgs = %s, want %s", got.ToolArgs, args)
+	}
+}
+
+func TestRunnerPermissionRequestWarnOnly(t *testing.T) {
+	hooks := []ResolvedHook{
+		{HookConfig: HookConfig{Command: "warn"}, Event: PermissionRequest},
+	}
+	spawner := func(_ context.Context, in SpawnInput) SpawnResult {
+		return SpawnResult{ExitCode: 2, Stderr: "notification failed"}
+	}
+	var notified string
+	r := NewRunner(hooks, "/tmp", spawner, func(msg string) { notified = msg })
+	r.PermissionRequest(context.Background(), "bash", "go test", nil)
+	if notified == "" {
+		t.Error("PermissionRequest warn should notify")
+	}
+}
+
 // --- Runner.PromptSubmit ---
 
 func TestRunnerPromptSubmitBlock(t *testing.T) {
@@ -319,6 +365,9 @@ func TestIsBlocking(t *testing.T) {
 func TestDefaultTimeout(t *testing.T) {
 	if defaultTimeout(PreToolUse) != 5*time.Second {
 		t.Errorf("PreToolUse timeout = %v", defaultTimeout(PreToolUse))
+	}
+	if defaultTimeout(PermissionRequest) != 5*time.Second {
+		t.Errorf("PermissionRequest timeout = %v", defaultTimeout(PermissionRequest))
 	}
 	if defaultTimeout(PostToolUse) != 30*time.Second {
 		t.Errorf("PostToolUse timeout = %v", defaultTimeout(PostToolUse))

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -132,13 +132,14 @@ bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local ca
 # disabled_skills = ["review"]                  # hide from prompt, slash invocation, and skill tools
 
 # Hooks run shell commands around the loop (PreToolUse / PostToolUse /
-# UserPromptSubmit / Stop). They are NOT configured here — put them in
+# PermissionRequest / UserPromptSubmit / Stop). They are NOT configured here — put them in
 # settings.json: ~/.reasonix/settings.json (global, always on) and
 # <project>/.reasonix/settings.json (project, runs only after `/hooks trust`).
 # Exit 0 = pass, exit 2 = block (PreToolUse / UserPromptSubmit only). Example
 # ~/.reasonix/settings.json:
 #   { "hooks": {
 #       "PreToolUse":  [ { "match": "bash", "command": "my-guard.sh" } ],
+#       "PermissionRequest": [ { "match": "bash", "command": "notify-send 'approval needed'" } ],
 #       "PostToolUse": [ { "match": ".*file", "command": "gofmt -w ." } ],
 #       "Stop":        [ { "command": "notify-send 'turn done'" } ] } }
 


### PR DESCRIPTION
## Summary
- add a dedicated `PermissionRequest` hook event for real tool approval prompts
- include tool `match` support plus `subject` in the hook payload
- keep plan approvals, policy allow/session grants, and YOLO/auto approvals from firing the hook

## Validation
- `go test ./internal/hook ./internal/control ./internal/cli ./internal/boot ./internal/permission ./internal/agent`
- `go test ./...`

Closes #3661