### PR TITLE
feat: show git branch in WorkspacePanel Changes tab header

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -3148,6 +3148,7 @@ export default function App() {
                   fileListRequest={workspaceFileListRequest}
                   changeListRequest={workspaceChangeListRequest}
                   showViewTabs={false}
+                  gitBranch={state.meta?.gitBranch}
                 />
               )}
             </div>

--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -199,6 +199,7 @@ export function WorkspacePanel({
   fileListRequest,
   changeListRequest,
   showViewTabs = true,
+  gitBranch,
 }: {
   open: boolean;
   tabId?: string;
@@ -217,6 +218,7 @@ export function WorkspacePanel({
   fileListRequest?: WorkspaceFileListRequest | null;
   changeListRequest?: WorkspaceChangeListRequest | null;
   showViewTabs?: boolean;
+  gitBranch?: string;
 }) {
   const t = useT();
   const panelRef = useRef<HTMLElement>(null);
@@ -707,7 +709,9 @@ export function WorkspacePanel({
     ? scopedChangeRows ? t("context.sessionChanges") : t("workspace.changedTab")
     : currentFileName;
   const previewSubtitle = changedMode && !selectedPath
-    ? scopedChangeRows ? t("context.changedMeta", { count: scopedChangeRows.length }) : shortCwd(cwd) || t("workspace.title")
+    ? scopedChangeRows
+      ? t("context.changedMeta", { count: scopedChangeRows.length })
+      : [gitBranch ? `@${gitBranch.trim()}` : "", cwd ? shortCwd(cwd) : ""].filter(Boolean).join(" · ") || t("workspace.title")
     : currentFileDir;
   const recentFiles = useMemo(() => [...openTabs].reverse(), [openTabs]);
   const flattened = useMemo(() => {


### PR DESCRIPTION
Display the current git branch (e.g. @main-v2) in the Changes tab preview header alongside the working directory, so users can see which branch they are working on without leaving the workspace panel.