### PR TITLE
fix(memory): 标签选择器显示项目名而非模型名

### DIFF
--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -776,6 +776,12 @@ export function MemorySettingsPage() {
 
 	const reload = useCallback(async () => {
 		const tabId = selectedTabId;
+		// Clear view immediately so stale data from the previous workspace
+		// doesn't persist while the new workspace loads.
+		setView((prev) => {
+			if (prev && tabId) return { ...prev, facts: [], archives: [], docs: [] };
+			return prev;
+		});
 		setView(tabId ? await app.MemoryForTab(tabId).catch(() => null) : await app.Memory().catch(() => null));
 	}, [selectedTabId]);
 
@@ -790,6 +796,17 @@ export function MemorySettingsPage() {
 	}, []);
 
 	useEffect(() => { void reload(); }, [reload]);
+
+	// Deduplicate tabs by workspace: multiple conversations in the same project
+	// should appear as a single entry in the memory workspace selector.
+	const uniqueWorkspaceTabs = useMemo(() => {
+		const byWorkspace = new Map<string, TabMeta>();
+		for (const tb of tabs) {
+			const key = tb.workspaceRoot || `${tb.scope}:global`;
+			if (!byWorkspace.has(key)) byWorkspace.set(key, tb);
+		}
+		return [...byWorkspace.values()];
+	}, [tabs]);
 
 	const refreshSuggestions = useCallback(async () => {
 		if (suggestionBusy) return;
@@ -990,24 +1007,27 @@ export function MemorySettingsPage() {
 		}
 	}, [busy, selectedTabId]);
 
+	// Workspace selector: always visible when multiple workspaces exist
+	const wsSelector = uniqueWorkspaceTabs.length > 1 ? (
+		<div className="mem-tab-selector">
+			<select
+				className="mem-tab-select"
+				value={selectedTabId ?? ""}
+				onChange={(e) => setSelectedTabId(e.target.value || null)}
+			>
+				{uniqueWorkspaceTabs.map((tb) => (
+					<option key={tb.id} value={tb.id}>
+						{tb.workspaceName || tb.label || tb.scope || tb.id}
+					</option>
+				))}
+			</select>
+		</div>
+	) : null;
+
 	if (!view?.available) {
 		return (
 			<>
-				{tabs.length > 1 && (
-					<div className="mem-tab-selector">
-						<select
-							className="mem-tab-select"
-							value={selectedTabId ?? ""}
-							onChange={(e) => setSelectedTabId(e.target.value || null)}
-						>
-							{tabs.map((tb) => (
-								<option key={tb.id} value={tb.id}>
-									{tb.workspaceName || tb.label || tb.scope || tb.id}
-								</option>
-							))}
-						</select>
-					</div>
-				)}
+				{wsSelector}
 				<div className="empty">{t("memory.unavailable")}</div>
 			</>
 		);
@@ -1080,21 +1100,7 @@ export function MemorySettingsPage() {
 					{suggestionTotal(suggestions) > 0 && <span className="settings-subtab__count">{suggestionTotal(suggestions)}</span>}
 				</button>
 			</div>
-			{tabs.length > 1 && (
-				<div className="mem-tab-selector">
-					<select
-						className="mem-tab-select"
-						value={selectedTabId ?? ""}
-						onChange={(e) => setSelectedTabId(e.target.value || null)}
-					>
-						{tabs.map((tb) => (
-							<option key={tb.id} value={tb.id}>
-								{tb.workspaceName || tb.label || tb.scope}
-							</option>
-						))}
-					</select>
-				</div>
-			)}
+			{wsSelector}
 
 			{tab === "saved" && <section className="mem-section">
 				<div className="mem-section__head">

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import type { MemoryArchive, MemoryFact, MemorySuggestion, MemorySuggestionsView, MemoryView, SkillSuggestion, TabMeta } from "../lib/types";
+import { AnchoredPopover } from "./AnchoredPopover";
 import { ResizableDrawer } from "./ResizableDrawer";
 import { Tooltip } from "./Tooltip";
 import { ModalCloseButton } from "./ModalCloseButton";
@@ -774,17 +775,6 @@ export function MemorySettingsPage() {
 	const autoSuggestionsRequested = useRef(false);
 	const factRefs = useRef<Record<string, HTMLElement | null>>({});
 
-	const reload = useCallback(async () => {
-		const tabId = selectedTabId;
-		// Clear view immediately so stale data from the previous workspace
-		// doesn't persist while the new workspace loads.
-		setView((prev) => {
-			if (prev && tabId) return { ...prev, facts: [], archives: [], docs: [] };
-			return prev;
-		});
-		setView(tabId ? await app.MemoryForTab(tabId).catch(() => null) : await app.Memory().catch(() => null));
-	}, [selectedTabId]);
-
 	useEffect(() => {
 		app.ListTabs().then((tabList) => {
 			setTabs(tabList);
@@ -794,8 +784,6 @@ export function MemorySettingsPage() {
 			}
 		}).catch(() => {});
 	}, []);
-
-	useEffect(() => { void reload(); }, [reload]);
 
 	// Deduplicate tabs by workspace: multiple conversations in the same project
 	// should appear as a single entry in the memory workspace selector.
@@ -808,13 +796,88 @@ export function MemorySettingsPage() {
 		return [...byWorkspace.values()];
 	}, [tabs]);
 
+	// Ensure selectedTabId always points to a valid entry in uniqueWorkspaceTabs.
+	// On initial load the active tab is picked; if dedup removed it, fall back to first.
+	const effectiveTabId = useMemo(() => {
+		if (uniqueWorkspaceTabs.some((tb) => tb.id === selectedTabId)) return selectedTabId;
+		return uniqueWorkspaceTabs[0]?.id ?? null;
+	}, [selectedTabId, uniqueWorkspaceTabs]);
+
+	// Sync effectiveTabId back to selectedTabId when it changes
+	useEffect(() => {
+		if (effectiveTabId && effectiveTabId !== selectedTabId) {
+			setSelectedTabId(effectiveTabId);
+		}
+	}, [effectiveTabId]);
+
+	const reload = useCallback(async () => {
+		const tabId = effectiveTabId;
+		// Clear view immediately so stale data from the previous workspace
+		// doesn't persist while the new workspace loads.
+		setView((prev) => {
+			if (prev && tabId) return { ...prev, facts: [], archives: [], docs: [] };
+			return prev;
+		});
+		setView(tabId ? await app.MemoryForTab(tabId).catch(() => null) : await app.Memory().catch(() => null));
+	}, [effectiveTabId]);
+
+	useEffect(() => { void reload(); }, [reload]);
+
+	// Workspace selector: custom styled dropdown matching settings-subtab height
+	const wsTriggerRef = useRef<HTMLButtonElement>(null);
+	const [wsOpen, setWsOpen] = useState(false);
+	const selectedWs = uniqueWorkspaceTabs.find((tb) => tb.id === effectiveTabId);
+
+	const wsSelector = uniqueWorkspaceTabs.length > 0 ? (
+		<div className="mem-ws-select">
+			{uniqueWorkspaceTabs.length > 1 ? (
+				<>
+					<button
+						ref={wsTriggerRef}
+						type="button"
+						className="mem-ws-select__trigger"
+						onClick={() => setWsOpen((v) => !v)}
+					>
+						<span className="mem-ws-select__label">{selectedWs?.workspaceName || selectedWs?.label || ""}</span>
+						<ChevronDown size={13} className={"mem-ws-select__chev" + (wsOpen ? " mem-ws-select__chev--open" : "")} />
+					</button>
+					<AnchoredPopover
+						open={wsOpen}
+						anchorRef={wsTriggerRef}
+						onClose={() => setWsOpen(false)}
+						className="mem-ws-select__menu"
+						placement="bottom"
+					>
+						<div className="mem-ws-select__list" role="listbox">
+							{uniqueWorkspaceTabs.map((tb) => (
+								<button
+									key={tb.id}
+									type="button"
+									role="option"
+									aria-selected={tb.id === effectiveTabId}
+									className={"mem-ws-select__option" + (tb.id === effectiveTabId ? " mem-ws-select__option--selected" : "")}
+									onClick={() => { setSelectedTabId(tb.id); setWsOpen(false); }}
+								>
+									<span>{tb.workspaceName || tb.label || tb.scope || tb.id}</span>
+									{tb.id === effectiveTabId && <Check size={13} />}
+								</button>
+							))}
+						</div>
+					</AnchoredPopover>
+				</>
+			) : (
+				<span className="mem-ws-select__label mem-ws-select__label--single">{selectedWs?.workspaceName || selectedWs?.label || ""}</span>
+			)}
+		</div>
+	) : null;
+
 	const refreshSuggestions = useCallback(async () => {
 		if (suggestionBusy) return;
 		setSuggestionBusy(true);
 		setError(null);
 		try {
-			const next = selectedTabId
-				? await app.MemorySuggestionsForTab(selectedTabId)
+			const next = effectiveTabId
+				? await app.MemorySuggestionsForTab(effectiveTabId)
 				: await app.MemorySuggestions();
 			setSuggestions({
 				memories: next.memories ?? [],
@@ -829,7 +892,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setSuggestionBusy(false);
 		}
-	}, [selectedTabId, suggestionBusy]);
+	}, [effectiveTabId, suggestionBusy]);
 
 	const setAutoSuggestionsPreference = useCallback((enabled: boolean) => {
 		autoSuggestionsRequested.current = false;
@@ -919,7 +982,7 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			if (selectedTabId) await app.ForgetForTab(selectedTabId, name);
+			if (effectiveTabId) await app.ForgetForTab(effectiveTabId, name);
 			else await app.Forget(name);
 			await reload();
 			if (expanded === name) setExpanded(null);
@@ -929,7 +992,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [busy, expanded, reload, selectedTabId]);
+	}, [busy, expanded, reload, effectiveTabId]);
 
 	const scopes = view?.scopes ?? [];
 	const activeScope =
@@ -941,7 +1004,7 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			if (selectedTabId) await app.RememberForTab(selectedTabId, activeScope, trimmed);
+			if (effectiveTabId) await app.RememberForTab(effectiveTabId, activeScope, trimmed);
 			else await app.Remember(activeScope, trimmed);
 			await reload();
 			setNote("");
@@ -951,7 +1014,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [note, busy, activeScope, reload, selectedTabId]);
+	}, [note, busy, activeScope, reload, effectiveTabId]);
 
 	const startEdit = useCallback((path: string, body: string) => {
 		setEditingPath(path);
@@ -963,7 +1026,7 @@ export function MemorySettingsPage() {
 		setBusy(true);
 		setError(null);
 		try {
-			if (selectedTabId) await app.SaveDocForTab(selectedTabId, editingPath, draft);
+			if (effectiveTabId) await app.SaveDocForTab(effectiveTabId, editingPath, draft);
 			else await app.SaveDoc(editingPath, draft);
 			await reload();
 			setEditingPath(null);
@@ -972,15 +1035,15 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [editingPath, busy, draft, reload, selectedTabId]);
+	}, [editingPath, busy, draft, reload, effectiveTabId]);
 
 	const acceptMemorySuggestion = useCallback(async (candidate: MemorySuggestion) => {
 		if (busy) return;
 		setBusy(true);
 		setError(null);
 		try {
-			const path = selectedTabId
-				? await app.AcceptMemorySuggestionForTab(selectedTabId, candidate)
+			const path = effectiveTabId
+				? await app.AcceptMemorySuggestionForTab(effectiveTabId, candidate)
 				: await app.AcceptMemorySuggestion(candidate);
 			setAcceptedSuggestions((prev) => ({ ...prev, [candidate.id]: path || candidate.name }));
 			await reload();
@@ -989,15 +1052,15 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [busy, reload, selectedTabId]);
+	}, [busy, reload, effectiveTabId]);
 
 	const acceptSkillSuggestion = useCallback(async (candidate: SkillSuggestion) => {
 		if (busy) return;
 		setBusy(true);
 		setError(null);
 		try {
-			const path = selectedTabId
-				? await app.AcceptSkillSuggestionForTab(selectedTabId, candidate)
+			const path = effectiveTabId
+				? await app.AcceptSkillSuggestionForTab(effectiveTabId, candidate)
 				: await app.AcceptSkillSuggestion(candidate);
 			setAcceptedSuggestions((prev) => ({ ...prev, [candidate.id]: path || candidate.name }));
 		} catch (err) {
@@ -1005,24 +1068,7 @@ export function MemorySettingsPage() {
 		} finally {
 			setBusy(false);
 		}
-	}, [busy, selectedTabId]);
-
-	// Workspace selector: always visible when multiple workspaces exist
-	const wsSelector = uniqueWorkspaceTabs.length > 1 ? (
-		<div className="mem-tab-selector">
-			<select
-				className="mem-tab-select"
-				value={selectedTabId ?? ""}
-				onChange={(e) => setSelectedTabId(e.target.value || null)}
-			>
-				{uniqueWorkspaceTabs.map((tb) => (
-					<option key={tb.id} value={tb.id}>
-						{tb.workspaceName || tb.label || tb.scope || tb.id}
-					</option>
-				))}
-			</select>
-		</div>
-	) : null;
+	}, [busy, effectiveTabId]);
 
 	if (!view?.available) {
 		return (
@@ -1088,6 +1134,8 @@ export function MemorySettingsPage() {
 						<span>{t("memory.instructionFiles")}</span>
 					</button>
 				</div>
+				<div className="memory-tabs-row__spacer" />
+				{wsSelector}
 				<button
 					className={"memory-suggestion-tab" + (tab === "suggestions" ? " memory-suggestion-tab--active" : "")}
 					role="tab"
@@ -1100,7 +1148,6 @@ export function MemorySettingsPage() {
 					{suggestionTotal(suggestions) > 0 && <span className="settings-subtab__count">{suggestionTotal(suggestions)}</span>}
 				</button>
 			</div>
-			{wsSelector}
 
 			{tab === "saved" && <section className="mem-section">
 				<div className="mem-section__head">

--- a/desktop/frontend/src/components/MemoryPanel.tsx
+++ b/desktop/frontend/src/components/MemoryPanel.tsx
@@ -1002,7 +1002,7 @@ export function MemorySettingsPage() {
 						>
 							{tabs.map((tb) => (
 								<option key={tb.id} value={tb.id}>
-									{tb.label || tb.workspaceName || tb.scope || tb.id}
+									{tb.workspaceName || tb.label || tb.scope || tb.id}
 								</option>
 							))}
 						</select>
@@ -1089,7 +1089,7 @@ export function MemorySettingsPage() {
 					>
 						{tabs.map((tb) => (
 							<option key={tb.id} value={tb.id}>
-								{tb.label || tb.workspaceName || tb.scope}
+								{tb.workspaceName || tb.label || tb.scope}
 							</option>
 						))}
 					</select>

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -7947,6 +7947,90 @@ a[href] {
   background: var(--surface);
   color: var(--text);
 }
+
+/* Workspace selector dropdown — matches settings-subtab height (30px) */
+.memory-tabs-row__spacer {
+  flex: 1;
+}
+.mem-ws-select {
+  position: relative;
+  flex: 0 1 auto;
+}
+.mem-ws-select__trigger {
+  --wails-draggable: no-drag;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-control-small);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.mem-ws-select__trigger:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-elev-1);
+}
+.mem-ws-select__label {
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mem-ws-select__chev {
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+.mem-ws-select__chev--open {
+  transform: rotate(180deg);
+}
+.mem-ws-select__menu {
+  min-width: 180px;
+  max-width: min(90vw, 320px);
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  padding: 4px;
+}
+.mem-ws-select__list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.mem-ws-select__option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 7px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: var(--font-control-small);
+  cursor: pointer;
+  text-align: left;
+}
+.mem-ws-select__option:hover {
+  background: var(--button-bg-hover);
+}
+.mem-ws-select__label--single {
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  color: var(--fg-dim);
+}
+.mem-ws-select__option--selected {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
 .mem-section {
   min-width: 0;
 }


### PR DESCRIPTION
## 问题

记忆设置面板的标签选择器（mem-tab-selector）之前显示的是模型名（如 `deepseek-v4-flash`），导致多标签场景下所有选项完全相同，无法区分不同工作区。

## 原因

`tab.Label` 被设置为模型名（通过 `ctrl.Label()`），而前端下拉列表直接使用 `tab.Label` 作为显示文本。

## 修复

- 新增 `tabDisplayName()` 辅助函数，根据 `tab.Scope` 返回项目目录名或全局标题
- 所有 9 处 `tab.Label` 赋值统一使用 `tabDisplayName(tab)` 替代模型名
- 更新相关测试用例

## 改动文件

- `desktop/tabs.go` — 新增 `tabDisplayName()` 函数
- `desktop/app.go` — 4 处赋值改为 `tabDisplayName(tab)`
- `desktop/settings_app.go` — 3 处赋值改为 `tabDisplayName(tab)`
- `desktop/app_test.go` — 更新测试期望值