### PR TITLE
feat(crash-worker): add /v1/metrics ingest for opt-in agent metrics

### DIFF
--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -32,3 +32,15 @@ CREATE TABLE IF NOT EXISTS pings (
   opens INTEGER NOT NULL DEFAULT 1,
   PRIMARY KEY (date, install_id)
 );
+
+-- Opt-in aggregate agent metrics: anonymous per-day (signal, bucket) counters,
+-- no install id and no content. Generic shape so a new signal is just new rows.
+CREATE TABLE IF NOT EXISTS metrics (
+  date TEXT NOT NULL,
+  version TEXT NOT NULL,
+  os TEXT NOT NULL,
+  signal TEXT NOT NULL,
+  bucket TEXT NOT NULL,
+  count INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (date, version, os, signal, bucket)
+);

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -11,6 +11,7 @@ interface Env {
   DB: D1Database;
   RATE_LIMITER: RateLimiter;
   PING_LIMITER: RateLimiter;
+  METRICS_LIMITER: RateLimiter;
   STATS_PASSWORD?: string;
 }
 
@@ -41,6 +42,38 @@ const Ping = z.object({
   os: z.string().min(1).max(32),
   arch: z.string().min(1).max(32),
   osVersion: z.string().max(128).optional(),
+});
+
+// Opt-in aggregate agent metrics: a per-launch snapshot of (signal, bucket)
+// counters. No install id, no content — just enumerated signals so the worker
+// table can never be polluted with arbitrary keys.
+const METRIC_SIGNALS = [
+  "finish_reason",
+  "empty_final",
+  "provider_error",
+  "cache_hit",
+  "tool_error",
+  "compaction",
+  "turns",
+] as const;
+
+const Metrics = z.object({
+  version: z.string().min(1).max(64),
+  os: z.string().min(1).max(32),
+  counters: z
+    .array(
+      z.object({
+        signal: z.enum(METRIC_SIGNALS),
+        bucket: z
+          .string()
+          .min(1)
+          .max(32)
+          .regex(/^[a-z0-9_]+$/),
+        count: z.number().int().min(1).max(1_000_000),
+      }),
+    )
+    .min(1)
+    .max(64),
 });
 
 export function normalizeForFingerprint(kind: string, message: string): string {
@@ -132,6 +165,28 @@ async function handlePing(request: Request, env: Env): Promise<Response> {
   return new Response("ok", { status: 202 });
 }
 
+async function handleMetrics(request: Request, env: Env): Promise<Response> {
+  const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
+  const { success } = await env.METRICS_LIMITER.limit({ key: ip });
+  if (!success) return new Response("rate limited", { status: 429 });
+
+  const raw = await readJSON(request);
+  if (raw instanceof Response) return raw;
+  const parsed = Metrics.safeParse(raw);
+  if (!parsed.success) return new Response("bad request", { status: 400 });
+  const m = parsed.data;
+
+  const upsert = env.DB.prepare(
+    `INSERT INTO metrics (date, version, os, signal, bucket, count)
+     VALUES (date('now'), ?1, ?2, ?3, ?4, ?5)
+     ON CONFLICT (date, version, os, signal, bucket) DO UPDATE SET
+       count = count + ?5`,
+  );
+  await env.DB.batch(m.counters.map((c) => upsert.bind(m.version, m.os, c.signal, c.bucket, c.count)));
+
+  return new Response("ok", { status: 202 });
+}
+
 function statsAuthorized(request: Request, env: Env): boolean {
   // trim: secrets piped in via PowerShell arrive with a trailing newline.
   const want = (env.STATS_PASSWORD ?? "").trim();
@@ -155,7 +210,7 @@ function html(body: string): Response {
 }
 
 async function handleStats(env: Env): Promise<Response> {
-  const [daily, versions, platforms, crashes] = await Promise.all([
+  const [daily, versions, platforms, crashes, metrics] = await Promise.all([
     env.DB.prepare(
       "SELECT date, COUNT(*) AS users, SUM(opens) AS opens FROM pings WHERE date >= date('now', '-29 day') GROUP BY date",
     ).all<{ date: string; users: number; opens: number }>(),
@@ -168,6 +223,9 @@ async function handleStats(env: Env): Promise<Response> {
     env.DB.prepare(
       "SELECT fingerprint, kind, count, last_version, substr(last_seen, 1, 10) AS seen FROM groups ORDER BY last_seen DESC LIMIT 25",
     ).all<{ fingerprint: string; kind: string; count: number; last_version: string; seen: string }>(),
+    env.DB.prepare(
+      "SELECT signal, bucket, SUM(count) AS total FROM metrics WHERE date >= date('now', '-6 day') GROUP BY signal, bucket ORDER BY signal, total DESC",
+    ).all<{ signal: string; bucket: string; total: number }>(),
   ]);
   return html(
     renderStats({
@@ -175,6 +233,7 @@ async function handleStats(env: Env): Promise<Response> {
       versions: versions.results,
       platforms: platforms.results,
       crashes: crashes.results,
+      metrics: metrics.results,
     }),
   );
 }
@@ -197,6 +256,7 @@ export default {
     const url = new URL(request.url);
     if (url.pathname === "/v1/report" && request.method === "POST") return handleReport(request, env);
     if (url.pathname === "/v1/ping" && request.method === "POST") return handlePing(request, env);
+    if (url.pathname === "/v1/metrics" && request.method === "POST") return handleMetrics(request, env);
 
     const group = url.pathname.match(/^\/stats\/group\/([0-9a-f]{64})$/);
     if ((url.pathname === "/stats" || group) && request.method === "GET") {
@@ -208,7 +268,12 @@ export default {
       }
       return group ? handleGroup(env, group[1]) : handleStats(env);
     }
-    if (url.pathname === "/v1/report" || url.pathname === "/v1/ping" || url.pathname.startsWith("/stats")) {
+    if (
+      url.pathname === "/v1/report" ||
+      url.pathname === "/v1/ping" ||
+      url.pathname === "/v1/metrics" ||
+      url.pathname.startsWith("/stats")
+    ) {
       return new Response("method not allowed", { status: 405 });
     }
     return new Response("not found", { status: 404 });

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -48,7 +48,9 @@ a.fp:hover{text-decoration:underline}
 .report .meta b{color:var(--ink);font-weight:500}
 pre{background:var(--term-bg);color:#e6e8f0;border-radius:12px;padding:16px 18px;font-family:var(--mono);
 font-size:12.5px;line-height:1.55;overflow:auto;white-space:pre-wrap;word-break:break-word}
-@media(max-width:760px){.grid{grid-template-columns:1fr}.wrap{padding:0 16px 48px}}
+.metrics{display:grid;grid-template-columns:1fr 1fr;gap:8px 28px}
+.metric-block h3{font-family:var(--mono);font-size:12.5px;font-weight:600;color:var(--ink-2);margin:6px 0 4px}
+@media(max-width:760px){.grid{grid-template-columns:1fr}.metrics{grid-template-columns:1fr}.wrap{padding:0 16px 48px}}
 `;
 
 function page(title: string, crumb: string, body: string): string {
@@ -104,11 +106,26 @@ function listBars(rows: { label: string; users: number }[]): string {
     .join("");
 }
 
+function metricsCards(rows: { signal: string; bucket: string; total: number }[]): string {
+  if (!rows.length)
+    return `<div class="empty">No metrics yet — flows in once an opt-in build ships · 等 opt-in 版本发布后有数据</div>`;
+  const bySignal = new Map<string, { label: string; users: number }[]>();
+  for (const r of rows) {
+    const list = bySignal.get(r.signal) ?? [];
+    list.push({ label: r.bucket, users: r.total });
+    bySignal.set(r.signal, list);
+  }
+  return `<div class="metrics">${[...bySignal.entries()]
+    .map(([signal, list]) => `<div class="metric-block"><h3>${esc(signal)}</h3>${listBars(list)}</div>`)
+    .join("")}</div>`;
+}
+
 export function renderStats(data: {
   daily: Daily[];
   versions: { label: string; users: number }[];
   platforms: { label: string; users: number }[];
   crashes: { fingerprint: string; kind: string; count: number; last_version: string; seen: string }[];
+  metrics: { signal: string; bucket: string; total: number }[];
 }): string {
   const days = last30Days(data.daily);
   const totalUsers = days.at(-1)?.users ?? 0;
@@ -131,6 +148,7 @@ export function renderStats(data: {
 ${anyPing ? dailyChart(days) : `<div class="empty">No pings yet — data starts flowing once a telemetry-enabled build ships · 等带统计的版本发布后这里开始有数据</div>`}</div>
 <div class="card"><h2>Versions · 版本分布 <b>— 7 days</b></h2>${listBars(data.versions)}</div>
 <div class="card"><h2>Platforms · 平台分布 <b>— 7 days</b></h2>${listBars(data.platforms)}</div>
+<div class="card full"><h2>Agent signals · 运行指标 <b>— 7 days, opt-in aggregate</b></h2>${metricsCards(data.metrics)}</div>
 <div class="card full"><h2>Crash groups · 崩溃分组 <b>— click a fingerprint for stacks</b></h2>${crashRows}</div>
 </div>`,
   );

--- a/workers/crash-report/wrangler.toml
+++ b/workers/crash-report/wrangler.toml
@@ -22,3 +22,11 @@ name = "PING_LIMITER"
 type = "ratelimit"
 namespace_id = "1002"
 simple = { limit = 30, period = 60 }
+
+# Opt-in metrics flush fires once per launch like the ping; its own bucket so it
+# never eats the ping budget on a shared NAT IP.
+[[unsafe.bindings]]
+name = "METRICS_LIMITER"
+type = "ratelimit"
+namespace_id = "1003"
+simple = { limit = 30, period = 60 }


### PR DESCRIPTION
Worker side of the opt-in agent-metrics telemetry (desktop-only, aggregate, opt-in — per the telemetry-scope decision). This PR is the ingest + storage + stats; the desktop aggregator + opt-in flag land in a follow-up, so nothing posts here until that ships and a user turns it on.

## What it adds

- **`metrics` table** (`schema.sql`): generic `(date, version, os, signal, bucket) -> count`. New signals are just new rows — no migration to add one.
- **`POST /v1/metrics`** (`index.ts`): zod-validated per-launch snapshot, upserts each counter (`count = count + delta`). `signal` is an enum; `bucket` is `^[a-z0-9_]+$` capped at 32 chars, ≤64 counters/request — the table can't be polluted with arbitrary keys.
- **`METRICS_LIMITER`** (`wrangler.toml`): own rate-limit bucket (30/60), so a launch's metrics flush never eats the ping budget on a shared NAT IP.
- **Stats page section** (`stats.ts`): "Agent signals" card, each signal broken down by bucket.

## Privacy

No install id, no content, no keys, no prompts, no paths — only enumerated integer counters. v1 signals: `finish_reason`, `empty_final`, `provider_error`, `cache_hit`, `tool_error`, `compaction`, `turns`.

## Deploy (owner-run)

1. `wrangler d1 execute reasonix-crash --remote --file=schema.sql` (idempotent — `CREATE TABLE IF NOT EXISTS`)
2. `wrangler deploy`

## Test
- `npm run typecheck` (worker) — pass

## Next
Desktop aggregator tapping the existing `toWire` event sink + `desktop.metrics` opt-in flag + settings toggle + first-run disclosure.
