### PR TITLE
fix(desktop): follow-up to #4225 — minimal migration, streaming scroll, dead code

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -224,17 +224,6 @@ export function Transcript({
     repinIfWasPinned(previous - footerHeight);
   }, [footerHeight]);
 
-  // Smooth transition when footer height changes.
-  const prevFooterRef = useRef(footerHeight);
-  useEffect(() => {
-    const prev = prevFooterRef.current;
-    if (prev !== footerHeight && scrollRef.current) {
-      // GSAP will handle scroll repositioning via repinIfWasPinned above.
-      // The composer and status bar transitions are handled by CSS.
-    }
-    prevFooterRef.current = footerHeight;
-  }, [footerHeight]);
-
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.
   const subcallsByParent = useMemo(() => {
@@ -316,7 +305,7 @@ export function Transcript({
   // (added by upstream PR #3423) instead of per-call renderSegments.
   const empty = items.length === 0;
 
-  // In compact/minimal mode, break each turn into step groups.
+  // In compact mode, break each turn into step groups.
   // A step = one assistant + its tool results, from one assistant to the next.
   // Each completed non-final step is folded into "Processed".
   const stepGroups = useMemo(() => {
@@ -383,7 +372,7 @@ export function Transcript({
       actionReady = false;
     };
 
-    // Compact/minimal mode: step-based rendering
+    // Compact mode: step-based rendering
     // Standard mode: flat rendering (no step groups)
     if (stepGroups) {
       // Collect consecutive completed non-final steps into batches
@@ -519,7 +508,7 @@ export function Transcript({
       pushTurnActions();
     }
     return out;
-  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, false]);
+  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups]);
 
   // ── Assemble rendered output ──────────────────────────────────────────────
   // Warm/cold zone is a separate memo'd WarmZone component so streaming tokens
@@ -857,7 +846,7 @@ function WarmTurnCard({
   );
 }
 
-// ── TurnCollapse: compact/minimal mode grouping ──────────────────────────────
+// ── TurnCollapse: compact mode grouping ──────────────────────────────────────
 
 type TurnCollapseProps = {
   items: Item[];       // intermediate items (tools, reasoning, phase)
@@ -873,8 +862,7 @@ function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) 
   useGSAPCollapse(bodyRef, open);
 
   // Keep only items the body will actually render — an expandable fold over
-  // nothing is worse than no fold. Minimal mode strips reasoning, so a
-  // reasoning-only assistant counts as empty there.
+  // nothing is worse than no fold.
   const displayItems = useMemo(() => {
     return items.filter((it) => {
       if (it.kind === "assistant") {

--- a/desktop/frontend/src/lib/displayMode.ts
+++ b/desktop/frontend/src/lib/displayMode.ts
@@ -7,6 +7,7 @@ export function getDisplayMode(): DisplayMode {
   if (typeof localStorage === "undefined") return "standard";
   const stored = localStorage.getItem(DISPLAY_MODE_KEY);
   if (stored === "standard" || stored === "compact") return stored;
+  if (stored === "minimal") return "compact";
   return "standard";
 }
 
@@ -17,9 +18,10 @@ export function setDisplayMode(mode: DisplayMode): void {
 
 /** Adopts the toml-persisted mode at boot so config is the source of truth across machines. */
 export function hydrateDisplayMode(mode: string | undefined): void {
-  if (mode !== "standard" && mode !== "compact") return;
-  if (mode === getDisplayMode()) return;
-  setDisplayMode(mode);
+  const next: DisplayMode | undefined = mode === "standard" || mode === "compact" ? mode : mode === "minimal" ? "compact" : undefined;
+  if (!next) return;
+  if (next === getDisplayMode()) return;
+  setDisplayMode(next);
 }
 
 export function onDisplayModeChange(cb: (mode: DisplayMode) => void): () => void {

--- a/desktop/frontend/src/lib/gsapAnimations.ts
+++ b/desktop/frontend/src/lib/gsapAnimations.ts
@@ -11,20 +11,8 @@ export const DUR_BASE = 0.18;
 /** 340ms — drawers, modals, panel slides. Matches CSS --dur-slow. */
 export const DUR_SLOW = 0.34;
 
-/** 420ms — large overlay fades. Matches CSS --dur-slower. */
-export const DUR_SLOWER = 0.42;
-
-/**
- * "power2.out" approximates the CSS `cubic-bezier(0.2, 0.72, 0.2, 1)`
- * used across the app. GSAP's power2.out is a canonical fast-out ease.
- */
+/** "power2.out" approximates the app-wide CSS cubic-bezier(0.2, 0.72, 0.2, 1). */
 export const EASE_OUT = "power2.out";
-
-/** Symmetric ease for entrances that should also decelerate out. */
-export const EASE_IN_OUT = "power2.inOut";
-
-/** Stronger deceleration for scroll / layout transitions. */
-export const EASE_SCROLL = "power3.out";
 
 /** Returns true when the user has requested reduced motion at the OS level. */
 export function prefersReducedMotion(): boolean {

--- a/desktop/frontend/src/lib/useEntranceAnimation.ts
+++ b/desktop/frontend/src/lib/useEntranceAnimation.ts
@@ -2,23 +2,9 @@ import { useEffect, useRef } from "react";
 import gsap from "gsap";
 import { DUR_SLOW, EASE_OUT, prefersReducedMotion } from "./gsapAnimations";
 
-/**
- * useEntranceAnimation — animates newly-mounted elements as they appear in
- * the DOM. Tracks seen item IDs so each element animates in only once.
- *
- * Key performance properties:
- *  - On first mount, ALL existing data-entrance IDs are pre-seeded into the
- *    "seen" set so no entrance animation runs for history items.
- *  - The scan only runs when `deps` changes (pass items.length or similar).
- *  - During streaming (text changes within same elements) the scanner is
- *    completely skipped, avoiding expensive querySelectorAll calls.
- *  - When `resetKey` changes (session switch), seen set + firstRun are
- *    cleared so the new session's first paint is also pre-seeded (no
- *    entrance animation for restored history).
- *
- * Usage:
- *   const entranceRef = useEntranceAnimation(items.length, sessionKey);
- */
+// Animates each data-entrance element in once. First mount (and every
+// resetKey change) pre-seeds the seen set so restored history never animates;
+// the scan only runs when deps changes, skipping streaming token updates.
 export function useEntranceAnimation<T extends HTMLElement>(
   resetKey?: unknown,
   deps?: unknown,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2577,7 +2577,6 @@ a[href] {
   padding: 24px 32px 32px;
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
-  scroll-behavior: smooth;
 }
 .transcript > * {
   max-width: var(--maxw);

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,7 +78,7 @@ type DesktopConfig struct {
 	Theme          string   `toml:"theme"`            // auto|dark|light; empty resolves to dark
 	ThemeStyle     string   `toml:"theme_style"`      // graphite|aurora|slate|carbon|nocturne|amber and legacy aliases
 	CloseBehavior  string   `toml:"close_behavior"`   // quit|background; desktop window close behavior
-	DisplayMode    string   `toml:"display_mode"`     // standard|compact|minimal; transcript display mode
+	DisplayMode    string   `toml:"display_mode"`     // standard|compact (legacy "minimal" maps to compact); transcript display mode
 	StatusBarStyle string   `toml:"status_bar_style"` // icon|text; desktop status bar metric labels
 	StatusBarItems []string `toml:"status_bar_items"` // ordered visible desktop status bar items
 	CheckUpdates   *bool    `toml:"check_updates"`    // startup update checks; nil keeps the default enabled
@@ -200,10 +200,8 @@ func (c *Config) DesktopDisplayMode() string {
 	switch strings.ToLower(strings.TrimSpace(c.Desktop.DisplayMode)) {
 	case "standard":
 		return "standard"
-	case "compact":
+	case "compact", "minimal":
 		return "compact"
-	case "minimal":
-		return "minimal"
 	default:
 		return "standard"
 	}

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -195,14 +195,12 @@ func (c *Config) SetDesktopCloseBehavior(mode string) error {
 // SetDesktopDisplayMode sets the transcript display mode. UI-only.
 func (c *Config) SetDesktopDisplayMode(mode string) error {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case "compact":
+	case "compact", "minimal":
 		c.Desktop.DisplayMode = "compact"
-	case "minimal":
-		c.Desktop.DisplayMode = "minimal"
 	case "", "standard":
 		c.Desktop.DisplayMode = "standard"
 	default:
-		return fmt.Errorf("display mode %q: must be standard|compact|minimal", mode)
+		return fmt.Errorf("display mode %q: must be standard|compact", mode)
 	}
 	return nil
 }


### PR DESCRIPTION
Follow-up cleanup on top of #4225 (GSAP animation refactor). Three independent commits.

## 1. Map legacy `minimal` display mode to compact (fix)
#4225 removed the `minimal` mode (functionally identical to `compact`) from the type system and UI, but left the migration incomplete: `Config.DesktopDisplayMode()` still returned `"minimal"` for an existing user's persisted toml, and the frontend `getDisplayMode`/`hydrateDisplayMode` now reject that value — so anyone who had selected minimal silently dropped to **standard** (fully verbose) instead of the equivalent **compact**. Normalized `minimal → compact` on both the Go read path (`config.go`, `edit.go`) and the localStorage hydrate path (`displayMode.ts`).

## 2. Drop `scroll-behavior: smooth` that fights instant streaming scroll (fix)
The streaming auto-scroll pins to the bottom with a direct `el.scrollTop = el.scrollHeight` write, which #4225 documents as *instant* specifically to avoid the perpetual tween-chase jitter. #4225 also added a global `scroll-behavior: smooth` on `.transcript`, which in Chromium/WebView2 turns that `scrollTop` write into an animated scroll — reintroducing the lag it set out to remove. Removed the rule; the two call sites that genuinely want smooth (jump-bar via GSAP, warm-turn expand via `scrollTo({ behavior: "smooth" })`) already request it explicitly and are unaffected.

## 3. Remove dead code left by the merge (refactor)
- No-op footer-height effect in `Transcript.tsx` (empty `if` body, ref never read elsewhere).
- Constant `false` trailing the hot-zone `useMemo` dependency array.
- Unused `DUR_SLOWER` / `EASE_IN_OUT` / `EASE_SCROLL` exports in `gsapAnimations.ts`.
- Stale `compact/minimal` comments now that minimal is gone, and the entrance-hook JSDoc whose usage example had the args reversed.

`go test ./internal/config/` passes; frontend changes are typechecked by CI.
