### PR TITLE
fix(control): prevent MemoryQuickAddNote from swallowing multi-line Markdown headings

### DIFF
--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -146,11 +146,17 @@ func activeGoalBlock(goal string) string {
 	return b.String()
 }
 
-// MemoryQuickAddNote parses the legacy "# <note>" memory shortcut. The space
-// after "#" is intentional: "#7", "#issue", and "#标题" are ordinary user
-// prompts, not memory writes.
+// MemoryQuickAddNote parses the "# <note>" memory shortcut. The space after
+// "#" is intentional: "#7", "#issue", and "#标题" are ordinary user prompts,
+// not memory writes. Multi-line input starting with "# " is NOT treated as a
+// quick-add note — it is almost certainly a Markdown heading in a structured
+// prompt (e.g. "# Context\n\n- file.go\n# Objective"). Only single-line input
+// may be a quick-add note.
 func MemoryQuickAddNote(input string) (note string, ok bool) {
 	trimmed := strings.TrimSpace(input)
+	if strings.Contains(trimmed, "\n") {
+		return "", false
+	}
 	if strings.HasPrefix(trimmed, "# ") || strings.HasPrefix(trimmed, "#\t") {
 		return strings.TrimSpace(trimmed[1:]), true
 	}

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -177,6 +177,12 @@ func TestMemoryQuickAddNoteRequiresWhitespace(t *testing.T) {
 		{in: "#issue needs work", ok: false},
 		{in: "# Heading", note: "Heading", ok: true},
 		{in: "#", ok: false},
+		// Multi-line input is NOT a quick-add — it's a Markdown heading (# Context)
+		// followed by structured content. Desktop users pasting COSTAR-style prompts
+		// hit this when the first line starts with "# ".
+		{in: "# Context\n\n- file.go\n", ok: false},
+		{in: "# Heading\nmore text", ok: false},
+		{in: "  # Context\n  - file.go  ", ok: false},
 	}
 	for _, tt := range tests {
 		got, ok := MemoryQuickAddNote(tt.in)


### PR DESCRIPTION
    
#4008: pasting a COSTAR-style prompt starting with "# Context" (or any Markdown H1 heading) on the Windows Wails desktop GUI caused the agent to never start — the entire multi-line input was silently saved as a memory note instead of being sent to the agent loop.
    
Root cause: MemoryQuickAddNote only checked for a "# " prefix. When the desktop calls ctrl.Submit() → submit(), the full multi-line input goes through MemoryQuickAddNote first. A prompt beginning with "# Context" matched the quick-add pattern, so submit() returned early after saving a memory note — the agent never ran.
    
Why the TUI is unaffected: the terminal UI folds pasted multi-line content into a "[P1]" label before the quick-add check runs, so the "# " prefix is never visible to MemoryQuickAddNote. The expanded text goes through ctrl.SendWithRaw(), which bypasses submit() entirely.
    
Fix: reject multi-line input in MemoryQuickAddNote. Any input containing a newline is now treated as a normal prompt, not a quick-add note. Single-line "# note" still works as before.
    
Test: added 3 multi-line cases (COSTAR-style with blank line, simple two-line, indented multi-line) all expecting ok=false; single-line "# Heading" preserves ok=true backward compatibility.
    
Fixes #4008