### PR TITLE
test(desktop): pass context.TODO() to emitReady, not nil

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -260,7 +260,7 @@ func TestEmitReadyInvokesReadyHook(t *testing.T) {
 		atomic.AddInt32(&calls, 1)
 	}
 
-	app.emitReady(nil)
+	app.emitReady(context.TODO())
 
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Fatalf("ready hook calls = %d, want 1", got)


### PR DESCRIPTION
Follow-up to #4250. The new `TestEmitReadyInvokesReadyHook` passed `nil` as the context; `emitReady` returns early when a `readyHook` is set, so the test behaves identically, but the call trips staticcheck SA1012 ("do not pass a nil Context"). Pass `context.TODO()` instead.

No behavior change; desktop-module test only.