### PR TITLE
fix(desktop): make the macOS tab-strip empty space drag the window

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -11838,6 +11838,13 @@ a[href] {
   --wails-draggable: no-drag;
 }
 
+/* The empty strip between the last tab and the search button must drag the
+   window like a native titlebar — the 10px top rail alone is unusable (#3853). */
+.app--darwin .app-chrome--tabs .tabbar__spacer {
+  --wails-draggable: drag;
+  align-self: stretch;
+}
+
 .app--darwin .app-chrome--tabs .app-chrome__drag-rail {
   display: block;
   position: absolute;


### PR DESCRIPTION
Repro (#3853 / #3852, drag half of #3843): on macOS 1.5.0 the titlebar doesn't drag the window — dragging over the tab strip selects text instead.

Cause: the darwin chrome blanket-marks the entire tab strip and every tabbar descendant `--wails-draggable: no-drag`, leaving a 10px-tall "drag rail" at the very top of the 44px header as the only drag region. Nobody aims for a 10px sliver; everyone grabs the visible empty strip next to the tabs, which is the no-drag spacer.

Fix: re-enable `--wails-draggable: drag` on `.tabbar__spacer` (the flexible empty area between the last tab and the search button) and `align-self: stretch` it to full strip height. Tabs, the new-tab button, and the search button stay no-drag, so tab interactions are unaffected. The top rail is kept as an additional region.

The "Auto/YOLO 时金额边上文字重叠" part of #3843 is a separate rendering issue I couldn't reproduce from the code alone — leaving that issue open.

Needs a visual confirm on a real mac before release.

Closes #3853
Closes #3852