### PR TITLE
fix(desktop): compact-mode step fold follow-ups (centering, empty folds, 0s label, thinking flicker)

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -267,12 +267,15 @@ export function TurnActions({
 export const AssistantMessage = memo(function AssistantMessage({
   item,
   defaultExpanded = false,
+  expandWhileStreaming = true,
 }: {
   item: AssistantItem;
   defaultExpanded?: boolean;
+  /** false in compact/minimal: completed steps fold away, so auto-open + fold reads as flicker. */
+  expandWhileStreaming?: boolean;
 }) {
   const t = useT();
-  const [reasoningOpen, setReasoningOpen] = useState(item.streaming || defaultExpanded);
+  const [reasoningOpen, setReasoningOpen] = useState((expandWhileStreaming && item.streaming) || defaultExpanded);
   const hasText = item.streaming || item.text.trim() !== "";
   const processOnly = Boolean(item.reasoning) && !hasText;
   const processWithText = Boolean(item.reasoning) && hasText;

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -18,10 +18,10 @@ type QuestionAnchor = { id: string; text: string; turn: number };
 const QUESTION_NAV_MIN_COUNT = 2;
 const LiveStreamContext = createContext<LiveStream | undefined>(undefined);
 
-const LiveAssistantMessage = memo(function LiveAssistantMessage({ item, defaultExpanded = false }: { item: AssistantItem; defaultExpanded?: boolean }) {
+const LiveAssistantMessage = memo(function LiveAssistantMessage({ item, defaultExpanded = false, expandWhileStreaming = true }: { item: AssistantItem; defaultExpanded?: boolean; expandWhileStreaming?: boolean }) {
   const live = useContext(LiveStreamContext);
   const shown = live && live.id === item.id ? { ...item, text: live.text, reasoning: live.reasoning, streaming: true } : item;
-  return <AssistantMessage item={shown} defaultExpanded={defaultExpanded} />;
+  return <AssistantMessage item={shown} defaultExpanded={defaultExpanded} expandWhileStreaming={expandWhileStreaming} />;
 });
 
 // ── Layer budgets ─────────────────────────────────────────────────────────────
@@ -426,6 +426,7 @@ export function Transcript({
             items={collapseBatch}
             durationMs={dur}
             mode={displayMode}
+            subcalls={subcallsByParent}
           />,
         );
         collapseBatch = [];
@@ -471,7 +472,7 @@ export function Transcript({
           flushReadOnlyBatch();
           switch (it.kind) {
             case "assistant":
-              out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} />);
+              out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} expandWhileStreaming={false} />);
               if (!it.streaming && it.text.trim() !== "") {
                 actionText = it.text;
                 actionReady = true;
@@ -879,30 +880,34 @@ type TurnCollapseProps = {
   items: Item[];       // intermediate items (tools, reasoning, phase)
   durationMs: number;  // summed tool execution time across the batch; 0 when unknown
   mode: DisplayMode;
+  subcalls: Map<string, ToolItem[]>;
 };
 
-function TurnCollapse({ items, durationMs, mode }: TurnCollapseProps) {
+function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) {
   const t = useT();
   const [open, setOpen] = useState(false);
 
-  // In minimal mode, filter to only writer tools + intermediate assistant messages
+  // Keep only items the body will actually render — an expandable fold over
+  // nothing is worse than no fold. Minimal mode strips reasoning, so a
+  // reasoning-only assistant counts as empty there.
   const displayItems = useMemo(() => {
-    if (mode === "minimal") {
-      return items.filter((it) => {
-        if (it.kind === "assistant") return true; // intermediate model replies
-        if (it.kind !== "tool") return false;
-        if (it.name === "bash") return false;       // shell
-        if (it.readOnly) return false;              // read-only tools
-        return true;                                 // writer tools
-      });
-    }
-    return items; // compact mode: show all
+    return items.filter((it) => {
+      if (it.kind === "assistant") {
+        if (it.text.trim() !== "") return true;
+        return mode !== "minimal" && Boolean(it.reasoning);
+      }
+      if (it.kind === "phase") return mode !== "minimal";
+      if (it.kind !== "tool") return false;
+      if (it.parentId || it.name === "todo_write" || it.name === "exit_plan_mode") return false;
+      if (mode === "minimal") return !it.readOnly && it.name !== "bash";
+      return true;
+    });
   }, [items, mode]);
 
-  const hasProcessedBody = displayItems.length > 0;
-  const label = durationMs > 0 ? t("transcript.processedDuration", { s: Math.round(durationMs / 1000) }) : t("transcript.processed");
+  const seconds = Math.round(durationMs / 1000);
+  const label = seconds > 0 ? t("transcript.processedDuration", { s: seconds }) : t("transcript.processed");
 
-  if (!hasProcessedBody) return null;
+  if (displayItems.length === 0) return null;
 
   return (
     <div className={`turn-collapse${open ? " turn-collapse--open" : ""}`}>
@@ -919,7 +924,7 @@ function TurnCollapse({ items, durationMs, mode }: TurnCollapseProps) {
         <div className="turn-collapse__body">
           {displayItems.map((it) => {
             switch (it.kind) {
-              case "tool": return <ToolCard key={it.id} item={it as ToolItem} />;
+              case "tool": return <ToolCard key={it.id} item={it as ToolItem} subcalls={subcalls.get(it.id)} />;
               case "phase": return <PhaseCard key={it.id} text={it.text} />;
               case "assistant": {
                 // In minimal mode, strip reasoning from expanded assistant messages

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2249,7 +2249,8 @@ a[href] {
 
 /* ── TurnCollapse (compact/minimal mode) ─────────────────────────── */
 .turn-collapse {
-  margin: 4px 0;
+  /* horizontal auto keeps the .transcript > * centered column; 0 would override it */
+  margin: 4px auto;
 }
 .turn-collapse__label {
   white-space: nowrap;
@@ -2265,7 +2266,7 @@ a[href] {
 
 /* ── ReadOnly batch (parent fold for read/search tools) ────────────── */
 .readonly-batch {
-  margin: 2px 0;
+  margin: 2px auto;
 }
 .readonly-batch__body {
   display: flex;


### PR DESCRIPTION
Follow-ups to #3991, all in the compact/minimal step-fold path:

1. **Centering** — `.turn-collapse` / `.readonly-batch` set `margin: Npx 0`, which outranks the `.transcript > *` column rule (`max-width + margin auto`) by source order, so folds rendered flush against the pane's left edge. Switch to horizontal `auto` like `.msg`/`.tool` already do.
2. **Empty folds** — the body filter counted reasoning-only assistants as content, but minimal mode strips reasoning on expand, producing a chevron over an empty body. Filter to items the body actually renders and hide the fold when nothing survives; also exclude subcall/todo_write/exit_plan_mode tools to match the live path.
3. **"Processed 0s"** — sub-second batches rounded to a literal "0s". Drop the seconds suffix below 1s.
4. **Thinking open/close flicker** — streaming reasoning auto-expanded, then the completed step immediately folded away, reading as repeated open/close. New `expandWhileStreaming={false}` in the step-group path keeps the shimmer head as the running indicator; the expand-thinking setting still wins.
5. Nested tool calls now show inside expanded folds (`subcalls` threaded through).
