### PR TITLE
style: unify expanded left-padding for foldable sections

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2726,7 +2726,7 @@ a[href] {
 .readonly-batch--open .readonly-batch__body,
 .turn-collapse--open .turn-collapse__body,
 .tool--open .tool__body {
-  padding: 0 11px 10px 30px;
+  padding: 0 11px 10px 12px;
   margin-top: 6px;
 }
 


### PR DESCRIPTION
## Summary

Change the expanded-state  of ReadOnlyBatch, TurnCollapse, and ToolCard from 30px to 12px, matching the collapsed state and keeping the visual border indent consistent with the Reasoning section.

All four collapsible sections now share the same 12px + 2px border indent.