### PR TITLE
release: move updater + codegraph downloads to dl.reasonix.io

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -278,7 +278,7 @@ jobs:
       - name: Rewrite latest.json URLs to R2
         if: env.HAS_R2 == 'true'
         env:
-          R2_PUBLIC_BASE: https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev
+          R2_PUBLIC_BASE: https://dl.reasonix.io
           TAG: ${{ steps.ver.outputs.tag }}
         run: |
           f=assets/latest.json

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -35,7 +35,7 @@ import (
 // fallback. The build channel picks the rolling pointer so a canary build polls
 // the canary line and a stable build polls latest; the two never cross.
 const (
-	r2Base         = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev"
+	r2Base         = "https://dl.reasonix.io"
 	ghReleasesBase = "https://github.com/esengine/reasonix/releases"
 	httpTimeout    = 15 * time.Second
 )

--- a/internal/codegraph/install.go
+++ b/internal/codegraph/install.go
@@ -23,7 +23,7 @@ const (
 	Version = "v0.9.7"
 	cgRepo  = "colbymchenry/codegraph"
 
-	officialMirrorBase         = "https://pub-147fb53b9c1e4bbf891a257968619ea7.r2.dev/codegraph"
+	officialMirrorBase         = "https://dl.reasonix.io/codegraph"
 	officialMainlandMirrorBase = ""
 	perSourceDownloadTimeout   = 15 * time.Second
 


### PR DESCRIPTION
Completes the dl.reasonix.io migration started on the website (#3923): the desktop updater, the manifest URLs rewritten at release time, and the codegraph mirror now all use the R2 bucket's custom domain instead of the rate-limited `pub-*.r2.dev` dev subdomain.

## Changes

- `desktop/updater.go` — `r2Base` → `https://dl.reasonix.io`. New builds poll the custom domain for both the `latest/` and `canary/` pointers; the GitHub releases fallback is unchanged.
- `.github/workflows/release-desktop.yml` — `R2_PUBLIC_BASE` → `https://dl.reasonix.io`, so the artifact/sig URLs `jq` writes into published `latest.json` manifests point at the custom domain.
- `internal/codegraph/install.go` — `officialMirrorBase` → `https://dl.reasonix.io/codegraph`; the GitHub source fallback is unchanged.

## Compatibility

Already-installed clients have the `pub-*.r2.dev` manifest endpoint baked into their binary. That URL keeps working — it is the same bucket, and public dev access stays enabled — and the artifact URLs inside newly published manifests resolve for old and new clients alike. Nothing needs to be dual-published.

## Verified before switching

- `dl.reasonix.io` serves `latest/latest.json`, `canary/latest.json`, and all three desktop artifacts with 200; range requests return 206.
- All six codegraph bundles (`darwin|linux|win32` × `x64|arm64`) plus `SHA256SUMS` return 200 on the custom domain, matching the dev-subdomain behavior exactly.
- `go build ./...` + codegraph and updater tests pass in both modules; the one failing desktop test (`TestUpdateMCPServerSplitsPastedCommandLine`) fails identically on clean `main-v2` on this machine and is unrelated.
