### PR TITLE
fix(desktop): stop pinning management modals to a compositor layer

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -8273,8 +8273,10 @@ a[href] {
   box-shadow: 0 16px 48px rgba(0, 0, 0, 0.32);
   overflow: hidden;
   transform-origin: 50% 48%;
-  will-change: transform, opacity;
-  animation: modal-in 280ms var(--ease-out) both;
+  /* No will-change / fill-mode: anything that keeps a transform applied after
+     entry pins a compositor layer rasterized at the entrance scale, leaving
+     text blurry on Windows fractional DPI until the next repaint (#3838). */
+  animation: modal-in 280ms var(--ease-out);
 }
 .history-modal {
   width: min(1360px, calc(100vw - 96px));
@@ -8318,7 +8320,7 @@ a[href] {
     opacity: 1;
   }
   100% {
-    transform: translate3d(0, 0, 0) scale(1);
+    transform: none;
     opacity: 1;
   }
 }


### PR DESCRIPTION
Repro (#3838 / #3902 / #3899): open Settings (or trash / history view) on Windows — all text in the panel renders blurry; it snaps crisp after clicking another tab or resizing the window.

Cause: `.management-modal` carried `will-change: transform, opacity` plus an entrance animation with `fill-mode: both` whose 100% frame retains a transform (`translate3d(0,0,0) scale(1)`). Both keep the modal promoted to a compositor layer whose texture was rasterized during the scaled entrance frames; on fractional display scaling (125%/150%) WebView2 then re-samples that texture instead of re-rasterizing, so text stays soft until something forces a repaint — exactly the "clears after clicking a tab / resizing" behavior in the reports.

Fix: drop `will-change` and the fill-mode, and end the keyframes at `transform: none`. The entrance looks identical (no delay, final frame equals the base style), but once it finishes no transform or animation style remains applied, so the layer is demoted and text rasterizes at native DPI.

CSS syntax + z-index token checks pass. Needs a quick visual confirm on a Windows 125%/150% scale machine before release.

Closes #3838
Closes #3902
Closes #3899