### PR TITLE
fix(control): never render compaction fold summaries as user bubbles

### DIFF
--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -69,9 +69,11 @@ func IsSyntheticUserMessage(content string) bool {
 }
 
 // syntheticPrefixes must be kept in sync with the synthetic user messages
-// injected by the controller (planApprovedMessage) and agent loop
+// injected by the controller (planApprovedMessage), agent loop
 // (streamRecoveryMessage, finalReadinessRetryMessage, emptyFinalRetryMessage,
-// executorHandoffRetryMessage in internal/agent/agent.go).
+// executorHandoffRetryMessage in internal/agent/agent.go), and compaction
+// folds (internal/agent/compact.go), which store summaries as user-role
+// messages the chat UI must never render as user bubbles (#3653).
 var syntheticPrefixes = []string{
 	"Plan approved — plan mode is off",
 	"Host final-answer readiness check failed",
@@ -80,6 +82,9 @@ var syntheticPrefixes = []string{
 	"The previous assistant response was interrupted during streaming",
 	"The previous assistant response was interrupted before visible",
 	"The previous assistant response finished without any visible answer",
+	"<compaction-summary>",
+	"Summary of the later conversation (compacted from here on):",
+	"Summary of earlier conversation (compacted up to here):",
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -620,6 +620,26 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			input: "The previous assistant response was interrupted by my VPN, can you retry?",
 			want:  false,
 		},
+		{
+			name:  "compaction fold summary",
+			input: "<compaction-summary>\nSummary of earlier conversation (older messages were compacted to save context):\nDid things with tools.\n</compaction-summary>",
+			want:  true,
+		},
+		{
+			name:  "summarize-from fold",
+			input: "Summary of the later conversation (compacted from here on):\nDid more things.",
+			want:  true,
+		},
+		{
+			name:  "summarize-upto fold",
+			input: "Summary of earlier conversation (compacted up to here):\nDid earlier things.",
+			want:  true,
+		},
+		{
+			name:  "user mentioning a summary is not synthetic",
+			input: "Summary of what I want: fix the login bug first.",
+			want:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
﻿## Root cause

Compaction folds store their summary as a **user-role** message (so the model treats it as plain context):

- `Compact` → `<compaction-summary>…` (`internal/agent/compact.go`)
- `SummarizeFrom` → `Summary of the later conversation (compacted from here on):…`
- `SummarizeUpTo` → `Summary of earlier conversation (compacted up to here):…`

The chat surfaces filter injected user-role messages through `IsSyntheticUserMessage`, but none of the three fold prefixes were registered. In the normal live flow you never notice — the transcript shows the compaction *card* built from events. The leak needs a **history reload that races a compaction pass**, which is exactly the repro @cinos-1 nailed down: tab A mid-`/compact` → switch to tab B → switch back to A. The return trip sees `local.running && !backend.running` (`missedTurnDone`), resets the transcript, and re-renders from `HistoryForTab` — which faithfully served the raw fold as a giant user bubble full of tool calls, commands, and console digests.

## Fix

Register the three fold prefixes in `syntheticPrefixes` (with the sync note extended to `compact.go`), so every history-replay surface — desktop reload, session resume, serve — drops them, matching what the live transcript shows. Table tests cover all three folds plus a guard that an ordinary user message starting with "Summary of…" is *not* swallowed.

Closes #3653
