### PR TITLE
site: same-origin avatars + dl.reasonix.io downloads (mainland access)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,4 @@ node_modules/
 Thumbs.db
 .idea/
 .vscode/
-
-# Scratch / agent working dirs (never committed)
-/tmp/
-/.codex/
+/site/public/av/

--- a/site/package.json
+++ b/site/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
+    "prebuild": "node scripts/fetch-community.mjs",
     "build": "astro build",
     "preview": "astro preview"
   },

--- a/site/scripts/fetch-community.mjs
+++ b/site/scripts/fetch-community.mjs
@@ -1,0 +1,47 @@
+// Prebuild: fetch live community stats + bake contributor avatars into public/av/.
+// Never fails the build — falls back to the committed snapshot on any error.
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+
+const repo = 'esengine/DeepSeek-Reasonix';
+const api = `https://api.github.com/repos/${repo}`;
+const headers = { 'User-Agent': 'reasonix-site', Accept: 'application/vnd.github+json' };
+if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+const fallback = JSON.parse(await readFile('src/data/contributors.json', 'utf8'));
+let { stars, mergedPrs, contributors, list } = fallback;
+
+try {
+  const r = await fetch(`${api}/contributors?per_page=100`, { headers });
+  if (r.ok) {
+    const humans = (await r.json())
+      .filter((c) => c.type === 'User')
+      .map((c) => ({ login: c.login, avatar: String(c.avatar_url).split('?')[0], url: c.html_url, c: c.contributions }));
+    if (humans.length) { list = humans; contributors = humans.length; }
+  }
+} catch {}
+try {
+  const r = await fetch(api, { headers });
+  if (r.ok) { const d = await r.json(); if (typeof d.stargazers_count === 'number') stars = d.stargazers_count; }
+} catch {}
+try {
+  const r = await fetch(`https://api.github.com/search/issues?q=repo:${repo}+is:pr+is:merged&per_page=1`, { headers });
+  if (r.ok) { const d = await r.json(); if (typeof d.total_count === 'number') mergedPrs = d.total_count; }
+} catch {}
+
+await mkdir('public/av', { recursive: true });
+let baked = 0;
+const out = await Promise.all(list.map(async (c) => {
+  const remote = `${c.avatar}?s=120`;
+  try {
+    const r = await fetch(remote);
+    if (!r.ok) throw new Error(String(r.status));
+    await writeFile(`public/av/${c.login}.png`, Buffer.from(await r.arrayBuffer()));
+    baked++;
+    return { ...c, avatar: `/av/${c.login}.png` };
+  } catch {
+    return { ...c, avatar: remote };
+  }
+}));
+
+await writeFile('src/data/community.json', JSON.stringify({ stars, mergedPrs, contributors, list: out }, null, 2) + '\n');
+console.log(`community: ${contributors} contributors · ${stars} stars · ${mergedPrs} merged PRs · ${baked}/${out.length} avatars baked`);

--- a/site/src/data/community.json
+++ b/site/src/data/community.json
@@ -1,0 +1,271 @@
+{
+  "stars": 20910,
+  "mergedPrs": 1799,
+  "contributors": 44,
+  "list": [
+    {
+      "login": "esengine",
+      "avatar": "/av/esengine.png",
+      "url": "https://github.com/esengine",
+      "c": 310
+    },
+    {
+      "login": "SivanCola",
+      "avatar": "/av/SivanCola.png",
+      "url": "https://github.com/SivanCola",
+      "c": 167
+    },
+    {
+      "login": "HUQIANTAO",
+      "avatar": "/av/HUQIANTAO.png",
+      "url": "https://github.com/HUQIANTAO",
+      "c": 73
+    },
+    {
+      "login": "GTC2080",
+      "avatar": "/av/GTC2080.png",
+      "url": "https://github.com/GTC2080",
+      "c": 16
+    },
+    {
+      "login": "lanshi17",
+      "avatar": "/av/lanshi17.png",
+      "url": "https://github.com/lanshi17",
+      "c": 10
+    },
+    {
+      "login": "SuMuxi66",
+      "avatar": "/av/SuMuxi66.png",
+      "url": "https://github.com/SuMuxi66",
+      "c": 10
+    },
+    {
+      "login": "Li-Charles-One",
+      "avatar": "/av/Li-Charles-One.png",
+      "url": "https://github.com/Li-Charles-One",
+      "c": 10
+    },
+    {
+      "login": "CVEngineer66",
+      "avatar": "/av/CVEngineer66.png",
+      "url": "https://github.com/CVEngineer66",
+      "c": 10
+    },
+    {
+      "login": "wade19990814-hue",
+      "avatar": "/av/wade19990814-hue.png",
+      "url": "https://github.com/wade19990814-hue",
+      "c": 7
+    },
+    {
+      "login": "paradoxSCH",
+      "avatar": "/av/paradoxSCH.png",
+      "url": "https://github.com/paradoxSCH",
+      "c": 7
+    },
+    {
+      "login": "YoungDan-hero",
+      "avatar": "/av/YoungDan-hero.png",
+      "url": "https://github.com/YoungDan-hero",
+      "c": 6
+    },
+    {
+      "login": "lizhengwu",
+      "avatar": "/av/lizhengwu.png",
+      "url": "https://github.com/lizhengwu",
+      "c": 5
+    },
+    {
+      "login": "Bernardxu123",
+      "avatar": "/av/Bernardxu123.png",
+      "url": "https://github.com/Bernardxu123",
+      "c": 5
+    },
+    {
+      "login": "CnsMaple",
+      "avatar": "/av/CnsMaple.png",
+      "url": "https://github.com/CnsMaple",
+      "c": 5
+    },
+    {
+      "login": "jiaxindeyang-a11y",
+      "avatar": "/av/jiaxindeyang-a11y.png",
+      "url": "https://github.com/jiaxindeyang-a11y",
+      "c": 3
+    },
+    {
+      "login": "kekexunxun",
+      "avatar": "/av/kekexunxun.png",
+      "url": "https://github.com/kekexunxun",
+      "c": 3
+    },
+    {
+      "login": "Tatlatat",
+      "avatar": "/av/Tatlatat.png",
+      "url": "https://github.com/Tatlatat",
+      "c": 3
+    },
+    {
+      "login": "AtmoOmen",
+      "avatar": "/av/AtmoOmen.png",
+      "url": "https://github.com/AtmoOmen",
+      "c": 3
+    },
+    {
+      "login": "nostalgia296",
+      "avatar": "/av/nostalgia296.png",
+      "url": "https://github.com/nostalgia296",
+      "c": 2
+    },
+    {
+      "login": "yhemeo613",
+      "avatar": "/av/yhemeo613.png",
+      "url": "https://github.com/yhemeo613",
+      "c": 2
+    },
+    {
+      "login": "whale-fall-ouo",
+      "avatar": "/av/whale-fall-ouo.png",
+      "url": "https://github.com/whale-fall-ouo",
+      "c": 2
+    },
+    {
+      "login": "ttmouse",
+      "avatar": "/av/ttmouse.png",
+      "url": "https://github.com/ttmouse",
+      "c": 2
+    },
+    {
+      "login": "lightfront",
+      "avatar": "/av/lightfront.png",
+      "url": "https://github.com/lightfront",
+      "c": 2
+    },
+    {
+      "login": "iysun",
+      "avatar": "/av/iysun.png",
+      "url": "https://github.com/iysun",
+      "c": 2
+    },
+    {
+      "login": "closss",
+      "avatar": "/av/closss.png",
+      "url": "https://github.com/closss",
+      "c": 2
+    },
+    {
+      "login": "XTLine",
+      "avatar": "/av/XTLine.png",
+      "url": "https://github.com/XTLine",
+      "c": 2
+    },
+    {
+      "login": "LVGG",
+      "avatar": "/av/LVGG.png",
+      "url": "https://github.com/LVGG",
+      "c": 2
+    },
+    {
+      "login": "xinrenH",
+      "avatar": "/av/xinrenH.png",
+      "url": "https://github.com/xinrenH",
+      "c": 1
+    },
+    {
+      "login": "lifu963",
+      "avatar": "/av/lifu963.png",
+      "url": "https://github.com/lifu963",
+      "c": 1
+    },
+    {
+      "login": "kabaka9527",
+      "avatar": "/av/kabaka9527.png",
+      "url": "https://github.com/kabaka9527",
+      "c": 1
+    },
+    {
+      "login": "dcs02280653-collab",
+      "avatar": "/av/dcs02280653-collab.png",
+      "url": "https://github.com/dcs02280653-collab",
+      "c": 1
+    },
+    {
+      "login": "ashishexee",
+      "avatar": "/av/ashishexee.png",
+      "url": "https://github.com/ashishexee",
+      "c": 1
+    },
+    {
+      "login": "alxbnct",
+      "avatar": "/av/alxbnct.png",
+      "url": "https://github.com/alxbnct",
+      "c": 1
+    },
+    {
+      "login": "PorunC",
+      "avatar": "/av/PorunC.png",
+      "url": "https://github.com/PorunC",
+      "c": 1
+    },
+    {
+      "login": "ERroooooR",
+      "avatar": "/av/ERroooooR.png",
+      "url": "https://github.com/ERroooooR",
+      "c": 1
+    },
+    {
+      "login": "LegGasai",
+      "avatar": "/av/LegGasai.png",
+      "url": "https://github.com/LegGasai",
+      "c": 1
+    },
+    {
+      "login": "JimmyDaddy",
+      "avatar": "/av/JimmyDaddy.png",
+      "url": "https://github.com/JimmyDaddy",
+      "c": 1
+    },
+    {
+      "login": "drafish",
+      "avatar": "/av/drafish.png",
+      "url": "https://github.com/drafish",
+      "c": 1
+    },
+    {
+      "login": "JesonChou",
+      "avatar": "/av/JesonChou.png",
+      "url": "https://github.com/JesonChou",
+      "c": 1
+    },
+    {
+      "login": "HorusJiang",
+      "avatar": "/av/HorusJiang.png",
+      "url": "https://github.com/HorusJiang",
+      "c": 1
+    },
+    {
+      "login": "HBLADEH",
+      "avatar": "/av/HBLADEH.png",
+      "url": "https://github.com/HBLADEH",
+      "c": 1
+    },
+    {
+      "login": "Diarica",
+      "avatar": "/av/Diarica.png",
+      "url": "https://github.com/Diarica",
+      "c": 1
+    },
+    {
+      "login": "Nahiyi",
+      "avatar": "/av/Nahiyi.png",
+      "url": "https://github.com/Nahiyi",
+      "c": 1
+    },
+    {
+      "login": "i1j",
+      "avatar": "/av/i1j.png",
+      "url": "https://github.com/i1j",
+      "c": 1
+    }
+  ]
+}

--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -2,8 +2,7 @@
 import Base from '../layouts/Base.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const R2BASE = 'https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev';
-const R2 = `${R2BASE}/latest`;
+const R2 = 'https://dl.reasonix.io/latest';
 const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
 
 let goVer = '1.1.0';

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,41 +1,15 @@
 ---
 import Base from '../layouts/Base.astro';
-import fallback from '../data/contributors.json';
+import community from '../data/community.json';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const R2BASE = 'https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev';
-const R2 = `${R2BASE}/latest`;
+const R2 = 'https://dl.reasonix.io/latest';
 const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
-const api = 'https://api.github.com/repos/esengine/DeepSeek-Reasonix';
 
 let goVer = '1.1.0';
 try {
   const r = await fetch(`${R2}/latest.json`);
   if (r.ok) { const d = await r.json(); goVer = String(d.version || '').replace(/^v/, '') || goVer; }
-} catch {}
-
-const headers = { 'User-Agent': 'reasonix-site', 'Accept': 'application/vnd.github+json' };
-const token = process.env.GITHUB_TOKEN;
-if (token) headers.Authorization = `Bearer ${token}`;
-
-let community = fallback;
-try {
-  const cr = await fetch(`${api}/contributors?per_page=100`, { headers });
-  if (cr.ok) {
-    const list = await cr.json();
-    const humans = list
-      .filter((c) => c.type === 'User')
-      .map((c) => ({ login: c.login, avatar: String(c.avatar_url).split('?')[0], url: c.html_url, c: c.contributions }));
-    if (humans.length) community = { ...community, contributors: humans.length, list: humans };
-  }
-} catch {}
-try {
-  const rr = await fetch(api, { headers });
-  if (rr.ok) { const d = await rr.json(); if (typeof d.stargazers_count === 'number') community = { ...community, stars: d.stargazers_count }; }
-} catch {}
-try {
-  const pr = await fetch('https://api.github.com/search/issues?q=repo:esengine/DeepSeek-Reasonix+is:pr+is:merged&per_page=1', { headers });
-  if (pr.ok) { const d = await pr.json(); if (typeof d.total_count === 'number') community = { ...community, mergedPrs: d.total_count }; }
 } catch {}
 
 const fmtN = (n) => Number(n).toLocaleString('en-US');
@@ -239,7 +213,7 @@ const ld = {
         <span class="crew-set">
           {rowA.map((c, i) => (
             <a class={avClass(i)} data-h={`@${c.login}`} href={c.url} target="_blank" rel="noreferrer" aria-label={c.login}>
-              <img src={`${c.avatar}?s=120`} alt={c.login} loading="lazy" width="60" height="60" />
+              <img src={c.avatar} alt={c.login} loading="lazy" width="60" height="60" />
             </a>
           ))}
         </span>
@@ -248,7 +222,7 @@ const ld = {
         <span class="crew-set">
           {rowB.map((c, i) => (
             <a class={avClass(i + 3)} data-h={`@${c.login}`} href={c.url} target="_blank" rel="noreferrer" aria-label={c.login}>
-              <img src={`${c.avatar}?s=120`} alt={c.login} loading="lazy" width="60" height="60" />
+              <img src={c.avatar} alt={c.login} loading="lazy" width="60" height="60" />
             </a>
           ))}
           <a class="av you" data-h="this could be you · 虚位以待" href={`${repo}/issues`} target="_blank" rel="noreferrer">+</a>

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -144,7 +144,7 @@
   });
 
   /* refresh the Go-preview version from the published manifest between rebuilds */
-  fetch("https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/latest/latest.json", { cache: "no-cache" })
+  fetch("https://dl.reasonix.io/latest/latest.json", { cache: "no-cache" })
     .then((r) => (r.ok ? r.json() : null))
     .then((d) => {
       const v = String((d && d.version) || "").replace(/^v/, "");


### PR DESCRIPTION
Two fixes for mainland-China access (and a general perf win everywhere):

**Contributor avatars baked into the build.** The community wall loaded 40+ images from `avatars.githubusercontent.com`, which is blocked in mainland China — visitors there saw a wall of broken images. A `prebuild` script now fetches the contributor list / stars / merged-PR count and downloads every avatar into `public/av/`, so the wall is served same-origin from reasonix.io with zero third-party requests. Failure handling: an avatar that fails to download keeps its remote URL, and the whole script degrades to the committed snapshot instead of ever failing the build.

**Downloads on the R2 custom domain.** Desktop download links and the runtime version check move from the rate-limited `pub-*.r2.dev` dev subdomain to the bucket's custom domain `dl.reasonix.io`. Verified live before switching: all three artifacts return 200 through Cloudflare and range requests return 206, so resumable downloads work.

`public/av/` is build output and gitignored. The pages workflow already passes `GITHUB_TOKEN` into the build, which the prebuild script picks up to avoid anonymous rate limits.

Verified with a clean local build: 44/44 avatars baked, zero `avatars.githubusercontent.com` / `r2.dev` references left in the built HTML/JS.
