### PR TITLE
feat(vision): downscale attached images before sending; add detail knob

### DIFF
--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/wailsapp/go-webview2 v1.0.23 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/image v0.42.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 )
 

--- a/desktop/go.sum
+++ b/desktop/go.sum
@@ -96,6 +96,8 @@ golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWP
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
 golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/image v0.42.0 h1:1gSs6ehNWXLbkHBIPcWztk3D/6aIA/8hauiAYtlodVY=
+golang.org/x/image v0.42.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/yuin/goldmark v1.8.2
 	go.uber.org/goleak v1.3.0
+	golang.org/x/image v0.42.0
 	golang.org/x/mod v0.37.0
 	golang.org/x/net v0.55.0
 	golang.org/x/sys v0.46.0

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/image v0.42.0 h1:1gSs6ehNWXLbkHBIPcWztk3D/6aIA/8hauiAYtlodVY=
+golang.org/x/image v0.42.0/go.mod h1:rrpelvGFt+kLPAjPM4HeWPgrl0FtafueU//e5N0qk/Q=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1193,6 +1193,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 			"reasoning_protocol": config.ReasoningProtocolForEntry(e),
 			"proxy_spec":         proxy,
 			"vision":             e.Vision,
+			"vision_detail":      e.VisionDetail,
 		},
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -787,8 +787,13 @@ type ProviderEntry struct {
 	// Vision marks the model as accepting image input. When set, images the user
 	// attaches are embedded in the request (image_url for openai-kind, base64
 	// blocks for anthropic). Off by default: text-only models 400 on image input,
-	// and embedding base64 would bloat the prompt and break prefix-cache stability.
+	// and image tokens are heavy — gating keeps text-only flows cheap (the prompt
+	// prefix is byte-identical with no image, so the cache is unaffected either way).
 	Vision bool `toml:"vision"`
+	// VisionDetail sets the openai image_url detail hint (low|high); empty = auto
+	// (the field is omitted). "low" caps an image to a fixed ~85 tokens for cheap
+	// coarse reads; ignored by providers without the knob (e.g. anthropic).
+	VisionDetail string `toml:"vision_detail"`
 	// ReasoningProtocol selects the request shape for OpenAI-compatible reasoning
 	// models. Empty/auto uses the model capability registry plus endpoint
 	// heuristics; none disables automatic reasoning controls for this provider.

--- a/internal/control/attachments.go
+++ b/internal/control/attachments.go
@@ -267,49 +267,70 @@ func saveLinuxClipboardImage() (string, error) {
 }
 
 func ImageDataURL(path string) (string, error) {
-	clean, err := cleanAttachmentPath(path)
+	raw, mime, err := readAttachmentImage(path)
 	if err != nil {
 		return "", err
+	}
+	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(raw), nil
+}
+
+// visionImageDataURL reads an attachment and, unlike ImageDataURL (which feeds
+// the desktop preview at full resolution), downscales/recompresses it before
+// base64 so an oversized photo doesn't balloon the request bytes and image
+// tokens. Best-effort: an undecodable format passes through at original size.
+func visionImageDataURL(path string) (string, error) {
+	raw, mime, err := readAttachmentImage(path)
+	if err != nil {
+		return "", err
+	}
+	raw, mime = compressForVision(raw, mime)
+	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(raw), nil
+}
+
+func readAttachmentImage(path string) (raw []byte, mime string, err error) {
+	clean, err := cleanAttachmentPath(path)
+	if err != nil {
+		return nil, "", err
 	}
 	info, err := os.Lstat(clean)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	if info.Mode()&os.ModeSymlink != 0 {
-		return "", fmt.Errorf("attachment path must not be a symlink")
+		return nil, "", fmt.Errorf("attachment path must not be a symlink")
 	}
 	if info.IsDir() || info.Size() <= 0 || info.Size() > maxImageAttachmentBytes {
-		return "", fmt.Errorf("attachment image must be between 1 byte and 10 MB")
+		return nil, "", fmt.Errorf("attachment image must be between 1 byte and 10 MB")
 	}
 	f, err := os.Open(clean)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	defer f.Close()
 	opened, err := f.Stat()
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	if !os.SameFile(info, opened) {
-		return "", fmt.Errorf("attachment changed while opening")
+		return nil, "", fmt.Errorf("attachment changed while opening")
 	}
-	raw, err := io.ReadAll(io.LimitReader(f, maxImageAttachmentBytes+1))
+	raw, err = io.ReadAll(io.LimitReader(f, maxImageAttachmentBytes+1))
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	if len(raw) == 0 || len(raw) > maxImageAttachmentBytes {
-		return "", fmt.Errorf("attachment image must be between 1 byte and 10 MB")
+		return nil, "", fmt.Errorf("attachment image must be between 1 byte and 10 MB")
 	}
 	if after, err := f.Stat(); err != nil {
-		return "", err
+		return nil, "", err
 	} else if !os.SameFile(opened, after) || after.Size() != opened.Size() {
-		return "", fmt.Errorf("attachment changed while reading")
+		return nil, "", fmt.Errorf("attachment changed while reading")
 	}
-	mime := detectedImageMime(raw)
+	mime = detectedImageMime(raw)
 	if mime == "" {
-		return "", fmt.Errorf("attachment is not an image")
+		return nil, "", fmt.Errorf("attachment is not an image")
 	}
-	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(raw), nil
+	return raw, mime, nil
 }
 
 func cleanAttachmentPath(path string) (string, error) {

--- a/internal/control/imagecompress.go
+++ b/internal/control/imagecompress.go
@@ -1,0 +1,77 @@
+package control
+
+import (
+	"bytes"
+	"image"
+	_ "image/gif" // register gif decoder
+	"image/jpeg"
+	"image/png"
+
+	xdraw "golang.org/x/image/draw"
+	_ "golang.org/x/image/webp" // register webp decoder
+)
+
+// maxVisionDim caps the longest image side sent to a model. OpenAI and Anthropic
+// downscale to roughly this server-side anyway, so a larger upload only wastes
+// request bytes and image tokens without adding fidelity.
+const maxVisionDim = 1568
+
+// maxDecodePixels guards against decompression-bomb attachments: a tiny file can
+// declare enormous dimensions. Beyond this we skip decoding and send as-is (still
+// bounded by the 10 MB file cap).
+const maxDecodePixels = 50_000_000
+
+// compressForVision downscales an oversized image to maxVisionDim and re-encodes
+// it — PNG/GIF stay lossless (screenshots, text, transparency), JPEG/WebP go to
+// JPEG. Best-effort: an undecodable format, a decode/encode failure, or an image
+// already within budget returns the original bytes and mime unchanged.
+func compressForVision(raw []byte, mime string) ([]byte, string) {
+	switch mime {
+	case "image/png", "image/jpeg", "image/gif", "image/webp":
+	default:
+		return raw, mime // bmp/tiff/svg: no decoder wired, send original
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(raw))
+	if err != nil || cfg.Width*cfg.Height > maxDecodePixels {
+		return raw, mime
+	}
+	if cfg.Width <= maxVisionDim && cfg.Height <= maxVisionDim {
+		return raw, mime // within budget — no point re-encoding
+	}
+	src, _, err := image.Decode(bytes.NewReader(raw))
+	if err != nil {
+		return raw, mime
+	}
+	w, h := scaledDims(cfg.Width, cfg.Height, maxVisionDim)
+	dst := image.NewRGBA(image.Rect(0, 0, w, h))
+	xdraw.CatmullRom.Scale(dst, dst.Bounds(), src, src.Bounds(), xdraw.Over, nil)
+
+	var buf bytes.Buffer
+	if mime == "image/png" || mime == "image/gif" {
+		if err := png.Encode(&buf, dst); err != nil {
+			return raw, mime
+		}
+		return buf.Bytes(), "image/png"
+	}
+	if err := jpeg.Encode(&buf, dst, &jpeg.Options{Quality: 85}); err != nil {
+		return raw, mime
+	}
+	return buf.Bytes(), "image/jpeg"
+}
+
+// scaledDims returns dimensions with the longest side clamped to m, preserving
+// aspect ratio (each side at least 1px).
+func scaledDims(w, h, m int) (int, int) {
+	if w >= h {
+		nh := h * m / w
+		if nh < 1 {
+			nh = 1
+		}
+		return m, nh
+	}
+	nw := w * m / h
+	if nw < 1 {
+		nw = 1
+	}
+	return nw, m
+}

--- a/internal/control/imagecompress_test.go
+++ b/internal/control/imagecompress_test.go
@@ -1,0 +1,75 @@
+package control
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/jpeg"
+	"image/png"
+	"testing"
+)
+
+func makeTestPNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: uint8(x ^ y), A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestCompressForVisionDownscalesOversizedPNG(t *testing.T) {
+	raw := makeTestPNG(t, 3000, 1500)
+	out, mime := compressForVision(raw, "image/png")
+	if mime != "image/png" {
+		t.Errorf("mime = %q, want image/png", mime)
+	}
+	cfg, _, err := image.DecodeConfig(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("decode out: %v", err)
+	}
+	// Pixel count is what governs vision token cost; assert the reduction there
+	// (byte size isn't a robust invariant for synthetic, highly-compressible input).
+	if cfg.Width != maxVisionDim || cfg.Height != 1500*maxVisionDim/3000 {
+		t.Errorf("dims = %dx%d, want %dx%d", cfg.Width, cfg.Height, maxVisionDim, 1500*maxVisionDim/3000)
+	}
+	if cfg.Width*cfg.Height >= 3000*1500 {
+		t.Errorf("pixel count %d not reduced from %d", cfg.Width*cfg.Height, 3000*1500)
+	}
+}
+
+func TestCompressForVisionKeepsSmallImageVerbatim(t *testing.T) {
+	raw := makeTestPNG(t, 100, 80)
+	out, mime := compressForVision(raw, "image/png")
+	if mime != "image/png" || !bytes.Equal(out, raw) {
+		t.Errorf("an in-budget image must pass through unchanged (got %d bytes, mime %q)", len(out), mime)
+	}
+}
+
+func TestCompressForVisionJPEGStaysJPEG(t *testing.T) {
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, image.NewRGBA(image.Rect(0, 0, 2400, 1200)), nil); err != nil {
+		t.Fatal(err)
+	}
+	out, mime := compressForVision(buf.Bytes(), "image/jpeg")
+	if mime != "image/jpeg" {
+		t.Fatalf("mime = %q, want image/jpeg", mime)
+	}
+	if cfg, _, _ := image.DecodeConfig(bytes.NewReader(out)); cfg.Width != maxVisionDim {
+		t.Errorf("width = %d, want %d", cfg.Width, maxVisionDim)
+	}
+}
+
+func TestCompressForVisionPassesThroughUndecodable(t *testing.T) {
+	raw := []byte("<svg xmlns='...'></svg>")
+	out, mime := compressForVision(raw, "image/svg+xml")
+	if mime != "image/svg+xml" || !bytes.Equal(out, raw) {
+		t.Error("an undecodable mime must pass through unchanged")
+	}
+}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -148,7 +148,7 @@ func (c *Controller) inputImages(line string) []string {
 		if r.kind != refImage {
 			continue
 		}
-		if url, err := ImageDataURL(r.path); err == nil {
+		if url, err := visionImageDataURL(r.path); err == nil {
 			urls = append(urls, url)
 		}
 	}

--- a/internal/provider/openai/image_test.go
+++ b/internal/provider/openai/image_test.go
@@ -42,3 +42,29 @@ func TestBuildRequestSkipsImagesWithoutVision(t *testing.T) {
 		t.Fatalf("non-vision content = %#v, want plain string", req.Messages[0].Content)
 	}
 }
+
+func TestImageURLDetailFromConfig(t *testing.T) {
+	c := &client{model: "gpt-4o", vision: true, visionDetail: "low"}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "x", Images: []string{"data:image/png;base64,AAAA"}},
+		},
+	})
+	parts := req.Messages[0].Content.([]chatContentPart)
+	if parts[1].ImageURL.Detail != "low" {
+		t.Fatalf("detail = %q, want low", parts[1].ImageURL.Detail)
+	}
+}
+
+func TestImageURLDetailOmittedByDefault(t *testing.T) {
+	c := &client{model: "gpt-4o", vision: true}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "x", Images: []string{"data:image/png;base64,AAAA"}},
+		},
+	})
+	body, _ := json.Marshal(req.Messages[0].Content.([]chatContentPart)[1])
+	if strings.Contains(string(body), "detail") {
+		t.Errorf("detail must be omitted when unset: %s", body)
+	}
+}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -62,6 +62,11 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	protocol, _ := cfg.Extra["reasoning_protocol"].(string)
 	protocol = normalizeReasoningProtocol(protocol)
 	vision, _ := cfg.Extra["vision"].(bool)
+	visionDetail, _ := cfg.Extra["vision_detail"].(string)
+	visionDetail = strings.ToLower(strings.TrimSpace(visionDetail))
+	if visionDetail != "low" && visionDetail != "high" {
+		visionDetail = "" // auto — omit the field
+	}
 	deepseek := protocol == "deepseek" || (protocol == "" && IsDeepSeek(cfg.BaseURL))
 	minimax := protocol == "" && IsMiniMax(cfg.BaseURL)
 	switch {
@@ -105,17 +110,18 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		return nil, fmt.Errorf("openai: network: %w", err)
 	}
 	return &client{
-		name:        name,
-		apiKey:      cfg.APIKey,
-		keyEnv:      keyEnv,
-		baseURL:     strings.TrimRight(cfg.BaseURL, "/"),
-		model:       cfg.Model,
-		deepseek:    deepseek,
-		minimax:     minimax,
-		vision:      vision,
-		effort:      effort,
-		http:        httpClient,
-		idleTimeout: defaultStreamIdleTimeout,
+		name:         name,
+		apiKey:       cfg.APIKey,
+		keyEnv:       keyEnv,
+		baseURL:      strings.TrimRight(cfg.BaseURL, "/"),
+		model:        cfg.Model,
+		deepseek:     deepseek,
+		minimax:      minimax,
+		vision:       vision,
+		visionDetail: visionDetail,
+		effort:       effort,
+		http:         httpClient,
+		idleTimeout:  defaultStreamIdleTimeout,
 	}, nil
 }
 
@@ -130,18 +136,19 @@ func newHTTPClient(cfg provider.Config) (*http.Client, error) {
 }
 
 type client struct {
-	name        string
-	apiKey      string
-	keyEnv      string // api_key_env name, surfaced in auth errors
-	baseURL     string
-	model       string
-	http        *http.Client
-	deepseek    bool
-	minimax     bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
-	vision      bool          // model accepts image input — embed attached images as image_url parts
-	effort      string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
-	idleTimeout time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
-	authed      atomic.Bool   // a request has succeeded — gate transient-401 retry
+	name         string
+	apiKey       string
+	keyEnv       string // api_key_env name, surfaced in auth errors
+	baseURL      string
+	model        string
+	http         *http.Client
+	deepseek     bool
+	minimax      bool          // true for api.minimaxi.com — emits MiniMax-M3's thinking knob instead of reasoning_effort
+	vision       bool          // model accepts image input — embed attached images as image_url parts
+	visionDetail string        // image_url detail hint (low|high); "" = auto/omit
+	effort       string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
+	idleTimeout  time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
+	authed       atomic.Bool   // a request has succeeded — gate transient-401 retry
 }
 
 func (c *client) Name() string { return c.name }
@@ -267,7 +274,7 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		}
 		switch {
 		case c.vision && m.Role == provider.RoleUser && len(m.Images) > 0:
-			cm.Content = imageContentParts(m.Content, m.Images)
+			cm.Content = imageContentParts(m.Content, m.Images, c.visionDetail)
 		case m.Role != provider.RoleAssistant || len(cm.ToolCalls) == 0 || m.Content != "":
 			cm.Content = m.Content
 		}
@@ -553,16 +560,17 @@ type chatContentPart struct {
 }
 
 type chatImageURL struct {
-	URL string `json:"url"`
+	URL    string `json:"url"`
+	Detail string `json:"detail,omitempty"`
 }
 
-func imageContentParts(text string, images []string) []chatContentPart {
+func imageContentParts(text string, images []string, detail string) []chatContentPart {
 	parts := make([]chatContentPart, 0, len(images)+1)
 	if text != "" {
 		parts = append(parts, chatContentPart{Type: "text", Text: text})
 	}
 	for _, url := range images {
-		parts = append(parts, chatContentPart{Type: "image_url", ImageURL: &chatImageURL{URL: url}})
+		parts = append(parts, chatContentPart{Type: "image_url", ImageURL: &chatImageURL{URL: url, Detail: detail}})
 	}
 	return parts
 }


### PR DESCRIPTION
Follow-up to #4204. That PR could *send* images but did nothing about size — an attached photo went out at full resolution (up to the 10 MB cap), wasting both request bytes and image tokens, since vision models downscale server-side anyway.

## What changed

- **Downscale before send** (`internal/control`). A vision-only path, `visionImageDataURL`, downscales an oversized image to **1568px** on its longest side (where OpenAI/Anthropic cap server-side) and re-encodes it: **PNG/GIF stay lossless** (screenshots, text, transparency), **JPEG/WebP → JPEG q85**. Guarded against decompression bombs (`DecodeConfig` dimension check before decode). Best-effort — an undecodable format (bmp/tiff/svg) passes through untouched. The **desktop preview** path (`ImageDataURL`) is left at full resolution; only the model-send path shrinks.
- **`vision_detail` knob** — a per-model `low|high` config flag sets the openai `image_url.detail` hint (empty = `auto`, field omitted). `low` pins an image to a fixed ~85 tokens for cheap coarse reads; anthropic has no such knob and ignores it.

## On compression headers (the original ask)

Request-body gzip was considered and **deliberately skipped**: it only shrinks the wire (~25%, undoing the base64 inflation) and is provider-support-dependent (OpenAI doesn't guarantee gzipped request bodies — sending one risks a 400), and it does **nothing for tokens or context**. Downscaling cuts both bytes *and* tokens, so it's the right lever.

## Also

Corrects the comment introduced in #4204 that said embedding images "breaks prefix-cache stability." They don't — images are vision-gated, append-only, and byte-stable across turns, so the prefix cache is unaffected; the real concern was always token cost.

## Tests

`internal/control`: oversized PNG → 1568px (pixel count reduced), in-budget image passes through verbatim, JPEG stays JPEG, undecodable mime passes through. `openai`: `detail` emitted from config, omitted by default. `go vet` + touched packages green locally; both go.mod/go.sum (main + desktop module) tidied for `golang.org/x/image`.
