### PR TITLE
fix(desktop): persist .mcp.json server edits

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4475,6 +4475,10 @@ func (a *App) desktopMCPServerForEdit(name string) (config.PluginEntry, bool, er
 }
 
 func (a *App) saveDesktopMCPServer(entry config.PluginEntry) error {
+	if a.desktopMCPServerOwnedByProjectMCPJSON(entry.Name) {
+		_, err := config.UpsertMCPJSONPlugin(projectMCPJSONPathForRoot(a.activeWorkspaceRoot()), entry)
+		return err
+	}
 	cfg, path, err := a.loadDesktopUserConfigForEdit()
 	if err != nil {
 		return err
@@ -4505,7 +4509,11 @@ func (a *App) removeDesktopMCPServer(name string) (bool, error) {
 	if err != nil {
 		return removed, err
 	}
-	return removed || projectRemoved, nil
+	mcpJSONRemoved, err := a.removeProjectMCPJSONServer(name)
+	if err != nil {
+		return removed || projectRemoved, err
+	}
+	return removed || projectRemoved || mcpJSONRemoved, nil
 }
 
 func (a *App) removeProjectMCPOverride(name string) (bool, error) {
@@ -4528,6 +4536,35 @@ func (a *App) removeProjectMCPOverride(name string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func (a *App) removeProjectMCPJSONServer(name string) (bool, error) {
+	return config.RemoveMCPJSONPlugin(projectMCPJSONPathForRoot(a.activeWorkspaceRoot()), name)
+}
+
+func (a *App) desktopMCPServerOwnedByProjectMCPJSON(name string) bool {
+	if strings.TrimSpace(name) == "" {
+		return false
+	}
+	cfg, _, err := a.loadDesktopUserConfigForEdit()
+	if err == nil {
+		if _, ok := findPluginEntry(cfg.Plugins, name); ok {
+			return false
+		}
+	}
+	projectCfg := config.LoadForEdit(projectConfigPathForRoot(a.activeWorkspaceRoot()))
+	if _, ok := findPluginEntry(projectCfg.Plugins, name); ok {
+		return false
+	}
+	_, ok, err := config.LoadMCPJSONPlugin(projectMCPJSONPathForRoot(a.activeWorkspaceRoot()), name)
+	return err == nil && ok
+}
+
+func projectMCPJSONPathForRoot(root string) string {
+	if strings.TrimSpace(root) == "" || root == "." {
+		return ".mcp.json"
+	}
+	return filepath.Join(root, ".mcp.json")
 }
 
 func findPluginEntry(entries []config.PluginEntry, name string) (config.PluginEntry, bool) {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2708,6 +2708,87 @@ args = ["serve"]
 	}
 }
 
+func TestRemoveMCPServerDeletesProjectMCPJSONEntry(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(`{
+  "mcpServers": {
+    "codegraph": { "command": "codegraph", "args": ["serve", "--mcp"] },
+    "keep": { "command": "keep-mcp" }
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{Host: plugin.NewHost()}), "")
+	defer app.activeCtrl().Close()
+
+	if err := app.RemoveMCPServer("codegraph"); err != nil {
+		t.Fatalf("RemoveMCPServer(.mcp.json codegraph): %v", err)
+	}
+	cfg, err := config.LoadForRoot(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := findPluginEntry(cfg.Plugins, "codegraph"); ok {
+		t.Fatalf("codegraph still merged after remove: %+v", cfg.Plugins)
+	}
+	if _, ok := findPluginEntry(cfg.Plugins, "keep"); !ok {
+		t.Fatalf("unrelated .mcp.json server should be preserved: %+v", cfg.Plugins)
+	}
+}
+
+func TestUpdateMCPServerEditsProjectMCPJSONEntry(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".mcp.json"), []byte(`{
+  "mcpServers": {
+    "codegraph": { "command": "codegraph", "args": ["serve", "--mcp"] }
+  }
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+	app.setTestCtrl(control.New(control.Options{Host: plugin.NewHost()}), "")
+	defer app.activeCtrl().Close()
+
+	if err := app.UpdateMCPServer("codegraph", MCPServerInput{
+		Name:      "codegraph",
+		Transport: "stdio",
+		Command:   "reasonix-missing-mcp-binary",
+		Args:      []string{"serve", "--mcp"},
+		Env:       map[string]string{"CODEGRAPH_LOG": "debug"},
+	}); err != nil {
+		t.Fatalf("UpdateMCPServer(.mcp.json codegraph): %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(dir, ".mcp.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		MCPServers map[string]struct {
+			Command string            `json:"command"`
+			Args    []string          `json:"args"`
+			Env     map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	got := doc.MCPServers["codegraph"]
+	if got.Command != "reasonix-missing-mcp-binary" || !reflect.DeepEqual(got.Args, []string{"serve", "--mcp"}) || got.Env["CODEGRAPH_LOG"] != "debug" {
+		t.Fatalf(".mcp.json codegraph = %+v, want updated command/args/env", got)
+	}
+	if _, ok := findPluginEntry(config.LoadForEdit(config.UserConfigPath()).Plugins, "codegraph"); ok {
+		t.Fatalf(".mcp.json update should not create a user config shadow entry")
+	}
+}
+
 func TestCapabilitiesMarksBackgroundRemoteMCPAuthPossible(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := robustTempDir(t)

--- a/internal/config/mcpjson.go
+++ b/internal/config/mcpjson.go
@@ -52,6 +52,20 @@ func loadMCPJSON(path string) ([]PluginEntry, error) {
 	return specsToEntries(doc.MCPServers, nil), nil
 }
 
+// LoadMCPJSONPlugin returns one server entry from a Claude-compatible .mcp.json.
+func LoadMCPJSONPlugin(path, name string) (PluginEntry, bool, error) {
+	entries, err := loadMCPJSON(path)
+	if err != nil {
+		return PluginEntry{}, false, err
+	}
+	for _, entry := range entries {
+		if entry.Name == name {
+			return entry, true, nil
+		}
+	}
+	return PluginEntry{}, false, nil
+}
+
 // specsToEntries converts an mcpServers map to PluginEntry values, sorted by name
 // for a stable connection order. Names in skip are dropped (used for v0.x's
 // mcpDisabled list).
@@ -200,6 +214,111 @@ func (c *Config) mergeMCPJSON(entries []PluginEntry) {
 	}
 }
 
+// UpsertMCPJSONPlugin writes one MCP server to a Claude-compatible .mcp.json
+// file, preserving unrelated top-level fields and unknown per-server fields.
+func UpsertMCPJSONPlugin(path string, entry PluginEntry) (bool, error) {
+	entry, _ = NormalizePluginCommandLine(entry)
+	if err := validatePlugin(entry); err != nil {
+		return false, err
+	}
+	root, servers, err := readMCPJSONRaw(path)
+	if err != nil {
+		return false, err
+	}
+	raw, existed := servers[entry.Name]
+	server := map[string]json.RawMessage{}
+	if existed && len(raw) > 0 {
+		if err := json.Unmarshal(raw, &server); err != nil || server == nil {
+			return false, fmt.Errorf("mcp config %s: server %q is not an object", path, entry.Name)
+		}
+	}
+	applyPluginEntryToMCPJSONServer(server, entry)
+	updatedRaw, err := json.Marshal(server)
+	if err != nil {
+		return false, fmt.Errorf("mcp config %s: server %q: %w", path, entry.Name, err)
+	}
+	servers[entry.Name] = updatedRaw
+	if err := writeMCPJSONServers(path, root, servers); err != nil {
+		return false, err
+	}
+	return !existed, nil
+}
+
+// RemoveMCPJSONPlugin removes one MCP server from a Claude-compatible .mcp.json
+// file. Missing files or missing entries are reported as unchanged.
+func RemoveMCPJSONPlugin(path, name string) (bool, error) {
+	root, servers, err := readMCPJSONRaw(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if _, ok := servers[name]; !ok {
+		return false, nil
+	}
+	delete(servers, name)
+	if err := writeMCPJSONServers(path, root, servers); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func readMCPJSONRaw(path string) (map[string]json.RawMessage, map[string]json.RawMessage, error) {
+	root := map[string]json.RawMessage{}
+	servers := map[string]json.RawMessage{}
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return root, servers, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("mcp config %s: %w", path, err)
+	}
+	if err := json.Unmarshal(b, &root); err != nil {
+		return nil, nil, fmt.Errorf("mcp config %s: %w", path, err)
+	}
+	raw, ok := root["mcpServers"]
+	if !ok || len(raw) == 0 || string(raw) == "null" {
+		return root, servers, nil
+	}
+	if err := json.Unmarshal(raw, &servers); err != nil || servers == nil {
+		return nil, nil, fmt.Errorf("mcp config %s: mcpServers must be an object", path)
+	}
+	return root, servers, nil
+}
+
+func applyPluginEntryToMCPJSONServer(server map[string]json.RawMessage, entry PluginEntry) {
+	transport := strings.ToLower(strings.TrimSpace(entry.Type))
+	if transport == "" {
+		transport = "stdio"
+	}
+	if transport == "stdio" {
+		delete(server, "type")
+		setMCPJSONString(server, "command", strings.TrimSpace(entry.Command))
+		setMCPJSONStringArray(server, "args", entry.Args)
+		setMCPJSONStringMap(server, "env", entry.Env)
+		delete(server, "url")
+		delete(server, "headers")
+	} else {
+		setMCPJSONString(server, "type", transport)
+		setMCPJSONString(server, "url", strings.TrimSpace(entry.URL))
+		setMCPJSONStringMap(server, "headers", entry.Headers)
+		setMCPJSONStringMap(server, "env", entry.Env)
+		delete(server, "command")
+		delete(server, "args")
+	}
+	setMCPJSONBool(server, "auto_start", entry.AutoStart)
+}
+
+func writeMCPJSONServers(path string, root map[string]json.RawMessage, servers map[string]json.RawMessage) error {
+	serversRaw, err := json.Marshal(servers)
+	if err != nil {
+		return fmt.Errorf("mcp config %s: %w", path, err)
+	}
+	root["mcpServers"] = serversRaw
+	return writeMCPJSON(path, root)
+}
+
 func clearMCPJSONAuthentication(path, name string) (PluginEntry, bool, error) {
 	b, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
@@ -274,6 +393,32 @@ func setMCPJSONString(server map[string]json.RawMessage, key, value string) {
 		return
 	}
 	raw, err := json.Marshal(value)
+	if err != nil {
+		delete(server, key)
+		return
+	}
+	server[key] = raw
+}
+
+func setMCPJSONStringArray(server map[string]json.RawMessage, key string, values []string) {
+	if len(values) == 0 {
+		delete(server, key)
+		return
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		delete(server, key)
+		return
+	}
+	server[key] = raw
+}
+
+func setMCPJSONBool(server map[string]json.RawMessage, key string, value *bool) {
+	if value == nil {
+		delete(server, key)
+		return
+	}
+	raw, err := json.Marshal(*value)
 	if err != nil {
 		delete(server, key)
 		return


### PR DESCRIPTION
## Problem

Desktop MCP servers loaded from a project `.mcp.json` appeared editable/removable in Settings, but delete only touched the user config and project `reasonix.toml`. A `.mcp.json` entry such as `codegraph` could therefore reappear after refresh/restart, which made the UI look like the remove action did not work.

Fixes #4751.

## Root Cause

`LoadForRoot()` merges user TOML, project TOML, and project `.mcp.json` into one `Config`. The desktop Settings mutation path edited that merged view as if every server had a TOML owner. `.mcp.json`-only servers had no TOML entry to remove, and edits created a user-level shadow entry instead of updating the real source file.

## Fix

- Add source-safe `.mcp.json` helpers for reading, upserting, and removing one MCP server while preserving unrelated JSON fields.
- Route desktop edits for `.mcp.json`-owned MCP servers back to the project `.mcp.json` file.
- Remove MCP servers from all desktop-managed sources, including `.mcp.json`, so deleting a shadowed server cannot reveal the underlying project entry again.
- Add regression coverage for deleting and editing project `.mcp.json` MCP servers.

## Verification

- `go test ./...`
- `cd desktop && go test ./...`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `gofmt -l desktop/app.go desktop/app_test.go internal/config/mcpjson.go`
- `git diff --check`
- `cd desktop/frontend && corepack pnpm run test:all`
- `cd desktop/frontend && corepack pnpm run build`
- `cd desktop && go test . -run 'Test(RemoveMCPServerDeletesProjectMCPJSONEntry|UpdateMCPServerEditsProjectMCPJSONEntry)' -count=1`
- `cd desktop && go test . -run 'Test.*MCP' -count=1`
- `go test ./internal/config -run 'Test(LoadMCPJSON|LoadMergesMCPJSON|MergeMCPJSONPrecedence|ClearPluginAuthenticationInSourceUsesMCPJSON)' -count=1`
