### PR TITLE
feat(desktop): token-driven generative ambient music (rebased #4175)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { asArray } from "./lib/array";
 import { clearLegacyLangPref, normalizeLangPref, readLegacyLangPref, useI18n, useT, type Translator } from "./lib/i18n";
 import { useController, type Item, type LiveStream } from "./lib/useController";
 import { app, onEvent, onProjectTreeChanged } from "./lib/bridge";
+import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { playSuccessChime } from "./lib/sound";
 import { Transcript } from "./components/Transcript";
 import { Composer } from "./components/Composer";
@@ -1425,6 +1426,26 @@ export default function App() {
     };
   }, []);
 
+  // Run the ambient engine only while the agent is generating.
+  useEffect(() => {
+    if (state.running && isGenerativeMusicEnabled()) {
+      generativeMusic.start();
+    } else {
+      generativeMusic.stop();
+    }
+    return () => generativeMusic.stop();
+  }, [state.running]);
+
+  // playTokenNote no-ops unless the engine is running, so subscribe unconditionally.
+  useEffect(() => {
+    const unsub = onEvent((e) => {
+      if (e.kind === "text" || e.kind === "reasoning" || e.kind === "tool_dispatch") {
+        generativeMusic.playTokenNote();
+      }
+    });
+    return unsub;
+  }, []);
+
   const toggleSidebar = useCallback(() => {
     closeTransientOverlays();
     pulseSidebarToggle();
@@ -2675,6 +2696,7 @@ export default function App() {
         <SettingsPanel
           initialTab={settingsTarget}
           isDevBuild={isDevBuild}
+          agentRunning={state.running}
           onClose={() => setSettingsTarget(null)}
           onChanged={() => {
             void refreshMeta();

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -27,6 +27,7 @@ import { Tooltip } from "./Tooltip";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { MCPServersSettingsPage, SkillsSettingsPage } from "./CapabilitiesPanel";
 import { MemorySettingsPage } from "./MemoryPanel";
+import { getGenerativePreset, setGenerativePreset, generativeMusic, type GenerativePreset } from "../lib/generative-music";
 import { SoundSelect } from "./SoundSelect";
 import { getSuccessPreference, setSuccessPreference, getAttentionPreference, setAttentionPreference, playSuccessChime, playAttentionChime, type SoundWavPref } from "../lib/sound";
 import { ModalCloseButton } from "./ModalCloseButton";
@@ -36,7 +37,19 @@ const SETTINGS_TABS: SettingsTab[] = ["general", "models", "bots", "mcp", "skill
 // SettingsPanel is the desktop settings centre — a centred modal with left
 // navigation and a right content area. It hosts all settings pages plus MCP,
 // Skills, and Memory management, replacing the old per-feature drawers.
-export function SettingsPanel({ onClose, onChanged, initialTab, isDevBuild }: { onClose: () => void; onChanged: () => void; initialTab?: SettingsTab; isDevBuild?: boolean }) {
+export function SettingsPanel({
+  onClose,
+  onChanged,
+  initialTab,
+  isDevBuild,
+  agentRunning = false,
+}: {
+  onClose: () => void;
+  onChanged: () => void;
+  initialTab?: SettingsTab;
+  isDevBuild?: boolean;
+  agentRunning?: boolean;
+}) {
   const t = useT();
   const [s, setS] = useState<SettingsView | null>(null);
   const [busy, setBusy] = useState(false);
@@ -128,7 +141,7 @@ export function SettingsPanel({ onClose, onChanged, initialTab, isDevBuild }: { 
               <div className="empty">{t("settings.loading")}</div>
             ) : (
               <>
-                {tab === "general" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><GeneralSection s={s} busy={busy} apply={apply} /></SettingsPageShell>}
+                {tab === "general" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><GeneralSection s={s} busy={busy} apply={apply} agentRunning={agentRunning} /></SettingsPageShell>}
                 {tab === "models" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><ModelsSection s={s} busy={busy} apply={apply} backgroundApply={backgroundApply} /></SettingsPageShell>}
                 {tab === "bots" && isDevBuild && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><BotsSection s={s} busy={busy} apply={apply} /></SettingsPageShell>}
                 {tab === "mcp" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><MCPServersSettingsPage /></SettingsPageShell>}
@@ -679,7 +692,7 @@ function reasoningProtocolLabel(protocol: string, t: ReturnType<typeof useT>): s
   }
 }
 
-function GeneralSection({ s, busy, apply }: SectionProps) {
+function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agentRunning: boolean }) {
   const { t, setPref } = useI18n();
   const closeBehavior = normalizeCloseBehavior(s.closeBehavior);
   const [displayMode, setDisplayMode] = useState<DisplayMode>(() => normalizeDisplayMode(getDisplayMode()));
@@ -694,6 +707,7 @@ function GeneralSection({ s, busy, apply }: SectionProps) {
   useEffect(() => () => mouseDragCleanupRef.current?.(), []);
   const autoPlan = normalizeAutoPlan(s.autoPlan);
   const languagePref = normalizeLangPref(s.desktopLanguage);
+  const [genMusicPreset, setGenMusicPreset] = useState<GenerativePreset>(getGenerativePreset());
   const [soundPref, setSoundPref] = useState<SoundWavPref>(getSuccessPreference());
   const [attentionPref, setAttentionPref] = useState<SoundWavPref>(getAttentionPreference());
   const statusBarStyle = normalizeStatusBarStyle(s.statusBarStyle);
@@ -920,6 +934,30 @@ function GeneralSection({ s, busy, apply }: SectionProps) {
           ))}
         </div>
       </SettingsField>
+      <SettingsField label={t("settings.generativeMusic")} hint={t("settings.generativeMusicHint")} stacked>
+        <div className="settings-notification-sound-row">
+          <span>{t("settings.generativeMusicPreset")}</span>
+          <GenMusicSelect
+            value={genMusicPreset}
+            onChange={(next) => {
+              setGenMusicPreset(next);
+              setGenerativePreset(next);
+              if (next === "off") {
+                generativeMusic.stop();
+              } else {
+                if (generativeMusic.isRunning) {
+                  generativeMusic.setPreset(next);
+                } else if (agentRunning) {
+                  generativeMusic.start(next);
+                }
+                generativeMusic.playPreview(next);
+              }
+            }}
+            onPreview={() => { if (genMusicPreset !== "off") generativeMusic.playPreview(genMusicPreset); }}
+            previewDisabled={genMusicPreset === "off"}
+          />
+        </div>
+      </SettingsField>
       <SettingsField label={t("settings.notificationSound")} hint={t("settings.notificationSoundHint")} stacked>
         <div className="settings-notification-sound-row">
           <span>{t("settings.notificationSoundSuccess")}</span>
@@ -1065,6 +1103,77 @@ function GeneralSection({ s, busy, apply }: SectionProps) {
         </div>
       </SettingsField>
     </SettingsSection>
+  );
+}
+
+const GENRE_OPTIONS: { value: GenerativePreset; labelKey: DictKey }[] = [
+  { value: "off", labelKey: "settings.generativeMusic.off" },
+  { value: "ethereal", labelKey: "settings.generativeMusic.presets.ethereal" },
+  { value: "classic", labelKey: "settings.generativeMusic.presets.classic" },
+  { value: "digital", labelKey: "settings.generativeMusic.presets.digital" },
+  { value: "retro", labelKey: "settings.generativeMusic.presets.retro" },
+];
+
+function GenMusicSelect({
+  value,
+  onChange,
+  onPreview,
+  previewDisabled,
+}: {
+  value: GenerativePreset;
+  onChange: (v: GenerativePreset) => void;
+  onPreview: () => void;
+  previewDisabled?: boolean;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const selected = GENRE_OPTIONS.find((o) => o.value === value) ?? GENRE_OPTIONS[0];
+
+  return (
+    <div className="sound-select">
+      <button
+        ref={triggerRef}
+        className="sound-select__trigger"
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="sound-select__label">{t(selected.labelKey)}</span>
+        <ChevronDown
+          size={16}
+          className={`sound-select__chev${open ? " sound-select__chev--open" : ""}`}
+        />
+      </button>
+      <button className="chip" type="button" title={t("settings.generativeMusicPreview")} onClick={onPreview} disabled={previewDisabled}>
+        &#x25B6;
+      </button>
+      <AnchoredPopover
+        open={open}
+        anchorRef={triggerRef}
+        onClose={() => setOpen(false)}
+        className="sound-select__menu"
+        placement="bottom"
+      >
+        <div className="sound-select__list" role="listbox">
+          {GENRE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              className={`sound-select__option${opt.value === value ? " sound-select__option--selected" : ""}`}
+              role="option"
+              aria-selected={opt.value === value}
+              type="button"
+              onClick={() => {
+                onChange(opt.value);
+                setOpen(false);
+              }}
+            >
+              <span>{t(opt.labelKey)}</span>
+              {opt.value === value && <Check size={14} className="sound-select__check" />}
+            </button>
+          ))}
+        </div>
+      </AnchoredPopover>
+    </div>
   );
 }
 

--- a/desktop/frontend/src/lib/generative-music.ts
+++ b/desktop/frontend/src/lib/generative-music.ts
@@ -1,0 +1,302 @@
+/** Token-driven generative ambient music; opt-in via the "generativeMusicPreset" localStorage key. */
+
+export type GenerativePreset = "off" | "classic" | "ethereal" | "digital" | "retro";
+
+type NonEmptyPreset = "classic" | "ethereal" | "digital" | "retro";
+
+interface PresetConfig {
+  oscillatorType: OscillatorType;
+  attack: number;          // 秒
+  decay: number;           // 秒
+  sustain: number;         // 0-1 电平
+  release: number;         // 秒
+  filterFreq: number;      // Hz
+  reverbDecay: number;     // 秒（脉冲响应长度）
+  reverbWet: number;       // 0-1 混合比
+  masterVolume: number;    // 0-1
+}
+
+const PRESETS: Record<NonEmptyPreset, PresetConfig> = {
+  classic: {
+    oscillatorType: "triangle",
+    attack: 0.01,
+    decay: 0.2,
+    sustain: 0.2,
+    release: 0.3,
+    filterFreq: 2000,
+    reverbDecay: 0.3,
+    reverbWet: 0.2,
+    masterVolume: 0.08,
+  },
+  ethereal: {
+    oscillatorType: "sine",
+    attack: 0.1,
+    decay: 0.4,
+    sustain: 0.4,
+    release: 0.8,
+    filterFreq: 3000,
+    reverbDecay: 0.8,
+    reverbWet: 0.35,
+    masterVolume: 0.07,
+  },
+  digital: {
+    oscillatorType: "square",
+    attack: 0.005,
+    decay: 0.1,
+    sustain: 0.1,
+    release: 0.1,
+    filterFreq: 5000,
+    reverbDecay: 0.05,
+    reverbWet: 0.05,
+    masterVolume: 0.06,
+  },
+  retro: {
+    oscillatorType: "sawtooth",
+    attack: 0.02,
+    decay: 0.3,
+    sustain: 0.3,
+    release: 0.4,
+    filterFreq: 1500,
+    reverbDecay: 0.35,
+    reverbWet: 0.25,
+    masterVolume: 0.08,
+  },
+};
+
+// C 大调五声音阶，无半音 → 任意顺序都和谐
+const SCALE_FREQS = [261.63, 293.66, 349.23, 392.0, 440.0, 523.25, 587.33]; // C4–D5
+const OCTAVE_FREQS = [130.81, 146.83, 174.61, 196.0, 220.0, 261.63, 293.66]; // C3–D3
+
+const PRESET_KEY = "generativeMusicPreset";
+
+function readPresetPref(): GenerativePreset {
+  if (typeof localStorage === "undefined") return "off";
+  const val = localStorage.getItem(PRESET_KEY);
+  if (val === "off" || val === "classic" || val === "ethereal" || val === "digital" || val === "retro") return val;
+  return "off";
+}
+
+function writePresetPref(pref: GenerativePreset): void {
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(PRESET_KEY, pref);
+  }
+}
+
+export function getGenerativePreset(): GenerativePreset {
+  return readPresetPref();
+}
+
+export function setGenerativePreset(pref: GenerativePreset): void {
+  writePresetPref(pref);
+}
+
+export function isGenerativeMusicEnabled(): boolean {
+  return readPresetPref() !== "off";
+}
+
+class GenerativeMusicEngine {
+  private ctx: AudioContext | null = null;
+  private masterGain: GainNode | null = null;
+  private filterNode: BiquadFilterNode | null = null;
+  private reverbNode: ConvolverNode | null = null;
+  private reverbGain: GainNode | null = null;      // wet
+  private preset: NonEmptyPreset = "ethereal";
+  private running = false;
+  private lastNoteTime = 0;
+  private tokenToggle = 0;
+
+  start(preset?: NonEmptyPreset): void {
+    if (this.running) return;
+    const p = preset ?? readPresetPref();
+    if (p === "off") return;
+    this.preset = p;
+    this.running = true;
+
+    try {
+      this.ctx = new AudioContext();
+      this.buildSignalChain();
+    } catch (e) {
+      console.warn("generative-music: failed to create AudioContext", e);
+      this.running = false;
+    }
+  }
+
+  stop(): void {
+    if (!this.running) return;
+    this.running = false;
+
+    if (this.masterGain && this.ctx) {
+      try {
+        const now = this.ctx.currentTime;
+        this.masterGain.gain.cancelScheduledValues(now);
+        this.masterGain.gain.setValueAtTime(this.masterGain.gain.value, now);
+        this.masterGain.gain.linearRampToValueAtTime(0, now + 0.3);
+      } catch (e) {
+        console.warn("generative-music: gain ramp failed", e);
+      }
+    }
+
+    const ctx = this.ctx;
+    setTimeout(() => {
+      ctx?.close();
+    }, 500);
+    this.ctx = null;
+    this.masterGain = null;
+    this.filterNode = null;
+    this.reverbNode = null;
+    this.reverbGain = null;
+  }
+
+  setPreset(preset: NonEmptyPreset): void {
+    this.preset = preset;
+    writePresetPref(preset);
+    if (this.ctx && this.masterGain) {
+      this.buildSignalChain();
+    }
+  }
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+
+  /** 双重节流：每 4 个 token + 最小 100ms 间隔，适配 DeepSeek 高频输出。 */
+  playTokenNote(): void {
+    if (!this.running || !this.ctx) return;
+
+    this.tokenToggle++;
+    if (this.tokenToggle % 4 !== 0) return;
+
+    const now = performance.now();
+    if (now - this.lastNoteTime < 100) return;
+    this.lastNoteTime = now;
+
+    const time = this.ctx.currentTime;
+
+    const useLow = Math.random() < 0.15;
+    const freqs = useLow ? OCTAVE_FREQS : SCALE_FREQS;
+    const freq = freqs[Math.floor(Math.random() * freqs.length)];
+
+    const detune = 1 + (Math.random() - 0.5) * 0.1;
+    this.playNote(time, freq * detune);
+  }
+
+  private buildSignalChain(): void {
+    if (!this.ctx) return;
+    const cfg = PRESETS[this.preset];
+
+    if (this.masterGain) this.masterGain.disconnect();
+    this.masterGain = this.ctx.createGain();
+    this.masterGain.gain.value = cfg.masterVolume;
+    this.masterGain.connect(this.ctx.destination);
+
+    if (this.filterNode) this.filterNode.disconnect();
+    this.filterNode = this.ctx.createBiquadFilter();
+    this.filterNode.type = "lowpass";
+    this.filterNode.frequency.value = cfg.filterFreq;
+    this.filterNode.Q.value = 1;
+    this.filterNode.connect(this.masterGain);
+
+    if (this.reverbNode) this.reverbNode.disconnect();
+    if (this.reverbGain) this.reverbGain.disconnect();
+
+    this.reverbNode = this.ctx.createConvolver();
+    this.reverbNode.buffer = this.createReverbImpulse(this.ctx, cfg.reverbDecay);
+    this.reverbGain = this.ctx.createGain();
+    this.reverbGain.gain.value = cfg.reverbWet;
+    this.filterNode.connect(this.reverbNode);
+    this.reverbNode.connect(this.reverbGain);
+    this.reverbGain.connect(this.masterGain);
+  }
+
+  private createReverbImpulse(ctx: AudioContext, duration: number): AudioBuffer {
+    const sampleRate = ctx.sampleRate;
+    const length = Math.max(Math.round(sampleRate * duration), 1);
+    const buffer = ctx.createBuffer(2, length, sampleRate);
+    for (let ch = 0; ch < 2; ch++) {
+      const data = buffer.getChannelData(ch);
+      for (let i = 0; i < length; i++) {
+        const t = i / length;
+        data[i] = (Math.random() * 2 - 1) * Math.pow(1 - t, 1.5) * (1 + Math.sin(t * Math.PI * 3) * 0.3);
+      }
+    }
+    return buffer;
+  }
+
+  private playNote(time: number, freq: number): void {
+    if (!this.ctx) return;
+    const cfg = PRESETS[this.preset];
+    const now = this.ctx.currentTime;
+    const t = Math.max(time, now + 0.005);
+
+    const osc = this.ctx.createOscillator();
+    osc.type = cfg.oscillatorType;
+    osc.frequency.setValueAtTime(freq, t);
+
+    const envGain = this.ctx.createGain();
+    const env = envGain.gain;
+    const noteEnd = t + cfg.attack + cfg.decay + cfg.release + 0.01;
+    env.setValueAtTime(0, t);
+    env.linearRampToValueAtTime(1, t + cfg.attack);
+    env.linearRampToValueAtTime(cfg.sustain, t + cfg.attack + cfg.decay);
+    env.setValueAtTime(cfg.sustain, t + cfg.attack + cfg.decay + 0.01);
+    env.linearRampToValueAtTime(0.001, t + cfg.attack + cfg.decay + 0.01 + cfg.release);
+
+    osc.connect(envGain);
+    if (this.filterNode) {
+      envGain.connect(this.filterNode);
+    } else {
+      envGain.connect(this.ctx.destination);
+    }
+
+    osc.start(t);
+    osc.stop(noteEnd);
+  }
+
+  playPreview(preset: NonEmptyPreset): void {
+    const ctx = new AudioContext();
+    const cfg = PRESETS[preset];
+
+    const filter = ctx.createBiquadFilter();
+    filter.type = "lowpass";
+    filter.frequency.value = cfg.filterFreq;
+
+    const reverb = ctx.createConvolver();
+    reverb.buffer = this.createReverbImpulse(ctx, cfg.reverbDecay);
+    const reverbGain = ctx.createGain();
+    reverbGain.gain.value = cfg.reverbWet;
+
+    const master = ctx.createGain();
+    master.gain.value = cfg.masterVolume * 2;
+    master.connect(ctx.destination);
+
+    filter.connect(master);
+    filter.connect(reverb);
+    reverb.connect(reverbGain);
+    reverbGain.connect(master);
+
+    const notes = [SCALE_FREQS[0], SCALE_FREQS[2], SCALE_FREQS[4], SCALE_FREQS[6]];
+    notes.forEach((freq, i) => {
+      const t = ctx.currentTime + i * 0.05;
+
+      const osc = ctx.createOscillator();
+      osc.type = cfg.oscillatorType;
+      osc.frequency.setValueAtTime(freq, t);
+
+      const env = ctx.createGain();
+      env.gain.setValueAtTime(0, t);
+      env.gain.linearRampToValueAtTime(1, t + cfg.attack);
+      env.gain.linearRampToValueAtTime(cfg.sustain, t + cfg.attack + cfg.decay);
+      env.gain.setValueAtTime(cfg.sustain, t + 0.05);
+      env.gain.linearRampToValueAtTime(0.001, t + cfg.attack + cfg.decay + cfg.release);
+
+      osc.connect(env);
+      env.connect(filter);
+      osc.start(t);
+      osc.stop(t + cfg.attack + cfg.decay + cfg.release + 0.05);
+    });
+
+    setTimeout(() => ctx.close(), 3000);
+  }
+}
+
+export const generativeMusic = new GenerativeMusicEngine();

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1149,6 +1149,15 @@ export const en = {
   "settings.language": "Language",
   "settings.langAuto": "Auto (system)",
   "settings.config": "config: {path}",
+  "settings.generativeMusic": "Generative background music",
+  "settings.generativeMusicHint": "Ambient music that loops during AI generation",
+  "settings.generativeMusicPreset": "Sound preset",
+  "settings.generativeMusic.presets.classic": "Classic (Triangle)",
+  "settings.generativeMusic.presets.ethereal": "Ethereal (Sine) ★",
+  "settings.generativeMusic.off": "Off",
+  "settings.generativeMusic.presets.digital": "Digital (Square)",
+  "settings.generativeMusic.presets.retro": "Retro (Sawtooth)",
+  "settings.generativeMusicPreview": "Preview",
 
   // todo bar
   "todo.title": "To-dos",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1151,6 +1151,15 @@ export const zh: Record<DictKey, string> = {
   "settings.language": "语言",
   "settings.langAuto": "自动（跟随系统）",
   "settings.config": "配置文件：{path}",
+  "settings.generativeMusic": "生成式背景音乐",
+  "settings.generativeMusicHint": "对话生成过程中播放背景音乐",
+  "settings.generativeMusicPreset": "音乐预设",
+  "settings.generativeMusic.presets.classic": "经典",
+  "settings.generativeMusic.presets.ethereal": "空灵",
+  "settings.generativeMusic.off": "关闭",
+  "settings.generativeMusic.presets.digital": "数字",
+  "settings.generativeMusic.presets.retro": "复古",
+  "settings.generativeMusicPreview": "试听",
 
   // 待办栏
   "todo.title": "待办",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10046,11 +10046,15 @@ a[href] {
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
+  width: 100%;
+  max-width: 640px;
+  min-width: 0;
 }
 
 .settings-notification-sound-row > span {
   flex: 0 0 auto;
   font-size: 13px;
+  color: var(--fg);
   min-width: 110px;
 }
 


### PR DESCRIPTION
Lands #4175 (token-driven generative ambient music in the desktop app) on current `main-v2`.

Squashed onto `main-v2` (the original PR had merged `main-v2` back in and #4188 had since moved `SettingsPanel.tsx`), plus a house-style comment pass on `generative-music.ts` / `App.tsx` — trimmed the multi-line file header, dropped the `// ── … ──` section banners and the restating one-liners, keeping only the non-obvious *why* (pentatonic scale, the double throttle, the `wet` gain). No behaviour change: the code lines are byte-identical to #4175.

Credit to @ttmouse for the feature and @SivanCola for the review fixes (default-off + live preset/stop sync), both folded into the single commit here.

## What it does
- Opt-in, **default off**. Preset picker in Settings → General (classic / ethereal / digital / retro).
- Each text/reasoning/tool token triggers a C-major-pentatonic note through a Web Audio chain (oscillator → ADSR → low-pass → reverb); fast generation → denser notes.
- Throttled (every 4th token + 100 ms floor) for DeepSeek's output rate.
- Switching to Off or another preset mid-generation takes effect immediately; nothing auto-plays on launch/upgrade.

## Verification (local)
- `pnpm --dir desktop/frontend typecheck` — clean apart from the usual ungenerated-`wailsjs` binding errors that `wails generate` resolves in CI.
- `go build ./...` in `desktop/` — green.
- Confirmed the cleanup is comment-only (PR-original vs. cleaned: code lines identical).

Closes #4175
