### PR TITLE
fix(desktop): preserve selected message copy

### DIFF
--- a/desktop/frontend/package.json
+++ b/desktop/frontend/package.json
@@ -10,9 +10,9 @@
     "check:css": "node scripts/check-css-syntax.mjs src/styles.css && node scripts/check-z-index-tokens.mjs src/styles.css",
     "test:todo-visibility": "node scripts/test-todo-visibility.mjs",
     "typecheck": "tsc --noEmit",
-    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts && tsx src/__tests__/send-failed.test.ts",
+    "test": "tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts && tsx src/__tests__/send-failed.test.ts && tsx src/__tests__/message-selection-copy.test.ts",
     "test:typecheck": "tsc --noEmit -p tsconfig.test.json",
-    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts && tsx src/__tests__/send-failed.test.ts"
+    "test:all": "tsc --noEmit -p tsconfig.test.json && tsx src/__tests__/math-golden.test.ts && tsx src/__tests__/text-size.test.ts && tsx src/__tests__/provider-model-refresh.test.ts && tsx src/__tests__/goal-draft-mode.test.ts && tsx src/__tests__/workspace-layout.test.ts && tsx src/__tests__/tool-approval-mode.test.ts && tsx src/__tests__/send-failed.test.ts && tsx src/__tests__/message-selection-copy.test.ts"
   },
   "dependencies": {
     "@tanstack/react-virtual": "^3.14.2",

--- a/desktop/frontend/src/__tests__/message-selection-copy.test.ts
+++ b/desktop/frontend/src/__tests__/message-selection-copy.test.ts
@@ -1,0 +1,93 @@
+// Run: tsx src/__tests__/message-selection-copy.test.ts
+
+import { messageSelectionCopyText } from "../lib/messageSelectionCopy";
+
+let passed = 0;
+let failed = 0;
+
+function eq(a: unknown, b: unknown, label: string) {
+  if (a === b) {
+    process.stdout.write(`  PASS  ${label}\n`);
+    passed += 1;
+  } else {
+    process.stdout.write(`  FAIL  ${label}: expected ${JSON.stringify(b)}, got ${JSON.stringify(a)}\n`);
+    failed += 1;
+  }
+}
+
+console.log("\nmessage selection copy");
+
+eq(
+  messageSelectionCopyText({
+    text: "selected assistant reply",
+    isCollapsed: false,
+    targetIsEditable: false,
+    intersectsMessage: true,
+    canWriteClipboard: true,
+  }),
+  "selected assistant reply",
+  "copies selected message text through the fallback handler",
+);
+
+eq(
+  messageSelectionCopyText({
+    text: "draft text",
+    isCollapsed: false,
+    targetIsEditable: true,
+    intersectsMessage: true,
+    canWriteClipboard: true,
+  }),
+  null,
+  "does not override native copy inside editable fields",
+);
+
+eq(
+  messageSelectionCopyText({
+    text: "   \n\t",
+    isCollapsed: false,
+    targetIsEditable: false,
+    intersectsMessage: true,
+    canWriteClipboard: true,
+  }),
+  null,
+  "ignores whitespace-only selections",
+);
+
+eq(
+  messageSelectionCopyText({
+    text: "settings panel text",
+    isCollapsed: false,
+    targetIsEditable: false,
+    intersectsMessage: false,
+    canWriteClipboard: true,
+  }),
+  null,
+  "leaves non-message selections to the browser",
+);
+
+eq(
+  messageSelectionCopyText({
+    text: "selected assistant reply",
+    isCollapsed: true,
+    targetIsEditable: false,
+    intersectsMessage: true,
+    canWriteClipboard: true,
+  }),
+  null,
+  "ignores collapsed selections",
+);
+
+eq(
+  messageSelectionCopyText({
+    text: "selected assistant reply",
+    isCollapsed: false,
+    targetIsEditable: false,
+    intersectsMessage: true,
+    canWriteClipboard: false,
+  }),
+  null,
+  "does not claim copy events without writable clipboard data",
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/messageSelectionCopy.ts
+++ b/desktop/frontend/src/lib/messageSelectionCopy.ts
@@ -1,0 +1,84 @@
+const MESSAGE_SELECTION_SELECTOR = ".msg__body, .reasoning__body";
+
+export interface MessageSelectionCopyState {
+  text: string;
+  isCollapsed: boolean;
+  targetIsEditable: boolean;
+  intersectsMessage: boolean;
+  canWriteClipboard: boolean;
+}
+
+export function messageSelectionCopyText(state: MessageSelectionCopyState): string | null {
+  if (state.isCollapsed) return null;
+  if (state.targetIsEditable) return null;
+  if (!state.intersectsMessage) return null;
+  if (!state.canWriteClipboard) return null;
+  if (state.text.trim() === "") return null;
+  return state.text;
+}
+
+export function installMessageSelectionCopy(doc: Document = document): () => void {
+  const onCopy = (event: ClipboardEvent) => {
+    const selection = doc.getSelection();
+    const text = messageSelectionCopyText({
+      text: selection?.toString() ?? "",
+      isCollapsed: selection == null || selection.isCollapsed,
+      targetIsEditable: isEditableTarget(event.target),
+      intersectsMessage: selectionIntersectsMessage(selection, doc),
+      canWriteClipboard: event.clipboardData != null,
+    });
+    if (text == null || event.clipboardData == null) return;
+
+    event.clipboardData.setData("text/plain", text);
+    event.preventDefault();
+  };
+
+  doc.addEventListener("copy", onCopy);
+  return () => doc.removeEventListener("copy", onCopy);
+}
+
+function selectionIntersectsMessage(selection: Selection | null, root: ParentNode): boolean {
+  if (selection == null || selection.rangeCount === 0 || selection.isCollapsed) return false;
+  for (let i = 0; i < selection.rangeCount; i += 1) {
+    if (rangeIntersectsMessage(selection.getRangeAt(i), root)) return true;
+  }
+  return false;
+}
+
+function rangeIntersectsMessage(range: Range, root: ParentNode): boolean {
+  const common = elementFromNode(range.commonAncestorContainer);
+  const directMessage = common?.closest(MESSAGE_SELECTION_SELECTOR);
+  if (directMessage) return true;
+
+  const scope = common ?? root;
+  const candidates = scope instanceof Element && scope.matches(MESSAGE_SELECTION_SELECTOR)
+    ? [scope, ...Array.from(scope.querySelectorAll(MESSAGE_SELECTION_SELECTOR))]
+    : Array.from(scope.querySelectorAll(MESSAGE_SELECTION_SELECTOR));
+
+  return candidates.some((node) => {
+    try {
+      return range.intersectsNode(node);
+    } catch {
+      return false;
+    }
+  });
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  const el = elementFromEventTarget(target);
+  if (!el) return false;
+  if (el.closest("input, textarea, select")) return true;
+  for (let node: Element | null = el; node; node = node.parentElement) {
+    if (node instanceof HTMLElement && node.isContentEditable) return true;
+  }
+  return false;
+}
+
+function elementFromEventTarget(target: EventTarget | null): Element | null {
+  return target instanceof Element ? target : null;
+}
+
+function elementFromNode(node: Node | null): Element | null {
+  if (!node) return null;
+  return node.nodeType === Node.ELEMENT_NODE ? node as Element : node.parentElement;
+}

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { installGlobalCrashHandlers } from "./lib/crash";
+import { installMessageSelectionCopy } from "./lib/messageSelectionCopy";
 import { LocaleProvider } from "./lib/i18n";
 import { ToastProvider } from "./lib/toast";
 import { initFontFamily } from "./lib/fontFamily";
@@ -37,6 +38,8 @@ function prewarmFontFallbacks() {
   });
 }
 prewarmFontFallbacks();
+
+installMessageSelectionCopy(document);
 
 // Inside the Wails shell, suppress the webview's default right-click menu — its
 // Reload / Back / Inspect entries are easy to hit by accident and can reset or

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2497,7 +2497,10 @@ a[href] {
 
 /* ── messages ────────────────────────────────────────────────────────────── */
 .msg {
+  --wails-draggable: no-drag;
   margin: 18px auto;
+  user-select: text;
+  -webkit-user-select: text;
 }
 .msg--user {
   display: flex;
@@ -3084,6 +3087,8 @@ a[href] {
 }
 .msg--assistant .msg__body {
   line-height: 1.68;
+  user-select: text;
+  -webkit-user-select: text;
 }
 .turn-actions {
   display: flex;


### PR DESCRIPTION
Fixes desktop message-fragment copying on macOS by adding an explicit copy-event fallback for selected chat text.

## Changes

- Adds a focused message selection copy handler that writes the exact selected text to `text/plain` when a non-empty selection intersects rendered message content.
- Leaves native copy behavior untouched for text inputs, editable fields, collapsed selections, whitespace-only selections, and selections outside message content.
- Marks message bubbles as selectable/non-draggable so macOS/Wails drag regions do not interfere with text selection.
- Adds regression coverage for the copy decision boundaries and includes it in the frontend test scripts.

## Verification

- `git diff --check`
- `gofmt -l .`
- `npm run test:all`
- `npm run build`
- `go test ./...`
- `(cd desktop && go test ./...)`
- Vite preview smoke test: loaded the desktop frontend, sent a mock message, and checked for console errors.

Closes #3861
