### PR TITLE
Fix cost currency display / 修复成本货币符号显示

### DIFF
--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -1,6 +1,7 @@
 // Run: tsx src/__tests__/context-panel-breakdown.test.ts
 
-import { contextBreakdown } from "../components/ContextPanel";
+import { contextBreakdown, contextCostDisplay } from "../components/ContextPanel";
+import { currencySymbol, formatMoney } from "../lib/money";
 
 let passed = 0;
 let failed = 0;
@@ -64,6 +65,19 @@ eq(
   },
   "unknown context window keeps donut segments empty",
 );
+
+console.log("\ncontext panel cost");
+
+const infoCost = contextCostDisplay({
+  info: { sessionCost: 0.1759, sessionCurrency: "$", sessionCostUsd: 0.1759 },
+  sessionCost: 0,
+  sessionCurrency: "¥",
+  usage: { cost: 0, costUsd: 0, currency: "¥" },
+});
+eq(infoCost, { amount: 0.1759, currency: "$" }, "panel cost keeps the panel currency instead of state default");
+eq(formatMoney(infoCost.amount, infoCost.currency, "dash"), "$0.1759", "USD panel cost renders with dollar sign");
+eq(currencySymbol("楼"), "¥", "unexpected currency text does not leak into money values");
+eq(currencySymbol("aud"), "AUD ", "unknown ISO currency codes stay readable");
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -78,6 +78,7 @@ eq(infoCost, { amount: 0.1759, currency: "$" }, "panel cost keeps the panel curr
 eq(formatMoney(infoCost.amount, infoCost.currency, "dash"), "$0.1759", "USD panel cost renders with dollar sign");
 eq(currencySymbol("楼"), "¥", "unexpected currency text does not leak into money values");
 eq(currencySymbol("aud"), "AUD ", "unknown ISO currency codes stay readable");
+eq(currencySymbol("A$"), "A$", "compact multi-character currency symbols are preserved");
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -5,6 +5,7 @@ import { FileText } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { useT, type Translator } from "../lib/i18n";
+import { formatMoney } from "../lib/money";
 import type { DictKey } from "../locales/en";
 import type { ContextInfo, ContextPanelInfo, WireUsage } from "../lib/types";
 
@@ -42,19 +43,6 @@ function fmtDuration(ms: number, t: Translator): string {
   return t("context.durationMinutesSeconds", { minutes, seconds });
 }
 
-function currencySymbol(currency?: string): string {
-  const value = (currency || "¥").trim();
-  if (/^(cny|rmb|yuan)$/i.test(value)) return "¥";
-  if (/^(usd|dollar)$/i.test(value)) return "$";
-  return value || "¥";
-}
-
-function fmtMoney(amount: number, currency?: string): string {
-  if (amount <= 0) return "-";
-  const symbol = currencySymbol(currency);
-  return `${symbol}${amount < 1 ? amount.toFixed(4) : amount.toFixed(2)}`;
-}
-
 interface HealthResult {
   tone: "good" | "notice" | "warn";
   shortKey: DictKey;
@@ -62,6 +50,35 @@ interface HealthResult {
 }
 
 type ContextFileRow = { key: string; path: string; meta: string; time: string; detail: string };
+
+export function contextCostDisplay({
+  info,
+  sessionCost,
+  sessionCurrency,
+  usage,
+}: {
+  info?: Pick<ContextPanelInfo, "sessionCost" | "sessionCurrency" | "sessionCostUsd"> | null;
+  sessionCost?: number;
+  sessionCurrency?: string;
+  usage?: Pick<WireUsage, "cost" | "costUsd" | "currency">;
+}): { amount: number; currency?: string } {
+  if (info?.sessionCost && info.sessionCost > 0) {
+    return { amount: info.sessionCost, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
+  }
+  if (sessionCost && sessionCost > 0) {
+    return { amount: sessionCost, currency: sessionCurrency || info?.sessionCurrency || usage?.currency };
+  }
+  if (usage?.cost && usage.cost > 0) {
+    return { amount: usage.cost, currency: usage.currency || sessionCurrency || info?.sessionCurrency };
+  }
+  if (info?.sessionCostUsd && info.sessionCostUsd > 0) {
+    return { amount: info.sessionCostUsd, currency: info.sessionCurrency || sessionCurrency || usage?.currency };
+  }
+  if (usage?.costUsd && usage.costUsd > 0) {
+    return { amount: usage.costUsd, currency: usage.currency || sessionCurrency || info?.sessionCurrency };
+  }
+  return { amount: 0, currency: info?.sessionCurrency || sessionCurrency || usage?.currency };
+}
 
 interface ContextBreakdown {
   promptTokens: number;
@@ -206,8 +223,7 @@ export function ContextPanel({
   const reasoningTokens = hasPanelUsage ? info?.reasoningTokens ?? 0 : usage?.reasoningTokens ?? 0;
   const cacheHitTokens = hasPanelUsage ? info?.cacheHitTokens ?? 0 : usage?.cacheHitTokens ?? 0;
   const cacheMissTokens = hasPanelUsage ? info?.cacheMissTokens ?? 0 : usage?.cacheMissTokens ?? 0;
-  const cost = info?.sessionCost && info.sessionCost > 0 ? info.sessionCost : sessionCost && sessionCost > 0 ? sessionCost : info?.sessionCostUsd ?? 0;
-  const currency = sessionCurrency || info?.sessionCurrency || usage?.currency || "¥";
+  const cost = contextCostDisplay({ info, sessionCost, sessionCurrency, usage });
   const readFiles = asArray(info?.readFiles);
   const changedFiles = asArray(info?.changedFiles);
 
@@ -282,7 +298,7 @@ export function ContextPanel({
             <SectionHeading title={t("context.costMetrics")} />
             <div className="context-panel__stats">
               <MetricCard label={t("context.cacheHit")} value={cachePct > 0 ? `${cachePct}%` : "-"} tone="accent" />
-              <MetricCard label={t("context.sessionCost")} value={fmtMoney(cost, currency)} />
+              <MetricCard label={t("context.sessionCost")} value={formatMoney(cost.amount, cost.currency, "dash")} />
             </div>
           </section>
           <section className="context-panel__section context-panel__section--status">

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Activity, CircleDollarSign, CircleGauge, Database, Layers, Percent, RefreshCw, Wallet, Zap } from "lucide-react";
 import { Tooltip } from "./Tooltip";
 import { useI18n, type Translator } from "../lib/i18n";
+import { formatMoney } from "../lib/money";
 import { type BalanceInfo, type CollaborationMode, type ContextInfo, type JobView, type ToolApprovalMode, type WireUsage } from "../lib/types";
 
 // JobsChip is the status-bar background-jobs indicator: a count that opens an
@@ -81,19 +82,6 @@ function rateValueClass(rate: string | null): string {
   if (pct >= 80) return "statusbar__rate-value--good";
   if (pct >= 50) return "statusbar__rate-value--notice";
   return "statusbar__rate-value--critical";
-}
-
-function currencySymbol(currency?: string): string {
-  const value = (currency || "¥").trim();
-  if (/^(cny|rmb|yuan)$/i.test(value)) return "¥";
-  if (/^(usd|dollar)$/i.test(value)) return "$";
-  return value || "¥";
-}
-
-function formatMoney(amount?: number, currency?: string): string {
-  const symbol = currencySymbol(currency);
-  if (typeof amount !== "number" || amount <= 0) return `${symbol}0.0000`;
-  return `${symbol}${amount < 1 ? amount.toFixed(4) : amount.toFixed(2)}`;
 }
 
 function formatTokenCount(tokens?: number): string {

--- a/desktop/frontend/src/lib/money.ts
+++ b/desktop/frontend/src/lib/money.ts
@@ -10,7 +10,8 @@ export function currencySymbol(currency?: string): string {
   if (/^(gbp|pound|pounds|sterling)$/.test(lower)) return "\u00A3";
   if (/^(jpy|yen)$/.test(lower)) return DEFAULT_CURRENCY_SYMBOL;
   if (value === "\uFFE5" || value === "\u00A5") return DEFAULT_CURRENCY_SYMBOL;
-  if (/^\p{Sc}$/u.test(value)) return value;
+  // contains, not equals \u2014 keep multi-char symbols (A$, HK$) off the \u00A5 default.
+  if (/\p{Sc}/u.test(value)) return value;
   if (/^[a-z]{3}$/i.test(value)) return `${value.toUpperCase()} `;
 
   return DEFAULT_CURRENCY_SYMBOL;

--- a/desktop/frontend/src/lib/money.ts
+++ b/desktop/frontend/src/lib/money.ts
@@ -1,0 +1,25 @@
+const DEFAULT_CURRENCY_SYMBOL = "\u00A5";
+
+export function currencySymbol(currency?: string): string {
+  const value = (currency || DEFAULT_CURRENCY_SYMBOL).trim();
+  const lower = value.toLowerCase();
+
+  if (/^(cny|rmb|yuan|renminbi|cnh)$/.test(lower)) return DEFAULT_CURRENCY_SYMBOL;
+  if (/^(usd|dollar|dollars|us dollar|us dollars|us\$)$/.test(lower)) return "$";
+  if (/^(eur|euro|euros)$/.test(lower)) return "\u20AC";
+  if (/^(gbp|pound|pounds|sterling)$/.test(lower)) return "\u00A3";
+  if (/^(jpy|yen)$/.test(lower)) return DEFAULT_CURRENCY_SYMBOL;
+  if (value === "\uFFE5" || value === "\u00A5") return DEFAULT_CURRENCY_SYMBOL;
+  if (/^\p{Sc}$/u.test(value)) return value;
+  if (/^[a-z]{3}$/i.test(value)) return `${value.toUpperCase()} `;
+
+  return DEFAULT_CURRENCY_SYMBOL;
+}
+
+export function formatMoney(amount?: number, currency?: string, empty: "zero" | "dash" = "zero"): string {
+  const symbol = currencySymbol(currency);
+  if (typeof amount !== "number" || amount <= 0) {
+    return empty === "dash" ? "-" : `${symbol}0.0000`;
+  }
+  return `${symbol}${amount < 1 ? amount.toFixed(4) : amount.toFixed(2)}`;
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7120,6 +7120,8 @@ a[href] {
   align-items: baseline;
   gap: 8px;
   overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   font-family: var(--mono);
   font-size: 11.5px;
   line-height: 1.35;
@@ -15292,6 +15294,7 @@ a[href] {
 
 .context-panel__metric {
   min-height: 54px;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -15300,16 +15303,27 @@ a[href] {
   border: 1px solid var(--border-soft);
   border-radius: 8px;
   background: var(--bg);
+  overflow: hidden;
 }
 
 .context-panel__metric span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--fg-dim);
   font-size: 12px;
 }
 
 .context-panel__metric strong {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--fg);
   font-size: 18px;
+  font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"reasonix/internal/nilutil"
 )
@@ -264,7 +266,7 @@ type Usage struct {
 }
 
 // Pricing is a provider's per-1M-token rates, used to estimate spend. Currency
-// is just a display symbol (default "¥"). toml tags let config decode it.
+// is a display symbol or ISO-like code (default "¥"). toml tags let config decode it.
 type Pricing struct {
 	CacheHit float64 `toml:"cache_hit"` // per 1M cached prompt tokens
 	Input    float64 `toml:"input"`     // per 1M uncached prompt tokens
@@ -287,7 +289,51 @@ func (p *Pricing) Symbol() string {
 	if p == nil || p.Currency == "" {
 		return "¥"
 	}
-	return p.Currency
+	return currencySymbol(p.Currency)
+}
+
+func currencySymbol(currency string) string {
+	value := strings.TrimSpace(currency)
+	if value == "" {
+		return "¥"
+	}
+	switch strings.ToLower(value) {
+	case "cny", "rmb", "yuan", "renminbi", "cnh":
+		return "¥"
+	case "usd", "dollar", "dollars", "us dollar", "us dollars", "us$":
+		return "$"
+	case "eur", "euro", "euros":
+		return "€"
+	case "gbp", "pound", "pounds", "sterling":
+		return "£"
+	case "jpy", "yen":
+		return "¥"
+	}
+	switch value {
+	case "￥", "¥":
+		return "¥"
+	case "$", "€", "£":
+		return value
+	}
+	if r, size := utf8.DecodeRuneInString(value); size == len(value) && r != utf8.RuneError && unicode.Is(unicode.Sc, r) {
+		return value
+	}
+	if isThreeLetterCurrencyCode(value) {
+		return strings.ToUpper(value) + " "
+	}
+	return "¥"
+}
+
+func isThreeLetterCurrencyCode(value string) bool {
+	if len(value) != 3 {
+		return false
+	}
+	for _, r := range value {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
 }
 
 // Chunk is a single streamed event. Read the field matching Type.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 
 	"reasonix/internal/nilutil"
 )
@@ -315,8 +314,11 @@ func currencySymbol(currency string) string {
 	case "$", "€", "£":
 		return value
 	}
-	if r, size := utf8.DecodeRuneInString(value); size == len(value) && r != utf8.RuneError && unicode.Is(unicode.Sc, r) {
-		return value
+	// any embedded currency sign → keep as-is (compact symbols like A$, HK$).
+	for _, r := range value {
+		if unicode.Is(unicode.Sc, r) {
+			return value
+		}
 	}
 	if isThreeLetterCurrencyCode(value) {
 		return strings.ToUpper(value) + " "

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -199,6 +199,28 @@ func TestPricingSymbolCustom(t *testing.T) {
 	}
 }
 
+func TestPricingSymbolNormalizesCurrencyCodes(t *testing.T) {
+	cases := []struct {
+		currency string
+		want     string
+	}{
+		{currency: "USD", want: "$"},
+		{currency: "dollars", want: "$"},
+		{currency: "CNY", want: "¥"},
+		{currency: "￥", want: "¥"},
+		{currency: "EUR", want: "€"},
+		{currency: "₹", want: "₹"},
+		{currency: "aud", want: "AUD "},
+		{currency: "楼", want: "¥"},
+	}
+	for _, tc := range cases {
+		p := &Pricing{Currency: tc.currency}
+		if got := p.Symbol(); got != tc.want {
+			t.Errorf("Currency %q Symbol() = %q, want %q", tc.currency, got, tc.want)
+		}
+	}
+}
+
 // --- AuthError ---
 
 func TestAuthErrorWithKeyEnv(t *testing.T) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -211,6 +211,8 @@ func TestPricingSymbolNormalizesCurrencyCodes(t *testing.T) {
 		{currency: "EUR", want: "€"},
 		{currency: "₹", want: "₹"},
 		{currency: "aud", want: "AUD "},
+		{currency: "A$", want: "A$"},
+		{currency: "HK$", want: "HK$"},
 		{currency: "楼", want: "¥"},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

- Pair context-panel cost values with the currency from the same data source so panel telemetry cannot be overwritten by the default session currency.
- Share frontend money formatting across the context panel and status bar, including normalization for common currency codes and symbols.
- Normalize provider pricing currency symbols on the Go side so unexpected text cannot leak into UI cost values.
- Add nowrap/ellipsis guards for compact metric values and restore command-palette hint ellipsis expectations.

## Root cause

The context panel could select `info.sessionCost` while still preferring the global session currency, whose initial value defaults to yuan. Separately, unknown currency text was passed through directly, so bad or stale currency values could appear before the numeric cost.

## Validation

- `npm --prefix desktop/frontend test`
- `npm --prefix desktop/frontend run build`
- `go test ./internal/provider`
- `go test ./...` from the desktop module

This change is display-only and does not modify provider request serialization, prompts, tool schemas, or other prompt-cache-sensitive paths.