### PR TITLE
fix(sandbox): stop creating an undeletable "nul" file from cmd-style redirects

### DIFF
--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -188,6 +189,23 @@ func windowsBashCandidates() []string {
 	return out
 }
 
+// nulRedirect matches a cmd.exe-style redirect to the "nul" device (>nul,
+// 2>nul, 1>>nul, &>nul …) where nul is a complete token. bash and PowerShell
+// treat "nul" as an ordinary filename, not the null device, so the redirect
+// would create an undeletable file named "nul" (a Windows reserved name) in the
+// working directory. #4252. Group 2 captures the trailing delimiter (RE2 has no
+// lookahead) so it can be re-emitted unchanged.
+var nulRedirect = regexp.MustCompile(`(?i)((?:\d+|&)?>>?)\s*nul([\s;&|<>)]|$)`)
+
+// normalizeNulRedirect rewrites those nul redirects to sink ("/dev/null" for
+// bash, "$null" for PowerShell), so the command discards output as intended.
+func normalizeNulRedirect(command, sink string) string {
+	return nulRedirect.ReplaceAllStringFunc(command, func(m string) string {
+		sub := nulRedirect.FindStringSubmatch(m)
+		return sub[1] + sink + sub[2]
+	})
+}
+
 // argv builds the exec argv that runs command under this shell.
 func (s Shell) argv(command string) []string {
 	path := s.Path
@@ -195,9 +213,9 @@ func (s Shell) argv(command string) []string {
 		path = s.Kind.String()
 	}
 	if s.Kind == ShellPowerShell {
-		return []string{path, "-NoProfile", "-NonInteractive", "-Command", psUTF8Prologue + command}
+		return []string{path, "-NoProfile", "-NonInteractive", "-Command", psUTF8Prologue + normalizeNulRedirect(command, "$null")}
 	}
-	return []string{path, "-c", command}
+	return []string{path, "-c", normalizeNulRedirect(command, "/dev/null")}
 }
 
 // SupportsChaining reports whether the shell parses '&&' / '||'. bash does;

--- a/internal/sandbox/shell_nul_test.go
+++ b/internal/sandbox/shell_nul_test.go
@@ -1,0 +1,42 @@
+package sandbox
+
+import "testing"
+
+func TestNormalizeNulRedirect(t *testing.T) {
+	const bash = "/dev/null"
+	cases := []struct {
+		in, sink, want string
+	}{
+		{"echo hi 2>nul", bash, "echo hi 2>/dev/null"},
+		{"echo hi 2>nul", "$null", "echo hi 2>$null"},
+		{"build >nul 2>&1", bash, "build >/dev/null 2>&1"},
+		{"a 2>nul; b", bash, "a 2>/dev/null; b"},
+		{"go test 1>>NUL", bash, "go test 1>>/dev/null"},
+		{"x > nul", bash, "x >/dev/null"},
+		{"x >nul", "$null", "x >$null"},
+		{"probe &>nul", bash, "probe &>/dev/null"},
+		// Not a nul redirect — leave untouched.
+		{"echo nul", bash, "echo nul"},
+		{"grep nul file.txt", bash, "grep nul file.txt"},
+		{"cat nul.txt", bash, "cat nul.txt"},
+		{"run 2>&1", bash, "run 2>&1"},
+		{"rm nul", bash, "rm nul"},
+		{"echo nullish", bash, "echo nullish"},
+	}
+	for _, c := range cases {
+		if got := normalizeNulRedirect(c.in, c.sink); got != c.want {
+			t.Errorf("normalizeNulRedirect(%q, %q) = %q, want %q", c.in, c.sink, got, c.want)
+		}
+	}
+}
+
+func TestArgvNormalizesNulRedirect(t *testing.T) {
+	bashArgv := Shell{Kind: ShellBash, Path: "bash"}.argv("echo hi 2>nul")
+	if last := bashArgv[len(bashArgv)-1]; last != "echo hi 2>/dev/null" {
+		t.Errorf("bash argv command = %q, want nul rewritten to /dev/null", last)
+	}
+	psArgv := Shell{Kind: ShellPowerShell, Path: "powershell"}.argv("echo hi 2>nul")
+	if last := psArgv[len(psArgv)-1]; last != psUTF8Prologue+"echo hi 2>$null" {
+		t.Errorf("powershell argv command = %q, want nul rewritten to $null", last)
+	}
+}


### PR DESCRIPTION
Closes #4252

## Problem
On Windows, an undeletable file named `nul` keeps appearing in the workspace root. It can't be removed by Explorer or `cmd` (reserved device name) — only `rm` from git bash works — and it breaks builds and `git` operations.

## Root cause
The model frequently appends the Windows cmd idiom `2>nul` / `>nul` to discard output. reasonix runs shell commands under **bash** or **PowerShell**, never `cmd.exe`. Only `cmd.exe` treats `nul` as the null device — bash and PowerShell treat it as an ordinary filename, so `2>nul` literally creates a file called `nul` in the cwd (the workspace root).

Reproduced on this box:
```
$ bash -c "echo hi 2>nul"          # → creates ./nul
PS> echo hi > /dev/null                  # → creates ./nul
```

## Fix
Normalize cmd-style `nul` redirects (`>nul`, `2>nul`, `1>>NUL`, `&>nul`, …) to the target shell's real null device — `/dev/null` for bash, `$null` for PowerShell — in `Shell.argv`, the single point every shell invocation funnels through. Non-redirect uses of the word (`echo nul`, `grep nul file`, `cat nul.txt`, `rm nul`) are left untouched (RE2 has no lookahead, so the trailing delimiter is captured and re-emitted).

## Validation
- Unit test `TestNormalizeNulRedirect` (rewrite cases + negatives) and `TestArgvNormalizesNulRedirect`.
- E2E: the rewritten form (`echo hi 2>/dev/null` / `2>$null`) creates **no** `nul` file under bash or PowerShell, whereas the original `2>nul` did.
- `go test ./internal/sandbox/` + `go vet` pass.
