### PR TITLE
fix(config): show the real per-OS user config path in docs and output / 修正各平台用户配置路径文档与输出

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ model       = "deepseek-v4-flash"
 api_key_env = "DEEPSEEK_API_KEY"
 ```
 
-Resolution order is **flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` >
-built-in defaults**; secrets come from the environment via `api_key_env` and are
+Resolution order is **flag > `./reasonix.toml` > the user config file >
+built-in defaults**; the user file lives in your OS config dir — `~/.config/reasonix/`
+on Linux, `~/Library/Application Support/reasonix/` on macOS, `%AppData%\reasonix\` on
+Windows. Secrets come from the environment via `api_key_env` and are
 never written to config files. Permissions, the sandbox, plugins (MCP), slash
 commands, `@` references, and two-model setup are all in the
 **[Guide](./docs/GUIDE.md)**.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,7 +108,8 @@ model       = "deepseek-v4-flash"
 api_key_env = "DEEPSEEK_API_KEY"
 ```
 
-优先级为 **flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` > 内置默认值**;
+优先级为 **flag > `./reasonix.toml` > 用户配置文件 > 内置默认值**;用户配置位于操作系统的配置目录——
+Linux 为 `~/.config/reasonix/`,macOS 为 `~/Library/Application Support/reasonix/`,Windows 为 `%AppData%\reasonix\`。
 密钥经环境变量通过 `api_key_env` 注入,绝不写入配置文件。权限、沙盒、插件(MCP)、
 斜杠命令、`@` 引用与双模型设置,全部在 **[指南](./docs/GUIDE.zh-CN.md)** 里。
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -21,8 +21,10 @@
 
 ## Configuration
 
-Resolution order: **flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` >
-built-in defaults**. Secrets come from the environment via `api_key_env` and are
+Resolution order: **flag > `./reasonix.toml` > the user config file >
+built-in defaults**. The user config lives in your OS config dir: `~/.config/reasonix/`
+on Linux, `~/Library/Application Support/reasonix/` on macOS, `%AppData%\reasonix\` on
+Windows. Secrets come from the environment via `api_key_env` and are
 never stored in config files.
 
 ```toml

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -21,7 +21,8 @@
 
 ## 配置
 
-优先级：**flag > `./reasonix.toml` > `~/.config/reasonix/config.toml` > 内置默认值**。
+优先级：**flag > `./reasonix.toml` > 用户配置文件 > 内置默认值**。用户配置位于操作系统配置目录：
+Linux 为 `~/.config/reasonix/`，macOS 为 `~/Library/Application Support/reasonix/`，Windows 为 `%AppData%\reasonix\`。
 密钥经环境变量通过 `api_key_env` 注入，绝不写入配置文件。
 
 ```toml

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -52,7 +52,7 @@ cd DeepSeek-Reasonix && make build                        # -> bin/reasonix(.exe
 
 | Legacy | Reasonix 1.0 |
 |---|---|
-| TS config files | `reasonix.toml` (project) / `~/.config/reasonix/config.toml` (user) — see `reasonix.example.toml` |
+| TS config files | `reasonix.toml` (project) / `config.toml` in your OS config dir (user; `~/.config/reasonix/` on Linux, `~/Library/Application Support/reasonix/` on macOS, `%AppData%\reasonix\` on Windows) — see `reasonix.example.toml` |
 | env / API keys | `.env` or the environment (`DEEPSEEK_API_KEY`, `MIMO_API_KEY`, …) via `api_key_env` |
 | project memory | `REASONIX.md` (+ auto-memory), Claude-Code-compatible |
 | MCP servers | `[[plugins]]` in `reasonix.toml`, or a Claude-Code `.mcp.json` (read as-is) |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -190,8 +190,9 @@ Long tasks eventually fill the model's context window. Reasonix manages this wit
   remainder is summarized — using the executor's own provider, no tools — in
   place. The boundary is aligned backward off any tool result so the recent tail
   never begins with an orphan tool message whose `tool_calls` were summarized away.
-- The dropped originals are archived to `~/.config/reasonix/archive/<timestamp>.jsonl`
-  (one message per line), so the full history stays traceable.
+- The dropped originals are archived under the user config dir
+  (`reasonix/archive/<timestamp>.jsonl`; see §5 for its per-OS location), one
+  message per line, so the full history stays traceable.
 - The read-only `history` tool gives the agent on-demand BM25 retrieval over
   saved session JSONL files. `scope="project"` searches the current controller's
   session directory; `scope="global"` also searches the user-global session
@@ -332,7 +333,7 @@ The chat TUI accepts `/command` input. Three kinds share one dispatch:
   confirmation, then discards the current context without saving it; it does not
   delete project memory.
 - **Custom commands** are Markdown files under `.reasonix/commands/` (project) and
-  `~/.config/reasonix/commands/` (user); the project dir overrides the user dir on a
+  `reasonix/commands/` in your OS config dir (user; see §5); the project dir overrides the user dir on a
   name clash. A file `review.md` becomes `/review`; a subdirectory namespaces it
   (`git/commit.md` → `/git:commit`). Invoking one renders its body and sends the
   result as the next user turn.
@@ -427,8 +428,10 @@ type Chunk struct {
 
 ## 5. Configuration (TOML)
 
-Resolution order: **flag > project `./reasonix.toml` > user `~/.config/reasonix/config.toml`
-> built-in defaults**. Secrets come from the environment via `api_key_env` and
+Resolution order: **flag > project `./reasonix.toml` > the user config file
+> built-in defaults**. The user config lives in your OS config dir — `~/.config/reasonix/`
+on Linux, `~/Library/Application Support/reasonix/` on macOS, `%AppData%\reasonix\` on
+Windows. Secrets come from the environment via `api_key_env` and
 are never stored in config files. A `.env` in the working directory is loaded if
 present. Step-limit preferences usually belong in the user config; project
 `reasonix.toml` should override them only when the repository needs shared

--- a/internal/cli/model.go
+++ b/internal/cli/model.go
@@ -32,7 +32,7 @@ func (m *chatTUI) runModelSubcommand(input string) {
 		m.notice(fmt.Sprintf(i18n.M.ModelAlreadyOnFmt, ref))
 		return
 	}
-	// Persist the user's choice to ~/.config/reasonix/config.toml so the next
+	// Persist the user's choice to the user config.toml so the next
 	// session starts on the same model instead of falling back to the global
 	// default. Mirrors the pattern used by /theme (persistTheme), /effort, and
 	// /language.
@@ -98,8 +98,8 @@ func (m *chatTUI) showModels() {
 	m.commitLine(renderModels(m.width, refs, m.modelRef))
 }
 
-// persistModel writes ref (a "provider/model" string) to default_model in
-// ~/.config/reasonix/config.toml so the next CLI launch starts on the same
+// persistModel writes ref (a "provider/model" string) to default_model in the
+// user config.toml so the next CLI launch starts on the same
 // model. The in-memory switch is always allowed to proceed regardless of the
 // outcome here, but every step (rejected by validation, save failed, or
 // persisted successfully) reports back to the TUI notice channel so the user

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,5 @@
 // Package config loads Reasonix's runtime configuration from TOML. Resolution order:
-// flag > project ./reasonix.toml > user ~/.config/reasonix/config.toml > built-in defaults.
+// flag > project ./reasonix.toml > user config.toml (in the OS user-config dir) > built-in defaults.
 // Secrets come from the environment via api_key_env and are never stored in
 // config files.
 package config
@@ -1637,12 +1637,29 @@ func userConfigPath() string {
 	return filepath.Join(dir, "reasonix", "config.toml")
 }
 
-// UserConfigPath is the user-global config file (~/.config/reasonix/config.toml),
-// or "" when the user config dir can't be resolved.
+// userConfigDisplayPath is userConfigPath collapsed to a ~-relative form for
+// comments rendered into the user's own config.toml, so macOS/Windows users see
+// the real location instead of a hardcoded ~/.config path.
+func userConfigDisplayPath() string {
+	p := userConfigPath()
+	if p == "" {
+		return "<os-config-dir>/reasonix/config.toml"
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		if rel, err := filepath.Rel(home, p); err == nil && !strings.HasPrefix(rel, "..") {
+			return "~/" + filepath.ToSlash(rel)
+		}
+	}
+	return p
+}
+
+// UserConfigPath is the user-global config.toml under os.UserConfigDir(): ~/.config
+// on Linux, ~/Library/Application Support on macOS, %AppData% on Windows. "" when
+// the user config dir can't be resolved.
 func UserConfigPath() string { return userConfigPath() }
 
 // UserCredentialsPath is the reasonix-owned global secrets file, beside
-// config.toml in the user config dir (e.g. ~/.config/reasonix/credentials). It
+// config.toml in the user config dir (os.UserConfigDir()/reasonix/credentials). It
 // holds KEY=value lines loaded into the environment by loadDotEnv. The setup
 // wizard writes API keys here, deliberately NOT named .env: keys never land in a
 // project's own .env (which can't be selectively gitignored), never get

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -40,7 +40,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	var b strings.Builder
 
 	b.WriteString("# Reasonix configuration.\n")
-	b.WriteString("# Resolution order: flag > ./reasonix.toml > ~/.config/reasonix/config.toml > built-in defaults.\n")
+	fmt.Fprintf(&b, "# Resolution order: flag > ./reasonix.toml > %s > built-in defaults.\n", userConfigDisplayPath())
 	b.WriteString("# Secrets come from the environment via api_key_env; never put keys here.\n\n")
 
 	fmt.Fprintf(&b, "config_version = %d   # schema marker for diagnostics; old versions may ignore it\n", configVersion(c))

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1,12 +1,46 @@
 package config
 
 import (
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
 )
+
+func isolateUserConfigHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("AppData", filepath.Join(home, "AppData", "Roaming"))
+	return home
+}
+
+func TestUserConfigDisplayPathCollapsesHome(t *testing.T) {
+	home := isolateUserConfigHome(t)
+	got := userConfigDisplayPath()
+	if !strings.HasPrefix(got, "~/") {
+		t.Fatalf("display path = %q, want ~/ prefix", got)
+	}
+	if !strings.HasSuffix(got, "reasonix/config.toml") {
+		t.Fatalf("display path = %q, want reasonix/config.toml suffix", got)
+	}
+	if strings.Contains(got, home) {
+		t.Fatalf("display path %q must not embed the absolute home", got)
+	}
+}
+
+func TestRenderTOMLHeaderShowsResolvedConfigPath(t *testing.T) {
+	isolateUserConfigHome(t)
+	out := RenderTOML(Default())
+	want := "> " + userConfigDisplayPath() + " > built-in defaults."
+	if !strings.Contains(out, want) {
+		t.Fatalf("rendered header missing resolved config path %q", want)
+	}
+}
 
 // TestRenderTOMLRoundTrips ensures the annotated TOML we emit parses back into
 // an equivalent config — i.e. the wizard never writes a file it can't read.


### PR DESCRIPTION
## Summary
- `os.UserConfigDir()` returns `~/Library/Application Support` on macOS and `%AppData%` on Windows, but the rendered `config.toml` header and the docs hardcoded `~/.config/reasonix/config.toml` — correct only on Linux. macOS/Windows users following the docs put their config where the tool never reads it.
- Render the **resolved** user-config path (home-collapsed to `~/…`) into the `config.toml` header via a new `userConfigDisplayPath()`, instead of a hardcoded Linux path. The file a macOS user opens now shows `~/Library/Application Support/reasonix/config.toml`.
- Document the three OS locations in README / README.zh-CN / GUIDE / GUIDE.zh-CN / MIGRATING / SPEC and the `internal/config` + `internal/cli/model.go` comments.

Keeping `os.UserConfigDir()` as the source of truth is deliberate — a `~/.config` fallback would split state across two trees (the exact dual-directory mess from the report), and macOS's `os.UserConfigDir()` ignores `XDG_CONFIG_HOME` anyway. This is the documentation/output-alignment fix; the separate "sandboxed agent can't self-edit global config" point is decoupled (mostly by design — `reasonix config` / `reasonix setup` / direct edits run outside the agent sandbox).

## Test
- `go test ./internal/config/` — adds `TestUserConfigDisplayPathCollapsesHome` (home-collapse + `reasonix/config.toml` suffix, no absolute home leak) and `TestRenderTOMLHeaderShowsResolvedConfigPath` (header uses the resolved path), both green on Linux/macOS/Windows env layouts.
- `go build ./...`, `go vet ./internal/config/`.

Closes #4148
