### PR TITLE
fix: new session inherits settings from active tab (#4019 & #4088)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -961,6 +961,7 @@ func (a *App) Fork(turn int) (TabMeta, error) {
 	model := sourceTab.model
 	effort := cloneStringPtr(sourceTab.effort)
 	mode := currentTabMode(sourceTab)
+	toolApprovalMode := currentTabToolApprovalMode(sourceTab)
 	disabledMCP := cloneServerViewMap(sourceTab.disabledMCP)
 	mcpOrder := append([]string(nil), sourceTab.mcpOrder...)
 	a.mu.RUnlock()
@@ -990,17 +991,18 @@ func (a *App) Fork(turn int) (TabMeta, error) {
 	a.mu.Lock()
 	tabID := a.newUniqueTabIDLocked()
 	tab := &WorkspaceTab{
-		ID:            tabID,
-		Scope:         scope,
-		WorkspaceRoot: workspaceRoot,
-		TopicID:       topicID,
-		TopicTitle:    topicTitle,
-		SessionPath:   newPath,
-		model:         model,
-		effort:        effort,
-		mode:          mode,
-		disabledMCP:   disabledMCP,
-		mcpOrder:      mcpOrder,
+		ID:               tabID,
+		Scope:            scope,
+		WorkspaceRoot:    workspaceRoot,
+		TopicID:          topicID,
+		TopicTitle:       topicTitle,
+		SessionPath:      newPath,
+		model:            model,
+		effort:           effort,
+		mode:             mode,
+		toolApprovalMode: toolApprovalMode,
+		disabledMCP:      disabledMCP,
+		mcpOrder:         mcpOrder,
 	}
 	tab.sink = &tabEventSink{tabID: tabID, app: a}
 	a.tabs[tabID] = tab

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -603,6 +603,13 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 	}
 
 	var created *WorkspaceTab
+	// Compute actual root early — both the indexed-topic fallback and the
+	// new-topic path need it when constructing the tab below.
+	actualRoot := workspaceRoot
+	if scope == "global" {
+		actualRoot = globalRoot
+	}
+
 	a.mu.Lock()
 	for _, id := range a.orderedTabIDsLocked() {
 		tab := a.tabs[id]
@@ -615,12 +622,53 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		}
 	}
 
+	// Inherit model, effort, mode, tool-approval, and MCP state from the
+	// active tab so a new blank session keeps the same settings (#4019).
+	var inheritedModel string
+	var inheritedEffort *string
+	inheritedMode := "normal"
+	inheritedToolApprovalMode := control.ToolApprovalAsk
+	inheritedDisabledMCP := map[string]ServerView{}
+	var inheritedMCPOrder []string
+	if active := a.activeTabLocked(); active != nil {
+		inheritedModel = active.model
+		inheritedEffort = cloneStringPtr(active.effort)
+		inheritedMode = currentTabMode(active)
+		inheritedToolApprovalMode = currentTabToolApprovalMode(active)
+		inheritedDisabledMCP = cloneServerViewMap(active.disabledMCP)
+		inheritedMCPOrder = append([]string(nil), active.mcpOrder...)
+	}
+
 	if topicID := a.indexedBlankTopicIDLocked(scope, workspaceRoot); topicID != "" {
-		a.mu.Unlock()
-		if scope == "global" {
-			return a.OpenGlobalTab(topicID)
+		// Reuse a previously-indexed but unused blank topic instead of
+		// creating a new one.  Build it inline (not via OpenProjectTab /
+		// OpenGlobalTab) so it inherits settings from the active tab.
+		tabID := a.newUniqueTabIDLocked()
+		topicTitle := topicTitleForTab(scope, workspaceRoot, topicID)
+		created = &WorkspaceTab{
+			ID:               tabID,
+			Scope:            scope,
+			WorkspaceRoot:    actualRoot,
+			TopicID:          topicID,
+			TopicTitle:       topicTitle,
+			model:            inheritedModel,
+			effort:           inheritedEffort,
+			mode:             inheritedMode,
+			toolApprovalMode: inheritedToolApprovalMode,
+			disabledMCP:      inheritedDisabledMCP,
+			mcpOrder:         inheritedMCPOrder,
 		}
-		return a.OpenProjectTab(workspaceRoot, topicID)
+		created.sink = &tabEventSink{tabID: tabID, app: a}
+		a.tabs[tabID] = created
+		a.tabOrder = append(a.tabOrder, tabID)
+		a.activeTabID = tabID
+		a.saveTabsLocked()
+		meta := a.tabMeta(created, true)
+		a.mu.Unlock()
+
+		a.startTabControllerBuild(created)
+		a.emitProjectTreeChanged()
+		return meta, nil
 	}
 
 	topicID := newTopicID()
@@ -644,19 +692,18 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 	}
 
 	tabID := a.newUniqueTabIDLocked()
-	actualRoot := workspaceRoot
-	if scope == "global" {
-		actualRoot = globalRoot
-	}
 	created = &WorkspaceTab{
 		ID:               tabID,
 		Scope:            scope,
 		WorkspaceRoot:    actualRoot,
 		TopicID:          topicID,
 		TopicTitle:       topicTitleForTab(scope, workspaceRoot, topicID),
-		mode:             "normal",
-		toolApprovalMode: control.ToolApprovalAsk,
-		disabledMCP:      map[string]ServerView{},
+		model:            inheritedModel,
+		effort:           inheritedEffort,
+		mode:             inheritedMode,
+		toolApprovalMode: inheritedToolApprovalMode,
+		disabledMCP:      inheritedDisabledMCP,
+		mcpOrder:         inheritedMCPOrder,
 	}
 	created.sink = &tabEventSink{tabID: tabID, app: a}
 	a.tabs[tabID] = created


### PR DESCRIPTION
## Summary

Fixes #4019 and #4088 — clicking "New Session" (or the "+" tab button) in the desktop app created a blank tab with hardcoded defaults instead of carrying over the current session's model, effort, collaboration mode, and tool-approval posture.

## Problem

When a user had model=deepseek-v4-pro, effort=max, and YOLO enabled in the current tab, clicking "New Session" would create a blank tab that **did not inherit** any of those settings:

| Setting       | Before (broken)                     | After (fixed)                |
|---------------|-------------------------------------|------------------------------|
| Model         | deepseek-v4-flash (fallback default)| Inherited from active tab    |
| Effort        | auto                                | Inherited from active tab    |
| Mode / YOLO   | normal + ask                        | Inherited from active tab    |
| Disabled MCP  | empty map                           | Inherited from active tab    |

## Root Cause

`EnsureBlankTab()` in `desktop/tabs.go` created the `WorkspaceTab` struct with hardcoded defaults and zero-value fields:

```go
mode:             "normal",              // hardcoded
toolApprovalMode: control.ToolApprovalAsk, // hardcoded
// model and effort left as zero values
```

No settings were carried over from the currently active tab.  Additionally, `Fork()` was missing `toolApprovalMode` from its carry-over set — every forked session silently reverted to "ask" approval.

## Changes

### `desktop/tabs.go` — `EnsureBlankTab` (main fix)

- **Inherit** model, effort, mode, toolApprovalMode, `disabledMCP`, and `mcpOrder` from the active tab before constructing the blank `WorkspaceTab`. Falls back to the previous hardcoded defaults only when no active tab exists (first launch).
- **Fallback path** (reusing a previously-indexed blank topic) now builds the tab inline instead of delegating to `OpenProjectTab` / `OpenGlobalTab`, which had their own hardcoded defaults.  Both code paths share the same inherited variables, so the reuse path is no longer a gap.

### `desktop/app.go` — `Fork`

- Added `toolApprovalMode` to the carry-over set (model, effort, mode, `disabledMCP`, and `mcpOrder` were already inherited).

## Affected code paths

| Action                        | Before                        | After                         |
|-------------------------------|-------------------------------|-------------------------------|
| Click "+" on tab bar          | Hardcoded defaults            | Inherits active tab settings  |
| Click "New Session" button    | Hardcoded defaults            | Inherits active tab settings  |
| Fork session                  | Loses toolApprovalMode        | Carries all settings          |
| Reuse indexed blank topic     | Delegated → hardcoded defaults| Inline → proper inheritance   |

## Verification

- `go build ./...` passes.
- Three rounds of code review addressed — the initial implementation, an external review identifying a bypass path and MCP asymmetry, and a final symptom-by-symptom verification against the issue's reproduction steps.
- No new dependencies, no public API changes, mutex discipline unchanged.