### PR TITLE
fix(config): comment out default max_steps/planner_max_steps in rendered project config

### DIFF
--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -164,8 +164,16 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	} else {
 		b.WriteString("# system_prompt_file = \"prompts/system.md\"   # overrides system_prompt when set\n")
 	}
-	fmt.Fprintf(&b, "max_steps         = %d   # executor tool-call rounds; 0 = no limit\n", c.Agent.MaxSteps)
-	fmt.Fprintf(&b, "planner_max_steps = %d   # planner read-only tool-call rounds; 0 = no limit\n", c.Agent.PlannerMaxSteps)
+	if c.Agent.MaxSteps != defaults.Agent.MaxSteps {
+		fmt.Fprintf(&b, "max_steps         = %d   # executor tool-call rounds; 0 = no limit\n", c.Agent.MaxSteps)
+	} else {
+		b.WriteString("# max_steps         = 0   # executor tool-call rounds; 0 = no limit\n")
+	}
+	if c.Agent.PlannerMaxSteps != defaults.Agent.PlannerMaxSteps {
+		fmt.Fprintf(&b, "planner_max_steps = %d   # planner read-only tool-call rounds; 0 = no limit\n", c.Agent.PlannerMaxSteps)
+	} else {
+		b.WriteString("# planner_max_steps = 12   # planner read-only tool-call rounds; 0 = no limit\n")
+	}
 	fmt.Fprintf(&b, "temperature       = %s\n", formatFloat(c.Agent.Temperature))
 	autoPlan := c.Agent.AutoPlan
 	switch strings.ToLower(strings.TrimSpace(autoPlan)) {

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -64,6 +65,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Notifications.TurnDone = true
 	orig.Notifications.ApprovalRequest = true
 	orig.Notifications.AskRequest = true
+	orig.Agent.MaxSteps = 30
+	orig.Agent.PlannerMaxSteps = 0
 	orig.Agent.AutoPlanClassifier = "deepseek-flash"
 	orig.Agent.SubagentModel = "mimo-pro"
 	orig.Agent.SubagentModels = map[string]string{"review": "deepseek-pro"}
@@ -472,3 +475,104 @@ func TestProjectRenderPreservesNonDefaultLegacySections(t *testing.T) {
 func boolPtr(v bool) *bool { return &v }
 
 func intPtr(v int) *int { return &v }
+
+func TestRenderTOMLDefaultStepsCommentedOut(t *testing.T) {
+	isolateUserConfigHome(t)
+	out := RenderTOML(Default())
+	agentLines := extractSectionLines(out, "[agent]")
+	for _, line := range agentLines {
+		if strings.HasPrefix(line, "max_steps ") || strings.HasPrefix(line, "max_steps=") {
+			if !strings.HasPrefix(line, "#") {
+				t.Errorf("default max_steps should be commented out in [agent], got: %s", line)
+			}
+		}
+		if strings.HasPrefix(line, "planner_max_steps ") || strings.HasPrefix(line, "planner_max_steps=") {
+			if !strings.HasPrefix(line, "#") {
+				t.Errorf("default planner_max_steps should be commented out in [agent], got: %s", line)
+			}
+		}
+	}
+}
+
+func extractSectionLines(toml, section string) []string {
+	var lines []string
+	inSection := false
+	for _, line := range strings.Split(toml, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, section) {
+			inSection = true
+			continue
+		}
+		if inSection && strings.HasPrefix(trimmed, "[") && !strings.HasPrefix(trimmed, "[[") {
+			break
+		}
+		if inSection {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}
+
+func TestRenderTOMLNonDefaultStepsWrittenExplicitly(t *testing.T) {
+	isolateUserConfigHome(t)
+	c := Default()
+	c.Agent.MaxSteps = 5
+	c.Agent.PlannerMaxSteps = 0
+	out := RenderTOML(c)
+	agentLines := extractSectionLines(out, "[agent]")
+	foundMax, foundPlanner := false, false
+	for _, line := range agentLines {
+		if !strings.HasPrefix(line, "#") && strings.HasPrefix(line, "max_steps ") {
+			foundMax = true
+		}
+		if !strings.HasPrefix(line, "#") && strings.HasPrefix(line, "planner_max_steps ") {
+			foundPlanner = true
+		}
+	}
+	if !foundMax {
+		t.Error("non-default max_steps should be written explicitly in [agent]")
+	}
+	if !foundPlanner {
+		t.Error("non-default planner_max_steps should be written explicitly in [agent]")
+	}
+}
+
+func TestRenderTOMLDefaultStepsDoNotOverrideGlobalConfig(t *testing.T) {
+	home := isolateUserConfigHome(t)
+	globalDir := filepath.Join(home, ".config", "reasonix")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	globalPath := filepath.Join(globalDir, "config.toml")
+	if err := os.WriteFile(globalPath, []byte("[agent]\nplanner_max_steps = 0\nmax_steps = 100\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	projectDir := t.TempDir()
+	projectTOML := RenderTOML(Default())
+	projectPath := filepath.Join(projectDir, "reasonix.toml")
+	if err := os.WriteFile(projectPath, []byte(projectTOML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Default()
+	if err := mergeFile(cfg, globalPath); err != nil {
+		t.Fatalf("global merge failed: %v", err)
+	}
+	if cfg.Agent.PlannerMaxSteps != 0 {
+		t.Fatalf("after global: planner_max_steps = %d, want 0", cfg.Agent.PlannerMaxSteps)
+	}
+	if cfg.Agent.MaxSteps != 100 {
+		t.Fatalf("after global: max_steps = %d, want 100", cfg.Agent.MaxSteps)
+	}
+
+	if err := mergeFile(cfg, projectPath); err != nil {
+		t.Fatalf("project merge failed: %v", err)
+	}
+	if cfg.Agent.PlannerMaxSteps != 0 {
+		t.Errorf("after project: planner_max_steps = %d, want 0 (global should not be overridden by commented-out default)", cfg.Agent.PlannerMaxSteps)
+	}
+	if cfg.Agent.MaxSteps != 100 {
+		t.Errorf("after project: max_steps = %d, want 100 (global should not be overridden by commented-out default)", cfg.Agent.MaxSteps)
+	}
+}


### PR DESCRIPTION
## Fixes #4166

### Problem
When a user sets `planner_max_steps = 0` in global config (e.g. via Desktop Settings), the project-level `reasonix.toml` generated by `RenderTOML` always writes `planner_max_steps = 12` as an explicit value. Since project config has higher priority than global config in `LoadForRoot()` (`flag > ./reasonix.toml > ~/.config/reasonix/config.toml > defaults`), the project's `12` silently overrides the user's `0`.

The same structural issue affects `max_steps`, though it is currently harmless since both default and written value are `0`.

### Root Cause
`render.go:167-168` unconditionally wrote explicit values for `max_steps` and `planner_max_steps`, even when they equal built-in defaults. This created a project-level override that defeated user global settings.

### Fix
Comment out `max_steps` and `planner_max_steps` when they equal `Default()` values — same pattern already used for `system_prompt`, `language`, `system_prompt_file`, etc. in the same function.

**Before (always written):**
```toml
max_steps         = 0   # executor tool-call rounds; 0 = no limit
planner_max_steps = 12  # planner read-only tool-call rounds; 0 = no limit
```

**After (commented out when at defaults):**
```toml
# max_steps         = 0   # executor tool-call rounds; 0 = no limit
# planner_max_steps = 12  # planner read-only tool-call rounds; 0 = no limit
```

Non-default values are still written explicitly, so intentional project-level overrides work as before.

### Tests
- `TestRenderTOMLDefaultStepsCommentedOut` — defaults render as comments in `[agent]` section
- `TestRenderTOMLNonDefaultStepsWrittenExplicitly` — non-defaults render as active TOML
- `TestRenderTOMLDefaultStepsDoNotOverrideGlobalConfig` — proves the bug is fixed: project config with commented-out defaults does not override global `planner_max_steps=0`
- Updated `TestRenderTOMLRoundTrips` to use non-default step values (consistent with other fields like `language`, `theme`, etc.)

### Files Changed
- `internal/config/render.go` — conditional comment-out for default step values
- `internal/config/render_test.go` — 3 new tests + round-trip test update