### PR TITLE
Fix desktop tab event deadlock / 修复桌面多标签事件死锁

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -106,6 +106,8 @@ type App struct {
 
 	metrics atomic.Pointer[metricsAggregator] // non-nil only when desktop.metrics is opted in; swapped live by SetDesktopMetrics
 
+	runtimeEvents asyncRuntimeEmitter
+
 	// promptHistoryTape is a lazy, cursor-addressed view of prompt history. It
 	// stores session order and per-session parsed entries only after that session is
 	// reached by ↑ navigation. See ScanPromptHistory.

--- a/desktop/tab_event_sink_test.go
+++ b/desktop/tab_event_sink_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+func TestTabEventSinkDoesNotBlockOnRuntimeEventsEmit(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	delivered := make(chan string, 2)
+	var calls atomic.Int32
+
+	sink := &tabEventSink{tabID: "tab", ctx: context.Background()}
+	sink.runtimeEvents.emit = func(_ context.Context, name string, payload ...interface{}) {
+		if name != eventChannel {
+			t.Errorf("event name = %q, want %q", name, eventChannel)
+		}
+		if len(payload) != 1 {
+			t.Errorf("payload count = %d, want 1", len(payload))
+			return
+		}
+		wire, ok := payload[0].(wireEventTab)
+		if !ok {
+			t.Errorf("payload type = %T, want wireEventTab", payload[0])
+			return
+		}
+		delivered <- wire.Text
+		if calls.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+	}
+
+	wrapped := event.Sync(sink)
+	wrapped.Emit(event.Event{Kind: event.Text, Text: "one"})
+
+	select {
+	case <-entered:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first runtime emit did not start")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wrapped.Emit(event.Event{Kind: event.Text, Text: "two"})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("second event blocked behind runtime EventsEmit")
+	}
+
+	close(release)
+	if got := <-delivered; got != "one" {
+		t.Fatalf("first delivered event = %q, want one", got)
+	}
+	select {
+	case got := <-delivered:
+		if got != "two" {
+			t.Fatalf("second delivered event = %q, want two", got)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("second queued event was not delivered")
+	}
+}
+
+func TestEmitProjectTreeChangedDoesNotBlockOnRuntimeEventsEmit(t *testing.T) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+
+	app := &App{ctx: context.Background()}
+	app.runtimeEvents.emit = func(_ context.Context, name string, payload ...interface{}) {
+		if name != "project-tree:changed" {
+			t.Errorf("event name = %q, want project-tree:changed", name)
+		}
+		if len(payload) != 0 {
+			t.Errorf("payload count = %d, want 0", len(payload))
+		}
+		if calls.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+	}
+
+	app.emitProjectTreeChanged()
+	select {
+	case <-entered:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first project tree runtime emit did not start")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		app.emitProjectTreeChanged()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("project tree event blocked behind runtime EventsEmit")
+	}
+
+	close(release)
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if calls.Load() >= 2 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("runtime emit calls = %d, want at least 2", calls.Load())
+}

--- a/desktop/tab_event_sink_test.go
+++ b/desktop/tab_event_sink_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -116,4 +117,54 @@ func TestEmitProjectTreeChangedDoesNotBlockOnRuntimeEventsEmit(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatalf("runtime emit calls = %d, want at least 2", calls.Load())
+}
+
+func TestAsyncRuntimeEmitterDrainsBacklogInOrder(t *testing.T) {
+	const backlog = 256
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	delivered := make(chan string, backlog)
+	var calls atomic.Int32
+
+	emitter := &asyncRuntimeEmitter{}
+	emitter.emit = func(_ context.Context, _ string, payload ...interface{}) {
+		if len(payload) != 1 {
+			t.Errorf("payload count = %d, want 1", len(payload))
+			return
+		}
+		value, ok := payload[0].(string)
+		if !ok {
+			t.Errorf("payload type = %T, want string", payload[0])
+			return
+		}
+		delivered <- value
+		if calls.Add(1) == 1 {
+			close(entered)
+			<-release
+		}
+	}
+
+	ctx := context.Background()
+	for i := 0; i < backlog; i++ {
+		emitter.Emit(ctx, "agent:event", strconv.Itoa(i))
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("first runtime emit did not start")
+	}
+	close(release)
+
+	for i := 0; i < backlog; i++ {
+		select {
+		case got := <-delivered:
+			if want := strconv.Itoa(i); got != want {
+				t.Fatalf("delivered[%d] = %q, want %q", i, got, want)
+			}
+		case <-time.After(500 * time.Millisecond):
+			t.Fatalf("timed out waiting for delivered event %d", i)
+		}
+	}
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -289,6 +289,7 @@ type asyncRuntimeEmitter struct {
 	mu      sync.Mutex
 	emit    runtimeEventEmitFunc
 	queue   []runtimeEventEnvelope
+	head    int
 	running bool
 }
 
@@ -314,22 +315,29 @@ func (e *asyncRuntimeEmitter) Clear() {
 	e.mu.Lock()
 	clear(e.queue)
 	e.queue = nil
+	e.head = 0
 	e.mu.Unlock()
 }
 
 func (e *asyncRuntimeEmitter) run() {
 	for {
 		e.mu.Lock()
-		if len(e.queue) == 0 {
+		if e.head >= len(e.queue) {
+			clear(e.queue)
+			e.queue = nil
+			e.head = 0
 			e.running = false
 			e.mu.Unlock()
 			return
 		}
-		item := e.queue[0]
-		copy(e.queue, e.queue[1:])
+		item := e.queue[e.head]
 		var zero runtimeEventEnvelope
-		e.queue[len(e.queue)-1] = zero
-		e.queue = e.queue[:len(e.queue)-1]
+		e.queue[e.head] = zero
+		e.head++
+		if e.head > 64 && e.head*2 >= len(e.queue) {
+			e.queue = append([]runtimeEventEnvelope(nil), e.queue[e.head:]...)
+			e.head = 0
+		}
 		emit := e.emit
 		if emit == nil {
 			emit = runtime.EventsEmit

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -203,9 +203,11 @@ func (t *WorkspaceTab) telemetrySnapshot() tabTelemetrySnapshot {
 // tabEventSink wraps a parent event.Sink and prepends a tabId to every wire
 // event so the frontend can route it to the correct tab's reducer.
 type tabEventSink struct {
-	tabID string
-	app   *App
-	ctx   context.Context
+	tabID         string
+	app           *App
+	mu            sync.RWMutex
+	ctx           context.Context
+	runtimeEvents asyncRuntimeEmitter
 }
 
 func (s *tabEventSink) Emit(e event.Event) {
@@ -225,9 +227,7 @@ func (s *tabEventSink) Emit(e event.Event) {
 			}
 		}
 	}
-	if s.ctx != nil {
-		runtime.EventsEmit(s.ctx, eventChannel, toWireTab(e, s.tabID))
-	}
+	s.emitRuntimeEvent(eventChannel, toWireTab(e, s.tabID))
 	if s.app != nil {
 		if status, update := topicActivityStatusFromEvent(e); update && s.app.setTabActivityStatus(s.tabID, status) {
 			s.app.emitProjectTreeChanged()
@@ -240,6 +240,99 @@ func (s *tabEventSink) Emit(e event.Event) {
 	// Persist after each turn so a force-kill loses at most the in-flight prompt.
 	if e.Kind == event.TurnDone && s.app != nil {
 		s.app.scheduleTabSnapshot(s.tabID)
+	}
+}
+
+func (s *tabEventSink) setContext(ctx context.Context) {
+	s.mu.Lock()
+	s.ctx = ctx
+	s.mu.Unlock()
+	if ctx == nil {
+		s.runtimeEvents.Clear()
+	}
+}
+
+func (s *tabEventSink) context() context.Context {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.ctx
+}
+
+func (s *tabEventSink) emitRuntimeEvent(name string, payload ...interface{}) {
+	if s == nil {
+		return
+	}
+	ctx := s.context()
+	if ctx == nil {
+		return
+	}
+	s.runtimeEvents.Emit(ctx, name, payload...)
+}
+
+type runtimeEventEmitFunc func(context.Context, string, ...interface{})
+
+type runtimeEventEnvelope struct {
+	ctx     context.Context
+	name    string
+	payload []interface{}
+}
+
+// asyncRuntimeEmitter decouples Wails' runtime event bridge from agent
+// emission. runtime.EventsEmit can block when the single webview event channel
+// backs up; callers enqueue in-order work and return without holding the
+// agent's event.Sync lock.
+type asyncRuntimeEmitter struct {
+	mu      sync.Mutex
+	emit    runtimeEventEmitFunc
+	queue   []runtimeEventEnvelope
+	running bool
+}
+
+func (e *asyncRuntimeEmitter) Emit(ctx context.Context, name string, payload ...interface{}) {
+	if ctx == nil {
+		return
+	}
+	item := runtimeEventEnvelope{
+		ctx:     ctx,
+		name:    name,
+		payload: append([]interface{}(nil), payload...),
+	}
+	e.mu.Lock()
+	e.queue = append(e.queue, item)
+	if !e.running {
+		e.running = true
+		go e.run()
+	}
+	e.mu.Unlock()
+}
+
+func (e *asyncRuntimeEmitter) Clear() {
+	e.mu.Lock()
+	clear(e.queue)
+	e.queue = nil
+	e.mu.Unlock()
+}
+
+func (e *asyncRuntimeEmitter) run() {
+	for {
+		e.mu.Lock()
+		if len(e.queue) == 0 {
+			e.running = false
+			e.mu.Unlock()
+			return
+		}
+		item := e.queue[0]
+		copy(e.queue, e.queue[1:])
+		var zero runtimeEventEnvelope
+		e.queue[len(e.queue)-1] = zero
+		e.queue = e.queue[:len(e.queue)-1]
+		emit := e.emit
+		if emit == nil {
+			emit = runtime.EventsEmit
+		}
+		e.mu.Unlock()
+
+		emit(item.ctx, item.name, item.payload...)
 	}
 }
 
@@ -902,7 +995,7 @@ func (a *App) CloseTab(tabID string) error {
 		tab.Ctrl.Close()
 	}
 	if tab.sink != nil {
-		tab.sink.ctx = nil // stop further emissions (nil ctx → Emit becomes no-op)
+		tab.sink.setContext(nil) // stop further emissions (nil ctx -> Emit becomes no-op)
 	}
 	return nil
 }
@@ -964,7 +1057,7 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 	a.mu.Unlock()
 
 	if tab.sink != nil {
-		tab.sink.ctx = wailsCtx
+		tab.sink.setContext(wailsCtx)
 	}
 
 	sessionDir := desktopSessionDir(root)
@@ -2590,9 +2683,14 @@ func (a *App) setTabActivityStatus(tabID, status string) bool {
 }
 
 func (a *App) emitProjectTreeChanged() {
-	if a.ctx != nil {
-		runtime.EventsEmit(a.ctx, "project-tree:changed")
+	a.emitRuntimeEvent("project-tree:changed")
+}
+
+func (a *App) emitRuntimeEvent(name string, payload ...interface{}) {
+	if a == nil || a.ctx == nil {
+		return
 	}
+	a.runtimeEvents.Emit(a.ctx, name, payload...)
 }
 
 // DeleteTopic removes a topic and its title metadata.
@@ -2688,7 +2786,7 @@ func (a *App) TrashTopic(topicID string) error {
 			item.ctrl.Close()
 		}
 		if item.sink != nil {
-			item.sink.ctx = nil
+			item.sink.setContext(nil)
 		}
 	}
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -247,9 +247,13 @@ func (s *tabEventSink) setContext(ctx context.Context) {
 	s.mu.Lock()
 	s.ctx = ctx
 	s.mu.Unlock()
-	if ctx == nil {
-		s.runtimeEvents.Clear()
-	}
+}
+
+func (s *tabEventSink) clearContext() {
+	s.mu.Lock()
+	s.ctx = nil
+	s.mu.Unlock()
+	s.runtimeEvents.Clear()
 }
 
 func (s *tabEventSink) context() context.Context {
@@ -995,7 +999,7 @@ func (a *App) CloseTab(tabID string) error {
 		tab.Ctrl.Close()
 	}
 	if tab.sink != nil {
-		tab.sink.setContext(nil) // stop further emissions (nil ctx -> Emit becomes no-op)
+		tab.sink.clearContext() // stop further emissions (nil ctx -> Emit becomes no-op)
 	}
 	return nil
 }
@@ -2786,7 +2790,7 @@ func (a *App) TrashTopic(topicID string) error {
 			item.ctrl.Close()
 		}
 		if item.sink != nil {
-			item.sink.setContext(nil)
+			item.sink.clearContext()
 		}
 	}
 


### PR DESCRIPTION
## Summary
- decouple desktop tab runtime event forwarding from the synchronous agent event sink path
- keep per-tab Wails event delivery ordered while avoiding blocked runtime.EventsEmit calls holding event.Sync locks
- route project tree change notifications through the same async runtime event bridge

Fixes #4386.

## Testing
- go test . -run 'TestTabEventSinkDoesNotBlockOnRuntimeEventsEmit|TestEmitProjectTreeChangedDoesNotBlockOnRuntimeEventsEmit' (from desktop module)
- go test . (from desktop module)
- go test ./... (from repository root)
- go test ./... (from desktop module)
- git diff --check