### PR TITLE
fix(cli): only prompt for API keys the active config references

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1398,13 +1398,24 @@ func promptMissingKeys(cfg *config.Config) int {
 	return 0
 }
 
-// providersWithMissingKeys returns the subset of cfg.Providers whose api_key_env
-// is declared but not currently set in the environment. configureKeys dedupes
-// shared envs, so duplicates are fine to leave in.
+// providersWithMissingKeys returns the providers the active configuration
+// actually references (default/planner/subagent models) whose api_key_env is
+// declared but not set. Merely-available presets stay silent — a DeepSeek-only
+// user must not be prompted for MIMO_API_KEY (#3939); the chat banner still
+// warns if they later switch to a model whose key is missing. configureKeys
+// dedupes shared envs, so duplicates are fine to leave in.
 func providersWithMissingKeys(cfg *config.Config) []config.ProviderEntry {
+	referenced := map[string]bool{
+		cfg.DefaultModel:        true,
+		cfg.Agent.PlannerModel:  true,
+		cfg.Agent.SubagentModel: true,
+	}
+	for _, m := range cfg.Agent.SubagentModels {
+		referenced[m] = true
+	}
 	var out []config.ProviderEntry
 	for _, p := range cfg.Providers {
-		if p.APIKeyEnv != "" && os.Getenv(p.APIKeyEnv) == "" {
+		if referenced[p.Name] && p.APIKeyEnv != "" && os.Getenv(p.APIKeyEnv) == "" {
 			out = append(out, p)
 		}
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -845,3 +845,33 @@ func captureStderr(t *testing.T, fn func()) string {
 	}
 	return string(data)
 }
+
+func TestProvidersWithMissingKeysOnlyReferenced(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	t.Setenv("MIMO_API_KEY", "")
+	cfg := config.Default()
+
+	got := providersWithMissingKeys(cfg)
+	envs := map[string]bool{}
+	for _, p := range got {
+		envs[p.APIKeyEnv] = true
+	}
+	if !envs["DEEPSEEK_API_KEY"] {
+		t.Errorf("the default model's missing key must be prompted, got %v", got)
+	}
+	if envs["MIMO_API_KEY"] {
+		t.Errorf("unreferenced preset keys must not be prompted, got %v", got)
+	}
+}
+
+func TestProvidersWithMissingKeysIncludesPlannerModel(t *testing.T) {
+	t.Setenv("DEEPSEEK_API_KEY", "set")
+	t.Setenv("MIMO_API_KEY", "")
+	cfg := config.Default()
+	cfg.Agent.PlannerModel = "mimo-pro"
+
+	got := providersWithMissingKeys(cfg)
+	if len(got) != 1 || got[0].APIKeyEnv != "MIMO_API_KEY" {
+		t.Errorf("planner model's missing key must be prompted, got %+v", got)
+	}
+}


### PR DESCRIPTION
A fresh DeepSeek-only install prompted for `MIMO_API_KEY` on every launch, because `promptMissingKeys` walked **all** preset providers (`config.Default()` ships deepseek-flash/pro + mimo-pro/flash) instead of the ones the session can actually use. Users assumed they'd installed the wrong tool (#3939, discussion #3920).

`providersWithMissingKeys` now restricts the prompt to providers referenced by `default_model`, `[agent].planner_model`, and the subagent model settings:

- DeepSeek-only user → asked once for `DEEPSEEK_API_KEY`, never for Mimo.
- Set `planner_model = "mimo-pro"` → `MIMO_API_KEY` is prompted, as before.
- Setup's explicit provider selection (`configureKeys` over the user's picks) is unchanged, and the chat banner still warns when the active model's key is missing.

Tests cover both directions (unreferenced preset silent, referenced planner prompted).

Closes #3939
