### PR TITLE
Handle slash-prefixed paths as prompts / 将斜杠开头路径作为普通提示处理

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -783,6 +783,14 @@ func (c *Controller) submit(input, display string) {
 			c.runRefTurn(ref, display)
 			return
 		}
+		if ref, ok := SlashPathLineRef(trimmed, c.cpRoot); ok {
+			c.runRefTurnWithRefs(input, ref, display)
+			return
+		}
+		if SlashPathLikeLine(trimmed) {
+			c.runRefTurn(input, display)
+			return
+		}
 		// Read-only management verbs (/model /memory /skills /hooks /mcp) emit a
 		// listing Notice, so Submit-based frontends (desktop, HTTP) get them with
 		// no extra wiring. (The chat TUI handles these itself with richer output.)
@@ -990,8 +998,15 @@ func (c *Controller) RunShell(command string) {
 // runRefTurn resolves a line's @references into a context block and starts a
 // turn with it prepended (or the raw line when nothing resolved).
 func (c *Controller) runRefTurn(input, display string) {
+	c.runRefTurnWithRefs(input, input, display)
+}
+
+// runRefTurnWithRefs resolves references from refLine while preserving input as
+// the user's actual prompt text. This lets compiler diagnostics such as
+// "/path/File.kt:12: error" attach @/path/File.kt without rewriting the error.
+func (c *Controller) runRefTurnWithRefs(input, refLine, display string) {
 	c.runGuarded(func(ctx context.Context) error {
-		block, errs := c.ResolveRefs(ctx, input)
+		block, errs := c.ResolveRefs(ctx, refLine)
 		for _, e := range errs {
 			c.notice(e)
 		}

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -221,6 +222,90 @@ func TestSubmitHashNumberStartsTurn(t *testing.T) {
 
 	if len(runner.inputs) != 1 || runner.inputs[0] != input {
 		t.Fatalf("#number prompt should start a model turn, inputs=%q", runner.inputs)
+	}
+}
+
+func TestSubmitSlashPathDiagnosticStartsTurnWithFileContext(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX absolute file path context is covered on POSIX runners")
+	}
+	dir := t.TempDir()
+	file := filepath.Join(dir, "app", "src", "main", "Foo.kt")
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("fun broken() = missingSymbol\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runner := &fakeTurnRunner{}
+	events := make(chan event.Event, 4)
+	c := New(Options{
+		AutoPlan: "off",
+		Runner:   runner,
+		Sink: event.FuncSink(func(e event.Event) {
+			events <- e
+		}),
+	})
+
+	input := file + ":12:13: error: unresolved reference: missingSymbol"
+	c.Submit(input)
+	waitForTurnDone(t, events)
+
+	if len(runner.inputs) != 1 {
+		t.Fatalf("slash path diagnostic should start a model turn, inputs=%q", runner.inputs)
+	}
+	got := runner.inputs[0]
+	if !strings.Contains(got, "Referenced context:") || !strings.Contains(got, "fun broken() = missingSymbol") {
+		t.Fatalf("slash path diagnostic should attach file context, got %q", got)
+	}
+	if !strings.Contains(got, input) {
+		t.Fatalf("slash path diagnostic should preserve original error text, got %q", got)
+	}
+}
+
+func TestSubmitMissingSlashPathDiagnosticStartsTurn(t *testing.T) {
+	runner := &fakeTurnRunner{}
+	events := make(chan event.Event, 4)
+	c := New(Options{
+		AutoPlan: "off",
+		Runner:   runner,
+		Sink: event.FuncSink(func(e event.Event) {
+			events <- e
+		}),
+	})
+
+	input := "/missing/Foo.kt:12: error: file no longer exists"
+	c.Submit(input)
+	waitForTurnDone(t, events)
+
+	if len(runner.inputs) != 1 || runner.inputs[0] != input {
+		t.Fatalf("missing slash path diagnostic should start a raw model turn, inputs=%q", runner.inputs)
+	}
+}
+
+func TestSubmitUnknownSlashCommandStillReportsNotice(t *testing.T) {
+	runner := &fakeTurnRunner{}
+	events := make(chan event.Event, 4)
+	c := New(Options{
+		AutoPlan: "off",
+		Runner:   runner,
+		Sink: event.FuncSink(func(e event.Event) {
+			events <- e
+		}),
+	})
+
+	c.Submit("/definitely-not-a-command")
+
+	if len(runner.inputs) != 0 {
+		t.Fatalf("unknown slash command should not start a model turn, inputs=%q", runner.inputs)
+	}
+	select {
+	case e := <-events:
+		if e.Kind != event.Notice || !strings.Contains(e.Text, "unknown command: /definitely-not-a-command") {
+			t.Fatalf("event = %+v, want unknown-command notice", e)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for unknown-command notice")
 	}
 }
 

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -52,6 +52,7 @@ type ref struct {
 
 // refTokenRe matches an @reference token: '@' then a run of non-space chars.
 var refTokenRe = regexp.MustCompile(`@([^\s]+)`)
+var pathLocationSuffixRe = regexp.MustCompile(`:\d+(?::\d+)?:?$`)
 
 // parseRefTokens extracts the deduped, punctuation-trimmed tokens following '@'
 // in a line. Pure: classification (server? file?) happens in classifyRef.
@@ -207,6 +208,77 @@ func FileRefLine(line string) (string, bool) {
 		return "", false
 	}
 	return "@" + p, true
+}
+
+// SlashPathLineRef reports whether a slash-prefixed line starts with a local file
+// path, including common compiler-location suffixes like ":12" or ":12:34".
+// It returns an @reference for the file so diagnostics that begin with an
+// absolute path can keep their original text while also attaching file context.
+func SlashPathLineRef(line, baseDir string) (string, bool) {
+	token, ok := leadingSlashPathToken(line)
+	if !ok {
+		return "", false
+	}
+	for _, p := range pathTokenCandidates(token) {
+		if fileRefExists(p, baseDir) {
+			return "@" + p, true
+		}
+	}
+	return "", false
+}
+
+// SlashPathLikeLine reports whether a slash-prefixed line looks like a POSIX
+// absolute path rather than a slash command. It intentionally stays conservative:
+// unknown "/foo" remains an unknown command, while "/foo/bar..." is sent as
+// ordinary prompt text even if the path no longer exists.
+func SlashPathLikeLine(line string) bool {
+	token, ok := leadingSlashPathToken(line)
+	if !ok {
+		return false
+	}
+	for _, p := range pathTokenCandidates(token) {
+		if strings.Contains(p[1:], "/") {
+			return true
+		}
+	}
+	return false
+}
+
+func leadingSlashPathToken(line string) (string, bool) {
+	fields := strings.Fields(strings.TrimSpace(line))
+	if len(fields) == 0 {
+		return "", false
+	}
+	token := strings.Trim(fields[0], `"'`)
+	if !strings.HasPrefix(token, "/") || strings.HasPrefix(token, "//") {
+		return "", false
+	}
+	return token, true
+}
+
+func pathTokenCandidates(token string) []string {
+	token = strings.TrimRight(strings.Trim(token, `"'`), ".,;!?)]}")
+	if token == "" {
+		return nil
+	}
+	candidates := []string{token}
+	if stripped := pathLocationSuffixRe.ReplaceAllString(token, ""); stripped != token {
+		candidates = append(candidates, stripped)
+	}
+	return candidates
+}
+
+func fileRefExists(path, baseDir string) bool {
+	statPath := path
+	if baseDir != "" {
+		absPath, _, ok := resolveAbsRef(path, baseDir)
+		if !ok {
+			return false
+		}
+		statPath = absPath
+	}
+	info, err := os.Stat(statPath)
+	return err == nil && !info.IsDir()
 }
 
 // ResolveRefs resolves the @references in a line into a single tagged context


### PR DESCRIPTION
## Summary

- Route slash-prefixed path diagnostics through the normal prompt path instead of treating them as unknown slash commands.
- Resolve existing file paths with compiler line/column suffixes as file references while preserving the original diagnostic text.
- Keep true unknown single-segment slash commands on the existing unknown-command notice path.

## Tests

- go test ./internal/control
- go test ./...
- (cd desktop && go test ./...)

Fixes #3884
Fixes #3798