### PR TITLE
fix(agent): close complete_step cross-turn evidence + loop gaps

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -212,6 +212,14 @@ type Agent struct {
 	// complete_step validate that cited evidence happened before the claim.
 	evidence *evidence.Ledger
 
+	// todoState is the host's canonical task list: the latest successful
+	// todo_write with completions applied by complete_step. Unlike the per-turn
+	// ledger it survives turn boundaries and compaction (it never rides in the
+	// prompt), so the final-answer gate still sees an unfinished plan a later
+	// turn would otherwise hide. Rebuilt from the session in SetSession.
+	todoMu    sync.Mutex
+	todoState []evidence.TodoItem
+
 	// projectChecks are structured project instructions that complete_step can
 	// verify against same-turn bash receipts after a write-backed completion.
 	projectChecks []instruction.VerifyCheck
@@ -302,8 +310,11 @@ func (a *Agent) Session() *Session {
 // running turn (it only fires while idle); sessMu guards the pointer swap itself.
 func (a *Agent) SetSession(s *Session) {
 	a.sessMu.Lock()
-	defer a.sessMu.Unlock()
 	a.session = s
+	a.sessMu.Unlock()
+	if s != nil {
+		a.rebuildTodoState(s.Snapshot())
+	}
 }
 
 // LastUsage returns the most recent per-turn token telemetry the provider
@@ -647,7 +658,11 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 	var missing []string
 	out := finalReadinessCheck{}
 	if !a.planMode.Load() {
-		if incomplete, hasTodos := a.evidence.IncompleteLatestTodos(); hasTodos && len(incomplete) > 0 {
+		incomplete, hasTodos := a.evidence.IncompleteLatestTodos()
+		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
+			incomplete, hasTodos = a.incompleteCanonicalTodos()
+		}
+		if hasTodos && len(incomplete) > 0 {
 			out.applies = true
 			out.incompleteTodos = len(incomplete)
 			missing = append(missing, finalReadinessIncompleteTodos(incomplete))
@@ -694,6 +709,145 @@ func finalReadinessIncompleteTodos(items []evidence.TodoStepMatch) string {
 		parts = append(parts, fmt.Sprintf("%s: %s", label, item.Status))
 	}
 	return "latest successful todo_write still has incomplete items: " + strings.Join(parts, ", ")
+}
+
+func (a *Agent) setTodoState(todos []evidence.TodoItem) {
+	a.todoMu.Lock()
+	a.todoState = append([]evidence.TodoItem(nil), todos...)
+	a.todoMu.Unlock()
+}
+
+func (a *Agent) incompleteCanonicalTodos() ([]evidence.TodoStepMatch, bool) {
+	a.todoMu.Lock()
+	defer a.todoMu.Unlock()
+	if len(a.todoState) == 0 {
+		return nil, false
+	}
+	return evidence.IncompleteTodos(a.todoState), true
+}
+
+// advanceCanonicalTodo flips the canonical todo matching a signed-off step to
+// completed (promoting the next pending item to in_progress) and emits a
+// synthetic todo_write so the task panel reflects it without the model
+// re-sending the whole list. No-op when nothing matches or it is already done.
+func (a *Agent) advanceCanonicalTodo(step string) {
+	a.todoMu.Lock()
+	if len(a.todoState) == 0 {
+		a.todoMu.Unlock()
+		return
+	}
+	m, ok := evidence.MatchStep(step, a.todoState)
+	if !ok || canonicalTodoStatus(a.todoState[m.Index-1].Status) == "completed" {
+		a.todoMu.Unlock()
+		return
+	}
+	a.todoState[m.Index-1].Status = "completed"
+	promoteNextPendingTodo(a.todoState)
+	snapshot := append([]evidence.TodoItem(nil), a.todoState...)
+	a.todoMu.Unlock()
+	a.recordTodoState(snapshot)
+	a.emitTodoState(snapshot)
+}
+
+// recordTodoState logs the host-advanced list as a synthetic todo_write receipt
+// so the per-turn final gate (which reads the ledger's latest todo_write) sees
+// the advance — the model no longer has to re-send a todo_write to mark the
+// completion. It bypasses the todo_write tool, so the completion-transition
+// guard never runs on it.
+func (a *Agent) recordTodoState(todos []evidence.TodoItem) {
+	if a.evidence == nil {
+		return
+	}
+	args, err := json.Marshal(map[string]any{"todos": todos})
+	if err != nil {
+		return
+	}
+	a.evidence.Record(evidence.ReceiptFromToolCall("todo_write", json.RawMessage(args), true, true))
+}
+
+func promoteNextPendingTodo(todos []evidence.TodoItem) {
+	for _, t := range todos {
+		if canonicalTodoStatus(t.Status) == "in_progress" {
+			return
+		}
+	}
+	for i := range todos {
+		if canonicalTodoStatus(todos[i].Status) == "pending" {
+			todos[i].Status = "in_progress"
+			return
+		}
+	}
+}
+
+func canonicalTodoStatus(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "pending"
+	}
+	return s
+}
+
+func (a *Agent) emitTodoState(todos []evidence.TodoItem) {
+	args, err := json.Marshal(map[string]any{"todos": todos})
+	if err != nil {
+		return
+	}
+	t := event.Tool{ID: "host-advance", Name: "todo_write", Args: string(args), ReadOnly: true}
+	a.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: t})
+	t.Output = "task list advanced by complete_step"
+	a.sink.Emit(event.Event{Kind: event.ToolResult, Tool: t})
+}
+
+// rebuildTodoState reconstructs the canonical task list from a transcript: the
+// latest successful todo_write is the base, then every complete_step after it
+// advances an item. Deterministic from persisted messages, so it survives a
+// fresh load or a rewind (the truncated history yields the historical state).
+// Empty after compaction drops the todo_write — no worse than no canonical list.
+func (a *Agent) rebuildTodoState(msgs []provider.Message) {
+	failed := failedToolCallIDs(msgs)
+	var todos []evidence.TodoItem
+	baseIdx := -1
+	for i, msg := range msgs {
+		for _, tc := range msg.ToolCalls {
+			if tc.Name != "todo_write" || failed[tc.ID] {
+				continue
+			}
+			if rec := evidence.ReceiptFromToolCall(tc.Name, json.RawMessage(tc.Arguments), true, true); len(rec.Todos) > 0 {
+				todos = append([]evidence.TodoItem(nil), rec.Todos...)
+				baseIdx = i
+			}
+		}
+	}
+	if baseIdx < 0 {
+		a.setTodoState(nil)
+		return
+	}
+	for i := baseIdx; i < len(msgs); i++ {
+		for _, tc := range msgs[i].ToolCalls {
+			if tc.Name != "complete_step" || failed[tc.ID] {
+				continue
+			}
+			rec := evidence.ReceiptFromToolCall(tc.Name, json.RawMessage(tc.Arguments), true, true)
+			if m, ok := evidence.MatchStep(rec.Step, todos); ok && canonicalTodoStatus(todos[m.Index-1].Status) != "completed" {
+				todos[m.Index-1].Status = "completed"
+				promoteNextPendingTodo(todos)
+			}
+		}
+	}
+	a.setTodoState(todos)
+}
+
+func failedToolCallIDs(msgs []provider.Message) map[string]bool {
+	failed := map[string]bool{}
+	for _, msg := range msgs {
+		if msg.Role != provider.RoleTool || msg.ToolCallID == "" {
+			continue
+		}
+		if strings.HasPrefix(msg.Content, "error:") || strings.HasPrefix(msg.Content, "blocked:") {
+			failed[msg.ToolCallID] = true
+		}
+	}
+	return failed
 }
 
 func finalReadinessCheckSource(check instruction.VerifyCheck) string {
@@ -1157,10 +1311,16 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	if a.evidence != nil {
 		if call.Name == "complete_step" {
 			if err == nil {
-				a.evidence.Record(evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), true, t.ReadOnly()))
+				rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), true, t.ReadOnly())
+				a.evidence.Record(rec)
+				a.advanceCanonicalTodo(rec.Step)
 			}
 		} else {
-			a.evidence.Record(evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), err == nil, t.ReadOnly()))
+			rec := evidence.ReceiptFromToolCall(call.Name, json.RawMessage(call.Arguments), err == nil, t.ReadOnly())
+			a.evidence.Record(rec)
+			if err == nil && call.Name == "todo_write" {
+				a.setTodoState(rec.Todos)
+			}
 		}
 	}
 	// PostToolUse hooks observe the result (they can't block); fired whether the

--- a/internal/agent/canonical_todo_test.go
+++ b/internal/agent/canonical_todo_test.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/evidence"
+	"reasonix/internal/provider"
+)
+
+func TestFinalReadinessFallsBackToCanonicalTodos(t *testing.T) {
+	ran := evidence.Receipt{ToolName: "bash", Success: true, Command: "git push"}
+	open := []evidence.TodoItem{{Content: "push", Status: "completed"}, {Content: "rebase", Status: "pending"}}
+
+	// Turn did work (a successful bash) but issued no todo_write this turn, so the
+	// per-turn ledger has no list — the canonical state must still gate.
+	a := &Agent{evidence: readinessLedger(ran), todoState: open}
+	if got := a.finalReadinessFailure(); !strings.Contains(got, "incomplete") {
+		t.Fatalf("cross-turn gate = %q, want it to report incomplete canonical todos", got)
+	}
+
+	// A turn that touched nothing (pure Q&A) must never gate on stale canonical state.
+	idle := &Agent{evidence: evidence.NewLedger(), todoState: open}
+	if got := idle.finalReadinessFailure(); got != "" {
+		t.Fatalf("no-work turn gated on canonical todos: %q", got)
+	}
+
+	// All canonical items completed → no gate even after work.
+	done := &Agent{evidence: readinessLedger(ran), todoState: []evidence.TodoItem{{Content: "push", Status: "completed"}}}
+	if got := done.finalReadinessFailure(); got != "" {
+		t.Fatalf("completed canonical todos still gated: %q", got)
+	}
+}
+
+func TestAdvanceCanonicalTodoCompletesAndPromotes(t *testing.T) {
+	a := &Agent{
+		sink: event.Discard,
+		todoState: []evidence.TodoItem{
+			{Content: "sync branch", Status: "in_progress"},
+			{Content: "push to origin", Status: "pending"},
+			{Content: "rebase", Status: "pending"},
+		},
+	}
+	a.advanceCanonicalTodo("sync branch")
+
+	if a.todoState[0].Status != "completed" {
+		t.Fatalf("signed-off item not completed: %+v", a.todoState[0])
+	}
+	if a.todoState[1].Status != "in_progress" {
+		t.Fatalf("next pending item not promoted: %+v", a.todoState[1])
+	}
+	if a.todoState[2].Status != "pending" {
+		t.Fatalf("a later item was promoted out of order: %+v", a.todoState[2])
+	}
+}
+
+func TestAdvanceCanonicalTodoMatchesByNumber(t *testing.T) {
+	a := &Agent{sink: event.Discard, todoState: []evidence.TodoItem{
+		{Content: "first", Status: "in_progress"},
+		{Content: "second", Status: "pending"},
+	}}
+	a.advanceCanonicalTodo("2")
+	if a.todoState[1].Status != "completed" {
+		t.Fatalf("numeric step did not complete the second todo: %+v", a.todoState)
+	}
+}
+
+func TestRebuildTodoStateReplaysCompleteSteps(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "t1", Name: "todo_write",
+			Arguments: `{"todos":[{"content":"a","status":"in_progress"},{"content":"b","status":"pending"}]}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "todo_write", Content: "Todos updated"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "c1", Name: "complete_step", Arguments: `{"step":"a"}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "c1", Name: "complete_step", Content: "signed off"},
+	}
+	a := &Agent{}
+	a.rebuildTodoState(msgs)
+
+	if len(a.todoState) != 2 {
+		t.Fatalf("rebuilt %d todos, want 2", len(a.todoState))
+	}
+	if a.todoState[0].Status != "completed" {
+		t.Fatalf("complete_step not replayed onto canonical state: %+v", a.todoState[0])
+	}
+	if a.todoState[1].Status != "in_progress" {
+		t.Fatalf("next item not promoted on replay: %+v", a.todoState[1])
+	}
+}
+
+func TestRebuildTodoStateSkipsFailedCompleteStep(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "t1", Name: "todo_write",
+			Arguments: `{"todos":[{"content":"a","status":"in_progress"}]}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "todo_write", Content: "Todos updated"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "c1", Name: "complete_step", Arguments: `{"step":"a"}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "c1", Name: "complete_step", Content: "error: no evidence"},
+	}
+	a := &Agent{}
+	a.rebuildTodoState(msgs)
+
+	if a.todoState[0].Status == "completed" {
+		t.Fatalf("a failed complete_step must not advance canonical state: %+v", a.todoState[0])
+	}
+}

--- a/internal/agent/complete_step_e2e_test.go
+++ b/internal/agent/complete_step_e2e_test.go
@@ -1,0 +1,220 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+
+	_ "reasonix/internal/tool/builtin"
+)
+
+type stubBash struct{}
+
+func (stubBash) Name() string        { return "bash" }
+func (stubBash) Description() string { return "stub bash" }
+func (stubBash) ReadOnly() bool      { return false }
+func (stubBash) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string"}},"required":["command"]}`)
+}
+func (stubBash) Execute(context.Context, json.RawMessage) (string, error) { return "ok", nil }
+
+type stubWrite struct{}
+
+func (stubWrite) Name() string        { return "write_file" }
+func (stubWrite) Description() string { return "stub write" }
+func (stubWrite) ReadOnly() bool      { return false }
+func (stubWrite) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}`)
+}
+func (stubWrite) Execute(context.Context, json.RawMessage) (string, error) { return "wrote", nil }
+
+// evidenceRegistry wires the real complete_step + todo_write builtins (the
+// enforcement surface under test) alongside bash/write stubs that emit real
+// receipts without touching the host — so the whole turn loop, ledger, gate,
+// and host-advance run end to end.
+func evidenceRegistry() *tool.Registry {
+	reg := tool.NewRegistry()
+	for _, bt := range tool.Builtins() {
+		if bt.Name() == "complete_step" || bt.Name() == "todo_write" {
+			reg.Add(bt)
+		}
+	}
+	reg.Add(stubBash{})
+	reg.Add(stubWrite{})
+	return reg
+}
+
+func hostAdvances(sink *recordSink) int {
+	n := 0
+	for _, e := range sink.kinds(event.ToolResult) {
+		if e.Tool.ID == "host-advance" {
+			n++
+		}
+	}
+	return n
+}
+
+func readinessBlocked(sink *recordSink) bool {
+	for _, e := range sink.kinds(event.Notice) {
+		if strings.Contains(e.Text, "readiness blocked") {
+			return true
+		}
+	}
+	return false
+}
+
+// sessionContains reports whether any message body holds sub — used to assert a
+// tool's own result text (a complete_step "signed off" or its rejection reason),
+// since Run returns nil whether or not a tool call was rejected mid-turn.
+func sessionContains(a *Agent, sub string) bool {
+	for _, m := range a.Session().Messages {
+		if strings.Contains(m.Content, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// Serial plan: the model establishes the list once, then signs off each step
+// with complete_step — the host advances the list (no per-step todo_write, so
+// the #3909 batch-completion failure can't arise) and a cited command tolerates
+// a cd-prefix drift. The final answer is allowed once every step is signed off.
+func TestE2ESerialPlanHostAdvancesAndAllowsFinalAnswer(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "t0", Name: "todo_write",
+			Arguments: `{"todos":[{"content":"build","status":"in_progress"},{"content":"test","status":"pending"}]}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash",
+			Arguments: `{"command":"cd /repo && go build ./..."}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
+			Arguments: `{"step":"build","result":"builds","evidence":[{"kind":"verification","summary":"build ok","command":"go build ./..."}]}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "b2", Name: "bash",
+			Arguments: `{"command":"go test ./..."}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c2", Name: "complete_step",
+			Arguments: `{"step":"test","result":"tests pass","evidence":[{"kind":"verification","summary":"tests pass","command":"go test ./..."}]}`}}},
+		testutil.Turn{Text: "all done"},
+	)
+	sink := &recordSink{}
+	a := New(mp, evidenceRegistry(), NewSession("sys"), Options{}, sink)
+
+	if err := a.Run(context.Background(), "implement the plan"); err != nil {
+		t.Fatalf("final answer blocked despite host-advanced completions: %v", err)
+	}
+	for i, td := range a.todoState {
+		if canonicalTodoStatus(td.Status) != "completed" {
+			t.Fatalf("canonical todo %d (%q) = %s, want completed", i+1, td.Content, td.Status)
+		}
+	}
+	if n := hostAdvances(sink); n < 2 {
+		t.Fatalf("host advanced %d times, want >=2 (one per complete_step)", n)
+	}
+	if readinessBlocked(sink) {
+		t.Fatal("a correctly signed-off plan should not trip the readiness gate")
+	}
+}
+
+// A command cited with a different string than it ran under (#2917: the model
+// drops the cd-prefix) is still accepted via segment matching, in-turn.
+func TestE2ECommandDriftAcceptedInTurn(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "b1", Name: "bash",
+			Arguments: `{"command":"cd /Users/x/repo && git merge upstream/main --ff-only"}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
+			Arguments: `{"step":"sync","result":"synced","evidence":[{"kind":"verification","summary":"fast-forwarded","command":"git merge upstream/main --ff-only"}]}`}}},
+		testutil.Turn{Text: "synced"},
+	)
+	a := New(mp, evidenceRegistry(), NewSession("sys"), Options{}, event.Discard)
+	if err := a.Run(context.Background(), "sync the branch"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !sessionContains(a, "signed off") {
+		t.Fatal("cd-prefixed command drift rejected a real verification")
+	}
+}
+
+// Cross-turn: a prior turn left an unfinished plan in the canonical state. A new
+// turn that does work and prematurely claims "all done" without re-asserting the
+// todos is blocked by the canonical fallback, then clears once both steps are
+// actually signed off (host-advanced) — the loop that #2917 could not close.
+func TestE2ECrossTurnCanonicalGateBlocksThenClears(t *testing.T) {
+	sess := NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+		ID: "t0", Name: "todo_write",
+		Arguments: `{"todos":[{"content":"alpha","status":"in_progress"},{"content":"beta","status":"pending"}]}`}}})
+	sess.Add(provider.Message{Role: provider.RoleTool, ToolCallID: "t0", Name: "todo_write", Content: "Todos updated"})
+
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "w1", Name: "write_file", Arguments: `{"path":"alpha.go"}`}}},
+		testutil.Turn{Text: "all done"},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
+			Arguments: `{"step":"alpha","result":"done","evidence":[{"kind":"diff","summary":"edited","paths":["alpha.go"]}]}`}}},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c2", Name: "complete_step",
+			Arguments: `{"step":"beta","result":"done","evidence":[{"kind":"manual","summary":"verified by inspection"}]}`}}},
+		testutil.Turn{Text: "all done now"},
+	)
+	sink := &recordSink{}
+	a := New(mp, evidenceRegistry(), sess, Options{}, sink)
+	a.SetSession(sess) // rebuilds canonical {alpha in_progress, beta pending}
+
+	if err := a.Run(context.Background(), "finish up"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !readinessBlocked(sink) {
+		t.Fatal("premature 'all done' was not blocked by the cross-turn canonical gate")
+	}
+	for i, td := range a.todoState {
+		if canonicalTodoStatus(td.Status) != "completed" {
+			t.Fatalf("canonical todo %d (%q) = %s after sign-off, want completed", i+1, td.Content, td.Status)
+		}
+	}
+}
+
+// Cross-turn diff evidence: a file edited in an earlier turn is signed off in a
+// later turn whose per-turn ledger is empty. The session-history fallback must
+// resolve the path receipt that the ledger no longer holds.
+func TestE2ECrossTurnDiffEvidenceViaSessionFallback(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "w1", Name: "write_file", Arguments: `{"path":"pkg/x.go"}`}}},
+		testutil.Turn{Text: "edited x.go"},
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
+			Arguments: `{"step":"edit x","result":"x updated","evidence":[{"kind":"diff","summary":"changed x","paths":["pkg/x.go"]}]}`}}},
+		testutil.Turn{Text: "signed off"},
+	)
+	a := New(mp, evidenceRegistry(), NewSession("sys"), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "edit x.go"); err != nil {
+		t.Fatalf("turn 1: %v", err)
+	}
+	if err := a.Run(context.Background(), "now sign off that change"); err != nil {
+		t.Fatalf("turn 2: %v", err)
+	}
+	if !sessionContains(a, "signed off") {
+		t.Fatal("turn 2 rejected a cross-turn diff citation the session proves")
+	}
+}
+
+// A diff citation for a file no turn ever wrote stays rejected — the session
+// fallback widens what counts as proof, it does not wave through fabrication.
+func TestE2EUnbackedDiffEvidenceStillRejected(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "complete_step",
+			Arguments: `{"step":"x","result":"y","evidence":[{"kind":"diff","summary":"claimed","paths":["never/written.go"]}]}`}}},
+		testutil.Turn{Text: "done"},
+	)
+	a := New(mp, evidenceRegistry(), NewSession("sys"), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "sign off without doing the work"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !sessionContains(a, "no matching successful writer") {
+		t.Fatal("a diff citation for a never-written file was accepted")
+	}
+	if sessionContains(a, "signed off") {
+		t.Fatal("an unbacked diff citation was signed off")
+	}
+}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -189,7 +189,7 @@ Executor instructions:
 - Do not ask the user how to trigger the executor. You are already in the executor phase.
 - If the task requires changes, call the appropriate tools (for example write/edit/bash) instead of only restating the plan.
 - If a target path is outside the writable workspace or otherwise blocked, explain that specific blocker and ask for the needed path/approval.
-- **Serial workflow**: after finishing EACH sub-task, immediately call complete_step with evidence, then call todo_write to mark it completed and advance the next sub-task. Never batch-complete multiple sub-tasks at once.
+- **Serial workflow**: establish the task list with one todo_write (first sub-task in_progress), then for EACH sub-task execute it and call complete_step with evidence. The host advances the list for you — it marks the sub-task completed and moves the next to in_progress, so you don't need another todo_write to mark completions. Sign off one sub-task at a time; never batch completions.
 
 Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, plan)
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -451,7 +451,7 @@ const planApprovalTool = "exit_plan_mode"
 
 // planApprovedMessage is the follow-up turn sent once the user approves a plan —
 // the in-context nudge to execute and keep the (already-seeded) task list honest.
-const planApprovedMessage = "Plan approved — plan mode is off; you’re cleared to make the changes without asking again. Implement the plan now. Use this serial workflow: 1) mark the first sub-step in_progress with todo_write; 2) execute it; 3) call complete_step with evidence; 4) call todo_write to mark it completed and set the next sub-step in_progress; 5) repeat until done. Never batch-complete multiple sub-steps at once — each sub-step must have its own complete_step before it is marked completed in todo_write."
+const planApprovedMessage = "Plan approved — plan mode is off; you’re cleared to make the changes without asking again. Implement the plan now. Use this serial workflow: 1) mark the first sub-step in_progress with todo_write (this establishes the task list); 2) execute the sub-step; 3) call complete_step with evidence — the host then marks that sub-step completed and moves the next one to in_progress for you. Repeat 2–3 for each remaining sub-step. You don’t need another todo_write to mark steps completed; each complete_step advances the list. Sign off one sub-step at a time — never batch multiple completions."
 
 // runTurn runs one model turn, then applies the plan-approval gate. This is the
 // single, frontend-agnostic plan flow: in plan mode the model just researches

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -262,23 +262,51 @@ func (l *Ledger) IncompleteLatestTodos() ([]TodoStepMatch, bool) {
 		if !r.Success || r.ToolName != "todo_write" {
 			continue
 		}
-		incomplete := make([]TodoStepMatch, 0)
-		for j, t := range r.Todos {
-			status := todoStatus(t.Status)
-			if status == "completed" {
-				continue
-			}
-			incomplete = append(incomplete, TodoStepMatch{
-				Found:      true,
-				Index:      j + 1,
-				Content:    t.Content,
-				Status:     status,
-				ActiveForm: t.ActiveForm,
-			})
-		}
-		return incomplete, true
+		return IncompleteTodos(r.Todos), true
 	}
 	return nil, false
+}
+
+// IncompleteTodos returns the items of a todo list that are not completed.
+func IncompleteTodos(todos []TodoItem) []TodoStepMatch {
+	incomplete := make([]TodoStepMatch, 0)
+	for j, t := range todos {
+		status := todoStatus(t.Status)
+		if status == "completed" {
+			continue
+		}
+		incomplete = append(incomplete, TodoStepMatch{
+			Found:      true,
+			Index:      j + 1,
+			Content:    t.Content,
+			Status:     status,
+			ActiveForm: t.ActiveForm,
+		})
+	}
+	return incomplete
+}
+
+// MatchStep resolves a complete_step.step (number, title, or drift-tolerant
+// variant) against a todo list, returning the matched item.
+func MatchStep(step string, todos []TodoItem) (TodoStepMatch, bool) {
+	m := matchTodoStep(step, todos)
+	return m, m.Found
+}
+
+// HasAnySuccessfulReceipt reports whether any tool succeeded this turn — the
+// signal that the turn did real work, not pure conversation.
+func (l *Ledger) HasAnySuccessfulReceipt() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.receipts {
+		if r.Success {
+			return true
+		}
+	}
+	return false
 }
 
 func (l *Ledger) HasSuccessfulWrite(paths []string) bool {
@@ -461,6 +489,53 @@ func WithSessionMessages(ctx context.Context, msgs []provider.Message) context.C
 func SessionMessagesFromContext(ctx context.Context) ([]provider.Message, bool) {
 	msgs, ok := ctx.Value(sessionMessagesKey{}).([]provider.Message)
 	return msgs, ok
+}
+
+// PathsProvenInSession reports whether every path is covered by a successful
+// (non-errored) tool call somewhere in msgs — the cross-turn fallback for diff
+// and files evidence, mirroring verifyCommandFromSession for the per-turn
+// ledger's path receipts (which reset each turn). wantWrite restricts to writer
+// tools (diff); false accepts a reader or writer (files).
+func PathsProvenInSession(msgs []provider.Message, paths []string, wantWrite bool) bool {
+	wanted := pathSet(normalizePaths(paths))
+	if len(wanted) == 0 {
+		return false
+	}
+	failed := failedSessionCallIDs(msgs)
+	found := map[string]bool{}
+	for _, msg := range msgs {
+		for _, tc := range msg.ToolCalls {
+			if failed[tc.ID] {
+				continue
+			}
+			r := ReceiptFromToolCall(tc.Name, json.RawMessage(tc.Arguments), true, false)
+			if wantWrite && !r.Write {
+				continue
+			}
+			if !wantWrite && !r.Read && !r.Write {
+				continue
+			}
+			for _, p := range normalizePaths(r.Paths) {
+				if _, ok := wanted[p]; ok {
+					found[p] = true
+				}
+			}
+		}
+	}
+	return len(found) == len(wanted)
+}
+
+func failedSessionCallIDs(msgs []provider.Message) map[string]bool {
+	failed := map[string]bool{}
+	for _, msg := range msgs {
+		if msg.Role != provider.RoleTool || msg.ToolCallID == "" {
+			continue
+		}
+		if strings.HasPrefix(msg.Content, "error:") || strings.HasPrefix(msg.Content, "blocked:") {
+			failed[msg.ToolCallID] = true
+		}
+	}
+	return failed
 }
 
 func ReceiptFromToolCall(toolName string, args json.RawMessage, success bool, readOnly bool) Receipt {

--- a/internal/tool/builtin/completestep.go
+++ b/internal/tool/builtin/completestep.go
@@ -43,7 +43,7 @@ var validEvidenceKinds = map[string]bool{
 func (completeStep) Name() string { return "complete_step" }
 
 func (completeStep) Description() string {
-	return "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. Keep the task list moving with todo_write (set the next step in_progress); use complete_step for the formal, evidenced sign-off of the finished one. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|diff|files|manual and a `summary`, plus optional `command`/`paths`), and optional `notes`."
+	return "Record the evidence-backed completion of ONE step of an approved plan. Call it as you finish each step instead of silently moving on: it signs the step off with PROOF it is done — the verification you ran (command + result), the diff/files you changed, or a manual check. A completion with no evidence is REJECTED, so don't claim a step is done until you can show why. The host advances the task list for you when you sign off — it marks this step completed and moves the next to in_progress, so you don't need a separate todo_write to mark completions. Fields: `step` (which step — its title or number, matching the task list), `result` (what is now true/changed), `evidence` (≥1 item, each with `kind` = verification|diff|files|manual and a `summary`, plus optional `command`/`paths`), and optional `notes`."
 }
 
 func (completeStep) Schema() json.RawMessage {
@@ -131,7 +131,7 @@ func (completeStep) Execute(ctx context.Context, args json.RawMessage) (string, 
 	if projectVerified > 0 {
 		projectStatus = fmt.Sprintf(" Project checks: project checks %d.", projectVerified)
 	}
-	return fmt.Sprintf("Step %q signed off with %d evidence item(s) [%s].%s Move the next step to in_progress with todo_write.",
+	return fmt.Sprintf("Step %q signed off with %d evidence item(s) [%s].%s The host advanced the task list; continue with the next step.",
 		p.Step, len(p.Evidence), strings.Join(kinds, ", "), hostStatus+todoStatus+projectStatus), nil
 }
 
@@ -158,7 +158,7 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 			if len(e.Paths) == 0 {
 				return 0, 0, fmt.Errorf("evidence %d: diff evidence requires paths for host verification — cite the files you changed", i+1)
 			}
-			if !ledger.HasSuccessfulWrite(e.Paths) {
+			if !ledger.HasSuccessfulWrite(e.Paths) && !verifyPathsFromSession(ctx, e.Paths, true) {
 				return 0, 0, fmt.Errorf("evidence %d: diff paths have no matching successful writer receipt in this turn%s", i+1, receiptHint("files written this turn", ledger.TouchedPaths(8, true)))
 			}
 			hostVerified++
@@ -166,7 +166,7 @@ func verifyStepEvidence(ctx context.Context, items []stepEvidence) (hostVerified
 			if len(e.Paths) == 0 {
 				return 0, 0, fmt.Errorf("evidence %d: files evidence requires paths for host verification — cite the files you touched", i+1)
 			}
-			if !ledger.HasSuccessfulReadOrWrite(e.Paths) && !ledger.HasSuccessfulBashMentioningPaths(e.Paths) {
+			if !ledger.HasSuccessfulReadOrWrite(e.Paths) && !ledger.HasSuccessfulBashMentioningPaths(e.Paths) && !verifyPathsFromSession(ctx, e.Paths, false) {
 				return 0, 0, fmt.Errorf("evidence %d: file paths have no matching successful read/write receipt in this turn%s", i+1, receiptHint("files touched this turn", ledger.TouchedPaths(8, false)))
 			}
 			hostVerified++
@@ -301,6 +301,17 @@ func verifyCommandFromSession(ctx context.Context, command string) bool {
 		}
 	}
 	return false
+}
+
+// verifyPathsFromSession is the diff/files analogue of verifyCommandFromSession:
+// it lets a completion cite a file written or read in an earlier turn (the
+// per-turn ledger only has this turn). wantWrite restricts to writer tools.
+func verifyPathsFromSession(ctx context.Context, paths []string, wantWrite bool) bool {
+	msgs, ok := evidence.SessionMessagesFromContext(ctx)
+	if !ok {
+		return false
+	}
+	return evidence.PathsProvenInSession(msgs, paths, wantWrite)
 }
 
 func failedCallIDs(msgs []provider.Message) map[string]bool {

--- a/internal/tool/builtin/completestep_test.go
+++ b/internal/tool/builtin/completestep_test.go
@@ -513,3 +513,37 @@ func TestCompleteStepFilesEvidenceAcceptsBashCreatedFile(t *testing.T) {
 		t.Fatal("a path no command mentions must still be rejected")
 	}
 }
+
+func TestCompleteStepSessionFallbackResolvesDiffPaths(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "w1", Name: "write_file", Arguments: `{"path":"internal/foo/bar.go"}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "w1", Name: "write_file", Content: "wrote 10 lines"},
+	}
+	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
+	ctx = evidence.WithSessionMessages(ctx, msgs)
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"diff","summary":"added bar","paths":["internal/foo/bar.go"]}]}`)); err != nil {
+		t.Fatalf("cross-turn diff citation of a written file rejected: %v", err)
+	}
+}
+
+func TestCompleteStepSessionFallbackSkipsFailedWrite(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID: "w1", Name: "write_file", Arguments: `{"path":"internal/foo/bar.go"}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "w1", Name: "write_file", Content: "error: permission denied"},
+	}
+	ctx := evidence.WithLedger(context.Background(), evidence.NewLedger())
+	ctx = evidence.WithSessionMessages(ctx, msgs)
+
+	if _, err := (completeStep{}).Execute(ctx, json.RawMessage(`{
+		"step":"x","result":"y",
+		"evidence":[{"kind":"diff","summary":"added bar","paths":["internal/foo/bar.go"]}]}`)); err == nil {
+		t.Fatal("a failed write must not satisfy cross-turn diff evidence")
+	}
+}


### PR DESCRIPTION
## Why

`complete_step`'s enforcement is bound to a **per-turn** evidence ledger (`a.evidence.Reset()` runs at the top of every `Run`). Two consequences users have hit:

1. **Cross-turn evidence is rejected.** Command evidence already falls back to scanning the full session (#3587), but **diff/files (path) evidence did not** — so citing a file you edited in an earlier turn (or before compaction) failed with "no matching writer receipt in this turn".
2. **The loop doesn't close across turns/compaction.** The final-answer gate reads only *this turn's* `todo_write`, so once the structured list is gone (a later turn, or compacted into a summary) a premature "all done" slips through — the unclosed loop in #2917.

## What

- **diff/files session fallback (mirrors #3587).** `PathsProvenInSession` resolves a path against any successful (non-errored) write/read tool call in the transcript; `verifyStepEvidence` consults it when the per-turn ledger misses. Fabricated paths are still rejected.
- **Host-side canonical todo list.** `Agent.todoState` is the latest `todo_write` with completions applied, rebuilt from the session on load/rewind (latest `todo_write` + replayed `complete_step`s). It never rides in the prompt, so it survives turn boundaries **and** compaction. The final gate falls back to it when a turn did work without a `todo_write`, so a premature "all done" is blocked until the plan is genuinely finished — bounded by the existing `maxFinalReadinessBlocks`.
- **`complete_step` advances the list.** A successful sign-off marks the matching step completed, promotes the next, records a synthetic `todo_write` for the in-turn gate, and emits an event so the panel updates. The model is told it no longer needs a `todo_write` to mark completions — which removes the manual batch-completion step that **#3909** tripped over (planApprovedMessage / executor handoff / tool copy updated to match).

All host-side, zero added tokens.

## Tests

Unit: cross-turn diff/files fallback, canonical gate fallback, advance + promote, rebuild (incl. skipping failed `complete_step`s).

End-to-end (real `complete_step`/`todo_write` builtins driven through `Agent.Run` across turns):
- serial plan, host auto-advances, no batch `todo_write`, final answer allowed
- cd-prefixed command drift accepted in-turn
- cross-turn diff evidence accepted via session fallback (and an unbacked path still rejected — asserted at the tool-result level, not just `Run` exit)
- cross-turn canonical gate blocks a premature "all done", then clears once the steps are actually signed off

`go test ./...` green; `gofmt`/`go vet` clean.

Closes #2917
