### PR TITLE
fix(codegraph): run the indexer daemon below normal priority

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -259,6 +259,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				Args:              []string{"serve", "--mcp"},
 				Dir:               root,
 				ReadOnlyToolNames: codegraph.ReadOnlyToolNames(),
+				// The daemon walks and indexes the whole tree; below-normal
+				// priority keeps it from starving the user's machine (#3797).
+				LowPriority: true,
 			}
 			warm := codegraph.Initialized(root)
 			if err := codegraph.EnsureInit(ctx, bin, root); err != nil {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -56,6 +56,9 @@ type Spec struct {
 	// instead of the redundant "mcp__codegraph__codegraph_context". The original
 	// raw name is preserved for MCP protocol calls.
 	StripRawPrefix string
+	// LowPriority runs a stdio subprocess below normal scheduling priority, for
+	// background indexers (CodeGraph) that must not starve the user's machine.
+	LowPriority bool
 }
 
 // transport carries JSON-RPC messages to and from one MCP server. call sends a

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -56,6 +56,9 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	}
 	cmd := exec.CommandContext(ctx, exe, s.Args...)
 	proc.HideWindow(cmd)
+	if s.LowPriority {
+		proc.LowPriority(cmd)
+	}
 	cmd.Env = env
 	if s.Dir != "" {
 		cmd.Dir = s.Dir // pin cwd-aware servers (e.g. CodeGraph) to the project root
@@ -77,6 +80,9 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	job, err := proc.StartTracked(cmd)
 	if err != nil {
 		return nil, err
+	}
+	if s.LowPriority {
+		proc.LowPriorityStarted(cmd)
 	}
 	t := &stdioTransport{
 		name:    s.Name,

--- a/internal/proc/priority_other.go
+++ b/internal/proc/priority_other.go
@@ -1,0 +1,20 @@
+//go:build !windows
+
+package proc
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// LowPriority is a no-op off Windows; unix sets niceness after start.
+func LowPriority(*exec.Cmd) {}
+
+// LowPriorityStarted renices a started command to below-normal priority,
+// for background helpers (indexers) that must not starve the user's machine.
+func LowPriorityStarted(cmd *exec.Cmd) {
+	if cmd.Process == nil {
+		return
+	}
+	_ = syscall.Setpriority(syscall.PRIO_PROCESS, cmd.Process.Pid, 10)
+}

--- a/internal/proc/priority_windows.go
+++ b/internal/proc/priority_windows.go
@@ -1,0 +1,22 @@
+//go:build windows
+
+package proc
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+const belowNormalPriorityClass = 0x00004000 // BELOW_NORMAL_PRIORITY_CLASS
+
+// LowPriority marks a not-yet-started command to run below normal priority,
+// for background helpers (indexers) that must not starve the user's machine.
+func LowPriority(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.CreationFlags |= belowNormalPriorityClass
+}
+
+// LowPriorityStarted is a no-op on Windows; priority is set at creation.
+func LowPriorityStarted(*exec.Cmd) {}

--- a/internal/proc/priority_windows_test.go
+++ b/internal/proc/priority_windows_test.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package proc
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestLowPrioritySetsBelowNormalClass(t *testing.T) {
+	cmd := exec.Command("cmd", "/c", "echo", "hi")
+	HideWindow(cmd)
+	LowPriority(cmd)
+	if cmd.SysProcAttr == nil || cmd.SysProcAttr.CreationFlags&belowNormalPriorityClass == 0 {
+		t.Fatalf("BELOW_NORMAL_PRIORITY_CLASS not set; CreationFlags=%#x", cmd.SysProcAttr.CreationFlags)
+	}
+	if cmd.SysProcAttr.CreationFlags&createNoWindow == 0 {
+		t.Fatal("LowPriority must not clobber HideWindow's flags")
+	}
+}


### PR DESCRIPTION
﻿## Problem

The CodeGraph daemon (`codegraph serve --mcp`) indexes the project tree in the background at normal priority. On large repos that competes head-on with everything else on the machine — on Apple Silicon it has collided with Spotlight indexing the same tree hard enough to freeze the system (#3797), and its steady-state watch load is the prime suspect in the idle-CPU report (#3771).

## Fix

`plugin.Spec` gains a `LowPriority` flag, applied only to the first-party CodeGraph spec:

- **Windows**: `BELOW_NORMAL_PRIORITY_CLASS` set at process creation (composes with the existing `CREATE_NO_WINDOW` — covered by test).
- **Unix/macOS**: `setpriority(PRIO_PROCESS, pid, 10)` right after start.

The daemon still uses every idle cycle, but the scheduler now lets the interactive session, the build you're running, and the OS indexer win contention instead of deadlocking against them. User-configured MCP servers are unaffected.

The disable escape hatch (`[codegraph] enabled = false`) remains for machines where even background indexing is unwanted.
