### PR TITLE
Support ACP model and effort switching / 支持 ACP 模型和推理强度切换

### DIFF
--- a/internal/acp/e2e_test.go
+++ b/internal/acp/e2e_test.go
@@ -349,7 +349,7 @@ func TestE2ESessionListResumeAndDelete(t *testing.T) {
 	default:
 	}
 
-	deleteResp := client2.call(t, "session/delete", SessionDeleteParams(nr))
+	deleteResp := client2.call(t, "session/delete", SessionDeleteParams{SessionID: nr.SessionID})
 	if deleteResp.Error != nil {
 		t.Fatalf("session/delete errored: %+v", deleteResp.Error)
 	}

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -147,7 +147,23 @@ func (e *MCPEnv) UnmarshalJSON(raw []byte) error {
 
 // SessionNewResult returns the opaque id used to address the session thereafter.
 type SessionNewResult struct {
-	SessionID string `json:"sessionId"`
+	SessionID     string                `json:"sessionId"`
+	Models        *SessionModelState    `json:"models,omitempty"`
+	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
+}
+
+// ModelInfo describes one selectable model in ACP's legacy model selector.
+type ModelInfo struct {
+	ModelID     string `json:"modelId"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// SessionModelState is ACP's legacy model selector state. New clients should
+// prefer the category:"model" config option, but some hosts still probe this.
+type SessionModelState struct {
+	AvailableModels []ModelInfo `json:"availableModels"`
+	CurrentModelID  string      `json:"currentModelId"`
 }
 
 // --- session/load ---
@@ -164,7 +180,10 @@ type SessionLoadParams struct {
 
 // SessionLoadResult is the empty ack; the conversation has already arrived as a
 // burst of session/update notifications by the time it is sent.
-type SessionLoadResult struct{}
+type SessionLoadResult struct {
+	Models        *SessionModelState    `json:"models,omitempty"`
+	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
+}
 
 // --- session/resume ---
 
@@ -176,7 +195,53 @@ type SessionResumeParams struct {
 }
 
 // SessionResumeResult is the empty ack returned once the session is ready.
-type SessionResumeResult struct{}
+type SessionResumeResult struct {
+	Models        *SessionModelState    `json:"models,omitempty"`
+	ConfigOptions []SessionConfigOption `json:"configOptions,omitempty"`
+}
+
+// --- session/set_config_option ---
+
+// SetSessionConfigOptionParams changes one advertised session config option.
+type SetSessionConfigOptionParams struct {
+	SessionID string `json:"sessionId"`
+	ConfigID  string `json:"configId"`
+	Value     string `json:"value"`
+}
+
+// SetSessionConfigOptionResult returns the full refreshed config state.
+type SetSessionConfigOptionResult struct {
+	ConfigOptions []SessionConfigOption `json:"configOptions"`
+}
+
+// SessionConfigOption is a single-value ACP session selector.
+type SessionConfigOption struct {
+	ID           string                      `json:"id"`
+	Name         string                      `json:"name"`
+	Description  string                      `json:"description,omitempty"`
+	Category     string                      `json:"category,omitempty"`
+	Type         string                      `json:"type"`
+	CurrentValue string                      `json:"currentValue"`
+	Options      []SessionConfigSelectOption `json:"options"`
+}
+
+// SessionConfigSelectOption is one selectable value for a config option.
+type SessionConfigSelectOption struct {
+	Value       string `json:"value"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// --- session/set_model ---
+
+// SetSessionModelParams is ACP's legacy model-switching request.
+type SetSessionModelParams struct {
+	SessionID string `json:"sessionId"`
+	ModelID   string `json:"modelId"`
+}
+
+// SetSessionModelResult is the empty ack for legacy model switching.
+type SetSessionModelResult struct{}
 
 // --- session/list ---
 
@@ -340,6 +405,12 @@ type toolCallUpdateMsg struct {
 type toolContent struct {
 	Type    string       `json:"type"`
 	Content ContentBlock `json:"content"`
+}
+
+// configOptionUpdate reports a complete refreshed session config state.
+type configOptionUpdate struct {
+	SessionUpdate string                `json:"sessionUpdate"`
+	ConfigOptions []SessionConfigOption `json:"configOptions"`
 }
 
 // --- session/cancel (client → agent notification) ---

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -14,6 +14,8 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/hook"
+	"reasonix/internal/provider"
 )
 
 // --- fakes: a Factory wrapping a behavior-driven runner in a real Controller ---
@@ -38,6 +40,115 @@ type fakeFactory struct {
 func (f *fakeFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
 	runner := &fakeRunner{sink: p.Sink, behavior: f.behavior}
 	return control.New(control.Options{Runner: runner, Sink: p.Sink}), nil
+}
+
+type configurableFactory struct {
+	mu         sync.Mutex
+	builds     []SessionParams
+	dir        string
+	withHooks  bool
+	hookEvents []hook.Event
+	behavior   func(ctx context.Context, sink event.Sink, input string, p SessionParams) error
+}
+
+func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
+	f.mu.Lock()
+	f.builds = append(f.builds, SessionParams{
+		Cwd:            p.Cwd,
+		Model:          p.Model,
+		EffortOverride: cloneStringPtr(p.EffortOverride),
+	})
+	f.mu.Unlock()
+	behavior := f.behavior
+	if behavior == nil {
+		behavior = func(_ context.Context, sink event.Sink, input string, p SessionParams) error {
+			sink.Emit(event.Event{Kind: event.Text, Text: p.Model + ":" + input})
+			return nil
+		}
+	}
+	runner := &fakeRunner{
+		sink:     p.Sink,
+		behavior: func(ctx context.Context, sink event.Sink, input string) error { return behavior(ctx, sink, input, p) },
+	}
+	opts := control.Options{Runner: runner, Sink: p.Sink, SessionDir: f.dir}
+	if f.withHooks {
+		opts.Hooks = f.hookRunner()
+	}
+	return control.New(opts), nil
+}
+
+func (f *configurableFactory) SessionDir() string { return f.dir }
+
+func (f *configurableFactory) SessionConfigState(_ context.Context, p SessionConfigStateParams) (SessionConfigState, error) {
+	model := strings.TrimSpace(p.Model)
+	if model == "" {
+		model = "fast"
+	}
+	if model != "fast" && model != "pro" {
+		return SessionConfigState{}, os.ErrInvalid
+	}
+	effort := "auto"
+	effortOverride := cloneStringPtr(p.EffortOverride)
+	if effortOverride != nil && *effortOverride != "" {
+		effort = *effortOverride
+	}
+	modelOptions := []SessionConfigSelectOption{
+		{Value: "fast", Name: "Fast"},
+		{Value: "pro", Name: "Pro"},
+	}
+	effortOptions := []SessionConfigSelectOption{
+		{Value: "auto", Name: "Auto"},
+		{Value: "high", Name: "High"},
+	}
+	return SessionConfigState{
+		Model:          model,
+		EffortOverride: effortOverride,
+		Models: &SessionModelState{
+			AvailableModels: []ModelInfo{{ModelID: "fast", Name: "Fast"}, {ModelID: "pro", Name: "Pro"}},
+			CurrentModelID:  model,
+		},
+		ConfigOptions: []SessionConfigOption{
+			{ID: "model", Name: "Model", Category: "model", Type: "select", CurrentValue: model, Options: modelOptions},
+			{ID: "effort", Name: "Effort", Category: "thought_level", Type: "select", CurrentValue: effort, Options: effortOptions},
+		},
+	}, nil
+}
+
+func (f *configurableFactory) buildAt(t *testing.T, idx int) SessionParams {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.builds) <= idx {
+		t.Fatalf("builds = %d, want index %d", len(f.builds), idx)
+	}
+	return f.builds[idx]
+}
+
+func (f *configurableFactory) buildCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.builds)
+}
+
+func (f *configurableFactory) hookRunner() *hook.Runner {
+	hooks := []hook.ResolvedHook{
+		{HookConfig: hook.HookConfig{Command: "session-start"}, Event: hook.SessionStart},
+		{HookConfig: hook.HookConfig{Command: "session-end"}, Event: hook.SessionEnd},
+	}
+	return hook.NewRunner(hooks, "", func(_ context.Context, in hook.SpawnInput) hook.SpawnResult {
+		var payload hook.Payload
+		_ = json.Unmarshal([]byte(in.Stdin), &payload)
+		f.mu.Lock()
+		f.hookEvents = append(f.hookEvents, payload.Event)
+		f.mu.Unlock()
+		return hook.SpawnResult{ExitCode: 0}
+	}, nil)
+}
+
+func (f *configurableFactory) hookEventsSnapshot() []hook.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]hook.Event(nil), f.hookEvents...)
 }
 
 // --- a minimal JSON-RPC client over the wire, for integration tests ---
@@ -253,6 +364,238 @@ func TestServeLifecycle(t *testing.T) {
 	}
 }
 
+func TestServeSessionConfigSwitchesModelAndEffort(t *testing.T) {
+	factory := &configurableFactory{}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+	if nr.Models == nil || nr.Models.CurrentModelID != "fast" {
+		t.Fatalf("models = %+v, want current fast", nr.Models)
+	}
+	modelOpt, ok := findConfigOption(nr.ConfigOptions, "model")
+	if !ok || modelOpt.CurrentValue != "fast" {
+		t.Fatalf("model config = %+v, want current fast", modelOpt)
+	}
+	if got := factory.buildAt(t, 0).Model; got != "fast" {
+		t.Fatalf("initial build model = %q, want fast", got)
+	}
+
+	setModelResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "model",
+		Value:     "pro",
+	})
+	var modelSet SetSessionConfigOptionResult
+	if err := json.Unmarshal(setModelResp.Result, &modelSet); err != nil {
+		t.Fatalf("set model result: %v", err)
+	}
+	modelOpt, _ = findConfigOption(modelSet.ConfigOptions, "model")
+	if modelOpt.CurrentValue != "pro" {
+		t.Fatalf("model after set_config_option = %q, want pro", modelOpt.CurrentValue)
+	}
+	if got := factory.buildAt(t, 1).Model; got != "pro" {
+		t.Fatalf("second build model = %q, want pro", got)
+	}
+
+	setEffortResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "effort",
+		Value:     "high",
+	})
+	var effortSet SetSessionConfigOptionResult
+	if err := json.Unmarshal(setEffortResp.Result, &effortSet); err != nil {
+		t.Fatalf("set effort result: %v", err)
+	}
+	effortOpt, _ := findConfigOption(effortSet.ConfigOptions, "effort")
+	if effortOpt.CurrentValue != "high" {
+		t.Fatalf("effort after set_config_option = %q, want high", effortOpt.CurrentValue)
+	}
+	effortBuild := factory.buildAt(t, 2)
+	if effortBuild.Model != "pro" || effortBuild.EffortOverride == nil || *effortBuild.EffortOverride != "high" {
+		t.Fatalf("effort build = model:%q effort:%v, want pro/high", effortBuild.Model, effortBuild.EffortOverride)
+	}
+
+	setLegacyResp := client.call(t, "session/set_model", SetSessionModelParams{SessionID: nr.SessionID, ModelID: "fast"})
+	if setLegacyResp.Error != nil {
+		t.Fatalf("session/set_model errored: %+v", setLegacyResp.Error)
+	}
+	if got := factory.buildAt(t, 3).Model; got != "fast" {
+		t.Fatalf("legacy set_model build model = %q, want fast", got)
+	}
+}
+
+func TestServeSessionConfigQueuesDuringActivePrompt(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	factory := &configurableFactory{
+		behavior: func(ctx context.Context, sink event.Sink, input string, p SessionParams) error {
+			once.Do(func() { close(started) })
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			sink.Emit(event.Event{Kind: event.Text, Text: p.Model + ":" + input})
+			return nil
+		},
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	first := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "first"}},
+	})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prompt never started")
+	}
+
+	setResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "model",
+		Value:     "pro",
+	})
+	if setResp.Error != nil {
+		t.Fatalf("set_config_option while running errored: %+v", setResp.Error)
+	}
+	var set SetSessionConfigOptionResult
+	if err := json.Unmarshal(setResp.Result, &set); err != nil {
+		t.Fatalf("set model result: %v", err)
+	}
+	modelOpt, _ := findConfigOption(set.ConfigOptions, "model")
+	if modelOpt.CurrentValue != "pro" {
+		t.Fatalf("queued model option = %q, want pro", modelOpt.CurrentValue)
+	}
+	if got := factory.buildCount(); got != 1 {
+		t.Fatalf("build count while prompt is active = %d, want only initial build", got)
+	}
+
+	close(release)
+	_, resp := drainPrompt(t, client, first)
+	if resp.Error != nil {
+		t.Fatalf("first prompt errored: %+v", resp.Error)
+	}
+	if got := factory.buildAt(t, 1).Model; got != "pro" {
+		t.Fatalf("queued rebuild model = %q, want pro", got)
+	}
+}
+
+func TestServeSessionConfigRebuildPreservesLifecycleHooks(t *testing.T) {
+	factory := &configurableFactory{withHooks: true}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "one"}},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("first prompt errored: %+v", resp.Error)
+	}
+	if got := factory.hookEventsSnapshot(); len(got) != 1 || got[0] != hook.SessionStart {
+		t.Fatalf("hook events after first prompt = %v, want [SessionStart]", got)
+	}
+
+	setResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "model",
+		Value:     "pro",
+	})
+	if setResp.Error != nil {
+		t.Fatalf("set_config_option errored: %+v", setResp.Error)
+	}
+	if got := factory.hookEventsSnapshot(); len(got) != 1 || got[0] != hook.SessionStart {
+		t.Fatalf("hook events after config rebuild = %v, want no lifecycle hook", got)
+	}
+
+	promptCh = client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "two"}},
+	})
+	_, resp = drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("second prompt errored: %+v", resp.Error)
+	}
+	if got := factory.hookEventsSnapshot(); len(got) != 1 || got[0] != hook.SessionStart {
+		t.Fatalf("hook events after second prompt = %v, want no duplicate SessionStart", got)
+	}
+
+	closeResp := client.call(t, "session/close", SessionCloseParams{SessionID: nr.SessionID})
+	if closeResp.Error != nil {
+		t.Fatalf("session/close errored: %+v", closeResp.Error)
+	}
+	if got := factory.hookEventsSnapshot(); len(got) != 2 || got[0] != hook.SessionStart || got[1] != hook.SessionEnd {
+		t.Fatalf("hook events after close = %v, want [SessionStart SessionEnd]", got)
+	}
+}
+
+func TestServeSessionLoadFallsBackFromStaleSavedModel(t *testing.T) {
+	dir := t.TempDir()
+	cwd := t.TempDir()
+	sessionID := "stale-model"
+	path := transcriptPath(dir, sessionID)
+	saved := agent.NewSession("")
+	saved.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if err := saved.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	effort := "high"
+	if err := saveACPMeta(path, acpSessionMeta{
+		SessionID:      sessionID,
+		Cwd:            cwd,
+		Model:          "missing/model",
+		EffortOverride: &effort,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := &configurableFactory{dir: dir}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	loadResp := client.call(t, "session/load", SessionLoadParams{SessionID: sessionID, Cwd: cwd})
+	if loadResp.Error != nil {
+		t.Fatalf("session/load with stale saved model errored: %+v", loadResp.Error)
+	}
+	if got := factory.buildAt(t, 0).Model; got != "fast" {
+		t.Fatalf("fallback build model = %q, want fast", got)
+	}
+	meta, ok, err := loadACPMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("load rewritten meta = %v, ok=%v", err, ok)
+	}
+	if meta.Model != "fast" {
+		t.Fatalf("rewritten meta model = %q, want fast", meta.Model)
+	}
+}
+
 func TestServeCancel(t *testing.T) {
 	started := make(chan struct{})
 	factory := &fakeFactory{behavior: func(ctx context.Context, _ event.Sink, _ string) error {
@@ -278,7 +621,7 @@ func TestServeCancel(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("prompt never started")
 	}
-	client.notify("session/cancel", SessionCancelParams(nr))
+	client.notify("session/cancel", SessionCancelParams{SessionID: nr.SessionID})
 
 	select {
 	case resp := <-promptCh:
@@ -351,7 +694,7 @@ func TestServeSessionClose(t *testing.T) {
 	var nr SessionNewResult
 	json.Unmarshal(newResp.Result, &nr)
 
-	closeResp := client.call(t, "session/close", SessionCloseParams(nr))
+	closeResp := client.call(t, "session/close", SessionCloseParams{SessionID: nr.SessionID})
 	if closeResp.Error != nil {
 		t.Fatalf("session/close errored: %+v", closeResp.Error)
 	}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -28,14 +28,16 @@ import (
 // routes "ask" decisions back through that sink as ApprovalRequest events, which
 // the sink forwards to the client over session/request_permission.
 //
-// The Factory picks the model (ACP's session/new carries no model selection).
 // Cwd roots the session's file tools and bash (built via builtin.Workspace).
-// MCPServers are the stdio MCP servers the client asked the agent to connect for
-// this session.
+// Model and EffortOverride are optional session-local provider selectors from
+// ACP config options. MCPServers are the stdio MCP servers the client asked the
+// agent to connect for this session.
 type SessionParams struct {
-	Cwd        string
-	MCPServers []plugin.Spec
-	Sink       event.Sink
+	Cwd            string
+	MCPServers     []plugin.Spec
+	Sink           event.Sink
+	Model          string
+	EffortOverride *string
 }
 
 // Factory builds the per-session controller. The composition root (the cli's
@@ -46,6 +48,30 @@ type SessionParams struct {
 // MCP subprocesses), so the service calls ctrl.Close() on teardown.
 type Factory interface {
 	NewSession(ctx context.Context, p SessionParams) (*control.Controller, error)
+}
+
+// SessionConfigStateParams asks the Factory for normalized session config
+// selectors. Empty Model means the Factory should use its configured default.
+// Nil EffortOverride means provider config wins; a non-nil empty string means
+// provider default for this session.
+type SessionConfigStateParams struct {
+	Cwd            string
+	Model          string
+	EffortOverride *string
+}
+
+// SessionConfigState is the complete ACP-visible config state for a session.
+type SessionConfigState struct {
+	Model          string
+	EffortOverride *string
+	Models         *SessionModelState
+	ConfigOptions  []SessionConfigOption
+}
+
+// SessionConfigStateProvider lets a Factory expose model and effort selectors
+// without making the ACP transport depend on a concrete config backend.
+type SessionConfigStateProvider interface {
+	SessionConfigState(ctx context.Context, p SessionConfigStateParams) (SessionConfigState, error)
 }
 
 // SessionDirProvider lets a Factory expose the persistent session directory
@@ -80,6 +106,8 @@ func Serve(ctx context.Context, r io.Reader, w io.Writer, factory Factory, info 
 	conn.Handle("session/load", svc.sessionLoad)
 	conn.Handle("session/resume", svc.sessionResume)
 	conn.Handle("session/prompt", svc.sessionPrompt)
+	conn.Handle("session/set_config_option", svc.sessionSetConfigOption)
+	conn.Handle("session/set_model", svc.sessionSetModel)
 	conn.Handle("session/close", svc.sessionClose)
 	conn.Handle("session/list", svc.sessionList)
 	conn.Handle("session/delete", svc.sessionDelete)
@@ -108,9 +136,14 @@ type acpSession struct {
 	sink       *updateSink
 	transcript string
 	cwd        string
-	title      string
-	createdAt  time.Time
-	updatedAt  time.Time
+	mcpServers []plugin.Spec
+	model      string
+	// nil means use config; non-nil empty string means provider default.
+	effortOverride *string
+	pendingConfig  *SessionConfigState
+	title          string
+	createdAt      time.Time
+	updatedAt      time.Time
 
 	mu      sync.Mutex
 	cancel  context.CancelFunc
@@ -227,6 +260,10 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	if err != nil {
 		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/new: " + err.Error()}
 	}
+	cfgState, err := s.sessionConfigState(ctx, SessionConfigStateParams{Cwd: cwd})
+	if err != nil {
+		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
+	}
 
 	id, err := newSessionID()
 	if err != nil {
@@ -235,9 +272,11 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 
 	sink := newUpdateSink(s.conn, id)
 	ctrl, err := s.factory.NewSession(ctx, SessionParams{
-		Cwd:        cwd,
-		MCPServers: mcpServers,
-		Sink:       sink,
+		Cwd:            cwd,
+		MCPServers:     mcpServers,
+		Sink:           sink,
+		Model:          cfgState.Model,
+		EffortOverride: cloneStringPtr(cfgState.EffortOverride),
 	})
 	if err != nil {
 		return nil, &RPCError{Code: ErrInternal, Message: "session/new: " + err.Error()}
@@ -246,7 +285,17 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	sink.bindApprove(ctrl.Approve)
 
 	now := time.Now().UTC()
-	sess := &acpSession{id: id, ctrl: ctrl, sink: sink, cwd: cwd, createdAt: now, updatedAt: now}
+	sess := &acpSession{
+		id:             id,
+		ctrl:           ctrl,
+		sink:           sink,
+		cwd:            cwd,
+		mcpServers:     clonePluginSpecs(mcpServers),
+		model:          cfgState.Model,
+		effortOverride: cloneStringPtr(cfgState.EffortOverride),
+		createdAt:      now,
+		updatedAt:      now,
+	}
 	// Pin a transcript file keyed by session id when the controller has a session
 	// dir, so every turn auto-saves there, session/prompt can hand the path back,
 	// and session/load can find it again by id across process restarts.
@@ -259,7 +308,11 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	s.sessions[id] = sess
 	s.mu.Unlock()
 
-	return SessionNewResult{SessionID: id}, nil
+	return SessionNewResult{
+		SessionID:     id,
+		Models:        cfgState.Models,
+		ConfigOptions: cfgState.ConfigOptions,
+	}, nil
 }
 
 // sessionLoad resumes a previously-saved session by id: it builds a controller
@@ -272,10 +325,11 @@ func (s *service) sessionLoad(ctx context.Context, raw json.RawMessage) (any, er
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/load: " + err.Error()}
 	}
-	if err := s.openExistingSession(ctx, "session/load", p.SessionID, p.Cwd, p.MCPServers, true); err != nil {
+	cfgState, err := s.openExistingSession(ctx, "session/load", p.SessionID, p.Cwd, p.MCPServers, true)
+	if err != nil {
 		return nil, err
 	}
-	return SessionLoadResult{}, nil
+	return SessionLoadResult{Models: cfgState.Models, ConfigOptions: cfgState.ConfigOptions}, nil
 }
 
 // sessionResume restores a previously-saved session without replaying its
@@ -285,40 +339,68 @@ func (s *service) sessionResume(ctx context.Context, raw json.RawMessage) (any, 
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/resume: " + err.Error()}
 	}
-	if err := s.openExistingSession(ctx, "session/resume", p.SessionID, p.Cwd, p.MCPServers, false); err != nil {
+	cfgState, err := s.openExistingSession(ctx, "session/resume", p.SessionID, p.Cwd, p.MCPServers, false)
+	if err != nil {
 		return nil, err
 	}
-	return SessionResumeResult{}, nil
+	return SessionResumeResult{Models: cfgState.Models, ConfigOptions: cfgState.ConfigOptions}, nil
 }
 
-func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam string, servers []MCPServerSpec, replay bool) error {
+func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam string, servers []MCPServerSpec, replay bool) (SessionConfigState, error) {
 	if err := validateSessionID(method, id); err != nil {
-		return err
+		return SessionConfigState{}, err
 	}
 	cwd, err := s.resolveSessionCwd(cwdParam, id)
 	if err != nil {
-		return &RPCError{Code: ErrInvalidParams, Message: method + ": " + err.Error()}
+		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": " + err.Error()}
 	}
 	mcpServers, err := mcpSpecs(servers, cwd)
 	if err != nil {
-		return &RPCError{Code: ErrInvalidParams, Message: method + ": " + err.Error()}
+		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": " + err.Error()}
 	}
 
 	if sess := s.session(id); sess != nil {
 		if replay {
 			newUpdateSink(s.conn, id).replay(sess.ctrl.History())
 		}
-		return nil
+		cfgState, err := s.configStateForSession(ctx, sess)
+		if err != nil {
+			return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
+		}
+		return cfgState, nil
+	}
+
+	var saved acpSessionMeta
+	if dir := s.sessionDir(); dir != "" {
+		meta, _, metaErr := loadACPMeta(transcriptPath(dir, id))
+		if metaErr != nil {
+			return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + metaErr.Error()}
+		}
+		saved = meta
+	}
+	cfgParams := SessionConfigStateParams{
+		Cwd:            cwd,
+		Model:          saved.Model,
+		EffortOverride: cloneStringPtr(saved.EffortOverride),
+	}
+	cfgState, err := s.sessionConfigState(ctx, cfgParams)
+	if err != nil && (strings.TrimSpace(saved.Model) != "" || saved.EffortOverride != nil) {
+		cfgState, err = s.sessionConfigState(ctx, SessionConfigStateParams{Cwd: cwd})
+	}
+	if err != nil {
+		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
 
 	sink := newUpdateSink(s.conn, id)
 	ctrl, err := s.factory.NewSession(ctx, SessionParams{
-		Cwd:        cwd,
-		MCPServers: mcpServers,
-		Sink:       sink,
+		Cwd:            cwd,
+		MCPServers:     mcpServers,
+		Sink:           sink,
+		Model:          cfgState.Model,
+		EffortOverride: cloneStringPtr(cfgState.EffortOverride),
 	})
 	if err != nil {
-		return &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
+		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
 	ctrl.EnableInteractiveApproval()
 	sink.bindApprove(ctrl.Approve)
@@ -326,30 +408,35 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	dir := ctrl.SessionDir()
 	if dir == "" {
 		ctrl.Close()
-		return &RPCError{Code: ErrInternal, Message: method + ": persistence is disabled"}
+		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": persistence is disabled"}
 	}
 	path := transcriptPath(dir, id)
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
 		ctrl.Close()
-		return &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
+		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
 	}
 	ctrl.Resume(loaded, path)
 
 	meta := metadataForLoadedSession(path, id, cwd, ctrl.History())
+	meta.Model = cfgState.Model
+	meta.EffortOverride = cloneStringPtr(cfgState.EffortOverride)
 	sess := &acpSession{
-		id:         id,
-		ctrl:       ctrl,
-		sink:       sink,
-		transcript: path,
-		cwd:        meta.Cwd,
-		title:      meta.Title,
-		createdAt:  meta.CreatedAt,
-		updatedAt:  meta.UpdatedAt,
+		id:             id,
+		ctrl:           ctrl,
+		sink:           sink,
+		transcript:     path,
+		cwd:            meta.Cwd,
+		mcpServers:     clonePluginSpecs(mcpServers),
+		model:          cfgState.Model,
+		effortOverride: cloneStringPtr(cfgState.EffortOverride),
+		title:          meta.Title,
+		createdAt:      meta.CreatedAt,
+		updatedAt:      meta.UpdatedAt,
 	}
 	if err := saveACPMeta(path, sess.meta()); err != nil {
 		ctrl.Close()
-		return &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
+		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + err.Error()}
 	}
 	s.mu.Lock()
 	s.sessions[id] = sess
@@ -358,7 +445,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	if replay {
 		sink.replay(ctrl.History())
 	}
-	return nil
+	return cfgState, nil
 }
 
 // transcriptPath is where a session's transcript lives — keyed by id so
@@ -394,6 +481,9 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	defer func() {
 		sess.sink.clearTurnContext()
 		sess.finish()
+		if err := s.applyPendingSessionConfig(ctx, sess); err != nil {
+			sess.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "session config switch failed after turn: " + err.Error()})
+		}
 		cancel()
 	}()
 	runErr := sess.ctrl.RunTurn(runCtx, text)
@@ -415,6 +505,183 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		res.TranscriptPath = &sess.transcript
 	}
 	return res, nil
+}
+
+// sessionSetConfigOption applies ACP's generic session-level selector. Reasonix
+// currently exposes model and reasoning-effort selectors through this path.
+func (s *service) sessionSetConfigOption(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p SetSessionConfigOptionParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_config_option: " + err.Error()}
+	}
+	sess := s.session(p.SessionID)
+	if sess == nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_config_option: unknown session " + p.SessionID}
+	}
+	cfgState, err := s.configStateForSession(ctx, sess)
+	if err != nil {
+		return nil, &RPCError{Code: ErrInternal, Message: "session/set_config_option: " + err.Error()}
+	}
+	option, ok := findConfigOption(cfgState.ConfigOptions, p.ConfigID)
+	if !ok {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_config_option: unknown config option " + p.ConfigID}
+	}
+	if !configOptionHasValue(option, p.Value) {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_config_option: invalid value " + p.Value + " for " + option.ID}
+	}
+
+	var next SessionConfigState
+	switch configOptionCategory(option) {
+	case "model":
+		next, err = s.switchSessionModel(ctx, sess, p.Value)
+	case "thought_level":
+		next, err = s.switchSessionEffort(ctx, sess, p.Value)
+	default:
+		err = &RPCError{Code: ErrInvalidParams, Message: "session/set_config_option: unsupported config option " + option.ID}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return SetSessionConfigOptionResult{ConfigOptions: next.ConfigOptions}, nil
+}
+
+// sessionSetModel keeps older ACP clients working while configOptions becomes
+// the preferred model selector.
+func (s *service) sessionSetModel(ctx context.Context, raw json.RawMessage) (any, error) {
+	var p SetSessionModelParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_model: " + err.Error()}
+	}
+	sess := s.session(p.SessionID)
+	if sess == nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/set_model: unknown session " + p.SessionID}
+	}
+	if _, err := s.switchSessionModel(ctx, sess, p.ModelID); err != nil {
+		return nil, err
+	}
+	return SetSessionModelResult{}, nil
+}
+
+func (s *service) switchSessionModel(ctx context.Context, sess *acpSession, modelID string) (SessionConfigState, error) {
+	params := sess.configStateParams()
+	params.Model = modelID
+	cfgState, err := s.sessionConfigState(ctx, params)
+	if err != nil {
+		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: "session/set_model: " + err.Error()}
+	}
+	if cfgState.Model == "" {
+		return SessionConfigState{}, &RPCError{Code: ErrInvalidRequest, Message: "session/set_model: model switching is unavailable in this session"}
+	}
+	if err := s.rebuildSession(ctx, sess, cfgState); err != nil {
+		return SessionConfigState{}, err
+	}
+	return cfgState, nil
+}
+
+func (s *service) switchSessionEffort(ctx context.Context, sess *acpSession, effort string) (SessionConfigState, error) {
+	params := sess.configStateParams()
+	level := strings.TrimSpace(effort)
+	if level == "auto" {
+		level = ""
+	}
+	params.EffortOverride = &level
+	cfgState, err := s.sessionConfigState(ctx, params)
+	if err != nil {
+		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: "session/set_config_option: " + err.Error()}
+	}
+	if err := s.rebuildSession(ctx, sess, cfgState); err != nil {
+		return SessionConfigState{}, err
+	}
+	return cfgState, nil
+}
+
+func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState SessionConfigState) error {
+	sess.mu.Lock()
+	if sess.deleted {
+		sess.mu.Unlock()
+		return &RPCError{Code: ErrInvalidRequest, Message: "session config: session is deleted"}
+	}
+	if sess.running || sess.ctrl.Running() {
+		pending := cloneSessionConfigState(cfgState)
+		sess.model = cfgState.Model
+		sess.effortOverride = cloneStringPtr(cfgState.EffortOverride)
+		sess.pendingConfig = &pending
+		if sess.transcript != "" && sessionFileExists(sess.transcript) {
+			_ = saveACPMeta(sess.transcript, sess.metaLocked())
+		}
+		sess.mu.Unlock()
+		sess.sink.send(configOptionUpdate{SessionUpdate: "config_option_update", ConfigOptions: cfgState.ConfigOptions})
+		return nil
+	}
+	sess.pendingConfig = nil
+
+	cur := sess.ctrl
+	prevPath := cur.SessionPath()
+	if err := cur.Snapshot(); err != nil {
+		sess.mu.Unlock()
+		return &RPCError{Code: ErrInternal, Message: "session config: snapshot before switch: " + err.Error()}
+	}
+	carried := cur.History()
+	sink := sess.sink
+	mcpServers := clonePluginSpecs(sess.mcpServers)
+	cwd := sess.cwd
+
+	newCtrl, err := s.factory.NewSession(ctx, SessionParams{
+		Cwd:            cwd,
+		MCPServers:     mcpServers,
+		Sink:           sink,
+		Model:          cfgState.Model,
+		EffortOverride: cloneStringPtr(cfgState.EffortOverride),
+	})
+	if err != nil {
+		sess.mu.Unlock()
+		return &RPCError{Code: ErrInternal, Message: "session config: " + err.Error()}
+	}
+	newCtrl.EnableInteractiveApproval()
+	sink.bindApprove(newCtrl.Approve)
+	if len(carried) > 0 {
+		newCtrl.Resume(&agent.Session{Messages: carried}, prevPath)
+	} else if prevPath != "" {
+		newCtrl.SetSessionPath(prevPath)
+	}
+	newCtrl.InheritLifecycleFrom(cur)
+
+	sess.ctrl = newCtrl
+	sess.model = cfgState.Model
+	sess.effortOverride = cloneStringPtr(cfgState.EffortOverride)
+	if sess.transcript != "" && sessionFileExists(sess.transcript) {
+		_ = saveACPMeta(sess.transcript, sess.metaLocked())
+	}
+	sess.mu.Unlock()
+
+	cur.ReleaseResources()
+	sink.send(configOptionUpdate{SessionUpdate: "config_option_update", ConfigOptions: cfgState.ConfigOptions})
+	return nil
+}
+
+func (s *service) applyPendingSessionConfig(ctx context.Context, sess *acpSession) error {
+	if s.session(sess.id) != sess {
+		return nil
+	}
+	sess.mu.Lock()
+	if sess.deleted || sess.pendingConfig == nil {
+		sess.mu.Unlock()
+		return nil
+	}
+	cfgState := cloneSessionConfigState(*sess.pendingConfig)
+	sess.pendingConfig = nil
+	sess.mu.Unlock()
+
+	if err := s.rebuildSession(ctx, sess, cfgState); err != nil {
+		sess.mu.Lock()
+		if !sess.deleted && sess.pendingConfig == nil {
+			pending := cloneSessionConfigState(cfgState)
+			sess.pendingConfig = &pending
+		}
+		sess.mu.Unlock()
+		return err
+	}
+	return nil
 }
 
 // sessionClose releases an active session. Unknown sessions are accepted as a
@@ -568,6 +835,103 @@ func (s *service) sessionDir() string {
 	return ""
 }
 
+func (s *service) sessionConfigState(ctx context.Context, p SessionConfigStateParams) (SessionConfigState, error) {
+	if provider, ok := s.factory.(SessionConfigStateProvider); ok {
+		return provider.SessionConfigState(ctx, p)
+	}
+	return SessionConfigState{}, nil
+}
+
+func (s *service) configStateForSession(ctx context.Context, sess *acpSession) (SessionConfigState, error) {
+	return s.sessionConfigState(ctx, sess.configStateParams())
+}
+
+func (s *acpSession) configStateParams() SessionConfigStateParams {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return SessionConfigStateParams{
+		Cwd:            s.cwd,
+		Model:          s.model,
+		EffortOverride: cloneStringPtr(s.effortOverride),
+	}
+}
+
+func findConfigOption(options []SessionConfigOption, id string) (SessionConfigOption, bool) {
+	id = normalizeConfigID(id)
+	for _, opt := range options {
+		if normalizeConfigID(opt.ID) == id {
+			return opt, true
+		}
+	}
+	return SessionConfigOption{}, false
+}
+
+func normalizeConfigID(id string) string {
+	switch strings.TrimSpace(id) {
+	case "models":
+		return "model"
+	case "reasoning_effort", "thought_level":
+		return "effort"
+	default:
+		return strings.TrimSpace(id)
+	}
+}
+
+func configOptionHasValue(option SessionConfigOption, value string) bool {
+	for _, opt := range option.Options {
+		if opt.Value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func configOptionCategory(option SessionConfigOption) string {
+	if option.Category != "" {
+		return option.Category
+	}
+	switch normalizeConfigID(option.ID) {
+	case "model":
+		return "model"
+	case "effort":
+		return "thought_level"
+	default:
+		return ""
+	}
+}
+
+func cloneStringPtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	return &cp
+}
+
+func cloneSessionConfigState(in SessionConfigState) SessionConfigState {
+	out := in
+	out.EffortOverride = cloneStringPtr(in.EffortOverride)
+	if in.Models != nil {
+		models := *in.Models
+		models.AvailableModels = append([]ModelInfo(nil), in.Models.AvailableModels...)
+		out.Models = &models
+	}
+	out.ConfigOptions = append([]SessionConfigOption(nil), in.ConfigOptions...)
+	for i := range out.ConfigOptions {
+		out.ConfigOptions[i].Options = append([]SessionConfigSelectOption(nil), out.ConfigOptions[i].Options...)
+	}
+	return out
+}
+
+func clonePluginSpecs(in []plugin.Spec) []plugin.Spec {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]plugin.Spec, len(in))
+	copy(out, in)
+	return out
+}
+
 func (s *service) resolveSessionCwd(cwd, sessionID string) (string, error) {
 	cwd = strings.TrimSpace(cwd)
 	if cwd != "" {
@@ -631,25 +995,25 @@ func (s *acpSession) persistAfterTurn(prompt string) {
 		s.createdAt = s.updatedAt
 	}
 	if s.transcript != "" && sessionFileExists(s.transcript) {
-		_ = saveACPMeta(s.transcript, acpSessionMeta{
-			SessionID: s.id,
-			Cwd:       s.cwd,
-			Title:     s.title,
-			CreatedAt: s.createdAt,
-			UpdatedAt: s.updatedAt,
-		})
+		_ = saveACPMeta(s.transcript, s.metaLocked())
 	}
 }
 
 func (s *acpSession) meta() acpSessionMeta {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.metaLocked()
+}
+
+func (s *acpSession) metaLocked() acpSessionMeta {
 	return acpSessionMeta{
-		SessionID: s.id,
-		Cwd:       s.cwd,
-		Title:     s.title,
-		CreatedAt: s.createdAt,
-		UpdatedAt: s.updatedAt,
+		SessionID:      s.id,
+		Cwd:            s.cwd,
+		Model:          s.model,
+		EffortOverride: cloneStringPtr(s.effortOverride),
+		Title:          s.title,
+		CreatedAt:      s.createdAt,
+		UpdatedAt:      s.updatedAt,
 	}
 }
 
@@ -666,11 +1030,13 @@ func (s *acpSession) info() SessionInfo {
 }
 
 type acpSessionMeta struct {
-	SessionID string    `json:"sessionId"`
-	Cwd       string    `json:"cwd"`
-	Title     string    `json:"title,omitempty"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	SessionID      string    `json:"sessionId"`
+	Cwd            string    `json:"cwd"`
+	Model          string    `json:"model,omitempty"`
+	EffortOverride *string   `json:"effortOverride,omitempty"`
+	Title          string    `json:"title,omitempty"`
+	CreatedAt      time.Time `json:"createdAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
 }
 
 func (m acpSessionMeta) info(extra map[string]any) SessionInfo {

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -74,13 +74,114 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		return nil, fmt.Errorf("session cwd must be an absolute path: %s", root)
 	}
 	return boot.Build(ctx, boot.Options{
-		Model:         f.model,
-		RequireKey:    true,
-		Sink:          p.Sink,
-		Stderr:        os.Stderr,
-		WorkspaceRoot: root,
-		ExtraPlugins:  p.MCPServers,
+		Model:          firstNonEmpty(p.Model, f.model),
+		RequireKey:     true,
+		Sink:           p.Sink,
+		EffortOverride: p.EffortOverride,
+		Stderr:         os.Stderr,
+		WorkspaceRoot:  root,
+		ExtraPlugins:   p.MCPServers,
 	})
+}
+
+func (f *acpFactory) SessionConfigState(_ context.Context, p acp.SessionConfigStateParams) (acp.SessionConfigState, error) {
+	root := strings.TrimSpace(p.Cwd)
+	if root == "" {
+		if wd, err := os.Getwd(); err == nil {
+			root = wd
+		}
+	}
+	if root != "" && !filepath.IsAbs(root) {
+		return acp.SessionConfigState{}, fmt.Errorf("session cwd must be an absolute path: %s", root)
+	}
+	_, _ = config.MigrateLegacyIfNeeded()
+	cfg, err := config.LoadForRoot(root)
+	if err != nil {
+		return acp.SessionConfigState{}, err
+	}
+
+	ref := firstNonEmpty(p.Model, f.model, cfg.DefaultModel)
+	if strings.TrimSpace(ref) == "" {
+		return acp.SessionConfigState{}, fmt.Errorf("no default_model configured")
+	}
+	entry, ok := cfg.ResolveModel(ref)
+	if !ok {
+		return acp.SessionConfigState{}, fmt.Errorf("unknown model %q", ref)
+	}
+	if !entry.Configured() {
+		return acp.SessionConfigState{}, fmt.Errorf("model %q is not configured", ref)
+	}
+	currentModel := entry.Name + "/" + entry.Model
+	modelOptions, modelInfos := acpModelOptions(cfg)
+	if !hasModelOption(modelOptions, currentModel) {
+		modelOptions = append(modelOptions, acp.SessionConfigSelectOption{
+			Value:       currentModel,
+			Name:        currentModel,
+			Description: entry.Name,
+		})
+		modelInfos = append(modelInfos, acp.ModelInfo{
+			ModelID:     currentModel,
+			Name:        currentModel,
+			Description: entry.Name,
+		})
+	}
+
+	effortEntry := *entry
+	effortOverride := cloneStringPtr(p.EffortOverride)
+	hadEffortOverride := effortOverride != nil
+	if effortOverride != nil {
+		if strings.TrimSpace(*effortOverride) == "" {
+			effortEntry.Effort = ""
+		} else {
+			normalized, err := config.NormalizeEffort(&effortEntry, *effortOverride)
+			if err != nil {
+				effortEntry.Effort = ""
+				cleared := ""
+				effortOverride = &cleared
+			} else {
+				effortEntry.Effort = normalized
+				effortOverride = &normalized
+			}
+		}
+	}
+
+	options := []acp.SessionConfigOption{{
+		ID:           "model",
+		Name:         "Model",
+		Category:     "model",
+		Type:         "select",
+		CurrentValue: currentModel,
+		Options:      modelOptions,
+	}}
+	if cap := config.EffortCapabilityForEntry(&effortEntry); cap.Supported {
+		currentEffort := config.EffortDisplay(&effortEntry)
+		if !containsString(cap.Levels, currentEffort) {
+			currentEffort = "auto"
+			auto := ""
+			effortOverride = &auto
+		}
+		options = append(options, acp.SessionConfigOption{
+			ID:           "effort",
+			Name:         "Effort",
+			Category:     "thought_level",
+			Type:         "select",
+			CurrentValue: currentEffort,
+			Options:      acpEffortOptions(cap.Levels),
+		})
+	} else if hadEffortOverride {
+		cleared := ""
+		effortOverride = &cleared
+	}
+
+	return acp.SessionConfigState{
+		Model:          currentModel,
+		EffortOverride: effortOverride,
+		Models: &acp.SessionModelState{
+			AvailableModels: modelInfos,
+			CurrentModelID:  currentModel,
+		},
+		ConfigOptions: options,
+	}, nil
 }
 
 func acpBuiltinTools(cfg *config.Config, cwd string, writeRoots []string) []tool.Tool {
@@ -94,6 +195,78 @@ func acpBuiltinTools(cfg *config.Config, cwd string, writeRoots []string) []tool
 		ProxySpec:   cfg.NetworkProxySpec(),
 	}
 	return ws.Tools(cfg.Tools.Enabled...)
+}
+
+func acpModelOptions(cfg *config.Config) ([]acp.SessionConfigSelectOption, []acp.ModelInfo) {
+	if cfg == nil {
+		return nil, nil
+	}
+	var options []acp.SessionConfigSelectOption
+	var models []acp.ModelInfo
+	for i := range cfg.Providers {
+		p := &cfg.Providers[i]
+		if !p.Configured() {
+			continue
+		}
+		for _, model := range p.ChatModelList() {
+			ref := p.Name + "/" + model
+			options = append(options, acp.SessionConfigSelectOption{
+				Value:       ref,
+				Name:        ref,
+				Description: p.Name,
+			})
+			models = append(models, acp.ModelInfo{
+				ModelID:     ref,
+				Name:        ref,
+				Description: p.Name,
+			})
+		}
+	}
+	return options, models
+}
+
+func hasModelOption(options []acp.SessionConfigSelectOption, ref string) bool {
+	for _, opt := range options {
+		if opt.Value == ref {
+			return true
+		}
+	}
+	return false
+}
+
+func acpEffortOptions(levels []string) []acp.SessionConfigSelectOption {
+	out := make([]acp.SessionConfigSelectOption, 0, len(levels))
+	for _, level := range levels {
+		out = append(out, acp.SessionConfigSelectOption{Value: level, Name: effortOptionName(level)})
+	}
+	return out
+}
+
+func effortOptionName(level string) string {
+	if level == "" {
+		return ""
+	}
+	if level == "xhigh" {
+		return "XHigh"
+	}
+	return strings.ToUpper(level[:1]) + level[1:]
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func cloneStringPtr(p *string) *string {
+	if p == nil {
+		return nil
+	}
+	cp := *p
+	return &cp
 }
 
 func acpTaskProfileDefaults(cfg *config.Config) (string, string) {

--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -112,6 +112,64 @@ api_key_env = "REASONIX_TEST_KEY"
 	t.Fatalf("ACP session did not load project command from cwd; commands=%v", ctrl.Commands())
 }
 
+func TestACPFactoryClearsEffortOverrideForUnsupportedModel(t *testing.T) {
+	isolateCLIConfigHome(t)
+	t.Setenv("REASONIX_TEST_KEY", "test-key")
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
+default_model = "reasoner/reasoning-model"
+
+[codegraph]
+enabled = false
+
+[[providers]]
+name = "reasoner"
+kind = "acp-test-provider"
+base_url = "http://example.invalid"
+model = "reasoning-model"
+api_key_env = "REASONIX_TEST_KEY"
+supported_efforts = ["low", "high"]
+
+[[providers]]
+name = "plain"
+kind = "acp-test-provider"
+base_url = "http://example.invalid"
+model = "plain-model"
+api_key_env = "REASONIX_TEST_KEY"
+effort = "high"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	high := "high"
+	state, err := (&acpFactory{}).SessionConfigState(context.Background(), acp.SessionConfigStateParams{
+		Cwd:            project,
+		Model:          "reasoner/reasoning-model",
+		EffortOverride: &high,
+	})
+	if err != nil {
+		t.Fatalf("reasoning SessionConfigState: %v", err)
+	}
+	if state.EffortOverride == nil || *state.EffortOverride != "high" {
+		t.Fatalf("reasoning effort override = %v, want high", state.EffortOverride)
+	}
+
+	state, err = (&acpFactory{}).SessionConfigState(context.Background(), acp.SessionConfigStateParams{
+		Cwd:            project,
+		Model:          "plain/plain-model",
+		EffortOverride: &high,
+	})
+	if err != nil {
+		t.Fatalf("plain SessionConfigState: %v", err)
+	}
+	if _, ok := findACPConfigOption(state.ConfigOptions, "effort"); ok {
+		t.Fatalf("plain model should not advertise effort option: %+v", state.ConfigOptions)
+	}
+	if state.EffortOverride == nil || *state.EffortOverride != "" {
+		t.Fatalf("plain effort override = %v, want explicit empty override", state.EffortOverride)
+	}
+}
+
 func TestACPTaskProfileDefaults(t *testing.T) {
 	cfg := config.Default()
 	cfg.Agent.SubagentModel = "default-model"
@@ -193,6 +251,15 @@ func TestACPSubagentProviderResolverRejectsInvalidEffort(t *testing.T) {
 	if _, _, _, err := resolve("", "max"); err == nil {
 		t.Fatal("invalid effort should fail before ACP task falls back to the parent profile")
 	}
+}
+
+func findACPConfigOption(options []acp.SessionConfigOption, id string) (acp.SessionConfigOption, bool) {
+	for _, opt := range options {
+		if opt.ID == id {
+			return opt, true
+		}
+	}
+	return acp.SessionConfigOption{}, false
 }
 
 func toolMap(tools []tool.Tool) map[string]tool.Tool {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2442,13 +2442,43 @@ func (c *Controller) Label() string { return c.label }
 // Empty means no scoping is in effect.
 func (c *Controller) WorkspaceRoot() string { return c.cpRoot }
 
+// InheritLifecycleFrom carries same-session lifecycle state across controller
+// rebuilds, such as model switches that preserve the conversation.
+func (c *Controller) InheritLifecycleFrom(prev *Controller) {
+	if prev == nil {
+		return
+	}
+	prev.mu.Lock()
+	started := prev.startedOnce
+	turn := prev.turn
+	prev.mu.Unlock()
+
+	c.mu.Lock()
+	c.startedOnce = started
+	if c.turn < turn {
+		c.turn = turn
+	}
+	c.mu.Unlock()
+}
+
+// ReleaseResources stops plugin subprocesses and releases resources without
+// firing SessionEnd. Use it only when replacing the controller for the same
+// logical session.
+func (c *Controller) ReleaseResources() {
+	c.close(false)
+}
+
 // Close stops plugin subprocesses and releases resources. A session that ever
 // started fires SessionEnd so a teardown hook runs.
 func (c *Controller) Close() {
+	c.close(true)
+}
+
+func (c *Controller) close(fireSessionEnd bool) {
 	c.mu.Lock()
 	started := c.startedOnce
 	c.mu.Unlock()
-	if started {
+	if fireSessionEnd && started {
 		c.hooks.SessionEnd(context.Background())
 	}
 	if c.jobs != nil {


### PR DESCRIPTION
## Summary
- advertise ACP session config options and legacy model metadata for model selectors
- implement `session/set_config_option` for model and effort changes plus legacy `session/set_model`
- rebuild ACP controllers with session-local model/effort while preserving transcript, history, and session MCP servers

## Root cause
Reasonix ACP only advertised lifecycle, prompt, and MCP capabilities. Hosts that rely on ACP session configuration could not discover or apply model/effort selectors, so they fell back to the configured default model.

## Validation
- `go test ./...`
- real stdio ACP smoke covering `initialize`, `session/new`, `session/set_config_option` for model and effort, and legacy `session/set_model`