### PR TITLE
fix(session): re-home project sessions stranded by version downgrade / 修复版本降级导致工程会话丢失

### DIFF
--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -281,13 +281,7 @@ func importJsonlSessions(entries []os.DirEntry, srcDir, globalDest string, hasEv
 		if !isMessageFormat(jsonlPath) {
 			continue
 		}
-		meta := readLegacyMeta(srcDir, base)
-		destDir := globalDest
-		if projectDir != nil && meta.Workspace != "" && dirExists(meta.Workspace) {
-			if d := projectDir(meta.Workspace); d != "" {
-				destDir = d
-			}
-		}
+		destDir, summary, copyBranchMeta := jsonlSessionDestDir(srcDir, jsonlPath, base, globalDest, projectDir)
 		dest := filepath.Join(destDir, base+".jsonl")
 		if _, err := os.Stat(dest); err == nil {
 			continue
@@ -299,10 +293,39 @@ func importJsonlSessions(entries []os.DirEntry, srcDir, globalDest string, hasEv
 		if srcInfo != nil {
 			_ = os.Chtimes(dest, srcInfo.ModTime(), srcInfo.ModTime())
 		}
-		recordImportedTitle(destDir, base, meta.Summary)
+		if copyBranchMeta {
+			copyBranchMetaSidecar(jsonlPath, dest)
+		}
+		recordImportedTitle(destDir, base, summary)
 		imported++
 	}
 	return imported
+}
+
+func jsonlSessionDestDir(srcDir, srcPath, base, globalDest string, projectDir func(string) string) (string, string, bool) {
+	if meta, ok, err := LoadBranchMeta(srcPath); err == nil && ok {
+		summary := strings.TrimSpace(meta.TopicTitle)
+		scope := meta.DefaultScope()
+		if projectDir != nil && scope == "project" && meta.WorkspaceRoot != "" && dirExists(meta.WorkspaceRoot) {
+			if d := projectDir(meta.WorkspaceRoot); d != "" {
+				return d, summary, true
+			}
+		}
+		// Explicit branch meta is newer than any stale v0.x sidecar. Preserve
+		// global branch metadata, but do not carry a dead project scope into the
+		// global directory when its workspace can no longer be resolved.
+		if meta.Scope != "" {
+			return globalDest, summary, scope == "global"
+		}
+	}
+	meta := readLegacyMeta(srcDir, base)
+	destDir := globalDest
+	if projectDir != nil && meta.Workspace != "" && dirExists(meta.Workspace) {
+		if d := projectDir(meta.Workspace); d != "" {
+			destDir = d
+		}
+	}
+	return destDir, meta.Summary, false
 }
 
 // migrateSubDirectory imports sessions from a project-scoped subdirectory
@@ -657,6 +680,7 @@ func rehomeStrandedSessions(srcDir, globalDest, marker string, projectDir func(s
 		return 0, nil
 	}
 	imported := 0
+	hadCopyFailure := false
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") ||
@@ -684,6 +708,7 @@ func rehomeStrandedSessions(srcDir, globalDest, marker string, projectDir func(s
 			continue // already routed on a previous boot
 		}
 		if err := transformAndCopyJsonl(srcPath, dest); err != nil {
+			hadCopyFailure = true
 			continue
 		}
 		_ = os.Chtimes(dest, info.ModTime(), info.ModTime()) // preserve resume ordering
@@ -691,10 +716,12 @@ func rehomeStrandedSessions(srcDir, globalDest, marker string, projectDir func(s
 		recordImportedTitle(destDir, base, summary)
 		imported++
 	}
-	// Advance the watermark so the next boot starts from here, regardless of
-	// whether anything matched this time.
-	now := time.Now()
-	_ = os.Chtimes(markerPath, now, now)
+	// Advance the watermark so the next boot starts from here, unless a matched
+	// project session failed to copy and still needs a retry.
+	if !hadCopyFailure {
+		now := time.Now()
+		_ = os.Chtimes(markerPath, now, now)
+	}
 	return imported, nil
 }
 

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -111,6 +111,7 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 	}
 
 	imported := 0
+	hadArtifactFailure := false
 
 	// Pass 1 — event-log sessions (*.events.jsonl). When a same-named .jsonl
 	// exists in the source with a modification time >= the event log's, prefer
@@ -177,7 +178,9 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 	// its own marker so existing upgraders whose events passes completed still
 	// get their .jsonl-only sessions imported.
 	if !importMarkerExists(globalDest, legacyJsonlPassMarker) {
-		imported += importJsonlSessions(entries, srcDir, globalDest, hasEvents, projectDir)
+		n, failed := importJsonlSessions(entries, srcDir, globalDest, hasEvents, projectDir)
+		imported += n
+		hadArtifactFailure = hadArtifactFailure || failed
 
 		// .jsonl.bak recovery: when the .jsonl was lost but a backup remains.
 		for _, e := range entries {
@@ -227,6 +230,9 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 		if !e.IsDir() {
 			continue
 		}
+		if e.Name() == "subagents" {
+			continue
+		}
 		subDir := filepath.Join(srcDir, e.Name())
 		subEntries, err := os.ReadDir(subDir)
 		if err != nil {
@@ -252,15 +258,19 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 
 	// Also stamp the flat markers so a downgrade to an older build doesn't
 	// re-run the flat import over routed sessions.
+	if hadArtifactFailure {
+		return imported, nil
+	}
 	writeImportMarkers(globalDest, marker, legacyImportMarker, legacyEventsHomeImportMarker, legacyEventsConfigImportMarker, legacyJsonlPassMarker)
 	return imported, nil
 }
 
 // importJsonlSessions copies .jsonl files that are already in message format
 // (no .events.jsonl counterpart) from srcDir into their appropriate destination
-// dirs. Returns the count imported.
-func importJsonlSessions(entries []os.DirEntry, srcDir, globalDest string, hasEvents map[string]bool, projectDir func(string) string) int {
+// dirs. Returns the count imported and whether a related artifact copy failed.
+func importJsonlSessions(entries []os.DirEntry, srcDir, globalDest string, hasEvents map[string]bool, projectDir func(string) string) (int, bool) {
 	imported := 0
+	hadArtifactFailure := false
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") || strings.HasSuffix(name, ".events.jsonl") || strings.HasSuffix(name, ".jsonl.bak") {
@@ -284,6 +294,11 @@ func importJsonlSessions(entries []os.DirEntry, srcDir, globalDest string, hasEv
 		destDir, summary, copyBranchMeta := jsonlSessionDestDir(srcDir, jsonlPath, base, globalDest, projectDir)
 		dest := filepath.Join(destDir, base+".jsonl")
 		if _, err := os.Stat(dest); err == nil {
+			if copyBranchMeta {
+				if err := copySubagentArtifacts(srcDir, destDir, base); err != nil {
+					hadArtifactFailure = true
+				}
+			}
 			continue
 		}
 		srcInfo, _ := e.Info()
@@ -295,11 +310,14 @@ func importJsonlSessions(entries []os.DirEntry, srcDir, globalDest string, hasEv
 		}
 		if copyBranchMeta {
 			copyBranchMetaSidecar(jsonlPath, dest)
+			if err := copySubagentArtifacts(srcDir, destDir, base); err != nil {
+				hadArtifactFailure = true
+			}
 		}
 		recordImportedTitle(destDir, base, summary)
 		imported++
 	}
-	return imported
+	return imported, hadArtifactFailure
 }
 
 func jsonlSessionDestDir(srcDir, srcPath, base, globalDest string, projectDir func(string) string) (string, string, bool) {
@@ -705,6 +723,9 @@ func rehomeStrandedSessions(srcDir, globalDest, marker string, projectDir func(s
 		}
 		dest := filepath.Join(destDir, name)
 		if _, err := os.Stat(dest); err == nil {
+			if err := copySubagentArtifacts(srcDir, destDir, base); err != nil {
+				hadCopyFailure = true
+			}
 			continue // already routed on a previous boot
 		}
 		if err := transformAndCopyJsonl(srcPath, dest); err != nil {
@@ -713,6 +734,9 @@ func rehomeStrandedSessions(srcDir, globalDest, marker string, projectDir func(s
 		}
 		_ = os.Chtimes(dest, info.ModTime(), info.ModTime()) // preserve resume ordering
 		copyBranchMetaSidecar(srcPath, dest)
+		if err := copySubagentArtifacts(srcDir, destDir, base); err != nil {
+			hadCopyFailure = true
+		}
 		recordImportedTitle(destDir, base, summary)
 		imported++
 	}
@@ -781,6 +805,71 @@ func copyBranchMetaSidecar(srcPath, dstPath string) {
 	if err := os.Rename(tmpPath, dstMeta); err != nil {
 		os.Remove(tmpPath)
 	}
+}
+
+func copySubagentArtifacts(srcSessionDir, dstSessionDir, parentSession string) error {
+	if sameDirPath(srcSessionDir, dstSessionDir) {
+		return nil
+	}
+	artifacts, err := ListSubagentsByParent(srcSessionDir, parentSession)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	dstSubagentDir := filepath.Join(dstSessionDir, "subagents")
+	for _, artifact := range artifacts {
+		for _, src := range []string{artifact.SessionPath, artifact.MetaPath} {
+			if err := copyFileIfExists(src, filepath.Join(dstSubagentDir, filepath.Base(src))); err != nil {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func copyFileIfExists(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.IsDir() {
+		return nil
+	}
+	if _, err := os.Stat(dst); err == nil {
+		return nil
+	} else if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	b, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".subagent.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, dst); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	_ = os.Chtimes(dst, info.ModTime(), info.ModTime())
+	return nil
 }
 
 // sameDirPath reports whether two directory paths resolve to the same location.

--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -87,7 +87,13 @@ func migrateLegacySessions(srcDir, globalDest, marker string, projectDir func(st
 	// whose events pass already stamped the routed marker must still reach the
 	// .jsonl-only / subdir passes below (Pass 1 is idempotent via dest checks).
 	if importMarkerExists(globalDest, marker) && importMarkerExists(globalDest, legacyJsonlPassMarker) {
-		return 0, nil
+		// The one-time full passes already ran for this source. Still run the
+		// bounded re-home pass: a user who downgrades to a pre-routing build
+		// (which writes every session to the flat dir) and then upgrades again
+		// leaves project sessions stranded in the flat dir that the marker would
+		// otherwise hide forever (#4666). The pass is watermarked by the marker
+		// mtime so a session the user imported and then deleted is not revived.
+		return rehomeStrandedSessions(srcDir, globalDest, marker, projectDir)
 	}
 	entries, err := os.ReadDir(srcDir)
 	if err != nil {
@@ -612,6 +618,156 @@ func writeImportMarkers(destDir string, markers ...string) {
 		seen[marker] = true
 		_ = os.WriteFile(filepath.Join(destDir, marker), nil, 0o644)
 	}
+}
+
+// rehomeStrandedSessions copies project-scoped sessions that were written into
+// the flat global dir AFTER the one-time routing pass already ran — the
+// signature of a user who downgraded to a pre-routing build (which writes every
+// session to the flat dir regardless of workspace) and then upgraded again
+// (#4666). Without this, the routing marker hides those sessions from the
+// desktop sidebar forever, even though they are sitting in the flat dir.
+//
+// It is deliberately conservative:
+//   - Only sessions whose mtime is newer than the marker (the last migration
+//     watermark) are considered, so a session the user imported and then
+//     deleted is never resurrected.
+//   - Only sessions that explicitly name a still-existing workspace — via a v1+
+//     branch-meta sidecar with scope=project, or a v0.x .meta.json — are moved.
+//     Flat global sessions (CLI conversations, the desktop's global tab) carry
+//     no workspace and are left untouched.
+//   - It never modifies the source files; the destination is written via the
+//     same transform-and-copy path the full passes use, and the branch-meta
+//     sidecar is copied alongside so the sidebar shows the right title/topic.
+//
+// The marker mtime is advanced to now after a successful scan so the next boot
+// does not re-walk the same files.
+func rehomeStrandedSessions(srcDir, globalDest, marker string, projectDir func(string) string) (int, error) {
+	if projectDir == nil {
+		return 0, nil
+	}
+	markerPath := filepath.Join(globalDest, marker)
+	markerInfo, err := os.Stat(markerPath)
+	if err != nil {
+		return 0, nil // no watermark to compare against — full passes own this dir
+	}
+	watermark := markerInfo.ModTime()
+
+	entries, err := os.ReadDir(srcDir)
+	if err != nil {
+		return 0, nil
+	}
+	imported := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".jsonl") ||
+			strings.HasSuffix(name, ".events.jsonl") || strings.HasSuffix(name, ".jsonl.bak") {
+			continue
+		}
+		base := strings.TrimSuffix(name, ".jsonl")
+		if strings.HasPrefix(base, "subagent-") {
+			continue // surfaced only through their parent session
+		}
+		info, ierr := e.Info()
+		if ierr != nil || !info.ModTime().After(watermark) {
+			continue // written before the last migration — not a downgrade straggler
+		}
+		srcPath := filepath.Join(srcDir, name)
+		if !isMessageFormat(srcPath) {
+			continue
+		}
+		destDir, summary := strandedSessionDestDir(srcDir, srcPath, base, projectDir)
+		if destDir == "" || sameDirPath(destDir, globalDest) {
+			continue // global session, or no live workspace — leave it in the flat dir
+		}
+		dest := filepath.Join(destDir, name)
+		if _, err := os.Stat(dest); err == nil {
+			continue // already routed on a previous boot
+		}
+		if err := transformAndCopyJsonl(srcPath, dest); err != nil {
+			continue
+		}
+		_ = os.Chtimes(dest, info.ModTime(), info.ModTime()) // preserve resume ordering
+		copyBranchMetaSidecar(srcPath, dest)
+		recordImportedTitle(destDir, base, summary)
+		imported++
+	}
+	// Advance the watermark so the next boot starts from here, regardless of
+	// whether anything matched this time.
+	now := time.Now()
+	_ = os.Chtimes(markerPath, now, now)
+	return imported, nil
+}
+
+// strandedSessionDestDir resolves the per-project session dir a flat-dir session
+// belongs to, preferring the v1+ branch-meta sidecar and falling back to the
+// v0.x .meta.json. It returns "" when the session is global or names a workspace
+// that no longer exists on disk. The second return is the display summary, if any.
+func strandedSessionDestDir(srcDir, srcPath, base string, projectDir func(string) string) (string, string) {
+	if meta, ok, err := LoadBranchMeta(srcPath); err == nil && ok {
+		if meta.DefaultScope() == "project" && meta.WorkspaceRoot != "" && dirExists(meta.WorkspaceRoot) {
+			if d := projectDir(meta.WorkspaceRoot); d != "" {
+				return d, strings.TrimSpace(meta.TopicTitle)
+			}
+		}
+		// A branch sidecar that explicitly marks the session global wins over a
+		// stale v0.x sidecar of the same name.
+		if meta.Scope != "" {
+			return "", ""
+		}
+	}
+	legacy := readLegacyMeta(srcDir, base)
+	if legacy.Workspace != "" && dirExists(legacy.Workspace) {
+		if d := projectDir(legacy.Workspace); d != "" {
+			return d, legacy.Summary
+		}
+	}
+	return "", ""
+}
+
+// copyBranchMetaSidecar copies <src>.meta to <dst>.meta when present so the
+// desktop sidebar keeps the session's title, topic, and tree position. Best
+// effort: a missing or unreadable sidecar just means the session shows with a
+// generated title.
+func copyBranchMetaSidecar(srcPath, dstPath string) {
+	b, err := os.ReadFile(BranchMetaPath(srcPath))
+	if err != nil {
+		return
+	}
+	dstMeta := BranchMetaPath(dstPath)
+	if err := os.MkdirAll(filepath.Dir(dstMeta), 0o755); err != nil {
+		return
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dstMeta), ".branch.*.tmp")
+	if err != nil {
+		return
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return
+	}
+	if err := os.Rename(tmpPath, dstMeta); err != nil {
+		os.Remove(tmpPath)
+	}
+}
+
+// sameDirPath reports whether two directory paths resolve to the same location.
+func sameDirPath(a, b string) bool {
+	ca, cb := filepath.Clean(a), filepath.Clean(b)
+	if ca == cb {
+		return true
+	}
+	if aa, err := filepath.Abs(ca); err == nil {
+		if bb, err := filepath.Abs(cb); err == nil {
+			return aa == bb
+		}
+	}
+	return false
 }
 
 // reconstructSession folds the chronological event stream into the provider

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -287,6 +287,57 @@ func TestRehomeStrandedSessionAfterDowngrade(t *testing.T) {
 	}
 }
 
+func TestJsonlPassRoutesBranchMetaWhenJsonlMarkerMissing(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	workspace := t.TempDir()
+	projectDest := t.TempDir()
+	projectDir := func(root string) string {
+		if root == workspace {
+			return projectDest
+		}
+		return ""
+	}
+
+	past := time.Now().Add(-24 * time.Hour)
+	routedMarker := filepath.Join(dest, legacyRoutedHomeImportMarker)
+	if err := os.WriteFile(routedMarker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(routedMarker, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	base := "20260101-003000.000000000-deepseek"
+	sessionPath := filepath.Join(src, base+".jsonl")
+	if err := os.WriteFile(sessionPath, []byte(v1MessageSession), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace, TopicTitle: "half-upgraded"}); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := MigrateLegacySessions(src, dest, projectDir)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("branch-meta jsonl session should be imported once, got %d", n)
+	}
+	if _, err := os.Stat(filepath.Join(projectDest, base+".jsonl")); err != nil {
+		t.Fatalf("session should be routed to the project dir while the jsonl marker is missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, base+".jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("project session must not be copied into the global dir: %v", err)
+	}
+	if _, err := os.Stat(BranchMetaPath(filepath.Join(projectDest, base+".jsonl"))); err != nil {
+		t.Fatalf("branch meta sidecar should be copied alongside: %v", err)
+	}
+	if n, err := MigrateLegacySessions(src, dest, projectDir); err != nil || n != 0 {
+		t.Fatalf("second run should be a no-op: n=%d err=%v", n, err)
+	}
+}
+
 // TestRehomeLeavesGlobalSessionsAlone guards the main risk: the flat dir is also
 // where CLI/global sessions live. A session with no project scope must stay put.
 func TestRehomeLeavesGlobalSessionsAlone(t *testing.T) {
@@ -380,6 +431,44 @@ func TestRehomeIsIdempotent(t *testing.T) {
 	}
 	if n, err := MigrateLegacySessions(src, dest, projectDir); err != nil || n != 0 {
 		t.Fatalf("second run must be a no-op: n=%d err=%v", n, err)
+	}
+}
+
+func TestRehomeKeepsWatermarkWhenProjectCopyFails(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	workspace := t.TempDir()
+	blocker := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(blocker, []byte("block"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	projectDir := func(root string) string {
+		if root == workspace {
+			return filepath.Join(blocker, "sessions")
+		}
+		return ""
+	}
+
+	past := time.Now().Add(-24 * time.Hour).Round(0)
+	stampMigrated(t, dest, past)
+	base := "20260101-023000.000000000-deepseek"
+	sessionPath := filepath.Join(src, base+".jsonl")
+	if err := os.WriteFile(sessionPath, []byte(v1MessageSession), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	if n, err := MigrateLegacySessions(src, dest, projectDir); err != nil || n != 0 {
+		t.Fatalf("copy failure should not import: n=%d err=%v", n, err)
+	}
+	info, err := os.Stat(filepath.Join(dest, legacyRoutedHomeImportMarker))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(past) {
+		t.Fatalf("watermark advanced after copy failure: got %s want %s", info.ModTime(), past)
 	}
 }
 

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -266,6 +266,8 @@ func TestRehomeStrandedSessionAfterDowngrade(t *testing.T) {
 	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace, TopicTitle: "downgrade work"}); err != nil {
 		t.Fatal(err)
 	}
+	ref := "sa_20260101_000000_000000000_aabbccddeeff"
+	writeMigratedSubagentArtifact(t, src, ref, base)
 
 	n, err := MigrateLegacySessions(src, dest, projectDir)
 	if err != nil {
@@ -280,6 +282,12 @@ func TestRehomeStrandedSessionAfterDowngrade(t *testing.T) {
 	// The branch sidecar must follow so the sidebar keeps title/topic.
 	if _, err := os.Stat(BranchMetaPath(filepath.Join(projectDest, base+".jsonl"))); err != nil {
 		t.Errorf("branch meta sidecar should be copied alongside: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDest, "subagents", ref+".jsonl")); err != nil {
+		t.Errorf("subagent transcript should be copied alongside: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDest, "subagents", ref+".meta.json")); err != nil {
+		t.Errorf("subagent metadata should be copied alongside: %v", err)
 	}
 	// Source is never modified.
 	if _, err := os.Stat(sessionPath); err != nil {
@@ -316,6 +324,8 @@ func TestJsonlPassRoutesBranchMetaWhenJsonlMarkerMissing(t *testing.T) {
 	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace, TopicTitle: "half-upgraded"}); err != nil {
 		t.Fatal(err)
 	}
+	ref := "sa_20260101_003000_000000000_aabbccddeeff"
+	writeMigratedSubagentArtifact(t, src, ref, base)
 
 	n, err := MigrateLegacySessions(src, dest, projectDir)
 	if err != nil {
@@ -332,6 +342,12 @@ func TestJsonlPassRoutesBranchMetaWhenJsonlMarkerMissing(t *testing.T) {
 	}
 	if _, err := os.Stat(BranchMetaPath(filepath.Join(projectDest, base+".jsonl"))); err != nil {
 		t.Fatalf("branch meta sidecar should be copied alongside: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDest, "subagents", ref+".jsonl")); err != nil {
+		t.Fatalf("subagent transcript should be copied alongside: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(projectDest, "subagents", ref+".meta.json")); err != nil {
+		t.Fatalf("subagent metadata should be copied alongside: %v", err)
 	}
 	if n, err := MigrateLegacySessions(src, dest, projectDir); err != nil || n != 0 {
 		t.Fatalf("second run should be a no-op: n=%d err=%v", n, err)
@@ -469,6 +485,73 @@ func TestRehomeKeepsWatermarkWhenProjectCopyFails(t *testing.T) {
 	}
 	if !info.ModTime().Equal(past) {
 		t.Fatalf("watermark advanced after copy failure: got %s want %s", info.ModTime(), past)
+	}
+}
+
+func TestRehomeKeepsWatermarkWhenSubagentCopyFails(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	workspace := t.TempDir()
+	projectDest := t.TempDir()
+	projectDir := func(root string) string {
+		if root == workspace {
+			return projectDest
+		}
+		return ""
+	}
+
+	past := time.Now().Add(-24 * time.Hour).Round(0)
+	stampMigrated(t, dest, past)
+	base := "20260101-024000.000000000-deepseek"
+	sessionPath := filepath.Join(src, base+".jsonl")
+	if err := os.WriteFile(sessionPath, []byte(v1MessageSession), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace}); err != nil {
+		t.Fatal(err)
+	}
+	writeMigratedSubagentArtifact(t, src, "sa_20260101_024000_000000000_aabbccddeeff", base)
+	if err := os.MkdirAll(projectDest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(projectDest, "subagents"), []byte("block"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if n, err := MigrateLegacySessions(src, dest, projectDir); err != nil || n != 1 {
+		t.Fatalf("parent session should still import: n=%d err=%v", n, err)
+	}
+	info, err := os.Stat(filepath.Join(dest, legacyRoutedHomeImportMarker))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.ModTime().Equal(past) {
+		t.Fatalf("watermark advanced after subagent copy failure: got %s want %s", info.ModTime(), past)
+	}
+}
+
+func writeMigratedSubagentArtifact(t *testing.T, sessionDir, ref, parentSession string) {
+	t.Helper()
+	subagentDir := filepath.Join(sessionDir, "subagents")
+	if err := os.MkdirAll(subagentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".jsonl"), []byte(`{"role":"user","content":"sub"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	meta := SubagentMeta{
+		Ref:           ref,
+		Status:        SubagentCompleted,
+		Kind:          "task",
+		Name:          "task",
+		ParentSession: parentSession,
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subagentDir, ref+".meta.json"), data, 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/agent/migrate_test.go
+++ b/internal/agent/migrate_test.go
@@ -217,6 +217,172 @@ func writeLegacyMeta(t *testing.T, srcDir, base, workspace, summary string) {
 	}
 }
 
+const v1MessageSession = `{"role":"user","content":"recovered after downgrade"}
+{"role":"assistant","content":"ok"}
+`
+
+// stampMigrated marks src/dest as already through the one-time passes, with the
+// routing watermark set to `at`. It mirrors what a completed migration leaves
+// behind so the re-home pass (not the full passes) handles the next run.
+func stampMigrated(t *testing.T, dest string, at time.Time) {
+	t.Helper()
+	for _, m := range []string{legacyRoutedHomeImportMarker, legacyJsonlPassMarker, legacyImportMarker} {
+		path := filepath.Join(dest, m)
+		if err := os.WriteFile(path, nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, at, at); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestRehomeStrandedSessionAfterDowngrade reproduces #4666: after the one-time
+// routing pass completes, a downgrade-to-old-build writes a project session into
+// the flat dir. The next upgrade must re-home it into its workspace dir even
+// though the routing marker is present.
+func TestRehomeStrandedSessionAfterDowngrade(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	workspace := t.TempDir()
+	projectDest := t.TempDir()
+	projectDir := func(root string) string {
+		if root == workspace {
+			return projectDest
+		}
+		return ""
+	}
+
+	// Migration already ran a day ago.
+	past := time.Now().Add(-24 * time.Hour)
+	stampMigrated(t, dest, past)
+
+	// The downgraded build then wrote a project session into the flat dir.
+	base := "20260101-000000.000000000-deepseek"
+	sessionPath := filepath.Join(src, base+".jsonl")
+	if err := os.WriteFile(sessionPath, []byte(v1MessageSession), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace, TopicTitle: "downgrade work"}); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := MigrateLegacySessions(src, dest, projectDir)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("stranded project session should be re-homed, imported %d", n)
+	}
+	if _, err := os.Stat(filepath.Join(projectDest, base+".jsonl")); err != nil {
+		t.Errorf("session should land in the project dir: %v", err)
+	}
+	// The branch sidecar must follow so the sidebar keeps title/topic.
+	if _, err := os.Stat(BranchMetaPath(filepath.Join(projectDest, base+".jsonl"))); err != nil {
+		t.Errorf("branch meta sidecar should be copied alongside: %v", err)
+	}
+	// Source is never modified.
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Errorf("source session must be left intact: %v", err)
+	}
+}
+
+// TestRehomeLeavesGlobalSessionsAlone guards the main risk: the flat dir is also
+// where CLI/global sessions live. A session with no project scope must stay put.
+func TestRehomeLeavesGlobalSessionsAlone(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	projectDir := func(string) string { return t.TempDir() }
+
+	stampMigrated(t, dest, time.Now().Add(-24*time.Hour))
+
+	// A global session (no branch meta, no workspace) written post-migration.
+	base := "20260101-010000.000000000-deepseek"
+	if err := os.WriteFile(filepath.Join(src, base+".jsonl"), []byte(v1MessageSession), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := MigrateLegacySessions(src, dest, projectDir)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("a global flat session must not be re-homed, imported %d", n)
+	}
+}
+
+// TestRehomeIgnoresSessionsOlderThanWatermark ensures a session the user
+// imported and then deleted is not resurrected: only files newer than the
+// migration watermark are candidates.
+func TestRehomeIgnoresSessionsOlderThanWatermark(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	workspace := t.TempDir()
+	projectDest := t.TempDir()
+	projectDir := func(root string) string {
+		if root == workspace {
+			return projectDest
+		}
+		return ""
+	}
+
+	now := time.Now()
+	stampMigrated(t, dest, now) // watermark = now
+
+	// A project session whose mtime predates the watermark (it was already seen
+	// by the original pass and the user deleted the import).
+	base := "20250101-000000.000000000-deepseek"
+	sessionPath := filepath.Join(src, base+".jsonl")
+	if err := os.WriteFile(sessionPath, []byte(v1MessageSession), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace}); err != nil {
+		t.Fatal(err)
+	}
+	old := now.Add(-48 * time.Hour)
+	if err := os.Chtimes(sessionPath, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := MigrateLegacySessions(src, dest, projectDir)
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("a pre-watermark session must not be revived, imported %d", n)
+	}
+}
+
+// TestRehomeIsIdempotent verifies the second boot does not re-import: the
+// destination check skips already-routed sessions and the watermark advances.
+func TestRehomeIsIdempotent(t *testing.T) {
+	src := t.TempDir()
+	dest := t.TempDir()
+	workspace := t.TempDir()
+	projectDest := t.TempDir()
+	projectDir := func(root string) string {
+		if root == workspace {
+			return projectDest
+		}
+		return ""
+	}
+
+	stampMigrated(t, dest, time.Now().Add(-24*time.Hour))
+	base := "20260101-020000.000000000-deepseek"
+	sessionPath := filepath.Join(src, base+".jsonl")
+	os.WriteFile(sessionPath, []byte(v1MessageSession), 0o644)
+	if err := SaveBranchMeta(sessionPath, BranchMeta{Scope: "project", WorkspaceRoot: workspace}); err != nil {
+		t.Fatal(err)
+	}
+
+	if n, _ := MigrateLegacySessions(src, dest, projectDir); n != 1 {
+		t.Fatalf("first run should re-home 1, got %d", n)
+	}
+	if n, err := MigrateLegacySessions(src, dest, projectDir); err != nil || n != 0 {
+		t.Fatalf("second run must be a no-op: n=%d err=%v", n, err)
+	}
+}
+
 func TestMigrateLegacySessionsRoutesByWorkspaceMeta(t *testing.T) {
 	src := t.TempDir()
 	global := t.TempDir()


### PR DESCRIPTION
## Problem

Fixes #4666. A user who downgraded to a pre-routing build and then upgraded again lost access to their project sessions in the desktop sidebar. The sessions were never deleted — they were stranded in the flat `~/.reasonix/sessions` directory where the sidebar does not look.

## Root cause

Session storage has two layouts:

- Flat global dir `~/.reasonix/sessions/` — used by older builds and CLI/global conversations.
- Per-project dir `~/.reasonix/projects/<slug>/sessions/` — what the desktop sidebar lists.

`MigrateLegacySessions` routes flat sessions into their per-project dir, but it is a one-time pass gated by marker files in the global dir. Once the markers are stamped, the guard returns early and does nothing.

A pre-routing build writes **every** session to the flat dir regardless of workspace. So the sequence "upgrade (markers stamped) → downgrade (new project sessions written flat) → upgrade again" leaves those new project sessions stranded: the marker makes the routing pass a no-op, and the sidebar never sees them.

## Fix

Add a bounded incremental re-home pass that runs precisely when the routing markers are already present. It is deliberately conservative:

- **Watermarked** by the routing marker's mtime — only flat-dir sessions written *after* the last migration are considered, so a session the user imported and then deleted is never revived.
- **Project-scoped only** — only sessions that explicitly name a still-existing workspace are moved (v1+ branch meta `scope=project`, or a v0.x `.meta.json`). Global/CLI sessions carry no workspace and are left untouched. This is the key safety property, since the flat dir is shared with global conversations.
- **Non-destructive** — source files are never modified; the destination is written through the same transform-and-copy path the full passes use, and the branch-meta sidecar is copied alongside so the sidebar keeps the session title/topic.
- **Idempotent** — a destination-exists check skips already-routed sessions, and the watermark is advanced after each scan to keep subsequent boots cheap.

It hooks into the existing boot-time `MigrateLegacySessionSources` call, so recovery is automatic on the next launch with no manual steps.

## Cache impact

None. This is disk-only session migration logic and does not touch the prompt prefix, tool schemas, provider serialization, or any cache-sensitive surface.

## Verification

`go test ./internal/agent/ ./internal/migration/` — all green, including the existing migration suite (no regressions) and four new tests covering this scenario:

- a stranded project session is re-homed after a downgrade (with its sidecar)
- a global flat session is left untouched
- a session older than the watermark is not revived
- the second boot is a no-op (idempotent)

Also ran the new tests under `-race` clean.
