### PR TITLE
refactor(evidence): reuse stepTextContains for todo overlap, hoist bounds guard

### DIFF
--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -678,14 +678,14 @@ func hasSuccessfulCompleteStepForTodo(receipts []Receipt, index int, current []T
 			continue
 		}
 		if r.TodoStep != nil && r.TodoStep.Found {
-			if index >= 1 && index <= len(current) && sameTodoMatch(current[index-1], *r.TodoStep) {
+			if index < 1 || index > len(current) {
+				continue
+			}
+			if sameTodoMatch(current[index-1], *r.TodoStep) {
 				return true
 			}
-			// sameTodoMatch failed — the todo content changed.
-			// Allow the fallback (matchTodoStep by index or text) only
-			// when the old and new content are recognisably related
-			// (substring overlap); otherwise block a replaced todo
-			// from reusing an old numeric complete_step receipt.
+			// Content changed: allow the index/text fallback only when old and
+			// new overlap, so a replaced todo can't reuse an old receipt.
 			if !todoContentRelates(current[index-1], *r.TodoStep) {
 				continue
 			}
@@ -723,21 +723,7 @@ func todoContentRelates(todo TodoItem, match TodoStepMatch) bool {
 }
 
 func textOverlaps(a, b string) bool {
-	a = normalizeStepText(a)
-	b = normalizeStepText(b)
-	if a == "" || b == "" {
-		return false
-	}
-	// Require ≥6 runes on the shorter side to avoid false positives on
-	// short shared substrings (same guard as stepTextContains).
-	short := a
-	if utf8.RuneCountInString(b) < utf8.RuneCountInString(a) {
-		short = b
-	}
-	if utf8.RuneCountInString(short) < 6 {
-		return false
-	}
-	return strings.Contains(a, b) || strings.Contains(b, a)
+	return stepTextContains(normalizeStepText(a), normalizeStepText(b))
 }
 
 func matchTodoStep(step string, todos []TodoItem) TodoStepMatch {


### PR DESCRIPTION
Follow-up to #4013 (no behavior change; `internal/evidence` tests pass unchanged).

- **Reuse `stepTextContains`.** `textOverlaps` was a verbatim copy of `stepTextContains` (#4006) with normalization folded in. Replace its body with `stepTextContains(normalizeStepText(a), normalizeStepText(b))` — drops ~15 duplicated lines.
- **Hoist the bounds guard.** `hasSuccessfulCompleteStepForTodo` guarded `index` inline on the `sameTodoMatch` line but accessed `current[index-1]` unguarded in the new overlap branch. Move the `index` range check to the top of the block so both accesses share one guard.
