### PR TITLE
fix(agent): 收紧 subagent fork 复用语义

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -445,10 +445,10 @@ func (s *SubagentStore) isAncestorSession(ancestor, current string) (bool, error
 		if strings.TrimSpace(meta.ID) != cursor {
 			return false, fmt.Errorf("branch metadata for session %q declares id %q", cursor, meta.ID)
 		}
-		parent := strings.TrimSpace(meta.ParentID)
-		if parent == ancestor {
+		if cursor == ancestor {
 			return true, nil
 		}
+		parent := strings.TrimSpace(meta.ParentID)
 		cursor = parent
 	}
 	return false, nil

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -260,6 +260,10 @@ func (s *SubagentStore) PrepareFork(ref string, spec SubagentSpec) (*SubagentRun
 		sourceRelease()
 		return nil, err
 	}
+	if err := s.validateForkOwner(meta, spec); err != nil {
+		sourceRelease()
+		return nil, err
+	}
 	sess, err := LoadSession(s.sessionPath(sourceRef))
 	if err != nil {
 		sourceRelease()
@@ -397,6 +401,57 @@ func validateContinueOwner(meta SubagentMeta, spec SubagentSpec) error {
 		return fmt.Errorf("subagent reference %q has no parent session; run a fresh subagent instead", meta.Ref)
 	}
 	return fmt.Errorf("subagent reference %q belongs to parent session %q, current parent session is %q; use fork_from to copy it into this session", meta.Ref, owner, current)
+}
+
+func (s *SubagentStore) validateForkOwner(meta SubagentMeta, spec SubagentSpec) error {
+	current := strings.TrimSpace(spec.ParentSession)
+	owner := strings.TrimSpace(meta.ParentSession)
+	if owner == current {
+		return nil
+	}
+	if owner == "" {
+		return fmt.Errorf("subagent reference %q has no parent session; run a fresh subagent instead", meta.Ref)
+	}
+	ok, err := s.isAncestorSession(owner, current)
+	if err != nil {
+		return fmt.Errorf("subagent reference %q belongs to parent session %q, but current parent session %q lineage could not be verified: %w", meta.Ref, owner, current, err)
+	}
+	if ok {
+		return nil
+	}
+	return fmt.Errorf("subagent reference %q belongs to parent session %q, which is not in current parent session %q lineage", meta.Ref, owner, current)
+}
+
+func (s *SubagentStore) isAncestorSession(ancestor, current string) (bool, error) {
+	ancestor = strings.TrimSpace(ancestor)
+	current = strings.TrimSpace(current)
+	if ancestor == "" || current == "" {
+		return false, nil
+	}
+	sessionDir := filepath.Dir(s.dir)
+	seen := map[string]bool{}
+	for cursor := current; cursor != ""; {
+		if seen[cursor] {
+			return false, fmt.Errorf("cycle at session %q", cursor)
+		}
+		seen[cursor] = true
+		meta, ok, err := LoadBranchMeta(filepath.Join(sessionDir, cursor+".jsonl"))
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, fmt.Errorf("missing branch metadata for session %q", cursor)
+		}
+		if strings.TrimSpace(meta.ID) != cursor {
+			return false, fmt.Errorf("branch metadata for session %q declares id %q", cursor, meta.ID)
+		}
+		parent := strings.TrimSpace(meta.ParentID)
+		if parent == ancestor {
+			return true, nil
+		}
+		cursor = parent
+	}
+	return false, nil
 }
 
 func (s *SubagentStore) lock(ref string) (func(), error) {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -99,6 +100,7 @@ func TestSubagentStoreForkFromAncestorSessionCreatesCurrentOwner(t *testing.T) {
 	}
 	run.Release()
 
+	saveTestBranchMeta(t, sessionDir, "root", "")
 	saveTestBranchMeta(t, sessionDir, "child", "root")
 	other := spec
 	other.ParentSession = "child"
@@ -119,6 +121,45 @@ func TestSubagentStoreForkFromAncestorSessionCreatesCurrentOwner(t *testing.T) {
 	}
 	if sourceMeta.ParentSession != spec.ParentSession {
 		t.Fatalf("source parent session = %q, want %q", sourceMeta.ParentSession, spec.ParentSession)
+	}
+}
+
+func TestSubagentStoreRejectsForkWhenSourceOwnerMetaMissing(t *testing.T) {
+	sessionDir, store, ref, spec := prepareCompletedSubagentForLineageTest(t, "root")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+
+	other := spec
+	other.ParentSession = "child"
+	if _, err := store.PrepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
+	}
+}
+
+func TestSubagentStoreRejectsForkWhenSourceOwnerMetaCorrupt(t *testing.T) {
+	sessionDir, store, ref, spec := prepareCompletedSubagentForLineageTest(t, "root")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	if err := os.WriteFile(filepath.Join(sessionDir, "root.jsonl.meta"), []byte("{"), 0o644); err != nil {
+		t.Fatalf("write corrupt branch meta: %v", err)
+	}
+
+	other := spec
+	other.ParentSession = "child"
+	if _, err := store.PrepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
+	}
+}
+
+func TestSubagentStoreRejectsForkWhenSourceOwnerMetaIDDiffers(t *testing.T) {
+	sessionDir, store, ref, spec := prepareCompletedSubagentForLineageTest(t, "root")
+	saveTestBranchMeta(t, sessionDir, "child", "root")
+	if err := SaveBranchMeta(filepath.Join(sessionDir, "root.jsonl"), BranchMeta{ID: "other-root"}); err != nil {
+		t.Fatalf("SaveBranchMeta(root): %v", err)
+	}
+
+	other := spec
+	other.ParentSession = "child"
+	if _, err := store.PrepareFork(ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
 	}
 }
 
@@ -312,4 +353,21 @@ func saveTestBranchMeta(t *testing.T, sessionDir, id, parent string) {
 	if err := SaveBranchMeta(filepath.Join(sessionDir, id+".jsonl"), BranchMeta{ParentID: parent}); err != nil {
 		t.Fatalf("SaveBranchMeta(%s): %v", id, err)
 	}
+}
+
+func prepareCompletedSubagentForLineageTest(t *testing.T, parentSession string) (string, *SubagentStore, string, SubagentSpec) {
+	t.Helper()
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = parentSession
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+	return sessionDir, store, run.Ref, spec
 }

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -83,9 +84,11 @@ func TestSubagentStoreRejectsContinueFromDifferentParentSession(t *testing.T) {
 	}
 }
 
-func TestSubagentStoreForkFromDifferentParentSessionCreatesCurrentOwner(t *testing.T) {
-	store := NewSubagentStore(t.TempDir())
+func TestSubagentStoreForkFromAncestorSessionCreatesCurrentOwner(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
 	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
 	run, err := store.PrepareFresh(spec)
 	if err != nil {
 		t.Fatalf("PrepareFresh: %v", err)
@@ -96,8 +99,9 @@ func TestSubagentStoreForkFromDifferentParentSessionCreatesCurrentOwner(t *testi
 	}
 	run.Release()
 
+	saveTestBranchMeta(t, sessionDir, "child", "root")
 	other := spec
-	other.ParentSession = "other-parent"
+	other.ParentSession = "child"
 	forked, err := store.PrepareFork(run.Ref, other)
 	if err != nil {
 		t.Fatalf("PrepareFork: %v", err)
@@ -106,8 +110,8 @@ func TestSubagentStoreForkFromDifferentParentSessionCreatesCurrentOwner(t *testi
 	if forked.Ref == run.Ref {
 		t.Fatalf("fork ref should be new, got %q", forked.Ref)
 	}
-	if forked.Meta.ParentSession != "other-parent" {
-		t.Fatalf("fork parent session = %q, want other-parent", forked.Meta.ParentSession)
+	if forked.Meta.ParentSession != "child" {
+		t.Fatalf("fork parent session = %q, want child", forked.Meta.ParentSession)
 	}
 	sourceMeta, err := store.LoadMeta(run.Ref)
 	if err != nil {
@@ -115,6 +119,74 @@ func TestSubagentStoreForkFromDifferentParentSessionCreatesCurrentOwner(t *testi
 	}
 	if sourceMeta.ParentSession != spec.ParentSession {
 		t.Fatalf("source parent session = %q, want %q", sourceMeta.ParentSession, spec.ParentSession)
+	}
+}
+
+func TestSubagentStoreRejectsForkFromSiblingSession(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "left"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "left", "root")
+	saveTestBranchMeta(t, sessionDir, "right", "root")
+	other := spec
+	other.ParentSession = "right"
+	if _, err := store.PrepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "not in current parent session") {
+		t.Fatalf("PrepareFork error = %v, want lineage rejection", err)
+	}
+}
+
+func TestSubagentStoreRejectsForkFromUnrelatedSession(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "source"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	saveTestBranchMeta(t, sessionDir, "root", "")
+	saveTestBranchMeta(t, sessionDir, "current", "root")
+	other := spec
+	other.ParentSession = "current"
+	if _, err := store.PrepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "not in current parent session") {
+		t.Fatalf("PrepareFork error = %v, want unrelated session rejection", err)
+	}
+}
+
+func TestSubagentStoreRejectsForkWhenLineageCannotBeProven(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := testSubagentSpec(t, "review")
+	spec.ParentSession = "root"
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	run.Release()
+
+	other := spec
+	other.ParentSession = "child"
+	if _, err := store.PrepareFork(run.Ref, other); err == nil || !strings.Contains(err.Error(), "lineage could not be verified") {
+		t.Fatalf("PrepareFork error = %v, want unverified lineage rejection", err)
 	}
 }
 
@@ -232,5 +304,12 @@ func testSubagentSpec(t *testing.T, name string) SubagentSpec {
 		Registry:      reg,
 		Model:         "deepseek",
 		Effort:        "max",
+	}
+}
+
+func saveTestBranchMeta(t *testing.T, sessionDir, id, parent string) {
+	t.Helper()
+	if err := SaveBranchMeta(filepath.Join(sessionDir, id+".jsonl"), BranchMeta{ParentID: parent}); err != nil {
+		t.Fatalf("SaveBranchMeta(%s): %v", id, err)
 	}
 }

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -139,7 +139,7 @@ func (t *TaskTool) Schema() json.RawMessage {
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},
   "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."},
   "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Requires a compatible subagent identity, including tools, model, effort, and workspace."},
-  "fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation on the same thread, use continue_from. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Mutually exclusive with continue_from."}
+  "fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation on the same thread, use continue_from. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Requires a compatible subagent identity, including tools, model, effort, and workspace. Mutually exclusive with continue_from."}
 },
 "required":["prompt"]
 }`)

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -138,8 +138,8 @@ func (t *TaskTool) Schema() json.RawMessage {
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."},
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},
   "effort":{"type":"string","description":"Optional reasoning effort for the sub-agent (e.g. high, max)."},
-  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Requires kind, system prompt, tools, model, effort, and workspace to match."},
-  "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy into a new transcript before running this task. Mutually exclusive with continue_from."}
+  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Requires a compatible subagent identity, including tools, model, effort, and workspace."},
+  "fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation on the same thread, use continue_from. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Mutually exclusive with continue_from."}
 },
 "required":["prompt"]
 }`)

--- a/internal/skill/tools.go
+++ b/internal/skill/tools.go
@@ -67,8 +67,8 @@ func (*runSkillTool) Schema() json.RawMessage {
 "properties":{
   "name":{"type":"string","description":"Skill identifier as it appears in the pinned Skills index (e.g. 'explore', 'review'). Case-sensitive. Just the identifier, not the [🧬 subagent] tag."},
   "arguments":{"type":"string","description":"Free-form arguments. For inline skills: appended as an 'Arguments:' line; the skill's own instructions decide how to use them. For subagent skills: REQUIRED — becomes the entire task the subagent receives."},
-  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Only valid for runAs=subagent skills."},
-  "fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Only valid for runAs=subagent skills; mutually exclusive with continue_from."}
+  "continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run; use in iterative loops (e.g. review -> fix -> review again) by passing only the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Only valid for runAs=subagent skills."},
+  "fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation, use continue_from. Only valid for runAs=subagent skills. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Mutually exclusive with continue_from."}
 },
 "required":["name"]
 }`)
@@ -211,7 +211,7 @@ func (t *subagentSkillTool) Description() string { return t.description }
 
 func (t *subagentSkillTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"task":{"type":"string","description":` +
-		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run. Use in iterative loops (e.g. review -> fix -> review again): pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line."},"fork_from":{"type":"string","description":"Optional subagent transcript reference to copy before running. Mutually exclusive with continue_from."}},"required":["task"]}`)
+		strconv.Quote(t.taskDesc) + `},"continue_from":{"type":"string","description":"Resume a prior subagent run in place: the subagent retains its context from the previous run. Use in iterative loops (e.g. review -> fix -> review again): pass only the 'sa_...' value from the prior result's 'Subagent reference: ...' line."},"fork_from":{"type":"string","description":"Fork a prior subagent run: copies its transcript, leaves the source unchanged, and continues independently. Use only when you need an independent branch; for iterative continuation, use continue_from. Pass the 'sa_...' value from the prior result's 'Subagent reference: ...' line. Mutually exclusive with continue_from."}},"required":["task"]}`)
 }
 
 func (t *subagentSkillTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {


### PR DESCRIPTION
## 摘要

- 将 `fork_from` 限制为只能复用当前会话或祖先会话链上的 subagent transcript，避免通过已知 `sa_...` ref 复用兄弟分支或无关会话的上下文。
- 对祖先链采用保守证明语义：只有完整、可读且 ID 一致的 branch metadata 链路才能证明 ancestry；链路缺失、损坏、循环或不一致时拒绝 fork。
- 优化 `fork_from` schema 描述，明确它是独立分叉而非同线程续接，并提示同一会话逻辑内应使用 `continue_from`。

## 验证

- `go test ./internal/agent ./internal/skill`
- `gofmt -l .`（排除 `desktop/`，无输出）
- `git merge-tree --write-tree HEAD origin/main-v2`
- `git diff --name-status origin/main-v2...HEAD`