### PR TITLE
Bound chrome tab strip width / 限制顶部标签栏最大宽度

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -64,6 +64,21 @@ ok(
 );
 
 ok(
+  finalDeclaration(".app-chrome__tab-strip", "overflow") === "hidden",
+  "AppChrome tab strip clips tabs to the available chrome width",
+);
+
+ok(
+  finalDeclaration(".app-chrome__tab-strip", "min-width") === "0",
+  "AppChrome tab strip can shrink beside the right dock",
+);
+
+ok(
+  finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar__tabs", "max-width") === "100%",
+  "themed AppChrome tab lists keep a bounded maximum width",
+);
+
+ok(
   /workbenchChrome \? \(\s*<span className="app-chrome__spacer" aria-hidden="true" \/>/s.test(appChromeSource),
   "AppChrome workbench branch skips the tab strip",
 );

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -83,11 +83,25 @@ ok(
   "AppChrome workbench branch skips the tab strip",
 );
 
+ok(
+  /app-chrome__tools--fixed/.test(appChromeSource),
+  "AppChrome renders the command search as a fixed chrome tool",
+);
+
 for (const selector of [
   ".app--darwin .app-chrome--tabs",
+  ":root[data-theme-style] .app--darwin .app-chrome--tabs",
+]) {
+  const rightSpace = finalDeclaration(selector, "padding-right") ?? finalDeclaration(selector, "padding") ?? "";
+  ok(
+    rightSpace.includes("--chrome-toggle-size") && !rightSpace.includes("--chrome-right-toggle-offset"),
+    `${selector} reserves fixed chrome tool width without shrinking for the right dock`,
+  );
+}
+
+for (const selector of [
   ".app--windows .app-chrome--native-tabs",
   ".app--linux .app-chrome--native-tabs",
-  ":root[data-theme-style] .app--darwin .app-chrome--tabs",
   ":root[data-theme-style] .app--windows .app-chrome--native-tabs",
   ":root[data-theme-style] .app--linux .app-chrome--native-tabs",
 ]) {

--- a/desktop/frontend/src/components/AppChrome.tsx
+++ b/desktop/frontend/src/components/AppChrome.tsx
@@ -58,7 +58,6 @@ export function AppChrome({
 }: AppChromeProps) {
   const t = useT();
   const darwinChrome = platform === "darwin";
-  const detachCommand = !darwinChrome;
   const showWindowsPreviewControls = browserPreviewChrome && platform === "windows";
   const chromeClassName = [
     "app-chrome",
@@ -79,7 +78,7 @@ export function AppChrome({
       onTabsClose={onTabsClose}
       onTabsReorder={onTabsReorder}
       onNewTab={onNewTab}
-      onOpenPalette={detachCommand ? undefined : onOpenPalette}
+      onOpenPalette={undefined}
       commandCompact={commandCompact}
     />
   );
@@ -123,9 +122,33 @@ export function AppChrome({
       {workbenchChrome ? (
         <span className="app-chrome__spacer" aria-hidden="true" />
       ) : darwinChrome ? (
-        <div className="app-chrome__tab-strip app-chrome__tab-strip--darwin">
-          {tabBar}
-        </div>
+        <>
+          <div className="app-chrome__tab-strip app-chrome__tab-strip--darwin">
+            {tabBar}
+          </div>
+          <div
+            className={[
+              "app-chrome__tools",
+              "app-chrome__tools--fixed",
+              workspaceTogglePressed ? "app-chrome__tools--workspace-pressed" : "",
+            ].filter(Boolean).join(" ")}
+            aria-label={t("tabBar.commandSearch")}
+          >
+            <button
+              className={[
+                "tabbar__command",
+                "tabbar__command--compact",
+                "app-chrome__command",
+              ].filter(Boolean).join(" ")}
+              type="button"
+              onClick={onOpenPalette}
+              aria-label={t("palette.placeholder")}
+              title={t("palette.placeholder")}
+            >
+              <Search size={16} className="tabbar__command-icon" />
+            </button>
+          </div>
+        </>
       ) : (
         <>
           <div className="app-chrome__tab-strip app-chrome__tab-strip--native">

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14780,6 +14780,16 @@ a[href] {
   min-width: 16px;
 }
 
+.app-chrome__tab-strip {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: stretch;
+  overflow: hidden;
+}
+
 .app-chrome__identity {
   flex: 0 0 auto;
   min-width: 128px;
@@ -18517,6 +18527,12 @@ a[href] {
 
 :root[data-theme-style] .tabbar__tabs::-webkit-scrollbar {
   display: none;
+}
+
+:root[data-theme-style] .app-chrome--tabs .tabbar,
+:root[data-theme-style] .app-chrome--tabs .tabbar__tabs {
+  flex: 1 1 auto;
+  max-width: 100%;
 }
 
 .app-chrome--workbench .app-chrome__workbench-search {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -14845,6 +14845,14 @@ a[href] {
   margin-left: 0;
 }
 
+.app-chrome__tools--fixed {
+  position: absolute;
+  top: 0;
+  right: calc(var(--chrome-toggle-size) + 8px);
+  z-index: var(--z-local-raised);
+  margin-left: 0;
+}
+
 .app-chrome__tools--workspace-pressed .app-chrome__command {
   animation: app-chrome-command-follow-toggle 260ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
@@ -14898,7 +14906,7 @@ a[href] {
 
 .app--darwin .app-chrome--tabs {
   align-items: stretch;
-  padding: 0 calc(var(--chrome-right-toggle-offset) + var(--chrome-toggle-size) + 8px) 0 calc(var(--chrome-left-toggle-offset) + var(--chrome-toggle-size) + 8px);
+  padding: 0 calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 16px) 0 calc(var(--chrome-left-toggle-offset) + var(--chrome-toggle-size) + 8px);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--bg-soft) 94%, var(--bg-elev)), var(--bg-soft));
   transition: padding 0.28s cubic-bezier(0.2, 0.72, 0.2, 1);
@@ -14914,7 +14922,7 @@ a[href] {
   position: absolute;
   top: 0;
   left: calc(var(--chrome-left-toggle-offset) + var(--chrome-toggle-size) + 12px);
-  right: calc(var(--chrome-right-toggle-offset) + var(--chrome-toggle-size) + 12px);
+  right: calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 20px);
   z-index: var(--z-local-handle);
   height: 10px;
   --wails-draggable: drag;
@@ -14967,7 +14975,7 @@ a[href] {
 }
 
 .app--darwin .app-chrome--tabs .app-chrome__panel-toggle--right {
-  right: var(--chrome-right-toggle-offset);
+  right: 8px;
 }
 
 .app--darwin .app-chrome--tabs .app-chrome__panel-toggle:hover {
@@ -17770,7 +17778,7 @@ a[href] {
 }
 
 .app--darwin .app-chrome--tabs {
-  padding-right: calc(var(--chrome-right-toggle-offset) + var(--chrome-toggle-size) + 10px);
+  padding-right: calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 16px);
   background: color-mix(in srgb, var(--bg-soft) 90%, var(--bg-elev));
 }
 
@@ -18359,7 +18367,7 @@ a[href] {
 
 :root[data-theme-style] .app--darwin .app-chrome--tabs {
   padding-left: calc(var(--chrome-left-safe-offset) + var(--chrome-toggle-size) + 8px);
-  padding-right: calc(var(--chrome-right-toggle-offset) + var(--chrome-toggle-size) + 12px);
+  padding-right: calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 16px);
   background: var(--bg-elev);
   transition: background var(--dur-fast), border-color var(--dur-fast);
 }
@@ -20564,11 +20572,15 @@ a[href] {
    new_design comps: panel toggles, run-mode badges, active sessions, and file
    tree folder rows all use each theme's accent + accent-soft pair. */
 :root[data-theme-style] .app--darwin .app-chrome--tabs {
-  padding-right: calc(var(--chrome-right-toggle-offset) + var(--chrome-toggle-size) + 12px);
+  padding-right: calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 16px);
 }
 
 :root[data-theme-style] .app--darwin .app-chrome--tabs .app-chrome__panel-toggle--right {
   right: 8px;
+}
+
+:root[data-theme-style] .app--darwin .app-chrome--tabs .app-chrome__tools--fixed {
+  right: calc(8px + var(--chrome-toggle-size) + 8px);
 }
 
 :root[data-theme-style] .app--darwin .app-chrome--tabs .app-chrome__panel-toggle--left.app-chrome__panel-toggle--active,


### PR DESCRIPTION
## Summary
- Bound the desktop chrome tab strip container so tabs stay clipped to the available chrome area.
- Keep themed chrome tab lists capped at `max-width: 100%` instead of allowing `max-width: none` to override the available area.
- Pin the macOS command-search button as a fixed chrome tool next to the right panel toggle, so opening the right dock does not drag the search button left or unnecessarily reduce tab capacity.
- Extend the focused AppChrome tab regression test to cover overflow clipping, bounded themed tab lists, and fixed macOS chrome tools.

## Root Cause
PR #4422 reserved the right dock width in the chrome padding, but the themed tab list still allowed `max-width: none`. That avoided some overlap but made the macOS chrome treat the right dock as unavailable tab space. With enough open tabs, the command-search button could move with the tab flow instead of staying fixed beside the right panel toggle.

## Solution
The tab strip is now bounded and scrollable, while macOS renders command search as a fixed chrome tool. macOS chrome padding reserves only the fixed search and panel-toggle controls, so the tab strip can use the full top chrome width even when the right dock is open.

## Verification
- `npm run check:css`
- `npx tsx src/__tests__/app-chrome-tabs.test.ts`
- `git diff --check origin/main-v2...HEAD`
