### PR TITLE
Integrate session ownership and state routing / 集成会话归属与状态路由

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1200,11 +1200,45 @@ func (a *App) DeleteSession(path string) error {
 	if _, ok := a.openSessionPaths(dir)[sessionPath]; ok {
 		return errActiveSession
 	}
-	if err := trashSessionArtifacts(dir, sessionPath, key); err != nil {
+	var destroys []control.SessionDestroyHandle
+	err = trashSessionArtifactsBeforeMove(dir, sessionPath, key, func() {
+		destroys = a.beginDestroySessionJobs(dir, sessionPath)
+	})
+	if err != nil {
+		if len(destroys) > 0 {
+			go runDestroyHandles(destroys)
+		}
 		return err
+	}
+	if len(destroys) > 0 {
+		go runDestroyHandles(destroys)
 	}
 	a.emitProjectTreeChanged()
 	return nil
+}
+
+func (a *App) beginDestroySessionJobs(dir, sessionPath string) []control.SessionDestroyHandle {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var destroys []control.SessionDestroyHandle
+	for _, tab := range a.tabs {
+		if tab == nil || tab.Ctrl == nil || tabSessionDir(tab) != dir {
+			continue
+		}
+		destroys = append(destroys, tab.Ctrl.BeginDestroySession(sessionPath))
+	}
+	return destroys
+}
+
+func runDestroyHandles(destroys []control.SessionDestroyHandle) {
+	for _, destroy := range destroys {
+		if destroy.Wait != nil {
+			destroy.Wait()
+		}
+		if destroy.Finish != nil {
+			destroy.Finish()
+		}
+	}
 }
 
 func (a *App) openSessionPaths(dir string) map[string]struct{} {
@@ -1251,14 +1285,32 @@ func (a *App) RestoreSession(path string) error {
 	if err != nil {
 		return err
 	}
+	target := filepath.Join(dir, key)
+	if a.sessionDestroying(dir, target) {
+		return fmt.Errorf("session cleanup is still in progress: %s", key)
+	}
 	if err := restoreTrashedSessionFile(dir, path); err != nil {
 		return err
 	}
-	if err := restoreSessionTopicIndex(dir, filepath.Join(dir, key)); err != nil {
+	if err := restoreSessionTopicIndex(dir, target); err != nil {
 		return err
 	}
 	a.emitProjectTreeChanged()
 	return nil
+}
+
+func (a *App) sessionDestroying(dir, sessionPath string) bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, tab := range a.tabs {
+		if tab == nil || tab.Ctrl == nil || tabSessionDir(tab) != dir {
+			continue
+		}
+		if tab.Ctrl.IsDestroyingSession(sessionPath) {
+			return true
+		}
+	}
+	return false
 }
 
 // PurgeTrashedSession permanently removes a trashed session and its title/display
@@ -4326,12 +4378,13 @@ type MemoryScope struct {
 // MemoryView is the whole memory panel payload: hierarchical docs, active saved
 // facts, archived facts, and the writable scopes for the quick-add selector.
 type MemoryView struct {
-	Docs      []MemoryDoc     `json:"docs"`
-	Facts     []MemoryFact    `json:"facts"`
-	Archives  []MemoryArchive `json:"archives"`
-	Scopes    []MemoryScope   `json:"scopes"`
-	StoreDir  string          `json:"storeDir"`
-	Available bool            `json:"available"`
+	Docs           []MemoryDoc     `json:"docs"`
+	Facts          []MemoryFact    `json:"facts"`
+	Archives       []MemoryArchive `json:"archives"`
+	Scopes         []MemoryScope   `json:"scopes"`
+	StoreDir       string          `json:"storeDir"`
+	StoreGlobalDir string          `json:"storeGlobalDir,omitempty"`
+	Available      bool            `json:"available"`
 }
 
 // writableScopes are the quick-add targets the panel offers, broad → specific.
@@ -4341,20 +4394,41 @@ var writableScopes = []memory.Scope{memory.ScopeUser, memory.ScopeProject, memor
 // active/archived auto-memories, and the writable scopes. Read-only; mutations
 // go through Remember / SaveDoc.
 func (a *App) Memory() MemoryView {
-	// Always return non-nil slices: a nil Go slice marshals to JSON `null`, which
-	// would crash the panel's `view.facts.length` / `.map`.
+	return a.memoryForCtrl(nil, true)
+}
+
+// MemoryForTab returns the loaded memory for a specific tab's controller,
+// so the panel can show memory for any open project, not just the active tab.
+// If the tab does not exist or has no controller, returns an empty view
+// instead of falling back to the active tab (which would show the wrong data).
+// An empty tabID is treated as "no tab specified" and falls back to the
+// active tab for backward compatibility.
+func (a *App) MemoryForTab(tabID string) MemoryView {
+	if tabID == "" {
+		return a.memoryForCtrl(nil, true)
+	}
+	return a.memoryForCtrl(a.ctrlByTabID(tabID), false)
+}
+
+func (a *App) memoryForCtrl(ctrl *control.Controller, fallback bool) MemoryView {
 	view := MemoryView{Docs: []MemoryDoc{}, Facts: []MemoryFact{}, Archives: []MemoryArchive{}, Scopes: []MemoryScope{}}
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
 	if ctrl == nil {
-		return view
+		if !fallback {
+			return view
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return view
+		}
 	}
 	set := ctrl.Memory()
 	if set == nil {
 		return view
 	}
 	view.StoreDir = set.Store.Dir
+	view.StoreGlobalDir = set.Store.GlobalDir
 	view.Available = true
 	for _, d := range set.Docs {
 		view.Docs = append(view.Docs, MemoryDoc{Path: d.Path, Scope: string(d.Scope), Body: d.Body})
@@ -4375,7 +4449,7 @@ func (a *App) Memory() MemoryView {
 		})
 	}
 	for _, sc := range writableScopes {
-		if p := set.DocPath(sc); p != "" { // user scope yields "" when no config dir
+		if p := set.DocPath(sc); p != "" {
 			view.Scopes = append(view.Scopes, MemoryScope{Scope: string(sc), Path: p})
 		}
 	}
@@ -4386,11 +4460,27 @@ func (a *App) Memory() MemoryView {
 // panel's explicit "remember" action, equivalent to typing "/remember <note>".
 // An unknown scope falls back to project. Returns the file written.
 func (a *App) Remember(scope, note string) (string, error) {
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
+	return a.rememberForCtrl(nil, scope, note, true)
+}
+
+func (a *App) RememberForTab(tabID, scope, note string) (string, error) {
+	if tabID == "" {
+		return a.rememberForCtrl(nil, scope, note, true)
+	}
+	return a.rememberForCtrl(a.ctrlByTabID(tabID), scope, note, false)
+}
+
+func (a *App) rememberForCtrl(ctrl *control.Controller, scope, note string, fallback bool) (string, error) {
 	if ctrl == nil {
-		return "", nil
+		if !fallback {
+			return "", nil
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return "", nil
+		}
 	}
 	return ctrl.QuickAdd(parseScope(scope), note)
 }
@@ -4398,11 +4488,27 @@ func (a *App) Remember(scope, note string) (string, error) {
 // Forget deletes a saved auto-memory by name — the panel's delete action for a
 // fact the model owns. A no-op when no controller is attached.
 func (a *App) Forget(name string) error {
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
+	return a.forgetForCtrl(nil, name, true)
+}
+
+func (a *App) ForgetForTab(tabID, name string) error {
+	if tabID == "" {
+		return a.forgetForCtrl(nil, name, true)
+	}
+	return a.forgetForCtrl(a.ctrlByTabID(tabID), name, false)
+}
+
+func (a *App) forgetForCtrl(ctrl *control.Controller, name string, fallback bool) error {
 	if ctrl == nil {
-		return nil
+		if !fallback {
+			return nil
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return nil
+		}
 	}
 	return ctrl.ForgetMemory(name)
 }
@@ -4410,11 +4516,27 @@ func (a *App) Forget(name string) error {
 // SaveDoc overwrites a memory doc with the panel editor's contents. The controller
 // validates path against the recognized memory files. Returns the file written.
 func (a *App) SaveDoc(path, body string) (string, error) {
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
+	return a.saveDocForCtrl(nil, path, body, true)
+}
+
+func (a *App) SaveDocForTab(tabID, path, body string) (string, error) {
+	if tabID == "" {
+		return a.saveDocForCtrl(nil, path, body, true)
+	}
+	return a.saveDocForCtrl(a.ctrlByTabID(tabID), path, body, false)
+}
+
+func (a *App) saveDocForCtrl(ctrl *control.Controller, path, body string, fallback bool) (string, error) {
 	if ctrl == nil {
-		return "", nil
+		if !fallback {
+			return "", nil
+		}
+		a.mu.RLock()
+		ctrl = a.activeCtrlLocked()
+		a.mu.RUnlock()
+		if ctrl == nil {
+			return "", nil
+		}
 	}
 	return ctrl.SaveDoc(path, body)
 }

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -17,6 +17,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/memory"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -1335,6 +1336,47 @@ func TestDeleteSessionRejectsInactiveOpenTab(t *testing.T) {
 	}
 	if open[filepath.Base(otherPath)] {
 		t.Fatalf("ListSessions marked unopened session open, got %#v", open)
+	}
+}
+
+func TestRestoreSessionRejectsDestroyingSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "trash-me.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	if err := deleteSessionFile(dir, sessionPath); err != nil {
+		t.Fatalf("deleteSessionFile: %v", err)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, filepath.Base(sessionPath), filepath.Base(sessionPath))
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: filepath.Join(dir, "active.jsonl"), Label: "active", Jobs: jm})
+	defer ctrl.Close()
+	destroy := ctrl.BeginDestroySession(sessionPath)
+	defer destroy.Finish()
+
+	app := NewApp()
+	app.setTestCtrl(ctrl, "")
+	if err := app.RestoreSession(trashPath); err == nil || !strings.Contains(err.Error(), "cleanup is still in progress") {
+		t.Fatalf("RestoreSession while destroying error = %v, want cleanup-in-progress", err)
+	}
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("trashed session should remain after rejected restore: %v", err)
+	}
+
+	destroy.Finish()
+	if err := app.RestoreSession(trashPath); err != nil {
+		t.Fatalf("RestoreSession after finish: %v", err)
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("session should be restored: %v", err)
 	}
 }
 

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -2,7 +2,7 @@ import { Check, ChevronDown, ChevronRight, FileText, Pencil, Plus, RefreshCw, Se
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
-import type { MemoryArchive, MemoryFact, MemorySuggestion, MemorySuggestionsView, MemoryView, SkillSuggestion } from "../lib/types";
+import type { MemoryArchive, MemoryFact, MemorySuggestion, MemorySuggestionsView, MemoryView, SkillSuggestion, TabMeta } from "../lib/types";
 import { ResizableDrawer } from "./ResizableDrawer";
 import { Tooltip } from "./Tooltip";
 import { ModalCloseButton } from "./ModalCloseButton";
@@ -572,7 +572,7 @@ export function MemoryPanel({
                                     {t("memory.confirmForget")}
                                   </button>
                                 </div>
-                              ) : (
+                               ) : (
                                 <button
                                   className="btn btn--small mem-fact__forget"
                                   onClick={() => setConfirmForget(f.name)}
@@ -591,8 +591,8 @@ export function MemoryPanel({
                   })}
                 </div>
               )}
-              {view.storeDir && (
-                <div className="mem-hint">{t("memory.storedUnder", { dir: view.storeDir })}</div>
+              {(view.storeDir || view.storeGlobalDir) && (
+                <div className="mem-hint">{t("memory.storedUnder", { dir: [view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ") })}</div>
               )}
             </section>
 
@@ -731,9 +731,9 @@ export function MemoryPanel({
                   </div>
                 ))
               )}
-              {view.storeDir && (
-                <div className="mem-hint" title={view.storeDir}>
-                  {t("memory.storedUnder", { dir: view.storeDir })}
+              {(view.storeDir || view.storeGlobalDir) && (
+                <div className="mem-hint" title={[view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ")}>
+                  {t("memory.storedUnder", { dir: [view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ") })}
                 </div>
               )}
             </section>
@@ -748,6 +748,8 @@ export function MemoryPanel({
 export function MemorySettingsPage() {
 	const t = useT();
 	const [view, setView] = useState<MemoryView | null>(null);
+	const [tabs, setTabs] = useState<TabMeta[]>([]);
+	const [selectedTabId, setSelectedTabId] = useState<string | null>(null);
 	const [note, setNote] = useState("");
 	const [scope, setScope] = useState("");
 	const [editingPath, setEditingPath] = useState<string | null>(null);
@@ -773,8 +775,20 @@ export function MemorySettingsPage() {
 	const factRefs = useRef<Record<string, HTMLElement | null>>({});
 
 	const reload = useCallback(async () => {
-		setView(await app.Memory().catch(() => null));
+		const tabId = selectedTabId;
+		setView(tabId ? await app.MemoryForTab(tabId).catch(() => null) : await app.Memory().catch(() => null));
+	}, [selectedTabId]);
+
+	useEffect(() => {
+		app.ListTabs().then((tabList) => {
+			setTabs(tabList);
+			if (!selectedTabId) {
+				const active = tabList.find((tb) => tb.active);
+				if (active) setSelectedTabId(active.id);
+			}
+		}).catch(() => {});
 	}, []);
+
 	useEffect(() => { void reload(); }, [reload]);
 
 	const refreshSuggestions = useCallback(async () => {
@@ -886,7 +900,8 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			await app.Forget(name);
+			if (selectedTabId) await app.ForgetForTab(selectedTabId, name);
+			else await app.Forget(name);
 			await reload();
 			if (expanded === name) setExpanded(null);
 			setConfirmForget(null);
@@ -895,7 +910,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [busy, expanded, reload]);
+	}, [busy, expanded, reload, selectedTabId]);
 
 	const scopes = view?.scopes ?? [];
 	const activeScope =
@@ -907,7 +922,8 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			await app.Remember(activeScope, trimmed);
+			if (selectedTabId) await app.RememberForTab(selectedTabId, activeScope, trimmed);
+			else await app.Remember(activeScope, trimmed);
 			await reload();
 			setNote("");
 			setShowAdd(false);
@@ -916,7 +932,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [note, busy, activeScope, reload]);
+	}, [note, busy, activeScope, reload, selectedTabId]);
 
 	const startEdit = useCallback((path: string, body: string) => {
 		setEditingPath(path);
@@ -928,7 +944,8 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			await app.SaveDoc(editingPath, draft);
+			if (selectedTabId) await app.SaveDocForTab(selectedTabId, editingPath, draft);
+			else await app.SaveDoc(editingPath, draft);
 			await reload();
 			setEditingPath(null);
 		} catch (err) {
@@ -936,7 +953,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [editingPath, busy, draft, reload]);
+	}, [editingPath, busy, draft, reload, selectedTabId]);
 
 	const acceptMemorySuggestion = useCallback(async (candidate: MemorySuggestion) => {
 		if (busy) return;
@@ -968,7 +985,26 @@ export function MemorySettingsPage() {
 	}, [busy]);
 
 	if (!view?.available) {
-		return <div className="empty">{t("memory.unavailable")}</div>;
+		return (
+			<>
+				{tabs.length > 1 && (
+					<div className="mem-tab-selector">
+						<select
+							className="mem-tab-select"
+							value={selectedTabId ?? ""}
+							onChange={(e) => setSelectedTabId(e.target.value || null)}
+						>
+							{tabs.map((tb) => (
+								<option key={tb.id} value={tb.id}>
+									{tb.label || tb.workspaceName || tb.scope || tb.id}
+								</option>
+							))}
+						</select>
+					</div>
+				)}
+				<div className="empty">{t("memory.unavailable")}</div>
+			</>
+		);
 	}
 
 	const hasSavedFilters = facts.length > 0;
@@ -1038,6 +1074,21 @@ export function MemorySettingsPage() {
 					{suggestionTotal(suggestions) > 0 && <span className="settings-subtab__count">{suggestionTotal(suggestions)}</span>}
 				</button>
 			</div>
+			{tabs.length > 1 && (
+				<div className="mem-tab-selector">
+					<select
+						className="mem-tab-select"
+						value={selectedTabId ?? ""}
+						onChange={(e) => setSelectedTabId(e.target.value || null)}
+					>
+						{tabs.map((tb) => (
+							<option key={tb.id} value={tb.id}>
+								{tb.label || tb.workspaceName || tb.scope}
+							</option>
+						))}
+					</select>
+				</div>
+			)}
 
 			{tab === "saved" && <section className="mem-section">
 				<div className="mem-section__head">
@@ -1265,6 +1316,9 @@ export function MemorySettingsPage() {
 						})}
 					</div>
 				)}
+			{(view.storeDir || view.storeGlobalDir) && (
+				<div className="mem-hint">{t("memory.storedUnder", { dir: [view.storeDir, view.storeGlobalDir].filter(Boolean).join(" + ") })}</div>
+			)}
 			</section>}
 
 			{tab === "suggestions" && <section className="mem-section">

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -199,9 +199,13 @@ export interface AppBindings {
   MemorySuggestions(): Promise<MemorySuggestionsView>;
   AcceptMemorySuggestion(suggestion: MemorySuggestion): Promise<string>;
   AcceptSkillSuggestion(suggestion: SkillSuggestion): Promise<string>;
+  MemoryForTab(tabID: string): Promise<MemoryView>;
   Remember(scope: string, note: string): Promise<string>;
+  RememberForTab(tabID: string, scope: string, note: string): Promise<string>;
   Forget(name: string): Promise<void>;
+  ForgetForTab(tabID: string, name: string): Promise<void>;
   SaveDoc(path: string, body: string): Promise<string>;
+  SaveDocForTab(tabID: string, path: string, body: string): Promise<string>;
   Settings(): Promise<SettingsView>;
   HooksSettings(scope: string): Promise<HooksSettingsView>;
   SaveHooksSettings(scope: string, hooks: HookConfigView[]): Promise<void>;
@@ -2060,6 +2064,7 @@ function makeMockApp(): AppBindings {
       return {
         available: true,
         storeDir: "~/.config/reasonix/projects/-mock/memory",
+        storeGlobalDir: "~/.config/reasonix/memory/global",
         docs: [
           {
             path: "REASONIX.md",
@@ -2135,16 +2140,28 @@ function makeMockApp(): AppBindings {
       emit({ kind: "notice", level: "info", text: `created suggested skill → ${suggestion.name}` });
       return `.reasonix/skills/${suggestion.name}/SKILL.md`;
     },
-    async Remember(scope: string, note: string) {
-      emit({ kind: "notice", level: "info", text: `remembered → ${scope}` });
-      return `${scope} REASONIX.md (mock): ${note}`;
+    async MemoryForTab(_tabID: string) {
+      return this.Memory();
     },
-    async Forget(name: string) {
-      emit({ kind: "notice", level: "info", text: `forgot → ${name}` });
+    async Remember(_scope: string, _note: string) {
+      emit({ kind: "notice", level: "info", text: `remembered → ${_scope}` });
+      return `${_scope} REASONIX.md (mock): ${_note}`;
     },
-    async SaveDoc(path: string, _body: string) {
-      emit({ kind: "notice", level: "info", text: `saved → ${path}` });
-      return path;
+    async RememberForTab(_tabID: string, scope: string, note: string) {
+      return this.Remember(scope, note);
+    },
+    async Forget(_name: string) {
+      emit({ kind: "notice", level: "info", text: `forgot → ${_name}` });
+    },
+    async ForgetForTab(_tabID: string, name: string) {
+      return this.Forget(name);
+    },
+    async SaveDoc(_path: string, _body: string) {
+      emit({ kind: "notice", level: "info", text: `saved → ${_path}` });
+      return _path;
+    },
+    async SaveDocForTab(_tabID: string, path: string, body: string) {
+      return this.SaveDoc(path, body);
     },
     async Settings() {
       return JSON.parse(JSON.stringify(settings)) as SettingsView;

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -567,6 +567,7 @@ export interface MemoryView {
   archives: MemoryArchive[];
   scopes: MemoryScope[];
   storeDir: string;
+  storeGlobalDir?: string;
   available: boolean;
 }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7412,6 +7412,18 @@ a[href] {
   flex-direction: column;
   gap: 22px;
 }
+.mem-tab-selector {
+  margin-bottom: 8px;
+}
+.mem-tab-select {
+  width: 100%;
+  padding: 6px 8px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+}
 .mem-section {
   min-width: 0;
 }

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -120,6 +120,10 @@ type trashedSessionMeta struct {
 }
 
 func trashSessionArtifacts(dir, sessionPath, key string) error {
+	return trashSessionArtifactsBeforeMove(dir, sessionPath, key, nil)
+}
+
+func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove func()) error {
 	if _, err := os.Stat(sessionPath); os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
@@ -133,6 +137,9 @@ func trashSessionArtifacts(dir, sessionPath, key string) error {
 	}
 	if err := os.MkdirAll(itemDir, 0o755); err != nil {
 		return err
+	}
+	if beforeMove != nil {
+		beforeMove()
 	}
 	if err := movePathIfExists(sessionPath, filepath.Join(itemDir, key)); err != nil {
 		return err

--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -98,7 +98,8 @@ func EphemeralSubagentRun(systemPrompt string) *SubagentRun {
 // SubagentStore persists sub-agent transcripts under config.SessionDir()/subagents.
 // Its locks are process-local; cross-process mutation is intentionally out of v1.
 type SubagentStore struct {
-	dir string
+	dir       string
+	destroyed func(parentSession string) bool
 
 	mu     sync.Mutex
 	locked map[string]bool
@@ -109,6 +110,16 @@ func NewSubagentStore(dir string) *SubagentStore {
 		return nil
 	}
 	return &SubagentStore{dir: dir, locked: map[string]bool{}}
+}
+
+// WithDestroyedChecker makes saves for destroyed parent sessions no-op. This is
+// used when a background sub-agent is cancelled because its parent session was
+// cleared or moved out of active history.
+func (s *SubagentStore) WithDestroyedChecker(fn func(parentSession string) bool) *SubagentStore {
+	if s != nil {
+		s.destroyed = fn
+	}
+	return s
 }
 
 // ListSubagentsByParent returns persisted sub-agent artifacts whose metadata
@@ -287,6 +298,9 @@ func (s *SubagentStore) MarkRunning(run *SubagentRun) error {
 	if s == nil || run == nil || run.Ref == "" {
 		return nil
 	}
+	if s.parentDestroyed(run) {
+		return nil
+	}
 	meta := run.Meta
 	meta.Status = SubagentRunning
 	meta.UpdatedAt = time.Now().UTC()
@@ -295,6 +309,9 @@ func (s *SubagentStore) MarkRunning(run *SubagentRun) error {
 
 func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
 	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	if s.parentDestroyed(run) {
 		return nil
 	}
 	if err := run.Session.Save(s.sessionPath(run.Ref)); err != nil {
@@ -309,6 +326,9 @@ func (s *SubagentStore) SaveCompleted(run *SubagentRun) error {
 
 func (s *SubagentStore) SaveFailed(run *SubagentRun) error {
 	if s == nil || run == nil || run.Ref == "" {
+		return nil
+	}
+	if s.parentDestroyed(run) {
 		return nil
 	}
 	var sessionErr error
@@ -506,6 +526,13 @@ func (s *SubagentStore) saveMeta(meta SubagentMeta) error {
 		return err
 	}
 	return fileutil.ReplaceFile(tmpPath, s.metaPath(meta.Ref))
+}
+
+func (s *SubagentStore) parentDestroyed(run *SubagentRun) bool {
+	if s == nil || s.destroyed == nil || run == nil {
+		return false
+	}
+	return s.destroyed(run.Meta.ParentSession)
 }
 
 func validSubagentRef(ref string) bool {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -332,6 +332,34 @@ func TestSubagentStoreSaveFailedPersistsTranscriptAndRejectsReuse(t *testing.T) 
 	}
 }
 
+func TestSubagentStoreSkipsSaveForDestroyedParent(t *testing.T) {
+	store := NewSubagentStore(t.TempDir()).WithDestroyedChecker(func(parentSession string) bool {
+		return parentSession == "parent-session"
+	})
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "answer after destroy"})
+	if err := store.SaveCompleted(run); err != nil {
+		t.Fatalf("SaveCompleted: %v", err)
+	}
+	if _, err := os.Stat(store.sessionPath(run.Ref)); !os.IsNotExist(err) {
+		t.Fatalf("destroyed parent should not save session, stat err = %v", err)
+	}
+	if _, err := os.Stat(store.metaPath(run.Ref)); !os.IsNotExist(err) {
+		t.Fatalf("destroyed parent should not save meta, stat err = %v", err)
+	}
+	if err := store.SaveFailed(run); err != nil {
+		t.Fatalf("SaveFailed: %v", err)
+	}
+	if _, err := os.Stat(store.sessionPath(run.Ref)); !os.IsNotExist(err) {
+		t.Fatalf("destroyed parent should still not save session, stat err = %v", err)
+	}
+	run.Release()
+}
+
 func testSubagentSpec(t *testing.T, name string) SubagentSpec {
 	t.Helper()
 	reg := tool.NewRegistry()

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -248,7 +248,7 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 				return "", err
 			}
 		}
-		job := jm.Start("task", label, func(jobCtx context.Context, _ io.Writer) (string, error) {
+		job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (string, error) {
 			defer run.Release()
 			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, prov, pricing, ctxWin, run.Session)
 			if err != nil {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -148,6 +148,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
 	}
 	jm := jobs.NewManager(sink)
+	sessionDir := opts.SessionDir
+	if sessionDir == "" {
+		sessionDir = config.SessionDir()
+	}
 
 	proxySpec := cfg.NetworkProxySpec()
 	if err := netclient.Validate(proxySpec); err != nil {
@@ -204,11 +208,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	allSkills := allSkillStore.List()
 	if !tokenEconomy {
 		sysPrompt = skill.ApplyIndex(sysPrompt, skills)
-	}
-
-	sessionDir := opts.SessionDir
-	if sessionDir == "" {
-		sessionDir = config.SessionDir()
 	}
 
 	reg := tool.NewRegistry()
@@ -440,7 +439,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if opts.MaxSteps > 0 {
 		maxSteps = opts.MaxSteps
 	}
-	subagentStore := newSubagentStore(config.SessionDir())
+	subagentStore := newSubagentStore(sessionDir)
+	if subagentStore != nil {
+		subagentStore.WithDestroyedChecker(jm.IsDestroying)
+	}
 
 	// Permission policy gates every tool call. The headless gate (no Approver)
 	// resolves "ask" to allow — preserving `reasonix run` autonomy — while deny

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -380,6 +380,56 @@ model = "x"
 	}
 }
 
+func TestBuildSubagentStoreHonorsSessionDirOverride(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerBootSubagentTestProvider()
+	prov := &bootSubagentTestProvider{}
+	setBootSubagentTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-subagent-test"
+model = "x"
+`)
+
+	sessionDir := filepath.Join(t.TempDir(), "desktop-workspace-sessions")
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard, SessionDir: sessionDir})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	sessionPath := agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label())
+	ctrl.SetSessionPath(sessionPath)
+
+	if err := ctrl.Run(context.Background(), "first review"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	ref := subagentRefFromHistory(t, ctrl.History())
+
+	overrideStore := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	meta, err := overrideStore.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta from override dir: %v", err)
+	}
+	if meta.ParentSession != agent.BranchID(sessionPath) {
+		t.Fatalf("parent session = %q, want %q", meta.ParentSession, agent.BranchID(sessionPath))
+	}
+	if _, err := os.Stat(filepath.Join(config.SessionDir(), "subagents", ref+".meta.json")); !os.IsNotExist(err) {
+		t.Fatalf("subagent metadata should not be written to global session dir, stat err = %v", err)
+	}
+}
+
 const bootSubagentTestProviderKind = "boot-subagent-test"
 
 var (
@@ -1245,6 +1295,10 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 // prefix is untouched by the memory feature.
 func TestBuildWithoutMemoryLeavesPromptUnchanged(t *testing.T) {
 	dir := robustTempDir(t)
+	home := robustTempDir(t)
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
 	t.Chdir(dir)
 	writeFile(t, dir, "reasonix.toml", `
 default_model = "test-model"

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -144,6 +145,16 @@ type Controller struct {
 	// just got cleared to do. Deny rules still bite (those never reach the
 	// approver). Reset when the execution turn returns.
 	approvedPlanAutoApproveTools bool
+
+	// approvedPlanActive carries that same go-ahead across user-directed pauses in
+	// an approved plan. It stays true only while the approved plan has not reported
+	// completion, so an explicit continuation turn resumes without downgrading into
+	// per-tool approval.
+	approvedPlanActive bool
+	// approvedPlanContinuationTurn is true only for the current user turn when
+	// the user explicitly asked to continue that approved plan.
+	approvedPlanContinuationTurn bool
+	approvedPlanStart            int // message index where the approved execution began
 
 	// toolApprovalMode is the runtime approval posture for permission-gated tool
 	// calls. "ask" prompts by default, "auto" lets the policy auto-approve the
@@ -312,6 +323,7 @@ func New(opts Options) *Controller {
 	}
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
 	c.rebindCheckpoints(opts.SessionPath)
+	c.setActiveJobSession(opts.SessionPath)
 	if c.executor != nil {
 		c.executor.SetPreEditHook(func(ch diff.Change) {
 			if c.cp != nil {
@@ -464,6 +476,11 @@ const planApprovalTool = "exit_plan_mode"
 // the in-context nudge to execute and keep the (already-seeded) task list honest.
 const planApprovedMessage = "Plan approved — plan mode is off; you’re cleared to make the changes without asking again. Implement the plan now. Use this serial workflow: 1) mark the first sub-step in_progress with todo_write (this establishes the task list); 2) execute the sub-step; 3) call complete_step with evidence — the host then marks that sub-step completed and moves the next one to in_progress for you. Repeat 2–3 for each remaining sub-step. You don’t need another todo_write to mark steps completed; each complete_step advances the list. Sign off one sub-step at a time — never batch multiple completions."
 
+// approvedPlanExecutionMarker is prepended to later user turns while an approved
+// plan is paused with unfinished todos. It preserves the execution contract in
+// model context without mutating the cache-stable system prompt or tool schema.
+const approvedPlanExecutionMarker = "[Approved plan execution continues — the prior plan is already approved. Continue the next unfinished step without asking again for ordinary work covered by that plan. Keep todo_write current by sending the complete list whenever a step starts or finishes.]"
+
 // runTurn runs one model turn, then applies the plan-approval gate. This is the
 // single, frontend-agnostic plan flow: in plan mode the model just researches
 // (writers are blocked) and writes its plan as a normal answer — no special tool.
@@ -522,9 +539,12 @@ func (c *Controller) runGoalLoopWithRawDisplay(ctx context.Context, input, raw, 
 }
 
 func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
+	defer c.clearApprovedPlanContinuationTurn()
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
-	ctx = agent.WithParentSession(ctx, c.parentSessionID())
+	parentSession := c.parentSessionID()
+	ctx = agent.WithParentSession(ctx, parentSession)
+	ctx = jobs.WithSession(ctx, parentSession)
 	ctx = agent.WithUserImages(ctx, c.inputImages(input))
 	input = c.Compose(input)
 	startMessages := c.messageCount()
@@ -549,6 +569,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	if err := c.runner.Run(ctx, input); err != nil {
 		return err
 	}
+	c.refreshApprovedPlanExecutionFromHistory()
 	c.mu.Lock()
 	plan := c.planMode
 	c.mu.Unlock()
@@ -569,7 +590,8 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		return nil // keep planning; plan mode stays on
 	}
 	c.SetPlanMode(false)
-	seededTodos := c.seedPlanTodos(proposal)
+	todoArgs := c.seedPlanTodos(proposal)
+	c.beginApprovedPlanExecution(todoArgs)
 	// The plan is the go-ahead: don't re-prompt for each write of the approved
 	// work. Auto-approve writers for the duration of this execution turn only.
 	c.mu.Lock()
@@ -580,11 +602,14 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		c.approvedPlanAutoApproveTools = false
 		c.mu.Unlock()
 	}()
-	if err := c.runner.Run(ctx, planApprovedMessage); err != nil {
-		return err
+	err = c.runner.Run(ctx, planApprovedMessage)
+	if err == nil && todoArgs != "" && !c.approvedPlanHasTodoUpdateSinceStart() {
+		c.completePlanTodos(todoArgs)
+		c.clearApprovedPlanExecution()
+		return nil
 	}
-	c.completePlanTodos(seededTodos)
-	return nil
+	c.refreshApprovedPlanExecutionFromHistory()
+	return err
 }
 
 func (c *Controller) continueGoal(ctx context.Context) error {
@@ -1058,7 +1083,9 @@ func (c *Controller) notice(text string) {
 // just needs the exit status — no TurnDone event, no cancel bookkeeping.
 func (c *Controller) Run(ctx context.Context, input string) error {
 	c.maybeSessionStart(ctx)
-	ctx = agent.WithParentSession(ctx, c.parentSessionID())
+	parentSession := c.parentSessionID()
+	ctx = agent.WithParentSession(ctx, parentSession)
+	ctx = jobs.WithSession(ctx, parentSession)
 	ctx = agent.WithUserImages(ctx, c.inputImages(input))
 	startMessages := c.messageCount()
 	defer c.snapshotActivityIfChanged(startMessages)
@@ -1266,6 +1293,11 @@ func (c *Controller) ReplayPendingPrompts() {
 func (c *Controller) SetPlanMode(v bool) {
 	c.mu.Lock()
 	c.planMode = v
+	if v {
+		c.approvedPlanActive = false
+		c.approvedPlanContinuationTurn = false
+		c.approvedPlanStart = 0
+	}
 	c.mu.Unlock()
 	if c.executor != nil {
 		c.executor.SetPlanMode(v)
@@ -1373,7 +1405,9 @@ func (c *Controller) NewSession() error {
 		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
 		c.mu.Unlock()
 	}
+	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.clearApprovedPlanExecution()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
@@ -1395,8 +1429,13 @@ func (c *Controller) ClearSession() error {
 	if running {
 		return fmt.Errorf("cannot clear while a turn is running")
 	}
-	if err := removeSessionArtifacts(oldPath); err != nil {
-		return err
+	destroy := c.BeginDestroySession(oldPath)
+	if !destroy.Async {
+		if err := removeSessionArtifacts(oldPath); err != nil {
+			destroy.Finish()
+			return err
+		}
+		destroy.Finish()
 	}
 	c.hooks.SessionEnd(context.Background())
 	if c.sessionDir != "" {
@@ -1404,12 +1443,23 @@ func (c *Controller) ClearSession() error {
 		c.sessionPath = agent.NewSessionPath(c.sessionDir, c.label)
 		c.mu.Unlock()
 	}
+	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.clearApprovedPlanExecution()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true
 	c.mu.Unlock()
 	c.hooks.SessionStart(context.Background())
+	if destroy.Async {
+		go func() {
+			destroy.Wait()
+			if err := removeSessionArtifacts(oldPath); err != nil {
+				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "clear session cleanup failed: " + err.Error()})
+			}
+			destroy.Finish()
+		}()
+	}
 	return nil
 }
 
@@ -1429,6 +1479,9 @@ func removeSessionArtifacts(path string) error {
 		if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
 			return err
 		}
+	}
+	if err := agent.DeleteSubagentsByParent(filepath.Dir(path), agent.BranchID(path)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -1582,7 +1635,9 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		c.executor.SetSession(sess)
 		c.mu.Lock()
 		c.sessionPath = newPath
+		c.clearApprovedPlanExecutionLocked()
 		c.mu.Unlock()
+		c.setActiveJobSession(newPath)
 		c.rebindCheckpoints(newPath)
 	}
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
@@ -1640,7 +1695,11 @@ func (c *Controller) Branch(name string) (string, error) {
 	c.executor.SetSession(sess)
 	c.mu.Lock()
 	c.sessionPath = newPath
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
 	c.mu.Unlock()
+	c.setActiveJobSession(newPath)
 	c.rebindCheckpoints(newPath)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("created branch %s", agent.BranchID(newPath))})
@@ -1686,7 +1745,11 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	}
 	c.mu.Lock()
 	c.sessionPath = match.Path
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
 	c.mu.Unlock()
+	c.setActiveJobSession(match.Path)
 	c.rebindCheckpoints(match.Path)
 	c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
 		Text: fmt.Sprintf("switched to branch %s", branchDisplayName(match))})
@@ -1784,7 +1847,11 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	}
 	c.mu.Lock()
 	c.sessionPath = path
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
 	c.mu.Unlock()
+	c.setActiveJobSession(path)
 	c.rebindCheckpoints(path)
 	c.maybeColdResumePrune(path)
 }
@@ -1915,7 +1982,54 @@ func (c *Controller) SetSessionPath(p string) {
 	c.mu.Lock()
 	c.sessionPath = p
 	c.mu.Unlock()
+	c.setActiveJobSession(p)
 	c.rebindCheckpoints(p)
+}
+
+// SessionDestroyHandle separates waiting for cancelled jobs from ending the
+// destroy window, so callers can move/delete persistent artifacts in between.
+type SessionDestroyHandle struct {
+	Wait   func()
+	Finish func()
+	Async  bool
+}
+
+// BeginDestroySession marks a session as leaving active use and cancels its
+// background jobs. Call Wait before moving/deleting artifacts, then Finish after
+// persistent cleanup/move work is complete.
+func (c *Controller) BeginDestroySession(sessionPath string) SessionDestroyHandle {
+	parentSession := agent.BranchID(sessionPath)
+	if c.jobs == nil || parentSession == "" {
+		noop := func() {}
+		return SessionDestroyHandle{Wait: noop, Finish: noop}
+	}
+	done := c.jobs.DestroySession(parentSession)
+	return SessionDestroyHandle{
+		Wait: func() {
+			for _, ch := range done {
+				<-ch
+			}
+		},
+		Finish: func() {
+			c.jobs.FinishDestroySession(parentSession)
+		},
+		Async: len(done) > 0,
+	}
+}
+
+// IsDestroyingSession reports whether sessionPath is currently in the destroy
+// window for this controller's job manager.
+func (c *Controller) IsDestroyingSession(sessionPath string) bool {
+	if c.jobs == nil {
+		return false
+	}
+	return c.jobs.IsDestroying(agent.BranchID(sessionPath))
+}
+
+func (c *Controller) setActiveJobSession(sessionPath string) {
+	if c.jobs != nil {
+		c.jobs.SetActiveSession(agent.BranchID(sessionPath))
+	}
 }
 
 // SessionDir reports the directory new session files land in ("" disables
@@ -2354,7 +2468,7 @@ func (c *Controller) Jobs() []jobs.View {
 	if c.jobs == nil {
 		return nil
 	}
-	return c.jobs.Running()
+	return c.jobs.RunningForSession(c.parentSessionID())
 }
 
 // SetToolApprovalMode changes the runtime approval posture for permission-gated
@@ -2578,8 +2692,9 @@ type gateApprover struct{ c *Controller }
 func (g gateApprover) Approve(ctx context.Context, tool, subject string, args json.RawMessage) (bool, bool, error) {
 	subject = approvalDisplaySubject(tool, subject, args)
 	// Auto-allow without prompting while executing a just-approved plan (the plan
-	// was the approval) or while YOLO/full-access tool auto-approval is on. Deny
-	// rules already bit before this point, so they still block.
+	// was the approval), during an explicit continuation turn of that approved
+	// plan, or while YOLO/full-access tool auto-approval is on. Deny rules already
+	// bit before this point, so they still block.
 	g.c.mu.Lock()
 	auto := g.c.approvalBypassAllowsLocked(tool)
 	g.c.mu.Unlock()
@@ -2785,6 +2900,108 @@ func parsePlanTodos(plan string) []seedTodo {
 	return todos
 }
 
+func (c *Controller) beginApprovedPlanExecution(todoArgs string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.approvedPlanActive = true
+	if todoArgs != "" {
+		c.approvedPlanActive = todosIncomplete(todoArgs)
+	}
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
+	if c.executor != nil {
+		c.approvedPlanStart = len(c.executor.Session().Messages)
+	}
+}
+
+func (c *Controller) clearApprovedPlanExecution() {
+	c.mu.Lock()
+	c.clearApprovedPlanExecutionLocked()
+	c.mu.Unlock()
+}
+
+func (c *Controller) clearApprovedPlanExecutionLocked() {
+	c.approvedPlanActive = false
+	c.approvedPlanContinuationTurn = false
+	c.approvedPlanStart = 0
+}
+
+func (c *Controller) clearApprovedPlanContinuationTurn() {
+	c.mu.Lock()
+	c.approvedPlanContinuationTurn = false
+	c.mu.Unlock()
+}
+
+func (c *Controller) refreshApprovedPlanExecutionFromHistory() {
+	c.mu.Lock()
+	active := c.approvedPlanActive
+	start := c.approvedPlanStart
+	c.mu.Unlock()
+	if !active || c.executor == nil {
+		return
+	}
+	msgs := c.executor.Session().Messages
+	if start < 0 || start > len(msgs) {
+		start = len(msgs)
+	}
+	args, ok := latestTodoArgsSince(msgs, start)
+	if !ok {
+		return
+	}
+	c.mu.Lock()
+	c.approvedPlanActive = todosIncomplete(args)
+	if !c.approvedPlanActive {
+		c.approvedPlanContinuationTurn = false
+		c.approvedPlanStart = 0
+	}
+	c.mu.Unlock()
+}
+
+func (c *Controller) approvedPlanHasTodoUpdateSinceStart() bool {
+	c.mu.Lock()
+	active := c.approvedPlanActive
+	start := c.approvedPlanStart
+	c.mu.Unlock()
+	if !active || c.executor == nil {
+		return false
+	}
+	msgs := c.executor.Session().Messages
+	if start < 0 || start > len(msgs) {
+		start = len(msgs)
+	}
+	_, ok := latestTodoArgsSince(msgs, start)
+	return ok
+}
+
+func latestTodoArgsSince(msgs []provider.Message, start int) (string, bool) {
+	for i := len(msgs) - 1; i >= start; i-- {
+		for j := len(msgs[i].ToolCalls) - 1; j >= 0; j-- {
+			tc := msgs[i].ToolCalls[j]
+			if tc.Name == "todo_write" {
+				return tc.Arguments, true
+			}
+		}
+	}
+	return "", false
+}
+
+func todosIncomplete(args string) bool {
+	var p struct {
+		Todos []struct {
+			Status string `json:"status"`
+		} `json:"todos"`
+	}
+	if err := json.Unmarshal([]byte(args), &p); err != nil || len(p.Todos) == 0 {
+		return false
+	}
+	for _, t := range p.Todos {
+		if t.Status != "completed" {
+			return true
+		}
+	}
+	return false
+}
+
 // listItem parses a markdown list line ("- x", "* x", "1. x", "2) x") into its
 // task text and a nesting level derived from leading indentation (0 for a
 // top-level item, 1 for an indented sub-step — capped at 1 since the plan is
@@ -2948,7 +3165,12 @@ func approvalNotificationText(tool, subject string) string {
 }
 
 func (c *Controller) approvalBypassAllowsLocked(tool string) bool {
-	return !requiresFreshApprovalTool(tool) && (c.toolApprovalMode == ToolApprovalYolo || c.approvedPlanAutoApproveTools)
+	if requiresFreshApprovalTool(tool) {
+		return false
+	}
+	return c.toolApprovalMode == ToolApprovalYolo ||
+		c.approvedPlanAutoApproveTools ||
+		(c.approvedPlanActive && c.approvedPlanContinuationTurn)
 }
 
 func (c *Controller) autoApprovalWouldAllowLocked(tool, subject string) bool {

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
 	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
@@ -38,6 +39,17 @@ type handoffRunner struct {
 
 func (r handoffRunner) Run(_ context.Context, input string) error {
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: "handoff: " + input})
+	return nil
+}
+
+type sessionContextRunner struct {
+	parentSession string
+	jobSession    string
+}
+
+func (r *sessionContextRunner) Run(ctx context.Context, input string) error {
+	r.parentSession = agent.ParentSession(ctx)
+	r.jobSession = jobs.SessionFromContext(ctx)
 	return nil
 }
 
@@ -86,6 +98,26 @@ func TestRunTurnSnapshotsActivityWhenTranscriptChanges(t *testing.T) {
 	}
 	if meta.UpdatedAt.IsZero() {
 		t.Fatal("activity meta should be marked")
+	}
+}
+
+func TestRunInjectsParentSessionForJobs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	runner := &sessionContextRunner{}
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Runner: runner, Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+
+	if err := c.Run(context.Background(), "hello"); err != nil {
+		t.Fatal(err)
+	}
+	want := agent.BranchID(path)
+	if runner.parentSession != want {
+		t.Fatalf("ParentSession = %q, want %q", runner.parentSession, want)
+	}
+	if runner.jobSession != want {
+		t.Fatalf("jobs session = %q, want %q", runner.jobSession, want)
 	}
 }
 
@@ -678,4 +710,201 @@ func TestMidTurnAutosavePersistsDuringLongTurn(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("session file was not written while the turn was still running")
+}
+
+type scriptedRunner struct {
+	exec    *agent.Agent
+	scripts []func(input string)
+}
+
+func (r *scriptedRunner) Run(_ context.Context, input string) error {
+	if len(r.scripts) == 0 {
+		return nil
+	}
+	next := r.scripts[0]
+	r.scripts = r.scripts[1:]
+	next(input)
+	return nil
+}
+
+func TestApprovedPlanSurvivesUserPauseUntilTodosComplete(t *testing.T) {
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	runner := &scriptedRunner{exec: exec}
+
+	var c *Controller
+	approvalPrompts := 0
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind != event.ApprovalRequest {
+			return
+		}
+		approvalPrompts++
+		if e.Approval.Tool == planApprovalTool {
+			go c.Approve(e.Approval.ID, true, false, false)
+			return
+		}
+		go c.Approve(e.Approval.ID, false, false, false)
+	})
+	c = New(Options{Runner: runner, Executor: exec, Sink: sink})
+	c.SetPlanMode(true)
+
+	runner.scripts = append(runner.scripts,
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "1. Create the file\n2. Update the file"})
+		},
+		func(input string) {
+			if input != planApprovedMessage {
+				t.Fatalf("approved execution input = %q, want planApprovedMessage", input)
+			}
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "first step done; paused for review", ToolCalls: []provider.ToolCall{{
+				ID: "todo-1", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"in_progress"}]}`,
+			}}})
+		},
+	)
+
+	if err := c.runTurn(context.Background(), "plan this"); err != nil {
+		t.Fatal(err)
+	}
+	if approvalPrompts != 1 {
+		t.Fatalf("approval prompts after plan = %d, want 1", approvalPrompts)
+	}
+
+	if got := c.Compose("继续"); got == "继续" {
+		t.Fatal("continuation turn should carry the approved-plan execution marker")
+	}
+	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
+	if err != nil || !allow {
+		t.Fatalf("writer during unfinished approved plan = (%v,%v), want auto-allow", allow, err)
+	}
+	if approvalPrompts != 1 {
+		t.Fatalf("unfinished approved plan should not prompt for writer, prompts=%d", approvalPrompts)
+	}
+
+	runner.scripts = append(runner.scripts, func(input string) {
+		exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "all done", ToolCalls: []provider.ToolCall{{
+			ID: "todo-2", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"completed"}]}`,
+		}}})
+	})
+	if err := c.runTurn(context.Background(), c.Compose("继续")); err != nil {
+		t.Fatal(err)
+	}
+
+	allow, _, err = gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/b", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allow {
+		t.Fatal("writer after approved plan completion should return to normal approval flow")
+	}
+	if approvalPrompts != 2 {
+		t.Fatalf("writer after completion should prompt once, prompts=%d", approvalPrompts)
+	}
+}
+
+func TestApprovedPlanDoesNotAutoApproveNonContinuationTurn(t *testing.T) {
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	runner := &scriptedRunner{exec: exec}
+
+	var c *Controller
+	approvalPrompts := 0
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind != event.ApprovalRequest {
+			return
+		}
+		approvalPrompts++
+		if e.Approval.Tool == planApprovalTool {
+			go c.Approve(e.Approval.ID, true, false, false)
+			return
+		}
+		go c.Approve(e.Approval.ID, false, false, false)
+	})
+	c = New(Options{Runner: runner, Executor: exec, Sink: sink})
+	c.SetPlanMode(true)
+
+	runner.scripts = append(runner.scripts,
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "1. Create the file\n2. Update the file"})
+		},
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "paused", ToolCalls: []provider.ToolCall{{
+				ID: "todo-1", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"in_progress"}]}`,
+			}}})
+		},
+	)
+
+	if err := c.runTurn(context.Background(), "plan this"); err != nil {
+		t.Fatal(err)
+	}
+	if got := c.Compose("先别继续"); got != "先别继续" {
+		t.Fatalf("non-continuation input should not be marker-prefixed, got %q", got)
+	}
+
+	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allow {
+		t.Fatal("non-continuation turn should not inherit approved-plan auto approval")
+	}
+	if approvalPrompts != 2 {
+		t.Fatalf("non-continuation writer should prompt after plan approval, prompts=%d", approvalPrompts)
+	}
+}
+
+func TestApprovedPlanContinuationWorksWithoutSeededTodos(t *testing.T) {
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	runner := &scriptedRunner{exec: exec}
+
+	var c *Controller
+	approvalPrompts := 0
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind != event.ApprovalRequest {
+			return
+		}
+		approvalPrompts++
+		if e.Approval.Tool == planApprovalTool {
+			go c.Approve(e.Approval.ID, true, false, false)
+			return
+		}
+		go c.Approve(e.Approval.ID, false, false, false)
+	})
+	c = New(Options{Runner: runner, Executor: exec, Sink: sink})
+	c.SetPlanMode(true)
+
+	runner.scripts = append(runner.scripts,
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "先创建文件，然后暂停让我审核。审核通过后继续修改文件。"})
+		},
+		func(input string) {
+			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "first step done; paused for review"})
+		},
+	)
+
+	if err := c.runTurn(context.Background(), "plan this"); err != nil {
+		t.Fatal(err)
+	}
+	if approvalPrompts != 1 {
+		t.Fatalf("approval prompts after prose plan = %d, want 1", approvalPrompts)
+	}
+
+	if got := c.Compose("continue"); got == "continue" {
+		t.Fatal("explicit continuation should carry the approved-plan execution marker")
+	}
+	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
+	if err != nil || !allow {
+		t.Fatalf("writer during prose-plan continuation = (%v,%v), want auto-allow", allow, err)
+	}
+
+	if got := c.Compose("revise the plan"); got != "revise the plan" {
+		t.Fatalf("non-continuation after prose plan should not be marker-prefixed, got %q", got)
+	}
+	allow, _, err = gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/b", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allow {
+		t.Fatal("non-continuation after prose plan should return to normal approval flow")
+	}
+	if approvalPrompts != 2 {
+		t.Fatalf("writer after non-continuation should prompt once, prompts=%d", approvalPrompts)
+	}
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -89,14 +89,27 @@ var syntheticPrefixes = []string{
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,
 // returning the message to actually send to the model. The frontend keeps
-// showing the raw text as the user bubble.
+// showing the raw text as the user bubble. When an approved plan is paused,
+// only an explicit continuation command carries that approval into the next turn.
 func (c *Controller) Compose(text string) string {
 	c.mu.Lock()
 	plan := c.planMode
 	goal := c.goal
 	goalStatus := c.goalStatus
+	approvedPlan := c.approvedPlanActive
+	continuation := false
 	notes := c.pendingMemory
 	c.pendingMemory = nil
+	if !plan && approvedPlan {
+		continuation = isApprovedPlanContinuation(text)
+		if continuation {
+			c.approvedPlanContinuationTurn = true
+		} else {
+			c.approvedPlanActive = false
+			c.approvedPlanContinuationTurn = false
+			c.approvedPlanStart = 0
+		}
+	}
 	c.mu.Unlock()
 
 	if strings.TrimSpace(goal) != "" && goalStatus == GoalStatusRunning {
@@ -104,6 +117,8 @@ func (c *Controller) Compose(text string) string {
 	}
 	if plan {
 		text = PlanModeMarker + "\n\n" + text
+	} else if continuation {
+		text = approvedPlanExecutionMarker + "\n\n" + text
 	}
 
 	// Memory added mid-session rides the turn (never the cached system prefix),
@@ -124,7 +139,7 @@ func (c *Controller) Compose(text string) string {
 	// model learns of completions even though the user-facing notices don't reach
 	// its context. Like memory, this never touches the cache-stable prefix.
 	if c.jobs != nil {
-		if note := c.jobs.DrainCompletedNote(); note != "" {
+		if note := c.jobs.DrainCompletedNoteForSession(c.parentSessionID()); note != "" {
 			text = "<background-jobs>\n" + note + "\n</background-jobs>\n\n" + text
 		}
 	}
@@ -143,6 +158,19 @@ func activeGoalBlock(goal string) string {
 	b.WriteString("\n")
 	b.WriteString(activeGoalClose)
 	return b.String()
+}
+
+func isApprovedPlanContinuation(text string) bool {
+	s := strings.ToLower(strings.TrimSpace(text))
+	s = strings.TrimRight(s, ".。!！")
+	s = strings.Join(strings.Fields(s), " ")
+	switch s {
+	case "继续", "继续执行", "继续吧", "接着执行", "下一步", "执行下一步",
+		"continue", "resume", "proceed", "go on", "continue execution":
+		return true
+	default:
+		return false
+	}
 }
 
 // MemoryQuickAddNote parses the "# <note>" memory shortcut. The space after

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -56,9 +56,10 @@ type Result struct {
 // terminal fields; the run goroutine writes them, readers (Output/Wait/snapshots)
 // take the same lock.
 type Job struct {
-	ID    string
-	Kind  string // "bash" | "task"
-	Label string
+	ID        string
+	Kind      string // "bash" | "task"
+	Label     string
+	SessionID string
 
 	mu         sync.Mutex
 	buf        bytes.Buffer
@@ -78,11 +79,18 @@ type Manager struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	mu        sync.Mutex
-	seq       int
-	jobs      map[string]*Job
-	order     []string
-	completed []string // finished-job summaries awaiting drain into the next turn
+	mu         sync.Mutex
+	seq        int
+	jobs       map[string]*Job
+	order      []string
+	completed  []completion // finished-job summaries awaiting drain into the next turn
+	active     string
+	destroying map[string]bool
+}
+
+type completion struct {
+	sessionID string
+	text      string
 }
 
 // NewManager returns a Manager whose jobs run under a fresh session-scoped
@@ -93,7 +101,7 @@ func NewManager(sink event.Sink) *Manager {
 		sink = event.Discard
 	}
 	root, cancel := context.WithCancel(context.Background())
-	return &Manager{sink: sink, root: root, cancel: cancel, jobs: map[string]*Job{}}
+	return &Manager{sink: sink, root: root, cancel: cancel, jobs: map[string]*Job{}, destroying: map[string]bool{}}
 }
 
 // jobWriter appends a job's streamed output under its lock so a concurrent
@@ -112,16 +120,23 @@ func (w jobWriter) Write(p []byte) (int, error) {
 // the buffer and returns ""). The job is marked killed when its context was
 // cancelled, failed on any other error, else done.
 func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io.Writer) (string, error)) *Job {
+	return m.StartForSession("", kind, label, run)
+}
+
+// StartForSession launches a job owned by parentSession. Session-scoped readers
+// only see jobs whose owner matches the active session.
+func (m *Manager) StartForSession(parentSession, kind, label string, run func(ctx context.Context, out io.Writer) (string, error)) *Job {
+	parentSession = strings.TrimSpace(parentSession)
 	m.mu.Lock()
 	m.seq++
 	id := fmt.Sprintf("%s-%d", kind, m.seq)
 	ctx, cancel := context.WithCancel(m.root)
-	j := &Job{ID: id, Kind: kind, Label: label, status: Running, startedAt: nowMs(), cancel: cancel, done: make(chan struct{})}
+	j := &Job{ID: id, Kind: kind, Label: label, SessionID: parentSession, status: Running, startedAt: nowMs(), cancel: cancel, done: make(chan struct{})}
 	m.jobs[id] = j
 	m.order = append(m.order, id)
 	m.mu.Unlock()
 
-	m.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: startedText(kind, id, label)})
+	m.emitIfActive(parentSession, event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: startedText(kind, id, label)})
 
 	m.wg.Add(1)
 	go func() {
@@ -146,7 +161,7 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 		// completion, skip j.done, and DrainCompletedNote would race ahead of the
 		// bookkeeping (the TestDrainMultiple -race flake). Recording first makes an
 		// observed terminal status imply the note is already queued.
-		m.recordCompletion(id, kind, label, st, err)
+		m.recordCompletion(parentSession, id, kind, label, st, err)
 
 		j.mu.Lock()
 		j.result = result
@@ -161,13 +176,24 @@ func (m *Manager) Start(kind, label string, run func(ctx context.Context, out io
 
 // recordCompletion queues the finished-job summary for DrainCompletedNote and
 // emits a closing Notice (warn for a failure, info otherwise).
-func (m *Manager) recordCompletion(id, kind, label string, st Status, err error) {
+func (m *Manager) recordCompletion(parentSession, id, kind, label string, st Status, err error) {
 	tag := id
 	if label != "" {
 		tag = fmt.Sprintf("%s (%s)", id, label)
 	}
+	parentSession = strings.TrimSpace(parentSession)
+	shouldEmit := false
 	m.mu.Lock()
-	m.completed = append(m.completed, fmt.Sprintf("%s — %s", tag, st))
+	if parentSession != "" && m.destroying[parentSession] {
+		m.mu.Unlock()
+		return
+	}
+	m.completed = append(m.completed, completion{
+		sessionID: parentSession,
+		text:      fmt.Sprintf("%s — %s", tag, st),
+	})
+	active := m.active
+	shouldEmit = active == "" || parentSession == "" || active == parentSession
 	m.mu.Unlock()
 
 	level, text := event.LevelInfo, fmt.Sprintf("background %s finished: %s", kind, id)
@@ -177,7 +203,9 @@ func (m *Manager) recordCompletion(id, kind, label string, st Status, err error)
 	case Killed:
 		text = fmt.Sprintf("background %s killed: %s", kind, id)
 	}
-	m.sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text})
+	if shouldEmit {
+		m.sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text})
+	}
 }
 
 func (m *Manager) get(id string) *Job {
@@ -189,8 +217,14 @@ func (m *Manager) get(id string) *Job {
 // Output returns the job's output produced since the last Output call plus its
 // current status. ok is false when the id is unknown.
 func (m *Manager) Output(id string) (text string, status Status, ok bool) {
+	return m.OutputForSession("", id)
+}
+
+// OutputForSession returns output only when id belongs to parentSession. Empty
+// parentSession preserves the legacy unscoped behavior.
+func (m *Manager) OutputForSession(parentSession, id string) (text string, status Status, ok bool) {
 	j := m.get(id)
-	if j == nil {
+	if j == nil || !sessionMatches(parentSession, j.SessionID) {
 		return "", "", false
 	}
 	j.mu.Lock()
@@ -211,8 +245,14 @@ func (m *Manager) Output(id string) (text string, status Status, ok bool) {
 // Kill cancels a running job. Returns false when the id is unknown or the job has
 // already finished.
 func (m *Manager) Kill(id string) bool {
+	return m.KillForSession("", id)
+}
+
+// KillForSession cancels a running job only when it belongs to parentSession.
+// Empty parentSession preserves the legacy unscoped behavior.
+func (m *Manager) KillForSession(parentSession, id string) bool {
 	j := m.get(id)
-	if j == nil {
+	if j == nil || !sessionMatches(parentSession, j.SessionID) {
 		return false
 	}
 	j.mu.Lock()
@@ -239,7 +279,13 @@ func (m *Manager) Kill(id string) bool {
 // (0 = no timeout). It returns each target's snapshot regardless of why it
 // returned, so a timeout still reports partial progress.
 func (m *Manager) Wait(ctx context.Context, ids []string, timeoutSec int) []Result {
-	targets := m.resolve(ids)
+	return m.WaitForSession(ctx, "", ids, timeoutSec)
+}
+
+// WaitForSession waits only on jobs owned by parentSession. Empty parentSession
+// preserves the legacy unscoped behavior.
+func (m *Manager) WaitForSession(ctx context.Context, parentSession string, ids []string, timeoutSec int) []Result {
+	targets := m.resolve(parentSession, ids)
 	if len(targets) == 0 {
 		return nil
 	}
@@ -262,13 +308,16 @@ func (m *Manager) Wait(ctx context.Context, ids []string, timeoutSec int) []Resu
 }
 
 // resolve maps requested ids to jobs; an empty list selects all running jobs.
-func (m *Manager) resolve(ids []string) []*Job {
+func (m *Manager) resolve(parentSession string, ids []string) []*Job {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var out []*Job
 	if len(ids) == 0 {
 		for _, id := range m.order {
 			j := m.jobs[id]
+			if !sessionMatches(parentSession, j.SessionID) {
+				continue
+			}
 			j.mu.Lock()
 			running := j.status == Running
 			j.mu.Unlock()
@@ -279,7 +328,7 @@ func (m *Manager) resolve(ids []string) []*Job {
 		return out
 	}
 	for _, id := range ids {
-		if j := m.jobs[id]; j != nil {
+		if j := m.jobs[id]; j != nil && sessionMatches(parentSession, j.SessionID) {
 			out = append(out, j)
 		}
 	}
@@ -302,11 +351,20 @@ func (m *Manager) results(targets []*Job) []Result {
 
 // Running returns a snapshot of the still-running jobs (for the status bar).
 func (m *Manager) Running() []View {
+	return m.RunningForSession("")
+}
+
+// RunningForSession returns still-running jobs owned by parentSession. Empty
+// parentSession preserves the legacy unscoped behavior.
+func (m *Manager) RunningForSession(parentSession string) []View {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var out []View
 	for _, id := range m.order {
 		j := m.jobs[id]
+		if !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
 		j.mu.Lock()
 		if j.status == Running {
 			out = append(out, View{ID: j.ID, Kind: j.Kind, Label: j.Label, Status: string(j.status), StartedAt: j.startedAt})
@@ -320,15 +378,108 @@ func (m *Manager) Running() []View {
 // finished since the last drain, for the controller to fold into the next turn
 // so the model learns of completions. "" when nothing finished.
 func (m *Manager) DrainCompletedNote() string {
+	return m.DrainCompletedNoteForSession("")
+}
+
+// DrainCompletedNoteForSession drains completion notes for parentSession only.
+// Notes for other sessions stay queued until that session becomes active again.
+// Empty parentSession preserves the legacy unscoped behavior.
+func (m *Manager) DrainCompletedNoteForSession(parentSession string) string {
 	m.mu.Lock()
-	c := m.completed
-	m.completed = nil
+	var c []string
+	if strings.TrimSpace(parentSession) == "" {
+		for _, item := range m.completed {
+			c = append(c, item.text)
+		}
+		m.completed = nil
+	} else {
+		remaining := m.completed[:0]
+		for _, item := range m.completed {
+			if item.sessionID == parentSession {
+				c = append(c, item.text)
+			} else {
+				remaining = append(remaining, item)
+			}
+		}
+		m.completed = remaining
+	}
 	m.mu.Unlock()
 	if len(c) == 0 {
 		return ""
 	}
 	return "Background jobs finished since your last message: " + strings.Join(c, "; ") +
 		". Read their output with bash_output or wait if you still need it."
+}
+
+// SetActiveSession controls which session receives lifecycle notices for jobs
+// that finish asynchronously. Empty active session preserves legacy behavior.
+func (m *Manager) SetActiveSession(parentSession string) {
+	m.mu.Lock()
+	m.active = strings.TrimSpace(parentSession)
+	m.mu.Unlock()
+}
+
+// DestroySession marks a parent session as being removed from active use and
+// cancels its running jobs. The returned channels close when each cancelled job
+// has fully unwound.
+func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession == "" {
+		return nil
+	}
+	var cancels []context.CancelFunc
+	var done []<-chan struct{}
+	m.mu.Lock()
+	m.destroying[parentSession] = true
+	remaining := m.completed[:0]
+	for _, item := range m.completed {
+		if item.sessionID != parentSession {
+			remaining = append(remaining, item)
+		}
+	}
+	m.completed = remaining
+	for _, id := range m.order {
+		j := m.jobs[id]
+		if !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
+		j.mu.Lock()
+		if j.status == Running {
+			j.status = Killed
+			cancels = append(cancels, j.cancel)
+			done = append(done, j.done)
+		}
+		j.mu.Unlock()
+	}
+	m.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+	return done
+}
+
+// IsDestroying reports whether parentSession is in the destroy window. Empty
+// parent sessions are never considered destroyed.
+func (m *Manager) IsDestroying(parentSession string) bool {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession == "" {
+		return false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.destroying[parentSession]
+}
+
+// FinishDestroySession ends the destroy window after all owned jobs have unwound
+// and persistent cleanup/move work has completed.
+func (m *Manager) FinishDestroySession(parentSession string) {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.destroying, parentSession)
+	m.mu.Unlock()
 }
 
 // Close cancels the session context and waits for every background job goroutine
@@ -350,9 +501,24 @@ func startedText(kind, id, label string) string {
 	return fmt.Sprintf("background %s started: %s", kind, id)
 }
 
+func (m *Manager) emitIfActive(parentSession string, ev event.Event) {
+	m.mu.Lock()
+	active := m.active
+	m.mu.Unlock()
+	if active == "" || strings.TrimSpace(parentSession) == "" || active == strings.TrimSpace(parentSession) {
+		m.sink.Emit(ev)
+	}
+}
+
+func sessionMatches(filter, jobSession string) bool {
+	filter = strings.TrimSpace(filter)
+	return filter == "" || strings.TrimSpace(jobSession) == filter
+}
+
 // --- call-context injection (mirrors agent.CallContext) ---
 
 type ctxKey struct{}
+type sessionCtxKey struct{}
 
 // WithManager stamps ctx with the job manager so tools can reach it via
 // FromContext. The agent sets this on every tool call's context.
@@ -365,4 +531,17 @@ func WithManager(ctx context.Context, m *Manager) context.Context {
 func FromContext(ctx context.Context) (*Manager, bool) {
 	m, ok := ctx.Value(ctxKey{}).(*Manager)
 	return m, ok && m != nil
+}
+
+// WithSession stamps ctx with the active parent session ID for session-scoped job
+// operations.
+func WithSession(ctx context.Context, parentSession string) context.Context {
+	return context.WithValue(ctx, sessionCtxKey{}, strings.TrimSpace(parentSession))
+}
+
+// SessionFromContext returns the active parent session ID for job ownership and
+// filtering. Empty means no session scope is available.
+func SessionFromContext(ctx context.Context) string {
+	session, _ := ctx.Value(sessionCtxKey{}).(string)
+	return strings.TrimSpace(session)
 }

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -4,11 +4,33 @@ import (
 	"context"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"reasonix/internal/event"
 )
+
+type recordingSink struct {
+	mu     sync.Mutex
+	events []event.Event
+}
+
+func (s *recordingSink) Emit(ev event.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, ev)
+}
+
+func (s *recordingSink) texts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.events))
+	for _, ev := range s.events {
+		out = append(out, ev.Text)
+	}
+	return out
+}
 
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
@@ -166,4 +188,126 @@ func TestRunning(t *testing.T) {
 	close(release)
 	m.Wait(context.Background(), []string{j.ID}, 5)
 	waitFor(t, func() bool { return len(m.Running()) == 0 })
+}
+
+func TestSessionScopedOperations(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	a := m.StartForSession("session-a", "bash", "a", func(_ context.Context, out io.Writer) (string, error) {
+		io.WriteString(out, "from-a\n")
+		<-releaseA
+		return "", nil
+	})
+	b := m.StartForSession("session-b", "bash", "b", func(_ context.Context, out io.Writer) (string, error) {
+		io.WriteString(out, "from-b\n")
+		<-releaseB
+		return "", nil
+	})
+
+	waitFor(t, func() bool {
+		txt, _, ok := m.OutputForSession("session-a", a.ID)
+		return ok && strings.Contains(txt, "from-a")
+	})
+	if _, _, ok := m.OutputForSession("session-a", b.ID); ok {
+		t.Fatal("session-a should not read session-b output")
+	}
+	if got := m.RunningForSession("session-a"); len(got) != 1 || got[0].ID != a.ID {
+		t.Fatalf("session-a running = %+v, want only %s", got, a.ID)
+	}
+	if got := m.WaitForSession(context.Background(), "session-a", []string{b.ID}, 1); len(got) != 0 {
+		t.Fatalf("session-a wait on session-b job = %+v, want none", got)
+	}
+	if m.KillForSession("session-a", b.ID) {
+		t.Fatal("session-a should not kill session-b job")
+	}
+
+	close(releaseA)
+	res := m.WaitForSession(context.Background(), "session-a", []string{a.ID}, 5)
+	if len(res) != 1 || res[0].ID != a.ID || res[0].Status != Done {
+		t.Fatalf("session-a wait all = %+v, want only done %s", res, a.ID)
+	}
+	if note := m.DrainCompletedNoteForSession("session-b"); note != "" {
+		t.Fatalf("session-b drain before completion = %q, want empty", note)
+	}
+	if note := m.DrainCompletedNoteForSession("session-a"); !strings.Contains(note, a.ID) {
+		t.Fatalf("session-a drain = %q, want %s", note, a.ID)
+	}
+
+	close(releaseB)
+	m.WaitForSession(context.Background(), "session-b", []string{b.ID}, 5)
+	if note := m.DrainCompletedNoteForSession("session-b"); !strings.Contains(note, b.ID) {
+		t.Fatalf("session-b drain = %q, want %s", note, b.ID)
+	}
+}
+
+func TestSessionScopedNoticesUseActiveSession(t *testing.T) {
+	sink := &recordingSink{}
+	m := NewManager(sink)
+	defer m.Close()
+	m.SetActiveSession("session-a")
+
+	releaseA := make(chan struct{})
+	releaseB := make(chan struct{})
+	a := m.StartForSession("session-a", "bash", "a", func(_ context.Context, _ io.Writer) (string, error) {
+		<-releaseA
+		return "", nil
+	})
+	b := m.StartForSession("session-b", "bash", "b", func(_ context.Context, _ io.Writer) (string, error) {
+		<-releaseB
+		return "", nil
+	})
+	close(releaseB)
+	m.Wait(context.Background(), []string{b.ID}, 5)
+	for _, text := range sink.texts() {
+		if strings.Contains(text, b.ID) {
+			t.Fatalf("inactive session job notice leaked: %q", text)
+		}
+	}
+
+	close(releaseA)
+	m.Wait(context.Background(), []string{a.ID}, 5)
+	waitFor(t, func() bool {
+		for _, text := range sink.texts() {
+			if strings.Contains(text, a.ID) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestDestroySessionCancelsOwnedJobsAndSuppressesCompletion(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	started := make(chan struct{})
+	j := m.StartForSession("session-a", "task", "cleanup", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	<-started
+
+	done := m.DestroySession("session-a")
+	if len(done) != 1 {
+		t.Fatalf("DestroySession returned %d done channels, want 1", len(done))
+	}
+	if !m.IsDestroying("session-a") {
+		t.Fatal("session-a should be marked destroying")
+	}
+	<-done[0]
+	res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5)
+	if len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("destroyed job result = %+v, want killed", res)
+	}
+	if note := m.DrainCompletedNoteForSession("session-a"); note != "" {
+		t.Fatalf("destroyed session should not queue completion note, got %q", note)
+	}
+	m.FinishDestroySession("session-a")
+	if m.IsDestroying("session-a") {
+		t.Fatal("session-a should no longer be marked destroying")
+	}
 }

--- a/internal/memory/memory.go
+++ b/internal/memory/memory.go
@@ -142,7 +142,13 @@ func (s *Set) Block() string {
 			"Read the linked file with read_file when one looks relevant, and before acting on one that names a file, function, or flag, verify it still exists. " +
 			"Save new durable facts with the `remember` tool; delete ones that turn out wrong with `forget`.\n\n")
 		b.WriteString(idx)
-		fmt.Fprintf(&b, "\n\n(stored under %s)\n", s.Store.Dir)
+		var dirs []string
+		for _, d := range s.Store.dirs() {
+			if d != "" {
+				dirs = append(dirs, d)
+			}
+		}
+		fmt.Fprintf(&b, "\n\n(stored under %s)\n", strings.Join(dirs, " and "))
 	}
 	return b.String()
 }

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -18,8 +18,13 @@ import (
 // cached system-prompt prefix at boot so the model always knows what it has
 // saved, and reads individual facts on demand with read_file. The whole thing is
 // plain files the user can edit by hand.
+//
+// Memories of type "user" and "feedback" are routed to GlobalDir (shared across
+// all projects), while "project" and "reference" stay in the project-specific Dir.
+// List() and Index() merge both directories so every session sees the full set.
 type Store struct {
-	Dir string // ...reasonix/projects/<slug>/memory
+	Dir       string // ...reasonix/projects/<slug>/memory
+	GlobalDir string // ...reasonix/memory/global (shared across projects)
 }
 
 // Type classifies a memory, mirroring the auto-memory taxonomy.
@@ -71,7 +76,21 @@ func StoreFor(userDir, cwd string) Store {
 	if userDir == "" {
 		return Store{}
 	}
-	return Store{Dir: filepath.Join(userDir, "projects", slugify(absOf(cwd)), "memory")}
+	return Store{
+		Dir:       filepath.Join(userDir, "projects", slugify(absOf(cwd)), "memory"),
+		GlobalDir: filepath.Join(userDir, "memory", "global"),
+	}
+}
+
+// DirFor returns the directory a memory of the given type should be stored in.
+// TypeUser and TypeFeedback go to GlobalDir (shared across all projects);
+// everything else goes to the project-specific Dir. When GlobalDir is empty,
+// all types fall back to Dir.
+func (s Store) DirFor(t Type) string {
+	if s.GlobalDir != "" && (t == TypeUser || t == TypeFeedback) {
+		return s.GlobalDir
+	}
+	return s.Dir
 }
 
 // indexFile is the human-readable index of saved memories.
@@ -85,23 +104,75 @@ func slugify(absPath string) string {
 	return r.Replace(absPath)
 }
 
+// dirs returns the directories to read from, in order: GlobalDir first (shared
+// memories), then Dir (project-specific).
+func (s Store) dirs() []string {
+	if s.GlobalDir != "" && s.GlobalDir != s.Dir {
+		return []string{s.GlobalDir, s.Dir}
+	}
+	return []string{s.Dir}
+}
+
 // Index returns the MEMORY.md contents (the per-line index of saved memories),
 // or "" if there are none yet. This is what loads into the cached prefix.
+// When both GlobalDir and Dir have indexes, they are merged with deduplication
+// (global first).
 func (s Store) Index() string {
-	if s.Dir == "" {
+	managed := map[string]string{}
+	for _, dir := range s.dirs() {
+		if dir == "" {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, indexFile))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(b), "\n") {
+			if mt := indexLineRe.FindStringSubmatch(line); mt != nil {
+				if _, exists := managed[mt[1]]; !exists {
+					managed[mt[1]] = strings.TrimRight(line, "\r")
+				}
+			}
+		}
+	}
+	if len(managed) == 0 {
 		return ""
 	}
-	b, err := os.ReadFile(filepath.Join(s.Dir, indexFile))
-	if err != nil {
-		return ""
+	names := make([]string, 0, len(managed))
+	for n := range managed {
+		names = append(names, n)
 	}
-	return strings.TrimSpace(string(b))
+	sort.Strings(names)
+	var b strings.Builder
+	for _, n := range names {
+		b.WriteString(managed[n])
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 // Path returns the absolute file path a memory with the given name lives at.
+// It checks GlobalDir first, then Dir, returning the first match. If no file
+// exists yet, it returns the path in Dir (the default for project types).
 func (s Store) Path(name string) string {
-	path, _ := safeJoin(s.Dir, slug(name)+".md")
-	return path
+	stem := slug(name) + ".md"
+	for _, dir := range s.dirs() {
+		if dir == "" {
+			continue
+		}
+		p, err := safeJoin(dir, stem)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	p, sjErr := safeJoin(s.Dir, stem)
+	if sjErr != nil {
+		return ""
+	}
+	return p
 }
 
 // Save writes (or overwrites) a memory file and refreshes its MEMORY.md index
@@ -109,21 +180,25 @@ func (s Store) Path(name string) string {
 // editor, and any future importer all go through here so the index never drifts
 // from the files. Returns the path written.
 func (s Store) Save(m Memory) (string, error) {
-	if s.Dir == "" {
+	dir := s.DirFor(m.Type)
+	if dir == "" {
 		return "", fmt.Errorf("memory store unavailable (no user config dir)")
 	}
 	name := slug(m.Name)
 	if name == "" {
 		return "", fmt.Errorf("memory needs a name")
 	}
-	if err := os.MkdirAll(s.Dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", err
 	}
-	path := filepath.Join(s.Dir, name+".md")
+	path, err := safeJoin(dir, name+".md")
+	if err != nil {
+		return "", err
+	}
 	if err := os.WriteFile(path, []byte(render(m, name)), 0o644); err != nil {
 		return "", err
 	}
-	if err := s.reindex(name, m); err != nil {
+	if err := reindexIn(dir, name, m); err != nil {
 		return path, err
 	}
 	return path, nil
@@ -133,19 +208,33 @@ func (s Store) Save(m Memory) (string, error) {
 // .archive/ for traceability. A missing file is not an error; the goal state
 // (not active) already holds. It returns the archive path, or "" when no file
 // existed to archive.
+// When both GlobalDir and Dir exist, it archives from every directory the
+// memory appears in (handles migration duplicates).
 func (s Store) Archive(name string) (string, error) {
-	if s.Dir == "" {
+	if s.Dir == "" && s.GlobalDir == "" {
 		return "", fmt.Errorf("memory store unavailable (no user config dir)")
 	}
 	name = slug(name)
 	if name == "" {
 		return "", fmt.Errorf("memory needs a name")
 	}
-	path, err := s.archiveMemoryFile(name)
-	if err != nil {
-		return "", err
+	var lastPath string
+	for _, dir := range s.dirs() {
+		if dir == "" {
+			continue
+		}
+		p, err := archiveInDir(dir, name)
+		if err != nil {
+			return "", err
+		}
+		if p != "" {
+			if err := flushIndexIn(dir, indexLinesExceptIn(dir, name)); err != nil {
+				return "", err
+			}
+			lastPath = p
+		}
 	}
-	return path, s.flushIndex(s.indexLinesExcept(name))
+	return lastPath, nil
 }
 
 // Delete removes a memory from the active store and its MEMORY.md line — the
@@ -158,11 +247,8 @@ func (s Store) Delete(name string) error {
 	return err
 }
 
-func (s Store) archiveMemoryFile(name string) (string, error) {
-	if s.Dir == "" {
-		return "", fmt.Errorf("memory store unavailable (no user config dir)")
-	}
-	root, err := os.OpenRoot(s.Dir)
+func archiveInDir(dir, name string) (string, error) {
+	root, err := os.OpenRoot(dir)
 	if os.IsNotExist(err) {
 		return "", nil
 	}
@@ -188,7 +274,7 @@ func (s Store) archiveMemoryFile(name string) (string, error) {
 	if err := renameMemoryFile(root, file, dest); err != nil {
 		return "", err
 	}
-	out, err := safeJoin(s.Dir, dest)
+	out, err := safeJoin(dir, dest)
 	if err != nil {
 		return "", err
 	}
@@ -293,10 +379,10 @@ func render(m Memory, name string) string {
 // MEMORY.md.
 var indexLineRe = regexp.MustCompile(`\]\(([^)]+)\.md\)`)
 
-// indexLinesExcept returns the managed MEMORY.md lines keyed by filename stem,
-// dropping the entry for name (a missing index → empty map).
-func (s Store) indexLinesExcept(name string) map[string]string {
-	existing, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+// indexLinesExceptIn returns the managed MEMORY.md lines keyed by filename stem
+// in the given directory, dropping the entry for name (a missing index → empty map).
+func indexLinesExceptIn(dir, name string) map[string]string {
+	existing, _ := os.ReadFile(filepath.Join(dir, indexFile))
 	keep := map[string]string{}
 	for _, line := range strings.Split(string(existing), "\n") {
 		if mt := indexLineRe.FindStringSubmatch(line); mt != nil && mt[1] != name {
@@ -306,8 +392,9 @@ func (s Store) indexLinesExcept(name string) map[string]string {
 	return keep
 }
 
-// flushIndex rewrites MEMORY.md from the managed lines, sorted by filename.
-func (s Store) flushIndex(lines map[string]string) error {
+// flushIndexIn rewrites MEMORY.md in the given directory from the managed lines,
+// sorted by filename.
+func flushIndexIn(dir string, lines map[string]string) error {
 	names := make([]string, 0, len(lines))
 	for n := range lines {
 		names = append(names, n)
@@ -320,36 +407,45 @@ func (s Store) flushIndex(lines map[string]string) error {
 		b.WriteString(lines[n])
 		b.WriteString("\n")
 	}
-	return os.WriteFile(filepath.Join(s.Dir, indexFile), []byte(b.String()), 0o644)
+	return os.WriteFile(filepath.Join(dir, indexFile), []byte(b.String()), 0o644)
 }
 
-// reindex rewrites the MEMORY.md line for name, preserving every other managed
-// line. The line is "- [<title>](<name>.md) — <description>"; title falls back
-// to a de-kebabed name so the index reads as a label, never a bare slug.
-func (s Store) reindex(name string, m Memory) error {
-	lines := s.indexLinesExcept(name)
+// reindexIn rewrites the MEMORY.md line for name in the given directory,
+// preserving every other managed line.
+func reindexIn(dir, name string, m Memory) error {
+	lines := indexLinesExceptIn(dir, name)
 	lines[name] = fmt.Sprintf("- [%s](%s.md) — %s", displayTitle(m.Title, name), name, oneLine(m.Description))
-	return s.flushIndex(lines)
+	return flushIndexIn(dir, lines)
 }
 
 // List returns the saved memories parsed from their files, sorted by name. Used
-// by `/memory` and the desktop memory panel. Files that fail to parse are
-// skipped so one bad file never hides the rest.
+// by `/memory` and the desktop memory panel. Reads from both GlobalDir and Dir,
+// merging results. Files that fail to parse are skipped so one bad file never
+// hides the rest.
 func (s Store) List() []Memory {
-	if s.Dir == "" {
-		return nil
-	}
-	entries, err := os.ReadDir(s.Dir)
-	if err != nil {
+	if s.Dir == "" && s.GlobalDir == "" {
 		return nil
 	}
 	var out []Memory
-	for _, e := range entries {
-		if e.IsDir() || e.Name() == indexFile || !strings.HasSuffix(e.Name(), ".md") {
+	seen := map[string]bool{}
+	for _, dir := range s.dirs() {
+		if dir == "" {
 			continue
 		}
-		if m, ok := loadMemory(filepath.Join(s.Dir, e.Name())); ok {
-			out = append(out, m)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || e.Name() == indexFile || !strings.HasSuffix(e.Name(), ".md") {
+				continue
+			}
+			if m, ok := loadMemory(filepath.Join(dir, e.Name())); ok {
+				if !seen[m.Name] {
+					out = append(out, m)
+					seen[m.Name] = true
+				}
+			}
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
@@ -358,33 +454,39 @@ func (s Store) List() []Memory {
 
 // ListArchived returns archived memories parsed from .archive/, newest first.
 // Archived files stay out of List() and the prompt index, so stale facts remain
-// inspectable without being reused as active truth.
+// inspectable without being reused as active truth. Reads from both GlobalDir
+// and Dir.
 func (s Store) ListArchived() []ArchivedMemory {
-	if s.Dir == "" {
-		return nil
-	}
-	dir := filepath.Join(s.Dir, ".archive")
-	entries, err := os.ReadDir(dir)
-	if err != nil {
+	if s.Dir == "" && s.GlobalDir == "" {
 		return nil
 	}
 	var out []ArchivedMemory
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+	for _, base := range s.dirs() {
+		if base == "" {
 			continue
 		}
-		path := filepath.Join(dir, e.Name())
-		m, ok := loadMemory(path)
-		if !ok {
+		dir := filepath.Join(base, ".archive")
+		entries, err := os.ReadDir(dir)
+		if err != nil {
 			continue
 		}
-		when := archiveTimeFromName(e.Name())
-		if when.IsZero() {
-			if info, err := e.Info(); err == nil {
-				when = info.ModTime()
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+				continue
 			}
+			path := filepath.Join(dir, e.Name())
+			m, ok := loadMemory(path)
+			if !ok {
+				continue
+			}
+			when := archiveTimeFromName(e.Name())
+			if when.IsZero() {
+				if info, err := e.Info(); err == nil {
+					when = info.ModTime()
+				}
+			}
+			out = append(out, ArchivedMemory{Memory: m, Path: path, ArchivedAt: when})
 		}
-		out = append(out, ArchivedMemory{Memory: m, Path: path, ArchivedAt: when})
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if !out[i].ArchivedAt.Equal(out[j].ArchivedAt) {

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -315,3 +315,334 @@ func TestDisabledStoreIsNoOp(t *testing.T) {
 		t.Fatal("disabled store Save should error, not silently drop")
 	}
 }
+
+// TestStoreGlobalAndProject verifies that TypeUser/TypeFeedback memories are
+// routed to GlobalDir, TypeProject/TypeReference stay in Dir, List() merges
+// both, and Delete() removes from the correct directory.
+func TestStoreGlobalAndProject(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// TypeUser → GlobalDir
+	pUser, err := s.Save(Memory{Name: "prefers-tabs", Description: "user pref", Type: TypeUser, Body: "use tabs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pUser, s.GlobalDir) {
+		t.Fatalf("TypeUser should go to GlobalDir, got %s", pUser)
+	}
+
+	// TypeProject → Dir
+	pProj, err := s.Save(Memory{Name: "build-target", Description: "build target", Type: TypeProject, Body: "go build"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pProj, s.Dir) {
+		t.Fatalf("TypeProject should go to Dir, got %s", pProj)
+	}
+
+	// TypeFeedback → GlobalDir
+	pFb, err := s.Save(Memory{Name: "no-emoji", Description: "no emoji", Type: TypeFeedback, Body: "skip emoji"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pFb, s.GlobalDir) {
+		t.Fatalf("TypeFeedback should go to GlobalDir, got %s", pFb)
+	}
+
+	// TypeReference → Dir
+	pRef, err := s.Save(Memory{Name: "api-docs", Description: "api docs", Type: TypeReference, Body: "see docs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(pRef, s.Dir) {
+		t.Fatalf("TypeReference should go to Dir, got %s", pRef)
+	}
+
+	// List merges both directories
+	list := s.List()
+	if len(list) != 4 {
+		t.Fatalf("want 4 memories, got %d", len(list))
+	}
+
+	// Index merges both directories
+	idx := s.Index()
+	if !strings.Contains(idx, "prefers-tabs") || !strings.Contains(idx, "build-target") {
+		t.Fatalf("index should contain both global and project memories:\n%s", idx)
+	}
+
+	// Delete removes from the correct directory
+	if err := s.Delete("prefers-tabs"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(pUser); !os.IsNotExist(err) {
+		t.Fatal("global memory file should be gone after delete")
+	}
+
+	// List after delete
+	list2 := s.List()
+	if len(list2) != 3 {
+		t.Fatalf("want 3 memories after delete, got %d", len(list2))
+	}
+
+	// Index should not duplicate # Memory headers (Block() adds its own).
+	idx2 := s.Index()
+	if strings.Count(idx2, "# Memory") != 0 {
+		t.Fatalf("Index should have 0 # Memory headers (Block() adds one), got %d:\n%s", strings.Count(idx2, "# Memory"), idx2)
+	}
+}
+
+// TestStoreForInitializesGlobalDir ensures StoreFor sets GlobalDir alongside Dir.
+func TestStoreForInitializesGlobalDir(t *testing.T) {
+	s := StoreFor("/home/me/.config/reasonix", "/Users/me/proj")
+	if s.GlobalDir == "" {
+		t.Fatal("StoreFor should set GlobalDir")
+	}
+	if !strings.Contains(s.GlobalDir, "memory") || !strings.Contains(s.GlobalDir, "global") {
+		t.Fatalf("unexpected GlobalDir: %s", s.GlobalDir)
+	}
+	if s.GlobalDir == s.Dir {
+		t.Fatal("GlobalDir and Dir should be different paths")
+	}
+}
+
+// TestDirForRoutesCorrectly verifies DirFor routes user/feedback to GlobalDir
+// and everything else to Dir.
+func TestDirForRoutesCorrectly(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+	if got := s.DirFor(TypeUser); got != s.GlobalDir {
+		t.Errorf("TypeUser: got %q, want %q", got, s.GlobalDir)
+	}
+	if got := s.DirFor(TypeFeedback); got != s.GlobalDir {
+		t.Errorf("TypeFeedback: got %q, want %q", got, s.GlobalDir)
+	}
+	if got := s.DirFor(TypeProject); got != s.Dir {
+		t.Errorf("TypeProject: got %q, want %q", got, s.Dir)
+	}
+	if got := s.DirFor(TypeReference); got != s.Dir {
+		t.Errorf("TypeReference: got %q, want %q", got, s.Dir)
+	}
+}
+
+// TestDirForFallsBackWhenNoGlobalDir ensures DirFor falls back to Dir when
+// GlobalDir is empty.
+func TestDirForFallsBackWhenNoGlobalDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{Dir: filepath.Join(dir, "memory")}
+	if got := s.DirFor(TypeUser); got != s.Dir {
+		t.Errorf("TypeUser without GlobalDir should fall back to Dir, got %q", got)
+	}
+}
+
+// TestStoreDeleteRemovesFromAllDirs verifies that after a type-routing migration
+// (same name in both GlobalDir and Dir), Delete removes both copies so the
+// memory truly disappears.
+func TestStoreDeleteRemovesFromAllDirs(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// Simulate migration: write a TypeUser memory directly into both dirs.
+	name := "prefers-tabs"
+	for _, d := range []string{s.Dir, s.GlobalDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := Memory{Name: name, Description: "user pref", Type: TypeUser, Body: "use tabs"}
+		if err := os.WriteFile(filepath.Join(d, name+".md"), []byte(render(m, name)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := reindexIn(d, name, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Both copies should appear, but deduplicated.
+	list := s.List()
+	if len(list) != 1 {
+		t.Fatalf("want 1 deduplicated memory, got %d", len(list))
+	}
+
+	// Delete should remove from BOTH directories.
+	if err := s.Delete(name); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(s.GlobalDir, name+".md")); !os.IsNotExist(err) {
+		t.Fatal("global copy should be gone after delete")
+	}
+	if _, err := os.Stat(filepath.Join(s.Dir, name+".md")); !os.IsNotExist(err) {
+		t.Fatal("project copy should be gone after delete")
+	}
+
+	list2 := s.List()
+	if len(list2) != 0 {
+		t.Fatalf("want 0 memories after delete, got %d", len(list2))
+	}
+	if idx := s.Index(); idx != "" {
+		t.Fatalf("Index() should be empty after deleting all entries, got:\n%s", idx)
+	}
+}
+
+// TestStoreIndexDeduplicatesAcrossDirs verifies Index() does not emit duplicate
+// lines when the same memory name exists in both GlobalDir and Dir.
+func TestStoreIndexDeduplicatesAcrossDirs(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// Write the same memory into both dirs (migration scenario).
+	name := "prefers-tabs"
+	for _, d := range []string{s.GlobalDir, s.Dir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := Memory{Name: name, Description: "user pref", Type: TypeUser, Body: "use tabs"}
+		if err := os.WriteFile(filepath.Join(d, name+".md"), []byte(render(m, name)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := reindexIn(d, name, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	idx := s.Index()
+	count := strings.Count(idx, name+".md")
+	if count != 1 {
+		t.Fatalf("want exactly 1 index line for %s, got %d:\n%s", name, count, idx)
+	}
+	if strings.Count(idx, "# Memory") != 0 {
+		t.Fatalf("merged index should have 0 # Memory headers (Block() adds one), got %d:\n%s", strings.Count(idx, "# Memory"), idx)
+	}
+}
+
+// TestStoreSaveVerifiesIndexDir verifies that Save writes the MEMORY.md
+// index to the correct directory for the memory type.
+func TestStoreSaveVerifiesIndexDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// TypeUser → GlobalDir
+	if _, err := s.Save(Memory{Name: "user-pref", Description: "d", Type: TypeUser, Body: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	gb, _ := os.ReadFile(filepath.Join(s.GlobalDir, indexFile))
+	pb, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+	if !strings.Contains(string(gb), "user-pref") {
+		t.Fatal("GlobalDir MEMORY.md should contain user-pref")
+	}
+	if strings.Contains(string(pb), "user-pref") {
+		t.Fatal("Dir MEMORY.md should NOT contain user-pref (it went to GlobalDir)")
+	}
+
+	// TypeProject → Dir
+	if _, err := s.Save(Memory{Name: "build-cmd", Description: "d", Type: TypeProject, Body: "b"}); err != nil {
+		t.Fatal(err)
+	}
+	pb2, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+	if !strings.Contains(string(pb2), "build-cmd") {
+		t.Fatal("Dir MEMORY.md should contain build-cmd")
+	}
+	gb2, _ := os.ReadFile(filepath.Join(s.GlobalDir, indexFile))
+	if strings.Contains(string(gb2), "build-cmd") {
+		t.Fatal("GlobalDir MEMORY.md should NOT contain build-cmd (it went to Dir)")
+	}
+}
+
+// TestStoreDeleteFlushesIndexPerDir verifies that Delete calls flushIndexIn
+// for each directory where the memory file existed.
+func TestStoreDeleteFlushesIndexPerDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// Write to both dirs manually (migration scenario).
+	name := "prefers-tabs"
+	for _, d := range []string{s.GlobalDir, s.Dir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		m := Memory{Name: name, Description: "d", Type: TypeUser, Body: "b"}
+		if err := os.WriteFile(filepath.Join(d, name+".md"), []byte(render(m, name)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := reindexIn(d, name, m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.Delete(name); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify both MEMORY.md files have the entry removed.
+	gb, _ := os.ReadFile(filepath.Join(s.GlobalDir, indexFile))
+	pb, _ := os.ReadFile(filepath.Join(s.Dir, indexFile))
+	if strings.Contains(string(gb), name+".md") {
+		t.Fatalf("GlobalDir MEMORY.md should not reference %s after delete:\n%s", name, gb)
+	}
+	if strings.Contains(string(pb), name+".md") {
+		t.Fatalf("Dir MEMORY.md should not reference %s after delete:\n%s", name, pb)
+	}
+
+	// Index() should return "" (no entries, no orphaned header).
+	idx := s.Index()
+	if idx != "" {
+		t.Fatalf("Index() should return empty after deleting all entries, got:\n%s", idx)
+	}
+}
+
+// TestStorePathWithGlobalDir verifies Path() checks GlobalDir first and
+// falls back to Dir for new files.
+func TestStorePathWithGlobalDir(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	// No files yet → defaults to Dir.
+	p := s.Path("new-fact")
+	if !strings.HasPrefix(p, s.Dir) {
+		t.Fatalf("Path for new file should default to Dir, got %s", p)
+	}
+
+	// Write a file to GlobalDir.
+	if err := os.MkdirAll(s.GlobalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(s.GlobalDir, "existing.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p2 := s.Path("existing")
+	if !strings.HasPrefix(p2, s.GlobalDir) {
+		t.Fatalf("Path for file in GlobalDir should return GlobalDir path, got %s", p2)
+	}
+
+	// Write a file to Dir (not GlobalDir).
+	if err := os.MkdirAll(s.Dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(s.Dir, "proj-fact.md"), []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p3 := s.Path("proj-fact")
+	if !strings.HasPrefix(p3, s.Dir) {
+		t.Fatalf("Path for file only in Dir should return Dir path, got %s", p3)
+	}
+}

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -921,15 +921,28 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "cannot delete active session", http.StatusConflict)
 		return
 	}
+	destroy := s.ctl().BeginDestroySession(abs)
 	if err := os.Remove(abs); err != nil {
+		go finishSessionDestroy(destroy)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	if err := agent.DeleteSubagentsByParent(dir, agent.BranchID(abs)); err != nil {
+		go finishSessionDestroy(destroy)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	go finishSessionDestroy(destroy)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func finishSessionDestroy(destroy control.SessionDestroyHandle) {
+	if destroy.Wait != nil {
+		destroy.Wait()
+	}
+	if destroy.Finish != nil {
+		destroy.Finish()
+	}
 }
 
 // sessionTitle returns a title for a session: the cached flash-generated title

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -145,7 +145,7 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		workDir := b.workDir
 		// The job runs under the manager's session context (no foreground timeout), so it
 		// survives this turn; its combined output streams to the job buffer.
-		job := jm.Start("bash", commandPreview(p.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
+		job := jm.StartForSession(jobs.SessionFromContext(ctx), "bash", commandPreview(p.Command), func(jobCtx context.Context, out io.Writer) (string, error) {
 			cmd := exec.CommandContext(jobCtx, argv[0], argv[1:]...)
 			cmd.Dir = workDir
 			cmd.Env = cmdEnv

--- a/internal/tool/builtin/bgjobs.go
+++ b/internal/tool/builtin/bgjobs.go
@@ -55,7 +55,7 @@ func (bashOutput) Execute(ctx context.Context, args json.RawMessage) (string, er
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
 	}
-	text, status, found := jm.Output(p.JobID)
+	text, status, found := jm.OutputForSession(jobs.SessionFromContext(ctx), p.JobID)
 	if !found {
 		return "", fmt.Errorf("no background job %q", p.JobID)
 	}
@@ -118,7 +118,7 @@ func (killShell) Execute(ctx context.Context, args json.RawMessage) (string, err
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
 	}
-	if jm.Kill(p.JobID) {
+	if jm.KillForSession(jobs.SessionFromContext(ctx), p.JobID) {
 		return fmt.Sprintf("Killed background job %q.", p.JobID), nil
 	}
 	return fmt.Sprintf("Background job %q was not running (already finished or unknown).", p.JobID), nil
@@ -154,7 +154,7 @@ func (waitJob) Execute(ctx context.Context, args json.RawMessage) (string, error
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
 	}
-	results := jm.Wait(ctx, p.JobIDs, p.TimeoutSeconds)
+	results := jm.WaitForSession(ctx, jobs.SessionFromContext(ctx), p.JobIDs, p.TimeoutSeconds)
 	if len(results) == 0 {
 		return "No background jobs to wait for.", nil
 	}


### PR DESCRIPTION
## Summary

This maintainer integration PR uses #4215 as the foundation and folds in compatible state-routing fixes from #4073 and #3935.

The combined change keeps session-owned runtime state aligned across Desktop and controller paths:

- Scope subagent transcripts and background jobs to the owning parent session.
- Prevent background job output, lifecycle notices, completion notes, and kill/wait/output operations from crossing session boundaries.
- Cancel and suppress late writeback when a session is cleared, deleted, or moved to trash.
- Route memory storage and the Desktop memory panel through the correct global/workspace scope.
- Preserve approved plan execution across pause/resume while coexisting with the session-scoped controller lifecycle.

## Credits / Attribution

This integration PR builds on prior contributor work:

- #4215 by @lifu963: session-scoped `SubagentStore`, background job ownership, session destroy cleanup, Desktop restore guarding, and late writeback prevention. Incorporated as the foundation of this PR.
- #4073 by @ashishexee: GlobalDir routing and tab-aware memory panel behavior. Incorporated the parts that align memory storage and display with per-workspace/per-tab state isolation.
- #3935 by @AresNing: preserving approved plan execution across pause/resume. Incorporated after reconciling it with the session-scoped controller lifecycle.

Not included in this integration PR:

- #4180 by @myipanta: embedded terminal panel. Left as a separate feature PR because it is not required for the session ownership fix.
- #3695 by @taibai233: Guardian subagent. Left separate because it currently has requested changes and conflicts with controller/rendering changes.

## Verification

- `gofmt -l $(git diff --name-only origin/main-v2...HEAD -- '*.go')` produced no output
- `git diff --check origin/main-v2...HEAD` passed
- `go test ./internal/jobs ./internal/control ./internal/agent ./internal/boot ./internal/tool/builtin ./internal/memory` passed
- `go test ./...` passed
- `go test ./...` in `desktop/` passed
- `go vet ./...` passed
- `go vet ./...` in `desktop/` passed
- `pnpm --dir desktop/frontend check:css` passed
- `pnpm --dir desktop/frontend typecheck` passed after generating Wails bindings with Wails 2.12.0
- `pnpm --dir desktop/frontend build` passed after generating Wails bindings with Wails 2.12.0
