### PR TITLE
fix(desktop): persist transcript display mode in user config / 修复“会话展示模式”无法保存

### DIFF
--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -108,6 +108,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 			fmt.Fprintf(&b, "provider_access = %s   # desktop settings: providers shown on Settings > Model > Access\n", renderStringArray(c.Desktop.ProviderAccess))
 		}
 		fmt.Fprintf(&b, "expand_thinking = %v   # desktop: show reasoning text expanded by default; false = collapsed\n", c.Desktop.ExpandThinking)
+		fmt.Fprintf(&b, "display_mode = %q   # desktop: standard|compact transcript display mode\n", c.DesktopDisplayMode())
 		b.WriteString("\n")
 
 		b.WriteString("[notifications]\n")

--- a/internal/config/render_test.go
+++ b/internal/config/render_test.go
@@ -102,6 +102,7 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	orig.Desktop.Theme = "dark"
 	orig.Desktop.ThemeStyle = "graphite"
 	orig.Desktop.CloseBehavior = "background"
+	orig.Desktop.DisplayMode = "compact"
 	orig.Desktop.StatusBarStyle = "text"
 	orig.Desktop.StatusBarItems = []string{"model", "balance", "cache"}
 	orig.Desktop.CheckUpdates = boolPtr(false)
@@ -222,6 +223,9 @@ func TestRenderTOMLRoundTrips(t *testing.T) {
 	}
 	if got.Desktop.CloseBehavior != "background" {
 		t.Errorf("desktop.close_behavior = %q, want background", got.Desktop.CloseBehavior)
+	}
+	if got.DesktopDisplayMode() != "compact" {
+		t.Errorf("desktop.display_mode = %q, want compact", got.DesktopDisplayMode())
 	}
 	if got.Desktop.StatusBarStyle != "text" {
 		t.Errorf("desktop.status_bar_style = %q, want text", got.Desktop.StatusBarStyle)
@@ -609,6 +613,24 @@ func TestRenderTOMLRoundTripsVisionModels(t *testing.T) {
 func boolPtr(v bool) *bool { return &v }
 
 func intPtr(v int) *int { return &v }
+
+func TestRenderTOMLPreservesDesktopDisplayMode(t *testing.T) {
+	c := Default()
+	if err := c.SetDesktopDisplayMode("compact"); err != nil {
+		t.Fatalf("SetDesktopDisplayMode: %v", err)
+	}
+	rendered := RenderTOMLForScope(c, RenderScopeUser)
+	if !strings.Contains(rendered, `display_mode = "compact"`) {
+		t.Fatalf("rendered user config missing display_mode:\n%s", rendered)
+	}
+	var got Config
+	if _, err := toml.Decode(rendered, &got); err != nil {
+		t.Fatalf("rendered TOML does not parse: %v\n---\n%s", err, rendered)
+	}
+	if got.DesktopDisplayMode() != "compact" {
+		t.Fatalf("display_mode after round trip = %q, want compact", got.DesktopDisplayMode())
+	}
+}
 
 func TestRenderTOMLDefaultStepsCommentedOut(t *testing.T) {
 	isolateUserConfigHome(t)


### PR DESCRIPTION
Fix transcript display mode persistence / 会话展示模式无法保存

## Summary

- 修复桌面端「会话展示模式」（标准 / 紧凑）重启后恢复为「标准」的问题。
- 根因：`SetDisplayMode` 会写 `~/.reasonix/config.toml`，但 `internal/config/render.go` 在序列化 `[desktop]` 段时遗漏了 `display_mode`，落盘时字段被丢弃；下次启动 `hydrateDisplayMode` 从 config 读回默认 `standard` 并覆盖 localStorage。
- 在 `[desktop]` 段补充 `display_mode` 输出，并增加 round-trip 测试（`TestRenderTOMLPreservesDesktopDisplayMode` + `TestRenderTOMLRoundTrips` 断言）。

## Verification

- [x] `go test ./internal/config/... -run 'TestRenderTOML(PreservesDesktopDisplayMode|RoundTrips)$'`
- [ ] 桌面端：设置 → 常规 → 选「紧凑」
- [ ] 确认 `~/.reasonix/config.toml` 的 `[desktop]` 含 `display_mode = "compact"`
- [ ] 完全退出并重启桌面端，会话展示仍为紧凑，设置面板显示紧凑

## Cache impact

- **Cache-impact:** `none` — 仅修复 desktop UI 配置的 TOML 序列化，不涉及 provider 请求、system prompt、memory prefix 或 skill index。
- **Cache-guard:** N/A — 无 cache 相关逻辑变更；现有 config round-trip 测试已覆盖 `display_mode` 持久化。
- **System-prompt-review:** N/A