### PR TITLE
Fix desktop tool diff previews / 修复桌面端工具 diff 预览

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2488,6 +2488,9 @@ type HistoryToolCall struct {
 	Arguments         string `json:"arguments"`
 	Subject           string `json:"subject,omitempty"`
 	Summary           string `json:"summary,omitempty"`
+	Diff              string `json:"diff,omitempty"`
+	Added             int    `json:"added,omitempty"`
+	Removed           int    `json:"removed,omitempty"`
 	ArgumentsArchived bool   `json:"argumentsArchived,omitempty"`
 }
 
@@ -2541,7 +2544,7 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 						args = replayed
 					}
 				}
-				hm.ToolCalls[i] = historyToolCall(tc.ID, tc.Name, args, toolResults[tc.ID])
+				hm.ToolCalls[i] = historyToolCall(tc, args, toolResults[tc.ID])
 			}
 		}
 		if m.Role == provider.RoleTool {
@@ -2556,18 +2559,21 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 
 const historyToolPreviewLimit = 2_000
 
-func historyToolCall(id, name, args string, result provider.Message) HistoryToolCall {
+func historyToolCall(tc provider.ToolCall, args string, result provider.Message) HistoryToolCall {
 	call := HistoryToolCall{
-		ID:      id,
-		Name:    name,
-		Subject: historyToolSubject(name, args),
-		Summary: historyToolSummary(name, args, result.Content),
+		ID:      tc.ID,
+		Name:    tc.Name,
+		Subject: historyToolSubject(tc.Name, args),
+		Summary: historyToolSummary(tc.Name, args, result.Content),
+		Diff:    tc.Diff,
+		Added:   tc.Added,
+		Removed: tc.Removed,
 	}
-	if name == "todo_write" {
+	if tc.Name == "todo_write" {
 		call.Arguments = args
 		return call
 	}
-	if id == "" {
+	if tc.ID == "" {
 		call.Arguments = args
 		return call
 	}
@@ -2949,7 +2955,7 @@ func previewEventSessionMessages(path string) ([]HistoryMessage, bool, error) {
 				id := tc.ID
 				name := firstNonEmpty(tc.Name, tc.Function.Name)
 				args := firstNonEmpty(tc.Arguments, tc.Function.Arguments)
-				hm.ToolCalls = append(hm.ToolCalls, historyToolCall(id, name, args, provider.Message{}))
+				hm.ToolCalls = append(hm.ToolCalls, historyToolCall(provider.ToolCall{ID: id, Name: name, Arguments: args}, args, provider.Message{}))
 				if id != "" {
 					toolName[id] = name
 				}

--- a/desktop/frontend/src/__tests__/diff-rendering.test.ts
+++ b/desktop/frontend/src/__tests__/diff-rendering.test.ts
@@ -3,7 +3,8 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { diffLines } from "../lib/diff";
+import { diffLines, diffRowsFromUnifiedDiff } from "../lib/diff";
+import { summarize } from "../lib/tools";
 import { initialState, reducer } from "../lib/useController";
 import type { Item } from "../lib/useController";
 
@@ -75,12 +76,107 @@ console.log("\ndiff rendering contract");
   ]), "diff rows carry old/new line numbers");
 }
 
+{
+  const rows = diffRowsFromUnifiedDiff([
+    "--- a/settings/settings_IO.gd",
+    "+++ b/settings/settings_IO.gd",
+    "@@ -27,2 +27,3 @@",
+    " func keep():",
+    "-func save():",
+    "+func save_file():",
+    "+func save_backup():",
+  ].join("\n"));
+  eq(JSON.stringify(rows.map((r) => [r.type, r.oldLine ?? "", r.newLine ?? "", r.text])), JSON.stringify([
+    ["ctx", 27, 27, "func keep():"],
+    ["del", 28, "", "func save():"],
+    ["add", "", 28, "func save_file():"],
+    ["add", "", 29, "func save_backup():"],
+  ]), "unified diff rows preserve hunk line numbers");
+}
+
+{
+  eq(summarize("write_file", ""), "", "archived write_file without args does not synthesize 0 lines");
+  eq(summarize("write_file", JSON.stringify({ content: "" })), "0 lines", "explicit empty write_file content still summarizes as 0 lines");
+}
+
 for (const prefix of ["diff", "inline-diff"]) {
   eq(finalDeclaration(`.${prefix}__table`, "min-width"), "max-content", `${prefix} rows share the longest scroll width`);
   eq(finalDeclaration(`.${prefix}__table`, "width"), "100%", `${prefix} table fills the visible viewport`);
   eq(finalDeclaration(`.${prefix}__row`, "width"), "100%", `${prefix} row background fills table width`);
   eq(finalDeclaration(`.${prefix}__gutter`, "position"), "sticky", `${prefix} gutter remains visible while horizontally scrolled`);
   eq(finalDeclaration(`.${prefix}__gutter`, "left"), "0", `${prefix} sticky gutter anchors at left`);
+}
+
+{
+  let s = reducer(initialState, { type: "event", e: { kind: "turn_started" } });
+  const fileDiff = [
+    "--- a/settings/pages/video_settings.tscn",
+    "+++ b/settings/pages/video_settings.tscn",
+    "@@ -42,2 +42,2 @@",
+    "-layout_mode = 3",
+    "+layout_mode = 1",
+  ].join("\n");
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_dispatch",
+      tool: {
+        id: "write-existing",
+        name: "write_file",
+        args: JSON.stringify({ path: "settings/pages/video_settings.tscn", content: "full\nreplacement\nfile\n" }),
+        readOnly: false,
+        diff: fileDiff,
+        added: 1,
+        removed: 1,
+      } as any,
+    },
+  });
+  let [tool] = toolItems(s);
+  eq(tool?.summary, "+1 -1", "writer dispatch uses preview file diff summary instead of content line count");
+  eq((tool as any)?.fileDiff?.diff, fileDiff, "writer dispatch keeps preview file diff for rendering");
+  s = reducer(s, { type: "event", e: { kind: "tool_result", tool: { id: "write-existing", name: "write_file", readOnly: false, output: "wrote 22 bytes", durationMs: 12 } } });
+  [tool] = toolItems(s);
+  eq(tool?.summary, "+1 -1", "completed writer archives with preview file diff summary");
+  ok(tool?.dataArchived === true, "completed writer with preview diff is still archived");
+}
+
+{
+  const fileDiff = [
+    "--- a/settings/settings_IO.gd",
+    "+++ b/settings/settings_IO.gd",
+    "@@ -27 +27 @@",
+    "-func save():",
+    "+func save_file():",
+  ].join("\n");
+  const s = reducer(initialState, {
+    type: "history",
+    messages: [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "hist-edit",
+          name: "edit_file",
+          arguments: "",
+          argumentsArchived: true,
+          subject: "settings/settings_IO.gd",
+          diff: fileDiff,
+          added: 1,
+          removed: 1,
+        }],
+      },
+      {
+        role: "tool",
+        content: "",
+        toolCallId: "hist-edit",
+        toolName: "edit_file",
+        toolResultArchived: true,
+      },
+    ] as any,
+  });
+  const [tool] = toolItems(s);
+  eq(tool?.summary, "+1 -1", "history writer restores preview file diff summary");
+  eq((tool as any)?.fileDiff?.diff, fileDiff, "history writer restores preview file diff body");
 }
 
 {

--- a/desktop/frontend/src/__tests__/diff-rendering.test.ts
+++ b/desktop/frontend/src/__tests__/diff-rendering.test.ts
@@ -85,6 +85,7 @@ console.log("\ndiff rendering contract");
     "-func save():",
     "+func save_file():",
     "+func save_backup():",
+    "",
   ].join("\n"));
   eq(JSON.stringify(rows.map((r) => [r.type, r.oldLine ?? "", r.newLine ?? "", r.text])), JSON.stringify([
     ["ctx", 27, 27, "func keep():"],

--- a/desktop/frontend/src/components/DiffView.tsx
+++ b/desktop/frontend/src/components/DiffView.tsx
@@ -1,8 +1,9 @@
 import { lazy, Suspense } from "react";
 
 export interface DiffProps {
-  original: string;
-  modified: string;
+  original?: string;
+  modified?: string;
+  diff?: string;
   language?: string;
   maxHeight?: number;
 }
@@ -20,7 +21,7 @@ const Impl = lazy(() => import("./editors/HljsDiff"));
 
 export function DiffView(props: DiffProps) {
   return (
-    <Suspense fallback={<pre className="code code--loading">{props.modified}</pre>}>
+    <Suspense fallback={<pre className="code code--loading">{props.modified ?? props.diff ?? ""}</pre>}>
       <Impl {...props} />
     </Suspense>
   );

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -3,7 +3,7 @@ import { ChevronRight } from "lucide-react";
 import { CodeViewer } from "./CodeViewer";
 import { DiffView } from "./DiffView";
 import { useT } from "../lib/i18n";
-import { diffsFor, subjectOf, summarize } from "../lib/tools";
+import { diffsFor, languageForToolArgs, subjectOf, summarize, summarizeFileDiff } from "../lib/tools";
 import { useShellExpand } from "../lib/shellExpand";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import type { Item } from "../lib/useController";
@@ -66,7 +66,8 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId }: { item
   const archivedWithoutFullData = Boolean(item.dataArchived && !fullData);
   const effectiveArgs = archivedWithoutFullData ? "" : fullData?.args ?? item.args;
   const effectiveOutput = fullData?.output ?? item.output;
-  const diffs = archivedWithoutFullData ? [] : diffsFor(item.name, effectiveArgs);
+  const previewDiff = item.fileDiff?.diff ? item.fileDiff : undefined;
+  const diffs = previewDiff || archivedWithoutFullData ? [] : diffsFor(item.name, effectiveArgs);
   const subject = fullData ? subjectOf(item.name, effectiveArgs) : item.subject || subjectOf(item.name, effectiveArgs);
   // Reset cached fullData when the item identity changes (e.g. after rewind).
   useEffect(() => {
@@ -77,12 +78,12 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId }: { item
   // else folds its args/output away by default.  Open while running so the
   // user sees progress; closed by default once settled.
   const hasArchivedOnDemandBody = Boolean(item.dataArchived && tabId);
-  const hasArgsOrOutput = diffs.length === 0 && (!!effectiveArgs || !!effectiveOutput || hasArchivedOnDemandBody);
+  const hasArgsOrOutput = !previewDiff && diffs.length === 0 && (!!effectiveArgs || !!effectiveOutput || hasArchivedOnDemandBody);
 
   // Shell output: split into preview + "show all" toggle.
   const shellOutput = item.isShell && effectiveOutput ? effectiveOutput : null;
   const shellPreview = shellOutput ? splitPreview(shellOutput, SHELL_PREVIEW_LINES) : null;
-  const hasBody = Boolean(diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error);
+  const hasBody = Boolean(previewDiff || diffs.length || hasNested || shellPreview || (!shellPreview && hasArgsOrOutput) || item.error);
   useEffect(() => {
     if (!open || !item.dataArchived || fullData || !tabId) return;
     let cancelled = false;
@@ -110,7 +111,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId }: { item
     item.readOnly && !hasNested && item.status !== "error" && item.status !== "stopped";
 
   const duration = item.status === "running" ? "" : formatToolDuration(item.durationMs);
-  const summary = item.status === "running" ? "" : item.summary || summarize(item.name, effectiveArgs, effectiveOutput, item.error);
+  const summary = item.status === "running" ? "" : item.summary || summarizeFileDiff(item.fileDiff) || (archivedWithoutFullData ? "" : summarize(item.name, effectiveArgs, effectiveOutput, item.error));
 
   // GSAP-driven collapse/expand for tool body
   const toolBodyRef = useRef<HTMLDivElement>(null);
@@ -145,12 +146,16 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId }: { item
 
       <div ref={toolBodyRef} className="tool__body">
 
-        {diffs.map((d, i) => (
-          <div key={i}>
-            {d.label && <div className="tool__difflabel">{d.label}</div>}
-            <DiffView original={d.original} modified={d.modified} language={d.lang} maxHeight={260} />
-          </div>
-        ))}
+        {previewDiff ? (
+          <DiffView diff={previewDiff.diff} language={languageForToolArgs(fullData?.args ?? item.args)} maxHeight={260} />
+        ) : (
+          diffs.map((d, i) => (
+            <div key={i}>
+              {d.label && <div className="tool__difflabel">{d.label}</div>}
+              <DiffView original={d.original} modified={d.modified} language={d.lang} maxHeight={260} />
+            </div>
+          ))
+        )}
 
         {hasNested && (
           <div className="tool__nested">

--- a/desktop/frontend/src/components/editors/HljsDiff.tsx
+++ b/desktop/frontend/src/components/editors/HljsDiff.tsx
@@ -1,5 +1,5 @@
 import type { DiffProps } from "../DiffView";
-import { diffLines } from "../../lib/diff";
+import { diffLines, diffRowsFromUnifiedDiff } from "../../lib/diff";
 import { highlightToHtml } from "../../lib/highlight";
 
 // HljsDiff is the syntax-highlighted default behind the diff seam: an LCS line
@@ -12,8 +12,8 @@ function lineNo(n?: number): string {
   return typeof n === "number" ? String(n) : "";
 }
 
-export default function HljsDiff({ original, modified, language, maxHeight }: DiffProps) {
-  const rows = diffLines(original, modified);
+export default function HljsDiff({ original = "", modified = "", diff = "", language, maxHeight }: DiffProps) {
+  const rows = diff ? diffRowsFromUnifiedDiff(diff) : diffLines(original, modified);
   return (
     <div className="diff hljs" style={maxHeight ? { maxHeight } : undefined}>
       <div className="diff__table">

--- a/desktop/frontend/src/lib/diff.ts
+++ b/desktop/frontend/src/lib/diff.ts
@@ -64,7 +64,8 @@ export function diffRowsFromUnifiedDiff(diff: string): DiffRow[] {
   let newLine = 0;
   let inHunk = false;
 
-  for (const line of diff.split("\n")) {
+  const lines = diff.endsWith("\n") ? diff.slice(0, -1).split("\n") : diff.split("\n");
+  for (const line of lines) {
     const header = hunkHeader.exec(line);
     if (header) {
       oldLine = Number(header[1]);

--- a/desktop/frontend/src/lib/diff.ts
+++ b/desktop/frontend/src/lib/diff.ts
@@ -52,6 +52,49 @@ export function diffLines(a: string, b: string): DiffRow[] {
   return rows;
 }
 
+const hunkHeader = /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/;
+
+// diffRowsFromUnifiedDiff renders an already-computed unified diff while keeping
+// the real hunk line numbers. This is used when the backend previewed a writer
+// tool against the whole file, so the UI does not have to re-diff tiny args
+// snippets and accidentally restart line numbers at 1.
+export function diffRowsFromUnifiedDiff(diff: string): DiffRow[] {
+  const rows: DiffRow[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const line of diff.split("\n")) {
+    const header = hunkHeader.exec(line);
+    if (header) {
+      oldLine = Number(header[1]);
+      newLine = Number(header[2]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith("\\ No newline")) continue;
+
+    const marker = line[0];
+    const text = marker === " " || marker === "+" || marker === "-" ? line.slice(1) : line;
+    if (marker === "+") {
+      rows.push({ type: "add", text, newLine });
+      newLine++;
+      continue;
+    }
+    if (marker === "-") {
+      rows.push({ type: "del", text, oldLine });
+      oldLine++;
+      continue;
+    }
+    rows.push({ type: "ctx", text, oldLine, newLine });
+    oldLine++;
+    newLine++;
+  }
+
+  return rows;
+}
+
 // cleanGitDiff strips standard git diff headers (diff --git, index, ---, +++)
 // and hunk headers (@@ -x,y +x,y @@) so the view focuses directly on the changed lines.
 export function cleanGitDiff(diff: string): string {

--- a/desktop/frontend/src/lib/tools.ts
+++ b/desktop/frontend/src/lib/tools.ts
@@ -16,6 +16,12 @@ export interface ToolDiff {
   label?: string; // multi_edit labels each step ("edit 1", …)
 }
 
+export interface ToolFileDiff {
+  diff: string;
+  added: number;
+  removed: number;
+}
+
 function parse(args: string): Record<string, unknown> {
   try {
     return JSON.parse(args) as Record<string, unknown>;
@@ -26,6 +32,23 @@ function parse(args: string): Record<string, unknown> {
 
 function str(a: Record<string, unknown>, key: string): string {
   return typeof a[key] === "string" ? (a[key] as string) : "";
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+export function fileDiffFromWire(value?: { diff?: unknown; added?: unknown; removed?: unknown }): ToolFileDiff | undefined {
+  const diff = typeof value?.diff === "string" ? value.diff : "";
+  const added = num(value?.added);
+  const removed = num(value?.removed);
+  if (!diff && added === 0 && removed === 0) return undefined;
+  return { diff, added, removed };
+}
+
+export function summarizeFileDiff(fileDiff?: ToolFileDiff): string {
+  if (!fileDiff || (fileDiff.added === 0 && fileDiff.removed === 0)) return "";
+  return `+${fileDiff.added} -${fileDiff.removed}`;
 }
 
 // subjectOf pulls the most informative one-liner out of a call's args — the
@@ -84,6 +107,11 @@ export function diffsFor(name: string, args: string): ToolDiff[] {
     return out;
   }
   return [];
+}
+
+export function languageForToolArgs(args: string): string {
+  const a = parse(args);
+  return extToLang(str(a, "path") || str(a, "file_path"));
 }
 
 export type TodoStatus = "pending" | "in_progress" | "completed";
@@ -154,7 +182,7 @@ export function summarize(name: string, args: string, output?: string, error?: s
   const a = parse(args);
   switch (name) {
     case "write_file":
-      return countOf(lineCount(str(a, "content")), "tool.lineOne", "tool.lineOther");
+      return typeof a.content === "string" ? countOf(lineCount(a.content), "tool.lineOne", "tool.lineOther") : "";
     case "edit_file": {
       if (typeof a.old_string === "string" && typeof a.new_string === "string") {
         const { add, del } = plusMinus(a.old_string, a.new_string);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -43,6 +43,9 @@ export interface WireTool {
   durationMs?: number;
   partial?: boolean; // an early dispatch (name only) — a full one with args follows
   parentId?: string; // set on a sub-agent's calls — the parent `task` call's id
+  diff?: string;
+  added?: number;
+  removed?: number;
   profile?: WireProfile; // subagent model/effort resolved for this call
 }
 
@@ -247,6 +250,9 @@ export interface HistoryToolCall {
   arguments: string;
   subject?: string;
   summary?: string;
+  diff?: string;
+  added?: number;
+  removed?: number;
   argumentsArchived?: boolean;
 }
 

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -10,7 +10,7 @@ import { app, onEvent, onReady } from "./bridge";
 import { invalidateCache } from "./composerHistory";
 import { createRafBatch } from "./rafBatch";
 import { t } from "./i18n";
-import { summarize } from "./tools";
+import { fileDiffFromWire, summarize, summarizeFileDiff, type ToolFileDiff } from "./tools";
 import { modeHasAutoApproveTools } from "./types";
 import type {
   BalanceInfo,
@@ -68,6 +68,7 @@ export type Item =
       durationMs?: number;
       subject?: string; // stable collapsed subject from archived history payloads
       summary?: string; // stable collapsed readout kept even after args/output archive
+      fileDiff?: ToolFileDiff; // previewed whole-file diff from writer dispatch
       isShell?: boolean; // true for !-prefix shell commands (controls default expand)
       parentId?: string; // a sub-agent call nests under the `task` call with this id
       profile?: { model?: string; effort?: string }; // subagent model/effort from tool event
@@ -280,6 +281,7 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
         const archived = Boolean(tc.argumentsArchived || result?.toolResultArchived);
         const output = result?.toolResultArchived ? undefined : result?.content ?? "";
         const error = result?.toolResultError || (output ? historyToolError(output) : undefined);
+        const fileDiff = fileDiffFromWire(tc);
         items.push({
           kind: "tool",
           id: tc.id || `${idPrefix}tool${seq}`,
@@ -291,7 +293,8 @@ export function historyMessagesToItems(messages: HistoryMessage[], idPrefix: str
           error,
           dataArchived: archived || undefined,
           subject: tc.subject,
-          summary: tc.summary,
+          summary: summarizeFileDiff(fileDiff) || tc.summary,
+          fileDiff,
           isShell: (tc.id || "").startsWith("shell-"),
         });
         seq++;
@@ -448,13 +451,15 @@ function applyEvent(s: State, e: WireEvent): State {
         const it = next[idx];
         if (it.kind === "tool") {
           const args = t.args ? t.args : it.args;
-          const summary = summarize(t.name, args) || (t.name === it.name && args === it.args ? it.summary : undefined);
-          next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, profile: t.profile ?? it.profile, summary };
+          const fileDiff = fileDiffFromWire(t);
+          const summary = summarizeFileDiff(fileDiff) || summarize(t.name, args) || (t.name === it.name && args === it.args ? it.summary : undefined);
+          next[idx] = { ...it, name: t.name, args, readOnly: t.readOnly, profile: t.profile ?? it.profile, summary, fileDiff };
         }
         return { ...s, items: next };
       }
       const args = t.args ?? "";
-      return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "tool", id, name: t.name, args, readOnly: t.readOnly, status: "running", summary: summarize(t.name, args), isShell: id.startsWith("shell-"), parentId: t.parentId, profile: t.profile }] };
+      const fileDiff = fileDiffFromWire(t);
+      return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "tool", id, name: t.name, args, readOnly: t.readOnly, status: "running", summary: summarizeFileDiff(fileDiff) || summarize(t.name, args), fileDiff, isShell: id.startsWith("shell-"), parentId: t.parentId, profile: t.profile }] };
     }
     case "tool_result": {
       const t = e.tool;

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -100,6 +100,30 @@ func TestHistoryMessagesArchiveCompletedToolPayloads(t *testing.T) {
 	}
 }
 
+func TestHistoryMessagesKeepToolFileDiffMetadata(t *testing.T) {
+	diff := "@@ -27 +27 @@\n-func save():\n+func save_file():\n"
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID:        "edit",
+			Name:      "edit_file",
+			Arguments: `{"path":"settings/settings_IO.gd","old_string":"func save():","new_string":"func save_file():"}`,
+			Diff:      diff,
+			Added:     1,
+			Removed:   1,
+		}}},
+		{Role: provider.RoleTool, Name: "edit_file", ToolCallID: "edit", Content: "edited settings/settings_IO.gd"},
+	}
+
+	got := historyMessages(msgs, func(content string) string { return content })
+	call := got[0].ToolCalls[0]
+	if call.Diff != diff || call.Added != 1 || call.Removed != 1 {
+		t.Fatalf("history tool diff metadata = diff:%q +%d -%d", call.Diff, call.Added, call.Removed)
+	}
+	if !call.ArgumentsArchived || call.Arguments != "" {
+		t.Fatalf("tool arguments should still be archived: %+v", call)
+	}
+}
+
 func TestHistoryMessagesKeepBoundedToolErrors(t *testing.T) {
 	largeError := "error: " + strings.Repeat("permission denied ", 400)
 	msgs := []provider.Message{

--- a/desktop/wire.go
+++ b/desktop/wire.go
@@ -65,6 +65,9 @@ type wireTool struct {
 	DurationMs int64        `json:"durationMs,omitempty"`
 	Partial    bool         `json:"partial,omitempty"`
 	ParentID   string       `json:"parentId,omitempty"`
+	Diff       string       `json:"diff,omitempty"`
+	Added      int          `json:"added,omitempty"`
+	Removed    int          `json:"removed,omitempty"`
 	Profile    *wireProfile `json:"profile,omitempty"`
 }
 
@@ -163,6 +166,7 @@ func toWire(e event.Event) wireEvent {
 			ReadOnly: e.Tool.ReadOnly, Truncated: e.Tool.Truncated,
 			DurationMs: e.Tool.DurationMs, Partial: e.Tool.Partial,
 			ParentID: e.Tool.ParentID,
+			Diff:     e.Tool.Diff, Added: e.Tool.Added, Removed: e.Tool.Removed,
 		}
 		if e.Tool.Profile != nil {
 			wt.Profile = &wireProfile{Model: e.Tool.Profile.Model, Effort: e.Tool.Profile.Effort}

--- a/desktop/wire_test.go
+++ b/desktop/wire_test.go
@@ -78,6 +78,27 @@ func TestToWireToolDispatchProfile(t *testing.T) {
 	}
 }
 
+func TestToWireToolDispatchFileDiff(t *testing.T) {
+	e := event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+		ID:       "1",
+		Name:     "edit_file",
+		Args:     `{"path":"settings/settings_IO.gd"}`,
+		FileDiff: event.FileDiff{Diff: "@@ -27 +27 @@\n-old\n+new\n", Added: 1, Removed: 1},
+	}}
+	w := toWire(e)
+	if w.Tool == nil {
+		t.Fatal("missing wire tool")
+	}
+	b, err := json.Marshal(w.Tool)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"diff":"@@ -27 +27 @@\n-old\n+new\n"`) || !strings.Contains(s, `"added":1`) || !strings.Contains(s, `"removed":1`) {
+		t.Fatalf("tool file diff was not serialized: %s", s)
+	}
+}
+
 func TestToWireToolResult(t *testing.T) {
 	e := event.Event{Kind: event.ToolResult, Tool: event.Tool{ID: "1", Output: "ok", Truncated: true, DurationMs: 522}}
 	w := toWire(e)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -647,6 +647,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		// archive. It is NOT re-uploaded to the API: the openai provider drops it
 		// when building the request, since re-sent reasoning is billable prompt
 		// input for no cache or coherence gain.
+		calls = a.withPreviewFileDiffs(calls)
 		a.session.Add(provider.Message{
 			Role:               provider.RoleAssistant,
 			Content:            text,
@@ -1160,10 +1161,13 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 	for _, c := range calls {
 		t, ok := a.tools.Get(c.Name)
 		ev := event.Tool{ID: c.ID, Name: c.Name, Args: c.Arguments, ReadOnly: ok && t.ReadOnly()}
-		if ok {
+		ev.FileDiff = event.FileDiff{Diff: c.Diff, Added: c.Added, Removed: c.Removed}
+		if ok && ev.Diff == "" && ev.Added == 0 && ev.Removed == 0 {
 			if ch, ok := tool.PreviewChange(t, json.RawMessage(c.Arguments)); ok {
 				ev.FileDiff = event.FileDiff{Diff: ch.Diff, Added: ch.Added, Removed: ch.Removed}
 			}
+		}
+		if ok {
 			if pr, ok := t.(interface {
 				ResolveProfile(json.RawMessage) *event.Profile
 			}); ok {
@@ -1212,6 +1216,29 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 	}
 	a.applyStormBreaker(calls, outcomes, results)
 	return results
+}
+
+func (a *Agent) withPreviewFileDiffs(calls []provider.ToolCall) []provider.ToolCall {
+	if len(calls) == 0 {
+		return calls
+	}
+	out := make([]provider.ToolCall, len(calls))
+	copy(out, calls)
+	for i := range out {
+		if out[i].Diff != "" || out[i].Added != 0 || out[i].Removed != 0 {
+			continue
+		}
+		t, ok := a.tools.Get(out[i].Name)
+		if !ok {
+			continue
+		}
+		if ch, ok := tool.PreviewChange(t, json.RawMessage(out[i].Arguments)); ok {
+			out[i].Diff = ch.Diff
+			out[i].Added = ch.Added
+			out[i].Removed = ch.Removed
+		}
+	}
+	return out
 }
 
 type toolCallBatch struct {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,6 +67,9 @@ type ToolCall struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Arguments string `json:"arguments"`
+	Diff      string `json:"diff,omitempty"`
+	Added     int    `json:"added,omitempty"`
+	Removed   int    `json:"removed,omitempty"`
 }
 
 // ToolSchema is a tool definition exposed to the model. Parameters is JSON Schema.

--- a/internal/serve/wire.go
+++ b/internal/serve/wire.go
@@ -64,6 +64,9 @@ type wireTool struct {
 	DurationMs int64        `json:"durationMs,omitempty"`
 	Partial    bool         `json:"partial,omitempty"`
 	ParentID   string       `json:"parentId,omitempty"`
+	Diff       string       `json:"diff,omitempty"`
+	Added      int          `json:"added,omitempty"`
+	Removed    int          `json:"removed,omitempty"`
 	Profile    *wireProfile `json:"profile,omitempty"`
 }
 
@@ -156,6 +159,7 @@ func toWire(e event.Event) wireEvent {
 			ReadOnly: e.Tool.ReadOnly, Truncated: e.Tool.Truncated,
 			DurationMs: e.Tool.DurationMs, Partial: e.Tool.Partial,
 			ParentID: e.Tool.ParentID,
+			Diff:     e.Tool.Diff, Added: e.Tool.Added, Removed: e.Tool.Removed,
 		}
 		if e.Tool.Profile != nil {
 			wt.Profile = &wireProfile{Model: e.Tool.Profile.Model, Effort: e.Tool.Profile.Effort}

--- a/internal/serve/wire_test.go
+++ b/internal/serve/wire_test.go
@@ -1,7 +1,9 @@
 package serve
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 
 	"reasonix/internal/event"
@@ -23,6 +25,25 @@ func TestToWire(t *testing.T) {
 		}})
 		if w.Tool == nil || w.Tool.Profile == nil || w.Tool.Profile.Model != "deepseek-pro" || w.Tool.Profile.Effort != "max" {
 			t.Errorf("profile = %+v", w.Tool)
+		}
+	})
+
+	t.Run("tool dispatch file diff", func(t *testing.T) {
+		w := toWire(event.Event{Kind: event.ToolDispatch, Tool: event.Tool{
+			Name:     "edit_file",
+			Args:     `{"path":"settings/settings_IO.gd"}`,
+			FileDiff: event.FileDiff{Diff: "@@ -27 +27 @@\n-old\n+new\n", Added: 1, Removed: 1},
+		}})
+		if w.Tool == nil {
+			t.Fatal("missing tool")
+		}
+		b, err := json.Marshal(w.Tool)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		s := string(b)
+		if !strings.Contains(s, `"diff":"@@ -27 +27 @@\n-old\n+new\n"`) || !strings.Contains(s, `"added":1`) || !strings.Contains(s, `"removed":1`) {
+			t.Fatalf("tool file diff was not serialized: %s", s)
 		}
 	})
 


### PR DESCRIPTION
## Problem

#4467 reports two desktop diff rendering regressions for writer tool cards:

- Restored/archived `write_file` cards can show `0 lines` while collapsed, then show the real line count only after expansion loads full args.
- Expanded `edit_file` / `multi_edit` diffs restart old/new line numbers at `1` instead of using the file's real hunk line numbers.

## Root Cause

The agent already computes whole-file preview diffs for writer tools, including `+N/-M` counts and unified-diff hunk line numbers. That metadata was not carried through the desktop/serve wire payloads or preserved in restored desktop history, so the frontend fell back to re-diffing tiny tool-argument snippets. For archived cards without loaded args, that fallback treated missing `write_file.content` as an empty file and synthesized `0 lines`.

## Fix

- Preserve preview diff metadata on local tool calls before saving the assistant turn, and expose it through desktop history plus desktop/serve event wire payloads.
- Restore `fileDiff` into frontend tool items and prefer its `+N -M` summary over content-line fallback summaries.
- Render preview diffs from unified-diff hunks so old/new line gutters keep real file line numbers.
- Stop synthesizing `0 lines` for archived `write_file` cards whose args are not loaded yet, while still showing `0 lines` for an explicit empty-file write.
- Extend regression coverage for wire serialization, history restoration, archived-summary behavior, and unified-diff hunk line numbering.

## Verification

- `go test ./...`
- `(cd desktop && go test ./...)`
- `(cd desktop/frontend && npm run test:all)`
- `(cd desktop/frontend && npm run build)`
- `git diff --check`
- `gofmt -l internal/provider/provider.go internal/agent/agent.go internal/serve/wire.go internal/serve/wire_test.go desktop/app.go desktop/wire.go desktop/wire_test.go desktop/history_test.go`

Fixes #4467
