### PR TITLE
feat(cli): full-width dim separator above and below user bubble

### DIFF
--- a/internal/cli/chat_render_test.go
+++ b/internal/cli/chat_render_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"charm.land/bubbles/v2/textarea"
+	"github.com/charmbracelet/x/ansi"
 
 	"reasonix/internal/event"
 )
@@ -418,5 +419,100 @@ func TestReasoningViewBounded(t *testing.T) {
 	}
 	if c := strings.Count(m.transcript[m.reasoningTextIdx], "\n") + 1; c > reasoningTailLines {
 		t.Fatalf("live reasoning block kept %d lines, want <= %d", c, reasoningTailLines)
+	}
+}
+
+// TestUserBubbleBlockScrollsAsThreeLines proves the user-bubble separator
+// token above and below a user bubble is committed as its own transcript
+// entry, expanded by expandSeparatorTokens to a real rule at the *current*
+// content width, and then wrapped by wrapTranscript into the viewport. The
+// resulting top/bottom lines must be exactly content-width cells wide (not
+// the snapshot width at commit time), and the middle line must contain the
+// user prompt.
+func TestUserBubbleBlockScrollsAsThreeLines(t *testing.T) {
+	prevColor := colorEnabled
+	colorEnabled = true
+	defer func() { colorEnabled = prevColor }()
+
+	const cw = 60
+	top, bubble, bottom := renderUserBubbleBlock("hi", false)
+	if top == "" || bottom == "" {
+		t.Fatalf("separators should be the non-empty token, got top=%q bottom=%q", top, bottom)
+	}
+
+	// Simulate the same pipeline the viewport runs: expand tokens to current
+	// content width, then wrap the joined transcript to that width.
+	expanded := expandSeparatorTokens([]string{top, bubble, bottom}, cw)
+	joined := strings.Join(expanded, "\n")
+	wrapped := wrapTranscript(joined, cw)
+	lines := strings.Split(wrapped, "\n")
+
+	if len(lines) < 3 {
+		t.Fatalf("expected at least 3 wrapped lines, got %d:\n%s", len(lines), wrapped)
+	}
+	// Strip ANSI and trailing spaces before width checks.
+	strip := func(s string) string { return strings.TrimRight(ansi.Strip(s), " ") }
+	if w := ansi.StringWidth(strip(lines[0])); w != cw {
+		t.Fatalf("top separator should be width %d, got %d (line=%q)", cw, w, strip(lines[0]))
+	}
+	if w := ansi.StringWidth(strip(lines[len(lines)-1])); w != cw {
+		t.Fatalf("bottom separator should be width %d, got %d (line=%q)", cw, w, strip(lines[len(lines)-1]))
+	}
+	// Middle line must contain the user prompt text.
+	if !strings.Contains(strip(lines[1]), "› hi") {
+		t.Fatalf("middle line should contain the prompt, got %q", strip(lines[1]))
+	}
+}
+
+// TestSeparatorTokenAdaptsToResize proves the user-bubble separator rule is
+// expanded to the *current* viewport width on every wrap. The same token in
+// the same transcript entry must render as a 60-cell rule at width 60 and
+// as a 100-cell rule at width 100 — no re-commit required when the terminal
+// is resized.
+func TestSeparatorTokenAdaptsToResize(t *testing.T) {
+	prevColor := colorEnabled
+	colorEnabled = true
+	defer func() { colorEnabled = prevColor }()
+
+	top, bubble, bottom := renderUserBubbleBlock("hi", false)
+
+	strip := func(s string) string { return strings.TrimRight(ansi.Strip(s), " ") }
+	renderAt := func(width int) (topLine, midLine, botLine string) {
+		expanded := expandSeparatorTokens([]string{top, bubble, bottom}, width)
+		wrapped := wrapTranscript(strings.Join(expanded, "\n"), width)
+		lines := strings.Split(wrapped, "\n")
+		return lines[0], lines[1], lines[len(lines)-1]
+	}
+
+	t60, mid, b60 := renderAt(60)
+	if w := ansi.StringWidth(strip(t60)); w != 60 {
+		t.Fatalf("top separator at width 60 should be 60 cells, got %d (%q)", w, strip(t60))
+	}
+	if w := ansi.StringWidth(strip(b60)); w != 60 {
+		t.Fatalf("bottom separator at width 60 should be 60 cells, got %d (%q)", w, strip(b60))
+	}
+	if !strings.Contains(strip(mid), "› hi") {
+		t.Fatalf("middle line should keep the prompt at width 60, got %q", strip(mid))
+	}
+
+	t100, _, b100 := renderAt(100)
+	if w := ansi.StringWidth(strip(t100)); w != 100 {
+		t.Fatalf("top separator at width 100 should be 100 cells, got %d (%q)", w, strip(t100))
+	}
+	if w := ansi.StringWidth(strip(b100)); w != 100 {
+		t.Fatalf("bottom separator at width 100 should be 100 cells, got %d (%q)", w, strip(b100))
+	}
+	// Sanity: the wider render should actually contain more '─' runes than
+	// the narrow one — guards against a regression where the expander
+	// accidentally caches the rule.
+	if cnt60, cnt100 := strings.Count(strip(t60), "─"), strings.Count(strip(t100), "─"); cnt100 <= cnt60 {
+		t.Fatalf("resized rule should be longer: at width 60 got %d '─', at width 100 got %d", cnt60, cnt100)
+	}
+
+	// And width<=0 should collapse the token to nothing — the rule should
+	// not appear at all in the rendered output.
+	expanded := expandSeparatorTokens([]string{top, bubble, bottom}, 0)
+	if strings.Contains(strings.Join(expanded, "\n"), "─") {
+		t.Fatalf("width<=0 should collapse the token to empty, got %q", strings.Join(expanded, "\n"))
 	}
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1363,7 +1363,7 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // finalized lines are also emitted into the terminal's native scrollback.
 func finalize(m chatTUI, cmds []tea.Cmd) tea.Cmd {
 	if m.nativeScrollback && len(*m.pendingCommit) > 0 {
-		out := strings.TrimRight(clampWidth(strings.Join(*m.pendingCommit, "\n"), m.width), "\n")
+		out := nativeScrollbackOutput(*m.pendingCommit, m.width)
 		*m.pendingCommit = (*m.pendingCommit)[:0]
 		var prints []tea.Cmd
 		for _, chunk := range chunkLines(out, m.scrollChunkHeight()) {
@@ -1374,6 +1374,11 @@ func finalize(m chatTUI, cmds []tea.Cmd) tea.Cmd {
 	}
 	*m.pendingCommit = (*m.pendingCommit)[:0]
 	return tea.Batch(cmds...)
+}
+
+func nativeScrollbackOutput(lines []string, width int) string {
+	expanded := expandSeparatorTokens(lines, width)
+	return strings.TrimRight(clampWidth(strings.Join(expanded, "\n"), width), "\n")
 }
 
 // scrollChunkHeight is the largest block (in lines) finalize prints at once in

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -675,7 +675,12 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Re-feed only when the content grew or the width changed (re-wrapping is
 	// the expensive part); a bare scroll or spinner tick keeps the offset.
 	if len(cm.transcript) != prevLines || cm.width != prevWidth || cm.transcriptDirty {
-		wrapped := wrapTranscript(strings.Join(cm.transcript, "\n"), contentW)
+		// Expand any user-bubble separator tokens to a freshly rendered rule
+		// of the *current* content width before wrapping. That way the rule
+		// always spans the visible area — terminal resizes, replays at a
+		// different width, and backfill all pick up the new width for free.
+		expanded := expandSeparatorTokens(cm.transcript, contentW)
+		wrapped := wrapTranscript(strings.Join(expanded, "\n"), contentW)
 		cm.viewport.SetContent(wrapped)
 		cm.wrappedLines = strings.Split(wrapped, "\n")
 		if wasAtBottom {
@@ -3177,8 +3182,14 @@ func (m *chatTUI) startTurnWithRaw(sent, displayed, restore, raw string) tea.Cmd
 	m.pendingRestore = restore
 	m.pendingPastes = m.pasteLabelsIn(restore)
 	m.bubbleStartIdx = len(m.transcript)
-	m.commitLine("") // blank line separating turns
-	m.commitLine(renderUserBubble(displayed, m.width, m.planMode))
+	// Commit the user bubble wrapped in a user-bubble separator token above
+	// and below (renderUserBubbleBlock). The token is expanded to a
+	// viewport-width dim rule by expandSeparatorTokens at render time, so
+	// the rule follows terminal resizes without re-committing.
+	top, bubble, bottom := renderUserBubbleBlock(displayed, m.planMode)
+	m.commitLine(top)
+	m.commitLine(bubble)
+	m.commitLine(bottom)
 	m.bubblePending = true
 	m.turnDiscarded = false
 
@@ -3765,7 +3776,8 @@ func replaySectionsFor(history []provider.Message, width int, renderer *mdRender
 		switch m.Role {
 		case provider.RoleUser:
 			content := control.StripComposePrefixes(m.Content)
-			out = append(out, renderUserBubble(content, width, false)+"\n\n")
+			top, bubble, bottom := renderUserBubbleBlock(content, false)
+			out = append(out, top+"\n", bubble+"\n", bottom+"\n")
 		case provider.RoleAssistant:
 			body := strings.TrimSpace(m.Content)
 			if body == "" {
@@ -3814,6 +3826,24 @@ func renderUserBubble(line string, width int, planMode bool) string {
 		return "│ " + prefix + line
 	}
 	return "  " + accent(prefix+line)
+}
+
+// renderUserBubbleBlock wraps renderUserBubble with a user-bubble separator
+// token above and below the bubble. The separators are committed as
+// userSeparatorToken (NOT pre-rendered rules) so they get expanded to the
+// current viewport width at render time by expandSeparatorTokens — that
+// keeps the rule aligned with the terminal on resize, replay, and any other
+// rewrap. The three strings are returned separately (not joined with \n) so
+// the caller can commitLine each one — that way the rule becomes its own
+// transcript entry and scrolls with the content rather than being painted
+// into the viewport background. renderUserBubble is reused unchanged to
+// preserve its existing contract (see TestUserBubbleIsLightweightTranscriptLine
+// in chat_tui_test.go).
+func renderUserBubbleBlock(line string, planMode bool) (top, bubble, bottom string) {
+	bubble = renderUserBubble(line, 0, planMode)
+	top = renderUserSeparatorToken()
+	bottom = renderUserSeparatorToken()
+	return top, bubble, bottom
 }
 
 var cliImageRefRe = regexp.MustCompile(`(?:^|\s)@\.reasonix/attachments/clipboard-\d{8}-\d{6}\.\d+(?:-(?:\d{6}|[a-f0-9]{8}))?\.(?:png|jpg|jpeg|gif|webp)`)

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -778,14 +778,29 @@ func TestUserBubbleCommitPathIncludesSeparators(t *testing.T) {
 	if !strings.Contains(strings.Join(got, "\n"), "hello world") {
 		t.Fatalf("bubble line should still contain the prompt, got %v", got)
 	}
-	// No standalone empty line should be emitted between the previous turn and
-	// the new top separator.
-	for _, ln := range m.transcript[:m.bubbleStartIdx] {
-		if ln == "" {
-			// allowed, but no *new* empty line should be added by the submit
-			// path itself — this loop just confirms the leading entries are
-			// untouched.
-		}
+}
+
+func TestNativeScrollbackOutputExpandsUserSeparatorTokens(t *testing.T) {
+	prevColor := colorEnabled
+	colorEnabled = false
+	defer func() { colorEnabled = prevColor }()
+
+	top, bubble, bottom := renderUserBubbleBlock("hello", false)
+	out := nativeScrollbackOutput([]string{top, bubble, bottom}, 24)
+
+	if strings.Contains(out, userSeparatorToken) || strings.Contains(out, "\x00") || strings.Contains(out, "\uE000") {
+		t.Fatalf("native scrollback output should not contain separator tokens: %q", out)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("native scrollback output should be three lines, got %d:\n%s", len(lines), out)
+	}
+	wantRule := strings.Repeat("-", 24)
+	if lines[0] != wantRule || lines[2] != wantRule {
+		t.Fatalf("native scrollback separators should expand to width-24 rules, got top=%q bottom=%q", lines[0], lines[2])
+	}
+	if !strings.Contains(lines[1], "› hello") {
+		t.Fatalf("native scrollback bubble should keep prompt text, got %q", lines[1])
 	}
 }
 

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -694,6 +694,101 @@ func TestUserBubbleIsLightweightTranscriptLine(t *testing.T) {
 	}
 }
 
+func TestRenderUserSeparatorIsFullWidthAndDimmed(t *testing.T) {
+	prevColor := colorEnabled
+	defer func() { colorEnabled = prevColor }()
+
+	// color enabled: should be a full-width dim '─' rule.
+	colorEnabled = true
+	got := renderUserSeparator(40)
+	plain := ansi.Strip(got)
+	if w := ansi.StringWidth(plain); w != 40 {
+		t.Fatalf("color separator should be width 40, got width %d text=%q", w, plain)
+	}
+	if !strings.HasPrefix(plain, "─") || strings.ContainsRune(plain, '-') {
+		t.Fatalf("color separator should be all '─' runes, got %q", plain)
+	}
+	if got == plain {
+		t.Fatalf("color separator should carry a dim SGR escape, got plain text %q", got)
+	}
+
+	// color disabled: should fall back to ASCII '-' and be un-styled.
+	colorEnabled = false
+	got = renderUserSeparator(40)
+	plain = ansi.Strip(got)
+	if plain != strings.Repeat("-", 40) {
+		t.Fatalf("ascii separator should be 40 '-', got %q", plain)
+	}
+	if got != plain {
+		t.Fatalf("ascii separator should be un-styled, got %q", got)
+	}
+
+	// width <= 0 should yield an empty string in both modes.
+	if got := renderUserSeparator(0); got != "" {
+		t.Fatalf("separator with width 0 should be empty, got %q", got)
+	}
+}
+
+func TestRenderUserBubbleBlockEmitsThreeLines(t *testing.T) {
+	prevColor := colorEnabled
+	colorEnabled = true
+	defer func() { colorEnabled = prevColor }()
+
+	top, bubble, bottom := renderUserBubbleBlock("hi", false)
+
+	// Middle must still be the plain user bubble (regression guard for
+	// TestUserBubbleIsLightweightTranscriptLine).
+	if plain := ansi.Strip(bubble); !strings.Contains(plain, "› hi") {
+		t.Fatalf("block's middle should contain the prompt text, got %q", plain)
+	}
+	if renderUserBubble("hi", 0, false) != bubble {
+		t.Fatalf("block's bubble should equal renderUserBubble output exactly")
+	}
+
+	// Both separators should be the userSeparatorToken placeholder, equal to
+	// each other, and tiny (so the committed transcript stays compact and
+	// the rule is filled in at render time by expandSeparatorTokens).
+	if top == "" || bottom == "" {
+		t.Fatalf("separators should be the token, not empty, top=%q bottom=%q", top, bottom)
+	}
+	if top != userSeparatorToken || bottom != userSeparatorToken {
+		t.Fatalf("separators should equal userSeparatorToken, top=%q bottom=%q", top, bottom)
+	}
+	if top != bottom {
+		t.Fatalf("top and bottom should be the same token, top=%q bottom=%q", top, bottom)
+	}
+}
+
+func TestUserBubbleCommitPathIncludesSeparators(t *testing.T) {
+	m := newTestChatTUI()
+	m.bubbleStartIdx = len(m.transcript)
+	top, bubble, bottom := renderUserBubbleBlock("hello world", m.planMode)
+	m.commitLine(top)
+	m.commitLine(bubble)
+	m.commitLine(bottom)
+
+	if len(m.transcript)-m.bubbleStartIdx != 3 {
+		t.Fatalf("expected 3 transcript entries (top/bubble/bottom), got %d (transcript=%v)",
+			len(m.transcript)-m.bubbleStartIdx, m.transcript[m.bubbleStartIdx:])
+	}
+	got := m.transcript[m.bubbleStartIdx:]
+	if got[0] != userSeparatorToken || got[1] != bubble || got[2] != userSeparatorToken {
+		t.Fatalf("transcript entries should be token/bubble/token, got %v", got)
+	}
+	if !strings.Contains(strings.Join(got, "\n"), "hello world") {
+		t.Fatalf("bubble line should still contain the prompt, got %v", got)
+	}
+	// No standalone empty line should be emitted between the previous turn and
+	// the new top separator.
+	for _, ln := range m.transcript[:m.bubbleStartIdx] {
+		if ln == "" {
+			// allowed, but no *new* empty line should be added by the submit
+			// path itself — this loop just confirms the leading entries are
+			// untouched.
+		}
+	}
+}
+
 // TestUnsendDiscardsBufferedEvents proves that after an un-send (Esc before any
 // packet) the turn's already-buffered events are swallowed — nothing reaches
 // scrollback — and its TurnDone settles the model back to idle.

--- a/internal/cli/transcript.go
+++ b/internal/cli/transcript.go
@@ -22,6 +22,62 @@ func wrapTranscript(s string, width int) string {
 	return lipgloss.NewStyle().Width(width).Render(s)
 }
 
+// renderUserSeparator returns a full-width dim horizontal rule used as a
+// scroll anchor above and below a committed user bubble. The rule is rendered
+// as a real transcript line (not a viewport background) so it scrolls with
+// the content, participates in wrapTranscript, and re-appears in resumed
+// sessions via the replay path. ASCII '-' is the no-color fallback so the
+// rule remains visible when the terminal is monochrome — matching the
+// conventions in md.go (markdown hr) and chooser.go (picker separator).
+func renderUserSeparator(width int) string {
+	if width <= 0 {
+		return ""
+	}
+	ch := "─"
+	if !colorEnabled {
+		ch = "-"
+	}
+	line := strings.Repeat(ch, width)
+	if colorEnabled {
+		line = dim(line)
+	}
+	return line
+}
+
+// userSeparatorToken is a tiny placeholder committed to the transcript in
+// place of an actual user-bubble separator. It is replaced by a real
+// renderUserSeparator(width) call at render time, so the rule always spans
+// the *current* viewport width — surviving terminal resizes, replays at a
+// different width, and any code path that reads back historical transcript
+// entries. The NUL-byte framing + a Private-Use-Area code point keeps the
+// token visually invisible and extremely unlikely to appear in real content.
+const userSeparatorToken = "\x00\uE000"
+
+// renderUserSeparatorToken returns the placeholder that should be committed
+// to the transcript in place of a real separator. Pair with
+// expandSeparatorTokens at render time.
+func renderUserSeparatorToken() string { return userSeparatorToken }
+
+// expandSeparatorTokens walks transcript entries and replaces every
+// occurrence of userSeparatorToken with a freshly rendered renderUserSeparator
+// of the given width. width <= 0 collapses the token to an empty string,
+// matching renderUserSeparator's own degradation. Entries with no token are
+// returned untouched, so non-separator lines pay no per-frame cost.
+func expandSeparatorTokens(lines []string, width int) []string {
+	if len(lines) == 0 {
+		return lines
+	}
+	out := make([]string, len(lines))
+	sep := renderUserSeparator(width)
+	for i, ln := range lines {
+		for strings.Contains(ln, userSeparatorToken) {
+			ln = strings.Replace(ln, userSeparatorToken, sep, 1)
+		}
+		out[i] = ln
+	}
+	return out
+}
+
 // clipboardWriteAll is the platform clipboard writer; a var so tests can force
 // the failure path (the tmux / SSH scenario) without a real display server.
 var clipboardWriteAll = clipboard.WriteAll


### PR DESCRIPTION
🤖 Generated by AI (CnsMaple + Reasonix)

## Problem

When mouse-scrolling back to find an older turn in the chat transcript, the
user's submitted prompt is hard to spot. The assistant's markdown reply ends
without a strong visual edge into the user bubble, so the eye has to hunt
through dense, dimmed text to find the `› …` line. This is a small but real
ergonomic pain on long sessions.

## Fix

A full-width dim `─` rule above and below each committed user bubble. The
rule frames the bubble and acts as a scroll anchor — when you scroll up
through an older turn, the two rules bracket the user's input cleanly.

The rule is **committed as a tiny placeholder token** (NUL + U+E000 + NUL)
and expanded to a real `renderUserSeparator(width)` call at wrap time, so
it always spans the *current* viewport width. Terminal resizes, replays at
a different width, and any other rewrap pick up the new width with no
re-commit.

## What changed

- `internal/cli/transcript.go`
  - New `userSeparatorToken` constant, `renderUserSeparatorToken()` factory,
    and `expandSeparatorTokens(lines, width)` expander. The expander walks
    transcript entries and replaces every token with a freshly rendered
    `renderUserSeparator(width)`, so resize is implicit.
  - `renderUserSeparator(width int) string` is kept as a public helper for
    direct use; it falls back to ASCII `-` when `colorEnabled` is false and
    to `""` when `width <= 0`.
- `internal/cli/chat_tui.go`
  - `wrapTranscript` is now preceded by `expandSeparatorTokens(cm.transcript,
    contentW)` on every transcript change — one insertion at the call site.
  - `renderUserBubbleBlock` now returns the token form (no `width`
    parameter) and is reused by both the submit path (`chat_tui.go:3180`)
    and the replay path (`replaySectionsFor`).
  - `renderUserBubble` is untouched; the regression guard
    `TestUserBubbleIsLightweightTranscriptLine` still passes.

## Tests

- `TestRenderUserSeparatorIsFullWidthAndDimmed` — covers color/ASCII paths
  and `width <= 0`.
- `TestRenderUserBubbleBlockEmitsThreeLines` — middle line is unchanged;
  separators are the token.
- `TestUserBubbleCommitPathIncludesSeparators` — three transcript entries
  after a submit, top/bottom are tokens.
- `TestUserBubbleBlockScrollsAsThreeLines` — full pipeline
  `expandSeparatorTokens → wrapTranscript`; top/bottom are exactly
  content-width cells.
- `TestSeparatorTokenAdaptsToResize` — same token-form transcript rendered
  at width 60 and width 100 produces rules of the matching widths and the
  wider one contains strictly more `─` runes (anti-cache guard).

## Notes

- The rule is a real transcript entry, **not** a viewport background, so it
  scrolls with the content and survives resumed sessions through the replay
  path. Historical sessions are not backfilled — only turns submitted after
  this change pick up the rule, matching the "rendering change" semantics.
- No new state, no new key bindings, no UI surface change outside the
  transcript. The user bubble itself is unchanged.
- AI-assisted implementation, reviewed manually by the author.
