### PR TITLE
refactor(control): drop phrase-matched approved-plan continuation

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -149,16 +149,6 @@ type Controller struct {
 	// approver). Reset when the execution turn returns.
 	approvedPlanAutoApproveTools bool
 
-	// approvedPlanActive carries that same go-ahead across user-directed pauses in
-	// an approved plan. It stays true only while the approved plan has not reported
-	// completion, so an explicit continuation turn resumes without downgrading into
-	// per-tool approval.
-	approvedPlanActive bool
-	// approvedPlanContinuationTurn is true only for the current user turn when
-	// the user explicitly asked to continue that approved plan.
-	approvedPlanContinuationTurn bool
-	approvedPlanStart            int // message index where the approved execution began
-
 	// toolApprovalMode is the runtime approval posture for permission-gated tool
 	// calls. "ask" prompts by default, "auto" lets the policy auto-approve the
 	// writer fallback while preserving ask/deny rules, and "yolo" skips every
@@ -484,11 +474,6 @@ const planApprovalTool = "exit_plan_mode"
 // the in-context nudge to execute and keep the (already-seeded) task list honest.
 const planApprovedMessage = "Plan approved — plan mode is off; you’re cleared to make the changes without asking again. Implement the plan now. Use this serial workflow: 1) mark the first sub-step in_progress with todo_write (this establishes the task list); 2) execute the sub-step; 3) call complete_step with evidence — the host then marks that sub-step completed and moves the next one to in_progress for you. Repeat 2–3 for each remaining sub-step. You don’t need another todo_write to mark steps completed; each complete_step advances the list. Sign off one sub-step at a time — never batch multiple completions."
 
-// approvedPlanExecutionMarker is prepended to later user turns while an approved
-// plan is paused with unfinished todos. It preserves the execution contract in
-// model context without mutating the cache-stable system prompt or tool schema.
-const approvedPlanExecutionMarker = "[Approved plan execution continues — the prior plan is already approved. Continue the next unfinished step without asking again for ordinary work covered by that plan. Keep todo_write current by sending the complete list whenever a step starts or finishes.]"
-
 // runTurn runs one model turn, then applies the plan-approval gate. This is the
 // single, frontend-agnostic plan flow: in plan mode the model just researches
 // (writers are blocked) and writes its plan as a normal answer — no special tool.
@@ -547,7 +532,6 @@ func (c *Controller) runGoalLoopWithRawDisplay(ctx context.Context, input, raw, 
 }
 
 func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, display string) error {
-	defer c.clearApprovedPlanContinuationTurn()
 	c.maybeSessionStart(ctx)
 	c.maybeAutoPlan(ctx, raw)
 	parentSession := c.parentSessionID()
@@ -577,7 +561,6 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	if err := c.runner.Run(ctx, input); err != nil {
 		return err
 	}
-	c.refreshApprovedPlanExecutionFromHistory()
 	c.mu.Lock()
 	plan := c.planMode
 	c.mu.Unlock()
@@ -599,9 +582,10 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	}
 	c.SetPlanMode(false)
 	todoArgs := c.seedPlanTodos(proposal)
-	c.beginApprovedPlanExecution(todoArgs)
+	execStart := c.sessionMessageCount()
 	// The plan is the go-ahead: don't re-prompt for each write of the approved
-	// work. Auto-approve writers for the duration of this execution turn only.
+	// work. Auto-approve writers for the duration of this execution turn only; a
+	// later turn (even "continue") falls back to the normal per-tool approval.
 	c.mu.Lock()
 	c.approvedPlanAutoApproveTools = true
 	c.mu.Unlock()
@@ -610,14 +594,13 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		c.approvedPlanAutoApproveTools = false
 		c.mu.Unlock()
 	}()
-	err = c.runner.Run(ctx, planApprovedMessage)
-	if err == nil && todoArgs != "" && !c.approvedPlanHasTodoUpdateSinceStart() {
-		c.completePlanTodos(todoArgs)
-		c.clearApprovedPlanExecution()
-		return nil
+	if err := c.runner.Run(ctx, planApprovedMessage); err != nil {
+		return err
 	}
-	c.refreshApprovedPlanExecutionFromHistory()
-	return err
+	if todoArgs != "" && !c.hasTodoUpdateSince(execStart) {
+		c.completePlanTodos(todoArgs)
+	}
+	return nil
 }
 
 func (c *Controller) continueGoal(ctx context.Context) error {
@@ -1301,11 +1284,6 @@ func (c *Controller) ReplayPendingPrompts() {
 func (c *Controller) SetPlanMode(v bool) {
 	c.mu.Lock()
 	c.planMode = v
-	if v {
-		c.approvedPlanActive = false
-		c.approvedPlanContinuationTurn = false
-		c.approvedPlanStart = 0
-	}
 	c.mu.Unlock()
 	if c.executor != nil {
 		c.executor.SetPlanMode(v)
@@ -1415,7 +1393,6 @@ func (c *Controller) NewSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
-	c.clearApprovedPlanExecution()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
@@ -1453,7 +1430,6 @@ func (c *Controller) ClearSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
-	c.clearApprovedPlanExecution()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true
@@ -1643,7 +1619,6 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		c.executor.SetSession(sess)
 		c.mu.Lock()
 		c.sessionPath = newPath
-		c.clearApprovedPlanExecutionLocked()
 		c.mu.Unlock()
 		c.setActiveJobSession(newPath)
 		c.rebindCheckpoints(newPath)
@@ -1703,9 +1678,6 @@ func (c *Controller) Branch(name string) (string, error) {
 	c.executor.SetSession(sess)
 	c.mu.Lock()
 	c.sessionPath = newPath
-	c.approvedPlanActive = false
-	c.approvedPlanContinuationTurn = false
-	c.approvedPlanStart = 0
 	c.mu.Unlock()
 	c.setActiveJobSession(newPath)
 	c.rebindCheckpoints(newPath)
@@ -1753,9 +1725,6 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	}
 	c.mu.Lock()
 	c.sessionPath = match.Path
-	c.approvedPlanActive = false
-	c.approvedPlanContinuationTurn = false
-	c.approvedPlanStart = 0
 	c.mu.Unlock()
 	c.setActiveJobSession(match.Path)
 	c.rebindCheckpoints(match.Path)
@@ -1855,9 +1824,6 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	}
 	c.mu.Lock()
 	c.sessionPath = path
-	c.approvedPlanActive = false
-	c.approvedPlanContinuationTurn = false
-	c.approvedPlanStart = 0
 	c.mu.Unlock()
 	c.setActiveJobSession(path)
 	c.rebindCheckpoints(path)
@@ -2908,69 +2874,18 @@ func parsePlanTodos(plan string) []seedTodo {
 	return todos
 }
 
-func (c *Controller) beginApprovedPlanExecution(todoArgs string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.approvedPlanActive = true
-	if todoArgs != "" {
-		c.approvedPlanActive = todosIncomplete(todoArgs)
+func (c *Controller) sessionMessageCount() int {
+	if c.executor == nil {
+		return 0
 	}
-	c.approvedPlanContinuationTurn = false
-	c.approvedPlanStart = 0
-	if c.executor != nil {
-		c.approvedPlanStart = len(c.executor.Session().Messages)
-	}
+	return len(c.executor.Session().Messages)
 }
 
-func (c *Controller) clearApprovedPlanExecution() {
-	c.mu.Lock()
-	c.clearApprovedPlanExecutionLocked()
-	c.mu.Unlock()
-}
-
-func (c *Controller) clearApprovedPlanExecutionLocked() {
-	c.approvedPlanActive = false
-	c.approvedPlanContinuationTurn = false
-	c.approvedPlanStart = 0
-}
-
-func (c *Controller) clearApprovedPlanContinuationTurn() {
-	c.mu.Lock()
-	c.approvedPlanContinuationTurn = false
-	c.mu.Unlock()
-}
-
-func (c *Controller) refreshApprovedPlanExecutionFromHistory() {
-	c.mu.Lock()
-	active := c.approvedPlanActive
-	start := c.approvedPlanStart
-	c.mu.Unlock()
-	if !active || c.executor == nil {
-		return
-	}
-	msgs := c.executor.Session().Messages
-	if start < 0 || start > len(msgs) {
-		start = len(msgs)
-	}
-	args, ok := latestTodoArgsSince(msgs, start)
-	if !ok {
-		return
-	}
-	c.mu.Lock()
-	c.approvedPlanActive = todosIncomplete(args)
-	if !c.approvedPlanActive {
-		c.approvedPlanContinuationTurn = false
-		c.approvedPlanStart = 0
-	}
-	c.mu.Unlock()
-}
-
-func (c *Controller) approvedPlanHasTodoUpdateSinceStart() bool {
-	c.mu.Lock()
-	active := c.approvedPlanActive
-	start := c.approvedPlanStart
-	c.mu.Unlock()
-	if !active || c.executor == nil {
+// hasTodoUpdateSince reports whether the model emitted its own todo_write after
+// index start, so the seeded plan todos aren't auto-completed over the model's
+// own bookkeeping.
+func (c *Controller) hasTodoUpdateSince(start int) bool {
+	if c.executor == nil {
 		return false
 	}
 	msgs := c.executor.Session().Messages
@@ -2991,23 +2906,6 @@ func latestTodoArgsSince(msgs []provider.Message, start int) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func todosIncomplete(args string) bool {
-	var p struct {
-		Todos []struct {
-			Status string `json:"status"`
-		} `json:"todos"`
-	}
-	if err := json.Unmarshal([]byte(args), &p); err != nil || len(p.Todos) == 0 {
-		return false
-	}
-	for _, t := range p.Todos {
-		if t.Status != "completed" {
-			return true
-		}
-	}
-	return false
 }
 
 // listItem parses a markdown list line ("- x", "* x", "1. x", "2) x") into its
@@ -3177,8 +3075,7 @@ func (c *Controller) approvalBypassAllowsLocked(tool string) bool {
 		return false
 	}
 	return c.toolApprovalMode == ToolApprovalYolo ||
-		c.approvedPlanAutoApproveTools ||
-		(c.approvedPlanActive && c.approvedPlanContinuationTurn)
+		c.approvedPlanAutoApproveTools
 }
 
 func (c *Controller) autoApprovalWouldAllowLocked(tool, subject string) bool {

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -727,7 +727,7 @@ func (r *scriptedRunner) Run(_ context.Context, input string) error {
 	return nil
 }
 
-func TestApprovedPlanSurvivesUserPauseUntilTodosComplete(t *testing.T) {
+func TestApprovedPlanAutoApproveEndsWithExecutionTurn(t *testing.T) {
 	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
 	runner := &scriptedRunner{exec: exec}
 
@@ -768,35 +768,21 @@ func TestApprovedPlanSurvivesUserPauseUntilTodosComplete(t *testing.T) {
 		t.Fatalf("approval prompts after plan = %d, want 1", approvalPrompts)
 	}
 
-	if got := c.Compose("继续"); got == "继续" {
-		t.Fatal("continuation turn should carry the approved-plan execution marker")
+	// The plan approval auto-approves writers for the execution turn only. A later
+	// turn does not inherit it, and "继续" carries no special meaning — Compose must
+	// not inject any marker, and the next writer falls back to per-tool approval.
+	if got := c.Compose("继续"); got != "继续" {
+		t.Fatalf("a paused approved plan must not marker-prefix the next turn, got %q", got)
 	}
 	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
-	if err != nil || !allow {
-		t.Fatalf("writer during unfinished approved plan = (%v,%v), want auto-allow", allow, err)
-	}
-	if approvalPrompts != 1 {
-		t.Fatalf("unfinished approved plan should not prompt for writer, prompts=%d", approvalPrompts)
-	}
-
-	runner.scripts = append(runner.scripts, func(input string) {
-		exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "all done", ToolCalls: []provider.ToolCall{{
-			ID: "todo-2", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"completed"}]}`,
-		}}})
-	})
-	if err := c.runTurn(context.Background(), c.Compose("继续")); err != nil {
-		t.Fatal(err)
-	}
-
-	allow, _, err = gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/b", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if allow {
-		t.Fatal("writer after approved plan completion should return to normal approval flow")
+		t.Fatal("writer after the execution turn should return to per-tool approval, not auto-allow")
 	}
 	if approvalPrompts != 2 {
-		t.Fatalf("writer after completion should prompt once, prompts=%d", approvalPrompts)
+		t.Fatalf("writer after the execution turn should prompt, prompts=%d", approvalPrompts)
 	}
 }
 
@@ -847,64 +833,5 @@ func TestApprovedPlanDoesNotAutoApproveNonContinuationTurn(t *testing.T) {
 	}
 	if approvalPrompts != 2 {
 		t.Fatalf("non-continuation writer should prompt after plan approval, prompts=%d", approvalPrompts)
-	}
-}
-
-func TestApprovedPlanContinuationWorksWithoutSeededTodos(t *testing.T) {
-	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
-	runner := &scriptedRunner{exec: exec}
-
-	var c *Controller
-	approvalPrompts := 0
-	sink := event.FuncSink(func(e event.Event) {
-		if e.Kind != event.ApprovalRequest {
-			return
-		}
-		approvalPrompts++
-		if e.Approval.Tool == planApprovalTool {
-			go c.Approve(e.Approval.ID, true, false, false)
-			return
-		}
-		go c.Approve(e.Approval.ID, false, false, false)
-	})
-	c = New(Options{Runner: runner, Executor: exec, Sink: sink})
-	c.SetPlanMode(true)
-
-	runner.scripts = append(runner.scripts,
-		func(input string) {
-			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "先创建文件，然后暂停让我审核。审核通过后继续修改文件。"})
-		},
-		func(input string) {
-			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "first step done; paused for review"})
-		},
-	)
-
-	if err := c.runTurn(context.Background(), "plan this"); err != nil {
-		t.Fatal(err)
-	}
-	if approvalPrompts != 1 {
-		t.Fatalf("approval prompts after prose plan = %d, want 1", approvalPrompts)
-	}
-
-	if got := c.Compose("continue"); got == "continue" {
-		t.Fatal("explicit continuation should carry the approved-plan execution marker")
-	}
-	allow, _, err := gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/a", nil)
-	if err != nil || !allow {
-		t.Fatalf("writer during prose-plan continuation = (%v,%v), want auto-allow", allow, err)
-	}
-
-	if got := c.Compose("revise the plan"); got != "revise the plan" {
-		t.Fatalf("non-continuation after prose plan should not be marker-prefixed, got %q", got)
-	}
-	allow, _, err = gateApprover{c}.Approve(context.Background(), "write_file", "/tmp/b", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if allow {
-		t.Fatal("non-continuation after prose plan should return to normal approval flow")
-	}
-	if approvalPrompts != 2 {
-		t.Fatalf("writer after non-continuation should prompt once, prompts=%d", approvalPrompts)
 	}
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -89,27 +89,14 @@ var syntheticPrefixes = []string{
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,
 // returning the message to actually send to the model. The frontend keeps
-// showing the raw text as the user bubble. When an approved plan is paused,
-// only an explicit continuation command carries that approval into the next turn.
+// showing the raw text as the user bubble.
 func (c *Controller) Compose(text string) string {
 	c.mu.Lock()
 	plan := c.planMode
 	goal := c.goal
 	goalStatus := c.goalStatus
-	approvedPlan := c.approvedPlanActive
-	continuation := false
 	notes := c.pendingMemory
 	c.pendingMemory = nil
-	if !plan && approvedPlan {
-		continuation = isApprovedPlanContinuation(text)
-		if continuation {
-			c.approvedPlanContinuationTurn = true
-		} else {
-			c.approvedPlanActive = false
-			c.approvedPlanContinuationTurn = false
-			c.approvedPlanStart = 0
-		}
-	}
 	c.mu.Unlock()
 
 	if strings.TrimSpace(goal) != "" && goalStatus == GoalStatusRunning {
@@ -117,8 +104,6 @@ func (c *Controller) Compose(text string) string {
 	}
 	if plan {
 		text = PlanModeMarker + "\n\n" + text
-	} else if continuation {
-		text = approvedPlanExecutionMarker + "\n\n" + text
 	}
 
 	// Memory added mid-session rides the turn (never the cached system prefix),
@@ -158,19 +143,6 @@ func activeGoalBlock(goal string) string {
 	b.WriteString("\n")
 	b.WriteString(activeGoalClose)
 	return b.String()
-}
-
-func isApprovedPlanContinuation(text string) bool {
-	s := strings.ToLower(strings.TrimSpace(text))
-	s = strings.TrimRight(s, ".。!！")
-	s = strings.Join(strings.Fields(s), " ")
-	switch s {
-	case "继续", "继续执行", "继续吧", "接着执行", "下一步", "执行下一步",
-		"continue", "resume", "proceed", "go on", "continue execution":
-		return true
-	default:
-		return false
-	}
 }
 
 // MemoryQuickAddNote parses the "# <note>" memory shortcut. The space after


### PR DESCRIPTION
Follow-up to #4250 / the review of session-ownership work.

#4250 added a mechanism to carry an approved plan's writer auto-approval across a *user pause*: on the next turn, if the text matched a fixed phrase whitelist (`继续` / `continue` / `proceed` / …) it re-armed auto-approval and injected a continuation marker; otherwise it dropped back to per-tool approval.

That phrase whitelist is exactly the brittle intent-detection this project deliberately removed elsewhere — and the failure mode isn't symmetric: a false positive (any user turn that happens to be a bare "continue") **silently widens writer auto-approval** for that turn.

**Change:** plan-approval auto-approval now covers the **execution turn only** (unchanged `approvedPlanAutoApproveTools`, reset on turn return). Any later turn — including "continue" — returns to the normal per-tool approval posture; `ask`/`auto`/`yolo` still govern it, and that's the explicit, non-fragile mechanism for unattended execution. The plan still seeds todos and still avoids clobbering the model's own `todo_write` (the kept `hasTodoUpdateSince` guard).

Removes `approvedPlanActive` / `approvedPlanContinuationTurn` / `approvedPlanStart`, the execution marker const, `isApprovedPlanContinuation`, and the now-dead reset sites — net **−204 lines** in non-test code.

Tests: rewrote the survive-pause test to lock in that "继续" no longer carries approval (writer prompts after the execution turn); kept the non-continuation test; dropped the prose-plan continuation test. `go build/vet`, `staticcheck`, and `go test ./internal/control` clean.