### PR TITLE
feat(packaging): add Scoop installation support for Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
 
   mirror-codegraph:
     name: mirror CodeGraph runtime to R2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,22 @@ homebrew_casks:
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/reasonix"]
           end
 
+scoops:
+  - name: reasonix
+    ids: [reasonix]
+    skip_upload: "auto"
+    repository:
+      owner: esengine
+      name: scoop-bucket
+      branch: main
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    homepage: "https://github.com/esengine/DeepSeek-Reasonix"
+    description: "Cache-first DeepSeek coding agent for the terminal."
+    license: MIT
+    commit_author:
+      name: reasonix
+      email: reasonix@deepseek.com
+
 release:
   prerelease: auto
   name_template: "Reasonix CLI {{ .Tag }}"

--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@
 ## Install
 
 ```sh
-npm i -g reasonix                  # any OS; pulls the prebuilt native binary
-brew install esengine/reasonix/reasonix   # macOS
+npm i -g reasonix                              # any OS; pulls the prebuilt native binary
+brew install esengine/reasonix/reasonix        # macOS
+scoop bucket add reasonix https://github.com/esengine/scoop-bucket && scoop install reasonix   # Windows
 ```
 
 Prebuilt archives (`darwin|linux|windows × amd64|arm64`) and `SHA256SUMS` are on

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,8 +63,9 @@
 ## 安装
 
 ```sh
-npm i -g reasonix                  # 任意系统;自动拉取对应平台的原生二进制
-brew install esengine/reasonix/reasonix   # macOS
+npm i -g reasonix                              # 任意系统;自动拉取对应平台的原生二进制
+brew install esengine/reasonix/reasonix        # macOS
+scoop bucket add reasonix https://github.com/esengine/scoop-bucket && scoop install reasonix   # Windows
 ```
 
 预编译归档(`darwin|linux|windows × amd64|arm64`)和 `SHA256SUMS` 见每个

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -18,6 +18,7 @@ provides the pre-release buffer instead of a long-lived branch.
 | Surface | Stable | Pre-release buffer |
 |---|---|---|
 | npm | `latest` (0.x), `next` (1.x) | `canary` (`npm i reasonix@canary`) |
+| Scoop | `esengine/scoop-bucket` (auto-updated by GoReleaser) | skipped for prereleases (`skip_upload: "auto"`) |
 | Desktop | R2 `latest/` pointer | R2 `canary/` pointer (R2-only — never on the GitHub releases page) |
 
 A canary build is isolated: it **never** moves `latest` / `next` / desktop `latest/`.


### PR DESCRIPTION
## Summary

Adds [Scoop](https://scoop.sh/) package manager support for Windows users, allowing installation via:

```sh
scoop bucket add reasonix https://github.com/esengine/scoop-bucket
scoop install reasonix
```

## Changes

- **`.goreleaser.yaml`** — added a `scoops` section to auto-publish the manifest to `esengine/scoop-bucket` on stable releases, using the same release-time publishing pattern as the existing Homebrew cask. Prereleases are skipped via `skip_upload: "auto"`.
- **`.github/workflows/release.yml`** — passes `SCOOP_BUCKET_TOKEN` to GoReleaser during the CLI release job.
- **`README.md` / `README.zh-CN.md`** — added the Scoop install command to the install sections.
- **`docs/RELEASING.md`** — documented the Scoop channel in the release channels table.

## Maintainer setup required before merge

This PR depends on release infrastructure that is not part of this branch. Before merging, a maintainer with `esengine` organization/repository admin permissions should complete this checklist:

1. Create the public bucket repository `esengine/scoop-bucket` with default branch `main`.
2. Create a fine-grained PAT or GitHub App token scoped only to `esengine/scoop-bucket` with `Contents: read/write` permission.
3. Add that token to `esengine/DeepSeek-Reasonix` as the Actions secret `SCOOP_BUCKET_TOKEN`, matching the existing `HOMEBREW_TAP_TOKEN` release pattern.
4. Verify the bucket is reachable before merge:
   ```sh
   gh api repos/esengine/scoop-bucket --jq '{full_name,default_branch,private,html_url}'
   git ls-remote https://github.com/esengine/scoop-bucket.git HEAD
   ```

Current status checked during review: `esengine/scoop-bucket` returns 404, so the README install command and the next stable `v*` CLI release would fail until the setup above is complete.

## How it works

GoReleaser generates a `reasonix.json` manifest from the Windows release archives (`reasonix-windows-amd64.zip`, `reasonix-windows-arm64.zip`) and their SHA256 checksums, then commits it to the bucket repo. Scoop reads this manifest to download and extract the correct binary.

Closes #4326
