### PR TITLE
feat(control): add external edit bridge for host-side synthetic tool events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,7 @@ Thumbs.db
 .vscode/
 /site/public/av/
 
+# Stray generated files
+null
+
 benchmarks/context-maintenance-e2e/run/

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,6 @@ Thumbs.db
 /site/public/av/
 
 # Stray generated files
-null
+/null
 
 benchmarks/context-maintenance-e2e/run/

--- a/desktop/external_edit_bridge.go
+++ b/desktop/external_edit_bridge.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"reasonix/internal/control"
+)
+
+var externalEditBridgeSeq atomic.Uint64
+
+var externalEditBridgeStore = struct {
+	mu    sync.Mutex
+	items map[string]*control.ExternalEdit
+}{items: map[string]*control.ExternalEdit{}}
+
+type externalEditBridge struct {
+	edit *control.ExternalEdit
+}
+
+// BeginExternalEditForTab starts a host-side edit bridge and returns an opaque
+// handle for EndExternalEdit. It is exported so Wails or another host shim can
+// wrap external patch runners without exposing function-valued bindings.
+func (a *App) BeginExternalEditForTab(tabID, label string, paths []string) (string, error) {
+	bridge, err := a.beginExternalEditForTab(tabID, label, paths)
+	if err != nil {
+		return "", err
+	}
+	id := fmt.Sprintf("external-edit-%d", externalEditBridgeSeq.Add(1))
+	externalEditBridgeStore.mu.Lock()
+	externalEditBridgeStore.items[id] = bridge.edit
+	externalEditBridgeStore.mu.Unlock()
+	return id, nil
+}
+
+// EndExternalEdit finishes a handle returned by BeginExternalEditForTab.
+// errMessage is empty on success; non-empty marks the synthetic tool result as
+// failed and avoids recording a checkpoint for any partial writes.
+func (a *App) EndExternalEdit(id, errMessage string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return fmt.Errorf("external edit id is required")
+	}
+	externalEditBridgeStore.mu.Lock()
+	edit := externalEditBridgeStore.items[id]
+	delete(externalEditBridgeStore.items, id)
+	externalEditBridgeStore.mu.Unlock()
+	if edit == nil {
+		return fmt.Errorf("external edit %q not found", id)
+	}
+	var err error
+	if msg := strings.TrimSpace(errMessage); msg != "" {
+		err = errors.New(msg)
+	}
+	return edit.End(err)
+}
+
+func (a *App) beginExternalEditForTab(tabID, label string, paths []string) (*externalEditBridge, error) {
+	if a.tabReadOnly(tabID) {
+		return nil, fmt.Errorf("tab is read-only")
+	}
+	ctrl := a.ctrlByTabID(tabID)
+	if ctrl == nil {
+		return nil, fmt.Errorf("tab %q not found", strings.TrimSpace(tabID))
+	}
+	edit := ctrl.BeginExternalEdit(label, paths)
+	if err := edit.BeginErr(); err != nil {
+		return nil, fmt.Errorf("cannot start external edit: %w", err)
+	}
+	return &externalEditBridge{edit: edit}, nil
+}
+
+func (b *externalEditBridge) End(err error) error {
+	if b == nil || b.edit == nil {
+		return err
+	}
+	return b.edit.End(err)
+}
+
+func (a *App) runExternalEditForTab(tabID, label string, paths []string, fn func(context.Context) error) error {
+	if a.tabReadOnly(tabID) {
+		return fmt.Errorf("tab is read-only")
+	}
+	ctrl := a.ctrlByTabID(tabID)
+	if ctrl == nil {
+		return fmt.Errorf("tab %q not found", strings.TrimSpace(tabID))
+	}
+	return ctrl.RunExternalEdit(context.Background(), label, paths, fn)
+}

--- a/desktop/external_edit_bridge_test.go
+++ b/desktop/external_edit_bridge_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/control"
+	"reasonix/internal/event"
+)
+
+func TestExternalEditBridgeUsesRequestedTab(t *testing.T) {
+	workspace := t.TempDir()
+	sessionDir := t.TempDir()
+	file := filepath.Join(workspace, "b.txt")
+	if err := os.WriteFile(file, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	execA := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	execB := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	ctrlA := control.New(control.Options{Executor: execA, SessionDir: sessionDir, SessionPath: filepath.Join(sessionDir, "a.jsonl"), WorkspaceRoot: workspace})
+	ctrlB := control.New(control.Options{Executor: execB, SessionDir: sessionDir, SessionPath: filepath.Join(sessionDir, "b.jsonl"), WorkspaceRoot: workspace})
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"a": {ID: "a", Scope: "project", WorkspaceRoot: workspace, Ctrl: ctrlA, Ready: true},
+			"b": {ID: "b", Scope: "project", WorkspaceRoot: workspace, Ctrl: ctrlB, Ready: true},
+		},
+		activeTabID: "a",
+	}
+
+	err := app.runExternalEditForTab("b", "apply_patch", []string{"b.txt"}, func(context.Context) error {
+		return os.WriteFile(file, []byte("after\n"), 0o644)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := len(ctrlA.History()); got != 1 {
+		t.Fatalf("active tab history changed: got %d messages, want only system", got)
+	}
+	if got := len(ctrlB.History()); got < 3 {
+		t.Fatalf("requested tab history messages = %d, want synthetic tool pair", got)
+	}
+	cps := ctrlB.Checkpoints()
+	if len(cps) != 1 || len(cps[0].Paths) != 1 || cps[0].Paths[0] != "b.txt" {
+		t.Fatalf("requested tab checkpoints = %+v, want b.txt", cps)
+	}
+}
+
+func TestExternalEditBridgeExportedHandleAPI(t *testing.T) {
+	workspace := t.TempDir()
+	sessionDir := t.TempDir()
+	file := filepath.Join(workspace, "a.txt")
+	if err := os.WriteFile(file, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	ctrl := control.New(control.Options{Executor: exec, SessionDir: sessionDir, SessionPath: filepath.Join(sessionDir, "a.jsonl"), WorkspaceRoot: workspace})
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"a": {ID: "a", Scope: "project", WorkspaceRoot: workspace, Ctrl: ctrl, Ready: true},
+		},
+		activeTabID: "a",
+	}
+
+	id, err := app.BeginExternalEditForTab("a", "apply_patch", []string{"a.txt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, []byte("after\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := app.EndExternalEdit(id, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(ctrl.History()); got < 3 {
+		t.Fatalf("history messages = %d, want synthetic tool pair", got)
+	}
+	changes := app.WorkspaceChanges("a")
+	if len(changes.Files) != 1 || changes.Files[0].Path != "a.txt" || !containsString(changes.Files[0].Sources, "session") {
+		t.Fatalf("workspace changes = %+v, want a.txt session source", changes.Files)
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2998,7 +2998,7 @@ export default function App() {
                   onPreviewModeChange={handleWorkspacePreviewModeChange}
                   onAddToChat={addWorkspaceTextToComposer}
                   onRequestPanelWidth={ensureWorkspacePanelWidth}
-                  refreshKey={dockRefreshKey}
+                  refreshKey={`${dockRefreshKey}:${state.checkpoints.length}`}
                   initialViewMode={rightDockMode === "changed" ? "changed" : "files"}
                   showViewTabs={false}
                 />

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -122,6 +122,8 @@ export interface AppBindings {
   SubmitDisplayToTab(tabID: string, display: string, input: string): Promise<void>;
   RunShell(command: string): Promise<void>;
   RunShellForTab(tabID: string, command: string): Promise<void>;
+  BeginExternalEditForTab(tabID: string, label: string, paths: string[]): Promise<string>;
+  EndExternalEdit(id: string, errMessage: string): Promise<void>;
   Steer(text: string): Promise<void>;
   SteerForTab(tabID: string, text: string): Promise<void>;
   Cancel(): Promise<void>;
@@ -1572,6 +1574,10 @@ function makeMockApp(): AppBindings {
         async RunShellForTab(_tabID, command) {
           await withMockTabScope(_tabID, () => this.RunShell(command));
         },
+        async BeginExternalEditForTab(_tabID, _label, _paths) {
+          return "mock-external-edit";
+        },
+        async EndExternalEdit(_id, _errMessage) {},
         async Steer(_text) {
           // Mock: emit a steer event as confirmation in the transcript.
           emit({ kind: "steer", text: _text });

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -883,6 +883,9 @@ export function useController() {
         app.EffortForTab(targetTabId).then((effort) => dispatchTo(targetTabId, { type: "effort", effort })).catch(() => {});
         void refreshCheckpoints(targetTabId);
       }
+      if (e.kind === "tool_result" && e.tool && (e.tool.diff || (e.tool.added ?? 0) > 0 || (e.tool.removed ?? 0) > 0)) {
+        void refreshCheckpoints(targetTabId);
+      }
       if (e.kind === "turn_done" || e.kind === "notice") {
         app.JobsForTab(targetTabId).then((jobs) => dispatchTo(targetTabId, { type: "jobs", jobs: asArray(jobs) })).catch(() => {});
       }

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -153,6 +153,20 @@ func (s *Store) Snapshot(ch diff.Change) {
 	s.persist(s.cur)
 }
 
+// Finish finalizes the current checkpoint so its touched paths are visible to
+// metadata consumers immediately. Agent turns usually finalize when the next
+// turn begins; host-side edits call this after their synthetic tool result.
+func (s *Store) Finish() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cur == nil {
+		return
+	}
+	s.done = append(s.done, s.cur)
+	s.cur = nil
+	s.seen = map[string]bool{}
+}
+
 func (s *Store) detectEncoding(p string) *fileenc.Kind {
 	abs, err := safePath(s.root, p)
 	if err != nil {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -237,6 +237,7 @@ type RuntimeStatus struct {
 	BackgroundJobs  int
 	CancelRequested bool
 	Cancellable     bool
+	ExternalEditOpen bool
 }
 
 const (
@@ -1587,14 +1588,16 @@ func (c *Controller) RuntimeStatus() RuntimeStatus {
 	running := c.running
 	pending := len(c.approvals) > 0 || len(c.asks) > 0
 	canceling := c.canceling
+	externalEditOpen := c.externalEditOpen
 	c.mu.Unlock()
 	backgroundJobs := len(c.Jobs())
 	return RuntimeStatus{
-		Running:         running,
-		PendingPrompt:   pending,
-		BackgroundJobs:  backgroundJobs,
-		CancelRequested: canceling,
-		Cancellable:     running || pending,
+		Running:          running,
+		PendingPrompt:    pending,
+		BackgroundJobs:   backgroundJobs,
+		CancelRequested:  canceling,
+		Cancellable:      running || pending,
+		ExternalEditOpen: externalEditOpen,
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -133,6 +133,7 @@ type Controller struct {
 	mu               sync.Mutex
 	cancel           context.CancelFunc
 	running          bool
+	externalEditOpen bool
 	canceling        bool
 	autosaveWG       sync.WaitGroup
 	planMode         bool
@@ -167,6 +168,14 @@ type Controller struct {
 	asks          map[string]pendingAsk
 	granted       map[string]bool
 	nextID        int
+	goalTurns        int
+	goalBlocks       int
+	goalBlock        string
+	sessionPath      string
+	approvals        map[string]pendingApproval
+	asks             map[string]pendingAsk
+	granted          map[string]bool
+	nextID           int
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
 	// approvedPlanAutoApproveTools auto-allows writer tool calls without prompting.
@@ -480,7 +489,7 @@ func (c *Controller) beginCheckpoint(input string) {
 // turn is already in flight.
 func (c *Controller) runGuarded(body func(ctx context.Context) error) {
 	c.mu.Lock()
-	if c.running {
+	if c.running || c.externalEditOpen {
 		c.mu.Unlock()
 		return
 	}
@@ -561,7 +570,7 @@ func (c *Controller) runTurn(ctx context.Context, input string) error {
 func (c *Controller) RunTurn(ctx context.Context, input string) error {
 	ctx, cancel := context.WithCancel(ctx)
 	c.mu.Lock()
-	if c.running {
+	if c.running || c.externalEditOpen {
 		c.mu.Unlock()
 		cancel()
 		return ErrTurnRunning

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -168,14 +168,6 @@ type Controller struct {
 	asks          map[string]pendingAsk
 	granted       map[string]bool
 	nextID        int
-	goalTurns        int
-	goalBlocks       int
-	goalBlock        string
-	sessionPath      string
-	approvals        map[string]pendingApproval
-	asks             map[string]pendingAsk
-	granted          map[string]bool
-	nextID           int
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
 	// approvedPlanAutoApproveTools auto-allows writer tool calls without prompting.

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,8 +3,10 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
@@ -42,7 +44,21 @@ type appendingRunner struct {
 	session *agent.Session
 }
 
-func (r appendingRunner) Run(_ context.Context, input string) error {
+func (r *appendingRunner) Name() string        { return "append" }
+func (r *appendingRunner) Description() string { return "append input to session" }
+func (r *appendingRunner) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"input":{"type":"string"}},"required":["input"]}`)
+}
+func (r *appendingRunner) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	var params struct{ Input string }
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", err
+	}
+	r.session.Add(provider.Message{Role: provider.RoleUser, Content: params.Input})
+	return "appended", nil
+}
+func (r *appendingRunner) ReadOnly() bool { return true }
+func (r *appendingRunner) Run(_ context.Context, input string) error {
 	r.session.Add(provider.Message{Role: provider.RoleUser, Content: input})
 	return nil
 }
@@ -240,7 +256,7 @@ func TestRunTurnSnapshotsActivityWhenTranscriptChanges(t *testing.T) {
 	sess := agent.NewSession("sys")
 	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
 	path := filepath.Join(dir, "session.jsonl")
-	c := New(Options{Runner: appendingRunner{session: sess}, Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	c := New(Options{Runner: &appendingRunner{session: sess}, Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
 
 	if err := c.runTurn(context.Background(), "hello"); err != nil {
 		t.Fatal(err)
@@ -1166,7 +1182,7 @@ func TestRunGuardedPanicEmitsTurnDone(t *testing.T) {
 	sess := agent.NewSession("sys")
 	events := make(chan event.Event, 4)
 	c := New(Options{
-		Runner: appendingRunner{session: sess},
+		Runner: &appendingRunner{session: sess},
 		Sink:   event.FuncSink(func(e event.Event) { events <- e }),
 	})
 
@@ -1201,7 +1217,7 @@ func TestRunGuardedPanicDoesNotDoubleEmitTurnDone(t *testing.T) {
 	var count int32
 	events := make(chan event.Event, 8)
 	c := New(Options{
-		Runner: appendingRunner{session: sess},
+		Runner: &appendingRunner{session: sess},
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.TurnDone {
 				atomic.AddInt32(&count, 1)
@@ -1396,4 +1412,235 @@ func TestApprovedPlanDoesNotAutoApproveNonContinuationTurn(t *testing.T) {
 	if approvalPrompts != 2 {
 		t.Fatalf("non-continuation writer should prompt after plan approval, prompts=%d", approvalPrompts)
 	}
+}
+
+func TestRunExternalEditEmitsDiffAndPersistsHistory(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "session.jsonl")
+	file := filepath.Join(root, "a.go")
+	if err := os.WriteFile(file, []byte("package a\n\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	var events []event.Event
+	c := New(Options{
+		Executor:      exec,
+		Sink:          event.FuncSink(func(e event.Event) { events = append(events, e) }),
+		SessionDir:    root,
+		SessionPath:   path,
+		WorkspaceRoot: root,
+	})
+
+	err := c.RunExternalEdit(context.Background(), "apply_patch", []string{"a.go"}, func(context.Context) error {
+		return os.WriteFile(file, []byte("package a\n\nfunc A() int { return 1 }\n"), 0o644)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dispatch, result := findToolEvents(events, "apply_patch")
+	if dispatch == nil {
+		t.Fatal("missing synthetic ToolDispatch")
+	}
+	if dispatch.Tool.ReadOnly {
+		t.Fatal("external edit should be a writer tool event")
+	}
+	if dispatch.Tool.Added == 0 || dispatch.Tool.Removed == 0 || !strings.Contains(dispatch.Tool.Diff, "func A() int") {
+		t.Fatalf("dispatch diff = added %d removed %d diff:\n%s", dispatch.Tool.Added, dispatch.Tool.Removed, dispatch.Tool.Diff)
+	}
+	if result == nil || result.Tool.Err != "" || !strings.Contains(result.Tool.Output, "1 files changed") {
+		t.Fatalf("bad synthetic ToolResult: %+v", result)
+	}
+
+	msgs := c.History()
+	if len(msgs) < 3 {
+		t.Fatalf("history messages = %d, want system + synthetic tool pair", len(msgs))
+	}
+	call := msgs[len(msgs)-2].ToolCalls[0]
+	if call.Name != "apply_patch" || call.Diff == "" || call.Added == 0 || call.Removed == 0 {
+		t.Fatalf("history tool call missing diff metadata: %+v", call)
+	}
+	if got := c.ToolResult(call.ID); got == nil || !strings.Contains(got.Output, "applied apply_patch") {
+		t.Fatalf("ToolResult lookup = %+v", got)
+	}
+	checkpoints := c.Checkpoints()
+	if len(checkpoints) != 1 || len(checkpoints[0].Paths) != 1 || checkpoints[0].Paths[0] != "a.go" {
+		t.Fatalf("external edit checkpoint paths = %+v, want a.go", checkpoints)
+	}
+	if _, err := agent.LoadSession(path); err != nil {
+		t.Fatalf("synthetic external edit history was not saved: %v", err)
+	}
+}
+
+func TestRunExternalEditDiffIsScopedToSnapshot(t *testing.T) {
+	root := t.TempDir()
+	oldDirty := filepath.Join(root, "old.txt")
+	touched := filepath.Join(root, "new.txt")
+	if err := os.WriteFile(oldDirty, []byte("preexisting dirty content\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(touched, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	var events []event.Event
+	c := New(Options{
+		Executor:      exec,
+		Sink:          event.FuncSink(func(e event.Event) { events = append(events, e) }),
+		WorkspaceRoot: root,
+	})
+
+	err := c.RunExternalEdit(context.Background(), "apply_patch", []string{"new.txt"}, func(context.Context) error {
+		return os.WriteFile(touched, []byte("after\n"), 0o644)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dispatch, _ := findToolEvents(events, "apply_patch")
+	if dispatch == nil {
+		t.Fatal("missing synthetic ToolDispatch")
+	}
+	if strings.Contains(dispatch.Tool.Args, "old.txt") || strings.Contains(dispatch.Tool.Diff, "preexisting dirty content") {
+		t.Fatalf("external diff leaked old dirty file: args=%s diff=\n%s", dispatch.Tool.Args, dispatch.Tool.Diff)
+	}
+	if !strings.Contains(dispatch.Tool.Args, "new.txt") || !strings.Contains(dispatch.Tool.Diff, "after") {
+		t.Fatalf("external diff missed touched file: args=%s diff=\n%s", dispatch.Tool.Args, dispatch.Tool.Diff)
+	}
+}
+
+func TestRunExternalEditFailureDoesNotExposeDiff(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "a.txt")
+	if err := os.WriteFile(file, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	exec := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	var events []event.Event
+	c := New(Options{
+		Executor:      exec,
+		Sink:          event.FuncSink(func(e event.Event) { events = append(events, e) }),
+		WorkspaceRoot: root,
+	})
+	wantErr := errors.New("patch rejected")
+	err := c.RunExternalEdit(context.Background(), "apply_patch", []string{"a.txt"}, func(context.Context) error {
+		if werr := os.WriteFile(file, []byte("partial\n"), 0o644); werr != nil {
+			return werr
+		}
+		return wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RunExternalEdit err = %v, want %v", err, wantErr)
+	}
+
+	dispatch, result := findToolEvents(events, "apply_patch")
+	if dispatch == nil || result == nil {
+		t.Fatalf("missing synthetic events: dispatch=%v result=%v", dispatch, result)
+	}
+	if dispatch.Tool.Diff != "" || dispatch.Tool.Added != 0 || dispatch.Tool.Removed != 0 {
+		t.Fatalf("failed external edit should not show diff: %+v", dispatch.Tool.FileDiff)
+	}
+	if result.Tool.Err == "" {
+		t.Fatal("failed external edit should emit ToolResult error")
+	}
+	if got := c.Checkpoints(); len(got) != 0 {
+		t.Fatalf("failed external edit should not create checkpoints, got %+v", got)
+	}
+}
+
+func TestRunExternalEditFallsBackToGitStatusWhenPathsUnknown(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	root := t.TempDir()
+	runGitIn(t, root, "init")
+	runGitIn(t, root, "config", "user.email", "test@example.com")
+	runGitIn(t, root, "config", "user.name", "Test")
+	if err := os.WriteFile(filepath.Join(root, "tracked.txt"), []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGitIn(t, root, "add", "tracked.txt")
+	runGitIn(t, root, "commit", "-m", "init")
+
+	execAgent := agent.New(nil, nil, agent.NewSession("sys"), agent.Options{}, event.Discard)
+	var events []event.Event
+	c := New(Options{
+		Executor:      execAgent,
+		Sink:          event.FuncSink(func(e event.Event) { events = append(events, e) }),
+		WorkspaceRoot: root,
+	})
+
+	err := c.RunExternalEdit(context.Background(), "apply_patch", nil, func(context.Context) error {
+		return os.WriteFile(filepath.Join(root, "tracked.txt"), []byte("new\n"), 0o644)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	dispatch, _ := findToolEvents(events, "apply_patch")
+	if dispatch == nil {
+		t.Fatal("missing synthetic ToolDispatch")
+	}
+	if !strings.Contains(dispatch.Tool.Args, "tracked.txt") || !strings.Contains(dispatch.Tool.Diff, "-old") || !strings.Contains(dispatch.Tool.Diff, "+new") {
+		t.Fatalf("git fallback diff = args=%s diff=\n%s", dispatch.Tool.Args, dispatch.Tool.Diff)
+	}
+}
+
+func TestExternalEditBlocksForegroundTurnUntilEnd(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "a.txt")
+	if err := os.WriteFile(file, []byte("before\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sess := agent.NewSession("sys")
+	tools := tool.NewRegistry()
+	tools.Add(&appendingRunner{session: sess})
+	execAgent := agent.New(nil, tools, sess, agent.Options{}, event.Discard)
+	c := New(Options{
+		Executor:      execAgent,
+		Runner:        &appendingRunner{session: sess},
+		WorkspaceRoot: root,
+	})
+
+	edit := c.BeginExternalEdit("apply_patch", []string{"a.txt"})
+	if err := edit.BeginErr(); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RunTurn(context.Background(), "normal turn"); !errors.Is(err, ErrTurnRunning) {
+		t.Fatalf("RunTurn during external edit err = %v, want ErrTurnRunning", err)
+	}
+	if err := os.WriteFile(file, []byte("after\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := edit.End(nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.RunTurn(context.Background(), "normal turn"); err != nil {
+		t.Fatalf("RunTurn after external edit = %v", err)
+	}
+}
+
+func runGitIn(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func findToolEvents(events []event.Event, name string) (*event.Event, *event.Event) {
+	var dispatch, result *event.Event
+	for i := range events {
+		if events[i].Tool.Name != name {
+			continue
+		}
+		switch events[i].Kind {
+		case event.ToolDispatch:
+			dispatch = &events[i]
+		case event.ToolResult:
+			result = &events[i]
+		}
+	}
+	return dispatch, result
 }

--- a/internal/control/external_edit.go
+++ b/internal/control/external_edit.go
@@ -1,0 +1,453 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"reasonix/internal/diff"
+	"reasonix/internal/event"
+	"reasonix/internal/proc"
+	"reasonix/internal/provider"
+)
+
+var externalEditSeq atomic.Uint64
+
+// ExternalEdit holds the pre-edit snapshot for a host-side writer. Call End
+// after the external process has returned to emit synthetic tool events and
+// persist replayable history. At most one of End or Cancel completes; the
+// second call is a no-op.
+type ExternalEdit struct {
+	controller  *Controller
+	label       string
+	start       time.Time
+	before      map[string]externalEditSnapshot
+	snapErr     error
+	gitFallback bool
+	beginErr    error
+
+	// ended serialises End/Cancel so only one call completes.
+	ended atomic.Bool
+}
+
+// RunExternalEdit wraps a host-side writer (for example Codex apply_patch) in
+// the same tool event and history contract as model-issued writer tools.
+func (c *Controller) RunExternalEdit(ctx context.Context, label string, paths []string, fn func(context.Context) error) error {
+	if fn == nil {
+		return fmt.Errorf("external edit %q has no runner", label)
+	}
+	edit := c.BeginExternalEdit(label, paths)
+	if err := edit.BeginErr(); err != nil {
+		return err
+	}
+	runErr := fn(ctx)
+	return edit.End(runErr)
+}
+
+// CanStartExternalEdit reports whether a host-side edit may append synthetic
+// tool messages without interleaving with a foreground model turn.
+func (c *Controller) CanStartExternalEdit() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return !c.running && !c.externalEditOpen
+}
+
+// BeginExternalEdit records the pre-edit content of the supplied paths. The
+// caller should pass the file list from the patch parser when available; an empty
+// list falls back to git status, which covers tracked/untracked git-visible files.
+func (c *Controller) BeginExternalEdit(label string, paths []string) *ExternalEdit {
+	label = strings.TrimSpace(label)
+	if label == "" {
+		label = "external_edit"
+	}
+	c.mu.Lock()
+	if c.running || c.externalEditOpen {
+		c.mu.Unlock()
+		return &ExternalEdit{controller: c, label: label, start: time.Now(), beginErr: ErrTurnRunning}
+	}
+	c.externalEditOpen = true
+	c.mu.Unlock()
+	touched := c.cleanExternalEditPaths(paths)
+	gitFallback := len(touched) == 0
+	if gitFallback {
+		touched, _ = externalEditGitStatusPaths(c.cpRoot)
+	}
+	before, snapErr := snapshotExternalEditFiles(c.cpRoot, touched)
+	return &ExternalEdit{
+		controller:  c,
+		label:       label,
+		start:       time.Now(),
+		before:      before,
+		snapErr:     snapErr,
+		gitFallback: gitFallback,
+	}
+}
+
+// BeginErr reports why the external edit could not acquire the controller
+// lifecycle slot. A non-nil error means the caller must not perform the write.
+func (e *ExternalEdit) BeginErr() error {
+	if e == nil {
+		return nil
+	}
+	return e.beginErr
+}
+
+// Cancel releases the controller lifecycle slot without emitting synthetic
+// events or persisting history. Use when the external process is abandoned
+// before completion (e.g. the caller crashes or the user cancels). At most
+// one of Cancel or End completes; subsequent calls are no-ops.
+func (e *ExternalEdit) Cancel() {
+	if e == nil || e.controller == nil || !e.ended.CompareAndSwap(false, true) {
+		return
+	}
+	e.controller.mu.Lock()
+	e.controller.externalEditOpen = false
+	e.controller.mu.Unlock()
+}
+
+// End emits the synthetic ToolDispatch/ToolResult pair and persists the
+// corresponding provider tool-call messages for history/replay. At most one
+// of End or Cancel completes; a second call is a no-op returning nil.
+func (e *ExternalEdit) End(runErr error) error {
+	if e == nil || e.controller == nil {
+		return runErr
+	}
+	if e.beginErr != nil {
+		if runErr != nil {
+			return runErr
+		}
+		return e.beginErr
+	}
+	if !e.ended.CompareAndSwap(false, true) {
+		return nil // already completed
+	}
+	c := e.controller
+	defer func() {
+		c.mu.Lock()
+		c.externalEditOpen = false
+		c.mu.Unlock()
+	}()
+	if e.gitFallback {
+		augmentExternalEditGitFallback(c.cpRoot, e.before)
+	}
+	changes, diffErr := diffExternalEditFiles(c.cpRoot, e.before)
+	fileDiff := combineExternalEditDiffs(changes)
+	args := externalEditArgs(changes)
+	id := fmt.Sprintf("external-patch-%d", externalEditSeq.Add(1))
+	toolEvent := event.Tool{
+		ID:         id,
+		Name:       e.label,
+		Args:       args,
+		ReadOnly:   false,
+		DurationMs: time.Since(e.start).Milliseconds(),
+	}
+	output := externalEditOutput(e.label, changes, e.snapErr, diffErr)
+	if runErr != nil {
+		toolEvent.Err = fmt.Sprintf("%s failed: %v", e.label, runErr)
+	} else {
+		toolEvent.Output = output
+		toolEvent.FileDiff = fileDiff
+	}
+
+	persistChanges := changes
+	if runErr != nil {
+		persistChanges = nil
+	}
+	// Append messages to in-memory session and write checkpoint files to
+	// disk, but do NOT finalize the checkpoint yet — that happens after
+	// the session file is safely persisted.
+	c.persistExternalEdit(id, e.label, args, output, toolEvent.Err, toolEvent.FileDiff, persistChanges)
+
+	// Save the session file to disk before finalizing the checkpoint so the
+	// on-disk session always has at least as many messages as the checkpoint
+	// MsgIndex references.
+	if err := c.SnapshotActivity(); runErr == nil && err != nil {
+		return err
+	}
+
+	// Finalize checkpoint visibility now that the session is safely on disk.
+	if c.cp != nil && len(persistChanges) > 0 {
+		c.cp.Finish()
+	}
+
+	c.sink.Emit(event.Event{Kind: event.ToolDispatch, Tool: toolEvent})
+	c.sink.Emit(event.Event{Kind: event.ToolResult, Tool: toolEvent})
+
+	return runErr
+}
+
+type externalEditSnapshot struct {
+	path   string
+	exists bool
+	text   string
+}
+
+func (c *Controller) cleanExternalEditPaths(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	seen := map[string]bool{}
+	for _, p := range paths {
+		rel := normalizeExternalEditPath(c.cpRoot, p)
+		if rel == "" || seen[rel] {
+			continue
+		}
+		seen[rel] = true
+		out = append(out, rel)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeExternalEditPath(root, p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" {
+		return ""
+	}
+	if filepath.IsAbs(p) {
+		if root == "" {
+			p = filepath.Clean(p)
+		} else if rel, err := filepath.Rel(root, p); err == nil {
+			p = rel
+		} else {
+			return ""
+		}
+	}
+	p = filepath.Clean(p)
+	if !filepath.IsLocal(p) {
+		return ""
+	}
+	return filepath.ToSlash(p)
+}
+
+func snapshotExternalEditFiles(root string, paths []string) (map[string]externalEditSnapshot, error) {
+	out := make(map[string]externalEditSnapshot, len(paths))
+	var firstErr error
+	for _, p := range paths {
+		abs := externalEditAbs(root, p)
+		b, err := os.ReadFile(abs)
+		s := externalEditSnapshot{path: p}
+		if err == nil {
+			s.exists = true
+			s.text = string(b)
+		} else if !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+		out[p] = s
+	}
+	return out, firstErr
+}
+
+func augmentExternalEditGitFallback(root string, before map[string]externalEditSnapshot) {
+	after, err := externalEditGitStatusPaths(root)
+	if err != nil {
+		return
+	}
+	prefix := externalEditGitPrefix(root)
+	for _, p := range after {
+		if _, ok := before[p]; ok {
+			continue
+		}
+		s := externalEditSnapshot{path: p}
+		if text, ok := externalEditGitHeadText(root, prefix, p); ok {
+			s.exists = true
+			s.text = text
+		}
+		before[p] = s
+	}
+}
+
+func externalEditGitStatusPaths(root string) ([]string, error) {
+	args := []string{"status", "--porcelain=v1", "-z", "--untracked-files=all"}
+	if root != "" {
+		args = append([]string{"-C", root}, args...)
+	}
+	cmd := exec.Command("git", args...)
+	proc.HideWindow(cmd)
+	raw, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.Split(string(raw), "\x00")
+	seen := map[string]bool{}
+	var out []string
+	for i := 0; i < len(parts); i++ {
+		part := parts[i]
+		if len(part) < 4 {
+			continue
+		}
+		status := part[:2]
+		path := part[3:]
+		if strings.ContainsAny(status, "RC") && i+1 < len(parts) {
+			i++
+			path = parts[i]
+		}
+		path = normalizeExternalEditPath(root, path)
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		out = append(out, path)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func externalEditGitPrefix(root string) string {
+	args := []string{"rev-parse", "--show-prefix"}
+	if root != "" {
+		args = append([]string{"-C", root}, args...)
+	}
+	cmd := exec.Command("git", args...)
+	proc.HideWindow(cmd)
+	raw, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+func externalEditGitHeadText(root, prefix, rel string) (string, bool) {
+	gitPath := filepath.ToSlash(filepath.Join(filepath.FromSlash(prefix), filepath.FromSlash(rel)))
+	args := []string{"show", "HEAD:" + gitPath}
+	if root != "" {
+		args = append([]string{"-C", root}, args...)
+	}
+	cmd := exec.Command("git", args...)
+	proc.HideWindow(cmd)
+	raw, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return string(raw), true
+}
+
+func diffExternalEditFiles(root string, before map[string]externalEditSnapshot) ([]diff.Change, error) {
+	paths := make([]string, 0, len(before))
+	for p := range before {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+
+	var changes []diff.Change
+	var firstErr error
+	for _, p := range paths {
+		s := before[p]
+		b, err := os.ReadFile(externalEditAbs(root, p))
+		exists := err == nil
+		if err != nil && !os.IsNotExist(err) && firstErr == nil {
+			firstErr = err
+		}
+		newText := ""
+		if exists {
+			newText = string(b)
+		}
+		if s.exists == exists && s.text == newText {
+			continue
+		}
+		kind := diff.Modify
+		switch {
+		case !s.exists && exists:
+			kind = diff.Create
+		case s.exists && !exists:
+			kind = diff.Delete
+		}
+		changes = append(changes, diff.Build(p, s.text, newText, kind))
+	}
+	return changes, firstErr
+}
+
+func externalEditAbs(root, rel string) string {
+	if filepath.IsAbs(rel) || root == "" {
+		return filepath.Clean(rel)
+	}
+	return filepath.Join(root, filepath.FromSlash(rel))
+}
+
+func combineExternalEditDiffs(changes []diff.Change) event.FileDiff {
+	var b strings.Builder
+	var added, removed int
+	for _, ch := range changes {
+		added += ch.Added
+		removed += ch.Removed
+		if ch.Diff == "" {
+			continue
+		}
+		if b.Len() > 0 {
+			b.WriteByte('\n')
+		}
+		b.WriteString(ch.Diff)
+	}
+	return event.FileDiff{Diff: b.String(), Added: added, Removed: removed}
+}
+
+func externalEditArgs(changes []diff.Change) string {
+	files := make([]string, 0, len(changes))
+	for _, ch := range changes {
+		files = append(files, ch.Path)
+	}
+	b, err := json.Marshal(struct {
+		Files []string `json:"files"`
+	}{Files: files})
+	if err != nil {
+		return `{"files":[]}`
+	}
+	return string(b)
+}
+
+func externalEditOutput(label string, changes []diff.Change, snapErr, diffErr error) string {
+	var added, removed int
+	for _, ch := range changes {
+		added += ch.Added
+		removed += ch.Removed
+	}
+	msg := fmt.Sprintf("applied external patch: %d files changed (+%d -%d)", len(changes), added, removed)
+	if label != "" {
+		msg = fmt.Sprintf("applied %s: %d files changed (+%d -%d)", label, len(changes), added, removed)
+	}
+	if snapErr != nil {
+		msg += fmt.Sprintf("; snapshot warning: %v", snapErr)
+	}
+	if diffErr != nil {
+		msg += fmt.Sprintf("; diff warning: %v", diffErr)
+	}
+	return msg
+}
+
+func (c *Controller) persistExternalEdit(id, name, args, output, errMsg string, fd event.FileDiff, changes []diff.Change) {
+	if c.executor == nil {
+		return
+	}
+	if c.cp != nil && len(changes) > 0 {
+		c.beginCheckpoint(name)
+		for _, ch := range changes {
+			c.cp.Snapshot(ch)
+		}
+		// Finish is called by End after SnapshotActivity succeeds so the
+		// on-disk session is never behind the checkpoint MsgIndex.
+	}
+	if errMsg != "" {
+		output = "error: " + errMsg
+	}
+	s := c.executor.Session()
+	s.Add(provider.Message{
+		Role: provider.RoleAssistant,
+		ToolCalls: []provider.ToolCall{{
+			ID:        id,
+			Name:      name,
+			Arguments: args,
+			Diff:      fd.Diff,
+			Added:     fd.Added,
+			Removed:   fd.Removed,
+		}},
+	})
+	s.Add(provider.Message{Role: provider.RoleTool, ToolCallID: id, Name: name, Content: output})
+}

--- a/internal/control/external_edit.go
+++ b/internal/control/external_edit.go
@@ -73,7 +73,7 @@ func (c *Controller) BeginExternalEdit(label string, paths []string) *ExternalEd
 	c.mu.Lock()
 	if c.running || c.externalEditOpen {
 		c.mu.Unlock()
-		return &ExternalEdit{controller: c, label: label, start: time.Now(), beginErr: ErrTurnRunning}
+		return &ExternalEdit{controller: nil, label: label, start: time.Now(), beginErr: ErrTurnRunning}
 	}
 	c.externalEditOpen = true
 	c.mu.Unlock()


### PR DESCRIPTION
Introduce ExternalEdit — a lifecycle type for host-side writers (e.g. Codex apply_patch) that emits synthetic ToolDispatch/ToolResult events and persists replayable history.

**Core (internal/control):**
- ExternalEdit: snapshot files before edit, diff after, emit events, persist
- Controller: `externalEditOpen` gates RunTurn/runGuarded to prevent interleaving
- RunExternalEdit / BeginExternalEdit + End for one-shot or two-phase use
- Git-fallback path discovery when paths are not provided

**Persistence (internal/checkpoint):**
- Add `Store.Finish()` to finalize current checkpoint immediately

**Desktop bridge (desktop/):**
- BeginExternalEditForTab / EndExternalEdit Wails bindings
- runExternalEditForTab for tab-targeted edits
- Exported handle for two-phase API with opaque ID

**Frontend (desktop/frontend/src/):**
- Bridge interface + mock for external edit methods
- Trigger checkpoint refresh on tool_result with file changes
- Include checkpoints.length in workbench dock refreshKey