### PR TITLE
fix(desktop): topicbar 复制按钮改用 Tooltip 气泡提示

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -9,6 +9,8 @@ gsap.registerPlugin(useGSAP, Flip, ScrollToPlugin);
 import {
   Activity,
   Command,
+  Copy,
+  Check,
   Download,
   SquarePen,
   FileDown,
@@ -838,6 +840,7 @@ export default function App() {
   const [renamingTopicId, setRenamingTopicId] = useState<string | null>(null);
   const [topicTitleDraft, setTopicTitleDraft] = useState("");
   const [topicExportOpen, setTopicExportOpen] = useState(false);
+  const [sessionCopied, setSessionCopied] = useState(false);
   const [sidebarTogglePressed, setSidebarTogglePressed] = useState(false);
   const [workspaceTogglePressed, setWorkspaceTogglePressed] = useState(false);
   const [clearContextPending, setClearContextPending] = useState(false);
@@ -2573,11 +2576,22 @@ export default function App() {
             <div className="topicbar__actions">
               {!sidebarImDetailConnection && (
               <>
-              <CopyButton
-                getText={getSessionMarkdown}
-                label={t("topicBar.copyAll")}
-                className="topicbar__action-btn topicbar__action-btn--icon topicbar__action-btn--utility"
-              />
+              <Tooltip label={sessionCopied ? t("msg.copied") : t("topicBar.copyAll")}>
+                <button
+                  className="topicbar__action-btn topicbar__action-btn--icon topicbar__action-btn--utility"
+                  type="button"
+                  aria-label={t("topicBar.copyAll")}
+                  onClick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(getSessionMarkdown());
+                      setSessionCopied(true);
+                      setTimeout(() => setSessionCopied(false), 1200);
+                    } catch { /* clipboard unavailable */ }
+                  }}
+                >
+                  {sessionCopied ? <Check size={14} /> : <Copy size={14} />}
+                </button>
+              </Tooltip>
               <div className={`topicbar__export${topicExportOpen ? " topicbar__export--open" : ""}`}>
                 <Tooltip label={t("topicBar.export")}>
                   <button


### PR DESCRIPTION
## 问题描述

Topicbar 的复制按钮使用 CopyButton 组件，hover 时显示内联文字（`.copybtn__label-inline`），而旁边的导出按钮使用 Tooltip 显示气泡提示，风格不一致。

## 修复方案

将 topicbar 的 CopyButton 替换为 Tooltip + button，和旁边导出按钮风格一致：

- hover 显示气泡提示（"Copy All" / "已复制"）
- 复制后图标切换为 ✓，1.2 秒后恢复
- 按钮样式和旁边导出按钮完全一致

## 涉及文件

| 文件 | 改动 |
|------|------|
| `App.tsx` | 替换 CopyButton 为 Tooltip + button |

Fixes #4338
<img width="408" height="168" alt="3" src="https://github.com/user-attachments/assets/ff9583ea-7d3d-44d6-87b4-c2f419419fda" />
