### PR TITLE
[codex] Add desktop update check controls / 增加桌面更新检查控制

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -52,6 +52,7 @@ import {
   type ProjectNode,
   type SessionMeta,
   type SettingsTab,
+  type SettingsView,
   type TabMeta,
   type ToolApprovalMode,
 } from "./lib/types";
@@ -428,6 +429,7 @@ export default function App() {
   // clearing the key mid-session is the Settings panel's job, not the gate's.
   const [needsOnboarding, setNeedsOnboarding] = useState<boolean | null>(null);
   const [settingsTarget, setSettingsTarget] = useState<SettingsTab | null>(null);
+  const [startupUpdateChecksEnabled, setStartupUpdateChecksEnabled] = useState<boolean | null>(null);
   const [histView, setHistView] = useState<HistoryViewState | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteSessions, setPaletteSessions] = useState<SessionMeta[]>([]);
@@ -537,6 +539,17 @@ export default function App() {
     };
   }, []);
 
+  const applyDesktopPreferences = useCallback(
+    (settings: Pick<SettingsView, "desktopTheme" | "desktopThemeStyle" | "desktopLanguage" | "checkUpdates">) => {
+      const nextTheme = normalizeThemePreference(settings.desktopTheme);
+      const nextStyle = normalizeThemeStyleForTheme(settings.desktopThemeStyle, nextTheme);
+      applyTheme(nextTheme, nextStyle, { persist: false });
+      setLocalePref(normalizeLangPref(settings.desktopLanguage));
+      setStartupUpdateChecksEnabled(settings.checkUpdates !== false);
+    },
+    [setLocalePref],
+  );
+
   useEffect(() => {
     let cancelled = false;
     const syncDesktopPreferences = async () => {
@@ -549,18 +562,16 @@ export default function App() {
       }
       const settings = await app.Settings();
       if (cancelled) return;
-      const nextTheme = normalizeThemePreference(settings.desktopTheme);
-      const nextStyle = normalizeThemeStyleForTheme(settings.desktopThemeStyle, nextTheme);
-      applyTheme(nextTheme, nextStyle, { persist: false });
-      setLocalePref(normalizeLangPref(settings.desktopLanguage));
+      applyDesktopPreferences(settings);
     };
     void syncDesktopPreferences().catch((e) => {
       console.warn("desktop preferences sync failed", e);
+      setStartupUpdateChecksEnabled(true);
     });
     return () => {
       cancelled = true;
     };
-  }, [setLocalePref]);
+  }, [applyDesktopPreferences]);
 
   // Open settings when the native menu item (CmdOrCtrl+,) is activated.
   useEffect(() => {
@@ -1925,7 +1936,7 @@ export default function App() {
             <div className="banner banner--error">{t("topbar.startupError", { msg: state.meta.startupErr })}</div>
           )}
 
-          <UpdateBanner />
+          <UpdateBanner enabled={startupUpdateChecksEnabled === true} />
 
           <main className="main">
             {state.meta?.ready === false && !state.meta?.startupErr ? (
@@ -2150,7 +2161,12 @@ export default function App() {
         <SettingsPanel
           initialTab={settingsTarget}
           onClose={() => setSettingsTarget(null)}
-          onChanged={() => void refreshMeta()}
+          onChanged={() => {
+            void refreshMeta();
+            void app.Settings()
+              .then(applyDesktopPreferences)
+              .catch((e) => console.warn("desktop preferences refresh failed", e));
+          }}
         />
       )}
 

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -161,7 +161,16 @@ export function SettingsPanel({ onClose, onChanged, initialTab }: { onClose: () 
                     />
                   </SettingsPageShell>
                 )}
-                {tab === "updates" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><UpdatesSection configPath={s.configPath} /></SettingsPageShell>}
+                {tab === "updates" && s && (
+                  <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}>
+                    <UpdatesSection
+                      configPath={s.configPath}
+                      checkUpdates={s.checkUpdates}
+                      settingsBusy={busy}
+                      applySettings={apply}
+                    />
+                  </SettingsPageShell>
+                )}
               </>
             )}
           </main>
@@ -227,22 +236,40 @@ function SettingsField({
   label,
   hint,
   children,
+  className,
   stacked = false,
 }: {
   label: ReactNode;
   hint?: ReactNode;
   children: ReactNode;
+  className?: string;
   stacked?: boolean;
 }) {
   return (
-    <div className={`settings-field${stacked ? " settings-field--stacked" : ""}`}>
+    <div className={`settings-field${stacked ? " settings-field--stacked" : ""}${className ? ` ${className}` : ""}`}>
       <div className="settings-field__copy">
         <div className="settings-field__label">{label}</div>
-        {hint && <div className="settings-field__hint">{hint}</div>}
+        {hint && (
+          <div className="settings-field__hint">
+            <SettingsHint hint={hint} />
+          </div>
+        )}
       </div>
       <div className="settings-field__control">{children}</div>
     </div>
   );
+}
+
+function SettingsHint({ hint }: { hint: ReactNode }) {
+  if (typeof hint === "string" || typeof hint === "number") {
+    const label = String(hint);
+    return (
+      <Tooltip label={label} fill block className="settings-field__hint-tooltip">
+        <span className="settings-field__hint-line">{label}</span>
+      </Tooltip>
+    );
+  }
+  return hint;
 }
 
 function settingsTabPageTitle(id: SettingsTab, t: ReturnType<typeof useT>): string {
@@ -540,6 +567,7 @@ function normalizeSettingsView(view: SettingsView | null | undefined): SettingsV
     desktopTheme: normalizeThemePreference(view.desktopTheme),
     desktopThemeStyle: normalizeThemeStyleForTheme(view.desktopThemeStyle, normalizeThemePreference(view.desktopTheme)),
     closeBehavior: normalizeCloseBehavior(view.closeBehavior),
+    checkUpdates: view.checkUpdates !== false,
   };
 }
 
@@ -3379,24 +3407,46 @@ function fontFamilyName(font: FontFamily, t: ReturnType<typeof useT>): string {
 const MB = 1024 * 1024;
 const mb = (n: number) => (n / MB).toFixed(1);
 
-// UpdatesSection is the manual side of the auto-updater: it shows the running
-// version and a Check button, then the same state machine the top banner uses
-// (useUpdater) — available → install/download, with progress and errors inline.
-function UpdatesSection({ configPath }: { configPath: string }) {
+// UpdatesSection is the manual side of the auto-updater: it shows the startup
+// check preference, running version, and a Check button, then the same state
+// machine the top banner uses (useUpdater) — available → install/download, with
+// progress and errors inline.
+function UpdatesSection({
+  configPath,
+  checkUpdates,
+  settingsBusy,
+  applySettings,
+}: {
+  configPath: string;
+  checkUpdates: boolean;
+  settingsBusy: boolean;
+  applySettings: (fn: () => Promise<void>) => Promise<void>;
+}) {
   const t = useT();
-  const { status, check, apply } = useUpdater();
+  const { status, check, apply: applyUpdate } = useUpdater();
   const [version, setVersion] = useState("");
   useEffect(() => {
     app.Version().then(setVersion).catch(() => {});
   }, []);
 
-  const busy =
+  const updaterBusy =
     status.kind === "checking" || status.kind === "downloading" || status.kind === "verifying" || status.kind === "applying";
 
   return (
     <SettingsSection title={t("updater.title")}>
+      <SettingsField
+        className="settings-field--wide-copy"
+        label={t("updater.autoCheckLabel")}
+        hint={t("updater.autoCheckHint")}
+      >
+        <ToggleSegment
+          value={checkUpdates}
+          disabled={settingsBusy}
+          onChange={(enabled) => void applySettings(() => app.SetDesktopCheckUpdates(enabled))}
+        />
+      </SettingsField>
       <SettingsField label={t("updater.currentVersion", { v: version || "…" })}>
-        <button className="btn btn--small" disabled={busy} onClick={() => void check()}>
+        <button className="btn btn--small" disabled={updaterBusy} onClick={() => void check()}>
           {status.kind === "checking" ? t("updater.checking") : t("updater.checkButton")}
         </button>
       </SettingsField>
@@ -3404,7 +3454,7 @@ function UpdatesSection({ configPath }: { configPath: string }) {
       {status.kind === "available" && (
         <>
           <SettingsField label={t("updater.available", { v: status.info.latest })}>
-            <button className="btn btn--primary btn--small" onClick={() => apply(status.info)}>
+            <button className="btn btn--primary btn--small" onClick={() => applyUpdate(status.info)}>
               {status.info.canSelfUpdate ? t("updater.installNow") : t("updater.goToDownload")}
             </button>
           </SettingsField>

--- a/desktop/frontend/src/components/UpdateBanner.tsx
+++ b/desktop/frontend/src/components/UpdateBanner.tsx
@@ -9,16 +9,19 @@ const mb = (n: number) => (n / MB).toFixed(1);
 // a dismissible top banner that drives the download → verify → install flow (or, on
 // macOS, links out to the download page). It renders nothing while idle, checking,
 // or already current — a quiet auto-check that only surfaces when actionable. A
-// failed check is silent here too (network blips shouldn't nag); the Settings panel
-// is where a manual check shows errors.
-export function UpdateBanner() {
+// failed check can be dismissed here (network blips shouldn't pin the UI); the
+// Settings panel is where a manual check shows errors inline.
+export function UpdateBanner({ enabled = true }: { enabled?: boolean }) {
   const t = useT();
-  const { status, check, apply } = useUpdater();
+  const { status, check, apply, reset } = useUpdater();
   const [dismissed, setDismissed] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!enabled) return;
     void check();
-  }, [check]);
+  }, [check, enabled]);
+
+  if (!enabled) return null;
 
   switch (status.kind) {
     case "available": {
@@ -57,12 +60,18 @@ export function UpdateBanner() {
     case "done":
       return <div className="banner banner--update">{t("updater.done")}</div>;
     case "error":
+      const failedMessage = t("updater.failed", { msg: status.message });
       return (
-        <div className="banner banner--error">
-          <span className="banner__msg">{t("updater.failed", { msg: status.message })}</span>
+        <div className="banner banner--update banner--error banner--actionable">
+          <span className="banner__msg" title={failedMessage}>
+            {failedMessage}
+          </span>
           <span className="banner__spacer" />
-          <button className="btn btn--small" onClick={() => void check()}>
+          <button className="btn btn--small btn--primary" onClick={() => void check()}>
             {t("updater.retry")}
+          </button>
+          <button className="btn btn--small" onClick={reset}>
+            {t("updater.dismiss")}
           </button>
         </div>
       );

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -216,6 +216,7 @@ export interface AppBindings {
   SetCloseBehavior(mode: string): Promise<void>;
   SetDesktopLanguage(lang: string): Promise<void>;
   SetDesktopAppearance(theme: string, style: string): Promise<void>;
+  SetDesktopCheckUpdates(enabled: boolean): Promise<void>;
   MigrateDesktopPreferences(language: string, theme: string, style: string): Promise<void>;
   SetAgentParams(temperature: number, maxSteps: number, plannerMaxSteps: number, systemPrompt: string): Promise<void>;
   SetTrayLocale(locale: "en" | "zh"): Promise<void>;
@@ -676,6 +677,7 @@ function makeMockApp(): AppBindings {
     desktopTheme: "light",
     desktopThemeStyle: "graphite",
     closeBehavior: "background",
+    checkUpdates: true,
     configPath: "~/projects/reasonix/reasonix.toml",
     providerKinds: ["openai"],
     autoApproveTools: false,
@@ -2013,6 +2015,9 @@ function makeMockApp(): AppBindings {
         async SetDesktopAppearance(theme: string, style: string) {
           settings.desktopTheme = theme === "auto" || theme === "light" ? theme : "dark";
           settings.desktopThemeStyle = style;
+        },
+        async SetDesktopCheckUpdates(enabled: boolean) {
+          settings.checkUpdates = enabled;
         },
         async MigrateDesktopPreferences(language: string, theme: string, style: string) {
           if (!settings.desktopLanguage) settings.desktopLanguage = language === "en" || language === "zh" ? language : "";

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -723,6 +723,7 @@ export interface SettingsView {
   desktopTheme: string; // "auto" | "dark" | "light"
   desktopThemeStyle: string;
   closeBehavior: string; // "background" | "quit"
+  checkUpdates: boolean; // check for new versions on startup
   configPath: string;
   providerKinds: string[]; // provider implementations the kernel registered (for the kind picker)
   autoApproveTools: boolean;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1012,6 +1012,8 @@ export const en = {
 
   // software update
   "updater.title": "Software update",
+  "updater.autoCheckLabel": "Check for updates on startup",
+  "updater.autoCheckHint": "When off, Reasonix won't check automatically when it opens. You can still check manually here.",
   "updater.currentVersion": "Current version: {v}",
   "updater.checkButton": "Check for updates",
   "updater.checking": "Checking for updates…",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1014,6 +1014,8 @@ export const zh: Record<DictKey, string> = {
 
   // 软件更新
   "updater.title": "软件更新",
+  "updater.autoCheckLabel": "启动时检测新版本",
+  "updater.autoCheckHint": "关闭后，Reasonix 打开时不会自动检查更新；你仍可在此页手动检查。",
   "updater.currentVersion": "当前版本：{v}",
   "updater.checkButton": "检查更新",
   "updater.checking": "正在检查更新…",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1939,8 +1939,24 @@ a[href] {
   color: var(--fg);
   border-bottom: 1px solid var(--border-soft);
 }
+.banner--update.banner--error {
+  background: var(--del-bg);
+  color: var(--err);
+  border-bottom-color: color-mix(in srgb, var(--err) 24%, var(--border-soft));
+}
+.banner--actionable {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
 .banner__msg {
+  min-width: 0;
   font-weight: 500;
+}
+.banner--actionable .banner__msg {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .banner__hint {
   color: var(--fg-dim);
@@ -1948,6 +1964,9 @@ a[href] {
 }
 .banner__spacer {
   flex: 1 1 auto;
+}
+.banner--actionable .btn {
+  flex: 0 0 auto;
 }
 .banner__progress {
   width: 180px;
@@ -8542,6 +8561,10 @@ a[href] {
   align-items: start;
 }
 
+.settings-field--wide-copy {
+  grid-template-columns: minmax(0, 1fr) max-content;
+}
+
 .settings-field__copy {
   min-width: 0;
 }
@@ -8558,6 +8581,18 @@ a[href] {
   color: var(--fg-dim);
   font-size: var(--text-2xs);
   line-height: 1.45;
+}
+
+.settings-field__hint-tooltip {
+  max-width: 100%;
+}
+
+.settings-field__hint-line {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .settings-field__control {
@@ -15693,6 +15728,11 @@ a[href] {
   animation: graphite-drop-in var(--dur-slow) var(--ease-out) both;
 }
 
+:root[data-theme-style="graphite"] .banner--update.banner--error {
+  border-color: color-mix(in srgb, var(--err) 28%, var(--app-graphite-hairline-strong));
+  background: linear-gradient(120deg, color-mix(in srgb, var(--err) 10%, var(--chat-bg)), color-mix(in srgb, var(--chat-bg) 94%, var(--bg-elev)));
+}
+
 :root[data-theme-style="graphite"] .banner--update .btn--primary {
   border: 0;
   border-radius: 7px;
@@ -15702,9 +15742,17 @@ a[href] {
 }
 
 :root[data-theme-style="graphite"] .banner--update .btn:not(.btn--primary) {
-  border: 0;
+  border: 1px solid color-mix(in srgb, var(--fg-faint) 28%, var(--border));
+  border-radius: 7px;
   color: var(--fg-dim);
-  background: transparent;
+  background: color-mix(in srgb, var(--bg-elev) 74%, transparent);
+}
+
+:root[data-theme-style="graphite"] .banner--update .btn:not(.btn--primary):hover:not(:disabled),
+:root[data-theme-style="graphite"] .banner--update .btn:not(.btn--primary):focus-visible:not(:disabled) {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg-faint) 40%, var(--border));
+  background: var(--bg-elev-2);
 }
 
 :root[data-theme-style="graphite"] .transcript {

--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 const devPort = Number(process.env.REASONIX_DESKTOP_VITE_PORT || "5173");
+const configDir = dirname(fileURLToPath(import.meta.url));
 
 // On macOS ≤ 12 (Safari 15 WebKit) a crossorigin module/stylesheet fetched over the
 // wails:// scheme is CORS-blocked (no Access-Control-Allow-Origin from the handler),
@@ -14,10 +18,25 @@ function stripCrossorigin(): Plugin {
   };
 }
 
+// Vite must empty dist before production builds so stale hashed assets disappear.
+// Recreate the tracked placeholder afterwards so git status stays clean and
+// Go's //go:embed all:frontend/dist still works on a fresh checkout.
+function keepDistPlaceholder(): Plugin {
+  return {
+    name: "keep-dist-placeholder",
+    apply: "build",
+    closeBundle: async () => {
+      const distDir = resolve(configDir, "dist");
+      await mkdir(distDir, { recursive: true });
+      await writeFile(resolve(distDir, ".gitkeep"), "\n");
+    },
+  };
+}
+
 // base: "./" so built asset URLs are relative. Wails serves the embedded dist from
 // the app root over the wails:// scheme, where absolute "/assets/..." URLs 404.
 export default defineConfig({
-  plugins: [react(), stripCrossorigin()],
+  plugins: [react(), stripCrossorigin(), keepDistPlaceholder()],
   base: "./",
   build: {
     outDir: "dist",

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -147,6 +147,7 @@ type SettingsView struct {
 	DesktopTheme      string          `json:"desktopTheme"`
 	DesktopThemeStyle string          `json:"desktopThemeStyle"`
 	CloseBehavior     string          `json:"closeBehavior"`
+	CheckUpdates      bool            `json:"checkUpdates"`
 	ConfigPath        string          `json:"configPath"`
 	// ProviderKinds lists the provider implementations the kernel actually
 	// registered (provider.Kinds()), so the editor's "kind" picker offers only
@@ -323,6 +324,7 @@ func (a *App) Settings() SettingsView {
 			DesktopTheme:      "light",
 			DesktopThemeStyle: "graphite",
 			CloseBehavior:     "background",
+			CheckUpdates:      true,
 		}
 	}
 	ctrl := a.activeCtrl()
@@ -366,6 +368,7 @@ func (a *App) Settings() SettingsView {
 		DesktopTheme:      cfg.DesktopTheme(),
 		DesktopThemeStyle: cfg.DesktopThemeStyle(),
 		CloseBehavior:     cfg.DesktopCloseBehavior(),
+		CheckUpdates:      cfg.DesktopCheckUpdates(),
 		ConfigPath:        cfgPath,
 		ProviderKinds:     nonNil(provider.Kinds()),
 		AutoApproveTools:  ctrl != nil && ctrl.AutoApproveTools(),
@@ -1287,6 +1290,12 @@ func (a *App) SetTrayLocale(locale string) error {
 // rebuild the active controller and must stay out of provider-visible requests.
 func (a *App) SetDesktopAppearance(theme, style string) error {
 	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopAppearance(theme, style) })
+}
+
+// SetDesktopCheckUpdates updates only the desktop startup update-check
+// preference. Manual checks in Settings are unaffected.
+func (a *App) SetDesktopCheckUpdates(enabled bool) error {
+	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopCheckUpdates(enabled) })
 }
 
 // MigrateDesktopPreferences imports old browser-local desktop preferences into

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -149,3 +149,26 @@ func TestSetAgentParamsPersistsStepLimitsToUserConfig(t *testing.T) {
 		t.Fatalf("saved config did not preserve other agent params: %+v", cfg.Agent)
 	}
 }
+
+func TestSetDesktopCheckUpdatesPersistsToUserConfig(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	app := NewApp()
+	if !app.Settings().CheckUpdates {
+		t.Fatal("Settings().CheckUpdates default = false, want true")
+	}
+	if err := app.SetDesktopCheckUpdates(false); err != nil {
+		t.Fatalf("SetDesktopCheckUpdates: %v", err)
+	}
+	view := app.Settings()
+	if view.CheckUpdates {
+		t.Fatal("Settings().CheckUpdates = true, want false")
+	}
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if cfg.Desktop.CheckUpdates == nil || *cfg.Desktop.CheckUpdates {
+		t.Fatalf("desktop.check_updates = %+v, want false", cfg.Desktop.CheckUpdates)
+	}
+	if cfg.DesktopCheckUpdates() {
+		t.Fatal("DesktopCheckUpdates() = true, want false")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ type DesktopConfig struct {
 	Theme          string   `toml:"theme"`           // auto|dark|light; empty resolves to dark
 	ThemeStyle     string   `toml:"theme_style"`     // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 	CloseBehavior  string   `toml:"close_behavior"`  // quit|background; desktop window close behavior
+	CheckUpdates   *bool    `toml:"check_updates"`   // startup update checks; nil keeps the default enabled
 	ProviderAccess []string `toml:"provider_access"` // desktop-only list of provider entries shown in Settings > Model > Access
 }
 
@@ -170,6 +171,15 @@ func (c *Config) DesktopCloseBehavior() string {
 // UICloseBehavior is the legacy name for DesktopCloseBehavior.
 func (c *Config) UICloseBehavior() string {
 	return c.DesktopCloseBehavior()
+}
+
+// DesktopCheckUpdates reports whether the desktop should check for updates on
+// startup. Missing configs default to true so existing users keep update notices.
+func (c *Config) DesktopCheckUpdates() bool {
+	if c == nil || c.Desktop.CheckUpdates == nil {
+		return true
+	}
+	return *c.Desktop.CheckUpdates
 }
 
 // LSPConfig governs the optional Language Server Protocol tools (lsp_definition,

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -178,6 +178,13 @@ func (c *Config) SetDesktopCloseBehavior(mode string) error {
 	return nil
 }
 
+// SetDesktopCheckUpdates sets whether the desktop app checks for updates on
+// startup. Manual checks remain available in Settings regardless of this value.
+func (c *Config) SetDesktopCheckUpdates(enabled bool) error {
+	c.Desktop.CheckUpdates = &enabled
+	return nil
+}
+
 // SetUICloseBehavior is kept for callers compiled against the old edit API.
 func (c *Config) SetUICloseBehavior(mode string) error {
 	return c.SetDesktopCloseBehavior(mode)

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -80,6 +80,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			b.WriteString("# theme_style = \"graphite\"   # graphite|ember|aurora|midnight|sandstone|porcelain|linen|glacier\n")
 		}
 		fmt.Fprintf(&b, "close_behavior = %q   # desktop: quit|background when the window close button is clicked\n", c.DesktopCloseBehavior())
+		fmt.Fprintf(&b, "check_updates = %v   # desktop: check for new versions on startup\n", c.DesktopCheckUpdates())
 		if len(c.Desktop.ProviderAccess) > 0 {
 			fmt.Fprintf(&b, "provider_access = %s   # desktop settings: providers shown on Settings > Model > Access\n", renderStringArray(c.Desktop.ProviderAccess))
 		}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -20,6 +20,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Desktop.Theme = "dark"
 	orig.Desktop.ThemeStyle = "graphite"
 	orig.Desktop.CloseBehavior = "background"
+	orig.Desktop.CheckUpdates = boolPtr(false)
 	orig.Notifications.Enabled = true
 	orig.Notifications.TurnDone = true
 	orig.Notifications.ApprovalRequest = true
@@ -105,6 +106,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Desktop.CloseBehavior != "background" {
 		t.Errorf("desktop.close_behavior = %q, want background", got.Desktop.CloseBehavior)
+	}
+	if got.Desktop.CheckUpdates == nil || *got.Desktop.CheckUpdates {
+		t.Errorf("desktop.check_updates = %+v, want false", got.Desktop.CheckUpdates)
 	}
 	if !got.Notifications.Enabled || !got.Notifications.TurnDone || !got.Notifications.ApprovalRequest || !got.Notifications.AskRequest {
 		t.Errorf("notifications not preserved: %+v", got.Notifications)
@@ -348,16 +352,17 @@ func TestScopedRenderSeparatesUserAndProjectConfig(t *testing.T) {
 	c.Desktop.Theme = "dark"
 	c.Desktop.ThemeStyle = "graphite"
 	c.Desktop.CloseBehavior = "background"
+	c.Desktop.CheckUpdates = boolPtr(false)
 
 	user := RenderTOMLForScope(c, RenderScopeUser)
-	for _, want := range []string{"config_version = 2", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, "[notifications]"} {
+	for _, want := range []string{"config_version = 2", "[desktop]", `theme = "dark"`, `close_behavior = "background"`, `check_updates = false`, "[notifications]"} {
 		if !strings.Contains(user, want) {
 			t.Fatalf("user render missing %q:\n%s", want, user)
 		}
 	}
 
 	project := RenderTOMLForScope(c, RenderScopeProject)
-	for _, forbidden := range []string{"[desktop]", "[notifications]", "close_behavior ="} {
+	for _, forbidden := range []string{"[desktop]", "[notifications]", "close_behavior =", "check_updates ="} {
 		if strings.Contains(project, forbidden) {
 			t.Fatalf("project render should not contain %q:\n%s", forbidden, project)
 		}


### PR DESCRIPTION
## Summary

- Add a desktop setting to enable or disable startup update checks while keeping manual checks available in Settings.
- Add a dismiss action for update error banners so transient network failures do not pin the UI.
- Keep settings helper text on one line with ellipsis and tooltip fallback, including the update preference row.
- Restore the tracked `dist/.gitkeep` placeholder after production frontend builds so Vite can still clear stale assets without leaving a tracked deletion.

## Validation

- `pnpm --dir desktop/frontend build`
- `go test ./internal/config`
- `go test .` from the desktop module

## Issues

Fixes #2822.
Fixes #3104.
Fixes #3699.
