### PR TITLE
fix(plugin): bound CodeGraph daemon idle timeout

### DIFF
--- a/internal/plugin/known_overrides.go
+++ b/internal/plugin/known_overrides.go
@@ -2,14 +2,24 @@ package plugin
 
 import "strings"
 
+const (
+	codeGraphDaemonIdleTimeoutEnv = "CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS"
+	// Keep CodeGraph's shared daemon enabled, but do not leave it holding
+	// watchers for the upstream default 300s after the last MCP client exits.
+	codeGraphDaemonIdleTimeoutDefaultMS = "5000"
+)
+
 // ApplyKnownOverrides fills compatibility hints for known MCP servers. These
 // are runtime-only adjustments; they do not make a server built-in or change
 // startup behavior.
 func ApplyKnownOverrides(s Spec, workspaceRoot string) Spec {
 	if isCodeGraphSpecName(s.Name) {
 		s.ReadOnlyToolNames = mergeReadOnlyToolNames(s.ReadOnlyToolNames, codeGraphReadOnlyToolNames())
-		if s.Dir == "" && isStdioSpecType(s.Type) {
-			s.Dir = strings.TrimSpace(workspaceRoot)
+		if isStdioSpecType(s.Type) {
+			if s.Dir == "" {
+				s.Dir = strings.TrimSpace(workspaceRoot)
+			}
+			s.Env = mergeDefaultEnv(s.Env, codeGraphDaemonIdleTimeoutEnv, codeGraphDaemonIdleTimeoutDefaultMS)
 		}
 	}
 	return s
@@ -40,6 +50,17 @@ func mergeReadOnlyToolNames(existing map[string]bool, extra map[string]bool) map
 		if ok {
 			out[name] = true
 		}
+	}
+	return out
+}
+
+func mergeDefaultEnv(existing map[string]string, key, value string) map[string]string {
+	out := make(map[string]string, len(existing)+1)
+	for name, v := range existing {
+		out[name] = v
+	}
+	if _, ok := out[key]; !ok {
+		out[key] = value
 	}
 	return out
 }

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -117,6 +117,9 @@ func TestApplyKnownOverridesPinsCodeGraphStdioToWorkspace(t *testing.T) {
 	if !got.ReadOnlyToolNames["codegraph_search"] {
 		t.Fatalf("codegraph read-only override missing: %+v", got.ReadOnlyToolNames)
 	}
+	if got.Env[codeGraphDaemonIdleTimeoutEnv] != codeGraphDaemonIdleTimeoutDefaultMS {
+		t.Fatalf("codegraph daemon idle timeout env = %q, want %s; env=%v", got.Env[codeGraphDaemonIdleTimeoutEnv], codeGraphDaemonIdleTimeoutDefaultMS, got.Env)
+	}
 
 	preset := ApplyKnownOverrides(Spec{Name: "codegraph", Dir: "/custom"}, "/workspace")
 	if preset.Dir != "/custom" {
@@ -127,10 +130,27 @@ func TestApplyKnownOverridesPinsCodeGraphStdioToWorkspace(t *testing.T) {
 	if httpSpec.Dir != "" {
 		t.Fatalf("http codegraph should not receive stdio Dir, got %q", httpSpec.Dir)
 	}
+	if _, ok := httpSpec.Env[codeGraphDaemonIdleTimeoutEnv]; ok {
+		t.Fatalf("http codegraph should not receive daemon idle env, got %+v", httpSpec.Env)
+	}
 
 	other := ApplyKnownOverrides(Spec{Name: "other"}, "/workspace")
 	if other.Dir != "" {
 		t.Fatalf("non-codegraph should not receive Dir, got %q", other.Dir)
+	}
+	if _, ok := other.Env[codeGraphDaemonIdleTimeoutEnv]; ok {
+		t.Fatalf("non-codegraph should not receive daemon idle env, got %+v", other.Env)
+	}
+}
+
+func TestApplyKnownOverridesPreservesConfiguredCodeGraphDaemonIdleTimeout(t *testing.T) {
+	got := ApplyKnownOverrides(Spec{
+		Name: "codegraph",
+		Env:  map[string]string{codeGraphDaemonIdleTimeoutEnv: "30000"},
+	}, "/workspace")
+
+	if got.Env[codeGraphDaemonIdleTimeoutEnv] != "30000" {
+		t.Fatalf("configured codegraph daemon idle timeout was overwritten: %+v", got.Env)
 	}
 }
 


### PR DESCRIPTION
## Problem

Closing or disabling the CodeGraph MCP server in Reasonix only disconnects the stdio proxy. CodeGraph's shared daemon intentionally lingers after the last client disconnects, so users can still see the matching daemon process for about five minutes after the MCP row is turned off or Reasonix exits.

## Root Cause

Reasonix already treats `codegraph` as a known MCP server for read-only tool hints and workspace-root pinning, but it did not bound CodeGraph's detached daemon idle timeout. Because the shared daemon is deliberately detached from the MCP host, closing the stdio proxy leaves the daemon to its upstream default idle timeout.

## Fix

- Add a CodeGraph-specific stdio override for `CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS=5000`, preserving any user-supplied value.
- Keep CodeGraph's shared daemon mode enabled, so sessions can still reuse the daemon while it is active.
- Leave HTTP CodeGraph entries and non-CodeGraph MCP servers untouched.

Fixes #4731

## Verification

- `go test ./internal/plugin -run 'TestApplyKnown(Overrides|ReadOnly)' -count=1`
- `go test ./internal/boot -run 'TestPluginSpecs(TrustKnownCodeGraphReadTools|ForRootPinsCodeGraphToWorkspace|ForRootDoesNotPinHTTPCodeGraph|DoNotTrustCodeGraphToolsForOtherServers)' -count=1`
- `go test ./...`
- `cd desktop && go test ./...`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `gofmt -l internal/plugin/known_overrides.go internal/plugin/plugin_test.go`
- `git diff --check`
