### PR TITLE
perf: reduce layer paints and remove streaming cursor

### DIFF
--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import { memo, useLayoutEffect, useMemo, useRef } from "react";
+import { memo, useMemo, useRef } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -18,56 +18,6 @@ import { openExternal } from "../lib/bridge";
 // delimiters to the $/$$ syntax remark-math understands, gates single-$
 // pairs through a classifier to avoid false positives on $5, $PATH, etc.,
 // and runs KaTeX-specific normalisations (text-mode escapes, |→\vert).
-
-const STREAMING_CURSOR_CLASS = "cursor";
-
-/**
- * Find the deepest last-element child of `container` that can hold inline
- * content.  Walks `lastElementChild` recursively, stopping at `<pre>` blocks
- * and void elements.  O(depth) — far cheaper than a full tree walker.
- */
-function deepestLastInlineElement(container: HTMLElement): HTMLElement {
-  let target: HTMLElement = container;
-  while (target.lastElementChild) {
-    const last = target.lastElementChild as HTMLElement;
-    const tag = last.tagName;
-    if (tag === "PRE" || tag === "BR" || tag === "HR" || tag === "IMG") break;
-    target = last;
-  }
-  return target;
-}
-
-// Inject a blinking cursor span at the end of the last inline content node
-// inside the container, skipping code blocks entirely.  Called from
-// useLayoutEffect so the cursor appears synchronously before paint.
-//
-// Optimisation: during streaming the cursor is usually already in the right
-// place (React updates text in-place within the same element), so we check
-// position first and skip the DOM mutation entirely when nothing moved.
-function injectStreamingCursor(container: HTMLElement): void {
-  const target = deepestLastInlineElement(container);
-
-  // Check whether the cursor is already correctly positioned.
-  const existing = container.querySelector(`.${STREAMING_CURSOR_CLASS}`);
-  if (existing && existing.parentElement === target && target.lastChild === existing) {
-    return; // still at the end — nothing to do.
-  }
-
-  // Remove stale cursor (if any).
-  if (existing) existing.remove();
-
-  // Insert at the new position.
-  const cursor = document.createElement("span");
-  cursor.className = STREAMING_CURSOR_CLASS;
-  cursor.dataset.streamingCursor = "true";
-  target.appendChild(cursor);
-}
-
-function removeStreamingCursor(container: HTMLElement): void {
-  container
-    .querySelectorAll(`.${STREAMING_CURSOR_CLASS}`)
-    .forEach((el) => el.remove());
-}
 
 const components: Components = {
   pre: ({ children }) => <>{children}</>,
@@ -102,26 +52,10 @@ const components: Components = {
 
 export const Markdown = memo(function Markdown({
   text,
-  showCursor,
 }: {
   text: string;
-  showCursor?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-
-  // Inject / remove cursor after every React render cycle so the cursor
-  // always sits at the tail of the current streaming content — without
-  // ever touching the raw Markdown string that ReactMarkdown parses.
-  useLayoutEffect(() => {
-    const el = containerRef.current;
-    if (!el) return;
-    if (showCursor) {
-      injectStreamingCursor(el);
-    } else {
-      removeStreamingCursor(el);
-    }
-  });
-
   const mathContent = useMemo(() => normalizeMath(text), [text]);
   return (
     <div className="md" ref={containerRef}>

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -426,7 +426,7 @@ export const AssistantMessage = memo(function AssistantMessage({
       )}
       {hasText && (
         <div className="msg__body">
-          <Markdown text={item.text} showCursor={item.streaming} />
+          <Markdown text={item.text} />
         </div>
       )}
     </div>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2748,6 +2748,8 @@ a[href] {
 /* ── TurnCollapse: fold line for completed steps ──────────────────── */
 .turn-collapse {
   margin: 4px auto;
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 36px;
 }
 .turn-collapse__label {
   white-space: nowrap;
@@ -3033,6 +3035,8 @@ a[href] {
   margin: 18px auto;
   user-select: text;
   -webkit-user-select: text;
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 60px;
 }
 .msg--user {
   display: flex;
@@ -3332,6 +3336,8 @@ a[href] {
   box-sizing: border-box;
   margin: 6px auto;
   overflow: hidden;
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 36px;
 }
 /* T1: a tone-colored sweep bar along the bottom while the card is running
    (running cards render a .process-card__spin status icon). */
@@ -3577,37 +3583,6 @@ a[href] {
   line-height: 1.7;
   white-space: pre-wrap;
 }
-/* live bubble while the answer streams — markdown renders in real time */
-.msg__stream {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-.msg__cursor {
-  display: inline-block;
-  width: 7px;
-  height: 1.05em;
-  margin-top: 4px;
-  background: var(--accent);
-  vertical-align: text-bottom;
-  animation: blink 1.05s steps(2, start) infinite;
-}
-.cursor {
-  display: inline-block;
-  width: 7px;
-  height: 1.05em;
-  margin-left: 2px;
-  background: var(--accent);
-  vertical-align: text-bottom;
-  animation: blink 1.05s steps(2, start) infinite;
-}
-@keyframes blink {
-  to {
-    visibility: hidden;
-  }
-}
-
-/* ── markdown prose ──────────────────────────────────────────────────────── */
 .md > :first-child {
   margin-top: 0;
 }
@@ -3857,6 +3832,8 @@ a[href] {
 .tool {
   margin: 6px auto;
   overflow: hidden;
+  content-visibility: auto;
+  contain-intrinsic-size: 1px 36px;
 }
 .tool__head {
   display: flex;
@@ -18683,11 +18660,6 @@ a[href] {
   color: var(--fg);
   font-size: 14px;
   line-height: 1.85;
-}
-
-:root[data-theme-style] .msg__cursor {
-  background: var(--accent);
-  border-radius: 2px;
 }
 
 :root[data-theme-style] .process-card,


### PR DESCRIPTION
### Changes

1. **content-visibility: auto** on .msg / .tool / .turn-collapse / .process-card
   - Off-screen elements skip paint → layer texture memory drops from ~97 MB to only the visible viewport
   - Paint count no longer grows linearly with session length

2. **Remove streaming cursor**
   - Remove the blink-animated cursor injected by Markdown.tsx into streaming output
   - Each blink triggered a full document paint — root cause of frequent flicker and high layer memory

### Files changed
- desktop/frontend/src/styles.css — content-visibility rules + cursor/blink keyframe cleanup
- desktop/frontend/src/components/Markdown.tsx — removed cursor injection/removal functions, showCursor prop, useLayoutEffect
- desktop/frontend/src/components/Message.tsx — removed showCursor={item.streaming}