### PR TITLE
fix: ensure todo panel syncs after complete_step sign-off

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1289,7 +1289,7 @@ export default function App() {
       }
     }
     return null;
-  }, [state.items]);
+  }, [state.items, state.items.length]);
   const todoItem = todoEntry?.item ?? null;
   const todos = useMemo(() => (todoItem ? parseTodos(todoItem.args) : []), [todoItem]);
   const [dismissedTodo, setDismissedTodo] = useState<string | null>(null);

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -789,7 +789,11 @@ func (a *Agent) advanceCanonicalTodo(step string) {
 	}
 	m, ok := evidence.MatchStep(step, a.todoState)
 	if !ok || canonicalTodoStatus(a.todoState[m.Index-1].Status) == "completed" {
+		// MatchStep failed or the step was already completed — still emit the
+		// current snapshot so the frontend stays in sync with the canonical state.
+		snapshot := append([]evidence.TodoItem(nil), a.todoState...)
 		a.todoMu.Unlock()
+		a.emitTodoState(snapshot, 0)
 		return
 	}
 	a.todoState[m.Index-1].Status = "completed"


### PR DESCRIPTION
Backend: advanceCanonicalTodo now emits current todoState snapshot even when MatchStep fails or the step is already completed, preventing silent UI staleness.

Frontend: add state.items.length to todoEntry useMemo deps for reliable re-computation when synthetic todo_write items are appended.