### PR TITLE
fix(fileref): skip Maven target outputs

### DIFF
--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -18,8 +18,9 @@ var skipEntryNames = map[string]bool{
 }
 
 var skipDirNames = map[string]bool{
-	"build": true,
-	"dist":  true,
+	"build":  true,
+	"dist":   true,
+	"target": true,
 }
 
 var skipDirPaths = map[string]bool{

--- a/internal/fileref/search.go
+++ b/internal/fileref/search.go
@@ -21,6 +21,7 @@ var skipDirNames = map[string]bool{
 	"build":  true,
 	"dist":   true,
 	"target": true,
+	"vendor": true,
 }
 
 var skipDirPaths = map[string]bool{

--- a/internal/fileref/search_test.go
+++ b/internal/fileref/search_test.go
@@ -152,3 +152,17 @@ func TestSearchSkipsNoiseStillWorks(t *testing.T) {
 		t.Fatalf("Search should still return legitimate hit, got %v", resultPaths(got))
 	}
 }
+
+func TestSearchSkipsMavenTargetDirectory(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "src", "main", "java", "App.java"))
+	writeFile(t, filepath.Join(root, "target", "classes", "App.class"))
+
+	got := Search(root, "app", 50)
+	if containsPath(got, "target/classes/App.class") {
+		t.Fatalf("Search should skip Maven target/ build output, got %v", resultPaths(got))
+	}
+	if !containsPath(got, "src/main/java/App.java") {
+		t.Fatalf("Search should still return source files, got %v", resultPaths(got))
+	}
+}

--- a/internal/fileref/search_test.go
+++ b/internal/fileref/search_test.go
@@ -137,6 +137,7 @@ func TestSearchSkipsNoiseStillWorks(t *testing.T) {
 	writeFile(t, filepath.Join(root, "node_modules", "planind", "index.tsx")) // must be skipped
 	writeFile(t, filepath.Join(root, "build", "planind", "index.tsx"))        // skipDirNames
 	writeFile(t, filepath.Join(root, "dist", "planind", "index.tsx"))         // skipDirNames
+	writeFile(t, filepath.Join(root, "vendor", "planind", "package.go"))      // skipDirNames
 
 	got := Search(root, "planind", 50)
 	if containsPath(got, "node_modules/planind/index.tsx") {
@@ -147,6 +148,9 @@ func TestSearchSkipsNoiseStillWorks(t *testing.T) {
 	}
 	if containsPath(got, "dist/planind/index.tsx") {
 		t.Fatalf("Search should skip dist/, got %v", resultPaths(got))
+	}
+	if containsPath(got, "vendor/planind/package.go") {
+		t.Fatalf("Search should skip vendor/, got %v", resultPaths(got))
 	}
 	if !containsPath(got, "src/planind/index.tsx") {
 		t.Fatalf("Search should still return legitimate hit, got %v", resultPaths(got))


### PR DESCRIPTION
## Summary
- skip Maven `target/` build output during file-reference search
- keep source matches such as `src/main/java` visible
- add a regression test for `target/classes` noise

Closes #4645

## Verification
- `GOTOOLCHAIN=local GOPROXY=off GOSUMDB=off go test ./internal/fileref -count=1`
- `git diff --check HEAD~1..HEAD`