### PR TITLE
fix(bash): preserve explicit detached background jobs

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -106,7 +106,7 @@ func (b bash) resolved() sandbox.Shell {
 }
 
 func (bash) Schema() json.RawMessage {
-	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute"},"run_in_background":{"type":"boolean","description":"Run detached: returns a job id immediately and keeps running across turns (no foreground timeout). Read new output with bash_output, wait for it with wait, stop it with kill_shell. Use for long-running commands like servers, watchers, or builds you don't need to block on."}},"required":["command"]}`)
+	return json.RawMessage(`{"type":"object","properties":{"command":{"type":"string","description":"Shell command to execute"},"run_in_background":{"type":"boolean","description":"Run detached: returns a job id immediately and keeps running across turns (no foreground timeout). Read new output with bash_output, wait with wait, stop it with kill_shell. Use for long-running commands like servers, watchers, or builds you don't need to block on."},"preserve_background_processes":{"type":"boolean","description":"After the shell command exits normally, keep any process-group members it intentionally left behind. Use only for deliberate daemonization, such as nohup/disown/setsid; cancellation and timeouts still kill the process group."}},"required":["command"]}`)
 }
 
 // ReadOnly is false: bash's effect cannot be inferred from args (rm, curl,
@@ -116,8 +116,9 @@ func (bash) ReadOnly() bool { return false }
 
 func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
-		Command         string `json:"command"`
-		RunInBackground bool   `json:"run_in_background"`
+		Command                     string `json:"command"`
+		RunInBackground             bool   `json:"run_in_background"`
+		PreserveBackgroundProcesses bool   `json:"preserve_background_processes"`
 	}
 	if err := json.Unmarshal(args, &p); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -154,7 +155,9 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 			cmd.Stdout = out
 			cmd.Stderr = out
 			runErr := cmd.Run()
-			reapTree(cmd) // reap process-group stragglers the job left running (#3702)
+			if shouldReapAfterRun(jobCtx, sh, p.Command, p.PreserveBackgroundProcesses) {
+				reapTree(cmd) // reap process-group stragglers the job left running (#3702)
+			}
 			return "", runErr
 		})
 		return fmt.Sprintf("Started background job %q. It keeps running across turns; read new output with bash_output(job_id=%q), wait for it with wait, or stop it with kill_shell(job_id=%q).", job.ID, job.ID, job.ID), nil
@@ -185,7 +188,9 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 	// server) leaves it in the process group; Wait only reaped the shell leader.
 	// Kill the group so those don't accumulate into an OOM (#3702). On cancel/
 	// timeout setKillTree's Cancel already did this; this covers normal exit.
-	reapTree(cmd)
+	if shouldReapAfterRun(runCtx, sh, p.Command, p.PreserveBackgroundProcesses) {
+		reapTree(cmd)
+	}
 	out := buf.String()
 
 	if errors.Is(context.Cause(runCtx), errBashTimeout) {
@@ -196,6 +201,29 @@ func (b bash) Execute(ctx context.Context, args json.RawMessage) (string, error)
 		return out, fmt.Errorf("command exited: %w", err)
 	}
 	return out, nil
+}
+
+func shouldReapAfterRun(ctx context.Context, sh sandbox.Shell, command string, preserveBackgroundProcesses bool) bool {
+	if ctx.Err() != nil {
+		return true
+	}
+	if preserveBackgroundProcesses {
+		return false
+	}
+	return sh.Kind != sandbox.ShellBash || !hasExplicitBackgroundKeepalive(command)
+}
+
+// hasExplicitBackgroundKeepalive detects common shell-level daemonization intent
+// without letting a plain "cmd &" bypass #3702's stray process cleanup.
+func hasExplicitBackgroundKeepalive(command string) bool {
+	if !hasUnquotedBackgroundOperator(command) {
+		return false
+	}
+	return hasShellCommandWord(command, map[string]struct{}{
+		"disown": {},
+		"nohup":  {},
+		"setsid": {},
+	})
 }
 
 func (b bash) foregroundTimeout() time.Duration {
@@ -238,6 +266,193 @@ func hasUnquotedSeq(s, seq string) bool {
 		}
 	}
 	return false
+}
+
+func hasUnquotedBackgroundOperator(s string) bool {
+	var quote byte
+	escaped := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if c == '\\' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '\'' || c == '"' {
+			quote = c
+			continue
+		}
+		if c != '&' {
+			continue
+		}
+		if i+1 < len(s) && s[i+1] == '&' {
+			i++
+			continue
+		}
+		prev := previousNonSpace(s, i)
+		if prev == '>' {
+			continue
+		}
+		next := nextNonSpace(s, i+1)
+		if next == '>' {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func hasShellCommandWord(s string, want map[string]struct{}) bool {
+	expectCommand := true
+	skipNextWord := false
+	for i := 0; i < len(s); {
+		c := s[i]
+		if isShellSpace(c) {
+			i++
+			continue
+		}
+		switch c {
+		case ';', '\n', '&', '|', '(':
+			if i+1 < len(s) && (s[i:i+2] == "&&" || s[i:i+2] == "||") {
+				i += 2
+			} else {
+				i++
+			}
+			expectCommand = true
+			skipNextWord = false
+			continue
+		case '<', '>':
+			i = skipShellRedirect(s, i)
+			skipNextWord = true
+			continue
+		}
+
+		word, next := readShellWord(s, i)
+		i = next
+		if word == "" {
+			continue
+		}
+		if skipNextWord {
+			skipNextWord = false
+			continue
+		}
+		if !expectCommand {
+			continue
+		}
+		if isShellAssignment(word) {
+			continue
+		}
+		base := shellWordBase(word)
+		if _, ok := want[base]; ok {
+			return true
+		}
+		if base == "command" || base == "env" {
+			continue
+		}
+		expectCommand = false
+	}
+	return false
+}
+
+func readShellWord(s string, start int) (string, int) {
+	var b strings.Builder
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if isShellSpace(c) || strings.ContainsRune(";|&()<>", rune(c)) {
+			return b.String(), i
+		}
+		switch c {
+		case '\\':
+			if i+1 < len(s) {
+				i++
+				b.WriteByte(s[i])
+			}
+		case '\'':
+			for i++; i < len(s) && s[i] != '\''; i++ {
+				b.WriteByte(s[i])
+			}
+		case '"':
+			for i++; i < len(s) && s[i] != '"'; i++ {
+				if s[i] == '\\' && i+1 < len(s) {
+					i++
+				}
+				b.WriteByte(s[i])
+			}
+		default:
+			b.WriteByte(c)
+		}
+	}
+	return b.String(), len(s)
+}
+
+func skipShellRedirect(s string, i int) int {
+	for i < len(s) && (s[i] == '<' || s[i] == '>' || s[i] == '&') {
+		i++
+	}
+	return i
+}
+
+func previousNonSpace(s string, before int) byte {
+	for i := before - 1; i >= 0; i-- {
+		if !isShellSpace(s[i]) {
+			return s[i]
+		}
+	}
+	return 0
+}
+
+func nextNonSpace(s string, after int) byte {
+	for i := after; i < len(s); i++ {
+		if !isShellSpace(s[i]) {
+			return s[i]
+		}
+	}
+	return 0
+}
+
+func isShellSpace(c byte) bool {
+	switch c {
+	case ' ', '\t', '\r', '\n':
+		return true
+	default:
+		return false
+	}
+}
+
+func isShellAssignment(word string) bool {
+	name, _, ok := strings.Cut(word, "=")
+	if !ok || name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if i == 0 {
+			if c != '_' && (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') {
+				return false
+			}
+			continue
+		}
+		if c != '_' && (c < 'A' || c > 'Z') && (c < 'a' || c > 'z') && (c < '0' || c > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func shellWordBase(word string) string {
+	if i := strings.LastIndexByte(word, '/'); i >= 0 {
+		return word[i+1:]
+	}
+	return word
 }
 
 // commandPreview is a short single-line label for a background bash job, surfaced

--- a/internal/tool/builtin/bash_reap_test.go
+++ b/internal/tool/builtin/bash_reap_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"reasonix/internal/proc"
+	"reasonix/internal/sandbox"
 )
 
 // TestReapTreeKillsGroupStragglers covers #3702: a foreground command that
@@ -58,6 +59,113 @@ func TestReapTreeKillsGroupStragglers(t *testing.T) {
 	}
 }
 
+func TestBashPreservesExplicitNoHupDisown(t *testing.T) {
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not found")
+	}
+
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "pid")
+	command := "nohup sleep 60 >/dev/null 2>&1 & echo $! > " + shellQuote(pidFile) + "; disown"
+	out, err := (bash{
+		shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: bashPath},
+	}).Execute(context.Background(), argsJSON(t, map[string]any{"command": command}))
+	if err != nil {
+		t.Fatalf("bash Execute failed: %v (out=%q)", err, out)
+	}
+
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		t.Fatalf("read pid file: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		t.Fatalf("parse backgrounded pid %q: %v", data, err)
+	}
+	defer func() { _ = syscall.Kill(pid, syscall.SIGKILL) }()
+
+	time.Sleep(200 * time.Millisecond)
+	if err := syscall.Kill(pid, 0); err != nil {
+		t.Fatalf("nohup/disown child %d did not survive bash completion: %v", pid, err)
+	}
+}
+
+func TestExplicitBackgroundKeepaliveDetection(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{
+			name:    "nohup background",
+			command: "nohup python train.py >train.log 2>&1 &",
+			want:    true,
+		},
+		{
+			name:    "disown background",
+			command: "sleep 60 >/dev/null 2>&1 & disown",
+			want:    true,
+		},
+		{
+			name:    "setsid background",
+			command: "setsid sleep 60 >/dev/null 2>&1 &",
+			want:    true,
+		},
+		{
+			name:    "plain background still reaped",
+			command: "sleep 60 >/dev/null 2>&1 &",
+			want:    false,
+		},
+		{
+			name:    "nohup without background still reaped",
+			command: "nohup sleep 1",
+			want:    false,
+		},
+		{
+			name:    "quoted nohup argument ignored",
+			command: "echo 'nohup sleep 60 &' &",
+			want:    false,
+		},
+		{
+			name:    "redirection ampersand ignored",
+			command: "nohup sleep 1 2>&1",
+			want:    false,
+		},
+		{
+			name:    "redirect target before command ignored",
+			command: "> nohup echo done &",
+			want:    false,
+		},
+		{
+			name:    "assignment before nohup",
+			command: "CUDA_VISIBLE_DEVICES=0 nohup python train.py >/dev/null 2>&1 &",
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasExplicitBackgroundKeepalive(tt.command); got != tt.want {
+				t.Fatalf("hasExplicitBackgroundKeepalive(%q) = %v, want %v", tt.command, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldReapAfterRunHonorsExplicitPreserveOnlyOnCompletion(t *testing.T) {
+	sh := sandbox.Shell{Kind: sandbox.ShellBash, Path: "bash"}
+	if shouldReapAfterRun(context.Background(), sh, "sleep 60 >/dev/null 2>&1 &", true) {
+		t.Fatal("preserve_background_processes should skip reap after normal completion")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if !shouldReapAfterRun(ctx, sh, "sleep 60 >/dev/null 2>&1 &", true) {
+		t.Fatal("cancelled commands should still reap the process group")
+	}
+}
+
 func TestShellPATHProbeDetachesControllingTerminal(t *testing.T) {
 	cmd := exec.CommandContext(context.Background(), "sh", "-c", "true")
 	proc.PrepareShellPATHProbe(cmd)
@@ -68,4 +176,8 @@ func TestShellPATHProbeDetachesControllingTerminal(t *testing.T) {
 	if !cmd.SysProcAttr.Setsid {
 		t.Fatal("login shell PATH probe should run in a new session so an interactive shell cannot take the TUI foreground")
 	}
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }


### PR DESCRIPTION
## Summary
- skip post-completion process-group reap when bash commands explicitly daemonize with `nohup`/`disown`/`setsid` plus a background operator
- add `preserve_background_processes` as an explicit escape hatch while keeping cancel/timeout cleanup intact
- cover the `nohup ... & disown` regression and preserve the #3702 plain-background reap behavior

Fixes #4642

## Tests
- `go test ./internal/tool/builtin -count=1`
- `go test ./...`