### PR TITLE
fix: keep tool schema snapshot stable per request

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -440,7 +440,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 			prevPrefixShape = prefixShape
 		}
 
-		text, reasoning, signature, calls, usage, interrupted, partialToolStarted, err := a.stream(ctx, step+1)
+		text, reasoning, signature, calls, usage, interrupted, partialToolStarted, err := a.stream(ctx, step+1, schemas)
 		if err != nil {
 			if interrupted && streamRecoveries < maxStreamRecoveries {
 				streamRecoveries++
@@ -671,13 +671,13 @@ func streamRecoveryMessage(hasPartialText, hadPartialTool bool) string {
 // stream so a sink can re-render the streamed raw text as styled markdown. The
 // accumulated text and reasoning are also returned so the caller can round-trip
 // reasoning on the next turn.
-func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, []provider.ToolCall, *provider.Usage, bool, bool, error) {
+func (a *Agent) stream(ctx context.Context, turn int, schemas []provider.ToolSchema) (string, string, string, []provider.ToolCall, *provider.Usage, bool, bool, error) {
 	ctx = provider.WithRetryNotify(ctx, func(info provider.RetryInfo) {
 		a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: info.Attempt, RetryMax: info.Max})
 	})
 	ch, err := a.prov.Stream(ctx, provider.Request{
 		Messages:    a.session.Messages,
-		Tools:       a.tools.Schemas(),
+		Tools:       schemas,
 		Temperature: a.temperature,
 	})
 	if err != nil {

--- a/internal/agent/cache_shape_test.go
+++ b/internal/agent/cache_shape_test.go
@@ -1,10 +1,13 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/tool"
 )
 
 func TestCaptureShapeNormalizesToolSchemaOrder(t *testing.T) {
@@ -33,5 +36,46 @@ func TestCaptureShapeNormalizesToolSchemaOrder(t *testing.T) {
 	}
 	if schemas[0].Name != "write_file" || schemas[1].Name != "read_file" {
 		t.Fatalf("CaptureShape mutated caller schema order: got [%s %s]", schemas[0].Name, schemas[1].Name)
+	}
+}
+
+type schemaSnapshotProvider struct {
+	req provider.Request
+}
+
+func (p *schemaSnapshotProvider) Name() string { return "schema-snapshot" }
+
+func (p *schemaSnapshotProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.req = req
+	ch := make(chan provider.Chunk, 2)
+	ch <- provider.Chunk{Type: provider.ChunkText, Text: "ok"}
+	ch <- provider.Chunk{Type: provider.ChunkDone}
+	close(ch)
+	return ch, nil
+}
+
+func TestStreamUsesCapturedSchemaSnapshot(t *testing.T) {
+	prov := &schemaSnapshotProvider{}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "cached_tool", readOnly: true})
+	a := New(prov, reg, NewSession("sys"), Options{}, event.Discard)
+
+	snapshot := []provider.ToolSchema{{
+		Name:        "cached_tool",
+		Description: "cached schema visible at turn start",
+		Parameters:  json.RawMessage(`{"type":"object"}`),
+	}}
+
+	// A lazy/background plugin can finish handshaking after prefix diagnostics
+	// capture the turn-start schema surface. That newly registered tool should
+	// wait for the next model request; changing Tools mid-request would perturb
+	// the provider's cache key and make the diagnostics lie about the prefix.
+	reg.Add(fakeTool{name: "late_tool", readOnly: true})
+
+	if _, _, _, _, _, _, _, err := a.stream(context.Background(), 1, snapshot); err != nil {
+		t.Fatalf("stream: %v", err)
+	}
+	if len(prov.req.Tools) != 1 || prov.req.Tools[0].Name != "cached_tool" {
+		t.Fatalf("request tools = %+v, want only captured cached_tool schema", prov.req.Tools)
 	}
 }


### PR DESCRIPTION
## Summary
- Reuse the same tool schema snapshot for cache-prefix diagnostics and the provider request.
- Prevent late lazy/background MCP tool registration from changing the tool surface inside a single model request.
- Add regression coverage for captured schema snapshot stability.

## Validation
- go test ./internal/agent -run 'TestStreamUsesCapturedSchemaSnapshot|TestCaptureShapeNormalizesToolSchemaOrder|TestRunPopulatesCacheDiagnosticsOnUsageEvents|TestPlanModeDoesNotMutateSystemOrTools' -count=1
- REASONIX_RELEASE_CACHE_GUARD=1 go test ./internal/agent -run '^TestReleaseCacheHitGuard$' -v -count=1
- go test ./internal/tool ./internal/provider/openai -count=1
- go test ./internal/agent -count=1