### PR TITLE
fix(agent): pin the user's task and prior summaries across compaction

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -20,14 +20,16 @@ import (
 // fraction of the window, so a huge window still compacts rarely while a small
 // one still lands below the trigger (which is what stops the re-compaction loop).
 const (
-	defaultSoftCompactRatio  = 0.5   // report growing context here, but keep the cache-stable prefix intact
-	defaultCompactRatio      = 0.8   // trigger: prompt at this fraction of the window compacts
-	defaultCompactForceRatio = 0.9   // force compaction at this high-water mark even for low-value folds
-	defaultCompactTarget     = 0.5   // safety cap: the kept tail never exceeds this fraction of the window
-	defaultTailTokens        = 16384 // verbatim recent-tail budget, in tokens
-	minRecentKeep            = 2     // never keep fewer recent messages than this
-	minCompactMessages       = 2     // skip compaction below this many compactable messages
-	fallbackTokPerChar       = 0.25  // ~4 chars/token, used before any usage is available to calibrate
+	defaultSoftCompactRatio   = 0.5   // report growing context here, but keep the cache-stable prefix intact
+	defaultCompactRatio       = 0.8   // trigger: prompt at this fraction of the window compacts
+	defaultCompactForceRatio  = 0.9   // force compaction at this high-water mark even for low-value folds
+	defaultCompactTarget      = 0.5   // safety cap: the kept tail never exceeds this fraction of the window
+	defaultTailTokens         = 16384 // verbatim recent-tail budget, in tokens
+	minRecentKeep             = 2     // never keep fewer recent messages than this
+	minCompactMessages        = 2     // skip compaction below this many compactable messages
+	fallbackTokPerChar        = 0.25  // ~4 chars/token, used before any usage is available to calibrate
+	maxPinnedFirstUserTokens  = 1500  // ceiling on pinning the first user turn verbatim; larger first turns (pasted content) stay foldable
+	pinnedFirstUserWindowFrac = 0.15  // and never pin a first turn worth more than this fraction of the window
 )
 
 // summaryTag wraps the compaction summary so the model can distinguish it from
@@ -315,16 +317,51 @@ func (a *Agent) SummarizeUpTo(ctx context.Context, toIdx int) error {
 	return nil
 }
 
-// planCompaction locates the region to summarize. head is the count of leading
-// messages preserved verbatim (the system prompt, if any); start is where the
-// preserved recent tail begins, so msgs[head:start] is compacted. The tail is
-// bounded by a token budget (not a message count), so a few large tool outputs
-// can't keep it above the trigger and re-fire compaction every turn. ok is false
-// when there is too little to compact.
-func (a *Agent) planCompaction(msgs []provider.Message, min int) (head, start int, ok bool) {
-	if len(msgs) > 0 && msgs[0].Role == provider.RoleSystem {
-		head = 1
+// isCompactionSummary reports whether m is a rolling summary from a prior fold.
+func isCompactionSummary(m provider.Message) bool {
+	return m.Role == provider.RoleUser &&
+		strings.HasPrefix(strings.TrimLeft(m.Content, "\n "), summaryTagOpen)
+}
+
+// pinnedPrefixLen counts the leading messages a fold keeps verbatim: the system
+// prompt, the first user turn (its task + stated facts/constraints) when it is
+// small enough to be a brief, and any prior summaries — so a fold never
+// summarizes the user's facts away, and a later fold never re-summarizes an
+// earlier summary into nothing (the drift that silently dropped user-stated facts
+// after the second compaction). A large first turn (pasted content) stays
+// foldable so pinning never starves the window.
+func (a *Agent) pinnedPrefixLen(msgs []provider.Message) int {
+	i := 0
+	if i < len(msgs) && msgs[i].Role == provider.RoleSystem {
+		i++
 	}
+	if i < len(msgs) && msgs[i].Role == provider.RoleUser && !isCompactionSummary(msgs[i]) && a.pinnableFirstUser(msgs[i]) {
+		i++
+	}
+	for i < len(msgs) && isCompactionSummary(msgs[i]) {
+		i++
+	}
+	return i
+}
+
+func (a *Agent) pinnableFirstUser(m provider.Message) bool {
+	budget := maxPinnedFirstUserTokens
+	if a.contextWindow > 0 {
+		if f := int(float64(a.contextWindow) * pinnedFirstUserWindowFrac); f < budget {
+			budget = f
+		}
+	}
+	return int(float64(msgChars(m))*a.tokPerChar()) <= budget
+}
+
+// planCompaction locates the region to summarize. head is the count of leading
+// messages preserved verbatim (see pinnedPrefixLen); start is where the preserved
+// recent tail begins, so msgs[head:start] is compacted. The tail is bounded by a
+// token budget (not a message count), so a few large tool outputs can't keep it
+// above the trigger and re-fire compaction every turn. ok is false when there is
+// too little to compact.
+func (a *Agent) planCompaction(msgs []provider.Message, min int) (head, start int, ok bool) {
+	head = a.pinnedPrefixLen(msgs)
 	if a.contextWindow > 0 {
 		budget := defaultTailTokens
 		if maxByWin := int(float64(a.contextWindow) * defaultCompactTarget); maxByWin < budget {

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -99,6 +99,37 @@ func TestTailStartSmallSession(t *testing.T) {
 	}
 }
 
+func TestPinnedPrefixLen(t *testing.T) {
+	sys := provider.Message{Role: provider.RoleSystem}
+	small := provider.Message{Role: provider.RoleUser, Content: "do X with token T"}
+	big := provider.Message{Role: provider.RoleUser, Content: strings.Repeat("x", 100000)}
+	sum := provider.Message{Role: provider.RoleUser, Content: summaryTagOpen + "\ndigest\n" + summaryTagClose}
+	as := provider.Message{Role: provider.RoleAssistant, Content: "a"}
+
+	newA := func(win int) *Agent {
+		return New(&fakeProvider{}, tool.NewRegistry(), &Session{}, Options{ContextWindow: win}, event.Discard)
+	}
+	cases := []struct {
+		name string
+		win  int
+		msgs []provider.Message
+		want int
+	}{
+		{"pins-system-and-small-task", 0, []provider.Message{sys, small, as, as}, 2},
+		{"also-pins-prior-summaries", 0, []provider.Message{sys, small, sum, sum, as}, 4},
+		{"large-first-turn-stays-foldable", 0, []provider.Message{sys, big, as, as}, 1},
+		{"tiny-window-wont-pin", 10, []provider.Message{sys, small, as, as}, 1},
+		{"summary-is-not-the-task-turn", 0, []provider.Message{sys, sum, as}, 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := newA(tc.win).pinnedPrefixLen(tc.msgs); got != tc.want {
+				t.Errorf("pinnedPrefixLen = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestCompactReplacesHistory(t *testing.T) {
 	prov := &fakeProvider{reply: "- goal: do X\n- changed file Y"}
 	bigStep := strings.Repeat("important implementation detail ", 80)
@@ -121,22 +152,26 @@ func TestCompactReplacesHistory(t *testing.T) {
 		t.Fatalf("rewrite version = %d, want 1", got)
 	}
 
-	// system + summary + last 2 verbatim.
-	if got := len(sess.Messages); got != 4 {
-		t.Fatalf("len = %d, want 4: %+v", got, sess.Messages)
+	// system + pinned first user turn + summary + last 2 verbatim.
+	if got := len(sess.Messages); got != 5 {
+		t.Fatalf("len = %d, want 5: %+v", got, sess.Messages)
 	}
 	if sess.Messages[0].Role != provider.RoleSystem {
 		t.Errorf("message 0 = %s, want system", sess.Messages[0].Role)
 	}
-	summary := sess.Messages[1]
+	if task := sess.Messages[1]; task.Role != provider.RoleUser || !strings.HasPrefix(task.Content, "task ") {
+		t.Errorf("first user turn not pinned verbatim: %+v", task)
+	}
+	summary := sess.Messages[2]
 	if summary.Role != provider.RoleUser || !strings.Contains(summary.Content, "Summary of earlier") || !strings.Contains(summary.Content, "do X") {
 		t.Errorf("summary message = %+v", summary)
 	}
-	if sess.Messages[2].Content != "next" || sess.Messages[3].Content != "ok" {
-		t.Errorf("recent tail not preserved: %+v", sess.Messages[2:])
+	if sess.Messages[3].Content != "next" || sess.Messages[4].Content != "ok" {
+		t.Errorf("recent tail not preserved: %+v", sess.Messages[3:])
 	}
 
-	// The 4 dropped originals were archived, one JSON object per line.
+	// The 3 dropped originals were archived, one JSON object per line (the task
+	// turn is pinned, not folded, so it is not among them).
 	entries, err := os.ReadDir(dir)
 	if err != nil || len(entries) != 1 {
 		t.Fatalf("archive dir: entries=%d err=%v", len(entries), err)
@@ -145,8 +180,8 @@ func TestCompactReplacesHistory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read archive: %v", err)
 	}
-	if lines := strings.Count(strings.TrimSpace(string(data)), "\n") + 1; lines != 4 {
-		t.Errorf("archived %d lines, want 4:\n%s", lines, data)
+	if lines := strings.Count(strings.TrimSpace(string(data)), "\n") + 1; lines != 3 {
+		t.Errorf("archived %d lines, want 3:\n%s", lines, data)
 	}
 	if !strings.HasSuffix(entries[0].Name(), ".jsonl") {
 		t.Errorf("archive name = %q, want .jsonl", entries[0].Name())
@@ -384,13 +419,16 @@ func TestMaybeCompactForceCeilingBypassesEconomics(t *testing.T) {
 	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 90})
-	// The token-budgeted tail keeps "small old answer", next, ok, so only the
-	// single early message folds — force bypasses the economics skip and installs
-	// a summary at index 1, leaving the count at 5.
+	// The first user turn is pinned (index 1) and the token-budgeted tail keeps
+	// next, ok, so only "small old answer" folds — force bypasses the economics
+	// skip and installs a summary at index 2, leaving the count at 5.
 	if got := len(sess.Messages); got != 5 {
 		t.Fatalf("len = %d, want 5 after forced single-message fold: %+v", got, sess.Messages)
 	}
-	if !strings.Contains(sess.Messages[1].Content, "forced summary") {
+	if sess.Messages[1].Content != "small old request" {
+		t.Fatalf("first user turn not pinned verbatim: %+v", sess.Messages[1])
+	}
+	if !strings.Contains(sess.Messages[2].Content, "forced summary") {
 		t.Fatalf("forced compact did not install summary: %+v", sess.Messages)
 	}
 	if len(prov.got) == 0 {

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -121,13 +121,28 @@ func TestMaybeCompactPruneAvoidsFold(t *testing.T) {
 
 func TestMaybeCompactForceRatioStillFolds(t *testing.T) {
 	prov := &fakeProvider{reply: "summary"}
-	sess := pruneFixture(strings.Repeat("x", 5000))
+	// A big assistant turn in the foldable region (after the pinned task, before the
+	// recent tail) survives pruning — only tool results prune — so the forced fold
+	// has real content to compact while the task turn stays pinned verbatim.
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: strings.Repeat("y", 5000)},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "read_file", Arguments: "{}"}}},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "read_file", Content: strings.Repeat("x", 5000)},
+		{Role: provider.RoleAssistant, Content: "step done"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
 	a := New(prov, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
 
 	a.maybeCompact(context.Background(), &provider.Usage{PromptTokens: 950})
 
 	if prov.got == nil {
 		t.Fatal("force ratio crossed but summarizer never called")
+	}
+	if got := sess.Snapshot()[1].Content; got != "task" {
+		t.Errorf("first user turn not pinned verbatim: %.40q", got)
 	}
 	found := false
 	for _, m := range sess.Snapshot() {


### PR DESCRIPTION
## The bug

A fact the user states up front gets dropped from context after repeated compaction, and the agent then "forgets" it. Reproduced end-to-end against the real provider:

- A deploy token stated in the first user turn was present in every request through the first fold, then **vanished from every request after the second fold** — and the agent could no longer recall it (wrote no answer, never restated it).
- The smoking gun: the second fold's summary degraded to `<compaction-summary>[assistant calls read_file] {"path":"data/f01.txt"}</compaction-summary>` — the `## Goal` was empty; the user's task and token were gone.

Root cause: `planCompaction` pinned only the system message (`head = 1`). The first user turn (the task brief + the user's stated facts/constraints) was always inside the summarized region, so its survival depended on a weak summarizer model re-extracting it correctly on **every** fold. One degenerate summary — which the model produces especially when re-summarizing an already-summarized region — drops the fact for good.

## The fix

`pinnedPrefixLen` now keeps in the verbatim prefix:
- the system prompt,
- the **first user turn** when it's small enough to be a brief, and
- **any prior compaction summaries**.

So a fold never summarizes the task away, and a later fold never re-folds an earlier summary into nothing. A large first turn (pasted content) stays foldable — gated by an absolute token ceiling and a window fraction — so pinning never starves the context.

## Verification

Same scenario, same small window, identical work:

| | compaction | result |
|---|---|---|
| before | folds | token dropped after 2nd fold → **forgot**, no answer |
| after | folds | task pinned verbatim at index 1 → **token retained in every request, answered correctly** |
| control (huge window) | none | retained, correct |

Post-fold request structure after the fix: `[system] [user: task verbatim, token present] [compaction-summary] [recent tail]`.

Tests: new `TestPinnedPrefixLen` (pins system+task+summaries; large/tiny-window turns stay foldable; a summary is not mistaken for the task turn); existing compaction/prune tests updated to the pinned-prefix behavior. `go test ./internal/agent/...`, control, and boot pass.
