### PR TITLE
fix(memory): add GlobalDir routing + tab-aware panel to fix empty memory view (#3756)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4326,12 +4326,13 @@ type MemoryScope struct {
 // MemoryView is the whole memory panel payload: hierarchical docs, active saved
 // facts, archived facts, and the writable scopes for the quick-add selector.
 type MemoryView struct {
-	Docs      []MemoryDoc     `json:"docs"`
-	Facts     []MemoryFact    `json:"facts"`
-	Archives  []MemoryArchive `json:"archives"`
-	Scopes    []MemoryScope   `json:"scopes"`
-	StoreDir  string          `json:"storeDir"`
-	Available bool            `json:"available"`
+	Docs           []MemoryDoc     `json:"docs"`
+	Facts          []MemoryFact    `json:"facts"`
+	Archives       []MemoryArchive `json:"archives"`
+	Scopes         []MemoryScope   `json:"scopes"`
+	StoreDir       string          `json:"storeDir"`
+	StoreGlobalDir string          `json:"storeGlobalDir,omitempty"`
+	Available      bool            `json:"available"`
 }
 
 // writableScopes are the quick-add targets the panel offers, broad → specific.
@@ -4341,20 +4342,41 @@ var writableScopes = []memory.Scope{memory.ScopeUser, memory.ScopeProject, memor
 // active/archived auto-memories, and the writable scopes. Read-only; mutations
 // go through Remember / SaveDoc.
 func (a *App) Memory() MemoryView {
-	// Always return non-nil slices: a nil Go slice marshals to JSON `null`, which
-	// would crash the panel's `view.facts.length` / `.map`.
+	return a.memoryForCtrl(nil, true)
+}
+
+// MemoryForTab returns the loaded memory for a specific tab's controller,
+// so the panel can show memory for any open project, not just the active tab.
+// If the tab does not exist or has no controller, returns an empty view
+// instead of falling back to the active tab (which would show the wrong data).
+// An empty tabID is treated as "no tab specified" and falls back to the
+// active tab for backward compatibility.
+func (a *App) MemoryForTab(tabID string) MemoryView {
+	if tabID == "" {
+		return a.memoryForCtrl(nil, true)
+	}
+	return a.memoryForCtrl(a.ctrlByTabID(tabID), false)
+}
+
+func (a *App) memoryForCtrl(ctrl *control.Controller, fallback bool) MemoryView {
 	view := MemoryView{Docs: []MemoryDoc{}, Facts: []MemoryFact{}, Archives: []MemoryArchive{}, Scopes: []MemoryScope{}}
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
 	if ctrl == nil {
-		return view
+		if !fallback {
+			return view
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return view
+		}
 	}
 	set := ctrl.Memory()
 	if set == nil {
 		return view
 	}
 	view.StoreDir = set.Store.Dir
+	view.StoreGlobalDir = set.Store.GlobalDir
 	view.Available = true
 	for _, d := range set.Docs {
 		view.Docs = append(view.Docs, MemoryDoc{Path: d.Path, Scope: string(d.Scope), Body: d.Body})
@@ -4375,7 +4397,7 @@ func (a *App) Memory() MemoryView {
 		})
 	}
 	for _, sc := range writableScopes {
-		if p := set.DocPath(sc); p != "" { // user scope yields "" when no config dir
+		if p := set.DocPath(sc); p != "" {
 			view.Scopes = append(view.Scopes, MemoryScope{Scope: string(sc), Path: p})
 		}
 	}
@@ -4386,11 +4408,27 @@ func (a *App) Memory() MemoryView {
 // panel's explicit "remember" action, equivalent to typing "/remember <note>".
 // An unknown scope falls back to project. Returns the file written.
 func (a *App) Remember(scope, note string) (string, error) {
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
+	return a.rememberForCtrl(nil, scope, note, true)
+}
+
+func (a *App) RememberForTab(tabID, scope, note string) (string, error) {
+	if tabID == "" {
+		return a.rememberForCtrl(nil, scope, note, true)
+	}
+	return a.rememberForCtrl(a.ctrlByTabID(tabID), scope, note, false)
+}
+
+func (a *App) rememberForCtrl(ctrl *control.Controller, scope, note string, fallback bool) (string, error) {
 	if ctrl == nil {
-		return "", nil
+		if !fallback {
+			return "", nil
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return "", nil
+		}
 	}
 	return ctrl.QuickAdd(parseScope(scope), note)
 }
@@ -4398,11 +4436,27 @@ func (a *App) Remember(scope, note string) (string, error) {
 // Forget deletes a saved auto-memory by name — the panel's delete action for a
 // fact the model owns. A no-op when no controller is attached.
 func (a *App) Forget(name string) error {
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
+	return a.forgetForCtrl(nil, name, true)
+}
+
+func (a *App) ForgetForTab(tabID, name string) error {
+	if tabID == "" {
+		return a.forgetForCtrl(nil, name, true)
+	}
+	return a.forgetForCtrl(a.ctrlByTabID(tabID), name, false)
+}
+
+func (a *App) forgetForCtrl(ctrl *control.Controller, name string, fallback bool) error {
 	if ctrl == nil {
-		return nil
+		if !fallback {
+			return nil
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return nil
+		}
 	}
 	return ctrl.ForgetMemory(name)
 }
@@ -4410,11 +4464,27 @@ func (a *App) Forget(name string) error {
 // SaveDoc overwrites a memory doc with the panel editor's contents. The controller
 // validates path against the recognized memory files. Returns the file written.
 func (a *App) SaveDoc(path, body string) (string, error) {
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
+	return a.saveDocForCtrl(nil, path, body, true)
+}
+
+func (a *App) SaveDocForTab(tabID, path, body string) (string, error) {
+	if tabID == "" {
+		return a.saveDocForCtrl(nil, path, body, true)
+	}
+	return a.saveDocForCtrl(a.ctrlByTabID(tabID), path, body, false)
+}
+
+func (a *App) saveDocForCtrl(ctrl *control.Controller, path, body string, fallback bool) (string, error) {
 	if ctrl == nil {
-		return "", nil
+		if !fallback {
+			return "", nil
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return "", nil
+		}
 	}
 	return ctrl.SaveDoc(path, body)
 }

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -2,7 +2,7 @@ import { Check, ChevronDown, ChevronRight, FileText, Pencil, Plus, RefreshCw, Se
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
-import type { MemoryArchive, MemoryFact, MemorySuggestion, MemorySuggestionsView, MemoryView, SkillSuggestion } from "../lib/types";
+import type { MemoryArchive, MemoryFact, MemorySuggestion, MemorySuggestionsView, MemoryView, SkillSuggestion, TabMeta } from "../lib/types";
 import { ResizableDrawer } from "./ResizableDrawer";
 import { Tooltip } from "./Tooltip";
 import { ModalCloseButton } from "./ModalCloseButton";
@@ -572,7 +572,7 @@ export function MemoryPanel({
                                     {t("memory.confirmForget")}
                                   </button>
                                 </div>
-                              ) : (
+                               ) : (
                                 <button
                                   className="btn btn--small mem-fact__forget"
                                   onClick={() => setConfirmForget(f.name)}
@@ -591,8 +591,8 @@ export function MemoryPanel({
                   })}
                 </div>
               )}
-              {view.storeDir && (
-                <div className="mem-hint">{t("memory.storedUnder", { dir: view.storeDir })}</div>
+              {(view.storeDir || view.storeGlobalDir) && (
+                <div className="mem-hint">{t("memory.storedUnder", { dir: [view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ") })}</div>
               )}
             </section>
 
@@ -731,9 +731,9 @@ export function MemoryPanel({
                   </div>
                 ))
               )}
-              {view.storeDir && (
-                <div className="mem-hint" title={view.storeDir}>
-                  {t("memory.storedUnder", { dir: view.storeDir })}
+              {(view.storeDir || view.storeGlobalDir) && (
+                <div className="mem-hint" title={[view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ")}>
+                  {t("memory.storedUnder", { dir: [view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ") })}
                 </div>
               )}
             </section>
@@ -748,6 +748,8 @@ export function MemoryPanel({
 export function MemorySettingsPage() {
 	const t = useT();
 	const [view, setView] = useState<MemoryView | null>(null);
+	const [tabs, setTabs] = useState<TabMeta[]>([]);
+	const [selectedTabId, setSelectedTabId] = useState<string | null>(null);
 	const [note, setNote] = useState("");
 	const [scope, setScope] = useState("");
 	const [editingPath, setEditingPath] = useState<string | null>(null);
@@ -773,8 +775,20 @@ export function MemorySettingsPage() {
 	const factRefs = useRef<Record<string, HTMLElement | null>>({});
 
 	const reload = useCallback(async () => {
-		setView(await app.Memory().catch(() => null));
+		const tabId = selectedTabId;
+		setView(tabId ? await app.MemoryForTab(tabId).catch(() => null) : await app.Memory().catch(() => null));
+	}, [selectedTabId]);
+
+	useEffect(() => {
+		app.ListTabs().then((tabList) => {
+			setTabs(tabList);
+			if (!selectedTabId) {
+				const active = tabList.find((tb) => tb.active);
+				if (active) setSelectedTabId(active.id);
+			}
+		}).catch(() => {});
 	}, []);
+
 	useEffect(() => { void reload(); }, [reload]);
 
 	const refreshSuggestions = useCallback(async () => {
@@ -886,7 +900,8 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			await app.Forget(name);
+			if (selectedTabId) await app.ForgetForTab(selectedTabId, name);
+			else await app.Forget(name);
 			await reload();
 			if (expanded === name) setExpanded(null);
 			setConfirmForget(null);
@@ -895,7 +910,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [busy, expanded, reload]);
+	}, [busy, expanded, reload, selectedTabId]);
 
 	const scopes = view?.scopes ?? [];
 	const activeScope =
@@ -907,7 +922,8 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			await app.Remember(activeScope, trimmed);
+			if (selectedTabId) await app.RememberForTab(selectedTabId, activeScope, trimmed);
+			else await app.Remember(activeScope, trimmed);
 			await reload();
 			setNote("");
 			setShowAdd(false);
@@ -916,7 +932,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [note, busy, activeScope, reload]);
+	}, [note, busy, activeScope, reload, selectedTabId]);
 
 	const startEdit = useCallback((path: string, body: string) => {
 		setEditingPath(path);
@@ -928,7 +944,8 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			await app.SaveDoc(editingPath, draft);
+			if (selectedTabId) await app.SaveDocForTab(selectedTabId, editingPath, draft);
+			else await app.SaveDoc(editingPath, draft);
 			await reload();
 			setEditingPath(null);
 		} catch (err) {
@@ -936,7 +953,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [editingPath, busy, draft, reload]);
+	}, [editingPath, busy, draft, reload, selectedTabId]);
 
 	const acceptMemorySuggestion = useCallback(async (candidate: MemorySuggestion) => {
 		if (busy) return;
@@ -968,7 +985,26 @@ export function MemorySettingsPage() {
 	}, [busy]);
 
 	if (!view?.available) {
-		return <div className="empty">{t("memory.unavailable")}</div>;
+		return (
+			<>
+				{tabs.length > 1 && (
+					<div className="mem-tab-selector">
+						<select
+							className="mem-tab-select"
+							value={selectedTabId ?? ""}
+							onChange={(e) => setSelectedTabId(e.target.value || null)}
+						>
+							{tabs.map((tb) => (
+								<option key={tb.id} value={tb.id}>
+									{tb.label || tb.workspaceName || tb.scope || tb.id}
+								</option>
+							))}
+						</select>
+					</div>
+				)}
+				<div className="empty">{t("memory.unavailable")}</div>
+			</>
+		);
 	}
 
 	const hasSavedFilters = facts.length > 0;
@@ -1038,6 +1074,21 @@ export function MemorySettingsPage() {
 					{suggestionTotal(suggestions) > 0 && <span className="settings-subtab__count">{suggestionTotal(suggestions)}</span>}
 				</button>
 			</div>
+			{tabs.length > 1 && (
+				<div className="mem-tab-selector">
+					<select
+						className="mem-tab-select"
+						value={selectedTabId ?? ""}
+						onChange={(e) => setSelectedTabId(e.target.value || null)}
+					>
+						{tabs.map((tb) => (
+							<option key={tb.id} value={tb.id}>
+								{tb.label || tb.workspaceName || tb.scope}
+							</option>
+						))}
+					</select>
+				</div>
+			)}
 
 			{tab === "saved" && <section className="mem-section">
 				<div className="mem-section__head">
@@ -1265,6 +1316,9 @@ export function MemorySettingsPage() {
 						})}
 					</div>
 				)}
+			{(view.storeDir || view.storeGlobalDir) && (
+				<div className="mem-hint">{t("memory.storedUnder", { dir: [view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ") })}</div>
+			)}
 			</section>}
 
 			{tab === "suggestions" && <section className="mem-section">

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -199,9 +199,13 @@ export interface AppBindings {
   MemorySuggestions(): Promise<MemorySuggestionsView>;
   AcceptMemorySuggestion(suggestion: MemorySuggestion): Promise<string>;
   AcceptSkillSuggestion(suggestion: SkillSuggestion): Promise<string>;
+  MemoryForTab(tabID: string): Promise<MemoryView>;
   Remember(scope: string, note: string): Promise<string>;
+  RememberForTab(tabID: string, scope: string, note: string): Promise<string>;
   Forget(name: string): Promise<void>;
+  ForgetForTab(tabID: string, name: string): Promise<void>;
   SaveDoc(path: string, body: string): Promise<string>;
+  SaveDocForTab(tabID: string, path: string, body: string): Promise<string>;
   Settings(): Promise<SettingsView>;
   HooksSettings(scope: string): Promise<HooksSettingsView>;
   SaveHooksSettings(scope: string, hooks: HookConfigView[]): Promise<void>;
@@ -2061,6 +2065,7 @@ function makeMockApp(): AppBindings {
       return {
         available: true,
         storeDir: "~/.config/reasonix/projects/-mock/memory",
+        storeGlobalDir: "~/.config/reasonix/memory/global",
         docs: [
           {
             path: "REASONIX.md",
@@ -2136,16 +2141,28 @@ function makeMockApp(): AppBindings {
       emit({ kind: "notice", level: "info", text: `created suggested skill → ${suggestion.name}` });
       return `.reasonix/skills/${suggestion.name}/SKILL.md`;
     },
-    async Remember(scope: string, note: string) {
-      emit({ kind: "notice", level: "info", text: `remembered → ${scope}` });
-      return `${scope} REASONIX.md (mock): ${note}`;
+    async MemoryForTab(_tabID: string) {
+      return this.Memory();
     },
-    async Forget(name: string) {
-      emit({ kind: "notice", level: "info", text: `forgot → ${name}` });
+    async Remember(_scope: string, _note: string) {
+      emit({ kind: "notice", level: "info", text: `remembered → ${_scope}` });
+      return `${_scope} REASONIX.md (mock): ${_note}`;
     },
-    async SaveDoc(path: string, _body: string) {
-      emit({ kind: "notice", level: "info", text: `saved → ${path}` });
-      return path;
+    async RememberForTab(_tabID: string, scope: string, note: string) {
+      return this.Remember(scope, note);
+    },
+    async Forget(_name: string) {
+      emit({ kind: "notice", level: "info", text: `forgot → ${_name}` });
+    },
+    async ForgetForTab(_tabID: string, name: string) {
+      return this.Forget(name);
+    },
+    async SaveDoc(_path: string, _body: string) {
+      emit({ kind: "notice", level: "info", text: `saved → ${_path}` });
+      return _path;
+    },
+    async SaveDocForTab(_tabID: string, path: string, body: string) {
+      return this.SaveDoc(path, body);
     },
     async Settings() {
       return JSON.parse(JSON.stringify(settings)) as SettingsView;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -567,6 +567,7 @@ export interface MemoryView {
   archives: MemoryArchive[];
   scopes: MemoryScope[];
   storeDir: string;
+  storeGlobalDir?: string;
   available: boolean;
 }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7398,6 +7398,18 @@ a[href] {
   flex-direction: column;
   gap: 22px;
 }
+.mem-tab-selector {
+  margin-bottom: 8px;
+}
+.mem-tab-select {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+}
 .mem-section {
   min-width: 0;
 }

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1245,6 +1245,10 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 // prefix is untouched by the memory feature.
 func TestBuildWithoutMemoryLeavesPromptUnchanged(t *testing.T) {
 	dir := robustTempDir(t)
+	home := robustTempDir(t)
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -142,7 +142,13 @@ func (s *Set) Block() string {
 			"Read the linked file with read_file when one looks relevant, and before acting on one that names a file, function, or flag, verify it still exists. " +
 			"Save new durable facts with the `remember` tool; delete ones that turn out wrong with `forget`.\n\n")
 		b.WriteString(idx)
-		fmt.Fprintf(&b, "\n\n(stored under %s)\n", s.Store.Dir)
+		var dirs []string
+		for _, d := range s.Store.dirs() {
+			if d != "" {
+				dirs = append(dirs, d)
+			}
+		}
+		fmt.Fprintf(&b, "\n\n(stored under %s)\n", strings.Join(dirs, " and "))
 	}
 	return b.String()
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -18,8 +18,13 @@ import (
 // cached system-prompt prefix at boot so the model always knows what it has
 // saved, and reads individual facts on demand with read_file. The whole thing is
 // plain files the user can edit by hand.
+//
+// Memories of type "user" and "feedback" are routed to GlobalDir (shared across
+// all projects), while "project" and "reference" stay in the project-specific Dir.
+// List() and Index() merge both directories so every session sees the full set.
 type Store struct {
-	Dir string // ...reasonix/projects/<slug>/memory
+	Dir       string // ...reasonix/projects/<slug>/memory
+	GlobalDir string // ...reasonix/memory/global (shared across projects)
 }
 
 // Type classifies a memory, mirroring the auto-memory taxonomy.
@@ -71,7 +76,21 @@ func StoreFor(userDir, cwd string) Store {
 	if userDir == "" {
 		return Store{}
 	}
-	return Store{Dir: filepath.Join(userDir, "projects", slugify(absOf(cwd)), "memory")}
+	return Store{
+		Dir:       filepath.Join(userDir, "projects", slugify(absOf(cwd)), "memory"),
+		GlobalDir: filepath.Join(userDir, "memory", "global"),
+	}
+}
+
+// DirFor returns the directory a memory of the given type should be stored in.
+// TypeUser and TypeFeedback go to GlobalDir (shared across all projects);
+// everything else goes to the project-specific Dir. When GlobalDir is empty,
+// all types fall back to Dir.
+func (s Store) DirFor(t Type) string {
+	if s.GlobalDir != "" && (t == TypeUser || t == TypeFeedback) {
+		return s.GlobalDir
+	}
+	return s.Dir
 }
 
 // indexFile is the human-readable index of saved memories.
@@ -85,23 +104,75 @@ func slugify(absPath string) string {
 	return r.Replace(absPath)
 }
 
+// dirs returns the directories to read from, in order: GlobalDir first (shared
+// memories), then Dir (project-specific).
+func (s Store) dirs() []string {
+	if s.GlobalDir != "" && s.GlobalDir != s.Dir {
+		return []string{s.GlobalDir, s.Dir}
+	}
+	return []string{s.Dir}
+}
+
 // Index returns the MEMORY.md contents (the per-line index of saved memories),
 // or "" if there are none yet. This is what loads into the cached prefix.
+// When both GlobalDir and Dir have indexes, they are merged with deduplication
+// (global first).
 func (s Store) Index() string {
-	if s.Dir == "" {
+	managed := map[string]string{}
+	for _, dir := range s.dirs() {
+		if dir == "" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, indexFile))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if mt := indexLineRe.FindStringSubmatch(line); mt != nil {
+				if _, exists := managed[mt[1]]; !exists {
+					managed[mt[1]] = strings.TrimRight(line, "\r")
+				}
+			}
+		}
+	}
+	if len(managed) == 0 {
 		return ""
 	}
-	b, err := os.ReadFile(filepath.Join(s.Dir, indexFile))
-	if err != nil {
-		return ""
+	names := make([]string, 0, len(managed))
+	for n := range managed {
+		names = append(names, n)
 	}
-	return strings.TrimSpace(string(b))
+	sort.Strings(names)
+	var b strings.Builder
+	for _, n := range names {
+		b.WriteString(managed[n])
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 // Path returns the absolute file path a memory with the given name lives at.
+// It checks GlobalDir first, then Dir, returning the first match. If no file
+// exists yet, it returns the path in Dir (the default for project types).
 func (s Store) Path(name string) string {
-	path, _ := safeJoin(s.Dir, slug(name)+".md")
-	return path
+	stem := slug(name) + ".md"
+	for _, dir := range s.dirs() {
+		if dir == "" {
+			continue
+		}
+		p, err := safeJoin(dir, stem)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	p, sjErr := safeJoin(s.Dir, stem)
+	if sjErr != nil {
+		return ""
+	}
+	return p
 }
 
 // Save writes (or overwrites) a memory file and refreshes its MEMORY.md index
@@ -109,21 +180,25 @@ func (s Store) Path(name string) string {
 // editor, and any future importer all go through here so the index never drifts
 // from the files. Returns the path written.
 func (s Store) Save(m Memory) (string, error) {
-	if s.Dir == "" {
+	dir := s.DirFor(m.Type)
+	if dir == "" {
 		return "", fmt.Errorf("memory store unavailable (no user config dir)")
 	}
 	name := slug(m.Name)
 	if name == "" {
 		return "", fmt.Errorf("memory needs a name")
 	}
-	if err := os.MkdirAll(s.Dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
-	path := filepath.Join(s.Dir, name+".md")
+	path, err := safeJoin(dir, name+".md")
+	if err != nil {
+		return "", err
+	}
 	if err := os.WriteFile(path, []byte(render(m, name)), 0o644); err != nil {
 		return "", err
 	}
-	if err := s.reindex(name, m); err != nil {
+	if err := reindexIn(dir, name, m); err != nil {
 		return path, err
 	}
 	return path, nil
@@ -133,19 +208,33 @@ func (s Store) Save(m Memory) (string, error) {
 // .archive/ for traceability. A missing file is not an error; the goal state
 // (not active) already holds. It returns the archive path, or "" when no file
 // existed to archive.
+// When both GlobalDir and Dir exist, it archives from every directory the
+// memory appears in (handles migration duplicates).
 func (s Store) Archive(name string) (string, error) {
-	if s.Dir == "" {
+	if s.Dir == "" && s.GlobalDir == "" {
 		return "", fmt.Errorf("memory store unavailable (no user config dir)")
 	}
 	name = slug(name)
 	if name == "" {
 		return "", fmt.Errorf("memory needs a name")
 	}
-	path, err := s.archiveMemoryFile(name)
-	if err != nil {
-		return "", err
+	var lastPath string
+	for _, dir := range s.dirs() {
+		if dir == "" {
+			continue
+		}
+		p, err := archiveInDir(dir, name)
+		if err != nil {
+			return "", err
+		}
+		if p != "" {
+			if err := flushIndexIn(dir, indexLinesExceptIn(dir, name)); err != nil {
+				return "", err
+			}
+			lastPath = p
+		}
 	}
-	return path, s.flushIndex(s.indexLinesExcept(name))
+	return lastPath, nil
 }
 
 // Delete removes a memory from the active store and its MEMORY.md line — the
@@ -158,11 +247,8 @@ func (s Store) Delete(name string) error {
 	return err
 }
 
-func (s Store) archiveMemoryFile(name string) (string, error) {
-	if s.Dir == "" {
-		return "", fmt.Errorf("memory store unavailable (no user config dir)")
-	}
-	root, err := os.OpenRoot(s.Dir)
+func archiveInDir(dir, name string) (string, error) {
+	root, err := os.OpenRoot(dir)
 	if os.IsNotExist(err) {
 		return "", nil
 	}
@@ -188,7 +274,7 @@ func (s Store) archiveMemoryFile(name string) (string, error) {
 	if err := renameMemoryFile(root, file, dest); err != nil {
 		return "", err
 	}
-	out, err := safeJoin(s.Dir, dest)
+	out, err := safeJoin(dir, dest)
 	if err != nil {
 		return "", err
 	}
@@ -293,10 +379,10 @@ func render(m Memory, name string) string {
 // MEMORY.md.
 var indexLineRe = regexp.MustCompile(`\]\(([^)]+)\.md\)`)
 
-// indexLinesExcept returns the managed MEMORY.md lines keyed by filename stem,
-// dropping the entry for name (a missing index → empty map).
-func (s Store) indexLinesExcept(name string) map[string]string {
-	existing, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+// indexLinesExceptIn returns the managed MEMORY.md lines keyed by filename stem
+// in the given directory, dropping the entry for name (a missing index → empty map).
+func indexLinesExceptIn(dir, name string) map[string]string {
+	existing, _ := os.ReadFile(filepath.Join(dir, indexFile))
 	keep := map[string]string{}
 	for _, line := range strings.Split(string(existing), "\n") {
 		if mt := indexLineRe.FindStringSubmatch(line); mt != nil && mt[1] != name {
@@ -306,8 +392,9 @@ func (s Store) indexLinesExcept(name string) map[string]string {
 	return keep
 }
 
-// flushIndex rewrites MEMORY.md from the managed lines, sorted by filename.
-func (s Store) flushIndex(lines map[string]string) error {
+// flushIndexIn rewrites MEMORY.md in the given directory from the managed lines,
+// sorted by filename.
+func flushIndexIn(dir string, lines map[string]string) error {
 	names := make([]string, 0, len(lines))
 	for n := range lines {
 		names = append(names, n)
@@ -320,36 +407,45 @@ func (s Store) flushIndex(lines map[string]string) error {
 		b.WriteString(lines[n])
 		b.WriteString("\n")
 	}
-	return os.WriteFile(filepath.Join(s.Dir, indexFile), []byte(b.String()), 0o644)
+	return os.WriteFile(filepath.Join(dir, indexFile), []byte(b.String()), 0o644)
 }
 
-// reindex rewrites the MEMORY.md line for name, preserving every other managed
-// line. The line is "- [<title>](<name>.md) — <description>"; title falls back
-// to a de-kebabed name so the index reads as a label, never a bare slug.
-func (s Store) reindex(name string, m Memory) error {
-	lines := s.indexLinesExcept(name)
+// reindexIn rewrites the MEMORY.md line for name in the given directory,
+// preserving every other managed line.
+func reindexIn(dir, name string, m Memory) error {
+	lines := indexLinesExceptIn(dir, name)
 	lines[name] = fmt.Sprintf("- [%s](%s.md) — %s", displayTitle(m.Title, name), name, oneLine(m.Description))
-	return s.flushIndex(lines)
+	return flushIndexIn(dir, lines)
 }
 
 // List returns the saved memories parsed from their files, sorted by name. Used
-// by `/memory` and the desktop memory panel. Files that fail to parse are
-// skipped so one bad file never hides the rest.
+// by `/memory` and the desktop memory panel. Reads from both GlobalDir and Dir,
+// merging results. Files that fail to parse are skipped so one bad file never
+// hides the rest.
 func (s Store) List() []Memory {
-	if s.Dir == "" {
-		return nil
-	}
-	entries, err := os.ReadDir(s.Dir)
-	if err != nil {
+	if s.Dir == "" && s.GlobalDir == "" {
 		return nil
 	}
 	var out []Memory
-	for _, e := range entries {
-		if e.IsDir() || e.Name() == indexFile || !strings.HasSuffix(e.Name(), ".md") {
+	seen := map[string]bool{}
+	for _, dir := range s.dirs() {
+		if dir == "" {
 			continue
 		}
-		if m, ok := loadMemory(filepath.Join(s.Dir, e.Name())); ok {
-			out = append(out, m)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || e.Name() == indexFile || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			if m, ok := loadMemory(filepath.Join(dir, e.Name())); ok {
+				if !seen[m.Name] {
+					out = append(out, m)
+					seen[m.Name] = true
+				}
+			}
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -358,33 +454,39 @@ func (s Store) List() []Memory {
 
 // ListArchived returns archived memories parsed from .archive/, newest first.
 // Archived files stay out of List() and the prompt index, so stale facts remain
-// inspectable without being reused as active truth.
+// inspectable without being reused as active truth. Reads from both GlobalDir
+// and Dir.
 func (s Store) ListArchived() []ArchivedMemory {
-	if s.Dir == "" {
-		return nil
-	}
-	dir := filepath.Join(s.Dir, ".archive")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
+	if s.Dir == "" && s.GlobalDir == "" {
 		return nil
 	}
 	var out []ArchivedMemory
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+	for _, base := range s.dirs() {
+		if base == "" {
 			continue
 		}
-		path := filepath.Join(dir, e.Name())
-		m, ok := loadMemory(path)
-		if !ok {
+		dir := filepath.Join(base, ".archive")
+		entries, err := os.ReadDir(dir)
+		if err != nil {
 			continue
 		}
-		when := archiveTimeFromName(e.Name())
-		if when.IsZero() {
-			if info, err := e.Info(); err == nil {
-				when = info.ModTime()
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
 			}
+			path := filepath.Join(dir, e.Name())
+			m, ok := loadMemory(path)
+			if !ok {
+				continue
+			}
+			when := archiveTimeFromName(e.Name())
+			if when.IsZero() {
+				if info, err := e.Info(); err == nil {
+					when = info.ModTime()
+				}
+			}
+			out = append(out, ArchivedMemory{Memory: m, Path: path, ArchivedAt: when})
 		}
-		out = append(out, ArchivedMemory{Memory: m, Path: path, ArchivedAt: when})
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if !out[i].ArchivedAt.Equal(out[j].ArchivedAt) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -315,3 +315,334 @@ func TestDisabledStoreIsNoOp(t *testing.T) {
 		t.Fatal("disabled store Save should error, not silently drop")
 	}
 }
+
+// TestStoreGlobalAndProject verifies that TypeUser/TypeFeedback memories are
+// routed to GlobalDir, TypeProject/TypeReference stay in Dir, List() merges
+// both, and Delete() removes from the correct directory.
+func TestStoreGlobalAndProject(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// TypeUser → GlobalDir
+	pUser, err := s.Save(Memory{Name: "prefers-tabs", Description: "user pref", Type: TypeUser, Body: "use tabs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pUser, s.GlobalDir) {
+		t.Fatalf("TypeUser should go to GlobalDir, got %s", pUser)
+	}
+
+	// TypeProject → Dir
+	pProj, err := s.Save(Memory{Name: "build-target", Description: "build target", Type: TypeProject, Body: "go build"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pProj, s.Dir) {
+		t.Fatalf("TypeProject should go to Dir, got %s", pProj)
+	}
+
+	// TypeFeedback → GlobalDir
+	pFb, err := s.Save(Memory{Name: "no-emoji", Description: "no emoji", Type: TypeFeedback, Body: "skip emoji"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pFb, s.GlobalDir) {
+		t.Fatalf("TypeFeedback should go to GlobalDir, got %s", pFb)
+	}
+
+	// TypeReference → Dir
+	pRef, err := s.Save(Memory{Name: "api-docs", Description: "api docs", Type: TypeReference, Body: "see docs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pRef, s.Dir) {
+		t.Fatalf("TypeReference should go to Dir, got %s", pRef)
+	}
+
+	// List merges both directories
+	list := s.List()
+	if len(list) != 4 {
+		t.Fatalf("want 4 memories, got %d", len(list))
+	}
+
+	// Index merges both directories
+	idx := s.Index()
+	if !strings.Contains(idx, "prefers-tabs") || !strings.Contains(idx, "build-target") {
+		t.Fatalf("index should contain both global and project memories:\n%s", idx)
+	}
+
+	// Delete removes from the correct directory
+	if err := s.Delete("prefers-tabs"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(pUser); !os.IsNotExist(err) {
+		t.Fatal("global memory file should be gone after delete")
+	}
+
+	// List after delete
+	list2 := s.List()
+	if len(list2) != 3 {
+		t.Fatalf("want 3 memories after delete, got %d", len(list2))
+	}
+
+	// Index should not duplicate # Memory headers (Block() adds its own).
+	idx2 := s.Index()
+	if strings.Count(idx2, "# Memory") != 0 {
+		t.Fatalf("Index should have 0 # Memory headers (Block() adds one), got %d:\n%s", strings.Count(idx2, "# Memory"), idx2)
+	}
+}
+
+// TestStoreForInitializesGlobalDir ensures StoreFor sets GlobalDir alongside Dir.
+func TestStoreForInitializesGlobalDir(t *testing.T) {
+	s := StoreFor("/home/me/.config/reasonix", "/Users/me/proj")
+	if s.GlobalDir == "" {
+		t.Fatal("StoreFor should set GlobalDir")
+	}
+	if !strings.Contains(s.GlobalDir, "memory") || !strings.Contains(s.GlobalDir, "global") {
+		t.Fatalf("unexpected GlobalDir: %s", s.GlobalDir)
+	}
+	if s.GlobalDir == s.Dir {
+		t.Fatal("GlobalDir and Dir should be different paths")
+	}
+}
+
+// TestDirForRoutesCorrectly verifies DirFor routes user/feedback to GlobalDir
+// and everything else to Dir.
+func TestDirForRoutesCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+	if got := s.DirFor(TypeUser); got != s.GlobalDir {
+		t.Errorf("TypeUser: got %q, want %q", got, s.GlobalDir)
+	}
+	if got := s.DirFor(TypeFeedback); got != s.GlobalDir {
+		t.Errorf("TypeFeedback: got %q, want %q", got, s.GlobalDir)
+	}
+	if got := s.DirFor(TypeProject); got != s.Dir {
+		t.Errorf("TypeProject: got %q, want %q", got, s.Dir)
+	}
+	if got := s.DirFor(TypeReference); got != s.Dir {
+		t.Errorf("TypeReference: got %q, want %q", got, s.Dir)
+	}
+}
+
+// TestDirForFallsBackWhenNoGlobalDir ensures DirFor falls back to Dir when
+// GlobalDir is empty.
+func TestDirForFallsBackWhenNoGlobalDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{Dir: filepath.Join(dir, "memory")}
+	if got := s.DirFor(TypeUser); got != s.Dir {
+		t.Errorf("TypeUser without GlobalDir should fall back to Dir, got %q", got)
+	}
+}
+
+// TestStoreDeleteRemovesFromAllDirs verifies that after a type-routing migration
+// (same name in both GlobalDir and Dir), Delete removes both copies so the
+// memory truly disappears.
+func TestStoreDeleteRemovesFromAllDirs(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// Simulate migration: write a TypeUser memory directly into both dirs.
+	name := "prefers-tabs"
+	for _, d := range []string{s.Dir, s.GlobalDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := Memory{Name: name, Description: "user pref", Type: TypeUser, Body: "use tabs"}
+		if err := os.WriteFile(filepath.Join(d, name+".md"), []byte(render(m, name)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := reindexIn(d, name, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Both copies should appear, but deduplicated.
+	list := s.List()
+	if len(list) != 1 {
+		t.Fatalf("want 1 deduplicated memory, got %d", len(list))
+	}
+
+	// Delete should remove from BOTH directories.
+	if err := s.Delete(name); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(s.GlobalDir, name+".md")); !os.IsNotExist(err) {
+		t.Fatal("global copy should be gone after delete")
+	}
+	if _, err := os.Stat(filepath.Join(s.Dir, name+".md")); !os.IsNotExist(err) {
+		t.Fatal("project copy should be gone after delete")
+	}
+
+	list2 := s.List()
+	if len(list2) != 0 {
+		t.Fatalf("want 0 memories after delete, got %d", len(list2))
+	}
+	if idx := s.Index(); idx != "" {
+		t.Fatalf("Index() should be empty after deleting all entries, got:\n%s", idx)
+	}
+}
+
+// TestStoreIndexDeduplicatesAcrossDirs verifies Index() does not emit duplicate
+// lines when the same memory name exists in both GlobalDir and Dir.
+func TestStoreIndexDeduplicatesAcrossDirs(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// Write the same memory into both dirs (migration scenario).
+	name := "prefers-tabs"
+	for _, d := range []string{s.GlobalDir, s.Dir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := Memory{Name: name, Description: "user pref", Type: TypeUser, Body: "use tabs"}
+		if err := os.WriteFile(filepath.Join(d, name+".md"), []byte(render(m, name)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := reindexIn(d, name, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	idx := s.Index()
+	count := strings.Count(idx, name+".md")
+	if count != 1 {
+		t.Fatalf("want exactly 1 index line for %s, got %d:\n%s", name, count, idx)
+	}
+	if strings.Count(idx, "# Memory") != 0 {
+		t.Fatalf("merged index should have 0 # Memory headers (Block() adds one), got %d:\n%s", strings.Count(idx, "# Memory"), idx)
+	}
+}
+
+// TestStoreSaveVerifiesIndexDir verifies that Save writes the MEMORY.md
+// index to the correct directory for the memory type.
+func TestStoreSaveVerifiesIndexDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// TypeUser → GlobalDir
+	if _, err := s.Save(Memory{Name: "user-pref", Description: "d", Type: TypeUser, Body: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	gb, _ := os.ReadFile(filepath.Join(s.GlobalDir, indexFile))
+	pb, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+	if !strings.Contains(string(gb), "user-pref") {
+		t.Fatal("GlobalDir MEMORY.md should contain user-pref")
+	}
+	if strings.Contains(string(pb), "user-pref") {
+		t.Fatal("Dir MEMORY.md should NOT contain user-pref (it went to GlobalDir)")
+	}
+
+	// TypeProject → Dir
+	if _, err := s.Save(Memory{Name: "build-cmd", Description: "d", Type: TypeProject, Body: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	pb2, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+	if !strings.Contains(string(pb2), "build-cmd") {
+		t.Fatal("Dir MEMORY.md should contain build-cmd")
+	}
+	gb2, _ := os.ReadFile(filepath.Join(s.GlobalDir, indexFile))
+	if strings.Contains(string(gb2), "build-cmd") {
+		t.Fatal("GlobalDir MEMORY.md should NOT contain build-cmd (it went to Dir)")
+	}
+}
+
+// TestStoreDeleteFlushesIndexPerDir verifies that Delete calls flushIndexIn
+// for each directory where the memory file existed.
+func TestStoreDeleteFlushesIndexPerDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// Write to both dirs manually (migration scenario).
+	name := "prefers-tabs"
+	for _, d := range []string{s.GlobalDir, s.Dir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := Memory{Name: name, Description: "d", Type: TypeUser, Body: "b"}
+		if err := os.WriteFile(filepath.Join(d, name+".md"), []byte(render(m, name)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := reindexIn(d, name, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.Delete(name); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify both MEMORY.md files have the entry removed.
+	gb, _ := os.ReadFile(filepath.Join(s.GlobalDir, indexFile))
+	pb, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+	if strings.Contains(string(gb), name+".md") {
+		t.Fatalf("GlobalDir MEMORY.md should not reference %s after delete:\n%s", name, gb)
+	}
+	if strings.Contains(string(pb), name+".md") {
+		t.Fatalf("Dir MEMORY.md should not reference %s after delete:\n%s", name, pb)
+	}
+
+	// Index() should return "" (no entries, no orphaned header).
+	idx := s.Index()
+	if idx != "" {
+		t.Fatalf("Index() should return empty after deleting all entries, got:\n%s", idx)
+	}
+}
+
+// TestStorePathWithGlobalDir verifies Path() checks GlobalDir first and
+// falls back to Dir for new files.
+func TestStorePathWithGlobalDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// No files yet → defaults to Dir.
+	p := s.Path("new-fact")
+	if !strings.HasPrefix(p, s.Dir) {
+		t.Fatalf("Path for new file should default to Dir, got %s", p)
+	}
+
+	// Write a file to GlobalDir.
+	if err := os.MkdirAll(s.GlobalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(s.GlobalDir, "existing.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p2 := s.Path("existing")
+	if !strings.HasPrefix(p2, s.GlobalDir) {
+		t.Fatalf("Path for file in GlobalDir should return GlobalDir path, got %s", p2)
+	}
+
+	// Write a file to Dir (not GlobalDir).
+	if err := os.MkdirAll(s.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(s.Dir, "proj-fact.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p3 := s.Path("proj-fact")
+	if !strings.HasPrefix(p3, s.Dir) {
+		t.Fatalf("Path for file only in Dir should return Dir path, got %s", p3)
+	}
+}


### PR DESCRIPTION
## Fix: Memory panel always empty on Global tab (#3756)

### Problem
The desktop memory panel always shows empty when the Global tab (or any tab whose project-specific memory directory has no auto-memories) is active. The root cause is two-fold:

1. **Store only has `Dir` (project-specific path)** — `App.Memory()` reads from the active controller's `Store.Dir`, which for the Global tab points to an empty `projects/<global-workspace-slug>/memory`. There is no concept of a shared memory directory for cross-project memories (user preferences, feedback).

2. **Panel has no tab awareness** — The memory panel always reads from the active tab's controller. When viewing settings from the Global tab, it gets the Global tab's empty store.

### Fix (two layers)

**Layer 1 — Backend `Store` (internal/memory):**
- Add `GlobalDir` field to `Store`, populated by `StoreFor()` as `<userDir>/memory/global`
- `DirFor(t Type)` routes `TypeUser`/`TypeFeedback` → `GlobalDir` (shared), others → `Dir` (project-specific); falls back to `Dir` when `GlobalDir` is empty
- `List()`, `Index()` merge both dirs with deduplication (global first)
- `Delete()` removes from all dirs (handles migration where same memory name exists in both)
- `Save()` routes via `DirFor()` and updates only the target dir's `MEMORY.md`
- `Index()` reconstructs a single clean index from managed lines across both dirs (no duplicate headers)

**Layer 2 — Desktop `App` + Frontend:**
- Add `MemoryForTab`/`RememberForTab`/`ForgetForTab`/`SaveDocForTab` using `ctrlByTabID(tabID)` with `fallback=false` (no silent fallback to wrong tab)
- Empty `tabID` falls back to active tab for backward compatibility
- Add `StoreGlobalDir` to `MemoryView` JSON payload
- `MemorySettingsPage` gets a tab selector dropdown (shown when >1 tab) so user can browse any project's memories
- All mutation calls use `*ForTab` when a tab is selected
- "Memory unavailable" screen still shows the tab selector so user can recover

### Backward Compatibility
- `Store{Dir: x}` with empty `GlobalDir` — `DirFor()` falls back to `Dir`, all methods work with single directory
- Old `Memory()`/`Remember()`/`Forget()`/`SaveDoc()` unchanged (delegate with `fallback=true`)

### Migration Safety
- Existing memories in `Dir` are unaffected — `List()` merges both dirs
- Same memory name in both dirs (pre-routing copy + new routing): `List()`/`Index()` deduplicate (GlobalDir first), `Delete()` cleans both
- `Index()` produces exactly one `# Memory` header regardless of how many dirs contribute entries

### Tests (9 new, 65 total pass)
- `TestStoreGlobalAndProject` — routing + merge + delete + header dedup
- `TestStoreForInitializesGlobalDir` — `StoreFor` sets `GlobalDir`
- `TestDirForRoutesCorrectly` — type→dir routing
- `TestDirForFallsBackWhenNoGlobalDir` — empty `GlobalDir` → `Dir`
- `TestStoreDeleteRemovesFromAllDirs` — migration: both copies deleted
- `TestStoreIndexDeduplicatesAcrossDirs` — no duplicate index lines/headers
- `TestStoreSaveVerifiesIndexDir` — `MEMORY.md` written to correct dir per type
- `TestStoreDeleteFlushesIndexPerDir` — both dirs' indexes flushed, `Index()` returns `""`
- `TestStorePathWithGlobalDir` — GlobalDir-first lookup + Dir fallback

---

Hi maintainers — this is my first time tackling a larger issue in this codebase. I've tried to be thorough with the implementation, test coverage, and edge cases (migration scenarios, stale tab handling, nil controller guards). That said, I'm sure there are things I could improve, and I'd genuinely appreciate any feedback on the approach, the code style, or anything I may have missed. Happy to iterate and learn. Thank you for your time reviewing this.