### PR TITLE
Check nested ResizeObserver errors / 检查嵌套 ResizeObserver 错误

### DIFF
--- a/desktop/frontend/src/__tests__/crash-reporting.test.ts
+++ b/desktop/frontend/src/__tests__/crash-reporting.test.ts
@@ -62,6 +62,24 @@ eq(
   false,
   "ignores ResizeObserver notices delivered through ErrorEvent.error",
 );
+eq(
+  shouldReportGlobalCrashEvent({
+    defaultPrevented: false,
+    message: "",
+    error: new Error("ResizeObserver loop limit exceeded"),
+  }),
+  false,
+  "checks ErrorEvent.error when ErrorEvent.message is empty",
+);
+eq(
+  shouldReportGlobalCrashEvent({
+    defaultPrevented: false,
+    message: "Uncaught Error",
+    error: new Error("ResizeObserver loop limit exceeded"),
+  }),
+  false,
+  "checks ErrorEvent.error when ErrorEvent.message is a wrapper",
+);
 
 const perf: PerformanceSnapshot = {
   reason: "event loop lag 1300ms",

--- a/desktop/frontend/src/lib/crash.ts
+++ b/desktop/frontend/src/lib/crash.ts
@@ -540,20 +540,25 @@ type GlobalCrashEventLike = Pick<Event, "defaultPrevented"> & {
 const RESIZE_OBSERVER_LOOP_MESSAGE_RE =
   /^ResizeObserver loop (?:limit exceeded|completed with undelivered notifications\.?)$/;
 
-function globalCrashEventMessage(e: GlobalCrashEventLike): string {
-  if (typeof e.message === "string") return e.message.trim();
+function globalCrashEventMessages(e: GlobalCrashEventLike): string[] {
+  const messages: string[] = [];
+  const pushMessage = (message: string) => {
+    const trimmed = message.trim();
+    if (trimmed) messages.push(trimmed);
+  };
+  if (typeof e.message === "string") pushMessage(e.message);
   const error = e.error;
-  if (typeof error === "string") return error.trim();
+  if (typeof error === "string") pushMessage(error);
   if (error && typeof error === "object" && "message" in error) {
     const msg = (error as { message?: unknown }).message;
-    if (typeof msg === "string") return msg.trim();
+    if (typeof msg === "string") pushMessage(msg);
   }
-  return "";
+  return messages;
 }
 
 export function shouldReportGlobalCrashEvent(e: GlobalCrashEventLike): boolean {
   if (e.defaultPrevented) return false;
-  if (RESIZE_OBSERVER_LOOP_MESSAGE_RE.test(globalCrashEventMessage(e))) return false;
+  if (globalCrashEventMessages(e).some((message) => RESIZE_OBSERVER_LOOP_MESSAGE_RE.test(message))) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Follow up on #4622 by checking all available global error messages instead of returning after the first `ErrorEvent.message` string.
- Suppress ResizeObserver loop notices when the browser puts the meaningful text on `ErrorEvent.error.message` and leaves `ErrorEvent.message` empty or wrapped.
- Add regression coverage for empty and wrapper `ErrorEvent.message` cases.

## Verification
- `pnpm exec tsx src/__tests__/crash-reporting.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`
