### PR TITLE
site: footer link to the stats page

### DIFF
--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -159,6 +159,7 @@ allow = ["bash(go test*)"]</div>
         <a href={repo}>GitHub</a>
         <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
         <a href={`${base}/#start`}><span class="l-en">Install</span><span class="l-zh">安装</span></a>
+        <a href="https://crash.reasonix.io/stats" rel="nofollow"><span class="l-en">Stats</span><span class="l-zh">统计</span></a>
       </nav>
     </div>
   </footer>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -305,6 +305,7 @@ const ld = {
         <a href="https://platform.deepseek.com" target="_blank" rel="noreferrer">DeepSeek</a>
         <a href={`${base}/docs/`}><span class="l-en">Docs</span><span class="l-zh">文档</span></a>
         <a href="#start"><span class="l-en">Install</span><span class="l-zh">安装</span></a>
+        <a href="https://crash.reasonix.io/stats" rel="nofollow"><span class="l-en">Stats</span><span class="l-zh">统计</span></a>
       </nav>
     </div>
     <div class="foot-sub">


### PR DESCRIPTION
## What

Adds a low-key "Stats / 统计" link to the site footer (home + docs pages), pointing at the Basic-auth stats page on `crash.reasonix.io/stats` (#3985). The page itself stays password-protected — visitors who click it just see a login prompt; `rel="nofollow"` keeps crawlers from bothering with it.

Verified with a local `astro build`: the link renders in the built footer of both pages.
