### PR TITLE
Add performance pressure diagnostics / 新增性能卡顿诊断上报

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -220,5 +220,5 @@ includes conversations, API keys, file contents, or paths.
 
 Opt out any time: Settings > Updates > "Anonymous usage ping", or set
 `telemetry = false` under `[desktop]` in the global config. Dev builds
-never ping. Crash reports are separate and only ever sent when the user
-clicks "Send report" on the crash screen.
+never ping. Crash and performance-pressure reports are separate and only
+ever sent when the user clicks "Send report" on the diagnostic UI.

--- a/desktop/crash_app.go
+++ b/desktop/crash_app.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 )
 
-// crash_app.go is the crash/feedback reporting surface. Reports are sent only on
-// an explicit user click in the frontend crash overlay — never automatically.
+// crash_app.go is the crash/feedback/performance reporting surface. Reports are
+// sent only on an explicit user click in the frontend UI — never automatically.
 
 var crashEndpoint = "https://crash.reasonix.io/v1/report"
 
@@ -100,7 +100,7 @@ type frontendCrashPayload struct {
 
 func normalizeReportKind(kind string) (string, bool) {
 	switch strings.TrimSpace(kind) {
-	case "crash", "exception", "feedback":
+	case "crash", "exception", "feedback", "performance":
 		return strings.TrimSpace(kind), true
 	default:
 		return "", false
@@ -165,6 +165,28 @@ func topFrameFromStack(stack string) string {
 	return ""
 }
 
+func nativeResourceContext() string {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	mb := func(n uint64) string {
+		return fmt.Sprintf("%.1f MB", float64(n)/1024/1024)
+	}
+	return strings.Join([]string{
+		"go heap alloc: " + mb(m.Alloc),
+		"go heap sys: " + mb(m.HeapSys),
+		"go total sys: " + mb(m.Sys),
+		fmt.Sprintf("goroutines: %d", runtime.NumGoroutine()),
+		fmt.Sprintf("gc cycles: %d", m.NumGC),
+	}, "\n")
+}
+
+func appendNativeResourceContext(kind, message string) string {
+	if kind != "performance" {
+		return message
+	}
+	return sanitizeCrashText(message+"\n\n--- native runtime context ---\n"+nativeResourceContext(), maxCrashDetailBytes)
+}
+
 func crashReportFromDetail(kind, detail string) (crashReport, error) {
 	rawKind := kind
 	kind, ok := normalizeReportKind(kind)
@@ -205,6 +227,7 @@ func crashReportFromDetail(kind, detail string) (crashReport, error) {
 		if r.Source == "" {
 			r.Source = "frontend"
 		}
+		r.Message = appendNativeResourceContext(r.Kind, r.Message)
 		return r, nil
 	}
 
@@ -212,6 +235,7 @@ func crashReportFromDetail(kind, detail string) (crashReport, error) {
 	r.Source = "legacy"
 	r.Label = kind
 	r.Message = sanitizeCrashText(detail, maxCrashDetailBytes)
+	r.Message = appendNativeResourceContext(r.Kind, r.Message)
 	return r, nil
 }
 

--- a/desktop/crash_app_test.go
+++ b/desktop/crash_app_test.go
@@ -147,3 +147,30 @@ func TestCrashReportFromStructuredDetail(t *testing.T) {
 		}
 	}
 }
+
+func TestCrashReportFromPerformanceDetail(t *testing.T) {
+	payload := frontendCrashPayload{
+		SchemaVersion: 2,
+		Kind:          "performance",
+		Source:        "frontend.performance",
+		Label:         "performance.pressure",
+		Message:       "[performance.pressure]\n\n--- performance context ---\nreason: event loop lag 1300ms",
+		ErrorType:     "PerformancePressure",
+		ErrorMessage:  "UI responsiveness degraded because the app observed long tasks, event-loop lag, or high JS heap pressure.",
+		TopFrame:      "frontend.performance",
+	}
+	detail, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := crashReportFromDetail("performance", string(detail))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Kind != "performance" || r.Source != "frontend.performance" || r.Label != "performance.pressure" {
+		t.Fatalf("performance fields not preserved: %+v", r)
+	}
+	if !strings.Contains(r.Message, "--- native runtime context ---") || !strings.Contains(r.Message, "goroutines:") {
+		t.Fatalf("native runtime context missing from performance report: %q", r.Message)
+	}
+}

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -1,6 +1,13 @@
 // Run: tsx src/__tests__/crash-reporting.test.ts
 
-import { buildCrashPayload, normalizeCrashError, topFrameFromStack } from "../lib/crash";
+import {
+  buildCrashPayload,
+  buildPerformancePayload,
+  formatPerformanceContext,
+  normalizeCrashError,
+  topFrameFromStack,
+  type PerformanceSnapshot,
+} from "../lib/crash";
 
 let passed = 0;
 let failed = 0;
@@ -28,6 +35,35 @@ eq(payload.source, "frontend.global", "global handler payload identifies source"
 eq(payload.errorType, "TypeError", "captures error type");
 eq(payload.componentStack, "component stack", "captures component stack");
 eq(payload.message.includes("[unhandledrejection]"), true, "keeps human-readable message");
+
+const perf: PerformanceSnapshot = {
+  reason: "event loop lag 1300ms",
+  uptimeMs: 42_000,
+  visibility: "visible",
+  focused: true,
+  online: true,
+  hardwareConcurrency: 10,
+  deviceMemoryGb: 16,
+  jsHeap: { usedMb: 700, totalMb: 780, limitMb: 900, usagePercent: 77.7 },
+  eventLoopLag: { currentMs: 1300, maxMs: 1300, avgMs: 220, samples: 6 },
+  longTasks: {
+    count: 3,
+    totalMs: 1800,
+    maxMs: 900,
+    recent: [
+      { startMs: 40_000, durationMs: 900 },
+      { startMs: 41_000, durationMs: 500 },
+    ],
+  },
+  connection: { effectiveType: "4g", rttMs: 50, downlinkMbps: 20, saveData: false },
+};
+const perfPayload = buildPerformancePayload(perf);
+eq(perfPayload.kind, "performance", "performance pressure reports use performance kind");
+eq(perfPayload.source, "frontend.performance", "performance pressure reports identify source");
+eq(perfPayload.errorType, "PerformancePressure", "performance pressure reports use a stable error type");
+eq(perfPayload.errorMessage.includes("1300"), false, "performance fingerprint message avoids dynamic durations");
+eq(formatPerformanceContext(perf).includes("long tasks: 3"), true, "formats long task context");
+eq(perfPayload.message.includes("event loop lag 1300ms"), true, "payload message keeps lag context");
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -5,6 +5,8 @@ import {
   buildPerformancePayload,
   formatPerformanceContext,
   normalizeCrashError,
+  performanceLabelForReason,
+  shouldRecordLongTaskSample,
   topFrameFromStack,
   type PerformanceSnapshot,
 } from "../lib/crash";
@@ -60,10 +62,17 @@ const perf: PerformanceSnapshot = {
 const perfPayload = buildPerformancePayload(perf);
 eq(perfPayload.kind, "performance", "performance pressure reports use performance kind");
 eq(perfPayload.source, "frontend.performance", "performance pressure reports identify source");
+eq(perfPayload.label, "performance.lag", "performance pressure reports partition by stable pressure label");
 eq(perfPayload.errorType, "PerformancePressure", "performance pressure reports use a stable error type");
 eq(perfPayload.errorMessage.includes("1300"), false, "performance fingerprint message avoids dynamic durations");
+eq(perfPayload.label.includes("1300"), false, "performance fingerprint label avoids dynamic durations");
 eq(formatPerformanceContext(perf).includes("long tasks: 3"), true, "formats long task context");
 eq(perfPayload.message.includes("event loop lag 1300ms"), true, "payload message keeps lag context");
+eq(performanceLabelForReason("long task 900ms"), "performance.longtask", "labels long task pressure");
+eq(performanceLabelForReason("js heap 87% of limit"), "performance.heap", "labels heap pressure");
+eq(shouldRecordLongTaskSample(14_000, 900, 15_000), false, "ignores startup long tasks before grace ends");
+eq(shouldRecordLongTaskSample(16_000, 40, 15_000), false, "ignores short long-task observer entries");
+eq(shouldRecordLongTaskSample(16_000, 900, 15_000), true, "records post-grace long tasks");
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -1,17 +1,51 @@
 // Last-resort crash surface: a React render error with no boundary unmounts the
 // whole tree (blank window), and global errors/rejections leave no trace either.
 
-import { dumpBreadcrumbs, snapshotBreadcrumbs, type Breadcrumb } from "./breadcrumbs";
+import { addBreadcrumb, dumpBreadcrumbs, snapshotBreadcrumbs, type Breadcrumb } from "./breadcrumbs";
 import { t } from "./i18n";
 
 declare const __BUILD_COMMIT__: string;
 declare const __BUILD_CHANNEL__: string;
 
-export type CrashKind = "crash" | "exception" | "feedback";
+export type CrashKind = "crash" | "exception" | "feedback" | "performance";
+
+export type PerformanceSnapshot = {
+  reason: string;
+  uptimeMs: number;
+  visibility: string;
+  focused: boolean;
+  online: boolean;
+  hardwareConcurrency: number;
+  deviceMemoryGb?: number;
+  jsHeap?: {
+    usedMb: number;
+    totalMb: number;
+    limitMb: number;
+    usagePercent?: number;
+  };
+  eventLoopLag?: {
+    currentMs: number;
+    maxMs: number;
+    avgMs: number;
+    samples: number;
+  };
+  longTasks?: {
+    count: number;
+    totalMs: number;
+    maxMs: number;
+    recent: { startMs: number; durationMs: number }[];
+  };
+  connection?: {
+    effectiveType?: string;
+    downlinkMbps?: number;
+    rttMs?: number;
+    saveData?: boolean;
+  };
+};
 
 export type CrashPayload = {
   schemaVersion: 2;
-  source: "frontend" | "frontend.react" | "frontend.global";
+  source: "frontend" | "frontend.react" | "frontend.global" | "frontend.performance";
   kind: CrashKind;
   label: string;
   message: string;
@@ -33,6 +67,40 @@ type NormalizedError = {
   errorMessage: string;
   stack?: string;
 };
+
+type LongTaskSample = {
+  startMs: number;
+  durationMs: number;
+};
+
+type BrowserPerformanceMemory = {
+  usedJSHeapSize?: number;
+  totalJSHeapSize?: number;
+  jsHeapSizeLimit?: number;
+};
+
+type BrowserNavigator = Navigator & {
+  deviceMemory?: number;
+  connection?: {
+    effectiveType?: string;
+    downlink?: number;
+    rtt?: number;
+    saveData?: boolean;
+  };
+};
+
+const LONG_TASK_WINDOW_MS = 60_000;
+const LONG_TASK_PROMPT_MS = 800;
+const LONG_TASK_TOTAL_PROMPT_MS = 1_500;
+const EVENT_LOOP_LAG_PROMPT_MS = 1_200;
+const STARTUP_GRACE_MS = 15_000;
+const PROMPT_COOLDOWN_MS = 10 * 60_000;
+const MAX_LAG_SAMPLES = 60;
+
+const longTasks: LongTaskSample[] = [];
+const lagSamples: number[] = [];
+let performanceMonitorInstalled = false;
+let lastPerformancePromptAt = 0;
 
 function clip(s: string, n: number): string {
   return s.length > n ? s.slice(0, n) : s;
@@ -106,6 +174,163 @@ function formatText(label: string, normalized: NormalizedError, extra?: string):
     .join("\n\n");
 }
 
+function fmtNumber(n: number, digits = 0): string {
+  return Number.isFinite(n) ? n.toFixed(digits) : "0";
+}
+
+function fmtMb(n: number): string {
+  return `${fmtNumber(n, 1)} MB`;
+}
+
+function readHeapSnapshot(): PerformanceSnapshot["jsHeap"] | undefined {
+  if (typeof performance === "undefined") return undefined;
+  const memory = (performance as Performance & { memory?: BrowserPerformanceMemory }).memory;
+  if (!memory?.usedJSHeapSize || !memory.totalJSHeapSize || !memory.jsHeapSizeLimit) return undefined;
+  const usedMb = memory.usedJSHeapSize / 1024 / 1024;
+  const totalMb = memory.totalJSHeapSize / 1024 / 1024;
+  const limitMb = memory.jsHeapSizeLimit / 1024 / 1024;
+  return {
+    usedMb,
+    totalMb,
+    limitMb,
+    usagePercent: limitMb > 0 ? (usedMb / limitMb) * 100 : undefined,
+  };
+}
+
+function pruneLongTasks(now = performance.now()): void {
+  while (longTasks.length && now - longTasks[0].startMs > LONG_TASK_WINDOW_MS) longTasks.shift();
+}
+
+function longTaskSummary(now = performance.now()): PerformanceSnapshot["longTasks"] {
+  pruneLongTasks(now);
+  if (!longTasks.length) return undefined;
+  const totalMs = longTasks.reduce((sum, t) => sum + t.durationMs, 0);
+  const maxMs = Math.max(...longTasks.map((t) => t.durationMs));
+  return {
+    count: longTasks.length,
+    totalMs,
+    maxMs,
+    recent: longTasks.slice(-5),
+  };
+}
+
+function eventLoopLagSummary(currentMs = 0): PerformanceSnapshot["eventLoopLag"] {
+  const samples = lagSamples.filter((n) => n > 0);
+  if (!samples.length && currentMs <= 0) return undefined;
+  const all = currentMs > 0 ? [...samples, currentMs] : samples;
+  const total = all.reduce((sum, n) => sum + n, 0);
+  return {
+    currentMs,
+    maxMs: Math.max(...all),
+    avgMs: total / all.length,
+    samples: all.length,
+  };
+}
+
+function networkSnapshot(): PerformanceSnapshot["connection"] {
+  if (typeof navigator === "undefined") return undefined;
+  const connection = (navigator as BrowserNavigator).connection;
+  if (!connection) return undefined;
+  return {
+    effectiveType: connection.effectiveType,
+    downlinkMbps: connection.downlink,
+    rttMs: connection.rtt,
+    saveData: connection.saveData,
+  };
+}
+
+function performanceSnapshot(reason: string, currentLagMs = 0): PerformanceSnapshot {
+  const nav = typeof navigator === "undefined" ? undefined : (navigator as BrowserNavigator);
+  const doc = typeof document === "undefined" ? undefined : document;
+  return {
+    reason,
+    uptimeMs: typeof performance !== "undefined" ? performance.now() : 0,
+    visibility: doc?.visibilityState ?? "",
+    focused: doc?.hasFocus?.() ?? false,
+    online: nav?.onLine ?? true,
+    hardwareConcurrency: nav?.hardwareConcurrency ?? 0,
+    deviceMemoryGb: nav?.deviceMemory,
+    jsHeap: readHeapSnapshot(),
+    eventLoopLag: eventLoopLagSummary(currentLagMs),
+    longTasks: typeof performance !== "undefined" ? longTaskSummary() : undefined,
+    connection: networkSnapshot(),
+  };
+}
+
+export function formatPerformanceContext(snapshot: PerformanceSnapshot): string {
+  const lines = [
+    `reason: ${snapshot.reason}`,
+    `uptime: ${fmtNumber(snapshot.uptimeMs / 1000, 1)}s`,
+    `visibility: ${snapshot.visibility || "unknown"}`,
+    `focused: ${snapshot.focused ? "true" : "false"}`,
+    `online: ${snapshot.online ? "true" : "false"}`,
+    `hardware concurrency: ${snapshot.hardwareConcurrency || "unknown"}`,
+  ];
+  if (snapshot.deviceMemoryGb) lines.push(`device memory: ${snapshot.deviceMemoryGb} GB`);
+  if (snapshot.jsHeap) {
+    const pct =
+      snapshot.jsHeap.usagePercent !== undefined ? `, ${fmtNumber(snapshot.jsHeap.usagePercent)}% of limit` : "";
+    lines.push(
+      `js heap: ${fmtMb(snapshot.jsHeap.usedMb)} used, ${fmtMb(snapshot.jsHeap.totalMb)} allocated, ${fmtMb(snapshot.jsHeap.limitMb)} limit${pct}`,
+    );
+  }
+  if (snapshot.eventLoopLag) {
+    lines.push(
+      `event loop lag: current ${fmtNumber(snapshot.eventLoopLag.currentMs)}ms, max ${fmtNumber(snapshot.eventLoopLag.maxMs)}ms, avg ${fmtNumber(snapshot.eventLoopLag.avgMs)}ms over ${snapshot.eventLoopLag.samples} samples`,
+    );
+  }
+  if (snapshot.longTasks) {
+    const recent = snapshot.longTasks.recent
+      .map((t) => `${fmtNumber(t.durationMs)}ms @ ${fmtNumber(t.startMs / 1000, 1)}s`)
+      .join("; ");
+    lines.push(
+      `long tasks: ${snapshot.longTasks.count} in the last 60s, max ${fmtNumber(snapshot.longTasks.maxMs)}ms, total ${fmtNumber(snapshot.longTasks.totalMs)}ms`,
+    );
+    if (recent) lines.push(`recent long tasks: ${recent}`);
+  }
+  if (snapshot.connection) {
+    const parts = [
+      snapshot.connection.effectiveType,
+      snapshot.connection.rttMs !== undefined ? `${snapshot.connection.rttMs}ms rtt` : "",
+      snapshot.connection.downlinkMbps !== undefined ? `${snapshot.connection.downlinkMbps} Mbps` : "",
+      snapshot.connection.saveData !== undefined ? `saveData ${snapshot.connection.saveData ? "true" : "false"}` : "",
+    ].filter(Boolean);
+    if (parts.length) lines.push(`connection: ${parts.join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+export function buildPerformancePayload(snapshot: PerformanceSnapshot): CrashPayload {
+  const buildCommit = typeof __BUILD_COMMIT__ === "string" ? __BUILD_COMMIT__ : "dev";
+  const context = formatPerformanceContext(snapshot);
+  const crumbs = dumpBreadcrumbs();
+  const errorMessage = "UI responsiveness degraded because the app observed long tasks, event-loop lag, or high JS heap pressure.";
+  return {
+    schemaVersion: 2,
+    source: "frontend.performance",
+    kind: "performance",
+    label: "performance.pressure",
+    message: [
+      "[performance.pressure]",
+      errorMessage,
+      `--- performance context ---\n${context}`,
+      crumbs && `--- breadcrumbs ---\n${crumbs}`,
+      `build ${buildCommit}`,
+    ]
+      .filter(Boolean)
+      .join("\n\n"),
+    errorType: "PerformancePressure",
+    errorMessage,
+    topFrame: "frontend.performance",
+    buildCommit,
+    channel: typeof __BUILD_CHANNEL__ === "string" ? __BUILD_CHANNEL__ : "",
+    language: typeof navigator !== "undefined" ? navigator.language || "" : "",
+    view: currentView(),
+    breadcrumbs: snapshotBreadcrumbs(),
+    occurredAt: new Date().toISOString(),
+  };
+}
+
 export function buildCrashPayload(label: string, err: unknown, extra?: string): CrashPayload {
   const normalized = normalizeCrashError(err);
   const buildCommit = typeof __BUILD_COMMIT__ === "string" ? __BUILD_COMMIT__ : "dev";
@@ -129,13 +354,13 @@ export function buildCrashPayload(label: string, err: unknown, extra?: string): 
   };
 }
 
-function sendButton(payload: CrashPayload): HTMLButtonElement | null {
+function sendButton(payload: CrashPayload, className = "crash-overlay__send"): HTMLButtonElement | null {
   // Resolved at click time via window.go, not the bridge module: this overlay must
   // stay usable even when the rest of the app (and its imports) is broken.
   const report = window.go?.main?.App?.ReportCrash;
   if (!report) return null;
   const send = document.createElement("button");
-  send.className = "crash-overlay__send";
+  send.className = className;
   send.textContent = t("crash.send");
   send.onclick = async () => {
     send.disabled = true;
@@ -148,6 +373,39 @@ function sendButton(payload: CrashPayload): HTMLButtonElement | null {
     }
   };
   return send;
+}
+
+function paintPerformancePrompt(payload: CrashPayload, snapshot: PerformanceSnapshot) {
+  if (typeof document === "undefined") return;
+  let host = document.getElementById("performance-report-prompt");
+  if (!host) {
+    host = document.createElement("div");
+    host.id = "performance-report-prompt";
+    document.body.appendChild(host);
+  }
+  const title = document.createElement("div");
+  title.className = "performance-report__title";
+  title.textContent = t("performanceReport.title");
+  const body = document.createElement("pre");
+  body.className = "performance-report__body";
+  body.textContent = formatPerformanceContext(snapshot);
+  const actions = document.createElement("div");
+  actions.className = "performance-report__actions";
+  const send = sendButton(payload, "performance-report__send");
+  const copy = document.createElement("button");
+  copy.className = "performance-report__copy";
+  copy.textContent = t("crash.copy");
+  copy.onclick = () => void navigator.clipboard?.writeText(payload.message);
+  const dismiss = document.createElement("button");
+  dismiss.className = "performance-report__dismiss";
+  dismiss.textContent = t("performanceReport.dismiss");
+  dismiss.onclick = () => host?.remove();
+  if (send) actions.append(send);
+  actions.append(copy, dismiss);
+  const note = document.createElement("div");
+  note.className = "performance-report__note";
+  note.textContent = t("performanceReport.privacyNote");
+  host.replaceChildren(title, body, actions, note);
 }
 
 function paint(payload: CrashPayload) {
@@ -180,6 +438,74 @@ function paint(payload: CrashPayload) {
 
 export function reportCrash(label: string, err: unknown, extra?: string) {
   paint(buildCrashPayload(label, err, extra));
+}
+
+function shouldPromptForPerformance(now: number): boolean {
+  if (now - lastPerformancePromptAt < PROMPT_COOLDOWN_MS) return false;
+  if (typeof document !== "undefined" && document.visibilityState === "hidden") return false;
+  return true;
+}
+
+function promptPerformanceReport(reason: string, currentLagMs = 0): void {
+  const now = Date.now();
+  if (!shouldPromptForPerformance(now)) return;
+  lastPerformancePromptAt = now;
+  addBreadcrumb("performance", reason);
+  const snapshot = performanceSnapshot(reason, currentLagMs);
+  paintPerformancePrompt(buildPerformancePayload(snapshot), snapshot);
+}
+
+function maybePromptForHeapPressure(): void {
+  const heap = readHeapSnapshot();
+  if (!heap?.usagePercent) return;
+  if (heap.usedMb >= 512 && heap.usagePercent >= 85) {
+    promptPerformanceReport(`js heap ${fmtNumber(heap.usagePercent)}% of limit`);
+  }
+}
+
+export function installPerformancePressureMonitor() {
+  if (performanceMonitorInstalled || typeof window === "undefined" || typeof performance === "undefined") return;
+  if (!window.runtime) return;
+  performanceMonitorInstalled = true;
+  const startedAt = performance.now();
+
+  const pastGrace = () => performance.now() - startedAt >= STARTUP_GRACE_MS;
+  const inspectLongTasks = () => {
+    if (!pastGrace()) return;
+    const summary = longTaskSummary();
+    if (!summary) return;
+    if (summary.maxMs >= LONG_TASK_PROMPT_MS || (summary.count >= 3 && summary.totalMs >= LONG_TASK_TOTAL_PROMPT_MS)) {
+      promptPerformanceReport(`long task ${fmtNumber(summary.maxMs)}ms`);
+    }
+  };
+
+  if (typeof PerformanceObserver !== "undefined") {
+    try {
+      const observer = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.duration < 50) continue;
+          longTasks.push({ startMs: Math.round(entry.startTime), durationMs: Math.round(entry.duration) });
+        }
+        pruneLongTasks();
+        inspectLongTasks();
+      });
+      observer.observe({ entryTypes: ["longtask"] });
+    } catch {
+      // Some WebViews expose PerformanceObserver without the longtask entry type.
+    }
+  }
+
+  let expected = performance.now() + 1000;
+  window.setInterval(() => {
+    const now = performance.now();
+    const lagMs = Math.max(0, now - expected);
+    expected = now + 1000;
+    lagSamples.push(lagMs);
+    if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
+    if (!pastGrace()) return;
+    if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);
+    maybePromptForHeapPressure();
+  }, 1000);
 }
 
 export function installGlobalCrashHandlers() {

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -300,18 +300,31 @@ export function formatPerformanceContext(snapshot: PerformanceSnapshot): string 
   return lines.join("\n");
 }
 
+export function performanceLabelForReason(reason: string): string {
+  const normalized = reason.trim().toLowerCase();
+  if (normalized.startsWith("event loop lag")) return "performance.lag";
+  if (normalized.startsWith("long task")) return "performance.longtask";
+  if (normalized.startsWith("js heap")) return "performance.heap";
+  return "performance.pressure";
+}
+
+export function shouldRecordLongTaskSample(startMs: number, durationMs: number, graceUntilMs: number): boolean {
+  return durationMs >= 50 && startMs >= graceUntilMs;
+}
+
 export function buildPerformancePayload(snapshot: PerformanceSnapshot): CrashPayload {
   const buildCommit = typeof __BUILD_COMMIT__ === "string" ? __BUILD_COMMIT__ : "dev";
   const context = formatPerformanceContext(snapshot);
   const crumbs = dumpBreadcrumbs();
+  const label = performanceLabelForReason(snapshot.reason);
   const errorMessage = "UI responsiveness degraded because the app observed long tasks, event-loop lag, or high JS heap pressure.";
   return {
     schemaVersion: 2,
     source: "frontend.performance",
     kind: "performance",
-    label: "performance.pressure",
+    label,
     message: [
-      "[performance.pressure]",
+      `[${label}]`,
       errorMessage,
       `--- performance context ---\n${context}`,
       crumbs && `--- breadcrumbs ---\n${crumbs}`,
@@ -468,8 +481,9 @@ export function installPerformancePressureMonitor() {
   if (!window.runtime) return;
   performanceMonitorInstalled = true;
   const startedAt = performance.now();
+  const graceUntil = startedAt + STARTUP_GRACE_MS;
 
-  const pastGrace = () => performance.now() - startedAt >= STARTUP_GRACE_MS;
+  const pastGrace = () => performance.now() >= graceUntil;
   const inspectLongTasks = () => {
     if (!pastGrace()) return;
     const summary = longTaskSummary();
@@ -483,7 +497,7 @@ export function installPerformancePressureMonitor() {
     try {
       const observer = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
-          if (entry.duration < 50) continue;
+          if (!shouldRecordLongTaskSample(entry.startTime, entry.duration, graceUntil)) continue;
           longTasks.push({ startMs: Math.round(entry.startTime), durationMs: Math.round(entry.duration) });
         }
         pruneLongTasks();
@@ -500,9 +514,9 @@ export function installPerformancePressureMonitor() {
     const now = performance.now();
     const lagMs = Math.max(0, now - expected);
     expected = now + 1000;
+    if (!pastGrace()) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
-    if (!pastGrace()) return;
     if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);
     maybePromptForHeapPressure();
   }, 1000);

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1400,6 +1400,9 @@ export const en = {
   "crash.sent": "Sent — thanks!",
   "crash.sendFailed": "Send failed — use Copy instead",
   "crash.privacyNote": "The report contains only the error text above (user names in paths removed) plus app version and OS.",
+  "performanceReport.title": "Reasonix noticed a responsiveness issue",
+  "performanceReport.dismiss": "Dismiss",
+  "performanceReport.privacyNote": "Before upload, the desktop scrubber removes paths and secrets. The diagnostic is intended to contain timing, memory, network state, recent breadcrumbs, app version, and OS.",
 
   // mock / demo seed data (browser dev only)
   "mock.sessionFixLogin": "fix the login bug in auth.go",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -1452,5 +1452,8 @@ export const zhTW: Record<DictKey, string> = {
   "crash.sent": "已傳送，謝謝！",
   "crash.sendFailed": "傳送失敗 —— 請改用複製",
   "crash.privacyNote": "報告僅包含上方錯誤文字（路徑中的使用者名稱已移除）以及應用版本和作業系統。",
+  "performanceReport.title": "Reasonix 偵測到回應卡頓",
+  "performanceReport.dismiss": "關閉",
+  "performanceReport.privacyNote": "上傳前桌面端會移除路徑與密鑰；診斷資訊只用於記錄耗時、記憶體、網路狀態、近期 breadcrumbs、應用版本和作業系統。",
   "mock.topicSysException": "異常處理與恢復演練",
 };

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1402,6 +1402,9 @@ export const zh: Record<DictKey, string> = {
   "crash.sent": "已发送，谢谢！",
   "crash.sendFailed": "发送失败 —— 请改用复制",
   "crash.privacyNote": "报告仅包含上方错误文本（路径中的用户名已移除）以及应用版本和操作系统。",
+  "performanceReport.title": "Reasonix 检测到响应卡顿",
+  "performanceReport.dismiss": "关闭",
+  "performanceReport.privacyNote": "上传前桌面端会移除路径与密钥；诊断信息只用于记录耗时、内存、网络状态、近期 breadcrumbs、应用版本和操作系统。",
 
   // 模拟/演示种子数据（仅浏览器开发模式）
   "mock.sessionFixLogin": "fix the login bug in auth.go",

--- a/desktop/frontend/src/main.tsx
+++ b/desktop/frontend/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
-import { installGlobalCrashHandlers } from "./lib/crash";
+import { installGlobalCrashHandlers, installPerformancePressureMonitor } from "./lib/crash";
 import { installBreadcrumbConsoleHook } from "./lib/breadcrumbs";
 import { installMessageSelectionCopy } from "./lib/messageSelectionCopy";
 import { LocaleProvider } from "./lib/i18n";
@@ -16,6 +16,7 @@ import "./styles.css";
 // featureless webview background, with the recent console trail attached.
 installGlobalCrashHandlers();
 installBreadcrumbConsoleHook();
+installPerformancePressureMonitor();
 
 // Apply the saved appearance (auto/light/dark) before the first paint.
 initTheme();

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -13752,6 +13752,78 @@ a[href] {
   font-size: 12px;
 }
 
+#performance-report-prompt {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: calc(var(--z-crash-overlay) - 1);
+  width: min(440px, calc(100vw - 24px));
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--border) 78%, #d97757 22%);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--panel, var(--bg-elev)) 96%, #d97757 4%);
+  color: var(--fg);
+  box-shadow: var(--shadow-2);
+}
+.performance-report__title {
+  font-size: 13px;
+  font-weight: 700;
+}
+.performance-report__body {
+  max-height: 170px;
+  margin: 0;
+  padding: 10px;
+  border: 1px solid var(--border-soft);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--fg-dim);
+  font-family: var(--mono, monospace);
+  font-size: 11.5px;
+  line-height: 1.45;
+  overflow: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.performance-report__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.performance-report__copy,
+.performance-report__send,
+.performance-report__dismiss {
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--button-bg);
+  color: var(--fg);
+  font-size: 12px;
+}
+.performance-report__send {
+  border-color: color-mix(in srgb, var(--accent) 68%, var(--border));
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.performance-report__send[disabled] {
+  opacity: 0.7;
+}
+.performance-report__note {
+  color: var(--fg-faint);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+
+@media (max-width: 560px) {
+  #performance-report-prompt {
+    right: 12px;
+    bottom: 12px;
+  }
+}
+
 /* onboarding — first-run gate covering the whole window. Sits above every
    other layer; the card is centered, terminal-styled, with a faint scanline
    accent so it reads as "stop and paste a key" rather than a generic modal. */

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -95,6 +95,7 @@
   --z-toast: 1302;
   --z-tooltip: 1302;
   --z-onboarding: 9999;
+  --z-performance-report-prompt: 99998;
   --z-crash-overlay: 99999;
 
   /* component recipes */
@@ -13756,7 +13757,7 @@ a[href] {
   position: fixed;
   right: 18px;
   bottom: 18px;
-  z-index: calc(var(--z-crash-overlay) - 1);
+  z-index: var(--z-performance-report-prompt);
   width: min(440px, calc(100vw - 24px));
   display: flex;
   flex-direction: column;

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -1,5 +1,6 @@
-// Ingest + dashboard for desktop crash/feedback reports and the anonymous launch
-// ping. Reports are user-initiated; pings are opt-out (desktop.telemetry).
+// Ingest + dashboard for desktop crash/feedback/performance reports and the
+// anonymous launch ping. Reports are user-initiated; pings are opt-out
+// (desktop.telemetry).
 import { z } from "zod";
 import type { Env } from "./env";
 import { html, redirect } from "./shell";
@@ -35,7 +36,7 @@ const Device = z
   .partial();
 
 const Report = z.object({
-  kind: z.enum(["crash", "exception", "feedback"]),
+  kind: z.enum(["crash", "exception", "feedback", "performance"]),
   version: z.string().min(1).max(64),
   os: z.string().min(1).max(32),
   arch: z.string().min(1).max(32),
@@ -208,6 +209,7 @@ export function crashTitle(message: string): string {
 
 function severityForKind(kind: string): string {
   if (kind === "crash") return "high";
+  if (kind === "performance") return "medium";
   if (kind === "exception") return "medium";
   return "low";
 }

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -133,7 +133,7 @@ export function renderStats(
   const platformLinks = data.platforms.length
     ? data.platforms.map((p) => `<a class="chip" href="${esc(filterQS({ platform: p.label }))}">${esc(p.label)} <b>${p.users}</b></a>`).join("")
     : `<span class="muted">no platforms yet</span>`;
-  const filters = `<div class="card full"><h2>Crash filters · 崩溃筛选 <b>— latest ${esc(data.latestVersion || "n/a")}</b></h2>
+  const filters = `<div class="card full"><h2>Report filters · 诊断筛选 <b>— latest ${esc(data.latestVersion || "n/a")}</b></h2>
 <div class="actions">
 <a class="btn sm ghost" href="/stats">All</a>
 <a class="btn sm ghost" href="${esc(filterQS({ status: "open" }))}">Open</a>
@@ -152,12 +152,12 @@ export function renderStats(
             `<tr><td><a class="fp" href="/stats/group/${esc(c.fingerprint)}">${esc(c.fingerprint.slice(0, 8))}</a></td><td class="summary"${c.title ? ` title="${esc(c.title)}"` : ""}>${c.title ? esc(clip(c.title, 90)) : `<span class="muted">—</span>`}${c.regressed_at ? ` <span class="pill ignored">regressed</span>` : ""}</td><td>${esc(c.source || "legacy")}</td><td><span class="pill">${esc(c.severity || "medium")}</span></td><td><span class="pill ${c.kind === "crash" ? "crash" : ""}">${esc(c.kind)}</span></td><td>${statusPill(c.status)}</td><td class="n">${c.count}</td><td class="n">${esc(c.first_version || "?")} → ${esc(c.last_version)}</td><td class="n">${esc([c.last_os, c.last_arch].filter(Boolean).join("/"))}</td><td class="n">${esc(c.seen)}</td></tr>`,
         )
         .join("")}</tbody></table>`
-    : `<div class="empty">No crash reports yet — that's the good kind of empty · 还没有崩溃报告</div>`;
+    : `<div class="empty">No reports yet — that's the good kind of empty · 还没有诊断报告</div>`;
 
   return page(
     "Reasonix · Stats",
     "stats",
-    `<h1>Desktop stats</h1><p class="sub">Today: <b>${totalUsers}</b> active installs · anonymous launch pings and crash reports only</p>
+    `<h1>Desktop stats</h1><p class="sub">Today: <b>${totalUsers}</b> active installs · anonymous launch pings and user-sent diagnostic reports only</p>
 <div class="grid">
 <div class="card full"><h2>Daily active installs · 每日活跃 <b>— 30 days</b> (solid: users, faded: opens)</h2>
 ${anyPing ? dailyChart(days) : `<div class="empty">No pings yet — data starts flowing once a telemetry-enabled build ships · 等带统计的版本发布后这里开始有数据</div>`}</div>
@@ -165,7 +165,7 @@ ${anyPing ? dailyChart(days) : `<div class="empty">No pings yet — data starts 
 <div class="card"><h2>Platforms · 平台分布 <b>— 7 days</b></h2>${listBars(data.platforms)}</div>
 <div class="card full"><h2>Agent signals · 运行指标 <b>— 7 days, opt-in aggregate</b></h2>${metricsCards(data.metrics)}</div>
 ${filters}
-<div class="card full"><h2>Crash groups · 崩溃分组 <b>— click a fingerprint for stacks</b></h2>${crashRows}</div>
+<div class="card full"><h2>Report groups · 诊断分组 <b>— click a fingerprint for details</b></h2>${crashRows}</div>
 </div>`,
     userNav(user),
   );


### PR DESCRIPTION
Follow-up to #4285.
Related: #4318 addresses one known streaming UI jank path; this PR adds diagnostics for future high-resource or responsiveness issues.

## Summary

- Add a user-initiated performance-pressure report prompt when the desktop observes long tasks, event-loop lag, or high JS heap pressure.
- Capture coarse diagnostic context such as timing, heap usage, visibility, network state, recent breadcrumbs, app version, and OS, then route it through the existing report scrubber and crash-report pipeline as `kind: performance`.
- Allow the crash-report Worker and dashboard to ingest and group performance diagnostics without a database schema migration.

## Cache behavior

- Does not change system prompts, tool schemas, tool lists, provider request serialization, compaction behavior, or model-visible context prefixes.

## CI follow-up

- Fixed the desktop CI frontend build failure by replacing the calculated z-index with a named `--z-performance-report-prompt` token accepted by the CSS z-index guard.

## Verification

- `pnpm --dir desktop/frontend build`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/crash-reporting.test.ts`
- `(cd desktop && go test . -run 'TestCrashReport|TestPostCrashReport|TestScrub')`
- `npm --prefix workers/crash-report run typecheck`
- `git diff --check`