### PR TITLE
fix(desktop): reset telemetry and context panel after /clear

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -884,6 +884,7 @@ func (a *App) ClearSession() error {
 	if err := ctrl.ClearSession(); err != nil {
 		return err
 	}
+	tab.resetTelemetry()
 	a.persistTabSessionPath(tab, ctrl.SessionPath())
 	return nil
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1364,6 +1364,7 @@ export default function App() {
     setClearContextPending(false);
     try {
       await clearSession();
+      setDockRefreshKey((v) => v + 1);
       notice(t("clearContext.done"));
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -200,6 +200,12 @@ export function ContextPanel({
     void refresh();
   }, [refresh, refreshKey]);
 
+  useEffect(() => {
+    if (context?.used === 0 && sessionTokens === 0 && info) {
+      setInfo(null);
+    }
+  }, [context?.used, sessionTokens]);
+
   const hasPanelUsage = Boolean(
     (info?.requestCount ?? 0) > 0 ||
     (info?.promptTokens ?? 0) > 0 ||

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -95,6 +95,7 @@ interface State {
   sessionCurrency: string;
   retry?: { attempt: number; max: number };
   seq: number;
+  sessionGen: number;
 }
 
 export const initialState: State = {
@@ -112,6 +113,7 @@ export const initialState: State = {
   sessionCost: 0,
   sessionCurrency: "¥",
   seq: 0,
+  sessionGen: 0,
 };
 
 function usageTotalTokens(usage?: WireUsage): number {
@@ -406,6 +408,7 @@ function applyEvent(s: State, e: WireEvent): State {
       return { ...s, items: next };
     }
     case "usage": {
+      if (!s.turnActive) return s;
       const used = e.usage && s.context.window ? e.usage.promptTokens : s.context.used;
       const turnTokens = s.turnTokens + (e.usage?.completionTokens ?? 0);
       const usageTokens = usageTotalTokens(e.usage);
@@ -514,7 +517,7 @@ export function reducer(s: State, a: Action): State {
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": return { ...s, approval: undefined };
     case "clearAsk": return { ...s, ask: undefined };
-    case "reset": return { ...initialState, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs };
+    case "reset": return { ...initialState, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs, sessionGen: s.sessionGen + 1 };
     case "event": return applyEvent(s, a.e);
     default: return s;
   }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -200,6 +200,13 @@ func (t *WorkspaceTab) telemetrySnapshot() tabTelemetrySnapshot {
 	return tabTelemetrySnapshot{Version: 2, ReadFiles: records, Usage: usage}
 }
 
+func (t *WorkspaceTab) resetTelemetry() {
+	t.telemMu.Lock()
+	t.readTelemetry = nil
+	t.usageTelemetry = sessionUsageStats{}
+	t.telemMu.Unlock()
+}
+
 // tabEventSink wraps a parent event.Sink and prepends a tabId to every wire
 // event so the frontend can route it to the correct tab's reducer.
 type tabEventSink struct {


### PR DESCRIPTION
Closes #4186

## Problem
After `/clear`, the context panel still shows stale token counts and workspace context.

Two sub-bugs:
- **(a)** `/clear` sometimes fails to clear context — stale `usage` events from the previous session re-populate state after the reset action zeros it.
- **(b)** Token info and workspace context are not refreshed after `/clear`.

## Root Causes
1. `ClearSession()` resets the executor session but NOT `tab.usageTelemetry`/`tab.readTelemetry`. `ContextPanel` reads from telemetry, returns stale data.
2. `dockRefreshKey` only bumps on `turn_done`, so ContextPanel doesn't refresh after `/clear`.
3. `ContextPanel.tsx` line 212 falls back to `info.usedTokens` when `context.used === 0`, showing stale values.
4. The `usage` event handler doesn't check `turnActive`, so stale events arriving after reset re-accumulate into session tokens.

## Fix
1. Add `resetTelemetry()` on `WorkspaceTab` — called from `App.ClearSession()` after clearing the executor session.
2. Bump `dockRefreshKey` in `confirmClearContext` to force ContextPanel refresh.
3. Clear stale `info` state in ContextPanel when `context.used === 0 && sessionTokens === 0`.
4. Guard `usage` handler with `turnActive` check — stale events from a cleared session are dropped.
5. Add `sessionGen` counter to State, incremented on `reset` — for future use to discard stale events by generation.

## Files Changed
- `desktop/tabs.go` — `resetTelemetry()` method
- `desktop/app.go` — calls `tab.resetTelemetry()` after `ClearSession()`
- `desktop/frontend/src/App.tsx` — bumps `dockRefreshKey` after clear
- `desktop/frontend/src/components/ContextPanel.tsx` — clears stale `info`
- `desktop/frontend/src/lib/useController.ts` — `sessionGen` counter, `usage` guard on `turnActive`

## Verification
```bash
go build ./cmd/reasonix
go vet ./...
go test ./internal/control/ -run TestSubmitClear -v -count=1
go test ./internal/agent/ -count=1
go test ./internal/config/ -count=1
```