### PR TITLE
chore: bump CLI version to 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the Go line (Reasonix 1.0+) are recorded here. The legacy
 `0.x` TypeScript history lives on the [`v1`](https://github.com/esengine/DeepSeek-Reasonix/tree/v1)
 branch.
 
+## [1.8.0] — 2026-06-15
+
+### Added
+
+- (Your additions here)
+
+### Fixed
+
+- (Your fixes here)
+
+### Changed
+
+- (Your changes here)
+
+[1.8.0]: https://github.com/esengine/DeepSeek-Reasonix/releases/tag/v1.8.0
+
 ## [1.0.0] — 2026-06-03
 
 First stable release — a **ground-up rewrite in Go**. Not an upgrade of the `0.x`

--- a/npm/reasonix/package.json
+++ b/npm/reasonix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reasonix",
-  "version": "0.0.0",
+  "version": "1.8.0",
   "description": "Cache-first DeepSeek coding agent for the terminal.",
   "bin": {
     "reasonix": "bin/reasonix.js"
@@ -29,11 +29,11 @@
     "tui"
   ],
   "optionalDependencies": {
-    "@reasonix/cli-darwin-arm64": "0.0.0",
-    "@reasonix/cli-darwin-x64": "0.0.0",
-    "@reasonix/cli-linux-arm64": "0.0.0",
-    "@reasonix/cli-linux-x64": "0.0.0",
-    "@reasonix/cli-win32-arm64": "0.0.0",
-    "@reasonix/cli-win32-x64": "0.0.0"
+    "@reasonix/cli-darwin-arm64": "1.8.0",
+    "@reasonix/cli-darwin-x64": "1.8.0",
+    "@reasonix/cli-linux-arm64": "1.8.0",
+    "@reasonix/cli-linux-x64": "1.8.0",
+    "@reasonix/cli-win32-arm64": "1.8.0",
+    "@reasonix/cli-win32-x64": "1.8.0"
   }
 }


### PR DESCRIPTION
## 概述

将 reasonix-cli 版本更新到 1.8.0。

## 变更

- **npm/reasonix/package.json**: 版本号 `0.0.0` → `1.8.0`，同步更新 optionalDependencies 中所有平台包的版本
- **CHANGELOG.md**: 添加 1.8.0 版本条目（请补充具体的 Added/Fixed/Changed 内容）

> 注意：未修改 desktop/wails.json，仅更新 CLI 版本。