### PR TITLE
fix(desktop): isolate full composer state per tab (#4133)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -825,6 +825,7 @@ export default function App() {
     setGoal: setControllerGoal,
     clearGoal: clearControllerGoal,
     clearSession,
+    setDraft,
     listSessions,
     listTrashedSessions,
     resumeSession,
@@ -2992,6 +2993,7 @@ export default function App() {
               />
             )}
             <Composer
+              key={activeTabId}
               running={state.running}
               collaborationMode={collaborationMode}
               toolApprovalMode={toolApprovalMode}
@@ -3022,6 +3024,8 @@ export default function App() {
               turnTokens={state.turnTokens}
               retry={state.retry}
               transientDismissSignal={transientOverlayDismissSignal}
+              draft={state.draft}
+              onDraftChange={setDraft}
             />
             <StatusBar
               context={state.context}

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -11,7 +11,7 @@ import { SPINNER_WORDS, useI18n } from "../lib/i18n";
 import { detectShortcutPlatform, matchesShortcut } from "../lib/keyboardShortcuts";
 import { clearLayoutSize, loadOptionalLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
 import { useToast } from "../lib/toast";
-import { type CollaborationMode, type CommandInfo, type ComposerInsertRequest, type DirEntry, type EffortInfo, type HistoryMessage, type Mode, type PromptHistoryEntry, type SessionMeta, type SessionReference, type SlashArgItem, type SlashArgsResult, type TokenMode, type ToolApprovalMode } from "../lib/types";
+import { type CollaborationMode, type CommandInfo, type ComposerDraft, type ComposerInsertRequest, type DirEntry, type EffortInfo, type HistoryMessage, type Mode, type PromptHistoryEntry, type SessionMeta, type SessionReference, type SlashArgItem, type SlashArgsResult, type TokenMode, type ToolApprovalMode, type Attachment, type WorkspaceReference, type PastedBlock } from "../lib/types";
 import {
   formatWorkspaceReference,
   parseWorkspaceReference,
@@ -27,20 +27,9 @@ import { ModelSwitcher } from "./ModelSwitcher";
 import { Tooltip } from "./Tooltip";
 import { ComposerContextCard } from "./ComposerContextCard";
 
-interface Attachment {
-  path: string;
-  previewUrl?: string;
-  displayName?: string;
-}
-
 interface AttachmentDedupKey {
   hash: string;
   source: string;
-}
-
-interface WorkspaceReference {
-  path: string;
-  isDir?: boolean;
 }
 
 const LONG_PASTE_MIN_CHARS = 2000;
@@ -54,11 +43,6 @@ const PROMPT_HISTORY_PREFETCH_REMAINING = 3;
 // it; the real gap is a few ms, so keep it short or a deliberate quick second
 // Enter (submit) gets eaten too.
 const IME_CONFIRM_GRACE_MS = 100;
-
-type PastedBlock = {
-  label: string;
-  text: string;
-};
 
 type WebkitFileEntry = {
   isDirectory?: boolean;
@@ -350,6 +334,8 @@ export function Composer({
   turnTokens,
   retry,
   transientDismissSignal,
+  draft,
+  onDraftChange,
 }: {
   running: boolean;
   collaborationMode: CollaborationMode;
@@ -387,15 +373,17 @@ export function Composer({
   turnTokens?: number;
   retry?: { attempt: number; max: number };
   transientDismissSignal?: number;
+  draft: ComposerDraft;
+  onDraftChange?: (tabId: string, draft: ComposerDraft) => void;
 }) {
   const { t, locale } = useI18n();
   const { showToast } = useToast();
   const shortcutPlatform = useMemo(() => detectShortcutPlatform(), []);
   const now = useTick(running);
-  const [text, setText] = useState("");
-  const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const [workspaceRefs, setWorkspaceRefs] = useState<WorkspaceReference[]>([]);
-  const [pastedBlocks, setPastedBlocks] = useState<PastedBlock[]>([]);
+  const [text, setText] = useState(draft.text);
+  const [attachments, setAttachments] = useState<Attachment[]>(draft.attachments);
+  const [workspaceRefs, setWorkspaceRefs] = useState<WorkspaceReference[]>(draft.workspaceRefs);
+  const [pastedBlocks, setPastedBlocks] = useState<PastedBlock[]>(draft.pastedBlocks);
   const [openPastedLabels, setOpenPastedLabels] = useState<string[]>([]);
   const [pendingPaste, setPendingPaste] = useState(0);
   const pastedBlocksRef = useRef<PastedBlock[]>([]);
@@ -414,7 +402,7 @@ export function Composer({
   const [showPastChats, setShowPastChats] = useState(false);
   const [pastChats, setPastChats] = useState<SessionMeta[]>([]);
   const [pastChatQuery, setPastChatQuery] = useState("");
-  const [sessionRefs, setSessionRefs] = useState<SessionReference[]>([]);
+  const [sessionRefs, setSessionRefs] = useState<SessionReference[]>(draft.sessionRefs);
   const [loadingPastChats, setLoadingPastChats] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [composerPrompt, setComposerPrompt] = useState<string | null>(null);
@@ -447,6 +435,34 @@ export function Composer({
   // workspace switches and discard stale responses (issue #3601).
   const cwdRef = useRef(cwd);
   cwdRef.current = cwd;
+  // Track latest composer state so the unmount cleanup can save it to per-tab state (#4133).
+  const draftRef = useRef<ComposerDraft>(draft);
+  draftRef.current = { text, attachments, workspaceRefs, pastedBlocks, sessionRefs };
+  // On unmount (tab switch via key={activeTabId}), persist the current draft — but
+  // only if anything actually changed. Reference equality works because every piece
+  // of state is initialised from draft.*, so untouched arrays share the same ref.
+  useEffect(() => {
+    return () => {
+      if (!tabId || !onDraftChange) return;
+      const cur = draftRef.current;
+      if (
+        cur.text === draft.text &&
+        cur.attachments === draft.attachments &&
+        cur.workspaceRefs === draft.workspaceRefs &&
+        cur.pastedBlocks === draft.pastedBlocks &&
+        cur.sessionRefs === draft.sessionRefs
+      ) return;
+      onDraftChange(tabId, {
+        text: cur.text,
+        attachments: cur.attachments,
+        workspaceRefs: cur.workspaceRefs,
+        pastedBlocks: cur.pastedBlocks,
+        sessionRefs: cur.sessionRefs,
+      });
+    };
+    // draft is the mount-time prop — captured once, stable for this instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabId, onDraftChange]);
   const attachmentDedupRef = useRef(new DedupIndex());
   const attachmentDedupKeysRef = useRef<Record<string, AttachmentDedupKey>>({});
 

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -325,6 +325,34 @@ export interface SessionReference {
   lastActivityAt?: number;
 }
 
+// Attachment represents a file attached to the composer input.
+export interface Attachment {
+  path: string;
+  previewUrl?: string;
+  displayName?: string;
+}
+
+// WorkspaceReference represents a workspace file/directory @-mentioned in the composer.
+export interface WorkspaceReference {
+  path: string;
+  isDir?: boolean;
+}
+
+// PastedBlock is a collapsed long-paste block in the composer.
+export interface PastedBlock {
+  label: string;
+  text: string;
+}
+
+// ComposerDraft captures all per-tab composer state that should survive tab switches.
+export interface ComposerDraft {
+  text: string;
+  attachments: Attachment[];
+  workspaceRefs: WorkspaceReference[];
+  pastedBlocks: PastedBlock[];
+  sessionRefs: SessionReference[];
+}
+
 export interface WorkspaceView {
   path: string;
   name: string;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -16,6 +16,7 @@ import type {
   BalanceInfo,
   CheckpointMeta,
   CollaborationMode,
+  ComposerDraft,
   ContextInfo,
   EffortInfo,
   HistoryMessage,
@@ -39,6 +40,8 @@ export type ToolStatus = "running" | "done" | "error" | "stopped";
 export type LiveStream = { id: string; text: string; reasoning: string; reasoningComplete: boolean };
 export type MessageActionScope = "fork" | "summ-from" | "summ-upto" | "conversation" | "code" | "both";
 export type MessageActionState = { turn: number; scope: MessageActionScope };
+
+const emptyDraft: ComposerDraft = { text: "", attachments: [], workspaceRefs: [], pastedBlocks: [], sessionRefs: [] };
 
 export type Item =
   | { kind: "user"; id: string; text: string; submitText?: string; failed?: boolean; createdAt?: number }
@@ -96,6 +99,7 @@ interface State {
   live?: LiveStream;
   pendingUser?: string;
   discardTurn?: boolean;
+  draft: ComposerDraft;
   turnStartAt: number;
   turnTokens: number;
   turnTotalTokens: number;
@@ -119,6 +123,7 @@ export const initialState: State = {
   context: { used: 0, window: 0, sessionTokens: 0 },
   jobs: [],
   checkpoints: [],
+  draft: { ...emptyDraft },
   turnStartAt: 0,
   turnTokens: 0,
   turnTotalTokens: 0,
@@ -241,6 +246,7 @@ type Action =
   | { type: "local_notice"; level: "info" | "warn"; text: string }
   | { type: "clearApproval" }
   | { type: "clearAsk" }
+  | { type: "set_draft"; draft: ComposerDraft }
   | { type: "reset" };
 
 // ---- reducer helpers (unchanged logic) ----
@@ -678,7 +684,8 @@ export function reducer(s: State, a: Action): State {
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": return { ...s, approval: undefined, pendingPrompt: false };
     case "clearAsk": return { ...s, ask: undefined, pendingPrompt: false };
-    case "reset": return { ...initialState, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs, sessionGen: s.sessionGen + 1 };
+    case "set_draft": return { ...s, draft: a.draft };
+    case "reset": return { ...initialState, draft: { ...emptyDraft }, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs, sessionGen: s.sessionGen + 1 };
     case "event": return applyEvent(s, a.e);
     default: return s;
   }
@@ -1077,6 +1084,10 @@ export function useController() {
     if (tabId) dispatchTo(tabId, { type: "reset" });
   }, [activeTabId, bumpCheckpointRefreshSeq, dispatchTo]);
 
+  const setDraft = useCallback((tabId: string, draft: ComposerDraft) => {
+    dispatchTo(tabId, { type: "set_draft", draft });
+  }, [dispatchTo]);
+
   const listSessions = useCallback(async (): Promise<SessionMeta[]> => asArray<SessionMeta>(await app.ListSessions().catch(() => [])), []);
   const listTrashedSessions = useCallback(async (): Promise<SessionMeta[]> => asArray<SessionMeta>(await app.ListTrashedSessions().catch(() => [])), []);
   const resumeSession = useCallback(async (path: string, tabId?: string) => {
@@ -1283,7 +1294,7 @@ export function useController() {
     state: activeState,
     activeTabId,
     send, sendToTab, runShell, steer, notice, cancel, approve, answerQuestion, setControllerMode, setCollaborationMode, setToolApprovalMode, setGoal, clearGoal,
-    newSession, clearSession, listSessions, listTrashedSessions, resumeSession, openChannelSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
+    newSession, clearSession, setDraft, listSessions, listTrashedSessions, resumeSession, openChannelSession, previewSession, deleteSession, restoreSession, purgeTrashedSession, renameSession,
     refreshMeta, pickWorkspace, switchWorkspace, compact, rewind, setModel, setEffort, setTokenMode,
     fetchMemory, remember, forget, saveDoc,
     switchTab, openProjectTab, openGlobalTab, openTopicSession, ensureBlankTab, closeTab, reorderTabs,


### PR DESCRIPTION
## Problem

Fixes #4133. When multiple tabs are open, the composer input box content was shared across all tabs instead of being independent. Editing text (or attaching files, adding @-refs, pasting blocks, selecting past:chats sessions) in Tab A was visible
in Tab B and vice versa.

**Root cause**: The `<Composer>` component was a single instance without a `key` prop, so React preserved its local state across tab switches. The per-tab `State` map (`TabStates`) did not track any composer draft state.

## Solution

Three-part fix:

1. **Per-tab draft storage** — `State` interface gains a `draft: ComposerDraft` field that persists all user-facing composer state (text, attachments, workspace @-refs, pasted blocks, session refs) keyed by tab ID.

2. **Force remount on tab switch** — `<Composer key={activeTabId}>` ensures React unmounts the old tab's composer and mounts a fresh instance for the new tab.

3. **Save on unmount, restore on mount** — A `useEffect` cleanup saves the full `ComposerDraft` to per-tab state when the component unmounts. `useState` initial values read from the `draft` prop on mount. A reference-equality guard skips the save when nothing changed, avoiding wasted re-renders.

## Design decisions

| Decision | Rationale |
|---|---|
| `key={activeTabId}` instead of `useEffect` on `tabId` | Guarantees clean isolation — no state leaks between tabs. The saved draft is the only bridge. |
| `ComposerDraft` aggregate type | Single field is simpler than 5 separate draft fields; `setDraft` is one dispatch call per unmount. |
| Reference-equality guard in cleanup | `cur.text === draft.text && cur.attachments === draft.attachments …` — since every state is initialised from `draft.*`, untouched arrays share the same reference. Skipping the save avoids `setDraft → bump() → re-render`. |
| UI-only state (menus, drag, height) not persisted | These are transient and cheap to reset; `composerHeight` already has its own layout-preference persistence. |
| `setDraft` passed directly (not inline arrow) | `useCallback`-wrapped → stable reference → no effect re-trigger loop. |

## Files changed

| File | +/− | Notes |
|---|---|---|
| `desktop/frontend/src/lib/types.ts` | +28 | New `Attachment`, `WorkspaceReference`, `PastedBlock`, `ComposerDraft` types |
| `desktop/frontend/src/lib/useController.ts` | +15/−1 | `draft` field, `set_draft` action, `setDraft()` export, `reset` guard |
| `desktop/frontend/src/components/Composer.tsx` | +60/−23 | Import types from `types.ts`, restore/save full draft, skip-noop guard |
| `desktop/frontend/src/App.tsx` | +4 | `key={activeTabId}`, `draft={state.draft}`, `onDraftChange={setDraft}` |

## Verification

- ✅ 190 frontend unit tests pass (zero failures)
- ✅ TypeScript compiles cleanly (`tsc --noEmit`)
- ✅ Manually tested on Windows: multiple tabs each retain independent composer state (text, attachments, @-refs, pasted blocks) across tab switches