### PR TITLE
fix(desktop): 搜索按钮宽度增大到 120px 防止内容截断

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14867,9 +14867,9 @@ a[href] {
 
 .app--windows .app-chrome--native-tabs .tabbar__command--compact,
 .app--linux .app-chrome--native-tabs .tabbar__command--compact {
-  flex: 0 0 112px;
-  width: 112px;
-  min-width: 112px;
+  flex: 0 0 120px;
+  width: 120px;
+  min-width: 120px;
 }
 
 .workspace-tabs-bar {
@@ -15497,10 +15497,10 @@ a[href] {
 }
 
 .tabbar__command--compact {
-  flex: 0 0 112px;
-  width: 112px;
-  min-width: 112px;
-  max-width: 112px;
+  flex: 0 0 120px;
+  width: 120px;
+  min-width: 120px;
+  max-width: 120px;
   justify-content: center;
   gap: 6px;
   padding: 0 9px;
@@ -18003,10 +18003,10 @@ a[href] {
 }
 
 :root[data-theme-style] .tabbar__command--compact {
-  width: 112px;
-  min-width: 112px;
-  max-width: 112px;
-  flex: 0 0 112px;
+  width: 120px;
+  min-width: 120px;
+  max-width: 120px;
+  flex: 0 0 120px;
   justify-content: center;
   gap: 6px;
   padding: 0 9px;
@@ -18074,9 +18074,9 @@ a[href] {
   }
 
   :root[data-theme-style] .tabbar__command--compact {
-    width: 104px;
-    min-width: 104px;
-    flex-basis: 104px;
+    width: 112px;
+    min-width: 112px;
+    flex-basis: 112px;
     padding: 0 8px;
   }
 }


### PR DESCRIPTION
## 问题描述

Compact 模式下搜索按钮固定 112px，内容（图标 13px + 文字 max 48px + 快捷键 min 30px）约 115px，溢出被截断导致显示不全。

## 修复方案

将搜索按钮宽度从 112px 增大到 120px，响应式断点从 104px 增大到 112px。

## 涉及文件

| 文件 | 改动 |
|------|------|
| `styles.css` | 4 处 compact command 宽度 112px → 120px |

Fixes #4302
<img width="390" height="255" alt="4" src="https://github.com/user-attachments/assets/0bfab44a-5d22-48e0-8d15-dd90ee14e65a" />
