### PR TITLE
fix(desktop): right-align the sidebar time-filter menu so it can't clip

### DIFF
--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -518,31 +518,21 @@ export function ProjectTree({
       : timeFilter === "5h" ? 5 * 60 * 60 * 1000
       : timeFilter === "1d" ? 24 * 60 * 60 * 1000
       : 0;
+    const nthLatestActivity = (n: number): number | null => {
+      const times = new Set<number>();
+      const collect = (nodes: ProjectNode[]) => {
+        for (const node of nodes) {
+          if (node.kind === "topic" || node.kind === "global_topic") times.add(topicActivityTime(node));
+          collect(asArray(node.children));
+        }
+      };
+      collect(tree);
+      const sorted = [...times].sort((a, b) => b - a);
+      return sorted.length === 0 ? null : sorted[Math.min(n, sorted.length) - 1];
+    };
     const cutoff: number | null = timeFilter === "all" ? null
-      : timeFilter === "10" ? (() => {
-          const times = new Set<number>();
-          const collect = (nodes: ProjectNode[]) => {
-            for (const n of nodes) {
-              if (n.kind === "topic" || n.kind === "global_topic") times.add(topicActivityTime(n));
-              collect(asArray(n.children));
-            }
-          };
-          collect(tree);
-          const sorted = [...times].sort((a, b) => b - a);
-          return sorted.length >= 10 ? sorted[9] : (sorted.length > 0 ? sorted[sorted.length - 1] : null);
-        })()
-      : timeFilter === "20" ? (() => {
-          const times = new Set<number>();
-          const collect = (nodes: ProjectNode[]) => {
-            for (const n of nodes) {
-              if (n.kind === "topic" || n.kind === "global_topic") times.add(topicActivityTime(n));
-              collect(asArray(n.children));
-            }
-          };
-          collect(tree);
-          const sorted = [...times].sort((a, b) => b - a);
-          return sorted.length >= 20 ? sorted[19] : (sorted.length > 0 ? sorted[sorted.length - 1] : null);
-        })()
+      : timeFilter === "10" ? nthLatestActivity(10)
+      : timeFilter === "20" ? nthLatestActivity(20)
       : Date.now() - diff;
     const topicMatchesTime = (node: ProjectNode) => {
       if (cutoff === null) return true;

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -15331,7 +15331,9 @@ a[href] {
 .project-tree__time-filter-menu {
   position: absolute;
   top: calc(100% + 4px);
-  left: 0;
+  /* Right-aligned: the trigger sits in the right-aligned header inside the
+     overflow:hidden sidebar, so opening leftward keeps the menu unclipped. */
+  right: 0;
   z-index: var(--z-menu);
   min-width: 84px;
   padding: 4px;


### PR DESCRIPTION
Follow-up to #4150 (the codex bot flagged the same thing).

The time-filter dropdown was `left: 0` inside the `overflow: hidden` sidebar; the trigger is in the right-aligned header, so on a narrow sidebar — and with the longer zh labels — the menu ran past the right edge and clipped. Right-align it so it opens leftward into the sidebar.

Also folds the duplicated Latest-10 / Latest-20 cutoff IIFEs into one helper, behavior-identical (same Set-dedup, sort, short-list fallback).