### PR TITLE
fix(agent): add active-goal to transient user block regex (#4464)

### DIFF
--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:reasoning-language|memory-update|background-jobs)>.*?</(?:reasoning-language|memory-update|background-jobs)>\s*\n?`)
+var reTransientUserBlock = regexp.MustCompile(`(?s)^\s*<(?:reasoning-language|memory-update|background-jobs|active-goal)>.*?</(?:reasoning-language|memory-update|background-jobs|active-goal)>\s*\n?`)
 
 // StripTransientUserBlocks removes controller-injected transient XML blocks
 // from persisted user messages before deriving display text, previews, or

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -1,8 +1,8 @@
 package agent_test
 
 import (
-	"testing"
 	"reasonix/internal/agent"
+	"testing"
 )
 
 func TestStripTransientBlocksActiveGoal(t *testing.T) {

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -1,0 +1,23 @@
+package agent_test
+
+import (
+	"testing"
+	"reasonix/internal/agent"
+)
+
+func TestStripTransientBlocksActiveGoal(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"<active-goal>\nFix all bugs\n</active-goal>\n\nfix the auth bug", "fix the auth bug"},
+		{"<reasoning-language>\nuse Chinese\n</reasoning-language>\n\n<active-goal>\nDo X\n</active-goal>\n\nhelp me", "help me"},
+		{"<memory-update>\n- note\n</memory-update>\n\n<active-goal>\nGoal text\n</active-goal>\n\ndo it", "do it"},
+		{"<active-goal>\n\nmulti-line\ngoal\n</active-goal>\n\nuser text", "user text"},
+	}
+	for _, tt := range tests {
+		got := agent.StripTransientUserBlocks(tt.in)
+		if got != tt.want {
+			t.Errorf("StripTransientUserBlocks(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
The StripTransientUserBlocks regex stripped reasoning-language, memory-update, and background-jobs XML blocks from persisted user messages before display, but missed active-goal blocks injected by goal/collaboration mode.  This caused the goal-mode injection prompt to leak into the chat transcript as visible user-bubble text.

Add active-goal to both alternation groups in the regex so the block is stripped alongside the other three transient blocks.