### PR TITLE
fix(provider): backfill tool-result name on old-session replay

### DIFF
--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -337,6 +337,31 @@ func TestBuildRequestRoundTripsReasoningOnDeepSeekToolCalls(t *testing.T) {
 	}
 }
 
+// An old session (pre-adde2d3e) saved tool results without a name field. The
+// call still carries its name, so buildRequest must backfill the result name —
+// otherwise the wire omits it and DeepSeek 400s "missing field name" (#4773).
+func TestBuildRequestBackfillsToolResultNameForOldSession(t *testing.T) {
+	c := &client{model: "deepseek-v4", deepseek: true}
+	req := c.buildRequest(provider.Request{
+		Messages: []provider.Message{
+			{Role: provider.RoleUser, Content: "count the go files"},
+			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"ls"}`}}},
+			{Role: provider.RoleTool, ToolCallID: "c1", Content: "14"},
+		},
+	})
+	tool := req.Messages[len(req.Messages)-1]
+	if tool.Role != "tool" {
+		t.Fatalf("last message role = %q, want tool", tool.Role)
+	}
+	b, err := json.Marshal(tool)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"name":"bash"`) {
+		t.Errorf("tool result must carry the backfilled name on the wire: %s", b)
+	}
+}
+
 func TestBuildRequestForwardsReasoningEffort(t *testing.T) {
 	c := &client{model: "mimo-v2", effort: "high"}
 	if got := c.buildRequest(provider.Request{}).ReasoningEffort; got != "high" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -111,11 +111,9 @@ func SanitizeToolPairing(msgs []Message) []Message {
 			for j < len(msgs) && msgs[j].Role == RoleTool {
 				j++
 			}
-			// Backfill empty tool-call names from the corresponding tool
-			// results so the model sees which tool was invoked (#4727).
-			// The wire-format fix (openai.go) ensures empty fields are
-			// never omitted, so this backfill is a UX improvement, not a
-			// correctness requirement.
+			// Cross-fill tool names both ways before pairing: old sessions
+			// can drop the call name or the result name, and DeepSeek 400s a
+			// tool message whose name is omitted on the wire (#4727, #4773).
 			calls := backfillToolCallNames(m.ToolCalls, msgs[i+1:j])
 			m2 := m
 			m2.ToolCalls = calls
@@ -230,6 +228,9 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 		}
 		for _, tc := range calls {
 			if r, ok := byID[tc.ID]; ok {
+				if r.Name == "" {
+					r.Name = tc.Name
+				}
 				out = append(out, r)
 			} else {
 				out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
@@ -240,6 +241,9 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 	for k, tc := range calls {
 		if k < len(avail) {
 			r := avail[k]
+			if r.Name == "" {
+				r.Name = tc.Name
+			}
 			r.ToolCallID = tc.ID
 			out = append(out, r)
 		} else {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -98,6 +98,31 @@ func TestSanitizeToolPairingLeavesWellFormedUnchanged(t *testing.T) {
 	}
 }
 
+func TestSanitizeToolPairingBackfillsResultName(t *testing.T) {
+	in := []Message{
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "bash"}}},
+		{Role: RoleTool, ToolCallID: "c1", Content: "out"}, // old session: no name
+	}
+	out := SanitizeToolPairing(in)
+	if out[1].Role != RoleTool || out[1].Name != "bash" {
+		t.Fatalf("tool result name not backfilled from call: %+v", out[1])
+	}
+	if in[1].Name != "" {
+		t.Fatalf("stored history mutated: result name = %q", in[1].Name)
+	}
+}
+
+func TestSanitizeToolPairingBackfillsResultNameByPosition(t *testing.T) {
+	in := []Message{
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "", Name: "read_file"}}},
+		{Role: RoleTool, ToolCallID: "", Content: "data"},
+	}
+	out := SanitizeToolPairing(in)
+	if out[1].Name != "read_file" {
+		t.Fatalf("position-matched tool result name not backfilled: %+v", out[1])
+	}
+}
+
 func TestSanitizeToolPairingClosesTruncatedArgs(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{`{`, `{}`},


### PR DESCRIPTION
## Problem

Loading an old session (saved before `adde2d3e`) still 400s on DeepSeek with `messages[n]: missing field name`, even after #4727.

#4727 fixed one direction — it dropped `omitempty` on the assistant `tool_call` function name and backfilled empty **call** names from their results — but left the reverse. A pre-`adde2d3e` tool **result** can be saved without a `name` field; `pairToolResults` passed the raw result straight through, the wire (`chatMessage.Name` is `json:"name,omitempty"`) then omits it, and DeepSeek's strict deserializer rejects a tool message with no `name`.

So this is a gap in our own #4727, not a new external regression. Thanks to @SvenZhao for the precise root-cause writeup.

## Fix

Cross-fill the result name from its paired call in `pairToolResults`, mirroring the existing `backfillToolCallNames` (which fills the call name from the result). The call name is recovered first, so the common old-session shape (call has the name, result lost it) now serializes the same `name` a fresh session would have sent.

I deliberately did **not** drop `omitempty` on `chatMessage.Name`: unlike the `tool_call` function name (only emitted inside an assistant turn, always populated for healthy sessions), `chatMessage.Name` is shared across roles and is normally empty for user/assistant/system. Dropping its `omitempty` would emit `"name":""` on every message — a cache-prefix change for all existing sessions, and some gateways reject an empty `name` on non-tool roles.

Healthy sessions (result already has a name) are untouched, so they serialize byte-identically and the prefix cache is unaffected.

## Tests

- `provider`: `TestSanitizeToolPairingBackfillsResultName` (id-matched) and `…ByPosition` (empty-id positional pairing), both asserting the stored history is not mutated.
- `openai`: `TestBuildRequestBackfillsToolResultNameForOldSession` — wire-level regression; the serialized tool message carries `"name":"bash"` instead of omitting it.

`go test ./internal/provider/...` green; full module builds.

## Same root cause

Also resolves the identical `missing field name` 400 reported in #4767, #4735, #4715, #4741, #4366.

Closes #4773
