### PR TITLE
增强后台 job 健壮性与可观测性

### DIFF
--- a/internal/agent/subagent_store.go
+++ b/internal/agent/subagent_store.go
@@ -21,9 +21,10 @@ import (
 type SubagentStatus string
 
 const (
-	SubagentRunning   SubagentStatus = "running"
-	SubagentCompleted SubagentStatus = "completed"
-	SubagentFailed    SubagentStatus = "failed"
+	SubagentRunning     SubagentStatus = "running"
+	SubagentCompleted   SubagentStatus = "completed"
+	SubagentFailed      SubagentStatus = "failed"
+	SubagentInterrupted SubagentStatus = "interrupted"
 )
 
 // SubagentMeta is the sidecar for a persisted sub-agent transcript. It captures
@@ -183,6 +184,47 @@ func DeleteSubagentsByParent(sessionDir, parentSession string) error {
 		}
 	}
 	return nil
+}
+
+// CleanupStaleRunning marks persisted running sub-agents as interrupted. It is
+// intended for startup, before this process accepts new background sub-agent
+// work, so a previous crash cannot leave ghost "running" refs behind.
+func (s *SubagentStore) CleanupStaleRunning() (int, error) {
+	if s == nil {
+		return 0, nil
+	}
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	now := time.Now().UTC()
+	cleaned := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".meta.json") {
+			continue
+		}
+		ref := strings.TrimSuffix(entry.Name(), ".meta.json")
+		if !validSubagentRef(ref) {
+			continue
+		}
+		meta, err := s.LoadMeta(ref)
+		if err != nil {
+			return cleaned, err
+		}
+		if meta.Status != SubagentRunning {
+			continue
+		}
+		meta.Status = SubagentInterrupted
+		meta.UpdatedAt = now
+		if err := s.saveMeta(meta); err != nil {
+			return cleaned, err
+		}
+		cleaned++
+	}
+	return cleaned, nil
 }
 
 func (s *SubagentStore) PrepareFresh(spec SubagentSpec) (*SubagentRun, error) {
@@ -383,6 +425,9 @@ func validateMeta(meta SubagentMeta, spec SubagentSpec) error {
 	}
 	if meta.Status == SubagentFailed {
 		return fmt.Errorf("subagent reference %q failed and cannot be continued", meta.Ref)
+	}
+	if meta.Status == SubagentInterrupted {
+		return fmt.Errorf("subagent reference %q was interrupted by a previous shutdown or crash and cannot be continued or forked; run a fresh subagent instead", meta.Ref)
 	}
 	want := metaFromSpec(meta.Ref, meta.Status, meta.CreatedAt, meta.UpdatedAt, spec)
 	switch {

--- a/internal/agent/subagent_store_test.go
+++ b/internal/agent/subagent_store_test.go
@@ -332,6 +332,42 @@ func TestSubagentStoreSaveFailedPersistsTranscriptAndRejectsReuse(t *testing.T) 
 	}
 }
 
+func TestSubagentStoreCleanupStaleRunningMarksInterrupted(t *testing.T) {
+	store := NewSubagentStore(t.TempDir())
+	spec := testSubagentSpec(t, "review")
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	run.Session.Add(provider.Message{Role: provider.RoleUser, Content: "interrupted prompt"})
+	if err := store.MarkRunning(run); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+	ref := run.Ref
+	run.Release()
+
+	cleaned, err := store.CleanupStaleRunning()
+	if err != nil {
+		t.Fatalf("CleanupStaleRunning: %v", err)
+	}
+	if cleaned != 1 {
+		t.Fatalf("cleaned = %d, want 1", cleaned)
+	}
+	meta, err := store.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != SubagentInterrupted {
+		t.Fatalf("status = %q, want interrupted", meta.Status)
+	}
+	if _, err := store.PrepareContinue(ref, spec); err == nil || !strings.Contains(err.Error(), "interrupted by a previous shutdown or crash") {
+		t.Fatalf("PrepareContinue error = %v, want interrupted rejection", err)
+	}
+	if _, err := store.PrepareFork(ref, spec); err == nil || !strings.Contains(err.Error(), "cannot be continued or forked") {
+		t.Fatalf("PrepareFork error = %v, want interrupted fork rejection", err)
+	}
+}
+
 func TestSubagentStoreSkipsSaveForDestroyedParent(t *testing.T) {
 	store := NewSubagentStore(t.TempDir()).WithDestroyedChecker(func(parentSession string) bool {
 		return parentSession == "parent-session"

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"strings"
 
 	"reasonix/internal/event"
@@ -248,8 +249,15 @@ func (t *TaskTool) Execute(ctx context.Context, args json.RawMessage) (string, e
 				return "", err
 			}
 		}
-		job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (string, error) {
+		job := jm.StartForSession(jobs.SessionFromContext(ctx), "task", label, func(jobCtx context.Context, _ io.Writer) (result string, err error) {
 			defer run.Release()
+			defer func() {
+				if r := recover(); r != nil {
+					panicErr := fmt.Errorf("internal error: panic: %v\n%s", r, debug.Stack())
+					result = FormatSubagentResult("", run.Ref, true)
+					err = errors.Join(panicErr, t.transcripts.SaveFailed(run))
+				}
+			}()
 			answer, err := t.runSubSession(jobCtx, p.Prompt, subReg, nested, maxSteps, prov, pricing, ctxWin, run.Session)
 			if err != nil {
 				return FormatSubagentResult("", run.Ref, true), errors.Join(err, t.transcripts.SaveFailed(run))

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -316,6 +317,43 @@ func TestTaskToolFailedForegroundContinuationPersistsAndRejectsReuse(t *testing.
 	}
 }
 
+func TestTaskToolBackgroundPanicPersistsFailedMetadata(t *testing.T) {
+	sub := panicProvider{name: "panic-sub"}
+	store := NewSubagentStore(t.TempDir())
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	task := NewTaskTool(sub, nil, reg, 20, 0, 0, 0, 0, 0.0, "", "sys", nil, "", "", nil).
+		WithTranscripts(store, t.TempDir(), "base-model", "base-effort")
+
+	jm := jobs.NewManager(event.Discard)
+	defer jm.Close()
+	ctx := testTaskContext()
+	ctx = jobs.WithSession(ctx, "parent-session")
+	ctx = jobs.WithManager(ctx, jm)
+	out, err := task.Execute(ctx, []byte(`{"prompt":"panic task","run_in_background":true}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	ref := subagentRefFromOutput(t, out)
+	res := jm.Wait(context.Background(), nil, 5)
+	if len(res) != 1 || res[0].Status != jobs.Failed {
+		t.Fatalf("background job result = %+v, want failed", res)
+	}
+	if !strings.Contains(res[0].Output, "Subagent reference (failed): "+ref) {
+		t.Fatalf("job output = %q, want failed subagent ref %s", res[0].Output, ref)
+	}
+	meta, err := store.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != SubagentFailed {
+		t.Fatalf("status = %q, want failed", meta.Status)
+	}
+	if _, err := task.Execute(testTaskContext(), []byte(`{"prompt":"again","continue_from":"`+ref+`"}`)); err == nil || !strings.Contains(err.Error(), "failed and cannot be continued") {
+		t.Fatalf("reuse error = %v, want failed continuation rejection", err)
+	}
+}
+
 func TestTaskToolRejectsMismatchedContinuationProfile(t *testing.T) {
 	sub := &mockProvider{name: "sub", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "answer"},
@@ -365,4 +403,12 @@ func newTestTaskTool(t *testing.T, prov provider.Provider, reg *tool.Registry, s
 	t.Helper()
 	return NewTaskTool(prov, nil, reg, 20, 0, 0, 0, 0, 0.0, "", sysPrompt, nil, subagentModel, subagentEffort, resolve).
 		WithTranscripts(NewSubagentStore(t.TempDir()), t.TempDir(), "base-model", "base-effort")
+}
+
+type panicProvider struct{ name string }
+
+func (p panicProvider) Name() string { return p.name }
+
+func (p panicProvider) Stream(context.Context, provider.Request) (<-chan provider.Chunk, error) {
+	panic("subagent boom")
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -429,7 +429,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if opts.MaxSteps > 0 {
 		maxSteps = opts.MaxSteps
 	}
-	subagentStore := newSubagentStore(sessionDir)
+	subagentStore, err := newSubagentStore(sessionDir)
+	if err != nil {
+		return nil, err
+	}
 	if subagentStore != nil {
 		subagentStore.WithDestroyedChecker(jm.IsDestroying)
 	}
@@ -1114,12 +1117,16 @@ func isGitMarker(path string) bool {
 	return err == nil && (fi.IsDir() || fi.Mode().IsRegular())
 }
 
-func newSubagentStore(sessionDir string) *agent.SubagentStore {
+func newSubagentStore(sessionDir string) (*agent.SubagentStore, error) {
 	sessionDir = strings.TrimSpace(sessionDir)
 	if sessionDir == "" {
-		return nil
+		return nil, nil
 	}
-	return agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	store := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	if _, err := store.CleanupStaleRunning(); err != nil {
+		return nil, fmt.Errorf("cleanup stale subagents: %w", err)
+	}
+	return store, nil
 }
 
 func subagentEffectiveIdentity(cfg *config.Config, baseModelRef string, base *config.ProviderEntry, modelRef, effort string) (string, string) {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -147,7 +147,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if !opts.RequireKey && entry.APIKeyEnv != "" && entry.APIKey() == "" {
 		sink.Emit(event.Event{Kind: event.Notice, Text: fmt.Sprintf("model %q is selected but its API key %s is not set — requests will fail until you set it", modelName, entry.APIKeyEnv)})
 	}
-	jm := jobs.NewManager(sink)
+	jm := jobs.NewManager(sink, jobs.WithStalledWarningAfter(time.Duration(cfg.BackgroundJobStalledWarningSeconds())*time.Second))
 	sessionDir := opts.SessionDir
 	if sessionDir == "" {
 		sessionDir = config.SessionDir()

--- a/internal/boot/subagent_model_test.go
+++ b/internal/boot/subagent_model_test.go
@@ -1,10 +1,13 @@
 package boot
 
 import (
+	"path/filepath"
 	"testing"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/skill"
+	"reasonix/internal/tool"
 )
 
 func TestSubagentModelRefUsesConfiguredDefault(t *testing.T) {
@@ -117,10 +120,54 @@ func TestSubagentEffectiveIdentityUsesResolvedModelAndEffort(t *testing.T) {
 }
 
 func TestNewSubagentStoreRequiresSessionDir(t *testing.T) {
-	if got := newSubagentStore(""); got != nil {
+	if got, err := newSubagentStore(""); err != nil || got != nil {
+		if err != nil {
+			t.Fatalf("empty session dir error = %v", err)
+		}
 		t.Fatalf("empty session dir should disable subagent store, got %#v", got)
 	}
-	if got := newSubagentStore(t.TempDir()); got == nil {
+	if got, err := newSubagentStore(t.TempDir()); err != nil || got == nil {
+		if err != nil {
+			t.Fatalf("non-empty session dir error = %v", err)
+		}
 		t.Fatal("non-empty session dir should create subagent store")
+	}
+}
+
+func TestNewSubagentStoreCleansStaleRunningRefs(t *testing.T) {
+	sessionDir := t.TempDir()
+	store := agent.NewSubagentStore(filepath.Join(sessionDir, "subagents"))
+	spec := agent.SubagentSpec{
+		Kind:          "task",
+		Name:          "task",
+		WorkspaceRoot: t.TempDir(),
+		ParentSession: "parent-session",
+		SystemPrompt:  "sys",
+		Registry:      tool.NewRegistry(),
+		Model:         "base-model",
+	}
+	run, err := store.PrepareFresh(spec)
+	if err != nil {
+		t.Fatalf("PrepareFresh: %v", err)
+	}
+	if err := store.MarkRunning(run); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+	ref := run.Ref
+	run.Release()
+
+	got, err := newSubagentStore(sessionDir)
+	if err != nil {
+		t.Fatalf("newSubagentStore: %v", err)
+	}
+	if got == nil {
+		t.Fatal("newSubagentStore returned nil")
+	}
+	meta, err := got.LoadMeta(ref)
+	if err != nil {
+		t.Fatalf("LoadMeta: %v", err)
+	}
+	if meta.Status != agent.SubagentInterrupted {
+		t.Fatalf("status = %q, want interrupted", meta.Status)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1058,13 +1058,18 @@ func clonePricing(p *provider.Pricing) *provider.Pricing {
 
 // ToolsConfig selects which built-in tools are enabled. Empty means all of them.
 type ToolsConfig struct {
-	Enabled            []string     `toml:"enabled"`
-	BashTimeoutSeconds *int         `toml:"bash_timeout_seconds"`
-	Search             SearchConfig `toml:"search"`
-	Shell              ShellConfig  `toml:"shell"`
+	Enabled            []string             `toml:"enabled"`
+	BashTimeoutSeconds *int                 `toml:"bash_timeout_seconds"`
+	BackgroundJobs     BackgroundJobsConfig `toml:"background_jobs"`
+	Search             SearchConfig         `toml:"search"`
+	Shell              ShellConfig          `toml:"shell"`
 }
 
-const defaultBashTimeoutSeconds = 120
+const (
+	defaultBashTimeoutSeconds             = 120
+	defaultBackgroundJobStalledWarningSec = 900
+	maxBackgroundJobStalledWarningSec     = 86400
+)
 
 // BashTimeoutSeconds returns the foreground bash timeout in seconds. An omitted
 // config keeps the historical 120s safety cap, explicit 0 disables the
@@ -1075,6 +1080,25 @@ func (c *Config) BashTimeoutSeconds() int {
 		return defaultBashTimeoutSeconds
 	}
 	return *c.Tools.BashTimeoutSeconds
+}
+
+// BackgroundJobsConfig tunes parent-created background jobs.
+type BackgroundJobsConfig struct {
+	StalledWarningSeconds *int `toml:"stalled_warning_seconds"`
+}
+
+// BackgroundJobStalledWarningSeconds returns the stalled warning threshold in
+// seconds. Omitted/negative values keep the default, explicit 0 disables the
+// notice, and oversized values clamp to one day so a typo cannot become
+// effectively invisible.
+func (c *Config) BackgroundJobStalledWarningSeconds() int {
+	if c.Tools.BackgroundJobs.StalledWarningSeconds == nil || *c.Tools.BackgroundJobs.StalledWarningSeconds < 0 {
+		return defaultBackgroundJobStalledWarningSec
+	}
+	if *c.Tools.BackgroundJobs.StalledWarningSeconds > maxBackgroundJobStalledWarningSec {
+		return maxBackgroundJobStalledWarningSec
+	}
+	return *c.Tools.BackgroundJobs.StalledWarningSeconds
 }
 
 // SearchConfig tunes the grep tool's engine. Engine is "auto" (default — use

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -299,6 +299,9 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 	}
 	fmt.Fprintf(&b, "bash_timeout_seconds = %d   # foreground safety cap; set 0 for no tool-local cap\n\n", c.BashTimeoutSeconds())
 
+	b.WriteString("[tools.background_jobs]\n")
+	fmt.Fprintf(&b, "stalled_warning_seconds = %d   # warn once per background job after this many quiet seconds; 0 disables\n\n", c.BackgroundJobStalledWarningSeconds())
+
 	b.WriteString("[codegraph]\n")
 	fmt.Fprintf(&b, "enabled      = %v   # built-in MCP server; off by default for first-run sessions\n", c.Codegraph.Enabled)
 	fmt.Fprintf(&b, "auto_install = %v   # fetch the runtime when CodeGraph is enabled but missing\n", c.Codegraph.AutoInstall)

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -73,6 +73,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Agent.SubagentModel = "mimo-pro"
 	orig.Agent.SubagentModels = map[string]string{"review": "deepseek-pro"}
 	orig.Tools.BashTimeoutSeconds = intPtr(900)
+	orig.Tools.BackgroundJobs.StalledWarningSeconds = intPtr(30)
 	orig.Permissions = PermissionsConfig{
 		Mode:  "deny",
 		Deny:  []string{"Bash(rm -rf*)"},
@@ -271,6 +272,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Tools.BashTimeoutSeconds == nil || *got.Tools.BashTimeoutSeconds != 900 {
 		t.Errorf("tools.bash_timeout_seconds = %v, want 900", got.Tools.BashTimeoutSeconds)
+	}
+	if got.Tools.BackgroundJobs.StalledWarningSeconds == nil || *got.Tools.BackgroundJobs.StalledWarningSeconds != 30 {
+		t.Errorf("tools.background_jobs.stalled_warning_seconds = %v, want 30", got.Tools.BackgroundJobs.StalledWarningSeconds)
 	}
 	if g, _ := got.Provider("mimo-pro"); g == nil || g.BaseURL != "http://localhost:8000/v1" || g.ReasoningProtocol != "openai" {
 		t.Errorf("mimo-pro base_url not preserved: %+v", g)

--- a/internal/config/tools_test.go
+++ b/internal/config/tools_test.go
@@ -44,3 +44,46 @@ func TestBashTimeoutSecondsFallsBackForNegative(t *testing.T) {
 		t.Fatalf("BashTimeoutSeconds() = %d, want 120", got)
 	}
 }
+
+func TestBackgroundJobStalledWarningSecondsDefault(t *testing.T) {
+	cfg := Default()
+	if cfg.Tools.BackgroundJobs.StalledWarningSeconds != nil {
+		t.Fatalf("default raw stalled warning = %v, want nil", *cfg.Tools.BackgroundJobs.StalledWarningSeconds)
+	}
+	if got := cfg.BackgroundJobStalledWarningSeconds(); got != 900 {
+		t.Fatalf("BackgroundJobStalledWarningSeconds() = %d, want 900", got)
+	}
+}
+
+func TestBackgroundJobStalledWarningSecondsAllowsExplicitZero(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.BackgroundJobs.StalledWarningSeconds = intPtr(0)
+	if got := cfg.BackgroundJobStalledWarningSeconds(); got != 0 {
+		t.Fatalf("BackgroundJobStalledWarningSeconds() = %d, want 0", got)
+	}
+}
+
+func TestBackgroundJobStalledWarningSecondsParsesExplicitZero(t *testing.T) {
+	cfg := Default()
+	if _, err := toml.Decode("[tools.background_jobs]\nstalled_warning_seconds = 0\n", cfg); err != nil {
+		t.Fatalf("decode explicit zero: %v", err)
+	}
+	if cfg.Tools.BackgroundJobs.StalledWarningSeconds == nil {
+		t.Fatal("explicit zero decoded as nil")
+	}
+	if got := cfg.BackgroundJobStalledWarningSeconds(); got != 0 {
+		t.Fatalf("BackgroundJobStalledWarningSeconds() = %d, want 0", got)
+	}
+}
+
+func TestBackgroundJobStalledWarningSecondsBounds(t *testing.T) {
+	cfg := Default()
+	cfg.Tools.BackgroundJobs.StalledWarningSeconds = intPtr(-1)
+	if got := cfg.BackgroundJobStalledWarningSeconds(); got != 900 {
+		t.Fatalf("negative BackgroundJobStalledWarningSeconds() = %d, want 900", got)
+	}
+	cfg.Tools.BackgroundJobs.StalledWarningSeconds = intPtr(90000)
+	if got := cfg.BackgroundJobStalledWarningSeconds(); got != 86400 {
+		t.Fatalf("oversized BackgroundJobStalledWarningSeconds() = %d, want 86400", got)
+	}
+}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -62,17 +62,18 @@ type Job struct {
 	Label     string
 	SessionID string
 
-	mu         sync.Mutex
-	buf        bytes.Buffer
-	readOffset int
-	status     Status
-	result     string
-	resultRead bool // result already surfaced by Output (task jobs stream nothing to buf)
-	startedAt  int64
-	activityAt int64
-	cancel     context.CancelFunc
-	done       chan struct{}
-	stalled    bool
+	mu          sync.Mutex
+	buf         bytes.Buffer
+	readOffset  int
+	status      Status
+	result      string
+	resultRead  bool // result already surfaced by Output (task jobs stream nothing to buf)
+	startedAt   int64
+	activityAt  int64
+	runReturned bool
+	cancel      context.CancelFunc
+	done        chan struct{}
+	stalled     bool
 }
 
 // Manager is the session's background-job table. It is safe for concurrent use.
@@ -172,6 +173,9 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 	go func() {
 		defer m.wg.Done()
 		result, err := runRecovered(ctx, jobWriter{j}, run)
+		j.mu.Lock()
+		j.runReturned = true
+		j.mu.Unlock()
 
 		var st Status
 		switch {
@@ -223,7 +227,7 @@ func (m *Manager) monitorStalled(parentSession string, j *Job) {
 			return
 		case <-timer.C:
 			j.mu.Lock()
-			if j.status != Running {
+			if j.runReturned || j.status != Running {
 				j.mu.Unlock()
 				return
 			}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -68,8 +69,10 @@ type Job struct {
 	result     string
 	resultRead bool // result already surfaced by Output (task jobs stream nothing to buf)
 	startedAt  int64
+	activityAt int64
 	cancel     context.CancelFunc
 	done       chan struct{}
+	stalled    bool
 }
 
 // Manager is the session's background-job table. It is safe for concurrent use.
@@ -86,6 +89,8 @@ type Manager struct {
 	completed  []completion // finished-job summaries awaiting drain into the next turn
 	active     string
 	destroying map[string]bool
+
+	stalledWarning time.Duration
 }
 
 type completion struct {
@@ -93,15 +98,34 @@ type completion struct {
 	text      string
 }
 
+// Option configures a Manager.
+type Option func(*Manager)
+
+// WithStalledWarningAfter enables one stalled warning per job after d without
+// job-owned visible output. A non-positive duration disables stalled warnings.
+func WithStalledWarningAfter(d time.Duration) Option {
+	return func(m *Manager) {
+		if d > 0 {
+			m.stalledWarning = d
+		}
+	}
+}
+
 // NewManager returns a Manager whose jobs run under a fresh session-scoped
 // context (cancelled by Close). sink receives job-lifecycle notices; pass the
 // session's synchronized sink (event.Sync) since jobs emit from goroutines.
-func NewManager(sink event.Sink) *Manager {
+func NewManager(sink event.Sink, opts ...Option) *Manager {
 	if nilutil.IsNil(sink) {
 		sink = event.Discard
 	}
 	root, cancel := context.WithCancel(context.Background())
-	return &Manager{sink: sink, root: root, cancel: cancel, jobs: map[string]*Job{}, destroying: map[string]bool{}}
+	m := &Manager{sink: sink, root: root, cancel: cancel, jobs: map[string]*Job{}, destroying: map[string]bool{}}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(m)
+		}
+	}
+	return m
 }
 
 // jobWriter appends a job's streamed output under its lock so a concurrent
@@ -111,6 +135,7 @@ type jobWriter struct{ j *Job }
 func (w jobWriter) Write(p []byte) (int, error) {
 	w.j.mu.Lock()
 	defer w.j.mu.Unlock()
+	w.j.activityAt = nowMs()
 	return w.j.buf.Write(p)
 }
 
@@ -131,7 +156,8 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 	m.seq++
 	id := fmt.Sprintf("%s-%d", kind, m.seq)
 	ctx, cancel := context.WithCancel(m.root)
-	j := &Job{ID: id, Kind: kind, Label: label, SessionID: parentSession, status: Running, startedAt: nowMs(), cancel: cancel, done: make(chan struct{})}
+	startedAt := nowMs()
+	j := &Job{ID: id, Kind: kind, Label: label, SessionID: parentSession, status: Running, startedAt: startedAt, activityAt: startedAt, cancel: cancel, done: make(chan struct{})}
 	m.jobs[id] = j
 	m.order = append(m.order, id)
 	m.mu.Unlock()
@@ -139,9 +165,13 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 	m.emitIfActive(parentSession, event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: startedText(kind, id, label)})
 
 	m.wg.Add(1)
+	if m.stalledWarning > 0 {
+		m.wg.Add(1)
+		go m.monitorStalled(parentSession, j)
+	}
 	go func() {
 		defer m.wg.Done()
-		result, err := run(ctx, jobWriter{j})
+		result, err := runRecovered(ctx, jobWriter{j}, run)
 
 		var st Status
 		switch {
@@ -172,6 +202,46 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		close(j.done)
 	}()
 	return j
+}
+
+func runRecovered(ctx context.Context, out io.Writer, run func(context.Context, io.Writer) (string, error)) (result string, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("internal error: panic: %v\n%s", r, debug.Stack())
+		}
+	}()
+	return run(ctx, out)
+}
+
+func (m *Manager) monitorStalled(parentSession string, j *Job) {
+	defer m.wg.Done()
+	timer := time.NewTimer(m.stalledWarning)
+	defer timer.Stop()
+	for {
+		select {
+		case <-j.done:
+			return
+		case <-timer.C:
+			j.mu.Lock()
+			if j.status != Running {
+				j.mu.Unlock()
+				return
+			}
+			idle := time.Since(time.UnixMilli(j.activityAt))
+			if idle >= m.stalledWarning && !j.stalled {
+				j.stalled = true
+				j.mu.Unlock()
+				m.recordStalled(parentSession, j.ID, j.Kind, j.Label)
+				return
+			}
+			wait := m.stalledWarning - idle
+			if wait <= 0 {
+				wait = m.stalledWarning
+			}
+			j.mu.Unlock()
+			timer.Reset(wait)
+		}
+	}
 }
 
 // recordCompletion queues the finished-job summary for DrainCompletedNote and
@@ -205,6 +275,31 @@ func (m *Manager) recordCompletion(parentSession, id, kind, label string, st Sta
 	}
 	if shouldEmit {
 		m.sink.Emit(event.Event{Kind: event.Notice, Level: level, Text: text})
+	}
+}
+
+func (m *Manager) recordStalled(parentSession, id, kind, label string) {
+	tag := id
+	if label != "" {
+		tag = fmt.Sprintf("%s (%s)", id, label)
+	}
+	parentSession = strings.TrimSpace(parentSession)
+	m.mu.Lock()
+	if parentSession != "" && m.destroying[parentSession] {
+		m.mu.Unlock()
+		return
+	}
+	text := fmt.Sprintf("%s may be stalled — still running after %s with no visible output. Inspect it with wait or bash_output, or stop it with kill_shell.", tag, m.stalledWarning.Round(time.Second))
+	m.completed = append(m.completed, completion{sessionID: parentSession, text: text})
+	active := m.active
+	shouldEmit := active == "" || parentSession == "" || active == parentSession
+	m.mu.Unlock()
+	if shouldEmit {
+		m.sink.Emit(event.Event{
+			Kind:  event.Notice,
+			Level: event.LevelWarn,
+			Text:  fmt.Sprintf("background %s may be stalled: %s — still running after %s with no visible output; inspect with wait/bash_output or stop with kill_shell", kind, id, m.stalledWarning.Round(time.Second)),
+		})
 	}
 }
 
@@ -407,7 +502,7 @@ func (m *Manager) DrainCompletedNoteForSession(parentSession string) string {
 	if len(c) == 0 {
 		return ""
 	}
-	return "Background jobs finished since your last message: " + strings.Join(c, "; ") +
+	return "Background job updates since your last message: " + strings.Join(c, "; ") +
 		". Read their output with bash_output or wait if you still need it."
 }
 

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -32,6 +32,24 @@ func (s *recordingSink) texts() []string {
 	return out
 }
 
+type blockingFinishedSink struct {
+	mu       sync.Mutex
+	events   []event.Event
+	entered  chan struct{}
+	released chan struct{}
+	once     sync.Once
+}
+
+func (s *blockingFinishedSink) Emit(ev event.Event) {
+	if strings.Contains(ev.Text, "background bash finished") {
+		s.once.Do(func() { close(s.entered) })
+		<-s.released
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, ev)
+}
+
 func waitFor(t *testing.T, cond func() bool) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -42,6 +60,33 @@ func waitFor(t *testing.T, cond func() bool) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Fatal("condition not met within deadline")
+}
+
+func TestStalledWarningIgnoresReturnedJobBeforeTerminalStatusPublished(t *testing.T) {
+	sink := &blockingFinishedSink{entered: make(chan struct{}), released: make(chan struct{})}
+	m := NewManager(sink, WithStalledWarningAfter(20*time.Millisecond))
+	defer func() {
+		close(sink.released)
+		m.Close()
+	}()
+
+	j := m.Start("bash", "", func(context.Context, io.Writer) (string, error) {
+		return "", nil
+	})
+	select {
+	case <-sink.entered:
+	case <-time.After(time.Second):
+		t.Fatal("completion notice did not start")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	note := m.DrainCompletedNote()
+	if strings.Contains(note, "may be stalled") {
+		t.Fatalf("got false stalled warning for already-returned job %s: %q", j.ID, note)
+	}
+	if !strings.Contains(note, j.ID) || !strings.Contains(note, string(Done)) {
+		t.Fatalf("completion note = %q, want done update for %s", note, j.ID)
+	}
 }
 
 // A job runs to completion: Wait reports Done with its output, and the completion

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -120,6 +120,64 @@ func TestKill(t *testing.T) {
 	}
 }
 
+func TestJobPanicRecoveredAsFailed(t *testing.T) {
+	sink := &recordingSink{}
+	m := NewManager(sink)
+	defer m.Close()
+
+	j := m.Start("task", "panic", func(context.Context, io.Writer) (string, error) {
+		panic("boom")
+	})
+	res := m.Wait(context.Background(), []string{j.ID}, 5)
+	if len(res) != 1 || res[0].Status != Failed {
+		t.Fatalf("want Failed result after panic, got %+v", res)
+	}
+	if !strings.Contains(res[0].Output, "internal error: panic: boom") {
+		t.Fatalf("panic output = %q, want internal panic message", res[0].Output)
+	}
+	waitFor(t, func() bool {
+		for _, text := range sink.texts() {
+			if strings.Contains(text, "background task failed") && strings.Contains(text, j.ID) && strings.Contains(text, "panic: boom") {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestStalledWarningEmitsNoticeAndDrainNote(t *testing.T) {
+	sink := &recordingSink{}
+	m := NewManager(sink, WithStalledWarningAfter(20*time.Millisecond))
+	defer m.Close()
+
+	j := m.Start("bash", "quiet", func(ctx context.Context, _ io.Writer) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	defer m.Kill(j.ID)
+
+	waitFor(t, func() bool {
+		for _, text := range sink.texts() {
+			if strings.Contains(text, "may be stalled") && strings.Contains(text, j.ID) {
+				return true
+			}
+		}
+		return false
+	})
+	if _, st, ok := m.Output(j.ID); !ok || st != Running {
+		t.Fatalf("stalled job output status = %q ok=%v, want running", st, ok)
+	}
+	note := m.DrainCompletedNote()
+	if !strings.Contains(note, "may be stalled") || !strings.Contains(note, j.ID) {
+		t.Fatalf("stalled drain note = %q, want stalled update for %s", note, j.ID)
+	}
+	// The warning is once per job.
+	time.Sleep(30 * time.Millisecond)
+	if again := m.DrainCompletedNote(); again != "" {
+		t.Fatalf("second stalled drain note = %q, want empty", again)
+	}
+}
+
 // Killed status is observable as soon as Kill returns, before the run goroutine
 // unwinds — otherwise a slow cancelled process tree (Windows taskkill + WaitDelay
 // drain) leaves Wait reporting Running until the goroutine finally returns, which

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -116,6 +116,9 @@ effort         = "high"
 enabled = []   # empty = all built-in tools
 bash_timeout_seconds = 120   # foreground safety cap; set 0 for no tool-local cap
 
+[tools.background_jobs]
+stalled_warning_seconds = 900   # warn once per background job after this many quiet seconds; 0 disables
+
 # CodeGraph code intelligence (symbol/call-graph search via tree-sitter + SQLite),
 # a built-in MCP server giving the agent codegraph_* search / context / explore /
 # trace / node tools. Off by default for first-run sessions. Once enabled, the


### PR DESCRIPTION
## 背景

后台 `bash(run_in_background=true)` 和 `task(run_in_background=true)` 由 session 级 `jobs.Manager` 管理。此前存在几个容易影响体验和稳定性的边界问题：后台 job goroutine panic 可能带崩进程；长时间无输出的后台 job 缺少可见 stalled 信号；进程异常退出后，持久化 subagent metadata 可能残留 `running`，导致后续 continuation 被 ghost running 阻塞。

## 做了什么

- 新增 `[tools.background_jobs].stalled_warning_seconds` 配置，默认 900 秒，`0` 可禁用，测试可调低阈值稳定验证。
- 为 `jobs.Manager` 管理的后台 job 增加 panic recovery，panic 会转为 job `failed`，并通过现有 notice / wait / bash_output 路径可见。
- 增加一次性 stalled 提醒：后台 job 长时间无自身 stdout/stderr 输出时，会发用户 notice，并注入下一轮 `<background-jobs>` note 让模型也能感知。
- 新增 subagent metadata 终态 `interrupted`，启动时把上次进程遗留的 stale `running` ref 清理为 `interrupted`。
- 后台 `task` subagent panic 时，除外层 job 失败外，也会把对应 subagent metadata 保存为 `failed`，避免残留假 running。

## 为什么这样做

这些改动把后台 job 的异常、卡住和进程退出后遗留状态都收敛到明确生命周期里：当前进程内失败是 `failed`，上次进程退出导致的遗留状态是 `interrupted`，疑似卡住则只提醒、不自动 kill。这样能避免后台任务静默挂住、ghost running 阻塞后续操作，或 panic 扩散到整个应用。

## 影响与结果

- 应用稳定性更好：后台 job panic 不再直接崩掉 Reasonix 进程。
- 用户可观测性更好：长时间无输出的后台 job 会有一次明确 stalled 提醒，并给出 `wait` / `bash_output` / `kill_shell` 操作建议。
- subagent continuation 语义更清楚：`failed` 和 `interrupted` 分开，`continue_from` / `fork_from` 都会拒绝 interrupted ref，避免复用不完整 transcript。
- 不改变当前边界：stalled 检测只看外层 job 自身 output activity。

## 验证

- `go test ./internal/config`
- `go test ./internal/jobs ./internal/boot`
- `go test ./internal/agent ./internal/boot`
- `go test ./...`