### PR TITLE
Restore saved session model on resume / 恢复会话时保留原模型

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1482,7 +1482,9 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 
 	model := strings.TrimSpace(tab.model)
 	if sessionModel, ok := agent.LoadSessionModel(startupSessionPath); ok {
-		model = sessionModel
+		if _, ok := cfg.ResolveModel(sessionModel); ok {
+			model = sessionModel
+		}
 	}
 	if model == "" {
 		model = cfg.DefaultModel

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1441,24 +1441,6 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 	// global credentials store so it follows the user to every other workspace.
 	promoteProviderKeysToCredentials(cfg)
 
-	model := strings.TrimSpace(tab.model)
-	if model == "" {
-		model = cfg.DefaultModel
-	}
-	requestedModel := model
-	if resolved, fallback, ok := cfg.ResolveModelWithFallback(model); ok {
-		if fallback && strings.TrimSpace(tab.model) != "" {
-			a.noticeForTab(tab.ID, fmt.Sprintf("model %q is no longer available; switched to %s", requestedModel, resolved))
-		}
-		model = resolved
-	}
-
-	a.mu.Lock()
-	tab.model = model
-	tab.Label = model
-	a.saveTabsLocked()
-	a.mu.Unlock()
-
 	if tab.sink != nil {
 		tab.sink.setContext(wailsCtx)
 	}
@@ -1491,6 +1473,33 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 			sessionDir = dir
 		}
 	}
+	startupSessionPath := ""
+	if pinnedPath, ok := pinnedTabSessionPath(sessionDir, tab.SessionPath); ok {
+		startupSessionPath = pinnedPath
+	} else if topicID != "" {
+		startupSessionPath = findTopicSession(sessionDir, topicID)
+	}
+
+	model := strings.TrimSpace(tab.model)
+	if sessionModel, ok := agent.LoadSessionModel(startupSessionPath); ok {
+		model = sessionModel
+	}
+	if model == "" {
+		model = cfg.DefaultModel
+	}
+	requestedModel := model
+	if resolved, fallback, ok := cfg.ResolveModelWithFallback(model); ok {
+		if fallback && strings.TrimSpace(tab.model) != "" {
+			a.noticeForTab(tab.ID, fmt.Sprintf("model %q is no longer available; switched to %s", requestedModel, resolved))
+		}
+		model = resolved
+	}
+
+	a.mu.Lock()
+	tab.model = model
+	tab.Label = model
+	a.saveTabsLocked()
+	a.mu.Unlock()
 
 	ctrl, err := boot.Build(buildCtx, boot.Options{
 		Model:          model,
@@ -4046,20 +4055,9 @@ func globalTabWorkspaceRoot() string {
 }
 
 func loadPinnedTabSession(dir, sessionPath string) (*agent.Session, string, bool) {
-	sessionPath = strings.TrimSpace(sessionPath)
-	if sessionPath == "" || dir == "" {
+	path, ok := pinnedTabSessionPath(dir, sessionPath)
+	if !ok {
 		return nil, "", false
-	}
-	path, _, err := validateSessionPath(dir, sessionPath)
-	if err != nil {
-		base := filepath.Base(sessionPath)
-		if base == "." || base == string(filepath.Separator) || !strings.HasSuffix(base, ".jsonl") {
-			return nil, "", false
-		}
-		path, _, err = validateSessionPath(dir, filepath.Join(dir, base))
-		if err != nil {
-			return nil, "", false
-		}
 	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
@@ -4069,6 +4067,25 @@ func loadPinnedTabSession(dir, sessionPath string) (*agent.Session, string, bool
 		return nil, "", false
 	}
 	return loaded, path, true
+}
+
+func pinnedTabSessionPath(dir, sessionPath string) (string, bool) {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" || dir == "" {
+		return "", false
+	}
+	path, _, err := validateSessionPath(dir, sessionPath)
+	if err != nil {
+		base := filepath.Base(sessionPath)
+		if base == "." || base == string(filepath.Separator) || !strings.HasSuffix(base, ".jsonl") {
+			return "", false
+		}
+		path, _, err = validateSessionPath(dir, filepath.Join(dir, base))
+		if err != nil {
+			return "", false
+		}
+	}
+	return path, true
 }
 
 func saveTabSessionMeta(tab *WorkspaceTab, path string) error {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -512,6 +512,65 @@ func TestBuildTabControllerRestoresPinnedSessionBeforeTopicFallback(t *testing.T
 	}
 }
 
+func TestBuildTabControllerIgnoresStaleSessionModelWhenTabModelResolves(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserConfigPath(), []byte(`
+default_model = "default-provider/default-model"
+
+[[providers]]
+name = "default-provider"
+kind = "openai"
+base_url = "https://default.invalid/v1"
+model = "default-model"
+api_key_env = "REASONIX_TEST_KEY"
+
+[[providers]]
+name = "tab-provider"
+kind = "openai"
+base_url = "https://tab.invalid/v1"
+model = "tab-model"
+api_key_env = "REASONIX_TEST_KEY"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	pinned := writeLegacySession(t, dir, "stale-model.jsonl", "resume with tab model", time.Now())
+	meta, err := agent.EnsureBranchMeta(pinned)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta.Model = "missing-provider/missing-model"
+	if err := agent.SaveBranchMetaPreserveUpdated(pinned, meta); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "tab_stale_model")
+	tab.SessionPath = pinned
+	tab.model = "tab-provider/tab-model"
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	app.buildTabController(tab)
+	if tab.Ctrl == nil {
+		t.Fatalf("tab controller was not built: %s", tab.StartupErr)
+	}
+	defer tab.Ctrl.Close()
+	if tab.model != "tab-provider/tab-model" {
+		t.Fatalf("tab model = %q, want valid tab model", tab.model)
+	}
+}
+
 func TestLoadPinnedTabSessionFallsBackToMigratedBasename(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -27,6 +27,7 @@ type BranchMeta struct {
 	WorkspaceRoot    string    `json:"workspace_root,omitempty"`
 	TopicID          string    `json:"topic_id,omitempty"`
 	TopicTitle       string    `json:"topic_title,omitempty"`
+	Model            string    `json:"model,omitempty"`
 }
 
 func (m BranchMeta) DefaultScope() string {
@@ -230,4 +231,32 @@ func RenameSession(sessionPath string, title string) error {
 	}
 	m.TopicTitle = title
 	return SaveBranchMeta(sessionPath, m)
+}
+
+// LoadSessionModel reads the canonical provider/model ref saved beside a
+// session transcript.
+func LoadSessionModel(sessionPath string) (string, bool) {
+	meta, ok, err := LoadBranchMeta(sessionPath)
+	if err != nil || !ok {
+		return "", false
+	}
+	model := strings.TrimSpace(meta.Model)
+	if model == "" {
+		return "", false
+	}
+	return model, true
+}
+
+// SetBranchModelPreserveUpdated stores the canonical provider/model ref without
+// changing the session activity timestamp.
+func SetBranchModelPreserveUpdated(sessionPath, model string) error {
+	if sessionPath == "" {
+		return fmt.Errorf("empty session path")
+	}
+	meta, err := EnsureBranchMeta(sessionPath)
+	if err != nil {
+		return err
+	}
+	meta.Model = strings.TrimSpace(model)
+	return SaveBranchMetaPreserveUpdated(sessionPath, meta)
 }

--- a/internal/agent/branch_test.go
+++ b/internal/agent/branch_test.go
@@ -53,3 +53,35 @@ func TestBranchMetaRoundTripAndList(t *testing.T) {
 		t.Fatalf("child with parent root and name experiment not found among %+v", branches)
 	}
 }
+
+func TestSessionModelRoundTripPreservesActivity(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	session := NewSession("sys")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if err := session.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := LoadSessionModel(path); ok {
+		t.Fatal("fresh session should not have a stored model")
+	}
+	meta, err := EnsureBranchMeta(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetBranchModelPreserveUpdated(path, "openrouter/anthropic/claude-sonnet"); err != nil {
+		t.Fatal(err)
+	}
+	model, ok := LoadSessionModel(path)
+	if !ok || model != "openrouter/anthropic/claude-sonnet" {
+		t.Fatalf("LoadSessionModel = %q, %v", model, ok)
+	}
+	updated, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta ok=%v err=%v", ok, err)
+	}
+	if !updated.UpdatedAt.Equal(meta.UpdatedAt) {
+		t.Fatalf("model write refreshed activity: before=%s after=%s", meta.UpdatedAt, updated.UpdatedAt)
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -132,6 +132,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if !ok {
 		return nil, fmt.Errorf("%w %q (configured: %s); note: defining [[providers]] replaces the built-in presets, so add a [[providers]] entry for it or use a configured name, or run `reasonix setup` to reconfigure", ErrUnknownModel, modelName, providerNames(cfg))
 	}
+	modelRef := entry.Name + "/" + entry.Model
 	if opts.EffortOverride != nil {
 		entry.Effort = *opts.EffortOverride
 		if entry.Kind == "anthropic" && strings.TrimSpace(entry.Effort) != "" && strings.TrimSpace(entry.Thinking) == "" {
@@ -797,6 +798,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		Sink:                   sink,
 		Policy:                 policy,
 		Label:                  label,
+		ModelRef:               modelRef,
 		SystemPrompt:           sysPrompt,
 		SessionDir:             sessionDir,
 		Host:                   pluginHost,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -209,6 +209,23 @@ func chdirTo(dir string) int {
 	return 0
 }
 
+func modelForResumePath(modelName, resumePath string, cfg *config.Config) string {
+	if strings.TrimSpace(modelName) != "" || strings.TrimSpace(resumePath) == "" {
+		return modelName
+	}
+	sessionModel, ok := agent.LoadSessionModel(resumePath)
+	if !ok {
+		return modelName
+	}
+	if cfg == nil {
+		return sessionModel
+	}
+	if _, ok := cfg.ResolveModel(sessionModel); !ok {
+		return modelName
+	}
+	return sessionModel
+}
+
 var newNotificationSender = func() notify.Sender { return notify.NewPlatformSender() }
 
 // withNotifications adds system notifications to CLI event streams when configured.
@@ -270,6 +287,13 @@ func runAgent(args []string) int {
 		sink = metrics
 	}
 	sink = withNotifications(sink, cfg)
+	if *resume != "" {
+		*model = modelForResumePath(*model, *resume, cfg)
+	} else if *cont {
+		if sessions, err := agent.ListSessions(resolveCLISessionDir()); err == nil && len(sessions) > 0 {
+			*model = modelForResumePath(*model, sessions[0].Path, cfg)
+		}
+	}
 	ctrl, err := setup(ctx, *model, *maxSteps, true, sink)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -337,6 +361,8 @@ func runServe(args []string) int {
 
 	ctx := context.Background()
 	bc := serve.NewBroadcaster()
+	cfg, _ := config.Load()
+	*model = modelForResumePath(*model, *resume, cfg)
 	ctrl, err := setup(ctx, *model, *maxSteps, true, bc)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
@@ -411,6 +437,7 @@ func chatREPL(args []string) int {
 	}
 
 	ctx := context.Background()
+	*model = modelForResumePath(*model, resumePath, cfg)
 
 	// Plumb the controller's typed event stream through a channel so each event
 	// can become a tea.Msg inside the TUI's update loop. Buffered generously:

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -15,6 +15,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/event"
 	"reasonix/internal/i18n"
@@ -50,6 +51,40 @@ func TestChdirTo(t *testing.T) {
 
 	if rc := chdirTo(filepath.Join(tmp, "does-not-exist")); rc != 2 {
 		t.Fatalf("chdirTo(missing) = %d, want 2", rc)
+	}
+}
+
+func TestModelForResumePathUsesStoredModelWhenAvailable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	session := agent.NewSession("sys")
+	session.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if err := session.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SetBranchModelPreserveUpdated(path, "saved/model"); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		DefaultModel: "default/model",
+		Providers: []config.ProviderEntry{
+			{Name: "default", Kind: "openai", BaseURL: "https://default.invalid/v1", Model: "model"},
+			{Name: "saved", Kind: "openai", BaseURL: "https://saved.invalid/v1", Model: "model"},
+		},
+	}
+
+	if got := modelForResumePath("", path, cfg); got != "saved/model" {
+		t.Fatalf("modelForResumePath = %q, want saved/model", got)
+	}
+	if got := modelForResumePath("explicit/model", path, cfg); got != "explicit/model" {
+		t.Fatalf("explicit model was overwritten: %q", got)
+	}
+	if got := modelForResumePath("", filepath.Join(dir, "missing.jsonl"), cfg); got != "" {
+		t.Fatalf("missing session model = %q, want empty fallback", got)
+	}
+	cfg.Providers = cfg.Providers[:1]
+	if got := modelForResumePath("", path, cfg); got != "" {
+		t.Fatalf("unknown stored model = %q, want empty fallback", got)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2058,13 +2058,13 @@ func (c *Controller) snapshot(markActivity bool) error {
 			return err
 		}
 	}
+	if err := s.Save(path); err != nil {
+		return err
+	}
 	if strings.TrimSpace(modelRef) != "" {
 		if err := agent.SetBranchModelPreserveUpdated(path, modelRef); err != nil {
 			return err
 		}
-	}
-	if err := s.Save(path); err != nil {
-		return err
 	}
 	if markActivity {
 		return agent.TouchBranchMeta(path)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -63,6 +63,7 @@ type Controller struct {
 	policy   permission.Policy
 
 	label             string
+	modelRef          string
 	systemPrompt      string
 	sessionDir        string
 	host              *plugin.Host
@@ -242,6 +243,7 @@ type Options struct {
 	Sink          event.Sink
 	Policy        permission.Policy
 	Label         string
+	ModelRef      string
 	SystemPrompt  string
 	SessionDir    string
 	SessionPath   string
@@ -307,6 +309,7 @@ func New(opts Options) *Controller {
 		sink:                   sink,
 		policy:                 opts.Policy,
 		label:                  opts.Label,
+		modelRef:               opts.ModelRef,
 		systemPrompt:           opts.SystemPrompt,
 		sessionDir:             opts.SessionDir,
 		sessionPath:            opts.SessionPath,
@@ -2041,6 +2044,7 @@ func (c *Controller) autosaveWhileRunning(ctx context.Context) {
 func (c *Controller) snapshot(markActivity bool) error {
 	c.mu.Lock()
 	path := c.sessionPath
+	modelRef := c.modelRef
 	c.mu.Unlock()
 	if c.executor == nil || path == "" {
 		return nil
@@ -2051,6 +2055,11 @@ func (c *Controller) snapshot(markActivity bool) error {
 	}
 	if !markActivity {
 		if _, err := agent.EnsureBranchMeta(path); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(modelRef) != "" {
+		if err := agent.SetBranchModelPreserveUpdated(path, modelRef); err != nil {
 			return err
 		}
 	}

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -219,6 +219,32 @@ func TestSnapshotActivityRefreshesSessionActivity(t *testing.T) {
 	}
 }
 
+func TestSnapshotActivitySavesTranscriptBeforeModelMeta(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	sess := agent.NewSession("sys")
+	sess.Add(provider.Message{Role: provider.RoleUser, Content: "must persist"})
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test", ModelRef: "provider/model-a"})
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agent.BranchMetaPath(path), []byte("{bad json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.SnapshotActivity(); err == nil {
+		t.Fatal("SnapshotActivity should report malformed branch metadata")
+	}
+	loaded, err := agent.LoadSession(path)
+	if err != nil {
+		t.Fatalf("transcript was not saved before metadata error: %v", err)
+	}
+	if len(loaded.Messages) == 0 || loaded.Messages[len(loaded.Messages)-1].Content != "must persist" {
+		t.Fatalf("saved transcript = %+v, want persisted user message", loaded.Messages)
+	}
+}
+
 func TestNewSessionStartsFreshContextAndSavesTranscript(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -161,7 +161,7 @@ func TestSnapshotDoesNotRefreshSessionActivity(t *testing.T) {
 	sess := agent.NewSession("sys")
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "first"})
 	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
-	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test", ModelRef: "provider/model-a"})
 	c.SetSessionPath(filepath.Join(dir, "session.jsonl"))
 
 	if err := c.SnapshotActivity(); err != nil {
@@ -183,6 +183,9 @@ func TestSnapshotDoesNotRefreshSessionActivity(t *testing.T) {
 	}
 	if !second.UpdatedAt.Equal(first.UpdatedAt) {
 		t.Fatalf("Snapshot refreshed activity: first=%s second=%s", first.UpdatedAt, second.UpdatedAt)
+	}
+	if second.Model != "provider/model-a" {
+		t.Fatalf("snapshot model = %q, want provider/model-a", second.Model)
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist the canonical provider/model ref in each session's BranchMeta sidecar
- prefer the stored session model before rebuilding controllers for CLI run/serve/chat resume flows and desktop tab startup
- keep stale or missing stored models non-blocking by falling back through the existing model resolution path
- preserve session activity ordering when only the stored model metadata is updated

## Related
Fixes #4519.
Supersedes #4618; this PR carries forward the same session-model persistence fix while preserving activity timestamps and covering the shared CLI/serve/chat plus desktop startup paths on the latest main-v2.

## Authorship note
@SivanCola is the primary author of this PR. @Juan-LukeKlopper contributed as a collaborator through the original #4618 implementation and problem analysis that this PR supersedes.

## Testing
- `go test ./...`
- `(cd desktop && go test ./...)`
- `git diff --check HEAD~1 HEAD`
