### PR TITLE
feat: goal enforcement enhancements — idle detection, plan-exec, prometheus, wisdom, module routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ Thumbs.db
 /site/public/av/
 
 benchmarks/context-maintenance-e2e/run/
+desktop-test.exe

--- a/docs/GOAL_ENFORCEMENT.zh-CN.md
+++ b/docs/GOAL_ENFORCEMENT.zh-CN.md
@@ -1,0 +1,102 @@
+# Goal 模式增强 — 强制执行与并行调度
+
+Reasonix 的 Goal 模式（`/goal`）在 v1.9+ 中增加了来自 Oh-My-OpenAgent 的三个核心强制执行模式，让 AI agent 更可靠地完成复杂任务。
+
+## 功能一览
+
+| 功能 | 触发方式 | 效果 |
+|------|----------|------|
+| Todo 拦截 | 默认 | agent 声称 `[goal:complete]` 但 todos 未完成时，第一次拦截提醒 |
+| Override | 默认 | 第二次连续 `[goal:complete]` 覆盖拦截，正常完成 |
+| Strict 模式 | `/goal --strict ...` | 持续拦截直到 todos 全部完成，不允许覆盖 |
+| 质量自检 | `--strict` | todos 全部完成后，提示 agent 做一轮自检（编译/测试/验证） |
+| Idle 检测 | 默认 | 连续 2 轮无工具调用时，提醒 agent 推进或说明卡点 |
+| 并行调度 | `parallel_tasks` 工具 | 并发派发多个子 agent，各自独立显示结果 |
+
+## 使用方式
+
+### 默认模式
+
+```bash
+/goal 实现一个 CLI 计算器
+```
+
+当 agent 干到一半就说"干完了"时，系统会自动拦截：
+
+```
+[!] goal intercept: incomplete todos remain
+(override with a second [goal:complete])
+```
+
+拦截后 agent 会看到具体的未完成项列表。如果确实干完了但忘更新 todo，第二次 `[goal:complete]` 会正常放行。
+
+### Strict 模式
+
+```bash
+/goal --strict 实现支付流程
+```
+
+每次 `[goal:complete]` 都会被拦住，直到 todos 全部完成。todos 完成后还会触发一轮自检（编译、跑测试、需求验证），通过后才真正结束。
+
+适合对可靠性要求高的场景，如：
+- 生产环境代码修改
+- 需要完整测试覆盖的任务
+- 多步骤复杂流程
+
+### 并行子任务
+
+```bash
+/goal 研究 Go 的三个标准库并写示例
+```
+
+Agent 可以调用 `parallel_tasks` 工具同时派发多个独立子任务：
+
+```
+parallel_tasks(tasks=[
+  {prompt: "研究 encoding/json，写示例", description: "json research"},
+  {prompt: "研究 net/http，写示例", description: "http research"},
+  {prompt: "研究 sync，写示例", description: "sync research"},
+])
+```
+
+每个子任务在独立 goroutine 中运行，工具调用会嵌套显示为独立卡片，结果聚合返回。
+
+## 实现细节
+
+### 证据审计门控
+
+`Agent.GoalReadinessFailure()` 同时检查：
+- Canonical todos（当前 todo 列表）
+- Project checks（来自 AGENTS.md 的 verify 指令）
+
+两者任一未通过就会阻止 `[goal:complete]`。
+
+### Todo 状态流
+
+```
+todo_write → agent 创建任务列表
+complete_step → agent 标记某一步完成
+advanceGoalAfterTurn → 检查 todos + project checks
+  ├─ 有不完整项 → goalInterceptMsg + 继续循环
+  └─ 全部完成 → 正常结束（strict 模式先自检）
+```
+
+### 并行调度架构
+
+```
+parallel_tasks Execute()
+  ├─ 对每个子任务:
+  │   ├─ 发射 ToolDispatch 事件（前端渲染卡片）
+  │   ├─ 创建嵌套 sink（subSinkFor）
+  │   ├─ 启动 goroutine 运行 RunSubAgentWithSession
+  │   └─ 子任务工具调用自动嵌套显示
+  ├─ WaitGroup 等待全部完成
+  └─ 聚合结果返回
+```
+
+## 相关代码
+
+- `internal/control/controller.go` — Goal 状态机、advanceGoalAfterTurn
+- `internal/control/input.go` — `/goal --strict` 命令解析
+- `internal/agent/parallel_tasks.go` — 并行调度工具
+- `internal/boot/boot.go` — 工具注册

--- a/docs/GOAL_ENFORCEMENT.zh-CN.md
+++ b/docs/GOAL_ENFORCEMENT.zh-CN.md
@@ -61,6 +61,20 @@ parallel_tasks(tasks=[
 
 每个子任务在独立 goroutine 中运行，工具调用会嵌套显示为独立卡片，结果聚合返回。
 
+### 任务依赖
+
+如果子任务之间有依赖关系，可以用 `depends_on` 指定：
+
+```
+parallel_tasks(tasks=[
+  {prompt: "写一个加法函数到 add.py", description: "add"},
+  {prompt: "写一个乘法函数到 mul.py", description: "mul"},
+  {prompt: "在 main.py 中调用 add 和 mul", description: "main", depends_on: [0, 1]},
+])
+```
+
+独立任务（add、mul）先并发执行；main 等前两个完成后再启动。
+
 ## 实现细节
 
 ### 证据审计门控

--- a/docs/GOAL_ENFORCEMENT.zh-CN.md
+++ b/docs/GOAL_ENFORCEMENT.zh-CN.md
@@ -75,6 +75,24 @@ parallel_tasks(tasks=[
 
 独立任务（add、mul）先并发执行；main 等前两个完成后再启动。
 
+## Prometheus 规划面试
+
+在写代码前，先让 AI 帮你理清需求：
+
+```
+/prometheus 重构用户认证模块，改成 JWT
+```
+
+Prometheus 会逐个问澄清问题：
+
+```
+1. 用户模块当前是 session 还是 token 认证？
+2. 需要支持 refresh token 吗？
+3. 现有用户表结构是什么样的？
+```
+
+回答完问题后，Prometheus 自动生成可执行的计划。然后你可以用 `/plan-exec` 来执行。
+
 ## 实现细节
 
 ### 证据审计门控

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1233,7 +1233,7 @@ func (a *Agent) stream(ctx context.Context, turn int) (string, string, string, [
 	// styled markdown now that it is complete. Reasoning rides along so the sink
 	// has the full chain if it wants it.
 	if text.Len() > 0 || display != "" {
-		a.sink.Emit(event.Event{Kind: event.Message, Text: text.String(), Reasoning: display})
+		a.sink.Emit(event.Event{Kind: event.Message, Text: StripGoalMarkers(text.String()), Reasoning: display})
 	}
 	return text.String(), stored, signature, calls, usage, false, false, nil
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -827,6 +827,13 @@ func (a *Agent) finalReadinessFailure() string {
 	return a.finalReadinessCheck().reason
 }
 
+// GoalReadinessFailure returns the final-readiness failure reason — a summary of
+// incomplete todos and unverified project checks — or empty string if none.
+// Exported so the Controller can gate [goal:complete] on evidence.
+func (a *Agent) GoalReadinessFailure() string {
+	return a.finalReadinessFailure()
+}
+
 type finalReadinessCheck struct {
 	applies              bool
 	reason               string

--- a/internal/agent/goal_display.go
+++ b/internal/agent/goal_display.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StripGoalMarkers removes goal status markers like [goal:complete],
+// [goal:continue], and [goal:blocked:...] from display text so users see
+// natural language instead of protocol markers. Exported for use by frontends.
+// The markers are still kept in the session history for controller parsing.
+func StripGoalMarkers(text string) string {
+	text = strings.TrimSpace(text)
+	lines := strings.Split(text, "\n")
+	cleaned := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "[goal:complete]" || trimmed == "[goal:continue]" {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[goal:blocked:") && strings.HasSuffix(trimmed, "]") {
+			reason := strings.TrimPrefix(trimmed, "[goal:blocked:")
+			reason = strings.TrimSuffix(reason, "]")
+			if reason != "" {
+				cleaned = append(cleaned, fmt.Sprintf("\u26a0\ufe0f Blocked: %s", reason))
+			}
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+	return strings.TrimSpace(strings.Join(cleaned, "\n"))
+}

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -1,0 +1,177 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"reasonix/internal/jobs"
+	"reasonix/internal/tool"
+)
+
+// ParallelTasksTool dispatches multiple sub-agent tasks concurrently and
+// collects all results. Each task runs in its own background sub-agent; the
+// tool blocks until every task finishes, then returns the aggregated output.
+// It wraps an inner *TaskTool to reuse its sub-agent machinery.
+type ParallelTasksTool struct {
+	taskTool *TaskTool
+	reg      *tool.Registry
+}
+
+// NewParallelTasksTool creates a parallel dispatch tool that reuses the given
+// TaskTool's sub-agent infrastructure.
+func NewParallelTasksTool(taskTool *TaskTool, reg *tool.Registry) *ParallelTasksTool {
+	return &ParallelTasksTool{taskTool: taskTool, reg: reg}
+}
+
+func (p *ParallelTasksTool) Name() string { return "parallel_tasks" }
+
+func (p *ParallelTasksTool) Description() string {
+	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all complete."
+}
+
+func (p *ParallelTasksTool) Schema() json.RawMessage {
+	return json.RawMessage(`{
+"type":"object",
+"properties":{
+  "tasks":{
+    "type":"array",
+    "description":"Array of sub-task descriptions to run in parallel.",
+    "items":{
+      "type":"object",
+      "properties":{
+        "prompt":{"type":"string","description":"The task prompt for the sub-agent."},
+        "description":{"type":"string","description":"Optional short label shown in the job list."},
+        "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist for the sub-agent."},
+        "max_steps":{"type":"integer","description":"Optional max tool-call rounds.","minimum":1},
+        "model":{"type":"string","description":"Optional model override."},
+        "effort":{"type":"string","description":"Optional reasoning effort override."}
+      },
+      "required":["prompt"]
+    }
+  }
+},
+"required":["tasks"]
+}`)
+}
+
+func (p *ParallelTasksTool) ReadOnly() bool { return true }
+
+// ParallelTaskItem mirrors one entry in the schema's tasks array.
+type ParallelTaskItem struct {
+	Prompt      string   `json:"prompt"`
+	Description string   `json:"description"`
+	Tools       []string `json:"tools"`
+	MaxSteps    int      `json:"max_steps"`
+	Model       string   `json:"model"`
+	Effort      string   `json:"effort"`
+}
+
+func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var params struct {
+		Tasks []ParallelTaskItem `json:"tasks"`
+	}
+	if err := json.Unmarshal(args, &params); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+	if len(params.Tasks) == 0 {
+		return "", fmt.Errorf("at least one task is required")
+	}
+	if len(params.Tasks) == 1 {
+		return "", fmt.Errorf("parallel_tasks with a single task is equivalent to task; use task instead")
+	}
+
+	jm, ok := jobs.FromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("background jobs are not available in this context")
+	}
+	session := jobs.SessionFromContext(ctx)
+
+	type jobRef struct {
+		id    string
+		label string
+	}
+	var refs []jobRef
+
+	for i, t := range params.Tasks {
+		if strings.TrimSpace(t.Prompt) == "" {
+			return "", fmt.Errorf("task %d: prompt is required", i+1)
+		}
+		label := t.Description
+		if label == "" {
+			label = fmt.Sprintf("task-%d", i+1)
+		}
+
+		subArgs := map[string]interface{}{
+			"prompt":            t.Prompt,
+			"description":       label,
+			"run_in_background": true,
+		}
+		if len(t.Tools) > 0 {
+			subArgs["tools"] = t.Tools
+		}
+		if t.MaxSteps > 0 {
+			subArgs["max_steps"] = t.MaxSteps
+		}
+		if t.Model != "" {
+			subArgs["model"] = t.Model
+		}
+		if t.Effort != "" {
+			subArgs["effort"] = t.Effort
+		}
+
+		subJSON, err := json.Marshal(subArgs)
+		if err != nil {
+			return "", fmt.Errorf("task %d: marshal: %w", i+1, err)
+		}
+
+		result, err := p.taskTool.Execute(ctx, subJSON)
+		if err != nil {
+			return "", fmt.Errorf("task %d dispatch: %w", i+1, err)
+		}
+		refs = append(refs, jobRef{id: extractJobID(result), label: label})
+		_ = result
+	}
+
+	if len(refs) == 0 {
+		return "", fmt.Errorf("no tasks were dispatched")
+	}
+
+	jobIDs := make([]string, len(refs))
+	for i, r := range refs {
+		jobIDs[i] = r.id
+	}
+
+	results := jm.WaitForSession(ctx, session, jobIDs, 0)
+	if len(results) == 0 {
+		return "No parallel task results available.", nil
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", len(results)))
+	for i, r := range results {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		label := r.ID
+		if r.Label != "" {
+			label = r.Label
+		}
+		fmt.Fprintf(&b, "── %s ──\n[%s] %s\n%s", label, r.ID, r.Status, strings.TrimSpace(r.Output))
+	}
+	return b.String(), nil
+}
+
+// extractJobID pulls the background job id from a task tool start message.
+func extractJobID(msg string) string {
+	quote := strings.Index(msg, `"`)
+	if quote < 0 {
+		return ""
+	}
+	end := strings.Index(msg[quote+1:], `"`)
+	if end < 0 {
+		return ""
+	}
+	return msg[quote+1 : quote+1+end]
+}

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -276,6 +276,21 @@ func (p *ParallelTasksTool) runAsBackgroundJobs(ctx context.Context, tasks []par
 	}
 	session := jobs.SessionFromContext(ctx)
 
+	// Validate all tasks upfront before dispatching any.
+	for i, t := range tasks {
+		if strings.TrimSpace(t.Prompt) == "" {
+			return "", fmt.Errorf("task %d: prompt is required", i+1)
+		}
+		for _, dep := range t.DependsOn {
+			if dep < 0 || dep >= len(tasks) {
+				return "", fmt.Errorf("task %d: depends_on[%d] = %d out of range (0-%d)", i+1, dep, dep, len(tasks)-1)
+			}
+			if dep == i {
+				return "", fmt.Errorf("task %d: self-referencing depends_on", i+1)
+			}
+		}
+	}
+
 	type jobRef struct {
 		id    string
 		label string

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -5,15 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 
+	"reasonix/internal/event"
 	"reasonix/internal/jobs"
+	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
 
 // ParallelTasksTool dispatches multiple sub-agent tasks concurrently and
-// collects all results. Each task runs in its own background sub-agent; the
-// tool blocks until every task finishes, then returns the aggregated output.
-// It wraps an inner *TaskTool to reuse its sub-agent machinery.
+// collects all results. Each sub-task runs as a foreground sub-agent in its
+// own goroutine, emitting nested events so the frontend renders independent
+// cards for each sub-task.
 type ParallelTasksTool struct {
 	taskTool *TaskTool
 	reg      *tool.Registry
@@ -28,7 +31,7 @@ func NewParallelTasksTool(taskTool *TaskTool, reg *tool.Registry) *ParallelTasks
 func (p *ParallelTasksTool) Name() string { return "parallel_tasks" }
 
 func (p *ParallelTasksTool) Description() string {
-	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all complete."
+	return "Dispatch multiple sub-agent tasks concurrently and collect their results. Each task runs in its own sub-agent in parallel. Blocks until all tasks complete."
 }
 
 func (p *ParallelTasksTool) Schema() json.RawMessage {
@@ -42,8 +45,8 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
       "type":"object",
       "properties":{
         "prompt":{"type":"string","description":"The task prompt for the sub-agent."},
-        "description":{"type":"string","description":"Optional short label shown in the job list."},
-        "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist for the sub-agent."},
+        "description":{"type":"string","description":"Optional short label."},
+        "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist."},
         "max_steps":{"type":"integer","description":"Optional max tool-call rounds.","minimum":1},
         "model":{"type":"string","description":"Optional model override."},
         "effort":{"type":"string","description":"Optional reasoning effort override."}
@@ -58,8 +61,7 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
 
 func (p *ParallelTasksTool) ReadOnly() bool { return true }
 
-// ParallelTaskItem mirrors one entry in the schema's tasks array.
-type ParallelTaskItem struct {
+type parallelTaskItem struct {
 	Prompt      string   `json:"prompt"`
 	Description string   `json:"description"`
 	Tools       []string `json:"tools"`
@@ -70,7 +72,7 @@ type ParallelTaskItem struct {
 
 func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
-		Tasks []ParallelTaskItem `json:"tasks"`
+		Tasks []parallelTaskItem `json:"tasks"`
 	}
 	if err := json.Unmarshal(args, &params); err != nil {
 		return "", fmt.Errorf("invalid args: %w", err)
@@ -82,6 +84,129 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		return "", fmt.Errorf("parallel_tasks with a single task is equivalent to task; use task instead")
 	}
 
+	parentID, sink, _, ok := CallContext(ctx)
+	if !ok || sink == nil {
+		// Fallback: no event sink available, use background-jobs approach.
+		return p.runAsBackgroundJobs(ctx, params.Tasks)
+	}
+
+	type subResult struct {
+		index   int
+		output  string
+		err     error
+	}
+
+	results := make(chan subResult, len(params.Tasks))
+	var wg sync.WaitGroup
+
+	for i, task := range params.Tasks {
+		if strings.TrimSpace(task.Prompt) == "" {
+			return "", fmt.Errorf("task %d: prompt is required", i+1)
+		}
+
+		wg.Add(1)
+		go func(idx int, t parallelTaskItem) {
+			defer wg.Done()
+
+			label := t.Description
+			if label == "" {
+				label = fmt.Sprintf("task-%d", idx+1)
+			}
+
+			// Each sub-task gets a unique ID nested under the parent call.
+			subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
+
+			// Emit ToolDispatch so the frontend shows a card.
+			dispatchArgs, _ := json.Marshal(map[string]string{"prompt": t.Prompt, "description": label})
+			sink.Emit(event.Event{
+				Kind: event.ToolDispatch,
+				Tool: event.Tool{
+					ID:       subID,
+					ParentID: parentID,
+					Name:     "task",
+					Args:     string(dispatchArgs),
+					ReadOnly: true,
+				},
+			})
+
+			// Build a nested sink so sub-agent events nest under this sub-task.
+			nested := subSinkFor(subID, sink)
+
+			// Resolve provider, build sub-registry, and run.
+			modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
+			subReg := p.taskTool.buildSubReg(t.Tools)
+
+			maxSteps := t.MaxSteps
+			if maxSteps <= 0 {
+				maxSteps = 20
+			}
+
+			prov, pricing, ctxWin, err := resolveSubagentProvider(p.taskTool, modelRef, effortRef)
+			if err != nil {
+				sink.Emit(event.Event{
+					Kind: event.ToolResult,
+					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: err.Error()},
+				})
+				results <- subResult{index: idx, err: err}
+				return
+			}
+
+			sess := NewSession("")
+			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
+				MaxSteps:          maxSteps,
+				Temperature:       p.taskTool.temperature,
+				Pricing:           pricing,
+				UsageSource:       event.UsageSourceSubagent,
+				Gate:              p.taskTool.gate,
+				ContextWindow:     ctxWin,
+				RecentKeep:        p.taskTool.recentKeep,
+				SoftCompactRatio:  p.taskTool.softCompactRatio,
+				CompactRatio:      p.taskTool.compactRatio,
+				CompactForceRatio: p.taskTool.compactForceRatio,
+				ArchiveDir:        p.taskTool.archiveDir,
+				KeepPolicy:        p.taskTool.keepPolicy,
+			}, nested)
+
+			if runErr != nil {
+				sink.Emit(event.Event{
+					Kind: event.ToolResult,
+					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: runErr.Error()},
+				})
+				results <- subResult{index: idx, err: runErr}
+				return
+			}
+
+			sink.Emit(event.Event{
+				Kind: event.ToolResult,
+				Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Output: output},
+			})
+			results <- subResult{index: idx, output: output}
+		}(i, task)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Collect in order.
+	ordered := make([]subResult, len(params.Tasks))
+	for r := range results {
+		ordered[r.index] = r
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", len(params.Tasks)))
+	for _, r := range ordered {
+		if r.err != nil {
+			fmt.Fprintf(&b, "── task-%d ──\n[FAILED] %s\n", r.index+1, r.err)
+		} else {
+			fmt.Fprintf(&b, "── task-%d ──\n%s\n", r.index+1, strings.TrimSpace(r.output))
+		}
+	}
+	return b.String(), nil
+}
+
+// runAsBackgroundJobs is the fallback path when no event sink is available.
+func (p *ParallelTasksTool) runAsBackgroundJobs(ctx context.Context, tasks []parallelTaskItem) (string, error) {
 	jm, ok := jobs.FromContext(ctx)
 	if !ok {
 		return "", fmt.Errorf("background jobs are not available in this context")
@@ -91,10 +216,11 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	type jobRef struct {
 		id    string
 		label string
+		idx   int
 	}
 	var refs []jobRef
 
-	for i, t := range params.Tasks {
+	for i, t := range tasks {
 		if strings.TrimSpace(t.Prompt) == "" {
 			return "", fmt.Errorf("task %d: prompt is required", i+1)
 		}
@@ -130,7 +256,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		if err != nil {
 			return "", fmt.Errorf("task %d dispatch: %w", i+1, err)
 		}
-		refs = append(refs, jobRef{id: extractJobID(result), label: label})
+		refs = append(refs, jobRef{id: extractJobID(result), label: label, idx: i})
 		_ = result
 	}
 
@@ -139,8 +265,10 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	}
 
 	jobIDs := make([]string, len(refs))
-	for i, r := range refs {
-		jobIDs[i] = r.id
+	order := make(map[string]int)
+	for _, r := range refs {
+		jobIDs = append(jobIDs, r.id)
+		order[r.id] = r.idx
 	}
 
 	results := jm.WaitForSession(ctx, session, jobIDs, 0)
@@ -150,20 +278,28 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", len(results)))
-	for i, r := range results {
-		if i > 0 {
-			b.WriteString("\n")
-		}
+	for _, r := range results {
+		idx := order[r.ID]
 		label := r.ID
 		if r.Label != "" {
 			label = r.Label
 		}
 		fmt.Fprintf(&b, "── %s ──\n[%s] %s\n%s", label, r.ID, r.Status, strings.TrimSpace(r.Output))
+		_ = idx
 	}
 	return b.String(), nil
 }
 
-// extractJobID pulls the background job id from a task tool start message.
+// resolveSubagentProvider resolves a provider for a sub-agent, using the
+// TaskTool's resolver or falling back to the task tool's own provider.
+func resolveSubagentProvider(tt *TaskTool, modelRef, effortRef string) (provider.Provider, *provider.Pricing, int, error) {
+	if tt.resolveProvider != nil && (modelRef != "" || effortRef != "") {
+		return tt.resolveProvider(modelRef, effortRef)
+	}
+	// Use the task tool's own defaults.
+	return tt.prov, tt.pricing, tt.contextWindow, nil
+}
+
 func extractJobID(msg string) string {
 	quote := strings.Index(msg, `"`)
 	if quote < 0 {

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -129,22 +129,46 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 
 	// Channels for task completion signals and for spawning tasks.
 	type runRequest struct {
-		idx int
-		t   parallelTaskItem
+		idx    int
+		prompt string
+		label  string
+		tools  []string
+		maxSteps int
+		model    string
+		effort   string
 	}
 	spawnCh := make(chan runRequest, n)
 	doneCh := make(chan subResult, n)
 	allDone := make(chan struct{})
 
-	// Dispatcher goroutine: spawns tasks when their deps are satisfied.
+	// Dispatcher goroutine: spawns tasks when their deps are satisfied,
+	// accumulating wisdom from completed tasks and passing it forward.
 	go func() {
 		spawned := 0
 		completed := 0
+		var wisdom strings.Builder
+
+		makePrompt := func(t parallelTaskItem) string {
+			if wisdom.Len() == 0 || len(t.DependsOn) == 0 {
+				return t.Prompt
+			}
+			return "Previous task results:\n" + wisdom.String() + "\n\nNow do:\n" + t.Prompt
+		}
+		makeLabel := func(t parallelTaskItem, idx int) string {
+			if t.Description != "" {
+				return t.Description
+			}
+			return fmt.Sprintf("task-%d", idx+1)
+		}
+
 		// Seed: spawn all tasks with no dependencies.
 		for i, t := range params.Tasks {
 			if remaining[i] == 0 && !running[i] && !done[i] {
 				running[i] = true
-				spawnCh <- runRequest{idx: i, t: t}
+				spawnCh <- runRequest{
+					idx: i, prompt: makePrompt(t), label: makeLabel(t, i),
+					tools: t.Tools, maxSteps: t.MaxSteps, model: t.Model, effort: t.Effort,
+				}
 				spawned++
 			}
 		}
@@ -156,10 +180,26 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			outputs[r.index] = r.output
 			errors[r.index] = r.err
 
+			// Accumulate wisdom from successful tasks.
+			if r.err == nil && r.output != "" {
+				summary := strings.TrimSpace(r.output)
+				if len(summary) > 200 {
+					summary = summary[:200] + "..."
+				}
+				if wisdom.Len() > 0 {
+					wisdom.WriteString("\n")
+				}
+				fmt.Fprintf(&wisdom, "- Task %d: %s", r.index+1, summary)
+			} else if r.err != nil {
+				if wisdom.Len() > 0 {
+					wisdom.WriteString("\n")
+				}
+				fmt.Fprintf(&wisdom, "- Task %d: FAILED - %s", r.index+1, r.err)
+			}
+
 			// Check if any waiting tasks are now unblocked.
 			for i, t := range params.Tasks {
 				if remaining[i] > 0 && !running[i] && !done[i] {
-					// Check if this dep is the one that just finished.
 					for _, dep := range t.DependsOn {
 						if dep == r.index {
 							remaining[i]--
@@ -167,7 +207,10 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 					}
 					if remaining[i] == 0 {
 						running[i] = true
-						spawnCh <- runRequest{idx: i, t: t}
+						spawnCh <- runRequest{
+							idx: i, prompt: makePrompt(t), label: makeLabel(t, i),
+							tools: t.Tools, maxSteps: t.MaxSteps, model: t.Model, effort: t.Effort,
+						}
 						spawned++
 					}
 				}
@@ -183,14 +226,16 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 		go func() {
 			defer wg.Done()
 			for req := range spawnCh {
-				idx, t := req.idx, req.t
-				label := t.Description
-				if label == "" {
-					label = fmt.Sprintf("task-%d", idx+1)
-				}
+				idx := req.idx
+				prompt := req.prompt
+				label := req.label
+				tools := req.tools
+				maxSteps := req.maxSteps
+				model := req.model
+				effort := req.effort
 
 				subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
-				dispatchArgs, _ := json.Marshal(map[string]string{"prompt": t.Prompt, "description": label})
+				dispatchArgs, _ := json.Marshal(map[string]string{"prompt": prompt, "description": label})
 				sink.Emit(event.Event{
 					Kind: event.ToolDispatch,
 					Tool: event.Tool{
@@ -200,12 +245,12 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				})
 
 				nested := subSinkFor(subID, sink)
-				modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
-				subReg := p.taskTool.buildSubReg(t.Tools)
+				modelRef, effortRef := p.taskTool.effectiveProfile(model, effort)
+				subReg := p.taskTool.buildSubReg(tools)
 
-				maxSteps := t.MaxSteps
-				if maxSteps <= 0 {
-					maxSteps = 20
+				max := maxSteps
+				if max <= 0 {
+					max = 20
 				}
 
 				prov, pricing, ctxWin, err := resolveSubagentProvider(p.taskTool, modelRef, effortRef)
@@ -219,8 +264,8 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				}
 
 				sess := NewSession("")
-				output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
-					MaxSteps:          maxSteps,
+				output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, prompt, Options{
+					MaxSteps:          max,
 					Temperature:       p.taskTool.temperature,
 					Pricing:           pricing,
 					UsageSource:       event.UsageSourceSubagent,

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -142,17 +144,25 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	allDone := make(chan struct{})
 
 	// Dispatcher goroutine: spawns tasks when their deps are satisfied,
-	// accumulating wisdom from completed tasks and passing it forward.
+	// accumulating wisdom from completed tasks as files on disk.
 	go func() {
 		spawned := 0
 		completed := 0
-		var wisdom strings.Builder
+		wisdomDir, _ := os.MkdirTemp("", "parallel-wisdom-*")
+		if wisdomDir != "" {
+			defer os.RemoveAll(wisdomDir)
+		}
 
 		makePrompt := func(t parallelTaskItem) string {
-			if wisdom.Len() == 0 || len(t.DependsOn) == 0 {
-				return t.Prompt
+			var prefix strings.Builder
+			if len(t.DependsOn) > 0 && wisdomDir != "" {
+				entries, _ := os.ReadDir(wisdomDir)
+				if len(entries) > 0 {
+					prefix.WriteString(fmt.Sprintf("Previous task results are available at %s. Read the relevant files with read_file before starting.\n\n", wisdomDir))
+				}
 			}
-			return "Previous task results:\n" + wisdom.String() + "\n\nNow do:\n" + t.Prompt
+			prefix.WriteString(t.Prompt)
+			return prefix.String()
 		}
 		makeLabel := func(t parallelTaskItem, idx int) string {
 			if t.Description != "" {
@@ -180,21 +190,15 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 			outputs[r.index] = r.output
 			errors[r.index] = r.err
 
-			// Accumulate wisdom from successful tasks.
-			if r.err == nil && r.output != "" {
-				summary := strings.TrimSpace(r.output)
-				if len(summary) > 200 {
-					summary = summary[:200] + "..."
-				}
-				if wisdom.Len() > 0 {
-					wisdom.WriteString("\n")
-				}
-				fmt.Fprintf(&wisdom, "- Task %d: %s", r.index+1, summary)
-			} else if r.err != nil {
-				if wisdom.Len() > 0 {
-					wisdom.WriteString("\n")
-				}
-				fmt.Fprintf(&wisdom, "- Task %d: FAILED - %s", r.index+1, r.err)
+			// Write wisdom to file instead of inlining in prompt.
+			if wisdomDir != "" && r.output != "" {
+				fname := filepath.Join(wisdomDir, fmt.Sprintf("task-%d.md", r.index+1))
+				summary := fmt.Sprintf("# Task %d Result\n\n%s", r.index+1, strings.TrimSpace(r.output))
+				_ = os.WriteFile(fname, []byte(summary), 0o644)
+			} else if wisdomDir != "" && r.err != nil {
+				fname := filepath.Join(wisdomDir, fmt.Sprintf("task-%d.md", r.index+1))
+				summary := fmt.Sprintf("# Task %d Result\n\nFAILED: %s", r.index+1, r.err)
+				_ = os.WriteFile(fname, []byte(summary), 0o644)
 			}
 
 			// Check if any waiting tasks are now unblocked.

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -49,7 +49,8 @@ func (p *ParallelTasksTool) Schema() json.RawMessage {
         "tools":{"type":"array","items":{"type":"string"},"description":"Optional tool whitelist."},
         "max_steps":{"type":"integer","description":"Optional max tool-call rounds.","minimum":1},
         "model":{"type":"string","description":"Optional model override."},
-        "effort":{"type":"string","description":"Optional reasoning effort override."}
+        "effort":{"type":"string","description":"Optional reasoning effort override."},
+        "depends_on":{"type":"array","items":{"type":"integer"},"description":"Optional 0-based indices of tasks this task depends on. Dependent tasks start only after all their dependencies finish."}
       },
       "required":["prompt"]
     }
@@ -68,6 +69,7 @@ type parallelTaskItem struct {
 	MaxSteps    int      `json:"max_steps"`
 	Model       string   `json:"model"`
 	Effort      string   `json:"effort"`
+	DependsOn   []int    `json:"depends_on"`
 }
 
 func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
@@ -91,115 +93,176 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 	}
 
 	type subResult struct {
-		index   int
-		output  string
-		err     error
+		index  int
+		output string
+		err    error
 	}
 
-	results := make(chan subResult, len(params.Tasks))
-	var wg sync.WaitGroup
+	n := len(params.Tasks)
 
-	for i, task := range params.Tasks {
-		if strings.TrimSpace(task.Prompt) == "" {
+	// Validate: no out-of-range deps, no self-references.
+	for i, t := range params.Tasks {
+		if strings.TrimSpace(t.Prompt) == "" {
 			return "", fmt.Errorf("task %d: prompt is required", i+1)
 		}
+		for _, dep := range t.DependsOn {
+			if dep < 0 || dep >= n {
+				return "", fmt.Errorf("task %d: depends_on[%d] = %d out of range (0-%d)", i+1, dep, dep, n-1)
+			}
+			if dep == i {
+				return "", fmt.Errorf("task %d: self-referencing depends_on", i+1)
+			}
+		}
+	}
 
+	// Dependency state: remaining = number of deps not yet completed.
+	remaining := make([]int, n)
+	running := make([]bool, n)
+	done := make([]bool, n)
+	outputs := make([]string, n)
+	errors := make([]error, n)
+	for i, t := range params.Tasks {
+		remaining[i] = len(t.DependsOn)
+		running[i] = false
+		done[i] = false
+	}
+
+	// Channels for task completion signals and for spawning tasks.
+	type runRequest struct {
+		idx int
+		t   parallelTaskItem
+	}
+	spawnCh := make(chan runRequest, n)
+	doneCh := make(chan subResult, n)
+	allDone := make(chan struct{})
+
+	// Dispatcher goroutine: spawns tasks when their deps are satisfied.
+	go func() {
+		spawned := 0
+		completed := 0
+		// Seed: spawn all tasks with no dependencies.
+		for i, t := range params.Tasks {
+			if remaining[i] == 0 && !running[i] && !done[i] {
+				running[i] = true
+				spawnCh <- runRequest{idx: i, t: t}
+				spawned++
+			}
+		}
+
+		for completed < n {
+			r := <-doneCh
+			completed++
+			done[r.index] = true
+			outputs[r.index] = r.output
+			errors[r.index] = r.err
+
+			// Check if any waiting tasks are now unblocked.
+			for i, t := range params.Tasks {
+				if remaining[i] > 0 && !running[i] && !done[i] {
+					// Check if this dep is the one that just finished.
+					for _, dep := range t.DependsOn {
+						if dep == r.index {
+							remaining[i]--
+						}
+					}
+					if remaining[i] == 0 {
+						running[i] = true
+						spawnCh <- runRequest{idx: i, t: t}
+						spawned++
+					}
+				}
+			}
+		}
+		close(allDone)
+	}()
+
+	// Worker pool: goroutines that pick up spawn requests and run sub-tasks.
+	var wg sync.WaitGroup
+	for w := 0; w < n; w++ {
 		wg.Add(1)
-		go func(idx int, t parallelTaskItem) {
+		go func() {
 			defer wg.Done()
+			for req := range spawnCh {
+				idx, t := req.idx, req.t
+				label := t.Description
+				if label == "" {
+					label = fmt.Sprintf("task-%d", idx+1)
+				}
 
-			label := t.Description
-			if label == "" {
-				label = fmt.Sprintf("task-%d", idx+1)
-			}
-
-			// Each sub-task gets a unique ID nested under the parent call.
-			subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
-
-			// Emit ToolDispatch so the frontend shows a card.
-			dispatchArgs, _ := json.Marshal(map[string]string{"prompt": t.Prompt, "description": label})
-			sink.Emit(event.Event{
-				Kind: event.ToolDispatch,
-				Tool: event.Tool{
-					ID:       subID,
-					ParentID: parentID,
-					Name:     "task",
-					Args:     string(dispatchArgs),
-					ReadOnly: true,
-				},
-			})
-
-			// Build a nested sink so sub-agent events nest under this sub-task.
-			nested := subSinkFor(subID, sink)
-
-			// Resolve provider, build sub-registry, and run.
-			modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
-			subReg := p.taskTool.buildSubReg(t.Tools)
-
-			maxSteps := t.MaxSteps
-			if maxSteps <= 0 {
-				maxSteps = 20
-			}
-
-			prov, pricing, ctxWin, err := resolveSubagentProvider(p.taskTool, modelRef, effortRef)
-			if err != nil {
+				subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
+				dispatchArgs, _ := json.Marshal(map[string]string{"prompt": t.Prompt, "description": label})
 				sink.Emit(event.Event{
-					Kind: event.ToolResult,
-					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: err.Error()},
+					Kind: event.ToolDispatch,
+					Tool: event.Tool{
+						ID: subID, ParentID: parentID, Name: "task",
+						Args: string(dispatchArgs), ReadOnly: true,
+					},
 				})
-				results <- subResult{index: idx, err: err}
-				return
+
+				nested := subSinkFor(subID, sink)
+				modelRef, effortRef := p.taskTool.effectiveProfile(t.Model, t.Effort)
+				subReg := p.taskTool.buildSubReg(t.Tools)
+
+				maxSteps := t.MaxSteps
+				if maxSteps <= 0 {
+					maxSteps = 20
+				}
+
+				prov, pricing, ctxWin, err := resolveSubagentProvider(p.taskTool, modelRef, effortRef)
+				if err != nil {
+					sink.Emit(event.Event{
+						Kind: event.ToolResult,
+						Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: err.Error()},
+					})
+					doneCh <- subResult{index: idx, err: err}
+					continue
+				}
+
+				sess := NewSession("")
+				output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
+					MaxSteps:          maxSteps,
+					Temperature:       p.taskTool.temperature,
+					Pricing:           pricing,
+					UsageSource:       event.UsageSourceSubagent,
+					Gate:              p.taskTool.gate,
+					ContextWindow:     ctxWin,
+					RecentKeep:        p.taskTool.recentKeep,
+					SoftCompactRatio:  p.taskTool.softCompactRatio,
+					CompactRatio:      p.taskTool.compactRatio,
+					CompactForceRatio: p.taskTool.compactForceRatio,
+					ArchiveDir:        p.taskTool.archiveDir,
+					KeepPolicy:        p.taskTool.keepPolicy,
+				}, nested)
+
+				if runErr != nil {
+					sink.Emit(event.Event{
+						Kind: event.ToolResult,
+						Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: runErr.Error()},
+					})
+					doneCh <- subResult{index: idx, err: runErr}
+				} else {
+					sink.Emit(event.Event{
+						Kind: event.ToolResult,
+						Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Output: output},
+					})
+					doneCh <- subResult{index: idx, output: output}
+				}
 			}
-
-			sess := NewSession("")
-			output, runErr := RunSubAgentWithSession(ctx, prov, subReg, sess, t.Prompt, Options{
-				MaxSteps:          maxSteps,
-				Temperature:       p.taskTool.temperature,
-				Pricing:           pricing,
-				UsageSource:       event.UsageSourceSubagent,
-				Gate:              p.taskTool.gate,
-				ContextWindow:     ctxWin,
-				RecentKeep:        p.taskTool.recentKeep,
-				SoftCompactRatio:  p.taskTool.softCompactRatio,
-				CompactRatio:      p.taskTool.compactRatio,
-				CompactForceRatio: p.taskTool.compactForceRatio,
-				ArchiveDir:        p.taskTool.archiveDir,
-				KeepPolicy:        p.taskTool.keepPolicy,
-			}, nested)
-
-			if runErr != nil {
-				sink.Emit(event.Event{
-					Kind: event.ToolResult,
-					Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: runErr.Error()},
-				})
-				results <- subResult{index: idx, err: runErr}
-				return
-			}
-
-			sink.Emit(event.Event{
-				Kind: event.ToolResult,
-				Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Output: output},
-			})
-			results <- subResult{index: idx, output: output}
-		}(i, task)
+		}()
 	}
 
 	wg.Wait()
-	close(results)
+	close(spawnCh)
+	<-allDone
 
 	// Collect in order.
-	ordered := make([]subResult, len(params.Tasks))
-	for r := range results {
-		ordered[r.index] = r
-	}
-
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", len(params.Tasks)))
-	for _, r := range ordered {
-		if r.err != nil {
-			fmt.Fprintf(&b, "── task-%d ──\n[FAILED] %s\n", r.index+1, r.err)
+	b.WriteString(fmt.Sprintf("Completed %d parallel tasks:\n", n))
+	for i := 0; i < n; i++ {
+		if errors[i] != nil {
+			fmt.Fprintf(&b, "── task-%d ──\n[FAILED] %s\n", i+1, errors[i])
 		} else {
-			fmt.Fprintf(&b, "── task-%d ──\n%s\n", r.index+1, strings.TrimSpace(r.output))
+			fmt.Fprintf(&b, "── task-%d ──\n%s\n", i+1, strings.TrimSpace(outputs[i]))
 		}
 	}
 	return b.String(), nil

--- a/internal/agent/task.go
+++ b/internal/agent/task.go
@@ -24,6 +24,7 @@ If you need to ask for clarification, fail with a precise question instead of gu
 
 var subagentMetaTools = []string{
 	"task",
+	"parallel_tasks",
 	"run_skill",
 	"read_skill",
 	"install_skill",

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -459,13 +459,15 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			return "task tool is already enabled."
 		}
 		taskToolAdded = true
-		reg.Add(agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
+		tt := agent.NewTaskTool(execProv, entry.Price, reg, maxSteps,
 			entry.ContextWindow, cfg.Agent.RecentKeep, cfg.Agent.SoftCompactRatio, cfg.Agent.CompactRatio, cfg.Agent.CompactForceRatio,
 			cfg.Agent.Temperature, config.ArchiveDir(), "", headlessGate,
 			keepPolicy,
 			taskModel, taskEffort, resolveSubagentProvider).
 			WithTranscripts(subagentStore, root, modelName, entry.Effort).
-			WithTranscriptIdentityResolver(subagentIdentity))
+			WithTranscriptIdentityResolver(subagentIdentity)
+		reg.Add(tt)
+		reg.Add(agent.NewParallelTasksTool(tt, reg))
 		return "enabled task."
 	}
 	if !tokenEconomy {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -126,17 +126,17 @@ type Controller struct {
 
 	// mu guards the run state and approval bookkeeping; every critical section
 	// under it is short and non-blocking.
-	mu          sync.Mutex
-	cancel      context.CancelFunc
-	running     bool
-	canceling   bool
-	autosaveWG  sync.WaitGroup
-	planMode    bool
-	goal        string
-	goalStatus  string
-	goalTurns   int
-	goalBlocks  int
-	goalBlock   string
+	mu         sync.Mutex
+	cancel     context.CancelFunc
+	running    bool
+	canceling  bool
+	autosaveWG sync.WaitGroup
+	planMode   bool
+	goal       string
+	goalStatus string
+	goalTurns  int
+	goalBlocks int
+	goalBlock  string
 	// goalInterceptMsg, when non-empty, overrides the generic goalContinueTurn prompt
 	// for the next continuation turn. Used by advanceGoalAfterTurn to inject specific
 	// feedback such as incomplete-todo reminders.
@@ -154,11 +154,11 @@ type Controller struct {
 	// injected for the current goal. On first [goal:complete] with all todos
 	// done, the agent is asked to self-verify before final completion.
 	goalSelfCheckDone bool
-	sessionPath string
-	approvals   map[string]pendingApproval
-	asks        map[string]pendingAsk
-	granted     map[string]bool
-	nextID      int
+	sessionPath       string
+	approvals         map[string]pendingApproval
+	asks              map[string]pendingAsk
+	granted           map[string]bool
+	nextID            int
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
 	// approvedPlanAutoApproveTools auto-allows writer tool calls without prompting.
@@ -242,8 +242,8 @@ const (
 )
 
 const (
-	maxGoalAutoTurns = 50
-	goalContinueTurn = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
+	maxGoalAutoTurns  = 50
+	goalContinueTurn  = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
 	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
 )
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -527,6 +527,10 @@ const planApprovalTool = "exit_plan_mode"
 // the in-context nudge to execute and keep the (already-seeded) task list honest.
 const planApprovedMessage = "Plan approved — plan mode is off; you’re cleared to make the changes without asking again. Implement the plan now. Use this serial workflow: 1) mark the first sub-step in_progress with todo_write (this establishes the task list); 2) execute the sub-step; 3) call complete_step with evidence — the host then marks that sub-step completed and moves the next one to in_progress for you. Repeat 2–3 for each remaining sub-step. You don’t need another todo_write to mark steps completed; each complete_step advances the list. Sign off one sub-step at a time — never batch multiple completions."
 
+// planApprovedHint is appended to planApprovedMessage to suggest parallel
+// execution for independent tasks.
+const planApprovedHint = "\n\nIf some steps are independent (no overlapping files or dependencies), you can use the parallel_tasks tool to dispatch them concurrently for faster execution."
+
 // runTurn runs one model turn, then applies the plan-approval gate. This is the
 // single, frontend-agnostic plan flow: in plan mode the model just researches
 // (writers are blocked) and writes its plan as a normal answer — no special tool.
@@ -649,7 +653,7 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 		c.approvedPlanAutoApproveTools = false
 		c.mu.Unlock()
 	}()
-	if err := c.runner.Run(ctx, c.ComposeSynthetic(planApprovedMessage)); err != nil {
+	if err := c.runner.Run(ctx, c.ComposeSynthetic(planApprovedMessage+planApprovedHint)); err != nil {
 		return err
 	}
 	if todoArgs != "" && !c.hasTodoUpdateSince(execStart) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1084,6 +1084,9 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 		case "/plan-exec":
 			c.applyPlanExec(trimmed, display)
 			return
+		case "/prometheus":
+			c.applyPrometheus(trimmed, display)
+			return
 		}
 		if c.managementNotice(trimmed) {
 			return
@@ -1218,6 +1221,34 @@ func (c *Controller) applyPlanExec(input, display string) {
 	c.SetGoal("execute plan: " + ShortGoalForNotice(todos[0].Content))
 	c.GoalStrict(strict)
 	c.notice(fmt.Sprintf("plan-exec: dispatching %d plan steps (strict=%v)", total, strict))
+	if c.runner != nil {
+		c.runGuarded(func(ctx context.Context) error {
+			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)
+		})
+	}
+}
+
+// prometheusPrompt is the strategic planner system prompt.
+const prometheusPrompt = "You are Prometheus, a strategic planner. Your job is to interview the user about their request before any plan is created.\n\nFollow this process:\n1. Ask one clarifying question at a time \u2014 do not dump all questions at once\n2. Cover: scope, files involved, constraints, test strategy, edge cases\n3. Listen to each answer before asking the next question\n4. When you have enough context to create a solid plan, output a numbered plan with acceptance criteria, then end with [goal:complete]\n5. Do not start implementing \u2014 your role is purely planning\n\nKeep questions concise. Plan steps should be concrete and actionable."
+
+// applyPrometheus starts an interactive planning interview, inspired by OMO's
+// Prometheus agent. It enters goal mode with a structured interview prompt.
+func (c *Controller) applyPrometheus(input, display string) {
+	args := strings.TrimSpace(strings.TrimPrefix(input, "/prometheus"))
+	if args == "" || args == "--strict" {
+		c.notice("usage: /prometheus <your task description>")
+		return
+	}
+	strict := false
+	if strings.HasPrefix(args, "--strict ") {
+		strict = true
+		args = strings.TrimPrefix(args, "--strict ")
+	}
+	prompt := prometheusPrompt + "\n\n## User request\n\n" + args + "\n\nBegin the interview by asking your first clarifying question."
+	c.SetPlanMode(false)
+	c.GoalStrict(strict)
+	c.SetGoal("plan: " + ShortGoalForNotice(args))
+	c.notice("prometheus: starting planning interview")
 	if c.runner != nil {
 		c.runGuarded(func(ctx context.Context) error {
 			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -154,6 +154,9 @@ type Controller struct {
 	// injected for the current goal. On first [goal:complete] with all todos
 	// done, the agent is asked to self-verify before final completion.
 	goalSelfCheckDone bool
+	// goalIdleTurns counts consecutive turns without any tool call. When this
+	// exceeds the threshold an idle reminder is injected via goalInterceptMsg.
+	goalIdleTurns int
 	sessionPath       string
 	approvals         map[string]pendingApproval
 	asks              map[string]pendingAsk
@@ -243,6 +246,7 @@ const (
 
 const (
 	maxGoalAutoTurns  = 50
+	maxGoalIdleTurns  = 2
 	goalContinueTurn  = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
 	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
 )
@@ -712,6 +716,7 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		// Self-check passed — complete the goal.
 		c.goalIntercepts = 0
 		c.goalSelfCheckDone = false
+		c.goalIdleTurns = 0
 		c.goal = ""
 		c.goalStatus = GoalStatusComplete
 		c.goalBlocks = 0
@@ -738,6 +743,21 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.goalBlock = ""
 		c.goalIntercepts = 0
 		c.goalSelfCheckDone = false
+		c.goalIdleTurns = 0
+	}
+	// Idle detection: if the agent went multiple turns without any tool
+	// calls, inject a reminder to make progress (unless the goal is already
+	// completing or hitting the auto-turn limit).
+	if notice == "" && c.goalInterceptMsg == "" {
+		if c.toolWasCalledLastTurn() {
+			c.goalIdleTurns = 0
+		} else {
+			c.goalIdleTurns++
+			if c.goalIdleTurns >= maxGoalIdleTurns {
+				c.goalIdleTurns = 0
+				c.goalInterceptMsg = "The agent has gone multiple turns without any tool calls. If progress is being made, describe what you are doing and use tools to verify. If you are blocked, explain the issue and use [goal:blocked:<reason>]."
+			}
+		}
 	}
 	if notice == "" && c.goalTurns >= maxGoalAutoTurns {
 		c.goalStatus = GoalStatusBlocked
@@ -745,6 +765,7 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.goalIntercepts = 0
 		c.goalSelfCheckDone = false
 		c.goalInterceptMsg = ""
+		c.goalIdleTurns = 0
 		notice = c.goalBlock
 	}
 	cont := notice == ""
@@ -795,6 +816,22 @@ func (c *Controller) incompleteGoalTodos() string {
 	}
 	b.WriteString("\nIf the work is actually done, update your task list with todo_write or complete_step and run the required verification commands, then signal [goal:complete] again. Otherwise finish the remaining work.")
 	return b.String()
+}
+
+// toolWasCalledLastTurn reports whether the most recent assistant message
+// contained any tool calls, indicating the agent made observable progress.
+func (c *Controller) toolWasCalledLastTurn() bool {
+	msgs := c.History()
+	for i := len(msgs) - 1; i >= 0; i-- {
+		m := msgs[i]
+		if m.Role == provider.RoleAssistant {
+			return len(m.ToolCalls) > 0
+		}
+		if m.Role == provider.RoleUser {
+			return false
+		}
+	}
+	return false
 }
 
 func parseGoalStatusMarker(text string) (status, reason string, ok bool) {
@@ -855,6 +892,7 @@ func (c *Controller) stopGoal(status string) {
 	c.goalInterceptMsg = ""
 	c.goalIntercepts = 0
 	c.goalSelfCheckDone = false
+	c.goalIdleTurns = 0
 	c.mu.Unlock()
 }
 
@@ -1571,6 +1609,7 @@ func (c *Controller) SetGoal(goal string) {
 	c.goalInterceptMsg = ""
 	c.goalIntercepts = 0
 	c.goalSelfCheckDone = false
+	c.goalIdleTurns = 0
 	c.goalStrict = false
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1081,6 +1081,9 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 				c.notice(err.Error())
 			}
 			return
+		case "/plan-exec":
+			c.applyPlanExec(display)
+			return
 		}
 		if c.managementNotice(trimmed) {
 			return
@@ -1155,6 +1158,36 @@ func ShortGoalForNotice(goal string) string {
 		return goal
 	}
 	return string(runes[:max]) + "..."
+}
+
+// applyPlanExec reads the current canonical todo list and starts a goal that
+// analyzes and dispatches independent steps concurrently via parallel_tasks.
+func (c *Controller) applyPlanExec(display string) {
+	todos := c.executor.CanonicalTodoState()
+	if len(todos) == 0 {
+		c.notice("no active plan with todos to execute")
+		return
+	}
+	var b strings.Builder
+	b.WriteString("Analyze the following plan steps and dispatch independent ones concurrently using parallel_tasks:\n\n")
+	for i, t := range todos {
+		status := t.Status
+		if status == "" {
+			status = "pending"
+		}
+		fmt.Fprintf(&b, "%d. [%s] %s\n", i+1, status, t.Content)
+	}
+	b.WriteString("\nGroup steps that don't overlap (different files, no dependency) into parallel batches. Steps in the same batch run concurrently via parallel_tasks. Dependent steps wait for their prerequisites. Report progress after each batch completes.")
+	prompt := b.String()
+
+	c.SetPlanMode(false)
+	c.SetGoal("execute plan: " + ShortGoalForNotice(todos[0].Content))
+	c.notice("plan-exec: analyzing and dispatching plan steps")
+	if c.runner != nil {
+		c.runGuarded(func(ctx context.Context) error {
+			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)
+		})
+	}
 }
 
 // shellTimeout is the maximum time a user-invoked "!command" may run. Matches

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1082,7 +1082,7 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 			}
 			return
 		case "/plan-exec":
-			c.applyPlanExec(display)
+			c.applyPlanExec(trimmed, display)
 			return
 		}
 		if c.managementNotice(trimmed) {
@@ -1162,27 +1162,62 @@ func ShortGoalForNotice(goal string) string {
 
 // applyPlanExec reads the current canonical todo list and starts a goal that
 // analyzes and dispatches independent steps concurrently via parallel_tasks.
-func (c *Controller) applyPlanExec(display string) {
+// Supports --strict flag: /plan-exec --strict enables strict goal mode.
+func (c *Controller) applyPlanExec(input, display string) {
 	todos := c.executor.CanonicalTodoState()
 	if len(todos) == 0 {
 		c.notice("no active plan with todos to execute")
 		return
 	}
+
+	// Parse --strict flag.
+	strict := false
+	fields := strings.Fields(input)
+	for _, f := range fields {
+		if f == "--strict" {
+			strict = true
+			break
+		}
+	}
+
+	// Count completion status.
+	total := len(todos)
+	done := 0
+	for _, t := range todos {
+		if t.Status == "completed" {
+			done++
+		}
+	}
+
 	var b strings.Builder
-	b.WriteString("Analyze the following plan steps and dispatch independent ones concurrently using parallel_tasks:\n\n")
-	for i, t := range todos {
+	b.WriteString("You are the execution conductor. Read the following plan and execute it:\n\n")
+	for _, t := range todos {
 		status := t.Status
 		if status == "" {
 			status = "pending"
 		}
-		fmt.Fprintf(&b, "%d. [%s] %s\n", i+1, status, t.Content)
+		mark := " "
+		if status == "completed" {
+			mark = "x"
+		}
+		fmt.Fprintf(&b, "- [%s] %s (%s)\n", mark, t.Content, status)
 	}
-	b.WriteString("\nGroup steps that don't overlap (different files, no dependency) into parallel batches. Steps in the same batch run concurrently via parallel_tasks. Dependent steps wait for their prerequisites. Report progress after each batch completes.")
+	b.WriteString("\nExecution rules:\n")
+	b.WriteString("1. Identify steps that are independent (different files, no dependency) and group them into batches\n")
+	b.WriteString("2. Dispatch each batch concurrently using parallel_tasks\n")
+	b.WriteString("3. Dependent steps run after their prerequisites complete\n")
+	b.WriteString("4. After each batch, verify results before proceeding\n")
+	b.WriteString("5. If a step fails, fix it before moving on\n")
+	b.WriteString("6. Report progress after each batch\n")
+	if done > 0 {
+		fmt.Fprintf(&b, "\nNote: %d/%d steps are already completed. Focus on the remaining %d steps.\n", done, total, total-done)
+	}
 	prompt := b.String()
 
 	c.SetPlanMode(false)
 	c.SetGoal("execute plan: " + ShortGoalForNotice(todos[0].Content))
-	c.notice("plan-exec: analyzing and dispatching plan steps")
+	c.GoalStrict(strict)
+	c.notice(fmt.Sprintf("plan-exec: dispatching %d plan steps (strict=%v)", total, strict))
 	if c.runner != nil {
 		c.runGuarded(func(ctx context.Context) error {
 			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1274,6 +1274,11 @@ func (c *Controller) applyPlanExec(input, display string) {
 	}
 	prompt := b.String()
 
+	// Show module preview.
+	if len(modules) > 0 {
+		c.notice(fmt.Sprintf("plan-exec: detected %d modules — %s", len(modules), strings.Join(modules, ", ")))
+	}
+
 	c.SetPlanMode(false)
 	c.SetGoal("execute plan: " + ShortGoalForNotice(todos[0].Content))
 	c.GoalStrict(strict)
@@ -3763,7 +3768,7 @@ func (c *Controller) detectProjectModules() []string {
 	root := c.sessionDir
 	for i := 0; i < 3 && root != ""; i++ {
 		if hasFile(root, "go.mod") || hasFile(root, "package.json") || hasFile(root, ".git") {
-			return listSourceDirs(root)
+			return listSourceDirs(root, 2)
 		}
 		root = filepath.Dir(root)
 		if root == filepath.Dir(root) {
@@ -3778,27 +3783,46 @@ func hasFile(dir, name string) bool {
 	return err == nil
 }
 
-func listSourceDirs(root string) []string {
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return nil
-	}
-	var dirs []string
+
+
+
+func listSourceDirs(root string, maxDepth int) []string {
 	skip := map[string]bool{
 		".git": true, ".github": true, "node_modules": true,
 		"vendor": true, ".reasonix": true, "desktop": true,
-		"dist": true, "build": true, ".cache": true,
+		"dist": true, "build": true, ".cache": true, "bin": true,
+	}
+	var dirs []string
+	walkDir(root, "", skip, maxDepth, &dirs)
+	return dirs
+}
+
+func walkDir(root, rel string, skip map[string]bool, depth int, out *[]string) {
+	if depth <= 0 {
+		return
+	}
+	dir := root
+	if rel != "" {
+		dir = filepath.Join(root, rel)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
 	}
 	for _, e := range entries {
 		name := e.Name()
 		if !e.IsDir() || skip[name] || strings.HasPrefix(name, ".") {
 			continue
 		}
-		if hasSourceFiles(filepath.Join(root, name)) {
-			dirs = append(dirs, name)
+		childRel := name
+		if rel != "" {
+			childRel = rel + "/" + name
 		}
+		if hasSourceFiles(filepath.Join(root, childRel)) {
+			*out = append(*out, childRel)
+		}
+		walkDir(root, childRel, skip, depth-1, out)
 	}
-	return dirs
 }
 
 func hasSourceFiles(dir string) bool {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -137,6 +137,23 @@ type Controller struct {
 	goalTurns   int
 	goalBlocks  int
 	goalBlock   string
+	// goalInterceptMsg, when non-empty, overrides the generic goalContinueTurn prompt
+	// for the next continuation turn. Used by advanceGoalAfterTurn to inject specific
+	// feedback such as incomplete-todo reminders.
+	goalInterceptMsg string
+	// goalIntercepts counts consecutive incomplete-todo intercepts for the current
+	// goal. After the first intercept, the agent is reminded to update its todo
+	// list if the work is actually done; a second consecutive claim of completion
+	// is treated as an override and let through.
+	goalIntercepts int
+	// goalStrict, when true, disables the override escape hatch: every
+	// [goal:complete] while todos are incomplete is intercepted, and the
+	// agent must actually finish or update all items before it can complete.
+	goalStrict bool
+	// goalSelfCheckDone tracks whether the quality self-check prompt has been
+	// injected for the current goal. On first [goal:complete] with all todos
+	// done, the agent is asked to self-verify before final completion.
+	goalSelfCheckDone bool
 	sessionPath string
 	approvals   map[string]pendingApproval
 	asks        map[string]pendingAsk
@@ -227,6 +244,7 @@ const (
 const (
 	maxGoalAutoTurns = 50
 	goalContinueTurn = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
+	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
 )
 
 // RememberResult describes what happened when an approval rule was persisted.
@@ -646,7 +664,17 @@ func (c *Controller) continueGoal(ctx context.Context) error {
 			c.stopGoal(GoalStatusStopped)
 			return err
 		}
-		if err := c.runTurnWithRawDisplay(ctx, goalContinueTurn, goalContinueTurn, ""); err != nil {
+		turn := goalContinueTurn
+		c.mu.Lock()
+		if c.goalInterceptMsg != "" {
+			turn = c.goalInterceptMsg
+			c.goalInterceptMsg = ""
+			c.mu.Unlock()
+			c.notice("goal intercept: incomplete todos remain (override with a second [goal:complete])")
+		} else {
+			c.mu.Unlock()
+		}
+		if err := c.runTurnWithRawDisplay(ctx, turn, turn, ""); err != nil {
 			if ctx.Err() != nil {
 				c.stopGoal(GoalStatusStopped)
 			}
@@ -667,10 +695,28 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 	c.goalTurns++
 	switch status {
 	case GoalStatusComplete:
+		if incomplete := c.incompleteGoalTodos(); len(incomplete) > 0 && (c.goalStrict || c.goalIntercepts == 0) {
+			// In strict mode every claim is blocked until todos are done;
+			// otherwise only the first consecutive claim is intercepted.
+			c.goalIntercepts++
+			c.goalInterceptMsg = incomplete
+			break
+		}
+		// Todos are all done — in strict mode run self-check before final
+		// completion. Non-strict mode completes immediately.
+		if c.goalStrict && !c.goalSelfCheckDone {
+			c.goalSelfCheckDone = true
+			c.goalInterceptMsg = goalSelfCheckTurn
+			break
+		}
+		// Self-check passed — complete the goal.
+		c.goalIntercepts = 0
+		c.goalSelfCheckDone = false
 		c.goal = ""
 		c.goalStatus = GoalStatusComplete
 		c.goalBlocks = 0
 		c.goalBlock = ""
+		c.goalInterceptMsg = ""
 		notice = "goal complete"
 	case GoalStatusBlocked:
 		reason = cleanGoalBlockReason(reason)
@@ -690,10 +736,15 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 	default:
 		c.goalBlocks = 0
 		c.goalBlock = ""
+		c.goalIntercepts = 0
+		c.goalSelfCheckDone = false
 	}
 	if notice == "" && c.goalTurns >= maxGoalAutoTurns {
 		c.goalStatus = GoalStatusBlocked
 		c.goalBlock = "goal continuation limit reached"
+		c.goalIntercepts = 0
+		c.goalSelfCheckDone = false
+		c.goalInterceptMsg = ""
 		notice = c.goalBlock
 	}
 	cont := notice == ""
@@ -702,6 +753,48 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.notice(notice)
 	}
 	return cont
+}
+
+// incompleteGoalTodos checks the executor's canonical todo state and evidence
+// readiness (project checks) for anything that should block [goal:complete].
+// Returns a formatted reminder string, or empty if nothing is blocking.
+func (c *Controller) incompleteGoalTodos() string {
+	if c.executor == nil {
+		return ""
+	}
+	var parts []string
+
+	// 1. Check canonical todos.
+	todos := c.executor.CanonicalTodoState()
+	if len(todos) > 0 {
+		incomplete := evidence.IncompleteTodos(todos)
+		if len(incomplete) > 0 {
+			var b strings.Builder
+			b.WriteString("the following tasks are still incomplete:")
+			for _, t := range incomplete {
+				fmt.Fprintf(&b, "\n  - %s (%s)", t.Content, t.Status)
+			}
+			parts = append(parts, b.String())
+		}
+	}
+
+	// 2. Check evidence readiness (project checks from AGENTS.md).
+	if reason := c.executor.GoalReadinessFailure(); reason != "" {
+		parts = append(parts, reason)
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.WriteString("The agent signaled goal completion but the following issues remain:\n")
+	for _, p := range parts {
+		b.WriteString(p)
+		b.WriteString("\n")
+	}
+	b.WriteString("\nIf the work is actually done, update your task list with todo_write or complete_step and run the required verification commands, then signal [goal:complete] again. Otherwise finish the remaining work.")
+	return b.String()
 }
 
 func parseGoalStatusMarker(text string) (status, reason string, ok bool) {
@@ -759,6 +852,9 @@ func (c *Controller) stopGoal(status string) {
 	if strings.TrimSpace(c.goal) != "" && c.goalStatus == GoalStatusRunning {
 		c.goalStatus = status
 	}
+	c.goalInterceptMsg = ""
+	c.goalIntercepts = 0
+	c.goalSelfCheckDone = false
 	c.mu.Unlock()
 }
 
@@ -987,6 +1083,7 @@ func (c *Controller) applyGoalCommand(input, display string) bool {
 	switch cmd.Action {
 	case GoalCommandSet:
 		c.SetPlanMode(false)
+		c.GoalStrict(cmd.Strict)
 		c.SetGoal(cmd.Text)
 		c.notice(fmt.Sprintf(i18n.M.GoalSetFmt, ShortGoalForNotice(cmd.Text)))
 		if c.runner != nil {
@@ -1439,6 +1536,15 @@ func (c *Controller) PlanMode() bool {
 	return c.planMode
 }
 
+// GoalStrict enables or disables strict goal mode. In strict mode the agent
+// cannot override an incomplete-todo intercept — it must actually finish or
+// update all items before [goal:complete] is accepted.
+func (c *Controller) GoalStrict(strict bool) {
+	c.mu.Lock()
+	c.goalStrict = strict
+	c.mu.Unlock()
+}
+
 // SetGoal stores a session-scoped active goal. Compose injects it into outgoing
 // user turns, not the system prompt or tool schema, so it does not disturb the
 // cache-stable prefix.
@@ -1462,6 +1568,10 @@ func (c *Controller) SetGoal(goal string) {
 	c.goalTurns = 0
 	c.goalBlocks = 0
 	c.goalBlock = ""
+	c.goalInterceptMsg = ""
+	c.goalIntercepts = 0
+	c.goalSelfCheckDone = false
+	c.goalStrict = false
 }
 
 func (c *Controller) ClearGoal() {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1128,8 +1128,8 @@ func (c *Controller) applyGoalCommand(input, display string) bool {
 	switch cmd.Action {
 	case GoalCommandSet:
 		c.SetPlanMode(false)
-		c.GoalStrict(cmd.Strict)
 		c.SetGoal(cmd.Text)
+		c.GoalStrict(cmd.Strict)
 		c.notice(fmt.Sprintf(i18n.M.GoalSetFmt, ShortGoalForNotice(cmd.Text)))
 		if c.runner != nil {
 			c.runGuarded(func(ctx context.Context) error {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1237,6 +1237,17 @@ func (c *Controller) applyPlanExec(input, display string) {
 
 	var b strings.Builder
 	b.WriteString("You are the execution conductor. Your job: route each plan step to the right sub-agent so each sub-agent has a clean, focused context.\n\n")
+
+	// Detect project structure for module-aware routing.
+	modules := c.detectProjectModules()
+	if len(modules) > 0 {
+		b.WriteString("## Project modules detected\n\n")
+		for _, m := range modules {
+			fmt.Fprintf(&b, "- %s/", m)
+		}
+		b.WriteString("\n\nRoute steps to the module they belong to. Steps in different modules can run in parallel.\n\n")
+	}
+
 	b.WriteString("## Plan steps\n\n")
 	for _, t := range todos {
 		status := t.Status
@@ -3744,4 +3755,61 @@ func (c *Controller) emitRememberResult(r RememberResult) {
 	case strings.TrimSpace(r.CoveredBy) != "":
 		c.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf(i18n.M.PermissionAlreadyAllowedFmt, r.Path, r.CoveredBy)})
 	}
+}
+
+// detectProjectModules scans the workspace root for top-level source directories
+// to enable module-aware task routing in /plan-exec.
+func (c *Controller) detectProjectModules() []string {
+	root := c.sessionDir
+	for i := 0; i < 3 && root != ""; i++ {
+		if hasFile(root, "go.mod") || hasFile(root, "package.json") || hasFile(root, ".git") {
+			return listSourceDirs(root)
+		}
+		root = filepath.Dir(root)
+		if root == filepath.Dir(root) {
+			break
+		}
+	}
+	return nil
+}
+
+func hasFile(dir, name string) bool {
+	_, err := os.Stat(filepath.Join(dir, name))
+	return err == nil
+}
+
+func listSourceDirs(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	skip := map[string]bool{
+		".git": true, ".github": true, "node_modules": true,
+		"vendor": true, ".reasonix": true, "desktop": true,
+		"dist": true, "build": true, ".cache": true,
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if !e.IsDir() || skip[name] || strings.HasPrefix(name, ".") {
+			continue
+		}
+		if hasSourceFiles(filepath.Join(root, name)) {
+			dirs = append(dirs, name)
+		}
+	}
+	return dirs
+}
+
+func hasSourceFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -104,6 +104,10 @@ type Controller struct {
 	reg       *tool.Registry
 	pluginCtx context.Context
 
+	// goalStatePath is where the current goal state is persisted for session
+	// continuity. Empty means no persistence.
+	goalStatePath string
+
 	// Checkpoints (snapshot-based rewind). cp is the per-session store rebound when
 	// the session path changes; cpRoot is the workspace root used to guard restore
 	// writes. cpTurn is the monotonic turn counter (decoupled from the store so it
@@ -721,6 +725,7 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.goalIntercepts = 0
 		c.goalSelfCheckDone = false
 		c.goalIdleTurns = 0
+		c.saveGoalState()
 		c.goal = ""
 		c.goalStatus = GoalStatusComplete
 		c.goalBlocks = 0
@@ -771,6 +776,9 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.goalInterceptMsg = ""
 		c.goalIdleTurns = 0
 		notice = c.goalBlock
+	}
+	if notice != "" {
+		c.saveGoalState()
 	}
 	cont := notice == ""
 	c.mu.Unlock()
@@ -897,7 +905,42 @@ func (c *Controller) stopGoal(status string) {
 	c.goalIntercepts = 0
 	c.goalSelfCheckDone = false
 	c.goalIdleTurns = 0
+	c.saveGoalState()
 	c.mu.Unlock()
+}
+
+// saveGoalState persists the current goal state to disk for session continuity.
+func (c *Controller) saveGoalState() {
+	if c.goalStatePath == "" || c.executor == nil {
+		return
+	}
+	todos := c.executor.CanonicalTodoState()
+	state := goalState{
+		Goal:       c.goal,
+		Status:     c.goalStatus,
+		Turns:      c.goalTurns,
+		Blocks:     c.goalBlocks,
+		Block:      c.goalBlock,
+		Strict:     c.goalStrict,
+		Todos:      todos,
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return
+	}
+	_ = os.MkdirAll(filepath.Dir(c.goalStatePath), 0o755)
+	_ = os.WriteFile(c.goalStatePath, data, 0o644)
+}
+
+// goalState is the serializable form of a running goal.
+type goalState struct {
+	Goal   string            `json:"goal,omitempty"`
+	Status string            `json:"status,omitempty"`
+	Turns  int               `json:"turns,omitempty"`
+	Blocks int               `json:"blocks,omitempty"`
+	Block  string            `json:"block,omitempty"`
+	Strict bool              `json:"strict,omitempty"`
+	Todos  []evidence.TodoItem `json:"todos,omitempty"`
 }
 
 // lastAssistantText returns the content of the most recent assistant message with
@@ -1714,6 +1757,7 @@ func (c *Controller) SetGoal(goal string) {
 	c.goalSelfCheckDone = false
 	c.goalIdleTurns = 0
 	c.goalStrict = false
+	c.saveGoalState()
 }
 
 func (c *Controller) ClearGoal() {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1236,7 +1236,8 @@ func (c *Controller) applyPlanExec(input, display string) {
 	}
 
 	var b strings.Builder
-	b.WriteString("You are the execution conductor. Read the following plan and execute it:\n\n")
+	b.WriteString("You are the execution conductor. Your job: route each plan step to the right sub-agent so each sub-agent has a clean, focused context.\n\n")
+	b.WriteString("## Plan steps\n\n")
 	for _, t := range todos {
 		status := t.Status
 		if status == "" {
@@ -1248,13 +1249,15 @@ func (c *Controller) applyPlanExec(input, display string) {
 		}
 		fmt.Fprintf(&b, "- [%s] %s (%s)\n", mark, t.Content, status)
 	}
-	b.WriteString("\nExecution rules:\n")
-	b.WriteString("1. Identify steps that are independent (different files, no dependency) and group them into batches\n")
-	b.WriteString("2. Dispatch each batch concurrently using parallel_tasks\n")
-	b.WriteString("3. Dependent steps run after their prerequisites complete\n")
-	b.WriteString("4. After each batch, verify results before proceeding\n")
-	b.WriteString("5. If a step fails, fix it before moving on\n")
-	b.WriteString("6. Report progress after each batch\n")
+	b.WriteString("\n## Routing rules\n")
+	b.WriteString("1. Analyze each step: what files/directories does it touch? What module is it about?\n")
+	b.WriteString("2. Group steps by MODULE — steps in different modules can run in parallel batches\n")
+	b.WriteString("3. Steps in the SAME module must run sequentially (to avoid context pollution)\n")
+	b.WriteString("4. Dispatch each batch using parallel_tasks — each sub-agent gets ONLY its module's context\n")
+	b.WriteString("5. After each batch, verify results before proceeding to the next batch\n")
+	b.WriteString("6. If a step fails, fix it before moving on\n")
+	b.WriteString("7. Report which module each batch covered\n")
+	b.WriteString("\nGoal: each sub-agent focuses on one module and does not carry irrelevant context.\n")
 	if done > 0 {
 		fmt.Fprintf(&b, "\nNote: %d/%d steps are already completed. Focus on the remaining %d steps.\n", done, total, total-done)
 	}
@@ -1272,7 +1275,7 @@ func (c *Controller) applyPlanExec(input, display string) {
 }
 
 // prometheusPrompt is the strategic planner system prompt.
-const prometheusPrompt = "You are Prometheus, a strategic planner. Your job is to interview the user about their request before any plan is created.\n\nFollow this process:\n1. Ask one clarifying question at a time \u2014 do not dump all questions at once\n2. Cover: scope, files involved, constraints, test strategy, edge cases\n3. Listen to each answer before asking the next question\n4. When you have enough context to create a solid plan, output a numbered plan with acceptance criteria, then end with [goal:complete]\n5. Do not start implementing \u2014 your role is purely planning\n\nKeep questions concise. Plan steps should be concrete and actionable."
+const prometheusPrompt = "You are Prometheus, a strategic planner. Your job is to interview the user and produce a plan organized by project module.\n\nProcess:\n1. Ask one clarifying question at a time\n2. Cover: scope, module boundaries, files involved, constraints, test strategy\n3. Understand which modules/directories are affected\n4. When ready, output a numbered plan with each step tagged by module, plus acceptance criteria\n5. End with [goal:complete]\n6. Do not start implementing\n\nEach plan step should specify which file, directory, or module it belongs to. This lets the execution conductor route steps to the right sub-agent."
 
 // applyPrometheus starts an interactive planning interview, inspired by OMO's
 // Prometheus agent. It enters goal mode with a structured interview prompt.

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -1291,8 +1291,8 @@ func TestApprovedPlanAutoApproveEndsWithExecutionTurn(t *testing.T) {
 			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "1. Create the file\n2. Update the file"})
 		},
 		func(input string) {
-			if input != planApprovedMessage {
-				t.Fatalf("approved execution input = %q, want planApprovedMessage", input)
+			if !strings.HasPrefix(input, planApprovedMessage) || !strings.HasSuffix(input, planApprovedHint) {
+				t.Fatalf("approved execution input = %q, want planApprovedMessage+planApprovedHint", input)
 			}
 			exec.Session().Add(provider.Message{Role: provider.RoleAssistant, Content: "first step done; paused for review", ToolCalls: []provider.ToolCall{{
 				ID: "todo-1", Name: "todo_write", Arguments: `{"todos":[{"content":"Create the file","status":"completed"},{"content":"Update the file","status":"in_progress"}]}`,

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -6,6 +6,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/event"
+	"reasonix/internal/evidence"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -147,5 +148,131 @@ func TestGoalRestartResetsBlockedAudit(t *testing.T) {
 	}
 	if got := c.GoalStatus(); got != GoalStatusComplete {
 		t.Fatalf("resumed GoalStatus() = %q, want complete; blocked audit should restart", got)
+	}
+}
+
+// TestIncompleteGoalTodos verifies that incompleteGoalTodos detects
+// unfinished tasks and returns a formatted reminder, and returns empty
+// when all todos are complete.
+func TestIncompleteGoalTodos(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("done")}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	c := New(Options{Runner: ag, Executor: ag, Sink: event.Discard})
+
+	// Seed with incomplete todos.
+	ag.SeedTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "in_progress"},
+		{Content: "Add tests", Status: "pending"},
+	})
+	msg := c.incompleteGoalTodos()
+	if msg == "" {
+		t.Fatal("incompleteGoalTodos() returned empty string, expected reminder")
+	}
+	if !strings.Contains(msg, "Fix the parser") {
+		t.Fatalf("reminder should mention 'Fix the parser', got: %q", msg)
+	}
+	if !strings.Contains(msg, "Add tests") {
+		t.Fatalf("reminder should mention 'Add tests', got: %q", msg)
+	}
+	if !strings.Contains(msg, "todo_write") {
+		t.Fatalf("reminder should suggest updating todos via todo_write, got: %q", msg)
+	}
+
+	// Mark all complete.
+	ag.ReplaceTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "completed"},
+		{Content: "Add tests", Status: "completed"},
+	})
+	if got := c.incompleteGoalTodos(); got != "" {
+		t.Fatalf("incompleteGoalTodos() with all-complete = %q, want empty", got)
+	}
+
+	// Empty todo list.
+	ag.ReplaceTodoState(nil)
+	if got := c.incompleteGoalTodos(); got != "" {
+		t.Fatalf("incompleteGoalTodos() with empty list = %q, want empty", got)
+	}
+}
+
+// TestGoalInterceptsCompleteWithIncompleteTodos verifies that when the
+// agent claims [goal:complete] but has unfinished canonical todos, the
+// goal loop intercepts the first claim, then lets a second consecutive
+// claim through as an override.
+func TestGoalInterceptsCompleteWithIncompleteTodos(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("All done.\n\n[goal:complete]"),
+		textTurn("All done.\n\n[goal:complete]"),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	// Seed incomplete todos before starting.
+	ag.SeedTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "in_progress"},
+	})
+
+	notices := make(chan string, 64)
+	done := make(chan event.Event, 1)
+	c := New(Options{
+		Runner:   ag,
+		Executor: ag,
+		Sink: event.FuncSink(func(e event.Event) {
+			switch e.Kind {
+			case event.Notice:
+				notices <- e.Text
+			case event.TurnDone:
+				done <- e
+			}
+		}),
+	})
+
+	c.Submit("/goal fix everything")
+	<-done // wait for the entire goal loop to finish
+	close(notices)
+
+	// Collect all notices.
+	var allNotices []string
+	for n := range notices {
+		allNotices = append(allNotices, n)
+	}
+
+	// Should see an intercept notice and the goal should complete
+	// (second [goal:complete] overrides the intercept).
+	found := false
+	for _, n := range allNotices {
+		if strings.Contains(n, "goal intercept") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a 'goal intercept' notice, got %v", allNotices)
+	}
+	if c.GoalStatus() != GoalStatusComplete {
+		t.Fatalf("GoalStatus() = %q, want complete (second [goal:complete] should override)", c.GoalStatus())
+	}
+}
+
+// TestStrictGoalBlocksRepeatedComplete verifies that in strict mode, every
+// [goal:complete] with incomplete todos is intercepted — no override allowed.
+func TestStrictGoalBlocksRepeatedComplete(t *testing.T) {
+	prov := &scriptedTurns{turns: [][]provider.Chunk{
+		textTurn("Done!\n\n[goal:complete]"),
+	}}
+	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
+	ag.SeedTodoState([]evidence.TodoItem{
+		{Content: "Fix the parser", Status: "in_progress"},
+	})
+
+	c := New(Options{Runner: ag, Executor: ag, Sink: event.Discard})
+
+	// Enable strict mode.
+	c.GoalStrict(true)
+	c.Submit("/goal fix everything")
+
+	// In strict mode the agent still has incomplete todos but only one
+	// turn was given (the provider recycles it). The goal loop keeps
+	// intercepting; when the turn-recycling hits maxGoalAutoTurns (50)
+	// the goal is blocked. Verify it's not "complete".
+	if c.GoalStatus() == GoalStatusComplete {
+		t.Fatal("strict mode should not allow goal completion with incomplete todos")
 	}
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -188,6 +188,7 @@ const (
 type GoalCommand struct {
 	Action GoalCommandAction
 	Text   string
+	Strict bool
 }
 
 func ParseGoalCommand(input string) (GoalCommand, bool) {
@@ -196,13 +197,27 @@ func ParseGoalCommand(input string) (GoalCommand, bool) {
 		return GoalCommand{}, false
 	}
 	args := strings.TrimSpace(trimmed[len("/goal"):])
-	switch strings.ToLower(args) {
+
+	// Parse --strict flag before checking action.
+	strict := false
+	fields := strings.Fields(args)
+	cleaned := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f == "--strict" {
+			strict = true
+		} else {
+			cleaned = append(cleaned, f)
+		}
+	}
+	actionArgs := strings.Join(cleaned, " ")
+
+	switch strings.ToLower(actionArgs) {
 	case "", "status":
-		return GoalCommand{Action: GoalCommandStatus}, true
+		return GoalCommand{Action: GoalCommandStatus, Strict: strict}, true
 	case "clear", "off", "stop", "done":
-		return GoalCommand{Action: GoalCommandClear}, true
+		return GoalCommand{Action: GoalCommandClear, Strict: strict}, true
 	default:
-		return GoalCommand{Action: GoalCommandSet, Text: args}, true
+		return GoalCommand{Action: GoalCommandSet, Text: actionArgs, Strict: strict}, true
 	}
 }
 

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -221,14 +221,14 @@ func TestGoalCommandSetsReportsAndClears(t *testing.T) {
 
 func TestParseGoalCommandWithStrict(t *testing.T) {
 	tests := []struct {
-		input string
-		text  string
+		input  string
+		text   string
 		strict bool
-		ok    bool
+		ok     bool
 	}{
 		{"/goal --strict implement calculator", "implement calculator", true, true},
 		{"/goal implement calculator", "implement calculator", false, true},
-		{"/goal --strict", "", true, true}, // --strict shows status
+		{"/goal --strict", "", true, true},        // --strict shows status
 		{"/goal --strict status", "", true, true}, // --strict shows status
 	}
 	for _, tt := range tests {

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -219,6 +219,36 @@ func TestGoalCommandSetsReportsAndClears(t *testing.T) {
 	}
 }
 
+func TestParseGoalCommandWithStrict(t *testing.T) {
+	tests := []struct {
+		input string
+		text  string
+		strict bool
+		ok    bool
+	}{
+		{"/goal --strict implement calculator", "implement calculator", true, true},
+		{"/goal implement calculator", "implement calculator", false, true},
+		{"/goal --strict", "", true, true}, // --strict shows status
+		{"/goal --strict status", "", true, true}, // --strict shows status
+	}
+	for _, tt := range tests {
+		cmd, ok := ParseGoalCommand(tt.input)
+		if ok != tt.ok {
+			t.Errorf("ParseGoalCommand(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if cmd.Text != tt.text {
+			t.Errorf("ParseGoalCommand(%q).Text = %q, want %q", tt.input, cmd.Text, tt.text)
+		}
+		if cmd.Strict != tt.strict {
+			t.Errorf("ParseGoalCommand(%q).Strict = %v, want %v", tt.input, cmd.Strict, tt.strict)
+		}
+	}
+}
+
 func TestComposeDrainsQueuedMemory(t *testing.T) {
 	c := New(Options{}) // no executor/memory — QueueMemory still queues a turn-tail note
 


### PR DESCRIPTION
## 概述

在 #4821（已合入 #4824）的基础上，增加了更多 OMO 风格的功能增强。

## 新增功能

### 1. Idle 检测
- 连续 2 轮无工具调用时自动提醒 agent 推进或说明卡点
- 通过 goalInterceptMsg 机制注入提醒，不额外消耗 token

### 2. Prometheus 规划面试（`/prometheus`）
- 交互式问答：一次问一个澄清问题，覆盖范围、文件、约束
- 收集足够上下文后自动生成带模块标签的计划
- 支持 `--strict` 模式

### 3. Atlas 执行指挥（`/plan-exec`）
- 读取 canonical todos，自动按模块分组并行执行
- 自动检测项目结构（2 层深度），注入模块地图到 conductor prompt
- 支持 `--strict` 模式
- `planApprovedMessage` 增加并行提示

### 4. 文件式 Wisdom 积累
- 子任务结果写入 temp 文件而非拼进 prompt
- 依赖任务通过 `read_file` 按需读取，节省 token

### 5. Goal 状态持久化
- 每次状态变化写入 `sessionDir/.goal-state.json`
- 留出恢复接口供后续开发使用

### 6. UI 改进
- `StripGoalMarkers()` 从显示文本剥离 `[goal:complete]`/`[goal:continue]`
- `[goal:blocked:xxx]` 转为 `⚠️ Blocked: xxx`

### 7. 文档
- `docs/GOAL_ENFORCEMENT.zh-CN.md` 中文指南
- 覆盖 todo 拦截、strict、并行调度、idle 检测

## 测试
`go test ./internal/control/ ./internal/agent/` — 全部通过。