### PR TITLE
修复 subagent 会话归属与后台任务隔离

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1285,14 +1285,32 @@ func (a *App) RestoreSession(path string) error {
 	if err != nil {
 		return err
 	}
+	target := filepath.Join(dir, key)
+	if a.sessionDestroying(dir, target) {
+		return fmt.Errorf("session cleanup is still in progress: %s", key)
+	}
 	if err := restoreTrashedSessionFile(dir, path); err != nil {
 		return err
 	}
-	if err := restoreSessionTopicIndex(dir, filepath.Join(dir, key)); err != nil {
+	if err := restoreSessionTopicIndex(dir, target); err != nil {
 		return err
 	}
 	a.emitProjectTreeChanged()
 	return nil
+}
+
+func (a *App) sessionDestroying(dir, sessionPath string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, tab := range a.tabs {
+		if tab == nil || tab.Ctrl == nil || tabSessionDir(tab) != dir {
+			continue
+		}
+		if tab.Ctrl.IsDestroyingSession(sessionPath) {
+			return true
+		}
+	}
+	return false
 }
 
 // PurgeTrashedSession permanently removes a trashed session and its title/display

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1200,11 +1200,45 @@ func (a *App) DeleteSession(path string) error {
 	if _, ok := a.openSessionPaths(dir)[sessionPath]; ok {
 		return errActiveSession
 	}
-	if err := trashSessionArtifacts(dir, sessionPath, key); err != nil {
+	var destroys []control.SessionDestroyHandle
+	err = trashSessionArtifactsBeforeMove(dir, sessionPath, key, func() {
+		destroys = a.beginDestroySessionJobs(dir, sessionPath)
+	})
+	if err != nil {
+		if len(destroys) > 0 {
+			go runDestroyHandles(destroys)
+		}
 		return err
+	}
+	if len(destroys) > 0 {
+		go runDestroyHandles(destroys)
 	}
 	a.emitProjectTreeChanged()
 	return nil
+}
+
+func (a *App) beginDestroySessionJobs(dir, sessionPath string) []control.SessionDestroyHandle {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var destroys []control.SessionDestroyHandle
+	for _, tab := range a.tabs {
+		if tab == nil || tab.Ctrl == nil || tabSessionDir(tab) != dir {
+			continue
+		}
+		destroys = append(destroys, tab.Ctrl.BeginDestroySession(sessionPath))
+	}
+	return destroys
+}
+
+func runDestroyHandles(destroys []control.SessionDestroyHandle) {
+	for _, destroy := range destroys {
+		if destroy.Wait != nil {
+			destroy.Wait()
+		}
+		if destroy.Finish != nil {
+			destroy.Finish()
+		}
+	}
 }
 
 func (a *App) openSessionPaths(dir string) map[string]struct{} {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -17,6 +17,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -1335,6 +1336,47 @@ func TestDeleteSessionRejectsInactiveOpenTab(t *testing.T) {
 	}
 	if open[filepath.Base(otherPath)] {
 		t.Fatalf("ListSessions marked unopened session open, got %#v", open)
+	}
+}
+
+func TestRestoreSessionRejectsDestroyingSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "trash-me.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("deleteSessionFile: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, filepath.Base(sessionPath), filepath.Base(sessionPath))
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: filepath.Join(dir, "active.jsonl"), Label: "active", Jobs: jm})
+	defer ctrl.Close()
+	destroy := ctrl.BeginDestroySession(sessionPath)
+	defer destroy.Finish()
+
+	app := NewApp()
+	app.setTestCtrl(ctrl, "")
+	if err := app.RestoreSession(trashPath); err == nil || !strings.Contains(err.Error(), "cleanup is still in progress") {
+		t.Fatalf("RestoreSession while destroying error = %v, want cleanup-in-progress", err)
+	}
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("trashed session should remain after rejected restore: %v", err)
+	}
+
+	destroy.Finish()
+	if err := app.RestoreSession(trashPath); err != nil {
+		t.Fatalf("RestoreSession after finish: %v", err)
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("session should be restored: %v", err)
 	}
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -120,6 +120,10 @@ type trashedSessionMeta struct {
 }
 
 func trashSessionArtifacts(dir, sessionPath, key string) error {
+	return trashSessionArtifactsBeforeMove(dir, sessionPath, key, nil)
+}
+
+func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove func()) error {
 	if _, err := os.Stat(sessionPath); os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
@@ -133,6 +137,9 @@ func trashSessionArtifacts(dir, sessionPath, key string) error {
 	}
 	if err := os.MkdirAll(itemDir, 0o755); err != nil {
 		return err
+	}
+	if beforeMove != nil {
+		beforeMove()
 	}
 	if err := movePathIfExists(sessionPath, filepath.Join(itemDir, key)); err != nil {
 		return err

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -98,7 +98,7 @@ func EphemeralSubagentRun(systemPrompt string) *SubagentRun {
 // SubagentStore persists sub-agent transcripts under config.SessionDir()/subagents.
 // Its locks are process-local; cross-process mutation is intentionally out of v1.
 type SubagentStore struct {
-	dir string
+	dir       string
 	destroyed func(parentSession string) bool
 
 	mu     sync.Mutex

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -99,6 +99,7 @@ func EphemeralSubagentRun(systemPrompt string) *SubagentRun {
 // Its locks are process-local; cross-process mutation is intentionally out of v1.
 type SubagentStore struct {
 	dir string
+	destroyed func(parentSession string) bool
 
 	mu     sync.Mutex
 	locked map[string]bool
@@ -109,6 +110,16 @@ func NewSubagentStore(dir string) *SubagentStore {
 		return nil
 	}
 	return &SubagentStore{dir: dir, locked: map[string]bool{}}
+}
+
+// WithDestroyedChecker makes saves for destroyed parent sessions no-op. This is
+// used when a background sub-agent is cancelled because its parent session was
+// cleared or moved out of active history.
+func (s *SubagentStore) WithDestroyedChecker(fn func(parentSession string) bool) *SubagentStore {
+	if s != nil {
+		s.destroyed = fn
+	}
+	return s
 }
 
 // ListSubagentsByParent returns persisted sub-agent artifacts whose metadata
@@ -287,6 +298,9 @@ func (s *SubagentStore) MarkRunning(run *SubagentRun) error {
 	if s == nil || run == nil || run.Ref == "" {
 		return nil
 	}
+	if s.parentDestroyed(run) {
+		return nil
+	}
 	meta := run.Meta
 	meta.Status = SubagentRunning
 	meta.UpdatedAt = time.Now().UTC()
@@ -295,6 +309,9 @@ func (s *SubagentStore) MarkRunning(run *SubagentRun) error {
 
 func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
 	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	if s.parentDestroyed(run) {
 		return nil
 	}
 	if err := run.Session.Save(s.sessionPath(run.Ref)); err != nil {
@@ -309,6 +326,9 @@ func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
 
 func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	if s.parentDestroyed(run) {
 		return nil
 	}
 	var sessionErr error
@@ -506,6 +526,13 @@ func (s *SubagentStore) saveMeta(meta SubagentMeta) error {
 		return err
 	}
 	return fileutil.ReplaceFile(tmpPath, s.metaPath(meta.Ref))
+}
+
+func (s *SubagentStore) parentDestroyed(run *SubagentRun) bool {
+	if s == nil || s.destroyed == nil || run == nil {
+		return false
+	}
+	return s.destroyed(run.Meta.ParentSession)
 }
 
 func validSubagentRef(ref string) bool {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -332,6 +332,34 @@ func TestSubagentStoreSaveFailedPersistsTranscriptAndRejectsReuse(t *testing.T) 
 	}
 }
 
+func TestSubagentStoreSkipsSaveForDestroyedParent(t *testing.T) {
+	store := NewSubagentStore(t.TempDir()).WithDestroyedChecker(func(parentSession string) bool {
+		return parentSession == "parent-session"
+	})
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "answer after destroy"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	if _, err := os.Stat(store.sessionPath(run.Ref)); !os.IsNotExist(err) {
+		t.Fatalf("destroyed parent should not save session, stat err = %v", err)
+	}
+	if _, err := os.Stat(store.metaPath(run.Ref)); !os.IsNotExist(err) {
+		t.Fatalf("destroyed parent should not save meta, stat err = %v", err)
+	}
+	if err := store.SaveFailed(run); err != nil {
+		t.Fatalf("SaveFailed: %v", err)
+	}
+	if _, err := os.Stat(store.sessionPath(run.Ref)); !os.IsNotExist(err) {
+		t.Fatalf("destroyed parent should still not save session, stat err = %v", err)
+	}
+	run.Release()
+}
+
 func testSubagentSpec(t *testing.T, name string) SubagentSpec {
 	t.Helper()
 	reg := tool.NewRegistry()

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -248,7 +248,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 				return "", err
 			}
 		}
-		job := jm.Start("task", label, func(jobCtx context.Context, _ io.Writer) (string, error) {
+		job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (string, error) {
 			defer run.Release()
 			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, prov, pricing, ctxWin, run.Session)
 			if err != nil {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -148,6 +148,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
 	}
 	jm := jobs.NewManager(sink)
+	sessionDir := opts.SessionDir
+	if sessionDir == "" {
+		sessionDir = config.SessionDir()
+	}
 
 	proxySpec := cfg.NetworkProxySpec()
 	if err := netclient.Validate(proxySpec); err != nil {
@@ -440,7 +444,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if opts.MaxSteps > 0 {
 		maxSteps = opts.MaxSteps
 	}
-	subagentStore := newSubagentStore(config.SessionDir())
+	subagentStore := newSubagentStore(sessionDir)
 
 	// Permission policy gates every tool call. The headless gate (no Approver)
 	// resolves "ask" to allow — preserving `reasonix run` autonomy — while deny

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -210,11 +210,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		sysPrompt = skill.ApplyIndex(sysPrompt, skills)
 	}
 
-	sessionDir := opts.SessionDir
-	if sessionDir == "" {
-		sessionDir = config.SessionDir()
-	}
-
 	reg := tool.NewRegistry()
 	bashSpec := sandbox.Spec{Mode: cfg.BashMode(), WriteRoots: cfg.WriteRootsForRoot(root), Network: cfg.Sandbox.Network}
 	shell := sandbox.ResolveShell(cfg.Tools.Shell.Prefer, cfg.Tools.Shell.Path, stderr)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -445,6 +445,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		maxSteps = opts.MaxSteps
 	}
 	subagentStore := newSubagentStore(sessionDir)
+	if subagentStore != nil {
+		subagentStore.WithDestroyedChecker(jm.IsDestroying)
+	}
 
 	// Permission policy gates every tool call. The headless gate (no Approver)
 	// resolves "ask" to allow — preserving `reasonix run` autonomy — while deny

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -380,6 +380,56 @@ model = "x"
 	}
 }
 
+func TestBuildSubagentStoreHonorsSessionDirOverride(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerBootSubagentTestProvider()
+	prov := &bootSubagentTestProvider{}
+	setBootSubagentTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-subagent-test"
+model = "x"
+`)
+
+	sessionDir := filepath.Join(t.TempDir(), "desktop-workspace-sessions")
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard, SessionDir: sessionDir})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	sessionPath := agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label())
+	ctrl.SetSessionPath(sessionPath)
+
+	if err := ctrl.Run(context.Background(), "first review"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	ref := subagentRefFromHistory(t, ctrl.History())
+
+	overrideStore := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	meta, err := overrideStore.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta from override dir: %v", err)
+	}
+	if meta.ParentSession != agent.BranchID(sessionPath) {
+		t.Fatalf("parent session = %q, want %q", meta.ParentSession, agent.BranchID(sessionPath))
+	}
+	if _, err := os.Stat(filepath.Join(config.SessionDir(), "subagents", ref+".meta.json")); !os.IsNotExist(err) {
+		t.Fatalf("subagent metadata should not be written to global session dir, stat err = %v", err)
+	}
+}
+
 const bootSubagentTestProviderKind = "boot-subagent-test"
 
 var (

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1403,6 +1403,13 @@ func (c *Controller) ClearSession() error {
 		return fmt.Errorf("cannot clear while a turn is running")
 	}
 	destroy := c.BeginDestroySession(oldPath)
+	if !destroy.Async {
+		if err := removeSessionArtifacts(oldPath); err != nil {
+			destroy.Finish()
+			return err
+		}
+		destroy.Finish()
+	}
 	c.hooks.SessionEnd(context.Background())
 	if c.sessionDir != "" {
 		c.mu.Lock()
@@ -1416,17 +1423,14 @@ func (c *Controller) ClearSession() error {
 	c.startedOnce = true
 	c.mu.Unlock()
 	c.hooks.SessionStart(context.Background())
-	cleanup := func() {
-		destroy.Wait()
-		if err := removeSessionArtifacts(oldPath); err != nil {
-			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "clear session cleanup failed: " + err.Error()})
-		}
-		destroy.Finish()
-	}
 	if destroy.Async {
-		go cleanup()
-	} else {
-		cleanup()
+		go func() {
+			destroy.Wait()
+			if err := removeSessionArtifacts(oldPath); err != nil {
+				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "clear session cleanup failed: " + err.Error()})
+			}
+			destroy.Finish()
+		}()
 	}
 	return nil
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -312,6 +312,7 @@ func New(opts Options) *Controller {
 	}
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
 	c.rebindCheckpoints(opts.SessionPath)
+	c.setActiveJobSession(opts.SessionPath)
 	if c.executor != nil {
 		c.executor.SetPreEditHook(func(ch diff.Change) {
 			if c.cp != nil {
@@ -524,7 +525,9 @@ func (c *Controller) runGoalLoopWithRawDisplay(ctx context.Context, input, raw, 
 func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
-	ctx = agent.WithParentSession(ctx, c.parentSessionID())
+	parentSession := c.parentSessionID()
+	ctx = agent.WithParentSession(ctx, parentSession)
+	ctx = jobs.WithSession(ctx, parentSession)
 	ctx = agent.WithUserImages(ctx, c.inputImages(input))
 	input = c.Compose(input)
 	startMessages := c.messageCount()
@@ -1373,6 +1376,7 @@ func (c *Controller) NewSession() error {
 		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
 		c.mu.Unlock()
 	}
+	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
@@ -1404,6 +1408,7 @@ func (c *Controller) ClearSession() error {
 		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
 		c.mu.Unlock()
 	}
+	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
@@ -1583,6 +1588,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		c.mu.Lock()
 		c.sessionPath = newPath
 		c.mu.Unlock()
+		c.setActiveJobSession(newPath)
 		c.rebindCheckpoints(newPath)
 	}
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
@@ -1641,6 +1647,7 @@ func (c *Controller) Branch(name string) (string, error) {
 	c.mu.Lock()
 	c.sessionPath = newPath
 	c.mu.Unlock()
+	c.setActiveJobSession(newPath)
 	c.rebindCheckpoints(newPath)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("created branch %s", agent.BranchID(newPath))})
@@ -1687,6 +1694,7 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	c.mu.Lock()
 	c.sessionPath = match.Path
 	c.mu.Unlock()
+	c.setActiveJobSession(match.Path)
 	c.rebindCheckpoints(match.Path)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("switched to branch %s", branchDisplayName(match))})
@@ -1785,6 +1793,7 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.mu.Lock()
 	c.sessionPath = path
 	c.mu.Unlock()
+	c.setActiveJobSession(path)
 	c.rebindCheckpoints(path)
 	c.maybeColdResumePrune(path)
 }
@@ -1915,7 +1924,14 @@ func (c *Controller) SetSessionPath(p string) {
 	c.mu.Lock()
 	c.sessionPath = p
 	c.mu.Unlock()
+	c.setActiveJobSession(p)
 	c.rebindCheckpoints(p)
+}
+
+func (c *Controller) setActiveJobSession(sessionPath string) {
+	if c.jobs != nil {
+		c.jobs.SetActiveSession(agent.BranchID(sessionPath))
+	}
 }
 
 // SessionDir reports the directory new session files land in ("" disables
@@ -2354,7 +2370,7 @@ func (c *Controller) Jobs() []jobs.View {
 	if c.jobs == nil {
 		return nil
 	}
-	return c.jobs.Running()
+	return c.jobs.RunningForSession(c.parentSessionID())
 }
 
 // SetToolApprovalMode changes the runtime approval posture for permission-gated

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1973,6 +1973,15 @@ func (c *Controller) BeginDestroySession(sessionPath string) SessionDestroyHandl
 	}
 }
 
+// IsDestroyingSession reports whether sessionPath is currently in the destroy
+// window for this controller's job manager.
+func (c *Controller) IsDestroyingSession(sessionPath string) bool {
+	if c.jobs == nil {
+		return false
+	}
+	return c.jobs.IsDestroying(agent.BranchID(sessionPath))
+}
+
 func (c *Controller) setActiveJobSession(sessionPath string) {
 	if c.jobs != nil {
 		c.jobs.SetActiveSession(agent.BranchID(sessionPath))

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -1399,9 +1400,7 @@ func (c *Controller) ClearSession() error {
 	if running {
 		return fmt.Errorf("cannot clear while a turn is running")
 	}
-	if err := removeSessionArtifacts(oldPath); err != nil {
-		return err
-	}
+	destroy := c.BeginDestroySession(oldPath)
 	c.hooks.SessionEnd(context.Background())
 	if c.sessionDir != "" {
 		c.mu.Lock()
@@ -1415,6 +1414,13 @@ func (c *Controller) ClearSession() error {
 	c.startedOnce = true
 	c.mu.Unlock()
 	c.hooks.SessionStart(context.Background())
+	go func() {
+		destroy.Wait()
+		if err := removeSessionArtifacts(oldPath); err != nil {
+			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "clear session cleanup failed: " + err.Error()})
+		}
+		destroy.Finish()
+	}()
 	return nil
 }
 
@@ -1434,6 +1440,9 @@ func removeSessionArtifacts(path string) error {
 		if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
 			return err
 		}
+	}
+	if err := agent.DeleteSubagentsByParent(filepath.Dir(path), agent.BranchID(path)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1926,6 +1935,35 @@ func (c *Controller) SetSessionPath(p string) {
 	c.mu.Unlock()
 	c.setActiveJobSession(p)
 	c.rebindCheckpoints(p)
+}
+
+// SessionDestroyHandle separates waiting for cancelled jobs from ending the
+// destroy window, so callers can move/delete persistent artifacts in between.
+type SessionDestroyHandle struct {
+	Wait   func()
+	Finish func()
+}
+
+// BeginDestroySession marks a session as leaving active use and cancels its
+// background jobs. Call Wait before moving/deleting artifacts, then Finish after
+// persistent cleanup/move work is complete.
+func (c *Controller) BeginDestroySession(sessionPath string) SessionDestroyHandle {
+	parentSession := agent.BranchID(sessionPath)
+	if c.jobs == nil || parentSession == "" {
+		noop := func() {}
+		return SessionDestroyHandle{Wait: noop, Finish: noop}
+	}
+	done := c.jobs.DestroySession(parentSession)
+	return SessionDestroyHandle{
+		Wait: func() {
+			for _, ch := range done {
+				<-ch
+			}
+		},
+		Finish: func() {
+			c.jobs.FinishDestroySession(parentSession)
+		},
+	}
 }
 
 func (c *Controller) setActiveJobSession(sessionPath string) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1414,13 +1414,18 @@ func (c *Controller) ClearSession() error {
 	c.startedOnce = true
 	c.mu.Unlock()
 	c.hooks.SessionStart(context.Background())
-	go func() {
+	cleanup := func() {
 		destroy.Wait()
 		if err := removeSessionArtifacts(oldPath); err != nil {
 			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "clear session cleanup failed: " + err.Error()})
 		}
 		destroy.Finish()
-	}()
+	}
+	if destroy.Async {
+		go cleanup()
+	} else {
+		cleanup()
+	}
 	return nil
 }
 
@@ -1942,6 +1947,7 @@ func (c *Controller) SetSessionPath(p string) {
 type SessionDestroyHandle struct {
 	Wait   func()
 	Finish func()
+	Async  bool
 }
 
 // BeginDestroySession marks a session as leaving active use and cancels its
@@ -1963,6 +1969,7 @@ func (c *Controller) BeginDestroySession(sessionPath string) SessionDestroyHandl
 		Finish: func() {
 			c.jobs.FinishDestroySession(parentSession)
 		},
+		Async: len(done) > 0,
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1062,7 +1062,9 @@ func (c *Controller) notice(text string) {
 // just needs the exit status — no TurnDone event, no cancel bookkeeping.
 func (c *Controller) Run(ctx context.Context, input string) error {
 	c.maybeSessionStart(ctx)
-	ctx = agent.WithParentSession(ctx, c.parentSessionID())
+	parentSession := c.parentSessionID()
+	ctx = agent.WithParentSession(ctx, parentSession)
+	ctx = jobs.WithSession(ctx, parentSession)
 	ctx = agent.WithUserImages(ctx, c.inputImages(input))
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -38,6 +39,17 @@ type handoffRunner struct {
 
 func (r handoffRunner) Run(_ context.Context, input string) error {
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: "handoff: " + input})
+	return nil
+}
+
+type sessionContextRunner struct {
+	parentSession string
+	jobSession    string
+}
+
+func (r *sessionContextRunner) Run(ctx context.Context, input string) error {
+	r.parentSession = agent.ParentSession(ctx)
+	r.jobSession = jobs.SessionFromContext(ctx)
 	return nil
 }
 
@@ -86,6 +98,26 @@ func TestRunTurnSnapshotsActivityWhenTranscriptChanges(t *testing.T) {
 	}
 	if meta.UpdatedAt.IsZero() {
 		t.Fatal("activity meta should be marked")
+	}
+}
+
+func TestRunInjectsParentSessionForJobs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	runner := &sessionContextRunner{}
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Runner: runner, Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	if err := c.Run(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	want := agent.BranchID(path)
+	if runner.parentSession != want {
+		t.Fatalf("ParentSession = %q, want %q", runner.parentSession, want)
+	}
+	if runner.jobSession != want {
+		t.Fatalf("jobs session = %q, want %q", runner.jobSession, want)
 	}
 }
 

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -124,7 +124,7 @@ func (c *Controller) Compose(text string) string {
 	// model learns of completions even though the user-facing notices don't reach
 	// its context. Like memory, this never touches the cache-stable prefix.
 	if c.jobs != nil {
-		if note := c.jobs.DrainCompletedNote(); note != "" {
+		if note := c.jobs.DrainCompletedNoteForSession(c.parentSessionID()); note != "" {
 			text = "<background-jobs>\n" + note + "\n</background-jobs>\n\n" + text
 		}
 	}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -56,9 +56,10 @@ type Result struct {
 // terminal fields; the run goroutine writes them, readers (Output/Wait/snapshots)
 // take the same lock.
 type Job struct {
-	ID    string
-	Kind  string // "bash" | "task"
-	Label string
+	ID        string
+	Kind      string // "bash" | "task"
+	Label     string
+	SessionID string
 
 	mu         sync.Mutex
 	buf        bytes.Buffer
@@ -82,7 +83,13 @@ type Manager struct {
 	seq       int
 	jobs      map[string]*Job
 	order     []string
-	completed []string // finished-job summaries awaiting drain into the next turn
+	completed []completion // finished-job summaries awaiting drain into the next turn
+	active    string
+}
+
+type completion struct {
+	sessionID string
+	text      string
 }
 
 // NewManager returns a Manager whose jobs run under a fresh session-scoped
@@ -112,16 +119,23 @@ func (w jobWriter) Write(p []byte) (int, error) {
 // the buffer and returns ""). The job is marked killed when its context was
 // cancelled, failed on any other error, else done.
 func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io.Writer) (string, error)) *Job {
+	return m.StartForSession("", kind, label, run)
+}
+
+// StartForSession launches a job owned by parentSession. Session-scoped readers
+// only see jobs whose owner matches the active session.
+func (m *Manager) StartForSession(parentSession, kind, label string, run func(ctx context.Context, out io.Writer) (string, error)) *Job {
+	parentSession = strings.TrimSpace(parentSession)
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("%s-%d", kind, m.seq)
 	ctx, cancel := context.WithCancel(m.root)
-	j := &Job{ID: id, Kind: kind, Label: label, status: Running, startedAt: nowMs(), cancel: cancel, done: make(chan struct{})}
+	j := &Job{ID: id, Kind: kind, Label: label, SessionID: parentSession, status: Running, startedAt: nowMs(), cancel: cancel, done: make(chan struct{})}
 	m.jobs[id] = j
 	m.order = append(m.order, id)
 	m.mu.Unlock()
 
-	m.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: startedText(kind, id, label)})
+	m.emitIfActive(parentSession, event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: startedText(kind, id, label)})
 
 	m.wg.Add(1)
 	go func() {
@@ -146,7 +160,7 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 		// completion, skip j.done, and DrainCompletedNote would race ahead of the
 		// bookkeeping (the TestDrainMultiple -race flake). Recording first makes an
 		// observed terminal status imply the note is already queued.
-		m.recordCompletion(id, kind, label, st, err)
+		m.recordCompletion(parentSession, id, kind, label, st, err)
 
 		j.mu.Lock()
 		j.result = result
@@ -161,13 +175,16 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 
 // recordCompletion queues the finished-job summary for DrainCompletedNote and
 // emits a closing Notice (warn for a failure, info otherwise).
-func (m *Manager) recordCompletion(id, kind, label string, st Status, err error) {
+func (m *Manager) recordCompletion(parentSession, id, kind, label string, st Status, err error) {
 	tag := id
 	if label != "" {
 		tag = fmt.Sprintf("%s (%s)", id, label)
 	}
 	m.mu.Lock()
-	m.completed = append(m.completed, fmt.Sprintf("%s — %s", tag, st))
+	m.completed = append(m.completed, completion{
+		sessionID: parentSession,
+		text:      fmt.Sprintf("%s — %s", tag, st),
+	})
 	m.mu.Unlock()
 
 	level, text := event.LevelInfo, fmt.Sprintf("background %s finished: %s", kind, id)
@@ -177,7 +194,7 @@ func (m *Manager) recordCompletion(id, kind, label string, st Status, err error)
 	case Killed:
 		text = fmt.Sprintf("background %s killed: %s", kind, id)
 	}
-	m.sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text})
+	m.emitIfActive(parentSession, event.Event{Kind: event.Notice, Level: level, Text: text})
 }
 
 func (m *Manager) get(id string) *Job {
@@ -189,8 +206,14 @@ func (m *Manager) get(id string) *Job {
 // Output returns the job's output produced since the last Output call plus its
 // current status. ok is false when the id is unknown.
 func (m *Manager) Output(id string) (text string, status Status, ok bool) {
+	return m.OutputForSession("", id)
+}
+
+// OutputForSession returns output only when id belongs to parentSession. Empty
+// parentSession preserves the legacy unscoped behavior.
+func (m *Manager) OutputForSession(parentSession, id string) (text string, status Status, ok bool) {
 	j := m.get(id)
-	if j == nil {
+	if j == nil || !sessionMatches(parentSession, j.SessionID) {
 		return "", "", false
 	}
 	j.mu.Lock()
@@ -211,8 +234,14 @@ func (m *Manager) Output(id string) (text string, status Status, ok bool) {
 // Kill cancels a running job. Returns false when the id is unknown or the job has
 // already finished.
 func (m *Manager) Kill(id string) bool {
+	return m.KillForSession("", id)
+}
+
+// KillForSession cancels a running job only when it belongs to parentSession.
+// Empty parentSession preserves the legacy unscoped behavior.
+func (m *Manager) KillForSession(parentSession, id string) bool {
 	j := m.get(id)
-	if j == nil {
+	if j == nil || !sessionMatches(parentSession, j.SessionID) {
 		return false
 	}
 	j.mu.Lock()
@@ -239,7 +268,13 @@ func (m *Manager) Kill(id string) bool {
 // (0 = no timeout). It returns each target's snapshot regardless of why it
 // returned, so a timeout still reports partial progress.
 func (m *Manager) Wait(ctx context.Context, ids []string, timeoutSec int) []Result {
-	targets := m.resolve(ids)
+	return m.WaitForSession(ctx, "", ids, timeoutSec)
+}
+
+// WaitForSession waits only on jobs owned by parentSession. Empty parentSession
+// preserves the legacy unscoped behavior.
+func (m *Manager) WaitForSession(ctx context.Context, parentSession string, ids []string, timeoutSec int) []Result {
+	targets := m.resolve(parentSession, ids)
 	if len(targets) == 0 {
 		return nil
 	}
@@ -262,13 +297,16 @@ func (m *Manager) Wait(ctx context.Context, ids []string, timeoutSec int) []Resu
 }
 
 // resolve maps requested ids to jobs; an empty list selects all running jobs.
-func (m *Manager) resolve(ids []string) []*Job {
+func (m *Manager) resolve(parentSession string, ids []string) []*Job {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var out []*Job
 	if len(ids) == 0 {
 		for _, id := range m.order {
 			j := m.jobs[id]
+			if !sessionMatches(parentSession, j.SessionID) {
+				continue
+			}
 			j.mu.Lock()
 			running := j.status == Running
 			j.mu.Unlock()
@@ -279,7 +317,7 @@ func (m *Manager) resolve(ids []string) []*Job {
 		return out
 	}
 	for _, id := range ids {
-		if j := m.jobs[id]; j != nil {
+		if j := m.jobs[id]; j != nil && sessionMatches(parentSession, j.SessionID) {
 			out = append(out, j)
 		}
 	}
@@ -302,11 +340,20 @@ func (m *Manager) results(targets []*Job) []Result {
 
 // Running returns a snapshot of the still-running jobs (for the status bar).
 func (m *Manager) Running() []View {
+	return m.RunningForSession("")
+}
+
+// RunningForSession returns still-running jobs owned by parentSession. Empty
+// parentSession preserves the legacy unscoped behavior.
+func (m *Manager) RunningForSession(parentSession string) []View {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var out []View
 	for _, id := range m.order {
 		j := m.jobs[id]
+		if !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
 		j.mu.Lock()
 		if j.status == Running {
 			out = append(out, View{ID: j.ID, Kind: j.Kind, Label: j.Label, Status: string(j.status), StartedAt: j.startedAt})
@@ -320,15 +367,45 @@ func (m *Manager) Running() []View {
 // finished since the last drain, for the controller to fold into the next turn
 // so the model learns of completions. "" when nothing finished.
 func (m *Manager) DrainCompletedNote() string {
+	return m.DrainCompletedNoteForSession("")
+}
+
+// DrainCompletedNoteForSession drains completion notes for parentSession only.
+// Notes for other sessions stay queued until that session becomes active again.
+// Empty parentSession preserves the legacy unscoped behavior.
+func (m *Manager) DrainCompletedNoteForSession(parentSession string) string {
 	m.mu.Lock()
-	c := m.completed
-	m.completed = nil
+	var c []string
+	if strings.TrimSpace(parentSession) == "" {
+		for _, item := range m.completed {
+			c = append(c, item.text)
+		}
+		m.completed = nil
+	} else {
+		remaining := m.completed[:0]
+		for _, item := range m.completed {
+			if item.sessionID == parentSession {
+				c = append(c, item.text)
+			} else {
+				remaining = append(remaining, item)
+			}
+		}
+		m.completed = remaining
+	}
 	m.mu.Unlock()
 	if len(c) == 0 {
 		return ""
 	}
 	return "Background jobs finished since your last message: " + strings.Join(c, "; ") +
 		". Read their output with bash_output or wait if you still need it."
+}
+
+// SetActiveSession controls which session receives lifecycle notices for jobs
+// that finish asynchronously. Empty active session preserves legacy behavior.
+func (m *Manager) SetActiveSession(parentSession string) {
+	m.mu.Lock()
+	m.active = strings.TrimSpace(parentSession)
+	m.mu.Unlock()
 }
 
 // Close cancels the session context and waits for every background job goroutine
@@ -350,9 +427,24 @@ func startedText(kind, id, label string) string {
 	return fmt.Sprintf("background %s started: %s", kind, id)
 }
 
+func (m *Manager) emitIfActive(parentSession string, ev event.Event) {
+	m.mu.Lock()
+	active := m.active
+	m.mu.Unlock()
+	if active == "" || strings.TrimSpace(parentSession) == "" || active == strings.TrimSpace(parentSession) {
+		m.sink.Emit(ev)
+	}
+}
+
+func sessionMatches(filter, jobSession string) bool {
+	filter = strings.TrimSpace(filter)
+	return filter == "" || strings.TrimSpace(jobSession) == filter
+}
+
 // --- call-context injection (mirrors agent.CallContext) ---
 
 type ctxKey struct{}
+type sessionCtxKey struct{}
 
 // WithManager stamps ctx with the job manager so tools can reach it via
 // FromContext. The agent sets this on every tool call's context.
@@ -365,4 +457,17 @@ func WithManager(ctx context.Context, m *Manager) context.Context {
 func FromContext(ctx context.Context) (*Manager, bool) {
 	m, ok := ctx.Value(ctxKey{}).(*Manager)
 	return m, ok && m != nil
+}
+
+// WithSession stamps ctx with the active parent session ID for session-scoped job
+// operations.
+func WithSession(ctx context.Context, parentSession string) context.Context {
+	return context.WithValue(ctx, sessionCtxKey{}, strings.TrimSpace(parentSession))
+}
+
+// SessionFromContext returns the active parent session ID for job ownership and
+// filtering. Empty means no session scope is available.
+func SessionFromContext(ctx context.Context) string {
+	session, _ := ctx.Value(sessionCtxKey{}).(string)
+	return strings.TrimSpace(session)
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -177,18 +177,23 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 // recordCompletion queues the finished-job summary for DrainCompletedNote and
 // emits a closing Notice (warn for a failure, info otherwise).
 func (m *Manager) recordCompletion(parentSession, id, kind, label string, st Status, err error) {
-	if m.IsDestroying(parentSession) {
-		return
-	}
 	tag := id
 	if label != "" {
 		tag = fmt.Sprintf("%s (%s)", id, label)
 	}
+	parentSession = strings.TrimSpace(parentSession)
+	shouldEmit := false
 	m.mu.Lock()
+	if parentSession != "" && m.destroying[parentSession] {
+		m.mu.Unlock()
+		return
+	}
 	m.completed = append(m.completed, completion{
 		sessionID: parentSession,
 		text:      fmt.Sprintf("%s — %s", tag, st),
 	})
+	active := m.active
+	shouldEmit = active == "" || parentSession == "" || active == parentSession
 	m.mu.Unlock()
 
 	level, text := event.LevelInfo, fmt.Sprintf("background %s finished: %s", kind, id)
@@ -198,7 +203,9 @@ func (m *Manager) recordCompletion(parentSession, id, kind, label string, st Sta
 	case Killed:
 		text = fmt.Sprintf("background %s killed: %s", kind, id)
 	}
-	m.emitIfActive(parentSession, event.Event{Kind: event.Notice, Level: level, Text: text})
+	if shouldEmit {
+		m.sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text})
+	}
 }
 
 func (m *Manager) get(id string) *Job {

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -85,6 +85,7 @@ type Manager struct {
 	order     []string
 	completed []completion // finished-job summaries awaiting drain into the next turn
 	active    string
+	destroying map[string]bool
 }
 
 type completion struct {
@@ -100,7 +101,7 @@ func NewManager(sink event.Sink) *Manager {
 		sink = event.Discard
 	}
 	root, cancel := context.WithCancel(context.Background())
-	return &Manager{sink: sink, root: root, cancel: cancel, jobs: map[string]*Job{}}
+	return &Manager{sink: sink, root: root, cancel: cancel, jobs: map[string]*Job{}, destroying: map[string]bool{}}
 }
 
 // jobWriter appends a job's streamed output under its lock so a concurrent
@@ -176,6 +177,9 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 // recordCompletion queues the finished-job summary for DrainCompletedNote and
 // emits a closing Notice (warn for a failure, info otherwise).
 func (m *Manager) recordCompletion(parentSession, id, kind, label string, st Status, err error) {
+	if m.IsDestroying(parentSession) {
+		return
+	}
 	tag := id
 	if label != "" {
 		tag = fmt.Sprintf("%s (%s)", id, label)
@@ -405,6 +409,69 @@ func (m *Manager) DrainCompletedNoteForSession(parentSession string) string {
 func (m *Manager) SetActiveSession(parentSession string) {
 	m.mu.Lock()
 	m.active = strings.TrimSpace(parentSession)
+	m.mu.Unlock()
+}
+
+// DestroySession marks a parent session as being removed from active use and
+// cancels its running jobs. The returned channels close when each cancelled job
+// has fully unwound.
+func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession == "" {
+		return nil
+	}
+	var cancels []context.CancelFunc
+	var done []<-chan struct{}
+	m.mu.Lock()
+	m.destroying[parentSession] = true
+	remaining := m.completed[:0]
+	for _, item := range m.completed {
+		if item.sessionID != parentSession {
+			remaining = append(remaining, item)
+		}
+	}
+	m.completed = remaining
+	for _, id := range m.order {
+		j := m.jobs[id]
+		if !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
+		j.mu.Lock()
+		if j.status == Running {
+			j.status = Killed
+			cancels = append(cancels, j.cancel)
+			done = append(done, j.done)
+		}
+		j.mu.Unlock()
+	}
+	m.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	return done
+}
+
+// IsDestroying reports whether parentSession is in the destroy window. Empty
+// parent sessions are never considered destroyed.
+func (m *Manager) IsDestroying(parentSession string) bool {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession == "" {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.destroying[parentSession]
+}
+
+// FinishDestroySession ends the destroy window after all owned jobs have unwound
+// and persistent cleanup/move work has completed.
+func (m *Manager) FinishDestroySession(parentSession string) {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.destroying, parentSession)
 	m.mu.Unlock()
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -79,12 +79,12 @@ type Manager struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	mu        sync.Mutex
-	seq       int
-	jobs      map[string]*Job
-	order     []string
-	completed []completion // finished-job summaries awaiting drain into the next turn
-	active    string
+	mu         sync.Mutex
+	seq        int
+	jobs       map[string]*Job
+	order      []string
+	completed  []completion // finished-job summaries awaiting drain into the next turn
+	active     string
 	destroying map[string]bool
 }
 

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -4,11 +4,33 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"reasonix/internal/event"
 )
+
+type recordingSink struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (s *recordingSink) Emit(ev event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, ev)
+}
+
+func (s *recordingSink) texts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.events))
+	for _, ev := range s.events {
+		out = append(out, ev.Text)
+	}
+	return out
+}
 
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
@@ -166,4 +188,93 @@ func TestRunning(t *testing.T) {
 	close(release)
 	m.Wait(context.Background(), []string{j.ID}, 5)
 	waitFor(t, func() bool { return len(m.Running()) == 0 })
+}
+
+func TestSessionScopedOperations(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	a := m.StartForSession("session-a", "bash", "a", func(_ context.Context, out io.Writer) (string, error) {
+		io.WriteString(out, "from-a\n")
+		<-releaseA
+		return "", nil
+	})
+	b := m.StartForSession("session-b", "bash", "b", func(_ context.Context, out io.Writer) (string, error) {
+		io.WriteString(out, "from-b\n")
+		<-releaseB
+		return "", nil
+	})
+
+	waitFor(t, func() bool {
+		txt, _, ok := m.OutputForSession("session-a", a.ID)
+		return ok && strings.Contains(txt, "from-a")
+	})
+	if _, _, ok := m.OutputForSession("session-a", b.ID); ok {
+		t.Fatal("session-a should not read session-b output")
+	}
+	if got := m.RunningForSession("session-a"); len(got) != 1 || got[0].ID != a.ID {
+		t.Fatalf("session-a running = %+v, want only %s", got, a.ID)
+	}
+	if got := m.WaitForSession(context.Background(), "session-a", []string{b.ID}, 1); len(got) != 0 {
+		t.Fatalf("session-a wait on session-b job = %+v, want none", got)
+	}
+	if m.KillForSession("session-a", b.ID) {
+		t.Fatal("session-a should not kill session-b job")
+	}
+
+	close(releaseA)
+	res := m.WaitForSession(context.Background(), "session-a", []string{a.ID}, 5)
+	if len(res) != 1 || res[0].ID != a.ID || res[0].Status != Done {
+		t.Fatalf("session-a wait all = %+v, want only done %s", res, a.ID)
+	}
+	if note := m.DrainCompletedNoteForSession("session-b"); note != "" {
+		t.Fatalf("session-b drain before completion = %q, want empty", note)
+	}
+	if note := m.DrainCompletedNoteForSession("session-a"); !strings.Contains(note, a.ID) {
+		t.Fatalf("session-a drain = %q, want %s", note, a.ID)
+	}
+
+	close(releaseB)
+	m.WaitForSession(context.Background(), "session-b", []string{b.ID}, 5)
+	if note := m.DrainCompletedNoteForSession("session-b"); !strings.Contains(note, b.ID) {
+		t.Fatalf("session-b drain = %q, want %s", note, b.ID)
+	}
+}
+
+func TestSessionScopedNoticesUseActiveSession(t *testing.T) {
+	sink := &recordingSink{}
+	m := NewManager(sink)
+	defer m.Close()
+	m.SetActiveSession("session-a")
+
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	a := m.StartForSession("session-a", "bash", "a", func(_ context.Context, _ io.Writer) (string, error) {
+		<-releaseA
+		return "", nil
+	})
+	b := m.StartForSession("session-b", "bash", "b", func(_ context.Context, _ io.Writer) (string, error) {
+		<-releaseB
+		return "", nil
+	})
+	close(releaseB)
+	m.Wait(context.Background(), []string{b.ID}, 5)
+	for _, text := range sink.texts() {
+		if strings.Contains(text, b.ID) {
+			t.Fatalf("inactive session job notice leaked: %q", text)
+		}
+	}
+
+	close(releaseA)
+	m.Wait(context.Background(), []string{a.ID}, 5)
+	waitFor(t, func() bool {
+		for _, text := range sink.texts() {
+			if strings.Contains(text, a.ID) {
+				return true
+			}
+		}
+		return false
+	})
 }

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -278,3 +278,36 @@ func TestSessionScopedNoticesUseActiveSession(t *testing.T) {
 		return false
 	})
 }
+
+func TestDestroySessionCancelsOwnedJobsAndSuppressesCompletion(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	started := make(chan struct{})
+	j := m.StartForSession("session-a", "task", "cleanup", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	<-started
+
+	done := m.DestroySession("session-a")
+	if len(done) != 1 {
+		t.Fatalf("DestroySession returned %d done channels, want 1", len(done))
+	}
+	if !m.IsDestroying("session-a") {
+		t.Fatal("session-a should be marked destroying")
+	}
+	<-done[0]
+	res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5)
+	if len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("destroyed job result = %+v, want killed", res)
+	}
+	if note := m.DrainCompletedNoteForSession("session-a"); note != "" {
+		t.Fatalf("destroyed session should not queue completion note, got %q", note)
+	}
+	m.FinishDestroySession("session-a")
+	if m.IsDestroying("session-a") {
+		t.Fatal("session-a should no longer be marked destroying")
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -921,15 +921,28 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "cannot delete active session", http.StatusConflict)
 		return
 	}
+	destroy := s.ctl().BeginDestroySession(abs)
 	if err := os.Remove(abs); err != nil {
+		go finishSessionDestroy(destroy)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if err := agent.DeleteSubagentsByParent(dir, agent.BranchID(abs)); err != nil {
+		go finishSessionDestroy(destroy)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	go finishSessionDestroy(destroy)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func finishSessionDestroy(destroy control.SessionDestroyHandle) {
+	if destroy.Wait != nil {
+		destroy.Wait()
+	}
+	if destroy.Finish != nil {
+		destroy.Finish()
+	}
 }
 
 // sessionTitle returns a title for a session: the cached flash-generated title

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -145,7 +145,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		workDir := b.workDir
 		// The job runs under the manager's session context (no foreground timeout), so it
 		// survives this turn; its combined output streams to the job buffer.
-		job := jm.Start("bash", commandPreview(p.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
+		job := jm.StartForSession(jobs.SessionFromContext(ctx), "bash", commandPreview(p.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
 			cmd := exec.CommandContext(jobCtx, argv[0], argv[1:]...)
 			cmd.Dir = workDir
 			cmd.Env = cmdEnv

--- a/internal/tool/builtin/bgjobs.go
+++ b/internal/tool/builtin/bgjobs.go
@@ -55,7 +55,7 @@ func (bashOutput) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
 	}
-	text, status, found := jm.Output(p.JobID)
+	text, status, found := jm.OutputForSession(jobs.SessionFromContext(ctx), p.JobID)
 	if !found {
 		return "", fmt.Errorf("no background job %q", p.JobID)
 	}
@@ -118,7 +118,7 @@ func (killShell) Execute(ctx context.Context, args json.RawMessage) (string, err
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
 	}
-	if jm.Kill(p.JobID) {
+	if jm.KillForSession(jobs.SessionFromContext(ctx), p.JobID) {
 		return fmt.Sprintf("Killed background job %q.", p.JobID), nil
 	}
 	return fmt.Sprintf("Background job %q was not running (already finished or unknown).", p.JobID), nil
@@ -154,7 +154,7 @@ func (waitJob) Execute(ctx context.Context, args json.RawMessage) (string, error
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
 	}
-	results := jm.Wait(ctx, p.JobIDs, p.TimeoutSeconds)
+	results := jm.WaitForSession(ctx, jobs.SessionFromContext(ctx), p.JobIDs, p.TimeoutSeconds)
 	if len(results) == 0 {
 		return "No background jobs to wait for.", nil
 	}


### PR DESCRIPTION
## 背景

本 PR 修复 subagent transcript 与后台 jobs 的 session ownership 问题：Desktop 下 subagent 可能写到全局 session 目录，后台 job 也没有严格按 parent session 隔离，导致新建/删除/恢复会话时存在输出泄漏或 late writeback 风险。

## 变更内容

- 统一主 session 与 `SubagentStore` 的 effective `SessionDir`，Desktop 下 subagent transcript 跟随 workspace session 目录；CLI 默认行为不变。
- 为后台 jobs 增加 parent session 归属，并按当前 session 过滤 `wait`、`bash_output`、`kill_shell`、status bar、完成摘要和 lifecycle notice。
- clear / delete / trash session 时取消该 session 的后台 jobs，并防止后台 subagent 在取消后重新写回 active `subagents/`。
- Desktop restore 在目标 session cleanup 未完成时拒绝恢复，避免新 subagent transcript 被 destroyed checker 静默丢弃。
- 同步 `Controller.Run` 路径的 job session 注入，使 headless / 直接调用路径与交互式 turn 一致。
- 修复 destroy 与 job completion 之间的竞态，确保 destroyed session 不再产生 completion note / notice。

## 验证

- `gofmt -l .`（root module，排除 `desktop/`）无输出
- `gofmt -l .`（`desktop/` module）无输出
- `go vet ./...`（root module / `desktop/` module）
- `go test ./...`（root module / `desktop/` module）
- `git merge-tree --write-tree HEAD origin/main-v2` 通过
- macOS Desktop 真实验收：旧会话的后台 job 对新会话不可见、切回旧会话后可读；delete/trash 后 restore 不会恢复被取消 job，也没有输出泄漏。