### PR TITLE
fix(ui): restore TurnCollapse step-based rendering, batch read-only in sub-agents

### DIFF
--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useState } from "react";
+import { memo, useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
@@ -344,6 +344,13 @@ export const AssistantMessage = memo(function AssistantMessage({
   // Thinking streams in before the answer — show it live while the model is still
   // working, then it stays available behind the toggle once the answer arrives.
   const [reasoningOpen, setReasoningOpen] = useState(item.streaming || defaultExpanded);
+  const reasoningUserToggled = useRef(false);
+  // Auto-close reasoning when streaming finishes, unless the user toggled it
+  useEffect(() => {
+    if (!item.streaming && !reasoningUserToggled.current) setReasoningOpen(false);
+    if (!item.streaming) reasoningUserToggled.current = false; // reset for next stream
+  }, [item.streaming]);
+  const toggleReasoning = () => { reasoningUserToggled.current = true; setReasoningOpen((v) => !v); };
   const hasText = item.streaming || item.text.trim() !== "";
   const processOnly = Boolean(item.reasoning) && !hasText;
   const processWithText = Boolean(item.reasoning) && hasText;
@@ -355,7 +362,7 @@ export const AssistantMessage = memo(function AssistantMessage({
             type="button"
             className="reasoning__head"
             data-running={item.streaming ? "" : undefined}
-            onClick={() => setReasoningOpen((v) => !v)}
+            onClick={toggleReasoning}
             aria-expanded={reasoningOpen}
           >
             <ProcessBrainIcon size={12} />

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState, type ReactNode } from "react";
 import { ChevronRight } from "lucide-react";
 import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
@@ -6,6 +6,8 @@ import { useT } from "../lib/i18n";
 import { diffsFor, subjectOf } from "../lib/tools";
 import { useShellExpand } from "../lib/shellExpand";
 import type { Item } from "../lib/useController";
+import { isReadOnlyTool } from "../lib/useController";
+import { ReadOnlyBatch } from "./ReadOnlyBatch";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 
@@ -59,12 +61,10 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
   const shellOutput = item.isShell && item.output ? item.output : null;
   const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
   const hasBody = Boolean(diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error);
-  // Writers keep their output/diff visible by default (don't make the user expand
-  // to see what a command produced); read-only research folds away. Sub-agents open
-  // while running so nested calls are visible. A click (or Ctrl/Cmd+B) overrides.
-  const defaultOpen = hasNested
-    ? item.status === "running"
-    : Boolean(item.error) || (!item.readOnly && (diffs.length > 0 || !!item.output));
+  // All tools default to collapsed. Sub-agent tools open while running so the
+  // user sees nested calls; they collapse when done. Reasoning (AssistantMessage)
+  // also opens while streaming and closes on finish.
+  const defaultOpen = hasNested ? item.status === "running" : false;
   const [userOpen, setUserOpen] = useState<boolean | null>(null);
   const open = userOpen ?? defaultOpen;
   const openRef = useRef(open);
@@ -98,9 +98,12 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
         aria-expanded={hasBody ? open : undefined}
       >
         <span className="tool__label-group">
+          {hasNested && <span className="tool__nested-count">⊞{nested.length}</span>}
+          {item.status === "error" && <span className="tool__status-icon tool__status-icon--err">✗</span>}
+          {item.status === "done" && <span className="tool__status-icon tool__status-icon--ok">✓</span>}
+          {item.status === "stopped" && <span className="tool__status-icon tool__status-icon--stopped">—</span>}
           <span className="tool__name">{item.name}</span>
           {subject && <span className="tool__subject">{subject}</span>}
-          {hasNested && <span className="tool__nested-count">⊞{nested.length}</span>}
         </span>
         {profileText && <span className="tool__profile">{profileText}</span>}
         {duration && <span className="tool__duration">{duration}</span>}
@@ -123,9 +126,25 @@ export const ToolCard = memo(function ToolCard({ item, subcalls }: { item: ToolI
 
         {hasNested && (
           <div className="tool__nested">
-            {nested.map((c) => (
-              <ToolCard key={c.id} item={c} />
-            ))}
+            {(() => {
+              const out: ReactNode[] = [];
+              const roBatch: typeof nested = [];
+              const flush = () => {
+                if (roBatch.length === 0) return;
+                out.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={new Map()} />);
+                roBatch.length = 0;
+              };
+              for (const c of nested) {
+                if (isReadOnlyTool(c.name) && c.name !== "todo_write") {
+                  roBatch.push(c);
+                  continue;
+                }
+                flush();
+                out.push(<ToolCard key={c.id} item={c} />);
+              }
+              flush();
+              return out;
+            })()}
           </div>
         )}
 

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -10,21 +10,7 @@ import { ChevronRight } from "lucide-react";
 import { Welcome } from "./Welcome";
 import { ReadOnlyBatch } from "./ReadOnlyBatch";
 import { getDisplayMode, onDisplayModeChange, type DisplayMode } from "../lib/displayMode";
-
-/** Matches Go backend's ReadOnly() + codegraph ReadOnlyToolNames(). */
-function isReadOnlyTool(name: string): boolean {
-  switch (name) {
-    case "read_file": case "ls": case "grep": case "glob": case "web_fetch":
-    case "bash_output": case "waitJob": case "todo_write": case "read_skill":
-    case "codegraph_callees": case "codegraph_callers": case "codegraph_context":
-    case "codegraph_explore": case "codegraph_files": case "codegraph_impact":
-    case "codegraph_node": case "codegraph_search": case "codegraph_status":
-    case "codegraph_trace":
-      return true;
-    default:
-      return false;
-  }
-}
+import { isReadOnlyTool } from "../lib/useController";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
@@ -358,6 +344,44 @@ export function Transcript({
   // (added by upstream PR #3423) instead of per-call renderSegments.
   const empty = items.length === 0;
 
+  // In compact/minimal mode, break each turn into step groups.
+  // A step = one assistant + its tool results, from one assistant to the next.
+  // Each completed non-final step is folded into "Processed".
+  const stepGroups = useMemo(() => {
+    if (displayMode === "standard") return null;
+    const groups: { items: Item[]; isFinal: boolean; isComplete: boolean }[] = [];
+    let current: Item[] = [];
+
+    for (let i = hotStartIdx; i < items.length; i++) {
+      const it = items[i];
+      if (it.kind === "user") {
+        if (current.length > 0) {
+          const first = current[0];
+          const isFinal = first.kind === "assistant" && !first.streaming && first.text.trim() !== "";
+          groups.push({ items: current, isFinal, isComplete: true });
+          current = [];
+        }
+        groups.push({ items: [it], isFinal: false, isComplete: true });
+        continue;
+      }
+      if (it.kind === "assistant") {
+        if (current.length > 0) {
+          groups.push({ items: current, isFinal: false, isComplete: true });
+          current = [];
+        }
+        current.push(it);
+      } else {
+        current.push(it);
+      }
+    }
+    if (current.length > 0) {
+      const first = current[0];
+      const isFinal = first.kind === "assistant" && !first.streaming && first.text.trim() !== "";
+      groups.push({ items: current, isFinal, isComplete: false });
+    }
+    return groups;
+  }, [displayMode, hotStartIdx, items]);
+
   const hotZoneNodes = useMemo<ReactNode[]>(() => {
     const out: ReactNode[] = [];
     let actionText = "";
@@ -387,65 +411,143 @@ export function Transcript({
       actionReady = false;
     };
 
-    // Compact/minimal: completed read-only research folds into a slim batch so a
-    // long run of reads stays quiet; running reads, writers, and the model's own
-    // text + thinking render directly so the turn's substance stays visible.
-    // Standard: flat, no batching. The warm zone (WarmTurnItems) renders the same way.
-    const batchReadOnly = displayMode !== "standard";
-    const roBatch: ToolItem[] = [];
-    const flushRO = () => {
-      if (roBatch.length === 0) return;
-      out.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={subcallsByParent} />);
-      roBatch.length = 0;
-    };
+    // Compact/minimal mode: step-based rendering
+    // Standard mode: flat rendering (no step groups)
+    if (stepGroups) {
+      // Collect consecutive completed non-final steps into batches
+      let collapseBatch: Item[] = [];
+      let collapseBatchStart: string | null = null;
+      const flushCollapseBatch = () => {
+        if (collapseBatch.length === 0) return;
+        const dur = collapseBatch.reduce((ms, it) => ms + (it.kind === "tool" ? it.durationMs ?? 0 : 0), 0);
+        out.push(
+          <TurnCollapse
+            key={`step-batch-${collapseBatchStart}`}
+            items={collapseBatch}
+            durationMs={dur}
+            mode={displayMode}
+            subcalls={subcallsByParent}
+          />,
+        );
+        collapseBatch = [];
+        collapseBatchStart = null;
+      };
 
-    for (let i = hotStartIdx; i < items.length; i++) {
-      const it = items[i];
-      if (
-        batchReadOnly &&
-        it.kind === "tool" &&
-        !it.parentId &&
-        it.status !== "running" &&
-        it.name !== "todo_write" &&
-        it.name !== "exit_plan_mode" &&
-        isReadOnlyTool(it.name)
-      ) {
-        roBatch.push(it as ToolItem);
-        continue;
-      }
-      flushRO();
-      switch (it.kind) {
-        case "user": {
+      for (const group of stepGroups) {
+        const first = group.items[0];
+
+        if (first.kind === "user") {
+          flushCollapseBatch();
           pushTurnActions();
-          const tn = userTurn.get(it.id);
+          const tn = userTurn.get(first.id);
           activeTurn = tn;
           out.push(
-            <UserMessage key={it.id} id={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
+            <UserMessage key={first.id} id={first.id} text={first.text} failed={first.failed} turn={tn} anchorId={questionAnchorId(first.id)} />,
           );
-          break;
+          continue;
         }
-        case "assistant":
+
+        // Completed non-final step → batch it
+        if (group.isComplete && !group.isFinal) {
+          if (!collapseBatchStart) collapseBatchStart = first.id;
+          collapseBatch.push(...group.items);
+          continue;
+        }
+
+        // Final answer or active step → flush any pending batch then render
+        flushCollapseBatch();
+        const nonAssistantItems = group.items.filter(
+          (it) => it.kind !== "assistant" || (it.streaming && !it.text.trim())
+        );
+        const hasRunning = nonAssistantItems.some((it) => it.kind === "tool" && it.status === "running");
+        if (nonAssistantItems.length > 0 && !hasRunning) {
+          const dur = nonAssistantItems.reduce((ms, it) => ms + (it.kind === "tool" ? ((it as ToolItem).durationMs ?? 0) : 0), 0);
+          out.push(
+            <TurnCollapse
+              key={`step-${first.id}`}
+              items={nonAssistantItems}
+              durationMs={dur}
+              mode={displayMode}
+              subcalls={subcallsByParent}
+            />,
+          );
+        } else if (nonAssistantItems.length > 0) {
+          for (const it of nonAssistantItems) {
+            if (it.kind === "tool") {
+              if (it.parentId) continue;
+              if (it.name === "todo_write" || it.name === "exit_plan_mode") continue;
+              out.push(<ToolCard key={it.id} item={it as ToolItem} subcalls={subcallsByParent.get(it.id)} />);
+            }
+            if (it.kind === "phase") out.push(<PhaseCard key={it.id} text={it.text} />);
+          }
+        }
+        // Render the final assistant message (if any) directly
+        for (const it of group.items) {
+          if (it.kind !== "assistant") continue;
           out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} />);
           if (!it.streaming && it.text.trim() !== "") {
             actionText = it.text;
             actionReady = true;
           }
-          break;
-        case "tool":
-          if (it.parentId) break;
-          if (it.name === "todo_write") break;
-          if (it.name === "exit_plan_mode") break;
-          out.push(<ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />);
-          break;
-        case "phase": out.push(<PhaseCard key={it.id} text={it.text} />); break;
-        case "notice": out.push(<NoticeCard key={it.id} level={it.level} text={it.text} />); break;
-        case "compaction": out.push(<CompactionCard key={it.id} item={it} />); break;
+        }
       }
+      flushCollapseBatch();
+      pushTurnActions();
+    } else {
+      // Standard mode: flat rendering
+      const roBatch: ToolItem[] = [];
+      const flushRO = () => {
+        if (roBatch.length === 0) return;
+        out.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={subcallsByParent} />);
+        roBatch.length = 0;
+      };
+      for (let i = hotStartIdx; i < items.length; i++) {
+        const it = items[i];
+        if (
+          it.kind === "tool" &&
+          !it.parentId &&
+          it.status !== "running" &&
+          it.name !== "todo_write" &&
+          it.name !== "exit_plan_mode" &&
+          isReadOnlyTool(it.name)
+        ) {
+          roBatch.push(it as ToolItem);
+          continue;
+        }
+        flushRO();
+        switch (it.kind) {
+          case "user": {
+            pushTurnActions();
+            const tn = userTurn.get(it.id);
+            activeTurn = tn;
+            out.push(
+              <UserMessage key={it.id} id={it.id} text={it.text} failed={it.failed} turn={tn} anchorId={questionAnchorId(it.id)} />,
+            );
+            break;
+          }
+          case "assistant":
+            out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} />);
+            if (!it.streaming && it.text.trim() !== "") {
+              actionText = it.text;
+              actionReady = true;
+            }
+            break;
+          case "tool":
+            if (it.parentId) break;
+            if (it.name === "todo_write") break;
+            if (it.name === "exit_plan_mode") break;
+            out.push(<ToolCard key={it.id} item={it} subcalls={subcallsByParent.get(it.id)} />);
+            break;
+          case "phase": out.push(<PhaseCard key={it.id} text={it.text} />); break;
+          case "notice": out.push(<NoticeCard key={it.id} level={it.level} text={it.text} />); break;
+          case "compaction": out.push(<CompactionCard key={it.id} item={it} />); break;
+        }
+      }
+      flushRO();
+      pushTurnActions();
     }
-    flushRO();
-    pushTurnActions();
     return out;
-  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, defaultExpandThinking]);
+  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, defaultExpandThinking]);
 
   // ── Assemble rendered output ──────────────────────────────────────────────
   // Warm/cold zone is a separate memo'd WarmZone component so streaming tokens
@@ -767,6 +869,90 @@ function WarmTurnCard({
         <div className="warm-turn__body">{children}</div>
       ) : (
         assistantPreview && <div className="warm-turn__assistant">{assistantPreview}</div>
+      )}
+    </div>
+  );
+}
+
+// ── TurnCollapse: compact/minimal mode grouping ──────────────────────────────
+
+type TurnCollapseProps = {
+  items: Item[];       // intermediate items (tools, reasoning, phase)
+  durationMs: number;  // summed tool execution time across the batch; 0 when unknown
+  mode: DisplayMode;
+  subcalls: Map<string, ToolItem[]>;
+};
+
+function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+
+  // Keep only items the body will actually render — an expandable fold over
+  // nothing is worse than no fold. Minimal mode strips reasoning, so a
+  // reasoning-only assistant counts as empty there.
+  const displayItems = useMemo(() => {
+    return items.filter((it) => {
+      if (it.kind === "assistant") {
+        if (it.text.trim() !== "") return true;
+        return mode !== "minimal" && Boolean(it.reasoning);
+      }
+      if (it.kind === "phase") return mode !== "minimal";
+      if (it.kind !== "tool") return false;
+      if (it.parentId || it.name === "todo_write" || it.name === "exit_plan_mode") return false;
+      if (mode === "minimal") return it.name !== "bash";
+      return true;
+    });
+  }, [items, mode]);
+
+  const seconds = Math.round(durationMs / 1000);
+  const label = seconds > 0 ? t("transcript.processedDuration", { s: seconds }) : t("transcript.processed");
+
+  if (displayItems.length === 0) return null;
+
+  // Pre-compute body: group consecutive completed read-only tools into ReadOnlyBatch
+  const body: ReactNode[] = [];
+  const roBatch: ToolItem[] = [];
+  const flushRO = () => {
+    if (roBatch.length === 0) return;
+    body.push(<ReadOnlyBatch key={`rob-${roBatch[0].id}`} items={[...roBatch]} subcalls={subcalls} />);
+    roBatch.length = 0;
+  };
+  for (const it of displayItems) {
+    if (it.kind === "tool" && !it.parentId && it.name !== "todo_write" && it.name !== "exit_plan_mode" && it.status !== "running" && isReadOnlyTool(it.name)) {
+      roBatch.push(it as ToolItem);
+      continue;
+    }
+    flushRO();
+    switch (it.kind) {
+      case "tool":
+        if (it.parentId) break;
+        if (it.name === "todo_write") break;
+        if (it.name === "exit_plan_mode") break;
+        body.push(<ToolCard key={it.id} item={it as ToolItem} subcalls={subcalls.get(it.id)} />);
+        break;
+      case "phase": body.push(<PhaseCard key={it.id} text={it.text} />); break;
+      case "assistant": {
+        const displayItem = mode === "minimal" ? { ...it, reasoning: "" } : it;
+        body.push(<AssistantMessage key={it.id} item={displayItem as AssistantItem} />);
+        break;
+      }
+    }
+  }
+  flushRO();
+
+  return (
+    <div className={`turn-collapse${open ? " turn-collapse--open" : ""}`}>
+      <button
+        type="button"
+        className="reasoning__head"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <ChevronRight className={`reasoning__chevron${open ? " reasoning__chevron--open" : ""}`} size={12} />
+        <span className="turn-collapse__label">{label}</span>
+      </button>
+      {open && (
+        <div className="turn-collapse__body">{body}</div>
       )}
     </div>
   );

--- a/desktop/frontend/src/lib/displayMode.ts
+++ b/desktop/frontend/src/lib/displayMode.ts
@@ -4,10 +4,10 @@ const DISPLAY_MODE_KEY = "reasonix-display-mode";
 const DISPLAY_MODE_EVENT = "reasonix:display-mode";
 
 export function getDisplayMode(): DisplayMode {
-  if (typeof localStorage === "undefined") return "minimal";
+  if (typeof localStorage === "undefined") return "standard";
   const stored = localStorage.getItem(DISPLAY_MODE_KEY);
   if (stored === "standard" || stored === "compact" || stored === "minimal") return stored;
-  return "minimal";
+  return "standard";
 }
 
 export function setDisplayMode(mode: DisplayMode): void {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -152,10 +152,8 @@ export function shouldReconcileStaleTurn(
   return Math.max(0, now - lastTurnActivityAt) >= timeoutMs;
 }
 
-/** Known read-only tool names. Session restore hardcodes readOnly=false for all
- *  tools, so we derive it from the name to enable correct batching.
- *  Mirrors Go backend ReadOnly() + codegraph ReadOnlyToolNames(). */
-function isReadOnlyTool(name: string): boolean {
+/** Mirrors Go backend's ReadOnly() + codegraph ReadOnlyToolNames(). */
+export function isReadOnlyTool(name: string): boolean {
   switch (name) {
     case "read_file":
     case "ls":

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1230,6 +1230,8 @@ export const en = {
   "turnActions.rewind": "Rewind",
   "transcript.showEarlierHistory": "Show {n} earlier turns",
   "transcript.toolCount": "{n} tools",
+  "transcript.processed": "Processed",
+  "transcript.processedDuration": "Processed {s}s",
   "notice.info": "Notice",
   "notice.warning": "Warning",
   "questionNav.label": "Question navigation",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -743,6 +743,8 @@ export const zhTW: Record<DictKey, string> = {
   "turnActions.rewind": "回溯",
   "transcript.showEarlierHistory": "展開前 {n} 輪對話",
   "transcript.toolCount": "{n} 個工具",
+  "transcript.processed": "已處理",
+  "transcript.processedDuration": "已處理 {s}s",
   "notice.info": "提示",
   "notice.warning": "警告",
   "questionNav.label": "問題導航",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1232,6 +1232,8 @@ export const zh: Record<DictKey, string> = {
   "turnActions.rewind": "回溯",
   "transcript.showEarlierHistory": "展开前 {n} 轮对话",
   "transcript.toolCount": "{n} 个工具",
+  "transcript.processed": "已处理",
+  "transcript.processedDuration": "已处理 {s}s",
   "notice.info": "提示",
   "notice.warning": "警告",
   "questionNav.label": "问题导航",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2718,12 +2718,26 @@ a[href] {
 .readonly-batch {
   margin: 2px auto;
 }
-.readonly-batch__body {
-  display: flex;
-  flex-direction: column;
+.readonly-batch__body,
+.turn-collapse__body {
+  margin-top: 6px;
+  padding-left: 12px;
+  border-left: 2px solid var(--border);
 }
-.readonly-batch__body > .tool--quiet {
-  padding-left: 20px;
+.readonly-batch__body > *,
+.turn-collapse__body > * {
+  max-width: var(--maxw);
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 6px;
+}
+
+/* ── TurnCollapse: fold line for completed steps ──────────────────── */
+.turn-collapse {
+  margin: 4px auto;
+}
+.turn-collapse__label {
+  white-space: nowrap;
 }
 
 .transcript > .jump-bar {
@@ -3856,6 +3870,7 @@ a[href] {
   align-items: center;
   gap: 4px;
   max-width: 70%;
+  min-width: 0;
   overflow: hidden;
 }
 .tool--running {
@@ -3870,7 +3885,6 @@ a[href] {
   color: var(--fg-dim);
 }
 .tool--quiet .tool__name {
-  color: var(--fg-dim);
   font-weight: 500;
 }
 .tool--quiet .tool__icon {
@@ -3951,6 +3965,20 @@ a[href] {
   font-size: 11px;
   color: var(--accent);
   flex-shrink: 0;
+}
+.tool__status-icon {
+  font-size: 13px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.tool__status-icon--ok {
+  color: var(--ok);
+}
+.tool__status-icon--err {
+  color: var(--err);
+}
+.tool__status-icon--stopped {
+  color: var(--fg-faint);
 }
 .tool__meta {
   margin-left: auto;

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -332,7 +332,7 @@ func (a *App) Settings() SettingsView {
 			DesktopTheme:      "light",
 			DesktopThemeStyle: "graphite",
 			CloseBehavior:     "background",
-			DisplayMode:       "minimal",
+			DisplayMode:       "standard",
 			StatusBarStyle:    "text",
 			StatusBarItems:    config.DefaultDesktopStatusBarItems(),
 			CheckUpdates:      true,

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -95,11 +95,9 @@ func (a *Agent) maybeCompact(ctx context.Context, u *provider.Usage) {
 	}
 	if u.PromptTokens < high {
 		// A turn that sits under the trigger is the breathing room a healthy
-		// compaction buys; it clears the stuck latch, the run counter, and the
-		// one-shot soft notice.
+		// compaction buys; it clears the stuck latch and the run counter.
 		a.consecutiveCompacts = 0
 		a.compactStuck = false
-		a.softCompactNoticed = false
 		return
 	}
 	if a.compactStuck {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -195,7 +195,7 @@ func (c *Config) UICloseBehavior() string {
 }
 
 // DesktopDisplayMode normalizes the transcript display mode. Default is
-// "minimal" (collapsed model-generated intermediate items).
+// "standard" (flat rendering, no folding).
 func (c *Config) DesktopDisplayMode() string {
 	switch strings.ToLower(strings.TrimSpace(c.Desktop.DisplayMode)) {
 	case "standard":
@@ -205,7 +205,7 @@ func (c *Config) DesktopDisplayMode() string {
 	case "minimal":
 		return "minimal"
 	default:
-		return "minimal"
+		return "standard"
 	}
 }
 


### PR DESCRIPTION
## 摘要

恢复被上游删除的步骤折叠渲染和「已处理 Xs」折叠线（TurnCollapse），三种展示模式现在有可见的视觉差异。

## 改动

### 1. TurnCollapse 恢复
- 重新添加 `stepGroups` 记忆计算、`collapseBatch`/`flushCollapseBatch` 管线以及紧凑/极简模式下的步骤分组渲染
- 标准模式：扁平渲染（不变）
- 紧凑模式：中间步骤折叠成「已处理 Xs」，只读工具在折叠内归入 ReadOnlyBatch
- 极简模式：同紧凑模式，但折叠内不显示 reasoning 和 phase
- **现在默认为标准模式**

### 2. 子代理嵌套内的只读批处理
- `explore`/`research`/`task` 等子代理卡片内部的工具调用同样获得 ReadOnlyBatch 折叠，连续完成的只读工具自动归并

### 3. 状态图标
- 工具名左侧显示状态：绿色 ✓（成功）、红色 ✗（错误）、—（停止）
- 子代理调用计数 `⊞N` 移到工具名左侧

### 4. UI 优化
- Shimmer 动效覆盖整个工具头部（工具名 + command），不再只作用于 command
- 思考过程在流式结束后自动折叠（尊重用户手动打开操作）
- 默认展示模式从 `minimal` 改为 `standard`

### 5. 上下文压缩提示
- "context reached X%" 提示改为 agent 生命周期内仅显示一次（原因为 `softCompactNoticed` 在每次工具循环中被错误重置）

### 6. 代码质量
- `isReadOnlyTool()` 提取到共享模块 `useController.ts`，不再在 ToolCard.tsx 和 Transcript.tsx 中重复定义
- 修复重复 `useEffect` 导致用户手动打开思考后仍被自动关闭的 bug
- 删除冗余条件判断

## 涉及文件（11 个，+331/-91）

| File | Change |
|---|---|
| `ToolCard.tsx` | Status icons, ⊞ left, shimmer uniformity |
| `Transcript.tsx` | TurnCollapse + stepGroups + ReadOnlyBatch batching |
| `Message.tsx` | Reasoning auto-close (respects user toggle) |
| `styles.css` | turn-collapse body, status icons |
| `displayMode.ts` | Default: minimal → standard |
| `locales/en.ts`, `zh.ts` | transcript.processed keys |
| `config.go`, `settings_app.go` | Default: minimal → standard |
| `compact.go` | Remove softCompactNoticed reset |
| `useController.ts` | Export isReadOnlyTool()