### PR TITLE
Fix planner context isolation across sessions / 修复跨会话规划上下文隔离

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -47,6 +47,7 @@ func PlannerPromptWithContext(context string) string {
 type Coordinator struct {
 	planner        provider.Provider
 	plannerSess    *Session
+	plannerSystem  string
 	plannerPricing *provider.Pricing
 	plannerAgent   *Agent
 	executor       *Agent
@@ -66,6 +67,10 @@ func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerP
 	if nilutil.IsNil(sink) {
 		sink = event.Discard
 	}
+	if plannerSession == nil {
+		plannerSession = NewSession("")
+	}
+	plannerSystem := sessionSystemPrompt(plannerSession)
 	var plannerAgent *Agent
 	if plannerTools != nil {
 		plannerOptions.Temperature = temperature
@@ -79,12 +84,44 @@ func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerP
 	return &Coordinator{
 		planner:        planner,
 		plannerSess:    plannerSession,
+		plannerSystem:  plannerSystem,
 		plannerPricing: plannerPricing,
 		plannerAgent:   plannerAgent,
 		executor:       executor,
 		temperature:    temperature,
 		sink:           sink,
 		shouldPlan:     shouldPlan,
+	}
+}
+
+func sessionSystemPrompt(s *Session) string {
+	if s == nil {
+		return ""
+	}
+	for _, m := range s.Snapshot() {
+		if m.Role == provider.RoleSystem {
+			return m.Content
+		}
+	}
+	return ""
+}
+
+// ResetPlannerSession discards turn-local planner history when the owning
+// controller moves to a different executor session. Saved transcripts only
+// persist executor-visible conversation; carrying the old planner transcript
+// into a new/resumed session can make the next plan reuse unrelated tasks.
+func (c *Coordinator) ResetPlannerSession() {
+	if c == nil {
+		return
+	}
+	system := c.plannerSystem
+	if system == "" {
+		system = sessionSystemPrompt(c.plannerSess)
+	}
+	next := NewSession(system)
+	c.plannerSess = next
+	if c.plannerAgent != nil {
+		c.plannerAgent.SetSession(next)
 	}
 }
 

--- a/internal/control/branches_test.go
+++ b/internal/control/branches_test.go
@@ -1,12 +1,15 @@
 package control
 
 import (
+	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
 	"reasonix/internal/provider"
+	"reasonix/internal/tool"
 )
 
 func TestBranchAndSwitch(t *testing.T) {
@@ -46,6 +49,88 @@ func TestBranchAndSwitch(t *testing.T) {
 	tree := c.BranchTreeText()
 	if !strings.Contains(tree, shortBranchID(rootID)) || !strings.Contains(tree, "try something") {
 		t.Fatalf("tree missing expected branches:\n%s", tree)
+	}
+}
+
+func TestBranchResetsTwoModelPlannerContext(t *testing.T) {
+	dir := t.TempDir()
+	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{
+		textTurn("OLD PLAN: inspect alpha.go"),
+		textTurn("BRANCH PLAN: inspect beta.go"),
+	}}
+	execProv := &recordingProvider{name: "executor", streams: [][]provider.Chunk{
+		textTurn("old done"),
+		textTurn("branch done"),
+	}}
+	exec := agent.New(execProv, tool.NewRegistry(), agent.NewSession("exec sys"), agent.Options{}, event.Discard)
+	coord := agent.NewCoordinator(planner, agent.NewSession("planner sys"), nil, tool.NewRegistry(), agent.Options{}, exec, 0, event.Discard, nil)
+	c := New(Options{Runner: coord, Executor: exec, SystemPrompt: "exec sys", SessionDir: dir, SessionPath: filepath.Join(dir, "root.jsonl"), Label: "test"})
+
+	if err := c.Run(context.Background(), "old task alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.Branch("child"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Run(context.Background(), "branch task beta"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(planner.requests) != 2 {
+		t.Fatalf("planner requests = %d, want 2", len(planner.requests))
+	}
+	second := requestMessagesText(planner.requests[1].Messages)
+	if strings.Contains(second, "old task alpha") || strings.Contains(second, "OLD PLAN") {
+		t.Fatalf("branch planner request leaked previous session context:\n%s", second)
+	}
+	if !strings.Contains(second, "branch task beta") {
+		t.Fatalf("branch planner request missing current task:\n%s", second)
+	}
+}
+
+func TestSwitchBranchResetsTwoModelPlannerContext(t *testing.T) {
+	dir := t.TempDir()
+	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{
+		textTurn("ROOT PLAN: inspect alpha.go"),
+		textTurn("CHILD PLAN: inspect beta.go"),
+		textTurn("ROOT AGAIN PLAN: inspect gamma.go"),
+	}}
+	execProv := &recordingProvider{name: "executor", streams: [][]provider.Chunk{
+		textTurn("root done"),
+		textTurn("child done"),
+		textTurn("root again done"),
+	}}
+	exec := agent.New(execProv, tool.NewRegistry(), agent.NewSession("exec sys"), agent.Options{}, event.Discard)
+	coord := agent.NewCoordinator(planner, agent.NewSession("planner sys"), nil, tool.NewRegistry(), agent.Options{}, exec, 0, event.Discard, nil)
+	rootPath := filepath.Join(dir, "root.jsonl")
+	c := New(Options{Runner: coord, Executor: exec, SystemPrompt: "exec sys", SessionDir: dir, SessionPath: rootPath, Label: "test"})
+
+	if err := c.Run(context.Background(), "root task alpha"); err != nil {
+		t.Fatal(err)
+	}
+	rootID := agent.BranchID(c.SessionPath())
+	if _, err := c.Branch("child"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Run(context.Background(), "child task beta"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.SwitchBranch(rootID); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Run(context.Background(), "root task gamma"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(planner.requests) != 3 {
+		t.Fatalf("planner requests = %d, want 3", len(planner.requests))
+	}
+	third := requestMessagesText(planner.requests[2].Messages)
+	if strings.Contains(third, "child task beta") || strings.Contains(third, "CHILD PLAN") {
+		t.Fatalf("switched planner request leaked previous branch context:\n%s", third)
+	}
+	if !strings.Contains(third, "root task gamma") {
+		t.Fatalf("switched planner request missing current task:\n%s", third)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -197,6 +197,10 @@ type pendingAsk struct {
 	reply     chan []event.AskAnswer
 }
 
+type plannerSessionResetter interface {
+	ResetPlannerSession()
+}
+
 // RuntimeStatus is the frontend-facing snapshot of foreground turn state. It is
 // intentionally more explicit than the legacy Running bool so UI code can
 // distinguish a cancellable foreground turn from pending prompts and background
@@ -1523,6 +1527,7 @@ func (c *Controller) NewSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.resetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
@@ -1560,6 +1565,7 @@ func (c *Controller) ClearSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
+	c.resetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true
@@ -1963,12 +1969,20 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	if c.executor != nil {
 		c.executor.SetSession(s)
 	}
+	c.resetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = path
 	c.mu.Unlock()
 	c.setActiveJobSession(path)
 	c.rebindCheckpoints(path)
 	c.maybeColdResumePrune(path)
+}
+
+func (c *Controller) resetPlannerSession() {
+	runner, ok := c.runner.(plannerSessionResetter)
+	if ok {
+		runner.ResetPlannerSession()
+	}
 }
 
 // cacheColdAfter approximates how long the provider keeps a prompt prefix

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1758,6 +1758,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	}
 	if switchToFork {
 		c.executor.SetSession(sess)
+		c.resetPlannerSession()
 		c.mu.Lock()
 		c.sessionPath = newPath
 		c.mu.Unlock()
@@ -1823,6 +1824,7 @@ func (c *Controller) Branch(name string) (string, error) {
 		return "", c.rewindFail(err)
 	}
 	c.executor.SetSession(sess)
+	c.resetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = newPath
 	c.mu.Unlock()
@@ -1870,6 +1872,7 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	if c.executor != nil {
 		c.executor.SetSession(loaded)
 	}
+	c.resetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = match.Path
 	c.mu.Unlock()

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -107,6 +107,45 @@ func (t startBackgroundJobTool) Execute(ctx context.Context, _ json.RawMessage) 
 	return "started " + j.ID, nil
 }
 
+type recordingProvider struct {
+	name     string
+	streams  [][]provider.Chunk
+	requests []provider.Request
+}
+
+func (p *recordingProvider) Name() string {
+	if p.name != "" {
+		return p.name
+	}
+	return "recording"
+}
+
+func (p *recordingProvider) Stream(_ context.Context, req provider.Request) (<-chan provider.Chunk, error) {
+	p.requests = append(p.requests, req)
+	i := len(p.requests) - 1
+	if i >= len(p.streams) {
+		i = len(p.streams) - 1
+	}
+	chunks := p.streams[i]
+	ch := make(chan provider.Chunk, len(chunks))
+	for _, c := range chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch, nil
+}
+
+func requestMessagesText(messages []provider.Message) string {
+	var b strings.Builder
+	for _, m := range messages {
+		b.WriteString(string(m.Role))
+		b.WriteString(": ")
+		b.WriteString(m.Content)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
 func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
 	var sink *typedNilControllerSink
 	c := New(Options{Sink: sink})
@@ -329,6 +368,81 @@ func TestNewSessionStartsFreshContextAndSavesTranscript(t *testing.T) {
 	current := exec.Session().Snapshot()
 	if len(current) != 1 || current[0].Role != provider.RoleSystem || current[0].Content != "sys" {
 		t.Fatalf("fresh context = %+v, want only system prompt", current)
+	}
+}
+
+func TestNewSessionResetsTwoModelPlannerContext(t *testing.T) {
+	dir := t.TempDir()
+	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{
+		textTurn("OLD PLAN: inspect alpha.go"),
+		textTurn("NEW PLAN: inspect beta.go"),
+	}}
+	execProv := &recordingProvider{name: "executor", streams: [][]provider.Chunk{
+		textTurn("old done"),
+		textTurn("new done"),
+	}}
+	exec := agent.New(execProv, tool.NewRegistry(), agent.NewSession("exec sys"), agent.Options{}, event.Discard)
+	plannerSess := agent.NewSession("planner sys")
+	coord := agent.NewCoordinator(planner, plannerSess, nil, tool.NewRegistry(), agent.Options{}, exec, 0, event.Discard, nil)
+	path := filepath.Join(dir, "session.jsonl")
+	c := New(Options{Runner: coord, Executor: exec, SystemPrompt: "exec sys", SessionDir: dir, SessionPath: path, Label: "test"})
+
+	if err := c.Run(context.Background(), "old task alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.NewSession(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Run(context.Background(), "new task beta"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(planner.requests) != 2 {
+		t.Fatalf("planner requests = %d, want 2", len(planner.requests))
+	}
+	second := requestMessagesText(planner.requests[1].Messages)
+	if strings.Contains(second, "old task alpha") || strings.Contains(second, "OLD PLAN") {
+		t.Fatalf("new planner request leaked previous session context:\n%s", second)
+	}
+	if !strings.Contains(second, "new task beta") {
+		t.Fatalf("new planner request missing current task:\n%s", second)
+	}
+}
+
+func TestResumeResetsTwoModelPlannerContext(t *testing.T) {
+	dir := t.TempDir()
+	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{
+		textTurn("OLD PLAN: inspect alpha.go"),
+		textTurn("RESUMED PLAN: inspect gamma.go"),
+	}}
+	execProv := &recordingProvider{name: "executor", streams: [][]provider.Chunk{
+		textTurn("old done"),
+		textTurn("resumed done"),
+	}}
+	exec := agent.New(execProv, tool.NewRegistry(), agent.NewSession("exec sys"), agent.Options{}, event.Discard)
+	plannerSess := agent.NewSession("planner sys")
+	coord := agent.NewCoordinator(planner, plannerSess, nil, tool.NewRegistry(), agent.Options{}, exec, 0, event.Discard, nil)
+	c := New(Options{Runner: coord, Executor: exec, SystemPrompt: "exec sys", SessionDir: dir, SessionPath: filepath.Join(dir, "old.jsonl"), Label: "test"})
+
+	if err := c.Run(context.Background(), "old task alpha"); err != nil {
+		t.Fatal(err)
+	}
+	resumed := agent.NewSession("exec sys")
+	resumed.Add(provider.Message{Role: provider.RoleUser, Content: "saved task gamma"})
+	c.Resume(resumed, filepath.Join(dir, "resumed.jsonl"))
+	if err := c.Run(context.Background(), "continue gamma"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(planner.requests) != 2 {
+		t.Fatalf("planner requests = %d, want 2", len(planner.requests))
+	}
+	second := requestMessagesText(planner.requests[1].Messages)
+	if strings.Contains(second, "old task alpha") || strings.Contains(second, "OLD PLAN") {
+		t.Fatalf("resumed planner request leaked previous session context:\n%s", second)
+	}
+	if !strings.Contains(second, "continue gamma") {
+		t.Fatalf("resumed planner request missing current task:\n%s", second)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reset the dedicated planner transcript whenever a controller starts a new session, clears the current session, or resumes another transcript.
- Keep the planner's standing system context intact while dropping stale turn history, and update the tool-enabled planner agent at the same time.
- Add regression coverage for `/new` and `Resume` so two-model planning cannot carry tasks or plans from a previous session into the next one.

## Root Cause

Two-model mode stores executor-visible conversation and planner conversation separately. Session lifecycle paths already replaced the executor transcript, but the coordinator's planner transcript stayed alive inside the same controller. After planning in one session, a later fresh or resumed session could send the old planner task/plan back to the planner model, making unrelated plans bleed into the next executor handoff.

## Verification

- `go test ./internal/control -run 'Test(NewSession|Resume)ResetsTwoModelPlannerContext' -count=1`
- `go test ./internal/agent -count=1`
- `go test ./internal/control -count=1`
- `go test ./...`
- `go test ./...` from `desktop/`
- `go vet ./...`
- `go vet ./...` from `desktop/`
- `git diff --check`
- `corepack pnpm run test:all` from `desktop/frontend`
- `corepack pnpm run build` from `desktop/frontend`

Fixes #4667
