### PR TITLE
Show context cache hit rate with decimals / 使用小数显示上下文缓存命中率

### DIFF
--- a/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
+++ b/desktop/frontend/src/__tests__/context-panel-breakdown.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/context-panel-breakdown.test.ts
 
-import { contextBreakdown, contextCostDisplay } from "../components/ContextPanel";
+import { contextBreakdown, contextCostDisplay, formatCacheHitRate } from "../components/ContextPanel";
 import { currencySymbol, formatMoney } from "../lib/money";
 
 let passed = 0;
@@ -79,6 +79,12 @@ eq(formatMoney(infoCost.amount, infoCost.currency, "dash"), "$0.1759", "USD pane
 eq(currencySymbol("楼"), "¥", "unexpected currency text does not leak into money values");
 eq(currencySymbol("aud"), "AUD ", "unknown ISO currency codes stay readable");
 eq(currencySymbol("A$"), "A$", "compact multi-character currency symbols are preserved");
+
+console.log("\ncontext panel cache rate");
+
+eq(formatCacheHitRate(99_950, 50), "99.95%", "cache hit rate preserves two decimal places");
+eq(formatCacheHitRate(0, 10_000), "0.00%", "cache hit rate shows zero when usage data exists");
+eq(formatCacheHitRate(0, 0), "-", "cache hit rate stays empty before usage data exists");
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -43,6 +43,12 @@ function fmtDuration(ms: number, t: Translator): string {
   return t("context.durationMinutesSeconds", { minutes, seconds });
 }
 
+export function formatCacheHitRate(hitTokens: number, missTokens: number): string {
+  const denom = hitTokens + missTokens;
+  if (denom <= 0) return "-";
+  return `${((hitTokens / denom) * 100).toFixed(2)}%`;
+}
+
 interface HealthResult {
   tone: "good" | "notice" | "warn";
   shortKey: DictKey;
@@ -269,9 +275,9 @@ export function ContextPanel({
 
   const usagePct = windowTokens > 0 ? Math.min(100, Math.round((usedTokens / windowTokens) * 100)) : 0;
   const compactPct = context?.compactRatio ? Math.round(context.compactRatio * 100) : 0;
-  const cachePct = cacheHitTokens + cacheMissTokens > 0
-    ? Math.round((cacheHitTokens / (cacheHitTokens + cacheMissTokens)) * 100)
-    : 0;
+  const cacheDenom = cacheHitTokens + cacheMissTokens;
+  const cachePct = cacheDenom > 0 ? (cacheHitTokens / cacheDenom) * 100 : 0;
+  const cachePctDisplay = formatCacheHitRate(cacheHitTokens, cacheMissTokens);
   const breakdown = contextBreakdown(usedTokens, windowTokens, promptTokens, completionTokens, reasoningTokens);
   const donutStyle = {
     background: `conic-gradient(#13a7a5 0 ${breakdown.promptPct}%, #2f6df6 ${breakdown.promptPct}% ${breakdown.completionPct}%, #f97316 ${breakdown.completionPct}% ${breakdown.reasoningPct}%, var(--border) ${breakdown.reasoningPct}% ${breakdown.otherPct}%, var(--border-soft) ${breakdown.otherPct}% 100%)`,
@@ -298,7 +304,7 @@ export function ContextPanel({
     time: fmtTime(f.latestTime),
     detail: asArray(f.turns).length > 0 ? `T${asArray(f.turns).join(",")}` : "",
   }));
-  const health = contextHealth(usagePct, cachePct, readRows.length);
+  const health = contextHealth(usagePct, Math.round(cachePct), readRows.length);
 
   return (
     <div className="context-panel">
@@ -337,7 +343,7 @@ export function ContextPanel({
           <section className="context-panel__section">
             <SectionHeading title={t("context.costMetrics")} />
             <div className="context-panel__stats">
-              <MetricCard label={t("context.cacheHit")} value={cachePct > 0 ? `${cachePct}%` : "-"} tone="accent" />
+              <MetricCard label={t("context.cacheHit")} value={cachePctDisplay} tone="accent" />
               <MetricCard label={t("context.sessionCost")} value={formatMoney(cost.amount, cost.currency, "dash")} />
             </div>
             {showCostSources && (


### PR DESCRIPTION
## Summary
- Show the right-side context panel cache-hit metric with two decimal places instead of integer rounding.
- Keep the existing low-cache health behavior by rounding only for the health threshold.
- Add targeted coverage for `99.95%`, `0.00%`, and the no-usage `-` state.

## Verification
- `git diff --check`
- `npm run check:css`
- `npx tsx src/__tests__/context-panel-breakdown.test.ts`
- Not run: `npm run typecheck` (blocked because generated Wails bindings are not present in this checkout: `wailsjs/go/main/App`, `wailsjs/runtime/runtime`)

## Related
- Adjacent open PRs touch ContextPanel cost/status metrics (#4485, #4329), but this PR is limited to cache-hit rate formatting.
