### PR TITLE
fix: keep settings refresh test off generated runtime imports

### DIFF
--- a/desktop/frontend/src/components/CopyButton.tsx
+++ b/desktop/frontend/src/components/CopyButton.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState } from "react";
 import { Check, Copy } from "lucide-react";
-import { ClipboardSetText } from "../../wailsjs/runtime/runtime";
 import { useT } from "../lib/i18n";
 
 function fallbackCopyText(value: string): boolean {
@@ -44,7 +43,7 @@ async function writeClipboardText(value: string): Promise<void> {
     /* try the desktop runtime below */
   }
   try {
-    if (typeof window !== "undefined" && window.runtime && (await ClipboardSetText(value))) return;
+    if (typeof window !== "undefined" && (await window.runtime?.ClipboardSetText?.(value))) return;
   } catch {
     /* runtime unavailable in browser dev */
   }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -320,6 +320,14 @@ export type _CheckGenToApp = AssertNever<Exclude<keyof typeof GeneratedApp, keyo
 interface WailsRuntime {
   EventsOn(name: string, cb: (...data: unknown[]) => void): () => void;
   BrowserOpenURL(url: string): void;
+  WindowSetSystemDefaultTheme?(): void;
+  WindowSetLightTheme?(): void;
+  WindowSetDarkTheme?(): void;
+  WindowSetBackgroundColour?(r: number, g: number, b: number, a: number): void;
+  WindowGetSize?(): Promise<{ w: number; h: number }>;
+  WindowGetPosition?(): Promise<{ x: number; y: number }>;
+  WindowIsMaximised?(): Promise<boolean>;
+  ClipboardSetText?(text: string): Promise<boolean>;
   // Native OS file drop (desktop only); useDropTarget gates delivery to elements
   // carrying the --wails-drop-target CSS property. Absent in the browser dev mock.
   OnFileDrop?(cb: (x: number, y: number, paths: string[]) => void, useDropTarget: boolean): void;

--- a/desktop/frontend/src/lib/theme.ts
+++ b/desktop/frontend/src/lib/theme.ts
@@ -7,13 +7,6 @@
 // When running inside the Wails shell, applyTheme also syncs the native window
 // theme (title bar, traffic lights, etc.) so the OS chrome matches the webview.
 
-import {
-  WindowSetDarkTheme,
-  WindowSetLightTheme,
-  WindowSetSystemDefaultTheme,
-  WindowSetBackgroundColour,
-} from "../../wailsjs/runtime/runtime";
-
 export type Theme = "auto" | "light" | "dark";
 export type ResolvedTheme = Exclude<Theme, "auto">;
 
@@ -120,14 +113,15 @@ export function applyTheme(theme: Theme, style: ThemeStyle = getThemeStyle(theme
   root.setAttribute("data-theme-style", nextStyle);
 
   // Sync the native window theme (title bar, traffic lights) to match.
-  if (typeof window !== "undefined" && window.runtime) {
+  const runtime = typeof window !== "undefined" ? window.runtime : undefined;
+  if (runtime) {
     syncAutoThemeBackgroundListener(theme);
     if (theme === "auto") {
-      WindowSetSystemDefaultTheme();
+      runtime.WindowSetSystemDefaultTheme?.();
     } else if (theme === "light") {
-      WindowSetLightTheme();
+      runtime.WindowSetLightTheme?.();
     } else if (theme === "dark") {
-      WindowSetDarkTheme();
+      runtime.WindowSetDarkTheme?.();
     }
     syncNativeWindowBackground(theme);
   }
@@ -206,12 +200,14 @@ export function initTheme(): void {
 }
 
 function syncNativeWindowBackground(theme: Theme): void {
+  const runtime = typeof window !== "undefined" ? window.runtime : undefined;
+  if (!runtime?.WindowSetBackgroundColour) return;
   const resolved = getResolvedTheme(theme);
   if (resolved === "light") {
     // Light shell: matches graphite --bg (#f4f3ef).
-    WindowSetBackgroundColour(244, 243, 239, 255);
+    runtime.WindowSetBackgroundColour(244, 243, 239, 255);
   } else {
     // Dark shell: matches :root --bg (#090a0c).
-    WindowSetBackgroundColour(9, 10, 12, 255);
+    runtime.WindowSetBackgroundColour(9, 10, 12, 255);
   }
 }

--- a/desktop/frontend/src/lib/windowState.ts
+++ b/desktop/frontend/src/lib/windowState.ts
@@ -11,18 +11,15 @@
 // to matter.
 
 import { useEffect, useRef } from "react";
-import {
-  WindowGetPosition,
-  WindowGetSize,
-  WindowIsMaximised,
-} from "../../wailsjs/runtime/runtime";
 import { app } from "./bridge";
 
 export function useWindowStatePersistence() {
   const lastState = useRef("");
 
   useEffect(() => {
-    if (typeof window === "undefined" || !window.runtime) return;
+    const runtime = typeof window !== "undefined" ? window.runtime : undefined;
+    if (!runtime?.WindowGetSize || !runtime.WindowGetPosition || !runtime.WindowIsMaximised) return;
+    const { WindowGetSize, WindowGetPosition, WindowIsMaximised } = runtime;
 
     let timer: ReturnType<typeof setInterval>;
 


### PR DESCRIPTION
## Summary
- remove static Wails runtime imports from frontend modules touched by component tests
- call optional window.runtime methods directly for native theme, window state, and clipboard behavior
- keep browser/test environments from loading ignored generated wailsjs runtime files

## Verification
- npm run typecheck
- npm run test:typecheck
- npx tsx src/__tests__/settings-refresh-snapshot.test.tsx
- npm test
- npm run build