### PR TITLE
fix(desktop): wait for the forked tab before loading its history

### DIFF
--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -897,6 +897,10 @@ export function useController() {
         const tab = await app.Fork(turn);
         if (tab?.id) {
           setActiveTabId(tab.id);
+          // The fork's controller builds in a background goroutine: an immediate
+          // load reads empty history, and the ready-event fallback can still
+          // target the source tab, leaving the fork blank (#3742).
+          await waitForTabReady(tab.id);
           await loadSessionDataForTab(tab.id, true);
         } else {
           await syncActiveTabFromBackend(true);
@@ -918,7 +922,7 @@ export function useController() {
     } finally {
       dispatchTo(sourceTabId, { type: "message_action_done" });
     }
-  }, [activeTabId, dispatchTo, loadSessionDataForTab, syncActiveTabFromBackend]);
+  }, [activeTabId, dispatchTo, loadSessionDataForTab, syncActiveTabFromBackend, waitForTabReady]);
 
   // Tab management: switch preserves per-tab state; open creates it.
   const switchTab = useCallback(async (tabId: string) => {

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -69,9 +69,11 @@ func IsSyntheticUserMessage(content string) bool {
 }
 
 // syntheticPrefixes must be kept in sync with the synthetic user messages
-// injected by the controller (planApprovedMessage) and agent loop
+// injected by the controller (planApprovedMessage), agent loop
 // (streamRecoveryMessage, finalReadinessRetryMessage, emptyFinalRetryMessage,
-// executorHandoffRetryMessage in internal/agent/agent.go).
+// executorHandoffRetryMessage in internal/agent/agent.go), and compaction
+// folds (internal/agent/compact.go), which store summaries as user-role
+// messages the chat UI must never render as user bubbles (#3653).
 var syntheticPrefixes = []string{
 	"Plan approved — plan mode is off",
 	"Host final-answer readiness check failed",
@@ -80,6 +82,9 @@ var syntheticPrefixes = []string{
 	"The previous assistant response was interrupted during streaming",
 	"The previous assistant response was interrupted before visible",
 	"The previous assistant response finished without any visible answer",
+	"<compaction-summary>",
+	"Summary of the later conversation (compacted from here on):",
+	"Summary of earlier conversation (compacted up to here):",
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -620,6 +620,26 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			input: "The previous assistant response was interrupted by my VPN, can you retry?",
 			want:  false,
 		},
+		{
+			name:  "compaction fold summary",
+			input: "<compaction-summary>\nSummary of earlier conversation (older messages were compacted to save context):\nDid things with tools.\n</compaction-summary>",
+			want:  true,
+		},
+		{
+			name:  "summarize-from fold",
+			input: "Summary of the later conversation (compacted from here on):\nDid more things.",
+			want:  true,
+		},
+		{
+			name:  "summarize-upto fold",
+			input: "Summary of earlier conversation (compacted up to here):\nDid earlier things.",
+			want:  true,
+		},
+		{
+			name:  "user mentioning a summary is not synthetic",
+			input: "Summary of what I want: fix the login bug first.",
+			want:  false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
﻿## Root cause

`Fork` returns as soon as the new tab exists, but the tab's controller — including the resume of the forked session file — builds in a **background goroutine** (`startTabControllerBuild`). The frontend's fork path then did `setActiveTabId` + `loadSessionDataForTab` immediately, so `HistoryForTab` ran against a tab with no controller yet and returned `[]` — a reset to an empty transcript.

The ready-event fallback was supposed to heal this, but it reloads `activeTabIdRef.current`, and when the backend build wins the race against React committing the new active-tab id, the reload targets the **source** tab — leaving the forked conversation permanently blank, exactly as reported.

## Fix

Gate the fork path on `waitForTabReady(tab.id)` before loading — the same deterministic gate `resumeSession` already uses for tabs it just created. The `sessionLoadSeq` guard dedupes any overlapping ready-triggered reload.

One-line behavioral change, no backend involvement.

Closes #3742
