### PR TITLE
feat(desktop): close tabs with middle click

### DIFF
--- a/desktop/frontend/src/components/TabBar.tsx
+++ b/desktop/frontend/src/components/TabBar.tsx
@@ -137,6 +137,14 @@ export function TabBar({ tabs, activeTabId, onTabChange, onTabClose, onTabsClose
     onTabChange(tabId);
   };
 
+  const handleTabAuxClick = (event: ReactMouseEvent<HTMLButtonElement>, tabId: string) => {
+    // DOM MouseEvent.button: 1 is the auxiliary button, normally the middle/wheel button.
+    if (event.button !== 1) return;
+    event.preventDefault();
+    event.stopPropagation();
+    handleClose(tabId);
+  };
+
   const openTabMenu = (event: ReactMouseEvent<HTMLButtonElement> | ReactKeyboardEvent<HTMLButtonElement>, tabId: string) => {
     event.preventDefault();
     event.stopPropagation();
@@ -224,6 +232,11 @@ export function TabBar({ tabs, activeTabId, onTabChange, onTabClose, onTabsClose
               aria-label={annotatedTitle}
               style={projectAccentStyle(tab.projectColor)}
               onClick={() => handleTabClick(tab.id)}
+              onAuxClick={(event) => handleTabAuxClick(event, tab.id)}
+              onMouseDown={(event) => {
+                // Prevent the browser/webview middle-click auto-scroll before auxclick fires.
+                if (event.button === 1) event.preventDefault();
+              }}
               onContextMenu={(event) => openTabMenu(event, tab.id)}
               onKeyDown={(event) => {
                 if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {


### PR DESCRIPTION
## Summary / 摘要

为桌面模式顶部标签页新增鼠标中键关闭功能：用户现在可以像用网页一样，用中键点击顶部的标签直接关闭对应会话。

Adds middle-click close support for the desktop top tab bar: users can now close a session tab by clicking it with the mouse middle/wheel button, matching common browser tab behavior.


## What was changed / 改动清单

* TabBar（前端）：新增 `onAuxClick` ，调用 `handleTabAuxClick` 仅在 `event.button == 1`  时进行关闭标签页操作
  Add `onAuxClick`, call `handleTabAuxClick` to close tabs only when `event. button == 1`.
* TabBar（前端）：在 `onMouseDown` 阶段拦截中键操作，避免和后面的 onAuxClick 冲突
  Prevent the default middle-button behavior during `onMouseDown`
* 注释：补充 `button === 1` 表示辅助键/常见中键
  Add comments explaining that `button === 1` is the auxiliary/middle button 

## Tests / 测试

```shell
cd desktop/frontend
npm run typecheck
npm run test:typecheck
npm run test
git diff --check -- desktop/frontend/src/components/TabBar.tsx
```

⛄

Fixes https://github.com/esengine/DeepSeek-Reasonix/issues/4279