### PR TITLE
Reduce desktop new session lookup overhead / 减少桌面新建会话查找开销

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1060,6 +1060,7 @@ func (a *App) Fork(turn int) (TabMeta, error) {
 	if err := agent.SaveBranchMeta(newPath, m); err != nil {
 		return TabMeta{}, err
 	}
+	invalidateTopicSessionIndexForPath(newPath)
 
 	a.mu.Lock()
 	tabID := a.newUniqueTabIDLocked()

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -792,6 +792,7 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 		}
 		openTopics[tab.TopicID] = true
 	}
+	sessionIndex, _ := topicSessionIndexForDir(config.SessionDir())
 	for _, topicID := range topicIDs {
 		if openTopics[topicID] {
 			continue
@@ -799,7 +800,7 @@ func (a *App) indexedBlankTopicIDLocked(scope, workspaceRoot string) string {
 		if topicTitleForTab(scope, workspaceRoot, topicID) != defaultTopicTitle {
 			continue
 		}
-		if findTopicSession(config.SessionDir(), topicID) != "" {
+		if topicSessionIndexHasTopic(sessionIndex, topicID) {
 			continue
 		}
 		return topicID
@@ -2140,27 +2141,38 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	}
 	legacyMigrationMu.Lock()
 	defer legacyMigrationMu.Unlock()
-	infos, err := agent.ListSessions(dir)
+	infos, err := agent.ListSessionOrder(dir)
 	if err != nil || len(infos) == 0 {
 		return nil
 	}
-	titles := loadSessionTitles(dir)
-	topicTitles := loadTopicTitles(topicTitleRoot)
-	topicSources := loadTopicTitleSources(topicTitleRoot)
-	f := loadProjectsFile()
 
 	var migratedTopicIDs []string
+	var titles map[string]string
+	var topicTitles map[string]string
+	var topicSources map[string]string
 	for _, info := range infos {
 		if strings.TrimSpace(info.TopicID) != "" {
+			continue
+		}
+		if meta, ok, err := agent.LoadBranchMeta(info.Path); err != nil {
+			continue
+		} else if ok && (meta.Scope != "" || strings.TrimSpace(meta.WorkspaceRoot) != "" || strings.TrimSpace(meta.TopicID) != "") {
 			continue
 		}
 		topicID := legacySessionTopicID(info.Path)
 		if topicID == "" {
 			continue
 		}
+		preview, turns := agent.SessionPreview(info.Path)
+		if turns == 0 {
+			continue
+		}
+		if titles == nil {
+			titles = loadSessionTitles(dir)
+		}
 		title := strings.TrimSpace(titles[filepath.Base(info.Path)])
 		if title == "" {
-			title = topicTitleFromText(info.Preview)
+			title = topicTitleFromText(preview)
 		} else if normalized := topicTitleFromText(title); normalized != "" {
 			title = normalized
 		}
@@ -2192,6 +2204,12 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		if err := agent.SaveBranchMetaPreserveUpdated(info.Path, meta); err != nil {
 			continue
 		}
+		if topicTitles == nil {
+			topicTitles = loadTopicTitles(topicTitleRoot)
+		}
+		if topicSources == nil {
+			topicSources = loadTopicTitleSources(topicTitleRoot)
+		}
 		if strings.TrimSpace(topicTitles[topicID]) == "" {
 			topicTitles[topicID] = title
 			topicSources[topicID] = topicTitleSourceManual
@@ -2201,6 +2219,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if len(migratedTopicIDs) == 0 {
 		return nil
 	}
+	f := loadProjectsFile()
 	if scope == "global" {
 		f.GlobalTopics = uniqueStrings(append(migratedTopicIDs, f.GlobalTopics...))
 	} else {
@@ -2213,8 +2232,13 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		}
 	}
 	_ = saveProjectsFile(f)
-	_ = saveTopicTitles(topicTitleRoot, topicTitles)
-	_ = saveTopicTitleSources(topicTitleRoot, topicSources)
+	if topicTitles != nil {
+		_ = saveTopicTitles(topicTitleRoot, topicTitles)
+	}
+	if topicSources != nil {
+		_ = saveTopicTitleSources(topicTitleRoot, topicSources)
+	}
+	invalidateTopicSessionIndex(dir)
 	return migratedTopicIDs
 }
 
@@ -2288,7 +2312,11 @@ func restoreSessionTopicIndex(dir, sessionPath string) error {
 	if err := saveProjectsFile(f); err != nil {
 		return err
 	}
-	return agent.SaveBranchMetaPreserveUpdated(sessionPath, meta)
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, meta); err != nil {
+		return err
+	}
+	invalidateTopicSessionIndexForPath(sessionPath)
+	return nil
 }
 
 func restoredSessionTopicTitle(dir, sessionPath string, meta agent.BranchMeta) string {
@@ -2556,20 +2584,15 @@ func (a *App) updateTopicSessionTitles(topicID, title string) {
 		return
 	}
 	for _, dir := range a.knownSessionDirs() {
-		infos, err := agent.ListSessions(dir)
-		if err != nil {
-			continue
-		}
-		for _, info := range infos {
-			if info.TopicID != topicID {
-				continue
-			}
-			meta, ok, err := agent.LoadBranchMeta(info.Path)
+		for _, match := range topicSessionMatches(dir, topicID) {
+			meta, ok, err := agent.LoadBranchMeta(match.path)
 			if err != nil || !ok {
 				continue
 			}
 			meta.TopicTitle = title
-			_ = agent.SaveBranchMetaPreserveUpdated(info.Path, meta)
+			if err := agent.SaveBranchMetaPreserveUpdated(match.path, meta); err == nil {
+				invalidateTopicSessionIndex(dir)
+			}
 		}
 	}
 }
@@ -3238,7 +3261,11 @@ func saveTabSessionMeta(tab *WorkspaceTab, path string) error {
 	m.WorkspaceRoot = tab.WorkspaceRoot
 	m.TopicID = tab.TopicID
 	m.TopicTitle = tab.TopicTitle
-	return agent.SaveBranchMetaPreserveUpdated(path, m)
+	if err := agent.SaveBranchMetaPreserveUpdated(path, m); err != nil {
+		return err
+	}
+	invalidateTopicSessionIndexForPath(path)
+	return nil
 }
 
 func canonicalTabSessionPath(path string) string {
@@ -3306,34 +3333,180 @@ func (a *App) knownSessionDirs() []string {
 	return out
 }
 
-// findTopicSession scans the session directory for a .jsonl file whose .meta
-// carries the given topicID. Returns the most recently updated match, or ""
-// if no session exists for this topic.
-func findTopicSession(dir, topicID string) string {
-	if topicID == "" || dir == "" {
+type topicSessionFileSignature struct {
+	name    string
+	size    int64
+	modTime int64
+}
+
+type topicSessionMatch struct {
+	path      string
+	updatedAt time.Time
+}
+
+type topicSessionDirIndex struct {
+	signature []topicSessionFileSignature
+	byTopic   map[string][]topicSessionMatch
+}
+
+var topicSessionIndexCache = struct {
+	sync.Mutex
+	byDir map[string]topicSessionDirIndex
+}{byDir: map[string]topicSessionDirIndex{}}
+
+func topicSessionDirKey(dir string) string {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
 		return ""
 	}
+	if abs, err := filepath.Abs(dir); err == nil {
+		return abs
+	}
+	return dir
+}
+
+func topicSessionDirSnapshot(dir string) ([]topicSessionFileSignature, []string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return ""
+		return nil, nil, err
 	}
-	var bestPath string
-	var bestTime time.Time
-	for _, e := range entries {
-		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+	signature := []topicSessionFileSignature{}
+	sessionNames := []string{}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
 			continue
 		}
-		path := filepath.Join(dir, e.Name())
+		isSession := filepath.Ext(name) == ".jsonl"
+		isMeta := strings.HasSuffix(name, ".jsonl.meta")
+		if !isSession && !isMeta {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		signature = append(signature, topicSessionFileSignature{
+			name:    name,
+			size:    info.Size(),
+			modTime: info.ModTime().UnixNano(),
+		})
+		if isSession {
+			sessionNames = append(sessionNames, name)
+		}
+	}
+	sort.Slice(signature, func(i, j int) bool {
+		return signature[i].name < signature[j].name
+	})
+	sort.Strings(sessionNames)
+	return signature, sessionNames, nil
+}
+
+func topicSessionSignaturesEqual(a, b []topicSessionFileSignature) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func topicSessionIndexForDir(dir string) (topicSessionDirIndex, error) {
+	key := topicSessionDirKey(dir)
+	if key == "" {
+		return topicSessionDirIndex{}, nil
+	}
+	signature, sessionNames, err := topicSessionDirSnapshot(key)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return topicSessionDirIndex{}, nil
+		}
+		return topicSessionDirIndex{}, err
+	}
+	topicSessionIndexCache.Lock()
+	cached, ok := topicSessionIndexCache.byDir[key]
+	if ok && topicSessionSignaturesEqual(cached.signature, signature) {
+		topicSessionIndexCache.Unlock()
+		return cached, nil
+	}
+	topicSessionIndexCache.Unlock()
+
+	index := topicSessionDirIndex{
+		signature: signature,
+		byTopic:   map[string][]topicSessionMatch{},
+	}
+	for _, name := range sessionNames {
+		path := filepath.Join(key, name)
 		meta, ok, err := agent.LoadBranchMeta(path)
 		if err != nil || !ok {
 			continue
 		}
-		if meta.TopicID != topicID {
+		topicID := strings.TrimSpace(meta.TopicID)
+		if topicID == "" {
 			continue
 		}
-		if meta.UpdatedAt.After(bestTime) {
-			bestTime = meta.UpdatedAt
-			bestPath = path
+		index.byTopic[topicID] = append(index.byTopic[topicID], topicSessionMatch{
+			path:      path,
+			updatedAt: meta.UpdatedAt,
+		})
+	}
+
+	topicSessionIndexCache.Lock()
+	topicSessionIndexCache.byDir[key] = index
+	topicSessionIndexCache.Unlock()
+	return index, nil
+}
+
+func topicSessionIndexHasTopic(index topicSessionDirIndex, topicID string) bool {
+	matches := index.byTopic[strings.TrimSpace(topicID)]
+	return len(matches) > 0
+}
+
+func topicSessionMatches(dir, topicID string) []topicSessionMatch {
+	index, err := topicSessionIndexForDir(dir)
+	if err != nil {
+		return nil
+	}
+	matches := index.byTopic[strings.TrimSpace(topicID)]
+	if len(matches) == 0 {
+		return nil
+	}
+	return append([]topicSessionMatch(nil), matches...)
+}
+
+func invalidateTopicSessionIndex(dir string) {
+	key := topicSessionDirKey(dir)
+	if key == "" {
+		return
+	}
+	topicSessionIndexCache.Lock()
+	delete(topicSessionIndexCache.byDir, key)
+	topicSessionIndexCache.Unlock()
+}
+
+func invalidateTopicSessionIndexForPath(path string) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return
+	}
+	invalidateTopicSessionIndex(filepath.Dir(path))
+}
+
+// findTopicSession returns the most recently updated .jsonl file whose .meta
+// carries the given topicID, using a directory-level sidecar index cache.
+func findTopicSession(dir, topicID string) string {
+	if topicID == "" || dir == "" {
+		return ""
+	}
+	var bestPath string
+	var bestTime time.Time
+	for _, match := range topicSessionMatches(dir, topicID) {
+		if match.updatedAt.After(bestTime) {
+			bestTime = match.updatedAt
+			bestPath = match.path
 		}
 	}
 	return bestPath

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1274,6 +1274,83 @@ func TestLegacyMigrationConcurrentRunsHaveNoLostUpdates(t *testing.T) {
 	}
 }
 
+func TestFindTopicSessionIndexRefreshesWhenMetaChanges(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	topicID := "topic_cache_refresh"
+	now := time.Now().UTC()
+	first := writeTopicSessionWithPrompt(t, dir, "first.jsonl", topicID, "First", "", "first prompt", now.Add(-time.Hour))
+
+	if got := findTopicSession(dir, topicID); got != first {
+		t.Fatalf("first lookup = %q, want %q", got, first)
+	}
+
+	second := writeTopicSessionWithPrompt(t, dir, "second.jsonl", topicID, "Second", "", "second prompt", now)
+	if got := findTopicSession(dir, topicID); got != second {
+		t.Fatalf("lookup after new session = %q, want newer %q", got, second)
+	}
+
+	meta, ok, err := agent.LoadBranchMeta(second)
+	if err != nil || !ok {
+		t.Fatalf("load second meta: ok=%v err=%v", ok, err)
+	}
+	meta.TopicID = "topic_cache_other"
+	meta.UpdatedAt = now.Add(time.Hour)
+	if err := agent.SaveBranchMetaPreserveUpdated(second, meta); err != nil {
+		t.Fatal(err)
+	}
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(agent.BranchMetaPath(second), future, future); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := findTopicSession(dir, topicID); got != first {
+		t.Fatalf("lookup after retopic = %q, want remaining %q", got, first)
+	}
+	if got := findTopicSession(dir, "topic_cache_other"); got != second {
+		t.Fatalf("lookup for retopic session = %q, want %q", got, second)
+	}
+}
+
+func TestUpdateTopicSessionTitlesUsesTopicIndex(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	topicID := "topic_title_index"
+	now := time.Now().UTC()
+	valid := writeTopicSessionWithPrompt(t, dir, "valid.jsonl", topicID, "Old", "", "hello", now)
+	unpreviewable := filepath.Join(dir, "unpreviewable.jsonl")
+	if err := os.WriteFile(unpreviewable, []byte("not-json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMetaPreserveUpdated(unpreviewable, agent.BranchMeta{
+		CreatedAt:  now.Add(-time.Minute),
+		UpdatedAt:  now,
+		Scope:      "global",
+		TopicID:    topicID,
+		TopicTitle: "Old",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	NewApp().updateTopicSessionTitles(topicID, "Renamed")
+
+	for _, path := range []string{valid, unpreviewable} {
+		meta, ok, err := agent.LoadBranchMeta(path)
+		if err != nil || !ok {
+			t.Fatalf("load meta for %s: ok=%v err=%v", path, ok, err)
+		}
+		if meta.TopicTitle != "Renamed" {
+			t.Fatalf("topic title for %s = %q, want Renamed", path, meta.TopicTitle)
+		}
+	}
+}
+
 func TestEnsureTopicIndexedConcurrentRunsHaveNoLostProjectUpdates(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -201,6 +201,12 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 	return out, nil
 }
 
+// SessionPreview returns the same preview and user-turn count used by
+// ListSessions for one session file.
+func SessionPreview(path string) (string, int) {
+	return previewSession(path)
+}
+
 // previewSession returns the first user message (truncated) and the number of
 // user-role messages so the picker can show "5 turns · 'help me debug the…'".
 // Errors are swallowed — a malformed file just shows up with an empty preview.


### PR DESCRIPTION
## Summary
- Avoid repeated full session scans when initializing new tabs by using a cached topic-session directory index.
- Speed up legacy session migration with session-order metadata and lighter filtering before loading full session previews.
- Invalidate the topic-session index on metadata updates and cover cache-refresh/title-propagation behavior with regression tests.

Fixes #4385

## Validation
- go test ./...
- go test ./... (from desktop/ module)
