### PR TITLE
fix: rewind tooltip + compaction filter + scroll timing

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1933,14 +1933,15 @@ export default function App() {
   // Display items: truncated when an optimistic rewind is pending.
   const displayItems = useMemo(() => {
     if (!rewindState) return state.items;
-    return state.items.slice(0, rewindState.boundaryIdx);
+    // Filter out compaction cards — they're legitimate history but
+    // confusing when shown in a rewound (truncated) transcript.
+    return state.items.slice(0, rewindState.boundaryIdx).filter((it) => it.kind !== "compaction");
   }, [state.items, rewindState]);
 
   // send wrapper: commits any pending optimistic rewind before sending.
   const commitThenSend = useCallback(async (displayText: string, submitText?: string) => {
     const rs = rewindStateRef.current;
     if (rs) {
-      setRewindState(null);
       try {
         await rewind(rs.turn, rs.scope);
         setRewindSignal((v) => v + 1);
@@ -1955,6 +1956,9 @@ export default function App() {
         // the controller emits a notice with the reason.
         return;
       }
+      // Clear AFTER Go rewind succeeds — keep displayItems truncated
+      // during the async call to prevent a flash of full conversation.
+      setRewindState(null);
     }
     send(displayText, submitText);
   }, [send, rewind]);

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -6,6 +6,7 @@ import { ProcessBrainIcon } from "./ProcessCard";
 import { parseAttachmentRefsForDisplay, sortDisplayAttachments } from "../lib/attachmentDisplay";
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
+import { Tooltip } from "./Tooltip";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import type { Item, MessageActionScope } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
@@ -232,6 +233,20 @@ export function TurnActions({
     }
     return "";
   };
+  const actionTooltipLabel = (scope: MessageActionScope): React.ReactNode => {
+    const reason = actionDisabledReason(scope);
+    if (reason) return <span>{reason}</span>;
+    if ((scope === "code" || scope === "both") && checkpoint?.files?.length) {
+      return (
+        <div className="rewind__files-tooltip">
+          {checkpoint.files.map((f) => (
+            <div key={f}>{f.split(/[/\\]/).pop() || f}</div>
+          ))}
+        </div>
+      );
+    }
+    return undefined;
+  };
   const runAction = (scope: MessageActionScope) => {
     setConfirmScope(null);
     onOpenMenu?.(null);
@@ -248,7 +263,8 @@ export function TurnActions({
   const renderAction = (scope: MessageActionScope, danger = false) => {
     const disabledReason = actionDisabledReason(scope);
     const meta = actionMeta(scope);
-    return (
+    const tipLabel = actionTooltipLabel(scope);
+    const btn = (
       <button
         className={[
           "rewind__menu-item",
@@ -257,13 +273,14 @@ export function TurnActions({
         ].filter(Boolean).join(" ")}
         type="button"
         disabled={Boolean(disabledReason)}
-        title={disabledReason || undefined}
         onClick={() => selectRewind(scope)}
+        {...(tipLabel ? {} : { title: disabledReason || undefined })}
       >
         <span>{actionLabel(scope)}</span>
         {meta && <span className="rewind__menu-meta">{meta}</span>}
       </button>
     );
+    return tipLabel ? <Tooltip key={scope} label={tipLabel} side="top" block fill>{btn}</Tooltip> : btn;
   };
   const forkDisabledReason = canAct ? actionDisabledReason("fork") : "";
   const toggleMenu = (menu: TurnActionMenu) => {


### PR DESCRIPTION
## Summary

Three fixes to the rewind (rollback) system:

1. **Rewind file tooltip** — code/both rewind buttons show a tooltip on hover listing the exact files that `RestoreCode` would touch. The file list is accumulated across all subsequent turns.

2. **Compaction card filter** — optimistic rewind preview filters out `CompactionCard` items from truncated display. Old compacted sessions no longer show confusing compaction artifacts during the preview phase.

3. **commitThenSend timing** — the optimistic state is now cleared AFTER the Go `Rewind` succeeds, not before. Previously `setRewindState(null)` ran before the async call, causing a flash of the full conversation in the UI while Go was still truncating.

## Files

- `desktop/frontend/src/App.tsx` — compaction filter + scroll timing
- `desktop/frontend/src/components/Message.tsx` — tooltip with file list