### PR TITLE
ci(desktop): gate stable Windows signing until the release cert is ready

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -173,10 +173,12 @@ jobs:
       # Authenticode-sign the Windows installer through SignPath. Runs BEFORE minisign:
       # the signature rewrites the installer's bytes, so the updater's minisign sig and
       # the manifest SHA must be computed over the signed build. SignPath pulls the file
-      # from the Actions artifact API, so it must be uploaded first. Canary signs with
-      # the test certificate; stable/rc use the Foundation release certificate.
+      # from the Actions artifact API, so it must be uploaded first. Canary signs with the
+      # test certificate; stable/rc sign with the Foundation release certificate, but only
+      # once SIGNPATH_RELEASE_SIGNING_READY is set — until that cert clears CSR-pending,
+      # stable ships unsigned instead of failing the whole release on an invalid policy.
       - name: Upload unsigned installer for SignPath
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (steps.ver.outputs.channel == 'canary' || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
         id: unsigned-installer
         uses: actions/upload-artifact@v7
         with:
@@ -186,7 +188,7 @@ jobs:
           retention-days: 1
 
       - name: Submit installer for Authenticode signing
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (steps.ver.outputs.channel == 'canary' || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -203,7 +205,7 @@ jobs:
           output-artifact-directory: signed
 
       - name: Replace installer with signed build
-        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true'
+        if: runner.os == 'Windows' && env.HAS_SIGNPATH == 'true' && (steps.ver.outputs.channel == 'canary' || vars.SIGNPATH_RELEASE_SIGNING_READY == 'true')
         run: cp signed/*installer*.exe dist/
 
       - name: Sign artifacts (minisign)


### PR DESCRIPTION
Protects the every-2-days stable release cadence while the SignPath release certificate is still `CSR PENDING`.

## Problem

After #4742, stable/rc tags route to the `release-signing` policy. That policy's certificate is still pending issuance, and `SIGNPATH_API_TOKEN` is now set — so cutting a `desktop-v*` tag today would submit to an invalid policy, fail the Windows build, and (via `needs: build`) block the **entire** release, macOS and Linux included.

## Fix

Gate the three Windows signing steps so they run only when `channel == canary` **or** the repo variable `SIGNPATH_RELEASE_SIGNING_READY == 'true'`.

- **Now** (variable unset): stable skips signing and ships unsigned, exactly like before SignPath was wired in — no release breakage. Canary still signs with the test certificate, so the validated path stays available.
- **When the release cert turns VALID**: set the repo Actions variable `SIGNPATH_RELEASE_SIGNING_READY` to `true`. The next stable tag signs with the real certificate. **No code change, no further PR — one variable flip.**

## Note

Until this merges, the instant stopgap is to remove the `SIGNPATH_API_TOKEN` secret (drops `HAS_SIGNPATH` to false, skipping all signing). Once this is in, the secret can stay set and the variable is the single switch.
