### PR TITLE
Improve runtime metric token layout / 优化运行指标 token 布局

### DIFF
--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -289,9 +289,9 @@ export function ContextPanel({
           <section className="context-panel__section">
             <SectionHeading title={t("context.runtimeMetrics")} />
             <div className="context-panel__stats">
-              <MetricCard label={t("context.sessionTokens")} value={totalTokens > 0 ? totalTokens.toLocaleString() : "-"} />
-              <MetricCard label={t("context.requests")} value={requestCount > 0 ? String(requestCount) : "-"} />
               <MetricCard label={t("context.time")} value={fmtDuration(elapsed, t)} />
+              <MetricCard label={t("context.requests")} value={requestCount > 0 ? String(requestCount) : "-"} />
+              <MetricCard label={t("context.sessionTokens")} value={totalTokens > 0 ? totalTokens.toLocaleString() : "-"} wide />
             </div>
           </section>
           <section className="context-panel__section">
@@ -393,10 +393,11 @@ function TokenLegend({ label, value, color }: { label: string; value: number; co
   );
 }
 
-function MetricCard({ label, value, tone }: { label: string; value: string; tone?: "accent" | "good" | "notice" | "warn" }) {
+function MetricCard({ label, value, tone, wide }: { label: string; value: string; tone?: "accent" | "good" | "notice" | "warn"; wide?: boolean }) {
   const toneClass = tone ? ` context-panel__metric--${tone}` : "";
+  const wideClass = wide ? " context-panel__metric--wide" : "";
   return (
-    <div className={`context-panel__metric${toneClass}`}>
+    <div className={`context-panel__metric${toneClass}${wideClass}`}>
       <span>{label}</span>
       <strong>{value}</strong>
     </div>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -16696,6 +16696,10 @@ a[href] {
   grid-column: 1 / -1;
 }
 
+.context-panel__metric--wide {
+  grid-column: 1 / -1;
+}
+
 .context-panel__metric {
   min-height: 54px;
   min-width: 0;


### PR DESCRIPTION
## Summary
- Move elapsed time and request count into the compact runtime metrics row.
- Give session tokens an explicit full-width metric card so large token totals stay readable.
- Keep the layout intent durable with a reusable wide metric card class.

## Verification
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/context-panel-breakdown.test.ts`
- `git diff --check`
- Attempted `pnpm --dir desktop/frontend typecheck`; it is blocked in this local checkout by missing generated Wails bindings and an existing bridge type constraint.

Authorship note: @SivanCola contributed the layout decision and review direction.