### PR TITLE
Fix workbench titlebar shadow / 修复工作台标题栏残留阴影

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -12,6 +12,8 @@ import {
   Command,
   Download,
   SquarePen,
+  PanelLeft,
+  PanelRight,
   FileDown,
   FileImage,
   FileText,
@@ -2316,6 +2318,7 @@ export default function App() {
     ? [topicbarWorkspaceLabel, topicbarImSourceLabel, sidebarImScopeLabel(sidebarImDetailConnection, t)].filter(Boolean).join(" · ")
     : [topicbarWorkspacePath || topicbarWorkspaceLabel, topicbarImSourceLabel].filter(Boolean).join(" · ");
   const sidebarWorkbench = desktopLayoutStyle === "workbench";
+  const workbenchChromeHidden = sidebarWorkbench;
   const sidebarClassName = [
     "sidebar",
     sidebarCollapsed ? "sidebar--collapsed" : "",
@@ -2339,6 +2342,7 @@ export default function App() {
         className={[
           "layout",
           sidebarWorkbench ? "layout--workbench" : "",
+          workbenchChromeHidden ? "layout--workbench-chrome-hidden" : "",
           sidebarCollapsed ? "layout--sidebar-collapsed" : "",
           sidebarResizing ? "layout--resizing layout--sidebar-resizing" : "",
           workspacePanelGridOpen ? "layout--workspace-open" : "",
@@ -2349,31 +2353,33 @@ export default function App() {
           .join(" ")}
         style={layoutStyle}
       >
-        <AppChrome
-          platform={desktopPlatform}
-          browserPreviewChrome={browserPreviewChrome}
-          workbenchChrome={sidebarWorkbench}
-          tabs={visibleTabs}
-          activeTabId={visibleTabId}
-          revealActiveSignal={tabRevealSignal}
-          commandCompact={true}
-          sidebarTogglePressed={sidebarTogglePressed}
-          sidebarExpandBlocked={sidebarExpandBlocked}
-          sidebarCollapsed={sidebarCollapsed}
-          sidebarToggleTitle={sidebarToggleTitle}
-          workspacePanelMaximized={workspacePanelMaximized}
-          workspacePanelRenderable={workspacePanelRenderable}
-          workspaceTogglePressed={workspaceTogglePressed}
-          workspacePanelLabel={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}
-          onToggleSidebar={toggleSidebar}
-          onToggleWorkspacePanel={toggleWorkspacePanel}
-          onTabChange={(id) => void handleTabChange(id)}
-          onTabClose={(id) => void handleTabClose(id)}
-          onTabsClose={(ids, nextActiveTabId) => void handleTabsClose(ids, nextActiveTabId)}
-          onTabsReorder={(ids) => void handleTabsReorder(ids)}
-          onNewTab={() => void handleNewTab()}
-          onOpenPalette={() => void openPalette()}
-        />
+        {!workbenchChromeHidden && (
+          <AppChrome
+            platform={desktopPlatform}
+            browserPreviewChrome={browserPreviewChrome}
+            workbenchChrome={sidebarWorkbench}
+            tabs={visibleTabs}
+            activeTabId={visibleTabId}
+            revealActiveSignal={tabRevealSignal}
+            commandCompact={true}
+            sidebarTogglePressed={sidebarTogglePressed}
+            sidebarExpandBlocked={sidebarExpandBlocked}
+            sidebarCollapsed={sidebarCollapsed}
+            sidebarToggleTitle={sidebarToggleTitle}
+            workspacePanelMaximized={workspacePanelMaximized}
+            workspacePanelRenderable={workspacePanelRenderable}
+            workspaceTogglePressed={workspaceTogglePressed}
+            workspacePanelLabel={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}
+            onToggleSidebar={toggleSidebar}
+            onToggleWorkspacePanel={toggleWorkspacePanel}
+            onTabChange={(id) => void handleTabChange(id)}
+            onTabClose={(id) => void handleTabClose(id)}
+            onTabsClose={(ids, nextActiveTabId) => void handleTabsClose(ids, nextActiveTabId)}
+            onTabsReorder={(ids) => void handleTabsReorder(ids)}
+            onNewTab={() => void handleNewTab()}
+            onOpenPalette={() => void openPalette()}
+          />
+        )}
         <a className="skip-to-composer" href="#composer-input">
           {t("shortcuts.skipToComposer")}
         </a>
@@ -2531,6 +2537,24 @@ export default function App() {
         <section className="chat-pane">
           <>
           <header className="topicbar">
+            {workbenchChromeHidden && (
+              <Tooltip label={sidebarToggleTitle}>
+                <button
+                  className={[
+                    "topicbar__chrome-btn",
+                    sidebarExpandBlocked ? "topicbar__chrome-btn--blocked" : "",
+                    sidebarTogglePressed ? "topicbar__chrome-btn--pressed" : "",
+                  ].filter(Boolean).join(" ")}
+                  type="button"
+                  onClick={sidebarExpandBlocked ? undefined : toggleSidebar}
+                  aria-label={sidebarToggleTitle}
+                  aria-pressed={!sidebarCollapsed}
+                  aria-disabled={sidebarExpandBlocked}
+                >
+                  <PanelLeft size={15} />
+                </button>
+              </Tooltip>
+            )}
             <div className="topicbar__identity">
               <div className="topicbar__title-row">
                 {topicbarEditing ? (
@@ -2581,6 +2605,24 @@ export default function App() {
             </div>
             <div className="topicbar__spacer" />
             <div className="topicbar__actions">
+              {workbenchChromeHidden && (
+                <Tooltip label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}>
+                  <button
+                    className={[
+                      "topicbar__chrome-btn",
+                      "topicbar__chrome-btn--workspace",
+                      workspacePanelRenderable ? "topicbar__chrome-btn--active" : "",
+                      workspaceTogglePressed ? "topicbar__chrome-btn--pressed" : "",
+                    ].filter(Boolean).join(" ")}
+                    type="button"
+                    onClick={toggleWorkspacePanel}
+                    aria-label={workspacePanelRenderable ? t("rightDock.collapse") : t("rightDock.expand")}
+                    aria-pressed={workspacePanelRenderable}
+                  >
+                    <PanelRight size={15} />
+                  </button>
+                </Tooltip>
+              )}
               {!sidebarImDetailConnection && (
               <>
               <Tooltip label={t("topicBar.copyAll")}>

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const testDir = dirname(fileURLToPath(import.meta.url));
+const appSource = readFileSync(resolve(testDir, "../App.tsx"), "utf8");
 const appChromeSource = readFileSync(resolve(testDir, "../components/AppChrome.tsx"), "utf8");
 const stylesSource = readFileSync(resolve(testDir, "../styles.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
 
@@ -103,6 +104,21 @@ ok(
   "AppChrome renders the command search as a fixed chrome tool",
 );
 
+ok(
+  /workbenchChromeHidden\s*=\s*sidebarWorkbench/.test(appSource),
+  "workbench chrome is hidden for every desktop platform",
+);
+
+ok(
+  /\{!workbenchChromeHidden && \(/.test(appSource),
+  "workbench skips rendering the top AppChrome row",
+);
+
+ok(
+  /topicbar__chrome-btn/.test(appSource),
+  "workbench keeps chrome controls in the topic bar",
+);
+
 for (const selector of [
   ".app--darwin .app-chrome--tabs",
   ":root[data-theme-style] .app--darwin .app-chrome--tabs",
@@ -126,6 +142,76 @@ for (const selector of [
     `${selector} reserves right-dock width before rendering tabs`,
   );
 }
+
+for (const selector of [
+  ".layout--workbench-chrome-hidden",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden",
+]) {
+  ok(
+    finalDeclaration(selector, "--app-chrome-height") === "0px" &&
+      finalDeclaration(selector, "grid-template-rows") === "minmax(0, 1fr)" &&
+      finalDeclaration(selector, "background") === "var(--bg)",
+    `${selector} removes the workbench chrome row`,
+  );
+}
+
+ok(
+  finalDeclaration(":root[data-theme-style] .app--darwin .layout--workbench-chrome-hidden", "--app-chrome-height") === "0px" &&
+    finalDeclaration(".app--darwin .layout--workbench-chrome-hidden .sidebar--workbench", "padding-top") === "46px" &&
+    finalDeclaration(".app--darwin .layout--workbench-chrome-hidden.layout--sidebar-collapsed .topicbar", "padding-left") === "96px",
+  "macOS workbench leaves safe space for inset window controls",
+);
+
+for (const selector of [
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__action-btn",
+]) {
+  ok(
+    finalDeclaration(selector, "box-shadow") === "none",
+    `${selector} stays flat after removing the workbench chrome row`,
+  );
+}
+
+ok(
+  finalDeclaration(":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar", "background") === "var(--chat-bg)",
+  "workbench topic bar uses a flat chat background",
+);
+
+for (const selector of [
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__identity",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__title-row",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__title-row h1",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .tooltip-trigger:has(.topicbar__icon-btn)",
+]) {
+  ok(
+    finalDeclaration(selector, "background") === "transparent" &&
+      finalDeclaration(selector, "box-shadow") === "none" &&
+      finalDeclaration(selector, "filter") === "none",
+    `${selector} cannot paint residual title-row shadows in workbench mode`,
+  );
+}
+
+for (const selector of [
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn:hover",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn:focus-visible",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn:hover:not(.topicbar__chrome-btn--blocked)",
+  ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn:focus-visible:not(.topicbar__chrome-btn--blocked)",
+]) {
+  ok(
+    finalDeclaration(selector, "background") === "transparent",
+    `${selector} does not paint a hover block in workbench mode`,
+  );
+}
+
+ok(
+  finalDeclaration(".skip-to-composer", "box-shadow") === "none" &&
+    finalDeclaration(".skip-to-composer:focus-visible", "box-shadow")?.includes("0 12px 28px"),
+  "offscreen skip link does not leak its focus shadow into the workbench title area",
+);
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1595,6 +1595,24 @@ a[href] {
   display: none;
 }
 
+.layout--workbench-chrome-hidden {
+  --app-chrome-height: 0px;
+  grid-template-rows: minmax(0, 1fr);
+  background: var(--bg);
+}
+
+.layout--workbench-chrome-hidden .sidebar,
+.layout--workbench-chrome-hidden .chat-pane,
+.layout--workbench-chrome-hidden .workspace-panel-resizer,
+.layout--workbench-chrome-hidden .context-inspector,
+.layout--workbench-chrome-hidden .workbench-dock {
+  grid-row: 1;
+}
+
+.app--darwin .layout--workbench-chrome-hidden.layout--sidebar-collapsed .topicbar {
+  padding-left: 96px;
+}
+
 .sidebar {
   --sidebar-entry-content-inset: 12px;
   grid-row: 2;
@@ -7884,13 +7902,14 @@ a[href] {
   font-size: var(--font-control-small);
   font-weight: 650;
   text-decoration: none;
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
+  box-shadow: none;
 }
 
 .skip-to-composer:focus-visible {
   transform: translate(-50%, 0);
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
 }
 
 :where(button, a, input, textarea, select):focus-visible {
@@ -16030,6 +16049,44 @@ a[href] {
   --wails-draggable: no-drag;
 }
 
+.topicbar__chrome-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--fg-faint);
+  line-height: 1;
+  transition: color 0.12s, border-color 0.12s, background 0.12s, transform 0.12s;
+}
+
+.topicbar__chrome-btn:hover:not(.topicbar__chrome-btn--blocked),
+.topicbar__chrome-btn:focus-visible:not(.topicbar__chrome-btn--blocked) {
+  color: var(--fg);
+  border-color: var(--border);
+  background: var(--bg-elev);
+}
+
+.topicbar__chrome-btn--active {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 24%, var(--border));
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-elev));
+}
+
+.topicbar__chrome-btn--pressed {
+  transform: scale(0.94);
+}
+
+.topicbar__chrome-btn--blocked {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
 .topicbar__identity {
   flex: 1 1 auto;
   min-width: 0;
@@ -18936,8 +18993,18 @@ a[href] {
   background: var(--bg);
 }
 
+:root[data-theme-style] .layout--workbench-chrome-hidden {
+  --app-chrome-height: 0px;
+  grid-template-rows: minmax(0, 1fr);
+  background: var(--bg);
+}
+
 :root[data-theme-style] .app--darwin .layout {
   --app-chrome-height: 46px;
+}
+
+:root[data-theme-style] .app--darwin .layout--workbench-chrome-hidden {
+  --app-chrome-height: 0px;
 }
 
 :root[data-theme-style] .app-chrome,
@@ -19787,6 +19854,27 @@ a[href] {
   border-bottom: 1px solid var(--border-soft);
 }
 
+:root[data-theme-style] .topicbar__chrome-btn {
+  width: 30px;
+  min-width: 30px;
+  height: 28px;
+  border-radius: 7px;
+  color: var(--fg-dim);
+}
+
+:root[data-theme-style] .topicbar__chrome-btn:hover:not(.topicbar__chrome-btn--blocked),
+:root[data-theme-style] .topicbar__chrome-btn:focus-visible:not(.topicbar__chrome-btn--blocked) {
+  border-color: color-mix(in srgb, var(--fg-faint) 30%, var(--border));
+  background: var(--bg-elev-2);
+}
+
+:root[data-theme-style] .topicbar__chrome-btn--active {
+  color: var(--fg-dim);
+  border-color: var(--border);
+  background: var(--bg-elev);
+  box-shadow: var(--app-graphite-shadow);
+}
+
 :root[data-theme-style] .topicbar__action-btn--label {
   width: 30px;
   min-width: 30px;
@@ -19861,6 +19949,40 @@ a[href] {
   color: var(--fg);
   border-color: color-mix(in srgb, var(--fg-faint) 30%, var(--border));
   background: var(--bg-elev-2);
+}
+
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__action-btn {
+  box-shadow: none;
+}
+
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar {
+  background: var(--chat-bg);
+}
+
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__identity,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__title-row,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__title-row h1,
+:root[data-theme-style] .layout--workbench-chrome-hidden .tooltip-trigger:has(.topicbar__icon-btn) {
+  background: transparent;
+  box-shadow: none;
+  filter: none;
+}
+
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn {
+  background: transparent;
+  filter: none;
+}
+
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn:hover,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__icon-btn:focus-visible,
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn:hover:not(.topicbar__chrome-btn--blocked),
+:root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn:focus-visible:not(.topicbar__chrome-btn--blocked) {
+  border-color: transparent;
+  background: transparent;
 }
 
 :root[data-theme-style] .banner--update {
@@ -21321,6 +21443,10 @@ a[href] {
 .app--darwin .sidebar--workbench,
 .sidebar--workbench {
   padding: 14px 12px calc(10px + var(--statusbar-height));
+}
+
+.app--darwin .layout--workbench-chrome-hidden .sidebar--workbench {
+  padding-top: 46px;
 }
 
 .sidebar--workbench .sidebar__head {


### PR DESCRIPTION
## Summary
- Hide the desktop AppChrome row in workbench mode and move the sidebar/right-dock chrome controls into the topic bar.
- Keep workbench topic-bar controls flat by clearing residual background, shadow, and filter effects.
- Prevent the offscreen skip link from leaking its focus shadow into the visible title area while preserving the focus shadow for keyboard users.

## Verification
- npm run check:css
- npm run typecheck
- npx tsx src/__tests__/app-chrome-tabs.test.ts
- Browser CSS verification on the running desktop frontend dev server