### PR TITLE
fix: add explicit serial workflow instructions to executor handoff and plan-approved message

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -189,6 +189,7 @@ Executor instructions:
 - Do not ask the user how to trigger the executor. You are already in the executor phase.
 - If the task requires changes, call the appropriate tools (for example write/edit/bash) instead of only restating the plan.
 - If a target path is outside the writable workspace or otherwise blocked, explain that specific blocker and ask for the needed path/approval.
+- **Serial workflow**: after finishing EACH sub-task, immediately call complete_step with evidence, then call todo_write to mark it completed and advance the next sub-task. Never batch-complete multiple sub-tasks at once.
 
 Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, plan)
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -436,7 +436,7 @@ const planApprovalTool = "exit_plan_mode"
 
 // planApprovedMessage is the follow-up turn sent once the user approves a plan —
 // the in-context nudge to execute and keep the (already-seeded) task list honest.
-const planApprovedMessage = "Plan approved — plan mode is off; you're cleared to make the changes without asking again. Implement the plan now. Keep the task list current with todo_write, preserving its two-level shape (phases at level 0, their sub-steps at level 1): mark the sub-step you start as in_progress, one in_progress at a time. Sign off each finished sub-step with complete_step, attaching the evidence it's done — the verification you ran, the diff/files you changed, or a manual check. Don't claim a step is done without evidence."
+const planApprovedMessage = "Plan approved — plan mode is off; you’re cleared to make the changes without asking again. Implement the plan now. Use this serial workflow: 1) mark the first sub-step in_progress with todo_write; 2) execute it; 3) call complete_step with evidence; 4) call todo_write to mark it completed and set the next sub-step in_progress; 5) repeat until done. Never batch-complete multiple sub-steps at once — each sub-step must have its own complete_step before it is marked completed in todo_write."
 
 // runTurn runs one model turn, then applies the plan-approval gate. This is the
 // single, frontend-agnostic plan flow: in plan mode the model just researches


### PR DESCRIPTION
## 问题

Close #3911

当Agent需要执行多个子任务时，倾向于先全部执行完毕再批量提交complete_step，导致 todo_write 的校验失败。

## 修改

两个文件的指令增强：

### 1. internal/agent/coordinator.go - formatHandoff

在 executor handoff 指令中新增一条：
> Serial workflow: after finishing EACH sub-task, immediately call complete_step with evidence, then call todo_write to mark it completed and advance the next sub-task. Never batch-complete multiple sub-tasks at once.

### 2. internal/control/controller.go - planApprovedMessage

将原本的隐式提示增强为显式的 5 步串行循环，并明确约束：Never batch-complete multiple sub-steps at once

## 验证

- todo_write 的 verifyTodoCompletionTransitions 本身是正确的防护机制
- complete_step 的 verifyStepEvidence 要求证据在同一 turn 的 ledger 中
- 此 PR 仅增强提示词指令，不修改运行时逻辑（低风险）