### PR TITLE
fix: feishu output issues (topic_group, UTF-8 truncation, ThreadID)

### DIFF
--- a/internal/bot/feishu/feishu.go
+++ b/internal/bot/feishu/feishu.go
@@ -58,6 +58,7 @@ type feishuMsgEvent struct {
 	MessageID string          `json:"message_id"`
 	RootID    string          `json:"root_id"`
 	ParentID  string          `json:"parent_id"`
+	ThreadID  string          `json:"thread_id"`
 	ChatID    string          `json:"chat_id"`
 	ChatType  string          `json:"chat_type"`
 	MsgType   string          `json:"msg_type"`
@@ -432,14 +433,19 @@ func (a *adapter) handleMessage(msg feishuMsgEvent) {
 		return
 	}
 
-	// @mention gating：仅在群聊中检查是否 @了 bot
+	// @mention gating：仅在群聊或话题群中检查是否 @了 bot
 	chatType := bot.ChatDM
-	if msg.ChatType == "group" {
+	if msg.ChatType == "group" || msg.ChatType == "topic_group" {
 		chatType = bot.ChatGroup
 		if a.cfg.RequireMention && len(msg.Mentions) == 0 {
 			a.logger.Info("feishu message ignored", "reason", "missing_mention", "chat", logHash(msg.ChatID), "message", logHash(msg.MessageID))
 			return
 		}
+	}
+
+	threadID := firstNonEmpty(msg.ThreadID, msg.RootID)
+	if threadID == "" && msg.ChatType == "topic_group" {
+		threadID = msg.ChatID
 	}
 
 	ib := bot.InboundMessage{
@@ -450,6 +456,7 @@ func (a *adapter) handleMessage(msg feishuMsgEvent) {
 		UserName:  "",
 		Text:      content.Text,
 		MessageID: msg.MessageID,
+		ThreadID:  threadID,
 	}
 
 	// 获取用户信息填充用户名
@@ -623,7 +630,11 @@ func (a *adapter) sendCard(ctx context.Context, msg bot.OutboundMessage) (bot.Se
 		"elements": elements,
 	}
 
-	cardJSON, _ := json.Marshal(cardPayload)
+	cardJSON, err := json.Marshal(cardPayload)
+	if err != nil {
+		a.logger.Warn("feishu card marshal error", "err", err)
+		return bot.SendResult{}, fmt.Errorf("feishu card marshal: %w", err)
+	}
 	return a.sendSDKContent(ctx, msg, larkim.MsgTypeInteractive, string(cardJSON))
 }
 

--- a/internal/bot/render.go
+++ b/internal/bot/render.go
@@ -93,10 +93,11 @@ func (s *renderSink) Emit(e event.Event) {
 		if e.Tool.Err != "" {
 			fmt.Fprintf(&s.buf, "\n❌ %s 出错: %s", name, e.Tool.Err)
 		} else {
-			// 截断输出
+			// 截断输出（按字符数而非字节数，避免截断多字节 UTF-8 字符）
 			output := e.Tool.Output
-			if len(output) > 500 {
-				output = output[:500] + "\n... (已截断)"
+			runes := []rune(output)
+			if len(runes) > 500 {
+				output = string(runes[:500]) + "\n... (已截断)"
 			}
 			fmt.Fprintf(&s.buf, "\n✅ %s 完成", name)
 			if output != "" {


### PR DESCRIPTION
## Summary
Fixes several issues found in the Feishu/Lark bot output code analysis.

## Changes

### 🔴 Critical fixes
1. **`handleMessage` now recognizes `topic_group` chat type** (2f80b50)
   - Webhook path previously only handled `"group"`, missing Feishu topic groups (`topic_group`)
   - This caused topic group messages to be treated as DM, bypassing `RequireMention` gating
   - Now matches the SDK path (`handleSDKMessage`) which already had this

2. **UTF-8 safe tool output truncation** (render.go)
   - Changed from byte-based `len(output) > 500` to rune-based `len([]rune(output)) > 500`
   - Prevents garbled text when tool output contains multi-byte UTF-8 characters near the 500-byte boundary

### 🟡 Improvements
3. **Added `ThreadID` field to `feishuMsgEvent` struct**
   - Webhook push events include `thread_id` but it wasn't being parsed
   - `handleMessage` now extracts and propagates `ThreadID` to `InboundMessage`

4. **Proper error handling in `sendCard`**
   - `json.Marshal` error was silently ignored with `_`
   - Now properly returns the error with `fmt.Errorf("feishu card marshal: %w", err)`

## Testing
- All existing tests pass (feishu: 9/9, bot: 20/20, full bot suite: 4/4 packages)
- Build verified with `go build`