### PR TITLE
fix(desktop): apply pnpm purge guard so post-sync wails dev stops aborting

### DIFF
--- a/desktop/frontend/.npmrc
+++ b/desktop/frontend/.npmrc
@@ -1,0 +1,3 @@
+# pnpm 11: don't re-check deps before `pnpm build` and never prompt to purge node_modules headless.
+confirm-modules-purge=false
+verify-deps-before-run=false

--- a/dev
+++ b/dev
@@ -29,9 +29,9 @@ wails_port="${REASONIX_DESKTOP_WAILS_PORT:-$((vite_port + 29000))}"
 
 export REASONIX_DESKTOP_VITE_PORT="$vite_port"
 export REASONIX_DEV=1
-# pnpm v11: suppress TTY prompts and skip lockfile age checks in headless mode.
-export PNPM_CONFIG_CONFIRM_MODULES_PURGE=false
-export PNPM_CONFIG_MINIMUM_RELEASE_AGE=0
+# pnpm honors npm_config_* not PNPM_CONFIG_*; suppress headless TTY purge prompt + age gate.
+export npm_config_confirm_modules_purge=false
+export npm_config_minimum_release_age=0
 
 echo "Reasonix desktop dev"
 echo "  worktree: $root"


### PR DESCRIPTION
## Problem

Every desktop `./dev` after an upstream sync fails at the frontend step:

```
• Compiling frontend: [ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY] Aborted removal of modules directory due to no TTY
[ERROR] Command failed with exit code 1: pnpm install
  at runDepsStatusCheck (.../pnpm.mjs)
```

## Root cause

Two layers:

1. **pnpm 11 `verify-deps-before-run`.** `frontend:install` (`pnpm install`) succeeds, but `frontend:build` (`pnpm build`) re-verifies deps before running the script (`runDepsStatusCheck`). After a sync the lockfile changed, so it decides `node_modules` is stale, triggers a reinstall that wants to **remove `node_modules`**, and — spawned by `wails dev` with no TTY — aborts.

2. **The guard in `dev` never applied.** `dev` exported `PNPM_CONFIG_CONFIRM_MODULES_PURGE=false`, but pnpm reads the npm-convention `npm_config_*`, not `PNPM_CONFIG_*`:

   | env set | `pnpm config get confirm-modules-purge` |
   |---|---|
   | `PNPM_CONFIG_CONFIRM_MODULES_PURGE=false` | `undefined` ❌ |
   | `npm_config_confirm_modules_purge=false` | `false` ✅ |

   So the purge/age guards were dead and the abort surfaced on every sync.

## Fix

- **`desktop/frontend/.npmrc`** (committed, TTY/CI/env-agnostic — the real fix; pnpm reads a project `.npmrc` when a `package.json` is present, verified):
  - `verify-deps-before-run=false` — `pnpm build` no longer re-checks/reinstalls; `frontend:install` already did.
  - `confirm-modules-purge=false` — any purge proceeds silently instead of aborting headless.
- **`dev`** — fix the env-var form to `npm_config_*` so the original headless intent works. `minimum_release_age=0` stays dev-only (not committed globally, so the supply-chain age gate is unchanged for everyone else).

## Test

`cd desktop/frontend && rm -rf node_modules && pnpm install && cd ../.. && ./dev` — frontend compiles, no purge abort. The `.npmrc` settings were validated against pnpm directly (`npm_config_*` honored, `PNPM_CONFIG_*` ignored; project `.npmrc` read with `package.json` present).
