### PR TITLE
Revert "fix(provider): backfill tool-result name on old-session replay (#4775)"

### DIFF
--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -337,31 +337,6 @@ func TestBuildRequestRoundTripsReasoningOnDeepSeekToolCalls(t *testing.T) {
 	}
 }
 
-// An old session (pre-adde2d3e) saved tool results without a name field. The
-// call still carries its name, so buildRequest must backfill the result name —
-// otherwise the wire omits it and DeepSeek 400s "missing field name" (#4773).
-func TestBuildRequestBackfillsToolResultNameForOldSession(t *testing.T) {
-	c := &client{model: "deepseek-v4", deepseek: true}
-	req := c.buildRequest(provider.Request{
-		Messages: []provider.Message{
-			{Role: provider.RoleUser, Content: "count the go files"},
-			{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{ID: "c1", Name: "bash", Arguments: `{"command":"ls"}`}}},
-			{Role: provider.RoleTool, ToolCallID: "c1", Content: "14"},
-		},
-	})
-	tool := req.Messages[len(req.Messages)-1]
-	if tool.Role != "tool" {
-		t.Fatalf("last message role = %q, want tool", tool.Role)
-	}
-	b, err := json.Marshal(tool)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	if !strings.Contains(string(b), `"name":"bash"`) {
-		t.Errorf("tool result must carry the backfilled name on the wire: %s", b)
-	}
-}
-
 func TestBuildRequestForwardsReasoningEffort(t *testing.T) {
 	c := &client{model: "mimo-v2", effort: "high"}
 	if got := c.buildRequest(provider.Request{}).ReasoningEffort; got != "high" {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -111,9 +111,11 @@ func SanitizeToolPairing(msgs []Message) []Message {
 			for j < len(msgs) && msgs[j].Role == RoleTool {
 				j++
 			}
-			// Cross-fill tool names both ways before pairing: old sessions
-			// can drop the call name or the result name, and DeepSeek 400s a
-			// tool message whose name is omitted on the wire (#4727, #4773).
+			// Backfill empty tool-call names from the corresponding tool
+			// results so the model sees which tool was invoked (#4727).
+			// The wire-format fix (openai.go) ensures empty fields are
+			// never omitted, so this backfill is a UX improvement, not a
+			// correctness requirement.
 			calls := backfillToolCallNames(m.ToolCalls, msgs[i+1:j])
 			m.ToolCalls = calls
 			out = append(out, repairToolCallArgs(m))
@@ -227,9 +229,6 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 		}
 		for _, tc := range calls {
 			if r, ok := byID[tc.ID]; ok {
-				if r.Name == "" {
-					r.Name = tc.Name
-				}
 				out = append(out, r)
 			} else {
 				out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
@@ -240,9 +239,6 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 	for k, tc := range calls {
 		if k < len(avail) {
 			r := avail[k]
-			if r.Name == "" {
-				r.Name = tc.Name
-			}
 			r.ToolCallID = tc.ID
 			out = append(out, r)
 		} else {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -98,31 +98,6 @@ func TestSanitizeToolPairingLeavesWellFormedUnchanged(t *testing.T) {
 	}
 }
 
-func TestSanitizeToolPairingBackfillsResultName(t *testing.T) {
-	in := []Message{
-		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "bash"}}},
-		{Role: RoleTool, ToolCallID: "c1", Content: "out"}, // old session: no name
-	}
-	out := SanitizeToolPairing(in)
-	if out[1].Role != RoleTool || out[1].Name != "bash" {
-		t.Fatalf("tool result name not backfilled from call: %+v", out[1])
-	}
-	if in[1].Name != "" {
-		t.Fatalf("stored history mutated: result name = %q", in[1].Name)
-	}
-}
-
-func TestSanitizeToolPairingBackfillsResultNameByPosition(t *testing.T) {
-	in := []Message{
-		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "", Name: "read_file"}}},
-		{Role: RoleTool, ToolCallID: "", Content: "data"},
-	}
-	out := SanitizeToolPairing(in)
-	if out[1].Name != "read_file" {
-		t.Fatalf("position-matched tool result name not backfilled: %+v", out[1])
-	}
-}
-
 func TestSanitizeToolPairingClosesTruncatedArgs(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{`{`, `{}`},


### PR DESCRIPTION
Reverts #4775. A live DeepSeek A/B disproved the premise behind #4773/#4775.

The `missing field name` 400 is caused by an **omitted assistant `tool_calls[].function.name`**, not by the tool result name. Raw probes against `deepseek-v4-flash` (tools declared):

| wire shape | result |
|---|---|
| tool result with **no** `name` | **200** (accepted) |
| assistant `function.name` **omitted** | **400** `messages[i]: missing field name` |
| both omitted | **400** (same `messages[i]`) |
| assistant `function.name: ""` (present, empty) | **200** (accepted) |
| tool result `name: ""` (present, empty) | **200** (accepted) |

#4727 already fully fixes the real 400: it dropped `omitempty` on `chatToolCall.Function.Name`, so the key is always sent (empty string when an old session lost it), which DeepSeek accepts. Backfilling the tool **result** name does nothing for the API and shipped a comment the live API contradicts, so it's reverted.

The duplicate reports (#4767, #4735, #4715, #4741, #4366) are real 400s resolved by #4727 — they need the build that includes it, not this change.

`go build ./...` and `go test ./internal/provider/` green after the revert.
