### PR TITLE
feat(desktop): anonymous launch ping, crash device info, /stats page

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -210,3 +210,15 @@ desktop/
         Markdown, CodeViewer, DiffView
         editors/  PlainCode, PlainDiff   ← editor seam impls (swap targets)
 ```
+
+## Telemetry
+
+The desktop app sends one anonymous ping per launch to `crash.reasonix.io`:
+a random install id (generated locally, tied to nothing), app version, OS,
+arch, and OS version. It exists solely to count active installs. It never
+includes conversations, API keys, file contents, or paths.
+
+Opt out any time: Settings > Updates > "Anonymous usage ping", or set
+`telemetry = false` under `[desktop]` in the global config. Dev builds
+never ping. Crash reports are separate and only ever sent when the user
+clicks "Send report" on the crash screen.

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -270,6 +270,7 @@ func (a *App) startup(ctx context.Context) {
 	a.startTray()
 
 	go a.restoreOrBuildTabs()
+	go a.sendStartupPing()
 }
 
 func (a *App) beforeClose(ctx context.Context) bool {

--- a/desktop/crash_app.go
+++ b/desktop/crash_app.go
@@ -24,11 +24,12 @@ func scrubUserPaths(s string) string {
 }
 
 type crashReport struct {
-	Kind    string `json:"kind"`
-	Version string `json:"version"`
-	OS      string `json:"os"`
-	Arch    string `json:"arch"`
-	Message string `json:"message"`
+	Kind    string     `json:"kind"`
+	Version string     `json:"version"`
+	OS      string     `json:"os"`
+	Arch    string     `json:"arch"`
+	Message string     `json:"message"`
+	Device  deviceInfo `json:"device"`
 }
 
 func (a *App) ReportCrash(kind, detail string) error {
@@ -51,6 +52,7 @@ func (a *App) ReportCrash(kind, detail string) error {
 		OS:      runtime.GOOS,
 		Arch:    runtime.GOARCH,
 		Message: scrubUserPaths(detail),
+		Device:  collectDeviceInfo(),
 	})
 }
 

--- a/desktop/devinfo.go
+++ b/desktop/devinfo.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// devinfo.go collects coarse machine facts attached to crash reports: OS version,
+// CPU model, core count, RAM. Nothing here identifies a user or machine.
+
+type deviceInfo struct {
+	OSVersion string `json:"osVersion,omitempty"`
+	CPU       string `json:"cpu,omitempty"`
+	Cores     int    `json:"cores"`
+	RAMGB     int    `json:"ramGb,omitempty"`
+}
+
+const gib = 1 << 30
+
+func collectDeviceInfo() deviceInfo {
+	return deviceInfo{
+		OSVersion: platformOSVersion(),
+		CPU:       platformCPU(),
+		Cores:     runtime.NumCPU(),
+		RAMGB:     int((platformRAMBytes() + gib/2) / gib),
+	}
+}
+
+func parseCPUModel(cpuinfo string) string {
+	for _, line := range strings.Split(cpuinfo, "\n") {
+		if name, ok := strings.CutPrefix(line, "model name"); ok {
+			if _, v, ok := strings.Cut(name, ":"); ok {
+				return strings.TrimSpace(v)
+			}
+		}
+	}
+	return ""
+}
+
+func parseMemTotalBytes(meminfo string) uint64 {
+	for _, line := range strings.Split(meminfo, "\n") {
+		if rest, ok := strings.CutPrefix(line, "MemTotal:"); ok {
+			kb, err := strconv.ParseUint(strings.TrimSuffix(strings.TrimSpace(rest), " kB"), 10, 64)
+			if err != nil {
+				return 0
+			}
+			return kb * 1024
+		}
+	}
+	return 0
+}
+
+func parseOSReleasePrettyName(osRelease string) string {
+	for _, line := range strings.Split(osRelease, "\n") {
+		if v, ok := strings.CutPrefix(line, "PRETTY_NAME="); ok {
+			return strings.Trim(strings.TrimSpace(v), `"`)
+		}
+	}
+	return ""
+}

--- a/desktop/devinfo_darwin.go
+++ b/desktop/devinfo_darwin.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func sysctlString(name string) string {
+	out, err := exec.Command("sysctl", "-n", name).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func platformOSVersion() string {
+	out, err := exec.Command("sw_vers", "-productVersion").Output()
+	if err != nil {
+		return "macOS"
+	}
+	return "macOS " + strings.TrimSpace(string(out))
+}
+
+func platformCPU() string {
+	return sysctlString("machdep.cpu.brand_string")
+}
+
+func platformRAMBytes() uint64 {
+	n, err := strconv.ParseUint(sysctlString("hw.memsize"), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/desktop/devinfo_linux.go
+++ b/desktop/devinfo_linux.go
@@ -1,0 +1,26 @@
+package main
+
+import "os"
+
+func readOr(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func platformOSVersion() string {
+	if name := parseOSReleasePrettyName(readOr("/etc/os-release")); name != "" {
+		return name
+	}
+	return "Linux"
+}
+
+func platformCPU() string {
+	return parseCPUModel(readOr("/proc/cpuinfo"))
+}
+
+func platformRAMBytes() uint64 {
+	return parseMemTotalBytes(readOr("/proc/meminfo"))
+}

--- a/desktop/devinfo_test.go
+++ b/desktop/devinfo_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestParseCPUModel(t *testing.T) {
+	cpuinfo := "processor\t: 0\nvendor_id\t: GenuineIntel\nmodel name\t: Intel(R) Core(TM) i7-12700K\nflags\t: fpu vme\n"
+	if got := parseCPUModel(cpuinfo); got != "Intel(R) Core(TM) i7-12700K" {
+		t.Errorf("parseCPUModel = %q", got)
+	}
+	if got := parseCPUModel("no such field"); got != "" {
+		t.Errorf("parseCPUModel on garbage = %q, want empty", got)
+	}
+}
+
+func TestParseMemTotalBytes(t *testing.T) {
+	meminfo := "MemTotal:       32652284 kB\nMemFree:         1234 kB\n"
+	if got := parseMemTotalBytes(meminfo); got != 32652284*1024 {
+		t.Errorf("parseMemTotalBytes = %d", got)
+	}
+	if got := parseMemTotalBytes("MemFree: 1 kB"); got != 0 {
+		t.Errorf("parseMemTotalBytes without MemTotal = %d, want 0", got)
+	}
+}
+
+func TestParseOSReleasePrettyName(t *testing.T) {
+	osRelease := "NAME=\"Ubuntu\"\nPRETTY_NAME=\"Ubuntu 24.04.1 LTS\"\nID=ubuntu\n"
+	if got := parseOSReleasePrettyName(osRelease); got != "Ubuntu 24.04.1 LTS" {
+		t.Errorf("parseOSReleasePrettyName = %q", got)
+	}
+}
+
+func TestCollectDeviceInfoSane(t *testing.T) {
+	d := collectDeviceInfo()
+	if d.Cores < 1 {
+		t.Errorf("Cores = %d", d.Cores)
+	}
+	if d.OSVersion == "" {
+		t.Error("OSVersion empty")
+	}
+}

--- a/desktop/devinfo_windows.go
+++ b/desktop/devinfo_windows.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+	"golang.org/x/sys/windows/registry"
+)
+
+func platformOSVersion() string {
+	v := windows.RtlGetVersion()
+	return fmt.Sprintf("Windows %d.%d build %d", v.MajorVersion, v.MinorVersion, v.BuildNumber)
+}
+
+func platformCPU() string {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `HARDWARE\DESCRIPTION\System\CentralProcessor\0`, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer k.Close()
+	name, _, err := k.GetStringValue("ProcessorNameString")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(name)
+}
+
+func platformRAMBytes() uint64 {
+	var kb uint64
+	proc := windows.NewLazySystemDLL("kernel32.dll").NewProc("GetPhysicallyInstalledSystemMemory")
+	if ret, _, _ := proc.Call(uintptr(unsafe.Pointer(&kb))); ret == 0 {
+		return 0
+	}
+	return kb * 1024
+}

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -166,6 +166,7 @@ export function SettingsPanel({ onClose, onChanged, initialTab }: { onClose: () 
                     <UpdatesSection
                       configPath={s.configPath}
                       checkUpdates={s.checkUpdates}
+                      telemetry={s.telemetry !== false}
                       settingsBusy={busy}
                       applySettings={apply}
                     />
@@ -3428,11 +3429,13 @@ const mb = (n: number) => (n / MB).toFixed(1);
 function UpdatesSection({
   configPath,
   checkUpdates,
+  telemetry,
   settingsBusy,
   applySettings,
 }: {
   configPath: string;
   checkUpdates: boolean;
+  telemetry: boolean;
   settingsBusy: boolean;
   applySettings: (fn: () => Promise<void>) => Promise<void>;
 }) {
@@ -3457,6 +3460,17 @@ function UpdatesSection({
           value={checkUpdates}
           disabled={settingsBusy}
           onChange={(enabled) => void applySettings(() => app.SetDesktopCheckUpdates(enabled))}
+        />
+      </SettingsField>
+      <SettingsField
+        className="settings-field--wide-copy"
+        label={t("settings.telemetryLabel")}
+        hint={t("settings.telemetryHint")}
+      >
+        <ToggleSegment
+          value={telemetry}
+          disabled={settingsBusy}
+          onChange={(enabled) => void applySettings(() => app.SetDesktopTelemetry(enabled))}
         />
       </SettingsField>
       <SettingsField label={t("updater.currentVersion", { v: version || "…" })}>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -219,6 +219,7 @@ export interface AppBindings {
   SetDesktopLanguage(lang: string): Promise<void>;
   SetDesktopAppearance(theme: string, style: string): Promise<void>;
   SetDesktopCheckUpdates(enabled: boolean): Promise<void>;
+  SetDesktopTelemetry(enabled: boolean): Promise<void>;
   SetExpandThinking(on: boolean): Promise<void>;
   MigrateDesktopPreferences(language: string, theme: string, style: string): Promise<void>;
   SetAgentParams(temperature: number, maxSteps: number, plannerMaxSteps: number, systemPrompt: string): Promise<void>;
@@ -684,6 +685,7 @@ function makeMockApp(): AppBindings {
     desktopThemeStyle: "graphite",
     closeBehavior: "background",
     checkUpdates: true,
+    telemetry: true,
     expandThinking: false,
     configPath: "~/projects/reasonix/reasonix.toml",
     providerKinds: ["openai"],
@@ -2043,6 +2045,9 @@ function makeMockApp(): AppBindings {
         },
         async SetDesktopCheckUpdates(enabled: boolean) {
           settings.checkUpdates = enabled;
+        },
+        async SetDesktopTelemetry(enabled: boolean) {
+          settings.telemetry = enabled;
         },
         async SetExpandThinking(on: boolean) {
           settings.expandThinking = on;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -727,6 +727,7 @@ export interface SettingsView {
   desktopThemeStyle: string;
   closeBehavior: string; // "background" | "quit"
   checkUpdates: boolean; // check for new versions on startup
+  telemetry: boolean; // anonymous launch ping (install id + version + OS)
   expandThinking: boolean; // show reasoning text expanded by default
   configPath: string;
   providerKinds: string[]; // provider implementations the kernel registered (for the kind picker)

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1031,6 +1031,8 @@ export const en = {
   "updater.title": "Software update",
   "updater.autoCheckLabel": "Check for updates on startup",
   "updater.autoCheckHint": "When off, Reasonix won't check automatically when it opens. You can still check manually here.",
+  "settings.telemetryLabel": "Anonymous usage ping",
+  "settings.telemetryHint": "On launch, send a random install id plus version and OS to count active installs. Never includes conversations, keys, or file contents.",
   "updater.currentVersion": "Current version: {v}",
   "updater.checkButton": "Check for updates",
   "updater.checking": "Checking for updates…",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1033,6 +1033,8 @@ export const zh: Record<DictKey, string> = {
   "updater.title": "软件更新",
   "updater.autoCheckLabel": "启动时检测新版本",
   "updater.autoCheckHint": "关闭后，Reasonix 打开时不会自动检查更新；你仍可在此页手动检查。",
+  "settings.telemetryLabel": "匿名启动统计",
+  "settings.telemetryHint": "启动时发送随机安装 ID、版本号和操作系统用于统计活跃安装量；绝不包含对话、密钥或文件内容。",
   "updater.currentVersion": "当前版本：{v}",
   "updater.checkButton": "检查更新",
   "updater.checking": "正在检查更新…",

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -148,6 +148,7 @@ type SettingsView struct {
 	DesktopThemeStyle string          `json:"desktopThemeStyle"`
 	CloseBehavior     string          `json:"closeBehavior"`
 	CheckUpdates      bool            `json:"checkUpdates"`
+	Telemetry         bool            `json:"telemetry"`
 	ExpandThinking    bool            `json:"expandThinking"`
 	ConfigPath        string          `json:"configPath"`
 	// ProviderKinds lists the provider implementations the kernel actually
@@ -326,6 +327,7 @@ func (a *App) Settings() SettingsView {
 			DesktopThemeStyle: "graphite",
 			CloseBehavior:     "background",
 			CheckUpdates:      true,
+			Telemetry:         true,
 			ExpandThinking:    false,
 		}
 	}
@@ -371,6 +373,7 @@ func (a *App) Settings() SettingsView {
 		DesktopThemeStyle: cfg.DesktopThemeStyle(),
 		CloseBehavior:     cfg.DesktopCloseBehavior(),
 		CheckUpdates:      cfg.DesktopCheckUpdates(),
+		Telemetry:         cfg.DesktopTelemetry(),
 		ExpandThinking:    cfg.Desktop.ExpandThinking,
 		ConfigPath:        cfgPath,
 		ProviderKinds:     nonNil(provider.Kinds()),
@@ -1299,6 +1302,11 @@ func (a *App) SetDesktopAppearance(theme, style string) error {
 // preference. Manual checks in Settings are unaffected.
 func (a *App) SetDesktopCheckUpdates(enabled bool) error {
 	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopCheckUpdates(enabled) })
+}
+
+// SetDesktopTelemetry sets whether the desktop sends the anonymous launch ping.
+func (a *App) SetDesktopTelemetry(enabled bool) error {
+	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopTelemetry(enabled) })
 }
 
 // SetExpandThinking sets whether reasoning text is expanded by default on

--- a/desktop/telemetry_app.go
+++ b/desktop/telemetry_app.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+
+	"reasonix/internal/config"
+)
+
+// telemetry_app.go is the anonymous launch ping: one POST per app start carrying a
+// random install id, version, and OS facts — never conversation, key, or file data.
+// Gated on config desktop.telemetry (default on) and skipped entirely in dev builds.
+
+var pingEndpoint = "https://crash.reasonix.io/v1/ping"
+
+var installIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+type startupPing struct {
+	InstallID string `json:"installId"`
+	Version   string `json:"version"`
+	OS        string `json:"os"`
+	Arch      string `json:"arch"`
+	OSVersion string `json:"osVersion,omitempty"`
+}
+
+func installID() (string, error) {
+	path := filepath.Join(filepath.Dir(config.UserConfigPath()), "install-id")
+	if b, err := os.ReadFile(path); err == nil {
+		if id := string(bytes.TrimSpace(b)); installIDPattern.MatchString(id) {
+			return id, nil
+		}
+	}
+	raw := make([]byte, 16)
+	if _, err := rand.Read(raw); err != nil {
+		return "", err
+	}
+	id := hex.EncodeToString(raw)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, []byte(id+"\n"), 0o644); err != nil {
+		return "", err
+	}
+	return id, nil
+}
+
+func (a *App) sendStartupPing() {
+	if version == "dev" {
+		return
+	}
+	cfg, err := config.Load()
+	if err != nil || !cfg.DesktopTelemetry() {
+		return
+	}
+	id, err := installID()
+	if err != nil {
+		return
+	}
+	c, err := httpClient()
+	if err != nil {
+		return
+	}
+	_ = postStartupPing(a.bootContext(), c, pingEndpoint, startupPing{
+		InstallID: id,
+		Version:   version,
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+		OSVersion: platformOSVersion(),
+	})
+}
+
+func postStartupPing(ctx context.Context, c *http.Client, endpoint string, p startupPing) error {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/desktop/telemetry_app_test.go
+++ b/desktop/telemetry_app_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestInstallIDStableAcrossCalls(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	first, err := installID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !installIDPattern.MatchString(first) {
+		t.Fatalf("installID() = %q, want 32 hex chars", first)
+	}
+	second, err := installID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second != first {
+		t.Errorf("second call returned %q, want stable %q", second, first)
+	}
+}
+
+func TestPostStartupPing(t *testing.T) {
+	var got startupPing
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Errorf("body not JSON: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	p := startupPing{InstallID: "0123456789abcdef0123456789abcdef", Version: "v9.9.9", OS: "windows", Arch: "amd64", OSVersion: "Windows 10.0 build 26200"}
+	if err := postStartupPing(context.Background(), srv.Client(), srv.URL, p); err != nil {
+		t.Fatal(err)
+	}
+	if got != p {
+		t.Errorf("server received %+v, want %+v", got, p)
+	}
+}
+
+func TestSendStartupPingSkipsDevBuild(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	old := pingEndpoint
+	pingEndpoint = srv.URL
+	defer func() { pingEndpoint = old }()
+
+	NewApp().sendStartupPing()
+	if hits != 0 {
+		t.Errorf("dev build sent %d pings, want 0", hits)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,7 @@ type DesktopConfig struct {
 	ThemeStyle     string   `toml:"theme_style"`     // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 	CloseBehavior  string   `toml:"close_behavior"`  // quit|background; desktop window close behavior
 	CheckUpdates   *bool    `toml:"check_updates"`   // startup update checks; nil keeps the default enabled
+	Telemetry      *bool    `toml:"telemetry"`       // anonymous launch ping (install id + version + OS); nil keeps the default enabled
 	ProviderAccess []string `toml:"provider_access"` // desktop-only list of provider entries shown in Settings > Model > Access
 	ExpandThinking bool     `toml:"expand_thinking"` // true = show reasoning text expanded by default; false = collapsed
 }
@@ -195,6 +196,15 @@ func (c *Config) DesktopCheckUpdates() bool {
 		return true
 	}
 	return *c.Desktop.CheckUpdates
+}
+
+// DesktopTelemetry reports whether the desktop sends the anonymous launch ping.
+// It carries no conversation, key, or file data — see desktop/README.md.
+func (c *Config) DesktopTelemetry() bool {
+	if c == nil || c.Desktop.Telemetry == nil {
+		return true
+	}
+	return *c.Desktop.Telemetry
 }
 
 // LSPConfig governs the optional Language Server Protocol tools (lsp_definition,

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -199,6 +199,12 @@ func (c *Config) SetDesktopCheckUpdates(enabled bool) error {
 	return nil
 }
 
+// SetDesktopTelemetry sets whether the desktop sends the anonymous launch ping.
+func (c *Config) SetDesktopTelemetry(enabled bool) error {
+	c.Desktop.Telemetry = &enabled
+	return nil
+}
+
 // SetUICloseBehavior is kept for callers compiled against the old edit API.
 func (c *Config) SetUICloseBehavior(mode string) error {
 	return c.SetDesktopCloseBehavior(mode)

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -91,6 +91,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		}
 		fmt.Fprintf(&b, "close_behavior = %q   # desktop: quit|background when the window close button is clicked\n", c.DesktopCloseBehavior())
 		fmt.Fprintf(&b, "check_updates = %v   # desktop: check for new versions on startup\n", c.DesktopCheckUpdates())
+		fmt.Fprintf(&b, "telemetry = %v   # desktop: anonymous launch ping (install id + version + OS); never content\n", c.DesktopTelemetry())
 		if len(c.Desktop.ProviderAccess) > 0 {
 			fmt.Fprintf(&b, "provider_access = %s   # desktop settings: providers shown on Settings > Model > Access\n", renderStringArray(c.Desktop.ProviderAccess))
 		}

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -22,6 +22,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Desktop.ThemeStyle = "graphite"
 	orig.Desktop.CloseBehavior = "background"
 	orig.Desktop.CheckUpdates = boolPtr(false)
+	orig.Desktop.Telemetry = boolPtr(false)
 	orig.Notifications.Enabled = true
 	orig.Notifications.TurnDone = true
 	orig.Notifications.ApprovalRequest = true

--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -16,7 +16,19 @@ CREATE TABLE IF NOT EXISTS reports (
   os TEXT NOT NULL,
   arch TEXT NOT NULL,
   message TEXT NOT NULL,
+  device TEXT NOT NULL DEFAULT '',
   created_at TEXT NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS reports_fingerprint ON reports (fingerprint);
+
+CREATE TABLE IF NOT EXISTS pings (
+  date TEXT NOT NULL,
+  install_id TEXT NOT NULL,
+  version TEXT NOT NULL,
+  os TEXT NOT NULL,
+  arch TEXT NOT NULL,
+  os_version TEXT NOT NULL DEFAULT '',
+  opens INTEGER NOT NULL DEFAULT 1,
+  PRIMARY KEY (date, install_id)
+);

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -1,5 +1,5 @@
-// Ingest endpoint for desktop crash/feedback reports — user-initiated only (the
-// client sends nothing without an explicit click on the crash overlay).
+// Ingest + stats for desktop crash/feedback reports and the anonymous launch
+// ping. Reports are user-initiated; pings are opt-out (desktop.telemetry).
 import { z } from "zod";
 
 interface RateLimiter {
@@ -9,10 +9,21 @@ interface RateLimiter {
 interface Env {
   DB: D1Database;
   RATE_LIMITER: RateLimiter;
+  PING_LIMITER: RateLimiter;
+  STATS_PASSWORD?: string;
 }
 
 const MAX_BODY_BYTES = 32 * 1024;
 const SAMPLES_PER_GROUP = 5;
+
+const Device = z
+  .object({
+    osVersion: z.string().max(128),
+    cpu: z.string().max(128),
+    cores: z.number().int().min(0).max(4096),
+    ramGb: z.number().min(0).max(65536),
+  })
+  .partial();
 
 const Report = z.object({
   kind: z.enum(["crash", "feedback"]),
@@ -20,6 +31,15 @@ const Report = z.object({
   os: z.string().min(1).max(32),
   arch: z.string().min(1).max(32),
   message: z.string().min(1).max(16 * 1024),
+  device: Device.optional(),
+});
+
+const Ping = z.object({
+  installId: z.string().regex(/^[0-9a-f]{32}$/),
+  version: z.string().min(1).max(64),
+  os: z.string().min(1).max(32),
+  arch: z.string().min(1).max(32),
+  osVersion: z.string().max(128).optional(),
 });
 
 export function normalizeForFingerprint(kind: string, message: string): string {
@@ -40,50 +60,175 @@ async function sha256Hex(s: string): Promise<string> {
   return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+async function readJSON(request: Request): Promise<unknown | Response> {
+  const length = Number(request.headers.get("content-length") ?? "0");
+  if (!length || length > MAX_BODY_BYTES) return new Response("payload too large", { status: 413 });
+  try {
+    return JSON.parse(await request.text());
+  } catch {
+    return new Response("bad request", { status: 400 });
+  }
+}
+
+async function handleReport(request: Request, env: Env): Promise<Response> {
+  const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
+  const { success } = await env.RATE_LIMITER.limit({ key: ip });
+  if (!success) return new Response("rate limited", { status: 429 });
+
+  const raw = await readJSON(request);
+  if (raw instanceof Response) return raw;
+  const parsed = Report.safeParse(raw);
+  if (!parsed.success) return new Response("bad request", { status: 400 });
+  const r = parsed.data;
+
+  const fingerprint = await sha256Hex(normalizeForFingerprint(r.kind, r.message));
+  const now = new Date().toISOString();
+
+  await env.DB.prepare(
+    `INSERT INTO groups (fingerprint, kind, count, first_seen, last_seen, last_version)
+     VALUES (?1, ?2, 1, ?3, ?3, ?4)
+     ON CONFLICT (fingerprint) DO UPDATE SET
+       count = count + 1, last_seen = ?3, last_version = ?4`,
+  )
+    .bind(fingerprint, r.kind, now, r.version)
+    .run();
+
+  const group = await env.DB.prepare("SELECT count FROM groups WHERE fingerprint = ?1")
+    .bind(fingerprint)
+    .first<{ count: number }>();
+  if ((group?.count ?? 1) <= SAMPLES_PER_GROUP) {
+    await env.DB.prepare(
+      `INSERT INTO reports (fingerprint, kind, version, os, arch, message, device, created_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`,
+    )
+      .bind(fingerprint, r.kind, r.version, r.os, r.arch, r.message, JSON.stringify(r.device ?? {}), now)
+      .run();
+  }
+
+  return new Response("ok", { status: 202 });
+}
+
+async function handlePing(request: Request, env: Env): Promise<Response> {
+  const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
+  const { success } = await env.PING_LIMITER.limit({ key: ip });
+  if (!success) return new Response("rate limited", { status: 429 });
+
+  const raw = await readJSON(request);
+  if (raw instanceof Response) return raw;
+  const parsed = Ping.safeParse(raw);
+  if (!parsed.success) return new Response("bad request", { status: 400 });
+  const p = parsed.data;
+
+  await env.DB.prepare(
+    `INSERT INTO pings (date, install_id, version, os, arch, os_version, opens)
+     VALUES (date('now'), ?1, ?2, ?3, ?4, ?5, 1)
+     ON CONFLICT (date, install_id) DO UPDATE SET
+       opens = opens + 1, version = ?2, os_version = ?5`,
+  )
+    .bind(p.installId, p.version, p.os, p.arch, p.osVersion ?? "")
+    .run();
+
+  return new Response("ok", { status: 202 });
+}
+
+function statsAuthorized(request: Request, env: Env): boolean {
+  // trim: secrets piped in via PowerShell arrive with a trailing newline.
+  const want = (env.STATS_PASSWORD ?? "").trim();
+  if (!want) return false;
+  const header = request.headers.get("authorization") ?? "";
+  if (!header.startsWith("Basic ")) return false;
+  let pass: string;
+  try {
+    pass = atob(header.slice(6)).split(":").slice(1).join(":");
+  } catch {
+    return false;
+  }
+  const enc = new TextEncoder();
+  const a = enc.encode(pass);
+  const b = enc.encode(want);
+  return a.byteLength === b.byteLength && crypto.subtle.timingSafeEqual(a, b);
+}
+
+function esc(s: unknown): string {
+  return String(s).replace(/[&<>"']/g, (c) => `&#${c.charCodeAt(0)};`);
+}
+
+function barTable(rows: Record<string, unknown>[], labelKey: string, valueKey: string, extraKeys: string[] = []): string {
+  const max = Math.max(1, ...rows.map((r) => Number(r[valueKey]) || 0));
+  const tr = rows
+    .map((r) => {
+      const v = Number(r[valueKey]) || 0;
+      const extras = extraKeys.map((k) => `<td>${esc(r[k])}</td>`).join("");
+      return `<tr><td>${esc(r[labelKey])}</td><td class="num">${v}</td>${extras}<td class="bar"><div style="width:${Math.round((v / max) * 100)}%"></div></td></tr>`;
+    })
+    .join("");
+  return `<table><tbody>${tr}</tbody></table>`;
+}
+
+async function handleStats(env: Env): Promise<Response> {
+  const [daily, versions, oses, crashes] = await Promise.all([
+    env.DB.prepare(
+      "SELECT date, COUNT(*) AS users, SUM(opens) AS opens FROM pings WHERE date >= date('now', '-29 day') GROUP BY date ORDER BY date DESC",
+    ).all(),
+    env.DB.prepare(
+      "SELECT version, COUNT(DISTINCT install_id) AS users FROM pings WHERE date >= date('now', '-6 day') GROUP BY version ORDER BY users DESC LIMIT 15",
+    ).all(),
+    env.DB.prepare(
+      "SELECT os || ' ' || arch AS platform, COUNT(DISTINCT install_id) AS users FROM pings WHERE date >= date('now', '-6 day') GROUP BY platform ORDER BY users DESC",
+    ).all(),
+    env.DB.prepare(
+      "SELECT substr(fingerprint, 1, 8) AS fp, kind, count, last_version, substr(last_seen, 1, 10) AS seen FROM groups ORDER BY last_seen DESC LIMIT 20",
+    ).all(),
+  ]);
+
+  const crashRows = (crashes.results as Record<string, unknown>[])
+    .map(
+      (r) =>
+        `<tr><td><code>${esc(r.fp)}</code></td><td>${esc(r.kind)}</td><td class="num">${esc(r.count)}</td><td>${esc(r.last_version)}</td><td>${esc(r.seen)}</td></tr>`,
+    )
+    .join("");
+
+  const html = `<!doctype html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Reasonix stats</title><style>
+body{font:14px/1.5 system-ui,sans-serif;background:#1a1a2e;color:#e6e6f0;max-width:880px;margin:24px auto;padding:0 16px}
+h1{font-size:18px}h2{font-size:15px;margin-top:28px;color:#9f9fc0}
+table{border-collapse:collapse;width:100%}td,th{padding:4px 10px 4px 0;text-align:left;border-bottom:1px solid #2a2a40}
+td.num{text-align:right;font-variant-numeric:tabular-nums}
+td.bar{width:45%}td.bar div{background:#5b8cff;height:10px;border-radius:3px;min-width:2px}
+code{color:#9f9fc0}.hint{color:#8a8aa3;font-size:12px}
+</style></head><body>
+<h1>Reasonix desktop stats</h1>
+<h2>Daily active installs (30 days) — users / opens</h2>
+${barTable(daily.results as Record<string, unknown>[], "date", "users", ["opens"])}
+<h2>Versions (last 7 days, distinct installs)</h2>
+${barTable(versions.results as Record<string, unknown>[], "version", "users")}
+<h2>Platforms (last 7 days, distinct installs)</h2>
+${barTable(oses.results as Record<string, unknown>[], "platform", "users")}
+<h2>Recent crash groups</h2>
+<table><thead><tr><th>fingerprint</th><th>kind</th><th>count</th><th>last version</th><th>last seen</th></tr></thead>
+<tbody>${crashRows}</tbody></table>
+<p class="hint">Crash stacks: wrangler d1 execute reasonix-crash --remote --command "SELECT message FROM reports WHERE fingerprint LIKE '&lt;fp&gt;%'"</p>
+</body></html>`;
+  return new Response(html, { headers: { "content-type": "text/html; charset=utf-8" } });
+}
+
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
-    if (url.pathname !== "/v1/report") return new Response("not found", { status: 404 });
-    if (request.method !== "POST") return new Response("method not allowed", { status: 405 });
-
-    const length = Number(request.headers.get("content-length") ?? "0");
-    if (!length || length > MAX_BODY_BYTES) return new Response("payload too large", { status: 413 });
-
-    const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
-    const { success } = await env.RATE_LIMITER.limit({ key: ip });
-    if (!success) return new Response("rate limited", { status: 429 });
-
-    let parsed: z.infer<typeof Report>;
-    try {
-      parsed = Report.parse(JSON.parse(await request.text()));
-    } catch {
-      return new Response("bad request", { status: 400 });
+    if (url.pathname === "/v1/report" && request.method === "POST") return handleReport(request, env);
+    if (url.pathname === "/v1/ping" && request.method === "POST") return handlePing(request, env);
+    if (url.pathname === "/stats" && request.method === "GET") {
+      if (!statsAuthorized(request, env)) {
+        return new Response("auth required", {
+          status: 401,
+          headers: { "www-authenticate": 'Basic realm="reasonix-stats"' },
+        });
+      }
+      return handleStats(env);
     }
-
-    const fingerprint = await sha256Hex(normalizeForFingerprint(parsed.kind, parsed.message));
-    const now = new Date().toISOString();
-
-    await env.DB.prepare(
-      `INSERT INTO groups (fingerprint, kind, count, first_seen, last_seen, last_version)
-       VALUES (?1, ?2, 1, ?3, ?3, ?4)
-       ON CONFLICT (fingerprint) DO UPDATE SET
-         count = count + 1, last_seen = ?3, last_version = ?4`,
-    )
-      .bind(fingerprint, parsed.kind, now, parsed.version)
-      .run();
-
-    const group = await env.DB.prepare("SELECT count FROM groups WHERE fingerprint = ?1")
-      .bind(fingerprint)
-      .first<{ count: number }>();
-    if ((group?.count ?? 1) <= SAMPLES_PER_GROUP) {
-      await env.DB.prepare(
-        `INSERT INTO reports (fingerprint, kind, version, os, arch, message, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)`,
-      )
-        .bind(fingerprint, parsed.kind, parsed.version, parsed.os, parsed.arch, parsed.message, now)
-        .run();
+    if (url.pathname === "/v1/report" || url.pathname === "/v1/ping" || url.pathname === "/stats") {
+      return new Response("method not allowed", { status: 405 });
     }
-
-    return new Response("ok", { status: 202 });
+    return new Response("not found", { status: 404 });
   },
 };

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -15,3 +15,10 @@ name = "RATE_LIMITER"
 type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 5, period = 60 }
+
+# Looser than RATE_LIMITER: many installs can share one office/campus NAT IP.
+[[unsafe.bindings]]
+name = "PING_LIMITER"
+type = "ratelimit"
+namespace_id = "1002"
+simple = { limit = 30, period = 60 }


### PR DESCRIPTION
## What

Follow-up to #3978. Crash reports tell us what broke; this adds the "for whom / how many" half, still entirely on our Cloudflare account.

### Anonymous launch ping

One POST per desktop start to `crash.reasonix.io/v1/ping`: a random install id (16 bytes from `crypto/rand`, stored next to the global config, tied to nothing else), version, `GOOS`/`GOARCH`, and OS version string. That is the complete payload — no conversations, keys, paths, or hardware serials.

Consent posture, since the client is open source and the community rightly cares:

- New `desktop.telemetry` config (default on), toggle in **Settings → Updates → Anonymous usage ping**, disclosed in `desktop/README.md`.
- Dev builds (`version == "dev"`) never ping, so local hacking stays silent.
- Ping failures are silently dropped — telemetry must never surface to the user.

### Device facts on crash reports

`ReportCrash` now attaches coarse machine info — OS version, CPU model, logical cores, RAM — so "only crashes on Windows 11 ARM" patterns become visible. Windows reads `RtlGetVersion`/registry/kernel32, macOS shells out to `sysctl`/`sw_vers`, Linux parses `/proc` + `/etc/os-release`; the parsers are portable and unit-tested.

### `/stats` page on the worker

Basic-auth (password in a worker secret), zero external assets, renders straight from D1: daily active installs + opens (30d), version and platform breakdown (7d distinct installs), recent crash groups. Day-to-day reading needs no SQL; per-day install dedup happens in SQL via `ON CONFLICT (date, install_id)` with an `opens` counter.

## Already deployed and verified live

D1 migrated (`device` column, `pings` table), worker deployed with the second rate-limit binding (30/min for pings vs 5/min for reports), `STATS_PASSWORD` secret set. Verified on production: ping dedup (two pings → one row, `opens = 2`), device JSON stored, `/stats` 200 with auth and 401 without/with wrong password. Smoke rows cleaned.

## Verification

- Root `internal/config` tests pass (round-trip includes the new `telemetry` key); desktop `go vet` + new unit tests pass (install-id stability, ping POST round-trip, dev-build skip, devinfo parsers).
- Frontend `tsc --noEmit`: zero new errors vs baseline. Worker package typechecks clean.

## Notes

- The launch ping is desktop-only for now; a CLI ping would follow the same endpoint if we want it later.
- `crash_app.go` shows as a whole-file diff locally under `gofmt -l` due to CRLF checkout; committed content is LF like the rest of the tree.
