### PR TITLE
fix(evidence): stop rejecting real complete_step verifications over command-string drift

### DIFF
--- a/internal/evidence/commandmatch.go
+++ b/internal/evidence/commandmatch.go
@@ -1,0 +1,92 @@
+package evidence
+
+import "strings"
+
+// CommandMatches reports whether a cited verification command is proven by a
+// command that actually ran. Models paraphrase commands when citing them
+// (dropping a `cd` prefix, changing quote style, omitting flags), so byte
+// equality rejects real verifications; instead both sides are split into
+// shell segments and each cited segment must be covered by some ran segment.
+func CommandMatches(cited, ran string) bool {
+	citedSegs := commandSegments(cited)
+	if len(citedSegs) == 0 {
+		return false
+	}
+	ranSegs := commandSegments(ran)
+	for _, c := range citedSegs {
+		if !segmentCovered(c, ranSegs) {
+			return false
+		}
+	}
+	return true
+}
+
+func segmentCovered(cited string, ranSegs []string) bool {
+	for _, r := range ranSegs {
+		if segmentMatches(cited, r) {
+			return true
+		}
+	}
+	return false
+}
+
+// segmentMatches accepts normalized equality, or a token subset with the same
+// head token (e.g. cited "ls x 2>&1" against ran "ls -la x 2>&1"). One-token
+// citations only match exactly, so a bare "ls" can't claim an unrelated run.
+func segmentMatches(cited, ran string) bool {
+	ct, rt := segmentTokens(cited), segmentTokens(ran)
+	if len(ct) == 0 || len(rt) == 0 {
+		return false
+	}
+	if strings.Join(ct, " ") == strings.Join(rt, " ") {
+		return true
+	}
+	if len(ct) < 2 || ct[0] != rt[0] {
+		return false
+	}
+	have := make(map[string]bool, len(rt))
+	for _, t := range rt {
+		have[t] = true
+	}
+	for _, t := range ct {
+		if !have[t] {
+			return false
+		}
+	}
+	return true
+}
+
+var segmentSeparators = []string{"&&", "||", ";", "|", "\n"}
+
+func commandSegments(s string) []string {
+	parts := []string{s}
+	for _, sep := range segmentSeparators {
+		var next []string
+		for _, p := range parts {
+			next = append(next, strings.Split(p, sep)...)
+		}
+		parts = next
+	}
+	var segs []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" || strings.HasPrefix(p, "#") {
+			continue
+		}
+		segs = append(segs, p)
+	}
+	return segs
+}
+
+func segmentTokens(s string) []string {
+	fields := strings.Fields(s)
+	tokens := make([]string, 0, len(fields))
+	for _, f := range fields {
+		f = strings.ReplaceAll(f, `"`, "")
+		f = strings.ReplaceAll(f, "'", "")
+		if f != "" {
+			tokens = append(tokens, f)
+		}
+	}
+	return tokens
+}

--- a/internal/evidence/commandmatch_test.go
+++ b/internal/evidence/commandmatch_test.go
@@ -1,0 +1,37 @@
+package evidence
+
+import "testing"
+
+func TestCommandMatches(t *testing.T) {
+	cases := []struct {
+		name  string
+		cited string
+		ran   string
+		want  bool
+	}{
+		{"exact", "go test ./...", "go test ./...", true},
+		{"cd prefix dropped", "git merge upstream/main-v2 --ff-only",
+			"cd /repo && git merge upstream/main-v2 --ff-only", true},
+		{"flag drift inside compound", "rm -v scripts/test_lines.txt && ls scripts/test_lines.txt 2>&1",
+			"rm -v scripts/test_lines.txt && ls -la scripts/test_lines.txt 2>&1 || true", true},
+		{"quote style drift", `test -f test-tools.md && echo 'still exists' || echo 'deleted'`,
+			`test -f test-tools.md && echo "still exists" || echo "deleted"`, true},
+		{"pipe tail dropped", "go test ./internal/tool/... -count=1 -timeout 60s",
+			"cd /f/Reasonix && go test ./internal/tool/... -count=1 -timeout 60s 2>&1 | tail -10", true},
+		{"whitespace collapse", "go  test   ./...", "go test ./...", true},
+		{"different command rejected", "go test ./...", "go vet ./...", false},
+		{"extra cited token rejected", "go test ./a/... ./b/...", "go test ./a/...", false},
+		{"bare token needs exact", "ls", "ls -la scripts", false},
+		{"bare token exact ok", "ls", "ls", true},
+		{"empty cited", "", "go test ./...", false},
+		{"comment lines ignored", "shuf -i 1-30 -n 10",
+			"# pick lines to delete\nshuf -i 1-30 -n 10 | sort -rn", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CommandMatches(tc.cited, tc.ran); got != tc.want {
+				t.Fatalf("CommandMatches(%q, %q) = %v, want %v", tc.cited, tc.ran, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -97,11 +97,71 @@ func (l *Ledger) HasSuccessfulCommand(command string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for _, r := range l.receipts {
-		if r.Success && r.ToolName == "bash" && r.Command == command {
+		if r.Success && r.ToolName == "bash" && CommandMatches(command, r.Command) {
 			return true
 		}
 	}
 	return false
+}
+
+// HasFailedCommand reports whether the cited command ran this turn but exited
+// non-zero — so callers can distinguish "ran and failed" from "never ran".
+func (l *Ledger) HasFailedCommand(command string) bool {
+	command = strings.TrimSpace(command)
+	if l == nil || command == "" {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.receipts {
+		if !r.Success && r.ToolName == "bash" && CommandMatches(command, r.Command) {
+			return true
+		}
+	}
+	return false
+}
+
+// SuccessfulCommands returns up to limit successful bash commands from this
+// turn, most recent first, for self-correction hints in rejection errors.
+func (l *Ledger) SuccessfulCommands(limit int) []string {
+	if l == nil || limit <= 0 {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	var out []string
+	for i := len(l.receipts) - 1; i >= 0 && len(out) < limit; i-- {
+		r := l.receipts[i]
+		if r.Success && r.ToolName == "bash" && r.Command != "" {
+			out = append(out, r.Command)
+		}
+	}
+	return out
+}
+
+// TouchedPaths returns up to limit distinct paths from this turn's successful
+// receipts, most recent first; writtenOnly restricts it to writer receipts.
+func (l *Ledger) TouchedPaths(limit int, writtenOnly bool) []string {
+	if l == nil || limit <= 0 {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	seen := map[string]bool{}
+	var out []string
+	for i := len(l.receipts) - 1; i >= 0 && len(out) < limit; i-- {
+		r := l.receipts[i]
+		if !r.Success || (writtenOnly && !r.Write) || (!writtenOnly && !r.Read && !r.Write) {
+			continue
+		}
+		for _, p := range r.Paths {
+			if !seen[p] && len(out) < limit {
+				seen[p] = true
+				out = append(out, p)
+			}
+		}
+	}
+	return out
 }
 
 func (l *Ledger) HasSuccessfulCommandAfter(command string, after int) bool {
@@ -118,7 +178,7 @@ func (l *Ledger) HasSuccessfulCommandAfter(command string, after int) bool {
 	defer l.mu.Unlock()
 	for i := start; i < len(l.receipts); i++ {
 		r := l.receipts[i]
-		if r.Success && r.ToolName == "bash" && r.Command == command {
+		if r.Success && r.ToolName == "bash" && CommandMatches(command, r.Command) {
 			return true
 		}
 	}

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -164,6 +164,37 @@ func (l *Ledger) TouchedPaths(limit int, writtenOnly bool) []string {
 	return out
 }
 
+// HasSuccessfulBashMentioningPaths reports whether every path appears in some
+// successful bash command this turn — files created or edited through shell
+// redirection (`seq … > file`) leave no reader/writer receipt, so the command
+// text naming the path is the receipt.
+func (l *Ledger) HasSuccessfulBashMentioningPaths(paths []string) bool {
+	wanted := normalizePaths(paths)
+	if l == nil || len(wanted) == 0 {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, p := range wanted {
+		needle := strings.ToLower(filepath.ToSlash(p))
+		found := false
+		for _, r := range l.receipts {
+			if !r.Success || r.ToolName != "bash" {
+				continue
+			}
+			command := strings.ToLower(strings.ReplaceAll(r.Command, `\`, `/`))
+			if strings.Contains(command, needle) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
 func (l *Ledger) HasSuccessfulCommandAfter(command string, after int) bool {
 	command = strings.TrimSpace(command)
 	if l == nil || command == "" {

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -8,6 +8,7 @@ import (
 
 	"reasonix/internal/evidence"
 	"reasonix/internal/instruction"
+	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
@@ -58,10 +59,10 @@ func (completeStep) Schema() json.RawMessage {
     "items":{
       "type":"object",
       "properties":{
-        "kind":{"type":"string","enum":["verification","diff","files","manual"],"description":"verification = a command/test was run; diff = a concrete code change; files = files created/edited/inspected; manual = a manual check."},
+        "kind":{"type":"string","enum":["verification","diff","files","manual"],"description":"verification = a command/test was run (command REQUIRED); diff = a concrete code change (paths REQUIRED); files = files created/edited/inspected (paths REQUIRED); manual = a manual check."},
         "summary":{"type":"string","description":"The evidence itself: the test result, what the diff does, or what was confirmed."},
-        "command":{"type":"string","description":"The command run, for verification evidence (e.g. \"go test ./...\")."},
-        "paths":{"type":"array","items":{"type":"string"},"description":"Files this evidence refers to."}
+        "command":{"type":"string","description":"REQUIRED for verification evidence: the command as it actually ran (e.g. \"go test ./...\") — it is checked against this session's real command history."},
+        "paths":{"type":"array","items":{"type":"string"},"description":"REQUIRED for diff/files evidence: the files this evidence refers to, as the paths were passed to the tools that touched them."}
       },
       "required":["kind","summary"]
     }
@@ -144,26 +145,29 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 		case "verification":
 			command := strings.TrimSpace(e.Command)
 			if command == "" {
-				return 0, 0, fmt.Errorf("evidence %d: verification command is required for host verification", i+1)
+				return 0, 0, fmt.Errorf("evidence %d: verification command is required for host verification — cite the command you ran, or use kind \"manual\"", i+1)
 			}
 			if !ledger.HasSuccessfulCommand(command) && !verifyCommandFromSession(ctx, command) {
-				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful bash receipt in this turn", i+1, command)
+				if ledger.HasFailedCommand(command) {
+					return 0, 0, fmt.Errorf("evidence %d: verification command %q ran but exited non-zero, so it can't prove the step; if the non-zero exit is itself the expected proof (e.g. a file is gone), re-run it so it succeeds (append \"|| true\") and sign off again", i+1, command)
+				}
+				return 0, 0, fmt.Errorf("evidence %d: verification command %q has no matching successful bash receipt in this turn%s", i+1, command, receiptHint("commands run this turn", ledger.SuccessfulCommands(5)))
 			}
 			hostVerified++
 		case "diff":
 			if len(e.Paths) == 0 {
-				return 0, 0, fmt.Errorf("evidence %d: diff evidence requires paths for host verification", i+1)
+				return 0, 0, fmt.Errorf("evidence %d: diff evidence requires paths for host verification — cite the files you changed", i+1)
 			}
 			if !ledger.HasSuccessfulWrite(e.Paths) {
-				return 0, 0, fmt.Errorf("evidence %d: diff paths have no matching successful writer receipt in this turn", i+1)
+				return 0, 0, fmt.Errorf("evidence %d: diff paths have no matching successful writer receipt in this turn%s", i+1, receiptHint("files written this turn", ledger.TouchedPaths(8, true)))
 			}
 			hostVerified++
 		case "files":
 			if len(e.Paths) == 0 {
-				return 0, 0, fmt.Errorf("evidence %d: files evidence requires paths for host verification", i+1)
+				return 0, 0, fmt.Errorf("evidence %d: files evidence requires paths for host verification — cite the files you touched", i+1)
 			}
 			if !ledger.HasSuccessfulReadOrWrite(e.Paths) {
-				return 0, 0, fmt.Errorf("evidence %d: file paths have no matching successful read/write receipt in this turn", i+1)
+				return 0, 0, fmt.Errorf("evidence %d: file paths have no matching successful read/write receipt in this turn%s", i+1, receiptHint("files touched this turn", ledger.TouchedPaths(8, false)))
 			}
 			hostVerified++
 		case "manual":
@@ -243,52 +247,34 @@ func verifyTodoStep(ctx context.Context, step string) (evidence.TodoStepMatch, b
 }
 
 // verifyCommandFromSession scans the full conversation history (not just the
-// per-turn ledger) so that a complete_step can cite commands that ran in an
-// earlier turn, that used a named tool instead of bash, or that were cited
-// with a slightly different string (trailing …,
-// truncation).
-//
-// Three scenarios this covers:
-//  1. Cross-turn: command ran in a prior turn, ledger was reset — scan the
-//     session transcript for the exact bash command.
-//  2. Non-bash tool: the model used the `ls` reader tool rather than
-//     bash "ls .", but complete_step cites command="ls ." — match by tool
-//     name (the first word of the command).
-//  3. Truncated string: the actual command was
-//     `find . -type f -not -path '*/node_modules/*'` but the model wrote
-//     command="find . -type f ..." — normalize both sides (strip …,
-//     trim, collapse whitespace) and fall back to prefix matching.
+// per-turn ledger) so a complete_step can cite a command that ran in an
+// earlier turn (the ledger resets per turn) or via a named tool instead of
+// bash. Calls whose recorded result is an error or a block are skipped — they
+// prove the command was attempted, not that it succeeded.
 func verifyCommandFromSession(ctx context.Context, command string) bool {
 	msgs, ok := evidence.SessionMessagesFromContext(ctx)
 	if !ok {
 		return false
 	}
-	lookup := normalizeVerifyCommand(command)
+	lookup := strings.TrimSuffix(strings.TrimSuffix(strings.TrimSpace(command), "..."), "…")
 	if lookup == "" {
 		return false
 	}
 	toolName := firstWord(lookup)
+	failed := failedCallIDs(msgs)
 
 	for _, msg := range msgs {
 		for _, tc := range msg.ToolCalls {
+			if failed[tc.ID] {
+				continue
+			}
 			cmd := extractCommandFromCall(tc.Name, tc.Arguments)
 			if cmd == "" {
 				continue
 			}
-			norm := normalizeVerifyCommand(cmd)
-			if norm == lookup {
+			if evidence.CommandMatches(lookup, cmd) {
 				return true
 			}
-			// Prefix match for truncated commands (scenario 3). Require the
-			// shorter side to be at least 8 chars to prevent false positives
-			// on very short fragments like "find" or "ls".
-			if len(norm) >= 8 && len(lookup) >= 8 {
-				if strings.HasPrefix(norm, lookup) || strings.HasPrefix(lookup, norm) {
-					return true
-				}
-			}
-			// Non-bash tool name match (scenario 2): the first word of the
-			// command matches a tool call name that isn't bash.
 			if toolName != "" && toolName != "bash" && tc.Name == toolName {
 				return true
 			}
@@ -297,14 +283,29 @@ func verifyCommandFromSession(ctx context.Context, command string) bool {
 	return false
 }
 
-// normalizeVerifyCommand strips trailing ellipsis,
-// trims whitespace, and collapses internal whitespace into single spaces.
-func normalizeVerifyCommand(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.TrimSuffix(s, "...")
-	s = strings.TrimSuffix(s, "…")
-	s = strings.TrimSpace(s)
-	return strings.Join(strings.Fields(s), " ")
+func failedCallIDs(msgs []provider.Message) map[string]bool {
+	failed := map[string]bool{}
+	for _, msg := range msgs {
+		if msg.Role != provider.RoleTool || msg.ToolCallID == "" {
+			continue
+		}
+		if strings.HasPrefix(msg.Content, "error:") || strings.HasPrefix(msg.Content, "blocked:") {
+			failed[msg.ToolCallID] = true
+		}
+	}
+	return failed
+}
+
+func receiptHint(label string, items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	for i, item := range items {
+		if len(item) > 80 {
+			items[i] = item[:80] + "…"
+		}
+	}
+	return fmt.Sprintf("; %s: %q — cite one as it actually ran, or run the check now", label, items)
 }
 
 func firstWord(s string) string {

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -166,7 +166,7 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 			if len(e.Paths) == 0 {
 				return 0, 0, fmt.Errorf("evidence %d: files evidence requires paths for host verification — cite the files you touched", i+1)
 			}
-			if !ledger.HasSuccessfulReadOrWrite(e.Paths) {
+			if !ledger.HasSuccessfulReadOrWrite(e.Paths) && !ledger.HasSuccessfulBashMentioningPaths(e.Paths) {
 				return 0, 0, fmt.Errorf("evidence %d: file paths have no matching successful read/write receipt in this turn%s", i+1, receiptHint("files touched this turn", ledger.TouchedPaths(8, false)))
 			}
 			hostVerified++

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -473,3 +473,27 @@ func TestCompleteStepSessionFallbackSkipsFailedCalls(t *testing.T) {
 		t.Fatal("a call whose recorded result is an error must not count as verification")
 	}
 }
+
+// Replay from the 2026-06-11 e2e run: a file created via bash redirection has
+// no reader/writer receipt, but the command text names the path.
+func TestCompleteStepFilesEvidenceAcceptsBashCreatedFile(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "bash",
+		Success:  true,
+		Command:  `mkdir -p scripts && seq -w 1 20 | while read i; do echo "line $i"; done > scripts/test_lines.txt && cat scripts/test_lines.txt`,
+	})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"files","paths":["scripts/test_lines.txt"],"summary":"file created with 20 lines"}]}`)); err != nil {
+		t.Fatalf("bash-created file should count as a files receipt: %v", err)
+	}
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"files","paths":["scripts/never_touched.txt"],"summary":"claimed"}]}`)); err == nil {
+		t.Fatal("a path no command mentions must still be rejected")
+	}
+}

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -8,6 +8,7 @@ import (
 
 	"reasonix/internal/evidence"
 	"reasonix/internal/instruction"
+	"reasonix/internal/provider"
 )
 
 func TestCompleteStepRejectsMissingEvidence(t *testing.T) {
@@ -118,7 +119,7 @@ func TestCompleteStepRejectsUnverifiedHostEvidence(t *testing.T) {
 		{
 			name: "failed verification command",
 			body: `{"step":"x","result":"y","evidence":[{"kind":"verification","summary":"claimed tests","command":"go test ./..."}]}`,
-			want: "successful bash receipt",
+			want: "exited non-zero",
 		},
 		{
 			name: "missing diff writer",
@@ -351,5 +352,124 @@ func TestCompleteStepIgnoresFailedTodoReceipt(t *testing.T) {
 func TestCompleteStepReadOnly(t *testing.T) {
 	if !(completeStep{}).ReadOnly() {
 		t.Fatal("complete_step must be ReadOnly so it stays available and needs no approval")
+	}
+}
+
+// Replays of real complete_step rejections captured from local sessions (2026-06-02) and issue #2917.
+func TestCompleteStepMatchesParaphrasedCommands(t *testing.T) {
+	cases := []struct {
+		name  string
+		ran   string
+		cited string
+	}{
+		{
+			name:  "cd prefix dropped",
+			ran:   "cd /repo && git merge upstream/main-v2 --ff-only",
+			cited: "git merge upstream/main-v2 --ff-only",
+		},
+		{
+			name:  "flag drift inside compound",
+			ran:   "rm -v scripts/test_lines.txt && ls -la scripts/test_lines.txt 2>&1 || true",
+			cited: "rm -v scripts/test_lines.txt && ls scripts/test_lines.txt 2>&1",
+		},
+		{
+			name:  "quote style drift",
+			ran:   `test -f test-tools.md && echo "still exists" || echo "deleted"`,
+			cited: `test -f test-tools.md && echo 'still exists' || echo 'deleted'`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ledger := evidence.NewLedger()
+			ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: tc.ran})
+			ctx := evidence.WithLedger(context.Background(), ledger)
+
+			body, _ := json.Marshal(map[string]any{
+				"step": "x", "result": "y",
+				"evidence": []map[string]any{{"kind": "verification", "summary": "verified", "command": tc.cited}},
+			})
+			if _, err := (completeStep{}).Execute(ctx, body); err != nil {
+				t.Fatalf("paraphrased citation of a ran command rejected: %v", err)
+			}
+		})
+	}
+}
+
+func TestCompleteStepExplainsFailedCommandReceipt(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "bash", Success: false, Command: "ls scripts/test_lines.txt 2>&1"})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"verification","summary":"ls confirms the file is gone","command":"ls scripts/test_lines.txt 2>&1"}]}`))
+	if err == nil {
+		t.Fatal("failed command citation should be rejected")
+	}
+	for _, want := range []string{"exited non-zero", "|| true"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should carry the recovery hint %q, got %v", want, err)
+		}
+	}
+}
+
+func TestCompleteStepRejectionListsRanCommands(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "bash", Success: true, Command: "wc -l scripts/test_lines.txt"})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"verification","summary":"claimed","command":"go test ./internal/nilutil/... ./internal/fileutil/..."}]}`))
+	if err == nil || !strings.Contains(err.Error(), "wc -l scripts/test_lines.txt") {
+		t.Fatalf("rejection should list the commands that actually ran, got %v", err)
+	}
+}
+
+func TestCompleteStepRejectionListsTouchedPaths(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{ToolName: "write_file", Success: true, Paths: []string{"changed.go"}, Write: true})
+	ctx := evidence.WithLedger(context.Background(), ledger)
+
+	_, err := completeStep{}.Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"diff","summary":"claimed","paths":["other.go"]}]}`))
+	if err == nil || !strings.Contains(err.Error(), "changed.go") {
+		t.Fatalf("rejection should list the files actually written, got %v", err)
+	}
+}
+
+func TestCompleteStepSessionFallbackUsesNormalizedMatching(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "c1", Name: "bash",
+			Arguments: `{"command":"go test ./internal/tool/... -count=1 -timeout 60s 2>&1 | tail -10"}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "c1", Name: "bash", Content: "ok\nPASS"},
+	}
+	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
+	ctx = evidence.WithSessionMessages(ctx, msgs)
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"verification","summary":"tool tests pass","command":"go test ./internal/tool/... -count=1 -timeout 60s"}]}`)); err != nil {
+		t.Fatalf("cross-turn citation of a ran command rejected: %v", err)
+	}
+}
+
+func TestCompleteStepSessionFallbackSkipsFailedCalls(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "c1", Name: "bash", Arguments: `{"command":"go test ./broken/..."}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "c1", Name: "bash", Content: "error: command exited: exit status 1\nFAIL"},
+	}
+	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
+	ctx = evidence.WithSessionMessages(ctx, msgs)
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"verification","summary":"tests pass","command":"go test ./broken/..."}]}`)); err == nil {
+		t.Fatal("a call whose recorded result is an error must not count as verification")
 	}
 }

--- a/internal/tool/builtin/todo.go
+++ b/internal/tool/builtin/todo.go
@@ -101,11 +101,12 @@ func verifyTodoCompletionTransitions(ctx context.Context, todos []todoItem) erro
 	if !hasBaseline || len(missing) == 0 {
 		return nil
 	}
+	const hint = "; sign each finished item off with complete_step first, then re-send this todo_write"
 	if len(missing) == 1 {
 		m := missing[0]
-		return fmt.Errorf("todo %d %q is newly completed but has no matching successful complete_step receipt in this turn", m.Index, m.Content)
+		return fmt.Errorf("todo %d %q is newly completed but has no matching successful complete_step receipt in this turn%s", m.Index, m.Content, hint)
 	}
-	return fmt.Errorf("%d todos are newly completed but have no matching successful complete_step receipts in this turn", len(missing))
+	return fmt.Errorf("%d todos are newly completed but have no matching successful complete_step receipts in this turn%s", len(missing), hint)
 }
 
 func toEvidenceTodos(todos []todoItem) []evidence.TodoItem {


### PR DESCRIPTION
## Problem

Users keep reporting that `complete_step` "fails all the time". Session forensics (local logs + #2917's attached transcript) show 5 of 18 real `complete_step` calls rejected, every one a **false negative**: the step was genuinely done and verified, but the citation didn't byte-match the receipt. Each rejection then cascades into a `todo_write` failure (its guard wants a prior `complete_step`), and in the worst case the model gives up and overclaims in the final answer (#2917).

The observed failure shapes, all from real transcripts:

1. **Dropped `cd` prefix** — ran `cd /repo && git merge upstream/main-v2 --ff-only`, cited `git merge upstream/main-v2 --ff-only` (#2917). Not a prefix relation, so the #3587 session fallback missed it too.
2. **Flag/quote drift** — ran `rm -v x && ls -la x 2>&1 || true`, cited `rm -v x && ls x 2>&1`; ran `echo "deleted"`, cited `echo 'deleted'`.
3. **Compound-segment citation** — ran `seq …; cat x; wc -l x`, cited just `wc -l x`.
4. **Negative verification dead end** — ran `ls deleted-file` to prove a deletion; it exits 2, so no successful receipt can ever exist. The old error was indistinguishable from "never ran".
5. **Schema said `command`/`paths` were optional** while the host requires them — models follow the schema and get rejected.
6. **Shell-redirect files** — `seq … > file` leaves no reader/writer receipt, so `files` evidence for the file always failed; models recovered by re-writing the whole file with `write_file` just to mint a receipt.

## Fix

- **Segment matching** (`evidence.CommandMatches`): split cited and ran commands on `&&`/`||`/`;`/`|`/newlines, quote-strip and whitespace-normalize tokens; a cited segment is covered by a ran segment that equals it or token-supersets it under the same head token. One-token citations still require exact equality; an aggregated citation that no single command covers is still rejected (anti-fabrication holds — a condensed made-up command in the e2e run was still refused).
- **Session fallback hardened**: uses the same matcher and now skips calls whose recorded result is an error or block, closing the false positive where any *attempted* command counted as proof.
- **Actionable rejections**: ran-but-nonzero is now distinguished from never-ran (with a `|| true` hint for negative verification); never-ran rejections list the turn's actual receipts; `todo_write`'s cascade error explains the `complete_step`-first order. In e2e, every remaining legitimate rejection self-corrected in 1–2 rounds instead of looping blind.
- **Schema truthful**: `command` is marked REQUIRED for `verification`, `paths` for `diff`/`files`.
- **Redirect-created files**: a successful bash command whose text names the path now counts as a `files` receipt.

## Verification

- Unit replays of all observed failures, verbatim from the transcripts (`completestep_test.go`, `commandmatch_test.go`).
- End-to-end A/B against the real DeepSeek API (`deepseek-v4-flash`, the same scenario the June 2 sessions failed on — create 20-line file → append → delete lines → delete file → negative-verify):
  - **base (origin/main-v2)**: 4/8 `complete_step` calls rejected, 21 rounds.
  - **fixed**: 4/4 `complete_step` first-try, 0 `todo_write` failures, 16 rounds, all sign-offs `host-verified 1, manual/unverified 0`.
- `go test ./internal/evidence/... ./internal/tool/builtin/... ./internal/agent/... ./internal/cli/... ./internal/control/...` green; `go vet` clean.

Related: #2917, #3469, #3911, #3587.
