### PR TITLE
fix(migrate): reach .jsonl-only pass for already-routed upgraders

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -949,24 +949,26 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 
 	sessionDir := desktopSessionDir(root)
 	topicID := strings.TrimSpace(tab.TopicID)
-	if tab.Scope == "global" {
-		migratedTopics := migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
-		if len(migratedTopics) > 0 {
-			a.emitProjectTreeChanged()
+
+	// Assign Global topics to legacy sessions in the global session dir so
+	// imported history appears in the project tree regardless of which tab
+	// triggered the build (the migration now sends everything to global).
+	migratedGlobalTopics := migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
+	if len(migratedGlobalTopics) > 0 {
+		a.emitProjectTreeChanged()
+	}
+	if tab.Scope == "global" && topicID == "" && len(migratedGlobalTopics) > 0 {
+		topicID = migratedGlobalTopics[0]
+		topicTitle := topicTitleForTab("global", "", topicID)
+		a.mu.Lock()
+		if strings.TrimSpace(tab.TopicID) == "" {
+			tab.TopicID = topicID
+			tab.TopicTitle = topicTitle
+			a.saveTabsLocked()
+		} else {
+			topicID = strings.TrimSpace(tab.TopicID)
 		}
-		if topicID == "" && len(migratedTopics) > 0 {
-			topicID = migratedTopics[0]
-			topicTitle := topicTitleForTab("global", "", topicID)
-			a.mu.Lock()
-			if strings.TrimSpace(tab.TopicID) == "" {
-				tab.TopicID = topicID
-				tab.TopicTitle = topicTitle
-				a.saveTabsLocked()
-			} else {
-				topicID = strings.TrimSpace(tab.TopicID)
-			}
-			a.mu.Unlock()
-		}
+		a.mu.Unlock()
 	}
 	if topicID != "" {
 		if _, dir := a.findKnownTopicSession(topicID); dir != "" {
@@ -2138,6 +2140,26 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
+	// Determine scope from the directory. The global session dir gets Global
+	// topics; a project session dir gets project-scoped topics under the
+	// matching workspace.
+	scope := "global"
+	workspaceRoot := ""
+	topicTitleRoot := "" // workspace root for topic-title persistence
+	if dir != config.SessionDir() {
+		f := loadProjectsFile()
+		for _, p := range f.Projects {
+			if config.ProjectSessionDir(p.Root) == dir {
+				scope = "project"
+				workspaceRoot = p.Root
+				topicTitleRoot = p.Root
+				break
+			}
+		}
+		if scope != "project" {
+			return nil // not a recognized project dir; skip
+		}
+	}
 	legacyMigrationMu.Lock()
 	defer legacyMigrationMu.Unlock()
 	infos, err := agent.ListSessions(dir)
@@ -2145,8 +2167,8 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		return nil
 	}
 	titles := loadSessionTitles(dir)
-	topicTitles := loadTopicTitles("")
-	topicSources := loadTopicTitleSources("")
+	topicTitles := loadTopicTitles(topicTitleRoot)
+	topicSources := loadTopicTitleSources(topicTitleRoot)
 	f := loadProjectsFile()
 
 	var migratedTopicIDs []string
@@ -2180,14 +2202,13 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		if err != nil {
 			continue
 		}
-		// Only adopt genuinely-global, unscoped legacy sessions. A session that
-		// already carries a project scope or workspace root is not legacy — never
-		// strip its binding into Global.
-		if meta.Scope == "project" || strings.TrimSpace(meta.WorkspaceRoot) != "" {
+		// Skip sessions that already have a scope or workspace — they were
+		// already assigned by a previous run or by the user.
+		if meta.Scope != "" || strings.TrimSpace(meta.WorkspaceRoot) != "" {
 			continue
 		}
-		meta.Scope = "global"
-		meta.WorkspaceRoot = ""
+		meta.Scope = scope
+		meta.WorkspaceRoot = workspaceRoot
 		meta.TopicID = topicID
 		meta.TopicTitle = title
 		if err := agent.SaveBranchMetaPreserveUpdated(info.Path, meta); err != nil {
@@ -2202,10 +2223,20 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if len(migratedTopicIDs) == 0 {
 		return nil
 	}
-	f.GlobalTopics = uniqueStrings(append(migratedTopicIDs, f.GlobalTopics...))
+	if scope == "global" {
+		f.GlobalTopics = uniqueStrings(append(migratedTopicIDs, f.GlobalTopics...))
+	} else {
+		// Find the project entry and add topics.
+		for i, p := range f.Projects {
+			if p.Root == workspaceRoot {
+				f.Projects[i].Topics = uniqueStrings(append(migratedTopicIDs, f.Projects[i].Topics...))
+				break
+			}
+		}
+	}
 	_ = saveProjectsFile(f)
-	_ = saveTopicTitles("", topicTitles)
-	_ = saveTopicTitleSources("", topicSources)
+	_ = saveTopicTitles(topicTitleRoot, topicTitles)
+	_ = saveTopicTitleSources(topicTitleRoot, topicSources)
 	return migratedTopicIDs
 }
 

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -47,6 +47,12 @@ const legacyEventsConfigImportMarker = ".legacy-imported.v0-events-config"
 const legacyRoutedHomeImportMarker = ".legacy-imported.v2-routed"
 const legacyRoutedConfigImportMarker = ".legacy-imported.v0-events-config.v2-routed"
 
+// legacyJsonlPassMarker gates the v3 pass that imports .jsonl files already in
+// message format (no .events.jsonl counterpart). It is independent of all
+// earlier markers so existing upgraders whose events-only passes completed still
+// get their .jsonl-only sessions imported.
+const legacyJsonlPassMarker = ".legacy-imported.v3-jsonl"
+
 // legacyMeta is the v0.x sidecar (<name>.meta.json): the workspace the session
 // belonged to and the generated summary used as its display title.
 type legacyMeta struct {
@@ -84,7 +90,22 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 	if err != nil {
 		return 0, nil
 	}
+
+	// Build the set of base names that have a .events.jsonl so the .jsonl-only
+	// pass can skip sessions that will be (or were) handled by event reconstruction.
+	hasEvents := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() && strings.HasSuffix(name, ".events.jsonl") {
+			hasEvents[strings.TrimSuffix(name, ".events.jsonl")] = true
+		}
+	}
+
 	imported := 0
+
+	// Pass 1 — event-log sessions (*.events.jsonl). When a same-named .jsonl
+	// exists in the source with a modification time >= the event log's, prefer
+	// the .jsonl directly (it is already in the native message format).
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".events.jsonl") {
@@ -102,12 +123,30 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 		if _, err := os.Stat(dest); err == nil {
 			continue // already imported, or a v1+ session of the same name
 		}
-		srcInfo, _ := e.Info()
-		if destDir != globalDest && moveFlatImport(filepath.Join(globalDest, base+".jsonl"), dest, srcInfo) {
+		eventsInfo, _ := e.Info()
+		if destDir != globalDest && moveFlatImport(filepath.Join(globalDest, base+".jsonl"), dest, eventsInfo) {
 			recordImportedTitle(destDir, base, meta.Summary)
 			imported++
 			continue
 		}
+
+		// If a .jsonl sidecar exists and is >= the event log's mtime, copy it
+		// directly — the TS version wrote the native format alongside or after
+		// the event log, so the .jsonl is the canonical record.
+		jsonlPath := filepath.Join(srcDir, base+".jsonl")
+		if jsonlInfo, err := os.Stat(jsonlPath); err == nil && isMessageFormat(jsonlPath) {
+			if eventsInfo == nil || !jsonlInfo.ModTime().Before(eventsInfo.ModTime()) {
+				if err := transformAndCopyJsonl(jsonlPath, dest); err == nil {
+					if eventsInfo != nil {
+						_ = os.Chtimes(dest, eventsInfo.ModTime(), eventsInfo.ModTime())
+					}
+					recordImportedTitle(destDir, base, meta.Summary)
+					imported++
+					continue
+				}
+			}
+		}
+
 		msgs, err := reconstructSession(filepath.Join(srcDir, name))
 		if err != nil || len(msgs) == 0 {
 			continue
@@ -116,16 +155,395 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 		if err := s.Save(dest); err != nil {
 			return imported, err
 		}
-		if srcInfo != nil {
-			_ = os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime()) // preserve resume ordering
+		if eventsInfo != nil {
+			_ = os.Chtimes(dest, eventsInfo.ModTime(), eventsInfo.ModTime()) // preserve resume ordering
 		}
 		recordImportedTitle(destDir, base, meta.Summary)
 		imported++
 	}
+
+	// Pass 2 — message-format .jsonl files without a .events.jsonl counterpart.
+	// These are sessions the TS version wrote directly in the v1+ format (ACP,
+	// desktop, subagent, and later-version chat sessions). The pass is gated by
+	// its own marker so existing upgraders whose events passes completed still
+	// get their .jsonl-only sessions imported.
+	if !importMarkerExists(globalDest, legacyJsonlPassMarker) {
+		imported += importJsonlSessions(entries, srcDir, globalDest, hasEvents, projectDir)
+
+		// .jsonl.bak recovery: when the .jsonl was lost but a backup remains.
+		for _, e := range entries {
+			name := e.Name()
+			if e.IsDir() || !strings.HasSuffix(name, ".jsonl.bak") {
+				continue
+			}
+			base := strings.TrimSuffix(name, ".jsonl.bak")
+			if hasEvents[base] {
+				continue
+			}
+			jsonlName := base + ".jsonl"
+			if _, err := os.Stat(filepath.Join(srcDir, jsonlName)); err == nil {
+				continue // .jsonl exists, prefer it
+			}
+			meta := readLegacyMeta(srcDir, base)
+			destDir := globalDest
+			if projectDir != nil && meta.Workspace != "" && dirExists(meta.Workspace) {
+				if d := projectDir(meta.Workspace); d != "" {
+					destDir = d
+				}
+			}
+			dest := filepath.Join(destDir, base+".jsonl")
+			if _, err := os.Stat(dest); err == nil {
+				continue
+			}
+			bakPath := filepath.Join(srcDir, name)
+			if !isMessageFormat(bakPath) {
+				continue
+			}
+			srcInfo, _ := e.Info()
+			if err := transformAndCopyJsonl(bakPath, dest); err != nil {
+				continue
+			}
+			if srcInfo != nil {
+				_ = os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime())
+			}
+			recordImportedTitle(destDir, base, meta.Summary)
+			imported++
+		}
+	}
+
+	// Pass 3 — recurse into subdirectories that look like project session dirs
+	// (e.g. Users_Yuki_git_polytone-audio-engine/ under ~/.reasonix/sessions/).
+	// The TS version nested project-scoped sessions under a workspace slug.
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		subDir := filepath.Join(srcDir, e.Name())
+		subEntries, err := os.ReadDir(subDir)
+		if err != nil {
+			continue
+		}
+		hasSessions := false
+		for _, se := range subEntries {
+			sn := se.Name()
+			if !se.IsDir() && (strings.HasSuffix(sn, ".jsonl") || strings.HasSuffix(sn, ".events.jsonl")) {
+				hasSessions = true
+				break
+			}
+		}
+		if !hasSessions {
+			continue
+		}
+		n, err := migrateSubDirectory(subDir, globalDest, projectDir)
+		if err != nil {
+			continue
+		}
+		imported += n
+	}
+
 	// Also stamp the flat markers so a downgrade to an older build doesn't
 	// re-run the flat import over routed sessions.
-	writeImportMarkers(globalDest, marker, legacyImportMarker, legacyEventsHomeImportMarker, legacyEventsConfigImportMarker)
+	writeImportMarkers(globalDest, marker, legacyImportMarker, legacyEventsHomeImportMarker, legacyEventsConfigImportMarker, legacyJsonlPassMarker)
 	return imported, nil
+}
+
+// importJsonlSessions copies .jsonl files that are already in message format
+// (no .events.jsonl counterpart) from srcDir into their appropriate destination
+// dirs. Returns the count imported.
+func importJsonlSessions(entries []os.DirEntry, srcDir, globalDest string, hasEvents map[string]bool, projectDir func(string) string) int {
+	imported := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".events.jsonl") || strings.HasSuffix(name, ".jsonl.bak") {
+			continue
+		}
+		base := strings.TrimSuffix(name, ".jsonl")
+		if hasEvents[base] {
+			continue // handled (or skipped) in the events pass
+		}
+		// Legacy subagent transcripts live under the subagents/ tree in the
+		// current version and are only meaningful when accessed through their
+		// parent session. Importing them as standalone sessions clutters the
+		// history panel with partial, out-of-context conversations.
+		if strings.HasPrefix(base, "subagent-") {
+			continue
+		}
+		jsonlPath := filepath.Join(srcDir, name)
+		if !isMessageFormat(jsonlPath) {
+			continue
+		}
+		meta := readLegacyMeta(srcDir, base)
+		destDir := globalDest
+		if projectDir != nil && meta.Workspace != "" && dirExists(meta.Workspace) {
+			if d := projectDir(meta.Workspace); d != "" {
+				destDir = d
+			}
+		}
+		dest := filepath.Join(destDir, base+".jsonl")
+		if _, err := os.Stat(dest); err == nil {
+			continue
+		}
+		srcInfo, _ := e.Info()
+		if err := transformAndCopyJsonl(jsonlPath, dest); err != nil {
+			continue
+		}
+		if srcInfo != nil {
+			_ = os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime())
+		}
+		recordImportedTitle(destDir, base, meta.Summary)
+		imported++
+	}
+	return imported
+}
+
+// migrateSubDirectory imports sessions from a project-scoped subdirectory
+// within the legacy session dir. It walks the subdirectory for .events.jsonl and
+// .jsonl files and imports them using the projectDir callback for routing.
+func migrateSubDirectory(subDir, globalDest string, projectDir func(string) string) (int, error) {
+	entries, err := os.ReadDir(subDir)
+	if err != nil {
+		return 0, nil
+	}
+	hasEvents := map[string]bool{}
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() && strings.HasSuffix(name, ".events.jsonl") {
+			hasEvents[strings.TrimSuffix(name, ".events.jsonl")] = true
+		}
+	}
+	imported := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			continue
+		}
+		var base string
+		var srcPath string
+		reconstruct := false
+		switch {
+		case strings.HasSuffix(name, ".events.jsonl"):
+			base = strings.TrimSuffix(name, ".events.jsonl")
+			srcPath = filepath.Join(subDir, name)
+			// Prefer .jsonl sidecar if it's newer.
+			if jsonlPath := filepath.Join(subDir, base+".jsonl"); fileExists(jsonlPath) && isMessageFormat(jsonlPath) {
+				eventsInfo, _ := e.Info()
+				if jsonlInfo, err := os.Stat(jsonlPath); err == nil {
+					if eventsInfo == nil || !jsonlInfo.ModTime().Before(eventsInfo.ModTime()) {
+						srcPath = jsonlPath
+						reconstruct = false
+					} else {
+						reconstruct = true
+					}
+				} else {
+					reconstruct = true
+				}
+			} else {
+				reconstruct = true
+			}
+		case strings.HasSuffix(name, ".jsonl") && !strings.HasSuffix(name, ".events.jsonl") && !strings.HasSuffix(name, ".jsonl.bak"):
+			base = strings.TrimSuffix(name, ".jsonl")
+			if hasEvents[base] {
+				continue // handled by the events branch above
+			}
+			srcPath = filepath.Join(subDir, name)
+			if !isMessageFormat(srcPath) {
+				continue
+			}
+			// reconstruct stays false
+		default:
+			continue
+		}
+		meta := readLegacyMeta(subDir, base)
+		destDir := globalDest
+		if projectDir != nil && meta.Workspace != "" && dirExists(meta.Workspace) {
+			if d := projectDir(meta.Workspace); d != "" {
+				destDir = d
+			}
+		}
+		dest := filepath.Join(destDir, base+".jsonl")
+		if _, err := os.Stat(dest); err == nil {
+			continue
+		}
+		srcInfo, _ := e.Info()
+		if reconstruct {
+			msgs, err := reconstructSession(srcPath)
+			if err != nil || len(msgs) == 0 {
+				continue
+			}
+			s := &Session{Messages: msgs}
+			if err := s.Save(dest); err != nil {
+				return imported, err
+			}
+		} else {
+			if err := transformAndCopyJsonl(srcPath, dest); err != nil {
+				continue
+			}
+		}
+		if srcInfo != nil {
+			_ = os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime())
+		}
+		recordImportedTitle(destDir, base, meta.Summary)
+		imported++
+	}
+	return imported, nil
+}
+
+// isMessageFormat returns true when path's first non-whitespace bytes look like
+// a JSON object with a "role" key — i.e. the v1+ message format — as opposed to
+// the legacy event-log format whose first key is "id".
+func isMessageFormat(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var buf [64]byte
+	n, _ := f.Read(buf[:])
+	s := strings.TrimLeft(string(buf[:n]), " \t\r\n")
+	return strings.HasPrefix(s, `{"role":`)
+}
+
+// copyFile copies the contents of src to dst, preserving no metadata beyond
+// what the caller applies afterward (mtime, etc.). The destination file is
+// written atomically via a temp file + rename to avoid partial writes.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".session.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := io.Copy(tmp, in); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, dst)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// legacyAssistantMsg is the minimal JSON shape needed to detect and transform
+// the legacy nested-function tool-call format into the flat format the Go
+// version expects.
+type legacyAssistantMsg struct {
+	Role      string          `json:"role"`
+	ToolCalls json.RawMessage `json:"tool_calls"`
+}
+
+// legacyToolCallObj matches the OpenAI-style tool call where name and
+// arguments live under a "function" key.
+type legacyToolCallObj struct {
+	ID       string `json:"id"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
+// transformAndCopyJsonl copies src to dst, flattening any legacy nested-function
+// tool calls into the flat name/arguments format the v1+ message format uses.
+// Non-assistant messages and messages without tool_calls pass through unchanged.
+func transformAndCopyJsonl(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".session.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	ok := false
+	defer func() {
+		if !ok {
+			os.Remove(tmpPath)
+		}
+	}()
+	enc := json.NewEncoder(tmp)
+	dec := json.NewDecoder(in)
+	for {
+		var raw json.RawMessage
+		if err := dec.Decode(&raw); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// Malformed tail — keep what we've written so far.
+			break
+		}
+		var m legacyAssistantMsg
+		if err := json.Unmarshal(raw, &m); err != nil || m.Role != "assistant" || len(m.ToolCalls) == 0 {
+			// Pass through unchanged (user, tool, or assistant without tool calls).
+			if err := enc.Encode(raw); err != nil {
+				return err
+			}
+			continue
+		}
+		// Try legacy nested-function format; if it doesn't match, pass through.
+		var legacyCalls []legacyToolCallObj
+		if err := json.Unmarshal(m.ToolCalls, &legacyCalls); err != nil || len(legacyCalls) == 0 {
+			if err := enc.Encode(raw); err != nil {
+				return err
+			}
+			continue
+		}
+		// Build flat-format tool calls.
+		flatCalls := make([]provider.ToolCall, len(legacyCalls))
+		for i, tc := range legacyCalls {
+			flatCalls[i] = provider.ToolCall{
+				ID:        tc.ID,
+				Name:      tc.Function.Name,
+				Arguments: tc.Function.Arguments,
+			}
+		}
+		// Re-serialize the full message with flat tool_calls. We only modify
+		// tool_calls; all other fields (content, reasoning_content, etc.) stay
+		// as-is by round-tripping through a map.
+		var full map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &full); err != nil {
+			if err := enc.Encode(raw); err != nil {
+				return err
+			}
+			continue
+		}
+		b, err := json.Marshal(flatCalls)
+		if err != nil {
+			if err := enc.Encode(raw); err != nil {
+				return err
+			}
+			continue
+		}
+		full["tool_calls"] = b
+		if err := enc.Encode(full); err != nil {
+			return err
+		}
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		return err
+	}
+	ok = true
+	return nil
 }
 
 // readLegacyMeta loads the v0.x sidecar for a session; missing or corrupt

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -83,7 +83,10 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 	if strings.TrimSpace(marker) == "" {
 		marker = legacyImportMarker
 	}
-	if importMarkerExists(globalDest, marker) {
+	// Gate on both the routed marker AND the jsonl marker: an existing upgrader
+	// whose events pass already stamped the routed marker must still reach the
+	// .jsonl-only / subdir passes below (Pass 1 is idempotent via dest checks).
+	if importMarkerExists(globalDest, marker) && importMarkerExists(globalDest, legacyJsonlPassMarker) {
 		return 0, nil
 	}
 	entries, err := os.ReadDir(srcDir)
@@ -401,35 +404,6 @@ func isMessageFormat(path string) bool {
 	n, _ := f.Read(buf[:])
 	s := strings.TrimLeft(string(buf[:n]), " \t\r\n")
 	return strings.HasPrefix(s, `{"role":`)
-}
-
-// copyFile copies the contents of src to dst, preserving no metadata beyond
-// what the caller applies afterward (mtime, etc.). The destination file is
-// written atomically via a temp file + rename to avoid partial writes.
-func copyFile(src, dst string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
-	}
-	tmp, err := os.CreateTemp(filepath.Dir(dst), ".session.*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	if _, err := io.Copy(tmp, in); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	return os.Rename(tmpPath, dst)
 }
 
 func fileExists(path string) bool {

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -587,6 +587,28 @@ func TestMigrateLegacySessionsJsonlPassIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestMigrateLegacySessionsJsonlPassRunsForExistingUpgrader(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	os.WriteFile(filepath.Join(src, "acp-chat.jsonl"), []byte(legacyMessageLog), 0o644)
+
+	// Simulate an upgrader whose events pass already completed in a prior
+	// version: the routed marker is stamped but the v3-jsonl marker is not.
+	writeImportMarkers(dest, legacyRoutedHomeImportMarker)
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d, want 1 (.jsonl-only must reach existing upgraders)", n)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "acp-chat.jsonl")); err != nil {
+		t.Errorf("jsonl-only session not imported for existing upgrader: %v", err)
+	}
+}
+
 // legacyNestedFunctionLog uses the OpenAI-style nested-function tool-call format
 // that the TS version wrote: name and arguments live under "function".
 const legacyNestedFunctionLog = `{"role":"user","content":"read the file"}

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -347,3 +347,297 @@ func TestMigrateLegacySessionsSkipsEmptyLog(t *testing.T) {
 		t.Errorf("a log with no user/assistant/tool messages should not produce a session, imported %d", n)
 	}
 }
+
+const legacyMessageLog = `{"role":"user","content":"hello from v0.x"}
+{"role":"assistant","content":"hi there","tool_calls":[{"id":"call_1","name":"read_file","arguments":"{\"path\":\"main.go\"}"}]}
+{"role":"tool","tool_call_id":"call_1","name":"read_file","content":"package main"}
+{"role":"assistant","content":"I found the file."}
+`
+
+func TestMigrateLegacySessionsImportsJsonlOnly(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "acp-chat.jsonl"), []byte(legacyMessageLog), 0o644)
+	writeLegacyMeta(t, src, "acp-chat", "", "ACP session about main.go")
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d sessions, want 1 (jsonl-only)", n)
+	}
+
+	destPath := filepath.Join(dest, "acp-chat.jsonl")
+	data, err := os.ReadFile(destPath)
+	if err != nil {
+		t.Fatalf("imported session missing: %v", err)
+	}
+	if !strings.Contains(string(data), `"hello from v0.x"`) {
+		t.Errorf("imported content wrong:\n%s", data)
+	}
+
+	// Title from the meta sidecar should be stored.
+	titles, err := os.ReadFile(filepath.Join(dest, ".titles.json"))
+	if err != nil {
+		t.Fatalf("titles file: %v", err)
+	}
+	m := map[string]string{}
+	if err := json.Unmarshal(titles, &m); err != nil || m["acp-chat.jsonl"] != "ACP session about main.go" {
+		t.Errorf("title = %q (err=%v), want ACP session about main.go", m["acp-chat.jsonl"], err)
+	}
+
+	// Marker must be stamped.
+	if _, err := os.Stat(filepath.Join(dest, legacyJsonlPassMarker)); err != nil {
+		t.Errorf("jsonl pass marker missing: %v", err)
+	}
+}
+
+func TestMigrateLegacySessionsPrefersJsonlWhenNewer(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	eventsPath := filepath.Join(src, "chat-1.events.jsonl")
+	jsonlPath := filepath.Join(src, "chat-1.jsonl")
+
+	// Write the event log first (older mtime).
+	os.WriteFile(eventsPath, []byte(legacyEventLog), 0o644)
+	time.Sleep(10 * time.Millisecond) // ensure mtime differs
+	// Write the .jsonl second (newer mtime) — it should be preferred.
+	os.WriteFile(jsonlPath, []byte(legacyMessageLog), 0o644)
+	writeLegacyMeta(t, src, "chat-1", "", "newer jsonl wins")
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d, want 1", n)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dest, "chat-1.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The .jsonl content ("hello from v0.x") should win over the reconstructed
+	// event log content ("list the files").
+	if !strings.Contains(string(data), `"hello from v0.x"`) {
+		t.Errorf("expected .jsonl content to be preferred:\n%s", data)
+	}
+}
+
+func TestMigrateLegacySessionsFallsBackToEventsWhenJsonlOlder(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	jsonlPath := filepath.Join(src, "chat-1.jsonl")
+	eventsPath := filepath.Join(src, "chat-1.events.jsonl")
+
+	// Write the .jsonl first (older mtime).
+	os.WriteFile(jsonlPath, []byte(legacyMessageLog), 0o644)
+	time.Sleep(10 * time.Millisecond)
+	// Write the events log second (newer mtime) — events should be reconstructed.
+	os.WriteFile(eventsPath, []byte(legacyEventLog), 0o644)
+	writeLegacyMeta(t, src, "chat-1", "", "events are newer")
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d, want 1", n)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dest, "chat-1.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The reconstructed event-log content ("list the files") should win because
+	// the events log has a newer mtime.
+	if !strings.Contains(string(data), `"list the files"`) {
+		t.Errorf("expected events content to be reconstructed:\n%s", data)
+	}
+}
+
+func TestMigrateLegacySessionsImportsJsonlBakFallback(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	// Only a .jsonl.bak — no .jsonl, no .events.jsonl. Should recover from bak.
+	os.WriteFile(filepath.Join(src, "recovered.jsonl.bak"), []byte(legacyMessageLog), 0o644)
+	writeLegacyMeta(t, src, "recovered", "", "recovered from bak")
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d, want 1 (.bak recovery)", n)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dest, "recovered.jsonl"))
+	if err != nil {
+		t.Fatalf("recovered session missing: %v", err)
+	}
+	if !strings.Contains(string(data), `"hello from v0.x"`) {
+		t.Errorf("recovered content wrong:\n%s", data)
+	}
+}
+
+func TestMigrateLegacySessionsSkipsBakWhenJsonlExists(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	// Both .jsonl and .jsonl.bak exist — prefer .jsonl.
+	os.WriteFile(filepath.Join(src, "chat.jsonl"), []byte(legacyMessageLog), 0o644)
+	os.WriteFile(filepath.Join(src, "chat.jsonl.bak"), []byte(`{"role":"user","content":"stale backup"}`+"\n"), 0o644)
+	writeLegacyMeta(t, src, "chat", "", "from jsonl not bak")
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d, want 1", n)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dest, "chat.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"hello from v0.x"`) {
+		t.Errorf("expected .jsonl content, not .bak:\n%s", data)
+	}
+}
+
+func TestMigrateLegacySessionsSkipsNonMessageJsonl(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	// A .jsonl file that is NOT in message format (starts with event-log "id").
+	os.WriteFile(filepath.Join(src, "bad.jsonl"), []byte(`{"id":1,"type":"model.turn.started"}`+"\n"), 0o644)
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("non-message .jsonl should be skipped, imported %d", n)
+	}
+}
+
+func TestMigrateLegacySessionsRecursesIntoSubdirectories(t *testing.T) {
+	src := t.TempDir()
+	global := t.TempDir()
+	workspace := t.TempDir()
+	projRoot := t.TempDir()
+	router := func(ws string) string { return filepath.Join(projRoot, filepath.Base(ws), "sessions") }
+
+	// Set up a project-scoped subdirectory with sessions.
+	subDir := filepath.Join(src, "Users_Yuki_git_polytone-audio-engine")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(subDir, "proj-chat.events.jsonl"), []byte(legacyEventLog), 0o644)
+	writeLegacyMeta(t, subDir, "proj-chat", workspace, "project session")
+
+	// Also add a subdirectory that has no session files — should be skipped.
+	emptySub := filepath.Join(src, "empty-dir")
+	os.MkdirAll(emptySub, 0o755)
+
+	n, err := MigrateLegacySessions(src, global, router)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d, want 1 (subdirectory session)", n)
+	}
+
+	// Should land in the project session dir, not global.
+	projDest := filepath.Join(projRoot, filepath.Base(workspace), "sessions", "proj-chat.jsonl")
+	if _, err := os.Stat(projDest); err != nil {
+		t.Errorf("subdirectory session not in project dir %s: %v", projDest, err)
+	}
+	if _, err := os.Stat(filepath.Join(global, "proj-chat.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("subdirectory session should not land in global dir")
+	}
+}
+
+func TestMigrateLegacySessionsJsonlPassIsIdempotent(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+
+	os.WriteFile(filepath.Join(src, "desktop-session.jsonl"), []byte(legacyMessageLog), 0o644)
+
+	// First run imports it.
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil || n != 1 {
+		t.Fatalf("first run: n=%d err=%v, want 1", n, err)
+	}
+	// Delete the imported session.
+	os.Remove(filepath.Join(dest, "desktop-session.jsonl"))
+
+	// Second run: jsonl pass marker exists, must not re-import.
+	n, err = MigrateLegacySessions(src, dest, nil)
+	if err != nil || n != 0 {
+		t.Fatalf("second run must be no-op: n=%d err=%v", n, err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "desktop-session.jsonl")); !os.IsNotExist(err) {
+		t.Errorf("deleted session must not reappear after jsonl pass marker")
+	}
+}
+
+// legacyNestedFunctionLog uses the OpenAI-style nested-function tool-call format
+// that the TS version wrote: name and arguments live under "function".
+const legacyNestedFunctionLog = `{"role":"user","content":"read the file"}
+{"role":"assistant","content":"","tool_calls":[{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\"path\":\"main.go\"}"}}],"reasoning_content":"need to read it"}
+{"role":"tool","tool_call_id":"call_1","name":"read_file","content":"package main\nfunc main() {}"}
+{"role":"assistant","content":"Found the main function."}
+`
+
+func TestTransformAndCopyJsonlFlattensNestedToolCalls(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	os.WriteFile(filepath.Join(src, "chat.jsonl"), []byte(legacyNestedFunctionLog), 0o644)
+	writeLegacyMeta(t, src, "chat", "", "nested tool calls test")
+
+	n, err := MigrateLegacySessions(src, dest, nil)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("imported %d, want 1", n)
+	}
+
+	// Reload and verify the tool calls are flat, not nested.
+	loaded, err := LoadSession(filepath.Join(dest, "chat.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	msgs := loaded.Messages
+	if len(msgs) != 4 {
+		t.Fatalf("message count = %d, want 4", len(msgs))
+	}
+	// Message 1: assistant with tool call.
+	if len(msgs[1].ToolCalls) != 1 {
+		t.Fatalf("assistant tool_calls = %d, want 1", len(msgs[1].ToolCalls))
+	}
+	tc := msgs[1].ToolCalls[0]
+	if tc.ID != "call_1" {
+		t.Errorf("tool call id = %q, want call_1", tc.ID)
+	}
+	if tc.Name != "read_file" {
+		t.Errorf("tool call name = %q, want read_file", tc.Name)
+	}
+	if tc.Arguments != `{"path":"main.go"}` {
+		t.Errorf("tool call arguments = %q, want {\"path\":\"main.go\"}", tc.Arguments)
+	}
+	// Message 2: tool result.
+	if msgs[2].Role != provider.RoleTool || msgs[2].ToolCallID != "call_1" || msgs[2].Name != "read_file" {
+		t.Errorf("tool result = %+v, want tool result for call_1", msgs[2])
+	}
+	// Message 3: final assistant text.
+	if msgs[3].Content != "Found the main function." {
+		t.Errorf("final content = %q", msgs[3].Content)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -171,7 +171,22 @@ func setup(ctx context.Context, modelName string, maxStepsOverride int, requireK
 		MaxSteps:   maxStepsOverride,
 		RequireKey: requireKey,
 		Sink:       sink,
+		SessionDir: resolveCLISessionDir(),
 	})
+}
+
+// resolveCLISessionDir returns the session dir for CLI invocations. When the
+// current working directory maps to a project session dir, the project dir is
+// used so /resume shows project history. Falls back to the global session dir.
+func resolveCLISessionDir() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return config.SessionDir()
+	}
+	if projDir := config.ProjectSessionDir(cwd); projDir != "" && projDir != config.SessionDir() {
+		return projDir
+	}
+	return config.SessionDir()
 }
 
 // setupQuiet is like setup but suppresses plugin subprocess stderr output.
@@ -281,12 +296,8 @@ func runAgent(args []string) int {
 		}
 		ctrl.Resume(loaded, *resume)
 	} else if *cont {
-		sessions, err := agent.ListSessions(config.SessionDir())
-		if err != nil {
-			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-			return 1
-		}
-		if len(sessions) == 0 {
+		sessions, err := agent.ListSessions(ctrl.SessionDir())
+		if err != nil || len(sessions) == 0 {
 			fmt.Fprintln(os.Stderr, i18n.M.NoSessionToResume)
 			return 1
 		}
@@ -398,12 +409,8 @@ func chatREPL(args []string) int {
 		}
 		resumePath = path
 	case *cont:
-		sessions, err := agent.ListSessions(config.SessionDir())
-		if err != nil {
-			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-			return 1
-		}
-		if len(sessions) == 0 {
+		sessions, err := agent.ListSessions(resolveCLISessionDir())
+		if err != nil || len(sessions) == 0 {
 			fmt.Fprintln(os.Stderr, i18n.M.NoSessionToResume)
 			return 1
 		}
@@ -764,12 +771,8 @@ func interactiveSetup(configPath, envPath string) int {
 // message so the user can pick one. Returns the chosen path and a process
 // exit code (non-zero when there's nothing to pick or the user cancelled).
 func pickSessionToResume() (string, int) {
-	sessions, err := agent.ListSessions(config.SessionDir())
-	if err != nil {
-		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-		return "", 1
-	}
-	if len(sessions) == 0 {
+	sessions, err := agent.ListSessions(resolveCLISessionDir())
+	if err != nil || len(sessions) == 0 {
 		fmt.Fprintln(os.Stderr, i18n.M.NoSessionToResume)
 		return "", 1
 	}


### PR DESCRIPTION
Builds on @heshuimu's #4221, which imports legacy `.jsonl`-only sessions (ACP / desktop / subagent — written directly in message format) alongside the `.events.jsonl` event logs, flattens legacy nested-function tool calls, and recurses project subdirectories. Two follow-up fixes so it lands cleanly and actually reaches the affected users:

- **Gating.** `migrateLegacySessions` returned early on the routed marker before the new `v3-jsonl` marker was ever checked. Users whose events pass had already completed in a prior version (the routed marker is already stamped) therefore never ran the `.jsonl`-only or subdirectory passes — exactly the population that reports missing history. The early return now requires *both* markers; Pass 1 stays idempotent via its per-session destination checks, so re-running it for already-imported sessions is a no-op. Added a regression test covering the existing-upgrader path.
- **Dead code.** Removed the unused `copyFile`; golangci-lint's `unused` linter (enabled in `.golangci.yml`) would have failed CI on it. All copy paths already go through `transformAndCopyJsonl`.

All original #4221 tests plus the new ones pass; root and desktop modules build and vet clean.

Closes #4221
