### PR TITLE
feat(provider): send attached images to vision-capable models

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -54,6 +54,7 @@ type Asker interface {
 // callContextKey carries the executing tool call's identity into Execute.
 type callContextKey struct{}
 type parentSessionContextKey struct{}
+type userImagesContextKey struct{}
 
 // callContext is the per-call context a tool can read. parentID is the call being
 // executed and sink is the agent's event sink (the `task` tool uses both to nest
@@ -101,6 +102,19 @@ func WithParentSession(ctx context.Context, parentSession string) context.Contex
 func ParentSession(ctx context.Context) string {
 	parentSession, _ := ctx.Value(parentSessionContextKey{}).(string)
 	return strings.TrimSpace(parentSession)
+}
+
+// WithUserImages carries the data URLs of images the user attached to this turn,
+// resolved by the controller (which owns attachments) since the agent must not
+// depend on it. Run embeds them on the user message; the provider sends them only
+// when the model is vision-capable.
+func WithUserImages(ctx context.Context, images []string) context.Context {
+	return context.WithValue(ctx, userImagesContextKey{}, images)
+}
+
+func userImages(ctx context.Context) []string {
+	images, _ := ctx.Value(userImagesContextKey{}).([]string)
+	return images
 }
 
 // Gate decides, per tool call, whether it may run. The agent consults it at
@@ -528,7 +542,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	}
 	a.repeatSuccessCounts = nil
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
-	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
+	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx)})
 
 	finalReadinessBlocks := 0
 	emptyFinalBlocks := 0

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1192,6 +1192,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 			"effort":             config.EffectiveEffort(e),
 			"reasoning_protocol": config.ReasoningProtocolForEntry(e),
 			"proxy_spec":         proxy,
+			"vision":             e.Vision,
 		},
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -784,6 +784,11 @@ type ProviderEntry struct {
 	// Empty = provider default.
 	Thinking string `toml:"thinking"`
 	Effort   string `toml:"effort"`
+	// Vision marks the model as accepting image input. When set, images the user
+	// attaches are embedded in the request (image_url for openai-kind, base64
+	// blocks for anthropic). Off by default: text-only models 400 on image input,
+	// and embedding base64 would bloat the prompt and break prefix-cache stability.
+	Vision bool `toml:"vision"`
 	// ReasoningProtocol selects the request shape for OpenAI-compatible reasoning
 	// models. Empty/auto uses the model capability registry plus endpoint
 	// heuristics; none disables automatic reasoning controls for this provider.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -525,6 +525,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
 	ctx = agent.WithParentSession(ctx, c.parentSessionID())
+	ctx = agent.WithUserImages(ctx, c.inputImages(input))
 	input = c.Compose(input)
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
@@ -1058,6 +1059,7 @@ func (c *Controller) notice(text string) {
 func (c *Controller) Run(ctx context.Context, input string) error {
 	c.maybeSessionStart(ctx)
 	ctx = agent.WithParentSession(ctx, c.parentSessionID())
+	ctx = agent.WithUserImages(ctx, c.inputImages(input))
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
 	if c.hooks.Enabled() {

--- a/internal/control/inputimages_test.go
+++ b/internal/control/inputimages_test.go
@@ -1,0 +1,28 @@
+package control
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestControllerInputImagesResolvesAttachment(t *testing.T) {
+	t.Chdir(t.TempDir())
+	ref, err := SaveImageDataURL("data:image/png;base64," + tinyPNG)
+	if err != nil {
+		t.Fatalf("SaveImageDataURL: %v", err)
+	}
+	urls := New(Options{}).inputImages("look at @" + ref)
+	if len(urls) != 1 {
+		t.Fatalf("inputImages = %v, want one resolved data URL", urls)
+	}
+	if !strings.HasPrefix(urls[0], "data:image/png;base64,") {
+		t.Errorf("resolved url = %q, want a png data URL", urls[0])
+	}
+}
+
+func TestControllerInputImagesIgnoresNonAttachmentRefs(t *testing.T) {
+	t.Chdir(t.TempDir())
+	if urls := New(Options{}).inputImages("plain text with @missing.png"); len(urls) != 0 {
+		t.Errorf("inputImages = %v, want none for a non-existent / non-attachment ref", urls)
+	}
+}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -139,6 +139,22 @@ func (c *Controller) HasRefs(line string) bool {
 	return len(c.detectRefs(line)) > 0
 }
 
+// inputImages resolves image @-attachments in the turn input to data URLs so the
+// turn can carry them to a vision-capable model. Best-effort: an unreadable
+// attachment is skipped — the @image ref still lands as text via ResolveRefs.
+func (c *Controller) inputImages(line string) []string {
+	var urls []string
+	for _, r := range c.detectRefs(line) {
+		if r.kind != refImage {
+			continue
+		}
+		if url, err := ImageDataURL(r.path); err == nil {
+			urls = append(urls, url)
+		}
+	}
+	return urls
+}
+
 // resolveBareNames batch-resolves simple filenames (no path separator) that
 // don't exist in cwd. It walks the working tree once and matches every
 // unresolved name against the set, stopping when all are found. This runs in

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -72,6 +72,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
 	thinking, _ := cfg.Extra["thinking"].(string)
 	effort, _ := cfg.Extra["effort"].(string)
+	vision, _ := cfg.Extra["vision"].(bool)
 	httpClient, err := newHTTPClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("anthropic: network: %w", err)
@@ -99,6 +100,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		model:       cfg.Model,
 		thinking:    thinking,
 		effort:      effort,
+		vision:      vision,
 		http:        httpClient, // no overall timeout; lifecycle is ctx-driven
 		idleTimeout: defaultStreamIdleTimeout,
 	}, nil
@@ -117,6 +119,7 @@ type client struct {
 	model       string
 	thinking    string // "adaptive" enables extended thinking; "" = off (config-driven)
 	effort      string // output_config.effort: low|medium|high|xhigh|max; "" = provider default
+	vision      bool   // model accepts image input — embed attached images as base64 image blocks
 	http        *http.Client
 	idleTimeout time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
 	authed      atomic.Bool   // a request has succeeded — gate transient-401 retry
@@ -203,6 +206,13 @@ func (c *client) buildRequest(req provider.Request) anthRequest {
 		case provider.RoleUser:
 			if m.Content != "" {
 				appendBlocks("user", contentBlock{Type: "text", Text: m.Content})
+			}
+			if c.vision {
+				for _, url := range m.Images {
+					if mt, data, ok := provider.ParseImageDataURL(url); ok {
+						appendBlocks("user", contentBlock{Type: "image", Source: &imageSource{Type: "base64", MediaType: mt, Data: data}})
+					}
+				}
 			}
 		case provider.RoleTool:
 			content := m.Content
@@ -506,7 +516,14 @@ type contentBlock struct {
 	Input        json.RawMessage `json:"input,omitempty"`       // tool_use
 	ToolUseID    string          `json:"tool_use_id,omitempty"` // tool_result
 	Content      string          `json:"content,omitempty"`     // tool_result
+	Source       *imageSource    `json:"source,omitempty"`      // image
 	CacheControl *cacheControl   `json:"cache_control,omitempty"`
+}
+
+type imageSource struct {
+	Type      string `json:"type"` // "base64"
+	MediaType string `json:"media_type"`
+	Data      string `json:"data"`
 }
 
 type anthTool struct {

--- a/internal/provider/anthropic/image_test.go
+++ b/internal/provider/anthropic/image_test.go
@@ -1,0 +1,37 @@
+package anthropic
+
+import (
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestBuildRequestEmbedsImageBlockForVisionModel(t *testing.T) {
+	c := &client{model: "claude-opus-4-8", vision: true}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "describe", Images: []string{"data:image/jpeg;base64,ZZZZ"}},
+		},
+	})
+	blocks := req.Messages[0].Content
+	if len(blocks) != 2 || blocks[0].Type != "text" || blocks[1].Type != "image" {
+		t.Fatalf("blocks = %+v, want [text, image]", blocks)
+	}
+	src := blocks[1].Source
+	if src == nil || src.Type != "base64" || src.MediaType != "image/jpeg" || src.Data != "ZZZZ" {
+		t.Fatalf("image source = %+v, want base64 / image/jpeg / ZZZZ", src)
+	}
+}
+
+func TestBuildRequestSkipsImageBlockWithoutVision(t *testing.T) {
+	c := &client{model: "claude-opus-4-8"} // vision unset
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "describe", Images: []string{"data:image/jpeg;base64,ZZZZ"}},
+		},
+	})
+	blocks := req.Messages[0].Content
+	if len(blocks) != 1 || blocks[0].Type != "text" {
+		t.Fatalf("blocks = %+v, want [text] only when vision is off", blocks)
+	}
+}

--- a/internal/provider/image_test.go
+++ b/internal/provider/image_test.go
@@ -1,0 +1,21 @@
+package provider
+
+import "testing"
+
+func TestParseImageDataURL(t *testing.T) {
+	mt, data, ok := ParseImageDataURL("data:image/png;base64,AQIDBA==")
+	if !ok || mt != "image/png" || data != "AQIDBA==" {
+		t.Fatalf("got (%q, %q, %v), want (image/png, AQIDBA==, true)", mt, data, ok)
+	}
+	for _, bad := range []string{
+		"",
+		"data:image/png,AQID",      // not base64-encoded
+		"http://example.com/x.png", // not a data URL
+		"data:image/png;base64",    // no payload separator
+		"data:;base64,AAAA",        // empty media type
+	} {
+		if _, _, ok := ParseImageDataURL(bad); ok {
+			t.Errorf("ParseImageDataURL(%q) = ok, want not-ok", bad)
+		}
+	}
+}

--- a/internal/provider/openai/image_test.go
+++ b/internal/provider/openai/image_test.go
@@ -1,0 +1,44 @@
+package openai
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/provider"
+)
+
+func TestBuildRequestEmbedsImagesForVisionModel(t *testing.T) {
+	c := &client{model: "gpt-4o", vision: true}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "what is this", Images: []string{"data:image/png;base64,AAAA"}},
+		},
+	})
+	parts, ok := req.Messages[0].Content.([]chatContentPart)
+	if !ok {
+		t.Fatalf("vision user content = %T, want []chatContentPart", req.Messages[0].Content)
+	}
+	if len(parts) != 2 || parts[0].Type != "text" || parts[1].Type != "image_url" {
+		t.Fatalf("parts = %+v, want [text, image_url]", parts)
+	}
+	if parts[1].ImageURL == nil || parts[1].ImageURL.URL != "data:image/png;base64,AAAA" {
+		t.Fatalf("image_url = %+v, want the data URL", parts[1].ImageURL)
+	}
+	body, _ := json.Marshal(req.Messages[0])
+	if !strings.Contains(string(body), `"type":"image_url"`) {
+		t.Errorf("serialized content missing image_url part: %s", body)
+	}
+}
+
+func TestBuildRequestSkipsImagesWithoutVision(t *testing.T) {
+	c := &client{model: "deepseek-v4"} // vision unset
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "ignore the image", Images: []string{"data:image/png;base64,AAAA"}},
+		},
+	})
+	if s, ok := req.Messages[0].Content.(string); !ok || s != "ignore the image" {
+		t.Fatalf("non-vision content = %#v, want plain string", req.Messages[0].Content)
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -61,6 +61,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	}
 	protocol, _ := cfg.Extra["reasoning_protocol"].(string)
 	protocol = normalizeReasoningProtocol(protocol)
+	vision, _ := cfg.Extra["vision"].(bool)
 	deepseek := protocol == "deepseek" || (protocol == "" && IsDeepSeek(cfg.BaseURL))
 	minimax := protocol == "" && IsMiniMax(cfg.BaseURL)
 	switch {
@@ -111,6 +112,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		model:       cfg.Model,
 		deepseek:    deepseek,
 		minimax:     minimax,
+		vision:      vision,
 		effort:      effort,
 		http:        httpClient,
 		idleTimeout: defaultStreamIdleTimeout,
@@ -136,6 +138,7 @@ type client struct {
 	http        *http.Client
 	deepseek    bool
 	minimax     bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
+	vision      bool          // model accepts image input — embed attached images as image_url parts
 	effort      string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
 	idleTimeout time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
 	authed      atomic.Bool   // a request has succeeded — gate transient-401 retry
@@ -262,9 +265,11 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 			wire.Function.Arguments = tc.Arguments
 			cm.ToolCalls = append(cm.ToolCalls, wire)
 		}
-		if m.Role != provider.RoleAssistant || len(cm.ToolCalls) == 0 || m.Content != "" {
-			content := m.Content
-			cm.Content = &content
+		switch {
+		case c.vision && m.Role == provider.RoleUser && len(m.Images) > 0:
+			cm.Content = imageContentParts(m.Content, m.Images)
+		case m.Role != provider.RoleAssistant || len(cm.ToolCalls) == 0 || m.Content != "":
+			cm.Content = m.Content
 		}
 		msgs[i] = cm
 	}
@@ -531,14 +536,35 @@ type chatMessage struct {
 	Role string `json:"role"`
 	// content is always present (never omitted): DeepSeek's strict deserializer
 	// rejects a message missing the field. A pure tool_calls assistant turn
-	// serializes as null (OpenAI-spec, and what strict clones expect); every
-	// other role/message serializes as a string, empty included — null is
-	// rejected by some backends for a tool message.
-	Content          *string        `json:"content"`
+	// serializes as null (nil here); a string for every other text message
+	// (empty included — null is rejected by some backends for a tool message);
+	// and a []chatContentPart array for a vision user turn carrying images.
+	Content          any            `json:"content"`
 	ReasoningContent string         `json:"reasoning_content,omitempty"`
 	ToolCalls        []chatToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string         `json:"tool_call_id,omitempty"`
 	Name             string         `json:"name,omitempty"`
+}
+
+type chatContentPart struct {
+	Type     string        `json:"type"`
+	Text     string        `json:"text,omitempty"`
+	ImageURL *chatImageURL `json:"image_url,omitempty"`
+}
+
+type chatImageURL struct {
+	URL string `json:"url"`
+}
+
+func imageContentParts(text string, images []string) []chatContentPart {
+	parts := make([]chatContentPart, 0, len(images)+1)
+	if text != "" {
+		parts = append(parts, chatContentPart{Type: "text", Text: text})
+	}
+	for _, url := range images {
+		parts = append(parts, chatContentPart{Type: "image_url", ImageURL: &chatImageURL{URL: url}})
+	}
+	return parts
 }
 
 type chatTool struct {

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -530,8 +530,10 @@ func TestBuildRequestPreservesEmptyIDToolResults(t *testing.T) {
 	})
 	var toolContents []string
 	for _, m := range req.Messages {
-		if m.Role == string(provider.RoleTool) && m.Content != nil {
-			toolContents = append(toolContents, *m.Content)
+		if m.Role == string(provider.RoleTool) {
+			if s, ok := m.Content.(string); ok {
+				toolContents = append(toolContents, s)
+			}
 		}
 	}
 	if len(toolContents) != 2 {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -28,9 +28,10 @@ const (
 
 // Message is a single conversation message.
 type Message struct {
-	Role             Role   `json:"role"`
-	Content          string `json:"content,omitempty"`
-	ReasoningContent string `json:"reasoning_content,omitempty"` // assistant: thinking-mode chain-of-thought, round-tripped on multi-turn
+	Role             Role     `json:"role"`
+	Content          string   `json:"content,omitempty"`
+	Images           []string `json:"images,omitempty"`            // data URLs (data:<mime>;base64,…); embedded only for vision-capable models
+	ReasoningContent string   `json:"reasoning_content,omitempty"` // assistant: thinking-mode chain-of-thought, round-tripped on multi-turn
 	// ReasoningSignature is an opaque, provider-issued proof that ReasoningContent
 	// is genuine model output. Anthropic requires the signed thinking block be
 	// replayed on the next turn when a tool call followed thinking; providers
@@ -40,6 +41,25 @@ type Message struct {
 	ToolCalls          []ToolCall `json:"tool_calls,omitempty"`   // set by assistant
 	ToolCallID         string     `json:"tool_call_id,omitempty"` // links a tool result to its call
 	Name               string     `json:"name,omitempty"`         // tool message: tool name
+}
+
+// ParseImageDataURL splits a `data:<media-type>;base64,<payload>` URL into its
+// media type and base64 payload. ok is false for anything that isn't a base64
+// data URL — providers that need the split (Anthropic) skip those silently.
+func ParseImageDataURL(dataURL string) (mediaType, base64Data string, ok bool) {
+	rest, found := strings.CutPrefix(dataURL, "data:")
+	if !found {
+		return "", "", false
+	}
+	meta, payload, found := strings.Cut(rest, ",")
+	if !found {
+		return "", "", false
+	}
+	mt, found := strings.CutSuffix(meta, ";base64")
+	if !found || mt == "" {
+		return "", "", false
+	}
+	return mt, payload, true
 }
 
 // ToolCall is a tool invocation requested by the model. Arguments is raw JSON.


### PR DESCRIPTION
Refs #4158. First cut of multimodal: send **attached images** to vision-capable models. Video / keyframe decoding is intentionally out of scope.

## The gap

Images dragged/pasted into chat are saved to `.reasonix/attachments/` and referenced as `@…png`. Today the controller turns that into a text block — `[image attachment available… use a vision MCP tool]` — and `provider.Message.Content` is a plain string, so the model never receives image data. The issue's root-cause read (openai `chatMessage.Content` is `*string`) was correct.

## What changed

- **`provider.Message.Images []string`** (data URLs). Agent history *is* `[]provider.Message`, so one field carries images through history, session persistence, and both providers.
- **openai**: `chatMessage.Content` → `any`; a `[]chatContentPart` array (text + `image_url`) for a vision user turn, the same string/`null` shape as before otherwise.
- **anthropic**: a `{type:image, source:{type:base64,media_type,data}}` block beside the text block (parsed from the data URL via the shared `provider.ParseImageDataURL`).
- **Gating** — a per-model `vision` config flag (forwarded through `Config.Extra`). Only `vision` models get image parts; text-only models never receive them (they'd `400`) and their prompt-cache prefix is byte-for-byte unchanged. **Set `vision = true` on the DeepSeek model entry once its multimodal API lands.**
- **Threading** — the controller resolves image `@refs` to data URLs and passes them via `agent.WithUserImages(ctx, …)`, mirroring `WithParentSession`, so `agent` stays free of an `internal/control` import.

## Cache safety

Images live only in user turns; embedding one doesn't retroactively invalidate the prefix before it (append-only history). Text-only flows are untouched because of the `vision` gate.

## Tests

`provider` (ParseImageDataURL), `openai` / `anthropic` (image parts/blocks when vision, plain content when not), `control` (image `@ref` → data URL on the turn). `go vet` + the touched packages all green locally.

## Known tradeoffs / follow-ups

- Images store inline as data URLs in session history → `.jsonl` bloat. A path-and-resolve-at-send design would keep history compact (deferred).
- Video → keyframes (ffmpeg) is a separate, larger effort.
- Anthropic vision works today; DeepSeek's main models are text-only until their multimodal API ships, so the immediate beneficiaries are Claude and other OpenAI-compatible vision endpoints.
