### PR TITLE
feat(agent): keep every user turn verbatim across compaction + structured facts digest

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -46,11 +46,14 @@ const (
 // next step — so the post-compaction turn doesn't lose the thread or re-derive
 // decisions already made.
 const summarySystemPrompt = `You are compacting the earlier part of a coding agent's conversation to save context.
-The agent will keep ONLY your summary (the original messages are dropped), so it must be able to resume the task from it alone.
-Write a briefing under these exact headings, omitting a heading only if it has no content:
+The agent keeps your summary alongside the user's own turns (kept verbatim) and the recent tail; your job is to fold the assistant/tool work into a briefing it can resume from.
+Write under these exact headings, omitting a heading only if it has no content:
+
+## Standing facts & constraints
+Everything the user stated that still governs the work — names, paths, IDs, versions, tokens, preferences, and hard "never do X" rules — in their own words. Be exhaustive; this is the durable contract, so prefer over- to under-including.
 
 ## Goal
-The user's request and intent, kept close to their own words. Include explicit requirements, constraints, and preferences.
+The user's request and intent.
 
 ## Decisions & rationale
 Key choices made so far and why — so they are not re-litigated or reversed.
@@ -193,9 +196,17 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	}
 	region := msgs[head:start]
 
-	// Economic check: skip if the region is too small to justify the summarizer
-	// call, unless force (manual /compact or the force-ratio ceiling) demands it.
-	if !force && !foldEconomics(region) {
+	// Base layer: every small user turn in the region is kept verbatim (the
+	// deterministic floor — a fact the user stated is never summarized away,
+	// wherever in the session they said it); only the rest folds into the digest.
+	kept, fold := a.partitionFold(region)
+	if len(fold) == 0 {
+		return nil // nothing but kept user turns — a fold would save nothing
+	}
+
+	// Economic check on the foldable part (kept user turns don't count toward the
+	// savings): skip if too small to justify the call, unless force demands it.
+	if !force && !foldEconomics(fold) {
 		return nil
 	}
 
@@ -214,7 +225,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 
 	archived := ""
 	if a.archiveDir != "" {
-		path, err := archiveMessages(a.archiveDir, region)
+		path, err := archiveMessages(a.archiveDir, fold)
 		if err != nil {
 			a.emitCompactionAborted(trigger)
 			return fmt.Errorf("archive: %w", err)
@@ -222,14 +233,19 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 		archived = path
 	}
 
+	// Upper layer: the digest is built from the whole region (kept turns included),
+	// so its structured "user facts & constraints" section consolidates what the
+	// user said into one tidy view — redundant with the verbatim turns by design,
+	// so a weak summarizer dropping a fact here loses nothing.
 	summary, err := a.summarize(ctx, region, instructions)
 	if err != nil {
 		a.emitCompactionAborted(trigger)
 		return err
 	}
 
-	compacted := make([]provider.Message, 0, head+1+len(msgs)-start)
+	compacted := make([]provider.Message, 0, head+len(kept)+1+len(msgs)-start)
 	compacted = append(compacted, msgs[:head]...)
+	compacted = append(compacted, kept...)
 	compacted = append(compacted, provider.Message{
 		Role: provider.RoleUser,
 		Content: summaryTagOpen + "\n" +
@@ -242,7 +258,7 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	a.session.IncrementRewrite()
 
 	a.sink.Emit(event.Event{Kind: event.CompactionDone, Compaction: event.Compaction{
-		Trigger: trigger, Messages: len(region), Summary: summary, Archive: archived,
+		Trigger: trigger, Messages: len(fold), Summary: summary, Archive: archived,
 	}})
 	return nil
 }
@@ -335,7 +351,7 @@ func (a *Agent) pinnedPrefixLen(msgs []provider.Message) int {
 	if i < len(msgs) && msgs[i].Role == provider.RoleSystem {
 		i++
 	}
-	if i < len(msgs) && msgs[i].Role == provider.RoleUser && !isCompactionSummary(msgs[i]) && a.pinnableFirstUser(msgs[i]) {
+	if i < len(msgs) && msgs[i].Role == provider.RoleUser && !isCompactionSummary(msgs[i]) && a.pinnableUserTurn(msgs[i]) {
 		i++
 	}
 	for i < len(msgs) && isCompactionSummary(msgs[i]) {
@@ -344,7 +360,10 @@ func (a *Agent) pinnedPrefixLen(msgs []provider.Message) int {
 	return i
 }
 
-func (a *Agent) pinnableFirstUser(m provider.Message) bool {
+// pinnableUserTurn reports whether a user turn is small enough to keep verbatim. A
+// turn larger than a brief (pasted content) folds like any other message so the
+// kept-verbatim floor never starves the window.
+func (a *Agent) pinnableUserTurn(m provider.Message) bool {
 	budget := maxPinnedFirstUserTokens
 	if a.contextWindow > 0 {
 		if f := int(float64(a.contextWindow) * pinnedFirstUserWindowFrac); f < budget {
@@ -352,6 +371,20 @@ func (a *Agent) pinnableFirstUser(m provider.Message) bool {
 		}
 	}
 	return int(float64(msgChars(m))*a.tokPerChar()) <= budget
+}
+
+// partitionFold splits a compaction region into the small user turns kept verbatim
+// (the deterministic floor — a fact the user stated is never summarized away) and
+// the rest, which folds into the digest. Order within each group is preserved.
+func (a *Agent) partitionFold(region []provider.Message) (kept, fold []provider.Message) {
+	for _, m := range region {
+		if m.Role == provider.RoleUser && !isCompactionSummary(m) && a.pinnableUserTurn(m) {
+			kept = append(kept, m)
+		} else {
+			fold = append(fold, m)
+		}
+	}
+	return kept, fold
 }
 
 // planCompaction locates the region to summarize. head is the count of leading

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -130,6 +130,57 @@ func TestPinnedPrefixLen(t *testing.T) {
 	}
 }
 
+func TestCompactKeepsMidSessionUserTurns(t *testing.T) {
+	big := strings.Repeat("work output ", 100)
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "first task"},
+		{Role: provider.RoleAssistant, Content: big},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "read_file", Content: big},
+		{Role: provider.RoleUser, Content: "by the way, always use pnpm not npm"},
+		{Role: provider.RoleAssistant, Content: big},
+		{Role: provider.RoleTool, ToolCallID: "2", Name: "read_file", Content: big},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(&fakeProvider{reply: "digest"}, tool.NewRegistry(), sess,
+		Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	// Both the pinned first turn and the mid-session fact survive verbatim — not as
+	// summary text — while the assistant/tool work between them is folded.
+	var pinnedFirst, keptMid bool
+	for _, m := range sess.Snapshot() {
+		if isCompactionSummary(m) {
+			continue
+		}
+		if m.Role == provider.RoleUser && m.Content == "first task" {
+			pinnedFirst = true
+		}
+		if m.Role == provider.RoleUser && strings.Contains(m.Content, "always use pnpm not npm") {
+			keptMid = true
+		}
+	}
+	if !pinnedFirst || !keptMid {
+		t.Fatalf("user turns not kept verbatim (first=%v mid=%v): %+v", pinnedFirst, keptMid, sess.Snapshot())
+	}
+	if strings.Contains(strings.Join(snapshotContents(sess), " "), big) {
+		t.Errorf("assistant/tool work was not folded")
+	}
+}
+
+func snapshotContents(s *Session) []string {
+	msgs := s.Snapshot()
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Content
+	}
+	return out
+}
+
 func TestCompactReplacesHistory(t *testing.T) {
 	prov := &fakeProvider{reply: "- goal: do X\n- changed file Y"}
 	bigStep := strings.Repeat("important implementation detail ", 80)


### PR DESCRIPTION
Follow-up to #4048. That PR pinned the **first** user turn; this adds the deterministic floor for facts stated at **any** point, plus a structured consolidation layer.

## Base layer — the guarantee
Compaction now keeps **every small user turn verbatim** and folds only assistant/tool work (and oversized user pastes). A fact the user states mid-session — "always deploy to eu-west-3, never us-east-1" at turn 4 — is preserved in its own words regardless of how the summarizer behaves. This removes the model from the loop for user-stated facts: the only way to guarantee a fact stays in context is to never let a model re-generate it.

`partitionFold` splits the compaction region into kept (small user turns) and folded (the rest); the kept turns are spliced back verbatim before the digest.

## Upper layer — the tidy view
The digest leads with a structured **`## Standing facts & constraints`** section that consolidates what the user stated into one clean list. It's redundant with the verbatim turns by design — best-effort consolidation on top of a deterministic floor, so a weak summarizer dropping a fact there loses nothing.

## Real-provider A/B
5-turn session, 14k window, **18 folds**. Fact A stated turn 1, fact B ("eu-west-3") stated mid-session at turn 2; final turn asks for both.

| | mid-session fact B in the final request |
|---|---|
| this PR | **verbatim user turn present** (deterministic) + also in the digest's facts section |
| #4048 only | **0 verbatim user turns** — survived only inside compaction summaries, i.e. by luck; one degenerate fold from loss |

Both recalled the fact this run (the old summary happened to keep it), but the mechanism differs: the floor makes presence structural, not stochastic.

## Tests
New `TestCompactKeepsMidSessionUserTurns` (a mid-session user fact survives a fold verbatim while the work folds). Existing compaction/prune tests unchanged and green; `go test ./internal/agent/...`, control, boot pass.
