### PR TITLE
feat(cli): add /diff-fold command to toggle diff line folding

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -266,6 +266,10 @@ type chatTUI struct {
 	// shown as the current entry in the /output-style listing. "" = default.
 	outputStyle string
 
+	// diffMaxLines controls the max lines shown in a diff view. 0 = show all
+	// (default); non-zero = fold at that many lines. Toggled by /diff-fold.
+	diffMaxLines int
+
 	// statuslineCmd is the user's custom status-line command (config
 	// [statusline].command); "" disables it. statuslineOut caches its latest
 	// one-line stdout, refreshed at startup and after each turn and rendered in
@@ -3299,7 +3303,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 			// No longer a tool, but guard anyway: the plan is the assistant's reply.
 		default:
 			m.commitSpacer()
-			if block := diffBlock(e.Tool.Name, e.Tool.Args, e.Tool.FileDiff, m.width, diffScrollbackMaxLines); block != nil {
+			if block := diffBlock(e.Tool.Name, e.Tool.Args, e.Tool.FileDiff, m.width, m.diffMaxLines); block != nil {
 				for _, ln := range block {
 					m.commitLine(ln)
 				}
@@ -3516,6 +3520,15 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 			m.notice(i18n.M.OutputStyleNone)
 		} else {
 			m.commitLine(renderOutputStyles(m.width, styles, m.outputStyle))
+		}
+	case "/diff-fold":
+		m.echoLocalCommand(input)
+		if m.diffMaxLines == 0 {
+			m.diffMaxLines = diffFoldLimit
+			m.notice(fmt.Sprintf(i18n.M.DiffFoldEnabledFmt, diffFoldLimit))
+		} else {
+			m.diffMaxLines = 0
+			m.notice(i18n.M.DiffFoldDisabled)
 		}
 	case "/theme":
 		m.echoLocalCommand(input)

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -266,8 +266,8 @@ type chatTUI struct {
 	// shown as the current entry in the /output-style listing. "" = default.
 	outputStyle string
 
-	// diffMaxLines controls the max lines shown in a diff view. 0 = show all
-	// (default); non-zero = fold at that many lines. Toggled by /diff-fold.
+	// diffMaxLines controls the max lines shown in a diff view. 0 = show all;
+	// non-zero = fold at that many lines. Toggled by /diff-fold.
 	diffMaxLines int
 
 	// statuslineCmd is the user's custom status-line command (config
@@ -473,6 +473,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		pending:              &strings.Builder{},
 		pendingCommit:        &commitBuf,
 		renderer:             newMarkdownRenderer(termW),
+		diffMaxLines:         diffFoldLimit,
 		showReasoning:        nativeScrollback,
 		shellOutputs:         make(map[string]string),
 		shellExpanded:        make(map[string]bool),

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -77,6 +77,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
 		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},
 		{label: "/verbose", insert: "/verbose", hint: i18n.M.CmdVerbose},
+		{label: "/diff-fold", insert: "/diff-fold", hint: i18n.M.CmdDiffFold},
 		{label: "/sandbox", insert: "/sandbox", hint: i18n.M.CmdSandbox},
 		{label: "/effort", insert: "/effort ", hint: i18n.M.CmdEffort, descend: true},
 		{label: "/auto-plan", insert: "/auto-plan ", hint: i18n.M.CmdAutoPlan, descend: true},

--- a/internal/cli/diffview.go
+++ b/internal/cli/diffview.go
@@ -21,7 +21,9 @@ import (
 const tabWidth = 4
 
 const (
-	diffScrollbackMaxLines = 40
+	// diffFoldLimit is the max lines to show in a diff when folding is enabled
+	// (/diff-fold toggle). 0 means show all lines.
+	diffFoldLimit = 40
 
 	bgDiffAdd = "\033[48;5;22m"
 	bgDiffDel = "\033[48;5;52m"

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -70,6 +70,7 @@ func builtinHelpItems() []compItem {
 		{label: "/hooks", hint: i18n.M.CmdHooks},
 		{label: "/memory", hint: i18n.M.CmdMemory},
 		{label: "/output-style", hint: i18n.M.CmdOutputStyle},
+		{label: "/diff-fold", hint: i18n.M.CmdDiffFold},
 		{label: "/sandbox", hint: i18n.M.CmdSandbox},
 		{label: "/verbose", hint: i18n.M.CmdVerbose},
 		{label: "/language", hint: i18n.M.CmdLanguage},

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -87,6 +87,8 @@ type Messages struct {
 	PermissionAlreadyAllowedFmt string // permission rule already covered notice: path, rule
 	PermissionSaveFailedFmt     string // permission rule save failure notice: rule, error
 	DiffFoldedFmt               string // "… +%d more lines" footer when a writer diff is folded
+	DiffFoldEnabledFmt          string // notice when /diff-fold enables folding, %d = line limit
+	DiffFoldDisabled            string // notice when /diff-fold disables folding (shows all lines)
 
 	// `ask` tool question card.
 	AskTypeSomething   string // the "type your own answer" option label
@@ -164,6 +166,7 @@ type Messages struct {
 	CmdLanguage     string // /language
 	CmdSkill        string // /skills
 	CmdVerbose      string // /verbose
+	CmdDiffFold     string // /diff-fold
 	CmdSandbox      string // /sandbox
 	CmdEffort       string // /effort
 	CmdAutoPlan     string // /auto-plan

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -69,6 +69,8 @@ var English = Messages{
 	PermissionAlreadyAllowedFmt: "permission already covered in %s: %s",
 	PermissionSaveFailedFmt:     "permission save failed for %s: %v",
 	DiffFoldedFmt:               "… +%d more lines",
+	DiffFoldEnabledFmt:          "diff folded to %d lines (/diff-fold to expand)",
+	DiffFoldDisabled:            "diff expanded — showing all lines (/diff-fold to fold)",
 
 	OutputStyleNone:    "no output styles available",
 	OutputStyleHeader:  "output styles:",
@@ -175,6 +177,7 @@ var English = Messages{
 	CmdLanguage:     "switch CLI language",
 	CmdSkill:        "manage skills",
 	CmdVerbose:      "toggle thinking text",
+	CmdDiffFold:     "toggle diff fold/expand",
 	CmdSandbox:      "show sandbox status",
 	CmdEffort:       "set reasoning effort",
 	CmdAutoPlan:     "configure automatic plan mode",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -70,6 +70,8 @@ var Chinese = Messages{
 	PermissionAlreadyAllowedFmt: "授权已由 %s 中的规则覆盖：%s",
 	PermissionSaveFailedFmt:     "保存授权 %s 失败：%v",
 	DiffFoldedFmt:               "… 还有 %d 行",
+	DiffFoldEnabledFmt:          "diff 已折叠至 %d 行（/diff-fold 展开）",
+	DiffFoldDisabled:            "diff 已展开 — 显示全部行（/diff-fold 折叠）",
 
 	OutputStyleNone:    "没有可用的输出风格",
 	OutputStyleHeader:  "输出风格：",
@@ -176,6 +178,7 @@ var Chinese = Messages{
 	CmdLanguage:     "切换 CLI 语言",
 	CmdSkill:        "管理 skills",
 	CmdVerbose:      "切换 thinking 原文显示",
+	CmdDiffFold:     "切换 diff 折叠/展开",
 	CmdSandbox:      "查看沙箱状态",
 	CmdEffort:       "设置推理强度",
 	CmdAutoPlan:     "配置自动计划模式",


### PR DESCRIPTION
Add a slash command that lets users toggle whether diffs show all lines or are folded to a limit (40 lines). The toggle is session-scoped and affects subsequent diff rendering without modifying historical content.

- Replace diffScrollbackMaxLines constant with diffFoldLimit (40)
- Add diffMaxLines field to chatTUI (default 0 = show all)
- Add /diff-fold command with toggle logic using i18n messages
- Register command in help listing and tab completion
- Add i18n messages for en and zh locales