### PR TITLE
fix(desktop): retry atomic writes past transient Windows locks

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -22,6 +22,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/fileutil"
 	"reasonix/internal/provider"
 )
 
@@ -1372,7 +1373,7 @@ func (a *App) saveTabsLocked() {
 	path := filepath.Join(dir, tabsFileName)
 	tmp := path + ".tmp"
 	os.WriteFile(tmp, b, 0o644)
-	os.Rename(tmp, path)
+	_ = fileutil.ReplaceFile(tmp, path)
 }
 
 func (a *App) orderedTabIDsLocked() []string {
@@ -1443,7 +1444,7 @@ func saveProjectsFile(f desktopProjectFile) error {
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	return fileutil.ReplaceFile(tmp, path)
 }
 
 func normalizeProjectRoot(root string) string {
@@ -1821,7 +1822,7 @@ func saveTopicTitles(workspaceRoot string, m map[string]string) error {
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	return fileutil.ReplaceFile(tmp, path)
 }
 
 func saveTopicTitleSources(workspaceRoot string, m map[string]string) error {
@@ -1837,7 +1838,7 @@ func saveTopicTitleSources(workspaceRoot string, m map[string]string) error {
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	return fileutil.ReplaceFile(tmp, path)
 }
 
 func saveTopicCreatedAts(workspaceRoot string, m map[string]int64) error {
@@ -1853,7 +1854,7 @@ func saveTopicCreatedAts(workspaceRoot string, m map[string]int64) error {
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	return fileutil.ReplaceFile(tmp, path)
 }
 
 func loadTopicTitle(workspaceRoot, topicID string) string {
@@ -2026,7 +2027,7 @@ func saveTelemetry(path string, snapshot tabTelemetrySnapshot) error {
 	if err := os.WriteFile(tmp, b, 0o644); err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	return fileutil.ReplaceFile(tmp, path)
 }
 
 func loadTelemetry(path string) tabTelemetrySnapshot {

--- a/internal/fileutil/atomicwrite.go
+++ b/internal/fileutil/atomicwrite.go
@@ -1,17 +1,42 @@
 package fileutil
 
-import "os"
+import (
+	"os"
+	"time"
+)
+
+var (
+	maxReplaceRetries = 8
+	replaceRetryBase  = 20 * time.Millisecond
+)
 
 // ReplaceFile renames tmp onto dest, falling back to a copy when the rename
 // fails — Windows encryption-software filter drivers report a cross-device link
-// (EXDEV) for a same-dir rename. The rename error surfaces only if the copy also fails.
+// (EXDEV) for a same-dir rename. A second Windows failure mode is a transient
+// lock on dest (antivirus, the search indexer, a second instance) that makes both
+// the rename and the copy fail with "Access is denied" for a few hundred ms, so
+// the replace is retried with a short backoff while the tmp source survives — a
+// missing tmp means the write itself failed and no retry can help. The rename
+// error surfaces only if every attempt fails.
 func ReplaceFile(tmp, dest string) error {
-	if err := os.Rename(tmp, dest); err != nil {
-		if copyErr := copyOnto(tmp, dest); copyErr != nil {
+	var err error
+	for attempt := 0; ; attempt++ {
+		if err = os.Rename(tmp, dest); err == nil {
+			return nil
+		}
+		if copyOnto(tmp, dest) == nil {
+			return nil
+		}
+		if attempt >= maxReplaceRetries || !fileExists(tmp) {
 			return err
 		}
+		time.Sleep(time.Duration(attempt+1) * replaceRetryBase)
 	}
-	return nil
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func copyOnto(tmp, dest string) error {

--- a/internal/fileutil/atomicwrite_test.go
+++ b/internal/fileutil/atomicwrite_test.go
@@ -4,7 +4,46 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
+
+func TestReplaceFileNoRetryWhenTmpMissing(t *testing.T) {
+	oldBase := replaceRetryBase
+	replaceRetryBase = 10 * time.Second
+	t.Cleanup(func() { replaceRetryBase = oldBase })
+
+	dir := t.TempDir()
+	start := time.Now()
+	err := ReplaceFile(filepath.Join(dir, "missing.tmp"), filepath.Join(dir, "x.txt"))
+	if err == nil {
+		t.Fatal("want error when tmp source is missing")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("missing tmp should fail fast, took %v — it retried", elapsed)
+	}
+}
+
+func TestReplaceFileRetriesThenReturnsError(t *testing.T) {
+	oldBase, oldMax := replaceRetryBase, maxReplaceRetries
+	replaceRetryBase, maxReplaceRetries = 0, 3
+	t.Cleanup(func() { replaceRetryBase, maxReplaceRetries = oldBase, oldMax })
+
+	dir := t.TempDir()
+	tmp := filepath.Join(dir, "x.tmp")
+	if err := os.WriteFile(tmp, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dest := filepath.Join(dir, "blocked")
+	if err := os.Mkdir(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := ReplaceFile(tmp, dest); err == nil {
+		t.Fatal("want error when dest can never be replaced")
+	}
+	if !fileExists(tmp) {
+		t.Error("tmp should survive a failed replace so the next launch can retry")
+	}
+}
 
 func TestReplaceFileRenamesInPlace(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Symptom

A recurring crash group, four different Windows users in one day (surfaced by the new dashboard summary column):

```
[unhandledrejection]
rename D:\...\.reasonix\desktop-topic-title-sources.json.tmp …\desktop-topic-title-sources.json: Access is denied.
```

## Cause

Antivirus, the Windows Search indexer, or a second instance holds the destination JSON for a few hundred milliseconds. `MoveFileEx` (Go's `os.Rename`) then fails with `ERROR_ACCESS_DENIED`, and because the desktop's cosmetic-state writers did a **raw `os.Rename(tmp, path)`** — bypassing `fileutil.ReplaceFile` and with no retry — the error propagated up a bound method and reached the frontend as an uncaught promise rejection, painting the full crash overlay over a cosmetic title-cache write.

## Fix

- **`fileutil.ReplaceFile`**: retry the replace a few times with a short escalating backoff *while the tmp source still exists* — a missing tmp means the write itself failed, so it fails fast with no pointless retry. The EXDEV copy fallback is unchanged. Every existing caller (branch metadata, session titles, config, dotenv, acp) gains the same Windows robustness.
- **`desktop/tabs.go`**: route the six raw `os.Rename(tmp, path)` writers (tabs, projects, topic titles / sources / created-ats, telemetry snapshot) through `ReplaceFile`.

## Verification

- `go test ./internal/fileutil` — new tests cover fast-fail on missing tmp and retry-then-return-error when the destination can never be replaced (tmp preserved for the next attempt).
- `go test ./desktop -run 'Topic|Tab|Telemetry|Title'` and `go vet ./desktop` — green.

A truly permanent FS error (e.g. a read-only `.reasonix`) still surfaces; that's a broken environment, not the transient lock these reports show. Catching the rejection frontend-side so even that degrades gracefully is a reasonable follow-up.
