### PR TITLE
fix(boot): resolve built-in provider pricing safely

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -436,14 +436,14 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if err != nil {
 			return nil, nil, 0, err
 		}
-		return p, me.Price, me.ContextWindow, nil
+		return p, resolvePricing(&me), me.ContextWindow, nil
 	}
 	subagentIdentity := func(modelRef, effort string) (string, string) {
 		return subagentEffectiveIdentity(cfg, modelName, entry, modelRef, effort)
 	}
 	taskModel := firstNonEmpty(cfg.Agent.SubagentModels["task"], cfg.Agent.SubagentModel)
 	taskEffort := firstNonEmpty(cfg.Agent.SubagentEfforts["task"], cfg.Agent.SubagentEffort)
-	reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
+	reg.Add(agent.NewTaskTool(execProv, resolvePricing(entry), reg, maxSteps,
 		entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
 		cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate,
 		taskModel, taskEffort, resolveSubagentProvider).
@@ -469,7 +469,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// task/skill meta-tools, to bar recursion), and an optional per-skill model.
 	// Its tool activity nests under the invoking call, like `task`.
 	skillRunner := func(sctx context.Context, sk skill.Skill, task string, runOpts skill.SubagentRunOptions) (string, error) {
-		prov, price, ctxWin := execProv, entry.Price, entry.ContextWindow
+		prov, price, ctxWin := execProv, resolvePricing(entry), entry.ContextWindow
 		modelRef := subagentModelRef(cfg, sk)
 		effortRef := subagentEffortRef(cfg, sk)
 		if modelRef != "" || effortRef != "" {
@@ -608,7 +608,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	executor := agent.New(execProv, reg, execSess, agent.Options{
 		MaxSteps:          maxSteps,
 		Temperature:       cfg.Agent.Temperature,
-		Pricing:           entry.Price,
+		Pricing:           resolvePricing(entry),
 		Gate:              headlessGate,
 		Hooks:             hookRunner,
 		Jobs:              jm,
@@ -668,7 +668,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 			plannerSess := agent.NewSession(agent.PlannerPromptWithContext(mem.Block()))
 			plannerTools := agent.PlannerToolRegistry(reg)
-			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, plannerTools, agent.Options{
+			runner = agent.NewCoordinator(plannerProv, plannerSess, resolvePricing(pe), plannerTools, agent.Options{
 				MaxSteps:          cfg.Agent.PlannerMaxSteps,
 				MaxStepsKey:       "agent.planner_max_steps",
 				Gate:              headlessGate,
@@ -944,6 +944,27 @@ func newSubagentStore(sessionDir string) *agent.SubagentStore {
 		return nil
 	}
 	return agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+}
+
+// resolvePricing returns an explicit provider price or the matching built-in
+// provider price. Matching includes provider identity so a third-party endpoint
+// serving a same-named model does not inherit the wrong price table.
+func resolvePricing(entry *config.ProviderEntry) *provider.Pricing {
+	if entry == nil {
+		return nil
+	}
+	if entry.Price != nil {
+		return entry.Price
+	}
+	for _, builtIn := range config.Default().Providers {
+		if entry.Name == builtIn.Name &&
+			entry.Kind == builtIn.Kind &&
+			entry.BaseURL == builtIn.BaseURL &&
+			builtIn.HasModel(entry.Model) {
+			return builtIn.Price
+		}
+	}
+	return nil
 }
 
 func subagentEffectiveIdentity(cfg *config.Config, baseModelRef string, base *config.ProviderEntry, modelRef, effort string) (string, string) {

--- a/internal/boot/pricing_test.go
+++ b/internal/boot/pricing_test.go
@@ -1,0 +1,50 @@
+package boot
+
+import (
+	"testing"
+
+	"reasonix/internal/config"
+	"reasonix/internal/provider"
+)
+
+func TestResolvePricingUsesExplicitProviderPrice(t *testing.T) {
+	price := &provider.Pricing{Input: 11, Output: 22, Currency: "$"}
+
+	got := resolvePricing(&config.ProviderEntry{
+		Name:  "deepseek-flash",
+		Model: "deepseek-v4-flash",
+		Price: price,
+	})
+
+	if got != price {
+		t.Fatalf("resolvePricing should return the explicitly configured price")
+	}
+}
+
+func TestResolvePricingFallsBackForMatchingBuiltInProvider(t *testing.T) {
+	got := resolvePricing(&config.ProviderEntry{
+		Name:    "deepseek-flash",
+		Kind:    "openai",
+		BaseURL: "https://api.deepseek.com",
+		Model:   "deepseek-v4-flash",
+	})
+	if got == nil {
+		t.Fatal("resolvePricing should use the built-in price for the built-in provider")
+	}
+	if got.Output != 2 || got.Currency != "¥" {
+		t.Fatalf("built-in deepseek-flash price = %+v, want output=2 currency=¥", got)
+	}
+}
+
+func TestResolvePricingDoesNotFallbackForThirdPartySameModel(t *testing.T) {
+	got := resolvePricing(&config.ProviderEntry{
+		Name:    "third-party-proxy",
+		Kind:    "openai",
+		BaseURL: "https://proxy.example.com/v1",
+		Model:   "deepseek-v4-flash",
+	})
+
+	if got != nil {
+		t.Fatalf("third-party provider with same model must not inherit built-in pricing: %+v", got)
+	}
+}


### PR DESCRIPTION
## Summary

Splits the provider pricing fallback out of the Guardian Subagent work into a standalone PR.

- Adds `resolvePricing` for boot-time agent/task/skill/planner pricing wiring.
- Preserves explicitly configured provider prices.
- Falls back only when the provider identity matches a built-in provider (`name`, `kind`, `base_url`) and the built-in provider serves the model.
- Avoids assigning built-in pricing to third-party providers that happen to expose the same model name.

## Why

The Guardian PR introduced pricing fallback while wiring Guardian usage display, but this affects executor, planner, task, and skill pricing globally. Keeping it separate makes the behavior easier to review and avoids mixing it with Guardian approval semantics.

## Validation

- `go test ./internal/boot -run TestResolvePricing`