### PR TITLE
feat(agent): preserve failure context with configurable compaction retention / 保留失败上下文并支持可配置压缩保留策略

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -273,6 +273,7 @@ type Agent struct {
 	softCompactNoticed  bool
 	recentKeep          int
 	archiveDir          string
+	keepPolicy          KeepPolicy
 	compactStuck        bool
 	consecutiveCompacts int
 
@@ -294,6 +295,15 @@ type Agent struct {
 	// error for the failure-only storm breaker to see.
 	repeatSuccessCounts map[string]int
 }
+
+// KeepPolicy is a bitmask controlling which messages are preserved beyond the
+// recent tail during compaction.
+type KeepPolicy int
+
+const (
+	KeepErrors KeepPolicy = 1 << iota
+	KeepUserMarked
+)
 
 // SetPlanMode flips the read-only gate. While true, executeOne refuses any
 // non-ReadOnly tool the model calls and returns a "blocked" result instead of
@@ -484,6 +494,7 @@ type Options struct {
 	CompactForceRatio float64
 	RecentKeep        int
 	ArchiveDir        string
+	KeepPolicy        KeepPolicy
 
 	// Hooks fires PreToolUse / PostToolUse shell hooks around tool calls. nil
 	// disables hook firing.
@@ -553,6 +564,7 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		compactForceRatio: opts.CompactForceRatio,
 		recentKeep:        opts.RecentKeep,
 		archiveDir:        opts.ArchiveDir,
+		keepPolicy:        opts.KeepPolicy,
 	}
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
 	return a

--- a/internal/agent/compact.go
+++ b/internal/agent/compact.go
@@ -386,14 +386,114 @@ func (a *Agent) pinnableUserTurn(m provider.Message) bool {
 // later fold never re-summarizes an earlier digest and drops the facts it already
 // captured) — and the rest, which folds. Order within each group is preserved.
 func (a *Agent) partitionFold(region []provider.Message) (kept, fold []provider.Message) {
-	for _, m := range region {
-		if isCompactionSummary(m) || (m.Role == provider.RoleUser && a.pinnableUserTurn(m)) {
+	policyKeep := keepIndexes(region, a.keepPolicy)
+	for i, m := range region {
+		if policyKeep[i] || isCompactionSummary(m) || (m.Role == provider.RoleUser && a.pinnableUserTurn(m)) {
 			kept = append(kept, m)
 		} else {
 			fold = append(fold, m)
 		}
 	}
 	return kept, fold
+}
+
+func keepIndexes(region []provider.Message, policy KeepPolicy) []bool {
+	keep := make([]bool, len(region))
+	policyStart := 0
+	for i, m := range region {
+		if isCompactionSummary(m) {
+			policyStart = i + 1
+		}
+	}
+	// Retention applies only to messages since the latest digest; older kept
+	// messages are allowed to fold on the next pass so they cannot grow forever.
+	for i, m := range region {
+		if i >= policyStart && shouldKeepMessage(m, policy) {
+			keep[i] = true
+		}
+	}
+	for i, m := range region {
+		if !keep[i] {
+			continue
+		}
+		switch m.Role {
+		case provider.RoleTool:
+			if j := findToolCaller(region, i, m.ToolCallID); j >= 0 {
+				keepToolCallGroup(region, keep, j)
+			}
+		case provider.RoleAssistant:
+			keepToolCallGroup(region, keep, i)
+		}
+	}
+	return keep
+}
+
+func keepToolCallGroup(region []provider.Message, keep []bool, assistantIndex int) {
+	if assistantIndex < 0 || assistantIndex >= len(region) {
+		return
+	}
+	m := region[assistantIndex]
+	if m.Role != provider.RoleAssistant || len(m.ToolCalls) == 0 {
+		return
+	}
+	keep[assistantIndex] = true
+	ids := toolCallIDs(m)
+	for j := assistantIndex + 1; j < len(region) && region[j].Role == provider.RoleTool; j++ {
+		if ids[region[j].ToolCallID] {
+			keep[j] = true
+		}
+	}
+}
+
+func shouldKeepMessage(m provider.Message, policy KeepPolicy) bool {
+	if policy&KeepErrors != 0 && isErrorMessage(m) {
+		return true
+	}
+	if policy&KeepUserMarked != 0 && isUserMarked(m) {
+		return true
+	}
+	return false
+}
+
+func isErrorMessage(m provider.Message) bool {
+	if m.Role != provider.RoleTool {
+		return false
+	}
+	s := strings.TrimSpace(strings.ToLower(m.Content))
+	return strings.HasPrefix(s, "error:") || strings.HasPrefix(s, "blocked:")
+}
+
+func isUserMarked(m provider.Message) bool {
+	if m.Role != provider.RoleUser {
+		return false
+	}
+	content := strings.TrimSpace(strings.ToLower(m.Content))
+	return strings.HasPrefix(content, "[[keep]]") ||
+		strings.HasPrefix(content, "[keep]") ||
+		strings.HasPrefix(content, "<keep>") ||
+		strings.HasPrefix(content, "<!-- keep -->")
+}
+
+func findToolCaller(region []provider.Message, toolIndex int, id string) int {
+	for i := toolIndex - 1; i >= 0; i-- {
+		if region[i].Role != provider.RoleAssistant {
+			continue
+		}
+		for _, tc := range region[i].ToolCalls {
+			if tc.ID == id {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func toolCallIDs(m provider.Message) map[string]bool {
+	ids := make(map[string]bool, len(m.ToolCalls))
+	for _, tc := range m.ToolCalls {
+		ids[tc.ID] = true
+	}
+	return ids
 }
 
 // planCompaction locates the region to summarize. head is the count of leading

--- a/internal/agent/compact_test.go
+++ b/internal/agent/compact_test.go
@@ -310,6 +310,121 @@ func TestCompactReplacesHistory(t *testing.T) {
 	}
 }
 
+func TestCompactKeepsErrorMessages(t *testing.T) {
+	prov := &fakeProvider{reply: "- normal work summarized"}
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "1", Name: "bash", Arguments: `{"cmd":"bad"}`}}},
+		{Role: provider.RoleTool, ToolCallID: "1", Name: "bash", Content: "error: command failed"},
+		{Role: provider.RoleUser, Content: "continue"},
+		{Role: provider.RoleAssistant, Content: "continued"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir(), KeepPolicy: KeepErrors}, event.Discard)
+
+	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	if len(sess.Messages) < 6 {
+		t.Fatalf("session unexpectedly short after compact: %+v", sess.Messages)
+	}
+	if sess.Messages[2].Role != provider.RoleAssistant || len(sess.Messages[2].ToolCalls) != 1 {
+		t.Fatalf("kept error lost its assistant tool call: %+v", sess.Messages)
+	}
+	if sess.Messages[3].Role != provider.RoleTool || sess.Messages[3].Content != "error: command failed" {
+		t.Fatalf("error tool result not kept verbatim: %+v", sess.Messages)
+	}
+	if strings.Contains(prov.got[1].Content, "error: command failed") {
+		t.Fatalf("kept error was still folded into summary input:\n%s", prov.got[1].Content)
+	}
+}
+
+func TestKeepIndexesKeepsSiblingToolResultsForKeptError(t *testing.T) {
+	region := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{
+			{ID: "err", Name: "bash", Arguments: `{"cmd":"bad"}`},
+			{ID: "ok", Name: "read_file", Arguments: `{"path":"main.go"}`},
+		}},
+		{Role: provider.RoleTool, ToolCallID: "err", Name: "bash", Content: "error: command failed"},
+		{Role: provider.RoleTool, ToolCallID: "ok", Name: "read_file", Content: "package main"},
+	}
+
+	keep := keepIndexes(region, KeepErrors)
+	for i, kept := range keep {
+		if !kept {
+			t.Fatalf("keep[%d] = false, want all sibling tool-call messages kept: %v", i, keep)
+		}
+	}
+}
+
+func TestKeepIndexesScopesPolicyAfterLatestSummary(t *testing.T) {
+	priorSummary := provider.Message{Role: provider.RoleUser, Content: summaryTagOpen + "\nprior digest\n" + summaryTagClose}
+	region := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "old", Name: "bash", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "old", Name: "bash", Content: "error: old failure"},
+		priorSummary,
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "new", Name: "bash", Arguments: `{}`}}},
+		{Role: provider.RoleTool, ToolCallID: "new", Name: "bash", Content: "error: new failure"},
+	}
+
+	keep := keepIndexes(region, KeepErrors)
+	want := []bool{false, false, false, true, true}
+	for i := range want {
+		if keep[i] != want[i] {
+			t.Fatalf("keep = %v, want %v", keep, want)
+		}
+	}
+}
+
+func TestCompactKeepsUserMarkedMessages(t *testing.T) {
+	prov := &fakeProvider{reply: "- unmarked work summarized"}
+	marked := "[[keep]] exact requirement " + strings.Repeat("must stay verbatim ", 200)
+	sess := &Session{Messages: []provider.Message{
+		{Role: provider.RoleSystem, Content: "sys"},
+		{Role: provider.RoleUser, Content: "task"},
+		{Role: provider.RoleUser, Content: marked},
+		{Role: provider.RoleAssistant, Content: "worked"},
+		{Role: provider.RoleUser, Content: "next"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	}}
+	a := New(prov, tool.NewRegistry(), sess, Options{RecentKeep: 2, ArchiveDir: t.TempDir(), KeepPolicy: KeepUserMarked}, event.Discard)
+
+	if err := a.compact(context.Background(), "manual", "", true); err != nil {
+		t.Fatalf("compact: %v", err)
+	}
+	var kept bool
+	for _, m := range sess.Messages {
+		if m.Content == marked {
+			kept = true
+			break
+		}
+	}
+	if !kept {
+		t.Fatalf("marked message not kept verbatim: %+v", sess.Messages)
+	}
+	if strings.Contains(prov.got[1].Content, "exact requirement") {
+		t.Fatalf("marked message was still folded into summary input:\n%s", prov.got[1].Content)
+	}
+}
+
+func TestKeepUserMarkedRequiresUserPrefixMarker(t *testing.T) {
+	region := []provider.Message{
+		{Role: provider.RoleAssistant, Content: "[keep] assistant output"},
+		{Role: provider.RoleUser, Content: "ordinary prose mentioning [keep] later"},
+		{Role: provider.RoleUser, Content: "  <keep> exact requirement"},
+	}
+
+	keep := keepIndexes(region, KeepUserMarked)
+	want := []bool{false, false, true}
+	for i := range want {
+		if keep[i] != want[i] {
+			t.Fatalf("keep = %v, want %v", keep, want)
+		}
+	}
+}
+
 // TestCompactFallsBackToMechanicalFoldWhenSummaryFails: when the summarizer is
 // unreachable, /compact must still free context (fold mechanically) and surface a
 // card, not hang or abort leaving a full window.

--- a/internal/agent/prune.go
+++ b/internal/agent/prune.go
@@ -42,6 +42,15 @@ func (a *Agent) PruneStaleToolResults() (PruneStats, error) {
 		if m.Role != provider.RoleTool || len(m.Content) < minPruneBytes || strings.HasPrefix(m.Content, prunedMarker) {
 			continue
 		}
+		// Honor the keep policy before pruning: an error:/blocked: tool result
+		// that KeepErrors would preserve must reach compact() verbatim.
+		// Eliding it here rewrites Content to the [elided ...] marker, so the
+		// KeepErrors predicate sees only the placeholder and the failure is
+		// lost on the next fold. Long build/test failures sit beyond the recent
+		// tail, exactly this range.
+		if a.keepPolicy&KeepErrors != 0 && isErrorMessage(m) {
+			continue
+		}
 		idx = append(idx, i)
 	}
 	if len(idx) == 0 {

--- a/internal/agent/prune_test.go
+++ b/internal/agent/prune_test.go
@@ -154,3 +154,45 @@ func TestMaybeCompactForceRatioStillFolds(t *testing.T) {
 		t.Error("no compaction summary in session after forced fold")
 	}
 }
+
+func TestPruneHonorsKeepErrors(t *testing.T) {
+	// KeepErrors must carry error/blocked tool results through pruning verbatim;
+	// eliding here rewrites Content to the [elided ...] marker, so compact()'s
+	// KeepErrors predicate sees only the placeholder and the failure is lost on
+	// the next fold.
+	for _, prefix := range []string{"error:", "blocked:"} {
+		content := prefix + strings.Repeat(" detail", 200)
+		sess := pruneFixture(content)
+		a := New(nil, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2, KeepPolicy: KeepErrors}, event.Discard)
+
+		st, err := a.PruneStaleToolResults()
+		if err != nil {
+			t.Fatalf("prune (%s): %v", prefix, err)
+		}
+		if st.Results != 0 {
+			t.Errorf("%s: Results = %d, want 0 (KeepErrors preserves error tool results)", prefix, st.Results)
+		}
+		if got := sess.Snapshot()[3].Content; !strings.HasPrefix(got, prefix) {
+			t.Errorf("%s: error tool result was elided: %.60q", prefix, got)
+		}
+	}
+}
+
+func TestPruneElidesErrorsWithoutKeepPolicy(t *testing.T) {
+	// Without KeepErrors, a large error tool result prunes like any other — a
+	// regression guard for the policy-gated skip.
+	content := "error: build failed\n" + strings.Repeat("x", 5000)
+	sess := pruneFixture(content)
+	a := New(nil, tool.NewRegistry(), sess, Options{ContextWindow: 1000, RecentKeep: 2}, event.Discard)
+
+	st, err := a.PruneStaleToolResults()
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if st.Results != 1 {
+		t.Errorf("Results = %d, want 1 (no keep policy)", st.Results)
+	}
+	if got := sess.Snapshot()[3].Content; !strings.HasPrefix(got, prunedMarker) {
+		t.Errorf("error tool result not elided without keep policy: %.60q", got)
+	}
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -61,8 +61,10 @@ type TaskTool struct {
 	softCompactRatio  float64
 	compactRatio      float64
 	compactForceRatio float64
+	recentKeep        int
 	temperature       float64
 	archiveDir        string
+	keepPolicy        KeepPolicy
 	sysPrompt         string
 	gate              Gate
 	subagentModel     string
@@ -82,8 +84,8 @@ type TaskTool struct {
 // deny rules still bite while autonomous sub-agents are never blocked on an
 // interactive prompt (there is no UI to answer one).
 func NewTaskTool(prov provider.Provider, pricing *provider.Pricing, parentReg *tool.Registry,
-	maxSteps, contextWindow int, softCompactRatio, compactRatio, compactForceRatio, temperature float64, archiveDir, sysPrompt string, gate Gate,
-	subagentModel, subagentEffort string, resolveProvider func(string, string) (provider.Provider, *provider.Pricing, int, error)) *TaskTool {
+	maxSteps, contextWindow, recentKeep int, softCompactRatio, compactRatio, compactForceRatio, temperature float64, archiveDir, sysPrompt string, gate Gate,
+	keepPolicy KeepPolicy, subagentModel, subagentEffort string, resolveProvider func(string, string) (provider.Provider, *provider.Pricing, int, error)) *TaskTool {
 	if sysPrompt == "" {
 		sysPrompt = DefaultTaskSystemPrompt
 	}
@@ -93,11 +95,13 @@ func NewTaskTool(prov provider.Provider, pricing *provider.Pricing, parentReg *t
 		parentReg:         parentReg,
 		maxSteps:          maxSteps,
 		contextWindow:     contextWindow,
+		recentKeep:        recentKeep,
 		softCompactRatio:  softCompactRatio,
 		compactRatio:      compactRatio,
 		compactForceRatio: compactForceRatio,
 		temperature:       temperature,
 		archiveDir:        archiveDir,
+		keepPolicy:        keepPolicy,
 		sysPrompt:         sysPrompt,
 		gate:              gate,
 		subagentModel:     subagentModel,
@@ -445,10 +449,12 @@ func (t *TaskTool) runSubSession(ctx context.Context, prompt string, subReg *too
 		UsageSource:       event.UsageSourceSubagent,
 		Gate:              t.gate,
 		ContextWindow:     ctxWin,
+		RecentKeep:        t.recentKeep,
 		SoftCompactRatio:  t.softCompactRatio,
 		CompactRatio:      t.compactRatio,
 		CompactForceRatio: t.compactForceRatio,
 		ArchiveDir:        t.archiveDir,
+		KeepPolicy:        t.keepPolicy,
 		ReasoningLanguage: ReasoningLanguageFromContext(ctx),
 	}, sink)
 }

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -176,7 +176,7 @@ func TestTaskToolRequiresTranscriptStore(t *testing.T) {
 		{Type: provider.ChunkText, Text: "answer"},
 		{Type: provider.ChunkDone},
 	}}
-	task := NewTaskTool(sub, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil)
+	task := NewTaskTool(sub, nil, tool.NewRegistry(), 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil)
 
 	_, err := task.Execute(testTaskContext(), []byte(`{"prompt":"x"}`))
 	if err == nil || !strings.Contains(err.Error(), "transcript store is required") {
@@ -284,7 +284,7 @@ func TestTaskToolFailedForegroundContinuationPersistsAndRejectsReuse(t *testing.
 	store := NewSubagentStore(t.TempDir())
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "read_file", readOnly: true})
-	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
 		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
 
 	first, err := task.Execute(testTaskContext(), []byte(`{"prompt":"first task"}`))
@@ -399,9 +399,16 @@ func TestSubSinkForwardsUsageToParent(t *testing.T) {
 	}
 }
 
+func TestTaskToolCarriesRecentKeepIntoSubsessions(t *testing.T) {
+	task := NewTaskTool(&mockProvider{name: "sub"}, nil, tool.NewRegistry(), 20, 0, 7, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil)
+	if task.recentKeep != 7 {
+		t.Fatalf("recentKeep = %d, want 7", task.recentKeep)
+	}
+}
+
 func newTestTaskTool(t *testing.T, prov provider.Provider, reg *tool.Registry, sysPrompt, subagentModel, subagentEffort string, resolve func(string, string) (provider.Provider, *provider.Pricing, int, error)) *TaskTool {
 	t.Helper()
-	return NewTaskTool(prov, nil, reg, 20, 0, 0, 0, 0, 0.0, "", sysPrompt, nil, subagentModel, subagentEffort, resolve).
+	return NewTaskTool(prov, nil, reg, 20, 0, 0, 0, 0, 0, 0.0, "", sysPrompt, nil, 0, subagentModel, subagentEffort, resolve).
 		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "base-effort")
 }
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -322,7 +322,7 @@ func TestTaskToolBackgroundPanicPersistsFailedMetadata(t *testing.T) {
 	store := NewSubagentStore(t.TempDir())
 	reg := tool.NewRegistry()
 	reg.Add(fakeTool{name: "read_file", readOnly: true})
-	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0, 0.0, "", "sys", nil, 0, "", "", nil).
 		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
 
 	jm := jobs.NewManager(event.Discard)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -49,6 +49,22 @@ import (
 // removed provider. Callers can detect it (errors.Is) to re-run setup.
 var ErrUnknownModel = errors.New("unknown model")
 
+func agentKeepPolicy(keep []string) agent.KeepPolicy {
+	if keep == nil {
+		return agent.KeepErrors
+	}
+	var p agent.KeepPolicy
+	for _, k := range keep {
+		switch strings.TrimSpace(k) {
+		case "errors":
+			p |= agent.KeepErrors
+		case "user_marked":
+			p |= agent.KeepUserMarked
+		}
+	}
+	return p
+}
+
 // Options carries the per-run knobs a frontend chooses; everything else is read
 // from configuration. Model "" falls back to the configured default_model;
 // MaxSteps 0 uses the config/default. RequireKey forces the executor's API key to
@@ -112,6 +128,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	}
 	tokenMode := NormalizeTokenMode(opts.TokenMode)
 	tokenEconomy := tokenMode == TokenModeEconomy
+	keepPolicy := agentKeepPolicy(cfg.Agent.Keep)
 	entry, ok := cfg.ResolveModel(modelName)
 	if !ok {
 		return nil, fmt.Errorf("%w %q (configured: %s); note: defining [[providers]] replaces the built-in presets, so add a [[providers]] entry for it or use a configured name, or run `reasonix setup` to reconfigure", ErrUnknownModel, modelName, providerNames(cfg))
@@ -505,8 +522,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 		taskToolAdded = true
 		reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
-			entry.ContextWindow, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
+			entry.ContextWindow, cfg.Agent.RecentKeep, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
 			cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate,
+			keepPolicy,
 			taskModel, taskEffort, resolveSubagentProvider).
 			WithTranscripts(subagentStore, root, modelName, entry.Effort).
 			WithTranscriptIdentityResolver(subagentIdentity))
@@ -604,7 +622,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			UsageSource:       event.UsageSourceSubagent,
 			Gate:              headlessGate,
 			ContextWindow:     ctxWin,
+			RecentKeep:        cfg.Agent.RecentKeep,
 			ArchiveDir:        config.ArchiveDir(),
+			KeepPolicy:        keepPolicy,
 			ReasoningLanguage: agent.ReasoningLanguageFromContext(sctx),
 		}, agent.NestedSink(sctx, event.Discard))
 		if err != nil {
@@ -824,7 +844,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
 		CompactRatio:      cfg.Agent.CompactRatio,
 		CompactForceRatio: cfg.Agent.CompactForceRatio,
+		RecentKeep:        cfg.Agent.RecentKeep,
 		ArchiveDir:        config.ArchiveDir(),
+		KeepPolicy:        keepPolicy,
 		ReasoningLanguage: cfg.ReasoningLanguage(),
 	}, sink)
 
@@ -856,7 +878,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
 				CompactRatio:      cfg.Agent.CompactRatio,
 				CompactForceRatio: cfg.Agent.CompactForceRatio,
+				RecentKeep:        cfg.Agent.RecentKeep,
 				ArchiveDir:        config.ArchiveDir(),
+				KeepPolicy:        keepPolicy,
 				ReasoningLanguage: cfg.ReasoningLanguage(),
 			}, executor, cfg.Agent.Temperature, sink, control.TaskWarrantsPlanner)
 			label = entry.Model + " + planner " + pe.Model

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -38,6 +38,18 @@ import (
 	_ "reasonix/internal/provider/openai"
 )
 
+func TestAgentKeepPolicyFromConfig(t *testing.T) {
+	if got := agentKeepPolicy(nil); got != agent.KeepErrors {
+		t.Fatalf("nil keep policy = %v, want KeepErrors", got)
+	}
+	if got := agentKeepPolicy([]string{}); got != 0 {
+		t.Fatalf("empty keep policy = %v, want 0", got)
+	}
+	if got := agentKeepPolicy([]string{"errors", "user_marked"}); got != agent.KeepErrors|agent.KeepUserMarked {
+		t.Fatalf("combined keep policy = %v, want errors|user_marked", got)
+	}
+}
+
 // TestBuildFoldsProjectMemoryIntoSystemPrompt is the end-to-end proof of the
 // cache-first wiring: a project REASONIX.md is discovered at boot and folded
 // into the session's system message (the cached prefix), and the `remember`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -877,6 +877,11 @@ type AgentConfig struct {
 	SoftCompactRatio  float64 `toml:"soft_compact_ratio"`
 	CompactRatio      float64 `toml:"compact_ratio"`
 	CompactForceRatio float64 `toml:"compact_force_ratio"`
+	// Keep controls which compactable messages stay verbatim beyond the current
+	// user-fact/digest floor and recent tail. Empty uses the conservative default
+	// of keeping error tool results.
+	Keep       []string `toml:"keep"`
+	RecentKeep int      `toml:"recent_keep"`
 	// ColdResumePrune elides stale tool results when a session reopens past the
 	// provider cache window. nil = default enabled.
 	ColdResumePrune *bool `toml:"cold_resume_prune"`

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -202,6 +202,16 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	fmt.Fprintf(&b, "soft_compact_ratio  = %s   # notice only; keeps cache-first prefix intact\n", formatFloat(c.Agent.SoftCompactRatio))
 	fmt.Fprintf(&b, "compact_ratio       = %s   # try compacting when prompt reaches this fraction\n", formatFloat(c.Agent.CompactRatio))
 	fmt.Fprintf(&b, "compact_force_ratio = %s   # force compacting at this high-water mark\n", formatFloat(c.Agent.CompactForceRatio))
+	if c.Agent.Keep != nil {
+		fmt.Fprintf(&b, "keep                = %s   # compaction keep policy: errors, user_marked\n", renderStringArray(c.Agent.Keep))
+	} else {
+		b.WriteString("# keep                = [\"errors\"]   # compaction keep policy: errors, user_marked\n")
+	}
+	if c.Agent.RecentKeep > 0 {
+		fmt.Fprintf(&b, "recent_keep         = %d   # minimum recent messages kept verbatim\n", c.Agent.RecentKeep)
+	} else {
+		b.WriteString("# recent_keep         = 2   # minimum recent messages kept verbatim\n")
+	}
 	fmt.Fprintf(&b, "cold_resume_prune   = %v   # elide stale tool results when reopening a session past the provider cache window\n", c.ColdResumePruneEnabled())
 	if c.Agent.PlannerModel != "" {
 		fmt.Fprintf(&b, "planner_model = %q   # low-frequency planner (two-model collaboration)\n", c.Agent.PlannerModel)

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -72,6 +72,8 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Agent.ReasoningLanguage = "zh"
 	orig.Agent.SubagentModel = "mimo-pro"
 	orig.Agent.SubagentModels = map[string]string{"review": "deepseek-pro"}
+	orig.Agent.Keep = []string{"errors", "user_marked"}
+	orig.Agent.RecentKeep = 4
 	orig.Tools.BashTimeoutSeconds = intPtr(900)
 	orig.Tools.BackgroundJobs.StalledWarningSeconds = intPtr(30)
 	orig.Permissions = PermissionsConfig{
@@ -226,6 +228,12 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Agent.CompactForceRatio != orig.Agent.CompactForceRatio {
 		t.Errorf("compact_force_ratio = %v, want %v", got.Agent.CompactForceRatio, orig.Agent.CompactForceRatio)
+	}
+	if strings.Join(got.Agent.Keep, ",") != strings.Join(orig.Agent.Keep, ",") {
+		t.Errorf("keep = %v, want %v", got.Agent.Keep, orig.Agent.Keep)
+	}
+	if got.Agent.RecentKeep != orig.Agent.RecentKeep {
+		t.Errorf("recent_keep = %d, want %d", got.Agent.RecentKeep, orig.Agent.RecentKeep)
 	}
 	if got.Agent.SystemPrompt != orig.Agent.SystemPrompt {
 		t.Errorf("system_prompt mismatch:\n got %q\nwant %q", got.Agent.SystemPrompt, orig.Agent.SystemPrompt)


### PR DESCRIPTION
## Summary
Transfer the finalized compaction retention policy work from #2407 onto the latest `main-v2` base.

## Root Cause
Long-running sessions need more control over what survives compaction and when compaction triggers. The previous PR also accumulated review history after multiple rebases, so this PR carries the final reviewed content forward on a clean branch.

## Technical Approach
- Add `KeepPolicy` flags and TOML config fields for `keep`, `compact_ratio`, and `recent_keep`.
- Default unset `agent.keep` to `["errors"]`, preserving error/blocked tool results for one compaction pass.
- Preserve complete assistant/tool-result groups when any retained tool result belongs to a multi-call turn.
- Scope keep-policy retention to messages since the latest compaction summary so retained groups can fold on later passes instead of growing the compaction floor.
- Keep `internal/config` provider-agnostic; `internal/boot` translates raw `agent.keep` values into the agent-owned `KeepPolicy` when assembling options.
- Wire the config through executor, planner, skill sub-agents, and `task` sub-sessions.

## Verification
- `go test ./internal/agent ./internal/config ./internal/boot`
- `go test ./...`
- `git diff --check`

Supersedes #2407.
