### PR TITLE
fix(desktop): surface send failures on the user bubble (#3056)

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -10,9 +10,9 @@
     "check:css": "node scripts/check-css-syntax.mjs src/styles.css && node scripts/check-z-index-tokens.mjs src/styles.css",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts",
+    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts && tsx src/__tests__/send-failed.test.ts",
     "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
-    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts"
+    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts && tsx src/__tests__/send-failed.test.ts"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.2",

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -1,0 +1,48 @@
+// Run: tsx src/__tests__/send-failed.test.ts
+
+import { initialState, reducer } from "../lib/useController";
+import type { WireEvent } from "../lib/types";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\nsend failure feedback");
+
+const sent = reducer({ ...initialState }, { type: "user", text: "hello", seq: 0 });
+eq(sent.items.length, 1, "submit appends the user bubble immediately");
+eq(sent.items[0].kind === "user" && sent.items[0].text, "hello", "bubble carries the submitted text");
+eq(sent.running, true, "submit marks the turn running");
+eq(sent.pendingUser, "hello", "submit tracks the optimistic bubble");
+
+const confirmed = reducer(sent, { type: "event", e: { kind: "text", text: "hi" } as WireEvent });
+eq(confirmed.items.filter((it) => it.kind === "user").length, 1, "first backend event confirms without duplicating");
+eq(confirmed.pendingUser, undefined, "confirmation clears the pending marker");
+
+const failedState = reducer(sent, { type: "send_failed", error: "Send failed: bridge unavailable" });
+const failedBubble = failedState.items.find((it) => it.kind === "user");
+eq(failedBubble?.kind === "user" && failedBubble.failed, true, "send_failed marks the bubble failed");
+const notice = failedState.items[failedState.items.length - 1];
+eq(notice.kind, "notice", "send_failed appends a notice");
+eq(notice.kind === "notice" && notice.level, "warn", "the notice is a warning");
+eq(failedState.running, false, "send_failed stops the running indicator");
+eq(failedState.pendingUser, undefined, "send_failed clears the pending marker");
+
+const lateFailure = reducer(confirmed, { type: "send_failed", error: "Send failed: late" });
+eq(lateFailure, confirmed, "send_failed after backend confirmation is a no-op");
+
+const unsent = reducer(sent, { type: "unsend" });
+eq(unsent.pendingUser, undefined, "unsend clears the pending marker");
+eq(unsent.discardTurn, true, "unsend discards the in-flight turn");
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -19,19 +19,22 @@ function attachmentIcon(kind: "image" | "file" | "folder") {
 
 export function UserMessage({
   text,
+  failed,
   turn,
   anchorId,
 }: {
   text: string;
+  failed?: boolean;
   turn?: number;
   anchorId?: string;
 }) {
   const t = useT();
   const { text: displayText, attachments } = parseAttachmentRefsForDisplay(text);
   return (
-    <div className="msg msg--user" id={anchorId} data-question-anchor={anchorId} data-turn={turn}>
+    <div className={`msg msg--user${failed ? " msg--user-failed" : ""}`} id={anchorId} data-question-anchor={anchorId} data-turn={turn}>
       <div className="msg__body">
         {displayText && <div className="msg__text">{displayText}</div>}
+        {failed && <div className="msg__send-failed">{t("msg.sendFailed")}</div>}
         {attachments.length > 0 && (
           <div className="msg-attachments" aria-label={t("msg.attachments")}>
             {attachments.map((attachment, index) => (

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -372,7 +372,7 @@ export function Transcript({
           const tn = userTurn.get(it.id);
           activeTurn = tn;
           out.push(
-            <UserMessage key={it.id} text={it.text} turn={tn} anchorId={questionAnchorId(it.id)} />,
+            <UserMessage key={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
           );
           break;
         }
@@ -629,7 +629,7 @@ function WarmTurnItems({
         const tn = userTurnMap.get(it.id);
         activeTurn = tn;
         nodes.push(
-          <UserMessage key={it.id} text={it.text} turn={tn} anchorId={questionAnchorId(it.id)} />,
+          <UserMessage key={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
         );
         break;
       }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -37,7 +37,7 @@ export type MessageActionScope = "fork" | "summ-from" | "summ-upto" | "conversat
 export type MessageActionState = { turn: number; scope: MessageActionScope };
 
 export type Item =
-  | { kind: "user"; id: string; text: string }
+  | { kind: "user"; id: string; text: string; failed?: boolean }
   | { kind: "assistant"; id: string; text: string; reasoning: string; streaming: boolean }
   | { kind: "phase"; id: string; text: string }
   | { kind: "notice"; id: string; level: "info" | "warn"; text: string }
@@ -92,7 +92,7 @@ interface State {
   seq: number;
 }
 
-const initialState: State = {
+export const initialState: State = {
   items: [],
   running: false,
   turnActive: false,
@@ -127,6 +127,7 @@ type Action =
   | { type: "event"; e: WireEvent }
   | { type: "user"; text: string; seq: number }
   | { type: "unsend" }
+  | { type: "send_failed"; error: string }
   | { type: "backend_status"; running: boolean }
   | { type: "meta"; meta: Meta }
   | { type: "context"; context: ContextInfo }
@@ -385,7 +386,7 @@ function applyEvent(s: State, e: WireEvent): State {
   }
 }
 
-function reducer(s: State, a: Action): State {
+export function reducer(s: State, a: Action): State {
   switch (a.type) {
     case "user": {
       const seq = a.seq !== undefined ? a.seq : s.seq;
@@ -401,6 +402,17 @@ function reducer(s: State, a: Action): State {
       };
     }
     case "unsend": return { ...s, pendingUser: undefined, discardTurn: true, running: false, live: undefined };
+    case "send_failed": {
+      if (s.pendingUser === undefined) return s;
+      let idx = -1;
+      for (let i = s.items.length - 1; i >= 0; i--) {
+        const it = s.items[i];
+        if (it.kind === "user" && it.text === s.pendingUser) { idx = i; break; }
+      }
+      const items = idx >= 0 ? s.items.map((it, i) => (i === idx ? { ...it, failed: true } : it)) : s.items;
+      const notice: Item = { kind: "notice", id: `n${s.seq}`, level: "warn", text: a.error };
+      return { ...s, pendingUser: undefined, running: false, turnActive: false, live: undefined, seq: s.seq + 1, items: [...items, notice] };
+    }
     case "backend_status": {
       if (a.running === s.running) return s;
       if (a.running) return { ...s, running: true, turnActive: true, turnStartAt: s.turnStartAt || Date.now() };
@@ -645,7 +657,9 @@ export function useController() {
       dispatchTo(tabId, { type: "user", text: displayText, seq });
       const display = displayText.trim();
       const submit = submitText.trim();
-      (display !== submit ? app.SubmitDisplayToTab(tabId, display, submit) : app.SubmitToTab(tabId, submit)).catch(() => {});
+      (display !== submit ? app.SubmitDisplayToTab(tabId, display, submit) : app.SubmitToTab(tabId, submit)).catch((error) => {
+        dispatchTo(tabId, { type: "send_failed", error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
+      });
     };
     const tabId = activeTabIdRef.current ?? activeTabId;
     if (tabId) {

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -947,6 +947,7 @@ export const en = {
   "msg.thinkingDone": "done",
   "msg.copy": "Copy",
   "msg.attachments": "Attachments",
+  "msg.sendFailed": "Send failed — message was not delivered",
   "msg.fileAttachment": "File",
   "msg.imageAttachment": "Image",
   "msg.workspaceReference": "Workspace reference",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -949,6 +949,7 @@ export const zh: Record<DictKey, string> = {
   "msg.thinkingDone": "已完成",
   "msg.copy": "复制",
   "msg.attachments": "附件",
+  "msg.sendFailed": "发送失败 — 消息未送达",
   "msg.fileAttachment": "文件",
   "msg.imageAttachment": "图片",
   "msg.workspaceReference": "工作区引用",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2620,6 +2620,15 @@ a[href] {
   font-weight: 450;
   line-height: 1.65;
 }
+.msg--user-failed .msg__body {
+  opacity: 0.7;
+  border-color: color-mix(in srgb, var(--danger) 35%, transparent);
+}
+.msg__send-failed {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--danger);
+}
 .msg-attachments {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
﻿Supersedes #3056 by @luffy-thanks. The core of that PR — showing the submitted message immediately — landed independently via #3430/#3441, which is why the original branch no longer applies. This carries forward the part main-v2 was still missing: submit rejections were silently swallowed (`.catch(() => {})`), so a failed send looked delivered.

What lands here, adapted to the per-tab state model:
- `send_failed` reducer action: marks the optimistic user bubble failed, appends a warning notice, stops the running indicator, and is a no-op once the backend has confirmed the turn.
- Submit wiring dispatches `send_failed` to the right tab on bridge rejection.
- Failed-bubble styling + en/zh copy.
- Reducer coverage in the repo's tsx test convention (immediate display, no-duplicate confirmation, failure marking, late-failure no-op, unsend), wired into `npm test`.

Author credit for the original diagnosis and design carried as commit co-author. The vitest harness from the original PR was intentionally dropped — the frontend already has a tsx-based test runner.

Closes #3056
