### PR TITLE
Fix macOS top chrome drag rail / 修复 macOS 顶部窗口拖拽区域

### DIFF
--- a/desktop/frontend/src/components/AppChrome.tsx
+++ b/desktop/frontend/src/components/AppChrome.tsx
@@ -91,6 +91,7 @@ export function AppChrome({
           <span />
         </div>
       )}
+      {darwinChrome && <span className="app-chrome__drag-rail" aria-hidden="true" />}
       <button
         className={[
           "app-chrome__panel-toggle",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11436,6 +11436,45 @@ a[href] {
   --wails-draggable: no-drag;
 }
 
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: calc(var(--chrome-left-toggle-offset) + var(--chrome-toggle-size) + 12px);
+  right: calc(var(--chrome-right-toggle-offset) + var(--chrome-toggle-size) + 12px);
+  z-index: var(--z-local-handle);
+  height: 10px;
+  --wails-draggable: drag;
+}
+
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail::before {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 50%;
+  width: calc(100% - 24px);
+  height: 3px;
+  transform: translateX(-50%);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg-faint) 40%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--border) 76%, transparent);
+  opacity: 0;
+  transition:
+    background 0.12s ease,
+    box-shadow 0.12s ease,
+    opacity 0.12s ease;
+}
+
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail:hover::before {
+  opacity: 0.72;
+}
+
+.app--darwin .app-chrome--tabs .app-chrome__drag-rail:active::before {
+  background: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 68%, transparent);
+  opacity: 0.95;
+}
+
 .app--darwin .app-chrome--tabs .app-chrome__panel-toggle {
   top: 7px;
   height: 30px;
@@ -12471,6 +12510,10 @@ a[href] {
 .tabbar__spacer {
   flex: 1 1 auto;
   min-width: 12px;
+}
+
+.app-chrome__drag-rail {
+  display: none;
 }
 
 .tabbar__tab-close {


### PR DESCRIPTION
## Summary
- Add a macOS-only invisible top drag rail above the tab strip so the window remains draggable even when tabs fill the chrome.
- Keep tab controls and buttons as `no-drag`, while the rail exposes a subtle full-width hover indicator and accent-colored active state.
- Leave Windows and Linux behavior unchanged.

## Root Cause
Reasonix uses an inset/hidden macOS title bar, so the webview must explicitly provide draggable regions. The tab strip is interactive and opts out of Wails dragging, which can leave no reliable drag target when the top chrome is full of tabs.

## Validation
- `pnpm --dir desktop/frontend run build`
- Browser preview with `platform=darwin` verified that the rail is the hit target, the rail is draggable, tab controls remain `no-drag`, and hover/active indicators render at the same full width.

Related: #3843, #3852, #3853
