### PR TITLE
Fix default interactive CLI routing / 修复默认交互 CLI 路由

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,7 +37,10 @@ import (
 	"golang.org/x/term"
 )
 
-var runInteractiveSession = chatREPL
+var (
+	runInteractiveSession = chatREPL
+	cliIsInteractive      = isInteractive
+)
 
 // Run is the CLI entry point; it returns a process exit code.
 func Run(args []string, version string) int {
@@ -64,8 +67,13 @@ func Run(args []string, version string) int {
 		}
 	}
 
-	if len(args) == 0 {
+	if len(args) == 0 && cliIsInteractive() {
 		return runInteractiveSession(nil)
+	}
+	if len(args) == 0 {
+		configureCLIThemeFromConfigForTTYOutput()
+		usage()
+		return 0
 	}
 	if cmd == "" {
 		return runInteractiveSession(args)
@@ -127,10 +135,8 @@ func isDefaultInteractiveFlag(arg string) bool {
 	case "--model", "--max-steps", "--continue", "-c", "--resume", "--dangerously-skip-permissions", "--yolo", "--dir":
 		return true
 	}
-	for _, prefix := range []string{"--model=", "--max-steps=", "--dir="} {
-		if strings.HasPrefix(arg, prefix) {
-			return true
-		}
+	if name, _, ok := strings.Cut(arg, "="); ok && isDefaultInteractiveFlag(name) {
+		return true
 	}
 	return false
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -178,7 +178,12 @@ func TestRunDefaultsToInteractiveSession(t *testing.T) {
 	isolateCLIConfigHome(t)
 
 	prev := runInteractiveSession
-	t.Cleanup(func() { runInteractiveSession = prev })
+	prevInteractive := cliIsInteractive
+	t.Cleanup(func() {
+		runInteractiveSession = prev
+		cliIsInteractive = prevInteractive
+	})
+	cliIsInteractive = func() bool { return true }
 
 	var gotArgs []string
 	runInteractiveSession = func(args []string) int {
@@ -194,24 +199,57 @@ func TestRunDefaultsToInteractiveSession(t *testing.T) {
 	}
 }
 
+func TestRunNoArgsNonInteractivePrintsUsage(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	prev := runInteractiveSession
+	prevInteractive := cliIsInteractive
+	t.Cleanup(func() {
+		runInteractiveSession = prev
+		cliIsInteractive = prevInteractive
+	})
+	cliIsInteractive = func() bool { return false }
+	runInteractiveSession = func(args []string) int {
+		t.Fatalf("non-interactive no-arg Run should not start session with %#v", args)
+		return 99
+	}
+
+	out := captureStdout(t, func() {
+		if rc := Run(nil, "test-version"); rc != 0 {
+			t.Fatalf("Run(nil) rc = %d, want 0", rc)
+		}
+	})
+	if !strings.Contains(out, "reasonix —") || !strings.Contains(out, "reasonix run") {
+		t.Fatalf("non-interactive no-arg Run should print usage, got:\n%s", out)
+	}
+}
+
 func TestRunRoutesBareInteractiveFlagsToSession(t *testing.T) {
 	isolateCLIConfigHome(t)
 
 	prev := runInteractiveSession
 	t.Cleanup(func() { runInteractiveSession = prev })
 
-	var gotArgs []string
-	runInteractiveSession = func(args []string) int {
-		gotArgs = append([]string(nil), args...)
-		return 23
-	}
+	for _, args := range [][]string{
+		{"--continue"},
+		{"--continue=true"},
+		{"-c=true"},
+		{"--resume=true"},
+		{"--yolo=true"},
+		{"--dangerously-skip-permissions=true"},
+	} {
+		var gotArgs []string
+		runInteractiveSession = func(args []string) int {
+			gotArgs = append([]string(nil), args...)
+			return 23
+		}
 
-	args := []string{"--continue"}
-	if rc := Run(args, "test-version"); rc != 23 {
-		t.Fatalf("Run(--continue) rc = %d, want 23", rc)
-	}
-	if !reflect.DeepEqual(gotArgs, args) {
-		t.Fatalf("interactive args = %#v, want %#v", gotArgs, args)
+		if rc := Run(args, "test-version"); rc != 23 {
+			t.Fatalf("Run(%#v) rc = %d, want 23", args, rc)
+		}
+		if !reflect.DeepEqual(gotArgs, args) {
+			t.Fatalf("interactive args = %#v, want %#v", gotArgs, args)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep bare `reasonix` on non-interactive stdin/stdout on a safe usage-output path instead of launching the TUI
- route boolean assignment forms such as `--continue=true`, `-c=true`, and `--yolo=true` to the interactive session parser
- add regression coverage for both review findings from #4632

## Tests
- `go test ./internal/cli`
- `go test ./...`