### PR TITLE
fix(evidence): allow rephrased todos to pass complete_step verification

### DIFF
--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -606,7 +606,14 @@ func hasSuccessfulCompleteStepForTodo(receipts []Receipt, index int, current []T
 			if index >= 1 && index <= len(current) && sameTodoMatch(current[index-1], *r.TodoStep) {
 				return true
 			}
-			continue
+			// sameTodoMatch failed — the todo content changed.
+			// Allow the fallback (matchTodoStep by index or text) only
+			// when the old and new content are recognisably related
+			// (substring overlap); otherwise block a replaced todo
+			// from reusing an old numeric complete_step receipt.
+			if !todoContentRelates(current[index-1], *r.TodoStep) {
+				continue
+			}
 		}
 		match := matchTodoStep(r.Step, current)
 		if match.Found && match.Index == index {
@@ -629,6 +636,33 @@ func latestTodoStep(step string, receipts []Receipt) TodoStepMatch {
 
 func sameTodoMatch(todo TodoItem, match TodoStepMatch) bool {
 	return sameStepText(todo.Content, match.Content) || sameStepText(todo.ActiveForm, match.ActiveForm)
+}
+
+// todoContentRelates reports whether a todo item's preferred text has a
+// recognisable semantic relationship (substring overlap) with the step match
+// that was stored against a previous todo_write list.  It returns true when
+// the model has rephrased the same task, not swapped it for a different one.
+func todoContentRelates(todo TodoItem, match TodoStepMatch) bool {
+	return textOverlaps(todo.Content, match.Content) ||
+		textOverlaps(todo.ActiveForm, match.ActiveForm)
+}
+
+func textOverlaps(a, b string) bool {
+	a = normalizeStepText(a)
+	b = normalizeStepText(b)
+	if a == "" || b == "" {
+		return false
+	}
+	// Require ≥6 runes on the shorter side to avoid false positives on
+	// short shared substrings (same guard as stepTextContains).
+	short := a
+	if utf8.RuneCountInString(b) < utf8.RuneCountInString(a) {
+		short = b
+	}
+	if utf8.RuneCountInString(short) < 6 {
+		return false
+	}
+	return strings.Contains(a, b) || strings.Contains(b, a)
 }
 
 func matchTodoStep(step string, todos []TodoItem) TodoStepMatch {

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -387,3 +387,42 @@ func TestLedgerNoBaselineDoesNotConstrainCompletedTodos(t *testing.T) {
 		t.Fatalf("no baseline should not report missing completions, got %+v", missing)
 	}
 }
+
+func TestLedgerNumericCompleteStepAuthorizesRephrasedTodo(t *testing.T) {
+	ledger := NewLedger()
+	ledger.Record(Receipt{
+		ToolName: "todo_write",
+		Success:  true,
+		Todos: []TodoItem{
+			{Content: "Add parser", Status: "in_progress"},
+			{Content: "Write tests", Status: "pending"},
+		},
+	})
+	ledger.Record(Receipt{ToolName: "complete_step", Success: true, Step: "1"})
+
+	// The model rephrased item 1 (added detail) but it's the same task.
+	missing, hasBaseline := ledger.UnverifiedCompletedTodos([]TodoItem{
+		{Content: "Add parser with streaming support", Status: "completed"},
+		{Content: "Write tests", Status: "pending"},
+	})
+	if !hasBaseline {
+		t.Fatal("expected prior todo_write baseline")
+	}
+	if len(missing) != 0 {
+		t.Fatalf("rephrased todo at same index should be authorized by content overlap, missing = %+v", missing)
+	}
+
+	// The model also rephrased item 2; still ok because the new text contains the old.
+	missing, hasBaseline = ledger.UnverifiedCompletedTodos([]TodoItem{
+		{Content: "Add parser with streaming support", Status: "completed"},
+		{Content: "Write tests and benchmarks", Status: "completed"},
+	})
+	if !hasBaseline {
+		t.Fatal("expected prior todo_write baseline for second rephrase")
+	}
+	// Item 1 is already authorized; item 2 is also rephrased but lacks a
+	// complete_step — so it should still be flagged.
+	if len(missing) != 1 || missing[0].Content != "Write tests and benchmarks" {
+		t.Fatalf("rephrased todo without complete_step should still be missing, got %+v", missing)
+	}
+}


### PR DESCRIPTION
Fixes #3992

## Problem

When the model rephrases a todo item's `content` between successive `todo_write` calls (e.g., "Analyze the bug" → "Analyze the bug and understand root cause"), `hasSuccessfulCompleteStepForTodo` rejects the completion. The `sameTodoMatch` exact-text guard fails, and the bare `continue` on L592 prevents the index-based fallback (`matchTodoStep`) from ever running. The `todo_write` call is rejected by `verifyTodoCompletionTransitions`, so the frontend **never sees the completed status** — checkmarks don't appear (#3992).

## Fix

Replace the `continue` with a **content-overlap guard** (`todoContentRelates` /
`textOverlaps`):

- When old and new text share a recognisable substring (case-folded, normalized, ≥6 runes on the shorter side — same discipline as `stepTextContains` from #4006), the receipt falls through to the index-based fallback.
- When they are unrelated ("Add parser" → "Ship parser"), the original block is preserved (`continue` still fires).

`textOverlaps` uses `normalizeStepText` (introduced in #4006) for consistency with the matching layer.

Two new helpers:
- `todoContentRelates` — gates the fallback on related task identity
- `textOverlaps` — normalized substring overlap with ≥6-rune minimum

## Test

- `TestLedgerNumericCompleteStepAuthorizesRephrasedTodo` — covers the happy path now enabled (rephrased-but-same-task authorized)
- All **11** existing `evidence` tests pass unchanged
- All **33** `builtin` todo/complete_step tests pass unchanged
- `TestLedgerNumericCompleteStepDoesNotAuthorizeReplacedTodo` still blocks genuinely different tasks

## Files

| File | Δ |
|------|---|
| `internal/evidence/evidence.go` | +35/−1 |
| `internal/evidence/evidence_test.go` | +39 |