### PR TITLE
fix(todo): auto-collapse panel when all items completed

### DIFF
--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -23,10 +23,13 @@ const completedTodos = [
   { content: "Ship the fix", status: "completed" },
 ];
 
+// Once every item is completed the panel is hidden — the user has watched
+// the progress and no longer needs to see the completed list. On restart
+// the panel also stays gone.
 assert.equal(
   shouldShowTodoPanel("todo-final", null, completedTodos),
-  true,
-  "the final all-completed todo_write must remain visible",
+  false,
+  "a fully-completed todo list hides the panel",
 );
 assert.equal(
   shouldShowTodoPanel("todo-active", null, [{ content: "Run tests", status: "in_progress" }]),
@@ -41,10 +44,20 @@ assert.equal(
 assert.equal(shouldShowTodoPanel(null, null, completedTodos), false, "no canonical todo item means no panel");
 assert.equal(shouldShowTodoPanel("todo-empty", null, []), false, "empty todo lists do not render a panel");
 
+// Mixed-status lists (some pending, some completed) still show.
+assert.equal(
+  shouldShowTodoPanel("todo-mixed", null, [
+    { content: "a", status: "completed" },
+    { content: "b", status: "pending" },
+  ]),
+  true,
+  "a partially-completed todo list stays visible",
+);
+
 const iterations = 200_000;
 const started = performance.now();
 for (let i = 0; i < iterations; i += 1) {
-  if (!shouldShowTodoPanel("todo-perf", null, completedTodos)) {
+  if (!shouldShowTodoPanel("todo-perf", null, [{ content: "keep", status: "pending" }])) {
     throw new Error("unexpected hidden todo panel during performance loop");
   }
 }

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -18,6 +18,14 @@ export function TodoPanel({ todos, onDismiss }: { todos: Todo[]; onDismiss: () =
 
   const done = todos.filter((t) => t.status === "completed").length;
   const current = todos.find((t) => t.status === "in_progress");
+  const allDone = done === todos.length && todos.length > 0;
+
+  // Auto-collapse when every item is completed; the user has watched the
+  // progress and no longer needs the expanded list. A fresh todo_write with
+  // new pending items will re-open it (via the parent's shouldShowTodoPanel).
+  useEffect(() => {
+    if (allDone) setOpen(false);
+  }, [allDone]);
 
   useEffect(() => {
     if (!open) return;

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -5,5 +5,8 @@ export function shouldShowTodoPanel(
   dismissedTodoId: string | null,
   todos: Todo[],
 ): boolean {
-  return !!todoId && todoId !== dismissedTodoId && todos.length > 0;
+  if (!todoId || todoId === dismissedTodoId || todos.length === 0) return false;
+  // Hide the panel when every todo item is completed — the user no longer
+  // needs to see the list, and after a restart the panel stays gone.
+  return todos.some((t) => t.status !== "completed");
 }


### PR DESCRIPTION
## Bug 修复：待办列表全部完成后自动收起

### 问题
待办列表全部完成后不自动收起，重启后仍显示。

### 根因
1. `shouldShowTodoPanel` 只检查 `todos.length > 0`，未检查是否全部已完成
2. `TodoPanel` 组件的 `open` 状态无自动收起逻辑

### 修改内容
| 文件 | 改动 |
|------|------|
| `todoVisibility.ts` | 增加 `todos.some(t => t.status !== "completed")` 全完成时返回 false |
| `TodoPanel.tsx` | 增加 `allDone` + `useEffect` 自动折叠 |
| `test-todo-visibility.mjs` | 更新测试断言匹配新行为 |

### 影响范围
仅影响前端 todo 面板的展示逻辑，不涉及后端。

Closes: #todo-panel-auto-collapse