### PR TITLE
fix(desktop): refine project tree folder hover and startup expansion / 优化项目树文件夹悬停icon和启动时的文件夹展开逻辑

### DIFF
--- a/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
+++ b/desktop/frontend/src/__tests__/project-tree-runtime.test.ts
@@ -3,6 +3,7 @@
 import {
   projectTreeFolderDisclosure,
   defaultExpandedProjectTreeKeys,
+  activeSessionAncestorKeys,
   projectTreeTopicOpenRequest,
 } from "../components/ProjectTree";
 import type { ProjectNode } from "../lib/types";
@@ -62,8 +63,26 @@ const tree: ProjectNode[] = [
 
 eq(
   defaultExpandedProjectTreeKeys(tree),
+  [],
+  "without an active tab, no folders default to expanded",
+);
+
+eq(
+  defaultExpandedProjectTreeKeys(tree, "global", "", "topic-a", "/tmp/b.jsonl"),
   ["global_folder", "global_topic_topic-a"],
-  "runtime-session topic rows default to expanded so child sessions are visible",
+  "active session path expands only ancestor folders",
+);
+
+eq(
+  activeSessionAncestorKeys(tree, "global", "", "topic-a", "/tmp/b.jsonl"),
+  ["global_folder", "global_topic_topic-a"],
+  "activeSessionAncestorKeys matches defaultExpandedProjectTreeKeys for active session",
+);
+
+eq(
+  activeSessionAncestorKeys(tree, "global", "", "topic-b"),
+  ["global_folder"],
+  "active topic without runtime session rows expands only parent folders",
 );
 
 eq(

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -4,7 +4,7 @@
 // new topic.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, DragEvent as ReactDragEvent, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from "react";
-import { Archive, ArrowDown, ChevronRight, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2 } from "lucide-react";
+import { Archive, ArrowDown, Pencil, Plus, Folder, FolderPlus, Search, BriefcaseBusiness, Copy, FolderOpen, XCircle, History, Check, ListCollapse, ListRestart, MessageSquare, Clock, Pin, MoreHorizontal, Minimize2, Maximize2 } from "lucide-react";
 import { asArray } from "../lib/array";
 import { app } from "../lib/bridge";
 import type { ProjectNode, ProjectTopicStatus } from "../lib/types";
@@ -90,6 +90,7 @@ export function projectTreeFolderDisclosure(hasChildren: boolean, isExpanded: bo
 function topicIsActive(node: ProjectNode, activeScope?: string, activeWorkspaceRoot?: string, activeTopicId?: string, activeSessionPath?: string): boolean {
   if (!isTopicNode(node) && !isRuntimeSessionNode(node)) return false;
   if (node.sessionPath) return Boolean(activeSessionPath && activeSessionPath === node.sessionPath);
+  if (activeSessionPath && asArray(node.children).some(isRuntimeSessionNode)) return false;
   const scope = node.kind === "global_topic" ? "global" : "project";
   return (
     activeTopicId === node.topicId &&
@@ -247,20 +248,36 @@ function collapsibleFolderKeys(nodes: ProjectNode[], depth = 0): string[] {
   return keys;
 }
 
-export function defaultExpandedProjectTreeKeys(nodes: ProjectNode[], depth = 0): string[] {
-  const keys: string[] = [];
-  for (const node of nodes) {
-    if (!node) continue;
-    const children = asArray(node.children);
-    if ((node.kind === "project" || node.kind === "global_folder") && children.length > 0) {
-      keys.push(projectNodeKey(node, depth));
+export function activeSessionAncestorKeys(
+  nodes: ProjectNode[],
+  activeScope?: string,
+  activeWorkspaceRoot?: string,
+  activeTopicId?: string,
+  activeSessionPath?: string,
+): string[] {
+  const walk = (nodeList: ProjectNode[], ancestors: string[]): string[] | null => {
+    for (const node of nodeList) {
+      if (!node) continue;
+      if (topicIsActive(node, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath)) return ancestors;
+      const children = asArray(node.children);
+      if (children.length > 0) {
+        const next = walk(children, [...ancestors, projectNodeKey(node, ancestors.length)]);
+        if (next) return next;
+      }
     }
-    if (isTopicNode(node) && children.some(isRuntimeSessionNode)) {
-      keys.push(projectNodeKey(node, depth));
-    }
-    keys.push(...defaultExpandedProjectTreeKeys(children, depth + 1));
-  }
-  return keys;
+    return null;
+  };
+  return walk(nodes, []) ?? [];
+}
+
+export function defaultExpandedProjectTreeKeys(
+  nodes: ProjectNode[],
+  activeScope?: string,
+  activeWorkspaceRoot?: string,
+  activeTopicId?: string,
+  activeSessionPath?: string,
+): string[] {
+  return activeSessionAncestorKeys(nodes, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath);
 }
 
 function reorderedProjectRoots(nodes: ProjectNode[], draggedRoot: string, targetRoot: string, position: ProjectDropPosition): string[] {
@@ -480,7 +497,7 @@ export function ProjectTree({
       setExpanded((prev) => {
         const next = new Set(prev);
         const collapsed = manuallyCollapsedRef.current;
-        for (const key of defaultExpandedProjectTreeKeys(list)) {
+        for (const key of defaultExpandedProjectTreeKeys(list, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath)) {
           if (!collapsed.has(key)) next.add(key);
         }
         return next;
@@ -488,7 +505,7 @@ export function ProjectTree({
     } catch {
       /* bridge unavailable */
     }
-  }, []);
+  }, [activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath]);
 
   useEffect(() => {
     manuallyCollapsedRef.current = manuallyCollapsed;
@@ -903,21 +920,10 @@ export function ProjectTree({
     };
   }, [clearProjectDrag, dragProjectRoot]);
 
-  const activeAncestorKeys = useMemo(() => {
-    const walk = (nodes: ProjectNode[], ancestors: string[]): string[] | null => {
-      for (const node of nodes) {
-        if (!node) continue;
-        if (topicIsActive(node, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath)) return ancestors;
-        const children = asArray(node.children);
-        if (children.length > 0) {
-          const next = walk(children, [...ancestors, projectNodeKey(node, ancestors.length)]);
-          if (next) return next;
-        }
-      }
-      return null;
-    };
-    return walk(tree, []) ?? [];
-  }, [activeScope, activeSessionPath, activeTopicId, activeWorkspaceRoot, tree]);
+  const activeAncestorKeys = useMemo(
+    () => activeSessionAncestorKeys(tree, activeScope, activeWorkspaceRoot, activeTopicId, activeSessionPath),
+    [activeScope, activeSessionPath, activeTopicId, activeWorkspaceRoot, tree],
+  );
 
   useEffect(() => {
     if (activeAncestorKeys.length === 0) return;
@@ -1403,11 +1409,6 @@ export function ProjectTree({
             aria-expanded={folderDisclosure.ariaExpanded}
           >
             <span className={folderDisclosure.iconStackClassName}>
-              {folderDisclosure.canExpand && (
-                <span className={`project-tree__chevron project-tree__chevron--on-hover${folderDisclosure.isOpen ? " project-tree__chevron--open" : ""}`}>
-                  <ChevronRight size={16} strokeWidth={2} />
-                </span>
-              )}
               {folderDisclosure.isOpen ? <FolderOpen size={14} className="project-tree__folder-icon" /> : <Folder size={14} className="project-tree__folder-icon" />}
             </span>
             <span className="project-tree__folder-color" aria-hidden="true" />

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -17433,19 +17433,7 @@ a[href] {
   overflow: hidden;
 }
 
-/* Chevron rotates 90° on expand; single icon keeps the rotation smooth. */
-.project-tree__chevron {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  transition: transform 0.2s ease;
-}
-
-.project-tree__chevron--open {
-  transform: rotate(90deg);
-}
-
-/* Project tree: icon stack holds chevron + folder icon at same position */
+/* Project tree: icon stack holds folder open/closed icon */
 .project-tree__icon-stack {
   display: inline-flex;
   align-items: center;
@@ -17459,31 +17447,6 @@ a[href] {
   width: 14px;
   height: 14px;
   color: var(--fg-faint);
-}
-.project-tree__icon-stack > .project-tree__chevron {
-  position: absolute;
-  color: var(--fg-faint);
-}
-/* Override workbench width constraint on chevron */
-.sidebar--workbench .project-tree__icon-stack > .project-tree__chevron {
-  width: auto;
-  height: auto;
-}
-.project-tree__icon-stack > .project-tree__chevron > svg {
-  display: block;
-}
-/* Default: hide chevron, show folder icon */
-.project-tree__chevron--on-hover {
-  display: none;
-}
-/* Hover: show chevron, hide folder icon */
-:root[data-theme-style] .project-tree__folder-main:hover .project-tree__icon-stack--expandable .project-tree__chevron--on-hover,
-.project-tree__folder-main:hover .project-tree__icon-stack--expandable .project-tree__chevron--on-hover {
-  display: inline-flex;
-}
-:root[data-theme-style] .project-tree__folder-main:hover .project-tree__icon-stack--expandable > .project-tree__folder-icon,
-.project-tree__folder-main:hover .project-tree__icon-stack--expandable > .project-tree__folder-icon {
-  display: none;
 }
 /* Topic hover/active effect: full row width (remove left margin) */
 :root[data-theme-style] .sidebar--workbench .project-tree__topic {
@@ -17550,13 +17513,13 @@ a[href] {
 }
 
 /* Folder: no active background, but very weak hover hint */
-:root[data-theme-style] .sidebar--workbench .project-tree__folder:hover {
+:root[data-theme-style] .sidebar--workbench .project-tree__folder:hover,
+:root[data-theme-style] .sidebar--workbench .project-tree__folder--active:hover,
+:root[data-theme-style] .sidebar--workbench .project-tree__folder--menu-open:hover {
   background: color-mix(in srgb, var(--sidebar-hover) 60%, transparent);
 }
 :root[data-theme-style] .sidebar--workbench .project-tree__folder--active,
-:root[data-theme-style] .sidebar--workbench .project-tree__folder--menu-open,
-:root[data-theme-style] .sidebar--workbench .project-tree__folder--active:hover,
-:root[data-theme-style] .sidebar--workbench .project-tree__folder--menu-open:hover {
+:root[data-theme-style] .sidebar--workbench .project-tree__folder--menu-open {
   background: transparent;
 }
 
@@ -17613,8 +17576,7 @@ a[href] {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .project-tree__children,
-  .project-tree__chevron {
+  .project-tree__children {
     transition: none;
   }
 
@@ -18628,9 +18590,13 @@ a[href] {
 }
 
 .project-tree__folder--active,
-.project-tree__folder--menu-open,
-.project-tree__folder--active:hover {
+.project-tree__folder--menu-open {
   background: color-mix(in srgb, var(--project-accent, var(--accent)) 7%, var(--bg-elev));
+}
+
+.project-tree__folder--active:hover,
+.project-tree__folder--menu-open:hover {
+  background: var(--sidebar-hover);
 }
 
 .project-tree__topic {
@@ -19728,9 +19694,14 @@ a[href] {
 }
 
 :root[data-theme-style] .project-tree__folder--active,
-:root[data-theme-style] .project-tree__folder--menu-open,
-:root[data-theme-style] .project-tree__folder--active:hover {
+:root[data-theme-style] .project-tree__folder--menu-open {
   background: color-mix(in srgb, var(--project-accent, var(--accent)) 5%, transparent);
+  color: var(--fg);
+}
+
+:root[data-theme-style] .project-tree__folder--active:hover,
+:root[data-theme-style] .project-tree__folder--menu-open:hover {
+  background: var(--sidebar-hover);
   color: var(--fg);
 }
 
@@ -21795,13 +21766,15 @@ a[href] {
   font-weight: 500;
 }
 
-.sidebar--workbench .project-tree__folder:hover {
-  background: transparent;
+.sidebar--workbench .project-tree__folder:hover,
+.sidebar--workbench .project-tree__folder--active:hover,
+.sidebar--workbench .project-tree__folder--menu-open:hover {
+  background: var(--sidebar-hover);
   color: var(--fg);
 }
 
 .sidebar--workbench .project-tree__folder--active,
-.sidebar--workbench .project-tree__folder--active:hover {
+.sidebar--workbench .project-tree__folder--menu-open {
   background: transparent;
   color: var(--fg);
 }
@@ -21830,18 +21803,13 @@ a[href] {
   stroke-width: 1.9;
 }
 
-.sidebar--workbench .project-tree__folder:hover .project-tree__folder-main > svg,
-.sidebar--workbench .project-tree__folder--active .project-tree__folder-main > svg {
+.sidebar--workbench .project-tree__folder:hover .project-tree__folder-icon,
+.sidebar--workbench .project-tree__folder--active:hover .project-tree__folder-icon {
   color: var(--fg);
 }
 
 .sidebar--workbench .project-tree__folder-color {
   display: none;
-}
-
-.sidebar--workbench .project-tree__chevron {
-  width: 12px;
-  color: var(--fg-faint);
 }
 
 .sidebar--workbench .project-tree__folder-action-slot {


### PR DESCRIPTION
## Summary

- 项目树文件夹 hover 时始终显示开/关文件夹图标，不再切换为 `>` chevron
- 启动时仅默认展开当前会话的祖先路径，不再递归展开所有项目/文件夹
- 修复当前会话所在项目文件夹 hover 无背景高亮的问题（workbench 与 classic 均适用）
- 新增 `activeSessionAncestorKeys` 辅助函数，并修正多 runtime session 场景下的 active 匹配逻辑

## Test plan

- [ ] 启动桌面应用，确认侧边栏仅当前 tab 对应路径展开，其余文件夹折叠
- [ ] 切换 tab，确认新会话路径自动展开；手动折叠的节点不被强制展开
- [ ] hover 可展开文件夹：显示 `Folder` / `FolderOpen`，无 `>` 符号
- [ ] hover 当前会话所在的项目文件夹：背景与图标高亮与其他文件夹一致
- [ ] 分别验证 workbench 与 classic 两种侧边栏布局
- [ ] 搜索项目树时仍全部展开
- [ ] `cd desktop/frontend && ./node_modules/.bin/tsx src/__tests__/project-tree-runtime.test.ts`