### PR TITLE
Fix Claude skill markdown warnings

### DIFF
--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -155,10 +155,14 @@ const (
 
 // Root is one discovery directory with its scope, priority, and status.
 type Root struct {
-	Dir               string
-	Scope             Scope
-	Priority          int
-	Status            PathStatus
+	Dir      string
+	Scope    Scope
+	Priority int
+	Status   PathStatus
+}
+
+type discoveryRoot struct {
+	Root
 	requireFlatMarker bool
 }
 
@@ -166,7 +170,7 @@ type Root struct {
 // convention dirs (config.ConventionDirs: .reasonix / .agents / .agent / .claude)
 // under the project root → custom paths → the same convention dirs under the home
 // dir. A later root never overrides an earlier one.
-func (s *Store) roots() []Root {
+func (s *Store) roots() []discoveryRoot {
 	type de struct {
 		dir               string
 		scope             Scope
@@ -184,18 +188,28 @@ func (s *Store) roots() []Root {
 	for _, c := range config.ConventionDirs {
 		dirs = append(dirs, de{filepath.Join(s.homeDir, c, SkillsDirname), ScopeGlobal, c == ".claude"})
 	}
-	out := make([]Root, 0, len(dirs))
+	out := make([]discoveryRoot, 0, len(dirs))
 	for _, d := range dirs {
 		if s.excludedPaths[config.CanonicalSkillPath(d.dir)] {
 			continue
 		}
-		out = append(out, Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir), requireFlatMarker: d.requireFlatMarker})
+		out = append(out, discoveryRoot{
+			Root:              Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir)},
+			requireFlatMarker: d.requireFlatMarker,
+		})
 	}
 	return out
 }
 
 // Roots exposes the discovery directories with their status for `/skill paths`.
-func (s *Store) Roots() []Root { return s.roots() }
+func (s *Store) Roots() []Root {
+	roots := s.roots()
+	out := make([]Root, 0, len(roots))
+	for _, r := range roots {
+		out = append(out, r.Root)
+	}
+	return out
+}
 
 func disabledNameSet(names []string) map[string]bool {
 	out := map[string]bool{}
@@ -302,7 +316,7 @@ func (s *Store) Read(name string) (Skill, bool) {
 	return Skill{}, false
 }
 
-func (s *Store) discoverRoot(r Root) []Skill {
+func (s *Store) discoverRoot(r discoveryRoot) []Skill {
 	var out []Skill
 	s.scanDir(r.Dir, r.Scope, r.requireFlatMarker, 1, map[string]bool{}, &out)
 	return out
@@ -450,8 +464,10 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 	}, true
 }
 
+var skillMarkerFrontmatterKeys = []string{"description", "name", "runas", "context", "agent", "allowed-tools", "model", "effort"}
+
 func hasSkillMarker(fm map[string]string) bool {
-	for _, key := range []string{"description", "name", "runas", "context", "agent", "allowed-tools", "model", "effort"} {
+	for _, key := range skillMarkerFrontmatterKeys {
 		if strings.TrimSpace(fm[key]) != "" {
 			return true
 		}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -444,10 +444,10 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 	}
 
 	name := stem
-	if v := fm["name"]; v != "" && IsValidName(v) {
+	if v := fm[skillFrontmatterName]; v != "" && IsValidName(v) {
 		name = v
 	}
-	desc := strings.TrimSpace(fm["description"])
+	desc := strings.TrimSpace(fm[skillFrontmatterDescription])
 	if desc == "" {
 		fmt.Fprintf(s.stderr, "warning: skill %q at %s has no description: — it will load but won't appear in the skills index\n", name, path)
 	}
@@ -457,14 +457,34 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 		Body:         loadBodyWithReferences(path, strings.TrimSpace(body)),
 		Scope:        scope,
 		Path:         path,
-		AllowedTools: parseAllowedTools(fm["allowed-tools"]),
-		RunAs:        parseRunAs(fm["runas"], fm["context"], fm["agent"]),
-		Model:        strings.TrimSpace(fm["model"]),
-		Effort:       strings.TrimSpace(fm["effort"]),
+		AllowedTools: parseAllowedTools(fm[skillFrontmatterAllowedTools]),
+		RunAs:        parseRunAs(fm[skillFrontmatterRunAs], fm[skillFrontmatterContext], fm[skillFrontmatterAgent]),
+		Model:        strings.TrimSpace(fm[skillFrontmatterModel]),
+		Effort:       strings.TrimSpace(fm[skillFrontmatterEffort]),
 	}, true
 }
 
-var skillMarkerFrontmatterKeys = []string{"description", "name", "runas", "context", "agent", "allowed-tools", "model", "effort"}
+const (
+	skillFrontmatterDescription  = "description"
+	skillFrontmatterName         = "name"
+	skillFrontmatterRunAs        = "runas"
+	skillFrontmatterContext      = "context"
+	skillFrontmatterAgent        = "agent"
+	skillFrontmatterAllowedTools = "allowed-tools"
+	skillFrontmatterModel        = "model"
+	skillFrontmatterEffort       = "effort"
+)
+
+var skillMarkerFrontmatterKeys = []string{
+	skillFrontmatterDescription,
+	skillFrontmatterName,
+	skillFrontmatterRunAs,
+	skillFrontmatterContext,
+	skillFrontmatterAgent,
+	skillFrontmatterAllowedTools,
+	skillFrontmatterModel,
+	skillFrontmatterEffort,
+}
 
 func hasSkillMarker(fm map[string]string) bool {
 	for _, key := range skillMarkerFrontmatterKeys {

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -6,8 +6,10 @@
 // enter the cache-stable system-prompt index (see index.go) — bodies load on
 // demand. Discovery scans several conventions (.reasonix / .agents / .agent /
 // .claude under the project root and the home dir — see config.ConventionDirs) so
-// skills authored for other agent tools migrate in unchanged, and follows
-// symlinks, so a linked skill directory or flat <name>.md is picked up like a real one.
+// skills authored for other agent tools migrate in unchanged. Directory skills
+// use <name>/SKILL.md; flat <name>.md files from Claude roots are loaded only
+// when they carry skill frontmatter. Discovery follows symlinks, so linked
+// skills are picked up like real ones.
 package skill
 
 import (
@@ -153,10 +155,11 @@ const (
 
 // Root is one discovery directory with its scope, priority, and status.
 type Root struct {
-	Dir      string
-	Scope    Scope
-	Priority int
-	Status   PathStatus
+	Dir               string
+	Scope             Scope
+	Priority          int
+	Status            PathStatus
+	requireFlatMarker bool
 }
 
 // roots returns the discovery directories, highest priority first: the
@@ -165,27 +168,28 @@ type Root struct {
 // dir. A later root never overrides an earlier one.
 func (s *Store) roots() []Root {
 	type de struct {
-		dir   string
-		scope Scope
+		dir               string
+		scope             Scope
+		requireFlatMarker bool
 	}
 	var dirs []de
 	if s.projectRoot != "" {
 		for _, c := range config.ConventionDirs {
-			dirs = append(dirs, de{filepath.Join(s.projectRoot, c, SkillsDirname), ScopeProject})
+			dirs = append(dirs, de{filepath.Join(s.projectRoot, c, SkillsDirname), ScopeProject, c == ".claude"})
 		}
 	}
 	for _, d := range s.customPaths {
-		dirs = append(dirs, de{d, ScopeCustom})
+		dirs = append(dirs, de{d, ScopeCustom, false})
 	}
 	for _, c := range config.ConventionDirs {
-		dirs = append(dirs, de{filepath.Join(s.homeDir, c, SkillsDirname), ScopeGlobal})
+		dirs = append(dirs, de{filepath.Join(s.homeDir, c, SkillsDirname), ScopeGlobal, c == ".claude"})
 	}
 	out := make([]Root, 0, len(dirs))
 	for _, d := range dirs {
 		if s.excludedPaths[config.CanonicalSkillPath(d.dir)] {
 			continue
 		}
-		out = append(out, Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir)})
+		out = append(out, Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir), requireFlatMarker: d.requireFlatMarker})
 	}
 	return out
 }
@@ -300,11 +304,11 @@ func (s *Store) Read(name string) (Skill, bool) {
 
 func (s *Store) discoverRoot(r Root) []Skill {
 	var out []Skill
-	s.scanDir(r.Dir, r.Scope, 1, map[string]bool{}, &out)
+	s.scanDir(r.Dir, r.Scope, r.requireFlatMarker, 1, map[string]bool{}, &out)
 	return out
 }
 
-func (s *Store) scanDir(dir string, scope Scope, depth int, seen map[string]bool, out *[]Skill) {
+func (s *Store) scanDir(dir string, scope Scope, requireFlatMarker bool, depth int, seen map[string]bool, out *[]Skill) {
 	key := filepath.Clean(dir)
 	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
 		key = filepath.Clean(resolved)
@@ -319,7 +323,7 @@ func (s *Store) scanDir(dir string, scope Scope, depth int, seen map[string]bool
 		return
 	}
 	for _, e := range entries {
-		sk, ok := s.readEntry(dir, scope, e)
+		sk, ok := s.readEntry(dir, scope, requireFlatMarker, e)
 		if ok {
 			if depth == 1 || strings.TrimSpace(sk.Description) != "" {
 				*out = append(*out, sk)
@@ -329,7 +333,7 @@ func (s *Store) scanDir(dir string, scope Scope, depth int, seen map[string]bool
 		if depth >= s.maxDepth || !s.canScanChildDir(dir, e) {
 			continue
 		}
-		s.scanDir(filepath.Join(dir, e.Name()), scope, depth+1, seen, out)
+		s.scanDir(filepath.Join(dir, e.Name()), scope, requireFlatMarker, depth+1, seen, out)
 	}
 }
 
@@ -362,10 +366,10 @@ func shouldSkipScanDir(name string) bool {
 }
 
 // readEntry turns one directory entry into a skill. It resolves symlinks via
-// os.Stat (os.ReadDir reports a symlink's own type, not its target's), so a
-// linked skill directory or a linked flat <name>.md is discovered like a real
-// one; a broken link fails Stat and is skipped.
-func (s *Store) readEntry(dir string, scope Scope, e os.DirEntry) (Skill, bool) {
+// os.Stat (os.ReadDir reports a symlink's own type, not its target's), so linked
+// skill directories and linked flat skill files behave like real ones; a broken
+// link fails Stat and is skipped.
+func (s *Store) readEntry(dir string, scope Scope, requireFlatMarker bool, e os.DirEntry) (Skill, bool) {
 	name := e.Name()
 	full := filepath.Join(dir, name)
 
@@ -395,7 +399,7 @@ func (s *Store) readEntry(dir string, scope Scope, e os.DirEntry) (Skill, bool) 
 		if !IsValidName(stem) {
 			return Skill{}, false
 		}
-		return s.parse(full, stem, scope)
+		return s.parseFlat(full, stem, scope, requireFlatMarker)
 	}
 	return Skill{}, false
 }
@@ -404,12 +408,26 @@ func (s *Store) readEntry(dir string, scope Scope, e os.DirEntry) (Skill, bool) 
 // filename stem when valid; a missing `description:` is a warning, not a failure
 // (the skill loads but won't appear in the model's index).
 func (s *Store) parse(path, stem string, scope Scope) (Skill, bool) {
+	return s.parseSkill(path, stem, scope, false)
+}
+
+// parseFlat reads a flat <name>.md skill candidate. Claude skill roots can also
+// contain ordinary documentation, so those flat files need explicit skill
+// frontmatter before they are treated as skills.
+func (s *Store) parseFlat(path, stem string, scope Scope, requireSkillMarker bool) (Skill, bool) {
+	return s.parseSkill(path, stem, scope, requireSkillMarker)
+}
+
+func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bool) (Skill, bool) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return Skill{}, false
 	}
 	content := strings.TrimPrefix(strings.ReplaceAll(string(b), "\r\n", "\n"), "\uFEFF")
 	fm, body := splitFrontmatter(content)
+	if requireSkillMarker && !hasSkillMarker(fm) {
+		return Skill{}, false
+	}
 
 	name := stem
 	if v := fm["name"]; v != "" && IsValidName(v) {
@@ -430,6 +448,15 @@ func (s *Store) parse(path, stem string, scope Scope) (Skill, bool) {
 		Model:        strings.TrimSpace(fm["model"]),
 		Effort:       strings.TrimSpace(fm["effort"]),
 	}, true
+}
+
+func hasSkillMarker(fm map[string]string) bool {
+	for _, key := range []string{"description", "name", "runas", "context", "agent", "allowed-tools", "model", "effort"} {
+		if strings.TrimSpace(fm[key]) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // Create scaffolds a new skill stub at the chosen scope. Refuses to overwrite.

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -157,7 +157,7 @@ func TestConventionDirsDiscovered(t *testing.T) {
 
 func TestNonSkillMarkdownInClaudeSkillRootsIgnored(t *testing.T) {
 	proj := t.TempDir()
-	writeSkill(t, proj, ".claude/skills/README.md", "# Skill notes\n\nThis is documentation, not a skill.")
+	writeSkill(t, proj, ".claude/skills/guide.md", "# Skill notes\n\nThis is documentation, not a skill.")
 	writeSkill(t, proj, ".claude/skills/notes.md", "---\ntitle: Notes\n---\n# Notes")
 	writeSkill(t, proj, ".claude/skills/real.md", "---\ndescription: real skill\n---\nbody")
 
@@ -167,7 +167,7 @@ func TestNonSkillMarkdownInClaudeSkillRootsIgnored(t *testing.T) {
 	if _, ok := find(list, "real"); !ok {
 		t.Fatal("real skill should be discovered")
 	}
-	for _, name := range []string{"README", "notes"} {
+	for _, name := range []string{"guide", "notes"} {
 		if _, ok := find(list, name); ok {
 			t.Errorf("non-skill markdown %q should not be listed", name)
 		}
@@ -176,7 +176,7 @@ func TestNonSkillMarkdownInClaudeSkillRootsIgnored(t *testing.T) {
 		t.Fatalf("non-skill markdown should not warn during List, got %q", got)
 	}
 
-	for _, name := range []string{"README", "notes"} {
+	for _, name := range []string{"guide", "notes"} {
 		stderr.Reset()
 		if _, ok := st.Read(name); ok {
 			t.Errorf("non-skill markdown %q should not be readable as a skill", name)
@@ -199,6 +199,24 @@ func TestSkillLikeFlatClaudeMarkdownWithoutDescriptionWarns(t *testing.T) {
 	}
 	if got := stderr.String(); !strings.Contains(got, "has no description") {
 		t.Fatalf("skill-like flat Claude markdown without description should warn, got %q", got)
+	}
+}
+
+func TestRunAsOnlyFlatClaudeMarkdownIsSkillLike(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".claude/skills/sub.md", "---\nrunAs: subagent\n---\nbody")
+
+	var stderr bytes.Buffer
+	st := New(Options{HomeDir: home, DisableBuiltins: true, Stderr: &stderr})
+	sk, ok := st.Read("sub")
+	if !ok {
+		t.Fatal("runAs-only Claude markdown should be treated as skill-like")
+	}
+	if sk.RunAs != RunSubagent {
+		t.Fatalf("runAs should be parsed despite frontmatter key casing, got %s", sk.RunAs)
+	}
+	if got := stderr.String(); !strings.Contains(got, "has no description") {
+		t.Fatalf("runAs-only Claude markdown without description should warn, got %q", got)
 	}
 }
 

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -151,6 +152,53 @@ func TestConventionDirsDiscovered(t *testing.T) {
 		if _, ok := find(list, name); !ok {
 			t.Errorf("convention dir for %q not scanned", name)
 		}
+	}
+}
+
+func TestNonSkillMarkdownInClaudeSkillRootsIgnored(t *testing.T) {
+	proj := t.TempDir()
+	writeSkill(t, proj, ".claude/skills/README.md", "# Skill notes\n\nThis is documentation, not a skill.")
+	writeSkill(t, proj, ".claude/skills/notes.md", "---\ntitle: Notes\n---\n# Notes")
+	writeSkill(t, proj, ".claude/skills/real.md", "---\ndescription: real skill\n---\nbody")
+
+	var stderr bytes.Buffer
+	st := New(Options{HomeDir: t.TempDir(), ProjectRoot: proj, DisableBuiltins: true, Stderr: &stderr})
+	list := st.List()
+	if _, ok := find(list, "real"); !ok {
+		t.Fatal("real skill should be discovered")
+	}
+	for _, name := range []string{"README", "notes"} {
+		if _, ok := find(list, name); ok {
+			t.Errorf("non-skill markdown %q should not be listed", name)
+		}
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("non-skill markdown should not warn during List, got %q", got)
+	}
+
+	for _, name := range []string{"README", "notes"} {
+		stderr.Reset()
+		if _, ok := st.Read(name); ok {
+			t.Errorf("non-skill markdown %q should not be readable as a skill", name)
+		}
+		if got := stderr.String(); got != "" {
+			t.Errorf("non-skill markdown %q should not warn during Read, got %q", name, got)
+		}
+	}
+}
+
+func TestSkillLikeFlatClaudeMarkdownWithoutDescriptionWarns(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".claude/skills/named.md", "---\nname: renamed\n---\nbody")
+
+	var stderr bytes.Buffer
+	st := New(Options{HomeDir: home, DisableBuiltins: true, Stderr: &stderr})
+	list := st.List()
+	if _, ok := find(list, "renamed"); !ok {
+		t.Fatal("skill-like flat Claude markdown should still load")
+	}
+	if got := stderr.String(); !strings.Contains(got, "has no description") {
+		t.Fatalf("skill-like flat Claude markdown without description should warn, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Require skill frontmatter before treating flat Markdown files in `.claude/skills` roots as skills.
- Preserve directory-layout `SKILL.md` loading and existing non-Claude flat skill behavior.
- Add regression coverage for plain Claude documentation files being ignored without warnings.

## Validation

- `go test ./internal/skill ./internal/config`
- `go test ./internal/boot` with isolated `HOME` and `XDG_CONFIG_HOME`
- `git diff --check -- internal/skill/skill.go internal/skill/skill_test.go`

Note: `go test ./internal/cli` failed in the default environment because configured model credentials made `TestModelRefsSkipsUnconfigured` see provider refs. A clean-env rerun was started but did not finish after several minutes, so it was stopped.
