### PR TITLE
Ignore ResizeObserver loop notices in crash reporting / 忽略 ResizeObserver 循环通知的崩溃上报

### DIFF
--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -44,6 +44,24 @@ eq(payload.componentStack, "component stack", "captures component stack");
 eq(payload.message.includes("[unhandledrejection]"), true, "keeps human-readable message");
 eq(shouldReportGlobalCrashEvent({ defaultPrevented: false }), true, "reports unhandled global events by default");
 eq(shouldReportGlobalCrashEvent({ defaultPrevented: true }), false, "ignores global events already handled by a filter");
+eq(
+  shouldReportGlobalCrashEvent({ defaultPrevented: false, message: "ResizeObserver loop limit exceeded" }),
+  false,
+  "ignores Chromium ResizeObserver loop limit notices",
+);
+eq(
+  shouldReportGlobalCrashEvent({
+    defaultPrevented: false,
+    message: "ResizeObserver loop completed with undelivered notifications.",
+  }),
+  false,
+  "ignores Chromium ResizeObserver undelivered notification notices",
+);
+eq(
+  shouldReportGlobalCrashEvent({ defaultPrevented: false, error: new Error("ResizeObserver loop limit exceeded") }),
+  false,
+  "ignores ResizeObserver notices delivered through ErrorEvent.error",
+);
 
 const perf: PerformanceSnapshot = {
   reason: "event loop lag 1300ms",

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -532,8 +532,29 @@ export function reportCrash(label: string, err: unknown, extra?: string) {
   paint(buildCrashPayload(label, err, extra));
 }
 
-export function shouldReportGlobalCrashEvent(e: Pick<Event, "defaultPrevented">): boolean {
-  return !e.defaultPrevented;
+type GlobalCrashEventLike = Pick<Event, "defaultPrevented"> & {
+  message?: unknown;
+  error?: unknown;
+};
+
+const RESIZE_OBSERVER_LOOP_MESSAGE_RE =
+  /^ResizeObserver loop (?:limit exceeded|completed with undelivered notifications\.?)$/;
+
+function globalCrashEventMessage(e: GlobalCrashEventLike): string {
+  if (typeof e.message === "string") return e.message.trim();
+  const error = e.error;
+  if (typeof error === "string") return error.trim();
+  if (error && typeof error === "object" && "message" in error) {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === "string") return msg.trim();
+  }
+  return "";
+}
+
+export function shouldReportGlobalCrashEvent(e: GlobalCrashEventLike): boolean {
+  if (e.defaultPrevented) return false;
+  if (RESIZE_OBSERVER_LOOP_MESSAGE_RE.test(globalCrashEventMessage(e))) return false;
+  return true;
 }
 
 export function shouldPromptForPerformanceLabel(


### PR DESCRIPTION
## Summary
- Ignore Chromium/WebView ResizeObserver loop notices in the global crash reporter.
- Preserve reporting for normal unhandled global errors and already-handled event suppression.
- Add crash-reporting coverage for ResizeObserver messages delivered through both `message` and `ErrorEvent.error`.

## Verification
- `pnpm exec tsx src/__tests__/crash-reporting.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`
