### PR TITLE
修复后台任务 teardown 阻塞与延迟清理

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1024,6 +1024,8 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Cont
 	})
 	if err != nil {
 		if teardownTimedOut {
+			// The old session was already marked cleanup-pending, so finish the
+			// destroy cleanup instead of re-exposing a runtime in teardown.
 			go delayedDesktopSessionCleanup(oldPath, destroys)
 		} else {
 			finishDestroyHandles(destroys)

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -37,6 +37,7 @@ import (
 	"reasonix/internal/fileref"
 	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/i18n"
+	"reasonix/internal/jobs"
 	"reasonix/internal/mcpdiag"
 	"reasonix/internal/memory"
 	"reasonix/internal/plugin"
@@ -1054,6 +1055,9 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Cont
 func removeDesktopSessionArtifacts(path string) error {
 	if strings.TrimSpace(path) == "" {
 		return nil
+	}
+	if err := jobs.RemoveArtifacts(path); err != nil {
+		return err
 	}
 	paths := []string{path, agent.BranchMetaPath(path)}
 	if strings.HasSuffix(path, ".jsonl") {

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1578,14 +1578,20 @@ func (a *App) DeleteSession(path string) error {
 		a.closeRemovedSessionRuntimes(removed)
 		return err
 	}
-	err = trashSessionArtifactsBeforeMove(dir, sessionPath, key, func() {
-		destroys := a.destroyHandlesForSession(dir, sessionPath, removed)
-		waitDestroyHandles(destroys)
+	destroys := a.destroyHandlesForSession(dir, sessionPath, removed)
+	if waitDestroyHandles(destroys) {
+		if err := agent.MarkCleanupPending(sessionPath, "delete"); err != nil {
+			a.closeRemovedSessionRuntimes(removed)
+			return err
+		}
+		go delayedDesktopSessionTrash(dir, sessionPath, key, destroys)
+	} else {
+		err = trashSessionArtifacts(dir, sessionPath, key)
 		finishDestroyHandles(destroys)
-	})
-	if err != nil {
-		a.closeRemovedSessionRuntimes(removed)
-		return err
+		if err != nil {
+			a.closeRemovedSessionRuntimes(removed)
+			return err
+		}
 	}
 	a.closeRemovedSessionRuntimes(removed)
 	if fallback.needs {
@@ -1799,6 +1805,14 @@ func delayedDesktopSessionCleanup(path string, destroys []control.SessionDestroy
 	waitAllDestroyHandles(destroys)
 	if err := removeDesktopSessionArtifacts(path); err != nil {
 		slog.Warn("desktop: delayed session cleanup failed", "path", path, "err", err)
+	}
+	finishDestroyHandles(destroys)
+}
+
+func delayedDesktopSessionTrash(dir, sessionPath, key string, destroys []control.SessionDestroyHandle) {
+	waitAllDestroyHandles(destroys)
+	if err := trashSessionArtifacts(dir, sessionPath, key); err != nil {
+		slog.Warn("desktop: delayed session trash failed", "path", sessionPath, "err", err)
 	}
 	finishDestroyHandles(destroys)
 }

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1062,7 +1062,7 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Cont
 		a.saveTabsLocked()
 	}
 	a.mu.Unlock()
-	oldCtrl.Close()
+	oldCtrl.CloseAfterDestroy()
 	a.emitProjectTreeChanged()
 	return nil
 }
@@ -1581,7 +1581,7 @@ func (a *App) DeleteSession(path string) error {
 	destroys := a.destroyHandlesForSession(dir, sessionPath, removed)
 	if waitDestroyHandles(destroys) {
 		if err := agent.MarkCleanupPending(sessionPath, "delete"); err != nil {
-			a.closeRemovedSessionRuntimes(removed)
+			a.closeRemovedSessionRuntimesAfterDestroy(removed)
 			return err
 		}
 		go delayedDesktopSessionTrash(dir, sessionPath, key, destroys)
@@ -1589,11 +1589,11 @@ func (a *App) DeleteSession(path string) error {
 		err = trashSessionArtifacts(dir, sessionPath, key)
 		finishDestroyHandles(destroys)
 		if err != nil {
-			a.closeRemovedSessionRuntimes(removed)
+			a.closeRemovedSessionRuntimesAfterDestroy(removed)
 			return err
 		}
 	}
-	a.closeRemovedSessionRuntimes(removed)
+	a.closeRemovedSessionRuntimesAfterDestroy(removed)
 	if fallback.needs {
 		if err := a.openFallbackRuntime(fallback); err != nil {
 			return err
@@ -1825,6 +1825,17 @@ func (a *App) closeRemovedSessionRuntimes(removed []removedSessionRuntime) {
 		}
 		seen[item.ctrl] = true
 		item.ctrl.Close()
+	}
+}
+
+func (a *App) closeRemovedSessionRuntimesAfterDestroy(removed []removedSessionRuntime) {
+	seen := map[*control.Controller]bool{}
+	for _, item := range removed {
+		if item.ctrl == nil || seen[item.ctrl] {
+			continue
+		}
+		seen[item.ctrl] = true
+		item.ctrl.CloseAfterDestroy()
 	}
 }
 

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2046,7 +2046,7 @@ func (a *App) rebindTabToSessionPath(tab *WorkspaceTab, sessionPath string) erro
 	if sessionPath == "" {
 		return fmt.Errorf("session path is required")
 	}
-	loaded, err := agent.LoadSession(sessionPath)
+	loaded, err := loadResumableSession(sessionPath)
 	if err != nil {
 		return err
 	}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1993,7 +1993,7 @@ func (a *App) ResumeSessionForTab(tabID, path string) ([]HistoryMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	if _, err := agent.LoadSession(sessionPath); err != nil {
+	if _, err := loadResumableSession(sessionPath); err != nil {
 		return nil, err
 	}
 	if sessionRuntimeKey(tab.currentSessionPath()) == sessionRuntimeKey(sessionPath) {
@@ -2018,7 +2018,7 @@ func (a *App) OpenChannelSessionForTab(tabID, path string) ([]HistoryMessage, er
 	if err != nil {
 		return nil, err
 	}
-	if _, err := agent.LoadSession(sessionPath); err != nil {
+	if _, err := loadResumableSession(sessionPath); err != nil {
 		return nil, err
 	}
 	if sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(sessionPath) {
@@ -2047,7 +2047,7 @@ func (a *App) rebindTabToSessionPath(tab *WorkspaceTab, sessionPath string) erro
 	if sessionPath == "" {
 		return fmt.Errorf("session path is required")
 	}
-	if _, err := agent.LoadSession(sessionPath); err != nil {
+	if _, err := loadResumableSession(sessionPath); err != nil {
 		return err
 	}
 	if sessionRuntimeKey(tab.currentSessionPath()) == sessionRuntimeKey(sessionPath) {
@@ -2101,6 +2101,13 @@ func (a *App) rebindTabToSessionPath(tab *WorkspaceTab, sessionPath string) erro
 		return fmt.Errorf("resume session: controller was not built")
 	}
 	return nil
+}
+
+func loadResumableSession(sessionPath string) (*agent.Session, error) {
+	if agent.IsCleanupPending(sessionPath) {
+		return nil, fmt.Errorf("session is pending cleanup")
+	}
+	return agent.LoadSession(sessionPath)
 }
 
 // PreviewSession reads a saved session for display only. It does not snapshot or

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1013,13 +1013,14 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Cont
 
 	newSink := &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:          tab.model,
-		RequireKey:     false,
-		Sink:           newSink,
-		WorkspaceRoot:  tab.WorkspaceRoot,
-		SessionDir:     tabSessionDir(tab),
-		EffortOverride: cloneStringPtr(tab.effort),
-		TokenMode:      currentTabTokenMode(tab),
+		Model:                    tab.model,
+		RequireKey:               false,
+		Sink:                     newSink,
+		WorkspaceRoot:            tab.WorkspaceRoot,
+		SessionDir:               tabSessionDir(tab),
+		EffortOverride:           cloneStringPtr(tab.effort),
+		TokenMode:                currentTabTokenMode(tab),
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 	})
 	if err != nil {
 		if teardownTimedOut {
@@ -4895,13 +4896,14 @@ func (a *App) SetModelForTab(tabID, name string) error {
 	}
 
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:          name,
-		RequireKey:     false,
-		Sink:           tab.sink,
-		WorkspaceRoot:  tab.WorkspaceRoot,
-		SessionDir:     tabSessionDir(tab),
-		EffortOverride: cloneStringPtr(effortOverride),
-		TokenMode:      currentTabTokenMode(tab),
+		Model:                    name,
+		RequireKey:               false,
+		Sink:                     tab.sink,
+		WorkspaceRoot:            tab.WorkspaceRoot,
+		SessionDir:               tabSessionDir(tab),
+		EffortOverride:           cloneStringPtr(effortOverride),
+		TokenMode:                currentTabTokenMode(tab),
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 	})
 	if err != nil {
 		return err
@@ -4991,13 +4993,14 @@ func (a *App) SetEffortForTab(tabID, level string) error {
 		tab.Ctrl.Close()
 	}
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:          modelRef,
-		RequireKey:     false,
-		Sink:           tab.sink,
-		WorkspaceRoot:  tab.WorkspaceRoot,
-		SessionDir:     tabSessionDir(tab),
-		EffortOverride: &effort,
-		TokenMode:      currentTabTokenMode(tab),
+		Model:                    modelRef,
+		RequireKey:               false,
+		Sink:                     tab.sink,
+		WorkspaceRoot:            tab.WorkspaceRoot,
+		SessionDir:               tabSessionDir(tab),
+		EffortOverride:           &effort,
+		TokenMode:                currentTabTokenMode(tab),
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 	})
 	if err != nil {
 		return err
@@ -5063,13 +5066,14 @@ func (a *App) SetTokenModeForTab(tabID, mode string) error {
 		carried = oldCtrl.History()
 	}
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
-		Model:          modelRef,
-		RequireKey:     false,
-		Sink:           tab.sink,
-		WorkspaceRoot:  tab.WorkspaceRoot,
-		SessionDir:     tabSessionDir(tab),
-		EffortOverride: cloneStringPtr(tab.effort),
-		TokenMode:      mode,
+		Model:                    modelRef,
+		RequireKey:               false,
+		Sink:                     tab.sink,
+		WorkspaceRoot:            tab.WorkspaceRoot,
+		SessionDir:               tabSessionDir(tab),
+		EffortOverride:           cloneStringPtr(tab.effort),
+		TokenMode:                mode,
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 	})
 	if err != nil {
 		return err

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4301,6 +4301,9 @@ func (a *App) AddMCPServer(in MCPServerInput) (int, error) {
 	if ctrl == nil {
 		return 0, fmt.Errorf("no active session")
 	}
+	if controllerHasActiveRuntimeWork(ctrl) {
+		return 0, rebuildControllerActiveWorkError("MCP server")
+	}
 	entry := config.PluginEntry{
 		Name:    in.Name,
 		Type:    normalizeMCPTransport(in.Transport),
@@ -4322,6 +4325,9 @@ func (a *App) UpdateMCPServer(name string, in MCPServerInput) error {
 	ctrl := a.activeCtrl()
 	if ctrl == nil {
 		return fmt.Errorf("no active session")
+	}
+	if controllerHasActiveRuntimeWork(ctrl) {
+		return rebuildControllerActiveWorkError("MCP server")
 	}
 	if strings.TrimSpace(in.Name) != "" && strings.TrimSpace(in.Name) != name {
 		return fmt.Errorf("renaming MCP servers is not supported; remove and add a new server")
@@ -4379,6 +4385,9 @@ func (a *App) RemoveMCPServer(name string) error {
 	if tab == nil || tab.Ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
+	if controllerHasActiveRuntimeWork(tab.Ctrl) {
+		return rebuildControllerActiveWorkError("MCP server")
+	}
 	disconnected := tab.Ctrl.DisconnectMCPServer(name)
 	removed, err := a.removeDesktopMCPServer(name)
 	if err != nil {
@@ -4401,6 +4410,9 @@ func (a *App) ReconnectMCPServer(name string) error {
 	tab := a.activeTab()
 	if tab == nil || tab.Ctrl == nil {
 		return fmt.Errorf("no active session")
+	}
+	if controllerHasActiveRuntimeWork(tab.Ctrl) {
+		return rebuildControllerActiveWorkError("MCP server")
 	}
 	tab.Ctrl.DisconnectMCPServer(name)
 	if h := tab.Ctrl.Host(); h != nil {
@@ -4435,6 +4447,9 @@ func (a *App) ClearMCPServerAuthentication(name string) error {
 	if ctrl == nil {
 		return fmt.Errorf("no active session")
 	}
+	if controllerHasActiveRuntimeWork(ctrl) {
+		return rebuildControllerActiveWorkError("MCP server")
+	}
 	if _, _, _, err := config.ClearPluginAuthenticationInSource(name); err != nil {
 		return err
 	}
@@ -4452,6 +4467,9 @@ func (a *App) SetMCPServerEnabled(name string, enabled bool) error {
 	tab := a.activeTab()
 	if tab == nil || tab.Ctrl == nil {
 		return fmt.Errorf("no active session")
+	}
+	if controllerHasActiveRuntimeWork(tab.Ctrl) {
+		return rebuildControllerActiveWorkError("MCP server")
 	}
 	configuredEntry, hasConfiguredEntry, err := a.desktopMCPServerForEdit(name)
 	if err != nil {
@@ -4510,6 +4528,10 @@ func (a *App) connectConfiguredMCPServerForTab(tab *WorkspaceTab, name string) (
 // retired tier field.
 func (a *App) SetMCPServerTier(name, tier string) error {
 	tier = normalizeMCPTier(tier)
+	tab := a.activeTab()
+	if tab != nil && controllerHasActiveRuntimeWork(tab.Ctrl) {
+		return rebuildControllerActiveWorkError("MCP server")
+	}
 	updated, found, err := a.desktopMCPServerForEdit(name)
 	if err != nil {
 		return err
@@ -4525,7 +4547,6 @@ func (a *App) SetMCPServerTier(name, tier string) error {
 	if err := a.saveDesktopMCPServer(updated); err != nil {
 		return err
 	}
-	tab := a.activeTab()
 	if tier != "lazy" && tab != nil && tab.Ctrl != nil && !mcpConnected(tab.Ctrl, name) {
 		if _, err := tab.Ctrl.ConnectMCPServer(updated); err != nil {
 			recordMCPFailure(tab.Ctrl, updated, err)
@@ -6107,6 +6128,9 @@ func (a *App) ConnectKey(apiKey string) (string, error) {
 	apiKey = strings.TrimSpace(apiKey)
 	if apiKey == "" {
 		return "", fmt.Errorf("key is required")
+	}
+	if tab := a.activeTab(); tab != nil && controllerHasActiveRuntimeWork(tab.Ctrl) {
+		return "", rebuildControllerActiveWorkError("provider key")
 	}
 	ctx, cancel := context.WithTimeout(a.ctx, 8*time.Second)
 	defer cancel()

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"mime"
 	"net/http"
 	"net/url"
@@ -37,6 +38,7 @@ import (
 	"reasonix/internal/fileref"
 	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/i18n"
+	"reasonix/internal/jobs"
 	"reasonix/internal/mcpdiag"
 	"reasonix/internal/memory"
 	"reasonix/internal/plugin"
@@ -1001,7 +1003,13 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Cont
 		}
 	}
 	destroy := oldCtrl.BeginDestroySession(oldPath)
-	waitDestroyHandles([]control.SessionDestroyHandle{destroy})
+	destroys := []control.SessionDestroyHandle{destroy}
+	teardownTimedOut := waitDestroyHandles(destroys)
+	if teardownTimedOut {
+		if err := agent.MarkCleanupPending(oldPath, "clear"); err != nil {
+			return err
+		}
+	}
 
 	newSink := &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
 	newCtrl, err := boot.Build(a.bootContext(), boot.Options{
@@ -1014,19 +1022,27 @@ func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Cont
 		TokenMode:      currentTabTokenMode(tab),
 	})
 	if err != nil {
-		finishDestroyHandles([]control.SessionDestroyHandle{destroy})
+		if teardownTimedOut {
+			go delayedDesktopSessionCleanup(oldPath, destroys)
+		} else {
+			finishDestroyHandles(destroys)
+		}
 		if oldSink != nil {
 			oldSink.tabID = tab.ID
 			oldSink.ctx = a.ctx
 		}
 		return err
 	}
-	if err := removeDesktopSessionArtifacts(oldPath); err != nil {
-		finishDestroyHandles([]control.SessionDestroyHandle{destroy})
-		newCtrl.Close()
-		return err
+	if teardownTimedOut {
+		go delayedDesktopSessionCleanup(oldPath, destroys)
+	} else {
+		if err := removeDesktopSessionArtifacts(oldPath); err != nil {
+			finishDestroyHandles(destroys)
+			newCtrl.Close()
+			return err
+		}
+		finishDestroyHandles(destroys)
 	}
-	finishDestroyHandles([]control.SessionDestroyHandle{destroy})
 	a.bindControllerDisplayRecorder(newCtrl)
 	newCtrl.EnableInteractiveApproval()
 	applyTabModeToController(newCtrl, tab.mode)
@@ -1055,6 +1071,9 @@ func removeDesktopSessionArtifacts(path string) error {
 	if strings.TrimSpace(path) == "" {
 		return nil
 	}
+	if err := jobs.RemoveArtifacts(path); err != nil {
+		return err
+	}
 	paths := []string{path, agent.BranchMetaPath(path)}
 	if strings.HasSuffix(path, ".jsonl") {
 		paths = append(paths, strings.TrimSuffix(path, ".jsonl")+".ckpt")
@@ -1067,7 +1086,10 @@ func removeDesktopSessionArtifacts(path string) error {
 			return err
 		}
 	}
-	return agent.DeleteSubagentsByParent(filepath.Dir(path), agent.BranchID(path))
+	if err := agent.DeleteSubagentsByParent(filepath.Dir(path), agent.BranchID(path)); err != nil {
+		return err
+	}
+	return agent.ClearCleanupPending(path)
 }
 
 // CheckpointMeta summarises one rewind point (a user turn) for the desktop.
@@ -1745,10 +1767,22 @@ func (a *App) destroyHandlesForSession(dir, sessionPath string, removed []remove
 	return destroys
 }
 
-func waitDestroyHandles(destroys []control.SessionDestroyHandle) {
+func waitDestroyHandles(destroys []control.SessionDestroyHandle) bool {
+	timedOut := false
 	for _, destroy := range destroys {
 		if destroy.Wait != nil {
-			destroy.Wait()
+			if destroy.Wait().HasTimedOut() {
+				timedOut = true
+			}
+		}
+	}
+	return timedOut
+}
+
+func waitAllDestroyHandles(destroys []control.SessionDestroyHandle) {
+	for _, destroy := range destroys {
+		if destroy.WaitAll != nil {
+			destroy.WaitAll()
 		}
 	}
 }
@@ -1759,6 +1793,14 @@ func finishDestroyHandles(destroys []control.SessionDestroyHandle) {
 			destroy.Finish()
 		}
 	}
+}
+
+func delayedDesktopSessionCleanup(path string, destroys []control.SessionDestroyHandle) {
+	waitAllDestroyHandles(destroys)
+	if err := removeDesktopSessionArtifacts(path); err != nil {
+		slog.Warn("desktop: delayed session cleanup failed", "path", path, "err", err)
+	}
+	finishDestroyHandles(destroys)
 }
 
 func (a *App) closeRemovedSessionRuntimes(removed []removedSessionRuntime) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -1887,6 +1887,48 @@ func TestClearSessionCancelsRunningRuntimeAndKeepsTopic(t *testing.T) {
 	}
 }
 
+func TestClearSessionRemovesRunningJobArtifacts(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "clear-running-job.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"old"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+	jm := jobs.NewManager(event.Discard)
+	oldCtrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "test", Jobs: jm})
+	app := NewApp()
+	app.projectTreeChangedHook = func() {}
+	app.setTestCtrl(oldCtrl, "deepseek-flash/deepseek-v4-flash")
+	defer func() {
+		if c := app.activeCtrl(); c != nil {
+			c.Close()
+		}
+	}()
+
+	started := make(chan struct{})
+	jm.StartForSession(agent.BranchID(path), "bash", "clear artifact", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	<-started
+	jobsDir := jobs.ArtifactDir(path)
+	if _, err := os.Stat(jobsDir); err != nil {
+		t.Fatalf("job sidecar should exist before clear: %v", err)
+	}
+
+	if err := app.ClearSession(); err != nil {
+		t.Fatalf("ClearSession: %v", err)
+	}
+	if _, err := os.Stat(jobsDir); !os.IsNotExist(err) {
+		t.Fatalf("old job sidecar should be removed after clear, stat err = %v", err)
+	}
+}
+
 func TestSearchFileRefsFindsNestedBasename(t *testing.T) {
 	orig, _ := os.Getwd()
 	defer os.Chdir(orig)

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -965,6 +965,24 @@ api_key_env = "DEEPSEEK_API_KEY"
 	}
 }
 
+func TestAddOfficialProviderAccessRejectsBackgroundJobsBeforeSavingKey(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	os.Unsetenv("DEEPSEEK_API_KEY")
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.setTestCtrl(newBackgroundJobController(t, "provider-access-job"), "deepseek-flash/deepseek-v4-flash")
+
+	_, err := app.AddOfficialProviderAccess("deepseek", "sk-test")
+	if err == nil || !strings.Contains(err.Error(), "stop background jobs") {
+		t.Fatalf("AddOfficialProviderAccess with background job error = %v, want active-work guard", err)
+	}
+	if data, readErr := os.ReadFile(config.UserCredentialsPath()); readErr == nil && strings.Contains(string(data), "DEEPSEEK_API_KEY") {
+		t.Fatalf("provider key should not be saved after rejected add access:\n%s", data)
+	}
+}
+
 func TestSetProviderKeyRestoresOfficialProviderAccess(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	t.Setenv("DEEPSEEK_API_KEY", "")
@@ -1529,6 +1547,95 @@ func TestDeleteProviderRejectsAffectedBackgroundJobs(t *testing.T) {
 	}
 	if _, ok := config.LoadForEdit(config.UserConfigPath()).Provider("prov-a"); !ok {
 		t.Fatal("provider should remain after rejected deletion")
+	}
+}
+
+func TestDeleteProviderRejectsUnaffectedBackgroundJobsBeforeSavingConfig(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+
+	cfg := config.Default()
+	cfg.DefaultModel = "prov-b/model-b1"
+	cfg.Providers = []config.ProviderEntry{
+		{Name: "prov-a", Kind: "openai", BaseURL: "https://a.example.com", Model: "model-a1", APIKeyEnv: "REASONIX_TEST_KEY"},
+		{Name: "prov-b", Kind: "openai", BaseURL: "https://b.example.com", Model: "model-b1", APIKeyEnv: "REASONIX_TEST_KEY"},
+	}
+	if err := cfg.SaveTo(config.UserConfigPath()); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.setTestCtrl(newBackgroundJobController(t, "provider-unaffected-job"), "prov-b/model-b1")
+
+	err := app.DeleteProvider("prov-a")
+	if err == nil || !strings.Contains(err.Error(), "stop background jobs") {
+		t.Fatalf("DeleteProvider with unaffected background job error = %v, want active-work guard", err)
+	}
+	if _, ok := config.LoadForEdit(config.UserConfigPath()).Provider("prov-a"); !ok {
+		t.Fatal("unaffected provider should remain after rejected deletion")
+	}
+}
+
+func TestRemoveBuiltInProviderAccessRejectsBackgroundJobsBeforeSavingConfig(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserConfigPath(), []byte(`
+default_model = "mimo-pro/mimo-v2.5-pro"
+
+[desktop]
+provider_access = ["deepseek-flash", "mimo-pro"]
+
+[[providers]]
+name = "deepseek-flash"
+kind = "openai"
+base_url = "https://api.deepseek.com"
+models = ["deepseek-v4-flash", "deepseek-v4-pro"]
+default = "deepseek-v4-flash"
+api_key_env = "DEEPSEEK_API_KEY"
+
+[[providers]]
+name = "mimo-pro"
+kind = "openai"
+base_url = "https://token-plan-cn.xiaomimimo.com/v1"
+model = "mimo-v2.5-pro"
+api_key_env = "MIMO_API_KEY"
+`), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.setTestCtrl(newBackgroundJobController(t, "provider-access-unaffected-job"), "mimo-token-plan/mimo-v2.5-pro")
+
+	err := app.RemoveProviderAccess("deepseek")
+	if err == nil || !strings.Contains(err.Error(), "stop background jobs") {
+		t.Fatalf("RemoveProviderAccess with background job error = %v, want active-work guard", err)
+	}
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	access := providerAccessSet(cfg.Desktop.ProviderAccess)
+	if !access["deepseek"] && !access["deepseek-flash"] {
+		t.Fatalf("provider_access should still contain deepseek after rejected removal: %+v", cfg.Desktop.ProviderAccess)
+	}
+}
+
+func TestConnectKeyRejectsBackgroundJobsBeforeSavingKey(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	t.Setenv("DEEPSEEK_API_KEY", "")
+	os.Unsetenv("DEEPSEEK_API_KEY")
+
+	app := NewApp()
+	app.ctx = context.Background()
+	app.setTestCtrl(newBackgroundJobController(t, "connect-key-job"), "deepseek-flash/deepseek-v4-flash")
+
+	_, err := app.ConnectKey("sk-test")
+	if err == nil || !strings.Contains(err.Error(), "stop background jobs") {
+		t.Fatalf("ConnectKey with background job error = %v, want active-work guard", err)
+	}
+	if data, readErr := os.ReadFile(config.UserCredentialsPath()); readErr == nil && strings.Contains(string(data), "DEEPSEEK_API_KEY") {
+		t.Fatalf("onboarding key should not be saved after rejected connect:\n%s", data)
 	}
 }
 
@@ -2858,6 +2965,21 @@ tier = "lazy"
 	t.Fatalf("time missing after disable: %+v", view.Servers)
 }
 
+func TestSetMCPServerEnabledRejectsBackgroundJobs(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	app := NewApp()
+	app.setTestCtrl(newBackgroundJobController(t, "mcp-enabled-job"), "")
+
+	err := app.SetMCPServerEnabled("time", false)
+	if err == nil || !strings.Contains(err.Error(), "stop background jobs") {
+		t.Fatalf("SetMCPServerEnabled with background job error = %v, want active-work guard", err)
+	}
+	if tab := app.activeTab(); tab == nil || len(tab.disabledMCP) != 0 {
+		t.Fatalf("disabled MCP state changed after rejected toggle: %+v", tab)
+	}
+}
+
 func TestEditAndRemoveConfiguredMCPWithBuiltInName(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := robustTempDir(t)
@@ -3334,6 +3456,38 @@ tier = "lazy"
 	t.Fatalf("broken MCP missing from Capabilities: %+v", view.Servers)
 }
 
+func TestSetMCPServerTierRejectsBackgroundJobsBeforeSavingConfig(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	if err := os.WriteFile(config.UserConfigPath(), []byte(`
+[[plugins]]
+name = "broken"
+command = "reasonix-missing-mcp-binary"
+tier = "lazy"
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.setTestCtrl(newBackgroundJobController(t, "mcp-tier-job"), "")
+
+	err := app.SetMCPServerTier("broken", "background")
+	if err == nil || !strings.Contains(err.Error(), "stop background jobs") {
+		t.Fatalf("SetMCPServerTier with background job error = %v, want active-work guard", err)
+	}
+	data, readErr := os.ReadFile(config.UserConfigPath())
+	if readErr != nil {
+		t.Fatalf("read config: %v", readErr)
+	}
+	if !strings.Contains(string(data), `tier = "lazy"`) {
+		t.Fatalf("plugin config changed after rejected tier update:\n%s", data)
+	}
+}
+
 func TestCapabilitiesMigratesFailedMCPConfiguredTierAfterRestart(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := robustTempDir(t)
@@ -3469,6 +3623,23 @@ func waitNotRunning(t *testing.T, ctrl *control.Controller) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func newBackgroundJobController(t *testing.T, label string) *control.Controller {
+	t.Helper()
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, label+".jsonl")
+	jm := jobs.NewManager(event.Discard)
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "test", Jobs: jm})
+	t.Cleanup(ctrl.Close)
+	jm.StartForSession(agent.BranchID(path), "bash", label, func(ctx context.Context, _ io.Writer) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	return ctrl
 }
 
 func hasLevel(levels []string, want string) bool {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2467,6 +2467,43 @@ func TestOpenChannelSessionForTabIsReadOnly(t *testing.T) {
 	}
 }
 
+func TestResumeSessionRejectsCleanupPending(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	activePath := filepath.Join(dir, "active.jsonl")
+	pendingPath := filepath.Join(dir, "pending.jsonl")
+	for _, path := range []string{activePath, pendingPath} {
+		if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	if err := agent.MarkCleanupPending(pendingPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: activePath, Label: "test"})
+	app.setTestCtrl(ctrl, "")
+	defer app.activeCtrl().Close()
+
+	if _, err := app.ResumeSession(pendingPath); err == nil || !strings.Contains(err.Error(), "pending cleanup") {
+		t.Fatalf("ResumeSession cleanup-pending error = %v, want pending cleanup", err)
+	}
+	if got := app.activeCtrl().SessionPath(); filepath.Clean(got) != filepath.Clean(activePath) {
+		t.Fatalf("active session path after rejected resume = %q, want %q", got, activePath)
+	}
+	if _, err := app.OpenChannelSessionForTab("test", pendingPath); err == nil || !strings.Contains(err.Error(), "pending cleanup") {
+		t.Fatalf("OpenChannelSessionForTab cleanup-pending error = %v, want pending cleanup", err)
+	}
+	if meta := app.tabMeta(app.activeTab(), true); meta.ReadOnly {
+		t.Fatalf("rejected channel open should not make tab read-only: %+v", meta)
+	}
+}
+
 func TestResumeSessionRejectsPathOutsideControllerSessionDir(t *testing.T) {
 	dirA := t.TempDir()
 	dirB := t.TempDir()

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2069,6 +2069,53 @@ func TestDeleteSessionCancelsActiveRuntime(t *testing.T) {
 	}
 }
 
+func TestDeleteSessionWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "stuck-delete.jsonl")
+	keepPath := filepath.Join(dir, "keep.jsonl")
+	for _, p := range []string{path, keepPath} {
+		if err := os.WriteFile(p, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+			t.Fatalf("write session %s: %v", p, err)
+		}
+	}
+
+	grace := 150 * time.Millisecond
+	jm := jobs.NewManager(event.Discard, jobs.WithTeardownGrace(grace))
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "test", Jobs: jm})
+	keepCtrl := control.New(control.Options{SessionDir: dir, SessionPath: keepPath, Label: "keep"})
+	releaseJob := startNonCooperativeSessionJob(t, jm, path)
+	defer func() {
+		releaseJob()
+		ctrl.Close()
+		keepCtrl.Close()
+	}()
+
+	app := NewApp()
+	app.setTestCtrl(ctrl, "")
+	app.tabs["keep"] = &WorkspaceTab{ID: "keep", Scope: "global", Ctrl: keepCtrl, Ready: true}
+	app.tabOrder = []string{"test", "keep"}
+
+	start := time.Now()
+	if err := app.DeleteSession(filepath.Base(path)); err != nil {
+		t.Fatalf("DeleteSession(stuck job): %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > grace+100*time.Millisecond {
+		t.Fatalf("DeleteSession took %s, want one teardown grace plus scheduling slack", elapsed)
+	}
+	if !agent.IsCleanupPending(path) {
+		t.Fatalf("stuck delete should mark cleanup pending")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stuck session file should remain until delayed cleanup: %v", err)
+	}
+}
+
 func TestDeleteSessionTrashConflictKeepsRuntime(t *testing.T) {
 	isolateDesktopUserDirs(t)
 
@@ -2175,6 +2222,74 @@ func TestDeleteSessionCancelsInactiveOpenRuntime(t *testing.T) {
 	}
 	if open[filepath.Base(inactivePath)] || open[filepath.Base(otherPath)] {
 		t.Fatalf("ListSessions marked unopened session open, got %#v", open)
+	}
+}
+
+func TestTrashTopicWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_stuck_trash"
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, topicID, "Stuck trash"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	sessionPath := writeTopicSession(t, dir, "stuck-topic.jsonl", topicID, "Stuck trash", projectRoot)
+
+	grace := 150 * time.Millisecond
+	jm := jobs.NewManager(event.Discard, jobs.WithTeardownGrace(grace))
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: sessionPath, Label: "test", Jobs: jm, WorkspaceRoot: projectRoot})
+	releaseJob := startNonCooperativeSessionJob(t, jm, sessionPath)
+	defer func() {
+		releaseJob()
+		ctrl.Close()
+	}()
+
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"stuck": {
+				ID:            "stuck",
+				Scope:         "project",
+				WorkspaceRoot: projectRoot,
+				TopicID:       topicID,
+				TopicTitle:    "Stuck trash",
+				Ctrl:          ctrl,
+				Ready:         true,
+				disabledMCP:   map[string]ServerView{},
+			},
+			"keep": {
+				ID:            "keep",
+				Scope:         "project",
+				WorkspaceRoot: projectRoot,
+				TopicID:       "topic_keep",
+				TopicTitle:    "Keep",
+				Ready:         true,
+				disabledMCP:   map[string]ServerView{},
+			},
+		},
+		tabOrder:    []string{"stuck", "keep"},
+		activeTabID: "stuck",
+	}
+
+	start := time.Now()
+	if err := app.TrashTopic(topicID); err != nil {
+		t.Fatalf("TrashTopic(stuck job): %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed > grace+100*time.Millisecond {
+		t.Fatalf("TrashTopic took %s, want one teardown grace plus scheduling slack", elapsed)
+	}
+	if !agent.IsCleanupPending(sessionPath) {
+		t.Fatalf("stuck topic trash should mark cleanup pending")
+	}
+	if _, err := os.Stat(sessionPath); err != nil {
+		t.Fatalf("stuck topic session should remain until delayed trash: %v", err)
 	}
 }
 
@@ -3236,6 +3351,31 @@ func (r *blockingRunner) Run(ctx context.Context, _ string) error {
 		return ctx.Err()
 	case <-r.release:
 		return nil
+	}
+}
+
+func startNonCooperativeSessionJob(t *testing.T, jm *jobs.Manager, sessionPath string) func() {
+	t.Helper()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	jm.StartForSession(agent.BranchID(sessionPath), "bash", "stuck job", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		<-release
+		return "", ctx.Err()
+	})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background job never started")
+	}
+	released := false
+	return func() {
+		if released {
+			return
+		}
+		released = true
+		close(release)
 	}
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2126,7 +2126,8 @@ func TestDeleteSessionWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 		}
 	}
 
-	grace := 150 * time.Millisecond
+	grace := 500 * time.Millisecond
+	slack := 300 * time.Millisecond
 	jm := jobs.NewManager(event.Discard, jobs.WithTeardownGrace(grace))
 	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: path, Label: "test", Jobs: jm})
 	keepCtrl := control.New(control.Options{SessionDir: dir, SessionPath: keepPath, Label: "keep"})
@@ -2147,7 +2148,7 @@ func TestDeleteSessionWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 		t.Fatalf("DeleteSession(stuck job): %v", err)
 	}
 	elapsed := time.Since(start)
-	if elapsed > grace+100*time.Millisecond {
+	if elapsed > grace+slack {
 		t.Fatalf("DeleteSession took %s, want one teardown grace plus scheduling slack", elapsed)
 	}
 	if !agent.IsCleanupPending(path) {
@@ -2284,7 +2285,8 @@ func TestTrashTopicWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 	}
 	sessionPath := writeTopicSession(t, dir, "stuck-topic.jsonl", topicID, "Stuck trash", projectRoot)
 
-	grace := 150 * time.Millisecond
+	grace := 500 * time.Millisecond
+	slack := 300 * time.Millisecond
 	jm := jobs.NewManager(event.Discard, jobs.WithTeardownGrace(grace))
 	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: sessionPath, Label: "test", Jobs: jm, WorkspaceRoot: projectRoot})
 	releaseJob := startNonCooperativeSessionJob(t, jm, sessionPath)
@@ -2324,7 +2326,7 @@ func TestTrashTopicWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 		t.Fatalf("TrashTopic(stuck job): %v", err)
 	}
 	elapsed := time.Since(start)
-	if elapsed > grace+100*time.Millisecond {
+	if elapsed > grace+slack {
 		t.Fatalf("TrashTopic took %s, want one teardown grace plus scheduling slack", elapsed)
 	}
 	if !agent.IsCleanupPending(sessionPath) {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -123,15 +123,47 @@ func trashSessionArtifacts(dir, sessionPath, key string) error {
 func reconcileDesktopCleanupPending(dir string) error {
 	return agent.ReconcileCleanupPending(dir, func(item agent.CleanupPendingInfo) error {
 		if strings.TrimSpace(item.Meta.Operation) == "delete" {
-			if _, err := os.Stat(item.SessionPath); os.IsNotExist(err) {
-				return agent.ClearCleanupPending(item.SessionPath)
-			} else if err != nil {
+			sessionPath, key, err := validateSessionPath(dir, item.SessionPath)
+			if err != nil {
 				return err
 			}
-			return trashSessionArtifacts(dir, item.SessionPath, filepath.Base(item.SessionPath))
+			return reconcileDesktopTrashSessionArtifacts(dir, sessionPath, key)
 		}
 		return removeDesktopSessionArtifacts(item.SessionPath)
 	})
+}
+
+func reconcileDesktopTrashSessionArtifacts(dir, sessionPath, key string) error {
+	itemDir := filepath.Join(sessionTrashPath(dir), key)
+	if err := os.MkdirAll(itemDir, 0o755); err != nil {
+		return err
+	}
+	if err := movePathIfExists(sessionPath, filepath.Join(itemDir, key)); err != nil {
+		return err
+	}
+	if err := movePathIfExists(sessionPath+".meta", filepath.Join(itemDir, key+".meta")); err != nil {
+		return err
+	}
+	ckptName := strings.TrimSuffix(key, ".jsonl") + ".ckpt"
+	if err := movePathIfExists(strings.TrimSuffix(sessionPath, ".jsonl")+".ckpt", filepath.Join(itemDir, ckptName)); err != nil {
+		return err
+	}
+	jobsName := strings.TrimSuffix(key, ".jsonl") + ".jobs"
+	if err := movePathIfExists(jobs.ArtifactDir(sessionPath), filepath.Join(itemDir, jobsName)); err != nil {
+		return err
+	}
+	if err := trashSubagentArtifacts(dir, sessionPath, itemDir); err != nil {
+		return err
+	}
+	meta := trashedSessionMeta{Key: key, DeletedAt: time.Now().UnixMilli()}
+	b, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, sessionTrashMetaFile), b, 0o644); err != nil {
+		return err
+	}
+	return agent.ClearCleanupPending(sessionPath)
 }
 
 func validateSessionTrashTarget(dir, sessionPath, key string) error {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -176,6 +176,9 @@ func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove fu
 	if err := os.WriteFile(filepath.Join(itemDir, sessionTrashMetaFile), b, 0o644); err != nil {
 		return err
 	}
+	if err := agent.ClearCleanupPending(sessionPath); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -120,6 +120,20 @@ func trashSessionArtifacts(dir, sessionPath, key string) error {
 	return trashSessionArtifactsBeforeMove(dir, sessionPath, key, nil)
 }
 
+func reconcileDesktopCleanupPending(dir string) error {
+	return agent.ReconcileCleanupPending(dir, func(item agent.CleanupPendingInfo) error {
+		if strings.TrimSpace(item.Meta.Operation) == "delete" {
+			if _, err := os.Stat(item.SessionPath); os.IsNotExist(err) {
+				return agent.ClearCleanupPending(item.SessionPath)
+			} else if err != nil {
+				return err
+			}
+			return trashSessionArtifacts(dir, item.SessionPath, filepath.Base(item.SessionPath))
+		}
+		return removeDesktopSessionArtifacts(item.SessionPath)
+	})
+}
+
 func validateSessionTrashTarget(dir, sessionPath, key string) error {
 	if _, err := os.Stat(sessionPath); os.IsNotExist(err) {
 		return nil

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -218,6 +218,93 @@ func TestReconcileDesktopCleanupPendingDeleteMovesArtifactsToTrash(t *testing.T)
 	}
 }
 
+func TestReconcileDesktopCleanupPendingDeleteReusesExistingTrashDir(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "partial.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"partial"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	itemDir := filepath.Join(sessionTrashPath(dir), "partial.jsonl")
+	if err := os.MkdirAll(itemDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(sessionPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reconcileDesktopCleanupPending(dir); err != nil {
+		t.Fatalf("reconcileDesktopCleanupPending: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(itemDir, "partial.jsonl")); err != nil {
+		t.Fatalf("session should be moved into existing trash dir: %v", err)
+	}
+	if _, err := os.Stat(agent.CleanupPendingPath(sessionPath)); !os.IsNotExist(err) {
+		t.Fatalf("cleanup marker still exists after reconciliation (err=%v)", err)
+	}
+}
+
+func TestReconcileDesktopCleanupPendingDeleteMovesRemainingSidecars(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "sidecars.jsonl")
+	if err := os.WriteFile(sessionPath+".meta", []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ckptDir := filepath.Join(dir, "sidecars.ckpt")
+	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ckptDir, "1.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(jobs.ArtifactDir(sessionPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobs.ArtifactDir(sessionPath), "job.log"), []byte("job output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ref := "sa_20260102_030405_000000000_aabbccddeeff"
+	writeSubagentArtifact(t, dir, ref, agent.BranchID(sessionPath))
+	itemDir := filepath.Join(sessionTrashPath(dir), "sidecars.jsonl")
+	if err := os.MkdirAll(itemDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(itemDir, "sidecars.jsonl"), []byte(`{"role":"user","content":"sidecars"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(sessionPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reconcileDesktopCleanupPending(dir); err != nil {
+		t.Fatalf("reconcileDesktopCleanupPending: %v", err)
+	}
+
+	for _, p := range []string{
+		filepath.Join(itemDir, "sidecars.jsonl.meta"),
+		filepath.Join(itemDir, "sidecars.ckpt", "1.json"),
+		filepath.Join(itemDir, "sidecars.jobs", "job.log"),
+		filepath.Join(itemDir, "subagents", ref+".jsonl"),
+		filepath.Join(itemDir, "subagents", ref+".meta.json"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected remaining artifact %s to move into trash: %v", p, err)
+		}
+	}
+	for _, p := range []string{
+		sessionPath + ".meta",
+		ckptDir,
+		jobs.ArtifactDir(sessionPath),
+		filepath.Join(dir, "subagents", ref+".jsonl"),
+		filepath.Join(dir, "subagents", ref+".meta.json"),
+		agent.CleanupPendingPath(sessionPath),
+	} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after reconciliation (err=%v)", p, err)
+		}
+	}
+}
+
 func TestDeleteSessionFileMovesOwnedSubagentsToTrash(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -181,6 +181,43 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 }
 
+func TestReconcileDesktopCleanupPendingDeleteMovesArtifactsToTrash(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "pending.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"pending"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(jobs.ArtifactDir(sessionPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobs.ArtifactDir(sessionPath), "job.log"), []byte("job output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(sessionPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reconcileDesktopCleanupPending(dir); err != nil {
+		t.Fatalf("reconcileDesktopCleanupPending: %v", err)
+	}
+
+	trashPath := filepath.Join(dir, sessionTrashDir, "pending.jsonl", "pending.jsonl")
+	trashJobsDir := filepath.Join(dir, sessionTrashDir, "pending.jsonl", "pending.jobs")
+	for _, p := range []string{
+		trashPath,
+		filepath.Join(trashJobsDir, "job.log"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected trashed artifact %s: %v", p, err)
+		}
+	}
+	for _, p := range []string{sessionPath, jobs.ArtifactDir(sessionPath), agent.CleanupPendingPath(sessionPath)} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after reconciliation (err=%v)", p, err)
+		}
+	}
+}
+
 func TestDeleteSessionFileMovesOwnedSubagentsToTrash(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -793,11 +793,12 @@ func (a *App) rebuild() error {
 	}
 	ctrl, err := boot.Build(a.bootContext(), boot.Options{
 		Model: model, RequireKey: false,
-		Sink:           tab.sink,
-		WorkspaceRoot:  tab.WorkspaceRoot,
-		SessionDir:     tabSessionDir(tab),
-		EffortOverride: cloneStringPtr(tab.effort),
-		TokenMode:      currentTabTokenMode(tab),
+		Sink:                     tab.sink,
+		WorkspaceRoot:            tab.WorkspaceRoot,
+		SessionDir:               tabSessionDir(tab),
+		EffortOverride:           cloneStringPtr(tab.effort),
+		TokenMode:                currentTabTokenMode(tab),
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 	})
 	if err != nil {
 		a.mu.Lock()

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -553,6 +553,20 @@ func (a *App) ensureActiveTabRebuildAllowed(setting string) error {
 	return nil
 }
 
+func (a *App) ensureLiveControllersRuntimeMutationAllowed(setting string) error {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	for _, tab := range a.tabs {
+		if tab == nil {
+			continue
+		}
+		if controllerHasActiveRuntimeWork(tab.Ctrl) {
+			return rebuildControllerActiveWorkError(setting)
+		}
+	}
+	return nil
+}
+
 func (a *App) loadDesktopUserConfigForEdit() (*config.Config, string, error) {
 	userPath := config.UserConfigPath()
 	if userPath == "" {
@@ -1124,6 +1138,9 @@ func (a *App) AddOfficialProviderAccess(kind, key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if err := a.ensureActiveTabRebuildAllowed("provider access"); err != nil {
+		return "", err
+	}
 	keyWarning := ""
 	if strings.TrimSpace(key) != "" && keyEnv != "" {
 		var err error
@@ -1265,6 +1282,11 @@ func (a *App) removeBuiltInProviderAccessAndRetargetTabs(name string) error {
 		a.mu.RUnlock()
 	}
 
+	if len(affected) == 0 {
+		if err := a.ensureActiveTabRebuildAllowed("provider access"); err != nil {
+			return err
+		}
+	}
 	retargetProviderReferences(cfg, name, fallbackRef)
 	removeProviderAccess(cfg, name)
 	if err := cfg.SaveTo(path); err != nil {
@@ -1342,6 +1364,11 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 
 	if len(affected) > 0 && fallbackRef == "" {
 		return fmt.Errorf("remove provider: %q is used by open tabs and no other configured provider exists", name)
+	}
+	if len(affected) == 0 {
+		if err := a.ensureActiveTabRebuildAllowed("provider"); err != nil {
+			return err
+		}
 	}
 	if err := cfg.RemoveProvider(name); err != nil {
 		return err
@@ -1723,6 +1750,9 @@ func (a *App) SetColdResumePrune(enabled bool) error {
 }
 
 func (a *App) SetReasoningLanguage(lang string) error {
+	if err := a.ensureLiveControllersRuntimeMutationAllowed("reasoning language"); err != nil {
+		return err
+	}
 	cfg, path, err := a.loadDesktopUserConfigForEdit()
 	if err != nil {
 		return err

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -545,6 +545,22 @@ func TestSetReasoningLanguageUpdatesLiveTabControllers(t *testing.T) {
 	}
 }
 
+func TestSetReasoningLanguageRejectsBackgroundJobsBeforeSavingConfig(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	app := NewApp()
+	app.setTestCtrl(newBackgroundJobController(t, "reasoning-language-job"), "")
+
+	err := app.SetReasoningLanguage("zh")
+	if err == nil || !strings.Contains(err.Error(), "stop background jobs") {
+		t.Fatalf("SetReasoningLanguage with background job error = %v, want active-work guard", err)
+	}
+	cfg := config.LoadForEdit(config.UserConfigPath())
+	if cfg.ReasoningLanguage() != "auto" {
+		t.Fatalf("reasoning language changed after rejected update: %q", cfg.ReasoningLanguage())
+	}
+}
+
 func TestSetDesktopCheckUpdatesPersistsToUserConfig(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3420,14 +3420,18 @@ func (a *App) TrashTopic(topicID string) error {
 	defer a.closeRemovedSessionRuntimes(removed)
 
 	for _, target := range targets {
-		var destroys []control.SessionDestroyHandle
-		err := trashSessionArtifactsBeforeMove(target.dir, target.sessionPath, target.key, func() {
-			destroys = a.destroyHandlesForSession(target.dir, target.sessionPath, removed)
-			waitDestroyHandles(destroys)
-		})
-		finishDestroyHandles(destroys)
-		if err != nil {
-			return err
+		destroys := a.destroyHandlesForSession(target.dir, target.sessionPath, removed)
+		if waitDestroyHandles(destroys) {
+			if err := agent.MarkCleanupPending(target.sessionPath, "delete"); err != nil {
+				return err
+			}
+			go delayedDesktopSessionTrash(target.dir, target.sessionPath, target.key, destroys)
+		} else {
+			err := trashSessionArtifacts(target.dir, target.sessionPath, target.key)
+			finishDestroyHandles(destroys)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if err := a.DeleteTopic(topicID); err != nil {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1558,7 +1558,7 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 		if path == "" && tab.TopicID != "" {
 			existingPath := findTopicSession(dir, tab.TopicID)
 			if existingPath != "" {
-				if loaded, err := agent.LoadSession(existingPath); err == nil {
+				if loaded, err := loadResumableSession(existingPath); err == nil {
 					ctrl.Resume(loaded, existingPath)
 					path = existingPath
 				}
@@ -4388,7 +4388,12 @@ func topicSessionIndexForDir(dir string) (topicSessionDirIndex, error) {
 
 func topicSessionIndexHasTopic(index topicSessionDirIndex, topicID string) bool {
 	matches := index.byTopic[strings.TrimSpace(topicID)]
-	return len(matches) > 0
+	for _, match := range matches {
+		if !agent.IsCleanupPending(match.path) {
+			return true
+		}
+	}
+	return false
 }
 
 func topicSessionMatches(dir, topicID string) []topicSessionMatch {
@@ -4400,7 +4405,17 @@ func topicSessionMatches(dir, topicID string) []topicSessionMatch {
 	if len(matches) == 0 {
 		return nil
 	}
-	return append([]topicSessionMatch(nil), matches...)
+	out := make([]topicSessionMatch, 0, len(matches))
+	for _, match := range matches {
+		if agent.IsCleanupPending(match.path) {
+			continue
+		}
+		out = append(out, match)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func invalidateTopicSessionIndex(dir string) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1475,7 +1475,9 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 	}
 	startupSessionPath := ""
 	if pinnedPath, ok := pinnedTabSessionPath(sessionDir, tab.SessionPath); ok {
-		startupSessionPath = pinnedPath
+		if !agent.IsCleanupPending(pinnedPath) {
+			startupSessionPath = pinnedPath
+		}
 	} else if topicID != "" {
 		startupSessionPath = findTopicSession(sessionDir, topicID)
 	}
@@ -4101,6 +4103,9 @@ func globalTabWorkspaceRoot() string {
 func loadPinnedTabSession(dir, sessionPath string) (*agent.Session, string, bool) {
 	path, ok := pinnedTabSessionPath(dir, sessionPath)
 	if !ok {
+		return nil, "", false
+	}
+	if agent.IsCleanupPending(path) {
 		return nil, "", false
 	}
 	loaded, err := agent.LoadSession(path)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3417,10 +3417,20 @@ func (a *App) TrashTopic(topicID string) error {
 		a.closeRemovedSessionRuntimes(removed)
 		return err
 	}
-	defer a.closeRemovedSessionRuntimes(removed)
+	destroyBegun := false
+	defer func() {
+		if destroyBegun {
+			a.closeRemovedSessionRuntimesAfterDestroy(removed)
+			return
+		}
+		a.closeRemovedSessionRuntimes(removed)
+	}()
 
 	for _, target := range targets {
 		destroys := a.destroyHandlesForSession(target.dir, target.sessionPath, removed)
+		if len(destroys) > 0 {
+			destroyBegun = true
+		}
 		if waitDestroyHandles(destroys) {
 			if err := agent.MarkCleanupPending(target.sessionPath, "delete"); err != nil {
 				return err

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1519,13 +1519,14 @@ func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSessi
 	a.mu.Unlock()
 
 	ctrl, err := boot.Build(buildCtx, boot.Options{
-		Model:          model,
-		RequireKey:     false,
-		Sink:           tab.sink,
-		WorkspaceRoot:  root,
-		SessionDir:     sessionDir,
-		EffortOverride: cloneStringPtr(tab.effort),
-		TokenMode:      currentTabTokenMode(tab),
+		Model:                    model,
+		RequireKey:               false,
+		Sink:                     tab.sink,
+		WorkspaceRoot:            root,
+		SessionDir:               sessionDir,
+		EffortOverride:           cloneStringPtr(tab.effort),
+		TokenMode:                currentTabTokenMode(tab),
+		CleanupPendingReconciler: reconcileDesktopCleanupPending,
 	})
 	if err != nil {
 		a.mu.Lock()

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1719,6 +1719,73 @@ func TestFindTopicSessionIndexRefreshesWhenMetaChanges(t *testing.T) {
 	}
 }
 
+func TestFindTopicSessionSkipsCleanupPending(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	topicID := "topic_skip_pending"
+	now := time.Now().UTC()
+	normal := writeTopicSessionWithPrompt(t, dir, "normal.jsonl", topicID, "Normal", "", "normal prompt", now)
+	pending := writeTopicSessionWithPrompt(t, dir, "pending.jsonl", topicID, "Pending", "", "pending prompt", now.Add(time.Hour))
+
+	if got := findTopicSession(dir, topicID); got != pending {
+		t.Fatalf("pre-marker lookup = %q, want newest pending %q", got, pending)
+	}
+	if err := agent.MarkCleanupPending(pending, "delete"); err != nil {
+		t.Fatal(err)
+	}
+	if got := findTopicSession(dir, topicID); got != normal {
+		t.Fatalf("lookup with cleanup-pending newest = %q, want normal %q", got, normal)
+	}
+	if err := agent.MarkCleanupPending(normal, "delete"); err != nil {
+		t.Fatal(err)
+	}
+	if got := findTopicSession(dir, topicID); got != "" {
+		t.Fatalf("lookup with only cleanup-pending sessions = %q, want empty", got)
+	}
+}
+
+func TestOpenProjectTabSkipsCleanupPendingTopicSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "Pending topic")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	dir := desktopSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pending := writeTopicSessionWithPrompt(t, dir, "pending-topic.jsonl", topic.ID, "Pending topic", projectRoot, "pending topic prompt", time.Now())
+	if err := agent.MarkCleanupPending(pending, "delete"); err != nil {
+		t.Fatal(err)
+	}
+	if got := findTopicSession(dir, topic.ID); got != "" {
+		t.Fatalf("topic lookup with only cleanup-pending session = %q, want empty", got)
+	}
+	if got, _ := app.findTopicSessionForTarget("project", projectRoot, topic.ID); got != "" {
+		t.Fatalf("target topic lookup with only cleanup-pending session = %q, want empty", got)
+	}
+
+	meta, err := app.OpenProjectTab(projectRoot, topic.ID)
+	if err != nil {
+		t.Fatalf("open project tab: %v", err)
+	}
+	tab := waitForTabReady(t, app, meta.ID)
+	if got := filepath.Clean(tab.Ctrl.SessionPath()); got == filepath.Clean(pending) {
+		t.Fatalf("opened cleanup-pending topic session path %q", got)
+	}
+	for _, msg := range tab.Ctrl.History() {
+		if msg.Content == "pending topic prompt" {
+			t.Fatalf("opened cleanup-pending topic history at path %q: %+v", tab.Ctrl.SessionPath(), tab.Ctrl.History())
+		}
+	}
+}
+
 func TestUpdateTopicSessionTitlesUsesTopicIndex(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := config.SessionDir()

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -590,6 +590,59 @@ func TestLoadPinnedTabSessionFallsBackToMigratedBasename(t *testing.T) {
 	}
 }
 
+func TestLoadPinnedTabSessionSkipsCleanupPending(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	path := writeLegacySession(t, dir, "pending-pinned.jsonl", "pending pinned", time.Now())
+	if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	if loaded, pinnedPath, ok := loadPinnedTabSession(dir, path); ok || loaded != nil || pinnedPath != "" {
+		t.Fatalf("loadPinnedTabSession cleanup-pending = loaded:%v path:%q ok:%v, want skipped", loaded, pinnedPath, ok)
+	}
+}
+
+func TestBuildTabControllerSkipsCleanupPendingPinnedSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	pending := writeLegacySession(t, dir, "pending-startup.jsonl", "pending startup", time.Now())
+	if err := agent.MarkCleanupPending(pending, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	tab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "tab_pending")
+	tab.SessionPath = pending
+	tab.sink = &tabEventSink{tabID: tab.ID, app: app}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	app.buildTabController(tab)
+	if tab.Ctrl == nil {
+		t.Fatalf("tab controller was not built: %s", tab.StartupErr)
+	}
+	defer tab.Ctrl.Close()
+
+	if got := filepath.Clean(tab.Ctrl.SessionPath()); got == filepath.Clean(pending) {
+		t.Fatalf("startup bound cleanup-pending pinned session path %q", got)
+	}
+	for _, msg := range tab.Ctrl.History() {
+		if msg.Content == "pending startup" {
+			t.Fatalf("startup loaded cleanup-pending history: %+v", tab.Ctrl.History())
+		}
+	}
+}
+
 func TestBuildTabControllerKeepsMissingPinnedSessionPath(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -933,6 +933,38 @@ func TestServeRejectsPathLikeSessionID(t *testing.T) {
 	}
 }
 
+func TestListACPMetasSkipsCleanupPending(t *testing.T) {
+	dir := t.TempDir()
+	visibleID := "visible"
+	pendingID := "pending"
+	for _, id := range []string{visibleID, pendingID} {
+		path := transcriptPath(dir, id)
+		if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := saveACPMeta(path, acpSessionMeta{
+			SessionID: id,
+			Cwd:       t.TempDir(),
+			Title:     id,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := agent.MarkCleanupPending(transcriptPath(dir, pendingID), "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	metas, err := listACPMetas(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(metas) != 1 || metas[0].SessionID != visibleID {
+		t.Fatalf("listACPMetas = %+v, want only %q", metas, visibleID)
+	}
+}
+
 func TestDeleteSessionFilesDeletesOwnedSubagents(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -947,10 +947,7 @@ func TestSessionDeleteWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 	}
 	releaseJob()
 	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if !agent.IsCleanupPending(path) {
-			break
-		}
+	for agent.IsCleanupPending(path) {
 		if time.Now().After(deadline) {
 			t.Fatalf("cleanup-pending marker was not cleared after stuck job release")
 		}

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -1032,6 +1032,36 @@ func TestDeleteSessionFilesDeletesOwnedSubagents(t *testing.T) {
 	}
 }
 
+func TestReconcileCleanupPendingDeletesACPMeta(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := transcriptPath(dir, "pending-acp")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveACPMeta(sessionPath, acpSessionMeta{Cwd: t.TempDir(), Model: "test-model"}); err != nil {
+		t.Fatal(err)
+	}
+	jobsDir := jobs.ArtifactDir(sessionPath)
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobsDir, "bash-1.log"), []byte("output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(sessionPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReconcileCleanupPending(dir); err != nil {
+		t.Fatalf("ReconcileCleanupPending: %v", err)
+	}
+	for _, path := range []string{sessionPath, acpMetaPath(sessionPath), jobsDir, agent.CleanupPendingPath(sessionPath)} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after reconciliation (err=%v)", path, err)
+		}
+	}
+}
+
 func writeACPSubagentArtifact(t *testing.T, dir, ref, parentSession string) {
 	t.Helper()
 	subagentDir := filepath.Join(dir, "subagents")

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -99,6 +99,42 @@ func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*c
 
 func (f *configurableFactory) SessionDir() string { return f.dir }
 
+type teardownFactory struct {
+	dir     string
+	grace   time.Duration
+	mu      sync.Mutex
+	manager *jobs.Manager
+}
+
+func (f *teardownFactory) SessionDir() string { return f.dir }
+
+func (f *teardownFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
+	jm := jobs.NewManager(event.Discard, jobs.WithTeardownGrace(f.grace))
+	f.mu.Lock()
+	f.manager = jm
+	f.mu.Unlock()
+	runner := &fakeRunner{
+		sink:     p.Sink,
+		behavior: func(context.Context, event.Sink, string) error { return nil },
+	}
+	return control.New(control.Options{
+		Runner:     runner,
+		Sink:       p.Sink,
+		SessionDir: f.dir,
+		Jobs:       jm,
+	}), nil
+}
+
+func (f *teardownFactory) lastManager(t *testing.T) *jobs.Manager {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.manager == nil {
+		t.Fatal("session manager was not created")
+	}
+	return f.manager
+}
+
 func (f *configurableFactory) SessionConfigState(_ context.Context, p SessionConfigStateParams) (SessionConfigState, error) {
 	model := strings.TrimSpace(p.Model)
 	if model == "" {
@@ -835,6 +871,54 @@ func TestServeSessionClose(t *testing.T) {
 	}
 }
 
+func TestSessionDeleteWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
+	dir := t.TempDir()
+	grace := 150 * time.Millisecond
+	factory := &teardownFactory{dir: dir, grace: grace}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil || nr.SessionID == "" {
+		t.Fatalf("session/new: %v (%q)", err, nr.SessionID)
+	}
+	path := transcriptPath(dir, nr.SessionID)
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"hello"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	releaseJob := startNonCooperativeACPJob(t, factory.lastManager(t), path)
+	defer releaseJob()
+
+	start := time.Now()
+	resp := client.call(t, "session/delete", SessionDeleteParams{SessionID: nr.SessionID})
+	elapsed := time.Since(start)
+	if resp.Error != nil {
+		t.Fatalf("session/delete errored: %+v", resp.Error)
+	}
+	if elapsed > grace+100*time.Millisecond {
+		t.Fatalf("session/delete took %s, want one teardown grace plus scheduling slack", elapsed)
+	}
+	if !agent.IsCleanupPending(path) {
+		t.Fatalf("stuck ACP delete should mark cleanup pending")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stuck ACP transcript should remain until delayed cleanup: %v", err)
+	}
+	releaseJob()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if !agent.IsCleanupPending(path) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("cleanup-pending marker was not cleared after stuck job release")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestServeRejectsPathLikeSessionID(t *testing.T) {
 	factory := &fakeFactory{behavior: func(context.Context, event.Sink, string) error { return nil }}
 	client, stop := startServer(t, factory)
@@ -900,6 +984,31 @@ func writeACPSubagentArtifact(t *testing.T, dir, ref, parentSession string) {
 	}
 	if err := os.WriteFile(filepath.Join(subagentDir, ref+".meta.json"), data, 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func startNonCooperativeACPJob(t *testing.T, jm *jobs.Manager, sessionPath string) func() {
+	t.Helper()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	jm.StartForSession(agent.BranchID(sessionPath), "bash", "stuck job", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		<-release
+		return "", ctx.Err()
+	})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background job never started")
+	}
+	released := false
+	return func() {
+		if released {
+			return
+		}
+		released = true
+		close(release)
 	}
 }
 

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -912,7 +912,8 @@ func TestServeSessionClose(t *testing.T) {
 
 func TestSessionDeleteWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 	dir := t.TempDir()
-	grace := 150 * time.Millisecond
+	grace := 500 * time.Millisecond
+	slack := 300 * time.Millisecond
 	factory := &teardownFactory{dir: dir, grace: grace}
 	client, stop := startServer(t, factory)
 	defer stop()
@@ -936,7 +937,7 @@ func TestSessionDeleteWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("session/delete errored: %+v", resp.Error)
 	}
-	if elapsed > grace+100*time.Millisecond {
+	if elapsed > grace+slack {
 		t.Fatalf("session/delete took %s, want one teardown grace plus scheduling slack", elapsed)
 	}
 	if !agent.IsCleanupPending(path) {

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -733,6 +733,45 @@ func TestServeSessionLoadFallsBackFromStaleSavedModel(t *testing.T) {
 	}
 }
 
+func TestServeSessionLoadRejectsCleanupPending(t *testing.T) {
+	dir := t.TempDir()
+	cwd := t.TempDir()
+	sessionID := "pending-load"
+	path := transcriptPath(dir, sessionID)
+	saved := agent.NewSession("")
+	saved.Add(provider.Message{Role: provider.RoleUser, Content: "hello"})
+	if err := saved.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveACPMeta(path, acpSessionMeta{
+		SessionID: sessionID,
+		Cwd:       cwd,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	factory := &configurableFactory{dir: dir}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	loadResp := client.call(t, "session/load", SessionLoadParams{SessionID: sessionID, Cwd: cwd})
+	if loadResp.Error == nil || !strings.Contains(loadResp.Error.Message, "unknown session") {
+		t.Fatalf("session/load cleanup-pending error = %+v, want unknown session", loadResp.Error)
+	}
+	factory.mu.Lock()
+	builds := append([]SessionParams(nil), factory.builds...)
+	factory.mu.Unlock()
+	if len(builds) != 0 {
+		t.Fatalf("cleanup-pending load should not build a controller, got builds %+v", builds)
+	}
+}
+
 func TestServeCancel(t *testing.T) {
 	started := make(chan struct{})
 	factory := &fakeFactory{behavior: func(ctx context.Context, _ event.Sink, _ string) error {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -796,19 +797,34 @@ func (s *service) sessionDelete(_ context.Context, raw json.RawMessage) (any, er
 	}
 
 	path := ""
+	var destroy control.SessionDestroyHandle
+	var delayed bool
 	if sess := s.takeSession(p.SessionID); sess != nil {
 		sess.deleteAndWait()
-		sess.ctrl.Close()
 		path = sess.transcript
+		destroy = sess.ctrl.BeginDestroySession(path)
+		if result := destroy.Wait(); result.HasTimedOut() {
+			if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+				go delayedDeleteSessionFiles(path, destroy)
+				sess.ctrl.Close()
+				return nil, &RPCError{Code: ErrInternal, Message: "session/delete: " + err.Error()}
+			}
+			go delayedDeleteSessionFiles(path, destroy)
+			delayed = true
+		}
+		sess.ctrl.Close()
 	}
 	if path == "" {
 		if dir := s.sessionDir(); dir != "" {
 			path = transcriptPath(dir, p.SessionID)
 		}
 	}
-	if path != "" {
+	if path != "" && !delayed {
 		if err := deleteSessionFiles(path); err != nil {
 			return nil, &RPCError{Code: ErrInternal, Message: "session/delete: " + err.Error()}
+		}
+		if destroy.Finish != nil {
+			destroy.Finish()
 		}
 	}
 	return SessionDeleteResult{}, nil
@@ -1414,7 +1430,19 @@ func deleteSessionFiles(sessionPath string) error {
 	if err := jobs.RemoveArtifacts(sessionPath); err != nil {
 		return err
 	}
-	return nil
+	return agent.ClearCleanupPending(sessionPath)
+}
+
+func delayedDeleteSessionFiles(sessionPath string, destroy control.SessionDestroyHandle) {
+	if destroy.WaitAll != nil {
+		destroy.WaitAll()
+	}
+	if err := deleteSessionFiles(sessionPath); err != nil {
+		slog.Warn("acp: delayed session delete failed", "path", sessionPath, "err", err)
+	}
+	if destroy.Finish != nil {
+		destroy.Finish()
+	}
 }
 
 func checkpointPath(sessionPath string) string {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1302,6 +1302,9 @@ func listACPMetas(dir string) ([]acpSessionMeta, error) {
 		}
 		id := strings.TrimSuffix(e.Name(), ".acp.json")
 		sessionPath := transcriptPath(dir, id)
+		if agent.IsCleanupPending(sessionPath) {
+			continue
+		}
 		if !sessionFileExists(sessionPath) {
 			continue
 		}

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -806,13 +806,13 @@ func (s *service) sessionDelete(_ context.Context, raw json.RawMessage) (any, er
 		if result := destroy.Wait(); result.HasTimedOut() {
 			if err := agent.MarkCleanupPending(path, "delete"); err != nil {
 				go delayedDeleteSessionFiles(path, destroy)
-				sess.ctrl.Close()
+				sess.ctrl.CloseAfterDestroy()
 				return nil, &RPCError{Code: ErrInternal, Message: "session/delete: " + err.Error()}
 			}
 			go delayedDeleteSessionFiles(path, destroy)
 			delayed = true
 		}
-		sess.ctrl.Close()
+		sess.ctrl.CloseAfterDestroy()
 	}
 	if path == "" {
 		if dir := s.sessionDir(); dir != "" {

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -387,6 +387,9 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	}
 
 	if sess := s.session(id); sess != nil {
+		if agent.IsCleanupPending(sess.transcript) {
+			return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
+		}
 		if replay {
 			newUpdateSink(s.conn, id).replay(sess.ctrl.History())
 		}
@@ -398,8 +401,13 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 	}
 
 	var saved acpSessionMeta
+	persistedPath := ""
 	if dir := s.sessionDir(); dir != "" {
-		meta, _, metaErr := loadACPMeta(transcriptPath(dir, id))
+		persistedPath = transcriptPath(dir, id)
+		if agent.IsCleanupPending(persistedPath) {
+			return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
+		}
+		meta, _, metaErr := loadACPMeta(persistedPath)
 		if metaErr != nil {
 			return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": " + metaErr.Error()}
 		}
@@ -439,6 +447,10 @@ func (s *service) openExistingSession(ctx context.Context, method, id, cwdParam 
 		return SessionConfigState{}, &RPCError{Code: ErrInternal, Message: method + ": persistence is disabled"}
 	}
 	path := transcriptPath(dir, id)
+	if path != persistedPath && agent.IsCleanupPending(path) {
+		ctrl.Close()
+		return SessionConfigState{}, &RPCError{Code: ErrInvalidParams, Message: method + ": unknown session " + id}
+	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {
 		ctrl.Close()

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -1448,6 +1448,14 @@ func deleteSessionFiles(sessionPath string) error {
 	return agent.ClearCleanupPending(sessionPath)
 }
 
+// ReconcileCleanupPending retries delayed ACP session cleanup left by a previous
+// process, including ACP's own metadata sidecar.
+func ReconcileCleanupPending(dir string) error {
+	return agent.ReconcileCleanupPending(dir, func(item agent.CleanupPendingInfo) error {
+		return deleteSessionFiles(item.SessionPath)
+	})
+}
+
 func delayedDeleteSessionFiles(sessionPath string, destroy control.SessionDestroyHandle) {
 	if destroy.WaitAll != nil {
 		destroy.WaitAll()

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -183,6 +183,9 @@ func ListBranches(dir string) ([]BranchInfo, error) {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
+		if !IsVisibleSession(path) {
+			continue
+		}
 		preview, turns := previewSession(path)
 		if turns == 0 {
 			continue

--- a/internal/agent/branch_test.go
+++ b/internal/agent/branch_test.go
@@ -54,6 +54,44 @@ func TestBranchMetaRoundTripAndList(t *testing.T) {
 	}
 }
 
+func TestListBranchesSkipsCleanupPending(t *testing.T) {
+	dir := t.TempDir()
+	visiblePath := filepath.Join(dir, "visible.jsonl")
+	pendingPath := filepath.Join(dir, "pending.jsonl")
+
+	visible := NewSession("sys")
+	visible.Add(provider.Message{Role: provider.RoleUser, Content: "visible prompt"})
+	if err := visible.Save(visiblePath); err != nil {
+		t.Fatal(err)
+	}
+	if err := TouchBranchMeta(visiblePath); err != nil {
+		t.Fatal(err)
+	}
+
+	pending := NewSession("sys")
+	pending.Add(provider.Message{Role: provider.RoleUser, Content: "pending prompt"})
+	if err := pending.Save(pendingPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveBranchMeta(pendingPath, BranchMeta{Name: "pending experiment"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := MarkCleanupPending(pendingPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	branches, err := ListBranches(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(branches) != 1 {
+		t.Fatalf("branches = %d, want 1: %+v", len(branches), branches)
+	}
+	if branches[0].Path != visiblePath {
+		t.Fatalf("listed branch path = %q, want %q", branches[0].Path, visiblePath)
+	}
+}
+
 func TestSessionModelRoundTripPreservesActivity(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "session.jsonl")

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -15,6 +15,8 @@ import (
 	"reasonix/internal/provider"
 )
 
+const cleanupPendingExt = ".cleanup-pending.json"
+
 // Save writes the session's messages to path in JSONL — one provider.Message
 // per line — so a user can resume the conversation later. The file is
 // rewritten in full on every save: chat sessions are small (kilobytes), and
@@ -108,6 +110,62 @@ type SessionOrderInfo struct {
 	TopicTitle     string
 }
 
+// CleanupPendingMeta records that a session was logically removed but still has
+// artifacts waiting for a background job to unwind before physical cleanup.
+type CleanupPendingMeta struct {
+	Operation string `json:"operation"`
+	CreatedAt int64  `json:"createdAt"`
+}
+
+// CleanupPendingPath returns the durable marker path for a session transcript.
+func CleanupPendingPath(sessionPath string) string {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return ""
+	}
+	return strings.TrimSuffix(sessionPath, ".jsonl") + cleanupPendingExt
+}
+
+// MarkCleanupPending hides a logically removed session from resume/list surfaces
+// until delayed physical cleanup has finished.
+func MarkCleanupPending(sessionPath, operation string) error {
+	path := CleanupPendingPath(sessionPath)
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	meta := CleanupPendingMeta{Operation: strings.TrimSpace(operation), CreatedAt: time.Now().UnixMilli()}
+	b, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+// ClearCleanupPending removes a delayed-cleanup marker after physical cleanup.
+func ClearCleanupPending(sessionPath string) error {
+	path := CleanupPendingPath(sessionPath)
+	if path == "" {
+		return nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// IsCleanupPending reports whether a session is hidden pending delayed cleanup.
+func IsCleanupPending(sessionPath string) bool {
+	path := CleanupPendingPath(sessionPath)
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // ListSessionOrder returns every *.jsonl session under dir in the same
 // most-recently-active order used by ListSessions, using only file metadata and
 // branch sidecars. A missing directory is not an error.
@@ -129,6 +187,9 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			continue
 		}
 		full := filepath.Join(dir, e.Name())
+		if IsCleanupPending(full) {
+			continue
+		}
 		createdAt := info.ModTime()
 		lastActivityAt := info.ModTime()
 		scope := "global"

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -166,6 +166,12 @@ func IsCleanupPending(sessionPath string) bool {
 	return err == nil
 }
 
+// IsVisibleSession reports whether a persisted session should appear on normal
+// user/agent-facing list, restore, and retrieval surfaces.
+func IsVisibleSession(sessionPath string) bool {
+	return strings.TrimSpace(sessionPath) != "" && !IsCleanupPending(sessionPath)
+}
+
 // ListSessionOrder returns every *.jsonl session under dir in the same
 // most-recently-active order used by ListSessions, using only file metadata and
 // branch sidecars. A missing directory is not an error.
@@ -187,7 +193,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			continue
 		}
 		full := filepath.Join(dir, e.Name())
-		if IsCleanupPending(full) {
+		if !IsVisibleSession(full) {
 			continue
 		}
 		createdAt := info.ModTime()

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -117,6 +117,14 @@ type CleanupPendingMeta struct {
 	CreatedAt int64  `json:"createdAt"`
 }
 
+// CleanupPendingInfo describes one durable delayed-cleanup marker and the
+// session transcript it belongs to.
+type CleanupPendingInfo struct {
+	SessionPath string
+	MarkerPath  string
+	Meta        CleanupPendingMeta
+}
+
 // CleanupPendingPath returns the durable marker path for a session transcript.
 func CleanupPendingPath(sessionPath string) string {
 	sessionPath = strings.TrimSpace(sessionPath)
@@ -170,6 +178,71 @@ func IsCleanupPending(sessionPath string) bool {
 // user/agent-facing list, restore, and retrieval surfaces.
 func IsVisibleSession(sessionPath string) bool {
 	return strings.TrimSpace(sessionPath) != "" && !IsCleanupPending(sessionPath)
+}
+
+// ListCleanupPending returns delayed-cleanup markers left in dir. A missing
+// directory is not an error.
+func ListCleanupPending(dir string) ([]CleanupPendingInfo, error) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out []CleanupPendingInfo
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), cleanupPendingExt) {
+			continue
+		}
+		markerPath := filepath.Join(dir, e.Name())
+		var meta CleanupPendingMeta
+		b, err := os.ReadFile(markerPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		if strings.TrimSpace(string(b)) != "" {
+			if err := json.Unmarshal(b, &meta); err != nil {
+				return nil, fmt.Errorf("read cleanup-pending marker %s: %w", markerPath, err)
+			}
+		}
+		name := strings.TrimSuffix(e.Name(), cleanupPendingExt) + ".jsonl"
+		out = append(out, CleanupPendingInfo{
+			SessionPath: filepath.Join(dir, name),
+			MarkerPath:  markerPath,
+			Meta:        meta,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].SessionPath < out[j].SessionPath
+	})
+	return out, nil
+}
+
+// ReconcileCleanupPending retries physical cleanup for leftover delayed-cleanup
+// markers. It keeps going after individual cleanup errors and returns them joined.
+func ReconcileCleanupPending(dir string, cleanup func(CleanupPendingInfo) error) error {
+	pending, err := ListCleanupPending(dir)
+	if err != nil {
+		return err
+	}
+	if cleanup == nil {
+		return nil
+	}
+	var errs []error
+	for _, item := range pending {
+		if err := cleanup(item); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", item.SessionPath, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // ListSessionOrder returns every *.jsonl session under dir in the same

--- a/internal/agent/save_test.go
+++ b/internal/agent/save_test.go
@@ -125,6 +125,41 @@ func TestListSessionsOrdersByMTime(t *testing.T) {
 	}
 }
 
+func TestListSessionsSkipsCleanupPending(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pending.jsonl")
+	s := NewSession("")
+	s.Add(provider.Message{Role: provider.RoleUser, Content: "preview"})
+	if err := s.Save(path); err != nil {
+		t.Fatal(err)
+	}
+	if err := MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+	if !IsCleanupPending(path) {
+		t.Fatal("session should be marked cleanup-pending")
+	}
+
+	got, err := ListSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("cleanup-pending session should be hidden, got %+v", got)
+	}
+
+	if err := ClearCleanupPending(path); err != nil {
+		t.Fatal(err)
+	}
+	got, err = ListSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Path != path {
+		t.Fatalf("session should be visible after clearing marker, got %+v", got)
+	}
+}
+
 func TestListSessionsOrdersByLastActivityMeta(t *testing.T) {
 	dir := t.TempDir()
 	aPath := filepath.Join(dir, "a.jsonl")

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -101,6 +101,10 @@ type Options struct {
 	// SessionDir overrides where persisted chat transcripts are written. When
 	// empty, the shared CLI/global session directory is used.
 	SessionDir string
+	// CleanupPendingReconciler retries delayed physical cleanup for session
+	// artifacts left by a previous process. Nil uses the core physical-delete
+	// reconciler; frontends with different deletion semantics can override it.
+	CleanupPendingReconciler func(sessionDir string) error
 }
 
 // Build loads config, resolves the model(s), and returns a Controller wrapping a
@@ -169,6 +173,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	sessionDir := opts.SessionDir
 	if sessionDir == "" {
 		sessionDir = config.SessionDir()
+	}
+	reconcileCleanupPending := opts.CleanupPendingReconciler
+	if reconcileCleanupPending == nil {
+		reconcileCleanupPending = control.ReconcileCleanupPending
+	}
+	if err := reconcileCleanupPending(sessionDir); err != nil {
+		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "cleanup-pending reconciliation failed: " + err.Error()})
 	}
 
 	proxySpec := cfg.NetworkProxySpec()

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -95,6 +95,45 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 }
 
+func TestBuildRunsCleanupPendingReconciler(t *testing.T) {
+	isolateConfigHome(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+	sessionDir := filepath.Join(t.TempDir(), "sessions")
+	called := false
+	ctrl, err := Build(context.Background(), Options{
+		SessionDir: sessionDir,
+		CleanupPendingReconciler: func(got string) error {
+			called = true
+			if filepath.Clean(got) != filepath.Clean(sessionDir) {
+				t.Fatalf("reconciler dir = %q, want %q", got, sessionDir)
+			}
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+	if !called {
+		t.Fatal("cleanup-pending reconciler was not called")
+	}
+}
+
 func TestBuildRegistersUsableHistoryAndMemoryRetrievalTools(t *testing.T) {
 	isolateConfigHome(t)
 	dir := robustTempDir(t)

--- a/internal/cli/acp.go
+++ b/internal/cli/acp.go
@@ -74,13 +74,14 @@ func (f *acpFactory) NewSession(ctx context.Context, p acp.SessionParams) (*cont
 		return nil, fmt.Errorf("session cwd must be an absolute path: %s", root)
 	}
 	return boot.Build(ctx, boot.Options{
-		Model:          firstNonEmpty(p.Model, f.model),
-		RequireKey:     true,
-		Sink:           p.Sink,
-		EffortOverride: p.EffortOverride,
-		Stderr:         os.Stderr,
-		WorkspaceRoot:  root,
-		ExtraPlugins:   p.MCPServers,
+		Model:                    firstNonEmpty(p.Model, f.model),
+		RequireKey:               true,
+		Sink:                     p.Sink,
+		EffortOverride:           p.EffortOverride,
+		Stderr:                   os.Stderr,
+		WorkspaceRoot:            root,
+		ExtraPlugins:             p.MCPServers,
+		CleanupPendingReconciler: acp.ReconcileCleanupPending,
 	})
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -261,6 +261,13 @@ func modelForResumePath(modelName, resumePath string, cfg *config.Config) string
 	return sessionModel
 }
 
+func loadResumableSession(path string) (*agent.Session, error) {
+	if agent.IsCleanupPending(path) {
+		return nil, fmt.Errorf("session is pending cleanup")
+	}
+	return agent.LoadSession(path)
+}
+
 var newNotificationSender = func() notify.Sender { return notify.NewPlatformSender() }
 
 // withNotifications adds system notifications to CLI event streams when configured.
@@ -297,6 +304,16 @@ func runAgent(args []string) int {
 	if prompt == "" {
 		fmt.Fprintln(os.Stderr, i18n.M.UsageRunHint)
 		return 2
+	}
+
+	var resumeSession *agent.Session
+	if *resume != "" {
+		var err error
+		resumeSession, err = loadResumableSession(*resume)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
@@ -341,12 +358,7 @@ func runAgent(args []string) int {
 	// precedence over --continue.
 	// --continue: resume the most recent saved session.
 	if *resume != "" {
-		loaded, err := agent.LoadSession(*resume)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-			return 1
-		}
-		ctrl.Resume(loaded, *resume)
+		ctrl.Resume(resumeSession, *resume)
 	} else if *cont {
 		sessions, err := agent.ListSessions(ctrl.SessionDir())
 		if err != nil || len(sessions) == 0 {
@@ -397,6 +409,15 @@ func runServe(args []string) int {
 	ctx := context.Background()
 	bc := serve.NewBroadcaster()
 	cfg, _ := config.Load()
+	var resumeSession *agent.Session
+	if *resume != "" {
+		var err error
+		resumeSession, err = loadResumableSession(*resume)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
+			return 1
+		}
+	}
 	*model = modelForResumePath(*model, *resume, cfg)
 	ctrl, err := setup(ctx, *model, *maxSteps, true, bc)
 	if err != nil {
@@ -407,12 +428,7 @@ func runServe(args []string) int {
 
 	// Auto-save target: reuse the resumed file, else a fresh one — same as chat.
 	if *resume != "" {
-		loaded, err := agent.LoadSession(*resume)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, i18n.M.ErrorPrefix, err)
-			return 1
-		}
-		ctrl.Resume(loaded, *resume)
+		ctrl.Resume(resumeSession, *resume)
 	} else if ctrl.SessionDir() != "" {
 		ctrl.SetSessionPath(agent.NewSessionPath(ctrl.SessionDir(), ctrl.Label()))
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -87,6 +87,57 @@ func TestModelForResumePathUsesStoredModelWhenAvailable(t *testing.T) {
 	}
 }
 
+func TestLoadResumableSessionRejectsCleanupPending(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pending.jsonl")
+	saveTestSession(t, path, "pending prompt")
+	if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := loadResumableSession(path); err == nil || !strings.Contains(err.Error(), "pending cleanup") {
+		t.Fatalf("loadResumableSession cleanup-pending error = %v, want pending cleanup", err)
+	}
+}
+
+func TestRunResumeRejectsCleanupPending(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	path := filepath.Join(t.TempDir(), "pending-run.jsonl")
+	saveTestSession(t, path, "pending prompt")
+	if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	errOut := captureStderr(t, func() {
+		if rc := runAgent([]string{"--resume", path, "continue task"}); rc != 1 {
+			t.Fatalf("run --resume cleanup-pending rc = %d, want 1", rc)
+		}
+	})
+	if !strings.Contains(errOut, "pending cleanup") {
+		t.Fatalf("run --resume cleanup-pending stderr = %q, want pending cleanup", errOut)
+	}
+}
+
+func TestServeResumeRejectsCleanupPending(t *testing.T) {
+	isolateCLIConfigHome(t)
+
+	path := filepath.Join(t.TempDir(), "pending-serve.jsonl")
+	saveTestSession(t, path, "pending prompt")
+	if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	errOut := captureStderr(t, func() {
+		if rc := runServe([]string{"--resume", path, "--addr", "127.0.0.1:0"}); rc != 1 {
+			t.Fatalf("serve --resume cleanup-pending rc = %d, want 1", rc)
+		}
+	})
+	if !strings.Contains(errOut, "pending cleanup") {
+		t.Fatalf("serve --resume cleanup-pending stderr = %q, want pending cleanup", errOut)
+	}
+}
+
 func TestReserveNativeScrollbackFrameWritesOnlyNewlines(t *testing.T) {
 	var b bytes.Buffer
 	reserveNativeScrollbackFrame(&b, 3)

--- a/internal/cli/complete_test.go
+++ b/internal/cli/complete_test.go
@@ -408,6 +408,18 @@ func TestSlashArgCompletionSwitchBranches(t *testing.T) {
 	if err := agent.SaveBranchMeta(childPath, agent.BranchMeta{Name: "experiment", ParentID: agent.BranchID(rootPath)}); err != nil {
 		t.Fatal(err)
 	}
+	pending := agent.NewSession("sys")
+	pending.Add(provider.Message{Role: provider.RoleUser, Content: "pending child prompt"})
+	pendingPath := filepath.Join(dir, "pending.jsonl")
+	if err := pending.Save(pendingPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(pendingPath, agent.BranchMeta{Name: "exp-pending", ParentID: agent.BranchID(rootPath)}); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(pendingPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
 
 	m := newTestChatTUI()
 	m.ctrl = ctrl

--- a/internal/control/branches_test.go
+++ b/internal/control/branches_test.go
@@ -52,6 +52,48 @@ func TestBranchAndSwitch(t *testing.T) {
 	}
 }
 
+func TestSwitchBranchRejectsCleanupPending(t *testing.T) {
+	dir := t.TempDir()
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	exec.Session().Add(provider.Message{Role: provider.RoleUser, Content: "root prompt"})
+	c := New(Options{Executor: exec, SessionDir: dir, Label: "test"})
+	c.SetSessionPath(filepath.Join(dir, "root.jsonl"))
+	if err := c.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+	rootPath := c.SessionPath()
+	rootID := agent.BranchID(rootPath)
+
+	if _, err := c.Branch("pending experiment"); err != nil {
+		t.Fatal(err)
+	}
+	pendingPath := c.SessionPath()
+	pendingID := agent.BranchID(pendingPath)
+	if _, err := c.SwitchBranch(rootID); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(pendingPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	tree := c.BranchTreeText()
+	if strings.Contains(tree, "pending experiment") || strings.Contains(tree, shortBranchID(pendingID)) {
+		t.Fatalf("tree leaked cleanup-pending branch:\n%s", tree)
+	}
+	if _, err := c.SwitchBranch(pendingID); err == nil {
+		t.Fatal("SwitchBranch cleanup-pending id error = nil, want not found")
+	}
+	if c.SessionPath() != rootPath {
+		t.Fatalf("session path changed to %q, want %q", c.SessionPath(), rootPath)
+	}
+	if _, err := c.SwitchBranch(pendingPath); err == nil {
+		t.Fatal("SwitchBranch cleanup-pending path error = nil, want not found")
+	}
+	if c.SessionPath() != rootPath {
+		t.Fatalf("session path changed to %q, want %q", c.SessionPath(), rootPath)
+	}
+}
+
 func TestBranchResetsTwoModelPlannerContext(t *testing.T) {
 	dir := t.TempDir()
 	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1887,6 +1887,9 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	if err != nil {
 		return agent.BranchInfo{}, c.rewindFail(err)
 	}
+	if !agent.IsVisibleSession(match.Path) {
+		return agent.BranchInfo{}, c.rewindFail(fmt.Errorf("branch %q not found", ref))
+	}
 	loaded, err := agent.LoadSession(match.Path)
 	if err != nil {
 		return agent.BranchInfo{}, c.rewindFail(err)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2155,7 +2155,7 @@ func (c *Controller) BeginDestroySession(sessionPath string) SessionDestroyHandl
 	teardown := c.jobs.BeginDestroySession(parentSession)
 	return SessionDestroyHandle{
 		Wait: func() jobs.TeardownResult {
-			return c.jobs.WaitTeardown(context.Background(), teardown, jobs.DefaultTeardownGrace)
+			return c.jobs.WaitTeardown(context.Background(), teardown, c.jobs.TeardownGrace())
 		},
 		WaitAll: func() {
 			for _, ch := range teardown.DoneChannels() {
@@ -2623,16 +2623,31 @@ func (c *Controller) InheritLifecycleFrom(prev *Controller) {
 // firing SessionEnd. Use it only when replacing the controller for the same
 // logical session.
 func (c *Controller) ReleaseResources() {
-	c.close(false)
+	c.close(false, closeJobsWithGrace)
 }
 
 // Close stops plugin subprocesses and releases resources. A session that ever
 // started fires SessionEnd so a teardown hook runs.
 func (c *Controller) Close() {
-	c.close(true)
+	c.close(true, closeJobsWithGrace)
 }
 
-func (c *Controller) close(fireSessionEnd bool) {
+// CloseAfterDestroy releases controller resources after the caller has already
+// begun session-specific job teardown. It avoids a second synchronous job grace
+// wait while still cancelling the manager root and reaping temporary artifacts
+// once every job goroutine finally exits.
+func (c *Controller) CloseAfterDestroy() {
+	c.close(true, closeJobsAsync)
+}
+
+type closeJobsMode int
+
+const (
+	closeJobsWithGrace closeJobsMode = iota
+	closeJobsAsync
+)
+
+func (c *Controller) close(fireSessionEnd bool, jobsMode closeJobsMode) {
 	c.mu.Lock()
 	started := c.startedOnce
 	c.mu.Unlock()
@@ -2640,7 +2655,12 @@ func (c *Controller) close(fireSessionEnd bool) {
 		c.hooks.SessionEnd(context.Background())
 	}
 	if c.jobs != nil {
-		c.jobs.Close() // cancel any still-running background jobs
+		switch jobsMode {
+		case closeJobsAsync:
+			c.jobs.CloseAsync()
+		default:
+			c.jobs.Close() // cancel any still-running background jobs
+		}
 	}
 	if c.cleanup != nil {
 		c.cleanup()

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1549,6 +1549,12 @@ func (c *Controller) ClearSession() error {
 	if running {
 		return fmt.Errorf("cannot clear while a turn is running")
 	}
+	preMarkedCleanup := c.hasUnfinishedSessionJobs(oldPath)
+	if preMarkedCleanup {
+		if err := agent.MarkCleanupPending(oldPath, "clear"); err != nil {
+			return err
+		}
+	}
 	destroy := c.BeginDestroySession(oldPath)
 	if !destroy.Async {
 		if err := removeSessionArtifacts(oldPath); err != nil {
@@ -1587,6 +1593,13 @@ func (c *Controller) ClearSession() error {
 		}()
 	}
 	return nil
+}
+
+func (c *Controller) hasUnfinishedSessionJobs(sessionPath string) bool {
+	if c.jobs == nil {
+		return false
+	}
+	return c.jobs.HasUnfinishedForSession(agent.BranchID(sessionPath))
 }
 
 func removeSessionArtifacts(path string) error {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1631,6 +1631,14 @@ func removeSessionArtifacts(path string) error {
 	return nil
 }
 
+// ReconcileCleanupPending retries physical cleanup for logically removed
+// sessions that were left behind by a previous process.
+func ReconcileCleanupPending(dir string) error {
+	return agent.ReconcileCleanupPending(dir, func(item agent.CleanupPendingInfo) error {
+		return removeSessionArtifacts(item.SessionPath)
+	})
+}
+
 // RewindScope selects what a Rewind restores.
 type RewindScope int
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1573,7 +1573,10 @@ func (c *Controller) ClearSession() error {
 	c.hooks.SessionStart(context.Background())
 	if destroy.Async {
 		go func() {
-			destroy.Wait()
+			result := destroy.Wait()
+			if result.HasTimedOut() && destroy.WaitAll != nil {
+				destroy.WaitAll()
+			}
 			if err := removeSessionArtifacts(oldPath); err != nil {
 				c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "clear session cleanup failed: " + err.Error()})
 			}
@@ -2127,9 +2130,10 @@ func (c *Controller) SetSessionPath(p string) {
 // SessionDestroyHandle separates waiting for cancelled jobs from ending the
 // destroy window, so callers can move/delete persistent artifacts in between.
 type SessionDestroyHandle struct {
-	Wait   func()
-	Finish func()
-	Async  bool
+	Wait    func() jobs.TeardownResult
+	WaitAll func()
+	Finish  func()
+	Async   bool
 }
 
 // BeginDestroySession marks a session as leaving active use and cancels its
@@ -2138,20 +2142,24 @@ type SessionDestroyHandle struct {
 func (c *Controller) BeginDestroySession(sessionPath string) SessionDestroyHandle {
 	parentSession := agent.BranchID(sessionPath)
 	if c.jobs == nil || parentSession == "" {
+		wait := func() jobs.TeardownResult { return jobs.TeardownResult{} }
 		noop := func() {}
-		return SessionDestroyHandle{Wait: noop, Finish: noop}
+		return SessionDestroyHandle{Wait: wait, WaitAll: noop, Finish: noop}
 	}
-	done := c.jobs.DestroySession(parentSession)
+	teardown := c.jobs.BeginDestroySession(parentSession)
 	return SessionDestroyHandle{
-		Wait: func() {
-			for _, ch := range done {
+		Wait: func() jobs.TeardownResult {
+			return c.jobs.WaitTeardown(context.Background(), teardown, jobs.DefaultTeardownGrace)
+		},
+		WaitAll: func() {
+			for _, ch := range teardown.DoneChannels() {
 				<-ch
 			}
 		},
 		Finish: func() {
 			c.jobs.FinishDestroySession(parentSession)
 		},
-		Async: len(done) > 0,
+		Async: teardown.Async(),
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1575,6 +1575,9 @@ func (c *Controller) ClearSession() error {
 		go func() {
 			result := destroy.Wait()
 			if result.HasTimedOut() && destroy.WaitAll != nil {
+				if err := agent.MarkCleanupPending(oldPath, "clear"); err != nil {
+					c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "mark cleanup pending failed: " + err.Error()})
+				}
 				destroy.WaitAll()
 			}
 			if err := removeSessionArtifacts(oldPath); err != nil {
@@ -1607,6 +1610,9 @@ func removeSessionArtifacts(path string) error {
 		}
 	}
 	if err := agent.DeleteSubagentsByParent(filepath.Dir(path), agent.BranchID(path)); err != nil {
+		return err
+	}
+	if err := agent.ClearCleanupPending(path); err != nil {
 		return err
 	}
 	return nil

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -153,6 +153,56 @@ func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
 	c.notice("typed nil sink should not panic")
 }
 
+func TestClearSessionMarksCleanupPendingBeforeReturningForRunningJobs(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old.jsonl")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte(`{"role":"user","content":"old"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	jm := jobs.NewManager(event.Discard)
+	release := make(chan struct{})
+	started := make(chan struct{})
+	defer func() {
+		close(release)
+		jm.Close()
+	}()
+	jm.StartForSession(agent.BranchID(oldPath), "task", "stuck clear", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		<-release
+		return "", ctx.Err()
+	})
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background job never started")
+	}
+
+	ctrl := New(Options{Executor: exec, SessionDir: dir, SessionPath: oldPath, Label: "test", Jobs: jm})
+	if err := ctrl.ClearSession(); err != nil {
+		t.Fatalf("ClearSession: %v", err)
+	}
+	if !agent.IsCleanupPending(oldPath) {
+		t.Fatalf("old session should be cleanup-pending before ClearSession returns")
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("old session file should remain until delayed cleanup: %v", err)
+	}
+	sessions, err := agent.ListSessions(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, session := range sessions {
+		if filepath.Clean(session.Path) == filepath.Clean(oldPath) {
+			t.Fatalf("cleanup-pending old session still listed: %+v", sessions)
+		}
+	}
+}
+
 func TestRunTurnSnapshotsActivityWhenTranscriptChanges(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -203,6 +203,38 @@ func TestClearSessionMarksCleanupPendingBeforeReturningForRunningJobs(t *testing
 	}
 }
 
+func TestReconcileCleanupPendingRemovesOrphanedArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "orphan.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"orphan"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{Name: "orphan"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(jobs.ArtifactDir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobs.ArtifactDir(path), "job.log"), []byte("job output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(ckptDir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ReconcileCleanupPending(dir); err != nil {
+		t.Fatalf("ReconcileCleanupPending: %v", err)
+	}
+	for _, p := range []string{path, agent.BranchMetaPath(path), jobs.ArtifactDir(path), ckptDir(path), agent.CleanupPendingPath(path)} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("%s still exists after reconciliation (err=%v)", p, err)
+		}
+	}
+}
+
 func TestRunTurnSnapshotsActivityWhenTranscriptChanges(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")

--- a/internal/history/search.go
+++ b/internal/history/search.go
@@ -230,6 +230,9 @@ func (s *Searcher) Around(ctx context.Context, req AroundRequest) ([]MessageCont
 	if !s.allowedPath(path) {
 		return nil, fmt.Errorf("session_path is outside the configured history roots")
 	}
+	if !s.visiblePath(path) {
+		return nil, fmt.Errorf("session_path is pending cleanup")
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -294,7 +297,7 @@ func (s *Searcher) sources(scope string) ([]sourceFile, error) {
 	out = appendSessionSources(out, seen, s.sessionDir, scopeProject)
 	if scope == scopeGlobal {
 		out = appendSessionSources(out, seen, s.globalSessionDir, scopeGlobal)
-		out = appendFiles(out, seen, listJSONL(s.archiveDir, "archive")...)
+		out = appendFiles(out, seen, listJSONL(s.archiveDir, "archive", nil)...)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].mod == out[j].mod {
@@ -306,9 +309,11 @@ func (s *Searcher) sources(scope string) ([]sourceFile, error) {
 }
 
 func appendSessionSources(out []sourceFile, seen map[string]bool, dir, source string) []sourceFile {
-	out = appendFiles(out, seen, listJSONL(dir, source)...)
+	out = appendFiles(out, seen, listJSONL(dir, source, agent.IsVisibleSession)...)
 	if strings.TrimSpace(dir) != "" {
-		out = appendFiles(out, seen, listJSONL(filepath.Join(dir, "subagents"), source)...)
+		out = appendFiles(out, seen, listJSONL(subagentsDir(dir), source, func(path string) bool {
+			return visibleSubagentSession(dir, path)
+		})...)
 	}
 	return out
 }
@@ -328,7 +333,7 @@ func appendFiles(out []sourceFile, seen map[string]bool, files ...sourceFile) []
 	return out
 }
 
-func listJSONL(dir, source string) []sourceFile {
+func listJSONL(dir, source string, visible func(string) bool) []sourceFile {
 	if strings.TrimSpace(dir) == "" {
 		return nil
 	}
@@ -345,8 +350,12 @@ func listJSONL(dir, source string) []sourceFile {
 		if err != nil {
 			continue
 		}
+		path := filepath.Join(dir, entry.Name())
+		if visible != nil && !visible(path) {
+			continue
+		}
 		out = append(out, sourceFile{
-			path:   filepath.Join(dir, entry.Name()),
+			path:   path,
 			source: source,
 			mod:    info.ModTime().UnixNano(),
 		})
@@ -475,13 +484,64 @@ func clamp(n, def, max int) int {
 	return n
 }
 
+func (s *Searcher) visiblePath(path string) bool {
+	switch {
+	case underRoot(path, subagentsDir(s.sessionDir)):
+		return visibleSubagentSession(s.sessionDir, path)
+	case underRoot(path, s.sessionDir):
+		return agent.IsVisibleSession(path)
+	case underRoot(path, subagentsDir(s.globalSessionDir)):
+		return visibleSubagentSession(s.globalSessionDir, path)
+	case underRoot(path, s.globalSessionDir):
+		return agent.IsVisibleSession(path)
+	case underRoot(path, s.archiveDir):
+		return true
+	default:
+		return false
+	}
+}
+
+func visibleSubagentSession(sessionDir, path string) bool {
+	if !agent.IsVisibleSession(path) {
+		return false
+	}
+	parentSession, ok := subagentParentSession(path)
+	if !ok || parentSession == "" {
+		return true
+	}
+	return !agent.IsCleanupPending(filepath.Join(sessionDir, parentSession+".jsonl"))
+}
+
+func subagentParentSession(path string) (string, bool) {
+	ref := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if ref == "" || ref == filepath.Base(path) {
+		return "", false
+	}
+	b, err := os.ReadFile(filepath.Join(filepath.Dir(path), ref+".meta.json"))
+	if err != nil {
+		return "", false
+	}
+	var meta agent.SubagentMeta
+	if err := json.Unmarshal(b, &meta); err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(meta.ParentSession), true
+}
+
+func subagentsDir(dir string) string {
+	if strings.TrimSpace(dir) == "" {
+		return ""
+	}
+	return filepath.Join(dir, "subagents")
+}
+
 func (s *Searcher) allowedPath(path string) bool {
 	roots := []string{s.sessionDir, s.globalSessionDir, s.archiveDir}
 	if s.sessionDir != "" {
-		roots = append(roots, filepath.Join(s.sessionDir, "subagents"))
+		roots = append(roots, subagentsDir(s.sessionDir))
 	}
 	if s.globalSessionDir != "" {
-		roots = append(roots, filepath.Join(s.globalSessionDir, "subagents"))
+		roots = append(roots, subagentsDir(s.globalSessionDir))
 	}
 	for _, root := range roots {
 		if underRoot(path, root) {

--- a/internal/history/search_test.go
+++ b/internal/history/search_test.go
@@ -2,6 +2,8 @@ package history
 
 import (
 	"context"
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -148,6 +150,80 @@ func TestSearchDropsCommonWordNoise(t *testing.T) {
 	}
 }
 
+func TestSearchSkipsCleanupPending(t *testing.T) {
+	sessionDir := t.TempDir()
+	visiblePath := filepath.Join(sessionDir, "visible.jsonl")
+	pendingPath := filepath.Join(sessionDir, "pending.jsonl")
+	writeSession(t, visiblePath, []provider.Message{
+		{Role: provider.RoleUser, Content: "ordinary alpha visible decision"},
+	})
+	writeSession(t, pendingPath, []provider.Message{
+		{Role: provider.RoleUser, Content: "hidden alpha cleanup pending secret"},
+	})
+	if err := agent.MarkCleanupPending(pendingPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher := NewSearcher(Options{SessionDir: sessionDir})
+	hits, err := searcher.Search(context.Background(), SearchRequest{Query: "alpha", Limit: 5})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(hits) != 1 || hits[0].SessionPath != visiblePath {
+		t.Fatalf("Search() hits = %+v, want only visible path %s", hits, visiblePath)
+	}
+	hits, err = searcher.Search(context.Background(), SearchRequest{Query: "cleanup pending secret", Limit: 5})
+	if err != nil {
+		t.Fatalf("Search() pending-only query error = %v", err)
+	}
+	if len(hits) != 0 {
+		t.Fatalf("Search() pending-only hits = %+v, want none", hits)
+	}
+}
+
+func TestAroundRejectsCleanupPending(t *testing.T) {
+	sessionDir := t.TempDir()
+	path := filepath.Join(sessionDir, "pending.jsonl")
+	writeSession(t, path, []provider.Message{{Role: provider.RoleUser, Content: "pending secret"}})
+	if err := agent.MarkCleanupPending(path, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher := NewSearcher(Options{SessionDir: sessionDir})
+	if _, err := searcher.Around(context.Background(), AroundRequest{SessionPath: path, MessageIndex: 0}); err == nil {
+		t.Fatal("Around() cleanup-pending error = nil, want rejection")
+	}
+}
+
+func TestHistorySkipsSubagentsOwnedByCleanupPendingParent(t *testing.T) {
+	sessionDir := t.TempDir()
+	parentPath := filepath.Join(sessionDir, "parent.jsonl")
+	writeSession(t, parentPath, []provider.Message{{Role: provider.RoleUser, Content: "parent prompt"}})
+	visibleParentPath := filepath.Join(sessionDir, "visible-parent.jsonl")
+	writeSession(t, visibleParentPath, []provider.Message{{Role: provider.RoleUser, Content: "visible parent prompt"}})
+
+	pendingSubagentPath := writeSubagentSession(t, sessionDir, "sa_pending", agent.BranchID(parentPath), "subagent hidden orchid result")
+	visibleSubagentPath := writeSubagentSession(t, sessionDir, "sa_visible", agent.BranchID(visibleParentPath), "subagent visible orchid result")
+	if err := agent.MarkCleanupPending(parentPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	searcher := NewSearcher(Options{SessionDir: sessionDir})
+	hits, err := searcher.Search(context.Background(), SearchRequest{Query: "orchid result", Limit: 5})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(hits) != 1 || hits[0].SessionPath != visibleSubagentPath {
+		t.Fatalf("Search() hits = %+v, want only visible subagent %s", hits, visibleSubagentPath)
+	}
+	if _, err := searcher.Around(context.Background(), AroundRequest{SessionPath: pendingSubagentPath, MessageIndex: 0}); err == nil {
+		t.Fatal("Around() cleanup-pending parent subagent error = nil, want rejection")
+	}
+	if _, err := searcher.Around(context.Background(), AroundRequest{SessionPath: visibleSubagentPath, MessageIndex: 0}); err != nil {
+		t.Fatalf("Around() visible subagent error = %v", err)
+	}
+}
+
 func TestAroundRequiresPathUnderHistoryRoots(t *testing.T) {
 	sessionDir := t.TempDir()
 	outside := t.TempDir()
@@ -194,4 +270,23 @@ func writeSession(t *testing.T, path string, msgs []provider.Message) {
 	if err := sess.Save(path); err != nil {
 		t.Fatalf("Save(%s) error = %v", path, err)
 	}
+}
+
+func writeSubagentSession(t *testing.T, sessionDir, ref, parentSession, content string) string {
+	t.Helper()
+	dir := filepath.Join(sessionDir, "subagents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, ref+".jsonl")
+	writeSession(t, path, []provider.Message{{Role: provider.RoleUser, Content: content}})
+	meta := agent.SubagentMeta{Ref: ref, ParentSession: parentSession}
+	b, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ref+".meta.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/internal/history/tool_test.go
+++ b/internal/history/tool_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"reasonix/internal/agent"
 	"reasonix/internal/provider"
 )
 
@@ -63,6 +64,42 @@ func TestHistoryToolSearchAndAroundAreUsable(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("around output missing %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestHistoryToolSkipsCleanupPending(t *testing.T) {
+	sessionDir := t.TempDir()
+	visiblePath := filepath.Join(sessionDir, "visible.jsonl")
+	pendingPath := filepath.Join(sessionDir, "pending.jsonl")
+	writeSession(t, visiblePath, []provider.Message{
+		{Role: provider.RoleUser, Content: "visible cleanup-safe retrieval note"},
+	})
+	writeSession(t, pendingPath, []provider.Message{
+		{Role: provider.RoleUser, Content: "pending cleanup-hidden retrieval note"},
+	})
+	if err := agent.MarkCleanupPending(pendingPath, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	tl := NewTool(Options{SessionDir: sessionDir})
+	out, err := tl.Execute(context.Background(), []byte(`{"operation":"search","query":"retrieval note","limit":5}`))
+	if err != nil {
+		t.Fatalf("Execute search: %v", err)
+	}
+	if !strings.Contains(out, "visible.jsonl") {
+		t.Fatalf("search output missing visible session:\n%s", out)
+	}
+	if strings.Contains(out, "pending.jsonl") || strings.Contains(out, "cleanup-hidden") {
+		t.Fatalf("search output leaked cleanup-pending session:\n%s", out)
+	}
+
+	args, _ := json.Marshal(map[string]any{
+		"operation":     "around",
+		"session_path":  pendingPath,
+		"message_index": 0,
+	})
+	if _, err := tl.Execute(context.Background(), args); err == nil {
+		t.Fatal("Execute around cleanup-pending error = nil, want rejection")
 	}
 }
 

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -73,7 +73,7 @@ type TeardownResult struct {
 	TimedOut []TeardownJob
 }
 
-// TimedOut reports whether teardown returned before every job had unwound.
+// HasTimedOut reports whether teardown returned before every job had unwound.
 func (r TeardownResult) HasTimedOut() bool { return len(r.TimedOut) > 0 }
 
 type teardownTarget struct {

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -39,6 +39,9 @@ const (
 	Killed  Status = "killed"
 )
 
+// DefaultTeardownGrace bounds Close and destroy waits for non-cooperative jobs.
+const DefaultTeardownGrace = 15 * time.Second
+
 // View is a read-only snapshot of a job for the status bar.
 type View struct {
 	ID        string `json:"id"`
@@ -55,6 +58,45 @@ type Result struct {
 	Label  string
 	Status Status
 	Output string // the terminal result text, or the streamed buffer when no result was set
+}
+
+// TeardownJob identifies a job that is still unwinding after teardown waited.
+type TeardownJob struct {
+	ID     string
+	Kind   string
+	Label  string
+	Waited time.Duration
+}
+
+// TeardownResult reports jobs that did not unwind within the teardown grace.
+type TeardownResult struct {
+	TimedOut []TeardownJob
+}
+
+// TimedOut reports whether teardown returned before every job had unwound.
+func (r TeardownResult) HasTimedOut() bool { return len(r.TimedOut) > 0 }
+
+type teardownTarget struct {
+	info TeardownJob
+	done <-chan struct{}
+}
+
+// SessionTeardown is the destroy handle for a session's owned background jobs.
+type SessionTeardown struct {
+	SessionID string
+	targets   []teardownTarget
+}
+
+// Async reports whether the handle has jobs to wait on.
+func (h SessionTeardown) Async() bool { return len(h.targets) > 0 }
+
+// DoneChannels returns each target's completion channel for legacy callers.
+func (h SessionTeardown) DoneChannels() []<-chan struct{} {
+	out := make([]<-chan struct{}, 0, len(h.targets))
+	for _, target := range h.targets {
+		out = append(out, target.done)
+	}
+	return out
 }
 
 // Job is one background job. The mutex guards the streaming buffer and the
@@ -107,6 +149,7 @@ type Manager struct {
 	tempRoot     string
 
 	stalledWarning time.Duration
+	teardownGrace  time.Duration
 }
 
 type completion struct {
@@ -127,6 +170,16 @@ func WithStalledWarningAfter(d time.Duration) Option {
 	}
 }
 
+// WithTeardownGrace overrides the Close/destroy grace window. Tests can set a
+// short value; production uses DefaultTeardownGrace.
+func WithTeardownGrace(d time.Duration) Option {
+	return func(m *Manager) {
+		if d >= 0 {
+			m.teardownGrace = d
+		}
+	}
+}
+
 // NewManager returns a Manager whose jobs run under a fresh session-scoped
 // context (cancelled by Close). sink receives job-lifecycle notices; pass the
 // session's synchronized sink (event.Sync) since jobs emit from goroutines.
@@ -137,14 +190,15 @@ func NewManager(sink event.Sink, opts ...Option) *Manager {
 	root, cancel := context.WithCancel(context.Background())
 	tempRoot, _ := os.MkdirTemp("", "reasonix-jobs-*")
 	m := &Manager{
-		sink:         sink,
-		root:         root,
-		cancel:       cancel,
-		jobs:         map[string]*Job{},
-		destroying:   map[string]bool{},
-		artifactDirs: map[string]string{},
-		loaded:       map[string]bool{},
-		tempRoot:     tempRoot,
+		sink:          sink,
+		root:          root,
+		cancel:        cancel,
+		jobs:          map[string]*Job{},
+		destroying:    map[string]bool{},
+		artifactDirs:  map[string]string{},
+		loaded:        map[string]bool{},
+		tempRoot:      tempRoot,
+		teardownGrace: DefaultTeardownGrace,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -1123,16 +1177,15 @@ func (m *Manager) loadSessionArtifacts(parentSession, dir string) {
 	m.loaded[parentSession] = true
 }
 
-// DestroySession marks a parent session as being removed from active use and
-// cancels its running jobs. The returned channels close when each cancelled job
-// has fully unwound.
-func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
+// BeginDestroySession marks a parent session as being removed from active use
+// and cancels its running jobs. WaitTeardown waits for the returned handle.
+func (m *Manager) BeginDestroySession(parentSession string) SessionTeardown {
 	parentSession = strings.TrimSpace(parentSession)
 	if parentSession == "" {
-		return nil
+		return SessionTeardown{}
 	}
 	var cancels []context.CancelFunc
-	var done []<-chan struct{}
+	var targets []teardownTarget
 	m.mu.Lock()
 	m.destroying[parentSession] = true
 	remaining := m.completed[:0]
@@ -1152,9 +1205,9 @@ func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
 		case Running:
 			j.status = Killed
 			cancels = append(cancels, j.cancel)
-			done = append(done, j.done)
+			targets = append(targets, teardownTarget{info: TeardownJob{ID: j.ID, Kind: j.Kind, Label: j.Label}, done: j.done})
 		case Killed:
-			done = append(done, j.done)
+			targets = append(targets, teardownTarget{info: TeardownJob{ID: j.ID, Kind: j.Kind, Label: j.Label}, done: j.done})
 		}
 		j.mu.Unlock()
 	}
@@ -1162,7 +1215,22 @@ func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
 	for _, cancel := range cancels {
 		cancel()
 	}
-	return done
+	return SessionTeardown{SessionID: parentSession, targets: targets}
+}
+
+// DestroySession preserves the legacy channel-based destroy API.
+func (m *Manager) DestroySession(parentSession string) []<-chan struct{} {
+	return m.BeginDestroySession(parentSession).DoneChannels()
+}
+
+// WaitTeardown waits for a destroy handle to unwind up to grace. A timed-out
+// result means the caller should defer physical cleanup until the jobs exit.
+func (m *Manager) WaitTeardown(ctx context.Context, h SessionTeardown, grace time.Duration) TeardownResult {
+	result, timedOut := waitTeardownTargets(ctx, h.targets, grace)
+	if timedOut {
+		m.emitTeardownTimeout("destroy session "+h.SessionID, result)
+	}
+	return result
 }
 
 // IsDestroying reports whether parentSession is in the destroy window. Empty
@@ -1205,14 +1273,135 @@ func (m *Manager) purgeSessionLocked(parentSession string) {
 	m.order = kept
 }
 
-// Close cancels the session context and waits for every background job goroutine
-// to return before unblocking. Jobs observe the cancel through their run context
-// (exec.CommandContext kills a bash job's process), so the wait is bounded. This
-// matters for callers tearing down a t.TempDir: without the wait, RemoveAll can
-// race a job goroutine that still holds a file under that dir.
+// Close cancels the session context and waits briefly for every background job
+// goroutine to return before unblocking. If a non-cooperative job ignores
+// cancellation, cleanup of the temporary artifact root continues in the
+// background after the goroutines eventually unwind.
 func (m *Manager) Close() {
+	_ = m.CloseWithGrace(m.teardownGrace)
+}
+
+// CloseWithGrace is Close with an explicit wait window, used by tests and
+// callers that need to surface non-cooperative jobs.
+func (m *Manager) CloseWithGrace(grace time.Duration) TeardownResult {
 	m.cancel()
-	m.wg.Wait()
+	done := make(chan struct{})
+	go func() {
+		m.wg.Wait()
+		close(done)
+	}()
+	result, timedOut := waitTeardownTargets(context.Background(), m.closeTargets(), grace, done)
+	if timedOut {
+		m.emitTeardownTimeout("close", result)
+		go func() {
+			<-done
+			m.removeTempRoot()
+		}()
+		return result
+	}
+	m.removeTempRoot()
+	return result
+}
+
+func waitTeardownTargets(ctx context.Context, targets []teardownTarget, grace time.Duration, allDone ...<-chan struct{}) (TeardownResult, bool) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	start := time.Now()
+	var timeout <-chan time.Time
+	if grace >= 0 {
+		timer := time.NewTimer(grace)
+		defer timer.Stop()
+		timeout = timer.C
+	}
+	if len(allDone) > 0 && allDone[0] != nil {
+		select {
+		case <-allDone[0]:
+			return TeardownResult{}, false
+		case <-ctx.Done():
+			return teardownTimedOut(targets, time.Since(start)), false
+		case <-timeout:
+			return teardownTimedOut(targets, time.Since(start)), true
+		}
+	}
+	for _, target := range targets {
+		select {
+		case <-target.done:
+		case <-ctx.Done():
+			return teardownTimedOut(targets, time.Since(start)), false
+		case <-timeout:
+			return teardownTimedOut(targets, time.Since(start)), true
+		}
+	}
+	return TeardownResult{}, false
+}
+
+func teardownTimedOut(targets []teardownTarget, waited time.Duration) TeardownResult {
+	var out []TeardownJob
+	for _, target := range targets {
+		select {
+		case <-target.done:
+			continue
+		default:
+		}
+		info := target.info
+		info.Waited = waited
+		out = append(out, info)
+	}
+	return TeardownResult{TimedOut: out}
+}
+
+func (m *Manager) closeTargets() []teardownTarget {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var targets []teardownTarget
+	for _, key := range m.order {
+		j := m.jobs[key]
+		if j == nil {
+			continue
+		}
+		select {
+		case <-j.done:
+			continue
+		default:
+		}
+		j.mu.Lock()
+		switch j.status {
+		case Running:
+			j.status = Killed
+			targets = append(targets, teardownTarget{info: TeardownJob{ID: j.ID, Kind: j.Kind, Label: j.Label}, done: j.done})
+		case Killed:
+			targets = append(targets, teardownTarget{info: TeardownJob{ID: j.ID, Kind: j.Kind, Label: j.Label}, done: j.done})
+		}
+		j.mu.Unlock()
+	}
+	return targets
+}
+
+func (m *Manager) emitTeardownTimeout(action string, result TeardownResult) {
+	if len(result.TimedOut) == 0 {
+		return
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "background job teardown timed out during %s", strings.TrimSpace(action))
+	for i, job := range result.TimedOut {
+		if i == 0 {
+			b.WriteString(": ")
+		} else {
+			b.WriteString("; ")
+		}
+		fmt.Fprintf(&b, "%s kind=%s", job.ID, job.Kind)
+		if strings.TrimSpace(job.Label) != "" {
+			fmt.Fprintf(&b, " label=%q", job.Label)
+		}
+		if job.Waited > 0 {
+			fmt.Fprintf(&b, " waited=%s", job.Waited.Round(time.Millisecond))
+		}
+	}
+	m.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: b.String()})
+}
+
+func (m *Manager) removeTempRoot() {
 	if m.tempRoot != "" {
 		_ = os.RemoveAll(m.tempRoot)
 	}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -804,6 +804,26 @@ func (m *Manager) RunningForSession(parentSession string) []View {
 	return out
 }
 
+// HasUnfinishedForSession reports whether parentSession owns any job whose
+// goroutine has not fully exited yet. Empty parentSession preserves the legacy
+// unscoped behavior.
+func (m *Manager) HasUnfinishedForSession(parentSession string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, key := range m.order {
+		j := m.jobs[key]
+		if !sessionMatches(parentSession, j.SessionID) {
+			continue
+		}
+		select {
+		case <-j.done:
+		default:
+			return true
+		}
+	}
+	return false
+}
+
 // DrainCompletedNote returns (and clears) a one-line summary of jobs that
 // finished since the last drain, for the controller to fold into the next turn
 // so the model learns of completions. "" when nothing finished.

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -180,6 +180,9 @@ func WithTeardownGrace(d time.Duration) Option {
 	}
 }
 
+// TeardownGrace reports the manager's configured close/destroy wait window.
+func (m *Manager) TeardownGrace() time.Duration { return m.teardownGrace }
+
 // NewManager returns a Manager whose jobs run under a fresh session-scoped
 // context (cancelled by Close). sink receives job-lifecycle notices; pass the
 // session's synchronized sink (event.Sync) since jobs emit from goroutines.
@@ -1279,6 +1282,18 @@ func (m *Manager) purgeSessionLocked(parentSession string) {
 // background after the goroutines eventually unwind.
 func (m *Manager) Close() {
 	_ = m.CloseWithGrace(m.teardownGrace)
+}
+
+// CloseAsync cancels the manager and returns immediately. It is used when a
+// caller has already begun session-specific teardown and owns the delayed
+// persistent cleanup, but still needs the manager's root context and temporary
+// artifact root released eventually.
+func (m *Manager) CloseAsync() {
+	m.cancel()
+	go func() {
+		m.wg.Wait()
+		m.removeTempRoot()
+	}()
 }
 
 // CloseWithGrace is Close with an explicit wait window, used by tests and

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -468,3 +468,97 @@ func TestDestroySessionWaitsForAlreadyKilledJobs(t *testing.T) {
 		t.Fatal("session-a should no longer be marked destroying")
 	}
 }
+
+func TestWaitTeardownTimesOutForNonCooperativeJob(t *testing.T) {
+	m := NewManager(event.Discard)
+	release := make(chan struct{})
+	defer func() {
+		close(release)
+		m.Close()
+	}()
+
+	started := make(chan struct{})
+	j := m.StartForSession("session-a", "task", "cleanup", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		<-release
+		return "", ctx.Err()
+	})
+	<-started
+
+	handle := m.BeginDestroySession("session-a")
+	start := time.Now()
+	result := m.WaitTeardown(context.Background(), handle, 25*time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("WaitTeardown took %s, want bounded wait", elapsed)
+	}
+	if len(result.TimedOut) != 1 {
+		t.Fatalf("timed out jobs = %+v, want one", result.TimedOut)
+	}
+	got := result.TimedOut[0]
+	if got.ID != j.ID || got.Kind != "task" || got.Label != "cleanup" || got.Waited <= 0 {
+		t.Fatalf("timed out job = %+v, want id=%s kind=task label=cleanup waited>0", got, j.ID)
+	}
+	if note := m.DrainCompletedNoteForSession("session-a"); note != "" {
+		t.Fatalf("destroyed session should not queue completion note, got %q", note)
+	}
+	if !m.IsDestroying("session-a") {
+		t.Fatal("session-a should stay destroying until delayed cleanup finishes")
+	}
+
+	close(release)
+	release = make(chan struct{}) // keep deferred close valid after releasing the job
+	for _, ch := range handle.DoneChannels() {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for delayed job unwind")
+		}
+	}
+	m.FinishDestroySession("session-a")
+	if m.IsDestroying("session-a") {
+		t.Fatal("session-a should no longer be destroying after Finish")
+	}
+}
+
+func TestCloseWithGraceTimesOutForNonCooperativeJob(t *testing.T) {
+	m := NewManager(event.Discard)
+	release := make(chan struct{})
+	defer func() {
+		close(release)
+		m.Close()
+	}()
+
+	started := make(chan struct{})
+	j := m.Start("task", "cleanup", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		<-ctx.Done()
+		<-release
+		return "", ctx.Err()
+	})
+	<-started
+
+	start := time.Now()
+	result := m.CloseWithGrace(25 * time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("CloseWithGrace took %s, want bounded wait", elapsed)
+	}
+	if len(result.TimedOut) != 1 {
+		t.Fatalf("timed out jobs = %+v, want one", result.TimedOut)
+	}
+	if got := result.TimedOut[0]; got.ID != j.ID || got.Kind != "task" || got.Label != "cleanup" || got.Waited <= 0 {
+		t.Fatalf("timed out job = %+v, want id=%s kind=task label=cleanup waited>0", got, j.ID)
+	}
+	if running := m.Running(); len(running) != 0 {
+		t.Fatalf("cancelled close jobs should not remain Running, got %+v", running)
+	}
+
+	close(release)
+	release = make(chan struct{}) // keep deferred close valid after releasing the job
+	res := m.Wait(context.Background(), []string{j.ID}, 5)
+	if len(res) != 1 || res[0].Status != Killed {
+		t.Fatalf("want killed after delayed close cleanup, got %+v", res)
+	}
+}

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -472,8 +472,10 @@ func TestDestroySessionWaitsForAlreadyKilledJobs(t *testing.T) {
 func TestWaitTeardownTimesOutForNonCooperativeJob(t *testing.T) {
 	m := NewManager(event.Discard)
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseJob := func() { releaseOnce.Do(func() { close(release) }) }
 	defer func() {
-		close(release)
+		releaseJob()
 		m.Close()
 	}()
 
@@ -507,8 +509,7 @@ func TestWaitTeardownTimesOutForNonCooperativeJob(t *testing.T) {
 		t.Fatal("session-a should stay destroying until delayed cleanup finishes")
 	}
 
-	close(release)
-	release = make(chan struct{}) // keep deferred close valid after releasing the job
+	releaseJob()
 	for _, ch := range handle.DoneChannels() {
 		select {
 		case <-ch:
@@ -525,8 +526,10 @@ func TestWaitTeardownTimesOutForNonCooperativeJob(t *testing.T) {
 func TestCloseWithGraceTimesOutForNonCooperativeJob(t *testing.T) {
 	m := NewManager(event.Discard)
 	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseJob := func() { releaseOnce.Do(func() { close(release) }) }
 	defer func() {
-		close(release)
+		releaseJob()
 		m.Close()
 	}()
 
@@ -555,8 +558,7 @@ func TestCloseWithGraceTimesOutForNonCooperativeJob(t *testing.T) {
 		t.Fatalf("cancelled close jobs should not remain Running, got %+v", running)
 	}
 
-	close(release)
-	release = make(chan struct{}) // keep deferred close valid after releasing the job
+	releaseJob()
 	res := m.Wait(context.Background(), []string{j.ID}, 5)
 	if len(res) != 1 || res[0].Status != Killed {
 		t.Fatalf("want killed after delayed close cleanup, got %+v", res)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -902,6 +902,9 @@ func (s *Server) sessions(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
+		if agent.IsCleanupPending(path) {
+			continue
+		}
 		name := strings.TrimSuffix(e.Name(), ".jsonl")
 		entry := sessionEntry{Name: name, Path: path, Current: filepath.Clean(path) == current}
 		if first, turns := previewSessionFile(path); turns > 0 {

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -745,6 +745,10 @@ func (s *Server) resume(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "path outside session dir", http.StatusForbidden)
 		return
 	}
+	if agent.IsCleanupPending(realPath) {
+		http.Error(w, "session is pending cleanup", http.StatusBadRequest)
+		return
+	}
 	// Snapshot the current session before switching away.
 	if err := s.ctl().Snapshot(); err != nil {
 		slog.Warn("serve: snapshot before resume", "err", err)

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -964,31 +964,60 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	destroy := s.ctl().BeginDestroySession(abs)
-	if err := os.Remove(abs); err != nil {
-		go finishSessionDestroy(destroy)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+	if result := finishSessionDestroy(destroy); result.HasTimedOut() {
+		if err := agent.MarkCleanupPending(abs, "delete"); err != nil {
+			go delayedSessionDelete(absDir, abs, destroy)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		go delayedSessionDelete(absDir, abs, destroy)
+		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	if err := agent.DeleteSubagentsByParent(dir, agent.BranchID(abs)); err != nil {
-		go finishSessionDestroy(destroy)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	finishSessionDestroy(destroy)
-	if err := jobs.RemoveArtifacts(abs); err != nil {
+	if err := removeSessionFiles(absDir, abs); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func finishSessionDestroy(destroy control.SessionDestroyHandle) {
+func finishSessionDestroy(destroy control.SessionDestroyHandle) jobs.TeardownResult {
 	if destroy.Wait != nil {
-		destroy.Wait()
+		result := destroy.Wait()
+		if destroy.Finish != nil && !result.HasTimedOut() {
+			destroy.Finish()
+		}
+		return result
 	}
 	if destroy.Finish != nil {
 		destroy.Finish()
 	}
+	return jobs.TeardownResult{}
+}
+
+func delayedSessionDelete(absDir, abs string, destroy control.SessionDestroyHandle) {
+	if destroy.WaitAll != nil {
+		destroy.WaitAll()
+	}
+	if err := removeSessionFiles(absDir, abs); err != nil {
+		slog.Warn("serve: delayed session delete failed", "path", abs, "err", err)
+	}
+	if destroy.Finish != nil {
+		destroy.Finish()
+	}
+}
+
+func removeSessionFiles(absDir, abs string) error {
+	if err := os.Remove(abs); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := agent.DeleteSubagentsByParent(absDir, agent.BranchID(abs)); err != nil {
+		return err
+	}
+	if err := jobs.RemoveArtifacts(abs); err != nil {
+		return err
+	}
+	return agent.ClearCleanupPending(abs)
 }
 
 // sessionTitle returns a title for a session: the cached flash-generated title

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -379,6 +379,41 @@ func TestResumeRequiresSessionPathInsideSessionDir(t *testing.T) {
 	}
 }
 
+func TestSessionsSkipsCleanupPending(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	pending := filepath.Join(dir, "pending.jsonl")
+	for _, path := range []string{active, pending} {
+		if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := agent.MarkCleanupPending(pending, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	srv := httptest.NewServer(New(ctrl, bc).Handler())
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/sessions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var got []struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Name != "active" || filepath.Clean(got[0].Path) != filepath.Clean(active) {
+		t.Fatalf("/sessions = %+v, want only active session", got)
+	}
+}
+
 func TestDeleteSessionRequiresSessionNameInsideSessionDir(t *testing.T) {
 	dir := t.TempDir()
 	active := filepath.Join(dir, "active.jsonl")

--- a/internal/serve/serve_test.go
+++ b/internal/serve/serve_test.go
@@ -379,6 +379,41 @@ func TestResumeRequiresSessionPathInsideSessionDir(t *testing.T) {
 	}
 }
 
+func TestResumeRejectsCleanupPendingSession(t *testing.T) {
+	dir := t.TempDir()
+	active := filepath.Join(dir, "active.jsonl")
+	pending := filepath.Join(dir, "pending.jsonl")
+	for _, path := range []string{active, pending} {
+		if err := os.WriteFile(path, []byte(`{"role":"user","content":"hi"}`+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := agent.MarkCleanupPending(pending, "delete"); err != nil {
+		t.Fatal(err)
+	}
+
+	bc := NewBroadcaster()
+	ctrl := control.New(control.Options{Sink: bc, SessionDir: dir, SessionPath: active})
+	srv := httptest.NewServer(New(ctrl, bc).Handler())
+	defer srv.Close()
+
+	body, err := json.Marshal(map[string]string{"path": pending})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(srv.URL+"/resume", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("cleanup-pending resume status = %d, want 400", resp.StatusCode)
+	}
+	if got := filepath.Clean(ctrl.SessionPath()); got != filepath.Clean(active) {
+		t.Fatalf("session path after rejected resume = %q, want active %q", got, active)
+	}
+}
+
 func TestSessionsSkipsCleanupPending(t *testing.T) {
 	dir := t.TempDir()
 	active := filepath.Join(dir, "active.jsonl")


### PR DESCRIPTION
## 背景

后台任务的取消依赖 `context.Context` 协作返回。正常的内置 bash、provider stream、MCP 调用大多已经会响应取消，但自定义 provider/tool 或第三方集成仍可能忽略取消，导致 session close、clear、delete、trash 等 teardown 流程被无限拖住。

这会带来两个问题：用户操作可能长时间不返回；如果为了让操作先返回而延后物理清理，又必须保证旧 transcript 和 job artifacts 在 job 真正退出前不会被误删、误移动，且不会被当作普通 session 恢复。

## 做了什么

- 在 `internal/jobs` 增加有界 teardown 等待、超时结果和诊断信息，`Close()` / session destroy 不再被非协作后台 job 无限阻塞。
- 在 control、desktop、HTTP serve、ACP delete/clear/trash 路径中接入 delayed cleanup：teardown 超时后用户操作返回，物理删除或 trash 延后到 job goroutine 真正退出后执行。
- 新增 durable cleanup-pending marker，用于隐藏逻辑删除但尚未完成物理清理的 session；物理清理成功后自动清除 marker。
- 过滤所有普通 list/resume surface：agent list、HTTP `/sessions`、ACP `session/list`、HTTP/ACP/Desktop direct resume、Desktop topic lookup/pinned startup、CLI `run --resume` / `serve --resume` 都不会恢复 cleanup-pending session。
- 修复 Desktop 清理路径对 `.jobs` sidecar 的处理，避免清空或删除 session 后遗留 job artifacts。

## 结果与影响

- 非协作后台 job 不再无限拖住 close/delete/clear/trash；用户可见操作会在 teardown grace 后继续返回。
- 仍可能被运行中 job 持有或写入的 transcript、job logs、metadata 不会在 job 退出前被删除或移动。
- delete/clear 已经返回但物理清理延后的 session，会被 durable marker 隐藏；即使重启或保留旧 path/session id，也不会作为普通可恢复 session 出现。
- 协作型后台任务、活跃 session 的 `wait` / `bash_output` / `kill_shell` 语义保持不变。

## 验证

- `go test ./...`
- `cd desktop && go test ./...`
- `git merge-tree --write-tree HEAD origin/main-v2` 无冲突。