### PR TITLE
feat(crash): capture Go panics, breadcrumbs, and group summaries

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -279,6 +279,7 @@ func (a *App) startup(ctx context.Context) {
 	go a.restoreOrBuildTabs()
 	go a.sendStartupPing()
 	go a.flushMetrics()
+	go a.flushPendingCrash()
 }
 
 func (a *App) beforeClose(ctx context.Context) bool {
@@ -362,6 +363,7 @@ func backgroundRestoreShouldMaximise(goos string, wasMaximised bool) bool {
 // restoreOrBuildTabs restores the tabs from the last session, or creates a
 // default Global tab on first launch.
 func (a *App) restoreOrBuildTabs() {
+	defer a.recoverToPending("restoreOrBuildTabs")
 	ctx := a.ctx
 	ensureWorkspace()
 

--- a/desktop/crash_pending.go
+++ b/desktop/crash_pending.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+
+	"reasonix/internal/config"
+)
+
+// crash_pending.go captures Go-side panics to disk and ships them on the next
+// launch. Frontend crashes are click-to-send, but an unrecovered Go panic kills the
+// process before the user can react, so the whole agent/provider/tool layer would
+// otherwise never surface a single report. The resend is gated on the same
+// desktop.telemetry opt-out as the launch ping.
+
+const pendingCrashFile = "crash-pending.json"
+
+func pendingCrashPath() string {
+	return filepath.Join(filepath.Dir(config.UserConfigPath()), pendingCrashFile)
+}
+
+// recoverToPending records a panicking goroutine to the pending-crash file and
+// re-raises, so the process still crashes exactly as before — the stack is now
+// shipped next launch instead of lost.
+func (a *App) recoverToPending(site string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	writePendingCrash(site, r, debug.Stack())
+	panic(r)
+}
+
+func writePendingCrash(site string, r any, stack []byte) {
+	msg := scrubUserPaths(fmt.Sprintf("[go panic] %s: %v\n\n%s", site, r, stack))
+	if len(msg) > maxCrashDetailBytes {
+		msg = msg[:maxCrashDetailBytes]
+	}
+	body, err := json.Marshal(crashReport{
+		Kind:    "crash",
+		Version: version,
+		OS:      runtime.GOOS,
+		Arch:    runtime.GOARCH,
+		Message: msg,
+		Device:  collectDeviceInfo(),
+	})
+	if err != nil {
+		return
+	}
+	path := pendingCrashPath()
+	if os.MkdirAll(filepath.Dir(path), 0o755) != nil {
+		return
+	}
+	_ = os.WriteFile(path, body, 0o644)
+}
+
+// flushPendingCrash drains a Go panic captured on a prior run and POSTs it, then
+// clears it. Runs at launch alongside the ping; honours the telemetry opt-out by
+// dropping the file unsent.
+func (a *App) flushPendingCrash() {
+	if version == "dev" {
+		return
+	}
+	path := pendingCrashPath()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	cfg, err := config.Load()
+	if err != nil || !cfg.DesktopTelemetry() {
+		_ = os.Remove(path)
+		return
+	}
+	var r crashReport
+	if json.Unmarshal(body, &r) != nil {
+		_ = os.Remove(path)
+		return
+	}
+	c, err := httpClient()
+	if err != nil {
+		return
+	}
+	if postCrashReport(a.bootContext(), c, crashEndpoint, r) == nil {
+		_ = os.Remove(path)
+	}
+}

--- a/desktop/crash_pending_test.go
+++ b/desktop/crash_pending_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func readPending(t *testing.T) (crashReport, bool) {
+	t.Helper()
+	body, err := os.ReadFile(pendingCrashPath())
+	if err != nil {
+		return crashReport{}, false
+	}
+	var r crashReport
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Fatalf("pending file not valid JSON: %v", err)
+	}
+	return r, true
+}
+
+func TestRecoverToPendingCapturesAndReraises(t *testing.T) {
+	t.Cleanup(func() { os.Remove(pendingCrashPath()) })
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Fatal("recoverToPending must re-raise the panic")
+			}
+		}()
+		app := NewApp()
+		defer app.recoverToPending("unit")
+		panic(`boom at C:\Users\alice\proj\x.go`)
+	}()
+
+	r, ok := readPending(t)
+	if !ok {
+		t.Fatal("expected a pending crash file")
+	}
+	if r.Kind != "crash" {
+		t.Errorf("kind = %q, want crash", r.Kind)
+	}
+	if !strings.Contains(r.Message, "[go panic] unit:") {
+		t.Errorf("message missing site prefix: %q", r.Message)
+	}
+	if strings.Contains(r.Message, `Users\alice`) {
+		t.Errorf("message not scrubbed: %q", r.Message)
+	}
+}
+
+func TestWritePendingCrashCaps(t *testing.T) {
+	t.Cleanup(func() { os.Remove(pendingCrashPath()) })
+	writePendingCrash("big", "x", []byte(strings.Repeat("a", 64<<10)))
+	r, ok := readPending(t)
+	if !ok {
+		t.Fatal("expected a pending crash file")
+	}
+	if len(r.Message) > maxCrashDetailBytes {
+		t.Errorf("message len = %d, want <= %d", len(r.Message), maxCrashDetailBytes)
+	}
+}
+
+func TestFlushPendingCrashSendsAndClears(t *testing.T) {
+	oldVersion, oldEndpoint := version, crashEndpoint
+	t.Cleanup(func() {
+		version, crashEndpoint = oldVersion, oldEndpoint
+		os.Remove(pendingCrashPath())
+	})
+	version = "v9.9.9"
+
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	crashEndpoint = srv.URL
+
+	writePendingCrash("flush", "boom", []byte("stack"))
+	NewApp().flushPendingCrash()
+
+	if hits.Load() != 1 {
+		t.Errorf("server hits = %d, want 1", hits.Load())
+	}
+	if _, ok := readPending(t); ok {
+		t.Error("pending file should be cleared after a successful send")
+	}
+}
+
+func TestFlushPendingCrashDevGuard(t *testing.T) {
+	oldVersion := version
+	t.Cleanup(func() {
+		version = oldVersion
+		os.Remove(pendingCrashPath())
+	})
+	version = "dev"
+
+	writePendingCrash("dev", "boom", []byte("stack"))
+	NewApp().flushPendingCrash()
+
+	if _, ok := readPending(t); !ok {
+		t.Error("dev build must leave the pending file untouched")
+	}
+}

--- a/desktop/frontend/src/lib/breadcrumbs.ts
+++ b/desktop/frontend/src/lib/breadcrumbs.ts
@@ -1,0 +1,39 @@
+// A small ring buffer of recent app events, attached to crash reports so a stack
+// trace arrives with the steps that led to it. Self-contained (no app imports) so
+// the crash overlay can read it even when the rest of the app is broken.
+
+type Breadcrumb = { t: number; cat: string; msg: string };
+
+const MAX = 30;
+const ring: Breadcrumb[] = [];
+
+export function addBreadcrumb(cat: string, msg: string): void {
+  ring.push({ t: Date.now(), cat, msg: msg.length > 200 ? `${msg.slice(0, 200)}…` : msg });
+  if (ring.length > MAX) ring.shift();
+}
+
+export function dumpBreadcrumbs(): string {
+  if (!ring.length) return "";
+  const now = Date.now();
+  return ring.map((b) => `-${((now - b.t) / 1000).toFixed(1)}s [${b.cat}] ${b.msg}`).join("\n");
+}
+
+function stringifyArg(a: unknown): string {
+  if (typeof a === "string") return a;
+  if (a instanceof Error) return a.message;
+  try {
+    return JSON.stringify(a);
+  } catch {
+    return String(a);
+  }
+}
+
+export function installBreadcrumbConsoleHook(): void {
+  for (const level of ["error", "warn"] as const) {
+    const orig = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      addBreadcrumb(`console.${level}`, args.map(stringifyArg).join(" "));
+      orig(...args);
+    };
+  }
+}

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -1,7 +1,10 @@
 // Last-resort crash surface: a React render error with no boundary unmounts the
 // whole tree (blank window), and global errors/rejections leave no trace either.
 
+import { dumpBreadcrumbs } from "./breadcrumbs";
 import { t } from "./i18n";
+
+declare const __BUILD_COMMIT__: string;
 
 function sendButton(text: string): HTMLButtonElement | null {
   // Resolved at click time via window.go, not the bridge module: this overlay must
@@ -55,7 +58,10 @@ function paint(text: string) {
 function format(label: string, err: unknown, extra?: string): string {
   const e = err as { message?: string; stack?: string } | null;
   const detail = e?.stack || e?.message || String(err);
-  return [`[${label}]`, detail, extra?.trim()].filter(Boolean).join("\n\n");
+  const crumbs = dumpBreadcrumbs();
+  return [`[${label}]`, detail, extra?.trim(), crumbs && `--- breadcrumbs ---\n${crumbs}`, `build ${__BUILD_COMMIT__}`]
+    .filter(Boolean)
+    .join("\n\n");
 }
 
 export function reportCrash(label: string, err: unknown, extra?: string) {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -5,6 +5,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { asArray } from "./array";
+import { addBreadcrumb } from "./breadcrumbs";
 import { app, onEvent, onReady } from "./bridge";
 import { createRafBatch } from "./rafBatch";
 import { t } from "./i18n";
@@ -992,6 +993,7 @@ export function useController() {
 
   // Tab management: switch preserves per-tab state; open creates it.
   const switchTab = useCallback(async (tabId: string) => {
+    addBreadcrumb("nav", `switch tab ${tabId}`);
     setActiveTabId(tabId);
     try {
       await app.SetActiveTab(tabId);

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { installGlobalCrashHandlers } from "./lib/crash";
+import { installBreadcrumbConsoleHook } from "./lib/breadcrumbs";
 import { installMessageSelectionCopy } from "./lib/messageSelectionCopy";
 import { LocaleProvider } from "./lib/i18n";
 import { ToastProvider } from "./lib/toast";
@@ -12,8 +13,9 @@ import { initTheme } from "./lib/theme";
 import "./styles.css";
 
 // Install first so startup/runtime failures paint a useful error instead of a
-// featureless webview background.
+// featureless webview background, with the recent console trail attached.
 installGlobalCrashHandlers();
+installBreadcrumbConsoleHook();
 
 // Apply the saved appearance (auto/light/dark) before the first paint.
 initTheme();

--- a/desktop/frontend/vite.config.ts
+++ b/desktop/frontend/vite.config.ts
@@ -1,11 +1,23 @@
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
+import { execSync } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const devPort = Number(process.env.REASONIX_DESKTOP_VITE_PORT || "5173");
 const configDir = dirname(fileURLToPath(import.meta.url));
+
+// Stamps the build commit into the bundle so a minified crash stack can be mapped
+// back to the sourcemap of the exact build. Falls back to "dev" off a git checkout.
+function buildCommit(): string {
+  if (process.env.REASONIX_COMMIT) return process.env.REASONIX_COMMIT;
+  try {
+    return execSync("git rev-parse --short HEAD", { cwd: configDir }).toString().trim();
+  } catch {
+    return "dev";
+  }
+}
 
 // On macOS ≤ 12 (Safari 15 WebKit) a crossorigin module/stylesheet fetched over the
 // wails:// scheme is CORS-blocked (no Access-Control-Allow-Origin from the handler),
@@ -38,6 +50,7 @@ function keepDistPlaceholder(): Plugin {
 export default defineConfig({
   plugins: [react(), stripCrossorigin(), keepDistPlaceholder()],
   base: "./",
+  define: { __BUILD_COMMIT__: JSON.stringify(buildCommit()) },
   build: {
     outDir: "dist",
     emptyOutDir: true,
@@ -47,9 +60,13 @@ export default defineConfig({
     minify: "terser",
     terserOptions: {
       compress: {
-        drop_console: true, // strip console.log in production
-        passes: 2,          // two compression passes for better tree-shaking
+        // Keep warn/error so crash breadcrumbs still capture them; drop the noise.
+        drop_console: ["log", "debug", "info", "trace"],
+        passes: 2,
       },
+      // Preserve names so minified crash stacks stay readable.
+      keep_classnames: true,
+      keep_fnames: true,
     },
     rollupOptions: {
       output: {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -898,6 +898,7 @@ func (a *App) startTabControllerBuild(tab *WorkspaceTab) {
 }
 
 func (a *App) buildTabController(tab *WorkspaceTab) {
+	defer a.recoverToPending("buildTabController")
 	wailsCtx := a.ctx
 	buildCtx := a.bootContext()
 
@@ -1191,6 +1192,7 @@ func (a *App) scheduleTabSnapshot(tabID string) {
 }
 
 func (a *App) tabSnapshotLoop(tab *WorkspaceTab) {
+	defer a.recoverToPending("tabSnapshotLoop")
 	for {
 		a.mu.RLock()
 		ctrl := tab.Ctrl

--- a/workers/crash-report/migrate-title.sql
+++ b/workers/crash-report/migrate-title.sql
@@ -1,0 +1,5 @@
+-- One-time: add the crash-group summary column to the live reasonix-crash DB.
+-- Apply once: wrangler d1 execute reasonix-crash --remote --file=migrate-title.sql
+-- Not idempotent (the ALTER errors if the column already exists). Fresh installs
+-- get the column from schema.sql.
+ALTER TABLE groups ADD COLUMN title TEXT NOT NULL DEFAULT '';

--- a/workers/crash-report/schema.sql
+++ b/workers/crash-report/schema.sql
@@ -7,7 +7,8 @@ CREATE TABLE IF NOT EXISTS groups (
   last_seen TEXT NOT NULL,
   last_version TEXT NOT NULL,
   status TEXT NOT NULL DEFAULT 'open',
-  note TEXT NOT NULL DEFAULT ''
+  note TEXT NOT NULL DEFAULT '',
+  title TEXT NOT NULL DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS reports (

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -92,8 +92,21 @@ export function normalizeForFingerprint(kind: string, message: string): string {
       .replace(/[A-Za-z]:\\[^\s)('"]+/g, "<path>")
       .replace(/(?:wails|https?|file):\/\/[^\s)('"]+/g, "<url>")
       .replace(/0x[0-9a-fA-F]+/g, "<addr>")
+      .replace(/^build [0-9a-f]+$/gm, "build <commit>")
       .replace(/:\d+(?::\d+)?/g, ":<n>")
   );
+}
+
+// One-line human summary for the dashboard list. Frontend reports are formatted
+// "[label]\n\n<detail>", so a bare label alone is folded together with its detail.
+export function crashTitle(message: string): string {
+  const lines = message
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  let head = lines[0] ?? "";
+  if (/^\[[^\]]+\]$/.test(head) && lines[1]) head = `${head} ${lines[1]}`;
+  return head.slice(0, 200);
 }
 
 async function sha256Hex(s: string): Promise<string> {
@@ -124,14 +137,15 @@ async function handleReport(request: Request, env: Env): Promise<Response> {
 
   const fingerprint = await sha256Hex(normalizeForFingerprint(r.kind, r.message));
   const now = new Date().toISOString();
+  const title = crashTitle(r.message);
 
   await env.DB.prepare(
-    `INSERT INTO groups (fingerprint, kind, count, first_seen, last_seen, last_version)
-     VALUES (?1, ?2, 1, ?3, ?3, ?4)
+    `INSERT INTO groups (fingerprint, kind, count, first_seen, last_seen, last_version, title)
+     VALUES (?1, ?2, 1, ?3, ?3, ?4, ?5)
      ON CONFLICT (fingerprint) DO UPDATE SET
-       count = count + 1, last_seen = ?3, last_version = ?4`,
+       count = count + 1, last_seen = ?3, last_version = ?4, title = ?5`,
   )
-    .bind(fingerprint, r.kind, now, r.version)
+    .bind(fingerprint, r.kind, now, r.version, title)
     .run();
 
   const group = await env.DB.prepare("SELECT count FROM groups WHERE fingerprint = ?1")
@@ -291,8 +305,8 @@ async function handleStats(env: Env, user: User): Promise<Response> {
       "SELECT os || ' ' || arch AS label, COUNT(DISTINCT install_id) AS users FROM pings WHERE date >= date('now', '-6 day') GROUP BY label ORDER BY users DESC",
     ).all<{ label: string; users: number }>(),
     env.DB.prepare(
-      "SELECT fingerprint, kind, count, last_version, substr(last_seen, 1, 10) AS seen, status FROM groups ORDER BY last_seen DESC LIMIT 25",
-    ).all<{ fingerprint: string; kind: string; count: number; last_version: string; seen: string; status: string }>(),
+      "SELECT fingerprint, kind, count, last_version, substr(last_seen, 1, 10) AS seen, status, title FROM groups ORDER BY last_seen DESC LIMIT 25",
+    ).all<{ fingerprint: string; kind: string; count: number; last_version: string; seen: string; status: string; title: string }>(),
     env.DB.prepare(
       "SELECT signal, bucket, SUM(count) AS total FROM metrics WHERE date >= date('now', '-6 day') GROUP BY signal, bucket ORDER BY signal, total DESC",
     ).all<{ signal: string; bucket: string; total: number }>(),

--- a/workers/crash-report/src/shell.ts
+++ b/workers/crash-report/src/shell.ts
@@ -46,6 +46,9 @@ table{border-collapse:collapse;width:100%;font-size:14px}
 th{text-align:left;color:var(--ink-3);font-weight:500;font-size:12.5px;padding:0 14px 8px 0}
 td{padding:8px 14px 8px 0;border-top:1px solid var(--line);vertical-align:middle}
 td.n{font-family:var(--mono);font-size:13px}
+td.summary{max-width:480px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-family:var(--mono);font-size:12.5px}
+.muted{color:var(--ink-3)}
+p.summary{font-family:var(--mono);font-size:14px;margin:2px 0 6px;word-break:break-word}
 a.fp{font-family:var(--mono);font-size:13px;color:var(--accent);text-decoration:none}
 a.fp:hover{text-decoration:underline}
 .pill{display:inline-block;font-size:12px;font-weight:500;padding:2px 10px;border-radius:999px;background:var(--accent-soft);color:var(--accent)}

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -66,7 +66,19 @@ function statusPill(status: string): string {
   return "";
 }
 
-type CrashRow = { fingerprint: string; kind: string; count: number; last_version: string; seen: string; status: string };
+type CrashRow = {
+  fingerprint: string;
+  kind: string;
+  count: number;
+  last_version: string;
+  seen: string;
+  status: string;
+  title: string;
+};
+
+function clip(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n - 1)}…` : s;
+}
 
 export function renderStats(
   data: {
@@ -82,10 +94,10 @@ export function renderStats(
   const totalUsers = days.at(-1)?.users ?? 0;
   const anyPing = days.some((d) => d.opens > 0);
   const crashRows = data.crashes.length
-    ? `<table><thead><tr><th>fingerprint</th><th>kind</th><th>status</th><th>count</th><th>last version</th><th>last seen</th></tr></thead><tbody>${data.crashes
+    ? `<table><thead><tr><th>fingerprint</th><th>summary</th><th>kind</th><th>status</th><th>count</th><th>last version</th><th>last seen</th></tr></thead><tbody>${data.crashes
         .map(
           (c) =>
-            `<tr><td><a class="fp" href="/stats/group/${esc(c.fingerprint)}">${esc(c.fingerprint.slice(0, 8))}</a></td><td><span class="pill ${c.kind === "crash" ? "crash" : ""}">${esc(c.kind)}</span></td><td>${statusPill(c.status)}</td><td class="n">${c.count}</td><td class="n">${esc(c.last_version)}</td><td class="n">${esc(c.seen)}</td></tr>`,
+            `<tr><td><a class="fp" href="/stats/group/${esc(c.fingerprint)}">${esc(c.fingerprint.slice(0, 8))}</a></td><td class="summary"${c.title ? ` title="${esc(c.title)}"` : ""}>${c.title ? esc(clip(c.title, 90)) : `<span class="muted">—</span>`}</td><td><span class="pill ${c.kind === "crash" ? "crash" : ""}">${esc(c.kind)}</span></td><td>${statusPill(c.status)}</td><td class="n">${c.count}</td><td class="n">${esc(c.last_version)}</td><td class="n">${esc(c.seen)}</td></tr>`,
         )
         .join("")}</tbody></table>`
     : `<div class="empty">No crash reports yet — that's the good kind of empty · 还没有崩溃报告</div>`;
@@ -126,6 +138,7 @@ export type Group = {
   last_version: string;
   status: string;
   note: string;
+  title: string;
 };
 
 function manageGroup(group: Group): string {
@@ -161,6 +174,7 @@ export function renderGroup(
     `Reasonix · ${group.fingerprint.slice(0, 8)}`,
     `stats / ${group.fingerprint.slice(0, 8)}`,
     `<h1><span class="pill ${group.kind === "crash" ? "crash" : ""}">${esc(group.kind)}</span> ${esc(group.fingerprint.slice(0, 8))} ${statusPill(group.status)}</h1>
+${group.title ? `<p class="summary">${esc(group.title)}</p>` : ""}
 <p class="sub"><b>${group.count}</b> occurrences · first ${esc(group.first_seen.slice(0, 10))} · last ${esc(group.last_seen.slice(0, 10))} on ${esc(group.last_version)}${noteLine}</p>
 <div class="card full"><h2>Samples <b>— newest first, up to 5 kept</b></h2>${samples}</div>
 ${user.role === "admin" ? manageGroup(group) : ""}


### PR DESCRIPTION
## Why

The desktop crash dashboard only ever saw frontend WebView errors. The entire
Go agent/provider/tool layer was invisible: an unrecovered panic kills the
process before the click-to-send overlay can paint, so it never produced a
single report. On top of that every group was an opaque `count=1` fingerprint
and minified stacks carried no symbols, so nothing was triageable without
opening each one.

## What changed

- **Go panic capture + deferred resend** (`desktop/crash_pending.go`). A
  `recoverToPending(site)` guard on the goroutines we own (restore / build
  controller / snapshot loop) writes a path-scrubbed stack to
  `crash-pending.json` and **re-raises**, so the process still crashes — the
  stack is recorded, not swallowed. `flushPendingCrash` drains and POSTs it on
  the next launch, gated on the same `desktop.telemetry` opt-out as the launch
  ping (dev builds and opt-out drop it unsent). Wails-managed bound-call
  goroutines are not yet wrapped — a known follow-up.

- **Dashboard group summaries** (worker). Each group now stores a one-line
  `title`, shown as a `summary` column in the list so a crash reads at a glance
  instead of requiring a click per fingerprint.

- **Frontend breadcrumbs** (`breadcrumbs.ts`). A 30-entry ring buffer
  (`console.error`/`warn`, tab navigation) folded into the report and scrubbed
  by the existing Go path scrubber. Terser's `drop_console: true` was deleting
  the very `console.*` calls the breadcrumbs collect, so production builds now
  keep `warn`/`error` and drop only the noise.

- **Readable stacks + build identity** (`vite.config.ts`). `keep_fnames` /
  `keep_classnames` preserve real function/component names through
  minification, and the build commit is stamped into each report. The worker
  fingerprint normalizes the `build <sha>` token so grouping stays stable
  across builds.

## Deploy notes (worker)

`groups.title` is a new column. Run the one-time migration **before** deploying
the worker, or the new queries hit a missing column:

```
wrangler d1 execute reasonix-crash --remote --file=workers/crash-report/migrate-title.sql
wrangler deploy   # from workers/crash-report
```

Fresh installs get the column from `schema.sql`.

## Verification

- `desktop`: `go vet` clean; new `crash_pending_test.go` covers capture +
  re-raise, path scrubbing, size cap, send-and-clear, and the dev guard.
- `workers/crash-report`: `tsc --noEmit` clean.
