### PR TITLE
fix(desktop): show session-scoped file changes in workspace panel

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -20,7 +20,7 @@ import { useToast } from "./lib/toast";
 import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, useI18n, useT } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
-import { app, onProjectTreeChanged } from "./lib/bridge";
+import { app, onEvent, onProjectTreeChanged } from "./lib/bridge";
 import { Transcript } from "./components/Transcript";
 import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
@@ -422,6 +422,17 @@ export default function App() {
   const [rightDockTreeWidth, setRightDockTreeWidth] = useState(loadRightDockTreeWidth);
   const [rightDockPreviewWidth, setRightDockPreviewWidth] = useState(loadRightDockPreviewWidth);
   const [workspacePreviewActive, setWorkspacePreviewActive] = useState(false);
+  // Bump dockRefreshKey after each turn so WorkspacePanel/ContextPanel re-fetch
+  // workspace changes, git history, and session metadata after AI tool writes.
+  useEffect(() => {
+    const unsub = onEvent((e) => {
+      if (e.kind === "turn_done") {
+        setDockRefreshKey((v) => v + 1);
+      }
+    });
+    return unsub;
+  }, []);
+
   const [workspacePanelResizing, setWorkspacePanelResizing] = useState(false);
   const [workspacePanelMaximized, setWorkspacePanelMaximized] = useState(false);
   const [rightDockMode, setRightDockMode] = useState<RightDockMode>("context");

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -26,7 +26,7 @@ import {
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { loadLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
-import type { DirEntry, FilePreview, GitCommitView, GitCommitDetailView } from "../lib/types";
+import type { DirEntry, FilePreview, GitCommitView, GitCommitDetailView, WorkspaceChangeView } from "../lib/types";
 import { formatWorkspaceReference, WORKSPACE_REF_DRAG_TYPE } from "../lib/workspaceDrag";
 import { cleanGitDiff } from "../lib/diff";
 import { CodeViewer } from "./CodeViewer";
@@ -229,6 +229,7 @@ export function WorkspacePanel({
   const [loadingPreview, setLoadingPreview] = useState(false);
   const [viewMode, setViewMode] = useState<"files" | "changed">(initialViewMode);
   const [gitHistory, setGitHistory] = useState<GitCommitView[]>([]);
+  const [workspaceChanges, setWorkspaceChanges] = useState<WorkspaceChangeView[] | null>(null);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [expandedCommit, setExpandedCommit] = useState<string | null>(null);
   const [commitDetail, setCommitDetail] = useState<GitCommitDetailView | null>(null);
@@ -275,6 +276,15 @@ export function WorkspacePanel({
       setLoadingHistory(false);
     }
   }, [selectedPath]);
+
+  const loadWorkspaceChanges = useCallback(async () => {
+    try {
+      const result = await app.WorkspaceChanges();
+      setWorkspaceChanges(result.files && result.files.length > 0 ? result.files : null);
+    } catch {
+      setWorkspaceChanges(null);
+    }
+  }, []);
 
   const toggleCommit = useCallback((hash: string) => {
     setExpandedCommit((prev) => {
@@ -509,16 +519,18 @@ export function WorkspacePanel({
     if (!open) return;
     if (viewMode === "changed") {
       void loadGitHistory();
+      void loadWorkspaceChanges();
     }
-  }, [selectedPath, viewMode, loadGitHistory, open]);
+  }, [selectedPath, viewMode, loadGitHistory, loadWorkspaceChanges, open]);
 
   useEffect(() => {
     if (!open || !refreshKey) return;
     if (viewMode === "changed") {
       void loadGitHistory();
+      void loadWorkspaceChanges();
     }
     openDirsRef.current.forEach((dir) => void loadDir(dir));
-  }, [loadGitHistory, loadDir, open, refreshKey, viewMode]);
+  }, [loadGitHistory, loadWorkspaceChanges, loadDir, open, refreshKey, viewMode]);
 
   useEffect(() => {
     if (!selectionMenu && !treeMenu) return;
@@ -581,6 +593,8 @@ export function WorkspacePanel({
     };
   }, [selectedPath]);
 
+
+
   useEffect(() => {
     if (!open || !selectedPath) return;
     return refreshSelected();
@@ -628,6 +642,11 @@ export function WorkspacePanel({
 
   const breadcrumbDirs = selectedPath ? parentDirs(selectedPath) : [""];
   const pathParts = selectedPath?.split("/").filter(Boolean) ?? [];
+  const sessionChanges = useMemo(
+    () => workspaceChanges?.filter((c) => c.sources.includes("session")) ?? null,
+    [workspaceChanges],
+  );
+
   const changedMode = viewMode === "changed";
   const currentFileName = selectedPath ? basename(selectedPath) : t("workspace.noFile");
   const currentFileDir = selectedPath ? parentPath(selectedPath) : "";
@@ -1083,9 +1102,40 @@ export function WorkspacePanel({
             </div>
           ) : viewMode === "changed" && !selectedPath ? (
             <div className="workspace-git-history">
+              {sessionChanges && sessionChanges.length > 0 && (
+                <div className="workspace-change-scope">
+                  <div className="workspace-change-scope__head">
+                    <span className="workspace-change-scope__title">{t("workspace.changedTab")}</span>
+                    <span className="workspace-change-scope__meta">{t("context.changedMeta", { count: sessionChanges.length })}</span>
+                  </div>
+                  <div className="workspace-change-scope__list">
+                    {sessionChanges.map((change) => {
+                      const dir = parentPath(change.path);
+                      return (
+                        <button
+                          key={change.path}
+                          className="workspace-change"
+                          type="button"
+                          onClick={() => selectFile(change.path)}
+                        >
+                          <FileText size={14} />
+                          <span className="workspace-change__body">
+                            <span className="workspace-change__name">{basename(change.path)}</span>
+                            {dir && <span className="workspace-change__path">{dir}</span>}
+                            {change.latestPrompt && <span className="workspace-change__detail">{change.latestPrompt}</span>}
+                          </span>
+                          <span className="workspace-change__meta">
+                            {change.gitStatus && <span className="workspace-change__badge workspace-change__badge--git">{change.gitStatus}</span>}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
               {loadingHistory ? (
                 <div className="workspace-empty">{t("workspace.loading")}</div>
-              ) : gitHistory.length === 0 ? (
+              ) : gitHistory.length === 0 && !(sessionChanges && sessionChanges.length > 0) ? (
                 <div className="workspace-empty">{t("workspace.noChanges")}</div>
               ) : (
                 <div className="workspace-git-history__list">


### PR DESCRIPTION
Two fixes for issue #4001:

1. App.tsx: subscribe to onEvent turn_done and bump dockRefreshKey so WorkspacePanel/ContextPanel re-fetch after AI tool writes.

2. WorkspacePanel.tsx:
   - Load app.WorkspaceChanges() alongside git history on refresh
   - Filter to sources: ['session'] — only files the agent actually wrote
   - Render session changes list above git history in 'changed' tab
   - Only show 'no changes' when both sources are empty