### PR TITLE
fix(desktop): 修复代码块复制按钮 tooltip 定位偏左的问题

### DIFF
--- a/desktop/frontend/src/components/CopyButton.tsx
+++ b/desktop/frontend/src/components/CopyButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { useT } from "../lib/i18n";
 import { Tooltip } from "./Tooltip";
@@ -20,6 +20,7 @@ export function CopyButton({
   showLabel?: boolean;
 }) {
   const t = useT();
+  const btnRef = useRef<HTMLButtonElement>(null);
   const [copied, setCopied] = useState(false);
   const actionLabel = label ?? t("msg.copy");
   const copy = async () => {
@@ -33,8 +34,9 @@ export function CopyButton({
     }
   };
   return (
-    <Tooltip label={copied ? t("msg.copied") : actionLabel}>
+    <Tooltip label={copied ? t("msg.copied") : actionLabel} triggerRef={btnRef}>
       <button
+        ref={btnRef}
         className={`copybtn ${className ?? ""}`}
         onClick={copy}
         aria-label={actionLabel}

--- a/desktop/frontend/src/components/Tooltip.tsx
+++ b/desktop/frontend/src/components/Tooltip.tsx
@@ -41,6 +41,7 @@ export function Tooltip({
   block = false,
   disabled = false,
   className,
+  triggerRef: externalTriggerRef,
 }: {
   label?: ReactNode;
   children: ReactNode;
@@ -49,6 +50,7 @@ export function Tooltip({
   block?: boolean;
   disabled?: boolean;
   className?: string;
+  triggerRef?: React.RefObject<HTMLElement | null>;
 }) {
   const id = useId();
   const triggerRef = useRef<HTMLElement | null>(null);
@@ -76,7 +78,7 @@ export function Tooltip({
   };
 
   const updatePosition = () => {
-    const trigger = triggerRef.current;
+    const trigger = externalTriggerRef?.current ?? triggerRef.current;
     const tip = tooltipRef.current;
     if (!trigger || !tip) return;
     const rect = trigger.getBoundingClientRect();


### PR DESCRIPTION
## 问题描述

代码块的复制按钮 hover 时，tooltip 显示在屏幕最左侧，而非按钮旁边。

## 根因分析

CopyButton 使用 Tooltip 包裹 button，Tooltip 默认用 span 包裹子元素。但复制按钮使用了 `position: absolute`（脱离文档流），导致 wrapper span 的宽度为 0。

`Tooltip.updatePosition()` 对这个零宽度 span 调用 `getBoundingClientRect()`，得到的 `rect.left` 是 code-block 的最左端，tooltip 就显示在了错误的位置。

## 修复方案

在 Tooltip 组件中新增可选 `triggerRef` 外部 ref 支持：

- **Tooltip.tsx** — 新增 `triggerRef` prop，`updatePosition` 优先使用外部 ref 的元素来计算位置
- **CopyButton.tsx** — 创建 button 的 ref，传给 Tooltip 的 `triggerRef`

wrapper span 仍保留用于事件绑定（hover/focus），位置计算改用 button 自身的实际位置。改动不影响其他 Tooltip 使用场景（`triggerRef` 是可选的）。

## 涉及文件

| 文件 | 改动 |
|------|------|
| `Tooltip.tsx` | 新增 `triggerRef` prop，`updatePosition` 优先使用它 |
| `CopyButton.tsx` | 创建 button ref，传给 Tooltip 的 `triggerRef` |

Fixes #3867
