### PR TITLE
fix(provider): retry transient 401s for a known-good key + clearer auth error (#3146)

### DIFF
--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -29,9 +29,9 @@ func explainError(err error) error {
 	}
 	var authErr *provider.AuthError
 	if errors.As(err, &authErr) {
-		msg := i18n.M.ProviderStatusMessage(authErr.Status)
-		if msg == "" {
-			return err
+		msg := i18n.M.ProviderErrAuth
+		if authErr.HasKey {
+			msg = i18n.M.ProviderErrAuthRejected
 		}
 		if authErr.KeyEnv != "" {
 			return fmt.Errorf("%s (%s)", msg, authErr.KeyEnv)

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -23,6 +23,17 @@ func TestExplainError(t *testing.T) {
 	if !strings.Contains(auth.Error(), "DEEPSEEK_API_KEY") {
 		t.Errorf("401 should name the key env: %q", auth.Error())
 	}
+	if !strings.Contains(auth.Error(), i18n.M.ProviderErrAuth) {
+		t.Errorf("401 without a key should use the missing-key message: %q", auth.Error())
+	}
+
+	rejected := explainError(&provider.AuthError{Provider: "mimo", KeyEnv: "MIMO_API_KEY", Status: 401, HasKey: true})
+	if !strings.Contains(rejected.Error(), i18n.M.ProviderErrAuthRejected) {
+		t.Errorf("401 with a key present should use the server-rejected message: %q", rejected.Error())
+	}
+	if !strings.Contains(rejected.Error(), "MIMO_API_KEY") {
+		t.Errorf("401 should still name the key env: %q", rejected.Error())
+	}
 
 	for _, status := range []int{400, 422, 429, 500, 503} {
 		got := explainError(&provider.APIError{Provider: "p", Status: status})

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -348,7 +348,8 @@ type Messages struct {
 
 	// provider HTTP error explanations — actionable, reason + fix per status code
 	ProviderErrBadRequest          string // 400
-	ProviderErrAuth                string // 401
+	ProviderErrAuth                string // 401 — no key configured / sent
+	ProviderErrAuthRejected        string // 401 — a key was sent but the server rejected it
 	ProviderErrInsufficientBalance string // 402
 	ProviderErrUnprocessable       string // 422
 	ProviderErrRateLimited         string // 429

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -308,7 +308,8 @@ var English = Messages{
 	WriteEnvErr:               "write .env:",
 
 	ProviderErrBadRequest:          "Malformed request (HTTP 400): the request body was rejected. This is likely a bug — please report it if it persists.",
-	ProviderErrAuth:                "Authentication failed (HTTP 401): your API key is missing, wrong, or expired. Check the key in .env or run `reasonix setup`.",
+	ProviderErrAuth:                "Authentication failed (HTTP 401): your API key is missing or unset. Add it to .env or run `reasonix setup`.",
+	ProviderErrAuthRejected:        "Authentication failed (HTTP 401): the server rejected your API key. It may be wrong or expired, or the provider hit a transient auth/quota issue — retried with backoff and still failed. Try again shortly, or check the key in .env / run `reasonix setup`.",
 	ProviderErrInsufficientBalance: "Insufficient balance (HTTP 402): your account is out of credit. Top up your account, then retry.",
 	ProviderErrUnprocessable:       "Invalid parameters (HTTP 422): a request parameter was rejected. This is likely a bug — please report it if it persists.",
 	ProviderErrRateLimited:         "Rate limit reached (HTTP 429): too many requests (TPM/RPM). Retried with backoff — slow down or try again shortly.",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -309,7 +309,8 @@ var Chinese = Messages{
 	WriteEnvErr:               "写入 .env 失败：",
 
 	ProviderErrBadRequest:          "请求格式错误 (HTTP 400)：请求体被拒绝，通常是程序缺陷。若持续出现请反馈。",
-	ProviderErrAuth:                "认证失败 (HTTP 401)：API key 缺失、错误或已过期。请检查 .env 中的密钥，或运行 `reasonix setup`。",
+	ProviderErrAuth:                "认证失败 (HTTP 401)：未读到 API key（缺失或未设置）。请在 .env 中配置密钥，或运行 `reasonix setup`。",
+	ProviderErrAuthRejected:        "认证失败 (HTTP 401)：服务端拒绝了你的 API key。可能是 key 错误或已过期，也可能是服务端出现瞬时鉴权/额度问题——已退避重试仍失败。请稍后再试，或检查 .env 中的密钥 / 运行 `reasonix setup`。",
 	ProviderErrInsufficientBalance: "余额不足 (HTTP 402)：账户余额不足，请前往充值后重试。",
 	ProviderErrUnprocessable:       "参数错误 (HTTP 422)：某个请求参数被拒绝，通常是程序缺陷。若持续出现请反馈。",
 	ProviderErrRateLimited:         "请求速率达到上限 (HTTP 429)：请求过于频繁 (TPM/RPM)。已退避重试，请放慢速率或稍后再试。",

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -119,9 +119,19 @@ type client struct {
 	effort      string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
 	http        *http.Client
 	idleTimeout time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
+	authed      atomic.Bool   // a request has succeeded — gate transient-401 retry
 }
 
 func (c *client) Name() string { return c.name }
+
+func (c *client) sendOpts() provider.SendOptions {
+	return provider.SendOptions{
+		Provider:   c.name,
+		KeyEnv:     c.keyEnv,
+		KeyPresent: c.apiKey != "",
+		RetryAuth:  c.authed.Load(),
+	}
+}
 
 // bufPool reuses byte buffers for JSON-marshalled request bodies, reducing GC
 // churn from repeated alloc/free of ~10-100KB buffers per turn.
@@ -151,10 +161,11 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 		httpReq.Header.Set("anthropic-version", anthropicVersion)
 		return httpReq, nil
 	}
-	resp, err := provider.SendWithRetry(ctx, c.http, c.name, c.keyEnv, newReq)
+	resp, err := provider.SendWithRetry(ctx, c.http, c.sendOpts(), newReq)
 	if err != nil {
 		return nil, err
 	}
+	c.authed.Store(true)
 
 	out := make(chan provider.Chunk)
 	go c.readStream(resp, out)

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -138,9 +138,19 @@ type client struct {
 	minimax     bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
 	effort      string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
 	idleTimeout time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
+	authed      atomic.Bool   // a request has succeeded — gate transient-401 retry
 }
 
 func (c *client) Name() string { return c.name }
+
+func (c *client) sendOpts() provider.SendOptions {
+	return provider.SendOptions{
+		Provider:   c.name,
+		KeyEnv:     c.keyEnv,
+		KeyPresent: c.apiKey != "",
+		RetryAuth:  c.authed.Load(),
+	}
+}
 
 func normalizeReasoningProtocol(raw string) string {
 	switch strings.ToLower(strings.TrimSpace(raw)) {
@@ -180,10 +190,11 @@ func (c *client) Stream(ctx context.Context, req provider.Request) (<-chan provi
 		httpReq.Header.Set("Accept", "text/event-stream")
 		return httpReq, nil
 	}
-	resp, err := provider.SendWithRetry(ctx, c.http, c.name, c.keyEnv, newReq)
+	resp, err := provider.SendWithRetry(ctx, c.http, c.sendOpts(), newReq)
 	if err != nil {
 		return nil, err
 	}
+	c.authed.Store(true)
 
 	out := make(chan provider.Chunk)
 	go c.streamWithReconnect(ctx, resp, newReq, out)
@@ -218,7 +229,7 @@ func (c *client) streamWithReconnect(ctx context.Context, resp *http.Response, n
 			out <- provider.Chunk{Type: provider.ChunkError, Err: err}
 			return
 		}
-		next, rerr := provider.SendWithRetry(ctx, c.http, c.name, c.keyEnv, newReq)
+		next, rerr := provider.SendWithRetry(ctx, c.http, c.sendOpts(), newReq)
 		if rerr != nil {
 			out <- provider.Chunk{Type: provider.ChunkError, Err: rerr}
 			return

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -355,6 +355,7 @@ type AuthError struct {
 	Provider string // the provider instance name, e.g. "deepseek"
 	KeyEnv   string // the api_key_env the key is read from, when known
 	Status   int    // the HTTP status (401 or 403)
+	HasKey   bool   // a non-empty key was sent — the server rejected it, vs. no key configured at all
 }
 
 func (e *AuthError) Error() string {

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -20,6 +20,21 @@ const MaxRetries = 10
 
 const maxBackoff = 15 * time.Second
 
+// maxAuthRetries bounds how many times a 401/403 is retried for a key that has
+// authenticated before: a transient server-side rejection (quota/gateway/rate)
+// usually clears in a couple of attempts, whereas a key that never worked is a
+// real config error and fails fast.
+const maxAuthRetries = 2
+
+// SendOptions carries the per-request context SendWithRetry needs to label
+// errors and decide whether a 401 is worth retrying.
+type SendOptions struct {
+	Provider   string // provider instance name, surfaced in errors
+	KeyEnv     string // api_key_env the key is read from, when known
+	KeyPresent bool   // a non-empty key is being sent — separates "rejected" from "missing"
+	RetryAuth  bool   // the key has authenticated before — retry transient 401s instead of failing fast
+}
+
 // RetryInfo describes a backoff about to happen: Attempt is the 1-based retry
 // number (of Max) and Delay is how long SendWithRetry will wait before it.
 type RetryInfo struct {
@@ -129,14 +144,18 @@ func parseRetryAfter(resp *http.Response) time.Duration {
 // SendWithRetry POSTs a streaming request built by newReq and returns the OK
 // response. It retries the connection+header phase up to MaxRetries times on
 // transient network errors and retryable statuses with capped exponential
-// backoff + jitter, honoring Retry-After. 401/403 become *AuthError; other
-// non-OK statuses become *APIError. A RetryNotify in ctx fires before each
-// sleep. Retries cover only the header phase — once the body streams, mid-stream
+// backoff + jitter, honoring Retry-After. A 401/403 becomes *AuthError: it
+// fails fast for a key that has never authenticated (opts.RetryAuth false), but
+// for a previously-good key it backs off and retries up to maxAuthRetries —
+// MiMo and similar gateways return a transient 401 under load. Other non-OK
+// statuses become *APIError. A RetryNotify in ctx fires before each sleep.
+// Retries cover only the header phase — once the body streams, mid-stream
 // failures are not retried (the model has already emitted tokens).
-func SendWithRetry(ctx context.Context, httpClient *http.Client, provName, keyEnv string, newReq func(context.Context) (*http.Request, error)) (*http.Response, error) {
+func SendWithRetry(ctx context.Context, httpClient *http.Client, opts SendOptions, newReq func(context.Context) (*http.Request, error)) (*http.Response, error) {
 	notify := retryNotifyFromContext(ctx)
 	var lastErr error
 	var retryAfter time.Duration
+	authRetries := 0
 
 	for attempt := 0; attempt <= MaxRetries; attempt++ {
 		if attempt > 0 {
@@ -154,14 +173,14 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, provName, keyEn
 
 		req, err := newReq(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("%s: build request: %w", provName, err)
+			return nil, fmt.Errorf("%s: build request: %w", opts.Provider, err)
 		}
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			if !transientErr(err) {
-				return nil, fmt.Errorf("%s: request failed: %w", provName, err)
+				return nil, fmt.Errorf("%s: request failed: %w", opts.Provider, err)
 			}
-			lastErr = fmt.Errorf("%s: request failed: %w", provName, err)
+			lastErr = fmt.Errorf("%s: request failed: %w", opts.Provider, err)
 			continue
 		}
 		if resp.StatusCode == http.StatusOK {
@@ -174,9 +193,15 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, provName, keyEn
 		resp.Body.Close()
 
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-			return nil, &AuthError{Provider: provName, KeyEnv: keyEnv, Status: resp.StatusCode}
+			authErr := &AuthError{Provider: opts.Provider, KeyEnv: opts.KeyEnv, Status: resp.StatusCode, HasKey: opts.KeyPresent}
+			if opts.RetryAuth && authRetries < maxAuthRetries {
+				authRetries++
+				lastErr = authErr
+				continue
+			}
+			return nil, authErr
 		}
-		apiErr := &APIError{Provider: provName, Status: resp.StatusCode, Body: strings.TrimSpace(string(msg))}
+		apiErr := &APIError{Provider: opts.Provider, Status: resp.StatusCode, Body: strings.TrimSpace(string(msg))}
 		if !RetryableStatus(resp.StatusCode) {
 			return nil, apiErr
 		}

--- a/internal/provider/retry_test.go
+++ b/internal/provider/retry_test.go
@@ -97,7 +97,7 @@ func TestSendWithRetryFailsFastOnClientErrors(t *testing.T) {
 			calls++
 			return statusResp(status, nil), nil
 		})}
-		_, err := SendWithRetry(context.Background(), cl, "p", "KEY", newDummyReq)
+		_, err := SendWithRetry(context.Background(), cl, SendOptions{Provider: "p", KeyEnv: "KEY"}, newDummyReq)
 		if calls != 1 {
 			t.Errorf("status %d retried (%d calls), should fail fast", status, calls)
 		}
@@ -114,13 +114,49 @@ func TestSendWithRetryAuthError(t *testing.T) {
 		calls++
 		return statusResp(401, nil), nil
 	})}
-	_, err := SendWithRetry(context.Background(), cl, "deepseek", "DEEPSEEK_API_KEY", newDummyReq)
+	_, err := SendWithRetry(context.Background(), cl, SendOptions{Provider: "deepseek", KeyEnv: "DEEPSEEK_API_KEY", KeyPresent: true}, newDummyReq)
 	if calls != 1 {
-		t.Errorf("401 retried (%d calls), should fail fast", calls)
+		t.Errorf("401 retried (%d calls), should fail fast for a never-authed key", calls)
 	}
 	var authErr *AuthError
 	if !errors.As(err, &authErr) || authErr.KeyEnv != "DEEPSEEK_API_KEY" {
 		t.Errorf("want *AuthError naming the key env, got %v", err)
+	}
+}
+
+func TestSendWithRetryRetriesTransientAuthForKnownKey(t *testing.T) {
+	calls := 0
+	cl := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		if calls <= 2 {
+			return statusResp(401, nil), nil
+		}
+		return statusResp(200, nil), nil
+	})}
+	resp, err := SendWithRetry(context.Background(), cl,
+		SendOptions{Provider: "mimo", KeyEnv: "MIMO_API_KEY", KeyPresent: true, RetryAuth: true}, newDummyReq)
+	if err != nil {
+		t.Fatalf("a previously-good key should recover from a transient 401: %v", err)
+	}
+	if resp.StatusCode != 200 || calls != 3 {
+		t.Fatalf("status=%d calls=%d, want 200 after 3 calls", resp.StatusCode, calls)
+	}
+}
+
+func TestSendWithRetryAuthGivesUpAfterMaxAuthRetries(t *testing.T) {
+	calls := 0
+	cl := &http.Client{Transport: rtFunc(func(r *http.Request) (*http.Response, error) {
+		calls++
+		return statusResp(401, nil), nil
+	})}
+	_, err := SendWithRetry(context.Background(), cl,
+		SendOptions{Provider: "mimo", KeyEnv: "MIMO_API_KEY", KeyPresent: true, RetryAuth: true}, newDummyReq)
+	if calls != 1+maxAuthRetries {
+		t.Errorf("persistent 401 made %d calls, want %d (initial + maxAuthRetries)", calls, 1+maxAuthRetries)
+	}
+	var authErr *AuthError
+	if !errors.As(err, &authErr) || !authErr.HasKey {
+		t.Fatalf("want *AuthError with HasKey=true, got %v", err)
 	}
 }
 
@@ -136,7 +172,7 @@ func TestSendWithRetryRecoversAndNotifies(t *testing.T) {
 	var infos []RetryInfo
 	ctx := WithRetryNotify(context.Background(), func(i RetryInfo) { infos = append(infos, i) })
 
-	resp, err := SendWithRetry(ctx, cl, "p", "KEY", newDummyReq)
+	resp, err := SendWithRetry(ctx, cl, SendOptions{Provider: "p", KeyEnv: "KEY"}, newDummyReq)
 	if err != nil {
 		t.Fatalf("should recover after one retry: %v", err)
 	}


### PR DESCRIPTION
## Problem

MiMo's `token-plan` gateway (`token-plan-cn.xiaomimimo.com`) returns a **transient 401** under load / quota / gateway hiccups, not a 429. Two things turned that into an apparent dead key (#3146):

1. We never retry a 401 — `RetryableStatus` treats every 4xx as unrecoverable.
2. Every 401 is shown as **"API key is missing, wrong, or expired"**, so a key that's actually fine reads as expired.

Users reported a working key "expiring" mid-session; re-entering the **same** key fixed it — but only because saving the key rebuilds the connection, not because the key changed. We do not delete the key anywhere; the 401 came from the server.

## Fix

- **Retry transient 401s for a known-good key.** `SendWithRetry` now takes a `SendOptions` with `RetryAuth` (true once a request on this client has succeeded) and `KeyPresent`. A 401/403 on a key that has authenticated before backs off and retries up to `maxAuthRetries` (2); a key that has **never** worked still fails fast, so a genuinely bad key isn't hammered.
- **Clearer message.** `AuthError.HasKey` lets the UI distinguish:
  - no key configured → *"API key is missing or unset…"*
  - key sent but rejected → *"the server rejected your API key… may be a transient auth/quota issue — retried with backoff and still failed; try again shortly."*

Wired through both the OpenAI-compatible provider (MiMo / DeepSeek / MiniMax) and Anthropic.

## Tests

- `SendWithRetry` retries a transient 401 for a known key and recovers (3 calls); gives up after `maxAuthRetries` with `HasKey=true`; still fails fast for a never-authed key.
- `explainError` selects the missing vs. server-rejected message by `HasKey`.

Closes #3146
