### PR TITLE
fix(config): 修复模型选择保存后被官方默认模型覆盖的问题

### DIFF
--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -951,8 +951,9 @@ func providerDefaultForModels(currentDefault string, models []string) string {
 	return ""
 }
 
-// SaveProvider adds or updates a provider. A single model fills `model`; several
-// fill `models` (with `default`). The shared key/endpoint live on the entry.
+// SaveProvider adds or updates a provider. Enabled models are persisted through
+// `models` even when only one model is selected, while `model` remains populated
+// in-memory for validation/back-compat. The shared key/endpoint live on the entry.
 func (a *App) SaveProvider(p ProviderView) error {
 	return a.applyConfigChange(func(c *config.Config) error {
 		e := config.ProviderEntry{Name: p.Name}
@@ -978,8 +979,8 @@ func (a *App) SaveProvider(p ProviderView) error {
 		models := chatProviderModels(p.Models)
 		if len(models) > 0 {
 			e.Model = models[0] // also satisfies validateProvider's model requirement
+			e.Models = models
 			if len(models) > 1 {
-				e.Models = models
 				e.Default = providerDefaultForModels(p.Default, models)
 			}
 		}

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -121,12 +121,31 @@ func TestSaveProviderFiltersNonChatModels(t *testing.T) {
 	if !ok {
 		t.Fatal("saved provider not found")
 	}
-	want := []string{"mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-omni"}
+	want := []string{"mimo-v2.5-pro"}
 	if !reflect.DeepEqual(got.ModelList(), want) {
 		t.Errorf("saved provider models = %v, want %v", got.ModelList(), want)
 	}
 	if got.DefaultModel() != "mimo-v2.5-pro" {
 		t.Errorf("saved provider default = %q, want mimo-v2.5-pro", got.DefaultModel())
+	}
+	raw, err := os.ReadFile(config.UserConfigPath())
+	if err != nil {
+		t.Fatalf("read saved config: %v", err)
+	}
+	saved := string(raw)
+	blockStart := strings.Index(saved, "\n[[providers]]\nname        = \"mimo-api\"")
+	if blockStart < 0 {
+		t.Fatalf("saved config missing mimo-api provider block:\n%s", raw)
+	}
+	block := saved[blockStart:]
+	if next := strings.Index(block[len("\n[[providers]]"):], "\n[[providers]]"); next >= 0 {
+		block = block[:len("\n[[providers]]")+next]
+	}
+	if !strings.Contains(block, `models      = ["mimo-v2.5-pro"]`) {
+		t.Fatalf("saved provider block did not persist single selection as models array:\n%s", block)
+	}
+	if strings.Contains(block, `model       = "mimo-v2.5-pro"`) {
+		t.Fatalf("saved provider block should not persist explicit single selection as legacy model:\n%s", block)
 	}
 }
 

--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -305,3 +305,73 @@ func TestNormalizeDesktopOfficialProviderAccessBackfillsExistingMimoTokenPlanAnd
 		t.Fatalf("mimo-token-plan mixed-model price = %+v, want nil", p.Price)
 	}
 }
+
+// ── Explicit model list: normalization must not override user selection ───────
+
+func TestBackfillDeepSeekProSkipsWhenExplicitModelList(t *testing.T) {
+	// User saved with only flash via Settings → Models = ["deepseek-v4-flash"].
+	c := &Config{Providers: []ProviderEntry{
+		{Name: "deepseek", Kind: "openai", BaseURL: "https://api.deepseek.com", Models: []string{"deepseek-v4-flash"}, Default: "deepseek-v4-flash", APIKeyEnv: "DEEPSEEK_API_KEY"},
+	}}
+	backfillDeepSeekPro(c)
+	if hasModel(c, "deepseek-v4-pro") != nil {
+		t.Fatal("deepseek-v4-pro must not be added when user has an explicit model list")
+	}
+	if len(c.Providers) != 1 {
+		t.Fatalf("providers = %d, want 1 (no new entry should be added)", len(c.Providers))
+	}
+}
+
+func TestEnsureProviderModelsSkipsWhenExplicitModelList(t *testing.T) {
+	// User saved with only flash via Settings → Models = ["deepseek-v4-flash"].
+	p := &ProviderEntry{
+		Name:    "deepseek",
+		BaseURL: "https://api.deepseek.com",
+		Models:  []string{"deepseek-v4-flash"},
+		Default: "deepseek-v4-flash",
+	}
+	ensureProviderModels(p, []string{"deepseek-v4-flash", "deepseek-v4-pro"}, "deepseek-v4-flash")
+	if p.HasModel("deepseek-v4-pro") {
+		t.Fatal("ensureProviderModels must not merge required models when Models is explicitly set")
+	}
+	if len(p.Models) != 1 || p.Models[0] != "deepseek-v4-flash" {
+		t.Fatalf("models = %v, want [deepseek-v4-flash]", p.Models)
+	}
+}
+
+func TestMergeCuratedModelsIntoProviderSkipsWhenExplicitModelList(t *testing.T) {
+	// User saved with only two mimo models via Settings.
+	p := &ProviderEntry{
+		Name:    "mimo-api",
+		BaseURL: "https://api.xiaomimimo.com/v1",
+		Models:  []string{"mimo-v2.5-pro", "mimo-v2.5"},
+		Default: "mimo-v2.5-pro",
+	}
+	mergeCuratedModelsIntoProvider(p, []string{"mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-omni"}, "mimo-v2.5-pro")
+	if p.HasModel("mimo-v2-omni") {
+		t.Fatal("mergeCuratedModelsIntoProvider must not add mimo-v2-omni when Models is explicitly set")
+	}
+	if len(p.Models) != 2 {
+		t.Fatalf("models = %v, want 2 selected models", p.Models)
+	}
+}
+
+func TestNormalizeOfficialDeepSeekModelsSkipsExplicitModelList(t *testing.T) {
+	// User saved with only flash via Settings → Models = ["deepseek-v4-flash"].
+	c := &Config{Providers: []ProviderEntry{{
+		Name:      "deepseek",
+		Kind:      "openai",
+		BaseURL:   "https://api.deepseek.com",
+		Models:    []string{"deepseek-v4-flash"},
+		Default:   "deepseek-v4-flash",
+		APIKeyEnv: "DEEPSEEK_API_KEY",
+	}}}
+	normalizeOfficialDeepSeekModels(c)
+	p, ok := c.Provider("deepseek")
+	if !ok {
+		t.Fatal("deepseek provider missing")
+	}
+	if p.HasModel("deepseek-v4-pro") {
+		t.Fatal("normalizeOfficialDeepSeekModels must not add pro when Models is explicitly set")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1393,6 +1393,11 @@ func backfillDeepSeekPro(c *Config) {
 	if flash == nil {
 		return
 	}
+	// If the user has explicitly curated a model list for the flash provider
+	// (e.g. unchecked pro in Settings), respect that choice and do not backfill.
+	if len(flash.Models) > 0 {
+		return
+	}
 	for _, bp := range Default().Providers {
 		if bp.Name == "deepseek-pro" {
 			bp.APIKeyEnv = flash.APIKeyEnv
@@ -1644,6 +1649,11 @@ func ensureProviderModels(p *ProviderEntry, required []string, fallbackDefault s
 	if p == nil {
 		return
 	}
+	// If the user has explicitly curated a model list (via Settings), respect
+	// that choice and do not merge additional required models.
+	if len(p.Models) > 0 {
+		return
+	}
 	models := mergeModelLists(required, p.ModelList())
 	if len(models) == 0 {
 		return
@@ -1872,6 +1882,11 @@ func isOpenAIProviderKind(e *ProviderEntry) bool {
 }
 
 func mergeCuratedModelsIntoProvider(e *ProviderEntry, models []string, fallback string) {
+	// If the user has explicitly curated a model list (via Settings), respect
+	// that choice and do not merge additional curated models.
+	if len(e.Models) > 0 {
+		return
+	}
 	currentDefault := e.Default
 	if strings.TrimSpace(currentDefault) == "" {
 		currentDefault = e.Model


### PR DESCRIPTION
## 问题描述

用户在设置中刷新模型列表，只勾选部分模型保存后，重新打开设置时发现模型被恢复为官方默认列表。例如 mimo 有 5 个模型，用户只选 2 个，保存后还是显示 3 个。

## 根因分析

配置加载时有三个 normalization 函数会无条件合并官方模型：

1. `ensureProviderModels`（被 `normalizeOfficialDeepSeekModels` 调用）
2. `mergeCuratedModelsIntoProvider`（被 `ensureMimoAPIProvider`/`ensureMimoTokenPlanProvider` 调用）
3. `backfillDeepSeekPro`

这些函数使用 `mergeModelLists` 把官方全部模型合并到用户已选模型中，覆盖了用户的选择。

此外，`SaveProvider` 只保存一个模型时输出 `model = "x"` 格式，重载后 `Models` 字段为空，无法区分"用户明确选择"和"从未配置"。

## 修复方案

- **render.go** — 单个模型也输出 `models = ["x"]` 格式，确保重载后 `Models` 非空
- **ensureProviderModels** — `len(p.Models) > 0` 时跳过合并
- **mergeCuratedModelsIntoProvider** — `len(e.Models) > 0` 时跳过合并
- **backfillDeepSeekPro** — `len(flash.Models) > 0` 时跳过补回

## 涉及文件

| 文件 | 改动 |
|------|------|
| `internal/config/render.go` | 单模型输出 `models = [...]` 格式 |
| `internal/config/config.go` | 三个 normalization 函数添加显式模型列表检查 |
| `internal/config/backfill_test.go` | 4 个新测试覆盖显式模型列表场景 |

Fixes #4512
