### PR TITLE
fix(agent): reinforce executor tool handoff

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1104,6 +1104,8 @@ func finalReadinessRetryMessage(reason string) string {
 func executorHandoffRetryMessage() string {
 	return `You are already in the executor phase. The planner's read-only limitations do not apply to you.
 
+The tool schema is still attached to this executor request. Do not invent that MCP servers or tools are unavailable; only report an unavailable tool after a real tool call or host error proves it.
+
 Do not answer as the planner and do not ask how to trigger the executor.
 Use your available tools now to carry out the task. If a write or command is blocked by permissions or workspace boundaries, state that specific blocker and ask for the needed approval/path.`
 }

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -169,7 +169,7 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 		return fmt.Errorf("planner: %w", err)
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
-	return c.executor.Run(ctx, formatHandoff(input, plan))
+	return c.executor.Run(ctx, formatHandoff(input, plan, executorToolHandoffContext(c.executor)))
 }
 
 // plan streams a plan from the planner and appends it to the planner session, so
@@ -241,7 +241,14 @@ func plannerSink(sink event.Sink) event.Sink {
 	})
 }
 
-func formatHandoff(task, plan string) string {
+func formatHandoff(task, plan string, toolContext ...string) string {
+	toolBlock := ""
+	if len(toolContext) > 0 {
+		toolBlock = strings.TrimSpace(toolContext[0])
+	}
+	if toolBlock != "" {
+		toolBlock = "\n\nExecutor tool context:\n" + toolBlock
+	}
 	return fmt.Sprintf(`# %s
 
 You are the executor now. Use your available tools to execute the task.
@@ -251,16 +258,63 @@ Original task:
 
 Planner output:
 %s
+%s
 
 Executor instructions:
 - Treat the planner output as context, not as your role or capability set.
 - Ignore any planner statement such as "I cannot write", "I only have read-only tools", or "hand this to the executor"; those limitations apply to the planner, not to you.
+- Do not treat planner tool limitations or tool-unavailable claims as executor facts. Use the attached executor tools directly; report a tool or MCP server as unavailable only after a real tool call or host error proves it.
 - Do not ask the user how to trigger the executor. You are already in the executor phase.
 - If the task requires changes, call the appropriate tools (for example write/edit/bash) instead of only restating the plan.
 - If a target path is outside the writable workspace or otherwise blocked, explain that specific blocker and ask for the needed path/approval.
 - **Serial workflow**: establish the task list with one todo_write (first sub-task in_progress), then for EACH sub-task execute it and call complete_step with evidence. The host advances the list for you — it marks the sub-task completed and moves the next to in_progress, so you don't need another todo_write to mark completions. Sign off one sub-task at a time; never batch completions.
 
-Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, plan)
+Carry out the task, adapting the plan as needed.`, executorHandoffMarker, task, plan, toolBlock)
+}
+
+func executorToolHandoffContext(a *Agent) string {
+	if a == nil || a.tools == nil {
+		return ""
+	}
+	schemas := a.tools.Schemas()
+	if len(schemas) == 0 {
+		return ""
+	}
+	toolNames := make([]string, 0, len(schemas))
+	mcpNames := make([]string, 0)
+	for _, schema := range schemas {
+		name := strings.TrimSpace(schema.Name)
+		if name == "" {
+			continue
+		}
+		toolNames = append(toolNames, name)
+		if strings.HasPrefix(name, tool.MCPNamePrefix) {
+			mcpNames = append(mcpNames, name)
+		}
+	}
+	if len(toolNames) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "- The executor request includes the full tool schema (%d tools). Tool names include: %s.", len(toolNames), boundedToolNames(toolNames, 24))
+	if len(mcpNames) > 0 {
+		fmt.Fprintf(&b, "\n- MCP tools are already registered for the executor in this request (%d MCP tools). MCP tool names include: %s.", len(mcpNames), boundedToolNames(mcpNames, 16))
+	}
+	return b.String()
+}
+
+func boundedToolNames(names []string, max int) string {
+	if len(names) == 0 {
+		return "(none)"
+	}
+	if max <= 0 {
+		max = 1
+	}
+	if len(names) <= max {
+		return strings.Join(names, ", ")
+	}
+	return fmt.Sprintf("%s, ... +%d more", strings.Join(names[:max], ", "), len(names)-max)
 }
 
 // HandoffTask returns the original user task embedded in an executor handoff

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -335,6 +335,61 @@ func TestCoordinatorNudgesExecutorThatAnswersWithoutActing(t *testing.T) {
 	}
 }
 
+func TestCoordinatorHandoffAffirmsExecutorToolSchemasWhenPlannerClaimsNoMCP(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "I only have read-only tools and cannot access GitHub MCP; tell the user the server is unavailable."},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "GitHub MCP 服务器暂不可用。"},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "mcp__github__search", Arguments: `{"query":"Reasonix discussions"}`}},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "Done."},
+			{Type: provider.ChunkDone},
+		},
+	}}
+
+	execReg := tool.NewRegistry()
+	execReg.Add(coordinatorTestTool{name: "mcp__github__search", readOnly: true, output: "discussion results"})
+	executor := New(exec, execReg, NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "查看 GitHub 上 Reasonix 的讨论区"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 3 {
+		t.Fatalf("executor requests = %d, want initial answer, corrective nudge, final answer", got)
+	}
+	if tools := toolSchemaNames(exec.requests[0].Tools); !contains(tools, "mcp__github__search") {
+		t.Fatalf("executor request tools = %v, want MCP schema attached", tools)
+	}
+	first := lastUser(exec.requests[0])
+	for _, want := range []string{
+		"The executor request includes the full tool schema",
+		"mcp__github__search",
+		"Do not treat planner tool limitations or tool-unavailable claims as executor facts",
+	} {
+		if !strings.Contains(first, want) {
+			t.Fatalf("initial executor handoff missing %q:\n%s", want, first)
+		}
+	}
+	retry := lastUser(exec.requests[1])
+	for _, want := range []string{
+		"The tool schema is still attached to this executor request",
+		"Do not invent that MCP servers or tools are unavailable",
+	} {
+		if !strings.Contains(retry, want) {
+			t.Fatalf("executor retry nudge missing %q:\n%s", want, retry)
+		}
+	}
+}
+
 func TestCoordinatorDoesNotNudgeExecutorThatActs(t *testing.T) {
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "Write the requested skill file."},


### PR DESCRIPTION
## Summary

- Fixes #4830 by making the two-model executor handoff explicitly state that the executor request still includes the full tool schema, including registered MCP tools.
- Adds a bounded executor tool-name summary to the handoff so planner claims like "MCP is unavailable" do not become executor facts.
- Strengthens the no-action executor retry nudge to require a real tool call or host error before reporting MCP/tools as unavailable.
- Adds regression coverage for a planner that incorrectly claims GitHub MCP is unavailable while the executor still receives an MCP tool schema.

## Verification

- [x] `go test ./internal/agent -run TestCoordinatorHandoffAffirmsExecutorToolSchemasWhenPlannerClaimsNoMCP -count=1`
- [x] `go test ./internal/agent -run 'TestCoordinator' -count=1`
- [x] `go test ./internal/agent -count=1`
- [x] `go test ./...`
- [x] `cd desktop && go test ./...`
- [x] `go vet ./...`
- [x] `cd desktop && go vet ./...`
- [x] `git diff --check`

## Cache impact

Cache-impact: low - changes only the two-model executor handoff/retry user message, not the cache-stable system prompt, memory prefix, skill index, provider request shape, or tool schema bytes. The added tool-name summary is bounded.
Cache-guard: `go test ./internal/agent -run TestCoordinatorHandoffAffirmsExecutorToolSchemasWhenPlannerClaimsNoMCP -count=1`; `go test ./...`.
System-prompt-review: N/A - no system prompt, memory prefix, output style, or skill index behavior change.
