### PR TITLE
持久化后台 job artifacts

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -13,6 +13,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/fileutil"
+	"reasonix/internal/jobs"
 )
 
 // sessions.go holds the desktop-only session-management state that the shared
@@ -160,6 +161,10 @@ func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove fu
 	if err := movePathIfExists(strings.TrimSuffix(sessionPath, ".jsonl")+".ckpt", filepath.Join(itemDir, ckptName)); err != nil {
 		return err
 	}
+	jobsName := strings.TrimSuffix(key, ".jsonl") + ".jobs"
+	if err := movePathIfExists(jobs.ArtifactDir(sessionPath), filepath.Join(itemDir, jobsName)); err != nil {
+		return err
+	}
 	if err := trashSubagentArtifacts(dir, sessionPath, itemDir); err != nil {
 		return err
 	}
@@ -241,6 +246,10 @@ func restoreTrashedSessionFile(dir, path string) error {
 	}
 	ckptName := strings.TrimSuffix(key, ".jsonl") + ".ckpt"
 	if err := movePathIfExists(filepath.Join(itemDir, ckptName), filepath.Join(dir, ckptName)); err != nil {
+		return err
+	}
+	jobsName := strings.TrimSuffix(key, ".jsonl") + ".jobs"
+	if err := movePathIfExists(filepath.Join(itemDir, jobsName), filepath.Join(dir, jobsName)); err != nil {
 		return err
 	}
 	if err := restoreSubagentArtifacts(dir, itemDir); err != nil {

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/jobs"
 )
 
 // --- loadSessionTitles ---
@@ -123,6 +124,13 @@ func TestDeleteSessionFile(t *testing.T) {
 		t.Fatalf("mkdir ckpt: %v", err)
 	}
 	os.WriteFile(filepath.Join(ckptDir, "1.json"), []byte("{}"), 0o644)
+	jobsDir := jobs.ArtifactDir(sessionPath)
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatalf("mkdir jobs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(jobsDir, "bash-1.log"), []byte("output"), 0o644); err != nil {
+		t.Fatalf("write job artifact: %v", err)
+	}
 
 	// Set a title first.
 	setSessionTitle(dir, sessionPath, "My Title")
@@ -136,6 +144,7 @@ func TestDeleteSessionFile(t *testing.T) {
 	trashPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl")
 	trashMetaPath := trashPath + ".meta"
 	trashCkptDir := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.ckpt")
+	trashJobsDir := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jobs")
 
 	// File should be moved out of the active session list.
 	if _, err := os.Stat(sessionPath); !os.IsNotExist(err) {
@@ -147,6 +156,9 @@ func TestDeleteSessionFile(t *testing.T) {
 	if _, err := os.Stat(ckptDir); !os.IsNotExist(err) {
 		t.Error("session checkpoints should be removed from active sessions")
 	}
+	if _, err := os.Stat(jobsDir); !os.IsNotExist(err) {
+		t.Error("session jobs should be removed from active sessions")
+	}
 	if _, err := os.Stat(trashPath); err != nil {
 		t.Fatalf("session file should be in trash: %v", err)
 	}
@@ -155,6 +167,9 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(trashCkptDir); err != nil {
 		t.Fatalf("session checkpoints should be in trash: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(trashJobsDir, "bash-1.log")); err != nil {
+		t.Fatalf("session jobs should be in trash: %v", err)
 	}
 	// Title/display should be retained until permanent deletion.
 	m := loadSessionTitles(dir)
@@ -232,6 +247,13 @@ func TestRestoreTrashedSessionFile(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(ckptDir, "1.json"), []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	jobsDir := jobs.ArtifactDir(sessionPath)
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobsDir, "bash-1.log"), []byte("output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := setSessionTitle(dir, sessionPath, "My Title"); err != nil {
 		t.Fatal(err)
 	}
@@ -252,6 +274,9 @@ func TestRestoreTrashedSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(ckptDir); err != nil {
 		t.Fatalf("session checkpoints should be restored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(jobsDir, "bash-1.log")); err != nil {
+		t.Fatalf("session jobs should be restored: %v", err)
 	}
 	if _, err := os.Stat(filepath.Dir(trashPath)); !os.IsNotExist(err) {
 		t.Fatalf("trash item should be removed after restore, stat err = %v", err)
@@ -320,6 +345,13 @@ func TestPurgeTrashedSessionFile(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")
 	os.WriteFile(sessionPath, []byte("data"), 0o644)
+	jobsDir := jobs.ArtifactDir(sessionPath)
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobsDir, "bash-1.log"), []byte("output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	if err := setSessionTitle(dir, sessionPath, "My Title"); err != nil {
 		t.Fatal(err)
 	}
@@ -335,6 +367,9 @@ func TestPurgeTrashedSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Dir(trashPath)); !os.IsNotExist(err) {
 		t.Fatalf("trash item should be removed after purge, stat err = %v", err)
+	}
+	if _, err := os.Stat(jobsDir); !os.IsNotExist(err) {
+		t.Fatalf("session jobs should be removed after purge, stat err = %v", err)
 	}
 	if _, ok := loadSessionTitles(dir)["session.jsonl"]; ok {
 		t.Fatal("title should be removed after purge")

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -17,6 +17,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
+	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
 )
 
@@ -856,6 +857,13 @@ func TestDeleteSessionFilesDeletesOwnedSubagents(t *testing.T) {
 	}
 	ref := "sa_20260102_030405_000000000_aabbccddeeff"
 	writeACPSubagentArtifact(t, dir, ref, agent.BranchID(sessionPath))
+	jobsDir := jobs.ArtifactDir(sessionPath)
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobsDir, "bash-1.log"), []byte("output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := deleteSessionFiles(sessionPath); err != nil {
 		t.Fatalf("deleteSessionFiles: %v", err)
@@ -865,6 +873,9 @@ func TestDeleteSessionFilesDeletesOwnedSubagents(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".meta.json")); !os.IsNotExist(err) {
 		t.Fatalf("subagent meta should be deleted, stat err = %v", err)
+	}
+	if _, err := os.Stat(jobsDir); !os.IsNotExist(err) {
+		t.Fatalf("jobs sidecar should be deleted, stat err = %v", err)
 	}
 }
 

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -17,6 +17,7 @@ import (
 	"reasonix/internal/control"
 	"reasonix/internal/event"
 	"reasonix/internal/fileutil"
+	"reasonix/internal/jobs"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
 )
@@ -1408,6 +1409,9 @@ func deleteSessionFiles(sessionPath string) error {
 		}
 	}
 	if err := agent.DeleteSubagentsByParent(filepath.Dir(sessionPath), agent.BranchID(sessionPath)); err != nil {
+		return err
+	}
+	if err := jobs.RemoveArtifacts(sessionPath); err != nil {
 		return err
 	}
 	return nil

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1575,6 +1575,9 @@ func removeSessionArtifacts(path string) error {
 	if path == "" {
 		return nil
 	}
+	if err := jobs.RemoveArtifacts(path); err != nil {
+		return err
+	}
 	for _, p := range []string{path, agent.BranchMetaPath(path)} {
 		if p == "" {
 			continue
@@ -2140,7 +2143,7 @@ func (c *Controller) IsDestroyingSession(sessionPath string) bool {
 
 func (c *Controller) setActiveJobSession(sessionPath string) {
 	if c.jobs != nil {
-		c.jobs.SetActiveSession(agent.BranchID(sessionPath))
+		c.jobs.SetActiveSessionPath(agent.BranchID(sessionPath), sessionPath)
 	}
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,6 +81,32 @@ func (fakeControlTool) Execute(context.Context, json.RawMessage) (string, error)
 }
 func (fakeControlTool) ReadOnly() bool { return true }
 
+type startBackgroundJobTool struct {
+	started chan string
+	release chan struct{}
+}
+
+func (t startBackgroundJobTool) Name() string        { return "start_background_job" }
+func (t startBackgroundJobTool) Description() string { return "start background job" }
+func (t startBackgroundJobTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object"}`)
+}
+func (t startBackgroundJobTool) ReadOnly() bool { return false }
+func (t startBackgroundJobTool) Execute(ctx context.Context, _ json.RawMessage) (string, error) {
+	jm, ok := jobs.FromContext(ctx)
+	if !ok {
+		return "", nil
+	}
+	j := jm.StartForSession(jobs.SessionFromContext(ctx), "bash", "controller", func(_ context.Context, out io.Writer) (string, error) {
+		_, _ = io.WriteString(out, "before\n")
+		<-t.release
+		_, _ = io.WriteString(out, "after\n")
+		return "", nil
+	})
+	t.started <- j.ID
+	return "started " + j.ID, nil
+}
+
 func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
 	var sink *typedNilControllerSink
 	c := New(Options{Sink: sink})
@@ -131,6 +158,39 @@ func TestRunInjectsParentSessionForJobs(t *testing.T) {
 	}
 	if runner.jobSession != want {
 		t.Fatalf("jobs session = %q, want %q", runner.jobSession, want)
+	}
+}
+
+func TestSetSessionPathAdoptsTemporaryBackgroundJobs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	started := make(chan string, 1)
+	release := make(chan struct{})
+	jm := jobs.NewManager(event.Discard)
+	reg := tool.NewRegistry()
+	reg.Add(startBackgroundJobTool{started: started, release: release})
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		toolCallTurn("call-1", "start_background_job", `{}`),
+		textTurn("done"),
+	}}
+	ag := agent.New(prov, reg, agent.NewSession("sys"), agent.Options{Jobs: jm}, event.Discard)
+	c := New(Options{Runner: ag, Executor: ag, SessionDir: dir, Label: "test", Jobs: jm})
+	defer c.Close()
+
+	if err := c.Run(context.Background(), "start background job"); err != nil {
+		t.Fatal(err)
+	}
+	jobID := <-started
+	c.SetSessionPath(path)
+	close(release)
+
+	parentSession := agent.BranchID(path)
+	res := c.jobs.WaitForSession(context.Background(), parentSession, []string{jobID}, 1)
+	if len(res) != 1 || !strings.Contains(res[0].Output, "before\n") || !strings.Contains(res[0].Output, "after\n") {
+		t.Fatalf("adopted controller job = %+v, want before/after output", res)
+	}
+	if _, err := os.Stat(filepath.Join(jobs.ArtifactDir(path), jobID+".log")); err != nil {
+		t.Fatalf("controller job artifact should be under persistent sidecar: %v", err)
 	}
 }
 

--- a/internal/jobs/artifacts.go
+++ b/internal/jobs/artifacts.go
@@ -1,0 +1,122 @@
+package jobs
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	jobLogExt        = ".log"
+	jobMetaExt       = ".json"
+	defaultTailBytes = 64 * 1024
+)
+
+// ArtifactDir returns the sidecar directory for a persistent session transcript.
+func ArtifactDir(sessionPath string) string {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return ""
+	}
+	return strings.TrimSuffix(sessionPath, ".jsonl") + ".jobs"
+}
+
+// RemoveArtifacts removes the job sidecar for a session transcript.
+func RemoveArtifacts(sessionPath string) error {
+	dir := ArtifactDir(sessionPath)
+	if dir == "" {
+		return nil
+	}
+	return os.RemoveAll(dir)
+}
+
+type artifactMeta struct {
+	ID               string `json:"id"`
+	Kind             string `json:"kind"`
+	Label            string `json:"label,omitempty"`
+	SessionID        string `json:"sessionId,omitempty"`
+	Status           Status `json:"status"`
+	StartedAt        int64  `json:"startedAt"`
+	FinishedAt       int64  `json:"finishedAt,omitempty"`
+	ArtifactComplete bool   `json:"artifactComplete"`
+	ArtifactError    string `json:"artifactError,omitempty"`
+	LogPath          string `json:"logPath,omitempty"`
+}
+
+func writeMeta(path string, meta artifactMeta) error {
+	if path == "" {
+		return fmt.Errorf("empty metadata path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".job-meta-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func readMeta(path string) (artifactMeta, error) {
+	var meta artifactMeta
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return meta, err
+	}
+	if err := json.Unmarshal(b, &meta); err != nil {
+		return meta, err
+	}
+	return meta, nil
+}
+
+func maxJobSeq(id string) int {
+	_, tail, ok := strings.Cut(id, "-")
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(tail)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func appendTail(buf []byte, p []byte, limit int) []byte {
+	if limit <= 0 {
+		return nil
+	}
+	if len(p) >= limit {
+		out := make([]byte, limit)
+		copy(out, p[len(p)-limit:])
+		return out
+	}
+	total := len(buf) + len(p)
+	if total <= limit {
+		out := make([]byte, total)
+		copy(out, buf)
+		copy(out[len(buf):], p)
+		return out
+	}
+	keep := limit - len(p)
+	out := make([]byte, limit)
+	copy(out, buf[len(buf)-keep:])
+	copy(out[keep:], p)
+	return out
+}

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -115,20 +115,53 @@ func TestSetActiveSessionPathMigratesRunningJobArtifacts(t *testing.T) {
 		return "", nil
 	})
 	<-wroteBefore
+	j.mu.Lock()
+	oldPath := j.artifactPath
+	j.mu.Unlock()
 
 	m.SetActiveSessionPath("session", sessionPath)
 	j.mu.Lock()
 	gotPath := j.artifactPath
 	j.mu.Unlock()
-	if !strings.HasPrefix(gotPath, ArtifactDir(sessionPath)+string(filepath.Separator)) {
-		t.Fatalf("artifact path = %q, want under %q", gotPath, ArtifactDir(sessionPath))
+	if gotPath != oldPath {
+		t.Fatalf("running artifact path = %q, want unchanged %q before completion", gotPath, oldPath)
 	}
 
 	releaseOnce.Do(func() { close(release) })
 	<-j.done
+	j.mu.Lock()
+	donePath := j.artifactPath
+	j.mu.Unlock()
+	if !strings.HasPrefix(donePath, ArtifactDir(sessionPath)+string(filepath.Separator)) {
+		t.Fatalf("completed artifact path = %q, want under %q", donePath, ArtifactDir(sessionPath))
+	}
 	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
 	if len(res) != 1 || !strings.Contains(res[0].Output, "before\n") || !strings.Contains(res[0].Output, "after\n") {
 		t.Fatalf("wait after migration = %+v, want before and after output", res)
+	}
+}
+
+func TestArtifactFailureDoesNotFailSuccessfulJob(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(ArtifactDir(sessionPath), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session", sessionPath)
+
+	j := m.StartForSession("session", "task", "artifact fail", func(context.Context, io.Writer) (string, error) {
+		return "successful result", nil
+	})
+	<-j.done
+
+	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 || res[0].Status != Done {
+		t.Fatalf("wait = %+v, want one done result", res)
+	}
+	if !strings.Contains(res[0].Output, "successful result") || !strings.Contains(res[0].Output, "job artifact incomplete:") {
+		t.Fatalf("output = %q, want result and artifact warning", res[0].Output)
 	}
 }
 
@@ -204,8 +237,8 @@ func TestSetActiveSessionPathAdoptsUnscopedJobsOnMigrationFailure(t *testing.T) 
 	m.SetActiveSessionPath("session", sessionPath)
 
 	out, status, ok := m.OutputForSession("session", j.ID)
-	if !ok || status != Failed {
-		t.Fatalf("scoped output ok/status = %v/%s, want true/failed", ok, status)
+	if !ok || status != Done {
+		t.Fatalf("scoped output ok/status = %v/%s, want true/done", ok, status)
 	}
 	if !strings.Contains(out, "temporary answer") || !strings.Contains(out, "job artifact incomplete: migration:") {
 		t.Fatalf("scoped output = %q, want answer and migration error", out)

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -128,6 +129,38 @@ func TestSetActiveSessionPathMigratesRunningJobArtifacts(t *testing.T) {
 	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
 	if len(res) != 1 || !strings.Contains(res[0].Output, "before\n") || !strings.Contains(res[0].Output, "after\n") {
 		t.Fatalf("wait after migration = %+v, want before and after output", res)
+	}
+}
+
+func TestMigrateArtifactDirFallsBackToCopyWhenRenameFails(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	dst := filepath.Join(root, "dst")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "bash-1.log"), []byte("persisted output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldRename := renamePath
+	renamePath = func(_, _ string) error {
+		return errors.New("forced rename failure")
+	}
+	t.Cleanup(func() { renamePath = oldRename })
+
+	if err := migrateArtifactDir(src, dst); err != nil {
+		t.Fatalf("migrateArtifactDir: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dst, "bash-1.log"))
+	if err != nil {
+		t.Fatalf("read migrated artifact: %v", err)
+	}
+	if string(got) != "persisted output" {
+		t.Fatalf("migrated artifact = %q, want persisted output", got)
+	}
+	if _, err := os.Stat(filepath.Join(src, "bash-1.log")); !os.IsNotExist(err) {
+		t.Fatalf("source artifact should be removed after copy fallback, stat err = %v", err)
 	}
 }
 

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -3,6 +3,7 @@ package jobs
 import (
 	"context"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -92,5 +93,73 @@ func TestFinishDestroySessionPurgesOwnedJobs(t *testing.T) {
 
 	if _, _, ok := m.OutputForSession("session", j.ID); ok {
 		t.Fatalf("destroyed session job %s should be purged", j.ID)
+	}
+}
+
+func TestSetActiveSessionPathMigratesRunningJobArtifacts(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	wroteBefore := make(chan struct{})
+	release := make(chan struct{})
+	j := m.StartForSession("session", "bash", "migrate", func(_ context.Context, out io.Writer) (string, error) {
+		_, _ = io.WriteString(out, "before\n")
+		close(wroteBefore)
+		<-release
+		_, _ = io.WriteString(out, "after\n")
+		return "", nil
+	})
+	<-wroteBefore
+
+	m.SetActiveSessionPath("session", sessionPath)
+	j.mu.Lock()
+	gotPath := j.artifactPath
+	j.mu.Unlock()
+	if !strings.HasPrefix(gotPath, ArtifactDir(sessionPath)+string(filepath.Separator)) {
+		t.Fatalf("artifact path = %q, want under %q", gotPath, ArtifactDir(sessionPath))
+	}
+
+	close(release)
+	<-j.done
+	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 || !strings.Contains(res[0].Output, "before\n") || !strings.Contains(res[0].Output, "after\n") {
+		t.Fatalf("wait after migration = %+v, want before and after output", res)
+	}
+}
+
+func TestSetActiveSessionPathReportsMigrationFailure(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(ArtifactDir(sessionPath), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var notices []string
+	m := NewManager(event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	}))
+	defer m.Close()
+
+	j := m.StartForSession("session", "task", "migrate fail", func(context.Context, io.Writer) (string, error) {
+		return "answer", nil
+	})
+	m.SetActiveSessionPath("session", sessionPath)
+	<-j.done
+
+	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 || !strings.Contains(res[0].Output, "job artifact incomplete: migration:") {
+		t.Fatalf("wait after migration failure = %+v, want artifact error", res)
+	}
+	found := false
+	for _, notice := range notices {
+		if strings.Contains(notice, "job artifact migration failed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("migration failure notice not emitted, got %q", notices)
 	}
 }

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -151,6 +151,38 @@ func TestSetActiveSessionPathAdoptsUnscopedTemporaryJobs(t *testing.T) {
 	}
 }
 
+func TestSetActiveSessionPathAdoptsUnscopedJobsOnMigrationFailure(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(ArtifactDir(sessionPath), []byte("not a dir"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	j := m.StartForSession("", "task", "temporary", func(context.Context, io.Writer) (string, error) {
+		return "temporary answer", nil
+	})
+	<-j.done
+
+	m.SetActiveSessionPath("session", sessionPath)
+
+	out, status, ok := m.OutputForSession("session", j.ID)
+	if !ok || status != Failed {
+		t.Fatalf("scoped output ok/status = %v/%s, want true/failed", ok, status)
+	}
+	if !strings.Contains(out, "temporary answer") || !strings.Contains(out, "job artifact incomplete: migration:") {
+		t.Fatalf("scoped output = %q, want answer and migration error", out)
+	}
+	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 || !strings.Contains(res[0].Output, "job artifact incomplete: migration:") {
+		t.Fatalf("scoped wait = %+v, want migration error", res)
+	}
+	if note := m.DrainCompletedNoteForSession("session"); !strings.Contains(note, j.ID) {
+		t.Fatalf("adopted completion note = %q, want job id %s", note, j.ID)
+	}
+}
+
 func TestSetActiveSessionPathReportsMigrationFailure(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -163,3 +163,38 @@ func TestSetActiveSessionPathReportsMigrationFailure(t *testing.T) {
 		t.Fatalf("migration failure notice not emitted, got %q", notices)
 	}
 }
+
+func TestOutputReadsArtifactFromOffset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bash-1.log")
+	prefix := strings.Repeat("x", 2*defaultTailBytes)
+	suffix := "new output\n"
+	if err := os.WriteFile(path, []byte(prefix+suffix), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := NewManager(event.Discard)
+	defer m.Close()
+	j := &Job{
+		ID:           "bash-1",
+		Kind:         "bash",
+		SessionID:    "session",
+		status:       Running,
+		readOffset:   int64(len(prefix)),
+		artifactPath: path,
+		done:         make(chan struct{}),
+	}
+	m.jobs[j.ID] = j
+	m.order = append(m.order, j.ID)
+
+	text, status, ok := m.OutputForSession("session", j.ID)
+	if !ok || status != Running {
+		t.Fatalf("OutputForSession ok/status = %v/%s, want true/running", ok, status)
+	}
+	if text != suffix {
+		t.Fatalf("OutputForSession text = %q, want %q", text, suffix)
+	}
+	if j.readOffset != int64(len(prefix)+len(suffix)) {
+		t.Fatalf("readOffset = %d, want %d", j.readOffset, len(prefix)+len(suffix))
+	}
+}

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"reasonix/internal/event"
@@ -103,6 +104,8 @@ func TestSetActiveSessionPathMigratesRunningJobArtifacts(t *testing.T) {
 
 	wroteBefore := make(chan struct{})
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
 	j := m.StartForSession("session", "bash", "migrate", func(_ context.Context, out io.Writer) (string, error) {
 		_, _ = io.WriteString(out, "before\n")
 		close(wroteBefore)
@@ -120,7 +123,7 @@ func TestSetActiveSessionPathMigratesRunningJobArtifacts(t *testing.T) {
 		t.Fatalf("artifact path = %q, want under %q", gotPath, ArtifactDir(sessionPath))
 	}
 
-	close(release)
+	releaseOnce.Do(func() { close(release) })
 	<-j.done
 	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
 	if len(res) != 1 || !strings.Contains(res[0].Output, "before\n") || !strings.Contains(res[0].Output, "after\n") {

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -1,0 +1,76 @@
+package jobs
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"reasonix/internal/event"
+)
+
+func TestCompletedJobPersistsOutputAndReleasesMemory(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session", sessionPath)
+
+	j := m.StartForSession("session", "bash", "persist", func(_ context.Context, out io.Writer) (string, error) {
+		_, _ = io.WriteString(out, strings.Repeat("x", defaultTailBytes+1024))
+		return "", nil
+	})
+	<-j.done
+
+	j.mu.Lock()
+	tailLen := len(j.tail)
+	result := j.result
+	artifactPath := j.artifactPath
+	j.mu.Unlock()
+
+	if tailLen != 0 {
+		t.Fatalf("completed artifact-backed job kept %d tail bytes, want 0", tailLen)
+	}
+	if result != "" {
+		t.Fatalf("completed artifact-backed job kept result %q, want empty", result)
+	}
+	if artifactPath == "" {
+		t.Fatal("artifact path should be set")
+	}
+
+	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 || len(res[0].Output) != defaultTailBytes+1024 {
+		t.Fatalf("wait output len = %d, want %d", len(res[0].Output), defaultTailBytes+1024)
+	}
+}
+
+func TestRestoreSessionArtifactsAndAdvanceSequence(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	first := NewManager(event.Discard)
+	first.SetActiveSessionPath("session", sessionPath)
+	j := first.StartForSession("session", "task", "answer", func(context.Context, io.Writer) (string, error) {
+		return "persisted answer", nil
+	})
+	<-j.done
+	first.Close()
+
+	second := NewManager(event.Discard)
+	defer second.Close()
+	second.SetActiveSessionPath("session", sessionPath)
+
+	res := second.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 || !strings.Contains(res[0].Output, "persisted answer") {
+		t.Fatalf("restored wait = %+v, want persisted answer", res)
+	}
+	if got := second.WaitForSession(context.Background(), "session", nil, 1); len(got) != 0 {
+		t.Fatalf("wait without ids should ignore restored completed artifacts, got %+v", got)
+	}
+
+	next := second.StartForSession("session", "bash", "next", func(context.Context, io.Writer) (string, error) {
+		return "", nil
+	})
+	<-next.done
+	if next.ID == j.ID {
+		t.Fatalf("new job reused restored id %q", next.ID)
+	}
+}

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -128,6 +128,29 @@ func TestSetActiveSessionPathMigratesRunningJobArtifacts(t *testing.T) {
 	}
 }
 
+func TestSetActiveSessionPathAdoptsUnscopedTemporaryJobs(t *testing.T) {
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	j := m.StartForSession("", "task", "temporary", func(context.Context, io.Writer) (string, error) {
+		return "temporary answer", nil
+	})
+	<-j.done
+
+	m.SetActiveSessionPath("session", sessionPath)
+	res := m.WaitForSession(context.Background(), "session", []string{j.ID}, 1)
+	if len(res) != 1 || !strings.Contains(res[0].Output, "temporary answer") {
+		t.Fatalf("adopted wait = %+v, want temporary answer", res)
+	}
+	if _, _, ok := m.OutputForSession("", j.ID); !ok {
+		t.Fatalf("legacy unscoped lookup should still find adopted job %s", j.ID)
+	}
+	if _, err := os.Stat(filepath.Join(ArtifactDir(sessionPath), j.ID+jobLogExt)); err != nil {
+		t.Fatalf("adopted artifact should be under persistent sidecar: %v", err)
+	}
+}
+
 func TestSetActiveSessionPathReportsMigrationFailure(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -74,3 +74,23 @@ func TestRestoreSessionArtifactsAndAdvanceSequence(t *testing.T) {
 		t.Fatalf("new job reused restored id %q", next.ID)
 	}
 }
+
+func TestFinishDestroySessionPurgesOwnedJobs(t *testing.T) {
+	m := NewManager(event.Discard)
+	defer m.Close()
+
+	j := m.StartForSession("session", "task", "done", func(context.Context, io.Writer) (string, error) {
+		return "answer", nil
+	})
+	<-j.done
+
+	done := m.DestroySession("session")
+	if len(done) != 0 {
+		t.Fatalf("finished job should not need destroy wait, got %d handles", len(done))
+	}
+	m.FinishDestroySession("session")
+
+	if _, _, ok := m.OutputForSession("session", j.ID); ok {
+		t.Fatalf("destroyed session job %s should be purged", j.ID)
+	}
+}

--- a/internal/jobs/artifacts_test.go
+++ b/internal/jobs/artifacts_test.go
@@ -184,8 +184,8 @@ func TestOutputReadsArtifactFromOffset(t *testing.T) {
 		artifactPath: path,
 		done:         make(chan struct{}),
 	}
-	m.jobs[j.ID] = j
-	m.order = append(m.order, j.ID)
+	m.jobs[jobKey("session", j.ID)] = j
+	m.order = append(m.order, jobKey("session", j.ID))
 
 	text, status, ok := m.OutputForSession("session", j.ID)
 	if !ok || status != Running {
@@ -196,5 +196,55 @@ func TestOutputReadsArtifactFromOffset(t *testing.T) {
 	}
 	if j.readOffset != int64(len(prefix)+len(suffix)) {
 		t.Fatalf("readOffset = %d, want %d", j.readOffset, len(prefix)+len(suffix))
+	}
+}
+
+func TestRestoredArtifactsAreScopedBySession(t *testing.T) {
+	root := t.TempDir()
+	pathA := filepath.Join(root, "a.jsonl")
+	pathB := filepath.Join(root, "b.jsonl")
+
+	first := NewManager(event.Discard)
+	first.SetActiveSessionPath("session-a", pathA)
+	jobA := first.StartForSession("session-a", "bash", "a", func(_ context.Context, out io.Writer) (string, error) {
+		_, _ = io.WriteString(out, "from-a")
+		return "", nil
+	})
+	<-jobA.done
+	first.Close()
+
+	second := NewManager(event.Discard)
+	second.SetActiveSessionPath("session-b", pathB)
+	jobB := second.StartForSession("session-b", "bash", "b", func(_ context.Context, out io.Writer) (string, error) {
+		_, _ = io.WriteString(out, "from-b")
+		return "", nil
+	})
+	<-jobB.done
+	second.Close()
+
+	if jobA.ID != "bash-1" || jobB.ID != "bash-1" {
+		t.Fatalf("test setup expected duplicate ids, got %s and %s", jobA.ID, jobB.ID)
+	}
+
+	m := NewManager(event.Discard)
+	defer m.Close()
+	m.SetActiveSessionPath("session-a", pathA)
+	m.SetActiveSessionPath("session-b", pathB)
+
+	resA := m.WaitForSession(context.Background(), "session-a", []string{"bash-1"}, 1)
+	if len(resA) != 1 || resA[0].Output != "from-a" {
+		t.Fatalf("session-a wait = %+v, want from-a", resA)
+	}
+	resB := m.WaitForSession(context.Background(), "session-b", []string{"bash-1"}, 1)
+	if len(resB) != 1 || resB[0].Output != "from-b" {
+		t.Fatalf("session-b wait = %+v, want from-b", resB)
+	}
+
+	next := m.StartForSession("session-b", "bash", "next", func(context.Context, io.Writer) (string, error) {
+		return "", nil
+	})
+	<-next.done
+	if next.ID == "bash-1" {
+		t.Fatal("new job should not reuse restored bash-1")
 	}
 }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -27,6 +27,8 @@ import (
 	"reasonix/internal/nilutil"
 )
 
+var renamePath = os.Rename
+
 // Status is a job's lifecycle state.
 type Status string
 
@@ -1007,11 +1009,48 @@ func migrateArtifactDir(src, dst string) error {
 		if entry.IsDir() {
 			continue
 		}
-		if err := os.Rename(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
+		if err := moveArtifactFile(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
 			return err
 		}
 	}
 	_ = os.Remove(src)
+	return nil
+}
+
+func moveArtifactFile(src, dst string) error {
+	if err := renamePath(src, dst); err == nil {
+		return nil
+	}
+	if err := copyArtifactFile(src, dst); err != nil {
+		return err
+	}
+	return os.Remove(src)
+}
+
+func copyArtifactFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	info, err := in.Stat()
+	if err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, in)
+	closeErr := out.Close()
+	if copyErr != nil {
+		_ = os.Remove(dst)
+		return copyErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(dst)
+		return closeErr
+	}
 	return nil
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -492,6 +492,9 @@ func (m *Manager) OutputForSession(parentSession, id string) (text string, statu
 		text = j.result
 		j.resultRead = true
 	}
+	if text == "" && j.artifactErr != "" {
+		text = "job artifact incomplete: " + j.artifactErr
+	}
 	return text, j.status, true
 }
 
@@ -731,10 +734,53 @@ func (m *Manager) SetActiveSessionPath(parentSession, sessionPath string) {
 	m.mu.Unlock()
 
 	if oldDir != "" && newDir != "" && oldDir != newDir {
-		_ = migrateArtifactDir(oldDir, newDir)
+		if err := migrateArtifactDir(oldDir, newDir); err != nil {
+			m.recordArtifactMigrationError(parentSession, err)
+		} else {
+			m.mu.Lock()
+			m.rebaseSessionArtifactsLocked(parentSession, newDir)
+			m.mu.Unlock()
+		}
 	}
 	if !loaded {
 		m.loadSessionArtifacts(parentSession, newDir)
+	}
+}
+
+func (m *Manager) rebaseSessionArtifactsLocked(parentSession, dir string) {
+	for _, j := range m.jobs {
+		if j == nil || !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
+		j.mu.Lock()
+		if j.artifactPath != "" {
+			j.artifactPath = filepath.Join(dir, filepath.Base(j.artifactPath))
+		}
+		if j.artifactMetaPath != "" {
+			j.artifactMetaPath = filepath.Join(dir, filepath.Base(j.artifactMetaPath))
+		}
+		j.mu.Unlock()
+	}
+}
+
+func (m *Manager) recordArtifactMigrationError(parentSession string, err error) {
+	text := "job artifact migration failed: " + err.Error()
+	m.mu.Lock()
+	for _, j := range m.jobs {
+		if j == nil || !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
+		j.mu.Lock()
+		if j.artifactErr == "" {
+			j.artifactErr = "migration: " + err.Error()
+			j.artifactComplete = false
+		}
+		j.mu.Unlock()
+	}
+	active := m.active
+	m.mu.Unlock()
+	if active == "" || active == parentSession {
+		m.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
 	}
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -250,6 +250,7 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 			j.tail = appendTail(j.tail, []byte(result), defaultTailBytes)
 			j.mu.Unlock()
 		}
+		targetDir := m.artifactTargetDirForJob(j)
 		j.mu.Lock()
 		if j.artifactFile != nil {
 			if closeErr := j.artifactFile.Close(); closeErr != nil && j.artifactErr == "" {
@@ -259,22 +260,16 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		}
 		if j.artifactErr != "" {
 			j.artifactComplete = false
-			if st == Done {
-				st = Failed
-			}
-			err = joinJobError(err, fmt.Errorf("job artifact incomplete: %s", j.artifactErr))
 		}
 		j.finishedAt = finishedAt
+		if targetDir != "" {
+			if moveErr := j.moveArtifactToDirLocked(targetDir); moveErr != nil {
+				j.noteArtifactErr("migration: " + moveErr.Error())
+			}
+		}
 		metaErr := m.writeJobMetaLocked(j, st)
 		if metaErr != nil {
-			if j.artifactErr == "" {
-				j.artifactErr = "metadata: " + metaErr.Error()
-			}
-			j.artifactComplete = false
-			if st == Done {
-				st = Failed
-			}
-			err = joinJobError(err, fmt.Errorf("job artifact metadata incomplete: %w", metaErr))
+			j.noteArtifactErr("metadata: " + metaErr.Error())
 		}
 		j.mu.Unlock()
 		// Queue the drain note (and emit the closing Notice) BEFORE publishing the
@@ -306,16 +301,6 @@ func runRecovered(ctx context.Context, out io.Writer, run func(context.Context, 
 		}
 	}()
 	return run(ctx, out)
-}
-
-func joinJobError(a, b error) error {
-	if a == nil {
-		return b
-	}
-	if b == nil {
-		return a
-	}
-	return fmt.Errorf("%v; %w", a, b)
 }
 
 func (m *Manager) openArtifactLocked(parentSession, id string) (logPath, metaPath string, file *os.File, artifactErr string) {
@@ -367,6 +352,54 @@ func (m *Manager) writeJobMetaLocked(j *Job, st Status) error {
 		ArtifactError:    j.artifactErr,
 		LogPath:          filepath.Base(j.artifactPath),
 	})
+}
+
+func (m *Manager) artifactTargetDirForJob(j *Job) string {
+	if j == nil {
+		return ""
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	session := strings.TrimSpace(j.SessionID)
+	if session == "" {
+		return ""
+	}
+	return strings.TrimSpace(m.artifactDirs[session])
+}
+
+func (j *Job) noteArtifactErr(msg string) {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return
+	}
+	if j.artifactErr == "" {
+		j.artifactErr = msg
+	} else {
+		j.artifactErr += "; " + msg
+	}
+	j.artifactComplete = false
+}
+
+func (j *Job) moveArtifactToDirLocked(dir string) error {
+	dir = strings.TrimSpace(dir)
+	if dir == "" || j.artifactPath == "" {
+		return nil
+	}
+	if filepath.Clean(filepath.Dir(j.artifactPath)) == filepath.Clean(dir) {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	newLogPath := filepath.Join(dir, filepath.Base(j.artifactPath))
+	if err := moveArtifactFile(j.artifactPath, newLogPath); err != nil {
+		return err
+	}
+	j.artifactPath = newLogPath
+	if j.artifactMetaPath != "" {
+		j.artifactMetaPath = filepath.Join(dir, filepath.Base(j.artifactMetaPath))
+	}
+	return nil
 }
 
 func (m *Manager) monitorStalled(parentSession string, j *Job) {
@@ -861,9 +894,6 @@ func (m *Manager) recordArtifactMigrationError(parentSession string, err error) 
 			j.artifactErr = "migration: " + err.Error()
 			j.artifactComplete = false
 		}
-		if j.status == Done {
-			j.status = Failed
-		}
 		j.mu.Unlock()
 	}
 	active := m.active
@@ -881,17 +911,12 @@ type artifactMigrationJob struct {
 func (m *Manager) migrateArtifactDirForSession(parentSession, oldDir, newDir string) error {
 	locked := m.lockArtifactJobsForMigration(parentSession, oldDir)
 	defer unlockArtifactMigrationJobs(locked)
-	closeErr := closeArtifactMigrationFiles(locked)
-	migrateErr := migrateArtifactDir(oldDir, newDir)
-	reopenDir := oldDir
+	skip := openArtifactMigrationFiles(locked)
+	migrateErr := migrateArtifactDirSkipping(oldDir, newDir, skip)
 	if migrateErr == nil {
 		rebaseArtifactMigrationJobs(locked, newDir)
-		reopenDir = newDir
 	}
-	if reopenErr := reopenArtifactMigrationFiles(locked, reopenDir); reopenErr != nil {
-		return joinJobError(closeErr, joinJobError(migrateErr, reopenErr))
-	}
-	return joinJobError(closeErr, migrateErr)
+	return migrateErr
 }
 
 func (m *Manager) lockArtifactJobsForMigration(parentSession, dir string) []artifactMigrationJob {
@@ -930,27 +955,27 @@ func artifactPathInDir(path, dir string) bool {
 	return filepath.Dir(path) == dir
 }
 
-func closeArtifactMigrationFiles(jobs []artifactMigrationJob) error {
-	var err error
+func openArtifactMigrationFiles(jobs []artifactMigrationJob) map[string]bool {
+	skip := map[string]bool{}
 	for _, item := range jobs {
 		j := item.job
 		if j == nil || j.artifactFile == nil {
 			continue
 		}
-		if closeErr := j.artifactFile.Close(); closeErr != nil {
-			j.artifactErr = closeErr.Error()
-			j.artifactComplete = false
-			err = joinJobError(err, fmt.Errorf("close %s: %w", j.ID, closeErr))
+		if j.artifactPath != "" {
+			skip[filepath.Base(j.artifactPath)] = true
 		}
-		j.artifactFile = nil
+		if j.artifactMetaPath != "" {
+			skip[filepath.Base(j.artifactMetaPath)] = true
+		}
 	}
-	return err
+	return skip
 }
 
 func rebaseArtifactMigrationJobs(jobs []artifactMigrationJob, dir string) {
 	for _, item := range jobs {
 		j := item.job
-		if j == nil {
+		if j == nil || item.wasOpen {
 			continue
 		}
 		if j.artifactPath != "" {
@@ -962,30 +987,6 @@ func rebaseArtifactMigrationJobs(jobs []artifactMigrationJob, dir string) {
 	}
 }
 
-func reopenArtifactMigrationFiles(jobs []artifactMigrationJob, dir string) error {
-	var err error
-	for _, item := range jobs {
-		j := item.job
-		if j == nil || !item.wasOpen {
-			continue
-		}
-		path := j.artifactPath
-		if path == "" {
-			path = filepath.Join(dir, j.ID+jobLogExt)
-			j.artifactPath = path
-		}
-		f, openErr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
-		if openErr != nil {
-			j.artifactErr = openErr.Error()
-			j.artifactComplete = false
-			err = joinJobError(err, fmt.Errorf("reopen %s: %w", j.ID, openErr))
-			continue
-		}
-		j.artifactFile = f
-	}
-	return err
-}
-
 func unlockArtifactMigrationJobs(jobs []artifactMigrationJob) {
 	for i := len(jobs) - 1; i >= 0; i-- {
 		if jobs[i].job != nil {
@@ -995,6 +996,10 @@ func unlockArtifactMigrationJobs(jobs []artifactMigrationJob) {
 }
 
 func migrateArtifactDir(src, dst string) error {
+	return migrateArtifactDirSkipping(src, dst, nil)
+}
+
+func migrateArtifactDirSkipping(src, dst string, skip map[string]bool) error {
 	entries, err := os.ReadDir(src)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -1007,6 +1012,9 @@ func migrateArtifactDir(src, dst string) error {
 	}
 	for _, entry := range entries {
 		if entry.IsDir() {
+			continue
+		}
+		if skip[entry.Name()] {
 			continue
 		}
 		if err := moveArtifactFile(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -766,6 +766,11 @@ func (m *Manager) SetActiveSessionPath(parentSession, sessionPath string) {
 		return
 	}
 	oldDir := m.artifactDirLocked(parentSession)
+	adoptDefault := false
+	if _, hasDir := m.artifactDirs[parentSession]; !hasDir && m.hasUnscopedJobsLocked() {
+		oldDir = m.artifactDirLocked("")
+		adoptDefault = true
+	}
 	newDir := ArtifactDir(sessionPath)
 	m.artifactDirs[parentSession] = newDir
 	loaded := m.loaded[parentSession]
@@ -776,12 +781,52 @@ func (m *Manager) SetActiveSessionPath(parentSession, sessionPath string) {
 			m.recordArtifactMigrationError(parentSession, err)
 		} else {
 			m.mu.Lock()
+			if adoptDefault {
+				m.adoptUnscopedJobsLocked(parentSession)
+			}
 			m.rebaseSessionArtifactsLocked(parentSession, newDir)
 			m.mu.Unlock()
 		}
 	}
 	if !loaded {
 		m.loadSessionArtifacts(parentSession, newDir)
+	}
+}
+
+func (m *Manager) hasUnscopedJobsLocked() bool {
+	for _, j := range m.jobs {
+		if j != nil && strings.TrimSpace(j.SessionID) == "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) adoptUnscopedJobsLocked(parentSession string) {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession == "" {
+		return
+	}
+	for oldKey, j := range m.jobs {
+		if j == nil || strings.TrimSpace(j.SessionID) != "" {
+			continue
+		}
+		newKey := jobKey(parentSession, j.ID)
+		if existing := m.jobs[newKey]; existing != nil && existing != j {
+			j.mu.Lock()
+			j.artifactErr = "migration: job id collision while adopting temporary session"
+			j.artifactComplete = false
+			j.mu.Unlock()
+			continue
+		}
+		delete(m.jobs, oldKey)
+		j.SessionID = parentSession
+		m.jobs[newKey] = j
+		for i, key := range m.order {
+			if key == oldKey {
+				m.order[i] = newKey
+			}
+		}
 	}
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -12,10 +12,11 @@
 package jobs
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"sync"
@@ -63,17 +64,25 @@ type Job struct {
 	SessionID string
 
 	mu          sync.Mutex
-	buf         bytes.Buffer
-	readOffset  int
+	tail        []byte
+	readOffset  int64
 	status      Status
 	result      string
 	resultRead  bool // result already surfaced by Output (task jobs stream nothing to buf)
 	startedAt   int64
+	finishedAt  int64
 	activityAt  int64
 	runReturned bool
 	cancel      context.CancelFunc
 	done        chan struct{}
 	stalled     bool
+
+	artifactPath     string
+	artifactMetaPath string
+	artifactFile     *os.File
+	artifactComplete bool
+	artifactErr      string
+	tombstone        bool
 }
 
 // Manager is the session's background-job table. It is safe for concurrent use.
@@ -83,13 +92,16 @@ type Manager struct {
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
 
-	mu         sync.Mutex
-	seq        int
-	jobs       map[string]*Job
-	order      []string
-	completed  []completion // finished-job summaries awaiting drain into the next turn
-	active     string
-	destroying map[string]bool
+	mu           sync.Mutex
+	seq          int
+	jobs         map[string]*Job
+	order        []string
+	completed    []completion // finished-job summaries awaiting drain into the next turn
+	active       string
+	destroying   map[string]bool
+	artifactDirs map[string]string
+	loaded       map[string]bool
+	tempRoot     string
 
 	stalledWarning time.Duration
 }
@@ -120,7 +132,17 @@ func NewManager(sink event.Sink, opts ...Option) *Manager {
 		sink = event.Discard
 	}
 	root, cancel := context.WithCancel(context.Background())
-	m := &Manager{sink: sink, root: root, cancel: cancel, jobs: map[string]*Job{}, destroying: map[string]bool{}}
+	tempRoot, _ := os.MkdirTemp("", "reasonix-jobs-*")
+	m := &Manager{
+		sink:         sink,
+		root:         root,
+		cancel:       cancel,
+		jobs:         map[string]*Job{},
+		destroying:   map[string]bool{},
+		artifactDirs: map[string]string{},
+		loaded:       map[string]bool{},
+		tempRoot:     tempRoot,
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(m)
@@ -137,7 +159,13 @@ func (w jobWriter) Write(p []byte) (int, error) {
 	w.j.mu.Lock()
 	defer w.j.mu.Unlock()
 	w.j.activityAt = nowMs()
-	return w.j.buf.Write(p)
+	w.j.tail = appendTail(w.j.tail, p, defaultTailBytes)
+	if w.j.artifactFile != nil {
+		if _, err := w.j.artifactFile.Write(p); err != nil {
+			w.j.artifactErr = err.Error()
+		}
+	}
+	return len(p), nil
 }
 
 // Start launches run on a goroutine under the manager's session context and
@@ -158,7 +186,23 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 	id := fmt.Sprintf("%s-%d", kind, m.seq)
 	ctx, cancel := context.WithCancel(m.root)
 	startedAt := nowMs()
-	j := &Job{ID: id, Kind: kind, Label: label, SessionID: parentSession, status: Running, startedAt: startedAt, activityAt: startedAt, cancel: cancel, done: make(chan struct{})}
+	logPath, metaPath, file, artifactErr := m.openArtifactLocked(parentSession, id)
+	j := &Job{
+		ID:               id,
+		Kind:             kind,
+		Label:            label,
+		SessionID:        parentSession,
+		status:           Running,
+		startedAt:        startedAt,
+		activityAt:       startedAt,
+		cancel:           cancel,
+		done:             make(chan struct{}),
+		artifactPath:     logPath,
+		artifactMetaPath: metaPath,
+		artifactFile:     file,
+		artifactComplete: artifactErr == "",
+		artifactErr:      artifactErr,
+	}
 	m.jobs[id] = j
 	m.order = append(m.order, id)
 	m.mu.Unlock()
@@ -189,6 +233,46 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		default:
 			st = Done
 		}
+		finishedAt := nowMs()
+		if result != "" {
+			j.mu.Lock()
+			if j.artifactFile != nil {
+				if _, writeErr := j.artifactFile.WriteString(result); writeErr != nil {
+					j.artifactErr = writeErr.Error()
+				}
+			} else {
+				j.result = result
+			}
+			j.tail = appendTail(j.tail, []byte(result), defaultTailBytes)
+			j.mu.Unlock()
+		}
+		j.mu.Lock()
+		if j.artifactFile != nil {
+			if closeErr := j.artifactFile.Close(); closeErr != nil && j.artifactErr == "" {
+				j.artifactErr = closeErr.Error()
+			}
+			j.artifactFile = nil
+		}
+		if j.artifactErr != "" {
+			j.artifactComplete = false
+			if st == Done {
+				st = Failed
+			}
+			err = joinJobError(err, fmt.Errorf("job artifact incomplete: %s", j.artifactErr))
+		}
+		j.finishedAt = finishedAt
+		metaErr := m.writeJobMetaLocked(j, st)
+		if metaErr != nil {
+			if j.artifactErr == "" {
+				j.artifactErr = "metadata: " + metaErr.Error()
+			}
+			j.artifactComplete = false
+			if st == Done {
+				st = Failed
+			}
+			err = joinJobError(err, fmt.Errorf("job artifact metadata incomplete: %w", metaErr))
+		}
+		j.mu.Unlock()
 		// Queue the drain note (and emit the closing Notice) BEFORE publishing the
 		// terminal status. Wait(nil)/resolve only block on Running jobs, so if the
 		// status flipped to terminal before the note was queued, a Wait could observe
@@ -198,9 +282,12 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		m.recordCompletion(parentSession, id, kind, label, st, err)
 
 		j.mu.Lock()
-		j.result = result
 		if j.status != Killed { // a concurrent Kill already published Killed — keep it
 			j.status = st
+		}
+		if j.artifactPath != "" && j.artifactComplete {
+			j.result = ""
+			j.tail = nil
 		}
 		j.mu.Unlock()
 		close(j.done)
@@ -215,6 +302,67 @@ func runRecovered(ctx context.Context, out io.Writer, run func(context.Context, 
 		}
 	}()
 	return run(ctx, out)
+}
+
+func joinJobError(a, b error) error {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	return fmt.Errorf("%v; %w", a, b)
+}
+
+func (m *Manager) openArtifactLocked(parentSession, id string) (logPath, metaPath string, file *os.File, artifactErr string) {
+	dir := m.artifactDirLocked(parentSession)
+	if dir == "" {
+		return "", "", nil, "artifact directory unavailable"
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return filepath.Join(dir, id+jobLogExt), filepath.Join(dir, id+jobMetaExt), nil, err.Error()
+	}
+	logPath = filepath.Join(dir, id+jobLogExt)
+	metaPath = filepath.Join(dir, id+jobMetaExt)
+	f, err := os.Create(logPath)
+	if err != nil {
+		return logPath, metaPath, nil, err.Error()
+	}
+	return logPath, metaPath, f, ""
+}
+
+func (m *Manager) artifactDirLocked(parentSession string) string {
+	parentSession = strings.TrimSpace(parentSession)
+	if parentSession != "" {
+		if dir := strings.TrimSpace(m.artifactDirs[parentSession]); dir != "" {
+			return dir
+		}
+	}
+	if strings.TrimSpace(m.tempRoot) == "" {
+		return ""
+	}
+	if parentSession == "" {
+		return filepath.Join(m.tempRoot, "default")
+	}
+	return filepath.Join(m.tempRoot, parentSession)
+}
+
+func (m *Manager) writeJobMetaLocked(j *Job, st Status) error {
+	if j.artifactMetaPath == "" {
+		return nil
+	}
+	return writeMeta(j.artifactMetaPath, artifactMeta{
+		ID:               j.ID,
+		Kind:             j.Kind,
+		Label:            j.Label,
+		SessionID:        j.SessionID,
+		Status:           st,
+		StartedAt:        j.startedAt,
+		FinishedAt:       j.finishedAt,
+		ArtifactComplete: j.artifactComplete && j.artifactErr == "",
+		ArtifactError:    j.artifactErr,
+		LogPath:          filepath.Base(j.artifactPath),
+	})
 }
 
 func (m *Manager) monitorStalled(parentSession string, j *Job) {
@@ -328,9 +476,15 @@ func (m *Manager) OutputForSession(parentSession, id string) (text string, statu
 	}
 	j.mu.Lock()
 	defer j.mu.Unlock()
-	full := j.buf.String()
-	text = full[j.readOffset:]
-	j.readOffset = len(full)
+	if j.artifactPath != "" {
+		text = j.readArtifactSinceOffsetLocked()
+	} else {
+		full := string(j.tail)
+		if j.readOffset < int64(len(full)) {
+			text = full[j.readOffset:]
+			j.readOffset = int64(len(full))
+		}
+	}
 	// A task job streams nothing to the buffer — its answer lands in result. Once
 	// it is terminal with no buffered output, surface that result once so a task's
 	// answer is visible here too (bash_output's description promises task support).
@@ -339,6 +493,37 @@ func (m *Manager) OutputForSession(parentSession, id string) (text string, statu
 		j.resultRead = true
 	}
 	return text, j.status, true
+}
+
+func (j *Job) readArtifactSinceOffsetLocked() string {
+	b, err := os.ReadFile(j.artifactPath)
+	if err != nil {
+		if j.artifactErr == "" {
+			j.artifactErr = err.Error()
+		}
+		return ""
+	}
+	if j.readOffset > int64(len(b)) {
+		j.readOffset = int64(len(b))
+		return ""
+	}
+	text := string(b[j.readOffset:])
+	j.readOffset = int64(len(b))
+	return text
+}
+
+func (j *Job) readArtifactAllLocked() string {
+	if j.artifactPath == "" {
+		return ""
+	}
+	b, err := os.ReadFile(j.artifactPath)
+	if err != nil {
+		if j.artifactErr == "" {
+			j.artifactErr = err.Error()
+		}
+		return ""
+	}
+	return string(b)
 }
 
 // Kill cancels a running job. Returns false when the id is unknown or the job has
@@ -439,8 +624,17 @@ func (m *Manager) results(targets []*Job) []Result {
 	for _, j := range targets {
 		j.mu.Lock()
 		text := j.result
+		if text == "" && j.artifactPath != "" {
+			text = j.readArtifactAllLocked()
+		}
 		if text == "" {
-			text = j.buf.String()
+			text = string(j.tail)
+		}
+		if j.artifactErr != "" {
+			if text != "" {
+				text += "\n"
+			}
+			text += "job artifact incomplete: " + j.artifactErr
 		}
 		out = append(out, Result{ID: j.ID, Kind: j.Kind, Label: j.Label, Status: j.status, Output: text})
 		j.mu.Unlock()
@@ -518,6 +712,115 @@ func (m *Manager) SetActiveSession(parentSession string) {
 	m.mu.Unlock()
 }
 
+// SetActiveSessionPath binds a parent session id to its persistent transcript
+// path, migrates any temporary artifacts, and loads completed job tombstones from
+// the session sidecar.
+func (m *Manager) SetActiveSessionPath(parentSession, sessionPath string) {
+	parentSession = strings.TrimSpace(parentSession)
+	sessionPath = strings.TrimSpace(sessionPath)
+	m.mu.Lock()
+	m.active = parentSession
+	if parentSession == "" || sessionPath == "" {
+		m.mu.Unlock()
+		return
+	}
+	oldDir := m.artifactDirLocked(parentSession)
+	newDir := ArtifactDir(sessionPath)
+	m.artifactDirs[parentSession] = newDir
+	loaded := m.loaded[parentSession]
+	m.mu.Unlock()
+
+	if oldDir != "" && newDir != "" && oldDir != newDir {
+		_ = migrateArtifactDir(oldDir, newDir)
+	}
+	if !loaded {
+		m.loadSessionArtifacts(parentSession, newDir)
+	}
+}
+
+func migrateArtifactDir(src, dst string) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if err := os.Rename(filepath.Join(src, entry.Name()), filepath.Join(dst, entry.Name())); err != nil {
+			return err
+		}
+	}
+	_ = os.Remove(src)
+	return nil
+}
+
+func (m *Manager) loadSessionArtifacts(parentSession, dir string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		m.mu.Lock()
+		m.loaded[parentSession] = true
+		m.mu.Unlock()
+		return
+	}
+	var loaded []*Job
+	maxSeq := 0
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != jobMetaExt {
+			continue
+		}
+		meta, err := readMeta(filepath.Join(dir, entry.Name()))
+		if err != nil || strings.TrimSpace(meta.ID) == "" {
+			continue
+		}
+		id := strings.TrimSpace(meta.ID)
+		if seq := maxJobSeq(id); seq > maxSeq {
+			maxSeq = seq
+		}
+		done := make(chan struct{})
+		close(done)
+		logPath := filepath.Join(dir, id+jobLogExt)
+		if strings.TrimSpace(meta.LogPath) != "" {
+			logPath = filepath.Join(dir, filepath.Base(meta.LogPath))
+		}
+		loaded = append(loaded, &Job{
+			ID:               id,
+			Kind:             meta.Kind,
+			Label:            meta.Label,
+			SessionID:        parentSession,
+			status:           meta.Status,
+			startedAt:        meta.StartedAt,
+			finishedAt:       meta.FinishedAt,
+			activityAt:       meta.FinishedAt,
+			done:             done,
+			artifactPath:     logPath,
+			artifactMetaPath: filepath.Join(dir, id+jobMetaExt),
+			artifactComplete: meta.ArtifactComplete,
+			artifactErr:      meta.ArtifactError,
+			tombstone:        true,
+		})
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, j := range loaded {
+		if _, exists := m.jobs[j.ID]; exists {
+			continue
+		}
+		m.jobs[j.ID] = j
+		m.order = append(m.order, j.ID)
+	}
+	if maxSeq > m.seq {
+		m.seq = maxSeq
+	}
+	m.loaded[parentSession] = true
+}
+
 // DestroySession marks a parent session as being removed from active use and
 // cancels its running jobs. The returned channels close when each cancelled job
 // has fully unwound.
@@ -592,6 +895,9 @@ func (m *Manager) FinishDestroySession(parentSession string) {
 func (m *Manager) Close() {
 	m.cancel()
 	m.wg.Wait()
+	if m.tempRoot != "" {
+		_ = os.RemoveAll(m.tempRoot)
+	}
 }
 
 func nowMs() int64 { return time.Now().UnixMilli() }

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -508,8 +508,11 @@ func (m *Manager) OutputForSession(parentSession, id string) (text string, statu
 		text = j.result
 		j.resultRead = true
 	}
-	if text == "" && j.artifactErr != "" {
-		text = "job artifact incomplete: " + j.artifactErr
+	if j.artifactErr != "" {
+		if text != "" {
+			text += "\n"
+		}
+		text += "job artifact incomplete: " + j.artifactErr
 	}
 	return text, j.status, true
 }
@@ -778,6 +781,11 @@ func (m *Manager) SetActiveSessionPath(parentSession, sessionPath string) {
 
 	if oldDir != "" && newDir != "" && oldDir != newDir {
 		if err := migrateArtifactDir(oldDir, newDir); err != nil {
+			if adoptDefault {
+				m.mu.Lock()
+				m.adoptUnscopedJobsLocked(parentSession)
+				m.mu.Unlock()
+			}
 			m.recordArtifactMigrationError(parentSession, err)
 		} else {
 			m.mu.Lock()
@@ -806,6 +814,11 @@ func (m *Manager) adoptUnscopedJobsLocked(parentSession string) {
 	parentSession = strings.TrimSpace(parentSession)
 	if parentSession == "" {
 		return
+	}
+	for i := range m.completed {
+		if strings.TrimSpace(m.completed[i].sessionID) == "" {
+			m.completed[i].sessionID = parentSession
+		}
 	}
 	for oldKey, j := range m.jobs {
 		if j == nil || strings.TrimSpace(j.SessionID) != "" {
@@ -857,6 +870,9 @@ func (m *Manager) recordArtifactMigrationError(parentSession string, err error) 
 		if j.artifactErr == "" {
 			j.artifactErr = "migration: " + err.Error()
 			j.artifactComplete = false
+		}
+		if j.status == Done {
+			j.status = Failed
 		}
 		j.mu.Unlock()
 	}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -780,7 +781,11 @@ func (m *Manager) SetActiveSessionPath(parentSession, sessionPath string) {
 	m.mu.Unlock()
 
 	if oldDir != "" && newDir != "" && oldDir != newDir {
-		if err := migrateArtifactDir(oldDir, newDir); err != nil {
+		oldSession := parentSession
+		if adoptDefault {
+			oldSession = ""
+		}
+		if err := m.migrateArtifactDirForSession(oldSession, oldDir, newDir); err != nil {
 			if adoptDefault {
 				m.mu.Lock()
 				m.adoptUnscopedJobsLocked(parentSession)
@@ -792,7 +797,6 @@ func (m *Manager) SetActiveSessionPath(parentSession, sessionPath string) {
 			if adoptDefault {
 				m.adoptUnscopedJobsLocked(parentSession)
 			}
-			m.rebaseSessionArtifactsLocked(parentSession, newDir)
 			m.mu.Unlock()
 		}
 	}
@@ -880,6 +884,127 @@ func (m *Manager) recordArtifactMigrationError(parentSession string, err error) 
 	m.mu.Unlock()
 	if active == "" || active == parentSession {
 		m.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: text})
+	}
+}
+
+type artifactMigrationJob struct {
+	job     *Job
+	wasOpen bool
+}
+
+func (m *Manager) migrateArtifactDirForSession(parentSession, oldDir, newDir string) error {
+	locked := m.lockArtifactJobsForMigration(parentSession, oldDir)
+	defer unlockArtifactMigrationJobs(locked)
+	closeErr := closeArtifactMigrationFiles(locked)
+	migrateErr := migrateArtifactDir(oldDir, newDir)
+	reopenDir := oldDir
+	if migrateErr == nil {
+		rebaseArtifactMigrationJobs(locked, newDir)
+		reopenDir = newDir
+	}
+	if reopenErr := reopenArtifactMigrationFiles(locked, reopenDir); reopenErr != nil {
+		return joinJobError(closeErr, joinJobError(migrateErr, reopenErr))
+	}
+	return joinJobError(closeErr, migrateErr)
+}
+
+func (m *Manager) lockArtifactJobsForMigration(parentSession, dir string) []artifactMigrationJob {
+	parentSession = strings.TrimSpace(parentSession)
+	dir = filepath.Clean(strings.TrimSpace(dir))
+	m.mu.Lock()
+	jobs := make([]*Job, 0, len(m.jobs))
+	for _, j := range m.jobs {
+		if j == nil || strings.TrimSpace(j.SessionID) != parentSession {
+			continue
+		}
+		jobs = append(jobs, j)
+	}
+	m.mu.Unlock()
+	sort.Slice(jobs, func(i, k int) bool {
+		return jobs[i].ID < jobs[k].ID
+	})
+	locked := make([]artifactMigrationJob, 0, len(jobs))
+	for _, j := range jobs {
+		j.mu.Lock()
+		if !artifactPathInDir(j.artifactPath, dir) {
+			j.mu.Unlock()
+			continue
+		}
+		locked = append(locked, artifactMigrationJob{job: j, wasOpen: j.artifactFile != nil})
+	}
+	return locked
+}
+
+func artifactPathInDir(path, dir string) bool {
+	path = filepath.Clean(strings.TrimSpace(path))
+	dir = filepath.Clean(strings.TrimSpace(dir))
+	if path == "." || dir == "." {
+		return false
+	}
+	return filepath.Dir(path) == dir
+}
+
+func closeArtifactMigrationFiles(jobs []artifactMigrationJob) error {
+	var err error
+	for _, item := range jobs {
+		j := item.job
+		if j == nil || j.artifactFile == nil {
+			continue
+		}
+		if closeErr := j.artifactFile.Close(); closeErr != nil {
+			j.artifactErr = closeErr.Error()
+			j.artifactComplete = false
+			err = joinJobError(err, fmt.Errorf("close %s: %w", j.ID, closeErr))
+		}
+		j.artifactFile = nil
+	}
+	return err
+}
+
+func rebaseArtifactMigrationJobs(jobs []artifactMigrationJob, dir string) {
+	for _, item := range jobs {
+		j := item.job
+		if j == nil {
+			continue
+		}
+		if j.artifactPath != "" {
+			j.artifactPath = filepath.Join(dir, filepath.Base(j.artifactPath))
+		}
+		if j.artifactMetaPath != "" {
+			j.artifactMetaPath = filepath.Join(dir, filepath.Base(j.artifactMetaPath))
+		}
+	}
+}
+
+func reopenArtifactMigrationFiles(jobs []artifactMigrationJob, dir string) error {
+	var err error
+	for _, item := range jobs {
+		j := item.job
+		if j == nil || !item.wasOpen {
+			continue
+		}
+		path := j.artifactPath
+		if path == "" {
+			path = filepath.Join(dir, j.ID+jobLogExt)
+			j.artifactPath = path
+		}
+		f, openErr := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if openErr != nil {
+			j.artifactErr = openErr.Error()
+			j.artifactComplete = false
+			err = joinJobError(err, fmt.Errorf("reopen %s: %w", j.ID, openErr))
+			continue
+		}
+		j.artifactFile = f
+	}
+	return err
+}
+
+func unlockArtifactMigrationJobs(jobs []artifactMigrationJob) {
+	for i := len(jobs) - 1; i >= 0; i-- {
+		if jobs[i].job != nil {
+			jobs[i].job.mu.Unlock()
+		}
 	}
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -499,19 +499,41 @@ func (m *Manager) OutputForSession(parentSession, id string) (text string, statu
 }
 
 func (j *Job) readArtifactSinceOffsetLocked() string {
-	b, err := os.ReadFile(j.artifactPath)
+	f, err := os.Open(j.artifactPath)
 	if err != nil {
 		if j.artifactErr == "" {
 			j.artifactErr = err.Error()
 		}
 		return ""
 	}
-	if j.readOffset > int64(len(b)) {
-		j.readOffset = int64(len(b))
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		if j.artifactErr == "" {
+			j.artifactErr = err.Error()
+		}
 		return ""
 	}
-	text := string(b[j.readOffset:])
-	j.readOffset = int64(len(b))
+	size := info.Size()
+	if j.readOffset > size {
+		j.readOffset = size
+		return ""
+	}
+	if _, err := f.Seek(j.readOffset, io.SeekStart); err != nil {
+		if j.artifactErr == "" {
+			j.artifactErr = err.Error()
+		}
+		return ""
+	}
+	b, err := io.ReadAll(f)
+	if err != nil {
+		if j.artifactErr == "" {
+			j.artifactErr = err.Error()
+		}
+		return ""
+	}
+	text := string(b)
+	j.readOffset = size
 	return text
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -847,22 +847,6 @@ func (m *Manager) adoptUnscopedJobsLocked(parentSession string) {
 	}
 }
 
-func (m *Manager) rebaseSessionArtifactsLocked(parentSession, dir string) {
-	for _, j := range m.jobs {
-		if j == nil || !sessionMatches(parentSession, j.SessionID) {
-			continue
-		}
-		j.mu.Lock()
-		if j.artifactPath != "" {
-			j.artifactPath = filepath.Join(dir, filepath.Base(j.artifactPath))
-		}
-		if j.artifactMetaPath != "" {
-			j.artifactMetaPath = filepath.Join(dir, filepath.Base(j.artifactMetaPath))
-		}
-		j.mu.Unlock()
-	}
-}
-
 func (m *Manager) recordArtifactMigrationError(parentSession string, err error) {
 	text := "job artifact migration failed: " + err.Error()
 	m.mu.Lock()

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -884,7 +884,23 @@ func (m *Manager) FinishDestroySession(parentSession string) {
 	}
 	m.mu.Lock()
 	delete(m.destroying, parentSession)
+	delete(m.artifactDirs, parentSession)
+	delete(m.loaded, parentSession)
+	m.purgeSessionLocked(parentSession)
 	m.mu.Unlock()
+}
+
+func (m *Manager) purgeSessionLocked(parentSession string) {
+	kept := m.order[:0]
+	for _, id := range m.order {
+		j := m.jobs[id]
+		if j == nil || sessionMatches(parentSession, j.SessionID) {
+			delete(m.jobs, id)
+			continue
+		}
+		kept = append(kept, id)
+	}
+	m.order = kept
 }
 
 // Close cancels the session context and waits for every background job goroutine

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -203,8 +203,9 @@ func (m *Manager) StartForSession(parentSession, kind, label string, run func(ct
 		artifactComplete: artifactErr == "",
 		artifactErr:      artifactErr,
 	}
-	m.jobs[id] = j
-	m.order = append(m.order, id)
+	key := jobKey(parentSession, id)
+	m.jobs[key] = j
+	m.order = append(m.order, key)
 	m.mu.Unlock()
 
 	m.emitIfActive(parentSession, event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: startedText(kind, id, label)})
@@ -455,10 +456,25 @@ func (m *Manager) recordStalled(parentSession, id, kind, label string) {
 	}
 }
 
-func (m *Manager) get(id string) *Job {
+func (m *Manager) get(parentSession, id string) *Job {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return m.jobs[id]
+	return m.findJobLocked(parentSession, id)
+}
+
+func (m *Manager) findJobLocked(parentSession, id string) *Job {
+	parentSession = strings.TrimSpace(parentSession)
+	id = strings.TrimSpace(id)
+	if parentSession != "" {
+		return m.jobs[jobKey(parentSession, id)]
+	}
+	for _, key := range m.order {
+		j := m.jobs[key]
+		if j != nil && j.ID == id {
+			return j
+		}
+	}
+	return nil
 }
 
 // Output returns the job's output produced since the last Output call plus its
@@ -470,8 +486,8 @@ func (m *Manager) Output(id string) (text string, status Status, ok bool) {
 // OutputForSession returns output only when id belongs to parentSession. Empty
 // parentSession preserves the legacy unscoped behavior.
 func (m *Manager) OutputForSession(parentSession, id string) (text string, status Status, ok bool) {
-	j := m.get(id)
-	if j == nil || !sessionMatches(parentSession, j.SessionID) {
+	j := m.get(parentSession, id)
+	if j == nil {
 		return "", "", false
 	}
 	j.mu.Lock()
@@ -560,8 +576,8 @@ func (m *Manager) Kill(id string) bool {
 // KillForSession cancels a running job only when it belongs to parentSession.
 // Empty parentSession preserves the legacy unscoped behavior.
 func (m *Manager) KillForSession(parentSession, id string) bool {
-	j := m.get(id)
-	if j == nil || !sessionMatches(parentSession, j.SessionID) {
+	j := m.get(parentSession, id)
+	if j == nil {
 		return false
 	}
 	j.mu.Lock()
@@ -622,8 +638,8 @@ func (m *Manager) resolve(parentSession string, ids []string) []*Job {
 	defer m.mu.Unlock()
 	var out []*Job
 	if len(ids) == 0 {
-		for _, id := range m.order {
-			j := m.jobs[id]
+		for _, key := range m.order {
+			j := m.jobs[key]
 			if !sessionMatches(parentSession, j.SessionID) {
 				continue
 			}
@@ -637,7 +653,7 @@ func (m *Manager) resolve(parentSession string, ids []string) []*Job {
 		return out
 	}
 	for _, id := range ids {
-		if j := m.jobs[id]; j != nil && sessionMatches(parentSession, j.SessionID) {
+		if j := m.findJobLocked(parentSession, id); j != nil {
 			out = append(out, j)
 		}
 	}
@@ -678,8 +694,8 @@ func (m *Manager) RunningForSession(parentSession string) []View {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var out []View
-	for _, id := range m.order {
-		j := m.jobs[id]
+	for _, key := range m.order {
+		j := m.jobs[key]
 		if !sessionMatches(parentSession, j.SessionID) {
 			continue
 		}
@@ -877,11 +893,12 @@ func (m *Manager) loadSessionArtifacts(parentSession, dir string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, j := range loaded {
-		if _, exists := m.jobs[j.ID]; exists {
+		key := jobKey(parentSession, j.ID)
+		if _, exists := m.jobs[key]; exists {
 			continue
 		}
-		m.jobs[j.ID] = j
-		m.order = append(m.order, j.ID)
+		m.jobs[key] = j
+		m.order = append(m.order, key)
 	}
 	if maxSeq > m.seq {
 		m.seq = maxSeq
@@ -908,8 +925,8 @@ func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
 		}
 	}
 	m.completed = remaining
-	for _, id := range m.order {
-		j := m.jobs[id]
+	for _, key := range m.order {
+		j := m.jobs[key]
 		if !sessionMatches(parentSession, j.SessionID) {
 			continue
 		}
@@ -960,13 +977,13 @@ func (m *Manager) FinishDestroySession(parentSession string) {
 
 func (m *Manager) purgeSessionLocked(parentSession string) {
 	kept := m.order[:0]
-	for _, id := range m.order {
-		j := m.jobs[id]
+	for _, key := range m.order {
+		j := m.jobs[key]
 		if j == nil || sessionMatches(parentSession, j.SessionID) {
-			delete(m.jobs, id)
+			delete(m.jobs, key)
 			continue
 		}
-		kept = append(kept, id)
+		kept = append(kept, key)
 	}
 	m.order = kept
 }
@@ -1005,6 +1022,10 @@ func (m *Manager) emitIfActive(parentSession string, ev event.Event) {
 func sessionMatches(filter, jobSession string) bool {
 	filter = strings.TrimSpace(filter)
 	return filter == "" || strings.TrimSpace(jobSession) == filter
+}
+
+func jobKey(parentSession, id string) string {
+	return strings.TrimSpace(parentSession) + "\x00" + strings.TrimSpace(id)
 }
 
 // --- call-context injection (mirrors agent.CallContext) ---

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -24,6 +24,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
+	"reasonix/internal/jobs"
 	"reasonix/internal/nilutil"
 	"reasonix/internal/provider"
 )
@@ -973,7 +974,11 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	go finishSessionDestroy(destroy)
+	finishSessionDestroy(destroy)
+	if err := jobs.RemoveArtifacts(abs); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -15,6 +15,7 @@ import (
 	"reasonix/internal/agent"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
+	"reasonix/internal/jobs"
 	"reasonix/internal/provider"
 )
 
@@ -389,6 +390,13 @@ func TestDeleteSessionRequiresSessionNameInsideSessionDir(t *testing.T) {
 	}
 	ref := "sa_20260102_030405_000000000_aabbccddeeff"
 	writeServeSubagentArtifact(t, dir, ref, agent.BranchID(old))
+	oldJobsDir := jobs.ArtifactDir(old)
+	if err := os.MkdirAll(oldJobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(oldJobsDir, "bash-1.log"), []byte("output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	sibling := dir + "-other"
 	if err := os.MkdirAll(sibling, 0o755); err != nil {
 		t.Fatal(err)
@@ -434,6 +442,9 @@ func TestDeleteSessionRequiresSessionNameInsideSessionDir(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "subagents", ref+".meta.json")); !os.IsNotExist(err) {
 		t.Fatalf("old session subagent meta still exists or stat failed unexpectedly: %v", err)
+	}
+	if _, err := os.Stat(oldJobsDir); !os.IsNotExist(err) {
+		t.Fatalf("old session jobs sidecar still exists or stat failed unexpectedly: %v", err)
 	}
 }
 


### PR DESCRIPTION
## 做了什么

- 将后台 `bash` / `task` job 的完整输出与最终结果写入 session 同级 `.jobs/` sidecar artifact，完成后内存只保留轻量 tombstone、读取 offset 和有界 tail。
- 在 session 绑定、恢复、删除、清空、trash/restore/purge、HTTP/SSE 删除和 ACP 删除路径中接入 job artifact 生命周期。
- 补充 artifact metadata、临时 artifact 迁移、迁移失败可见错误、跨 session job id 隔离、增量读取大日志等测试覆盖。

## 为什么这么做

原实现会把已完成后台 job 的输出 buffer / result 长期保留在 `jobs.Manager` 内存中。长时间打开会话并频繁运行后台 job 时，内存会随历史输出总量持续增长。完整结果又需要在恢复保存过的 session 后继续可读，因此不能简单删除完成 job。

## 结果与影响

- 后台 job 的完整输出默认保存在磁盘 artifact 中，不再要求完整内容常驻内存。
- `bash_output`、`wait`、`kill_shell` 的 Agent 可见使用方式保持不变；工具内部会按需从 artifact 读取结果。
- 保存过的 session 恢复后仍可读取已完成 job；被 clear/delete/purge 的 session 不会留下孤儿 `.jobs/` 目录。
- artifact 写入或迁移失败会通过 metadata / notice / tool result 暴露，不会退回到无界内存保存。

## 验证

- `go test ./internal/jobs ./internal/control ./internal/serve ./internal/acp`
- `cd desktop && go test .`
- `git diff --name-only origin/main-v2...HEAD | rg '^(AGENTS\\.md|architecture/|context/)' || true` 无输出
- `git merge-tree --write-tree HEAD origin/main-v2` 可生成 merge tree，无冲突