### PR TITLE
fix(cli): route slog.Warn/Error to TUI Notice events during chat session

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -425,6 +425,11 @@ func chatREPL(args []string) int {
 	// agent goroutine.
 	eventCh := make(chan event.Event, 1024)
 
+	// Route slog.Warn/Error through TUI Notice events while bubbletea owns
+	// the terminal so raw-mode stderr writes don't corrupt the display.
+	restoreSlog := routeSlogToTUI(eventCh)
+	defer restoreSlog()
+
 	var sink event.Sink = &eventSink{ch: eventCh}
 	sink = withNotifications(sink, cfg)
 	ctrl, err := setup(ctx, *model, *maxSteps, false, sink)
@@ -549,6 +554,7 @@ func chatREPL(args []string) int {
 		}
 	}()
 	final, runErr := p.Run()
+	restoreSlog()
 	signal.Stop(hangup)
 	// Close the active controller plus any retired ones from /model switches.
 	// Retired controllers were stashed rather than closed at switch time

--- a/internal/cli/tui_slog.go
+++ b/internal/cli/tui_slog.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"log/slog"
+	"strings"
+	"sync"
+
+	"reasonix/internal/event"
+)
+
+// tuiNoticeWriter is an io.Writer that turns each Write into a TUI Notice
+// event on the given channel. Writes are non-blocking: when the channel is
+// full the log line is discarded rather than blocking the caller.
+type tuiNoticeWriter struct {
+	ch chan<- event.Event
+}
+
+func (w tuiNoticeWriter) Write(p []byte) (int, error) {
+	line := strings.TrimSuffix(string(p), "\n")
+	if line == "" {
+		return len(p), nil
+	}
+	ev := event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: line}
+	select {
+	case w.ch <- ev:
+	default:
+	}
+	return len(p), nil
+}
+
+// dropTimeAndLevel removes time and level keys so the TextHandler output is
+// just msg and attributes.
+func dropTimeAndLevel(groups []string, a slog.Attr) slog.Attr {
+	if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+		return slog.Attr{}
+	}
+	return a
+}
+
+// routeSlogToTUI replaces the default slog.Logger with one that writes Warn
+// and above as TUI Notice events into ch. Info and Debug are discarded.
+// Returns a function that restores the original logger.
+func routeSlogToTUI(ch chan<- event.Event) func() {
+	prev := slog.Default()
+	handler := slog.NewTextHandler(tuiNoticeWriter{ch: ch}, &slog.HandlerOptions{
+		Level:       slog.LevelWarn,
+		ReplaceAttr: dropTimeAndLevel,
+	})
+	slog.SetDefault(slog.New(handler))
+	var once sync.Once
+	return func() { once.Do(func() { slog.SetDefault(prev) }) }
+}

--- a/internal/cli/tui_slog_test.go
+++ b/internal/cli/tui_slog_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func TestRouteSlogToTUI_WarnBecomesNotice(t *testing.T) {
+	ch := make(chan event.Event, 1)
+	restore := routeSlogToTUI(ch)
+	defer restore()
+
+	slog.Warn("test warning", "key", "value")
+
+	select {
+	case e := <-ch:
+		if e.Kind != event.Notice {
+			t.Fatalf("expected Notice, got %v", e.Kind)
+		}
+		if e.Level != event.LevelWarn {
+			t.Fatalf("expected LevelWarn, got %v", e.Level)
+		}
+		if !strings.Contains(e.Text, "test warning") {
+			t.Fatalf("expected text to contain 'test warning', got %q", e.Text)
+		}
+		if !strings.Contains(e.Text, "key=value") {
+			t.Fatalf("expected text to contain 'key=value', got %q", e.Text)
+		}
+	default:
+		t.Fatal("expected a Notice event, got none")
+	}
+}
+
+func TestRouteSlogToTUI_InfoDiscarded(t *testing.T) {
+	ch := make(chan event.Event, 1)
+	restore := routeSlogToTUI(ch)
+	defer restore()
+
+	slog.Info("info message")
+
+	select {
+	case <-ch:
+		t.Fatal("expected no event for Info level")
+	default:
+	}
+}
+
+func TestRouteSlogToTUI_ChannelFullNonBlocking(t *testing.T) {
+	ch := make(chan event.Event) // unbuffered
+	restore := routeSlogToTUI(ch)
+	defer restore()
+
+	// This must not block: no goroutine is reading from ch.
+	slog.Warn("should not block")
+}
+
+func TestRouteSlogToTUI_Restore(t *testing.T) {
+	prev := slog.Default()
+	ch := make(chan event.Event, 1)
+	restore := routeSlogToTUI(ch)
+	restore()
+
+	if slog.Default() != prev {
+		t.Fatal("expected default logger to be restored")
+	}
+}
+
+func TestRouteSlogToTUI_ErrorLevelBecomesNotice(t *testing.T) {
+	ch := make(chan event.Event, 1)
+	restore := routeSlogToTUI(ch)
+	defer restore()
+
+	slog.Error("fatal error", "err", "something broke")
+
+	select {
+	case e := <-ch:
+		if e.Kind != event.Notice {
+			t.Fatalf("expected Notice, got %v", e.Kind)
+		}
+		if e.Level != event.LevelWarn {
+			t.Fatalf("expected LevelWarn, got %v", e.Level)
+		}
+		if !strings.Contains(e.Text, "fatal error") {
+			t.Fatalf("expected text to contain 'fatal error', got %q", e.Text)
+		}
+	default:
+		t.Fatal("expected a Notice event for Error level")
+	}
+}


### PR DESCRIPTION
  In reasonix chat TUI mode, when MCP plugin timeouts or background tasks call slog.Warn/Error, the logs write directly to stderr, corrupting Bubble Tea's alt-screen terminal display.

  This PR routes Warn-and-above logs through the TUI event channel during the TUI lifecycle, so they render inline in the scrollback instead of writing to stderr.

  Before / After

  Before: stderr logs interleave at the top of the TUI, breaking the layout.

  After: logs appear as warning notices inline in the TUI scrollback:

    ! msg="plugin: start auxiliary resource client failed" server=everything err="context deadline exceeded"

  Scope

  - Only affects reasonix chat TUI mode
  - desktop, serve, run, bot, acp are unaffected
  - MCP timeout semantics and plugin behavior are unchanged