### PR TITLE
Surface credential source diagnostics / 显示凭据来源诊断

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5850,7 +5850,8 @@ func (a *App) ConnectKey(apiKey string) error {
 	if _, err := billing.FetchWithClient(ctx, nil, onboardingBalanceURL, apiKey); err != nil {
 		return fmt.Errorf("validate: %w", err)
 	}
-	if err := upsertDotEnv(onboardingKeyEnv, apiKey); err != nil {
+	warning, err := a.saveProviderCredential(onboardingKeyEnv, apiKey)
+	if err != nil {
 		return fmt.Errorf("save: %w", err)
 	}
 	if err := a.rebuild(); err != nil {
@@ -5860,6 +5861,9 @@ func (a *App) ConnectKey(apiKey string) error {
 			tab.StartupErr = err.Error()
 		}
 		a.mu.Unlock()
+	}
+	if warning != "" {
+		return fmt.Errorf("%s", warning)
 	}
 	return nil
 }

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -5840,19 +5840,19 @@ func (a *App) NeedsOnboarding() bool {
 
 // ConnectKey validates apiKey against the balance endpoint, persists it to the
 // global credential store, and rebuilds the controller so the new key takes effect.
-func (a *App) ConnectKey(apiKey string) error {
+func (a *App) ConnectKey(apiKey string) (string, error) {
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
-		return fmt.Errorf("key is required")
+		return "", fmt.Errorf("key is required")
 	}
 	ctx, cancel := context.WithTimeout(a.ctx, 8*time.Second)
 	defer cancel()
 	if _, err := billing.FetchWithClient(ctx, nil, onboardingBalanceURL, apiKey); err != nil {
-		return fmt.Errorf("validate: %w", err)
+		return "", fmt.Errorf("validate: %w", err)
 	}
 	warning, err := a.saveProviderCredential(onboardingKeyEnv, apiKey)
 	if err != nil {
-		return fmt.Errorf("save: %w", err)
+		return "", fmt.Errorf("save: %w", err)
 	}
 	if err := a.rebuild(); err != nil {
 		// Key is persisted; surface the failure but let the next rebuild load it.
@@ -5862,8 +5862,5 @@ func (a *App) ConnectKey(apiKey string) error {
 		}
 		a.mu.Unlock()
 	}
-	if warning != "" {
-		return fmt.Errorf("%s", warning)
-	}
-	return nil
+	return warning, nil
 }

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -815,6 +815,8 @@ func TestSettingsDoesNotInferBuiltInsWithoutKeys(t *testing.T) {
 
 func TestAddOfficialProviderAccessReplacesLegacyProviderWithoutModel(t *testing.T) {
 	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	os.Unsetenv("DEEPSEEK_API_KEY")
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -832,7 +832,7 @@ api_key_env = "DEEPSEEK_API_KEY"
 		t.Fatalf("write config: %v", err)
 	}
 
-	if err := NewApp().AddOfficialProviderAccess("deepseek", "test-key"); err != nil {
+	if _, err := NewApp().AddOfficialProviderAccess("deepseek", "test-key"); err != nil {
 		t.Fatalf("AddOfficialProviderAccess: %v", err)
 	}
 	cfg := config.LoadForEdit(config.UserConfigPath())
@@ -863,7 +863,7 @@ language = "zh"
 		t.Fatalf("write config: %v", err)
 	}
 
-	if err := NewApp().AddOfficialProviderAccess("deepseek", ""); err != nil {
+	if _, err := NewApp().AddOfficialProviderAccess("deepseek", ""); err != nil {
 		t.Fatalf("AddOfficialProviderAccess: %v", err)
 	}
 	cfg := config.LoadForEdit(config.UserConfigPath())

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -753,6 +753,8 @@ function normalizeProviderView(p: ProviderView): ProviderView {
     modelsUrl: p.modelsUrl ?? "",
     reasoningProtocol: normalizeReasoningProtocol(p.reasoningProtocol),
     supportedEfforts: asArray(p.supportedEfforts),
+    keySource: p.keySource ?? "",
+    keySourcePath: p.keySourcePath ?? "",
   };
 }
 
@@ -3589,6 +3591,8 @@ type ProviderAccessGroup = {
   providers: ProviderView[];
   apiKeyEnv: string;
   keySet: boolean;
+  keySource?: string;
+  keySourcePath?: string;
   baseUrl: string;
   kind: string;
   models: string[];
@@ -3845,6 +3849,7 @@ function ProviderAccessCard({
         <span>{group.kind}</span>
         <span>{group.baseUrl}</span>
         <span>{group.apiKeyEnv || t("common.none")}</span>
+        {group.keySource && <span title={group.keySourcePath || undefined}>{t("settings.keySource", { source: group.keySource })}</span>}
       </div>
 
       <div className="provider-card-block">
@@ -4028,6 +4033,8 @@ function providerAccessGroups(providers: ProviderView[], t: ReturnType<typeof us
     if (existing) {
       existing.providers.push(p);
       existing.keySet = existing.keySet || p.keySet;
+      if (!existing.keySource && p.keySource) existing.keySource = p.keySource;
+      if (!existing.keySourcePath && p.keySourcePath) existing.keySourcePath = p.keySourcePath;
       existing.models = uniqueStrings([...existing.models, ...p.models]);
       continue;
     }
@@ -4039,6 +4046,8 @@ function providerAccessGroups(providers: ProviderView[], t: ReturnType<typeof us
       providers: [p],
       apiKeyEnv: p.apiKeyEnv,
       keySet: p.keySet,
+      keySource: p.keySource,
+      keySourcePath: p.keySourcePath,
       baseUrl: p.baseUrl,
       kind: p.kind,
       models: uniqueStrings(p.models),
@@ -4302,7 +4311,10 @@ function ProviderEditor({
         {initial && onSaveKey && keyEnv && (
           <>
             <div className="provider-key-status provider-key-status--managed provider-key-status--compact">
-              <span>{initial.keySet ? t("settings.configuredKey", { env: keyEnv }) : t("settings.notConfiguredKey", { env: keyEnv })}</span>
+              <span title={initial.keySourcePath || undefined}>
+                {initial.keySet ? t("settings.configuredKey", { env: keyEnv }) : t("settings.notConfiguredKey", { env: keyEnv })}
+                {initial.keySource ? ` · ${t("settings.keySource", { source: initial.keySource })}` : ""}
+              </span>
               {initial.keySet && onClearKey && (
                 <InlineConfirmButton
                   label={t("settings.clearKey")}
@@ -4487,6 +4499,11 @@ function ProviderEditor({
       {initial && onSaveKey && apiKeyEnv.trim() && (
         <>
           <label className="set-label">{t("settings.providerKey")}</label>
+          {initial.keySource && (
+            <div className="mem-hint" title={initial.keySourcePath || undefined}>
+              {t("settings.keySource", { source: initial.keySource })}
+            </div>
+          )}
           <KeyField
             apiKeyEnv={apiKeyEnv.trim()}
             busy={busy || fetchingModels}

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -80,6 +80,7 @@ export function SettingsPanel({
   const [s, setS] = useState<SettingsView | null>(null);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
   const [theme, setThemeState] = useState<Theme>(getTheme());
   const [themeStyle, setThemeStyleState] = useState<ThemeStyle>(() => getThemeStyle(getTheme()));
   const [textSize, setTextSizeState] = useState<TextSize>(getTextSize());
@@ -105,13 +106,17 @@ export function SettingsPanel({
   }, [s?.desktopTheme, s?.desktopThemeStyle]);
 
   // apply runs a mutation, re-reads settings, and refreshes the topbar/model.
-  const apply = async (fn: () => Promise<void>) => {
+  const apply = async (fn: () => Promise<unknown>) => {
     setBusy(true);
     setErr(null);
+    setWarning(null);
     try {
-      await fn();
+      const result = await fn();
       await reload();
       onChanged();
+      if (typeof result === "string" && result.trim()) {
+        setWarning(result.trim());
+      }
     } catch (e) {
       setErr(String((e as Error)?.message ?? e));
     } finally {
@@ -120,6 +125,7 @@ export function SettingsPanel({
   };
   const backgroundApply = async (fn: () => Promise<void>) => {
     setErr(null);
+    setWarning(null);
     try {
       await fn();
       await reload();
@@ -166,6 +172,7 @@ export function SettingsPanel({
           </nav>
           <main className="settings-center__content">
             {needsSettings && err && <div className="banner banner--error">{err}</div>}
+            {needsSettings && warning && <div className="banner banner--warning">{warning}</div>}
             {needsSettings && !s ? (
               <div className="empty">{t("settings.loading")}</div>
             ) : (
@@ -247,7 +254,7 @@ export function SettingsPanel({
   );
 }
 
-function SettingsPageShell({ s: _s, tab, children }: { s: SettingsView | null; tab: SettingsTab; busy: boolean; apply: (fn: () => Promise<void>) => Promise<void>; children: ReactNode }) {
+function SettingsPageShell({ s: _s, tab, children }: { s: SettingsView | null; tab: SettingsTab; busy: boolean; apply: (fn: () => Promise<unknown>) => Promise<void>; children: ReactNode }) {
   const t = useT();
   const descKey = `settings.pageDesc.${tab}` as keyof typeof import("../locales/en").en;
   const desc = t(descKey as any);
@@ -359,7 +366,7 @@ function settingsTabPageTitle(id: SettingsTab, t: ReturnType<typeof useT>): stri
 type SectionProps = {
   s: SettingsView;
   busy: boolean;
-  apply: (fn: () => Promise<void>) => Promise<void>;
+  apply: (fn: () => Promise<unknown>) => Promise<void>;
 };
 
 type ModelsSectionProps = SectionProps & {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -227,11 +227,11 @@ export interface AppBindings {
   SetSubagentEffort(level: string): Promise<void>;
   SetAutoPlan(mode: string): Promise<void>;
   SaveProvider(p: ProviderView): Promise<void>;
-  AddOfficialProviderAccess(kind: string, key: string): Promise<void>;
+  AddOfficialProviderAccess(kind: string, key: string): Promise<string>;
   FetchProviderModels(p: ProviderView): Promise<string[]>;
   DeleteProvider(name: string): Promise<void>;
   RemoveProviderAccess(name: string): Promise<void>;
-  SetProviderKey(apiKeyEnv: string, value: string): Promise<void>;
+  SetProviderKey(apiKeyEnv: string, value: string): Promise<string>;
   ClearProviderKey(apiKeyEnv: string): Promise<void>;
   SetPermissionMode(mode: string): Promise<void>;
   AddPermissionRule(list: string, rule: string): Promise<void>;
@@ -271,7 +271,7 @@ export interface AppBindings {
   ApplyUpdate(): Promise<void>;
   OpenDownloadPage(): Promise<void>;
   NeedsOnboarding(): Promise<boolean>;
-  ConnectKey(apiKey: string): Promise<void>;
+  ConnectKey(apiKey: string): Promise<string>;
   // Crash overlay "Send report" (desktop/crash_app.go): scrubs user paths, attaches
   // version/os/arch, POSTs to the collection endpoint. Only ever sent on user click.
   ReportCrash(kind: string, detail: string): Promise<void>;
@@ -2375,6 +2375,7 @@ function makeMockApp(): AppBindings {
       const i = settings.providers.findIndex((x) => x.name === next.name);
       if (i >= 0) settings.providers[i] = { ...settings.providers[i], ...next, keySet: next.keySet || settings.providers[i].keySet };
       else settings.providers.push(next);
+      return "";
     },
     async FetchProviderModels(p: ProviderView) {
       if (!p.baseUrl.trim()) throw new Error(t("settings.fetchModelsMissingBaseUrl"));
@@ -2396,6 +2397,7 @@ function makeMockApp(): AppBindings {
       settings.providers.forEach((p) => {
         if (p.apiKeyEnv === apiKeyEnv) p.keySet = true;
       });
+      return "";
     },
     async ClearProviderKey(apiKeyEnv: string) {
       settings.providers.forEach((p) => {
@@ -2615,6 +2617,7 @@ function makeMockApp(): AppBindings {
         if (p.apiKeyEnv === "DEEPSEEK_API_KEY") p.keySet = true;
       });
       await delay(300);
+      return "";
     },
     async ReportCrash() {
       await delay(300);

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -653,6 +653,8 @@ export interface ProviderView {
   default: string;
   apiKeyEnv: string;
   keySet: boolean; // the env var currently resolves to a value
+  keySource?: string;
+  keySourcePath?: string;
   balanceUrl: string; // optional wallet-balance endpoint; "" disables the readout
   contextWindow: number;
   reasoningProtocol: string; // auto|deepseek|openai|none; empty = auto/model registry

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1242,6 +1242,7 @@ export const en = {
   "settings.keyStatus": "Key",
   "settings.configuredKey": "Saved {env}",
   "settings.notConfiguredKey": "No key saved for {env}",
+  "settings.keySource": "Source: {source}",
   "settings.moreModels": "{n} more",
   "settings.permissionsModeHint": "Controls the default behavior for file writes, shell commands, and other writer actions.",
   "settings.modeAskShort": "Prompt before writers",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -759,6 +759,7 @@ export const zhTW: Record<DictKey, string> = {
   "settings.keyStatus": "金鑰",
   "settings.configuredKey": "已填寫 {env}",
   "settings.notConfiguredKey": "未填寫 {env}",
+  "settings.keySource": "來源：{source}",
   "settings.moreModels": "還有 {n} 個",
   "settings.permissionsModeHint": "控制寫檔案、執行命令等寫操作預設如何被處理。",
   "settings.modeAskShort": "寫操作前詢問",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1244,6 +1244,7 @@ export const zh: Record<DictKey, string> = {
   "settings.keyStatus": "密钥",
   "settings.configuredKey": "已填写 {env}",
   "settings.notConfiguredKey": "未填写 {env}",
+  "settings.keySource": "来源：{source}",
   "settings.moreModels": "还有 {n} 个",
   "settings.permissionsModeHint": "控制写文件、执行命令等写操作默认如何被处理。",
   "settings.modeAskShort": "写操作前询问",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -2227,6 +2227,11 @@ a[href] {
   color: var(--err);
   border-bottom: 1px solid var(--border-soft);
 }
+.banner--warning {
+  background: color-mix(in srgb, var(--warn) 12%, var(--bg-elev));
+  color: var(--warn);
+  border-bottom: 1px solid var(--border-soft);
+}
 .banner--update {
   display: flex;
   align-items: center;

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -38,6 +38,8 @@ type ProviderView struct {
 	Default           string   `json:"default"`
 	APIKeyEnv         string   `json:"apiKeyEnv"`
 	KeySet            bool     `json:"keySet"` // the env var currently resolves to a non-empty value
+	KeySource         string   `json:"keySource,omitempty"`
+	KeySourcePath     string   `json:"keySourcePath,omitempty"`
 	BalanceURL        string   `json:"balanceUrl"`
 	ContextWindow     int      `json:"contextWindow"`
 	ReasoningProtocol string   `json:"reasoningProtocol"`
@@ -272,17 +274,24 @@ func removeProviderAccess(c *config.Config, names ...string) {
 }
 
 func providerViewFromEntry(p config.ProviderEntry, builtIn, added bool) ProviderView {
+	return providerViewFromEntryForRoot(p, builtIn, added, ".")
+}
+
+func providerViewFromEntryForRoot(p config.ProviderEntry, builtIn, added bool, root string) ProviderView {
 	models := p.ChatModelList()
 	visionModels := p.VisionModels
 	visionModelsSet := p.Vision || p.VisionModels != nil
 	if p.Vision {
 		visionModels = models
 	}
+	key := config.ResolveCredentialForRoot(root, p.APIKeyEnv)
 	return ProviderView{
 		Name: p.Name, BuiltIn: builtIn, Added: added, Kind: p.Kind, BaseURL: p.BaseURL,
 		Models: nonNil(models), VisionModels: nonNil(providerVisionModels(models, visionModels)), VisionModelsSet: visionModelsSet, ModelsURL: p.ModelsURL, Default: p.DefaultModel(),
 		APIKeyEnv:         p.APIKeyEnv,
-		KeySet:            p.APIKeyEnv != "" && os.Getenv(p.APIKeyEnv) != "",
+		KeySet:            key.Set,
+		KeySource:         key.Source.Label,
+		KeySourcePath:     key.Source.Path,
 		BalanceURL:        p.BalanceURL,
 		ContextWindow:     p.ContextWindow,
 		ReasoningProtocol: p.ReasoningProtocol,
@@ -292,6 +301,10 @@ func providerViewFromEntry(p config.ProviderEntry, builtIn, added bool) Provider
 }
 
 func officialProviderViews(added map[string]bool, pricingLanguage string) []ProviderView {
+	return officialProviderViewsForRoot(added, pricingLanguage, ".")
+}
+
+func officialProviderViewsForRoot(added map[string]bool, pricingLanguage, root string) []ProviderView {
 	var out []ProviderView
 	for _, kind := range []string{"deepseek", "mimo-api", "mimo-token-plan"} {
 		entries, _, err := officialProviderTemplate(kind, pricingLanguage)
@@ -299,7 +312,7 @@ func officialProviderViews(added map[string]bool, pricingLanguage string) []Prov
 			continue
 		}
 		for _, entry := range entries {
-			out = append(out, providerViewFromEntry(entry, true, added[entry.Name]))
+			out = append(out, providerViewFromEntryForRoot(entry, true, added[entry.Name], root))
 		}
 	}
 	return out
@@ -414,10 +427,11 @@ func (a *App) Settings() SettingsView {
 		Bypass:             ctrl != nil && ctrl.AutoApproveTools(),
 	}
 	added := providerAccessSet(cfg.Desktop.ProviderAccess)
-	v.OfficialProviders = officialProviderViews(officialProviderAddedSet(cfg), cfg.DeepSeekOfficialPricingLanguage())
+	root := a.activeWorkspaceRoot()
+	v.OfficialProviders = officialProviderViewsForRoot(officialProviderAddedSet(cfg), cfg.DeepSeekOfficialPricingLanguage(), root)
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
-		v.Providers = append(v.Providers, providerViewFromEntry(*p, isOfficialBuiltInProvider(*p), added[p.Name]))
+		v.Providers = append(v.Providers, providerViewFromEntryForRoot(*p, isOfficialBuiltInProvider(*p), added[p.Name], root))
 	}
 	return v
 }
@@ -658,6 +672,30 @@ func (a *App) activeWorkspaceRoot() string {
 		return tab.WorkspaceRoot
 	}
 	return "."
+}
+
+func (a *App) saveProviderCredential(apiKeyEnv, value string) (string, error) {
+	apiKeyEnv = strings.TrimSpace(apiKeyEnv)
+	value = strings.TrimSpace(value)
+	root := a.activeWorkspaceRoot()
+	before := config.ResolveCredentialForRoot(root, apiKeyEnv)
+	if err := upsertDotEnv(apiKeyEnv, value); err != nil {
+		return "", err
+	}
+	return providerCredentialShadowWarning(apiKeyEnv, value, root, before), nil
+}
+
+func providerCredentialShadowWarning(apiKeyEnv, value, root string, before config.CredentialResolution) string {
+	if before.Set && before.Source.Kind == config.CredentialSourceEnvironment && before.Value != "" && before.Value != value {
+		return fmt.Sprintf("saved %s to Reasonix credentials, but an existing environment variable with the same name can override it after restart; update or remove that environment variable", apiKeyEnv)
+	}
+	current := config.ResolveCredentialForRoot(root, apiKeyEnv)
+	for _, source := range current.Shadowed {
+		if source.Kind == config.CredentialSourceProjectEnv {
+			return fmt.Sprintf("saved %s to Reasonix credentials, but this workspace's project .env also defines %s and can override it after restart; update or remove that project .env entry", apiKeyEnv, apiKeyEnv)
+		}
+	}
+	return ""
 }
 
 func projectConfigPathForRoot(root string) string {
@@ -1044,12 +1082,15 @@ func (a *App) AddOfficialProviderAccess(kind, key string) error {
 	if err != nil {
 		return err
 	}
+	keyWarning := ""
 	if strings.TrimSpace(key) != "" && keyEnv != "" {
-		if err := upsertDotEnv(keyEnv, key); err != nil {
+		var err error
+		keyWarning, err = a.saveProviderCredential(keyEnv, key)
+		if err != nil {
 			return err
 		}
 	}
-	return a.applyConfigChange(func(c *config.Config) error {
+	if err := a.applyConfigChange(func(c *config.Config) error {
 		names := make([]string, 0, len(entries))
 		for _, e := range entries {
 			if err := c.UpsertProvider(e); err != nil {
@@ -1059,7 +1100,13 @@ func (a *App) AddOfficialProviderAccess(kind, key string) error {
 		}
 		addProviderAccess(c, names...)
 		return nil
-	})
+	}); err != nil {
+		return err
+	}
+	if keyWarning != "" {
+		return fmt.Errorf("%s", keyWarning)
+	}
+	return nil
 }
 
 // FetchProviderModels probes the provider's OpenAI-compatible model-list
@@ -1312,10 +1359,17 @@ func (a *App) SetProviderKey(apiKeyEnv, value string) error {
 	if err := a.ensureActiveTabRebuildAllowed("provider key"); err != nil {
 		return err
 	}
-	if err := upsertDotEnv(apiKeyEnv, value); err != nil {
+	warning, err := a.saveProviderCredential(apiKeyEnv, value)
+	if err != nil {
 		return err
 	}
-	return a.rebuild()
+	if err := a.rebuild(); err != nil {
+		return err
+	}
+	if warning != "" {
+		return fmt.Errorf("%s", warning)
+	}
+	return nil
 }
 
 // ClearProviderKey removes a provider secret from the global credential store

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -679,14 +679,18 @@ func (a *App) saveProviderCredential(apiKeyEnv, value string) (string, error) {
 	value = strings.TrimSpace(value)
 	root := a.activeWorkspaceRoot()
 	before := config.ResolveCredentialForRoot(root, apiKeyEnv)
+	beforeEnvValue, beforeEnvSet := os.LookupEnv(apiKeyEnv)
 	if err := upsertDotEnv(apiKeyEnv, value); err != nil {
 		return "", err
 	}
-	return providerCredentialShadowWarning(apiKeyEnv, value, root, before), nil
+	return providerCredentialShadowWarning(apiKeyEnv, value, root, before, beforeEnvSet, beforeEnvValue), nil
 }
 
-func providerCredentialShadowWarning(apiKeyEnv, value, root string, before config.CredentialResolution) string {
-	if before.Set && before.Source.Kind == config.CredentialSourceEnvironment && before.Value != "" && before.Value != value {
+func providerCredentialShadowWarning(apiKeyEnv, value, root string, before config.CredentialResolution, beforeEnvSet bool, beforeEnvValue string) string {
+	if beforeEnvSet && beforeEnvValue != value {
+		return fmt.Sprintf("saved %s to Reasonix credentials, but an existing environment variable with the same name can override it after restart; update or remove that environment variable", apiKeyEnv)
+	}
+	if before.Set && before.Source.Kind == config.CredentialSourceEnvironment && before.Value != value {
 		return fmt.Sprintf("saved %s to Reasonix credentials, but an existing environment variable with the same name can override it after restart; update or remove that environment variable", apiKeyEnv)
 	}
 	current := config.ResolveCredentialForRoot(root, apiKeyEnv)
@@ -1073,21 +1077,21 @@ func (a *App) SaveProvider(p ProviderView) error {
 // AddOfficialProviderAccess adds one curated desktop provider template to the
 // Settings > Model > Access list. The runtime default providers still exist
 // independently; this only records the user's explicit access setup.
-func (a *App) AddOfficialProviderAccess(kind, key string) error {
+func (a *App) AddOfficialProviderAccess(kind, key string) (string, error) {
 	cfg, _, err := a.loadDesktopUserConfigForEdit()
 	if err != nil {
-		return err
+		return "", err
 	}
 	entries, keyEnv, err := officialProviderTemplate(kind, cfg.DeepSeekOfficialPricingLanguage())
 	if err != nil {
-		return err
+		return "", err
 	}
 	keyWarning := ""
 	if strings.TrimSpace(key) != "" && keyEnv != "" {
 		var err error
 		keyWarning, err = a.saveProviderCredential(keyEnv, key)
 		if err != nil {
-			return err
+			return "", err
 		}
 	}
 	if err := a.applyConfigChange(func(c *config.Config) error {
@@ -1101,12 +1105,9 @@ func (a *App) AddOfficialProviderAccess(kind, key string) error {
 		addProviderAccess(c, names...)
 		return nil
 	}); err != nil {
-		return err
+		return "", err
 	}
-	if keyWarning != "" {
-		return fmt.Errorf("%s", keyWarning)
-	}
-	return nil
+	return keyWarning, nil
 }
 
 // FetchProviderModels probes the provider's OpenAI-compatible model-list
@@ -1352,24 +1353,21 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 // SetProviderKey writes a secret to the global credential store under the given
 // env-var name (the one a provider's api_key_env points at) and rebuilds so it
 // resolves immediately.
-func (a *App) SetProviderKey(apiKeyEnv, value string) error {
+func (a *App) SetProviderKey(apiKeyEnv, value string) (string, error) {
 	if strings.TrimSpace(apiKeyEnv) == "" {
-		return fmt.Errorf("this provider has no api_key_env set")
+		return "", fmt.Errorf("this provider has no api_key_env set")
 	}
 	if err := a.ensureActiveTabRebuildAllowed("provider key"); err != nil {
-		return err
+		return "", err
 	}
 	warning, err := a.saveProviderCredential(apiKeyEnv, value)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if err := a.rebuild(); err != nil {
-		return err
+		return "", err
 	}
-	if warning != "" {
-		return fmt.Errorf("%s", warning)
-	}
-	return nil
+	return warning, nil
 }
 
 // ClearProviderKey removes a provider secret from the global credential store

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -87,6 +87,52 @@ func TestProviderViewFromEntry_MigratesProviderWideVision(t *testing.T) {
 	}
 }
 
+func TestProviderViewFromEntryShowsKeySource(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("TEST_PROVIDER_KEY_SOURCE", "")
+	os.Unsetenv("TEST_PROVIDER_KEY_SOURCE")
+	if _, err := config.SetCredential("TEST_PROVIDER_KEY_SOURCE", "sk-test"); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+
+	view := providerViewFromEntry(config.ProviderEntry{
+		Name:      "custom",
+		APIKeyEnv: "TEST_PROVIDER_KEY_SOURCE",
+	}, false, true)
+	if !view.KeySet {
+		t.Fatal("KeySet = false, want true")
+	}
+	if view.KeySource == "" || !strings.Contains(view.KeySource, "credentials") {
+		t.Fatalf("KeySource = %q, want credentials source", view.KeySource)
+	}
+}
+
+func TestSetProviderKeyWarnsWhenProjectEnvWillShadowSavedKey(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, ".env"), []byte("TEST_PROVIDER_SHADOW=old-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TEST_PROVIDER_SHADOW", "")
+	os.Unsetenv("TEST_PROVIDER_SHADOW")
+
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"project": {ID: "project", WorkspaceRoot: project}},
+		activeTabID: "project",
+	}
+	err := app.SetProviderKey("TEST_PROVIDER_SHADOW", "new-key")
+	if err == nil || !strings.Contains(err.Error(), "project .env") {
+		t.Fatalf("SetProviderKey error = %v, want project .env shadow warning", err)
+	}
+	data, readErr := os.ReadFile(config.UserCredentialsPath())
+	if readErr != nil {
+		t.Fatalf("read credentials: %v", readErr)
+	}
+	if !strings.Contains(string(data), "TEST_PROVIDER_SHADOW=new-key") {
+		t.Fatalf("saved credentials missing new key:\n%s", data)
+	}
+}
+
 func TestFetchProviderModelsFiltersNonChatModels(t *testing.T) {
 	t.Setenv("TEST_PROVIDER_KEY", "test-key")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -120,9 +120,12 @@ func TestSetProviderKeyWarnsWhenProjectEnvWillShadowSavedKey(t *testing.T) {
 		tabs:        map[string]*WorkspaceTab{"project": {ID: "project", WorkspaceRoot: project}},
 		activeTabID: "project",
 	}
-	err := app.SetProviderKey("TEST_PROVIDER_SHADOW", "new-key")
-	if err == nil || !strings.Contains(err.Error(), "project .env") {
-		t.Fatalf("SetProviderKey error = %v, want project .env shadow warning", err)
+	warning, err := app.SetProviderKey("TEST_PROVIDER_SHADOW", "new-key")
+	if err != nil {
+		t.Fatalf("SetProviderKey: %v", err)
+	}
+	if !strings.Contains(warning, "project .env") {
+		t.Fatalf("SetProviderKey warning = %q, want project .env shadow warning", warning)
 	}
 	data, readErr := os.ReadFile(config.UserCredentialsPath())
 	if readErr != nil {
@@ -130,6 +133,49 @@ func TestSetProviderKeyWarnsWhenProjectEnvWillShadowSavedKey(t *testing.T) {
 	}
 	if !strings.Contains(string(data), "TEST_PROVIDER_SHADOW=new-key") {
 		t.Fatalf("saved credentials missing new key:\n%s", data)
+	}
+}
+
+func TestSetProviderKeyWarnsWhenEmptyEnvironmentWillShadowSavedKey(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("TEST_PROVIDER_EMPTY_ENV", "")
+
+	app := &App{}
+	warning, err := app.SetProviderKey("TEST_PROVIDER_EMPTY_ENV", "new-key")
+	if err != nil {
+		t.Fatalf("SetProviderKey: %v", err)
+	}
+	if !strings.Contains(warning, "environment variable") {
+		t.Fatalf("SetProviderKey warning = %q, want environment variable shadow warning", warning)
+	}
+	data, readErr := os.ReadFile(config.UserCredentialsPath())
+	if readErr != nil {
+		t.Fatalf("read credentials: %v", readErr)
+	}
+	if !strings.Contains(string(data), "TEST_PROVIDER_EMPTY_ENV=new-key") {
+		t.Fatalf("saved credentials missing new key:\n%s", data)
+	}
+}
+
+func TestSetProviderKeyWarnsWhenEmptyProjectEnvWillShadowSavedKey(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, ".env"), []byte("TEST_PROVIDER_EMPTY_PROJECT=\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TEST_PROVIDER_EMPTY_PROJECT", "")
+	os.Unsetenv("TEST_PROVIDER_EMPTY_PROJECT")
+
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"project": {ID: "project", WorkspaceRoot: project}},
+		activeTabID: "project",
+	}
+	warning, err := app.SetProviderKey("TEST_PROVIDER_EMPTY_PROJECT", "new-key")
+	if err != nil {
+		t.Fatalf("SetProviderKey: %v", err)
+	}
+	if !strings.Contains(warning, "project .env") {
+		t.Fatalf("SetProviderKey warning = %q, want project .env shadow warning", warning)
 	}
 }
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1049,6 +1049,7 @@ func NewProvider(e *config.ProviderEntry) (provider.Provider, error) {
 // NewProviderWithProxy builds a provider.Provider with the configured ordinary
 // network proxy settings.
 func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (provider.Provider, error) {
+	keyResolution := config.ResolveCredential(e.APIKeyEnv)
 	return provider.New(e.Kind, provider.Config{
 		Name:    e.Name,
 		BaseURL: e.BaseURL,
@@ -1059,6 +1060,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 		// default_effort when the user has not explicitly selected /effort.
 		Extra: map[string]any{
 			"api_key_env":        e.APIKeyEnv,
+			"api_key_source":     keyResolution.Source.Label,
 			"thinking":           e.Thinking,
 			"effort":             config.EffectiveEffort(e),
 			"reasoning_protocol": config.ReasoningProtocolForEntry(e),

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/zalando/go-keyring"
@@ -21,6 +22,38 @@ const (
 
 	credentialsKeyringService = "reasonix"
 )
+
+const (
+	CredentialSourceEnvironment = "environment"
+	CredentialSourceProjectEnv  = "project_env"
+	CredentialSourceCredentials = "credentials"
+	CredentialSourceHomeEnv     = "home_env"
+	CredentialSourceLegacy      = "legacy_credentials"
+)
+
+type CredentialSource struct {
+	Kind  string `json:"kind"`
+	Path  string `json:"path,omitempty"`
+	Label string `json:"label,omitempty"`
+}
+
+type CredentialResolution struct {
+	Name     string             `json:"name"`
+	Set      bool               `json:"set"`
+	Value    string             `json:"-"`
+	Source   CredentialSource   `json:"source,omitempty"`
+	Shadowed []CredentialSource `json:"shadowed,omitempty"`
+}
+
+type trackedCredentialSource struct {
+	source CredentialSource
+	value  string
+}
+
+var credentialSourceTracker = struct {
+	sync.Mutex
+	byKey map[string]trackedCredentialSource
+}{byKey: map[string]trackedCredentialSource{}}
 
 func normalizeCredentialsStore(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
@@ -100,20 +133,22 @@ func loadCredentialStoreForRoot(root string) {
 	if mode == CredentialsStoreAuto || mode == CredentialsStoreKeyring {
 		for _, name := range names {
 			if _, exists := os.LookupEnv(name); exists {
+				recordExistingCredentialSource(name)
 				continue
 			}
 			value, err := keyring.Get(credentialsKeyringService, name)
 			if err == nil && value != "" {
 				_ = os.Setenv(name, value)
+				recordCredentialSource(name, value, CredentialSource{Kind: CredentialSourceCredentials, Label: "system credential store"})
 			}
 		}
 	}
 	if mode == CredentialsStoreAuto || mode == CredentialsStoreFile {
 		if p := UserCredentialsPath(); p != "" {
-			loadDotEnvFile(p)
+			loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials"})
 		}
 		for _, p := range legacyCredentialsPaths() {
-			loadDotEnvFile(p)
+			loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceLegacy, Path: p, Label: "legacy Reasonix credentials"})
 		}
 	}
 }
@@ -255,7 +290,151 @@ func parseCredentialLines(lines []string) map[string]string {
 func pinCredentialAssignments(assignments map[string]string) {
 	for key, value := range assignments {
 		_ = os.Setenv(key, value)
+		recordCredentialSource(key, value, CredentialSource{Kind: CredentialSourceCredentials, Label: "Reasonix credentials"})
 	}
+}
+
+func recordExistingCredentialSource(key string) {
+	key = strings.TrimSpace(key)
+	value := os.Getenv(key)
+	if key == "" || value == "" {
+		return
+	}
+	credentialSourceTracker.Lock()
+	defer credentialSourceTracker.Unlock()
+	if current, ok := credentialSourceTracker.byKey[key]; ok && current.value == value {
+		return
+	}
+	if _, ok := credentialSourceTracker.byKey[key]; ok {
+		return
+	}
+	credentialSourceTracker.byKey[key] = trackedCredentialSource{
+		source: CredentialSource{Kind: CredentialSourceEnvironment, Label: "environment variable"},
+		value:  value,
+	}
+}
+
+func recordCredentialSource(key, value string, source CredentialSource) {
+	key = strings.TrimSpace(key)
+	if key == "" || value == "" {
+		return
+	}
+	source.Label = credentialSourceLabel(source)
+	credentialSourceTracker.Lock()
+	credentialSourceTracker.byKey[key] = trackedCredentialSource{source: source, value: value}
+	credentialSourceTracker.Unlock()
+}
+
+func trackedCredential(key, value string) (CredentialSource, bool) {
+	credentialSourceTracker.Lock()
+	defer credentialSourceTracker.Unlock()
+	current, ok := credentialSourceTracker.byKey[key]
+	if !ok || current.value != value {
+		return CredentialSource{}, false
+	}
+	return current.source, true
+}
+
+func credentialSourceLabel(source CredentialSource) string {
+	if strings.TrimSpace(source.Label) != "" {
+		return source.Label
+	}
+	switch source.Kind {
+	case CredentialSourceProjectEnv:
+		return "project .env"
+	case CredentialSourceCredentials:
+		return "Reasonix credentials"
+	case CredentialSourceHomeEnv:
+		return "home .env"
+	case CredentialSourceLegacy:
+		return "legacy Reasonix credentials"
+	case CredentialSourceEnvironment:
+		return "environment variable"
+	default:
+		return ""
+	}
+}
+
+func ResolveCredential(key string) CredentialResolution {
+	return ResolveCredentialForRoot(".", key)
+}
+
+func ResolveCredentialForRoot(root, key string) CredentialResolution {
+	key = strings.TrimSpace(key)
+	res := CredentialResolution{Name: key}
+	if key == "" {
+		return res
+	}
+	value := os.Getenv(key)
+	if value == "" {
+		return res
+	}
+	res.Set = true
+	res.Value = value
+	if source, ok := trackedCredential(key, value); ok {
+		res.Source = source
+	} else if source, ok := inferCredentialSource(root, key, value); ok {
+		res.Source = source
+	} else {
+		res.Source = CredentialSource{Kind: CredentialSourceEnvironment, Label: credentialSourceLabel(CredentialSource{Kind: CredentialSourceEnvironment})}
+	}
+	res.Source.Label = credentialSourceLabel(res.Source)
+	res.Shadowed = shadowedCredentialSources(root, key, value, res.Source)
+	return res
+}
+
+func inferCredentialSource(root, key, value string) (CredentialSource, bool) {
+	for _, candidate := range credentialSourceCandidates(root) {
+		if v, ok := envFileValue(candidate.Path, key); ok && v == value {
+			candidate.Label = credentialSourceLabel(candidate)
+			return candidate, true
+		}
+	}
+	return CredentialSource{}, false
+}
+
+func shadowedCredentialSources(root, key, activeValue string, active CredentialSource) []CredentialSource {
+	var out []CredentialSource
+	for _, candidate := range credentialSourceCandidates(root) {
+		if sameCredentialSource(candidate, active) {
+			continue
+		}
+		if v, ok := envFileValue(candidate.Path, key); ok && v != "" && v != activeValue {
+			candidate.Label = credentialSourceLabel(candidate)
+			out = append(out, candidate)
+		}
+	}
+	return out
+}
+
+func credentialSourceCandidates(root string) []CredentialSource {
+	root = resolveRoot(root)
+	var out []CredentialSource
+	dotEnvPath := ".env"
+	if root != "" && root != "." {
+		dotEnvPath = filepath.Join(root, ".env")
+	}
+	out = append(out, CredentialSource{Kind: CredentialSourceProjectEnv, Path: dotEnvPath})
+	if p := UserCredentialsPath(); p != "" {
+		out = append(out, CredentialSource{Kind: CredentialSourceCredentials, Path: p})
+	}
+	for _, p := range legacyCredentialsPaths() {
+		out = append(out, CredentialSource{Kind: CredentialSourceLegacy, Path: p})
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		out = append(out, CredentialSource{Kind: CredentialSourceHomeEnv, Path: filepath.Join(home, ".env")})
+	}
+	return out
+}
+
+func sameCredentialSource(a, b CredentialSource) bool {
+	if a.Kind != b.Kind {
+		return false
+	}
+	if a.Path == "" || b.Path == "" {
+		return a.Path == b.Path
+	}
+	return samePath(a.Path, b.Path)
 }
 
 func storeCredentialsInKeyring(assignments map[string]string) error {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -399,7 +399,7 @@ func shadowedCredentialSources(root, key, activeValue string, active CredentialS
 		if sameCredentialSource(candidate, active) {
 			continue
 		}
-		if v, ok := envFileValue(candidate.Path, key); ok && v != "" && v != activeValue {
+		if v, ok := envFileValue(candidate.Path, key); ok && v != activeValue {
 			candidate.Label = credentialSourceLabel(candidate)
 			out = append(out, candidate)
 		}

--- a/internal/config/dotenv.go
+++ b/internal/config/dotenv.go
@@ -60,12 +60,6 @@ func legacyCredentialsPaths() []string {
 	return paths
 }
 
-// loadDotEnvFile reads one .env file (if present) and sets any keys not already
-// present in the environment. Lenient, zero-dependency parsing.
-func loadDotEnvFile(path string) {
-	loadDotEnvFileAs(path, CredentialSource{})
-}
-
 func loadDotEnvFileAs(path string, source CredentialSource) {
 	f, err := os.Open(path)
 	if err != nil {

--- a/internal/config/dotenv.go
+++ b/internal/config/dotenv.go
@@ -25,10 +25,11 @@ func loadDotEnvForRoot(root string) {
 	if root != "" && root != "." {
 		dotEnvPath = filepath.Join(root, ".env")
 	}
-	loadDotEnvFile(dotEnvPath)
+	loadDotEnvFileAs(dotEnvPath, CredentialSource{Kind: CredentialSourceProjectEnv, Path: dotEnvPath})
 	loadCredentialStoreForRoot(root)
 	if home, err := os.UserHomeDir(); err == nil {
-		loadDotEnvFile(filepath.Join(home, ".env"))
+		homeEnv := filepath.Join(home, ".env")
+		loadDotEnvFileAs(homeEnv, CredentialSource{Kind: CredentialSourceHomeEnv, Path: homeEnv})
 	}
 }
 
@@ -62,6 +63,10 @@ func legacyCredentialsPaths() []string {
 // loadDotEnvFile reads one .env file (if present) and sets any keys not already
 // present in the environment. Lenient, zero-dependency parsing.
 func loadDotEnvFile(path string) {
+	loadDotEnvFileAs(path, CredentialSource{})
+}
+
+func loadDotEnvFileAs(path string, source CredentialSource) {
 	f, err := os.Open(path)
 	if err != nil {
 		return
@@ -84,8 +89,41 @@ func loadDotEnvFile(path string) {
 		if key == "" {
 			continue
 		}
-		if _, exists := os.LookupEnv(key); !exists {
-			os.Setenv(key, val)
+		if _, exists := os.LookupEnv(key); exists {
+			recordExistingCredentialSource(key)
+			continue
+		}
+		if err := os.Setenv(key, val); err == nil && source.Kind != "" {
+			source.Path = path
+			recordCredentialSource(key, val, source)
 		}
 	}
+}
+
+func envFileValue(path, wantKey string) (string, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimPrefix(line, "export ")
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key != wantKey {
+			continue
+		}
+		val = strings.Trim(strings.TrimSpace(val), `"'`)
+		return val, true
+	}
+	return "", false
 }

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -90,6 +90,90 @@ func TestLoadDotEnvReadsGlobalCredentials(t *testing.T) {
 	}
 }
 
+func TestResolveCredentialSourceShowsProjectEnvShadowingCredentials(t *testing.T) {
+	cwd := t.TempDir()
+	cfgHome := t.TempDir()
+
+	t.Chdir(cwd)
+	t.Setenv("HOME", cfgHome)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+	t.Setenv("USERPROFILE", cfgHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(cfgHome, ".config"))
+	t.Setenv("AppData", filepath.Join(cfgHome, "AppData"))
+
+	key := "KEY_SOURCE_PROJECT"
+	cred := UserCredentialsPath()
+	if cred == "" {
+		t.Skip("user config dir unresolved on this platform")
+	}
+	if err := os.MkdirAll(filepath.Dir(cred), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cred, []byte(key+"=from_credentials\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, ".env"), []byte(key+"=from_project\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(key, "")
+	os.Unsetenv(key)
+
+	loadDotEnv()
+
+	got := ResolveCredentialForRoot(cwd, key)
+	if !got.Set || got.Source.Kind != CredentialSourceProjectEnv {
+		t.Fatalf("source = %+v set=%v, want project .env", got.Source, got.Set)
+	}
+	foundCredentialsShadow := false
+	for _, source := range got.Shadowed {
+		if source.Kind == CredentialSourceCredentials {
+			foundCredentialsShadow = true
+		}
+	}
+	if !foundCredentialsShadow {
+		t.Fatalf("shadowed = %+v, want credentials shadowed by project .env", got.Shadowed)
+	}
+}
+
+func TestResolveCredentialSourceShowsCredentialsBeforeHomeEnv(t *testing.T) {
+	cwd := t.TempDir()
+	cfgHome := t.TempDir()
+
+	t.Chdir(cwd)
+	t.Setenv("HOME", cfgHome)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+	t.Setenv("USERPROFILE", cfgHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(cfgHome, ".config"))
+	t.Setenv("AppData", filepath.Join(cfgHome, "AppData"))
+
+	key := "KEY_SOURCE_CREDENTIALS"
+	cred := UserCredentialsPath()
+	if cred == "" {
+		t.Skip("user config dir unresolved on this platform")
+	}
+	if err := os.MkdirAll(filepath.Dir(cred), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cred, []byte(key+"=from_credentials\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cfgHome, ".env"), []byte(key+"=from_home\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(key, "")
+	os.Unsetenv(key)
+
+	loadDotEnv()
+
+	got := ResolveCredentialForRoot(cwd, key)
+	if !got.Set || got.Source.Kind != CredentialSourceCredentials {
+		t.Fatalf("source = %+v set=%v, want Reasonix credentials", got.Source, got.Set)
+	}
+	if got.Value != "from_credentials" {
+		t.Fatalf("value = %q, want credentials value", got.Value)
+	}
+}
+
 func TestStoreCredentialLinesFileMode(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -135,6 +135,50 @@ func TestResolveCredentialSourceShowsProjectEnvShadowingCredentials(t *testing.T
 	}
 }
 
+func TestResolveCredentialSourceShowsEmptyProjectEnvShadowingCredentials(t *testing.T) {
+	cwd := t.TempDir()
+	cfgHome := t.TempDir()
+
+	t.Chdir(cwd)
+	t.Setenv("HOME", cfgHome)
+	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
+	t.Setenv("USERPROFILE", cfgHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(cfgHome, ".config"))
+	t.Setenv("AppData", filepath.Join(cfgHome, "AppData"))
+
+	key := "KEY_SOURCE_EMPTY_PROJECT"
+	cred := UserCredentialsPath()
+	if cred == "" {
+		t.Skip("user config dir unresolved on this platform")
+	}
+	if err := os.MkdirAll(filepath.Dir(cred), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cred, []byte(key+"=from_credentials\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, ".env"), []byte(key+"=\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(key, "")
+	os.Unsetenv(key)
+
+	if _, err := StoreCredentialLines([]string{key + "=from_credentials"}); err != nil {
+		t.Fatalf("StoreCredentialLines: %v", err)
+	}
+
+	got := ResolveCredentialForRoot(cwd, key)
+	foundProjectShadow := false
+	for _, source := range got.Shadowed {
+		if source.Kind == CredentialSourceProjectEnv {
+			foundProjectShadow = true
+		}
+	}
+	if !foundProjectShadow {
+		t.Fatalf("shadowed = %+v, want empty project .env shadowing credentials", got.Shadowed)
+	}
+}
+
 func TestResolveCredentialSourceShowsCredentialsBeforeHomeEnv(t *testing.T) {
 	cwd := t.TempDir()
 	cfgHome := t.TempDir()

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -34,6 +34,9 @@ func explainError(err error) error {
 			msg = i18n.M.ProviderErrAuthRejected
 		}
 		if authErr.KeyEnv != "" {
+			if authErr.KeySource != "" {
+				return fmt.Errorf("%s (%s from %s)", msg, authErr.KeyEnv, authErr.KeySource)
+			}
 			return fmt.Errorf("%s (%s)", msg, authErr.KeyEnv)
 		}
 		return errors.New(msg)

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -35,6 +35,11 @@ func TestExplainError(t *testing.T) {
 		t.Errorf("401 should still name the key env: %q", rejected.Error())
 	}
 
+	sourced := explainError(&provider.AuthError{Provider: "deepseek", KeyEnv: "DEEPSEEK_API_KEY", KeySource: "project .env", Status: 401, HasKey: true})
+	if !strings.Contains(sourced.Error(), "DEEPSEEK_API_KEY from project .env") {
+		t.Errorf("401 should name the key source: %q", sourced.Error())
+	}
+
 	for _, status := range []int{400, 422, 429, 500, 503} {
 		got := explainError(&provider.APIError{Provider: "p", Status: status})
 		if got.Error() == "" || got.Error() == (&provider.APIError{Provider: "p", Status: status}).Error() {

--- a/internal/provider/anthropic/anthropic.go
+++ b/internal/provider/anthropic/anthropic.go
@@ -70,6 +70,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		baseURL = defaultBaseURL
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
+	keySource, _ := cfg.Extra["api_key_source"].(string)
 	thinking, _ := cfg.Extra["thinking"].(string)
 	effort, _ := cfg.Extra["effort"].(string)
 	vision, _ := cfg.Extra["vision"].(bool)
@@ -96,6 +97,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		name:        name,
 		apiKey:      cfg.APIKey,
 		keyEnv:      keyEnv,
+		keySource:   keySource,
 		baseURL:     root,
 		model:       cfg.Model,
 		thinking:    thinking,
@@ -115,6 +117,7 @@ type client struct {
 	name        string
 	apiKey      string
 	keyEnv      string // api_key_env name, surfaced in auth errors
+	keySource   string // source of keyEnv, surfaced in auth errors
 	baseURL     string
 	model       string
 	thinking    string // "adaptive" enables extended thinking; "" = off (config-driven)
@@ -131,6 +134,7 @@ func (c *client) sendOpts() provider.SendOptions {
 	return provider.SendOptions{
 		Provider:   c.name,
 		KeyEnv:     c.keyEnv,
+		KeySource:  c.keySource,
 		KeyPresent: c.apiKey != "",
 		RetryAuth:  c.authed.Load(),
 	}

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -54,6 +54,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		name = "openai"
 	}
 	keyEnv, _ := cfg.Extra["api_key_env"].(string) // for actionable auth errors
+	keySource, _ := cfg.Extra["api_key_source"].(string)
 	effort, _ := cfg.Extra["effort"].(string)
 	effort = strings.ToLower(strings.TrimSpace(effort))
 	if effort == "auto" {
@@ -113,6 +114,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		name:         name,
 		apiKey:       cfg.APIKey,
 		keyEnv:       keyEnv,
+		keySource:    keySource,
 		baseURL:      strings.TrimRight(cfg.BaseURL, "/"),
 		model:        cfg.Model,
 		deepseek:     deepseek,
@@ -139,6 +141,7 @@ type client struct {
 	name         string
 	apiKey       string
 	keyEnv       string // api_key_env name, surfaced in auth errors
+	keySource    string // source of keyEnv, surfaced in auth errors
 	baseURL      string
 	model        string
 	http         *http.Client
@@ -157,6 +160,7 @@ func (c *client) sendOpts() provider.SendOptions {
 	return provider.SendOptions{
 		Provider:   c.name,
 		KeyEnv:     c.keyEnv,
+		KeySource:  c.keySource,
 		KeyPresent: c.apiKey != "",
 		RetryAuth:  c.authed.Load(),
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -430,16 +430,20 @@ type Config struct {
 // surface it verbatim instead of dumping a raw status body. Providers should
 // return this (rather than a generic status error) for auth failures.
 type AuthError struct {
-	Provider string // the provider instance name, e.g. "deepseek"
-	KeyEnv   string // the api_key_env the key is read from, when known
-	Status   int    // the HTTP status (401 or 403)
-	HasKey   bool   // a non-empty key was sent — the server rejected it, vs. no key configured at all
+	Provider  string // the provider instance name, e.g. "deepseek"
+	KeyEnv    string // the api_key_env the key is read from, when known
+	KeySource string // human-readable source of KeyEnv, when known
+	Status    int    // the HTTP status (401 or 403)
+	HasKey    bool   // a non-empty key was sent — the server rejected it, vs. no key configured at all
 }
 
 func (e *AuthError) Error() string {
 	key := "the API key"
 	if e.KeyEnv != "" {
 		key = e.KeyEnv
+	}
+	if e.KeySource != "" {
+		key += " from " + e.KeySource
 	}
 	return fmt.Sprintf("authentication failed for provider %q (HTTP %d): %s is invalid or expired — update it (in .env or your environment) and retry, or run `reasonix setup`",
 		e.Provider, e.Status, key)

--- a/internal/provider/retry.go
+++ b/internal/provider/retry.go
@@ -31,6 +31,7 @@ const maxAuthRetries = 2
 type SendOptions struct {
 	Provider   string // provider instance name, surfaced in errors
 	KeyEnv     string // api_key_env the key is read from, when known
+	KeySource  string // human-readable source of KeyEnv, when known
 	KeyPresent bool   // a non-empty key is being sent — separates "rejected" from "missing"
 	RetryAuth  bool   // the key has authenticated before — retry transient 401s instead of failing fast
 }
@@ -193,7 +194,7 @@ func SendWithRetry(ctx context.Context, httpClient *http.Client, opts SendOption
 		resp.Body.Close()
 
 		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-			authErr := &AuthError{Provider: opts.Provider, KeyEnv: opts.KeyEnv, Status: resp.StatusCode, HasKey: opts.KeyPresent}
+			authErr := &AuthError{Provider: opts.Provider, KeyEnv: opts.KeyEnv, KeySource: opts.KeySource, Status: resp.StatusCode, HasKey: opts.KeyPresent}
 			if opts.RetryAuth && authRetries < maxAuthRetries {
 				authRetries++
 				lastErr = authErr


### PR DESCRIPTION
## Summary
- Track the effective source for provider credentials, including environment variables, project `.env`, Reasonix credentials, home `.env`, and legacy credentials.
- Surface credential source labels in desktop settings and provider auth errors.
- Warn when saving a provider key would still be shadowed by an environment variable or project `.env` after restart.

## Verification
- `go test ./...`
- `go test .` in the desktop module
- `npm --prefix desktop/frontend run typecheck`

Related: #4608
Related: #4401