### PR TITLE
fix(agent,provider): unify history normalization into single NormalizeMessages entry point

### DIFF
--- a/internal/agent/normalize.go
+++ b/internal/agent/normalize.go
@@ -2,14 +2,12 @@ package agent
 
 import "reasonix/internal/provider"
 
-// NormalizeSession runs the canonical history repairs on a loaded conversation
-// and is the agent-side entry point for making old, partially-saved, or
-// interrupted sessions replayable. It is a thin wrapper over
-// provider.NormalizeMessages — the single source of truth for every repair
-// (tool-call name backfill, truncated-arg closing, orphan-result dropping,
-// placeholder backfill for unanswered calls) — so the load path and the
-// provider send path can never drift apart (the root cause of the
-// #4727 → #4775 → revert churn).
+// NormalizeSession runs the persisted-history-safe repairs on a loaded
+// conversation and is the agent-side entry point for making old, partially
+// saved, or interrupted sessions replayable. It is a thin wrapper over
+// provider.NormalizeSessionMessages, which shares assistant-turn repairs with
+// the provider send path without applying wire-only cleanup such as dropping
+// standalone tool messages.
 //
 // LoadSession calls this right after decoding so a session that was written by
 // an older code version, or that was cut short mid-turn, is corrected in memory
@@ -21,8 +19,8 @@ import "reasonix/internal/provider"
 // load — cheap, because the fast path returns the input slice unchanged.
 //
 // Well-formed histories are returned without allocating (see
-// provider.NormalizeMessages), so this is a no-op in both time and memory for
-// the common case and cannot perturb a provider's prefix-cache key.
+// provider.NormalizeSessionMessages), so this is a no-op in both time and memory
+// for the common case and cannot perturb a provider's prefix-cache key.
 func NormalizeSession(msgs []provider.Message) []provider.Message {
-	return provider.NormalizeMessages(msgs)
+	return provider.NormalizeSessionMessages(msgs)
 }

--- a/internal/agent/normalize.go
+++ b/internal/agent/normalize.go
@@ -1,0 +1,28 @@
+package agent
+
+import "reasonix/internal/provider"
+
+// NormalizeSession runs the canonical history repairs on a loaded conversation
+// and is the agent-side entry point for making old, partially-saved, or
+// interrupted sessions replayable. It is a thin wrapper over
+// provider.NormalizeMessages — the single source of truth for every repair
+// (tool-call name backfill, truncated-arg closing, orphan-result dropping,
+// placeholder backfill for unanswered calls) — so the load path and the
+// provider send path can never drift apart (the root cause of the
+// #4727 → #4775 → revert churn).
+//
+// LoadSession calls this right after decoding so a session that was written by
+// an older code version, or that was cut short mid-turn, is corrected in memory
+// before anything reads it. The corrected messages are persisted lazily: the
+// next Session.Save (naturally triggered by the following turn) rewrites the
+// whole file with the repairs baked in, so the same stale-data bug is not
+// re-repaired on every turn forever. A session that is only ever read (never
+// appended to) stays unmodified on disk and is simply re-normalized on the next
+// load — cheap, because the fast path returns the input slice unchanged.
+//
+// Well-formed histories are returned without allocating (see
+// provider.NormalizeMessages), so this is a no-op in both time and memory for
+// the common case and cannot perturb a provider's prefix-cache key.
+func NormalizeSession(msgs []provider.Message) []provider.Message {
+	return provider.NormalizeMessages(msgs)
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -77,15 +77,15 @@ func LoadSession(path string) (*Session, error) {
 		}
 		s.Messages = append(s.Messages, m)
 	}
-	// Repair the history in memory before anything reads it. Old sessions (pre
-	// adde2d3e) and interrupted turns can carry empty tool-call names, dangling
-	// tool_calls, orphan results, or half-streamed argument JSON that DeepSeek
-	// rejects with a 400 on replay. Normalizing once here — at the single
-	// source of truth — means the provider send path no longer has to re-repair
-	// the same stale data every turn. The fast path returns the input slice
-	// unchanged for a well-formed history, so we detect an actual repair by
-	// comparing slice headers: when NormalizeSession allocated a new backing
-	// array, the session is marked dirty so the next Save persists the fix.
+	// Repair persisted-history-safe issues before anything reads the session.
+	// Old sessions (pre adde2d3e) and interrupted turns can carry empty tool-call
+	// names, dangling tool_calls, or half-streamed argument JSON that DeepSeek
+	// rejects with a 400 on replay. Wire-only cleanup, such as dropping orphan
+	// tool messages, stays in the provider send path so Save/LoadSession keeps
+	// its round-trip contract. The fast path returns the input slice unchanged
+	// for a well-formed history, so we detect an actual repair by comparing
+	// slice headers: when NormalizeSession allocated a new backing array, the
+	// session is marked dirty so the next Save persists the fix.
 	normalized := NormalizeSession(s.Messages)
 	if len(normalized) != len(s.Messages) || (len(s.Messages) > 0 && &normalized[0] != &s.Messages[0]) {
 		s.normalizedDirty = true

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -77,6 +77,20 @@ func LoadSession(path string) (*Session, error) {
 		}
 		s.Messages = append(s.Messages, m)
 	}
+	// Repair the history in memory before anything reads it. Old sessions (pre
+	// adde2d3e) and interrupted turns can carry empty tool-call names, dangling
+	// tool_calls, orphan results, or half-streamed argument JSON that DeepSeek
+	// rejects with a 400 on replay. Normalizing once here — at the single
+	// source of truth — means the provider send path no longer has to re-repair
+	// the same stale data every turn. The fast path returns the input slice
+	// unchanged for a well-formed history, so we detect an actual repair by
+	// comparing slice headers: when NormalizeSession allocated a new backing
+	// array, the session is marked dirty so the next Save persists the fix.
+	normalized := NormalizeSession(s.Messages)
+	if len(normalized) != len(s.Messages) || (len(s.Messages) > 0 && &normalized[0] != &s.Messages[0]) {
+		s.normalizedDirty = true
+	}
+	s.Messages = normalized
 	return s, nil
 }
 

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -17,6 +17,12 @@ type Session struct {
 	mu             sync.RWMutex
 	Messages       []provider.Message
 	rewriteVersion int // bumped each time the log is rewritten (compact/fold)
+	// normalizedDirty is set when LoadSession repaired the history on the way in
+	// (empty tool-call names, dangling calls, truncated args, …). The repair
+	// already lives in Messages, so the next Save persists it automatically as
+	// part of the usual full rewrite; the flag exists for observability and to
+	// let callers opt out of work that a dirty session would make redundant.
+	normalizedDirty bool
 }
 
 // NewSession initializes a session with an optional system prompt.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -94,15 +94,38 @@ type Request struct {
 // responding to each 'tool_call_id'".
 const interruptedToolResult = "[no result: the previous turn was interrupted before this tool call completed]"
 
-// SanitizeToolPairing repairs a history so it satisfies the tool-call contract the
-// OpenAI-compatible and Anthropic APIs enforce: every assistant tool_calls entry
-// must be answered by a following tool message for its id, and a tool message must
-// follow such a call. It backfills a placeholder result for any unanswered call
-// (so the turn stays intact), drops orphan tool messages, and closes truncated
-// call-argument JSON (DeepSeek 400s on replayed half-streamed args, #3953).
-// Well-formed histories pass through unchanged (results stay in call order).
-// Callers send the result; the stored session keeps the original.
-func SanitizeToolPairing(msgs []Message) []Message {
+// SanitizeToolPairing is the provider-side alias for NormalizeMessages. It repairs
+// a history so it satisfies the tool-call contract the OpenAI-compatible and
+// Anthropic APIs enforce (every assistant tool_calls answered, no orphan tool
+// messages, truncated args closed) right before sending it to the wire — without
+// touching the stored session. Kept as a distinct name so call sites read as
+// "defensive wire prep" rather than "session mutation".
+func SanitizeToolPairing(msgs []Message) []Message { return NormalizeMessages(msgs) }
+
+// NormalizeMessages repairs a conversation history so it satisfies the tool-call
+// contract the OpenAI-compatible and Anthropic APIs enforce: every assistant
+// tool_calls entry must be answered by a following tool message for its id, and a
+// tool message must follow such a call. It backfills a placeholder result for any
+// unanswered call (so the turn stays intact), drops orphan tool messages,
+// backfills empty tool-call names from their results (#4727 — old sessions saved
+// before adde2d3e can carry an empty name), and closes truncated call-argument
+// JSON (DeepSeek 400s on replayed half-streamed args, #3953).
+//
+// This is the single source of truth for the repairs applied to a stored
+// conversation — both the agent's LoadSession (which persists the result lazily
+// via the next Save) and the provider's send path (SanitizeToolPairing) route
+// through it, so load-time and send-time never drift apart. That single-ownership
+// is what makes the #4727 → #4775 → revert churn impossible to reintroduce: a
+// behavior change lands in one place and both paths inherit it.
+//
+// A well-formed history — no unanswered calls, no orphan results, no empty tool-
+// call names, no truncated args — returns the input slice unchanged (same backing
+// array, zero allocation). This keeps the prefix-cache key stable for healthy
+// sessions and makes repeated normalization cheap.
+func NormalizeMessages(msgs []Message) []Message {
+	if normalized, ok := tryNormalizeFastPath(msgs); ok {
+		return normalized // well-formed: pass through without allocating
+	}
 	out := make([]Message, 0, len(msgs))
 	for i := 0; i < len(msgs); {
 		m := msgs[i]
@@ -131,6 +154,24 @@ func SanitizeToolPairing(msgs []Message) []Message {
 		i++
 	}
 	return out
+}
+
+// tryNormalizeFastPath reports whether msgs needs no repair and, if so, returns
+// it as-is so the caller can skip allocating. A history is repair-free when it
+// has no assistant tool_calls turns (nothing to pair), and no leading tool
+// messages (no orphans to drop). The per-turn deeper checks — name backfill,
+// arg repair — are handled by backfillToolCallNames/repairToolCallArgs own
+// fast paths once the slow path is entered.
+func tryNormalizeFastPath(msgs []Message) ([]Message, bool) {
+	for _, m := range msgs {
+		if m.Role == RoleAssistant && len(m.ToolCalls) > 0 {
+			return nil, false
+		}
+		if m.Role == RoleTool {
+			return nil, false
+		}
+	}
+	return msgs, true
 }
 
 // repairToolCallArgs returns m with any undecodable tool-call Arguments closed

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -111,19 +111,30 @@ func SanitizeToolPairing(msgs []Message) []Message { return NormalizeMessages(ms
 // before adde2d3e can carry an empty name), and closes truncated call-argument
 // JSON (DeepSeek 400s on replayed half-streamed args, #3953).
 //
-// This is the single source of truth for the repairs applied to a stored
-// conversation — both the agent's LoadSession (which persists the result lazily
-// via the next Save) and the provider's send path (SanitizeToolPairing) route
-// through it, so load-time and send-time never drift apart. That single-ownership
-// is what makes the #4727 → #4775 → revert churn impossible to reintroduce: a
-// behavior change lands in one place and both paths inherit it.
+// This is the wire-safe entry point for provider requests. Stored session loads
+// use NormalizeSessionMessages so they can share the assistant-turn repairs
+// without deleting standalone tool messages that must round-trip through
+// reasonix --resume.
 //
 // A well-formed history — no unanswered calls, no orphan results, no empty tool-
 // call names, no truncated args — returns the input slice unchanged (same backing
 // array, zero allocation). This keeps the prefix-cache key stable for healthy
 // sessions and makes repeated normalization cheap.
 func NormalizeMessages(msgs []Message) []Message {
-	if normalized, ok := tryNormalizeFastPath(msgs); ok {
+	return normalizeMessages(msgs, true)
+}
+
+// NormalizeSessionMessages applies only repairs that are safe to persist in a
+// saved session. It shares assistant-turn repairs with NormalizeMessages, but
+// preserves existing tool messages instead of dropping or reordering them so
+// Save/LoadSession remains a byte-for-byte conversation round trip for histories
+// that were already on disk.
+func NormalizeSessionMessages(msgs []Message) []Message {
+	return normalizeMessages(msgs, false)
+}
+
+func normalizeMessages(msgs []Message, dropOrphanTools bool) []Message {
+	if normalized, ok := tryNormalizeFastPath(msgs, dropOrphanTools); ok {
 		return normalized // well-formed: pass through without allocating
 	}
 	out := make([]Message, 0, len(msgs))
@@ -142,12 +153,20 @@ func NormalizeMessages(msgs []Message) []Message {
 			calls := backfillToolCallNames(m.ToolCalls, msgs[i+1:j])
 			m.ToolCalls = calls
 			out = append(out, repairToolCallArgs(m))
-			out = append(out, pairToolResults(calls, msgs[i+1:j])...)
+			if dropOrphanTools {
+				out = append(out, pairToolResults(calls, msgs[i+1:j])...)
+			} else {
+				out = append(out, sessionToolResults(calls, msgs[i+1:j])...)
+			}
 			i = j
 			continue
 		}
 		if m.Role == RoleTool {
-			i++ // orphan tool message (no preceding assistant tool_calls) — drop
+			if !dropOrphanTools {
+				out = append(out, m)
+			}
+			// Orphan tool message: provider sends drop it; session loads preserve it.
+			i++
 			continue
 		}
 		out = append(out, m)
@@ -157,21 +176,54 @@ func NormalizeMessages(msgs []Message) []Message {
 }
 
 // tryNormalizeFastPath reports whether msgs needs no repair and, if so, returns
-// it as-is so the caller can skip allocating. A history is repair-free when it
-// has no assistant tool_calls turns (nothing to pair), and no leading tool
-// messages (no orphans to drop). The per-turn deeper checks — name backfill,
-// arg repair — are handled by backfillToolCallNames/repairToolCallArgs own
-// fast paths once the slow path is entered.
-func tryNormalizeFastPath(msgs []Message) ([]Message, bool) {
-	for _, m := range msgs {
+// it as-is so the caller can skip allocating. Healthy tool-call/tool-result
+// turns pass through unchanged; malformed turns take the slow path.
+func tryNormalizeFastPath(msgs []Message, dropOrphanTools bool) ([]Message, bool) {
+	for i := 0; i < len(msgs); {
+		m := msgs[i]
 		if m.Role == RoleAssistant && len(m.ToolCalls) > 0 {
+			j := i + 1
+			for j < len(msgs) && msgs[j].Role == RoleTool {
+				j++
+			}
+			if !toolTurnWellFormed(m.ToolCalls, msgs[i+1:j]) || needsToolCallArgRepair(m.ToolCalls) {
+				return nil, false
+			}
+			i = j
+			continue
+		}
+		if m.Role == RoleTool && dropOrphanTools {
 			return nil, false
 		}
-		if m.Role == RoleTool {
-			return nil, false
-		}
+		i++
 	}
 	return msgs, true
+}
+
+func toolTurnWellFormed(calls []ToolCall, results []Message) bool {
+	if len(calls) != len(results) {
+		return false
+	}
+	for _, tc := range calls {
+		if tc.Name == "" {
+			return false
+		}
+	}
+	for k, tc := range calls {
+		if results[k].ToolCallID != tc.ID {
+			return false
+		}
+	}
+	return true
+}
+
+func needsToolCallArgRepair(calls []ToolCall) bool {
+	for _, tc := range calls {
+		if tc.Arguments != "" && !json.Valid([]byte(tc.Arguments)) {
+			return true
+		}
+	}
+	return false
 }
 
 // repairToolCallArgs returns m with any undecodable tool-call Arguments closed
@@ -285,6 +337,31 @@ func pairToolResults(calls []ToolCall, avail []Message) []Message {
 		} else {
 			out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
 		}
+	}
+	return out
+}
+
+// sessionToolResults preserves every stored tool result and appends placeholders
+// only for calls that have no recorded answer. Load-time normalization must not
+// drop or reorder user history; provider sends can still use pairToolResults for
+// strict wire formatting.
+func sessionToolResults(calls []ToolCall, avail []Message) []Message {
+	out := append([]Message(nil), avail...)
+	if idDistinct(calls) {
+		answered := make(map[string]struct{}, len(avail))
+		for _, r := range avail {
+			answered[r.ToolCallID] = struct{}{}
+		}
+		for _, tc := range calls {
+			if _, ok := answered[tc.ID]; !ok {
+				out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
+			}
+		}
+		return out
+	}
+	for k := len(avail); k < len(calls); k++ {
+		tc := calls[k]
+		out = append(out, Message{Role: RoleTool, ToolCallID: tc.ID, Name: tc.Name, Content: interruptedToolResult})
 	}
 	return out
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -91,10 +91,50 @@ func TestSanitizeToolPairingLeavesWellFormedUnchanged(t *testing.T) {
 	if len(out) != len(in) {
 		t.Fatalf("well-formed history changed length: %d -> %d", len(in), len(out))
 	}
+	if &out[0] != &in[0] {
+		t.Fatalf("well-formed history should return the input slice without allocating")
+	}
 	for i := range in {
 		if out[i].Role != in[i].Role || out[i].Content != in[i].Content || out[i].ToolCallID != in[i].ToolCallID {
 			t.Fatalf("well-formed message %d mutated: %+v -> %+v", i, in[i], out[i])
 		}
+	}
+}
+
+func TestNormalizeSessionMessagesPreservesStandaloneToolMessage(t *testing.T) {
+	in := []Message{
+		{Role: RoleSystem, Content: "sys"},
+		{Role: RoleUser, Content: "run it"},
+		{Role: RoleTool, ToolCallID: "c1", Name: "bash", Content: "large output"},
+	}
+	out := NormalizeSessionMessages(in)
+	if len(out) != len(in) {
+		t.Fatalf("session normalization changed length: %d -> %d", len(in), len(out))
+	}
+	if &out[0] != &in[0] {
+		t.Fatalf("session-safe orphan tool should keep the input slice unchanged")
+	}
+	if out[2].Role != RoleTool || out[2].Content != "large output" {
+		t.Fatalf("standalone tool message was not preserved: %+v", out)
+	}
+}
+
+func TestNormalizeSessionMessagesPreservesExtraToolResult(t *testing.T) {
+	in := []Message{
+		{Role: RoleAssistant, ToolCalls: []ToolCall{{ID: "c1", Name: "bash"}}},
+		{Role: RoleTool, ToolCallID: "c1", Name: "bash", Content: "ok"},
+		{Role: RoleTool, ToolCallID: "ghost", Name: "bash", Content: "saved extra output"},
+	}
+	out := NormalizeSessionMessages(in)
+	if len(out) != len(in) {
+		t.Fatalf("session normalization changed length: %d -> %d", len(in), len(out))
+	}
+	if out[2].ToolCallID != "ghost" || out[2].Content != "saved extra output" {
+		t.Fatalf("extra stored tool result was not preserved: %+v", out)
+	}
+	wire := SanitizeToolPairing(in)
+	if len(wire) != 2 {
+		t.Fatalf("wire sanitize should still drop the extra orphan result, got %+v", wire)
 	}
 }
 


### PR DESCRIPTION
## Issue
The back-and-forth cycle of #4727 -> #4775 -> revert came from the load path and send path carrying overlapping historical-message remediation logic. Logic drift made the same replay bug easy to reintroduce.

## Changes
- Kept `NormalizeMessages` as the provider wire-safe normalization entry point for tool-call name backfill, truncated-argument repair, orphan-result cleanup, and unanswered-call placeholders.
- Added `NormalizeSessionMessages` for `LoadSession`, sharing assistant-turn repairs while preserving existing stored tool messages so `Save`/`LoadSession` remains a round-trip contract.
- Refactored `SanitizeToolPairing` to delegate to `NormalizeMessages`.
- Tightened the fast path so healthy tool-call/tool-result histories return the original slice without allocation.
- Added coverage for standalone stored tool results, extra stored tool results, and healthy-history fast-path stability.
- Added the `normalizedDirty` field to `Session` to track sessions that have undergone persisted-safe remediation.

Cache-impact: low - provider-visible bytes for healthy histories stay unchanged, and the fast path now explicitly preserves the original slice for well-formed tool-call histories.
Cache-guard: `go test ./internal/provider -run 'TestSanitizeToolPairing|TestNormalizeSessionMessages|TestBackfill' -count=1`; `go test ./internal/agent -run 'TestSaveLoadRoundTrip|TestSaveLoadLargeMessage' -count=1`; `go test ./...`

## Related Files
- `internal/provider/provider.go` - `NormalizeMessages`, `NormalizeSessionMessages`, fast-path checks
- `internal/agent/normalize.go` - session-safe normalization wrapper
- `internal/agent/save.go` - `LoadSession` call site
- `internal/agent/session.go` - `normalizedDirty` field
- `internal/provider/provider_test.go` - normalization regression coverage

## 问题
#4727 -> #4775 -> revert 的反复折腾，根因是 load 路径和 send 路径各自维护历史消息修复逻辑，逻辑漂移后同类 replay bug 容易反复出现。

## 改动
- 保留 `NormalizeMessages` 作为 provider 发送前的 wire-safe 归一化入口，负责 tool-call name 回填、截断参数修复、孤立结果清理和未应答调用占位。
- 新增 `NormalizeSessionMessages` 给 `LoadSession` 使用，共享 assistant turn 修复，但保留磁盘里已有的 tool message，避免破坏 `Save`/`LoadSession` round-trip 合约。
- `SanitizeToolPairing` 委托 `NormalizeMessages`。
- 强化 fast path：健康的 tool-call/tool-result 历史会原 slice 返回，不分配。
- 补充 standalone/extra stored tool result 以及健康历史 fast-path 稳定性的测试。
- `Session` 新增 `normalizedDirty` 字段标记经过 persisted-safe 修复的会话。
