### PR TITLE
fix(config): read the pre-mcpServers `mcp` string list from v0.x config.json

### DIFF
--- a/internal/config/mcpjson.go
+++ b/internal/config/mcpjson.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
+	"strings"
 
 	"reasonix/internal/fileutil"
 	"reasonix/internal/mcpdiag"
@@ -78,11 +80,13 @@ func legacyConfigPath() string {
 }
 
 // loadLegacyMCP reads the v0.x ~/.reasonix/config.json and returns its enabled
-// mcpServers as PluginEntry values (servers listed in its mcpDisabled are
-// skipped), so upgrading from v0.x keeps MCP servers working without rewriting
-// them as [[plugins]]. Absent or malformed → nil: a stale legacy file must never
-// block startup, and it is the lowest-priority source anyway (the v2 config and
-// .mcp.json win on a name collision — see Load).
+// MCP servers as PluginEntry values — both the canonical mcpServers map and the
+// older `mcp` string list (mcpServers wins on a name collision, matching v0.x;
+// servers listed in mcpDisabled are skipped) — so upgrading from v0.x keeps MCP
+// servers working without rewriting them as [[plugins]]. Absent or malformed →
+// nil: a stale legacy file must never block startup, and it is the
+// lowest-priority source anyway (the v2 config and .mcp.json win on a name
+// collision — see Load).
 func loadLegacyMCP(path string) []PluginEntry {
 	if path == "" {
 		return nil
@@ -92,8 +96,10 @@ func loadLegacyMCP(path string) []PluginEntry {
 		return nil
 	}
 	var doc struct {
-		MCPServers  map[string]mcpServerSpec `json:"mcpServers"`
-		MCPDisabled []string                 `json:"mcpDisabled"`
+		MCP         []string                     `json:"mcp"`
+		MCPServers  map[string]mcpServerSpec     `json:"mcpServers"`
+		MCPEnv      map[string]map[string]string `json:"mcpEnv"`
+		MCPDisabled []string                     `json:"mcpDisabled"`
 	}
 	if err := json.Unmarshal(b, &doc); err != nil {
 		return nil
@@ -102,7 +108,63 @@ func loadLegacyMCP(path string) []PluginEntry {
 	for _, n := range doc.MCPDisabled {
 		disabled[n] = true
 	}
-	return specsToEntries(doc.MCPServers, disabled)
+	entries := specsToEntries(doc.MCPServers, disabled)
+	have := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		have[e.Name] = true
+	}
+	for i, raw := range doc.MCP {
+		pe, ok := parseLegacyMCPSpec(raw)
+		if !ok || disabled[pe.Name] {
+			continue
+		}
+		if pe.Name == "" {
+			pe.Name = anonymousMCPName(i)
+		} else if pe.Command != "" {
+			pe.Env = doc.MCPEnv[pe.Name]
+		}
+		if have[pe.Name] {
+			continue
+		}
+		have[pe.Name] = true
+		pe, _ = NormalizePluginCommandLine(pe)
+		entries = append(entries, pe)
+	}
+	return entries
+}
+
+var legacyMCPSpecName = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_-]*)=(.*)$`)
+
+// parseLegacyMCPSpec parses one v0.x `--mcp`-format string: "name=cmd args...",
+// "name=https://url" (SSE), or "name=streamable+https://url" (streamable HTTP);
+// the name= prefix is optional.
+func parseLegacyMCPSpec(raw string) (PluginEntry, bool) {
+	body := strings.TrimSpace(raw)
+	var name string
+	if m := legacyMCPSpecName.FindStringSubmatch(body); m != nil {
+		name, body = m[1], strings.TrimSpace(m[2])
+	}
+	if body == "" {
+		return PluginEntry{}, false
+	}
+	lower := strings.ToLower(body)
+	if strings.HasPrefix(lower, "streamable+http://") || strings.HasPrefix(lower, "streamable+https://") {
+		return PluginEntry{Name: name, Type: "http", URL: body[len("streamable+"):]}, true
+	}
+	if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+		return PluginEntry{Name: name, Type: "sse", URL: body}, true
+	}
+	parts, ok := splitPluginCommandLine(body)
+	if !ok || len(parts) == 0 {
+		return PluginEntry{}, false
+	}
+	return PluginEntry{Name: name, Command: parts[0], Args: parts[1:]}, true
+}
+
+// anonymousMCPName names a v0.x spec that carried no name= prefix (its tools
+// registered unprefixed in v0.x; v1+ plugins require a name).
+func anonymousMCPName(i int) string {
+	return fmt.Sprintf("mcp-%d", i+1)
 }
 
 func pluginEntryFromMCPSpec(name string, s mcpServerSpec) PluginEntry {

--- a/internal/config/mcpjson_test.go
+++ b/internal/config/mcpjson_test.go
@@ -426,6 +426,46 @@ func TestLoadLegacyMCP(t *testing.T) {
 		t.Errorf("remote mapped wrong: %+v", got[1])
 	}
 
+	doc = `{
+  "mcp": [
+    "memory=npx -y @modelcontextprotocol/server-memory",
+    "remote=https://x/sse",
+    "stream=streamable+https://x/http",
+    "github=node dupe.js",
+    "off=npx server-off",
+    "uvx run anonymous-server"
+  ],
+  "mcpServers": { "github": { "command": "npx" } },
+  "mcpEnv": { "memory": { "MEMORY_PATH": "/tmp/mem" } },
+  "mcpDisabled": ["off"]
+}`
+	if err := os.WriteFile(path, []byte(doc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got = loadLegacyMCP(path)
+	byName := map[string]PluginEntry{}
+	for _, e := range got {
+		byName[e.Name] = e
+	}
+	if m := byName["memory"]; m.Command != "npx" || m.Env["MEMORY_PATH"] != "/tmp/mem" {
+		t.Errorf("legacy mcp string entry mapped wrong: %+v", m)
+	}
+	if r := byName["remote"]; r.Type != "sse" || r.URL != "https://x/sse" {
+		t.Errorf("plain URL should map to SSE: %+v", r)
+	}
+	if s := byName["stream"]; s.Type != "http" || s.URL != "https://x/http" {
+		t.Errorf("streamable+ URL should map to http: %+v", s)
+	}
+	if g := byName["github"]; g.Command != "npx" || len(g.Args) != 0 {
+		t.Errorf("mcpServers should win the github name collision: %+v", g)
+	}
+	if a := byName["mcp-6"]; a.Command != "uvx" || len(a.Args) != 2 {
+		t.Errorf("anonymous spec should get a synthesized name: %+v", a)
+	}
+	if _, hasOff := byName["off"]; hasOff || len(got) != 5 {
+		t.Errorf("disabled entry should be skipped, got %d: %+v", len(got), got)
+	}
+
 	// Absent, malformed, and empty paths must not error — just yield nil, so a
 	// stale legacy file can never block startup.
 	if got := loadLegacyMCP(filepath.Join(dir, "nope.json")); got != nil {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -18,6 +18,7 @@ type legacyConfig struct {
 	APIKey      string                       `json:"apiKey"`
 	BaseURL     string                       `json:"baseUrl"`
 	Lang        string                       `json:"lang"`
+	MCP         []string                     `json:"mcp"` // pre-mcpServers `--mcp`-format strings
 	MCPServers  map[string]legacyMCPServer   `json:"mcpServers"`
 	MCPEnv      map[string]map[string]string `json:"mcpEnv"`
 	MCPDisabled []string                     `json:"mcpDisabled"`
@@ -172,19 +173,42 @@ func migrateLegacyBaseURL(cfg *Config, baseURL string) {
 }
 
 func legacyPlugins(legacy legacyConfig) []PluginEntry {
-	if len(legacy.MCPServers) == 0 {
-		return nil
-	}
 	disabled := make(map[string]bool, len(legacy.MCPDisabled))
 	for _, n := range legacy.MCPDisabled {
 		disabled[n] = true
+	}
+	var out []PluginEntry
+	index := make(map[string]int)
+	add := func(pe PluginEntry, off bool) {
+		if off {
+			v := false
+			pe.AutoStart = &v
+		}
+		pe, _ = NormalizePluginCommandLine(pe)
+		if j, dup := index[pe.Name]; dup {
+			out[j] = pe // mcpServers overrides the `mcp` list on a name collision, matching v0.x
+			return
+		}
+		index[pe.Name] = len(out)
+		out = append(out, pe)
+	}
+	for i, raw := range legacy.MCP {
+		pe, ok := parseLegacyMCPSpec(raw)
+		if !ok {
+			continue
+		}
+		if pe.Name == "" {
+			pe.Name = anonymousMCPName(i)
+		} else if pe.Command != "" {
+			pe.Env = mergeEnv(nil, legacy.MCPEnv[pe.Name])
+		}
+		add(pe, disabled[pe.Name])
 	}
 	names := make([]string, 0, len(legacy.MCPServers))
 	for n := range legacy.MCPServers {
 		names = append(names, n)
 	}
 	sort.Strings(names)
-	out := make([]PluginEntry, 0, len(names))
 	for _, name := range names {
 		s := legacy.MCPServers[name]
 		pe := PluginEntry{
@@ -196,12 +220,7 @@ func legacyPlugins(legacy legacyConfig) []PluginEntry {
 			URL:     s.URL,
 			Headers: s.Headers,
 		}
-		if s.Disabled || disabled[name] {
-			off := false
-			pe.AutoStart = &off
-		}
-		pe, _ = NormalizePluginCommandLine(pe)
-		out = append(out, pe)
+		add(pe, s.Disabled || disabled[name])
 	}
 	return out
 }

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -78,6 +78,59 @@ func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
 	}
 }
 
+// TestMigrateImportsLegacyMCPStringList covers the pre-mcpServers `mcp` format
+// (#3949): `--mcp`-style strings, with mcpEnv/mcpDisabled keyed by name and
+// mcpServers winning a name collision.
+func TestMigrateImportsLegacyMCPStringList(t *testing.T) {
+	src, _, _ := legacyHome(t)
+	writeLegacy(t, src, `{
+		"mcp": [
+			"memory=npx -y @modelcontextprotocol/server-memory",
+			"search=https://mcp.example.com/sse",
+			"stream=streamable+https://mcp.example.com/http",
+			"fs=node old-fs.js",
+			"off=npx -y server-off"
+		],
+		"mcpServers": {"fs": {"command": "npx", "args": ["-y", "server-fs"]}},
+		"mcpEnv": {"memory": {"MEMORY_PATH": "/tmp/mem"}},
+		"mcpDisabled": ["off"]
+	}`)
+
+	if _, err := MigrateLegacyIfNeeded(); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	byName := map[string]PluginEntry{}
+	for _, p := range cfg.Plugins {
+		byName[p.Name] = p
+	}
+	mem := byName["memory"]
+	if mem.Command != "npx" || len(mem.Args) != 2 || mem.Args[1] != "@modelcontextprotocol/server-memory" {
+		t.Errorf("memory spec not parsed: %+v", mem)
+	}
+	if mem.Env["MEMORY_PATH"] != "/tmp/mem" {
+		t.Errorf("mcpEnv not applied to memory: %+v", mem.Env)
+	}
+	if s := byName["search"]; s.Type != "sse" || s.URL != "https://mcp.example.com/sse" {
+		t.Errorf("plain URL should migrate as SSE: %+v", s)
+	}
+	if s := byName["stream"]; s.Type != "http" || s.URL != "https://mcp.example.com/http" {
+		t.Errorf("streamable+ URL should migrate as http: %+v", s)
+	}
+	if fs := byName["fs"]; len(fs.Args) != 2 || fs.Args[1] != "server-fs" {
+		t.Errorf("mcpServers should win the fs name collision: %+v", fs)
+	}
+	if off := byName["off"]; off.AutoStart == nil || *off.AutoStart {
+		t.Errorf("mcpDisabled entry should migrate with auto_start=false: %+v", off)
+	}
+	if len(cfg.Plugins) != 5 {
+		t.Errorf("got %d plugins, want 5: %+v", len(cfg.Plugins), cfg.Plugins)
+	}
+}
+
 func TestMigrateRoundTripsThroughLoad(t *testing.T) {
 	src, _, _ := legacyHome(t)
 	writeLegacy(t, src, `{"apiKey":"sk-x","mcpServers":{"fs":{"command":"npx","env":{"A":"1"}}}}`)


### PR DESCRIPTION
v0.x stored MCP servers in two shapes: the canonical `mcpServers` map and the older `mcp` list of `--mcp`-format strings (`name=cmd args`, `name=https://url` for SSE, `name=streamable+https://url` for streamable HTTP), with `mcpEnv` / `mcpDisabled` keyed by server name. The Go line only read `mcpServers` — in both the one-time migration *and* the live lowest-priority legacy source — so servers configured the old way (including the default memory server the v0.x setup writes) silently vanished on upgrade.

- `parseLegacyMCPSpec` parses one `--mcp` string into a `PluginEntry` (same transport inference as v0.x: `streamable+` prefix → http, plain `http(s)://` → SSE, otherwise stdio via the existing command-line splitter).
- `MigrateLegacyIfNeeded` now imports the `mcp` list, applying `mcpEnv` to named stdio specs and migrating `mcpDisabled` entries with `auto_start = false`; `mcpServers` wins a name collision, matching the v0.x merge order.
- `loadLegacyMCP` (the every-boot legacy source for users whose v2 config already exists) reads the list the same way, skipping disabled names.
- Anonymous specs (no `name=` prefix) get a synthesized `mcp-N` name, since v1+ plugins require one.

Verified the string format against the v0.x source (`src/mcp/spec.ts` `parseMcpSpec` / `normalizeMcpConfig` on the v1 branch) rather than guessing.

Closes #3949