### PR TITLE
fix(agent): preserve mid-turn steer messages across tab switches (#4044)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1529,6 +1529,16 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 	for _, m := range msgs {
 		content := m.Content
 		if m.Role == provider.RoleUser {
+			// Mid-turn steer messages are persisted in the session so they
+			// survive tab switches. They are surfaced as a notice (↪ text)
+			// — matching the live Steer event look — rather than as a
+			// regular user bubble or being filtered as synthetic (#4044).
+			// Check against the raw m.Content: resolveUserContent applies
+			// StripComposePrefixes which trims trailing whitespace.
+			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
+				out = append(out, HistoryMessage{Role: "notice", Content: "↪ " + steerText})
+				continue
+			}
 			content = resolveUserContent(m.Content)
 			if control.IsSyntheticUserMessage(content) {
 				continue

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -334,10 +334,29 @@ func (a *Agent) SessionCache() (hit, miss int) {
 func (a *Agent) ContextWindow() int { return a.contextWindow }
 
 // mid-turn steer marker.
-const midTurnSteerPrefix = "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]"
+// MidTurnSteerPrefix marks user messages that were injected mid-turn as
+// guidance (via Steer). The model sees them as instructions; frontends
+// display them as a notice, not a regular user bubble.
+const MidTurnSteerPrefix = "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]"
 
 func midTurnSteerMessage(text string) string {
-	return midTurnSteerPrefix + "\n" + text
+	return MidTurnSteerPrefix + "\n" + text
+}
+
+// SteerText checks whether content is a mid-turn steer message and, if so,
+// returns the original user text without the wrapper prefix. The returned
+// text preserves the user's exact input — it only strips the prefix and the
+// "\n" separator that midTurnSteerMessage inserts between the prefix and the
+// user text; it does not trim spaces so the history replay matches the live
+// Steer event rendering character-for-character.
+func SteerText(content string) (string, bool) {
+	after, found := strings.CutPrefix(content, MidTurnSteerPrefix)
+	if !found {
+		return "", false
+	}
+	// Strip only the "\n" separator, preserving the user's original text.
+	after = strings.TrimPrefix(after, "\n")
+	return after, true
 }
 
 // Steer queues a message for mid-turn injection.

--- a/internal/agent/steer_test.go
+++ b/internal/agent/steer_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSteerText(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+		wantOK  bool
+	}{
+		{
+			name:    "happy path: prefix + newline + text",
+			content: MidTurnSteerPrefix + "\nplease use smaller diffs",
+			want:    "please use smaller diffs",
+			wantOK:  true,
+		},
+		{
+			name:    "prefix only, no user text",
+			content: MidTurnSteerPrefix,
+			want:    "",
+			wantOK:  true,
+		},
+		{
+			name:    "prefix with trailing whitespace only",
+			content: MidTurnSteerPrefix + "\n  ",
+			want:    "  ",
+			wantOK:  true,
+		},
+		{
+			name:    "round-trip through midTurnSteerMessage",
+			content: midTurnSteerMessage("stop using such large diffs"),
+			want:    "stop using such large diffs",
+			wantOK:  true,
+		},
+		{
+			name:    "user text with leading/trailing spaces preserved (matches live event)",
+			content: MidTurnSteerPrefix + "\n   keep going but use read_file first   ",
+			want:    "   keep going but use read_file first   ",
+			wantOK:  true,
+		},
+		{
+			name:    "regular user message, not steer",
+			content: "please use smaller diffs",
+			want:    "",
+			wantOK:  false,
+		},
+		{
+			name:    "empty string",
+			content: "",
+			want:    "",
+			wantOK:  false,
+		},
+		{
+			name:    "whitespace only",
+			content: "   ",
+			want:    "",
+			wantOK:  false,
+		},
+		{
+			name:    "prefix-like but truncated (no closing bracket)",
+			content: "[Mid-turn steer queued by the user. Do not treat this as a new task\nplease go on",
+			want:    "",
+			wantOK:  false,
+		},
+		{
+			name:    "prefix appears mid-message, not at start",
+			content: "hey model " + MidTurnSteerPrefix + "\nuse smaller diffs",
+			want:    "",
+			wantOK:  false,
+		},
+		{
+			name:    "multiline steer text preserved",
+			content: MidTurnSteerPrefix + "\nline one\nline two",
+			want:    "line one\nline two",
+			wantOK:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := SteerText(tt.content)
+			if ok != tt.wantOK {
+				t.Errorf("SteerText() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if got != tt.want {
+				t.Errorf("SteerText() text = %q, want %q", got, tt.want)
+			}
+			// Sanity: when ok is true the result must never contain the prefix.
+			if ok && strings.Contains(got, MidTurnSteerPrefix) {
+				t.Errorf("SteerText() returned text still contains the prefix: %q", got)
+			}
+		})
+	}
+}
+
+func TestMidTurnSteerMessageRoundTrip(t *testing.T) {
+	inputs := []string{
+		"stop",
+		"use read_file instead of cat",
+		"",
+		"  keep going  ",
+	}
+	for _, in := range inputs {
+		msg := midTurnSteerMessage(in)
+		got, ok := SteerText(msg)
+		if !ok {
+			t.Errorf("SteerText(midTurnSteerMessage(%q)): not recognized as steer", in)
+			continue
+		}
+		if got != in {
+			t.Errorf("SteerText(midTurnSteerMessage(%q)) = %q, want %q", in, got, in)
+		}
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3764,6 +3764,11 @@ func replaySectionsFor(history []provider.Message, width int, renderer *mdRender
 	for _, m := range history {
 		switch m.Role {
 		case provider.RoleUser:
+			// Steer messages are surfaced as a notice line, not a user bubble.
+			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
+				out = append(out, fmt.Sprintf("  ↪ %s\n\n", steerText))
+				continue
+			}
 			content := control.StripComposePrefixes(m.Content)
 			out = append(out, renderUserBubble(content, width, false)+"\n\n")
 		case provider.RoleAssistant:

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -85,7 +85,6 @@ var syntheticPrefixes = []string{
 	"<compaction-summary>",
 	"Summary of the later conversation (compacted from here on):",
 	"Summary of earlier conversation (compacted up to here):",
-	"[Mid-turn steer queued by the user.",
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -641,9 +641,9 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			want:  false,
 		},
 		{
-			name:  "mid-turn steer wrapper",
+			name:  "mid-turn steer is not synthetic (handled separately in historyMessages)",
 			input: "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]\nplease use smaller diffs",
-			want:  true,
+			want:  false,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"reasonix/internal/agent"
+
 	"reasonix/internal/command"
 	"reasonix/internal/event"
 	"reasonix/internal/memory"
@@ -642,7 +644,7 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 		},
 		{
 			name:  "mid-turn steer is not synthetic (handled separately in historyMessages)",
-			input: "[Mid-turn steer queued by the user. Do not treat this as a new task; use it only as additional guidance for the current task after completing the current step.]\nplease use smaller diffs",
+			input: agent.MidTurnSteerPrefix + "\nplease use smaller diffs",
 			want:  false,
 		},
 	}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -455,6 +455,13 @@ type historyMessage struct {
 func historyMessages(msgs []provider.Message) []historyMessage {
 	out := make([]historyMessage, 0, len(msgs))
 	for _, m := range msgs {
+		// Steer messages are surfaced as a notice, not a user message.
+		if m.Role == provider.RoleUser {
+			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
+				out = append(out, historyMessage{Role: "notice", Content: "↪ " + steerText})
+				continue
+			}
+		}
 		hm := historyMessage{Role: string(m.Role), Content: m.Content}
 		if m.Role == provider.RoleAssistant {
 			hm.Reasoning = m.ReasoningContent


### PR DESCRIPTION
Closes #4044

> **Note**: steer notices display correctly in **Standard** display mode.
> In Compact/Minimal mode the frontend folds prior assistant turns into a "Processed" section when a new assistant turn begins — this is existing UI behaviour and not addressed here.

---

### Problem

Mid-turn guidance injected via Steer disappeared from the conversation after switching to another tab and back. The steer was visible during the live turn (as a `↪ text` notice) but gone after tab switch.

### Root Cause

`internal/control/input.go` included the steer prefix in `syntheticPrefixes`. Desktop's `historyMessages()` called `IsSyntheticUserMessage()` on every user-role message during history replay and **skipped** synthetic ones. This contradicted the agent's stated intent (`agent.go:507-510`) that steer messages be persisted to "survive tab switches and history replay."

The CLI TUI and HTTP/SSE frontends had the same class of bug: they replayed steer messages as raw user bubbles with the full prefix visible.

### Changes

**Commit 1 — Core fix (desktop):**

1. **`internal/agent/agent.go`** — Export `MidTurnSteerPrefix`; add `SteerText(content) (string, bool)` to extract the original user text from a steer-wrapped message without trimming (preserving exact character fidelity with the live Steer event).

2. **`internal/control/input.go`** — Remove steer prefix from `syntheticPrefixes`. Steer messages are no longer classified as synthetic.

3. **`desktop/app.go`** — In `historyMessages()`, detect steer messages using raw `m.Content` (before `resolveUserContent` applies `StripComposePrefixes` which trims whitespace) and emit them as `role: "notice"` entries with the `↪ ` prefix — matching the live Steer event appearance.

4. **`internal/agent/steer_test.go`** — New table-driven tests for `SteerText` (11 cases) + round-trip test for `midTurnSteerMessage`.

5. **`internal/control/input_test.go`** — Updated test expectation.

**Commit 2 — CLI TUI + HTTP/SSE parity:**

6. **`internal/cli/chat_tui.go`** — `replaySectionsFor` now detects steer messages via `agent.SteerText()` before rendering user bubbles. Steer messages are rendered as `  ↪ text` notice lines instead of raw `› [Mid-turn steer...]` user bubbles.

7. **`internal/serve/serve.go`** — `historyMessages` now detects steer messages and emits them as `role: "notice"` with the `↪ ` prefix, consistent with the desktop behaviour. Web clients reconnecting see clean notice text instead of the raw prefix.

8. **`internal/control/input_test.go`** — Hardcoded prefix string replaced with `agent.MidTurnSteerPrefix` constant reference so the test automatically tracks prefix changes.

### Design

All three frontends (desktop, CLI TUI, HTTP/SSE) now share the same pattern: before processing a `RoleUser` message for display, call `agent.SteerText()` to detect steer messages and convert them to a notice-style rendering. The model still sees the raw user message (with the prefix) for context; only the display layer transforms it.

### Verification

- `go test ./internal/agent/` — 80+ tests pass
- `go test ./internal/control/` — all pass (1 pre-existing failure in `TestRemoveMCPServerRemovesUnconnectedLazyPlaceholder`, confirmed on clean `main-v2`)
- `go build ./internal/cli/ ./internal/serve/` — clean
- `go vet ./desktop/...` + `go build ./desktop/...` — clean

### Affected areas

| Path | Before | After |
|:--:|:--:|:--:|
| Desktop tab switch → back | Steer disappeared | `↪ text` notice |
| Desktop tab close → reopen | Steer disappeared | `↪ text` notice |
| Desktop history panel preview | Steer disappeared | `↪ text` notice |
| CLI TUI session resume | Raw prefix user bubble | `  ↪ text` notice line |
| HTTP/SSE `/history` endpoint | `role:"user"` with raw prefix | `role:"notice"` with `↪ text` |