### PR TITLE
fix(desktop): reconcile stale completed turns

### DIFF
--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/use-controller-meta.test.ts
 
-import { sameMeta } from "../lib/useController";
+import { initialState, reducer, sameMeta, shouldReconcileStaleTurn } from "../lib/useController";
 import type { Meta } from "../lib/types";
 
 let passed = 0;
@@ -38,6 +38,17 @@ console.log("\nuse controller meta");
 {
   eq(sameMeta(meta(), meta()), true, "identical meta is unchanged");
   eq(sameMeta(meta({ collaborationMode: "normal" }), meta({ collaborationMode: "plan" })), false, "collaboration mode changes invalidate meta equality");
+}
+
+{
+  const started = reducer(initialState, { type: "event", e: { kind: "turn_started" } });
+  const rendered = reducer(started, { type: "event", e: { kind: "message", text: "done", reasoning: "" } });
+  eq(rendered.running, true, "message without turn_done leaves local runtime marked running");
+  eq(rendered.turnActive, true, "message without turn_done still belongs to an active turn");
+  eq(rendered.live, undefined, "final message closes the live stream before turn_done");
+  eq(shouldReconcileStaleTurn(rendered, 1_000, 31_000), true, "stale completed stream still reconciles missed turn_done");
+  eq(shouldReconcileStaleTurn(rendered, 1_000, 20_000), false, "fresh completed stream waits before reconciling");
+  eq(shouldReconcileStaleTurn({ ...rendered, turnActive: false }, 1_000, 31_000), false, "local pending send before turn_started does not reconcile");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -137,6 +137,18 @@ export function sameMeta(a?: Meta, b?: Meta): boolean {
   );
 }
 
+const STALE_TURN_RECONCILE_MS = 30_000;
+
+export function shouldReconcileStaleTurn(
+  state: Pick<State, "running" | "turnActive"> | undefined,
+  lastTurnActivityAt: number,
+  now = Date.now(),
+  timeoutMs = STALE_TURN_RECONCILE_MS,
+): boolean {
+  if (!state?.running || !state.turnActive || lastTurnActivityAt <= 0) return false;
+  return Math.max(0, now - lastTurnActivityAt) >= timeoutMs;
+}
+
 /** Known read-only tool names. Session restore hardcodes readOnly=false for all
  *  tools, so we derive it from the name to enable correct batching.
  *  Mirrors Go backend ReadOnly() + codegraph ReadOnlyToolNames(). */
@@ -549,7 +561,7 @@ async function refreshMetaForTab(tabId: string, dispatchTo: (tabId: string, acti
 
 export function useController() {
   const statesRef = useRef<TabStates>(new Map());
-  const lastTokenAt = useRef(0);
+  const lastTurnActivityAtByTab = useRef(new Map<string, number>());
   const [activeTabId, setActiveTabId] = useState<string | undefined>();
   const activeTabIdRef = useRef<string | undefined>(undefined);
   // A render-triggering counter so that mutations to a non-active tab's state still
@@ -672,8 +684,16 @@ export function useController() {
     const off = onEvent((e) => {
       const targetTabId = e.tabId || activeTabIdRef.current;
       if (!targetTabId) return;
-      if (e.kind === "turn_started" || e.kind === "text" || e.kind === "reasoning") {
-        lastTokenAt.current = Date.now();
+      if (
+        e.kind === "turn_started" ||
+        e.kind === "text" ||
+        e.kind === "reasoning" ||
+        e.kind === "message" ||
+        e.kind === "tool_dispatch" ||
+        e.kind === "tool_progress" ||
+        e.kind === "tool_result"
+      ) {
+        lastTurnActivityAtByTab.current.set(targetTabId, Date.now());
       }
       if (e.kind === "text" || e.kind === "reasoning") {
         textBatch.push({ tabId: targetTabId, e });
@@ -715,27 +735,30 @@ export function useController() {
     return () => { textBatch.drain(); off(); offReady(); };
   }, [dispatchTo, loadSessionDataForTab, refreshCheckpoints, syncActiveTabFromBackend]);
 
-  // Stale-stream watchdog: if the frontend thinks the agent is running but
-  // no token events have arrived for 30 seconds, reconcile with the backend.
-  // This catches the case where the Wails event channel silently drops the
-  // turn_done event after a model-service interruption (#3746).
+  // Stale-turn watchdog: if the frontend thinks the agent is running but the
+  // turn stream has gone quiet, reconcile with the backend. This catches cases
+  // where the Wails event channel silently drops turn_done after the final
+  // message or synthetic todo update has already closed the live stream.
   useEffect(() => {
     if (!activeTabId) return;
     const s = statesRef.current.get(activeTabId);
-    if (!s?.running || !s.live) return;
-    const since = Date.now() - lastTokenAt.current;
-    if (since >= 30_000) {
+    const now = Date.now();
+    const lastTurnActivityAt = lastTurnActivityAtByTab.current.get(activeTabId) ?? 0;
+    if (!s?.running || !s.turnActive || lastTurnActivityAt <= 0) return;
+    const since = Math.max(0, now - lastTurnActivityAt);
+    if (shouldReconcileStaleTurn(s, lastTurnActivityAt, now)) {
       void reconcileTabRuntime(activeTabId);
       return;
     }
     const timer = window.setTimeout(() => {
       const cur = statesRef.current.get(activeTabId);
-      if (cur?.running && cur.live && Date.now() - lastTokenAt.current >= 30_000) {
+      const lastActivity = lastTurnActivityAtByTab.current.get(activeTabId) ?? 0;
+      if (shouldReconcileStaleTurn(cur, lastActivity)) {
         void reconcileTabRuntime(activeTabId);
       }
-    }, 30_000 - since);
+    }, STALE_TURN_RECONCILE_MS - since);
     return () => window.clearTimeout(timer);
-  }, [activeTabId, reconcileTabRuntime, activeState.running, activeState.live]);
+  }, [activeTabId, reconcileTabRuntime, activeState.running, activeState.turnActive]);
 
   const send = useCallback((displayText: string, submitText = displayText) => {
     const submitForTab = (tabId: string) => {


### PR DESCRIPTION
## Summary
- Fix stale desktop running state when the final `turn_done` event is missed after the message stream has already closed.
- Rework the stale-turn watchdog to reconcile any quiet active turn, not only turns with a live text/reasoning stream.
- Track turn activity per tab so background-tab events do not delay recovery for the active tab.

Fixes #4167.

## Root cause
The desktop frontend only reconciled a missed `turn_done` when `state.live` was still present. After a final message or synthetic todo update, `live` is cleared before `turn_done`; if that last event is dropped, the UI can show completed todos while still displaying the running/stop state.

## Verification
- `npx tsx src/__tests__/use-controller-meta.test.ts` (red before the fix, green after)
- `npm run test:all` in `desktop/frontend`
- `npm run build` in `desktop/frontend`
- `go test ./...`
- `go test ./...` in `desktop`
- `gofmt -l .`
- `git diff --check`
- Browser smoke: `http://127.0.0.1:5173/` loads `Reasonix` with no console errors
