### PR TITLE
修复 TUI 分割线在 transcript 视口中换行

### DIFF
--- a/internal/cli/branch.go
+++ b/internal/cli/branch.go
@@ -118,8 +118,9 @@ func (m *chatTUI) replayActiveBranch(title string) {
 	if title != "" {
 		m.commitLine(dim("  -- " + title + " --"))
 	}
-	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
-	for _, section := range replaySectionsFor(m.ctrl.History(), m.width, m.renderer) {
+	contentW := transcriptContentWidth(m.width, m.nativeScrollback)
+	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", contentW), "\n"))
+	for _, section := range replaySectionsFor(m.ctrl.History(), contentW, m.renderer) {
 		m.commitLine(strings.TrimRight(section, "\n"))
 	}
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -460,6 +460,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 
 	commitBuf := []string{}
 	nativeScrollback := detectTermuxTerminal()
+	renderW := transcriptContentWidth(termW, nativeScrollback)
 	return chatTUI{
 		ctrl:                 ctrl,
 		label:                ctrl.Label(),
@@ -477,7 +478,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		reasoning:            &strings.Builder{},
 		pending:              &strings.Builder{},
 		pendingCommit:        &commitBuf,
-		renderer:             newMarkdownRenderer(termW),
+		renderer:             newMarkdownRenderer(renderW),
 		diffMaxLines:         diffFoldLimit,
 		showReasoning:        nativeScrollback,
 		shellOutputs:         make(map[string]string),
@@ -492,6 +493,13 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		viewport:             viewport.New(viewport.WithWidth(termW)),
 		statusLineCount:      2,
 	}
+}
+
+func transcriptContentWidth(termW int, nativeScrollback bool) int {
+	if !nativeScrollback {
+		termW-- // reserve the last column for the transcript scrollbar
+	}
+	return max(termW, 1)
 }
 
 func configureChatTextarea(ti *textarea.Model) {
@@ -668,14 +676,7 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	next, cmd := m.update(msg)
 	cm := next.(chatTUI)
 
-	contentW := cm.width - 1 // last column is the scrollbar
-	if contentW < 1 {
-		contentW = 1
-	}
-	// Recompute the wrapped status-line count so bottomRows reserves the right
-	// height for the viewport. The data-line tags (model, git, effort, context,
-	// cache, jobs, balance) are the ones most likely to wrap on a narrow terminal.
-	cm.statusLineCount = cm.computeStatusLineCount(contentW)
+	contentW := transcriptContentWidth(cm.width, cm.nativeScrollback)
 	cm.viewport.SetWidth(contentW)
 	// Recompute the wrapped status-line count so bottomRows reserves the right
 	// height for the viewport. Use cm.width (same as boxW in View()) so the
@@ -714,16 +715,17 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.input.SetWidth(msg.Width - 4)
-		m.renderer = newMarkdownRenderer(msg.Width)
+		contentW := transcriptContentWidth(msg.Width, m.nativeScrollback)
+		m.renderer = newMarkdownRenderer(contentW)
 		// Commit the banner — and a resumed session's transcript — once, now
 		// that the width is known.
 		if !m.started {
 			m.started = true
 			var b strings.Builder
-			b.WriteString(renderTUIBanner(m.label, m.missing, msg.Width))
+			b.WriteString(renderTUIBanner(m.label, m.missing, contentW))
 			if len(m.history) > 0 {
-				r := newMarkdownRenderer(msg.Width)
-				for _, sec := range replaySectionsFor(m.history, msg.Width, r) {
+				r := newMarkdownRenderer(contentW)
+				for _, sec := range replaySectionsFor(m.history, contentW, r) {
 					b.WriteString(sec)
 				}
 				m.history = nil

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -514,6 +514,22 @@ func TestMainManagerFollowsTranscriptWithoutTopPadding(t *testing.T) {
 	}
 }
 
+func TestMarkdownDividerFitsTranscriptContentWidth(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	m = m0.(chatTUI)
+
+	rule := strings.TrimRight(m.renderer.Render("---"), "\n")
+	lines := strings.Split(wrapTranscript(rule, m.viewport.Width()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("markdown divider wrapped into %d lines at width %d: %q", len(lines), m.viewport.Width(), lines)
+	}
+	if w := visibleWidth(lines[0]); w != m.viewport.Width() {
+		t.Fatalf("markdown divider width = %d, want %d: %q", w, m.viewport.Width(), lines[0])
+	}
+}
+
 func TestModalPanelsHideComposerBox(t *testing.T) {
 	ask := event.Ask{
 		ID: "ask-1",

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -61,7 +61,7 @@ func (m *chatTUI) resetFreshContextView(clearTranscript bool) {
 	} else {
 		m.commitLine("")
 	}
-	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
+	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", transcriptContentWidth(m.width, m.nativeScrollback)), "\n"))
 	m.transcriptDirty = true
 	m.forceGotoBottom = true
 }


### PR DESCRIPTION
## 摘要

Fixes #4789.

修复 TUI 中 Markdown 分割线可能多占一列、换到下一行的问题。

## 问题原因

transcript 视口最后一列会预留给滚动条，所以实际内容宽度是 `terminal width - 1`。但 Markdown 输出、初始 banner 和历史回放之前仍按完整终端宽度渲染。

当 Markdown 水平分割线按完整宽度填满时，后续 transcript 包装阶段会按更窄的内容宽度重新处理，导致最后一格被挤到下一行。

## 改动

- 新增 `transcriptContentWidth`，统一 transcript 内容区宽度计算。
- 启动和窗口 resize 时，让 Markdown renderer 使用内容区宽度。
- 初始 banner、分支回放、历史回放、清空/重置后的 banner 都改用同一宽度。
- 增加回归测试，覆盖 Markdown 分割线不会超过 transcript 内容区宽度。

## 验证

- `go test ./internal/cli -run TestMarkdownDividerFitsTranscriptContentWidth -count=1`
- `go test ./internal/cli -count=1`
- 已从修复分支编译 `bin/reasonix` 做本地测试。