### PR TITLE
feat(tui): /clear executes immediately without confirmation

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3453,7 +3453,13 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 		m.notice(i18n.M.SlashNewDone)
 	case "/clear":
 		m.echoLocalCommand(input)
-		m.clearConfirm = &clearConfirm{confirm: 1}
+		if err := m.ctrl.ClearSession(); err != nil {
+			m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashClearFailed, err))
+			return nil
+		}
+		m.resetFreshContextView(true)
+		m.notice(i18n.M.SlashClearDone)
+		return tea.ClearScreen
 	case "/resume":
 		m.runResumeCommand(input)
 	case "/todo":

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -222,10 +222,6 @@ type chatTUI struct {
 	mcp         *mcpManager
 	mcpDisabled map[string]bool
 
-	// clearConfirm is the destructive "/clear" confirmation overlay. It is separate
-	// from /new because /clear discards the current transcript instead of saving it.
-	clearConfirm *clearConfirm
-
 	// lastCtrlCAt records when Ctrl+C was pressed while idle on an empty
 	// composer, enabling a "press again to quit" confirmation pattern (1.5s
 	// window). Reset when Ctrl+C clears non-empty input instead.
@@ -812,7 +808,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateCompletion()
 			return m, finalize(m, cmds)
 		}
-		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.clearConfirm == nil && m.mcpImport == nil && m.skillPick == nil && m.shouldFoldPaste(msg.Content) {
+		if !m.chooserTyping() && m.pendingApproval == nil && m.rewind == nil && m.resumePick == nil && m.mcp == nil && m.mcpImport == nil && m.skillPick == nil && m.shouldFoldPaste(msg.Content) {
 			m.insertFoldedPaste(msg.Content)
 			m.growInputToFit()
 			m.updateCompletion()
@@ -885,10 +881,6 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// The MCP manager is modal while open: keys navigate it.
 		if m.mcp != nil {
 			return m.handleMCPManagerKey(msg)
-		}
-		// The destructive /clear confirmation is modal while open.
-		if m.clearConfirm != nil {
-			return m.handleClearConfirmKey(msg)
 		}
 		// The skill picker is modal while open: keys navigate it.
 		if m.skillPick != nil {
@@ -1491,7 +1483,7 @@ func (m chatTUI) bottomRows() int {
 // reserve rows for a composer that cannot receive input, leaving a confusing
 // blank/bordered area at the bottom of the TUI.
 func (m chatTUI) hideComposer() bool {
-	if m.mcp != nil || m.clearConfirm != nil || m.mcpImport != nil || m.skillPick != nil || m.resumePick != nil || m.rewind != nil || m.pendingApproval != nil {
+	if m.mcp != nil || m.mcpImport != nil || m.skillPick != nil || m.resumePick != nil || m.rewind != nil || m.pendingApproval != nil {
 		return true
 	}
 	return m.chooser != nil && !m.chooser.typing
@@ -1508,9 +1500,6 @@ func (m chatTUI) transcriptHeight() int {
 
 func (m chatTUI) renderMainManager() string {
 	if card := m.renderMCPManager(); card != "" {
-		return card
-	}
-	if card := m.renderClearConfirm(); card != "" {
 		return card
 	}
 	return m.renderSkillPicker()
@@ -1533,8 +1522,6 @@ func (m chatTUI) renderMainManagerFooter() string {
 	switch {
 	case m.mcp != nil:
 		hint = m.mcp.footerHint()
-	case m.clearConfirm != nil:
-		hint = "Enter confirm · y clear · n/Esc cancel"
 	case m.skillPick != nil:
 		hint = m.skillPickerFooterHint()
 	}

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -362,7 +362,7 @@ func TestMCPManagerHidesComposerBox(t *testing.T) {
 	}
 }
 
-func TestClearCommandRequiresConfirmationAndDiscardsSession(t *testing.T) {
+func TestSlashClearExecutesImmediately(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "old context"})
@@ -374,61 +374,26 @@ func TestClearCommandRequiresConfirmationAndDiscardsSession(t *testing.T) {
 	}
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
 
-	if cmd := m.runSlashCommand("/clear"); cmd != nil {
-		t.Fatal("/clear should open a local confirmation without returning a command")
+	// /clear should execute immediately and return a tea.Cmd (tea.ClearScreen)
+	cmd := m.runSlashCommand("/clear")
+	if cmd == nil {
+		t.Fatal("/clear should return a tea.Cmd for screen clear")
 	}
-	if m.clearConfirm == nil {
-		t.Fatal("/clear should open a confirmation prompt")
-	}
-	if m.clearConfirm.confirm != 1 {
-		t.Fatalf("/clear confirmation should default to cancel, got %d", m.clearConfirm.confirm)
-	}
-	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
-	m = m0.(chatTUI)
-	footerRows := strings.Count(m.renderMainManagerFooter(), "\n") + 1
-	if got, want := m.bottomRows(), footerRows+m.statusLineCount; got != want {
-		t.Fatalf("bottomRows with /clear confirmation = %d, want %d (footer + status rows; confirmation renders in main area)", got, want)
-	}
-	if !m.hideComposer() {
-		t.Fatal("/clear confirmation should hide the composer")
-	}
-	content := ansi.Strip(m.View().Content)
-	if !strings.Contains(content, "Clear current context without saving?") {
-		t.Fatalf("/clear confirmation prompt missing from view:\n%s", content)
-	}
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("session should still exist before confirmation: %v", err)
-	}
-	if current := exec.Session().Snapshot(); len(current) != 2 {
-		t.Fatalf("context changed before confirmation: %+v", current)
-	}
-
-	next, _ := m.handleClearConfirmKey(tea.KeyPressMsg{Code: tea.KeyEnter})
-	m = next.(chatTUI)
-	if m.clearConfirm != nil {
-		t.Fatal("Enter on default cancel should close the confirmation")
-	}
-	if ctrl.SessionPath() != path {
-		t.Fatal("cancelled /clear should not rotate the session path")
-	}
-	if _, err := os.Stat(path); err != nil {
-		t.Fatalf("cancelled /clear should keep the session file: %v", err)
-	}
-
-	m.runSlashCommand("/clear")
-	next, _ = m.handleClearConfirmKey(tea.KeyPressMsg{Code: 'y'})
-	m = next.(chatTUI)
+	// Session should have been rotated
 	if ctrl.SessionPath() == path {
-		t.Fatal("confirmed /clear should rotate to a fresh session path")
+		t.Fatal("/clear should rotate to a fresh session path")
 	}
+	// Old session file should be removed
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		t.Fatalf("confirmed /clear should remove the old transcript, stat err=%v", err)
+		t.Fatalf("/clear should remove the old transcript, stat err=%v", err)
 	}
+	// Context should contain only the system prompt
 	current := exec.Session().Snapshot()
 	if len(current) != 1 || current[0].Role != provider.RoleSystem || current[0].Content != "sys" {
 		t.Fatalf("cleared context = %+v, want only system prompt", current)
 	}
-	if len(m.transcript) == 0 || strings.Contains(strings.Join(m.transcript, "\n"), "old context") {
+	// Transcript should be reset (banner present but no "old context" remnants)
+	if strings.Contains(strings.Join(m.transcript, "\n"), "old context") {
 		t.Fatalf("TUI transcript was not reset after /clear: %+v", m.transcript)
 	}
 }

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -1,49 +1,8 @@
 package cli
 
 import (
-	"fmt"
 	"strings"
-
-	tea "charm.land/bubbletea/v2"
-
-	"reasonix/internal/i18n"
 )
-
-type clearConfirm struct {
-	confirm int // 0 = clear, 1 = cancel
-}
-
-func (m chatTUI) handleClearConfirmKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
-	case "up", "down", "left", "right", "j", "k", "tab", "shift+tab":
-		if m.clearConfirm.confirm == 0 {
-			m.clearConfirm.confirm = 1
-		} else {
-			m.clearConfirm.confirm = 0
-		}
-	case "y", "Y":
-		return m.confirmClearContext()
-	case "n", "N", "esc", "ctrl+c":
-		m.clearConfirm = nil
-	case "enter":
-		if m.clearConfirm.confirm == 0 {
-			return m.confirmClearContext()
-		}
-		m.clearConfirm = nil
-	}
-	return m, nil
-}
-
-func (m chatTUI) confirmClearContext() (tea.Model, tea.Cmd) {
-	m.clearConfirm = nil
-	if err := m.ctrl.ClearSession(); err != nil {
-		m.notice(fmt.Sprintf("%s: %v", i18n.M.SlashClearFailed, err))
-		return m, nil
-	}
-	m.resetFreshContextView(true)
-	m.notice(i18n.M.SlashClearDone)
-	return m, tea.ClearScreen
-}
 
 func (m *chatTUI) resetFreshContextView(clearTranscript bool) {
 	m.finalizeStreamed()
@@ -63,17 +22,4 @@ func (m *chatTUI) resetFreshContextView(clearTranscript bool) {
 	}
 	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
 	m.transcriptDirty = true
-}
-
-func (m chatTUI) renderClearConfirm() string {
-	if m.clearConfirm == nil {
-		return ""
-	}
-	w := max(viewWidth(m.width), 40)
-	var b strings.Builder
-	b.WriteString(i18n.M.SlashClearPrompt + "\n")
-	b.WriteString(viewMeta("This deletes the current transcript from local history and keeps only the system prompt.") + "\n\n")
-	b.WriteString(rowLine(m.clearConfirm.confirm == 0, 1, "", "Clear", false) + "\n")
-	b.WriteString(rowLine(m.clearConfirm.confirm == 1, 2, "", "Cancel", false))
-	return choicePanelStyle.Width(w).Render(b.String())
 }

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -122,7 +122,6 @@ type Messages struct {
 	SlashCompactFailed string // "/compact" errored, prefixed before the underlying error
 	SlashNewDone       string // "/new" succeeded
 	SlashNewFailed     string // "/new" errored
-	SlashClearPrompt   string // "/clear" destructive confirmation prompt
 	SlashClearDone     string // "/clear" succeeded
 	SlashClearFailed   string // "/clear" errored
 	SlashTodoCleared   string // "/todo" dismissed the pinned task list

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -91,7 +91,6 @@ var English = Messages{
 	SlashCompactFailed: "compaction failed",
 	SlashNewDone:       "new session started — previous transcript saved",
 	SlashNewFailed:     "could not start a new session",
-	SlashClearPrompt:   "Clear current context without saving?",
 	SlashClearDone:     "current context cleared",
 	SlashClearFailed:   "could not clear current context",
 	SlashUnavailable:   "command unavailable in this build",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -92,7 +92,6 @@ var Chinese = Messages{
 	SlashCompactFailed: "压缩失败",
 	SlashNewDone:       "已开启新会话 — 之前的对话已存档",
 	SlashNewFailed:     "新建会话失败",
-	SlashClearPrompt:   "清空当前上下文且不保存？",
 	SlashClearDone:     "已清空当前上下文",
 	SlashClearFailed:   "清空当前上下文失败",
 	SlashUnavailable:   "当前构建不支持该命令",


### PR DESCRIPTION
## Summary

Make the TUI `/clear` command immediately create a new session and clear the screen, removing the Y/N confirmation overlay.

## Changes

- `/clear` now calls `ctrl.ClearSession()` + `resetFreshContextView(true)` + `tea.ClearScreen` directly
- Removed `clearConfirm` overlay: struct, modal key handler, renderer, all nil-checks
- Removed unused `SlashClearPrompt` i18n string
- New test `TestSlashClearExecutesImmediately` verifies immediate session rotation, old file deletion, context reset to system-only, and transcript clear

## Net impact

5 files, +21 / −120 lines