### PR TITLE
fix(npm): auto-publish stable 1.x releases under latest tag

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -6,15 +6,14 @@ name: Release npm
 # own tag lets a prerelease ship to npm's `next` channel without touching the
 # stable Homebrew cask (and lets a stable cask ship without forcing npm to leave
 # its rc). Bump with:
-#   git tag npm-vX.Y.Z          # stable  -> publishes under `next`
+#   git tag npm-vX.Y.Z          # stable  -> publishes under `latest`
 #   git tag npm-vX.Y.Z-rc.N     # prerelease -> publishes under `next`
 #   git push origin <tag>
 #
 # A manual workflow_dispatch with base_version publishes an opt-in canary to the
 # `canary` dist-tag (npm i reasonix@canary) from the current ref; it never moves
-# `next`/`latest`. build.mjs decides the dist-tag: 0.x stable is `latest`; a
-# `-canary.` build is `canary`; the 1.x line and rc prereleases are `next`. Promote
-# a 1.x stable to the default install with `npm dist-tag add reasonix@X.Y.Z latest`.
+# `next`/`latest`. build.mjs decides the dist-tag: any stable release goes to
+# `latest`; a `-canary.` build is `canary`; rc and other prereleases are `next`.
 on:
   push:
     tags: ['npm-v*']

--- a/npm/build.mjs
+++ b/npm/build.mjs
@@ -99,16 +99,18 @@ if (!publish) {
   process.exit(0);
 }
 
-// Three independent dist-tags: 0.x stable is the promoted default (`latest`); a
-// `-canary.` build is the opt-in tester channel (`canary`); everything else — the
-// 1.x line and rc prereleases — ships under `next`. Only a `--tag canary` publish
-// moves canary, so `next`/`latest` users never resolve a canary. Promote a 1.x
-// stable to default with a manual `npm dist-tag add reasonix@<ver> latest`.
-const distTag = version.includes("-canary.")
-  ? "canary"
-  : version.startsWith("0.") && !version.includes("-")
-    ? "latest"
-    : "next";
+// Three independent dist-tags: any stable release (no prerelease suffix
+// like `-rc` or `-canary`) publishes under `latest` — the default install
+// channel for `npm i -g reasonix`. A `-canary.` build goes to `canary`;
+// rc and other prereleases go to `next`. The `release` environment approval
+// in CI already gates stable publishing, so there's no need for a separate
+// manual `npm dist-tag` promotion step.
+const isPrerelease = version.includes("-");
+const distTag = isPrerelease
+  ? version.includes("-canary.")
+    ? "canary"
+    : "next"
+  : "latest";
 const publishArgs = ["publish", "--access", "public", "--tag", distTag];
 
 for (const sub of subPackages) {


### PR DESCRIPTION
## Problem

`npm i -g reasonix` currently installs version **0.53.2** (legacy TypeScript build) instead of the latest Go rewrite. This is because the dist-tag logic in `npm/build.mjs` only promoted 0.x stable releases to the `latest` tag, while all 1.x releases (1.0.0, 1.1.0, 1.2.0) were published under `next`.

The README explicitly says `npm i -g reasonix` is the install command for the Go binary, but users who follow it end up with the old TypeScript version — a confusing first experience.

## Root Cause

`npm/build.mjs` lines 107-111:
```js
const distTag = version.includes("-canary.")
  ? "canary"
  : version.startsWith("0.") && !version.includes("-")
    ? "latest"
    : "next";
```

The comment said "Promote a 1.x stable to default with a manual `npm dist-tag add reasonix@<ver> latest`" — but this manual step was never performed after any release.

## Fix

Any stable release (no prerelease suffix like `-rc` or `-canary`) now automatically publishes under `latest`. The CI `release` environment approval already gates stable publishing, so the separate manual promotion step is redundant.

New logic:
- **`-canary.`** → `canary` tag
- **`-rc` etc. (any prerelease)** → `next` tag
- **Stable (no `-` in version)** → `latest` tag

## Files Changed
- `npm/build.mjs` — updated dist-tag selection logic and comment
- `.github/workflows/release-npm.yml` — updated workflow comment to reflect new behavior