### PR TITLE
fix(config): resolve linux config path without XDG_CONFIG_HOME

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1999,9 +1999,29 @@ func retargetDesktopOfficialRef(ref string, access map[string]bool) string {
 	}
 }
 
+var (
+	osUserConfigDir = os.UserConfigDir
+	osUserHomeDir   = os.UserHomeDir
+)
+
+func userConfigDir() string {
+	dir, err := osUserConfigDir()
+	if err == nil && strings.TrimSpace(dir) != "" {
+		return dir
+	}
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return ""
+	}
+	home, homeErr := osUserHomeDir()
+	if homeErr != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".config")
+}
+
 func userConfigPath() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
+	dir := userConfigDir()
+	if dir == "" {
 		return ""
 	}
 	return filepath.Join(dir, "reasonix", "config.toml")
@@ -2036,8 +2056,8 @@ func UserConfigPath() string { return userConfigPath() }
 // committed, and resolve from any working directory. "" when the user config dir
 // can't be resolved.
 func UserCredentialsPath() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
+	dir := userConfigDir()
+	if dir == "" {
 		return ""
 	}
 	return filepath.Join(dir, "reasonix", "credentials")
@@ -2047,8 +2067,8 @@ func UserCredentialsPath() string {
 // traceability (one timestamped .jsonl per compaction). Empty if the user config
 // directory cannot be resolved, in which case archiving is skipped.
 func ArchiveDir() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
+	dir := userConfigDir()
+	if dir == "" {
 		return ""
 	}
 	return filepath.Join(dir, "reasonix", "archive")
@@ -2058,8 +2078,8 @@ func ArchiveDir() string {
 // Used by `reasonix chat --continue` / `--resume` to find the recent ones. Empty
 // if the user config dir can't be resolved — sessions then aren't saved.
 func SessionDir() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
+	dir := userConfigDir()
+	if dir == "" {
 		return ""
 	}
 	return filepath.Join(dir, "reasonix", "sessions")
@@ -2092,8 +2112,8 @@ func WorkspaceSlug(absPath string) string {
 // shares one root the user can wipe in a single rm. Empty when the OS dir is
 // unavailable — callers must tolerate that (caching is best-effort).
 func CacheDir() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
+	dir := userConfigDir()
+	if dir == "" {
 		return ""
 	}
 	return filepath.Join(dir, "reasonix", "cache")
@@ -2103,8 +2123,8 @@ func CacheDir() string {
 // the user-global REASONIX.md and the per-project auto-memory store live. Empty
 // when the user config dir can't be resolved, which disables user-scoped memory.
 func MemoryUserDir() string {
-	dir, err := os.UserConfigDir()
-	if err != nil {
+	dir := userConfigDir()
+	if dir == "" {
 		return ""
 	}
 	return filepath.Join(dir, "reasonix")

--- a/internal/config/user_config_path_test.go
+++ b/internal/config/user_config_path_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestUserConfigDirFallsBackToHomeDotConfigOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		t.Skip("the explicit ~/.config fallback is for Linux/Unix XDG config paths")
+	}
+	home := t.TempDir()
+	oldUserConfigDir := osUserConfigDir
+	oldUserHomeDir := osUserHomeDir
+	t.Cleanup(func() {
+		osUserConfigDir = oldUserConfigDir
+		osUserHomeDir = oldUserHomeDir
+	})
+	osUserConfigDir = func() (string, error) {
+		return "", errors.New("config dir unavailable")
+	}
+	osUserHomeDir = func() (string, error) {
+		return home, nil
+	}
+
+	base := filepath.Join(home, ".config", "reasonix")
+	if got := UserConfigPath(); got != filepath.Join(base, "config.toml") {
+		t.Fatalf("UserConfigPath() = %q, want %q", got, filepath.Join(base, "config.toml"))
+	}
+	if got := UserCredentialsPath(); got != filepath.Join(base, "credentials") {
+		t.Fatalf("UserCredentialsPath() = %q, want %q", got, filepath.Join(base, "credentials"))
+	}
+	if got := ArchiveDir(); got != filepath.Join(base, "archive") {
+		t.Fatalf("ArchiveDir() = %q, want %q", got, filepath.Join(base, "archive"))
+	}
+	if got := SessionDir(); got != filepath.Join(base, "sessions") {
+		t.Fatalf("SessionDir() = %q, want %q", got, filepath.Join(base, "sessions"))
+	}
+	if got := CacheDir(); got != filepath.Join(base, "cache") {
+		t.Fatalf("CacheDir() = %q, want %q", got, filepath.Join(base, "cache"))
+	}
+	if got := MemoryUserDir(); got != base {
+		t.Fatalf("MemoryUserDir() = %q, want %q", got, base)
+	}
+}


### PR DESCRIPTION
fixes #4521.

## summary

resolve the linux/unix user config root consistently when `XDG_CONFIG_HOME` is unset and the os config-dir lookup is unavailable.

this keeps the existing `os.UserConfigDir()` path when available, falls back to `$HOME/.config` on linux/unix, and leaves macos/windows behavior unchanged.

the shared helper is now used for config, credentials, archive, sessions, cache, and memory paths so user state stays under the same `~/.config/reasonix` root.

## tests

- `gofmt -l .`
- `env -u DEEPSEEK_API_KEY go test ./...`