### PR TITLE
Fix topicbar copy tooltip clipping / 修复话题栏复制提示截断

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2573,11 +2573,14 @@ export default function App() {
             <div className="topicbar__actions">
               {!sidebarImDetailConnection && (
               <>
-              <CopyButton
-                getText={getSessionMarkdown}
-                label={t("topicBar.copyAll")}
-                className="topicbar__action-btn topicbar__action-btn--icon topicbar__action-btn--utility"
-              />
+              <Tooltip label={t("topicBar.copyAll")}>
+                <CopyButton
+                  getText={getSessionMarkdown}
+                  label={t("topicBar.copyAll")}
+                  className="topicbar__action-btn topicbar__action-btn--icon topicbar__action-btn--utility"
+                  showInlineLabel={false}
+                />
+              </Tooltip>
               <div className={`topicbar__export${topicExportOpen ? " topicbar__export--open" : ""}`}>
                 <Tooltip label={t("topicBar.export")}>
                   <button

--- a/desktop/frontend/src/components/CopyButton.tsx
+++ b/desktop/frontend/src/components/CopyButton.tsx
@@ -10,11 +10,13 @@ export function CopyButton({
   getText,
   className,
   label,
+  showInlineLabel = true,
 }: {
   text?: string;
   getText?: () => string | Promise<string>;
   className?: string;
   label?: string;
+  showInlineLabel?: boolean;
 }) {
   const t = useT();
   const [copied, setCopied] = useState(false);
@@ -37,7 +39,9 @@ export function CopyButton({
       type="button"
     >
       {copied ? <Check size={13} /> : <Copy size={13} />}
-      <span className="copybtn__label-inline">{copied ? t("msg.copied") : actionLabel}</span>
+      {showInlineLabel && (
+        <span className="copybtn__label-inline">{copied ? t("msg.copied") : actionLabel}</span>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Wrap the topicbar copy-session button in the shared Tooltip component.
- Add an opt-out for CopyButton's inline hover label so icon-only toolbar buttons do not clip localized labels.
- Keep existing CopyButton behavior unchanged for message actions, code blocks, and bot detail actions.

Fixes #4297.

## Verification
- `git diff --check -- desktop/frontend/src/App.tsx desktop/frontend/src/components/CopyButton.tsx`
- Browser-rendered CSS smoke test confirmed the topicbar copy button remains icon-only while the tooltip shows the full `复制会话` label.