### PR TITLE
feat: add diagnostic logging for credential persistence

### DIFF
--- a/desktop/dotenv.go
+++ b/desktop/dotenv.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,8 +86,10 @@ func upsertEnvFile(path, key, value string) error {
 	}
 	if err := fileutil.ReplaceFile(tmpPath, path); err != nil {
 		os.Remove(tmpPath)
+		slog.Warn("dotenv: write failed", "path", path, "key", key, "err", err)
 		return err
 	}
+	slog.Debug("dotenv: upserted", "path", path, "key", key)
 	return os.Setenv(key, value)
 }
 
@@ -183,11 +186,14 @@ func promoteProviderKeysToCredentials(cfg *config.Config) {
 		}
 		val := os.Getenv(env)
 		if val == "" {
+			slog.Debug("promote: key not in env", "env", env)
 			continue
 		}
 		if err := upsertEnvFile(credPath, env, val); err != nil {
+			slog.Warn("promote: write failed", "env", env, "err", err)
 			continue
 		}
+		slog.Info("promote: key migrated to credentials", "env", env)
 		have[env] = true
 		removeHomeEnvKey(env)
 	}

--- a/internal/config/dotenv.go
+++ b/internal/config/dotenv.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bufio"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,10 +41,12 @@ func loadDotEnvForRoot(root string) {
 func loadDotEnvFile(path string) {
 	f, err := os.Open(path)
 	if err != nil {
+		slog.Debug("config: dotenv file not loaded", "path", path, "err", err)
 		return
 	}
 	defer f.Close()
 
+	count := 0
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
@@ -62,6 +65,10 @@ func loadDotEnvFile(path string) {
 		}
 		if _, exists := os.LookupEnv(key); !exists {
 			os.Setenv(key, val)
+			count++
 		}
+	}
+	if count > 0 {
+		slog.Info("config: dotenv loaded", "path", path, "keys", count)
 	}
 }


### PR DESCRIPTION
Add slog logging at critical points in the credential save/load path to help diagnose #4390 (API key lost on Windows restart):

- config.loadDotEnvFile: log loaded path + key count
- desktop.upsertEnvFile: log write failures
- desktop.promoteProviderKeysToCredentials: log migration activity