### PR TITLE
fix(control,cli): survive SSH drops with mid-turn autosave and SIGHUP save

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,6 +18,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/boot"
@@ -230,7 +231,7 @@ func runAgent(args []string) int {
 		return 2
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 	defer stop()
 
 	// Live run: render the agent's event stream to stdout. Markdown post-stream
@@ -345,7 +346,7 @@ func runServe(args []string) int {
 
 	fmt.Printf("reasonix serve — %s on http://%s\n", ctrl.Label(), *addr)
 	// Use graceful shutdown so SIGINT/SIGTERM drain active connections.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if err := serve.New(ctrl, bc).RunGraceful(ctx, *addr); err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -521,7 +522,19 @@ func chatREPL(args []string) int {
 	// in the normal buffer so native touch scrollback and soft-keyboard focus
 	// keep working; finalized transcript lines are emitted via tea.Println.
 	p := tea.NewProgram(m)
+	// SSH drop (SIGHUP) or service stop (SIGTERM): persist the conversation
+	// before the terminal goes away, then unwind through the normal close path
+	// so resume picks up the interrupted session (#3772).
+	hangup := make(chan os.Signal, 1)
+	signal.Notify(hangup, syscall.SIGHUP, syscall.SIGTERM)
+	go func() {
+		for range hangup {
+			_ = ctrl.Snapshot()
+			p.Quit()
+		}
+	}()
 	final, runErr := p.Run()
+	signal.Stop(hangup)
 	// Close the active controller plus any retired ones from /model switches.
 	// Retired controllers were stashed rather than closed at switch time
 	// because Controller.Close() runs SessionEnd hooks and kills plugin

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -121,6 +122,7 @@ type Controller struct {
 	mu          sync.Mutex
 	cancel      context.CancelFunc
 	running     bool
+	autosaveWG  sync.WaitGroup
 	planMode    bool
 	goal        string
 	goalStatus  string
@@ -402,6 +404,11 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 	c.running = true
 	c.mu.Unlock()
 
+	c.autosaveWG.Add(1)
+	go func() {
+		defer c.autosaveWG.Done()
+		c.autosaveWhileRunning(ctx)
+	}()
 	go func() {
 		defer cancel()
 		defer func() {
@@ -1775,6 +1782,31 @@ func (c *Controller) Snapshot() error {
 // recent-session pickers.
 func (c *Controller) SnapshotActivity() error {
 	return c.snapshot(true)
+}
+
+// midTurnSnapshotInterval is atomic (nanoseconds) so a test shrinking it
+// cannot race a previous test's still-parking autosave goroutine.
+var midTurnSnapshotInterval atomic.Int64
+
+func init() { midTurnSnapshotInterval.Store(int64(30 * time.Second)) }
+
+// autosaveWhileRunning snapshots the session periodically while a turn runs,
+// so an abrupt kill (SSH drop, force-quit) loses at most one interval of a
+// long turn instead of all of it (#3772). Session.Save copies under the lock
+// and replaces the file atomically, so racing the turn's appends is safe.
+func (c *Controller) autosaveWhileRunning(ctx context.Context) {
+	t := time.NewTicker(time.Duration(midTurnSnapshotInterval.Load()))
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			if err := c.snapshot(false); err != nil {
+				slog.Warn("controller: mid-turn snapshot", "err", err)
+			}
+		}
+	}
 }
 
 func (c *Controller) snapshot(markActivity bool) error {

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -564,3 +564,42 @@ func TestRunGuardedPanicDoesNotDoubleEmitTurnDone(t *testing.T) {
 		}
 	}
 }
+
+type blockingRunner struct {
+	session *agent.Session
+	release chan struct{}
+}
+
+func (r blockingRunner) Run(_ context.Context, input string) error {
+	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
+	<-r.release
+	return nil
+}
+
+func TestMidTurnAutosavePersistsDuringLongTurn(t *testing.T) {
+	old := midTurnSnapshotInterval.Load()
+	midTurnSnapshotInterval.Store(int64(10 * time.Millisecond))
+	defer midTurnSnapshotInterval.Store(old)
+
+	dir := t.TempDir()
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	path := filepath.Join(dir, "session.jsonl")
+	release := make(chan struct{})
+	c := New(Options{Runner: blockingRunner{session: sess, release: release}, Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	// Unblock the turn and wait for the autosaver to exit before TempDir
+	// cleanup, which fails on Windows while a snapshot tmp write is in flight.
+	defer c.autosaveWG.Wait()
+	defer close(release)
+
+	c.Send("hello mid-turn persistence")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(path); err == nil && strings.Contains(string(b), "hello mid-turn persistence") {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("session file was not written while the turn was still running")
+}


### PR DESCRIPTION
﻿## Root cause (two gaps)

1. **No mid-turn persistence.** The session saved only via the `defer snapshotActivityIfChanged` at turn end. The SSH workflow is exactly the one that breaks this: kick off a long autonomous turn, disconnect — the process dies mid-turn and everything since the *previous* turn is gone, which is why `resume` offered an old conversation.
2. **The chat TUI caught no signals.** `tea.NewProgram(m)` ran bare; only `run`/`serve` had `NotifyContext(os.Interrupt)`. An SSH drop delivers SIGHUP and the process died on the spot.

## Fix

- `runGuarded` now starts a per-turn autosave ticker: while a turn runs, the session snapshots every 30s. `Session.Save` copies under the session lock and lands via atomic tmp+rename, so racing the turn's appends can neither tear the read nor corrupt the file; a snapshot that ends on a dangling tool call is repaired by the existing resume-side pairing sanitizer. Worst case after a hard kill is now ~30s of one turn, not the whole turn. (This also narrows the desktop force-quit data-loss window — same mechanism.)
- The chat TUI registers SIGHUP/SIGTERM: persist the conversation immediately, then `p.Quit()` so the normal close path runs.
- `run` cancels on SIGTERM/SIGHUP too (its in-flight turn then saves via the turn-end defer); `serve` adds SIGTERM, matching what its own comment already claimed.

Interval is a package var; the new test shrinks it and asserts the session file exists *while* the turn is still blocked. The auto-resume-to-last-session ask from the thread is a separate UX feature and not covered here.

Closes #3772
