### PR TITLE
Fix settings credential lookup lag / 优化设置凭据解析延迟

### DIFF
--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -280,13 +280,20 @@ func providerViewFromEntry(p config.ProviderEntry, builtIn, added bool) Provider
 }
 
 func providerViewFromEntryForRoot(p config.ProviderEntry, builtIn, added bool, root string) ProviderView {
+	return providerViewFromEntryForRootWithResolver(p, builtIn, added, root, nil)
+}
+
+func providerViewFromEntryForRootWithResolver(p config.ProviderEntry, builtIn, added bool, root string, resolver *config.CredentialResolver) ProviderView {
 	models := p.ChatModelList()
 	visionModels := p.VisionModels
 	visionModelsSet := p.Vision || p.VisionModels != nil
 	if p.Vision {
 		visionModels = models
 	}
-	key := config.ResolveCredentialForRootGlobalFirst(root, p.APIKeyEnv)
+	if resolver == nil {
+		resolver = config.NewCredentialResolverForRoot(root)
+	}
+	key := resolver.ResolveGlobalFirst(p.APIKeyEnv)
 	requiresKey := p.RequiresAPIKey()
 	return ProviderView{
 		Name: p.Name, BuiltIn: builtIn, Added: added, Kind: p.Kind, BaseURL: p.BaseURL,
@@ -310,14 +317,21 @@ func officialProviderViews(added map[string]bool, pricingLanguage string) []Prov
 }
 
 func officialProviderViewsForRoot(added map[string]bool, pricingLanguage, root string) []ProviderView {
+	return officialProviderViewsForRootWithResolver(added, pricingLanguage, root, nil)
+}
+
+func officialProviderViewsForRootWithResolver(added map[string]bool, pricingLanguage, root string, resolver *config.CredentialResolver) []ProviderView {
 	var out []ProviderView
+	if resolver == nil {
+		resolver = config.NewCredentialResolverForRoot(root)
+	}
 	for _, kind := range []string{"deepseek", "mimo-api", "mimo-token-plan"} {
 		entries, _, err := officialProviderTemplate(kind, pricingLanguage)
 		if err != nil {
 			continue
 		}
 		for _, entry := range entries {
-			out = append(out, providerViewFromEntryForRoot(entry, true, added[entry.Name], root))
+			out = append(out, providerViewFromEntryForRootWithResolver(entry, true, added[entry.Name], root, resolver))
 		}
 	}
 	return out
@@ -433,10 +447,11 @@ func (a *App) Settings() SettingsView {
 	}
 	added := providerAccessSet(cfg.Desktop.ProviderAccess)
 	root := a.activeWorkspaceRoot()
-	v.OfficialProviders = officialProviderViewsForRoot(officialProviderAddedSet(cfg), cfg.DeepSeekOfficialPricingLanguage(), root)
+	resolver := config.NewCredentialResolverForRoot(root)
+	v.OfficialProviders = officialProviderViewsForRootWithResolver(officialProviderAddedSet(cfg), cfg.DeepSeekOfficialPricingLanguage(), root, resolver)
 	for i := range cfg.Providers {
 		p := &cfg.Providers[i]
-		v.Providers = append(v.Providers, providerViewFromEntryForRoot(*p, isOfficialBuiltInProvider(*p), added[p.Name], root))
+		v.Providers = append(v.Providers, providerViewFromEntryForRootWithResolver(*p, isOfficialBuiltInProvider(*p), added[p.Name], root, resolver))
 	}
 	return v
 }

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -55,6 +55,56 @@ var credentialSourceTracker = struct {
 	byKey map[string]trackedCredentialSource
 }{byKey: map[string]trackedCredentialSource{}}
 
+var storedCredentialValueLookup = storedCredentialValue
+
+// CredentialResolver resolves credentials repeatedly for one caller-owned view
+// build. It keeps expensive global credential-store lookups bounded to one per
+// key while preserving the same source/shadow reporting as the one-shot helpers.
+type CredentialResolver struct {
+	root string
+
+	mu               sync.Mutex
+	globalFirstCache map[string]CredentialResolution
+}
+
+// NewCredentialResolverForRoot returns a resolver scoped to a workspace root.
+func NewCredentialResolverForRoot(root string) *CredentialResolver {
+	return &CredentialResolver{root: resolveRoot(root)}
+}
+
+// ResolveGlobalFirst resolves key with the Reasonix credential store taking
+// precedence over project env files. Repeated calls for the same key reuse the
+// first result so UI views with multiple provider entries sharing api_key_env do
+// not repeatedly hit the OS credential store.
+func (r *CredentialResolver) ResolveGlobalFirst(key string) CredentialResolution {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return CredentialResolution{Name: key}
+	}
+	if r == nil {
+		return resolveCredentialForRootGlobalFirst(".", key)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.globalFirstCache == nil {
+		r.globalFirstCache = map[string]CredentialResolution{}
+	}
+	if cached, ok := r.globalFirstCache[key]; ok {
+		return cloneCredentialResolution(cached)
+	}
+	res := resolveCredentialForRootGlobalFirst(r.root, key)
+	r.globalFirstCache[key] = cloneCredentialResolution(res)
+	return res
+}
+
+func cloneCredentialResolution(res CredentialResolution) CredentialResolution {
+	if len(res.Shadowed) > 0 {
+		res.Shadowed = append([]CredentialSource(nil), res.Shadowed...)
+	}
+	return res
+}
+
 func normalizeCredentialsStore(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
 	case CredentialsStoreKeyring:
@@ -389,11 +439,16 @@ func ResolveCredentialForRoot(root, key string) CredentialResolution {
 
 func ResolveCredentialForRootGlobalFirst(root, key string) CredentialResolution {
 	key = strings.TrimSpace(key)
+	return NewCredentialResolverForRoot(root).ResolveGlobalFirst(key)
+}
+
+func resolveCredentialForRootGlobalFirst(root, key string) CredentialResolution {
+	root = resolveRoot(root)
 	res := CredentialResolution{Name: key}
 	if key == "" {
 		return res
 	}
-	if value, source, ok := storedCredentialValue(key); ok {
+	if value, source, ok := storedCredentialValueLookup(key); ok {
 		res.Set = true
 		res.Value = value
 		res.Source = source

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -125,6 +125,42 @@ func TestResolveCredentialGlobalFirstDoesNotMutateProjectEnv(t *testing.T) {
 	}
 }
 
+func TestCredentialResolverCachesGlobalFirstLookups(t *testing.T) {
+	project := t.TempDir()
+	key := "KEY_SETTINGS_CACHE"
+	calls := 0
+	stubStoredCredentialValueForTest(t, func(got string) (string, CredentialSource, bool) {
+		calls++
+		if got != key {
+			t.Fatalf("stored credential lookup key = %q, want %q", got, key)
+		}
+		return "from_credentials", CredentialSource{Kind: CredentialSourceCredentials, Label: "Reasonix credentials"}, true
+	})
+
+	resolver := NewCredentialResolverForRoot(project)
+	first := resolver.ResolveGlobalFirst(key)
+	second := resolver.ResolveGlobalFirst(key)
+
+	if !first.Set || first.Value != "from_credentials" {
+		t.Fatalf("first credential = %+v, want stored credential", first)
+	}
+	if !second.Set || second.Value != "from_credentials" {
+		t.Fatalf("second credential = %+v, want cached stored credential", second)
+	}
+	if calls != 1 {
+		t.Fatalf("stored credential lookups = %d, want 1 for repeated key in one resolver", calls)
+	}
+}
+
+func stubStoredCredentialValueForTest(t *testing.T, fn func(string) (string, CredentialSource, bool)) {
+	t.Helper()
+	old := storedCredentialValueLookup
+	storedCredentialValueLookup = fn
+	t.Cleanup(func() {
+		storedCredentialValueLookup = old
+	})
+}
+
 func TestResolveCredentialSourceShowsCredentialsShadowingProjectEnv(t *testing.T) {
 	cwd := t.TempDir()
 	cfgHome := t.TempDir()


### PR DESCRIPTION
## Problem

Fixes #4713.

After the v1.9.1 desktop credential-priority changes, Settings page loads and Settings save/reload interactions could feel slower when multiple provider entries shared the same `api_key_env`.

The visible report included broader page-operation lag. The reproducible backend hotspot is the Settings provider/key-state path: opening Settings and saving lightweight Settings controls both rebuild the provider view, and that path was doing repeated credential-store work on the UI interaction path.

## Root Cause

`Settings()` builds both the official provider templates and the configured provider list. Each provider row called `ResolveCredentialForRootGlobalFirst()` independently.

That one-shot resolver checks the global credential store before project/home env files and also computes shadowed sources. Default desktop providers intentionally share keys such as `DEEPSEEK_API_KEY` and `MIMO_API_KEY`, so one Settings refresh could hit the same macOS Keychain / Reasonix credentials lookup multiple times for identical keys.

## Fix

- Add a per-view `CredentialResolver` that caches global-first credential resolution by key while preserving the existing source and shadowed-source metadata.
- Reuse one resolver across `Settings()` official provider rows and configured provider rows.
- Keep the existing one-shot `ResolveCredentialForRootGlobalFirst()` API intact for other callers.
- Add regression coverage proving repeated global-first resolution for the same key performs one stored credential lookup.

## Cache impact

None. This only changes desktop Settings credential-status lookup plumbing. It does not change provider request bodies, model selection semantics, prompt content, tool schemas, or cache-sensitive prefixes.

## Verification

- `go test ./internal/config -run 'TestCredentialResolverCachesGlobalFirstLookups|TestResolveCredentialGlobalFirstDoesNotMutateProjectEnv|TestResolveCredentialSourceShowsCredentials' -count=1`
- `cd desktop && go test . -run 'TestSettings(LoadsActiveWorkspaceCredentialsWithUserConfig|ShowsGlobalCredentialWithoutMutatingWorkspaceEnv|SeedsMissingUserConfigFromLegacyProjectConfig)' -count=1`
- `go test ./internal/config -count=1`
- `cd desktop && go test . -count=1`
- `go test ./...`
- `cd desktop && go test ./...`
- `cd desktop && go run github.com/wailsapp/wails/v2/cmd/wails@v2.12.0 generate module`
- `cd desktop/frontend && corepack pnpm run test:all`
- `cd desktop/frontend && corepack pnpm run build`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `gofmt -l .`
- `git diff --check`
