### PR TITLE
Fix CodeQL security alerts / 修复 CodeQL 安全告警

### DIFF
--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -311,7 +310,8 @@ func safePath(root, p string) (string, error) {
 	abs = filepath.Clean(abs)
 	if root != "" {
 		r := filepath.Clean(root)
-		if abs != r && !strings.HasPrefix(abs, r+string(os.PathSeparator)) {
+		rel, err := filepath.Rel(r, abs)
+		if err != nil || !filepath.IsLocal(rel) {
 			return "", fmt.Errorf("checkpoint path %q escapes workspace %q", p, root)
 		}
 	}

--- a/internal/codegraph/install.go
+++ b/internal/codegraph/install.go
@@ -288,7 +288,7 @@ func resolveWithin(root, name string) (string, error) {
 }
 
 func cleanSymlinkTarget(root, linkPath, linkname string) (string, error) {
-	if linkname == "" || !filepath.IsLocal(linkname) {
+	if linkname == "" || filepath.IsAbs(linkname) {
 		return "", fmt.Errorf("unsafe symlink target %q in archive", linkname)
 	}
 	clean := filepath.Clean(linkname)

--- a/internal/codegraph/install.go
+++ b/internal/codegraph/install.go
@@ -299,7 +299,7 @@ func cleanSymlinkTarget(root, linkPath, linkname string) (string, error) {
 	if dest != root && !strings.HasPrefix(dest, root+string(os.PathSeparator)) {
 		return "", fmt.Errorf("unsafe symlink target %q in archive", linkname)
 	}
-	return clean, nil
+	return filepath.ToSlash(clean), nil
 }
 
 // symlinkWithin rejects a symlink whose target escapes root. linkPath is the

--- a/internal/codegraph/install.go
+++ b/internal/codegraph/install.go
@@ -263,6 +263,9 @@ func sha256For(sums, name string) (string, error) {
 // the symlink-redirect variant a lexical "../" check misses: a parent component
 // an earlier entry turned into a symlink, written *through* to land outside root.
 func resolveWithin(root, name string) (string, error) {
+	if !filepath.IsLocal(name) {
+		return "", fmt.Errorf("unsafe path %q in archive", name)
+	}
 	target := filepath.Join(root, name)
 	if target != root && !strings.HasPrefix(target, root+string(os.PathSeparator)) {
 		return "", fmt.Errorf("unsafe path %q in archive", name)
@@ -282,6 +285,21 @@ func resolveWithin(root, name string) (string, error) {
 		return "", fmt.Errorf("unsafe path %q in archive: escapes via symlink", name)
 	}
 	return filepath.Join(realParent, filepath.Base(target)), nil
+}
+
+func cleanSymlinkTarget(root, linkPath, linkname string) (string, error) {
+	if linkname == "" || !filepath.IsLocal(linkname) {
+		return "", fmt.Errorf("unsafe symlink target %q in archive", linkname)
+	}
+	clean := filepath.Clean(linkname)
+	dest, err := filepath.EvalSymlinks(filepath.Join(filepath.Dir(linkPath), clean))
+	if err != nil {
+		return "", fmt.Errorf("unsafe symlink target %q in archive: %w", linkname, err)
+	}
+	if dest != root && !strings.HasPrefix(dest, root+string(os.PathSeparator)) {
+		return "", fmt.Errorf("unsafe symlink target %q in archive", linkname)
+	}
+	return clean, nil
 }
 
 // symlinkWithin rejects a symlink whose target escapes root. linkPath is the
@@ -328,11 +346,15 @@ func extractTarGz(data []byte, dir string) error {
 				return err
 			}
 		case tar.TypeSymlink:
-			if err := symlinkWithin(root, target, hdr.Linkname); err != nil {
+			linkname, err := cleanSymlinkTarget(root, target, hdr.Linkname)
+			if err != nil {
+				return err
+			}
+			if err := symlinkWithin(root, target, linkname); err != nil {
 				return err
 			}
 			_ = os.Remove(target)
-			if err := os.Symlink(hdr.Linkname, target); err != nil {
+			if err := os.Symlink(linkname, target); err != nil {
 				return err
 			}
 		case tar.TypeReg:

--- a/internal/codegraph/symlink_escape_test.go
+++ b/internal/codegraph/symlink_escape_test.go
@@ -98,6 +98,26 @@ func TestExtractAllowsInternalSymlink(t *testing.T) {
 	}
 }
 
+func TestExtractAllowsParentRelativeInternalSymlink(t *testing.T) {
+	dir := t.TempDir()
+	probe := filepath.Join(dir, "probe-link")
+	if err := os.Symlink("probe-target", probe); err != nil {
+		t.Skipf("symlink creation is not available in this environment: %v", err)
+	}
+	_ = os.Remove(probe)
+	data := tarGz(
+		&tar.Header{Name: "codegraph-linux-x64/lib/tool", Typeflag: tar.TypeReg, Mode: 0o755},
+		&tar.Header{Name: "codegraph-linux-x64/bin/tool", Typeflag: tar.TypeSymlink, Linkname: "../lib/tool", Mode: 0o777},
+	)
+	if err := extractTarGz(data, dir); err != nil {
+		t.Fatalf("parent-relative internal symlink should be allowed: %v", err)
+	}
+	link := filepath.Join(dir, "codegraph-linux-x64", "bin", "tool")
+	if got, err := os.Readlink(link); err != nil || got != "../lib/tool" {
+		t.Fatalf("symlink target = %q, %v; want ../lib/tool", got, err)
+	}
+}
+
 func TestExtractRejectsDanglingSymlink(t *testing.T) {
 	dir := t.TempDir()
 	err := extractTarGz(tarGzWithSymlink("link", "missing-target"), dir)

--- a/internal/codegraph/symlink_escape_test.go
+++ b/internal/codegraph/symlink_escape_test.go
@@ -113,7 +113,7 @@ func TestExtractAllowsParentRelativeInternalSymlink(t *testing.T) {
 		t.Fatalf("parent-relative internal symlink should be allowed: %v", err)
 	}
 	link := filepath.Join(dir, "codegraph-linux-x64", "bin", "tool")
-	if got, err := os.Readlink(link); err != nil || got != "../lib/tool" {
+	if got, err := os.Readlink(link); err != nil || filepath.ToSlash(got) != "../lib/tool" {
 		t.Fatalf("symlink target = %q, %v; want ../lib/tool", got, err)
 	}
 }

--- a/internal/codegraph/symlink_escape_test.go
+++ b/internal/codegraph/symlink_escape_test.go
@@ -21,6 +21,14 @@ func tarGzWithSymlink(link, dest string) []byte {
 	return buf.Bytes()
 }
 
+func tarGzWithExistingSymlinkTarget(link, dest string) []byte {
+	cleanDest := filepath.Clean(dest)
+	return tarGz(
+		&tar.Header{Name: cleanDest, Typeflag: tar.TypeReg, Mode: 0o644},
+		&tar.Header{Name: link, Typeflag: tar.TypeSymlink, Linkname: dest, Mode: 0o777},
+	)
+}
+
 // TestExtractRejectsEscapingSymlink proves a symlink pointing outside the
 // extraction dir is refused — otherwise a later entry written through it escapes
 // (tar-slip via symlink), letting a malicious third-party release plant files
@@ -84,8 +92,16 @@ func TestExtractAllowsInternalSymlink(t *testing.T) {
 	}
 	_ = os.Remove(probe)
 	for _, dest := range []string{"bin/codegraph", "./node", "sub/dir/../tool"} {
-		if err := extractTarGz(tarGzWithSymlink("link", dest), dir); err != nil {
+		if err := extractTarGz(tarGzWithExistingSymlinkTarget("link", dest), dir); err != nil {
 			t.Errorf("internal symlink -> %q should be allowed, got %v", dest, err)
 		}
+	}
+}
+
+func TestExtractRejectsDanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	err := extractTarGz(tarGzWithSymlink("link", "missing-target"), dir)
+	if err == nil || !strings.Contains(err.Error(), "unsafe symlink") {
+		t.Fatalf("dangling symlink should be rejected, got %v", err)
 	}
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -759,6 +759,13 @@ func (c *Controller) Submit(input string) {
 	c.submit(input, "")
 }
 
+// SubmitHTTP accepts input from the unauthenticated localhost HTTP frontend. It
+// deliberately omits the trusted TUI-only "!cmd" shell shortcut and resolves file
+// references only through the controller's workspace root.
+func (c *Controller) SubmitHTTP(input string) {
+	c.submitHTTP(input, "")
+}
+
 // SubmitDisplay runs input as a turn while remembering the user-facing display
 // text for transcript replay when controller-side composition expands input.
 func (c *Controller) SubmitDisplay(display, input string) {
@@ -781,6 +788,36 @@ func (c *Controller) submit(input, display string) {
 	if strings.HasPrefix(trimmed, "!") {
 		c.RunShell(trimmed[1:])
 		return
+	}
+	c.submitCommandOrTurn(trimmed, input, display, false)
+}
+
+func (c *Controller) submitHTTP(input, display string) {
+	trimmed := strings.TrimSpace(input)
+	if note, ok := MemoryQuickAddNote(trimmed); ok {
+		c.rememberProjectNote(note)
+		return
+	}
+	if note, ok := RememberCommandNote(trimmed); ok {
+		c.rememberProjectNote(note)
+		return
+	}
+	if c.applyGoalCommand(trimmed, display) {
+		return
+	}
+	if strings.HasPrefix(trimmed, "!") {
+		c.notice("shell commands are unavailable from this frontend")
+		return
+	}
+	c.submitCommandOrTurn(trimmed, input, display, true)
+}
+
+func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedRefsOnly bool) {
+	runRefTurn := c.runRefTurn
+	runRefTurnWithRefs := c.runRefTurnWithRefs
+	if scopedRefsOnly {
+		runRefTurn = c.runScopedRefTurn
+		runRefTurnWithRefs = c.runScopedRefTurnWithRefs
 	}
 	switch {
 	case trimmed == "/compact" || strings.HasPrefix(trimmed, "/compact "):
@@ -826,18 +863,18 @@ func (c *Controller) submit(input, display string) {
 	case strings.HasPrefix(trimmed, "//"):
 		// Double-slash — not a command. Common in code snippets (JS
 		// comments, file:// URLs). Run as a normal turn.
-		c.runRefTurn(input, display)
+		runRefTurn(input, display)
 	case strings.HasPrefix(trimmed, "/"):
 		if ref, ok := FileRefLine(trimmed); ok {
-			c.runRefTurn(ref, display)
+			runRefTurn(ref, display)
 			return
 		}
 		if ref, ok := SlashPathLineRef(trimmed, c.cpRoot); ok {
-			c.runRefTurnWithRefs(input, ref, display)
+			runRefTurnWithRefs(input, ref, display)
 			return
 		}
 		if SlashPathLikeLine(trimmed) {
-			c.runRefTurn(input, display)
+			runRefTurn(input, display)
 			return
 		}
 		// Read-only management verbs (/model /memory /skills /hooks /mcp) emit a
@@ -899,7 +936,7 @@ func (c *Controller) submit(input, display string) {
 		}
 		c.notice("unknown command: " + trimmed)
 	default:
-		c.runRefTurn(input, display)
+		runRefTurn(input, display)
 	}
 }
 
@@ -1053,12 +1090,24 @@ func (c *Controller) runRefTurn(input, display string) {
 	c.runRefTurnWithRefs(input, input, display)
 }
 
+func (c *Controller) runScopedRefTurn(input, display string) {
+	c.runScopedRefTurnWithRefs(input, input, display)
+}
+
 // runRefTurnWithRefs resolves references from refLine while preserving input as
 // the user's actual prompt text. This lets compiler diagnostics such as
 // "/path/File.kt:12: error" attach @/path/File.kt without rewriting the error.
 func (c *Controller) runRefTurnWithRefs(input, refLine, display string) {
+	c.runRefTurnWithResolver(input, refLine, display, c.ResolveRefs)
+}
+
+func (c *Controller) runScopedRefTurnWithRefs(input, refLine, display string) {
+	c.runRefTurnWithResolver(input, refLine, display, c.ResolveScopedRefs)
+}
+
+func (c *Controller) runRefTurnWithResolver(input, refLine, display string, resolve func(context.Context, string) (string, []string)) {
 	c.runGuarded(func(ctx context.Context) error {
-		block, errs := c.ResolveRefs(ctx, refLine)
+		block, errs := resolve(ctx, refLine)
 		for _, e := range errs {
 			c.notice(e)
 		}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -105,28 +105,44 @@ func isImageAttachmentRef(token string) bool {
 // detectRefs finds the @references in a line: MCP resources for connected
 // servers, and local paths that exist on disk.
 func (c *Controller) detectRefs(line string) []ref {
+	return c.detectRefsMode(line, false)
+}
+
+func (c *Controller) detectScopedRefs(line string) []ref {
+	return c.detectRefsMode(line, true)
+}
+
+func (c *Controller) detectRefsMode(line string, scopedOnly bool) []ref {
 	known := map[string]bool{}
 	if c.host != nil {
 		for _, n := range c.host.ServerNames() {
 			known[n] = true
 		}
 	}
-	exists := func(p string) bool {
-		if c.cpRoot != "" {
-			absPath, _, ok := resolveAbsRef(p, c.cpRoot)
-			if !ok {
-				return false
-			}
-			_, err := os.Stat(absPath)
-			return err == nil
-		}
-		_, err := os.Stat(p)
-		return err == nil
-	}
 
 	var refs []ref
 	for _, tok := range parseRefTokens(line) {
-		if r, ok := classifyRef(tok, known, exists); ok {
+		if i := strings.Index(tok, ":"); i > 0 && i+1 < len(tok) && known[tok[:i]] {
+			refs = append(refs, ref{kind: refResource, server: tok[:i], uri: tok[i+1:], raw: tok})
+			continue
+		}
+		if c.cpRoot != "" {
+			if rel, ok := workspaceRefPath(tok, c.cpRoot); ok {
+				kind := refFile
+				if isImageAttachmentRef(tok) || (isAttachmentRef(tok) && isImageAttachmentRef(rel)) {
+					kind = refImage
+				}
+				refs = append(refs, ref{kind: kind, path: rel, raw: tok})
+			}
+			continue
+		}
+		if scopedOnly {
+			continue
+		}
+		if r, ok := classifyRef(tok, known, func(p string) bool {
+			_, err := os.Stat(p)
+			return err == nil
+		}); ok {
 			refs = append(refs, r)
 		}
 	}
@@ -167,16 +183,14 @@ func resolveBareNames(refs []ref, workspaceRoot string) []ref {
 		if r.kind != refFile || strings.ContainsAny(r.raw, "/\\") {
 			continue
 		}
-		statPath := r.raw
 		if workspaceRoot != "" {
-			absPath, _, ok := resolveAbsRef(r.raw, workspaceRoot)
-			if !ok {
+			if _, ok := workspaceRefPath(r.raw, workspaceRoot); ok {
 				continue
 			}
-			statPath = absPath
-		}
-		if _, err := os.Stat(statPath); err == nil {
-			continue
+		} else {
+			if _, err := os.Stat(r.raw); err == nil {
+				continue
+			}
 		}
 		need[r.raw] = r
 		names = append(names, r.raw)
@@ -285,16 +299,49 @@ func pathTokenCandidates(token string) []string {
 }
 
 func fileRefExists(path, baseDir string) bool {
-	statPath := path
 	if baseDir != "" {
-		absPath, _, ok := resolveAbsRef(path, baseDir)
+		rel, _, absBase, ok := workspaceRel(path, baseDir)
 		if !ok {
 			return false
 		}
-		statPath = absPath
+		root, err := os.OpenRoot(absBase)
+		if err != nil {
+			return false
+		}
+		defer root.Close()
+		info, err := root.Stat(rel)
+		return err == nil && !info.IsDir()
 	}
-	info, err := os.Stat(statPath)
+	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+func workspaceRefPath(path, baseDir string) (string, bool) {
+	rel, _, absBase, ok := workspaceRel(path, baseDir)
+	if !ok {
+		return "", false
+	}
+	root, err := os.OpenRoot(absBase)
+	if err != nil {
+		return "", false
+	}
+	defer root.Close()
+	if _, err := root.Stat(rel); err != nil {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
+func workspaceRel(path, baseDir string) (rel, absPath, absBase string, ok bool) {
+	absPath, absBase, ok = resolveAbsRef(path, baseDir)
+	if !ok || absBase == "" {
+		return "", "", "", false
+	}
+	rel, err := filepath.Rel(absBase, absPath)
+	if err != nil || !filepath.IsLocal(rel) {
+		return "", "", "", false
+	}
+	return rel, absPath, absBase, true
 }
 
 // ResolveRefs resolves the @references in a line into a single tagged context
@@ -302,7 +349,17 @@ func fileRefExists(path, baseDir string) bool {
 // strings for any that failed. An empty block means no references resolved.
 // Safe to call off a frontend's event loop; honours ctx for the resource reads.
 func (c *Controller) ResolveRefs(ctx context.Context, line string) (block string, errs []string) {
-	refs := c.detectRefs(line)
+	return c.resolveRefs(ctx, line, false)
+}
+
+// ResolveScopedRefs is the HTTP/frontend variant: file references are honored
+// only when they can be resolved under the controller workspace root.
+func (c *Controller) ResolveScopedRefs(ctx context.Context, line string) (block string, errs []string) {
+	return c.resolveRefs(ctx, line, true)
+}
+
+func (c *Controller) resolveRefs(ctx context.Context, line string, scopedOnly bool) (block string, errs []string) {
+	refs := c.detectRefsMode(line, scopedOnly)
 	refs = resolveBareNames(refs, c.cpRoot)
 	var b strings.Builder
 	for _, r := range refs {
@@ -558,7 +615,7 @@ func resolveAbsRef(path, baseDir string) (absPath, absBase string, ok bool) {
 		cleaned = filepath.Join(absBase, cleaned)
 	}
 	rel, err := filepath.Rel(absBase, cleaned)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err != nil || !filepath.IsLocal(rel) {
 		return "", "", false
 	}
 	return cleaned, absBase, true

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -108,10 +108,6 @@ func (c *Controller) detectRefs(line string) []ref {
 	return c.detectRefsMode(line, false)
 }
 
-func (c *Controller) detectScopedRefs(line string) []ref {
-	return c.detectRefsMode(line, true)
-}
-
 func (c *Controller) detectRefsMode(line string, scopedOnly bool) []ref {
 	known := map[string]bool{}
 	if c.host != nil {
@@ -426,6 +422,7 @@ func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
 	if rerr != nil {
 		return "", false, rerr
 	}
+	displayPath := filepath.ToSlash(rel)
 
 	info, err := root.Stat(rel)
 	if err != nil {
@@ -462,10 +459,10 @@ func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
 	data := buf[:n]
 
 	if mime := imageMime(data, rel); mime != "" {
-		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — image bytes are not inlined. Use an available MCP image/OCR/vision tool with this path when visual understanding is needed.]", rel, mime, info.Size()), false, nil
+		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — image bytes are not inlined. Use an available MCP image/OCR/vision tool with this path when visual understanding is needed.]", displayPath, mime, info.Size()), false, nil
 	}
 	if bytes.IndexByte(data[:min(n, 8192)], 0) >= 0 {
-		return fmt.Sprintf("[binary file %s, %d bytes — not shown]", rel, info.Size()), false, nil
+		return fmt.Sprintf("[binary file %s, %d bytes — not shown]", displayPath, info.Size()), false, nil
 	}
 	if n > maxFileRefBytes {
 		return string(data[:maxFileRefBytes]) + fmt.Sprintf("\n…[truncated; file is %d bytes]…", info.Size()), false, nil

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -129,7 +129,7 @@ func (c *Controller) detectRefsMode(line string, scopedOnly bool) []ref {
 		if c.cpRoot != "" {
 			if rel, ok := workspaceRefPath(tok, c.cpRoot); ok {
 				kind := refFile
-				if isImageAttachmentRef(tok) || (isAttachmentRef(tok) && isImageAttachmentRef(rel)) {
+				if isAttachmentRef(rel) && isImageAttachmentRef(rel) {
 					kind = refImage
 				}
 				refs = append(refs, ref{kind: kind, path: rel, raw: tok})

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -491,6 +491,44 @@ func TestResolveRefsWithWorkspaceRootStoresRelativePath(t *testing.T) {
 	}
 }
 
+func TestWorkspaceImageRefsOnlyTreatAttachmentsAsImages(t *testing.T) {
+	workspace := t.TempDir()
+	diagram := filepath.Join(workspace, "docs", "diagram.png")
+	if err := os.MkdirAll(filepath.Dir(diagram), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(diagram, []byte("\x89PNG\r\n\x1a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	attachment := filepath.Join(workspace, ".reasonix", "attachments", "shot.png")
+	if err := os.MkdirAll(filepath.Dir(attachment), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(attachment, []byte("\x89PNG\r\n\x1a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Controller{cpRoot: workspace}
+	refs := c.detectRefs("see @" + diagram + " @" + attachment)
+	if len(refs) != 2 {
+		t.Fatalf("detectRefs = %+v, want two refs", refs)
+	}
+	if refs[0].kind != refFile || refs[0].path != "docs/diagram.png" {
+		t.Fatalf("workspace png ref = %+v, want file ref", refs[0])
+	}
+	if refs[1].kind != refImage || refs[1].path != ".reasonix/attachments/shot.png" {
+		t.Fatalf("attachment png ref = %+v, want image attachment ref", refs[1])
+	}
+
+	block, errs := c.ResolveRefs(context.Background(), "see @"+diagram)
+	if len(errs) != 0 {
+		t.Fatalf("ResolveRefs errors = %v", errs)
+	}
+	if !strings.Contains(block, `<file path="docs/diagram.png">`) || !strings.Contains(block, "image file docs/diagram.png") {
+		t.Fatalf("workspace png should resolve as image-file metadata:\n%s", block)
+	}
+}
+
 func TestReadFileRefPDFExtractionWithBaseDirUsesAbsPath(t *testing.T) {
 	base := t.TempDir()
 	pdfPath := filepath.Join(base, "docs", "report.pdf")

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -464,6 +464,33 @@ func TestDetectRefsUsesWorkspaceRootNotProcessCWD(t *testing.T) {
 	}
 }
 
+func TestResolveRefsWithWorkspaceRootStoresRelativePath(t *testing.T) {
+	workspace := t.TempDir()
+	absPath := filepath.Join(workspace, "docs", "note.txt")
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(absPath, []byte("workspace note"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Controller{cpRoot: workspace}
+	refs := c.detectRefs("see @" + absPath)
+	if len(refs) != 1 {
+		t.Fatalf("detectRefs absolute workspace path = %+v, want 1 ref", refs)
+	}
+	if refs[0].path != "docs/note.txt" {
+		t.Fatalf("ref path = %q, want workspace-relative path", refs[0].path)
+	}
+	block, errs := c.ResolveRefs(context.Background(), "see @"+absPath)
+	if len(errs) != 0 {
+		t.Fatalf("ResolveRefs errors = %v", errs)
+	}
+	if !strings.Contains(block, `<file path="docs/note.txt">`) || !strings.Contains(block, "workspace note") {
+		t.Fatalf("ResolveRefs block did not use relative workspace path:\n%s", block)
+	}
+}
+
 func TestReadFileRefPDFExtractionWithBaseDirUsesAbsPath(t *testing.T) {
 	base := t.TempDir()
 	pdfPath := filepath.Join(base, "docs", "report.pdf")

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -356,6 +356,10 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	trimmed := strings.TrimSpace(body.Input)
+	if strings.HasPrefix(trimmed, "!") {
+		http.Error(w, "shell commands are unavailable over HTTP", http.StatusForbidden)
+		return
+	}
 	// Intercept /model <ref> for runtime model switching (the controller's
 	// Submit path only lists models — switching is frontend-specific).
 	if strings.HasPrefix(trimmed, "/model ") {
@@ -381,7 +385,7 @@ func (s *Server) submit(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	s.ctl().Submit(body.Input)
+	s.ctl().SubmitHTTP(body.Input)
 	w.WriteHeader(http.StatusAccepted)
 }
 
@@ -709,16 +713,45 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing path", http.StatusBadRequest)
 		return
 	}
+	dir := s.ctl().SessionDir()
+	if dir == "" {
+		http.Error(w, "sessions disabled", http.StatusBadRequest)
+		return
+	}
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		http.Error(w, "invalid session dir", http.StatusBadRequest)
+		return
+	}
+	realDir, err := filepath.EvalSymlinks(absDir)
+	if err != nil {
+		http.Error(w, "invalid session dir", http.StatusBadRequest)
+		return
+	}
+	absPath, err := filepath.Abs(strings.TrimSpace(body.Path))
+	if err != nil || filepath.Ext(absPath) != ".jsonl" {
+		http.Error(w, "invalid session path", http.StatusBadRequest)
+		return
+	}
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		http.Error(w, "invalid session path", http.StatusBadRequest)
+		return
+	}
+	if realPath == realDir || !strings.HasPrefix(realPath, realDir+string(os.PathSeparator)) {
+		http.Error(w, "path outside session dir", http.StatusForbidden)
+		return
+	}
 	// Snapshot the current session before switching away.
 	if err := s.ctl().Snapshot(); err != nil {
 		slog.Warn("serve: snapshot before resume", "err", err)
 	}
-	loaded, err := agent.LoadSession(body.Path)
+	loaded, err := agent.LoadSession(realPath)
 	if err != nil {
 		http.Error(w, "load session: "+err.Error(), http.StatusBadRequest)
 		return
 	}
-	s.ctl().Resume(loaded, body.Path)
+	s.ctl().Resume(loaded, realPath)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -114,6 +114,28 @@ func TestServeEndpoints(t *testing.T) {
 	}
 }
 
+func TestServeSubmitRejectsShellShortcut(t *testing.T) {
+	bc := NewBroadcaster()
+	got := make(chan string, 1)
+	ctrl := control.New(control.Options{Runner: fakeRunner{got: got}, Sink: bc})
+	srv := httptest.NewServer(New(ctrl, bc).Handler())
+	defer srv.Close()
+
+	resp, err := http.Post(srv.URL+"/submit", "application/json", strings.NewReader(`{"input":"!echo nope"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("shell submit status = %d, want 403", resp.StatusCode)
+	}
+	select {
+	case in := <-got:
+		t.Fatalf("runner should not run shell submit, got %q", in)
+	default:
+	}
+}
+
 func TestHistoryMessagesPreserveToolDetails(t *testing.T) {
 	got := historyMessages([]provider.Message{
 		{Role: provider.RoleUser, Content: "run command"},
@@ -309,6 +331,50 @@ func TestServeIndexPagePassesLanguagePreferenceToClient(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "const __LANG_PREF = 'en';") {
 		t.Fatalf("pinned desktop language was not passed through:\n%s", string(body))
+	}
+}
+
+func TestResumeRequiresSessionPathInsideSessionDir(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	inside := filepath.Join(dir, "inside.jsonl")
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "outside.jsonl")
+	for _, path := range []string{active, inside, outside} {
+		if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	srv := httptest.NewServer(New(ctrl, bc).Handler())
+	defer srv.Close()
+
+	post := func(path string) int {
+		body, err := json.Marshal(map[string]string{"path": path})
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+	if got := post(outside); got != http.StatusForbidden {
+		t.Fatalf("outside resume status = %d, want 403", got)
+	}
+	if got := post(inside); got != http.StatusNoContent {
+		t.Fatalf("inside resume status = %d, want 204", got)
+	}
+	want, err := filepath.EvalSymlinks(inside)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := filepath.Clean(ctrl.SessionPath()); got != filepath.Clean(want) {
+		t.Fatalf("session path = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Harden archive extraction against traversal and unsafe symlink targets.
- Reject HTTP shell shortcuts and constrain session resume paths to the session directory.
- Scope frontend file references to workspace-relative paths and tighten checkpoint path containment.

## Verification
- `go test ./internal/codegraph ./internal/control ./internal/serve ./internal/checkpoint ./internal/agent ./internal/fileutil`
- CodeQL Go code-scanning suite: 0 results
