### PR TITLE
fix(plugin): enrich + memoize shell PATH for MCP stdio subprocesses

### DIFF
--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -100,6 +100,11 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 var stdioShellPATH = defaultStdioShellPATH
 
 func resolveStdioExecutable(ctx context.Context, s Spec, env []string) (string, []string, error) {
+	// Unconditionally enrich PATH with the user's shell PATH so every
+	// subprocess—including wrapper scripts that invoke npx, uvx, etc.—
+	// inherits the expected tool locations even under a GUI launch.
+	env = enrichStdioShellPATH(ctx, env)
+
 	if hasPathSeparator(s.Command) {
 		return s.Command, env, nil
 	}
@@ -108,17 +113,6 @@ func resolveStdioExecutable(ctx context.Context, s Spec, env []string) (string, 
 	}
 
 	currentPath, _ := envValue(env, "PATH")
-	if shellPath := strings.TrimSpace(stdioShellPATH(ctx)); shellPath != "" {
-		fallbackPath := mergePathLists(shellPath, currentPath)
-		if fallbackPath != currentPath {
-			fallbackEnv := setEnvValue(env, "PATH", fallbackPath)
-			if exe, ok := lookPathInEnv(s.Command, fallbackEnv); ok {
-				return exe, fallbackEnv, nil
-			}
-			env = fallbackEnv
-			currentPath = fallbackPath
-		}
-	}
 	if runtime.GOOS == "windows" {
 		fallbackPath := mergePathLists(windowsStdioFallbackPATH(env), currentPath)
 		if fallbackPath != currentPath {
@@ -133,6 +127,20 @@ func resolveStdioExecutable(ctx context.Context, s Spec, env []string) (string, 
 
 	return "", env, fmt.Errorf("stdio plugin %q: command %q not found on PATH; GUI launches and non-interactive sessions may not inherit your shell PATH. Use an absolute command path or set PATH in the MCP server env. PATH=%q",
 		s.Name, s.Command, currentPath)
+}
+
+// enrichStdioShellPATH probes the user's interactive login shell for its PATH
+// and prepends those directories to the current environment. The result is the
+// subprocess environment with a PATH that matches what the user sees in their
+// terminal, even when Reasonix was launched from the Finder / Dock / open(1).
+func enrichStdioShellPATH(ctx context.Context, env []string) []string {
+	currentPath, _ := envValue(env, "PATH")
+	if shellPath := strings.TrimSpace(stdioShellPATH(ctx)); shellPath != "" {
+		if fallbackPath := mergePathLists(shellPath, currentPath); fallbackPath != currentPath {
+			env = setEnvValue(env, "PATH", fallbackPath)
+		}
+	}
+	return env
 }
 
 func hasPathSeparator(s string) bool {

--- a/internal/plugin/transport_stdio.go
+++ b/internal/plugin/transport_stdio.go
@@ -97,7 +97,29 @@ func newStdioTransport(ctx context.Context, s Spec) (*stdioTransport, error) {
 	return t, nil
 }
 
-var stdioShellPATH = defaultStdioShellPATH
+var stdioShellPATH = cachedShellPATH(defaultStdioShellPATH)
+
+// cachedShellPATH memoizes the first non-empty shell-PATH probe: the user's
+// interactive PATH is stable for the process, and resolveStdioExecutable now
+// probes for every stdio plugin, so caching avoids a login shell per server.
+func cachedShellPATH(probe func(context.Context) string) func(context.Context) string {
+	var (
+		mu     sync.Mutex
+		cached string
+		done   bool
+	)
+	return func(ctx context.Context) string {
+		mu.Lock()
+		defer mu.Unlock()
+		if done {
+			return cached
+		}
+		if p := probe(ctx); p != "" {
+			cached, done = p, true
+		}
+		return cached
+	}
+}
 
 func resolveStdioExecutable(ctx context.Context, s Spec, env []string) (string, []string, error) {
 	// Unconditionally enrich PATH with the user's shell PATH so every

--- a/internal/plugin/transport_stdio_cache_test.go
+++ b/internal/plugin/transport_stdio_cache_test.go
@@ -1,0 +1,43 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCachedShellPATHMemoizesNonEmpty(t *testing.T) {
+	calls := 0
+	probe := cachedShellPATH(func(context.Context) string {
+		calls++
+		return "/opt/homebrew/bin"
+	})
+	for range 3 {
+		if got := probe(context.Background()); got != "/opt/homebrew/bin" {
+			t.Fatalf("probe() = %q", got)
+		}
+	}
+	if calls != 1 {
+		t.Errorf("probe ran %d times, want 1 (memoized)", calls)
+	}
+}
+
+func TestCachedShellPATHRetriesAfterEmpty(t *testing.T) {
+	calls := 0
+	results := []string{"", "", "/usr/local/bin"}
+	probe := cachedShellPATH(func(context.Context) string {
+		r := results[calls]
+		calls++
+		return r
+	})
+	// Empty results are not cached, so the probe keeps trying; once it returns
+	// a non-empty PATH that value is memoized.
+	want := []string{"", "", "/usr/local/bin", "/usr/local/bin"}
+	for i, w := range want {
+		if got := probe(context.Background()); got != w {
+			t.Fatalf("call %d: probe() = %q, want %q", i, got, w)
+		}
+	}
+	if calls != 3 {
+		t.Errorf("probe ran %d times, want 3", calls)
+	}
+}


### PR DESCRIPTION
Lands #4220 (by @weikejia123) and adds probe memoization. Closes #4220.

## The bug (#4220)
An MCP stdio server launched by absolute path (e.g. a `wrapper.sh`) ran with a `PATH` that lacked the user's interactive-shell directories (`/opt/homebrew/bin`, …). GUI launches (Finder / Dock / `open(1)`) don't inherit `~/.zshrc`'s PATH, so the wrapper's `exec uvx`/`npx` failed with `exec: uvx: not found`.

`resolveStdioExecutable` only enriched PATH from the shell on the *command-not-found fallback* path, so absolute-path commands (which resolve immediately) never got it — even though their child processes need it just as much.

## Fix (commit 1, @weikejia123)
Hoist the shell-PATH enrichment into an unconditional first step (`enrichStdioShellPATH`) so every stdio subprocess inherits the interactive PATH. Bare-command and Windows paths are unchanged.

## Memoization (commit 2)
Because the probe now runs for *every* stdio plugin, and `defaultStdioShellPATH` spawns an interactive login shell (`zsh -l -i -c …`, 2s timeout), N servers meant N shell spawns at startup. The interactive PATH is stable for the process, so the first **non-empty** probe is cached behind the injectable `stdioShellPATH` seam — one login shell per process instead of per server. Empty probes aren't cached, so a shell that becomes resolvable later is still picked up. Tests override the seam, so isolation is preserved.

## Validation
- `go build ./internal/plugin/`, `go vet`, `go test ./internal/plugin/` (existing 11 + 2 new cache tests) all pass.
