### PR TITLE
fix(desktop): restore min-width floor on Windows to fix titlebar/bottom overlap (v1.6 regression)

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1440,7 +1440,7 @@ a[href] {
 .app {
   height: 100%;
   min-height: 0;
-  overflow-x: hidden;
+  overflow-x: auto;
   overflow-y: hidden;
 }
 
@@ -1493,15 +1493,15 @@ a[href] {
 }
 .layout--workspace-open {
   --chrome-right-toggle-offset: calc(var(--workspace-width) + var(--workspace-resizer-width));
-  min-width: 0;
+  min-width: min(780px, 100vw);
   grid-template-columns: var(--sidebar-width) minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open:not(.layout--sidebar-collapsed) {
-  min-width: 0;
+  min-width: min(780px, 100vw);
   grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open.layout--sidebar-collapsed {
-  min-width: 0;
+  min-width: min(560px, 100vw);
   grid-template-columns: 0px minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
 }
 .layout--workspace-maximized {


### PR DESCRIPTION
Fixes #4065

Root cause: v1.6 removed the min-width floor on .layout--workspace-open variants and changed .app overflow-x to hidden. On Windows 11 25H2 this allows the layout to collapse over OS chrome, covering the titlebar and bottom bar.

Changes:
- Restored min-width floor on layout variants
- Reverted overflow-x to auto

Tested: Windows 11 25H2 as reported by muyaCode.