### PR TITLE
feat(agent): deterministic tool-result pruning + cache-TTL-aware cold-resume maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ Thumbs.db
 .idea/
 .vscode/
 /site/public/av/
+
+benchmarks/context-maintenance-e2e/run/

--- a/benchmarks/context-maintenance-e2e/main.go
+++ b/benchmarks/context-maintenance-e2e/main.go
@@ -1,0 +1,243 @@
+// Drives the context-maintenance E2E scenarios against the real DeepSeek API:
+// seed → (idle past cache TTL) → resume A/B-compares cold-restart miss tokens with and without pruning.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	_ "reasonix/internal/provider/openai"
+	"reasonix/internal/tool"
+	"reasonix/internal/tool/builtin"
+)
+
+const (
+	model      = "deepseek-v4-flash"
+	baseURL    = "https://api.deepseek.com"
+	fatResults = 20
+	fatBytes   = 12_000
+)
+
+func prov() provider.Provider {
+	key := os.Getenv("DEEPSEEK_API_KEY")
+	if key == "" {
+		fmt.Fprintln(os.Stderr, "DEEPSEEK_API_KEY not set")
+		os.Exit(1)
+	}
+	p, err := provider.New("openai", provider.Config{Name: "e2e", BaseURL: baseURL, Model: model, APIKey: key})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return p
+}
+
+func fakeGoFile(nonce string, i, size int) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "// module %s file%02d\npackage stress\n\n", nonce, i)
+	line := 0
+	for b.Len() < size {
+		fmt.Fprintf(&b, "func helper_%s_%02d_%04d(x int) int { return x*%d + %d }\n", nonce, i, line, line+3, line*7)
+		line++
+	}
+	return b.String()
+}
+
+func seedSession(nonce string) *agent.Session {
+	s := agent.NewSession("You are a terse coding agent reviewing a Go codebase.")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "Review every file in module " + nonce + " one by one. Keep notes short."})
+	for i := 0; i < fatResults; i++ {
+		id := fmt.Sprintf("c%02d", i)
+		name := fmt.Sprintf("src/file%02d.go", i)
+		s.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: id, Name: "read_file", Arguments: fmt.Sprintf(`{"path":%q}`, name)}}})
+		s.Add(provider.Message{Role: provider.RoleTool, ToolCallID: id, Name: "read_file", Content: fakeGoFile(nonce, i, fatBytes)})
+		s.Add(provider.Message{Role: provider.RoleAssistant, Content: fmt.Sprintf("Reviewed %s.", name)})
+	}
+	return s
+}
+
+// oneShot appends a user message and runs a single completion, returning usage.
+func oneShot(p provider.Provider, msgs []provider.Message, question string) (provider.Usage, error) {
+	req := provider.Request{
+		Messages:  append(append([]provider.Message(nil), msgs...), provider.Message{Role: provider.RoleUser, Content: question}),
+		MaxTokens: 32,
+	}
+	ch, err := p.Stream(context.Background(), req)
+	if err != nil {
+		return provider.Usage{}, err
+	}
+	var u provider.Usage
+	for c := range ch {
+		switch c.Type {
+		case provider.ChunkUsage:
+			u = *c.Usage
+		case provider.ChunkError:
+			return u, c.Err
+		}
+	}
+	return u, nil
+}
+
+type meta struct {
+	SeededAt time.Time                 `json:"seeded_at"`
+	Nonces   map[string]string         `json:"nonces"`
+	SeedUse  map[string]provider.Usage `json:"seed_usage"`
+}
+
+func seed(dir string) {
+	p := prov()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	m := meta{SeededAt: time.Now(), Nonces: map[string]string{}, SeedUse: map[string]provider.Usage{}}
+	for _, arm := range []string{"pruned", "control"} {
+		nonce := fmt.Sprintf("%s%d", arm, time.Now().UnixNano()%1_000_000)
+		s := seedSession(nonce)
+		u, err := oneShot(p, s.Snapshot(), "How many files have you reviewed so far? Reply with just the number.")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "seed %s: %v\n", arm, err)
+			os.Exit(1)
+		}
+		if err := s.Save(filepath.Join(dir, arm+".jsonl")); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		m.Nonces[arm] = nonce
+		m.SeedUse[arm] = u
+		fmt.Printf("seeded %-7s prompt=%d hit=%d miss=%d\n", arm, u.PromptTokens, u.CacheHitTokens, u.CacheMissTokens)
+	}
+	b, _ := json.MarshalIndent(m, "", "  ")
+	os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644)
+}
+
+func resume(dir string) {
+	p := prov()
+	raw, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	var m meta
+	json.Unmarshal(raw, &m)
+	idle := time.Since(m.SeededAt).Round(time.Minute)
+
+	out := map[string]provider.Usage{}
+	for _, arm := range []string{"pruned", "control"} {
+		s, err := agent.LoadSession(filepath.Join(dir, arm+".jsonl"))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		prunes := 0
+		if arm == "pruned" {
+			a := agent.New(nil, tool.NewRegistry(), s, agent.Options{ContextWindow: 1_000_000, ArchiveDir: filepath.Join(dir, "archive")}, event.Discard)
+			st, err := a.PruneStaleToolResults()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "prune:", err)
+				os.Exit(1)
+			}
+			prunes = st.Results
+		}
+		u, err := oneShot(p, s.Snapshot(), "Which file did you review first? Reply with just the path.")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "resume %s: %v\n", arm, err)
+			os.Exit(1)
+		}
+		out[arm] = u
+		fmt.Printf("resume %-7s idle=%s pruned=%d prompt=%d hit=%d miss=%d\n", arm, idle, prunes, u.PromptTokens, u.CacheHitTokens, u.CacheMissTokens)
+	}
+	b, _ := json.MarshalIndent(map[string]any{"idle": idle.String(), "resume_usage": out}, "", "  ")
+	os.WriteFile(filepath.Join(dir, fmt.Sprintf("resume-%d.json", time.Now().Unix())), b, 0o644)
+
+	c, pr := out["control"], out["pruned"]
+	if c.CacheMissTokens > 0 {
+		fmt.Printf("\ncold-restart miss tokens: control=%d pruned=%d (%.0f%% reduction)\n",
+			c.CacheMissTokens, pr.CacheMissTokens, 100*(1-float64(pr.CacheMissTokens)/float64(c.CacheMissTokens)))
+	}
+}
+
+// comprehension checks that the agent re-reads a file behind a prune placeholder
+// instead of hallucinating: the answer is a number that exists only in the file.
+func comprehension(trials int) {
+	p := prov()
+	pass := 0
+	for t := 0; t < trials; t++ {
+		dir, err := os.MkdirTemp("", "cm-e2e-")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		secret := fmt.Sprintf("%d", 1000+time.Now().UnixNano()%9000)
+		content := "package cfg\n\n// retention floor, milliseconds\nconst cacheRetentionFloor = " + secret + "\n" + strings.Repeat("// padding line filler for prune eligibility\n", 400)
+		os.WriteFile(filepath.Join(dir, "config.go"), []byte(content), 0o644)
+
+		s := agent.NewSession("You are a terse coding agent. Use tools when you need file contents.")
+		s.Add(provider.Message{Role: provider.RoleUser, Content: "Read config.go and note its constants."})
+		s.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "r1", Name: "read_file", Arguments: `{"path":"config.go"}`}}})
+		s.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "r1", Name: "read_file", Content: content})
+		s.Add(provider.Message{Role: provider.RoleAssistant, Content: "Noted the constants in config.go."})
+		for i := 0; i < 4; i++ {
+			s.Add(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("ack %d", i)})
+			s.Add(provider.Message{Role: provider.RoleAssistant, Content: "ok"})
+		}
+
+		reg := tool.NewRegistry()
+		for _, tl := range (builtin.Workspace{Dir: dir}).Tools("read_file") {
+			reg.Add(tl)
+		}
+		a := agent.New(p, reg, s, agent.Options{ContextWindow: 2000, RecentKeep: 2, MaxSteps: 5}, event.Discard)
+		st, err := a.PruneStaleToolResults()
+		if err != nil || st.Results == 0 {
+			fmt.Fprintf(os.Stderr, "trial %d: prune did not fire (st=%+v err=%v)\n", t, st, err)
+			os.Exit(1)
+		}
+
+		err = a.Run(context.Background(), "What is the exact numeric value of cacheRetentionFloor in config.go? Reply with just the number.")
+		reRead, answered := false, false
+		for _, msg := range s.Snapshot() {
+			if msg.Role == provider.RoleTool && strings.Contains(msg.Content, "cacheRetentionFloor = "+secret) {
+				reRead = true
+			}
+			if msg.Role == provider.RoleAssistant && strings.Contains(msg.Content, secret) {
+				answered = true
+			}
+		}
+		ok := err == nil && reRead && answered
+		if ok {
+			pass++
+		}
+		fmt.Printf("trial %d: re-read=%v answered=%v err=%v\n", t, reRead, answered, err)
+		os.RemoveAll(dir)
+	}
+	fmt.Printf("\ncomprehension: %d/%d passed\n", pass, trials)
+	if pass < trials {
+		os.Exit(1)
+	}
+}
+
+func main() {
+	dir := flag.String("dir", "benchmarks/context-maintenance-e2e/run", "state directory for seed/resume")
+	trials := flag.Int("trials", 5, "comprehension trials")
+	flag.Parse()
+	switch flag.Arg(0) {
+	case "seed":
+		seed(*dir)
+	case "resume":
+		resume(*dir)
+	case "comprehension":
+		comprehension(*trials)
+	default:
+		fmt.Fprintln(os.Stderr, "usage: context-maintenance-e2e [seed|resume|comprehension]")
+		os.Exit(1)
+	}
+}

--- a/benchmarks/context-maintenance-e2e/main.go
+++ b/benchmarks/context-maintenance-e2e/main.go
@@ -117,7 +117,10 @@ func seed(dir string) {
 		fmt.Printf("seeded %-7s prompt=%d hit=%d miss=%d\n", arm, u.PromptTokens, u.CacheHitTokens, u.CacheMissTokens)
 	}
 	b, _ := json.MarshalIndent(m, "", "  ")
-	os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644)
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), b, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }
 
 func resume(dir string) {
@@ -128,7 +131,10 @@ func resume(dir string) {
 		os.Exit(1)
 	}
 	var m meta
-	json.Unmarshal(raw, &m)
+	if err := json.Unmarshal(raw, &m); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 	idle := time.Since(m.SeededAt).Round(time.Minute)
 
 	out := map[string]provider.Usage{}
@@ -157,7 +163,10 @@ func resume(dir string) {
 		fmt.Printf("resume %-7s idle=%s pruned=%d prompt=%d hit=%d miss=%d\n", arm, idle, prunes, u.PromptTokens, u.CacheHitTokens, u.CacheMissTokens)
 	}
 	b, _ := json.MarshalIndent(map[string]any{"idle": idle.String(), "resume_usage": out}, "", "  ")
-	os.WriteFile(filepath.Join(dir, fmt.Sprintf("resume-%d.json", time.Now().Unix())), b, 0o644)
+	if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("resume-%d.json", time.Now().Unix())), b, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 
 	c, pr := out["control"], out["pruned"]
 	if c.CacheMissTokens > 0 {
@@ -179,7 +188,10 @@ func comprehension(trials int) {
 		}
 		secret := fmt.Sprintf("%d", 1000+time.Now().UnixNano()%9000)
 		content := "package cfg\n\n// retention floor, milliseconds\nconst cacheRetentionFloor = " + secret + "\n" + strings.Repeat("// padding line filler for prune eligibility\n", 400)
-		os.WriteFile(filepath.Join(dir, "config.go"), []byte(content), 0o644)
+		if err := os.WriteFile(filepath.Join(dir, "config.go"), []byte(content), 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 
 		s := agent.NewSession("You are a terse coding agent. Use tools when you need file contents.")
 		s.Add(provider.Message{Role: provider.RoleUser, Content: "Read config.go and note its constants."})

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -96,6 +96,17 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 		return
 	}
 	force := u.PromptTokens >= int(float64(a.contextWindow)*a.compactForceRatio)
+	// Prune before folding: when eliding stale tool results alone clears the
+	// trigger, this turn's (paid) summarize call is skipped entirely.
+	ratio := a.tokPerChar()
+	if st, err := a.PruneStaleToolResults(); err == nil && st.Results > 0 {
+		saved := int(float64(st.SavedChars) * ratio)
+		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
+			"pruned %d stale tool results (~%d tokens est.) before compaction", st.Results, saved)})
+		if !force && u.PromptTokens-saved < high {
+			return
+		}
+	}
 	if err := a.compact(ctx, "auto", "", force); err != nil {
 		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("compaction skipped: %v", err)})
 		return

--- a/internal/agent/compact_loop_e2e_test.go
+++ b/internal/agent/compact_loop_e2e_test.go
@@ -28,10 +28,13 @@ func (f fatTool) Execute(context.Context, json.RawMessage) (string, error) {
 
 // loopMock emits exactly one tool call per user turn (a tool call when the last
 // message is the user's, a final answer when it is the tool result), so each Run
-// does one tool round — the step that triggers maybeCompact.
+// does one tool round — the step that triggers maybeCompact. finalText overrides
+// the per-turn closing answer so a test can grow the session with assistant text
+// (which pruning never touches) instead of tool output.
 type loopMock struct {
-	t      *testing.T
-	rounds int
+	t         *testing.T
+	rounds    int
+	finalText string
 }
 
 func lastRole(msgs []json.RawMessage) string {
@@ -59,8 +62,12 @@ func (m *loopMock) handler(w http.ResponseWriter, r *http.Request) {
 	promptTok := charsOf(msgs) / 4
 
 	if lastRole(msgs) == "tool" {
+		text := m.finalText
+		if text == "" {
+			text = "Done with this step."
+		}
 		writeSSE(w, m.t,
-			streamChunk(deltaText("Done with this step.")),
+			streamChunk(deltaText(text)),
 			finishChunk("stop"),
 			usageChunk(promptTok, 20, 0, promptTok))
 		return
@@ -76,9 +83,9 @@ func (m *loopMock) handler(w http.ResponseWriter, r *http.Request) {
 // compactionsPerTurn drives `turns` user messages through a fresh agent wired to
 // loopMock and reports, per turn, how many compactions started and whether an
 // auto-compaction-paused notice was seen.
-func compactionsPerTurn(t *testing.T, windowTok int, blob string, turns int) (perTurn []int, paused bool) {
+func compactionsPerTurn(t *testing.T, windowTok int, blob, finalText string, turns int) (perTurn []int, paused bool, prunes int) {
 	t.Helper()
-	mock := &loopMock{t: t}
+	mock := &loopMock{t: t, finalText: finalText}
 	srv := httptest.NewServer(http.HandlerFunc(mock.handler))
 	defer srv.Close()
 
@@ -95,6 +102,9 @@ func compactionsPerTurn(t *testing.T, windowTok int, blob string, turns int) (pe
 			if strings.Contains(e.Text, "Auto-compaction paused") {
 				paused = true
 			}
+			if strings.Contains(e.Text, "pruned") {
+				prunes++
+			}
 		}
 	})
 
@@ -106,7 +116,7 @@ func compactionsPerTurn(t *testing.T, windowTok int, blob string, turns int) (pe
 		}
 		perTurn[i] = started - before
 	}
-	return perTurn, paused
+	return perTurn, paused, prunes
 }
 
 func consecutiveCompactingTurns(perTurn []int) int {
@@ -130,7 +140,7 @@ func consecutiveCompactingTurns(perTurn []int) int {
 // notice — instead of looping turn after turn.
 func TestCompactionPausesWhenWindowTooSmall(t *testing.T) {
 	// One fat_read result (~1750 tok) exceeds the 0.8×1600 trigger on its own.
-	perTurn, paused := compactionsPerTurn(t, 1600, strings.Repeat("LARGE FILE CONTENTS. ", 350), 8)
+	perTurn, paused, _ := compactionsPerTurn(t, 1600, strings.Repeat("LARGE FILE CONTENTS. ", 350), "", 8)
 
 	total := 0
 	for _, n := range perTurn {
@@ -146,12 +156,12 @@ func TestCompactionPausesWhenWindowTooSmall(t *testing.T) {
 	}
 }
 
-// TestCompactionHealthyWindowNeverLoops is the companion: with a window big
-// enough to summarize a turn under, compaction still fires as the session grows
-// but reclaims enough headroom that it never fires on consecutive turns and never
-// trips the stuck guard.
+// TestCompactionHealthyWindowNeverLoops is the companion: when growth comes from
+// assistant text (which pruning never touches), compaction still fires as the
+// session grows but reclaims enough headroom that it never fires on consecutive
+// turns and never trips the stuck guard.
 func TestCompactionHealthyWindowNeverLoops(t *testing.T) {
-	perTurn, paused := compactionsPerTurn(t, 40000, strings.Repeat("file line. ", 1100), 20)
+	perTurn, paused, _ := compactionsPerTurn(t, 40000, "small tool output", strings.Repeat("analysis paragraph. ", 600), 20)
 
 	total := 0
 	for _, n := range perTurn {
@@ -167,5 +177,29 @@ func TestCompactionHealthyWindowNeverLoops(t *testing.T) {
 	}
 	if c := consecutiveCompactingTurns(perTurn); c > 1 {
 		t.Errorf("compaction fired on %d consecutive turns; a healthy compaction should leave breathing room", c)
+	}
+}
+
+// TestPruneKeepsToolHeavySessionBounded: when growth comes from tool results,
+// pruning alone keeps the prompt under the trigger for the whole session — the
+// paid summarize call never happens and the stuck guard never trips. 20 turns of
+// ~3k-token blobs would otherwise cross 0.8×40000 around turn 11.
+func TestPruneKeepsToolHeavySessionBounded(t *testing.T) {
+	perTurn, paused, prunes := compactionsPerTurn(t, 40000, strings.Repeat("file line. ", 1100), "", 20)
+
+	total := 0
+	for _, n := range perTurn {
+		total += n
+	}
+	t.Logf("compactions per turn: %v (total %d), paused=%v, prunes=%d", perTurn, total, paused, prunes)
+
+	if total != 0 {
+		t.Errorf("compaction fired %d times; pruning should keep a tool-heavy session bounded without folding", total)
+	}
+	if paused {
+		t.Errorf("auto-compaction paused; pruning should have prevented the stuck loop entirely")
+	}
+	if prunes == 0 {
+		t.Errorf("expected at least one prune pass over a tool-heavy session")
 	}
 }

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -1,0 +1,73 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+
+	"reasonix/internal/provider"
+)
+
+// Pruning is the free half of context maintenance: stale tool results are
+// re-derivable (files can be re-read, commands re-run), so eliding them needs
+// no summarizer call and never drops a message — tool_call/result pairing and
+// assistant content (including signed reasoning) are untouched by construction.
+const (
+	prunedMarker  = "[elided tool result — "
+	minPruneBytes = 1024
+)
+
+// PruneStats reports one prune pass.
+type PruneStats struct {
+	Results    int
+	SavedChars int
+	Archive    string
+}
+
+// PruneStaleToolResults elides tool-result content older than the protected
+// recent tail, archiving the originals first. Idempotent; a no-op when
+// compaction is disabled (no context window).
+func (a *Agent) PruneStaleToolResults() (PruneStats, error) {
+	var st PruneStats
+	if a.contextWindow <= 0 {
+		return st, nil
+	}
+	msgs := a.session.Messages
+	head, start, ok := a.planCompaction(msgs, 1)
+	if !ok {
+		return st, nil
+	}
+	var idx []int
+	for i := head; i < start; i++ {
+		m := msgs[i]
+		if m.Role != provider.RoleTool || len(m.Content) < minPruneBytes || strings.HasPrefix(m.Content, prunedMarker) {
+			continue
+		}
+		idx = append(idx, i)
+	}
+	if len(idx) == 0 {
+		return st, nil
+	}
+	if a.archiveDir != "" {
+		originals := make([]provider.Message, 0, len(idx))
+		for _, i := range idx {
+			originals = append(originals, msgs[i])
+		}
+		path, err := archiveMessages(a.archiveDir, originals)
+		if err != nil {
+			return st, fmt.Errorf("archive: %w", err)
+		}
+		st.Archive = path
+	}
+	next := append([]provider.Message(nil), msgs...)
+	for _, i := range idx {
+		m := next[i]
+		placeholder := fmt.Sprintf("%s%s, %d bytes dropped to save context; re-run the tool if the data is needed again]", prunedMarker, m.Name, len(m.Content))
+		st.SavedChars += len(m.Content) - len(placeholder)
+		m.Content = placeholder
+		next[i] = m
+		st.Results++
+	}
+	a.session.Replace(next)
+	a.session.IncrementRewrite()
+	return st, nil
+}

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+func pruneFixture(toolContent string) *Session {
+	return &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "read_file", Arguments: "{}"}}},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "read_file", Content: toolContent},
+		{Role: provider.RoleAssistant, Content: "step done"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+}
+
+func TestPruneStaleToolResults(t *testing.T) {
+	big := strings.Repeat("x", 5000)
+	sess := pruneFixture(big)
+	dir := t.TempDir()
+	a := New(nil, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: dir}, event.Discard)
+
+	st, err := a.PruneStaleToolResults()
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if st.Results != 1 {
+		t.Fatalf("Results = %d, want 1", st.Results)
+	}
+	if st.SavedChars < 4000 {
+		t.Errorf("SavedChars = %d, want > 4000", st.SavedChars)
+	}
+	msgs := sess.Snapshot()
+	if len(msgs) != 7 {
+		t.Fatalf("message count changed: %d", len(msgs))
+	}
+	pruned := msgs[3]
+	if !strings.HasPrefix(pruned.Content, prunedMarker) {
+		t.Errorf("tool content not elided: %.60q", pruned.Content)
+	}
+	if pruned.ToolCallID != "1" || pruned.Name != "read_file" || pruned.Role != provider.RoleTool {
+		t.Errorf("tool pairing fields changed: %+v", pruned)
+	}
+	if len(msgs[2].ToolCalls) != 1 || msgs[2].ToolCalls[0].ID != "1" {
+		t.Errorf("assistant tool_calls touched: %+v", msgs[2])
+	}
+	if got := sess.RewriteVersion(); got != 1 {
+		t.Errorf("RewriteVersion = %d, want 1", got)
+	}
+	if st.Archive == "" {
+		t.Fatal("no archive written")
+	}
+	raw, err := os.ReadFile(st.Archive)
+	if err != nil {
+		t.Fatalf("read archive: %v", err)
+	}
+	if !strings.Contains(string(raw), big[:64]) {
+		t.Error("archive does not contain the original tool output")
+	}
+	if filepath.Dir(st.Archive) != dir {
+		t.Errorf("archive outside dir: %s", st.Archive)
+	}
+
+	st2, err := a.PruneStaleToolResults()
+	if err != nil {
+		t.Fatalf("second prune: %v", err)
+	}
+	if st2.Results != 0 {
+		t.Errorf("second pass pruned %d, want 0 (idempotent)", st2.Results)
+	}
+	if got := sess.RewriteVersion(); got != 1 {
+		t.Errorf("no-op pass bumped RewriteVersion to %d", got)
+	}
+}
+
+func TestPruneNoopWithoutWindow(t *testing.T) {
+	sess := pruneFixture(strings.Repeat("x", 5000))
+	a := New(nil, tool.NewRegistry(), sess, Options{RecentKeep: 2}, event.Discard)
+	st, err := a.PruneStaleToolResults()
+	if err != nil || st.Results != 0 {
+		t.Fatalf("st=%+v err=%v, want no-op", st, err)
+	}
+}
+
+func TestPruneSkipsSmallResults(t *testing.T) {
+	sess := pruneFixture(strings.Repeat("x", 200))
+	a := New(nil, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2}, event.Discard)
+	st, err := a.PruneStaleToolResults()
+	if err != nil || st.Results != 0 {
+		t.Fatalf("st=%+v err=%v, want small result kept", st, err)
+	}
+	if got := sess.Snapshot()[3].Content; !strings.HasPrefix(got, "xxx") {
+		t.Errorf("small tool result was rewritten: %.40q", got)
+	}
+}
+
+func TestMaybeCompactPruneAvoidsFold(t *testing.T) {
+	prov := &fakeProvider{reply: "summary"}
+	sess := pruneFixture(strings.Repeat("x", 5000))
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 850})
+
+	if prov.got != nil {
+		t.Fatal("summarizer was called although pruning cleared the trigger")
+	}
+	if got := sess.Snapshot()[3].Content; !strings.HasPrefix(got, prunedMarker) {
+		t.Errorf("tool result not pruned: %.60q", got)
+	}
+}
+
+func TestMaybeCompactForceRatioStillFolds(t *testing.T) {
+	prov := &fakeProvider{reply: "summary"}
+	sess := pruneFixture(strings.Repeat("x", 5000))
+	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 950})
+
+	if prov.got == nil {
+		t.Fatal("force ratio crossed but summarizer never called")
+	}
+	found := false
+	for _, m := range sess.Snapshot() {
+		if strings.Contains(m.Content, summaryTagOpen) {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no compaction summary in session after forced fold")
+	}
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1772,8 +1772,10 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 // cacheColdAfter approximates how long the provider keeps a prompt prefix
 // cached. A session idle longer than this resumes against a cold cache, so a
 // history rewrite at that moment costs no extra cache misses — it only shrinks
-// the full-price first request. Calibrated against benchmarks/cache-ttl-probe.
-var cacheColdAfter = 4 * time.Hour
+// the full-price first request. Deliberately conservative: too small burns a
+// live cache (~4× the miss tokens, measured), too large only forgoes a prune.
+// Tighten from benchmarks/cache-ttl-probe data, never below measured retention.
+var cacheColdAfter = 24 * time.Hour
 
 // maybeColdResumePrune elides stale tool results when a resumed session has
 // been idle past the provider's cache retention, then persists the pruned

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1766,6 +1766,41 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.sessionPath = path
 	c.mu.Unlock()
 	c.rebindCheckpoints(path)
+	c.maybeColdResumePrune(path)
+}
+
+// cacheColdAfter approximates how long the provider keeps a prompt prefix
+// cached. A session idle longer than this resumes against a cold cache, so a
+// history rewrite at that moment costs no extra cache misses — it only shrinks
+// the full-price first request. Calibrated against benchmarks/cache-ttl-probe.
+var cacheColdAfter = 4 * time.Hour
+
+// maybeColdResumePrune elides stale tool results when a resumed session has
+// been idle past the provider's cache retention, then persists the pruned
+// transcript so the saved file and the prompt stay in sync.
+func (c *Controller) maybeColdResumePrune(path string) {
+	if c.executor == nil || path == "" {
+		return
+	}
+	var last time.Time
+	if m, ok, err := agent.LoadBranchMeta(path); err == nil && ok && !m.UpdatedAt.IsZero() {
+		last = m.UpdatedAt
+	} else if info, err := os.Stat(path); err == nil {
+		last = info.ModTime()
+	}
+	if last.IsZero() || time.Since(last) < cacheColdAfter {
+		return
+	}
+	st, err := c.executor.PruneStaleToolResults()
+	if err != nil || st.Results == 0 {
+		return
+	}
+	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(
+		"resumed after %s idle (provider cache expired) — elided %d stale tool results to cheapen the cold restart",
+		time.Since(last).Round(time.Minute), st.Results)})
+	if err := c.Snapshot(); err != nil {
+		slog.Warn("controller: post-prune snapshot", "err", err)
+	}
 }
 
 // Snapshot writes the executor's conversation to the active session file. No-op

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1784,13 +1784,15 @@ func (c *Controller) maybeColdResumePrune(path string) {
 	if c.executor == nil || path == "" {
 		return
 	}
-	var last time.Time
-	if m, ok, err := agent.LoadBranchMeta(path); err == nil && ok && !m.UpdatedAt.IsZero() {
-		last = m.UpdatedAt
-	} else if info, err := os.Stat(path); err == nil {
-		last = info.ModTime()
+	// Idle time comes from branch meta only — every session the controller has
+	// ever snapshotted carries one. A meta-less transcript (e.g. a legacy import
+	// not yet saved) skips the prune until its first snapshot creates the meta.
+	m, ok, err := agent.LoadBranchMeta(path)
+	if err != nil || !ok || m.UpdatedAt.IsZero() {
+		return
 	}
-	if last.IsZero() || time.Since(last) < cacheColdAfter {
+	last := m.UpdatedAt
+	if time.Since(last) < cacheColdAfter {
 		return
 	}
 	st, err := c.executor.PruneStaleToolResults()

--- a/internal/control/resume_prune_test.go
+++ b/internal/control/resume_prune_test.go
@@ -30,6 +30,9 @@ func coldResumeFixture(t *testing.T, threshold time.Duration) (*agent.Session, s
 	if err := loaded.Save(path); err != nil {
 		t.Fatalf("save: %v", err)
 	}
+	if _, err := agent.EnsureBranchMeta(path); err != nil {
+		t.Fatalf("meta: %v", err)
+	}
 
 	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: dir}, event.Discard)
 	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})

--- a/internal/control/resume_prune_test.go
+++ b/internal/control/resume_prune_test.go
@@ -1,0 +1,72 @@
+package control
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+func coldResumeFixture(t *testing.T, threshold time.Duration) (*agent.Session, string) {
+	t.Helper()
+	old := cacheColdAfter
+	cacheColdAfter = threshold
+	t.Cleanup(func() { cacheColdAfter = old })
+
+	dir := t.TempDir()
+	loaded := &agent.Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "grep", Arguments: "{}"}}},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "grep", Content: strings.Repeat("y", 5000)},
+		{Role: provider.RoleAssistant, Content: "step done"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	path := agent.NewSessionPath(dir, "test")
+	if err := loaded.Save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: dir}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.Resume(loaded, path)
+	return loaded, path
+}
+
+func TestColdResumePrunesAndPersists(t *testing.T) {
+	loaded, path := coldResumeFixture(t, 0)
+
+	msgs := loaded.Snapshot()
+	if !strings.HasPrefix(msgs[3].Content, "[elided tool result") {
+		t.Fatalf("stale tool result not pruned on cold resume: %.60q", msgs[3].Content)
+	}
+	re, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !strings.HasPrefix(re.Messages[3].Content, "[elided tool result") {
+		t.Error("pruned transcript was not persisted")
+	}
+	if re.Messages[3].ToolCallID != "1" {
+		t.Error("tool pairing lost in persisted transcript")
+	}
+}
+
+func TestWarmResumeLeavesHistoryAlone(t *testing.T) {
+	loaded, path := coldResumeFixture(t, 24*time.Hour)
+
+	if got := loaded.Snapshot()[3].Content; !strings.HasPrefix(got, "yyy") {
+		t.Fatalf("warm resume rewrote history: %.60q", got)
+	}
+	re, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !strings.HasPrefix(re.Messages[3].Content, "yyy") {
+		t.Error("warm resume rewrote the saved transcript")
+	}
+}


### PR DESCRIPTION
## Why

Multiple users report runaway token consumption on 1.x (#3098 closed: ~$20/hour; one commenter measured 18M input tokens on a single task at 99% cache hit; #3615 / #3007 / #3329 circle the same pain). Root cause analysis:

- With the 1M default `context_window` and the 0.8 trigger, a session effectively never folds — the prompt grows unbounded and every tool round resends all of it.
- Stale tool results dominate that growth, yet they are fully re-derivable (files can be re-read, commands re-run). Today the only reducers are the 32 KB per-result cap and the full LLM-summarizing fold.
- Because cache hits are 50–120× cheaper than misses, carrying dead weight per-turn is nearly free. The real damage concentrates in **cache-miss events** — every fold, and above all every **cold resume**, where a session reopened after the provider cache expired pays full price on the entire prompt.

So this does not fold earlier (compression-eval already showed early folding costs more). It shrinks the prompt deterministically, and schedules rewrites into windows where the cache is already cold so they cost nothing.

## What

**Prune primitive** (`internal/agent/prune.go`): replace the `Content` of tool results older than the protected recent tail with a one-line placeholder. Deterministic, zero LLM calls, originals archived first. No message is ever removed, so `tool_calls`/`tool_call_id` pairing cannot break and assistant messages (including signed reasoning) are never touched.

Two trigger points, both at moments where a cache reset is already being paid:

1. **Before the fold** (`maybeCompact`): prune first; skip the paid summarize call entirely when eliding alone clears the trigger.
2. **Cold resume** (`Controller.Resume`): when idle time (branch-meta `UpdatedAt`) exceeds `cacheColdAfter`, the cache is gone anyway — pruning is free in cache terms and directly shrinks the full-price first request. Pruned transcript is snapshotted atomically; a crash before the snapshot just replays the prune on next resume (idempotent).

Between maintenance points the history stays strictly append-only; warm sessions are never rewritten.

## Real-API validation (deepseek-v4-flash)

- **Placeholder comprehension 5/5**: an agent asked for a constant that only exists behind a pruned placeholder re-read the file via `read_file` and answered with the exact value in every trial — no hallucination (`benchmarks/context-maintenance-e2e comprehension`).
- **Prompt reduction**: an 88.7k-token session pruned 15 stale results down to a 23.6k-token prompt (−73%).
- **Warm-prune penalty (why the TTL gate exists)**: pruning a still-cached session cost 23,598 miss tokens vs 5,900 unpruned — ~4×. The gate keeps this from ever happening: `cacheColdAfter` defaults to a risk-asymmetric 24h (too small burns a live cache; too large only forgoes a free prune).
- **Cache retention probe** (`benchmarks/cache-ttl-probe`): unique ~18k-token prefixes re-probed after idle intervals; full hits through 30 min so far, longer intervals still collecting. Follow-up will tighten `cacheColdAfter` from the measured retention and add the cold-resume A/B numbers (two 88k sessions are already seeded and going cold).

## Tests

- Unit: tail protection, pairing intact, idempotency, no-op without a window, small results kept, prune-skips-fold, force-ratio still folds, cold-resume prunes-and-persists, warm-resume untouched.
- Closed-loop e2e (`compact_loop_e2e_test.go`): a 20-turn tool-heavy session now stays bounded by pruning alone — zero paid folds, stuck-guard never trips; a new assistant-text-heavy variant keeps the fold path under regression.
- `go test ./...` green except `TestModelSwitchRefreshesCustomStatusline`, which fails identically on a pristine `origin/main-v2` checkout in this environment (upstream, unrelated).
