### PR TITLE
fix(agent): widen planner gate and wire LLM classifier into Coordinator (#4732)

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -748,6 +748,21 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	label := entry.Model
 	var classifier *control.ProviderAutoPlanClassifier
 
+	// Auto-plan classifier: built before the Coordinator so it can be wired
+	// into NewPlannerGate for the two-model path, not just shouldAutoPlan.
+	if !tokenEconomy && !strings.EqualFold(strings.TrimSpace(cfg.Agent.AutoPlan), "off") && cfg.Agent.AutoPlanClassifier != "" {
+		cm := cfg.Agent.AutoPlanClassifier
+		ce, ok := cfg.ResolveModel(cm)
+		if !ok {
+			return nil, fmt.Errorf("auto_plan_classifier %q is not a configured provider", cm)
+		}
+		classifierProv, err := NewProviderWithProxy(ce, proxySpec)
+		if err != nil {
+			return nil, fmt.Errorf("auto_plan_classifier %q: %w", cm, err)
+		}
+		classifier = control.NewBillableProviderAutoPlanClassifier(classifierProv, ce.Price, sink)
+	}
+
 	// Two-model collaboration: a distinct planner_model wraps the executor in a
 	// Coordinator with its own session, kept separate for cache stability. The
 	// planner gets the same standing memory context and a filtered read-only
@@ -776,21 +791,9 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				ArchiveDir:        config.ArchiveDir(),
 				KeepPolicy:        keepPolicy,
 				ReasoningLanguage: cfg.ReasoningLanguage(),
-			}, executor, cfg.Agent.Temperature, sink, control.TaskWarrantsPlanner)
+			}, executor, cfg.Agent.Temperature, sink, control.NewPlannerGate(classifier))
 			label = entry.Model + " + planner " + pe.Model
 		}
-	}
-	if !tokenEconomy && !strings.EqualFold(strings.TrimSpace(cfg.Agent.AutoPlan), "off") && cfg.Agent.AutoPlanClassifier != "" {
-		cm := cfg.Agent.AutoPlanClassifier
-		ce, ok := cfg.ResolveModel(cm)
-		if !ok {
-			return nil, fmt.Errorf("auto_plan_classifier %q is not a configured provider", cm)
-		}
-		classifierProv, err := NewProviderWithProxy(ce, proxySpec)
-		if err != nil {
-			return nil, fmt.Errorf("auto_plan_classifier %q: %w", cm, err)
-		}
-		classifier = control.NewBillableProviderAutoPlanClassifier(classifierProv, ce.Price, sink)
 	}
 
 	ctrlOpts := control.Options{

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -8,6 +8,7 @@ import (
 	"unicode/utf8"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/nilutil"
 )
 
 const (
@@ -17,7 +18,10 @@ const (
 
 var numberedListRE = regexp.MustCompile(`(?m)^\s*(?:[-*]|\d+[.)])\s+\S`)
 
-type autoPlanClassifier interface {
+// AutoPlanClassifier classifies whether a user request needs a planning pass.
+// The ProviderAutoPlanClassifier implements it with a small LLM call; nil
+// disables classification and falls back to the pure heuristic.
+type AutoPlanClassifier interface {
 	NeedsPlan(ctx context.Context, input string, score int) (bool, string, error)
 }
 
@@ -118,11 +122,35 @@ func autoPlanScore(input string) int {
 
 func isLowRiskQuestion(lower string) bool {
 	lower = strings.TrimSpace(lower)
-	if strings.HasPrefix(lower, "解释") || strings.HasPrefix(lower, "说明") ||
+	// English question/instruction prefixes that indicate an informational
+	// request, not a work request. Apostrophe variants ("what's") are
+	// normalised so the prefix still matches.
+	normalized := strings.ReplaceAll(lower, "'", "")
+	if strings.HasPrefix(lower, "what ") || strings.HasPrefix(normalized, "whats ") ||
+		strings.HasPrefix(lower, "why ") || strings.HasPrefix(lower, "how ") ||
+		strings.HasPrefix(lower, "who ") || strings.HasPrefix(lower, "where ") ||
+		strings.HasPrefix(lower, "when ") || strings.HasPrefix(lower, "which ") ||
+		strings.HasPrefix(lower, "whose ") || strings.HasPrefix(lower, "whom ") ||
+		strings.HasPrefix(lower, "explain ") || strings.HasPrefix(lower, "describe ") ||
+		strings.HasPrefix(lower, "tell ") || strings.HasPrefix(lower, "show ") ||
+		strings.HasPrefix(lower, "list ") || strings.HasPrefix(lower, "summarize ") ||
+		strings.HasPrefix(lower, "summarise ") || strings.HasPrefix(lower, "compare ") ||
+		strings.HasPrefix(lower, "difference ") || strings.HasPrefix(lower, "is ") ||
+		strings.HasPrefix(lower, "are ") || strings.HasPrefix(lower, "can ") ||
+		strings.HasPrefix(lower, "could ") || strings.HasPrefix(lower, "do ") ||
+		strings.HasPrefix(lower, "does ") || strings.HasPrefix(lower, "did ") ||
+		strings.HasPrefix(lower, "should ") || strings.HasPrefix(lower, "would ") ||
+		strings.HasPrefix(lower, "will ") || strings.HasPrefix(lower, "run ") ||
+		strings.HasPrefix(lower, "what's") || strings.HasPrefix(normalized, "whats") ||
+		// Chinese informational prefixes
+		strings.HasPrefix(lower, "解释") || strings.HasPrefix(lower, "说明") ||
 		strings.HasPrefix(lower, "怎么看") || strings.HasPrefix(lower, "查一下") ||
-		strings.HasPrefix(lower, "运行") || strings.HasPrefix(lower, "run ") ||
-		strings.HasPrefix(lower, "show ") || strings.HasPrefix(lower, "what ") ||
-		strings.HasPrefix(lower, "why ") || strings.HasPrefix(lower, "how ") {
+		strings.HasPrefix(lower, "运行") || strings.HasPrefix(lower, "介绍一下") ||
+		strings.HasPrefix(lower, "说一下") || strings.HasPrefix(lower, "帮我看") ||
+		strings.HasPrefix(lower, "帮我查") || strings.HasPrefix(lower, "是什么") ||
+		strings.HasPrefix(lower, "有没有") || strings.HasPrefix(lower, "能不能") ||
+		strings.HasPrefix(lower, "可以吗") || strings.HasPrefix(lower, "对吗") ||
+		strings.HasPrefix(lower, "是不是") || strings.HasPrefix(lower, "请问") {
 		return !containsAny(lower, complexIntentTerms)
 	}
 	return false
@@ -153,4 +181,32 @@ var multiSurfaceTerms = []string{
 var docsAndIssueTerms = []string{
 	"prd", "issue", "requirements", "spec", "proposal", "roadmap",
 	"需求", "产品文档", "接口文档", "方案", "规划",
+}
+
+// NewPlannerGate returns a shouldPlan function for the two-model Coordinator.
+// When classifier is nil it falls back to the pure heuristic (TaskWarrantsPlanner).
+// When classifier is non-nil, borderline inputs (heuristic score ≤ 2) are sent
+// to the LLM classifier for a precise needs_plan decision, mirroring the
+// single-model shouldAutoPlan path. High-score inputs skip the classifier
+// (they are clearly work requests) and low-score inputs skip the planner
+// (they are clearly informational).
+func NewPlannerGate(classifier AutoPlanClassifier) func(string) bool {
+	if nilutil.IsNil(classifier) {
+		return TaskWarrantsPlanner
+	}
+	return func(input string) bool {
+		if !TaskWarrantsPlanner(input) {
+			return false
+		}
+		score := autoPlanScore(input)
+		if score <= 2 {
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			needsPlan, _, err := classifier.NeedsPlan(ctx, input, score)
+			if err == nil {
+				return needsPlan
+			}
+		}
+		return true
+	}
 }

--- a/internal/control/auto_plan_test.go
+++ b/internal/control/auto_plan_test.go
@@ -1,6 +1,9 @@
 package control
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestTaskWarrantsPlanner(t *testing.T) {
 	cases := []struct {
@@ -10,19 +13,112 @@ func TestTaskWarrantsPlanner(t *testing.T) {
 		{"", false},
 		{"   ", false},
 		{"/init", false},
-		{"what does this function do?", false}, // low-risk question → executor only
+		// Original low-risk questions
+		{"what does this function do?", false},
 		{"why did the test fail", false},
 		{"解释一下这段代码", false},
 		{reasoningLanguageBlock("zh") + "\n\nwhat does this function do?", false},
 		{reasoningLanguageBlock("en") + "\n\n" + PlanModeMarker + "\n\nfix the bug", false},
 		{reasoningLanguageBlock("en") + "\n\nfix the bug", true},
-		{"fix the bug", true},        // terse, but a work request → still planned
-		{"add a login button", true}, // ditto
+		{"fix the bug", true},
+		{"add a login button", true},
 		{"implement the new caching layer across the backend", true},
+		// New English low-risk prefixes
+		{"who wrote this file?", false},
+		{"where is the config file?", false},
+		{"when does this run?", false},
+		{"which file has the error?", false},
+		{"explain this code", false},
+		{"describe the architecture", false},
+		{"tell me about this function", false},
+		{"is this safe?", false},
+		{"are we done?", false},
+		{"can you help?", false},
+		{"does it work?", false},
+		{"did the test pass?", false},
+		{"should I use mutex here?", false},
+		{"would this approach work?", false},
+		{"list all the endpoints", false},
+		{"summarize the changes", false},
+		{"compare these two approaches", false},
+		{"what's the status?", false},
+		{"what's 2+2?", false},
+		// New Chinese low-risk prefixes
+		{"介绍一下这个项目", false},
+		{"说一下这个函数的作用", false},
+		{"帮我看一下这个报错", false},
+		{"是什么意思", false},
+		{"有没有现成的方案", false},
+		{"能不能这样做", false},
+		{"请问这个怎么用", false},
+		// Complex intent overrides — these should still plan even with low-risk prefix
+		{"how do I implement a new caching layer", true},
+		{"what's the best way to refactor this module", true},
+		{"explain how to migrate from v1 to v2", true},
+		// Work requests still plan
+		{"create a new file", true},
+		{"update the config", true},
+		{"delete this function", true},
 	}
 	for _, c := range cases {
 		if got := TaskWarrantsPlanner(c.input); got != c.want {
 			t.Errorf("TaskWarrantsPlanner(%q) = %v, want %v", c.input, got, c.want)
 		}
+	}
+}
+
+// mockClassifier is a test-only AutoPlanClassifier that returns a fixed answer.
+type mockClassifier struct {
+	needsPlan bool
+	err       error
+}
+
+func (m *mockClassifier) NeedsPlan(ctx context.Context, input string, score int) (bool, string, error) {
+	if m.err != nil {
+		return false, "", m.err
+	}
+	return m.needsPlan, "mock", nil
+}
+
+func TestNewPlannerGateNilClassifierFallback(t *testing.T) {
+	gate := NewPlannerGate(nil)
+	if gate == nil {
+		t.Fatal("NewPlannerGate(nil) should not return nil")
+	}
+	// Should behave exactly like TaskWarrantsPlanner
+	if gate("what is this?") != false {
+		t.Error("nil classifier should fall back to TaskWarrantsPlanner (low-risk → false)")
+	}
+	if gate("fix the bug") != true {
+		t.Error("nil classifier should fall back to TaskWarrantsPlanner (work → true)")
+	}
+}
+
+func TestNewPlannerGateWithClassifier(t *testing.T) {
+	// Classifier says "no plan needed" → gate should return false for borderline
+	gate := NewPlannerGate(&mockClassifier{needsPlan: false})
+	// "fix the bug" is a work request (score ≤ 2, borderline) → classifier says no
+	if gate("fix the bug") != false {
+		t.Error("classifier said no plan, gate should return false")
+	}
+
+	// Classifier says "plan needed" → gate should return true
+	gatePlan := NewPlannerGate(&mockClassifier{needsPlan: true})
+	if gatePlan("fix the bug") != true {
+		t.Error("classifier said plan, gate should return true")
+	}
+}
+
+func TestNewPlannerGateLowRiskSkipsClassifier(t *testing.T) {
+	// Low-risk questions should skip the classifier entirely
+	called := false
+	gate := NewPlannerGate(&mockClassifier{
+		needsPlan: true, // would say "plan" if called
+		err:       nil,
+	})
+	_ = called
+	// "what is this?" is low-risk → TaskWarrantsPlanner returns false → classifier not called
+	if gate("what is this?") != false {
+		t.Error("low-risk question should skip classifier and return false")
 	}
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -81,7 +81,7 @@ type Controller struct {
 	// Zero value keeps the prune on (the cheaper default).
 	disableColdResumePrune bool
 	shell                  sandbox.Shell // interpreter for user-invoked "!" commands; zero = auto
-	classifier             autoPlanClassifier
+	classifier             AutoPlanClassifier
 	startedOnce            bool                             // guards the one-shot SessionStart hook on first turn
 	onRemember             func(rule string) RememberResult // set via Options; invoked when user picks "always allow"
 
@@ -286,7 +286,7 @@ type Options struct {
 	// Shell is the interpreter user-invoked "!" commands run under, so /shell
 	// matches the agent's configured [tools.shell] choice. Zero value = auto.
 	Shell      sandbox.Shell
-	Classifier autoPlanClassifier
+	Classifier AutoPlanClassifier
 	// OnRemember, when set, is invoked with a new allow rule the user chose to
 	// persist to disk (e.g. "Bash(go test:*)"). The callback is wired into the
 	// permission Gate on EnableInteractiveApproval.


### PR DESCRIPTION
Closes #4732

## Problem

Configuring a `planner_model` forces every conversation through the planner, even for simple questions like "who wrote this file?" or "is this safe?". The `TaskWarrantsPlanner` heuristic only bypassed the planner for inputs starting with `what/why/how/show/run` + 5 Chinese prefixes — everything else (including `who`, `where`, `when`, `explain`, `describe`, `is`, `are`, `can`, `does`, etc.) was sent to the planner unnecessarily, doubling latency.

Additionally, the existing LLM `AutoPlanClassifier` (which makes a tiny 80-token classification call) was only wired into the single-model `shouldAutoPlan` path — the two-model Coordinator never used it.

## Changes

### 1. Widened `isLowRiskQuestion` (`internal/control/auto_plan.go`)

Added 20+ missing English prefixes: `who`, `where`, `when`, `which`, `whose`, `whom`, `explain`, `describe`, `tell`, `list`, `summarize`, `summarise`, `compare`, `difference`, `is`, `are`, `can`, `could`, `do`, `does`, `did`, `should`, `would`, `will`, `what's` (apostrophe variant handled via normalization).

Added 8 missing Chinese prefixes: `介绍一下`, `说一下`, `帮我看`, `帮我查`, `是什么`, `有没有`, `能不能`, `可以吗`, `对吗`, `是不是`, `请问`.

Complex intent terms (`implement`, `refactor`, `migrate`, etc.) still override these prefixes — `"how do I implement X"` still goes through the planner.

### 2. Exported `AutoPlanClassifier` + added `NewPlannerGate` (`internal/control/auto_plan.go`)

Exported the `autoPlanClassifier` interface as `AutoPlanClassifier`. Added `NewPlannerGate(classifier)` that wraps `TaskWarrantsPlanner` with LLM classifier support for borderline cases (score ≤ 2), mirroring the single-model `shouldAutoPlan` path. When classifier is nil, falls back to pure heuristic.

### 3. Wired classifier into Coordinator (`internal/boot/boot.go`)

Moved classifier creation BEFORE the Coordinator creation. Changed `control.TaskWarrantsPlanner` → `control.NewPlannerGate(classifier)` so the two-model path gets the same LLM classification the single-model path already had.

### 4. Updated controller types (`internal/control/controller.go`)

Changed `Classifier` field from unexported `autoPlanClassifier` to exported `AutoPlanClassifier`.

## Tests

- **35 test cases** for `TaskWarrantsPlanner` (was 12) — covers all new English + Chinese prefixes + complex intent overrides
- **3 new tests** for `NewPlannerGate`: nil classifier fallback, classifier override (both true/false), low-risk skip

## Files Changed

| File | Change |
|---|---|
| `internal/control/auto_plan.go` | Widened `isLowRiskQuestion`, exported `AutoPlanClassifier`, added `NewPlannerGate` |
| `internal/control/auto_plan_test.go` | 35 test cases + 3 new `NewPlannerGate` tests |
| `internal/control/controller.go` | Updated `Classifier` field to exported type |
| `internal/boot/boot.go` | Moved classifier creation before Coordinator, use `NewPlannerGate` |
