### PR TITLE
fix(desktop): 修复窄窗口下工作区右侧栏布局，并改善低分辨率适配

### DIFF
--- a/desktop/frontend/pnpm-lock.yaml
+++ b/desktop/frontend/pnpm-lock.yaml
@@ -523,66 +523,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import {
   Settings as SettingsIcon,
   Pencil,
   Trash2,
+  X,
 } from "lucide-react";
 import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
@@ -101,6 +102,11 @@ const SIDEBAR_VIEWPORT_RATIO = 0.18;
 const CHAT_MIN_WIDTH = 400;
 const CHAT_COMFORT_MIN_WIDTH = 560;
 const WORKSPACE_RESIZER_WIDTH = 8;
+const WORKSPACE_FLOATING_MARGIN = 12;
+const CHAT_FLOATING_VISIBLE_MIN_WIDTH = 280;
+const WORKSPACE_FLOATING_MIN_WIDTH = 260;
+const LOW_RES_WIDTH_BREAKPOINT = 620;
+const LOW_RES_HEIGHT_BREAKPOINT = 640;
 
 function isThemeMode(value: string): value is Theme {
   return value === "auto" || value === "light" || value === "dark";
@@ -694,6 +700,7 @@ export default function App() {
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
+  const [viewportHeight, setViewportHeight] = useState(() => (typeof window === "undefined" ? 900 : window.innerHeight));
   const [workspacePanelOpen, setWorkspacePanelOpen] = useState(true);
   const [rightDockTreeWidth, setRightDockTreeWidth] = useState(loadRightDockTreeWidth);
   const [rightDockPreviewWidth, setRightDockPreviewWidth] = useState(loadRightDockPreviewWidth);
@@ -892,7 +899,10 @@ export default function App() {
   }, [closeTransientOverlays]);
   useEffect(() => {
     if (typeof window === "undefined") return;
-    const onResize = () => setViewportWidth(window.innerWidth);
+    const onResize = () => {
+      setViewportWidth(window.innerWidth);
+      setViewportHeight(window.innerHeight);
+    };
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
@@ -904,10 +914,12 @@ export default function App() {
   const rightDockDetailActive = rightDockMode !== "context" && workspacePreviewActive;
   const preferredWorkspacePanelWidth = rightDockDetailActive ? rightDockPreviewWidth : rightDockTreeWidth;
   const workspacePanelMinWidth = rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH;
+  const lowResolutionWindow = viewportWidth <= LOW_RES_WIDTH_BREAKPOINT || viewportHeight <= LOW_RES_HEIGHT_BREAKPOINT;
+  const sidebarSuppressed = lowResolutionWindow || sidebarCollapsed;
   const chatReservedWidth = workspacePanelOpen && !workspacePanelMaximized ? CHAT_COMFORT_MIN_WIDTH : CHAT_MIN_WIDTH;
   const workspacePanelAvailableWidth = availableWorkspacePanelWidth({
     viewportWidth,
-    sidebarCollapsed,
+    sidebarCollapsed: sidebarSuppressed,
     sidebarWidth,
     chatMinWidth: chatReservedWidth,
     resizerWidth: WORKSPACE_RESIZER_WIDTH,
@@ -921,10 +933,26 @@ export default function App() {
     availableWidth: workspacePanelAvailableWidth,
   });
 
+  const sidebarRenderWidth = sidebarSuppressed ? 0 : sidebarWidth;
+  const workspacePanelFloating =
+    workspacePanelOpen
+    && !workspacePanelMaximized
+    && (lowResolutionWindow || resolvedWorkspacePanelWidth < RIGHT_DOCK_MIN_RENDER_WIDTH);
+  const floatingWorkspacePanelWidth = Math.min(
+    preferredWorkspacePanelWidth,
+    Math.max(
+      WORKSPACE_FLOATING_MIN_WIDTH,
+      viewportWidth - sidebarRenderWidth - WORKSPACE_FLOATING_MARGIN * 2 - CHAT_FLOATING_VISIBLE_MIN_WIDTH,
+    ),
+  );
   const workspacePanelRenderable =
-    workspacePanelOpen && (workspacePanelMaximized || resolvedWorkspacePanelWidth >= RIGHT_DOCK_MIN_RENDER_WIDTH);
-  const workspacePanelGridOpen = workspacePanelRenderable && !workspacePanelMaximized;
-  const workspacePanelRenderWidth = workspacePanelMaximized ? preferredWorkspacePanelWidth : resolvedWorkspacePanelWidth;
+    workspacePanelOpen && (workspacePanelMaximized || workspacePanelFloating || resolvedWorkspacePanelWidth >= RIGHT_DOCK_MIN_RENDER_WIDTH);
+  const workspacePanelGridOpen = workspacePanelRenderable && !workspacePanelMaximized && !workspacePanelFloating;
+  const workspacePanelRenderWidth = workspacePanelMaximized
+    ? preferredWorkspacePanelWidth
+    : workspacePanelFloating
+      ? floatingWorkspacePanelWidth
+      : resolvedWorkspacePanelWidth;
   const activeTab = useMemo(
     () => tabMetas.find((tab) => tab.id === activeTabId) ?? tabMetas.find((tab) => tab.active),
     [activeTabId, tabMetas],
@@ -2193,8 +2221,10 @@ export default function App() {
         className={[
           "layout",
           sidebarCollapsed ? "layout--sidebar-collapsed" : "",
+          lowResolutionWindow ? "layout--low-res" : "",
           sidebarResizing ? "layout--resizing layout--sidebar-resizing" : "",
           workspacePanelGridOpen ? "layout--workspace-open" : "",
+          workspacePanelRenderable && workspacePanelFloating ? "layout--workspace-floating" : "",
           workspacePanelOpen && workspacePanelMaximized ? "layout--workspace-maximized" : "",
           workspacePanelResizing ? "layout--resizing layout--workspace-resizing" : "",
         ]
@@ -2645,6 +2675,7 @@ export default function App() {
             className={[
               "workbench-dock",
               `workbench-dock--${rightDockMode}`,
+              workspacePanelFloating ? "workbench-dock--floating" : "",
             ].join(" ")}
             aria-label={t("rightDock.workbench")}
           >
@@ -2683,6 +2714,19 @@ export default function App() {
                   <span className="workbench-dock__tab-label">{t("workspace.changedTab")}</span>
                 </button>
               </div>
+              {workspacePanelFloating && (
+                <>
+                  <span className="workbench-dock__tools-spacer" />
+                  <button
+                    className="workspace-iconbtn workbench-dock__close"
+                    type="button"
+                    aria-label={t("rightDock.collapse")}
+                    onClick={closeWorkspacePanel}
+                  >
+                    <X size={15} />
+                  </button>
+                </>
+              )}
             </div>
             <div className="workbench-dock__body">
               {rightDockMode === "context" ? (

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -17,7 +17,6 @@ import {
   Settings as SettingsIcon,
   Pencil,
   Trash2,
-  X,
 } from "lucide-react";
 import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
@@ -2675,7 +2674,6 @@ export default function App() {
             className={[
               "workbench-dock",
               `workbench-dock--${rightDockMode}`,
-              workspacePanelFloating ? "workbench-dock--floating" : "",
             ].join(" ")}
             aria-label={t("rightDock.workbench")}
           >
@@ -2714,19 +2712,6 @@ export default function App() {
                   <span className="workbench-dock__tab-label">{t("workspace.changedTab")}</span>
                 </button>
               </div>
-              {workspacePanelFloating && (
-                <>
-                  <span className="workbench-dock__tools-spacer" />
-                  <button
-                    className="workspace-iconbtn workbench-dock__close"
-                    type="button"
-                    aria-label={t("rightDock.collapse")}
-                    onClick={closeWorkspacePanel}
-                  >
-                    <X size={15} />
-                  </button>
-                </>
-              )}
             </div>
             <div className="workbench-dock__body">
               {rightDockMode === "context" ? (

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1511,6 +1511,21 @@ a[href] {
 .layout--workspace-maximized.layout--sidebar-collapsed {
   grid-template-columns: 0px minmax(0, 1fr);
 }
+.layout--workspace-floating {
+  min-width: 0;
+}
+.layout--low-res {
+  grid-template-columns: minmax(0, 1fr);
+}
+.layout--low-res .sidebar {
+  display: none !important;
+}
+.layout--low-res .sidebar-resizer {
+  display: none !important;
+}
+.layout--low-res .chat-pane {
+  grid-column: 1 / -1;
+}
 .layout--workspace-maximized .chat-pane {
   display: none;
 }
@@ -12327,6 +12342,38 @@ a[href] {
     flex-wrap: wrap;
     justify-content: center;
   }
+
+  .layout--workspace-floating:not(.layout--low-res) {
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  }
+
+  .layout:not(.layout--sidebar-collapsed):not(.layout--workspace-floating):not(.layout--low-res) {
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
+  }
+
+  .layout--workspace-floating:not(.layout--low-res) .sidebar {
+    display: flex;
+  }
+
+  .layout:not(.layout--sidebar-collapsed):not(.layout--workspace-floating):not(.layout--low-res) .sidebar {
+    display: flex;
+  }
+
+  .layout--workspace-floating:not(.layout--low-res) .sidebar-resizer {
+    display: block;
+  }
+
+  .layout:not(.layout--sidebar-collapsed):not(.layout--workspace-floating):not(.layout--low-res) .sidebar-resizer {
+    display: block;
+  }
+
+  .layout--workspace-floating:not(.layout--low-res) .chat-pane {
+    grid-column: 2;
+  }
+
+  .layout:not(.layout--sidebar-collapsed):not(.layout--workspace-floating):not(.layout--low-res) .chat-pane {
+    grid-column: 2;
+  }
 }
 
 #crash-overlay {
@@ -14938,6 +14985,26 @@ a[href] {
   container-type: inline-size;
 }
 
+.layout--workspace-floating .workbench-dock {
+  position: absolute;
+  top: calc(var(--app-chrome-height) + 8px);
+  right: 12px;
+  bottom: calc(12px + var(--statusbar-height));
+  width: min(var(--workspace-width), calc(100% - var(--sidebar-width) - 24px));
+  max-width: calc(100% - var(--sidebar-width) - 24px);
+  height: auto;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  box-shadow: var(--shadow-2);
+  overflow: hidden;
+  z-index: var(--z-dock);
+}
+
+.layout--low-res.layout--workspace-floating .workbench-dock {
+  width: min(var(--workspace-width), calc(100% - 24px));
+  max-width: calc(100% - 24px);
+}
+
 .layout--workspace-maximized .workbench-dock {
   width: auto;
   max-width: none;
@@ -14958,6 +15025,15 @@ a[href] {
   gap: 8px;
   padding: 7px 10px 3px;
   border-bottom: 1px solid transparent;
+}
+
+.workbench-dock__tools-spacer {
+  flex: 1 1 auto;
+  min-width: 8px;
+}
+
+.workbench-dock__close {
+  flex: 0 0 auto;
 }
 
 .workbench-dock__tabs {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14986,23 +14986,7 @@ a[href] {
 }
 
 .layout--workspace-floating .workbench-dock {
-  position: absolute;
-  top: calc(var(--app-chrome-height) + 8px);
-  right: 12px;
-  bottom: calc(12px + var(--statusbar-height));
-  width: min(var(--workspace-width), calc(100% - var(--sidebar-width) - 24px));
-  max-width: calc(100% - var(--sidebar-width) - 24px);
-  height: auto;
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  box-shadow: var(--shadow-2);
-  overflow: hidden;
-  z-index: var(--z-dock);
-}
-
-.layout--low-res.layout--workspace-floating .workbench-dock {
-  width: min(var(--workspace-width), calc(100% - 24px));
-  max-width: calc(100% - 24px);
+  min-width: 0;
 }
 
 .layout--workspace-maximized .workbench-dock {
@@ -15025,15 +15009,6 @@ a[href] {
   gap: 8px;
   padding: 7px 10px 3px;
   border-bottom: 1px solid transparent;
-}
-
-.workbench-dock__tools-spacer {
-  flex: 1 1 auto;
-  min-width: 8px;
-}
-
-.workbench-dock__close {
-  flex: 0 0 auto;
 }
 
 .workbench-dock__tabs {


### PR DESCRIPTION
## 变更说明
修复 v1.5 桌面端在窗口宽度变窄或整体分辨率过低时，右侧工作区面板挤压主聊天区域、导致聊天内容和输入框不可用的问题。

本次 PR 仅保留 响应式布局逻辑 ，不涉及浮窗 UI 改动。核心思路：在空间不足时，通过计算让右侧工作区退出网格布局（ workspacePanelFloating ），避免其继续参与主布局挤压；同时增加低分辨率模式，在窗口过小时自动隐藏左侧导航栏，优先保证聊天主区可用。

## 具体改动
### 逻辑层（App.tsx）
- 新增 viewportHeight 状态，resize 监听同时追踪窗口宽高
- 新增 lowResolutionWindow 计算：宽度 ≤ 620px 或高度 ≤ 640px 时判定为低分辨率
- 新增 sidebarSuppressed ：低分辨率或侧边栏折叠时，布局计算中将侧边栏视为不存在
- 新增 workspacePanelFloating 状态：当空间不足以正常渲染右侧工作区时，使其退出网格布局
- 新增 floatingWorkspacePanelWidth 计算：浮动模式下工作区的合理宽度
- workspacePanelGridOpen 排除浮动状态，避免浮动面板占据网格列
### 样式层（styles.css）
- .layout--workspace-floating ：设置 min-width: 0 ，允许内容收缩
- .layout--low-res ：低分辨率模式下切换单列布局，隐藏侧边栏和调整器
- .layout--low-res .chat-pane ：聊天区跨满整行
- 响应式断点（≤820px）中排除 layout--workspace-floating 和 layout--low-res ，避免特殊布局模式被通用规则干扰
- 浮动模式下恢复侧边栏显示和正确的网格列定义
### 依赖
- 新增 qrcode.react （上游新代码引入的依赖）
## 行为说明
场景 行为 正常窗口宽度 右侧工作区保持原有侧边栏行为 窄窗口（空间不足） 右侧工作区退出网格布局，不再挤压聊天区 低分辨率（≤620×640） 左侧导航栏自动隐藏，聊天区占满宽度

## 已移除的内容
初版 PR 包含浮窗 UI 改动（绝对定位、圆角边框、阴影、关闭按钮等），经审查后已移除，仅保留响应式布局逻辑。移除原因：

1. 浮窗视觉样式与主题覆盖规则存在 CSS 特异性冲突，会导致主题模式下浮窗丢失阴影和边框
2. 浮窗模式缺少平滑过渡动画，切换时位置会跳变
3. 布局逻辑与 UI 表现应分层推进，先确保布局正确再优化视觉
## 验证情况
- 已在桌面端 wails dev 模式下手动测试，覆盖尺寸：818×838、700×700、620×700、520×700、818×620
- 右侧工作区不再挤压聊天主区
- 低分辨率模式下侧边栏正确隐藏，聊天区可用
- CSS 语法检查和 z-index 检查通过
- main-v2 分支存在与本次改动无关的既有 TypeScript 构建问题（ PromptShelf.tsx 、 bridge.ts ）
## 关联问题
- fixes #3975