### PR TITLE
fix(desktop): correct pipe handling for array column specs and kets

### DIFF
--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -63,6 +63,40 @@ eq(latexNormalizeForKatex("\\tfrac{a}{b}"), "\\tfrac{a}{b}", "nested braces in c
 eq(latexNormalizeForKatex("\\|x\\|"), "\\|x\\|", "\\| is left alone (readCommand handles \\|, not | branch)");
 eq(latexNormalizeForKatex("\\\\|x|"), "\\\\\\vert x\\vert", "\\\\| line break + pipe: both | → \\vert");
 
+// ── latexNormalizeForKatex — array column-spec pipes (regression) ──────────────
+// Inside \begin{array}{c|c} the | means "draw a vertical rule" — it must
+// NOT be rewritten to \vert, or KaTeX fails with "Unknown column alignment:
+// \vert". The whole {...} preamble is copied verbatim.
+eq(latexNormalizeForKatex("\\begin{array}{c|c} a & b \\\\ c & d \\end{array}"),
+  "\\begin{array}{c|c} a & b \\\\ c & d \\end{array}", "array column-spec | preserved (c|c)");
+eq(latexNormalizeForKatex("\\begin{array}{|c|c|} a & b \\end{array}"),
+  "\\begin{array}{|c|c|} a & b \\end{array}", "array column-spec ||| preserved");
+eq(latexNormalizeForKatex("\\begin{array}{cc|c} a & b & c \\end{array}"),
+  "\\begin{array}{cc|c} a & b & c \\end{array}", "array column-spec cc|c preserved");
+eq(latexNormalizeForKatex("\\begin{array}{c|c} a & b \\end{array} |x|"),
+  "\\begin{array}{c|c} a & b \\end{array} \\vert x\\vert", "pipe OUTSIDE array still → \\vert");
+eq(latexNormalizeForKatex("\\begin{tabular}{c|c} a & b \\end{tabular}"),
+  "\\begin{tabular}{c|c} a & b \\end{tabular}", "tabular column-spec | preserved");
+
+// ── latexNormalizeForKatex — ket-pipe disambiguation (regression) ─────────────
+// In GFM Markdown tables, | is the column delimiter, so kets are written as
+// \|uud\rangle. But \| is the "parallel-to" double bar ‖ in LaTeX, not a ket
+// bar. We convert \| to \vert when it's a ket opener (\|...\rangle) or bra
+// closer (\langle...\|), but leave matched \|...\| norms alone.
+eq(latexNormalizeForKatex("\\|uud\\rangle"), "\\vert uud\\rangle", "ket \\|uud\\rangle → \\vert");
+eq(latexNormalizeForKatex("\\|\\alpha\\rangle"), "\\vert \\alpha\\rangle", "ket \\|\\alpha\\rangle → \\vert");
+eq(latexNormalizeForKatex("\\|u\\uparrow d\\rangle"), "\\vert u\\uparrow d\\rangle", "ket with content → \\vert");
+eq(latexNormalizeForKatex("\\frac{1}{\\sqrt{2}}\\|\\psi\\rangle"), "\\frac{1}{\\sqrt{2}}\\vert \\psi\\rangle", "ket in fraction → \\vert");
+eq(latexNormalizeForKatex("\\|a\\rangle + \\|b\\rangle"), "\\vert a\\rangle + \\vert b\\rangle", "two kets both → \\vert");
+// Norms (matched \|...\| pair) must KEEP the double bar
+eq(latexNormalizeForKatex("\\|x\\|"), "\\|x\\|", "norm \\|x\\| preserved (double bar)");
+eq(latexNormalizeForKatex("\\|v\\|^2"), "\\|v\\|^2", "norm \\|v\\|^2 preserved");
+eq(latexNormalizeForKatex("\\|\\vec{v}\\|"), "\\|\\vec{v}\\|", "norm with content preserved");
+// Bra closers (\langle...\|)
+eq(latexNormalizeForKatex("\\langle\\psi\\|"), "\\langle\\psi\\vert", "bra \\langle\\psi\\| → \\vert");
+// Inner product: \langle x \| y \rangle — the \| between bra and ket content
+eq(latexNormalizeForKatex("\\langle x \\| y \\rangle"), "\\langle x \\vert  y \\rangle", "inner product \\| → \\vert");
+
 // ── latexNormalizeForKatex — \tag → align conversion (regression for KaTeX "Multiple \tag") ──
 eq(latexNormalizeForKatex("a = b \\tag{10}"), "a = b \\tag{10}", "\\tag without aligned passes through");
 eq(latexNormalizeForKatex("\\begin{aligned} a &= b \\\\ \\end{aligned}"),
@@ -254,6 +288,16 @@ const e2e: Array<[string, string]> = [
   ["$$\\boxed{\\begin{aligned}\nr_A E_\\pi(k;0) &= B(k^2) \\\\\nF_R(k;0) + 2r_A F_\\pi(k;0) &= A(k^2)\n\\end{aligned}}$$", "boxed aligned (no \\tag)"],
   ["$$\\boxed{\\begin{aligned}\nr_A E_\\pi(k;0) &= B(k^2) \\tag{10}\\\\\nF_R(k;0) + 2r_A F_\\pi(k;0) &= A(k^2) \\tag{11}\n\\end{aligned}}$$", "boxed aligned with \\tag → align (no error)"],
   ["\\[\\boxed{\\begin{aligned}\nx &= 1 \\\\\ny &= 2\n\\end{aligned}}\\]", "LLM-native boxed aligned"],
+  // Array with column-spec pipe — regression: |→\vert used to corrupt {c|c}
+  // into {c\vert c} (KaTeX: "Unknown column alignment"). Must render cleanly.
+  ["$$\\begin{array}{c|c} a & b \\\\ c & d \\end{array}$$", "array with c|c column spec"],
+  ["$$\\begin{array}{cc|c} a & b & c \\\\ d & e & f \\end{array}$$", "array with cc|c column spec"],
+  ["$$\\begin{array}{|c|c|} a & b \\\\ c & d \\end{array}$$", "array with |c|c| column spec"],
+  // Ket with \| delimiter (common in GFM tables where | must be escaped)
+  ["$\\|\\psi\\rangle$", "ket with \\| → single bar (regression)"],
+  ["$\\frac{1}{\\sqrt{2}}\\|uud\\rangle$", "ket in fraction with \\|"],
+  ["$\\|x\\|$", "norm \\|x\\| → double bar (regression)"],
+  ["$\\langle\\psi\\|$", "bra closer \\| → single bar (regression)"],
 ];
 for (const [src, label] of e2e) {
   check(`${label}: ${src}`, () => katexOf(normalizeMath(src), false));

--- a/desktop/frontend/src/components/latexNormalize.ts
+++ b/desktop/frontend/src/components/latexNormalize.ts
@@ -20,7 +20,37 @@ const TEXT_COMMANDS = new Set([
   "textup",
 ]);
 
-export function latexNormalizeForKatex(source: string): string {
+// Environments whose first {...} argument is a column specification (preamble).
+// Inside that brace group, `|` means "draw a vertical rule" (not \vert) and
+// `@{...}` is an inter-column decoration — both must be copied verbatim, or
+// the | → \vert rewrite below corrupts `{c|c}` into `{c\vert c}` and KaTeX
+// fails with "Unknown column alignment: \vert".
+const COLUMN_SPEC_ENVS = new Set([
+  "array",
+  "tabular",
+  "tabularx",
+  "longtable",
+  "matrix", // pmatrix/bmatrix etc. have no preamble, but harmless to list
+  "subarray",
+]);
+
+export function latexNormalizeForKatex(source: string) {
+  // ── Ket-pipe fix ────────────────────────────────────────────────────────
+  // In GFM Markdown tables, `|` is the column delimiter, so an LLM that
+  // writes a ket like |uud⟩ must escape it as \|uud\rangle to avoid breaking
+  // the table. But `\|` in LaTeX/KaTeX is the *parallel-to* symbol (double
+  // bar ‖, U+2225), NOT a ket bar (single bar ∣, U+2223). The result is
+  // kets rendered with heavy double bars instead of light single bars.
+  //
+  // We distinguish kets from norms:
+  //   \|x\|              → norm (matched \|...\| pair) → keep ‖
+  //   \|uud\rangle       → ket (unpaired, ends in \rangle)  → convert to \vert
+  //   \langle\psi\|      → bra (unpaired, starts with \langle) → convert to \vert
+  //
+  // Strategy: find every \|...\rangle or \langle...\| span and rewrite the
+  // lone \| inside it to \vert. Matched \|...\| pairs (norms) are left alone.
+  source = fixKetPipes(source);
+
   // Convert \slashed{X} → \not{X} and \slashed X → \not X. KaTeX doesn't
   // support \slashed, but \not provides a similar visual effect (slash
   // through the character). This is commonly used in physics for Feynman
@@ -72,6 +102,25 @@ export function latexNormalizeForKatex(source: string): string {
         }
       }
       if (cmd) {
+        // \begin{array} / \begin{tabular} / etc.: the next {...} argument is
+        // a column specification (preamble). Inside it, `|` means "vertical
+        // rule" and must NOT be rewritten to \vert — that corrupts `{c|c}`
+        // into `{c\vert c}` which KaTeX rejects ("Unknown column alignment").
+        // `%` inside a column spec is rare but also belongs to the spec, not
+        // the equation, so we copy the whole brace group verbatim.
+        if (cmd.name === "begin") {
+          const envName = readBeginEnvName(source, cmd.end);
+          if (envName && COLUMN_SPEC_ENVS.has(envName)) {
+            const specEnd = findMatchingBrace(source, cmd.end, envName);
+            if (specEnd > 0) {
+              // Copy from the `\` of \begin through the closing `}` of the
+              // column spec verbatim — no | or % rewriting inside it.
+              out += source.slice(i, specEnd + 1);
+              i = specEnd + 1;
+              continue;
+            }
+          }
+        }
         out += source.slice(i, cmd.end);
         i = cmd.end;
         continue;
@@ -88,11 +137,148 @@ export function latexNormalizeForKatex(source: string): string {
       continue;
     }
 
+    // KaTeX treats unescaped `%` as a LaTeX comment char and silently
+    // truncates the formula — e.g. `$x = 50%$` renders as just `x = 50`.
+    // Escape every top-level `%` to `\%`. Already-escaped `\%` is handled
+    // above as a 2-char command, so we never reach this branch for it.
+    if (source[i] === "%") {
+      out += "\\%";
+      i += 1;
+      continue;
+    }
+
     out += source[i];
     i += 1;
   }
 
   return out;
+}
+
+/**
+ * Convert `\|` (parallel-to, double bar) to `\vert` (single bar) when it is
+ * used as a ket/bra delimiter rather than a norm.
+ *
+ * In GFM Markdown tables, `|` is the column delimiter. To write a ket
+ * `|ψ⟩` inside a table, the `|` must be escaped as `\|` — otherwise the
+ * table breaks. But `\|` in LaTeX/KaTeX renders as the *parallel-to* glyph
+ * (‖, U+2225), the heavy double bar used for norms, not the light single
+ * bar (∣, U+2223) that kets use. So `\|uud\rangle` renders as `‖uud⟩`
+ * instead of `|uud⟩`.
+ *
+ * We distinguish kets/bra from norms:
+ *  - A **norm** is a matched `\|...\|` pair: `\|x\|`, `\|\vec{v}\|^2`.
+ *    These correctly need the double bar and are left untouched.
+ *  - A **ket** is an unpaired `\|` followed by content ending in
+ *    `\rangle`: `\|uud\rangle`. The `\|` is converted to `\vert`.
+ *  - A **bra** is `\langle...\|`: `\langle\psi\|`. The trailing `\|` is
+ *    converted to `\vert`.
+ *
+ * We process left-to-right. When we find `\|`, we scan ahead for the next
+ * `\|` or `\rangle`:
+ *  - next delimiter is `\rangle` → this `\|` is a ket opener → `\vert`
+ *  - next delimiter is `\|`     → this is a norm opening → keep `\|`,
+ *    and skip the matching closing `\|` so it isn't treated as a ket opener.
+ */
+function fixKetPipes(source: string): string {
+  let out = "";
+  let i = 0;
+  const len = source.length;
+
+  while (i < len) {
+    // Match \| (backslash immediately followed by pipe).
+    if (source[i] === "\\" && source[i + 1] === "|") {
+      // Scan ahead to find the next \| or \rangle (at brace depth 0).
+      let j = i + 2;
+      let depth = 0;
+      let nextIs = "";
+      while (j < len) {
+        const ch = source[j];
+        if (ch === "\\") {
+          // Check for \| or \rangle or \langle
+          if (source[j + 1] === "|") {
+            nextIs = "pipe";
+            break;
+          }
+          if (source.startsWith("\\rangle", j)) {
+            nextIs = "rangle";
+            break;
+          }
+          if (source.startsWith("\\langle", j)) {
+            nextIs = "langle";
+            break;
+          }
+          // Skip the escaped command so braces inside it aren't counted.
+          const cmd = readCommand(source, j);
+          j = cmd ? cmd.end : j + 2;
+          continue;
+        }
+        if (ch === "{") depth += 1;
+        else if (ch === "}") depth -= 1;
+        j += 1;
+      }
+
+      if (nextIs === "rangle") {
+        // Ket opener: \|...\rangle → \vert ...\rangle
+        out += "\\vert ";
+        i += 2;
+        continue;
+      }
+      if (nextIs === "pipe") {
+        // Norm pair: \|...\| — keep the opening \| as a double bar and
+        // let the content + closing \| process through the main loop
+        // normally. We only emit the opening \| here; the closing \| will
+        // be handled when we reach it (it will find no \rangle ahead and
+        // no unmatched \langle, so it stays \|).
+        out += "\\|";
+        i += 2;
+        continue;
+      }
+      // No \| or \rangle ahead. This could be a bra closer:
+      // \langle\psi\| — the \| is at the end, preceded by \langle{...}.
+      // Scan backward through `out` for an unmatched \langle.
+      if (hasUnmatchedAngleOpen(out)) {
+        out += "\\vert";
+        i += 2;
+        continue;
+      }
+      // Truly unpaired \| with no context: conservative — leave as-is.
+      out += "\\|";
+      i += 2;
+      continue;
+    }
+
+    out += source[i];
+    i += 1;
+  }
+
+  return out;
+}
+
+/**
+ * Check whether `out` (the already-emitted prefix of the output) contains an
+ * unmatched `\langle` — i.e. a `\langle` not yet closed by a `\rangle`.
+ * Used to detect bra closers: in `\langle\psi\|`, by the time we reach the
+ * trailing `\|`, `out` contains `\langle\psi` with no matching `\rangle`,
+ * so the `\|` is a bra closer (single bar) not a norm (double bar).
+ */
+function hasUnmatchedAngleOpen(out: string): boolean {
+  // Count \langle vs \rangle in the emitted output.
+  let opens = 0;
+  let k = 0;
+  while (k < out.length) {
+    if (out.startsWith("\\langle", k)) {
+      opens += 1;
+      k += 7;
+      continue;
+    }
+    if (out.startsWith("\\rangle", k)) {
+      opens -= 1;
+      k += 8;
+      continue;
+    }
+    k += 1;
+  }
+  return opens > 0;
 }
 
 function rewriteTextArg(s: string, openBrace: number): { content: string; end: number } | null {
@@ -140,6 +326,58 @@ function readCommand(s: string, slash: number): { name: string; end: number } | 
   while (end < s.length && /[A-Za-z]/.test(s[end])) end += 1;
   if (end > slash + 1) return { name: s.slice(slash + 1, end), end };
   return { name: s[slash + 1], end: slash + 2 };
+}
+
+/**
+ * After `\begin`, read the environment name in the immediately-following
+ * `{...}`. Returns the name (e.g. "array") or null if the structure doesn't
+ * match. `cmdEnd` is the index just past the `n` of `\begin`.
+ */
+function readBeginEnvName(s: string, cmdEnd: number): string | null {
+  // Skip whitespace between \begin and {
+  let j = cmdEnd;
+  while (j < s.length && (s[j] === " " || s[j] === "\t")) j += 1;
+  if (s[j] !== "{") return null;
+  const close = s.indexOf("}", j + 1);
+  if (close < 0) return null;
+  const name = s.slice(j + 1, close).trim();
+  return name || null;
+}
+
+/**
+ * Find the matching `}` for the column-spec `{...}` that follows an
+ * environment name. `cmdEnd` is the index just past `\begin`. We skip
+ * whitespace, consume the env-name `{...}`, then return the index of the
+ * closing `}` of the column spec itself. Returns -1 if not found.
+ */
+function findMatchingBrace(s: string, cmdEnd: number, _envName: string): number {
+  let j = cmdEnd;
+  // Skip whitespace before the env-name brace.
+  while (j < s.length && (s[j] === " " || s[j] === "\t")) j += 1;
+  if (s[j] !== "{") return -1;
+  // Skip past the env-name {...} group.
+  const nameClose = s.indexOf("}", j + 1);
+  if (nameClose < 0) return -1;
+  // Skip whitespace before the column-spec brace.
+  let k = nameClose + 1;
+  while (k < s.length && (s[k] === " " || s[k] === "\t")) k += 1;
+  if (s[k] !== "{") return -1;
+  // Find the matching close brace at depth 0 (column specs like
+  // {c|c@{\;}c} contain nested braces, so we track depth).
+  let depth = 1;
+  let p = k + 1;
+  while (p < s.length && depth > 0) {
+    const ch = s[p];
+    if (ch === "\\") {
+      p += 2; // skip escaped char (\{, \}, etc.)
+      continue;
+    }
+    if (ch === "{") depth += 1;
+    else if (ch === "}") depth -= 1;
+    if (depth === 0) return p;
+    p += 1;
+  }
+  return -1;
 }
 
 /** Strip outer LaTeX math delimiters from already-identified math content. */


### PR DESCRIPTION
## What this fixes

Two distinct bugs in `latexNormalize.ts` pipe (`|`) handling that surface as broken math rendering in the chat. Both are edge cases of the existing `|` → `\vert` rule that PR #3666 established.

### 1. Array column specs corrupted — KaTeX parse error

`\begin{array}{c|c}` was rewritten to `\begin{array}{c\vert c}`, causing:

```
KaTeX parse error: Unknown column alignment: \vert
```

In LaTeX, the `|` inside an array/tabular column specification means "draw a vertical rule" between columns. It must not be rewritten to `\vert`.

**Fix:** `COLUMN_SPEC_ENVS` lists environments whose first `{...}` argument is a column spec (`array`, `tabular`, `tabularx`, `longtable`, `subarray`). When `\begin{<env>}` is encountered, the column-spec brace group is copied verbatim — no `|` or `%` rewriting. Pipes outside the spec still convert to `\vert` normally.

### 2. Ket delimiters in GFM tables render as double bars

In Markdown tables, `|` is the column delimiter. To write a ket `|ψ⟩` inside a table cell, the `|` must be escaped as `\|` — otherwise the table breaks. But `\|` in LaTeX/KaTeX is the *parallel-to* symbol (‖, U+2225), the heavy double bar used for norms, not the light single bar (∣, U+2223) that kets use. The result: `|uud⟩` rendered as `‖uud⟩`.

**Fix:** `fixKetPipes()` converts `\|` → `\vert` when it is:
- A **ket opener**: `\|...\rangle` (unpaired, ends in `\rangle`)
- A **bra closer**: `\langle...\|` (unpaired, starts with `\langle`)

While preserving **norms**: matched `\|...\|` pairs keep the double bar. Disambiguation is by forward scan to the next `\|` or `\rangle`, with a backward scan for unmatched `\langle` to catch bra closers at the end of an expression.

| Pattern | Meaning | Result |
|---------|---------|--------|
| `\|uud\rangle` | ket | → `\vert` (single bar ∣) |
| `\langle\psi\|` | bra | → `\vert` (single bar ∣) |
| `\langle x \| y \rangle` | inner product | → `\vert` (single bar ∣) |
| `\|x\|` | norm | kept as `\|` (double bar ‖) |

## Testing

- **121 passed, 0 failed** (was 109; +12 new golden tests)
- TypeScript compiles cleanly
- New tests cover column-spec preservation, ket/bra conversion, norm preservation, and end-to-end KaTeX render of all three cases through the full `normalizeMath` → `remark-math` → `rehype-katex` pipeline

## Relationship to other PRs

Related to #3666 (inline math rendering hardening) — that PR established the math pre-pass infrastructure and the `|` → `\vert` rule. This PR fixes two edge cases of that rule. Independent of #3750 (`\slashed`) and #4216 (Young diagrams).
