### PR TITLE
fix(desktop): 优化命令面板样式与信息展示

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1641,7 +1641,7 @@ export default function App() {
       title: s.title?.trim() || s.preview || t("history.emptySession"),
       hint: s.workspaceRoot || undefined,
       meta: dayLabel(sessionActivityTime(s)),
-      badge: `${s.turns}轮`,
+      badge: t(s.turns === 1 ? "history.turnOne" : "history.turnOther", { n: s.turns }),
       run: () => void onResumeSession(s),
     }));
     return [...cmds, ...sessionItems];

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1620,13 +1620,13 @@ export default function App() {
   }, [openPalette]);
   const paletteItems = useMemo<PaletteItem[]>(() => {
     const cmds: PaletteItem[] = [
-      { id: "cmd-new", group: t("palette.group.commands"), title: t("palette.cmd.newSession"), icon: <SquarePen size={15} />, keywords: ["new", "新建"], run: () => void handleNewTab() },
-      { id: "cmd-history", group: t("palette.group.commands"), title: t("palette.cmd.history"), icon: <History size={15} />, keywords: ["history", "历史"], run: () => void openAllHistory() },
-      { id: "cmd-trash", group: t("palette.group.commands"), title: t("palette.cmd.trash"), icon: <Trash2 size={15} />, keywords: ["trash", "回收站"], run: () => void openTrash() },
-      { id: "cmd-settings", group: t("palette.group.commands"), title: t("palette.cmd.settings"), icon: <SettingsIcon size={15} />, keywords: ["settings", "设置"], run: () => setSettingsTarget("general") },
-      { id: "cmd-appearance", group: t("palette.group.commands"), title: t("palette.cmd.appearance"), icon: <Palette size={15} />, keywords: ["theme", "appearance", "外观", "主题"], run: () => setSettingsTarget("appearance") },
-      { id: "cmd-memory", group: t("palette.group.commands"), title: t("palette.cmd.memory"), icon: <Brain size={15} />, keywords: ["memory", "记忆"], run: () => setSettingsTarget("memory") },
-      { id: "cmd-models", group: t("palette.group.commands"), title: t("palette.cmd.models"), icon: <Cpu size={15} />, keywords: ["model", "模型"], run: () => setSettingsTarget("models") },
+      { id: "cmd-new", group: t("palette.group.commands"), title: t("palette.cmd.newSession"), icon: <SquarePen size={15} />, compact: true, keywords: ["new", "新建"], run: () => void handleNewTab() },
+      { id: "cmd-history", group: t("palette.group.commands"), title: t("palette.cmd.history"), icon: <History size={15} />, compact: true, keywords: ["history", "历史"], run: () => void openAllHistory() },
+      { id: "cmd-trash", group: t("palette.group.commands"), title: t("palette.cmd.trash"), icon: <Trash2 size={15} />, compact: true, keywords: ["trash", "回收站"], run: () => void openTrash() },
+      { id: "cmd-settings", group: t("palette.group.commands"), title: t("palette.cmd.settings"), icon: <SettingsIcon size={15} />, compact: true, keywords: ["settings", "设置"], run: () => setSettingsTarget("general") },
+      { id: "cmd-appearance", group: t("palette.group.commands"), title: t("palette.cmd.appearance"), icon: <Palette size={15} />, compact: true, keywords: ["theme", "appearance", "外观", "主题"], run: () => setSettingsTarget("appearance") },
+      { id: "cmd-memory", group: t("palette.group.commands"), title: t("palette.cmd.memory"), icon: <Brain size={15} />, compact: true, keywords: ["memory", "记忆"], run: () => setSettingsTarget("memory") },
+      { id: "cmd-models", group: t("palette.group.commands"), title: t("palette.cmd.models"), icon: <Cpu size={15} />, compact: true, keywords: ["model", "模型"], run: () => setSettingsTarget("models") },
     ];
     const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
     const dayLabel = (ms: number) => {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -15,6 +15,9 @@ import {
   Settings as SettingsIcon,
   Pencil,
   Trash2,
+  Brain,
+  Cpu,
+  Palette,
 } from "lucide-react";
 import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
@@ -71,6 +74,7 @@ import {
 } from "./lib/toolApprovalMode";
 import { loadLayoutSize, saveLayoutSize } from "./lib/layoutPreferences";
 import { blobToBase64, renderSessionImageBlob, renderSessionPdfBlob } from "./lib/sessionExport";
+import { sessionActivityTime } from "./lib/session";
 import {
   applyTheme,
   clearLegacyThemePreference,
@@ -1616,19 +1620,28 @@ export default function App() {
   }, [openPalette]);
   const paletteItems = useMemo<PaletteItem[]>(() => {
     const cmds: PaletteItem[] = [
-      { id: "cmd-new", group: t("palette.group.commands"), title: t("palette.cmd.newSession"), keywords: ["new", "新建"], run: () => void handleNewTab() },
-      { id: "cmd-history", group: t("palette.group.commands"), title: t("palette.cmd.history"), keywords: ["history", "历史"], run: () => void openAllHistory() },
-      { id: "cmd-trash", group: t("palette.group.commands"), title: t("palette.cmd.trash"), keywords: ["trash", "回收站"], run: () => void openTrash() },
-      { id: "cmd-settings", group: t("palette.group.commands"), title: t("palette.cmd.settings"), keywords: ["settings", "设置"], run: () => setSettingsTarget("general") },
-      { id: "cmd-appearance", group: t("palette.group.commands"), title: t("palette.cmd.appearance"), keywords: ["theme", "appearance", "外观", "主题"], run: () => setSettingsTarget("appearance") },
-      { id: "cmd-memory", group: t("palette.group.commands"), title: t("palette.cmd.memory"), keywords: ["memory", "记忆"], run: () => setSettingsTarget("memory") },
-      { id: "cmd-models", group: t("palette.group.commands"), title: t("palette.cmd.models"), keywords: ["model", "模型"], run: () => setSettingsTarget("models") },
+      { id: "cmd-new", group: t("palette.group.commands"), title: t("palette.cmd.newSession"), icon: <SquarePen size={15} />, keywords: ["new", "新建"], run: () => void handleNewTab() },
+      { id: "cmd-history", group: t("palette.group.commands"), title: t("palette.cmd.history"), icon: <History size={15} />, keywords: ["history", "历史"], run: () => void openAllHistory() },
+      { id: "cmd-trash", group: t("palette.group.commands"), title: t("palette.cmd.trash"), icon: <Trash2 size={15} />, keywords: ["trash", "回收站"], run: () => void openTrash() },
+      { id: "cmd-settings", group: t("palette.group.commands"), title: t("palette.cmd.settings"), icon: <SettingsIcon size={15} />, keywords: ["settings", "设置"], run: () => setSettingsTarget("general") },
+      { id: "cmd-appearance", group: t("palette.group.commands"), title: t("palette.cmd.appearance"), icon: <Palette size={15} />, keywords: ["theme", "appearance", "外观", "主题"], run: () => setSettingsTarget("appearance") },
+      { id: "cmd-memory", group: t("palette.group.commands"), title: t("palette.cmd.memory"), icon: <Brain size={15} />, keywords: ["memory", "记忆"], run: () => setSettingsTarget("memory") },
+      { id: "cmd-models", group: t("palette.group.commands"), title: t("palette.cmd.models"), icon: <Cpu size={15} />, keywords: ["model", "模型"], run: () => setSettingsTarget("models") },
     ];
+    const startOfDay = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    const dayLabel = (ms: number) => {
+      const days = Math.round((startOfDay(new Date()) - startOfDay(new Date(ms))) / 86_400_000);
+      if (days <= 0) return t("history.today");
+      if (days === 1) return t("history.yesterday");
+      return new Date(ms).toLocaleDateString();
+    };
     const sessionItems: PaletteItem[] = paletteSessions.slice(0, 12).map((s) => ({
       id: `sess-${s.path}`,
       group: t("palette.group.sessions"),
       title: s.title?.trim() || s.preview || t("history.emptySession"),
       hint: s.workspaceRoot || undefined,
+      meta: dayLabel(sessionActivityTime(s)),
+      badge: `${s.turns}轮`,
       run: () => void onResumeSession(s),
     }));
     return [...cmds, ...sessionItems];

--- a/desktop/frontend/src/components/CommandPalette.tsx
+++ b/desktop/frontend/src/components/CommandPalette.tsx
@@ -34,6 +34,8 @@ export interface PaletteItem {
   badge?: string;
   // icon overrides the default Command icon shown on the left.
   icon?: ReactNode;
+  // compact renders the item as a grid chip (icon + title, no hint/meta).
+  compact?: boolean;
   // group is the section header this item belongs to.
   group: string;
   // keywords add to the searchable text (e.g. slash-command aliases).
@@ -201,43 +203,74 @@ export function CommandPalette({
           {flat.length === 0 ? (
             <div className="palette__empty">{emptyText}</div>
           ) : (
-            grouped.map((g) => (
-              <div className="palette__group" key={g.group}>
+            grouped.map((g) => {
+              const isCompact = g.items[0]?.compact;
+              return (
+              <div className={`palette__group ${isCompact ? "palette__group--grid" : ""}`} key={g.group}>
                 <div className="palette__group-title">{g.group}</div>
-                {g.items.map((it) => {
-                  const idx = running++;
-                  const on = idx === active;
-                  return (
-                    <button
-                      type="button"
-                      role="option"
-                      aria-selected={on}
-                      key={it.id}
-                      className={`palette__item ${on ? "palette__item--on" : ""}`}
-                      onMouseEnter={() => setActive(idx)}
-                      onClick={() => {
-                        void it.run();
-                        onClose();
-                      }}
-                    >
-                      <span className="palette__item-icon" aria-hidden="true">
-                        {it.icon ?? <Command size={15} />}
-                      </span>
-                      <span className="palette__body">
-                        <span className="palette__title">{it.title}</span>
-                        {(it.hint || it.meta || it.badge) && (
-                          <span className="palette__hint">
-                            {it.hint}
-                            {it.meta && <span className="palette__meta">{it.meta}</span>}
-                            {it.badge && <span className="palette__badge">{it.badge}</span>}
-                          </span>
-                        )}
-                      </span>
-                    </button>
-                  );
-                })}
+                {isCompact ? (
+                  <div className="palette__grid">
+                  {g.items.map((it) => {
+                    const idx = running++;
+                    const on = idx === active;
+                    return (
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={on}
+                        key={it.id}
+                        className={`palette__chip ${on ? "palette__chip--on" : ""}`}
+                        onMouseEnter={() => setActive(idx)}
+                        onClick={() => {
+                          void it.run();
+                          onClose();
+                        }}
+                      >
+                        <span className="palette__chip-icon" aria-hidden="true">
+                          {it.icon ?? <Command size={15} />}
+                        </span>
+                        <span className="palette__chip-label">{it.title}</span>
+                      </button>
+                    );
+                  })}
+                  </div>
+                ) : (
+                  g.items.map((it) => {
+                    const idx = running++;
+                    const on = idx === active;
+                    return (
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={on}
+                        key={it.id}
+                        className={`palette__item ${on ? "palette__item--on" : ""}`}
+                        onMouseEnter={() => setActive(idx)}
+                        onClick={() => {
+                          void it.run();
+                          onClose();
+                        }}
+                      >
+                        <span className="palette__item-icon" aria-hidden="true">
+                          {it.icon ?? <Command size={15} />}
+                        </span>
+                        <span className="palette__body">
+                          <span className="palette__title">{it.title}</span>
+                          {(it.hint || it.meta || it.badge) && (
+                            <span className="palette__hint">
+                              {it.hint}
+                              {it.meta && <span className="palette__meta">{it.meta}</span>}
+                              {it.badge && <span className="palette__badge">{it.badge}</span>}
+                            </span>
+                          )}
+                        </span>
+                      </button>
+                    );
+                  })
+                )}
               </div>
-            ))
+              );
+            })
           )}
         </div>
         <div className="palette__foot">

--- a/desktop/frontend/src/components/CommandPalette.tsx
+++ b/desktop/frontend/src/components/CommandPalette.tsx
@@ -258,7 +258,7 @@ export function CommandPalette({
                           <span className="palette__title">{it.title}</span>
                           {(it.hint || it.meta || it.badge) && (
                             <span className="palette__hint">
-                              {it.hint}
+                              {it.hint && <span className="palette__hint-text">{it.hint}</span>}
                               {it.meta && <span className="palette__meta">{it.meta}</span>}
                               {it.badge && <span className="palette__badge">{it.badge}</span>}
                             </span>

--- a/desktop/frontend/src/components/CommandPalette.tsx
+++ b/desktop/frontend/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { Command, Search } from "lucide-react";
 import { useMountTransition } from "../lib/useMountTransition";
 
@@ -27,6 +28,12 @@ export interface PaletteItem {
   title: string;
   // hint is the secondary line (a path, a command's source, etc.).
   hint?: string;
+  // meta is right-aligned secondary text (e.g. a timestamp).
+  meta?: string;
+  // badge is a right-aligned counter or label (e.g. turn count).
+  badge?: string;
+  // icon overrides the default Command icon shown on the left.
+  icon?: ReactNode;
   // group is the section header this item belongs to.
   group: string;
   // keywords add to the searchable text (e.g. slash-command aliases).
@@ -214,11 +221,17 @@ export function CommandPalette({
                       }}
                     >
                       <span className="palette__item-icon" aria-hidden="true">
-                        <Command size={15} />
+                        {it.icon ?? <Command size={15} />}
                       </span>
                       <span className="palette__body">
                         <span className="palette__title">{it.title}</span>
-                        {it.hint && <span className="palette__hint">{it.hint}</span>}
+                        {(it.hint || it.meta || it.badge) && (
+                          <span className="palette__hint">
+                            {it.hint}
+                            {it.meta && <span className="palette__meta">{it.meta}</span>}
+                            {it.badge && <span className="palette__badge">{it.badge}</span>}
+                          </span>
+                        )}
                       </span>
                     </button>
                   );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6436,6 +6436,47 @@ a[href] {
   text-transform: uppercase;
   color: var(--fg-faint);
 }
+.palette__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+  gap: 6px;
+  padding: 4px 12px 8px;
+}
+.palette__chip {
+  --wails-draggable: no-drag;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  padding: 10px 6px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 11.5px;
+  text-align: center;
+  cursor: pointer;
+}
+.palette__chip:hover,
+.palette__chip--on {
+  background: var(--accent-soft);
+}
+.palette__chip-icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: 6px;
+  background: var(--bg-soft);
+  color: var(--accent);
+}
+.palette__chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
 .palette__item {
   --wails-draggable: no-drag;
   display: flex;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6533,6 +6533,13 @@ a[href] {
   line-height: 1.35;
   color: var(--fg-faint);
 }
+.palette__hint-text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .palette__meta {
   flex: none;
   margin-left: auto;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6483,13 +6483,24 @@ a[href] {
   color: var(--accent);
 }
 .palette__hint {
-  display: block;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  overflow: hidden;
   font-family: var(--mono);
   font-size: 11.5px;
+  line-height: 1.35;
   color: var(--fg-faint);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+}
+.palette__meta {
+  flex: none;
+  margin-left: auto;
+}
+.palette__badge {
+  flex: none;
+  min-width: 2.5em;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 .palette__foot {
   flex: none;
@@ -14417,141 +14428,6 @@ a[href] {
 .workspace-branch-menu__item:disabled {
   opacity: 0.4;
   cursor: default;
-}
-
-/* ── Command palette (⌘K) ─────────────────────────────────────────── */
-.drawer-backdrop:has(.palette) {
-  justify-content: center;
-  align-items: flex-start;
-  padding-top: 12vh;
-}
-
-.palette {
-  position: relative;
-  width: min(520px, 90vw);
-  max-height: 60vh;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.36);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  animation: palette-in 0.1s ease;
-}
-
-@keyframes palette-in {
-  from { opacity: 0; transform: translateY(-12px) scale(0.97); }
-  to   { opacity: 1; transform: translateY(0) scale(1); }
-}
-
-.palette__inputrow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--border);
-}
-
-.palette__input {
-  flex: 1;
-  border: none;
-  outline: none;
-  background: transparent;
-  color: var(--fg);
-  font-size: 14px;
-  line-height: 1.4;
-}
-
-.palette__input::placeholder {
-  color: var(--fg-muted);
-}
-
-.palette__esc {
-  font-size: 11px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  color: var(--fg-muted);
-  background: var(--bg-base);
-  font-family: inherit;
-  line-height: 1.3;
-}
-
-.palette__list {
-  flex: 1;
-  overflow-y: auto;
-  padding: 6px 0;
-}
-
-.palette__empty {
-  padding: 24px 14px;
-  color: var(--fg-muted);
-  text-align: center;
-  font-size: 13px;
-}
-
-.palette__group-title {
-  padding: 8px 14px 4px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--fg-muted);
-}
-
-.palette__item {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  width: 100%;
-  padding: 8px 14px;
-  border: none;
-  background: transparent;
-  color: var(--fg);
-  cursor: pointer;
-  text-align: left;
-  font-family: inherit;
-  font-size: 13px;
-  line-height: 1.3;
-}
-
-.palette__item--on {
-  background: var(--accent-bg, rgba(77, 151, 255, 0.12));
-}
-
-.palette__item:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
-}
-
-.palette__title {
-  font-weight: 500;
-}
-
-.palette__hint {
-  font-size: 11px;
-  color: var(--fg-muted);
-}
-
-.palette__foot {
-  display: flex;
-  gap: 12px;
-  padding: 7px 14px;
-  border-top: 1px solid var(--border);
-  font-size: 11px;
-  color: var(--fg-muted);
-}
-
-.palette__foot kbd {
-  padding: 1px 4px;
-  border-radius: 3px;
-  border: 1px solid var(--border);
-  background: var(--bg-base);
-  font-family: inherit;
-  font-size: 10px;
-  line-height: 1.3;
-  margin-right: 2px;
 }
 
 /* Respect the OS reduced-motion preference: squash all animations and force


### PR DESCRIPTION
- 移除重复的 palette CSS 规则集，统一使用主样式
- 为每个命令添加独立图标（SquarePen、History、Trash2 等）
- 会话项显示工作空间路径、相对日期和对话轮数
- 轮数使用 tabular-nums 等宽对齐
- hint 改为 flex 布局，路径/日期/轮数各占一位
Fixes https://github.com/esengine/DeepSeek-Reasonix/issues/3903

<img width="759" height="739" alt="1" src="https://github.com/user-attachments/assets/97d4cfb6-ba61-4ad1-95e2-5f8325cf335f" />
