### PR TITLE
Prompt only for active model keys / 仅提示活跃模型密钥

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
@@ -1385,12 +1386,12 @@ func withBuiltinFamilies(providers []config.ProviderEntry) []config.ProviderEntr
 	return providers
 }
 
-// promptMissingKeys re-runs the wizard's key-entry step for any enabled
-// provider whose api_key_env is unset. Newly entered values are appended to the
-// reasonix-owned global .env so the chat session that follows picks them up via
-// config.Load. The user can hit Enter to skip — the chat banner falls back to a
-// one-line warning so they still see what's missing. Returns a non-zero exit
-// code only when writing the env file fails.
+// promptMissingKeys re-runs the wizard's key-entry step for model refs that are
+// actually active and whose api_key_env is unset. Newly entered values are
+// appended to the reasonix-owned global .env so the chat session that follows
+// picks them up via config.Load. The user can hit Enter to skip — the chat
+// banner falls back to a one-line warning so they still see what's missing.
+// Returns a non-zero exit code only when writing the env file fails.
 func promptMissingKeys(cfg *config.Config) int {
 	missing := providersWithMissingKeys(cfg)
 	if len(missing) == 0 {
@@ -1418,19 +1419,39 @@ func promptMissingKeys(cfg *config.Config) int {
 // warns if they later switch to a model whose key is missing. configureKeys
 // dedupes shared envs, so duplicates are fine to leave in.
 func providersWithMissingKeys(cfg *config.Config) []config.ProviderEntry {
-	referenced := map[string]bool{
-		cfg.DefaultModel:        true,
-		cfg.Agent.PlannerModel:  true,
-		cfg.Agent.SubagentModel: true,
+	if cfg == nil {
+		return nil
 	}
-	for _, m := range cfg.Agent.SubagentModels {
-		referenced[m] = true
+	refs := []string{
+		cfg.DefaultModel,
+		cfg.Agent.PlannerModel,
+		cfg.Agent.SubagentModel,
+		cfg.Agent.AutoPlanClassifier,
 	}
-	var out []config.ProviderEntry
-	for _, p := range cfg.Providers {
-		if referenced[p.Name] && p.APIKeyEnv != "" && os.Getenv(p.APIKeyEnv) == "" {
-			out = append(out, p)
+	if len(cfg.Agent.SubagentModels) > 0 {
+		keys := make([]string, 0, len(cfg.Agent.SubagentModels))
+		for key := range cfg.Agent.SubagentModels {
+			keys = append(keys, key)
 		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			refs = append(refs, cfg.Agent.SubagentModels[key])
+		}
+	}
+
+	var out []config.ProviderEntry
+	seen := map[string]bool{}
+	for _, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			continue
+		}
+		p, ok := cfg.ResolveModel(ref)
+		if !ok || p.APIKeyEnv == "" || os.Getenv(p.APIKeyEnv) != "" || seen[p.APIKeyEnv] {
+			continue
+		}
+		seen[p.APIKeyEnv] = true
+		out = append(out, *p)
 	}
 	return out
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1426,7 +1426,9 @@ func providersWithMissingKeys(cfg *config.Config) []config.ProviderEntry {
 		cfg.DefaultModel,
 		cfg.Agent.PlannerModel,
 		cfg.Agent.SubagentModel,
-		cfg.Agent.AutoPlanClassifier,
+	}
+	if !strings.EqualFold(strings.TrimSpace(cfg.Agent.AutoPlan), "off") {
+		refs = append(refs, cfg.Agent.AutoPlanClassifier)
 	}
 	if len(cfg.Agent.SubagentModels) > 0 {
 		keys := make([]string, 0, len(cfg.Agent.SubagentModels))

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -260,6 +260,50 @@ func TestWelcomePromptMissingKeysRequiresConfigSource(t *testing.T) {
 	}
 }
 
+func TestProvidersWithMissingKeysOnlyChecksActiveDefaultModel(t *testing.T) {
+	cfg := config.Default()
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	t.Setenv("MIMO_API_KEY", "")
+
+	missing := providersWithMissingKeys(cfg)
+	if len(missing) != 1 {
+		t.Fatalf("missing providers = %+v, want only active default model provider", missing)
+	}
+	if missing[0].APIKeyEnv != "DEEPSEEK_API_KEY" {
+		t.Fatalf("missing key env = %q, want DEEPSEEK_API_KEY", missing[0].APIKeyEnv)
+	}
+}
+
+func TestProvidersWithMissingKeysIgnoresUnusedBuiltInPresets(t *testing.T) {
+	cfg := config.Default()
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("MIMO_API_KEY", "")
+
+	if missing := providersWithMissingKeys(cfg); len(missing) != 0 {
+		t.Fatalf("missing providers = %+v, want none when only unused MiMo presets are keyless", missing)
+	}
+}
+
+func TestProvidersWithMissingKeysIncludesReferencedSecondaryModels(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.PlannerModel = "mimo-pro"
+	cfg.Agent.SubagentModel = "mimo-flash"
+	cfg.Agent.SubagentModels = map[string]string{
+		"review": "mimo-pro/mimo-v2.5-pro",
+	}
+	cfg.Agent.AutoPlanClassifier = "mimo-flash/mimo-v2.5"
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("MIMO_API_KEY", "")
+
+	missing := providersWithMissingKeys(cfg)
+	if len(missing) != 1 {
+		t.Fatalf("missing providers = %+v, want MiMo once", missing)
+	}
+	if missing[0].APIKeyEnv != "MIMO_API_KEY" {
+		t.Fatalf("missing key env = %q, want MIMO_API_KEY", missing[0].APIKeyEnv)
+	}
+}
+
 type cliRecordSink struct {
 	events []event.Kind
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -304,6 +304,27 @@ func TestProvidersWithMissingKeysIncludesReferencedSecondaryModels(t *testing.T)
 	}
 }
 
+func TestProvidersWithMissingKeysSkipsDisabledAutoPlanClassifier(t *testing.T) {
+	cfg := config.Default()
+	cfg.Agent.AutoPlan = "off"
+	cfg.Agent.AutoPlanClassifier = "mimo-flash/mimo-v2.5"
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	t.Setenv("MIMO_API_KEY", "")
+
+	if missing := providersWithMissingKeys(cfg); len(missing) != 0 {
+		t.Fatalf("missing providers = %+v, want none when auto-plan classifier is disabled", missing)
+	}
+
+	cfg.Agent.AutoPlan = "on"
+	missing := providersWithMissingKeys(cfg)
+	if len(missing) != 1 {
+		t.Fatalf("missing providers = %+v, want enabled auto-plan classifier provider", missing)
+	}
+	if missing[0].APIKeyEnv != "MIMO_API_KEY" {
+		t.Fatalf("missing key env = %q, want MIMO_API_KEY", missing[0].APIKeyEnv)
+	}
+}
+
 type cliRecordSink struct {
 	events []event.Kind
 }

--- a/internal/cli/rewind_test.go
+++ b/internal/cli/rewind_test.go
@@ -5,9 +5,13 @@ import (
 	"testing"
 
 	"reasonix/internal/checkpoint"
+	"reasonix/internal/i18n"
 )
 
 func TestOneLine(t *testing.T) {
+	i18n.DetectLanguage("en")
+	t.Cleanup(func() { i18n.DetectLanguage("en") })
+
 	if got := oneLine("", 10); got != "(empty)" {
 		t.Fatalf("empty -> %q", got)
 	}
@@ -20,6 +24,9 @@ func TestOneLine(t *testing.T) {
 }
 
 func TestRenderRewindSmoke(t *testing.T) {
+	i18n.DetectLanguage("en")
+	t.Cleanup(func() { i18n.DetectLanguage("en") })
+
 	metas := []checkpoint.Meta{
 		{Turn: 0, Prompt: "add the parser", Paths: []string{"a.go"}},
 		{Turn: 1, Prompt: "fix the bug", Paths: []string{"b.go", "c.go"}},


### PR DESCRIPTION
## Summary
- resolve active missing-key prompts through the normal model resolver instead of matching provider names directly
- include `auto_plan_classifier` and deterministic subagent model ordering in the active key scan
- add regression coverage for DeepSeek-only startup, unused MiMo presets, and explicitly referenced MiMo secondary models
- isolate rewind tests from global CLI language state

## Testing
- `go test ./internal/cli -count=1`

Refs #3939