### PR TITLE
Fix runtime cancellation state and stop controls / 修复运行取消状态与停止控制

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -936,7 +936,7 @@ func (a *App) NewSession() error {
 		return workspaceNotReadyErr(tab)
 	}
 	// Tab is already blank — just persist and skip the new-session dance.
-	if !ctrl.Running() && !messagesHaveConversationContent(ctrl.History()) {
+	if !controllerHasActiveRuntimeWork(ctrl) && !messagesHaveConversationContent(ctrl.History()) {
 		a.persistTabSessionPath(tab, ctrl.SessionPath())
 		return nil
 	}
@@ -992,7 +992,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Cont
 		oldSink.tabID = detachedRuntimeTabID(oldPath)
 		oldSink.ctx = nil
 	}
-	if oldCtrl.Running() {
+	if oldCtrl.RuntimeStatus().Cancellable {
 		oldCtrl.Cancel()
 		if err := waitControllerStopped(oldCtrl); err != nil {
 			return err
@@ -4931,7 +4931,11 @@ func modelProviderAccessAllowed(access map[string]bool, name string) bool {
 }
 
 func controllerHasActiveRuntimeWork(ctrl *control.Controller) bool {
-	return ctrl != nil && (ctrl.Running() || ctrl.PendingPrompt() || len(ctrl.Jobs()) > 0)
+	if ctrl == nil {
+		return false
+	}
+	status := ctrl.RuntimeStatus()
+	return status.Running || status.PendingPrompt || status.BackgroundJobs > 0
 }
 
 func rebuildControllerActiveWorkError(setting string) error {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -80,6 +80,17 @@ func modelRefsFromView(models []ModelInfo) map[string]bool {
 	return out
 }
 
+type desktopAskRuntimeRunner struct {
+	ask func(context.Context) error
+}
+
+func (r *desktopAskRuntimeRunner) Run(ctx context.Context, _ string) error {
+	if r.ask == nil {
+		return nil
+	}
+	return r.ask(ctx)
+}
+
 func TestCommandsIncludesEffortNotThinking(t *testing.T) {
 	app := NewApp()
 	cmds := app.Commands()
@@ -176,6 +187,56 @@ func TestListTabsDoesNotExposeConfiguredSandboxPath(t *testing.T) {
 	}
 	if strings.Contains(string(raw), "sandboxPath") || strings.Contains(string(raw), configuredSandboxRoot) {
 		t.Fatalf("tab metadata should not expose configured sandbox root as sandboxPath: %s", raw)
+	}
+}
+
+func TestListTabsExposesStructuredRuntimeStatus(t *testing.T) {
+	asks := make(chan event.Ask, 1)
+	done := make(chan event.Event, 1)
+	runner := &desktopAskRuntimeRunner{}
+	ctrl := control.New(control.Options{
+		Runner: runner,
+		Sink: event.FuncSink(func(e event.Event) {
+			switch e.Kind {
+			case event.AskRequest:
+				asks <- e.Ask
+			case event.TurnDone:
+				done <- e
+			}
+		}),
+	})
+	runner.ask = func(ctx context.Context) error {
+		_, err := ctrl.Ask(ctx, []event.AskQuestion{{
+			ID:      "choice",
+			Prompt:  "Pick one",
+			Options: []event.AskOption{{Label: "A"}, {Label: "B"}},
+		}})
+		return err
+	}
+
+	app := NewApp()
+	app.setTestCtrl(ctrl, "prov/model")
+	app.tabOrder = []string{"test"}
+	ctrl.Send("ask user")
+	select {
+	case <-asks:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ask request")
+	}
+
+	tabs := app.ListTabs()
+	if len(tabs) != 1 {
+		t.Fatalf("tabs = %d, want 1", len(tabs))
+	}
+	if !tabs[0].Running || !tabs[0].PendingPrompt || !tabs[0].Cancellable || tabs[0].CancelRequested {
+		t.Fatalf("tab runtime = running:%v pending:%v cancellable:%v cancel:%v", tabs[0].Running, tabs[0].PendingPrompt, tabs[0].Cancellable, tabs[0].CancelRequested)
+	}
+
+	app.CancelTab("test")
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for turn_done")
 	}
 }
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2946,6 +2946,9 @@ export default function App() {
                   applyCollaborationMode("normal");
                   approve(state.approval!.id, false, false, false);
                 }}
+                onStop={() => {
+                  cancel();
+                }}
               />
             )}
             {state.ask && (
@@ -2953,6 +2956,9 @@ export default function App() {
                 ask={state.ask}
                 onAnswer={answerQuestion}
                 onDismiss={() => answerQuestion(state.ask!.id, [])}
+                onStop={() => {
+                  cancel();
+                }}
               />
             )}
             {clearContextPending && (

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -1,6 +1,6 @@
 // Run: tsx src/__tests__/use-controller-meta.test.ts
 
-import { initialState, reducer, sameMeta, shouldReconcileStaleTurn } from "../lib/useController";
+import { foregroundRunningFromRuntimeMeta, initialState, reducer, sameMeta, shouldReconcileStaleTurn } from "../lib/useController";
 import type { Meta, WireUsage } from "../lib/types";
 
 let passed = 0;
@@ -91,6 +91,13 @@ console.log("\nuse controller meta");
   eq(backgroundOnly.running, false, "background jobs alone do not make the composer runstatus active");
   eq(backgroundOnly.backgroundJobs, 1, "backend_status stores background job count");
   eq(backgroundOnly.cancellable, false, "background jobs alone are not foreground-cancellable");
+
+  const omittedCancellableBackgroundOnly = reducer(initialState, { type: "backend_status", running: true, backgroundJobs: 1 });
+  eq(omittedCancellableBackgroundOnly.running, false, "missing cancellable does not promote background-only metadata");
+  eq(omittedCancellableBackgroundOnly.cancellable, false, "missing cancellable stays non-cancellable with background-only metadata");
+  eq(foregroundRunningFromRuntimeMeta({ running: true }), true, "legacy running metadata remains foreground-running");
+  eq(foregroundRunningFromRuntimeMeta({ running: true, pendingPrompt: true, backgroundJobs: 1 }), true, "pending prompts remain foreground-running");
+  eq(foregroundRunningFromRuntimeMeta({ running: true, backgroundJobs: 1 }), false, "background jobs without cancellable are background-only");
 }
 
 {

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -73,6 +73,27 @@ console.log("\nuse controller meta");
 }
 
 {
+  const started = reducer(initialState, { type: "event", e: { kind: "turn_started" } });
+  const waiting = reducer(started, { type: "event", e: { kind: "approval_request", approval: { id: "1", tool: "bash", subject: "go test" } } });
+  eq(waiting.running, true, "approval prompt keeps the turn running");
+  eq(waiting.pendingPrompt, true, "approval prompt marks pendingPrompt");
+  eq(waiting.cancellable, true, "approval prompt remains cancellable");
+
+  const canceling = reducer(waiting, { type: "cancel_requested" });
+  eq(canceling.approval, undefined, "cancel_requested clears approval prompt locally");
+  eq(canceling.pendingPrompt, false, "cancel_requested clears pendingPrompt locally");
+  eq(canceling.cancelRequested, true, "cancel_requested marks cancelling");
+  eq(canceling.running, true, "cancel_requested waits for backend turn_done before idling");
+  const stalePrompt = reducer(canceling, { type: "event", e: { kind: "approval_request", approval: { id: "late", tool: "bash", subject: "sleep" } } });
+  eq(stalePrompt.approval, undefined, "late approval after cancel_requested stays hidden");
+
+  const backgroundOnly = reducer(initialState, { type: "backend_status", running: false, backgroundJobs: 1, cancellable: false });
+  eq(backgroundOnly.running, false, "background jobs alone do not make the composer runstatus active");
+  eq(backgroundOnly.backgroundJobs, 1, "backend_status stores background job count");
+  eq(backgroundOnly.cancellable, false, "background jobs alone are not foreground-cancellable");
+}
+
+{
   const idleExecutor = reducer(
     { ...initialState, context: { used: 0, window: 200, sessionTokens: 0 } },
     { type: "event", e: { kind: "usage", usage: usage("executor") } },

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -11,11 +11,13 @@ export function ApprovalModal({
   onAnswer,
   onRevisePlan,
   onExitPlan,
+  onStop,
 }: {
   approval: WireApproval;
   onAnswer: (allow: boolean, session: boolean, persist: boolean) => void;
   onRevisePlan?: (text: string) => void;
   onExitPlan?: () => void;
+  onStop: () => void;
 }) {
   const t = useT();
   const isPlanApproval = approval.tool === "exit_plan_mode";
@@ -54,14 +56,16 @@ export function ApprovalModal({
   const choosePlanAction = (key: string) => {
     if (key === "1") setRevisionOpen((open) => !open);
     else if (key === "2") answerWithExit(() => onAnswer(true, false, false));
-    else if (key === "3" || key === "Escape") answerWithExit(() => (onExitPlan ?? (() => onAnswer(false, false, false)))());
+    else if (key === "3") answerWithExit(() => (onExitPlan ?? (() => onAnswer(false, false, false)))());
+    else if (key === "Escape") answerWithExit(onStop);
   };
 
   const chooseToolAction = (key: string) => {
     if (key === "1") answerWithExit(() => onAnswer(true, false, false));
     else if (key === "2") answerWithExit(() => onAnswer(true, true, false));
     else if (key === "3") answerWithExit(() => onAnswer(true, true, true));
-    else if (key === "4" || key === "Escape") answerWithExit(() => onAnswer(false, false, false));
+    else if (key === "4") answerWithExit(() => onAnswer(false, false, false));
+    else if (key === "Escape") answerWithExit(onStop);
   };
 
   useEffect(() => {
@@ -103,7 +107,7 @@ export function ApprovalModal({
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [isPlanApproval, onAnswer, onExitPlan, actionCount]);
+  }, [isPlanApproval, onAnswer, onExitPlan, onStop, actionCount]);
 
   useEffect(() => {
     if (revisionOpen) inputRef.current?.focus();
@@ -137,6 +141,7 @@ export function ApprovalModal({
               onClick={() => answerWithExit(() => (onExitPlan ?? (() => onAnswer(false, false, false)))())}
               selected={selectedIndex === 2}
             />
+            <PromptAction keyLabel="Esc" label={t("composer.stopShort")} onClick={() => answerWithExit(onStop)} />
           </>
         }
       >
@@ -196,6 +201,7 @@ export function ApprovalModal({
           <PromptAction keyLabel="2" label={t("approval.allowRuleSession")} onClick={() => answerWithExit(() => onAnswer(true, true, false))} selected={selectedIndex === 1} />
           <PromptAction keyLabel="3" label={t("approval.allowRulePersistent")} onClick={() => answerWithExit(() => onAnswer(true, true, true))} selected={selectedIndex === 2} />
           <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => answerWithExit(() => onAnswer(false, false, false))} selected={selectedIndex === 3} />
+          <PromptAction keyLabel="Esc" label={t("composer.stopShort")} onClick={() => answerWithExit(onStop)} />
         </>
       }
     >

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -11,10 +11,12 @@ export function AskCard({
   ask,
   onAnswer,
   onDismiss,
+  onStop,
 }: {
   ask: WireAsk;
   onAnswer: (id: string, answers: QuestionAnswer[]) => void;
   onDismiss: () => void;
+  onStop: () => void;
 }) {
   const t = useT();
   // Per-question state: selected option labels, and an optional typed answer.
@@ -118,7 +120,7 @@ export function AskCard({
 
       if (event.key === "Escape") {
         event.preventDefault();
-        onDismiss();
+        onStop();
         return;
       }
       if ((event.key === "ArrowLeft" || event.key === "Backspace") && active > 0) {
@@ -134,7 +136,7 @@ export function AskCard({
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, [active, custom, onDismiss, q, sel]);
+  }, [active, custom, onDismiss, onStop, q, sel]);
 
   const answeredSummary = useMemo(
     () =>
@@ -193,6 +195,10 @@ export function AskCard({
           <button className="prompt-action prompt-action--quiet" onClick={onDismiss}>
             <span className="prompt-action__label">{t("ask.justChat")}</span>
           </button>
+          <button className="prompt-action prompt-action--quiet" onClick={onStop}>
+            <span className="prompt-action__key">Esc</span>
+            <span className="prompt-action__label">{t("composer.stopShort")}</span>
+          </button>
         </>
       }
       crumbs={
@@ -236,6 +242,9 @@ export function AskCard({
               )}
               <button className="btn" onClick={onDismiss}>
                 {t("ask.justChat")}
+              </button>
+              <button className="btn" onClick={onStop}>
+                {t("composer.stopShort")}
               </button>
               {(q.multi || custom[q.id]?.trim()) && (
                 <button className="btn btn--primary" onClick={() => finishOrAdvance()} disabled={!currentAnswered}>

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -1554,7 +1554,7 @@ export function Composer({
     }
     // Esc interrupts the in-flight turn (matches the Stop button's hint), and
     // restores the text if the server hadn't replied yet.
-    if (e.key === "Escape" && running && !decisionPending) {
+    if (e.key === "Escape" && running) {
       e.preventDefault();
       handleCancel();
     }
@@ -1895,7 +1895,7 @@ export function Composer({
             <span className="composer-runstatus__dot" />
             <span className="composer-runstatus__text">{runActivity}</span>
             <Tooltip label={t("composer.stop")}>
-              <button className="composer-runstatus__stop" type="button" onClick={handleCancel} disabled={decisionPending}>
+              <button className="composer-runstatus__stop" type="button" onClick={handleCancel}>
                 <Square size={10} fill="currentColor" />
                 <span>{t("composer.stopShort")}</span>
               </button>

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -139,6 +139,10 @@ export interface TabMeta {
   label: string;
   ready: boolean;
   running: boolean;
+  pendingPrompt?: boolean;
+  backgroundJobs?: number;
+  cancelRequested?: boolean;
+  cancellable?: boolean;
   mode: Mode;
   collaborationMode?: CollaborationMode;
   toolApprovalMode?: ToolApprovalMode;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -137,6 +137,19 @@ function usageTotalTokens(usage?: WireUsage): number {
   return Math.max(0, promptTokens + usage.completionTokens);
 }
 
+type RuntimeMetaSnapshot = {
+  running: boolean;
+  pendingPrompt?: boolean;
+  backgroundJobs?: number;
+  cancellable?: boolean;
+};
+
+export function foregroundRunningFromRuntimeMeta(meta: RuntimeMetaSnapshot): boolean {
+  if (typeof meta.cancellable === "boolean") return meta.cancellable;
+  if ((meta.backgroundJobs ?? 0) > 0 && !meta.pendingPrompt) return false;
+  return Boolean(meta.running);
+}
+
 function updatesContextGauge(usage?: WireUsage): boolean {
   const source = usage?.source?.trim();
   return !source || source === "executor";
@@ -606,15 +619,16 @@ export function reducer(s: State, a: Action): State {
       const pendingPrompt = Boolean(a.pendingPrompt);
       const backgroundJobs = Math.max(0, a.backgroundJobs ?? s.backgroundJobs ?? 0);
       const cancelRequested = Boolean(a.cancelRequested);
-      const cancellable = Boolean(a.cancellable ?? a.running);
+      const foregroundRunning = foregroundRunningFromRuntimeMeta({ running: a.running, pendingPrompt, backgroundJobs, cancellable: a.cancellable });
+      const cancellable = foregroundRunning;
       if (
-        a.running === s.running &&
+        foregroundRunning === s.running &&
         pendingPrompt === s.pendingPrompt &&
         backgroundJobs === s.backgroundJobs &&
         cancelRequested === s.cancelRequested &&
         cancellable === s.cancellable
       ) return s;
-      if (a.running) {
+      if (foregroundRunning) {
         return {
           ...s,
           running: true,
@@ -819,7 +833,7 @@ export function useController() {
     if (!tab) return undefined;
     const local = statesRef.current.get(tabId);
     const needsInitialLoad = !local?.meta;
-    const foregroundRunning = Boolean(tab.cancellable ?? tab.running);
+    const foregroundRunning = foregroundRunningFromRuntimeMeta(tab);
     const missedTurnDone = Boolean(local?.running && !foregroundRunning);
     dispatchTo(tabId, {
       type: "backend_status",
@@ -827,7 +841,7 @@ export function useController() {
       pendingPrompt: Boolean(tab.pendingPrompt),
       backgroundJobs: tab.backgroundJobs ?? 0,
       cancelRequested: Boolean(tab.cancelRequested),
-      cancellable: Boolean(tab.cancellable),
+      cancellable: foregroundRunning,
     });
     if (needsInitialLoad || missedTurnDone) {
       await loadSessionDataForTab(tabId, missedTurnDone);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -78,6 +78,10 @@ interface State {
   items: Item[];
   running: boolean;
   turnActive: boolean;
+  pendingPrompt: boolean;
+  backgroundJobs: number;
+  cancelRequested: boolean;
+  cancellable: boolean;
   approval?: WireApproval;
   ask?: WireAsk;
   usage?: WireUsage;
@@ -108,6 +112,10 @@ export const initialState: State = {
   items: [],
   running: false,
   turnActive: false,
+  pendingPrompt: false,
+  backgroundJobs: 0,
+  cancelRequested: false,
+  cancellable: false,
   context: { used: 0, window: 0, sessionTokens: 0 },
   jobs: [],
   checkpoints: [],
@@ -206,7 +214,8 @@ type Action =
   | { type: "user"; text: string; seq: number }
   | { type: "unsend" }
   | { type: "send_failed"; error: string }
-  | { type: "backend_status"; running: boolean }
+  | { type: "backend_status"; running: boolean; pendingPrompt?: boolean; backgroundJobs?: number; cancelRequested?: boolean; cancellable?: boolean }
+  | { type: "cancel_requested" }
   | { type: "meta"; meta: Meta }
   | { type: "context"; context: ContextInfo }
   | { type: "balance"; balance: BalanceInfo }
@@ -401,7 +410,7 @@ function flushPendingUser(s: State): State {
 
 function applyEvent(s: State, e: WireEvent): State {
   if (s.discardTurn) {
-    if (e.kind === "turn_done") return { ...s, discardTurn: false, running: false, turnActive: false, currentAssistant: undefined, live: undefined };
+    if (e.kind === "turn_done") return { ...s, discardTurn: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, live: undefined };
     return s;
   }
   if (s.pendingUser !== undefined && e.kind !== "turn_done") {
@@ -420,7 +429,7 @@ function applyEvent(s: State, e: WireEvent): State {
       let cur: State = s;
       if (cur.pendingUser !== undefined) cur = flushPendingUser(cur);
       const { items, id, seq } = ensureAssistant(cur);
-      return { ...cur, items, currentAssistant: id, seq, live: { id, text: "", reasoning: "", reasoningComplete: false }, running: true, turnActive: true, turnStartAt: Date.now(), turnTokens: 0, turnTotalTokens: 0, turnCost: 0 };
+      return { ...cur, items, currentAssistant: id, seq, live: { id, text: "", reasoning: "", reasoningComplete: false }, running: true, turnActive: true, pendingPrompt: false, cancelRequested: false, cancellable: true, turnStartAt: Date.now(), turnTokens: 0, turnTotalTokens: 0, turnCost: 0 };
     }
     case "text":
     case "reasoning": {
@@ -537,8 +546,14 @@ function applyEvent(s: State, e: WireEvent): State {
     }
     case "steer":
       return { ...s, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `s${s.seq}`, level: "info", text: `↪ ${e.text ?? ""}` }] };
-    case "approval_request": return { ...s, approval: e.approval };
-    case "ask_request": return { ...s, ask: e.ask };
+    case "approval_request": {
+      if (s.cancelRequested) return s;
+      return { ...s, approval: e.approval, pendingPrompt: true, running: true, turnActive: true, cancellable: true };
+    }
+    case "ask_request": {
+      if (s.cancelRequested) return s;
+      return { ...s, ask: e.ask, pendingPrompt: true, running: true, turnActive: true, cancellable: true };
+    }
     case "turn_done": {
       if (s.pendingUser !== undefined) s = flushPendingUser(s);
       const finalized = s.items.map((it) => {
@@ -548,7 +563,7 @@ function applyEvent(s: State, e: WireEvent): State {
         return it;
       });
       let items: Item[] = e.err ? [...finalized, { kind: "notice", id: `e${s.seq}`, level: "warn", text: e.err }] : finalized;
-      return { ...s, items, live: undefined, running: false, turnActive: false, currentAssistant: undefined, approval: undefined, ask: undefined, seq: s.seq + 1 };
+      return { ...s, items, live: undefined, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, approval: undefined, ask: undefined, seq: s.seq + 1 };
     }
     default: return s;
   }
@@ -563,6 +578,9 @@ export function reducer(s: State, a: Action): State {
         seq: seq + 1,
         items: [...s.items, { kind: "user", id: `u${seq}`, text: a.text }],
         running: true,
+        pendingPrompt: false,
+        cancelRequested: false,
+        cancellable: true,
         turnStartAt: Date.now(),
         turnTokens: 0,
         turnTotalTokens: 0,
@@ -571,7 +589,8 @@ export function reducer(s: State, a: Action): State {
         discardTurn: false,
       };
     }
-    case "unsend": return { ...s, pendingUser: undefined, discardTurn: true, running: false, live: undefined };
+    case "unsend": return { ...s, pendingUser: undefined, discardTurn: true, running: false, pendingPrompt: false, cancelRequested: true, cancellable: false, approval: undefined, ask: undefined, live: undefined };
+    case "cancel_requested": return { ...s, pendingPrompt: false, cancelRequested: true, approval: undefined, ask: undefined, cancellable: s.running || s.turnActive };
     case "send_failed": {
       if (s.pendingUser === undefined) return s;
       let idx = -1;
@@ -581,18 +600,39 @@ export function reducer(s: State, a: Action): State {
       }
       const items = idx >= 0 ? s.items.map((it, i) => (i === idx ? { ...it, failed: true } : it)) : s.items;
       const notice: Item = { kind: "notice", id: `n${s.seq}`, level: "warn", text: a.error };
-      return { ...s, pendingUser: undefined, running: false, turnActive: false, live: undefined, seq: s.seq + 1, items: [...items, notice] };
+      return { ...s, pendingUser: undefined, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, live: undefined, seq: s.seq + 1, items: [...items, notice] };
     }
     case "backend_status": {
-      if (a.running === s.running) return s;
-      if (a.running) return { ...s, running: true, turnActive: true, turnStartAt: s.turnStartAt || Date.now() };
+      const pendingPrompt = Boolean(a.pendingPrompt);
+      const backgroundJobs = Math.max(0, a.backgroundJobs ?? s.backgroundJobs ?? 0);
+      const cancelRequested = Boolean(a.cancelRequested);
+      const cancellable = Boolean(a.cancellable ?? a.running);
+      if (
+        a.running === s.running &&
+        pendingPrompt === s.pendingPrompt &&
+        backgroundJobs === s.backgroundJobs &&
+        cancelRequested === s.cancelRequested &&
+        cancellable === s.cancellable
+      ) return s;
+      if (a.running) {
+        return {
+          ...s,
+          running: true,
+          turnActive: true,
+          pendingPrompt,
+          backgroundJobs,
+          cancelRequested,
+          cancellable,
+          turnStartAt: s.turnStartAt || Date.now(),
+        };
+      }
       const finalized = s.items.map((it) => {
         if (it.kind === "assistant" && s.live && it.id === s.live.id) return { ...it, text: s.live.text, reasoning: s.live.reasoning, streaming: false };
         if (it.kind === "assistant" && it.streaming) return { ...it, streaming: false };
         if (it.kind === "tool" && it.status === "running") return { ...it, status: "stopped" as const };
         return it;
       });
-      return { ...s, items: finalized, running: false, turnActive: false, live: undefined, currentAssistant: undefined, approval: undefined, ask: undefined };
+      return { ...s, items: finalized, running: false, turnActive: false, pendingPrompt, backgroundJobs, cancelRequested, cancellable, live: undefined, currentAssistant: undefined, approval: undefined, ask: undefined };
     }
     case "meta": return sameMeta(s.meta, a.meta) ? s : { ...s, meta: a.meta };
     case "context": {
@@ -622,8 +662,8 @@ export function reducer(s: State, a: Action): State {
       return { ...s, items: archived, seq };
     }
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
-    case "clearApproval": return { ...s, approval: undefined };
-    case "clearAsk": return { ...s, ask: undefined };
+    case "clearApproval": return { ...s, approval: undefined, pendingPrompt: false };
+    case "clearAsk": return { ...s, ask: undefined, pendingPrompt: false };
     case "reset": return { ...initialState, meta: s.meta, context: { ...s.context, used: 0, sessionTokens: 0 }, balance: s.balance, effort: s.effort, jobs: s.jobs, sessionGen: s.sessionGen + 1 };
     case "event": return applyEvent(s, a.e);
     default: return s;
@@ -779,8 +819,16 @@ export function useController() {
     if (!tab) return undefined;
     const local = statesRef.current.get(tabId);
     const needsInitialLoad = !local?.meta;
-    const missedTurnDone = Boolean(local?.running && !tab.running);
-    dispatchTo(tabId, { type: "backend_status", running: Boolean(tab.running) });
+    const foregroundRunning = Boolean(tab.cancellable ?? tab.running);
+    const missedTurnDone = Boolean(local?.running && !foregroundRunning);
+    dispatchTo(tabId, {
+      type: "backend_status",
+      running: foregroundRunning,
+      pendingPrompt: Boolean(tab.pendingPrompt),
+      backgroundJobs: tab.backgroundJobs ?? 0,
+      cancelRequested: Boolean(tab.cancelRequested),
+      cancellable: Boolean(tab.cancellable),
+    });
     if (needsInitialLoad || missedTurnDone) {
       await loadSessionDataForTab(tabId, missedTurnDone);
       return tabs;
@@ -938,7 +986,10 @@ export function useController() {
       }
       return text;
     }
-    if (tabId) app.CancelTab(tabId).catch(() => {});
+    if (tabId) {
+      dispatchTo(tabId, { type: "cancel_requested" });
+      app.CancelTab(tabId).catch(() => {});
+    }
     return undefined;
   }, [activeTabId, dispatchTo]);
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -165,7 +165,8 @@ func (t *WorkspaceTab) hasActiveRuntimeWork() bool {
 	if t == nil || t.Ctrl == nil {
 		return false
 	}
-	return t.Ctrl.Running() || t.Ctrl.PendingPrompt() || len(t.Ctrl.Jobs()) > 0
+	status := t.Ctrl.RuntimeStatus()
+	return status.Running || status.PendingPrompt || status.BackgroundJobs > 0
 }
 
 func sessionRuntimeKey(path string) string {
@@ -840,6 +841,10 @@ type TabMeta struct {
 	Label             string `json:"label"`
 	Ready             bool   `json:"ready"`
 	Running           bool   `json:"running"`
+	PendingPrompt     bool   `json:"pendingPrompt,omitempty"`
+	BackgroundJobs    int    `json:"backgroundJobs,omitempty"`
+	CancelRequested   bool   `json:"cancelRequested,omitempty"`
+	Cancellable       bool   `json:"cancellable,omitempty"`
 	Mode              string `json:"mode"`
 	CollaborationMode string `json:"collaborationMode"`
 	ToolApprovalMode  string `json:"toolApprovalMode"`
@@ -898,7 +903,12 @@ func (a *App) tabMeta(tab *WorkspaceTab, active bool) TabMeta {
 		m.ProjectColor = projectColor(tab.WorkspaceRoot)
 	}
 	if tab.Ctrl != nil {
-		m.Running = tab.Ctrl.Running()
+		status := tab.Ctrl.RuntimeStatus()
+		m.Running = status.Running || status.PendingPrompt || status.BackgroundJobs > 0
+		m.PendingPrompt = status.PendingPrompt
+		m.BackgroundJobs = status.BackgroundJobs
+		m.CancelRequested = status.CancelRequested
+		m.Cancellable = status.Cancellable
 	}
 	return m
 }
@@ -1224,7 +1234,7 @@ func (a *App) blankTabMatchesTargetLocked(tab *WorkspaceTab, scope, workspaceRoo
 	if tab.Ctrl == nil {
 		return strings.TrimSpace(tab.SessionPath) == ""
 	}
-	if tab.Ctrl.Running() {
+	if tab.hasActiveRuntimeWork() {
 		return false
 	}
 	return !messagesHaveConversationContent(tab.Ctrl.History())
@@ -2688,16 +2698,17 @@ func activityStatusForTab(tab *WorkspaceTab) string {
 	if tab.Ctrl == nil {
 		return status
 	}
-	if tab.Ctrl.PendingPrompt() {
+	runtimeStatus := tab.Ctrl.RuntimeStatus()
+	if runtimeStatus.PendingPrompt {
 		return topicStatusWaitingConfirmation
 	}
-	if tab.Ctrl.Running() {
+	if runtimeStatus.Running {
 		if status == "" || status == topicStatusError {
 			return topicStatusThinking
 		}
 		return status
 	}
-	if len(tab.Ctrl.Jobs()) > 0 {
+	if runtimeStatus.BackgroundJobs > 0 {
 		return topicStatusBackgroundJob
 	}
 	if status == topicStatusError || status == topicStatusPaused {
@@ -3524,7 +3535,11 @@ func (a *App) ListProjectTree() []ProjectNode {
 		info := sessionInfos[sessionPath]
 		label := runtimeSessionTreeLabel(tab, info, sessionTitles[sessionPath])
 		status := activityStatusForTab(tab)
-		running := status != "" || (tab.Ctrl != nil && (tab.Ctrl.Running() || tab.Ctrl.PendingPrompt() || len(tab.Ctrl.Jobs()) > 0))
+		runtimeStatus := control.RuntimeStatus{}
+		if tab.Ctrl != nil {
+			runtimeStatus = tab.Ctrl.RuntimeStatus()
+		}
+		running := status != "" || runtimeStatus.Running || runtimeStatus.PendingPrompt || runtimeStatus.BackgroundJobs > 0
 		runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)] = append(runtimeSessionsByTopic[topicSummaryKey(tab.Scope, tab.WorkspaceRoot, tab.TopicID)], runtimeSessionStatus{
 			sessionPath:    sessionPath,
 			label:          label,

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -844,7 +844,7 @@ type TabMeta struct {
 	PendingPrompt     bool   `json:"pendingPrompt,omitempty"`
 	BackgroundJobs    int    `json:"backgroundJobs,omitempty"`
 	CancelRequested   bool   `json:"cancelRequested,omitempty"`
-	Cancellable       bool   `json:"cancellable,omitempty"`
+	Cancellable       bool   `json:"cancellable"`
 	Mode              string `json:"mode"`
 	CollaborationMode string `json:"collaborationMode"`
 	ToolApprovalMode  string `json:"toolApprovalMode"`

--- a/desktop/tabs_runtime_status_test.go
+++ b/desktop/tabs_runtime_status_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -192,6 +194,20 @@ func TestProjectTreeShowsBackgroundJobStatus(t *testing.T) {
 	topic := nodes[0].Children[0]
 	if topic.Status != topicStatusBackgroundJob || !topic.Running {
 		t.Fatalf("background job topic status = %+v, want background_job/running", topic)
+	}
+	tabs := app.ListTabs()
+	if len(tabs) != 1 {
+		t.Fatalf("tabs = %d, want 1", len(tabs))
+	}
+	if !tabs[0].Running || tabs[0].PendingPrompt || tabs[0].Cancellable || tabs[0].BackgroundJobs != 1 {
+		t.Fatalf("tab runtime = running:%v pending:%v cancellable:%v background:%d, want background-only running tab", tabs[0].Running, tabs[0].PendingPrompt, tabs[0].Cancellable, tabs[0].BackgroundJobs)
+	}
+	raw, err := json.Marshal(tabs[0])
+	if err != nil {
+		t.Fatalf("marshal tab meta: %v", err)
+	}
+	if !strings.Contains(string(raw), `"cancellable":false`) {
+		t.Fatalf("tab metadata should serialize explicit cancellable=false: %s", raw)
 	}
 
 	close(release)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -130,6 +130,7 @@ type Controller struct {
 	mu          sync.Mutex
 	cancel      context.CancelFunc
 	running     bool
+	canceling   bool
 	autosaveWG  sync.WaitGroup
 	planMode    bool
 	goal        string
@@ -195,6 +196,18 @@ type pendingApproval struct {
 type pendingAsk struct {
 	questions []event.AskQuestion
 	reply     chan []event.AskAnswer
+}
+
+// RuntimeStatus is the frontend-facing snapshot of foreground turn state. It is
+// intentionally more explicit than the legacy Running bool so UI code can
+// distinguish a cancellable foreground turn from pending prompts and background
+// jobs.
+type RuntimeStatus struct {
+	Running         bool
+	PendingPrompt   bool
+	BackgroundJobs  int
+	CancelRequested bool
+	Cancellable     bool
 }
 
 const (
@@ -430,6 +443,7 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	c.cancel = cancel
 	c.running = true
+	c.canceling = false
 	c.mu.Unlock()
 
 	c.autosaveWG.Add(1)
@@ -444,6 +458,7 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 				c.mu.Lock()
 				c.running = false
 				c.cancel = nil
+				c.canceling = false
 				c.mu.Unlock()
 				c.sink.Emit(event.Event{Kind: event.TurnDone, Err: fmt.Errorf("internal error: %v", r)})
 			}
@@ -452,6 +467,7 @@ func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 		c.mu.Lock()
 		c.running = false
 		c.cancel = nil
+		c.canceling = false
 		c.mu.Unlock()
 		c.sink.Emit(event.Event{Kind: event.TurnDone, Err: explainError(err)})
 	}()
@@ -508,12 +524,14 @@ func (c *Controller) RunTurn(ctx context.Context, input string) error {
 	}
 	c.cancel = cancel
 	c.running = true
+	c.canceling = false
 	c.mu.Unlock()
 
 	defer func() {
 		c.mu.Lock()
 		c.running = false
 		c.cancel = nil
+		c.canceling = false
 		c.mu.Unlock()
 		cancel()
 	}()
@@ -1152,6 +1170,15 @@ func (c *Controller) Run(ctx context.Context, input string) error {
 func (c *Controller) Cancel() {
 	c.mu.Lock()
 	cancel := c.cancel
+	if cancel != nil {
+		c.canceling = true
+		for id := range c.approvals {
+			delete(c.approvals, id)
+		}
+		for id := range c.asks {
+			delete(c.asks, id)
+		}
+	}
 	c.mu.Unlock()
 	if cancel != nil {
 		cancel()
@@ -1171,6 +1198,23 @@ func (c *Controller) PendingPrompt() bool {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return len(c.approvals) > 0 || len(c.asks) > 0
+}
+
+// RuntimeStatus reports the active work owned by the foreground controller.
+func (c *Controller) RuntimeStatus() RuntimeStatus {
+	c.mu.Lock()
+	running := c.running
+	pending := len(c.approvals) > 0 || len(c.asks) > 0
+	canceling := c.canceling
+	c.mu.Unlock()
+	backgroundJobs := len(c.Jobs())
+	return RuntimeStatus{
+		Running:         running,
+		PendingPrompt:   pending,
+		BackgroundJobs:  backgroundJobs,
+		CancelRequested: canceling,
+		Cancellable:     running || pending,
+	}
 }
 
 // Turn returns the current turn number (0 before the first submit).

--- a/internal/control/runtime_status_test.go
+++ b/internal/control/runtime_status_test.go
@@ -1,0 +1,112 @@
+package control
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"reasonix/internal/event"
+)
+
+type approvalBlockingRunner struct {
+	c *Controller
+}
+
+func (r *approvalBlockingRunner) Run(ctx context.Context, _ string) error {
+	_, _, err := gateApprover{c: r.c}.Approve(ctx, "bash", "go test ./...", nil)
+	return err
+}
+
+type askBlockingRunner struct {
+	c *Controller
+}
+
+func (r *askBlockingRunner) Run(ctx context.Context, _ string) error {
+	_, err := r.c.Ask(ctx, []event.AskQuestion{{
+		ID:      "choice",
+		Prompt:  "Pick one",
+		Options: []event.AskOption{{Label: "A"}, {Label: "B"}},
+	}})
+	return err
+}
+
+func TestCancelClearsPendingApprovalRuntimeStatus(t *testing.T) {
+	approvals := make(chan event.Approval, 1)
+	done := make(chan event.Event, 1)
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		switch e.Kind {
+		case event.ApprovalRequest:
+			approvals <- e.Approval
+		case event.TurnDone:
+			done <- e
+		}
+	})})
+	runner := &approvalBlockingRunner{c: c}
+	c.runner = runner
+
+	c.Send("needs approval")
+	select {
+	case <-approvals:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for approval request")
+	}
+	if st := c.RuntimeStatus(); !st.Running || !st.PendingPrompt || !st.Cancellable || st.CancelRequested {
+		t.Fatalf("status before cancel = %+v, want running pending cancellable", st)
+	}
+
+	c.Cancel()
+	c.Cancel()
+	if st := c.RuntimeStatus(); !st.Running || st.PendingPrompt || !st.Cancellable || !st.CancelRequested {
+		t.Fatalf("status immediately after cancel = %+v, want running cancelling without pending prompt", st)
+	}
+	waitTurnDoneEvent(t, done)
+	if st := c.RuntimeStatus(); st.Running || st.PendingPrompt || st.Cancellable || st.CancelRequested {
+		t.Fatalf("status after turn done = %+v, want idle", st)
+	}
+}
+
+func TestCancelClearsPendingAskRuntimeStatus(t *testing.T) {
+	asks := make(chan event.Ask, 1)
+	done := make(chan event.Event, 1)
+	c := New(Options{Sink: event.FuncSink(func(e event.Event) {
+		switch e.Kind {
+		case event.AskRequest:
+			asks <- e.Ask
+		case event.TurnDone:
+			done <- e
+		}
+	})})
+	runner := &askBlockingRunner{c: c}
+	c.runner = runner
+
+	c.Send("ask user")
+	select {
+	case <-asks:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for ask request")
+	}
+	if st := c.RuntimeStatus(); !st.Running || !st.PendingPrompt || !st.Cancellable || st.CancelRequested {
+		t.Fatalf("status before cancel = %+v, want running pending cancellable", st)
+	}
+
+	c.Cancel()
+	if st := c.RuntimeStatus(); !st.Running || st.PendingPrompt || !st.Cancellable || !st.CancelRequested {
+		t.Fatalf("status immediately after cancel = %+v, want running cancelling without pending prompt", st)
+	}
+	waitTurnDoneEvent(t, done)
+	if st := c.RuntimeStatus(); st.Running || st.PendingPrompt || st.Cancellable || st.CancelRequested {
+		t.Fatalf("status after turn done = %+v, want idle", st)
+	}
+}
+
+func waitTurnDoneEvent(t *testing.T, done <-chan event.Event) {
+	t.Helper()
+	select {
+	case e := <-done:
+		if e.Kind != event.TurnDone {
+			t.Fatalf("event = %v, want TurnDone", e.Kind)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for turn_done")
+	}
+}

--- a/internal/tool/builtin/bash_cancel_windows_test.go
+++ b/internal/tool/builtin/bash_cancel_windows_test.go
@@ -1,0 +1,91 @@
+//go:build windows
+
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/sandbox"
+)
+
+func TestBashCancelKillsWindowsChildProcessTree(t *testing.T) {
+	powershell, err := exec.LookPath("powershell")
+	if err != nil {
+		t.Skip("powershell not found")
+	}
+	tmp := t.TempDir()
+	pidFile := filepath.Join(tmp, "child.pid")
+	quotedPIDFile := strings.ReplaceAll(pidFile, "'", "''")
+	command := fmt.Sprintf(
+		"$p = Start-Process -FilePath powershell -ArgumentList '-NoProfile','-NonInteractive','-Command','Start-Sleep -Seconds 120' -PassThru; "+
+			"Set-Content -LiteralPath '%s' -Value $p.Id; "+
+			"Start-Sleep -Seconds 120",
+		quotedPIDFile,
+	)
+	args, _ := json.Marshal(map[string]any{"command": command})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, runErr := (bash{
+			shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: powershell},
+		}).Execute(ctx, args)
+		done <- runErr
+	}()
+
+	childPID := waitForWindowsPIDFile(t, pidFile)
+	cancel()
+	select {
+	case err = <-done:
+	case <-time.After(40 * time.Second):
+		killWindowsPID(childPID)
+		t.Fatal("cancel did not interrupt bash within 40s")
+	}
+	if err == nil {
+		t.Fatal("expected cancel to return an error")
+	}
+	for i := 0; i < 50; i++ {
+		if !windowsProcessAlive(childPID) {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	killWindowsPID(childPID)
+	t.Fatalf("child process %d survived bash cancel", childPID)
+}
+
+func waitForWindowsPIDFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(data)))
+			if parseErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for child pid file %s", path)
+	return 0
+}
+
+func windowsProcessAlive(pid int) bool {
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", fmt.Sprintf("if (Get-Process -Id %d -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }", pid))
+	return cmd.Run() == nil
+}
+
+func killWindowsPID(pid int) {
+	_ = exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid)).Run()
+}


### PR DESCRIPTION
Closes #4404
Closes #4107
Closes #3411
Addresses #4066 (the uninterruptible bash process-tree path)

Related: #4522 repairs stale prompt replay after frontend reconciliation. This PR is complementary: it fixes the authoritative runtime/cancel contract and makes Stop reachable while the turn is waiting for approval or ask input.

## Summary

- Added a structured controller runtime snapshot with `running`, `pendingPrompt`, `backgroundJobs`, `cancelRequested`, and `cancellable`.
- Made `Cancel()` idempotently mark cancellation immediately, clear pending approval/ask prompts, and still settle through the normal turn completion path.
- Switched desktop tab/runtime metadata to the backend-authoritative snapshot so sidebar/chrome guards and composer state no longer disagree.
- Kept Stop reachable during approval and ask prompts, including Esc handling inside those pending-decision surfaces.
- Added regression coverage for approval cancellation, ask cancellation, desktop runtime metadata, frontend runtime reconciliation, and Windows bash child-process tree cancellation.

## Verification

- `go test ./internal/control`
- `(cd desktop && go test .)`
- `(cd desktop/frontend && npm run typecheck)`
- `(cd desktop/frontend && npm run test:typecheck)`
- `(cd desktop/frontend && npm test)`
- Windows cross-compile of the `./internal/tool/builtin` test package passed.
- `go test ./internal/tool/builtin -run 'TestBashCancelReturnsPromptly|TestReapTreeKillsGroupStragglers' -count=1`
- `go test ./internal/provider/openai -run TestStreamStallTimesOut -count=1`
- `go test ./internal/agent -run TestRunCancelledMidStreamLeavesResumableSession -count=1`
- `go test ./... -skip 'TestSandboxEnforcesWrites|TestBashSandboxConfinement'`

The skipped root-suite cases are the existing macOS sandbox-enforcement checks that fail independently in this local environment; the cancellation/runtime changes and focused suites passed.
