### PR TITLE
test(provider): cover tool-call name backfill; skip copy when unneeded

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -117,9 +117,8 @@ func SanitizeToolPairing(msgs []Message) []Message {
 			// never omitted, so this backfill is a UX improvement, not a
 			// correctness requirement.
 			calls := backfillToolCallNames(m.ToolCalls, msgs[i+1:j])
-			m2 := m
-			m2.ToolCalls = calls
-			out = append(out, repairToolCallArgs(m2))
+			m.ToolCalls = calls
+			out = append(out, repairToolCallArgs(m))
 			out = append(out, pairToolResults(calls, msgs[i+1:j])...)
 			i = j
 			continue
@@ -249,12 +248,23 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 	return out
 }
 
-// backfillToolCallNames returns a copy of calls with any empty Name filled in
-// from the matching tool result (by id, then by position). Old sessions (#4727)
-// may have saved assistant tool-calls with an empty name; backfilling gives the
-// model useful context during replay. Unpaired calls keep their empty name,
+// backfillToolCallNames returns calls with any empty Name filled in from the
+// matching tool result (by id, then by position). Old sessions (#4727) may have
+// saved assistant tool-calls with an empty name; backfilling gives the model
+// useful context during replay. The common case (no empty names) returns the
+// input unchanged without allocating. Unpaired calls keep their empty name,
 // which the wire-format fix (openai.go) handles gracefully.
 func backfillToolCallNames(calls []ToolCall, results []Message) []ToolCall {
+	missing := false
+	for _, c := range calls {
+		if c.Name == "" {
+			missing = true
+			break
+		}
+	}
+	if !missing {
+		return calls
+	}
 	out := make([]ToolCall, len(calls))
 	copy(out, calls)
 	if idDistinct(calls) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -126,6 +126,63 @@ func TestSanitizeToolPairingClosesTruncatedArgs(t *testing.T) {
 	}
 }
 
+func TestBackfillToolCallNamesByID(t *testing.T) {
+	calls := []ToolCall{{ID: "c1"}, {ID: "c2", Name: "grep"}}
+	results := []Message{
+		{Role: RoleTool, ToolCallID: "c2", Name: "grep"},
+		{Role: RoleTool, ToolCallID: "c1", Name: "ls"}, // returned out of call order
+	}
+	out := backfillToolCallNames(calls, results)
+	if out[0].Name != "ls" {
+		t.Fatalf("empty name not backfilled by id: got %q want ls", out[0].Name)
+	}
+	if out[1].Name != "grep" {
+		t.Fatalf("non-empty name clobbered: got %q want grep", out[1].Name)
+	}
+	if calls[0].Name != "" {
+		t.Fatalf("input slice mutated: %+v", calls)
+	}
+}
+
+func TestBackfillToolCallNamesPositional(t *testing.T) {
+	// Empty ids defeat idDistinct, so names pair by position instead.
+	calls := []ToolCall{{}, {}}
+	results := []Message{{Role: RoleTool, Name: "ls"}, {Role: RoleTool, Name: "cat"}}
+	out := backfillToolCallNames(calls, results)
+	if out[0].Name != "ls" || out[1].Name != "cat" {
+		t.Fatalf("positional backfill wrong: %+v", out)
+	}
+}
+
+func TestBackfillToolCallNamesUnpairedStaysEmpty(t *testing.T) {
+	out := backfillToolCallNames([]ToolCall{{ID: "c1"}}, nil)
+	if out[0].Name != "" {
+		t.Fatalf("unpaired call should keep its empty name, got %q", out[0].Name)
+	}
+}
+
+func TestBackfillToolCallNamesNoEmptyReturnsInput(t *testing.T) {
+	calls := []ToolCall{{ID: "c1", Name: "ls"}, {ID: "c2", Name: "grep"}}
+	out := backfillToolCallNames(calls, []Message{{Role: RoleTool, ToolCallID: "c1", Name: "x"}})
+	if &out[0] != &calls[0] {
+		t.Fatalf("no empty names: want the input slice back without copying")
+	}
+}
+
+func TestSanitizeToolPairingBackfillsEmptyName(t *testing.T) {
+	in := []Message{
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1"}}}, // old session: name lost
+		{Role: RoleTool, ToolCallID: "c1", Name: "ls", Content: "main.go"},
+	}
+	out := SanitizeToolPairing(in)
+	if out[0].ToolCalls[0].Name != "ls" {
+		t.Fatalf("empty tool-call name not backfilled on replay: %+v", out[0].ToolCalls)
+	}
+	if in[0].ToolCalls[0].Name != "" {
+		t.Fatalf("stored history mutated: %+v", in[0].ToolCalls)
+	}
+}
+
 // --- Pricing.Cost ---
 
 func TestPricingCostNil(t *testing.T) {


### PR DESCRIPTION
Follow-up to #4738.

- **Tests**: `backfillToolCallNames` id-keyed / positional / unpaired / no-empty-name fast path, plus the #4727 empty-name replay end-to-end through `SanitizeToolPairing` (with an input-not-mutated assertion).
- **Skip the copy when nothing is empty**: `backfillToolCallNames` now returns the input slice unchanged unless a name is actually empty, mirroring `repairToolCallArgs`' broken-check — `SanitizeToolPairing` runs over the full history on every request, so the healthy common case should not allocate.
- **Drop the redundant message copy** in `SanitizeToolPairing` now that backfill is copy-on-write.

No behavior change to the fix itself; pure test + hot-path tidy.