### PR TITLE
fix(agent): clarify subagent continuation guidance

### DIFF
--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -138,7 +138,7 @@ func (t *TaskTool) Schema() json.RawMessage {
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."},
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},
   "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."},
-  "continue_from":{"type":"string","description":"Optional subagent transcript reference to continue in place. The current kind, prompt persona, tools, model, effort, and workspace must match the saved transcript."},
+  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing the 'Subagent reference: sa_...' token from the prior result. Requires kind, system prompt, tools, model, effort, and workspace to match."},
   "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy into a new transcript before running this task. Mutually exclusive with continue_from."}
 },
 "required":["prompt"]

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -138,7 +138,7 @@ func (t *TaskTool) Schema() json.RawMessage {
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."},
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},
   "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."},
-  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing the 'Subagent reference: sa_...' token from the prior result. Requires kind, system prompt, tools, model, effort, and workspace to match."},
+  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Requires kind, system prompt, tools, model, effort, and workspace to match."},
   "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy into a new transcript before running this task. Mutually exclusive with continue_from."}
 },
 "required":["prompt"]

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -67,7 +67,7 @@ func (*runSkillTool) Schema() json.RawMessage {
 "properties":{
   "name":{"type":"string","description":"Skill identifier as it appears in the pinned Skills index (e.g. 'explore', 'review'). Case-sensitive. Just the identifier, not the [🧬 subagent] tag."},
   "arguments":{"type":"string","description":"Free-form arguments. For inline skills: appended as an 'Arguments:' line; the skill's own instructions decide how to use them. For subagent skills: REQUIRED — becomes the entire task the subagent receives."},
-  "continue_from":{"type":"string","description":"Optional subagent transcript reference to continue in place. Only valid for runAs=subagent skills."},
+  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context; use in iterative loops (e.g. review -> fix -> review again) by passing the 'Subagent reference: sa_...' token from the prior result. Only valid for runAs=subagent skills."},
   "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Only valid for runAs=subagent skills; mutually exclusive with continue_from."}
 },
 "required":["name"]
@@ -211,7 +211,7 @@ func (t *subagentSkillTool) Description() string { return t.description }
 
 func (t *subagentSkillTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"task":{"type":"string","description":` +
-		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Optional subagent transcript reference to continue in place."},"fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Mutually exclusive with continue_from."}},"required":["task"]}`)
+		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run. Use in iterative loops (e.g. review -> fix -> review again): pass the 'Subagent reference: sa_...' token from the prior result."},"fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Mutually exclusive with continue_from."}},"required":["task"]}`)
 }
 
 func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -67,7 +67,7 @@ func (*runSkillTool) Schema() json.RawMessage {
 "properties":{
   "name":{"type":"string","description":"Skill identifier as it appears in the pinned Skills index (e.g. 'explore', 'review'). Case-sensitive. Just the identifier, not the [🧬 subagent] tag."},
   "arguments":{"type":"string","description":"Free-form arguments. For inline skills: appended as an 'Arguments:' line; the skill's own instructions decide how to use them. For subagent skills: REQUIRED — becomes the entire task the subagent receives."},
-  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context; use in iterative loops (e.g. review -> fix -> review again) by passing the 'Subagent reference: sa_...' token from the prior result. Only valid for runAs=subagent skills."},
+  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Only valid for runAs=subagent skills."},
   "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Only valid for runAs=subagent skills; mutually exclusive with continue_from."}
 },
 "required":["name"]
@@ -211,7 +211,7 @@ func (t *subagentSkillTool) Description() string { return t.description }
 
 func (t *subagentSkillTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"task":{"type":"string","description":` +
-		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run. Use in iterative loops (e.g. review -> fix -> review again): pass the 'Subagent reference: sa_...' token from the prior result."},"fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Mutually exclusive with continue_from."}},"required":["task"]}`)
+		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run. Use in iterative loops (e.g. review -> fix -> review again): pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line."},"fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Mutually exclusive with continue_from."}},"required":["task"]}`)
 }
 
 func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {


### PR DESCRIPTION
## Summary
本 PR 优化了三个工具暴露给模型的 `continue_from` schema 描述：

- 通用 `task` tool
- `run_skill`
- 专用 subagent skill wrapper

当前项目实现已经存在：subagent 完成后会返回 `Subagent reference: sa_...` token，将该 token 作为 `continue_from` 传入即可在原位续接/复用同一个子会话。此前 schema 只把这个字段描述为“可选引用”，但没有让模型在调用时明确意识到三点：

- `continue_from` 会保留 subagent 之前的上下文；
- 某些场景（如`review -> fix -> review again`）这类迭代循环可以考虑复用同一个 subagent；
- 参数值应来自上一次工具结果里的 `Subagent reference: sa_...` token。

## Why This Matters
subagent 的价值之一，是把聚焦的探索、分析或 review 上下文隔离在父会话之外。但在多轮工作流里，如果每次都启动 fresh window subagent，就会丢失上一个 subagent 刚刚建立的专注上下文。此前 `continue_from` 只被描述成一个通用的可选引用，模型很容易忽略这一点。

本改动刻意保持很小：它只让现有工具契约更自解释，使模型在任务结构需要时，更容易根据当前任务场景，主动思考是否要选择已有的续接路径。

## Validation
已运行：

```text
gofmt -l internal/agent/task.go internal/skill/tools.go
go test ./internal/agent ./internal/skill
go build ./...
go vet ./...
go test ./...
```