### PR TITLE
fix(checkpoint): ignore out-of-workspace rewind snapshots

### DIFF
--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -134,24 +134,43 @@ func (s *Store) Snapshot(ch diff.Change) {
 	if ch.Path == "" {
 		return
 	}
+	path, ok := s.snapshotPath(ch.Path)
+	if !ok {
+		return
+	}
 	var enc *fileenc.Kind
 	if ch.Kind != diff.Create {
-		enc = s.detectEncoding(ch.Path)
+		enc = s.detectEncoding(path)
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.cur == nil || s.seen[ch.Path] {
+	if s.cur == nil || s.seen[path] {
 		return
 	}
-	s.seen[ch.Path] = true
+	s.seen[path] = true
 	var content *string
 	if ch.Kind != diff.Create { // create == file didn't exist → leave nil (restore deletes)
 		old := ch.OldText
 		content = &old
 	}
-	s.cur.Files = append(s.cur.Files, FileSnap{Path: ch.Path, Content: content, Encoding: enc})
+	s.cur.Files = append(s.cur.Files, FileSnap{Path: path, Content: content, Encoding: enc})
 	s.persist(s.cur)
+}
+
+func (s *Store) snapshotPath(p string) (string, bool) {
+	if s.root == "" {
+		return filepath.Clean(p), true
+	}
+	abs, err := safePath(s.root, p)
+	if err != nil {
+		return "", false
+	}
+	rel, err := filepath.Rel(filepath.Clean(s.root), abs)
+	if err != nil || rel == "." || relEscapesRoot(rel) {
+		return "", false
+	}
+	return filepath.ToSlash(filepath.Clean(rel)), true
 }
 
 func (s *Store) detectEncoding(p string) *fileenc.Kind {
@@ -260,7 +279,7 @@ func (s *Store) RestoreCode(fromTurn int) (written, deleted []string, err error)
 	for _, p := range order {
 		abs, gerr := safePath(root, p)
 		if gerr != nil {
-			err = gerr
+			slog.Warn("checkpoint: skipped restore path outside workspace", "path", p, "root", root, "err", gerr)
 			continue
 		}
 		snap := earliest[p]
@@ -311,9 +330,14 @@ func safePath(root, p string) (string, error) {
 	abs = filepath.Clean(abs)
 	if root != "" {
 		r := filepath.Clean(root)
-		if abs != r && !strings.HasPrefix(abs, r+string(os.PathSeparator)) {
+		rel, err := filepath.Rel(r, abs)
+		if err != nil || relEscapesRoot(rel) {
 			return "", fmt.Errorf("checkpoint path %q escapes workspace %q", p, root)
 		}
 	}
 	return abs, nil
+}
+
+func relEscapesRoot(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel)
 }

--- a/internal/checkpoint/checkpoint_test.go
+++ b/internal/checkpoint/checkpoint_test.go
@@ -205,18 +205,70 @@ func TestSnapshotDedupsFirstTouchWins(t *testing.T) {
 	}
 }
 
-func TestRestoreRejectsPathEscape(t *testing.T) {
+func TestRestoreSkipsPersistedPathEscape(t *testing.T) {
 	root := t.TempDir()
+	inside := filepath.Join(root, "a.txt")
 	outside := filepath.Join(t.TempDir(), "evil.txt")
+	write(t, inside, "old")
 	write(t, outside, "keep")
 	s := New("", root)
 	s.Begin(0, "p", 0)
-	s.Snapshot(diff.Change{Path: outside, Kind: diff.Modify, OldText: "hacked"})
-	if _, _, err := s.RestoreCode(0); err == nil {
-		t.Fatal("RestoreCode should reject a path outside the workspace")
+	before := "old"
+	outsideBefore := "hacked"
+	s.cur.Files = append(s.cur.Files, FileSnap{Path: "a.txt", Content: &before})
+	s.cur.Files = append(s.cur.Files, FileSnap{Path: outside, Content: &outsideBefore})
+	write(t, inside, "new")
+	if _, _, err := s.RestoreCode(0); err != nil {
+		t.Fatalf("RestoreCode should skip a persisted path outside the workspace: %v", err)
+	}
+	if got := read(t, inside); got != "old" {
+		t.Fatalf("inside file = %q, want old", got)
 	}
 	if got := read(t, outside); got != "keep" {
 		t.Fatalf("outside file was modified: %q", got)
+	}
+}
+
+func TestSnapshotSkipsOutsideWorkspaceWithoutBreakingRestore(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "a.txt")
+	outside := filepath.Join(t.TempDir(), "memory.txt")
+	write(t, inside, "old")
+	write(t, outside, "keep")
+
+	s := New("", root)
+	s.Begin(0, "p", 0)
+	s.Snapshot(diff.Change{Path: inside, Kind: diff.Modify, OldText: "old"})
+	s.Snapshot(diff.Change{Path: outside, Kind: diff.Modify, OldText: "memory-old"})
+	write(t, inside, "new")
+	write(t, outside, "changed-outside")
+
+	if _, _, err := s.RestoreCode(0); err != nil {
+		t.Fatalf("RestoreCode should ignore outside-workspace snapshots captured during the turn: %v", err)
+	}
+	if got := read(t, inside); got != "old" {
+		t.Fatalf("inside file = %q, want old", got)
+	}
+	if got := read(t, outside); got != "changed-outside" {
+		t.Fatalf("outside file should not be restored, got %q", got)
+	}
+}
+
+func TestSnapshotStoresWorkspaceRelativePaths(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "sub", "a.txt")
+	write(t, inside, "old")
+
+	s := New("", root)
+	s.Begin(0, "p", 0)
+	s.Snapshot(diff.Change{Path: inside, Kind: diff.Modify, OldText: "old"})
+	s.Snapshot(diff.Change{Path: filepath.Join("sub", "a.txt"), Kind: diff.Modify, OldText: "new"})
+
+	if len(s.cur.Files) != 1 {
+		t.Fatalf("snapshots = %d, want 1", len(s.cur.Files))
+	}
+	if got := s.cur.Files[0].Path; got != "sub/a.txt" {
+		t.Fatalf("snapshot path = %q, want workspace-relative slash path", got)
 	}
 }
 


### PR DESCRIPTION
Closes #4246

## Problem
Code-only rewind can fail on Windows with an error like `rewind code: checkpoint path ... escapes workspace ...` when a checkpoint contains a path outside the active project root. In that state the desktop shows the rewind action, but the restore aborts before the user's project files are rolled back.

## Root cause
Checkpoint snapshots recorded writer-preview paths verbatim. In project tabs, that allowed absolute paths outside `WorkspaceRoot` (for example Reasonix-managed project or memory files) to be persisted beside normal workspace edits. `RestoreCode` later rejected those paths with the workspace escape guard, which is safe but made one out-of-scope snapshot fail the whole code rewind. Existing sessions could keep hitting the same failure because the bad path was already persisted.

## Fix
- Normalize in-workspace snapshot paths to workspace-relative slash paths before storing them.
- Skip new snapshots whose preview path is outside the checkpoint workspace root.
- Keep the restore-time escape guard, but skip legacy out-of-workspace checkpoint entries instead of failing the entire restore.
- Switch the root containment check to `filepath.Rel`, avoiding fragile string-prefix comparisons.

## Validation
- `go test ./internal/checkpoint -run 'TestRestoreSkipsPersistedPathEscape|TestSnapshotSkipsOutsideWorkspaceWithoutBreakingRestore|TestSnapshotStoresWorkspaceRelativePaths' -count=1`
- Clean detached worktree at this commit:
  - `gofmt -l .`
  - `git diff --check HEAD^ HEAD`
  - `go test ./...`
  - `go test ./...` in `desktop/`
  - `go vet ./...`
  - `go vet ./...` in `desktop/`
  - `go build ./...`
  - `go build ./...` in `desktop/`
  - `npm run test:all` in `desktop/frontend`
  - `npm run build` in `desktop/frontend`
