### PR TITLE
fix(migrate): import legacy default model and run migration before desktop config load

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -369,6 +369,11 @@ func (a *App) restoreOrBuildTabs() {
 	ctx := a.ctx
 	ensureWorkspace()
 
+	// Run legacy config migration before the first config load so the
+	// freshly written config (including the user's default_model) is
+	// picked up by Load instead of falling back to built-in defaults.
+	config.MigrateLegacyIfNeeded()
+
 	// Load i18n from the first available config.
 	// Prefer DesktopLanguage (desktop UI setting) over Language (CLI setting),
 	// so the user's language choice in desktop settings takes effect.

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -17,6 +17,7 @@ import (
 type legacyConfig struct {
 	APIKey      string                       `json:"apiKey"`
 	BaseURL     string                       `json:"baseUrl"`
+	Model       string                       `json:"model"`
 	Lang        string                       `json:"lang"`
 	MCP         []string                     `json:"mcp"` // pre-mcpServers `--mcp`-format strings
 	MCPServers  map[string]legacyMCPServer   `json:"mcpServers"`
@@ -96,6 +97,9 @@ func MigrateLegacyIfNeeded() (*MigrationResult, error) {
 	if legacy.Lang != "" {
 		cfg.Language = legacy.Lang
 		_ = cfg.SetDesktopLanguage(legacy.Lang)
+	}
+	if legacy.Model != "" {
+		cfg.DefaultModel = legacy.Model
 	}
 	migrateLegacyBaseURL(cfg, legacy.BaseURL)
 	cfg.Plugins = legacyPlugins(legacy)

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -99,7 +99,11 @@ func MigrateLegacyIfNeeded() (*MigrationResult, error) {
 		_ = cfg.SetDesktopLanguage(legacy.Lang)
 	}
 	if legacy.Model != "" {
-		cfg.DefaultModel = legacy.Model
+		if entry, ok := cfg.ResolveModel(legacy.Model); ok {
+			cfg.DefaultModel = entry.Name + "/" + entry.Model
+		} else {
+			cfg.DefaultModel = legacy.Model
+		}
 	}
 	migrateLegacyBaseURL(cfg, legacy.BaseURL)
 	cfg.Plugins = legacyPlugins(legacy)

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -73,7 +73,7 @@ func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
 			t.Errorf("dest config missing %q:\n%s", want, toml)
 		}
 	}
-	if !strings.Contains(toml, `default_model = "deepseek-v4-pro"`) {
+	if !strings.Contains(toml, `default_model = "deepseek-pro/deepseek-v4-pro"`) {
 		t.Errorf("dest config missing imported model:\n%s", toml)
 	}
 
@@ -81,8 +81,8 @@ func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load: %v", err)
 	}
-	if loaded.DefaultModel != "deepseek-v4-pro" {
-		t.Errorf("DefaultModel = %q, want deepseek-v4-pro", loaded.DefaultModel)
+	if loaded.DefaultModel != "deepseek-pro/deepseek-v4-pro" {
+		t.Errorf("DefaultModel = %q, want deepseek-pro/deepseek-v4-pro", loaded.DefaultModel)
 	}
 
 	if _, err := os.Stat(src); err != nil {

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -33,6 +33,7 @@ func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
 	src, dest, home := legacyHome(t)
 	writeLegacy(t, src, `{
 		"apiKey": "sk-legacy-123",
+		"model": "deepseek-v4-pro",
 		"lang": "zh",
 		"mcpServers": {
 			"fs": {"command": "npx", "args": ["-y", "server-fs"], "type": "stdio"},
@@ -71,6 +72,17 @@ func TestMigrateImportsKeyPluginsAndLang(t *testing.T) {
 		if !strings.Contains(toml, want) {
 			t.Errorf("dest config missing %q:\n%s", want, toml)
 		}
+	}
+	if !strings.Contains(toml, `default_model = "deepseek-v4-pro"`) {
+		t.Errorf("dest config missing imported model:\n%s", toml)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded.DefaultModel != "deepseek-v4-pro" {
+		t.Errorf("DefaultModel = %q, want deepseek-v4-pro", loaded.DefaultModel)
 	}
 
 	if _, err := os.Stat(src); err != nil {


### PR DESCRIPTION
The v0.x `~/.reasonix/config.json` stored the user's model in a `"model"` key (e.g. `"deepseek-v4-pro"`), but `legacyConfig` had no field for it — every v0.x migration silently wrote `"deepseek-flash"` from `Default()`.

Two fixes:

- **Missing field:** Add `Model` to `legacyConfig`. Resolve the bare model name to a `"provider/model"` ref (e.g. `"deepseek-pro/deepseek-v4-pro"`) so the frontend doesn't scan providers and land on the wrong one.

- **Desktop startup race:** Move `MigrateLegacyIfNeeded()` before `config.Load` in `restoreOrBuildTabs`. It was running after tabs had already resolved their model against the missing-config defaults, so the corrected `default_model` never reached the chat window.