### PR TITLE
ci(desktop): rebuild site after stable release so version follows

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -238,6 +238,9 @@ jobs:
     name: mirror to R2
     needs: publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # gh release download
+      actions: write # dispatch pages.yml to re-bake the site version
     # Skip cleanly when R2 isn't configured; GitHub release still works as fallback.
     if: ${{ github.repository_owner == 'esengine' }}
     env:
@@ -316,3 +319,11 @@ jobs:
           else
             aws s3 cp assets/ "s3://${R2_BUCKET}/latest/" --recursive --endpoint-url "$ENDPOINT"
           fi
+
+      # Stable release moved R2 latest/ — rebuild the site so its build-time baked
+      # version + JSON-LD follow (site.js's runtime .rxv refresh can't touch first paint / SEO).
+      - name: Refresh site to the new version
+        if: env.HAS_R2 == 'true' && steps.ver.outputs.channel != 'canary' && steps.ver.outputs.prerelease != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run pages.yml --ref main-v2


### PR DESCRIPTION
## Why

The marketing site resolves the displayed version from R2's `latest.json`
in two layers: a build-time bake in `index.astro` and a runtime refresh in
`site.js` that rewrites every `.rxv` span on page load. The runtime layer
keeps the live page current, but `pages.yml` only rebuilds on `site/**`
pushes — so after a release the *baked* value (and the JSON-LD
`softwareVersion` used for SEO) lagged behind until an unrelated site edit
triggered a rebuild. First paint briefly showed the old version.

## What

Dispatch `pages.yml` from the desktop release's `mirror` job, right after a
stable release has actually moved R2 `latest/` (skipped for canary and rc,
which don't move `latest/`). The job gets a scoped `actions: write` for the
dispatch. No new secrets.

This pairs with the R2 CORS fix that lets the runtime `.rxv` refresh reach
`dl.reasonix.io` from `reasonix.io`; together the site now follows every
release with no manual edit.
