### PR TITLE
fix: do not truncate MCP paths containing spaces

### DIFF
--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -1244,13 +1244,12 @@ function EditServerForm({
   const ready = isStdio ? command.trim() !== "" : url.trim() !== "";
 
   const submit = () => {
-    const parts = command.trim().split(/\s+/).filter(Boolean);
     const envText = env.trim();
     onSave({
       name: s.name,
       transport,
-      command: isStdio ? (parts[0] ?? "") : "",
-      args: isStdio ? parts.slice(1) : [],
+      command: isStdio ? command.trim() : "",
+      args: [],
       url: isStdio ? "" : url.trim(),
       env: envText === "" ? null : parseEnvText(envText),
     });
@@ -1625,7 +1624,6 @@ function AddServerForm({
   const ready = name.trim() !== "" && (isStdio ? command.trim() !== "" : url.trim() !== "");
 
   const submit = () => {
-    const parts = command.trim().split(/\s+/).filter(Boolean);
     const envMap: Record<string, string> = {};
     for (const line of env.split("\n")) {
       const eq = line.indexOf("=");
@@ -1634,8 +1632,8 @@ function AddServerForm({
     onAdd({
       name: name.trim(),
       transport,
-      command: isStdio ? (parts[0] ?? "") : "",
-      args: isStdio ? parts.slice(1) : [],
+      command: isStdio ? command.trim() : "",
+      args: [],
       url: isStdio ? "" : url.trim(),
       env: envMap,
     });

--- a/internal/config/mcpjson.go
+++ b/internal/config/mcpjson.go
@@ -158,7 +158,10 @@ func parseLegacyMCPSpec(raw string) (PluginEntry, bool) {
 	if !ok || len(parts) == 0 {
 		return PluginEntry{}, false
 	}
-	return PluginEntry{Name: name, Command: parts[0], Args: parts[1:]}, true
+	if shouldSplitPluginCommand(body, parts[0]) {
+		return PluginEntry{Name: name, Command: parts[0], Args: parts[1:]}, true
+	}
+	return PluginEntry{Name: name, Command: body}, true
 }
 
 // anonymousMCPName names a v0.x spec that carried no name= prefix (its tools


### PR DESCRIPTION
Two code paths were splitting MCP server commands on whitespace without the shouldSplitPluginCommand guard, which truncated any command path with spaces.

Bug 1 - Frontend forms

AddServerForm and EditServerForm in CapabilitiesPanel.tsx used command.trim().split(/\s+/) before sending to the Go backend. A path like C:\Program Files\MyApp\server.exe became command=C:\Program with args [Files\MyApp\server.exe].

Bug 2 - Legacy config.json parser

parseLegacyMCPSpec in mcpjson.go always split the command body on spaces via splitPluginCommandLine. The v0.x config.json format uses name=command args... lines. For a path with spaces like ida=C:\PersonalData\Software\Learn\IDA Pro\ida_bridge.bat, this truncated the executable to C:\PersonalData\Software\Learn\IDA.

Fix

- Frontend: pass the full command string through; the Go side NormalizePluginCommandLine already has a quote-aware tokenizer and shouldSplitPluginCommand guard.
- parseLegacyMCPSpec: only split when shouldSplitPluginCommand returns true; otherwise preserve the full body as the command.

Files

- desktop/frontend/src/components/CapabilitiesPanel.tsx (+2/-2)
- internal/config/mcpjson.go (+6/-5)