### PR TITLE
fix(config): backfill official context windows

### DIFF
--- a/internal/config/backfill_test.go
+++ b/internal/config/backfill_test.go
@@ -135,6 +135,59 @@ func TestNormalizeDesktopOfficialProviderAccessCanonicalizesLegacyIDs(t *testing
 	}
 }
 
+func TestNormalizeDesktopOfficialProviderAccessBackfillsOfficialContextWindow(t *testing.T) {
+	c := &Config{
+		Desktop: DesktopConfig{ProviderAccess: []string{"deepseek-flash", "mimo-api", "mimo-token-plan"}},
+		Providers: []ProviderEntry{
+			{
+				Name:      "deepseek-flash",
+				Kind:      "openai",
+				BaseURL:   "https://api.deepseek.com",
+				Model:     "deepseek-v4-flash",
+				APIKeyEnv: "DEEPSEEK_API_KEY",
+			},
+			{
+				Name:      "mimo-api",
+				Kind:      "openai",
+				BaseURL:   "https://api.xiaomimimo.com/v1",
+				Model:     "mimo-v2.5-pro",
+				APIKeyEnv: "MIMO_API_KEY",
+			},
+			{
+				Name:      "mimo-token-plan",
+				Kind:      "openai",
+				BaseURL:   "https://token-plan-cn.xiaomimimo.com/v1",
+				Model:     "mimo-v2.5-pro",
+				APIKeyEnv: "MIMO_API_KEY",
+			},
+		},
+	}
+
+	normalizeDesktopOfficialProviderAccess(c)
+
+	deepseek, ok := c.Provider("deepseek")
+	if !ok {
+		t.Fatal("deepseek provider missing")
+	}
+	if deepseek.ContextWindow != 1_000_000 {
+		t.Fatalf("deepseek context_window = %d, want official default", deepseek.ContextWindow)
+	}
+	mimoAPI, ok := c.Provider("mimo-api")
+	if !ok {
+		t.Fatal("mimo-api provider missing")
+	}
+	if mimoAPI.ContextWindow != 1_048_576 {
+		t.Fatalf("mimo-api context_window = %d, want official default", mimoAPI.ContextWindow)
+	}
+	mimoTokenPlan, ok := c.Provider("mimo-token-plan")
+	if !ok {
+		t.Fatal("mimo-token-plan provider missing")
+	}
+	if mimoTokenPlan.ContextWindow != 1_048_576 {
+		t.Fatalf("mimo-token-plan context_window = %d, want official default", mimoTokenPlan.ContextWindow)
+	}
+}
+
 func TestNormalizeDesktopOfficialProviderAccessKeepsCustomAlias(t *testing.T) {
 	c := &Config{
 		Desktop: DesktopConfig{ProviderAccess: []string{"deepseek-flash"}},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2105,7 +2105,10 @@ func desktopProviderAccessMap(names []string) map[string]bool {
 }
 
 func ensureDeepSeekOfficialProvider(c *Config) {
-	if _, ok := c.Provider("deepseek"); ok {
+	if p, ok := c.Provider("deepseek"); ok {
+		if officialProviderKind(p) == "deepseek" {
+			backfillOfficialContextWindow(p, 1_000_000)
+		}
 		return
 	}
 	entry := ProviderEntry{
@@ -2125,6 +2128,7 @@ func ensureDeepSeekOfficialProvider(c *Config) {
 		entry.Models = mergeModelLists([]string{"deepseek-v4-flash", "deepseek-v4-pro"}, old.ModelList())
 		entry.Default = firstKnownModel(entry.Default, entry.Models, "deepseek-v4-flash")
 	}
+	backfillOfficialContextWindow(&entry, 1_000_000)
 	c.Providers = append(c.Providers, entry)
 }
 
@@ -2133,6 +2137,7 @@ func ensureMimoAPIProvider(c *Config) {
 	visionModels := []string{"mimo-v2.5", "mimo-v2-omni"}
 	if p, ok := c.Provider("mimo-api"); ok {
 		if isOfficialMimoAPIProvider(p) {
+			backfillOfficialContextWindow(p, 1_048_576)
 			mergeCuratedModelsIntoProvider(p, models, "mimo-v2.5-pro")
 			mergeVisionModelsIntoProvider(p, visionModels)
 			backfillMimoDomesticPrices(p)
@@ -2158,6 +2163,7 @@ func ensureMimoTokenPlanProvider(c *Config, includeMimoFlash bool) {
 	visionModels := []string{"mimo-v2.5"}
 	if p, ok := c.Provider("mimo-token-plan"); ok {
 		if isOfficialMimoTokenPlanProvider(p) {
+			backfillOfficialContextWindow(p, 1_048_576)
 			mergeCuratedModelsIntoProvider(p, models, "mimo-v2.5-pro")
 			mergeVisionModelsIntoProvider(p, visionModels)
 			clearMixedMimoTokenPlanPrice(p)
@@ -2191,6 +2197,7 @@ func ensureMimoTokenPlanProvider(c *Config, includeMimoFlash bool) {
 	}
 	clearMixedMimoTokenPlanPrice(&entry)
 	backfillMimoDomesticPrices(&entry)
+	backfillOfficialContextWindow(&entry, 1_048_576)
 	c.Providers = append(c.Providers, entry)
 }
 
@@ -2244,6 +2251,12 @@ func mergeVisionModelsIntoProvider(e *ProviderEntry, models []string) {
 func clearMixedMimoTokenPlanPrice(e *ProviderEntry) {
 	if e != nil && e.HasModel("mimo-v2.5-pro") && e.HasModel("mimo-v2.5") {
 		e.Price = nil
+	}
+}
+
+func backfillOfficialContextWindow(e *ProviderEntry, fallback int) {
+	if e != nil && e.ContextWindow <= 0 {
+		e.ContextWindow = fallback
 	}
 }
 


### PR DESCRIPTION
## Problem

Official desktop provider access can end up with `context_window = 0` after upgrading older configs or reusing official provider entries that were saved without a context window. That makes Settings and the runtime report a zero-token context window for DeepSeek/MiMo official providers, which also disables compaction.

## Root Cause

The desktop official-provider normalization copied legacy provider fields wholesale. A missing TOML `context_window` decodes as Go's zero value, and existing official entries returned early before the built-in defaults were restored.

## Fix

- Backfill the official context-window defaults when recognized DeepSeek/MiMo official entries have a non-positive value.
- Apply the repair to both legacy alias migration and already-canonical official provider entries.
- Keep the repair scoped to known official endpoints so custom proxy providers are left untouched.
- Add regression coverage for legacy DeepSeek access plus existing MiMo official entries saved without a context window.

## Verification

- `go test ./internal/config -run TestNormalizeDesktopOfficialProviderAccessBackfillsOfficialContextWindow -count=1`
- `go test ./internal/config -count=1`
- `go test ./...`
- `cd desktop && go test ./...`
- `cd desktop/frontend && corepack pnpm run test:all`
- `cd desktop/frontend && corepack pnpm run build`
- `gofmt -l .`
- `git diff --check`
- `go vet ./...`
- `cd desktop && go vet ./...`

Fixes #4769
