### PR TITLE
docs(crash): disclose Go-panic resend in telemetry copy

### DIFF
--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1240,7 +1240,7 @@ export const en = {
   "updater.autoCheckLabel": "Check for updates on startup",
   "updater.autoCheckHint": "When off, Reasonix won't check automatically when it opens. You can still check manually here.",
   "settings.telemetryLabel": "Anonymous usage ping",
-  "settings.telemetryHint": "On launch, send a random install id plus version and OS to count active installs. Never includes conversations, keys, or file contents.",
+  "settings.telemetryHint": "On launch, send a random install id plus version and OS to count active installs, and — if the app crashed on a previous run — resend that crash report. Never includes conversations, keys, or file contents.",
   "settings.metricsLabel": "Share aggregate quality metrics",
   "settings.metricsHint": "Off by default. When on, send anonymous counts of how turns end (finish reason, cache-hit rate, error and tool-failure categories) so issues can be spotted across versions. Only enumerated counters — never conversations, prompts, keys, paths, or any text.",
   "updater.currentVersion": "Current version: {v}",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1242,7 +1242,7 @@ export const zh: Record<DictKey, string> = {
   "updater.autoCheckLabel": "启动时检测新版本",
   "updater.autoCheckHint": "关闭后，Reasonix 打开时不会自动检查更新；你仍可在此页手动检查。",
   "settings.telemetryLabel": "匿名启动统计",
-  "settings.telemetryHint": "启动时发送随机安装 ID、版本号和操作系统用于统计活跃安装量；绝不包含对话、密钥或文件内容。",
+  "settings.telemetryHint": "启动时发送随机安装 ID、版本号和操作系统用于统计活跃安装量；若上次运行发生崩溃，则在本次启动补发该崩溃报告。绝不包含对话、密钥或文件内容。",
   "settings.metricsLabel": "共享聚合质量指标",
   "settings.metricsHint": "默认关闭。开启后发送匿名的轮次结束统计（结束原因、缓存命中率、错误与工具失败的类别），用于跨版本发现问题。只含枚举化计数——绝不包含对话、提示词、密钥、路径或任何文本。",
   "updater.currentVersion": "当前版本：{v}",

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -105,7 +105,7 @@ export function renderStats(
   return page(
     "Reasonix · Stats",
     "stats",
-    `<h1>Desktop stats</h1><p class="sub">Today: <b>${totalUsers}</b> active installs · anonymous launch pings and user-sent crash reports only</p>
+    `<h1>Desktop stats</h1><p class="sub">Today: <b>${totalUsers}</b> active installs · anonymous launch pings and crash reports only</p>
 <div class="grid">
 <div class="card full"><h2>Daily active installs · 每日活跃 <b>— 30 days</b> (solid: users, faded: opens)</h2>
 ${anyPing ? dailyChart(days) : `<div class="empty">No pings yet — data starts flowing once a telemetry-enabled build ships · 等带统计的版本发布后这里开始有数据</div>`}</div>


### PR DESCRIPTION
Follow-up to #4187. That PR added an automatic resend of a Go-side panic
captured on a prior run, gated on the same `desktop.telemetry` opt-out as the
launch ping. Two copy surfaces still claimed only the ping / only user-sent
crashes were collected:

- **Settings hint** (`settings.telemetryHint`, en + zh) — the toggle now also
  controls the prior-run crash resend, so the hint says so. The "never includes
  conversations, keys, or file contents" guarantee is unchanged.
- **Dashboard `/stats` line** — dropped "user-sent ... only", since the list
  now includes Go crashes resent on next launch as well.

Copy only; no behavior change.
