### PR TITLE
fix(agent): derive previews and auto-titles from the original task in dual-model sessions

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1206,7 +1206,7 @@ func topicTitleFromSession(path string) string {
 			return ""
 		}
 		if msg.Role == "user" {
-			return topicTitleFromText(msg.Content)
+			return topicTitleFromText(agent.HandoffTask(msg.Content))
 		}
 	}
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -193,3 +193,27 @@ Executor instructions:
 
 Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, plan)
 }
+
+// HandoffTask returns the original user task embedded in an executor handoff
+// message, or s unchanged when it is not one. Session previews and auto-titles
+// use it so dual-model sessions surface the user's words, not the handoff
+// boilerplate (#3860).
+func HandoffTask(s string) string {
+	trimmed := strings.TrimSpace(s)
+	if !strings.HasPrefix(trimmed, "# "+executorHandoffMarker) {
+		return s
+	}
+	const header = "Original task:\n"
+	i := strings.Index(trimmed, header)
+	if i < 0 {
+		return s
+	}
+	rest := trimmed[i+len(header):]
+	if j := strings.Index(rest, "\n\nPlanner output:"); j >= 0 {
+		rest = rest[:j]
+	}
+	if task := strings.TrimSpace(rest); task != "" {
+		return task
+	}
+	return s
+}

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -84,6 +84,23 @@ func TestCoordinatorHandsPlanToExecutor(t *testing.T) {
 	}
 }
 
+// TestHandoffTaskRecoversOriginalInput guards the dual-model auto-title path
+// (#3860): previews must surface the user's words, not handoff boilerplate.
+func TestHandoffTaskRecoversOriginalInput(t *testing.T) {
+	if got := HandoffTask(formatHandoff("修复登录页的 bug", "1. read login.go")); got != "修复登录页的 bug" {
+		t.Errorf("HandoffTask(handoff) = %q, want the original task", got)
+	}
+	multi := "fix the bug\n\nsteps:\n- a\n- b"
+	if got := HandoffTask(formatHandoff(multi, "plan")); got != multi {
+		t.Errorf("HandoffTask(multi-line) = %q, want %q", got, multi)
+	}
+	for _, plain := range []string{"ordinary input", "", "# Reasonix executor handoff with no sections"} {
+		if got := HandoffTask(plain); got != plain {
+			t.Errorf("HandoffTask(%q) = %q, want unchanged", plain, got)
+		}
+	}
+}
+
 // TestCoordinatorSkipsPlannerForTrivialTurn checks the gate: when shouldPlan
 // rejects the turn, the planner is never called and the executor gets the raw
 // input (no plan handoff).

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -183,7 +183,7 @@ func previewSession(path string) (string, int) {
 		if m.Role == provider.RoleUser {
 			turns++
 			if first == "" {
-				s := strings.TrimSpace(m.Content)
+				s := strings.TrimSpace(HandoffTask(m.Content))
 				if r := []rune(s); len(r) > 80 {
 					s = string(r[:77]) + "…"
 				}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -975,7 +975,7 @@ func previewSessionFile(path string) (string, int) {
 		if m.Role == "user" {
 			turns++
 			if first == "" {
-				first = strings.TrimSpace(m.Content)
+				first = strings.TrimSpace(agent.HandoffTask(m.Content))
 			}
 		}
 	}


### PR DESCRIPTION
In planner+executor mode the executor session's first user message is the handoff boilerplate (`# Reasonix executor handoff ... Original task: ...`), so every session preview and every auto-generated title collapsed to "Reasonix" / "Reasonix executor" — indistinguishable sessions in the picker and the desktop sidebar. Single-model sessions were unaffected.

`agent.HandoffTask` extracts the embedded original task from a handoff message (pass-through for anything else), and the three preview/title consumers use it: the CLI session picker (`previewSession`), the serve preview (`previewSessionFile`, which also feeds title generation), and the desktop topic auto-title (`topicTitleFromSession`).

The stored session is untouched — only what previews and the title model see changes.

Closes #3860