### PR TITLE
Improve desktop session restore performance / 优化桌面会话恢复性能

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1926,7 +1926,8 @@ func (a *App) ResumeSessionForTab(tabID, path string) ([]HistoryMessage, error) 
 	if err != nil {
 		return nil, err
 	}
-	if _, err := agent.LoadSession(sessionPath); err != nil {
+	loaded, err := agent.LoadSession(sessionPath)
+	if err != nil {
 		return nil, err
 	}
 	if sessionRuntimeKey(tab.currentSessionPath()) == sessionRuntimeKey(sessionPath) {
@@ -1934,7 +1935,7 @@ func (a *App) ResumeSessionForTab(tabID, path string) ([]HistoryMessage, error) 
 		return a.HistoryForTab(tabID), nil
 	}
 
-	if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {
+	if err := a.rebindTabToLoadedSessionPath(tab, sessionPath, loaded); err != nil {
 		return nil, err
 	}
 	a.setTabReadOnly(tab.ID, false)
@@ -1951,11 +1952,12 @@ func (a *App) OpenChannelSessionForTab(tabID, path string) ([]HistoryMessage, er
 	if err != nil {
 		return nil, err
 	}
-	if _, err := agent.LoadSession(sessionPath); err != nil {
+	loaded, err := agent.LoadSession(sessionPath)
+	if err != nil {
 		return nil, err
 	}
 	if sessionRuntimeKey(tab.currentSessionPath()) != sessionRuntimeKey(sessionPath) {
-		if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {
+		if err := a.rebindTabToLoadedSessionPath(tab, sessionPath, loaded); err != nil {
 			return nil, err
 		}
 	}
@@ -1973,6 +1975,18 @@ func (a *App) setTabReadOnly(tabID string, readOnly bool) {
 }
 
 func (a *App) rebindTabToSessionPath(tab *WorkspaceTab, sessionPath string) error {
+	sessionPath = canonicalTabSessionPath(sessionPath)
+	if sessionPath == "" {
+		return fmt.Errorf("session path is required")
+	}
+	loaded, err := agent.LoadSession(sessionPath)
+	if err != nil {
+		return err
+	}
+	return a.rebindTabToLoadedSessionPath(tab, sessionPath, loaded)
+}
+
+func (a *App) rebindTabToLoadedSessionPath(tab *WorkspaceTab, sessionPath string, loaded *agent.Session) error {
 	if tab == nil {
 		return fmt.Errorf("tab is not ready")
 	}
@@ -1980,8 +1994,12 @@ func (a *App) rebindTabToSessionPath(tab *WorkspaceTab, sessionPath string) erro
 	if sessionPath == "" {
 		return fmt.Errorf("session path is required")
 	}
-	if _, err := agent.LoadSession(sessionPath); err != nil {
-		return err
+	if loaded == nil {
+		var err error
+		loaded, err = agent.LoadSession(sessionPath)
+		if err != nil {
+			return err
+		}
 	}
 	if sessionRuntimeKey(tab.currentSessionPath()) == sessionRuntimeKey(sessionPath) {
 		return nil
@@ -1997,7 +2015,7 @@ func (a *App) rebindTabToSessionPath(tab *WorkspaceTab, sessionPath string) erro
 		tab.sink = &tabEventSink{tabID: tab.ID, app: a, ctx: a.ctx}
 		a.saveTabsLocked()
 		a.mu.Unlock()
-		a.buildTabController(tab)
+		a.buildTabControllerWithLoadedSession(tab, loadedTabSession{Path: sessionPath, Session: loaded})
 		if tab.Ctrl == nil {
 			if tab.StartupErr != "" {
 				return fmt.Errorf("resume session: %s", tab.StartupErr)
@@ -2026,7 +2044,7 @@ func (a *App) rebindTabToSessionPath(tab *WorkspaceTab, sessionPath string) erro
 	a.saveTabsLocked()
 	a.mu.Unlock()
 
-	a.buildTabController(tab)
+	a.buildTabControllerWithLoadedSession(tab, loadedTabSession{Path: sessionPath, Session: loaded})
 	if tab.Ctrl == nil {
 		if tab.StartupErr != "" {
 			return fmt.Errorf("resume session: %s", tab.StartupErr)

--- a/desktop/history_test.go
+++ b/desktop/history_test.go
@@ -474,6 +474,57 @@ func TestResumeSessionForTabDetachesRunningRuntimeForDifferentSessionPath(t *tes
 	waitNotRunning(t, ctrlA)
 }
 
+func TestRebindTabToLoadedSessionReusesPreloadedTranscript(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	root := globalTabWorkspaceRoot()
+	dir := desktopSessionDir(root)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+
+	currentPath := filepath.Join(dir, "current.jsonl")
+	targetPath := filepath.Join(dir, "target.jsonl")
+	writeHistoryTestSession(t, currentPath, "current prompt")
+	writeHistoryTestSession(t, targetPath, "target prompt")
+
+	loaded, err := agent.LoadSession(targetPath)
+	if err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if err := os.Remove(targetPath); err != nil {
+		t.Fatalf("remove target session: %v", err)
+	}
+
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: currentPath, Label: "current", Sink: event.Discard})
+	defer ctrl.Close()
+
+	app := NewApp()
+	tab := &WorkspaceTab{
+		ID:            "tab",
+		Scope:         "global",
+		WorkspaceRoot: root,
+		SessionPath:   currentPath,
+		Ctrl:          ctrl,
+		Ready:         true,
+		sink:          &tabEventSink{tabID: "tab", app: app},
+		disabledMCP:   map[string]ServerView{},
+	}
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	if err := app.rebindTabToLoadedSessionPath(tab, targetPath, loaded); err != nil {
+		t.Fatalf("rebindTabToLoadedSessionPath: %v", err)
+	}
+	got := app.HistoryForTab(tab.ID)
+	if len(got) != 1 || got[0].Content != "target prompt" {
+		t.Fatalf("rebound history = %+v, want target prompt", got)
+	}
+	if gotPath := app.tabs[tab.ID].Ctrl.SessionPath(); gotPath != targetPath {
+		t.Fatalf("rebound session path = %q, want %q", gotPath, targetPath)
+	}
+}
+
 func writeHistoryTestSession(t *testing.T, path, prompt string) {
 	t.Helper()
 	session := agent.NewSession("")

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1415,6 +1415,19 @@ func (a *App) startTabControllerBuild(tab *WorkspaceTab) {
 }
 
 func (a *App) buildTabController(tab *WorkspaceTab) {
+	a.buildTabControllerWithLoadedSession(tab, loadedTabSession{})
+}
+
+type loadedTabSession struct {
+	Path    string
+	Session *agent.Session
+}
+
+func (s loadedTabSession) matches(path string) bool {
+	return s.Session != nil && sessionRuntimeKey(s.Path) != "" && sessionRuntimeKey(s.Path) == sessionRuntimeKey(path)
+}
+
+func (a *App) buildTabControllerWithLoadedSession(tab *WorkspaceTab, loadedSession loadedTabSession) {
 	defer a.recoverToPending("buildTabController")
 	wailsCtx := a.ctx
 	buildCtx := a.bootContext()
@@ -1545,7 +1558,7 @@ func (a *App) buildTabController(tab *WorkspaceTab) {
 		// Prefer the exact session file persisted for this tab. Topic lookup is a
 		// compatibility fallback for older desktop-tabs.json files that only stored
 		// topicId and could pick the wrong session when one topic had multiple files.
-		if loaded, pinnedPath, ok := loadPinnedTabSession(dir, tab.SessionPath); ok {
+		if loaded, pinnedPath, ok := loadPinnedTabSessionWithPreload(dir, tab.SessionPath, loadedSession); ok {
 			if loaded != nil {
 				ctrl.Resume(loaded, pinnedPath)
 			} else {
@@ -4085,9 +4098,16 @@ func globalTabWorkspaceRoot() string {
 }
 
 func loadPinnedTabSession(dir, sessionPath string) (*agent.Session, string, bool) {
+	return loadPinnedTabSessionWithPreload(dir, sessionPath, loadedTabSession{})
+}
+
+func loadPinnedTabSessionWithPreload(dir, sessionPath string, preloaded loadedTabSession) (*agent.Session, string, bool) {
 	path, ok := pinnedTabSessionPath(dir, sessionPath)
 	if !ok {
 		return nil, "", false
+	}
+	if preloaded.matches(path) {
+		return preloaded.Session, path, true
 	}
 	loaded, err := agent.LoadSession(path)
 	if err != nil {


### PR DESCRIPTION
## Problem

During the desktop performance audit, the session restore/open path had an avoidable hot spot: switching a tab to a different saved session could reload the same JSONL transcript more than once before rendering the restored history.

For small sessions this is hard to notice, but large transcripts with many tool records amplify the repeated disk IO and JSON decoding on an interaction path that users expect to feel immediate.

## Root Cause

`ResumeSessionForTab()` and `OpenChannelSessionForTab()` already loaded the target session to validate it. They then called the generic rebind path, which loaded the same session again, and the controller build path could load the pinned tab session once more before calling `ctrl.Resume()`.

## Fix

- Reuse the already-loaded `*agent.Session` when rebinding a tab to a restored or channel session.
- Thread an optional preloaded session through the desktop controller build path while keeping the existing `buildTabController()` entrypoint unchanged for normal startup.
- Fall back to the old on-demand load behavior when no preloaded session is available.
- Add a regression test proving a preloaded transcript can drive the rebind path without requiring another JSONL read.

## Performance Data

The optimized restore/open path now does one target-session JSONL load in the public entrypoint and reuses that loaded transcript through rebind/controller setup. The previous path could load the same target transcript again in `rebindTabToSessionPath()` and again while resolving the pinned tab session during controller build.

The regression test `TestRebindTabToLoadedSessionReusesPreloadedTranscript` preloads the target transcript, removes the JSONL file, and verifies the rebind still renders the restored history. That locks the no-second-read behavior directly.

Post-change benchmark snapshots:

- Frontend long-history restore benchmark: `10000-turns-archived-1-tool` produced `messages=30000`, `items=30000`, `convertMs=3.80`, `reducerMs=2.78`, `transcriptComputeMs=8.50`.
- Frontend transcript grouping contract: `groups 10k turns in 2.63ms` in the full frontend test run.
- Go history conversion benchmark: `BenchmarkHistoryMessagesSynthetic/1000x10KB-bash-success` ran at `1452255 ns/op`, `2607833 B/op`, `37047 allocs/op`.
- Go history marshal benchmark: `BenchmarkHistoryMessagesMarshalSynthetic/1000x10KB-bash-success` ran at `2024026 ns/op`, `3635856 B/op`, `37066 allocs/op`.
- Session-dir helper benchmark: `BenchmarkDesktopSessionDir` ran at `509.7 ns/op`, `848 B/op`, `6 allocs/op`.

## Verification

- `go test ./...`
- `cd desktop && go test ./...`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `cd desktop/frontend && corepack pnpm run test:all`
- `cd desktop/frontend && corepack pnpm run build`
- `cd desktop && go test . -run 'Test(ResumeSessionForTab|RebindTabToLoadedSession|OpenChannelSessionForTab)'`
- `cd desktop/frontend && corepack pnpm exec tsx src/__tests__/render-optimization.test.ts`
- `cd desktop/frontend && corepack pnpm exec tsx src/__tests__/transcript-grouping.test.ts`
- `cd desktop/frontend && corepack pnpm exec tsx src/__tests__/history-performance-benchmark.tsx`
- `cd desktop && go test . -run '^$' -bench 'Benchmark(HistoryMessages|DesktopListSessionsScoped|DesktopSessionDir)' -benchmem -count=1`
- `git diff --check`
