### PR TITLE
feat(desktop): opt-in aggregate agent-metrics aggregator + flush

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -77,6 +77,8 @@ type App struct {
 
 	mediaTokens *mediaTokenStore
 	botInstalls map[string]*botInstallSession
+
+	metrics *metricsAggregator // non-nil only when desktop.metrics is opted in
 }
 
 // mediaTokenEntry holds metadata for a workspace media file served via temporary URL.
@@ -269,8 +271,13 @@ func (a *App) startup(ctx context.Context) {
 	installSystemQuitHook()
 	a.startTray()
 
+	if cfg, err := config.Load(); err == nil && cfg.DesktopMetrics() && version != "dev" {
+		a.metrics = newMetricsAggregator(filepath.Dir(config.UserConfigPath()))
+	}
+
 	go a.restoreOrBuildTabs()
 	go a.sendStartupPing()
+	go a.flushMetrics()
 }
 
 func (a *App) beforeClose(ctx context.Context) bool {

--- a/desktop/metrics_app.go
+++ b/desktop/metrics_app.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+
+	"reasonix/internal/config"
+	"reasonix/internal/event"
+)
+
+// metrics_app.go is the opt-in aggregate agent-metrics flush: anonymous
+// (signal, bucket) counters observed from the event stream, POSTed once per
+// launch. Never carries content, keys, prompts, or paths — only enumerated
+// integer counts. Gated on config desktop.metrics (default off), dev-skipped.
+
+var metricsEndpoint = "https://crash.reasonix.io/v1/metrics"
+
+const metricsPendingFile = "metrics-pending.json"
+
+var statusCodePattern = regexp.MustCompile(`status (\d{3})`)
+
+type counters map[string]map[string]int // signal -> bucket -> count
+
+func (c counters) add(signal, bucket string, n int) {
+	if c[signal] == nil {
+		c[signal] = map[string]int{}
+	}
+	c[signal][bucket] += n
+}
+
+func (c counters) merge(other counters) {
+	for sig, buckets := range other {
+		for b, n := range buckets {
+			c.add(sig, b, n)
+		}
+	}
+}
+
+// metricsAggregator accumulates one session's (signal, bucket) counts and merges
+// them into a pending file that flushMetrics drains on the next launch.
+type metricsAggregator struct {
+	path string
+	mu   sync.Mutex
+	c    counters
+}
+
+func newMetricsAggregator(configDir string) *metricsAggregator {
+	return &metricsAggregator{path: filepath.Join(configDir, metricsPendingFile), c: counters{}}
+}
+
+func (m *metricsAggregator) inc(signal, bucket string) {
+	m.mu.Lock()
+	m.c.add(signal, bucket, 1)
+	m.mu.Unlock()
+}
+
+// observe maps one event to counter increments, reading only enumerated facts
+// (finish reason, error class, cache-hit bucket) — never message text.
+func (m *metricsAggregator) observe(e event.Event) {
+	switch e.Kind {
+	case event.Usage:
+		if e.Usage == nil {
+			return
+		}
+		if e.Usage.FinishReason != "" {
+			m.inc("finish_reason", e.Usage.FinishReason)
+		}
+		if e.Usage.CacheHitTokens+e.Usage.CacheMissTokens > 0 {
+			m.inc("cache_hit", cacheBucket(e.Usage.CacheHitTokens, e.Usage.CacheMissTokens))
+		}
+	case event.TurnDone:
+		m.inc("turns", "total")
+		if e.Err != nil {
+			m.inc("provider_error", errorClass(e.Err.Error()))
+		}
+	case event.ToolResult:
+		if e.Tool.Err != "" {
+			m.inc("tool_error", toolErrorClass(e.Tool.Err))
+		}
+	case event.CompactionDone:
+		m.inc("compaction", "total")
+	case event.Notice:
+		if strings.HasPrefix(e.Text, "empty final answer blocked") {
+			m.inc("empty_final", "total")
+		}
+	}
+}
+
+func cacheBucket(hit, miss int) string {
+	pct := float64(hit) / float64(hit+miss) * 100
+	switch {
+	case pct < 50:
+		return "0_50"
+	case pct < 80:
+		return "50_80"
+	case pct < 95:
+		return "80_95"
+	case pct < 99:
+		return "95_99"
+	default:
+		return "99_100"
+	}
+}
+
+// errorClass extracts only the failure category — never the message itself, which
+// can echo request content back from a provider.
+func errorClass(msg string) string {
+	if mm := statusCodePattern.FindStringSubmatch(msg); mm != nil {
+		switch code := mm[1]; {
+		case code == "400":
+			return "http_400"
+		case code == "401" || code == "403":
+			return "http_401"
+		case code == "429":
+			return "http_429"
+		case code[0] == '5':
+			return "http_5xx"
+		}
+	}
+	low := strings.ToLower(msg)
+	switch {
+	case strings.Contains(low, "reset"), strings.Contains(low, "interrupt"), strings.Contains(low, "eof"):
+		return "stream_interrupted"
+	case strings.Contains(low, "timeout"), strings.Contains(low, "deadline"):
+		return "timeout"
+	default:
+		return "other"
+	}
+}
+
+func toolErrorClass(msg string) string {
+	low := strings.ToLower(msg)
+	switch {
+	case strings.Contains(low, "permission"):
+		return "permission"
+	case strings.Contains(low, "plan mode"):
+		return "planmode"
+	case strings.Contains(low, "hook"):
+		return "hook"
+	case strings.Contains(low, "timeout"), strings.Contains(low, "deadline"):
+		return "timeout"
+	default:
+		return "exec"
+	}
+}
+
+// persist merges the session delta into the pending file and resets it, so a
+// force-kill loses at most the counts since the last turn.
+func (m *metricsAggregator) persist() {
+	m.mu.Lock()
+	if len(m.c) == 0 {
+		m.mu.Unlock()
+		return
+	}
+	delta := m.c
+	m.c = counters{}
+	m.mu.Unlock()
+
+	pending := readCounters(m.path)
+	pending.merge(delta)
+	writeCounters(m.path, pending)
+}
+
+func readCounters(path string) counters {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return counters{}
+	}
+	var c counters
+	if json.Unmarshal(b, &c) != nil || c == nil {
+		return counters{}
+	}
+	return c
+}
+
+func writeCounters(path string, c counters) {
+	if b, err := json.Marshal(c); err == nil {
+		_ = os.WriteFile(path, b, 0o644)
+	}
+}
+
+type metricCounter struct {
+	Signal string `json:"signal"`
+	Bucket string `json:"bucket"`
+	Count  int    `json:"count"`
+}
+
+type metricsPayload struct {
+	Version  string          `json:"version"`
+	OS       string          `json:"os"`
+	Counters []metricCounter `json:"counters"`
+}
+
+func flatten(c counters) []metricCounter {
+	out := make([]metricCounter, 0, len(c))
+	for sig, buckets := range c {
+		for b, n := range buckets {
+			if n > 0 {
+				out = append(out, metricCounter{Signal: sig, Bucket: b, Count: n})
+			}
+		}
+	}
+	return out
+}
+
+// flushMetrics drains the pending file from prior sessions and POSTs it, then
+// clears it on success or folds it back to retry next launch. Runs at launch
+// (mirroring the ping) so the current session's counts ship next time.
+func (a *App) flushMetrics() {
+	if version == "dev" {
+		return
+	}
+	cfg, err := config.Load()
+	if err != nil || !cfg.DesktopMetrics() {
+		return
+	}
+	path := filepath.Join(filepath.Dir(config.UserConfigPath()), metricsPendingFile)
+	temp := path + ".sending"
+	if os.Rename(path, temp) != nil {
+		return // nothing pending
+	}
+	flat := flatten(readCounters(temp))
+	if len(flat) == 0 || a.postMetrics(metricsPayload{Version: version, OS: runtime.GOOS, Counters: flat}) {
+		_ = os.Remove(temp)
+		return
+	}
+	pending := readCounters(path)
+	pending.merge(readCounters(temp))
+	writeCounters(path, pending)
+	_ = os.Remove(temp)
+}
+
+func (a *App) postMetrics(p metricsPayload) bool {
+	body, err := json.Marshal(p)
+	if err != nil {
+		return false
+	}
+	c, err := httpClient()
+	if err != nil {
+		return false
+	}
+	req, err := http.NewRequestWithContext(a.bootContext(), http.MethodPost, metricsEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode < 300
+}

--- a/desktop/metrics_app_test.go
+++ b/desktop/metrics_app_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+func TestObserveClassifiesEvents(t *testing.T) {
+	m := newMetricsAggregator(t.TempDir())
+	feed := []event.Event{
+		{Kind: event.Usage, Usage: &provider.Usage{FinishReason: "stop", CacheHitTokens: 99, CacheMissTokens: 1}},
+		{Kind: event.Usage, Usage: &provider.Usage{FinishReason: "tool_calls", CacheHitTokens: 60, CacheMissTokens: 40}},
+		{Kind: event.ToolResult, Tool: event.Tool{Name: "bash", Err: "blocked by permission policy"}},
+		{Kind: event.CompactionDone},
+		{Kind: event.Notice, Text: "empty final answer blocked: model returned no visible answer text; retrying"},
+		{Kind: event.TurnDone, Err: errors.New("deepseek-flash: status 429: rate limited")},
+		{Kind: event.TurnDone},
+	}
+	for _, e := range feed {
+		m.observe(e)
+	}
+
+	want := map[string]map[string]int{
+		"finish_reason":  {"stop": 1, "tool_calls": 1},
+		"cache_hit":      {"99_100": 1, "50_80": 1},
+		"tool_error":     {"permission": 1},
+		"compaction":     {"total": 1},
+		"empty_final":    {"total": 1},
+		"provider_error": {"http_429": 1},
+		"turns":          {"total": 2},
+	}
+	for sig, buckets := range want {
+		for b, n := range buckets {
+			if got := m.c[sig][b]; got != n {
+				t.Errorf("%s/%s = %d, want %d", sig, b, got, n)
+			}
+		}
+	}
+}
+
+func TestObserveReadsNoMessageText(t *testing.T) {
+	m := newMetricsAggregator(t.TempDir())
+	// A notice that merely mentions the phrase mid-string must not count.
+	m.observe(event.Event{Kind: event.Notice, Text: "see docs: empty final answer blocked is a guard"})
+	if m.c["empty_final"] != nil {
+		t.Errorf("empty_final should only match the notice prefix, got %v", m.c["empty_final"])
+	}
+}
+
+func TestErrorClass(t *testing.T) {
+	cases := map[string]string{
+		"deepseek: status 400: bad":           "http_400",
+		"status 401 unauthorized":             "http_401",
+		"status 403 forbidden":                "http_401",
+		"status 429 too many":                 "http_429",
+		"status 503 unavailable":              "http_5xx",
+		"read: connection reset by peer":      "stream_interrupted",
+		"stream interrupted mid-flight":       "stream_interrupted",
+		"context deadline exceeded (timeout)": "timeout",
+		"some unrecognized failure":           "other",
+	}
+	for msg, want := range cases {
+		if got := errorClass(msg); got != want {
+			t.Errorf("errorClass(%q) = %q, want %q", msg, got, want)
+		}
+	}
+}
+
+func TestCacheBucket(t *testing.T) {
+	cases := []struct {
+		hit, miss int
+		want      string
+	}{
+		{0, 100, "0_50"},
+		{49, 51, "0_50"},
+		{60, 40, "50_80"},
+		{90, 10, "80_95"},
+		{97, 3, "95_99"},
+		{999, 1, "99_100"},
+	}
+	for _, c := range cases {
+		if got := cacheBucket(c.hit, c.miss); got != c.want {
+			t.Errorf("cacheBucket(%d,%d) = %q, want %q", c.hit, c.miss, got, c.want)
+		}
+	}
+}
+
+func TestPersistMergesAcrossSessions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, metricsPendingFile)
+
+	s1 := newMetricsAggregator(dir)
+	s1.observe(event.Event{Kind: event.TurnDone})
+	s1.persist()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("pending file should exist after persist: %v", err)
+	}
+
+	// A second session merges into the same file rather than overwriting.
+	s2 := newMetricsAggregator(dir)
+	s2.observe(event.Event{Kind: event.TurnDone})
+	s2.persist()
+
+	if got := readCounters(path)["turns"]["total"]; got != 2 {
+		t.Errorf("merged turns/total = %d, want 2", got)
+	}
+	if n := len(flatten(readCounters(path))); n != 1 {
+		t.Errorf("flatten produced %d counters, want 1", n)
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -216,6 +216,12 @@ func (s *tabEventSink) Emit(e event.Event) {
 		case event.TurnDone:
 			s.recordTurnDone()
 		}
+		if s.app.metrics != nil {
+			s.app.metrics.observe(e)
+			if e.Kind == event.TurnDone {
+				s.app.metrics.persist()
+			}
+		}
 	}
 	if s.ctx != nil {
 		runtime.EventsEmit(s.ctx, eventChannel, toWireTab(e, s.tabID))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,7 @@ type DesktopConfig struct {
 	DisplayMode    string   `toml:"display_mode"`    // standard|compact|minimal; transcript display mode
 	CheckUpdates   *bool    `toml:"check_updates"`   // startup update checks; nil keeps the default enabled
 	Telemetry      *bool    `toml:"telemetry"`       // anonymous launch ping (install id + version + OS); nil keeps the default enabled
+	Metrics        *bool    `toml:"metrics"`         // opt-in aggregate agent metrics (anonymous signal/bucket counts; no content); nil = disabled
 	ProviderAccess []string `toml:"provider_access"` // desktop-only list of provider entries shown in Settings > Model > Access
 	ExpandThinking bool     `toml:"expand_thinking"` // true = show reasoning text expanded by default; false = collapsed
 }
@@ -221,6 +222,15 @@ func (c *Config) DesktopTelemetry() bool {
 		return true
 	}
 	return *c.Desktop.Telemetry
+}
+
+// DesktopMetrics reports whether the desktop sends opt-in aggregate agent
+// metrics — anonymous (signal, bucket) counters, never content. Default off.
+func (c *Config) DesktopMetrics() bool {
+	if c == nil || c.Desktop.Metrics == nil {
+		return false
+	}
+	return *c.Desktop.Metrics
 }
 
 // LSPConfig governs the optional Language Server Protocol tools (lsp_definition,

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -220,6 +220,12 @@ func (c *Config) SetDesktopTelemetry(enabled bool) error {
 	return nil
 }
 
+// SetDesktopMetrics sets whether the desktop sends opt-in aggregate agent metrics.
+func (c *Config) SetDesktopMetrics(enabled bool) error {
+	c.Desktop.Metrics = &enabled
+	return nil
+}
+
 // SetUICloseBehavior is kept for callers compiled against the old edit API.
 func (c *Config) SetUICloseBehavior(mode string) error {
 	return c.SetDesktopCloseBehavior(mode)

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -92,6 +92,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		fmt.Fprintf(&b, "close_behavior = %q   # desktop: quit|background when the window close button is clicked\n", c.DesktopCloseBehavior())
 		fmt.Fprintf(&b, "check_updates = %v   # desktop: check for new versions on startup\n", c.DesktopCheckUpdates())
 		fmt.Fprintf(&b, "telemetry = %v   # desktop: anonymous launch ping (install id + version + OS); never content\n", c.DesktopTelemetry())
+		fmt.Fprintf(&b, "metrics = %v   # desktop: opt-in aggregate agent metrics (anonymous signal/bucket counts); never content\n", c.DesktopMetrics())
 		if len(c.Desktop.ProviderAccess) > 0 {
 			fmt.Fprintf(&b, "provider_access = %s   # desktop settings: providers shown on Settings > Model > Access\n", renderStringArray(c.Desktop.ProviderAccess))
 		}


### PR DESCRIPTION
Desktop side of the opt-in agent-metrics telemetry. The worker `/v1/metrics` endpoint is already merged (#4030) and **deployed live** (schema applied, smoke-tested 202/400/405), so once this ships and a user opts in, counts start flowing.

## How it works

- **`metricsAggregator`** taps the existing `tabEventSink.Emit` event stream — `internal/agent` is untouched, so the **CLI stays zero-egress** (desktop-only, per the telemetry-scope decision).
- **`observe(e)`** counts enumerated facts only: `finish_reason`, `empty_final`, `provider_error` (class), `cache_hit` (bucket), `tool_error` (class), `compaction`, `turns`. Error classes come from a `status (\d{3})` regex + keyword match — **never the message body**, which can echo request content.
- Counts **persist per turn** (merge into a pending file) and **flush once at the next launch**, mirroring the ping. A failed POST folds back to retry.

## Privacy / opt-in

- New `desktop.metrics` flag, **default off**, separate from the default-on launch ping. Dev builds skip it.
- No install id, no content, no keys, no prompts, no paths — only enumerated integer counters. Worker rejects any non-enum signal / bad bucket (zod), so the table can't be polluted.

## Test
- `go test ./` (desktop) — aggregator classification, error/cache bucketing, cross-session merge; verified each mapping
- `go test ./internal/config/...`, `go build ./...` (desktop), `go vet ./...` — pass

## Not in this PR (follow-up)
Settings toggle + first-run disclosure (the user-facing opt-in switch). Until then the flag is set via `[desktop] metrics = true` in config.toml. No new bound App method here, so no bridge.ts AppBindings change.
