### PR TITLE
fix(chat): clear accumulated shell output on re-run of !commands

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1940,6 +1940,9 @@ func (m *chatTUI) beginToolRunning(id string) {
 	m.toolTail = m.toolTail[:0]
 	m.toolPartial = ""
 	m.toolLineCount = 0
+	// Clear accumulated output for this tool ID so a re-run (e.g. repeated
+	// !pwd with the same "shell-pwd" id) doesn't append to old output.
+	delete(m.shellOutputs, id)
 	m.toolStreamStart = time.Now()
 	m.toolStreamFrame = 0
 	if m.nativeScrollback {


### PR DESCRIPTION
## Problem

Repeated `!pwd` (or any `!` shell command) accumulates output lines across runs instead of showing only the current run's output.

**Before (3× `!pwd`):**
```
  › !pwd

  ● Bash(pwd)
  ⎿  /d/about_fish/ProgramProtable/DeepSeek-Reasonix

  › !pwd

  ● Bash(pwd)
  ⎿  /d/about_fish/ProgramProtable/DeepSeek-Reasonix
     /d/about_fish/ProgramProtable/DeepSeek-Reasonix

  › !pwd

  ● Bash(pwd)
  ⎿  /d/about_fish/ProgramProtable/DeepSeek-Reasonix
     /d/about_fish/ProgramProtable/DeepSeek-Reasonix
     /d/about_fish/ProgramProtable/DeepSeek-Reasonix
```

## Root Cause

`controller.RunShell` generates a fixed tool ID for each `!` command (e.g. `"shell-pwd"`). `streamToolOutput` appends output with `m.shellOutputs[id] += chunk`, but `beginToolRunning` never cleared the map entry, so every subsequent run added to the previous output. `collapseShellSlot` then rendered all accumulated lines.

## Fix

Clear `m.shellOutputs[id]` in `beginToolRunning` so each re-run of the same tool ID starts with a clean slate. This is a one-line `delete` with a comment.

**After (3× `!pwd`):**
```
  › !pwd

  ● Bash(pwd)
  ⎿  /d/about_fish/ProgramProtable/DeepSeek-Reasonix

  › !pwd

  ● Bash(pwd)
  ⎿  /d/about_fish/ProgramProtable/DeepSeek-Reasonix

  › !pwd

  ● Bash(pwd)
  ⎿  /d/about_fish/ProgramProtable/DeepSeek-Reasonix
```