### PR TITLE
refactor(cli): extract pickCLIRelease and drop dead normalizeOS

### DIFF
--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -106,7 +106,7 @@ func upgradeCommand(args []string, version string) int {
 	}
 
 	// 5. Find the asset for the current platform.
-	base := fmt.Sprintf("reasonix-%s-%s", normalizeOS(runtime.GOOS), runtime.GOARCH)
+	base := fmt.Sprintf("reasonix-%s-%s", runtime.GOOS, runtime.GOARCH)
 	var asset *ghAsset
 	for i := range rel.Assets {
 		if strings.HasPrefix(rel.Assets[i].Name, base) {
@@ -179,15 +179,6 @@ func normalizeVersion(v string) (string, bool) {
 	return semver.Canonical(v), true
 }
 
-// normalizeOS maps Go's runtime.GOOS to the goreleaser archive naming.
-func normalizeOS(goos string) string {
-	// Goreleaser uses "darwin" for macOS and "windows"/"linux" as-is.
-	// runtime.GOOS already matches except for "darwin" vs "macos" in
-	// some naming conventions — but goreleaser templates use Os directly,
-	// which for GOOS=darwin outputs "Darwin". Our archives use lowercase.
-	return goos
-}
-
 // isCLITag reports whether a tag belongs to the CLI release namespace (v*).
 // Tags like "desktop-v1.5.0" or "npm-v1.4.0" are excluded.
 func isCLITag(tag string) bool {
@@ -195,9 +186,22 @@ func isCLITag(tag string) bool {
 	return len(tag) >= 2 && tag[0] == 'v' && tag[1] >= '0' && tag[1] <= '9'
 }
 
+// pickCLIRelease returns the newest CLI-namespace (v*) release from a
+// reverse-chronological list, skipping foreign namespaces ("desktop-v",
+// "npm-v"). Prereleases are kept: only 1.x carries `reasonix upgrade`, and the
+// 1.x line ships as rc on npm @next, so there is no stable user to hold back —
+// the command should always move to the newest 1.x.
+func pickCLIRelease(rels []ghRelease) *ghRelease {
+	for i := range rels {
+		if isCLITag(rels[i].TagName) {
+			return &rels[i]
+		}
+	}
+	return nil
+}
+
 // fetchLatestRelease queries the GitHub Releases API and returns the newest
-// release whose tag belongs to the CLI namespace (v*). Tags with a prefix
-// such as "desktop-v" or "npm-v" are skipped.
+// CLI-namespace (v*) release.
 func fetchLatestRelease(c *http.Client) (*ghRelease, error) {
 	req, err := http.NewRequest("GET", ghAPIReleases, nil)
 	if err != nil {
@@ -220,12 +224,8 @@ func fetchLatestRelease(c *http.Client) (*ghRelease, error) {
 		return nil, err
 	}
 
-	// The /releases endpoint returns releases in reverse chronological
-	// order; pick the first one whose tag is a CLI release (v*).
-	for i := range rels {
-		if isCLITag(rels[i].TagName) {
-			return &rels[i], nil
-		}
+	if rel := pickCLIRelease(rels); rel != nil {
+		return rel, nil
 	}
 	return nil, fmt.Errorf("no CLI release (v*) found in recent releases")
 }

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -183,26 +183,35 @@ func TestHumanSize(t *testing.T) {
 	}
 }
 
-func TestFetchLatestRelease_FiltersTags(t *testing.T) {
-	// Simulate the GitHub /releases list with mixed namespaces.
-	// fetchLatestRelease is tested indirectly via isCLITag + the list logic.
-	rels := []ghRelease{
-		{TagName: "desktop-v1.5.0"},
+func TestPickCLIRelease(t *testing.T) {
+	pick := func(rels []ghRelease) string {
+		if r := pickCLIRelease(rels); r != nil {
+			return r.TagName
+		}
+		return ""
+	}
+
+	// Skips foreign namespaces (GitHub's "latest" can be a desktop-v release).
+	mixed := []ghRelease{
+		{TagName: "desktop-v1.6.0"},
 		{TagName: "npm-v1.4.0"},
 		{TagName: "v1.6.0"},
 	}
-	// Walk the same way fetchLatestRelease does.
-	var found *ghRelease
-	for i := range rels {
-		if isCLITag(rels[i].TagName) {
-			found = &rels[i]
-			break
-		}
+	if got := pick(mixed); got != "v1.6.0" {
+		t.Errorf("foreign namespaces: got %q, want v1.6.0", got)
 	}
-	if found == nil {
-		t.Fatal("no CLI release found")
+
+	// The 1.x line ships as rc on npm @next, so a newer prerelease must be
+	// selected, not skipped — `reasonix upgrade` always moves to the newest 1.x.
+	withRC := []ghRelease{
+		{TagName: "v1.7.0-rc.1"},
+		{TagName: "v1.6.0"},
 	}
-	if found.TagName != "v1.6.0" {
-		t.Errorf("got %q, want v1.6.0", found.TagName)
+	if got := pick(withRC); got != "v1.7.0-rc.1" {
+		t.Errorf("newest 1.x (incl. rc) must win: got %q, want v1.7.0-rc.1", got)
+	}
+
+	if got := pick([]ghRelease{{TagName: "desktop-v1.0.0"}}); got != "" {
+		t.Errorf("no CLI release should return nil, got %q", got)
 	}
 }


### PR DESCRIPTION
Follow-up to #4005 — cleanup only, **no behavior change**.

`reasonix upgrade` deliberately tracks the newest 1.x release, **including rc**. Rationale (verified 2026-06-12):

- Only 1.x builds carry the `upgrade` command, so a 0.5x user never reaches this path — there's no legacy-stable user to protect.
- The 1.x line ships as **rc on npm `@next`** (`@latest` is frozen at the deprecated `0.53.2`); brew/GitHub relabel the same content as stable `v1.6.0`. So for the people who *can* run `upgrade`, "the latest 1.x" is the rc/@next line — they should always move to the newest 1.x, not be held on an older stable.

#4005 already picked the newest `v*` release regardless of the prerelease flag; this PR keeps that and just tidies up:

- Extract the selection into a pure `pickCLIRelease` (foreign `desktop-v`/`npm-v` tags skipped) and unit-test it without a network call — including a case that locks in "a newer rc wins", so nobody re-adds a prerelease skip by mistake.
- Remove `normalizeOS`, a no-op that returned `runtime.GOOS` unchanged behind a multi-line comment (real assets are `reasonix-<goos>-<goarch>`).

Note: the namespace filter is load-bearing — GitHub's `latest=true` badge is currently on `desktop-v1.6.0`, so listing `/releases` + skipping foreign namespaces is what reaches the CLI's `v1.6.0`.
