### PR TITLE
Improve site download guidance / 优化官网下载指引

### DIFF
--- a/site/src/pages/docs.astro
+++ b/site/src/pages/docs.astro
@@ -2,14 +2,21 @@
 import Base from '../layouts/Base.astro';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const R2 = 'https://dl.reasonix.io/latest';
+const R2_LATEST = 'https://dl.reasonix.io/latest';
 const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
 
+let desktopVersion = 'v1.1.0';
 let goVer = '1.1.0';
 try {
-  const r = await fetch(`${R2}/latest.json`);
-  if (r.ok) { const d = await r.json(); goVer = String(d.version || '').replace(/^v/, '') || goVer; }
+  const r = await fetch(`${R2_LATEST}/latest.json`);
+  if (r.ok) {
+    const d = await r.json();
+    const version = String(d.version || desktopVersion).replace(/^v?/, 'v');
+    desktopVersion = version;
+    goVer = desktopVersion.replace(/^v/, '') || goVer;
+  }
 } catch {}
+const R2_DESKTOP = `https://dl.reasonix.io/desktop-${desktopVersion}`;
 ---
 <Base
   title="Docs — Reasonix"
@@ -41,6 +48,7 @@ try {
         <span class="gh"><span class="l-en">Getting started</span><span class="l-zh">快速开始</span></span>
         <a href="#install"><span class="l-en">CLI / TUI</span><span class="l-zh">CLI / TUI</span></a>
         <a href="#desktop"><span class="l-en">Desktop app</span><span class="l-zh">桌面端下载</span></a>
+        <a href="#macos-quarantine"><span class="l-en">macOS warning</span><span class="l-zh">macOS 拦截处理</span></a>
         <a href="#quickstart"><span class="l-en">Quick start</span><span class="l-zh">快速上手</span></a>
         <a href="#config"><span class="l-en">Configuration</span><span class="l-zh">配置</span></a>
       </div>
@@ -78,27 +86,41 @@ brew install esengine/reasonix/reasonix</div>
           <li><span class="l-en">Scriptable runs through <code>reasonix run</code>, including piped input and explicit model selection.</span><span class="l-zh">可脚本化的 <code>reasonix run</code>,支持管道输入和显式模型选择。</span></li>
         </ul>
       </div>
-      <div class="callout"><span class="ico">!</span><span><span class="l-en">To install the legacy <strong>0.x</strong> version, run <code>npm i -g reasonix@latest</code>. The commands above, Homebrew, and desktop/release downloads install Reasonix 1.x; the current desktop download build is <strong>v{goVer}</strong>.</span><span class="l-zh">如需安装 legacy <strong>0.x</strong> 版本,命令是: <code>npm i -g reasonix@latest</code>。上方命令、Homebrew 与桌面端/Release 下载对应 Reasonix 1.x；当前桌面端下载构建为 <strong>v{goVer}</strong>。</span></span></div>
+      <div class="callout"><span class="ico">!</span><span><span class="l-en">To install the legacy <strong>0.x</strong> version, run <code>npm i -g reasonix@latest</code>. The commands above, Homebrew, and desktop/release downloads install Reasonix 1.x; the current desktop download build is <strong>v<span class="rxv">{goVer}</span></strong>.</span><span class="l-zh">如需安装 legacy <strong>0.x</strong> 版本,命令是: <code>npm i -g reasonix@latest</code>。上方命令、Homebrew 与桌面端/Release 下载对应 Reasonix 1.x；当前桌面端下载构建为 <strong>v<span class="rxv">{goVer}</span></strong>。</span></span></div>
 
       <h2 id="desktop"><span class="l-en">Desktop app</span><span class="l-zh">桌面端</span></h2>
       <div class="desktop-panel">
         <div class="desktop-panel-head">
-          <span class="desktop-kicker"><span class="l-en">Native app · v{goVer}</span><span class="l-zh">原生桌面端 · v{goVer}</span></span>
+          <span class="desktop-kicker"><span class="l-en">Native app · v<span class="rxv">{goVer}</span></span><span class="l-zh">原生桌面端 · v<span class="rxv">{goVer}</span></span></span>
           <h3><span class="l-en">Use Reasonix with a full desktop workspace</span><span class="l-zh">用完整桌面工作区运行 Reasonix</span></h3>
           <p><span class="l-en">The desktop app runs the same local Reasonix engine as the CLI, with visual sessions, settings, MCP status, memory, checkpoints, tool approvals, and IM bot connections in one place.</span><span class="l-zh">桌面端运行与 CLI 相同的本地 Reasonix 引擎,并把可视化会话、设置、MCP 状态、记忆、检查点、工具审批和 IM Bot 连接集中到一个工作区。</span></p>
         </div>
         <div class="desktop-downloads" aria-label="Desktop downloads">
-          <a class="desktop-download" href={`${R2}/Reasonix-darwin-universal.dmg`} download>
+          <a class="desktop-download" href={`${R2_DESKTOP}/Reasonix-darwin-universal.dmg`} data-desktop-asset="Reasonix-darwin-universal.dmg" download>
             <strong>macOS</strong>
-            <span><span class="l-en">Universal DMG</span><span class="l-zh">通用 DMG</span></span>
+            <span><span class="l-en">Universal DMG · Apple Silicon + Intel</span><span class="l-zh">通用 DMG · Apple Silicon + Intel</span></span>
           </a>
-          <a class="desktop-download" href={`${R2}/Reasonix-windows-amd64-installer.exe`} download>
+          <a class="desktop-download" href={`${R2_DESKTOP}/Reasonix-windows-amd64-installer.exe`} data-desktop-asset="Reasonix-windows-amd64-installer.exe" download>
             <strong>Windows</strong>
             <span><span class="l-en">x64 installer</span><span class="l-zh">x64 安装器</span></span>
           </a>
-          <a class="desktop-download" href={`${R2}/Reasonix-linux-amd64.tar.gz`} download>
+          <a class="desktop-download" href={`${R2_DESKTOP}/Reasonix-linux-amd64.deb`} data-desktop-asset="Reasonix-linux-amd64.deb" download>
             <strong>Linux</strong>
-            <span><span class="l-en">amd64 tarball</span><span class="l-zh">amd64 压缩包</span></span>
+            <span><span class="l-en">Debian / Ubuntu .deb</span><span class="l-zh">Debian / Ubuntu .deb</span></span>
+          </a>
+        </div>
+        <div class="desktop-downloads desktop-downloads--secondary" aria-label="Alternate desktop downloads">
+          <a class="desktop-download" href={`${R2_DESKTOP}/Reasonix-darwin-arm64.zip`} data-desktop-asset="Reasonix-darwin-arm64.zip" download>
+            <strong>macOS</strong>
+            <span>Apple Silicon zip</span>
+          </a>
+          <a class="desktop-download" href={`${R2_DESKTOP}/Reasonix-windows-arm64-installer.exe`} data-desktop-asset="Reasonix-windows-arm64-installer.exe" download>
+            <strong>Windows</strong>
+            <span>ARM64 installer</span>
+          </a>
+          <a class="desktop-download" href={`${R2_DESKTOP}/Reasonix-linux-amd64.tar.gz`} data-desktop-asset="Reasonix-linux-amd64.tar.gz" download>
+            <strong>Linux</strong>
+            <span><span class="l-en">Generic amd64 tarball</span><span class="l-zh">通用 amd64 压缩包</span></span>
           </a>
         </div>
         <ul class="desktop-feature-list">
@@ -107,6 +129,11 @@ brew install esengine/reasonix/reasonix</div>
           <li><span class="l-en">Connect Feishu, Lark, or WeChat bots from Settings and handle remote approvals locally.</span><span class="l-zh">在设置中连接飞书、Lark 或微信 Bot,并在本地处理远程审批。</span></li>
         </ul>
       </div>
+      <h3 id="macos-quarantine"><span class="l-en">macOS quarantine warning</span><span class="l-zh">macOS 隔离属性提示</span></h3>
+      <p><span class="l-en">Use this only when Reasonix was downloaded from the official site or GitHub release, moved to <code>/Applications</code>, and macOS still says the app cannot be opened, cannot be verified, or is damaged. This removes the quarantine flag that macOS attaches to downloaded apps.</span><span class="l-zh">仅在 Reasonix 来自官网或 GitHub Release、已经放入 <code>/Applications</code>,但 macOS 仍提示“无法打开”“无法验证开发者”或“应用已损坏”时使用。它会移除 macOS 给下载应用附加的隔离属性。</span></p>
+      <div class="codeblock"><button data-copy="sudo xattr -rd com.apple.quarantine /Applications/Reasonix.app">Copy</button><span class="c"># Quit Reasonix first, then run in Terminal.</span>
+sudo xattr -rd com.apple.quarantine /Applications/Reasonix.app</div>
+      <div class="callout"><span class="ico">!</span><span><span class="l-en">Only run this for an official Reasonix app you trust. If the app is installed somewhere else, replace <code>/Applications/Reasonix.app</code> with that exact app path, then reopen Reasonix.</span><span class="l-zh">只对可信的官方 Reasonix 应用执行这条命令。如果安装在其他位置,请把 <code>/Applications/Reasonix.app</code> 替换为实际 app 路径,然后重新打开 Reasonix。</span></span></div>
 
       <h2 id="quickstart"><span class="l-en">Quick start</span><span class="l-zh">快速上手</span></h2>
       <p><span class="l-en">First run is minimal — <code>reasonix setup</code> walks you through picking a provider and keys, saving new keys to the configured credential store. Then point Reasonix at a repo and start a session:</span><span class="l-zh">首次运行很简单——<code>reasonix setup</code> 引导你选择 provider 与密钥,新密钥会保存到配置的凭据存储。然后指向仓库、开始会话:</span></p>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -3,14 +3,21 @@ import Base from '../layouts/Base.astro';
 import community from '../data/community.json';
 
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
-const R2 = 'https://dl.reasonix.io/latest';
+const R2_LATEST = 'https://dl.reasonix.io/latest';
 const repo = 'https://github.com/esengine/DeepSeek-Reasonix';
 
+let desktopVersion = 'v1.1.0';
 let goVer = '1.1.0';
 try {
-  const r = await fetch(`${R2}/latest.json`);
-  if (r.ok) { const d = await r.json(); goVer = String(d.version || '').replace(/^v/, '') || goVer; }
+  const r = await fetch(`${R2_LATEST}/latest.json`);
+  if (r.ok) {
+    const d = await r.json();
+    const version = String(d.version || desktopVersion).replace(/^v?/, 'v');
+    desktopVersion = version;
+    goVer = desktopVersion.replace(/^v/, '') || goVer;
+  }
 } catch {}
+const R2_DESKTOP = `https://dl.reasonix.io/desktop-${desktopVersion}`;
 
 const fmtN = (n) => Number(n).toLocaleString('en-US');
 const avClass = (i) => 'av' + (i % 5 === 2 ? ' sm' : i % 7 === 3 ? ' lg' : '');
@@ -275,21 +282,40 @@ const ld = {
         <div class="os-grid">
           <div class="os-card" data-os="mac">
             <h4>macOS</h4>
-            <span class="meta">.dmg · universal (Apple Silicon &amp; Intel)</span>
-            <a class="btn btn-light" href={`${R2}/Reasonix-darwin-universal.dmg`} download><span class="l-en">Download · v<span class="rxv">{goVer}</span></span><span class="l-zh">下载 · v<span class="rxv">{goVer}</span></span></a>
+            <span class="meta"><span class="l-en">Universal DMG · Apple Silicon &amp; Intel</span><span class="l-zh">通用 DMG · Apple Silicon 与 Intel</span></span>
+            <a class="btn btn-light" href={`${R2_DESKTOP}/Reasonix-darwin-universal.dmg`} data-desktop-asset="Reasonix-darwin-universal.dmg" download><span class="l-en">Download Universal · v<span class="rxv">{goVer}</span></span><span class="l-zh">下载通用版 · v<span class="rxv">{goVer}</span></span></a>
+            <div class="os-options" aria-label="macOS alternate downloads">
+              <a href={`${R2_DESKTOP}/Reasonix-darwin-arm64.zip`} data-desktop-asset="Reasonix-darwin-arm64.zip" download>Apple Silicon zip</a>
+              <a href={`${R2_DESKTOP}/Reasonix-darwin-amd64.zip`} data-desktop-asset="Reasonix-darwin-amd64.zip" download>Intel zip</a>
+            </div>
           </div>
           <div class="os-card" data-os="win">
             <h4>Windows</h4>
-            <span class="meta">.exe installer · x64 · Windows 10+</span>
-            <a class="btn btn-light" href={`${R2}/Reasonix-windows-amd64-installer.exe`} download><span class="l-en">Download · v<span class="rxv">{goVer}</span></span><span class="l-zh">下载 · v<span class="rxv">{goVer}</span></span></a>
+            <span class="meta"><span class="l-en">Installer · Windows 10+ · x64 / ARM64</span><span class="l-zh">安装器 · Windows 10+ · x64 / ARM64</span></span>
+            <a class="btn btn-light" href={`${R2_DESKTOP}/Reasonix-windows-amd64-installer.exe`} data-desktop-asset="Reasonix-windows-amd64-installer.exe" download><span class="l-en">Download · v<span class="rxv">{goVer}</span></span><span class="l-zh">下载 · v<span class="rxv">{goVer}</span></span></a>
+            <div class="os-options" aria-label="Windows alternate downloads">
+              <a href={`${R2_DESKTOP}/Reasonix-windows-arm64-installer.exe`} data-desktop-asset="Reasonix-windows-arm64-installer.exe" download>ARM64 installer</a>
+              <a href={`${R2_DESKTOP}/Reasonix-windows-amd64.zip`} data-desktop-asset="Reasonix-windows-amd64.zip" download>Portable zip</a>
+            </div>
           </div>
           <div class="os-card" data-os="linux">
             <h4>Linux</h4>
-            <span class="meta">.tar.gz · amd64</span>
-            <a class="btn btn-light" href={`${R2}/Reasonix-linux-amd64.tar.gz`} download><span class="l-en">Download · v<span class="rxv">{goVer}</span></span><span class="l-zh">下载 · v<span class="rxv">{goVer}</span></span></a>
+            <span class="meta"><span class="l-en">Debian / Ubuntu package · amd64</span><span class="l-zh">Debian / Ubuntu 安装包 · amd64</span></span>
+            <a class="btn btn-light" href={`${R2_DESKTOP}/Reasonix-linux-amd64.deb`} data-desktop-asset="Reasonix-linux-amd64.deb" download><span class="l-en">Download .deb · v<span class="rxv">{goVer}</span></span><span class="l-zh">下载 .deb · v<span class="rxv">{goVer}</span></span></a>
+            <div class="os-options" aria-label="Linux alternate downloads">
+              <a href={`${R2_DESKTOP}/Reasonix-linux-amd64.tar.gz`} data-desktop-asset="Reasonix-linux-amd64.tar.gz" download>Generic tar.gz</a>
+              <a href={`${repo}/releases`}><span class="l-en">All releases</span><span class="l-zh">全部版本</span></a>
+            </div>
           </div>
         </div>
         <div class="dl-note"><span class="l-en">v<span class="rxv">{goVer}</span> · built-in auto-updates · same engine as the CLI · <a href={`${repo}/releases`}>all releases →</a></span><span class="l-zh">v<span class="rxv">{goVer}</span> · 内置自动更新 · 与 CLI 同一引擎 · <a href={`${repo}/releases`}>全部版本 →</a></span></div>
+        <div class="dl-help">
+          <strong><span class="l-en">macOS opens with a quarantine warning?</span><span class="l-zh">macOS 提示无法打开或已损坏?</span></strong>
+          <span><span class="l-en">If the app was installed from the official download and placed in <code>/Applications</code>, quit Reasonix, then run:</span><span class="l-zh">如果来自官网下载并已放入 <code>/Applications</code>,先退出 Reasonix,再运行:</span></span>
+          <code>sudo xattr -rd com.apple.quarantine /Applications/Reasonix.app</code>
+          <button type="button" data-copy="sudo xattr -rd com.apple.quarantine /Applications/Reasonix.app">Copy</button>
+          <a href={`${base}/docs/#macos-quarantine`}><span class="l-en">When to use this →</span><span class="l-zh">查看适用场景 →</span></a>
+        </div>
       </div>
     </div>
   </section>

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -144,17 +144,29 @@
   });
 
   /* refresh the published version and immutable desktop download links between rebuilds */
+  const desktopAssets = [
+    "Reasonix-darwin-universal.dmg",
+    "Reasonix-darwin-arm64.zip",
+    "Reasonix-darwin-amd64.zip",
+    "Reasonix-windows-amd64-installer.exe",
+    "Reasonix-windows-arm64-installer.exe",
+    "Reasonix-windows-amd64.zip",
+    "Reasonix-linux-amd64.deb",
+    "Reasonix-linux-amd64.tar.gz",
+  ];
   fetch("https://dl.reasonix.io/latest/latest.json", { cache: "no-cache" })
     .then((r) => (r.ok ? r.json() : null))
     .then((d) => {
       const rawVersion = String((d && d.version) || "");
-      const v = rawVersion.replace(/^v/, "");
-      if (!v) return;
+      const versionMatch = rawVersion.match(/^v?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)$/);
+      if (!versionMatch) return;
+      const v = versionMatch[1];
       const desktopBase = "https://dl.reasonix.io/desktop-v" + v;
       document.querySelectorAll(".rxv").forEach((e) => { e.textContent = v; });
-      document.querySelectorAll("[data-desktop-asset]").forEach((a) => {
-        const asset = a.getAttribute("data-desktop-asset");
-        if (asset) a.href = desktopBase + "/" + asset;
+      desktopAssets.forEach((asset) => {
+        document.querySelectorAll('[data-desktop-asset="' + asset + '"]').forEach((a) => {
+          a.href = desktopBase + "/" + asset;
+        });
       });
       document.querySelectorAll("a.rxnotes").forEach((a) => {
         a.href = a.href.replace(/releases\/tag\/v[^/]*$/, "releases/tag/v" + v);

--- a/site/src/scripts/site.js
+++ b/site/src/scripts/site.js
@@ -143,13 +143,19 @@
     });
   });
 
-  /* refresh the Go-preview version from the published manifest between rebuilds */
+  /* refresh the published version and immutable desktop download links between rebuilds */
   fetch("https://dl.reasonix.io/latest/latest.json", { cache: "no-cache" })
     .then((r) => (r.ok ? r.json() : null))
     .then((d) => {
-      const v = String((d && d.version) || "").replace(/^v/, "");
+      const rawVersion = String((d && d.version) || "");
+      const v = rawVersion.replace(/^v/, "");
       if (!v) return;
+      const desktopBase = "https://dl.reasonix.io/desktop-v" + v;
       document.querySelectorAll(".rxv").forEach((e) => { e.textContent = v; });
+      document.querySelectorAll("[data-desktop-asset]").forEach((a) => {
+        const asset = a.getAttribute("data-desktop-asset");
+        if (asset) a.href = desktopBase + "/" + asset;
+      });
       document.querySelectorAll("a.rxnotes").forEach((a) => {
         a.href = a.href.replace(/releases\/tag\/v[^/]*$/, "releases/tag/v" + v);
       });

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -499,6 +499,21 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 .os-card h4 { font-size: 20px; font-weight: 600; letter-spacing: -0.01em; color: var(--ink); }
 .os-card .meta { font-family: var(--font-mono); font-size: 11.5px; line-height: 1.7; color: var(--ink-3); }
 .os-card .btn { margin-top: 16px; }
+.os-options {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin-top: 4px;
+}
+.os-options a {
+  display: inline-flex; align-items: center; min-height: 28px;
+  padding: 5px 9px; border-radius: 7px;
+  background: var(--bg-soft); border: 1px solid var(--line);
+  color: var(--ink-2); text-decoration: none;
+  font-size: 12px; font-weight: 600; line-height: 1.2;
+}
+.os-options a:hover {
+  border-color: color-mix(in oklch, var(--accent) 40%, var(--line));
+  color: var(--accent); text-decoration: none;
+}
 .os-card .alt {
   font-size: 12.5px; color: var(--ink-3); text-align: center; margin-top: 2px;
 }
@@ -506,6 +521,29 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
 .os-card .alt a:hover { text-decoration: underline; }
 .btn-light { background: var(--accent-soft); color: var(--accent); }
 .btn-light:hover { background: color-mix(in oklch, var(--accent) 14%, white); }
+.dl-help {
+  position: relative; display: grid; grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 8px 12px; align-items: center;
+  max-width: 900px; margin: 18px auto 0; padding: 16px 18px;
+  background: #fff; border: 1px solid var(--line); border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-1); text-align: left;
+  color: var(--ink-2); font-size: 13.5px; line-height: 1.5;
+}
+.dl-help strong { grid-column: 1 / -1; color: var(--ink); font-size: 14.5px; }
+.dl-help code {
+  grid-column: 1 / 2; min-width: 0; overflow-x: auto;
+  font-family: var(--font-mono); font-size: 12.5px;
+  background: var(--bg-soft); border-radius: 8px; padding: 8px 10px;
+  color: var(--ink); white-space: nowrap;
+}
+.dl-help button {
+  font-family: var(--font-sans); font-size: 12.5px; font-weight: 600;
+  color: var(--accent); background: var(--accent-soft);
+  border: none; border-radius: 999px; padding: 7px 13px; cursor: pointer;
+}
+.dl-help button.copied { background: oklch(0.55 0.14 155); color: #fff; }
+.dl-help a { color: var(--accent); text-decoration: none; font-weight: 600; }
+.dl-help a:hover { text-decoration: underline; }
 .os-card.detected { box-shadow: 0 0 0 2px var(--accent), var(--shadow-1); }
 @keyframes cardFlash {
   0%, 100% { box-shadow: 0 0 0 2px var(--accent), var(--shadow-1); }
@@ -609,6 +647,10 @@ body.how-flat .how-stage { position: static; min-height: 0; display: block; }
   display: grid; grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px; margin-top: 20px;
 }
+.desktop-downloads--secondary { margin-top: 10px; }
+.desktop-downloads--secondary .desktop-download {
+  box-shadow: none; background: color-mix(in oklch, var(--bg-soft) 72%, white);
+}
 .desktop-download {
   display: flex; flex-direction: column; gap: 4px;
   min-width: 0; padding: 15px 16px; border-radius: 10px;
@@ -688,6 +730,9 @@ footer { background: var(--bg); border-top: 1px solid var(--line); margin-top: 0
   .step { padding: 0; }
   .step + .step { padding-left: 0; border-left: none; border-top: 1px solid var(--line); padding-top: 28px; }
   .dl-tab { padding: 9px 14px; font-size: 13px; }
+  .dl-help { grid-template-columns: 1fr; }
+  .dl-help code { grid-column: auto; white-space: normal; overflow-wrap: anywhere; }
+  .dl-help button { justify-self: start; }
   .cache-panel { padding: 36px 24px; }
   .hero { padding-top: 130px; }
   section { padding-top: 100px; }


### PR DESCRIPTION
## Summary
- Use immutable versioned desktop download URLs and refresh them from the published manifest between site rebuilds.
- Expand desktop download choices for macOS, Windows, and Linux so users can pick the right package more easily.
- Add macOS quarantine warning guidance with a copyable Terminal command and a detailed docs anchor.

## Verification
- `npx astro build`
- `git diff --check`
- Confirmed source links no longer use `latest/Reasonix*` fixed asset URLs.