### PR TITLE
feat(desktop): add time filter to sidebar project tree

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -695,11 +695,11 @@ export default function App() {
   const [sidebarImExpanded, setSidebarImExpanded] = useState(false);
   const [isDevBuild, setIsDevBuild] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(loadSidebarCollapsed);
-  type TimeFilter = "all" | "10" | "1h" | "3h" | "5h" | "1d";
+  type TimeFilter = "all" | "10" | "20" | "1h" | "3h" | "5h" | "1d";
   const [topicTimeFilter, setTopicTimeFilter] = useState<TimeFilter>(() => {
     try {
       const saved = localStorage.getItem("projectTree:timeFilter");
-      if (saved === "all" || saved === "10" || saved === "1h" || saved === "3h" || saved === "5h" || saved === "1d") return saved;
+      if (saved === "all" || saved === "10" || saved === "20" || saved === "1h" || saved === "3h" || saved === "5h" || saved === "1d") return saved;
     } catch { /* localStorage unavailable */ }
     return "all";
   });

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -695,6 +695,17 @@ export default function App() {
   const [sidebarImExpanded, setSidebarImExpanded] = useState(false);
   const [isDevBuild, setIsDevBuild] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(loadSidebarCollapsed);
+  type TimeFilter = "all" | "10" | "1h" | "3h" | "5h" | "1d";
+  const [topicTimeFilter, setTopicTimeFilter] = useState<TimeFilter>(() => {
+    try {
+      const saved = localStorage.getItem("projectTree:timeFilter");
+      if (saved === "all" || saved === "10" || saved === "1h" || saved === "3h" || saved === "5h" || saved === "1d") return saved;
+    } catch { /* localStorage unavailable */ }
+    return "all";
+  });
+  useEffect(() => {
+    try { localStorage.setItem("projectTree:timeFilter", topicTimeFilter); } catch { /* ignore */ }
+  }, [topicTimeFilter]);
   const [sidebarWidth, setSidebarWidth] = useState(loadSidebarWidth);
   const [sidebarResizing, setSidebarResizing] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === "undefined" ? 1440 : window.innerWidth));
@@ -2281,6 +2292,8 @@ export default function App() {
               onAddProject={async () => {
                 await switchFolder();
               }}
+              timeFilter={topicTimeFilter}
+              onTimeFilterChange={setTopicTimeFilter}
             />
           </section>
 

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -995,18 +995,6 @@ export function ProjectTree({
           {t("projectTree.workspaceTitle")}
         </span>
         <span className="project-tree__header-actions">
-          <Tooltip label={collapseToggleLabel} className="project-tree__action-slot project-tree__header-action-slot project-tree__action-slot--collapse">
-            <button
-              type="button"
-              className={`project-tree__collapse-all${canRestoreCollapsedView ? " project-tree__collapse-all--restore" : ""}`}
-              aria-label={collapseToggleLabel}
-              aria-pressed={canRestoreCollapsedView}
-              disabled={!canToggleCollapsedView}
-              onClick={toggleCollapsedView}
-            >
-              {canRestoreCollapsedView ? <ListRestart size={14} /> : <ListCollapse size={14} />}
-            </button>
-          </Tooltip>
           <Tooltip label={t("projectTree.timeFilter")} className="project-tree__action-slot project-tree__header-action-slot">
             <div ref={filterRef} className="project-tree__time-filter">
               <button
@@ -1075,6 +1063,18 @@ export function ProjectTree({
                 </div>
               )}
             </div>
+          </Tooltip>
+          <Tooltip label={collapseToggleLabel} className="project-tree__action-slot project-tree__header-action-slot project-tree__action-slot--collapse">
+            <button
+              type="button"
+              className={`project-tree__collapse-all${canRestoreCollapsedView ? " project-tree__collapse-all--restore" : ""}`}
+              aria-label={collapseToggleLabel}
+              aria-pressed={canRestoreCollapsedView}
+              disabled={!canToggleCollapsedView}
+              onClick={toggleCollapsedView}
+            >
+              {canRestoreCollapsedView ? <ListRestart size={14} /> : <ListCollapse size={14} />}
+            </button>
           </Tooltip>
           <Tooltip label={t("projectTree.addProjectTooltip")} className="project-tree__action-slot project-tree__header-action-slot project-tree__action-slot--add">
             <button

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -4,10 +4,11 @@
 // new topic.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { Archive, ChevronRight, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check, ListCollapse, ListRestart, MessageSquare } from "lucide-react";
+import { Archive, ChevronRight, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check, ListCollapse, ListRestart, MessageSquare, Clock } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import type { ProjectNode, ProjectTopicStatus } from "../lib/types";
+import { topicActivityTime } from "../lib/session";
 import { getLocale, useT, type DictKey, type Translator } from "../lib/i18n";
 import { PROJECT_COLOR_OPTIONS, projectColorValue } from "../lib/projectColors";
 import { ContextMenu, contextMenuPointFromEvent, type ContextMenuItem, type ContextMenuPoint } from "./ContextMenu";
@@ -25,6 +26,8 @@ interface ProjectTreeProps {
   onRenameTopic?: (topicId: string, title: string) => Promise<void> | void;
   onTopicsChanged?: () => Promise<void> | void;
   refreshSignal?: number;
+  timeFilter: "all" | "10" | "1h" | "3h" | "5h" | "1d";
+  onTimeFilterChange: (filter: "all" | "10" | "1h" | "3h" | "5h" | "1d") => void;
 }
 
 type ProjectTreeImTopicSource = {
@@ -207,6 +210,8 @@ export function ProjectTree({
   onRenameTopic,
   onTopicsChanged,
   refreshSignal,
+  timeFilter,
+  onTimeFilterChange,
 }: ProjectTreeProps) {
   const t = useT();
   const [tree, setTree] = useState<ProjectNode[]>([]);
@@ -228,6 +233,8 @@ export function ProjectTree({
   const [dropProject, setDropProject] = useState<{ root: string; position: ProjectDropPosition } | null>(null);
   const [collapseSnapshot, setCollapseSnapshot] = useState<CollapseSnapshot | null>(null);
   const [platform, setPlatform] = useState("");
+  const filterRef = useRef<HTMLDivElement>(null);
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const creatingRef = useRef(false);
   const manuallyCollapsedRef = useRef(manuallyCollapsed);
 
@@ -282,6 +289,18 @@ export function ProjectTree({
       cancelled = true;
     };
   }, []);
+
+  // Close time-filter menu when clicking outside.
+  useEffect(() => {
+    if (!filterMenuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (filterRef.current && !filterRef.current.contains(e.target as Node)) {
+        setFilterMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [filterMenuOpen]);
 
   const toggleExpand = (key: string) => {
     const willCollapse = expanded.has(key);
@@ -493,20 +512,56 @@ export function ProjectTree({
 
   const visibleTree = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return tree;
-    const matches = (node: ProjectNode) =>
+    // Time filter: compute cutoff timestamp.
+    const diff = timeFilter === "1h" ? 60 * 60 * 1000
+      : timeFilter === "3h" ? 3 * 60 * 60 * 1000
+      : timeFilter === "5h" ? 5 * 60 * 60 * 1000
+      : timeFilter === "1d" ? 24 * 60 * 60 * 1000
+      : 0;
+    const cutoff: number | null = timeFilter === "all" ? null
+      : timeFilter === "10" ? (() => {
+          const times = new Set<number>();
+          const collect = (nodes: ProjectNode[]) => {
+            for (const n of nodes) {
+              if (n.kind === "topic" || n.kind === "global_topic") times.add(topicActivityTime(n));
+              collect(asArray(n.children));
+            }
+          };
+          collect(tree);
+          const sorted = [...times].sort((a, b) => b - a);
+          return sorted.length >= 10 ? sorted[9] : (sorted.length > 0 ? sorted[sorted.length - 1] : null);
+        })()
+      : Date.now() - diff;
+    const topicMatchesTime = (node: ProjectNode) => {
+      if (cutoff === null) return true;
+      if (timeFilter === "10") return topicActivityTime(node) >= cutoff;
+      return topicActivityTime(node) >= cutoff;
+    };
+    const matchesQuery = (node: ProjectNode) =>
       [node.label, node.root, node.topicId].some((value) => (value ?? "").toLowerCase().includes(q));
     const filterNode = (node: ProjectNode): ProjectNode | null => {
+      // For folder nodes: always show when time filter is active (so the tree structure remains navigable).
+      const isFolder = node.kind === "project" || node.kind === "global_folder";
       const children = asArray(node.children)
         .map(filterNode)
         .filter((child): child is ProjectNode => child !== null);
-      if (matches(node) || children.length > 0) return { ...node, children };
-      return null;
+      if (isFolder) {
+        if (cutoff !== null && children.length === 0 && !matchesQuery(node) && q === "") return null;
+        if (children.length > 0 || matchesQuery(node)) return { ...node, children };
+        if (q) return null;
+        // With only time filter, show folder if it has any child that matches the time.
+        const hasTimeMatch = asArray(node.children).some((c) => topicMatchesTime(c));
+        return hasTimeMatch ? { ...node, children: asArray(node.children).filter(topicMatchesTime) } : null;
+      }
+      if (!q && cutoff === null) return node;
+      if (cutoff !== null && !topicMatchesTime(node)) return null;
+      if (q && !matchesQuery(node)) return null;
+      return node;
     };
     return tree
       .map(filterNode)
       .filter((node): node is ProjectNode => node !== null);
-  }, [query, tree]);
+  }, [query, tree, timeFilter]);
 
   const projectDragEnabled = query.trim() === "";
 
@@ -952,6 +1007,75 @@ export function ProjectTree({
               {canRestoreCollapsedView ? <ListRestart size={14} /> : <ListCollapse size={14} />}
             </button>
           </Tooltip>
+          <Tooltip label={t("projectTree.timeFilter")} className="project-tree__action-slot project-tree__header-action-slot">
+            <div ref={filterRef} className="project-tree__time-filter">
+              <button
+                type="button"
+                className={`project-tree__header-action-btn${timeFilter !== "all" ? " project-tree__header-action-btn--active" : ""}`}
+                aria-label={t("projectTree.timeFilter")}
+                onClick={() => setFilterMenuOpen(!filterMenuOpen)}
+              >
+                <Clock size={14} />
+                {timeFilter !== "all" && (
+                  <span className="project-tree__time-filter-label">
+                    {timeFilter === "1d" ? "24h" : timeFilter}
+                  </span>
+                )}
+              </button>
+              {filterMenuOpen && (
+                <div className="project-tree__time-filter-menu" role="menu" aria-label={t("projectTree.timeFilter")}>
+                  <button
+                    type="button"
+                    className={`project-tree__time-filter-opt${timeFilter === "all" ? " project-tree__time-filter-opt--on" : ""}`}
+                    onClick={() => { onTimeFilterChange("all"); setFilterMenuOpen(false); }}
+                    role="menuitem"
+                  >
+                    {t("projectTree.timeFilterAll")}
+                  </button>
+                  <button
+                    type="button"
+                    className={`project-tree__time-filter-opt${timeFilter === "10" ? " project-tree__time-filter-opt--on" : ""}`}
+                    onClick={() => { onTimeFilterChange("10"); setFilterMenuOpen(false); }}
+                    role="menuitem"
+                  >
+                    {t("projectTree.timeFilter10")}
+                  </button>
+                  <button
+                    type="button"
+                    className={`project-tree__time-filter-opt${timeFilter === "1h" ? " project-tree__time-filter-opt--on" : ""}`}
+                    onClick={() => { onTimeFilterChange("1h"); setFilterMenuOpen(false); }}
+                    role="menuitem"
+                  >
+                    {t("projectTree.timeFilter1h")}
+                  </button>
+                  <button
+                    type="button"
+                    className={`project-tree__time-filter-opt${timeFilter === "3h" ? " project-tree__time-filter-opt--on" : ""}`}
+                    onClick={() => { onTimeFilterChange("3h"); setFilterMenuOpen(false); }}
+                    role="menuitem"
+                  >
+                    {t("projectTree.timeFilter3h")}
+                  </button>
+                  <button
+                    type="button"
+                    className={`project-tree__time-filter-opt${timeFilter === "5h" ? " project-tree__time-filter-opt--on" : ""}`}
+                    onClick={() => { onTimeFilterChange("5h"); setFilterMenuOpen(false); }}
+                    role="menuitem"
+                  >
+                    {t("projectTree.timeFilter5h")}
+                  </button>
+                  <button
+                    type="button"
+                    className={`project-tree__time-filter-opt${timeFilter === "1d" ? " project-tree__time-filter-opt--on" : ""}`}
+                    onClick={() => { onTimeFilterChange("1d"); setFilterMenuOpen(false); }}
+                    role="menuitem"
+                  >
+                    {t("projectTree.timeFilter1d")}
+                  </button>
+                </div>
+              )}
+            </div>
+          </Tooltip>
           <Tooltip label={t("projectTree.addProjectTooltip")} className="project-tree__action-slot project-tree__header-action-slot project-tree__action-slot--add">
             <button
               type="button"
@@ -969,6 +1093,16 @@ export function ProjectTree({
         {visibleTree.length === 0 ? (
           query.trim() ? (
             <div className="project-tree__empty">{t("projectTree.emptyNoMatch")}</div>
+          ) : timeFilter !== "all" ? (
+            <div className="project-tree__empty">{t("projectTree.emptyNoTimeFilterMatch")}
+              <button
+                type="button"
+                className="project-tree__empty-primary"
+                onClick={() => onTimeFilterChange("all")}
+              >
+                {t("projectTree.clearTimeFilter")}
+              </button>
+            </div>
           ) : (
             <div className="project-tree__empty-state">
               <div className="project-tree__empty project-tree__empty--subtle">{t("projectTree.emptyNoProjects")}</div>

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -546,7 +546,6 @@ export function ProjectTree({
       : Date.now() - diff;
     const topicMatchesTime = (node: ProjectNode) => {
       if (cutoff === null) return true;
-      if (timeFilter === "10" || timeFilter === "20") return topicActivityTime(node) >= cutoff;
       return topicActivityTime(node) >= cutoff;
     };
     const matchesQuery = (node: ProjectNode) =>

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1032,6 +1032,7 @@ export function ProjectTree({
                   >
                     {t("projectTree.timeFilterAll")}
                   </button>
+                  <div className="project-tree__time-filter-sep" role="separator" />
                   <button
                     type="button"
                     className={`project-tree__time-filter-opt${timeFilter === "10" ? " project-tree__time-filter-opt--on" : ""}`}
@@ -1048,6 +1049,7 @@ export function ProjectTree({
                   >
                     {t("projectTree.timeFilter20")}
                   </button>
+                  <div className="project-tree__time-filter-sep" role="separator" />
                   <button
                     type="button"
                     className={`project-tree__time-filter-opt${timeFilter === "1h" ? " project-tree__time-filter-opt--on" : ""}`}

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -26,8 +26,8 @@ interface ProjectTreeProps {
   onRenameTopic?: (topicId: string, title: string) => Promise<void> | void;
   onTopicsChanged?: () => Promise<void> | void;
   refreshSignal?: number;
-  timeFilter: "all" | "10" | "1h" | "3h" | "5h" | "1d";
-  onTimeFilterChange: (filter: "all" | "10" | "1h" | "3h" | "5h" | "1d") => void;
+  timeFilter: "all" | "10" | "20" | "1h" | "3h" | "5h" | "1d";
+  onTimeFilterChange: (filter: "all" | "10" | "20" | "1h" | "3h" | "5h" | "1d") => void;
 }
 
 type ProjectTreeImTopicSource = {
@@ -531,10 +531,22 @@ export function ProjectTree({
           const sorted = [...times].sort((a, b) => b - a);
           return sorted.length >= 10 ? sorted[9] : (sorted.length > 0 ? sorted[sorted.length - 1] : null);
         })()
+      : timeFilter === "20" ? (() => {
+          const times = new Set<number>();
+          const collect = (nodes: ProjectNode[]) => {
+            for (const n of nodes) {
+              if (n.kind === "topic" || n.kind === "global_topic") times.add(topicActivityTime(n));
+              collect(asArray(n.children));
+            }
+          };
+          collect(tree);
+          const sorted = [...times].sort((a, b) => b - a);
+          return sorted.length >= 20 ? sorted[19] : (sorted.length > 0 ? sorted[sorted.length - 1] : null);
+        })()
       : Date.now() - diff;
     const topicMatchesTime = (node: ProjectNode) => {
       if (cutoff === null) return true;
-      if (timeFilter === "10") return topicActivityTime(node) >= cutoff;
+      if (timeFilter === "10" || timeFilter === "20") return topicActivityTime(node) >= cutoff;
       return topicActivityTime(node) >= cutoff;
     };
     const matchesQuery = (node: ProjectNode) =>
@@ -995,7 +1007,7 @@ export function ProjectTree({
           {t("projectTree.workspaceTitle")}
         </span>
         <span className="project-tree__header-actions">
-          <Tooltip label={t("projectTree.timeFilter")} className="project-tree__action-slot project-tree__header-action-slot">
+          <Tooltip label={t("projectTree.timeFilter")} className="project-tree__action-slot project-tree__header-action-slot project-tree__header-action-slot--filter">
             <div ref={filterRef} className="project-tree__time-filter">
               <button
                 type="button"
@@ -1027,6 +1039,14 @@ export function ProjectTree({
                     role="menuitem"
                   >
                     {t("projectTree.timeFilter10")}
+                  </button>
+                  <button
+                    type="button"
+                    className={`project-tree__time-filter-opt${timeFilter === "20" ? " project-tree__time-filter-opt--on" : ""}`}
+                    onClick={() => { onTimeFilterChange("20"); setFilterMenuOpen(false); }}
+                    role="menuitem"
+                  >
+                    {t("projectTree.timeFilter20")}
                   </button>
                   <button
                     type="button"

--- a/desktop/frontend/src/lib/session.ts
+++ b/desktop/frontend/src/lib/session.ts
@@ -1,5 +1,12 @@
-import type { SessionMeta } from "./types";
+import type { ProjectNode, SessionMeta } from "./types";
 
 export function sessionActivityTime(session: SessionMeta): number {
   return session.lastActivityAt ?? session.modTime;
+}
+
+// topicActivityTime returns the last-activity timestamp for a sidebar topic
+// node. Falls back to the topic's creation time so blank topics (no session
+// files yet) are still visible under time-based filters.
+export function topicActivityTime(node: ProjectNode): number {
+  return node.lastActivityAt || node.createdAt || 0;
 }

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -526,6 +526,7 @@ export const en = {
   "projectTree.timeFilter": "Filter by time",
   "projectTree.timeFilterAll": "All",
   "projectTree.timeFilter10": "Latest 10",
+  "projectTree.timeFilter20": "Latest 20",
   "projectTree.timeFilter1h": "Last hour",
   "projectTree.timeFilter3h": "Last 3 hours",
   "projectTree.timeFilter5h": "Last 5 hours",

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -523,6 +523,15 @@ export const en = {
   "projectTree.addProjectTooltip": "Add new project",
   "projectTree.collapseAllTooltip": "Collapse all projects",
   "projectTree.restoreCollapsedTooltip": "Restore previous view",
+  "projectTree.timeFilter": "Filter by time",
+  "projectTree.timeFilterAll": "All",
+  "projectTree.timeFilter10": "Latest 10",
+  "projectTree.timeFilter1h": "Last hour",
+  "projectTree.timeFilter3h": "Last 3 hours",
+  "projectTree.timeFilter5h": "Last 5 hours",
+  "projectTree.timeFilter1d": "Last 24 hours",
+  "projectTree.emptyNoTimeFilterMatch": "No topics match the time filter",
+  "projectTree.clearTimeFilter": "Clear filter",
 
   // memory drawer
   "memory.title": "Memory",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -524,6 +524,15 @@ export const zh: Record<DictKey, string> = {
   "projectTree.addProjectTooltip": "添加新项目",
   "projectTree.collapseAllTooltip": "收起所有项目",
   "projectTree.restoreCollapsedTooltip": "恢复上次展开",
+  "projectTree.timeFilter": "按时间筛选",
+  "projectTree.timeFilterAll": "全部时间",
+  "projectTree.timeFilter10": "最新 10 条",
+  "projectTree.timeFilter1h": "最近 1 小时",
+  "projectTree.timeFilter3h": "最近 3 小时",
+  "projectTree.timeFilter5h": "最近 5 小时",
+  "projectTree.timeFilter1d": "最近 1 天",
+  "projectTree.emptyNoTimeFilterMatch": "没有话题符合时间筛选条件",
+  "projectTree.clearTimeFilter": "清除筛选",
 
   // 记忆抽屉
   "memory.title": "记忆",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -527,6 +527,7 @@ export const zh: Record<DictKey, string> = {
   "projectTree.timeFilter": "按时间筛选",
   "projectTree.timeFilterAll": "全部时间",
   "projectTree.timeFilter10": "最新 10 条",
+  "projectTree.timeFilter20": "最新 20 条",
   "projectTree.timeFilter1h": "最近 1 小时",
   "projectTree.timeFilter3h": "最近 3 小时",
   "projectTree.timeFilter5h": "最近 5 小时",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14365,6 +14365,7 @@ a[href] {
 
 .project-tree__add-project,
 .project-tree__collapse-all,
+.project-tree__header-action-btn,
 .project-tree__new-topic {
   --wails-draggable: no-drag;
   width: 24px;
@@ -14381,7 +14382,8 @@ a[href] {
 }
 
 .project-tree__header-actions .project-tree__add-project,
-.project-tree__header-actions .project-tree__collapse-all {
+.project-tree__header-actions .project-tree__collapse-all,
+.project-tree__header-actions .project-tree__header-action-btn {
   width: 22px;
   height: 22px;
   border-radius: 7px;
@@ -14390,7 +14392,8 @@ a[href] {
 }
 
 .project-tree__add-project:hover:not(:disabled),
-.project-tree__collapse-all:hover:not(:disabled) {
+.project-tree__collapse-all:hover:not(:disabled),
+.project-tree__header-action-btn:hover {
   background: var(--button-bg);
   border-color: color-mix(in srgb, var(--accent) 28%, var(--border-soft));
   color: var(--fg);
@@ -14398,7 +14401,8 @@ a[href] {
 }
 
 .project-tree__add-project:disabled,
-.project-tree__collapse-all:disabled {
+.project-tree__collapse-all:disabled,
+.project-tree__header-action-btn:disabled {
   cursor: default;
   opacity: 0.34;
 }
@@ -14410,29 +14414,13 @@ a[href] {
   opacity: 0.96;
 }
 
-/* Time filter button in the project tree header — same size/shape as collapse/add buttons. */
-.project-tree__header-action-btn {
-  --wails-draggable: no-drag;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 7px;
-  border: 0.5px solid transparent;
-  background: var(--bg-elev);
-  box-shadow: 0 1px 2px color-mix(in srgb, var(--shadow) 9%, transparent);
-  color: var(--fg-muted);
-  cursor: pointer;
+/* Header-action-btn in the header-actions row uses min-width so it can
+   expand when a time-filter label is shown alongside the clock icon. */
+.project-tree__header-actions .project-tree__header-action-btn {
+  min-width: 22px;
   transition: background 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
-  gap: 1px;
 }
-.project-tree__header-action-btn:hover {
-  background: var(--button-bg);
-  border-color: color-mix(in srgb, var(--accent) 28%, var(--border-soft));
-  color: var(--fg);
-  opacity: 1;
-}
+
 .project-tree__header-action-btn--active {
   border-color: color-mix(in srgb, var(--accent) 24%, var(--border-soft));
   background: color-mix(in srgb, var(--accent) 9%, var(--bg-elev));

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14417,8 +14417,15 @@ a[href] {
 /* Header-action-btn in the header-actions row uses min-width so it can
    expand when a time-filter label is shown alongside the clock icon. */
 .project-tree__header-actions .project-tree__header-action-btn {
+  width: auto;
   min-width: 22px;
-  transition: background 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+  padding: 0 4px;
+}
+
+/* Time-filter action slot: no fixed width so the button can grow when label shown. */
+.project-tree__header-action-slot--filter {
+  flex-basis: auto !important;
+  width: auto !important;
 }
 
 .project-tree__header-action-btn--active {
@@ -14436,7 +14443,7 @@ a[href] {
 .project-tree__time-filter-label {
   font-size: 9px;
   line-height: 1;
-  margin-left: 1px;
+  margin-left: 3px;
   font-weight: 500;
 }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14495,7 +14495,8 @@ a[href] {
 }
 
 .project-tree__header-actions .project-tree__add-project:focus-visible,
-.project-tree__header-actions .project-tree__collapse-all:focus-visible {
+.project-tree__header-actions .project-tree__collapse-all:focus-visible,
+.project-tree__header-actions .project-tree__header-action-btn:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring);
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14410,6 +14410,89 @@ a[href] {
   opacity: 0.96;
 }
 
+/* Time filter button in the project tree header — same size/shape as collapse/add buttons. */
+.project-tree__header-action-btn {
+  --wails-draggable: no-drag;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  border: 0.5px solid transparent;
+  background: var(--bg-elev);
+  box-shadow: 0 1px 2px color-mix(in srgb, var(--shadow) 9%, transparent);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+  gap: 1px;
+}
+.project-tree__header-action-btn:hover {
+  background: var(--button-bg);
+  border-color: color-mix(in srgb, var(--accent) 28%, var(--border-soft));
+  color: var(--fg);
+  opacity: 1;
+}
+.project-tree__header-action-btn--active {
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border-soft));
+  background: color-mix(in srgb, var(--accent) 9%, var(--bg-elev));
+  color: var(--accent);
+  opacity: 0.96;
+}
+
+.project-tree__time-filter {
+  display: inline-flex;
+  position: relative;
+}
+
+.project-tree__time-filter-label {
+  font-size: 9px;
+  line-height: 1;
+  margin-left: 1px;
+  font-weight: 500;
+}
+
+.project-tree__time-filter-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: var(--z-menu);
+  min-width: 84px;
+  padding: 4px;
+  border: none;
+  border-radius: 8px;
+  background: var(--bg-elev);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+}
+
+.project-tree__time-filter-opt {
+  --wails-draggable: no-drag;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  height: 28px;
+  padding: 0 8px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.project-tree__time-filter-opt:hover {
+  background: var(--sidebar-hover);
+  color: var(--fg);
+}
+
+.project-tree__time-filter-opt--on {
+  color: var(--accent);
+  font-weight: 400;
+}
+
 .project-tree__header-actions .project-tree__add-project:focus-visible,
 .project-tree__header-actions .project-tree__collapse-all:focus-visible {
   outline: none;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14488,6 +14488,12 @@ a[href] {
   font-weight: 400;
 }
 
+.project-tree__time-filter-sep {
+  height: 1px;
+  margin: 4px 8px;
+  background: var(--border-soft);
+}
+
 .project-tree__header-actions .project-tree__add-project:focus-visible,
 .project-tree__header-actions .project-tree__collapse-all:focus-visible {
   outline: none;


### PR DESCRIPTION
Add a clock button in the project tree header that lets users filter sidebar topics by time.

- All / Latest 10 / Latest 20 / Last 1h / 3h / 5h / 24h
- Dropdown grouped into three sections (all / count / time)
- Pure frontend filtering using `topicActivityTime()`
- Persistent filter state via `localStorage`
- Empty-state message + clear filter button when no results match

### Notes
- Backend (Go) changes for `CreatedAt` persistence on `ProjectNode` were already present in upstream, no backend changes needed
- Only frontend changes (6 files, +290/-10 lines)
- Filter is purely client-side, no extra API calls