### PR TITLE
fix(desktop): toast instead of crash when a tab opens on an unreachable path

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1474,11 +1474,20 @@ export default function App() {
   }, [activeTab?.scope, activeTab?.workspaceRoot]);
 
   const openBlankSession = useCallback(async (scope: string, workspaceRoot: string) => {
-    await ensureBlankTab(scope, scope === "project" ? workspaceRoot : "");
+    try {
+      await ensureBlankTab(scope, scope === "project" ? workspaceRoot : "");
+    } catch {
+      if (scope === "project" && workspaceRoot) {
+        showToast(t("history.failedOpenProject", { name: workspaceDisplayName(workspaceRoot), path: workspaceRoot }));
+      } else {
+        showToast(t("history.failedOpenSession"));
+      }
+      return;
+    }
     setProjectRevision((value) => value + 1);
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
-  }, [ensureBlankTab, refreshTabMetas]);
+  }, [ensureBlankTab, refreshTabMetas, showToast, t]);
 
   useEffect(() => {
     void refreshTabMetas();
@@ -2014,14 +2023,23 @@ export default function App() {
   const handleOpenTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string) => {
     closeTransientOverlays();
     setSidebarImDetailConnectionId("");
-    if (scope === "global") {
-      await openGlobalTab(topicId);
-    } else {
-      await openProjectTab(workspaceRoot, topicId);
+    try {
+      if (scope === "global") {
+        await openGlobalTab(topicId);
+      } else {
+        await openProjectTab(workspaceRoot, topicId);
+      }
+    } catch {
+      if (scope === "project" && workspaceRoot) {
+        showToast(t("history.failedOpenProject", { name: workspaceDisplayName(workspaceRoot), path: workspaceRoot }));
+      } else {
+        showToast(t("history.failedOpenSession"));
+      }
+      return;
     }
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
-  }, [closeTransientOverlays, openGlobalTab, openProjectTab, refreshTabMetas]);
+  }, [closeTransientOverlays, openGlobalTab, openProjectTab, refreshTabMetas, showToast, t]);
 
   const openSidebarImConnectionSession = useCallback(async (connection: SidebarImConnection) => {
     const target = mappedSessionTarget(connection.sessionId);


### PR DESCRIPTION
## What

Opening a project topic (`handleOpenTopic`) or a blank session (`openBlankSession`) could crash the whole desktop window instead of failing gracefully. The crash telemetry signature is:

```
[unhandledrejection]
mkdir F:\Bus: The system cannot find the path specified.
```

## Why it happened

The per-project session directory is rooted at the project's working directory (`config.ProjectSessionDir(root)`). When that root sits on a drive that is no longer reachable at that moment — a removable drive unplugged, a drive letter that changed since the project was last opened — the backend's `os.MkdirAll` returns `ERROR_PATH_NOT_FOUND` and the Wails binding promise rejects.

`handleOpenTopic` and `openBlankSession` awaited those bindings without a `catch`, so the rejection floated up to the global `unhandledrejection` handler in `crash.ts`, which escalates *any* uncaught rejection into a full crash overlay plus a telemetry report. A recoverable filesystem error was being reported as a hard crash.

The two sibling handlers that open tabs — `onResumeSession` and `openSidebarImConnectionSession` — already wrap the same calls in `try/catch` + `showToast`. These two paths simply missed it.

## Fix

Wrap both handlers in `try/catch` and surface the existing "cannot open" toast (`history.failedOpenProject` / `history.failedOpenSession`), matching the established pattern. No new strings, no backend change, no new bindings.

- The `mkdir` itself is already recursive (`os.MkdirAll`); the defect was purely error handling at the binding boundary, not the FS code.
- This is a latent bug, not a v1.7.0 regression — it only became visible now that crash telemetry is collecting.

## Test

- `tsc --noEmit` is clean for `App.tsx` (the only remaining errors are the known missing-`wailsjs/` stubs that CI regenerates via `wails generate module`).
- Manual: open a project whose drive is detached → a warning toast appears, the window stays alive, and no crash report is emitted.
