### PR TITLE
fix(chat): clear accumulated shell output on !command re-run (+ regression test)

### DIFF
--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -311,6 +311,27 @@ func TestConsecutiveToolCallsKeepMarkersUnderOwnCard(t *testing.T) {
 	}
 }
 
+// TestRepeatedShellCommandDoesNotAccumulateOutput is the regression test for a
+// re-run of the same "!" command (e.g. !pwd three times). RunShell derives a
+// stable id from the command text ("shell-pwd"), so streamToolOutput kept
+// appending each run's output onto the previous run's in m.shellOutputs[id];
+// beginToolRunning now clears the entry so each run starts from a clean slate.
+func TestRepeatedShellCommandDoesNotAccumulateOutput(t *testing.T) {
+	m := newTestChatTUI()
+	const id = "shell-pwd"
+	const out = "/home/user/project\n"
+
+	for range 3 {
+		m.ingestEvent(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{ID: id, Name: "bash", Args: `{"command":"pwd"}`}})
+		m.ingestEvent(event.Event{Kind: event.ToolProgress, Tool: event.Tool{ID: id, Output: out}})
+		m.ingestEvent(event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: id, Name: "bash", Output: out}})
+	}
+
+	if got := m.shellOutputs[id]; got != out {
+		t.Fatalf("a re-run must not accumulate prior output: shellOutputs[%q] = %q, want %q", id, got, out)
+	}
+}
+
 // TestConsecutiveNonShellToolsDoNotRenderNegativeLineCount is the regression
 // test for the review-blocking case. The original fix to back-to-back shell
 // tools records every dispatched id in shellTranscriptIdx so a late

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1940,6 +1940,9 @@ func (m *chatTUI) beginToolRunning(id string) {
 	m.toolTail = m.toolTail[:0]
 	m.toolPartial = ""
 	m.toolLineCount = 0
+	// Clear accumulated output for this tool ID so a re-run (e.g. repeated
+	// !pwd with the same "shell-pwd" id) doesn't append to old output.
+	delete(m.shellOutputs, id)
 	m.toolStreamStart = time.Now()
 	m.toolStreamFrame = 0
 	if m.nativeScrollback {


### PR DESCRIPTION
Lands @CnsMaple's fix from #4020 with an added regression test.

Closes #4020

## Problem

Repeated `!pwd` (or any `!` command) accumulated output across runs. `RunShell`
derives a stable tool id from the command text (`shell-pwd`), and
`streamToolOutput` does `m.shellOutputs[id] += chunk` — `beginToolRunning` never
cleared the entry, so each re-run appended to the prior run's output and
`collapseShellSlot` rendered all of it.

## Fix (@CnsMaple, #4020)

Clear `m.shellOutputs[id]` in `beginToolRunning`, which runs on each `ToolDispatch`
— before the new run accumulates and after the previous run already collapsed
into the transcript. One `delete`, both render modes.

## Added here

`TestRepeatedShellCommandDoesNotAccumulateOutput`: three identical `shell-pwd`
runs must leave one run's output in `shellOutputs`, not three. Verified it fails
without the fix (`"…\n…\n…\n"`) and passes with it.

## Test
- `go test ./internal/cli/` — pass
