### PR TITLE
[codex] Show status bar amounts in RMB

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3001,7 +3001,6 @@ export default function App() {
               turnTokens={state.turnTotalTokens}
               turnCost={state.turnCost}
               cost={state.sessionCost}
-              currency={state.sessionCurrency}
               modelLabel={state.meta?.label}
               labelStyle={statusBarStyle}
               items={statusBarItems}

--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -76,7 +76,7 @@ const infoCost = contextCostDisplay({
 });
 eq(infoCost, { amount: 0.1759, currency: "$" }, "panel cost keeps the panel currency instead of state default");
 eq(formatMoney(infoCost.amount, infoCost.currency, "dash"), "$0.1759", "USD panel cost renders with dollar sign");
-eq(formatCnyMoney(infoCost.amount, "dash"), "¥0.1759", "status bar cost renders as RMB");
+eq(formatCnyMoney(infoCost.amount, "dash"), "¥0.1759", "status bar and workbench costs render as RMB");
 eq(normalizeCnyMoneyDisplay("$2.33"), "¥2.33", "status bar balance normalizes dollar display to RMB");
 eq(normalizeCnyMoneyDisplay("CNY 2.33"), "¥2.33", "status bar balance normalizes CNY code to RMB");
 eq(currencySymbol("楼"), "¥", "unexpected currency text does not leak into money values");

--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -1,7 +1,7 @@
 // Run: tsx src/__tests__/context-panel-breakdown.test.ts
 
 import { contextBreakdown, contextCostDisplay } from "../components/ContextPanel";
-import { currencySymbol, formatMoney } from "../lib/money";
+import { currencySymbol, formatCnyMoney, formatMoney, normalizeCnyMoneyDisplay } from "../lib/money";
 
 let passed = 0;
 let failed = 0;
@@ -76,6 +76,9 @@ const infoCost = contextCostDisplay({
 });
 eq(infoCost, { amount: 0.1759, currency: "$" }, "panel cost keeps the panel currency instead of state default");
 eq(formatMoney(infoCost.amount, infoCost.currency, "dash"), "$0.1759", "USD panel cost renders with dollar sign");
+eq(formatCnyMoney(infoCost.amount, "dash"), "¥0.1759", "status bar cost renders as RMB");
+eq(normalizeCnyMoneyDisplay("$2.33"), "¥2.33", "status bar balance normalizes dollar display to RMB");
+eq(normalizeCnyMoneyDisplay("CNY 2.33"), "¥2.33", "status bar balance normalizes CNY code to RMB");
 eq(currencySymbol("楼"), "¥", "unexpected currency text does not leak into money values");
 eq(currencySymbol("aud"), "AUD ", "unknown ISO currency codes stay readable");
 eq(currencySymbol("A$"), "A$", "compact multi-character currency symbols are preserved");

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -5,7 +5,7 @@ import { FileText } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { useT, type Translator } from "../lib/i18n";
-import { formatMoney } from "../lib/money";
+import { formatCnyMoney } from "../lib/money";
 import type { DictKey } from "../locales/en";
 import type { ContextInfo, ContextPanelInfo, UsageSourceStats, WireUsage } from "../lib/types";
 
@@ -338,14 +338,14 @@ export function ContextPanel({
             <SectionHeading title={t("context.costMetrics")} />
             <div className="context-panel__stats">
               <MetricCard label={t("context.cacheHit")} value={cachePct > 0 ? `${cachePct}%` : "-"} tone="accent" />
-              <MetricCard label={t("context.sessionCost")} value={formatMoney(cost.amount, cost.currency, "dash")} />
+              <MetricCard label={t("context.sessionCost")} value={formatCnyMoney(cost.amount, "dash")} />
             </div>
             {showCostSources && (
               <div className="context-panel__source-list" aria-label={t("context.costBreakdown")}>
                 {costSources.map((row) => (
                   <div className="context-panel__source-row" key={row.source}>
                     <span>{sourceLabel(row.label, t)}</span>
-                    <strong>{formatMoney(row.cost, row.currency, "dash")}</strong>
+                    <strong>{formatCnyMoney(row.cost, "dash")}</strong>
                     <em>{t("context.sourceRequests", { count: row.requests })}</em>
                   </div>
                 ))}

--- a/desktop/frontend/src/components/StatusBar.tsx
+++ b/desktop/frontend/src/components/StatusBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Activity, CircleDollarSign, CircleGauge, Database, Layers, Percent, RefreshCw, Wallet, Zap } from "lucide-react";
 import { Tooltip } from "./Tooltip";
 import { useI18n, type Translator } from "../lib/i18n";
-import { formatMoney } from "../lib/money";
+import { formatCnyMoney, normalizeCnyMoneyDisplay } from "../lib/money";
 import { normalizeStatusBarItems, type StatusBarItemId } from "../lib/statusBarItems";
 import { type BalanceInfo, type CollaborationMode, type ContextInfo, type JobView, type ToolApprovalMode, type WireUsage } from "../lib/types";
 
@@ -118,7 +118,6 @@ export function StatusBar({
   turnTokens,
   turnCost,
   cost,
-  currency,
   modelLabel,
   labelStyle = "text",
   items,
@@ -135,7 +134,6 @@ export function StatusBar({
   turnTokens?: number;
   turnCost?: number;
   cost?: number;
-  currency?: string;
   modelLabel?: string;
   labelStyle?: StatusBarLabelStyle;
   items?: readonly string[];
@@ -148,12 +146,12 @@ export function StatusBar({
   const nowPct = nowRate(usage);
   const avgPct = avgRate(usage);
   const jobsList = jobs ?? [];
-  const turnCostLabel = formatMoney(turnCost, currency);
-  const costLabel = formatMoney(cost, currency);
+  const turnCostLabel = formatCnyMoney(turnCost);
+  const costLabel = formatCnyMoney(cost);
   const turnLabel = formatTurnCount(sessionTurns, t);
   const tokenLabel = formatTokenCount(sessionTokens);
   const turnTokenLabel = formatTokenCount(turnTokens);
-  const balanceLabel = balance?.available && balance.display ? balance.display : "-";
+  const balanceLabel = balance?.available && balance.display ? normalizeCnyMoneyDisplay(balance.display) : "-";
   const planMode = collaborationMode === "plan";
   const goalMode = collaborationMode === "goal";
   const metricLabelStyle = labelStyle === "text" ? "text" : "icon";

--- a/desktop/frontend/src/lib/money.ts
+++ b/desktop/frontend/src/lib/money.ts
@@ -24,3 +24,15 @@ export function formatMoney(amount?: number, currency?: string, empty: "zero" | 
   }
   return `${symbol}${amount < 1 ? amount.toFixed(4) : amount.toFixed(2)}`;
 }
+
+export function formatCnyMoney(amount?: number, empty: "zero" | "dash" = "zero"): string {
+  return formatMoney(amount, DEFAULT_CURRENCY_SYMBOL, empty);
+}
+
+export function normalizeCnyMoneyDisplay(display?: string): string {
+  const value = (display ?? "").trim();
+  if (!value) return "";
+  const amount = value.match(/[-+]?\d[\d,]*(?:\.\d+)?/);
+  if (!amount) return value;
+  return `${DEFAULT_CURRENCY_SYMBOL}${amount[0]}`;
+}


### PR DESCRIPTION
## Summary
- Format the desktop status bar's turn cost and session cost with the RMB symbol.
- Normalize the status bar balance display to the same RMB prefix so balance and spend readouts match.
- Format the right workbench/context panel cost cards and cost breakdown rows with the same RMB display.
- Keep the shared `formatMoney` behavior unchanged for places that intentionally need source-currency formatting.

## Root Cause
The desktop UI mixed display paths: status bar cost readouts used the session currency from usage events, wallet balance used the backend-provided display string, and the right workbench context panel still formatted its session cost with the original panel currency. That allowed spend to show as `$...` while balance showed as `¥...`.

## Validation
- `npx.cmd tsx src/__tests__/context-panel-breakdown.test.ts`
- `npm.cmd test`
- `npm.cmd run test:typecheck` was attempted earlier on this branch but still fails locally because `desktop/frontend/wailsjs` is not generated in this checkout (`Cannot find module '../../wailsjs/go/main/App'`).