### PR TITLE
Integrate skill discovery fixes / 集成技能发现修复

### DIFF
--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -6,8 +6,10 @@
 // enter the cache-stable system-prompt index (see index.go) — bodies load on
 // demand. Discovery scans several conventions (.reasonix / .agents / .agent /
 // .claude under the project root and the home dir — see config.ConventionDirs) so
-// skills authored for other agent tools migrate in unchanged, and follows
-// symlinks, so a linked skill directory or flat <name>.md is picked up like a real one.
+// skills authored for other agent tools migrate in unchanged. Directory skills
+// use <name>/SKILL.md; flat <name>.md files from Claude roots are loaded only
+// when they carry skill frontmatter. Discovery follows symlinks, so linked
+// skills are picked up like real ones.
 package skill
 
 import (
@@ -159,39 +161,55 @@ type Root struct {
 	Status   PathStatus
 }
 
+type discoveryRoot struct {
+	Root
+	requireFlatMarker bool
+}
+
 // roots returns the discovery directories, highest priority first: the
 // convention dirs (config.ConventionDirs: .reasonix / .agents / .agent / .claude)
 // under the project root → custom paths → the same convention dirs under the home
 // dir. A later root never overrides an earlier one.
-func (s *Store) roots() []Root {
+func (s *Store) roots() []discoveryRoot {
 	type de struct {
-		dir   string
-		scope Scope
+		dir               string
+		scope             Scope
+		requireFlatMarker bool
 	}
 	var dirs []de
 	if s.projectRoot != "" {
 		for _, c := range config.ConventionDirs {
-			dirs = append(dirs, de{filepath.Join(s.projectRoot, c, SkillsDirname), ScopeProject})
+			dirs = append(dirs, de{filepath.Join(s.projectRoot, c, SkillsDirname), ScopeProject, c == ".claude"})
 		}
 	}
 	for _, d := range s.customPaths {
-		dirs = append(dirs, de{d, ScopeCustom})
+		dirs = append(dirs, de{d, ScopeCustom, false})
 	}
 	for _, c := range config.ConventionDirs {
-		dirs = append(dirs, de{filepath.Join(s.homeDir, c, SkillsDirname), ScopeGlobal})
+		dirs = append(dirs, de{filepath.Join(s.homeDir, c, SkillsDirname), ScopeGlobal, c == ".claude"})
 	}
-	out := make([]Root, 0, len(dirs))
+	out := make([]discoveryRoot, 0, len(dirs))
 	for _, d := range dirs {
 		if s.excludedPaths[config.CanonicalSkillPath(d.dir)] {
 			continue
 		}
-		out = append(out, Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir)})
+		out = append(out, discoveryRoot{
+			Root:              Root{Dir: d.dir, Scope: d.scope, Priority: len(out), Status: pathStatus(d.dir)},
+			requireFlatMarker: d.requireFlatMarker,
+		})
 	}
 	return out
 }
 
 // Roots exposes the discovery directories with their status for `/skill paths`.
-func (s *Store) Roots() []Root { return s.roots() }
+func (s *Store) Roots() []Root {
+	roots := s.roots()
+	out := make([]Root, 0, len(roots))
+	for _, r := range roots {
+		out = append(out, r.Root)
+	}
+	return out
+}
 
 func disabledNameSet(names []string) map[string]bool {
 	out := map[string]bool{}
@@ -298,13 +316,13 @@ func (s *Store) Read(name string) (Skill, bool) {
 	return Skill{}, false
 }
 
-func (s *Store) discoverRoot(r Root) []Skill {
+func (s *Store) discoverRoot(r discoveryRoot) []Skill {
 	var out []Skill
-	s.scanDir(r.Dir, r.Scope, 1, map[string]bool{}, &out)
+	s.scanDir(r.Dir, r.Scope, r.requireFlatMarker, 1, map[string]bool{}, &out)
 	return out
 }
 
-func (s *Store) scanDir(dir string, scope Scope, depth int, seen map[string]bool, out *[]Skill) {
+func (s *Store) scanDir(dir string, scope Scope, requireFlatMarker bool, depth int, seen map[string]bool, out *[]Skill) {
 	key := filepath.Clean(dir)
 	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
 		key = filepath.Clean(resolved)
@@ -319,7 +337,7 @@ func (s *Store) scanDir(dir string, scope Scope, depth int, seen map[string]bool
 		return
 	}
 	for _, e := range entries {
-		sk, ok := s.readEntry(dir, scope, e)
+		sk, ok := s.readEntry(dir, scope, requireFlatMarker, e)
 		if ok {
 			if depth == 1 || strings.TrimSpace(sk.Description) != "" {
 				*out = append(*out, sk)
@@ -329,7 +347,7 @@ func (s *Store) scanDir(dir string, scope Scope, depth int, seen map[string]bool
 		if depth >= s.maxDepth || !s.canScanChildDir(dir, e) {
 			continue
 		}
-		s.scanDir(filepath.Join(dir, e.Name()), scope, depth+1, seen, out)
+		s.scanDir(filepath.Join(dir, e.Name()), scope, requireFlatMarker, depth+1, seen, out)
 	}
 }
 
@@ -338,15 +356,18 @@ func (s *Store) canScanChildDir(dir string, e os.DirEntry) bool {
 	if shouldSkipScanDir(name) {
 		return false
 	}
-	full := filepath.Join(dir, name)
 	if e.IsDir() {
 		return true
 	}
-	if e.Type()&os.ModeSymlink == 0 {
+	if !shouldStatEntryTarget(e.Type()) {
 		return false
 	}
-	info, err := os.Stat(full)
+	info, err := os.Stat(filepath.Join(dir, name))
 	return err == nil && info.IsDir()
+}
+
+func shouldStatEntryTarget(mode os.FileMode) bool {
+	return mode&os.ModeSymlink != 0 || mode&os.ModeIrregular != 0
 }
 
 func shouldSkipScanDir(name string) bool {
@@ -361,17 +382,17 @@ func shouldSkipScanDir(name string) bool {
 	}
 }
 
-// readEntry turns one directory entry into a skill. It resolves symlinks via
-// os.Stat (os.ReadDir reports a symlink's own type, not its target's), so a
-// linked skill directory or a linked flat <name>.md is discovered like a real
-// one; a broken link fails Stat and is skipped.
-func (s *Store) readEntry(dir string, scope Scope, e os.DirEntry) (Skill, bool) {
+// readEntry turns one directory entry into a skill. It resolves symlink and
+// Windows reparse-style entries via os.Stat (os.ReadDir can report the link's
+// own type, not its target's), so a linked skill directory or flat <name>.md is
+// discovered like a real one; a broken link fails Stat and is skipped.
+func (s *Store) readEntry(dir string, scope Scope, requireFlatMarker bool, e os.DirEntry) (Skill, bool) {
 	name := e.Name()
 	full := filepath.Join(dir, name)
 
 	isDir := e.IsDir()
 	isFile := e.Type().IsRegular()
-	if e.Type()&os.ModeSymlink != 0 {
+	if !isDir && !isFile && shouldStatEntryTarget(e.Type()) {
 		info, err := os.Stat(full) // follows the link
 		if err != nil {
 			return Skill{}, false // broken link
@@ -395,7 +416,7 @@ func (s *Store) readEntry(dir string, scope Scope, e os.DirEntry) (Skill, bool) 
 		if !IsValidName(stem) {
 			return Skill{}, false
 		}
-		return s.parse(full, stem, scope)
+		return s.parseFlat(full, stem, scope, requireFlatMarker)
 	}
 	return Skill{}, false
 }
@@ -404,18 +425,32 @@ func (s *Store) readEntry(dir string, scope Scope, e os.DirEntry) (Skill, bool) 
 // filename stem when valid; a missing `description:` is a warning, not a failure
 // (the skill loads but won't appear in the model's index).
 func (s *Store) parse(path, stem string, scope Scope) (Skill, bool) {
+	return s.parseSkill(path, stem, scope, false)
+}
+
+// parseFlat reads a flat <name>.md skill candidate. Claude skill roots can also
+// contain ordinary documentation, so those flat files need explicit skill
+// frontmatter before they are treated as skills.
+func (s *Store) parseFlat(path, stem string, scope Scope, requireSkillMarker bool) (Skill, bool) {
+	return s.parseSkill(path, stem, scope, requireSkillMarker)
+}
+
+func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bool) (Skill, bool) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return Skill{}, false
 	}
 	content := strings.TrimPrefix(strings.ReplaceAll(string(b), "\r\n", "\n"), "\uFEFF")
 	fm, body := splitFrontmatter(content)
+	if requireSkillMarker && !hasSkillMarker(fm) {
+		return Skill{}, false
+	}
 
 	name := stem
-	if v := fm["name"]; v != "" && IsValidName(v) {
+	if v := fm[skillFrontmatterName]; v != "" && IsValidName(v) {
 		name = v
 	}
-	desc := strings.TrimSpace(fm["description"])
+	desc := strings.TrimSpace(fm[skillFrontmatterDescription])
 	if desc == "" {
 		fmt.Fprintf(s.stderr, "warning: skill %q at %s has no description: — it will load but won't appear in the skills index\n", name, path)
 	}
@@ -425,11 +460,42 @@ func (s *Store) parse(path, stem string, scope Scope) (Skill, bool) {
 		Body:         loadBodyWithReferences(path, strings.TrimSpace(body)),
 		Scope:        scope,
 		Path:         path,
-		AllowedTools: parseAllowedTools(fm["allowed-tools"]),
-		RunAs:        parseRunAs(fm["runas"], fm["context"], fm["agent"]),
-		Model:        strings.TrimSpace(fm["model"]),
-		Effort:       strings.TrimSpace(fm["effort"]),
+		AllowedTools: parseAllowedTools(fm[skillFrontmatterAllowedTools]),
+		RunAs:        parseRunAs(fm[skillFrontmatterRunAs], fm[skillFrontmatterContext], fm[skillFrontmatterAgent]),
+		Model:        strings.TrimSpace(fm[skillFrontmatterModel]),
+		Effort:       strings.TrimSpace(fm[skillFrontmatterEffort]),
 	}, true
+}
+
+const (
+	skillFrontmatterDescription  = "description"
+	skillFrontmatterName         = "name"
+	skillFrontmatterRunAs        = "runas"
+	skillFrontmatterContext      = "context"
+	skillFrontmatterAgent        = "agent"
+	skillFrontmatterAllowedTools = "allowed-tools"
+	skillFrontmatterModel        = "model"
+	skillFrontmatterEffort       = "effort"
+)
+
+var skillMarkerFrontmatterKeys = []string{
+	skillFrontmatterDescription,
+	skillFrontmatterName,
+	skillFrontmatterRunAs,
+	skillFrontmatterContext,
+	skillFrontmatterAgent,
+	skillFrontmatterAllowedTools,
+	skillFrontmatterModel,
+	skillFrontmatterEffort,
+}
+
+func hasSkillMarker(fm map[string]string) bool {
+	for _, key := range skillMarkerFrontmatterKeys {
+		if strings.TrimSpace(fm[key]) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // Create scaffolds a new skill stub at the chosen scope. Refuses to overwrite.

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -442,7 +442,7 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 	}
 	content := strings.TrimPrefix(strings.ReplaceAll(string(b), "\r\n", "\n"), "\uFEFF")
 	fm, body := splitFrontmatter(content)
-	if requireSkillMarker && !hasSkillMarker(fm) {
+	if requireSkillMarker && !hasSkillMarker(content, fm) {
 		return Skill{}, false
 	}
 
@@ -489,9 +489,42 @@ var skillMarkerFrontmatterKeys = []string{
 	skillFrontmatterEffort,
 }
 
-func hasSkillMarker(fm map[string]string) bool {
+func hasSkillMarker(content string, fm map[string]string) bool {
 	for _, key := range skillMarkerFrontmatterKeys {
 		if strings.TrimSpace(fm[key]) != "" {
+			return true
+		}
+	}
+	return frontmatterHasSkillMarkerKey(content)
+}
+
+func frontmatterHasSkillMarkerKey(content string) bool {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return false
+	}
+	end := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == "---" {
+			end = i
+			break
+		}
+	}
+	if end < 0 {
+		return false
+	}
+	for _, line := range lines[1:end] {
+		key, _, ok := strings.Cut(line, ":")
+		if ok && isSkillMarkerFrontmatterKey(strings.ToLower(strings.TrimSpace(key))) {
+			return true
+		}
+	}
+	return false
+}
+
+func isSkillMarkerFrontmatterKey(key string) bool {
+	for _, marker := range skillMarkerFrontmatterKeys {
+		if key == marker {
 			return true
 		}
 	}

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -1,11 +1,13 @@
 package skill
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"reasonix/internal/config"
 )
@@ -151,6 +153,71 @@ func TestConventionDirsDiscovered(t *testing.T) {
 		if _, ok := find(list, name); !ok {
 			t.Errorf("convention dir for %q not scanned", name)
 		}
+	}
+}
+
+func TestNonSkillMarkdownInClaudeSkillRootsIgnored(t *testing.T) {
+	proj := t.TempDir()
+	writeSkill(t, proj, ".claude/skills/guide.md", "# Skill notes\n\nThis is documentation, not a skill.")
+	writeSkill(t, proj, ".claude/skills/notes.md", "---\ntitle: Notes\n---\n# Notes")
+	writeSkill(t, proj, ".claude/skills/real.md", "---\ndescription: real skill\n---\nbody")
+
+	var stderr bytes.Buffer
+	st := New(Options{HomeDir: t.TempDir(), ProjectRoot: proj, DisableBuiltins: true, Stderr: &stderr})
+	list := st.List()
+	if _, ok := find(list, "real"); !ok {
+		t.Fatal("real skill should be discovered")
+	}
+	for _, name := range []string{"guide", "notes"} {
+		if _, ok := find(list, name); ok {
+			t.Errorf("non-skill markdown %q should not be listed", name)
+		}
+	}
+	if got := stderr.String(); got != "" {
+		t.Fatalf("non-skill markdown should not warn during List, got %q", got)
+	}
+
+	for _, name := range []string{"guide", "notes"} {
+		stderr.Reset()
+		if _, ok := st.Read(name); ok {
+			t.Errorf("non-skill markdown %q should not be readable as a skill", name)
+		}
+		if got := stderr.String(); got != "" {
+			t.Errorf("non-skill markdown %q should not warn during Read, got %q", name, got)
+		}
+	}
+}
+
+func TestSkillLikeFlatClaudeMarkdownWithoutDescriptionWarns(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".claude/skills/named.md", "---\nname: renamed\n---\nbody")
+
+	var stderr bytes.Buffer
+	st := New(Options{HomeDir: home, DisableBuiltins: true, Stderr: &stderr})
+	list := st.List()
+	if _, ok := find(list, "renamed"); !ok {
+		t.Fatal("skill-like flat Claude markdown should still load")
+	}
+	if got := stderr.String(); !strings.Contains(got, "has no description") {
+		t.Fatalf("skill-like flat Claude markdown without description should warn, got %q", got)
+	}
+}
+
+func TestRunAsOnlyFlatClaudeMarkdownIsSkillLike(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".claude/skills/sub.md", "---\nrunAs: subagent\n---\nbody")
+
+	var stderr bytes.Buffer
+	st := New(Options{HomeDir: home, DisableBuiltins: true, Stderr: &stderr})
+	sk, ok := st.Read("sub")
+	if !ok {
+		t.Fatal("runAs-only Claude markdown should be treated as skill-like")
+	}
+	if sk.RunAs != RunSubagent {
+		t.Fatalf("runAs should be parsed despite frontmatter key casing, got %s", sk.RunAs)
+	}
+	if got := stderr.String(); !strings.Contains(got, "has no description") {
+		t.Fatalf("runAs-only Claude markdown without description should warn, got %q", got)
 	}
 }
 
@@ -397,6 +464,48 @@ func TestSymlinkedDirAndFile(t *testing.T) {
 	}
 	if _, ok := find(st.List(), "broken"); ok {
 		t.Error("broken symlink should not yield a skill")
+	}
+}
+
+type fakeDirEntry struct {
+	name  string
+	isDir bool
+	typ   os.FileMode
+}
+
+func (f fakeDirEntry) Name() string      { return f.name }
+func (f fakeDirEntry) IsDir() bool       { return f.isDir }
+func (f fakeDirEntry) Type() os.FileMode { return f.typ }
+func (f fakeDirEntry) Info() (os.FileInfo, error) {
+	return fakeFileInfo{name: f.name, mode: f.typ}, nil
+}
+
+type fakeFileInfo struct {
+	name string
+	mode os.FileMode
+}
+
+func (f fakeFileInfo) Name() string       { return f.name }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return f.mode.IsDir() }
+func (f fakeFileInfo) Sys() any           { return nil }
+
+func TestIrregularDirectoryEntryFollowsTarget(t *testing.T) {
+	home := t.TempDir()
+	root := filepath.Join(home, ".agents", "skills")
+	writeSkill(t, root, "linkedpack/SKILL.md", "---\ndescription: linked pack\n---\nbody")
+	writeSkill(t, root, "collection/nested.md", "---\ndescription: nested\n---\nbody")
+
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	linkedPack := fakeDirEntry{name: "linkedpack", typ: os.ModeIrregular}
+	if sk, ok := st.readEntry(root, ScopeGlobal, false, linkedPack); !ok || sk.Name != "linkedpack" {
+		t.Fatalf("irregular directory-layout entry should follow target, got %+v ok=%v", sk, ok)
+	}
+	collection := fakeDirEntry{name: "collection", typ: os.ModeIrregular}
+	if !st.canScanChildDir(root, collection) {
+		t.Fatal("irregular directory entry should be scannable when its target is a directory")
 	}
 }
 

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -203,6 +203,42 @@ func TestSkillLikeFlatClaudeMarkdownWithoutDescriptionWarns(t *testing.T) {
 	}
 }
 
+func TestBlankDescriptionFlatClaudeMarkdownIsSkillLike(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{name: "blank", content: "---\ndescription:\n---\nbody"},
+		{name: "quoted", content: "---\ndescription: \"\"\n---\nbody"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			writeSkill(t, home, ".claude/skills/"+tc.name+".md", tc.content)
+
+			var stderr bytes.Buffer
+			st := New(Options{HomeDir: home, DisableBuiltins: true, Stderr: &stderr})
+			if _, ok := find(st.List(), tc.name); !ok {
+				t.Fatal("blank description marker should still list flat Claude markdown as skill-like")
+			}
+			if got := stderr.String(); !strings.Contains(got, "has no description") {
+				t.Fatalf("blank description listed skill should warn, got %q", got)
+			}
+
+			stderr.Reset()
+			sk, ok := st.Read(tc.name)
+			if !ok {
+				t.Fatal("blank description marker should still make flat Claude markdown skill-like")
+			}
+			if sk.Description != "" {
+				t.Fatalf("description should stay empty, got %q", sk.Description)
+			}
+			if got := stderr.String(); !strings.Contains(got, "has no description") {
+				t.Fatalf("blank description skill should warn, got %q", got)
+			}
+		})
+	}
+}
+
 func TestRunAsOnlyFlatClaudeMarkdownIsSkillLike(t *testing.T) {
 	home := t.TempDir()
 	writeSkill(t, home, ".claude/skills/sub.md", "---\nrunAs: subagent\n---\nbody")


### PR DESCRIPTION
## Summary

- Require skill-like frontmatter for flat Markdown files in `.claude/skills`, so ordinary Claude docs are ignored without warnings.
- Follow symlink and Windows reparse-style skill directory entries when scanning skill roots.
- Combine the overlapping `internal/skill` changes from #4441 and #4442 on current `main-v2` so they can merge without one PR blocking the other.

Fixes #4417.

## Related PRs

- Supersedes #4441. Thanks @thomasvan for the Claude Markdown warning fix and regression tests.
- Supersedes #4442. Thanks @ferstar for the Windows linked skill directory fix and regression tests.

Authorship note: @SivanCola is the maintainer integrator for this PR. @thomasvan and @ferstar contributed as repository collaborators through #4441 and #4442; their work is acknowledged as part of the shared skill-discovery fix.

## Cache impact

- Skill discovery becomes less noisy for `.claude/skills` flat Markdown and more complete for linked skill directories.
- No per-turn dynamic skill metadata, tool schemas, provider serialization, or prompt construction order changes were introduced beyond deterministic discovery of intended skill files.

## Verification

- `go test ./internal/skill ./internal/config`
- `go test ./internal/boot` with isolated `HOME` and `XDG_CONFIG_HOME`
- `go test -run 'TestSkillRootsView|TestCapabilitiesIncludesDisabledSkills|TestNormalizeSkillPath' .` from `desktop/`
- `git diff --check`

`go test ./...` was also attempted with isolated `HOME` and `XDG_CONFIG_HOME`; only sandbox confinement tests failed because this local runner does not enforce the expected sandbox denial behavior.
