### PR TITLE
Keep new tab button beside tabs / 固定新建会话按钮贴近标签页

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -79,6 +79,16 @@ ok(
 );
 
 ok(
+  finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar__tabs", "flex") === "0 1 auto",
+  "themed AppChrome tab lists size to tab content before shrinking",
+);
+
+ok(
+  finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar__tabs", "width") === "max-content",
+  "themed AppChrome tab lists keep the new-tab button next to the last tab",
+);
+
+ok(
   finalDeclaration(":root[data-theme-style] .app-chrome--tabs .tabbar > .tooltip-trigger:has(.tabbar__new)", "flex")?.includes("--chrome-panel-control-size"),
   "themed AppChrome new-tab button keeps a stable slot beside the tabs",
 );

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -18582,7 +18582,8 @@ a[href] {
 }
 
 :root[data-theme-style] .app-chrome--tabs .tabbar__tabs {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
+  width: max-content;
   max-width: calc(100% - var(--chrome-panel-control-size, 30px) - 10px);
 }
 


### PR DESCRIPTION
## Summary
- Keep the themed desktop tab list sized to its tab content before it shrinks.
- Preserve a stable new-session button slot immediately after the last visible tab.
- Add AppChrome CSS contract coverage so the themed tab list cannot grow into empty chrome space again.

## Root cause
The themed AppChrome tab list used `flex: 1 1 auto`, so it expanded across the remaining titlebar space and pushed the `+` new-session button toward the right chrome controls when the right dock changed the available width.

## Verification
- `npm run check:css`
- `tsx src/__tests__/app-chrome-tabs.test.ts`
- Browser DOM check confirmed the tab list no longer flex-grows and the `+` button sits beside the last tab.

## Related
- Fixes #4483
- Related to #3986, which proposes removing the top `+` button entirely. This PR keeps the button and fixes its placement for the current UI direction.
