### PR TITLE
Fix workspace changes refresh per tab / 修复改动列表按会话刷新

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5356,7 +5356,10 @@ func skipWorkspaceEntry(rel, name string, isDir bool) bool {
 }
 
 func (a *App) activeWorkspaceBase() (string, error) {
-	root := a.activeWorkspaceRoot()
+	return workspaceBaseFromRoot(a.activeWorkspaceRoot())
+}
+
+func workspaceBaseFromRoot(root string) (string, error) {
 	if strings.TrimSpace(root) == "" || root == "." {
 		return os.Getwd()
 	}

--- a/desktop/bound_array_contract_test.go
+++ b/desktop/bound_array_contract_test.go
@@ -33,8 +33,8 @@ func TestBoundArrayPayloadsAreNonNilBeforeStartup(t *testing.T) {
 	if got := app.SlashArgs("/skill "); got.Items == nil {
 		t.Fatal("SlashArgs().Items is nil; frontend expects []")
 	}
-	if got := app.WorkspaceChanges(); got.Files == nil {
-		t.Fatal("WorkspaceChanges().Files is nil; frontend expects []")
+	if got := app.WorkspaceChanges(""); got.Files == nil {
+		t.Fatal(`WorkspaceChanges("").Files is nil; frontend expects []`)
 	}
 	if got := app.ContextPanel("missing"); got.ReadFiles == nil || got.ChangedFiles == nil {
 		t.Fatalf("ContextPanel(missing) arrays = read:%v changed:%v, want non-nil", got.ReadFiles, got.ChangedFiles)

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1867,15 +1867,23 @@ export default function App() {
     openWorkspacePanel("context");
   }, [closeWorkspacePanel, openWorkspacePanel, pulseWorkspaceToggle, workspacePanelRenderable]);
 
+  const clearWorkspaceRequests = useCallback(() => {
+    setWorkspaceRevealRequest(null);
+    setWorkspaceChangeRevealRequest(null);
+    setWorkspaceFileListRequest(null);
+    setWorkspaceChangeListRequest(null);
+  }, []);
+
+  useEffect(() => {
+    clearWorkspaceRequests();
+  }, [activeTabId, clearWorkspaceRequests]);
+
   const openRightDockMode = useCallback(
     (mode: RightDockMode) => {
-      setWorkspaceRevealRequest(null);
-      setWorkspaceChangeRevealRequest(null);
-      setWorkspaceFileListRequest(null);
-      setWorkspaceChangeListRequest(null);
+      clearWorkspaceRequests();
       openWorkspacePanel(mode);
     },
-    [openWorkspacePanel],
+    [clearWorkspaceRequests, openWorkspacePanel],
   );
 
   const openRightDockFile = useCallback(
@@ -1977,14 +1985,11 @@ export default function App() {
 
   const handleTabChange = useCallback(async (id: string) => {
     closeTransientOverlays();
-    setWorkspaceRevealRequest(null);
-    setWorkspaceChangeRevealRequest(null);
-    setWorkspaceFileListRequest(null);
-    setWorkspaceChangeListRequest(null);
+    clearWorkspaceRequests();
     const tabs = await switchTab(id);
     if (tabs) setTabMetas(tabs);
     setTabRevealSignal((signal) => signal + 1);
-  }, [closeTransientOverlays, switchTab]);
+  }, [clearWorkspaceRequests, closeTransientOverlays, switchTab]);
 
   const handleTabClose = useCallback(async (id: string) => {
     closeTransientOverlays();

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1977,6 +1977,10 @@ export default function App() {
 
   const handleTabChange = useCallback(async (id: string) => {
     closeTransientOverlays();
+    setWorkspaceRevealRequest(null);
+    setWorkspaceChangeRevealRequest(null);
+    setWorkspaceFileListRequest(null);
+    setWorkspaceChangeListRequest(null);
     const tabs = await switchTab(id);
     if (tabs) setTabMetas(tabs);
     setTabRevealSignal((signal) => signal + 1);
@@ -3090,6 +3094,7 @@ export default function App() {
               ) : (
                 <WorkspacePanel
                   open={workspacePanelRenderable}
+                  tabId={activeTabId}
                   cwd={state.meta?.cwd}
                   maximized={workspacePanelMaximized}
                   panelWidth={workspacePanelRenderWidth}

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -183,6 +183,7 @@ function formatCommitDate(dateStr: string): string {
 
 export function WorkspacePanel({
   open,
+  tabId,
   cwd,
   maximized,
   panelWidth,
@@ -200,6 +201,7 @@ export function WorkspacePanel({
   showViewTabs = true,
 }: {
   open: boolean;
+  tabId?: string;
   cwd?: string;
   maximized: boolean;
   panelWidth?: number;
@@ -253,6 +255,7 @@ export function WorkspacePanel({
   const dismissedFileListRequestIdRef = useRef<number | null>(null);
   const lastChangeListRequestIdRef = useRef<number | null>(null);
   const dismissedChangeListRequestIdRef = useRef<number | null>(null);
+  const lastWorkspaceTabIdRef = useRef(tabId ?? "");
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
 
@@ -279,12 +282,12 @@ export function WorkspacePanel({
 
   const loadWorkspaceChanges = useCallback(async () => {
     try {
-      const result = await app.WorkspaceChanges();
+      const result = await app.WorkspaceChanges(tabId ?? "");
       setWorkspaceChanges(result.files && result.files.length > 0 ? result.files : null);
     } catch {
       setWorkspaceChanges(null);
     }
-  }, []);
+  }, [tabId]);
 
   const toggleCommit = useCallback((hash: string) => {
     setExpandedCommit((prev) => {
@@ -359,6 +362,27 @@ export function WorkspacePanel({
     setTreeVisible(true);
     void loadDir("");
   }, [cwd, loadDir, open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const nextTabId = tabId ?? "";
+    if (lastWorkspaceTabIdRef.current === nextTabId) return;
+    lastWorkspaceTabIdRef.current = nextTabId;
+    setWorkspaceChanges(null);
+    setGitHistory([]);
+    setExpandedCommit(null);
+    setCommitDetail(null);
+    setScopedChangeRows(null);
+    lastChangeRevealRequestIdRef.current = null;
+    dismissedChangeRevealRequestIdRef.current = null;
+    lastChangeListRequestIdRef.current = null;
+    dismissedChangeListRequestIdRef.current = null;
+    if (viewMode === "changed") {
+      setSelectedPath(null);
+      setOpenTabs([]);
+      setPreview(null);
+    }
+  }, [open, tabId]);
 
   useEffect(() => {
     if (!open) return;

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -256,6 +256,9 @@ export function WorkspacePanel({
   const lastChangeListRequestIdRef = useRef<number | null>(null);
   const dismissedChangeListRequestIdRef = useRef<number | null>(null);
   const lastWorkspaceTabIdRef = useRef(tabId ?? "");
+  const workspaceChangesRequestIdRef = useRef(0);
+  const gitHistoryRequestIdRef = useRef(0);
+  const commitDetailRequestIdRef = useRef(0);
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
   const openDirsRef = useRef(openDirs);
 
@@ -269,23 +272,37 @@ export function WorkspacePanel({
   }, []);
 
   const loadGitHistory = useCallback(async () => {
+    const requestId = ++gitHistoryRequestIdRef.current;
+    const requestTabId = tabId ?? "";
     setLoadingHistory(true);
     try {
-      const result = await app.WorkspaceGitHistory(selectedPath || "");
-      setGitHistory(result || []);
+      const result = await app.WorkspaceGitHistory(requestTabId, selectedPath || "");
+      if (gitHistoryRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+        setGitHistory(result || []);
+      }
     } catch (err) {
-      setGitHistory([]);
+      if (gitHistoryRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+        setGitHistory([]);
+      }
     } finally {
-      setLoadingHistory(false);
+      if (gitHistoryRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+        setLoadingHistory(false);
+      }
     }
-  }, [selectedPath]);
+  }, [selectedPath, tabId]);
 
   const loadWorkspaceChanges = useCallback(async () => {
+    const requestId = ++workspaceChangesRequestIdRef.current;
+    const requestTabId = tabId ?? "";
     try {
-      const result = await app.WorkspaceChanges(tabId ?? "");
-      setWorkspaceChanges(result.files && result.files.length > 0 ? result.files : null);
+      const result = await app.WorkspaceChanges(requestTabId);
+      if (workspaceChangesRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+        setWorkspaceChanges(result.files && result.files.length > 0 ? result.files : null);
+      }
     } catch {
-      setWorkspaceChanges(null);
+      if (workspaceChangesRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+        setWorkspaceChanges(null);
+      }
     }
   }, [tabId]);
 
@@ -300,26 +317,35 @@ export function WorkspacePanel({
   useEffect(() => {
     if (!open) return;
     if (expandedCommit) {
+      const requestId = ++commitDetailRequestIdRef.current;
+      const requestTabId = tabId ?? "";
       let live = true;
       setLoadingCommit(true);
       app
-        .WorkspaceGitCommitDetail(expandedCommit, selectedPath || "")
+        .WorkspaceGitCommitDetail(requestTabId, expandedCommit, selectedPath || "")
         .then((detail) => {
-          if (live) setCommitDetail(detail);
+          if (live && commitDetailRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+            setCommitDetail(detail);
+          }
         })
         .catch(() => {
-          if (live) setCommitDetail(null);
+          if (live && commitDetailRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+            setCommitDetail(null);
+          }
         })
         .finally(() => {
-          if (live) setLoadingCommit(false);
+          if (live && commitDetailRequestIdRef.current === requestId && lastWorkspaceTabIdRef.current === requestTabId) {
+            setLoadingCommit(false);
+          }
         });
       return () => {
         live = false;
       };
     } else {
+      commitDetailRequestIdRef.current += 1;
       setCommitDetail(null);
     }
-  }, [expandedCommit, selectedPath, open]);
+  }, [expandedCommit, selectedPath, open, tabId]);
 
   const selectFile = useCallback(
     (path: string) => {
@@ -368,6 +394,9 @@ export function WorkspacePanel({
     const nextTabId = tabId ?? "";
     if (lastWorkspaceTabIdRef.current === nextTabId) return;
     lastWorkspaceTabIdRef.current = nextTabId;
+    workspaceChangesRequestIdRef.current += 1;
+    gitHistoryRequestIdRef.current += 1;
+    commitDetailRequestIdRef.current += 1;
     setWorkspaceChanges(null);
     setGitHistory([]);
     setExpandedCommit(null);

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -180,7 +180,7 @@ export interface AppBindings {
   ListDir(rel: string): Promise<DirEntry[]>;
   SearchFileRefs(query: string): Promise<DirEntry[]>;
   ReadFile(rel: string): Promise<FilePreview>;
-  WorkspaceChanges(): Promise<WorkspaceChangesView>;
+  WorkspaceChanges(tabID: string): Promise<WorkspaceChangesView>;
   GitBranches(): Promise<string[]>;
   GitCheckout(branch: string): Promise<void>;
   WorkspaceGitHistory(path: string): Promise<GitCommitView[]>;
@@ -2098,7 +2098,7 @@ function makeMockApp(): AppBindings {
         binary: false,
       };
     },
-    async WorkspaceChanges() {
+    async WorkspaceChanges(_tabID: string) {
       return {
         gitAvailable: true,
         gitBranch: "main",

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -183,8 +183,8 @@ export interface AppBindings {
   WorkspaceChanges(tabID: string): Promise<WorkspaceChangesView>;
   GitBranches(): Promise<string[]>;
   GitCheckout(branch: string): Promise<void>;
-  WorkspaceGitHistory(path: string): Promise<GitCommitView[]>;
-  WorkspaceGitCommitDetail(hash: string, path: string): Promise<GitCommitDetailView>;
+  WorkspaceGitHistory(tabID: string, path: string): Promise<GitCommitView[]>;
+  WorkspaceGitCommitDetail(tabID: string, hash: string, path: string): Promise<GitCommitDetailView>;
   OpenWorkspacePath(rel: string): Promise<void>;
   RevealWorkspacePath(rel: string): Promise<void>;
   RevealPath(path: string): Promise<void>;
@@ -2122,12 +2122,12 @@ function makeMockApp(): AppBindings {
     async GitCheckout(_branch: string) {
       console.info("mock GitCheckout", _branch);
     },
-    async WorkspaceGitHistory(path: string) {
+    async WorkspaceGitHistory(_tabID: string, path: string) {
       return [
         { hash: "abcdef123456", author: "Mock Author", date: new Date().toISOString(), message: "Mock commit message for " + path },
       ];
     },
-    async WorkspaceGitCommitDetail(_hash: string, path: string) {
+    async WorkspaceGitCommitDetail(_tabID: string, _hash: string, path: string) {
       if (path) {
         return { diff: "--- a/mock\n+++ b/mock\n@@ -1,1 +1,1 @@\n-mock\n+mock diff" };
       }

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"reasonix/internal/control"
 	"reasonix/internal/proc"
 )
 
@@ -23,9 +24,31 @@ type workspaceChangeAccumulator struct {
 	hasGit     bool
 }
 
-func (a *App) WorkspaceChanges() WorkspaceChangesView {
-	out := WorkspaceChangesView{GitAvailable: true}
-	base, err := a.activeWorkspaceBase()
+func (a *App) WorkspaceChanges(tabID string) WorkspaceChangesView {
+	out := WorkspaceChangesView{Files: []WorkspaceChangeView{}, GitAvailable: true}
+	tabID = strings.TrimSpace(tabID)
+
+	a.mu.RLock()
+	var tab *WorkspaceTab
+	if tabID == "" {
+		tab = a.activeTabLocked()
+	} else {
+		tab = a.tabs[tabID]
+	}
+	var workspaceRoot string
+	var ctrl *control.Controller
+	if tab != nil {
+		workspaceRoot = tab.WorkspaceRoot
+		ctrl = tab.Ctrl
+	}
+	a.mu.RUnlock()
+	if tabID != "" && tab == nil {
+		out.GitAvailable = false
+		out.GitErr = fmt.Sprintf("tab %q not found", tabID)
+		return out
+	}
+
+	base, err := workspaceBaseFromRoot(workspaceRoot)
 	if err != nil {
 		out.GitAvailable = false
 		out.GitErr = err.Error()
@@ -46,9 +69,6 @@ func (a *App) WorkspaceChanges() WorkspaceChangesView {
 		return changes[path]
 	}
 
-	a.mu.RLock()
-	ctrl := a.activeCtrlLocked()
-	a.mu.RUnlock()
 	if ctrl != nil {
 		for _, meta := range ctrl.Checkpoints() {
 			for _, path := range meta.Paths {

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -28,21 +28,8 @@ func (a *App) WorkspaceChanges(tabID string) WorkspaceChangesView {
 	out := WorkspaceChangesView{Files: []WorkspaceChangeView{}, GitAvailable: true}
 	tabID = strings.TrimSpace(tabID)
 
-	a.mu.RLock()
-	var tab *WorkspaceTab
-	if tabID == "" {
-		tab = a.activeTabLocked()
-	} else {
-		tab = a.tabs[tabID]
-	}
-	var workspaceRoot string
-	var ctrl *control.Controller
-	if tab != nil {
-		workspaceRoot = tab.WorkspaceRoot
-		ctrl = tab.Ctrl
-	}
-	a.mu.RUnlock()
-	if tabID != "" && tab == nil {
+	workspaceRoot, ctrl, ok := a.workspaceChangesTarget(tabID)
+	if !ok {
 		out.GitAvailable = false
 		out.GitErr = fmt.Sprintf("tab %q not found", tabID)
 		return out
@@ -121,6 +108,30 @@ func (a *App) WorkspaceChanges(tabID string) WorkspaceChangesView {
 		return strings.ToLower(a.Path) < strings.ToLower(b.Path)
 	})
 	return out
+}
+
+func (a *App) workspaceChangesTarget(tabID string) (string, *control.Controller, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	var tab *WorkspaceTab
+	if tabID == "" {
+		tab = a.activeTabLocked()
+	} else {
+		tab = a.tabs[tabID]
+	}
+	if tab == nil {
+		return "", nil, tabID == ""
+	}
+	return tab.WorkspaceRoot, tab.Ctrl, true
+}
+
+func (a *App) workspaceBaseForTab(tabID string) (string, error) {
+	tabID = strings.TrimSpace(tabID)
+	workspaceRoot, _, ok := a.workspaceChangesTarget(tabID)
+	if !ok {
+		return "", fmt.Errorf("tab %q not found", tabID)
+	}
+	return workspaceBaseFromRoot(workspaceRoot)
 }
 
 // workspaceGit builds a console-hidden git probe: CREATE_NO_WINDOW so git's own
@@ -278,8 +289,8 @@ type GitCommitDetailView struct {
 	Files []string `json:"files,omitempty"`
 }
 
-func (a *App) WorkspaceGitHistory(path string) ([]GitCommitView, error) {
-	base, err := a.activeWorkspaceBase()
+func (a *App) WorkspaceGitHistory(tabID string, path string) ([]GitCommitView, error) {
+	base, err := a.workspaceBaseForTab(tabID)
 	if err != nil {
 		return nil, err
 	}
@@ -309,8 +320,8 @@ func (a *App) WorkspaceGitHistory(path string) ([]GitCommitView, error) {
 	return out, nil
 }
 
-func (a *App) WorkspaceGitCommitDetail(hash string, path string) (GitCommitDetailView, error) {
-	base, err := a.activeWorkspaceBase()
+func (a *App) WorkspaceGitCommitDetail(tabID string, hash string, path string) (GitCommitDetailView, error) {
+	base, err := a.workspaceBaseForTab(tabID)
 	if err != nil {
 		return GitCommitDetailView{}, err
 	}

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -13,7 +13,9 @@ import (
 	"time"
 
 	"golang.org/x/text/encoding/simplifiedchinese"
+	"reasonix/internal/checkpoint"
 	"reasonix/internal/config"
+	"reasonix/internal/control"
 )
 
 // --- workspaceStatePath ---
@@ -735,12 +737,63 @@ func TestWorkspaceChangesNonGitDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := (&App{}).WorkspaceChanges()
+	got := (&App{}).WorkspaceChanges("")
 	if got.GitAvailable {
 		t.Fatal("non-git directory should mark git unavailable")
 	}
 	if len(got.Files) != 0 {
 		t.Fatalf("files = %+v, want none", got.Files)
+	}
+}
+
+func TestWorkspaceChangesUsesRequestedTabCheckpoints(t *testing.T) {
+	workspace := t.TempDir()
+	sessionDir := t.TempDir()
+	sessionA := filepath.Join(sessionDir, "a.jsonl")
+	sessionB := filepath.Join(sessionDir, "b.jsonl")
+	content := "old"
+	now := time.Now()
+
+	for _, tc := range []struct {
+		session string
+		path    string
+		prompt  string
+	}{
+		{sessionA, "a.txt", "edit a"},
+		{sessionB, "b.txt", "edit b"},
+	} {
+		ckptDir := strings.TrimSuffix(tc.session, ".jsonl") + ".ckpt"
+		if err := os.MkdirAll(ckptDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		seedCheckpoint(t, ckptDir, checkpoint.Checkpoint{
+			Turn:   0,
+			Time:   now,
+			Prompt: tc.prompt,
+			Files:  []checkpoint.FileSnap{{Path: tc.path, Content: &content}},
+		})
+	}
+
+	ctrlA := control.New(control.Options{SessionDir: sessionDir, SessionPath: sessionA, Label: "a"})
+	ctrlB := control.New(control.Options{SessionDir: sessionDir, SessionPath: sessionB, Label: "b"})
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"a": {ID: "a", Scope: "project", WorkspaceRoot: workspace, Ctrl: ctrlA, Ready: true},
+			"b": {ID: "b", Scope: "project", WorkspaceRoot: workspace, Ctrl: ctrlB, Ready: true},
+		},
+		activeTabID: "a",
+	}
+
+	got := app.WorkspaceChanges("b")
+	byPath := map[string]WorkspaceChangeView{}
+	for _, file := range got.Files {
+		byPath[file.Path] = file
+	}
+	if _, ok := byPath["a.txt"]; ok {
+		t.Fatalf("requested tab b included active tab a changes: %+v", got.Files)
+	}
+	if byPath["b.txt"].LatestPrompt != "edit b" {
+		t.Fatalf("requested tab b changes = %+v, want b.txt from tab b", got.Files)
 	}
 }
 
@@ -768,7 +821,7 @@ func TestWorkspaceChangesGitStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := (&App{}).WorkspaceChanges()
+	got := (&App{}).WorkspaceChanges("")
 	if !got.GitAvailable {
 		t.Fatalf("git unavailable: %s", got.GitErr)
 	}
@@ -819,7 +872,7 @@ func TestWorkspaceChangesGitStatusFromRepoSubdirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := (&App{}).WorkspaceChanges()
+	got := (&App{}).WorkspaceChanges("")
 	if !got.GitAvailable {
 		t.Fatalf("git unavailable: %s", got.GitErr)
 	}
@@ -860,7 +913,7 @@ func TestWorkspaceChangesUntrackedDirectoryListsFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := (&App{}).WorkspaceChanges()
+	got := (&App{}).WorkspaceChanges("")
 	byPath := map[string]WorkspaceChangeView{}
 	for _, file := range got.Files {
 		byPath[file.Path] = file
@@ -895,7 +948,7 @@ func TestWorkspaceChangesGitBranchDetachedHead(t *testing.T) {
 	short := gitOutput(t, "rev-parse", "--short", "HEAD")
 	runGit(t, "checkout", "--detach", "HEAD")
 
-	got := (&App{}).WorkspaceChanges()
+	got := (&App{}).WorkspaceChanges("")
 	if !got.GitAvailable {
 		t.Fatalf("git unavailable: %s", got.GitErr)
 	}

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -986,7 +986,7 @@ func TestWorkspaceGitHistory(t *testing.T) {
 	runGit(t, "commit", "-m", "init file2")
 
 	app := &App{}
-	history, err := app.WorkspaceGitHistory("")
+	history, err := app.WorkspaceGitHistory("", "")
 	if err != nil {
 		t.Fatalf("WorkspaceGitHistory err = %v", err)
 	}
@@ -1001,7 +1001,7 @@ func TestWorkspaceGitHistory(t *testing.T) {
 	}
 
 	// Test history for specific file
-	history, err = app.WorkspaceGitHistory("file1.txt")
+	history, err = app.WorkspaceGitHistory("", "file1.txt")
 	if err != nil {
 		t.Fatalf("WorkspaceGitHistory err = %v", err)
 	}
@@ -1010,6 +1010,52 @@ func TestWorkspaceGitHistory(t *testing.T) {
 	}
 	if history[0].Message != "init file1" {
 		t.Errorf("expected commit message 'init file1', got %q", history[0].Message)
+	}
+}
+
+func TestWorkspaceGitHistoryUsesRequestedTabWorkspace(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	makeRepo := func(name, message string) string {
+		t.Helper()
+		dir := filepath.Join(t.TempDir(), name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chdir(dir); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, "init")
+		runGit(t, "config", "user.email", "test@example.com")
+		runGit(t, "config", "user.name", "Test User")
+		if err := os.WriteFile("file.txt", []byte(message+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		runGit(t, "add", "file.txt")
+		runGit(t, "commit", "-m", message)
+		return dir
+	}
+
+	repoA := makeRepo("a", "repo a commit")
+	repoB := makeRepo("b", "repo b commit")
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"a": {ID: "a", Scope: "project", WorkspaceRoot: repoA, Ready: true},
+			"b": {ID: "b", Scope: "project", WorkspaceRoot: repoB, Ready: true},
+		},
+		activeTabID: "a",
+	}
+
+	history, err := app.WorkspaceGitHistory("b", "")
+	if err != nil {
+		t.Fatalf("WorkspaceGitHistory err = %v", err)
+	}
+	if len(history) != 1 || history[0].Message != "repo b commit" {
+		t.Fatalf("history for requested tab = %+v, want repo b commit", history)
 	}
 }
 
@@ -1046,7 +1092,7 @@ func TestWorkspaceGitCommitDetail(t *testing.T) {
 	app := &App{}
 
 	// Test project level detail
-	detail, err := app.WorkspaceGitCommitDetail(hash, "")
+	detail, err := app.WorkspaceGitCommitDetail("", hash, "")
 	if err != nil {
 		t.Fatalf("WorkspaceGitCommitDetail err = %v", err)
 	}
@@ -1058,7 +1104,7 @@ func TestWorkspaceGitCommitDetail(t *testing.T) {
 	}
 
 	// Test file level detail
-	detail, err = app.WorkspaceGitCommitDetail(hash, "file1.txt")
+	detail, err = app.WorkspaceGitCommitDetail("", hash, "file1.txt")
 	if err != nil {
 		t.Fatalf("WorkspaceGitCommitDetail err = %v", err)
 	}


### PR DESCRIPTION
## Summary
- Scope `WorkspaceChanges` to a requested tab instead of always reading the globally active tab.
- Pass the active tab id from the desktop workspace panel and clear stale workspace reveal/list requests when switching tabs.
- Add regression coverage for two sessions in the same workspace so one tab's changed files cannot appear in another tab's changes view.

Fixes #4489.

## Cache impact
- None expected. This only changes desktop workspace-change state lookup and UI refresh behavior; it does not touch provider request serialization, prompt prefixes, tool schemas, or compaction.

## Verification
- `go test .` from `desktop/`
- `npm run typecheck` from `desktop/frontend/`
- `npm test` from `desktop/frontend/`
- `npm run build` from `desktop/frontend/`
