### PR TITLE
fix(agent): use unique IDs for host-advance todo_write events to prevent frontend panel merge

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -220,6 +220,11 @@ type Agent struct {
 	todoMu    sync.Mutex
 	todoState []evidence.TodoItem
 
+	// hostAdvanceSeq guarantees unique tool IDs across turns: every
+	// emitTodoState call increments it so the frontend always sees a fresh
+	// dispatch even when the same panel index is signed off in different turns.
+	hostAdvanceSeq atomic.Int64
+
 	// projectChecks are structured project instructions that complete_step can
 	// verify against same-turn bash receipts after a write-backed completion.
 	projectChecks []instruction.VerifyCheck
@@ -769,7 +774,7 @@ func (a *Agent) advanceCanonicalTodo(step string) {
 	snapshot := append([]evidence.TodoItem(nil), a.todoState...)
 	a.todoMu.Unlock()
 	a.recordTodoState(snapshot)
-	a.emitTodoState(snapshot)
+	a.emitTodoState(snapshot, m.Index)
 }
 
 // recordTodoState logs the host-advanced list as a synthetic todo_write receipt
@@ -810,12 +815,16 @@ func canonicalTodoStatus(s string) string {
 	return s
 }
 
-func (a *Agent) emitTodoState(todos []evidence.TodoItem) {
+// emitTodoState emits a synthetic todo_write event so the frontend task panel
+// reflects a host-advanced completion without the model re-sending the list.
+// itemIndex is the 1-based position of the completed todo in the panel.
+func (a *Agent) emitTodoState(todos []evidence.TodoItem, itemIndex int) {
 	args, err := json.Marshal(map[string]any{"todos": todos})
 	if err != nil {
 		return
 	}
-	t := event.Tool{ID: "host-advance", Name: "todo_write", Args: string(args), ReadOnly: true}
+	id := fmt.Sprintf("host-advance-%d-%d", a.hostAdvanceSeq.Add(1), itemIndex)
+	t := event.Tool{ID: id, Name: "todo_write", Args: string(args), ReadOnly: true}
 	a.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: t})
 	t.Output = "task list advanced by complete_step"
 	a.sink.Emit(event.Event{Kind: event.ToolResult, Tool: t})

--- a/internal/agent/complete_step_e2e_test.go
+++ b/internal/agent/complete_step_e2e_test.go
@@ -53,7 +53,7 @@ func evidenceRegistry() *tool.Registry {
 func hostAdvances(sink *recordSink) int {
 	n := 0
 	for _, e := range sink.kinds(event.ToolResult) {
-		if e.Tool.ID == "host-advance" {
+		if strings.HasPrefix(e.Tool.ID, "host-advance-") {
 			n++
 		}
 	}


### PR DESCRIPTION
Closes #4105

## Description

### Problem

`emitTodoState` emits a synthetic `todo_write` event after each `complete_step` sign-off to refresh the frontend TodoPanel.  Every event used the static tool ID `"host-advance"`:

    // Before — all sign-offs shared the same ID
    t := event.Tool{ID: "host-advance", Name: "todo_write", ...}

The frontend (`useController.ts`) resolves tool items by ID: when it finds an existing item, it updates it in place instead of creating a new one.  Multiple `complete_step` calls within a single turn therefore merged into one item, and the TodoPanel only rendered the first sign-off.  Subsequent advances were silently dropped.

Reproduction (reported in #4105):

1. Model sets up todo list: [A:in_progress, B:pending, C:pending]
2. Model signs off A → host advances → emit host-advance → panel shows 1/3 ✓
3. Model signs off B → host advances → emit host-advance → ID collision, merged → panel still 1/3 ✗
4. Model signs off C → host advances → emit host-advance → ID collision, merged → panel still 1/3 ✗

Impact: the model follows the system prompt ("you don't need a separate todo_write") but the panel never catches up.  The model's observed workaround is to manually re-send `todo_write` after every sign-off, adding turns and token overhead.

### Design

Add a monotonic `atomic.Int64` counter (`hostAdvanceSeq`) to the Agent struct, and pass the matched todo item index from `advanceCanonicalTodo` into `emitTodoState` to form a unique, self-documenting tool ID:

    // After
    id := fmt.Sprintf("host-advance-%d-%d", a.hostAdvanceSeq.Add(1), itemIndex)

| Component | Meaning | Purpose |
|-----------|---------|---------|
| `hostAdvanceSeq` (prefix) | Monotonic counter | Guarantees uniqueness across turns |
| `itemIndex` (suffix) | 1-based panel position | Self-documenting for debugging |

Examples:

    host-advance-1-1  → 1st advance, panel item 1
    host-advance-2-3  → 2nd advance, panel item 3
    host-advance-3-2  → 3rd advance, panel item 2

### Preserved (unchanged)

- `verifyTodoCompletionTransitions` (#2576: blocks unverified completions)
- `recordTodoState` (#4014: synthetic receipt for cross-turn gate)
- Canonical todo state, `rebuildTodoState`, `incompleteCanonicalTodos`
- Frontend matching (keys on `name === "todo_write"`, not ID)
- `plan-seed` synthetic events (separate ID namespace)
- No frontend changes required

### Related

- Closes #4105 (todo panel desync)
- Preserves guards from #2576, #2920, #4014

### Files changed

    internal/agent/agent.go                  | 15 ++++++++++++---
    internal/agent/complete_step_e2e_test.go |  2 +-
    2 files changed, 13 insertions(+), 4 deletions(-)

### Tests

All passing:
- `complete_step_e2e_test.go` — 5 E2E tests (helper updated for prefix match)
- `canonical_todo_test.go` — `TestAdvanceCanonicalTodoCompletesAndPromotes` etc.
- `evidence_flow_test.go` — 10 evidence flow tests
- `final_readiness_test.go` — cross-turn gate behaviour
- `internal/evidence` — receipt matching
- `internal/tool/builtin` — complete_step / todo_write execution