### PR TITLE
Fix CodeGraph idle timeout launch paths / 修复 CodeGraph 启动路径空闲超时

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -292,20 +292,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
 				Text: "codegraph: project root is a filesystem root — skipped to avoid indexing the whole volume"})
 		case ok:
-			spec := plugin.Spec{
-				Name:           "codegraph",
-				StripRawPrefix: "codegraph_",
-				Command:        bin,
-				Args:           []string{"serve", "--mcp"},
-				Env: map[string]string{
-					codegraph.DaemonIdleTimeoutEnv: codegraph.ReasonixDaemonIdleTimeoutMS,
-				},
-				Dir:               root,
-				ReadOnlyToolNames: codegraph.ReadOnlyToolNames(),
-				// The daemon walks and indexes the whole tree; below-normal
-				// priority keeps it from starving the user's machine (#3797).
-				LowPriority: true,
-			}
+			spec := codegraph.MCPSpec(bin, root)
 			warm := codegraph.Initialized(root)
 			if err := codegraph.EnsureInit(ctx, bin, root); err != nil {
 				sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn,
@@ -783,15 +770,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				if err := codegraph.EnsureInit(ctx, bin, root); err != nil {
 					return "", fmt.Errorf("codegraph init: %w", err)
 				}
-				spec := plugin.Spec{
-					Name:              "codegraph",
-					StripRawPrefix:    "codegraph_",
-					Command:           bin,
-					Args:              []string{"serve", "--mcp"},
-					Dir:               root,
-					ReadOnlyToolNames: codegraph.ReadOnlyToolNames(),
-					LowPriority:       true,
-				}
+				spec := codegraph.MCPSpec(bin, root)
 				if opts.Stderr != nil {
 					spec.Stderr = opts.Stderr
 				}

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1003,6 +1003,65 @@ model = "x"
 	}
 }
 
+func TestBuildTokenEconomyCodegraphSetsShortDaemonIdleTimeout(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	launcher := writeCodegraphHelper(t, dir)
+	envOut := filepath.Join(dir, "codegraph-idle-env")
+	t.Setenv("REASONIX_CODEGRAPH_HELPER_ENV_OUT", envOut)
+
+	registerBootTokenProfileTestProvider()
+	prov := testutil.NewMock("token-economy",
+		testutil.Turn{ToolCalls: []provider.ToolCall{
+			{ID: "source-1", Name: "connect_tool_source", Arguments: `{"source":"codegraph"}`},
+		}},
+		testutil.Turn{Text: "done"},
+	)
+	setBootTokenProfileTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", fmt.Sprintf(`
+default_model = "test-model"
+
+[codegraph]
+enabled = true
+path = %q
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-token-profile-test"
+model = "x"
+`, launcher))
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard, TokenMode: TokenModeEconomy})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if err := ctrl.Run(context.Background(), "enable codegraph later"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := prov.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("requests = %d, want 2", len(reqs))
+	}
+	if requestHasToolPrefix(reqs[0], "mcp__codegraph__") {
+		t.Fatalf("first request should hide codegraph; tools=%v", toolSchemaNames(reqs[0].Tools))
+	}
+	if !requestHasToolPrefix(reqs[1], "mcp__codegraph__") {
+		t.Fatalf("second request should expose codegraph after connect_tool_source; tools=%v", toolSchemaNames(reqs[1].Tools))
+	}
+	got, err := os.ReadFile(envOut)
+	if err != nil {
+		t.Fatalf("read codegraph idle timeout env: %v", err)
+	}
+	if string(got) != codegraph.ReasonixDaemonIdleTimeoutMS {
+		t.Fatalf("%s = %q; want %q", codegraph.DaemonIdleTimeoutEnv, got, codegraph.ReasonixDaemonIdleTimeoutMS)
+	}
+}
+
 func TestBuildTokenEconomyPlanModeCanConnectWebFetch(t *testing.T) {
 	isolateConfigHome(t)
 	dir := robustTempDir(t)

--- a/internal/codegraph/spec.go
+++ b/internal/codegraph/spec.go
@@ -1,0 +1,24 @@
+package codegraph
+
+import "reasonix/internal/plugin"
+
+// MCPSpec returns the built-in CodeGraph MCP plugin spec used by every Reasonix
+// launch path. Keeping this in one place prevents lifecycle env overrides from
+// drifting between boot, token-economy on-demand enablement, and manual MCP
+// reconnects.
+func MCPSpec(bin, root string) plugin.Spec {
+	return plugin.Spec{
+		Name:           "codegraph",
+		StripRawPrefix: "codegraph_",
+		Command:        bin,
+		Args:           []string{"serve", "--mcp"},
+		Env: map[string]string{
+			DaemonIdleTimeoutEnv: ReasonixDaemonIdleTimeoutMS,
+		},
+		Dir:               root,
+		ReadOnlyToolNames: ReadOnlyToolNames(),
+		// The daemon walks and indexes the whole tree; below-normal priority keeps
+		// it from starving the user's machine (#3797).
+		LowPriority: true,
+	}
+}

--- a/internal/codegraph/spec_test.go
+++ b/internal/codegraph/spec_test.go
@@ -1,0 +1,22 @@
+package codegraph
+
+import "testing"
+
+func TestMCPSpecSetsReasonixDaemonIdleTimeout(t *testing.T) {
+	spec := MCPSpec("/tmp/codegraph", "/tmp/project")
+	if spec.Name != "codegraph" {
+		t.Fatalf("Name = %q, want codegraph", spec.Name)
+	}
+	if spec.StripRawPrefix != "codegraph_" {
+		t.Fatalf("StripRawPrefix = %q, want codegraph_", spec.StripRawPrefix)
+	}
+	if got := spec.Env[DaemonIdleTimeoutEnv]; got != ReasonixDaemonIdleTimeoutMS {
+		t.Fatalf("%s = %q, want %q", DaemonIdleTimeoutEnv, got, ReasonixDaemonIdleTimeoutMS)
+	}
+	if !spec.LowPriority {
+		t.Fatal("LowPriority = false, want true")
+	}
+	if !spec.ReadOnlyToolNames["codegraph_search"] {
+		t.Fatal("ReadOnlyToolNames missing codegraph_search")
+	}
+}

--- a/internal/control/codegraph_test.go
+++ b/internal/control/codegraph_test.go
@@ -1,0 +1,164 @@
+package control
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"reasonix/internal/codegraph"
+	"reasonix/internal/plugin"
+)
+
+func TestConnectConfiguredCodegraphSetsShortDaemonIdleTimeout(t *testing.T) {
+	isolateControlConfigHome(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	launcher := writeControlCodegraphHelper(t, dir)
+	envOut := filepath.Join(dir, "codegraph-idle-env")
+	t.Setenv("REASONIX_CODEGRAPH_HELPER_ENV_OUT", envOut)
+	writeControlFile(t, dir, "reasonix.toml", `
+[codegraph]
+enabled = true
+path = "`+escapeTOMLPath(launcher)+`"
+`)
+
+	ctrl := New(Options{Host: plugin.NewHost()})
+	defer ctrl.Close()
+	if _, err := ctrl.ConnectConfiguredMCPServer("codegraph"); err != nil {
+		t.Fatalf("ConnectConfiguredMCPServer(codegraph): %v", err)
+	}
+
+	got, err := os.ReadFile(envOut)
+	if err != nil {
+		t.Fatalf("read codegraph idle timeout env: %v", err)
+	}
+	if string(got) != codegraph.ReasonixDaemonIdleTimeoutMS {
+		t.Fatalf("%s = %q; want %q", codegraph.DaemonIdleTimeoutEnv, got, codegraph.ReasonixDaemonIdleTimeoutMS)
+	}
+	if !ctrl.DisconnectMCPServer("codegraph") {
+		t.Fatal("DisconnectMCPServer(codegraph) returned false")
+	}
+	time.Sleep(100 * time.Millisecond)
+}
+
+func isolateControlConfigHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	xdg := filepath.Join(home, ".config")
+	appData := filepath.Join(home, "AppData")
+	if err := os.MkdirAll(xdg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(appData, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("AppData", appData)
+}
+
+func writeControlCodegraphHelper(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "codegraph-helper")
+	if runtime.GOOS == "windows" {
+		path += ".exe"
+	}
+	src := filepath.Join(dir, "codegraph-helper.go")
+	if err := os.WriteFile(src, []byte(`package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+func main() {
+	if len(os.Args) >= 3 && os.Args[1] == "init" {
+		_ = os.MkdirAll(filepath.Join(os.Args[2], ".codegraph"), 0o755)
+		return
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		if out := os.Getenv("REASONIX_CODEGRAPH_HELPER_ENV_OUT"); out != "" {
+			_ = os.WriteFile(out, []byte(os.Getenv("CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS")), 0o644)
+		}
+	}
+
+	in := bufio.NewReader(os.Stdin)
+	for {
+		line, err := in.ReadBytes('\n')
+		if err != nil {
+			return
+		}
+		line = bytes.TrimSpace(line)
+		if len(line) == 0 {
+			continue
+		}
+
+		var req struct {
+			ID     *int            `+"`json:\"id\"`"+`
+			Method string          `+"`json:\"method\"`"+`
+			Params json.RawMessage `+"`json:\"params\"`"+`
+		}
+		if err := json.Unmarshal(line, &req); err != nil || req.ID == nil {
+			continue
+		}
+
+		var result any
+		switch req.Method {
+		case "initialize":
+			result = map[string]any{
+				"protocolVersion": "2024-11-05",
+				"serverInfo":      map[string]any{"name": "codegraph", "version": "0"},
+				"capabilities":    map[string]any{},
+			}
+		case "tools/list":
+			result = map[string]any{"tools": []map[string]any{{
+				"name":        "search",
+				"description": "Search symbols.",
+				"inputSchema": map[string]any{"type": "object"},
+			}}}
+		}
+
+		resp := map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": result}
+		b, _ := json.Marshal(resp)
+		_, _ = os.Stdout.Write(append(b, '\n'))
+	}
+}
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.CommandContext(context.Background(), "go", "build", "-o", path, src)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("build codegraph helper: %v\n%s", err, out)
+	}
+	return path
+}
+
+func writeControlFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(name))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func escapeTOMLPath(path string) string {
+	escaped := ""
+	for _, r := range path {
+		if r == '\\' || r == '"' {
+			escaped += "\\"
+		}
+		escaped += string(r)
+	}
+	return escaped
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2414,13 +2414,7 @@ func (c *Controller) connectCodegraphMCPServer(cfg *config.Config) (int, error) 
 	if err := codegraph.EnsureInit(c.pluginCtx, bin, cwd); err != nil {
 		return 0, fmt.Errorf("codegraph init: %w", err)
 	}
-	return c.connectMCPSpec(plugin.Spec{
-		Name:              "codegraph",
-		Command:           bin,
-		Args:              []string{"serve", "--mcp"},
-		Dir:               cwd,
-		ReadOnlyToolNames: codegraph.ReadOnlyToolNames(),
-	})
+	return c.connectMCPSpec(codegraph.MCPSpec(bin, cwd))
 }
 
 // RemoveMCPServer disconnects a live MCP server — its tools vanish from the next


### PR DESCRIPTION
## Summary
- add a shared CodeGraph built-in MCP spec helper with the Reasonix daemon idle-timeout env
- use it for normal boot, token-economy on-demand CodeGraph, and manual CodeGraph MCP reconnects
- cover the helper plus token-economy and controller launch paths with focused tests

## Verification
- go test ./internal/codegraph -run TestMCPSpecSetsReasonixDaemonIdleTimeout -count=1
- go test ./internal/boot -run 'TestBuild(CodegraphSetsShortDaemonIdleTimeout|TokenEconomyCodegraphSetsShortDaemonIdleTimeout)' -count=1
- go test ./internal/control -run TestConnectConfiguredCodegraphSetsShortDaemonIdleTimeout -count=1
- go test ./internal/codegraph ./internal/boot ./internal/control -count=1
- git diff --check

Fixes follow-up from #4332 discussion_r3409168127.