### PR TITLE
fix(bot): handle QQ API expires_in as json.Number for string/int compatibility

### DIFF
--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -132,8 +132,8 @@ func (a *adapter) getAccessToken(ctx context.Context) (string, error) {
 	defer resp.Body.Close()
 
 	var result struct {
-		AccessToken string `json:"access_token"`
-		ExpiresIn   int    `json:"expires_in"`
+		AccessToken string      `json:"access_token"`
+		ExpiresIn   json.Number `json:"expires_in"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", err
@@ -143,8 +143,12 @@ func (a *adapter) getAccessToken(ctx context.Context) (string, error) {
 	}
 	a.tokenMu.Lock()
 	a.token = result.AccessToken
-	if result.ExpiresIn > 60 {
-		a.tokenExpiry = time.Now().Add(time.Duration(result.ExpiresIn-60) * time.Second)
+	expiresIn := int64(0)
+	if n, err := result.ExpiresIn.Int64(); err == nil {
+		expiresIn = n
+	}
+	if expiresIn > 60 {
+		a.tokenExpiry = time.Now().Add(time.Duration(expiresIn-60) * time.Second)
 	} else {
 		a.tokenExpiry = time.Now().Add(5 * time.Minute)
 	}


### PR DESCRIPTION
## 问题

QQ Bot 启动时报错：

```
ERROR msg="get access token failed" platform=qq err="json: cannot unmarshal string into Go struct field .expires_in of type int"
```

**原因：** QQ REST API (`https://bots.qq.com/app/getAppAccessToken`) 返回的 JSON 中 `expires_in` 字段可能是字符串 `"7200"` 而非整数 `7200`。`json.Unmarshal` 无法将字符串反序列化为 `int`。

## 修复

将 `getAccessToken()` 中的 `ExpiresIn` 字段类型从 `int` 改为 `json.Number`，然后通过 `Int64()` 解析，同时兼容字符串和整数两种格式。

**变更：** `internal/bot/qq/gateway.go` — 仅 3 行核心改动：
```go
// Before:
ExpiresIn   int    `json:"expires_in"`

// After:
ExpiresIn   json.Number `json:"expires_in"`
```

配套解析代码：
```go
expiresIn := int64(0)
if n, err := result.ExpiresIn.Int64(); err == nil {
    expiresIn = n
}
```

## 验证

修复后 `reasonix bot start --channels qq` 正常启动，不再报错。`bot doctor` 全部通过。

Closes #4283