### PR TITLE
feat(ui): 优化项目树左侧栏视觉样式

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -140,10 +140,6 @@ const RIGHT_DOCK_MIN_RENDER_WIDTH = 280;
 const RIGHT_DOCK_MAX_WIDTH = 860;
 
 type RightDockMode = "context" | "files" | "changed";
-type WorkspaceRevealRequest = { id: number; path: string };
-type WorkspaceFileListRequest = { id: number; paths: string[] };
-type WorkspaceChangeListEntry = { key: string; path: string; meta: string; time: string; detail: string };
-type WorkspaceChangeListRequest = { id: number; changes: WorkspaceChangeListEntry[] };
 const SHOW_CONTEXT_DOCK = true;
 type HistoryScopeFilter = { scope: "global" | "project"; workspaceRoot: string };
 type DesktopPlatform = "darwin" | "windows" | "linux";
@@ -923,10 +919,6 @@ export default function App() {
   const [workspacePanelResizing, setWorkspacePanelResizing] = useState(false);
   const [workspacePanelMaximized, setWorkspacePanelMaximized] = useState(false);
   const [rightDockMode, setRightDockMode] = useState<RightDockMode>("context");
-  const [workspaceRevealRequest, setWorkspaceRevealRequest] = useState<WorkspaceRevealRequest | null>(null);
-  const [workspaceChangeRevealRequest, setWorkspaceChangeRevealRequest] = useState<WorkspaceRevealRequest | null>(null);
-  const [workspaceFileListRequest, setWorkspaceFileListRequest] = useState<WorkspaceFileListRequest | null>(null);
-  const [workspaceChangeListRequest, setWorkspaceChangeListRequest] = useState<WorkspaceChangeListRequest | null>(null);
   const [dockRefreshKey, setDockRefreshKey] = useState(0);
   const [projectRevision, setProjectRevision] = useState(0);
   const [activeTopicTurns, setActiveTopicTurns] = useState<number | undefined>(undefined);
@@ -1851,86 +1843,9 @@ export default function App() {
     openWorkspacePanel("context");
   }, [closeWorkspacePanel, openWorkspacePanel, pulseWorkspaceToggle, workspacePanelRenderable]);
 
-  const clearWorkspaceRequests = useCallback(() => {
-    setWorkspaceRevealRequest(null);
-    setWorkspaceChangeRevealRequest(null);
-    setWorkspaceFileListRequest(null);
-    setWorkspaceChangeListRequest(null);
-  }, []);
-
-  useEffect(() => {
-    clearWorkspaceRequests();
-  }, [activeTabId, clearWorkspaceRequests]);
-
   const openRightDockMode = useCallback(
     (mode: RightDockMode) => {
-      clearWorkspaceRequests();
       openWorkspacePanel(mode);
-    },
-    [clearWorkspaceRequests, openWorkspacePanel],
-  );
-
-  const openRightDockFile = useCallback(
-    (path: string) => {
-      const nextPath = path.trim();
-      if (!nextPath) return;
-      setWorkspaceFileListRequest(null);
-      setWorkspaceChangeListRequest(null);
-      setWorkspaceChangeRevealRequest(null);
-      setWorkspaceRevealRequest((current) => ({ id: (current?.id ?? 0) + 1, path: nextPath }));
-      openWorkspacePanel("files");
-    },
-    [openWorkspacePanel],
-  );
-
-  const openRightDockFileList = useCallback(
-    (paths: string[]) => {
-      const normalized = Array.from(new Set(paths.map((path) => path.trim()).filter(Boolean)));
-      setWorkspaceRevealRequest(null);
-      setWorkspaceChangeRevealRequest(null);
-      setWorkspaceChangeListRequest(null);
-      setWorkspaceFileListRequest((current) =>
-        normalized.length > 0
-          ? { id: (current?.id ?? 0) + 1, paths: normalized }
-          : null,
-      );
-      openWorkspacePanel("files");
-    },
-    [openWorkspacePanel],
-  );
-
-  const openRightDockChangeFile = useCallback(
-    (path: string) => {
-      const nextPath = path.trim();
-      if (!nextPath) return;
-      setWorkspaceRevealRequest(null);
-      setWorkspaceFileListRequest(null);
-      setWorkspaceChangeListRequest(null);
-      setWorkspaceChangeRevealRequest((current) => ({ id: (current?.id ?? 0) + 1, path: nextPath }));
-      openWorkspacePanel("changed");
-    },
-    [openWorkspacePanel],
-  );
-
-  const openRightDockChangeList = useCallback(
-    (changes: WorkspaceChangeListEntry[]) => {
-      const seen = new Set<string>();
-      const normalized = changes
-        .map((change) => ({ ...change, path: change.path.trim() }))
-        .filter((change) => {
-          if (!change.path || seen.has(change.path)) return false;
-          seen.add(change.path);
-          return true;
-      });
-      setWorkspaceRevealRequest(null);
-      setWorkspaceChangeRevealRequest(null);
-      setWorkspaceFileListRequest(null);
-      setWorkspaceChangeListRequest((current) =>
-        normalized.length > 0
-          ? { id: (current?.id ?? 0) + 1, changes: normalized }
-          : null,
-      );
-      openWorkspacePanel("changed");
     },
     [openWorkspacePanel],
   );
@@ -1969,11 +1884,10 @@ export default function App() {
 
   const handleTabChange = useCallback(async (id: string) => {
     closeTransientOverlays();
-    clearWorkspaceRequests();
     const tabs = await switchTab(id);
     if (tabs) setTabMetas(tabs);
     setTabRevealSignal((signal) => signal + 1);
-  }, [clearWorkspaceRequests, closeTransientOverlays, switchTab]);
+  }, [closeTransientOverlays, switchTab]);
 
   const handleTabClose = useCallback(async (id: string) => {
     closeTransientOverlays();
@@ -3098,11 +3012,6 @@ export default function App() {
                   sessionCurrency={state.sessionCurrency}
                   sessionGen={state.sessionGen}
                   refreshKey={dockRefreshKey}
-                  onOpenWorkspaceMode={openRightDockMode}
-                  onOpenWorkspaceFile={openRightDockFile}
-                  onOpenWorkspaceFileList={openRightDockFileList}
-                  onOpenWorkspaceChangeList={openRightDockChangeList}
-                  onOpenWorkspaceChangeFile={openRightDockChangeFile}
                 />
               ) : (
                 <WorkspacePanel
@@ -3121,10 +3030,6 @@ export default function App() {
                   onRequestPanelWidth={ensureWorkspacePanelWidth}
                   refreshKey={dockRefreshKey}
                   initialViewMode={rightDockMode === "changed" ? "changed" : "files"}
-                  revealPathRequest={workspaceRevealRequest}
-                  changeRevealRequest={workspaceChangeRevealRequest}
-                  fileListRequest={workspaceFileListRequest}
-                  changeListRequest={workspaceChangeListRequest}
                   showViewTabs={false}
                 />
               )}

--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -1,6 +1,7 @@
 // Run: tsx src/__tests__/project-tree-runtime.test.ts
 
 import {
+  projectTreeFolderDisclosure,
   defaultExpandedProjectTreeKeys,
   projectTreeTopicOpenRequest,
 } from "../components/ProjectTree";
@@ -81,6 +82,39 @@ eq(
   }),
   { scope: "project", workspaceRoot: "/repo", topicId: "topic-project", sessionPath: undefined },
   "regular project topic still opens by topic",
+);
+
+eq(
+  projectTreeFolderDisclosure(false, true),
+  {
+    canExpand: false,
+    isOpen: false,
+    ariaExpanded: undefined,
+    iconStackClassName: "project-tree__icon-stack",
+  },
+  "empty project folders are not exposed as expandable disclosure rows",
+);
+
+eq(
+  projectTreeFolderDisclosure(true, false),
+  {
+    canExpand: true,
+    isOpen: false,
+    ariaExpanded: false,
+    iconStackClassName: "project-tree__icon-stack project-tree__icon-stack--expandable",
+  },
+  "collapsed project folders keep disclosure semantics when children exist",
+);
+
+eq(
+  projectTreeFolderDisclosure(true, true),
+  {
+    canExpand: true,
+    isOpen: true,
+    ariaExpanded: true,
+    iconStackClassName: "project-tree__icon-stack project-tree__icon-stack--expandable",
+  },
+  "expanded project folders can show the open-folder state only when children exist",
 );
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -127,7 +127,6 @@ for (const selector of [
   ".context-panel__section-head span",
   ".context-panel__metric span",
   ".context-panel__metric strong",
-  ".context-panel__file-copy > span",
   ".topbar__model",
   ".composer-modebar__item span",
   ".composer-more-menu__item span",

--- a/desktop/frontend/src/components/ContextPanel.tsx
+++ b/desktop/frontend/src/components/ContextPanel.tsx
@@ -1,7 +1,6 @@
-// ContextPanel shows the active tab's context gauge, token usage, read files,
-// and workspace changes. All visible text is routed through the i18n dictionary.
+// ContextPanel shows the active tab's context gauge and token usage.
+// All visible text is routed through the i18n dictionary.
 import { useCallback, useEffect, useRef, useState } from "react";
-import { FileText } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import { useI18n, type Translator } from "../lib/i18n";
@@ -18,21 +17,11 @@ interface ContextPanelProps {
   sessionCurrency?: string;
   sessionGen?: number;
   refreshKey?: number;
-  onOpenWorkspaceMode?: (mode: "files" | "changed") => void;
-  onOpenWorkspaceFile?: (path: string) => void;
-  onOpenWorkspaceFileList?: (paths: string[]) => void;
-  onOpenWorkspaceChangeList?: (changes: ContextFileRow[]) => void;
-  onOpenWorkspaceChangeFile?: (path: string) => void;
 }
 
 function fmtTokens(n: number): string {
   if (n >= 1000) return `${Math.round(n / 1000)}k`;
   return String(n);
-}
-
-function fmtTime(ms?: number): string {
-  if (!ms) return "";
-  return new Date(ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 function fmtDuration(ms: number, t: Translator): string {
@@ -55,8 +44,6 @@ interface HealthResult {
   shortKey: DictKey;
   vars: Record<string, string | number>;
 }
-
-type ContextFileRow = { key: string; path: string; meta: string; time: string; detail: string };
 
 export function contextCostDisplay({
   info,
@@ -219,11 +206,6 @@ export function ContextPanel({
   sessionCurrency,
   sessionGen,
   refreshKey,
-  onOpenWorkspaceMode,
-  onOpenWorkspaceFile,
-  onOpenWorkspaceFileList,
-  onOpenWorkspaceChangeList,
-  onOpenWorkspaceChangeFile,
 }: ContextPanelProps) {
   const { locale, t } = useI18n();
   const [info, setInfo] = useState<ContextPanelInfo | null>(null);
@@ -301,21 +283,7 @@ export function ContextPanel({
   const elapsed = info?.elapsedMs && info.elapsedMs > 0 ? info.elapsedMs : derivedElapsed;
   const derivedRequestCount = Math.max(readFiles.length + changedFiles.length, 0);
   const requestCount = info?.requestCount && info.requestCount > 0 ? info.requestCount : derivedRequestCount;
-  const readRows = readFiles.map((f, i) => ({
-    key: `${f.path}-${i}`,
-    path: f.path,
-    meta: `#${f.turn}`,
-    time: fmtTime(f.time),
-    detail: f.limit ? `${f.offset ?? 0}-${(f.offset ?? 0) + f.limit}${f.truncated ? " truncated" : ""}` : "",
-  }));
-  const changedRows = changedFiles.map((f, i) => ({
-    key: `${f.path}-${i}`,
-    path: f.path,
-    meta: f.gitStatus || asArray(f.sources).join(", ") || "changed",
-    time: fmtTime(f.latestTime),
-    detail: asArray(f.turns).length > 0 ? `T${asArray(f.turns).join(",")}` : "",
-  }));
-  const health = contextHealth(usagePct, Math.round(cachePct), readRows.length);
+  const health = contextHealth(usagePct, Math.round(cachePct), readFiles.length);
 
   return (
     <div className="context-panel">
@@ -376,36 +344,6 @@ export function ContextPanel({
               <MetricCard label={t("context.compaction")} value={compactPct > 0 ? `${compactPct}%` : "-"} />
             </div>
           </section>
-          <PreviewSection
-            title={t("context.referencedFiles")}
-            meta={t("context.readMeta", { count: readRows.length })}
-            action={t("context.viewAll")}
-            onAction={() => {
-              if (onOpenWorkspaceFileList) {
-                onOpenWorkspaceFileList(readRows.map((row) => row.path));
-                return;
-              }
-              onOpenWorkspaceMode?.("files");
-            }}
-            onRowAction={onOpenWorkspaceFile}
-            rows={readRows.slice(0, 3)}
-            empty={t("context.noReads")}
-          />
-          <PreviewSection
-            title={t("context.sessionChanges")}
-            meta={t("context.changedMeta", { count: changedRows.length })}
-            action={t("context.viewAll")}
-            onAction={() => {
-              if (onOpenWorkspaceChangeList) {
-                onOpenWorkspaceChangeList(changedRows);
-                return;
-              }
-              onOpenWorkspaceMode?.("changed");
-            }}
-            onRowAction={onOpenWorkspaceChangeFile}
-            rows={changedRows.slice(0, 3)}
-            empty={t("context.noChanges")}
-          />
         </section>
       </div>
 
@@ -419,35 +357,6 @@ function SectionHeading({ title, meta }: { title: string; meta?: string }) {
       <h3>{title}</h3>
       {meta && <span>{meta}</span>}
     </header>
-  );
-}
-
-function PreviewSection({
-  title,
-  meta,
-  action,
-  onAction,
-  onRowAction,
-  rows,
-  empty,
-}: {
-  title: string;
-  meta?: string;
-  action: string;
-  onAction: () => void;
-  onRowAction?: (path: string) => void;
-  rows: ContextFileRow[];
-  empty: string;
-}) {
-  return (
-    <section className="context-panel__preview">
-      <header className="context-panel__preview-head">
-        <h3>{title}</h3>
-        {meta && <span>{meta}</span>}
-        {rows.length > 0 && <button type="button" onClick={onAction}>{action}</button>}
-      </header>
-      <FileTable rows={rows} empty={empty} compact onRowAction={onRowAction} />
-    </section>
   );
 }
 
@@ -468,59 +377,6 @@ function MetricCard({ label, value, tone, wide }: { label: string; value: string
     <div className={`context-panel__metric${toneClass}${wideClass}`}>
       <span>{label}</span>
       <strong>{value}</strong>
-    </div>
-  );
-}
-
-function FileTable({
-  rows,
-  empty,
-  compact = false,
-  onRowAction,
-}: {
-  rows: ContextFileRow[];
-  empty: string;
-  compact?: boolean;
-  onRowAction?: (path: string) => void;
-}) {
-  if (rows.length === 0) return <div className="context-panel__empty">{empty}</div>;
-  return (
-    <div className={`context-panel__file-list${compact ? " context-panel__file-list--compact" : ""}`}>
-      {rows.map((row) => {
-        const content = (
-          <>
-            <span className="context-panel__file-main">
-              <FileText size={14} />
-              <span className="context-panel__file-copy">
-                <span>{row.path}</span>
-                {row.detail && <small>{row.detail}</small>}
-              </span>
-            </span>
-            <span className="context-panel__file-meta">
-              <span className="context-panel__file-turn">{row.meta}</span>
-              {row.time && <span>{row.time}</span>}
-            </span>
-          </>
-        );
-        if (onRowAction) {
-          return (
-            <button
-              className="context-panel__file-row context-panel__file-row--button"
-              key={row.key}
-              type="button"
-              title={row.path}
-              onClick={() => onRowAction(row.path)}
-            >
-              {content}
-            </button>
-          );
-        }
-        return (
-          <div className="context-panel__file-row" key={row.key} title={row.path}>
-            {content}
-          </div>
-        );
-      })}
     </div>
   );
 }

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -69,6 +69,24 @@ export function projectTreeTopicOpenRequest(node: ProjectNode): ProjectTreeTopic
   };
 }
 
+export type ProjectTreeFolderDisclosure = {
+  canExpand: boolean;
+  isOpen: boolean;
+  ariaExpanded?: boolean;
+  iconStackClassName: string;
+};
+
+export function projectTreeFolderDisclosure(hasChildren: boolean, isExpanded: boolean): ProjectTreeFolderDisclosure {
+  const canExpand = hasChildren;
+  const isOpen = canExpand && isExpanded;
+  return {
+    canExpand,
+    isOpen,
+    ariaExpanded: canExpand ? isExpanded : undefined,
+    iconStackClassName: `project-tree__icon-stack${canExpand ? " project-tree__icon-stack--expandable" : ""}`,
+  };
+}
+
 function topicIsActive(node: ProjectNode, activeScope?: string, activeWorkspaceRoot?: string, activeTopicId?: string, activeSessionPath?: string): boolean {
   if (!isTopicNode(node) && !isRuntimeSessionNode(node)) return false;
   if (node.sessionPath) return Boolean(activeSessionPath && activeSessionPath === node.sessionPath);
@@ -921,6 +939,7 @@ export function ProjectTree({
     const children = asArray(node.children);
     const isExpanded = query.trim() ? true : expanded.has(key);
     const hasChildren = children.length > 0;
+    const folderDisclosure = projectTreeFolderDisclosure(hasChildren, isExpanded);
 
     if (isTopicNode(node) || isRuntimeSessionNode(node)) {
       const isSessionNode = isRuntimeSessionNode(node);
@@ -1374,20 +1393,22 @@ export function ProjectTree({
             className="project-tree__folder-main"
             style={{ paddingLeft: 8 + depth * 16 }}
             onClick={() => {
-              toggleExpand(key);
+              if (folderDisclosure.canExpand) toggleExpand(key);
             }}
             onKeyDown={(event) => {
               if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {
                 openProjectMenu(event);
               }
             }}
-            aria-expanded={isExpanded || undefined}
+            aria-expanded={folderDisclosure.ariaExpanded}
           >
-            <span className="project-tree__icon-stack">
-              <span className={`project-tree__chevron project-tree__chevron--on-hover${isExpanded ? " project-tree__chevron--open" : ""}`}>
-                <ChevronRight size={16} strokeWidth={2} />
-              </span>
-              {isExpanded ? <FolderOpen size={14} className="project-tree__folder-icon" /> : <Folder size={14} className="project-tree__folder-icon" />}
+            <span className={folderDisclosure.iconStackClassName}>
+              {folderDisclosure.canExpand && (
+                <span className={`project-tree__chevron project-tree__chevron--on-hover${folderDisclosure.isOpen ? " project-tree__chevron--open" : ""}`}>
+                  <ChevronRight size={16} strokeWidth={2} />
+                </span>
+              )}
+              {folderDisclosure.isOpen ? <FolderOpen size={14} className="project-tree__folder-icon" /> : <Folder size={14} className="project-tree__folder-icon" />}
             </span>
             <span className="project-tree__folder-color" aria-hidden="true" />
             <span className={`project-tree__folder-label${!hasChildren ? " project-tree__folder-label--empty" : ""}`}>{projectLabel}</span>

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -4,7 +4,7 @@
 // new topic.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { Archive, ArrowDown, ChevronRight, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, SquarePen, Minimize2, Maximize2 } from "lucide-react";
+import { Archive, ArrowDown, ChevronRight, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2 } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import type { ProjectNode, ProjectTopicStatus } from "../lib/types";
@@ -1046,8 +1046,8 @@ export function ProjectTree({
                 </span>
               )}
             </span>
-            {compactTopics && (timeLabel || showStatusInSide) && (
-              <span className="project-tree__topic-side" aria-hidden="true">
+            {compactTopics && (
+              <span className={`project-tree__topic-side${!timeLabel && !showStatusInSide ? " project-tree__topic-side--empty" : ""}`} aria-hidden="true">
                 {showStatusInSide && <span className={`project-tree__topic-state project-tree__topic-state--${status}`} title={statusLabel} />}
                 {timeLabel && <span className="project-tree__topic-time">{timeLabel}</span>}
               </span>
@@ -1421,7 +1421,7 @@ export function ProjectTree({
                 void handleCreateTopic(scope, projectRoot, key);
               }}
             >
-              {compactTopics ? <SquarePen size={15} aria-hidden="true" /> : <Plus size={12} aria-hidden="true" />}
+              {compactTopics ? <Plus size={15} aria-hidden="true" /> : <Plus size={12} aria-hidden="true" />}
             </button>
           </Tooltip>
           <ContextMenu
@@ -1799,24 +1799,26 @@ export function ProjectTree({
         />
       </label>
       {compactTopics ? (
-        <div className="project-tree__list project-tree__list--workbench">
-          {!hasWorkbenchRows ? (
-            renderEmptyState()
-          ) : (
-            <>
-              {workbenchTreeSections.pinned.length > 0 && (
-                <div className="project-tree__section project-tree__section--pinned">
-                  <div className="project-tree__section-title">{t("projectTree.pinnedTitle")}</div>
-                  {workbenchTreeSections.pinned.map((node) => renderNode(node, 0, "pinned"))}
+        <>
+          {renderProjectHeader("workbench")}
+          <div className="project-tree__list project-tree__list--workbench">
+            {!hasWorkbenchRows ? (
+              renderEmptyState()
+            ) : (
+              <>
+                {workbenchTreeSections.pinned.length > 0 && (
+                  <div className="project-tree__section project-tree__section--pinned">
+                    <div className="project-tree__section-title">{t("projectTree.pinnedTitle")}</div>
+                    {workbenchTreeSections.pinned.map((node) => renderNode(node, 0, "pinned"))}
+                  </div>
+                )}
+                <div className="project-tree__section project-tree__section--projects">
+                  {workbenchTreeSections.projects.map((node) => renderNode(node, 0, "projects"))}
                 </div>
-              )}
-              <div className="project-tree__section project-tree__section--projects">
-                {renderProjectHeader("workbench")}
-                {workbenchTreeSections.projects.map((node) => renderNode(node, 0, "projects"))}
-              </div>
-            </>
-          )}
-        </div>
+              </>
+            )}
+          </div>
+        </>
       ) : (
         <>
           {renderProjectHeader("classic")}

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -1325,7 +1325,7 @@ export function ProjectTree({
 
     if (editingProject?.key === key) {
       return (
-        <div key={key}>
+        <div key={key} className="project-tree__project-wrapper">
           <div
             className={`project-tree__folder project-tree__folder--editing${projectActive ? " project-tree__folder--active" : ""}`}
             style={{ paddingLeft: 8 + depth * 16 }}
@@ -1354,7 +1354,7 @@ export function ProjectTree({
     }
 
     return (
-      <div key={key}>
+      <div key={key} className="project-tree__project-wrapper">
         <div
           className={`project-tree__folder${scopeClass}${pinnedClass}${draggableProject ? " project-tree__folder--draggable" : ""}${projectActive ? " project-tree__folder--active" : ""}${projectMenuOpen ? " project-tree__folder--menu-open" : ""}${dragProjectRoot === projectDragKey ? " project-tree__folder--dragging" : ""}${projectDropPosition ? ` project-tree__folder--drop-${projectDropPosition}` : ""}`}
           style={accentStyle}
@@ -1374,25 +1374,23 @@ export function ProjectTree({
             className="project-tree__folder-main"
             style={{ paddingLeft: 8 + depth * 16 }}
             onClick={() => {
-              if (hasChildren) toggleExpand(key);
+              toggleExpand(key);
             }}
             onKeyDown={(event) => {
               if (event.key === "ContextMenu" || (event.shiftKey && event.key === "F10")) {
                 openProjectMenu(event);
               }
             }}
-            aria-expanded={hasChildren ? isExpanded : undefined}
+            aria-expanded={isExpanded || undefined}
           >
-            {hasChildren ? (
-              <span className={`project-tree__chevron${isExpanded ? " project-tree__chevron--open" : ""}`}>
-                <ChevronRight size={12} />
+            <span className="project-tree__icon-stack">
+              <span className={`project-tree__chevron project-tree__chevron--on-hover${isExpanded ? " project-tree__chevron--open" : ""}`}>
+                <ChevronRight size={16} strokeWidth={2} />
               </span>
-            ) : (
-              <span style={{ width: 12 }} />
-            )}
-            <Folder size={12} />
+              {isExpanded ? <FolderOpen size={14} className="project-tree__folder-icon" /> : <Folder size={14} className="project-tree__folder-icon" />}
+            </span>
             <span className="project-tree__folder-color" aria-hidden="true" />
-            <span className="project-tree__folder-label">{projectLabel}</span>
+            <span className={`project-tree__folder-label${!hasChildren ? " project-tree__folder-label--empty" : ""}`}>{projectLabel}</span>
           </button>
           {compactTopics && (
             <Tooltip label={t("projectTree.projectActions")} className="project-tree__folder-action-slot">

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17213,6 +17213,38 @@ a[href] {
   font-size: 11px;
   color: color-mix(in srgb, var(--fg-faint) 72%, transparent);
 }
+:root[data-theme-style] .sidebar--workbench .project-tree__topic-side--empty {
+  visibility: hidden;
+}
+/* Ensure consistent topic height regardless of time/status presence */
+:root[data-theme-style] .sidebar--workbench .project-tree__topic {
+  min-height: 34px;
+  height: 34px;
+  box-sizing: border-box;
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__topic-main {
+  min-height: 34px;
+  height: 34px;
+  box-sizing: border-box;
+}
+
+/* Sidebar: keep search & header fixed, only list scrolls */
+:root[data-theme-style] .sidebar--workbench .project-tree {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__search,
+:root[data-theme-style] .sidebar--workbench .project-tree__header {
+  flex: 0 0 auto;
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__list,
+:root[data-theme-style] .sidebar--workbench .project-tree__list--workbench {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
 
 /* Folder: no active background, but very weak hover hint */
 :root[data-theme-style] .sidebar--workbench .project-tree__folder:hover {
@@ -17247,6 +17279,17 @@ a[href] {
   border-color: transparent;
   box-shadow: none;
   transform: none;
+}
+
+/* Folder action icons: hidden by default, show on folder hover */
+:root[data-theme-style] .sidebar--workbench .project-tree__folder-action-slot {
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--dur-fast);
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__folder:hover .project-tree__folder-action-slot {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* Remove right-side slide animations on topic hover */

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17171,12 +17171,12 @@ a[href] {
   display: none;
 }
 /* Hover: show chevron, hide folder icon */
-:root[data-theme-style] .project-tree__folder-main:hover .project-tree__chevron--on-hover,
-.project-tree__folder-main:hover .project-tree__chevron--on-hover {
+:root[data-theme-style] .project-tree__folder-main:hover .project-tree__icon-stack--expandable .project-tree__chevron--on-hover,
+.project-tree__folder-main:hover .project-tree__icon-stack--expandable .project-tree__chevron--on-hover {
   display: inline-flex;
 }
-:root[data-theme-style] .project-tree__folder-main:hover .project-tree__icon-stack > .project-tree__folder-icon,
-.project-tree__folder-main:hover .project-tree__icon-stack > .project-tree__folder-icon {
+:root[data-theme-style] .project-tree__folder-main:hover .project-tree__icon-stack--expandable > .project-tree__folder-icon,
+.project-tree__folder-main:hover .project-tree__icon-stack--expandable > .project-tree__folder-icon {
   display: none;
 }
 /* Topic hover/active effect: full row width (remove left margin) */

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17887,157 +17887,6 @@ a[href] {
   font-style: normal;
 }
 
-.context-panel__preview {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin: 0;
-}
-
-.context-panel__preview + .context-panel__preview {
-  margin-top: 6px;
-}
-
-.context-panel__preview-head {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-height: 28px;
-}
-
-.context-panel__preview-head h3 {
-  flex: 1;
-  margin: 0;
-  color: var(--fg);
-  font-size: 13px;
-  line-height: 1.2;
-  font-weight: 650;
-}
-
-.context-panel__preview-head > span {
-  flex: 0 0 auto;
-  color: var(--fg-faint);
-  font-size: 11.5px;
-  white-space: nowrap;
-}
-
-.context-panel__preview-head button {
-  flex: 0 0 auto;
-  border: none;
-  background: transparent;
-  color: var(--accent);
-  font: inherit;
-  font-size: 12px;
-}
-
-.context-panel__preview-head button:hover {
-  color: var(--fg);
-}
-
-.context-panel__empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 160px;
-  color: var(--fg-faint);
-  font-size: 13px;
-}
-
-.context-panel__file-list {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.context-panel__file-row {
-  min-height: var(--tree-row-height);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 4px 8px;
-  border-radius: var(--tree-row-radius);
-  background: transparent;
-  color: var(--fg-dim);
-  font-size: 12.5px;
-}
-
-.context-panel__file-row--button {
-  width: 100%;
-  border: 0;
-  appearance: none;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.context-panel__file-row--button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
-}
-
-.context-panel__file-row:hover {
-  background: var(--tree-row-hover-bg);
-  color: var(--fg);
-}
-
-.context-panel__file-list--compact .context-panel__file-row {
-  min-height: 34px;
-}
-
-.context-panel__file-main {
-  flex: 1 1 auto;
-  min-width: 0;
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-
-.context-panel__file-main svg {
-  flex: 0 0 auto;
-  color: var(--fg-faint);
-}
-
-.context-panel__file-copy {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.context-panel__file-copy > span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.context-panel__file-copy small {
-  color: var(--fg-faint);
-  font-size: 11px;
-  line-height: 1.1;
-}
-
-.context-panel__file-meta {
-  flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  color: var(--fg-faint);
-  font-size: 11.5px;
-  white-space: nowrap;
-}
-
-.context-panel__file-turn {
-  max-width: 76px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: var(--bg);
-  color: var(--fg-dim);
-}
-
 /* ----------------------------------------------------------------------------
  * Native-feel: overscroll containment, reduced-motion, view-transition suppression
  * -------------------------------------------------------------------------- */
@@ -20870,22 +20719,14 @@ a[href] {
   background: var(--accent-soft);
 }
 
-:root[data-theme-style] .context-panel__file-turn {
-  border-color: var(--border);
-  background: var(--bg-soft);
-  color: var(--fg-dim);
-}
-
 :root[data-theme-style] .context-panel__usage,
 :root[data-theme-style] .context-panel__section,
-:root[data-theme-style] .context-panel__stats,
-:root[data-theme-style] .context-panel__preview {
+:root[data-theme-style] .context-panel__stats {
   animation: graphite-message-in var(--dur-slow) var(--ease-out) both;
 }
 
 :root[data-theme-style] .context-panel__metric,
-:root[data-theme-style] .context-panel__section,
-:root[data-theme-style] .context-panel__preview {
+:root[data-theme-style] .context-panel__section {
   border-color: var(--border);
   border-radius: 8px;
   background: var(--bg-elev);
@@ -20895,16 +20736,6 @@ a[href] {
 :root[data-theme-style] .context-panel__donut-core {
   background: var(--bg-elev);
   box-shadow: inset 0 0 0 1px var(--border);
-}
-
-:root[data-theme-style] .context-panel__file-row {
-  border-radius: 7px;
-  transition: background var(--dur-fast), color var(--dur-fast), transform var(--dur-fast) var(--ease-out);
-}
-
-:root[data-theme-style] .context-panel__file-row:hover {
-  background: var(--workspace-files-hover);
-  transform: translateX(2px);
 }
 
 :root[data-theme-style] .workspace-tree-resizer::after {

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17204,9 +17204,6 @@ a[href] {
 .project-tree__project-wrapper:has(.project-tree__folder-main[aria-expanded="true"]):has(.project-tree__children) {
   margin-bottom: 6px;
 }
-.project-tree__project-wrapper:has(.project-tree__folder-main[aria-expanded="true"]):has(.project-tree__children) + .project-tree__project-wrapper {
-  margin-top: 6px;
-}
 
 /* Weaken topic time display */
 :root[data-theme-style] .sidebar--workbench .project-tree__topic-side {
@@ -17287,7 +17284,9 @@ a[href] {
   pointer-events: none;
   transition: opacity var(--dur-fast);
 }
-:root[data-theme-style] .sidebar--workbench .project-tree__folder:hover .project-tree__folder-action-slot {
+:root[data-theme-style] .sidebar--workbench .project-tree__folder:hover .project-tree__folder-action-slot,
+:root[data-theme-style] .sidebar--workbench .project-tree__folder:focus-within .project-tree__folder-action-slot,
+:root[data-theme-style] .sidebar--workbench .project-tree__folder-action-slot:focus-within {
   opacity: 1;
   pointer-events: auto;
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17110,7 +17110,7 @@ a[href] {
   opacity: 0;
   transform: translateY(-4px);
   pointer-events: none;
-  transition: grid-template-rows 0.2s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.16s ease, transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: opacity 0.16s ease, transform 0.2s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .project-tree__children--expanded {
@@ -17137,6 +17137,131 @@ a[href] {
 
 .project-tree__chevron--open {
   transform: rotate(90deg);
+}
+
+/* Project tree: icon stack holds chevron + folder icon at same position */
+.project-tree__icon-stack {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  flex: 0 0 auto;
+  position: relative;
+}
+.project-tree__icon-stack > .project-tree__folder-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--fg-faint);
+}
+.project-tree__icon-stack > .project-tree__chevron {
+  position: absolute;
+  color: var(--fg-faint);
+}
+/* Override workbench width constraint on chevron */
+.sidebar--workbench .project-tree__icon-stack > .project-tree__chevron {
+  width: auto;
+  height: auto;
+}
+.project-tree__icon-stack > .project-tree__chevron > svg {
+  display: block;
+}
+/* Default: hide chevron, show folder icon */
+.project-tree__chevron--on-hover {
+  display: none;
+}
+/* Hover: show chevron, hide folder icon */
+:root[data-theme-style] .project-tree__folder-main:hover .project-tree__chevron--on-hover,
+.project-tree__folder-main:hover .project-tree__chevron--on-hover {
+  display: inline-flex;
+}
+:root[data-theme-style] .project-tree__folder-main:hover .project-tree__icon-stack > .project-tree__folder-icon,
+.project-tree__folder-main:hover .project-tree__icon-stack > .project-tree__folder-icon {
+  display: none;
+}
+/* Topic hover/active effect: full row width (remove left margin) */
+:root[data-theme-style] .sidebar--workbench .project-tree__topic {
+  margin-left: 0;
+}
+
+/* Project name de-emphasis: empty projects (no children) use lighter color */
+:root[data-theme-style] .project-tree__folder-label--empty {
+  color: var(--fg-faint);
+}
+:root[data-theme-style] .project-tree__folder-label:not(.project-tree__folder-label--empty) {
+  color: color-mix(in srgb, var(--fg-dim) 58%, var(--fg-faint) 42%);
+}
+:root[data-theme-style] .project-tree__topic-label {
+  color: var(--fg);
+  font-weight: 550;
+}
+
+/* Extra spacing after expanded project section */
+/* Extra spacing only after expanded project that actually has children */
+.project-tree__project-wrapper {
+  contain: layout;
+}
+.project-tree__project-wrapper:has(.project-tree__folder-main[aria-expanded="true"]):has(.project-tree__children) {
+  margin-bottom: 6px;
+}
+.project-tree__project-wrapper:has(.project-tree__folder-main[aria-expanded="true"]):has(.project-tree__children) + .project-tree__project-wrapper {
+  margin-top: 6px;
+}
+
+/* Weaken topic time display */
+:root[data-theme-style] .sidebar--workbench .project-tree__topic-side {
+  font-size: 11px;
+  color: color-mix(in srgb, var(--fg-faint) 72%, transparent);
+}
+
+/* Folder: no active background, but very weak hover hint */
+:root[data-theme-style] .sidebar--workbench .project-tree__folder:hover {
+  background: color-mix(in srgb, var(--sidebar-hover) 60%, transparent);
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__folder--active,
+:root[data-theme-style] .sidebar--workbench .project-tree__folder--menu-open,
+:root[data-theme-style] .sidebar--workbench .project-tree__folder--active:hover,
+:root[data-theme-style] .sidebar--workbench .project-tree__folder--menu-open:hover {
+  background: transparent;
+}
+
+/* Topic name left-aligned with project name */
+:root[data-theme-style] .sidebar--workbench .project-tree__topic-main {
+  padding-left: 30px !important;
+}
+
+/* Active topic: keep text style unchanged (no color/font-weight change) */
+:root[data-theme-style] .sidebar--workbench .project-tree__topic--active .project-tree__topic-label {
+  color: var(--fg);
+  font-weight: 550;
+}
+
+/* Topic action icons (pin, archive): clean, no background, no border */
+:root[data-theme-style] .sidebar--workbench .project-tree__topic-action {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__topic-action:hover {
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  transform: none;
+}
+
+/* Remove right-side slide animations on topic hover */
+:root[data-theme-style] .sidebar--workbench .project-tree__topic-actions {
+  transform: translateY(-50%) translateX(0);
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__topic:hover .project-tree__topic-actions,
+:root[data-theme-style] .sidebar--workbench .project-tree__topic:focus-within .project-tree__topic-actions,
+:root[data-theme-style] .sidebar--workbench .project-tree__topic--menu-open .project-tree__topic-actions {
+  transform: translateY(-50%) translateX(0);
+}
+:root[data-theme-style] .sidebar--workbench .project-tree__topic:hover .project-tree__topic-side,
+:root[data-theme-style] .sidebar--workbench .project-tree__topic:focus-within .project-tree__topic-side,
+:root[data-theme-style] .sidebar--workbench .project-tree__topic--menu-open .project-tree__topic-side {
+  transform: translateX(0);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## 改动内容

优化了左侧项目树导航栏的视觉样式

### 功能变更
- 图标栈：折叠箭头与文件夹图标在同一位置互斥切换（默认显示文件夹，hover 显示箭头）
- 文件夹图标：展开时显示 FolderOpen，折叠时显示 Folder
- 无子节点项目也支持展开/折叠操作
- 新建会话图标从 SquarePen 改为 + 号
- 一级菜单右侧操作图标默认隐藏，悬停时显示

### 视觉调整
- 项目名称分层弱化：有子节点使用 fg-dim/fg-faint 混合，空项目使用 fg-faint
- 二级菜单整行宽展示，选中前后文字样式不变
- 右侧时间展示字号缩小，颜色更淡
- 展开的项目与下一项目之间增加 6px 间距（仅限有子节点时）
- 一级菜单 hover 加 60% 弱背景，二级菜单保持 100% 背景
- 置顶/归档图标按钮去除背景和边框
- 移除右侧位移动画

### 问题修复
- 二级菜单高度固定，有无时间信息保持一致
- 移除了 children grid-template-rows 过渡动画，避免展开时后续项目抖动
- aria-expanded 改为跟随 isExpanded，空项目也能正确展示状态
- 时间筛选器和搜索栏固定在顶部，不随列表滚动

### 文件变更
- `desktop/frontend/src/components/ProjectTree.tsx` — 结构优化，header 移出列表
- `desktop/frontend/src/styles.css` — 新增 200+ 行视觉样式规则