### PR TITLE
fix(desktop): widen model switcher popover for long model names (#3641)

### DIFF
--- a/desktop/frontend/src/components/ModelSwitcher.tsx
+++ b/desktop/frontend/src/components/ModelSwitcher.tsx
@@ -72,7 +72,7 @@ export function ModelSwitcher({ label, tabId, onPick }: { label: string; tabId?:
         anchorRef={triggerRef}
         onClose={() => closeMenu()}
         className="modelsw__menu modelsw__menu--portal"
-        style={{ width: triggerWidth, minWidth: triggerWidth ? Math.max(triggerWidth, 160) : undefined }}
+        style={{ minWidth: triggerWidth ? Math.max(triggerWidth, 160) : undefined, maxWidth: 400 }}
       >
         <div role="listbox">
           {models.length === 0 && <div className="modelsw__empty">{t("status.noModels")}</div>}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4627,14 +4627,17 @@ a[href] {
   flex-direction: column;
   gap: 2px;
 }
-.modelsw__model,
-.modelsw__provider {
+.modelsw__model {
   display: block;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 .modelsw__provider {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   color: var(--fg-faint);
   font-size: 11px;
 }


### PR DESCRIPTION
﻿Re-lands #3641 by @0xzqy (zqy) on top of current main-v2 — the original branch conflicted with the post-#3885 popover sizing change.

Conflict resolution: kept the 160px floor that main-v2 added (`minWidth: max(triggerWidth, 160)`) while adopting the decoupled growth from the original PR (`maxWidth: 400`, no fixed `width`), so long model refs widen the popover without regressing the minimum size. The `title` hover fallbacks and ellipsis CSS land unchanged. Author credit preserved on the commit.

Closes #3641

Fixes #3628
