### PR TITLE
feat: rewind undo banner + scroll to rewound message

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
 import { ApprovalModal } from "./components/ApprovalModal";
 import { AskCard } from "./components/AskCard";
+import { UndoRewindBanner, type UndoRewindMeta } from "./components/UndoRewindBanner";
 import { ClearContextCard } from "./components/ClearContextCard";
 import { StatusBar } from "./components/StatusBar";
 import { HistoryPanel } from "./components/HistoryPanel";
@@ -57,6 +58,7 @@ import { shouldShowTodoPanel } from "./lib/todoVisibility";
 import {
   type BotConnectionView,
   type BotSettingsView,
+  type CheckpointMeta,
   type CollaborationMode,
   type ComposerInsertRequest,
   type Mode,
@@ -1910,7 +1912,30 @@ export default function App() {
     await openBlankSession(target.scope, target.workspaceRoot);
   }, [blankSessionTarget, closeTransientOverlays, openBlankSession]);
 
+  const [rewindSignal, setRewindSignal] = useState(0);
+  const [rewindUndo, setRewindUndo] = useState<UndoRewindMeta | null>(null);
+  const itemsRef = useRef<Item[]>([]);
+  itemsRef.current = state.items;
+  const checkpointsRef = useRef<CheckpointMeta[]>([]);
+  checkpointsRef.current = state.checkpoints as CheckpointMeta[];
+
   const handleMessageAction = useCallback(async (turn: number, scope: string) => {
+    const prevItems = itemsRef.current ?? [];
+    const prevCheckpoints = checkpointsRef.current ?? [];
+    const prevUserCount = prevItems.filter((it) => it.kind === "user").length;
+    const prevLastCp = prevCheckpoints[prevCheckpoints.length - 1];
+    const prevFiles = prevLastCp?.files ?? [];
+
+    // For non-fork rewinds, silently fork before truncating so undo can
+    // switch back to the pre-rewind state.
+    let undoForkTabId: string | undefined;
+    if (scope !== "fork") {
+      try {
+        const undoFork = await app.Fork(turn);
+        if (undoFork?.id) undoForkTabId = undoFork.id;
+      } catch { /* undo fork failed silently */ }
+    }
+
     await rewind(turn, scope);
     if (scope === "fork") {
       await refreshTabMetas();
@@ -1922,7 +1947,26 @@ export default function App() {
       setDockRefreshKey((value) => value + 1);
       setProjectRevision((value) => value + 1);
     }
-  }, [refreshTabMetas, rewind]);
+    // Compute undo meta from before/after state.
+    const nowUserCount = (itemsRef.current ?? []).filter((it) => it.kind === "user").length;
+    const turnDiff = prevUserCount - nowUserCount;
+    const nowCp = (checkpointsRef.current ?? [])[(checkpointsRef.current ?? []).length - 1];
+    const nowFiles = nowCp?.files ?? [];
+    const restored = prevFiles.filter((f: string) => !nowFiles.includes(f));
+    const removed = nowFiles.filter((f: string) => !prevFiles.includes(f));
+    if (turnDiff > 0 || restored.length > 0 || removed.length > 0) {
+      setRewindUndo({
+        turns: turnDiff,
+        filesRestored: restored,
+        filesRemoved: removed,
+        onUndo: () => {
+          setRewindUndo(null);
+          if (undoForkTabId) switchTab(undoForkTabId);
+        },
+      });
+    }
+    setRewindSignal((v) => v + 1);
+  }, [refreshTabMetas, rewind, switchTab]);
 
   const handleOpenTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string) => {
     closeTransientOverlays();
@@ -2584,6 +2628,7 @@ export default function App() {
                 checkpoints={state.checkpoints}
                 actionPending={state.messageAction != null}
                 rewindDisabled={state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+                rewindSignal={rewindSignal}
               />
             )}
           </main>
@@ -2591,6 +2636,9 @@ export default function App() {
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
             {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
+            {rewindUndo && (
+              <UndoRewindBanner meta={rewindUndo} onDismiss={() => setRewindUndo(null)} />
+            )}
             {state.approval && (
               <ApprovalModal
                 key={state.approval.id}

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -141,6 +141,7 @@ export function Transcript({
   actionPending = false,
   rewindDisabled = false,
   questionNavigator = true,
+  rewindSignal = 0,
 }: {
   items: Item[];
   live?: LiveStream;
@@ -151,6 +152,7 @@ export function Transcript({
   actionPending?: boolean;
   rewindDisabled?: boolean;
   questionNavigator?: boolean;
+  rewindSignal?: number;
 }) {
   const {
     scrollRef,
@@ -223,6 +225,18 @@ export function Transcript({
     lastFooterHeight.current = footerHeight;
     repinIfWasPinned(previous - footerHeight);
   }, [footerHeight]);
+
+  // After a non-fork rewind, scroll to the last user message (the
+  // rewound-to point) so the user knows where they are.
+  useEffect(() => {
+    if (rewindSignal <= 0 || questions.length === 0) return;
+    const lastQ = questions[questions.length - 1];
+    const el = document.getElementById(questionAnchorId(lastQ.id));
+    if (!el || !scrollRef.current) return;
+    stick.current = false;
+    scrollRef.current.scrollTop = el.offsetTop - scrollRef.current.offsetTop - 12;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rewindSignal]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.

--- a/desktop/frontend/src/components/UndoRewindBanner.tsx
+++ b/desktop/frontend/src/components/UndoRewindBanner.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { useT } from "../lib/i18n";
+
+export interface UndoRewindMeta {
+  /** How many conversation turns were lost. */
+  turns: number;
+  /** File paths that were restored (code rewind). */
+  filesRestored: string[];
+  /** File paths that were removed (code rewind). */
+  filesRemoved: string[];
+  /** Callback when the user confirms undo. */
+  onUndo: () => void;
+}
+
+export function UndoRewindBanner({ meta, onDismiss }: { meta: UndoRewindMeta; onDismiss: () => void }) {
+  const t = useT();
+  const [confirm, setConfirm] = useState(false);
+  void onDismiss; // reserve for explicit dismiss (X button)
+
+  const parts: string[] = [];
+  if (meta.turns > 0) parts.push(t("undoRewind.turns", { n: meta.turns }));
+  if (meta.filesRestored.length > 0)
+    parts.push(t("undoRewind.filesRestored", { n: meta.filesRestored.length }));
+  if (meta.filesRemoved.length > 0)
+    parts.push(t("undoRewind.filesRemoved", { n: meta.filesRemoved.length }));
+  const summary = parts.join(" · ");
+
+  const files = [...new Set([...meta.filesRestored, ...meta.filesRemoved])];
+  const fileList = files.length > 0 ? files.slice(0, 3).map((f) => f.split(/[/\\]/).pop() || f).join(", ") + (files.length > 3 ? ` +${files.length - 3}` : "") : "";
+
+  return (
+    <div className="undo-rewind">
+      <div className="undo-rewind__info">
+        <span className="undo-rewind__label">{summary}</span>
+        {fileList && <span className="undo-rewind__files">{fileList}</span>}
+      </div>
+      <button
+        type="button"
+        className={`undo-rewind__btn${confirm ? " undo-rewind__btn--confirm" : ""}`}
+        onClick={() => {
+          if (confirm) {
+            meta.onUndo();
+            setConfirm(false);
+          } else {
+            setConfirm(true);
+          }
+        }}
+      >
+        {confirm ? t("undoRewind.confirm") : t("undoRewind.undo")}
+      </button>
+    </div>
+  );
+}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1271,6 +1271,11 @@ export const en = {
   "rewind.busyConversation": "Rewinding conversation…",
   "rewind.busyCode": "Rewinding code…",
   "rewind.busyBoth": "Rewinding code and conversation…",
+  "undoRewind.turns": "Rolled back {n} turn(s)",
+  "undoRewind.filesRestored": "{n} file(s) restored",
+  "undoRewind.filesRemoved": "{n} file(s) removed",
+  "undoRewind.undo": "Undo",
+  "undoRewind.confirm": "Confirm undo?",
   "msg.copied": "Copied",
 
   // tool card summaries

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -781,6 +781,11 @@ export const zhTW: Record<DictKey, string> = {
   "rewind.busyConversation": "正在回滾對話…",
   "rewind.busyCode": "正在回滾程式碼…",
   "rewind.busyBoth": "正在回滾程式碼和對話…",
+  "undoRewind.turns": "已回滾 {n} 輪對話",
+  "undoRewind.filesRestored": "還原了 {n} 個檔案",
+  "undoRewind.filesRemoved": "移除了 {n} 個檔案",
+  "undoRewind.undo": "撤回",
+  "undoRewind.confirm": "確認撤回？",
   "msg.copied": "已複製",
 
   // 工具卡片摘要

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1273,6 +1273,11 @@ export const zh: Record<DictKey, string> = {
   "rewind.busyConversation": "正在回滚对话…",
   "rewind.busyCode": "正在回滚代码…",
   "rewind.busyBoth": "正在回滚代码和对话…",
+  "undoRewind.turns": "已回滚 {n} 轮对话",
+  "undoRewind.filesRestored": "还原了 {n} 个文件",
+  "undoRewind.filesRemoved": "移除了 {n} 个文件",
+  "undoRewind.undo": "撤回",
+  "undoRewind.confirm": "确认撤回？",
   "msg.copied": "已复制",
 
   // 工具卡片摘要

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4107,6 +4107,65 @@ a[href] {
   background: var(--chat-bg);
   padding: 12px 32px 10px;
 }
+
+/* ── undo-rewind banner (above composer after a rewind) ─────────────── */
+.undo-rewind {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: var(--maxw);
+  margin: 0 auto 8px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elev);
+  font-size: 12.5px;
+  color: var(--fg-dim);
+}
+.undo-rewind__info {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  overflow: hidden;
+}
+.undo-rewind__label {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.undo-rewind__files {
+  color: var(--fg-faint);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.undo-rewind__btn {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.undo-rewind__btn:hover {
+  border-color: var(--accent-soft);
+  color: var(--accent);
+}
+.undo-rewind__btn--confirm {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: var(--accent-soft);
+}
+.undo-rewind__btn--confirm:hover {
+  background: color-mix(in srgb, var(--accent-soft) 80%, transparent);
+}
+
 .composer-wrap {
   position: relative;
   max-width: var(--maxw);


### PR DESCRIPTION
## Summary

After a non-fork rewind, show an undo banner above the composer that displays how many turns were rolled back and which files changed. The banner includes a two-click confirm undo button that switches to a silently-created fork tab, fully restoring the pre-rewind session.

Additionally, after rewind the transcript automatically scrolls to the last user message (the rewound-to point) so the user knows exactly where they are.

## What changed

- **UndoRewindBanner** — new component: shows turns rolled back + file changes + undo button (two-click confirm)
- **Silent fork before rewind** — creates a backup tab that undo switches to
- **rewindSignal** prop — Transcript scrolls to rewound-to user message
- CSS + locales for undo banner