### PR TITLE
Default built-in pricing to CNY / 默认内置计费使用人民币

### DIFF
--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -2829,7 +2829,7 @@ function makeMockApp(): AppBindings {
         requestCount: 10,
         elapsedMs: 33 * 60 * 1000,
         sessionCost: 0.018,
-        sessionCurrency: "$",
+        sessionCurrency: "¥",
         sessionCostUsd: 0.018,
         sources: {
           executor: {
@@ -2841,7 +2841,7 @@ function makeMockApp(): AppBindings {
             cacheMissTokens: 9000,
             requestCount: 4,
             sessionCost: 0.0124,
-            sessionCurrency: "$",
+            sessionCurrency: "¥",
             sessionCostUsd: 0.0124,
           },
           planner: {
@@ -2853,7 +2853,7 @@ function makeMockApp(): AppBindings {
             cacheMissTokens: 700,
             requestCount: 1,
             sessionCost: 0.0011,
-            sessionCurrency: "$",
+            sessionCurrency: "¥",
             sessionCostUsd: 0.0011,
           },
           subagent: {
@@ -2865,7 +2865,7 @@ function makeMockApp(): AppBindings {
             cacheMissTokens: 2100,
             requestCount: 2,
             sessionCost: 0.0032,
-            sessionCurrency: "$",
+            sessionCurrency: "¥",
             sessionCostUsd: 0.0032,
           },
           compaction: {
@@ -2877,7 +2877,7 @@ function makeMockApp(): AppBindings {
             cacheMissTokens: 900,
             requestCount: 1,
             sessionCost: 0.0009,
-            sessionCurrency: "$",
+            sessionCurrency: "¥",
             sessionCostUsd: 0.0009,
           },
           classifier: {
@@ -2889,7 +2889,7 @@ function makeMockApp(): AppBindings {
             cacheMissTokens: 250,
             requestCount: 1,
             sessionCost: 0.0003,
-            sessionCurrency: "$",
+            sessionCurrency: "¥",
             sessionCostUsd: 0.0003,
           },
           title: {
@@ -2901,7 +2901,7 @@ function makeMockApp(): AppBindings {
             cacheMissTokens: 50,
             requestCount: 1,
             sessionCost: 0.0001,
-            sessionCurrency: "$",
+            sessionCurrency: "¥",
             sessionCostUsd: 0.0001,
           },
         },

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -891,31 +891,42 @@ func officialProviderTemplate(kind string) ([]config.ProviderEntry, string, erro
 			BalanceURL:    "https://api.deepseek.com/user/balance",
 			ContextWindow: 1_000_000,
 			Prices: map[string]*provider.Pricing{
-				"deepseek-v4-flash": &provider.Pricing{CacheHit: 0.0028, Input: 0.14, Output: 0.28, Currency: "$"},
-				"deepseek-v4-pro":   &provider.Pricing{CacheHit: 0.003625, Input: 0.435, Output: 0.87, Currency: "$"},
+				"deepseek-v4-flash": &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"},
+				"deepseek-v4-pro":   &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"},
 			},
 		}}, "DEEPSEEK_API_KEY", nil
 	case "mimo-api", "xiaomi-mimo", "xiaomi_mimo":
+		models := []string{"mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-omni"}
 		return []config.ProviderEntry{{
 			Name:          "mimo-api",
 			Kind:          "openai",
 			BaseURL:       "https://api.xiaomimimo.com/v1",
-			Models:        []string{"mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-omni"},
+			Models:        models,
 			Default:       "mimo-v2.5-pro",
 			APIKeyEnv:     "MIMO_API_KEY",
 			ContextWindow: 1_048_576,
-			NoProxy:       true,
+			Prices: map[string]*provider.Pricing{
+				"mimo-v2.5-pro": &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"},
+				"mimo-v2.5":     &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"},
+				"mimo-v2-omni":  &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"},
+			},
+			NoProxy: true,
 		}}, "MIMO_API_KEY", nil
 	case "mimo-token-plan", "xiaomi-mimo-token-plan", "xiaomi_mimo_token_plan":
+		models := []string{"mimo-v2.5-pro", "mimo-v2.5"}
 		return []config.ProviderEntry{{
 			Name:          "mimo-token-plan",
 			Kind:          "openai",
 			BaseURL:       "https://token-plan-cn.xiaomimimo.com/v1",
-			Models:        []string{"mimo-v2.5-pro", "mimo-v2.5"},
+			Models:        models,
 			Default:       "mimo-v2.5-pro",
 			APIKeyEnv:     "MIMO_API_KEY",
 			ContextWindow: 1_048_576,
-			NoProxy:       true,
+			Prices: map[string]*provider.Pricing{
+				"mimo-v2.5-pro": &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"},
+				"mimo-v2.5":     &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"},
+			},
+			NoProxy: true,
 		}}, "MIMO_API_KEY", nil
 	default:
 		return nil, "", fmt.Errorf("unknown official provider template %q", kind)

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -147,6 +147,15 @@ func TestOfficialMimoAPITemplateIncludesVisionModels(t *testing.T) {
 	if got.DefaultModel() != "mimo-v2.5-pro" {
 		t.Fatalf("mimo-api default = %q, want mimo-v2.5-pro", got.DefaultModel())
 	}
+	if got.Prices["mimo-v2.5-pro"] == nil || got.Prices["mimo-v2.5-pro"].Currency != "¥" || got.Prices["mimo-v2.5-pro"].Output != 6 {
+		t.Fatalf("mimo-v2.5-pro price = %+v, want RMB domestic pricing", got.Prices["mimo-v2.5-pro"])
+	}
+	if got.Prices["mimo-v2.5"] == nil || got.Prices["mimo-v2.5"].Currency != "¥" || got.Prices["mimo-v2.5"].Output != 2 {
+		t.Fatalf("mimo-v2.5 price = %+v, want RMB domestic pricing", got.Prices["mimo-v2.5"])
+	}
+	if got.Prices["mimo-v2-omni"] == nil || got.Prices["mimo-v2-omni"].Currency != "¥" || got.Prices["mimo-v2-omni"].Output != 2 {
+		t.Fatalf("mimo-v2-omni price = %+v, want RMB domestic pricing", got.Prices["mimo-v2-omni"])
+	}
 }
 
 func TestSetAgentParamsPersistsStepLimitsToUserConfig(t *testing.T) {

--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -25,7 +25,7 @@ func TestBackfillDeepSeekProRestoresPro(t *testing.T) {
 	pro := hasModel(c, "deepseek-v4-pro")
 	if pro == nil {
 		t.Fatal("deepseek-v4-pro not restored")
-	} else if pro.Price == nil || pro.Price.Output != 0.87 || pro.Price.Currency != "$" {
+	} else if pro.Price == nil || pro.Price.Output != 6 || pro.Price.Currency != "¥" {
 		t.Errorf("pro price not the preset: %+v", pro.Price)
 	}
 }
@@ -196,7 +196,7 @@ func TestBackfillDeepSeekOfficialPrices(t *testing.T) {
 	if !ok {
 		t.Fatal("deepseek provider missing")
 	}
-	if p.Prices["deepseek-v4-flash"].Output != 0.28 || p.Prices["deepseek-v4-pro"].Output != 0.87 {
+	if p.Prices["deepseek-v4-flash"].Output != 2 || p.Prices["deepseek-v4-pro"].Output != 6 {
 		t.Fatalf("deepseek prices = %+v, want current V4 flash/pro prices", p.Prices)
 	}
 }
@@ -210,22 +210,22 @@ func TestResolveModelUsesPerModelPricing(t *testing.T) {
 		Default: "deepseek-v4-flash",
 		Price:   &provider.Pricing{CacheHit: 9, Input: 9, Output: 9, Currency: "$"},
 		Prices: map[string]*provider.Pricing{
-			"deepseek-v4-flash": &provider.Pricing{CacheHit: 0.0028, Input: 0.14, Output: 0.28, Currency: "$"},
-			"deepseek-v4-pro":   &provider.Pricing{CacheHit: 0.003625, Input: 0.435, Output: 0.87, Currency: "$"},
+			"deepseek-v4-flash": &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"},
+			"deepseek-v4-pro":   &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"},
 		},
 	}}}
 	pro, ok := c.ResolveModel("deepseek/deepseek-v4-pro")
 	if !ok {
 		t.Fatal("deepseek pro did not resolve")
 	}
-	if pro.Price == nil || pro.Price.Output != 0.87 {
+	if pro.Price == nil || pro.Price.Output != 6 {
 		t.Fatalf("pro price = %+v, want model-specific pro price", pro.Price)
 	}
 	flash, ok := c.ResolveModel("deepseek")
 	if !ok {
 		t.Fatal("deepseek default did not resolve")
 	}
-	if flash.Price == nil || flash.Price.Output != 0.28 {
+	if flash.Price == nil || flash.Price.Output != 2 {
 		t.Fatalf("flash price = %+v, want model-specific flash price", flash.Price)
 	}
 }
@@ -303,5 +303,11 @@ func TestNormalizeDesktopOfficialProviderAccessBackfillsExistingMimoTokenPlanAnd
 	}
 	if p.Price != nil {
 		t.Fatalf("mimo-token-plan mixed-model price = %+v, want nil", p.Price)
+	}
+	if p.Prices["mimo-v2.5-pro"] == nil || p.Prices["mimo-v2.5-pro"].Currency != "¥" || p.Prices["mimo-v2.5-pro"].Output != 6 {
+		t.Fatalf("mimo-v2.5-pro price = %+v, want RMB domestic pricing", p.Prices["mimo-v2.5-pro"])
+	}
+	if p.Prices["mimo-v2.5"] == nil || p.Prices["mimo-v2.5"].Currency != "¥" || p.Prices["mimo-v2.5"].Output != 2 {
+		t.Fatalf("mimo-v2.5 price = %+v, want RMB domestic pricing", p.Prices["mimo-v2.5"])
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1261,24 +1261,69 @@ func Default() *Config {
 		Providers: []ProviderEntry{
 			{Name: "deepseek-flash", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: deepSeekV4FlashPrice()},
 			{Name: "deepseek-pro", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4-pro", APIKeyEnv: "DEEPSEEK_API_KEY", BalanceURL: "https://api.deepseek.com/user/balance", ContextWindow: 1_000_000, Price: deepSeekV4ProPrice()},
-			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}, NoProxy: true},
-			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}, NoProxy: true},
+			{Name: "mimo-pro", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5-pro", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: mimoV25ProPrice(), NoProxy: true},
+			{Name: "mimo-flash", Kind: "openai", BaseURL: "https://token-plan-cn.xiaomimimo.com/v1", Model: "mimo-v2.5", APIKeyEnv: "MIMO_API_KEY", ContextWindow: 1_000_000, Price: mimoV25Price(), NoProxy: true},
 		},
 	}
 }
 
 func deepSeekV4FlashPrice() *provider.Pricing {
-	return &provider.Pricing{CacheHit: 0.0028, Input: 0.14, Output: 0.28, Currency: "$"}
+	return &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}
 }
 
 func deepSeekV4ProPrice() *provider.Pricing {
-	return &provider.Pricing{CacheHit: 0.003625, Input: 0.435, Output: 0.87, Currency: "$"}
+	return &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}
 }
 
 func deepSeekV4Prices() map[string]*provider.Pricing {
 	return map[string]*provider.Pricing{
 		"deepseek-v4-flash": deepSeekV4FlashPrice(),
 		"deepseek-v4-pro":   deepSeekV4ProPrice(),
+	}
+}
+
+func mimoV25ProPrice() *provider.Pricing {
+	return &provider.Pricing{CacheHit: 0.025, Input: 3, Output: 6, Currency: "¥"}
+}
+
+func mimoV25Price() *provider.Pricing {
+	return &provider.Pricing{CacheHit: 0.02, Input: 1, Output: 2, Currency: "¥"}
+}
+
+func mimoV2FlashPrice() *provider.Pricing {
+	return &provider.Pricing{CacheHit: 0.07, Input: 0.70, Output: 2.10, Currency: "¥"}
+}
+
+func mimoDomesticPrices(models []string) map[string]*provider.Pricing {
+	prices := map[string]*provider.Pricing{}
+	for _, model := range models {
+		switch strings.TrimSpace(model) {
+		case "mimo-v2.5-pro", "mimo-v2-pro":
+			prices[model] = mimoV25ProPrice()
+		case "mimo-v2.5", "mimo-v2-omni":
+			prices[model] = mimoV25Price()
+		case "mimo-v2-flash":
+			prices[model] = mimoV2FlashPrice()
+		}
+	}
+	return prices
+}
+
+func backfillMimoDomesticPrices(e *ProviderEntry) {
+	if e == nil {
+		return
+	}
+	defaults := mimoDomesticPrices(e.ModelList())
+	if len(defaults) == 0 {
+		return
+	}
+	if e.Prices == nil {
+		e.Prices = map[string]*provider.Pricing{}
+	}
+	for model, price := range defaults {
+		if e.Prices[model] == nil {
+			e.Prices[model] = clonePricing(price)
+		}
 	}
 }
 
@@ -1809,6 +1854,7 @@ func ensureMimoAPIProvider(c *Config) {
 	if p, ok := c.Provider("mimo-api"); ok {
 		if isOfficialMimoAPIProvider(p) {
 			mergeCuratedModelsIntoProvider(p, models, "mimo-v2.5-pro")
+			backfillMimoDomesticPrices(p)
 		}
 		return
 	}
@@ -1820,6 +1866,7 @@ func ensureMimoAPIProvider(c *Config) {
 		Default:       "mimo-v2.5-pro",
 		APIKeyEnv:     "MIMO_API_KEY",
 		ContextWindow: 1_048_576,
+		Prices:        mimoDomesticPrices(models),
 		NoProxy:       true,
 	})
 }
@@ -1830,6 +1877,7 @@ func ensureMimoTokenPlanProvider(c *Config, includeMimoFlash bool) {
 		if isOfficialMimoTokenPlanProvider(p) {
 			mergeCuratedModelsIntoProvider(p, models, "mimo-v2.5-pro")
 			clearMixedMimoTokenPlanPrice(p)
+			backfillMimoDomesticPrices(p)
 		}
 		return
 	}
@@ -1841,6 +1889,7 @@ func ensureMimoTokenPlanProvider(c *Config, includeMimoFlash bool) {
 		Default:       "mimo-v2.5-pro",
 		APIKeyEnv:     "MIMO_API_KEY",
 		ContextWindow: 1_048_576,
+		Prices:        mimoDomesticPrices(models),
 		NoProxy:       true,
 	}
 	if old, ok := c.Provider("mimo-pro"); ok {
@@ -1856,6 +1905,7 @@ func ensureMimoTokenPlanProvider(c *Config, includeMimoFlash bool) {
 		entry.Default = firstKnownModel(entry.Default, entry.Models, entry.Default)
 	}
 	clearMixedMimoTokenPlanPrice(&entry)
+	backfillMimoDomesticPrices(&entry)
 	c.Providers = append(c.Providers, entry)
 }
 

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -507,7 +507,7 @@ func TestRenderTOMLRoundTripsPerModelPrices(t *testing.T) {
 	if !ok {
 		t.Fatal("deepseek provider missing after round trip")
 	}
-	if p.Prices["deepseek-v4-flash"].Input != 0.14 || p.Prices["deepseek-v4-pro"].Output != 0.87 {
+	if p.Prices["deepseek-v4-flash"].Input != 1 || p.Prices["deepseek-v4-pro"].Output != 6 {
 		t.Fatalf("prices after round trip = %+v", p.Prices)
 	}
 }

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -54,7 +54,7 @@ models      = ["deepseek-v4-flash", "deepseek-v4-pro"]
 default     = "deepseek-v4-flash"   # optional; defaults to the first of `models`
 api_key_env = "DEEPSEEK_API_KEY"
 context_window = 1000000
-prices      = { "deepseek-v4-flash" = { cache_hit = 0.0028, input = 0.14, output = 0.28, currency = "$" }, "deepseek-v4-pro" = { cache_hit = 0.003625, input = 0.435, output = 0.87, currency = "$" } }   # per 1M tokens
+prices      = { "deepseek-v4-flash" = { cache_hit = 0.02, input = 1, output = 2, currency = "¥" }, "deepseek-v4-pro" = { cache_hit = 0.025, input = 3, output = 6, currency = "¥" } }   # per 1M tokens
 # DeepSeek thinking is always on; effort: high | max. Omit for auto (provider default).
 effort      = "high"
 
@@ -69,6 +69,7 @@ base_url       = "https://api.xiaomimimo.com/v1"
 model          = "mimo-v2.5-pro"   # thinking-mode on by default; reasoning_content rendered dim above the answer
 api_key_env    = "MIMO_API_KEY"
 context_window = 1000000
+price          = { cache_hit = 0.025, input = 3, output = 6, currency = "¥" }   # per 1M tokens
 
 [[providers]]
 name           = "mimo-flash"
@@ -77,6 +78,7 @@ base_url       = "https://api.xiaomimimo.com/v1"
 model          = "mimo-v2-flash"   # thinking-mode off by default; cheaper / faster
 api_key_env    = "MIMO_API_KEY"
 context_window = 65536
+price          = { cache_hit = 0.07, input = 0.70, output = 2.10, currency = "¥" }   # per 1M tokens
 
 # Custom /effort levels for a provider. When supported_efforts is set, the
 # /effort command exposes these levels; default_effort is what "/effort auto"


### PR DESCRIPTION
## Summary
- Switch DeepSeek built-in and official-template prices to CNY values.
- Add MiMo domestic CNY pricing for built-in providers and official desktop templates.
- Keep default money display fallbacks in CNY while preserving explicit USD/custom currency display.

## Verification
- `go test ./internal/provider ./internal/config`
- `(cd desktop && go test ./...)`
- `(cd desktop/frontend && npm run typecheck && npm exec -- tsx src/__tests__/context-panel-breakdown.test.ts)`
- `git diff --check`