### PR TITLE
fix: backfill empty tool-call name/arguments on old session replay (#4727)

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -597,8 +597,8 @@ type chatToolCall struct {
 	ID       string `json:"id,omitempty"`
 	Type     string `json:"type,omitempty"`
 	Function struct {
-		Name      string `json:"name,omitempty"`
-		Arguments string `json:"arguments,omitempty"`
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
 	} `json:"function"`
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -111,9 +111,17 @@ func SanitizeToolPairing(msgs []Message) []Message {
 			for j < len(msgs) && msgs[j].Role == RoleTool {
 				j++
 			}
-			out = append(out, repairToolCallArgs(m))
-			out = append(out, pairToolResults(m.ToolCalls, msgs[i+1:j])...)
-			i = j // tool messages consumed here; any non-matching ones are orphans, dropped
+			// Backfill empty tool-call names from the corresponding tool
+			// results so the model sees which tool was invoked (#4727).
+			// The wire-format fix (openai.go) ensures empty fields are
+			// never omitted, so this backfill is a UX improvement, not a
+			// correctness requirement.
+			calls := backfillToolCallNames(m.ToolCalls, msgs[i+1:j])
+			m2 := m
+			m2.ToolCalls = calls
+			out = append(out, repairToolCallArgs(m2))
+			out = append(out, pairToolResults(calls, msgs[i+1:j])...)
+			i = j
 			continue
 		}
 		if m.Role == RoleTool {
@@ -236,6 +244,39 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 			out = append(out, r)
 		} else {
 			out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
+		}
+	}
+	return out
+}
+
+// backfillToolCallNames returns a copy of calls with any empty Name filled in
+// from the matching tool result (by id, then by position). Old sessions (#4727)
+// may have saved assistant tool-calls with an empty name; backfilling gives the
+// model useful context during replay. Unpaired calls keep their empty name,
+// which the wire-format fix (openai.go) handles gracefully.
+func backfillToolCallNames(calls []ToolCall, results []Message) []ToolCall {
+	out := make([]ToolCall, len(calls))
+	copy(out, calls)
+	if idDistinct(calls) {
+		byID := make(map[string]string, len(results))
+		for _, r := range results {
+			if r.Name != "" {
+				byID[r.ToolCallID] = r.Name
+			}
+		}
+		for k := range out {
+			if out[k].Name == "" {
+				if n, ok := byID[out[k].ID]; ok {
+					out[k].Name = n
+				}
+			}
+		}
+		return out
+	}
+	// Fallback: positional pairing (same order as pairToolResults).
+	for k := range out {
+		if out[k].Name == "" && k < len(results) {
+			out[k].Name = results[k].Name
 		}
 	}
 	return out


### PR DESCRIPTION
## 问题

旧会话发送消息时 HTTP 400 "missing field `name` / `arguments`"，状态按钮弹出即消失。新建会话正常。

## 根因

1. **数据来源**：commit `adde2d3e`（6月11日）之前创建的会话，assistant tool_calls 的 `name` 和 `arguments` 可能是空字符串 `""`。旧版 stream parser 在 SSE 代理中断时，将不完整的 tool_call（只有 ID，没有 name/arguments）提交到了 session 中。
2. **序列化遗漏**：`chatToolCall.Function.Name` 和 `Arguments` 带 `json:"...,omitempty"` tag，空值被省略 → API 收到 `"function":{}`（缺少 name/arguments key）→ HTTP 400。
3. **已修复的不完整**：`repairToolCallArgs` 只修复了**截断**的参数 JSON，不处理**完全为空**的情况。

## 修复（两层防御）

| 层 | 文件 | 改动 |
|----|------|------|
| 数据修复 | `internal/provider/provider.go` | `SanitizeToolPairing` 中新增 `backfillToolCallNames()`，从匹配的 tool result 回填空 name |
| 序列化保障 | `internal/provider/openai/openai.go` | 移除 `chatToolCall.Function.Name`/`Arguments` 的 `omitempty`，wire 格式始终携带这两个 key |

第 2 层是最关键的修复——即使第 1 层回填失败，API 也不会因为 key 缺失而拒绝。

### stream 解析安全性

`omitempty` 移除对解析无影响：`readStream` 已有 `tc.Function.Name != ""` 守卫，`cur.Arguments += ""` 是空操作。

### 前缀缓存

无影响。新/正常旧会话的 name/arguments 本就不为空，序列化结果不变。

## 关联 Issue（全部 Open）

- Fixes #4727 — MacOS 旧会话无法对话（你的 issue）
- Ref #4735 — Windows `messages[2]: missing field name`（完全相同错误）
- Ref #4715 — macOS 升级 1.9.1 后 Malformed request（完全相同错误）
- Ref #4497 — OpenCode Go provider 400 `tools[0].function: missing field "name"`（不同 provider，同根因）
- Ref #4394 — 本地模型对话报错（可能相关）
- Ref #4072 — Malformed request (HTTP 400)（可能相关）

## 验证

- [x] `go build ./...` ✅
- [x] `go test ./internal/provider/... -count=1` ✅
- [x] 验证旧 session JSONL 中空 tool_call 字段数据
