### PR TITLE
fix(site): serve from custom domain reasonix.io

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,8 +1,7 @@
 import { defineConfig } from 'astro/config';
 
-// Served from GitHub Pages under the repo subpath.
+// Served from the custom domain reasonix.io at the site root.
 export default defineConfig({
-  site: 'https://esengine.github.io',
-  base: '/DeepSeek-Reasonix',
+  site: 'https://reasonix.io',
   build: { assets: 'static' },
 });

--- a/site/src/layouts/Base.astro
+++ b/site/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const { title, description } = Astro.props;
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
 ---
 <!doctype html>
 <html lang="en">
@@ -10,12 +11,12 @@ const { title, description } = Astro.props;
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>{title}</title>
   <meta name="description" content={description} />
-  <link rel="canonical" href="https://esengine.github.io/DeepSeek-Reasonix/" />
+  <link rel="canonical" href={canonical} />
   <link rel="icon" href={`${base}/favicon.svg`} type="image/svg+xml" />
   <meta property="og:type" content="website" />
   <meta property="og:title" content={title} />
   <meta property="og:description" content={description} />
-  <meta property="og:url" content="https://esengine.github.io/DeepSeek-Reasonix/" />
+  <meta property="og:url" content={canonical} />
   <meta name="twitter:card" content="summary_large_image" />
 </head>
 <body>


### PR DESCRIPTION
## What

The landing site is now served from the apex custom domain **reasonix.io** at the site root, not from the GitHub Pages repo subpath (`esengine.github.io/DeepSeek-Reasonix/`).

## Why

After pointing `reasonix.io` at GitHub Pages, the site rendered unstyled: the build still carried the Astro `base: '/DeepSeek-Reasonix'`, so every asset URL was prefixed (e.g. the stylesheet resolved to `/DeepSeek-Reasonix/static/index.*.css`) and 404'd at the domain root. `canonical` and `og:url` were also hardcoded to the old `esengine.github.io/DeepSeek-Reasonix/` URL.

## Changes

- `site/astro.config.mjs`: set `site: 'https://reasonix.io'`, drop `base: '/DeepSeek-Reasonix'`.
- `site/src/layouts/Base.astro`: derive `canonical`/`og:url` from `Astro.site` instead of hardcoding the URL, so they won't go stale on a future domain change.

## Verification

Local `npm run build` output now resolves to root-relative paths (stylesheet `/static/index.*.css`, favicon `/favicon.svg`, canonical/og:url `https://reasonix.io/`). No residual `/DeepSeek-Reasonix` prefixes remain in the build output.

Note: this is independent of the pending HTTPS certificate issuance for the custom domain.
