### PR TITLE
ci(desktop): Authenticode-sign Windows installer via SignPath

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -55,6 +55,9 @@ jobs:
   build:
     name: build (${{ matrix.name }})
     needs: cache-guard
+    permissions:
+      contents: read # checkout only; the publish job holds contents: write
+      actions: read # SignPath reads run details + downloads the unsigned artifact
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +69,10 @@ jobs:
           - { runner: windows-11-arm, platform: windows/arm64, name: windows-arm64 }
           - { runner: ubuntu-22.04, platform: linux/amd64, name: linux-amd64 }
     runs-on: ${{ matrix.runner }}
+    env:
+      # Windows Authenticode signing engages only when the SignPath token is set, so
+      # forks / token-less runs still build (unsigned), mirroring the APPLE_* gate.
+      HAS_SIGNPATH: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
     defaults:
       run:
         shell: bash # desktop-build.sh is bash; windows runners default to pwsh otherwise
@@ -162,6 +169,39 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
         run: scripts/desktop-build.sh "${{ matrix.platform }}" "${{ steps.ver.outputs.version }}" "${{ steps.ver.outputs.channel }}"
+
+      # Authenticode-sign the Windows installer through SignPath. Runs BEFORE minisign:
+      # the signature rewrites the installer's bytes, so the updater's minisign sig and
+      # the manifest SHA must be computed over the signed build. SignPath pulls the file
+      # from the Actions artifact API, so it must be uploaded first. Canary signs with
+      # the test certificate; stable/rc use the Foundation release certificate.
+      - name: Upload unsigned installer for SignPath
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        id: unsigned-installer
+        uses: actions/upload-artifact@v7
+        with:
+          name: unsigned-${{ matrix.name }}
+          path: dist/*installer*.exe
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Submit installer for Authenticode signing
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: DeepSeek-Reasonix
+          signing-policy-slug: ${{ steps.ver.outputs.channel == 'canary' && 'test-signing' || 'release-signing' }}
+          artifact-configuration-slug: windows-installer
+          github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}
+          github-token: ${{ github.token }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+
+      - name: Replace installer with signed build
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        run: cp signed/*installer*.exe dist/
 
       - name: Sign artifacts (minisign)
         working-directory: desktop

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -190,13 +190,16 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          organization-id: ${{ secrets.SIGNPATH_ORGANIZATION_ID }}
           project-slug: DeepSeek-Reasonix
           signing-policy-slug: ${{ steps.ver.outputs.channel == 'canary' && 'test-signing' || 'release-signing' }}
           artifact-configuration-slug: windows-installer
           github-artifact-id: ${{ steps.unsigned-installer.outputs.artifact-id }}
           github-token: ${{ github.token }}
           wait-for-completion: true
+          # The policy uses an approval process — leave headroom for a human to approve
+          # the request (the approver gets an email on submit) before the job gives up.
+          wait-for-completion-timeout-in-seconds: 1800
           output-artifact-directory: signed
 
       - name: Replace installer with signed build

--- a/.signpath/artifact-configurations/windows-installer.xml
+++ b/.signpath/artifact-configurations/windows-installer.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- GitHub Actions wraps every uploaded artifact in a zip, so the installer arrives
+     zipped even though it is a single file — match and sign the .exe inside. -->
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <pe-file-set>
+      <include path="*installer*.exe" min-matches="1" max-matches="1" />
+      <for-each>
+        <authenticode-sign />
+      </for-each>
+    </pe-file-set>
+  </zip-file>
+</artifact-configuration>


### PR DESCRIPTION
Wires SignPath into the desktop release pipeline so the Windows installer ships Authenticode-signed. The README already advertises this; this makes it real.

## What it does

- Adds `signpath/github-action-submit-signing-request@v2` to the Windows build leg, **between `Build and package` and `Sign artifacts (minisign)`**. Authenticode rewrites the PE, so it has to run before minisign/manifest — otherwise the updater's signature and the manifest SHA would cover stale, unsigned bytes.
- Uploads the unsigned installer as an Actions artifact first (the action signs by `github-artifact-id`), then copies the signed result back over `dist/`.
- Grants the build job `actions: read` so SignPath can read run details and pull the artifact (the top-level `contents: write` alone leaves `actions` at `none`).
- Policy split: canary → `test-signing`, stable/rc → `release-signing`.
- Gated on `secrets.SIGNPATH_API_TOKEN` — forks and token-less runs still build unsigned, same shape as the `APPLE_*` path.
- `wait-for-completion-timeout-in-seconds: 1800` because both policies use a manual approval process; the job waits up to 30 min for the approver to act.

## Before this activates

Merging is a no-op while the token secret is unset, so it's safe to land early. To actually sign:

1. **Artifact configuration** — create one that signs a single PE (`.exe`); this PR assumes its slug is `windows-installer`. (Can be made in the dashboard, or committed as `.signpath/artifact-configurations/windows-installer.xml`.)
2. **GitHub secrets** — `SIGNPATH_API_TOKEN` (CI user token) and `SIGNPATH_ORGANIZATION_ID` (org GUID).
3. **SignPath GitHub App** — confirm it's installed on this repo and authorized.

Already done by the Foundation onboarding: the **GitHub.com** trusted build system is added and linked to both policies. Origin verification is on, but no `.signpath/policies` file is required — it's verified automatically via the App + trusted build system (SignPath's own demo repos ship no policy file).

## Cert status / testing

- The **release certificate is still `CSR PENDING`**, so stable signing can't work yet — don't cut a `desktop-v*` tag until it flips to VALID.
- The **test certificate is VALID**, so validate the full pipeline now via a manual `workflow_dispatch` with `channel: canary` (signs with the test cert; approve the request in SignPath when the email arrives, then inspect the installer's Digital Signatures tab).

## Known gap (follow-up)

Only the installer `.exe` is signed. The portable `.zip`'s inner `Reasonix.exe`, and the app exe embedded inside the NSIS installer, stay unsigned. A nested-PE artifact configuration can cover the portable zip in a follow-up.
