### PR TITLE
fix(agent): don't execute when the user picks 'just chat' on an ask / 选"只是聊聊"不应直接执行

### DIFF
--- a/internal/agent/ask.go
+++ b/internal/agent/ask.go
@@ -130,11 +130,23 @@ func (*AskTool) Execute(ctx context.Context, args json.RawMessage) (string, erro
 }
 
 // formatAnswers renders the user's selections as a compact, model-facing summary,
-// keyed by question header so the model can tell which answer is which.
+// keyed by question header so the model can tell which answer is which. When the
+// user picked nothing at all (the "just chat" / dismiss path), it returns an
+// explicit stop signal instead of a per-question "(no answer)" — otherwise the
+// model reads the empty result as license to proceed and acts unasked.
 func formatAnswers(qs []event.AskQuestion, answers []event.AskAnswer) string {
 	pick := make(map[string][]string, len(answers))
 	for _, a := range answers {
 		pick[a.QuestionID] = a.Selected
+	}
+	answered := 0
+	for _, q := range qs {
+		if len(pick[q.ID]) > 0 {
+			answered++
+		}
+	}
+	if answered == 0 {
+		return "The user dismissed the question without choosing — read this as \"don't decide for me, let's just talk.\" Do not pick an option, run a tool, or take any further action toward this; stop and wait for the user's next message."
 	}
 	var b strings.Builder
 	b.WriteString("The user answered:\n")
@@ -145,7 +157,7 @@ func formatAnswers(qs []event.AskQuestion, answers []event.AskAnswer) string {
 			label = q.Prompt
 		}
 		if len(sel) == 0 {
-			fmt.Fprintf(&b, "- %s: (no answer)\n", label)
+			fmt.Fprintf(&b, "- %s: (left unanswered — don't assume a choice)\n", label)
 			continue
 		}
 		fmt.Fprintf(&b, "- %s: %s\n", label, strings.Join(sel, ", "))

--- a/internal/agent/ask_test.go
+++ b/internal/agent/ask_test.go
@@ -105,6 +105,52 @@ func TestAskToolTrimsPromptAndOptionsBeforePrompting(t *testing.T) {
 	}
 }
 
+type fixedAsker struct{ answers []event.AskAnswer }
+
+func (f fixedAsker) Ask(_ context.Context, _ []event.AskQuestion) ([]event.AskAnswer, error) {
+	return f.answers, nil
+}
+
+func TestAskToolDismissTellsModelToStopNotProceed(t *testing.T) {
+	ctx := withCallContext(context.Background(), "call_1", event.Discard, fixedAsker{answers: nil}, false)
+	out, err := NewAskTool().Execute(ctx, []byte(`{
+		"questions":[{
+			"header":"Config",
+			"question":"Configure a statusline script?",
+			"options":[{"label":"Yes"},{"label":"No"}]
+		}]
+	}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if strings.Contains(out, "(no answer)") {
+		t.Fatalf("dismiss result still uses the (no answer) wording the model reads as proceed: %q", out)
+	}
+	if !strings.Contains(out, "Do not") || !strings.Contains(out, "wait for the user") {
+		t.Fatalf("dismiss result should tell the model to stop and wait, got %q", out)
+	}
+}
+
+func TestAskToolPartialAnswerMarksUnansweredQuestions(t *testing.T) {
+	ctx := withCallContext(context.Background(), "call_1", event.Discard,
+		fixedAsker{answers: []event.AskAnswer{{QuestionID: "q1", Selected: []string{"Deploy"}}}}, false)
+	out, err := NewAskTool().Execute(ctx, []byte(`{
+		"questions":[
+			{"header":"Release","question":"What next?","options":[{"label":"Deploy"},{"label":"Hold"}]},
+			{"header":"Notify","question":"Tell the team?","options":[{"label":"Yes"},{"label":"No"}]}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(out, "Release: Deploy") {
+		t.Fatalf("answered question should be reported, got %q", out)
+	}
+	if !strings.Contains(out, "Notify:") || !strings.Contains(out, "don't assume a choice") {
+		t.Fatalf("unanswered question should be marked, got %q", out)
+	}
+}
+
 func TestAskToolHeadlessFallbackIsExplicitModelAssumption(t *testing.T) {
 	out, err := NewAskTool().Execute(context.Background(), []byte(`{
 		"questions":[{


### PR DESCRIPTION
## Summary
When the user dismisses an `ask` — the **"Just chat" / "先不选择，直接回复"** option, or `esc` — the chooser/desktop send empty answers, and `formatAnswers` rendered that to the model as `- <question>: (no answer)`. The model reads "(no answer)" as *no constraint* and proceeds unasked: in #4160 the user picked "just chat" and the agent went ahead and wrote a statusline config anyway ("看来你没有明确选，我直接帮你配置").

Root cause is purely the model-facing wording — "the user explicitly declined" was being phrased as "the user didn't answer."

- A **fully-declined** ask now returns an explicit stop signal: *don't decide for me, let's just talk — do not pick an option, run a tool, or take further action; wait for the user's next message.*
- **Partial** answers (multi-question asks) now mark the skipped questions as `(left unanswered — don't assume a choice)` instead of a bare `(no answer)`, so the model reports the real picks without fabricating the rest.

Shared fix: CLI (`chooser`) and desktop (`onDismiss → answerQuestion(id, [])`) both resolve the ask through `AskTool` → `formatAnswers`, so one change covers both surfaces.

## Test
- `go test ./internal/agent/` — adds `TestAskToolDismissTellsModelToStopNotProceed` (empty answers ⇒ stop/wait, no "(no answer)") and `TestAskToolPartialAnswerMarksUnansweredQuestions` (answered picks kept, skipped ones marked). Existing ask tests and the headless-fallback test still pass.
- `go vet ./internal/agent/`.

Closes #4160
