### PR TITLE
fix(desktop): replay pending approval/ask prompts on (re)connect

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -608,6 +608,25 @@ func (a *App) ApproveTabWithScope(tabID, id string, allow, session, persist bool
 	}
 }
 
+// ReplayPendingPrompts asks every tab's controller to re-emit any approval/ask
+// prompt that is currently blocking its run loop. The frontend calls this once
+// its event subscription is live (on load/reconnect) so a session that was
+// already awaiting confirmation rebuilds its modal instead of showing a
+// "waiting" status with no way to answer — and no way to stop.
+func (a *App) ReplayPendingPrompts() {
+	a.mu.RLock()
+	tabs := make([]*WorkspaceTab, 0, len(a.tabs))
+	for _, t := range a.tabs {
+		tabs = append(tabs, t)
+	}
+	a.mu.RUnlock()
+	for _, t := range tabs {
+		if t.Ctrl != nil {
+			t.Ctrl.ReplayPendingPrompts()
+		}
+	}
+}
+
 // SetPlanMode toggles the read-only plan axis while preserving the current
 // tool-auto-approval axis.
 func (a *App) SetPlanMode(on bool) {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -100,6 +100,7 @@ export interface AppBindings {
   ApproveTabWithScope(tabID: string, id: string, allow: boolean, session: boolean, persist: boolean, scope: string): Promise<void>;
   AnswerQuestion(id: string, answers: QuestionAnswer[]): Promise<void>;
   AnswerQuestionForTab(tabID: string, id: string, answers: QuestionAnswer[]): Promise<void>;
+  ReplayPendingPrompts(): Promise<void>;
   SetPlanMode(on: boolean): Promise<void>;
   SetMode(mode: string): Promise<void>;
   SetModeForTab(tabID: string, mode: string): Promise<void>;
@@ -1244,6 +1245,7 @@ function makeMockApp(): AppBindings {
         async AnswerQuestionForTab(_tabID, id, answers) {
           await withMockTabScope(_tabID, () => this.AnswerQuestion(id, answers));
         },
+        async ReplayPendingPrompts() {},
         async ConfirmAction(req) {
           void req;
           return false;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -630,6 +630,11 @@ export function useController() {
     });
 
     void syncActiveTabFromBackend();
+    // The event subscription is live now, so ask the backend to re-emit any
+    // approval/ask prompt that was already blocking a tab before this load —
+    // otherwise a session left mid-confirmation shows "waiting" with no modal
+    // and no way to stop (#3844).
+    void app.ReplayPendingPrompts().catch(() => {});
 
     return () => { textBatch.drain(); off(); offReady(); };
   }, [dispatchTo, loadSessionDataForTab, refreshCheckpoints, syncActiveTabFromBackend]);

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -129,7 +129,7 @@ type Controller struct {
 	goalBlock   string
 	sessionPath string
 	approvals   map[string]pendingApproval
-	asks        map[string]chan []event.AskAnswer
+	asks        map[string]pendingAsk
 	granted     map[string]bool
 	nextID      int
 	// turn counts model turns this session, passed to hooks in their payload.
@@ -178,6 +178,14 @@ type pendingApproval struct {
 	subject   string
 	autoDrain bool
 	reply     chan approvalReply
+}
+
+// pendingAsk is an in-flight ask question batch. questions is retained so the
+// AskRequest can be re-emitted to a frontend that reconnected after the original
+// event (see ReplayPendingPrompts).
+type pendingAsk struct {
+	questions []event.AskQuestion
+	reply     chan []event.AskAnswer
 }
 
 const (
@@ -287,7 +295,7 @@ func New(opts Options) *Controller {
 		cpRoot:           opts.WorkspaceRoot,
 		toolApprovalMode: ToolApprovalAsk,
 		approvals:        map[string]pendingApproval{},
-		asks:             map[string]chan []event.AskAnswer{},
+		asks:             map[string]pendingAsk{},
 		granted:          map[string]bool{},
 	}
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
@@ -1125,7 +1133,7 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 	c.nextID++
 	id := strconv.Itoa(c.nextID)
 	reply := make(chan []event.AskAnswer, 1)
-	c.asks[id] = reply
+	c.asks[id] = pendingAsk{questions: questions, reply: reply}
 	c.mu.Unlock()
 
 	c.sink.Emit(event.Event{Kind: event.AskRequest, Ask: event.Ask{ID: id, Questions: questions}})
@@ -1145,11 +1153,37 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 // Unknown/expired IDs are ignored.
 func (c *Controller) AnswerQuestion(id string, answers []event.AskAnswer) {
 	c.mu.Lock()
-	reply := c.asks[id]
+	pending, ok := c.asks[id]
 	delete(c.asks, id)
 	c.mu.Unlock()
-	if reply != nil {
-		reply <- answers // buffered, never blocks
+	if ok {
+		pending.reply <- answers // buffered, never blocks
+	}
+}
+
+// ReplayPendingPrompts re-emits the ApprovalRequest / AskRequest event for every
+// prompt currently blocking the run loop. A frontend that reconnected or reloaded
+// after the original event has no way to rebuild its approval/ask modal otherwise,
+// so the blocked gate goroutine stays stuck forever while the session shows a
+// "waiting" status with no actionable prompt. promptMu serialises Ask and
+// requestApproval, so in practice at most one prompt is outstanding; the loops
+// stay general so a future concurrent prompt would still replay correctly.
+func (c *Controller) ReplayPendingPrompts() {
+	c.mu.Lock()
+	approvals := make([]event.Approval, 0, len(c.approvals))
+	for id, p := range c.approvals {
+		approvals = append(approvals, event.Approval{ID: id, Tool: p.tool, Subject: p.subject})
+	}
+	asks := make([]event.Ask, 0, len(c.asks))
+	for id, p := range c.asks {
+		asks = append(asks, event.Ask{ID: id, Questions: p.questions})
+	}
+	c.mu.Unlock()
+	for _, a := range approvals {
+		c.sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: a})
+	}
+	for _, a := range asks {
+		c.sink.Emit(event.Event{Kind: event.AskRequest, Ask: a})
 	}
 }
 

--- a/internal/control/replay_pending_test.go
+++ b/internal/control/replay_pending_test.go
@@ -1,0 +1,92 @@
+package control
+
+import (
+	"context"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+// TestReplayPendingPromptsReEmitsBlockedApproval proves a tool approval that is
+// still blocking the gate is re-emitted on demand, so a frontend that reloaded
+// after the original ApprovalRequest can rebuild its modal instead of leaving the
+// gate stuck (#3844).
+func TestReplayPendingPromptsReEmitsBlockedApproval(t *testing.T) {
+	reqs := make(chan event.Approval, 8)
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		if e.Kind == event.ApprovalRequest {
+			reqs <- e.Approval
+		}
+	})})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _, _ = gateApprover{c}.Approve(context.Background(), "bash", "go test ./...", nil)
+	}()
+
+	first := <-reqs
+	if first.Tool != "bash" || first.Subject != "go test ./..." {
+		t.Fatalf("first request = %+v, want bash / go test ./...", first)
+	}
+
+	c.ReplayPendingPrompts()
+
+	replayed := <-reqs
+	if replayed != first {
+		t.Fatalf("replayed = %+v, want identical re-emit of %+v", replayed, first)
+	}
+
+	c.Approve(first.ID, true, false, false)
+	<-done
+}
+
+// TestReplayPendingPromptsReEmitsBlockedAsk proves the same for a blocked `ask`
+// question, including its question payload (which the controller now retains).
+func TestReplayPendingPromptsReEmitsBlockedAsk(t *testing.T) {
+	asks := make(chan event.Ask, 8)
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		if e.Kind == event.AskRequest {
+			asks <- e.Ask
+		}
+	})})
+
+	questions := []event.AskQuestion{{
+		ID:      "q1",
+		Header:  "Pick",
+		Prompt:  "Which option?",
+		Options: []event.AskOption{{Label: "A"}, {Label: "B"}},
+	}}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = c.Ask(context.Background(), questions)
+	}()
+
+	first := <-asks
+	c.ReplayPendingPrompts()
+	replayed := <-asks
+
+	if replayed.ID != first.ID || len(replayed.Questions) != 1 || replayed.Questions[0].Prompt != "Which option?" {
+		t.Fatalf("replayed ask = %+v, want same id and questions as %+v", replayed, first)
+	}
+
+	c.AnswerQuestion(first.ID, []event.AskAnswer{{QuestionID: "q1", Selected: []string{"A"}}})
+	<-done
+}
+
+// TestReplayPendingPromptsNoOpWhenIdle proves replay emits nothing when no prompt
+// is outstanding, so a frontend (re)connect on an idle session is silent.
+func TestReplayPendingPromptsNoOpWhenIdle(t *testing.T) {
+	var count int
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		if e.Kind == event.ApprovalRequest || e.Kind == event.AskRequest {
+			count++
+		}
+	})})
+
+	c.ReplayPendingPrompts()
+	if count != 0 {
+		t.Fatalf("emitted %d prompts with nothing pending, want 0", count)
+	}
+}


### PR DESCRIPTION
## Problem

A session blocked awaiting a tool approval or `ask` question can deadlock with **no way out**: the project tree shows the topic as `待确认` / *waiting* but no approval modal appears, the Stop button does nothing, and only typing a new message unblocks it (#3844).

## Root cause

The "waiting" status and the approval modal come from **two independent channels**:

- **Status badge** — the backend (`desktop/tabs.go`, `topicActivityStatusFromEvent`) derives a tab's activity status from the event stream and keeps it server-side, so it survives a WebView reload/reconnect.
- **Approval modal** — driven purely by the live `ApprovalRequest`/`AskRequest` event in the in-memory frontend reducer (`useController.ts`), with **no restore path**: `MetaForTab` carries no pending prompt, and nothing re-emits it.

So if the live event is ever missed — app restart while blocked, WebView reload, event-stream reconnect, or a subscribe-after-emit race — the controller's `requestApproval`/`Ask` goroutine stays blocked, the badge still says *waiting*, but the modal never rebuilds. (Same class as the dashboard fix in #1770.)

## Fix

- `Controller.ReplayPendingPrompts()` re-emits the `ApprovalRequest`/`AskRequest` event for any prompt still blocking the run loop. `promptMu` serialises the two, so at most one is outstanding; the loops stay general regardless.
- `asks` now retains its `questions` (new `pendingAsk`) so an `AskRequest` replays faithfully.
- `App.ReplayPendingPrompts()` fans it across all tabs.
- The frontend calls it once its event subscription is live (on load/reconnect), so a session left mid-confirmation rebuilds its modal — events route back by `tabId` exactly like the originals.

## Tests

- `internal/control`: new `replay_pending_test.go` — a blocked approval and a blocked ask are both re-emitted identically on `ReplayPendingPrompts`; an idle controller emits nothing.
- `go test ./internal/control/...`, `go build ./...`, `cd desktop && go build ./... && go vet ./...` all pass.

Closes #3844