### PR TITLE
Refresh docs site install and desktop guidance / 刷新文档站点安装与桌面端说明

### DIFF
--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -15,7 +15,7 @@ try {
   title="Docs — Reasonix"
   titleEn="Docs — Reasonix"
   titleZh="文档 — Reasonix"
-  description="Install Reasonix, start your first session, configure DeepSeek, and understand the prefix-cache loop. CLI commands, slash commands, MCP plugins, permissions and sandbox.">
+  description="Install Reasonix, start your first session, configure providers and credentials, and understand prefix cache, permissions, sandboxing, MCP plugins, memory, rewind, desktop and bot workflows.">
 
   <header class="nav scrolled">
     <div class="nav-inner">
@@ -39,7 +39,8 @@ try {
     <aside class="docs-side">
       <div class="side-group">
         <span class="gh"><span class="l-en">Getting started</span><span class="l-zh">快速开始</span></span>
-        <a href="#install"><span class="l-en">Installation</span><span class="l-zh">安装</span></a>
+        <a href="#install"><span class="l-en">CLI / TUI</span><span class="l-zh">CLI / TUI</span></a>
+        <a href="#desktop"><span class="l-en">Desktop app</span><span class="l-zh">桌面端下载</span></a>
         <a href="#quickstart"><span class="l-en">Quick start</span><span class="l-zh">快速上手</span></a>
         <a href="#config"><span class="l-en">Configuration</span><span class="l-zh">配置</span></a>
       </div>
@@ -48,53 +49,90 @@ try {
         <a href="#cache"><span class="l-en">Prefix cache</span><span class="l-zh">前缀缓存</span></a>
         <a href="#permissions"><span class="l-en">Permissions &amp; sandbox</span><span class="l-zh">权限与沙箱</span></a>
         <a href="#mcp"><span class="l-en">Plugins (MCP)</span><span class="l-zh">插件(MCP)</span></a>
+        <a href="#memory"><span class="l-en">Memory &amp; rewind</span><span class="l-zh">记忆与回退</span></a>
       </div>
       <div class="side-group">
         <span class="gh"><span class="l-en">Reference</span><span class="l-zh">参考</span></span>
         <a href="#cli"><span class="l-en">CLI &amp; slash commands</span><span class="l-zh">命令行与斜杠命令</span></a>
         <a href="#configfile"><span class="l-en">Config file</span><span class="l-zh">配置文件</span></a>
+        <a href="#surfaces"><span class="l-en">Desktop &amp; bots</span><span class="l-zh">桌面端与 Bot</span></a>
       </div>
     </aside>
 
     <article class="docs-main">
       <h1><span class="l-en">Documentation</span><span class="l-zh">文档</span></h1>
-      <p class="lede"><span class="l-en">Everything you need to install Reasonix, start your first session, and understand why long sessions stay cheap. For the full engineering contract, see the <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>Spec</a> and <a href={`${repo}/blob/main-v2/docs/GUIDE.md`}>Guide</a> on GitHub.</span><span class="l-zh">从安装到第一次会话,以及理解为什么长会话依然便宜——你需要的都在这里。完整工程契约见 GitHub 上的 <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>Spec</a> 与 <a href={`${repo}/blob/main-v2/docs/GUIDE.md`}>Guide</a>。</span></p>
+      <p class="lede"><span class="l-en">Everything you need to install Reasonix, start your first session, configure providers and credentials, and understand why long sessions stay cheap. For the full engineering contract, see the <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>Spec</a> and <a href={`${repo}/blob/main-v2/docs/GUIDE.md`}>Guide</a> on GitHub.</span><span class="l-zh">从安装、第一次会话、provider 与凭据配置,到理解为什么长会话依然便宜——你需要的入口都在这里。完整工程契约见 GitHub 上的 <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>Spec</a> 与 <a href={`${repo}/blob/main-v2/docs/GUIDE.md`}>Guide</a>。</span></p>
 
-      <h2 id="install"><span class="l-en">Installation</span><span class="l-zh">安装</span></h2>
-      <p><span class="l-en">One command on macOS, Linux, Windows, or WSL.</span><span class="l-zh">一条命令,支持 macOS、Linux、Windows 或 WSL。</span></p>
+      <h2 id="install"><span class="l-en">CLI / TUI</span><span class="l-zh">CLI / TUI</span></h2>
+      <p><span class="l-en">Install the terminal app with one command on macOS, Linux, Windows, or WSL. <code>reasonix</code> opens the interactive TUI; <code>reasonix run</code> is the headless automation entry.</span><span class="l-zh">一条命令安装终端应用,支持 macOS、Linux、Windows 或 WSL。<code>reasonix</code> 打开交互式 TUI；<code>reasonix run</code> 用于无界面自动执行。</span></p>
       <div class="codeblock"><button data-copy="npm i -g reasonix@next">Copy</button><span class="c"># npm (recommended · 推荐)</span>
 npm i -g reasonix@next
 
 <span class="c"># Homebrew</span>
 brew install esengine/reasonix/reasonix</div>
-      <div class="callout"><span class="ico">!</span><span><span class="l-en">The npm <code>latest</code> tag is pinned at <strong>v0.53</strong> — a deprecated line that no longer receives updates. All 1.x releases (currently <strong>v{goVer}</strong>, a single Go binary with no Node runtime) ship on <code>@next</code>.</span><span class="l-zh">npm 的 <code>latest</code> 标签固定在 <strong>v0.53</strong>——该线已废弃、不再更新。所有 1.x 版本(当前 <strong>v{goVer}</strong>,单 Go 二进制、无需 Node)均发布在 <code>@next</code> 渠道。</span></span></div>
-      <p><span class="l-en">Prefer a GUI? Desktop apps for macOS, Windows, and Linux are on the <a href={`${base}/#start`}>download page</a>.</span><span class="l-zh">想用图形界面?macOS、Windows、Linux 桌面端请前往<a href={`${base}/#start`}>下载页</a>。</span></p>
+      <div class="tui-panel">
+        <span class="desktop-kicker"><span class="l-en">Terminal-first workflow</span><span class="l-zh">终端优先工作流</span></span>
+        <ul class="desktop-feature-list">
+          <li><span class="l-en">Interactive TUI with Plan, Ask, Auto, YOLO, transcript scrolling, and tool approval prompts.</span><span class="l-zh">交互式 TUI 支持 Plan、Ask、Auto、YOLO、对话滚动与工具审批提示。</span></li>
+          <li><span class="l-en">Keyboard-native coding: slash commands, <code>@</code> file references, image paste, prompt history, and `/rewind`.</span><span class="l-zh">键盘原生编码体验：斜杠命令、<code>@</code> 文件引用、图片粘贴、提示历史和 `/rewind`。</span></li>
+          <li><span class="l-en">Scriptable runs through <code>reasonix run</code>, including piped input and explicit model selection.</span><span class="l-zh">可脚本化的 <code>reasonix run</code>,支持管道输入和显式模型选择。</span></li>
+        </ul>
+      </div>
+      <div class="callout"><span class="ico">!</span><span><span class="l-en">To install the legacy <strong>0.x</strong> version, run <code>npm i -g reasonix@latest</code>. The commands above, Homebrew, and desktop/release downloads install Reasonix 1.x; the current desktop download build is <strong>v{goVer}</strong>.</span><span class="l-zh">如需安装 legacy <strong>0.x</strong> 版本,命令是: <code>npm i -g reasonix@latest</code>。上方命令、Homebrew 与桌面端/Release 下载对应 Reasonix 1.x；当前桌面端下载构建为 <strong>v{goVer}</strong>。</span></span></div>
+
+      <h2 id="desktop"><span class="l-en">Desktop app</span><span class="l-zh">桌面端</span></h2>
+      <div class="desktop-panel">
+        <div class="desktop-panel-head">
+          <span class="desktop-kicker"><span class="l-en">Native app · v{goVer}</span><span class="l-zh">原生桌面端 · v{goVer}</span></span>
+          <h3><span class="l-en">Use Reasonix with a full desktop workspace</span><span class="l-zh">用完整桌面工作区运行 Reasonix</span></h3>
+          <p><span class="l-en">The desktop app runs the same local Reasonix engine as the CLI, with visual sessions, settings, MCP status, memory, checkpoints, tool approvals, and IM bot connections in one place.</span><span class="l-zh">桌面端运行与 CLI 相同的本地 Reasonix 引擎,并把可视化会话、设置、MCP 状态、记忆、检查点、工具审批和 IM Bot 连接集中到一个工作区。</span></p>
+        </div>
+        <div class="desktop-downloads" aria-label="Desktop downloads">
+          <a class="desktop-download" href={`${R2}/Reasonix-darwin-universal.dmg`} download>
+            <strong>macOS</strong>
+            <span><span class="l-en">Universal DMG</span><span class="l-zh">通用 DMG</span></span>
+          </a>
+          <a class="desktop-download" href={`${R2}/Reasonix-windows-amd64-installer.exe`} download>
+            <strong>Windows</strong>
+            <span><span class="l-en">x64 installer</span><span class="l-zh">x64 安装器</span></span>
+          </a>
+          <a class="desktop-download" href={`${R2}/Reasonix-linux-amd64.tar.gz`} download>
+            <strong>Linux</strong>
+            <span><span class="l-en">amd64 tarball</span><span class="l-zh">amd64 压缩包</span></span>
+          </a>
+        </div>
+        <ul class="desktop-feature-list">
+          <li><span class="l-en">Open and resume project sessions from a visual sidebar.</span><span class="l-zh">从可视化侧边栏打开和恢复项目会话。</span></li>
+          <li><span class="l-en">Approve tools, review checkpoints, and rewind code or conversation without leaving the app.</span><span class="l-zh">在应用内审批工具、查看 checkpoint,并回退代码或对话。</span></li>
+          <li><span class="l-en">Connect Feishu, Lark, or WeChat bots from Settings and handle remote approvals locally.</span><span class="l-zh">在设置中连接飞书、Lark 或微信 Bot,并在本地处理远程审批。</span></li>
+        </ul>
+      </div>
 
       <h2 id="quickstart"><span class="l-en">Quick start</span><span class="l-zh">快速上手</span></h2>
-      <p><span class="l-en">First run is minimal — <code>reasonix setup</code> walks you through picking a provider and keys. Then point Reasonix at a repo and start a session:</span><span class="l-zh">首次运行很简单——<code>reasonix setup</code> 引导你选择 provider 与密钥。然后指向仓库、开始会话:</span></p>
+      <p><span class="l-en">First run is minimal — <code>reasonix setup</code> walks you through picking a provider and keys, saving new keys to the configured credential store. Then point Reasonix at a repo and start a session:</span><span class="l-zh">首次运行很简单——<code>reasonix setup</code> 引导你选择 provider 与密钥,新密钥会保存到配置的凭据存储。然后指向仓库、开始会话:</span></p>
       <div class="codeblock"><button data-copy="cd your-project && reasonix">Copy</button>cd your-project
 reasonix</div>
       <p><span class="l-en">Then just describe the task:</span><span class="l-zh">然后直接描述任务:</span></p>
       <div class="codeblock"><span class="a">›</span> add retry with backoff to the http client
 <span class="a">›</span> refactor the auth flow, keep the public API stable
 <span class="a">›</span> why is the worker leaking memory?</div>
-      <p><span class="l-en">Leave the session running — context is append-only, so every new turn starts from a cache hit instead of a cold start.</span><span class="l-zh">让会话一直跑着——上下文只追加,每一轮都从缓存命中开始,而不是冷启动。</span></p>
+      <p><span class="l-en">Run <code>/init</code> when you want project memory, then leave the session running — context is append-only, so every new turn starts from a cache hit instead of a cold start.</span><span class="l-zh">需要项目记忆时运行 <code>/init</code>,然后让会话持续运行——上下文只追加,每一轮都从缓存命中开始,而不是冷启动。</span></p>
 
       <h2 id="config"><span class="l-en">Configuration</span><span class="l-zh">配置</span></h2>
-      <p><span class="l-en">Reasonix talks directly to DeepSeek with your own API key. Secrets come from the environment via <code>api_key_env</code> and are never written to config files:</span><span class="l-zh">Reasonix 使用你自己的 API Key 直连 DeepSeek。密钥通过 <code>api_key_env</code> 从环境读取,绝不写入配置文件:</span></p>
+      <p><span class="l-en">Reasonix talks directly to configured OpenAI-compatible providers such as DeepSeek or MiMo with your own API keys. Config files name an environment variable through <code>api_key_env</code>; new keys saved by Reasonix go to the OS credential store when available, with a Reasonix-owned file fallback.</span><span class="l-zh">Reasonix 使用你自己的 API Key 直连配置好的 OpenAI-compatible provider,例如 DeepSeek 或 MiMo。配置文件通过 <code>api_key_env</code> 指定环境变量；Reasonix 保存的新密钥优先进入系统密钥库,不可用时使用 Reasonix 自己的文件 fallback。</span></p>
       <div class="codeblock"><button data-copy="export DEEPSEEK_API_KEY=sk-...">Copy</button>export DEEPSEEK_API_KEY=sk-...</div>
-      <p><span class="l-en">Your code goes to your machine and the model — nowhere else. Persistent options live in the <a href="#configfile">config file</a>.</span><span class="l-zh">你的代码只会经过你的机器与模型,不去任何别处。持久化选项见<a href="#configfile">配置文件</a>。</span></p>
+      <p><span class="l-en">Project <code>.env</code> files are read for compatibility and deliberate per-project overrides, but Reasonix does not write new keys there. Persistent options live in the <a href="#configfile">config file</a>.</span><span class="l-zh">项目 <code>.env</code> 会被读取,用于兼容旧项目或明确的项目级覆盖,但 Reasonix 不会把新密钥写入那里。持久化选项见<a href="#configfile">配置文件</a>。</span></p>
 
       <h2 id="cache"><span class="l-en">Prefix cache</span><span class="l-zh">前缀缓存</span></h2>
       <p><span class="l-en">DeepSeek bills cached prefix tokens at a fraction of fresh computation. Most agents waste this: they reorder messages, rewrite summaries mid-session, or inject volatile timestamps — every change invalidates the cache from that point on.</span><span class="l-zh">DeepSeek 对缓存前缀 token 的计费远低于新计算。多数智能体浪费了这一点:重排消息、会话中改写摘要、注入易变的时间戳——任何改动都会让其后的缓存全部失效。</span></p>
       <p><span class="l-en">Reasonix serializes context deterministically and only ever appends. The practical effect: hours-long sessions where 90%+ of every request replays from cache, and input-token cost collapses to ~1/5. See the <a href={`${base}/#how`}>animated walkthrough</a> on the home page.</span><span class="l-zh">Reasonix 以确定性方式序列化上下文,并且永远只追加。实际效果:数小时的会话中每次请求 90% 以上从缓存重放,输入 token 成本降到约 1/5。可在首页查看<a href={`${base}/#how`}>动态演示</a>。</span></p>
 
       <h2 id="permissions"><span class="l-en">Permissions &amp; sandbox</span><span class="l-zh">权限与沙箱</span></h2>
-      <p><span class="l-en">Permissions gate each tool call: <code>deny</code> &gt; <code>ask</code> &gt; <code>allow</code> &gt; fallback. Readers always allow; writers fall back to <code>[permissions] mode</code>. <code>reasonix</code> prompts before each writer; <code>reasonix run</code> stays autonomous but still honours <code>deny</code>.</span><span class="l-zh">权限逐个把关工具调用:<code>deny</code> &gt; <code>ask</code> &gt; <code>allow</code> &gt; 兜底。读工具始终放行;写工具回退到 <code>[permissions] mode</code>。<code>reasonix</code> 在每次写操作前询问;<code>reasonix run</code> 自主运行,但仍遵守 <code>deny</code>。</span></p>
-      <p><span class="l-en">The sandbox is enforcement: file-writers refuse any path outside <code>[sandbox] workspace_root</code> (default: the current dir), resolving symlinks and <code>..</code> so a link can't tunnel out. Reads are unrestricted.</span><span class="l-zh">沙箱负责强制执行:写文件工具拒绝 <code>[sandbox] workspace_root</code>(默认当前目录)之外的任何路径,并解析符号链接与 <code>..</code>,防止借链接逃逸。读取不受限。</span></p>
+      <p><span class="l-en">Permissions gate each tool call: <code>deny</code> &gt; <code>ask</code> &gt; <code>allow</code> &gt; fallback. Read-only tools generally pass; writers fall back to <code>[permissions] mode</code>. <code>reasonix</code> prompts before fallback writers; <code>reasonix run</code> stays autonomous but still honours <code>deny</code>.</span><span class="l-zh">权限逐个把关工具调用:<code>deny</code> &gt; <code>ask</code> &gt; <code>allow</code> &gt; 兜底。只读工具通常放行；写工具回退到 <code>[permissions] mode</code>。<code>reasonix</code> 会在 fallback 写操作前询问；<code>reasonix run</code> 自主运行,但仍遵守 <code>deny</code>。</span></p>
+      <p><span class="l-en">The sandbox is enforcement: file-writers refuse any path outside <code>[sandbox] workspace_root</code> (default: the current dir), resolving symlinks and <code>..</code> so a link cannot tunnel out. On macOS, <code>bash</code> is jailed by default with the same write roots; other platforms currently fall back to unconfined shell execution. Reads are unrestricted.</span><span class="l-zh">沙箱负责强制执行:写文件工具拒绝 <code>[sandbox] workspace_root</code>(默认当前目录)之外的任何路径,并解析符号链接与 <code>..</code>,防止借链接逃逸。macOS 上 <code>bash</code> 默认也会按同一组写入根目录隔离；其他平台目前回退到非隔离 shell 执行。读取不受限。</span></p>
 
       <h2 id="mcp"><span class="l-en">Plugins (MCP)</span><span class="l-zh">插件(MCP)</span></h2>
-      <p><span class="l-en">Reasonix is an MCP client. A <code>[[plugins]]</code> entry's <code>type</code> selects the transport — <code>stdio</code> (default) launches a local subprocess, <code>http</code> connects to a remote <code>url</code>. Tools surface to the model as <code>mcp__&lt;server&gt;__&lt;tool&gt;</code>. Already have an <code>.mcp.json</code>? Drop it in the project root and Reasonix reads it as-is.</span><span class="l-zh">Reasonix 是一个 MCP 客户端。<code>[[plugins]]</code> 条目的 <code>type</code> 选择传输方式——<code>stdio</code>(默认)启动本地子进程,<code>http</code> 连接远程 <code>url</code>。工具以 <code>mcp__&lt;server&gt;__&lt;tool&gt;</code> 呈现给模型。已有 <code>.mcp.json</code>?放到项目根目录,Reasonix 会原样读取。</span></p>
+      <p><span class="l-en">Reasonix is an MCP client. A <code>[[plugins]]</code> entry's <code>type</code> selects the transport: <code>stdio</code> launches a local subprocess, while <code>http</code> connects to a Streamable HTTP server with optional headers expanded from the environment. Tools surface to the model as <code>mcp__&lt;server&gt;__&lt;tool&gt;</code>.</span><span class="l-zh">Reasonix 是一个 MCP 客户端。<code>[[plugins]]</code> 条目的 <code>type</code> 选择传输方式：<code>stdio</code> 启动本地子进程；<code>http</code> 连接 Streamable HTTP server,可从环境变量展开静态 headers。工具以 <code>mcp__&lt;server&gt;__&lt;tool&gt;</code> 呈现给模型。</span></p>
       <div class="codeblock"><span class="c"># reasonix.toml</span>
 [[plugins]]                       <span class="c"># local stdio server</span>
 name    = "example"
@@ -105,24 +143,38 @@ name    = "stripe"
 type    = "http"
 url     = "https://mcp.stripe.com"
 headers = &#123; Authorization = "Bearer $&#123;STRIPE_KEY&#125;" &#125;</div>
+      <p><span class="l-en">MCP prompts also become slash commands such as <code>/mcp__server__prompt</code>, and MCP resources can be referenced with <code>@server:uri</code>. Enabled servers connect in the background after a session starts; use <code>/mcp</code> or the desktop MCP panel to inspect, refresh, reconnect, or disable servers. Already have an <code>.mcp.json</code>? Put it in the project root; Reasonix reads the Claude Code <code>mcpServers</code> schema as-is and lets <code>reasonix.toml</code> win on name collisions.</span><span class="l-zh">MCP prompts 也会变成 <code>/mcp__server__prompt</code> 这样的斜杠命令,MCP resources 可通过 <code>@server:uri</code> 引用。启用的 server 会在会话开始后后台连接；用 <code>/mcp</code> 或桌面端 MCP 面板查看、刷新、重连或临时禁用。已有 <code>.mcp.json</code>?放到项目根目录即可；Reasonix 会原样读取 Claude Code 的 <code>mcpServers</code> schema,同名时 <code>reasonix.toml</code> 优先。</span></p>
+
+      <h2 id="memory"><span class="l-en">Memory &amp; rewind</span><span class="l-zh">记忆与回退</span></h2>
+      <p><span class="l-en">Reasonix keeps project memory in <code>REASONIX.md</code> or <code>AGENTS.md</code>, and stores approved auto-memory facts under Reasonix home. During turns, read-only <code>history</code> and <code>memory</code> tools retrieve prior sessions, compacted archives, and saved facts on demand instead of injecting noisy dynamic state into the stable prompt prefix.</span><span class="l-zh">Reasonix 将项目记忆放在 <code>REASONIX.md</code> 或 <code>AGENTS.md</code>,并把经过批准的 auto-memory fact 存在 Reasonix home 下。运行时,只读 <code>history</code> 与 <code>memory</code> 工具按需检索历史会话、压缩归档和已保存事实,而不是把易变状态塞进稳定 prompt 前缀。</span></p>
+      <p><span class="l-en">Agent-initiated <code>remember</code> and <code>forget</code> always ask for fresh approval, even in YOLO. <code>/memory</code> shows active and archived facts; <code>/forget</code> archives rather than permanently erasing a fact from traceability.</span><span class="l-zh">模型主动调用 <code>remember</code> 与 <code>forget</code> 时,即使在 YOLO 下也会重新请求批准。<code>/memory</code> 可查看 active 与 archived facts；<code>/forget</code> 会归档而不是永久抹掉可追溯记录。</span></p>
+      <p><span class="l-en">Rewind is snapshot-based, not git-based. Press double <code>Esc</code> in the CLI, use <code>/rewind</code>, or use the desktop hover control to restore code, conversation, or both from an earlier turn without touching <code>.git</code>.</span><span class="l-zh">回退基于文件快照,不是 git。CLI 中双击 <code>Esc</code>、使用 <code>/rewind</code>,或在桌面端用户消息上使用 hover 控件,即可从较早 turn 恢复代码、对话或两者,不会触碰 <code>.git</code>。</span></p>
 
       <h2 id="cli"><span class="l-en">CLI &amp; slash commands</span><span class="l-zh">命令行与斜杠命令</span></h2>
       <div class="codeblock">reasonix setup            <span class="c"># first-run: pick provider + keys</span>
 reasonix                  <span class="c"># interactive session, prompts before writes</span>
-reasonix run "&lt;task&gt;"     <span class="c"># autonomous run, honours deny rules</span></div>
+reasonix run "&lt;task&gt;"     <span class="c"># autonomous run, honours deny rules</span>
+reasonix bot doctor       <span class="c"># check saved IM bot connections</span></div>
       <p><span class="l-en">Inside a session, slash commands run locally — <code>/help</code> lists them all:</span><span class="l-zh">会话中,斜杠命令在本地运行——<code>/help</code> 列出全部:</span></p>
-      <div class="codeblock">/compact   /new      /rewind   /tree     /branch
-/switch    /todo     /model    /mcp      /skills
-/hooks     /memory   /language /output-style       /help</div>
-      <p><span class="l-en"><code>/branch [name]</code> forks the current conversation tip, <code>/switch &lt;id|name&gt;</code> loads another branch. Custom commands are Markdown files under <code>.reasonix/commands/</code>.</span><span class="l-zh"><code>/branch [name]</code> 从当前会话尖端分叉,<code>/switch &lt;id|name&gt;</code> 加载另一条分支。自定义命令是 <code>.reasonix/commands/</code> 下的 Markdown 文件。</span></p>
+      <div class="codeblock">/compact   /new      /clear    /rewind   /tree
+/branch    /switch   /todo     /model    /mcp
+/skills    /hooks    /memory   /sandbox  /language
+/auto-plan /reasoning-language /output-style /help</div>
+      <p><span class="l-en"><code>/branch [name]</code> forks the current conversation tip, <code>/switch &lt;id|name&gt;</code> loads another branch, and <code>/clear</code> confirms before discarding unsaved context. Custom commands are Markdown files under <code>.reasonix/commands/</code> or <code>~/.reasonix/commands/</code>.</span><span class="l-zh"><code>/branch [name]</code> 从当前会话尖端分叉,<code>/switch &lt;id|name&gt;</code> 加载另一条分支,<code>/clear</code> 会确认后丢弃未保存上下文。自定义命令是 <code>.reasonix/commands/</code> 或 <code>~/.reasonix/commands/</code> 下的 Markdown 文件。</span></p>
+      <p><span class="l-en">Use <code>@path</code> to inject files or directories, and <code>@server:uri</code> for MCP resources. <code>reasonix config auto-plan off|on</code> and <code>reasonix config reasoning-language auto|zh|en</code> update user defaults from scripts; add <code>--local</code> only for project-local overrides.</span><span class="l-zh">用 <code>@path</code> 注入文件或目录,用 <code>@server:uri</code> 引入 MCP resource。脚本中可用 <code>reasonix config auto-plan off|on</code> 与 <code>reasonix config reasoning-language auto|zh|en</code> 更新用户级默认值；只有明确需要项目级覆盖时才加 <code>--local</code>。</span></p>
 
       <h2 id="configfile"><span class="l-en">Config file</span><span class="l-zh">配置文件</span></h2>
-      <p><span class="l-en">Resolution order: flag &gt; <code>./reasonix.toml</code> &gt; <code>~/.config/reasonix/config.toml</code> &gt; built-in defaults.</span><span class="l-zh">解析顺序:flag &gt; <code>./reasonix.toml</code> &gt; <code>~/.config/reasonix/config.toml</code> &gt; 内置默认值。</span></p>
-      <div class="codeblock"><span class="c"># ~/.config/reasonix/config.toml</span>
+      <p><span class="l-en">Resolution order: flags &gt; <code>./reasonix.toml</code> &gt; global <code>config.toml</code> under Reasonix home &gt; compatible legacy config &gt; built-in defaults. Starting with v1.8.1, Reasonix home is <code>~/.reasonix</code> on macOS/Linux and <code>%APPDATA%\reasonix</code> on Windows; set <code>REASONIX_HOME</code> only for tests, CI, or portable installs.</span><span class="l-zh">解析顺序:flags &gt; <code>./reasonix.toml</code> &gt; Reasonix home 下的全局 <code>config.toml</code> &gt; 兼容 legacy config &gt; 内置默认值。从 v1.8.1 起,Reasonix home 在 macOS/Linux 为 <code>~/.reasonix</code>,Windows 为 <code>%APPDATA%\reasonix</code>；只有测试、CI 或便携安装才需要设置 <code>REASONIX_HOME</code>。</span></p>
+      <div class="codeblock"><span class="c"># ~/.reasonix/config.toml (macOS/Linux)</span>
 default_model = "deepseek-flash"
 
+[ui]
+shortcut_layout = "desktop"        <span class="c"># optional compatibility setting</span>
+
 [agent]
-auto_plan = "ask"                  <span class="c"># off|ask|on</span>
+auto_plan = "off"                  <span class="c"># off|on</span>
+reasoning_language = "auto"        <span class="c"># auto|zh|en</span>
+planner_model = "deepseek-pro"     <span class="c"># optional read-only planner</span>
 
 [[providers]]
 name        = "deepseek-flash"
@@ -131,18 +183,48 @@ base_url    = "https://api.deepseek.com"
 model       = "deepseek-v4-flash"
 api_key_env = "DEEPSEEK_API_KEY"
 
+[tools]
+bash_timeout_seconds = 120
+
 [permissions]
 mode  = "ask"                                <span class="c"># ask|allow|deny</span>
-deny  = ["bash(rm -rf*)", "bash(git push*)"]
-allow = ["bash(go test*)"]</div>
-      <p><span class="l-en">For the full schema and every field's contract, see <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>SPEC.md §5</a>.</span><span class="l-zh">完整 schema 与每个字段的契约见 <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>SPEC.md §5</a>。</span></p>
+deny  = ["Bash(rm -rf*)", "Bash(git push*)"]
+allow = ["Bash(go test:*)"]
+
+[sandbox]
+workspace_root = ""                          <span class="c"># empty = current dir</span>
+
+[[plugins]]
+name    = "example"
+command = "reasonix-plugin-example"</div>
+      <p><span class="l-en">Legacy config, credentials, memory, and sessions are migrated non-destructively when v1.8.1+ starts. If Reasonix was opened before old paths were available, run <code>/migrate</code> from the CLI TUI or desktop composer. For the full schema and every field's contract, see <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>SPEC.md §5</a>.</span><span class="l-zh">v1.8.1+ 启动时会非破坏性迁移 legacy config、credentials、memory 与 sessions。如果旧路径尚不可用时已经打开过 Reasonix,可在 CLI TUI 或桌面端 composer 中运行 <code>/migrate</code>。完整 schema 与每个字段的契约见 <a href={`${repo}/blob/main-v2/docs/SPEC.md`}>SPEC.md §5</a>。</span></p>
+
+      <h2 id="surfaces"><span class="l-en">Desktop &amp; bots</span><span class="l-zh">桌面端与 Bot</span></h2>
+      <p><span class="l-en">The desktop app shares the same config, credential store, controller, permissions, sandbox, MCP lifecycle, memory, and checkpoint model as the CLI. Desktop-only settings such as shortcuts and bot connections are stored under Reasonix home.</span><span class="l-zh">桌面端与 CLI 共用同一套 config、凭据存储、controller、权限、沙箱、MCP 生命周期、记忆与 checkpoint 模型。快捷键、Bot 连接等桌面端设置存储在 Reasonix home 下。</span></p>
+      <p><span class="l-en">From <strong>Settings -> Bots</strong>, connect Feishu, Lark, or WeChat, then send Reasonix messages from IM. The local desktop runtime handles model calls, tools, approvals, and sandboxing, while IM receives progress, approval cards or text commands, and final results. Headless gateways can be started with <code>reasonix bot start --channels feishu,lark,weixin --dir /path/to/project</code>.</span><span class="l-zh">在 <strong>Settings -> Bots</strong> 中连接飞书、Lark 或微信后,即可从 IM 给 Reasonix 发消息。本地桌面运行时负责模型调用、工具、审批和沙箱,IM 侧接收进度、审批卡片或文本命令以及最终结果。也可以用 <code>reasonix bot start --channels feishu,lark,weixin --dir /path/to/project</code> 启动 headless gateway。</span></p>
 
       <div class="doc-cards">
         <a class="doc-card" href={`${base}/#how`}>
           <h3><span class="l-en">See the cache in action →</span><span class="l-zh">看缓存如何工作 →</span></h3>
           <p><span class="l-en">Scroll-driven walkthrough of prefix replay on the home page.</span><span class="l-zh">首页的滚动演示:前缀重放的每一轮。</span></p>
         </a>
-        <a class="doc-card" href={repo}>
+        <a class="doc-card" href={`${repo}/blob/main-v2/docs/CONFIG_PATHS.md`}>
+          <h3><span class="l-en">Configuration paths →</span><span class="l-zh">配置路径 →</span></h3>
+          <p><span class="l-en">Reasonix home, credentials, sessions, archives, memory, and migration rescue.</span><span class="l-zh">Reasonix home、凭据、会话、归档、记忆与迁移救援。</span></p>
+        </a>
+        <a class="doc-card" href={`${repo}/blob/main-v2/docs/REASONING_LANGUAGE.md`}>
+          <h3><span class="l-en">Reasoning language →</span><span class="l-zh">思考语言 →</span></h3>
+          <p><span class="l-en">Visible thinking language preference without changing the stable prompt prefix.</span><span class="l-zh">可见思考语言偏好,不改变稳定 prompt 前缀。</span></p>
+        </a>
+        <a class="doc-card" href={`${repo}/blob/main-v2/docs/CHECKPOINTS.md`}>
+          <h3><span class="l-en">Checkpoints &amp; rewind →</span><span class="l-zh">检查点与回退 →</span></h3>
+          <p><span class="l-en">Restore code, conversation, or both from snapshot-based checkpoints.</span><span class="l-zh">通过快照式 checkpoint 恢复代码、对话或两者。</span></p>
+        </a>
+        <a class="doc-card" href={`${repo}/blob/main-v2/docs/BOT_GUIDE.md`}>
+          <h3><span class="l-en">Bot guide →</span><span class="l-zh">Bot 指南 →</span></h3>
+          <p><span class="l-en">Connect Feishu, Lark, and WeChat bots, then approve work from IM.</span><span class="l-zh">连接飞书、Lark 与微信 Bot,并从 IM 中审批任务。</span></p>
+        </a>
+        <a class="doc-card" href={`${repo}/graphs/contributors`}>
           <h3><span class="l-en">Contribute →</span><span class="l-zh">参与贡献 →</span></h3>
           <p><span class="l-en">Reasonix is MIT-licensed and open source — good first issues are waiting.</span><span class="l-zh">Reasonix 采用 MIT 许可、开源——新手友好任务等着你。</span></p>
         </a>

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -525,6 +525,7 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
   max-width: 1180px; margin: 0 auto; padding: 130px 40px 110px;
 }
 .docs-side { position: sticky; top: 110px; align-self: start; display: flex; flex-direction: column; gap: 28px; }
+.docs-main { min-width: 0; }
 .side-group .gh {
   font-size: 12px; font-weight: 600; letter-spacing: 0.06em;
   text-transform: uppercase; color: var(--ink-3); display: block; margin-bottom: 8px; padding-left: 16px;
@@ -581,6 +582,59 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
   width: 22px; height: 22px; border-radius: 50%;
   background: var(--accent); color: #fff; font-size: 13px; font-weight: 700;
 }
+.tui-panel {
+  margin: 18px 0 20px; padding: 20px 22px;
+  border: 1px solid var(--line); border-radius: var(--radius-sm);
+  background: var(--bg-soft);
+}
+.tui-panel .desktop-feature-list { margin-top: 10px !important; }
+.desktop-panel {
+  margin: 20px 0 8px; padding: 24px;
+  border: 1px solid color-mix(in oklch, var(--accent) 18%, var(--line));
+  border-radius: var(--radius-sm);
+  background: linear-gradient(180deg, color-mix(in oklch, var(--accent) 9%, white), #fff 72%);
+}
+.desktop-panel-head { max-width: 680px; }
+.desktop-kicker {
+  display: inline-flex; align-items: center; margin-bottom: 10px;
+  font-size: 12px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--accent);
+}
+.docs-main .desktop-panel h3 {
+  margin: 0 0 8px; font-size: 21px; line-height: 1.25;
+  letter-spacing: -0.012em; color: var(--ink);
+}
+.docs-main .desktop-panel p { margin: 0; max-width: 720px; }
+.desktop-downloads {
+  display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px; margin-top: 20px;
+}
+.desktop-download {
+  display: flex; flex-direction: column; gap: 4px;
+  min-width: 0; padding: 15px 16px; border-radius: 10px;
+  background: #fff; border: 1px solid var(--line);
+  color: var(--ink); text-decoration: none;
+  box-shadow: var(--shadow-1);
+  transition: border-color 0.2s, box-shadow 0.2s, transform 0.2s var(--ease);
+}
+.desktop-download:hover {
+  border-color: color-mix(in oklch, var(--accent) 42%, var(--line));
+  box-shadow: var(--shadow-2); transform: translateY(-1px); text-decoration: none;
+}
+.desktop-download strong { font-size: 15px; font-weight: 700; color: var(--ink); }
+.desktop-download span { font-size: 13px; color: var(--ink-2); line-height: 1.35; }
+.desktop-feature-list {
+  display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px 16px; margin: 18px 0 0 !important; padding: 0; list-style: none;
+}
+.desktop-feature-list li {
+  position: relative; padding-left: 16px;
+  font-size: 13.5px; line-height: 1.55; color: var(--ink-2);
+}
+.desktop-feature-list li::before {
+  content: ""; position: absolute; left: 0; top: 0.62em;
+  width: 6px; height: 6px; border-radius: 50%; background: var(--accent);
+}
 .doc-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 22px; }
 .doc-card {
   position: relative; display: block; text-decoration: none;
@@ -621,6 +675,7 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .lang-switch { margin-left: auto; }
   .docs-layout { grid-template-columns: 1fr; gap: 36px; padding: 110px 24px 80px; }
   .docs-side { position: static; }
+  .desktop-downloads, .desktop-feature-list { grid-template-columns: 1fr; }
   .doc-cards { grid-template-columns: 1fr; }
   .divider { display: none; }
   .divider + section { padding-top: 100px; }


### PR DESCRIPTION
## Summary
- Refresh the docs page to foreground CLI/TUI installation, desktop downloads, memory/rewind, MCP, config, and bot workflows.
- Clarify that the legacy 0.x npm install command is `npm i -g reasonix@latest`, while 1.x uses `@next`, Homebrew, or desktop/release downloads.
- Point the contribution card to the repository contributors graph and add responsive styling for the new docs panels.

## Verification
- `npm run build`
- `git diff --check`
- Local preview HTML check for CLI/TUI text, legacy npm command, desktop download links, and contributors link