### PR TITLE
fix(desktop): surface an error when session actions race controller startup

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -810,6 +810,16 @@ func (a *App) Compact() error {
 	return ctrl.Compact(a.ctx, "")
 }
 
+// workspaceNotReadyErr names why a session action arrived before the tab's
+// controller existed: still starting, or failed to start. Silently returning
+// nil here swallowed the click with no feedback (#3938).
+func workspaceNotReadyErr(tab *WorkspaceTab) error {
+	if tab != nil && strings.TrimSpace(tab.StartupErr) != "" {
+		return fmt.Errorf("workspace failed to start: %s", tab.StartupErr)
+	}
+	return fmt.Errorf("workspace is still starting")
+}
+
 // NewSession snapshots the current conversation and rotates to a fresh one.
 func (a *App) NewSession() error {
 	a.mu.RLock()
@@ -817,7 +827,7 @@ func (a *App) NewSession() error {
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
 	if ctrl == nil {
-		return nil
+		return workspaceNotReadyErr(tab)
 	}
 	// Tab is already blank — just persist and skip the new-session dance.
 	if !ctrl.Running() && !messagesHaveConversationContent(ctrl.History()) {
@@ -848,7 +858,7 @@ func (a *App) ClearSession() error {
 	ctrl := a.activeCtrlLocked()
 	a.mu.RUnlock()
 	if ctrl == nil {
-		return nil
+		return workspaceNotReadyErr(tab)
 	}
 	if err := ctrl.ClearSession(); err != nil {
 		return err

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2108,3 +2108,22 @@ func hasDirEntry(entries []DirEntry, name string) bool {
 	}
 	return false
 }
+
+func TestSessionActionsWithoutControllerReturnError(t *testing.T) {
+	app := &App{tabs: map[string]*WorkspaceTab{}}
+	if err := app.NewSession(); err == nil {
+		t.Error("NewSession with no controller must surface an error, not silently no-op")
+	}
+	if err := app.ClearSession(); err == nil {
+		t.Error("ClearSession with no controller must surface an error")
+	}
+
+	app = &App{
+		tabs:        map[string]*WorkspaceTab{"t1": {ID: "t1", StartupErr: "boot exploded"}},
+		activeTabID: "t1",
+	}
+	err := app.NewSession()
+	if err == nil || !strings.Contains(err.Error(), "boot exploded") {
+		t.Errorf("error should carry the tab's startup failure, got %v", err)
+	}
+}

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -797,14 +797,22 @@ export function useController() {
   const newSession = useCallback(async () => {
     const tabId = activeTabId;
     if (tabId) bumpCheckpointRefreshSeq(tabId);
-    await app.NewSession().catch(() => {});
+    try {
+      await app.NewSession();
+    } catch {
+      return; // backend refused (workspace starting / failed) — keep the transcript
+    }
     if (tabId) dispatchTo(tabId, { type: "reset" });
   }, [activeTabId, bumpCheckpointRefreshSeq, dispatchTo]);
 
   const clearSession = useCallback(async () => {
     const tabId = activeTabId;
     if (tabId) bumpCheckpointRefreshSeq(tabId);
-    await app.ClearSession();
+    try {
+      await app.ClearSession();
+    } catch {
+      return;
+    }
     if (tabId) dispatchTo(tabId, { type: "reset" });
   }, [activeTabId, bumpCheckpointRefreshSeq, dispatchTo]);
 


### PR DESCRIPTION
With two workspaces open, "new session" in the not-yet-started workspace did nothing: `App.NewSession`/`ClearSession` return `nil` when the tab's controller is still being built (lazy per-tab construction includes MCP startup, so the window is real — cf. #3818), and the frontend then dispatched its `reset` regardless, clearing the visible transcript even though the backend did nothing. Silent success-shaped failure on both sides (#3938, discussion #3831).

- Backend: a nil-controller session action now returns a named reason — `workspace is still starting`, or `workspace failed to start: <tab.StartupErr>` when the build actually failed (that case already has the topbar banner explaining itself).
- Frontend: `newSession`/`clearSession` only reset the transcript when the backend call succeeded; a refusal keeps the conversation on screen instead of faking a fresh session.

Test covers both the no-controller error and the startup-failure message carrying the tab's error.

Closes #3938
