### PR TITLE
fix: skip fade-in animation for history-restored messages

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -65,11 +65,13 @@ export function UserMessage({
   failed,
   turn,
   anchorId,
+  id,
 }: {
   text: string;
   failed?: boolean;
   turn?: number;
   anchorId?: string;
+  id?: string;
 }) {
   const t = useT();
   const imSource = parseImSourceMessage(text);
@@ -106,6 +108,7 @@ export function UserMessage({
       data-question-anchor={anchorId}
       data-turn={turn}
       data-im-source={imSource?.provider || undefined}
+      data-history-restore={id && id.startsWith("h") ? "" : undefined}
     >
       <div className="msg__body">
         {imSource ? (
@@ -345,7 +348,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   const processOnly = Boolean(item.reasoning) && !hasText;
   const processWithText = Boolean(item.reasoning) && hasText;
   return (
-    <div className={`msg msg--assistant${processOnly ? " msg--process-only" : ""}${processWithText ? " msg--process-with-text" : ""}`}>
+    <div className={`msg msg--assistant${processOnly ? " msg--process-only" : ""}${processWithText ? " msg--process-with-text" : ""}`} data-history-restore={item.id.startsWith("h") ? "" : undefined}>
       {item.reasoning && (
         <div className="reasoning">
           <button

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -420,7 +420,7 @@ export function Transcript({
           const tn = userTurn.get(it.id);
           activeTurn = tn;
           out.push(
-            <UserMessage key={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
+            <UserMessage key={it.id} id={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
           );
           break;
         }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17221,6 +17221,10 @@ a[href] {
   animation: graphite-message-in var(--dur-slow) var(--ease-out) both;
 }
 
+:root[data-theme-style] .msg[data-history-restore] {
+  animation: none;
+}
+
 :root[data-theme-style="graphite"] .msg--user .msg__body {
   max-width: min(80%, 650px);
   padding: 11px 15px;


### PR DESCRIPTION
Session restore loads every message with `animation: graphite-message-in 340ms ease-out both`. The `both` fill-mode means ALL messages start at `opacity:0` and animate in simultaneously — on a session with dozens of turns this causes visible text flickering / flashing on startup.

**Diagnosis:** Historical messages are reloaded all at once during session restore. Each `.msg` element has a CSS `graphite-message-in` keyframe animation (opacity 0→1 + translateY 10px→0, 340ms). With `animation-fill-mode: both`, all elements start invisible, then simultaneously fade in — the user sees a flash.

Live-streamed messages should keep the entrance animation; only static history items need to skip it. History items are reliably identified by their `"h"`-prefixed IDs (set by `historyMessagesToItems` in useController).

**Fix:** Add a `data-history-restore` attribute on `.msg` elements whose id starts with `"h"`, and disable the animation via CSS:

```css
.msg[data-history-restore] { animation: none; }
```

- **Message.tsx**: accept `id` prop on UserMessage; set `data-history-restore` on both UserMessage and AssistantMessage when id starts with `"h"`
- **Transcript.tsx**: pass `id` to UserMessage (hot zone + warm zone)
- **styles.css**: add override rule after the `.msg` animation definition