### PR TITLE
Fix stale planner model startup / 修复陈旧规划模型导致启动失败

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -751,9 +751,8 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if pm := cfg.Agent.PlannerModel; pm != "" && !tokenEconomy {
 		pe, ok := cfg.ResolveModel(pm)
 		if !ok {
-			return nil, fmt.Errorf("planner_model %q is not a configured provider", pm)
-		}
-		if pe.Model != entry.Model {
+			sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: fmt.Sprintf("planner_model %q is not a configured provider; continuing with %s/%s only", pm, entry.Name, entry.Model)})
+		} else if pe.Model != entry.Model {
 			plannerProv, err := NewProviderWithProxy(pe, proxySpec)
 			if err != nil {
 				return nil, fmt.Errorf("planner %q: %w", pm, err)

--- a/internal/boot/model_error_test.go
+++ b/internal/boot/model_error_test.go
@@ -82,3 +82,43 @@ api_key_env = "`+keyEnv+`"
 		t.Fatalf("expected a notice naming the unset key env %q; got %v", keyEnv, notices)
 	}
 }
+
+func TestBuildContinuesWhenOptionalPlannerModelIsStale(t *testing.T) {
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "executor/main"
+
+[agent]
+planner_model = "OpenRouter/moonshotai/kimi-k2.6:free"
+
+[[providers]]
+name = "executor"
+kind = "openai"
+base_url = "https://example.invalid/v1"
+model = "main"
+`)
+
+	var notices []string
+	ctrl, err := Build(context.Background(), Options{
+		Sink: event.FuncSink(func(e event.Event) {
+			if e.Kind == event.Notice {
+				notices = append(notices, e.Text)
+			}
+		}),
+	})
+	if err != nil {
+		t.Fatalf("Build should keep the executor usable when optional planner_model is stale: %v", err)
+	}
+	defer ctrl.Close()
+
+	found := false
+	for _, n := range notices {
+		if strings.Contains(n, `planner_model "OpenRouter/moonshotai/kimi-k2.6:free"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a notice naming the stale planner_model; got %v", notices)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2465,6 +2465,29 @@ func (c *Config) Provider(name string) (*ProviderEntry, bool) {
 	return nil, false
 }
 
+func (c *Config) providerForModelRef(name string) (*ProviderEntry, bool) {
+	if e, ok := c.Provider(name); ok {
+		return e, true
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil, false
+	}
+	match := -1
+	for i := range c.Providers {
+		if strings.EqualFold(c.Providers[i].Name, name) {
+			if match >= 0 {
+				return nil, false
+			}
+			match = i
+		}
+	}
+	if match >= 0 {
+		return &c.Providers[match], true
+	}
+	return nil, false
+}
+
 // ResolveModel resolves a model reference to a provider entry whose Model is the
 // selected model string (a copy, so the config's lists stay intact). It accepts:
 //   - "provider/model" — that exact model under that provider;
@@ -2476,6 +2499,7 @@ func (c *Config) Provider(name string) (*ProviderEntry, bool) {
 // without duplicating base_url/api_key_env. Single-`model` entries still resolve
 // by provider name, keeping older configs working unchanged.
 func (c *Config) ResolveModel(ref string) (*ProviderEntry, bool) {
+	ref = strings.TrimSpace(ref)
 	if ref == "" {
 		return nil, false
 	}
@@ -2484,7 +2508,7 @@ func (c *Config) ResolveModel(ref string) (*ProviderEntry, bool) {
 	}
 	// "provider/model"
 	if prov, model, ok := strings.Cut(ref, "/"); ok {
-		if e, found := c.Provider(prov); found && e.HasModel(model) {
+		if e, found := c.providerForModelRef(prov); found && e.HasModel(model) {
 			cp := *e
 			cp.Model = model
 			cp.applyModelPrice()
@@ -2492,7 +2516,7 @@ func (c *Config) ResolveModel(ref string) (*ProviderEntry, bool) {
 		}
 	}
 	// a provider name → its default model
-	if e, found := c.Provider(ref); found {
+	if e, found := c.providerForModelRef(ref); found {
 		cp := *e
 		cp.Model = e.DefaultModel()
 		cp.applyModelPrice()

--- a/internal/config/model_fallback_test.go
+++ b/internal/config/model_fallback_test.go
@@ -52,6 +52,40 @@ func TestResolveModelWithFallback(t *testing.T) {
 	}
 }
 
+func TestResolveModelAcceptsProviderNameCaseInsensitiveRef(t *testing.T) {
+	t.Setenv("OPENROUTER_API_KEY", "sk-test")
+	c := &Config{
+		DefaultModel: "openrouter/moonshotai/kimi-k2.6:free",
+		Agent: AgentConfig{
+			PlannerModel: "OpenRouter/moonshotai/kimi-k2.6:free",
+		},
+		Providers: []ProviderEntry{{
+			Name:      "openrouter",
+			Kind:      "openai",
+			BaseURL:   "https://openrouter.ai/api/v1",
+			Models:    []string{"moonshotai/kimi-k2.6:free"},
+			APIKeyEnv: "OPENROUTER_API_KEY",
+		}},
+	}
+
+	entry, ok := c.ResolveModel(c.Agent.PlannerModel)
+	if !ok {
+		t.Fatalf("ResolveModel(%q) did not match configured provider %q", c.Agent.PlannerModel, c.Providers[0].Name)
+	}
+	if entry.Name != "openrouter" || entry.Model != "moonshotai/kimi-k2.6:free" {
+		t.Fatalf("resolved entry = %s/%s, want openrouter/moonshotai/kimi-k2.6:free", entry.Name, entry.Model)
+	}
+
+	got, fallback, ok := c.ResolveModelWithFallback(c.Agent.PlannerModel)
+	if !ok || fallback || got != "openrouter/moonshotai/kimi-k2.6:free" {
+		t.Fatalf("ResolveModelWithFallback(%q) = (%q, %v, %v), want canonical ref without fallback", c.Agent.PlannerModel, got, fallback, ok)
+	}
+
+	if _, ok := c.ResolveModel("OpenRouter/moonshotai/KIMI-k2.6:free"); ok {
+		t.Fatal("model IDs must remain case-sensitive even when provider names are matched case-insensitively")
+	}
+}
+
 func TestResolveModelWithFallbackSkipsKeylessProvider(t *testing.T) {
 	c := testModelFallbackConfig(t)
 	// Make the first provider keyless. A fallback must skip it and pick the next


### PR DESCRIPTION
## Problem

#4615 reports that after a forced shutdown, the desktop app can restart into a startup error like:

`planner_model "OpenRouter/moonshotai/kimi-k2.6:free" is not a configured provider`

That leaves the primary chat surface unusable even when the executor model is still configured.

## Root Cause

Two startup paths were too strict for recovered desktop configuration state:

- Model references matched the provider segment with exact casing only, so a recovered `OpenRouter/...` ref could miss a configured `openrouter` provider even though the model id itself was valid.
- `agent.planner_model` is optional, but boot treated a stale planner reference as fatal after the executor model had already resolved successfully.

## Fix

- Resolve the provider segment of `provider/model` refs with exact-match priority and a unique case-insensitive fallback, while keeping model ids case-sensitive.
- Treat an unresolved optional `planner_model` as a warning and continue with the executor model instead of blocking startup.
- Add regression coverage for mixed-case OpenRouter refs and stale optional planner refs during boot.

## Verification

- `go test ./internal/config -run TestResolveModelAcceptsProviderNameCaseInsensitiveRef -count=1`
- `go test ./internal/boot -run TestBuildContinuesWhenOptionalPlannerModelIsStale -count=1`
- `go test ./internal/config ./internal/boot`
- `go test ./...`
- `(cd desktop && go test ./...)`
- `go vet ./...`
- `(cd desktop && go vet ./...)`
- `git diff --check`
- `gofmt -l .`

Fixes #4615
