### PR TITLE
Backfill MCP servers into global config / 将 MCP 服务器补齐到全局配置

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -426,6 +426,8 @@ func (a *App) restoreOrBuildTabs() {
 	// freshly written config (including the user's default_model) is
 	// picked up by Load instead of falling back to built-in defaults.
 	_, _ = config.MigrateLegacyIfNeeded()
+	f := loadTabsFile()
+	_, _ = config.MigrateMCPToUserConfigOnUpgrade(desktopMCPMigrationRoots(f))
 	_, _ = config.ResetOfficialProviderPricingOnUpgrade(config.UserConfigPath())
 
 	// Load i18n from the first available config.
@@ -439,7 +441,6 @@ func (a *App) restoreOrBuildTabs() {
 		i18n.DetectLanguage(lang)
 	}
 
-	f := loadTabsFile()
 	if len(f.Tabs) > 0 {
 		toBuild := make([]*WorkspaceTab, 0, len(f.Tabs))
 		for _, entry := range f.Tabs {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -427,8 +427,8 @@ func (a *App) restoreOrBuildTabs() {
 	// picked up by Load instead of falling back to built-in defaults.
 	_, _ = config.MigrateLegacyIfNeeded()
 	f := loadTabsFile()
-	_, _ = config.MigrateMCPToUserConfigOnUpgrade(desktopMCPMigrationRoots(f))
 	_, _ = config.ResetOfficialProviderPricingOnUpgrade(config.UserConfigPath())
+	_, _ = config.MigrateMCPToUserConfigOnUpgrade(desktopMCPMigrationRoots(f))
 
 	// Load i18n from the first available config.
 	// Prefer DesktopLanguage (desktop UI setting) over Language (CLI setting),

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1993,6 +1993,31 @@ func loadTabsFile() desktopTabsFile {
 	return f
 }
 
+func desktopMCPMigrationRoots(tabs desktopTabsFile) []string {
+	seen := map[string]bool{}
+	var roots []string
+	add := func(root string) {
+		root = normalizeProjectRoot(root)
+		if root == "" || seen[root] {
+			return
+		}
+		seen[root] = true
+		roots = append(roots, root)
+	}
+	if cur := loadWorkspace(); cur != "" {
+		add(cur)
+	}
+	for _, entry := range tabs.Tabs {
+		if entry.Scope == "project" {
+			add(entry.WorkspaceRoot)
+		}
+	}
+	for _, project := range loadProjectsFile().Projects {
+		add(project.Root)
+	}
+	return roots
+}
+
 func loadProjectsFile() desktopProjectFile {
 	path := filepath.Join(desktopConfigDir(), desktopProjectsFile)
 	b, err := os.ReadFile(path)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2007,6 +2007,9 @@ func desktopMCPMigrationRoots(tabs desktopTabsFile) []string {
 	if cur := loadWorkspace(); cur != "" {
 		add(cur)
 	}
+	for _, root := range loadWorkspaces() {
+		add(root)
+	}
 	for _, entry := range tabs.Tabs {
 		if entry.Scope == "project" {
 			add(entry.WorkspaceRoot)

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -65,6 +66,47 @@ func TestSaveWorkspaceOnlyRemembersLastWorkspace(t *testing.T) {
 	}
 	if got := loadWorkspaces(); len(got) != 0 {
 		t.Fatalf("saveWorkspace should not maintain legacy workspace list, got %v", got)
+	}
+}
+
+func TestDesktopMCPMigrationRootsIncludesLegacyWorkspaces(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	active := t.TempDir()
+	legacy := t.TempDir()
+	tabRoot := t.TempDir()
+	projectRoot := t.TempDir()
+
+	saveWorkspace(active)
+	if err := os.MkdirAll(filepath.Dir(workspaceListPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, err := json.Marshal([]string{legacy, active, legacy})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workspaceListPath(), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveProjectsFile(desktopProjectFile{Projects: []desktopProject{{Root: projectRoot}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	roots := desktopMCPMigrationRoots(desktopTabsFile{
+		Tabs: []desktopTabEntry{{Scope: "project", WorkspaceRoot: tabRoot}},
+	})
+	want := []string{
+		normalizeProjectRoot(active),
+		normalizeProjectRoot(legacy),
+		normalizeProjectRoot(tabRoot),
+		normalizeProjectRoot(projectRoot),
+	}
+	if len(roots) != len(want) {
+		t.Fatalf("roots len = %d, want %d: %+v", len(roots), len(want), roots)
+	}
+	for i, root := range want {
+		if roots[i] != root {
+			t.Fatalf("roots[%d] = %q, want %q; roots=%+v", i, roots[i], root, roots)
+		}
 	}
 }
 

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -86,6 +86,14 @@ configured credential store / Reasonix home when the new destination does not
 already exist. If the new global config already exists, it wins and legacy
 config files are only kept as compatibility fallbacks.
 
+Starting in **v1.9.1**, Reasonix also backfills MCP servers from known legacy
+paths, legacy `config.json`, desktop-registered projects, and restored tab
+projects into the global `<Reasonix home>/config.toml`. Existing global
+`[[plugins]]` entries win by name, so project or legacy entries never overwrite a
+server the user already configured globally. Source files are left untouched, and
+the backfill writes a one-time marker so a user-deleted global MCP server is not
+recreated repeatedly from an old project config.
+
 ## Manual Migration Rescue
 
 If Reasonix has already created the new home directory but some legacy data was

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -73,6 +73,12 @@ Windows:     %APPDATA%\reasonix\config.toml
 
 旧 credentials、memory 文件和 sessions 也会在新目标不存在时导入到配置的 credential store / Reasonix home。若新的全局配置已经存在，则新配置优先；旧配置只作为兼容 fallback 保留。
 
+从 **v1.9.1** 开始，Reasonix 还会在升级时把已知旧路径、legacy `config.json`、
+桌面端已登记项目和恢复 tabs 对应项目里的 MCP 配置汇总补齐到全局
+`<Reasonix home>/config.toml`。已有的全局 `[[plugins]]` 按名称优先，不会被旧
+配置或项目配置覆盖；源文件会保留不变。该补齐会写入一次性 marker，避免用户之后
+主动删除某个全局 MCP 时又被旧项目配置反复恢复。
+
 ## 手动补救迁移
 
 如果 Reasonix 已经创建了新的 home 目录，但当时旧数据还不在可扫描路径里；或者先打开了桌面端，导致自动迁移没有把旧路径数据补齐，可以在任一前端运行补救命令：

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -117,6 +117,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// written config + ~/.env are picked up this same boot. CLI Run also calls this
 	// before config-only commands; this call stays as the shared frontend fallback.
 	migrated, migErr := config.MigrateLegacyIfNeeded()
+	migratedMCP, mcpMigErr := config.MigrateMCPToUserConfigOnUpgrade([]string{root})
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
 		return nil, err
@@ -155,6 +156,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "config migration from ~/.reasonix failed: " + migErr.Error()})
 	} else if migrated != nil {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: migrated.Notice()})
+	}
+	if mcpMigErr != nil {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "MCP global config migration failed: " + mcpMigErr.Error()})
+	} else if migratedMCP != nil && migratedMCP.Added > 0 {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("MCP migration: imported %d server(s) into %s", migratedMCP.Added, migratedMCP.To)})
 	}
 	migration.MigrateLegacyMemorySources(sink)
 	migration.MigrateLegacySessionSources(sink)

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -117,7 +117,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	// written config + ~/.env are picked up this same boot. CLI Run also calls this
 	// before config-only commands; this call stays as the shared frontend fallback.
 	migrated, migErr := config.MigrateLegacyIfNeeded()
-	migratedMCP, mcpMigErr := config.MigrateMCPToUserConfigOnUpgrade([]string{root})
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
 		return nil, err
@@ -156,11 +155,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "config migration from ~/.reasonix failed: " + migErr.Error()})
 	} else if migrated != nil {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: migrated.Notice()})
-	}
-	if mcpMigErr != nil {
-		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "MCP global config migration failed: " + mcpMigErr.Error()})
-	} else if migratedMCP != nil && migratedMCP.Added > 0 {
-		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("MCP migration: imported %d server(s) into %s", migratedMCP.Added, migratedMCP.To)})
 	}
 	migration.MigrateLegacyMemorySources(sink)
 	migration.MigrateLegacySessionSources(sink)

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -95,6 +95,7 @@ func (f *acpFactory) SessionConfigState(_ context.Context, p acp.SessionConfigSt
 		return acp.SessionConfigState{}, fmt.Errorf("session cwd must be an absolute path: %s", root)
 	}
 	_, _ = config.MigrateLegacyIfNeeded()
+	_, _ = config.MigrateMCPToUserConfigOnUpgrade([]string{root})
 	cfg, err := config.LoadForRoot(root)
 	if err != nil {
 		return acp.SessionConfigState{}, err

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -154,6 +154,11 @@ func migrateLegacyConfigForCLI() {
 	if _, err := config.MigrateLegacyIfNeeded(); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: config migration failed:", err)
 	}
+	if wd, err := os.Getwd(); err == nil {
+		if _, err := config.MigrateMCPToUserConfigOnUpgrade([]string{wd}); err != nil {
+			fmt.Fprintln(os.Stderr, "warning: MCP config migration failed:", err)
+		}
+	}
 }
 
 func configureCLIThemeFromConfig() {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -154,6 +154,9 @@ func migrateLegacyConfigForCLI() {
 	if _, err := config.MigrateLegacyIfNeeded(); err != nil {
 		fmt.Fprintln(os.Stderr, "warning: config migration failed:", err)
 	}
+}
+
+func migrateMCPConfigForCLIWorkspace() {
 	if wd, err := os.Getwd(); err == nil {
 		if _, err := config.MigrateMCPToUserConfigOnUpgrade([]string{wd}); err != nil {
 			fmt.Fprintln(os.Stderr, "warning: MCP config migration failed:", err)
@@ -190,6 +193,7 @@ func configureCLIThemeFromConfigNoProbe() {
 // the agent's typed event stream — runAgent passes a TextSink that renders to
 // stdout, the TUI passes an event-channel sink so events become tea.Msgs.
 func setup(ctx context.Context, modelName string, maxStepsOverride int, requireKey bool, sink event.Sink) (*control.Controller, error) {
+	migrateMCPConfigForCLIWorkspace()
 	return boot.Build(ctx, boot.Options{
 		Model:      modelName,
 		MaxSteps:   maxStepsOverride,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -129,6 +129,40 @@ func isolateCLIConfigHome(t *testing.T) string {
 	return home
 }
 
+func TestMCPMigrationWaitsForCLIWorkspace(t *testing.T) {
+	isolateCLIConfigHome(t)
+	cwd := mustGetwd(t)
+	if err := os.WriteFile(filepath.Join(cwd, "reasonix.toml"), []byte(`
+[[plugins]]
+name = "cwd-project"
+command = "cwd-project-bin"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	migrateLegacyConfigForCLI()
+	if cfg := config.LoadForEdit(config.UserConfigPath()); hasPluginNamed(cfg, "cwd-project") {
+		t.Fatalf("early CLI legacy migration imported the cwd project plugin: %+v", cfg.Plugins)
+	}
+
+	migrateMCPConfigForCLIWorkspace()
+	if cfg := config.LoadForEdit(config.UserConfigPath()); !hasPluginNamed(cfg, "cwd-project") {
+		t.Fatalf("workspace-aware CLI migration did not import project plugin: %+v", cfg.Plugins)
+	}
+}
+
+func hasPluginNamed(cfg *config.Config, name string) bool {
+	if cfg == nil {
+		return false
+	}
+	for _, plugin := range cfg.Plugins {
+		if plugin.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
 func TestMetadataCommandsDoNotProbeTerminalTheme(t *testing.T) {
 	defer func(prev func() (terminalRGB, bool)) {
 		queryTerminalBackgroundForTheme = prev

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1726,16 +1726,33 @@ func mergeTOMLProviderAccess(paths []string) ([]string, bool, error) {
 // of resetting to defaults. .env is loaded so api_key_env resolution works while
 // the wizard decides which keys are still missing.
 func LoadForEdit(path string) *Config {
+	cfg, err := loadForEditStrict(path)
+	if err == nil {
+		return cfg
+	}
+	slog.Warn("config: load for edit failed, using defaults", "path", path, "err", err)
+	loadDotEnv()
+	cfg = Default()
+	normalizeConfigForEdit(cfg)
+	return cfg
+}
+
+func loadForEditStrict(path string) (*Config, error) {
 	loadDotEnv()
 	cfg := Default()
 	if _, err := os.Stat(path); err == nil {
 		if err := migrateLegacyMCPTiersFile(path); err != nil {
-			slog.Warn("config: legacy mcp tier migration failed", "path", path, "err", err)
+			return nil, fmt.Errorf("config %s: %w", path, err)
 		}
 	}
 	if err := mergeFile(cfg, path); err != nil {
-		slog.Warn("config: load for edit failed, using defaults", "path", path, "err", err)
+		return nil, err
 	}
+	normalizeConfigForEdit(cfg)
+	return cfg, nil
+}
+
+func normalizeConfigForEdit(cfg *Config) {
 	normalizePluginCommandLines(cfg)
 	normalizeLegacyEffort(cfg)
 	normalizeLegacyMCPTiers(cfg)
@@ -1744,7 +1761,6 @@ func LoadForEdit(path string) *Config {
 	applyDeepSeekOfficialDefaultPricing(cfg)
 	backfillDeepSeekOfficialPrices(cfg)
 	normalizeEffortConfig(cfg)
-	return cfg
 }
 
 // mergeFile decodes a TOML file onto cfg if it exists. An absent file is not an error.

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/BurntSushi/toml"
 )
 
 // legacyConfig is the subset of the v0.x (~/.reasonix/config.json) schema this
@@ -53,6 +55,14 @@ type MigrationResult struct {
 	KeyToEnv bool
 	Plugins  int
 	Warnings []string
+}
+
+// MCPGlobalMigrationResult summarizes the v1.9.1 MCP backfill that lifts MCP
+// servers from legacy and project-local sources into the user-global config.
+type MCPGlobalMigrationResult struct {
+	To      string
+	Added   int
+	Sources int
 }
 
 func (r *MigrationResult) Notice() string {
@@ -150,6 +160,169 @@ func MigrateLegacyIfNeeded() (*MigrationResult, error) {
 		}
 	}
 	return res, credErr
+}
+
+// MigrateMCPToUserConfigOnUpgrade runs a one-time best-effort backfill for the
+// v1.9.1 desktop/CLI upgrade: MCP servers found in legacy TOML, legacy v0.x JSON,
+// and known project roots are copied into the user-global config so the MCP
+// settings page is stable across Global/project tabs. Existing global entries win
+// on name collisions, and source files are left untouched.
+func MigrateMCPToUserConfigOnUpgrade(projectRoots []string) (*MCPGlobalMigrationResult, error) {
+	marker := mcpGlobalMigrationMarkerPath()
+	if marker == "" {
+		return nil, nil
+	}
+	if _, err := os.Stat(marker); err == nil {
+		return nil, nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+
+	res, err := migrateMCPToUserConfig(projectRoots)
+	if err != nil {
+		return res, err
+	}
+	if res == nil {
+		return nil, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(marker), 0o755); err != nil {
+		return res, err
+	}
+	if err := os.WriteFile(marker, []byte("v1\n"), 0o644); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+func migrateMCPToUserConfig(projectRoots []string) (*MCPGlobalMigrationResult, error) {
+	dest := userConfigPath()
+	if dest == "" {
+		return nil, nil
+	}
+	userCfg := LoadForEdit(dest)
+	have := make(map[string]bool, len(userCfg.Plugins))
+	for _, p := range userCfg.Plugins {
+		if name := strings.TrimSpace(p.Name); name != "" {
+			have[name] = true
+		}
+	}
+
+	result := &MCPGlobalMigrationResult{To: dest}
+	addEntries := func(entries []PluginEntry) {
+		if len(entries) == 0 {
+			return
+		}
+		result.Sources++
+		for _, entry := range entries {
+			entry, _ = NormalizePluginCommandLine(entry)
+			name := strings.TrimSpace(entry.Name)
+			if name == "" || have[name] || validatePlugin(entry) != nil {
+				continue
+			}
+			userCfg.Plugins = append(userCfg.Plugins, entry)
+			have[name] = true
+			result.Added++
+		}
+	}
+
+	home, _ := os.UserHomeDir()
+	for _, path := range mcpMigrationLegacyTOMLPaths(dest, home) {
+		addEntries(loadPluginEntriesFromTOML(path))
+	}
+	addEntries(loadLegacyConfigPlugins(legacyConfigPath()))
+	for _, root := range normalizedMCPMigrationRoots(projectRoots) {
+		addEntries(loadPluginEntriesFromTOML(filepath.Join(root, "reasonix.toml")))
+		if entries, err := loadMCPJSON(filepath.Join(root, mcpJSONFile)); err == nil {
+			addEntries(entries)
+		}
+	}
+
+	if result.Sources == 0 {
+		return nil, nil
+	}
+	if result.Added > 0 {
+		userCfg.ConfigVersion = Default().ConfigVersion
+		if err := userCfg.SaveTo(dest); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
+}
+
+func mcpGlobalMigrationMarkerPath() string {
+	dir := userSupportDir()
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "mcp-global-migration-v1")
+}
+
+func mcpMigrationLegacyTOMLPaths(dest, home string) []string {
+	var paths []string
+	for _, path := range legacyTOMLPaths(dest, home) {
+		if path == "" || samePath(path, dest) {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	return paths
+}
+
+func loadPluginEntriesFromTOML(path string) []PluginEntry {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil
+	}
+	var cfg Config
+	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+		return nil
+	}
+	out := make([]PluginEntry, 0, len(cfg.Plugins))
+	for _, p := range cfg.Plugins {
+		p, _ = NormalizePluginCommandLine(p)
+		out = append(out, p)
+	}
+	return out
+}
+
+func loadLegacyConfigPlugins(path string) []PluginEntry {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var legacy legacyConfig
+	data = bytes.TrimPrefix(data, []byte{0xEF, 0xBB, 0xBF})
+	if err := json.Unmarshal(data, &legacy); err != nil {
+		return nil
+	}
+	return legacyPlugins(legacy)
+}
+
+func normalizedMCPMigrationRoots(roots []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(root); err == nil {
+			root = abs
+		}
+		root = filepath.Clean(root)
+		if seen[root] {
+			continue
+		}
+		seen[root] = true
+		out = append(out, root)
+	}
+	return out
 }
 
 func migrateLegacyCredentialsIfNeeded() error {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -163,8 +163,8 @@ func MigrateLegacyIfNeeded() (*MigrationResult, error) {
 }
 
 // MigrateMCPToUserConfigOnUpgrade runs a one-time best-effort backfill for the
-// v1.9.1 desktop/CLI upgrade: MCP servers found in legacy TOML, legacy v0.x JSON,
-// and known project roots are copied into the user-global config so the MCP
+// v1.9.1 desktop/CLI upgrade: MCP servers found in legacy TOML, known project
+// roots, and legacy v0.x JSON are copied into the user-global config so the MCP
 // settings page is stable across Global/project tabs. Existing global entries win
 // on name collisions, and source files are left untouched.
 func MigrateMCPToUserConfigOnUpgrade(projectRoots []string) (*MCPGlobalMigrationResult, error) {
@@ -199,7 +199,10 @@ func migrateMCPToUserConfig(projectRoots []string) (*MCPGlobalMigrationResult, e
 	if dest == "" {
 		return nil, nil
 	}
-	userCfg := LoadForEdit(dest)
+	userCfg, err := loadForEditStrict(dest)
+	if err != nil {
+		return nil, err
+	}
 	have := make(map[string]bool, len(userCfg.Plugins))
 	for _, p := range userCfg.Plugins {
 		if name := strings.TrimSpace(p.Name); name != "" {
@@ -229,19 +232,18 @@ func migrateMCPToUserConfig(projectRoots []string) (*MCPGlobalMigrationResult, e
 	for _, path := range mcpMigrationLegacyTOMLPaths(dest, home) {
 		addEntries(loadPluginEntriesFromTOML(path))
 	}
-	addEntries(loadLegacyConfigPlugins(legacyConfigPath()))
 	for _, root := range normalizedMCPMigrationRoots(projectRoots) {
 		addEntries(loadPluginEntriesFromTOML(filepath.Join(root, "reasonix.toml")))
 		if entries, err := loadMCPJSON(filepath.Join(root, mcpJSONFile)); err == nil {
 			addEntries(entries)
 		}
 	}
+	addEntries(loadLegacyConfigPlugins(legacyConfigPath()))
 
 	if result.Sources == 0 {
 		return nil, nil
 	}
 	if result.Added > 0 {
-		userCfg.ConfigVersion = Default().ConfigVersion
 		if err := userCfg.SaveTo(dest); err != nil {
 			return result, err
 		}

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -232,6 +232,116 @@ func TestMigrateSkipsWhenDestExists(t *testing.T) {
 	}
 }
 
+func TestMigrateMCPToUserConfigOnUpgradeCollectsKnownSources(t *testing.T) {
+	srcJSON, dest, _ := legacyHome(t)
+	writeLegacy(t, srcJSON, `{
+		"mcpServers": {
+			"legacy-json": {"command": "legacy-json-bin"},
+			"disabled-json": {"command": "disabled-json-bin", "disabled": true},
+			"global": {"command": "legacy-should-not-win"}
+		}
+	}`)
+	writeLegacy(t, legacyUserConfigPath(), `
+[[plugins]]
+name = "legacy-toml"
+command = "legacy-toml-bin"
+`)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`
+[[plugins]]
+name = "global"
+command = "global-bin"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectTOML := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectTOML, "reasonix.toml"), []byte(`
+[[plugins]]
+name = "project-toml"
+command = "project-toml-bin"
+
+[[plugins]]
+name = "global"
+command = "project-should-not-win"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectJSON := t.TempDir()
+	if err := os.WriteFile(filepath.Join(projectJSON, ".mcp.json"), []byte(`{
+		"mcpServers": {
+			"project-json": {"command": "project-json-bin"}
+		}
+	}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := MigrateMCPToUserConfigOnUpgrade([]string{projectTOML, projectJSON, projectTOML})
+	if err != nil {
+		t.Fatalf("MigrateMCPToUserConfigOnUpgrade: %v", err)
+	}
+	if res == nil || res.Added != 5 {
+		t.Fatalf("migration result = %+v, want 5 added", res)
+	}
+	cfg := LoadForEdit(dest)
+	byName := map[string]PluginEntry{}
+	for _, p := range cfg.Plugins {
+		byName[p.Name] = p
+	}
+	for name, command := range map[string]string{
+		"global":        "global-bin",
+		"disabled-json": "disabled-json-bin",
+		"legacy-toml":   "legacy-toml-bin",
+		"legacy-json":   "legacy-json-bin",
+		"project-toml":  "project-toml-bin",
+		"project-json":  "project-json-bin",
+	} {
+		if byName[name].Command != command {
+			t.Fatalf("%s command = %q, want %q; plugins=%+v", name, byName[name].Command, command, cfg.Plugins)
+		}
+	}
+	if p := byName["disabled-json"]; p.AutoStart == nil || *p.AutoStart {
+		t.Fatalf("disabled legacy MCP should migrate with auto_start=false: %+v", p)
+	}
+	if _, err := os.Stat(mcpGlobalMigrationMarkerPath()); err != nil {
+		t.Fatalf("migration marker missing: %v", err)
+	}
+
+	lateProject := t.TempDir()
+	if err := os.WriteFile(filepath.Join(lateProject, "reasonix.toml"), []byte(`
+[[plugins]]
+name = "late"
+command = "late-bin"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	res, err = MigrateMCPToUserConfigOnUpgrade([]string{lateProject})
+	if err != nil {
+		t.Fatalf("second migration: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("second migration result = %+v, want nil due marker", res)
+	}
+	if got := LoadForEdit(dest); len(got.Plugins) != len(cfg.Plugins) {
+		t.Fatalf("second migration changed plugins: %+v", got.Plugins)
+	}
+}
+
+func TestMigrateMCPToUserConfigOnUpgradeDoesNotMarkEmptyScan(t *testing.T) {
+	_, _, _ = legacyHome(t)
+	res, err := MigrateMCPToUserConfigOnUpgrade(nil)
+	if err != nil {
+		t.Fatalf("MigrateMCPToUserConfigOnUpgrade: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("result = %+v, want nil", res)
+	}
+	if _, err := os.Stat(mcpGlobalMigrationMarkerPath()); !os.IsNotExist(err) {
+		t.Fatalf("empty scan should not write marker, stat err=%v", err)
+	}
+}
+
 func TestMigrateImportsLegacyV1TOMLBeforeJSON(t *testing.T) {
 	srcJSON, dest, _ := legacyHome(t)
 	legacyTOML := filepath.Join(filepath.Dir(dest), "reasonix.toml")

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -238,6 +238,7 @@ func TestMigrateMCPToUserConfigOnUpgradeCollectsKnownSources(t *testing.T) {
 		"mcpServers": {
 			"legacy-json": {"command": "legacy-json-bin"},
 			"disabled-json": {"command": "disabled-json-bin", "disabled": true},
+			"project-json": {"command": "legacy-json-should-not-win"},
 			"global": {"command": "legacy-should-not-win"}
 		}
 	}`)
@@ -339,6 +340,71 @@ func TestMigrateMCPToUserConfigOnUpgradeDoesNotMarkEmptyScan(t *testing.T) {
 	}
 	if _, err := os.Stat(mcpGlobalMigrationMarkerPath()); !os.IsNotExist(err) {
 		t.Fatalf("empty scan should not write marker, stat err=%v", err)
+	}
+}
+
+func TestMigrateMCPToUserConfigOnUpgradeRefusesMalformedGlobalConfig(t *testing.T) {
+	srcJSON, dest, _ := legacyHome(t)
+	writeLegacy(t, srcJSON, `{
+		"mcpServers": {
+			"legacy-json": {"command": "legacy-json-bin"}
+		}
+	}`)
+	const malformed = "[[plugins]\nname = \"broken\"\n"
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(malformed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := MigrateMCPToUserConfigOnUpgrade(nil)
+	if err == nil {
+		t.Fatal("expected malformed global config to abort MCP migration")
+	}
+	if res != nil {
+		t.Fatalf("result = %+v, want nil", res)
+	}
+	if got, readErr := os.ReadFile(dest); readErr != nil {
+		t.Fatalf("read dest: %v", readErr)
+	} else if string(got) != malformed {
+		t.Fatalf("malformed config was overwritten:\n%s", got)
+	}
+	if _, statErr := os.Stat(mcpGlobalMigrationMarkerPath()); !os.IsNotExist(statErr) {
+		t.Fatalf("failed migration must not write marker, stat err=%v", statErr)
+	}
+}
+
+func TestMigrateMCPToUserConfigOnUpgradePreservesConfigVersion(t *testing.T) {
+	_, dest, _ := legacyHome(t)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte("config_version = 1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	project := t.TempDir()
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
+[[plugins]]
+name = "project"
+command = "project-bin"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := MigrateMCPToUserConfigOnUpgrade([]string{project})
+	if err != nil {
+		t.Fatalf("MigrateMCPToUserConfigOnUpgrade: %v", err)
+	}
+	if res == nil || res.Added != 1 {
+		t.Fatalf("result = %+v, want 1 added", res)
+	}
+	got, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	if !strings.Contains(string(got), "config_version = 1") {
+		t.Fatalf("MCP migration should not advance config_version:\n%s", got)
 	}
 }
 

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -241,7 +241,7 @@ func TestMigrateMCPToUserConfigOnUpgradeCollectsKnownSources(t *testing.T) {
 			"global": {"command": "legacy-should-not-win"}
 		}
 	}`)
-	writeLegacy(t, legacyUserConfigPath(), `
+	writeLegacy(t, filepath.Join(filepath.Dir(dest), "reasonix.toml"), `
 [[plugins]]
 name = "legacy-toml"
 command = "legacy-toml-bin"


### PR DESCRIPTION
## Summary
- add a one-time upgrade backfill that copies MCP servers from legacy config, known desktop projects, restored tab projects, project `reasonix.toml`, and project `.mcp.json` into the global config
- preserve existing global MCP entries on name collisions and write a marker so deleted global servers are not repeatedly restored
- document the v1.9.1 MCP backfill behavior in English and Chinese config path docs

## Cache / tool surface note
- This can restore MCP tools that users already configured but 1.9.0 no longer showed globally, so the provider-visible tool list may grow back to the intended user configuration. The migration is one-time and deterministic by name to avoid repeated churn.

## Verification
- `go test ./internal/config`
- `go test ./internal/boot ./internal/cli ./internal/serve`
- `go test ./...` from the desktop module
