### PR TITLE
fix: display empty tool-call name/args in history transcript (#4727)

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2791,11 +2791,17 @@ func historyMessages(msgs []provider.Message, resolveUserContent func(string) st
 const historyToolPreviewLimit = 2_000
 
 func historyToolCall(tc provider.ToolCall, args string, result provider.Message) HistoryToolCall {
+	// Old sessions (#4727) may have tool_calls with an empty name; backfill
+	// from the tool result so the frontend can display the tool name.
+	name := tc.Name
+	if name == "" && result.Name != "" {
+		name = result.Name
+	}
 	call := HistoryToolCall{
 		ID:      tc.ID,
-		Name:    tc.Name,
-		Subject: historyToolSubject(tc.Name, args),
-		Summary: historyToolSummary(tc.Name, args, result.Content),
+		Name:    name,
+		Subject: historyToolSubject(name, args),
+		Summary: historyToolSummary(name, args, result.Content),
 		Diff:    tc.Diff,
 		Added:   tc.Added,
 		Removed: tc.Removed,

--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -131,7 +131,7 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId }: { item
           {item.status === "error" && <span className="tool__status-icon tool__status-icon--err">✗</span>}
           {item.status === "done" && <span className="tool__status-icon tool__status-icon--ok">✓</span>}
           {item.status === "stopped" && <span className="tool__status-icon tool__status-icon--stopped">—</span>}
-          <span className="tool__name">{item.name}</span>
+          <span className="tool__name">{item.name || item.id?.replace(/^call_(\d+)_?(.{0,8}).*/, "tool_$1_$2…") || "(unknown tool)"}</span>
           {subject && <span className="tool__subject">{subject}</span>}
         </span>
         {profileText && <span className="tool__profile">{profileText}</span>}


### PR DESCRIPTION
## 问题

旧会话历史消息中，tool 卡片只显示 ✓/✗ 状态图标和折叠按钮，tool 名称和参数完全不可见。

## 根因

旧会话（commit `adde2d3e` 之前创建）的 JSONL 中 assistant tool_calls 的 `name` 和 `arguments` 为空字符串。历史回放时：

```
JSONL: tool_calls=[{name:"", arguments:""}]
  → historyToolCall() 直接取 tc.Name → HistoryToolCall{Name:""}
    → 前端 Item{name:"", args:""}
      → ToolCard <span class="tool__name">""</span> → 空白
      → subjectOf("", "") → "" → subject 行不渲染
      → effectiveArgs="" → args 代码块不渲染
```

可见的只有 ✓/✗（来自 tool result 的 status）和折叠按钮（来自 tool output）。

## 修复

### 第 1 层 — 后端回填（desktop/app.go）

`historyToolCall()` 中，当 `tc.Name` 为空时，从匹配的 tool result 回填：

```go
name := tc.Name
if name == "" && result.Name != "" {
    name = result.Name  // "web_fetch", "bash", "read_file" ...
}
```

tool result 消息始终有正确的 `Name` 字段，按 `tool_call_id` 配对。

### 第 2 层 — 前端 fallback（ToolCard.tsx）

极端情况下后端回填也失败（无 tool result），不显示空白的 `<span>`：

```tsx
// 改动前：空字符串 → 看不见
<span className="tool__name">{item.name}</span>

// 改动后：空时显示 tool_call_id 简写或 "(unknown tool)"
<span className="tool__name">
  {item.name || item.id?.replace(/^call_\d+_?(.{0,8}).*/, "tool_$1_…") || "(unknown tool)"}
</span>
```

## 关联

- Ref #4727 — 上游根 issue

## 验证

- [x] `go build ./desktop/...` ✅
- [x] `npx tsc --noEmit` ✅（前端无报错）
- [x] `pnpm build` ✅（commit hook 自动运行）
