### PR TITLE
Fix system_prompt_file workspace root resolution

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -154,7 +154,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		return nil, err
 	}
 
-	sysPrompt, err := cfg.ResolveSystemPrompt()
+	sysPrompt, err := cfg.ResolveSystemPromptForRoot(root)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1843,8 +1843,19 @@ func (e *ProviderEntry) Configured() bool {
 
 // ResolveSystemPrompt returns the system prompt, reading system_prompt_file if set.
 func (c *Config) ResolveSystemPrompt() (string, error) {
+	return c.ResolveSystemPromptForRoot(".")
+}
+
+// ResolveSystemPromptForRoot is like ResolveSystemPrompt but resolves a relative
+// system_prompt_file against root. Desktop tabs pass their workspace root here so
+// prompt files are project-scoped even when the process cwd is elsewhere.
+func (c *Config) ResolveSystemPromptForRoot(root string) (string, error) {
 	if c.Agent.SystemPromptFile != "" {
-		b, err := os.ReadFile(c.Agent.SystemPromptFile)
+		path := c.Agent.SystemPromptFile
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(resolveRoot(root), path)
+		}
+		b, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("system_prompt_file: %w", err)
 		}

--- a/internal/config/system_prompt_test.go
+++ b/internal/config/system_prompt_test.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSystemPromptForRootRelativePath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "prompts"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "prompts", "session.md"), []byte(" project session prompt \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(t.TempDir())
+
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = filepath.Join("prompts", "session.md")
+
+	got, err := cfg.ResolveSystemPromptForRoot(root)
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "project session prompt" {
+		t.Fatalf("system prompt = %q, want %q", got, "project session prompt")
+	}
+}
+
+func TestResolveSystemPromptForRootAbsolutePath(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "session.md")
+	if err := os.WriteFile(path, []byte(" absolute session prompt \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(t.TempDir())
+
+	cfg := Default()
+	cfg.Agent.SystemPromptFile = path
+
+	got, err := cfg.ResolveSystemPromptForRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("ResolveSystemPromptForRoot: %v", err)
+	}
+	if got != "absolute session prompt" {
+		t.Fatalf("system prompt = %q, want %q", got, "absolute session prompt")
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve relative `[agent] system_prompt_file` paths against the active workspace root instead of the process cwd.
- Wire `boot.Build` to pass its resolved workspace root into system prompt loading.
- Add config tests for workspace-relative and absolute prompt file paths.

## Test plan
- `gofmt -l . | rg -v '^desktop/' || true`
- `go test ./internal/config/ -run 'TestResolveSystemPromptForRoot' -v`
- `go test ./internal/config/ -count=1`
- `go test ./internal/boot/ -count=1`

## Notes
- PR diff intentionally excludes local-only files such as `AGENTS.md`, `architecture/`, `context/`, and `proposal.md`.
- Manual Desktop validation was not run in this session.

Made with [Cursor](https://cursor.com)