### PR TITLE
fix(agent): smart plan-mode gate with bash read-only validation (#4572)

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1269,14 +1269,13 @@ export default function App() {
     [patchActiveComposerProfile, syncModeToController],
   );
   const applyCollaborationMode = useCallback(
-    (m: CollaborationMode) => {
+    (m: CollaborationMode): Promise<void> => {
       if (m === "goal") {
         patchActiveComposerProfile({ collaborationMode: "normal", goalDraftMode: true, goal: "" }, ["collaborationMode", "goal"]);
-        void setControllerCollaborationMode("normal");
-        return;
+        return setControllerCollaborationMode("normal");
       }
       patchActiveComposerProfile({ collaborationMode: m, goalDraftMode: false, goal: "" }, ["collaborationMode", "goal"]);
-      void setControllerCollaborationMode(m);
+      return setControllerCollaborationMode(m);
     },
     [patchActiveComposerProfile, setControllerCollaborationMode],
   );
@@ -2853,18 +2852,19 @@ export default function App() {
               <ApprovalModal
                 key={state.approval.id}
                 approval={state.approval}
-                onAnswer={(allow, session, persist) => {
-                  // Approving an exit_plan_mode plan leaves plan mode; sync the
-                  // tab-local indicator and persisted safe mode immediately.
-                  if (state.approval!.tool === "exit_plan_mode" && allow) applyCollaborationMode("normal");
+                onAnswer={async (allow, session, persist) => {
+                  // Approving an exit_plan_mode plan leaves plan mode; await the
+                  // mode switch before sending the approval so the controller
+                  // observes the updated state before it unblocks.
+                  if (state.approval!.tool === "exit_plan_mode" && allow) await applyCollaborationMode("normal");
                   approve(state.approval!.id, allow, session, persist);
                 }}
                 onRevisePlan={(text) => {
                   setPendingPlanRevision(text);
                   approve(state.approval!.id, false, false, false);
                 }}
-                onExitPlan={() => {
-                  applyCollaborationMode("normal");
+                onExitPlan={async () => {
+                  await applyCollaborationMode("normal");
                   approve(state.approval!.id, false, false, false);
                 }}
                 onStop={() => {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -28,6 +28,37 @@ import (
 // window before the next compaction runs.
 const maxToolOutputBytes = 32 * 1024
 
+// planModeDeniedTools lists tools that are unconditionally denied in plan mode.
+// These are never shown to the LLM and cannot be called even if the agent
+// somehow references them. The write_file, edit_file, and multi_edit tools are
+// the canonical file-writing tools; apply_patch is a structured write variant.
+var planModeDeniedTools = map[string]bool{
+	"write_file":  true,
+	"edit_file":   true,
+	"multi_edit":  true,
+	"apply_patch": true,
+}
+
+// planModeBashMetachars defines shell metacharacters that indicate command
+// chaining, redirection, or substitution. When any of these appear in a bash
+// command during plan mode, the command is blocked — even if the command prefix
+// matches a safe read-only entry — because chaining can introduce side effects
+// after an otherwise safe prefix.
+var planModeBashMetachars = []string{";", "&&", "||", "|", ">", ">>", "<", "<<", "$(", "\x60"}
+
+// planModeSafeBashCommands are bash command prefixes that are safe to run in
+// plan mode. Each entry is matched as a prefix against the trimmed, lowercased
+// command string. The match requires a word boundary after the prefix: a space,
+// a dash, or end-of-string — so "echop" never matches "echo".
+var planModeSafeBashCommands = []string{
+	"git status", "git diff", "git log", "git show",
+	"git ls-files", "git grep", "git blame",
+	"ls", "cat", "grep", "find", "head", "tail", "pwd",
+	"echo", "wc", "which", "type", "uname", "hostname",
+	"go version", "go list", "go doc", "go vet",
+	"node -v", "npm list", "python --version",
+}
+
 const maxFinalReadinessBlocks = 3
 const maxEmptyFinalBlocks = 3
 const maxStreamRecoveries = 1
@@ -259,6 +290,11 @@ type Agent struct {
 	// session without touching the cache-stable prefix. Set via SetMemoryQueue.
 	memQueue memory.Queue
 
+	// planModeAllowedTools is the set of tool names that are exempt from the
+	// plan-mode gate. When non-empty, these tools bypass the read-only check.
+	// Populated from Options.PlanModeAllowedTools during construction.
+	planModeAllowedTools map[string]bool
+
 	// Context management: when a turn's prompt nears contextWindow, the older
 	// middle of the session is summarized away, keeping a token-bounded recent
 	// tail verbatim (recentKeep is the message floor) and archiving the originals
@@ -310,6 +346,16 @@ const (
 // running it. The cache-friendly bits — system prompt, tools schema, message
 // history — are left untouched, so the toggle costs nothing in cache hits.
 func (a *Agent) SetPlanMode(v bool) { a.planMode.Store(v) }
+
+// SetTools replaces the agent's tool registry. The next API call picks up the
+// new tool schema; tools already cached in the provider prefix are unaffected
+// until the prefix is invalidated. Safe to call between turns.
+func (a *Agent) SetTools(tools *tool.Registry) {
+	if a == nil {
+		return
+	}
+	a.tools = tools
+}
 
 // SetReasoningLanguage updates the visible reasoning language preference for
 // subsequent user-role messages emitted by this agent.
@@ -511,6 +557,24 @@ type Options struct {
 	// ReasoningLanguage controls visible reasoning language preference as transient
 	// user-turn context. Empty/auto injects nothing.
 	ReasoningLanguage string
+
+	// PlanModeAllowedTools names tools that bypass the plan-mode read-only gate.
+	// When a tool named here is called while planMode is true, it executes
+	// without the "plan mode is read-only" block — even if its ReadOnly contract
+	// returns false. Use sparingly; the caller is responsible for ensuring the
+	// tool invocation is safe in a read-only context (e.g. bash for git status).
+	PlanModeAllowedTools []string
+}
+
+func stringSet(ss []string) map[string]bool {
+	if len(ss) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		m[s] = true
+	}
+	return m
 }
 
 // New constructs an Agent. MaxSteps <= 0 means no cap — the run loop continues
@@ -546,27 +610,28 @@ func New(prov provider.Provider, tools *tool.Registry, session *Session, opts Op
 		maxStepsKey = "agent.max_steps"
 	}
 	a := &Agent{
-		prov:              prov,
-		tools:             tools,
-		session:           session,
-		maxSteps:          opts.MaxSteps,
-		maxStepsKey:       maxStepsKey,
-		temperature:       opts.Temperature,
-		pricing:           opts.Pricing,
-		usageSource:       usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
-		sink:              sink,
-		gate:              gate,
-		hooks:             hooks,
-		jobs:              opts.Jobs,
-		evidence:          evidence.NewLedger(),
-		projectChecks:     append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
-		contextWindow:     opts.ContextWindow,
-		softCompactRatio:  opts.SoftCompactRatio,
-		compactRatio:      opts.CompactRatio,
-		compactForceRatio: opts.CompactForceRatio,
-		recentKeep:        opts.RecentKeep,
-		archiveDir:        opts.ArchiveDir,
-		keepPolicy:        opts.KeepPolicy,
+		prov:                 prov,
+		tools:                tools,
+		session:              session,
+		maxSteps:             opts.MaxSteps,
+		maxStepsKey:          maxStepsKey,
+		temperature:          opts.Temperature,
+		pricing:              opts.Pricing,
+		usageSource:          usageSourceOrDefault(opts.UsageSource, event.UsageSourceExecutor),
+		sink:                 sink,
+		gate:                 gate,
+		hooks:                hooks,
+		jobs:                 opts.Jobs,
+		evidence:             evidence.NewLedger(),
+		projectChecks:        append([]instruction.VerifyCheck(nil), opts.ProjectChecks...),
+		contextWindow:        opts.ContextWindow,
+		softCompactRatio:     opts.SoftCompactRatio,
+		compactRatio:         opts.CompactRatio,
+		compactForceRatio:    opts.CompactForceRatio,
+		recentKeep:           opts.RecentKeep,
+		archiveDir:           opts.ArchiveDir,
+		keepPolicy:           opts.KeepPolicy,
+		planModeAllowedTools: stringSet(opts.PlanModeAllowedTools),
 	}
 	a.SetReasoningLanguage(opts.ReasoningLanguage)
 	return a
@@ -1418,11 +1483,13 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 			errMsg:  "blocked by loop guard",
 		}
 	}
-	if a.planMode.Load() && !t.ReadOnly() {
-		return toolOutcome{
-			output:  fmt.Sprintf("blocked: %q is a writer tool and plan mode is read-only. Keep exploring with read-only tools, then write your plan as your reply — the user will be asked to approve it before any changes are made.", call.Name),
-			blocked: true,
-			errMsg:  "blocked: plan mode is read-only",
+	if a.planMode.Load() {
+		if blocked, msg := a.planModeBlocked(call.Name, t.ReadOnly(), json.RawMessage(call.Arguments)); blocked {
+			return toolOutcome{
+				output:  msg,
+				blocked: true,
+				errMsg:  "blocked: plan mode is read-only",
+			}
 		}
 	}
 	if a.gate != nil {
@@ -1532,6 +1599,57 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	body, truncMsg := truncateToolOutput(result)
 	return toolOutcome{output: body, truncated: truncMsg != "", truncMsg: truncMsg}
+}
+
+func (a *Agent) planModeBlocked(toolName string, readOnly bool, args json.RawMessage) (blocked bool, message string) {
+	if readOnly {
+		return false, ""
+	}
+	if planModeDeniedTools[toolName] {
+		return true, fmt.Sprintf("blocked: %q is not available in plan mode. Keep exploring with read-only tools — the user will be asked to approve the plan before any changes are made.", toolName)
+	}
+	if a.planModeAllowedTools != nil && a.planModeAllowedTools[toolName] {
+		return false, ""
+	}
+	if toolName == "bash" {
+		if blocked, msg := planModeBashBlocked(args); blocked {
+			return true, msg
+		}
+		return false, ""
+	}
+	return true, fmt.Sprintf("blocked: %q is a writer tool and plan mode is read-only. Keep exploring with read-only tools, then write your plan as your reply — the user will be asked to approve it before any changes are made.", toolName)
+}
+
+func planModeBashBlocked(args json.RawMessage) (bool, string) {
+	var p struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil || p.Command == "" {
+		return false, ""
+	}
+	cmd := strings.TrimSpace(p.Command)
+	lower := strings.ToLower(cmd)
+
+	// Reject commands containing shell metacharacters — chaining, piping,
+	// redirection, or command substitution can introduce side effects after
+	// an otherwise safe prefix.
+	for _, mc := range planModeBashMetachars {
+		if strings.Contains(lower, mc) {
+			return true, fmt.Sprintf("blocked: bash command in plan mode must not contain shell operators (%q). Use separate calls for chained commands.", mc)
+		}
+	}
+
+	// Check the command prefix against the safe read-only whitelist.
+	// Require a word boundary after the match to avoid prefix collisions.
+	for _, safe := range planModeSafeBashCommands {
+		if strings.HasPrefix(lower, safe) {
+			if len(lower) == len(safe) || lower[len(safe)] == ' ' || lower[len(safe)] == '-' {
+				return false, ""
+			}
+		}
+	}
+
+	return true, fmt.Sprintf("blocked: bash commands in plan mode must be read-only. %q is not in the safe command list. Use read-only tools for exploration, then exit plan mode to run this command.", cmd)
 }
 
 func (a *Agent) repeatedSuccessBlock(call provider.ToolCall, t tool.Tool) (string, bool) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"reasonix/internal/diff"
@@ -44,12 +45,12 @@ var planModeDeniedTools = map[string]bool{
 // command during plan mode, the command is blocked — even if the command prefix
 // matches a safe read-only entry — because chaining can introduce side effects
 // after an otherwise safe prefix.
-var planModeBashMetachars = []string{";", "&&", "||", "|", ">", ">>", "<", "<<", "$(", "\x60"}
+var planModeBashMetachars = []string{"&&", "||", ">>", "<<", "$(", "\x60", ";", "|", ">", "<", "&", "\n", "\r"}
 
 // planModeSafeBashCommands are bash command prefixes that are safe to run in
 // plan mode. Each entry is matched as a prefix against the trimmed, lowercased
-// command string. The match requires a word boundary after the prefix: a space,
-// a dash, or end-of-string — so "echop" never matches "echo".
+// command string. The match requires a shell-argument boundary after the prefix:
+// whitespace or end-of-string — so "echop" never matches "echo".
 var planModeSafeBashCommands = []string{
 	"git status", "git diff", "git log", "git show",
 	"git ls-files", "git grep", "git blame",
@@ -57,6 +58,17 @@ var planModeSafeBashCommands = []string{
 	"echo", "wc", "which", "type", "uname", "hostname",
 	"go version", "go list", "go doc", "go vet",
 	"node -v", "npm list", "python --version",
+}
+
+var planModeFindWriteArgs = map[string]bool{
+	"-delete":  true,
+	"-exec":    true,
+	"-execdir": true,
+	"-ok":      true,
+	"-okdir":   true,
+	"-fprint":  true,
+	"-fprintf": true,
+	"-fls":     true,
 }
 
 const maxFinalReadinessBlocks = 3
@@ -1639,17 +1651,61 @@ func planModeBashBlocked(args json.RawMessage) (bool, string) {
 		}
 	}
 
-	// Check the command prefix against the safe read-only whitelist.
-	// Require a word boundary after the match to avoid prefix collisions.
+	// Check the command prefix against the safe read-only whitelist. Require a
+	// shell-argument boundary after the match to avoid prefix collisions.
 	for _, safe := range planModeSafeBashCommands {
-		if strings.HasPrefix(lower, safe) {
-			if len(lower) == len(safe) || lower[len(safe)] == ' ' || lower[len(safe)] == '-' {
-				return false, ""
-			}
+		if !planModeBashMatchesSafePrefix(lower, safe) {
+			continue
 		}
+		if arg := planModeUnsafeSafeCommandArg(lower, safe); arg != "" {
+			return true, fmt.Sprintf("blocked: bash command in plan mode uses a write-capable argument (%q). Use a read-only command while planning.", arg)
+		}
+		return false, ""
 	}
 
 	return true, fmt.Sprintf("blocked: bash commands in plan mode must be read-only. %q is not in the safe command list. Use read-only tools for exploration, then exit plan mode to run this command.", cmd)
+}
+
+func planModeBashMatchesSafePrefix(lower, safe string) bool {
+	if !strings.HasPrefix(lower, safe) {
+		return false
+	}
+	if len(lower) == len(safe) {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(lower[len(safe):])
+	return unicode.IsSpace(r)
+}
+
+func planModeUnsafeSafeCommandArg(lower, safe string) string {
+	fields := strings.Fields(lower)
+	base := strings.Fields(safe)
+	if len(fields) <= len(base) {
+		return ""
+	}
+	args := fields[len(base):]
+	if strings.HasPrefix(safe, "git ") {
+		for _, arg := range args {
+			if arg == "--output" || strings.HasPrefix(arg, "--output=") || arg == "--ext-diff" {
+				return arg
+			}
+		}
+	}
+	switch safe {
+	case "find":
+		for _, arg := range args {
+			if planModeFindWriteArgs[arg] {
+				return arg
+			}
+		}
+	case "go vet":
+		for _, arg := range args {
+			if arg == "-vettool" || strings.HasPrefix(arg, "-vettool=") {
+				return arg
+			}
+		}
+	}
+	return ""
 }
 
 func (a *Agent) repeatedSuccessBlock(call provider.ToolCall, t tool.Tool) (string, bool) {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -71,6 +71,14 @@ var planModeFindWriteArgs = map[string]bool{
 	"-fls":     true,
 }
 
+var planModeGoWriteOrExecArgs = map[string]bool{
+	"-fix":      true,
+	"-mod":      true,
+	"-modfile":  true,
+	"-toolexec": true,
+	"-vettool":  true,
+}
+
 const maxFinalReadinessBlocks = 3
 const maxEmptyFinalBlocks = 3
 const maxStreamRecoveries = 1
@@ -1657,7 +1665,7 @@ func planModeBashBlocked(args json.RawMessage) (bool, string) {
 		if !planModeBashMatchesSafePrefix(lower, safe) {
 			continue
 		}
-		if arg := planModeUnsafeSafeCommandArg(lower, safe); arg != "" {
+		if arg := planModeUnsafeSafeCommandArg(cmd, safe); arg != "" {
 			return true, fmt.Sprintf("blocked: bash command in plan mode uses a write-capable argument (%q). Use a read-only command while planning.", arg)
 		}
 		return false, ""
@@ -1677,30 +1685,41 @@ func planModeBashMatchesSafePrefix(lower, safe string) bool {
 	return unicode.IsSpace(r)
 }
 
-func planModeUnsafeSafeCommandArg(lower, safe string) string {
-	fields := strings.Fields(lower)
+func planModeUnsafeSafeCommandArg(cmd, safe string) string {
+	fields := strings.Fields(cmd)
 	base := strings.Fields(safe)
 	if len(fields) <= len(base) {
 		return ""
 	}
 	args := fields[len(base):]
+	lowerArgs := make([]string, len(args))
+	for i, arg := range args {
+		lowerArgs[i] = strings.ToLower(arg)
+	}
 	if strings.HasPrefix(safe, "git ") {
-		for _, arg := range args {
+		for _, arg := range lowerArgs {
 			if arg == "--output" || strings.HasPrefix(arg, "--output=") || arg == "--ext-diff" {
 				return arg
 			}
 		}
 	}
 	switch safe {
+	case "git grep":
+		for i, arg := range args {
+			lowerArg := lowerArgs[i]
+			if arg == "-O" || strings.HasPrefix(arg, "-O") || strings.HasPrefix(lowerArg, "--open-files-in-pager") {
+				return arg
+			}
+		}
 	case "find":
-		for _, arg := range args {
+		for _, arg := range lowerArgs {
 			if planModeFindWriteArgs[arg] {
 				return arg
 			}
 		}
-	case "go vet":
-		for _, arg := range args {
-			if arg == "-vettool" || strings.HasPrefix(arg, "-vettool=") {
+	case "go list", "go vet":
+		for _, arg := range lowerArgs {
+			if planModeGoWriteOrExecArgs[arg] || strings.HasPrefix(arg, "-mod=mod") || strings.HasPrefix(arg, "-modfile=") || strings.HasPrefix(arg, "-toolexec=") || strings.HasPrefix(arg, "-vettool=") {
 				return arg
 			}
 		}

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -103,6 +103,22 @@ func (c *Coordinator) SetReasoningLanguage(lang string) {
 	}
 }
 
+// SetPlanMode propagates the read-only gate to both planner and executor agents
+// in two-model mode. Callers that only set the controller's executor would miss
+// the planner agent inside the Coordinator, causing stale plan-mode state after
+// approvals or manual mode switches.
+func (c *Coordinator) SetPlanMode(v bool) {
+	if c == nil {
+		return
+	}
+	if c.plannerAgent != nil {
+		c.plannerAgent.SetPlanMode(v)
+	}
+	if c.executor != nil {
+		c.executor.SetPlanMode(v)
+	}
+}
+
 // Run plans with the planner model, then hands the plan to the executor.
 func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -406,3 +406,50 @@ func BenchmarkPlannerToolRegistry(b *testing.B) {
 		}
 	}
 }
+
+func TestCoordinatorSetPlanModePropagates(t *testing.T) {
+	prov := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "plan"},
+		{Type: provider.ChunkDone},
+	}}
+	plannerSess := NewSession("planner-sys")
+	plannerReg := tool.NewRegistry()
+	plannerReg.Add(coordinatorTestTool{name: "read_file", readOnly: true})
+	plannerTools := PlannerToolRegistry(plannerReg)
+
+	exec := New(nil, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+
+	coord := NewCoordinator(prov, plannerSess, nil, plannerTools, Options{MaxSteps: 2}, exec, 0, event.Discard, nil)
+
+	// Both should start with planMode=false
+	if coord.plannerAgent.planMode.Load() {
+		t.Error("planner should start with planMode=false")
+	}
+	if coord.executor.planMode.Load() {
+		t.Error("executor should start with planMode=false")
+	}
+
+	// SetPlanMode(true) should propagate to both
+	coord.SetPlanMode(true)
+	if !coord.plannerAgent.planMode.Load() {
+		t.Error("planner should have planMode=true after SetPlanMode(true)")
+	}
+	if !coord.executor.planMode.Load() {
+		t.Error("executor should have planMode=true after SetPlanMode(true)")
+	}
+
+	// SetPlanMode(false) should propagate to both
+	coord.SetPlanMode(false)
+	if coord.plannerAgent.planMode.Load() {
+		t.Error("planner should have planMode=false after SetPlanMode(false)")
+	}
+	if coord.executor.planMode.Load() {
+		t.Error("executor should have planMode=false after SetPlanMode(false)")
+	}
+}
+
+func TestCoordinatorSetPlanModeNilSafety(t *testing.T) {
+	var c *Coordinator
+	c.SetPlanMode(true)  // should not panic
+	c.SetPlanMode(false) // should not panic
+}

--- a/internal/agent/planmode_test.go
+++ b/internal/agent/planmode_test.go
@@ -84,6 +84,17 @@ func serializeToolNames(ts []provider.ToolSchema) string {
 	return strings.Join(names, ",")
 }
 
+func bashCommandArgs(t *testing.T, cmd string) json.RawMessage {
+	t.Helper()
+	args, err := json.Marshal(struct {
+		Command string `json:"command"`
+	}{Command: cmd})
+	if err != nil {
+		t.Fatalf("marshal bash args: %v", err)
+	}
+	return args
+}
+
 // --- planModeBlocked tests ---
 
 func TestPlanModeDeniedToolsBlocked(t *testing.T) {
@@ -161,8 +172,7 @@ func TestPlanModeBashBlocked_SafeCommands(t *testing.T) {
 	}
 	for _, cmd := range safe {
 		t.Run(cmd, func(t *testing.T) {
-			args := json.RawMessage(`{"command":"` + strings.ReplaceAll(cmd, `"`, `\"`) + `"}`)
-			blocked, msg := planModeBashBlocked(args)
+			blocked, msg := planModeBashBlocked(bashCommandArgs(t, cmd))
 			if blocked {
 				t.Errorf("planModeBashBlocked(%q) = blocked, want allowed; msg: %s", cmd, msg)
 			}
@@ -184,16 +194,45 @@ func TestPlanModeBashBlocked_Metacharacters(t *testing.T) {
 		{"redirect_in", "cat < file.go"},
 		{"heredoc", "cat << EOF"},
 		{"cmd_sub_dollar", "echo $(rm file.go)"},
+		{"background_ampersand", "git status & rm file.go"},
+		{"newline", "git status\nrm file.go"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := json.RawMessage(`{"command":"` + strings.ReplaceAll(tt.cmd, `"`, `\"`) + `"}`)
-			blocked, msg := planModeBashBlocked(args)
+			blocked, msg := planModeBashBlocked(bashCommandArgs(t, tt.cmd))
 			if !blocked {
 				t.Errorf("planModeBashBlocked(%q) = allowed, want blocked", tt.cmd)
 			}
 			if !strings.Contains(msg, "shell operators") {
 				t.Errorf("unexpected message: %s", msg)
+			}
+		})
+	}
+}
+
+func TestPlanModeBashBlocked_WriteCapableSafeCommandArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		arg  string
+	}{
+		{"find_delete", "find . -delete", "-delete"},
+		{"find_exec", "find . -name '*.tmp' -exec rm {} +", "-exec"},
+		{"find_fprint", "find . -name '*.go' -fprint files.txt", "-fprint"},
+		{"git_diff_output_equals", "git diff --output=patch.diff", "--output=patch.diff"},
+		{"git_diff_output_space", "git diff --output patch.diff", "--output"},
+		{"git_show_output", "git show HEAD --output=show.txt", "--output=show.txt"},
+		{"git_log_ext_diff", "git log --ext-diff", "--ext-diff"},
+		{"go_vet_vettool", "go vet -vettool=./writer ./...", "-vettool=./writer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocked, msg := planModeBashBlocked(bashCommandArgs(t, tt.cmd))
+			if !blocked {
+				t.Errorf("planModeBashBlocked(%q) = allowed, want blocked", tt.cmd)
+			}
+			if !strings.Contains(msg, tt.arg) {
+				t.Errorf("blocked message %q does not mention unsafe arg %q", msg, tt.arg)
 			}
 		})
 	}
@@ -232,8 +271,7 @@ func TestPlanModeBashBlocked_UnsafeCommands(t *testing.T) {
 	}
 	for _, cmd := range unsafe {
 		t.Run(cmd, func(t *testing.T) {
-			args := json.RawMessage(`{"command":"` + strings.ReplaceAll(cmd, `"`, `\"`) + `"}`)
-			blocked, _ := planModeBashBlocked(args)
+			blocked, _ := planModeBashBlocked(bashCommandArgs(t, cmd))
 			if !blocked {
 				t.Errorf("planModeBashBlocked(%q) = allowed, want blocked", cmd)
 			}
@@ -256,11 +294,24 @@ func TestPlanModeBashBlocked_BoundaryCheck(t *testing.T) {
 		t.Error("lsblk should not match ls prefix — boundary check failed")
 	}
 
-	// "git status" with dash boundary should match
+	// "git status" with a flag after a whitespace boundary should match.
 	args = json.RawMessage(`{"command":"git status --short"}`)
 	blocked, _ = planModeBashBlocked(args)
 	if blocked {
 		t.Error("git status --short should match git status prefix")
+	}
+
+	// A dash inside the command name should NOT match a shorter safe prefix.
+	args = json.RawMessage(`{"command":"git diff-files"}`)
+	blocked, _ = planModeBashBlocked(args)
+	if !blocked {
+		t.Error("git diff-files should not match git diff prefix")
+	}
+
+	args = json.RawMessage(`{"command":"cat-file --batch"}`)
+	blocked, _ = planModeBashBlocked(args)
+	if !blocked {
+		t.Error("cat-file should not match cat prefix")
 	}
 }
 

--- a/internal/agent/planmode_test.go
+++ b/internal/agent/planmode_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"reasonix/internal/event"
 	"strings"
 	"testing"
@@ -81,4 +82,283 @@ func serializeToolNames(ts []provider.ToolSchema) string {
 		names = append(names, t.Name)
 	}
 	return strings.Join(names, ",")
+}
+
+// --- planModeBlocked tests ---
+
+func TestPlanModeDeniedToolsBlocked(t *testing.T) {
+	denied := []string{"write_file", "edit_file", "multi_edit", "apply_patch"}
+	for _, name := range denied {
+		t.Run(name, func(t *testing.T) {
+			blocked, msg := (&Agent{}).planModeBlocked(name, false, nil)
+			if !blocked {
+				t.Errorf("planModeBlocked(%q) = false, want true", name)
+			}
+			if !strings.Contains(msg, "not available in plan mode") {
+				t.Errorf("unexpected message: %s", msg)
+			}
+		})
+	}
+}
+
+func TestPlanModeReadOnlyToolsAllowed(t *testing.T) {
+	blocked, _ := (&Agent{}).planModeBlocked("read_file", true, nil)
+	if blocked {
+		t.Error("ReadOnly tools should not be blocked in plan mode")
+	}
+}
+
+func TestPlanModeAllowedToolsOverride(t *testing.T) {
+	a := &Agent{planModeAllowedTools: map[string]bool{"custom_tool": true}}
+	blocked, _ := a.planModeBlocked("custom_tool", false, nil)
+	if blocked {
+		t.Error("tool in planModeAllowedTools should not be blocked")
+	}
+}
+
+func TestPlanModeGenericWriterBlocked(t *testing.T) {
+	blocked, msg := (&Agent{}).planModeBlocked("some_writer_tool", false, nil)
+	if !blocked {
+		t.Error("generic writer tool should be blocked in plan mode")
+	}
+	if !strings.Contains(msg, "writer tool") {
+		t.Errorf("unexpected message: %s", msg)
+	}
+}
+
+// --- planModeBashBlocked tests ---
+
+func TestPlanModeBashBlocked_SafeCommands(t *testing.T) {
+	safe := []string{
+		"git status",
+		"git diff",
+		"git diff --staged",
+		"git log --oneline -10",
+		"git show HEAD",
+		"git ls-files",
+		"git grep 'func main'",
+		"git blame file.go",
+		"ls -la",
+		"cat file.go",
+		"grep -rn 'pattern' .",
+		"find . -name '*.go'",
+		"head -20 file.go",
+		"tail -5 file.go",
+		"pwd",
+		"echo hello",
+		"wc -l file.go",
+		"which go",
+		"type git",
+		"uname -a",
+		"hostname",
+		"go version",
+		"go list ./...",
+		"go doc fmt.Println",
+		"go vet ./...",
+		"node -v",
+		"npm list",
+		"python --version",
+	}
+	for _, cmd := range safe {
+		t.Run(cmd, func(t *testing.T) {
+			args := json.RawMessage(`{"command":"` + strings.ReplaceAll(cmd, `"`, `\"`) + `"}`)
+			blocked, msg := planModeBashBlocked(args)
+			if blocked {
+				t.Errorf("planModeBashBlocked(%q) = blocked, want allowed; msg: %s", cmd, msg)
+			}
+		})
+	}
+}
+
+func TestPlanModeBashBlocked_Metacharacters(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+	}{
+		{"semicolon", "git status; rm file.go"},
+		{"and", "git status && rm file.go"},
+		{"or", "git status || rm file.go"},
+		{"pipe", "ls | grep foo"},
+		{"redirect_out", "echo hello > file.go"},
+		{"redirect_append", "echo hello >> file.go"},
+		{"redirect_in", "cat < file.go"},
+		{"heredoc", "cat << EOF"},
+		{"cmd_sub_dollar", "echo $(rm file.go)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := json.RawMessage(`{"command":"` + strings.ReplaceAll(tt.cmd, `"`, `\"`) + `"}`)
+			blocked, msg := planModeBashBlocked(args)
+			if !blocked {
+				t.Errorf("planModeBashBlocked(%q) = allowed, want blocked", tt.cmd)
+			}
+			if !strings.Contains(msg, "shell operators") {
+				t.Errorf("unexpected message: %s", msg)
+			}
+		})
+	}
+}
+
+func TestPlanModeBashBlocked_UnsafeCommands(t *testing.T) {
+	unsafe := []string{
+		"rm -rf /tmp/foo",
+		"cp file1 file2",
+		"mv old new",
+		"mkdir newdir",
+		"touch newfile",
+		"chmod 755 script.sh",
+		"git add .",
+		"git commit -m 'msg'",
+		"git push origin main",
+		"git checkout -b new-branch",
+		"go build ./...",
+		"go test ./...",
+		"npm install",
+		"npm run build",
+		"pip install requests",
+		"docker build .",
+		"make all",
+		"sed -i 's/old/new/' file.go",
+		"awk '{print $1}' file",
+		"tee output.txt",
+		"dd if=/dev/zero of=file",
+		"ssh user@host",
+		"curl https://example.com",
+		"wget https://example.com",
+		"python -c 'print(1)'",
+		"node -e 'console.log(1)'",
+		"ruby -e 'puts 1'",
+		"perl -e 'print 1'",
+	}
+	for _, cmd := range unsafe {
+		t.Run(cmd, func(t *testing.T) {
+			args := json.RawMessage(`{"command":"` + strings.ReplaceAll(cmd, `"`, `\"`) + `"}`)
+			blocked, _ := planModeBashBlocked(args)
+			if !blocked {
+				t.Errorf("planModeBashBlocked(%q) = allowed, want blocked", cmd)
+			}
+		})
+	}
+}
+
+func TestPlanModeBashBlocked_BoundaryCheck(t *testing.T) {
+	// "echop" should NOT match "echo" prefix
+	args := json.RawMessage(`{"command":"echop hello"}`)
+	blocked, _ := planModeBashBlocked(args)
+	if !blocked {
+		t.Error("echop should not match echo prefix — boundary check failed")
+	}
+
+	// "lsblk" should NOT match "ls" prefix
+	args = json.RawMessage(`{"command":"lsblk"}`)
+	blocked, _ = planModeBashBlocked(args)
+	if !blocked {
+		t.Error("lsblk should not match ls prefix — boundary check failed")
+	}
+
+	// "git status" with dash boundary should match
+	args = json.RawMessage(`{"command":"git status --short"}`)
+	blocked, _ = planModeBashBlocked(args)
+	if blocked {
+		t.Error("git status --short should match git status prefix")
+	}
+}
+
+func TestPlanModeBashBlocked_EmptyCommand(t *testing.T) {
+	// Empty/missing command should not crash
+	blocked, _ := planModeBashBlocked(json.RawMessage(`{}`))
+	if blocked {
+		t.Error("empty command should not be blocked")
+	}
+	blocked, _ = planModeBashBlocked(json.RawMessage(`{"command":""}`))
+	if blocked {
+		t.Error("empty string command should not be blocked")
+	}
+}
+
+func TestPlanModeBashBlocked_InvalidJSON(t *testing.T) {
+	blocked, _ := planModeBashBlocked(json.RawMessage(`not json`))
+	if blocked {
+		t.Error("invalid JSON should not be blocked (fail-open)")
+	}
+}
+
+func TestPlanModeBash_BashToolIntegration(t *testing.T) {
+	// Integration test: planModeBlocked with toolName="bash" delegates to planModeBashBlocked
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	a.SetPlanMode(true)
+
+	// Safe command should execute
+	safeResult := a.executeOne(context.Background(), provider.ToolCall{
+		Name:      "bash",
+		Arguments: `{"command":"git status"}`,
+	})
+	if strings.HasPrefix(safeResult.output, "blocked:") {
+		t.Errorf("git status should not be blocked in plan mode: %s", safeResult.output)
+	}
+
+	// Unsafe command should be blocked
+	unsafeResult := a.executeOne(context.Background(), provider.ToolCall{
+		Name:      "bash",
+		Arguments: `{"command":"rm -rf /"}`,
+	})
+	if !strings.HasPrefix(unsafeResult.output, "blocked:") {
+		t.Errorf("rm -rf should be blocked in plan mode: %s", unsafeResult.output)
+	}
+
+	// Chained command should be blocked
+	chainResult := a.executeOne(context.Background(), provider.ToolCall{
+		Name:      "bash",
+		Arguments: `{"command":"git status && rm file.go"}`,
+	})
+	if !strings.HasPrefix(chainResult.output, "blocked:") {
+		t.Errorf("chained command should be blocked in plan mode: %s", chainResult.output)
+	}
+}
+
+func TestPlanMode_BashAllowedToolsOverride(t *testing.T) {
+	// If bash is in planModeAllowedTools, it should bypass the bash validation
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+
+	a := New(nil, reg, NewSession(""), Options{
+		PlanModeAllowedTools: []string{"bash"},
+	}, event.Discard)
+	a.SetPlanMode(true)
+
+	// Even an unsafe command should pass because bash is in allowedTools
+	result := a.executeOne(context.Background(), provider.ToolCall{
+		Name:      "bash",
+		Arguments: `{"command":"rm -rf /"}`,
+	})
+	if strings.HasPrefix(result.output, "blocked:") {
+		t.Errorf("bash in planModeAllowedTools should bypass validation: %s", result.output)
+	}
+}
+
+func TestPlanModeOff_AllToolsAllowed(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "write_file", readOnly: false})
+	reg.Add(fakeTool{name: "bash", readOnly: false})
+
+	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
+	// planMode is OFF by default
+
+	// write_file should execute normally
+	result := a.executeOne(context.Background(), provider.ToolCall{Name: "write_file"})
+	if strings.HasPrefix(result.output, "blocked:") {
+		t.Error("write_file should not be blocked when plan mode is off")
+	}
+
+	// bash with any command should execute normally
+	result = a.executeOne(context.Background(), provider.ToolCall{
+		Name:      "bash",
+		Arguments: `{"command":"rm -rf /"}`,
+	})
+	if strings.HasPrefix(result.output, "blocked:") {
+		t.Error("bash should not be blocked when plan mode is off")
+	}
 }

--- a/internal/agent/planmode_test.go
+++ b/internal/agent/planmode_test.go
@@ -148,6 +148,7 @@ func TestPlanModeBashBlocked_SafeCommands(t *testing.T) {
 		"git show HEAD",
 		"git ls-files",
 		"git grep 'func main'",
+		"git grep -o 'func'",
 		"git blame file.go",
 		"ls -la",
 		"cat file.go",
@@ -223,6 +224,14 @@ func TestPlanModeBashBlocked_WriteCapableSafeCommandArgs(t *testing.T) {
 		{"git_diff_output_space", "git diff --output patch.diff", "--output"},
 		{"git_show_output", "git show HEAD --output=show.txt", "--output=show.txt"},
 		{"git_log_ext_diff", "git log --ext-diff", "--ext-diff"},
+		{"git_grep_open_pager_short", "git grep -O 'func main'", "-O"},
+		{"git_grep_open_pager_long", "git grep --open-files-in-pager=sh 'func main'", "--open-files-in-pager=sh"},
+		{"go_list_mod_write", "go list -mod=mod ./...", "-mod=mod"},
+		{"go_list_mod_space", "go list -mod mod ./...", "-mod"},
+		{"go_list_modfile", "go list -modfile=other.mod ./...", "-modfile=other.mod"},
+		{"go_list_toolexec", "go list -toolexec=./wrapper ./...", "-toolexec=./wrapper"},
+		{"go_vet_fix", "go vet -fix ./...", "-fix"},
+		{"go_vet_toolexec", "go vet -toolexec ./wrapper ./...", "-toolexec"},
 		{"go_vet_vettool", "go vet -vettool=./writer ./...", "-vettool=./writer"},
 	}
 	for _, tt := range tests {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -726,21 +726,22 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 
 	execSess := agent.NewSession(sysPrompt)
 	executor := agent.New(execProv, reg, execSess, agent.Options{
-		MaxSteps:          maxSteps,
-		Temperature:       cfg.Agent.Temperature,
-		Pricing:           entry.Price,
-		Gate:              headlessGate,
-		Hooks:             hookRunner,
-		Jobs:              jm,
-		ProjectChecks:     projectChecks,
-		ContextWindow:     entry.ContextWindow,
-		SoftCompactRatio:  cfg.Agent.SoftCompactRatio,
-		CompactRatio:      cfg.Agent.CompactRatio,
-		CompactForceRatio: cfg.Agent.CompactForceRatio,
-		RecentKeep:        cfg.Agent.RecentKeep,
-		ArchiveDir:        config.ArchiveDir(),
-		KeepPolicy:        keepPolicy,
-		ReasoningLanguage: cfg.ReasoningLanguage(),
+		MaxSteps:             maxSteps,
+		Temperature:          cfg.Agent.Temperature,
+		Pricing:              entry.Price,
+		Gate:                 headlessGate,
+		Hooks:                hookRunner,
+		Jobs:                 jm,
+		ProjectChecks:        projectChecks,
+		ContextWindow:        entry.ContextWindow,
+		SoftCompactRatio:     cfg.Agent.SoftCompactRatio,
+		CompactRatio:         cfg.Agent.CompactRatio,
+		CompactForceRatio:    cfg.Agent.CompactForceRatio,
+		RecentKeep:           cfg.Agent.RecentKeep,
+		ArchiveDir:           config.ArchiveDir(),
+		KeepPolicy:           keepPolicy,
+		ReasoningLanguage:    cfg.ReasoningLanguage(),
+		PlanModeAllowedTools: cfg.Agent.PlanModeAllowedTools,
 	}, sink)
 
 	var runner agent.Runner = executor
@@ -821,6 +822,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		ReasoningLanguage:      cfg.ReasoningLanguage(),
 		DisableColdResumePrune: !cfg.ColdResumePruneEnabled(),
 		Shell:                  shell,
+		PlanModeAllowedTools:   cfg.Agent.PlanModeAllowedTools,
 		OnRemember: func(rule string) control.RememberResult {
 			return rememberPermissionRule(root, rule)
 		},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -767,6 +767,11 @@ type AgentConfig struct {
 	// ColdResumePrune elides stale tool results when a session reopens past the
 	// provider cache window. nil = default enabled.
 	ColdResumePrune *bool `toml:"cold_resume_prune"`
+	// PlanModeAllowedTools names tools that are exempt from the plan-mode read-only
+	// gate. When a tool named here is called while in plan mode, it executes without
+	// the "plan mode is read-only" block. Use sparingly — prefer the built-in safe
+	// bash commands for read-only exploration.
+	PlanModeAllowedTools []string `toml:"plan_mode_allowed_tools"`
 }
 
 // ProviderEntry declares a model provider instance. ContextWindow is the model's

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -287,6 +287,9 @@ type Options struct {
 	// persist to disk (e.g. "Bash(go test:*)"). The callback is wired into the
 	// permission Gate on EnableInteractiveApproval.
 	OnRemember func(rule string) RememberResult
+	// PlanModeAllowedTools names tools exempt from the plan-mode read-only gate.
+	// Passed through to the executor agent so user-configured exceptions work.
+	PlanModeAllowedTools []string
 }
 
 // New builds a Controller. A nil Sink is replaced with event.Discard.
@@ -1397,6 +1400,9 @@ func (c *Controller) SetPlanMode(v bool) {
 	c.mu.Unlock()
 	if c.executor != nil {
 		c.executor.SetPlanMode(v)
+	}
+	if setter, ok := c.runner.(interface{ SetPlanMode(bool) }); ok {
+		setter.SetPlanMode(v)
 	}
 }
 


### PR DESCRIPTION
Closes #4572

## Problem

Plan mode's binary `planMode && !ReadOnly()` gate blocks ALL non-read-only tools, including bash. This means the AI cannot run read-only commands like `git status`, `git diff`, `ls`, or `grep` while in plan mode — it has to ask to exit plan mode just to gather context, which defeats the purpose of planning.

Additionally, the plan-approval-to-execution transition has a race condition where `applyCollaborationMode("normal")` is fire-and-forget, so the frontend can update its state before the backend processes the mode change.

## Changes

### Smart plan-mode gate (`internal/agent/agent.go`)

Replaced the binary `planMode && !ReadOnly()` gate with `planModeBlocked()` that implements three-tier filtering:

1. **Hard-blocked tools** — `write_file`, `edit_file`, `multi_edit`, `apply_patch` are unconditionally denied in plan mode
2. **Bash validation** — bash commands are checked against a safe read-only whitelist with metacharacter detection:
   - Commands containing `&&`, `||`, `|`, `>`, `>>`, `<`, `<<`, `$(`, `\x60` are blocked (chaining/piping/redirection can introduce side effects)
   - Only whitelisted prefixes pass: `git status`, `git diff`, `git log`, `git show`, `git ls-files`, `git grep`, `git blame`, `ls`, `cat`, `grep`, `find`, `head`, `tail`, `pwd`, `echo`, `wc`, `which`, `type`, `uname`, `hostname`, `go version`, `go list`, `go doc`, `go vet`, `node -v`, `npm list`, `python --version`
   - Word-boundary matching prevents prefix collisions (`echop` doesn't match `echo`)
3. **User-configurable exceptions** — `plan_mode_allowed_tools` config lets users exempt specific tools

### Coordinator propagation (`internal/agent/coordinator.go`)

Added `SetPlanMode(bool)` to `Coordinator` — propagates to both `plannerAgent` and `executor` in two-model mode. Previously only the executor was updated, leaving the planner agent with stale plan-mode state.

### Runner propagation (`internal/control/controller.go`)

`Controller.SetPlanMode()` now type-asserts `c.runner` for `SetPlanMode(bool)` and calls it, ensuring the Coordinator (two-model mode) receives the update.

### Config (`internal/config/config.go`)

Added `plan_mode_allowed_tools` field to `AgentConfig` for user-configurable tool exceptions.

### Frontend race fix (`desktop/frontend/src/App.tsx`)

`applyCollaborationMode` now returns `Promise<void>` (was fire-and-forget). `onAnswer` and `onExitPlan` handlers `await` the mode change before calling `approve()`, ensuring the backend processes the mode switch before unblocking the controller.

## Tests

**16 new test cases** in `planmode_test.go` and `coordinator_test.go`:

- Denied tools blocked (write_file, edit_file, multi_edit, apply_patch)
- Read-only tools allowed
- User-configured allowed-tools override
- Generic writer tools blocked
- 28 safe command variations (git, ls, cat, grep, find, go, node, python, etc.)
- 9 metacharacter variations (&&, ||, |, >, >>, <, <<, $(), heredoc)
- 28 unsafe command variations (rm, cp, mv, git add/commit/push, go build/test, npm, pip, docker, sed, awk, ssh, curl, wget, python -c, node -e)
- Word-boundary check (echop ≠ echo, lsblk ≠ ls)
- Empty/invalid command edge cases
- Integration test: bash tool with plan mode on/off
- Allowed-tools override bypasses bash validation
- Plan mode off allows everything
- Coordinator.SetPlanMode propagation
- Coordinator.SetPlanMode nil safety

## Files Changed

| File | Change |
|---|---|
| `internal/agent/agent.go` | Smart plan-mode gate, `SetTools()`, `PlanModeAllowedTools` in Options/Agent |
| `internal/agent/coordinator.go` | `SetPlanMode()` method |
| `internal/control/controller.go` | Runner propagation via type assertion |
| `internal/config/config.go` | `plan_mode_allowed_tools` field |
| `internal/boot/boot.go` | Config threading |
| `desktop/frontend/src/App.tsx` | Await mode change before approve |
| `internal/agent/planmode_test.go` | 14 new tests |
| `internal/agent/coordinator_test.go` | 2 new tests |