### PR TITLE
Fix desktop welcome clipping on fullscreen resize / 修复桌面端全屏后欢迎页裁剪

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -106,7 +106,7 @@ import {
   type Theme,
 } from "./lib/theme";
 import { applyTextSize, DEFAULT_TEXT_SIZE, getTextSize, nextTextSize } from "./lib/textSize";
-import { useWindowStatePersistence } from "./lib/windowState";
+import { useViewportHeightVar, useWindowStatePersistence } from "./lib/windowState";
 import { availableWorkspacePanelWidth, resolveWorkspacePanelWidth, workspacePanelAriaMinWidth } from "./lib/workspaceLayout";
 import logoWordmark from "./assets/logo-wordmark.svg";
 
@@ -968,6 +968,7 @@ export default function App() {
 
   // Persist window geometry across launches.
   useWindowStatePersistence();
+  useViewportHeightVar();
   useEffect(() => {
     document.documentElement.setAttribute("data-platform", desktopPlatform);
   }, [desktopPlatform]);

--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -95,6 +95,14 @@ eq(
 );
 eq(finalDeclaration(".transcript--empty", "overflow-y"), "auto", "empty transcript can scroll instead of clipping");
 eq(finalDeclaration(".welcome", "overflow"), "visible", "welcome empty state is not clipped by its own box");
+ok(
+  hasDeclaration(".transcript--empty > .welcome", "margin-block", "auto"),
+  "empty-state auto margins apply only to the welcome content",
+);
+ok(
+  finalDeclaration(".transcript--empty > *", "margin-block") === undefined,
+  "empty-state generic children do not receive auto margins",
+);
 eq(
   finalDeclaration(":root[data-theme-style] .statusbar", "height"),
   "var(--statusbar-dock-height)",

--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -89,6 +89,13 @@ ok(
   "layout reserves scaled status bar height",
 );
 eq(
+  finalDeclaration(".app", "height"),
+  "var(--app-viewport-height, 100%)",
+  "app height follows the live viewport height variable",
+);
+eq(finalDeclaration(".transcript--empty", "overflow-y"), "auto", "empty transcript can scroll instead of clipping");
+eq(finalDeclaration(".welcome", "overflow"), "visible", "welcome empty state is not clipped by its own box");
+eq(
   finalDeclaration(":root[data-theme-style] .statusbar", "height"),
   "var(--statusbar-dock-height)",
   "fixed status bar height follows the scaled dock token",

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -1,4 +1,4 @@
-import { createContext, memo, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, memo, type CSSProperties, type MouseEvent as ReactMouseEvent, type ReactNode, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { Item, LiveStream } from "../lib/useController";
 import type { CheckpointMeta } from "../lib/types";
 import { useT } from "../lib/i18n";
@@ -136,6 +136,7 @@ export function Transcript({
   // updates into one layout read/write per animation frame.
   const contentVersion = useMemo(() => scrollVersion(items), [items]);
   useEffect(() => {
+    if (items.length === 0) return;
     if (!stick.current) return;
     if (autoScrollFrame.current !== null) return;
     autoScrollFrame.current = requestAnimationFrame(() => {
@@ -162,6 +163,7 @@ export function Transcript({
     const observer = new ResizeObserver(() => {
       const previous = lastClientHeight.current ?? el.clientHeight;
       lastClientHeight.current = el.clientHeight;
+      if (items.length === 0) return;
       repinIfWasPinned(el.clientHeight - previous);
     });
     observer.observe(el);
@@ -172,7 +174,7 @@ export function Transcript({
         resizeFrame.current = null;
       }
     };
-  }, []);
+  }, [items.length]);
 
   // Footer height changes → smooth scroll repin with GSAP.
   useEffect(() => {
@@ -180,8 +182,9 @@ export function Transcript({
     if (!el) return;
     const previous = lastFooterHeight.current ?? footerHeight;
     lastFooterHeight.current = footerHeight;
+    if (items.length === 0) return;
     repinIfWasPinned(previous - footerHeight);
-  }, [footerHeight]);
+  }, [footerHeight, items.length]);
 
   // After a non-fork rewind, scroll to the last user message (the
   // rewound-to point) so the user knows where they are.
@@ -274,6 +277,18 @@ export function Transcript({
   // the warm/cold zone JSX trees. Uses LiveStreamContext for streaming data
   // (added by upstream PR #3423) instead of per-call renderSegments.
   const empty = items.length === 0;
+
+  useLayoutEffect(() => {
+    if (!empty) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = 0;
+    stick.current = false;
+    const frame = requestAnimationFrame(() => {
+      el.scrollTop = 0;
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [empty, scrollRef, stick, tabId]);
 
   // In compact mode, break each turn into step groups.
   // A step = one assistant + its tool results, from one assistant to the next.

--- a/desktop/frontend/src/lib/theme.ts
+++ b/desktop/frontend/src/lib/theme.ts
@@ -126,6 +126,7 @@ export function applyTheme(theme: Theme, style: ThemeStyle = getThemeStyle(theme
     } else if (theme === "dark") {
       WindowSetDarkTheme();
     }
+    syncNativeWindowBackground(theme);
   }
 
   void options;
@@ -169,15 +170,15 @@ export function clearLegacyThemePreference(): void {
 export function initTheme(): void {
   const theme = getTheme();
   applyTheme(theme, getThemeStyle(theme), { persist: false });
+}
 
-  if (typeof window !== "undefined" && window.runtime) {
-    const resolved = getResolvedTheme(theme);
-    if (resolved === "light") {
-      // Light shell: matches graphite --bg (#f4f3ef).
-      WindowSetBackgroundColour(244, 243, 239, 255);
-    } else {
-      // Dark shell: matches :root --bg (#090a0c).
-      WindowSetBackgroundColour(9, 10, 12, 255);
-    }
+function syncNativeWindowBackground(theme: Theme): void {
+  const resolved = getResolvedTheme(theme);
+  if (resolved === "light") {
+    // Light shell: matches graphite --bg (#f4f3ef).
+    WindowSetBackgroundColour(244, 243, 239, 255);
+  } else {
+    // Dark shell: matches :root --bg (#090a0c).
+    WindowSetBackgroundColour(9, 10, 12, 255);
   }
 }

--- a/desktop/frontend/src/lib/windowState.ts
+++ b/desktop/frontend/src/lib/windowState.ts
@@ -70,3 +70,35 @@ export function useWindowStatePersistence() {
     };
   }, []);
 }
+
+export function useViewportHeightVar() {
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof document === "undefined") return;
+
+    let frame = 0;
+    const root = document.documentElement;
+    const setHeight = () => {
+      frame = 0;
+      const height = Math.round(window.visualViewport?.height ?? window.innerHeight);
+      if (height > 0) root.style.setProperty("--app-viewport-height", `${height}px`);
+    };
+    const schedule = () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(setHeight);
+    };
+
+    schedule();
+    window.addEventListener("resize", schedule);
+    window.addEventListener("orientationchange", schedule);
+    document.addEventListener("fullscreenchange", schedule);
+    window.visualViewport?.addEventListener("resize", schedule);
+
+    return () => {
+      if (frame) window.cancelAnimationFrame(frame);
+      window.removeEventListener("resize", schedule);
+      window.removeEventListener("orientationchange", schedule);
+      document.removeEventListener("fullscreenchange", schedule);
+      window.visualViewport?.removeEventListener("resize", schedule);
+    };
+  }, []);
+}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2671,6 +2671,8 @@ a[href] {
 }
 .transcript--empty > * {
   max-width: none;
+}
+.transcript--empty > .welcome {
   margin-block: auto;
   margin-inline: 0;
 }
@@ -3101,7 +3103,7 @@ a[href] {
 }
 
 @container (max-height: 330px) {
-  .transcript--empty > * {
+  .transcript--empty > .welcome {
     margin-block: 0 auto;
   }
   .welcome--brand {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1483,6 +1483,7 @@ html,
 body,
 #root {
   height: 100%;
+  min-height: 100%;
   margin: 0;
 }
 html {
@@ -1514,7 +1515,7 @@ a[href] {
 }
 
 .app {
-  height: 100%;
+  height: var(--app-viewport-height, 100%);
   min-height: 0;
   overflow-x: auto;
   overflow-y: hidden;
@@ -2660,14 +2661,18 @@ a[href] {
 }
 .transcript--empty {
   container-type: size;
-  display: grid;
-  place-items: center;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  overflow-x: hidden;
+  overflow-y: auto;
   padding: 16px 32px;
 }
 .transcript--empty > * {
   max-width: none;
-  margin: 0;
+  margin-block: auto;
+  margin-inline: 0;
 }
 .warm-collapse {
   display: block;
@@ -2944,7 +2949,7 @@ a[href] {
   --welcome-brand-height: 56px;
   --welcome-brand-gap: 26px;
   width: min(100%, 600px);
-  max-height: 100%;
+  max-height: none;
   min-height: 0;
   display: grid;
   align-content: center;
@@ -2953,10 +2958,11 @@ a[href] {
   align-items: center;
   text-align: center;
   color: var(--fg-faint);
-  overflow: hidden;
+  overflow: visible;
 }
 .welcome--brand {
-  margin-top: -20px;
+  margin-top: 0;
+  transform: translateY(-20px);
 }
 .welcome__brand {
   display: inline-flex;
@@ -3047,7 +3053,7 @@ a[href] {
     --welcome-brand-width: 224px;
     --welcome-brand-height: 52px;
     --welcome-brand-gap: 22px;
-    margin-top: -16px;
+    transform: translateY(-16px);
   }
   .welcome__brand {
     margin-bottom: var(--welcome-brand-gap);
@@ -3095,6 +3101,12 @@ a[href] {
 }
 
 @container (max-height: 330px) {
+  .transcript--empty > * {
+    margin-block: 0 auto;
+  }
+  .welcome--brand {
+    transform: none;
+  }
   .welcome__tag,
   .welcome__hints {
     display: none;


### PR DESCRIPTION
## Summary
- Track the live viewport height so the desktop shell follows macOS fullscreen and resize updates.
- Let the empty transcript scroll instead of clipping the welcome actions, and reset empty-state scroll position.
- Keep the native window background synced with the active theme to avoid exposing a black shell during repaint gaps.

Fixes #4494

## Verification
- `npm run check:css`
- `npx tsx src/__tests__/typography-overflow-contract.test.ts`
- `npm run build`
- Browser preview checked with `?platform=darwin&mock=fresh` at normal and short viewport heights.