### PR TITLE
fix(desktop): new session inherits settings from active tab (#4019, #4088)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -961,6 +961,7 @@ func (a *App) Fork(turn int) (TabMeta, error) {
 	model := sourceTab.model
 	effort := cloneStringPtr(sourceTab.effort)
 	mode := currentTabMode(sourceTab)
+	toolApprovalMode := currentTabToolApprovalMode(sourceTab)
 	disabledMCP := cloneServerViewMap(sourceTab.disabledMCP)
 	mcpOrder := append([]string(nil), sourceTab.mcpOrder...)
 	a.mu.RUnlock()
@@ -990,17 +991,18 @@ func (a *App) Fork(turn int) (TabMeta, error) {
 	a.mu.Lock()
 	tabID := a.newUniqueTabIDLocked()
 	tab := &WorkspaceTab{
-		ID:            tabID,
-		Scope:         scope,
-		WorkspaceRoot: workspaceRoot,
-		TopicID:       topicID,
-		TopicTitle:    topicTitle,
-		SessionPath:   newPath,
-		model:         model,
-		effort:        effort,
-		mode:          mode,
-		disabledMCP:   disabledMCP,
-		mcpOrder:      mcpOrder,
+		ID:               tabID,
+		Scope:            scope,
+		WorkspaceRoot:    workspaceRoot,
+		TopicID:          topicID,
+		TopicTitle:       topicTitle,
+		SessionPath:      newPath,
+		model:            model,
+		effort:           effort,
+		mode:             mode,
+		toolApprovalMode: toolApprovalMode,
+		disabledMCP:      disabledMCP,
+		mcpOrder:         mcpOrder,
 	}
 	tab.sink = &tabEventSink{tabID: tabID, app: a}
 	a.tabs[tabID] = tab

--- a/desktop/new_session_inherit_test.go
+++ b/desktop/new_session_inherit_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/control"
+)
+
+func TestEnsureBlankTabInheritsActiveTabSettings(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	workspace := robustTempDir(t)
+	if err := os.WriteFile(filepath.Join(workspace, "reasonix.toml"),
+		[]byte("[codegraph]\nenabled = false\n"), 0o644); err != nil {
+		t.Fatalf("write workspace config: %v", err)
+	}
+
+	effort := "max"
+	app := NewApp()
+	src := &WorkspaceTab{
+		ID:               "src",
+		Scope:            "project",
+		WorkspaceRoot:    workspace,
+		TopicID:          "topic_src",
+		SessionPath:      filepath.Join(workspace, "src.jsonl"), // non-empty so src isn't reused as the blank tab
+		model:            "inherit/model",
+		effort:           &effort,
+		mode:             "plan",
+		toolApprovalMode: control.ToolApprovalYolo,
+		disabledMCP:      map[string]ServerView{"srv-x": {}},
+		mcpOrder:         []string{"srv-x", "srv-y"},
+	}
+	src.sink = &tabEventSink{tabID: "src", app: app}
+	app.tabs["src"] = src
+	app.tabOrder = []string{"src"}
+	app.activeTabID = "src"
+
+	meta, err := app.EnsureBlankTab("project", workspace)
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if meta.ID == "" || meta.ID == "src" {
+		t.Fatalf("expected a fresh tab, got meta.ID=%q", meta.ID)
+	}
+
+	created := app.tabs[meta.ID]
+	if created == nil {
+		t.Fatalf("new tab %q missing from app.tabs", meta.ID)
+	}
+	if created.effort == nil || *created.effort != "max" {
+		t.Fatalf("effort = %v, want inherited \"max\"", created.effort)
+	}
+	if created.toolApprovalMode != control.ToolApprovalYolo {
+		t.Fatalf("toolApprovalMode = %q, want inherited %q", created.toolApprovalMode, control.ToolApprovalYolo)
+	}
+	if created.mode != "plan" {
+		t.Fatalf("mode = %q, want inherited \"plan\"", created.mode)
+	}
+	if _, ok := created.disabledMCP["srv-x"]; !ok {
+		t.Fatalf("disabledMCP = %v, want inherited key \"srv-x\"", created.disabledMCP)
+	}
+	if len(created.mcpOrder) != 2 || created.mcpOrder[0] != "srv-x" {
+		t.Fatalf("mcpOrder = %v, want inherited [srv-x srv-y]", created.mcpOrder)
+	}
+}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -603,6 +603,13 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 	}
 
 	var created *WorkspaceTab
+	// Compute actual root early — both the indexed-topic fallback and the
+	// new-topic path need it when constructing the tab below.
+	actualRoot := workspaceRoot
+	if scope == "global" {
+		actualRoot = globalRoot
+	}
+
 	a.mu.Lock()
 	for _, id := range a.orderedTabIDsLocked() {
 		tab := a.tabs[id]
@@ -615,12 +622,53 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		}
 	}
 
+	// Inherit model, effort, mode, tool-approval, and MCP state from the
+	// active tab so a new blank session keeps the same settings (#4019).
+	var inheritedModel string
+	var inheritedEffort *string
+	inheritedMode := "normal"
+	inheritedToolApprovalMode := control.ToolApprovalAsk
+	inheritedDisabledMCP := map[string]ServerView{}
+	var inheritedMCPOrder []string
+	if active := a.activeTabLocked(); active != nil {
+		inheritedModel = active.model
+		inheritedEffort = cloneStringPtr(active.effort)
+		inheritedMode = currentTabMode(active)
+		inheritedToolApprovalMode = currentTabToolApprovalMode(active)
+		inheritedDisabledMCP = cloneServerViewMap(active.disabledMCP)
+		inheritedMCPOrder = append([]string(nil), active.mcpOrder...)
+	}
+
 	if topicID := a.indexedBlankTopicIDLocked(scope, workspaceRoot); topicID != "" {
-		a.mu.Unlock()
-		if scope == "global" {
-			return a.OpenGlobalTab(topicID)
+		// Reuse a previously-indexed but unused blank topic instead of
+		// creating a new one.  Build it inline (not via OpenProjectTab /
+		// OpenGlobalTab) so it inherits settings from the active tab.
+		tabID := a.newUniqueTabIDLocked()
+		topicTitle := topicTitleForTab(scope, workspaceRoot, topicID)
+		created = &WorkspaceTab{
+			ID:               tabID,
+			Scope:            scope,
+			WorkspaceRoot:    actualRoot,
+			TopicID:          topicID,
+			TopicTitle:       topicTitle,
+			model:            inheritedModel,
+			effort:           inheritedEffort,
+			mode:             inheritedMode,
+			toolApprovalMode: inheritedToolApprovalMode,
+			disabledMCP:      inheritedDisabledMCP,
+			mcpOrder:         inheritedMCPOrder,
 		}
-		return a.OpenProjectTab(workspaceRoot, topicID)
+		created.sink = &tabEventSink{tabID: tabID, app: a}
+		a.tabs[tabID] = created
+		a.tabOrder = append(a.tabOrder, tabID)
+		a.activeTabID = tabID
+		a.saveTabsLocked()
+		meta := a.tabMeta(created, true)
+		a.mu.Unlock()
+
+		a.startTabControllerBuild(created)
+		a.emitProjectTreeChanged()
+		return meta, nil
 	}
 
 	topicID := newTopicID()
@@ -644,19 +692,18 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 	}
 
 	tabID := a.newUniqueTabIDLocked()
-	actualRoot := workspaceRoot
-	if scope == "global" {
-		actualRoot = globalRoot
-	}
 	created = &WorkspaceTab{
 		ID:               tabID,
 		Scope:            scope,
 		WorkspaceRoot:    actualRoot,
 		TopicID:          topicID,
 		TopicTitle:       topicTitleForTab(scope, workspaceRoot, topicID),
-		mode:             "normal",
-		toolApprovalMode: control.ToolApprovalAsk,
-		disabledMCP:      map[string]ServerView{},
+		model:            inheritedModel,
+		effort:           inheritedEffort,
+		mode:             inheritedMode,
+		toolApprovalMode: inheritedToolApprovalMode,
+		disabledMCP:      inheritedDisabledMCP,
+		mcpOrder:         inheritedMCPOrder,
 	}
 	created.sink = &tabEventSink{tabID: tabID, app: a}
 	a.tabs[tabID] = created


### PR DESCRIPTION
Lands @JesonChou's fix from #4087 (via origin so required checks run on the protected branch) plus a regression test.

## Fix (by @JesonChou, #4087)

Clicking "New Session" / the "+" tab button created a blank tab with hardcoded defaults instead of carrying over the active tab's model, effort, mode, tool-approval, and MCP state.

- `EnsureBlankTab` now inherits model / effort / mode / `toolApprovalMode` / `disabledMCP` / `mcpOrder` from the active tab, falling back to the old defaults only on first launch (no active tab).
- The indexed-blank-topic reuse path builds the tab inline instead of delegating to `OpenProjectTab` / `OpenGlobalTab`, which carried their own hardcoded defaults — so that bypass no longer drops the inherited settings.
- `Fork` gained the missing `toolApprovalMode` carry-over (forks previously reverted to "ask").

## Added test

`desktop/new_session_inherit_test.go` asserts a blank tab opened from an active session inherits effort, mode, tool-approval, and MCP state instead of falling back to defaults. Mutation-checked — disabling the inherit block fails the test.

Closes #4087
Closes #4019
Closes #4088
