### PR TITLE
feat(goal): add OMO-inspired enforcement features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ Thumbs.db
 /site/public/av/
 
 benchmarks/context-maintenance-e2e/run/
+desktop-test.exe

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -827,6 +827,13 @@ func (a *Agent) finalReadinessFailure() string {
 	return a.finalReadinessCheck().reason
 }
 
+// GoalReadinessFailure returns the final-readiness failure reason — a summary of
+// incomplete todos and unverified project checks — or empty string if none.
+// Exported so the Controller can gate [goal:complete] on evidence.
+func (a *Agent) GoalReadinessFailure() string {
+	return a.finalReadinessFailure()
+}
+
 type finalReadinessCheck struct {
 	applies              bool
 	reason               string

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/jobs"
+	"reasonix/internal/tool"
+)
+
+// ParallelTasksTool dispatches multiple sub-agent tasks concurrently and
+// collects all results. Each task runs in its own background sub-agent; the
+// tool blocks until every task finishes, then returns the aggregated output.
+// It wraps an inner *TaskTool to reuse its sub-agent machinery.
+type ParallelTasksTool struct {
+	taskTool *TaskTool
+	reg      *tool.Registry
+}
+
+// NewParallelTasksTool creates a parallel dispatch tool that reuses the given
+// TaskTool's sub-agent infrastructure.
+func NewParallelTasksTool(taskTool *TaskTool, reg *tool.Registry) *ParallelTasksTool {
+	return &ParallelTasksTool{taskTool: taskTool, reg: reg}
+}
+
+func (p *ParallelTasksTool) Name() string { return "parallel_tasks" }
+
+func (p *ParallelTasksTool) Description() string {
+	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all complete."
+}
+
+func (p *ParallelTasksTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "tasks":{
+    "type":"array",
+    "description":"Array of sub-task descriptions to run in parallel.",
+    "items":{
+      "type":"object",
+      "properties":{
+        "prompt":{"type":"string","description":"The task prompt for the sub-agent."},
+        "description":{"type":"string","description":"Optional short label shown in the job list."},
+        "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist for the sub-agent."},
+        "max_steps":{"type":"integer","description":"Optional max tool-call rounds.","minimum":1},
+        "model":{"type":"string","description":"Optional model override."},
+        "effort":{"type":"string","description":"Optional reasoning effort override."}
+      },
+      "required":["prompt"]
+    }
+  }
+},
+"required":["tasks"]
+}`)
+}
+
+func (p *ParallelTasksTool) ReadOnly() bool { return true }
+
+// ParallelTaskItem mirrors one entry in the schema's tasks array.
+type ParallelTaskItem struct {
+	Prompt      string   `json:"prompt"`
+	Description string   `json:"description"`
+	Tools       []string `json:"tools"`
+	MaxSteps    int      `json:"max_steps"`
+	Model       string   `json:"model"`
+	Effort      string   `json:"effort"`
+}
+
+func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var params struct {
+		Tasks []ParallelTaskItem `json:"tasks"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if len(params.Tasks) == 0 {
+		return "", fmt.Errorf("at least one task is required")
+	}
+	if len(params.Tasks) == 1 {
+		return "", fmt.Errorf("parallel_tasks with a single task is equivalent to task; use task instead")
+	}
+
+	jm, ok := jobs.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("background jobs are not available in this context")
+	}
+	session := jobs.SessionFromContext(ctx)
+
+	type jobRef struct {
+		id    string
+		label string
+	}
+	var refs []jobRef
+
+	for i, t := range params.Tasks {
+		if strings.TrimSpace(t.Prompt) == "" {
+			return "", fmt.Errorf("task %d: prompt is required", i+1)
+		}
+		label := t.Description
+		if label == "" {
+			label = fmt.Sprintf("task-%d", i+1)
+		}
+
+		subArgs := map[string]interface{}{
+			"prompt":            t.Prompt,
+			"description":       label,
+			"run_in_background": true,
+		}
+		if len(t.Tools) > 0 {
+			subArgs["tools"] = t.Tools
+		}
+		if t.MaxSteps > 0 {
+			subArgs["max_steps"] = t.MaxSteps
+		}
+		if t.Model != "" {
+			subArgs["model"] = t.Model
+		}
+		if t.Effort != "" {
+			subArgs["effort"] = t.Effort
+		}
+
+		subJSON, err := json.Marshal(subArgs)
+		if err != nil {
+			return "", fmt.Errorf("task %d: marshal: %w", i+1, err)
+		}
+
+		result, err := p.taskTool.Execute(ctx, subJSON)
+		if err != nil {
+			return "", fmt.Errorf("task %d dispatch: %w", i+1, err)
+		}
+		refs = append(refs, jobRef{id: extractJobID(result), label: label})
+		_ = result
+	}
+
+	if len(refs) == 0 {
+		return "", fmt.Errorf("no tasks were dispatched")
+	}
+
+	jobIDs := make([]string, len(refs))
+	for i, r := range refs {
+		jobIDs[i] = r.id
+	}
+
+	results := jm.WaitForSession(ctx, session, jobIDs, 0)
+	if len(results) == 0 {
+		return "No parallel task results available.", nil
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", len(results)))
+	for i, r := range results {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		label := r.ID
+		if r.Label != "" {
+			label = r.Label
+		}
+		fmt.Fprintf(&b, "── %s ──\n[%s] %s\n%s", label, r.ID, r.Status, strings.TrimSpace(r.Output))
+	}
+	return b.String(), nil
+}
+
+// extractJobID pulls the background job id from a task tool start message.
+func extractJobID(msg string) string {
+	quote := strings.Index(msg, `"`)
+	if quote < 0 {
+		return ""
+	}
+	end := strings.Index(msg[quote+1:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return msg[quote+1 : quote+1+end]
+}

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -5,15 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
+	"reasonix/internal/event"
 	"reasonix/internal/jobs"
+	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
 // ParallelTasksTool dispatches multiple sub-agent tasks concurrently and
-// collects all results. Each task runs in its own background sub-agent; the
-// tool blocks until every task finishes, then returns the aggregated output.
-// It wraps an inner *TaskTool to reuse its sub-agent machinery.
+// collects all results. Each sub-task runs as a foreground sub-agent in its
+// own goroutine, emitting nested events so the frontend renders independent
+// cards for each sub-task.
 type ParallelTasksTool struct {
 	taskTool *TaskTool
 	reg      *tool.Registry
@@ -28,7 +31,7 @@ func NewParallelTasksTool(taskTool *TaskTool, reg *tool.Registry) *ParallelTasks
 func (p *ParallelTasksTool) Name() string { return "parallel_tasks" }
 
 func (p *ParallelTasksTool) Description() string {
-	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all complete."
+	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all tasks complete."
 }
 
 func (p *ParallelTasksTool) Schema() json.RawMessage {
@@ -42,8 +45,8 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
       "type":"object",
       "properties":{
         "prompt":{"type":"string","description":"The task prompt for the sub-agent."},
-        "description":{"type":"string","description":"Optional short label shown in the job list."},
-        "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist for the sub-agent."},
+        "description":{"type":"string","description":"Optional short label."},
+        "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist."},
         "max_steps":{"type":"integer","description":"Optional max tool-call rounds.","minimum":1},
         "model":{"type":"string","description":"Optional model override."},
         "effort":{"type":"string","description":"Optional reasoning effort override."}
@@ -58,8 +61,7 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
 
 func (p *ParallelTasksTool) ReadOnly() bool { return true }
 
-// ParallelTaskItem mirrors one entry in the schema's tasks array.
-type ParallelTaskItem struct {
+type parallelTaskItem struct {
 	Prompt      string   `json:"prompt"`
 	Description string   `json:"description"`
 	Tools       []string `json:"tools"`
@@ -70,7 +72,7 @@ type ParallelTaskItem struct {
 
 func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
-		Tasks []ParallelTaskItem `json:"tasks"`
+		Tasks []parallelTaskItem `json:"tasks"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -82,6 +84,129 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		return "", fmt.Errorf("parallel_tasks with a single task is equivalent to task; use task instead")
 	}
 
+	parentID, sink, _, ok := CallContext(ctx)
+	if !ok || sink == nil {
+		// Fallback: no event sink available, use background-jobs approach.
+		return p.runAsBackgroundJobs(ctx, params.Tasks)
+	}
+
+	type subResult struct {
+		index   int
+		output  string
+		err     error
+	}
+
+	results := make(chan subResult, len(params.Tasks))
+	var wg sync.WaitGroup
+
+	for i, task := range params.Tasks {
+		if strings.TrimSpace(task.Prompt) == "" {
+			return "", fmt.Errorf("task %d: prompt is required", i+1)
+		}
+
+		wg.Add(1)
+		go func(idx int, t parallelTaskItem) {
+			defer wg.Done()
+
+			label := t.Description
+			if label == "" {
+				label = fmt.Sprintf("task-%d", idx+1)
+			}
+
+			// Each sub-task gets a unique ID nested under the parent call.
+			subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
+
+			// Emit ToolDispatch so the frontend shows a card.
+			dispatchArgs, _ := json.Marshal(map[string]string{"prompt": t.Prompt, "description": label})
+			sink.Emit(event.Event{
+				Kind: event.ToolDispatch,
+				Tool: event.Tool{
+					ID:       subID,
+					ParentID: parentID,
+					Name:     "task",
+					Args:     string(dispatchArgs),
+					ReadOnly: true,
+				},
+			})
+
+			// Build a nested sink so sub-agent events nest under this sub-task.
+			nested := subSinkFor(subID, sink)
+
+			// Resolve provider, build sub-registry, and run.
+			modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
+			subReg := p.taskTool.buildSubReg(t.Tools)
+
+			maxSteps := t.MaxSteps
+			if maxSteps <= 0 {
+				maxSteps = 20
+			}
+
+			prov, pricing, ctxWin, err := resolveSubagentProvider(p.taskTool, modelRef, effortRef)
+			if err != nil {
+				sink.Emit(event.Event{
+					Kind: event.ToolResult,
+					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: err.Error()},
+				})
+				results <- subResult{index: idx, err: err}
+				return
+			}
+
+			sess := NewSession("")
+			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
+				MaxSteps:          maxSteps,
+				Temperature:       p.taskTool.temperature,
+				Pricing:           pricing,
+				UsageSource:       event.UsageSourceSubagent,
+				Gate:              p.taskTool.gate,
+				ContextWindow:     ctxWin,
+				RecentKeep:        p.taskTool.recentKeep,
+				SoftCompactRatio:  p.taskTool.softCompactRatio,
+				CompactRatio:      p.taskTool.compactRatio,
+				CompactForceRatio: p.taskTool.compactForceRatio,
+				ArchiveDir:        p.taskTool.archiveDir,
+				KeepPolicy:        p.taskTool.keepPolicy,
+			}, nested)
+
+			if runErr != nil {
+				sink.Emit(event.Event{
+					Kind: event.ToolResult,
+					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: runErr.Error()},
+				})
+				results <- subResult{index: idx, err: runErr}
+				return
+			}
+
+			sink.Emit(event.Event{
+				Kind: event.ToolResult,
+				Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Output: output},
+			})
+			results <- subResult{index: idx, output: output}
+		}(i, task)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Collect in order.
+	ordered := make([]subResult, len(params.Tasks))
+	for r := range results {
+		ordered[r.index] = r
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", len(params.Tasks)))
+	for _, r := range ordered {
+		if r.err != nil {
+			fmt.Fprintf(&b, "── task-%d ──\n[FAILED] %s\n", r.index+1, r.err)
+		} else {
+			fmt.Fprintf(&b, "── task-%d ──\n%s\n", r.index+1, strings.TrimSpace(r.output))
+		}
+	}
+	return b.String(), nil
+}
+
+// runAsBackgroundJobs is the fallback path when no event sink is available.
+func (p *ParallelTasksTool) runAsBackgroundJobs(ctx context.Context, tasks []parallelTaskItem) (string, error) {
 	jm, ok := jobs.FromContext(ctx)
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
@@ -91,10 +216,11 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	type jobRef struct {
 		id    string
 		label string
+		idx   int
 	}
 	var refs []jobRef
 
-	for i, t := range params.Tasks {
+	for i, t := range tasks {
 		if strings.TrimSpace(t.Prompt) == "" {
 			return "", fmt.Errorf("task %d: prompt is required", i+1)
 		}
@@ -130,7 +256,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		if err != nil {
 			return "", fmt.Errorf("task %d dispatch: %w", i+1, err)
 		}
-		refs = append(refs, jobRef{id: extractJobID(result), label: label})
+		refs = append(refs, jobRef{id: extractJobID(result), label: label, idx: i})
 		_ = result
 	}
 
@@ -139,8 +265,10 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	}
 
 	jobIDs := make([]string, len(refs))
-	for i, r := range refs {
-		jobIDs[i] = r.id
+	order := make(map[string]int)
+	for _, r := range refs {
+		jobIDs = append(jobIDs, r.id)
+		order[r.id] = r.idx
 	}
 
 	results := jm.WaitForSession(ctx, session, jobIDs, 0)
@@ -150,20 +278,28 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", len(results)))
-	for i, r := range results {
-		if i > 0 {
-			b.WriteString("\n")
-		}
+	for _, r := range results {
+		idx := order[r.ID]
 		label := r.ID
 		if r.Label != "" {
 			label = r.Label
 		}
 		fmt.Fprintf(&b, "── %s ──\n[%s] %s\n%s", label, r.ID, r.Status, strings.TrimSpace(r.Output))
+		_ = idx
 	}
 	return b.String(), nil
 }
 
-// extractJobID pulls the background job id from a task tool start message.
+// resolveSubagentProvider resolves a provider for a sub-agent, using the
+// TaskTool's resolver or falling back to the task tool's own provider.
+func resolveSubagentProvider(tt *TaskTool, modelRef, effortRef string) (provider.Provider, *provider.Pricing, int, error) {
+	if tt.resolveProvider != nil && (modelRef != "" || effortRef != "") {
+		return tt.resolveProvider(modelRef, effortRef)
+	}
+	// Use the task tool's own defaults.
+	return tt.prov, tt.pricing, tt.contextWindow, nil
+}
+
 func extractJobID(msg string) string {
 	quote := strings.Index(msg, `"`)
 	if quote < 0 {

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -459,13 +459,15 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return "task tool is already enabled."
 		}
 		taskToolAdded = true
-		reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
+		tt := agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
 			entry.ContextWindow, cfg.Agent.RecentKeep, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
 			cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate,
 			keepPolicy,
 			taskModel, taskEffort, resolveSubagentProvider).
 			WithTranscripts(subagentStore, root, modelName, entry.Effort).
-			WithTranscriptIdentityResolver(subagentIdentity))
+			WithTranscriptIdentityResolver(subagentIdentity)
+		reg.Add(tt)
+		reg.Add(agent.NewParallelTasksTool(tt, reg))
 		return "enabled task."
 	}
 	if !tokenEconomy {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -126,17 +126,17 @@ type Controller struct {
 
 	// mu guards the run state and approval bookkeeping; every critical section
 	// under it is short and non-blocking.
-	mu          sync.Mutex
-	cancel      context.CancelFunc
-	running     bool
-	canceling   bool
-	autosaveWG  sync.WaitGroup
-	planMode    bool
-	goal        string
-	goalStatus  string
-	goalTurns   int
-	goalBlocks  int
-	goalBlock   string
+	mu         sync.Mutex
+	cancel     context.CancelFunc
+	running    bool
+	canceling  bool
+	autosaveWG sync.WaitGroup
+	planMode   bool
+	goal       string
+	goalStatus string
+	goalTurns  int
+	goalBlocks int
+	goalBlock  string
 	// goalInterceptMsg, when non-empty, overrides the generic goalContinueTurn prompt
 	// for the next continuation turn. Used by advanceGoalAfterTurn to inject specific
 	// feedback such as incomplete-todo reminders.
@@ -154,11 +154,11 @@ type Controller struct {
 	// injected for the current goal. On first [goal:complete] with all todos
 	// done, the agent is asked to self-verify before final completion.
 	goalSelfCheckDone bool
-	sessionPath string
-	approvals   map[string]pendingApproval
-	asks        map[string]pendingAsk
-	granted     map[string]bool
-	nextID      int
+	sessionPath       string
+	approvals         map[string]pendingApproval
+	asks              map[string]pendingAsk
+	granted           map[string]bool
+	nextID            int
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
 	// approvedPlanAutoApproveTools auto-allows writer tool calls without prompting.
@@ -242,8 +242,8 @@ const (
 )
 
 const (
-	maxGoalAutoTurns = 50
-	goalContinueTurn = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
+	maxGoalAutoTurns  = 50
+	goalContinueTurn  = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
 	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
 )
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -137,6 +137,23 @@ type Controller struct {
 	goalTurns   int
 	goalBlocks  int
 	goalBlock   string
+	// goalInterceptMsg, when non-empty, overrides the generic goalContinueTurn prompt
+	// for the next continuation turn. Used by advanceGoalAfterTurn to inject specific
+	// feedback such as incomplete-todo reminders.
+	goalInterceptMsg string
+	// goalIntercepts counts consecutive incomplete-todo intercepts for the current
+	// goal. After the first intercept, the agent is reminded to update its todo
+	// list if the work is actually done; a second consecutive claim of completion
+	// is treated as an override and let through.
+	goalIntercepts int
+	// goalStrict, when true, disables the override escape hatch: every
+	// [goal:complete] while todos are incomplete is intercepted, and the
+	// agent must actually finish or update all items before it can complete.
+	goalStrict bool
+	// goalSelfCheckDone tracks whether the quality self-check prompt has been
+	// injected for the current goal. On first [goal:complete] with all todos
+	// done, the agent is asked to self-verify before final completion.
+	goalSelfCheckDone bool
 	sessionPath string
 	approvals   map[string]pendingApproval
 	asks        map[string]pendingAsk
@@ -227,6 +244,7 @@ const (
 const (
 	maxGoalAutoTurns = 50
 	goalContinueTurn = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
+	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
 )
 
 // RememberResult describes what happened when an approval rule was persisted.
@@ -646,7 +664,17 @@ func (c *Controller) continueGoal(ctx context.Context) error {
 			c.stopGoal(GoalStatusStopped)
 			return err
 		}
-		if err := c.runTurnWithRawDisplay(ctx, goalContinueTurn, goalContinueTurn, ""); err != nil {
+		turn := goalContinueTurn
+		c.mu.Lock()
+		if c.goalInterceptMsg != "" {
+			turn = c.goalInterceptMsg
+			c.goalInterceptMsg = ""
+			c.mu.Unlock()
+			c.notice("goal intercept: incomplete todos remain (override with a second [goal:complete])")
+		} else {
+			c.mu.Unlock()
+		}
+		if err := c.runTurnWithRawDisplay(ctx, turn, turn, ""); err != nil {
 			if ctx.Err() != nil {
 				c.stopGoal(GoalStatusStopped)
 			}
@@ -667,10 +695,28 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 	c.goalTurns++
 	switch status {
 	case GoalStatusComplete:
+		if incomplete := c.incompleteGoalTodos(); len(incomplete) > 0 && (c.goalStrict || c.goalIntercepts == 0) {
+			// In strict mode every claim is blocked until todos are done;
+			// otherwise only the first consecutive claim is intercepted.
+			c.goalIntercepts++
+			c.goalInterceptMsg = incomplete
+			break
+		}
+		// Todos are all done — in strict mode run self-check before final
+		// completion. Non-strict mode completes immediately.
+		if c.goalStrict && !c.goalSelfCheckDone {
+			c.goalSelfCheckDone = true
+			c.goalInterceptMsg = goalSelfCheckTurn
+			break
+		}
+		// Self-check passed — complete the goal.
+		c.goalIntercepts = 0
+		c.goalSelfCheckDone = false
 		c.goal = ""
 		c.goalStatus = GoalStatusComplete
 		c.goalBlocks = 0
 		c.goalBlock = ""
+		c.goalInterceptMsg = ""
 		notice = "goal complete"
 	case GoalStatusBlocked:
 		reason = cleanGoalBlockReason(reason)
@@ -690,10 +736,15 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 	default:
 		c.goalBlocks = 0
 		c.goalBlock = ""
+		c.goalIntercepts = 0
+		c.goalSelfCheckDone = false
 	}
 	if notice == "" && c.goalTurns >= maxGoalAutoTurns {
 		c.goalStatus = GoalStatusBlocked
 		c.goalBlock = "goal continuation limit reached"
+		c.goalIntercepts = 0
+		c.goalSelfCheckDone = false
+		c.goalInterceptMsg = ""
 		notice = c.goalBlock
 	}
 	cont := notice == ""
@@ -702,6 +753,48 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.notice(notice)
 	}
 	return cont
+}
+
+// incompleteGoalTodos checks the executor's canonical todo state and evidence
+// readiness (project checks) for anything that should block [goal:complete].
+// Returns a formatted reminder string, or empty if nothing is blocking.
+func (c *Controller) incompleteGoalTodos() string {
+	if c.executor == nil {
+		return ""
+	}
+	var parts []string
+
+	// 1. Check canonical todos.
+	todos := c.executor.CanonicalTodoState()
+	if len(todos) > 0 {
+		incomplete := evidence.IncompleteTodos(todos)
+		if len(incomplete) > 0 {
+			var b strings.Builder
+			b.WriteString("the following tasks are still incomplete:")
+			for _, t := range incomplete {
+				fmt.Fprintf(&b, "\n  - %s (%s)", t.Content, t.Status)
+			}
+			parts = append(parts, b.String())
+		}
+	}
+
+	// 2. Check evidence readiness (project checks from AGENTS.md).
+	if reason := c.executor.GoalReadinessFailure(); reason != "" {
+		parts = append(parts, reason)
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("The agent signaled goal completion but the following issues remain:\n")
+	for _, p := range parts {
+		b.WriteString(p)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nIf the work is actually done, update your task list with todo_write or complete_step and run the required verification commands, then signal [goal:complete] again. Otherwise finish the remaining work.")
+	return b.String()
 }
 
 func parseGoalStatusMarker(text string) (status, reason string, ok bool) {
@@ -759,6 +852,9 @@ func (c *Controller) stopGoal(status string) {
 	if strings.TrimSpace(c.goal) != "" && c.goalStatus == GoalStatusRunning {
 		c.goalStatus = status
 	}
+	c.goalInterceptMsg = ""
+	c.goalIntercepts = 0
+	c.goalSelfCheckDone = false
 	c.mu.Unlock()
 }
 
@@ -987,6 +1083,7 @@ func (c *Controller) applyGoalCommand(input, display string) bool {
 	switch cmd.Action {
 	case GoalCommandSet:
 		c.SetPlanMode(false)
+		c.GoalStrict(cmd.Strict)
 		c.SetGoal(cmd.Text)
 		c.notice(fmt.Sprintf(i18n.M.GoalSetFmt, ShortGoalForNotice(cmd.Text)))
 		if c.runner != nil {
@@ -1439,6 +1536,15 @@ func (c *Controller) PlanMode() bool {
 	return c.planMode
 }
 
+// GoalStrict enables or disables strict goal mode. In strict mode the agent
+// cannot override an incomplete-todo intercept — it must actually finish or
+// update all items before [goal:complete] is accepted.
+func (c *Controller) GoalStrict(strict bool) {
+	c.mu.Lock()
+	c.goalStrict = strict
+	c.mu.Unlock()
+}
+
 // SetGoal stores a session-scoped active goal. Compose injects it into outgoing
 // user turns, not the system prompt or tool schema, so it does not disturb the
 // cache-stable prefix.
@@ -1462,6 +1568,10 @@ func (c *Controller) SetGoal(goal string) {
 	c.goalTurns = 0
 	c.goalBlocks = 0
 	c.goalBlock = ""
+	c.goalInterceptMsg = ""
+	c.goalIntercepts = 0
+	c.goalSelfCheckDone = false
+	c.goalStrict = false
 }
 
 func (c *Controller) ClearGoal() {

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -6,6 +6,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -147,5 +148,131 @@ func TestGoalRestartResetsBlockedAudit(t *testing.T) {
 	}
 	if got := c.GoalStatus(); got != GoalStatusComplete {
 		t.Fatalf("resumed GoalStatus() = %q, want complete; blocked audit should restart", got)
+	}
+}
+
+// TestIncompleteGoalTodos verifies that incompleteGoalTodos detects
+// unfinished tasks and returns a formatted reminder, and returns empty
+// when all todos are complete.
+func TestIncompleteGoalTodos(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("done")}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	c := New(Options{Runner: ag, Executor: ag, Sink: event.Discard})
+
+	// Seed with incomplete todos.
+	ag.SeedTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "in_progress"},
+		{Content: "Add tests", Status: "pending"},
+	})
+	msg := c.incompleteGoalTodos()
+	if msg == "" {
+		t.Fatal("incompleteGoalTodos() returned empty string, expected reminder")
+	}
+	if !strings.Contains(msg, "Fix the parser") {
+		t.Fatalf("reminder should mention 'Fix the parser', got: %q", msg)
+	}
+	if !strings.Contains(msg, "Add tests") {
+		t.Fatalf("reminder should mention 'Add tests', got: %q", msg)
+	}
+	if !strings.Contains(msg, "todo_write") {
+		t.Fatalf("reminder should suggest updating todos via todo_write, got: %q", msg)
+	}
+
+	// Mark all complete.
+	ag.ReplaceTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "completed"},
+		{Content: "Add tests", Status: "completed"},
+	})
+	if got := c.incompleteGoalTodos(); got != "" {
+		t.Fatalf("incompleteGoalTodos() with all-complete = %q, want empty", got)
+	}
+
+	// Empty todo list.
+	ag.ReplaceTodoState(nil)
+	if got := c.incompleteGoalTodos(); got != "" {
+		t.Fatalf("incompleteGoalTodos() with empty list = %q, want empty", got)
+	}
+}
+
+// TestGoalInterceptsCompleteWithIncompleteTodos verifies that when the
+// agent claims [goal:complete] but has unfinished canonical todos, the
+// goal loop intercepts the first claim, then lets a second consecutive
+// claim through as an override.
+func TestGoalInterceptsCompleteWithIncompleteTodos(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("All done.\n\n[goal:complete]"),
+		textTurn("All done.\n\n[goal:complete]"),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	// Seed incomplete todos before starting.
+	ag.SeedTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "in_progress"},
+	})
+
+	notices := make(chan string, 64)
+	done := make(chan event.Event, 1)
+	c := New(Options{
+		Runner:   ag,
+		Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			switch e.Kind {
+			case event.Notice:
+				notices <- e.Text
+			case event.TurnDone:
+				done <- e
+			}
+		}),
+	})
+
+	c.Submit("/goal fix everything")
+	<-done // wait for the entire goal loop to finish
+	close(notices)
+
+	// Collect all notices.
+	var allNotices []string
+	for n := range notices {
+		allNotices = append(allNotices, n)
+	}
+
+	// Should see an intercept notice and the goal should complete
+	// (second [goal:complete] overrides the intercept).
+	found := false
+	for _, n := range allNotices {
+		if strings.Contains(n, "goal intercept") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'goal intercept' notice, got %v", allNotices)
+	}
+	if c.GoalStatus() != GoalStatusComplete {
+		t.Fatalf("GoalStatus() = %q, want complete (second [goal:complete] should override)", c.GoalStatus())
+	}
+}
+
+// TestStrictGoalBlocksRepeatedComplete verifies that in strict mode, every
+// [goal:complete] with incomplete todos is intercepted — no override allowed.
+func TestStrictGoalBlocksRepeatedComplete(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("Done!\n\n[goal:complete]"),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	ag.SeedTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "in_progress"},
+	})
+
+	c := New(Options{Runner: ag, Executor: ag, Sink: event.Discard})
+
+	// Enable strict mode.
+	c.GoalStrict(true)
+	c.Submit("/goal fix everything")
+
+	// In strict mode the agent still has incomplete todos but only one
+	// turn was given (the provider recycles it). The goal loop keeps
+	// intercepting; when the turn-recycling hits maxGoalAutoTurns (50)
+	// the goal is blocked. Verify it's not "complete".
+	if c.GoalStatus() == GoalStatusComplete {
+		t.Fatal("strict mode should not allow goal completion with incomplete todos")
 	}
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -188,6 +188,7 @@ const (
 type GoalCommand struct {
 	Action GoalCommandAction
 	Text   string
+	Strict bool
 }
 
 func ParseGoalCommand(input string) (GoalCommand, bool) {
@@ -196,13 +197,27 @@ func ParseGoalCommand(input string) (GoalCommand, bool) {
 		return GoalCommand{}, false
 	}
 	args := strings.TrimSpace(trimmed[len("/goal"):])
-	switch strings.ToLower(args) {
+
+	// Parse --strict flag before checking action.
+	strict := false
+	fields := strings.Fields(args)
+	cleaned := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f == "--strict" {
+			strict = true
+		} else {
+			cleaned = append(cleaned, f)
+		}
+	}
+	actionArgs := strings.Join(cleaned, " ")
+
+	switch strings.ToLower(actionArgs) {
 	case "", "status":
-		return GoalCommand{Action: GoalCommandStatus}, true
+		return GoalCommand{Action: GoalCommandStatus, Strict: strict}, true
 	case "clear", "off", "stop", "done":
-		return GoalCommand{Action: GoalCommandClear}, true
+		return GoalCommand{Action: GoalCommandClear, Strict: strict}, true
 	default:
-		return GoalCommand{Action: GoalCommandSet, Text: args}, true
+		return GoalCommand{Action: GoalCommandSet, Text: actionArgs, Strict: strict}, true
 	}
 }
 

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -221,14 +221,14 @@ func TestGoalCommandSetsReportsAndClears(t *testing.T) {
 
 func TestParseGoalCommandWithStrict(t *testing.T) {
 	tests := []struct {
-		input string
-		text  string
+		input  string
+		text   string
 		strict bool
-		ok    bool
+		ok     bool
 	}{
 		{"/goal --strict implement calculator", "implement calculator", true, true},
 		{"/goal implement calculator", "implement calculator", false, true},
-		{"/goal --strict", "", true, true}, // --strict shows status
+		{"/goal --strict", "", true, true},        // --strict shows status
 		{"/goal --strict status", "", true, true}, // --strict shows status
 	}
 	for _, tt := range tests {

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -219,6 +219,36 @@ func TestGoalCommandSetsReportsAndClears(t *testing.T) {
 	}
 }
 
+func TestParseGoalCommandWithStrict(t *testing.T) {
+	tests := []struct {
+		input string
+		text  string
+		strict bool
+		ok    bool
+	}{
+		{"/goal --strict implement calculator", "implement calculator", true, true},
+		{"/goal implement calculator", "implement calculator", false, true},
+		{"/goal --strict", "", true, true}, // --strict shows status
+		{"/goal --strict status", "", true, true}, // --strict shows status
+	}
+	for _, tt := range tests {
+		cmd, ok := ParseGoalCommand(tt.input)
+		if ok != tt.ok {
+			t.Errorf("ParseGoalCommand(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if cmd.Text != tt.text {
+			t.Errorf("ParseGoalCommand(%q).Text = %q, want %q", tt.input, cmd.Text, tt.text)
+		}
+		if cmd.Strict != tt.strict {
+			t.Errorf("ParseGoalCommand(%q).Strict = %v, want %v", tt.input, cmd.Strict, tt.strict)
+		}
+	}
+}
+
 func TestComposeDrainsQueuedMemory(t *testing.T) {
 	c := New(Options{}) // no executor/memory — QueueMemory still queues a turn-tail note
 


### PR DESCRIPTION
## 概述

将 Oh-My-OpenAgent 的三个核心强制执行模式引入 Reasonix 的 Goal 模式，让 `/goal` 更可靠地确保任务真正完成后再结束。

## 改动内容

### 1. 证据审计门控（`internal/agent/agent.go`, `internal/control/controller.go`）

- 暴露 `Agent.GoalReadinessFailure()` 方法，让 Controller 在接收 `[goal:complete]` 前能同时检查 canonical todos 和 project checks（来自 AGENTS.md 的 verify 指令）
- `incompleteGoalTodos()` 现在聚合未完成项 + 未验证的 project checks 为一条拦截消息

### 2. Todo 强制执行（`internal/control/controller.go`, `internal/control/input.go`）

- 当 agent 声称 `[goal:complete]` 但 canonical todos 还有未完成项时，第一次拦截并提醒 agent 要么干完活、要么更新 todo 列表
- 第二次连续 `[goal:complete]` 会覆盖拦截，正常完成
- **Strict 模式**（`/goal --strict ...`）：每次 `[goal:complete]` 都会被拦截直到 todos 全部完成——不允许覆盖
  - Strict 模式下，todos 全部完成后还会提示 agent 做一轮自检（编译、测试、需求验证）才真正结束
- Controller 新增 `GoalStrict()` 方法；`ParseGoalCommand()` 增加 `--strict` 参数解析

### 3. 并行子 agent 调度（`internal/agent/parallel_tasks.go`, `internal/boot/boot.go`）

- 新增 `parallel_tasks` 工具，并发分发多个前台子 agent，每个子 agent 在独立 goroutine 中运行
- **每个子任务发射独立的 ToolDispatch/ToolResult 事件**，通过嵌套 sink 挂载到父调用下，前端渲染为独立卡片
- 复用现有 `TaskTool` 基础设施（`RunSubAgentWithSession`），子任务工具调用自动嵌套显示
- 当事件 sink 不可用时自动降级为后台 job 模式
- 在 `internal/boot/boot.go` 中注册，与现有 `task` 工具并列

### 测试

- `TestGoalInterceptsCompleteWithIncompleteTodos` — 验证拦截一次后，第二次覆盖通过
- `TestStrictGoalBlocksRepeatedComplete` — 验证 strict 模式不允许覆盖
- `TestIncompleteGoalTodos` — 校验助手的单元测试
- `TestParseGoalCommandWithStrict` — 验证 `/goal --strict` 参数解析

`internal/control`、`internal/agent`、`internal/boot` 所有现有测试均通过。

## 使用方法

```bash
# 默认：拦截一次，第二次 [goal:complete] 覆盖放行
/goal 实现支付流程

# Strict：持续拦截直到 todos 全部完成，然后自检
/goal --strict 实现支付流程

# 并行调度：同时派发多个独立子任务
parallel_tasks(tasks=[
  {prompt: "研究 API 文档", description: "research"},
  {prompt: "写单元测试", description: "tests"},
])
```