### PR TITLE
Fix reasoning language propagation / 修复思考语言设置传播

### DIFF
--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1484,7 +1484,40 @@ func (a *App) SetColdResumePrune(enabled bool) error {
 }
 
 func (a *App) SetReasoningLanguage(lang string) error {
-	return a.applyConfigChange(func(c *config.Config) error { return c.SetReasoningLanguage(lang) })
+	cfg, path, err := a.loadDesktopUserConfigForEdit()
+	if err != nil {
+		return err
+	}
+	if err := cfg.SetReasoningLanguage(lang); err != nil {
+		return err
+	}
+	if err := cfg.SaveTo(path); err != nil {
+		return err
+	}
+	a.applyReasoningLanguageToLiveControllers(cfg.ReasoningLanguage())
+	return nil
+}
+
+func (a *App) applyReasoningLanguageToLiveControllers(fallback string) {
+	type liveTab struct {
+		root string
+		ctrl *control.Controller
+	}
+	var tabs []liveTab
+	a.mu.RLock()
+	for _, tab := range a.tabs {
+		if tab != nil && tab.Ctrl != nil {
+			tabs = append(tabs, liveTab{root: tab.WorkspaceRoot, ctrl: tab.Ctrl})
+		}
+	}
+	a.mu.RUnlock()
+	for _, tab := range tabs {
+		mode := fallback
+		if cfg, err := config.LoadForRoot(tab.root); err == nil {
+			mode = cfg.ReasoningLanguage()
+		}
+		tab.ctrl.SetReasoningLanguage(mode)
+	}
 }
 
 // trimList drops blank entries from a string slice (and returns a non-nil slice).

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -7,9 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"reasonix/internal/config"
+	"reasonix/internal/control"
 	"reasonix/internal/hook"
 	"reasonix/internal/provider"
 )
@@ -169,6 +171,49 @@ func TestSetReasoningLanguagePersistsToUserConfig(t *testing.T) {
 	cfg := config.LoadForEdit(config.UserConfigPath())
 	if cfg.Agent.ReasoningLanguage != "zh" || cfg.ReasoningLanguage() != "zh" {
 		t.Fatalf("saved reasoning language = %q/%q, want zh", cfg.Agent.ReasoningLanguage, cfg.ReasoningLanguage())
+	}
+}
+
+func TestSetReasoningLanguageUpdatesLiveTabControllers(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	projectRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectRoot, "reasonix.toml"), []byte("[agent]\nreasoning_language = \"en\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	userCtrl := control.New(control.Options{ReasoningLanguage: "auto"})
+	projectCtrl := control.New(control.Options{ReasoningLanguage: "auto"})
+	app.tabs = map[string]*WorkspaceTab{
+		"user": {
+			ID:          "user",
+			Scope:       "global",
+			Ctrl:        userCtrl,
+			Ready:       true,
+			disabledMCP: map[string]ServerView{},
+		},
+		"project": {
+			ID:            "project",
+			Scope:         "project",
+			WorkspaceRoot: projectRoot,
+			Ctrl:          projectCtrl,
+			Ready:         true,
+			disabledMCP:   map[string]ServerView{},
+		},
+	}
+	app.activeTabID = "user"
+
+	if err := app.SetReasoningLanguage("zh"); err != nil {
+		t.Fatalf("SetReasoningLanguage: %v", err)
+	}
+
+	userComposed := userCtrl.Compose("hi")
+	if !strings.Contains(userComposed, "Simplified Chinese") {
+		t.Fatalf("user-level tab Compose = %q, want zh reasoning language", userComposed)
+	}
+	projectComposed := projectCtrl.Compose("hi")
+	if !strings.Contains(projectComposed, "use English") {
+		t.Fatalf("project override tab Compose = %q, want en reasoning language", projectComposed)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -164,6 +164,7 @@ type Agent struct {
 	executorHandoffGuard bool
 	temperature          float64
 	pricing              *provider.Pricing
+	reasoningLanguage    atomic.Value // string: auto|zh|en
 
 	// sink receives the turn's typed event stream (reasoning/text deltas, tool
 	// dispatch/results, usage, notices). The agent no longer formats output
@@ -299,6 +300,15 @@ type Agent struct {
 // history — are left untouched, so the toggle costs nothing in cache hits.
 func (a *Agent) SetPlanMode(v bool) { a.planMode.Store(v) }
 
+// SetReasoningLanguage updates the visible reasoning language preference for
+// subsequent user-role messages emitted by this agent.
+func (a *Agent) SetReasoningLanguage(lang string) {
+	if a == nil {
+		return
+	}
+	a.reasoningLanguage.Store(NormalizeReasoningLanguage(lang))
+}
+
 // SetGate installs the per-call permission gate. Used by `reasonix chat` to swap the
 // headless gate built in setup for an interactive one that prompts the user;
 // nil disables gating. Safe to call before the run loop starts.
@@ -307,6 +317,19 @@ func (a *Agent) SetGate(g Gate) {
 		g = nil
 	}
 	a.gate = g
+}
+
+func (a *Agent) withReasoningLanguage(input string) string {
+	if a == nil {
+		return input
+	}
+	lang := "auto"
+	if v := a.reasoningLanguage.Load(); v != nil {
+		if s, ok := v.(string); ok {
+			lang = s
+		}
+	}
+	return WithReasoningLanguage(input, lang)
 }
 
 // SetAsker installs the asker the `ask` tool uses to question the user.
@@ -469,6 +492,10 @@ type Options struct {
 
 	// ProjectChecks are host-observable structured checks extracted during boot.
 	ProjectChecks []instruction.VerifyCheck
+
+	// ReasoningLanguage controls visible reasoning language preference as transient
+	// user-turn context. Empty/auto injects nothing.
+	ReasoningLanguage string
 }
 
 // New constructs an Agent. MaxSteps <= 0 means no cap — the run loop continues
@@ -503,7 +530,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 	if strings.TrimSpace(maxStepsKey) == "" {
 		maxStepsKey = "agent.max_steps"
 	}
-	return &Agent{
+	a := &Agent{
 		prov:              prov,
 		tools:             tools,
 		session:           session,
@@ -524,6 +551,8 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		recentKeep:        opts.RecentKeep,
 		archiveDir:        opts.ArchiveDir,
 	}
+	a.SetReasoningLanguage(opts.ReasoningLanguage)
+	return a
 }
 
 // Run appends the user input and drives the tool loop until the model returns a
@@ -542,6 +571,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	}
 	a.repeatSuccessCounts = nil
 	a.sink.Emit(event.Event{Kind: event.TurnStarted})
+	input = a.withReasoningLanguage(input)
 	a.session.Add(provider.Message{Role: provider.RoleUser, Content: input, Images: userImages(ctx)})
 
 	finalReadinessBlocks := 0
@@ -556,7 +586,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		// guidance (with a prefix), not a new task. One cache miss per
 		// steer is unavoidable — the model must see the new instruction.
 		if text, ok := a.consumeSteer(); ok {
-			a.session.Add(provider.Message{Role: provider.RoleUser, Content: midTurnSteerMessage(text)})
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(midTurnSteerMessage(text))})
 			a.sink.Emit(event.Event{Kind: event.Steer, Text: text})
 		}
 		schemas := a.tools.Schemas()
@@ -580,7 +610,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				}
 				a.session.Add(provider.Message{
 					Role:    provider.RoleUser,
-					Content: streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted),
+					Content: a.withReasoningLanguage(streamRecoveryMessage(hasVisibleFinalAnswer(text), partialToolStarted)),
 				})
 				a.sink.Emit(event.Event{Kind: event.Retrying, RetryAttempt: streamRecoveries, RetryMax: maxStreamRecoveries})
 				step-- // recovery retries do not consume the tool-round maxSteps budget
@@ -625,7 +655,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				}
 				event.RecordReadinessAudit(a.sink, readiness.audit(result, false))
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "final-answer readiness blocked: " + readiness.reason})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: finalReadinessRetryMessage(readiness.reason)})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(finalReadinessRetryMessage(readiness.reason))})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
@@ -635,14 +665,14 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 					return fmt.Errorf("model finished without a visible final answer %d times", emptyFinalBlocks)
 				}
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: emptyFinalNotice(a.prov.Name(), usage, len(reasoning))})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: emptyFinalRetryMessage()})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(emptyFinalRetryMessage())})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
 			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges {
 				handoffNudges++
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor answered without taking any action; nudging it to use its tools"})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: executorHandoffRetryMessage()})
+				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(executorHandoffRetryMessage())})
 				a.maybeCompact(ctx, usage)
 				continue
 			}
@@ -1362,6 +1392,11 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	if a.jobs != nil {
 		cctx = jobs.WithManager(cctx, a.jobs)
+	}
+	if v := a.reasoningLanguage.Load(); v != nil {
+		if lang, ok := v.(string); ok {
+			cctx = WithReasoningLanguagePreference(cctx, lang)
+		}
 	}
 	if a.memQueue != nil {
 		cctx = memory.WithQueue(cctx, a.memQueue)

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -87,6 +87,21 @@ func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerP
 	}
 }
 
+// SetReasoningLanguage updates both agents in two-model mode. The raw planner
+// path receives controller-composed input directly, but a tool-enabled planner
+// owns its own Agent and must clear stale zh/en preferences on live changes.
+func (c *Coordinator) SetReasoningLanguage(lang string) {
+	if c == nil {
+		return
+	}
+	if c.plannerAgent != nil {
+		c.plannerAgent.SetReasoningLanguage(lang)
+	}
+	if c.executor != nil {
+		c.executor.SetReasoningLanguage(lang)
+	}
+}
+
 // Run plans with the planner model, then hands the plan to the executor.
 func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -195,6 +195,32 @@ func TestCoordinatorPlannerUsesReadOnlyResearchTools(t *testing.T) {
 	}
 }
 
+func TestCoordinatorSetReasoningLanguageClearsPlannerAgent(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "1. inspect the narrow path"},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Done."},
+		{Type: provider.ChunkDone},
+	}}
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{ReasoningLanguage: "zh"}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, tool.NewRegistry(), Options{ReasoningLanguage: "zh"}, executor, 0, event.Discard, nil)
+	coord.SetReasoningLanguage("auto")
+
+	if err := coord.Run(context.Background(), "plan a change"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if got := lastUser(planner.requests[0]); strings.Contains(got, "<reasoning-language>") {
+		t.Fatalf("planner should clear stale reasoning language after live auto update, got %q", got)
+	}
+	if got := lastUser(exec.requests[0]); strings.Contains(got, "<reasoning-language>") {
+		t.Fatalf("executor should clear stale reasoning language after live auto update, got %q", got)
+	}
+}
+
 func TestCoordinatorPlannerMaxStepsUsesPlannerConfigKey(t *testing.T) {
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
 		{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "read_file", Arguments: `{"path":"REASONIX.md"}`}},

--- a/internal/agent/empty_final_test.go
+++ b/internal/agent/empty_final_test.go
@@ -37,6 +37,36 @@ func TestRunRetriesReasoningOnlyFinalAnswer(t *testing.T) {
 	}
 }
 
+func TestRunPrefixesReasoningLanguageOnSyntheticRetry(t *testing.T) {
+	prov := &mockProvider{name: "p", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkReasoning, Text: "I should answer the user."},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "visible reply"},
+			{Type: provider.ChunkDone},
+		},
+	}}
+	a := New(prov, tool.NewRegistry(), NewSession(""), Options{ReasoningLanguage: "zh"}, event.Discard)
+
+	if err := a.Run(context.Background(), "answer me"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(prov.requests) != 2 {
+		t.Fatalf("provider requests = %d, want 2", len(prov.requests))
+	}
+	for i, req := range prov.requests {
+		got := lastUser(req)
+		if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") {
+			t.Fatalf("request %d last user = %q, want reasoning-language prefix", i, got)
+		}
+	}
+	if !strings.Contains(lastUser(prov.requests[1]), "visible answer") {
+		t.Fatalf("retry request last user = %q, want visible-answer retry", lastUser(prov.requests[1]))
+	}
+}
+
 func TestRunStopsAfterRepeatedEmptyFinalAnswers(t *testing.T) {
 	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
 		{{Type: provider.ChunkReasoning, Text: "thinking 1"}, {Type: provider.ChunkDone}},

--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -35,25 +35,59 @@ func ReasoningLanguageBlock(lang string) string {
 }
 
 // WithReasoningLanguage prefixes content with the transient reasoning-language
-// block unless it is already present. The broad contains check avoids duplicate
-// blocks in controller-composed turns and coordinator handoffs.
+// block unless the turn already starts with an injected reasoning-language
+// block. User-authored mentions of the tag later in the prompt must not suppress
+// the configured preference.
 func WithReasoningLanguage(content, lang string) string {
 	block := ReasoningLanguageBlock(lang)
-	if block == "" || strings.Contains(content, "<reasoning-language>") {
+	if block == "" || hasLeadingReasoningLanguageBlock(content) {
 		return content
 	}
 	return block + "\n\n" + content
 }
 
-// WithReasoningLanguagePreference carries the runtime preference to spawned
-// tools, especially task sub-agents whose first user turn is created outside the
-// parent controller.
-func WithReasoningLanguagePreference(ctx context.Context, lang string) context.Context {
-	mode := NormalizeReasoningLanguage(lang)
-	if mode == "auto" {
-		return ctx
+func hasLeadingReasoningLanguageBlock(content string) bool {
+	s := strings.TrimLeft(content, " \t\r\n")
+	for {
+		switch {
+		case strings.HasPrefix(s, "<reasoning-language>"):
+			return strings.Contains(s, "</reasoning-language>")
+		case strings.HasPrefix(s, "<memory-update>"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "memory-update")
+			if !ok {
+				return false
+			}
+		case strings.HasPrefix(s, "<background-jobs>"):
+			var ok bool
+			s, ok = trimLeadingTransientBlock(s, "background-jobs")
+			if !ok {
+				return false
+			}
+		default:
+			return false
+		}
 	}
-	return context.WithValue(ctx, reasoningLanguageContextKey{}, mode)
+}
+
+func trimLeadingTransientBlock(content, tag string) (string, bool) {
+	closeTag := "</" + tag + ">"
+	i := strings.Index(content, closeTag)
+	if i < 0 {
+		return content, false
+	}
+	return strings.TrimLeft(content[i+len(closeTag):], " \t\r\n"), true
+}
+
+// WithReasoningLanguagePreference carries the runtime preference to spawned
+// tools, especially sub-agents whose first user turn is created outside the
+// parent controller. It stores auto explicitly so live zh/en -> auto changes
+// clear stale boot-time preferences in child paths.
+func WithReasoningLanguagePreference(ctx context.Context, lang string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, reasoningLanguageContextKey{}, NormalizeReasoningLanguage(lang))
 }
 
 // ReasoningLanguageFromContext returns auto|zh|en.

--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -1,0 +1,68 @@
+package agent
+
+import (
+	"context"
+	"strings"
+)
+
+type reasoningLanguageContextKey struct{}
+
+// NormalizeReasoningLanguage returns one of auto|zh|en for runtime-only visible
+// reasoning preferences. Keep this local to agent so sub-agents can inherit the
+// preference without depending on config.
+func NormalizeReasoningLanguage(lang string) string {
+	switch strings.ToLower(strings.TrimSpace(lang)) {
+	case "zh", "cn", "chinese", "中文":
+		return "zh"
+	case "en", "english":
+		return "en"
+	default:
+		return "auto"
+	}
+}
+
+// ReasoningLanguageBlock is transient user-turn context. It deliberately does
+// not belong in the stable system prompt or tool schemas.
+func ReasoningLanguageBlock(lang string) string {
+	switch NormalizeReasoningLanguage(lang) {
+	case "zh":
+		return "<reasoning-language>\nVisible reasoning/thinking text preference: use Simplified Chinese when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
+	case "en":
+		return "<reasoning-language>\nVisible reasoning/thinking text preference: use English when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
+	default:
+		return ""
+	}
+}
+
+// WithReasoningLanguage prefixes content with the transient reasoning-language
+// block unless it is already present. The broad contains check avoids duplicate
+// blocks in controller-composed turns and coordinator handoffs.
+func WithReasoningLanguage(content, lang string) string {
+	block := ReasoningLanguageBlock(lang)
+	if block == "" || strings.Contains(content, "<reasoning-language>") {
+		return content
+	}
+	return block + "\n\n" + content
+}
+
+// WithReasoningLanguagePreference carries the runtime preference to spawned
+// tools, especially task sub-agents whose first user turn is created outside the
+// parent controller.
+func WithReasoningLanguagePreference(ctx context.Context, lang string) context.Context {
+	mode := NormalizeReasoningLanguage(lang)
+	if mode == "auto" {
+		return ctx
+	}
+	return context.WithValue(ctx, reasoningLanguageContextKey{}, mode)
+}
+
+// ReasoningLanguageFromContext returns auto|zh|en.
+func ReasoningLanguageFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return "auto"
+	}
+	if v, ok := ctx.Value(reasoningLanguageContextKey{}).(string); ok {
+		return NormalizeReasoningLanguage(v)
+	}
+	return "auto"
+}

--- a/internal/agent/reasoning_language_test.go
+++ b/internal/agent/reasoning_language_test.go
@@ -1,0 +1,24 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestWithReasoningLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
+	userMention := "explain why <reasoning-language> appears in this file"
+	got := WithReasoningLanguage(userMention, "zh")
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, userMention) {
+		t.Fatalf("WithReasoningLanguage should prefix user-authored tag mentions, got %q", got)
+	}
+
+	alreadyPrefixed := ReasoningLanguageBlock("zh") + "\n\n" + userMention
+	if got := WithReasoningLanguage(alreadyPrefixed, "zh"); got != alreadyPrefixed {
+		t.Fatalf("WithReasoningLanguage duplicated a leading injected block:\n got %q\nwant %q", got, alreadyPrefixed)
+	}
+
+	withLeadingMemory := "<memory-update>\nRemember this.\n</memory-update>\n\n" + alreadyPrefixed
+	if got := WithReasoningLanguage(withLeadingMemory, "zh"); got != withLeadingMemory {
+		t.Fatalf("WithReasoningLanguage duplicated a reasoning block after leading transient context:\n got %q\nwant %q", got, withLeadingMemory)
+	}
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -440,6 +440,7 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 		CompactRatio:      t.compactRatio,
 		CompactForceRatio: t.compactForceRatio,
 		ArchiveDir:        t.archiveDir,
+		ReasoningLanguage: ReasoningLanguageFromContext(ctx),
 	}, sink)
 }
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -45,6 +45,23 @@ func TestTaskToolReturnsSubAgentFinalAnswer(t *testing.T) {
 	}
 }
 
+func TestTaskToolInheritsReasoningLanguageFromContext(t *testing.T) {
+	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "done"},
+		{Type: provider.ChunkDone},
+	}}
+	task := newTestTaskTool(t, sub, tool.NewRegistry(), "sys", "", "", nil)
+
+	ctx := WithReasoningLanguagePreference(testTaskContext(), "zh")
+	if _, err := task.Execute(ctx, []byte(`{"prompt":"inspect auth"}`)); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := lastUser(sub.lastReq)
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "inspect auth") {
+		t.Fatalf("sub-agent user = %q, want reasoning-language-prefixed prompt", got)
+	}
+}
+
 // TestTaskToolFiltersTools verifies the whitelist behaviour: when the caller
 // names a subset of tools, the sub-agent's registry contains exactly that set
 // with subagent/skill meta-tools stripped to prevent recursive delegation.

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -610,7 +610,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			Gate:              headlessGate,
 			ContextWindow:     ctxWin,
 			ArchiveDir:        config.ArchiveDir(),
-			ReasoningLanguage: cfg.ReasoningLanguage(),
+			ReasoningLanguage: agent.ReasoningLanguageFromContext(sctx),
 		}, agent.NestedSink(sctx, event.Discard))
 		if err != nil {
 			return "", errors.Join(err, subagentStore.SaveFailed(run))

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -604,12 +604,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 		}
 		answer, err := agent.RunSubAgentWithSession(sctx, prov, subReg, run.Session, task, agent.Options{
-			MaxSteps:      steps,
-			Temperature:   cfg.Agent.Temperature,
-			Pricing:       price,
-			Gate:          headlessGate,
-			ContextWindow: ctxWin,
-			ArchiveDir:    config.ArchiveDir(),
+			MaxSteps:          steps,
+			Temperature:       cfg.Agent.Temperature,
+			Pricing:           price,
+			Gate:              headlessGate,
+			ContextWindow:     ctxWin,
+			ArchiveDir:        config.ArchiveDir(),
+			ReasoningLanguage: cfg.ReasoningLanguage(),
 		}, agent.NestedSink(sctx, event.Discard))
 		if err != nil {
 			return "", errors.Join(err, subagentStore.SaveFailed(run))
@@ -837,6 +838,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		CompactRatio:      cfg.Agent.CompactRatio,
 		CompactForceRatio: cfg.Agent.CompactForceRatio,
 		ArchiveDir:        config.ArchiveDir(),
+		ReasoningLanguage: cfg.ReasoningLanguage(),
 	}, sink)
 
 	var runner agent.Runner = executor
@@ -868,6 +870,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				CompactRatio:      cfg.Agent.CompactRatio,
 				CompactForceRatio: cfg.Agent.CompactForceRatio,
 				ArchiveDir:        config.ArchiveDir(),
+				ReasoningLanguage: cfg.ReasoningLanguage(),
 			}, executor, cfg.Agent.Temperature, sink, control.TaskWarrantsPlanner)
 			label = entry.Model + " + planner " + pe.Model
 		}

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -430,6 +430,52 @@ model = "x"
 	}
 }
 
+func TestBuildSubagentSkillUsesLiveReasoningLanguage(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerBootSubagentTestProvider()
+	prov := &bootSubagentTestProvider{}
+	setBootSubagentTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+reasoning_language = "zh"
+
+[[providers]]
+name = "test-model"
+kind = "boot-subagent-test"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	ctrl.SetReasoningLanguage("auto")
+
+	if err := ctrl.Run(context.Background(), "first review"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := prov.requestsSnapshot()
+	if len(reqs) < 2 {
+		t.Fatalf("provider requests = %d, want parent request plus skill subagent request", len(reqs))
+	}
+	if got := bootLastUser(reqs[1]); strings.Contains(got, "<reasoning-language>") {
+		t.Fatalf("skill subagent kept stale boot-time reasoning language after live auto update: %q", got)
+	}
+	if got := bootLastUser(reqs[1]); got != "first skill task" {
+		t.Fatalf("skill subagent user prompt = %q, want first skill task", got)
+	}
+}
+
 const bootSubagentTestProviderKind = "boot-subagent-test"
 
 var (
@@ -469,6 +515,7 @@ type bootSubagentTestProvider struct {
 	mu          sync.Mutex
 	calls       int
 	continueRef string
+	requests    []provider.Request
 }
 
 func (p *bootSubagentTestProvider) Name() string { return "boot-subagent-test" }
@@ -479,11 +526,12 @@ func (p *bootSubagentTestProvider) setContinueRef(ref string) {
 	p.continueRef = ref
 }
 
-func (p *bootSubagentTestProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+func (p *bootSubagentTestProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
 	p.mu.Lock()
 	call := p.calls
 	p.calls++
 	ref := p.continueRef
+	p.requests = append(p.requests, req)
 	p.mu.Unlock()
 
 	var chunks []provider.Chunk
@@ -510,6 +558,23 @@ func (p *bootSubagentTestProvider) Stream(context.Context, provider.Request) (<-
 	}
 	close(ch)
 	return ch, nil
+}
+
+func (p *bootSubagentTestProvider) requestsSnapshot() []provider.Request {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]provider.Request, len(p.requests))
+	copy(out, p.requests)
+	return out
+}
+
+func bootLastUser(req provider.Request) string {
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		if req.Messages[i].Role == provider.RoleUser {
+			return req.Messages[i].Content
+		}
+	}
+	return ""
 }
 
 func subagentRefFromHistory(t *testing.T, msgs []provider.Message) string {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1311,7 +1311,9 @@ func (c *Controller) SetReasoningLanguage(lang string) {
 	c.mu.Lock()
 	c.reasoningLanguage = mode
 	c.mu.Unlock()
-	if c.executor != nil {
+	if setter, ok := c.runner.(interface{ SetReasoningLanguage(string) }); ok {
+		setter.SetReasoningLanguage(mode)
+	} else if c.executor != nil {
 		c.executor.SetReasoningLanguage(mode)
 	}
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -600,7 +600,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		c.approvedPlanAutoApproveTools = false
 		c.mu.Unlock()
 	}()
-	if err := c.runner.Run(ctx, planApprovedMessage); err != nil {
+	if err := c.runner.Run(ctx, c.ComposeSynthetic(planApprovedMessage)); err != nil {
 		return err
 	}
 	if todoArgs != "" && !c.hasTodoUpdateSince(execStart) {
@@ -1307,9 +1307,13 @@ func (c *Controller) SetAutoPlan(mode string) {
 // SetReasoningLanguage updates the visible reasoning language preference for
 // subsequent turns.
 func (c *Controller) SetReasoningLanguage(lang string) {
+	mode := config.NormalizeReasoningLanguage(lang)
 	c.mu.Lock()
-	c.reasoningLanguage = config.NormalizeReasoningLanguage(lang)
+	c.reasoningLanguage = mode
 	c.mu.Unlock()
+	if c.executor != nil {
+		c.executor.SetReasoningLanguage(mode)
+	}
 }
 
 // PlanMode reports whether outgoing turns currently receive the plan-mode

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -45,7 +45,7 @@ func StripComposePrefixes(content string) string {
 // approval, stream recovery, readiness retry, etc.). These should not be shown
 // in the chat UI.
 func IsSyntheticUserMessage(content string) bool {
-	trimmed := strings.TrimSpace(content)
+	trimmed := strings.TrimSpace(agent.StripTransientUserBlocks(content))
 	if trimmed == planApprovedMessage {
 		return true
 	}
@@ -84,6 +84,7 @@ func (c *Controller) Compose(text string) string {
 	plan := c.planMode
 	goal := c.goal
 	goalStatus := c.goalStatus
+	reasoningLanguage := c.reasoningLanguage
 	notes := c.pendingMemory
 	c.pendingMemory = nil
 	c.mu.Unlock()
@@ -94,9 +95,7 @@ func (c *Controller) Compose(text string) string {
 	if plan {
 		text = PlanModeMarker + "\n\n" + text
 	}
-	if note := reasoningLanguageBlock(c.reasoningLanguage); note != "" {
-		text = note + "\n\n" + text
-	}
+	text = agent.WithReasoningLanguage(text, reasoningLanguage)
 
 	// Memory added mid-session rides the turn (never the cached system prefix),
 	// so it takes effect now without invalidating the prompt cache. It folds into
@@ -124,14 +123,14 @@ func (c *Controller) Compose(text string) string {
 }
 
 func reasoningLanguageBlock(lang string) string {
-	switch strings.ToLower(strings.TrimSpace(lang)) {
-	case "zh":
-		return "<reasoning-language>\nVisible reasoning/thinking text preference: use Simplified Chinese when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
-	case "en":
-		return "<reasoning-language>\nVisible reasoning/thinking text preference: use English when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
-	default:
-		return ""
-	}
+	return agent.ReasoningLanguageBlock(lang)
+}
+
+func (c *Controller) ComposeSynthetic(text string) string {
+	c.mu.Lock()
+	lang := c.reasoningLanguage
+	c.mu.Unlock()
+	return agent.WithReasoningLanguage(text, lang)
 }
 
 func activeGoalBlock(goal string) string {

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -39,6 +39,15 @@ func (f *fakeTurnRunner) Run(ctx context.Context, input string) error {
 	return nil
 }
 
+type fakeLanguageRunner struct {
+	fakeTurnRunner
+	lang string
+}
+
+func (f *fakeLanguageRunner) SetReasoningLanguage(lang string) {
+	f.lang = lang
+}
+
 func TestCustomCommandLookup(t *testing.T) {
 	c := New(Options{Commands: []command.Command{{Name: "review"}, {Name: "git:commit"}}})
 
@@ -130,6 +139,21 @@ func TestRunComposesReasoningLanguagePreference(t *testing.T) {
 	got := runner.inputs[0]
 	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "hi") {
 		t.Fatalf("headless Run should compose the reasoning language preference, got %q", got)
+	}
+}
+
+func TestSetReasoningLanguageUpdatesRunner(t *testing.T) {
+	runner := &fakeLanguageRunner{}
+	c := New(Options{Runner: runner})
+
+	c.SetReasoningLanguage("zh")
+	if runner.lang != "zh" {
+		t.Fatalf("runner reasoning language = %q, want zh", runner.lang)
+	}
+
+	c.SetReasoningLanguage("auto")
+	if runner.lang != "auto" {
+		t.Fatalf("runner reasoning language = %q, want auto", runner.lang)
 	}
 }
 

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -133,6 +133,18 @@ func TestRunComposesReasoningLanguagePreference(t *testing.T) {
 	}
 }
 
+func TestComposeSyntheticReasoningLanguagePreference(t *testing.T) {
+	c := New(Options{ReasoningLanguage: "zh"})
+
+	got := c.ComposeSynthetic(planApprovedMessage)
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, planApprovedMessage) {
+		t.Fatalf("ComposeSynthetic should prefix reasoning language, got %q", got)
+	}
+	if !IsSyntheticUserMessage(got) {
+		t.Fatalf("reasoning-language-prefixed plan approval should still be synthetic")
+	}
+}
+
 func TestComposeIncludesActiveGoal(t *testing.T) {
 	c := New(Options{})
 	c.SetGoal("ship the approval redesign")
@@ -613,6 +625,11 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 		{
 			name:  "plan approved message",
 			input: planApprovedMessage,
+			want:  true,
+		},
+		{
+			name:  "plan approved message with reasoning language",
+			input: reasoningLanguageBlock("zh") + "\n\n" + planApprovedMessage,
 			want:  true,
 		},
 		{


### PR DESCRIPTION
## Summary
- Apply saved reasoning-language changes to all live desktop tab controllers while respecting project-level overrides.
- Route normal and synthetic user turns through a shared transient `<reasoning-language>` helper, including plan approval and retry/nudge turns.
- Pass the reasoning-language runtime preference through agent, planner, direct subagent, and task-subagent paths.

## Cache behavior
- Keeps the preference in transient user-turn context.
- Does not change the system prompt, tool schemas, tool list, or provider request serialization.

## Tests
- `go test ./...`
- `(cd desktop && go test .)`