### PR TITLE
fix(desktop): reveal files via explorer.exe's full path, not a PATH lookup

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3897,7 +3897,18 @@ func revealPath(path string) error {
 	case "darwin":
 		return exec.Command("open", "-R", path).Start()
 	case "windows":
-		return exec.Command("explorer", "/select,", path).Start()
+		// explorer.exe lives in %SystemRoot%, which isn't always on PATH (the
+		// launch environment can strip it), so resolve it directly rather than
+		// relying on a PATH lookup.
+		explorer := "explorer.exe"
+		root := os.Getenv("SystemRoot")
+		if root == "" {
+			root = os.Getenv("windir")
+		}
+		if root != "" {
+			explorer = filepath.Join(root, "explorer.exe")
+		}
+		return exec.Command(explorer, "/select,", path).Start()
 	default:
 		dir := path
 		if info, err := os.Stat(path); err == nil && !info.IsDir() {

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -789,7 +789,7 @@ export function ProjectTree({
         label: t(revealLabelKey(platform)),
         disabled: !projectPath,
         onSelect: () => {
-          void app.RevealPath(projectPath);
+          void app.RevealPath(projectPath).catch(() => {});
           closeMenu();
         },
       },

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -864,7 +864,7 @@ export function WorkspacePanel({
   const revealInFileManager = () => {
     if (!treeMenu) return;
     setTreeMenu(null);
-    void app.RevealWorkspacePath(treeMenu.path);
+    void app.RevealWorkspacePath(treeMenu.path).catch(() => {});
   };
 
   const renderRows = (dir: string, depth: number): ReactElement[] => {


### PR DESCRIPTION
## Crash

Three crash-telemetry reports on Windows v1.6.0, all the same:

```
[unhandledrejection]
exec: "explorer": executable file not found in %PATH%
```

## Cause

`revealPath` ("Reveal in file manager") ran `exec.Command("explorer", "/select,", path)`, which does a PATH lookup. `explorer.exe` lives in `%SystemRoot%` (`C:\Windows`), and on installs whose launch environment doesn't carry `%SystemRoot%` on PATH the lookup fails. The two frontend callers fire the call with a bare `void app.RevealPath(...)` — no `.catch` — so the rejected promise became an `[unhandledrejection]` and got reported as a crash.

## Fix

- Resolve `explorer.exe` directly from `%SystemRoot%` (then `%windir%`), mirroring the `SystemRoot`/`windir` resolution already used in `sandbox/shell.go`. Falls back to the bare name if neither is set.
- Add `.catch(() => {})` at both reveal call sites (`ProjectTree`, `WorkspacePanel`) so any future reveal failure (deleted path, etc.) degrades silently instead of crash-reporting.

`cd desktop && go build ./... && go vet .` clean; gofmt clean. Frontend change is a one-token `.catch` at each site (no new bindings/types).
