### PR TITLE
fix(site): use relative base so CSS loads on custom domain

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -1,8 +1,14 @@
 import { defineConfig } from 'astro/config';
 
-// Served from GitHub Pages under the repo subpath.
+// `site` is the canonical origin for OG / canonical tags.
+// `base: './'` emits **relative** asset paths so the same build works at
+//   - https://esengine.github.io/DeepSeek-Reasonix/   (GitHub Pages project URL)
+//   - http://reasonix.io/                             (custom domain, served from root)
+// The previous `base: '/DeepSeek-Reasonix'` baked that prefix into every
+// emitted URL, so the custom domain rendered unstyled (CSS 404'd).
+// Relative URLs are deploy-anywhere and add zero cost on the github.io path.
 export default defineConfig({
   site: 'https://esengine.github.io',
-  base: '/DeepSeek-Reasonix',
+  base: './',
   build: { assets: 'static' },
 });


### PR DESCRIPTION
The hardcoded /DeepSeek-Reasonix base prefix caused asset 404s on
reasonix.io. Switch to relative paths so one build works on both
GitHub Pages and the custom domain.

Co-authored-by: Cursor <cursoragent@cursor.com>