### PR TITLE
fix(agent): compact at end of a final-answer turn to prevent context overflow

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -605,6 +605,10 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 			if a.steerQueueLen() > 0 {
 				continue
 			}
+			// A final-answer turn otherwise skips compaction, so a large context
+			// carries into the next turn un-folded and can overflow the model window.
+			// No-op below the trigger, so normal turns keep their warm cache.
+			a.maybeCompact(ctx, usage)
 			return nil // model gave a final answer
 		}
 		emptyFinalBlocks = 0

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -15,16 +15,20 @@ import (
 // fakeProvider returns a fixed reply and records the messages it was asked to
 // complete, so tests can drive summarization without a network call.
 type fakeProvider struct {
-	reply string
-	got   []provider.Message
+	reply        string
+	promptTokens int
+	got          []provider.Message
 }
 
 func (f *fakeProvider) Name() string { return "fake" }
 
 func (f *fakeProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	f.got = req.Messages
-	ch := make(chan provider.Chunk, 2)
+	ch := make(chan provider.Chunk, 3)
 	ch <- provider.Chunk{Type: provider.ChunkText, Text: f.reply}
+	if f.promptTokens > 0 {
+		ch <- provider.Chunk{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: f.promptTokens, TotalTokens: f.promptTokens}}
+	}
 	ch <- provider.Chunk{Type: provider.ChunkDone}
 	close(ch)
 	return ch, nil
@@ -179,6 +183,28 @@ func snapshotContents(s *Session) []string {
 		out[i] = m.Content
 	}
 	return out
+}
+
+func TestRunCompactsAfterFinalAnswer(t *testing.T) {
+	// A turn that ends with a final answer (no trailing tool batch) must still
+	// compact when the context is over the trigger; otherwise a large context
+	// carries into the next turn un-folded and overflows the model window.
+	big := strings.Repeat("old work ", 200)
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: big},
+		{Role: provider.RoleAssistant, Content: big},
+	}}
+	a := New(&fakeProvider{reply: "done", promptTokens: 95}, tool.NewRegistry(), sess,
+		Options{ContextWindow: 100, RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	if err := a.Run(context.Background(), "what's the status?"); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := sess.RewriteVersion(); got != 1 {
+		t.Fatalf("final-answer turn over the trigger did not compact: rewrite version = %d, want 1", got)
+	}
 }
 
 func TestCompactReplacesHistory(t *testing.T) {


### PR DESCRIPTION
Found while stress-testing long multi-turn sessions with repeated heavy compaction.

## The bug
`maybeCompact` runs only after a tool batch (and in the readiness/empty-final retry paths). A turn that ends with a clean **final answer** (no trailing tool call) returns without compacting. So when a turn ends with a large context, it carries into the next turn un-folded; across a multi-turn session the context accumulates until a request exceeds the model's hard limit and the provider returns **400 (maximum context length)** — the session then breaks (every `--continue` re-sends the over-limit context).

Most acute for turns that add large content but call no tools (pasting big input, pure Q&A over a large context).

## Repro (real provider)
6-turn session, each turn fed a ~380k-token batch, `context_window` 700k:
- turn 3 reached ~766k and ended with a final answer → **no compaction**
- turn 4 then sent ~1.16M tokens → `400: maximum context length is 1048565 tokens, requested 1158757` → session dead

After the fix, the same session runs to completion (9 folds, no 400).

## The fix
Call `maybeCompact` on the final-answer path too. It's a no-op below the trigger (normal turns keep their warm cache); it folds only when the context is already over the threshold — exactly when the next turn would otherwise overflow.

## Test
`TestRunCompactsAfterFinalAnswer`: a final-answer turn over the trigger must compact. Verified it **fails without the one-line change** and passes with it. Full `internal/agent` suite green.
