### PR TITLE
Surface opt-in PostToolUse advisories to model context

### DIFF
--- a/docs/DESKTOP_HOOKS.zh-CN.md
+++ b/docs/DESKTOP_HOOKS.zh-CN.md
@@ -97,10 +97,12 @@ Hooks 让 Reasonix 在会话、用户输入、工具调用、模型返回、压�
 | 字段 | 类型 | 说明 |
 | --- | --- | --- |
 | `command` | string | 必填。通过平台 shell 执行的命令。空字符串会被忽略。 |
+| `name` | string | 可选。hook 的稳定名称；当 `PostToolUse` 输出进入模型上下文时用于标注来源。 |
 | `match` | string | 仅 `PreToolUse`、`PostToolUse` 使用。锚定正则，空字符串或 `*` 表示匹配所有工具。 |
 | `description` | string | 可选。显示在 hooks 列表或设置页里的说明。 |
 | `timeout` | number | 可选。毫秒数。未设置时，阻塞型事件默认 5000ms，其它事件默认 30000ms。 |
 | `cwd` | string | 可选。覆盖 hook 命令工作目录。默认使用当前会话的 `cwd`。 |
+| `model_context` | boolean | 可选。仅对 `PostToolUse` 生效；为 `true` 时，exit 0 且非空的 stdout 会作为主机建议进入下一次模型请求。默认 `false`。 |
 
 `match` 是锚定正则：`"file"` 不会匹配 `read_file`，需要写成 `".*file"`。正则非法时该 hook 不会触发。
 
@@ -113,7 +115,7 @@ Hooks 让 Reasonix 在会话、用户输入、工具调用、模型返回、压�
 | 事件 key | 触发时机 | 是否可阻塞 | stdout 特殊作用 |
 | --- | --- | --- | --- |
 | `PreToolUse` | 工具权限已通过、工具真正执行前 | 是 | 无特殊作用 |
-| `PostToolUse` | 工具执行后，不论成功或失败 | 否 | 无特殊作用 |
+| `PostToolUse` | 工具执行后，不论成功或失败 | 否 | 设置 `model_context: true` 时，exit 0 且非空的 stdout 会进入下一次模型请求 |
 | `UserPromptSubmit` | 用户输入提交后、本轮模型调用前 | 是 | 无特殊作用 |
 | `Stop` | 一轮对话结束后 | 否 | 无特殊作用 |
 | `PostLLMCall` | 模型流式返回完成后，reasoning 入库前 | 否 | exit 0 且 stdout 非空时，用 stdout 替换展示的 reasoning |
@@ -139,7 +141,7 @@ Reasonix 会把一行 JSON 写入 hook 命令的 stdin。所有 payload 都至�
 | 事件 key | 额外 payload key | 示例 |
 | --- | --- | --- |
 | `PreToolUse` | `toolName`, `toolArgs` | `{"event":"PreToolUse","cwd":"/repo","toolName":"bash","toolArgs":{"command":"go test ./..."}}` |
-| `PostToolUse` | `toolName`, `toolArgs`, `toolResult` | `{"event":"PostToolUse","cwd":"/repo","toolName":"bash","toolArgs":{"command":"go test ./..."},"toolResult":"ok"}` |
+| `PostToolUse` | `toolCallId`, `toolName`, `toolArgs`, `toolResult` | `{"event":"PostToolUse","cwd":"/repo","toolCallId":"call_1","toolName":"bash","toolArgs":{"command":"go test ./..."},"toolResult":"ok"}` |
 | `UserPromptSubmit` | `prompt`, `turn` | `{"event":"UserPromptSubmit","cwd":"/repo","prompt":"修复测试","turn":1}` |
 | `Stop` | `lastAssistantText`, `turn` | `{"event":"Stop","cwd":"/repo","lastAssistantText":"已修复","turn":1}` |
 | `PostLLMCall` | `reasoning`, `turn` | `{"event":"PostLLMCall","cwd":"/repo","reasoning":"raw reasoning","turn":1}` |
@@ -166,8 +168,28 @@ stdout 和 stderr 会被捕获、去掉首尾空白，并限制单路输出最�
 特殊 stdout 行为：
 
 - `PostLLMCall`：exit 0 且 stdout 非空时，stdout 会替换用户看到的 reasoning。若 provider 的 reasoning 带签名，Reasonix 会保留原始 signed reasoning 用于后续请求，同时仍展示 hook 转换后的文本。
+- `PostToolUse`：默认不把 stdout 发给模型。只有该 hook 显式设置 `model_context: true`、命令 exit 0、且 stdout 非空时，Reasonix 才会在本轮所有工具结果之后追加一条合成的用户角色消息，把 stdout 作为主机建议发给下一次模型请求。该消息不会显示成真实用户输入。
 - `PreCompact`：所有非空 stdout 会按换行拼接，作为本次压缩摘要的额外指导。
 - 其它事件：stdout 只在非通过结果中作为提示文本使用，不会自动进入模型上下文。
+
+## 示例：把工具后的检查结果发给模型
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "name": "policy-ledger",
+        "match": "bash",
+        "command": "node .reasonix/hooks/post-tool-ledger.js",
+        "model_context": true
+      }
+    ]
+  }
+}
+```
+
+这个 hook 的 stdout 只在 exit 0 时进入模型上下文；非零退出仍只作为 warning 展示给用户。Reasonix 会限制进入模型的输出大小，并去除 ANSI 控制序列。
 
 ## 示例：阻止危险 bash 命令
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -181,12 +181,13 @@ type Gate interface {
 
 // ToolHooks fires user-configured shell hooks around each tool call. PreToolUse
 // runs before the call and may block it (block=true; message is the reason fed
-// back to the model); PostToolUse runs after and only surfaces output to the
-// user (it can't block). It is interface-shaped so the agent stays independent
-// of the hook package — a nil hooks field disables hook firing entirely.
+// back to the model); PostToolUse runs after and may return opt-in advisory
+// output for the next model turn. It is interface-shaped so the agent stays
+// independent of the hook package — a nil hooks field disables hook firing
+// entirely.
 type ToolHooks interface {
 	PreToolUse(ctx context.Context, name string, args json.RawMessage) (block bool, message string)
-	PostToolUse(ctx context.Context, name string, args json.RawMessage, result string)
+	PostToolUse(ctx context.Context, callID, name string, args json.RawMessage, result string) []string
 	// PostLLMCall fires after each model turn completes (streaming finishes)
 	// but before reasoning_content is stored. It returns the (possibly
 	// translated) reasoning string — the original when no hook is configured.
@@ -803,14 +804,17 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		emptyFinalBlocks = 0
 		usedAnyTool = true
 
-		results := a.executeBatch(ctx, calls)
+		batch := a.executeBatch(ctx, calls)
 		for i, call := range calls {
 			a.session.Add(provider.Message{
 				Role:       provider.RoleTool,
-				Content:    results[i],
+				Content:    batch.results[i],
 				ToolCallID: call.ID,
 				Name:       call.Name,
 			})
+		}
+		if advisory := FormatPostToolUseAdvisoryMessage(batch.postToolAdvisories); advisory != "" {
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: advisory})
 		}
 
 		// The prompt only grows from here; compact before the next turn so it
@@ -1256,7 +1260,7 @@ func (a *Agent) systemPrompt() string {
 // write/read ordering stays provider-ordered. ToolResult events are emitted
 // after the batch in call order, so emission stays serial even when execution
 // parallelised.
-func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []string {
+func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) toolBatchResult {
 	for _, c := range calls {
 		t, ok := a.tools.Get(c.Name)
 		ev := event.Tool{ID: c.ID, Name: c.Name, Args: c.Arguments, ReadOnly: ok && t.ReadOnly()}
@@ -1314,7 +1318,16 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 		}
 	}
 	a.applyStormBreaker(calls, outcomes, results)
-	return results
+	var advisories []string
+	for _, o := range outcomes {
+		advisories = append(advisories, o.postToolAdvisories...)
+	}
+	return toolBatchResult{results: results, postToolAdvisories: advisories}
+}
+
+type toolBatchResult struct {
+	results            []string
+	postToolAdvisories []string
 }
 
 func (a *Agent) withPreviewFileDiffs(calls []provider.ToolCall) []provider.ToolCall {
@@ -1478,11 +1491,12 @@ func batchStormSignature(calls []provider.ToolCall, outcomes []toolOutcome) (str
 // blocked narrows that to a refusal (plan mode / permission). truncMsg is set
 // (without the "· " prefix) when the output was head+tailed.
 type toolOutcome struct {
-	output    string
-	blocked   bool
-	errMsg    string
-	truncated bool
-	truncMsg  string
+	output             string
+	blocked            bool
+	errMsg             string
+	truncated          bool
+	truncMsg           string
+	postToolAdvisories []string
 }
 
 // executeOne runs a single tool call. It is pure with respect to the event sink
@@ -1595,8 +1609,9 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 	}
 	// PostToolUse hooks observe the result (they can't block); fired whether the
 	// call succeeded or errored, since the tool did run.
+	var postToolAdvisories []string
 	if a.hooks != nil {
-		a.hooks.PostToolUse(ctx, call.Name, json.RawMessage(call.Arguments), result)
+		postToolAdvisories = a.hooks.PostToolUse(ctx, call.ID, call.Name, json.RawMessage(call.Arguments), result)
 	}
 	if err != nil {
 		detail := result
@@ -1608,7 +1623,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 			detail = strings.TrimRight(detail, "\n") + "\nThe arguments were not valid JSON. Re-emit them exactly per this schema:\n" + string(t.Schema())
 		}
 		body, truncMsg := truncateToolOutput(fmt.Sprintf("error: %v\n%s", err, detail))
-		return toolOutcome{output: body, errMsg: firstLine(err.Error()), truncated: truncMsg != "", truncMsg: truncMsg}
+		return toolOutcome{output: body, errMsg: firstLine(err.Error()), truncated: truncMsg != "", truncMsg: truncMsg, postToolAdvisories: postToolAdvisories}
 	}
 	a.recordRepeatSuccess(call, t)
 	// A foreground `task` sub-agent just finished — its result is the final answer.
@@ -1618,7 +1633,7 @@ func (a *Agent) executeOne(ctx context.Context, call provider.ToolCall) toolOutc
 		a.hooks.SubagentStop(ctx, result)
 	}
 	body, truncMsg := truncateToolOutput(result)
-	return toolOutcome{output: body, truncated: truncMsg != "", truncMsg: truncMsg}
+	return toolOutcome{output: body, truncated: truncMsg != "", truncMsg: truncMsg, postToolAdvisories: postToolAdvisories}
 }
 
 func (a *Agent) planModeBlocked(toolName string, readOnly bool, args json.RawMessage) (blocked bool, message string) {

--- a/internal/agent/guards_test.go
+++ b/internal/agent/guards_test.go
@@ -226,7 +226,7 @@ func TestExecuteBatchParallelReadOnly(t *testing.T) {
 	a := New(nil, reg, NewSession(""), Options{}, event.Discard)
 
 	start := time.Now()
-	results := a.executeBatch(context.Background(), []provider.ToolCall{{Name: "a"}, {Name: "b"}, {Name: "c"}})
+	results := a.executeBatch(context.Background(), []provider.ToolCall{{Name: "a"}, {Name: "b"}, {Name: "c"}}).results
 	elapsed := time.Since(start)
 
 	if calls != 3 {
@@ -265,7 +265,7 @@ func TestExecuteBatchSegmentsAroundWrites(t *testing.T) {
 		{Name: "rw"},
 		{Name: "ro3"},
 		{Name: "ro4"},
-	})
+	}).results
 	elapsed := time.Since(start)
 
 	want := []string{"ro1 done", "ro2 done", "rw done", "ro3 done", "ro4 done"}
@@ -304,7 +304,7 @@ func TestExecuteBatchFeedsReceiptsToCompleteStep(t *testing.T) {
 			"result":"checks passed",
 			"evidence":[{"kind":"verification","summary":"tests passed","command":"go test ./internal/..."}]
 		}`},
-	})
+	}).results
 
 	if len(results) != 2 {
 		t.Fatalf("got %d results, want 2", len(results))

--- a/internal/agent/hooks_test.go
+++ b/internal/agent/hooks_test.go
@@ -13,15 +13,17 @@ import (
 
 // stubHooks blocks PreToolUse for named tools and records what it saw.
 type stubHooks struct {
-	blockPre      map[string]bool
-	preSeen       []string
-	postSeen      []string
-	preCompactOut string   // returned from PreCompact (extra summary guidance)
-	subagentSeen  []string // last-answer text passed to each SubagentStop
-	hasPostLLM    bool     // whether HasPostLLMCall reports a PostLLMCall hook
-	postLLMOut    string   // replacement returned from PostLLMCall (when hasPostLLM)
-	postLLMSeen   []string // reasoning text each PostLLMCall received
-	postLLMTurns  []int    // turn number each PostLLMCall received
+	blockPre       map[string]bool
+	preSeen        []string
+	postSeen       []string
+	postCallIDs    []string
+	postAdvisories map[string][]string
+	preCompactOut  string   // returned from PreCompact (extra summary guidance)
+	subagentSeen   []string // last-answer text passed to each SubagentStop
+	hasPostLLM     bool     // whether HasPostLLMCall reports a PostLLMCall hook
+	postLLMOut     string   // replacement returned from PostLLMCall (when hasPostLLM)
+	postLLMSeen    []string // reasoning text each PostLLMCall received
+	postLLMTurns   []int    // turn number each PostLLMCall received
 }
 
 func (h *stubHooks) PreToolUse(_ context.Context, name string, _ json.RawMessage) (bool, string) {
@@ -32,8 +34,10 @@ func (h *stubHooks) PreToolUse(_ context.Context, name string, _ json.RawMessage
 	return false, ""
 }
 
-func (h *stubHooks) PostToolUse(_ context.Context, name string, _ json.RawMessage, _ string) {
+func (h *stubHooks) PostToolUse(_ context.Context, callID, name string, _ json.RawMessage, _ string) []string {
 	h.postSeen = append(h.postSeen, name)
+	h.postCallIDs = append(h.postCallIDs, callID)
+	return h.postAdvisories[name]
 }
 
 func (h *stubHooks) SubagentStop(_ context.Context, last string) {

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -173,3 +173,43 @@ func TestRunWellFormedToolLoopRoundTrips(t *testing.T) {
 		t.Errorf("repair mutated a well-formed session: %d -> %d", before, after)
 	}
 }
+
+func TestRunPostToolUseAdvisoryReachesNextModelTurn(t *testing.T) {
+	mp := testutil.NewMock("m",
+		testutil.Turn{ToolCalls: []provider.ToolCall{{ID: "c1", Name: "echo", Arguments: `{"text":"hi"}`}}},
+		testutil.Turn{Text: "all set"},
+	)
+	hooks := &stubHooks{postAdvisories: map[string][]string{
+		"echo": []string{"observer: remember nonce 7b42"},
+	}}
+	a := New(mp, echoRegistry(), NewSession(""), Options{Hooks: hooks}, event.Discard)
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reqs := mp.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("provider requests = %d, want 2", len(reqs))
+	}
+	second := reqs[1].Messages
+	if len(second) < 2 {
+		t.Fatalf("second request missing tool/advisory messages: %+v", second)
+	}
+	toolMsg := second[len(second)-2]
+	advisory := second[len(second)-1]
+	if toolMsg.Role != provider.RoleTool || toolMsg.ToolCallID != "c1" {
+		t.Fatalf("tool result should immediately precede advisory, got %+v", toolMsg)
+	}
+	if advisory.Role != provider.RoleUser || !IsPostToolUseAdvisoryMessage(advisory.Content) {
+		t.Fatalf("last message should be synthetic advisory, got %+v", advisory)
+	}
+	if !strings.Contains(advisory.Content, "nonce 7b42") {
+		t.Fatalf("advisory content missing hook output: %q", advisory.Content)
+	}
+	if after := len(provider.SanitizeToolPairing(second)); after != len(second) {
+		t.Fatalf("advisory should preserve tool pairing, messages %d -> %d", len(second), after)
+	}
+	if got := strings.Join(hooks.postCallIDs, ","); got != "c1" {
+		t.Fatalf("PostToolUse should receive call id, got %q", got)
+	}
+}

--- a/internal/agent/nil_boundary_test.go
+++ b/internal/agent/nil_boundary_test.go
@@ -24,11 +24,13 @@ type typedNilHooks struct{}
 func (*typedNilHooks) PreToolUse(context.Context, string, json.RawMessage) (bool, string) {
 	return false, ""
 }
-func (*typedNilHooks) PostToolUse(context.Context, string, json.RawMessage, string) {}
-func (*typedNilHooks) PostLLMCall(context.Context, string, int) string              { return "" }
-func (*typedNilHooks) HasPostLLMCall() bool                                         { return false }
-func (*typedNilHooks) SubagentStop(context.Context, string)                         {}
-func (*typedNilHooks) PreCompact(context.Context, string) string                    { return "" }
+func (*typedNilHooks) PostToolUse(context.Context, string, string, json.RawMessage, string) []string {
+	return nil
+}
+func (*typedNilHooks) PostLLMCall(context.Context, string, int) string { return "" }
+func (*typedNilHooks) HasPostLLMCall() bool                            { return false }
+func (*typedNilHooks) SubagentStop(context.Context, string)            {}
+func (*typedNilHooks) PreCompact(context.Context, string) string       { return "" }
 
 func TestNewNormalizesTypedNilInterfaces(t *testing.T) {
 	var sink *typedNilAgentSink

--- a/internal/agent/posttool_advisory.go
+++ b/internal/agent/posttool_advisory.go
@@ -1,0 +1,84 @@
+package agent
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	postToolUseAdvisoryOpen  = "<post-tool-use-advisory>"
+	postToolUseAdvisoryClose = "</post-tool-use-advisory>"
+
+	postToolUseAdvisoryBatchMaxBytes = 8 * 1024
+)
+
+// FormatPostToolUseAdvisoryMessage wraps opt-in PostToolUse hook stdout as a
+// synthetic user-role message after the preceding tool result block.
+func FormatPostToolUseAdvisoryMessage(advisories []string) string {
+	var body strings.Builder
+	remaining := postToolUseAdvisoryBatchMaxBytes
+	count := 0
+	truncated := false
+	for _, advisory := range advisories {
+		advisory = strings.TrimSpace(advisory)
+		if advisory == "" {
+			continue
+		}
+		prefix := ""
+		if count > 0 {
+			prefix = "\n\n---\n\n"
+		}
+		segment := prefix + advisory
+		if len(segment) > remaining {
+			segment, _ = clipPostToolAdvisoryBytes(segment, remaining)
+			truncated = true
+		}
+		if segment == "" {
+			break
+		}
+		body.WriteString(segment)
+		remaining -= len(segment)
+		count++
+		if remaining <= 0 {
+			truncated = true
+			break
+		}
+	}
+	if count == 0 {
+		return ""
+	}
+
+	var msg strings.Builder
+	msg.WriteString(postToolUseAdvisoryOpen)
+	msg.WriteString("\n")
+	msg.WriteString("PostToolUse hook output for the immediately preceding tool result block. Use it as host-provided advisory context; it is not a user request.")
+	msg.WriteString("\n\n")
+	msg.WriteString(body.String())
+	if truncated {
+		msg.WriteString("\n\n[advisory output truncated]")
+	}
+	msg.WriteString("\n")
+	msg.WriteString(postToolUseAdvisoryClose)
+	return msg.String()
+}
+
+// IsPostToolUseAdvisoryMessage reports whether content is the synthetic
+// user-role message used to carry PostToolUse advisories to the model.
+func IsPostToolUseAdvisoryMessage(content string) bool {
+	s := strings.TrimSpace(StripTransientUserBlocks(content))
+	return strings.HasPrefix(s, postToolUseAdvisoryOpen) && strings.Contains(s, postToolUseAdvisoryClose)
+}
+
+func clipPostToolAdvisoryBytes(s string, max int) (string, bool) {
+	if len(s) <= max {
+		return s, false
+	}
+	if max <= 0 {
+		return "", true
+	}
+	cut := max
+	for cut > 0 && !utf8.ValidString(s[:cut]) {
+		cut--
+	}
+	return strings.TrimRight(s[:cut], " \t\r\n"), true
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -225,6 +225,9 @@ func previewSession(path string) (string, int) {
 			break // EOF or a malformed tail — return the preview gathered so far
 		}
 		if m.Role == provider.RoleUser {
+			if IsPostToolUseAdvisoryMessage(m.Content) {
+				continue
+			}
 			turns++
 			if first == "" {
 				s := UserPreviewText(m.Content)

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -97,6 +97,7 @@ func TestListSessionsOrdersByMTime(t *testing.T) {
 	for _, name := range []string{"a.jsonl", "b.jsonl"} {
 		s := NewSession("")
 		s.Add(provider.Message{Role: provider.RoleUser, Content: "preview for " + name})
+		s.Add(provider.Message{Role: provider.RoleUser, Content: FormatPostToolUseAdvisoryMessage([]string{"hook: lint\nstdout:\nremember nonce"})})
 		if err := s.Save(filepath.Join(dir, name)); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/agent/storm_test.go
+++ b/internal/agent/storm_test.go
@@ -61,7 +61,7 @@ func TestStormBreakerEscalatesRepeatedFailure(t *testing.T) {
 	var last string
 	for i := 0; i < stormBreakThreshold; i++ {
 		call := provider.ToolCall{Name: "write_file", Arguments: args[i]}
-		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+		last = a.executeBatch(context.Background(), []provider.ToolCall{call}).results[0]
 	}
 
 	if !strings.Contains(last, "[loop guard]") {
@@ -94,7 +94,7 @@ func TestStormBreakerEscalatesRepeatedBatch(t *testing.T) {
 	}
 	var first string
 	for i := 0; i < stormBreakThreshold; i++ {
-		first = a.executeBatch(context.Background(), batch)[0]
+		first = a.executeBatch(context.Background(), batch).results[0]
 	}
 
 	if !strings.Contains(first, "[loop guard]") {
@@ -124,7 +124,7 @@ func TestStormBreakerBatchResetsOnPartialSuccess(t *testing.T) {
 	}
 	var first string
 	for i := 0; i < stormBreakThreshold+2; i++ {
-		first = a.executeBatch(context.Background(), batch)[0]
+		first = a.executeBatch(context.Background(), batch).results[0]
 	}
 
 	if strings.Contains(first, "[loop guard]") {
@@ -146,7 +146,7 @@ func TestStormBreakerSilentBelowThreshold(t *testing.T) {
 	call := provider.ToolCall{Name: "write_file", Arguments: `{"content":"x`}
 	var last string
 	for i := 0; i < stormBreakThreshold-1; i++ {
-		last = a.executeBatch(context.Background(), []provider.ToolCall{call})[0]
+		last = a.executeBatch(context.Background(), []provider.ToolCall{call}).results[0]
 	}
 
 	if strings.Contains(last, "[loop guard]") {
@@ -170,11 +170,11 @@ func TestStormBreakerResetsOnSuccess(t *testing.T) {
 	good := provider.ToolCall{Name: "read_file", Arguments: `{"path":"x"}`}
 	ctx := context.Background()
 
-	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
-	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 2
-	a.executeBatch(ctx, []provider.ToolCall{good})            // success → reset
-	a.executeBatch(ctx, []provider.ToolCall{fail})            // count 1
-	last := a.executeBatch(ctx, []provider.ToolCall{fail})[0] // count 2 — still below threshold
+	a.executeBatch(ctx, []provider.ToolCall{fail})                    // count 1
+	a.executeBatch(ctx, []provider.ToolCall{fail})                    // count 2
+	a.executeBatch(ctx, []provider.ToolCall{good})                    // success → reset
+	a.executeBatch(ctx, []provider.ToolCall{fail})                    // count 1
+	last := a.executeBatch(ctx, []provider.ToolCall{fail}).results[0] // count 2 — still below threshold
 
 	if strings.Contains(last, "[loop guard]") {
 		t.Fatalf("guard should have reset after a successful turn, got: %q", last)

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3796,6 +3796,9 @@ func replaySectionsFor(history []provider.Message, width int, renderer *mdRender
 	for _, m := range history {
 		switch m.Role {
 		case provider.RoleUser:
+			if agent.IsPostToolUseAdvisoryMessage(m.Content) {
+				continue
+			}
 			// Steer messages are surfaced as a notice line, not a user bubble.
 			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
 				out = append(out, fmt.Sprintf("  ↪ %s\n\n", steerText))

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -46,6 +46,9 @@ func StripComposePrefixes(content string) string {
 // in the chat UI.
 func IsSyntheticUserMessage(content string) bool {
 	trimmed := strings.TrimSpace(agent.StripTransientUserBlocks(content))
+	if agent.IsPostToolUseAdvisoryMessage(trimmed) {
+		return true
+	}
 	if trimmed == planApprovedMessage {
 		return true
 	}

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -717,6 +717,11 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "post tool use advisory",
+			input: agent.FormatPostToolUseAdvisoryMessage([]string{"hook: lint\nstdout:\nremember nonce"}),
+			want:  true,
+		},
+		{
 			name:  "user mentioning a summary is not synthetic",
 			input: "Summary of what I want: fix the login bug first.",
 			want:  false,

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -90,6 +90,8 @@ const (
 
 // HookConfig is one hook as written in settings.json.
 type HookConfig struct {
+	// Name is an optional stable label used in model-visible hook advisories.
+	Name string `json:"name,omitempty"`
 	// Match is an anchored regex selecting tools (Pre/PostToolUse and
 	// PermissionRequest only); "" or "*" = every tool. Anchored: "file" won't
 	// match "read_file" — use ".*file".
@@ -102,6 +104,9 @@ type HookConfig struct {
 	Timeout int `json:"timeout,omitempty"`
 	// Cwd overrides the working directory (defaults to the payload's cwd).
 	Cwd string `json:"cwd,omitempty"`
+	// ModelContext opts a passing PostToolUse hook's stdout into the next model
+	// request as host-provided advisory context. Ignored for other events.
+	ModelContext bool `json:"model_context,omitempty"`
 }
 
 // Settings is the shape of a settings.json (only hooks for now).
@@ -247,6 +252,7 @@ func MatchesTool(h ResolvedHook, toolName string) bool {
 type Payload struct {
 	Event         Event           `json:"event"`
 	Cwd           string          `json:"cwd"`
+	ToolCallID    string          `json:"toolCallId,omitempty"`
 	ToolName      string          `json:"toolName,omitempty"`
 	ToolArgs      json.RawMessage `json:"toolArgs,omitempty"`
 	Subject       string          `json:"subject,omitempty"`

--- a/internal/hook/runner.go
+++ b/internal/hook/runner.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // Runner binds a set of resolved hooks to a session: a working directory, the
@@ -66,13 +69,15 @@ func (r *Runner) PreToolUse(ctx context.Context, name string, args json.RawMessa
 }
 
 // PostToolUse fires after a tool call. It can't block; non-pass outcomes are
-// surfaced to the user via notify.
-func (r *Runner) PostToolUse(ctx context.Context, name string, args json.RawMessage, result string) {
+// surfaced to the user via notify. Passing hooks that opt into model_context
+// return bounded stdout advisories for the next model turn.
+func (r *Runner) PostToolUse(ctx context.Context, callID, name string, args json.RawMessage, result string) []string {
 	if !r.Enabled() {
-		return
+		return nil
 	}
-	rep := Run(ctx, Payload{Event: PostToolUse, Cwd: r.cwd, ToolName: name, ToolArgs: args, ToolResult: result}, r.hooks, r.spawner)
+	rep := Run(ctx, Payload{Event: PostToolUse, Cwd: r.cwd, ToolCallID: callID, ToolName: name, ToolArgs: args, ToolResult: result}, r.hooks, r.spawner)
 	r.handle(rep)
+	return postToolUseModelAdvisories(rep, callID, name)
 }
 
 // PermissionRequest fires before a tool approval prompt is shown. It can't
@@ -228,4 +233,84 @@ func clipRunes(s string, max int) string {
 		return ""
 	}
 	return string(r[:max]) + "…"
+}
+
+const postToolUseModelContextMaxBytes = 4 * 1024
+
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+
+func postToolUseModelAdvisories(rep Report, callID, toolName string) []string {
+	var out []string
+	for _, o := range rep.Outcomes {
+		if o.Decision != DecisionPass || !o.Hook.ModelContext {
+			continue
+		}
+		stdout := sanitizeAdvisoryText(o.Stdout)
+		if stdout == "" {
+			continue
+		}
+		stdout, truncated := clipUTF8Bytes(stdout, postToolUseModelContextMaxBytes)
+		var b strings.Builder
+		b.WriteString("hook: ")
+		b.WriteString(postToolUseHookLabel(o.Hook))
+		b.WriteString("\ntool: ")
+		b.WriteString(toolName)
+		if callID != "" {
+			b.WriteString("\ntool_call_id: ")
+			b.WriteString(callID)
+		}
+		if truncated || o.Truncated {
+			b.WriteString("\ntruncated: true")
+		}
+		b.WriteString("\nstdout:\n")
+		b.WriteString(stdout)
+		out = append(out, b.String())
+	}
+	return out
+}
+
+func postToolUseHookLabel(h ResolvedHook) string {
+	if s := strings.TrimSpace(h.Name); s != "" {
+		return clipRunes(oneLine(s), 80)
+	}
+	if s := strings.TrimSpace(h.Description); s != "" {
+		return clipRunes(oneLine(s), 80)
+	}
+	return string(h.Scope) + "/" + string(h.Event)
+}
+
+func oneLine(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.Join(strings.Fields(s), " ")
+	return s
+}
+
+func sanitizeAdvisoryText(s string) string {
+	s = strings.ToValidUTF8(s, "")
+	s = ansiEscapeRE.ReplaceAllString(s, "")
+	s = strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\r' || r == '\t' {
+			return r
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+	return strings.TrimSpace(s)
+}
+
+func clipUTF8Bytes(s string, max int) (string, bool) {
+	if len(s) <= max {
+		return s, false
+	}
+	if max <= 0 {
+		return "", true
+	}
+	cut := max
+	for cut > 0 && !utf8.ValidString(s[:cut]) {
+		cut--
+	}
+	return strings.TrimRight(s[:cut], " \t\r\n"), true
 }

--- a/internal/hook/runner_test.go
+++ b/internal/hook/runner_test.go
@@ -3,6 +3,7 @@ package hook
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 )
@@ -90,7 +91,9 @@ func TestRunnerPreToolUseBlock(t *testing.T) {
 func TestRunnerPostToolUseNoHooks(t *testing.T) {
 	r := NewRunner(nil, "/tmp", nil, nil)
 	// Should not panic.
-	r.PostToolUse(context.Background(), "bash", nil, "ok")
+	if got := r.PostToolUse(context.Background(), "call_1", "bash", nil, "ok"); got != nil {
+		t.Fatalf("no hooks should return no advisories, got %v", got)
+	}
 }
 
 func TestRunnerPostToolUseWarn(t *testing.T) {
@@ -103,9 +106,49 @@ func TestRunnerPostToolUseWarn(t *testing.T) {
 	var notified string
 	notify := func(msg string) { notified = msg }
 	r := NewRunner(hooks, "/tmp", spawner, notify)
-	r.PostToolUse(context.Background(), "bash", nil, "result")
+	advisories := r.PostToolUse(context.Background(), "call_1", "bash", nil, "result")
 	if notified == "" {
 		t.Error("PostToolUse warn should notify")
+	}
+	if len(advisories) != 0 {
+		t.Fatalf("warn outcomes should not produce model advisories: %v", advisories)
+	}
+}
+
+func TestRunnerPostToolUseModelContextAdvisory(t *testing.T) {
+	hooks := []ResolvedHook{
+		{HookConfig: HookConfig{Name: "lint", Command: "advise", ModelContext: true}, Event: PostToolUse},
+		{HookConfig: HookConfig{Name: "silent", Command: "silent"}, Event: PostToolUse},
+	}
+	var got Payload
+	spawner := func(_ context.Context, in SpawnInput) SpawnResult {
+		if err := json.Unmarshal([]byte(in.Stdin), &got); err != nil {
+			t.Fatalf("payload json: %v", err)
+		}
+		if in.Command == "silent" {
+			return SpawnResult{ExitCode: 0, Stdout: "not opted in"}
+		}
+		return SpawnResult{ExitCode: 0, Stdout: "\x1b[31mremember exact nonce\x1b[0m\x00"}
+	}
+	r := NewRunner(hooks, "/tmp", spawner, nil)
+	args := json.RawMessage(`{"command":"go test"}`)
+	advisories := r.PostToolUse(context.Background(), "call_1", "bash", args, "ok")
+
+	if got.ToolCallID != "call_1" {
+		t.Fatalf("ToolCallID = %q, want call_1", got.ToolCallID)
+	}
+	if got.ToolName != "bash" || string(got.ToolArgs) != string(args) || got.ToolResult != "ok" {
+		t.Fatalf("unexpected payload: %+v", got)
+	}
+	if len(advisories) != 1 {
+		t.Fatalf("advisories = %d, want 1: %v", len(advisories), advisories)
+	}
+	adv := advisories[0]
+	if !strings.Contains(adv, "hook: lint") || !strings.Contains(adv, "tool_call_id: call_1") || !strings.Contains(adv, "remember exact nonce") {
+		t.Fatalf("advisory missing expected fields: %q", adv)
+	}
+	if strings.Contains(adv, "\x1b[") || strings.Contains(adv, "\x00") || strings.Contains(adv, "not opted in") {
+		t.Fatalf("advisory should be sanitized and opt-in only: %q", adv)
 	}
 }
 

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -464,6 +464,9 @@ func historyMessages(msgs []provider.Message) []historyMessage {
 	for _, m := range msgs {
 		// Steer messages are surfaced as a notice, not a user message.
 		if m.Role == provider.RoleUser {
+			if agent.IsPostToolUseAdvisoryMessage(m.Content) {
+				continue
+			}
 			if steerText, isSteer := agent.SteerText(m.Content); isSteer {
 				out = append(out, historyMessage{Role: "notice", Content: "↪ " + steerText})
 				continue
@@ -1039,6 +1042,9 @@ func previewSessionFile(path string) (string, int) {
 			break
 		}
 		if m.Role == "user" {
+			if agent.IsPostToolUseAdvisoryMessage(m.Content) {
+				continue
+			}
 			turns++
 			if first == "" {
 				first = agent.UserPreviewText(m.Content)

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -160,11 +160,31 @@ func TestHistoryMessagesPreserveToolDetails(t *testing.T) {
 	}
 }
 
+func TestHistoryMessagesDropPostToolUseAdvisory(t *testing.T) {
+	advisory := agent.FormatPostToolUseAdvisoryMessage([]string{"hook: lint\nstdout:\nremember nonce"})
+	got := historyMessages([]provider.Message{
+		{Role: provider.RoleUser, Content: "run command"},
+		{Role: provider.RoleTool, Name: "bash", ToolCallID: "call_1", Content: "ok"},
+		{Role: provider.RoleUser, Content: advisory},
+		{Role: provider.RoleAssistant, Content: "done"},
+	})
+
+	if len(got) != 3 {
+		t.Fatalf("history length = %d, want 3: %+v", len(got), got)
+	}
+	for _, m := range got {
+		if strings.Contains(m.Content, "remember nonce") {
+			t.Fatalf("synthetic advisory should not render in history: %+v", got)
+		}
+	}
+}
+
 func TestPreviewSessionFileStripsTransientReasoningLanguageBlock(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")
 	s := agent.NewSession("system")
 	s.Add(provider.Message{Role: provider.RoleUser, Content: "<reasoning-language>\nVisible reasoning/thinking text preference: use English.\n</reasoning-language>\n\nExplain this module"})
+	s.Add(provider.Message{Role: provider.RoleUser, Content: agent.FormatPostToolUseAdvisoryMessage([]string{"hook: lint\nstdout:\nremember nonce"})})
 	if err := s.Save(path); err != nil {
 		t.Fatal(err)
 	}

--- a/reasonix.example.toml
+++ b/reasonix.example.toml
@@ -137,12 +137,14 @@ stalled_warning_seconds = 900   # warn once per background job after this many q
 # PermissionRequest / UserPromptSubmit / Stop). They are NOT configured here — put them in
 # settings.json: ~/.reasonix/settings.json (global, always on) and
 # <project>/.reasonix/settings.json (project, runs only after `/hooks trust`).
+# PostToolUse stdout is user-visible only by default; set "model_context": true on
+# a PostToolUse hook to send passing stdout as advisory context after tool results.
 # Exit 0 = pass, exit 2 = block (PreToolUse / UserPromptSubmit only). Example
 # ~/.reasonix/settings.json:
 #   { "hooks": {
 #       "PreToolUse":  [ { "match": "bash", "command": "my-guard.sh" } ],
 #       "PermissionRequest": [ { "match": "bash", "command": "notify-send 'approval needed'" } ],
-#       "PostToolUse": [ { "match": ".*file", "command": "gofmt -w ." } ],
+#       "PostToolUse": [ { "name": "formatter", "match": ".*file", "command": "gofmt -w .", "model_context": true } ],
 #       "Stop":        [ { "command": "notify-send 'turn done'" } ] } }
 
 # A custom status line: a command whose first stdout line replaces the built-in


### PR DESCRIPTION
## Summary
- add opt-in `model_context` support for PostToolUse hooks and pass `toolCallId` in the hook payload
- append successful opt-in hook stdout as one synthetic user-role advisory after the full tool-result block and before the next model request
- hide advisory messages from chat replay, web history, synthetic-user detection, and session previews
- document the new hook fields and behavior

## Tests
- `go test ./internal/hook ./internal/agent ./internal/control ./internal/serve`
- `go test ./...`
- Spark-native read-only verifier `019ed47d-da6f-7423-b59b-30857e364c43`: no PR blocker found

## Manual intervention
- Used GitHub Pulls REST API because AgentStack `make pr-drive` manages the local `dofumiso/agentstack` PR lifecycle, while this PR targets external upstream `esengine/DeepSeek-Reasonix`.