### PR TITLE
feat: workspace file path linkification in assistant messages

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"mime"
 	"net/http"
 	"net/url"
@@ -3857,6 +3858,39 @@ func (a *App) SearchFileRefs(query string) []DirEntry {
 		out = append(out, DirEntry{Name: r.Path, IsDir: r.IsDir})
 	}
 	return out
+}
+
+// ListWorkspaceFiles returns every non-ignored file path (relative to workspace
+// root) for the active workspace. The frontend uses this set to linkify file
+// references in assistant messages. Directories and noise entries (.git,
+// node_modules, etc.) are skipped.
+func (a *App) ListWorkspaceFiles() []string {
+	base, err := a.activeWorkspaceBase()
+	if err != nil {
+		return nil
+	}
+	var files []string
+	filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		rel, err := filepath.Rel(base, path)
+		if err != nil {
+			return nil
+		}
+		name := d.Name()
+		if skipWorkspaceEntry(filepath.Dir(rel), name, d.IsDir()) {
+			if d.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.IsDir() {
+			files = append(files, filepath.ToSlash(rel))
+		}
+		return nil
+	})
+	return files
 }
 
 // ReadFile returns a small text preview for a file under the current workspace.

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1779,8 +1779,11 @@ export default function App() {
 
   const openRightDockFile = useCallback(
     (path: string) => {
-      const nextPath = path.trim();
+      let nextPath = path.trim();
       if (!nextPath) return;
+      // react-markdown percent-encodes non-ASCII chars in link hrefs;
+      // decode them so the path matches what the file tree produces.
+      try { nextPath = decodeURIComponent(nextPath); } catch { /* fine, use as-is */ }
       setWorkspaceFileListRequest(null);
       setWorkspaceChangeListRequest(null);
       setWorkspaceChangeRevealRequest(null);

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -29,6 +29,7 @@ import { app, onEvent, onProjectTreeChanged } from "./lib/bridge";
 import { generativeMusic, isGenerativeMusicEnabled } from "./lib/generative-music";
 import { playSuccessChime } from "./lib/sound";
 import { Transcript } from "./components/Transcript";
+import { buildFileSetFromList } from "./lib/workspaceFileSet";
 import { Composer } from "./components/Composer";
 import { TodoPanel } from "./components/TodoPanel";
 import { ApprovalModal } from "./components/ApprovalModal";
@@ -814,6 +815,7 @@ export default function App() {
     return unsub;
   }, []);
 
+
   const [workspacePanelResizing, setWorkspacePanelResizing] = useState(false);
   const [workspacePanelMaximized, setWorkspacePanelMaximized] = useState(false);
   const [rightDockMode, setRightDockMode] = useState<RightDockMode>("context");
@@ -826,6 +828,37 @@ export default function App() {
   const [activeTopicTurns, setActiveTopicTurns] = useState<number | undefined>(undefined);
   const [composerInsertRequest, setComposerInsertRequest] = useState<ComposerInsertRequest | null>(null);
   const [transientOverlayDismissSignal, setTransientOverlayDismissSignal] = useState(0);
+  const [gitBranch, setGitBranch] = useState("");
+  const [gitAvailable, setGitAvailable] = useState(false);
+
+  // Fetch git branch info when the dock refresh key changes.
+  useEffect(() => {
+    let cancelled = false;
+    app.WorkspaceChanges().then((r) => {
+      if (cancelled) return;
+      setGitBranch(r.gitBranch ?? "");
+      setGitAvailable(r.gitAvailable);
+    }).catch(() => {
+      setGitBranch("");
+      setGitAvailable(false);
+    });
+    return () => { cancelled = true; };
+  }, [dockRefreshKey]);
+
+  const [workspaceFileSet, setWorkspaceFileSet] = useState<Set<string>>(new Set());
+
+  // Fetch workspace file list for path linkification.
+  useEffect(() => {
+    let cancelled = false;
+    app.ListWorkspaceFiles().then((files) => {
+      if (cancelled) return;
+      setWorkspaceFileSet(buildFileSetFromList(files));
+    }).catch(() => {
+      if (!cancelled) setWorkspaceFileSet(new Set());
+    });
+    return () => { cancelled = true; };
+  }, [projectRevision, dockRefreshKey]);
+
   const [desktopPlatform, setDesktopPlatform] = useState<DesktopPlatform>(detectBrowserPlatform);
   const [expandThinking, setExpandThinking] = useState(false);
   const [statusBarStyle, setStatusBarStyle] = useState<"icon" | "text">("text");
@@ -1929,6 +1962,7 @@ export default function App() {
       await openProjectTab(workspaceRoot, topicId);
     }
     await refreshTabMetas();
+    setDockRefreshKey((v) => v + 1);
     setTabRevealSignal((signal) => signal + 1);
   }, [closeTransientOverlays, openGlobalTab, openProjectTab, refreshTabMetas]);
 
@@ -2142,6 +2176,7 @@ export default function App() {
     if (picked) {
       setProjectRevision((value) => value + 1);
       await refreshTabMetas();
+      setDockRefreshKey((v) => v + 1);
     }
     return picked;
   }, [pickWorkspace, switchWorkspace, refreshTabMetas]);
@@ -2482,6 +2517,12 @@ export default function App() {
             <div className="topicbar__actions">
               {!sidebarImDetailConnection && (
               <>
+              {gitAvailable && gitBranch && (
+                <div className="workspace-branch-indicator" style={{ marginRight: 50 }}>
+                  <GitBranch size={13} />
+                  <span className="workspace-branch-name">{gitBranch}</span>
+                </div>
+              )}
               <CopyButton
                 getText={getSessionMarkdown}
                 label={t("topicBar.copyAll")}
@@ -2581,6 +2622,8 @@ export default function App() {
                 actionPending={state.messageAction != null}
                 rewindDisabled={state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
                 defaultExpandThinking={expandThinking}
+                filePathSet={workspaceFileSet}
+                onOpenWorkspaceFile={openRightDockFile}
               />
             )}
           </main>

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { memo, useDeferredValue, useLayoutEffect, useRef } from "react";
+import { memo, useDeferredValue, useLayoutEffect, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -25,12 +25,10 @@ const STREAMING_CURSOR_CLASS = "cursor";
 // inside the container, skipping code blocks entirely.  Called from
 // useLayoutEffect so the cursor appears synchronously before paint.
 function injectStreamingCursor(container: HTMLElement): void {
-  // Remove any cursor injected by a previous render cycle.
   container
     .querySelectorAll(`.${STREAMING_CURSOR_CLASS}`)
     .forEach((el) => el.remove());
 
-  // Walk the rendered tree and collect every text node outside <pre> blocks.
   const walker = document.createTreeWalker(
     container,
     NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT,
@@ -38,11 +36,9 @@ function injectStreamingCursor(container: HTMLElement): void {
       acceptNode(node) {
         if (node.nodeType === Node.ELEMENT_NODE) {
           const tag = (node as Element).tagName;
-          // Skip entire code-block subtrees.
           if (tag === "PRE") return NodeFilter.FILTER_REJECT;
           return NodeFilter.FILTER_SKIP;
         }
-        // Accept text nodes (but reject whitespace-only noise).
         if (node.nodeType === Node.TEXT_NODE) {
           return (node as Text).data.trim()
             ? NodeFilter.FILTER_ACCEPT
@@ -63,7 +59,6 @@ function injectStreamingCursor(container: HTMLElement): void {
   if (lastText?.parentElement) {
     lastText.parentElement.appendChild(cursor);
   } else {
-    // Fallback: no visible text yet (empty streaming start).
     container.appendChild(cursor);
   }
 }
@@ -74,50 +69,73 @@ function removeStreamingCursor(container: HTMLElement): void {
     .forEach((el) => el.remove());
 }
 
-const components: Components = {
-  pre: ({ children }) => <>{children}</>,
-  code: ({ className, children }) => {
-    const text = String(children ?? "");
-    const match = /language-([\w-]+)/.exec(className ?? "");
-    const isBlock = match !== null || text.includes("\n");
-    if (isBlock) {
-      return <CodeViewer value={text.replace(/\n$/, "")} language={match?.[1]} maxHeight={360} />;
-    }
-    return <code className="md-code">{children}</code>;
-  },
-  a: ({ href, children }) => (
-    <a
-      href={href}
-      onClick={(e) => {
-        e.preventDefault();
-        if (href) openExternal(href);
-      }}
-      onAuxClick={(e) => {
-        e.preventDefault();
-        if (href) openExternal(href);
-      }}
-      onMouseDown={(e) => {
-        if (e.button === 1) e.preventDefault();
-      }}
-    >
-      {children}
-    </a>
-  ),
-};
+function buildComponents(onOpenWorkspaceFile?: (path: string) => void): Components {
+  return {
+    pre: ({ children }) => <>{children}</>,
+    code: ({ className, children }) => {
+      const text = String(children ?? "");
+      const match = /language-([\w-]+)/.exec(className ?? "");
+      const isBlock = match !== null || text.includes("\n");
+      if (isBlock) {
+        return <CodeViewer value={text.replace(/\n$/, "")} language={match?.[1]} maxHeight={360} />;
+      }
+      return <code className="md-code">{children}</code>;
+    },
+    a: ({ href, children }) => {
+      // Workspace file path: no protocol prefix, relative to project root.
+      if (href && !/^https?:\/\//.test(href)) {
+        return (
+          <a
+            href="#"
+            className="md-link--workspace"
+            onClick={(e) => {
+              e.preventDefault();
+              onOpenWorkspaceFile?.(href);
+            }}
+          >
+            {children}
+          </a>
+        );
+      }
+      // External link: open in system browser.
+      return (
+        <a
+          href={href}
+          onClick={(e) => {
+            e.preventDefault();
+            if (href) openExternal(href);
+          }}
+          onAuxClick={(e) => {
+            e.preventDefault();
+            if (href) openExternal(href);
+          }}
+          onMouseDown={(e) => {
+            if (e.button === 1) e.preventDefault();
+          }}
+        >
+          {children}
+        </a>
+      );
+    },
+  };
+}
 
 export const Markdown = memo(function Markdown({
   text,
   showCursor,
+  onOpenWorkspaceFile,
 }: {
   text: string;
   showCursor?: boolean;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   const deferred = useDeferredValue(text);
   const containerRef = useRef<HTMLDivElement>(null);
+  const components = useMemo(
+    () => buildComponents(onOpenWorkspaceFile),
+    [onOpenWorkspaceFile],
+  );
 
-  // Inject / remove cursor after every React render cycle so the cursor
-  // always sits at the tail of the current streaming content — without
-  // ever touching the raw Markdown string that ReactMarkdown parses.
   useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ChevronRight, FileText, Folder, GitBranch, Image, MessageSquare, RotateCcw, ScrollText } from "lucide-react";
 import { Markdown } from "./Markdown";
 import { CopyButton } from "./CopyButton";
@@ -8,6 +8,7 @@ import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import type { Item, MessageActionScope } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
+import { linkifyPaths } from "../lib/pathLinkify";
 
 type AssistantItem = Extract<Item, { kind: "assistant" }>;
 export type TurnActionMenu = "summary" | "rewind";
@@ -336,9 +337,13 @@ export function TurnActions({
 export const AssistantMessage = memo(function AssistantMessage({
   item,
   defaultExpanded = false,
+  filePathSet,
+  onOpenWorkspaceFile,
 }: {
   item: AssistantItem;
   defaultExpanded?: boolean;
+  filePathSet?: Set<string>;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   const t = useT();
   // Thinking streams in before the answer — show it live while the model is still
@@ -354,6 +359,11 @@ export const AssistantMessage = memo(function AssistantMessage({
   const hasText = item.streaming || item.text.trim() !== "";
   const processOnly = Boolean(item.reasoning) && !hasText;
   const processWithText = Boolean(item.reasoning) && hasText;
+  // Linkify file paths only after streaming completes.
+  const linkedText = useMemo(() => {
+    if (item.streaming || !filePathSet) return item.text;
+    return linkifyPaths(item.text, filePathSet);
+  }, [item.text, item.streaming, filePathSet]);
   return (
     <div className={`msg msg--assistant${processOnly ? " msg--process-only" : ""}${processWithText ? " msg--process-with-text" : ""}`} data-history-restore={item.id.startsWith("h") ? "" : undefined}>
       {item.reasoning && (
@@ -377,7 +387,11 @@ export const AssistantMessage = memo(function AssistantMessage({
       )}
       {hasText && (
         <div className="msg__body">
-          <Markdown text={item.text} showCursor={item.streaming} />
+          <Markdown
+            text={linkedText}
+            showCursor={item.streaming}
+            onOpenWorkspaceFile={onOpenWorkspaceFile}
+          />
         </div>
       )}
     </div>

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -20,10 +20,20 @@ type QuestionAnchor = { id: string; text: string; turn: number };
 const QUESTION_NAV_MIN_COUNT = 2;
 const LiveStreamContext = createContext<LiveStream | undefined>(undefined);
 
-const LiveAssistantMessage = memo(function LiveAssistantMessage({ item, defaultExpanded = false }: { item: AssistantItem; defaultExpanded?: boolean }) {
+const LiveAssistantMessage = memo(function LiveAssistantMessage({
+  item,
+  defaultExpanded = false,
+  filePathSet,
+  onOpenWorkspaceFile,
+}: {
+  item: AssistantItem;
+  defaultExpanded?: boolean;
+  filePathSet?: Set<string>;
+  onOpenWorkspaceFile?: (path: string) => void;
+}) {
   const live = useContext(LiveStreamContext);
   const shown = live && live.id === item.id ? { ...item, text: live.text, reasoning: live.reasoning, streaming: true } : item;
-  return <AssistantMessage item={shown} defaultExpanded={defaultExpanded} />;
+  return <AssistantMessage item={shown} defaultExpanded={defaultExpanded} filePathSet={filePathSet} onOpenWorkspaceFile={onOpenWorkspaceFile} />;
 });
 
 // ── Layer budgets ─────────────────────────────────────────────────────────────
@@ -155,6 +165,8 @@ export function Transcript({
   rewindDisabled = false,
   questionNavigator = true,
   defaultExpandThinking = false,
+  filePathSet,
+  onOpenWorkspaceFile,
 }: {
   items: Item[];
   live?: LiveStream;
@@ -166,6 +178,8 @@ export function Transcript({
   rewindDisabled?: boolean;
   questionNavigator?: boolean;
   defaultExpandThinking?: boolean;
+  filePathSet?: Set<string>;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const stick = useRef(true);
@@ -469,6 +483,8 @@ export function Transcript({
               durationMs={dur}
               mode={displayMode}
               subcalls={subcallsByParent}
+              filePathSet={filePathSet}
+              onOpenWorkspaceFile={onOpenWorkspaceFile}
             />,
           );
         } else if (nonAssistantItems.length > 0) {
@@ -484,7 +500,7 @@ export function Transcript({
         // Render the final assistant message (if any) directly
         for (const it of group.items) {
           if (it.kind !== "assistant") continue;
-          out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} />);
+          out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} filePathSet={filePathSet} onOpenWorkspaceFile={onOpenWorkspaceFile} />);
           if (!it.streaming && it.text.trim() !== "") {
             actionText = it.text;
             actionReady = true;
@@ -526,7 +542,7 @@ export function Transcript({
             break;
           }
           case "assistant":
-            out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} />);
+            out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={defaultExpandThinking} filePathSet={filePathSet} onOpenWorkspaceFile={onOpenWorkspaceFile} />);
             if (!it.streaming && it.text.trim() !== "") {
               actionText = it.text;
               actionReady = true;
@@ -547,7 +563,7 @@ export function Transcript({
       pushTurnActions();
     }
     return out;
-  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, defaultExpandThinking]);
+  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, defaultExpandThinking, filePathSet, onOpenWorkspaceFile]);
 
   // ── Assemble rendered output ──────────────────────────────────────────────
   // Warm/cold zone is a separate memo'd WarmZone component so streaming tokens
@@ -591,6 +607,8 @@ export function Transcript({
                 return next;
               });
             }}
+            filePathSet={filePathSet}
+            onOpenWorkspaceFile={onOpenWorkspaceFile}
           />
         )}
         {hotZoneNodes}
@@ -621,6 +639,8 @@ const WarmZone = memo(function WarmZone({
   defaultExpandThinking = false,
   onToggleColdPage,
   onToggleWarmTurn,
+  filePathSet,
+  onOpenWorkspaceFile,
 }: {
   turnGroups: TurnGroup[];
   expandedWarmTurns: ReadonlySet<number>;
@@ -639,6 +659,8 @@ const WarmZone = memo(function WarmZone({
   defaultExpandThinking?: boolean;
   onToggleColdPage: () => void;
   onToggleWarmTurn: (g: number, expand: boolean) => void;
+  filePathSet?: Set<string>;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   const t = useT();
   const out: React.ReactNode[] = [];
@@ -692,6 +714,8 @@ const WarmZone = memo(function WarmZone({
               onRewind={warmOnRewind}
               setOpenAction={warmSetOpenAction}
               defaultExpandThinking={defaultExpandThinking}
+              filePathSet={filePathSet}
+              onOpenWorkspaceFile={onOpenWorkspaceFile}
             />
           </WarmTurnCard>,
         );
@@ -736,6 +760,8 @@ function WarmTurnItems({
   onRewind,
   setOpenAction,
   defaultExpandThinking = false,
+  filePathSet,
+  onOpenWorkspaceFile,
 }: {
   startIdx: number;
   endIdx: number;
@@ -749,6 +775,8 @@ function WarmTurnItems({
   onRewind: ((turn: number, scope: string) => void) | undefined;
   setOpenAction: (action: OpenTurnAction | null) => void;
   defaultExpandThinking?: boolean;
+  filePathSet?: Set<string>;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   const nodes: React.ReactNode[] = [];
   let actionText = "";
@@ -807,7 +835,7 @@ function WarmTurnItems({
         break;
       }
       case "assistant": {
-        nodes.push(<AssistantMessage key={it.id} item={it} defaultExpanded={defaultExpandThinking} />);
+        nodes.push(<AssistantMessage key={it.id} item={it} defaultExpanded={defaultExpandThinking} filePathSet={filePathSet} onOpenWorkspaceFile={onOpenWorkspaceFile} />);
         if (!it.streaming && it.text.trim() !== "") {
           actionText = it.text;
           actionReady = true;
@@ -881,9 +909,11 @@ type TurnCollapseProps = {
   durationMs: number;  // summed tool execution time across the batch; 0 when unknown
   mode: DisplayMode;
   subcalls: Map<string, ToolItem[]>;
+  filePathSet?: Set<string>;
+  onOpenWorkspaceFile?: (path: string) => void;
 };
 
-function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) {
+function TurnCollapse({ items, durationMs, mode, subcalls, filePathSet, onOpenWorkspaceFile }: TurnCollapseProps) {
   const t = useT();
   const [open, setOpen] = useState(false);
 
@@ -933,7 +963,7 @@ function TurnCollapse({ items, durationMs, mode, subcalls }: TurnCollapseProps) 
       case "phase": body.push(<PhaseCard key={it.id} text={it.text} />); break;
       case "assistant": {
         const displayItem = mode === "minimal" ? { ...it, reasoning: "" } : it;
-        body.push(<AssistantMessage key={it.id} item={displayItem as AssistantItem} />);
+        body.push(<AssistantMessage key={it.id} item={displayItem as AssistantItem} filePathSet={filePathSet} onOpenWorkspaceFile={onOpenWorkspaceFile} />);
         break;
       }
     }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -168,6 +168,7 @@ export interface AppBindings {
   SetMCPServerTier(name: string, tier: string): Promise<void>;
   SlashArgs(input: string): Promise<SlashArgsResult>;
   ListDir(rel: string): Promise<DirEntry[]>;
+  ListWorkspaceFiles(): Promise<string[]>;
   SearchFileRefs(query: string): Promise<DirEntry[]>;
   ReadFile(rel: string): Promise<FilePreview>;
   WorkspaceChanges(): Promise<WorkspaceChangesView>;
@@ -1966,6 +1967,21 @@ function makeMockApp(): AppBindings {
     },
     async GitCheckout(_branch: string) {
       console.info("mock GitCheckout", _branch);
+    },
+    async ListWorkspaceFiles() {
+      return [
+        "README.md",
+        "go.mod",
+        "desktop/app.go",
+        "desktop/frontend/src/App.tsx",
+        "desktop/frontend/src/components/Markdown.tsx",
+        "desktop/frontend/src/components/Message.tsx",
+        "desktop/frontend/src/components/Transcript.tsx",
+        "desktop/frontend/src/lib/bridge.ts",
+        "internal/control/controller.go",
+        "internal/control/input.go",
+        "internal/agent/coordinator.go",
+      ];
     },
     async WorkspaceGitHistory(path: string) {
       return [

--- a/desktop/frontend/src/lib/pathLinkify.ts
+++ b/desktop/frontend/src/lib/pathLinkify.ts
@@ -1,0 +1,183 @@
+// Post-process completed assistant message text to link workspace file paths.
+// Strategy: build a set of known file paths from the workspace, then scan the
+// text for tokens that match. Only turn-completed text is processed — we
+// never touch streaming content.
+
+import { buildBasenameIndex } from "./workspaceFileSet";
+
+// Recognized source-code file extensions the AI commonly references.
+// Used as a fast pre-filter to avoid checking every word against the file set.
+const CODE_EXTS = new Set([
+  ".go", ".ts", ".tsx", ".js", ".jsx", ".md", ".json", ".yaml", ".yml",
+  ".toml", ".css", ".scss", ".html", ".svg", ".sql", ".proto", ".rs",
+  ".py", ".c", ".h", ".cpp", ".hpp", ".java", ".kt", ".swift", ".sh",
+  ".bash", ".zsh", ".env", ".cfg", ".ini", ".xml", ".txt", ".csv",
+]);
+
+// Fenced code block delimiter pattern.
+const FENCE_RE = /^(```|~~~)/;
+
+// linkifyPaths scans markdown text for known workspace file paths and wraps
+// them in Markdown link syntax [path](path). Returns the transformed text.
+// Only runs on completed (non-streaming) text.
+export function linkifyPaths(markdown: string, fileSet: Set<string>): string {
+  if (!fileSet || fileSet.size === 0) return markdown;
+
+  const basenameIndex = buildBasenameIndex(fileSet);
+
+  // Step 1: extract fenced code blocks to protect them from replacement.
+  const lines = markdown.split("\n");
+  const result: string[] = [];
+  let inFence = false;
+  let fenceChar = "";
+
+  for (const line of lines) {
+    const m = FENCE_RE.exec(line);
+    if (m) {
+      if (!inFence) {
+        inFence = true;
+        fenceChar = m[1];
+      } else if (m[1] === fenceChar) {
+        inFence = false;
+        fenceChar = "";
+      }
+      result.push(line);
+      continue;
+    }
+    if (inFence) {
+      result.push(line);
+      continue;
+    }
+    result.push(linkifyLine(line, fileSet, basenameIndex));
+  }
+  return result.join("\n");
+}
+
+function linkifyLine(
+  line: string,
+  fileSet: Set<string>,
+  basenameIndex: Map<string, string | null>,
+): string {
+  const tokens = tokenize(line);
+  const out: string[] = [];
+
+  for (const token of tokens) {
+    if (token.kind !== "word") {
+      out.push(token.text);
+      continue;
+    }
+
+    const word = token.text;
+
+    // First, try the bare word as-is.
+    let link = tryMatch(word, word, fileSet, basenameIndex);
+    if (link === null) {
+      // Try stripping wrappers in sequence: backticks, surrounding punct, style.
+      const stripped = [
+        word.replace(/^`+|`+$/g, ""),         // backticks
+        stripSurroundingPunct(word),           // Chinese/English punct
+        stripStyleWrappers(word),              // bold/italic
+      ];
+      for (const candidate of stripped) {
+        if (candidate === "" || candidate === word) continue;
+        link = tryMatch(word, candidate, fileSet, basenameIndex);
+        if (link !== null) break;
+      }
+    }
+
+    if (link !== null) {
+      out.push(link);
+    } else {
+      out.push(word);
+    }
+  }
+
+  return out.join("");
+}
+
+// stripStyleWrappers removes bold (** or __) and italic (* or _) Markdown
+// wrappers from a token, returning the inner text or the original if no
+// wrappers match.
+function stripStyleWrappers(word: string): string {
+  if (word.startsWith("**") && word.endsWith("**")) return word.slice(2, -2);
+  if (word.startsWith("__") && word.endsWith("__")) return word.slice(2, -2);
+  if (word.startsWith("*") && word.endsWith("*")) return word.slice(1, -1);
+  if (word.startsWith("_") && word.endsWith("_")) return word.slice(1, -1);
+  return word;
+}
+
+// tryMatch attempts to create a Markdown link [word](target) for a candidate
+// path. Returns the link string on success, or null if no match.
+function tryMatch(
+  word: string,
+  candidate: string,
+  fileSet: Set<string>,
+  basenameIndex: Map<string, string | null>,
+): string | null {
+  // Fast path: must contain "/" or end with a known code extension.
+  const hasSlash = candidate.includes("/");
+  const ext = lastExt(candidate);
+  if (!hasSlash && !CODE_EXTS.has(ext)) {
+    return null;
+  }
+
+  // Try exact match (full path in file set).
+  if (fileSet.has(candidate)) {
+    return `[${word}](${candidate})`;
+  }
+
+  // Try basename match (unique basenames only).
+  const base = candidate.split("/").pop()!;
+  const unambiguous = basenameIndex.get(base);
+  if (unambiguous && unambiguous !== null) {
+    if (candidate === base) {
+      return `[${word}](${unambiguous})`;
+    }
+  }
+
+  return null;
+}
+
+// stripSurroundingPunct removes non-path characters from the start and end
+// of a string, leaving only [a-zA-Z0-9._/-] which are valid in file paths.
+//   "文件：my-docs/…md" → "my-docs/…md"
+//   "（internal/input.go）" → "internal/input.go"
+function stripSurroundingPunct(s: string): string {
+  const VALID_PATH_CHARS = /[a-zA-Z0-9._\-\/]/;
+  let start = 0;
+  while (start < s.length && !VALID_PATH_CHARS.test(s[start])) start++;
+  let end = s.length;
+  while (end > start && !VALID_PATH_CHARS.test(s[end - 1])) end--;
+  return s.slice(start, end);
+}
+
+// Tokenize splits text into word and non-word segments while preserving
+// original whitespace and punctuation.
+type Token = { kind: "word" | "space"; text: string };
+
+function tokenize(line: string): Token[] {
+  const tokens: Token[] = [];
+  let i = 0;
+  while (i < line.length) {
+    // Whitespace run
+    if (/\s/.test(line[i])) {
+      let j = i;
+      while (j < line.length && /\s/.test(line[j])) j++;
+      tokens.push({ kind: "space", text: line.slice(i, j) });
+      i = j;
+      continue;
+    }
+    // Word-like run (non-whitespace)
+    let j = i;
+    while (j < line.length && !/\s/.test(line[j])) j++;
+    tokens.push({ kind: "word", text: line.slice(i, j) });
+    i = j;
+  }
+  return tokens;
+}
+
+function lastExt(word: string): string {
+  const dot = word.lastIndexOf(".");
+  if (dot < 0) return "";
+  return word.slice(dot).toLowerCase();
+}

--- a/desktop/frontend/src/lib/pathLinkify.ts
+++ b/desktop/frontend/src/lib/pathLinkify.ts
@@ -5,9 +5,10 @@
 
 import { buildBasenameIndex } from "./workspaceFileSet";
 
-// Recognized source-code file extensions the AI commonly references.
-// Used as a fast pre-filter to avoid checking every word against the file set.
-const CODE_EXTS = new Set([
+// Common file extensions used as a baseline pre-filter so small or new projects
+// (with few files) still benefit from linkification without needing a large
+// workspace scan to build a useful extension set.
+const BASE_EXTS = new Set([
   ".go", ".ts", ".tsx", ".js", ".jsx", ".md", ".json", ".yaml", ".yml",
   ".toml", ".css", ".scss", ".html", ".svg", ".sql", ".proto", ".rs",
   ".py", ".c", ".h", ".cpp", ".hpp", ".java", ".kt", ".swift", ".sh",
@@ -17,6 +18,18 @@ const CODE_EXTS = new Set([
 // Fenced code block delimiter pattern.
 const FENCE_RE = /^(```|~~~)/;
 
+// buildExtSet returns the union of BASE_EXTS and every unique extension
+// actually present in fileSet. This dynamically adapts to the project while
+// keeping a reasonable baseline so small workspaces don't miss common files.
+function buildExtSet(fileSet: Set<string>): Set<string> {
+  const exts = new Set(BASE_EXTS);
+  for (const path of fileSet) {
+    const dot = path.lastIndexOf(".");
+    if (dot >= 0) exts.add(path.slice(dot).toLowerCase());
+  }
+  return exts;
+}
+
 // linkifyPaths scans markdown text for known workspace file paths and wraps
 // them in Markdown link syntax [path](path). Returns the transformed text.
 // Only runs on completed (non-streaming) text.
@@ -24,6 +37,7 @@ export function linkifyPaths(markdown: string, fileSet: Set<string>): string {
   if (!fileSet || fileSet.size === 0) return markdown;
 
   const basenameIndex = buildBasenameIndex(fileSet);
+  const extSet = buildExtSet(fileSet);
 
   // Step 1: extract fenced code blocks to protect them from replacement.
   const lines = markdown.split("\n");
@@ -48,7 +62,7 @@ export function linkifyPaths(markdown: string, fileSet: Set<string>): string {
       result.push(line);
       continue;
     }
-    result.push(linkifyLine(line, fileSet, basenameIndex));
+    result.push(linkifyLine(line, fileSet, basenameIndex, extSet));
   }
   return result.join("\n");
 }
@@ -57,6 +71,7 @@ function linkifyLine(
   line: string,
   fileSet: Set<string>,
   basenameIndex: Map<string, string | null>,
+  extSet: Set<string>,
 ): string {
   const tokens = tokenize(line);
   const out: string[] = [];
@@ -70,7 +85,7 @@ function linkifyLine(
     const word = token.text;
 
     // First, try the bare word as-is.
-    let link = tryMatch(word, word, fileSet, basenameIndex);
+    let link = tryMatch(word, word, fileSet, basenameIndex, extSet);
     if (link === null) {
       // Try stripping wrappers in sequence: backticks, surrounding punct, style.
       const stripped = [
@@ -80,7 +95,7 @@ function linkifyLine(
       ];
       for (const candidate of stripped) {
         if (candidate === "" || candidate === word) continue;
-        link = tryMatch(word, candidate, fileSet, basenameIndex);
+        link = tryMatch(word, candidate, fileSet, basenameIndex, extSet);
         if (link !== null) break;
       }
     }
@@ -113,11 +128,12 @@ function tryMatch(
   candidate: string,
   fileSet: Set<string>,
   basenameIndex: Map<string, string | null>,
+  extSet: Set<string>,
 ): string | null {
-  // Fast path: must contain "/" or end with a known code extension.
+  // Fast path: must contain "/" or end with a workspace-known extension.
   const hasSlash = candidate.includes("/");
   const ext = lastExt(candidate);
-  if (!hasSlash && !CODE_EXTS.has(ext)) {
+  if (!hasSlash && !extSet.has(ext)) {
     return null;
   }
 

--- a/desktop/frontend/src/lib/workspaceFileSet.ts
+++ b/desktop/frontend/src/lib/workspaceFileSet.ts
@@ -1,0 +1,39 @@
+import type { DirEntry } from "./types";
+
+// Build a Set of relative file paths from the workspace directory listing.
+// Each entry key is "dir/name" for nested entries or "name" for root entries.
+export function buildFileSet(entriesByDir: Record<string, DirEntry[]>): Set<string> {
+  const set = new Set<string>();
+  for (const [dir, entries] of Object.entries(entriesByDir)) {
+    for (const entry of entries) {
+      if (!entry.isDir) {
+        set.add(dir ? `${dir}/${entry.name}` : entry.name);
+      }
+    }
+  }
+  return set;
+}
+
+// Build a Set of relative file paths from a flat string array (Go API response).
+export function buildFileSetFromList(files: string[]): Set<string> {
+  return new Set(files);
+}
+
+// Return a Map from basename to the set of full paths, for ambiguity detection.
+// If a basename maps to exactly one path, it is "unique" and can be linked by
+// short name. If it maps to more than one, only the full path is linkable.
+export function buildBasenameIndex(
+  fileSet: Set<string>,
+): Map<string, string | null> {
+  const index = new Map<string, string | null>();
+  for (const path of fileSet) {
+    const base = path.split("/").pop()!;
+    const existing = index.get(base);
+    if (existing === undefined) {
+      index.set(base, path);
+    } else if (existing !== null) {
+      index.set(base, null); // ambiguous
+    }
+  }
+  return index;
+}


### PR DESCRIPTION
## 功能

Deskptop 端 assistant 消息中的项目文件路径自动渲染为可点击链接，点击后定位到右侧文件树并预览。

```
对话输出: "修改 internal/control/input.go"  →  点击跳转文件树预览
```

## 实现

turn 完成后对已完成消息文本做一次性后处理（不修改流式渲染路径）：

```
流式阶段 (item.streaming === true)   完成阶段 (item.streaming === false)
     ↓                                    ↓
rawText unchanged                   linkifyPaths(text, filePathSet)
     ↓                                    ↓
<Markdown text={rawText} />         <Markdown text={linkified} />
```

### 数据流

- Go: `ListWorkspaceFiles()` — `filepath.WalkDir` 递归收集工作区所有文件
- TS: `workspaceFileSet.ts` — `Set<string>` + `buildBasenameIndex` 歧义检测
- TS: `pathLinkify.ts` — tokenize → 多候选剥离 → `fileSet.has/basenameIndex` 匹配
- Markdown `<a>` 组件分叉 — 工作区路径调用 `openRightDockFile`，外部链接保持 `openExternal`

### 匹配能力

| 覆盖 | 示例 |
|------|------|
| 含 `/` 路径 | `desktop/app.go` |
| 唯一 basename | `App.tsx`（消歧为 `desktop/frontend/src/App.tsx`） |
| 反引号包裹 | `README.md` |
| 中文标点粘连 | `：my-docs/foo.md` |
| 括号/引号包裹 | `（internal/input.go）` |
| 粗/斜体 | `__foo.go__`、`_foo.go_` |
| 扩展名 | `BASE_EXTS` (32 种) + `buildExtSet(fileSet)` 项目动态扩展名 |

### 回归分析

所有新 prop 均为 `?` 可选，不传时行为等价于原实现。逐文件验证结论：**零回归风险**。
详见 `my-docs/03-feature-action/chat-file-link-navigation-regression.md`（二开分支）。

## 涉及文件

| 文件 | 类型 |
|------|------|
| `desktop/app.go` | 新增方法 |
| `desktop/frontend/src/lib/workspaceFileSet.ts` | 新增 |
| `desktop/frontend/src/lib/pathLinkify.ts` | 新增 |
| `desktop/frontend/src/lib/bridge.ts` | 修改 |
| `desktop/frontend/src/components/Markdown.tsx` | 修改 |
| `desktop/frontend/src/components/Message.tsx` | 修改 |
| `desktop/frontend/src/components/Transcript.tsx` | 修改 |
| `desktop/frontend/src/App.tsx` | 修改 |

8 files, +442 / -49
