### PR TITLE
fix(desktop): keep the tray responsive when the webview is wedged

### DIFF
--- a/desktop/tray.go
+++ b/desktop/tray.go
@@ -30,7 +30,11 @@ func (a *App) startTray() {
 		systray.SetIcon(trayIconBytes)
 		systray.SetTitle("Reasonix")
 		systray.SetTooltip("Reasonix")
-		systray.SetOnTapped(func() { a.showFromTray() })
+		// Run off the systray Win32 message loop: SetOnTapped fires inside wndProc,
+		// so a blocking showFromTray (a wedged webview after sleep freezes
+		// runtime.WindowShow) would stall the whole tray's message pump (#3834). The
+		// menu items below are already decoupled via goroutines for the same reason.
+		systray.SetOnTapped(func() { go a.showFromTray() })
 		// Keep secondary/right-click on systray's native menu path.
 		systray.SetOnSecondaryTapped(nil)
 


### PR DESCRIPTION
## Problem

After minimizing to the tray, then sleeping the machine and losing the network for a while, clicking the Reasonix tray icon does nothing — the icon is still there (selectable via <kbd>Win</kbd>+<kbd>B</kbd>) but no click responds (#3834).

## Root cause

`fyne.io/systray` dispatches a left-click straight from its Win32 message loop:

```
nativeLoop → GetMessage/DispatchMessage → wndProc → WM_LBUTTONUP → systrayLeftClick() → tappedLeft()
```

`tappedLeft` is our `SetOnTapped(func(){ a.showFromTray() })`, which runs `runtime.WindowShow`. When the webview / main thread is wedged (a known post-sleep + dropped-connection state), that call blocks, so `wndProc` never returns and the tray's message pump freezes — the icon stays registered with the shell (hence selectable) but stops processing any click.

The tray **menu items** don't hit this: they're already decoupled onto goroutines (`for range item.ClickedCh`). The left-tap handler was the last callback still running on the message loop.

## Fix

Dispatch `showFromTray` on a goroutine so `wndProc` returns immediately and the pump never blocks — matching the menu-item pattern. A wedged `WindowShow` then leaks a short-lived goroutine at worst (it completes when the webview recovers) instead of freezing the whole tray.

## Test

No unit test — this is a threading fix on a third-party Win32 callback (the menu-item decoupling it mirrors is likewise untested). Verified `cd desktop && go build ./... && go vet ./...`.

Closes #3834