### PR TITLE
fix(agent): bound compaction summary and mechanically fold on failure

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -38,6 +39,10 @@ const (
 	summaryTagOpen  = "<compaction-summary>"
 	summaryTagClose = "</compaction-summary>"
 )
+
+// summaryTimeout bounds one summarizer call so a stalled stream surfaces a clear
+// failure (then a mechanical fold) instead of hanging compaction indefinitely.
+const summaryTimeout = 90 * time.Second
 
 // summarySystemPrompt steers the executor to distill older history into a
 // structured briefing it can keep relying on after the originals are dropped.
@@ -237,10 +242,14 @@ func (a *Agent) compact(ctx context.Context, trigger, instructions string, force
 	// are spliced back verbatim, so a fact that reached a digest once is never
 	// re-summarized away and the user's own words are never touched. Digests
 	// accumulate (small) rather than collapsing into one lossy rolling summary.
-	summary, err := a.summarize(ctx, fold, instructions)
+	summary, err := a.summarizeWithRetry(ctx, fold, instructions)
 	if err != nil {
-		a.emitCompactionAborted(trigger)
-		return err
+		// Mechanical fold: the foldable region is already archived, so stand in a
+		// deterministic marker rather than aborting. /compact then always frees
+		// context (and auto-compaction can't loop on a still-full window); the
+		// verbatim user turns kept above are untouched.
+		a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "compaction summary unavailable (" + err.Error() + "); folded mechanically"})
+		summary = mechanicalFoldDigest(len(fold), archived)
 	}
 
 	compacted := make([]provider.Message, 0, head+len(kept)+1+len(msgs)-start)
@@ -491,6 +500,8 @@ func charsOfMessages(msgs []provider.Message) int {
 // is appended to the system prompt as extra focus guidance (from /compact <focus>
 // and/or a PreCompact hook).
 func (a *Agent) summarize(ctx context.Context, region []provider.Message, instructions string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, summaryTimeout)
+	defer cancel()
 	sys := summarySystemPrompt
 	if strings.TrimSpace(instructions) != "" {
 		sys += "\n\nAdditional focus for this compaction (prioritize keeping this):\n" + strings.TrimSpace(instructions)
@@ -506,20 +517,51 @@ func (a *Agent) summarize(ctx context.Context, region []provider.Message, instru
 		return "", err
 	}
 
+	// select on ctx.Done so a stalled stream (open but never delivering or closing)
+	// unblocks on timeout instead of pinning the "compacting…" placeholder forever.
 	var b strings.Builder
-	for chunk := range ch {
-		switch chunk.Type {
-		case provider.ChunkText:
-			b.WriteString(chunk.Text)
-		case provider.ChunkError:
-			return "", chunk.Err
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case chunk, ok := <-ch:
+			if !ok {
+				s := strings.TrimSpace(b.String())
+				if s == "" {
+					return "", fmt.Errorf("summarizer returned empty output")
+				}
+				return s, nil
+			}
+			switch chunk.Type {
+			case provider.ChunkText:
+				b.WriteString(chunk.Text)
+			case provider.ChunkError:
+				return "", chunk.Err
+			}
 		}
 	}
-	s := strings.TrimSpace(b.String())
-	if s == "" {
-		return "", fmt.Errorf("summarizer returned empty output")
+}
+
+// summarizeWithRetry retries one non-timeout failure (a transient stream drop or
+// rate blip); a timeout or a second failure returns so the caller folds
+// mechanically rather than waiting again.
+func (a *Agent) summarizeWithRetry(ctx context.Context, fold []provider.Message, instructions string) (string, error) {
+	summary, err := a.summarize(ctx, fold, instructions)
+	if err == nil || errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return summary, err
 	}
-	return s, nil
+	return a.summarize(ctx, fold, instructions)
+}
+
+// mechanicalFoldDigest is the deterministic stand-in used when the summarizer is
+// unreachable: the foldable region is already archived, so the digest just notes
+// the gap and points the model at the user for anything it needs from before it.
+func mechanicalFoldDigest(n int, archive string) string {
+	where := "."
+	if archive != "" {
+		where = " (archived to " + archive + ")."
+	}
+	return fmt.Sprintf("%d earlier message(s) were folded here to free context, but the automatic summary was unavailable%s Ask the user if you need details from before this point.", n, where)
 }
 
 // renderTranscript flattens messages into a readable transcript for summarization.

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"reasonix/internal/event"
@@ -18,13 +19,23 @@ type fakeProvider struct {
 	reply        string
 	promptTokens int
 	got          []provider.Message
+	streamErr    error // when set, Stream emits a ChunkError instead of the reply
+	hang         bool  // when true, Stream returns a channel that never sends or closes
 }
 
 func (f *fakeProvider) Name() string { return "fake" }
 
 func (f *fakeProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	f.got = req.Messages
+	if f.hang {
+		return make(chan provider.Chunk), nil
+	}
 	ch := make(chan provider.Chunk, 3)
+	if f.streamErr != nil {
+		ch <- provider.Chunk{Type: provider.ChunkError, Err: f.streamErr}
+		close(ch)
+		return ch, nil
+	}
 	ch <- provider.Chunk{Type: provider.ChunkText, Text: f.reply}
 	if f.promptTokens > 0 {
 		ch <- provider.Chunk{Type: provider.ChunkUsage, Usage: &provider.Usage{PromptTokens: f.promptTokens, TotalTokens: f.promptTokens}}
@@ -296,6 +307,53 @@ func TestCompactReplacesHistory(t *testing.T) {
 	}
 	if !strings.HasSuffix(entries[0].Name(), ".jsonl") {
 		t.Errorf("archive name = %q, want .jsonl", entries[0].Name())
+	}
+}
+
+// TestCompactFallsBackToMechanicalFoldWhenSummaryFails: when the summarizer is
+// unreachable, /compact must still free context (fold mechanically) and surface a
+// card, not hang or abort leaving a full window.
+func TestCompactFallsBackToMechanicalFoldWhenSummaryFails(t *testing.T) {
+	prov := &fakeProvider{streamErr: errors.New("provider down")}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, Content: "step one"},
+		{Role: provider.RoleUser, Content: "more"},
+		{Role: provider.RoleAssistant, Content: "step two"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	var got []event.Event
+	sink := event.FuncSink(func(e event.Event) { got = append(got, e) })
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir()}, sink)
+
+	before := len(sess.Messages)
+	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+		t.Fatalf("compact should fall back, not error: %v", err)
+	}
+	if len(sess.Messages) >= before {
+		t.Fatalf("session not compacted on summarizer failure: %d -> %d", before, len(sess.Messages))
+	}
+	var done *event.Compaction
+	for i := range got {
+		if got[i].Kind == event.CompactionDone {
+			done = &got[i].Compaction
+		}
+	}
+	if done == nil || !strings.Contains(done.Summary, "summary was unavailable") {
+		t.Fatalf("CompactionDone = %+v, want a mechanical-fold summary", done)
+	}
+}
+
+// TestSummarizeRespectsContextCancel: a stalled stream (open but never closing)
+// must unblock on context cancellation instead of pinning compaction forever.
+func TestSummarizeRespectsContextCancel(t *testing.T) {
+	a := New(&fakeProvider{hang: true}, tool.NewRegistry(), &Session{}, Options{}, event.Discard)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := a.summarize(ctx, []provider.Message{{Role: provider.RoleUser, Content: "x"}}, ""); err == nil {
+		t.Fatal("summarize must return when ctx is cancelled, not hang")
 	}
 }
 


### PR DESCRIPTION
## Problem

A user reported that `/compact` showed "compacting conversation…" and then **nothing** — no card, no error, indefinitely.

Root cause (traced through the code): after the `CompactionStarted` event, every *fast* failure already surfaces (`compact failed: …` for archive/stream/empty-output errors). The one gap was an **unbounded wait**:

- The CLI calls `ctrl.Compact(context.Background(), …)` — no deadline anywhere down the chain.
- `summarize` did `for chunk := range ch`, which only unblocks when the provider closes the channel — it never watched `ctx`.

So a stalled summarizer stream (open but never delivering/closing — a hung connection, or a reasoning model streaming thinking with no final text) pinned the "compacting…" placeholder forever: no `CompactionDone`, no error, no resolution.

## Fix

All in `internal/agent/compact.go`; the fold/keep algorithm is unchanged.

- **90s timeout** per summary call (`summaryTimeout`).
- **`select` on `ctx.Done()`** in the stream loop, so a stalled stream unblocks even if the provider never closes the channel.
- **One retry** on a non-timeout failure (transient stream drop / rate blip).
- **Mechanical fold fallback** when the summarizer is genuinely unreachable: the foldable region is already archived, so it's replaced with a deterministic marker. `/compact` then **always frees context** instead of aborting on a still-full window (and auto-compaction can't loop on one). Verbatim user turns are untouched.

## Cache safety

The fold/keep logic is unchanged; the fallback produces a digest with the **same structure** as a normal compaction (head + kept-verbatim + digest + tail), just with deterministic content. No new prompt-history cache hazard beyond what compaction already does.

## Tests

- `TestCompactFallsBackToMechanicalFoldWhenSummaryFails` — summarizer errors → session still compacts, `CompactionDone` carries a mechanical-fold summary.
- `TestSummarizeRespectsContextCancel` — a stalled (never-closing) stream returns on cancellation rather than hanging.
- Full `internal/agent` suite green.

## Deferred

Live progress streaming ("thinking…" during a slow summary) touches the CLI + desktop renderers and is a separate change; the 90s bound + always-resolving fallback already removes the "infinite nothing" symptom.
