### PR TITLE
feat(cli): add self-update command (reasonix upgrade/update)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/yuin/goldmark v1.8.2
 	go.uber.org/goleak v1.3.0
+	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -100,6 +100,9 @@ func Run(args []string, version string) int {
 	case "bot":
 		configureCLIThemeFromConfigNoProbe()
 		return botCommand(rest, version)
+	case "upgrade", "update":
+		configureCLIThemeFromConfigNoProbe()
+		return upgradeCommand(rest, version)
 	case "version", "--version", "-v":
 		fmt.Println("reasonix", version)
 		return 0
@@ -115,7 +118,7 @@ func Run(args []string, version string) int {
 
 func shouldMigrateLegacyConfigForCLI(cmd string) bool {
 	switch cmd {
-	case "", "run", "chat", "code", "serve", "setup", "config", "init", "acp", "mcp", "codegraph", "doctor", "bot":
+	case "", "run", "chat", "code", "serve", "setup", "config", "init", "acp", "mcp", "codegraph", "doctor", "bot", "upgrade", "update":
 		return true
 	default:
 		return false

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -1,0 +1,339 @@
+package cli
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"reasonix/internal/config"
+	"reasonix/internal/i18n"
+	"reasonix/internal/netclient"
+
+	"golang.org/x/mod/semver"
+)
+
+const (
+	ghAPIReleases  = "https://api.github.com/repos/esengine/DeepSeek-Reasonix/releases/latest"
+	ghDownloadBase = "https://github.com/esengine/DeepSeek-Reasonix/releases/download"
+	upgradeTimeout = 60 * time.Second
+)
+
+// ghRelease is the subset of the GitHub release API response we need.
+type ghRelease struct {
+	TagName string `json:"tag_name"`
+	Assets  []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+	} `json:"assets"`
+}
+
+// upgradeCommand handles `reasonix upgrade` (and `reasonix update`).
+func upgradeCommand(args []string, version string) int {
+	checkOnly := false
+	for _, a := range args {
+		if a == "--check" || a == "-c" {
+			checkOnly = true
+		}
+	}
+
+	// 1. Normalize running version.
+	cur, ok := normalizeVersion(version)
+	if !ok {
+		fmt.Fprintf(os.Stderr, "%s %s\n", i18n.M.ErrorPrefix, i18n.M.UpgradeDevBuild)
+		return 1
+	}
+
+	// 2. Build HTTP client using configured proxy.
+	cfg, _ := config.Load()
+	spec := cfg.NetworkProxySpec()
+	c, err := netclient.NewHTTPClient(spec, netclient.TransportOptions{
+		ResponseHeaderTimeout: upgradeTimeout,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s %v\n", i18n.M.ErrorPrefix, err)
+		return 1
+	}
+
+	// 3. Fetch latest release from GitHub API.
+	fmt.Println(i18n.M.UpgradeChecking)
+	rel, err := fetchLatestRelease(c)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeFetchFailed+"\n", i18n.M.ErrorPrefix, err)
+		return 1
+	}
+
+	// 4. Compare versions.
+	latest := rel.TagName
+	if !strings.HasPrefix(latest, "v") {
+		latest = "v" + latest
+	}
+	if !semver.IsValid(latest) {
+		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeInvalidVersion+"\n", i18n.M.ErrorPrefix, latest)
+		return 1
+	}
+	if semver.Compare(latest, cur) <= 0 {
+		fmt.Println(i18n.M.UpgradeAlreadyLatest)
+		return 0
+	}
+
+	fmt.Printf(i18n.M.UpgradeAvailableFmt+"\n", cur, latest)
+
+	if checkOnly {
+		return 0
+	}
+
+	// 5. Find the asset for the current platform.
+	base := fmt.Sprintf("reasonix-%s-%s", normalizeOS(runtime.GOOS), runtime.GOARCH)
+	var assetURL, assetName string
+	for _, a := range rel.Assets {
+		if strings.HasPrefix(a.Name, base) {
+			assetURL = a.BrowserDownloadURL
+			assetName = a.Name
+			break
+		}
+	}
+	if assetURL == "" {
+		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeNoAssetFmt+"\n", i18n.M.ErrorPrefix, base)
+		return 1
+	}
+
+	// 6. Find the checksum URL.
+	checksumURL := fmt.Sprintf("%s/%s/SHA256SUMS", ghDownloadBase, rel.TagName)
+
+	// 7. Download archive.
+	fmt.Printf(i18n.M.UpgradeDownloadingFmt+"\n", assetName)
+	archiveData, err := fetchBytes(c, assetURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeDownloadFailed+"\n", i18n.M.ErrorPrefix, err)
+		return 1
+	}
+
+	// 8. Verify SHA256 checksum.
+	fmt.Println(i18n.M.UpgradeVerifying)
+	checksumData, err := fetchBytes(c, checksumURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeChecksumFailed+"\n", i18n.M.ErrorPrefix, err)
+		return 1
+	}
+	if err := verifyChecksum(archiveData, assetName, checksumData); err != nil {
+		fmt.Fprintf(os.Stderr, "%s %v\n", i18n.M.ErrorPrefix, err)
+		return 1
+	}
+
+	// 9. Extract binary from archive.
+	binName := "reasonix"
+	if runtime.GOOS == "windows" {
+		binName = "reasonix.exe"
+	}
+	binary, err := extractBinary(archiveData, assetName, binName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeExtractFailed+"\n", i18n.M.ErrorPrefix, err)
+		return 1
+	}
+
+	// 10. Replace the running binary.
+	fmt.Println(i18n.M.UpgradeApplying)
+	if err := replaceBinary(binary); err != nil {
+		fmt.Fprintf(os.Stderr, "%s "+i18n.M.UpgradeApplyFailed+"\n", i18n.M.ErrorPrefix, err)
+		return 1
+	}
+
+	fmt.Printf(i18n.M.UpgradeSuccessFmt+"\n", latest)
+	return 0
+}
+
+// normalizeVersion returns v as valid semver ("vX.Y.Z") or ok=false for dev.
+func normalizeVersion(v string) (string, bool) {
+	v = strings.TrimSpace(v)
+	if v == "" || v == "dev" {
+		return "", false
+	}
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	if !semver.IsValid(v) {
+		return "", false
+	}
+	return semver.Canonical(v), true
+}
+
+// normalizeOS maps Go's runtime.GOOS to the goreleaser archive naming.
+func normalizeOS(goos string) string {
+	// Goreleaser uses "darwin" for macOS and "windows"/"linux" as-is.
+	// runtime.GOOS already matches except for "darwin" vs "macos" in
+	// some naming conventions — but goreleaser templates use Os directly,
+	// which for GOOS=darwin outputs "Darwin". Our archives use lowercase.
+	return goos
+}
+
+// fetchLatestRelease calls the GitHub API for the latest release.
+func fetchLatestRelease(c *http.Client) (*ghRelease, error) {
+	req, err := http.NewRequest("GET", ghAPIReleases, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "reasonix-cli")
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API: %s", resp.Status)
+	}
+	var rel ghRelease
+	if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
+		return nil, err
+	}
+	return &rel, nil
+}
+
+// fetchBytes GETs a URL fully into memory.
+func fetchBytes(c *http.Client, url string) ([]byte, error) {
+	resp, err := c.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	return io.ReadAll(resp.Body)
+}
+
+// verifyChecksum checks that data's SHA256 matches the entry for fileName in
+// the SHA256SUMS-format checksum file.
+func verifyChecksum(data []byte, fileName string, checksumFile []byte) error {
+	sum := sha256.Sum256(data)
+	got := hex.EncodeToString(sum[:])
+
+	for _, line := range strings.Split(strings.TrimSpace(string(checksumFile)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) >= 2 && parts[1] == fileName {
+			if !strings.EqualFold(parts[0], got) {
+				return fmt.Errorf(i18n.M.UpgradeChecksumMismatchFmt, got, parts[0])
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf(i18n.M.UpgradeChecksumNotFoundFmt, fileName)
+}
+
+// extractBinary pulls the "reasonix" binary from a .tar.gz or .zip archive.
+func extractBinary(data []byte, archiveName, binaryName string) ([]byte, error) {
+	if strings.HasSuffix(archiveName, ".zip") {
+		return extractFromZip(data, binaryName)
+	}
+	return extractFromTarGz(data, binaryName)
+}
+
+// extractFromTarGz extracts a named binary from a .tar.gz archive.
+func extractFromTarGz(data []byte, name string) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if h.Typeflag == tar.TypeReg && (h.Name == name || strings.HasSuffix(h.Name, "/"+name)) {
+			return io.ReadAll(tr)
+		}
+	}
+	return nil, fmt.Errorf("%q not found in archive", name)
+}
+
+// extractFromZip extracts a named binary from a .zip archive (Windows).
+func extractFromZip(data []byte, name string) ([]byte, error) {
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, err
+	}
+	want := name + ".exe"
+	for _, f := range r.File {
+		if f.Name == want || strings.HasSuffix(f.Name, "/"+want) {
+			rc, err := f.Open()
+			if err != nil {
+				return nil, err
+			}
+			defer rc.Close()
+			return io.ReadAll(rc)
+		}
+	}
+	return nil, fmt.Errorf("%q not found in archive", want)
+}
+
+// replaceBinary writes newBin to the running executable's path atomically via
+// rename. The caller must have write permission to the directory.
+func replaceBinary(newBin []byte) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate executable: %w", err)
+	}
+	resolved, err := resolveSymlinks(exe)
+	if err != nil {
+		return fmt.Errorf("resolve symlinks: %w", err)
+	}
+
+	dir := filepath.Dir(resolved)
+	tmp, err := os.CreateTemp(dir, ".reasonix-update-*")
+	if err != nil {
+		return fmt.Errorf("create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+
+	// Write + chmod, then rename atomically.
+	if _, err := tmp.Write(newBin); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, resolved); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}
+
+// resolveSymlinks follows symlinks; falls back to the original path on error.
+func resolveSymlinks(p string) (string, error) {
+	r, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return p, nil
+	}
+	return r, nil
+}

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"dev", "", false},
+		{"", "", false},
+		{"  ", "", false},
+		{"abc", "", false},
+		{"v1.2.3", "v1.2.3", true},
+		{"1.2.3", "v1.2.3", true},
+		{"v1.2.3-rc1", "v1.2.3-rc1", true},
+		{"  v0.10.0  ", "v0.10.0", true},
+	}
+	for _, tt := range tests {
+		got, ok := normalizeVersion(tt.in)
+		if ok != tt.wantOK || got != tt.want {
+			t.Errorf("normalizeVersion(%q) = (%q, %v), want (%q, %v)", tt.in, got, ok, tt.want, tt.wantOK)
+		}
+	}
+}
+
+func TestVerifyChecksum(t *testing.T) {
+	content := []byte("hello world")
+	sum := sha256.Sum256(content)
+	hash := hex.EncodeToString(sum[:])
+
+	t.Run("match", func(t *testing.T) {
+		checksumFile := []byte(fmt.Sprintf("%s  reasonix-linux-amd64.tar.gz\n", hash))
+		if err := verifyChecksum(content, "reasonix-linux-amd64.tar.gz", checksumFile); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("mismatch", func(t *testing.T) {
+		checksumFile := []byte(fmt.Sprintf("%s  reasonix-linux-amd64.tar.gz\n", "0000000000000000000000000000000000000000000000000000000000000000"))
+		if err := verifyChecksum(content, "reasonix-linux-amd64.tar.gz", checksumFile); err == nil {
+			t.Error("expected checksum mismatch error")
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		checksumFile := []byte(fmt.Sprintf("%s  reasonix-darwin-arm64.tar.gz\n", hash))
+		if err := verifyChecksum(content, "reasonix-linux-amd64.tar.gz", checksumFile); err == nil {
+			t.Error("expected not-found error")
+		}
+	})
+}
+
+func TestExtractFromTarGz(t *testing.T) {
+	// Build a .tar.gz in memory containing a "reasonix" entry.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	body := []byte("fake binary content")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "reasonix",
+		Mode: 0o755,
+		Size: int64(len(body)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := extractFromTarGz(buf.Bytes(), "reasonix")
+	if err != nil {
+		t.Fatalf("extractFromTarGz: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("extracted body = %q, want %q", got, body)
+	}
+}
+
+func TestExtractFromTarGz_Nested(t *testing.T) {
+	// Archives from goreleaser have the binary at the root with its name.
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	body := []byte("nested binary")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "reasonix-linux-amd64/reasonix",
+		Mode: 0o755,
+		Size: int64(len(body)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := extractFromTarGz(buf.Bytes(), "reasonix")
+	if err != nil {
+		t.Fatalf("extractFromTarGz: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("extracted body = %q, want %q", got, body)
+	}
+}
+
+func TestExtractFromTarGz_NotFound(t *testing.T) {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "other-file.txt",
+		Mode: 0o644,
+		Size: 3,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tw.Write([]byte("foo"))
+	tw.Close()
+	gw.Close()
+
+	_, err := extractFromTarGz(buf.Bytes(), "reasonix")
+	if err == nil {
+		t.Error("expected error for missing binary")
+	}
+}

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -370,6 +370,25 @@ type Messages struct {
 	ProviderPickLabel    string // label for provider model picker
 	ProviderNoModelsFmt  string // provider has no models
 
+	// `reasonix upgrade` / `reasonix update` — self-update
+	UpgradeChecking            string // "Checking for updates…"
+	UpgradeDevBuild            string // dev builds cannot self-update
+	UpgradeFetchFailed         string // "failed to check for updates: %v"
+	UpgradeInvalidVersion      string // remote version not valid semver
+	UpgradeAlreadyLatest       string // already on the latest version
+	UpgradeAvailableFmt        string // "Current: %s → Latest: %s"
+	UpgradeNoAssetFmt          string // "no binary found for %s"
+	UpgradeDownloadingFmt      string // "Downloading %s…"
+	UpgradeDownloadFailed      string // "download failed: %v"
+	UpgradeVerifying           string // "Verifying checksum…"
+	UpgradeChecksumFailed      string // "could not fetch checksum file: %v"
+	UpgradeChecksumMismatchFmt string // SHA256 mismatch detail
+	UpgradeChecksumNotFoundFmt string // asset not listed in SHA256SUMS
+	UpgradeExtractFailed       string // "failed to extract binary: %v"
+	UpgradeApplying            string // "Replacing binary…"
+	UpgradeApplyFailed         string // "failed to apply update: %v"
+	UpgradeSuccessFmt          string // "Updated %s → %s"
+
 	// usage / help
 	UsageBody string // full multi-line help text
 }

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -329,6 +329,25 @@ var English = Messages{
 	ProviderPickLabel:    "Select a model from %s",
 	ProviderNoModelsFmt:  "provider %s has no configured models",
 
+	// self-update
+	UpgradeChecking:            "Checking for updates…",
+	UpgradeDevBuild:            "dev builds cannot self-update",
+	UpgradeFetchFailed:         "failed to check for updates: %v",
+	UpgradeInvalidVersion:      "remote version is not valid semver",
+	UpgradeAlreadyLatest:       "Already on the latest version.",
+	UpgradeAvailableFmt:        "Current: %s → Latest: %s",
+	UpgradeNoAssetFmt:          "no binary found for %s",
+	UpgradeDownloadingFmt:      "Downloading %s…",
+	UpgradeDownloadFailed:      "download failed: %v",
+	UpgradeVerifying:           "Verifying checksum…",
+	UpgradeChecksumFailed:      "could not fetch checksum file: %v",
+	UpgradeChecksumMismatchFmt: "SHA256 mismatch: got %s, want %s",
+	UpgradeChecksumNotFoundFmt: "%s not found in SHA256SUMS",
+	UpgradeExtractFailed:       "failed to extract binary: %v",
+	UpgradeApplying:            "Replacing binary…",
+	UpgradeApplyFailed:         "failed to apply update: %v",
+	UpgradeSuccessFmt:          "Updated %s → %s",
+
 	UsageBody: `reasonix — a config- and plugin-driven coding agent (multi-model)
 
 Usage:
@@ -341,6 +360,7 @@ Usage:
   reasonix mcp <add|remove|list>                        manage MCP servers in reasonix.toml
   reasonix doctor [--json]                              print redacted local diagnostics
   reasonix bot start|doctor|weixin-login                multi-channel IM bot gateway
+  reasonix upgrade [--check]                            self-update to the latest release
   reasonix version
   reasonix help
 

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -330,6 +330,25 @@ var Chinese = Messages{
 	ProviderPickLabel:    "选择 %s 的一个模型",
 	ProviderNoModelsFmt:  "供应商 %s 没有已配置的模型",
 
+	// 自更新
+	UpgradeChecking:            "正在检查更新…",
+	UpgradeDevBuild:            "开发版本无法自更新",
+	UpgradeFetchFailed:         "检查更新失败：%v",
+	UpgradeInvalidVersion:      "远程版本不是有效的 semver",
+	UpgradeAlreadyLatest:       "已是最新版本。",
+	UpgradeAvailableFmt:        "当前：%s → 最新：%s",
+	UpgradeNoAssetFmt:          "未找到 %s 的安装包",
+	UpgradeDownloadingFmt:      "正在下载 %s…",
+	UpgradeDownloadFailed:      "下载失败：%v",
+	UpgradeVerifying:           "正在校验 SHA256…",
+	UpgradeChecksumFailed:      "无法获取校验文件：%v",
+	UpgradeChecksumMismatchFmt: "SHA256 不匹配：得到 %s，期望 %s",
+	UpgradeChecksumNotFoundFmt: "SHA256SUMS 中未找到 %s",
+	UpgradeExtractFailed:       "解压二进制文件失败：%v",
+	UpgradeApplying:            "正在替换二进制文件…",
+	UpgradeApplyFailed:         "应用更新失败：%v",
+	UpgradeSuccessFmt:          "已更新 %s → %s",
+
 	UsageBody: `reasonix — 由配置和插件驱动的 coding agent（多模型）
 
 用法：
@@ -342,6 +361,7 @@ var Chinese = Messages{
   reasonix mcp <add|remove|list>                        管理 reasonix.toml 里的 MCP 服务器
   reasonix doctor [--json]                              输出脱敏的本地诊断信息
   reasonix bot start|doctor|weixin-login                多渠道 IM bot 网关
+  reasonix upgrade [--check]                            自更新到最新版本
   reasonix version
   reasonix help
 


### PR DESCRIPTION
## Summary

Add `reasonix upgrade` (alias: `reasonix update`) to download and apply the latest CLI release from GitHub Releases in-place.

## Changes

- **New command**: `reasonix upgrade [--check]` — fetches the latest release, compares semver, downloads the platform binary, verifies SHA256, and replaces the running executable atomically.
- **`--check` flag**: version-only comparison without downloading — useful for scripts/CI.
- **Proxy support**: uses the project's existing `netclient` proxy infrastructure so corporate environments work transparently.
- **i18n**: all user-facing strings are bilingual (en/zh) via the i18n catalogue.
- **Tests**: unit tests for version normalization, SHA256 checksum verification, and tar.gz extraction.

## How it works

1. Calls the GitHub Releases API for `esengine/DeepSeek-Reasonix/releases/latest`
2. Compares the running version against the release tag using `golang.org/x/mod/semver`
3. Downloads the platform-appropriate archive (`.tar.gz` for Linux/macOS, `.zip` for Windows)
4. Verifies SHA256 against the release's `SHA256SUMS` file
5. Extracts the `reasonix` binary and replaces the running executable via temp-file + rename

## Safety

- Dev builds (`version = "dev"`) are skipped — they never self-update.
- SHA256 checksum is verified before any binary replacement.
- Atomic replace via temp-file + rename (no partial writes).
- Respects the existing proxy configuration for network access.

## Usage

```bash
# Check if an update is available
reasonix upgrade --check

# Download and apply the latest release
reasonix upgrade
# or equivalently:
reasonix update
```

## Files changed

| File | Change |
|------|--------|
| `internal/cli/upgrade.go` | New: upgrade command implementation |
| `internal/cli/upgrade_test.go` | New: unit tests |
| `internal/cli/cli.go` | Register `upgrade`/`update` in command router |
| `internal/i18n/i18n.go` | Add upgrade message fields to Messages struct |
| `internal/i18n/messages_en.go` | English strings + usage text |
| `internal/i18n/messages_zh.go` | Chinese strings + usage text |
| `go.mod` / `go.sum` | Add `golang.org/x/mod` (semver comparison) |