### PR TITLE
Document headless bot gateway usage / 补充无界面 Bot 网关说明

### DIFF
--- a/docs/BOT_GUIDE.md
+++ b/docs/BOT_GUIDE.md
@@ -14,6 +14,7 @@
 
 - [What the bot does](#what-the-bot-does)
 - [Connect the three channels](#connect-the-three-channels)
+- [Run the bot headlessly](#run-the-bot-headlessly)
 - [Usage flow](#usage-flow)
 - [Channel interaction differences](#channel-interaction-differences)
 - [Command quick reference](#command-quick-reference)
@@ -86,6 +87,44 @@ approval modes.
 
 WeChat does not provide interactive card buttons here, so approvals and Ask
 questions are handled through text commands.
+
+## Run the bot headlessly
+
+The desktop app is the easiest way to create and test bot connections, but the
+runtime itself can also run as a long-lived headless gateway:
+
+```sh
+reasonix bot doctor
+reasonix bot start --channels feishu,lark,weixin --dir /path/to/project
+```
+
+Use `--channels` to choose which configured IM inputs to accept. `feishu` and
+`lark` select the matching Feishu-family connection; `weixin` selects the saved
+WeChat iLink account; `qq` selects the configured QQ bot. Use `--dir` to attach
+incoming messages to a project workspace and `--model` to override the default
+model for this process.
+
+The headless gateway uses the same config records as the desktop app:
+
+- `[[bot.connections]]` identifies each IM input. `provider` is the adapter
+  family (`feishu`, `weixin`, or `qq`), while `domain` distinguishes variants
+  such as Feishu vs Lark.
+- `credential.app_id`, `credential.app_secret_env`, `credential.account_id`,
+  and `credential.token_env` point to app IDs, app secrets, saved accounts, and
+  tokens. Secrets stay in environment variables or the Reasonix user credentials
+  store.
+- `workspace_root`, `model`, and `tool_approval_mode` can be set per
+  connection. This lets different IM channels route to different local projects
+  or approval postures.
+- `session_mappings` are filled from inbound messages. They store the remote
+  chat ID and the local Reasonix session ID so the desktop UI can open the
+  matching conversation later.
+
+Access control is still mandatory. Either enable an allowlist under
+`[bot.allowlist]` for the relevant platform user IDs / group IDs, or set
+`allow_all = true` deliberately. Remote users go through the same controller,
+permission policy, tool approval mode, and sandbox rules as local desktop or CLI
+turns.
 
 ## Usage flow
 

--- a/docs/BOT_GUIDE.md
+++ b/docs/BOT_GUIDE.md
@@ -116,15 +116,17 @@ The headless gateway uses the same config records as the desktop app:
 - `workspace_root`, `model`, and `tool_approval_mode` can be set per
   connection. This lets different IM channels route to different local projects
   or approval postures.
-- `session_mappings` are filled from inbound messages. They store the remote
-  chat ID and the local Reasonix session ID so the desktop UI can open the
-  matching conversation later.
+- `session_mappings` are filled from inbound messages with the remote chat ID
+  and scope. The desktop UI can open the matching conversation once the mapping
+  also has a local `session_id` target, such as a saved `path:` session target
+  from a desktop-managed bot runtime or a manually configured mapping.
 
 Access control is still mandatory. Either enable an allowlist under
-`[bot.allowlist]` for the relevant platform user IDs / group IDs, or set
-`allow_all = true` deliberately. Remote users go through the same controller,
-permission policy, tool approval mode, and sandbox rules as local desktop or CLI
-turns.
+`[bot.allowlist]` with at least one relevant platform user ID, or set
+`allow_all = true` deliberately. Group IDs are optional additional scoping for
+group chats; they do not replace the required user allowlist. Remote users go
+through the same controller, permission policy, tool approval mode, and sandbox
+rules as local desktop or CLI turns.
 
 ## Usage flow
 

--- a/docs/BOT_GUIDE.zh-CN.md
+++ b/docs/BOT_GUIDE.zh-CN.md
@@ -13,6 +13,7 @@
 
 - [能做什么](#能做什么)
 - [连接三个渠道](#连接三个渠道)
+- [无界面运行 Bot](#无界面运行-bot)
 - [使用流程](#使用流程)
 - [三种渠道的交互差异](#三种渠道的交互差异)
 - [命令速查](#命令速查)
@@ -81,6 +82,38 @@ flowchart LR
 5. 给微信 Bot 发送消息。
 
 微信没有交互卡片按钮，因此审批和问答主要通过文字命令完成。
+
+## 无界面运行 Bot
+
+桌面端是创建和测试 Bot 连接最简单的入口，但 Bot 运行时也可以作为长期运行的
+无界面网关启动：
+
+```sh
+reasonix bot doctor
+reasonix bot start --channels feishu,lark,weixin --dir /path/to/project
+```
+
+`--channels` 用来选择接受哪些已配置的 IM 输入。`feishu` 和 `lark` 会选择对应
+飞书系连接，`weixin` 会选择已保存的微信 iLink 账号，`qq` 会选择已配置的 QQ
+Bot。`--dir` 用来把远端消息绑定到某个项目工作区，`--model` 可以为这个进程
+临时覆盖默认模型。
+
+无界面网关复用桌面端保存的同一套配置：
+
+- `[[bot.connections]]` 标识每个 IM 输入。`provider` 是适配器类型
+  （`feishu`、`weixin` 或 `qq`），`domain` 用来区分飞书和 Lark 等变体。
+- `credential.app_id`、`credential.app_secret_env`、`credential.account_id`
+  和 `credential.token_env` 指向应用 ID、应用密钥、保存的账号或 token。
+  密钥仍保存在环境变量或 Reasonix 用户凭据中。
+- `workspace_root`、`model` 和 `tool_approval_mode` 可以按连接单独设置，
+  因此不同 IM 渠道可以路由到不同本地项目或审批模式。
+- `session_mappings` 会根据收到的远端消息自动填充，记录远端 chat ID 和
+  本地 Reasonix 会话 ID，之后桌面端就能打开对应会话。
+
+访问控制仍然是必需项。你需要在 `[bot.allowlist]` 下为对应平台配置用户 ID /
+群 ID 白名单，或者有意设置 `allow_all = true`。远端用户进入的是同一个
+Reasonix controller、权限策略、工具审批模式和沙盒边界，和本地桌面端或 CLI
+回合一致。
 
 ## 使用流程
 

--- a/docs/BOT_GUIDE.zh-CN.md
+++ b/docs/BOT_GUIDE.zh-CN.md
@@ -107,13 +107,15 @@ Bot。`--dir` 用来把远端消息绑定到某个项目工作区，`--model` �
   密钥仍保存在环境变量或 Reasonix 用户凭据中。
 - `workspace_root`、`model` 和 `tool_approval_mode` 可以按连接单独设置，
   因此不同 IM 渠道可以路由到不同本地项目或审批模式。
-- `session_mappings` 会根据收到的远端消息自动填充，记录远端 chat ID 和
-  本地 Reasonix 会话 ID，之后桌面端就能打开对应会话。
+- `session_mappings` 会根据收到的远端消息自动填充远端 chat ID 和作用域。
+  只有当该映射同时具备本地 `session_id` 目标时，桌面端才能打开对应会话；
+  例如桌面端托管的 Bot runtime 保存了 `path:` 会话目标，或用户手动配置了
+  映射目标。
 
-访问控制仍然是必需项。你需要在 `[bot.allowlist]` 下为对应平台配置用户 ID /
-群 ID 白名单，或者有意设置 `allow_all = true`。远端用户进入的是同一个
-Reasonix controller、权限策略、工具审批模式和沙盒边界，和本地桌面端或 CLI
-回合一致。
+访问控制仍然是必需项。你需要在 `[bot.allowlist]` 下为对应平台至少配置一个
+用户 ID，或者有意设置 `allow_all = true`。群 ID 是群聊里的额外收窄条件，
+不能替代用户白名单。远端用户进入的是同一个 Reasonix controller、权限策略、
+工具审批模式和沙盒边界，和本地桌面端或 CLI 回合一致。
 
 ## 使用流程
 


### PR DESCRIPTION
## Summary
- Add English and Chinese Bot Guide sections for `reasonix bot start`.
- Document channel selection, per-connection config, credentials, session mappings, and allowlist requirements for headless IM operation.
- Clarify how existing Feishu/Lark/WeChat/QQ bot inputs map to the local Reasonix controller and result callbacks.

Refs #4371.

## Tests
- Not run; documentation-only change.
