### PR TITLE
fix(control,desktop): keep steer messages out of the turn count

### DIFF
--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -724,11 +724,11 @@ export function useController() {
 
   const steer = useCallback((text: string) => {
     if (!activeTabId) return;
-    // Steer is queued to the agent and persisted to session for history
-    dispatchTo(activeTabId, { type: "user", text, seq: getOrCreateState(statesRef.current, activeTabId).seq });
-    // Steer event drives a compact guidance notice in the transcript,
+    // No optimistic user bubble: rewind/fork map turns by counting user items,
+    // and a steer is not a backend turn — the Steer event's ↪ notice is the
+    // visible confirmation (#3660).
     app.SteerForTab(activeTabId, text).catch(() => {});
-  }, [activeTabId, dispatchTo]);
+  }, [activeTabId]);
 
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
     if (!activeTabId) return;

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -85,6 +85,7 @@ var syntheticPrefixes = []string{
 	"<compaction-summary>",
 	"Summary of the later conversation (compacted from here on):",
 	"Summary of earlier conversation (compacted up to here):",
+	"[Mid-turn steer queued by the user.",
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -640,6 +640,11 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			input: "Summary of what I want: fix the login bug first.",
 			want:  false,
 		},
+		{
+			name:  "mid-turn steer wrapper",
+			input: "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]\nplease use smaller diffs",
+			want:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
﻿Follow-up hardening for the turn-mapping invariant behind #3660.

`rewind`/`fork` resolve a clicked message to a backend turn by **counting user bubbles** in the transcript, so any user-role item that is not a real backend turn shifts every later target. #3932 removed the compaction-fold phantoms; this closes the remaining (freshly introduced) source: mid-turn steers from #3360 added a user bubble live *and* replayed their persisted `[Mid-turn steer queued by the user.…]` wrapper as another one.

- `syntheticPrefixes` gains the steer wrapper, so history replay (desktop, serve, resume) no longer renders it as a user bubble.
- The live `steer()` path drops its optimistic user-bubble dispatch — the `Steer` event's `↪` notice (which #3360 added precisely as the delivery confirmation) is the visible trace, live and after reload, keeping both representations consistent.

Table test covers the wrapper prefix.
