### PR TITLE
fix(desktop): stop clipping the tool name in the card header

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3869,9 +3869,8 @@ a[href] {
   display: inline-flex;
   align-items: center;
   gap: 4px;
-  max-width: 70%;
   min-width: 0;
-  overflow: hidden;
+  flex: 0 1 auto;
 }
 .tool--running {
   border-color: var(--accent-soft);
@@ -3942,6 +3941,7 @@ a[href] {
   color: inherit;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+  flex-shrink: 0;
 }
 .tool__subject {
   flex: 1 1 auto;


### PR DESCRIPTION
Follow-up to #4206. After the status icon + `⊞`count moved into `tool__label-group` left of the name, that group's `max-width: 70%` + `overflow: hidden` hard-cut the (non-shrinking) tool name whenever icons + name reached the cap with no subject to absorb the overflow — a sub-agent `explore` card rendered as `explor`, `research` as `resea…`-with-no-ellipsis.

Fix: drop the fixed cap + hard clip on the group and let it shrink as a flex unit (`flex: 0 1 auto`). The subject keeps ellipsizing via its own rule, the name stays whole, and `tool__duration` is pinned (`flex-shrink: 0`) so a long subject can't squeeze it out. In an extreme-narrow card the chevron clips before the name now, which is the right priority.

Verified `pnpm --dir desktop/frontend check:css` green.
