### PR TITLE
fix(desktop): make the updater download resilient — retry, resume, IPv4 fallback

### DIFF
--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -164,8 +164,44 @@ func evaluate(current string, m *update.Manifest) UpdateInfo {
 	return info
 }
 
-// fetchBytes GETs a URL fully into memory.
+// downloadAttempts caps how many times a transient transport failure (connection
+// reset, read timeout, gateway 5xx) is retried before the update gives up. CN IPv6
+// routes to Cloudflare reset mid-transfer often enough that a retry or two usually
+// completes the download instead of surfacing a "forcibly closed" error.
+const downloadAttempts = 3
+
+// retryBackoff is the pause before the Nth retry; a package var so tests shrink it.
+var retryBackoff = func(attempt int) time.Duration { return time.Duration(attempt) * 500 * time.Millisecond }
+
+// retryTransient runs fetch up to downloadAttempts times, pausing between tries, and
+// returns the first success. It stops early when ctx is cancelled (window closed /
+// user cancelled). Only the transport is retried; the signature and sha256 checks
+// run downstream in downloadVerify and are not retried.
+func retryTransient(ctx context.Context, fetch func() ([]byte, error)) ([]byte, error) {
+	var data []byte
+	var err error
+	for attempt := 1; attempt <= downloadAttempts; attempt++ {
+		if data, err = fetch(); err == nil {
+			return data, nil
+		}
+		if ctx.Err() != nil || attempt == downloadAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(retryBackoff(attempt)):
+		}
+	}
+	return data, err
+}
+
+// fetchBytes GETs a URL fully into memory, retrying transient transport failures.
 func fetchBytes(ctx context.Context, c *http.Client, url string) ([]byte, error) {
+	return retryTransient(ctx, func() ([]byte, error) { return fetchBytesOnce(ctx, c, url) })
+}
+
+func fetchBytesOnce(ctx context.Context, c *http.Client, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -181,9 +217,14 @@ func fetchBytes(ctx context.Context, c *http.Client, url string) ([]byte, error)
 	return io.ReadAll(resp.Body)
 }
 
-// download fetches url into memory, invoking onProgress as bytes arrive. total is
-// the expected size for the progress denominator (overridden by Content-Length).
+// download fetches url into memory, invoking onProgress as bytes arrive, retrying
+// transient transport failures (a retry restarts the byte count from zero). total
+// is the expected size for the progress denominator (overridden by Content-Length).
 func download(ctx context.Context, c *http.Client, url string, total int64, onProgress func(received, total int64)) ([]byte, error) {
+	return retryTransient(ctx, func() ([]byte, error) { return downloadOnce(ctx, c, url, total, onProgress) })
+}
+
+func downloadOnce(ctx context.Context, c *http.Client, url string, total int64, onProgress func(received, total int64)) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/desktop/updater.go
+++ b/desktop/updater.go
@@ -15,6 +15,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -84,12 +85,18 @@ type updateProgress struct {
 	Err      string `json:"err,omitempty"`
 }
 
-func httpClient() (*http.Client, error) {
+func httpClient() (*http.Client, error) { return newHTTPClient(false) }
+
+// httpClientIPv4 pins the dialer to IPv4 — the download fallback when the default
+// (often IPv6-first) route to Cloudflare keeps resetting mid-transfer.
+func httpClientIPv4() (*http.Client, error) { return newHTTPClient(true) }
+
+func newHTTPClient(forceIPv4 bool) (*http.Client, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, err
 	}
-	return netclient.NewHTTPClient(cfg.NetworkProxySpec(), netclient.TransportOptions{})
+	return netclient.NewHTTPClient(cfg.NetworkProxySpec(), netclient.TransportOptions{ForceIPv4: forceIPv4})
 }
 
 // canSelfUpdate reports whether in-place update is possible. macOS is excluded:
@@ -173,32 +180,38 @@ const downloadAttempts = 3
 // retryBackoff is the pause before the Nth retry; a package var so tests shrink it.
 var retryBackoff = func(attempt int) time.Duration { return time.Duration(attempt) * 500 * time.Millisecond }
 
-// retryTransient runs fetch up to downloadAttempts times, pausing between tries, and
-// returns the first success. It stops early when ctx is cancelled (window closed /
-// user cancelled). Only the transport is retried; the signature and sha256 checks
+// retryTransient runs attempt 1..downloadAttempts of fetch, pausing between tries,
+// until one succeeds. fetch receives the 1-based attempt number so a caller can
+// switch transports on a retry. It stops early when ctx is cancelled (window closed
+// / user cancelled). Only the transport is retried; the signature and sha256 checks
 // run downstream in downloadVerify and are not retried.
-func retryTransient(ctx context.Context, fetch func() ([]byte, error)) ([]byte, error) {
-	var data []byte
+func retryTransient(ctx context.Context, fetch func(attempt int) error) error {
 	var err error
 	for attempt := 1; attempt <= downloadAttempts; attempt++ {
-		if data, err = fetch(); err == nil {
-			return data, nil
+		if err = fetch(attempt); err == nil {
+			return nil
 		}
 		if ctx.Err() != nil || attempt == downloadAttempts {
 			break
 		}
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return ctx.Err()
 		case <-time.After(retryBackoff(attempt)):
 		}
 	}
-	return data, err
+	return err
 }
 
 // fetchBytes GETs a URL fully into memory, retrying transient transport failures.
 func fetchBytes(ctx context.Context, c *http.Client, url string) ([]byte, error) {
-	return retryTransient(ctx, func() ([]byte, error) { return fetchBytesOnce(ctx, c, url) })
+	var data []byte
+	err := retryTransient(ctx, func(int) error {
+		var e error
+		data, e = fetchBytesOnce(ctx, c, url)
+		return e
+	})
+	return data, err
 }
 
 func fetchBytesOnce(ctx context.Context, c *http.Client, url string) ([]byte, error) {
@@ -217,35 +230,75 @@ func fetchBytesOnce(ctx context.Context, c *http.Client, url string) ([]byte, er
 	return io.ReadAll(resp.Body)
 }
 
-// download fetches url into memory, invoking onProgress as bytes arrive, retrying
-// transient transport failures (a retry restarts the byte count from zero). total
-// is the expected size for the progress denominator (overridden by Content-Length).
-func download(ctx context.Context, c *http.Client, url string, total int64, onProgress func(received, total int64)) ([]byte, error) {
-	return retryTransient(ctx, func() ([]byte, error) { return downloadOnce(ctx, c, url, total, onProgress) })
-}
-
-func downloadOnce(ctx context.Context, c *http.Client, url string, total int64, onProgress func(received, total int64)) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-	resp, err := c.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
-	}
-	if resp.ContentLength > 0 {
-		total = resp.ContentLength
-	}
+// download fetches url into memory, invoking onProgress as bytes arrive. A transient
+// transport failure is retried; the retry resumes from the bytes already received
+// via a Range request instead of restarting, and switches to the IPv4 fallback
+// client (when provided) since a reset usually means the IPv6 route is the problem.
+// total is the expected size for the progress denominator (refined from the response).
+func download(ctx context.Context, c, fallback *http.Client, url string, total int64, onProgress func(received, total int64)) ([]byte, error) {
 	var buf bytes.Buffer
-	pr := &progressReader{r: resp.Body, total: total, onProgress: onProgress}
-	if _, err := io.Copy(&buf, pr); err != nil {
+	err := retryTransient(ctx, func(attempt int) error {
+		client := c
+		if attempt > 1 && fallback != nil {
+			client = fallback
+		}
+		return downloadInto(ctx, client, url, &buf, &total, onProgress)
+	})
+	if err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+// downloadInto appends url's body to buf, resuming from buf's current length via a
+// Range request so a retry continues the partial download. A 206 carries the
+// remaining bytes; a 200 means the server ignored Range, so buf is reset and the
+// whole file re-downloaded. total is refined from the response for the progress
+// denominator (Content-Length on 200, the size field of Content-Range on 206).
+func downloadInto(ctx context.Context, c *http.Client, url string, buf *bytes.Buffer, total *int64, onProgress func(received, total int64)) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	if buf.Len() > 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", buf.Len()))
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		buf.Reset()
+		if resp.ContentLength > 0 {
+			*total = resp.ContentLength
+		}
+	case http.StatusPartialContent:
+		if t := totalFromContentRange(resp.Header.Get("Content-Range")); t > 0 {
+			*total = t
+		}
+	default:
+		return fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	have := int64(buf.Len())
+	pr := &progressReader{r: resp.Body, received: have, lastEmit: have, total: *total, onProgress: onProgress}
+	_, err = io.Copy(buf, pr)
+	return err
+}
+
+// totalFromContentRange parses the total size out of a "bytes 200-999/1000" header,
+// returning 0 when it's absent or "*" (unknown).
+func totalFromContentRange(v string) int64 {
+	i := strings.LastIndex(v, "/")
+	if i < 0 {
+		return 0
+	}
+	n, err := strconv.ParseInt(strings.TrimSpace(v[i+1:]), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // progressReader reports cumulative bytes read, throttled so the event channel

--- a/desktop/updater_app.go
+++ b/desktop/updater_app.go
@@ -127,7 +127,8 @@ func (a *App) downloadVerify(asset update.Asset) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	data, err := download(a.reqCtx(), c, asset.URL, asset.Size, func(rcv, total int64) {
+	v4, _ := httpClientIPv4() // best-effort IPv4 fallback; nil just means retries reuse c
+	data, err := download(a.reqCtx(), c, v4, asset.URL, asset.Size, func(rcv, total int64) {
 		a.emitProgress("downloading", rcv, total, "")
 	})
 	if err != nil {

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -4,9 +4,15 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"reasonix/desktop/internal/update"
 )
@@ -142,5 +148,84 @@ func TestExtractBinary(t *testing.T) {
 	}
 	if _, err := extractBinary(buf.Bytes(), "missing"); err == nil {
 		t.Error("missing entry should error")
+	}
+}
+
+func fastRetry(t *testing.T) {
+	t.Helper()
+	restore := retryBackoff
+	retryBackoff = func(int) time.Duration { return time.Millisecond }
+	t.Cleanup(func() { retryBackoff = restore })
+}
+
+func TestDownloadRecoversFromMidStreamReset(t *testing.T) {
+	fastRetry(t)
+	const body = "complete-installer-bytes"
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) < int32(downloadAttempts) {
+			// Mid-stream reset: promise 100 bytes, send a few, drop the socket —
+			// the client's body read fails with unexpected EOF, exactly the CN-IPv6
+			// "forcibly closed" case the retry exists for.
+			conn, bw, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			bw.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial")
+			bw.Flush()
+			conn.Close()
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	data, err := download(context.Background(), srv.Client(), srv.URL, 0, nil)
+	if err != nil {
+		t.Fatalf("download should recover after %d resets: %v", downloadAttempts-1, err)
+	}
+	if string(data) != body {
+		t.Fatalf("got %q, want %q", data, body)
+	}
+	if n := atomic.LoadInt32(&calls); n != int32(downloadAttempts) {
+		t.Fatalf("made %d attempts, want %d", n, downloadAttempts)
+	}
+}
+
+func TestDownloadGivesUpAfterCap(t *testing.T) {
+	fastRetry(t)
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Errorf("hijack: %v", err)
+			return
+		}
+		conn.Close()
+	}))
+	defer srv.Close()
+
+	if _, err := download(context.Background(), srv.Client(), srv.URL, 0, nil); err == nil {
+		t.Fatal("download should fail after exhausting retries")
+	}
+	if n := atomic.LoadInt32(&calls); n != int32(downloadAttempts) {
+		t.Fatalf("made %d attempts, want %d", n, downloadAttempts)
+	}
+}
+
+func TestRetryTransientStopsWhenCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	if _, err := retryTransient(ctx, func() ([]byte, error) {
+		calls++
+		return nil, errors.New("boom")
+	}); err == nil {
+		t.Fatal("cancelled retry should return the error")
+	}
+	if calls != 1 {
+		t.Fatalf("cancelled retry made %d calls, want 1", calls)
 	}
 }

--- a/desktop/updater_test.go
+++ b/desktop/updater_test.go
@@ -6,6 +6,8 @@ import (
 	"compress/gzip"
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -181,7 +183,7 @@ func TestDownloadRecoversFromMidStreamReset(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	data, err := download(context.Background(), srv.Client(), srv.URL, 0, nil)
+	data, err := download(context.Background(), srv.Client(), nil, srv.URL, 0, nil)
 	if err != nil {
 		t.Fatalf("download should recover after %d resets: %v", downloadAttempts-1, err)
 	}
@@ -207,7 +209,7 @@ func TestDownloadGivesUpAfterCap(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := download(context.Background(), srv.Client(), srv.URL, 0, nil); err == nil {
+	if _, err := download(context.Background(), srv.Client(), nil, srv.URL, 0, nil); err == nil {
 		t.Fatal("download should fail after exhausting retries")
 	}
 	if n := atomic.LoadInt32(&calls); n != int32(downloadAttempts) {
@@ -219,9 +221,9 @@ func TestRetryTransientStopsWhenCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	calls := 0
-	if _, err := retryTransient(ctx, func() ([]byte, error) {
+	if err := retryTransient(ctx, func(int) error {
 		calls++
-		return nil, errors.New("boom")
+		return errors.New("boom")
 	}); err == nil {
 		t.Fatal("cancelled retry should return the error")
 	}
@@ -229,3 +231,84 @@ func TestRetryTransientStopsWhenCancelled(t *testing.T) {
 		t.Fatalf("cancelled retry made %d calls, want 1", calls)
 	}
 }
+
+func TestDownloadResumesWithRange(t *testing.T) {
+	fastRetry(t)
+	full := bytes.Repeat([]byte("0123456789"), 50) // 500 bytes
+	const cut = 200
+	var calls int32
+	rangeCh := make(chan string, 4)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			// First attempt: promise the whole file, send a prefix, drop the socket.
+			conn, bw, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack: %v", err)
+				return
+			}
+			fmt.Fprintf(bw, "HTTP/1.1 200 OK\r\nContent-Length: %d\r\n\r\n", len(full))
+			bw.Write(full[:cut])
+			bw.Flush()
+			conn.Close()
+			return
+		}
+		// Resume attempt: honor the Range header with a 206 + Content-Range.
+		rng := r.Header.Get("Range")
+		rangeCh <- rng
+		start := 0
+		fmt.Sscanf(rng, "bytes=%d-", &start)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, len(full)-1, len(full)))
+		w.WriteHeader(http.StatusPartialContent)
+		w.Write(full[start:])
+	}))
+	defer srv.Close()
+
+	data, err := download(context.Background(), srv.Client(), nil, srv.URL, 0, nil)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if !bytes.Equal(data, full) {
+		t.Fatalf("assembled %d bytes, want %d (equal=%v)", len(data), len(full), bytes.Equal(data, full))
+	}
+	select {
+	case rng := <-rangeCh:
+		if rng != fmt.Sprintf("bytes=%d-", cut) {
+			t.Fatalf("resume Range = %q, want bytes=%d-", rng, cut)
+		}
+	default:
+		t.Fatal("resume attempt sent no Range header")
+	}
+}
+
+func TestDownloadFallsBackToSecondClient(t *testing.T) {
+	fastRetry(t)
+	const body = "served-over-ipv4"
+	primary := &http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("connection reset (ipv6)")
+	})}
+	var fbCalls int32
+	fallback := &http.Client{Transport: rtFunc(func(*http.Request) (*http.Response, error) {
+		atomic.AddInt32(&fbCalls, 1)
+		return &http.Response{
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(strings.NewReader(body)),
+			ContentLength: int64(len(body)),
+			Header:        make(http.Header),
+		}, nil
+	})}
+
+	data, err := download(context.Background(), primary, fallback, "http://example.invalid/x", 0, nil)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if string(data) != body {
+		t.Fatalf("got %q, want %q", data, body)
+	}
+	if atomic.LoadInt32(&fbCalls) == 0 {
+		t.Fatal("fallback client was never used after the primary failed")
+	}
+}
+
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -4,6 +4,7 @@
 package netclient
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -41,12 +42,14 @@ type ProxySpec struct {
 }
 
 // TransportOptions lets callers keep their existing network timeouts while
-// sharing proxy behavior.
+// sharing proxy behavior. ForceIPv4 pins the dialer to tcp4 — the desktop updater
+// uses it to retry over IPv4 when an IPv6 route (CN → Cloudflare) resets mid-transfer.
 type TransportOptions struct {
 	DialTimeout           time.Duration
 	KeepAlive             time.Duration
 	TLSHandshakeTimeout   time.Duration
 	ResponseHeaderTimeout time.Duration
+	ForceIPv4             bool
 }
 
 // NormalizeMode maps empty and unknown modes to auto, preserving a fail-open
@@ -95,9 +98,23 @@ func NewTransport(spec ProxySpec, opts TransportOptions) (*http.Transport, error
 		return nil, err
 	}
 	tr.Proxy = proxy
-	if opts.DialTimeout != 0 || opts.KeepAlive != 0 {
+	if opts.DialTimeout != 0 || opts.KeepAlive != 0 || opts.ForceIPv4 {
 		d := &net.Dialer{Timeout: opts.DialTimeout, KeepAlive: opts.KeepAlive}
-		tr.DialContext = d.DialContext
+		if opts.ForceIPv4 {
+			// Default-transport dialer uses 30s/30s; keep those when no explicit
+			// timeout is set so forcing IPv4 doesn't drop the dial deadline.
+			if d.Timeout == 0 {
+				d.Timeout = 30 * time.Second
+			}
+			if d.KeepAlive == 0 {
+				d.KeepAlive = 30 * time.Second
+			}
+			tr.DialContext = func(ctx context.Context, _, addr string) (net.Conn, error) {
+				return d.DialContext(ctx, "tcp4", addr)
+			}
+		} else {
+			tr.DialContext = d.DialContext
+		}
 	}
 	if opts.TLSHandshakeTimeout != 0 {
 		tr.TLSHandshakeTimeout = opts.TLSHandshakeTimeout

--- a/internal/netclient/netclient_test.go
+++ b/internal/netclient/netclient_test.go
@@ -559,3 +559,31 @@ func mustURL(s string) *url.URL {
 	}
 	return u
 }
+
+func TestForceIPv4Dials(t *testing.T) {
+	tr, err := NewTransport(ProxySpec{Mode: ModeOff}, TransportOptions{ForceIPv4: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tr.DialContext == nil {
+		t.Fatal("ForceIPv4 should install a DialContext")
+	}
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	conn, err := tr.DialContext(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("forced-IPv4 dial to a v4 listener failed: %v", err)
+	}
+	conn.Close()
+
+	// A tcp4 dialer rejects an IPv6 literal outright (address-family mismatch),
+	// which is exactly the IPv6 route the fallback is meant to skip.
+	if c, err := tr.DialContext(context.Background(), "tcp", "[::1]:9"); err == nil {
+		c.Close()
+		t.Error("forced-IPv4 dial should reject an IPv6 address")
+	}
+}


### PR DESCRIPTION
Makes the desktop self-updater survive flaky links — specifically the CN IPv6 → Cloudflare routes that reset mid-transfer and surfaced as:

> 更新失败：Get "https://dl.reasonix.io/desktop-v1.6.0/Reasonix-windows-amd64-installer.exe": ... wsarecv: An existing connection was forcibly closed by the remote host.

The updater did a single GET for the manifest, the installer asset, and the signature, and gave up on the first reset.

## Changes

1. **Retry transient transport failures** — `retryTransient` wraps the manifest, asset, and signature fetches and retries up to 3 times with a short backoff (0.5s, 1s), bailing immediately on context cancellation. Signature + sha256 verification stay downstream and terminal, so a corrupt body is never retried into a "success".

2. **Resume instead of restart** — on a retry, `download` sends a `Range: bytes=<n>-` request and continues from the bytes already received rather than re-pulling the whole tens-of-MB installer. A `206` carries the remainder (total taken from `Content-Range`); a `200` means the server ignored `Range`, so we reset and re-download in full.

3. **IPv4 fallback** — a first-try reset usually means the IPv6 route is the problem, so retries switch to an IPv4-pinned client. `netclient.TransportOptions` gains a `ForceIPv4` flag that pins the dialer to `tcp4` (preserving the default 30s dial/keep-alive). Off by default — no behavior change for any existing caller.

## Tests

- `TestDownloadRecoversFromMidStreamReset` — server truncates the body mid-stream for the first N-1 attempts, then serves the full body; download recovers.
- `TestDownloadResumesWithRange` — first attempt sends a prefix then drops the socket; the retry sends `Range: bytes=200-`, the server replies `206`, and the assembled bytes equal the original file.
- `TestDownloadFallsBackToSecondClient` — primary client always errors; download completes via the fallback client.
- `TestDownloadGivesUpAfterCap` / `TestRetryTransientStopsWhenCancelled` — persistent failure stops after the cap; a cancelled context short-circuits after one attempt.
- `TestForceIPv4Dials` (netclient) — the forced-IPv4 transport dials a v4 listener and rejects an IPv6 literal.

All updater + netclient tests pass locally (`go vet` clean). The race detector runs in CI (local box has no cgo/gcc).
