### PR TITLE
fix(chat): render correct line count under each parallel bash marker

### DIFF
--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -37,6 +37,7 @@ func newTestChatTUI() chatTUI {
 		shellOutputs:         shellOut,
 		shellExpanded:        shellExp,
 		shellTranscriptIdx:   shellIdx,
+		toolLineCountByID:    map[string]int{},
 	}
 }
 

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -161,11 +161,21 @@ type chatTUI struct {
 	// shellTranscriptIdx maps a shell tool ID to the transcript index of its
 	// collapsed output block, so Ctrl+B can rewrite it in place.
 	shellTranscriptIdx map[string]int
+	// toolLineCountByID records the last line count a streamed tool emitted
+	// (toolLineCount + (toolPartial != "")), keyed by the tool's call id. When
+	// streamToolOutput switches to a new id the old one's live tail/lineCount
+	// get reset; this map keeps the old count so collapseShellSlot's late
+	// path can still render the correct "⎿ N lines" summary for a non-
+	// streaming-prefixed tool (e.g. DeepSeek-scheduled bash with id "call_N")
+	// whose ToolResult arrives after another tool has taken over. Without
+	// it, late collapse would fall through to "⎿ -1 lines" because the
+	// shellOutputs accumulator is restricted to "shell-" ids.
 	// toolStreamStart / toolStreamFrame drive the "⎿ working · Ns" line shown
 	// under a dispatched tool that hasn't produced output yet, so a slow tool
 	// (e.g. codegraph_context) reads as making progress rather than frozen.
-	toolStreamStart time.Time
-	toolStreamFrame int
+	toolLineCountByID map[string]int
+	toolStreamStart   time.Time
+	toolStreamFrame   int
 	transcriptDirty bool
 	eventCh         chan event.Event
 	started         bool // banner + resumed history committed once
@@ -470,6 +480,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		shellOutputs:         make(map[string]string),
 		shellExpanded:        make(map[string]bool),
 		shellTranscriptIdx:   make(map[string]int),
+		toolLineCountByID:    make(map[string]int),
 		eventCh:              eventCh,
 		history:              ctrl.History(),
 		host:                 ctrl.Host(),
@@ -1659,13 +1670,33 @@ func (m *chatTUI) streamToolOutput(id, chunk string) {
 		//       already wrote for that id, so the live block stays directly
 		//       under the earlier tool's card rather than stacking at the end.
 		if existingIdx, ok := m.shellTranscriptIdx[id]; ok && existingIdx >= 0 && existingIdx < len(m.transcript) {
+			// Preserve the previous id's line count before we reset the
+			// streaming state. The transcript slot is still on screen
+			// with the old tail; when its ToolResult eventually arrives,
+			// collapseShellSlot's late path will use this count to render
+			// the correct "⎿ N lines" summary — the same value the active
+			// path would have computed had the result landed before
+			// another tool's progress pre-empted the stream.
+			if m.toolStreamID != "" && m.toolStreamID != id {
+				n := m.toolLineCount
+				if m.toolPartial != "" {
+					n++
+				}
+				if n > 0 {
+					m.toolLineCountByID[m.toolStreamID] = n
+				}
+			}
 			m.toolStreamID = id
 			m.toolStreamIdx = existingIdx
 			m.toolTail = m.toolTail[:0]
 			m.toolPartial = ""
 			m.toolLineCount = 0
 		} else {
-			m.collapseToolOutput(m.toolStreamID)
+			// Unknown id (not in shellTranscriptIdx). Collapse the
+			// currently-active stream with no result output — the
+			// active path still has the live line count, so this is
+			// only ever reached when a tool never produced output.
+			m.collapseToolOutput(m.toolStreamID, "")
 			m.toolStreamID = id
 			m.toolTail = m.toolTail[:0]
 			m.toolPartial = ""
@@ -1724,8 +1755,13 @@ func (m *chatTUI) pushToolLine(line string) {
 // "⎿ N lines" summary, so the scrollback keeps a marker of the run without the
 // full output (which the model already received). For shell commands ("shell-"
 // prefix), it shows the first shellPreviewLines with a Ctrl+B hint instead.
-// No-op when id isn't streaming.
-func (m *chatTUI) collapseToolOutput(id string) {
+// No-op when id isn't streaming. resultOutput is the tool's final output
+// (from the ToolResult event) and is the last-resort source of truth for
+// the line count when neither the live streaming state nor shellOutputs
+// have anything — e.g. a back-to-back bash tool whose progress arrived
+// after the slot was already overtaken by another tool, or one that
+// never streamed at all and the result is the only signal.
+func (m *chatTUI) collapseToolOutput(id, resultOutput string) {
 	if m.nativeScrollback {
 		if id == "" || m.toolStreamID != id {
 			return
@@ -1770,13 +1806,16 @@ func (m *chatTUI) collapseToolOutput(id string) {
 		// still have a transcript index for it — set by beginToolRunning
 		// when the dispatch landed — collapse in place so a late
 		// ToolResult for a back-to-back tool doesn't leave the previous
-		// tool's live block as raw streamed text.
+		// tool's live block as raw streamed text. Pass resultOutput so
+		// collapseShellSlot has the tool's final output as a last-resort
+		// source for the line count when neither the live state nor
+		// shellOutputs know about this id.
 		if idx, ok := m.shellTranscriptIdx[id]; ok && idx >= 0 && idx < len(m.transcript) {
-			m.collapseShellSlot(id, idx)
+			m.collapseShellSlot(id, idx, resultOutput)
 		}
 		return
 	}
-	m.collapseShellSlot(id, m.toolStreamIdx)
+	m.collapseShellSlot(id, m.toolStreamIdx, resultOutput)
 	m.toolStreamIdx = -1
 	m.toolStreamID = ""
 	m.toolTail = m.toolTail[:0]
@@ -1790,24 +1829,44 @@ func (m *chatTUI) collapseToolOutput(id string) {
 // tool was first dispatched). The active path uses the live streaming
 // state (m.toolLineCount + m.toolPartial) for the line count; the late
 // path derives it from the accumulated shellOutputs map (only populated
-// for "shell-" prefixed ids), since toolTail/toolLineCount are reset
-// whenever a new tool takes over via beginToolRunning.
-func (m *chatTUI) collapseShellSlot(id string, idx int) {
+// for "shell-" prefixed ids), then the per-id line count captured by
+// streamToolOutput (call_N-style ids that stream but aren't "shell-"),
+// then the final output carried by the ToolResult event itself — the
+// tool-tail line count is reset whenever a new tool takes over via
+// beginToolRunning, so without these fallbacks a late collapse would
+// either render "⎿ -1 lines" or blank the slot. Sets transcriptDirty
+// so the rewritten slot paints immediately, not on the next unrelated
+// event.
+func (m *chatTUI) collapseShellSlot(id string, idx int, resultOutput string) {
 	m.transcriptDirty = true
 	n := -1
 	if id == m.toolStreamID {
+		// Active path. The live streaming line count reflects the chunks
+		// already rendered into the working block. When the ToolResult
+		// also carries a final output (e.g. the last chunk of a slow
+		// tool arrived in the same call as the result, or the result is
+		// the only signal we ever get for a tool that never streamed
+		// its progress) prefer the larger of the two: resultOutput is
+		// the authoritative end-state. toolLineCount + toolPartial is
+		// the live state and may be lower.
 		n = m.toolLineCount
 		if m.toolPartial != "" {
 			n++
 		}
+		if resultOutput != "" {
+			fromResult := len(strings.Split(strings.TrimRight(resultOutput, "\n"), "\n"))
+			if fromResult > n {
+				n = fromResult
+			}
+		}
 	}
 	if n < 0 {
-		// Late-result path. shellOutputs is the most reliable record of
-		// what the tool actually emitted, but it's only populated for
-		// shell-prefixed ids; for other tools we fall back to leaving
-		// the slot blank.
 		if full, ok := m.shellOutputs[id]; ok {
 			n = len(strings.Split(strings.TrimRight(full, "\n"), "\n"))
+		} else if c, ok := m.toolLineCountByID[id]; ok {
+			n = c
+		} else if resultOutput != "" {
+			n = len(strings.Split(strings.TrimRight(resultOutput, "\n"), "\n"))
 		}
 	}
 	if n < 0 {
@@ -3306,8 +3365,10 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 	case event.ToolResult:
 		// A successful result is silent (it only feeds the model); a blocked/failed
 		// call surfaces a red "⏺ Verb ⊘ <reason>" card. A live-output block (bash)
-		// collapses to a one-line "⎿ N lines" summary first.
-		m.collapseToolOutput(e.Tool.ID)
+		// collapses to a one-line "⎿ N lines" summary first. Pass the final
+		// output so collapseToolOutput has a last-resort source for the line
+		// count when the live state was already reset by a back-to-back tool.
+		m.collapseToolOutput(e.Tool.ID, e.Tool.Output)
 		if e.Tool.Name == "todo_write" && e.Tool.Err == "" {
 			m.todoArgs = e.Tool.Args
 		}
@@ -3399,7 +3460,7 @@ func (m *chatTUI) ingestEvent(e event.Event) {
 // finalizeStreamed freezes any in-progress reasoning + answer into scrollback so
 // a following event line lands after them, preserving chronological order.
 func (m *chatTUI) finalizeStreamed() {
-	m.collapseToolOutput(m.toolStreamID)
+	m.collapseToolOutput(m.toolStreamID, "")
 	m.commitReasoning()
 	m.commitPending()
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -161,21 +161,14 @@ type chatTUI struct {
 	// shellTranscriptIdx maps a shell tool ID to the transcript index of its
 	// collapsed output block, so Ctrl+B can rewrite it in place.
 	shellTranscriptIdx map[string]int
-	// toolLineCountByID records the last line count a streamed tool emitted
-	// (toolLineCount + (toolPartial != "")), keyed by the tool's call id. When
-	// streamToolOutput switches to a new id the old one's live tail/lineCount
-	// get reset; this map keeps the old count so collapseShellSlot's late
-	// path can still render the correct "⎿ N lines" summary for a non-
-	// streaming-prefixed tool (e.g. DeepSeek-scheduled bash with id "call_N")
-	// whose ToolResult arrives after another tool has taken over. Without
-	// it, late collapse would fall through to "⎿ -1 lines" because the
-	// shellOutputs accumulator is restricted to "shell-" ids.
+	// toolLineCountByID keeps a switched-away tool's last line count so a late
+	// ToolResult can still render "⎿ N lines" (shellOutputs only tracks "shell-" ids).
+	toolLineCountByID map[string]int
 	// toolStreamStart / toolStreamFrame drive the "⎿ working · Ns" line shown
 	// under a dispatched tool that hasn't produced output yet, so a slow tool
 	// (e.g. codegraph_context) reads as making progress rather than frozen.
-	toolLineCountByID map[string]int
-	toolStreamStart   time.Time
-	toolStreamFrame   int
+	toolStreamStart time.Time
+	toolStreamFrame int
 	transcriptDirty bool
 	eventCh         chan event.Event
 	started         bool // banner + resumed history committed once
@@ -1670,13 +1663,8 @@ func (m *chatTUI) streamToolOutput(id, chunk string) {
 		//       already wrote for that id, so the live block stays directly
 		//       under the earlier tool's card rather than stacking at the end.
 		if existingIdx, ok := m.shellTranscriptIdx[id]; ok && existingIdx >= 0 && existingIdx < len(m.transcript) {
-			// Preserve the previous id's line count before we reset the
-			// streaming state. The transcript slot is still on screen
-			// with the old tail; when its ToolResult eventually arrives,
-			// collapseShellSlot's late path will use this count to render
-			// the correct "⎿ N lines" summary — the same value the active
-			// path would have computed had the result landed before
-			// another tool's progress pre-empted the stream.
+			// Stash the switched-away id's live count before resetting it;
+			// its late ToolResult reads it back via toolLineCountByID.
 			if m.toolStreamID != "" && m.toolStreamID != id {
 				n := m.toolLineCount
 				if m.toolPartial != "" {
@@ -1692,10 +1680,7 @@ func (m *chatTUI) streamToolOutput(id, chunk string) {
 			m.toolPartial = ""
 			m.toolLineCount = 0
 		} else {
-			// Unknown id (not in shellTranscriptIdx). Collapse the
-			// currently-active stream with no result output — the
-			// active path still has the live line count, so this is
-			// only ever reached when a tool never produced output.
+			// Unknown id: collapse the active stream (its live count is intact).
 			m.collapseToolOutput(m.toolStreamID, "")
 			m.toolStreamID = id
 			m.toolTail = m.toolTail[:0]
@@ -1755,12 +1740,8 @@ func (m *chatTUI) pushToolLine(line string) {
 // "⎿ N lines" summary, so the scrollback keeps a marker of the run without the
 // full output (which the model already received). For shell commands ("shell-"
 // prefix), it shows the first shellPreviewLines with a Ctrl+B hint instead.
-// No-op when id isn't streaming. resultOutput is the tool's final output
-// (from the ToolResult event) and is the last-resort source of truth for
-// the line count when neither the live streaming state nor shellOutputs
-// have anything — e.g. a back-to-back bash tool whose progress arrived
-// after the slot was already overtaken by another tool, or one that
-// never streamed at all and the result is the only signal.
+// No-op when id isn't streaming. resultOutput (the ToolResult's final output)
+// is the last-resort line-count source when the live state was already reset.
 func (m *chatTUI) collapseToolOutput(id, resultOutput string) {
 	if m.nativeScrollback {
 		if id == "" || m.toolStreamID != id {
@@ -1801,15 +1782,9 @@ func (m *chatTUI) collapseToolOutput(id, resultOutput string) {
 		return
 	}
 	if m.toolStreamIdx < 0 || id == "" || m.toolStreamID != id {
-		// The slot is no longer active (e.g. another tool has since taken
-		// over via beginToolRunning, or this id was never streamed). If we
-		// still have a transcript index for it — set by beginToolRunning
-		// when the dispatch landed — collapse in place so a late
-		// ToolResult for a back-to-back tool doesn't leave the previous
-		// tool's live block as raw streamed text. Pass resultOutput so
-		// collapseShellSlot has the tool's final output as a last-resort
-		// source for the line count when neither the live state nor
-		// shellOutputs know about this id.
+		// Slot no longer active (another tool took over, or this id never
+		// streamed). If beginToolRunning recorded a transcript index, collapse
+		// in place so a late ToolResult doesn't leave raw streamed text behind.
 		if idx, ok := m.shellTranscriptIdx[id]; ok && idx >= 0 && idx < len(m.transcript) {
 			m.collapseShellSlot(id, idx, resultOutput)
 		}
@@ -1824,31 +1799,16 @@ func (m *chatTUI) collapseToolOutput(id, resultOutput string) {
 }
 
 // collapseShellSlot finalises a tool's live block at idx. Used both by the
-// active-tool path (idx == toolStreamIdx, with the streaming state intact)
-// and the late-result path (idx was recorded in shellTranscriptIdx when the
-// tool was first dispatched). The active path uses the live streaming
-// state (m.toolLineCount + m.toolPartial) for the line count; the late
-// path derives it from the accumulated shellOutputs map (only populated
-// for "shell-" prefixed ids), then the per-id line count captured by
-// streamToolOutput (call_N-style ids that stream but aren't "shell-"),
-// then the final output carried by the ToolResult event itself — the
-// tool-tail line count is reset whenever a new tool takes over via
-// beginToolRunning, so without these fallbacks a late collapse would
-// either render "⎿ -1 lines" or blank the slot. Sets transcriptDirty
-// so the rewritten slot paints immediately, not on the next unrelated
-// event.
+// active-tool path (idx == toolStreamIdx, streaming state intact) and the
+// late-result path (idx recorded in shellTranscriptIdx at dispatch). Line-count
+// sources, in order: live streaming state, shellOutputs ("shell-" ids only),
+// the per-id count stashed by streamToolOutput, then the ToolResult's output.
 func (m *chatTUI) collapseShellSlot(id string, idx int, resultOutput string) {
 	m.transcriptDirty = true
 	n := -1
 	if id == m.toolStreamID {
-		// Active path. The live streaming line count reflects the chunks
-		// already rendered into the working block. When the ToolResult
-		// also carries a final output (e.g. the last chunk of a slow
-		// tool arrived in the same call as the result, or the result is
-		// the only signal we ever get for a tool that never streamed
-		// its progress) prefer the larger of the two: resultOutput is
-		// the authoritative end-state. toolLineCount + toolPartial is
-		// the live state and may be lower.
+		// Prefer the larger of the live count and resultOutput: resultOutput
+		// is the authoritative end-state, the live state may lag behind it.
 		n = m.toolLineCount
 		if m.toolPartial != "" {
 			n++
@@ -1870,26 +1830,13 @@ func (m *chatTUI) collapseShellSlot(id string, idx int, resultOutput string) {
 		}
 	}
 	if n < 0 {
-		// No shellOutputs and the live state doesn't apply — e.g. a
-		// late ToolResult for a back-to-back read_file (no shellOutputs
-		// ever populated because the id lacks the "shell-" prefix), or
-		// a shell- tool whose result arrived with no prior
-		// ToolProgress chunks. Without this guard the n == 0 branch
-		// below would miss and the final else would render
-		// "⎿ -1 lines". Treat the unknown as zero output: clear the
-		// slot rather than fabricate a count. The id is still recorded
-		// in shellTranscriptIdx (set by beginToolRunning), so a late
-		// ToolProgress could still land here if one ever arrives.
+		// Nothing applies (e.g. a late result for a non-"shell-" id that never
+		// streamed): treat as zero rather than fabricate a "-1 lines" count.
 		n = 0
 	}
 	if n == 0 {
-		// The live block was a "working…" placeholder for a tool that
-		// finished with no output. Clear the rendered text so "working"
-		// disappears from scrollback, but keep the slot in place: the
-		// transcript index is still recorded in shellTranscriptIdx so a
-		// late ToolProgress for this id can land here. If no late
-		// progress ever arrives, this slot becomes a blank line — visible
-		// but harmless.
+		// Tool finished with no output: clear the "working…" placeholder but
+		// keep the slot (shellTranscriptIdx still points here for late progress).
 		m.transcript[idx] = ""
 		return
 	}

--- a/internal/cli/consecutive_tool_markers_test.go
+++ b/internal/cli/consecutive_tool_markers_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+// TestParallelBashMarkersKeepOwnLineCount reproduces the DeepSeek-scheduled
+// parallel bash case: 3 Bash(ls) dispatched in one turn, each tool id is
+// "call_<n>" (no "shell-" prefix), each streams its own 22-line output, each
+// finishes with a ToolResult. The transcript must show three cards, each
+// followed by its own "⎿ 22 lines" marker — not "⎿ -1 lines" or a blank
+// line, and not all three markers stacked under the last card.
+//
+// Root cause: streamToolOutput reset the active id's toolLineCount on every
+// switch, and collapseShellSlot's late path only had shellOutputs[id] to
+// recover it from (and shellOutputs is only populated for "shell-" prefixed
+// ids). For call_N-style ids n fell through to -1 and the final else branch
+// rendered "⎿ -1 lines" (or, with a defensive n<0=0 guard, the slot was
+// blanked). Fix: streamToolOutput now stashes the per-id line count before
+// resetting, and collapseShellSlot also accepts the ToolResult's final
+// output as a last-resort source.
+func TestParallelBashMarkersKeepOwnLineCount(t *testing.T) {
+	m := newTestChatTUI()
+	ids := []string{"call_1", "call_2", "call_3"}
+	for _, id := range ids {
+		m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: id, Name: "bash", Partial: true}})
+	}
+	for _, id := range ids {
+		m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: id, Name: "bash", Args: `{"command":"ls"}`, Partial: false}})
+	}
+	for _, id := range ids {
+		for i := 0; i < 22; i++ {
+			m.ingestEvent(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: id, Output: "line\n"}})
+		}
+	}
+	for _, id := range ids {
+		m.ingestEvent(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: id, Name: "bash", Output: strings.Repeat("line\n", 22)}})
+	}
+	transcript := m.transcript
+	if joined := strings.Join(transcript, "\n"); strings.Contains(joined, "-1 lines") {
+		t.Fatalf("transcript must not contain a negative line count:\n%s", joined)
+	}
+	// Locate each card and assert the marker directly below it contains the
+	// correct line count. With 22 lines of output per call the summary is
+	// "⎿ 22 lines".
+	cardIdx := map[string]int{}
+	for i, ln := range transcript {
+		if idx, ok := cardIdx["c1"]; !ok && strings.Contains(ln, "Bash(ls)") {
+			_ = idx
+			if _, seen := cardIdx["c1"]; !seen {
+				cardIdx["c1"] = i
+				continue
+			}
+		}
+		if _, seen := cardIdx["c2"]; !seen && len(cardIdx) == 1 && strings.Contains(ln, "Bash(ls)") {
+			cardIdx["c2"] = i
+			continue
+		}
+		if _, seen := cardIdx["c3"]; !seen && len(cardIdx) == 2 && strings.Contains(ln, "Bash(ls)") {
+			cardIdx["c3"] = i
+		}
+	}
+	if len(cardIdx) != 3 {
+		t.Fatalf("expected three bash cards in transcript, got %v\n%s", cardIdx, strings.Join(transcript, "\n"))
+	}
+	for name, idx := range cardIdx {
+		marker := transcript[idx+1]
+		if !strings.Contains(marker, "⎿") {
+			t.Fatalf("%s: marker slot at transcript[%d] should contain ⎿, got %q\nfull transcript:\n%s",
+				name, idx+1, marker, strings.Join(transcript, "\n"))
+		}
+		if !strings.Contains(marker, "22 lines") {
+			t.Fatalf("%s: marker slot at transcript[%d] should report 22 lines, got %q\nfull transcript:\n%s",
+				name, idx+1, marker, strings.Join(transcript, "\n"))
+		}
+	}
+}
+
+// TestNonShellToolLateResultShowsCorrectCount is the no-streaming variant
+// of the parallel-tool regression: a second Bash dispatches before the
+// first has produced any ToolProgress, and the first's ToolResult arrives
+// last. The slot must still end with a "⎿ N lines" marker (driven by the
+// ToolResult's own Output) — not "-1 lines" and not blank.
+func TestNonShellToolLateResultShowsCorrectCount(t *testing.T) {
+	m := newTestChatTUI()
+	m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "call_a", Name: "bash", Args: `{"command":"echo a"}`}})
+	m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "call_b", Name: "bash", Args: `{"command":"echo b"}`}})
+	// No ToolProgress for either; the result is the only signal.
+	m.ingestEvent(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "call_a", Name: "bash", Output: "a\nsecond\nthird\n"}})
+	m.ingestEvent(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "call_b", Name: "bash", Output: "b\n"}})
+	transcript := m.transcript
+	joined := strings.Join(transcript, "\n")
+	if strings.Contains(joined, "-1 lines") {
+		t.Fatalf("transcript must not contain a negative line count:\n%s", joined)
+	}
+	wantSubstrings := map[string]string{
+		"call_a": "3 lines", // a\nsecond\nthird\n → 3 lines
+		"call_b": "1 lines", // b\n → 1 line
+	}
+	cardIdx := map[string]int{}
+	for i, ln := range transcript {
+		if strings.Contains(ln, "echo a") {
+			cardIdx["call_a"] = i
+		}
+		if strings.Contains(ln, "echo b") {
+			cardIdx["call_b"] = i
+		}
+	}
+	for id, want := range wantSubstrings {
+		idx, ok := cardIdx[id]
+		if !ok {
+			t.Fatalf("missing %s card in transcript:\n%s", id, joined)
+		}
+		marker := transcript[idx+1]
+		if !strings.Contains(marker, "⎿") {
+			t.Fatalf("%s: marker at transcript[%d] should contain ⎿, got %q", id, idx+1, marker)
+		}
+		if !strings.Contains(marker, want) {
+			t.Fatalf("%s: marker at transcript[%d] should report %s, got %q", id, idx+1, want, marker)
+		}
+	}
+}

--- a/internal/cli/consecutive_tool_markers_test.go
+++ b/internal/cli/consecutive_tool_markers_test.go
@@ -7,21 +7,10 @@ import (
 	"reasonix/internal/event"
 )
 
-// TestParallelBashMarkersKeepOwnLineCount reproduces the DeepSeek-scheduled
-// parallel bash case: 3 Bash(ls) dispatched in one turn, each tool id is
-// "call_<n>" (no "shell-" prefix), each streams its own 22-line output, each
-// finishes with a ToolResult. The transcript must show three cards, each
-// followed by its own "⎿ 22 lines" marker — not "⎿ -1 lines" or a blank
-// line, and not all three markers stacked under the last card.
-//
-// Root cause: streamToolOutput reset the active id's toolLineCount on every
-// switch, and collapseShellSlot's late path only had shellOutputs[id] to
-// recover it from (and shellOutputs is only populated for "shell-" prefixed
-// ids). For call_N-style ids n fell through to -1 and the final else branch
-// rendered "⎿ -1 lines" (or, with a defensive n<0=0 guard, the slot was
-// blanked). Fix: streamToolOutput now stashes the per-id line count before
-// resetting, and collapseShellSlot also accepts the ToolResult's final
-// output as a last-resort source.
+// 3 parallel Bash(ls) in one turn, ids "call_<n>" (no "shell-" prefix), each
+// streams 22 lines then finishes. Every card must keep its own "⎿ 22 lines"
+// marker. Regression: collapseShellSlot's late path recovered the count only
+// from shellOutputs ("shell-" ids), so call_N ids fell through to "-1 lines".
 func TestParallelBashMarkersKeepOwnLineCount(t *testing.T) {
 	m := newTestChatTUI()
 	ids := []string{"call_1", "call_2", "call_3"}
@@ -79,11 +68,9 @@ func TestParallelBashMarkersKeepOwnLineCount(t *testing.T) {
 	}
 }
 
-// TestNonShellToolLateResultShowsCorrectCount is the no-streaming variant
-// of the parallel-tool regression: a second Bash dispatches before the
-// first has produced any ToolProgress, and the first's ToolResult arrives
-// last. The slot must still end with a "⎿ N lines" marker (driven by the
-// ToolResult's own Output) — not "-1 lines" and not blank.
+// No-streaming variant: a second Bash dispatches before the first emits any
+// ToolProgress, and the first's result lands last. The slot must still show
+// "⎿ N lines" driven by the ToolResult's own Output, not "-1 lines" or blank.
 func TestNonShellToolLateResultShowsCorrectCount(t *testing.T) {
 	m := newTestChatTUI()
 	m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: "call_a", Name: "bash", Args: `{"command":"echo a"}`}})


### PR DESCRIPTION
Parallel `call_N`-style bash tools (DeepSeek schedules several in one turn) were
losing their per-call line count: `streamToolOutput` reset the active id's
`toolLineCount` on every switch, and `collapseShellSlot`'s late path could only
recover it from `shellOutputs`, which is populated for `"shell-"` ids only. For
`call_N` ids the count fell through to `-1`, so each card rendered `⎿ -1 lines`
(or a blank slot) instead of its real count.

Fix: `streamToolOutput` stashes the per-id line count before resetting, and
`collapseShellSlot` also accepts the `ToolResult`'s final output as a
last-resort source. Adds two regression tests.

Supersedes #4003 by @CnsMaple (the original fork branch couldn't take a
maintainer push for the gofmt/comment cleanup). Credit to @CnsMaple for the fix.

Closes #4003
