### PR TITLE
fix(config): add workspace and git_branch to known status bar items

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -252,6 +252,8 @@ func (c *Config) DesktopStatusBarStyle() string {
 
 var defaultDesktopStatusBarItems = []string{
 	"model",
+	"workspace",
+	"git_branch",
 	"cache",
 	"cache_avg",
 	"session_tokens",
@@ -266,6 +268,8 @@ var defaultDesktopStatusBarItems = []string{
 
 var knownDesktopStatusBarItems = map[string]bool{
 	"model":          true,
+	"workspace":      true,
+	"git_branch":     true,
 	"cache":          true,
 	"cache_avg":      true,
 	"session_tokens": true,


### PR DESCRIPTION
## 问题

设置面板中新增了「工作区」(workspace) 和「Git 分支」(git_branch) 两个状态栏维度，但在设置面板中无法开启。

## 根因

前端代码（枚举定义、SettingsPanel 标签、StatusBar 渲染器、i18n 翻译）已完整支持 workspace 和 git_branch，但 **Go 后端** 的 `knownDesktopStatusBarItems` 映射和 `defaultDesktopStatusBarItems` 列表中缺少这两项，导致后端在 `SetDesktopStatusBarItems()` 和 `normalizeDesktopStatusBarItems()` 时将其过滤掉。

## 修复

在 `internal/config/config.go` 中：
1. `defaultDesktopStatusBarItems` 添加 `"workspace"` 和 `"git_branch"`，位于 `"model"` 之后
2. `knownDesktopStatusBarItems` 添加对应的 `true` 条目

## 验证

- `go build ./internal/config/...` ✅
- `go test ./internal/config/... -run TestDesktopStatusBar` ✅