### PR TITLE
fix(agent): keep prior digests verbatim across compaction; document the limit

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -185,14 +185,24 @@ Long tasks eventually fill the model's context window. Reasonix manages this wit
 - Each provider declares its `context_window` (tokens). When a turn's reported
   `prompt_tokens` reach `compactRatio` (default `0.8`) of that window, the
   executor compacts **once** before the next turn.
-- Compaction summarizes the older middle of the session into a single briefing —
-  using the executor's own provider, no tools — and replaces it in place: the
-  session becomes `system + summary + recentKeep` (default `8`) verbatim
-  messages. The boundary is aligned backward off any tool result so the recent
-  tail never begins with an orphan tool message whose `tool_calls` were
-  summarized away.
+- Compaction folds only the assistant/tool work. Every **user turn** small
+  enough to be a brief and every **prior digest** is kept verbatim; the foldable
+  remainder is summarized — using the executor's own provider, no tools — in
+  place. The boundary is aligned backward off any tool result so the recent tail
+  never begins with an orphan tool message whose `tool_calls` were summarized away.
 - The dropped originals are archived to `~/.config/reasonix/archive/<timestamp>.jsonl`
   (one message per line), so the full history stays traceable.
+
+**What survives a fold.** A fact the user states in a normal-sized turn is kept
+verbatim and is never summarized away — at any point in the session, across any
+number of compactions. A digest, once written, is likewise kept verbatim rather
+than re-summarized, so facts it captured are not lost to drift. The one
+**best-effort** boundary: a fact buried inside a single oversized message (a
+large paste, over the per-turn pin budget) folds with the rest, so its survival
+depends on the summarizer catching it while compressing bulk. There is no
+reliable way to auto-detect an arbitrary fact in bulk, so durable facts belong in
+their own turn rather than buried in a large paste; the raw oversized content is
+still archived and recoverable either way.
 
 This is the **only** point where the prompt prefix changes — a deliberate, rare
 "cache-reset point". Between compactions the session grows prepend-only and

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -233,11 +233,11 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 		archived = path
 	}
 
-	// Upper layer: the digest is built from the whole region (kept turns included),
-	// so its structured "user facts & constraints" section consolidates what the
-	// user said into one tidy view — redundant with the verbatim turns by design,
-	// so a weak summarizer dropping a fact here loses nothing.
-	summary, err := a.summarize(ctx, region, instructions)
+	// The digest covers only the foldable work; kept user turns and prior digests
+	// are spliced back verbatim, so a fact that reached a digest once is never
+	// re-summarized away and the user's own words are never touched. Digests
+	// accumulate (small) rather than collapsing into one lossy rolling summary.
+	summary, err := a.summarize(ctx, fold, instructions)
 	if err != nil {
 		a.emitCompactionAborted(trigger)
 		return err
@@ -373,12 +373,13 @@ func (a *Agent) pinnableUserTurn(m provider.Message) bool {
 	return int(float64(msgChars(m))*a.tokPerChar()) <= budget
 }
 
-// partitionFold splits a compaction region into the small user turns kept verbatim
-// (the deterministic floor — a fact the user stated is never summarized away) and
-// the rest, which folds into the digest. Order within each group is preserved.
+// partitionFold splits a compaction region into what is kept verbatim — small user
+// turns (a fact the user stated is never summarized away) and prior digests (so a
+// later fold never re-summarizes an earlier digest and drops the facts it already
+// captured) — and the rest, which folds. Order within each group is preserved.
 func (a *Agent) partitionFold(region []provider.Message) (kept, fold []provider.Message) {
 	for _, m := range region {
-		if m.Role == provider.RoleUser && !isCompactionSummary(m) && a.pinnableUserTurn(m) {
+		if isCompactionSummary(m) || (m.Role == provider.RoleUser && a.pinnableUserTurn(m)) {
 			kept = append(kept, m)
 		} else {
 			fold = append(fold, m)

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -207,6 +207,40 @@ func TestRunCompactsAfterFinalAnswer(t *testing.T) {
 	}
 }
 
+func TestCompactKeepsPriorDigests(t *testing.T) {
+	// A prior digest anywhere in the folded region is kept verbatim, not
+	// re-summarized — so a fact it already captured is not lost to re-fold drift.
+	priorDigest := summaryTagOpen + "\n## Standing facts\n- db is orion_prod_42\n" + summaryTagClose
+	big := strings.Repeat("work output ", 200)
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: big}, // breaks leading-summary contiguity
+		{Role: provider.RoleUser, Content: priorDigest},
+		{Role: provider.RoleAssistant, Content: big},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(&fakeProvider{reply: "new digest"}, tool.NewRegistry(), sess,
+		Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, event.Discard)
+
+	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+
+	// The fake summarizer returns "new digest" (no fact); the prior fact survives
+	// only because the prior digest was kept verbatim rather than re-folded.
+	var kept bool
+	for _, m := range sess.Snapshot() {
+		if strings.Contains(m.Content, "orion_prod_42") {
+			kept = true
+		}
+	}
+	if !kept {
+		t.Fatalf("prior digest re-summarized away: %+v", sess.Snapshot())
+	}
+}
+
 func TestCompactReplacesHistory(t *testing.T) {
 	prov := &fakeProvider{reply: "- goal: do X\n- changed file Y"}
 	bigStep := strings.Repeat("important implementation detail ", 80)


### PR DESCRIPTION
Follow-up to #4048/#4052. Two parts: a robustness fix and an honest doc of the limit.

## Keep prior digests verbatim
A compaction digest was eligible to be re-summarized by the next fold (`partitionFold` only kept user turns; digests went into the foldable set, and the summary was built from the whole region). So a fact a digest had already captured could be dropped to summary-of-summary drift on the next fold.

Now `partitionFold` keeps prior digests verbatim too, and the new digest summarizes only the foldable work (`summarize(fold)`, not the whole region). Digests accumulate (each small) instead of collapsing into one lossy rolling summary, so a fact that reached a digest once is not lost to re-folding.

`TestCompactKeepsPriorDigests` covers it (verified it fails without the change).

## Document the limit (SPEC 3.6)
We chased "facts the user said get forgotten" to ground. The guarantees, now written down:
- a fact stated in a normal-sized turn is kept verbatim, never summarized away, across any number of folds;
- a fact a digest captured is likewise kept (this PR);
- **best-effort** only for a fact buried inside a single oversized message (a large paste over the per-turn pin budget) — it folds with the rest, so survival depends on the summarizer catching it while compressing bulk.

There is no reliable way to auto-detect an arbitrary fact in bulk (keyword matching is fragile intent-detection; the summarizer drops needles; full-verbatim doesn't fit the window with multiple large pastes), so the doc tells users to state durable facts in their own turn. The raw oversized content is archived and recoverable either way.

`go test ./internal/agent/...` green.
