### PR TITLE
Fix desktop model switcher provider scope merge / 修复桌面模型切换器配置作用域合并

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -790,6 +790,53 @@ func TestModelsForTabListsMimoAPIPaidAccess(t *testing.T) {
 	}
 }
 
+func TestModelsForTabKeepsUserProvidersWithProjectConfig(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	t.Setenv("MIMO_API_KEY", "sk-test")
+
+	userCfg := config.Default()
+	userCfg.DefaultModel = "mimo-token-plan/mimo-v2.5-pro"
+	userCfg.Desktop.ProviderAccess = []string{"deepseek-flash", "mimo-pro"}
+	if err := userCfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save user config: %v", err)
+	}
+
+	projectRoot := t.TempDir()
+	projectConfig := `default_model = "deepseek-flash/deepseek-v4-flash"
+
+[desktop]
+provider_access = ["deepseek-flash"]
+
+[[providers]]
+name = "deepseek-flash"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+`
+	if err := os.WriteFile(filepath.Join(projectRoot, "reasonix.toml"), []byte(projectConfig), 0o644); err != nil {
+		t.Fatalf("write project config: %v", err)
+	}
+
+	app := NewApp()
+	tab := &WorkspaceTab{ID: "project", WorkspaceRoot: projectRoot, Ready: true}
+	app.tabs = map[string]*WorkspaceTab{tab.ID: tab}
+	app.activeTabID = tab.ID
+
+	models := app.ModelsForTab(tab.ID)
+	refs := modelRefsFromView(models)
+	for _, want := range []string{
+		"deepseek/deepseek-v4-flash",
+		"mimo-token-plan/mimo-v2.5-pro",
+		"mimo-token-plan/mimo-v2.5",
+	} {
+		if !refs[want] {
+			t.Fatalf("ModelsForTab refs = %+v, missing %s", models, want)
+		}
+	}
+}
+
 func TestSetModelForTabRejectsProviderOutsideAccess(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	t.Setenv("DEEPSEEK_API_KEY", "sk-test")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1330,6 +1330,16 @@ func LoadForRoot(root string) (*Config, error) {
 		return nil, err
 	}
 	cfg.Plugins = plugins
+	if providers, ok, err := mergeTOMLProviders(tomlSources); err != nil {
+		return nil, err
+	} else if ok {
+		cfg.Providers = providers
+	}
+	if access, ok, err := mergeTOMLProviderAccess(tomlSources); err != nil {
+		return nil, err
+	} else if ok {
+		cfg.Desktop.ProviderAccess = access
+	}
 
 	// Claude Code's .mcp.json (project root) is read last and merged into
 	// [[plugins]], so a server configured for Claude works here unchanged.
@@ -1479,6 +1489,70 @@ func mergeTOMLPlugins(paths []string) ([]PluginEntry, error) {
 		}
 	}
 	return merged, nil
+}
+
+// mergeTOMLProviders merges [[providers]] across TOML sources by name (later
+// source wins). This preserves account-level desktop providers when a project
+// reasonix.toml declares its own provider table.
+func mergeTOMLProviders(paths []string) ([]ProviderEntry, bool, error) {
+	var merged []ProviderEntry
+	index := map[string]int{}
+	saw := false
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		var f Config
+		if _, err := toml.DecodeFile(path, &f); err != nil {
+			return nil, false, fmt.Errorf("config %s: %w", path, err)
+		}
+		if len(f.Providers) == 0 {
+			continue
+		}
+		saw = true
+		for _, p := range f.Providers {
+			normalizeProviderEffortFields(&p)
+			if i, ok := index[p.Name]; ok {
+				merged[i] = p
+				continue
+			}
+			index[p.Name] = len(merged)
+			merged = append(merged, p)
+		}
+	}
+	return merged, saw, nil
+}
+
+// mergeTOMLProviderAccess merges desktop.provider_access across TOML sources so
+// project desktop settings do not hide account-level providers from the desktop
+// model switcher.
+func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
+	var merged []string
+	seen := map[string]bool{}
+	saw := false
+	for _, path := range paths {
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		var f Config
+		meta, err := toml.DecodeFile(path, &f)
+		if err != nil {
+			return nil, false, fmt.Errorf("config %s: %w", path, err)
+		}
+		if !meta.IsDefined("desktop", "provider_access") {
+			continue
+		}
+		saw = true
+		for _, name := range f.Desktop.ProviderAccess {
+			name = strings.TrimSpace(name)
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			merged = append(merged, name)
+		}
+	}
+	return merged, saw, nil
 }
 
 // LoadForEdit returns a config to seed the `reasonix setup` wizard when reconfiguring:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1501,10 +1501,10 @@ func mergeTOMLPlugins(paths []string) ([]PluginEntry, error) {
 	return merged, nil
 }
 
-// mergeTOMLProviders merges [[providers]] across TOML sources by provider key
-// (later source wins). Official desktop aliases share their canonical provider
-// key, so a project deepseek-flash entry overrides a user deepseek entry instead
-// of leaving two providers for later canonicalization to pick from.
+// mergeTOMLProviders merges [[providers]] across TOML sources by provider name
+// (later source wins). Keep official legacy aliases distinct here: they can carry
+// different default models and effort capabilities, and the later desktop
+// normalization layer handles canonical Settings access.
 func mergeTOMLProviders(paths []string) ([]ProviderEntry, map[string]providerSourceScope, bool, error) {
 	var merged []ProviderEntry
 	index := map[string]int{}
@@ -1546,31 +1546,7 @@ func providerSourceForPath(path string) providerSourceScope {
 }
 
 func providerMergeKey(p ProviderEntry) string {
-	name := strings.TrimSpace(p.Name)
-	if name == "" {
-		return ""
-	}
-	canonical := canonicalDesktopOfficialProviderName(name)
-	if canonical == name {
-		return name
-	}
-	if isOfficialProviderAliasForMerge(p, canonical) {
-		return canonical
-	}
-	return name
-}
-
-func isOfficialProviderAliasForMerge(p ProviderEntry, canonical string) bool {
-	switch canonical {
-	case "deepseek":
-		return officialProviderHost(p.BaseURL) == "api.deepseek.com"
-	case "mimo-api":
-		return officialMimoHost(p.BaseURL) == "api.xiaomimimo.com"
-	case "mimo-token-plan":
-		return officialMimoHost(p.BaseURL) == "token-plan-cn.xiaomimimo.com"
-	default:
-		return false
-	}
+	return strings.TrimSpace(p.Name)
 }
 
 // mergeTOMLProviderAccess merges desktop.provider_access across TOML sources so

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -60,7 +60,16 @@ type Config struct {
 	Statusline        StatuslineConfig        `toml:"statusline"`
 	LSP               LSPConfig               `toml:"lsp"`
 	Bot               BotConfig               `toml:"bot"`
+
+	providerSources map[string]providerSourceScope
 }
+
+type providerSourceScope string
+
+const (
+	providerSourceUser    providerSourceScope = "user"
+	providerSourceProject providerSourceScope = "project"
+)
 
 // UIConfig controls CLI presentation-only settings. Desktop appearance is kept in
 // DesktopConfig so desktop preferences cannot alter terminal output or prompts.
@@ -1330,10 +1339,11 @@ func LoadForRoot(root string) (*Config, error) {
 		return nil, err
 	}
 	cfg.Plugins = plugins
-	if providers, ok, err := mergeTOMLProviders(tomlSources); err != nil {
+	if providers, providerSources, ok, err := mergeTOMLProviders(tomlSources); err != nil {
 		return nil, err
 	} else if ok {
 		cfg.Providers = providers
+		cfg.providerSources = providerSources
 	}
 	if access, ok, err := mergeTOMLProviderAccess(tomlSources); err != nil {
 		return nil, err
@@ -1491,12 +1501,14 @@ func mergeTOMLPlugins(paths []string) ([]PluginEntry, error) {
 	return merged, nil
 }
 
-// mergeTOMLProviders merges [[providers]] across TOML sources by name (later
-// source wins). This preserves account-level desktop providers when a project
-// reasonix.toml declares its own provider table.
-func mergeTOMLProviders(paths []string) ([]ProviderEntry, bool, error) {
+// mergeTOMLProviders merges [[providers]] across TOML sources by provider key
+// (later source wins). Official desktop aliases share their canonical provider
+// key, so a project deepseek-flash entry overrides a user deepseek entry instead
+// of leaving two providers for later canonicalization to pick from.
+func mergeTOMLProviders(paths []string) ([]ProviderEntry, map[string]providerSourceScope, bool, error) {
 	var merged []ProviderEntry
 	index := map[string]int{}
+	sources := map[string]providerSourceScope{}
 	saw := false
 	for _, path := range paths {
 		if _, err := os.Stat(path); err != nil {
@@ -1504,23 +1516,61 @@ func mergeTOMLProviders(paths []string) ([]ProviderEntry, bool, error) {
 		}
 		var f Config
 		if _, err := toml.DecodeFile(path, &f); err != nil {
-			return nil, false, fmt.Errorf("config %s: %w", path, err)
+			return nil, nil, false, fmt.Errorf("config %s: %w", path, err)
 		}
 		if len(f.Providers) == 0 {
 			continue
 		}
 		saw = true
+		source := providerSourceForPath(path)
 		for _, p := range f.Providers {
 			normalizeProviderEffortFields(&p)
-			if i, ok := index[p.Name]; ok {
+			key := providerMergeKey(p)
+			if i, ok := index[key]; ok {
 				merged[i] = p
-				continue
+			} else {
+				index[key] = len(merged)
+				merged = append(merged, p)
 			}
-			index[p.Name] = len(merged)
-			merged = append(merged, p)
+			sources[key] = source
 		}
 	}
-	return merged, saw, nil
+	return merged, sources, saw, nil
+}
+
+func providerSourceForPath(path string) providerSourceScope {
+	if isUserConfigPath(path) {
+		return providerSourceUser
+	}
+	return providerSourceProject
+}
+
+func providerMergeKey(p ProviderEntry) string {
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		return ""
+	}
+	canonical := canonicalDesktopOfficialProviderName(name)
+	if canonical == name {
+		return name
+	}
+	if isOfficialProviderAliasForMerge(p, canonical) {
+		return canonical
+	}
+	return name
+}
+
+func isOfficialProviderAliasForMerge(p ProviderEntry, canonical string) bool {
+	switch canonical {
+	case "deepseek":
+		return officialProviderHost(p.BaseURL) == "api.deepseek.com"
+	case "mimo-api":
+		return officialMimoHost(p.BaseURL) == "api.xiaomimimo.com"
+	case "mimo-token-plan":
+		return officialMimoHost(p.BaseURL) == "token-plan-cn.xiaomimimo.com"
+	default:
+		return false
+	}
 }
 
 // mergeTOMLProviderAccess merges desktop.provider_access across TOML sources so

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -982,7 +982,7 @@ func TestSaveToScopesUserAndProjectFiles(t *testing.T) {
 	}
 }
 
-func TestLoadForRootMergesOfficialProviderAliasesByCanonicalID(t *testing.T) {
+func TestLoadForRootKeepsOfficialProviderAliasesDistinct(t *testing.T) {
 	isolateUserConfigHome(t)
 	root := t.TempDir()
 	userPath := UserConfigPath()
@@ -1022,17 +1022,19 @@ effort = "max"
 	if err != nil {
 		t.Fatalf("LoadForRoot: %v", err)
 	}
-	p, ok := cfg.Provider("deepseek")
+	userProvider, ok := cfg.Provider("deepseek")
 	if !ok {
-		t.Fatalf("canonical deepseek provider missing: %+v", cfg.Providers)
+		t.Fatalf("user deepseek provider missing: %+v", cfg.Providers)
 	}
-	if p.APIKeyEnv != "PROJECT_DEEPSEEK_KEY" || p.Effort != "max" {
-		t.Fatalf("deepseek provider = %+v, want project override", p)
+	if userProvider.APIKeyEnv != "USER_DEEPSEEK_KEY" {
+		t.Fatalf("deepseek provider = %+v, want user provider preserved", userProvider)
 	}
-	for _, p := range cfg.Providers {
-		if p.APIKeyEnv == "USER_DEEPSEEK_KEY" {
-			t.Fatalf("user deepseek provider survived canonical merge: %+v", cfg.Providers)
-		}
+	projectProvider, ok := cfg.Provider("deepseek-flash")
+	if !ok {
+		t.Fatalf("project deepseek-flash provider missing: %+v", cfg.Providers)
+	}
+	if projectProvider.APIKeyEnv != "PROJECT_DEEPSEEK_KEY" || projectProvider.Effort != "max" {
+		t.Fatalf("deepseek-flash provider = %+v, want project provider preserved", projectProvider)
 	}
 }
 

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -982,6 +982,120 @@ func TestSaveToScopesUserAndProjectFiles(t *testing.T) {
 	}
 }
 
+func TestLoadForRootMergesOfficialProviderAliasesByCanonicalID(t *testing.T) {
+	isolateUserConfigHome(t)
+	root := t.TempDir()
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(`
+config_version = 2
+default_model = "deepseek/deepseek-v4-flash"
+
+[desktop]
+provider_access = ["deepseek"]
+
+[[providers]]
+name = "deepseek"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+models = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default = "deepseek-v4-flash"
+api_key_env = "USER_DEEPSEEK_KEY"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "reasonix.toml"), []byte(`
+[[providers]]
+name = "deepseek-flash"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+model = "deepseek-v4-flash"
+api_key_env = "PROJECT_DEEPSEEK_KEY"
+effort = "max"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRoot(root)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	p, ok := cfg.Provider("deepseek")
+	if !ok {
+		t.Fatalf("canonical deepseek provider missing: %+v", cfg.Providers)
+	}
+	if p.APIKeyEnv != "PROJECT_DEEPSEEK_KEY" || p.Effort != "max" {
+		t.Fatalf("deepseek provider = %+v, want project override", p)
+	}
+	for _, p := range cfg.Providers {
+		if p.APIKeyEnv == "USER_DEEPSEEK_KEY" {
+			t.Fatalf("user deepseek provider survived canonical merge: %+v", cfg.Providers)
+		}
+	}
+}
+
+func TestSaveForRootDoesNotWriteUserProvidersIntoProjectConfig(t *testing.T) {
+	isolateUserConfigHome(t)
+	root := t.TempDir()
+	userPath := UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(userPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(userPath, []byte(`
+config_version = 2
+
+[[providers]]
+name = "global"
+kind = "openai"
+base_url = "https://global.example/v1"
+model = "global-model"
+api_key_env = "GLOBAL_KEY"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectPath := filepath.Join(root, "reasonix.toml")
+	if err := os.WriteFile(projectPath, []byte(`
+config_version = 2
+default_model = "project-local/project-model"
+
+[[providers]]
+name = "project-local"
+kind = "openai"
+base_url = "https://project.example/v1"
+model = "project-model"
+api_key_env = "PROJECT_KEY"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadForRoot(root)
+	if err != nil {
+		t.Fatalf("LoadForRoot: %v", err)
+	}
+	if _, ok := cfg.Provider("global"); !ok {
+		t.Fatal("runtime config should include user provider before saving")
+	}
+	if _, ok := cfg.Provider("project-local"); !ok {
+		t.Fatal("runtime config should include project provider before saving")
+	}
+	if err := cfg.SaveForRoot(root); err != nil {
+		t.Fatalf("SaveForRoot: %v", err)
+	}
+
+	var got Config
+	if _, err := toml.DecodeFile(projectPath, &got); err != nil {
+		t.Fatalf("saved project config does not parse: %v", err)
+	}
+	if _, ok := got.Provider("global"); ok {
+		t.Fatalf("user provider leaked into project config: %+v", got.Providers)
+	}
+	if _, ok := got.Provider("project-local"); !ok {
+		t.Fatalf("project provider missing after save: %+v", got.Providers)
+	}
+}
+
 func TestSetNetworkRejectsIncompleteCustomProxy(t *testing.T) {
 	c := Default()
 	if err := c.SetNetwork(NetworkConfig{ProxyMode: "custom"}); err == nil {

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -38,6 +38,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	default:
 		scope = RenderScopeFull
 	}
+	if scope == RenderScopeProject {
+		c = projectScopedConfigForRender(c)
+	}
 	defaults := Default()
 	var b strings.Builder
 
@@ -570,6 +573,21 @@ func shouldRenderProviders(c, defaults *Config, scope RenderScope) bool {
 		return true
 	}
 	return !reflect.DeepEqual(c.Providers, defaults.Providers)
+}
+
+func projectScopedConfigForRender(c *Config) *Config {
+	if c == nil || len(c.providerSources) == 0 {
+		return c
+	}
+	cp := *c
+	cp.Providers = make([]ProviderEntry, 0, len(c.Providers))
+	for _, p := range c.Providers {
+		if c.providerSources[providerMergeKey(p)] == providerSourceUser {
+			continue
+		}
+		cp.Providers = append(cp.Providers, p)
+	}
+	return &cp
 }
 
 func shouldRenderBot(c, defaults *Config, scope RenderScope) bool {


### PR DESCRIPTION
## Summary
- Merge `[[providers]]` across user and project TOML sources by provider name, matching the existing plugin merge behavior.
- Merge desktop `provider_access` across config scopes so project desktop settings do not hide account-level providers from the chat model switcher.
- Add a regression test for a workspace project config that previously hid user-configured MiniMax models.

Fixes #4486.

## Verification
- `go test ./internal/config`
- `go test ./internal/config ./internal/control ./internal/boot` with isolated user config
- `go test .` in the desktop module
