### PR TITLE
fix(migrate): route legacy v0.x sessions into their workspace session dirs

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -36,10 +36,6 @@ func sessionDisplayPath(dir string) string { return filepath.Join(dir, sessionDi
 func sessionTrashPath(dir string) string   { return filepath.Join(dir, sessionTrashDir) }
 
 func desktopSessionDir(root string) string {
-	base := config.MemoryUserDir()
-	if base == "" {
-		return config.SessionDir()
-	}
 	root = strings.TrimSpace(root)
 	if root == "" {
 		cwd, err := os.Getwd()
@@ -48,14 +44,10 @@ func desktopSessionDir(root string) string {
 		}
 		root = cwd
 	}
-	if abs, err := filepath.Abs(root); err == nil {
-		root = abs
+	if dir := config.ProjectSessionDir(root); dir != "" {
+		return dir
 	}
-	return filepath.Join(base, "projects", desktopWorkspaceSlug(root), "sessions")
-}
-
-func desktopWorkspaceSlug(absPath string) string {
-	return strings.NewReplacer(string(os.PathSeparator), "-", "/", "-", "\\", "-", ":", "-").Replace(absPath)
+	return config.SessionDir()
 }
 
 // loadSessionTitles reads the basename→title map (missing/corrupt → empty).

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -256,7 +256,7 @@ func TestV05LegacyEventSessionsImportIntoGlobalTopic(t *testing.T) {
 	destDir := config.SessionDir()
 	writeLegacyEventSession(t, legacyDir, "v053-chat.events.jsonl", "hello from v0.53", "hi from v0.53", time.Now().Add(-time.Hour))
 
-	imported, err := agent.MigrateLegacySessions(legacyDir, destDir)
+	imported, err := agent.MigrateLegacySessions(legacyDir, destDir, config.ProjectSessionDir)
 	if err != nil {
 		t.Fatalf("migrate legacy sessions: %v", err)
 	}

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -61,8 +61,11 @@ On first launch v2 runs a one-time, **non-destructive** import: it reads a v0.x
 `~/.reasonix/config.json` (API key, base URL, language, MCP servers) and imports
 past sessions from `~/.reasonix/sessions` and legacy event logs already located
 in the current user config session directory, leaves the old files untouched, and
-prints a boot notice when it does. Imported sessions resume with `--resume` or the
-history panel. The config import only runs when no v2 config exists yet — if v2
+prints a boot notice when it does. Each session lands in the workspace it
+belonged to (read from its v0.x sidecar meta, summary carried over as the title),
+so the desktop sidebar lists it under the right project; sessions whose workspace
+no longer exists land in the global session dir. Imported sessions resume with
+`--resume` or the history panel. The config import only runs when no v2 config exists yet — if v2
 wrote its config before your `0.x` data was in place nothing is overwritten, so
 copy any missing values across by hand.
 

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"reasonix/internal/provider"
 )
@@ -40,34 +41,43 @@ const legacyImportMarker = ".legacy-imported"
 const legacyEventsHomeImportMarker = ".legacy-imported.v0-events-home"
 const legacyEventsConfigImportMarker = ".legacy-imported.v0-events-config"
 
+// Routed markers are independent of the flat-import ones above: the routed pass
+// must run once even for users whose flat import already completed, because it
+// re-homes sessions the flat import left in the global dir (#3937).
+const legacyRoutedHomeImportMarker = ".legacy-imported.v2-routed"
+const legacyRoutedConfigImportMarker = ".legacy-imported.v0-events-config.v2-routed"
+
+// legacyMeta is the v0.x sidecar (<name>.meta.json): the workspace the session
+// belonged to and the generated summary used as its display title.
+type legacyMeta struct {
+	Workspace string `json:"workspace"`
+	Summary   string `json:"summary"`
+}
+
 // MigrateLegacySessions imports v0.x event-log sessions (<name>.events.jsonl under
-// srcDir) into the v1+ message-log format (<name>.jsonl under destDir), back-filling
-// any whose .jsonl isn't already present. It runs once — guarded by a marker file in
-// destDir — so it still imports when destDir already holds v1+ sessions (the old
-// all-or-nothing skip hid a v0.x user's history the moment they opened v1, #2869)
-// without re-importing on every launch. Never modifies the legacy files. Returns the
-// count imported.
-func MigrateLegacySessions(srcDir, destDir string) (int, error) {
-	return migrateLegacySessions(srcDir, destDir, legacyEventsHomeImportMarker, true)
+// srcDir) into the v1+ message-log format, routing each session into the
+// per-workspace dir its sidecar meta names (via projectDir) so the desktop
+// sidebar can see it; sessions without a live workspace land in globalDest. It
+// also re-homes sessions a previous flat import left in globalDest. Runs once —
+// guarded by a marker in globalDest — and never modifies the legacy files.
+// Returns the count imported (including re-homed).
+func MigrateLegacySessions(srcDir, globalDest string, projectDir func(workspaceRoot string) string) (int, error) {
+	return migrateLegacySessions(srcDir, globalDest, legacyRoutedHomeImportMarker, projectDir)
 }
 
 // MigrateLegacySessionsFromConfigDir imports v0.x event-log sessions found in
 // the current user config session directory. It uses an independent marker so a
 // previous ~/.reasonix import marker cannot hide sessions from a redirected
 // config root on Windows/macOS.
-func MigrateLegacySessionsFromConfigDir(srcDir, destDir string) (int, error) {
-	return migrateLegacySessions(srcDir, destDir, legacyEventsConfigImportMarker, false)
+func MigrateLegacySessionsFromConfigDir(srcDir, globalDest string, projectDir func(workspaceRoot string) string) (int, error) {
+	return migrateLegacySessions(srcDir, globalDest, legacyRoutedConfigImportMarker, projectDir)
 }
 
-func migrateLegacySessions(srcDir, destDir, marker string, honorLegacyMarker bool) (int, error) {
+func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(string) string) (int, error) {
 	if strings.TrimSpace(marker) == "" {
 		marker = legacyImportMarker
 	}
-	if importMarkerExists(destDir, marker) {
-		return 0, nil
-	}
-	if honorLegacyMarker && importMarkerExists(destDir, legacyImportMarker) {
-		writeImportMarkers(destDir, marker)
+	if importMarkerExists(globalDest, marker) {
 		return 0, nil
 	}
 	entries, err := os.ReadDir(srcDir)
@@ -80,9 +90,23 @@ func migrateLegacySessions(srcDir, destDir, marker string, honorLegacyMarker boo
 		if e.IsDir() || !strings.HasSuffix(name, ".events.jsonl") {
 			continue
 		}
-		dest := filepath.Join(destDir, strings.TrimSuffix(name, ".events.jsonl")+".jsonl")
+		base := strings.TrimSuffix(name, ".events.jsonl")
+		meta := readLegacyMeta(srcDir, base)
+		destDir := globalDest
+		if projectDir != nil && meta.Workspace != "" && dirExists(meta.Workspace) {
+			if d := projectDir(meta.Workspace); d != "" {
+				destDir = d
+			}
+		}
+		dest := filepath.Join(destDir, base+".jsonl")
 		if _, err := os.Stat(dest); err == nil {
 			continue // already imported, or a v1+ session of the same name
+		}
+		srcInfo, _ := e.Info()
+		if destDir != globalDest && moveFlatImport(filepath.Join(globalDest, base+".jsonl"), dest, srcInfo) {
+			recordImportedTitle(destDir, base, meta.Summary)
+			imported++
+			continue
 		}
 		msgs, err := reconstructSession(filepath.Join(srcDir, name))
 		if err != nil || len(msgs) == 0 {
@@ -92,17 +116,84 @@ func migrateLegacySessions(srcDir, destDir, marker string, honorLegacyMarker boo
 		if err := s.Save(dest); err != nil {
 			return imported, err
 		}
-		if info, err := e.Info(); err == nil {
-			_ = os.Chtimes(dest, info.ModTime(), info.ModTime()) // preserve resume ordering
+		if srcInfo != nil {
+			_ = os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime()) // preserve resume ordering
 		}
+		recordImportedTitle(destDir, base, meta.Summary)
 		imported++
 	}
-	markers := []string{marker}
-	if honorLegacyMarker {
-		markers = append(markers, legacyImportMarker)
-	}
-	writeImportMarkers(destDir, markers...)
+	// Also stamp the flat markers so a downgrade to an older build doesn't
+	// re-run the flat import over routed sessions.
+	writeImportMarkers(globalDest, marker, legacyImportMarker, legacyEventsHomeImportMarker, legacyEventsConfigImportMarker)
 	return imported, nil
+}
+
+// readLegacyMeta loads the v0.x sidecar for a session; missing or corrupt
+// sidecars yield the zero value (session routes to the global dir, untitled).
+func readLegacyMeta(srcDir, base string) legacyMeta {
+	var m legacyMeta
+	b, err := os.ReadFile(filepath.Join(srcDir, base+".meta.json"))
+	if err != nil {
+		return m
+	}
+	_ = json.Unmarshal(b, &m)
+	m.Workspace = strings.TrimSpace(m.Workspace)
+	m.Summary = strings.TrimSpace(m.Summary)
+	return m
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+// moveFlatImport re-homes a session the flat import left in the global dir.
+// The legacy event log's mtime was stamped onto the imported file, so a match
+// identifies it; a same-named native v1+ session never matches and stays put.
+func moveFlatImport(oldPath, newPath string, srcInfo os.FileInfo) bool {
+	if srcInfo == nil {
+		return false
+	}
+	info, err := os.Stat(oldPath)
+	if err != nil {
+		return false
+	}
+	d := info.ModTime().Sub(srcInfo.ModTime())
+	if d < -2*time.Second || d > 2*time.Second {
+		return false
+	}
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+		return false
+	}
+	return os.Rename(oldPath, newPath) == nil
+}
+
+// recordImportedTitle stores the legacy summary as the session's display title
+// in the dir's .titles.json — the same map the desktop sidebar reads
+// (desktop/sessions.go). Existing titles are never overwritten.
+func recordImportedTitle(destDir, base, summary string) {
+	if summary == "" {
+		return
+	}
+	path := filepath.Join(destDir, ".titles.json")
+	titles := map[string]string{}
+	if b, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(b, &titles)
+	}
+	key := base + ".jsonl"
+	if titles[key] != "" {
+		return
+	}
+	titles[key] = summary
+	b, err := json.MarshalIndent(titles, "", "  ")
+	if err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, path)
 }
 
 func importMarkerExists(destDir, marker string) bool {

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -1,9 +1,12 @@
 package agent
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/provider"
 )
@@ -23,7 +26,7 @@ func TestMigrateLegacySessionsReconstructsConversation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	n, err := MigrateLegacySessions(src, dest)
+	n, err := MigrateLegacySessions(src, dest, nil)
 	if err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -61,7 +64,7 @@ func TestMigrateLegacySessionsBackfillsAlongsideExisting(t *testing.T) {
 	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
 	os.WriteFile(filepath.Join(dest, "existing.jsonl"), []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644)
 
-	n, err := MigrateLegacySessions(src, dest)
+	n, err := MigrateLegacySessions(src, dest, nil)
 	if err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -81,14 +84,14 @@ func TestMigrateLegacySessionsRunsOnce(t *testing.T) {
 	dest := t.TempDir()
 	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
 
-	if n, err := MigrateLegacySessions(src, dest); err != nil || n != 1 {
+	if n, err := MigrateLegacySessions(src, dest, nil); err != nil || n != 1 {
 		t.Fatalf("first run: n=%d err=%v, want 1", n, err)
 	}
 	// User deletes the imported session, then a second launch happens.
 	if err := os.Remove(filepath.Join(dest, "chat-1.jsonl")); err != nil {
 		t.Fatal(err)
 	}
-	if n, err := MigrateLegacySessions(src, dest); err != nil || n != 0 {
+	if n, err := MigrateLegacySessions(src, dest, nil); err != nil || n != 0 {
 		t.Fatalf("second run must be a no-op (marker present): n=%d err=%v", n, err)
 	}
 	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); !os.IsNotExist(err) {
@@ -102,29 +105,27 @@ func TestMigrateLegacySessionsRunsOnce(t *testing.T) {
 	}
 }
 
-func TestMigrateLegacySessionsHonorsLegacyMarkerForHomeSource(t *testing.T) {
+func TestMigrateLegacySessionsRoutedPassIgnoresFlatMarkers(t *testing.T) {
 	src := t.TempDir()
 	dest := t.TempDir()
 	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
-	if err := os.MkdirAll(dest, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dest, legacyImportMarker), nil, 0o644); err != nil {
-		t.Fatal(err)
+	for _, m := range []string{legacyImportMarker, legacyEventsHomeImportMarker} {
+		if err := os.WriteFile(filepath.Join(dest, m), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	n, err := MigrateLegacySessions(src, dest)
+	// Flat markers must not block the routed pass — it has to run once for
+	// existing upgraders to re-home sessions the flat import stranded (#3937).
+	n, err := MigrateLegacySessions(src, dest, nil)
 	if err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	if n != 0 {
-		t.Fatalf("legacy marker should protect the home source from re-importing, got %d", n)
+	if n != 1 {
+		t.Fatalf("routed pass should run despite flat markers, got %d", n)
 	}
-	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); !os.IsNotExist(err) {
-		t.Errorf("legacy marker should keep deleted/imported sessions from reappearing")
-	}
-	if _, err := os.Stat(filepath.Join(dest, legacyEventsHomeImportMarker)); err != nil {
-		t.Errorf("legacy marker should be upgraded to source marker: %v", err)
+	if n, err := MigrateLegacySessions(src, dest, nil); err != nil || n != 0 {
+		t.Fatalf("routed marker must gate the second run: n=%d err=%v", n, err)
 	}
 }
 
@@ -140,7 +141,7 @@ func TestMigrateLegacySessionsSourceMarkersAreIndependent(t *testing.T) {
 	}
 
 	const appDataMarker = ".legacy-imported.v0-events-appdata"
-	n, err := migrateLegacySessions(src, dest, appDataMarker, false)
+	n, err := migrateLegacySessions(src, dest, appDataMarker, nil)
 	if err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -161,17 +162,14 @@ func TestMigrateLegacyConfigSourceDoesNotBlockHomeSource(t *testing.T) {
 	dest := t.TempDir()
 	os.WriteFile(filepath.Join(homeSrc, "home-chat.events.jsonl"), []byte(legacyEventLog), 0o644)
 
-	if n, err := MigrateLegacySessionsFromConfigDir(configSrc, dest); err != nil || n != 0 {
+	if n, err := MigrateLegacySessionsFromConfigDir(configSrc, dest, nil); err != nil || n != 0 {
 		t.Fatalf("config source without events: n=%d err=%v, want 0 nil", n, err)
 	}
-	if _, err := os.Stat(filepath.Join(dest, legacyEventsConfigImportMarker)); err != nil {
+	if _, err := os.Stat(filepath.Join(dest, legacyRoutedConfigImportMarker)); err != nil {
 		t.Fatalf("config source marker missing: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dest, legacyImportMarker)); !os.IsNotExist(err) {
-		t.Fatalf("config source must not block the home source with the generic marker, stat err=%v", err)
-	}
 
-	if n, err := MigrateLegacySessions(homeSrc, dest); err != nil || n != 1 {
+	if n, err := MigrateLegacySessions(homeSrc, dest, nil); err != nil || n != 1 {
 		t.Fatalf("home source after config source: n=%d err=%v, want 1 nil", n, err)
 	}
 	if _, err := os.Stat(filepath.Join(dest, "home-chat.jsonl")); err != nil {
@@ -185,7 +183,7 @@ func TestMigrateLegacySessionsSkipsAlreadyImported(t *testing.T) {
 	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
 	os.WriteFile(filepath.Join(dest, "chat-1.jsonl"), []byte(`{"role":"user","content":"edited"}`+"\n"), 0o644)
 
-	n, err := MigrateLegacySessions(src, dest)
+	n, err := MigrateLegacySessions(src, dest, nil)
 	if err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
@@ -202,9 +200,137 @@ func TestMigrateLegacySessionsSkipsAlreadyImported(t *testing.T) {
 }
 
 func TestMigrateLegacySessionsNoSrcIsNoop(t *testing.T) {
-	n, err := MigrateLegacySessions(filepath.Join(t.TempDir(), "nope"), t.TempDir())
+	n, err := MigrateLegacySessions(filepath.Join(t.TempDir(), "nope"), t.TempDir(), nil)
 	if err != nil || n != 0 {
 		t.Errorf("missing legacy session dir should be a silent no-op, got n=%d err=%v", n, err)
+	}
+}
+
+func writeLegacyMeta(t *testing.T, srcDir, base, workspace, summary string) {
+	t.Helper()
+	b, err := json.Marshal(map[string]string{"workspace": workspace, "summary": summary})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, base+".meta.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMigrateLegacySessionsRoutesByWorkspaceMeta(t *testing.T) {
+	src := t.TempDir()
+	global := t.TempDir()
+	workspace := t.TempDir()
+	projRoot := t.TempDir()
+	router := func(ws string) string { return filepath.Join(projRoot, filepath.Base(ws), "sessions") }
+	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
+	writeLegacyMeta(t, src, "chat-1", workspace, "fix the retry test")
+
+	n, err := MigrateLegacySessions(src, global, router)
+	if err != nil || n != 1 {
+		t.Fatalf("migrate: n=%d err=%v, want 1 nil", n, err)
+	}
+	dest := filepath.Join(projRoot, filepath.Base(workspace), "sessions")
+	if _, err := os.Stat(filepath.Join(dest, "chat-1.jsonl")); err != nil {
+		t.Fatalf("session should land in the workspace dir: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(global, "chat-1.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("session must not also land in the global dir")
+	}
+	titles, err := os.ReadFile(filepath.Join(dest, ".titles.json"))
+	if err != nil {
+		t.Fatalf("titles file: %v", err)
+	}
+	m := map[string]string{}
+	if err := json.Unmarshal(titles, &m); err != nil || m["chat-1.jsonl"] != "fix the retry test" {
+		t.Errorf("title = %q (err=%v), want legacy summary", m["chat-1.jsonl"], err)
+	}
+}
+
+func TestMigrateLegacySessionsDeadWorkspaceFallsBackToGlobal(t *testing.T) {
+	src := t.TempDir()
+	global := t.TempDir()
+	projRoot := t.TempDir()
+	router := func(ws string) string { return filepath.Join(projRoot, filepath.Base(ws), "sessions") }
+	os.WriteFile(filepath.Join(src, "chat-1.events.jsonl"), []byte(legacyEventLog), 0o644)
+	writeLegacyMeta(t, src, "chat-1", filepath.Join(src, "no-such-workspace"), "")
+
+	n, err := MigrateLegacySessions(src, global, router)
+	if err != nil || n != 1 {
+		t.Fatalf("migrate: n=%d err=%v, want 1 nil", n, err)
+	}
+	if _, err := os.Stat(filepath.Join(global, "chat-1.jsonl")); err != nil {
+		t.Errorf("session with a dead workspace should fall back to the global dir: %v", err)
+	}
+}
+
+func TestMigrateLegacySessionsRehomesFlatImport(t *testing.T) {
+	src := t.TempDir()
+	global := t.TempDir()
+	workspace := t.TempDir()
+	projRoot := t.TempDir()
+	router := func(ws string) string { return filepath.Join(projRoot, filepath.Base(ws), "sessions") }
+	srcLog := filepath.Join(src, "chat-1.events.jsonl")
+	os.WriteFile(srcLog, []byte(legacyEventLog), 0o644)
+	writeLegacyMeta(t, src, "chat-1", workspace, "fix the retry test")
+
+	// Simulate the old flat import: file in the global dir, mtime stamped from
+	// the legacy event log.
+	flat := filepath.Join(global, "chat-1.jsonl")
+	os.WriteFile(flat, []byte(`{"role":"user","content":"flat-imported"}`+"\n"), 0o644)
+	info, err := os.Stat(srcLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(flat, info.ModTime(), info.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := MigrateLegacySessions(src, global, router)
+	if err != nil || n != 1 {
+		t.Fatalf("migrate: n=%d err=%v, want 1 nil", n, err)
+	}
+	moved := filepath.Join(projRoot, filepath.Base(workspace), "sessions", "chat-1.jsonl")
+	b, err := os.ReadFile(moved)
+	if err != nil {
+		t.Fatalf("re-homed session missing: %v", err)
+	}
+	if !strings.Contains(string(b), "flat-imported") {
+		t.Errorf("re-home must move the existing import, not reconstruct: %s", b)
+	}
+	if _, err := os.Stat(flat); !os.IsNotExist(err) {
+		t.Errorf("flat import should be moved out of the global dir")
+	}
+}
+
+func TestMigrateLegacySessionsKeepsNativeSameNameSession(t *testing.T) {
+	src := t.TempDir()
+	global := t.TempDir()
+	workspace := t.TempDir()
+	projRoot := t.TempDir()
+	router := func(ws string) string { return filepath.Join(projRoot, filepath.Base(ws), "sessions") }
+	srcLog := filepath.Join(src, "chat-1.events.jsonl")
+	os.WriteFile(srcLog, []byte(legacyEventLog), 0o644)
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(srcLog, old, old); err != nil {
+		t.Fatal(err)
+	}
+	writeLegacyMeta(t, src, "chat-1", workspace, "")
+
+	// A native v1+ session that happens to share the name: mtime won't match
+	// the legacy log, so it must stay where it is.
+	native := filepath.Join(global, "chat-1.jsonl")
+	os.WriteFile(native, []byte(`{"role":"user","content":"native"}`+"\n"), 0o644)
+
+	if _, err := MigrateLegacySessions(src, global, router); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	b, err := os.ReadFile(native)
+	if err != nil || !strings.Contains(string(b), "native") {
+		t.Errorf("native global session must be left intact: err=%v body=%s", err, b)
+	}
+	if _, err := os.Stat(filepath.Join(projRoot, filepath.Base(workspace), "sessions", "chat-1.jsonl")); err != nil {
+		t.Errorf("legacy session should still be reconstructed into its workspace dir: %v", err)
 	}
 }
 
@@ -213,7 +339,7 @@ func TestMigrateLegacySessionsSkipsEmptyLog(t *testing.T) {
 	dest := t.TempDir()
 	os.WriteFile(filepath.Join(src, "empty.events.jsonl"), []byte(`{"type":"model.turn.started","id":1,"ts":"t","turn":0}`+"\n"), 0o644)
 
-	n, err := MigrateLegacySessions(src, dest)
+	n, err := MigrateLegacySessions(src, dest, nil)
 	if err != nil {
 		t.Fatalf("migrate: %v", err)
 	}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -742,7 +742,7 @@ func migrateLegacySessionSources(sink event.Sink) {
 	type legacySource struct {
 		dir     string
 		label   string
-		migrate func(srcDir, destDir string) (int, error)
+		migrate func(srcDir, globalDest string, projectDir func(string) string) (int, error)
 	}
 	var sources []legacySource
 	if home, herr := os.UserHomeDir(); herr == nil {
@@ -771,7 +771,7 @@ func migrateLegacySessionSources(sink event.Sink) {
 			continue
 		}
 		seen[key] = true
-		if n, serr := src.migrate(src.dir, dest); serr == nil && n > 0 {
+		if n, serr := src.migrate(src.dir, dest, config.ProjectSessionDir); serr == nil && n > 0 {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("imported %d past session(s) from %s — resume them with --resume or the history panel", n, src.label)})
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1581,6 +1581,27 @@ func SessionDir() string {
 	return filepath.Join(dir, "reasonix", "sessions")
 }
 
+// ProjectSessionDir is the per-workspace session directory the desktop sidebar
+// lists: <config root>/projects/<slug>/sessions. Empty when either the config
+// root or workspaceRoot doesn't resolve.
+func ProjectSessionDir(workspaceRoot string) string {
+	base := MemoryUserDir()
+	root := strings.TrimSpace(workspaceRoot)
+	if base == "" || root == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(root); err == nil {
+		root = abs
+	}
+	return filepath.Join(base, "projects", WorkspaceSlug(root), "sessions")
+}
+
+// WorkspaceSlug flattens an absolute workspace path into the directory name
+// used under <config root>/projects.
+func WorkspaceSlug(absPath string) string {
+	return strings.NewReplacer(string(os.PathSeparator), "-", "/", "-", "\\", "-", ":", "-").Replace(absPath)
+}
+
 // CacheDir is the per-user cache root for derived/regenerable artefacts: MCP
 // handshake snapshots, plugin startup-latency telemetry. Lives beside the
 // existing dirs (UserConfigDir/reasonix/...) so the whole reasonix state tree


### PR DESCRIPTION
Fixes the headline complaint from every 0.53→1.x upgrade thread: sessions import "successfully" and then nobody can see them.

## Root cause (from #3937)

The flat import (#3247) reconstructs v0.x sessions into the **global** config session dir, but the desktop sidebar only lists the **per-workspace** `projects/<slug>/sessions` dirs, and nothing reads the v0.x sidecar (`<name>.meta.json`) that says which workspace a session belonged to.

## What this does

- **Layout helper moves down**: the per-workspace session-dir layout is now `config.ProjectSessionDir` / `config.WorkspaceSlug`; the desktop helper delegates to it. Two consumers (sidebar + importer) → the concept lives in the root module.
- **Meta-aware routing**: the importer reads each session's sidecar. A live workspace routes the session into that workspace's sessions dir and carries the summary into `.titles.json` (the map the sidebar reads) so imported sessions are labeled. Dead or missing workspaces fall back to the global dir as before.
- **One-time re-home pass for existing upgraders**: the routed pass runs once even where the flat-import markers are already present, moving stranded global-dir sessions into their workspace dirs. A file is only moved when its mtime matches the legacy event log (the flat import stamped it), so a same-named native v1+ session is never touched. The pass stamps the flat markers too, so a downgrade doesn't re-run the flat import over routed sessions.

## Trade-off, stated plainly

A session the user deliberately deleted *after* the flat import reappears once (in its workspace) during the routed pass — there is no record distinguishing "deleted by user" from "never imported". Recovering every stranded upgrade beats protecting against one resurrection.

## Tests

- routing by sidecar workspace + title carry-over
- dead-workspace fallback to global
- re-home moves the flat import (content preserved, not re-reconstructed)
- mtime mismatch keeps a native same-named session intact
- routed pass ignores flat markers, gates on its own
- all existing migrate/boot/desktop session tests updated and green

Closes #3937
