### PR TITLE
perf(desktop): wrap Transcript in React.memo to prevent IME input lag

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -144,7 +144,7 @@ function buildTurnGroups(items: Item[], questions: QuestionAnchor[]): TurnGroup[
 
 // ── Transcript component ──────────────────────────────────────────────────────
 
-export function Transcript({
+export const Transcript = memo(function Transcript({
   items,
   live,
   footerHeight = 0,
@@ -597,7 +597,7 @@ export function Transcript({
       </LiveStreamContext.Provider>
     </div>
   );
-}
+});
 
 // ── WarmZone sub-component (React.memo for streaming isolation) ────────────
 // Receives structural props only; reads streaming state (items, live) via refs


### PR DESCRIPTION
## Problem

When renaming a session topic or performing any action that triggers an App-level `setState` (e.g. typing in the rename input), the Transcript component re-renders even though none of its props changed. This causes all ~100+ child `useGSAPCollapse` `useLayoutEffect` hooks to execute synchronously, blocking the main thread and causing visible IME input lag.

## Root Cause

`Transcript` was exported as a plain function component without `React.memo`. Since Transcript is purely prop-driven (no internal context dependencies), it should not re-render when parent state changes that don't affect its props.

## Fix

Wrap Transcript in `React.memo`:

```diff
-export function Transcript({
+export const Transcript = memo(function Transcript({
   ...
-}
+});
```

`memo` was already imported at the top of the file — zero new imports needed.

## Change

- 1 file, 2 lines changed