### PR TITLE
fix(desktop): use balance currency as session currency source, prevent ¥→$ flip after first turn / 修复成本符号显示不正确

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3288,10 +3288,12 @@ func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 // BalanceInfo is the wallet-balance readout for the status bar. Available is true
 // only when a balance was fetched; Display is the formatted amount (e.g. "¥110.00")
 // and is "" when the active provider declares no balance_url — the frontend then
-// omits the readout. Err carries a fetch failure for an optional tooltip.
+// omits the readout. Currency is the display symbol ("¥", "$", …). Err carries a
+// fetch failure for an optional tooltip.
 type BalanceInfo struct {
 	Available bool   `json:"available"`
 	Display   string `json:"display"`
+	Currency  string `json:"currency,omitempty"`
 	Err       string `json:"err,omitempty"`
 }
 
@@ -3315,7 +3317,7 @@ func (a *App) BalanceForTab(tabID string) BalanceInfo {
 	if b == nil {
 		return BalanceInfo{} // provider declares no balance endpoint
 	}
-	return BalanceInfo{Available: true, Display: b.Display()}
+	return BalanceInfo{Available: true, Display: b.Display(), Currency: b.Currency()}
 }
 
 // JobView is one running background job (bash/task started with

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -664,10 +664,11 @@ export interface ProviderView {
 
 // BalanceInfo is the wallet-balance readout (desktop/app.go Balance). available
 // is false when the provider declares no balanceUrl or a fetch failed; display is
-// the formatted amount (e.g. "¥110.00").
+// the formatted amount (e.g. "¥110.00"); currency is the display symbol.
 export interface BalanceInfo {
   available: boolean;
   display: string;
+  currency?: string;
   err?: string;
 }
 

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -116,7 +116,7 @@ export const initialState: State = {
   turnCost: 0,
   sessionTokens: 0,
   sessionCost: 0,
-  sessionCurrency: "¥",
+  sessionCurrency: "",
   seq: 0,
 };
 
@@ -507,7 +507,7 @@ function applyEvent(s: State, e: WireEvent): State {
       const usageCost = e.usage?.cost ?? e.usage?.costUsd ?? 0;
       const turnCost = s.turnCost + usageCost;
       const sessionCost = s.sessionCost + usageCost;
-      const sessionCurrency = e.usage?.currency || s.sessionCurrency || "¥";
+      const sessionCurrency = s.sessionCurrency || e.usage?.currency || "¥";
       const usage = updateContextGauge ? e.usage : s.usage ?? e.usage;
       return { ...s, usage, context: { ...s.context, used, sessionTokens }, turnTokens, turnTotalTokens, turnCost, sessionTokens, sessionCost, sessionCurrency };
     }
@@ -595,7 +595,7 @@ export function reducer(s: State, a: Action): State {
         : s.sessionTokens;
       return { ...s, context: a.context, sessionTokens };
     }
-    case "balance": return { ...s, balance: a.balance };
+    case "balance": return { ...s, balance: a.balance, sessionCurrency: a.balance.currency || s.sessionCurrency || "" };
     case "effort": return { ...s, effort: a.effort };
     case "jobs": return { ...s, jobs: a.jobs };
     case "checkpoints": return { ...s, checkpoints: a.checkpoints };
@@ -618,7 +618,7 @@ export function reducer(s: State, a: Action): State {
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": return { ...s, approval: undefined };
     case "clearAsk": return { ...s, ask: undefined };
-    case "reset": return { ...initialState, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs };
+    case "reset": return { ...initialState, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs, sessionCurrency: s.sessionCurrency };
     case "event": return applyEvent(s, a.e);
     default: return s;
   }

--- a/internal/billing/balance.go
+++ b/internal/billing/balance.go
@@ -117,12 +117,25 @@ func (b *Balance) Display() string {
 	if b == nil || len(b.Infos) == 0 {
 		return ""
 	}
-	pick := b.Infos[0]
-	for _, i := range b.Infos {
+	pick := primaryInfo(b.Infos)
+	return symbol(pick.Currency) + strings.TrimSpace(pick.TotalBalance)
+}
+
+// Currency returns the primary currency symbol (e.g. "¥", "$") for the balance.
+// It prefers CNY, then the first reported currency. "" when there's nothing.
+func (b *Balance) Currency() string {
+	if b == nil || len(b.Infos) == 0 {
+		return ""
+	}
+	return symbol(primaryInfo(b.Infos).Currency)
+}
+
+func primaryInfo(infos []Info) Info {
+	pick := infos[0]
+	for _, i := range infos {
 		if strings.EqualFold(i.Currency, "CNY") {
-			pick = i
-			break
+			return i
 		}
 	}
-	return symbol(pick.Currency) + strings.TrimSpace(pick.TotalBalance)
+	return pick
 }


### PR DESCRIPTION
### Problem

Fixes #4500.

Status bar session cost shows ¥ at startup, then flips to $ after the first conversation turn and never recovers.

**Root cause:** `sessionCurrency` was hardcoded to `"¥"` in initialState, but usage events from the backend carry `"$"` (DeepSeek pricing config has `Currency: "$"`). The reducer unconditionally replaced the value:

```typescript
const sessionCurrency = e.usage?.currency || s.sessionCurrency || "¥";
//                      ^^^^^^^^^^^^^^^^^^
//                      "$" from DeepSeek pricing, overwrites "¥" every turn
```

A naive priority swap would freeze ¥ forever, breaking USD-billing users.

### Solution

Three-tier fallback, with the **balance endpoint as the source of truth**. Once set, `sessionCurrency` is never overwritten:

```
Balance (real billing currency — most reliable)
  ↓ fallback
Usage event (model pricing config)
  ↓ fallback
"¥" (default)
```

The balance endpoint already receives per-currency data from DeepSeek (`"CNY"`, `"USD"`). A new `Currency()` method exposes the raw symbol, piped through `BalanceInfo` to the frontend.

### Scenario coverage

| User | Balance | Source | Result |
|:--:|:--:|:--:|:--:|
| Chinese UI, CNY billing | `"¥"` | balance endpoint | Stays ¥ |
| English UI, USD billing | `"$"` | balance endpoint | Stays $ |
| No balance endpoint | — | first usage event | Stays as set |
| Nothing available | — | default | ¥ |

### Files changed

| File | +/− | What |
|:--:|:--:|:--:|
| `internal/billing/balance.go` | +18/−5 | `Currency()` method + `primaryInfo` helper |
| `desktop/app.go` | +4/−2 | `BalanceInfo.Currency` field |
| `desktop/frontend/src/lib/types.ts` | +2/−1 | `BalanceInfo.currency` field |
| `desktop/frontend/src/lib/useController.ts` | +4/−4 | 空初始值 + balance 优先 + reset 保留 |

### Verification

- ✅ 25 frontend test suites — zero failures
- ✅ Go `internal/billing` + `desktop` compile cleanly