### PR TITLE
fix(desktop): preserve scroll position across tab switches (#4584) / 对PR #4602的优化，补充修复会话切换滚动条位置不保持问题

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2738,6 +2738,7 @@ export default function App() {
               </div>
             ) : (
               <Transcript
+                key={activeTabId ?? "__history__"}
                 items={displayItems}
                 live={state.live}
                 tabId={activeTabId}

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -70,6 +70,14 @@ const WARM_PAGE_SIZE = 20; // cold-zone pagination batch
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+// Module-level cache for per-tab scroll positions.  Keyed by tabId.  Lives
+// across Transcript mount/unmount cycles created by the key={activeTabId}
+// boundary in App.tsx.  Entries are tiny (a number + boolean) and live for
+// the lifetime of the app window; they are never evicted because tab close
+// events are not available at this level.  In practice the memory cost is
+// negligible even with hundreds of tabs (#4584).
+const scrollStateCache = new Map<string, { scrollTop: number; stick: boolean }>();
+
 // ── Transcript component ──────────────────────────────────────────────────────
 
 export function Transcript({
@@ -134,13 +142,39 @@ export function Transcript({
   // Track question count and auto-scroll on new messages.
   useEffect(() => { trackQuestions(questions.length); }, [questions.length, trackQuestions]);
 
-  // Reset the auto-scroll pin when switching tabs so the new session always
-  // starts at the bottom. Without this, stick.current from the previous tab
-  // persists across React re-renders (Transcript is not keyed by tabId) and
-  // disables auto-scroll when the user had scrolled up in the old tab (#4584).
+  // ── Per-tab scroll-position persistence (#4584) ──────────────────────
+  // Transcript is keyed by activeTabId in App.tsx so each tab gets its
+  // own component instance.  On unmount the scroll state is saved to a
+  // module-level cache; on mount it is restored (first-open tabs default
+  // to bottom, letting the auto-scroll effect pin to the newest output).
+  const cacheKey = tabId ?? "";
+  const skipPersist = !tabId; // HistoryPanel uses no tabId — don't persist.
   useEffect(() => {
-    stick.current = true;
-  }, [tabId]);
+    if (skipPersist) return;
+    const saved = scrollStateCache.get(cacheKey);
+    if (!saved) {
+      stick.current = true;
+      return;
+    }
+    stick.current = saved.stick;
+    const el = scrollRef.current;
+    const frame = requestAnimationFrame(() => {
+      if (el) el.scrollTop = saved.scrollTop;
+    });
+    return () => cancelAnimationFrame(frame);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Save on unmount.  useLayoutEffect cleanup runs before the DOM is
+  // detached, so scrollRef.current is still valid.
+  useLayoutEffect(() => {
+    const key = cacheKey;
+    const persist = !skipPersist;
+    return () => {
+      if (!persist) return;
+      const el = scrollRef.current;
+      if (el) scrollStateCache.set(key, { scrollTop: el.scrollTop, stick: stick.current });
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Auto-scroll to bottom during streaming. Coalesce fast token/reasoning
   // updates into one layout read/write per animation frame.


### PR DESCRIPTION
## 概述

优化 #4602 的 desktop 端修复。#4602 解决了 CLI 端 transcript 累积问题，但desktop 端的修复较为简单 — 每次 Tab 切换重置 `stick.current = true`，强制滚到底部，导致已打开 Tab 的滚动位置丢失。

本 PR 按 Tab 维度精确保存/恢复滚动位置（`scrollTop` + 自动滚动标记 `stick`），确保切回已打开 Tab 时停留在离开时的位置。

Closes #4584。

## 问题根因

Transcript 组件未以 `tabId` 为 key，React 跨 Tab 复用同一组件实例和 DOM 节点。`useScrollManager` 的 `stick` ref 因此被跨 Tab 共享 — 用户在 Tab A 向上滚动（`stick=false`）后，Tab B 也会被禁用自动滚动。切换回来后更是因为浏览器对 `scrollTop` 的 clamp 导致位置随机偏移。

## 改动

### `desktop/frontend/src/App.tsx` (+1)

- 为 `<Transcript>` 添加 `key={activeTabId ?? "__history__"}`，使 React 在 Tab 切换时 unmount 旧实例、mount 新实例，彻底隔离各 Tab 的组件状态。

### `desktop/frontend/src/components/Transcript.tsx` (+36 / −6)

- 新增模块级 `scrollStateCache`  Map，在 mount/unmount 周期之间持久化。
- `useEffect` mount 恢复：通过 `requestAnimationFrame` 恢复保存的 `{scrollTop, stick}`；首次打开的 Tab 默认 `stick=true`。
- `useLayoutEffect` unmount 保存：在 DOM 卸载前将滚动状态写入缓存。
- 移除 #4602 中引入的 `stick.current = true` 无条件重置。

## 行为对照

| 场景 | 结果 |
|:--:|:--:|
| 打开新 Tab | 自动滚到底部（与之前一致） |
| Tab A 向上滚动 → 切到 Tab B → 切回 Tab A | 精确回到离开时的位置 |
| 切走时 Tab 在底部 | 切回时仍在底部 |
| HistoryPanel 预览（无 tabId） | 不做持久化（与之前一致） |

## 验证

- `npx tsc --noEmit` — 零错误
- `transcript-grouping.test.ts` — 8/8 通过
- `render-optimization.test.ts` — 16/16 通过
- `go test ./internal/cli/... -run TestResumeWhileScrolledUpPinsViewportToBottom` — 通过
- 代码审查通过，所有意见已处理