### PR TITLE
feat(desktop): build the Windows ARM64 desktop app

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -63,6 +63,7 @@ jobs:
           # runner — avoids the scarce/slow macos-13 Intel runner.
           - { runner: macos-14, platform: darwin/universal, name: darwin-universal }
           - { runner: windows-latest, platform: windows/amd64, name: windows-amd64 }
+          - { runner: windows-11-arm, platform: windows/arm64, name: windows-arm64 }
           - { runner: ubuntu-22.04, platform: linux/amd64, name: linux-amd64 }
     runs-on: ${{ matrix.runner }}
     defaults:

--- a/desktop/cmd/sign/main.go
+++ b/desktop/cmd/sign/main.go
@@ -35,7 +35,7 @@ import (
 // platforms are the manifest keys we publish. A built artifact is matched to a key
 // by substring (file names embed the key, e.g. Reasonix-darwin-arm64.zip), so the
 // generator and the updater agree on update.PlatformKey output.
-var platforms = []string{"darwin-arm64", "darwin-amd64", "windows-amd64", "linux-amd64"}
+var platforms = []string{"darwin-arm64", "darwin-amd64", "windows-amd64", "windows-arm64", "linux-amd64"}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -212,7 +212,9 @@ func matchPlatform(name string) string {
 	if strings.HasSuffix(name, ".deb") {
 		return ""
 	}
-	if strings.Contains(name, "windows-amd64") && !strings.HasSuffix(name, "-installer.exe") {
+	// The Windows updater channel is the per-arch -installer.exe; the portable .zip
+	// is a human download, so skip it or it would shadow the installer's key.
+	if strings.Contains(name, "windows-") && !strings.HasSuffix(name, "-installer.exe") {
 		return ""
 	}
 	for _, p := range platforms {

--- a/desktop/cmd/sign/main_test.go
+++ b/desktop/cmd/sign/main_test.go
@@ -57,6 +57,8 @@ func TestGenManifest(t *testing.T) {
 		"Reasonix-darwin-amd64.zip",
 		"Reasonix-windows-amd64-installer.exe",
 		"Reasonix-windows-amd64.zip", // portable download, not the updater channel
+		"Reasonix-windows-arm64-installer.exe",
+		"Reasonix-windows-arm64.zip", // portable download, not the updater channel
 		"Reasonix-linux-amd64.tar.gz",
 		"Reasonix-linux-amd64.deb",            // human download, not the updater channel
 		"Reasonix-linux-amd64.tar.gz.minisig", // must be skipped
@@ -83,8 +85,8 @@ func TestGenManifest(t *testing.T) {
 	if m.Version != "v1.2.0" {
 		t.Fatalf("version = %q, want v1.2.0", m.Version)
 	}
-	if len(m.Platforms) != 4 {
-		t.Fatalf("want 4 platforms, got %d: %v", len(m.Platforms), m.Platforms)
+	if len(m.Platforms) != 5 {
+		t.Fatalf("want 5 platforms, got %d: %v", len(m.Platforms), m.Platforms)
 	}
 	win, ok := m.Platforms["windows-amd64"]
 	if !ok {
@@ -99,6 +101,15 @@ func TestGenManifest(t *testing.T) {
 	}
 	if win.SHA256 == "" || win.Size == 0 {
 		t.Fatalf("windows asset missing digest/size: %+v", win)
+	}
+	// The Windows updater channel is the per-arch -installer.exe; the portable .zip
+	// must not shadow the windows-arm64 key.
+	arm, ok := m.Platforms["windows-arm64"]
+	if !ok {
+		t.Fatal("windows-arm64 missing")
+	}
+	if !strings.HasSuffix(arm.URL, "/Reasonix-windows-arm64-installer.exe") {
+		t.Fatalf("windows-arm64 url = %q, want the installer, not the portable zip", arm.URL)
 	}
 	// The Linux updater channel must stay the .tar.gz; the co-located .deb is a
 	// human download and must not shadow the linux-amd64 key.


### PR DESCRIPTION
Adds a Windows on ARM64 build of the desktop app, for Snapdragon / Windows-ARM devices.

## What changed
- **Release matrix** — a `windows/arm64` target on a native `windows-11-arm` runner. The build script already notes Wails can't cross-compile its CGO+WebView binary, so each arch builds on its own native runner; this just adds the missing one (GitHub's `windows-11-arm` runner is GA for public repos).
- **Manifest generator** (`desktop/cmd/sign`) — added the `windows-arm64` platform key and generalized the portable-`.zip` skip to any `windows-` arch, so the updater channel stays the per-arch `-installer.exe`.

Nothing else needed changing:
- `scripts/desktop-build.sh` is already arch-parameterized (`Reasonix-windows-arm64-installer.exe`, etc.).
- The updater's `CurrentPlatform()` is `GOOS-GOARCH`, so an arm64 build already resolves `windows-arm64`.
- The codegraph dependency already ships `codegraph-win32-arm64.zip`.

## Validation
- `cd desktop && go test ./cmd/sign` passes, including new coverage that `Reasonix-windows-arm64-installer.exe` maps to `windows-arm64` and the portable `.zip` is skipped.
- Workflow YAML parses; matrix targets are `darwin-universal, windows-amd64, windows-arm64, linux-amd64`.

## Note
The desktop build job only runs on a `desktop-v*` tag or a manual `workflow_dispatch`, so **PR CI does not exercise the arm64 build** — the first desktop release (or a canary dispatch) validates the runner toolchain (Wails + WebView2 + NSIS + cgo on ARM64). `fail-fast: false` is already set, so an arm64 build failure won't sink the other platforms; the manifest simply omits the arm64 key if its artifact is missing.

The CLI already supports Windows ARM64 today (`reasonix@next` → `@reasonix/cli-win32-arm64`); this brings the desktop app to parity.
