### PR TITLE
Fix user-owned choice prompts / 修复用户选择提示

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1098,7 +1098,7 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 }
 
 func finalReadinessRetryMessage(reason string) string {
-	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
+	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied. If the missing item depends on a user-owned choice or manual action, call the ask tool with concrete options so the UI can show a choice. Do not ask in prose, infer a choice from silence, or continue by choosing for the user; do not choose for the user."
 }
 
 func executorHandoffRetryMessage() string {

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -94,3 +94,16 @@ func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 		t.Fatalf("audit.IncompleteTodos = %d, want 1", audit.IncompleteTodos)
 	}
 }
+
+func TestFinalReadinessRetryMessageRoutesUserChoicesThroughAsk(t *testing.T) {
+	got := finalReadinessRetryMessage("latest successful todo_write still has incomplete items: user manual test")
+	for _, want := range []string{
+		"call the ask tool",
+		"Do not ask in prose",
+		"do not choose for the user",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("final readiness retry message missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -211,6 +211,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if st, ok := outputstyle.Resolve(cfg.Agent.OutputStyle, outputstyle.Dirs()); ok {
 		sysPrompt = outputstyle.Apply(sysPrompt, st)
 	}
+	sysPrompt += "\n\n" + config.UserDecisionPolicy
 	sysPrompt += "\n\n" + config.LanguagePolicy
 	if tokenEconomy {
 		sysPrompt += "\n\n" + tokenEconomyPrompt

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1465,7 +1465,9 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 		base = sys[:i]
 	}
 	// The language policy is always appended at boot; strip it so this assertion
-	// is purely about whether project/ancestor memory leaked into the base.
+	// is purely about whether project/ancestor memory leaked into the base. The
+	// user-decision policy is another fixed boot policy and is stripped for the
+	// same reason.
 	base = stripLanguagePolicy(base)
 	if base != "JUST THE BASE" {
 		t.Fatalf("expected untouched base prompt, got:\n%s", sys)
@@ -1501,6 +1503,41 @@ api_key_env = "REASONIX_TEST_KEY_UNSET"
 	}
 }
 
+func TestBuildAppendsUserDecisionPolicyToCustomSystemPrompt(t *testing.T) {
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "reasonix.toml", `
+default_model = "test-model"
+
+[agent]
+system_prompt = "BASE"
+
+[[providers]]
+name = "test-model"
+kind = "openai"
+base_url = "https://example.invalid"
+model = "x"
+api_key_env = "REASONIX_TEST_KEY_UNSET"
+`)
+
+	ctrl, err := Build(context.Background(), Options{})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	sys := systemMessage(ctrl.History())
+	for _, want := range []string{
+		"User-owned choices",
+		"call the ask tool",
+		"Do not ask in prose",
+	} {
+		if !strings.Contains(sys, want) {
+			t.Fatalf("user decision policy missing %q from custom system prompt:\n%s", want, sys)
+		}
+	}
+}
+
 func systemMessage(msgs []provider.Message) string {
 	for _, m := range msgs {
 		if m.Role == provider.RoleSystem {
@@ -1514,6 +1551,7 @@ func stripLanguagePolicy(s string) string {
 	s = strings.TrimSpace(s)
 	for _, policy := range []string{
 		config.LanguagePolicy,
+		config.UserDecisionPolicy,
 	} {
 		s = strings.TrimSpace(strings.TrimSuffix(s, policy))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1107,19 +1107,16 @@ const DefaultSystemPrompt = `You are Reasonix, a coding agent focused on executi
 Use the provided tools to read and write files and run shell commands.
 Principles: understand the request before acting; verify with tools instead of
 guessing; keep changes minimal and correct; briefly summarize what you did.
-When the request leaves a real choice to the user — which approach or library,
-the scope, or a consequential or ambiguous decision — call the ask tool to offer
-2-4 concrete options rather than guessing or burying the question in prose. Skip
-it when there's an obvious default; don't ask just to confirm. Approval-bypass
-modes do not answer ask questions or approve plans for the user. If no
-interactive user is available, the ask tool returns a model-assumption fallback;
-state the assumption you made before proceeding.
 For multi-step work, track progress with the todo_write tool: lay out the steps,
 keep exactly one in_progress, and flip each to completed as you finish it — update
 the list as you go, not just at the end.
 In plan mode the harness blocks writer tools: do read-only research, then write a
 concise plan as your reply and stop. The user is asked to approve before anything
 is changed; once approved, work through the steps, updating the task list as you go.`
+
+// UserDecisionPolicy is appended to every system prompt, including user-custom
+// prompts, so custom personas cannot accidentally remove the `ask` UI contract.
+const UserDecisionPolicy = `User-owned choices: when a real decision belongs to the user — scope, approach, library, risk, manual validation, or any ambiguous or consequential path — and there is no obvious safe default, call the ask tool with 2-4 concrete options so the UI shows a choice. Do not ask in prose, infer a choice from silence, or continue by choosing for the user; do not choose for the user. Tool-approval bypass modes do not answer ask questions or approve plans. If no interactive user is available, the ask tool returns a model-assumption fallback; state that assumption and choose the safest reversible path.`
 
 // LanguagePolicy is the auto fallback appended to the system prompt when no
 // concrete UI language is resolved. It is static English text, so it stays part


### PR DESCRIPTION
## Summary

Fixes #4851.

- Preserve the user-owned choice contract for custom system prompts by appending a fixed `UserDecisionPolicy` during boot.
- Update final-readiness retry guidance so pending user/manual decisions are routed through the `ask` tool instead of prose or model self-selection.
- Add regression coverage for custom prompt boot composition and readiness retry messaging.

## Verification

- `go test ./internal/boot ./internal/agent -run 'TestBuildAppendsUserDecisionPolicyToCustomSystemPrompt|TestFinalReadinessRetryMessageRoutesUserChoicesThroughAsk'`
- `go test ./internal/config ./internal/boot ./internal/agent ./internal/control`
- `go test ./...`
- `(cd desktop && go test ./...)`
- `go vet ./...`
- `(cd desktop && go vet ./...)`
- `gofmt -l .`
- `git diff --check`
- `bash scripts/cache-guard.sh`
- `(cd desktop/frontend && corepack pnpm run test:all)`
- `(cd desktop/frontend && corepack pnpm run build)`

## Cache impact

Cache-impact: medium - provider-visible system prompt gains a fixed user-decision policy for all sessions, including custom prompts; no dynamic per-turn churn or tool schema changes.
Cache-guard: `bash scripts/cache-guard.sh`; focused boot/retry regression tests listed above.
System-prompt-review: required - this intentionally changes the provider-visible system prompt to preserve the structured `ask` UI contract for user-owned decisions.
