### PR TITLE
fix(desktop): remove duplicate '+' button in TabBar

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1467,7 +1467,6 @@ export default function App() {
               onTabClose={(id) => void handleTabClose(id)}
               onTabsClose={(ids, nextActiveTabId) => void handleTabsClose(ids, nextActiveTabId)}
               onTabsReorder={(ids) => void handleTabsReorder(ids)}
-              onNewTab={() => void handleNewTab()}
             />
             {!workspacePanelMaximized && (
               <Tooltip

--- a/desktop/frontend/src/components/TabBar.tsx
+++ b/desktop/frontend/src/components/TabBar.tsx
@@ -2,11 +2,10 @@
 // open project/global topic, so switching tabs switches the active conversation.
 import { useEffect, useRef, useState } from "react";
 import type { CSSProperties, DragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { FileText, Plus, X } from "lucide-react";
+import { FileText, X } from "lucide-react";
 import type { TabMeta } from "../lib/types";
 import { projectColorValue } from "../lib/projectColors";
 import { useT } from "../lib/i18n";
-import { Tooltip } from "./Tooltip";
 import { ContextMenu, contextMenuPointFromEvent, type ContextMenuItem, type ContextMenuPoint } from "./ContextMenu";
 
 interface TabBarProps {
@@ -16,7 +15,6 @@ interface TabBarProps {
   onTabClose: (tabId: string) => void;
   onTabsClose: (tabIds: string[], nextActiveTabId?: string) => void;
   onTabsReorder: (tabIds: string[]) => void;
-  onNewTab: () => void;
   revealActiveSignal?: number;
 }
 
@@ -50,7 +48,7 @@ function projectAccentStyle(color?: string): CSSProperties | undefined {
   return { "--project-accent": value } as CSSProperties;
 }
 
-export function TabBar({ tabs, activeTabId, onTabChange, onTabClose, onTabsClose, onTabsReorder, onNewTab, revealActiveSignal = 0 }: TabBarProps) {
+export function TabBar({ tabs, activeTabId, onTabChange, onTabClose, onTabsClose, onTabsReorder, revealActiveSignal = 0 }: TabBarProps) {
   const t = useT();
   const [draggingTabId, setDraggingTabId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<{ id: string; side: DropSide } | null>(null);
@@ -250,11 +248,6 @@ export function TabBar({ tabs, activeTabId, onTabChange, onTabClose, onTabsClose
           );
         })}
       </div>
-      <Tooltip label={t("tabBar.newSession")}>
-        <button className="tabbar__new" type="button" aria-label={t("tabBar.newSession")} onClick={onNewTab}>
-          <Plus size={13} />
-        </button>
-      </Tooltip>
       <ContextMenu
         open={Boolean(menuTabId)}
         point={menuPoint}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -33,7 +33,7 @@ export const en = {
   "tabBar.closeTab": "Close tab",
   "tabBar.closeOtherTabs": "Close other tabs",
   "tabBar.closeTabsToRight": "Close tabs to right",
-  "tabBar.newSession": "New session",
+
   "tabBar.tabActions": "Tab actions",
 
   // sidebar

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -34,7 +34,7 @@ export const zh: Record<DictKey, string> = {
   "tabBar.closeTab": "关闭标签页",
   "tabBar.closeOtherTabs": "关闭其他标签页",
   "tabBar.closeTabsToRight": "关闭右侧标签页",
-  "tabBar.newSession": "新建会话",
+
   "tabBar.tabActions": "标签页操作",
 
   // 侧边栏

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9478,25 +9478,6 @@ a[href] {
   color: var(--fg);
 }
 
-.tabbar__new {
-  flex: 0 0 auto;
-  width: 30px;
-  height: 30px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: 1px;
-  border: none;
-  border-radius: 7px;
-  background: transparent;
-  color: var(--fg-dim);
-}
-
-.tabbar__new:hover {
-  background: var(--button-bg);
-  color: var(--fg);
-}
-
 .project-tree {
   --project-tree-action-column: 36px;
   --project-tree-edge-gap: 6px;


### PR DESCRIPTION
## Summary
- Remove the redundant '+' (new session) button from the TabBar component
- The sidebar already has a prominent 'New Session' button, making the TabBar's small '+' button unnecessary
- This simplifies the UI and eliminates user confusion about duplicate functionality

## Changes
- **TabBar.tsx**: Removed the '+' button, its Tooltip wrapper, and the onNewTab prop
- **App.tsx**: Removed the onNewTab prop from TabBar usage
- **styles.css**: Removed the .tabbar__new and .tabbar__new:hover CSS rules
- **en.ts** / **zh.ts**: Cleaned up the unused tabBar.newSession i18n key

## Related Issue
Fixes #3933

## Testing
- TypeScript type check passes (npm run typecheck)
- No new type errors introduced
- The sidebar's 'New Session' button remains functional for creating new sessions
