### PR TITLE
fix(agent): persist model in session metadata so resume restores the correct model

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1442,6 +1442,14 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 	promoteProviderKeysToCredentials(cfg)
 
 	model := strings.TrimSpace(tab.model)
+	// Prefer the session's original model from BranchMeta — the session file
+	// always knows what model created it, so it survives tab-model drift
+	// across restarts.
+	if tab.SessionPath != "" {
+		if sm, ok := agent.LoadSessionModel(tab.SessionPath); ok {
+			model = sm
+		}
+	}
 	if model == "" {
 		model = cfg.DefaultModel
 	}

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -27,6 +27,7 @@ type BranchMeta struct {
 	WorkspaceRoot    string    `json:"workspace_root,omitempty"`
 	TopicID          string    `json:"topic_id,omitempty"`
 	TopicTitle       string    `json:"topic_title,omitempty"`
+	Model            string    `json:"model,omitempty"`
 }
 
 func (m BranchMeta) DefaultScope() string {
@@ -229,5 +230,29 @@ func RenameSession(sessionPath string, title string) error {
 		return err
 	}
 	m.TopicTitle = title
+	return SaveBranchMeta(sessionPath, m)
+}
+
+// LoadSessionModel reads the model ref from a session's .jsonl.meta sidecar.
+// Returns the model (empty when absent) and whether a meta file was found.
+func LoadSessionModel(sessionPath string) (string, bool) {
+	m, ok, err := LoadBranchMeta(sessionPath)
+	if err != nil || !ok || m.Model == "" {
+		return "", false
+	}
+	return m.Model, true
+}
+
+// SetBranchModel sets the model ref in a session's .jsonl.meta sidecar.
+// If no meta file exists yet, one is created.
+func SetBranchModel(sessionPath, model string) error {
+	if sessionPath == "" {
+		return fmt.Errorf("empty session path")
+	}
+	m, err := EnsureBranchMeta(sessionPath)
+	if err != nil {
+		return err
+	}
+	m.Model = model
 	return SaveBranchMeta(sessionPath, m)
 }

--- a/internal/agent/branch_test.go
+++ b/internal/agent/branch_test.go
@@ -53,3 +53,48 @@ func TestBranchMetaRoundTripAndList(t *testing.T) {
 		t.Fatalf("child with parent root and name experiment not found among %+v", branches)
 	}
 }
+
+func TestBranchMetaModelRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hi"})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// Model should be absent initially.
+	if m, ok := LoadSessionModel(path); ok {
+		t.Fatalf("LoadSessionModel on fresh session = %q, want empty", m)
+	}
+
+	// Set model and verify it is persisted.
+	if err := SetBranchModel(path, "openrouter/anthropic/claude-sonnet"); err != nil {
+		t.Fatal(err)
+	}
+	m, ok := LoadSessionModel(path)
+	if !ok {
+		t.Fatal("LoadSessionModel failed after SetBranchModel")
+	}
+	if m != "openrouter/anthropic/claude-sonnet" {
+		t.Fatalf("model = %q, want %q", m, "openrouter/anthropic/claude-sonnet")
+	}
+
+	// Update model and verify.
+	if err := SetBranchModel(path, "deepseek/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+	m, ok = LoadSessionModel(path)
+	if !ok {
+		t.Fatal("LoadSessionModel failed after update")
+	}
+	if m != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("model = %q, want %q", m, "deepseek/deepseek-v4-flash")
+	}
+
+	// LoadSessionModel returns false for a non-existent file.
+	if _, ok := LoadSessionModel(filepath.Join(dir, "nonexistent.jsonl")); ok {
+		t.Fatal("LoadSessionModel on nonexistent path returned ok")
+	}
+}

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -246,3 +246,43 @@ func TestListSessionsMissingDir(t *testing.T) {
 		t.Errorf("missing dir = %v / %v, want nil/nil", got, err)
 	}
 }
+
+func TestSetAndLoadSessionModel(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.jsonl")
+
+	s := NewSession("sys")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not find a model in a fresh session.
+	if _, ok := LoadSessionModel(path); ok {
+		t.Fatal("expected no model in fresh session")
+	}
+
+	// Set model and verify round-trip.
+	if err := SetBranchModel(path, "openrouter/anthropic/claude-sonnet"); err != nil {
+		t.Fatal(err)
+	}
+	m, ok := LoadSessionModel(path)
+	if !ok {
+		t.Fatal("expected model after SetBranchModel")
+	}
+	if m != "openrouter/anthropic/claude-sonnet" {
+		t.Fatalf("model = %q, want %q", m, "openrouter/anthropic/claude-sonnet")
+	}
+
+	// Update model.
+	if err := SetBranchModel(path, "deepseek/deepseek-v4-flash"); err != nil {
+		t.Fatal(err)
+	}
+	m, ok = LoadSessionModel(path)
+	if !ok {
+		t.Fatal("expected model after update")
+	}
+	if m != "deepseek/deepseek-v4-flash" {
+		t.Fatalf("model = %q, want %q", m, "deepseek/deepseek-v4-flash")
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -795,6 +795,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Sink:                   sink,
 		Policy:                 policy,
 		Label:                  label,
+		ModelRef:               modelName,
 		SystemPrompt:           sysPrompt,
 		SessionDir:             sessionDir,
 		Host:                   pluginHost,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -270,6 +270,25 @@ func runAgent(args []string) int {
 		sink = metrics
 	}
 	sink = withNotifications(sink, cfg)
+
+	// When resuming without an explicit --model, read the model from the
+	// session's BranchMeta sidecar so the conversation continues with the
+	// same model it was created with.
+	if *model == "" {
+		if *resume != "" {
+			if sm, ok := agent.LoadSessionModel(*resume); ok {
+				*model = sm
+			}
+		} else if *cont {
+			sessions, err := agent.ListSessions(resolveCLISessionDir())
+			if err == nil && len(sessions) > 0 {
+				if sm, ok := agent.LoadSessionModel(sessions[0].Path); ok {
+					*model = sm
+				}
+			}
+		}
+	}
+
 	ctrl, err := setup(ctx, *model, *maxSteps, true, sink)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -337,6 +356,15 @@ func runServe(args []string) int {
 
 	ctx := context.Background()
 	bc := serve.NewBroadcaster()
+
+	// When resuming without an explicit --model, read the model from the
+	// session's BranchMeta sidecar.
+	if *model == "" && *resume != "" {
+		if sm, ok := agent.LoadSessionModel(*resume); ok {
+			*model = sm
+		}
+	}
+
 	ctrl, err := setup(ctx, *model, *maxSteps, true, bc)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -411,6 +439,15 @@ func chatREPL(args []string) int {
 	}
 
 	ctx := context.Background()
+
+	// When resuming without an explicit --model, read the model from the
+	// session's BranchMeta sidecar so the conversation continues with the
+	// same model it was created with.
+	if resumePath != "" && *model == "" {
+		if sm, ok := agent.LoadSessionModel(resumePath); ok {
+			*model = sm
+		}
+	}
 
 	// Plumb the controller's typed event stream through a channel so each event
 	// can become a tea.Msg inside the TUI's update loop. Buffered generously:

--- a/internal/cli/resume.go
+++ b/internal/cli/resume.go
@@ -67,6 +67,10 @@ func (m *chatTUI) runResumeCommand(input string) {
 	// Persist the conversation we're leaving so switching back later restores it.
 	_ = m.ctrl.Snapshot()
 	m.ctrl.Resume(loaded, target.Path)
+	// Warn when the session was created with a different model (#4519).
+	if sm, ok := agent.LoadSessionModel(target.Path); ok && sm != m.ctrl.Label() && !strings.Contains(sm, m.ctrl.Label()) {
+		m.notice(fmt.Sprintf("session was created with model %q but the current model is %q — use /model %s to switch", sm, m.ctrl.Label(), sm))
+	}
 	m.replayActiveBranch(i18n.M.ResumedTitle)
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -63,6 +63,7 @@ type Controller struct {
 	policy   permission.Policy
 
 	label             string
+	modelRef          string
 	systemPrompt      string
 	sessionDir        string
 	host              *plugin.Host
@@ -242,6 +243,7 @@ type Options struct {
 	Sink          event.Sink
 	Policy        permission.Policy
 	Label         string
+	ModelRef      string
 	SystemPrompt  string
 	SessionDir    string
 	SessionPath   string
@@ -307,6 +309,7 @@ func New(opts Options) *Controller {
 		sink:                   sink,
 		policy:                 opts.Policy,
 		label:                  opts.Label,
+		modelRef:               opts.ModelRef,
 		systemPrompt:           opts.SystemPrompt,
 		sessionDir:             opts.SessionDir,
 		sessionPath:            opts.SessionPath,
@@ -2052,6 +2055,12 @@ func (c *Controller) snapshot(markActivity bool) error {
 	if !markActivity {
 		if _, err := agent.EnsureBranchMeta(path); err != nil {
 			return err
+		}
+		// Persist the model ref so resume can restore the correct model.
+		if ref := c.modelRef; ref != "" {
+			if err := agent.SetBranchModel(path, ref); err != nil {
+				return err
+			}
 		}
 	}
 	if err := s.Save(path); err != nil {


### PR DESCRIPTION
Fixes #4519.

### What happened

When a conversation is started with a custom model (e.g. from OpenRouter) and the user closes and reopens Reasonix, resuming that conversation falls back to the default model instead of using the original custom model.

### Root cause

The model ref was never stored inside the session file. It was held only in:

- Desktop tab state (`tab.model` → `desktop-tabs.json`): lost on restart if model resolution silently falls back and overwrites it
- Controller memory (`label`): gone on close
- Session filename: cosmetic, never parsed back

### Fix

Store the full model ref (e.g. `"openrouter/anthropic/claude-sonnet"`) in the `.jsonl.meta` sidecar (BranchMeta) and read it back on every resume path:

- **BranchMeta**: new `Model` field + `LoadSessionModel()` / `SetBranchModel()` helpers
- **Controller**: new `modelRef` field, persisted to BranchMeta on every `snapshot()`
- **CLI** (`--continue`, `--resume`, `chat`, `run`, `serve`): read model from session meta before building controller, unless `--model` is explicitly set
- **Desktop**: `buildTabController` prefers the session meta model over `tab.model`
- **TUI `/resume`**: warns when the target session was created with a different model

### Backward compatibility

Old sessions without a model in their `.jsonl.meta` sidecar fall through to the existing behaviour (`tab.model` → `cfg.DefaultModel`). The model is written on the next snapshot after this change lands.