### PR TITLE
feat: toggle Developer Tools (Cmd+I)

### DIFF
--- a/desktop/menu.go
+++ b/desktop/menu.go
@@ -27,6 +27,11 @@ func (a *App) createAppMenu() *menu.Menu {
 			runtime.EventsEmit(a.ctx, "app:open-settings")
 		}
 	})
+	fileMenu.AddText("Toggle Developer Tools", keys.CmdOrCtrl("i"), func(_ *menu.CallbackData) {
+		if a.ctx != nil {
+			runtime.WindowExecJS(a.ctx, `window.webkit.messageHandlers.external.postMessage("wails:openInspector");`)
+		}
+	})
 	fileMenu.AddText("Show Reasonix", nil, func(_ *menu.CallbackData) {
 		a.showMainWindow()
 	})


### PR DESCRIPTION
Add a native menu item "Toggle Developer Tools" (Cmd+I) that opens the WebKit Inspector via `runtime.WindowExecJS` with the `wails:openInspector` protocol.