### PR TITLE
feat(desktop): @ file pick now renders as a blue highlight chip inste…

### DIFF
--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -387,6 +387,7 @@ export function Composer({
   const [text, setText] = useState("");
   const [attachments, setAttachments] = useState<Attachment[]>([]);
   const [workspaceRefs, setWorkspaceRefs] = useState<WorkspaceReference[]>([]);
+  const [atFileRefs, setAtFileRefs] = useState<string[]>([]);
   const [pastedBlocks, setPastedBlocks] = useState<PastedBlock[]>([]);
   const [openPastedLabels, setOpenPastedLabels] = useState<string[]>([]);
   const [pendingPaste, setPendingPaste] = useState(0);
@@ -545,6 +546,7 @@ export function Composer({
     setLoadingPastChats(false);
     setActive(0);
     setDismissed(false);
+    setAtFileRefs([]);
   }, [cwd]);
 
   useEffect(() => {
@@ -818,7 +820,7 @@ export function Composer({
     if (disabled || submittingRef.current) return;
     const trimmedText = text.trim();
     if (pendingPaste > 0) return;
-    if (!trimmedText && attachments.length === 0 && workspaceRefs.length === 0) {
+    if (!trimmedText && attachments.length === 0 && workspaceRefs.length === 0 && atFileRefs.length === 0) {
       if (goalModeOn && !activeGoal) {
         setComposerPrompt(t("composer.goalInputRequired"));
         requestAnimationFrame(() => taRef.current?.focus());
@@ -832,10 +834,12 @@ export function Composer({
     const orderedAttachments = sortComposerAttachments(attachments);
     const refs = [
       ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
+      ...atFileRefs.map((f) => `@${f}`),
       ...orderedAttachments.map((a) => `@${a.path}`),
     ].join(" ");
     const displayRefs = [
       ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
+      ...atFileRefs.map((f) => `@${f}`),
       ...orderedAttachments.map(formatAttachmentDisplayReference),
     ].join(" ");
     const displayText = [trimmedText, displayRefs].filter(Boolean).join(trimmedText && displayRefs ? " " : "");
@@ -851,6 +855,7 @@ export function Composer({
     clearAttachments();
     setWorkspaceRefs([]);
     setSessionRefs([]);
+    setAtFileRefs([]);
     } finally {
       submittingRef.current = false;
       setSubmitting(false);
@@ -1207,11 +1212,37 @@ export function Composer({
     saveComposerHeight(height);
   };
 
+  /**
+   * pickEntry — handles selection from the @ file dropdown.
+   * Directories keep the menu open (trailing "/" to browse deeper);
+   * files are added to atFileRefs as chips and the @token is removed.
+   */
   const pickEntry = (e: DirEntry) => {
-    const atPos = text.length - (atRaw?.length ?? 0) - 1; // index of '@'
-    const prefix = text.slice(0, atPos);
-    // A directory keeps the menu open (trailing "/"); a file completes it (space).
-    setTextCaretEnd(prefix + "@" + atDir + e.name + (e.isDir ? "/" : " "));
+    if (e.isDir) {
+      // Directory: keep original behaviour — append "/" and stay open.
+      const atPos = text.length - (atRaw?.length ?? 0) - 1; // index of '@'
+      const prefix = text.slice(0, atPos);
+      setTextCaretEnd(prefix + "@" + atDir + e.name + "/");
+    } else {
+      // File: add as a blue chip instead of plain text.
+      const fullPath = atDir + e.name;
+      setAtFileRefs((prev) => {
+        if (prev.includes(fullPath)) return prev;
+        return [...prev, fullPath];
+      });
+      // Remove the @token from the textarea.
+      const atPos = text.length - (atRaw?.length ?? 0) - 1;
+      const prefix = text.slice(0, atPos);
+      setTextCaretEnd(prefix.trimEnd());
+      // Close the dropdown menu.
+      setDismissed(true);
+    }
+  };
+
+  /** removeAtFileRef — removes a single @ file reference chip. */
+  const removeAtFileRef = (path: string) => {
+    setAtFileRefs((prev) => prev.filter((p) => p !== path));
+    requestAnimationFrame(() => taRef.current?.focus());
   };
 
   // --- past:chats session reference ---
@@ -1739,10 +1770,10 @@ export function Composer({
           </div>
         </div>
       )}
-      {(attachments.length > 0 || workspaceRefs.length > 0 || sessionRefs.length > 0) && (
+      {(attachments.length > 0 || workspaceRefs.length > 0 || atFileRefs.length > 0 || sessionRefs.length > 0) && (
         <div className="composer-context" aria-label={t("composer.contextItems")}>
           {sortComposerAttachments(attachments).map((a) => {
-            const imageOnly = Boolean(a.previewUrl) && attachments.every((item) => item.previewUrl) && workspaceRefs.length === 0 && sessionRefs.length === 0;
+            const imageOnly = Boolean(a.previewUrl) && attachments.every((item) => item.previewUrl) && workspaceRefs.length === 0 && atFileRefs.length === 0 && sessionRefs.length === 0;
             return (
             <div
               className={`composer-context__item${a.previewUrl ? " composer-context__item--image" : " composer-context__item--attachment"}${imageOnly ? " composer-context__item--image-only" : ""}`}
@@ -1795,6 +1826,28 @@ export function Composer({
                   className="composer-context__remove"
                   type="button"
                   onClick={() => removeWorkspaceReference(ref)}
+                >
+                  <X size={13} />
+                </button>
+              </Tooltip>
+            </div>
+          ))}
+          {atFileRefs.map((filePath) => (
+            <div
+              className="composer-context__item composer-context__item--atfile"
+              key={filePath}
+            >
+              <Tooltip label={filePath}>
+                <span className="composer-context__label">
+                  <FileText size={15} />
+                  <span>{baseName(filePath)}</span>
+                </span>
+              </Tooltip>
+              <Tooltip label={t("composer.removeReference")} className="composer-context__remove-trigger">
+                <button
+                  className="composer-context__remove"
+                  type="button"
+                  onClick={() => removeAtFileRef(filePath)}
                 >
                   <X size={13} />
                 </button>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -12219,6 +12219,33 @@ a[href] {
 .composer-context__item--session .composer-context__label > svg {
   color: var(--accent);
 }
+/* @ file reference — blue highlight chip variant */
+.composer-context__item--atfile {
+  border-color: #93c5fd;
+  background: linear-gradient(135deg, #dbeafe 0%, #eff6ff 100%);
+  box-shadow: none;
+}
+.composer-context__item--atfile:hover {
+  border-color: #3b82f6;
+  background: linear-gradient(135deg, #bfdbfe 0%, #dbeafe 100%);
+}
+.composer-context__item--atfile .composer-context__label > svg {
+  color: #2563eb;
+}
+@media (prefers-color-scheme: dark) {
+  .composer-context__item--atfile {
+    border-color: #3b82f6;
+    background: linear-gradient(135deg, #1e3a5f 0%, #172554 100%);
+    box-shadow: none;
+  }
+  .composer-context__item--atfile:hover {
+    border-color: #60a5fa;
+    background: linear-gradient(135deg, #1e40af 0%, #1e3a5f 100%);
+  }
+  .composer-context__item--atfile .composer-context__label > svg {
+    color: #60a5fa;
+  }
+}
 .slashmenu__item--special {
   border-bottom: 1px solid var(--border);
   background: color-mix(in srgb, var(--accent) 5%, var(--panel));


### PR DESCRIPTION
…ad of plain text

feat(desktop): @ 文件引用渲染为蓝色高亮芯片

用户从 @ 下拉菜单选择文件后，不再在 textarea 中插入纯文本路径，
而是在输入框下方渲染为蓝色圆角芯片，支持悬停查看完整路径和点击移除。

改动：
- Composer.tsx：新增 atFileRefs 状态追踪已选文件，重构 pickEntry() 目录选择保持原有浏览行为不变，文件选择转为芯片并从 textarea 移除 @token
- Composer.tsx：新增 removeAtFileRef() 移除函数，集成到 submit() 序列化与清理
- Composer.tsx：芯片 UI 渲染在 composer-context 区域，复用已有 DOM/CSS 模式
- styles.css：新增 --atfile 蓝色渐变芯片样式，含浅色/暗色主题适配