### PR TITLE
Fix session ownership follow-up review issues / 修复会话归属后续评审问题

### DIFF
--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -796,7 +796,9 @@ export function MemorySettingsPage() {
 		setSuggestionBusy(true);
 		setError(null);
 		try {
-			const next = await app.MemorySuggestions();
+			const next = selectedTabId
+				? await app.MemorySuggestionsForTab(selectedTabId)
+				: await app.MemorySuggestions();
 			setSuggestions({
 				memories: next.memories ?? [],
 				skills: next.skills ?? [],
@@ -810,7 +812,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setSuggestionBusy(false);
 		}
-	}, [suggestionBusy]);
+	}, [selectedTabId, suggestionBusy]);
 
 	const setAutoSuggestionsPreference = useCallback((enabled: boolean) => {
 		autoSuggestionsRequested.current = false;
@@ -960,7 +962,9 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			const path = await app.AcceptMemorySuggestion(candidate);
+			const path = selectedTabId
+				? await app.AcceptMemorySuggestionForTab(selectedTabId, candidate)
+				: await app.AcceptMemorySuggestion(candidate);
 			setAcceptedSuggestions((prev) => ({ ...prev, [candidate.id]: path || candidate.name }));
 			await reload();
 		} catch (err) {
@@ -968,21 +972,23 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [busy, reload]);
+	}, [busy, reload, selectedTabId]);
 
 	const acceptSkillSuggestion = useCallback(async (candidate: SkillSuggestion) => {
 		if (busy) return;
 		setBusy(true);
 		setError(null);
 		try {
-			const path = await app.AcceptSkillSuggestion(candidate);
+			const path = selectedTabId
+				? await app.AcceptSkillSuggestionForTab(selectedTabId, candidate)
+				: await app.AcceptSkillSuggestion(candidate);
 			setAcceptedSuggestions((prev) => ({ ...prev, [candidate.id]: path || candidate.name }));
 		} catch (err) {
 			setError(errorMessage(err));
 		} finally {
 			setBusy(false);
 		}
-	}, [busy]);
+	}, [busy, selectedTabId]);
 
 	if (!view?.available) {
 		return (

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -200,6 +200,9 @@ export interface AppBindings {
   AcceptMemorySuggestion(suggestion: MemorySuggestion): Promise<string>;
   AcceptSkillSuggestion(suggestion: SkillSuggestion): Promise<string>;
   MemoryForTab(tabID: string): Promise<MemoryView>;
+  MemorySuggestionsForTab(tabID: string): Promise<MemorySuggestionsView>;
+  AcceptMemorySuggestionForTab(tabID: string, suggestion: MemorySuggestion): Promise<string>;
+  AcceptSkillSuggestionForTab(tabID: string, suggestion: SkillSuggestion): Promise<string>;
   Remember(scope: string, note: string): Promise<string>;
   RememberForTab(tabID: string, scope: string, note: string): Promise<string>;
   Forget(name: string): Promise<void>;
@@ -2140,6 +2143,15 @@ function makeMockApp(): AppBindings {
     async AcceptSkillSuggestion(suggestion: SkillSuggestion) {
       emit({ kind: "notice", level: "info", text: `created suggested skill → ${suggestion.name}` });
       return `.reasonix/skills/${suggestion.name}/SKILL.md`;
+    },
+    async MemorySuggestionsForTab(_tabID: string) {
+      return this.MemorySuggestions();
+    },
+    async AcceptMemorySuggestionForTab(_tabID: string, suggestion: MemorySuggestion) {
+      return this.AcceptMemorySuggestion(suggestion);
+    },
+    async AcceptSkillSuggestionForTab(_tabID: string, suggestion: SkillSuggestion) {
+      return this.AcceptSkillSuggestion(suggestion);
     },
     async MemoryForTab(_tabID: string) {
       return this.Memory();

--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -76,6 +76,12 @@ type workflowCategory struct {
 // MemorySuggestions scans recent local history and returns draft memory/skill
 // candidates. It does not modify memory, skills, sessions, or model context.
 func (a *App) MemorySuggestions() MemorySuggestionsView {
+	return a.MemorySuggestionsForTab("")
+}
+
+// MemorySuggestionsForTab scans recent local history for the selected tab's
+// session directory and workspace, instead of whichever tab is currently active.
+func (a *App) MemorySuggestionsForTab(tabID string) MemorySuggestionsView {
 	view := MemorySuggestionsView{
 		Memories:    []MemorySuggestion{},
 		Skills:      []SkillSuggestion{},
@@ -83,7 +89,7 @@ func (a *App) MemorySuggestions() MemorySuggestionsView {
 	}
 
 	a.mu.RLock()
-	tab := a.activeTabLocked()
+	tab := a.tabByIDLocked(tabID)
 	var ctrl *control.Controller
 	workspaceRoot := ""
 	sessionDir := ""
@@ -111,9 +117,13 @@ func (a *App) MemorySuggestions() MemorySuggestionsView {
 
 // AcceptMemorySuggestion persists a previously previewed memory candidate.
 func (a *App) AcceptMemorySuggestion(in MemorySuggestion) (string, error) {
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
+	return a.AcceptMemorySuggestionForTab("", in)
+}
+
+// AcceptMemorySuggestionForTab persists a memory candidate into the selected
+// tab's memory store, matching the tab used to generate suggestions.
+func (a *App) AcceptMemorySuggestionForTab(tabID string, in MemorySuggestion) (string, error) {
+	ctrl := a.ctrlByTabID(tabID)
 	if ctrl == nil {
 		return "", nil
 	}
@@ -136,8 +146,14 @@ func (a *App) AcceptMemorySuggestion(in MemorySuggestion) (string, error) {
 // skill store so name validation, scope handling, and no-overwrite behavior stay
 // centralized.
 func (a *App) AcceptSkillSuggestion(in SkillSuggestion) (string, error) {
+	return a.AcceptSkillSuggestionForTab("", in)
+}
+
+// AcceptSkillSuggestionForTab writes a skill candidate into the selected tab's
+// workspace/global skill store, matching the tab used to generate suggestions.
+func (a *App) AcceptSkillSuggestionForTab(tabID string, in SkillSuggestion) (string, error) {
 	a.mu.RLock()
-	tab := a.activeTabLocked()
+	tab := a.tabByIDLocked(tabID)
 	workspaceRoot := ""
 	if tab != nil {
 		workspaceRoot = tab.WorkspaceRoot

--- a/desktop/memory_suggestions_test.go
+++ b/desktop/memory_suggestions_test.go
@@ -66,6 +66,87 @@ func TestMemorySuggestionsAcceptMemoryCandidate(t *testing.T) {
 	}
 }
 
+func TestMemorySuggestionsForTabUsesSelectedTab(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	activeUserDir := t.TempDir()
+	selectedUserDir := t.TempDir()
+	activeCwd := t.TempDir()
+	selectedCwd := t.TempDir()
+	activeSessionDir := t.TempDir()
+	selectedSessionDir := t.TempDir()
+	activeStore := memory.StoreFor(activeUserDir, activeCwd)
+	selectedStore := memory.StoreFor(selectedUserDir, selectedCwd)
+	writeSuggestionSession(t, selectedSessionDir, "selected.jsonl",
+		provider.Message{Role: provider.RoleUser, Content: "以后请始终用中文回复，除非我明确要求英文。"},
+		provider.Message{Role: provider.RoleAssistant, Content: "好的。"},
+	)
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{
+		Memory:     &memory.Set{Store: activeStore, CWD: activeCwd, UserDir: activeUserDir},
+		SessionDir: activeSessionDir,
+	}), "test-model")
+	app.tabs["test"].WorkspaceRoot = activeCwd
+	app.tabs["selected"] = &WorkspaceTab{
+		ID:            "selected",
+		Scope:         "project",
+		WorkspaceRoot: selectedCwd,
+		Ctrl: control.New(control.Options{
+			Memory:     &memory.Set{Store: selectedStore, CWD: selectedCwd, UserDir: selectedUserDir},
+			SessionDir: selectedSessionDir,
+		}),
+		Ready:       true,
+		disabledMCP: map[string]ServerView{},
+	}
+
+	if view := app.MemorySuggestions(); len(view.Memories) != 0 {
+		t.Fatalf("active tab suggestions = %+v, want none", view.Memories)
+	}
+	view := app.MemorySuggestionsForTab("selected")
+	if len(view.Memories) == 0 {
+		t.Fatalf("MemorySuggestionsForTab(selected) memories = %+v, want at least one candidate", view.Memories)
+	}
+	path, err := app.AcceptMemorySuggestionForTab("selected", view.Memories[0])
+	if err != nil {
+		t.Fatalf("AcceptMemorySuggestionForTab: %v", err)
+	}
+	if !strings.HasPrefix(path, selectedStore.Dir) && !strings.HasPrefix(path, selectedStore.GlobalDir) {
+		t.Fatalf("memory path = %q, want selected store under %q or %q", path, selectedStore.Dir, selectedStore.GlobalDir)
+	}
+	if got := activeStore.List(); len(got) != 0 {
+		t.Fatalf("active store should remain untouched, got %+v", got)
+	}
+	got := selectedStore.List()
+	if len(got) != 1 || !strings.Contains(got[0].Body, "中文回复") {
+		t.Fatalf("selected store = %+v, want confirmed candidate body", got)
+	}
+
+	skillPath, err := app.AcceptSkillSuggestionForTab("selected", SkillSuggestion{
+		ID:          "selected-skill",
+		Name:        "selected-workflow",
+		Description: "Selected workspace workflow",
+		Scope:       "project",
+		Body:        "Use the selected workspace context before changing files.",
+	})
+	if err != nil {
+		t.Fatalf("AcceptSkillSuggestionForTab: %v", err)
+	}
+	wantSkillPath := filepath.Join(selectedCwd, ".reasonix", "skills", "selected-workflow", "SKILL.md")
+	if skillPath != wantSkillPath {
+		t.Fatalf("skill path = %q, want %q", skillPath, wantSkillPath)
+	}
+	if _, err := os.Stat(filepath.Join(activeCwd, ".reasonix", "skills", "selected-workflow", "SKILL.md")); !os.IsNotExist(err) {
+		t.Fatalf("active workspace should not receive selected skill, stat err = %v", err)
+	}
+	body, err := os.ReadFile(skillPath)
+	if err != nil {
+		t.Fatalf("read selected skill: %v", err)
+	}
+	if !strings.Contains(string(body), "selected workspace context") {
+		t.Fatalf("selected skill body missing candidate content:\n%s", body)
+	}
+}
+
 func TestMemorySuggestionsAcceptSkillCandidate(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	userDir := t.TempDir()

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -444,9 +444,12 @@ func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
 			continue
 		}
 		j.mu.Lock()
-		if j.status == Running {
+		switch j.status {
+		case Running:
 			j.status = Killed
 			cancels = append(cancels, j.cancel)
+			done = append(done, j.done)
+		case Killed:
 			done = append(done, j.done)
 		}
 		j.mu.Unlock()

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -311,3 +311,57 @@ func TestDestroySessionCancelsOwnedJobsAndSuppressesCompletion(t *testing.T) {
 		t.Fatal("session-a should no longer be marked destroying")
 	}
 }
+
+func TestDestroySessionWaitsForAlreadyKilledJobs(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	j := m.StartForSession("session-a", "task", "cleanup", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		<-release
+		return "", ctx.Err()
+	})
+	<-started
+
+	if !m.KillForSession("session-a", j.ID) {
+		t.Fatal("KillForSession on a running job returned false")
+	}
+	waitFor(t, func() bool {
+		_, status, ok := m.OutputForSession("session-a", j.ID)
+		return ok && status == Killed
+	})
+
+	done := m.DestroySession("session-a")
+	if len(done) != 1 {
+		t.Fatalf("DestroySession returned %d done channels, want 1", len(done))
+	}
+	if !m.IsDestroying("session-a") {
+		t.Fatal("session-a should be marked destroying")
+	}
+	select {
+	case <-done[0]:
+		t.Fatal("done channel closed before killed job finished unwinding")
+	default:
+	}
+
+	close(release)
+	select {
+	case <-done[0]:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for killed job to unwind")
+	}
+	res := m.WaitForSession(context.Background(), "session-a", []string{j.ID}, 5)
+	if len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("destroyed job result = %+v, want killed", res)
+	}
+	if note := m.DrainCompletedNoteForSession("session-a"); note != "" {
+		t.Fatalf("destroyed session should not queue completion note, got %q", note)
+	}
+	m.FinishDestroySession("session-a")
+	if m.IsDestroying("session-a") {
+		t.Fatal("session-a should no longer be marked destroying")
+	}
+}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -201,6 +201,14 @@ func (s Store) Save(m Memory) (string, error) {
 	if err := reindexIn(dir, name, m); err != nil {
 		return path, err
 	}
+	for _, otherDir := range s.dirs() {
+		if sameDir(otherDir, dir) {
+			continue
+		}
+		if err := removeActiveMemoryInDir(otherDir, name); err != nil {
+			return path, err
+		}
+	}
 	return path, nil
 }
 
@@ -227,14 +235,30 @@ func (s Store) Archive(name string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if p != "" {
+		if p != "" || indexContainsIn(dir, name) {
 			if err := flushIndexIn(dir, indexLinesExceptIn(dir, name)); err != nil {
 				return "", err
 			}
+		}
+		if p != "" {
 			lastPath = p
 		}
 	}
 	return lastPath, nil
+}
+
+func removeActiveMemoryInDir(dir, name string) error {
+	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	p, err := archiveInDir(dir, name)
+	if err != nil {
+		return err
+	}
+	if p != "" || indexContainsIn(dir, name) {
+		return flushIndexIn(dir, indexLinesExceptIn(dir, name))
+	}
+	return nil
 }
 
 // Delete removes a memory from the active store and its MEMORY.md line — the
@@ -390,6 +414,19 @@ func indexLinesExceptIn(dir, name string) map[string]string {
 		}
 	}
 	return keep
+}
+
+func indexContainsIn(dir, name string) bool {
+	existing, err := os.ReadFile(filepath.Join(dir, indexFile))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(existing), "\n") {
+		if mt := indexLineRe.FindStringSubmatch(line); mt != nil && mt[1] == name {
+			return true
+		}
+	}
+	return false
 }
 
 // flushIndexIn rewrites MEMORY.md in the given directory from the managed lines,

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -240,6 +240,34 @@ func TestStoreArchiveReturnsArchivePath(t *testing.T) {
 	}
 }
 
+func TestStoreArchiveFlushesStaleIndexWithoutFile(t *testing.T) {
+	s := Store{Dir: t.TempDir()}
+	if _, err := s.Save(Memory{Name: "beta", Description: "keep", Type: TypeProject, Body: "body"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := flushIndexIn(s.Dir, map[string]string{
+		"alpha": "- [alpha](alpha.md) — stale",
+		"beta":  "- [beta](beta.md) — keep",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	archive, err := s.Archive("alpha")
+	if err != nil {
+		t.Fatalf("Archive stale index: %v", err)
+	}
+	if archive != "" {
+		t.Fatalf("Archive should return no path for missing file, got %q", archive)
+	}
+	idx := s.Index()
+	if strings.Contains(idx, "alpha.md") {
+		t.Fatalf("stale index line should be removed:\n%s", idx)
+	}
+	if !strings.Contains(idx, "beta.md") {
+		t.Fatalf("unrelated index line should remain:\n%s", idx)
+	}
+}
+
 func TestStoreListArchivedNewestFirst(t *testing.T) {
 	s := Store{Dir: t.TempDir()}
 	dir := filepath.Join(s.Dir, ".archive")
@@ -392,6 +420,48 @@ func TestStoreGlobalAndProject(t *testing.T) {
 	idx2 := s.Index()
 	if strings.Count(idx2, "# Memory") != 0 {
 		t.Fatalf("Index should have 0 # Memory headers (Block() adds one), got %d:\n%s", strings.Count(idx2, "# Memory"), idx2)
+	}
+}
+
+func TestStoreSaveRemovesStaleCopyWhenScopeChanges(t *testing.T) {
+	dir := t.TempDir()
+	s := Store{
+		Dir:       filepath.Join(dir, "project", "memory"),
+		GlobalDir: filepath.Join(dir, "global"),
+	}
+
+	globalPath, err := s.Save(Memory{Name: "same-name", Description: "old global", Type: TypeUser, Body: "old body"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	projectPath, err := s.Save(Memory{Name: "same-name", Description: "new project", Type: TypeProject, Body: "new body"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(projectPath, s.Dir) {
+		t.Fatalf("project-scoped rewrite should land in project dir, got %s", projectPath)
+	}
+	if _, err := os.Stat(globalPath); !os.IsNotExist(err) {
+		t.Fatalf("old global active file should be archived away, stat err = %v", err)
+	}
+	globalIndex, err := os.ReadFile(filepath.Join(s.GlobalDir, indexFile))
+	if err != nil {
+		t.Fatalf("read global index: %v", err)
+	}
+	if strings.Contains(string(globalIndex), "same-name.md") {
+		t.Fatalf("old global index line should be removed:\n%s", globalIndex)
+	}
+
+	list := s.List()
+	if len(list) != 1 {
+		t.Fatalf("List() = %+v, want one active copy", list)
+	}
+	if list[0].Type != TypeProject || !strings.Contains(list[0].Body, "new body") {
+		t.Fatalf("active copy = %+v, want new project body", list[0])
+	}
+	idx := s.Index()
+	if strings.Contains(idx, "old global") || !strings.Contains(idx, "new project") {
+		t.Fatalf("merged index should reflect new scope only:\n%s", idx)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4250 for the bot review threads that were left as post-merge cleanup:

- Flush stale `MEMORY.md` entries even when the active memory file is already absent.
- Archive/remove the old active memory copy and stale index line when the same memory name is saved into a different scope.
- Keep `DestroySession` waiting on jobs that were already marked `Killed` but have not finished unwinding.
- Route memory suggestion generation and acceptance through the selected Memory panel tab instead of the active tab.
- The approved-plan `complete_step` review point is already resolved on current `main-v2` by #4266, so this PR leaves that controller path unchanged.

## Credits / Attribution

This follow-up is part of the #4250 integration and keeps the original contributor attribution:

- #4215 by @lifu963: session-scoped `SubagentStore`, background job ownership, session destroy cleanup, Desktop restore guarding, and late writeback prevention. This PR fixes the follow-up `DestroySession` edge for already-killed jobs.
- #4073 by @ashishexee: `GlobalDir` routing and tab-aware memory panel behavior. This PR fixes stale memory scope/index cleanup and tab-scoped suggestion APIs on top of that work.
- #3935 by @AresNing: approved-plan pause/resume behavior. The remaining bot thread for that area was addressed on `main-v2` by #4266.

The commit includes `Co-authored-by` trailers for @lifu963, @ashishexee, and @AresNing so GitHub can credit them as co-authors.

## Verification

- `PATH="$(go env GOPATH)/bin:$PATH" wails generate module` with Wails 2.12.0
- `go test ./internal/memory`
- `go test ./internal/jobs`
- `go test ./internal/control -run 'TestApprovedPlan'`
- `go test . -run 'TestMemorySuggestions'` in `desktop/`
- `npm run build` in `desktop/frontend`
