### PR TITLE
fix: Ctrl+C in running state copies selection instead of cancelling turn

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -978,6 +978,13 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "ctrl+c", "super+c", "meta+c":
 			if m.state == tuiRunning {
+				// Selection takes precedence: copy instead of cancel, same as idle.
+				if sel.active && !sel.empty() {
+					m.sel = sel
+					text := m.selectedText()
+					m.sel = selection{}
+					return m, tea.Batch(copyToClipboard(text), finalize(m, cmds))
+				}
 				if m.bubblePending {
 					m.unsendPending() // server not yet replied — restore text, leave no trace
 				} else {


### PR DESCRIPTION
## Problem

When the chat TUI is running (tuiRunning state), selecting text and pressing Ctrl+C should copy the selection to clipboard — same as the idle-state behavior. Instead, it cancels the in-flight turn.

## Fix

In the Ctrl+C handler for the tuiRunning state, check for an active text selection first:
- **Selection active** -> copy to clipboard (reuses the same copy logic as the idle state)
- **No selection** -> cancel the current turn (original behavior)