### PR TITLE
[codex] Fix short-window layout overflow

### DIFF
--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -100,7 +100,10 @@ eq(
 );
 
 eq(finalDeclaration(".statusbar", "white-space"), "nowrap", "status bar keeps metrics on one row");
-eq(finalDeclaration(".statusbar", "overflow"), "hidden", "status bar clips instead of overflowing");
+eq(finalDeclaration(".statusbar", "overflow-x"), "auto", "status bar can scroll to reveal all metrics");
+eq(finalDeclaration(".statusbar", "overflow-y"), "hidden", "status bar stays one-line vertically");
+eq(finalDeclaration(".chat-pane", "overflow-y"), "auto", "chat pane scrolls when the window is too short");
+eq(finalDeclaration(".sidebar", "overflow-y"), "auto", "sidebar scrolls when the window is too short");
 clipsSingleLine(".statusbar__model");
 
 for (const selector of [

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1606,7 +1606,13 @@ a[href] {
   border-right: 1px solid var(--border-soft);
   --wails-draggable: drag;
   user-select: none;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+
+.sidebar::-webkit-scrollbar {
+  display: none;
 }
 
 .app--darwin .sidebar {
@@ -2084,6 +2090,8 @@ a[href] {
   min-width: 0;
   min-height: 0;
   background: var(--chat-bg);
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 /* ── top bar (drag region) ───────────────────────────────────────────────── */
@@ -5274,7 +5282,19 @@ a[href] {
      CJK text breaks one character per line. The metric chips keep their width
      (flex-shrink: 0) and only the model label ellipsizes to absorb the squeeze. */
   white-space: nowrap;
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: thin;
+}
+.statusbar::-webkit-scrollbar {
+  height: 4px;
+}
+.statusbar::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg-faint) 30%, transparent);
+}
+.statusbar::-webkit-scrollbar-track {
+  background: transparent;
 }
 .statusbar > * {
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Let the sidebar and chat pane scroll vertically when the desktop window is shorter than the fixed chrome/footer stack.
- Change the status bar from clipping overflow to horizontal scrolling so right-side metrics remain reachable in windowed layouts.
- Update the typography overflow contract test to lock in the new behavior.

## Root Cause
The desktop shell used fixed-height chrome/footer regions inside a `body`/layout that hides overflow. At very short heights, content outside the available column height was clipped. The status bar also forced a single line while using `overflow: hidden`, so metrics at the right edge disappeared when the window was not wide enough.

## Validation
- `npm.cmd run check:css`
- `npx.cmd tsx src/__tests__/typography-overflow-contract.test.ts`
- `npm.cmd test`
- `npm.cmd run test:typecheck` was attempted but still fails locally because `desktop/frontend/wailsjs` is not generated in this checkout (`Cannot find module '../../wailsjs/go/main/App'`).
- Vite served `http://127.0.0.1:5174/` with HTTP 200, but screenshot-level Browser verification was blocked by the local Windows sandbox (`CreateProcessAsUserW failed: 5`).