### PR TITLE
fix(chat): repaint late-collapsed tool slots immediately

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1777,7 +1777,6 @@ func (m *chatTUI) collapseToolOutput(id string) {
 		return
 	}
 	m.collapseShellSlot(id, m.toolStreamIdx)
-	m.transcriptDirty = true
 	m.toolStreamIdx = -1
 	m.toolStreamID = ""
 	m.toolTail = m.toolTail[:0]
@@ -1794,6 +1793,7 @@ func (m *chatTUI) collapseToolOutput(id string) {
 // for "shell-" prefixed ids), since toolTail/toolLineCount are reset
 // whenever a new tool takes over via beginToolRunning.
 func (m *chatTUI) collapseShellSlot(id string, idx int) {
+	m.transcriptDirty = true
 	n := -1
 	if id == m.toolStreamID {
 		n = m.toolLineCount


### PR DESCRIPTION
Follow-up to #3951 (cross-posted there): the late-result branch of `collapseToolOutput` mutates the transcript and returns without setting `transcriptDirty`, so a late-collapsed slot doesn't repaint until the next unrelated event arrives. Moved the flag into `collapseShellSlot` so both callers are covered, and dropped the now-redundant set in the active path.