### PR TITLE
fixed code snippets in chat replies not using custom fonts

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3924,6 +3924,10 @@ a[href] {
   white-space: pre;
   color: var(--fg);
 }
+.code code {
+  font-family: inherit;
+}
+
 .code--loading {
   opacity: 0.55;
 }


### PR DESCRIPTION
## PR Title

**fix(desktop): code snippets in chat replies not using custom fonts**

## Summary

Chat 回复中的代码块（`.code` 容器内的 `<code>` 元素）没有继承自定义字体，而是回退到了浏览器默认的等宽字体（如 `Courier New` 或 `Consolas`），与页面其他部分的字体风格不一致。

## Root Cause

`<code>` 标签在浏览器默认样式中有独立的 `font-family: monospace` 声明，优先级高于从 `.code` 父容器继承的字体设置。

## Fix

在 `desktop/frontend/src/styles.css` 中追加一条规则，显式让 `.code` 内的 `<code>` 元素继承父级字体：

```css
.code code {
  font-family: inherit;
}
```

这样自定义字体（如用户配置的 monospace 字体）能正确穿透到代码片段内部。

## Diff

```
 desktop/frontend/src/styles.css | 4 ++++
 1 file changed, 4 insertions(+)
```

## Checklist

- [x] 本地验证代码块字体与页面其他区域一致
- [x] 无副作用 — 仅新增选择器，不改动现有样式
