### PR TITLE
fix(evidence): tolerate citation drift when matching complete_step to todos

### DIFF
--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"reasonix/internal/provider"
 )
@@ -344,6 +345,22 @@ func (l *Ledger) MatchLatestTodoStep(step string) (TodoStepMatch, bool) {
 	return TodoStepMatch{}, false
 }
 
+// LatestTodos returns the todo list from this turn's latest successful todo_write.
+func (l *Ledger) LatestTodos() ([]TodoItem, bool) {
+	if l == nil {
+		return nil, false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := len(l.receipts) - 1; i >= 0; i-- {
+		r := l.receipts[i]
+		if r.Success && r.ToolName == "todo_write" {
+			return append([]TodoItem(nil), r.Todos...), true
+		}
+	}
+	return nil, false
+}
+
 // UnverifiedCompletedTodos reports current completed todos that transitioned
 // from the latest prior successful todo_write receipt without a matching
 // successful complete_step receipt earlier in the same turn. If this turn has no
@@ -615,7 +632,7 @@ func sameTodoMatch(todo TodoItem, match TodoStepMatch) bool {
 }
 
 func matchTodoStep(step string, todos []TodoItem) TodoStepMatch {
-	if n, ok := parseStepIndex(step); ok && n >= 1 && n <= len(todos) {
+	if n, ok := parseStepIndex(normalizeStepText(step)); ok && n >= 1 && n <= len(todos) {
 		t := todos[n-1]
 		return TodoStepMatch{Found: true, Index: n, Content: t.Content, Status: t.Status, ActiveForm: t.ActiveForm}
 	}
@@ -624,19 +641,64 @@ func matchTodoStep(step string, todos []TodoItem) TodoStepMatch {
 			return TodoStepMatch{Found: true, Index: i + 1, Content: t.Content, Status: t.Status, ActiveForm: t.ActiveForm}
 		}
 	}
+	// Containment fallback for wording drift; an ambiguous citation (containing
+	// or contained by two different todos) stays unmatched rather than guessing.
+	norm := normalizeStepText(step)
+	found := -1
+	for i, t := range todos {
+		if stepTextContains(norm, normalizeStepText(t.Content)) || stepTextContains(norm, normalizeStepText(t.ActiveForm)) {
+			if found >= 0 && found != i {
+				return TodoStepMatch{}
+			}
+			found = i
+		}
+	}
+	if found >= 0 {
+		t := todos[found]
+		return TodoStepMatch{Found: true, Index: found + 1, Content: t.Content, Status: t.Status, ActiveForm: t.ActiveForm}
+	}
 	return TodoStepMatch{}
 }
 
 func parseStepIndex(step string) (int, bool) {
-	step = strings.TrimSpace(strings.TrimSuffix(step, "."))
+	step = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(step), "."))
 	n, err := strconv.Atoi(step)
 	return n, err == nil
 }
 
+// normalizeStepText folds the drift models introduce when citing a todo:
+// fullwidth ASCII forms → halfwidth (："５ → :"5), all whitespace dropped,
+// case-insensitive.
+func normalizeStepText(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= 0xFF01 && r <= 0xFF5E {
+			r -= 0xFEE0
+		}
+		b.WriteRune(r)
+	}
+	return strings.ToLower(strings.Join(strings.Fields(b.String()), ""))
+}
+
 func sameStepText(a, b string) bool {
-	a = strings.TrimSpace(a)
-	b = strings.TrimSpace(b)
-	return a != "" && b != "" && strings.EqualFold(a, b)
+	na, nb := normalizeStepText(a), normalizeStepText(b)
+	return na != "" && na == nb
+}
+
+// stepTextContains: substring match between normalized texts, but only when the
+// shorter side is substantial enough (≥6 runes) to not match by accident.
+func stepTextContains(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	short := a
+	if utf8.RuneCountInString(b) < utf8.RuneCountInString(a) {
+		short = b
+	}
+	if utf8.RuneCountInString(short) < 6 {
+		return false
+	}
+	return strings.Contains(a, b) || strings.Contains(b, a)
 }
 
 func pathSet(paths []string) map[string]bool {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -207,10 +207,10 @@ func TestMatchTodoStepToleratesCitationDrift(t *testing.T) {
 	})
 
 	matches := map[string]int{
-		"Phase 5: 脚本编辑与执行代码":   2,
+		"Phase 5: 脚本编辑与执行代码":  2,
 		"phase 5：脚本编辑与执行代码":   2,
 		"  Phase　5：脚本编辑与执行代码": 2,
-		"脚本编辑与执行代码":          2,
+		"脚本编辑与执行代码":           2,
 		"Phase 4：环境":          1,
 		"REVIEW NOTES":        3,
 		"２":                   2,

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -192,6 +192,64 @@ func TestLedgerMatchesLatestSuccessfulTodoStep(t *testing.T) {
 	}
 }
 
+func TestMatchTodoStepToleratesCitationDrift(t *testing.T) {
+	// Verbatim shape from discussion #3970: todo authored with a fullwidth
+	// colon, cited back with a halfwidth one — and stuck forever.
+	ledger := NewLedger()
+	ledger.Record(Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []TodoItem{
+			{Content: "Phase 4：环境准备", Status: "completed"},
+			{Content: "Phase 5：脚本编辑与执行代码", Status: "in_progress"},
+			{Content: "Review notes", Status: "pending"},
+		},
+	})
+
+	matches := map[string]int{
+		"Phase 5: 脚本编辑与执行代码":   2,
+		"phase 5：脚本编辑与执行代码":   2,
+		"  Phase　5：脚本编辑与执行代码": 2,
+		"脚本编辑与执行代码":          2,
+		"Phase 4：环境":          1,
+		"REVIEW NOTES":        3,
+		"２":                   2,
+	}
+	for step, want := range matches {
+		match, ok := ledger.MatchLatestTodoStep(step)
+		if !ok || !match.Found {
+			t.Fatalf("step %q should match todo %d, got found=%v", step, want, match.Found)
+		}
+		if match.Index != want {
+			t.Errorf("step %q matched todo %d, want %d", step, match.Index, want)
+		}
+	}
+
+	for _, step := range []string{"deploy backend", "代码", "Phase 9：不存在的阶段"} {
+		if match, _ := ledger.MatchLatestTodoStep(step); match.Found {
+			t.Errorf("step %q should not match, got todo %d (%q)", step, match.Index, match.Content)
+		}
+	}
+}
+
+func TestMatchTodoStepAmbiguousContainmentStaysUnmatched(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Record(Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []TodoItem{
+			{Content: "Deploy backend service", Status: "in_progress"},
+			{Content: "Deploy backend worker", Status: "pending"},
+		},
+	})
+	if match, _ := ledger.MatchLatestTodoStep("Deploy backend"); match.Found {
+		t.Fatalf("ambiguous citation should stay unmatched, got todo %d (%q)", match.Index, match.Content)
+	}
+	if match, _ := ledger.MatchLatestTodoStep("Deploy backend worker"); !match.Found || match.Index != 2 {
+		t.Fatal("exact citation must still resolve despite shared prefix")
+	}
+}
+
 func TestLedgerRequiresCompleteStepForNewCompletedTodos(t *testing.T) {
 	ledger := NewLedger()
 	ledger.Record(Receipt{

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -236,7 +236,7 @@ func verifyTodoStep(ctx context.Context, step string) (evidence.TodoStepMatch, b
 		return evidence.TodoStepMatch{}, false, nil
 	}
 	if !match.Found {
-		return evidence.TodoStepMatch{}, true, fmt.Errorf("step %q has no matching todo_write item in this turn", step)
+		return evidence.TodoStepMatch{}, true, fmt.Errorf("step %q has no matching todo_write item in this turn; cite a todo verbatim or by number: %s", step, todoInventory(ledger))
 	}
 	switch match.Status {
 	case "", "pending", "in_progress", "completed":
@@ -244,6 +244,26 @@ func verifyTodoStep(ctx context.Context, step string) (evidence.TodoStepMatch, b
 	default:
 		return evidence.TodoStepMatch{}, true, fmt.Errorf("step %q matches todo %d (%q) but its status is %q; complete_step requires pending, in_progress, or completed", step, match.Index, match.Content, match.Status)
 	}
+}
+
+func todoInventory(ledger *evidence.Ledger) string {
+	todos, ok := ledger.LatestTodos()
+	if !ok || len(todos) == 0 {
+		return "(no todos recorded this turn)"
+	}
+	parts := make([]string, 0, len(todos))
+	for i, t := range todos {
+		content := t.Content
+		if r := []rune(content); len(r) > 60 {
+			content = string(r[:60]) + "…"
+		}
+		parts = append(parts, fmt.Sprintf("%d) %q", i+1, content))
+		if len(parts) == 12 && len(todos) > 12 {
+			parts = append(parts, fmt.Sprintf("… %d more", len(todos)-12))
+			break
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // verifyCommandFromSession scans the full conversation history (not just the

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -11,6 +11,22 @@ import (
 	"reasonix/internal/provider"
 )
 
+func TestTodoInventoryListsTurnTodos(t *testing.T) {
+	ledger := evidence.NewLedger()
+	ledger.Record(evidence.Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos:    []evidence.TodoItem{{Content: "Phase 5：脚本编辑与执行代码"}, {Content: "Review notes"}},
+	})
+	got := todoInventory(ledger)
+	if !strings.Contains(got, `1) "Phase 5：脚本编辑与执行代码"`) || !strings.Contains(got, `2) "Review notes"`) {
+		t.Fatalf("inventory should list both todos, got %s", got)
+	}
+	if got := todoInventory(evidence.NewLedger()); !strings.Contains(got, "no todos") {
+		t.Fatalf("empty ledger inventory = %s", got)
+	}
+}
+
 func TestCompleteStepRejectsMissingEvidence(t *testing.T) {
 	_, err := completeStep{}.Execute(context.Background(),
 		json.RawMessage(`{"step":"Add the parser","result":"parser added","evidence":[]}`))


### PR DESCRIPTION
## Problem

Discussion #3970: the plan completes but the todo list never updates, and in the worst case the model loops on `complete_step` retries — each one rejected with `step "Phase 5：脚本编辑与执行代码" has no matching todo_write item in this turn` — quietly burning tokens.

Root cause is exactly what the reporter guessed: `matchTodoStep` required byte-exact (case-folded) equality between the cited step and a todo's text. Any drift — fullwidth `：` cited back as halfwidth `: `, an extra space, a wording subset — could never match, and nothing in the error told the model how to fix its citation, so it retried the same string forever. #3982 fixed this disease for command citations; the todo-text limb still had it.

## Fix

- **Normalize before comparing**: fullwidth ASCII forms → halfwidth, whitespace dropped, case-folded. The reported case (`Phase 5：` vs `Phase 5: `) now matches.
- **Unique-containment fallback**: a citation that is a substring of exactly one todo (or vice versa, shorter side ≥ 6 runes) resolves to it; if it would match two todos, it stays unmatched rather than guessing.
- **Actionable rejection**: the error now lists this turn's todos (`cite a todo verbatim or by number: 1) "…", 2) "…"`), the same receipts-in-error pattern that let models self-correct within 1–2 turns in #3982's A/B run.

## Tests

- Verbatim #3970 shape: fullwidth-colon todo cited with halfwidth colon, plus case/whitespace/U+3000/subset/fullwidth-digit-index variants.
- Negative cases: unrelated text, too-short containment, ambiguous shared-prefix citations stay unmatched while exact ones still resolve.
- `todoInventory` lists todos and degrades cleanly on an empty ledger.

`go test ./internal/evidence/... ./internal/tool/builtin/...` passes.

Addresses the remaining half of discussion #3970; #3982 covered the command-citation half.
