### PR TITLE
ci: require cache impact notes for sensitive PRs / 要求缓存敏感 PR 填写影响说明

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+-
+
+## Verification
+
+-
+
+## Cache impact
+
+Cache-impact: TODO
+Cache-guard: TODO
+System-prompt-review: N/A
+
+For cache-sensitive changes, fill these lines before requesting review:
+
+- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
+- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
+- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.

--- a/.github/workflows/cache-impact.yml
+++ b/.github/workflows/cache-impact.yml
@@ -1,0 +1,27 @@
+name: Cache impact guard
+
+on:
+  pull_request:
+    branches: [main-v2]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-impact-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cache-impact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check cache-sensitive PR metadata
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash scripts/check-cache-impact.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,28 @@ make hooks          # install git hooks (pre-push: go vet)
 make cross          # cross-compile for all 6 targets
 ```
 
+### Cache-first review gate
+
+Reasonix treats high prompt-cache hit rate as product behavior. Changes that
+touch provider-visible system prompt construction, memory prefix, output styles,
+skill index behavior, default tool surfaces, tool schemas, provider request
+serialization, compaction, or MCP/tool registration need explicit cache review.
+
+For these changes:
+
+- Keep system prompt changes low-frequency and require explicit review.
+- Fill the PR body `Cache-impact:` line with `none`, `low`, `medium`, or `high`
+  plus the reason.
+- Fill the PR body `Cache-guard:` line with the focused guard test/command added
+  or run, or explain why an existing guard covers the change.
+- Fill `System-prompt-review:` when system prompt, memory prefix, output style,
+  or skill index behavior changes.
+- Prefer focused guard tests near the changed surface; `scripts/cache-guard.sh`
+  remains the broader release-level cache-hit check.
+
+CI enforces this metadata for cache-sensitive paths so prompt/tool prefix churn
+is called out before review.
+
 ### Running tests
 
 ```bash

--- a/scripts/check-cache-impact.sh
+++ b/scripts/check-cache-impact.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-cache-impact.sh [changed-file ...]
+
+Checks that PRs touching cache-sensitive prompt or tool surfaces include an
+explicit cache-impact note and guard-test note in the pull request body.
+
+Inputs:
+  CACHE_IMPACT_PR_BODY or PR_BODY          Pull request body text.
+  CACHE_IMPACT_PR_BODY_FILE               File containing the pull request body.
+  CACHE_IMPACT_CHANGED_FILES              Newline-separated changed files.
+  CACHE_IMPACT_BASE_SHA / BASE_SHA        Diff base when files are not supplied.
+  CACHE_IMPACT_HEAD_SHA / HEAD_SHA        Diff head when files are not supplied.
+USAGE
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+body="${CACHE_IMPACT_PR_BODY:-${PR_BODY:-}}"
+if [[ -n "${CACHE_IMPACT_PR_BODY_FILE:-}" ]]; then
+  body="$(cat "$CACHE_IMPACT_PR_BODY_FILE")"
+fi
+
+changed_input=""
+if [[ "$#" -gt 0 ]]; then
+  changed_input="$(printf '%s\n' "$@")"
+elif [[ -n "${CACHE_IMPACT_CHANGED_FILES:-}" ]]; then
+  changed_input="$CACHE_IMPACT_CHANGED_FILES"
+else
+  base="${CACHE_IMPACT_BASE_SHA:-${BASE_SHA:-}}"
+  head="${CACHE_IMPACT_HEAD_SHA:-${HEAD_SHA:-HEAD}}"
+  if [[ -z "$base" ]]; then
+    base="$(git merge-base origin/main-v2 "$head" 2>/dev/null || git merge-base main-v2 "$head")"
+  fi
+  changed_input="$(git diff --name-only "$base" "$head")"
+fi
+
+changed_files=()
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  changed_files+=("$file")
+done <<< "$changed_input"
+
+cache_sensitive=()
+system_prompt_sensitive=()
+
+for file in "${changed_files[@]:-}"; do
+  case "$file" in
+    internal/agent/agent.go|\
+    internal/agent/cache*|\
+    internal/agent/compact*|\
+    internal/agent/parallel_tasks.go|\
+    internal/agent/prune*|\
+    internal/agent/subagent_registry*|\
+    internal/agent/task.go|\
+    internal/boot/*|\
+    internal/config/system_prompt*|\
+    internal/memory/*|\
+    internal/outputstyle/*|\
+    internal/plugin/*|\
+    internal/provider/*|\
+    internal/skill/*|\
+    internal/tool/*|\
+    scripts/cache-guard.sh|\
+    scripts/check-cache-impact.sh)
+      cache_sensitive+=("$file")
+      ;;
+  esac
+
+  case "$file" in
+    internal/boot/*|\
+    internal/config/system_prompt*|\
+    internal/memory/*|\
+    internal/outputstyle/*|\
+    internal/skill/*)
+      system_prompt_sensitive+=("$file")
+      ;;
+  esac
+done
+
+if [[ "${#cache_sensitive[@]}" -eq 0 ]]; then
+  echo "No cache-sensitive prompt/tool files changed."
+  exit 0
+fi
+
+failures=()
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+field_value() {
+  local label="$1"
+  local line
+  line="$(printf '%s\n' "$body" | grep -Eim1 "^[[:space:]>#*_-]*${label}[[:space:]]*:" || true)"
+  [[ -z "$line" ]] && return 1
+  trim "${line#*:}"
+}
+
+require_field() {
+  local label="$1"
+  local value
+  if ! value="$(field_value "$label")"; then
+    failures+=("missing ${label}: line")
+    return
+  fi
+  if [[ -z "$value" || "$value" =~ ^[Tt][Oo][Dd][Oo]($|[[:space:]:-]) || "$value" =~ ^[Tt][Bb][Dd]($|[[:space:]:-]) ]]; then
+    failures+=("${label}: must be filled out")
+  fi
+}
+
+require_review_field() {
+  local label="$1"
+  local value
+  if ! value="$(field_value "$label")"; then
+    failures+=("missing ${label}: line")
+    return
+  fi
+  local lower
+  lower="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')"
+  if [[ -z "$value" || "$lower" =~ ^todo($|[[:space:]:-]) || "$lower" =~ ^tbd($|[[:space:]:-]) || "$lower" =~ ^n/?a($|[[:space:]:-]) || "$lower" =~ ^none($|[[:space:]:-]) ]]; then
+    failures+=("${label}: must name the explicit system-prompt review/approval")
+  fi
+}
+
+require_field "Cache-impact"
+require_field "Cache-guard"
+
+if [[ "${#system_prompt_sensitive[@]}" -gt 0 ]]; then
+  require_review_field "System-prompt-review"
+fi
+
+if [[ "${#failures[@]}" -gt 0 ]]; then
+  {
+    echo "Cache impact check failed."
+    echo
+    echo "Cache-sensitive files changed:"
+    printf '  - %s\n' "${cache_sensitive[@]}"
+    if [[ "${#system_prompt_sensitive[@]}" -gt 0 ]]; then
+      echo
+      echo "System-prompt-sensitive files changed:"
+      printf '  - %s\n' "${system_prompt_sensitive[@]}"
+    fi
+    echo
+    echo "Required PR body lines:"
+    echo "  Cache-impact: <none|low|medium|high> - <reason>"
+    echo "  Cache-guard: <focused guard test/command or existing guard rationale>"
+    if [[ "${#system_prompt_sensitive[@]}" -gt 0 ]]; then
+      echo "  System-prompt-review: <reviewer/approval note>"
+    fi
+    echo
+    echo "Failures:"
+    printf '  - %s\n' "${failures[@]}"
+  } >&2
+  exit 1
+fi
+
+echo "Cache impact check passed."
+echo "Cache-sensitive files:"
+printf '  - %s\n' "${cache_sensitive[@]}"


### PR DESCRIPTION
## Summary

- Add a pull request template with explicit cache-impact, cache-guard, and system-prompt-review fields.
- Add a cache-impact guard workflow that requires those fields when cache-sensitive prompt/tool paths change.
- Document the cache-first review gate in CONTRIBUTING.

## Verification

- `bash -n scripts/check-cache-impact.sh`
- `git diff --check`
- Simulated cache-impact check cases for non-sensitive paths, tool-schema paths, system-prompt paths, and missing required fields
- `bash scripts/cache-guard.sh`

## Cache impact

Cache-impact: low - governance and CI metadata only; runtime system prompt and provider-visible tool schema bytes are unchanged.
Cache-guard: `bash -n scripts/check-cache-impact.sh`; simulated README/tool/system-prompt PR body cases; `bash scripts/cache-guard.sh`.
System-prompt-review: N/A

Follow-up to #4827 after it was merged.
