### PR TITLE
Clarify ask shelf action hierarchy

### DIFF
--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -154,6 +154,7 @@ export function AskCard({
       barRef={shelfRef}
       titleId="ask-shelf-title"
       title={t("ask.title")}
+      modifier="ask"
       actionsWrap
       badges={
         <>

--- a/desktop/frontend/src/components/PromptShelf.tsx
+++ b/desktop/frontend/src/components/PromptShelf.tsx
@@ -12,6 +12,7 @@ export function PromptShelf({
   quickActions,
   barRef,
   actionsWrap = false,
+  modifier,
 }: {
   titleId: string;
   title: ReactNode;
@@ -23,9 +24,16 @@ export function PromptShelf({
   quickActions?: ReactNode;
   barRef?: RefObject<HTMLDivElement | null>;
   actionsWrap?: boolean;
+  // Optional extra BEM-style modifier appended to the root class
+  // (e.g. "ask" → "prompt-shelf prompt-shelf--ask"). Keep it simple — used
+  // for one-off visual variants like the ask tool's decision shelf.
+  modifier?: string;
 }) {
+  const rootClass = `prompt-shelf${actionsWrap ? " prompt-shelf--actions-wrap" : ""}${
+    modifier ? ` prompt-shelf--${modifier}` : ""
+  }`;
   return (
-    <div className={`prompt-shelf${actionsWrap ? " prompt-shelf--actions-wrap" : ""}`} aria-live="polite">
+    <div className={rootClass} aria-live="polite">
       <div
         ref={barRef}
         className="prompt-shelf__bar"

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6122,6 +6122,31 @@ a[href] {
   color: var(--fg);
   background: var(--bg-soft);
 }
+/* ask tool: emphasize the "Details" toggle and demote the "Just chat"
+   dismissal so the primary action reads clearly. The ask shelf opts in
+   with the prompt-shelf--ask modifier; other shelves (e.g. the approval
+   modal) keep the neutral defaults above. */
+.prompt-shelf--ask .prompt-detail-toggle {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--border-soft));
+  background: var(--accent-soft);
+}
+.prompt-shelf--ask .prompt-detail-toggle:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-elev));
+}
+.prompt-shelf--ask .prompt-action--quiet {
+  color: var(--fg-faint);
+  border-color: transparent;
+  background: transparent;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.prompt-shelf--ask .prompt-action--quiet:hover {
+  color: var(--fg);
+  border-color: var(--border-soft);
+  background: var(--bg-soft);
+}
 .prompt-action__key {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Clarify ask shelf action hierarchy / 修正 ask 决策弹窗按钮视觉层级

The ask tool's decision shelf rendered the muted-gray **"Details"** toggle
as if it were disabled while the bordered **"Just chat"** dismissal read as
a primary action, so users tended to click the wrong button. Emphasize
"Details" with the theme accent and demote "Just chat" to a borderless
text link that grows a neutral button shape on hover. Scoped under a new
`prompt-shelf--ask` modifier so the shared `PromptShelf` used by the
approval modal is untouched.

ask 决策弹窗原样式：'详细' 用淡灰底像不可点，'只是聊聊' 带边框看着像主
按钮，导致用户经常误点。'详细' 改为用主题强调色突出，'只是聊聊' 改
为无边框文字链接，hover 时长出中性按钮形状。样式用新增的
`prompt-shelf--ask` 修饰类限定作用域，审批弹窗共用的 `PromptShelf` 不
受影响。

## Verification

- `corepack pnpm --dir desktop/frontend test:typecheck` — TypeScript type
  check passes
- `corepack pnpm --dir desktop/frontend check:css` — CSS syntax check
  passes (`check-css-syntax.mjs` + `check-z-index-tokens.mjs`)
- `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/tool-approval-mode.test.ts`
  — closest related test suite still passes 9/9 (covers the approval
  shelf that also uses `PromptShelf`; confirms the new scope modifier
  does not leak)
- Manual visual check at `?mockAsk=1`: rendered the ask shelf with
  fixture data; "Details" reads as a primary accent button, "Just chat"
  reads as a quiet text link, both register as clickable on hover

## Cache impact

Cache-impact: none
Cache-guard: N/A — no Go kernel, provider, prompt, or memory path touched
System-prompt-review: N/A — no provider-visible system prompt, memory
prefix, output style, or skill index behavior changes
