### PR TITLE
fix(ui): restrict inverted user bubble style to graphite theme only

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17179,7 +17179,7 @@ a[href] {
   animation: graphite-message-in var(--dur-slow) var(--ease-out) both;
 }
 
-:root[data-theme-style] .msg--user .msg__body {
+:root[data-theme-style="graphite"] .msg--user .msg__body {
   max-width: min(80%, 650px);
   padding: 11px 15px;
   border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
@@ -17189,7 +17189,7 @@ a[href] {
   box-shadow: var(--app-graphite-shadow);
 }
 
-:root[data-theme="dark"][data-theme-style] .msg--user .msg__body {
+:root[data-theme="dark"][data-theme-style="graphite"] .msg--user .msg__body {
   background: var(--fg);
   color: var(--bg);
 }


### PR DESCRIPTION
`[data-theme-style]` (bare, no value) matched every theme direction — graphite, carbon, aurora, slate — but the rule body uses graphite-specific colors (`--fg` as background, `--bg` as text). This turned user chat bubbles inside-out on non-graphite themes:

| Theme | Before (wrong) | After (correct) |
|---|---|---|
| carbon light | dark bubble, light text | `#f8f6f2` bg, `#1a1714` text |
| carbon dark | light bubble, dark text | `#1e1c1a` bg, `#ede9e3` text |

Fixed by narrowing both selectors to `[data-theme-style="graphite"]`.

Also fixes the pnpm environment variable in `dev`: pnpm v11 uses `pnmp_confirm_modules_purge`, not `PNPM_CONFIG_CONFIRM_MODULES_PURGE` (which is npm's format), so Wails' headless pnpm install was always blocked by the TTY prompt.