### PR TITLE
fix(desktop): close stuck thinking window after stream interruption (#3893)

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -250,6 +250,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   const hasText = item.streaming || item.text.trim() !== "";
   const processOnly = Boolean(item.reasoning) && !hasText;
   const processWithText = Boolean(item.reasoning) && hasText;
+  const [reasoningOpen, setReasoningOpen] = useState(item.streaming || defaultExpanded);
   return (
     <div className={`msg msg--assistant${processOnly ? " msg--process-only" : ""}${processWithText ? " msg--process-with-text" : ""}`}>
       {item.reasoning && (
@@ -264,7 +265,8 @@ export const AssistantMessage = memo(function AssistantMessage({
               <span>{item.streaming ? t("msg.thinkingRunning") : t("msg.thinkingDone")}</span>
             </>
           }
-          defaultOpen={item.streaming || defaultExpanded}
+          open={reasoningOpen}
+          onOpenChange={setReasoningOpen}
         >
           <div className="reasoning__body">{item.reasoning}</div>
         </ProcessCard>

--- a/desktop/frontend/src/components/ProcessCard.tsx
+++ b/desktop/frontend/src/components/ProcessCard.tsx
@@ -142,6 +142,7 @@ export function ProcessCard({
         type="button"
         className="process-card__head"
         onClick={toggle}
+        onKeyDown={(e) => { if (e.key === "Escape") { e.preventDefault(); toggle(); } }}
         aria-expanded={hasBody ? actualOpen : undefined}
       >
         <span className="process-card__icon">{icon}</span>

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -506,6 +506,7 @@ async function refreshMetaForTab(tabId: string, dispatchTo: (tabId: string, acti
 
 export function useController() {
   const statesRef = useRef<TabStates>(new Map());
+  const lastTokenAt = useRef(0);
   const [activeTabId, setActiveTabId] = useState<string | undefined>();
   const activeTabIdRef = useRef<string | undefined>(undefined);
   // A render-triggering counter so that mutations to a non-active tab's state still
@@ -628,6 +629,9 @@ export function useController() {
     const off = onEvent((e) => {
       const targetTabId = e.tabId || activeTabIdRef.current;
       if (!targetTabId) return;
+      if (e.kind === "turn_started" || e.kind === "text" || e.kind === "reasoning") {
+        lastTokenAt.current = Date.now();
+      }
       if (e.kind === "text" || e.kind === "reasoning") {
         textBatch.push({ tabId: targetTabId, e });
       } else {
@@ -667,6 +671,28 @@ export function useController() {
 
     return () => { textBatch.drain(); off(); offReady(); };
   }, [dispatchTo, loadSessionDataForTab, refreshCheckpoints, syncActiveTabFromBackend]);
+
+  // Stale-stream watchdog: if the frontend thinks the agent is running but
+  // no token events have arrived for 30 seconds, reconcile with the backend.
+  // This catches the case where the Wails event channel silently drops the
+  // turn_done event after a model-service interruption (#3746).
+  useEffect(() => {
+    if (!activeTabId) return;
+    const s = statesRef.current.get(activeTabId);
+    if (!s?.running || !s.live) return;
+    const since = Date.now() - lastTokenAt.current;
+    if (since >= 30_000) {
+      void reconcileTabRuntime(activeTabId);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const cur = statesRef.current.get(activeTabId);
+      if (cur?.running && cur.live && Date.now() - lastTokenAt.current >= 30_000) {
+        void reconcileTabRuntime(activeTabId);
+      }
+    }, 30_000 - since);
+    return () => window.clearTimeout(timer);
+  }, [activeTabId, reconcileTabRuntime, activeState.running, activeState.live]);
 
   const send = useCallback((displayText: string, submitText = displayText) => {
     const submitForTab = (tabId: string) => {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -404,6 +404,15 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 
 	go func() {
 		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				c.mu.Lock()
+				c.running = false
+				c.cancel = nil
+				c.mu.Unlock()
+				c.sink.Emit(event.Event{Kind: event.TurnDone, Err: fmt.Errorf("internal error: %v", r)})
+			}
+		}()
 		err := body(ctx)
 		c.mu.Lock()
 		c.running = false

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -488,5 +489,78 @@ func TestParseRewindEmptyCheckpoints(t *testing.T) {
 	_, _, err := parseRewind("", nil)
 	if err == nil {
 		t.Fatal("expected error when no checkpoints")
+	}
+}
+
+func TestRunGuardedPanicEmitsTurnDone(t *testing.T) {
+	sess := agent.NewSession("sys")
+	events := make(chan event.Event, 4)
+	c := New(Options{
+		Runner: appendingRunner{session: sess},
+		Sink:   event.FuncSink(func(e event.Event) { events <- e }),
+	})
+
+	go func() {
+		c.runGuarded(func(ctx context.Context) error {
+			panic("boom")
+		})
+	}()
+
+	select {
+	case e := <-events:
+		if e.Kind != event.TurnDone {
+			t.Fatalf("expected TurnDone after panic, got %v", e.Kind)
+		}
+		if e.Err == nil || !strings.Contains(e.Err.Error(), "boom") {
+			t.Fatalf("expected TurnDone.Err to contain panic message, got %v", e.Err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for TurnDone after panic")
+	}
+
+	c.mu.Lock()
+	running := c.running
+	c.mu.Unlock()
+	if running {
+		t.Fatal("c.running should be false after panic recovery")
+	}
+}
+
+func TestRunGuardedPanicDoesNotDoubleEmitTurnDone(t *testing.T) {
+	sess := agent.NewSession("sys")
+	var count int32
+	events := make(chan event.Event, 8)
+	c := New(Options{
+		Runner: appendingRunner{session: sess},
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.TurnDone {
+				atomic.AddInt32(&count, 1)
+			}
+			events <- e
+		}),
+	})
+
+	go func() {
+		c.runGuarded(func(ctx context.Context) error {
+			panic("boom")
+		})
+	}()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-events:
+			n := atomic.LoadInt32(&count)
+			if n >= 1 {
+				time.Sleep(50 * time.Millisecond)
+				n2 := atomic.LoadInt32(&count)
+				if n2 > 1 {
+					t.Fatalf("TurnDone emitted %d times, expected 1", n2)
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for TurnDone")
+		}
 	}
 }


### PR DESCRIPTION
﻿Re-lands #3893 by @ashishexee — approved after re-review (all four earlier review points addressed: top-level watchdog effect with `lastTokenAt` ref and proper deps, controlled reasoning-card open state, focused-card-only ESC, plus the original `runGuarded` panic recovery with emit-once tests). The branch conflicted with today's #3919 merge.

Conflict resolution: the controlled open state now seeds from `item.streaming || defaultExpanded`, so the new `expand_thinking` preference still expands completed cards by default while a stuck streaming card stays user-closable — both features' intents preserved.

Verified locally: `internal/control` tests pass (including both new panic-recovery tests); touched frontend files parse clean. Author credit preserved.

Closes #3893

Closes #3746
