### PR TITLE
fix(codegraph): name codegraph tools by their real MCP-prefixed names in steering

### DIFF
--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -29,15 +29,21 @@ import (
 const initTimeout = 30 * time.Second
 
 // SteerText is injected into the system prompt when CodeGraph tools are
-// available, so the model knows to prefer them for symbol-level questions.
+// available, so the model knows to prefer them for symbol-level questions. The
+// tool names are the model-visible registered names (mcp__codegraph__<tool>);
+// TestSteerTextNamesMatchRegisteredTools fails if they drift from the daemon's
+// actual tools so the model is never told to call a name it can't use.
 const SteerText = `## Code Intelligence (codegraph)
 You have codegraph tools for symbol-level code intelligence. For architecture questions, "how does X work", call graphs, symbol search, and impact analysis, prefer codegraph tools over grep/read_file:
-- codegraph_context — entry points + related symbols + key code in one call (USE THIS FIRST for "how does X work")
-- codegraph_search — find symbols by name (functions, types, interfaces)
-- codegraph_callers / codegraph_callees — trace call chains
-- codegraph_impact — what breaks if I change X
-- codegraph_trace — full call path between two symbols
-- codegraph_files — project file tree with symbol counts
+- mcp__codegraph__context — entry points + related symbols + key code in one call (USE THIS FIRST for "how does X work")
+- mcp__codegraph__search — find symbols by name (functions, types, interfaces)
+- mcp__codegraph__callers / mcp__codegraph__callees — trace call chains
+- mcp__codegraph__impact — what breaks if I change X
+- mcp__codegraph__trace — full call path between two symbols
+- mcp__codegraph__explore — walk the graph around a symbol (neighbours and relationships)
+- mcp__codegraph__node — full detail for one symbol (definition, location, signature)
+- mcp__codegraph__files — project file tree with symbol counts
+- mcp__codegraph__status — code-intelligence index build/health status
 Use grep/read_file for content search (comments, strings, config values) and when codegraph is not available.`
 
 // BundleDirName is the optional directory, beside the reasonix executable, where

--- a/internal/codegraph/steer_test.go
+++ b/internal/codegraph/steer_test.go
@@ -1,0 +1,33 @@
+package codegraph
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSteerTextNamesMatchRegisteredTools keeps the system-prompt steering names
+// in lockstep with the daemon's tools. A model-visible name is
+// "mcp__codegraph__" + the raw tool name with the spec's StripRawPrefix
+// ("codegraph_") removed — the mirror of plugin.ToolPrefix + Spec.StripRawPrefix
+// applied in boot.go. If a tool is added/renamed or the steering text drifts,
+// this fails instead of silently telling the model to call a name it can't use.
+func TestSteerTextNamesMatchRegisteredTools(t *testing.T) {
+	const prefix = "mcp__codegraph__"
+
+	want := make(map[string]bool, len(ReadOnlyToolNames()))
+	for raw := range ReadOnlyToolNames() {
+		want[prefix+strings.TrimPrefix(raw, "codegraph_")] = true
+	}
+
+	for name := range want {
+		if !strings.Contains(SteerText, name) {
+			t.Errorf("SteerText is missing %q — the model won't know this tool exists", name)
+		}
+	}
+
+	for _, field := range strings.Fields(SteerText) {
+		if strings.HasPrefix(field, prefix) && !want[field] {
+			t.Errorf("SteerText names %q, which is not a registered codegraph tool", field)
+		}
+	}
+}


### PR DESCRIPTION
Closes #4111.

The codegraph steering injected into the system prompt named the tools by short name (`codegraph_context`), but they register under the MCP namespace as `mcp__codegraph__context`. A model that follows the steering verbatim calls a name that doesn't exist → "unknown tool". The list was also missing `explore`, `node`, and `status`.

## Diagnosis (verified against current main-v2)

I reproduced the registration path in a test before changing anything: the codegraph daemon emits raw tool names `codegraph_*`, the spec sets `StripRawPrefix: "codegraph_"`, and `LazyToolset` strips it before namespacing — so the real registered name is `mcp__codegraph__context` (single prefix). The doubled `mcp__codegraph__codegraph_context` in the report is stale (a build before `StripRawPrefix`, #3133); strip works on current main.

## Fix (option D — static + drift-guard)

- Use the real `mcp__codegraph__<tool>` names and cover all ten tools.
- Kept as a **static constant** so the cached system-prompt prefix stays byte-for-byte identical across sessions with the same codegraph — no cache impact. (The text is injected once at boot and frozen for the session, so turn-to-turn caching was never at risk; this just keeps cross-session reuse intact too.)
- New `TestSteerTextNamesMatchRegisteredTools` asserts, in both directions, that the steering names exactly match `ReadOnlyToolNames()` mapped through the prefix/strip — so if a codegraph tool is added/renamed or the text drifts, CI fails instead of silently shipping a name the model can't call.

`go test ./internal/codegraph ./internal/boot` green; gofmt/vet clean.
