### PR TITLE
feat(desktop): settings toggle for opt-in agent metrics

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -78,7 +78,7 @@ type App struct {
 	mediaTokens *mediaTokenStore
 	botInstalls map[string]*botInstallSession
 
-	metrics *metricsAggregator // non-nil only when desktop.metrics is opted in
+	metrics atomic.Pointer[metricsAggregator] // non-nil only when desktop.metrics is opted in; swapped live by SetDesktopMetrics
 }
 
 // mediaTokenEntry holds metadata for a workspace media file served via temporary URL.
@@ -272,7 +272,7 @@ func (a *App) startup(ctx context.Context) {
 	a.startTray()
 
 	if cfg, err := config.Load(); err == nil && cfg.DesktopMetrics() && version != "dev" {
-		a.metrics = newMetricsAggregator(filepath.Dir(config.UserConfigPath()))
+		a.metrics.Store(newMetricsAggregator(filepath.Dir(config.UserConfigPath())))
 	}
 
 	go a.restoreOrBuildTabs()

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -168,6 +168,7 @@ export function SettingsPanel({ onClose, onChanged, initialTab, isDevBuild }: { 
                       configPath={s.configPath}
                       checkUpdates={s.checkUpdates}
                       telemetry={s.telemetry !== false}
+                      metrics={s.metrics === true}
                       settingsBusy={busy}
                       applySettings={apply}
                     />
@@ -3400,12 +3401,14 @@ function UpdatesSection({
   configPath,
   checkUpdates,
   telemetry,
+  metrics,
   settingsBusy,
   applySettings,
 }: {
   configPath: string;
   checkUpdates: boolean;
   telemetry: boolean;
+  metrics: boolean;
   settingsBusy: boolean;
   applySettings: (fn: () => Promise<void>) => Promise<void>;
 }) {
@@ -3441,6 +3444,17 @@ function UpdatesSection({
           value={telemetry}
           disabled={settingsBusy}
           onChange={(enabled) => void applySettings(() => app.SetDesktopTelemetry(enabled))}
+        />
+      </SettingsField>
+      <SettingsField
+        className="settings-field--wide-copy"
+        label={t("settings.metricsLabel")}
+        hint={t("settings.metricsHint")}
+      >
+        <ToggleSegment
+          value={metrics}
+          disabled={settingsBusy}
+          onChange={(enabled) => void applySettings(() => app.SetDesktopMetrics(enabled))}
         />
       </SettingsField>
       <SettingsField label={t("updater.currentVersion", { v: version || "…" })}>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -221,6 +221,7 @@ export interface AppBindings {
   SetDesktopAppearance(theme: string, style: string): Promise<void>;
   SetDesktopCheckUpdates(enabled: boolean): Promise<void>;
   SetDesktopTelemetry(enabled: boolean): Promise<void>;
+  SetDesktopMetrics(enabled: boolean): Promise<void>;
   SetExpandThinking(on: boolean): Promise<void>;
   MigrateDesktopPreferences(language: string, theme: string, style: string): Promise<void>;
   SetAgentParams(temperature: number, maxSteps: number, plannerMaxSteps: number, systemPrompt: string): Promise<void>;
@@ -747,6 +748,7 @@ function makeMockApp(): AppBindings {
     displayMode: "minimal",
     checkUpdates: true,
     telemetry: true,
+    metrics: false,
     expandThinking: false,
     configPath: "~/projects/reasonix/reasonix.toml",
     providerKinds: ["openai"],
@@ -2183,6 +2185,9 @@ function makeMockApp(): AppBindings {
         },
         async SetDesktopTelemetry(enabled: boolean) {
           settings.telemetry = enabled;
+        },
+        async SetDesktopMetrics(enabled: boolean) {
+          settings.metrics = enabled;
         },
         async SetExpandThinking(on: boolean) {
           settings.expandThinking = on;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -733,6 +733,7 @@ export interface SettingsView {
   displayMode: string;   // "standard" | "compact" | "minimal"
   checkUpdates: boolean; // check for new versions on startup
   telemetry: boolean; // anonymous launch ping (install id + version + OS)
+  metrics: boolean; // opt-in aggregate agent metrics (anonymous signal/bucket counts)
   expandThinking: boolean; // show reasoning text expanded by default
   configPath: string;
   providerKinds: string[]; // provider implementations the kernel registered (for the kind picker)

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1116,6 +1116,8 @@ export const en = {
   "updater.autoCheckHint": "When off, Reasonix won't check automatically when it opens. You can still check manually here.",
   "settings.telemetryLabel": "Anonymous usage ping",
   "settings.telemetryHint": "On launch, send a random install id plus version and OS to count active installs. Never includes conversations, keys, or file contents.",
+  "settings.metricsLabel": "Share aggregate quality metrics",
+  "settings.metricsHint": "Off by default. When on, send anonymous counts of how turns end (finish reason, cache-hit rate, error and tool-failure categories) so issues can be spotted across versions. Only enumerated counters — never conversations, prompts, keys, paths, or any text.",
   "updater.currentVersion": "Current version: {v}",
   "updater.checkButton": "Check for updates",
   "updater.checking": "Checking for updates…",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1118,6 +1118,8 @@ export const zh: Record<DictKey, string> = {
   "updater.autoCheckHint": "关闭后，Reasonix 打开时不会自动检查更新；你仍可在此页手动检查。",
   "settings.telemetryLabel": "匿名启动统计",
   "settings.telemetryHint": "启动时发送随机安装 ID、版本号和操作系统用于统计活跃安装量；绝不包含对话、密钥或文件内容。",
+  "settings.metricsLabel": "共享聚合质量指标",
+  "settings.metricsHint": "默认关闭。开启后发送匿名的轮次结束统计（结束原因、缓存命中率、错误与工具失败的类别），用于跨版本发现问题。只含枚举化计数——绝不包含对话、提示词、密钥、路径或任何文本。",
   "updater.currentVersion": "当前版本：{v}",
   "updater.checkButton": "检查更新",
   "updater.checking": "正在检查更新…",

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -150,6 +150,7 @@ type SettingsView struct {
 	DisplayMode       string          `json:"displayMode"`
 	CheckUpdates      bool            `json:"checkUpdates"`
 	Telemetry         bool            `json:"telemetry"`
+	Metrics           bool            `json:"metrics"`
 	ExpandThinking    bool            `json:"expandThinking"`
 	ConfigPath        string          `json:"configPath"`
 	// ProviderKinds lists the provider implementations the kernel actually
@@ -330,6 +331,7 @@ func (a *App) Settings() SettingsView {
 			DisplayMode:       "minimal",
 			CheckUpdates:      true,
 			Telemetry:         true,
+			Metrics:           false,
 			ExpandThinking:    false,
 		}
 	}
@@ -377,6 +379,7 @@ func (a *App) Settings() SettingsView {
 		DisplayMode:       cfg.DesktopDisplayMode(),
 		CheckUpdates:      cfg.DesktopCheckUpdates(),
 		Telemetry:         cfg.DesktopTelemetry(),
+		Metrics:           cfg.DesktopMetrics(),
 		ExpandThinking:    cfg.Desktop.ExpandThinking,
 		ConfigPath:        cfgPath,
 		ProviderKinds:     nonNil(provider.Kinds()),
@@ -1315,6 +1318,21 @@ func (a *App) SetDesktopCheckUpdates(enabled bool) error {
 // SetDesktopTelemetry sets whether the desktop sends the anonymous launch ping.
 func (a *App) SetDesktopTelemetry(enabled bool) error {
 	return a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopTelemetry(enabled) })
+}
+
+// SetDesktopMetrics sets whether the desktop sends opt-in aggregate agent metrics,
+// starting or stopping the live aggregator so the toggle takes effect immediately.
+func (a *App) SetDesktopMetrics(enabled bool) error {
+	if err := a.applyConfigOnly(func(c *config.Config) error { return c.SetDesktopMetrics(enabled) }); err != nil {
+		return err
+	}
+	switch {
+	case enabled && a.metrics.Load() == nil && version != "dev":
+		a.metrics.Store(newMetricsAggregator(filepath.Dir(config.UserConfigPath())))
+	case !enabled:
+		a.metrics.Store(nil)
+	}
+	return nil
 }
 
 // SetExpandThinking sets whether reasoning text is expanded by default on

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -216,10 +216,10 @@ func (s *tabEventSink) Emit(e event.Event) {
 		case event.TurnDone:
 			s.recordTurnDone()
 		}
-		if s.app.metrics != nil {
-			s.app.metrics.observe(e)
+		if m := s.app.metrics.Load(); m != nil {
+			m.observe(e)
 			if e.Kind == event.TurnDone {
-				s.app.metrics.persist()
+				m.persist()
 			}
 		}
 	}


### PR DESCRIPTION
Phase 3 of the opt-in agent metrics: the user-facing Settings toggle. With this, the feature is fully wired end-to-end — worker `/v1/metrics` (live), desktop aggregator (#4033), and now a way to turn it on.

## What it adds

- **Settings toggle** under Updates, mirroring the telemetry-ping wiring across every layer: `SettingsView.Metrics`, `SetDesktopMetrics` bound method, bridge `AppBindings` + dev mock, the panel `ToggleSegment`, and en/zh strings.
- **The hint is the disclosure**: it states only enumerated counters ship (finish reason, cache-hit rate, error/tool-failure categories) — never conversations, prompts, keys, or paths. Default **off**, so nothing happens until the user flips it.
- **Live toggle**: `SetDesktopMetrics` starts/stops the aggregator immediately, and `a.metrics` is now an `atomic.Pointer` so the hot event sink reads it race-free while the setting flips mid-session.

## Test
- `go build ./...`, `go test ./` (desktop) — pass
- `SetDesktopMetrics` is mirrored in the hand-written `AppBindings` + dev mock, so the binding-drift check stays satisfied; frontend tsc runs in CI.

This completes the telemetry track. Worker is already deployed; this ships in the next desktop build.
