### PR TITLE
Reserve mac tabbar new button slot / 预留 mac 标签栏新建按钮槽位

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -74,8 +74,13 @@ ok(
 );
 
 ok(
-  finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar__tabs", "max-width") === "100%",
-  "themed AppChrome tab lists keep a bounded maximum width",
+  finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar__tabs", "max-width")?.includes("--chrome-panel-control-size"),
+  "themed AppChrome tab lists reserve a flowing new-tab button slot",
+);
+
+ok(
+  finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar > .tooltip-trigger:has(.tabbar__new)", "flex")?.includes("--chrome-panel-control-size"),
+  "themed AppChrome new-tab button keeps a stable slot beside the tabs",
 );
 
 ok(

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -18537,10 +18537,21 @@ a[href] {
   display: none;
 }
 
-:root[data-theme-style] .app-chrome--tabs .tabbar,
-:root[data-theme-style] .app-chrome--tabs .tabbar__tabs {
+:root[data-theme-style] .app-chrome--tabs .tabbar {
   flex: 1 1 auto;
   max-width: 100%;
+}
+
+:root[data-theme-style] .app-chrome--tabs .tabbar__tabs {
+  flex: 1 1 auto;
+  max-width: calc(100% - var(--chrome-panel-control-size, 30px) - 10px);
+}
+
+:root[data-theme-style] .app-chrome--tabs .tabbar > .tooltip-trigger:has(.tabbar__new) {
+  flex: 0 0 var(--chrome-panel-control-size, 30px);
+  width: var(--chrome-panel-control-size, 30px);
+  min-width: var(--chrome-panel-control-size, 30px);
+  display: inline-flex;
 }
 
 .app-chrome--workbench .app-chrome__workbench-search {


### PR DESCRIPTION
## Summary
- Keep the macOS tabbar new-session button in the flowing tab strip instead of pinning it as a fixed chrome tool.
- Reserve a stable new-button slot by subtracting the button width from themed AppChrome tab-list max width.
- Add a focused AppChrome regression test so the tab list cannot consume the new-button slot again.

## Root Cause
After the command search button was pinned as a fixed chrome tool, themed AppChrome still let `.tabbar__tabs` use `max-width: 100%`. With enough tabs, the scrollable tab list consumed the whole tabbar width and pushed the flowing new-session button under the fixed search button.

## Solution
The tab list remains scrollable, the new-session button still follows the rightmost visible tab, and the themed chrome tab list now reserves the new-button slot before the fixed search area.

## Verification
- `npm run check:css`
- `npx tsx src/__tests__/app-chrome-tabs.test.ts`
- `git diff --check origin/main-v2...HEAD`
