### PR TITLE
Fix anchored popover resize positioning / 修复弹层尺寸变化后的定位

### DIFF
--- a/desktop/frontend/src/components/AnchoredPopover.tsx
+++ b/desktop/frontend/src/components/AnchoredPopover.tsx
@@ -97,16 +97,35 @@ export function AnchoredPopover({
       setPosition(null);
       return;
     }
+    let frame: number | null = null;
     const updatePosition = () => {
+      frame = null;
       const anchor = anchorRef.current?.getBoundingClientRect();
       const menu = popoverRef.current?.getBoundingClientRect();
       if (!anchor || !menu) return;
       const next = calculatePosition(anchor, menu, align, offset, placement);
       setPosition((current) => (samePosition(current, next) ? current : next));
     };
+    const scheduleUpdate = () => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(updatePosition);
+    };
     updatePosition();
-    const frame = window.requestAnimationFrame(updatePosition);
-    return () => window.cancelAnimationFrame(frame);
+    scheduleUpdate();
+
+    const anchor = anchorRef.current;
+    const menu = popoverRef.current;
+    let observer: ResizeObserver | null = null;
+    if (typeof ResizeObserver !== "undefined") {
+      observer = new ResizeObserver(scheduleUpdate);
+      if (anchor) observer.observe(anchor);
+      if (menu) observer.observe(menu);
+    }
+
+    return () => {
+      if (frame !== null) window.cancelAnimationFrame(frame);
+      observer?.disconnect();
+    };
   }, [rendered, anchorRef, align, offset, placement]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Reposition anchored popovers when the anchor or menu size changes, using a ResizeObserver with requestAnimationFrame batching.
- Keeps model, effort, composer, settings, and workspace popovers anchored after async content loads or layout changes.

## Verification
- npm --prefix desktop/frontend run test
- npm --prefix desktop/frontend run build
- Checked the model switcher and adjacent popovers in the Codex in-app browser on a local dev server; no console warnings or errors.

## Cache impact
- No provider request, prompt, tool schema, or cache-prefix changes.