### PR TITLE
fix(desktop): replay pending prompts on tab switch to preserve plan m…

### DIFF
--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/send-failed.test.ts
 
-import { initialState, reducer } from "../lib/useController";
+import { initialState, reducer, replayPendingPromptsForActiveTab } from "../lib/useController";
 import type { WireEvent } from "../lib/types";
 
 let passed = 0;
@@ -43,6 +43,26 @@ eq(lateFailure, confirmed, "send_failed after backend confirmation is a no-op");
 const unsent = reducer(sent, { type: "unsend" });
 eq(unsent.pendingUser, undefined, "unsend clears the pending marker");
 eq(unsent.discardTurn, true, "unsend discards the in-flight turn");
+
+let replayCalls = 0;
+replayPendingPromptsForActiveTab(undefined, () => {
+  replayCalls += 1;
+  return Promise.resolve();
+});
+eq(replayCalls, 0, "no active tab does not replay pending prompts");
+
+replayPendingPromptsForActiveTab("tab-a", () => {
+  replayCalls += 1;
+  return Promise.resolve();
+});
+eq(replayCalls, 1, "active tab switch replays pending prompts");
+
+replayPendingPromptsForActiveTab("tab-b", () => {
+  replayCalls += 1;
+  return Promise.reject(new Error("bridge unavailable"));
+});
+await new Promise((resolve) => setTimeout(resolve, 0));
+eq(replayCalls, 2, "replay bridge failures are swallowed by the tab-switch effect");
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -544,6 +544,11 @@ async function refreshMetaForTab(tabId: string, dispatchTo: (tabId: string, acti
   }
 }
 
+export function replayPendingPromptsForActiveTab(activeTabId: string | undefined, replay: () => Promise<void> = () => app.ReplayPendingPrompts()): void {
+  if (!activeTabId) return;
+  void replay().catch(() => {});
+}
+
 export function useController() {
   const statesRef = useRef<TabStates>(new Map());
   const lastTokenAt = useRef(0);
@@ -737,7 +742,7 @@ export function useController() {
   // Replay any pending approval/ask prompts when switching tabs, so a
   // plan-mode session left awaiting confirmation rebuilds its modal (#4275).
   useEffect(() => {
-    if (activeTabId) void app.ReplayPendingPrompts().catch(() => {});
+    replayPendingPromptsForActiveTab(activeTabId);
   }, [activeTabId]);
 
   const send = useCallback((displayText: string, submitText = displayText) => {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -734,6 +734,12 @@ export function useController() {
     return () => window.clearTimeout(timer);
   }, [activeTabId, reconcileTabRuntime, activeState.running, activeState.live]);
 
+  // Replay any pending approval/ask prompts when switching tabs, so a
+  // plan-mode session left awaiting confirmation rebuilds its modal (#4275).
+  useEffect(() => {
+    if (activeTabId) void app.ReplayPendingPrompts().catch(() => {});
+  }, [activeTabId]);
+
   const send = useCallback((displayText: string, submitText = displayText) => {
     const submitForTab = (tabId: string) => {
       const seq = getOrCreateState(statesRef.current, tabId).seq;


### PR DESCRIPTION
…odal (#4275)

When switching back to a plan-mode tab, the 3-button modal (revise/execute/exit) was lost because ReplayPendingPrompts() was only called on initial mount, not on tab change. The backend still held the pending exit_plan_mode approval event but the frontend never re-emitted it.

Root cause: ReplayPendingPrompts() was only in the mount-effect, never triggered when activeTabId changes.

Fix: add a useEffect that calls app.ReplayPendingPrompts() on every activeTabId change, so switching back to a plan-mode session rebuilds the approval modal.