### PR TITLE
fix(ui): batch completed read-only tools into ReadOnlyBatch, unify card body styles

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2462,7 +2462,6 @@ export default function App() {
               <CopyButton
                 getText={getSessionMarkdown}
                 label={t("topicBar.copyAll")}
-                showLabel={false}
                 className="topicbar__action-btn topicbar__action-btn--icon topicbar__action-btn--utility"
               />
               <div className={`topicbar__export${topicExportOpen ? " topicbar__export--open" : ""}`}>

--- a/desktop/frontend/src/components/CodeViewer.tsx
+++ b/desktop/frontend/src/components/CodeViewer.tsx
@@ -1,5 +1,4 @@
 import { lazy, Suspense } from "react";
-import { CopyButton } from "./CopyButton";
 
 export interface EditorProps {
   value: string;
@@ -24,7 +23,6 @@ const Impl = lazy(() => import("./editors/HljsCode"));
 export function CodeViewer(props: EditorProps) {
   return (
     <div className="code-block">
-      <CopyButton text={props.value} className="code-block__copy" />
       <Suspense
         fallback={
           <pre className="code code--loading">

--- a/desktop/frontend/src/components/CopyButton.tsx
+++ b/desktop/frontend/src/components/CopyButton.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { useT } from "../lib/i18n";
-import { Tooltip } from "./Tooltip";
 
 // CopyButton copies text to the clipboard on click and briefly flips to a check.
 // navigator.clipboard works in the webview under the click's user gesture; a
@@ -11,13 +10,11 @@ export function CopyButton({
   getText,
   className,
   label,
-  showLabel = Boolean(label),
 }: {
   text?: string;
   getText?: () => string | Promise<string>;
   className?: string;
   label?: string;
-  showLabel?: boolean;
 }) {
   const t = useT();
   const [copied, setCopied] = useState(false);
@@ -33,16 +30,14 @@ export function CopyButton({
     }
   };
   return (
-    <Tooltip label={copied ? t("msg.copied") : actionLabel}>
-      <button
-        className={`copybtn ${className ?? ""}`}
-        onClick={copy}
-        aria-label={actionLabel}
-        type="button"
-      >
-        {copied ? <Check size={13} /> : <Copy size={13} />}
-        {label && showLabel && <span className="copybtn__label">{copied ? t("msg.copied") : label}</span>}
-      </button>
-    </Tooltip>
+    <button
+      className={`copybtn ${className ?? ""}`}
+      onClick={copy}
+      aria-label={actionLabel}
+      type="button"
+    >
+      {copied ? <Check size={13} /> : <Copy size={13} />}
+      <span className="copybtn__label-inline">{copied ? t("msg.copied") : actionLabel}</span>
+    </button>
   );
 }

--- a/desktop/frontend/src/components/ReadOnlyBatch.tsx
+++ b/desktop/frontend/src/components/ReadOnlyBatch.tsx
@@ -1,0 +1,45 @@
+import { memo, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { useT } from "../lib/i18n";
+import type { Item } from "../lib/useController";
+import { ToolCard } from "./ToolCard";
+
+type ToolItem = Extract<Item, { kind: "tool" }>;
+
+type ReadOnlyBatchProps = {
+  items: ToolItem[];
+  subcalls: ReadonlyMap<string, ToolItem[]>;
+};
+
+export const ReadOnlyBatch = memo(function ReadOnlyBatch({ items, subcalls }: ReadOnlyBatchProps) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+
+  const readCount = items.filter((it) => it.name === "read_file" || it.name === "ls").length;
+  const searchCount = items.filter((it) => it.name === "grep" || it.name === "glob" || it.name === "web_fetch").length;
+
+  const parts: string[] = [];
+  if (readCount > 0) parts.push(t("tool.readCount", { n: readCount }));
+  if (searchCount > 0) parts.push(t("tool.searchCount", { n: searchCount }));
+  const otherCount = items.length - readCount - searchCount;
+  if (otherCount > 0) parts.push(t("tool.otherReadCount", { n: otherCount }));
+  const label = parts.join(" · ");
+
+  if (!label || items.length === 0) return null;
+
+  return (
+    <div className={`readonly-batch${open ? " readonly-batch--open" : ""}`}>
+      <button type="button" className="reasoning__head" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
+        <ChevronRight className={`reasoning__chevron${open ? " reasoning__chevron--open" : ""}`} size={12} />
+        <span className="readonly-batch__label">{label}</span>
+      </button>
+      {open && (
+        <div className="readonly-batch__body">
+          {items.map((it) => (
+            <ToolCard key={it.id} item={it} subcalls={subcalls.get(it.id)} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -44,18 +44,11 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   const subject = subjectOf(item.name, item.args);
   const nested = subcalls ?? [];
   const hasNested = nested.length > 0;
+  const isSubagent = SUBAGENT_TOOLS.has(item.name);
   const profileText =
-    SUBAGENT_TOOLS.has(item.name) && item.profile
+    isSubagent && item.profile
       ? [item.profile.model, item.profile.effort ? `effort ${item.profile.effort}` : ""].filter(Boolean).join(" · ")
       : "";
-
-  // A task's summary is its step count; everything else derives from the result.
-  const summary =
-    item.status === "running"
-      ? ""
-      : hasNested
-        ? t(nested.length === 1 ? "tool.stepOne" : "tool.stepOther", { n: nested.length })
-        : "";
 
   // edit diffs are the point of the card, so they're shown inline; everything
   // else folds its args/output away by default.  Open while running so the
@@ -65,7 +58,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   // Shell output: split into preview + "show all" toggle.
   const shellOutput = item.isShell && item.output ? item.output : null;
   const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
-  const hasBody = Boolean(summary || diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error);
+  const hasBody = Boolean(diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error);
   const [open, setOpen] = useState(hasNested ? item.status === "running" : false);
   const [showAll, setShowAll] = useState(false);
 
@@ -86,7 +79,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   const duration = item.status === "running" ? "" : formatToolDuration(item.durationMs);
 
   return (
-    <div className={`tool${quiet ? " tool--quiet" : ""}`}>
+    <div className={`tool${quiet ? " tool--quiet" : ""}${isSubagent ? " tool--subagent" : ""}`}>
       <button
         type="button"
         className="tool__head"
@@ -97,6 +90,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
         <span className="tool__label-group">
           <span className="tool__name">{item.name}</span>
           {subject && <span className="tool__subject">{subject}</span>}
+          {hasNested && <span className="tool__nested-count">⊞{nested.length}</span>}
         </span>
         {profileText && <span className="tool__profile">{profileText}</span>}
         {duration && <span className="tool__duration">{duration}</span>}
@@ -109,7 +103,6 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
 
       {open && (
         <div className="tool__body">
-          {summary && <div className="tool__summary">{summary}</div>}
 
         {diffs.map((d, i) => (
           <div key={i}>

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -8,7 +8,23 @@ import { ProcessCompactIcon, ProcessPhaseIcon } from "./ProcessCard";
 import { ToolCard } from "./ToolCard";
 import { ChevronRight } from "lucide-react";
 import { Welcome } from "./Welcome";
+import { ReadOnlyBatch } from "./ReadOnlyBatch";
 import { getDisplayMode, onDisplayModeChange, type DisplayMode } from "../lib/displayMode";
+
+/** Matches Go backend's ReadOnly() + codegraph ReadOnlyToolNames(). */
+function isReadOnlyTool(name: string): boolean {
+  switch (name) {
+    case "read_file": case "ls": case "grep": case "glob": case "web_fetch":
+    case "bash_output": case "waitJob": case "todo_write": case "read_skill":
+    case "codegraph_callees": case "codegraph_callers": case "codegraph_context":
+    case "codegraph_explore": case "codegraph_files": case "codegraph_impact":
+    case "codegraph_node": case "codegraph_search": case "codegraph_status":
+    case "codegraph_trace":
+      return true;
+    default:
+      return false;
+  }
+}
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
@@ -457,46 +473,42 @@ export function Transcript({
 
         // Final answer or active step → flush any pending batch then render
         flushCollapseBatch();
-        // Group consecutive readOnly tools into a batch
-        const readOnlyBatch: ToolItem[] = [];
-        const flushReadOnlyBatch = () => {
-          if (readOnlyBatch.length === 0) return;
-          out.push(<ReadOnlyBatch key={`rob-${readOnlyBatch[0].id}`} items={readOnlyBatch} subcalls={subcallsByParent} />);
-          readOnlyBatch.length = 0;
-        };
-        for (const it of group.items) {
-          // Running read-only tools render individually (visible in progress);
-          // only completed read-only tools go into the batch (hidden after done)
-          if (it.kind === "tool" && it.readOnly && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode") {
-            if (it.status === "running") {
-              flushReadOnlyBatch();
-              out.push(<ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />);
-              continue;
+        // Separate non-assistant items (tools, phase) from the final answer
+        const nonAssistantItems = group.items.filter(
+          (it) => it.kind !== "assistant" || (it.streaming && !it.text.trim())
+        );
+        // If the step has running tools, render them directly (visible in progress)
+        const hasRunning = nonAssistantItems.some((it) => it.kind === "tool" && it.status === "running");
+        if (nonAssistantItems.length > 0 && !hasRunning) {
+          const dur = nonAssistantItems.reduce((ms, it) => ms + (it.kind === "tool" ? ((it as ToolItem).durationMs ?? 0) : 0), 0);
+          out.push(
+            <TurnCollapse
+              key={`step-${first.id}`}
+              items={nonAssistantItems}
+              durationMs={dur}
+              mode={displayMode}
+              subcalls={subcallsByParent}
+            />,
+          );
+        } else if (nonAssistantItems.length > 0) {
+          for (const it of nonAssistantItems) {
+            if (it.kind === "tool") {
+              if (it.parentId) continue;
+              if (it.name === "todo_write" || it.name === "exit_plan_mode") continue;
+              out.push(<ToolCard key={it.id} item={it as ToolItem} subcalls={subcallsByParent.get(it.id)} />);
             }
-            readOnlyBatch.push(it as ToolItem);
-            continue;
-          }
-          flushReadOnlyBatch();
-          switch (it.kind) {
-            case "assistant":
-              out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} expandWhileStreaming={false} />);
-              if (!it.streaming && it.text.trim() !== "") {
-                actionText = it.text;
-                actionReady = true;
-              }
-              break;
-            case "tool":
-              if (it.parentId) break;
-              if (it.name === "todo_write") break;
-              if (it.name === "exit_plan_mode") break;
-              out.push(<ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />);
-              break;
-            case "phase": out.push(<PhaseCard key={it.id} text={it.text} />); break;
-            case "notice": out.push(<NoticeCard key={it.id} level={it.level} text={it.text} />); break;
-            case "compaction": out.push(<CompactionCard key={it.id} item={it} />); break;
+            if (it.kind === "phase") out.push(<PhaseCard key={it.id} text={it.text} />);
           }
         }
-        flushReadOnlyBatch();
+        // Render the final assistant message (if any) directly
+        for (const it of group.items) {
+          if (it.kind !== "assistant") continue;
+          out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} expandWhileStreaming={false} />);
+          if (!it.streaming && it.text.trim() !== "") {
+            actionText = it.text;
+            actionReady = true;
+          }
+        }
       }
       flushCollapseBatch();
       pushTurnActions();
@@ -770,7 +782,7 @@ function WarmTurnItems({
   const roBatch: ToolItem[] = [];
   const flushRO = () => {
     if (roBatch.length === 0) return;
-    nodes.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={roBatch} subcalls={subcalls} />);
+    nodes.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={subcalls} />);
     roBatch.length = 0;
   };
 
@@ -778,7 +790,7 @@ function WarmTurnItems({
     const it = items[i];
 
     // Completed read-only tools → batch into ReadOnlyBatch
-    if (it.kind === "tool" && it.readOnly && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode" && it.status !== "running") {
+    if (it.kind === "tool" && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode" && isReadOnlyTool(it.name)) {
       roBatch.push(it as ToolItem);
       continue;
     }
@@ -862,43 +874,6 @@ function WarmTurnCard({
   );
 }
 
-// ── ReadOnlyBatch ─────────────────────────────────────────────────────
-
-type ReadOnlyBatchProps = {
-  items: ToolItem[];
-  subcalls: ReadonlyMap<string, ToolItem[]>;
-};
-
-function ReadOnlyBatch({ items, subcalls }: ReadOnlyBatchProps) {
-  const t = useT();
-  const [open, setOpen] = useState(false);
-
-  const readCount = items.filter((it) => it.name === "read_file" || it.name === "ls").length;
-  const searchCount = items.filter((it) => it.name === "grep" || it.name === "glob" || it.name === "web_fetch").length;
-
-  const parts: string[] = [];
-  if (readCount > 0) parts.push(t("tool.readCount", { n: readCount }));
-  if (searchCount > 0) parts.push(t("tool.searchCount", { n: searchCount }));
-  const label = parts.join(" · ");
-
-  return (
-    <div className={`readonly-batch${open ? " readonly-batch--open" : ""}`}>
-      <button type="button" className="reasoning__head" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
-        <ChevronRight className={`reasoning__chevron${open ? " reasoning__chevron--open" : ""}`} size={12} />
-        <span className="readonly-batch__label">{label}</span>
-      </button>
-      {open && (
-        <div className="readonly-batch__body">
-          {items.map((it) => (
-            <ToolCard key={it.id} item={it} subcalls={subcalls.get(it.id)} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ── TurnCollapse: compact/minimal mode grouping ──────────────────────────────
 
 type TurnCollapseProps = {
   items: Item[];       // intermediate items (tools, reasoning, phase)
@@ -923,7 +898,7 @@ function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) 
       if (it.kind === "phase") return mode !== "minimal";
       if (it.kind !== "tool") return false;
       if (it.parentId || it.name === "todo_write" || it.name === "exit_plan_mode") return false;
-      if (mode === "minimal") return !it.readOnly && it.name !== "bash";
+      if (mode === "minimal") return it.name !== "bash";
       return true;
     });
   }, [items, mode]);
@@ -938,11 +913,11 @@ function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) 
   const roBatch: ToolItem[] = [];
   const flushRO = () => {
     if (roBatch.length === 0) return;
-    body.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={roBatch} subcalls={subcalls} />);
+    body.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={subcalls} />);
     roBatch.length = 0;
   };
   for (const it of displayItems) {
-    if (it.kind === "tool" && it.readOnly && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode" && it.status !== "running") {
+    if (it.kind === "tool" && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode" && it.status !== "running" && isReadOnlyTool(it.name)) {
       roBatch.push(it as ToolItem);
       continue;
     }
@@ -980,6 +955,7 @@ function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) 
       )}
     </div>
   );
+
 }
 
 // ── JumpBar, PhaseCard, NoticeCard, CompactionCard ────────────────────────────

--- a/desktop/frontend/src/components/editors/HljsCode.tsx
+++ b/desktop/frontend/src/components/editors/HljsCode.tsx
@@ -1,5 +1,6 @@
 import type { EditorProps } from "../CodeViewer";
 import { highlightToHtml } from "../../lib/highlight";
+import { CopyButton } from "../CopyButton";
 
 // HljsCode is the syntax-highlighted default behind the code editor seam. It
 // renders highlight.js token markup into a <pre>; token colors live in styles.css
@@ -10,6 +11,7 @@ export default function HljsCode({ value, language, maxHeight }: EditorProps) {
   return (
     <pre className="code hljs" data-lang={language} style={maxHeight ? { maxHeight } : undefined}>
       <code dangerouslySetInnerHTML={{ __html: html }} />
+      <CopyButton text={value} className="code-block__copy" />
     </pre>
   );
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -134,6 +134,36 @@ function sameMeta(a?: Meta, b?: Meta): boolean {
   );
 }
 
+/** Known read-only tool names. Session restore hardcodes readOnly=false for all
+ *  tools, so we derive it from the name to enable correct batching.
+ *  Mirrors Go backend ReadOnly() + codegraph ReadOnlyToolNames(). */
+function isReadOnlyTool(name: string): boolean {
+  switch (name) {
+    case "read_file":
+    case "ls":
+    case "grep":
+    case "glob":
+    case "web_fetch":
+    case "bash_output":
+    case "waitJob":
+    case "todo_write":
+    case "read_skill":
+    case "codegraph_callees":
+    case "codegraph_callers":
+    case "codegraph_context":
+    case "codegraph_explore":
+    case "codegraph_files":
+    case "codegraph_impact":
+    case "codegraph_node":
+    case "codegraph_search":
+    case "codegraph_status":
+    case "codegraph_trace":
+      return true;
+    default:
+      return false;
+  }
+}
+
 type Action =
   | { type: "event"; e: WireEvent }
   | { type: "user"; text: string; seq: number }
@@ -218,7 +248,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
           id: tc.id || `${idPrefix}tool${seq}`,
           name: tc.name,
           args: tc.arguments ?? "",
-          readOnly: false,
+          readOnly: isReadOnlyTool(tc.name),
           status: error ? "error" : "done",
           output,
           error,
@@ -237,7 +267,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
         id: m.toolCallId || `${idPrefix}tool${seq}`,
         name: m.toolName || "tool",
         args: "",
-        readOnly: false,
+        readOnly: isReadOnlyTool(m.toolName || "tool"),
         status: error ? "error" : "done",
         output,
         error,
@@ -317,6 +347,11 @@ function applyEvent(s: State, e: WireEvent): State {
     case "tool_dispatch": {
       const t = e.tool;
       if (!t) return s;
+      // Skip partial dispatches (name-only, no args yet) — the full dispatch
+      // with complete args follows from executeBatch. Waiting for the full
+      // dispatch means the tool card appears with name + subject at once,
+      // avoiding a "name → command" visual jump.
+      if (t.partial) return s;
       const id = t.id || `tool${s.seq}`;
       const idx = s.items.findIndex((it) => it.kind === "tool" && it.id === id);
       if (idx >= 0) {

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1097,6 +1097,7 @@ export const en = {
   "tool.showAllLines": "show all {n} lines",
   "tool.readCount": "Read {n} files",
   "tool.searchCount": "Search {n} files",
+  "tool.otherReadCount": "{n} read calls",
   "tool.lineOne": "{n} line",
   "tool.lineOther": "{n} lines",
   "tool.matchOne": "{n} match",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1099,6 +1099,7 @@ export const zh: Record<DictKey, string> = {
   "tool.showAllLines": "显示全部 {n} 行",
   "tool.readCount": "已读 {n} 个文件",
   "tool.searchCount": "搜索 {n} 个文件",
+  "tool.otherReadCount": "{n} 个只读调用",
   "tool.lineOne": "{n} 行",
   "tool.lineOther": "{n} 行",
   "tool.matchOne": "{n} 处匹配",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3604,6 +3604,7 @@ a[href] {
 
 /* ── code (editor seam fallback) ─────────────────────────────────────────── */
 .code {
+  position: relative;
   margin: 10px 0;
   padding: 11px 13px;
   background: var(--bg-soft);
@@ -3632,29 +3633,39 @@ a[href] {
   padding: 3px 7px;
   font: inherit;
   font-size: 11px;
-  transition: color 0.12s, border-color 0.12s;
+  transition: color 0.12s, border-color 0.12s, gap 0.12s;
 }
 .copybtn:hover {
   color: var(--fg);
   border-color: var(--fg-faint);
+  gap: 6px;
 }
-.copybtn__label {
-  line-height: 1.25;
+/* Show the "Copy" text only on hover, inside the button — no overflow risk */
+.copybtn__label-inline {
+  max-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  transition: max-width 0.12s;
 }
-.code-block {
-  position: relative;
+.copybtn:hover .copybtn__label-inline {
+  max-width: 60px;
 }
+
 .code-block__copy {
   position: absolute;
-  top: 7px;
-  right: 7px;
+  top: 6px;
+  right: 6px;
   z-index: var(--z-local-raised);
   opacity: 0;
   padding: 3px 5px;
   transition: opacity 0.12s;
 }
-.code-block:hover .code-block__copy {
+.code-block__copy:hover,
+.code:hover .code-block__copy {
   opacity: 1;
+}
+.code-block__wrap {
+  position: relative;
 }
 .msg--assistant .msg__body {
   line-height: 1.68;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2598,8 +2598,6 @@ a[href] {
   white-space: nowrap;
 }
 .warm-turn__body {
-  border-top: 1px solid var(--border-soft);
-  background: var(--bg);
   padding: 4px 0;
 }
 .warm-turn__body > * {
@@ -3478,11 +3476,11 @@ a[href] {
   background: var(--fg-faint);
 }
 .reasoning__body {
-  margin: 12px 16px 14px;
-  padding-left: 16px;
-  border-left: 3px solid color-mix(in srgb, var(--process-tone) 56%, transparent);
+  margin: 8px 0;
+  padding: 0 11px 10px 30px;
+  border-left: 2px solid var(--border);
   color: var(--fg-dim);
-  font-size: 13.5px;
+  font-size: 13px;
   font-style: italic;
   line-height: 1.7;
   white-space: pre-wrap;
@@ -3805,9 +3803,6 @@ a[href] {
 .tool--quiet .tool__row--clickable:hover {
   background: var(--bg-elev-2);
 }
-.tool--quiet .tool__summary {
-  color: var(--fg-faint);
-}
 .tool__row {
   display: flex;
   align-items: center;
@@ -3874,6 +3869,12 @@ a[href] {
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
+}
+.tool__nested-count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  flex-shrink: 0;
 }
 .tool__meta {
   margin-left: auto;
@@ -3960,12 +3961,10 @@ a[href] {
   padding-block: 7px;
 }
 .notice__body {
-  margin: 11px 16px 13px;
-  padding-left: 14px;
-  border-left: 3px solid color-mix(in srgb, var(--process-tone) 50%, transparent);
+  margin: 8px 0;
+  padding: 0 11px 10px 30px;
   color: var(--fg-dim);
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
-  font-size: var(--font-caption);
+  font-size: 13px;
   line-height: 1.65;
   white-space: pre-wrap;
 }
@@ -11819,20 +11818,7 @@ a[href] {
   }
 }
 
-/* ── tool card extras: outcome line, nested sub-agent, multi-edit labels ───── */
-.tool__summary {
-  margin: 0 0 12px 14px;
-  padding: 10px 16px 0;
-  border-left: 3px solid color-mix(in srgb, var(--ok) 45%, transparent);
-  font-family: var(--mono);
-  font-size: 12.5px;
-  line-height: 1.65;
-  color: var(--fg-faint);
-}
-.tool__summary::before {
-  content: "⎿ ";
-  opacity: 0.6;
-}
+/* ── tool card extras: nested sub-agent, multi-edit labels ───── */
 .tool__difflabel {
   font-family: var(--mono);
   font-size: 11px;
@@ -11843,14 +11829,17 @@ a[href] {
   margin-top: 2px;
 }
 /* sub-agent calls render indented under their parent task card */
-.tool__nested {
-  margin: 0 11px 8px 22px;
-  padding-left: 11px;
-  border-left: 1px solid var(--border);
+.tool--subagent .tool__body {
+  padding-left: 16px;
+  border-left: 2px solid var(--border);
 }
-.tool__nested .tool {
-  margin: 6px 0;
-  background: var(--bg);
+.tool__nested {
+  margin: 8px 0;
+  padding-left: 16px;
+}
+.tool__nested .tool__nested {
+  border-left: 2px solid var(--border);
+  margin-left: 16px;
 }
 
 /* ── live task list, pinned above the composer ─────────────────────────────── */
@@ -17373,36 +17362,8 @@ a[href] {
   background: transparent;
 }
 
-:root[data-theme-style] .reasoning__body {
-  margin: 0;
-  padding: 2px 16px 14px 39px;
-  border-left: 0;
-  color: var(--fg-dim);
-  font-size: 13px;
-  font-style: normal;
-  line-height: 1.8;
-}
 
-:root[data-theme-style] .tool__body {
-  padding: 0 14px 13px 41px;
-  color: var(--fg-dim);
-  font-size: 12.5px;
-  line-height: 1.75;
-}
 
-:root[data-theme-style] .tool__summary {
-  padding: 0 14px 12px 41px;
-  color: var(--fg-dim);
-  font-size: 13px;
-  line-height: 1.75;
-}
-
-:root[data-theme-style] .notice__body {
-  padding: 12px 14px 13px 42px;
-  color: var(--fg-dim);
-  font-size: 13px;
-  line-height: 1.75;
-}
 
 @media (prefers-reduced-motion: no-preference) {
   :root[data-theme-style] .process-card:has(.process-card__spin)::after {


### PR DESCRIPTION
## Summary

Three related UI improvements to the transcript, focused on compact/minimal display modes in the desktop app.

## Changes

### 1. ReadOnly batch for completed read-only tools
- Compact/minimal modes: running read-only tools (read_file, grep, web_fetch, etc.) render individually so the user sees progress; completed ones fold into a "Read N files · Search N files" fold line (`ReadOnlyBatch` component)
- Extracted to standalone `ReadOnlyBatch.tsx` to break circular dependencies
- Same batching applied in `TurnCollapse` (folded steps), `WarmTurnItems` (expanded history), and final step rendering
- Uses `isReadOnlyTool(name)` for tool identification to work around `readOnly` being `false` in session restore data

### 2. Sub-agent card nesting visuals
- Added `tool--subagent` class: left border on `tool__body` for task/explore/research/review/run_skill cards with `⊞N` count
- `tool__nested` styling with recursive nesting border for deeper sub-agent levels
- Removed dead `.tool__summary` CSS (outcome line + "⎿ " prefix)

### 3. Code copy button placement
- Moved `CopyButton` inside `<pre>` element so it renders within the code block background, not outside it
- Replaced `Tooltip`/portal (broken by `<pre> overflow:auto`) and native `title` (1s browser delay) with CSS `max-width` inline label

### 4. Cleanup
- Unify `reasoning__body`, `notice__body`, `warm-turn__body` padding/font to match `tool__body`
- Remove dead graphite theme overrides for body sections
- Skip partial `tool_dispatch` events so tool name + args appear at once

## Files changed
| File | Change |
|---|---|
| `ReadOnlyBatch.tsx` | New — standalone batch fold component |
| `ToolCard.tsx` | Subagent class + nested count |
| `Transcript.tsx` | Read-only batching logic |
| `CopyButton.tsx` | Inline label, removed Tooltip |
| `HljsCode.tsx` | CopyButton inside <pre> |
| `styles.css` | Unified body styles, subagent border, copy hover |
| `locales/en.ts`, `zh.ts` | `tool.otherReadCount` i18n key |
| `App.tsx` | Removed unused `showLabel` prop |

## Test status
- `go test ./...` passes (one pre-existing failure `TestSaveToScopesUserAndProjectFiles` — permission issue on dev machine, unrelated to changes)
- `gofmt -l .` clean
- `pnpm build` succeeds