### PR TITLE
fix(control): preserve approved plan execution across pauses

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -145,6 +145,16 @@ type Controller struct {
 	// approver). Reset when the execution turn returns.
 	approvedPlanAutoApproveTools bool
 
+	// approvedPlanActive carries that same go-ahead across user-directed pauses in
+	// an approved plan. It stays true only while the approved plan has not reported
+	// completion, so an explicit continuation turn resumes without downgrading into
+	// per-tool approval.
+	approvedPlanActive bool
+	// approvedPlanContinuationTurn is true only for the current user turn when
+	// the user explicitly asked to continue that approved plan.
+	approvedPlanContinuationTurn bool
+	approvedPlanStart            int // message index where the approved execution began
+
 	// toolApprovalMode is the runtime approval posture for permission-gated tool
 	// calls. "ask" prompts by default, "auto" lets the policy auto-approve the
 	// writer fallback while preserving ask/deny rules, and "yolo" skips every
@@ -464,6 +474,11 @@ const planApprovalTool = "exit_plan_mode"
 // the in-context nudge to execute and keep the (already-seeded) task list honest.
 const planApprovedMessage = "Plan approved — plan mode is off; you’re cleared to make the changes without asking again. Implement the plan now. Use this serial workflow: 1) mark the first sub-step in_progress with todo_write (this establishes the task list); 2) execute the sub-step; 3) call complete_step with evidence — the host then marks that sub-step completed and moves the next one to in_progress for you. Repeat 2–3 for each remaining sub-step. You don’t need another todo_write to mark steps completed; each complete_step advances the list. Sign off one sub-step at a time — never batch multiple completions."
 
+// approvedPlanExecutionMarker is prepended to later user turns while an approved
+// plan is paused with unfinished todos. It preserves the execution contract in
+// model context without mutating the cache-stable system prompt or tool schema.
+const approvedPlanExecutionMarker = "[Approved plan execution continues — the prior plan is already approved. Continue the next unfinished step without asking again for ordinary work covered by that plan. Keep todo_write current by sending the complete list whenever a step starts or finishes.]"
+
 // runTurn runs one model turn, then applies the plan-approval gate. This is the
 // single, frontend-agnostic plan flow: in plan mode the model just researches
 // (writers are blocked) and writes its plan as a normal answer — no special tool.
@@ -522,6 +537,7 @@ func (c *Controller) runGoalLoopWithRawDisplay(ctx context.Context, input, raw, 
 }
 
 func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
+	defer c.clearApprovedPlanContinuationTurn()
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
 	ctx = agent.WithParentSession(ctx, c.parentSessionID())
@@ -548,6 +564,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	if err := c.runner.Run(ctx, input); err != nil {
 		return err
 	}
+	c.refreshApprovedPlanExecutionFromHistory()
 	c.mu.Lock()
 	plan := c.planMode
 	c.mu.Unlock()
@@ -568,7 +585,8 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		return nil // keep planning; plan mode stays on
 	}
 	c.SetPlanMode(false)
-	seededTodos := c.seedPlanTodos(proposal)
+	todoArgs := c.seedPlanTodos(proposal)
+	c.beginApprovedPlanExecution(todoArgs)
 	// The plan is the go-ahead: don't re-prompt for each write of the approved
 	// work. Auto-approve writers for the duration of this execution turn only.
 	c.mu.Lock()
@@ -579,11 +597,14 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		c.approvedPlanAutoApproveTools = false
 		c.mu.Unlock()
 	}()
-	if err := c.runner.Run(ctx, planApprovedMessage); err != nil {
-		return err
+	err = c.runner.Run(ctx, planApprovedMessage)
+	if err == nil && todoArgs != "" && !c.approvedPlanHasTodoUpdateSinceStart() {
+		c.completePlanTodos(todoArgs)
+		c.clearApprovedPlanExecution()
+		return nil
 	}
-	c.completePlanTodos(seededTodos)
-	return nil
+	c.refreshApprovedPlanExecutionFromHistory()
+	return err
 }
 
 func (c *Controller) continueGoal(ctx context.Context) error {
@@ -1264,6 +1285,11 @@ func (c *Controller) ReplayPendingPrompts() {
 func (c *Controller) SetPlanMode(v bool) {
 	c.mu.Lock()
 	c.planMode = v
+	if v {
+		c.approvedPlanActive = false
+		c.approvedPlanContinuationTurn = false
+		c.approvedPlanStart = 0
+	}
 	c.mu.Unlock()
 	if c.executor != nil {
 		c.executor.SetPlanMode(v)
@@ -1372,6 +1398,7 @@ func (c *Controller) NewSession() error {
 		c.mu.Unlock()
 	}
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.clearApprovedPlanExecution()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
@@ -1403,6 +1430,7 @@ func (c *Controller) ClearSession() error {
 		c.mu.Unlock()
 	}
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.clearApprovedPlanExecution()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true
@@ -1580,6 +1608,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		c.executor.SetSession(sess)
 		c.mu.Lock()
 		c.sessionPath = newPath
+		c.clearApprovedPlanExecutionLocked()
 		c.mu.Unlock()
 		c.rebindCheckpoints(newPath)
 	}
@@ -1638,6 +1667,9 @@ func (c *Controller) Branch(name string) (string, error) {
 	c.executor.SetSession(sess)
 	c.mu.Lock()
 	c.sessionPath = newPath
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
 	c.mu.Unlock()
 	c.rebindCheckpoints(newPath)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
@@ -1684,6 +1716,9 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	}
 	c.mu.Lock()
 	c.sessionPath = match.Path
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
 	c.mu.Unlock()
 	c.rebindCheckpoints(match.Path)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
@@ -1782,6 +1817,9 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	}
 	c.mu.Lock()
 	c.sessionPath = path
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
 	c.mu.Unlock()
 	c.rebindCheckpoints(path)
 	c.maybeColdResumePrune(path)
@@ -2576,8 +2614,9 @@ type gateApprover struct{ c *Controller }
 func (g gateApprover) Approve(ctx context.Context, tool, subject string, args json.RawMessage) (bool, bool, error) {
 	subject = approvalDisplaySubject(tool, subject, args)
 	// Auto-allow without prompting while executing a just-approved plan (the plan
-	// was the approval) or while YOLO/full-access tool auto-approval is on. Deny
-	// rules already bit before this point, so they still block.
+	// was the approval), during an explicit continuation turn of that approved
+	// plan, or while YOLO/full-access tool auto-approval is on. Deny rules already
+	// bit before this point, so they still block.
 	g.c.mu.Lock()
 	auto := g.c.approvalBypassAllowsLocked(tool)
 	g.c.mu.Unlock()
@@ -2783,6 +2822,108 @@ func parsePlanTodos(plan string) []seedTodo {
 	return todos
 }
 
+func (c *Controller) beginApprovedPlanExecution(todoArgs string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.approvedPlanActive = true
+	if todoArgs != "" {
+		c.approvedPlanActive = todosIncomplete(todoArgs)
+	}
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
+	if c.executor != nil {
+		c.approvedPlanStart = len(c.executor.Session().Messages)
+	}
+}
+
+func (c *Controller) clearApprovedPlanExecution() {
+	c.mu.Lock()
+	c.clearApprovedPlanExecutionLocked()
+	c.mu.Unlock()
+}
+
+func (c *Controller) clearApprovedPlanExecutionLocked() {
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
+}
+
+func (c *Controller) clearApprovedPlanContinuationTurn() {
+	c.mu.Lock()
+	c.approvedPlanContinuationTurn = false
+	c.mu.Unlock()
+}
+
+func (c *Controller) refreshApprovedPlanExecutionFromHistory() {
+	c.mu.Lock()
+	active := c.approvedPlanActive
+	start := c.approvedPlanStart
+	c.mu.Unlock()
+	if !active || c.executor == nil {
+		return
+	}
+	msgs := c.executor.Session().Messages
+	if start < 0 || start > len(msgs) {
+		start = len(msgs)
+	}
+	args, ok := latestTodoArgsSince(msgs, start)
+	if !ok {
+		return
+	}
+	c.mu.Lock()
+	c.approvedPlanActive = todosIncomplete(args)
+	if !c.approvedPlanActive {
+		c.approvedPlanContinuationTurn = false
+		c.approvedPlanStart = 0
+	}
+	c.mu.Unlock()
+}
+
+func (c *Controller) approvedPlanHasTodoUpdateSinceStart() bool {
+	c.mu.Lock()
+	active := c.approvedPlanActive
+	start := c.approvedPlanStart
+	c.mu.Unlock()
+	if !active || c.executor == nil {
+		return false
+	}
+	msgs := c.executor.Session().Messages
+	if start < 0 || start > len(msgs) {
+		start = len(msgs)
+	}
+	_, ok := latestTodoArgsSince(msgs, start)
+	return ok
+}
+
+func latestTodoArgsSince(msgs []provider.Message, start int) (string, bool) {
+	for i := len(msgs) - 1; i >= start; i-- {
+		for j := len(msgs[i].ToolCalls) - 1; j >= 0; j-- {
+			tc := msgs[i].ToolCalls[j]
+			if tc.Name == "todo_write" {
+				return tc.Arguments, true
+			}
+		}
+	}
+	return "", false
+}
+
+func todosIncomplete(args string) bool {
+	var p struct {
+		Todos []struct {
+			Status string `json:"status"`
+		} `json:"todos"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil || len(p.Todos) == 0 {
+		return false
+	}
+	for _, t := range p.Todos {
+		if t.Status != "completed" {
+			return true
+		}
+	}
+	return false
+}
+
 // listItem parses a markdown list line ("- x", "* x", "1. x", "2) x") into its
 // task text and a nesting level derived from leading indentation (0 for a
 // top-level item, 1 for an indented sub-step — capped at 1 since the plan is
@@ -2946,7 +3087,12 @@ func approvalNotificationText(tool, subject string) string {
 }
 
 func (c *Controller) approvalBypassAllowsLocked(tool string) bool {
-	return !requiresFreshApprovalTool(tool) && (c.toolApprovalMode == ToolApprovalYolo || c.approvedPlanAutoApproveTools)
+	if requiresFreshApprovalTool(tool) {
+		return false
+	}
+	return c.toolApprovalMode == ToolApprovalYolo ||
+		c.approvedPlanAutoApproveTools ||
+		(c.approvedPlanActive && c.approvedPlanContinuationTurn)
 }
 
 func (c *Controller) autoApprovalWouldAllowLocked(tool, subject string) bool {

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -679,3 +679,200 @@ func TestMidTurnAutosavePersistsDuringLongTurn(t *testing.T) {
 	}
 	t.Fatal("session file was not written while the turn was still running")
 }
+
+type scriptedRunner struct {
+	exec    *agent.Agent
+	scripts []func(input string)
+}
+
+func (r *scriptedRunner) Run(_ context.Context, input string) error {
+	if len(r.scripts) == 0 {
+		return nil
+	}
+	next := r.scripts[0]
+	r.scripts = r.scripts[1:]
+	next(input)
+	return nil
+}
+
+func TestApprovedPlanSurvivesUserPauseUntilTodosComplete(t *testing.T) {
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	runner := &scriptedRunner{exec: exec}
+
+	var c *Controller
+	approvalPrompts := 0
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind != event.ApprovalRequest {
+			return
+		}
+		approvalPrompts++
+		if e.Approval.Tool == planApprovalTool {
+			go c.Approve(e.Approval.ID, true, false, false)
+			return
+		}
+		go c.Approve(e.Approval.ID, false, false, false)
+	})
+	c = New(Options{Runner: runner, Executor: exec, Sink: sink})
+	c.SetPlanMode(true)
+
+	runner.scripts = append(runner.scripts,
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "1. Create the file\n2. Update the file"})
+		},
+		func(input string) {
+			if input != planApprovedMessage {
+				t.Fatalf("approved execution input = %q, want planApprovedMessage", input)
+			}
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "first step done; paused for review", ToolCalls: []provider.ToolCall{{
+				ID: "todo-1", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"in_progress"}]}`,
+			}}})
+		},
+	)
+
+	if err := c.runTurn(context.Background(), "plan this"); err != nil {
+		t.Fatal(err)
+	}
+	if approvalPrompts != 1 {
+		t.Fatalf("approval prompts after plan = %d, want 1", approvalPrompts)
+	}
+
+	if got := c.Compose("继续"); got == "继续" {
+		t.Fatal("continuation turn should carry the approved-plan execution marker")
+	}
+	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
+	if err != nil || !allow {
+		t.Fatalf("writer during unfinished approved plan = (%v,%v), want auto-allow", allow, err)
+	}
+	if approvalPrompts != 1 {
+		t.Fatalf("unfinished approved plan should not prompt for writer, prompts=%d", approvalPrompts)
+	}
+
+	runner.scripts = append(runner.scripts, func(input string) {
+		exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "all done", ToolCalls: []provider.ToolCall{{
+			ID: "todo-2", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"completed"}]}`,
+		}}})
+	})
+	if err := c.runTurn(context.Background(), c.Compose("继续")); err != nil {
+		t.Fatal(err)
+	}
+
+	allow, _, err = gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/b", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allow {
+		t.Fatal("writer after approved plan completion should return to normal approval flow")
+	}
+	if approvalPrompts != 2 {
+		t.Fatalf("writer after completion should prompt once, prompts=%d", approvalPrompts)
+	}
+}
+
+func TestApprovedPlanDoesNotAutoApproveNonContinuationTurn(t *testing.T) {
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	runner := &scriptedRunner{exec: exec}
+
+	var c *Controller
+	approvalPrompts := 0
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind != event.ApprovalRequest {
+			return
+		}
+		approvalPrompts++
+		if e.Approval.Tool == planApprovalTool {
+			go c.Approve(e.Approval.ID, true, false, false)
+			return
+		}
+		go c.Approve(e.Approval.ID, false, false, false)
+	})
+	c = New(Options{Runner: runner, Executor: exec, Sink: sink})
+	c.SetPlanMode(true)
+
+	runner.scripts = append(runner.scripts,
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "1. Create the file\n2. Update the file"})
+		},
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "paused", ToolCalls: []provider.ToolCall{{
+				ID: "todo-1", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"in_progress"}]}`,
+			}}})
+		},
+	)
+
+	if err := c.runTurn(context.Background(), "plan this"); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Compose("先别继续"); got != "先别继续" {
+		t.Fatalf("non-continuation input should not be marker-prefixed, got %q", got)
+	}
+
+	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allow {
+		t.Fatal("non-continuation turn should not inherit approved-plan auto approval")
+	}
+	if approvalPrompts != 2 {
+		t.Fatalf("non-continuation writer should prompt after plan approval, prompts=%d", approvalPrompts)
+	}
+}
+
+func TestApprovedPlanContinuationWorksWithoutSeededTodos(t *testing.T) {
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	runner := &scriptedRunner{exec: exec}
+
+	var c *Controller
+	approvalPrompts := 0
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind != event.ApprovalRequest {
+			return
+		}
+		approvalPrompts++
+		if e.Approval.Tool == planApprovalTool {
+			go c.Approve(e.Approval.ID, true, false, false)
+			return
+		}
+		go c.Approve(e.Approval.ID, false, false, false)
+	})
+	c = New(Options{Runner: runner, Executor: exec, Sink: sink})
+	c.SetPlanMode(true)
+
+	runner.scripts = append(runner.scripts,
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "先创建文件，然后暂停让我审核。审核通过后继续修改文件。"})
+		},
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "first step done; paused for review"})
+		},
+	)
+
+	if err := c.runTurn(context.Background(), "plan this"); err != nil {
+		t.Fatal(err)
+	}
+	if approvalPrompts != 1 {
+		t.Fatalf("approval prompts after prose plan = %d, want 1", approvalPrompts)
+	}
+
+	if got := c.Compose("continue"); got == "continue" {
+		t.Fatal("explicit continuation should carry the approved-plan execution marker")
+	}
+	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
+	if err != nil || !allow {
+		t.Fatalf("writer during prose-plan continuation = (%v,%v), want auto-allow", allow, err)
+	}
+
+	if got := c.Compose("revise the plan"); got != "revise the plan" {
+		t.Fatalf("non-continuation after prose plan should not be marker-prefixed, got %q", got)
+	}
+	allow, _, err = gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/b", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allow {
+		t.Fatal("non-continuation after prose plan should return to normal approval flow")
+	}
+	if approvalPrompts != 2 {
+		t.Fatalf("writer after non-continuation should prompt once, prompts=%d", approvalPrompts)
+	}
+}

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -89,14 +89,27 @@ var syntheticPrefixes = []string{
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,
 // returning the message to actually send to the model. The frontend keeps
-// showing the raw text as the user bubble.
+// showing the raw text as the user bubble. When an approved plan is paused,
+// only an explicit continuation command carries that approval into the next turn.
 func (c *Controller) Compose(text string) string {
 	c.mu.Lock()
 	plan := c.planMode
 	goal := c.goal
 	goalStatus := c.goalStatus
+	approvedPlan := c.approvedPlanActive
+	continuation := false
 	notes := c.pendingMemory
 	c.pendingMemory = nil
+	if !plan && approvedPlan {
+		continuation = isApprovedPlanContinuation(text)
+		if continuation {
+			c.approvedPlanContinuationTurn = true
+		} else {
+			c.approvedPlanActive = false
+			c.approvedPlanContinuationTurn = false
+			c.approvedPlanStart = 0
+		}
+	}
 	c.mu.Unlock()
 
 	if strings.TrimSpace(goal) != "" && goalStatus == GoalStatusRunning {
@@ -104,6 +117,8 @@ func (c *Controller) Compose(text string) string {
 	}
 	if plan {
 		text = PlanModeMarker + "\n\n" + text
+	} else if continuation {
+		text = approvedPlanExecutionMarker + "\n\n" + text
 	}
 
 	// Memory added mid-session rides the turn (never the cached system prefix),
@@ -143,6 +158,19 @@ func activeGoalBlock(goal string) string {
 	b.WriteString("\n")
 	b.WriteString(activeGoalClose)
 	return b.String()
+}
+
+func isApprovedPlanContinuation(text string) bool {
+	s := strings.ToLower(strings.TrimSpace(text))
+	s = strings.TrimRight(s, ".。!！")
+	s = strings.Join(strings.Fields(s), " ")
+	switch s {
+	case "继续", "继续执行", "继续吧", "接着执行", "下一步", "执行下一步",
+		"continue", "resume", "proceed", "go on", "continue execution":
+		return true
+	default:
+		return false
+	}
 }
 
 // MemoryQuickAddNote parses the "# <note>" memory shortcut. The space after


### PR DESCRIPTION
Fixes #3760

## Summary
- Preserve approved plan execution state across user-directed pauses.
- Require an explicit continuation turn before carrying approved-plan auto-approval across turns.
- Keep prose/no-list approved plans resumable even when initial todo seeding is unavailable.

## Root Cause
Plan approval previously set auto-approval only for the immediate execution turn after `exit_plan_mode`. If the model paused for user review, that turn ended and auto-approval was reset. The next `continue` turn no longer had structured approved-plan state, so writer tools went through the normal approval gate and the task list could stop updating.

## Fix
- Add controller-scoped approved-plan execution state.
- Split session-level approved-plan activity from per-turn continuation authorization.
- Inject an approved-plan continuation marker only for explicit continuation commands.
- Auto-allow ordinary writer tools only during the immediate approved turn or an explicit continuation turn.
- Support approved prose plans without seeded markdown todos.
- Clear approved-plan scope on completed `todo_write`, non-continuation input, or session/plan context changes.

## Validation
- `gofmt -l .`
- `go test ./...`

## Note
The desktop top-level package requires `frontend/dist` before `go test .`; without built frontend assets it fails at embed setup. This is unrelated to the controller fix.