### PR TITLE
fix(codegraph): shorten shared daemon idle cleanup safely / 安全缩短共享 daemon 空闲清理

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -285,7 +285,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	//
 	// CodeGraph is fixed to background startup. Legacy tier values are ignored so
 	// enabling it never blocks chat startup.
-	var codegraphRoot string
 	if cfg.Codegraph.Enabled && !tokenEconomy {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
@@ -293,12 +292,14 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 				Text: "codegraph: project root is a filesystem root — skipped to avoid indexing the whole volume"})
 		case ok:
-			codegraphRoot = root
 			spec := plugin.Spec{
-				Name:              "codegraph",
-				StripRawPrefix:    "codegraph_",
-				Command:           bin,
-				Args:              []string{"serve", "--mcp"},
+				Name:           "codegraph",
+				StripRawPrefix: "codegraph_",
+				Command:        bin,
+				Args:           []string{"serve", "--mcp"},
+				Env: map[string]string{
+					codegraph.DaemonIdleTimeoutEnv: codegraph.ReasonixDaemonIdleTimeoutMS,
+				},
 				Dir:               root,
 				ReadOnlyToolNames: codegraph.ReadOnlyToolNames(),
 				// The daemon walks and indexes the whole tree; below-normal
@@ -435,13 +436,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 		prev := cleanup
 		cleanup = func() { prev(); lspMgr.Close() }
-	}
-
-	// CodeGraph daemon detaches via setsid and escapes the process-group kill in
-	// KillTree; hunt it down explicitly via the PID it logs on startup.
-	if codegraphRoot != "" {
-		prev := cleanup
-		cleanup = func() { prev(); codegraph.KillDaemon(codegraphRoot) }
 	}
 
 	maxSteps := cfg.Agent.MaxSteps

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -285,6 +285,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	//
 	// CodeGraph is fixed to background startup. Legacy tier values are ignored so
 	// enabling it never blocks chat startup.
+	var codegraphRoot string
 	if cfg.Codegraph.Enabled && !tokenEconomy {
 		bin, ok := codegraph.Resolve(cfg.Codegraph.Path)
 		switch {
@@ -292,6 +293,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 				Text: "codegraph: project root is a filesystem root — skipped to avoid indexing the whole volume"})
 		case ok:
+			codegraphRoot = root
 			spec := plugin.Spec{
 				Name:              "codegraph",
 				StripRawPrefix:    "codegraph_",
@@ -433,6 +435,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 		prev := cleanup
 		cleanup = func() { prev(); lspMgr.Close() }
+	}
+
+	// CodeGraph daemon detaches via setsid and escapes the process-group kill in
+	// KillTree; hunt it down explicitly via the PID it logs on startup.
+	if codegraphRoot != "" {
+		prev := cleanup
+		cleanup = func() { prev(); codegraph.KillDaemon(codegraphRoot) }
 	}
 
 	maxSteps := cfg.Agent.MaxSteps

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -22,6 +22,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/agent/testutil"
 	"reasonix/internal/builtinmcp"
+	"reasonix/internal/codegraph"
 	"reasonix/internal/config"
 	"reasonix/internal/event"
 	"reasonix/internal/memory"
@@ -1888,6 +1889,57 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 }
 
+func TestBuildCodegraphSetsShortDaemonIdleTimeout(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	launcher := writeCodegraphHelper(t, dir)
+	envOut := filepath.Join(dir, "codegraph-idle-env")
+	t.Setenv("REASONIX_CODEGRAPH_HELPER_ENV_OUT", envOut)
+
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = true
+path = %q
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`, launcher))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	ctrl, err := Build(ctx, Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	deadline := time.Now().Add(5 * time.Second)
+	var got []byte
+	for {
+		got, err = os.ReadFile(envOut)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("codegraph helper never recorded idle timeout env: %v", err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if string(got) != codegraph.ReasonixDaemonIdleTimeoutMS {
+		t.Fatalf("%s = %q; want %q", codegraph.DaemonIdleTimeoutEnv, got, codegraph.ReasonixDaemonIdleTimeoutMS)
+	}
+}
+
 func TestBuildWarmCodegraphIgnoresLegacyEagerTier(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake launcher is a POSIX-sh script")
@@ -2135,6 +2187,11 @@ func main() {
 	if len(os.Args) >= 3 && os.Args[1] == "init" {
 		_ = os.MkdirAll(filepath.Join(os.Args[2], ".codegraph"), 0o755)
 		return
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		if out := os.Getenv("REASONIX_CODEGRAPH_HELPER_ENV_OUT"); out != "" {
+			_ = os.WriteFile(out, []byte(os.Getenv("CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS")), 0o644)
+		}
 	}
 
 	in := bufio.NewReader(os.Stdin)

--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -16,12 +16,13 @@ package codegraph
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -29,6 +30,22 @@ import (
 )
 
 const initTimeout = 30 * time.Second
+const daemonProbeTimeout = 300 * time.Millisecond
+
+// DaemonIdleTimeoutEnv is CodeGraph's own root-scoped daemon idle timeout knob.
+const DaemonIdleTimeoutEnv = "CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS"
+
+// ReasonixDaemonIdleTimeoutMS keeps Reasonix-launched daemons short-lived after
+// the last client disconnects while still preserving CodeGraph's shared-client
+// refcount semantics.
+const ReasonixDaemonIdleTimeoutMS = "1000"
+
+type daemonInfo struct {
+	PID        int    `json:"pid"`
+	Version    string `json:"version"`
+	SocketPath string `json:"socketPath"`
+	StartedAt  int64  `json:"startedAt"`
+}
 
 // SteerText is injected into the system prompt when CodeGraph tools are
 // available, so the model knows to prefer them for symbol-level questions. The
@@ -210,59 +227,80 @@ func isExec(p string) bool {
 	return fi.Mode()&0o111 != 0
 }
 
-// DaemonPID returns the PID of the most recently started CodeGraph daemon for
-// root, parsed from the daemon log. It returns 0, false when the log doesn't
-// exist, is empty, or contains no parsable PID line.
-//
-// The daemon writes lines like:
-//
-//	[CodeGraph daemon] Listening on /path/.codegraph/daemon.sock (pid 12345, v0.9.7). Idle timeout 300000ms.
-//
-// We scan for the last such line to handle log rotation/restart.
+// DaemonPID returns the PID recorded in CodeGraph's structured daemon lockfile.
+// It returns 0, false when the lockfile doesn't exist or does not contain the
+// full pid/version/socket record written by CodeGraph's daemon.
 func DaemonPID(root string) (int, bool) {
-	logPath := filepath.Join(root, ".codegraph", "daemon.log")
-	f, err := os.Open(logPath)
-	if err != nil {
+	info, ok := readDaemonInfo(root)
+	if !ok {
 		return 0, false
 	}
-	defer f.Close()
-
-	var lastPID int
-	sc := bufio.NewScanner(f)
-	for sc.Scan() {
-		line := sc.Text()
-		if !strings.Contains(line, "Listening on") {
-			continue
-		}
-		idx := strings.Index(line, "(pid ")
-		if idx == -1 {
-			continue
-		}
-		rest := line[idx+5:] // after "(pid "
-		end := strings.IndexByte(rest, ',')
-		if end == -1 {
-			continue
-		}
-		pid, err := strconv.Atoi(rest[:end])
-		if err != nil || pid <= 0 {
-			continue
-		}
-		lastPID = pid
-	}
-	return lastPID, lastPID > 0
+	return info.PID, true
 }
 
-// KillDaemon sends SIGKILL (or the platform equivalent) to the most recently
-// started CodeGraph daemon for root. It is a no-op when no daemon PID can be
-// found or the daemon has already exited.
+func readDaemonInfo(root string) (daemonInfo, bool) {
+	pidPath := filepath.Join(root, ".codegraph", "daemon.pid")
+	raw, err := os.ReadFile(pidPath)
+	if err != nil {
+		return daemonInfo{}, false
+	}
+	var info daemonInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return daemonInfo{}, false
+	}
+	if info.PID <= 0 || info.Version == "" || info.SocketPath == "" || info.StartedAt <= 0 {
+		return daemonInfo{}, false
+	}
+	return info, true
+}
+
+// KillDaemon terminates the CodeGraph daemon for root after verifying that the
+// recorded PID still answers on the daemon socket as the same CodeGraph process.
+// This is intentionally for explicit cleanup paths such as tests/diagnostics:
+// CodeGraph daemons are root-scoped and may be shared by other MCP clients, so a
+// normal Reasonix controller close must only close its proxy connection and let
+// CodeGraph's own refcount/idle timer own daemon lifetime.
 func KillDaemon(root string) {
-	pid, ok := DaemonPID(root)
+	info, ok := readDaemonInfo(root)
 	if !ok {
 		return
 	}
-	p, err := os.FindProcess(pid)
+	if !daemonIdentityMatches(info) {
+		return
+	}
+	p, err := os.FindProcess(info.PID)
 	if err != nil {
 		return
 	}
 	_ = p.Kill()
+}
+
+func daemonIdentityMatches(info daemonInfo) bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	conn, err := net.DialTimeout("unix", info.SocketPath, daemonProbeTimeout)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(daemonProbeTimeout))
+
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	var hello struct {
+		Codegraph  string `json:"codegraph"`
+		PID        int    `json:"pid"`
+		SocketPath string `json:"socketPath"`
+		Protocol   int    `json:"protocol"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &hello); err != nil {
+		return false
+	}
+	return hello.Codegraph != "" &&
+		hello.PID == info.PID &&
+		hello.SocketPath == info.SocketPath &&
+		hello.Protocol == 1
 }

--- a/internal/codegraph/codegraph.go
+++ b/internal/codegraph/codegraph.go
@@ -14,12 +14,14 @@
 package codegraph
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -206,4 +208,61 @@ func isExec(p string) bool {
 		return true
 	}
 	return fi.Mode()&0o111 != 0
+}
+
+// DaemonPID returns the PID of the most recently started CodeGraph daemon for
+// root, parsed from the daemon log. It returns 0, false when the log doesn't
+// exist, is empty, or contains no parsable PID line.
+//
+// The daemon writes lines like:
+//
+//	[CodeGraph daemon] Listening on /path/.codegraph/daemon.sock (pid 12345, v0.9.7). Idle timeout 300000ms.
+//
+// We scan for the last such line to handle log rotation/restart.
+func DaemonPID(root string) (int, bool) {
+	logPath := filepath.Join(root, ".codegraph", "daemon.log")
+	f, err := os.Open(logPath)
+	if err != nil {
+		return 0, false
+	}
+	defer f.Close()
+
+	var lastPID int
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if !strings.Contains(line, "Listening on") {
+			continue
+		}
+		idx := strings.Index(line, "(pid ")
+		if idx == -1 {
+			continue
+		}
+		rest := line[idx+5:] // after "(pid "
+		end := strings.IndexByte(rest, ',')
+		if end == -1 {
+			continue
+		}
+		pid, err := strconv.Atoi(rest[:end])
+		if err != nil || pid <= 0 {
+			continue
+		}
+		lastPID = pid
+	}
+	return lastPID, lastPID > 0
+}
+
+// KillDaemon sends SIGKILL (or the platform equivalent) to the most recently
+// started CodeGraph daemon for root. It is a no-op when no daemon PID can be
+// found or the daemon has already exited.
+func KillDaemon(root string) {
+	pid, ok := DaemonPID(root)
+	if !ok {
+		return
+	}
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return
+	}
+	_ = p.Kill()
 }

--- a/internal/codegraph/codegraph_test.go
+++ b/internal/codegraph/codegraph_test.go
@@ -92,6 +92,115 @@ func TestEnsureInitPropagatesFailure(t *testing.T) {
 	}
 }
 
+func TestDaemonPIDNoLog(t *testing.T) {
+	root := t.TempDir()
+	pid, ok := DaemonPID(root)
+	if ok || pid != 0 {
+		t.Fatalf("DaemonPID with no log = %d, %v; want 0, false", pid, ok)
+	}
+}
+
+func TestDaemonPIDEmptyLog(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pid, ok := DaemonPID(root)
+	if ok || pid != 0 {
+		t.Fatalf("DaemonPID with empty log = %d, %v; want 0, false", pid, ok)
+	}
+}
+
+func TestDaemonPIDNoListeningLine(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	log := "[CodeGraph MCP] File watcher active\n[CodeGraph MCP] Caught up 7 file(s)\n"
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pid, ok := DaemonPID(root)
+	if ok || pid != 0 {
+		t.Fatalf("DaemonPID with no Listening line = %d, %v; want 0, false", pid, ok)
+	}
+}
+
+func TestDaemonPIDSingleLine(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 12345, v0.9.7). Idle timeout 300000ms.\n"
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pid, ok := DaemonPID(root)
+	if !ok || pid != 12345 {
+		t.Fatalf("DaemonPID = %d, %v; want 12345, true", pid, ok)
+	}
+}
+
+func TestDaemonPIDReturnsLast(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 100, v0.9.7). Idle timeout 300000ms.\n"
+	log += "[CodeGraph daemon] Shutting down (idle timeout; clients=0).\n"
+	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 99999, v0.9.9). Idle timeout 300000ms.\n"
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pid, ok := DaemonPID(root)
+	if !ok || pid != 99999 {
+		t.Fatalf("DaemonPID = %d, %v; want 99999 (last), true", pid, ok)
+	}
+}
+
+func TestDaemonPIDSkipsMalformed(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Lines missing "(pid ", with non-numeric PID, and with zero PID should all be skipped.
+	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (v0.9.7). Idle timeout 300000ms.\n"
+	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid abc, v0.9.7). Idle timeout 300000ms.\n"
+	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 0, v0.9.7). Idle timeout 300000ms.\n"
+	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid -5, v0.9.7). Idle timeout 300000ms.\n"
+	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 42, v0.9.7). Idle timeout 300000ms.\n"
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pid, ok := DaemonPID(root)
+	if !ok || pid != 42 {
+		t.Fatalf("DaemonPID = %d, %v; want 42 (only valid PID), true", pid, ok)
+	}
+}
+
+func TestKillDaemonNoLog(t *testing.T) {
+	// Must not panic or error when there is no .codegraph directory at all.
+	root := t.TempDir()
+	KillDaemon(root) // no-op
+}
+
+func TestKillDaemonBadPID(t *testing.T) {
+	// PID that doesn't correspond to a running process: KillDaemon must not error.
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Use a PID that almost certainly doesn't exist (max int32).
+	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 2147483647, v0.9.7). Idle timeout 300000ms.\n"
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	KillDaemon(root) // best-effort; must not panic
+}
+
 func TestIndexableRootRejectsFilesystemRoots(t *testing.T) {
 	if got := IndexableRoot(t.TempDir()); !got {
 		t.Fatal("a real project dir must be indexable")

--- a/internal/codegraph/codegraph_test.go
+++ b/internal/codegraph/codegraph_test.go
@@ -2,10 +2,15 @@ package codegraph
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 )
 
 // writeExec writes an executable file at path with the given content and +x.
@@ -92,113 +97,200 @@ func TestEnsureInitPropagatesFailure(t *testing.T) {
 	}
 }
 
-func TestDaemonPIDNoLog(t *testing.T) {
+func TestDaemonPIDNoLock(t *testing.T) {
 	root := t.TempDir()
 	pid, ok := DaemonPID(root)
 	if ok || pid != 0 {
-		t.Fatalf("DaemonPID with no log = %d, %v; want 0, false", pid, ok)
+		t.Fatalf("DaemonPID with no lock = %d, %v; want 0, false", pid, ok)
 	}
 }
 
-func TestDaemonPIDEmptyLog(t *testing.T) {
+func TestDaemonPIDEmptyLock(t *testing.T) {
 	root := t.TempDir()
 	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(""), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.pid"), []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	pid, ok := DaemonPID(root)
 	if ok || pid != 0 {
-		t.Fatalf("DaemonPID with empty log = %d, %v; want 0, false", pid, ok)
+		t.Fatalf("DaemonPID with empty lock = %d, %v; want 0, false", pid, ok)
 	}
 }
 
-func TestDaemonPIDNoListeningLine(t *testing.T) {
+func TestDaemonPIDRejectsLegacyPlainPID(t *testing.T) {
 	root := t.TempDir()
 	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	log := "[CodeGraph MCP] File watcher active\n[CodeGraph MCP] Caught up 7 file(s)\n"
-	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.pid"), []byte("12345\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	pid, ok := DaemonPID(root)
 	if ok || pid != 0 {
-		t.Fatalf("DaemonPID with no Listening line = %d, %v; want 0, false", pid, ok)
+		t.Fatalf("DaemonPID with legacy plain PID = %d, %v; want 0, false", pid, ok)
 	}
 }
 
-func TestDaemonPIDSingleLine(t *testing.T) {
+func TestDaemonPIDStructuredLock(t *testing.T) {
 	root := t.TempDir()
-	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 12345, v0.9.7). Idle timeout 300000ms.\n"
-	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeDaemonInfo(t, root, daemonInfo{
+		PID:        12345,
+		Version:    "0.9.7",
+		SocketPath: filepath.Join(root, ".codegraph", "daemon.sock"),
+		StartedAt:  123456789,
+	})
 	pid, ok := DaemonPID(root)
 	if !ok || pid != 12345 {
 		t.Fatalf("DaemonPID = %d, %v; want 12345, true", pid, ok)
 	}
 }
 
-func TestDaemonPIDReturnsLast(t *testing.T) {
+func TestDaemonPIDRejectsPartialLock(t *testing.T) {
 	root := t.TempDir()
 	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 100, v0.9.7). Idle timeout 300000ms.\n"
-	log += "[CodeGraph daemon] Shutting down (idle timeout; clients=0).\n"
-	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 99999, v0.9.9). Idle timeout 300000ms.\n"
-	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.pid"), []byte(`{"pid":42}`), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	pid, ok := DaemonPID(root)
-	if !ok || pid != 99999 {
-		t.Fatalf("DaemonPID = %d, %v; want 99999 (last), true", pid, ok)
+	if ok || pid != 0 {
+		t.Fatalf("DaemonPID with partial lock = %d, %v; want 0, false", pid, ok)
 	}
 }
 
-func TestDaemonPIDSkipsMalformed(t *testing.T) {
-	root := t.TempDir()
-	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	// Lines missing "(pid ", with non-numeric PID, and with zero PID should all be skipped.
-	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (v0.9.7). Idle timeout 300000ms.\n"
-	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid abc, v0.9.7). Idle timeout 300000ms.\n"
-	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 0, v0.9.7). Idle timeout 300000ms.\n"
-	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid -5, v0.9.7). Idle timeout 300000ms.\n"
-	log += "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 42, v0.9.7). Idle timeout 300000ms.\n"
-	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	pid, ok := DaemonPID(root)
-	if !ok || pid != 42 {
-		t.Fatalf("DaemonPID = %d, %v; want 42 (only valid PID), true", pid, ok)
-	}
-}
-
-func TestKillDaemonNoLog(t *testing.T) {
+func TestKillDaemonNoLock(t *testing.T) {
 	// Must not panic or error when there is no .codegraph directory at all.
 	root := t.TempDir()
 	KillDaemon(root) // no-op
 }
 
-func TestKillDaemonBadPID(t *testing.T) {
-	// PID that doesn't correspond to a running process: KillDaemon must not error.
+func TestKillDaemonRequiresMatchingSocketHello(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix process/signal semantics only")
+	}
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep command not available")
+	}
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	t.Cleanup(func() {
+		if processExists(cmd.Process.Pid) {
+			_ = cmd.Process.Kill()
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+	})
+
 	root := t.TempDir()
-	if err := os.Mkdir(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+	writeDaemonInfo(t, root, daemonInfo{
+		PID:        cmd.Process.Pid,
+		Version:    "0.9.7",
+		SocketPath: filepath.Join(root, ".codegraph", "missing.sock"),
+		StartedAt:  123456789,
+	})
+
+	KillDaemon(root)
+	if !processExists(cmd.Process.Pid) {
+		t.Fatal("KillDaemon killed a process without a matching daemon socket hello")
+	}
+}
+
+func TestKillDaemonKillsMatchingSocketDaemon(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix socket/process semantics only")
+	}
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep command not available")
+	}
+	root := shortTempDir(t)
+	cgDir := filepath.Join(root, ".codegraph")
+	if err := os.Mkdir(cgDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// Use a PID that almost certainly doesn't exist (max int32).
-	log := "[CodeGraph daemon] Listening on /tmp/.codegraph/daemon.sock (pid 2147483647, v0.9.7). Idle timeout 300000ms.\n"
-	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.log"), []byte(log), 0o644); err != nil {
+	socketPath := filepath.Join(cgDir, "daemon.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
 		t.Fatal(err)
 	}
-	KillDaemon(root) // best-effort; must not panic
+	defer ln.Close()
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	t.Cleanup(func() {
+		if processExists(cmd.Process.Pid) {
+			_ = cmd.Process.Kill()
+		}
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+	})
+	writeDaemonInfo(t, root, daemonInfo{
+		PID:        cmd.Process.Pid,
+		Version:    "0.9.7",
+		SocketPath: socketPath,
+		StartedAt:  123456789,
+	})
+
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		fmt.Fprintf(conn, `{"codegraph":"0.9.7","pid":%d,"socketPath":%q,"protocol":1}`+"\n", cmd.Process.Pid, socketPath)
+		close(accepted)
+	}()
+
+	KillDaemon(root)
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("KillDaemon did not probe the daemon socket")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("KillDaemon did not kill the matching daemon process")
+	}
+}
+
+func shortTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "reasonix-codegraph-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func writeDaemonInfo(t *testing.T, root string, info daemonInfo) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, ".codegraph"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".codegraph", "daemon.pid"), append(b, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestIndexableRootRejectsFilesystemRoots(t *testing.T) {

--- a/internal/codegraph/e2e_test.go
+++ b/internal/codegraph/e2e_test.go
@@ -118,8 +118,8 @@ func TestE2ECodegraphMCP(t *testing.T) {
 // TestE2ECodegraphKillDaemon verifies that KillDaemon can reap a real CodeGraph
 // daemon that escapes the process-group kill in KillTree. The daemon does
 // setsid(2) to detach into its own process group, so the negative-PID SIGKILL
-// that KillTree sends to the launcher's group misses it. KillDaemon reads the
-// daemon's PID from its log and sends a direct SIGKILL.
+// that KillTree sends to the launcher's group misses it. KillDaemon verifies the
+// daemon lockfile against the socket hello before sending a direct SIGKILL.
 //
 // Gated on REASONIX_CODEGRAPH_E2E=1 like the other E2E test; skipped on Windows
 // because the Job Object (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) already captures
@@ -155,7 +155,7 @@ func TestE2ECodegraphKillDaemon(t *testing.T) {
 	}
 
 	// Start the codegraph server — this launches the MCP bridge (foreground) and
-	// a daemon (background). The daemon logs its PID on startup.
+	// a daemon (background). The daemon records its PID in its lockfile on startup.
 	host, _, err := plugin.StartAll(ctx, []plugin.Spec{{
 		Name:              "codegraph",
 		Command:           bin,
@@ -167,7 +167,7 @@ func TestE2ECodegraphKillDaemon(t *testing.T) {
 		t.Fatalf("StartAll: %v", err)
 	}
 
-	// Give the daemon a moment to start and write its PID to the log.
+	// Give the daemon a moment to start and write its PID lockfile.
 	var daemonPID int
 	var daemonOK bool
 	deadline := time.Now().Add(10 * time.Second)
@@ -179,7 +179,7 @@ func TestE2ECodegraphKillDaemon(t *testing.T) {
 	}
 	if !daemonOK {
 		host.Close()
-		t.Fatal("daemon PID never appeared in .codegraph/daemon.log")
+		t.Fatal("daemon PID never appeared in .codegraph/daemon.pid")
 	}
 	t.Logf("daemon PID: %d", daemonPID)
 

--- a/internal/codegraph/e2e_test.go
+++ b/internal/codegraph/e2e_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -68,7 +70,11 @@ func TestE2ECodegraphMCP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("StartAll: %v", err)
 	}
-	defer host.Close()
+	defer func() {
+		host.Close()
+		// Reap the daemon that escapes process-group kill via setsid.
+		KillDaemon(root)
+	}()
 	if len(tools) == 0 {
 		t.Fatal("codegraph exposed no MCP tools")
 	}
@@ -107,4 +113,121 @@ func TestE2ECodegraphMCP(t *testing.T) {
 		time.Sleep(300 * time.Millisecond)
 	}
 	t.Logf("e2e ok — %d tools (%v); search surfaced Greet", len(tools), names)
+}
+
+// TestE2ECodegraphKillDaemon verifies that KillDaemon can reap a real CodeGraph
+// daemon that escapes the process-group kill in KillTree. The daemon does
+// setsid(2) to detach into its own process group, so the negative-PID SIGKILL
+// that KillTree sends to the launcher's group misses it. KillDaemon reads the
+// daemon's PID from its log and sends a direct SIGKILL.
+//
+// Gated on REASONIX_CODEGRAPH_E2E=1 like the other E2E test; skipped on Windows
+// because the Job Object (JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE) already captures
+// every descendant regardless of reparenting.
+func TestE2ECodegraphKillDaemon(t *testing.T) {
+	if os.Getenv("REASONIX_CODEGRAPH_E2E") == "" {
+		t.Skip("set REASONIX_CODEGRAPH_E2E=1 to run the CodeGraph E2E daemon-kill test")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("daemon escape is Unix-only; Windows Job Objects capture all descendants")
+	}
+
+	bin := os.Getenv("REASONIX_CODEGRAPH_BIN")
+	if bin == "" {
+		var ok bool
+		if bin, ok = Resolve(""); !ok {
+			t.Fatal("REASONIX_CODEGRAPH_E2E is set but no codegraph binary found — set REASONIX_CODEGRAPH_BIN to the launcher path")
+		}
+	}
+	t.Logf("codegraph binary: %s", bin)
+
+	root := t.TempDir()
+	src := "package demo\n\nfunc Greet(name string) string { return \"hi \" + name }\n"
+	if err := os.WriteFile(filepath.Join(root, "greet.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if err := EnsureInit(ctx, bin, root); err != nil {
+		t.Fatalf("EnsureInit: %v", err)
+	}
+
+	// Start the codegraph server — this launches the MCP bridge (foreground) and
+	// a daemon (background). The daemon logs its PID on startup.
+	host, _, err := plugin.StartAll(ctx, []plugin.Spec{{
+		Name:              "codegraph",
+		Command:           bin,
+		Args:              []string{"serve", "--mcp"},
+		Dir:               root,
+		ReadOnlyToolNames: ReadOnlyToolNames(),
+	}})
+	if err != nil {
+		t.Fatalf("StartAll: %v", err)
+	}
+
+	// Give the daemon a moment to start and write its PID to the log.
+	var daemonPID int
+	var daemonOK bool
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if daemonPID, daemonOK = DaemonPID(root); daemonOK {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !daemonOK {
+		host.Close()
+		t.Fatal("daemon PID never appeared in .codegraph/daemon.log")
+	}
+	t.Logf("daemon PID: %d", daemonPID)
+
+	// Verify the daemon is alive before we close.
+	if !processExists(daemonPID) {
+		host.Close()
+		t.Fatalf("daemon PID %d not alive before Close", daemonPID)
+	}
+	t.Logf("daemon %d alive before host.Close()", daemonPID)
+
+	// host.Close kills the launcher via KillTree (process-group SIGKILL), but the
+	// daemon has detached into its own process group via setsid and escapes.
+	host.Close()
+
+	// Give the kernel a moment to deliver the SIGKILL and reap the launcher.
+	time.Sleep(300 * time.Millisecond)
+
+	if processExists(daemonPID) {
+		t.Logf("daemon %d survived process-group kill (as expected — it escaped via setsid)", daemonPID)
+
+		// Now explicitly kill the daemon via its logged PID.
+		KillDaemon(root)
+
+		// Poll for exit with a short deadline.
+		deadline := time.Now().Add(5 * time.Second)
+		for processExists(daemonPID) {
+			if time.Now().After(deadline) {
+				t.Fatalf("daemon %d still alive after KillDaemon", daemonPID)
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		t.Logf("daemon %d killed by KillDaemon", daemonPID)
+	} else {
+		// The daemon didn't escape — process-group kill worked. This can happen
+		// if codegraph is built without daemonization or if the OS doesn't
+		// support setsid semantics. KillDaemon is still a safe no-op here.
+		t.Logf("daemon %d was already dead after host.Close() (process-group kill succeeded)", daemonPID)
+		KillDaemon(root) // no-op — best-effort is safe
+	}
+}
+
+// processExists reports whether a process with the given PID is currently
+// running. It sends signal 0 (null signal) on Unix; on Windows it always
+// returns false (but the daemon-kill test skips Windows anyway).
+func processExists(pid int) bool {
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return p.Signal(syscall.Signal(0)) == nil
 }


### PR DESCRIPTION
CodeGraph `serve --mcp` starts a root-scoped shared daemon that detaches into its own process group. The launcher/proxy can be killed by Reasonix cleanup, but the daemon intentionally outlives any single MCP client and exits only after its idle timer once the last client disconnects.

This PR keeps that shared-client lifecycle intact while making Reasonix-launched daemons short-lived after use.

**Changes:**

- Set `CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS=1000` on the built-in CodeGraph MCP spec, so a daemon started by Reasonix exits quickly after the last client disconnects instead of lingering for the default 5 minutes.
- Do **not** call `KillDaemon(root)` from normal `ctrl.Close()` cleanup. Closing a controller now only tears down Reasonix’s proxy connection; CodeGraph’s own refcount decides when the shared daemon may exit.
- Keep `KillDaemon(root)` for explicit test/diagnostic cleanup, but harden it to read `.codegraph/daemon.pid` and require the daemon socket hello to match the recorded pid/socket/protocol before sending a direct kill. This avoids killing an unrelated process after stale PID reuse.
- Update E2E cleanup comments and add focused coverage for lock parsing, PID-reuse protection, matching-socket cleanup, and the boot-time idle-timeout env contract.

**Verification:**

- `go test ./internal/codegraph`
- `go test ./internal/boot`
- `git diff --check`

**Authorship note:** @heshuimu is the primary author of the original PR. @SivanCola contributed the follow-up hardening commit that preserves CodeGraph shared-daemon semantics and guards explicit daemon cleanup against stale PID reuse.
