### PR TITLE
fix(provider): stop committing half-streamed tool-call args

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -346,6 +347,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	started := map[int]bool{}
 	var order []int
 	var lastFinishReason string
+	var sawDone bool
 	var think thinkSplitter
 
 	scanner := bufio.NewScanner(resp.Body)
@@ -362,6 +364,7 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		}
 		data := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
 		if data == "[DONE]" {
+			sawDone = true
 			break
 		}
 
@@ -431,6 +434,12 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 	}
 	if err := scanner.Err(); err != nil {
 		return emitted, fmt.Errorf("%s: read stream: %w", c.name, err)
+	}
+	// A proxy that idle-closes with a clean FIN ends the scan with no error. Without
+	// this check the turn would be committed as complete — including half-streamed
+	// tool-call arguments, which then 400 on every replay (#3953).
+	if !sawDone && lastFinishReason == "" {
+		return emitted, fmt.Errorf("%s: stream ended before completion: %w", c.name, io.ErrUnexpectedEOF)
 	}
 
 	if r, txt := think.flush(); r != "" || txt != "" {

--- a/internal/provider/openai/reconnect_test.go
+++ b/internal/provider/openai/reconnect_test.go
@@ -79,6 +79,118 @@ func TestStreamReconnectsOnEarlyConnReset(t *testing.T) {
 	}
 }
 
+// TestStreamTreatsCleanEOFWithoutDoneAsCut reproduces issue #3953: a proxy that
+// idle-closes the SSE connection with a clean FIN ends the scan with no error,
+// which used to commit the turn as complete — including half-streamed tool-call
+// arguments that then 400 on every replay. Before output, the cut must be
+// replayed; the caller sees one clean stream with the full tool call.
+func TestStreamTreatsCleanEOFWithoutDoneAsCut(t *testing.T) {
+	var reqs int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs++
+		w.Header().Set("Content-Type", "text/event-stream")
+		if reqs == 1 {
+			_, _ = io.WriteString(w, ": keep-alive\n\n") // clean close, no [DONE], no finish_reason
+			return
+		}
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"function\":{\"name\":\"bash\",\"arguments\":\"{\\\"cmd\\\": \\\"ls\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var call *provider.ToolCall
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkError:
+			t.Fatalf("clean EOF before output should be replayed, not surfaced: %v", chunk.Err)
+		case provider.ChunkToolCall:
+			call = chunk.ToolCall
+		}
+	}
+	if call == nil || call.Arguments != `{"cmd": "ls"}` {
+		t.Errorf("tool call = %+v, want complete arguments from the replay", call)
+	}
+	if reqs != 2 {
+		t.Errorf("server saw %d requests, want 2 (one cut + one replay)", reqs)
+	}
+}
+
+// TestStreamDropsPartialToolCallOnCleanEOF is the post-output half of #3953: the
+// connection dies mid-tool-call after the call's start was forwarded. The partial
+// arguments must never surface as a ChunkToolCall; the cut surfaces as a stream
+// interruption so the agent's recovery path takes over.
+func TestStreamDropsPartialToolCallOnCleanEOF(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"c1\",\"function\":{\"name\":\"bash\",\"arguments\":\"{\"}}]}}]}\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var gotInterrupted bool
+	for chunk := range ch {
+		switch chunk.Type {
+		case provider.ChunkToolCall:
+			t.Fatalf("partial tool call surfaced: %+v", chunk.ToolCall)
+		case provider.ChunkError:
+			var interrupted *provider.StreamInterruptedError
+			gotInterrupted = errors.As(chunk.Err, &interrupted)
+		}
+	}
+	if !gotInterrupted {
+		t.Error("a cut after the tool-call start should surface as a stream interruption")
+	}
+}
+
+// TestStreamAcceptsFinishReasonWithoutDone keeps gateways that omit the [DONE]
+// sentinel working: a finish_reason marks the turn complete on its own.
+func TestStreamAcceptsFinishReasonWithoutDone(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, "data: {\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\n")
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+
+	var text strings.Builder
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("finish_reason without [DONE] should complete cleanly: %v", chunk.Err)
+		}
+		if chunk.Type == provider.ChunkText {
+			text.WriteString(chunk.Text)
+		}
+	}
+	if text.String() != "hello" {
+		t.Errorf("text = %q, want %q", text.String(), "hello")
+	}
+}
+
 // TestStreamDoesNotReplayAfterOutput guards against duplicated output: once a
 // token has streamed, a mid-stream reset must surface as an error rather than
 // replaying the request (which would re-emit the already-shown text).

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"reasonix/internal/nilutil"
 )
@@ -73,9 +74,10 @@ const interruptedToolResult = "[no result: the previous turn was interrupted bef
 // OpenAI-compatible and Anthropic APIs enforce: every assistant tool_calls entry
 // must be answered by a following tool message for its id, and a tool message must
 // follow such a call. It backfills a placeholder result for any unanswered call
-// (so the turn stays intact) and drops orphan tool messages. Well-formed histories
-// pass through unchanged (results stay in call order). Callers send the result;
-// the stored session keeps the original.
+// (so the turn stays intact), drops orphan tool messages, and closes truncated
+// call-argument JSON (DeepSeek 400s on replayed half-streamed args, #3953).
+// Well-formed histories pass through unchanged (results stay in call order).
+// Callers send the result; the stored session keeps the original.
 func SanitizeToolPairing(msgs []Message) []Message {
 	out := make([]Message, 0, len(msgs))
 	for i := 0; i < len(msgs); {
@@ -85,7 +87,7 @@ func SanitizeToolPairing(msgs []Message) []Message {
 			for j < len(msgs) && msgs[j].Role == RoleTool {
 				j++
 			}
-			out = append(out, m)
+			out = append(out, repairToolCallArgs(m))
 			out = append(out, pairToolResults(m.ToolCalls, msgs[i+1:j])...)
 			i = j // tool messages consumed here; any non-matching ones are orphans, dropped
 			continue
@@ -96,6 +98,87 @@ func SanitizeToolPairing(msgs []Message) []Message {
 		}
 		out = append(out, m)
 		i++
+	}
+	return out
+}
+
+// repairToolCallArgs returns m with any undecodable tool-call Arguments closed
+// into valid JSON (copy-on-write; the caller's history is never mutated). Empty
+// arguments pass through — some gateways send "" for no-arg tools.
+func repairToolCallArgs(m Message) Message {
+	broken := false
+	for _, tc := range m.ToolCalls {
+		if tc.Arguments != "" && !json.Valid([]byte(tc.Arguments)) {
+			broken = true
+			break
+		}
+	}
+	if !broken {
+		return m
+	}
+	calls := make([]ToolCall, len(m.ToolCalls))
+	copy(calls, m.ToolCalls)
+	for i := range calls {
+		if calls[i].Arguments == "" || json.Valid([]byte(calls[i].Arguments)) {
+			continue
+		}
+		calls[i].Arguments = closeTruncatedJSON(calls[i].Arguments)
+	}
+	m.ToolCalls = calls
+	return m
+}
+
+// closeTruncatedJSON best-effort completes a JSON document cut off mid-stream
+// (unterminated string, open braces, dangling comma/colon); anything still
+// invalid after closing degrades to "{}".
+func closeTruncatedJSON(s string) string {
+	var stack []byte
+	inStr, esc := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inStr {
+			switch {
+			case esc:
+				esc = false
+			case c == '\\':
+				esc = true
+			case c == '"':
+				inStr = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inStr = true
+		case '{':
+			stack = append(stack, '}')
+		case '[':
+			stack = append(stack, ']')
+		case '}', ']':
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	out := s
+	if esc {
+		out = out[:len(out)-1]
+	}
+	if inStr {
+		out += `"`
+	}
+	trimmed := strings.TrimRight(out, " \t\r\n")
+	switch {
+	case strings.HasSuffix(trimmed, ","):
+		out = trimmed[:len(trimmed)-1]
+	case strings.HasSuffix(trimmed, ":"):
+		out = trimmed + "null"
+	}
+	for i := len(stack) - 1; i >= 0; i-- {
+		out += string(stack[i])
+	}
+	if !json.Valid([]byte(out)) {
+		return "{}"
 	}
 	return out
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -98,6 +98,34 @@ func TestSanitizeToolPairingLeavesWellFormedUnchanged(t *testing.T) {
 	}
 }
 
+func TestSanitizeToolPairingClosesTruncatedArgs(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`{`, `{}`},
+		{`{"time": 2`, `{"time": 2}`},
+		{`{"command": "ls -la`, `{"command": "ls -la"}`},
+		{`{"a": 1,`, `{"a": 1}`},
+		{`{"a":`, `{"a":null}`},
+		{`{"path": "C:\\tmp\`, `{"path": "C:\\tmp"}`},
+		{`{"items": [1, 2`, `{"items": [1, 2]}`},
+		{`total garbage`, `{}`},
+		{`{"ok": true}`, `{"ok": true}`},
+		{``, ``},
+	}
+	for _, c := range cases {
+		in := []Message{
+			{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "bash", Arguments: c.in}}},
+			{Role: RoleTool, ToolCallID: "c1", Content: "r"},
+		}
+		out := SanitizeToolPairing(in)
+		if got := out[0].ToolCalls[0].Arguments; got != c.want {
+			t.Errorf("args %q repaired to %q, want %q", c.in, got, c.want)
+		}
+		if in[0].ToolCalls[0].Arguments != c.in {
+			t.Errorf("stored history mutated for %q: %q", c.in, in[0].ToolCalls[0].Arguments)
+		}
+	}
+}
+
 // --- Pricing.Cost ---
 
 func TestPricingCostNil(t *testing.T) {


### PR DESCRIPTION
﻿A clean-FIN idle close from a proxy ends the SSE scan loop with no scanner error, so `readStream` treated the stream as complete and the agent committed the turn — including half-streamed tool-call `arguments` (`"{"`, `{"time": 2`, …). Every later request replays that truncated JSON and DeepSeek rejects it with HTTP 400, so the session is permanently stuck until the user abandons it.

Two layers:

- **Detect the cut at the source.** `readStream` now treats a clean EOF without `[DONE]` *and* without any `finish_reason` as a connection cut. That routes it through the existing machinery from #3148: replayed transparently if nothing was emitted yet, surfaced as `StreamInterruptedError` (agent recovery, partial calls discarded) if output already streamed. Gateways that omit `[DONE]` but send `finish_reason` keep working.
- **Repair already-poisoned histories.** `SanitizeToolPairing` now best-effort closes truncated argument JSON (unterminated string, open braces, dangling comma/colon; anything unrecoverable degrades to `{}`) when building the wire request, for both the OpenAI-compatible and Anthropic providers. The stored session keeps the original bytes; this also un-bricks sessions users already have on disk, and covers the `finish_reason: length` mid-call truncation case.

Tests: clean-EOF-before-output replays and yields the full call; clean EOF mid-call surfaces as interruption with no partial `ChunkToolCall`; `finish_reason` without `[DONE]` still completes; arg-repair table incl. copy-on-write (stored history never mutated).

Closes #3953
