### PR TITLE
feat(shell): let [tools.shell] pick the bash tool's interpreter

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -454,6 +454,10 @@ api_key_env = "MIMO_API_KEY"
 enabled = []   # omit/empty = all built-ins
 bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
 
+[tools.shell]
+prefer = "auto"   # auto (default) | bash | powershell | pwsh — force the shell tool's interpreter
+# path = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"   # explicit executable for the chosen shell
+
 [skills]
 # paths = ["~/my-skills", "../shared/skills"]   # extra custom skill roots
 # excluded_paths = ["~/.agents/skills"]         # hide convention roots without deleting folders

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -195,11 +195,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 
 	reg := tool.NewRegistry()
 	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: cfg.WriteRootsForRoot(root), Network: cfg.Sandbox.Network}
+	shell := sandbox.ResolveShell(cfg.Tools.Shell.Prefer, cfg.Tools.Shell.Path, stderr)
+	bashSpec.Shell = shell
 	if bashSpec.Mode == "enforce" && !sandbox.Available() {
 		fmt.Fprintln(stderr, "warning: bash sandbox requested but unavailable on this platform; running bash unconfined")
 	}
-	if sandbox.ResolveShell().Kind == sandbox.ShellPowerShell {
-		fmt.Fprintln(stderr, "warning: bash not found on PATH; the shell tool will run commands under Windows PowerShell. Install Git for Windows or WSL to use bash.")
+	if autoShellPrefer(cfg.Tools.Shell.Prefer) && shell.Kind == sandbox.ShellPowerShell {
+		fmt.Fprintln(stderr, "warning: bash not found on PATH; the shell tool will run commands under Windows PowerShell. Install Git for Windows or WSL to use bash, or set [tools.shell] prefer=\"powershell\" to silence this.")
 	}
 	searchSpec := builtin.ResolveSearch(cfg.Tools.Search.Engine, cfg.Tools.Search.RgPath, stderr)
 	bashTimeout := time.Duration(cfg.BashTimeoutSeconds()) * time.Second
@@ -729,6 +731,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		PluginCtx:     ctx,
 		WorkspaceRoot: root,
 		AutoPlan:      cfg.Agent.AutoPlan,
+		Shell:         shell,
 		OnRemember: func(rule string) control.RememberResult {
 			return rememberPermissionRule(root, rule)
 		},
@@ -1103,6 +1106,14 @@ func pluginSpecNames(specs []plugin.Spec) []string {
 		names = append(names, s.Name)
 	}
 	return names
+}
+
+// autoShellPrefer reports whether [tools.shell] left the interpreter to
+// auto-detection, so the "fell back to PowerShell" hint is suppressed once the
+// user has explicitly chosen a shell.
+func autoShellPrefer(prefer string) bool {
+	p := strings.ToLower(strings.TrimSpace(prefer))
+	return p == "" || p == "auto"
 }
 
 // MCPStartupNotice formats the warning shown when configured MCP servers failed

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -834,6 +834,7 @@ type ToolsConfig struct {
 	Enabled            []string     `toml:"enabled"`
 	BashTimeoutSeconds *int         `toml:"bash_timeout_seconds"`
 	Search             SearchConfig `toml:"search"`
+	Shell              ShellConfig  `toml:"shell"`
 }
 
 const defaultBashTimeoutSeconds = 120
@@ -856,6 +857,15 @@ func (c *Config) BashTimeoutSeconds() int {
 type SearchConfig struct {
 	Engine string `toml:"engine"`
 	RgPath string `toml:"rg_path"`
+}
+
+// ShellConfig chooses the interpreter the bash tool runs commands under. Prefer
+// is "auto" (default — real bash when present, else PowerShell on Windows),
+// "bash", or "powershell"/"pwsh" (force it; warn at startup and fall back to
+// auto if absent). Path optionally points at a specific shell executable.
+type ShellConfig struct {
+	Prefer string `toml:"prefer"`
+	Path   string `toml:"path"`
 }
 
 // PermissionsConfig declares the per-call permission policy (see

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -75,6 +75,7 @@ type Controller struct {
 	mem           *memory.Set
 	cleanup       func()
 	autoPlan      string
+	shell         sandbox.Shell // interpreter for user-invoked "!" commands; zero = auto
 	classifier    autoPlanClassifier
 	startedOnce   bool                             // guards the one-shot SessionStart hook on first turn
 	onRemember    func(rule string) RememberResult // set via Options; invoked when user picks "always allow"
@@ -246,7 +247,10 @@ type Options struct {
 	// no confinement). Frontends pass the cwd they launched the session in.
 	WorkspaceRoot string
 	AutoPlan      string
-	Classifier    autoPlanClassifier
+	// Shell is the interpreter user-invoked "!" commands run under, so /shell
+	// matches the agent's configured [tools.shell] choice. Zero value = auto.
+	Shell      sandbox.Shell
+	Classifier autoPlanClassifier
 	// OnRemember, when set, is invoked with a new allow rule the user chose to
 	// persist to disk (e.g. "Bash(go test:*)"). The callback is wired into the
 	// permission Gate on EnableInteractiveApproval.
@@ -286,6 +290,7 @@ func New(opts Options) *Controller {
 		mem:              opts.Memory,
 		cleanup:          opts.Cleanup,
 		autoPlan:         normalizeAutoPlan(opts.AutoPlan),
+		shell:            opts.Shell,
 		classifier:       classifier,
 		onRemember:       opts.OnRemember,
 		balanceURL:       opts.BalanceURL,
@@ -950,7 +955,10 @@ func (c *Controller) RunShell(command string) {
 		return
 	}
 	c.runGuarded(func(ctx context.Context) error {
-		sh := sandbox.ResolveShell()
+		sh := c.shell
+		if sh.Path == "" {
+			sh = sandbox.ResolveShell("", "", nil)
+		}
 		argv, _ := sandbox.Command(sandbox.Spec{}, sh, command) // false = unsandboxed (user invoked)
 
 		preview := []rune(command)

--- a/internal/control/shell_test.go
+++ b/internal/control/shell_test.go
@@ -150,7 +150,7 @@ func TestRunShell_CancelStopsCommand(t *testing.T) {
 	ctrl := &Controller{sink: sink}
 
 	command := "sleep 30"
-	if sandbox.ResolveShell().Kind == sandbox.ShellPowerShell {
+	if sandbox.ResolveShell("", "", nil).Kind == sandbox.ShellPowerShell {
 		command = "Start-Sleep -Seconds 30"
 	}
 	ctrl.RunShell(command)

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -24,6 +24,10 @@ type Spec struct {
 	// command cannot exfiltrate or fetch; many dev commands (module/package
 	// downloads) need it, so it defaults on at the config layer.
 	Network bool
+	// Shell is the interpreter the bash tool runs under. A zero value (empty
+	// Path) means the tool resolves one itself; the composition root sets it from
+	// [tools.shell] so the configured choice rides along with the spec.
+	Shell Shell
 }
 
 // enforce reports whether the spec asks for confinement.

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -3,6 +3,7 @@ package sandbox
 import (
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -124,13 +125,66 @@ func TestResolveShellDecisionTable(t *testing.T) {
 		{"wsl bash on PATH, no git → powershell not wsl", "windows", onPath("bash", "powershell"), gitBash, never, always, wslIsPathBash, ShellPowerShell, ""},
 	}
 	for _, c := range cases {
-		got := resolveShell(c.goos, c.lookPath, c.exists, c.candidates, c.probe, c.isWSL)
+		got := resolveShell("", "", nil, c.goos, c.lookPath, c.exists, c.candidates, c.probe, c.isWSL)
 		if got.Kind != c.wantKind {
 			t.Errorf("%s: kind = %s, want %s (path=%s)", c.name, got.Kind, c.wantKind, got.Path)
 		}
 		if c.wantPath != "" && got.Path != c.wantPath {
 			t.Errorf("%s: path = %q, want %q", c.name, got.Path, c.wantPath)
 		}
+	}
+}
+
+func TestResolveShellPrefer(t *testing.T) {
+	onPath := func(names ...string) func(string) (string, error) {
+		set := map[string]bool{}
+		for _, n := range names {
+			set[n] = true
+		}
+		return func(name string) (string, error) {
+			if set[name] {
+				return `C:\fake\` + name + ".exe", nil
+			}
+			return "", exec.ErrNotFound
+		}
+	}
+	gitBash := []string{`C:\fake\Git\bin\bash.exe`}
+	always := func(string) bool { return true }
+	never := func(string) bool { return false }
+	noWSL := func(string) bool { return false }
+
+	// prefer=powershell forces PowerShell even when bash is present and probes ok.
+	got := resolveShell("powershell", "", nil, "windows", onPath("bash", "powershell", "pwsh"), never, gitBash, always, noWSL)
+	if got.Kind != ShellPowerShell {
+		t.Errorf(`prefer="powershell": kind = %s, want powershell`, got.Kind)
+	}
+
+	// prefer=bash forces bash even on a host where PowerShell exists.
+	got = resolveShell("bash", "", nil, "windows", onPath("bash", "powershell"), never, gitBash, always, noWSL)
+	if got.Kind != ShellBash {
+		t.Errorf(`prefer="bash": kind = %s, want bash`, got.Kind)
+	}
+
+	// An explicit path is honoured for the forced kind.
+	got = resolveShell("pwsh", `C:\custom\pwsh.exe`, nil, "windows", onPath(), always, gitBash, never, noWSL)
+	if got.Kind != ShellPowerShell || got.Path != `C:\custom\pwsh.exe` {
+		t.Errorf(`prefer="pwsh" path: got {%s %q}, want {powershell "C:\custom\pwsh.exe"}`, got.Kind, got.Path)
+	}
+
+	// A forced shell that isn't installed warns and falls back to auto-detection.
+	var warn strings.Builder
+	got = resolveShell("powershell", "", &warn, "linux", onPath("bash"), never, gitBash, always, noWSL)
+	if got.Kind != ShellBash {
+		t.Errorf("missing forced powershell should fall back to bash, got %s", got.Kind)
+	}
+	if !strings.Contains(warn.String(), "powershell") {
+		t.Errorf("fallback should warn about the missing shell, got %q", warn.String())
+	}
+
+	// An unrecognised value is treated as auto, not an error.
+	got = resolveShell("fish", "", nil, "windows", onPath("bash"), never, gitBash, always, noWSL)
+	if got.Kind != ShellBash {
+		t.Errorf("unknown prefer should auto-detect, got %s", got.Kind)
 	}
 }
 

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -2,6 +2,8 @@ package sandbox
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,35 +41,89 @@ type Shell struct {
 	Path string
 }
 
-// ResolveShell picks the interpreter the shell tool runs commands under. It
-// prefers a real bash so the model's POSIX habits work; on Windows, where bash
-// is usually absent from PATH, it probes the Git-for-Windows install locations
-// and only then falls back to PowerShell so the tool still functions.
-func ResolveShell() Shell {
-	return resolveShell(runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates(), probeBash, isWindowsWSLBash)
+// ResolveShell picks the interpreter the shell tool runs commands under. With
+// prefer "auto"/"" it favours a real bash so the model's POSIX habits work and
+// only falls back to PowerShell on Windows when bash is absent. prefer "bash" or
+// "powershell"/"pwsh" forces that interpreter (path overrides the PATH lookup),
+// warning to warn and falling back to auto-detection if the forced one is
+// missing — so a typo or an uninstalled shell can never leave the tool broken.
+func ResolveShell(prefer, path string, warn io.Writer) Shell {
+	return resolveShell(prefer, path, warn, runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates(), probeBash, isWindowsWSLBash)
 }
 
 // resolveShell is ResolveShell with its environment lookups injected — including
 // the Git-for-Windows bash candidates, which derive from %ProgramFiles% and so
 // are empty off Windows — so the decision table is deterministically testable on
 // any host.
-func resolveShell(goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string, probe func(string) bool, isWSL func(string) bool) Shell {
-	if p, err := lookPath("bash"); err == nil && !isWSL(p) && probe(p) {
-		return Shell{Kind: ShellBash, Path: p}
-	}
-	if goos == "windows" {
+func resolveShell(prefer, path string, warn io.Writer, goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string, probe func(string) bool, isWSL func(string) bool) Shell {
+	findBash := func() (Shell, bool) {
+		if p, err := lookPath("bash"); err == nil && !isWSL(p) && probe(p) {
+			return Shell{Kind: ShellBash, Path: p}, true
+		}
 		for _, p := range winBashCandidates {
 			if exists(p) && probe(p) {
-				return Shell{Kind: ShellBash, Path: p}
+				return Shell{Kind: ShellBash, Path: p}, true
 			}
 		}
-		for _, name := range []string{"pwsh", "powershell"} {
-			if p, err := lookPath(name); err == nil {
-				return Shell{Kind: ShellPowerShell, Path: p}
-			}
-		}
+		return Shell{}, false
 	}
-	return Shell{Kind: ShellBash, Path: "bash"}
+	findPowerShell := func(order []string) (Shell, bool) {
+		for _, name := range order {
+			if p, err := lookPath(name); err == nil {
+				return Shell{Kind: ShellPowerShell, Path: p}, true
+			}
+		}
+		return Shell{}, false
+	}
+	auto := func() Shell {
+		if sh, ok := findBash(); ok {
+			return sh
+		}
+		if goos == "windows" {
+			if sh, ok := findPowerShell([]string{"pwsh", "powershell"}); ok {
+				return sh
+			}
+		}
+		return Shell{Kind: ShellBash, Path: "bash"}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(prefer)) {
+	case "", "auto":
+		return auto()
+	case "bash":
+		if path != "" && exists(path) && probe(path) {
+			return Shell{Kind: ShellBash, Path: path}
+		}
+		if sh, ok := findBash(); ok {
+			return sh
+		}
+		warnMissingShell(warn, prefer)
+		return auto()
+	case "powershell", "pwsh":
+		if path != "" && exists(path) {
+			return Shell{Kind: ShellPowerShell, Path: path}
+		}
+		order := []string{"pwsh", "powershell"}
+		if strings.EqualFold(strings.TrimSpace(prefer), "powershell") {
+			order = []string{"powershell", "pwsh"}
+		}
+		if sh, ok := findPowerShell(order); ok {
+			return sh
+		}
+		warnMissingShell(warn, prefer)
+		return auto()
+	default:
+		if warn != nil {
+			fmt.Fprintf(warn, "warning: [tools.shell] prefer=%q is not recognised (use auto/bash/powershell); using auto-detection\n", prefer)
+		}
+		return auto()
+	}
+}
+
+func warnMissingShell(warn io.Writer, prefer string) {
+	if warn != nil {
+		fmt.Fprintf(warn, "warning: [tools.shell] prefer=%q but that shell was not found; using auto-detection\n", prefer)
+	}
 }
 
 // isWindowsWSLBash reports whether a resolved bash path is the WSL launcher

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -99,7 +99,10 @@ func (b bash) resolved() sandbox.Shell {
 	if b.shell.Path != "" {
 		return b.shell
 	}
-	return sandbox.ResolveShell()
+	if b.sb.Shell.Path != "" {
+		return b.sb.Shell
+	}
+	return sandbox.ResolveShell("", "", nil)
 }
 
 func (bash) Schema() json.RawMessage {

--- a/internal/tool/builtin/bash_cancel_test.go
+++ b/internal/tool/builtin/bash_cancel_test.go
@@ -18,7 +18,7 @@ func TestBashCancelReturnsPromptly(t *testing.T) {
 		t.Fatal("bash not registered")
 	}
 	cmd := "sleep 120"
-	if sandbox.ResolveShell().Kind == sandbox.ShellPowerShell {
+	if sandbox.ResolveShell("", "", nil).Kind == sandbox.ShellPowerShell {
 		cmd = "Start-Sleep -Seconds 120"
 	}
 	args, _ := json.Marshal(map[string]any{"command": cmd})

--- a/internal/tool/builtin/bash_timeout_test.go
+++ b/internal/tool/builtin/bash_timeout_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBashForegroundTimeoutConfig(t *testing.T) {
-	sh := sandbox.ResolveShell()
+	sh := sandbox.ResolveShell("", "", nil)
 	b := bash{shell: sh, timeout: 150 * time.Millisecond}
 
 	start := time.Now()
@@ -28,7 +28,7 @@ func TestBashForegroundTimeoutConfig(t *testing.T) {
 }
 
 func TestBashExplicitZeroTimeoutDoesNotCapForeground(t *testing.T) {
-	sh := sandbox.ResolveShell()
+	sh := sandbox.ResolveShell("", "", nil)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -47,7 +47,7 @@ func TestBashExplicitZeroTimeoutDoesNotCapForeground(t *testing.T) {
 }
 
 func TestWorkspacePassesBashTimeout(t *testing.T) {
-	sh := sandbox.ResolveShell()
+	sh := sandbox.ResolveShell("", "", nil)
 	b := byName(Workspace{Dir: t.TempDir(), BashTimeout: 150 * time.Millisecond}.Tools())["bash"]
 
 	out, err := b.Execute(context.Background(), argsJSON(t, map[string]any{"command": longSleepCommand(sh)}))

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -15,7 +15,11 @@ import (
 // the unconfined instance registered at init. When the spec enforces, bash runs
 // each command through the sandbox (see package sandbox).
 func ConfineBash(spec sandbox.Spec, timeout ...time.Duration) tool.Tool {
-	b := bash{sb: spec, shell: sandbox.ResolveShell()}
+	shell := spec.Shell
+	if shell.Path == "" {
+		shell = sandbox.ResolveShell("", "", nil)
+	}
+	b := bash{sb: spec, shell: shell}
 	if len(timeout) > 0 {
 		b.timeout = timeout[0]
 	}


### PR DESCRIPTION
Part of #4114. This is the **backend / config-file** half; the desktop Settings dropdown follows in a separate PR (it builds on this `[tools.shell]` field).

## Problem

The shell tool auto-detects its interpreter (real bash → Git-for-Windows bash → PowerShell) with no override. A Windows user who prefers PowerShell but has Git for Windows installed is stuck on Git bash.

## Change

A `[tools.shell]` config block, mirroring the existing `[tools.search]` engine config:

```toml
[tools.shell]
prefer = "powershell"   # auto (default) | bash | powershell | pwsh
# path = "C:\Program Files\PowerShell\7\pwsh.exe"   # optional explicit executable
```

- `prefer = "auto"` (default) is the exact current behaviour.
- `bash` / `powershell` / `pwsh` force that interpreter; `path` overrides the PATH lookup.
- A forced shell that isn't installed **warns at startup and falls back to auto-detection** (same posture as `[tools.search] engine="rg"`), so a typo can't break the tool.
- The resolved shell rides on `sandbox.Spec`, so it reaches both the agent's bash tool (via `ConfineBash`) and user-invoked `!` commands (the controller stores it). The "bash not found → using PowerShell" hint is suppressed once a shell is chosen explicitly.

## Cache

No impact by default: `prefer=auto` resolves identically to today, so the bash tool's description (the only shell-dependent part of the prompt) is byte-for-byte the same. Forcing a shell changes that description to match the chosen interpreter — intrinsic to switching shells, and stable per config.

## Tests

`resolveShell` is dependency-injected; the existing decision table is updated and a new `TestResolveShellPrefer` covers force / explicit-path / missing-shell-fallback / unknown-value. `go test ./internal/{sandbox,config,boot,control,tool/builtin}` green; `cd desktop && go build ./...` green; gofmt/vet clean.
