### PR TITLE
agent: align subagent tool surface with runtime

### DIFF
--- a/internal/agent/subagent_registry_test.go
+++ b/internal/agent/subagent_registry_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"reasonix/internal/tool"
+)
+
+type subagentRegistryTool struct {
+	name     string
+	schema   string
+	readOnly bool
+	result   string
+}
+
+func (t subagentRegistryTool) Name() string { return t.name }
+func (t subagentRegistryTool) Description() string {
+	return "Execute a command in the shell and return combined stdout/stderr."
+}
+func (t subagentRegistryTool) Schema() json.RawMessage {
+	if t.schema != "" {
+		return json.RawMessage(t.schema)
+	}
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (t subagentRegistryTool) ReadOnly() bool { return t.readOnly }
+func (t subagentRegistryTool) Execute(context.Context, json.RawMessage) (string, error) {
+	return t.result, nil
+}
+
+func TestSubagentToolRegistryFiltersUnavailableToolsAndWrapsBash(t *testing.T) {
+	parent := tool.NewRegistry()
+	for _, name := range []string{
+		"task",
+		"run_skill",
+		"read_skill",
+		"install_skill",
+		"install_source",
+		"explore",
+		"research",
+		"review",
+		"security_review",
+		"wait",
+		"bash_output",
+		"kill_shell",
+	} {
+		parent.Add(subagentRegistryTool{name: name})
+	}
+	parent.Add(subagentRegistryTool{name: "read_file", readOnly: true})
+	parent.Add(subagentRegistryTool{
+		name:   "bash",
+		schema: `{"type":"object","properties":{"command":{"type":"string"},"run_in_background":{"type":"boolean"}},"required":["command"]}`,
+		result: "foreground ok",
+	})
+
+	sub := SubagentToolRegistry(parent, nil)
+	for _, hidden := range []string{
+		"task",
+		"run_skill",
+		"read_skill",
+		"install_skill",
+		"install_source",
+		"explore",
+		"research",
+		"review",
+		"security_review",
+		"wait",
+		"bash_output",
+		"kill_shell",
+	} {
+		if _, ok := sub.Get(hidden); ok {
+			t.Fatalf("subagent registry should hide %q; got %v", hidden, sub.Names())
+		}
+	}
+	if _, ok := sub.Get("read_file"); !ok {
+		t.Fatalf("subagent registry should keep read_file; got %v", sub.Names())
+	}
+	bash, ok := sub.Get("bash")
+	if !ok {
+		t.Fatalf("subagent registry should keep foreground bash; got %v", sub.Names())
+	}
+	if bash.ReadOnly() {
+		t.Fatal("foreground-only bash must remain a writer")
+	}
+	if strings.Contains(string(bash.Schema()), "run_in_background") {
+		t.Fatalf("subagent bash schema should not advertise run_in_background: %s", bash.Schema())
+	}
+	out, err := bash.Execute(context.Background(), json.RawMessage(`{"command":"printf ok"}`))
+	if err != nil || out != "foreground ok" {
+		t.Fatalf("foreground bash delegated to inner tool = %q, %v; want foreground ok, nil", out, err)
+	}
+	if _, err := bash.Execute(context.Background(), json.RawMessage(`{"command":"sleep 1","run_in_background":true}`)); err == nil || !strings.Contains(err.Error(), "background bash is unavailable in subagents") {
+		t.Fatalf("background bash should return a subagent-specific error, got %v", err)
+	}
+}
+
+func TestTaskToolBuildSubRegUsesSubagentToolRegistry(t *testing.T) {
+	parent := tool.NewRegistry()
+	parent.Add(subagentRegistryTool{name: "task"})
+	parent.Add(subagentRegistryTool{name: "wait"})
+	parent.Add(subagentRegistryTool{
+		name:   "bash",
+		schema: `{"type":"object","properties":{"command":{"type":"string"},"run_in_background":{"type":"boolean"}}}`,
+	})
+	task := &TaskTool{parentReg: parent}
+
+	sub := task.buildSubReg(nil)
+	for _, hidden := range []string{"task", "wait"} {
+		if _, ok := sub.Get(hidden); ok {
+			t.Fatalf("task subagent registry should hide %q; got %v", hidden, sub.Names())
+		}
+	}
+	bash, ok := sub.Get("bash")
+	if !ok {
+		t.Fatalf("task subagent registry should keep bash; got %v", sub.Names())
+	}
+	if strings.Contains(string(bash.Schema()), "run_in_background") {
+		t.Fatalf("task subagent bash schema should be foreground-only: %s", bash.Schema())
+	}
+}

--- a/internal/agent/subagent_registry_test.go
+++ b/internal/agent/subagent_registry_test.go
@@ -121,3 +121,17 @@ func TestTaskToolBuildSubRegUsesSubagentToolRegistry(t *testing.T) {
 		t.Fatalf("task subagent bash schema should be foreground-only: %s", bash.Schema())
 	}
 }
+
+func TestTaskToolDescribesSubagentToolBoundary(t *testing.T) {
+	task := &TaskTool{}
+	for label, text := range map[string]string{
+		"description": task.Description(),
+		"schema":      string(task.Schema()),
+	} {
+		for _, want := range []string{"wait", "bash_output", "kill_shell", "foreground-only"} {
+			if !strings.Contains(text, want) {
+				t.Fatalf("task %s should mention %q in subagent tool boundary: %s", label, want, text)
+			}
+		}
+	}
+}

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -33,6 +33,12 @@ var subagentMetaTools = []string{
 	"security_review",
 }
 
+var subagentJobTools = []string{
+	"wait",
+	"bash_output",
+	"kill_shell",
+}
+
 // SubagentMetaTools returns the tool names that spawned agents should not inherit
 // from the parent registry unless a future call site deliberately opts into a
 // different boundary. They can spawn or author more agent work, so excluding them
@@ -42,6 +48,54 @@ func SubagentMetaTools() []string {
 	copy(out, subagentMetaTools)
 	return out
 }
+
+// SubagentToolRegistry returns the tool set exposed inside spawned sub-agents:
+// the requested whitelist (or every parent tool), minus meta tools that would
+// spawn more agent work and job tools whose runtime manager is not injected into
+// sub-agents. When bash is present, it is wrapped to advertise and allow only
+// foreground execution.
+func SubagentToolRegistry(parent *tool.Registry, names []string) *tool.Registry {
+	exclude := append(SubagentMetaTools(), subagentJobTools...)
+	sub := FilterRegistry(parent, names, exclude...)
+	if bash, ok := sub.Get("bash"); ok {
+		sub.Add(foregroundOnlyBash{inner: bash})
+	}
+	return sub
+}
+
+type foregroundOnlyBash struct {
+	inner tool.Tool
+}
+
+func (b foregroundOnlyBash) Name() string { return "bash" }
+
+func (b foregroundOnlyBash) Description() string {
+	desc := strings.TrimSpace(b.inner.Description())
+	if desc == "" {
+		desc = "Execute a command in the shell and return combined stdout/stderr."
+	}
+	desc = strings.Replace(desc, "Execute a command in the shell", "Execute a foreground command in the shell", 1)
+	return desc + " Background execution is unavailable inside subagents."
+}
+
+func (foregroundOnlyBash) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute in the foreground"}},"required":["command"]}`)
+}
+
+func (b foregroundOnlyBash) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		RunInBackground bool `json:"run_in_background"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if p.RunInBackground {
+		return "", fmt.Errorf("background bash is unavailable in subagents; run a foreground command or ask the parent agent to start a background job")
+	}
+	return b.inner.Execute(ctx, args)
+}
+
+func (b foregroundOnlyBash) ReadOnly() bool { return b.inner.ReadOnly() }
 
 // TaskTool spawns a sub-agent in its own session for a focused sub-task. The
 // sub-agent runs with a filtered tool whitelist and the same step budget shape
@@ -344,10 +398,9 @@ func (t *TaskTool) effectiveEffortIdentity(effort string) string {
 }
 
 // buildSubReg returns the sub-agent's tool set: the named whitelist (minus
-// subagent/skill meta-tools, to bar recursive nesting), or every parent tool
-// except those meta-tools.
+// unavailable sub-agent tools), or every parent tool except those tools.
 func (t *TaskTool) buildSubReg(names []string) *tool.Registry {
-	return FilterRegistry(t.parentReg, names, SubagentMetaTools()...)
+	return SubagentToolRegistry(t.parentReg, names)
 }
 
 // FilterRegistry builds a sub-registry from parent: the named whitelist (empty =
@@ -355,11 +408,14 @@ func (t *TaskTool) buildSubReg(names []string) *tool.Registry {
 // sub-agent — a `task` sub-agent or a subagent skill — may call, e.g. excluding
 // `task` to bar recursive nesting, or restricting to a skill's allowed-tools.
 func FilterRegistry(parent *tool.Registry, names []string, exclude ...string) *tool.Registry {
+	sub := tool.NewRegistry()
+	if parent == nil {
+		return sub
+	}
 	ex := make(map[string]bool, len(exclude))
 	for _, e := range exclude {
 		ex[e] = true
 	}
-	sub := tool.NewRegistry()
 	src := names
 	if len(src) == 0 {
 		src = parent.Names()

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -39,6 +39,8 @@ var subagentJobTools = []string{
 	"kill_shell",
 }
 
+const subagentToolBoundarySummary = "Recursive agent/skill tools and unsupported background job tools (wait, bash_output, kill_shell) are excluded; bash is exposed as foreground-only inside subagents."
+
 // SubagentMetaTools returns the tool names that spawned agents should not inherit
 // from the parent registry unless a future call site deliberately opts into a
 // different boundary. They can spawn or author more agent work, so excluding them
@@ -178,7 +180,7 @@ func (t *TaskTool) WithTranscriptIdentityResolver(resolve func(modelRef, effort 
 func (t *TaskTool) Name() string { return "task" }
 
 func (t *TaskTool) Description() string {
-	return "Spawn a sub-agent for a focused sub-task. The sub-agent runs in its own session with the same provider and a filtered tool list (defaults to every parent tool except subagent/skill meta-tools, so delegation stays one layer deep). Only its final answer is returned. Use this to (a) keep long exploration sequences out of the parent's context budget, or (b) delegate self-contained work like 'find every place that calls X and summarise the patterns'."
+	return "Spawn a sub-agent for a focused sub-task. The sub-agent runs in its own session with the same provider and a filtered tool list (defaults to every parent tool, then applies the subagent boundary: " + subagentToolBoundarySummary + "). Only its final answer is returned. Use this to (a) keep long exploration sequences out of the parent's context budget, or (b) delegate self-contained work like 'find every place that calls X and summarise the patterns'."
 }
 
 func (t *TaskTool) Schema() json.RawMessage {
@@ -187,7 +189,7 @@ func (t *TaskTool) Schema() json.RawMessage {
 "properties":{
   "prompt":{"type":"string","description":"What the sub-agent should accomplish. Be specific about the deliverable — the sub-agent does not see this conversation."},
   "description":{"type":"string","description":"Short label for the sub-task (3-7 words). Surfaced in the dispatch line so the user sees what's running."},
-  "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist. Subagent/skill meta-tools are still excluded so delegation stays one layer deep."},
+  "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist. ` + subagentToolBoundarySummary + `"},
   "max_steps":{"type":"integer","description":"Optional cap on tool-call rounds. Defaults to half the parent's cap (min 5).","minimum":1},
   "run_in_background":{"type":"boolean","description":"Run the sub-agent asynchronously: returns a job id immediately and keeps working across turns. Collect its final answer with wait, and you'll be notified when it finishes. Use for long, independent sub-tasks you don't need to block on right now."},
   "model":{"type":"string","description":"Optional model override for the sub-agent (a configured provider/model name)."},

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -544,7 +544,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 			prov, price, ctxWin = p, pr, cw
 		}
-		subReg := agent.FilterRegistry(reg, sk.AllowedTools, agent.SubagentMetaTools()...)
+		subReg := agent.SubagentToolRegistry(reg, sk.AllowedTools)
 		continueFrom, forkFrom := strings.TrimSpace(runOpts.ContinueFrom), strings.TrimSpace(runOpts.ForkFrom)
 		if continueFrom != "" && forkFrom != "" {
 			return "", fmt.Errorf("continue_from and fork_from are mutually exclusive")

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -264,6 +264,15 @@ func requestHasTool(req provider.Request, name string) bool {
 	return false
 }
 
+func requestToolSchemaContains(req provider.Request, name, want string) bool {
+	for _, schema := range req.Tools {
+		if schema.Name == name {
+			return strings.Contains(string(schema.Parameters), want)
+		}
+	}
+	return false
+}
+
 func requestHasToolPrefix(req provider.Request, prefix string) bool {
 	for _, schema := range req.Tools {
 		if strings.HasPrefix(schema.Name, prefix) {
@@ -474,6 +483,65 @@ model = "x"
 	}
 	if got := bootLastUser(reqs[1]); got != "first skill task" {
 		t.Fatalf("skill subagent user prompt = %q, want first skill task", got)
+	}
+}
+
+func TestBuildSubagentSkillGetsForegroundOnlyBash(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	registerBootSubagentTestProvider()
+	prov := &bootSubagentTestProvider{}
+	setBootSubagentTestProvider(t, prov)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[codegraph]
+enabled = false
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "boot-subagent-test"
+model = "x"
+`)
+
+	ctrl, err := Build(context.Background(), Options{Sink: event.Discard})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	ctrl.SetSessionPath(agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label()))
+
+	if err := ctrl.Run(context.Background(), "first review"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	reqs := prov.requestsSnapshot()
+	if len(reqs) < 2 {
+		t.Fatalf("provider requests = %d, want parent request plus skill subagent request", len(reqs))
+	}
+	parentReq, subReq := reqs[0], reqs[1]
+	for _, want := range []string{"task", "bash", "wait", "bash_output", "kill_shell"} {
+		if !requestHasTool(parentReq, want) {
+			t.Fatalf("parent request missing %q; tools=%v", want, toolSchemaNames(parentReq.Tools))
+		}
+	}
+	if !requestToolSchemaContains(parentReq, "bash", "run_in_background") {
+		t.Fatalf("parent bash schema should include run_in_background")
+	}
+	for _, hidden := range []string{"task", "run_skill", "read_skill", "install_skill", "install_source", "explore", "research", "review", "security_review", "wait", "bash_output", "kill_shell"} {
+		if requestHasTool(subReq, hidden) {
+			t.Fatalf("skill subagent request should hide %q; tools=%v", hidden, toolSchemaNames(subReq.Tools))
+		}
+	}
+	if !requestHasTool(subReq, "bash") {
+		t.Fatalf("skill subagent request should keep foreground bash; tools=%v", toolSchemaNames(subReq.Tools))
+	}
+	if requestToolSchemaContains(subReq, "bash", "run_in_background") {
+		t.Fatalf("skill subagent bash schema should not include run_in_background")
 	}
 }
 

--- a/internal/cli/review.go
+++ b/internal/cli/review.go
@@ -76,14 +76,8 @@ func reviewCommand(args []string) int {
 		return 1
 	}
 
-	// 5. Build tool registry scoped to the review skill's allowed tools
-	// (read_file, ls, glob, grep, bash).
-	reg := tool.NewRegistry()
-	for _, name := range reviewSk.AllowedTools {
-		if tl, ok := tool.LookupBuiltin(name); ok {
-			reg.Add(tl)
-		}
-	}
+	// 5. Build a review-scoped sub-agent registry.
+	reg := buildReviewSubagentRegistry(reviewSk)
 
 	// 6. Prepare the review prompt.
 	task := buildReviewTask(diff, *instructions)
@@ -103,6 +97,19 @@ func reviewCommand(args []string) int {
 
 	fmt.Print(result)
 	return 0
+}
+
+func buildReviewSubagentRegistry(reviewSk skill.Skill) *tool.Registry {
+	// The shared helper strips subagent-unavailable background capabilities while
+	// preserving foreground bash. This direct CLI path does not go through boot,
+	// so it first builds the small parent set from the review skill allow-list.
+	parentReg := tool.NewRegistry()
+	for _, name := range reviewSk.AllowedTools {
+		if tl, ok := tool.LookupBuiltin(name); ok {
+			parentReg.Add(tl)
+		}
+	}
+	return agent.SubagentToolRegistry(parentReg, reviewSk.AllowedTools)
 }
 
 // getReviewDiff runs the appropriate git diff command and returns its output.

--- a/internal/cli/review_test.go
+++ b/internal/cli/review_test.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"reasonix/internal/skill"
 )
 
 func TestBuildReviewTask(t *testing.T) {
@@ -33,5 +37,31 @@ func TestBuildReviewTask(t *testing.T) {
 	}
 	if len(got) > 16500 {
 		t.Errorf("truncated output too long: %d", len(got))
+	}
+}
+
+func TestBuildReviewSubagentRegistryUsesForegroundOnlyBash(t *testing.T) {
+	reg := buildReviewSubagentRegistry(skill.Skill{AllowedTools: []string{
+		"bash",
+		"wait",
+		"bash_output",
+		"kill_shell",
+		"task",
+	}})
+
+	for _, hidden := range []string{"wait", "bash_output", "kill_shell", "task"} {
+		if _, ok := reg.Get(hidden); ok {
+			t.Fatalf("review subagent registry should hide %q; got %v", hidden, reg.Names())
+		}
+	}
+	bash, ok := reg.Get("bash")
+	if !ok {
+		t.Fatalf("review subagent registry should keep bash; got %v", reg.Names())
+	}
+	if strings.Contains(string(bash.Schema()), "run_in_background") {
+		t.Fatalf("review subagent bash schema should not include run_in_background: %s", bash.Schema())
+	}
+	if _, err := bash.Execute(context.Background(), json.RawMessage(`{"command":"sleep 1","run_in_background":true}`)); err == nil || !strings.Contains(err.Error(), "background bash is unavailable in subagents") {
+		t.Fatalf("review subagent background bash should return a clear error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- 新增统一的 subagent tool registry 构造入口，所有 subagent 路径都会先规范化工具面。
- 在 subagent 中过滤掉会再次触发 agent/skill 调度的工具，例如 `task`、`run_skill`、`read_skill`、`install_skill`、`install_source`、`explore`、`research`、`review`、`security_review`，避免 subagent 递归启动新的 agent 工作流。
- 在 subagent 中过滤后台 job 管理工具：`wait`、`bash_output`、`kill_shell`。
- 将 subagent 可见的 `bash` 包装为 foreground-only：schema 不再暴露 `run_in_background`；普通前台命令仍正常执行；如果仍传入 `run_in_background=true`，会返回明确的 subagent 专用错误。
- 该规范化覆盖 `task` subagent、skill subagent，以及直接 CLI review subagent 路径。

## Why
Subagent 当前不注入后台 job manager，因此它无法真正启动或管理跨 turn 的后台任务。之前 subagent 可能继承 parent registry 中的 `wait`、`bash_output`、`kill_shell`，也可能看到包含 `run_in_background` 的 `bash` schema。结果是模型会认为这些能力可用，但调用时只能在 `jobs.FromContext` 处失败，出现泛化的 `background execution is not available in this context` 之类错误。

这违反了“工具 schema 应代表真实可用能力”的原则。本次改动让 subagent 的工具说明与实际 runtime 能力一致：不可用的后台 job 工具不再出现在工具列表里；`bash` 只声明前台能力；误传后台参数时返回更明确的错误，提示应运行前台命令或让 parent agent 启动后台任务。

## Result
- Parent agent 的后台任务能力保持不变。
- Subagent 不再看到实际 runtime 不支持的后台 job 能力。
- 模型更少因为错误工具面做无效调用。
- 出错时错误信息更具体，更容易自我修正。