### PR TITLE
Sanitize malformed MCP required schemas / 清洗异常 MCP required schema

### DIFF
--- a/internal/provider/schema_canonicalize.go
+++ b/internal/provider/schema_canonicalize.go
@@ -27,35 +27,34 @@ func CanonicalizeSchema(raw json.RawMessage) json.RawMessage {
 	return json.RawMessage(b)
 }
 
-var setLikeSchemaArrays = map[string]bool{
-	"required":          true,
-	"dependentRequired": true,
-}
-
 func canonicalizeSchemaValue(v any) any {
 	switch val := v.(type) {
 	case map[string]any:
 		for k, inner := range val {
 			val[k] = canonicalizeSchemaValue(inner)
 		}
-		for key := range val {
-			if setLikeSchemaArrays[key] {
-				if arr, ok := val[key].([]any); ok {
-					sort.SliceStable(arr, func(i, j int) bool {
-						return schemaJSONString(arr[i]) < schemaJSONString(arr[j])
-					})
-				}
+		if req, ok := val["required"]; ok {
+			if arr, ok := req.([]any); ok {
+				sortSchemaArray(arr)
+			} else {
+				// Some MCP servers emit OpenAPI-style property metadata such as
+				// {"required": true}. OpenAI-compatible function schemas require
+				// JSON Schema's array form; dropping the invalid value keeps the
+				// whole tool list from being rejected with HTTP 400.
+				delete(val, "required")
 			}
 		}
 		if dr, ok := val["dependentRequired"]; ok {
 			if drMap, ok := dr.(map[string]any); ok {
-				for _, inner := range drMap {
+				for key, inner := range drMap {
 					if arr, ok := inner.([]any); ok {
-						sort.SliceStable(arr, func(i, j int) bool {
-							return schemaJSONString(arr[i]) < schemaJSONString(arr[j])
-						})
+						sortSchemaArray(arr)
+					} else {
+						delete(drMap, key)
 					}
 				}
+			} else {
+				delete(val, "dependentRequired")
 			}
 		}
 		return val
@@ -67,6 +66,12 @@ func canonicalizeSchemaValue(v any) any {
 	default:
 		return v
 	}
+}
+
+func sortSchemaArray(arr []any) {
+	sort.SliceStable(arr, func(i, j int) bool {
+		return schemaJSONString(arr[i]) < schemaJSONString(arr[j])
+	})
 }
 
 func schemaJSONString(v any) string {

--- a/internal/provider/schema_canonicalize.go
+++ b/internal/provider/schema_canonicalize.go
@@ -28,10 +28,19 @@ func CanonicalizeSchema(raw json.RawMessage) json.RawMessage {
 }
 
 func canonicalizeSchemaValue(v any) any {
+	return canonicalizeSchemaObject(v)
+}
+
+func canonicalizeSchemaObject(v any) any {
 	switch val := v.(type) {
 	case map[string]any:
 		for k, inner := range val {
-			val[k] = canonicalizeSchemaValue(inner)
+			switch k {
+			case "properties", "patternProperties", "$defs", "definitions", "dependentSchemas":
+				val[k] = canonicalizeNamedSchemas(inner)
+			default:
+				val[k] = canonicalizeSchemaObject(inner)
+			}
 		}
 		if req, ok := val["required"]; ok {
 			if arr, ok := req.([]any); ok {
@@ -60,12 +69,23 @@ func canonicalizeSchemaValue(v any) any {
 		return val
 	case []any:
 		for i, elem := range val {
-			val[i] = canonicalizeSchemaValue(elem)
+			val[i] = canonicalizeSchemaObject(elem)
 		}
 		return val
 	default:
 		return v
 	}
+}
+
+func canonicalizeNamedSchemas(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return canonicalizeSchemaObject(v)
+	}
+	for name, schema := range m {
+		m[name] = canonicalizeSchemaObject(schema)
+	}
+	return m
 }
 
 func sortSchemaArray(arr []any) {

--- a/internal/provider/schema_canonicalize.go
+++ b/internal/provider/schema_canonicalize.go
@@ -38,6 +38,8 @@ func canonicalizeSchemaObject(v any) any {
 			switch k {
 			case "properties", "patternProperties", "$defs", "definitions", "dependentSchemas":
 				val[k] = canonicalizeNamedSchemas(inner)
+			case "dependentRequired":
+				val[k] = canonicalizeDependentRequired(inner)
 			default:
 				val[k] = canonicalizeSchemaObject(inner)
 			}
@@ -53,18 +55,8 @@ func canonicalizeSchemaObject(v any) any {
 				delete(val, "required")
 			}
 		}
-		if dr, ok := val["dependentRequired"]; ok {
-			if drMap, ok := dr.(map[string]any); ok {
-				for key, inner := range drMap {
-					if arr, ok := inner.([]any); ok {
-						sortSchemaArray(arr)
-					} else {
-						delete(drMap, key)
-					}
-				}
-			} else {
-				delete(val, "dependentRequired")
-			}
+		if dr, ok := val["dependentRequired"]; ok && !isJSONObject(dr) {
+			delete(val, "dependentRequired")
 		}
 		return val
 	case []any:
@@ -86,6 +78,26 @@ func canonicalizeNamedSchemas(v any) any {
 		m[name] = canonicalizeSchemaObject(schema)
 	}
 	return m
+}
+
+func canonicalizeDependentRequired(v any) any {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return v
+	}
+	for key, inner := range m {
+		if arr, ok := inner.([]any); ok {
+			sortSchemaArray(arr)
+		} else {
+			delete(m, key)
+		}
+	}
+	return m
+}
+
+func isJSONObject(v any) bool {
+	_, ok := v.(map[string]any)
+	return ok
 }
 
 func sortSchemaArray(arr []any) {

--- a/internal/provider/schema_canonicalize_test.go
+++ b/internal/provider/schema_canonicalize_test.go
@@ -54,3 +54,22 @@ func TestCanonicalizeSchemaDependentRequired(t *testing.T) {
 		t.Fatalf("CanonicalizeSchema() = %s, want %s", got, want)
 	}
 }
+
+func TestCanonicalizeSchemaPreservesDependentRequiredPropertyName(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"dependentRequired":{"type":"string"},
+			"x":{"type":"string"}
+		},
+		"dependentRequired":{
+			"dependentRequired":["x"]
+		}
+	}`)
+
+	got := string(CanonicalizeSchema(raw))
+	want := `{"dependentRequired":{"dependentRequired":["x"]},"properties":{"dependentRequired":{"type":"string"},"x":{"type":"string"}},"type":"object"}`
+	if got != want {
+		t.Fatalf("CanonicalizeSchema() = %s, want %s", got, want)
+	}
+}

--- a/internal/provider/schema_canonicalize_test.go
+++ b/internal/provider/schema_canonicalize_test.go
@@ -22,6 +22,23 @@ func TestCanonicalizeSchemaDropsNonArrayRequired(t *testing.T) {
 	}
 }
 
+func TestCanonicalizeSchemaPreservesPropertyNamedRequired(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"required":{"type":"boolean","description":"Whether the item is required"},
+			"normal":{"type":"string"}
+		},
+		"required":["required"]
+	}`)
+
+	got := string(CanonicalizeSchema(raw))
+	want := `{"properties":{"normal":{"type":"string"},"required":{"description":"Whether the item is required","type":"boolean"}},"required":["required"],"type":"object"}`
+	if got != want {
+		t.Fatalf("CanonicalizeSchema() = %s, want %s", got, want)
+	}
+}
+
 func TestCanonicalizeSchemaDependentRequired(t *testing.T) {
 	raw := json.RawMessage(`{
 		"type":"object",

--- a/internal/provider/schema_canonicalize_test.go
+++ b/internal/provider/schema_canonicalize_test.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCanonicalizeSchemaDropsNonArrayRequired(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"object",
+		"properties":{
+			"query":{"type":"string","required":true},
+			"nested":{"type":"object","required":false,"properties":{"x":{"type":"string"}}}
+		},
+		"required":["query","nested"]
+	}`)
+
+	got := string(CanonicalizeSchema(raw))
+	want := `{"properties":{"nested":{"properties":{"x":{"type":"string"}},"type":"object"},"query":{"type":"string"}},"required":["nested","query"],"type":"object"}`
+	if got != want {
+		t.Fatalf("CanonicalizeSchema() = %s, want %s", got, want)
+	}
+}
+
+func TestCanonicalizeSchemaDependentRequired(t *testing.T) {
+	raw := json.RawMessage(`{
+		"type":"object",
+		"dependentRequired":{
+			"cc":["billing_address","name"],
+			"bad":true
+		}
+	}`)
+
+	got := string(CanonicalizeSchema(raw))
+	want := `{"dependentRequired":{"cc":["billing_address","name"]},"type":"object"}`
+	if got != want {
+		t.Fatalf("CanonicalizeSchema() = %s, want %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #4456 by dropping malformed non-array `required` values during provider schema canonicalization.
- Preserves valid JSON Schema `required: [...]` and `dependentRequired` arrays with deterministic sorting.
- Adds regression coverage for MCP schemas that use OpenAPI-style `required: true` metadata.

## Verification
- `go test ./internal/provider ./internal/plugin ./internal/tool`
- `HOME=$(mktemp -d) go test ./...` was attempted; unrelated sandbox confinement tests failed in this full-access local environment while the affected provider/plugin/tool packages passed.

## Cache impact
- Provider-visible schema bytes change only for malformed schemas that previously caused HTTP 400 request rejection. Valid schema ordering and canonical JSON behavior are preserved.