### PR TITLE
Allow manual stable npm releases / 支持手动稳定 npm 发布

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -10,8 +10,9 @@ name: Release npm
 #   git tag npm-vX.Y.Z-rc.N     # prerelease -> publishes under `next`
 #   git push origin <tag>
 #
-# A manual workflow_dispatch with base_version publishes an opt-in canary to the
-# `canary` dist-tag (npm i reasonix@canary) from the current ref; it never moves
+# A manual workflow_dispatch can publish either an opt-in canary from the current
+# ref or an approved stable/next version when tag creation is restricted. Canary
+# publishes to the `canary` dist-tag (npm i reasonix@canary) and never moves
 # `next`/`latest`. build.mjs decides the dist-tag: 0.x stable is `latest`; a
 # `-canary.` build is `canary`; the 1.x line and rc prereleases are `next`. Promote
 # a 1.x stable to the default install with `npm dist-tag add reasonix@X.Y.Z latest`.
@@ -20,8 +21,16 @@ on:
     tags: ['npm-v*']
   workflow_dispatch:
     inputs:
+      channel:
+        description: "Publish channel"
+        required: true
+        default: canary
+        type: choice
+        options:
+          - canary
+          - stable
       base_version:
-        description: "canary: intended next stable version, e.g. 1.5.0"
+        description: "Version to publish. Canary appends -canary.<run_number>; stable publishes exactly this version."
         required: true
         type: string
 
@@ -44,9 +53,10 @@ jobs:
     name: publish npm packages
     needs: cache-guard
     runs-on: ubuntu-latest
-    # A tag push (npm-v*) publishes a stable/next release and goes through the
-    # `release` environment (esengine approves); a canary dispatch runs free.
-    environment: ${{ github.event_name == 'workflow_dispatch' && 'canary' || 'release' }}
+    # A tag push (npm-v*) or manual stable dispatch publishes a stable/next
+    # release and goes through the `release` environment (esengine approves);
+    # canary dispatches run free.
+    environment: ${{ github.event_name == 'workflow_dispatch' && inputs.channel == 'canary' && 'canary' || 'release' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -57,14 +67,19 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      # Tag push uses the npm-v* tag; a canary dispatch synthesizes a
-      # <base>-canary.<run_number> version. build.mjs strips the leading `npm-`/`v`.
+      # Tag push uses the npm-v* tag. A canary dispatch synthesizes a
+      # <base>-canary.<run_number> version; a manual stable dispatch publishes
+      # the requested semver exactly. build.mjs strips the leading `npm-`/`v`.
       - name: Resolve version
         id: ver
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             base="${{ inputs.base_version }}"; base="${base#v}"
-            echo "arg=v${base}-canary.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+            if [ "${{ inputs.channel }}" = "canary" ]; then
+              echo "arg=v${base}-canary.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+            else
+              echo "arg=v${base}" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "arg=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary
- add a `channel` selector to the npm release workflow dispatch
- keep canary as the default manual dispatch behavior
- let maintainers publish an approved stable/next npm version from the current ref when repository rules block direct tag creation

## Why
- ACP registry requires a pure semver npx package version
- the ACP fixes are merged and verified in `reasonix@1.8.0-canary.9`, but `reasonix@1.8.0` still needs a stable npm publish before the prepared registry entry can pass CI

## Verification
- `node npm/build.mjs v1.8.0`
- `git diff --check`

Refs #3540