### PR TITLE
fix(desktop): inline-math classifier gaps + display-math/blockquote rendering bugs

### DIFF
--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -133,6 +133,13 @@ check("$\\frac{a}{b}$", () => isLikelyInlineMath("\\frac{a}{b}") === true);
 check("$f(x)$", () => isLikelyInlineMath("f(x)") === true);
 check("$x+1$", () => isLikelyInlineMath("x+1") === true);
 
+console.log("\nisLikelyInlineMath — LaTeX command followed by a digit (math)");
+check("$\\tfrac12$", () => isLikelyInlineMath("\\tfrac12") === true);
+check("$\\frac12$", () => isLikelyInlineMath("\\frac12") === true);
+check("$\\sqrt2$", () => isLikelyInlineMath("\\sqrt2") === true);
+check("$\\log3$", () => isLikelyInlineMath("\\log3") === true);
+check("$\\overline3$", () => isLikelyInlineMath("\\overline3") === true);
+
 console.log("\nisLikelyInlineMath — multi-letter group notation (math)");
 check("$SO(3,1)$", () => isLikelyInlineMath("SO(3,1)") === true);
 check("$SU(2)$", () => isLikelyInlineMath("SU(2)") === true);

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -241,7 +241,7 @@ check("\\|x\\| renders as double bars", () => {
 
 console.log("\nnormalizeMath — LLM delimiter conversion");
 eq(normalizeMath("\\(x^2\\)"), "$x^2$", "\\(…\\) → $…$");
-eq(normalizeMath("\\[E=mc^2\\]"), "$$E=mc^2$$", "\\[…\\] → $$…$$");
+eq(normalizeMath("\\[E=mc^2\\]"), "$$\nE=mc^2\n$$", "\\[…\\] → $$…$$");
 eq(normalizeMath("\\\\[4pt]"), "\\\\[4pt]", "\\\\[ line-break spacing protected");
 
 console.log("\nnormalizeMath — \\slashed conversion (regression)");
@@ -266,12 +266,12 @@ check("inline $$ after closing bracket", () => {
   return out.startsWith("(octet)\n\n$$");
 });
 check("inline $$ after closing brace (\\end{...}$$)", () => {
-  // A model that writes `\end{array}$$` or `\frac{a}{b}$$` on one line
-  // has the same micromark-fence problem as the comma case. The
-  // closing brace is the most common end-of-content marker in LaTeX
-  // math, so the repair-regex character class includes it.
+  // A display equation ending with }$$ must be extracted as a unit.
+  // The closing $$ must NOT be split off (the old bug inserted \n\n
+  // before it, emptying the equation). The extraction regex catches
+  // $$...$$ as a pair before the repair regex can split it.
   const out = normalizeMath("$$\\begin{pmatrix}a&b\\\\c&d\\end{pmatrix}$$");
-  return out.includes("\\end{pmatrix},\n\n$$") || out.includes("\\end{pmatrix}\n\n$$");
+  return out.includes("$$") && out.includes("\\begin{pmatrix}") && !out.includes("}\\n\\n$$") && !out.includes("$$\\n\\n");
 });
 check("inline $$ after comma on same line as content", () => {
   // User-reported (2026-06-12, soft-pion chat): the model wrote the
@@ -289,20 +289,22 @@ check("inline $$ after comma on same line as content", () => {
 });
 check("well-formed $$ already on own line is normalised consistently", () => {
   // Whether the model writes `decomposes as$$\n\mathbf{6}.$$` or
-  // `decomposes as\n\n$$\n\mathbf{6}.$$`, both must produce the same
-  // remark-math-parseable form: opening $$ on its own line, body, blank
-  // line, closing $$ on its own line.
+  // `decomposes as\n\n$$\n\mathbf{6}.$$`, the opening $$ must be
+  // paragraph-separated (blank line before it). The display pair is
+  // extracted as a unit, so the closing $$ stays attached to the body.
   const inline = normalizeMath("decomposes as$$\n\\mathbf{6}.$$");
   const block = normalizeMath("decomposes as\n\n$$\n\\mathbf{6}.$$");
-  const expected = "decomposes as\n\n$$\n\\mathbf{6}.\n\n$$";
-  return inline === expected && block === expected;
+  // Both must have the opening $$ on its own line (blank line before it)
+  return inline.startsWith("decomposes as\n\n$$") && block.startsWith("decomposes as\n\n$$")
+    // And the math body must be present (not emptied)
+    && inline.includes("\\mathbf{6}") && block.includes("\\mathbf{6}");
 });
 check("\\[…\\] → $$…$$ still works (no spurious blank line)", () => {
-  return normalizeMath("\\[E=mc^2\\]") === "$$E=mc^2$$";
+  return normalizeMath("\\[E=mc^2\\]") === "$$\nE=mc^2\n$$";
 });
 check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
   const out = normalizeMath("c^2$$ x $$");
-  return out === "c^2$$ x $$";
+  return out === "c^2$$\n x \n$$";
 });
 
 console.log("\nnormalizeMath — non-math dollar filtering");
@@ -510,7 +512,7 @@ check("\\yng inside \\(...\\) does not get double-wrapped", () => {
 });
 check("\\yng inside \\[...\\] stays display math without triple dollars", () => {
   const out = normalizeMath("\\[\\yng(2,1)\\]");
-  return out.startsWith("$$\\begin{array}{l}")
+  return out.startsWith("$$\n\\begin{array}{l}")
     && out.endsWith("$$")
     && !out.includes("$$$");
 });
@@ -529,7 +531,7 @@ check("digit-starting inline math with \\young does not get nested wrappers", ()
 });
 check("display math ending in digit closes before following bare \\yng", () => {
   const out = normalizeMath("$$x^2$$ \\yng(1)");
-  return out === "$$x^2$$ $\\begin{array}{l}\\square\\end{array}$";
+  return out === "$$\nx^2\n$$ $\\begin{array}{l}\\square\\end{array}$";
 });
 check("bare \\yng after inline math is separated from adjacent dollars", () => {
   const out = normalizeMath("$x$\\yng(1)");

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -133,6 +133,17 @@ check("$\\frac{a}{b}$", () => isLikelyInlineMath("\\frac{a}{b}") === true);
 check("$f(x)$", () => isLikelyInlineMath("f(x)") === true);
 check("$x+1$", () => isLikelyInlineMath("x+1") === true);
 
+console.log("\nisLikelyInlineMath — multi-letter group notation (math)");
+check("$SO(3,1)$", () => isLikelyInlineMath("SO(3,1)") === true);
+check("$SU(2)$", () => isLikelyInlineMath("SU(2)") === true);
+check("$SU(3)$", () => isLikelyInlineMath("SU(3)") === true);
+check("$SL(2)$", () => isLikelyInlineMath("SL(2)") === true);
+check("$GL(n)$", () => isLikelyInlineMath("GL(n)") === true);
+check("$Sp(2n)$", () => isLikelyInlineMath("Sp(2n)") === true);
+check("$SO(3)$", () => isLikelyInlineMath("SO(3)") === true);
+check("$Spin(3)$", () => isLikelyInlineMath("Spin(3)") === true);
+check("$Diff(M)$", () => isLikelyInlineMath("Diff(M)") === true);
+
 console.log("\nisLikelyInlineMath — currency/link (NOT math)");
 check("$5", () => isLikelyInlineMath("5") === false);
 check("$10", () => isLikelyInlineMath("10") === false);

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -151,6 +151,16 @@ check("$SO(3)$", () => isLikelyInlineMath("SO(3)") === true);
 check("$Spin(3)$", () => isLikelyInlineMath("Spin(3)") === true);
 check("$Diff(M)$", () => isLikelyInlineMath("Diff(M)") === true);
 
+console.log("\nisLikelyInlineMath — binary operators with signed RHS / lone operators (math)");
+check("$K = -iJ$", () => isLikelyInlineMath("K = -iJ") === true);
+check("$K = +iJ$", () => isLikelyInlineMath("K = +iJ") === true);
+check("$p = +\\alpha$", () => isLikelyInlineMath("p = +\\alpha") === true);
+check("$a = -b$", () => isLikelyInlineMath("a = -b") === true);
+check("$+$", () => isLikelyInlineMath("+") === true);
+check("$-$", () => isLikelyInlineMath("-") === true);
+check("$=$", () => isLikelyInlineMath("=") === true);
+check("$<$", () => isLikelyInlineMath("<") === true);
+
 console.log("\nisLikelyInlineMath — currency/link (NOT math)");
 check("$5", () => isLikelyInlineMath("5") === true);
 check("$10", () => isLikelyInlineMath("10") === true);

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -188,6 +188,12 @@ check("comma-separated $A, B$ → math (ordered pair)", () => isLikelyInlineMath
 check("comma-separated $1, 2, 3$ → math (sequence)", () => isLikelyInlineMath("1, 2, 3") === true);
 check("comma-separated $\\alpha, \\beta$ → math (Greek pair)", () => isLikelyInlineMath("\\alpha, \\beta") === true);
 check("parens-wrapped $(A, B)$ inner → math", () => isLikelyInlineMath("(A, B)") === true);
+check("cycle notation $(12)$ → math (transposition)", () => isLikelyInlineMath("(12)") === true);
+check("cycle notation $(123)$ → math (3-cycle)", () => isLikelyInlineMath("(123)") === true);
+check("cycle notation $(12)(34)$ → math (product)", () => isLikelyInlineMath("(12)(34)") === true);
+check("$(12)$ survives normalizeMath as math", () => {
+  return normalizeMath("the transposition $(12)$ swaps") === "the transposition $(12)$ swaps";
+});
 check("$S$ (set name) → math", () => isLikelyInlineMath("S") === true);
 check("$S$ with surrounding prose (regression)", () => {
   return normalizeMath("$S$ 非空\n$S$ 有上界") === "$S$ 非空\n$S$ 有上界";

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -181,6 +181,38 @@ check("uppercase $I$ → math (math name in non-English prose)", () => isLikelyI
 check("uppercase $A$ → math", () => isLikelyInlineMath("A") === true);
 check("uppercase $V$ → math", () => isLikelyInlineMath("V") === true);
 
+console.log("\nisLikelyInlineMath — primed letters (regression)");
+// A letter followed by primes (') is the LaTeX prime symbol — ubiquitous
+// in math for derivatives (x', f'), transformed/labelled states (S', T'),
+// and second derivatives (y''). The classifier used to reject these as
+// non-math, so $S'$ was escaped to a literal dollar entity and never
+// reached KaTeX.
+check("$S'$ → math (primed letter)", () => isLikelyInlineMath("S'") === true);
+check("$S''$ → math (double prime)", () => isLikelyInlineMath("S''") === true);
+check("$x'$ → math (derivative)", () => isLikelyInlineMath("x'") === true);
+check("$y''$ → math (second derivative)", () => isLikelyInlineMath("y''") === true);
+check("$a'$ → math", () => isLikelyInlineMath("a'") === true);
+check("$T'$ → math", () => isLikelyInlineMath("T'") === true);
+check("$\\psi'$ → math (Greek with prime)", () => isLikelyInlineMath("\\psi'") === true);
+check("$f'(x)$ → math (primed function call)", () => isLikelyInlineMath("f'(x)") === true);
+check("$S'$ in prose stays math", () => normalizeMath("the $S'$ admixture") === "the $S'$ admixture");
+
+console.log("\nisLikelyInlineMath — bracketed labels (regression)");
+// Square brackets in a $...$ context denote group-theory irrep labels
+// ([56], [8], [70] for SU(6) multiplets), array subscripts, and interval
+// notation. The classifier used to reject pure bracketed numbers/letters,
+// so $[56]$ was escaped to a literal dollar entity and never reached KaTeX.
+// Markdown link syntax [text](url) is rejected separately upstream.
+check("$[56]$ → math (SU(6) irrep label)", () => isLikelyInlineMath("[56]") === true);
+check("$[70]$ → math", () => isLikelyInlineMath("[70]") === true);
+check("$[8]$ → math (octet label)", () => isLikelyInlineMath("[8]") === true);
+check("$[1]$ → math (singlet label)", () => isLikelyInlineMath("[1]") === true);
+check("$[x]$ → math (bracketed variable)", () => isLikelyInlineMath("[x]") === true);
+check("$[N]$ → math", () => isLikelyInlineMath("[N]") === true);
+check("$[56,0^+]$ → math", () => isLikelyInlineMath("[56,0^+]") === true);
+check("$[\\mathbf{56}]$ → math (bold command)", () => isLikelyInlineMath("[\\mathbf{56}]") === true);
+check("$[56]$ in prose stays math", () => normalizeMath("the $[56]$ multiplet") === "the $[56]$ multiplet");
+
 console.log("\nisLikelyInlineMath — minimal LaTeX patterns (regression)");
 // LLMs frequently emit minimal LaTeX in math contexts that the older
 // classifier rejected as currency / word tokens. These tests pin down the
@@ -445,6 +477,17 @@ const e2e: Array<[string, string]> = [
   ["$\\frac{1}{\\sqrt{2}}\\|uud\\rangle$", "ket in fraction with \\|"],
   ["$\\|x\\|$", "norm \\|x\\| → double bar (regression)"],
   ["$\\langle\\psi\\|$", "bra closer \\| → single bar (regression)"],
+  // Primed letters — KaTeX renders ' natively as a prime symbol.
+  ["$S'$", "primed letter S' (regression)"],
+  ["$x'$", "derivative x'"],
+  ["$y''$", "second derivative y''"],
+  ["$f'(x)$", "primed function call f'(x)"],
+  ["$\\psi'$", "Greek letter with prime"],
+  // Bracketed irrep labels — common in SU(6) baryon physics.
+  ["$[56]$", "SU(6) [56] multiplet (regression)"],
+  ["$[8]$", "[8] octet label"],
+  ["$[56,0^+]$", "[56,0^+] labelled irrep"],
+  ["$[\\mathbf{56}]$", "[\\mathbf{56}] bold command in brackets"],
 ];
 for (const [src, label] of e2e) {
   check(`${label}: ${src}`, () => katexOf(normalizeMath(src), false));

--- a/desktop/frontend/src/__tests__/math-golden.test.ts
+++ b/desktop/frontend/src/__tests__/math-golden.test.ts
@@ -152,10 +152,10 @@ check("$Spin(3)$", () => isLikelyInlineMath("Spin(3)") === true);
 check("$Diff(M)$", () => isLikelyInlineMath("Diff(M)") === true);
 
 console.log("\nisLikelyInlineMath — currency/link (NOT math)");
-check("$5", () => isLikelyInlineMath("5") === false);
-check("$10", () => isLikelyInlineMath("10") === false);
-check("$10.50", () => isLikelyInlineMath("10.50") === false);
-check("$100%", () => isLikelyInlineMath("100%") === false);
+check("$5", () => isLikelyInlineMath("5") === true);
+check("$10", () => isLikelyInlineMath("10") === true);
+check("$10.50", () => isLikelyInlineMath("10.50") === true);
+check("$100%", () => isLikelyInlineMath("100%") === true);
 check("URL", () => isLikelyInlineMath("https://example.com") === false);
 check("prose text", () => isLikelyInlineMath("hello world today") === false);
 check("prose $x y z$ (spaces)", () => isLikelyInlineMath("x y z") === false);
@@ -176,8 +176,8 @@ console.log("\nisLikelyInlineMath — minimal LaTeX patterns (regression)");
 // classifier rejected as currency / word tokens. These tests pin down the
 // deliberately-permissive rules for common math patterns while keeping pure
 // numeric dollar pairs literal because they are common in prose prices.
-check("single-digit $1$, $2$, $5$ → NOT math (currency-shaped)", () => isLikelyInlineMath("1") === false);
-check("multi-digit $42$ → NOT math (currency-shaped)", () => isLikelyInlineMath("42") === false);
+check("single-digit $1$, $2$, $5$ → NOT math (currency-shaped)", () => isLikelyInlineMath("1") === true);
+check("multi-digit $42$ → NOT math (currency-shaped)", () => isLikelyInlineMath("42") === true);
 check("$2.5x$ is math (number with variable)", () => isLikelyInlineMath("2.5x") === true);
 check("$10\%$ is math (percentage with LaTeX)", () => isLikelyInlineMath("10\\%") === true);
 check("$2.5x dollars$ → NOT math (prefix-only numeric variable)", () => isLikelyInlineMath("2.5x dollars") === false);
@@ -308,11 +308,11 @@ check("digit before $$ is NOT a prose boundary (preserves c^2$$)", () => {
 });
 
 console.log("\nnormalizeMath — non-math dollar filtering");
-eq(normalizeMath("costs $1$ today"), "costs &#36;1&#36; today", "$1$ not math");
+eq(normalizeMath("costs $1$ today"), "costs $1$ today", "$1$ is math (single digit)");
 eq(normalizeMath("env $PATH$ here"), "env &#36;PATH&#36; here", "$PATH$ not math (env var → &#36; entities so remark-math leaves it literal)");
 eq(normalizeMath("solve $x^2 + y^2 = z^2$ please"), "solve $x^2 + y^2 = z^2$ please", "$x^2+y^2$ is math");
 eq(normalizeMath("$\\alpha + \\beta$"), "$\\alpha + \\beta$", "$\\alpha+\\beta$ is math");
-eq(normalizeMath("price is $10.50$ each"), "price is &#36;10.50&#36; each", "$10.50$ not math");
+eq(normalizeMath("price is $10.50$ each"), "price is $10.50$ each", "$10.50$ is math (decimal)");
 eq(normalizeMath("$I$ think"), "$I$ think", "$I$ is math (uppercase single letter)");
 eq(normalizeMath("it costs $5 and $10 total"), "it costs &#36;5 and &#36;10 total", "multiple prose $ → &#36; entities (dollars preserved, not parsed as math)");
 
@@ -384,7 +384,7 @@ check("$\\|x\\|$ norm preserved (no \\vert mangling)", () => {
 
 console.log("\nnormalizeMath — % in math");
 eq(normalizeMath("$x = 50%$"), "$x = 50\\%$", "trailing % escaped");
-eq(normalizeMath("$100%$"), "&#36;100%&#36;", "pure percentage stays literal");
+eq(normalizeMath("$100%$"), "$100\\%$", "pure percentage is math (% escaped)");
 eq(normalizeMath("$10\\%$"), "$10\\%$", "already-escaped \\% left alone");
 
 // ── normalizeMath — end-to-end KaTeX render of common LLM outputs ──────────────
@@ -445,7 +445,7 @@ for (const [src, label] of e2e) {
 console.log("\nnormalizeMath — non-math inputs pass through");
 type Passthrough = { src: string; expected: string; label: string };
 const passthrough: Passthrough[] = [
-  { src: "costs $100$ today", expected: "costs &#36;100&#36; today", label: "multi-digit currency stays literal" },
+  { src: "costs $100$ today", expected: "costs $100$ today", label: "multi-digit number is math" },
   { src: "line break \\\\[4pt] here", expected: "line break \\\\[4pt] here", label: "LaTeX line-break spacing" },
   { src: "hello world", expected: "hello world", label: "plain text" },
 ];

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -13,7 +13,10 @@ export function isLikelyInlineMath(math: string): boolean {
   // Unary plus/minus: +2, -x, +\alpha, - 3.14
   if (/^[+\-]\s*(?:\d+(?:\.\d+)?|[A-Za-z\\])/.test(math)) return true;
 
-  if (/\\[A-Za-z]+\b/.test(math)) return true;
+  // LaTeX command (\alpha, \frac{x}{y}, \tfrac12, …). No \b after the
+  // command name: \tfrac12 / \sqrt2 / \log3 have no word boundary between
+  // the name and a trailing digit, so \b would wrongly reject them.
+  if (/\\[A-Za-z]+/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
   if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
   // Function / group notation: a short identifier (1–6 letters) immediately

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -16,7 +16,14 @@ export function isLikelyInlineMath(math: string): boolean {
   if (/\\[A-Za-z]+\b/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
   if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
-  if (/^[A-Za-z]\s*\([^)]{1,80}\)$/.test(math)) return true;
+  // Function / group notation: a short identifier (1–6 letters) immediately
+  // followed by parenthesised arguments. Single-letter covers f(x), g(x);
+  // multi-letter covers standard group notation such as SO(3,1), SU(2),
+  // SL(2), GL(n), Sp(2n), Spin(n), Diff(M), Hom(A,B) — all of which would
+  // otherwise fall through to the final "single letter" check and be
+  // misclassified as prose. The 6-letter cap and the requirement that the
+  // whole token sits inside one $...$ span keep prose parentheticals out.
+  if (/^[A-Za-z]{1,6}\s*\([^)]{1,80}\)$/.test(math)) return true;
   if (/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[A-Za-z0-9([{\\]/.test(math)) return true;
   // One-sided comparison: < B, > 0, B < — comparison against an implicit
   // operand is common in prose.

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -5,10 +5,11 @@ export function isLikelyInlineMath(math: string): boolean {
   if (/^\d+(?:\.\d+)?[A-Za-z](?:[A-Za-z0-9^_{}]*)?$/.test(math)) return true;
   // Number with LaTeX escape: 10\%, 5\cdot3
   if (/^\d+(?:\.\d+)?\\(?:%|[A-Za-z]+)(?:\{[^{}]*\})?(?:[A-Za-z0-9\\{}^_+\-*/=<>.()]*)$/.test(math)) return true;
-  // Pure numbers, decimals, and percentages are too often currency or
-  // prose percentages to parse as math. More explicit numeric math
-  // forms are accepted above/below: 2.5x, 10\%, +2, x=50%, etc.
-  if (/^\d+(?:\.\d+)?%?$/.test(math)) return false;
+  // Pure numbers (single/multi-digit, optional decimal/percentage) are
+  // math in context (mass eigenvalue $0$, $42$ elements, etc.). Currency
+  // in prose is typically written without the closing $ (costs $5), so
+  // the $N$ form almost always means math.
+  if (/^\d+(?:\.\d+)?%?$/.test(math)) return true;
 
   // Unary plus/minus: +2, -x, +\alpha, - 3.14
   if (/^[+\-]\s*(?:\d+(?:\.\d+)?|[A-Za-z\\])/.test(math)) return true;

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -27,6 +27,12 @@ export function isLikelyInlineMath(math: string): boolean {
   // misclassified as prose. The 6-letter cap and the requirement that the
   // whole token sits inside one $...$ span keep prose parentheticals out.
   if (/^[A-Za-z]{1,6}\s*\([^)]{1,80}\)$/.test(math)) return true;
+  // Permutation cycle notation: (12), (123), (12)(34), (123)(45), … —
+  // one or more parenthesised digit groups with no separating commas.
+  // Without this, $(12)$ falls through every accept rule and is rendered
+  // as a literal dollar span instead of reaching KaTeX. (Comma-separated
+  // tuples like $(1, 2, 3)$ are already accepted by the rule above.)
+  if (/^(?:\(\d+\))+$/.test(math)) return true;
   if (/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[A-Za-z0-9([{\\]/.test(math)) return true;
   // One-sided comparison: < B, > 0, B < — comparison against an implicit
   // operand is common in prose.

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -31,6 +31,11 @@ export function isLikelyInlineMath(math: string): boolean {
   // misclassified as prose. The 6-letter cap and the requirement that the
   // whole token sits inside one $...$ span keep prose parentheticals out.
   if (/^[A-Za-z]{1,6}\s*\([^)]{1,80}\)$/.test(math)) return true;
+  // Primed function call: f'(x), g''(x), L'(t). The prime between the
+  // function name and the argument list is a LaTeX prime symbol, not an
+  // English apostrophe — contractions like "don't" never appear in the
+  // shape letter+'+paren.
+  if (/^[A-Za-z]'{1,}\s*\([^)]{1,80}\)$/.test(math)) return true;
   // Permutation cycle notation: (12), (123), (12)(34), (123)(45), … —
   // one or more parenthesised digit groups with no separating commas.
   // Without this, $(12)$ falls through every accept rule and is rendered
@@ -48,10 +53,25 @@ export function isLikelyInlineMath(math: string): boolean {
   // \alpha, \beta. Currency/env-var usage never looks like this.
   if (/^\(?(?:[A-Za-z0-9]|\\[A-Za-z]+)(?:\s*,\s*(?:[A-Za-z0-9]|\\[A-Za-z]+)){1,10}\)?$/.test(math)) return true;
 
+  // Bracketed label/index: [56], [8], [N], [\mathbf{56}], [56,0^+]. Square
+  // brackets in a $...$ context are math — group-theory irrep labels
+  // ([56] is the SU(6) multiplet), array subscripts, interval notation.
+  // Markdown link syntax [text](url) is already rejected above by the "]("
+  // check, so a bare [content] token is unambiguous.
+  if (/^\[[A-Za-z0-9^_+\-,.\\\s{}]+\]$/.test(math)) return true;
+
   if (/[A-Za-z]\s+[A-Za-z]/.test(math)) return false;
   if (/^[A-Z][A-Z0-9_]{1,}$/.test(math)) return false;
   if (/^v\d+(?:\.\d+)*$/i.test(math)) return false;
   if (/^[A-Za-z]{2,}$/.test(math)) return false;
+
+  // Letter or Greek command followed by one or more primes: x', S', y'',
+  // \psi'. The prime (') is the LaTeX prime symbol — ubiquitous in math
+  // for derivatives, transformed quantities, and labelled states (e.g.
+  // the S' mixed-symmetry baryon). An English word never ends in ' in a
+  // $...$ context, so this is unambiguously math. Placed after the
+  // multi-letter-word rejection so plain prose words stay non-math.
+  if (/^(?:[A-Za-z]|\\[A-Za-z]+)'{1,}$/.test(math)) return true;
 
   // Single letter (a-z, A-Z). Uppercase single letters (S, A, G, …) are
   // common math names (sets, algebras, groups) and $X$ is essentially

--- a/desktop/frontend/src/components/mathClassify.ts
+++ b/desktop/frontend/src/components/mathClassify.ts
@@ -19,6 +19,9 @@ export function isLikelyInlineMath(math: string): boolean {
   // the name and a trailing digit, so \b would wrongly reject them.
   if (/\\[A-Za-z]+/.test(math)) return true;
   if (/[\^_{}|]/.test(math)) return true;
+  // Lone math operators: +, -, =, <, >, ±, ∓. Common in physics prose
+  // ("the sign of $+$", "the $<$ relation"). Must be exactly one operator.
+  if (/^[+\-=<>±∓]$/.test(math)) return true;
   if (/\b(?:alpha|beta|gamma|sum|int|prod|lim|infty|sqrt|frac|sin|cos|tan|log|ln|max|min|partial|nabla|left|right)\b/.test(math)) return true;
   // Function / group notation: a short identifier (1–6 letters) immediately
   // followed by parenthesised arguments. Single-letter covers f(x), g(x);
@@ -34,7 +37,10 @@ export function isLikelyInlineMath(math: string): boolean {
   // as a literal dollar span instead of reaching KaTeX. (Comma-separated
   // tuples like $(1, 2, 3)$ are already accepted by the rule above.)
   if (/^(?:\(\d+\))+$/.test(math)) return true;
-  if (/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[A-Za-z0-9([{\\]/.test(math)) return true;
+  // Binary operator between operands: A = B, x + 1, E = mc^2. The RHS
+  // allows a leading sign ([+\-]?) so that K = -iJ, p = +\alpha,
+  // a = -b are recognised (the sign starts a unary operand).
+  if (/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[+\-]?\s*[A-Za-z0-9([{\\]/.test(math)) return true;
   // One-sided comparison: < B, > 0, B < — comparison against an implicit
   // operand is common in prose.
   if (/^(?:<=?|>=?|≠|≤|≥)\s*[A-Za-z0-9]|[A-Za-z0-9]\s*(?:<=?|>=?|≠|≤|≥)$/.test(math)) return true;

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -67,9 +67,22 @@ function normalizeMathText(s: string): string {
   const escapedDollarToken = unusedEscapedDollarToken(r);
   r = r.split("\\$").join(escapedDollarToken);
 
-  // Step 3: repair inline $$. CommonMark requires a blank line before
-  // block math; without it remark-math parses the opening $$ as an
-  // empty math node and the formula leaks out as literal text.
+  // Step 3: extract well-formed $$…$$ display pairs into placeholders as
+  // a unit, BEFORE the repair regex below can split the closing $$.
+  // (Without this, the repair regex would turn `…x$$` into `…x\n\n$$`,
+  // breaking display math — the d450aec1 regression.) When the opening $$
+  // is glued to preceding prose, insert a blank line before it.
+  r = r.replace(/\$\$([\s\S]*?)\$\$/g, (_m, m, offset, full) => {
+    const prefix = offset > 0 && /[A-Za-z\)\]\>\.。！？,{}]/.test(full[offset - 1])
+      ? "\n\n"
+      : "";
+    return prefix + DM + latexNormalizeForKatex(m) + DM;
+  });
+
+  // Step 3.5: repair any remaining glued $$. After extracting well-formed
+  // $$…$$ pairs above, remaining $$ are orphaned openings (model forgot
+  // the closing $$) or stray double-dollars. Insert a blank line before
+  // them so remark-math recognises a block boundary.
   // Digits are excluded so `c^2$$` inside a formula is left alone.
   // Comma is included so `…D(q^2),$$` (closing $$ on the same line as
   // the trailing content) is repaired: micromark-extension-math only
@@ -86,11 +99,6 @@ function normalizeMathText(s: string): string {
   // converting it to a lone $ would interact badly with the $…$
   // matcher below and wrap whole prose paragraphs in math spans. The
   // right fix is upstream — a post-generation lint or stricter prompt.
-
-  // Step 4: $$…$$ → display placeholders. KaTeX-specific normalisation
-  // runs here so |→\vert (with \| protected) and \text{} escapes both
-  // apply to display math.
-  r = r.replace(/\$\$([\s\S]*?)\$\$/g, (_m, m) => `${DM}${latexNormalizeForKatex(m)}${DM}`);
 
   // Step 5: $\cmd{...}$ pairs where the body may contain a stray $
   // (e.g. $\text{price is $5}$). Recognised first so the inner $ doesn't
@@ -111,10 +119,36 @@ function normalizeMathText(s: string): string {
   });
 
   // Step 7: restore standard $/$$ delimiters for remark-math to parse.
-  return r
-    .replace(new RegExp(DM, "g"), () => "$$")
-    .replace(new RegExp(IM, "g"), "$")
-    .split(escapedDollarToken).join("\\$");
+  // Display math: restore as $$\n...\n$$ so remark-math recognises block
+  // math (it requires $$ on its own line, not glued to content like $$x$$).
+  // Inside a blockquote, the closing $$ must be prefixed with the blockquote
+  // marker (>) so remark-math recognises the fence boundary — otherwise it
+  // swallows the following paragraph as math content.
+  let displayOpen = true;
+  let lastDisplayContext = "";
+  r = r.replace(new RegExp(DM, "g"), (_match, offset, full) => {
+    let delim: string;
+    if (displayOpen) {
+      // Remember the text before this opening $$ so the closing $$ can
+      // detect whether we're inside a blockquote.
+      lastDisplayContext = full.slice(0, offset);
+      delim = "$$\n";
+    } else {
+      // Check if the opening $$ was inside a blockquote: look at the line
+      // the opening $$ was on. If it starts with ">" (possibly preceded by
+      // other > lines), we're in a blockquote and the closing $$ needs a >
+      // prefix for remark-math to recognise the fence.
+      const lastLineStart = lastDisplayContext.lastIndexOf("\n") + 1;
+      const lastLine = lastDisplayContext.slice(lastLineStart);
+      const inBlockquote = /^\s*>/.test(lastLine);
+      delim = inBlockquote ? "\n> $$" : "\n$$";
+    }
+    displayOpen = !displayOpen;
+    return delim;
+  });
+  r = r.replace(new RegExp(IM, "g"), "$");
+  // Restore escaped dollars (hidden before the $...$ classifier passes).
+  return r.split(escapedDollarToken).join("\\$");
 }
 
 function unusedEscapedDollarToken(s: string): string {

--- a/desktop/frontend/src/components/mathNormalize.ts
+++ b/desktop/frontend/src/components/mathNormalize.ts
@@ -121,27 +121,35 @@ function normalizeMathText(s: string): string {
   // Step 7: restore standard $/$$ delimiters for remark-math to parse.
   // Display math: restore as $$\n...\n$$ so remark-math recognises block
   // math (it requires $$ on its own line, not glued to content like $$x$$).
-  // Inside a blockquote, the closing $$ must be prefixed with the blockquote
-  // marker (>) so remark-math recognises the fence boundary — otherwise it
-  // swallows the following paragraph as math content.
+  //
+  // Blockquote workaround: remark-math has a known limitation where multi-line
+  // $$...$$ display math inside a Markdown blockquote (>) breaks inline math
+  // parsing on subsequent blockquote lines. To avoid this, when display math
+  // is detected inside a blockquote, we close the blockquote before the
+  // display math and reopen it after — putting the math outside the quote.
   let displayOpen = true;
-  let lastDisplayContext = "";
+  let lastDisplayInBlockquote = false;
   r = r.replace(new RegExp(DM, "g"), (_match, offset, full) => {
     let delim: string;
     if (displayOpen) {
-      // Remember the text before this opening $$ so the closing $$ can
-      // detect whether we're inside a blockquote.
-      lastDisplayContext = full.slice(0, offset);
-      delim = "$$\n";
+      // Detect blockquote: check the line the opening $$ was on
+      const before = full.slice(0, offset);
+      const lastLineStart = before.lastIndexOf("\n") + 1;
+      const lastLine = before.slice(lastLineStart);
+      lastDisplayInBlockquote = /^\s*>/.test(lastLine);
+      if (lastDisplayInBlockquote) {
+        // Close the blockquote before the display math
+        delim = "\n\n$$\n";
+      } else {
+        delim = "$$\n";
+      }
     } else {
-      // Check if the opening $$ was inside a blockquote: look at the line
-      // the opening $$ was on. If it starts with ">" (possibly preceded by
-      // other > lines), we're in a blockquote and the closing $$ needs a >
-      // prefix for remark-math to recognise the fence.
-      const lastLineStart = lastDisplayContext.lastIndexOf("\n") + 1;
-      const lastLine = lastDisplayContext.slice(lastLineStart);
-      const inBlockquote = /^\s*>/.test(lastLine);
-      delim = inBlockquote ? "\n> $$" : "\n$$";
+      if (lastDisplayInBlockquote) {
+        // Reopen the blockquote after the display math
+        delim = "\n$$\n\n> ";
+      } else {
+        delim = "\n$$";
+      }
     }
     displayOpen = !displayOpen;
     return delim;


### PR DESCRIPTION
# Fix: inline-math classifier gaps + display-math/blockquote rendering bugs

## Overview

This PR fixes **ten** rendering bugs in the math pipeline — eight in the inline-math classifier (`mathClassify.ts`) and two in the display-math pre-pass (`mathNormalize.ts`). All ten produce visible KaTeX failures (red error blocks or raw `$...$` text / literal `$` signs) in LLM chat output.

Each classifier gap has the same root cause: `isLikelyInlineMath()` returns `false` for a legitimate math token, so `normalizeMath` rewrites `$token$` → `&#36;token&#36;` (literal dollar HTML entities) and the token never reaches KaTeX.

---

## Classifier fixes (`mathClassify.ts`)

### 1. LaTeX command immediately followed by a digit — `$\tfrac12$`, `$\sqrt2$`, `$\log3$`

```js
// Before (bug): \b is a word boundary, but \tfrac12 has no boundary
// between "tfrac" and "12" — both are word characters.
if (/\\[A-Za-z]+\b/.test(math)) return true;
// After (fix):
if (/\\[A-Za-z]+/.test(math)) return true;
```

### 2. Multi-letter group notation — `$SO(3,1)$`, `$SU(2)$`, `$SL(2)$`, `$GL(n)$`

```js
// Before (bug): only single-letter names accepted (f(x), g(x))
if (/^[A-Za-z]\s*\([^)]{1,80}\)$/.test(math)) return true;
// After (fix): 1–6 letter identifiers
if (/^[A-Za-z]{1,6}\s*\([^)]{1,80}\)$/.test(math)) return true;
```

### 3. Permutation cycle notation — `$(12)$`, `$(123)$`, `$(12)(34)$`

```js
// New rule: one or more parenthesised all-digit groups
if (/^(?:\(\d+\))+$/.test(math)) return true;
```

### 4. Pure numbers rejected — `$0$`, `$1$`, `$42$`

The classifier rejected all pure numbers (`return false`) to avoid `$5` currency false-positives. But `$0$` (mass eigenvalue), `$1$`, `$42$` are extremely common in math/physics and rendered as literal dollar signs.

```js
// Before (bug): rejects ALL pure numbers
if (/^\d+(?:\.\d+)?%?$/.test(math)) return false;
// After (fix): currency is almost always written WITHOUT a closing $
// ("costs $5", not "costs $5$"), so the $N$ form almost always means math.
if (/^\d+(?:\.\d+)?%?$/.test(math)) return true;
```

Unpaired currency (`$5` with no closing `$`) is still correctly treated as literal text by the `$...$` pairing logic, so "costs $5 and $6" is unaffected.

### 5. Binary operator with signed RHS — `$K = -iJ$`, `$p = +\alpha$`

The binary-operator regex required an operand character (`[A-Za-z0-9...]`) immediately after the operator, but `-` was not in that class — so `= -` (operator followed by a unary sign) failed to match. This rejected common physics expressions like `$K = -iJ$`, `$a = -b$`, `$p = +\alpha$`.

```js
// Before (bug): K = -iJ fails (no operand right after =)
/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[A-Za-z0-9([{\\]/
// After (fix):  allows an optional sign before the RHS operand
/[A-Za-z0-9)\]}]\s*[+\-*/=<>]\s*[+\-]?\s*[A-Za-z0-9([{\\]/
```

### 6. Lone operators — `$+$`, `$-$`, `$=$`, `$<$`

Single-character operator tokens (`+`, `-`, `=`, `<`, `>`, `±`, `∓`) matched no accept rule and were rendered as literal text. These are common in physics prose ("the sign of `$+$`", "the `$<$` relation").

```js
if (/^[+\-=<>±∓]$/.test(math)) return true;
```

### 7. Primed letters — `$S'$`, `$x'$`, `$y''$`, `$f'(x)$`

A letter or Greek command followed by one or more primes matched no rule and fell through to the final `/^[A-Za-z]$/` check (which requires exactly one letter), so primed tokens were escaped to literal dollars. The prime (`'`) is the LaTeX prime symbol — ubiquitous for derivatives, transformed quantities, and labelled states (e.g. the **S′** mixed-symmetry baryon in SU(6) physics).

```js
// New rules:
/^[A-Za-z]'{1,}\s*\([^)]{1,80}\)$/          // primed function call: f'(x), g''(t)
/^(?:[A-Za-z]|\\[A-Za-z]+)'{1,}$/           // letter/Greek + primes: x', S', y'', \psi'
```

### 8. Bracketed irrep labels — `$[56]$`, `$[8]$`, `$[56,0^+]$`

Square brackets in a `$...$` context denote group-theory irrep labels (`[56]` is the SU(6) multiplet), array subscripts, and interval notation. Pure bracketed numbers/letters matched no rule and were escaped. Markdown-link syntax `[text](url)` is already rejected upstream by the `](` guard (top of the function), so a bare `[content]` token is unambiguous.

```js
// New rule: [56], [8], [N], [\mathbf{56}], [56,0^+]
/^\[[A-Za-z0-9^_+\-,.\\\s{}]+\]$/.test(math)
```

---

## Display-math fixes (`mathNormalize.ts`)

### 9. Repair-before-extraction ordering — closing `$$` split off

The repair regex (which inserts `\n\n` before glued `$$`) ran **before** the display-pair extraction. So it split the closing `$$` of well-formed pairs like `\end{pmatrix}$$` or `> $$x$$`, breaking display math.

**Fix:** extract `$$…$$` pairs as a unit **first**, then repair only remaining orphaned `$$`. This is the `d450aec1` ordering fix applied to current main-v2.

### 10. Blockquote display-math fence — `remark-math` upstream limitation

`remark-math` has a known limitation: multi-line `$$...$$` display math inside a Markdown blockquote (`>`) breaks inline math parsing on subsequent blockquote lines. The closing fence isn't recognised and inline `$...$` after the display block gets swallowed.

**Fix:** when display math is detected inside a blockquote, `normalizeMath` closes the blockquote before the display math (`\n\n$$\n...\n$$\n\n> `) and reopens it after. This puts the math outside the quote, avoiding the remark-math fence bug entirely while preserving the visual blockquote structure.

---

## Verification

| Check | Result |
|---|---|
| math-golden suite | **242/242** (was 189, +53 regression tests across all fixes) |
| Typecheck | 0 errors in touched files (`bridge.ts` error is pre-existing on base) |
| `$\tfrac12$`, `$\sqrt2$`, `$\log3$` | ✅ now renders |
| `$SO(3,1)$`, `$SU(2)$`, `$SL(2)$`, `$GL(n)$` | ✅ now renders |
| `$(12)$`, `$(123)$`, `$(12)(34)$` | ✅ now renders |
| `$0$`, `$1$`, `$42$` | ✅ now renders |
| `$K = -iJ$`, `$p = +\alpha$` | ✅ now renders |
| `$+$`, `$-$`, `$=$`, `$<$` | ✅ now renders |
| `$S'$`, `$x'$`, `$y''$`, `$f'(x)$`, `$\psi'$` | ✅ now renders |
| `$[56]$`, `$[8]$`, `$[70]$`, `$[56,0^+]$`, `$[\mathbf{56}]$` | ✅ now renders |
| `the apples cost $5 and $6.` (unpaired currency) | ✅ stays literal (no false-positive) |
| markdown link `[text](url)` | ✅ still a link, not math |
| Haar theorem blockquote (display + inline) | ✅ 0 errors |
| Mackey theorem blockquote (display + inline after) | ✅ 0 errors |
| `$$\end{pmatrix}$$` (closing brace) | ✅ closing `$$` preserved |
| `$PATH$`, `costs $5` (unpaired) | ✅ still literal |

## Files changed

| File | Change |
|---|---|
| `desktop/frontend/src/components/mathClassify.ts` | Drop `\b`; broaden function-call rule to 1–6 letters; add cycle-notation, primed-letter, primed-function-call, and bracketed-label rules; accept pure numbers; signed RHS in binary-op rule; lone operators |
| `desktop/frontend/src/components/mathNormalize.ts` | Extract `$$…$$` before repair regex; newline-delimited DM restore; blockquote-aware closing (break quote around display math) |
| `desktop/frontend/src/__tests__/math-golden.test.ts` | +53 regression tests across all 10 fixes |

## Commits

- `792df63c` — multi-letter group notation (`SO(3,1)`, `SU(2)`, …) classified as inline math
- `6c64bc91` — classify LaTeX commands followed by a digit (`\tfrac12`, `\sqrt2`) as math
- `e7c0254f` — render permutation cycle notation like `(12)` as inline math
- `2b050155` — classify pure numbers (`$0$`, `$1$`, `$42$`) as inline math
- `7ceeebfa` — classify operators with signed RHS (`$K = -iJ$`) and lone operators (`$+$`)
- `6f7ef086` — repair display-math extraction ordering + blockquote `$$` closing
- `84e6ac81` — break blockquote around display math to avoid remark-math fence bug
- `d29b963b` — classify primed letters (`$S'$`) and bracketed irrep labels (`$[56]$`) as math
