### PR TITLE
fix(desktop): optimistic rewind + checkpoint boundary corrections

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -928,12 +928,22 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 	// RestoreCode(turn) reverts every file touched in this turn or any later one, so
 	// a turn can rewind code even when it changed no files itself — as long as a
 	// later turn did. Propagate CanCode backwards over the oldest-first list.
+	// Also propagate the cumulative unique file count so the UI shows how many
+	// files RestoreCode would actually affect from this turn.
 	hasCodeAfter := false
+	codeFileSet := make(map[string]bool, len(metas)*2)
 	for i := len(out) - 1; i >= 0; i-- {
 		if len(out[i].Files) > 0 {
 			hasCodeAfter = true
 		}
+		for _, f := range out[i].Files {
+			codeFileSet[f] = true
+		}
 		out[i].CanCode = hasCodeAfter
+		out[i].Files = make([]string, 0, len(codeFileSet))
+		for f := range codeFileSet {
+			out[i].Files = append(out[i].Files, f)
+		}
 	}
 	return out
 }

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -944,6 +944,7 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 		for f := range codeFileSet {
 			out[i].Files = append(out[i].Files, f)
 		}
+		sort.Strings(out[i].Files) // map iteration is unordered; keep the list stable
 	}
 	return out
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1944,10 +1944,15 @@ export default function App() {
       try {
         await rewind(rs.turn, rs.scope);
         setRewindSignal((v) => v + 1);
+        if (rs.scope === "both") {
+          // Code was only reverted now (deferred), so refresh the dock here.
+          setDockRefreshKey((v) => v + 1);
+          setProjectRevision((v) => v + 1);
+        }
       } catch {
-        // Rewind failed — restore full items so the transcript isn't
-        // silently broken.  The controller emits a notice with details.
-        setRewindState({ ...rs, fullItems: rs.fullItems });
+        // Rewind failed: the Go conversation is intact, so the cleared
+        // optimistic state already shows the full transcript. Don't send —
+        // the controller emits a notice with the reason.
         return;
       }
     }
@@ -2002,11 +2007,6 @@ export default function App() {
     // Fill composer with the rewound-to user message.
     const insertId = Date.now();
     setComposerInsertRequest({ id: insertId, text: userItem?.text ?? "" });
-
-    if (scope === "both") {
-      setDockRefreshKey((v) => v + 1);
-      setProjectRevision((v) => v + 1);
-    }
 
     setRewindSignal((v) => v + 1);
   }, [state.items, rewind, refreshTabMetas, setComposerInsertRequest]);
@@ -2685,9 +2685,11 @@ export default function App() {
                   turns: rewindState.turnDiff,
                   filesRestored: [], // optimistic: files haven't changed yet
                   filesRemoved: [],
-                  onUndo: () => setRewindState(null),
+                  onUndo: () => {
+                    setRewindState(null);
+                    setComposerInsertRequest({ id: Date.now(), text: "" });
+                  },
                 }}
-                onDismiss={() => setRewindState(null)}
               />
             )}
             {state.approval && (

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
 import { ApprovalModal } from "./components/ApprovalModal";
 import { AskCard } from "./components/AskCard";
+import { UndoRewindBanner, type UndoRewindMeta } from "./components/UndoRewindBanner";
 import { ClearContextCard } from "./components/ClearContextCard";
 import { StatusBar } from "./components/StatusBar";
 import { HistoryPanel } from "./components/HistoryPanel";
@@ -57,6 +58,7 @@ import { shouldShowTodoPanel } from "./lib/todoVisibility";
 import {
   type BotConnectionView,
   type BotSettingsView,
+  type CheckpointMeta,
   type CollaborationMode,
   type ComposerInsertRequest,
   type Mode,
@@ -1910,7 +1912,30 @@ export default function App() {
     await openBlankSession(target.scope, target.workspaceRoot);
   }, [blankSessionTarget, closeTransientOverlays, openBlankSession]);
 
+  const [rewindSignal, setRewindSignal] = useState(0);
+  const [rewindUndo, setRewindUndo] = useState<UndoRewindMeta | null>(null);
+  const itemsRef = useRef<Item[]>([]);
+  itemsRef.current = state.items;
+  const checkpointsRef = useRef<CheckpointMeta[]>([]);
+  checkpointsRef.current = state.checkpoints as CheckpointMeta[];
+
   const handleMessageAction = useCallback(async (turn: number, scope: string) => {
+    const prevItems = itemsRef.current ?? [];
+    const prevCheckpoints = checkpointsRef.current ?? [];
+    const prevUserCount = prevItems.filter((it) => it.kind === "user").length;
+    const prevLastCp = prevCheckpoints[prevCheckpoints.length - 1];
+    const prevFiles = prevLastCp?.files ?? [];
+
+    // For non-fork rewinds, silently fork before truncating so undo can
+    // switch back to the pre-rewind state.
+    let undoForkTabId: string | undefined;
+    if (scope !== "fork") {
+      try {
+        const undoFork = await app.Fork(turn);
+        if (undoFork?.id) undoForkTabId = undoFork.id;
+      } catch { /* undo fork failed silently */ }
+    }
+
     await rewind(turn, scope);
     if (scope === "fork") {
       await refreshTabMetas();
@@ -1922,7 +1947,26 @@ export default function App() {
       setDockRefreshKey((value) => value + 1);
       setProjectRevision((value) => value + 1);
     }
-  }, [refreshTabMetas, rewind]);
+    // Compute undo meta from before/after state.
+    const nowUserCount = (itemsRef.current ?? []).filter((it) => it.kind === "user").length;
+    const turnDiff = prevUserCount - nowUserCount;
+    const nowCp = (checkpointsRef.current ?? [])[(checkpointsRef.current ?? []).length - 1];
+    const nowFiles = nowCp?.files ?? [];
+    const restored = prevFiles.filter((f: string) => !nowFiles.includes(f));
+    const removed = nowFiles.filter((f: string) => !prevFiles.includes(f));
+    if (turnDiff > 0 || restored.length > 0 || removed.length > 0) {
+      setRewindUndo({
+        turns: turnDiff,
+        filesRestored: restored,
+        filesRemoved: removed,
+        onUndo: () => {
+          setRewindUndo(null);
+          if (undoForkTabId) switchTab(undoForkTabId);
+        },
+      });
+    }
+    setRewindSignal((v) => v + 1);
+  }, [refreshTabMetas, rewind, switchTab]);
 
   const handleOpenTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string) => {
     closeTransientOverlays();
@@ -2584,6 +2628,7 @@ export default function App() {
                 checkpoints={state.checkpoints}
                 actionPending={state.messageAction != null}
                 rewindDisabled={state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+                rewindSignal={rewindSignal}
               />
             )}
           </main>
@@ -2591,6 +2636,9 @@ export default function App() {
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
             {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
+            {rewindUndo && (
+              <UndoRewindBanner meta={rewindUndo} onDismiss={() => setRewindUndo(null)} />
+            )}
             {state.approval && (
               <ApprovalModal
                 key={state.approval.id}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -38,7 +38,7 @@ import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
 import { ApprovalModal } from "./components/ApprovalModal";
 import { AskCard } from "./components/AskCard";
-import { UndoRewindBanner, type UndoRewindMeta } from "./components/UndoRewindBanner";
+import { UndoRewindBanner } from "./components/UndoRewindBanner";
 import { ClearContextCard } from "./components/ClearContextCard";
 import { StatusBar } from "./components/StatusBar";
 import { HistoryPanel } from "./components/HistoryPanel";
@@ -58,7 +58,6 @@ import { shouldShowTodoPanel } from "./lib/todoVisibility";
 import {
   type BotConnectionView,
   type BotSettingsView,
-  type CheckpointMeta,
   type CollaborationMode,
   type ComposerInsertRequest,
   type Mode,
@@ -1242,7 +1241,7 @@ export default function App() {
       const trimmed = nextGoal.trim();
       if (!trimmed) return;
       applyGoal(trimmed);
-      send(trimmed, `/goal ${trimmed}`);
+      commitThenSend(trimmed, `/goal ${trimmed}`);
     },
     [applyGoal, send],
   );
@@ -1350,7 +1349,7 @@ export default function App() {
     if (!pendingPlanRevision || state.running) return;
     const text = pendingPlanRevision;
     setPendingPlanRevision(null);
-    send(text);
+    commitThenSend(text);
   }, [pendingPlanRevision, send, state.running]);
 
   useEffect(() => {
@@ -1419,12 +1418,12 @@ export default function App() {
         } else if (["clear", "off", "stop", "done"].includes(arg.toLowerCase())) {
           applyGoal("");
         }
-        send(trimmed, submitText.trim());
+        commitThenSend(trimmed, submitText.trim());
         return;
       }
       if (collaborationMode === "goal" && !goal.trim()) {
         applyGoal(trimmed);
-        send(trimmed, `/goal ${submitText.trim()}`);
+        commitThenSend(trimmed, `/goal ${submitText.trim()}`);
         return;
       }
       const theme = /^\/theme(?:\s+(\S+))?$/.exec(trimmed);
@@ -1457,7 +1456,7 @@ export default function App() {
       await setControllerCollaborationMode(controllerComposerProfileCollaborationMode(composerProfile));
       await setControllerToolApprovalMode(toolApprovalMode);
       if (goal.trim()) await setControllerGoal(goal);
-      send(trimmed, submitText.trim());
+      commitThenSend(trimmed, submitText.trim());
     },
     [applyGoal, closeTransientOverlays, collaborationMode, composerProfile, goal, send, runShell, notice, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, steer, switchModel, t, toolApprovalMode],
   );
@@ -1913,60 +1912,104 @@ export default function App() {
   }, [blankSessionTarget, closeTransientOverlays, openBlankSession]);
 
   const [rewindSignal, setRewindSignal] = useState(0);
-  const [rewindUndo, setRewindUndo] = useState<UndoRewindMeta | null>(null);
-  const itemsRef = useRef<Item[]>([]);
-  itemsRef.current = state.items;
-  const checkpointsRef = useRef<CheckpointMeta[]>([]);
-  checkpointsRef.current = state.checkpoints as CheckpointMeta[];
 
-  const handleMessageAction = useCallback(async (turn: number, scope: string) => {
-    const prevItems = itemsRef.current ?? [];
-    const prevCheckpoints = checkpointsRef.current ?? [];
-    const prevUserCount = prevItems.filter((it) => it.kind === "user").length;
-    const prevLastCp = prevCheckpoints[prevCheckpoints.length - 1];
-    const prevFiles = prevLastCp?.files ?? [];
+  // ── Optimistic rewind ─────────────────────────────────────────────────
+  // Rewind is optimistic: the UI immediately truncates, scrolls to the
+  // target, fills the composer, and shows an undo banner.  The real Go
+  // Rewind is deferred until the user SENDS a new message.  Undo simply
+  // restores the full items list — no Go call needed.
+  type RewindState = {
+    turn: number;
+    scope: string;
+    fullItems: Item[];     // pre-truncation items (for undo)
+    boundaryIdx: number;   // first item index of the rewound-to turn
+    turnDiff: number;      // turns rolled back
+    prompt: string;        // user message text for composer fill
+  };
+  const [rewindState, setRewindState] = useState<RewindState | null>(null);
+  const rewindStateRef = useRef(rewindState);
+  rewindStateRef.current = rewindState;
 
-    // For non-fork rewinds, silently fork before truncating so undo can
-    // switch back to the pre-rewind state.
-    let undoForkTabId: string | undefined;
-    if (scope !== "fork") {
+  // Display items: truncated when an optimistic rewind is pending.
+  const displayItems = useMemo(() => {
+    if (!rewindState) return state.items;
+    return state.items.slice(0, rewindState.boundaryIdx);
+  }, [state.items, rewindState]);
+
+  // send wrapper: commits any pending optimistic rewind before sending.
+  const commitThenSend = useCallback(async (displayText: string, submitText?: string) => {
+    const rs = rewindStateRef.current;
+    if (rs) {
+      setRewindState(null);
       try {
-        const undoFork = await app.Fork(turn);
-        if (undoFork?.id) undoForkTabId = undoFork.id;
-      } catch { /* undo fork failed silently */ }
+        await rewind(rs.turn, rs.scope);
+        setRewindSignal((v) => v + 1);
+      } catch {
+        // Rewind failed — restore full items so the transcript isn't
+        // silently broken.  The controller emits a notice with details.
+        setRewindState({ ...rs, fullItems: rs.fullItems });
+        return;
+      }
     }
+    send(displayText, submitText);
+  }, [send, rewind]);
 
-    await rewind(turn, scope);
+  const handleMessageAction = useCallback((turn: number, scope: string) => {
     if (scope === "fork") {
-      await refreshTabMetas();
-      setProjectRevision((value) => value + 1);
-      setTabRevealSignal((signal) => signal + 1);
+      // Fork still goes through the controller (not optimistic).
+      rewind(turn, scope).then(() => {
+        refreshTabMetas();
+        setProjectRevision((v) => v + 1);
+        setTabRevealSignal((v) => v + 1);
+      });
       return;
     }
-    if (scope === "code" || scope === "both") {
-      setDockRefreshKey((value) => value + 1);
-      setProjectRevision((value) => value + 1);
+
+    // Code-only rewind only affects files — no message truncation,
+    // no optimistic UI needed.  Execute immediately.
+    if (scope === "code") {
+      rewind(turn, scope);
+      setDockRefreshKey((v) => v + 1);
+      setProjectRevision((v) => v + 1);
+      return;
     }
-    // Compute undo meta from before/after state.
-    const nowUserCount = (itemsRef.current ?? []).filter((it) => it.kind === "user").length;
-    const turnDiff = prevUserCount - nowUserCount;
-    const nowCp = (checkpointsRef.current ?? [])[(checkpointsRef.current ?? []).length - 1];
-    const nowFiles = nowCp?.files ?? [];
-    const restored = prevFiles.filter((f: string) => !nowFiles.includes(f));
-    const removed = nowFiles.filter((f: string) => !prevFiles.includes(f));
-    if (turnDiff > 0 || restored.length > 0 || removed.length > 0) {
-      setRewindUndo({
-        turns: turnDiff,
-        filesRestored: restored,
-        filesRemoved: removed,
-        onUndo: () => {
-          setRewindUndo(null);
-          if (undoForkTabId) switchTab(undoForkTabId);
-        },
-      });
+
+    const items = state.items;
+    // Find the boundary: index of the Nth user message where N = turn.
+    let boundaryIdx = 0;
+    let userCount = 0;
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].kind === "user") {
+        if (userCount === turn) { boundaryIdx = i; break; }
+        userCount++;
+      }
     }
+
+    const prevUserCount = items.filter((it) => it.kind === "user").length;
+    const turnDiff = prevUserCount - userCount;
+
+    // Save full items for undo.
+    const userItem = items[boundaryIdx]?.kind === "user" ? items[boundaryIdx] as Extract<Item, { kind: "user" }> : undefined;
+    setRewindState({
+      turn,
+      scope,
+      fullItems: items,
+      boundaryIdx,
+      turnDiff,
+      prompt: userItem?.text ?? "",
+    });
+
+    // Fill composer with the rewound-to user message.
+    const insertId = Date.now();
+    setComposerInsertRequest({ id: insertId, text: userItem?.text ?? "" });
+
+    if (scope === "both") {
+      setDockRefreshKey((v) => v + 1);
+      setProjectRevision((v) => v + 1);
+    }
+
     setRewindSignal((v) => v + 1);
-  }, [refreshTabMetas, rewind, switchTab]);
+  }, [state.items, rewind, refreshTabMetas, setComposerInsertRequest]);
 
   const handleOpenTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string) => {
     closeTransientOverlays();
@@ -2620,10 +2663,10 @@ export default function App() {
               </div>
             ) : (
               <Transcript
-                items={state.items}
+                items={displayItems}
                 live={state.live}
                 footerHeight={footerHeight}
-                onPrompt={send}
+                onPrompt={commitThenSend}
                 onRewind={handleMessageAction}
                 checkpoints={state.checkpoints}
                 actionPending={state.messageAction != null}
@@ -2636,8 +2679,16 @@ export default function App() {
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
             {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoItem!.id)} />}
-            {rewindUndo && (
-              <UndoRewindBanner meta={rewindUndo} onDismiss={() => setRewindUndo(null)} />
+            {rewindState && (
+              <UndoRewindBanner
+                meta={{
+                  turns: rewindState.turnDiff,
+                  filesRestored: [], // optimistic: files haven't changed yet
+                  filesRemoved: [],
+                  onUndo: () => setRewindState(null),
+                }}
+                onDismiss={() => setRewindState(null)}
+              />
             )}
             {state.approval && (
               <ApprovalModal

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -141,6 +141,7 @@ export function Transcript({
   actionPending = false,
   rewindDisabled = false,
   questionNavigator = true,
+  rewindSignal = 0,
 }: {
   items: Item[];
   live?: LiveStream;
@@ -151,6 +152,7 @@ export function Transcript({
   actionPending?: boolean;
   rewindDisabled?: boolean;
   questionNavigator?: boolean;
+  rewindSignal?: number;
 }) {
   const {
     scrollRef,
@@ -223,6 +225,18 @@ export function Transcript({
     lastFooterHeight.current = footerHeight;
     repinIfWasPinned(previous - footerHeight);
   }, [footerHeight]);
+
+  // After a non-fork rewind, scroll to the last user message (the
+  // rewound-to point) so the user knows where they are.
+  useEffect(() => {
+    if (rewindSignal <= 0 || questions.length === 0) return;
+    const lastQ = questions[questions.length - 1];
+    const el = document.getElementById(questionAnchorId(lastQ.id));
+    if (!el || !scrollRef.current) return;
+    stick.current = false;
+    scrollRef.current.scrollTop = el.offsetTop - scrollRef.current.offsetTop - 12;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rewindSignal]);
 
   // Sub-agent calls carry a parentId; collect them under their parent `task`
   // call so the parent card can render them nested, and skip them at top level.

--- a/desktop/frontend/src/components/UndoRewindBanner.tsx
+++ b/desktop/frontend/src/components/UndoRewindBanner.tsx
@@ -12,10 +12,9 @@ export interface UndoRewindMeta {
   onUndo: () => void;
 }
 
-export function UndoRewindBanner({ meta, onDismiss }: { meta: UndoRewindMeta; onDismiss: () => void }) {
+export function UndoRewindBanner({ meta }: { meta: UndoRewindMeta }) {
   const t = useT();
   const [confirm, setConfirm] = useState(false);
-  void onDismiss; // reserve for explicit dismiss (X button)
 
   const parts: string[] = [];
   if (meta.turns > 0) parts.push(t("undoRewind.turns", { n: meta.turns }));

--- a/desktop/frontend/src/components/UndoRewindBanner.tsx
+++ b/desktop/frontend/src/components/UndoRewindBanner.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import { useT } from "../lib/i18n";
+
+export interface UndoRewindMeta {
+  /** How many conversation turns were lost. */
+  turns: number;
+  /** File paths that were restored (code rewind). */
+  filesRestored: string[];
+  /** File paths that were removed (code rewind). */
+  filesRemoved: string[];
+  /** Callback when the user confirms undo. */
+  onUndo: () => void;
+}
+
+export function UndoRewindBanner({ meta, onDismiss }: { meta: UndoRewindMeta; onDismiss: () => void }) {
+  const t = useT();
+  const [confirm, setConfirm] = useState(false);
+  void onDismiss; // reserve for explicit dismiss (X button)
+
+  const parts: string[] = [];
+  if (meta.turns > 0) parts.push(t("undoRewind.turns", { n: meta.turns }));
+  if (meta.filesRestored.length > 0)
+    parts.push(t("undoRewind.filesRestored", { n: meta.filesRestored.length }));
+  if (meta.filesRemoved.length > 0)
+    parts.push(t("undoRewind.filesRemoved", { n: meta.filesRemoved.length }));
+  const summary = parts.join(" · ");
+
+  const files = [...new Set([...meta.filesRestored, ...meta.filesRemoved])];
+  const fileList = files.length > 0 ? files.slice(0, 3).map((f) => f.split(/[/\\]/).pop() || f).join(", ") + (files.length > 3 ? ` +${files.length - 3}` : "") : "";
+
+  return (
+    <div className="undo-rewind">
+      <div className="undo-rewind__info">
+        <span className="undo-rewind__label">{summary}</span>
+        {fileList && <span className="undo-rewind__files">{fileList}</span>}
+      </div>
+      <button
+        type="button"
+        className={`undo-rewind__btn${confirm ? " undo-rewind__btn--confirm" : ""}`}
+        onClick={() => {
+          if (confirm) {
+            meta.onUndo();
+            setConfirm(false);
+          } else {
+            setConfirm(true);
+          }
+        }}
+      >
+        {confirm ? t("undoRewind.confirm") : t("undoRewind.undo")}
+      </button>
+    </div>
+  );
+}

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1275,6 +1275,11 @@ export const en = {
   "rewind.busyConversation": "Rewinding conversation…",
   "rewind.busyCode": "Rewinding code…",
   "rewind.busyBoth": "Rewinding code and conversation…",
+  "undoRewind.turns": "Rolled back {n} turn(s)",
+  "undoRewind.filesRestored": "{n} file(s) restored",
+  "undoRewind.filesRemoved": "{n} file(s) removed",
+  "undoRewind.undo": "Undo",
+  "undoRewind.confirm": "Confirm undo?",
   "msg.copied": "Copied",
 
   // tool card summaries

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -785,6 +785,11 @@ export const zhTW: Record<DictKey, string> = {
   "rewind.busyConversation": "正在回滾對話…",
   "rewind.busyCode": "正在回滾程式碼…",
   "rewind.busyBoth": "正在回滾程式碼和對話…",
+  "undoRewind.turns": "已回滾 {n} 輪對話",
+  "undoRewind.filesRestored": "還原了 {n} 個檔案",
+  "undoRewind.filesRemoved": "移除了 {n} 個檔案",
+  "undoRewind.undo": "撤回",
+  "undoRewind.confirm": "確認撤回？",
   "msg.copied": "已複製",
 
   // 工具卡片摘要

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1277,6 +1277,11 @@ export const zh: Record<DictKey, string> = {
   "rewind.busyConversation": "正在回滚对话…",
   "rewind.busyCode": "正在回滚代码…",
   "rewind.busyBoth": "正在回滚代码和对话…",
+  "undoRewind.turns": "已回滚 {n} 轮对话",
+  "undoRewind.filesRestored": "还原了 {n} 个文件",
+  "undoRewind.filesRemoved": "移除了 {n} 个文件",
+  "undoRewind.undo": "撤回",
+  "undoRewind.confirm": "确认撤回？",
   "msg.copied": "已复制",
 
   // 工具卡片摘要

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4107,6 +4107,65 @@ a[href] {
   background: var(--chat-bg);
   padding: 12px 32px 10px;
 }
+
+/* ── undo-rewind banner (above composer after a rewind) ─────────────── */
+.undo-rewind {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: var(--maxw);
+  margin: 0 auto 8px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-elev);
+  font-size: 12.5px;
+  color: var(--fg-dim);
+}
+.undo-rewind__info {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  overflow: hidden;
+}
+.undo-rewind__label {
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.undo-rewind__files {
+  color: var(--fg-faint);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.undo-rewind__btn {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  transition: border-color 0.12s, background 0.12s, color 0.12s;
+}
+.undo-rewind__btn:hover {
+  border-color: var(--accent-soft);
+  color: var(--accent);
+}
+.undo-rewind__btn--confirm {
+  color: var(--accent);
+  border-color: var(--accent-soft);
+  background: var(--accent-soft);
+}
+.undo-rewind__btn--confirm:hover {
+  background: color-mix(in srgb, var(--accent-soft) 80%, transparent);
+}
+
 .composer-wrap {
   position: relative;
   max-width: var(--maxw);

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -212,6 +212,12 @@ func (s *Store) List() []Meta {
 		for i, f := range c.Files {
 			paths[i] = f.Path
 		}
+		// The current in-progress turn's files haven't been committed
+		// yet — they must not participate in CanCode propagation.
+		// Include the turn itself so it still appears as a rewind point.
+		if c == s.cur {
+			paths = nil
+		}
 		out = append(out, Meta{Turn: c.Turn, Time: c.Time, Prompt: c.Prompt, Paths: paths})
 	}
 	return out

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1631,8 +1631,14 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 func (c *Controller) CheckpointHasBoundary(turn int) bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	_, ok := c.cpBound[turn]
-	return ok
+	boundary, ok := c.cpBound[turn]
+	if !ok {
+		return false
+	}
+	// After compaction the key may still exist but the boundary value is
+	// stale (it points past the truncated message log).  Treat those
+	// turns the same as "no boundary" so the UI can disable the button.
+	return boundary <= len(c.executor.Session().Messages)
 }
 
 // Branch copies the current conversation into a child branch and switches to it.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1518,8 +1518,10 @@ func (c *Controller) Rewind(turn int, scope RewindScope) error {
 		if err != nil {
 			return c.rewindFail(fmt.Errorf("rewind code: %w", err))
 		}
-		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
-			Text: fmt.Sprintf("rewound code to turn %d — %d file(s) restored, %d removed", turn, len(written), len(deleted))})
+		if len(written) > 0 || len(deleted) > 0 {
+			c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo,
+				Text: fmt.Sprintf("rewound code to turn %d — %d file(s) restored, %d removed", turn, len(written), len(deleted))})
+		}
 	}
 	if scope == RewindConversation || scope == RewindBoth {
 		if !hasBound {


### PR DESCRIPTION
Lands #4269 (by @CVEngineer66) and tightens a few rough edges in the optimistic-rewind flow. Closes #4269.

## What #4269 fixes (commits 1–4, @CVEngineer66)
- **CheckpointHasBoundary**: after compaction the `cpBound[turn]` key can survive while its boundary points past the truncated log. Now validates `boundary <= len(Messages)` — exactly the guard `Rewind` itself applies — so the UI button state matches what a rewind will accept.
- **checkpoint.List()**: the in-progress turn's files no longer participate in CanCode propagation (its `Paths` are nilled), while the turn still shows as a rewind point.
- **RestoreCode notice**: only emitted when files actually changed (no more "0 restored, 0 removed").
- **CheckpointsForTab**: propagates the cumulative unique file set backward so the UI shows how many files a code rewind would really affect.
- **Optimistic rewind**: clicking rewind truncates the UI, refills the composer, and shows an undo banner immediately; the real Go `Rewind` is deferred until the next send. Undo restores the full items with no Go call.

## Follow-on tightening (commit 5)
- **Failure path**: if the deferred rewind throws, leave the optimistic state cleared (full transcript shown, matching the intact Go conversation) instead of re-truncating to a view the Go side no longer matches.
- **scope=both**: defer the dock/project refresh until the rewind actually commits, so the file dock no longer flashes the un-rewound state.
- **Undo** clears the refilled composer.
- **Deterministic Files**: sort `CheckpointsForTab`'s cumulative list (Go map order is unordered).
- Drop the unused `onDismiss` prop from `UndoRewindBanner`.

## Validation
- `go build ./...` (desktop + core), `go vet`, `go test ./internal/checkpoint/ ./internal/control/` pass.
- `tsc --noEmit` (after `wails generate module`) + `check:css` pass.
