### PR TITLE
Fix bare ref path probing / 修复 bare ref 路径探测

### DIFF
--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -176,15 +176,12 @@ func resolveBareNames(refs []ref, workspaceRoot string) []ref {
 	var names []string
 	for i := range refs {
 		r := &refs[i]
-		if r.kind != refFile || strings.ContainsAny(r.raw, "/\\") {
+		if r.kind != refFile || r.path != "" || !isSafeBareRefName(r.raw) {
 			continue
 		}
 		if workspaceRoot != "" {
-			if _, ok := workspaceRefPath(r.raw, workspaceRoot); ok {
-				continue
-			}
-		} else {
-			if _, err := os.Stat(r.raw); err == nil {
+			if rel, ok := workspaceRefPath(r.raw, workspaceRoot); ok {
+				r.path = rel
 				continue
 			}
 		}
@@ -219,6 +216,16 @@ func resolveBareNames(refs []ref, workspaceRoot string) []ref {
 		return nil
 	})
 	return refs
+}
+
+func isSafeBareRefName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return false
+	}
+	return filepath.Base(name) == name && filepath.IsLocal(name)
 }
 
 // FileRefLine reports whether a submitted line is nothing but a path to an

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -383,6 +383,63 @@ func TestResolveBareNamesWithWorkspaceRoot(t *testing.T) {
 	}
 }
 
+func TestResolveBareNamesSkipsAlreadyResolvedRefs(t *testing.T) {
+	refs := []ref{{kind: refFile, raw: "main.go", path: "main.go"}}
+
+	resolved := resolveBareNames(refs, t.TempDir())
+
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(resolved))
+	}
+	if resolved[0].path != "main.go" {
+		t.Fatalf("already resolved ref path = %q, want main.go", resolved[0].path)
+	}
+}
+
+func TestResolveBareNamesWithWorkspaceRootStoresRootFilePath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "main.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := []ref{{kind: refFile, raw: "main.go"}}
+	resolved := resolveBareNames(refs, root)
+
+	if len(resolved) != 1 {
+		t.Fatalf("expected 1 ref, got %d", len(resolved))
+	}
+	if resolved[0].path != "main.go" {
+		t.Fatalf("root workspace ref path = %q, want main.go", resolved[0].path)
+	}
+}
+
+func TestResolveBareNamesRejectsUnsafeBareNames(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "safe.txt"), []byte("safe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bad..name.txt"), []byte("unsafe"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := []ref{
+		{kind: refFile, raw: "safe.txt"},
+		{kind: refFile, raw: "bad..name.txt"},
+		{kind: refFile, raw: ".."},
+	}
+	resolved := resolveBareNames(refs, root)
+
+	if resolved[0].path != "safe.txt" {
+		t.Fatalf("safe bare name path = %q, want safe.txt", resolved[0].path)
+	}
+	if resolved[1].path != "" {
+		t.Fatalf("unsafe bare name should stay unresolved, got %q", resolved[1].path)
+	}
+	if resolved[2].path != "" {
+		t.Fatalf("parent-dir bare name should stay unresolved, got %q", resolved[2].path)
+	}
+}
+
 func TestResolveAbsRef(t *testing.T) {
 	temp := t.TempDir()
 


### PR DESCRIPTION
Addresses CodeQL code scanning alert #183 (`go/path-injection`).

## Summary
- reject unresolved bare `@ref` names unless they are safe single filename components
- skip already resolved file refs before basename search, so raw HTTP input no longer reaches direct path probing
- preserve workspace-root bare file resolution by storing the safe relative path when the root file exists

## Verification
- `go test ./internal/control`
- `go test ./internal/serve`
- `go test ./...`