### PR TITLE
fix(desktop): close stuck thinking window after stream interruption (#3746)

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -245,6 +245,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   const hasText = item.streaming || item.text.trim() !== "";
   const processOnly = Boolean(item.reasoning) && !hasText;
   const processWithText = Boolean(item.reasoning) && hasText;
+  const [reasoningOpen, setReasoningOpen] = useState(item.streaming);
   return (
     <div className={`msg msg--assistant${processOnly ? " msg--process-only" : ""}${processWithText ? " msg--process-with-text" : ""}`}>
       {item.reasoning && (
@@ -259,7 +260,8 @@ export const AssistantMessage = memo(function AssistantMessage({
               <span>{item.streaming ? t("msg.thinkingRunning") : t("msg.thinkingDone")}</span>
             </>
           }
-          defaultOpen={item.streaming}
+          open={reasoningOpen}
+          onOpenChange={setReasoningOpen}
         >
           <div className="reasoning__body">{item.reasoning}</div>
         </ProcessCard>

--- a/desktop/frontend/src/components/ProcessCard.tsx
+++ b/desktop/frontend/src/components/ProcessCard.tsx
@@ -142,6 +142,7 @@ export function ProcessCard({
         type="button"
         className="process-card__head"
         onClick={toggle}
+        onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); toggle(); } }}
         aria-expanded={hasBody ? actualOpen : undefined}
       >
         <span className="process-card__icon">{icon}</span>

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -477,6 +477,7 @@ async function refreshMetaForTab(tabId: string, dispatchTo: (tabId: string, acti
 
 export function useController() {
   const statesRef = useRef<TabStates>(new Map());
+  const lastTokenAt = useRef(0);
   const [activeTabId, setActiveTabId] = useState<string | undefined>();
   const activeTabIdRef = useRef<string | undefined>(undefined);
   // A render-triggering counter so that mutations to a non-active tab's state still
@@ -599,6 +600,9 @@ export function useController() {
     const off = onEvent((e) => {
       const targetTabId = e.tabId || activeTabIdRef.current;
       if (!targetTabId) return;
+      if (e.kind === "turn_started" || e.kind === "text" || e.kind === "reasoning") {
+        lastTokenAt.current = Date.now();
+      }
       if (e.kind === "text" || e.kind === "reasoning") {
         textBatch.push({ tabId: targetTabId, e });
       } else {
@@ -638,6 +642,28 @@ export function useController() {
 
     return () => { textBatch.drain(); off(); offReady(); };
   }, [dispatchTo, loadSessionDataForTab, refreshCheckpoints, syncActiveTabFromBackend]);
+
+  // Stale-stream watchdog: if the frontend thinks the agent is running but
+  // no token events have arrived for 30 seconds, reconcile with the backend.
+  // This catches the case where the Wails event channel silently drops the
+  // turn_done event after a model-service interruption (#3746).
+  useEffect(() => {
+    if (!activeTabId) return;
+    const s = statesRef.current.get(activeTabId);
+    if (!s?.running || !s.live) return;
+    const since = Date.now() - lastTokenAt.current;
+    if (since >= 30_000) {
+      void reconcileTabRuntime(activeTabId);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const cur = statesRef.current.get(activeTabId);
+      if (cur?.running && cur.live && Date.now() - lastTokenAt.current >= 30_000) {
+        void reconcileTabRuntime(activeTabId);
+      }
+    }, 30_000 - since);
+    return () => window.clearTimeout(timer);
+  }, [activeTabId, reconcileTabRuntime, activeState.running, activeState.live]);
 
   const send = useCallback((displayText: string, submitText = displayText) => {
     const submitForTab = (tabId: string) => {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -404,6 +404,15 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 
 	go func() {
 		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				c.mu.Lock()
+				c.running = false
+				c.cancel = nil
+				c.mu.Unlock()
+				c.sink.Emit(event.Event{Kind: event.TurnDone, Err: fmt.Errorf("internal error: %v", r)})
+			}
+		}()
 		err := body(ctx)
 		c.mu.Lock()
 		c.running = false

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -488,5 +489,78 @@ func TestParseRewindEmptyCheckpoints(t *testing.T) {
 	_, _, err := parseRewind("", nil)
 	if err == nil {
 		t.Fatal("expected error when no checkpoints")
+	}
+}
+
+func TestRunGuardedPanicEmitsTurnDone(t *testing.T) {
+	sess := agent.NewSession("sys")
+	events := make(chan event.Event, 4)
+	c := New(Options{
+		Runner: appendingRunner{session: sess},
+		Sink:   event.FuncSink(func(e event.Event) { events <- e }),
+	})
+
+	go func() {
+		c.runGuarded(func(ctx context.Context) error {
+			panic("boom")
+		})
+	}()
+
+	select {
+	case e := <-events:
+		if e.Kind != event.TurnDone {
+			t.Fatalf("expected TurnDone after panic, got %v", e.Kind)
+		}
+		if e.Err == nil || !strings.Contains(e.Err.Error(), "boom") {
+			t.Fatalf("expected TurnDone.Err to contain panic message, got %v", e.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for TurnDone after panic")
+	}
+
+	c.mu.Lock()
+	running := c.running
+	c.mu.Unlock()
+	if running {
+		t.Fatal("c.running should be false after panic recovery")
+	}
+}
+
+func TestRunGuardedPanicDoesNotDoubleEmitTurnDone(t *testing.T) {
+	sess := agent.NewSession("sys")
+	var count int32
+	events := make(chan event.Event, 8)
+	c := New(Options{
+		Runner: appendingRunner{session: sess},
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.TurnDone {
+				atomic.AddInt32(&count, 1)
+			}
+			events <- e
+		}),
+	})
+
+	go func() {
+		c.runGuarded(func(ctx context.Context) error {
+			panic("boom")
+		})
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-events:
+			n := atomic.LoadInt32(&count)
+			if n >= 1 {
+				time.Sleep(50 * time.Millisecond)
+				n2 := atomic.LoadInt32(&count)
+				if n2 > 1 {
+					t.Fatalf("TurnDone emitted %d times, expected 1", n2)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for TurnDone")
+		}
 	}
 }


### PR DESCRIPTION
Closes #3746

## Problem

When the model service is interrupted during the thinking/reasoning phase, the "thinking window" (ProcessCard) gets stuck open and cannot be closed by clicking or pressing ESC. The UI shows a perpetual "running" spinner.

## Solution

5 changes across 5 files (+113, -1):

### Fix 1: Stale-stream watchdog (`useController.ts`)

Top-level `useEffect` watchdog that detects when the frontend has `running + live` set but no token events (`text`/`reasoning`) have arrived for 30 seconds. Uses a `lastTokenAt` ref (reset on `turn_started`/`text`/`reasoning`) and explicit deps `[activeTabId, reconcileTabRuntime, activeState.running, activeState.live]`. Calculates elapsed time and schedules a timeout for the remaining delay, with a double-check guard inside the callback. When triggered, calls `reconcileTabRuntime()` which queries the backend and dispatches `backend_status: {running: false}` if the backend is no longer running.

Addresses review feedback:
- **Hoisted** from inside the event-subscription `useEffect` (was a nested hook → Rules of Hooks violation / crash) to a **top-level sibling** effect.
- **Replaced** the no-deps "reset on every render" trick with a `lastTokenAt` ref + explicit deps, so the timer only re-arms when `running`/`live`/`activeTabId` change, and correctly measures time since the last token event.
- **Added** `turn_started` to the `lastTokenAt` reset events to prevent spurious reconcile on fresh turns where `lastTokenAt.current` was still 0 or stale from a previous turn.

### Fix 2: Panic recovery (`controller.go`)

Adds `defer recover()` to the `runGuarded` goroutine. On panic: sets `c.running = false`, emits `TurnDone` with error. On normal path: `recover()` returns nil, guard is a no-op — no double `TurnDone`.

### Fix 3: Controlled `open` on reasoning card (`Message.tsx`)

Replaces `defaultOpen={item.streaming}` (uncontrolled, one-time `useState` initializer that ignores prop changes) with **controlled mode**: `useState(item.streaming)` seeds `reasoningOpen`, and `open={reasoningOpen}` + `onOpenChange={setReasoningOpen}` gives full control. No `useEffect` auto-close — the card stays open after normal completion (original UX: user can review reasoning), and the stuck-spinner is resolved by the watchdog transitioning the status icon from "running" to "done".

Addresses review feedback:
- Completed turns from disk: `useState(false)` → card starts collapsed (matches original `defaultOpen={false}`).
- Streaming turns: `useState(true)` → card starts open, stays open after completion.
- Watchdog stuck case: when `streaming → false`, the status icon changes from spinner to checkmark, so the card no longer appears "stuck" even though it remains open.

### Fix 4: Scoped ESC handler (`ProcessCard.tsx`)

Replaces the global `document.addEventListener("keydown")` (which closed ALL open cards on a single ESC and collided with ESC elsewhere) with a scoped `onKeyDown` on the `<button>` element. ESC only closes the card whose header button currently has focus. Removes `useEffect` import entirely.

### Fix 5: Panic recovery tests (`controller_test.go`)

Two new tests:
- `TestRunGuardedPanicEmitsTurnDone` — verifies panic recovery emits `TurnDone` with error and sets `c.running = false`
- `TestRunGuardedPanicDoesNotDoubleEmitTurnDone` — verifies no double `TurnDone` emission on the panic path

## Testing

```
go vet ./internal/control/...  — clean
go test ./internal/control/... — 22/22 pass (including 2 new panic recovery tests)
git diff --check               — clean
```