### PR TITLE
[codex] Attach workspace image refs to vision turns

### DIFF
--- a/internal/control/inputimages_test.go
+++ b/internal/control/inputimages_test.go
@@ -1,6 +1,8 @@
 package control
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -24,5 +26,40 @@ func TestControllerInputImagesIgnoresNonAttachmentRefs(t *testing.T) {
 	t.Chdir(t.TempDir())
 	if urls := New(Options{}).inputImages("plain text with @missing.png"); len(urls) != 0 {
 		t.Errorf("inputImages = %v, want none for a non-existent / non-attachment ref", urls)
+	}
+}
+
+func TestControllerInputImagesResolvesWorkspaceImage(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "docs", "diagram.png")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	urls := (&Controller{cpRoot: workspace}).inputImages("look at @docs/diagram.png")
+	if len(urls) != 1 {
+		t.Fatalf("inputImages = %v, want one resolved data URL", urls)
+	}
+	if !strings.HasPrefix(urls[0], "data:image/png;base64,") {
+		t.Errorf("resolved url = %q, want a png data URL", urls[0])
+	}
+}
+
+func TestControllerInputImagesResolvesAbsoluteWorkspaceImage(t *testing.T) {
+	workspace := t.TempDir()
+	path := filepath.Join(workspace, "diagram.png")
+	if err := os.WriteFile(path, mustBase64(t, tinyPNG), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	urls := (&Controller{cpRoot: workspace}).inputImages("look at @" + path)
+	if len(urls) != 1 {
+		t.Fatalf("inputImages = %v, want one resolved data URL", urls)
+	}
+	if !strings.HasPrefix(urls[0], "data:image/png;base64,") {
+		t.Errorf("resolved url = %q, want a png data URL", urls[0])
 	}
 }

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -3,6 +3,7 @@ package control
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"net/http"
@@ -151,20 +152,103 @@ func (c *Controller) HasRefs(line string) bool {
 	return len(c.detectRefs(line)) > 0
 }
 
-// inputImages resolves image @-attachments in the turn input to data URLs so the
-// turn can carry them to a vision-capable model. Best-effort: an unreadable
-// attachment is skipped — the @image ref still lands as text via ResolveRefs.
+// inputImages resolves image @-references in the turn input to data URLs so the
+// turn can carry them to a vision-capable model. Best-effort: an unreadable image
+// is skipped — the @ref still lands as text via ResolveRefs.
 func (c *Controller) inputImages(line string) []string {
 	var urls []string
 	for _, r := range c.detectRefs(line) {
-		if r.kind != refImage {
-			continue
-		}
-		if url, err := visionImageDataURL(r.path); err == nil {
+		if url, err := visionRefImageDataURL(r, c.cpRoot); err == nil {
 			urls = append(urls, url)
 		}
 	}
 	return urls
+}
+
+func visionRefImageDataURL(r ref, baseDir string) (string, error) {
+	switch r.kind {
+	case refImage:
+		return visionImageDataURL(r.path)
+	case refFile:
+		return visionFileImageDataURL(r.path, baseDir)
+	default:
+		return "", fmt.Errorf("reference is not an image")
+	}
+}
+
+func visionFileImageDataURL(path, baseDir string) (string, error) {
+	absPath, absBase, ok := resolveAbsRef(path, baseDir)
+	if !ok {
+		return "", os.ErrNotExist
+	}
+	if absBase == "" {
+		return visionFileImageDataURLUnscoped(absPath)
+	}
+
+	if info, err := os.Lstat(absPath); err != nil {
+		return "", err
+	} else if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("image path must not be a symlink")
+	}
+
+	root, err := os.OpenRoot(absBase)
+	if err != nil {
+		return "", err
+	}
+	defer root.Close()
+
+	rel, err := filepath.Rel(absBase, absPath)
+	if err != nil {
+		return "", err
+	}
+	info, err := root.Stat(rel)
+	if err != nil {
+		return "", err
+	}
+	if info.IsDir() || info.Size() <= 0 || info.Size() > maxImageAttachmentBytes {
+		return "", fmt.Errorf("image must be between 1 byte and 10 MB")
+	}
+	f, err := root.Open(rel)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return dataURLFromImageReader(f, path)
+}
+
+func visionFileImageDataURLUnscoped(path string) (string, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return "", err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return "", fmt.Errorf("image path must not be a symlink")
+	}
+	if info.IsDir() || info.Size() <= 0 || info.Size() > maxImageAttachmentBytes {
+		return "", fmt.Errorf("image must be between 1 byte and 10 MB")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	return dataURLFromImageReader(f, path)
+}
+
+func dataURLFromImageReader(r io.Reader, path string) (string, error) {
+	raw, err := io.ReadAll(io.LimitReader(r, maxImageAttachmentBytes+1))
+	if err != nil {
+		return "", err
+	}
+	if len(raw) == 0 || len(raw) > maxImageAttachmentBytes {
+		return "", fmt.Errorf("image must be between 1 byte and 10 MB")
+	}
+	mime := detectedImageMime(raw)
+	if mime == "" {
+		return "", fmt.Errorf("%s is not a supported image", path)
+	}
+	raw, mime = compressForVision(raw, mime)
+	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(raw), nil
 }
 
 // resolveBareNames batch-resolves simple filenames (no path separator) that
@@ -379,7 +463,7 @@ func (c *Controller) resolveRefs(ctx context.Context, line string, scopedOnly bo
 			}
 			appendRefBlock(&b, tag, `path="`+r.path+`"`, text)
 		case refImage:
-			appendRefBlock(&b, "image", `path="`+r.path+`"`, "[image attachment available at @"+r.path+"; use an image/OCR/vision MCP tool if visual understanding is needed]")
+			appendRefBlock(&b, "image", `path="`+r.path+`"`, "[image attachment available at @"+r.path+" and attached to this turn as model image input when the selected model supports vision; no local extraction tool is needed for direct visual understanding]")
 		}
 	}
 	return b.String(), errs
@@ -459,7 +543,7 @@ func readFileRef(path, baseDir string) (content string, isDir bool, err error) {
 	data := buf[:n]
 
 	if mime := imageMime(data, rel); mime != "" {
-		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — image bytes are not inlined. Use an available MCP image/OCR/vision tool with this path when visual understanding is needed.]", displayPath, mime, info.Size()), false, nil
+		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — attached to this turn as model image input when the selected model supports vision; no local extraction tool is needed for direct visual understanding.]", displayPath, mime, info.Size()), false, nil
 	}
 	if bytes.IndexByte(data[:min(n, 8192)], 0) >= 0 {
 		return fmt.Sprintf("[binary file %s, %d bytes — not shown]", displayPath, info.Size()), false, nil
@@ -536,7 +620,7 @@ func readFileRefUnscoped(path string) (content string, isDir bool, err error) {
 	data := buf[:n]
 
 	if mime := imageMime(data, path); mime != "" {
-		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — image bytes are not inlined. Use an available MCP image/OCR/vision tool with this path when visual understanding is needed.]", path, mime, info.Size()), false, nil
+		return fmt.Sprintf("[image file %s, mime=%s, %d bytes — attached to this turn as model image input when the selected model supports vision; no local extraction tool is needed for direct visual understanding.]", path, mime, info.Size()), false, nil
 	}
 	if bytes.IndexByte(data[:min(n, 8192)], 0) >= 0 {
 		return fmt.Sprintf("[binary file %s, %d bytes — not shown]", path, info.Size()), false, nil

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -491,7 +491,7 @@ func TestResolveRefsWithWorkspaceRootStoresRelativePath(t *testing.T) {
 	}
 }
 
-func TestWorkspaceImageRefsOnlyTreatAttachmentsAsImages(t *testing.T) {
+func TestWorkspaceImageRefsAlsoAttachAsModelImages(t *testing.T) {
 	workspace := t.TempDir()
 	diagram := filepath.Join(workspace, "docs", "diagram.png")
 	if err := os.MkdirAll(filepath.Dir(diagram), 0o755); err != nil {
@@ -524,8 +524,11 @@ func TestWorkspaceImageRefsOnlyTreatAttachmentsAsImages(t *testing.T) {
 	if len(errs) != 0 {
 		t.Fatalf("ResolveRefs errors = %v", errs)
 	}
-	if !strings.Contains(block, `<file path="docs/diagram.png">`) || !strings.Contains(block, "image file docs/diagram.png") {
-		t.Fatalf("workspace png should resolve as image-file metadata:\n%s", block)
+	if !strings.Contains(block, `<file path="docs/diagram.png">`) || !strings.Contains(block, "attached to this turn as model image input") || strings.Contains(block, "OCR") {
+		t.Fatalf("workspace png should resolve as attached image-file metadata without OCR guidance:\n%s", block)
+	}
+	if urls := c.inputImages("see @" + diagram); len(urls) != 1 || !strings.HasPrefix(urls[0], "data:image/png;base64,") {
+		t.Fatalf("workspace png inputImages = %v, want one png data URL", urls)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Attach workspace image references (`@docs/image.png` and absolute paths under the workspace) to user turns as model image input, matching the existing attachment-image path.
- Keep image refs visible in referenced context, but stop prompting the model to reach for OCR/vision tools when direct image input is available.
- Add regression coverage for workspace-relative and absolute workspace image refs.

## Root Cause

Reasonix only populated `provider.Message.Images` for `.reasonix/attachments/...` image refs. Regular workspace image refs were resolved as file metadata with text saying the bytes were not inlined and suggesting OCR/vision tooling, so vision-capable local providers could be steered away from their native multimodal path.

## Validation

- `GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.google.cn go test ./internal/control ./internal/provider/openai ./internal/provider/anthropic ./internal/config`
- `GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.google.cn go test ./cmd/reasonix ./internal/boot`
- Local smoke test with an oMLX Qwen3.6 vision-capable model using a workspace PNG ref; the model answered from direct image input without requesting OCR.
