### PR TITLE
docs(readme): add uninstall instructions for npm and Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ npm uninstall -g reasonix          # remove the npm-installed binary
 brew uninstall reasonix            # remove the Homebrew-installed binary
 ```
 
+### Upgrade
+
+```sh
+reasonix upgrade                   # self-update to the latest release
+reasonix upgrade --check           # check without installing
+npm i -g reasonix@next             # or upgrade via npm
+```
+
 Prebuilt archives (`darwin|linux|windows × amd64|arm64`) and `SHA256SUMS` are on
 every [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases).
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ npm i -g reasonix                  # any OS; pulls the prebuilt native binary
 brew install esengine/reasonix/reasonix   # macOS
 ```
 
+### Uninstall
+
+```sh
+npm uninstall -g reasonix          # remove the npm-installed binary
+brew uninstall reasonix            # remove the Homebrew-installed binary
+```
+
 Prebuilt archives (`darwin|linux|windows × amd64|arm64`) and `SHA256SUMS` are on
 every [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -74,6 +74,14 @@ npm uninstall -g reasonix          # 卸载 npm 安装的二进制
 brew uninstall reasonix            # 卸载 Homebrew 安装的二进制
 ```
 
+### 升级
+
+```sh
+reasonix upgrade                   # 自更新到最新发行版
+reasonix upgrade --check           # 仅检查，不安装
+npm i -g reasonix@next             # 或通过 npm 升级
+```
+
 预编译归档(`darwin|linux|windows × amd64|arm64`)和 `SHA256SUMS` 见每个
 [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases)。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,13 @@ npm i -g reasonix                  # 任意系统;自动拉取对应平台的原
 brew install esengine/reasonix/reasonix   # macOS
 ```
 
+### 卸载
+
+```sh
+npm uninstall -g reasonix          # 卸载 npm 安装的二进制
+brew uninstall reasonix            # 卸载 Homebrew 安装的二进制
+```
+
 预编译归档(`darwin|linux|windows × amd64|arm64`)和 `SHA256SUMS` 见每个
 [GitHub release](https://github.com/esengine/DeepSeek-Reasonix/releases)。
 


### PR DESCRIPTION
docs(readme): add uninstall instructions for npm and Homebrew

在 README.md 和 README.zh-CN.md 的安装章节后补充 npm 和 Homebrew 的卸载命令说明