### PR TITLE
fix(desktop): stop git.exe console flashes from workspace probes

### DIFF
--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -103,16 +103,23 @@ func (a *App) WorkspaceChanges() WorkspaceChangesView {
 	return out
 }
 
+// workspaceGit builds a console-hidden git probe: CREATE_NO_WINDOW so git's own
+// children inherit the invisible console, fsmonitor/auto-maintenance off so a
+// probe never spawns a background daemon that opens a console of its own (#3906).
+func workspaceGit(args ...string) *exec.Cmd {
+	cmd := exec.Command("git", append([]string{"-c", "core.fsmonitor=false", "-c", "maintenance.auto=false"}, args...)...)
+	proc.HideWindow(cmd)
+	return cmd
+}
+
 func workspaceGitStatus(base string) ([]gitStatusEntry, error) {
-	cmd := exec.Command("git", "-C", base, "status", "--porcelain=v1", "-z", "--untracked-files=all")
-	proc.HideWindowDetached(cmd)
+	cmd := workspaceGit("-C", base, "status", "--porcelain=v1", "-z", "--untracked-files=all")
 	raw, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
 	entries := parseGitStatusPorcelainZ(raw)
-	topCmd := exec.Command("git", "-C", base, "rev-parse", "--show-toplevel")
-	proc.HideWindowDetached(topCmd)
+	topCmd := workspaceGit("-C", base, "rev-parse", "--show-toplevel")
 	topRaw, err := topCmd.Output()
 	if err != nil {
 		return nil, err
@@ -185,8 +192,7 @@ func workspaceRelPathFromGitStatus(repoRoot, base, path string) string {
 // at base, or an empty string when base is not inside a git repository or when
 // git is unavailable.
 func workspaceGitBranch(base string) string {
-	cmd := exec.Command("git", "-C", base, "branch", "--show-current")
-	proc.HideWindowDetached(cmd)
+	cmd := workspaceGit("-C", base, "branch", "--show-current")
 	raw, err := cmd.Output()
 	if err != nil {
 		return ""
@@ -195,8 +201,7 @@ func workspaceGitBranch(base string) string {
 		return branch
 	}
 
-	headCmd := exec.Command("git", "-C", base, "rev-parse", "--short", "HEAD")
-	proc.HideWindowDetached(headCmd)
+	headCmd := workspaceGit("-C", base, "rev-parse", "--short", "HEAD")
 	raw, err = headCmd.Output()
 	if err != nil {
 		return ""
@@ -214,8 +219,7 @@ func (a *App) GitBranches() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmd := exec.Command("git", "-C", base, "branch", "--format=%(refname:short)")
-	proc.HideWindowDetached(cmd)
+	cmd := workspaceGit("-C", base, "branch", "--format=%(refname:short)")
 	raw, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -231,8 +235,7 @@ func (a *App) GitCheckout(branch string) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("git", "-C", base, "checkout", branch)
-	proc.HideWindowDetached(cmd)
+	cmd := workspaceGit("-C", base, "checkout", branch)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if len(out) > 0 {
@@ -266,8 +269,7 @@ func (a *App) WorkspaceGitHistory(path string) ([]GitCommitView, error) {
 		args = append(args, "--", path)
 	}
 
-	cmd := exec.Command("git", args...)
-	proc.HideWindowDetached(cmd)
+	cmd := workspaceGit(args...)
 	raw, err := cmd.Output()
 	if err != nil {
 		return nil, err
@@ -295,8 +297,7 @@ func (a *App) WorkspaceGitCommitDetail(hash string, path string) (GitCommitDetai
 
 	if path != "" {
 		// Single file diff
-		cmd := exec.Command("git", "-C", base, "show", "--relative", "--pretty=format:", "--patch", hash, "--", path)
-		proc.HideWindowDetached(cmd)
+		cmd := workspaceGit("-C", base, "show", "--relative", "--pretty=format:", "--patch", hash, "--", path)
 		raw, err := cmd.Output()
 		if err != nil {
 			return GitCommitDetailView{}, err
@@ -306,8 +307,7 @@ func (a *App) WorkspaceGitCommitDetail(hash string, path string) (GitCommitDetai
 	}
 
 	// Project level: list of files changed
-	cmd := exec.Command("git", "-C", base, "diff-tree", "--relative", "--no-commit-id", "--name-only", "-r", hash)
-	proc.HideWindowDetached(cmd)
+	cmd := workspaceGit("-C", base, "diff-tree", "--relative", "--no-commit-id", "--name-only", "-r", hash)
 	raw, err := cmd.Output()
 	if err != nil {
 		return GitCommitDetailView{}, err

--- a/desktop/workspace_changes_test.go
+++ b/desktop/workspace_changes_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"runtime"
+	"slices"
+	"testing"
+)
+
+func TestWorkspaceGitDisablesDaemonSpawns(t *testing.T) {
+	cmd := workspaceGit("-C", "repo", "status", "--porcelain=v1")
+	want := []string{"git", "-c", "core.fsmonitor=false", "-c", "maintenance.auto=false", "-C", "repo", "status", "--porcelain=v1"}
+	if !slices.Equal(cmd.Args, want) {
+		t.Fatalf("args = %v, want %v", cmd.Args, want)
+	}
+	if runtime.GOOS == "windows" && cmd.SysProcAttr == nil {
+		t.Fatal("workspaceGit must hide the console window on Windows")
+	}
+}

--- a/internal/proc/hide_other.go
+++ b/internal/proc/hide_other.go
@@ -6,6 +6,3 @@ import "os/exec"
 
 // HideWindow is a no-op off Windows.
 func HideWindow(*exec.Cmd) {}
-
-// HideWindowDetached is a no-op off Windows.
-func HideWindowDetached(*exec.Cmd) {}

--- a/internal/proc/hide_windows.go
+++ b/internal/proc/hide_windows.go
@@ -7,10 +7,7 @@ import (
 	"syscall"
 )
 
-const (
-	createNoWindow  = 0x08000000 // CREATE_NO_WINDOW
-	detachedProcess = 0x00000008 // DETACHED_PROCESS
-)
+const createNoWindow = 0x08000000 // CREATE_NO_WINDOW
 
 // HideWindow stops a child process from flashing a console window on Windows,
 // where a GUI parent (the desktop app) has no console of its own to inherit.
@@ -22,15 +19,4 @@ func HideWindow(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.HideWindow = true
 	cmd.SysProcAttr.CreationFlags |= createNoWindow
-}
-
-// HideWindowDetached is for short-lived desktop-only probes whose descendants
-// have been observed to flash their own console windows. Do not use it for tools
-// that rely on console-program stdout/stderr capture, such as PowerShell.
-func HideWindowDetached(cmd *exec.Cmd) {
-	if cmd.SysProcAttr == nil {
-		cmd.SysProcAttr = &syscall.SysProcAttr{}
-	}
-	cmd.SysProcAttr.HideWindow = true
-	cmd.SysProcAttr.CreationFlags |= detachedProcess
 }

--- a/internal/proc/hide_windows_test.go
+++ b/internal/proc/hide_windows_test.go
@@ -18,6 +18,7 @@ func TestHideWindowSetsCreateNoWindow(t *testing.T) {
 	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
 		t.Fatalf("CREATE_NO_WINDOW not set; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
 	}
+	const detachedProcess = 0x00000008
 	if cmd.SysProcAttr.CreationFlags&detachedProcess != 0 {
 		t.Fatalf("DETACHED_PROCESS should not be set by HideWindow; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
 	}
@@ -33,23 +34,6 @@ func TestHideWindowPreservesExistingFlags(t *testing.T) {
 	}
 	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
 		t.Fatal("HideWindow did not add CREATE_NO_WINDOW")
-	}
-}
-
-func TestHideWindowDetachedSetsDetachedProcess(t *testing.T) {
-	cmd := exec.Command("git", "status")
-	HideWindowDetached(cmd)
-	if cmd.SysProcAttr == nil {
-		t.Fatal("SysProcAttr is nil; HideWindowDetached did not set it")
-	}
-	if !cmd.SysProcAttr.HideWindow {
-		t.Fatal("HideWindowDetached did not set HideWindow")
-	}
-	if cmd.SysProcAttr.CreationFlags&createNoWindow != 0 {
-		t.Fatalf("CREATE_NO_WINDOW should not be combined with DETACHED_PROCESS; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
-	}
-	if cmd.SysProcAttr.CreationFlags&detachedProcess == 0 {
-		t.Fatalf("DETACHED_PROCESS not set; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
 	}
 }
 


### PR DESCRIPTION
﻿## Root cause

#2935 switched the desktop's workspace git probes to `DETACHED_PROCESS` to stop the probe's own console from flashing. That worked for git itself — but a detached process has **no console at all**, so any console child that git spawns (most commonly the `fsmonitor--daemon` on repos with `core.fsmonitor` enabled, or a credential helper) allocates a **new visible console**. With probes firing on app startup and on every file-change refresh, that's the stream of black `git.exe` windows reported in #3906 — including the focus steal that interrupts typing.

## Fix

- All nine workspace probes now go through one `workspaceGit` helper:
  - `CREATE_NO_WINDOW` instead of `DETACHED_PROCESS` — the probe gets an *invisible* console that its children inherit, so nothing down the tree can pop a window.
  - `-c core.fsmonitor=false -c maintenance.auto=false` — a read-only probe should never spawn a background daemon in the first place, regardless of console flags.
- `HideWindowDetached` has no callers left and is removed (both build variants + its test).
- Regression test pins the daemon-suppressing argv shape and the hidden-console attribute on Windows.

Verified: `internal/proc` tests pass, root and desktop modules build clean.

Closes #3906
