### PR TITLE
fix(desktop): keep thinking, answers, and writer output visible in compact view

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -333,15 +333,14 @@ export function TurnActions({
 export const AssistantMessage = memo(function AssistantMessage({
   item,
   defaultExpanded = false,
-  expandWhileStreaming = true,
 }: {
   item: AssistantItem;
   defaultExpanded?: boolean;
-  /** false in compact/minimal: completed steps fold away, so auto-open + fold reads as flicker. */
-  expandWhileStreaming?: boolean;
 }) {
   const t = useT();
-  const [reasoningOpen, setReasoningOpen] = useState((expandWhileStreaming && item.streaming) || defaultExpanded);
+  // Thinking streams in before the answer — show it live while the model is still
+  // working, then it stays available behind the toggle once the answer arrives.
+  const [reasoningOpen, setReasoningOpen] = useState(item.streaming || defaultExpanded);
   const hasText = item.streaming || item.text.trim() !== "";
   const processOnly = Boolean(item.reasoning) && !hasText;
   const processWithText = Boolean(item.reasoning) && hasText;

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { ChevronRight } from "lucide-react";
 import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
@@ -59,15 +59,25 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   const shellOutput = item.isShell && item.output ? item.output : null;
   const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
   const hasBody = Boolean(diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error);
-  const [open, setOpen] = useState(hasNested ? item.status === "running" : false);
+  // Writers keep their output/diff visible by default (don't make the user expand
+  // to see what a command produced); read-only research folds away. Sub-agents open
+  // while running so nested calls are visible. A click (or Ctrl/Cmd+B) overrides.
+  const defaultOpen = hasNested
+    ? item.status === "running"
+    : Boolean(item.error) || (!item.readOnly && (diffs.length > 0 || !!item.output));
+  const [userOpen, setUserOpen] = useState<boolean | null>(null);
+  const open = userOpen ?? defaultOpen;
+  const openRef = useRef(open);
+  openRef.current = open;
   const [showAll, setShowAll] = useState(false);
 
   // Register this shell card's toggle with the global ShellExpand context so
-  // Ctrl/Cmd+B can expand/collapse the most recent shell output.
+  // Ctrl/Cmd+B can expand/collapse the most recent shell output. openRef keeps the
+  // registered closure flipping the current state, not a stale one.
   const shellExpand = useShellExpand();
   useEffect(() => {
     if (!item.isShell || !shellExpand) return;
-    return shellExpand.register(item.id, () => setOpen((v) => !v));
+    return shellExpand.register(item.id, () => setUserOpen(!openRef.current));
   }, [item.isShell, item.id, shellExpand]);
 
   // Read-only "research" calls (read/grep/ls/glob/web_fetch) are hidden after
@@ -84,7 +94,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
         type="button"
         className="tool__head"
         data-running={item.status === "running" ? "" : undefined}
-        onClick={() => hasBody && setOpen((v) => !v)}
+        onClick={() => hasBody && setUserOpen(!open)}
         aria-expanded={hasBody ? open : undefined}
       >
         <span className="tool__label-group">

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -34,10 +34,10 @@ type QuestionAnchor = { id: string; text: string; turn: number };
 const QUESTION_NAV_MIN_COUNT = 2;
 const LiveStreamContext = createContext<LiveStream | undefined>(undefined);
 
-const LiveAssistantMessage = memo(function LiveAssistantMessage({ item, defaultExpanded = false, expandWhileStreaming = true }: { item: AssistantItem; defaultExpanded?: boolean; expandWhileStreaming?: boolean }) {
+const LiveAssistantMessage = memo(function LiveAssistantMessage({ item, defaultExpanded = false }: { item: AssistantItem; defaultExpanded?: boolean }) {
   const live = useContext(LiveStreamContext);
   const shown = live && live.id === item.id ? { ...item, text: live.text, reasoning: live.reasoning, streaming: true } : item;
-  return <AssistantMessage item={shown} defaultExpanded={defaultExpanded} expandWhileStreaming={expandWhileStreaming} />;
+  return <AssistantMessage item={shown} defaultExpanded={defaultExpanded} />;
 });
 
 // ── Layer budgets ─────────────────────────────────────────────────────────────
@@ -358,47 +358,6 @@ export function Transcript({
   // (added by upstream PR #3423) instead of per-call renderSegments.
   const empty = items.length === 0;
 
-  // In compact/minimal mode, break each turn into step groups.
-  // A step = one assistant + its tool results, from one assistant to the next.
-  // Each completed non-final step is folded into "Processed".
-  const stepGroups = useMemo(() => {
-    if (displayMode === "standard") return null;
-    const groups: { items: Item[]; isFinal: boolean; isComplete: boolean }[] = [];
-    let current: Item[] = [];
-
-    for (let i = hotStartIdx; i < items.length; i++) {
-      const it = items[i];
-      if (it.kind === "user") {
-        // Close pending group — if it's a non-streaming text assistant it's the final answer
-        if (current.length > 0) {
-          const first = current[0];
-          const isFinal = first.kind === "assistant" && !first.streaming && first.text.trim() !== "";
-          groups.push({ items: current, isFinal, isComplete: true });
-          current = [];
-        }
-        groups.push({ items: [it], isFinal: false, isComplete: true });
-        continue;
-      }
-      if (it.kind === "assistant") {
-        if (current.length > 0) {
-          // Previous step is complete — a new assistant has appeared
-          groups.push({ items: current, isFinal: false, isComplete: true });
-          current = [];
-        }
-        current.push(it);
-      } else {
-        current.push(it);
-      }
-    }
-    // Last group in progress
-    if (current.length > 0) {
-      const first = current[0];
-      const isFinal = first.kind === "assistant" && !first.streaming && first.text.trim() !== "";
-      groups.push({ items: current, isFinal, isComplete: false });
-    }
-    return groups;
-  }, [displayMode, hotStartIdx, items]);
-
   const hotZoneNodes = useMemo<ReactNode[]>(() => {
     const out: ReactNode[] = [];
     let actionText = "";
@@ -428,126 +387,65 @@ export function Transcript({
       actionReady = false;
     };
 
-    if (stepGroups) {
-      // Compact/minimal mode: step-based rendering
-      // Collect consecutive completed non-final steps into batches
-      let collapseBatch: Item[] = [];
-      let collapseBatchStart: string | null = null;
-      const flushCollapseBatch = () => {
-        if (collapseBatch.length === 0) return;
-        const dur = collapseBatch.reduce((ms, it) => ms + (it.kind === "tool" ? it.durationMs ?? 0 : 0), 0);
-        out.push(
-          <TurnCollapse
-            key={`step-batch-${collapseBatchStart}`}
-            items={collapseBatch}
-            durationMs={dur}
-            mode={displayMode}
-            subcalls={subcallsByParent}
-          />,
-        );
-        collapseBatch = [];
-        collapseBatchStart = null;
-      };
+    // Compact/minimal: completed read-only research folds into a slim batch so a
+    // long run of reads stays quiet; running reads, writers, and the model's own
+    // text + thinking render directly so the turn's substance stays visible.
+    // Standard: flat, no batching. The warm zone (WarmTurnItems) renders the same way.
+    const batchReadOnly = displayMode !== "standard";
+    const roBatch: ToolItem[] = [];
+    const flushRO = () => {
+      if (roBatch.length === 0) return;
+      out.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={subcallsByParent} />);
+      roBatch.length = 0;
+    };
 
-      for (const group of stepGroups) {
-        const first = group.items[0];
-
-        // User message
-        if (first.kind === "user") {
-          flushCollapseBatch();
+    for (let i = hotStartIdx; i < items.length; i++) {
+      const it = items[i];
+      if (
+        batchReadOnly &&
+        it.kind === "tool" &&
+        !it.parentId &&
+        it.status !== "running" &&
+        it.name !== "todo_write" &&
+        it.name !== "exit_plan_mode" &&
+        isReadOnlyTool(it.name)
+      ) {
+        roBatch.push(it as ToolItem);
+        continue;
+      }
+      flushRO();
+      switch (it.kind) {
+        case "user": {
           pushTurnActions();
-          const tn = userTurn.get(first.id);
+          const tn = userTurn.get(it.id);
           activeTurn = tn;
           out.push(
-            <UserMessage key={first.id} text={first.text} failed={first.failed} turn={tn} anchorId={questionAnchorId(first.id)} />,
+            <UserMessage key={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
           );
-          continue;
+          break;
         }
-
-        // Completed non-final step → batch it
-        if (group.isComplete && !group.isFinal && displayMode !== "standard") {
-          if (!collapseBatchStart) collapseBatchStart = first.id;
-          collapseBatch.push(...group.items);
-          continue;
-        }
-
-        // Final answer or active step → flush any pending batch then render
-        flushCollapseBatch();
-        // Separate non-assistant items (tools, phase) from the final answer
-        const nonAssistantItems = group.items.filter(
-          (it) => it.kind !== "assistant" || (it.streaming && !it.text.trim())
-        );
-        // If the step has running tools, render them directly (visible in progress)
-        const hasRunning = nonAssistantItems.some((it) => it.kind === "tool" && it.status === "running");
-        if (nonAssistantItems.length > 0 && !hasRunning) {
-          const dur = nonAssistantItems.reduce((ms, it) => ms + (it.kind === "tool" ? ((it as ToolItem).durationMs ?? 0) : 0), 0);
-          out.push(
-            <TurnCollapse
-              key={`step-${first.id}`}
-              items={nonAssistantItems}
-              durationMs={dur}
-              mode={displayMode}
-              subcalls={subcallsByParent}
-            />,
-          );
-        } else if (nonAssistantItems.length > 0) {
-          for (const it of nonAssistantItems) {
-            if (it.kind === "tool") {
-              if (it.parentId) continue;
-              if (it.name === "todo_write" || it.name === "exit_plan_mode") continue;
-              out.push(<ToolCard key={it.id} item={it as ToolItem} subcalls={subcallsByParent.get(it.id)} />);
-            }
-            if (it.kind === "phase") out.push(<PhaseCard key={it.id} text={it.text} />);
-          }
-        }
-        // Render the final assistant message (if any) directly
-        for (const it of group.items) {
-          if (it.kind !== "assistant") continue;
-          out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} expandWhileStreaming={false} />);
+        case "assistant":
+          out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} />);
           if (!it.streaming && it.text.trim() !== "") {
             actionText = it.text;
             actionReady = true;
           }
-        }
+          break;
+        case "tool":
+          if (it.parentId) break;
+          if (it.name === "todo_write") break;
+          if (it.name === "exit_plan_mode") break;
+          out.push(<ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />);
+          break;
+        case "phase": out.push(<PhaseCard key={it.id} text={it.text} />); break;
+        case "notice": out.push(<NoticeCard key={it.id} level={it.level} text={it.text} />); break;
+        case "compaction": out.push(<CompactionCard key={it.id} item={it} />); break;
       }
-      flushCollapseBatch();
-      pushTurnActions();
-    } else {
-      // Standard mode: flat rendering
-      for (let i = hotStartIdx; i < items.length; i++) {
-        const it = items[i];
-        switch (it.kind) {
-          case "user": {
-            pushTurnActions();
-            const tn = userTurn.get(it.id);
-            activeTurn = tn;
-            out.push(
-              <UserMessage key={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
-            );
-            break;
-          }
-          case "assistant":
-            out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} />);
-            if (!it.streaming && it.text.trim() !== "") {
-              actionText = it.text;
-              actionReady = true;
-            }
-            break;
-          case "tool":
-            if (it.parentId) break;
-            if (it.name === "todo_write") break;
-            if (it.name === "exit_plan_mode") break;
-            out.push(<ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />);
-            break;
-          case "phase": out.push(<PhaseCard key={it.id} text={it.text} />); break;
-          case "notice": out.push(<NoticeCard key={it.id} level={it.level} text={it.text} />); break;
-          case "compaction": out.push(<CompactionCard key={it.id} item={it} />); break;
-        }
-      }
-      pushTurnActions();
     }
+    flushRO();
+    pushTurnActions();
     return out;
-  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups]);
+  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, defaultExpandThinking]);
 
   // ── Assemble rendered output ──────────────────────────────────────────────
   // Warm/cold zone is a separate memo'd WarmZone component so streaming tokens
@@ -872,90 +770,6 @@ function WarmTurnCard({
       )}
     </div>
   );
-}
-
-
-type TurnCollapseProps = {
-  items: Item[];       // intermediate items (tools, reasoning, phase)
-  durationMs: number;  // summed tool execution time across the batch; 0 when unknown
-  mode: DisplayMode;
-  subcalls: Map<string, ToolItem[]>;
-};
-
-function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) {
-  const t = useT();
-  const [open, setOpen] = useState(false);
-
-  // Keep only items the body will actually render — an expandable fold over
-  // nothing is worse than no fold. Minimal mode strips reasoning, so a
-  // reasoning-only assistant counts as empty there.
-  const displayItems = useMemo(() => {
-    return items.filter((it) => {
-      if (it.kind === "assistant") {
-        if (it.text.trim() !== "") return true;
-        return mode !== "minimal" && Boolean(it.reasoning);
-      }
-      if (it.kind === "phase") return mode !== "minimal";
-      if (it.kind !== "tool") return false;
-      if (it.parentId || it.name === "todo_write" || it.name === "exit_plan_mode") return false;
-      if (mode === "minimal") return it.name !== "bash";
-      return true;
-    });
-  }, [items, mode]);
-
-  const seconds = Math.round(durationMs / 1000);
-  const label = seconds > 0 ? t("transcript.processedDuration", { s: seconds }) : t("transcript.processed");
-
-  if (displayItems.length === 0) return null;
-
-  // Pre-compute body: group consecutive completed read-only tools into ReadOnlyBatch
-  const body: ReactNode[] = [];
-  const roBatch: ToolItem[] = [];
-  const flushRO = () => {
-    if (roBatch.length === 0) return;
-    body.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={subcalls} />);
-    roBatch.length = 0;
-  };
-  for (const it of displayItems) {
-    if (it.kind === "tool" && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode" && it.status !== "running" && isReadOnlyTool(it.name)) {
-      roBatch.push(it as ToolItem);
-      continue;
-    }
-    flushRO();
-    switch (it.kind) {
-      case "tool":
-        if (it.parentId) break;
-        if (it.name === "todo_write") break;
-        if (it.name === "exit_plan_mode") break;
-        body.push(<ToolCard key={it.id} item={it as ToolItem} subcalls={subcalls.get(it.id)} />);
-        break;
-      case "phase": body.push(<PhaseCard key={it.id} text={it.text} />); break;
-      case "assistant": {
-        const displayItem = mode === "minimal" ? { ...it, reasoning: "" } : it;
-        body.push(<AssistantMessage key={it.id} item={displayItem as AssistantItem} />);
-        break;
-      }
-    }
-  }
-  flushRO();
-
-  return (
-    <div className={`turn-collapse${open ? " turn-collapse--open" : ""}`}>
-      <button
-        type="button"
-        className="reasoning__head"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-      >
-        <ChevronRight className={`reasoning__chevron${open ? " reasoning__chevron--open" : ""}`} size={12} />
-        <span className="turn-collapse__label">{label}</span>
-      </button>
-      {open && (
-        <div className="turn-collapse__body">{body}</div>
-      )}
-    </div>
-  );
-
 }
 
 // ── JumpBar, PhaseCard, NoticeCard, CompactionCard ────────────────────────────

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1052,8 +1052,6 @@ export const en = {
   "transcript.toolCount": "{n} tools",
   "notice.info": "Notice",
   "notice.warning": "Warning",
-  "transcript.processed": "Processed",
-  "transcript.processedDuration": "Processed {s}s",
   "questionNav.label": "Question navigation",
   "questionNav.progress": "Question {current} / {total}",
   "questionNav.jump": "Jump to question {n}",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1054,8 +1054,6 @@ export const zh: Record<DictKey, string> = {
   "transcript.toolCount": "{n} 个工具",
   "notice.info": "提示",
   "notice.warning": "警告",
-  "transcript.processed": "已处理",
-  "transcript.processedDuration": "已处理 {s}s",
   "questionNav.label": "问题导航",
   "questionNav.progress": "问题 {current} / {total}",
   "questionNav.jump": "跳转到问题 {n}",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2632,23 +2632,6 @@ a[href] {
   word-break: break-word;
 }
 
-/* ── TurnCollapse (compact/minimal mode) ─────────────────────────── */
-.turn-collapse {
-  /* horizontal auto keeps the .transcript > * centered column; 0 would override it */
-  margin: 4px auto;
-}
-.turn-collapse__label {
-  white-space: nowrap;
-}
-.turn-collapse__body {
-  margin-top: 6px;
-  padding-left: 12px;
-  border-left: 2px solid var(--border);
-}
-.turn-collapse__body > * {
-  margin-bottom: 6px;
-}
-
 /* ── ReadOnly batch (parent fold for read/search tools) ────────────── */
 .readonly-batch {
   margin: 2px auto;


### PR DESCRIPTION
## Summary

Follow-up to #4059. In compact/minimal mode the transcript folded every completed step into a "Processed" block, which hid the substance of a turn:

- **Thinking** was never shown live (the active step rendered with `expandWhileStreaming={false}`), and minimal mode stripped reasoning from completed steps entirely.
- **Answer text** the model wrote between tool calls got buried in the fold.
- **Writer output** was hidden behind an expand, and minimal mode stripped completed `bash` cards outright.

Only read-only *research* (read/grep/glob/ls/web_fetch) should fold to keep a long run of reads quiet. Everything else is the substance the user wants visible.

## Changes

- **Transcript hot zone** now renders the way the warm zone (`WarmTurnItems`) already does: flat, batching only *completed* read-only tools into `ReadOnlyBatch`. Running tools, writers, and assistant text/thinking render directly. Removes the `stepGroups` + `TurnCollapse` step-fold machinery (net -175 lines).
- **Thinking shows live**: dropped the `expandWhileStreaming` flag (it only existed to mask the now-gone fold flicker); reasoning auto-opens while streaming, then stays available behind the toggle once the answer arrives.
- **Writers keep their output**: `ToolCard` opens by default for non-read-only tools that produced a diff or output (and for any errored tool), so you see what a command did without expanding. Read-only research stays folded. Sub-agent cards still open while running. Manual toggle / Ctrl+B still override.
- Removed the orphaned `TurnCollapse` CSS and the `transcript.processed*` i18n keys.

## Behavior by mode

| | thinking | answer text | writer output | read-only |
|---|---|---|---|---|
| **standard** | toggle | visible | visible by default | folded card |
| **compact / minimal** | live while streaming, then toggle | visible | visible by default | batched fold |

Compact and minimal now behave the same (both show substance + batch reads); collapsing the two modes can be a separate follow-up.

## Test status

- `tsc --noEmit` clean for the changed files (local env still reports the usual `wailsjs` / new-dep gaps that CI resolves via `wails generate` + a fresh install).
- No frontend test imports the changed components.
