### PR TITLE
Fix status bar workspace items / 修复信息栏工作区项勾选

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -251,6 +251,8 @@ func (c *Config) DesktopStatusBarStyle() string {
 
 var defaultDesktopStatusBarItems = []string{
 	"model",
+	"workspace",
+	"git_branch",
 	"cache",
 	"cache_avg",
 	"session_tokens",
@@ -263,18 +265,14 @@ var defaultDesktopStatusBarItems = []string{
 	"balance",
 }
 
-var knownDesktopStatusBarItems = map[string]bool{
-	"model":          true,
-	"cache":          true,
-	"cache_avg":      true,
-	"session_tokens": true,
-	"turn_tokens":    true,
-	"turn_cost":      true,
-	"session_turns":  true,
-	"context":        true,
-	"compact":        true,
-	"cost":           true,
-	"balance":        true,
+var knownDesktopStatusBarItems = desktopStatusBarItemSet(defaultDesktopStatusBarItems)
+
+func desktopStatusBarItemSet(items []string) map[string]bool {
+	out := make(map[string]bool, len(items))
+	for _, item := range items {
+		out[item] = true
+	}
+	return out
 }
 
 // DefaultDesktopStatusBarItems returns the default ordered visible desktop

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -211,6 +212,11 @@ func TestDesktopStatusBarItemsNormalizeAndValidate(t *testing.T) {
 	if got, want := Default().DesktopStatusBarItems(), DefaultDesktopStatusBarItems(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("default desktop status bar items = %v, want %v", got, want)
 	}
+	for _, id := range []string{"workspace", "git_branch"} {
+		if !slices.Contains(DefaultDesktopStatusBarItems(), id) {
+			t.Fatalf("default desktop status bar items must include configurable item %q", id)
+		}
+	}
 
 	c := Default()
 	c.Desktop.StatusBarItems = []string{" balance ", "cache", "cache", "unknown", "model"}
@@ -224,6 +230,14 @@ func TestDesktopStatusBarItemsNormalizeAndValidate(t *testing.T) {
 	}
 	if got, want := c.DesktopStatusBarItems(), []string{"balance", "cache", "model"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("saved desktop status bar items = %v, want %v", got, want)
+	}
+
+	c = Default()
+	if err := c.SetDesktopStatusBarItems([]string{"workspace", "git_branch", "model"}); err != nil {
+		t.Fatalf("SetDesktopStatusBarItems workspace metadata: %v", err)
+	}
+	if got, want := c.DesktopStatusBarItems(), []string{"workspace", "git_branch", "model"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("saved workspace metadata status bar items = %v, want %v", got, want)
 	}
 
 	if err := c.SetDesktopStatusBarItems(nil); err != nil {


### PR DESCRIPTION
## Problem

Fixes #4661. In Desktop Settings -> General -> Status bar items, enabling "Workspace" or "Git branch" fails with:

`status bar item "workspace": unknown item`

The frontend already exposes both status bar items, but saving the setting goes through the backend config validator.

## Root cause

The desktop frontend's status bar item registry includes `workspace` and `git_branch`, and the status bar renderer already knows how to display both. The backend config registry was still missing those two ids, so `SetDesktopStatusBarItems` rejected them as unknown when the settings panel tried to persist the new selection.

The backend default item list and validation map were also maintained separately, which made this kind of registry drift easy to reintroduce.

## Fix

Add `workspace` and `git_branch` to the backend desktop status bar item list, matching the frontend order.

Derive the backend `knownDesktopStatusBarItems` map from that list so the default set and validation set stay in sync. Existing normalization, de-duplication, unknown-item rejection, and user ordering behavior are unchanged.

## Cache impact

None. This is desktop UI preference validation only and does not touch provider requests, prompt prefixes, tool schemas, model selection, or cache-sensitive surfaces.

## Verification

- `go test ./internal/config -run TestDesktopStatusBarItemsNormalizeAndValidate`
- `go test ./internal/config`
- `go test ./...`
- `cd desktop && go test ./...`
- `cd desktop/frontend && corepack pnpm exec tsx src/__tests__/statusbar-workspace.test.tsx`
- `cd desktop/frontend && corepack pnpm run test:all`
- `cd desktop/frontend && corepack pnpm run build`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `gofmt -l .`
- `git diff --check`
