### PR TITLE
ci(desktop): lint the desktop module with golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,13 @@ jobs:
       - name: vet
         run: go vet ./...
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          working-directory: desktop
+          args: --timeout=5m
+
       - name: build
         run: go build ./...
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -372,7 +372,7 @@ func (a *App) restoreOrBuildTabs() {
 	// Run legacy config migration before the first config load so the
 	// freshly written config (including the user's default_model) is
 	// picked up by Load instead of falling back to built-in defaults.
-	config.MigrateLegacyIfNeeded()
+	_, _ = config.MigrateLegacyIfNeeded()
 
 	// Load i18n from the first available config.
 	// Prefer DesktopLanguage (desktop UI setting) over Language (CLI setting),
@@ -1984,14 +1984,6 @@ func (a *App) SetAutoApproveTools(on bool) {
 		return
 	}
 	a.SetToolApprovalModeForTab("", control.ToolApprovalAsk)
-}
-
-func (a *App) setAutoApproveToolsForTab(tabID string, on bool) {
-	if on {
-		a.SetToolApprovalModeForTab(tabID, control.ToolApprovalYolo)
-		return
-	}
-	a.SetToolApprovalModeForTab(tabID, control.ToolApprovalAsk)
 }
 
 // SetBypass is the legacy Wails binding for SetAutoApproveTools.
@@ -3832,14 +3824,6 @@ func (a *App) workspacePath(rel string) (string, bool, error) {
 	return workspacePathForBase(base, rel)
 }
 
-func workspacePath(rel string) (string, bool, error) {
-	base, err := os.Getwd()
-	if err != nil {
-		return "", false, err
-	}
-	return workspacePathForBase(base, rel)
-}
-
 func workspacePathForBase(base, rel string) (string, bool, error) {
 	base = filepath.Clean(base)
 	if rel == "" {
@@ -4057,19 +4041,11 @@ func revealPath(path string) error {
 	}
 }
 
-func (a *App) notice(text string) {
-	a.noticeForTab("", text)
-}
-
 func (a *App) noticeForTab(tabID, text string) {
 	tab := a.tabByID(tabID)
 	if tab != nil && tab.sink != nil {
 		tab.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: text})
 	}
-}
-
-func (a *App) runEffortCommand(input string) {
-	a.runEffortCommandForTab("", input)
 }
 
 func (a *App) runEffortCommandForTab(tabID, input string) {
@@ -4106,10 +4082,6 @@ func (a *App) runEffortCommandForTab(tabID, input string) {
 		display = "auto"
 	}
 	a.noticeForTab(tabID, fmt.Sprintf("effort for %s set to %s", entry.Name, display))
-}
-
-func (a *App) currentProviderEntry() (*config.ProviderEntry, error) {
-	return a.currentProviderEntryForTab("")
 }
 
 func (a *App) currentProviderEntryForTab(tabID string) (*config.ProviderEntry, error) {

--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -7,6 +7,9 @@ import (
 	"time"
 	"unicode"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
@@ -431,7 +434,7 @@ func workflowEvidence(cat workflowCategory, sessions []suggestionSession) []stri
 func skillCandidateBody(cat workflowCategory, evidence []string) string {
 	var b strings.Builder
 	title := strings.TrimPrefix(strings.ReplaceAll(cat.Name, "-", " "), "reasonix ")
-	b.WriteString("# " + strings.Title(title) + "\n\n")
+	b.WriteString("# " + cases.Title(language.Und).String(title) + "\n\n")
 	b.WriteString("Use this skill when the user asks for this repeated Reasonix workflow.\n\n")
 	b.WriteString("## Evidence\n\n")
 	for _, ev := range evidence {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -460,10 +460,11 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 		Active:            active,
 		Cwd:               tab.WorkspaceRoot,
 	}
-	if tab.Scope == "global" {
+	switch tab.Scope {
+	case "global":
 		m.ProjectColor = globalProjectColor()
 		m.WorkspaceName = globalProjectTitle()
-	} else if tab.Scope == "project" {
+	case "project":
 		m.ProjectColor = projectColor(tab.WorkspaceRoot)
 	}
 	if tab.Ctrl != nil {
@@ -1130,50 +1131,6 @@ func (a *App) ctrlByTabID(tabID string) *control.Controller {
 	return tab.Ctrl
 }
 
-// activeSink returns the active tab's event sink, or nil.
-func (a *App) activeSink() *tabEventSink {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	t := a.activeTabLocked()
-	if t == nil {
-		return nil
-	}
-	return t.sink
-}
-
-// activeModel returns the active tab's model ref.
-func (a *App) activeModel() string {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	t := a.activeTabLocked()
-	if t == nil {
-		return ""
-	}
-	return t.model
-}
-
-// activeDisabledMCP returns the active tab's disabled MCP map.
-func (a *App) activeDisabledMCP() map[string]ServerView {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	t := a.activeTabLocked()
-	if t == nil {
-		return map[string]ServerView{}
-	}
-	return t.disabledMCP
-}
-
-// activeMCPOrder returns the active tab's MCP order.
-func (a *App) activeMCPOrder() []string {
-	a.mu.RLock()
-	defer a.mu.RUnlock()
-	t := a.activeTabLocked()
-	if t == nil {
-		return nil
-	}
-	return t.mcpOrder
-}
-
 // --- autosave per tab -------------------------------------------------------
 
 func (a *App) scheduleTabSnapshot(tabID string) {
@@ -1351,7 +1308,7 @@ func desktopConfigDir() string {
 
 func (a *App) saveTabsLocked() {
 	dir := desktopConfigDir()
-	os.MkdirAll(dir, 0o755)
+	_ = os.MkdirAll(dir, 0o755)
 	var entries []desktopTabEntry
 	for _, id := range a.orderedTabIDsLocked() {
 		if tab := a.tabs[id]; tab != nil {
@@ -1374,7 +1331,7 @@ func (a *App) saveTabsLocked() {
 	b, _ := json.MarshalIndent(f, "", "  ")
 	path := filepath.Join(dir, tabsFileName)
 	tmp := path + ".tmp"
-	os.WriteFile(tmp, b, 0o644)
+	_ = os.WriteFile(tmp, b, 0o644)
 	_ = fileutil.ReplaceFile(tmp, path)
 }
 
@@ -1418,7 +1375,7 @@ func loadTabsFile() desktopTabsFile {
 		return desktopTabsFile{}
 	}
 	var f desktopTabsFile
-	json.Unmarshal(b, &f)
+	_ = json.Unmarshal(b, &f)
 	return f
 }
 
@@ -1429,13 +1386,15 @@ func loadProjectsFile() desktopProjectFile {
 		return desktopProjectFile{}
 	}
 	var f desktopProjectFile
-	json.Unmarshal(b, &f)
+	_ = json.Unmarshal(b, &f)
 	return normalizeProjectsFile(f)
 }
 
 func saveProjectsFile(f desktopProjectFile) error {
 	dir := desktopConfigDir()
-	os.MkdirAll(dir, 0o755)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
 	f = normalizeProjectsFile(f)
 	b, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
@@ -1739,16 +1698,6 @@ func removeProject(root string) error {
 	return saveProjectsFile(f)
 }
 
-func projectTitle(root string) string {
-	root = normalizeProjectRoot(root)
-	for _, p := range loadProjectsFile().Projects {
-		if p.Root == root {
-			return projectDisplayName(p)
-		}
-	}
-	return workspaceName(root)
-}
-
 // --- topic helpers ----------------------------------------------------------
 
 const (
@@ -1787,7 +1736,7 @@ func loadTopicTitles(workspaceRoot string) map[string]string {
 	if err != nil {
 		return m
 	}
-	json.Unmarshal(b, &m)
+	_ = json.Unmarshal(b, &m)
 	return m
 }
 
@@ -1797,7 +1746,7 @@ func loadTopicTitleSources(workspaceRoot string) map[string]string {
 	if err != nil {
 		return m
 	}
-	json.Unmarshal(b, &m)
+	_ = json.Unmarshal(b, &m)
 	return m
 }
 
@@ -1807,7 +1756,7 @@ func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
 	if err != nil {
 		return m
 	}
-	json.Unmarshal(b, &m)
+	_ = json.Unmarshal(b, &m)
 	return m
 }
 
@@ -1924,16 +1873,6 @@ func setTopicTitleWithSource(workspaceRoot, topicID, title, source string) error
 	return saveTopicTitleSources(workspaceRoot, sources)
 }
 
-func setTopicTitleSource(workspaceRoot, topicID, source string) error {
-	sources := loadTopicTitleSources(workspaceRoot)
-	if strings.TrimSpace(source) == "" {
-		delete(sources, topicID)
-	} else {
-		sources[topicID] = strings.TrimSpace(source)
-	}
-	return saveTopicTitleSources(workspaceRoot, sources)
-}
-
 func setTopicCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
 	created := loadTopicCreatedAts(workspaceRoot)
 	topicID = strings.TrimSpace(topicID)
@@ -1995,24 +1934,6 @@ func ensureTopicIndexed(scope, workspaceRoot, topicID, title, source string) err
 }
 
 // --- telemetry --------------------------------------------------------------
-
-func (a *App) tabTelemetryPath(tabID string) string {
-	a.mu.RLock()
-	tab, ok := a.tabs[tabID]
-	var ctrl *control.Controller
-	if ok && tab != nil {
-		ctrl = tab.Ctrl
-	}
-	a.mu.RUnlock()
-	if !ok || ctrl == nil {
-		return ""
-	}
-	sp := ctrl.SessionPath()
-	if sp == "" {
-		return ""
-	}
-	return sp + ".telemetry.json"
-}
 
 func saveTelemetry(path string, snapshot tabTelemetrySnapshot) error {
 	if snapshot.Version == 0 {


### PR DESCRIPTION
The `desktop/` module is a separate Go module, and the root `lint` job (root `go.mod`) never covered it — so `unused`/errcheck/staticcheck findings accumulated unseen (the desktop job only ran gofmt/vet/build/test). Independent housekeeping, surfaced while reviewing #4250.

**CI:** add a `golangci-lint` step (v2.12.2, same root `.golangci.yml`) to the desktop job via `working-directory: desktop`.

**Cleared the existing findings so the gate goes in green:**
- **unused (12):** dropped dead `*ForTab` "" delegators and orphaned helpers (`notice`, `runEffortCommand`, `currentProviderEntry`, `setAutoApproveToolsForTab`, `workspacePath`, `active{Sink,Model,DisabledMCP,MCPOrder}`, `projectTitle`, `setTopicTitleSource`, `tabTelemetryPath`). The `*ForTab` implementations they wrapped stay.
- **errcheck (9):** made the best-effort `json.Unmarshal` / `os.MkdirAll` / `os.WriteFile` error-drops explicit (`_ =`); `saveProjectsFile` now returns the `MkdirAll` error since it already returns errors. The `MigrateLegacyIfNeeded` call from #4224 was one of these.
- **staticcheck (2):** `tab.Scope` if-chain → tagged switch (QF1003); deprecated `strings.Title` → `cases.Title(language.Und)` (SA1019; `x/text` is already a direct dep).

No behavior change. Verified locally: `golangci-lint run` clean on desktop, `go build/vet` clean, `go mod tidy` no-op. `go test ./...` passes except two failures that also fail on `main-v2` (Windows TempDir flake + a test reading the dev box's real `~/.agents/skills`) — neither present on Linux CI.