### PR TITLE
fix(desktop): restore palette focus outline and platform-correct search kbd

### DIFF
--- a/desktop/frontend/src/components/AppChrome.tsx
+++ b/desktop/frontend/src/components/AppChrome.tsx
@@ -134,7 +134,7 @@ export function AppChrome({
                 <Search size={13} className="tabbar__command-icon" />
                 <span className="tabbar__command-text tabbar__command-text--full">{t("tabBar.commandSearch")}</span>
                 <span className="tabbar__command-text tabbar__command-text--compact">{t("tabBar.commandSearchCompact")}</span>
-                <kbd className="tabbar__command-kbd">⌘K</kbd>
+                <kbd className="tabbar__command-kbd">Ctrl+K</kbd>
               </button>
             </div>
           )}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6454,6 +6454,10 @@ a[href] {
 .palette__item--on {
   background: var(--accent-soft);
 }
+.palette__item:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
 .palette__item-icon {
   width: 30px;
   height: 30px;


### PR DESCRIPTION
Reworked after #3962 landed the stale-block removal (came in first, with a regression test). What remains here are the two deltas:

- restore the `.palette__item:focus-visible` outline — the deleted legacy block was its only carrier
- label the detached chrome search button `Ctrl+K`; it only renders on Windows/Linux, where the hardcoded `⌘K` was wrong (the TabBar-embedded variant is macOS-only and keeps `⌘K`)

CSS checks + the new command-palette-css regression test pass locally.

Closes #3841