### PR TITLE
fix(cli&desktop): Fix stale scroll and transcript accumulation on session switch / 修复会话切换时滚动偏移与对话累积

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -134,6 +134,14 @@ export function Transcript({
   // Track question count and auto-scroll on new messages.
   useEffect(() => { trackQuestions(questions.length); }, [questions.length, trackQuestions]);
 
+  // Reset the auto-scroll pin when switching tabs so the new session always
+  // starts at the bottom. Without this, stick.current from the previous tab
+  // persists across React re-renders (Transcript is not keyed by tabId) and
+  // disables auto-scroll when the user had scrolled up in the old tab (#4584).
+  useEffect(() => {
+    stick.current = true;
+  }, [tabId]);
+
   // Auto-scroll to bottom during streaming. Coalesce fast token/reasoning
   // updates into one layout read/write per animation frame.
   const contentVersion = useMemo(() => scrollVersion(items), [items]);

--- a/internal/cli/branch.go
+++ b/internal/cli/branch.go
@@ -105,6 +105,15 @@ func (m *chatTUI) replayActiveBranch(title string) {
 	m.bubblePending = false
 	m.turnDiscarded = false
 
+	// Discard the previous session's transcript so the viewport only shows the
+	// newly loaded session. Without this the transcript accumulates across
+	// every /resume / /switch / /rewind / /branch, bloating memory and causing
+	// the scroll position to be preserved at a stale offset inside the merged
+	// content (#4584).
+	m.transcript = nil
+	m.transcriptDirty = true
+	m.forceGotoBottom = true
+
 	m.commitLine("")
 	if title != "" {
 		m.commitLine(dim("  -- " + title + " --"))

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -170,6 +170,10 @@ type chatTUI struct {
 	toolStreamStart time.Time
 	toolStreamFrame int
 	transcriptDirty bool
+	// forceGotoBottom is set by replayActiveBranch and resetFreshContextView to
+	// pin the viewport to the bottom after a session / branch / clear switch
+	// regardless of the previous wasAtBottom state (#4584).
+	forceGotoBottom bool
 	eventCh         chan event.Event
 	started         bool // banner + resumed history committed once
 
@@ -683,8 +687,9 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		wrapped := wrapTranscript(strings.Join(cm.transcript, "\n"), contentW)
 		cm.viewport.SetContent(wrapped)
 		cm.wrappedLines = strings.Split(wrapped, "\n")
-		if wasAtBottom {
+		if wasAtBottom || cm.forceGotoBottom {
 			cm.viewport.GotoBottom() // tail-follow: stay pinned to newest output
+			cm.forceGotoBottom = false
 		}
 	}
 	cm.transcriptDirty = false

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -63,6 +63,7 @@ func (m *chatTUI) resetFreshContextView(clearTranscript bool) {
 	}
 	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
 	m.transcriptDirty = true
+	m.forceGotoBottom = true
 }
 
 func (m chatTUI) renderClearConfirm() string {

--- a/internal/cli/resume_test.go
+++ b/internal/cli/resume_test.go
@@ -159,6 +159,69 @@ func TestResumeDispatchSwitchesAndReplays(t *testing.T) {
 	}
 }
 
+// TestResumeWhileScrolledUpPinsViewportToBottom covers the session-switch
+// regression where a stale scroll offset was preserved if the user had read
+// back in the old transcript before resuming another session.
+func TestResumeWhileScrolledUpPinsViewportToBottom(t *testing.T) {
+	dir := t.TempDir()
+	active := agent.NewSession("sys")
+	for i := 0; i < 18; i++ {
+		active.Add(provider.Message{Role: provider.RoleUser, Content: "active prompt " + strconv.Itoa(i)})
+	}
+	exec := agent.New(nil, nil, active, agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: exec, SessionDir: dir, Label: "test"})
+	activePath := filepath.Join(dir, "active.jsonl")
+	ctrl.SetSessionPath(activePath)
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+
+	otherPath := filepath.Join(dir, "other.jsonl")
+	saveTestSession(t, otherPath, "OTHER-SESSION-PROMPT")
+
+	target := 0
+	for i, s := range recentSessions(dir) {
+		if s.Path == otherPath {
+			target = i + 1
+		}
+	}
+	if target == 0 {
+		t.Fatal("other session not listed by recentSessions")
+	}
+
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	cur := adv(newChatTUI(ctrl, "", make(chan event.Event, 1), 80), tea.WindowSizeMsg{Width: 80, Height: 8})
+	if !cur.viewport.AtBottom() {
+		t.Fatal("initial resumed history should start at the bottom")
+	}
+
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if cur.viewport.AtBottom() {
+		t.Fatal("wheel-up should move the old transcript away from the bottom")
+	}
+
+	cur.input.SetValue("/resume " + strconv.Itoa(target))
+	cur = adv(cur, tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if got := ctrl.SessionPath(); got != otherPath {
+		t.Fatalf("session path = %q, want %q", got, otherPath)
+	}
+	out := strings.Join(cur.transcript, "\n")
+	if !strings.Contains(out, "OTHER-SESSION-PROMPT") {
+		t.Fatalf("transcript should replay the resumed session:\n%s", out)
+	}
+	if strings.Contains(out, "active prompt") {
+		t.Fatalf("transcript should not retain the previous session after resume:\n%s", out)
+	}
+	if !cur.viewport.AtBottom() {
+		t.Fatalf("resume while scrolled up should pin to bottom, AtBottom=%v, YOffset=%d", cur.viewport.AtBottom(), cur.viewport.YOffset())
+	}
+}
+
 func saveTestSession(t *testing.T, path, prompt string) {
 	t.Helper()
 	s := agent.NewSession("sys")


### PR DESCRIPTION
Closes #4584. Also fixes #4594 — "always scrolls to top when entering a conversation" is the same root cause: when resuming from the history panel, wasAtBottom is false so GotoBottom() is never called. The forceGotoBottom flag forces a bottom pin on every session switch regardless of prior scroll state.

Summary
-------

When switching sessions in the CLI (`/resume`, `/switch`, `/branch`, `/rewind`) or tabs in the desktop app, the scroll position is often not at the bottom after the switch. The bug is not 100% reproducible — scrolling even one line up before switching is enough to trigger it.

**CLI root cause:** `replayActiveBranch` never cleared `m.transcript` before replaying the new session history, so each switch appended to the old transcript. Bubbletea's viewport `SetContent` preserves the previous `YOffset` when it remains within bounds, and the outer `Update` only called `GotoBottom()` when `wasAtBottom` was true before the switch.

**Desktop root cause:** `Transcript` is not keyed by `tabId` in `App.tsx`, so React reuses the same component instance across tab switches. `useScrollManager` stores the auto-scroll decision in a `useRef`, which also persists. When the user scrolls up in tab A, tab B inherits the stale `stick.current = false`.

Changes
-------

### CLI (3 files, +16 −1)

- `internal/cli/branch.go` — `replayActiveBranch` clears `m.transcript = nil` before replay, sets `transcriptDirty` and `forceGotoBottom`
- `internal/cli/chat_tui.go` — new `forceGotoBottom` field; `GotoBottom()` condition extended to `wasAtBottom || forceGotoBottom`, flag cleared after use
- `internal/cli/clear_confirm.go` — `resetFreshContextView` also sets `forceGotoBottom = true` (covers `/new` and `/clear`)

### Desktop (1 file, +8)

- `desktop/frontend/src/components/Transcript.tsx` — new `useEffect([tabId])` resets `stick.current = true` on tab switch, so the existing auto-scroll mechanism correctly pins new content to the bottom

Verification
------------

```bash
# CLI
go build ./internal/cli/...
go test ./internal/cli/... -run "TestResume|TestBranch|TestTranscript|TestScroll|TestClear|TestEmptyEnter|TestTailFollow|TestRewind|TestNew|TestSwitch" -count=1
# → 13 passed, 0 failed

# Desktop
npx tsc --noEmit
# → zero errors

npx tsx src/__tests__/transcript-grouping.test.ts
# → 8 passed, 0 failed

npx tsx src/__tests__/render-optimization.test.ts
# → 16 passed, 0 failed
```

Code review on both changes passed; all suggestions applied.