### PR TITLE
fix(agent): redact tool-call args in compaction transcript

### DIFF
--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -574,7 +575,7 @@ func renderTranscript(msgs []provider.Message) string {
 				fmt.Fprintf(&b, "[assistant]\n%s\n", m.Content)
 			}
 			for _, tc := range m.ToolCalls {
-				fmt.Fprintf(&b, "[assistant calls %s] %s\n", tc.Name, tc.Arguments)
+				fmt.Fprintf(&b, "[assistant calls %s] %s\n", tc.Name, summarizeToolArgs(tc.Arguments))
 			}
 			b.WriteString("\n")
 		case provider.RoleTool:
@@ -584,6 +585,27 @@ func renderTranscript(msgs []provider.Message) string {
 		}
 	}
 	return b.String()
+}
+
+// summarizeToolArgs returns a short summary of tool-call arguments instead of
+// the full JSON. This prevents the summarizer from reproducing long argument
+// text (like sub-agent task prompts) in the compaction summary, which would
+// leak into the session as a user message (#4317).
+func summarizeToolArgs(args string) string {
+	if args == "" {
+		return "(no arguments)"
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(args), &parsed); err != nil {
+		// Not valid JSON — return a length hint instead of raw text.
+		return fmt.Sprintf("(%d bytes)", len(args))
+	}
+	keys := make([]string, 0, len(parsed))
+	for k := range parsed {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("{%s} (%d keys)", strings.Join(keys, ", "), len(parsed))
 }
 
 // archiveMessages writes the dropped originals to a timestamped .jsonl (one

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -642,3 +642,70 @@ func TestMaybeCompactFoldsSingleLargeMessageAtThreshold(t *testing.T) {
 		t.Fatalf("single large message was not compacted at threshold: %+v", sess.Messages)
 	}
 }
+
+func TestRenderTranscriptRedactsToolCallArgs(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleUser, Content: "Find me popular GitHub MCP projects"},
+		{
+			Role:    provider.RoleAssistant,
+			Content: "I'll research that.",
+			ToolCalls: []provider.ToolCall{
+				{Name: "research", Arguments: `{"task":"Search for recently popular GitHub projects that let AI use/control any software through MCP..."}`},
+			},
+		},
+		{Role: provider.RoleTool, Name: "research", Content: "Found 5 projects."},
+	}
+
+	out := renderTranscript(msgs)
+
+	if strings.Contains(out, "Search for recently popular") {
+		t.Fatalf("renderTranscript leaked tool-call arguments into transcript:\n%s", out)
+	}
+	if !strings.Contains(out, "[assistant calls research]") {
+		t.Fatalf("renderTranscript missing tool-call label:\n%s", out)
+	}
+	if !strings.Contains(out, "task") {
+		t.Fatalf("renderTranscript missing key names:\n%s", out)
+	}
+}
+
+func TestSummarizeToolArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    string
+		want    string
+		wantNot string
+	}{
+		{
+			name: "redacts long task prompt",
+			args: `{"task":"Search for recently popular GitHub projects that let AI use/control any software through MCP..."}`,
+			want: "task",
+		},
+		{
+			name: "empty args",
+			args: "",
+			want: "no arguments",
+		},
+		{
+			name: "invalid json",
+			args: "not json",
+			want: "bytes",
+		},
+		{
+			name: "multiple keys sorted",
+			args: `{"prompt":"do something","model":"gpt-4"}`,
+			want: "model, prompt",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeToolArgs(tt.args)
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("summarizeToolArgs(%q) = %q, want contains %q", tt.args, got, tt.want)
+			}
+			if tt.wantNot != "" && strings.Contains(got, tt.wantNot) {
+				t.Errorf("summarizeToolArgs(%q) = %q, should NOT contain %q", tt.args, got, tt.wantNot)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4317

## Problem
Sub-agent task arguments leak into the user-visible conversation after compaction. The summarizer reproduces raw tool-call arguments (like task prompts) in its output, which gets inserted as a role:user message. This corrupts the session and causes HTTP 400 errors on subsequent API calls.

## Root Cause
renderTranscript (compact.go:577) dumps full tool-call JSON arguments into the text sent to the summarizer. The summarizer may reproduce these arguments verbatim in its summary.

## Fix
Replace raw arguments with a short summary (key names + count) via summarizeToolArgs. The summarizer knows what tools were called but can't reproduce the full argument text.

## Files Changed
- internal/agent/compact.go — renderTranscript now calls summarizeToolArgs; new summarizeToolArgs helper
- internal/agent/compact_test.go — 2 new tests

## Verification
```bash
go build ./cmd/reasonix
go vet ./...
go test ./internal/agent/ -run TestRenderTranscriptRedacts -v -count=1
go test ./internal/agent/ -run TestSummarizeToolArgs -v -count=1
go test ./internal/agent/ ./internal/config/ ./internal/control/ -count=1
```