### PR TITLE
fix(desktop): keep workspace dock within viewport

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -10,9 +10,9 @@
     "check:css": "node scripts/check-css-syntax.mjs src/styles.css && node scripts/check-z-index-tokens.mjs src/styles.css",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts",
+    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts",
     "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
-    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts"
+    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.2",

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -84,7 +84,6 @@ const SIDEBAR_MIN_WIDTH = 264;
 const SIDEBAR_MAX_WIDTH = 300;
 const SIDEBAR_VIEWPORT_RATIO = 0.18;
 const CHAT_MIN_WIDTH = 400;
-const CHAT_DOCKED_MIN_WIDTH = 640;
 const WORKSPACE_RESIZER_WIDTH = 8;
 
 function isThemeMode(value: string): value is Theme {
@@ -94,7 +93,7 @@ const RIGHT_DOCK_TREE_DEFAULT_WIDTH = 300;
 const RIGHT_DOCK_TREE_MIN_WIDTH = 300;
 const RIGHT_DOCK_TREE_MAX_WIDTH = 560;
 const RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH = 660;
-const RIGHT_DOCK_PREVIEW_MIN_WIDTH = RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH;
+const RIGHT_DOCK_PREVIEW_MIN_WIDTH = 420;
 const RIGHT_DOCK_MAX_WIDTH = 860;
 
 type RightDockMode = "context" | "files" | "changed";
@@ -435,6 +434,7 @@ export default function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(loadSidebarCollapsed);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
   const [workspacePanelOpen, setWorkspacePanelOpen] = useState(true);
   const [rightDockTreeWidth, setRightDockTreeWidth] = useState(loadRightDockTreeWidth);
   const [rightDockPreviewWidth, setRightDockPreviewWidth] = useState(loadRightDockPreviewWidth);
@@ -569,6 +569,12 @@ export default function App() {
       setSettingsTarget("general");
     });
   }, [closeTransientOverlays]);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
   const [pendingPlanRevision, setPendingPlanRevision] = useState<string | null>(null);
   const [footerHeight, setFooterHeight] = useState(0);
   const footerHeightRef = useRef(0);
@@ -576,9 +582,13 @@ export default function App() {
   const rightDockDetailActive = rightDockMode === "context" ? contextDetailActive : workspacePreviewActive;
   const preferredWorkspacePanelWidth = rightDockDetailActive ? rightDockPreviewWidth : rightDockTreeWidth;
   const workspacePanelMinWidth = rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH;
+  const availableWorkspacePanelWidth = Math.max(
+    0,
+    viewportWidth - (sidebarCollapsed ? 0 : sidebarWidth) - CHAT_MIN_WIDTH - WORKSPACE_RESIZER_WIDTH,
+  );
 
   const resolvedWorkspacePanelWidth = workspacePanelOpen && !workspacePanelMaximized
-    ? Math.max(workspacePanelMinWidth, preferredWorkspacePanelWidth)
+    ? Math.min(Math.max(workspacePanelMinWidth, preferredWorkspacePanelWidth), availableWorkspacePanelWidth)
     : preferredWorkspacePanelWidth;
 
   const workspacePanelRenderable = workspacePanelOpen && (workspacePanelMaximized || resolvedWorkspacePanelWidth > 0);
@@ -1211,7 +1221,7 @@ export default function App() {
       closeTransientOverlays();
       setWorkspacePanelResizing(true);
       const startX = event.clientX;
-      const startDockWidth = preferredWorkspacePanelWidth;
+      const startDockWidth = workspacePanelRenderWidth;
       let nextDockWidth = startDockWidth;
       const onMove = (moveEvent: PointerEvent) => {
         const delta = moveEvent.clientX - startX;
@@ -1237,14 +1247,14 @@ export default function App() {
       window.addEventListener("pointerup", onDone);
       window.addEventListener("pointercancel", onDone);
     },
-    [closeTransientOverlays, preferredWorkspacePanelWidth, rightDockDetailActive, setSavedWorkspacePanelWidth, workspacePanelOpen],
+    [closeTransientOverlays, rightDockDetailActive, setSavedWorkspacePanelWidth, workspacePanelOpen, workspacePanelRenderWidth],
   );
 
   const resizeWorkspacePanelWithKeyboard = useCallback(
     (event: KeyboardEvent<HTMLButtonElement>) => {
       if (event.key === "ArrowLeft" || event.key === "ArrowRight") {
         event.preventDefault();
-        setSavedWorkspacePanelWidth(preferredWorkspacePanelWidth + (event.key === "ArrowLeft" ? 16 : -16));
+        setSavedWorkspacePanelWidth(workspacePanelRenderWidth + (event.key === "ArrowLeft" ? 16 : -16));
       } else if (event.key === "Home") {
         event.preventDefault();
         setSavedWorkspacePanelWidth(rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH);
@@ -1253,7 +1263,7 @@ export default function App() {
         setSavedWorkspacePanelWidth(rightDockDetailActive ? RIGHT_DOCK_MAX_WIDTH : RIGHT_DOCK_TREE_MAX_WIDTH);
       }
     },
-    [preferredWorkspacePanelWidth, rightDockDetailActive, setSavedWorkspacePanelWidth],
+    [rightDockDetailActive, setSavedWorkspacePanelWidth, workspacePanelRenderWidth],
   );
 
   const openWorkspacePanel = useCallback(
@@ -1336,7 +1346,6 @@ export default function App() {
       ({
         "--sidebar-expanded-width": `${sidebarWidth}px`,
         "--chat-min-width": `${CHAT_MIN_WIDTH}px`,
-        "--chat-docked-min-width": `${CHAT_DOCKED_MIN_WIDTH}px`,
         "--workspace-width": `${workspacePanelRenderWidth}px`,
         "--workspace-resizer-width": `${WORKSPACE_RESIZER_WIDTH}px`,
       }) as CSSProperties,

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1677,6 +1677,7 @@ export default function App() {
   const workspacePanelResetWidth = rightDockDetailActive
     ? RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH
     : defaultRightDockTreeWidth();
+  const workspacePanelAriaMinWidth = Math.min(workspacePanelMinWidth, workspacePanelRenderWidth);
   const workspacePanelMaxWidth = rightDockDetailActive ? RIGHT_DOCK_MAX_WIDTH : RIGHT_DOCK_TREE_MAX_WIDTH;
   const topicbarTitle = topicDisplayTitle(activeTab);
   const topicbarWorkspaceLabel = activeTab ? tabWorkspaceTitle(activeTab) : "";
@@ -2028,7 +2029,7 @@ export default function App() {
             role="separator"
             aria-orientation="vertical"
             aria-label={t("rightDock.resize")}
-            aria-valuemin={workspacePanelMinWidth}
+            aria-valuemin={workspacePanelAriaMinWidth}
             aria-valuemax={Math.max(workspacePanelMaxWidth, workspacePanelRenderWidth)}
             aria-valuenow={workspacePanelRenderWidth}
             onPointerDown={startWorkspacePanelResize}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1283,10 +1283,8 @@ export default function App() {
         nextMaximized = false;
         setWorkspacePanelMaximized(false);
       } else {
-        // When user explicitly opens the panel, we do NOT force maximize.
-        // If there's not enough room, the panel will open in floating mode
-        // over the chat area, preserving the chat area's minimum width
-        // and keeping the panel's close button accessible.
+        // Keep file/change views docked; the rendered dock width is clamped to
+        // the viewport so opening it reflows instead of forcing maximize.
         nextMaximized = false;
         setWorkspacePanelMaximized(false);
       }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -76,6 +76,7 @@ import {
 } from "./lib/theme";
 import { applyTextSize, DEFAULT_TEXT_SIZE, getTextSize, nextTextSize } from "./lib/textSize";
 import { useWindowStatePersistence } from "./lib/windowState";
+import { availableWorkspacePanelWidth, resolveWorkspacePanelWidth, workspacePanelAriaMinWidth } from "./lib/workspaceLayout";
 import logoWordmark from "./assets/logo-wordmark.svg";
 
 const SIDEBAR_COLLAPSED_KEY = "reasonix.sidebar.collapsed";
@@ -582,14 +583,21 @@ export default function App() {
   const rightDockDetailActive = rightDockMode === "context" ? contextDetailActive : workspacePreviewActive;
   const preferredWorkspacePanelWidth = rightDockDetailActive ? rightDockPreviewWidth : rightDockTreeWidth;
   const workspacePanelMinWidth = rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH;
-  const availableWorkspacePanelWidth = Math.max(
-    0,
-    viewportWidth - (sidebarCollapsed ? 0 : sidebarWidth) - CHAT_MIN_WIDTH - WORKSPACE_RESIZER_WIDTH,
-  );
+  const workspacePanelAvailableWidth = availableWorkspacePanelWidth({
+    viewportWidth,
+    sidebarCollapsed,
+    sidebarWidth,
+    chatMinWidth: CHAT_MIN_WIDTH,
+    resizerWidth: WORKSPACE_RESIZER_WIDTH,
+  });
 
-  const resolvedWorkspacePanelWidth = workspacePanelOpen && !workspacePanelMaximized
-    ? Math.min(Math.max(workspacePanelMinWidth, preferredWorkspacePanelWidth), availableWorkspacePanelWidth)
-    : preferredWorkspacePanelWidth;
+  const resolvedWorkspacePanelWidth = resolveWorkspacePanelWidth({
+    open: workspacePanelOpen,
+    maximized: workspacePanelMaximized,
+    preferredWidth: preferredWorkspacePanelWidth,
+    minWidth: workspacePanelMinWidth,
+    availableWidth: workspacePanelAvailableWidth,
+  });
 
   const workspacePanelRenderable = workspacePanelOpen && (workspacePanelMaximized || resolvedWorkspacePanelWidth > 0);
   const workspacePanelGridOpen = workspacePanelRenderable && !workspacePanelMaximized;
@@ -1675,7 +1683,7 @@ export default function App() {
   const workspacePanelResetWidth = rightDockDetailActive
     ? RIGHT_DOCK_PREVIEW_DEFAULT_WIDTH
     : defaultRightDockTreeWidth();
-  const workspacePanelAriaMinWidth = Math.min(workspacePanelMinWidth, workspacePanelRenderWidth);
+  const workspacePanelResizeMinWidth = workspacePanelAriaMinWidth(workspacePanelMinWidth, workspacePanelRenderWidth);
   const workspacePanelMaxWidth = rightDockDetailActive ? RIGHT_DOCK_MAX_WIDTH : RIGHT_DOCK_TREE_MAX_WIDTH;
   const topicbarTitle = topicDisplayTitle(activeTab);
   const topicbarWorkspaceLabel = activeTab ? tabWorkspaceTitle(activeTab) : "";
@@ -2027,7 +2035,7 @@ export default function App() {
             role="separator"
             aria-orientation="vertical"
             aria-label={t("rightDock.resize")}
-            aria-valuemin={workspacePanelAriaMinWidth}
+            aria-valuemin={workspacePanelResizeMinWidth}
             aria-valuemax={Math.max(workspacePanelMaxWidth, workspacePanelRenderWidth)}
             aria-valuenow={workspacePanelRenderWidth}
             onPointerDown={startWorkspacePanelResize}

--- a/desktop/frontend/src/__tests__/workspace-layout.test.ts
+++ b/desktop/frontend/src/__tests__/workspace-layout.test.ts
@@ -1,0 +1,112 @@
+// Run: tsx src/__tests__/workspace-layout.test.ts
+
+import {
+  availableWorkspacePanelWidth,
+  resolveWorkspacePanelWidth,
+  workspacePanelAriaMinWidth,
+} from "../lib/workspaceLayout";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+const CHAT_MIN_WIDTH = 400;
+const SIDEBAR_WIDTH = 264;
+const RESIZER_WIDTH = 8;
+const PREVIEW_MIN_WIDTH = 420;
+const PREVIEW_DEFAULT_WIDTH = 660;
+
+console.log("\nworkspace dock layout");
+
+const expandedAvailable = availableWorkspacePanelWidth({
+  viewportWidth: 1280,
+  sidebarCollapsed: false,
+  sidebarWidth: SIDEBAR_WIDTH,
+  chatMinWidth: CHAT_MIN_WIDTH,
+  resizerWidth: RESIZER_WIDTH,
+});
+eq(expandedAvailable, 608, "1280px viewport leaves room for an expanded-sidebar dock");
+eq(
+  resolveWorkspacePanelWidth({
+    open: true,
+    maximized: false,
+    preferredWidth: PREVIEW_DEFAULT_WIDTH,
+    minWidth: PREVIEW_MIN_WIDTH,
+    availableWidth: expandedAvailable,
+  }),
+  608,
+  "expanded-sidebar preview clamps to available width instead of overflowing",
+);
+
+const collapsedAvailable = availableWorkspacePanelWidth({
+  viewportWidth: 1280,
+  sidebarCollapsed: true,
+  sidebarWidth: SIDEBAR_WIDTH,
+  chatMinWidth: CHAT_MIN_WIDTH,
+  resizerWidth: RESIZER_WIDTH,
+});
+eq(collapsedAvailable, 872, "collapsed sidebar restores workspace room");
+eq(
+  resolveWorkspacePanelWidth({
+    open: true,
+    maximized: false,
+    preferredWidth: PREVIEW_DEFAULT_WIDTH,
+    minWidth: PREVIEW_MIN_WIDTH,
+    availableWidth: collapsedAvailable,
+  }),
+  PREVIEW_DEFAULT_WIDTH,
+  "wide-enough collapsed layout keeps the preferred preview width",
+);
+
+const narrowAvailable = availableWorkspacePanelWidth({
+  viewportWidth: 900,
+  sidebarCollapsed: false,
+  sidebarWidth: SIDEBAR_WIDTH,
+  chatMinWidth: CHAT_MIN_WIDTH,
+  resizerWidth: RESIZER_WIDTH,
+});
+const narrowRendered = resolveWorkspacePanelWidth({
+  open: true,
+  maximized: false,
+  preferredWidth: PREVIEW_DEFAULT_WIDTH,
+  minWidth: PREVIEW_MIN_WIDTH,
+  availableWidth: narrowAvailable,
+});
+eq(narrowAvailable, 228, "very narrow viewports may leave less than the nominal dock minimum");
+eq(narrowRendered, 228, "very narrow dock still stays inside the viewport");
+eq(workspacePanelAriaMinWidth(PREVIEW_MIN_WIDTH, narrowRendered), 228, "ARIA minimum follows constrained rendered width");
+
+eq(
+  resolveWorkspacePanelWidth({
+    open: false,
+    maximized: false,
+    preferredWidth: PREVIEW_DEFAULT_WIDTH,
+    minWidth: PREVIEW_MIN_WIDTH,
+    availableWidth: 0,
+  }),
+  PREVIEW_DEFAULT_WIDTH,
+  "closed panel preserves the saved preferred width",
+);
+eq(
+  resolveWorkspacePanelWidth({
+    open: true,
+    maximized: true,
+    preferredWidth: PREVIEW_DEFAULT_WIDTH,
+    minWidth: PREVIEW_MIN_WIDTH,
+    availableWidth: 228,
+  }),
+  PREVIEW_DEFAULT_WIDTH,
+  "maximized panel preserves the saved preferred width",
+);
+
+console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/workspaceLayout.ts
+++ b/desktop/frontend/src/lib/workspaceLayout.ts
@@ -1,0 +1,36 @@
+export function availableWorkspacePanelWidth({
+  viewportWidth,
+  sidebarCollapsed,
+  sidebarWidth,
+  chatMinWidth,
+  resizerWidth,
+}: {
+  viewportWidth: number;
+  sidebarCollapsed: boolean;
+  sidebarWidth: number;
+  chatMinWidth: number;
+  resizerWidth: number;
+}): number {
+  return Math.max(0, viewportWidth - (sidebarCollapsed ? 0 : sidebarWidth) - chatMinWidth - resizerWidth);
+}
+
+export function resolveWorkspacePanelWidth({
+  open,
+  maximized,
+  preferredWidth,
+  minWidth,
+  availableWidth,
+}: {
+  open: boolean;
+  maximized: boolean;
+  preferredWidth: number;
+  minWidth: number;
+  availableWidth: number;
+}): number {
+  if (!open || maximized) return preferredWidth;
+  return Math.min(Math.max(minWidth, preferredWidth), Math.max(0, availableWidth));
+}
+
+export function workspacePanelAriaMinWidth(minWidth: number, renderedWidth: number): number {
+  return Math.min(minWidth, renderedWidth);
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1440,14 +1440,13 @@ a[href] {
 .app {
   height: 100%;
   min-height: 0;
-  overflow-x: auto;
+  overflow-x: hidden;
   overflow-y: hidden;
 }
 
 .layout {
   --sidebar-width: var(--sidebar-expanded-width, clamp(264px, 18vw, 300px));
   --chat-min-width: 760px;
-  --chat-docked-min-width: 640px;
   --workspace-width: 420px;
   --workspace-resizer-width: 8px;
   --app-chrome-height: 38px;
@@ -1494,16 +1493,16 @@ a[href] {
 }
 .layout--workspace-open {
   --chrome-right-toggle-offset: calc(var(--workspace-width) + var(--workspace-resizer-width));
-  min-width: calc(var(--sidebar-width) + var(--chat-docked-min-width) + var(--workspace-resizer-width) + var(--workspace-width));
-  grid-template-columns: var(--sidebar-width) minmax(var(--chat-docked-min-width), 1fr) var(--workspace-resizer-width) var(--workspace-width);
+  min-width: 0;
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open:not(.layout--sidebar-collapsed) {
-  min-width: calc(var(--sidebar-expanded-width) + var(--chat-docked-min-width) + var(--workspace-resizer-width) + var(--workspace-width));
-  grid-template-columns: var(--sidebar-expanded-width) minmax(var(--chat-docked-min-width), 1fr) var(--workspace-resizer-width) var(--workspace-width);
+  min-width: 0;
+  grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open.layout--sidebar-collapsed {
-  min-width: calc(var(--chat-docked-min-width) + var(--workspace-resizer-width) + var(--workspace-width));
-  grid-template-columns: 0px minmax(var(--chat-docked-min-width), 1fr) var(--workspace-resizer-width) var(--workspace-width);
+  min-width: 0;
+  grid-template-columns: 0px minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
 }
 .layout--workspace-maximized {
   min-width: 0;


### PR DESCRIPTION
## Summary
- Clamp the right Workspace dock to available viewport width so opening file previews no longer pushes content past the window edge.
- Replace the docked layout's summed min-width with shrinkable grid tracks and keep Workspace resize metadata valid under constrained widths.
- Clarify the Workspace open behavior comment to match the viewport-clamped dock strategy.

## Test plan
- `pnpm --dir desktop/frontend run build` after `wails generate module`
- Manual macOS Wails GUI acceptance at normal window sizes, including Workspace file preview with the sidebar collapsed and expanded

## Notes
- Fixes #3863

Made with [Cursor](https://cursor.com)