### PR TITLE
fix(config): honor default_model in ResolveModelWithFallback before iterating providers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1756,11 +1756,22 @@ func (c *Config) ResolveModel(ref string) (*ProviderEntry, bool) {
 
 // ResolveModelWithFallback resolves a model reference to the canonical
 // "provider/model" form used by the desktop runtime. If ref is stale or empty,
-// it falls back to the first provider with at least one model.
+// it tries the user's configured default_model before falling back to the first
+// configured provider — so preference isn't overwritten by iteration order.
 func (c *Config) ResolveModelWithFallback(ref string) (resolvedRef string, fallback bool, ok bool) {
-	if strings.TrimSpace(ref) != "" {
+	ref = strings.TrimSpace(ref)
+	if ref != "" {
 		if e, found := c.ResolveModel(ref); found {
 			return e.Name + "/" + e.Model, false, true
+		}
+	}
+	// Before falling back to the first configured provider (which may not be the
+	// user's preferred choice), try the configured default_model.  Skip when ref
+	// already WAS the DefaultModel (it already failed above, so retrying won't
+	// help) or when the default provider has no API key configured.
+	if ref != c.DefaultModel && c.DefaultModel != "" {
+		if e, found := c.ResolveModel(c.DefaultModel); found && e.Configured() {
+			return e.Name + "/" + e.Model, true, true
 		}
 	}
 	for i := range c.Providers {

--- a/internal/config/model_fallback_test.go
+++ b/internal/config/model_fallback_test.go
@@ -68,6 +68,45 @@ func TestResolveModelWithFallbackSkipsKeylessProvider(t *testing.T) {
 	}
 }
 
+// TestResolveModelWithFallbackHonorsDefaultModel verifies that when the ref is
+// stale or empty, the function tries c.DefaultModel before iterating providers
+// in order. Without this, the first provider (deepseek, by default) always wins
+// even when the user has configured a different default_model (#3801).
+func TestResolveModelWithFallbackHonorsDefaultModel(t *testing.T) {
+	c := testModelFallbackConfig(t)
+	// Set DefaultModel to prov-b (not the first provider). An empty/stale ref
+	// should fall back to prov-b, not prov-a.
+	c.DefaultModel = "prov-b"
+
+	// Empty ref → must use DefaultModel = prov-b
+	got, fallback, ok := c.ResolveModelWithFallback("")
+	if !ok || !fallback {
+		t.Fatalf("ResolveModelWithFallback(\"\") = (%q, %v, %v), want fallback to prov-b", got, fallback, ok)
+	}
+	if got != "prov-b/model-b1" {
+		t.Errorf("empty ref fallback = %q, want prov-b/model-b1 (DefaultModel)", got)
+	}
+
+	// Stale ref → same: must use DefaultModel
+	got, fallback, ok = c.ResolveModelWithFallback("deleted/model")
+	if !ok || !fallback {
+		t.Fatalf("ResolveModelWithFallback(\"deleted/model\") = (%q, %v, %v), want fallback", got, fallback, ok)
+	}
+	if got != "prov-b/model-b1" {
+		t.Errorf("stale ref fallback = %q, want prov-b/model-b1 (DefaultModel)", got)
+	}
+
+	// DefaultModel pointing to a keyless provider must be skipped
+	c.Providers[1].APIKeyEnv = "REASONIX_TEST_EMPTY" // prov-b, the DefaultModel
+	got, fallback, ok = c.ResolveModelWithFallback("stale/ref")
+	if !ok || !fallback {
+		t.Fatalf("keyless DefaultModel fallback = (%q, %v, %v), want next configured", got, fallback, ok)
+	}
+	if got != "prov-a/model-a1" {
+		t.Errorf("keyless DefaultModel fallback = %q, want prov-a/model-a1 (only configured left)", got)
+	}
+}
+
 func TestModelRefsProvider(t *testing.T) {
 	if !ModelRefsProvider("deepseek-flash", "deepseek-flash") {
 		t.Fatal("bare provider ref should match provider")


### PR DESCRIPTION
## Problem

Fixes #3801

When the user configures a `default_model` (e.g. `glm5`) but that model is not the first provider in iteration order, `ResolveModelWithFallback` ignores it and falls back to the first configured provider instead. This causes new conversations to be assigned the wrong model (e.g. `deepseek-v4-flash`), forcing the user to manually switch every time.

## Root Cause

`ResolveModelWithFallback` had only two paths:
1. Direct resolve the given ref
2. Iterate providers in order and pick the first configured one

There was no check for the user's `DefaultModel` between step 1 and step 2.

## Fix

Added a `DefaultModel` preference check between the direct-resolve and the provider-iteration fallback:

- Try the configured `DefaultModel` first (skip if the stale ref *was* the DefaultModel — it already failed above, so retrying is pointless)
- Skip the DefaultModel provider if it has no API key configured (mirrors the existing `Configured()` gate on the provider-iteration path)
- Fall through to provider iteration only if DefaultModel is unavailable

## Changes

- `internal/config/config.go` — 3-line block added to `ResolveModelWithFallback`
- `internal/config/model_fallback_test.go` — new test `TestResolveModelWithFallbackHonorsDefaultModel` covering empty ref, stale ref, and keyless-default → next-configured chaining

## Verification