### PR TITLE
Fix reusable blank tab title reset / 修复复用空白标签页标题重置

### DIFF
--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -101,6 +101,67 @@ func TestEnsureBlankTabCreatesOneBlankPerProject(t *testing.T) {
 	}
 }
 
+func TestEnsureBlankTabResetsReusableAutoTopicTitle(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := setTopicTitleWithSource(projectRoot, topic.ID, "Old auto title", topicTitleSourceAuto); err != nil {
+		t.Fatalf("set stale auto title: %v", err)
+	}
+	tab := app.createTabEntryWithID("project", projectRoot, topic.ID, "tab1")
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	meta, err := app.EnsureBlankTab("project", projectRoot)
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if got := meta.TopicTitle; got != defaultTopicTitle {
+		t.Fatalf("reused auto topic title = %q, want %q", got, defaultTopicTitle)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != defaultTopicTitle {
+		t.Fatalf("stored title = %q, want %q", got, defaultTopicTitle)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceAuto {
+		t.Fatalf("title source = %q, want auto", got)
+	}
+}
+
+func TestEnsureBlankTabPreservesReusableManualTopicTitle(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "Manual title")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	tab := app.createTabEntryWithID("project", projectRoot, topic.ID, "tab1")
+	app.tabs[tab.ID] = tab
+	app.tabOrder = []string{tab.ID}
+	app.activeTabID = tab.ID
+
+	meta, err := app.EnsureBlankTab("project", projectRoot)
+	if err != nil {
+		t.Fatalf("EnsureBlankTab: %v", err)
+	}
+	if got := meta.TopicTitle; got != "Manual title" {
+		t.Fatalf("reused manual topic title = %q, want Manual title", got)
+	}
+	if got := loadTopicTitle(projectRoot, topic.ID); got != "Manual title" {
+		t.Fatalf("stored title = %q, want Manual title", got)
+	}
+	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
+		t.Fatalf("title source = %q, want manual", got)
+	}
+}
+
 // EnsureBlankTab picks up an existing blank topic created in the sidebar
 // instead of creating a fresh topic, for global scope.
 

--- a/desktop/app_session_dedup_test.go
+++ b/desktop/app_session_dedup_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -159,6 +160,41 @@ func TestEnsureBlankTabPreservesReusableManualTopicTitle(t *testing.T) {
 	}
 	if got := loadTopicTitleSource(projectRoot, topic.ID); got != topicTitleSourceManual {
 		t.Fatalf("title source = %q, want manual", got)
+	}
+}
+
+func TestEnsureBlankTabKeepsActiveTabWhenTitleResetFails(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	app := NewApp()
+	topic, err := app.CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	if err := setTopicTitleWithSource(projectRoot, topic.ID, "Old auto title", topicTitleSourceAuto); err != nil {
+		t.Fatalf("set stale auto title: %v", err)
+	}
+	activeTab := app.createTabEntryWithID("global", globalTabWorkspaceRoot(), "", "active-tab")
+	reusableTab := app.createTabEntryWithID("project", projectRoot, topic.ID, "reusable-tab")
+	app.tabs[activeTab.ID] = activeTab
+	app.tabs[reusableTab.ID] = reusableTab
+	app.tabOrder = []string{activeTab.ID, reusableTab.ID}
+	app.activeTabID = activeTab.ID
+
+	titlePath := topicTitlesPath(projectRoot)
+	if err := os.Remove(titlePath); err != nil {
+		t.Fatalf("remove title file: %v", err)
+	}
+	if err := os.Mkdir(titlePath, 0o755); err != nil {
+		t.Fatalf("replace title file with directory: %v", err)
+	}
+
+	if _, err := app.EnsureBlankTab("project", projectRoot); err == nil {
+		t.Fatal("EnsureBlankTab succeeded, want title reset error")
+	}
+	if got := app.activeTabID; got != activeTab.ID {
+		t.Fatalf("active tab after failed title reset = %q, want %q", got, activeTab.ID)
 	}
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1115,6 +1115,10 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 		tab := a.tabs[id]
 		if a.blankTabMatchesTargetLocked(tab, scope, workspaceRoot) {
 			a.activeTabID = tab.ID
+			if err := resetReusableBlankTabTitle(tab, scope, workspaceRoot); err != nil {
+				a.mu.Unlock()
+				return TabMeta{}, err
+			}
 			meta := a.tabMeta(tab, true)
 			a.saveTabsLocked()
 			a.mu.Unlock()
@@ -1238,6 +1242,25 @@ func (a *App) blankTabMatchesTargetLocked(tab *WorkspaceTab, scope, workspaceRoo
 		return false
 	}
 	return !messagesHaveConversationContent(tab.Ctrl.History())
+}
+
+func resetReusableBlankTabTitle(tab *WorkspaceTab, scope, workspaceRoot string) error {
+	if tab == nil {
+		return nil
+	}
+	topicID := strings.TrimSpace(tab.TopicID)
+	if topicID == "" {
+		return nil
+	}
+	titleRoot := topicTitleRoot(scope, workspaceRoot)
+	if source := loadTopicTitleSource(titleRoot, topicID); source != topicTitleSourceAuto {
+		return nil
+	}
+	if err := setTopicTitleWithSource(titleRoot, topicID, defaultTopicTitle, topicTitleSourceAuto); err != nil {
+		return err
+	}
+	tab.TopicTitle = defaultTopicTitle
+	return nil
 }
 
 // indexedBlankTopicIDLocked finds a blank topic ID that is indexed on disk

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1114,11 +1114,11 @@ func (a *App) EnsureBlankTab(scope, workspaceRoot string) (TabMeta, error) {
 	for _, id := range a.orderedTabIDsLocked() {
 		tab := a.tabs[id]
 		if a.blankTabMatchesTargetLocked(tab, scope, workspaceRoot) {
-			a.activeTabID = tab.ID
 			if err := resetReusableBlankTabTitle(tab, scope, workspaceRoot); err != nil {
 				a.mu.Unlock()
 				return TabMeta{}, err
 			}
+			a.activeTabID = tab.ID
 			meta := a.tabMeta(tab, true)
 			a.saveTabsLocked()
 			a.mu.Unlock()


### PR DESCRIPTION
## Summary

Supersedes #4799 with a PR title/body that matches the final implementation.

- Reset a reused blank tab title only when the topic title source is `auto`.
- Preserve manually renamed blank topics when `EnsureBlankTab` reuses an open blank tab.
- Keep the stored topic title/source consistent with the returned tab metadata.
- Keep the backend active tab unchanged if the reusable blank title reset fails.
- Add focused regressions for auto-title reset, manual-title preservation, and failed title-reset active-tab stability.

## Bot feedback audit from #4799

- The three `App.tsx` metadata-pending comments were valid for the intermediate frontend fallback change in #4799, but that frontend change was reverted and is not part of this PR. No extra frontend fix is needed here.
- The manually named blank topic comment was valid. This PR fixes it by checking the topic title source before resetting the reusable blank tab title.

## Bot feedback audit from #4819

- The active-tab-before-fallible-reset comment was valid. This PR now runs the title reset before updating `activeTabID`, so a reset failure does not desynchronize backend and frontend active-tab state.

## Verification

- `go test ./... -run 'TestEnsureBlankTab' -count=1` from `desktop`
- `go test ./...` from `desktop`
- `git diff --check`
- PR CI is green on the latest head commit.

Authorship note: @ttmouse is the primary author of this PR. @SivanCola contributed as a collaborator by reviewing #4799, fixing the follow-up title/reset issues, and verifying the final state.