### PR TITLE
Fix TUI transcript divider width / 修复 TUI transcript 分割线宽度

### DIFF
--- a/internal/cli/branch.go
+++ b/internal/cli/branch.go
@@ -118,8 +118,9 @@ func (m *chatTUI) replayActiveBranch(title string) {
 	if title != "" {
 		m.commitLine(dim("  -- " + title + " --"))
 	}
-	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
-	for _, section := range replaySectionsFor(m.ctrl.History(), m.width, m.renderer) {
+	contentW := transcriptContentWidth(m.width, m.nativeScrollback)
+	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", contentW), "\n"))
+	for _, section := range replaySectionsFor(m.ctrl.History(), contentW, m.renderer) {
 		m.commitLine(strings.TrimRight(section, "\n"))
 	}
 }

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -460,6 +460,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 
 	commitBuf := []string{}
 	nativeScrollback := detectTermuxTerminal()
+	renderW := transcriptContentWidth(termW, nativeScrollback)
 	return chatTUI{
 		ctrl:                 ctrl,
 		label:                ctrl.Label(),
@@ -477,7 +478,7 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		reasoning:            &strings.Builder{},
 		pending:              &strings.Builder{},
 		pendingCommit:        &commitBuf,
-		renderer:             newMarkdownRenderer(termW),
+		renderer:             newMarkdownRenderer(renderW),
 		diffMaxLines:         diffFoldLimit,
 		showReasoning:        nativeScrollback,
 		shellOutputs:         make(map[string]string),
@@ -492,6 +493,13 @@ func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Eve
 		viewport:             viewport.New(viewport.WithWidth(termW)),
 		statusLineCount:      2,
 	}
+}
+
+func transcriptContentWidth(termW int, nativeScrollback bool) int {
+	if !nativeScrollback {
+		termW-- // reserve the last column for the transcript scrollbar
+	}
+	return max(termW, 1)
 }
 
 func configureChatTextarea(ti *textarea.Model) {
@@ -668,14 +676,7 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	next, cmd := m.update(msg)
 	cm := next.(chatTUI)
 
-	contentW := cm.width - 1 // last column is the scrollbar
-	if contentW < 1 {
-		contentW = 1
-	}
-	// Recompute the wrapped status-line count so bottomRows reserves the right
-	// height for the viewport. The data-line tags (model, git, effort, context,
-	// cache, jobs, balance) are the ones most likely to wrap on a narrow terminal.
-	cm.statusLineCount = cm.computeStatusLineCount(contentW)
+	contentW := transcriptContentWidth(cm.width, cm.nativeScrollback)
 	cm.viewport.SetWidth(contentW)
 	// Recompute the wrapped status-line count so bottomRows reserves the right
 	// height for the viewport. Use cm.width (same as boxW in View()) so the
@@ -714,16 +715,17 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.input.SetWidth(msg.Width - 4)
-		m.renderer = newMarkdownRenderer(msg.Width)
+		contentW := transcriptContentWidth(msg.Width, m.nativeScrollback)
+		m.renderer = newMarkdownRenderer(contentW)
 		// Commit the banner — and a resumed session's transcript — once, now
 		// that the width is known.
 		if !m.started {
 			m.started = true
 			var b strings.Builder
-			b.WriteString(renderTUIBanner(m.label, m.missing, msg.Width))
+			b.WriteString(renderTUIBanner(m.label, m.missing, contentW))
 			if len(m.history) > 0 {
-				r := newMarkdownRenderer(msg.Width)
-				for _, sec := range replaySectionsFor(m.history, msg.Width, r) {
+				r := newMarkdownRenderer(contentW)
+				for _, sec := range replaySectionsFor(m.history, contentW, r) {
 					b.WriteString(sec)
 				}
 				m.history = nil

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -514,6 +514,38 @@ func TestMainManagerFollowsTranscriptWithoutTopPadding(t *testing.T) {
 	}
 }
 
+func TestMarkdownDividerFitsTranscriptContentWidth(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
+	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 20})
+	m = m0.(chatTUI)
+
+	wantW := transcriptContentWidth(80, false)
+	if m.viewport.Width() != wantW {
+		t.Fatalf("viewport width = %d, want transcript content width %d", m.viewport.Width(), wantW)
+	}
+	rule := strings.TrimRight(m.renderer.Render("---"), "\n")
+	lines := strings.Split(wrapTranscript(rule, m.viewport.Width()), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("markdown divider wrapped into %d lines at width %d: %q", len(lines), m.viewport.Width(), lines)
+	}
+	if w := visibleWidth(lines[0]); w != m.viewport.Width() {
+		t.Fatalf("markdown divider width = %d, want %d: %q", w, m.viewport.Width(), lines[0])
+	}
+}
+
+func TestTranscriptContentWidthReservesScrollbarColumn(t *testing.T) {
+	if got := transcriptContentWidth(80, false); got != 79 {
+		t.Fatalf("transcriptContentWidth(80, false) = %d, want 79", got)
+	}
+	if got := transcriptContentWidth(80, true); got != 80 {
+		t.Fatalf("transcriptContentWidth(80, true) = %d, want 80", got)
+	}
+	if got := transcriptContentWidth(0, false); got != 1 {
+		t.Fatalf("transcriptContentWidth(0, false) = %d, want 1", got)
+	}
+}
+
 func TestModalPanelsHideComposerBox(t *testing.T) {
 	ask := event.Ask{
 		ID: "ask-1",

--- a/internal/cli/clear_confirm.go
+++ b/internal/cli/clear_confirm.go
@@ -61,7 +61,7 @@ func (m *chatTUI) resetFreshContextView(clearTranscript bool) {
 	} else {
 		m.commitLine("")
 	}
-	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", m.width), "\n"))
+	m.commitLine(strings.TrimRight(renderTUIBanner(m.label, "", transcriptContentWidth(m.width, m.nativeScrollback)), "\n"))
 	m.transcriptDirty = true
 	m.forceGotoBottom = true
 }


### PR DESCRIPTION
## Summary

Fixes #4789.

This integration PR fixes the TUI transcript divider wrap bug by making Markdown transcript rendering use the same content width as the transcript viewport. The normal transcript reserves the last terminal column for the scrollbar, while native scrollback keeps the full terminal width.

## Integrated work

- Integrates the root-cause fix from #4791: a shared `transcriptContentWidth` helper now drives Markdown rendering, startup banners, branch replay, history replay, and clear-context banners.
- Absorbs the useful width-contract idea from #4095 without taking its broader user-bubble separator feature: tests now assert that transcript rendering uses the current content width rather than the raw terminal width.

## Verification

- `git diff --check`
- `go test ./internal/cli -run 'TestMarkdownDividerFitsTranscriptContentWidth|TestTranscriptContentWidthReservesScrollbarColumn' -count=1`
- `go test ./internal/cli -count=1`

## Authorship note

@SivanCola is the primary author of this integration PR. @taibai233 contributed the original divider-width diagnosis and patch in #4791. @CnsMaple contributed the related current-width separator/testing approach in #4095.
