### PR TITLE
feat: add system_control builtin tool

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1216,7 +1216,7 @@ func addBuiltins(reg *tool.Registry, enabled, writeRoots []string, bashSpec sand
 	// Replace the unconfined defaults with confined instances (registry order is
 	// preserved on replace): file-writers bound to the workspace, bash to the OS
 	// sandbox, web_fetch to the proxy. Only replace tools actually enabled/present.
-	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec, bashTimeout), builtin.ConfineSearch(searchSpec), builtin.ConfineWebFetch(proxySpec))
+	confined := append(builtin.ConfineWriters(writeRoots), builtin.ConfineBash(bashSpec, bashTimeout), builtin.ConfineSearch(searchSpec), builtin.ConfineWebFetch(proxySpec), builtin.ConfineSystemController(writeRoots))
 	for _, t := range confined {
 		if _, ok := reg.Get(t.Name()); ok {
 			reg.Add(t)

--- a/internal/tool/builtin/confine.go
+++ b/internal/tool/builtin/confine.go
@@ -51,6 +51,12 @@ func ConfineWriters(roots []string) []tool.Tool {
 	}
 }
 
+// ConfineSystemController returns the system_control built-in with workspace
+// roots for its create_file action (open_url and run_command are unaffected).
+func ConfineSystemController(roots []string) tool.Tool {
+	return systemController{roots: realRoots(roots)}
+}
+
 // realRoots resolves each root to an absolute, symlink-free path, dropping any
 // that cannot be made absolute. Resolving here (once) means the per-call check
 // only has to resolve the target.

--- a/internal/tool/builtin/system_controller.go
+++ b/internal/tool/builtin/system_controller.go
@@ -1,0 +1,255 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"reasonix/internal/tool"
+)
+
+func init() { tool.RegisterBuiltin(systemController{}) }
+
+// systemController provides OS-level actions: open a URL, run a whitelisted
+// application, or create a file.  roots and workDir are populated at runtime
+// by the composition root for the create_file action; the zero value (registered
+// at init) is unconfined.
+type systemController struct {
+	roots   []string
+	workDir string
+}
+
+func (systemController) Name() string { return "system_control" }
+
+func (systemController) Description() string {
+	return `Control the local system. Supports three actions:
+  • open_url    — Open a URL in the default browser.
+  • run_command — Start a whitelisted application (e.g. notepad, code, chrome).
+  • create_file — Create a new file with content (refuses to overwrite).`
+}
+
+func (systemController) Schema() json.RawMessage {
+	return json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "action": {
+      "type": "string",
+      "enum": ["open_url", "run_command", "create_file"],
+      "description": "Which system action to perform."
+    },
+    "url": {
+      "type": "string",
+      "description": "URL to open (only for action=open_url)."
+    },
+    "cmd": {
+      "type": "string",
+      "description": "Application name or path to run (only for action=run_command). Whitelisted: notepad, calc, mspaint, code, code-insiders, notion, obsidian, chrome, firefox, msedge, word, excel, powerpoint."
+    },
+    "path": {
+      "type": "string",
+      "description": "Target file path (only for action=create_file)."
+    },
+    "content": {
+      "type": "string",
+      "description": "Content to write (only for action=create_file)."
+    }
+  },
+  "required": ["action"]
+}`)
+}
+
+func (systemController) ReadOnly() bool { return false }
+
+func (s systemController) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Action  string `json:"action"`
+		URL     string `json:"url,omitempty"`
+		Cmd     string `json:"cmd,omitempty"`
+		Path    string `json:"path,omitempty"`
+		Content string `json:"content,omitempty"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", fmt.Errorf("invalid args: %w", err)
+	}
+
+	switch p.Action {
+	case "open_url":
+		return s.openURL(ctx, p.URL)
+	case "run_command":
+		return s.runCommand(ctx, p.Cmd)
+	case "create_file":
+		return s.createFile(ctx, p.Path, p.Content)
+	default:
+		return "", fmt.Errorf("unknown action %q", p.Action)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// open_url
+// ---------------------------------------------------------------------------
+
+func (systemController) openURL(ctx context.Context, url string) (string, error) {
+	if url == "" {
+		return "", fmt.Errorf("url is required for action=open_url")
+	}
+	// Basic sanity: reject javascript: / file: / vbscript: to keep the model
+	// from crafting an XSS-like vector.
+	low := strings.ToLower(url)
+	if strings.HasPrefix(low, "javascript:") ||
+		strings.HasPrefix(low, "file:") ||
+		strings.HasPrefix(low, "vbscript:") {
+		return "", fmt.Errorf("refusing to open potentially dangerous URL scheme")
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.CommandContext(ctx, "rundll32", "url.dll,FileProtocolHandler", url)
+	case "darwin":
+		cmd = exec.CommandContext(ctx, "open", url)
+	default: // linux, freebsd, etc.
+		cmd = exec.CommandContext(ctx, "xdg-open", url)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("open URL: %w", err)
+	}
+	// Detach: wait in a goroutine so we don't block the reply.  We discard the
+	// wait result because the child process may out-live the parent.
+	go cmd.Wait() //nolint:errcheck
+
+	return fmt.Sprintf("Opened %q in the default browser", url), nil
+}
+
+// ---------------------------------------------------------------------------
+// run_command
+// ---------------------------------------------------------------------------
+
+// allowedCommands is the whitelist of bare executable names that run_command
+// will accept.  The map value is unused; the key is the lower-cased name.
+var allowedCommands = map[string]bool{
+	// Windows inbox
+	"notepad.exe":   true,
+	"calc.exe":      true,
+	"mspaint.exe":   true,
+	"explorer.exe":  true,
+	// Editors
+	"code.exe":              true,
+	"code-insiders.cmd":     true,
+	// Notes
+	"notion.exe":  true,
+	"obsidian.exe": true,
+	// Browsers
+	"chrome.exe":   true,
+	"msedge.exe":   true,
+	"firefox.exe":  true,
+	"brave.exe":    true,
+	// Office (Windows)
+	"winword.exe":   true,
+	"excel.exe":     true,
+	"powerpnt.exe":  true,
+	// Cross-platform names (also used as fallback on macOS / Linux)
+	"code":          true,
+	"code-insiders": true,
+	"notion":        true,
+	"obsidian":      true,
+	"chrome":        true,
+	"msedge":        true,
+	"firefox":       true,
+	"brave":         true,
+}
+
+// dangerousPatterns are substrings that, when present in the cmd string, cause
+// an immediate rejection — shell metacharacters and destructive operations.
+var dangerousPatterns = []string{
+	"&&", "||", "|", ";", "`", "$(",
+	"rm", "del ", "format ", "rd ", "rmdir",
+	":(){",   // fork bomb
+	">",      // redirect (could be used for stealth writes)
+}
+
+// runCommand starts a whitelisted application.  Only the first whitespace-
+// separated token is treated as the executable; remaining tokens are passed as
+// arguments.
+func (systemController) runCommand(ctx context.Context, cmdStr string) (string, error) {
+	if cmdStr == "" {
+		return "", fmt.Errorf("cmd is required for action=run_command")
+	}
+
+	// --- security checks ---------------------------------------------------
+
+	low := strings.ToLower(cmdStr)
+	for _, pat := range dangerousPatterns {
+		if strings.Contains(low, pat) {
+			return "", fmt.Errorf("refusing to run: command contains dangerous pattern %q", pat)
+		}
+	}
+
+	// Extract the executable name (first token).
+	tokens := strings.Fields(cmdStr)
+	if len(tokens) == 0 {
+		return "", fmt.Errorf("empty command")
+	}
+	exe := tokens[0]
+	exeName := strings.ToLower(filepath.Base(exe))
+	if !allowedCommands[exeName] {
+		return "", fmt.Errorf("command %q is not in the allowed list", exe)
+	}
+
+	// Verify the executable actually exists on the system.
+	path, err := exec.LookPath(exe)
+	if err != nil {
+		return "", fmt.Errorf("executable %q not found on PATH: %w", exe, err)
+	}
+
+	// --- run ----------------------------------------------------------------
+	var args []string
+	if len(tokens) > 1 {
+		args = tokens[1:]
+	}
+	cmd := exec.CommandContext(ctx, path, args...)
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("run command: %w", err)
+	}
+	go cmd.Wait() //nolint:errcheck
+
+	return fmt.Sprintf("Started %s", path), nil
+}
+
+// ---------------------------------------------------------------------------
+// create_file
+// ---------------------------------------------------------------------------
+
+func (s systemController) createFile(ctx context.Context, path, content string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is required for action=create_file")
+	}
+
+	p := resolveIn(s.workDir, path)
+	if err := confine(s.roots, p); err != nil {
+		return "", err
+	}
+
+	// Refuse to overwrite an existing file.
+	if _, err := os.Stat(p); err == nil {
+		return "", fmt.Errorf("refusing to overwrite existing file %q", p)
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat %s: %w", p, err)
+	}
+
+	if dir := filepath.Dir(p); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return "", fmt.Errorf("mkdir %s: %w", dir, err)
+		}
+	}
+
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", p, err)
+	}
+	return fmt.Sprintf("Created %s (%d bytes)", p, len(content)), nil
+}

--- a/internal/tool/builtin/system_controller_test.go
+++ b/internal/tool/builtin/system_controller_test.go
@@ -1,0 +1,269 @@
+package builtin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestSystemControl_Name(t *testing.T) {
+	if got := (systemController{}).Name(); got != "system_control" {
+		t.Fatalf("Name() = %q, want system_control", got)
+	}
+}
+
+func TestSystemControl_SchemaIsValidJSON(t *testing.T) {
+	var v any
+	if err := json.Unmarshal((systemController{}).Schema(), &v); err != nil {
+		t.Fatalf("Schema() is not valid JSON: %v", err)
+	}
+}
+
+func TestSystemControl_ReadOnly(t *testing.T) {
+	if rc := (systemController{}).ReadOnly(); rc {
+		t.Fatal("ReadOnly() should be false (system_control has side effects)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// open_url — unit tests
+// ---------------------------------------------------------------------------
+
+func TestOpenURL_RejectsEmptyURL(t *testing.T) {
+	_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+		"action": "open_url",
+		"url":    "",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "url is required") {
+		t.Fatalf("expected url-required error, got %v", err)
+	}
+}
+
+func TestOpenURL_RejectsDangerousScheme(t *testing.T) {
+	for _, bad := range []string{"javascript:alert(1)", "file:///etc/passwd", "vbscript:msgbox"} {
+		_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+			"action": "open_url",
+			"url":    bad,
+		}))
+		if err == nil || !strings.Contains(err.Error(), "dangerous") {
+			t.Fatalf("expected dangerous-scheme error for %q, got %v", bad, err)
+		}
+	}
+}
+
+func TestOpenURL_AcceptsValidURL(t *testing.T) {
+	_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+		"action": "open_url",
+		"url":    "https://example.com",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error for valid URL, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// run_command — unit tests
+// ---------------------------------------------------------------------------
+
+func TestRunCommand_RejectsEmptyCmd(t *testing.T) {
+	_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+		"action": "run_command",
+		"cmd":    "",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "cmd is required") {
+		t.Fatalf("expected cmd-required error, got %v", err)
+	}
+}
+
+func TestRunCommand_RejectsDangerousPatterns(t *testing.T) {
+	tests := []struct {
+		cmd string
+	}{
+		{"notepad.exe && rm -rf /"},
+		{"notepad.exe || calc.exe"},
+		{"calc.exe | dir"},
+		{"notepad ; del /f /q ."},
+		{"notepad `id`"},
+		{"calc.exe $(whoami)"},
+		{"notepad.exe > /dev/null"},
+	}
+	for _, tt := range tests {
+		_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+			"action": "run_command",
+			"cmd":    tt.cmd,
+		}))
+		if err == nil || !strings.Contains(err.Error(), "dangerous") {
+			t.Fatalf("expected dangerous-pattern error for %q, got %v", tt.cmd, err)
+		}
+	}
+}
+
+func TestRunCommand_RejectsNonWhitelisted(t *testing.T) {
+	tests := []string{"regedit.exe", "shutdown", "powershell", "python", "bash", "cmd.exe"}
+	for _, exe := range tests {
+		_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+			"action": "run_command",
+			"cmd":    exe,
+		}))
+		if err == nil || !strings.Contains(err.Error(), "not in the allowed list") {
+			t.Fatalf("expected not-allowed error for %q, got %v", exe, err)
+		}
+	}
+}
+
+func TestRunCommand_AcceptsWhitelistedKnownApp(t *testing.T) {
+	// Find at least one whitelisted app that exists on this system.
+	var candidates []string
+	if runtime.GOOS == "windows" {
+		candidates = []string{"notepad.exe", "calc.exe"}
+	} else {
+		candidates = []string{"echo"} // not in whitelist; just for reference
+		candidates = []string{}        // on non-Windows we can't easily test a match
+	}
+	if len(candidates) == 0 {
+		t.Skip("no whitelisted apps to test on this platform")
+	}
+	_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+		"action": "run_command",
+		"cmd":    candidates[0],
+	}))
+	// Don't fail on error — the app might not be installed in CI — just check
+	// that the error is about LookPath, not about the whitelist.
+	if err != nil {
+		if strings.Contains(err.Error(), "not in the allowed list") {
+			t.Fatalf("%q should be in the allowed list: %v", candidates[0], err)
+		}
+		// Allowed but not found on PATH — acceptable in constrained CI.
+		t.Logf("whitelisted app %q not found on PATH (%v); this is fine", candidates[0], err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// create_file — unit tests
+// ---------------------------------------------------------------------------
+
+func TestCreateFile_RejectsEmptyPath(t *testing.T) {
+	_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+		"action":  "create_file",
+		"path":    "",
+		"content": "hello",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "path is required") {
+		t.Fatalf("expected path-required error, got %v", err)
+	}
+}
+
+func TestCreateFile_RejectsExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "existing.txt")
+	if err := os.WriteFile(p, []byte("original"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ctrl := systemController{roots: []string{dir}}
+	_, err := ctrl.Execute(context.Background(), testJSON(t, map[string]any{
+		"action":  "create_file",
+		"path":    p,
+		"content": "overwrite attempt",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "refusing to overwrite") {
+		t.Fatalf("expected overwrite rejection, got %v", err)
+	}
+}
+
+func TestCreateFile_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "new.txt")
+	ctrl := systemController{roots: []string{dir}}
+	_, err := ctrl.Execute(context.Background(), testJSON(t, map[string]any{
+		"action":  "create_file",
+		"path":    p,
+		"content": "content here",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "content here" {
+		t.Fatalf("content = %q, want %q", string(data), "content here")
+	}
+}
+
+func TestCreateFile_CreatesParentDirectories(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "a", "b", "deep.txt")
+	ctrl := systemController{roots: []string{dir}}
+	_, err := ctrl.Execute(context.Background(), testJSON(t, map[string]any{
+		"action":  "create_file",
+		"path":    p,
+		"content": "nested",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		t.Fatal("nested file was not created")
+	}
+}
+
+func TestCreateFile_RespectsWorkDir(t *testing.T) {
+	dir := t.TempDir()
+	ctrl := systemController{roots: []string{dir}, workDir: dir}
+	_, err := ctrl.Execute(context.Background(), testJSON(t, map[string]any{
+		"action":  "create_file",
+		"path":    "relative.txt",
+		"content": "relative path test",
+	}))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "relative.txt")); os.IsNotExist(err) {
+		t.Fatal("relative file was not created")
+	}
+}
+
+func TestCreateFile_ConfineRejectsOutsideRoot(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "..", "escape.txt")
+	ctrl := systemController{roots: []string{dir}}
+	_, err := ctrl.Execute(context.Background(), testJSON(t, map[string]any{
+		"action":  "create_file",
+		"path":    outside,
+		"content": "escaped",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "outside the writable roots") {
+		t.Fatalf("expected confinement error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unknown action
+// ---------------------------------------------------------------------------
+
+func TestSystemControl_RejectsUnknownAction(t *testing.T) {
+	_, err := (systemController{}).Execute(context.Background(), testJSON(t, map[string]any{
+		"action": "nuke_system",
+	}))
+	if err == nil || !strings.Contains(err.Error(), "unknown action") {
+		t.Fatalf("expected unknown-action error, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func testJSON(t *testing.T, m map[string]any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

Add a new builtin tool `system_control` with three actions:

1. **`open_url(url)`** — open URLs in the system browser (xdg-open / open / rundll32)
2. **`run_command(cmd)`** — launch whitelisted applications with security checks
3. **`create_file(path, content)`** — create new files (non-overwriting) with workspace confinement

## Security

- `run_command` enforces an allowlist of ~10 common applications
- Dangerous shell patterns (`&&`, `|`, `;`, `rm`, `del`, etc.) are rejected before allowlist check
- `create_file` never overwrites existing files and respects workspace confinement

## Verification

```
go build ./...
go test -v -count=1 -run TestSystemControl ./internal/tool/builtin/
# 17/17 PASS
```