### PR TITLE
Fix ACP Zed integration gaps / 修复 ACP 的 Zed 集成缺口

### DIFF
--- a/internal/acp/dispatch.go
+++ b/internal/acp/dispatch.go
@@ -47,6 +47,7 @@ type updateSink struct {
 	conn      notifier
 	sessionID string
 	approve   func(id string, allow, session, persist bool)
+	answer    func(id string, answers []event.AskAnswer)
 	mu        sync.Mutex
 	turnCtx   context.Context
 }
@@ -63,6 +64,12 @@ func (s *updateSink) bindApprove(fn func(id string, allow, session, persist bool
 		return
 	}
 	s.approve = fn
+}
+
+// bindAnswer installs the controller's AnswerQuestion callback for AskRequest
+// events.
+func (s *updateSink) bindAnswer(fn func(id string, answers []event.AskAnswer)) {
+	s.answer = fn
 }
 
 func (s *updateSink) setTurnContext(ctx context.Context) {
@@ -158,6 +165,13 @@ func (s *updateSink) Emit(e event.Event) {
 		// (the agent emits serially); the answer unblocks the loop.
 		turnCtx := s.currentTurnContext()
 		go s.requestPermission(turnCtx, e.Approval)
+
+	case event.AskRequest:
+		// ACP has no separate "ask the user a business question" method. Reuse
+		// the standard permission round-trip with the question options as choices;
+		// clients such as Zed already know how to render this interaction.
+		turnCtx := s.currentTurnContext()
+		go s.requestAsk(turnCtx, e.Ask)
 	}
 }
 
@@ -243,6 +257,78 @@ func (s *updateSink) requestPermission(ctx context.Context, a event.Approval) {
 		}
 	}
 	s.approve(a.ID, allow, session, persist)
+}
+
+func (s *updateSink) requestAsk(ctx context.Context, a event.Ask) {
+	if s.answer == nil {
+		return
+	}
+	answers := make([]event.AskAnswer, 0, len(a.Questions))
+	for _, q := range a.Questions {
+		selected, ok := s.requestAskQuestion(ctx, a.ID, q)
+		if !ok {
+			s.answer(a.ID, nil)
+			return
+		}
+		answers = append(answers, event.AskAnswer{QuestionID: q.ID, Selected: []string{selected}})
+	}
+	s.answer(a.ID, answers)
+}
+
+func (s *updateSink) requestAskQuestion(ctx context.Context, askID string, q event.AskQuestion) (string, bool) {
+	title := strings.TrimSpace(q.Prompt)
+	if title == "" {
+		title = strings.TrimSpace(q.Header)
+	}
+	if title == "" {
+		title = "Question"
+	}
+	content := []toolContent(nil)
+	if q.Header != "" && q.Header != title {
+		content = append(content, toolContent{Type: "content", Content: textBlock(q.Header)})
+	}
+	options := make([]PermissionOption, 0, len(q.Options)+1)
+	labelsByID := make(map[string]string, len(q.Options))
+	for i, opt := range q.Options {
+		id := fmt.Sprintf("%s:%d", q.ID, i+1)
+		name := strings.TrimSpace(opt.Label)
+		if strings.TrimSpace(opt.Description) != "" {
+			name += " - " + strings.TrimSpace(opt.Description)
+		}
+		options = append(options, PermissionOption{OptionID: id, Name: name, Kind: OptAllowOnce})
+		labelsByID[id] = opt.Label
+	}
+	options = append(options, PermissionOption{OptionID: q.ID + ":cancel", Name: "Cancel", Kind: OptRejectOnce})
+
+	rawInput, _ := json.Marshal(map[string]any{
+		"id":       q.ID,
+		"question": title,
+		"options":  q.Options,
+		"multi":    q.Multi,
+	})
+	params := PermissionRequestParams{
+		SessionID: s.sessionID,
+		ToolCall: PermissionToolCall{
+			ToolCallID: "ask-" + askID + "-" + q.ID,
+			Title:      title,
+			Kind:       "other",
+			Status:     "pending",
+			Content:    content,
+			RawInput:   rawInput,
+		},
+		Options: options,
+	}
+
+	raw, err := s.conn.Request(ctx, "session/request_permission", params)
+	if err != nil {
+		return "", false
+	}
+	var res PermissionRequestResult
+	if json.Unmarshal(raw, &res) != nil || res.Outcome.Outcome != "selected" {
+		return "", false
+	}
+	label, ok := labelsByID[res.Outcome.OptionID]
+	return label, ok
 }
 
 func approvalOptionNames(tool, subject string) (session, persistent string) {

--- a/internal/acp/dispatch_test.go
+++ b/internal/acp/dispatch_test.go
@@ -306,6 +306,96 @@ func TestUpdateSinkApprovalDenied(t *testing.T) {
 	}
 }
 
+func TestUpdateSinkAskRequestUsesPermissionChoices(t *testing.T) {
+	fn := &fakeNotifier{onReq: func(method string, params any) (json.RawMessage, error) {
+		if method != "session/request_permission" {
+			t.Errorf("request method = %q, want session/request_permission", method)
+		}
+		raw, _ := json.Marshal(params)
+		var p PermissionRequestParams
+		if err := json.Unmarshal(raw, &p); err != nil {
+			t.Fatalf("permission params: %v", err)
+		}
+		if p.SessionID != "sess-1" {
+			t.Errorf("sessionId = %q", p.SessionID)
+		}
+		if p.ToolCall.ToolCallID != "ask-ask-1-q1" {
+			t.Errorf("toolCallId = %q, want ask-ask-1-q1", p.ToolCall.ToolCallID)
+		}
+		if p.ToolCall.Title != "Choose a target" {
+			t.Errorf("title = %q", p.ToolCall.Title)
+		}
+		if len(p.Options) != 3 {
+			t.Fatalf("options = %+v, want two answers plus cancel", p.Options)
+		}
+		if p.Options[0].Name != "Tests - Run the suite" || p.Options[0].Kind != OptAllowOnce {
+			t.Fatalf("first option = %+v", p.Options[0])
+		}
+		res, _ := json.Marshal(PermissionRequestResult{
+			Outcome: PermissionOutcome{Outcome: "selected", OptionID: "q1:2"},
+		})
+		return res, nil
+	}}
+	sink := newUpdateSink(fn, "sess-1")
+	got := make(chan []event.AskAnswer, 1)
+	sink.bindAnswer(func(id string, answers []event.AskAnswer) {
+		if id != "ask-1" {
+			t.Errorf("answer id = %q, want ask-1", id)
+		}
+		got <- answers
+	})
+
+	sink.Emit(event.Event{Kind: event.AskRequest, Ask: event.Ask{
+		ID: "ask-1",
+		Questions: []event.AskQuestion{{
+			ID:     "q1",
+			Header: "Topic",
+			Prompt: "Choose a target",
+			Options: []event.AskOption{
+				{Label: "Tests", Description: "Run the suite"},
+				{Label: "Docs"},
+			},
+		}},
+	}})
+
+	select {
+	case answers := <-got:
+		if len(answers) != 1 || answers[0].QuestionID != "q1" || len(answers[0].Selected) != 1 || answers[0].Selected[0] != "Docs" {
+			t.Fatalf("answers = %+v, want q1 Docs", answers)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask answer was never called")
+	}
+}
+
+func TestUpdateSinkAskCancelledReturnsNoAnswers(t *testing.T) {
+	fn := &fakeNotifier{onReq: func(string, any) (json.RawMessage, error) {
+		res, _ := json.Marshal(PermissionRequestResult{Outcome: PermissionOutcome{Outcome: "cancelled"}})
+		return res, nil
+	}}
+	sink := newUpdateSink(fn, "sess-1")
+	got := make(chan []event.AskAnswer, 1)
+	sink.bindAnswer(func(_ string, answers []event.AskAnswer) { got <- answers })
+
+	sink.Emit(event.Event{Kind: event.AskRequest, Ask: event.Ask{
+		ID: "ask-2",
+		Questions: []event.AskQuestion{{
+			ID:      "q1",
+			Prompt:  "Continue?",
+			Options: []event.AskOption{{Label: "Yes"}, {Label: "No"}},
+		}},
+	}})
+
+	select {
+	case answers := <-got:
+		if answers != nil {
+			t.Fatalf("answers = %+v, want nil on cancelled ask", answers)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask cancellation was never returned")
+	}
+}
+
 func TestUpdateSinkApprovalUsesTurnContext(t *testing.T) {
 	reqStarted := make(chan struct{})
 	fn := &fakeNotifier{onReqCtx: func(ctx context.Context, _ string, _ any) (json.RawMessage, error) {

--- a/internal/acp/protocol.go
+++ b/internal/acp/protocol.go
@@ -50,12 +50,12 @@ type Implementation struct {
 
 // InitializeResult advertises what this agent supports: persisted session load,
 // ACP v1 session lifecycle helpers, inline resource text (embeddedContext) but
-// not image/audio, and stdio-only MCP (no http/sse).
+// not image/audio, and stdio / Streamable HTTP MCP (no legacy sse).
 type InitializeResult struct {
 	ProtocolVersion   int               `json:"protocolVersion"`
 	AgentCapabilities AgentCapabilities `json:"agentCapabilities"`
 	AgentInfo         Implementation    `json:"agentInfo"`
-	AuthMethods       []any             `json:"authMethods"`
+	AuthMethods       []AuthMethod      `json:"authMethods"`
 }
 
 // AgentCapabilities is the agentCapabilities object in InitializeResult.
@@ -90,22 +90,44 @@ type MCPCapabilities struct {
 	SSE  bool `json:"sse"`
 }
 
+// AuthMethod advertises how a client can prepare credentials for the agent.
+type AuthMethod struct {
+	ID          string            `json:"id"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	Type        string            `json:"type,omitempty"`
+	Args        []string          `json:"args,omitempty"`
+	Env         map[string]string `json:"env,omitempty"`
+}
+
+// AuthenticateParams selects one advertised auth method. Terminal methods are
+// normally handled by the client by launching the agent with the method's args;
+// accepting this request keeps clients that call authenticate directly working.
+type AuthenticateParams struct {
+	MethodID string `json:"methodId"`
+}
+
+// AuthenticateResult is the empty authentication ack.
+type AuthenticateResult struct{}
+
 // --- session/new ---
 
-// SessionNewParams opens a session rooted at cwd, optionally with stdio MCP
-// servers the agent should connect for the session's lifetime.
+// SessionNewParams opens a session rooted at cwd, optionally with MCP servers
+// the agent should connect for the session's lifetime.
 type SessionNewParams struct {
 	Cwd        string          `json:"cwd,omitempty"`
 	MCPServers []MCPServerSpec `json:"mcpServers,omitempty"`
 }
 
-// MCPServerSpec describes one stdio MCP server the client asks the agent to run.
+// MCPServerSpec describes one MCP server the client asks the agent to connect.
 type MCPServerSpec struct {
-	Name    string   `json:"name"`
-	Type    string   `json:"type,omitempty"`
-	Command string   `json:"command,omitempty"`
-	Args    []string `json:"args,omitempty"`
-	Env     MCPEnv   `json:"env,omitempty"`
+	Name    string            `json:"name"`
+	Type    string            `json:"type,omitempty"`
+	Command string            `json:"command,omitempty"`
+	Args    []string          `json:"args,omitempty"`
+	Env     MCPEnv            `json:"env,omitempty"`
+	URL     string            `json:"url,omitempty"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 // MCPEnv accepts ACP's official EnvVariable[] shape while still accepting the
@@ -407,6 +429,26 @@ type toolContent struct {
 	Content ContentBlock `json:"content"`
 }
 
+// availableCommandsUpdate advertises slash commands that the ACP client may
+// surface in its composer. The client sends invocations back as normal
+// session/prompt text such as "/review diff".
+type availableCommandsUpdate struct {
+	SessionUpdate     string             `json:"sessionUpdate"`
+	AvailableCommands []AvailableCommand `json:"availableCommands"`
+}
+
+// AvailableCommand is one slash command available in a session.
+type AvailableCommand struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Input       *AvailableCommandInput `json:"input,omitempty"`
+}
+
+// AvailableCommandInput describes a command's free-form text argument.
+type AvailableCommandInput struct {
+	Hint string `json:"hint"`
+}
+
 // configOptionUpdate reports a complete refreshed session config state.
 type configOptionUpdate struct {
 	SessionUpdate string                `json:"sessionUpdate"`
@@ -453,6 +495,7 @@ type PermissionToolCall struct {
 	Title      string          `json:"title,omitempty"`
 	Kind       string          `json:"kind,omitempty"`
 	Status     string          `json:"status,omitempty"`
+	Content    []toolContent   `json:"content,omitempty"`
 	RawInput   json.RawMessage `json:"rawInput,omitempty"`
 }
 

--- a/internal/acp/protocol_test.go
+++ b/internal/acp/protocol_test.go
@@ -142,13 +142,14 @@ func TestMcpSpecsNil(t *testing.T) {
 func TestMcpSpecsConversion(t *testing.T) {
 	in := []MCPServerSpec{
 		{Name: "search", Command: "search-mcp", Args: []string{"--stdio"}, Env: MCPEnv{"HOME": "/tmp"}},
+		{Name: "remote", Type: "http", URL: "https://mcp.example.test", Headers: map[string]string{"Authorization": "Bearer token"}},
 	}
 	got, err := mcpSpecs(in, "/workspace")
 	if err != nil {
 		t.Fatalf("mcpSpecs: %v", err)
 	}
-	if len(got) != 1 {
-		t.Fatalf("len = %d, want 1", len(got))
+	if len(got) != 2 {
+		t.Fatalf("len = %d, want 2", len(got))
 	}
 	if got[0].Name != "search" || got[0].Type != "stdio" || got[0].Command != "search-mcp" {
 		t.Errorf("spec = %+v", got[0])
@@ -161,6 +162,12 @@ func TestMcpSpecsConversion(t *testing.T) {
 	}
 	if got[0].Dir != "/workspace" {
 		t.Errorf("dir = %q, want /workspace", got[0].Dir)
+	}
+	if got[1].Name != "remote" || got[1].Type != "http" || got[1].URL != "https://mcp.example.test" {
+		t.Errorf("http spec = %+v", got[1])
+	}
+	if got[1].Headers["Authorization"] != "Bearer token" {
+		t.Errorf("headers = %v", got[1].Headers)
 	}
 }
 
@@ -188,9 +195,13 @@ func TestMCPEnvAcceptsOfficialArrayShape(t *testing.T) {
 }
 
 func TestMcpSpecsRejectsUnsupportedTransport(t *testing.T) {
-	_, err := mcpSpecs([]MCPServerSpec{{Name: "remote", Type: "http", Command: "ignored"}}, "/tmp")
+	_, err := mcpSpecs([]MCPServerSpec{{Name: "remote", Type: "sse", URL: "https://example.test/sse"}}, "/tmp")
 	if err == nil || !strings.Contains(err.Error(), "unsupported transport") {
 		t.Fatalf("mcpSpecs unsupported transport err = %v", err)
+	}
+	_, err = mcpSpecs([]MCPServerSpec{{Name: "remote", Type: "http"}}, "/tmp")
+	if err == nil || !strings.Contains(err.Error(), "url is required") {
+		t.Fatalf("mcpSpecs missing url err = %v", err)
 	}
 }
 

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -3,6 +3,7 @@ package acp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/command"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
@@ -40,6 +42,23 @@ type fakeFactory struct {
 func (f *fakeFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
 	runner := &fakeRunner{sink: p.Sink, behavior: f.behavior}
 	return control.New(control.Options{Runner: runner, Sink: p.Sink}), nil
+}
+
+type commandFactory struct {
+	commands []command.Command
+	seen     chan string
+}
+
+func (f *commandFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
+	runner := &fakeRunner{
+		sink: p.Sink,
+		behavior: func(_ context.Context, sink event.Sink, input string) error {
+			f.seen <- input
+			sink.Emit(event.Event{Kind: event.Text, Text: input})
+			return nil
+		},
+	}
+	return control.New(control.Options{Runner: runner, Sink: p.Sink, Commands: f.commands}), nil
 }
 
 type configurableFactory struct {
@@ -333,6 +352,21 @@ func TestServeLifecycle(t *testing.T) {
 	if ir.AgentCapabilities.PromptCapabilities.Image {
 		t.Errorf("image must not be advertised")
 	}
+	if len(ir.AuthMethods) != 1 || ir.AuthMethods[0].ID != "reasonix-setup" || ir.AuthMethods[0].Type != "terminal" {
+		t.Fatalf("authMethods = %+v, want terminal reasonix setup", ir.AuthMethods)
+	}
+	if len(ir.AuthMethods[0].Args) != 1 || ir.AuthMethods[0].Args[0] != "setup" {
+		t.Fatalf("auth args = %+v, want [setup]", ir.AuthMethods[0].Args)
+	}
+
+	authResp := client.call(t, "authenticate", AuthenticateParams{MethodID: "reasonix-setup"})
+	if authResp.Error != nil {
+		t.Fatalf("authenticate errored: %+v", authResp.Error)
+	}
+	badAuthResp := client.call(t, "authenticate", AuthenticateParams{MethodID: "missing"})
+	if badAuthResp.Error == nil || badAuthResp.Error.Code != ErrInvalidParams {
+		t.Fatalf("bad authenticate = %+v, want invalid params", badAuthResp.Error)
+	}
 
 	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
 	var nr SessionNewResult
@@ -361,6 +395,72 @@ func TestServeLifecycle(t *testing.T) {
 	}
 	if pr.StopReason != StopEndTurn {
 		t.Errorf("stopReason = %q, want %q", pr.StopReason, StopEndTurn)
+	}
+}
+
+func TestServeAdvertisesAndExpandsCustomCommands(t *testing.T) {
+	factory := &commandFactory{
+		seen: make(chan string, 1),
+		commands: []command.Command{{
+			Name:        "review",
+			Description: "Review the target",
+			ArgHint:     "path",
+			Body:        "Review $1",
+		}},
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil || nr.SessionID == "" {
+		t.Fatalf("session/new result: %v (%q)", err, nr.SessionID)
+	}
+
+	var advertised bool
+	select {
+	case n := <-client.notifs:
+		var p struct {
+			Update struct {
+				SessionUpdate     string             `json:"sessionUpdate"`
+				AvailableCommands []AvailableCommand `json:"availableCommands"`
+			} `json:"update"`
+		}
+		if err := json.Unmarshal(n.Params, &p); err != nil {
+			t.Fatalf("available commands update: %v", err)
+		}
+		for _, cmd := range p.Update.AvailableCommands {
+			if p.Update.SessionUpdate == "available_commands_update" &&
+				cmd.Name == "review" &&
+				cmd.Description == "Review the target" &&
+				cmd.Input != nil &&
+				cmd.Input.Hint == "path" {
+				advertised = true
+			}
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for available_commands_update")
+	}
+	if !advertised {
+		t.Fatal("review command was not advertised")
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "/review src/main.go"}},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("prompt errored: %+v", resp.Error)
+	}
+	select {
+	case got := <-factory.seen:
+		if got != "Review src/main.go" {
+			t.Fatalf("runner input = %q, want expanded command", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runner did not receive prompt")
 	}
 }
 
@@ -632,6 +732,32 @@ func TestServeCancel(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("cancel did not end the prompt")
+	}
+}
+
+func TestServePromptErrorIsNotReportedAsCancelled(t *testing.T) {
+	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error {
+		return errors.New("provider failed")
+	}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{})
+	var nr SessionNewResult
+	json.Unmarshal(newResp.Result, &nr)
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "fail"}},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	var pr SessionPromptResult
+	if err := json.Unmarshal(resp.Result, &pr); err != nil {
+		t.Fatalf("prompt result: %v", err)
+	}
+	if pr.StopReason != StopError {
+		t.Errorf("stopReason = %q, want error", pr.StopReason)
 	}
 }
 

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -30,8 +30,8 @@ import (
 //
 // Cwd roots the session's file tools and bash (built via builtin.Workspace).
 // Model and EffortOverride are optional session-local provider selectors from
-// ACP config options. MCPServers are the stdio MCP servers the client asked the
-// agent to connect for this session.
+// ACP config options. MCPServers are the MCP servers the client asked the agent
+// to connect for this session.
 type SessionParams struct {
 	Cwd            string
 	MCPServers     []plugin.Spec
@@ -102,6 +102,7 @@ func Serve(ctx context.Context, r io.Reader, w io.Writer, factory Factory, info 
 		sessions: make(map[string]*acpSession),
 	}
 	conn.Handle("initialize", svc.initialize)
+	conn.Handle("authenticate", svc.authenticate)
 	conn.Handle("session/new", svc.sessionNew)
 	conn.Handle("session/load", svc.sessionLoad)
 	conn.Handle("session/resume", svc.sessionResume)
@@ -217,7 +218,8 @@ func (s *acpSession) deleteAndWait() {
 
 // initialize advertises the agent's capability set: persisted load plus ACP v1
 // list/resume/close/delete lifecycle helpers, prompts carrying inline resource
-// text (embeddedContext) but not image/audio, and stdio-only MCP (no http/sse).
+// text (embeddedContext) but not image/audio, and stdio / Streamable HTTP MCP
+// (no legacy sse).
 func (s *service) initialize(_ context.Context, _ json.RawMessage) (any, error) {
 	return InitializeResult{
 		ProtocolVersion: ProtocolVersion,
@@ -234,11 +236,32 @@ func (s *service) initialize(_ context.Context, _ json.RawMessage) (any, error) 
 				Audio:           false,
 				EmbeddedContext: true,
 			},
-			MCPCapabilities: MCPCapabilities{HTTP: false, SSE: false},
+			MCPCapabilities: MCPCapabilities{HTTP: true, SSE: false},
 		},
 		AgentInfo:   Implementation{Name: s.info.Name, Version: s.info.Version},
-		AuthMethods: []any{},
+		AuthMethods: []AuthMethod{reasonixSetupAuthMethod()},
 	}, nil
+}
+
+func reasonixSetupAuthMethod() AuthMethod {
+	return AuthMethod{
+		ID:          "reasonix-setup",
+		Name:        "Reasonix setup",
+		Description: "Configure Reasonix providers and credentials in a terminal",
+		Type:        "terminal",
+		Args:        []string{"setup"},
+	}
+}
+
+func (s *service) authenticate(_ context.Context, raw json.RawMessage) (any, error) {
+	var p AuthenticateParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "authenticate: " + err.Error()}
+	}
+	if strings.TrimSpace(p.MethodID) != reasonixSetupAuthMethod().ID {
+		return nil, &RPCError{Code: ErrInvalidParams, Message: "authenticate: unknown methodId " + p.MethodID}
+	}
+	return AuthenticateResult{}, nil
 }
 
 // sessionNew opens a session: it mints an id, builds the session's sink bound to
@@ -283,6 +306,7 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	}
 	ctrl.EnableInteractiveApproval()
 	sink.bindApprove(ctrl.Approve)
+	sink.bindAnswer(ctrl.AnswerQuestion)
 
 	now := time.Now().UTC()
 	sess := &acpSession{
@@ -307,6 +331,7 @@ func (s *service) sessionNew(ctx context.Context, raw json.RawMessage) (any, err
 	s.mu.Lock()
 	s.sessions[id] = sess
 	s.mu.Unlock()
+	s.sendAvailableCommands(sess)
 
 	return SessionNewResult{
 		SessionID:     id,
@@ -404,6 +429,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	}
 	ctrl.EnableInteractiveApproval()
 	sink.bindApprove(ctrl.Approve)
+	sink.bindAnswer(ctrl.AnswerQuestion)
 
 	dir := ctrl.SessionDir()
 	if dir == "" {
@@ -441,6 +467,7 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	s.mu.Lock()
 	s.sessions[id] = sess
 	s.mu.Unlock()
+	s.sendAvailableCommands(sess)
 
 	if replay {
 		sink.replay(ctrl.History())
@@ -472,6 +499,7 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 	if text == "" {
 		return nil, &RPCError{Code: ErrInvalidParams, Message: "session/prompt: empty prompt"}
 	}
+	text = s.resolveSlashPrompt(ctx, sess, text)
 
 	runCtx, cancel, ok := sess.begin(ctx)
 	if !ok {
@@ -639,6 +667,7 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	}
 	newCtrl.EnableInteractiveApproval()
 	sink.bindApprove(newCtrl.Approve)
+	sink.bindAnswer(newCtrl.AnswerQuestion)
 	if len(carried) > 0 {
 		newCtrl.Resume(&agent.Session{Messages: carried}, prevPath)
 	} else if prevPath != "" {
@@ -655,6 +684,7 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	sess.mu.Unlock()
 
 	cur.ReleaseResources()
+	s.sendAvailableCommands(sess)
 	sink.send(configOptionUpdate{SessionUpdate: "config_option_update", ConfigOptions: cfgState.ConfigOptions})
 	return nil
 }
@@ -1029,6 +1059,100 @@ func (s *acpSession) info() SessionInfo {
 	return meta.info(extra)
 }
 
+func (s *service) sendAvailableCommands(sess *acpSession) {
+	if sess == nil || sess.ctrl == nil {
+		return
+	}
+	cmds := availableCommandsFor(sess.ctrl)
+	if len(cmds) == 0 {
+		return
+	}
+	sess.sink.send(availableCommandsUpdate{
+		SessionUpdate:     "available_commands_update",
+		AvailableCommands: cmds,
+	})
+}
+
+func availableCommandsFor(ctrl *control.Controller) []AvailableCommand {
+	if ctrl == nil {
+		return nil
+	}
+	byName := map[string]AvailableCommand{}
+	for _, cmd := range ctrl.Commands() {
+		name := strings.TrimSpace(cmd.Name)
+		if name == "" {
+			continue
+		}
+		desc := strings.TrimSpace(cmd.Description)
+		if desc == "" {
+			desc = "Run the " + name + " command"
+		}
+		ac := AvailableCommand{Name: name, Description: desc}
+		if hint := strings.TrimSpace(cmd.ArgHint); hint != "" {
+			ac.Input = &AvailableCommandInput{Hint: hint}
+		}
+		byName[name] = ac
+	}
+	for _, sk := range ctrl.Skills() {
+		name := strings.TrimSpace(sk.Name)
+		if name == "" {
+			continue
+		}
+		if _, exists := byName[name]; exists {
+			continue
+		}
+		desc := strings.TrimSpace(sk.Description)
+		if desc == "" {
+			desc = "Run the " + name + " skill"
+		}
+		byName[name] = AvailableCommand{
+			Name:        name,
+			Description: desc,
+			Input:       &AvailableCommandInput{Hint: "instructions"},
+		}
+	}
+	if host := ctrl.Host(); host != nil {
+		for _, prompt := range host.Prompts() {
+			name := strings.TrimSpace(prompt.Name)
+			if name == "" {
+				continue
+			}
+			desc := strings.TrimSpace(prompt.Description)
+			if desc == "" {
+				desc = "Run the " + name + " MCP prompt"
+			}
+			ac := AvailableCommand{Name: name, Description: desc}
+			if len(prompt.Args) > 0 {
+				ac.Input = &AvailableCommandInput{Hint: "arguments"}
+			}
+			byName[name] = ac
+		}
+	}
+	out := make([]AvailableCommand, 0, len(byName))
+	for _, cmd := range byName {
+		out = append(out, cmd)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+func (s *service) resolveSlashPrompt(ctx context.Context, sess *acpSession, text string) string {
+	line := strings.TrimSpace(text)
+	if sess == nil || sess.ctrl == nil || !strings.HasPrefix(line, "/") {
+		return text
+	}
+	if sent, ok := sess.ctrl.CustomCommand(line); ok {
+		return sent
+	}
+	if sent, ok := sess.ctrl.RunSkill(line); ok {
+		return sent
+	}
+	if sent, ok, err := sess.ctrl.MCPPrompt(ctx, line); err == nil && ok {
+		return sent
+	}
+	return text
+}
+
 type acpSessionMeta struct {
 	SessionID      string    `json:"sessionId"`
 	Cwd            string    `json:"cwd"`
@@ -1296,8 +1420,7 @@ func checkpointPath(sessionPath string) string {
 	return strings.TrimSuffix(sessionPath, ".jsonl") + ".ckpt"
 }
 
-// mcpSpecs converts ACP stdio MCP server declarations to plugin.Spec. ACP's
-// session/new only carries stdio servers (the agent advertises http/sse off).
+// mcpSpecs converts ACP MCP server declarations to plugin.Spec.
 func mcpSpecs(in []MCPServerSpec, cwd string) ([]plugin.Spec, error) {
 	if len(in) == 0 {
 		return nil, nil
@@ -1308,25 +1431,45 @@ func mcpSpecs(in []MCPServerSpec, cwd string) ([]plugin.Spec, error) {
 		if typ == "" {
 			typ = "stdio"
 		}
-		if typ != "stdio" {
-			return nil, fmt.Errorf("MCP server %q uses unsupported transport %q", m.Name, m.Type)
-		}
 		if strings.TrimSpace(m.Name) == "" {
 			return nil, fmt.Errorf("MCP server name is required")
 		}
-		if strings.TrimSpace(m.Command) == "" {
-			return nil, fmt.Errorf("MCP server %q command is required", m.Name)
+		switch typ {
+		case "stdio":
+			if strings.TrimSpace(m.Command) == "" {
+				return nil, fmt.Errorf("MCP server %q command is required", m.Name)
+			}
+		case "http", "streamable-http", "streamable_http":
+			if strings.TrimSpace(m.URL) == "" {
+				return nil, fmt.Errorf("MCP server %q url is required", m.Name)
+			}
+			typ = "http"
+		default:
+			return nil, fmt.Errorf("MCP server %q uses unsupported transport %q", m.Name, m.Type)
 		}
 		out = append(out, plugin.Spec{
-			Name:    m.Name,
+			Name:    strings.TrimSpace(m.Name),
 			Type:    typ,
-			Command: m.Command,
-			Args:    m.Args,
-			Env:     map[string]string(m.Env),
+			Command: strings.TrimSpace(m.Command),
+			Args:    append([]string(nil), m.Args...),
+			Env:     mapString(m.Env),
+			URL:     strings.TrimSpace(m.URL),
+			Headers: mapString(m.Headers),
 			Dir:     cwd,
 		})
 	}
 	return out, nil
+}
+
+func mapString(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // newSessionID returns a random RFC 4122 v4 UUID string used to address a session.


### PR DESCRIPTION
## Summary
- advertise ACP terminal auth via `reasonix setup` and accept `authenticate` for registry/client compatibility
- accept Streamable HTTP MCP server specs from ACP clients and advertise HTTP MCP capability
- send `available_commands_update` for loaded slash commands and expand `/command` prompts before running the turn
- route structured `ask` requests through ACP permission choices so Zed can render selectable options
- add regressions for `stopReason:error`, ACP auth, command advertising/expansion, HTTP MCP specs, and ask choices

## Verification
- `go test ./internal/acp ./internal/cli ./internal/control`
- `go test ./...`
- `printf ... | go run ./cmd/reasonix --acp` initialize smoke verified HTTP MCP capability and terminal auth method

Closes #2999
Closes #3509
Closes #4064
Closes #4205
Closes #4209
Closes #4499
Refs #3540