### PR TITLE
fix(desktop): use optimistic updates for settings toggles to eliminate click delay / 使用乐观更新进行设置切换以消除点击延迟

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -920,7 +920,7 @@ function reasoningProtocolLabel(protocol: string, t: ReturnType<typeof useT>): s
 
 function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agentRunning: boolean }) {
   const { t, setPref } = useI18n();
-  const closeBehavior = normalizeCloseBehavior(s.closeBehavior);
+  const [closeBehavior, setCloseBehavior] = useState(() => normalizeCloseBehavior(s.closeBehavior));
   const [displayMode, setDisplayMode] = useState<DisplayMode>(() => normalizeDisplayMode(getDisplayMode()));
   const [statusBarItemsExpanded, setStatusBarItemsExpanded] = useState(false);
   const [draggingStatusBarItem, setDraggingStatusBarItem] = useState<StatusBarItemId | null>(null);
@@ -932,14 +932,14 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
   const statusBarItemsPanelId = useId();
   useEffect(() => onDisplayModeChange((mode) => setDisplayMode(mode)), []);
   useEffect(() => () => mouseDragCleanupRef.current?.(), []);
-  const autoPlan = normalizeAutoPlan(s.autoPlan);
+  const [autoPlan, setAutoPlan] = useState(() => normalizeAutoPlan(s.autoPlan));
   const languagePref = normalizeLangPref(s.desktopLanguage);
-  const desktopLayoutStyle = normalizeDesktopLayoutStyle(s.desktopLayoutStyle);
+  const [localDesktopLayoutStyle, setLocalDesktopLayoutStyle] = useState(() => normalizeDesktopLayoutStyle(s.desktopLayoutStyle));
   const [genMusicPreset, setGenMusicPreset] = useState<GenerativePreset>(getGenerativePreset());
   const [soundPref, setSoundPref] = useState<SoundWavPref>(getSuccessPreference());
   const [attentionPref, setAttentionPref] = useState<SoundWavPref>(getAttentionPreference());
   const [soundExpanded, setSoundExpanded] = useState(false);
-  const statusBarStyle = normalizeStatusBarStyle(s.statusBarStyle);
+  const [statusBarStyle, setStatusBarStyle] = useState(() => normalizeStatusBarStyle(s.statusBarStyle));
   const statusBarItems = normalizeStatusBarItems(s.statusBarItems);
   const soundStatus = summarizeSoundStatus(genMusicPreset, soundPref, attentionPref);
   const visibleStatusItems = new Set<StatusBarItemId>(statusBarItems);
@@ -1110,9 +1110,9 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
           {(["classic", "workbench"] as const).map((style) => (
             <button
               key={style}
-              className={`set-seg__btn${desktopLayoutStyle === style ? " set-seg__btn--on" : ""}`}
+              className={`set-seg__btn${localDesktopLayoutStyle === style ? " set-seg__btn--on" : ""}`}
               disabled={busy}
-              onClick={() => void apply(() => app.SetDesktopLayoutStyle(style))}
+              onClick={() => { setLocalDesktopLayoutStyle(style); void apply(() => app.SetDesktopLayoutStyle(style)); }}
             >
               {desktopLayoutStyleLabel(style, t)}
             </button>
@@ -1126,7 +1126,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
               key={mode}
               className={`set-seg__btn${closeBehavior === mode ? " set-seg__btn--on" : ""}`}
               disabled={busy}
-              onClick={() => void apply(() => app.SetCloseBehavior(mode))}
+              onClick={() => { setCloseBehavior(mode); void apply(() => app.SetCloseBehavior(mode)); }}
             >
               {closeBehaviorLabel(mode, t)}
             </button>
@@ -1157,7 +1157,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
               key={mode}
               className={`set-seg__btn${autoPlan === mode ? " set-seg__btn--on" : ""}`}
               disabled={busy}
-              onClick={() => void apply(() => app.SetAutoPlan(mode))}
+              onClick={() => { setAutoPlan(mode); void apply(() => app.SetAutoPlan(mode)); }}
             >
               {t(`settings.autoPlan.${mode}`)}
             </button>
@@ -1244,7 +1244,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
               key={style}
               className={`set-seg__btn${statusBarStyle === style ? " set-seg__btn--on" : ""}`}
               disabled={busy}
-              onClick={() => void apply(() => app.SetStatusBarStyle(style))}
+              onClick={() => { setStatusBarStyle(style); void apply(() => app.SetStatusBarStyle(style)); }}
             >
               {t(`settings.statusBarStyle.${style}`)}
             </button>
@@ -5381,6 +5381,9 @@ function UpdatesSection({
 }) {
   const t = useT();
   const { status, check, download: downloadUpdate, install: installUpdate } = useUpdater();
+  const [localCheckUpdates, setLocalCheckUpdates] = useState(checkUpdates);
+  const [localTelemetry, setLocalTelemetry] = useState(telemetry);
+  const [localMetrics, setLocalMetrics] = useState(metrics);
   const [version, setVersion] = useState("");
   useEffect(() => {
     app.Version().then(setVersion).catch(() => {});
@@ -5397,9 +5400,9 @@ function UpdatesSection({
         hint={t("updater.autoCheckHint")}
       >
         <ToggleSegment
-          value={checkUpdates}
+          value={localCheckUpdates}
           disabled={settingsBusy}
-          onChange={(enabled) => void applySettings(() => app.SetDesktopCheckUpdates(enabled))}
+          onChange={(enabled) => { setLocalCheckUpdates(enabled); void applySettings(() => app.SetDesktopCheckUpdates(enabled)); }}
         />
       </SettingsField>
       <SettingsField
@@ -5408,9 +5411,9 @@ function UpdatesSection({
         hint={t("settings.telemetryHint")}
       >
         <ToggleSegment
-          value={telemetry}
+          value={localTelemetry}
           disabled={settingsBusy}
-          onChange={(enabled) => void applySettings(() => app.SetDesktopTelemetry(enabled))}
+          onChange={(enabled) => { setLocalTelemetry(enabled); void applySettings(() => app.SetDesktopTelemetry(enabled)); }}
         />
       </SettingsField>
       <SettingsField
@@ -5419,9 +5422,9 @@ function UpdatesSection({
         hint={t("settings.metricsHint")}
       >
         <ToggleSegment
-          value={metrics}
+          value={localMetrics}
           disabled={settingsBusy}
-          onChange={(enabled) => void applySettings(() => app.SetDesktopMetrics(enabled))}
+          onChange={(enabled) => { setLocalMetrics(enabled); void applySettings(() => app.SetDesktopMetrics(enabled)); }}
         />
       </SettingsField>
       <SettingsField label={t("updater.currentVersion", { v: version || "…" })}>


### PR DESCRIPTION
fix(desktop): use optimistic updates for settings toggles to eliminate click delay / 使用乐观更新进行设置切换以消除点击延迟

## Summary

- Settings 通用页面的开关（关闭行为、布局风格、自动计划、状态栏样式）和更新页面的开关（启动时检测新版本、匿名启动统计、共享聚合质量指标）在点击时存在明显延迟，尤其在 Intel Mac 上。
- 根本原因是每次切换都需要两次串行 Go IPC 往返（写入配置 + 重新读取全量 Settings），按钮状态完全依赖 Go 端返回值。
- 解决方案：为这些开关添加 React local state 乐观更新，点击时立即更新 UI 状态，后台异步执行 apply()。与会话展示模式（displayMode）已有的即时响应模式一致。

## Verification

- `npx tsc --noEmit` 通过，零错误
- 测试文件 `settings-refresh-snapshot.test.tsx` 验证的 displayMode 行为不受影响

## Cache impact

Cache-impact: none
Cache-guard: N/A — 仅前端 UI 状态管理变更，不涉及系统提示词或缓存前缀
System-prompt-review: N/A