### PR TITLE
Fix stale DeepSeek desktop model fallback / 修复桌面端 DeepSeek 旧模型兜底

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3527,6 +3527,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	if err != nil {
 		return err
 	}
+	modelRef := entry.Name + "/" + entry.Model
 	effort, err := config.NormalizeEffort(entry, level)
 	if err != nil {
 		return err
@@ -3540,7 +3541,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		tab.Ctrl.Close()
 	}
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:          tab.model,
+		Model:          modelRef,
 		RequireKey:     false,
 		Sink:           tab.sink,
 		WorkspaceRoot:  tab.WorkspaceRoot,
@@ -3554,6 +3555,7 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 	a.bindControllerDisplayRecorder(newCtrl)
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
+	tab.model = modelRef
 	tab.effort = &effort
 	tab.Label = newCtrl.Label()
 	tab.StartupErr = ""
@@ -3594,6 +3596,13 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	if ctrl != nil && ctrl.Running() {
 		return fmt.Errorf("finish or cancel the current turn before changing token mode")
 	}
+	modelRef, fallback, err := a.resolvedModelForTab(tab)
+	if err != nil {
+		return err
+	}
+	if fallback && strings.TrimSpace(tab.model) != "" {
+		a.noticeForTab(tab.ID, fmt.Sprintf("model %q is no longer available; switched to %s", tab.model, modelRef))
+	}
 
 	var carried []provider.Message
 	prevPath := ""
@@ -3604,7 +3613,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		carried = oldCtrl.History()
 	}
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:          tab.model,
+		Model:          modelRef,
 		RequireKey:     false,
 		Sink:           tab.sink,
 		WorkspaceRoot:  tab.WorkspaceRoot,
@@ -3621,6 +3630,7 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 	}
 	a.mu.Lock()
 	tab.Ctrl = newCtrl
+	tab.model = modelRef
 	tab.tokenMode = mode
 	tab.Label = newCtrl.Label()
 	tab.StartupErr = ""
@@ -4125,6 +4135,25 @@ func (a *App) currentProviderEntryForTab(tabID string) (*config.ProviderEntry, e
 		entry.Effort = *effortOverride
 	}
 	return entry, nil
+}
+
+func (a *App) resolvedModelForTab(tab *WorkspaceTab) (string, bool, error) {
+	if tab == nil {
+		return "", false, fmt.Errorf("no active tab")
+	}
+	cfg, err := config.LoadForRoot(tab.WorkspaceRoot)
+	if err != nil {
+		return "", false, err
+	}
+	ref := strings.TrimSpace(tab.model)
+	if ref == "" {
+		ref = cfg.DefaultModel
+	}
+	resolved, fallback, ok := cfg.ResolveModelWithFallback(ref)
+	if !ok {
+		return "", false, fmt.Errorf("unknown model %q", ref)
+	}
+	return resolved, fallback, nil
 }
 
 func (a *App) withActiveWorkspace(fn func() (string, error)) (string, error) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -995,6 +995,47 @@ func TestSetEffortRebuildsController(t *testing.T) {
 	}
 }
 
+func TestSetEffortMigratesStaleOfficialDeepSeekTabModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "deepseek/deepseek-v4-flash"
+	cfg.Desktop.ProviderAccess = []string{"deepseek"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "deepseek",
+		Kind:      "openai",
+		BaseURL:   "https://api.deepseek.com",
+		Model:     "glm-5",
+		APIKeyEnv: "DEEPSEEK_API_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	old := control.New(control.Options{Label: "old-controller"})
+	app.setTestCtrl(old, "deepseek-flash/deepseek-v4-flash")
+	defer func() {
+		if c := app.activeCtrl(); c != nil {
+			c.Close()
+		}
+	}()
+
+	if err := app.SetEffort("max"); err != nil {
+		t.Fatalf("SetEffort(max): %v", err)
+	}
+	tab := app.activeTab()
+	if tab == nil {
+		t.Fatal("active tab missing")
+	}
+	if tab.model != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("tab model = %q, want migrated official ref", tab.model)
+	}
+}
+
 func TestSetTokenModeRebuildsController(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
@@ -1034,8 +1075,54 @@ func TestSetTokenModeRebuildsController(t *testing.T) {
 	}
 }
 
+func TestSetTokenModeMigratesStaleOfficialDeepSeekTabModel(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "deepseek/deepseek-v4-flash"
+	cfg.Desktop.ProviderAccess = []string{"deepseek"}
+	cfg.Providers = []config.ProviderEntry{{
+		Name:      "deepseek",
+		Kind:      "openai",
+		BaseURL:   "https://api.deepseek.com",
+		Model:     "glm-5",
+		APIKeyEnv: "DEEPSEEK_API_KEY",
+	}}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.readyHook = func() {}
+	old := control.New(control.Options{Label: "old-controller"})
+	app.setTestCtrl(old, "deepseek-flash/deepseek-v4-flash")
+	defer func() {
+		if c := app.activeCtrl(); c != nil {
+			c.Close()
+		}
+	}()
+
+	if err := app.SetTokenMode("economy"); err != nil {
+		t.Fatalf("SetTokenMode(economy): %v", err)
+	}
+	tab := app.activeTab()
+	if tab == nil {
+		t.Fatal("active tab missing")
+	}
+	if tab.model != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("tab model = %q, want migrated official ref", tab.model)
+	}
+	if got := currentTabTokenMode(tab); got != "economy" {
+		t.Fatalf("token mode = %q, want economy", got)
+	}
+}
+
 func TestSetTokenModeKeepsControllerWhenRebuildFails(t *testing.T) {
 	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	t.Setenv("MIMO_API_KEY", "")
 
 	app := NewApp()
 	app.ctx = context.Background()

--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -111,6 +111,54 @@ func TestNormalizeDesktopOfficialProviderAccessCanonicalizesLegacyIDs(t *testing
 	}
 }
 
+func TestNormalizeOfficialDeepSeekModelsRepairsCanonicalProvider(t *testing.T) {
+	c := &Config{
+		DefaultModel: "deepseek-flash/deepseek-v4-flash",
+		Desktop:      DesktopConfig{ProviderAccess: []string{"deepseek"}},
+		Providers: []ProviderEntry{{
+			Name:      "deepseek",
+			Kind:      "openai",
+			BaseURL:   "https://api.deepseek.com",
+			Model:     "glm-5",
+			APIKeyEnv: "DEEPSEEK_API_KEY",
+		}},
+	}
+	normalizeDesktopOfficialProviderAccess(c)
+	normalizeOfficialDeepSeekModels(c)
+
+	p, ok := c.Provider("deepseek")
+	if !ok {
+		t.Fatal("deepseek provider missing")
+	}
+	if !p.HasModel("deepseek-v4-flash") || !p.HasModel("deepseek-v4-pro") || !p.HasModel("glm-5") {
+		t.Fatalf("deepseek models = %+v, want official models plus existing model", p.ModelList())
+	}
+	if c.DefaultModel != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("default_model = %q, want retargeted official ref", c.DefaultModel)
+	}
+	if _, ok := c.ResolveModel(c.DefaultModel); !ok {
+		t.Fatalf("retargeted default_model %q should resolve", c.DefaultModel)
+	}
+}
+
+func TestNormalizeOfficialDeepSeekModelsLeavesExternalEndpointUntouched(t *testing.T) {
+	c := &Config{Providers: []ProviderEntry{{
+		Name:    "deepseek",
+		Kind:    "openai",
+		BaseURL: "https://proxy.example.com/v1",
+		Model:   "glm-5",
+	}}}
+	normalizeOfficialDeepSeekModels(c)
+
+	p, ok := c.Provider("deepseek")
+	if !ok {
+		t.Fatal("deepseek provider missing")
+	}
+	if p.HasModel("deepseek-v4-flash") || p.HasModel("deepseek-v4-pro") {
+		t.Fatalf("external endpoint models = %+v, want untouched custom list", p.ModelList())
+	}
+}
+
 func TestNormalizeDesktopOfficialProviderAccessEnsuresMimoAPI(t *testing.T) {
 	c := Default()
 	c.DefaultModel = "mimo-api/mimo-v2.5-pro"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1231,6 +1231,7 @@ func LoadForRoot(root string) (*Config, error) {
 	normalizeLegacyMCPTiers(cfg)
 	normalizeLegacyProviderModels(cfg)
 	normalizeDesktopOfficialProviderAccess(cfg)
+	normalizeOfficialDeepSeekModels(cfg)
 	normalizeEffortConfig(cfg)
 	backfillDeepSeekPro(cfg)
 	// First run (no config file anywhere): keep CodeGraph off until the user opts
@@ -1450,6 +1451,52 @@ func normalizeLegacyProviderModels(c *Config) {
 			p.Model = model
 		}
 	}
+}
+
+func normalizeOfficialDeepSeekModels(c *Config) {
+	if c == nil {
+		return
+	}
+	for i := range c.Providers {
+		p := &c.Providers[i]
+		if officialProviderHost(p.BaseURL) != "api.deepseek.com" {
+			continue
+		}
+		switch strings.TrimSpace(p.Name) {
+		case "deepseek":
+			ensureProviderModels(p, []string{"deepseek-v4-flash", "deepseek-v4-pro"}, "deepseek-v4-flash")
+		case "deepseek-flash":
+			ensureProviderModels(p, []string{"deepseek-v4-flash"}, "deepseek-v4-flash")
+		case "deepseek-pro":
+			ensureProviderModels(p, []string{"deepseek-v4-pro"}, "deepseek-v4-pro")
+		}
+	}
+}
+
+func officialProviderHost(baseURL string) string {
+	u, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(u.Hostname())
+}
+
+func ensureProviderModels(p *ProviderEntry, required []string, fallbackDefault string) {
+	if p == nil {
+		return
+	}
+	models := mergeModelLists(required, p.ModelList())
+	if len(models) == 0 {
+		return
+	}
+	p.Model = models[0]
+	if len(models) > 1 {
+		p.Models = models
+		p.Default = firstKnownModel(p.Default, models, fallbackDefault)
+		return
+	}
+	p.Models = nil
+	p.Default = ""
 }
 
 func legacyOfficialProviderModel(name string) string {


### PR DESCRIPTION
## Summary
- Backfill official DeepSeek model IDs for the official api.deepseek.com provider during config load.
- Normalize stale desktop tab model refs before effort/token-mode controller rebuilds.
- Add regression coverage for stale DeepSeek tab refs and official-provider model repair.

## Root cause
Desktop tabs could retain legacy refs such as `deepseek-flash/deepseek-v4-flash` while the settings flow had migrated official access to the canonical `deepseek` provider. Some rebuild paths still passed the stale tab ref directly to boot, so model validation failed before any provider request.

## Validation
- `go test ./internal/config`
- `go test .` from the desktop module
- `go test ./...`