### PR TITLE
ci: harden cache impact guard / 加固缓存影响门禁

### DIFF
--- a/.github/workflows/cache-impact.yml
+++ b/.github/workflows/cache-impact.yml
@@ -1,14 +1,16 @@
 name: Cache impact guard
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main-v2]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: cache-impact-${{ github.ref }}
+  group: cache-impact-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -17,11 +19,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Collect PR changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh api --paginate "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' > "$RUNNER_TEMP/cache-impact-files.txt"
 
       - name: Check cache-sensitive PR metadata
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CACHE_IMPACT_CHANGED_FILES_FILE: ${{ runner.temp }}/cache-impact-files.txt
         run: bash scripts/check-cache-impact.sh

--- a/scripts/check-cache-impact.sh
+++ b/scripts/check-cache-impact.sh
@@ -12,6 +12,7 @@ Inputs:
   CACHE_IMPACT_PR_BODY or PR_BODY          Pull request body text.
   CACHE_IMPACT_PR_BODY_FILE               File containing the pull request body.
   CACHE_IMPACT_CHANGED_FILES              Newline-separated changed files.
+  CACHE_IMPACT_CHANGED_FILES_FILE         File containing newline-separated changed files.
   CACHE_IMPACT_BASE_SHA / BASE_SHA        Diff base when files are not supplied.
   CACHE_IMPACT_HEAD_SHA / HEAD_SHA        Diff head when files are not supplied.
 USAGE
@@ -30,6 +31,8 @@ fi
 changed_input=""
 if [[ "$#" -gt 0 ]]; then
   changed_input="$(printf '%s\n' "$@")"
+elif [[ -n "${CACHE_IMPACT_CHANGED_FILES_FILE:-}" ]]; then
+  changed_input="$(cat "$CACHE_IMPACT_CHANGED_FILES_FILE")"
 elif [[ -n "${CACHE_IMPACT_CHANGED_FILES:-}" ]]; then
   changed_input="$CACHE_IMPACT_CHANGED_FILES"
 else
@@ -38,7 +41,11 @@ else
   if [[ -z "$base" ]]; then
     base="$(git merge-base origin/main-v2 "$head" 2>/dev/null || git merge-base main-v2 "$head")"
   fi
-  changed_input="$(git diff --name-only "$base" "$head")"
+  diff_base="$base"
+  if merge_base="$(git merge-base "$base" "$head" 2>/dev/null)"; then
+    diff_base="$merge_base"
+  fi
+  changed_input="$(git diff --name-only "$diff_base" "$head")"
 fi
 
 changed_files=()
@@ -53,6 +60,7 @@ system_prompt_sensitive=()
 for file in "${changed_files[@]:-}"; do
   case "$file" in
     internal/agent/agent.go|\
+    internal/agent/ask.go|\
     internal/agent/cache*|\
     internal/agent/compact*|\
     internal/agent/parallel_tasks.go|\
@@ -60,7 +68,12 @@ for file in "${changed_files[@]:-}"; do
     internal/agent/subagent_registry*|\
     internal/agent/task.go|\
     internal/boot/*|\
+    internal/command/slashtool.go|\
+    internal/config/config.go|\
     internal/config/system_prompt*|\
+    internal/history/tool.go|\
+    internal/installsource/*|\
+    internal/lsp/tool.go|\
     internal/memory/*|\
     internal/outputstyle/*|\
     internal/plugin/*|\
@@ -74,7 +87,9 @@ for file in "${changed_files[@]:-}"; do
   esac
 
   case "$file" in
+    internal/agent/task.go|\
     internal/boot/*|\
+    internal/config/config.go|\
     internal/config/system_prompt*|\
     internal/memory/*|\
     internal/outputstyle/*|\


### PR DESCRIPTION
## Summary

- Run the cache-impact gate from the trusted base revision with `pull_request_target` and PR file metadata, without checking out PR code.
- Re-run the gate when the PR body is edited, so adding or removing cache metadata is revalidated.
- Use merge-base-aware diffs for local/manual mode and expand sensitive path coverage for config prompts, subagent prompts, and non-builtin tool packages.

## Verification

- `bash -n scripts/check-cache-impact.sh`
- `git diff --check`
- Simulated cache-impact check cases for changed-file files, `internal/config/config.go`, `internal/agent/task.go`, `internal/lsp/tool.go`, missing system-prompt review, and merge-base/base-only changes
- `bash scripts/cache-guard.sh`

## Cache impact

Cache-impact: low - hardens the governance/CI gate only; runtime system prompt and provider-visible tool schema bytes are unchanged.
Cache-guard: `bash -n scripts/check-cache-impact.sh`; simulated file-list/config/task/lsp/failure/merge-base cases; `bash scripts/cache-guard.sh`.
System-prompt-review: N/A

Follow-up to #4829 and its automated review comments.
