### PR TITLE
fix(openai): round-trip reasoning_content on DeepSeek tool_calls turns

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -576,7 +576,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				if emptyFinalBlocks >= maxEmptyFinalBlocks {
 					return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
 				}
-				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "empty final answer blocked: model returned no visible answer text; retrying"})
+				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: emptyFinalNotice(a.prov.Name(), usage, len(reasoning))})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: emptyFinalRetryMessage()})
 				a.maybeCompact(ctx, usage)
 				continue
@@ -724,6 +724,14 @@ func hasVisibleFinalAnswer(text string) bool {
 
 func emptyFinalRetryMessage() string {
 	return "The previous assistant response finished without any visible answer text. Continue the same task now and provide a concise visible answer to the user. Do not send reasoning only."
+}
+
+func emptyFinalNotice(prov string, u *provider.Usage, reasoningLen int) string {
+	finish := "unknown"
+	if u != nil && u.FinishReason != "" {
+		finish = u.FinishReason
+	}
+	return fmt.Sprintf("empty final answer blocked: %s returned no visible answer text (finish=%s, reasoning=%d chars); retrying", prov, finish, reasoningLen)
 }
 
 func streamRecoveryMessage(hasPartialText, hadPartialTool bool) string {

--- a/internal/agent/guards_test.go
+++ b/internal/agent/guards_test.go
@@ -83,6 +83,21 @@ func TestFinishReasonMessage(t *testing.T) {
 	}
 }
 
+// TestEmptyFinalNotice carries the diagnostics that tell the three empty-answer
+// causes apart in reports: which provider, how it stopped, and whether the model
+// produced reasoning-only output.
+func TestEmptyFinalNotice(t *testing.T) {
+	msg := emptyFinalNotice("deepseek-flash", &provider.Usage{FinishReason: "stop"}, 512)
+	for _, want := range []string{"deepseek-flash", "finish=stop", "reasoning=512"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("notice %q missing %q", msg, want)
+		}
+	}
+	if got := emptyFinalNotice("p", nil, 0); !strings.Contains(got, "finish=unknown") {
+		t.Errorf("nil usage should report finish=unknown, got %q", got)
+	}
+}
+
 // --- parallel-dispatch tests ---
 
 // fakeTool is a minimal Tool stand-in for dispatch tests; ReadOnly is

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -234,16 +234,16 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 	src := provider.SanitizeToolPairing(req.Messages)
 	msgs := make([]chatMessage, len(src))
 	for i, m := range src {
-		// reasoning_content is deliberately NOT sent back: it's a response-only
-		// field. DeepSeek counts re-sent reasoning as billable prompt input
-		// (measured ~500 extra tokens per turn on a reasoner chain); MiMo accepts
-		// it but does not require it (verified empirically: multi-turn tool-call
-		// sessions work fine without it, saving ~18 tokens/turn). The session
-		// still keeps it (for display/archive); we just don't pay to re-upload it.
 		cm := chatMessage{
 			Role:       string(m.Role),
 			ToolCallID: m.ToolCallID,
 			Name:       m.Name,
+		}
+		// DeepSeek thinking mode 400s a tool_calls turn whose reasoning_content was
+		// dropped on a cache-miss replay ("reasoning_content … must be passed back"),
+		// so round it back — but only on the turn that carries the tool calls.
+		if c.deepseek && m.Role == provider.RoleAssistant && len(m.ToolCalls) > 0 {
+			cm.ReasoningContent = m.ReasoningContent
 		}
 		for _, tc := range m.ToolCalls {
 			wire := chatToolCall{ID: tc.ID, Type: "function"}
@@ -523,12 +523,11 @@ type chatMessage struct {
 	// serializes as null (OpenAI-spec, and what strict clones expect); every
 	// other role/message serializes as a string, empty included — null is
 	// rejected by some backends for a tool message.
-	Content    *string        `json:"content"`
-	ToolCalls  []chatToolCall `json:"tool_calls,omitempty"`
-	ToolCallID string         `json:"tool_call_id,omitempty"`
-	Name       string         `json:"name,omitempty"`
-	// no reasoning_content field: it is a response-only signal and is never sent
-	// back upstream — re-uploading it is paid prompt input.
+	Content          *string        `json:"content"`
+	ReasoningContent string         `json:"reasoning_content,omitempty"`
+	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
+	ToolCallID       string         `json:"tool_call_id,omitempty"`
+	Name             string         `json:"name,omitempty"`
 }
 
 type chatTool struct {

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -289,8 +289,8 @@ func TestNormaliseUsageMiMoShape(t *testing.T) {
 // back in the outgoing request. DeepSeek otherwise counts it as paid prompt
 // input (~500 tok/turn on a reasoner chain). The session keeps it for
 // display/archive; the wire request must not carry it.
-func TestBuildRequestDropsReasoningContent(t *testing.T) {
-	c := &client{model: "deepseek-reasoner"}
+func TestBuildRequestDropsReasoningOnPlainAssistantTurn(t *testing.T) {
+	c := &client{model: "deepseek-reasoner", deepseek: true}
 	req := c.buildRequest(provider.Request{
 		Messages: []provider.Message{
 			{Role: provider.RoleUser, Content: "explain"},
@@ -303,14 +303,37 @@ func TestBuildRequestDropsReasoningContent(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	if strings.Contains(string(b), "reasoning_content") {
-		t.Errorf("outgoing request must not carry a reasoning_content field: %s", b)
+		t.Errorf("a no-tool-calls assistant turn must not carry reasoning_content: %s", b)
 	}
 	if strings.Contains(string(b), "SECRET-CHAIN-OF-THOUGHT") {
 		t.Errorf("the assistant chain-of-thought leaked into the request: %s", b)
 	}
-	// The visible answer must survive — we only drop reasoning, not content.
 	if !strings.Contains(string(b), "the answer") {
 		t.Errorf("assistant content was dropped along with reasoning: %s", b)
+	}
+}
+
+// DeepSeek thinking mode 400s a tool_calls turn whose reasoning_content was
+// dropped on a cache-miss replay, so it must be round-tripped — but only on the
+// turn that carries tool calls, and only for the DeepSeek protocol.
+func TestBuildRequestRoundTripsReasoningOnDeepSeekToolCalls(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "count the go files"},
+		{
+			Role:             provider.RoleAssistant,
+			ReasoningContent: "CHAIN-OF-THOUGHT",
+			ToolCalls:        []provider.ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"ls"}`}},
+		},
+		{Role: provider.RoleTool, Content: "14", ToolCallID: "c1", Name: "bash"},
+	}
+	deepseek, _ := json.Marshal((&client{model: "deepseek-v4", deepseek: true}).buildRequest(provider.Request{Messages: msgs}).Messages)
+	if !strings.Contains(string(deepseek), "reasoning_content") || !strings.Contains(string(deepseek), "CHAIN-OF-THOUGHT") {
+		t.Errorf("DeepSeek tool_calls turn must round-trip reasoning_content: %s", deepseek)
+	}
+
+	other, _ := json.Marshal((&client{model: "mimo-v2"}).buildRequest(provider.Request{Messages: msgs}).Messages)
+	if strings.Contains(string(other), "CHAIN-OF-THOUGHT") {
+		t.Errorf("non-DeepSeek backends must not re-upload reasoning_content: %s", other)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related fixes around DeepSeek thinking mode, found while running the agent loop against the live API with the real provider.

### 1. `fix(openai)` — round-trip `reasoning_content` on DeepSeek tool_calls turns

DeepSeek's thinking mode now **requires** `reasoning_content` to be passed back on an assistant turn that carries `tool_calls`. The provider stripped it unconditionally, so the request fails with:

```
400 "The `reasoning_content` in the thinking mode must be passed back to the API."
```

The failure is **cache-state dependent**, which is why it looked intermittent:

| Condition | Result |
|---|---|
| Warm consecutive turns in a live session | ✅ tolerated — DeepSeek still holds the reasoning server-side |
| Cold replay: session resume, compaction, post-cache-TTL, tab switch | ❌ hard 400 |

Reproduced with the real provider on **both** `deepseek-v4-flash` and `deepseek-v4-pro`. A plain assistant *text* turn does **not** require it (verified), so the round-trip is scoped to `deepseek && assistant && len(tool_calls) > 0`.

**Cache safety:** the reasoning enters the cached prefix and is reused on later turns — measured `cacheHit 256 → 384`, `cacheMiss → 27` across rounds, no cache collapse. Cost is one miss per chain (DeepSeek-mandated), not a regression.

Edge case left as-is: a pre-fix archive whose tool_calls turn has no stored reasoning still 400s on resume — there's no data to round-trip.

### 2. `feat(agent)` — diagnostics on the empty-final notice

`empty final answer blocked ... retrying` carried no context, so we couldn't tell its causes apart. A live sweep (flash + pro) shows natural multi-round loops basically never hit it (0/6 realistic tasks, 0/10 warm wrap-ups); the reproduced triggers are all niche — the `<think>`-leading think-splitter path, or the model genuinely emitting no/whitespace content.

The notice now reports the provider, `finish_reason`, and reasoning length so each occurrence is self-diagnosing (length-truncation vs reasoning-only vs swallowed answer) instead of a guess.

## Test
- `go test ./internal/provider/openai/ ./internal/agent/` — pass
- New: `TestBuildRequestRoundTripsReasoningOnDeepSeekToolCalls`, `TestEmptyFinalNotice`; tightened `TestBuildRequestDropsReasoningOnPlainAssistantTurn`
