### PR TITLE
refactor(ui): keep running read-only tools out of the warm-turn batch

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -778,7 +778,7 @@ function WarmTurnItems({
     const it = items[i];
 
     // Completed read-only tools → batch into ReadOnlyBatch
-    if (it.kind === "tool" && it.readOnly && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode") {
+    if (it.kind === "tool" && it.readOnly && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode" && it.status !== "running") {
       roBatch.push(it as ToolItem);
       continue;
     }
@@ -980,7 +980,6 @@ function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) 
       )}
     </div>
   );
-
 }
 
 // ── JumpBar, PhaseCard, NoticeCard, CompactionCard ────────────────────────────


### PR DESCRIPTION
Follow-up to #4031.

- **Consistency.** The hot-zone and `TurnCollapse` read-only batch paths skip tools with `status === "running"` (they render individually with the shimmer); `WarmTurnItems` batched read-only tools without that guard. Add `it.status !== "running"` so an interrupted running tool lingering in a warm turn renders individually instead of folding silently into the batch. No-op for normal history (warm turns are complete).
- **Drop a stray blank line** before the `TurnCollapse` close brace.
