### PR TITLE
fix(desktop): resolve session-switch freeze on Windows 11 (#4337)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -71,6 +71,11 @@ type App struct {
 	activeTabID string
 	readyHook   func()
 
+	// tabsSaveMu serializes writes to desktop-tabs.json and its fixed .tmp path.
+	tabsSaveMu             sync.Mutex
+	tabsSaveVersion        uint64 // protected by mu; assigned when collecting a snapshot
+	tabsLastWrittenVersion uint64 // protected by tabsSaveMu
+
 	forceQuit           atomic.Bool
 	backgroundMaximised atomic.Bool
 	trayReady           bool

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1848,10 +1848,10 @@ export default function App() {
 
   const handleTabChange = useCallback(async (id: string) => {
     closeTransientOverlays();
-    await switchTab(id);
-    await refreshTabMetas();
+    const tabs = await switchTab(id);
+    if (tabs) setTabMetas(tabs);
     setTabRevealSignal((signal) => signal + 1);
-  }, [closeTransientOverlays, refreshTabMetas, switchTab]);
+  }, [closeTransientOverlays, setTabMetas, switchTab]);
 
   const handleTabClose = useCallback(async (id: string) => {
     closeTransientOverlays();

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -663,17 +663,17 @@ export function useController() {
     return active.id;
   }, [activeTabFromBackend, loadSessionDataForTab]);
 
-  const reconcileTabRuntime = useCallback(async (tabId: string) => {
+  const reconcileTabRuntime = useCallback(async (tabId: string): Promise<TabMeta[] | undefined> => {
     const tabs = asArray(await app.ListTabs().catch(() => [] as TabMeta[]));
     const tab = tabs.find((candidate) => candidate.id === tabId);
-    if (!tab) return;
+    if (!tab) return undefined;
     const local = statesRef.current.get(tabId);
     const needsInitialLoad = !local?.meta;
     const missedTurnDone = Boolean(local?.running && !tab.running);
     dispatchTo(tabId, { type: "backend_status", running: Boolean(tab.running) });
     if (needsInitialLoad || missedTurnDone) {
       await loadSessionDataForTab(tabId, missedTurnDone);
-      return;
+      return tabs;
     }
     const [jobs, effort, balance] = await Promise.all([
       app.JobsForTab(tabId).catch(() => undefined),
@@ -683,6 +683,7 @@ export function useController() {
     if (jobs) dispatchTo(tabId, { type: "jobs", jobs: asArray(jobs) });
     if (effort) dispatchTo(tabId, { type: "effort", effort });
     if (balance) dispatchTo(tabId, { type: "balance", balance });
+    return tabs;
   }, [dispatchTo, loadSessionDataForTab]);
 
   useEffect(() => {
@@ -1028,13 +1029,14 @@ export function useController() {
   }, [activeTabId, dispatchTo, loadSessionDataForTab, syncActiveTabFromBackend, waitForTabReady]);
 
   // Tab management: switch preserves per-tab state; open creates it.
-  const switchTab = useCallback(async (tabId: string) => {
+  const switchTab = useCallback(async (tabId: string): Promise<TabMeta[] | undefined> => {
     addBreadcrumb("nav", `switch tab ${tabId}`);
     setActiveTabId(tabId);
     try {
       await app.SetActiveTab(tabId);
-      await reconcileTabRuntime(tabId);
+      return await reconcileTabRuntime(tabId);
     } catch { /* ignore */ }
+    return undefined;
   }, [reconcileTabRuntime]);
 
   const openProjectTab = useCallback(async (workspaceRoot: string, topicId: string): Promise<TabMeta> => {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -476,8 +476,21 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 // ListTabs returns every open tab's metadata for the frontend TabBar.
 func (a *App) ListTabs() []TabMeta {
 	a.mu.RLock()
-	defer a.mu.RUnlock()
 	out := make([]TabMeta, 0, len(a.tabs))
+	ordered, needsRepair := a.orderedTabIDsSnapshotLocked()
+	for _, id := range ordered {
+		if tab := a.tabs[id]; tab != nil {
+			out = append(out, a.tabMeta(tab, tab.ID == a.activeTabID))
+		}
+	}
+	a.mu.RUnlock()
+	if !needsRepair {
+		return out
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	out = make([]TabMeta, 0, len(a.tabs))
 	for _, id := range a.orderedTabIDsLocked() {
 		if tab := a.tabs[id]; tab != nil {
 			out = append(out, a.tabMeta(tab, tab.ID == a.activeTabID))
@@ -1375,6 +1388,14 @@ func (a *App) saveTabsWrite(dir string, entries []desktopTabEntry, activeID stri
 }
 
 func (a *App) orderedTabIDsLocked() []string {
+	ordered, needsRepair := a.orderedTabIDsSnapshotLocked()
+	if needsRepair {
+		a.tabOrder = append([]string(nil), ordered...)
+	}
+	return ordered
+}
+
+func (a *App) orderedTabIDsSnapshotLocked() ([]string, bool) {
 	seen := make(map[string]bool, len(a.tabs))
 	ordered := make([]string, 0, len(a.tabs))
 	for _, id := range a.tabOrder {
@@ -1391,10 +1412,7 @@ func (a *App) orderedTabIDsLocked() []string {
 	}
 	sort.Strings(missing)
 	ordered = append(ordered, missing...)
-	if len(ordered) != len(a.tabOrder) || len(missing) > 0 {
-		a.tabOrder = append([]string(nil), ordered...)
-	}
-	return ordered
+	return ordered, len(ordered) != len(a.tabOrder) || len(missing) > 0
 }
 
 func (a *App) removeTabOrderLocked(tabID string) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -475,8 +475,8 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 
 // ListTabs returns every open tab's metadata for the frontend TabBar.
 func (a *App) ListTabs() []TabMeta {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	out := make([]TabMeta, 0, len(a.tabs))
 	for _, id := range a.orderedTabIDsLocked() {
 		if tab := a.tabs[id]; tab != nil {
@@ -798,15 +798,21 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 // already active or unknown.
 func (a *App) SetActiveTab(tabID string) error {
 	a.mu.Lock()
-	defer a.mu.Unlock()
 	if _, ok := a.tabs[tabID]; !ok {
+		a.mu.Unlock()
 		return fmt.Errorf("tab %q not found", tabID)
 	}
 	if a.activeTabID == tabID {
+		a.mu.Unlock()
 		return nil
 	}
 	a.activeTabID = tabID
-	a.saveTabsLocked()
+	dir, entries, activeID, version := a.saveTabsCollectLocked()
+	a.mu.Unlock()
+
+	// I/O outside the lock — disk writes can block for hundreds of ms on
+	// Windows when antivirus or the search indexer briefly locks the file.
+	a.saveTabsWrite(dir, entries, activeID, version)
 	return nil
 }
 
@@ -1307,8 +1313,16 @@ func desktopConfigDir() string {
 }
 
 func (a *App) saveTabsLocked() {
+	dir, entries, activeID, version := a.saveTabsCollectLocked()
+	a.saveTabsWrite(dir, entries, activeID, version)
+}
+
+// saveTabsCollectLocked gathers the tab-snapshot data under the caller's lock
+// (it calls orderedTabIDsLocked which requires a.mu). Returns the config dir,
+// the serializable entries, the active tab ID, and a monotonic snapshot version.
+// The write can happen outside the lock to avoid blocking the UI with disk I/O.
+func (a *App) saveTabsCollectLocked() (string, []desktopTabEntry, string, uint64) {
 	dir := desktopConfigDir()
-	_ = os.MkdirAll(dir, 0o755)
 	var entries []desktopTabEntry
 	for _, id := range a.orderedTabIDsLocked() {
 		if tab := a.tabs[id]; tab != nil {
@@ -1327,12 +1341,37 @@ func (a *App) saveTabsLocked() {
 			})
 		}
 	}
-	f := desktopTabsFile{Tabs: entries, ActiveTab: a.activeTabID}
-	b, _ := json.MarshalIndent(f, "", "  ")
+	a.tabsSaveVersion++
+	return dir, entries, a.activeTabID, a.tabsSaveVersion
+}
+
+// saveTabsWrite writes the tab-snapshot to disk. It does not require a.mu, but
+// writes must be serialized because every save uses the same destination and
+// fixed .tmp path.
+func (a *App) saveTabsWrite(dir string, entries []desktopTabEntry, activeID string, version uint64) {
+	a.tabsSaveMu.Lock()
+	defer a.tabsSaveMu.Unlock()
+	if version < a.tabsLastWrittenVersion {
+		return
+	}
+
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	f := desktopTabsFile{Tabs: entries, ActiveTab: activeID}
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return
+	}
 	path := filepath.Join(dir, tabsFileName)
 	tmp := path + ".tmp"
-	_ = os.WriteFile(tmp, b, 0o644)
-	_ = fileutil.ReplaceFile(tmp, path)
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return
+	}
+	if err := fileutil.ReplaceFile(tmp, path); err != nil {
+		return
+	}
+	a.tabsLastWrittenVersion = version
 }
 
 func (a *App) orderedTabIDsLocked() []string {

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -56,6 +56,23 @@ func TestListTabsKeepsExplicitOrderWhenActiveChanges(t *testing.T) {
 	}
 }
 
+func TestSaveTabsSkipsOlderSnapshot(t *testing.T) {
+	app := testAppWithOrderedTabs(t, "a", "a", "b")
+
+	app.mu.Lock()
+	dir, oldEntries, oldActiveID, oldVersion := app.saveTabsCollectLocked()
+	app.activeTabID = "b"
+	_, newEntries, newActiveID, newVersion := app.saveTabsCollectLocked()
+	app.mu.Unlock()
+
+	app.saveTabsWrite(dir, newEntries, newActiveID, newVersion)
+	app.saveTabsWrite(dir, oldEntries, oldActiveID, oldVersion)
+
+	if got := loadTabsFile().ActiveTab; got != "b" {
+		t.Fatalf("persisted active tab = %q, want b", got)
+	}
+}
+
 func TestReorderTabsPersistsSubmittedOrder(t *testing.T) {
 	app := testAppWithOrderedTabs(t, "a", "a", "b", "c")
 

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -53,6 +54,38 @@ func TestListTabsKeepsExplicitOrderWhenActiveChanges(t *testing.T) {
 	assertTabIDs(t, app.ListTabs(), "a", "b", "c")
 	if got := app.activeTabID; got != "c" {
 		t.Fatalf("active tab = %q, want c", got)
+	}
+}
+
+func TestListTabsRepairsStaleOrderWithoutRacing(t *testing.T) {
+	app := testAppWithOrderedTabs(t, "a", "a", "b", "c")
+	app.tabOrder = []string{"a"}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan string, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 100; j++ {
+				if got := strings.Join(tabIDs(app.ListTabs()), ","); got != "a,b,c" {
+					errs <- got
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for got := range errs {
+		t.Fatalf("tab ids = %q, want a,b,c", got)
+	}
+
+	if got := strings.Join(app.tabOrder, ","); got != "a,b,c" {
+		t.Fatalf("repaired tab order = %q, want a,b,c", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #4337 — switching chat sessions in v1.7.0 caused the entire window to freeze for many seconds on Windows 11.

## Root cause

Three compounding factors, all introduced or worsened in v1.7.0:

1. **`ListTabs` used a write lock (`Lock()`) for a read-heavy operation** — blocked the 2-second polling timer and user tab switches from proceeding concurrently.

2. **`SetActiveTab` held the write lock across disk I/O** — `saveTabsLocked()` called `os.MkdirAll` + `os.WriteFile` + `fileutil.ReplaceFile` (which can retry transient Windows locks) all while holding `a.mu.Lock()`.

3. **`handleTabChange` called `ListTabs` twice in sequence** — once inside `switchTab` → `reconcileTabRuntime`, and once more via `refreshTabMetas`.

## Changes

| # | Change | File | Impact |
|---|--------|------|--------|
| 1 | `ListTabs` now uses an `RLock` read-only fast path and reacquires `Lock` only when stale tab order needs repair | `desktop/tabs.go` | Reduces polling/switch contention without writing shared state under a read lock |
| 2 | Split `saveTabsLocked` into collect-phase (under `mu`) + write-phase (outside `mu`); `SetActiveTab` unlocks before I/O | `desktop/tabs.go` | Disk I/O no longer blocks UI; added `tabsSaveMu` + version stamping to prevent stale snapshot races |
| 3 | `reconcileTabRuntime` returns `TabMeta[]`, `switchTab` propagates it, `handleTabChange` reuses it for `setTabMetas` | `useController.ts`, `App.tsx` | One `ListTabs` call instead of two per tab switch |
| 4 | Added stale-order and stale-snapshot regression tests | `tabs_order_test.go` | Verifies concurrent `ListTabs` does not race and older snapshots do not overwrite newer saves |

## Verification

- `go test . -run 'Test(ListTabsKeepsExplicitOrderWhenActiveChanges|ListTabsRepairsStaleOrderWithoutRacing|SaveTabsSkipsOlderSnapshot)' -count=1` — clean
- `go test -race . -run TestListTabsRepairsStaleOrderWithoutRacing -count=1` — clean
- `go test -race . -run TestSaveTabsSkipsOlderSnapshot -count=1` — clean
- `go test . -count=1 -timeout=120s` — clean
- `git diff --check` — clean
