### PR TITLE
Ignore background performance pressure / 忽略后台性能压力误报

### DIFF
--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -80,14 +80,17 @@ eq(shouldRecordLongTaskSample(16_000, 900, 15_000), true, "records post-grace lo
 eq(shouldRecordLongTaskSample(60_000, 900, 15_000, true, 20_000), false, "ignores long tasks while the window is hidden");
 eq(shouldRecordLongTaskSample(23_000, 900, 15_000, false, 20_000), false, "ignores long tasks immediately after visibility resumes");
 eq(shouldRecordLongTaskSample(26_000, 900, 15_000, false, 20_000), true, "records long tasks after the visibility resume grace period");
+eq(shouldRecordLongTaskSample(570_000, 92, 15_000, false, 20_000, false), false, "ignores long tasks while unfocused");
 eq(shouldRecordEventLoopLagSample(true, 60_000), false, "ignores event-loop lag while the window is hidden");
 eq(shouldRecordEventLoopLagSample(false, 3_000), false, "ignores event-loop lag immediately after visibility resumes");
 eq(shouldRecordEventLoopLagSample(false, 6_000), true, "records event-loop lag after the visibility resume grace period");
+eq(shouldRecordEventLoopLagSample(false, 60_000, false), false, "ignores event-loop lag while unfocused");
 
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false), true, "prompts an unhandled label past cooldown while visible");
 eq(shouldPromptForPerformanceLabel(true, 11 * 60_000, false), false, "suppresses an already reported or dismissed label");
 eq(shouldPromptForPerformanceLabel(false, 5 * 60_000, false), false, "respects the prompt cooldown window");
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, true), false, "never prompts while the window is hidden");
+eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false, false), false, "never prompts while unfocused");
 
 const reportedPerf = serializeReportedPerf(new Set(["performance.lag"]), "abc123");
 eq([...parseReportedPerf(reportedPerf, "abc123")], ["performance.lag"], "round-trips reported labels for the same build");

--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -8,6 +8,7 @@ import {
   parseReportedPerf,
   performanceLabelForReason,
   serializeReportedPerf,
+  shouldRecordEventLoopLagSample,
   shouldPromptForPerformanceLabel,
   shouldRecordLongTaskSample,
   topFrameFromStack,
@@ -76,6 +77,12 @@ eq(performanceLabelForReason("js heap 87% of limit"), "performance.heap", "label
 eq(shouldRecordLongTaskSample(14_000, 900, 15_000), false, "ignores startup long tasks before grace ends");
 eq(shouldRecordLongTaskSample(16_000, 40, 15_000), false, "ignores short long-task observer entries");
 eq(shouldRecordLongTaskSample(16_000, 900, 15_000), true, "records post-grace long tasks");
+eq(shouldRecordLongTaskSample(60_000, 900, 15_000, true, 20_000), false, "ignores long tasks while the window is hidden");
+eq(shouldRecordLongTaskSample(23_000, 900, 15_000, false, 20_000), false, "ignores long tasks immediately after visibility resumes");
+eq(shouldRecordLongTaskSample(26_000, 900, 15_000, false, 20_000), true, "records long tasks after the visibility resume grace period");
+eq(shouldRecordEventLoopLagSample(true, 60_000), false, "ignores event-loop lag while the window is hidden");
+eq(shouldRecordEventLoopLagSample(false, 3_000), false, "ignores event-loop lag immediately after visibility resumes");
+eq(shouldRecordEventLoopLagSample(false, 6_000), true, "records event-loop lag after the visibility resume grace period");
 
 eq(shouldPromptForPerformanceLabel(false, 11 * 60_000, false), true, "prompts an unhandled label past cooldown while visible");
 eq(shouldPromptForPerformanceLabel(true, 11 * 60_000, false), false, "suppresses an already reported or dismissed label");

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -366,12 +366,19 @@ export function shouldRecordLongTaskSample(
   graceUntilMs: number,
   visibilityHidden = false,
   visibleSinceMs = 0,
+  focused = true,
 ): boolean {
+  if (!focused) return false;
   if (visibilityHidden) return false;
   return durationMs >= 50 && startMs >= graceUntilMs && startMs - visibleSinceMs >= VISIBILITY_RESUME_GRACE_MS;
 }
 
-export function shouldRecordEventLoopLagSample(visibilityHidden: boolean, msSinceVisible: number): boolean {
+export function shouldRecordEventLoopLagSample(
+  visibilityHidden: boolean,
+  msSinceVisible: number,
+  focused = true,
+): boolean {
+  if (!focused) return false;
   if (visibilityHidden) return false;
   return msSinceVisible >= VISIBILITY_RESUME_GRACE_MS;
 }
@@ -529,10 +536,12 @@ export function shouldPromptForPerformanceLabel(
   alreadyHandled: boolean,
   msSinceLastPrompt: number,
   visibilityHidden: boolean,
+  focused = true,
 ): boolean {
   if (alreadyHandled) return false;
   if (msSinceLastPrompt < PROMPT_COOLDOWN_MS) return false;
   if (visibilityHidden) return false;
+  if (!focused) return false;
   return true;
 }
 
@@ -542,7 +551,8 @@ function isPerfLabelHandled(label: string): boolean {
 
 function shouldPromptForPerformance(now: number, label: string): boolean {
   const hidden = typeof document !== "undefined" && document.visibilityState === "hidden";
-  return shouldPromptForPerformanceLabel(isPerfLabelHandled(label), now - lastPerformancePromptAt, hidden);
+  const focused = typeof document === "undefined" || document.hasFocus?.() !== false;
+  return shouldPromptForPerformanceLabel(isPerfLabelHandled(label), now - lastPerformancePromptAt, hidden, focused);
 }
 
 function promptPerformanceReport(reason: string, currentLagMs = 0): void {
@@ -570,6 +580,7 @@ export function installPerformancePressureMonitor() {
   const startedAt = performance.now();
   const graceUntil = startedAt + STARTUP_GRACE_MS;
   const isHidden = () => typeof document !== "undefined" && document.visibilityState === "hidden";
+  const isFocused = () => typeof document === "undefined" || document.hasFocus?.() !== false;
   let visibleSince = isHidden() ? Number.POSITIVE_INFINITY : startedAt;
   let expected = performance.now() + 1000;
 
@@ -596,7 +607,7 @@ export function installPerformancePressureMonitor() {
     try {
       const observer = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
-          if (!shouldRecordLongTaskSample(entry.startTime, entry.duration, graceUntil, isHidden(), visibleSince)) continue;
+          if (!shouldRecordLongTaskSample(entry.startTime, entry.duration, graceUntil, isHidden(), visibleSince, isFocused())) continue;
           longTasks.push({ startMs: Math.round(entry.startTime), durationMs: Math.round(entry.duration) });
         }
         pruneLongTasks();
@@ -613,7 +624,7 @@ export function installPerformancePressureMonitor() {
     const lagMs = Math.max(0, now - expected);
     expected = now + 1000;
     if (!pastGrace()) return;
-    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince)) return;
+    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince, isFocused())) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
     if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -96,6 +96,7 @@ const EVENT_LOOP_LAG_PROMPT_MS = 1_200;
 const STARTUP_GRACE_MS = 15_000;
 const PROMPT_COOLDOWN_MS = 10 * 60_000;
 const MAX_LAG_SAMPLES = 60;
+const VISIBILITY_RESUME_GRACE_MS = 5_000;
 
 const longTasks: LongTaskSample[] = [];
 const lagSamples: number[] = [];
@@ -359,8 +360,20 @@ export function performanceLabelForReason(reason: string): string {
   return "performance.pressure";
 }
 
-export function shouldRecordLongTaskSample(startMs: number, durationMs: number, graceUntilMs: number): boolean {
-  return durationMs >= 50 && startMs >= graceUntilMs;
+export function shouldRecordLongTaskSample(
+  startMs: number,
+  durationMs: number,
+  graceUntilMs: number,
+  visibilityHidden = false,
+  visibleSinceMs = 0,
+): boolean {
+  if (visibilityHidden) return false;
+  return durationMs >= 50 && startMs >= graceUntilMs && startMs - visibleSinceMs >= VISIBILITY_RESUME_GRACE_MS;
+}
+
+export function shouldRecordEventLoopLagSample(visibilityHidden: boolean, msSinceVisible: number): boolean {
+  if (visibilityHidden) return false;
+  return msSinceVisible >= VISIBILITY_RESUME_GRACE_MS;
 }
 
 export function buildPerformancePayload(snapshot: PerformanceSnapshot): CrashPayload {
@@ -556,6 +569,9 @@ export function installPerformancePressureMonitor() {
   performanceMonitorInstalled = true;
   const startedAt = performance.now();
   const graceUntil = startedAt + STARTUP_GRACE_MS;
+  const isHidden = () => typeof document !== "undefined" && document.visibilityState === "hidden";
+  let visibleSince = isHidden() ? Number.POSITIVE_INFINITY : startedAt;
+  let expected = performance.now() + 1000;
 
   const pastGrace = () => performance.now() >= graceUntil;
   const inspectLongTasks = () => {
@@ -567,11 +583,20 @@ export function installPerformancePressureMonitor() {
     }
   };
 
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", () => {
+      longTasks.length = 0;
+      lagSamples.length = 0;
+      expected = performance.now() + 1000;
+      if (!isHidden()) visibleSince = performance.now();
+    });
+  }
+
   if (typeof PerformanceObserver !== "undefined") {
     try {
       const observer = new PerformanceObserver((list) => {
         for (const entry of list.getEntries()) {
-          if (!shouldRecordLongTaskSample(entry.startTime, entry.duration, graceUntil)) continue;
+          if (!shouldRecordLongTaskSample(entry.startTime, entry.duration, graceUntil, isHidden(), visibleSince)) continue;
           longTasks.push({ startMs: Math.round(entry.startTime), durationMs: Math.round(entry.duration) });
         }
         pruneLongTasks();
@@ -583,12 +608,12 @@ export function installPerformancePressureMonitor() {
     }
   }
 
-  let expected = performance.now() + 1000;
   window.setInterval(() => {
     const now = performance.now();
     const lagMs = Math.max(0, now - expected);
     expected = now + 1000;
     if (!pastGrace()) return;
+    if (!shouldRecordEventLoopLagSample(isHidden(), now - visibleSince)) return;
     lagSamples.push(lagMs);
     if (lagSamples.length > MAX_LAG_SAMPLES) lagSamples.shift();
     if (lagMs >= EVENT_LOOP_LAG_PROMPT_MS) promptPerformanceReport(`event loop lag ${fmtNumber(lagMs)}ms`, lagMs);


### PR DESCRIPTION
## Summary
- Ignore performance-pressure samples while the desktop window is hidden, immediately after it becomes visible again, or visible but unfocused.
- Suppress performance report prompts when the window is not focused, matching the reported visible-but-unfocused long-task case.
- Add regression coverage for hidden-window, visibility-resume grace, and unfocused-window behavior.

## Verification
- `wails generate module`
- `npx tsx src/__tests__/crash-reporting.test.ts`
- `npm run test:typecheck`
- `npm run build`
- `git diff --check`
