### PR TITLE
Fix workbench dock chrome safety / 修复工作台 Dock 顶部安全区

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -162,6 +162,24 @@ ok(
   "macOS workbench leaves safe space for inset window controls",
 );
 
+ok(
+  finalDeclaration(".app--darwin .layout--workbench-chrome-hidden.layout--workspace-maximized .workbench-dock__tools", "padding-left") === "96px",
+  "macOS maximized workbench dock leaves safe space for inset window controls",
+);
+
+ok(
+  /@media \(max-width: 820px\) \{[\s\S]*\.app--darwin \.layout--workbench-chrome-hidden \.topicbar\s*\{[\s\S]*padding-left:\s*96px;/.test(stylesSource) &&
+    /@media \(max-width: 820px\) \{[\s\S]*\.app--darwin \.layout--workbench-chrome-hidden\.layout--workspace-maximized \.workbench-dock__tools\s*\{[\s\S]*padding-left:\s*96px;/.test(stylesSource),
+  "macOS workbench keeps safe space when responsive CSS hides the sidebar",
+);
+
+ok(
+  finalDeclaration(".workbench-dock__tools", "--wails-draggable") === "drag" &&
+    finalDeclaration(".workbench-dock__tabs", "--wails-draggable") === "no-drag" &&
+    finalDeclaration(".workbench-dock__tab", "--wails-draggable") === "no-drag",
+  "maximized workbench dock keeps a draggable title region while tabs remain clickable",
+);
+
 for (const selector of [
   ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar",
   ":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__chrome-btn",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1613,6 +1613,10 @@ a[href] {
   padding-left: 96px;
 }
 
+.app--darwin .layout--workbench-chrome-hidden.layout--workspace-maximized .workbench-dock__tools {
+  padding-left: 96px;
+}
+
 .sidebar {
   --sidebar-entry-content-inset: 12px;
   grid-row: 2;
@@ -14704,6 +14708,12 @@ a[href] {
   .chat-pane {
     grid-column: 1;
   }
+  .app--darwin .layout--workbench-chrome-hidden .topicbar {
+    padding-left: 96px;
+  }
+  .app--darwin .layout--workbench-chrome-hidden.layout--workspace-maximized .workbench-dock__tools {
+    padding-left: 96px;
+  }
   .topbar {
     padding: 0 12px 0 82px; /* clear macOS inset traffic lights when the sidebar is hidden */
   }
@@ -17816,9 +17826,11 @@ a[href] {
   gap: 8px;
   padding: 7px 10px 3px;
   border-bottom: 1px solid transparent;
+  --wails-draggable: drag;
 }
 
 .workbench-dock__tabs {
+  --wails-draggable: no-drag;
   flex: 0 1 auto;
   width: max-content;
   max-width: 100%;


### PR DESCRIPTION
## Summary
- Follow up on bot feedback from #4669 after the original PR merged.
- Reserve the macOS native-control safe area for the maximized workbench dock header.
- Preserve macOS safe-area spacing when responsive CSS hides the sidebar without setting the collapsed-sidebar class.
- Make the workbench dock tools strip draggable while keeping dock tabs explicitly non-draggable/clickable.

## Verification
- npm run check:css
- npm run typecheck
- npx tsx src/__tests__/app-chrome-tabs.test.ts
- Browser CSS verification on the running desktop frontend dev server