### PR TITLE
fix: simplify blocking prompt cards and harden todo state handling

### DIFF
--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -29,8 +29,8 @@ const activeTodos = [
 
 assert.equal(
   shouldShowTodoPanel("todo-final", null, completedTodos),
-  false,
-  "the final all-completed todo_write must auto-collapse",
+  true,
+  "a completed todo list stays visible in collapsed form until the user dismisses it",
 );
 assert.equal(
   shouldShowTodoPanel("todo-active", null, [{ content: "Run tests", status: "in_progress" }]),
@@ -53,8 +53,8 @@ assert.equal(
 );
 assert.equal(
   shouldShowTodoPanel(activeKey, activeKey, activeTodos),
-  false,
-  "a user dismissal hides the same restored todo list",
+  true,
+  "an incomplete restored todo list must reappear even after a stale local dismissal",
 );
 assert.notEqual(
   activeKey,
@@ -65,7 +65,7 @@ assert.notEqual(
 const iterations = 200_000;
 const started = performance.now();
 for (let i = 0; i < iterations; i += 1) {
-  if (shouldShowTodoPanel("todo-perf", null, completedTodos)) {
+  if (shouldShowTodoPanel("todo-perf", "todo-perf", completedTodos)) {
     throw new Error("unexpected visible todo panel during performance loop");
   }
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1349,10 +1349,11 @@ export default function App() {
 
   // The live task list pinned above the composer comes from the most recent
   // successful top-level todo_write result; failed or still-running attempts do
-  // not advance the canonical panel state. It stays visible while any item is
-  // incomplete. It can be dismissed by the user (the ✕). A dismissal is keyed to
-  // the list's stable state, so host-advanced events and history reloads
-  // do not resurrect the same task list under a different event id.
+  // not advance the canonical panel state. Incomplete lists are always shown so
+  // a stale local dismissal cannot hide work that still blocks final readiness;
+  // completed lists collapse automatically and can then be dismissed. The
+  // dismissal key is still based on stable todo content/state so history reloads
+  // do not resurrect the same finished list under a different event id.
   const todoEntry = useMemo(() => {
     for (let i = state.items.length - 1; i >= 0; i--) {
       const it = state.items[i];
@@ -2760,7 +2761,7 @@ export default function App() {
 
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
-            {showTodos && <TodoPanel todos={todos} onDismiss={() => setDismissedTodo(todoKey)} />}
+            {showTodos && <TodoPanel todoKey={todoKey} todos={todos} onDismiss={() => setDismissedTodo(todoKey)} />}
             {rewindState && (
               <UndoRewindBanner
                 meta={{

--- a/desktop/frontend/src/__tests__/tool-data-archive.test.ts
+++ b/desktop/frontend/src/__tests__/tool-data-archive.test.ts
@@ -1,9 +1,9 @@
 // Run: tsx src/__tests__/tool-data-archive.test.ts
 //
-// Verifies that the tool_result reducer archives ALL completed tools
-// immediately: args are trimmed to 200 chars, output is set to undefined,
-// and the dataArchived flag is set. Collapsed cards only keep tool name
-// + command in memory; full data is loaded on demand via the backend.
+// Verifies that the tool_result reducer archives completed tools immediately:
+// output is dropped, dataArchived is set, and most args are trimmed to 200
+// chars. Structured todo_write args are the exception because the bottom task
+// panel parses them directly from the live tool item.
 
 import { initialState, reducer } from "../lib/useController";
 import type { Item } from "../lib/useController";
@@ -198,6 +198,38 @@ console.log("\ntool data archiving on tool_result");
   ok(Boolean(todo), "history restored todo_write");
   eq(todo?.args, args, "todo_write args are not truncated during history restore");
   eq(JSON.parse(todo?.args ?? "{}").todos.length, todos.length, "todo_write args remain parseable JSON");
+}
+
+// ── Test 8: Live todo_write result keeps full args for the bottom task panel ──
+{
+  const todos = Array.from({ length: 8 }, (_, i) => ({
+    content: `Task ${i} ${"x".repeat(30)}`,
+    status: i === 0 ? "in_progress" : "pending",
+  }));
+  const args = JSON.stringify({ todos });
+  let s = initialState;
+  s = reducer(s, { type: "event", e: { kind: "turn_started" } });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_dispatch",
+      tool: { id: "todo-live", name: "todo_write", args, readOnly: true },
+    },
+  });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_result",
+      tool: { id: "todo-live", name: "todo_write", readOnly: true, output: "Todos updated", durationMs: 15 },
+    },
+  });
+
+  const tools = toolItems(s);
+  const todo = tools.find((tool) => tool.id === "todo-live");
+  ok(Boolean(todo), "live todo_write result is recorded");
+  eq(todo?.dataArchived, true, "live todo_write still marks output as archived");
+  eq(todo?.args, args, "live todo_write args are not truncated");
+  eq(JSON.parse(todo?.args ?? "{}").todos.length, todos.length, "live todo_write args remain parseable JSON");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/__tests__/tool-data-archive.test.ts
+++ b/desktop/frontend/src/__tests__/tool-data-archive.test.ts
@@ -2,8 +2,8 @@
 //
 // Verifies that the tool_result reducer archives completed tools immediately:
 // output is dropped, dataArchived is set, and most args are trimmed to 200
-// chars. Structured todo_write args are the exception because the bottom task
-// panel parses them directly from the live tool item.
+// chars. For todo_write, only the latest successful top-level snapshot keeps
+// full JSON because the bottom task panel parses that canonical entry directly.
 
 import { initialState, reducer } from "../lib/useController";
 import type { Item } from "../lib/useController";
@@ -50,6 +50,15 @@ function addTools(state: TestState, count: number, argsLen = 5000, outputLen = 1
 
 function toolItems(s: TestState): ToolItem[] {
   return s.items.filter((it): it is ToolItem => it.kind === "tool");
+}
+
+function todoArgs(label: string, active = 0): string {
+  return JSON.stringify({
+    todos: Array.from({ length: 8 }, (_, i) => ({
+      content: `${label} task ${i} ${"x".repeat(30)}`,
+      status: i === active ? "in_progress" : "pending",
+    })),
+  });
 }
 
 console.log("\ntool data archiving on tool_result");
@@ -165,13 +174,10 @@ console.log("\ntool data archiving on tool_result");
   ok(totalStringBytes < args.length + output.length, "history restore avoids large args/output strings");
 }
 
-// ── Test 7: Restored todo_write keeps full structured args for the todo panel ──
+// ── Test 7: History keeps only the latest successful top-level todo_write full ──
 {
-  const todos = Array.from({ length: 8 }, (_, i) => ({
-    content: `Task ${i} ${"x".repeat(30)}`,
-    status: i === 0 ? "in_progress" : "pending",
-  }));
-  const args = JSON.stringify({ todos });
+  const oldArgs = todoArgs("old");
+  const latestArgs = todoArgs("latest", 2);
   const s = reducer(initialState, {
     type: "history",
     messages: [
@@ -179,57 +185,135 @@ console.log("\ntool data archiving on tool_result");
         role: "assistant",
         content: "",
         toolCalls: [{
-          id: "todo-long",
+          id: "todo-old",
           name: "todo_write",
-          arguments: args,
+          arguments: oldArgs,
         }],
       },
       {
         role: "tool",
         content: "",
-        toolCallId: "todo-long",
+        toolCallId: "todo-old",
+        toolName: "todo_write",
+        toolResultArchived: true,
+      },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{
+          id: "todo-latest",
+          name: "todo_write",
+          arguments: latestArgs,
+        }],
+      },
+      {
+        role: "tool",
+        content: "",
+        toolCallId: "todo-latest",
         toolName: "todo_write",
         toolResultArchived: true,
       },
     ] as any,
   });
   const tools = toolItems(s);
-  const todo = tools.find((tool) => tool.name === "todo_write");
-  ok(Boolean(todo), "history restored todo_write");
-  eq(todo?.args, args, "todo_write args are not truncated during history restore");
-  eq(JSON.parse(todo?.args ?? "{}").todos.length, todos.length, "todo_write args remain parseable JSON");
+  const oldTodo = tools.find((tool) => tool.id === "todo-old");
+  const latestTodo = tools.find((tool) => tool.id === "todo-latest");
+  ok(Boolean(oldTodo), "history restored older todo_write");
+  ok(Boolean(latestTodo), "history restored latest todo_write");
+  ok((oldTodo?.args.length ?? 0) <= 205, "older todo_write args are truncated during history restore");
+  ok(oldTodo?.args !== oldArgs, "older todo_write no longer keeps full JSON");
+  eq(latestTodo?.args, latestArgs, "latest todo_write keeps full args during history restore");
+  eq(JSON.parse(latestTodo?.args ?? "{}").todos.length, 8, "latest todo_write args remain parseable JSON");
 }
 
-// ── Test 8: Live todo_write result keeps full args for the bottom task panel ──
+// ── Test 8: Live updates keep only the latest successful top-level todo_write full ──
 {
-  const todos = Array.from({ length: 8 }, (_, i) => ({
-    content: `Task ${i} ${"x".repeat(30)}`,
-    status: i === 0 ? "in_progress" : "pending",
-  }));
-  const args = JSON.stringify({ todos });
+  const firstArgs = todoArgs("first");
+  const latestArgs = todoArgs("latest", 3);
   let s = initialState;
   s = reducer(s, { type: "event", e: { kind: "turn_started" } });
   s = reducer(s, {
     type: "event",
     e: {
       kind: "tool_dispatch",
-      tool: { id: "todo-live", name: "todo_write", args, readOnly: true },
+      tool: { id: "todo-first", name: "todo_write", args: firstArgs, readOnly: true },
     },
   });
   s = reducer(s, {
     type: "event",
     e: {
       kind: "tool_result",
-      tool: { id: "todo-live", name: "todo_write", readOnly: true, output: "Todos updated", durationMs: 15 },
+      tool: { id: "todo-first", name: "todo_write", readOnly: true, output: "Todos updated", durationMs: 15 },
+    },
+  });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_dispatch",
+      tool: { id: "todo-latest", name: "todo_write", args: latestArgs, readOnly: true },
+    },
+  });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_result",
+      tool: { id: "todo-latest", name: "todo_write", readOnly: true, output: "Todos updated", durationMs: 20 },
     },
   });
 
   const tools = toolItems(s);
-  const todo = tools.find((tool) => tool.id === "todo-live");
-  ok(Boolean(todo), "live todo_write result is recorded");
-  eq(todo?.dataArchived, true, "live todo_write still marks output as archived");
-  eq(todo?.args, args, "live todo_write args are not truncated");
-  eq(JSON.parse(todo?.args ?? "{}").todos.length, todos.length, "live todo_write args remain parseable JSON");
+  const firstTodo = tools.find((tool) => tool.id === "todo-first");
+  const latestTodo = tools.find((tool) => tool.id === "todo-latest");
+  ok(Boolean(firstTodo), "first live todo_write result is recorded");
+  ok(Boolean(latestTodo), "latest live todo_write result is recorded");
+  eq(firstTodo?.dataArchived, true, "older live todo_write stays archived");
+  ok((firstTodo?.args.length ?? 0) <= 205, "older live todo_write args are truncated");
+  eq(latestTodo?.dataArchived, true, "latest live todo_write still marks output as archived");
+  eq(latestTodo?.args, latestArgs, "latest live todo_write keeps full args");
+  eq(JSON.parse(latestTodo?.args ?? "{}").todos.length, 8, "latest live todo_write args remain parseable JSON");
+}
+
+// ── Test 9: A later failed todo_write does not steal the canonical snapshot ──
+{
+  const successArgs = todoArgs("success", 1);
+  const failedArgs = todoArgs("failed", 4);
+  let s = initialState;
+  s = reducer(s, { type: "event", e: { kind: "turn_started" } });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_dispatch",
+      tool: { id: "todo-success", name: "todo_write", args: successArgs, readOnly: true },
+    },
+  });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_result",
+      tool: { id: "todo-success", name: "todo_write", readOnly: true, output: "Todos updated", durationMs: 15 },
+    },
+  });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_dispatch",
+      tool: { id: "todo-failed", name: "todo_write", args: failedArgs, readOnly: true },
+    },
+  });
+  s = reducer(s, {
+    type: "event",
+    e: {
+      kind: "tool_result",
+      tool: { id: "todo-failed", name: "todo_write", readOnly: true, err: "write failed", durationMs: 15 },
+    },
+  });
+
+  const tools = toolItems(s);
+  const successTodo = tools.find((tool) => tool.id === "todo-success");
+  const failedTodo = tools.find((tool) => tool.id === "todo-failed");
+  eq(successTodo?.args, successArgs, "previous successful todo_write remains canonical after a later failure");
+  ok((failedTodo?.args.length ?? 0) <= 205, "failed todo_write args are truncated");
+  eq(failedTodo?.status, "error", "failed todo_write keeps error status");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -135,10 +135,10 @@ export function ApprovalModal({
           }
           actions={
             <>
-              <PromptAction keyLabel="" label={t("approval.revisePlan")} onClick={() => setRevisionOpen((open) => !open)} selected={selectedIndex === 0} />
-              <PromptAction keyLabel="" label={t("approval.startExecution")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 1} />
+              <PromptAction keyLabel="1" label={t("approval.revisePlan")} onClick={() => setRevisionOpen((open) => !open)} selected={selectedIndex === 0} />
+              <PromptAction keyLabel="2" label={t("approval.startExecution")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 1} />
               <PromptAction
-                keyLabel=""
+                keyLabel="3"
                 label={t("approval.exitPlan")}
                 onClick={() => answerWithExit(() => (onExitPlan ?? (() => onAnswer(false, false, false)))())}
                 selected={selectedIndex === 2}
@@ -189,10 +189,10 @@ export function ApprovalModal({
         }
         actions={
           <>
-            <PromptAction keyLabel="" label={t("approval.allowOnce")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 0} />
-            <PromptAction keyLabel="" label={t("approval.allowRuleSession")} onClick={() => answerWithExit(() => onAnswer(true, true, false))} selected={selectedIndex === 1} />
-            <PromptAction keyLabel="" label={t("approval.allowRulePersistent")} onClick={() => answerWithExit(() => onAnswer(true, true, true))} selected={selectedIndex === 2} />
-            <PromptAction keyLabel="" label={t("approval.deny")} onClick={() => answerWithExit(() => onAnswer(false, false, false))} selected={selectedIndex === 3} />
+            <PromptAction keyLabel="1" label={t("approval.allowOnce")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 0} />
+            <PromptAction keyLabel="2" label={t("approval.allowRuleSession")} onClick={() => answerWithExit(() => onAnswer(true, true, false))} selected={selectedIndex === 1} />
+            <PromptAction keyLabel="3" label={t("approval.allowRulePersistent")} onClick={() => answerWithExit(() => onAnswer(true, true, true))} selected={selectedIndex === 2} />
+            <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => answerWithExit(() => onAnswer(false, false, false))} selected={selectedIndex === 3} />
           </>
         }
       >

--- a/desktop/frontend/src/components/ApprovalModal.tsx
+++ b/desktop/frontend/src/components/ApprovalModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import gsap from "gsap";
 import { useT } from "../lib/i18n";
 import type { WireApproval } from "../lib/types";
-import { PromptAction, PromptDetailToggle, PromptShelf } from "./PromptShelf";
+import { PromptAction, PromptBadge, PromptHeaderAction, PromptShelf } from "./PromptShelf";
 import { playAttentionChime } from "../lib/sound";
 import { DUR_FAST } from "../lib/gsapAnimations";
 
@@ -23,7 +23,6 @@ export function ApprovalModal({
   const isPlanApproval = approval.tool === "exit_plan_mode";
   const [revisionOpen, setRevisionOpen] = useState(false);
   const [revisionText, setRevisionText] = useState("");
-  const [detailsOpen, setDetailsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(() => (isPlanApproval ? 1 : 0));
   const cardRef = useRef<HTMLDivElement | null>(null);
   const shelfRef = useRef<HTMLDivElement | null>(null);
@@ -33,8 +32,6 @@ export function ApprovalModal({
   // jarring pop when the API cycles through 4+ pending approvals.
   const closingRef = useRef(false);
   const subject = approval.subject.trim();
-  const subjectSummary = subject.split("\n").find((line) => line.trim())?.trim() ?? "";
-
 
   const answerWithExit = (fn: () => void) => {
     if (closingRef.current) return;
@@ -72,7 +69,6 @@ export function ApprovalModal({
     cardRef.current?.focus();
     setRevisionOpen(false);
     setRevisionText("");
-    setDetailsOpen(false);
     setSelectedIndex(isPlanApproval ? 1 : 0);
     playAttentionChime();
   }, [approval.id, isPlanApproval]);
@@ -128,48 +124,53 @@ export function ApprovalModal({
       <div ref={shelfRef}>
         <PromptShelf
           barRef={cardRef}
-        titleId="plan-approval-title"
-        title={t("approval.planReady")}
-        meta={t("approval.planReadyHint")}
-        actions={
-          <>
-            <PromptAction keyLabel="1" label={t("approval.revisePlan")} onClick={() => setRevisionOpen((open) => !open)} selected={selectedIndex === 0} />
-            <PromptAction keyLabel="2" label={t("approval.startExecution")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 1} />
-            <PromptAction
-              keyLabel="3"
-              label={t("approval.exitPlan")}
-              onClick={() => answerWithExit(() => (onExitPlan ?? (() => onAnswer(false, false, false)))())}
-              selected={selectedIndex === 2}
-            />
-            <PromptAction keyLabel="Esc" label={t("composer.stopShort")} onClick={() => answerWithExit(onStop)} />
-          </>
-        }
-      >
-        {revisionOpen && (
-          <div className="plan-revision">
-            <textarea
-              ref={inputRef}
-              className="plan-revision__input"
-              value={revisionText}
-              rows={3}
-              placeholder={t("approval.revisePlanPlaceholder")}
-              onChange={(event) => setRevisionText(event.target.value)}
-              onKeyDown={(event) => {
-                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") submitRevision();
-                event.stopPropagation();
-              }}
-            />
-            <div className="plan-revision__actions">
-              <button className="btn" onClick={() => setRevisionOpen(false)}>
-                {t("common.cancel")}
-              </button>
-              <button className="btn btn--primary" onClick={submitRevision}>
-                {t("approval.sendRevision")}
-              </button>
+          titleId="plan-approval-title"
+          title={t("approval.planReady")}
+          meta={t("approval.planReadyHint")}
+          badges={revisionOpen ? <PromptBadge>{t("approval.revisePlan")}</PromptBadge> : undefined}
+          headerActions={
+            <PromptHeaderAction onClick={() => answerWithExit(onStop)} ariaLabel={t("composer.stopShort")}>
+              Esc
+            </PromptHeaderAction>
+          }
+          actions={
+            <>
+              <PromptAction keyLabel="" label={t("approval.revisePlan")} onClick={() => setRevisionOpen((open) => !open)} selected={selectedIndex === 0} />
+              <PromptAction keyLabel="" label={t("approval.startExecution")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 1} />
+              <PromptAction
+                keyLabel=""
+                label={t("approval.exitPlan")}
+                onClick={() => answerWithExit(() => (onExitPlan ?? (() => onAnswer(false, false, false)))())}
+                selected={selectedIndex === 2}
+              />
+            </>
+          }
+        >
+          {revisionOpen && (
+            <div className="plan-revision">
+              <textarea
+                ref={inputRef}
+                className="plan-revision__input"
+                value={revisionText}
+                rows={3}
+                placeholder={t("approval.revisePlanPlaceholder")}
+                onChange={(event) => setRevisionText(event.target.value)}
+                onKeyDown={(event) => {
+                  if ((event.metaKey || event.ctrlKey) && event.key === "Enter") submitRevision();
+                  event.stopPropagation();
+                }}
+              />
+              <div className="plan-revision__actions">
+                <button className="btn" onClick={() => setRevisionOpen(false)}>
+                  {t("common.cancel")}
+                </button>
+                <button className="btn btn--primary" onClick={submitRevision}>
+                  {t("approval.sendRevision")}
+                </button>
+              </div>
             </div>
-          </div>
-        )}
-      </PromptShelf>
+          )}
+        </PromptShelf>
       </div>
     );
   }
@@ -178,38 +179,27 @@ export function ApprovalModal({
     <div ref={shelfRef}>
       <PromptShelf
         barRef={cardRef}
-      titleId="tool-approval-title"
-      title={t("approval.toolPending")}
-      actionsWrap
-      meta={
-        <>
-          <span className="tool__name">{approval.tool}</span>
-          {subjectSummary && <span className="prompt-shelf__subject"> · {subjectSummary}</span>}
-        </>
-      }
-      actions={
-        <>
-          {subject && (
-            <PromptDetailToggle
-              open={detailsOpen}
-              label={t("approval.details")}
-              openLabel={t("approval.hideDetails")}
-              onClick={() => setDetailsOpen((open) => !open)}
-            />
-          )}
-          <PromptAction keyLabel="1" label={t("approval.allowOnce")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 0} />
-          <PromptAction keyLabel="2" label={t("approval.allowRuleSession")} onClick={() => answerWithExit(() => onAnswer(true, true, false))} selected={selectedIndex === 1} />
-          <PromptAction keyLabel="3" label={t("approval.allowRulePersistent")} onClick={() => answerWithExit(() => onAnswer(true, true, true))} selected={selectedIndex === 2} />
-          <PromptAction keyLabel="4" label={t("approval.deny")} onClick={() => answerWithExit(() => onAnswer(false, false, false))} selected={selectedIndex === 3} />
-          <PromptAction keyLabel="Esc" label={t("composer.stopShort")} onClick={() => answerWithExit(onStop)} />
-        </>
-      }
-    >
-      {detailsOpen && subject && (
-        <pre className="approval-subject">{subject}</pre>
-      )}
-    </PromptShelf>
+        titleId="tool-approval-title"
+        title={t("approval.toolPending")}
+        badges={<PromptBadge>{approval.tool}</PromptBadge>}
+        headerActions={
+          <PromptHeaderAction onClick={() => answerWithExit(onStop)} ariaLabel={t("composer.stopShort")}>
+            Esc
+          </PromptHeaderAction>
+        }
+        actions={
+          <>
+            <PromptAction keyLabel="" label={t("approval.allowOnce")} onClick={() => answerWithExit(() => onAnswer(true, false, false))} selected={selectedIndex === 0} />
+            <PromptAction keyLabel="" label={t("approval.allowRuleSession")} onClick={() => answerWithExit(() => onAnswer(true, true, false))} selected={selectedIndex === 1} />
+            <PromptAction keyLabel="" label={t("approval.allowRulePersistent")} onClick={() => answerWithExit(() => onAnswer(true, true, true))} selected={selectedIndex === 2} />
+            <PromptAction keyLabel="" label={t("approval.deny")} onClick={() => answerWithExit(() => onAnswer(false, false, false))} selected={selectedIndex === 3} />
+          </>
+        }
+      >
+        {subject && (
+          <pre className="approval-subject">{subject}</pre>
+        )}
+      </PromptShelf>
     </div>
   );
-
 }

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -170,12 +170,12 @@ export function AskCard({
       }
       actions={
         <>
-          {q.options.map((o) => {
+          {q.options.map((o, index) => {
             const on = (sel[q.id] ?? []).includes(o.label);
             return (
               <PromptAction
                 key={o.label}
-                keyLabel=""
+                keyLabel={q.options.length <= 9 ? String(index + 1) : ""}
                 label={o.label}
                 description={o.description}
                 onClick={() => toggle(q, o.label)}

--- a/desktop/frontend/src/components/AskCard.tsx
+++ b/desktop/frontend/src/components/AskCard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useT } from "../lib/i18n";
 import type { QuestionAnswer, WireAsk, WireAskQuestion } from "../lib/types";
-import { PromptAction, PromptBadge, PromptDetailToggle, PromptShelf } from "./PromptShelf";
+import { PromptAction, PromptHeaderAction, PromptShelf } from "./PromptShelf";
 import { playAttentionChime } from "../lib/sound";
 
 // AskCard renders the `ask` tool as a compact prompt shelf near the composer. It
@@ -23,7 +23,6 @@ export function AskCard({
   const [sel, setSel] = useState<Record<string, string[]>>({});
   const [custom, setCustom] = useState<Record<string, string>>({});
   const [active, setActive] = useState(0);
-  const [detailsOpen, setDetailsOpen] = useState(false);
   const shelfRef = useRef<HTMLDivElement | null>(null);
   const advanceTimer = useRef<number | null>(null);
 
@@ -38,7 +37,6 @@ export function AskCard({
     setSel({});
     setCustom({});
     setActive(0);
-    setDetailsOpen(false);
     if (advanceTimer.current != null) window.clearTimeout(advanceTimer.current);
     playAttentionChime();
   }, [ask.id]);
@@ -68,6 +66,7 @@ export function AskCard({
     (sel[question.id]?.length ?? 0) > 0 || (custom[question.id]?.trim() ?? "") !== "";
 
   const currentAnswered = q ? answered(q) : false;
+  const showSubmitAction = q ? q.multi || Boolean(custom[q.id]?.trim()) : false;
 
   const finishOrAdvance = (nextSel = sel, nextCustom = custom) => {
     if (advanceTimer.current != null) {
@@ -78,7 +77,6 @@ export function AskCard({
       onAnswer(ask.id, answersFrom(nextSel, nextCustom));
       return;
     }
-    setDetailsOpen(false);
     setActive((i) => Math.min(i + 1, questions.length - 1));
   };
 
@@ -108,7 +106,6 @@ export function AskCard({
       window.clearTimeout(advanceTimer.current);
       advanceTimer.current = null;
     }
-    setDetailsOpen(false);
     setActive((i) => Math.max(0, i - 1));
   };
 
@@ -154,107 +151,80 @@ export function AskCard({
       barRef={shelfRef}
       titleId="ask-shelf-title"
       title={t("ask.title")}
-      actionsWrap
       badges={
-        <>
-          {q.header && <PromptBadge>{q.header}</PromptBadge>}
-          {hasMultipleQuestions && <PromptBadge>{t("ask.questionProgress", { progress })}</PromptBadge>}
-        </>
+        <span className="ask-shelf__header-meta">
+          {q.header && <span className="ask-shelf__header-text">{q.header}</span>}
+          {hasMultipleQuestions && (
+            <span className="ask-shelf__header-text ask-shelf__header-text--progress">
+              {t("ask.questionProgress", { progress })}
+            </span>
+          )}
+        </span>
       }
       meta={q.prompt}
+      headerActions={
+        <>
+          <PromptHeaderAction onClick={onDismiss}>{t("ask.justChat")}</PromptHeaderAction>
+          <PromptHeaderAction onClick={onStop} ariaLabel={t("composer.stopShort")}>Esc</PromptHeaderAction>
+        </>
+      }
       actions={
         <>
-          {active > 0 && (
-            <button className="prompt-action prompt-action--quiet" onClick={goBack}>
-              <span className="prompt-action__label">{t("ask.back")}</span>
-            </button>
-          )}
-          {q.options.map((o, index) => {
+          {q.options.map((o) => {
             const on = (sel[q.id] ?? []).includes(o.label);
             return (
               <PromptAction
                 key={o.label}
-                keyLabel={String(index + 1)}
+                keyLabel=""
                 label={o.label}
+                description={o.description}
                 onClick={() => toggle(q, o.label)}
                 selected={on}
               />
             );
           })}
-          {q.multi && (
-            <button className="prompt-action prompt-action--selected" onClick={() => finishOrAdvance()} disabled={!currentAnswered}>
-              <span className="prompt-action__label">{isLast ? t("common.submit") : t("ask.next")}</span>
-            </button>
+        </>
+      }
+      quickActions={
+        <>
+          {active > 0 && (
+            <PromptAction keyLabel="" label={t("ask.back")} onClick={goBack} quiet />
           )}
-          <PromptDetailToggle
-            open={detailsOpen}
-            label={t("ask.details")}
-            openLabel={t("ask.hideDetails")}
-            onClick={() => setDetailsOpen((open) => !open)}
-          />
-          <button className="prompt-action prompt-action--quiet" onClick={onDismiss}>
-            <span className="prompt-action__label">{t("ask.justChat")}</span>
-          </button>
-          <button className="prompt-action prompt-action--quiet" onClick={onStop}>
-            <span className="prompt-action__key">Esc</span>
-            <span className="prompt-action__label">{t("composer.stopShort")}</span>
-          </button>
+          {showSubmitAction && (
+            <PromptAction
+              keyLabel=""
+              label={isLast ? t("common.submit") : t("ask.next")}
+              onClick={() => finishOrAdvance()}
+              primary
+              disabled={!currentAnswered}
+            />
+          )}
         </>
       }
       crumbs={
         answeredSummary.length > 0 && (
-        <div className="ask-shelf__crumbs">
-          {answeredSummary.map((answer, index) => (
-            <span className="ask-shelf__crumb" key={`${index}-${answer}`}>
-              {index + 1}. {answer}
-            </span>
-          ))}
-        </div>
+          <div className="ask-shelf__crumbs">
+            {answeredSummary.map((answer, index) => (
+              <span className="ask-shelf__crumb" key={`${index}-${answer}`}>
+                {index + 1}. {answer}
+              </span>
+            ))}
+          </div>
         )
       }
     >
-      {detailsOpen && (
-        <>
-          <div className="ask-shelf__detail-list">
-            {q.options.map((o) => (
-              <div className="ask-shelf__detail" key={o.label}>
-                <span className="ask-shelf__detail-label">{o.label}</span>
-                {o.description && <span className="ask-shelf__detail-desc">{o.description}</span>}
-              </div>
-            ))}
-          </div>
-          <div className="ask-shelf__custom-row">
-            <input
-              className="ask-shelf__custom"
-              placeholder={t("ask.customPlaceholder")}
-              value={custom[q.id] ?? ""}
-              onChange={(e) => setTyped(q, e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && currentAnswered) finishOrAdvance();
-                e.stopPropagation();
-              }}
-            />
-            <div className="ask-shelf__panel-actions">
-              {active > 0 && (
-                <button className="btn" onClick={goBack}>
-                  {t("ask.back")}
-                </button>
-              )}
-              <button className="btn" onClick={onDismiss}>
-                {t("ask.justChat")}
-              </button>
-              <button className="btn" onClick={onStop}>
-                {t("composer.stopShort")}
-              </button>
-              {(q.multi || custom[q.id]?.trim()) && (
-                <button className="btn btn--primary" onClick={() => finishOrAdvance()} disabled={!currentAnswered}>
-                  {isLast ? t("common.submit") : t("ask.next")}
-                </button>
-              )}
-            </div>
-          </div>
-        </>
-      )}
+      <div className="ask-shelf__custom-row">
+        <input
+          className="ask-shelf__custom"
+          placeholder={t("ask.customPlaceholder")}
+          value={custom[q.id] ?? ""}
+          onChange={(e) => setTyped(q, e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && currentAnswered) finishOrAdvance();
+            e.stopPropagation();
+          }}
+        />
+      </div>
     </PromptShelf>
   );
 }

--- a/desktop/frontend/src/components/ClearContextCard.tsx
+++ b/desktop/frontend/src/components/ClearContextCard.tsx
@@ -50,11 +50,7 @@ export function ClearContextCard({
         </>
       }
     >
-      <div className="ask-shelf__detail-list">
-        <div className="ask-shelf__detail clear-context-card__detail">
-          <span className="ask-shelf__detail-desc">{t("clearContext.detail")}</span>
-        </div>
-      </div>
+      <p className="prompt-shelf__note">{t("clearContext.detail")}</p>
     </PromptShelf>
   );
 }

--- a/desktop/frontend/src/components/PromptShelf.tsx
+++ b/desktop/frontend/src/components/PromptShelf.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode, RefObject } from "react";
-import { ChevronDown, ChevronUp, PauseCircle } from "lucide-react";
 
 export function PromptShelf({
   titleId,
@@ -10,45 +9,47 @@ export function PromptShelf({
   children,
   crumbs,
   quickActions,
+  headerActions,
   barRef,
-  actionsWrap = false,
+  role = "dialog",
 }: {
   titleId: string;
   title: ReactNode;
   badges?: ReactNode;
-  meta: ReactNode;
-  actions: ReactNode;
+  meta?: ReactNode;
+  actions?: ReactNode;
   children?: ReactNode;
   crumbs?: ReactNode;
   quickActions?: ReactNode;
+  headerActions?: ReactNode;
   barRef?: RefObject<HTMLDivElement | null>;
-  actionsWrap?: boolean;
+  role?: "dialog" | "region";
 }) {
   return (
-    <div className={`prompt-shelf${actionsWrap ? " prompt-shelf--actions-wrap" : ""}`} aria-live="polite">
+    <div className="prompt-shelf" aria-live="polite">
       <div
         ref={barRef}
-        className="prompt-shelf__bar"
-        role="dialog"
-        aria-modal="false"
+        className="prompt-shelf__card"
+        role={role}
+        aria-modal={role === "dialog" ? "false" : undefined}
         aria-labelledby={titleId}
         tabIndex={-1}
       >
-        <div className="prompt-shelf__summary">
-          <PauseCircle size={16} aria-hidden="true" />
+        <div className="prompt-shelf__header">
           <div className="prompt-shelf__copy">
             <div id={titleId} className="prompt-shelf__title">
               <span className="prompt-shelf__heading">{title}</span>
               {badges && <span className="prompt-shelf__badges">{badges}</span>}
             </div>
-            <div className="prompt-shelf__meta">{meta}</div>
+            {meta && <div className="prompt-shelf__meta">{meta}</div>}
           </div>
+          {headerActions && <div className="prompt-shelf__header-actions">{headerActions}</div>}
         </div>
-        <div className="prompt-shelf__actions">{actions}</div>
+        {crumbs}
+        {children && <div className="prompt-shelf__body">{children}</div>}
+        {actions && <div className="prompt-shelf__actions">{actions}</div>}
+        {quickActions && <div className="prompt-shelf__quick-actions">{quickActions}</div>}
       </div>
-      {crumbs}
-      {children && <div className="prompt-shelf__panel">{children}</div>}
-      {quickActions}
     </div>
   );
 }
@@ -57,42 +58,73 @@ export function PromptBadge({ children }: { children: ReactNode }) {
   return <span className="prompt-shelf__badge">{children}</span>;
 }
 
-export function PromptAction({
-  keyLabel,
-  label,
+export function PromptHeaderAction({
+  children,
   onClick,
-  primary = false,
-  selected = false,
+  ariaLabel,
+  disabled = false,
 }: {
-  keyLabel: string;
-  label: ReactNode;
+  children: ReactNode;
   onClick: () => void;
-  primary?: boolean;
-  selected?: boolean;
+  ariaLabel?: string;
+  disabled?: boolean;
 }) {
   return (
-    <button className={`prompt-action${primary || selected ? " prompt-action--selected" : ""}`} onClick={onClick}>
-      <span className="prompt-action__key">{keyLabel}</span>
-      <span className="prompt-action__label">{label}</span>
+    <button
+      className="prompt-shelf__header-button"
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      disabled={disabled}
+    >
+      {children}
     </button>
   );
 }
 
-export function PromptDetailToggle({
-  open,
+export function PromptAction({
+  keyLabel,
   label,
-  openLabel = label,
+  description,
   onClick,
+  ariaLabel,
+  primary = false,
+  selected = false,
+  quiet = false,
+  disabled = false,
 }: {
-  open: boolean;
-  label: ReactNode;
-  openLabel?: ReactNode;
+  keyLabel: string;
+  label?: ReactNode;
+  description?: ReactNode;
   onClick: () => void;
+  ariaLabel?: string;
+  primary?: boolean;
+  selected?: boolean;
+  quiet?: boolean;
+  disabled?: boolean;
 }) {
+  const hasCopy = description != null || (label != null && label !== "");
   return (
-    <button className="prompt-detail-toggle" onClick={onClick}>
-      <span>{open ? openLabel : label}</span>
-      {open ? <ChevronUp size={14} aria-hidden="true" /> : <ChevronDown size={14} aria-hidden="true" />}
+    <button
+      type="button"
+      className={[
+        "prompt-action",
+        primary || selected ? " prompt-action--selected" : "",
+        quiet ? " prompt-action--quiet" : "",
+        description ? " prompt-action--descriptive" : "",
+        !hasCopy ? " prompt-action--key-only" : "",
+      ].join("")}
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel}
+    >
+      {keyLabel && <span className="prompt-action__key">{keyLabel}</span>}
+      {hasCopy && (
+        <span className="prompt-action__copy">
+          {label != null && label !== "" && <span className="prompt-action__label">{label}</span>}
+          {description && <span className="prompt-action__desc">{description}</span>}
+        </span>
+      )}
     </button>
   );
 }

--- a/desktop/frontend/src/components/TodoPanel.tsx
+++ b/desktop/frontend/src/components/TodoPanel.tsx
@@ -1,23 +1,33 @@
 import { useEffect, useRef, useState } from "react";
-import { Check, ChevronDown, ChevronRight, Circle, CircleDot, X } from "lucide-react";
 import { useT } from "../lib/i18n";
 import type { Todo } from "../lib/tools";
-import { Tooltip } from "./Tooltip";
+import { PromptBadge, PromptHeaderAction, PromptShelf } from "./PromptShelf";
 
 // TodoPanel is the live task list pinned just above the composer — the kernel's
 // latest todo_write call drives it, and it updates in place as the agent flips
-// items to in_progress / completed, so the user watches the plan get worked
-// through one item at a time. Collapsed, it still
-// shows the current item so the footer stays compact during a long run. The ✕
-// dismisses it (onDismiss) when the user abandons the task; a fresh todo_write
-// brings it back.
-export function TodoPanel({ todos, onDismiss }: { todos: Todo[]; onDismiss: () => void }) {
+// items to in_progress / completed. Completed lists collapse automatically so
+// the user still sees the final state without the footer staying tall forever.
+export function TodoPanel({
+  todoKey,
+  todos,
+  onDismiss,
+}: {
+  todoKey: string;
+  todos: Todo[];
+  onDismiss: () => void;
+}) {
   const t = useT();
   const [open, setOpen] = useState(true);
   const currentRef = useRef<HTMLLIElement | null>(null);
 
   const done = todos.filter((t) => t.status === "completed").length;
   const current = todos.find((t) => t.status === "in_progress");
+  const allDone = todos.length > 0 && done === todos.length;
+  const summary = current?.activeForm || current?.content || todos[todos.length - 1]?.content || "";
+
+  useEffect(() => {
+    setOpen(!allDone);
+  }, [todoKey, allDone]);
 
   useEffect(() => {
     if (!open) return;
@@ -27,47 +37,68 @@ export function TodoPanel({ todos, onDismiss }: { todos: Todo[]; onDismiss: () =
   if (todos.length === 0) return null;
 
   return (
-    <div className="todobar">
-      <div className="todobar__head">
-        <button className="todobar__toggle" onClick={() => setOpen((v) => !v)}>
-          {open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
-          <span className="todobar__title">{t("todo.title")}</span>
-          <span className="todobar__count">
-            {done}/{todos.length}
-          </span>
-          {!open && current && (
-            <span className="todobar__current">{current.activeForm || current.content}</span>
+    <PromptShelf
+      titleId="todo-shelf-title"
+      title={t("todo.title")}
+      badges={<PromptBadge>{done}/{todos.length}</PromptBadge>}
+      meta={summary}
+      role="region"
+      headerActions={
+        <>
+          <PromptHeaderAction onClick={() => setOpen((value) => !value)}>
+            {open ? t("common.collapse") : t("common.expand")}
+          </PromptHeaderAction>
+          {allDone && (
+            <PromptHeaderAction onClick={onDismiss}>
+              {t("common.close")}
+            </PromptHeaderAction>
           )}
-        </button>
-        <Tooltip label={t("todo.dismiss")}>
-          <button className="todobar__close" onClick={onDismiss}>
-            <X size={13} />
-          </button>
-        </Tooltip>
-      </div>
-
+        </>
+      }
+    >
       {open && (
         <ul className="todobar__list">
-          {todos.map((t, i) => (
-            <li
-              key={i}
-              ref={t.status === "in_progress" ? currentRef : undefined}
-              className={`todobar__item todobar__item--${t.status}${t.level ? " todobar__item--sub" : ""}`}
-            >
-              {t.status === "completed" ? (
-                <Check size={14} className="todobar__ico todobar__ico--done" />
-              ) : t.status === "in_progress" ? (
-                <CircleDot size={14} className="todobar__ico todobar__ico--active" />
-              ) : (
-                <Circle size={14} className="todobar__ico" />
-              )}
-              <span className="todobar__text">
-                {t.status === "in_progress" && t.activeForm ? t.activeForm : t.content}
-              </span>
-            </li>
-          ))}
+          {todos.map((todo, index) => {
+            const status = normalizeTodoStatus(todo.status);
+            return (
+              <li
+                key={index}
+                ref={status === "in_progress" ? currentRef : undefined}
+                className={`todobar__item todobar__item--${status}${todo.level ? " todobar__item--sub" : ""}`}
+              >
+                <span className={`todobar__status todobar__status--${status}`}>
+                  {t(todoStatusLabelKey(status))}
+                </span>
+                <span className="todobar__text">
+                  {status === "in_progress" && todo.activeForm ? todo.activeForm : todo.content}
+                </span>
+              </li>
+            );
+          })}
         </ul>
       )}
-    </div>
+    </PromptShelf>
   );
+}
+
+function normalizeTodoStatus(status: Todo["status"]): "pending" | "in_progress" | "completed" {
+  switch (String(status ?? "").trim()) {
+    case "completed":
+      return "completed";
+    case "in_progress":
+      return "in_progress";
+    default:
+      return "pending";
+  }
+}
+
+function todoStatusLabelKey(status: "pending" | "in_progress" | "completed"): "todo.pending" | "todo.inProgress" | "todo.completed" {
+  switch (status) {
+    case "completed":
+      return "todo.completed";
+    case "in_progress":
+      return "todo.inProgress";
+    default:
+      return "todo.pending";
+  }
 }

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -15,10 +15,16 @@ export function shouldShowTodoPanel(
   dismissedTodoKey: string | null,
   todos: Todo[],
 ): boolean {
-  return !!todoKey && todoKey !== dismissedTodoKey && todos.some((todo) => todoStatus(todo.status) !== "completed");
+  if (!todoKey || todos.length === 0) return false;
+  if (hasIncompleteTodos(todos)) return true;
+  return todoKey !== dismissedTodoKey;
 }
 
 function todoStatus(status: unknown): string {
   const normalized = String(status ?? "").trim();
   return normalized || "pending";
+}
+
+function hasIncompleteTodos(todos: Todo[]): boolean {
+  return todos.some((todo) => todoStatus(todo.status) !== "completed");
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -74,6 +74,8 @@ export type Item =
       profile?: { model?: string; effort?: string }; // subagent model/effort from tool event
     };
 
+type ToolItem = Extract<Item, { kind: "tool" }>;
+
 interface State {
   items: Item[];
   running: boolean;
@@ -211,6 +213,28 @@ export function isReadOnlyTool(name: string): boolean {
     default:
       return false;
   }
+}
+
+const ARCHIVED_TOOL_ARG_LIMIT = 200;
+
+function preserveStructuredToolArgs(name: string): boolean {
+  // The bottom task panel parses todo_write JSON directly from the tool item, so
+  // those args must remain intact even after the finished tool card is archived.
+  return name === "todo_write";
+}
+
+function archivedToolArgs(name: string, args: string): string {
+  if (preserveStructuredToolArgs(name)) return args;
+  return args && args.length > ARCHIVED_TOOL_ARG_LIMIT ? args.slice(0, ARCHIVED_TOOL_ARG_LIMIT) + "…" : args;
+}
+
+function archiveCompletedTool(tool: ToolItem): ToolItem {
+  return {
+    ...tool,
+    args: archivedToolArgs(tool.name, tool.args),
+    output: undefined,
+    dataArchived: true,
+  };
 }
 
 type Action =
@@ -498,9 +522,16 @@ function applyEvent(s: State, e: WireEvent): State {
           // subject (from args). Drop output entirely; full data is loaded on
           // demand via app.ToolResultForTab when the card is expanded.
           const existing = it;
-          const shortArgs = existing.args && existing.args.length > 200 ? existing.args.slice(0, 200) + "…" : existing.args;
           const summary = t.err ? undefined : existing.summary || summarize(existing.name, existing.args, t.output);
-          next[idx] = { ...existing, status: t.err ? "error" : "done", args: shortArgs, output: undefined, error: t.err, truncated: t.truncated, durationMs: t.durationMs, dataArchived: true, summary };
+          next[idx] = archiveCompletedTool({
+            ...existing,
+            status: t.err ? "error" : "done",
+            output: t.output,
+            error: t.err,
+            truncated: t.truncated,
+            durationMs: t.durationMs,
+            summary,
+          });
         }
       }
       return { ...s, items: next };
@@ -659,8 +690,8 @@ export function reducer(s: State, a: Action): State {
       const archived = items.map((it) => {
         if (it.kind !== "tool") return it;
         const t = it;
-        if (t.name === "todo_write") return it;
-        const shortArgs = t.args && t.args.length > 200 ? t.args.slice(0, 200) + "…" : t.args;
+        if (preserveStructuredToolArgs(t.name)) return it;
+        const shortArgs = archivedToolArgs(t.name, t.args);
         if (shortArgs === t.args && (t.output === undefined || t.output === "")) return it;
         return { ...t, args: shortArgs, output: undefined, dataArchived: true };
       });

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -217,24 +217,36 @@ export function isReadOnlyTool(name: string): boolean {
 
 const ARCHIVED_TOOL_ARG_LIMIT = 200;
 
-function preserveStructuredToolArgs(name: string): boolean {
-  // The bottom task panel parses todo_write JSON directly from the tool item, so
-  // those args must remain intact even after the finished tool card is archived.
-  return name === "todo_write";
-}
-
-function archivedToolArgs(name: string, args: string): string {
-  if (preserveStructuredToolArgs(name)) return args;
+function archivedToolArgs(_name: string, args: string): string {
   return args && args.length > ARCHIVED_TOOL_ARG_LIMIT ? args.slice(0, ARCHIVED_TOOL_ARG_LIMIT) + "…" : args;
 }
 
-function archiveCompletedTool(tool: ToolItem): ToolItem {
-  return {
-    ...tool,
-    args: archivedToolArgs(tool.name, tool.args),
-    output: undefined,
-    dataArchived: true,
-  };
+function isCanonicalTodoTool(tool: ToolItem): boolean {
+  return tool.name === "todo_write" && !tool.parentId && tool.status === "done" && !tool.error;
+}
+
+function latestCanonicalTodoToolIndex(items: Item[]): number {
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const item = items[i];
+    if (item.kind === "tool" && isCanonicalTodoTool(item)) return i;
+  }
+  return -1;
+}
+
+function compactArchivedToolItems(items: Item[]): Item[] {
+  const canonicalTodoIndex = latestCanonicalTodoToolIndex(items);
+  return items.map((item, index) => {
+    if (item.kind !== "tool" || item.status === "running") return item;
+    const preserveArgs = index === canonicalTodoIndex;
+    const nextArgs = preserveArgs ? item.args : archivedToolArgs(item.name, item.args);
+    if (nextArgs === item.args && item.output === undefined && item.dataArchived === true) return item;
+    return {
+      ...item,
+      args: nextArgs,
+      output: undefined,
+      dataArchived: true,
+    };
+  });
 }
 
 type Action =
@@ -523,7 +535,7 @@ function applyEvent(s: State, e: WireEvent): State {
           // demand via app.ToolResultForTab when the card is expanded.
           const existing = it;
           const summary = t.err ? undefined : existing.summary || summarize(existing.name, existing.args, t.output);
-          next[idx] = archiveCompletedTool({
+          next[idx] = {
             ...existing,
             status: t.err ? "error" : "done",
             output: t.output,
@@ -531,10 +543,10 @@ function applyEvent(s: State, e: WireEvent): State {
             truncated: t.truncated,
             durationMs: t.durationMs,
             summary,
-          });
+          };
         }
       }
-      return { ...s, items: next };
+      return { ...s, items: compactArchivedToolItems(next) };
     }
     case "tool_progress": {
       const t = e.tool;
@@ -685,17 +697,7 @@ export function reducer(s: State, a: Action): State {
     case "message_action_done": return { ...s, messageAction: undefined };
     case "history": {
       const { items, seq } = historyMessagesToItems(a.messages, "h", s.seq);
-      // Archive all tool items loaded from history: collapsed cards only need
-      // tool name + command; full data is loaded on demand from the backend.
-      const archived = items.map((it) => {
-        if (it.kind !== "tool") return it;
-        const t = it;
-        if (preserveStructuredToolArgs(t.name)) return it;
-        const shortArgs = archivedToolArgs(t.name, t.args);
-        if (shortArgs === t.args && (t.output === undefined || t.output === "")) return it;
-        return { ...t, args: shortArgs, output: undefined, dataArchived: true };
-      });
-      return { ...s, items: archived, seq };
+      return { ...s, items: compactArchivedToolItems(items), seq };
     }
     case "local_notice": return { ...s, running: false, turnActive: false, seq: s.seq + 1, items: [...s.items, { kind: "notice", id: `n${s.seq}`, level: a.level, text: a.text }] };
     case "clearApproval": return { ...s, approval: undefined, pendingPrompt: false };

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1324,6 +1324,9 @@ export const en = {
   // todo bar
   "todo.title": "To-dos",
   "todo.dismiss": "Dismiss the task list",
+  "todo.pending": "Pending",
+  "todo.inProgress": "In progress",
+  "todo.completed": "Completed",
 
   // slash menu tags
   "slash.project": "project",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -783,6 +783,9 @@ export const zhTW: Record<DictKey, string> = {
   // 待辦欄
   "todo.title": "待辦",
   "todo.dismiss": "關閉待辦列表",
+  "todo.pending": "待處理",
+  "todo.inProgress": "進行中",
+  "todo.completed": "已完成",
 
   // 斜線選單標籤
   "slash.project": "專案",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1326,6 +1326,9 @@ export const zh: Record<DictKey, string> = {
   // 待办栏
   "todo.title": "待办",
   "todo.dismiss": "关闭待办列表",
+  "todo.pending": "待处理",
+  "todo.inProgress": "进行中",
+  "todo.completed": "已完成",
 
   // 斜杠菜单标签
   "slash.project": "项目",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -5974,128 +5974,145 @@ a[href] {
     transform: translateY(10px);
   }
 }
-.prompt-shelf__bar {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  min-height: 54px;
+.prompt-shelf__card {
+  display: grid;
+  gap: 8px;
   border: 1px solid color-mix(in srgb, var(--accent) 24%, var(--border));
   border-radius: 10px;
   background: var(--bg-elev);
-  box-shadow:
-    inset 3px 0 0 color-mix(in srgb, var(--accent) 68%, transparent),
-    0 7px 18px rgba(0, 0, 0, 0.1);
-  padding: 7px 9px 7px 10px;
+  box-shadow: 0 5px 14px rgba(0, 0, 0, 0.08);
+  padding: 10px;
   outline: none;
 }
-.prompt-shelf--actions-wrap .prompt-shelf__bar {
-  flex-wrap: wrap;
-}
-.prompt-shelf__bar:focus-visible {
+.prompt-shelf__card:focus-visible {
   border-color: var(--accent);
+  box-shadow:
+    0 7px 18px rgba(0, 0, 0, 0.1),
+    0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
 }
-.prompt-shelf__summary {
+.prompt-shelf__header {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  min-width: 260px;
-  flex: 0 1 300px;
-}
-.prompt-shelf__summary > svg {
-  color: var(--accent);
-  flex: 0 0 auto;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
 }
 .prompt-shelf__copy {
   min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+  flex: 1;
+  display: grid;
+  gap: 4px;
 }
 .prompt-shelf__title {
   display: flex;
-  align-items: center;
-  gap: 7px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 6px;
   color: var(--fg);
-  font-size: 13px;
+  font-size: 12.5px;
   font-weight: 650;
   line-height: 1.25;
 }
 .prompt-shelf__heading {
-  flex: 0 0 auto;
-  white-space: nowrap;
+  min-width: 0;
 }
 .prompt-shelf__badges {
-  min-width: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  overflow: hidden;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 .prompt-shelf__badge {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--bg-soft);
   color: var(--fg-faint);
   font-size: 11px;
   font-weight: 600;
+  line-height: 1.2;
 }
 .prompt-shelf__meta {
   color: var(--fg-dim);
-  font-size: 12px;
-  line-height: 1.3;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  font-size: 11.5px;
+  line-height: 1.4;
+  white-space: normal;
 }
-.prompt-shelf__subject {
-  color: var(--fg-faint);
-}
-.prompt-shelf__actions {
+.prompt-shelf__header-actions,
+.prompt-shelf__quick-actions {
   display: flex;
-  align-items: center;
+  flex-wrap: wrap;
   gap: 6px;
-  min-width: 0;
-  flex: 1 1 auto;
   justify-content: flex-end;
 }
-.prompt-shelf--actions-wrap .prompt-shelf__actions {
-  flex: 1 1 560px;
-  flex-wrap: wrap;
-}
-.prompt-action,
-.prompt-detail-toggle {
+.prompt-shelf__header-button {
   --wails-draggable: no-drag;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  min-height: 34px;
-  min-width: 0;
-  max-width: 188px;
+  min-height: 24px;
+  padding: 0 8px;
   border: 1px solid var(--border-soft);
-  border-radius: 7px;
+  border-radius: 999px;
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.prompt-shelf__header-button:hover {
+  border-color: var(--fg-faint);
+  background: var(--bg-elev-2);
+  color: var(--fg);
+}
+.prompt-shelf__header-button:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-elev));
+  color: var(--fg);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+.prompt-shelf__body {
+  display: grid;
+  gap: 8px;
+}
+.prompt-shelf__actions {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+}
+.prompt-action {
+  --wails-draggable: no-drag;
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  width: 100%;
+  border: 1px solid var(--border-soft);
+  border-radius: 8px;
   background: var(--bg-soft);
   color: var(--fg);
+  cursor: pointer;
   font: inherit;
-  font-size: 12px;
-  line-height: 1.25;
-  padding: 0 9px;
-  white-space: nowrap;
+  font-size: 11.5px;
+  line-height: 1.35;
+  padding: 7px 9px;
+  text-align: left;
   transition: border-color 0.12s, background 0.12s;
-}
-.prompt-shelf--actions-wrap .prompt-action {
-  max-width: 240px;
 }
 .prompt-action:disabled {
   cursor: default;
   opacity: 0.48;
 }
-.prompt-action:hover,
-.prompt-detail-toggle:hover {
+.prompt-action:hover {
   border-color: var(--fg-faint);
   background: var(--bg-elev-2);
+}
+.prompt-action:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
 }
 .prompt-action:disabled:hover {
   border-color: var(--border-soft);
@@ -6110,32 +6127,57 @@ a[href] {
   background: color-mix(in srgb, var(--accent) 18%, var(--bg-elev));
 }
 .prompt-action--quiet {
-  flex: 0 0 auto;
-  max-width: 120px;
+  width: auto;
+  min-height: 28px;
+  padding: 4px 8px;
   background: transparent;
   color: var(--fg-dim);
 }
-.prompt-shelf--actions-wrap .prompt-action--quiet {
-  max-width: 140px;
+.prompt-action--quiet.prompt-action--selected {
+  background: var(--accent-soft);
 }
 .prompt-action--quiet:hover {
   color: var(--fg);
   background: var(--bg-soft);
 }
+.prompt-shelf__quick-actions > .prompt-action {
+  width: auto;
+  min-height: 28px;
+  padding: 4px 8px;
+}
+.prompt-action--key-only {
+  justify-content: center;
+}
+.prompt-action--quiet.prompt-action--key-only {
+  min-height: auto;
+  padding: 0;
+  border-color: transparent;
+  background: transparent;
+}
+.prompt-action--quiet.prompt-action--key-only:hover {
+  background: transparent;
+}
 .prompt-action__key {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
+  min-width: 20px;
   height: 20px;
+  padding: 0 5px;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 5px;
   color: var(--fg-dim);
   background: var(--bg);
   font-family: var(--mono);
-  font-size: 11px;
+  font-size: 10.5px;
   font-weight: 700;
   flex: 0 0 auto;
+}
+.prompt-action__copy {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 2px;
 }
 .prompt-action--selected .prompt-action__key {
   border-color: var(--accent);
@@ -6143,28 +6185,24 @@ a[href] {
   color: var(--accent-fg);
 }
 .prompt-action__label {
-  display: inline-block;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  line-height: 1.4;
-  padding-block: 1px;
+  white-space: normal;
+  line-height: 1.35;
 }
-.prompt-detail-toggle {
-  flex: 0 0 auto;
-  max-width: 92px;
-  color: var(--fg-faint);
+.prompt-action__desc {
+  color: var(--fg-dim);
+  font-size: 11px;
+  line-height: 1.35;
 }
-.prompt-shelf__panel {
-  margin-top: 6px;
-  border: 1px solid color-mix(in srgb, var(--accent) 18%, var(--border));
-  border-radius: 10px;
-  background: var(--bg-elev);
-  box-shadow: 0 7px 18px rgba(0, 0, 0, 0.1);
-  padding: 10px;
+.prompt-shelf__note {
+  margin: 0;
+  color: var(--fg-dim);
+  font-size: 11.5px;
+  line-height: 1.45;
 }
 .plan-revision {
-  margin-top: 6px;
+  display: grid;
+  gap: 8px;
 }
 .plan-revision__input {
   box-sizing: border-box;
@@ -6196,23 +6234,37 @@ a[href] {
 }
 .approval-subject {
   margin: 0;
-  padding: 9px 11px;
+  padding: 8px 10px;
   background: var(--bg-soft);
   border: 1px solid var(--border-soft);
   border-radius: 8px;
   font-family: var(--mono);
-  font-size: 12.5px;
+  font-size: 11.5px;
+  line-height: 1.45;
   white-space: pre-wrap;
   word-break: break-word;
-  max-height: 150px;
+  max-height: 180px;
   overflow: auto;
 }
-/* ── ask tool: decision details ───────────────────────────────────────────── */
 .ask-shelf__crumbs {
   display: flex;
   flex-wrap: wrap;
   gap: 5px;
   margin-top: 6px;
+}
+.ask-shelf__header-meta {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.ask-shelf__header-text {
+  color: var(--fg-dim);
+  font-size: 11.5px;
+  line-height: 1.3;
+}
+.ask-shelf__header-text--progress {
+  font-variant-numeric: tabular-nums;
 }
 .ask-shelf__crumb {
   max-width: 260px;
@@ -6227,48 +6279,20 @@ a[href] {
   line-height: 1.25;
   padding: 5px 8px;
 }
-.ask-shelf__detail-list {
+.ask-shelf__custom-row {
   display: grid;
   gap: 6px;
-  margin-bottom: 8px;
-}
-.ask-shelf__detail {
-  display: grid;
-  grid-template-columns: minmax(120px, 0.45fr) 1fr;
-  gap: 10px;
-  border: 1px solid var(--border-soft);
-  border-radius: 8px;
-  background: var(--bg-soft);
-  padding: 8px 9px;
-}
-.ask-shelf__detail-label {
-  color: var(--fg);
-  font-size: 12.5px;
-  font-weight: 600;
-}
-.ask-shelf__detail-desc {
-  color: var(--fg-dim);
-  font-size: 12px;
-  line-height: 1.35;
-}
-.clear-context-card__detail {
-  grid-template-columns: 1fr;
-}
-.ask-shelf__custom-row {
-  display: flex;
-  align-items: center;
-  gap: 8px;
 }
 .ask-shelf__custom {
   min-width: 0;
-  flex: 1;
+  width: 100%;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 7px;
   color: var(--fg);
   font: inherit;
-  font-size: 13px;
-  padding: 7px 9px;
+  font-size: 12px;
+  padding: 6px 8px;
   box-sizing: border-box;
 }
 .ask-shelf__custom:focus {
@@ -6277,12 +6301,6 @@ a[href] {
 }
 .ask-shelf__custom::placeholder {
   color: var(--fg-faint);
-}
-.ask-shelf__panel-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-  flex: 0 0 auto;
 }
 .modal__plannote {
   margin: 0 0 16px;
@@ -14247,75 +14265,13 @@ a[href] {
     transform: translateY(var(--motion-rise));
   }
 }
-.todobar__head {
-  display: flex;
-  align-items: center;
-  padding: 0 7px 0 11px;
-}
-.todobar__toggle {
-  --wails-draggable: no-drag;
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  flex: 1;
-  min-width: 0;
-  padding: 7px 0;
-  background: none;
-  border: none;
-  color: var(--fg-dim);
-  font: inherit;
-  text-align: left;
-}
-.todobar__toggle > svg {
-  color: var(--fg-faint);
-  flex-shrink: 0;
-}
-.todobar__close {
-  --wails-draggable: no-drag;
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  padding: 4px;
-  background: none;
-  border: none;
-  color: var(--fg-faint);
-  border-radius: 5px;
-}
-.todobar__close:hover {
-  color: var(--fg);
-  background: var(--bg-elev);
-}
-.todobar__title {
-  font-family: inherit;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--fg-dim);
-  flex-shrink: 0;
-}
-.todobar__count {
-  font-family: inherit;
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  color: var(--fg-faint);
-  flex-shrink: 0;
-}
-.todobar__current {
-  margin-left: 4px;
-  font-size: 12px;
-  color: var(--accent);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-}
 .todobar__list {
   list-style: none;
   margin: 0;
-  padding: 2px 11px 9px;
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-  max-height: 168px;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+  max-height: 220px;
   overflow-y: auto;
   animation: todo-list-in var(--dur-base) var(--ease-out) both;
 }
@@ -14326,21 +14282,33 @@ a[href] {
   }
 }
 .todobar__item {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   align-items: flex-start;
-  gap: 8px;
+  gap: 10px;
   font-size: 13px;
   line-height: 1.5;
+  padding-block: 2px;
 }
-.todobar__ico {
-  flex-shrink: 0;
-  margin-top: 2px;
-  color: var(--fg-faint);
+.todobar__status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  border: 1px solid var(--border-soft);
+  border-radius: 999px;
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  font-size: 11px;
+  line-height: 1.35;
+  white-space: nowrap;
 }
-.todobar__ico--done {
+.todobar__status--completed {
+  border-color: color-mix(in srgb, var(--ok) 30%, var(--border-soft));
   color: var(--ok);
 }
-.todobar__ico--active {
+.todobar__status--in_progress {
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--border-soft));
   color: var(--accent);
 }
 .todobar__text {
@@ -14358,7 +14326,7 @@ a[href] {
   color: var(--fg-dim);
 }
 .todobar__item--sub {
-  padding-left: 20px;
+  padding-left: 18px;
 }
 
 /* ── composer run status ──────────────────────────────────────────────────── */
@@ -14735,36 +14703,21 @@ a[href] {
   .footer {
     padding: 10px 16px 8px;
   }
-  .prompt-shelf__bar {
-    align-items: stretch;
+  .prompt-shelf__card {
+    padding: 10px;
+  }
+  .prompt-shelf__header {
     flex-direction: column;
   }
-  .prompt-shelf__summary {
-    min-width: 0;
-    flex-basis: auto;
+  .prompt-shelf__header-actions,
+  .prompt-shelf__quick-actions {
+    justify-content: flex-start;
   }
   .prompt-shelf__actions {
-    flex-wrap: wrap;
-    justify-content: stretch;
-  }
-  .prompt-action {
-    flex: 1 1 auto;
-    max-width: none;
-  }
-  .prompt-action--quiet,
-  .prompt-detail-toggle {
-    max-width: none;
-  }
-  .ask-shelf__custom-row {
-    align-items: stretch;
-    flex-direction: column;
-  }
-  .ask-shelf__panel-actions {
-    flex-wrap: wrap;
-  }
-  .ask-shelf__detail {
     grid-template-columns: 1fr;
-    gap: 3px;
+  }
+  .prompt-shelf__quick-actions > .prompt-action {
+    width: 100%;
   }
   .welcome__hints {
     flex-wrap: wrap;

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -855,7 +855,7 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
 			incomplete, hasTodos = a.incompleteCanonicalTodos()
 		}
-		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulNonTodoReceipt() {
+		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
 			out.applies = true
 			out.incompleteTodos = len(incomplete)
 			missing = append(missing, finalReadinessIncompleteTodos(incomplete))

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -855,7 +855,7 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
 			incomplete, hasTodos = a.incompleteCanonicalTodos()
 		}
-		if hasTodos && len(incomplete) > 0 {
+		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulNonTodoReceipt() {
 			out.applies = true
 			out.incompleteTodos = len(incomplete)
 			missing = append(missing, finalReadinessIncompleteTodos(incomplete))

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -439,6 +439,35 @@ func TestTodoWriteOnlyTurnMayEndWithIncompleteTodos(t *testing.T) {
 	}
 }
 
+func TestReadOnlyContextAndTodoTurnMayEndWithIncompleteTodos(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(fakeTool{name: "read_file", readOnly: true})
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "read_file", `{"path":"README.md"}`),
+			toolCallChunk("c2", "todo_write", `{"todos":[{"content":"Draft plan","status":"in_progress"},{"content":"Implement","status":"pending"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "I reviewed the context and wrote the list."}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "read context and only draft a todo list"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want 2 without readiness retry", prov.call)
+	}
+	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "Todos updated") {
+		t.Fatalf("todo_write result = %q, want successful todo update", got)
+	}
+}
+
 func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {

--- a/internal/agent/evidence_flow_test.go
+++ b/internal/agent/evidence_flow_test.go
@@ -412,6 +412,33 @@ func TestFinalReadinessStopsAfterRepeatedBlocks(t *testing.T) {
 	}
 }
 
+func TestTodoWriteOnlyTurnMayEndWithIncompleteTodos(t *testing.T) {
+	todoWrite, ok := tool.LookupBuiltin("todo_write")
+	if !ok {
+		t.Fatal("todo_write builtin not registered")
+	}
+	reg := tool.NewRegistry()
+	reg.Add(todoWrite)
+	prov := &scriptedProvider{name: "p", turns: [][]provider.Chunk{
+		{
+			toolCallChunk("c1", "todo_write", `{"todos":[{"content":"Draft plan","status":"in_progress"},{"content":"Implement","status":"pending"}]}`),
+			{Type: provider.ChunkDone},
+		},
+		{{Type: provider.ChunkText, Text: "here is the task list"}, {Type: provider.ChunkDone}},
+	}}
+	a := New(prov, reg, NewSession(""), Options{}, event.Discard)
+
+	if err := a.Run(context.Background(), "create a todo list only"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if prov.call != 2 {
+		t.Fatalf("provider calls = %d, want 2 without readiness retry", prov.call)
+	}
+	if got := lastToolResult(a.session, "todo_write"); !strings.Contains(got, "Todos updated") {
+		t.Fatalf("todo_write result = %q, want successful todo update", got)
+	}
+}
+
 func TestFinalReadinessAuditRecordsTerminalError(t *testing.T) {
 	todoWrite, ok := tool.LookupBuiltin("todo_write")
 	if !ok {

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -19,6 +19,7 @@ func readinessLedger(receipts ...evidence.Receipt) *evidence.Ledger {
 func TestFinalReadinessFailureBranches(t *testing.T) {
 	check := instruction.VerifyCheck{Command: "go test ./...", SourcePath: "AGENTS.md", Line: 3}
 	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
+	readOnly := evidence.Receipt{ToolName: "read_file", Success: true, Read: true, Paths: []string{"a.go"}}
 	checkAfter := evidence.Receipt{ToolName: "bash", Success: true, Command: "go test ./..."}
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
 	completeAfter := evidence.Receipt{ToolName: "complete_step", Success: true, Step: "edit"}
@@ -34,6 +35,7 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 		{"nil evidence never gates", []instruction.VerifyCheck{check}, nil, true, ""},
 		{"no writer never gates", []instruction.VerifyCheck{check}, readinessLedger(checkAfter), true, ""},
 		{"todo-only turn may end with incomplete list", nil, readinessLedger(todo), true, ""},
+		{"read-only context plus todo may end with incomplete list", nil, readinessLedger(readOnly, todo), true, ""},
 		{"completed todo without writer satisfies", nil, readinessLedger(doneTodo), true, ""},
 		{"writer without checks or todo never gates", nil, readinessLedger(writer), true, ""},
 		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, "go test ./..."},

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -33,7 +33,7 @@ func TestFinalReadinessFailureBranches(t *testing.T) {
 	}{
 		{"nil evidence never gates", []instruction.VerifyCheck{check}, nil, true, ""},
 		{"no writer never gates", []instruction.VerifyCheck{check}, readinessLedger(checkAfter), true, ""},
-		{"incomplete todo without writer is reported", nil, readinessLedger(todo), false, "latest successful todo_write"},
+		{"todo-only turn may end with incomplete list", nil, readinessLedger(todo), true, ""},
 		{"completed todo without writer satisfies", nil, readinessLedger(doneTodo), true, ""},
 		{"writer without checks or todo never gates", nil, readinessLedger(writer), true, ""},
 		{"missing project check after writer is reported", []instruction.VerifyCheck{check}, readinessLedger(checkAfter, writer), false, "go test ./..."},
@@ -77,7 +77,8 @@ func TestFinalReadinessAllowsIncompleteTodosInPlanMode(t *testing.T) {
 
 func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 	todo := evidence.Receipt{ToolName: "todo_write", Success: true, Todos: []evidence.TodoItem{{Content: "edit", Status: "in_progress"}}}
-	a := &Agent{evidence: readinessLedger(todo)}
+	writer := evidence.Receipt{ToolName: "write_file", Success: true, Write: true, Paths: []string{"a.go"}}
+	a := &Agent{evidence: readinessLedger(writer, todo)}
 
 	got := a.finalReadinessCheck()
 	if !got.applies {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -251,19 +251,20 @@ func (l *Ledger) HasSuccessfulTodoWrite() bool {
 	return false
 }
 
-// HasSuccessfulNonTodoReceipt reports whether any successful tool other than
-// todo_write ran this turn. A pure "show me a task list" turn should not be
-// gated the same way an execution turn is.
-func (l *Ledger) HasSuccessfulNonTodoReceipt() bool {
+// HasSuccessfulTodoProgressReceipt reports whether any successful receipt in
+// the turn reflects execution progress rather than read-only context gathering
+// or a bare todo snapshot.
+func (l *Ledger) HasSuccessfulTodoProgressReceipt() bool {
 	if l == nil {
 		return false
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	for _, r := range l.receipts {
-		if r.Success && r.ToolName != "todo_write" {
-			return true
+		if !r.Success || r.ToolName == "todo_write" || r.Read {
+			continue
 		}
+		return true
 	}
 	return false
 }
@@ -578,10 +579,19 @@ func ReceiptFromToolCall(toolName string, args json.RawMessage, success bool, re
 
 	if isWriterTool(toolName) {
 		r.Write = true
-	} else if isReaderTool(toolName) || (readOnly && len(r.Paths) > 0) {
+	} else if isReadReceipt(toolName, readOnly) {
 		r.Read = true
 	}
 	return r
+}
+
+func isReadReceipt(name string, readOnly bool) bool {
+	switch name {
+	case "todo_write", "complete_step":
+		return false
+	default:
+		return isReaderTool(name) || readOnly
+	}
 }
 
 func isWriterTool(name string) bool {

--- a/internal/evidence/evidence.go
+++ b/internal/evidence/evidence.go
@@ -251,6 +251,23 @@ func (l *Ledger) HasSuccessfulTodoWrite() bool {
 	return false
 }
 
+// HasSuccessfulNonTodoReceipt reports whether any successful tool other than
+// todo_write ran this turn. A pure "show me a task list" turn should not be
+// gated the same way an execution turn is.
+func (l *Ledger) HasSuccessfulNonTodoReceipt() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.receipts {
+		if r.Success && r.ToolName != "todo_write" {
+			return true
+		}
+	}
+	return false
+}
+
 func (l *Ledger) IncompleteLatestTodos() ([]TodoStepMatch, bool) {
 	if l == nil {
 		return nil, false

--- a/internal/evidence/evidence_test.go
+++ b/internal/evidence/evidence_test.go
@@ -122,6 +122,11 @@ func TestReceiptFromToolCallExtractsEvidenceFields(t *testing.T) {
 	if !read.Read || len(read.Paths) != 1 {
 		t.Fatalf("read receipt not extracted: %+v", read)
 	}
+
+	glob := ReceiptFromToolCall("glob", json.RawMessage(`{"pattern":"**/*.go"}`), true, true)
+	if !glob.Read {
+		t.Fatalf("generic read-only tool should be treated as read context: %+v", glob)
+	}
 }
 
 func TestReceiptFromToolCallExtractsTodoWriteItems(t *testing.T) {
@@ -150,6 +155,9 @@ func TestReceiptFromToolCallExtractsCompleteStep(t *testing.T) {
 
 	if receipt.Step != "Add parser" {
 		t.Fatalf("complete_step step = %q", receipt.Step)
+	}
+	if receipt.Read {
+		t.Fatalf("complete_step should not be treated as read-only context: %+v", receipt)
 	}
 }
 

--- a/internal/evidence/readiness_test.go
+++ b/internal/evidence/readiness_test.go
@@ -30,7 +30,7 @@ func TestHasSuccessfulTodoWriteMatchesOnlySuccessfulTodoWrite(t *testing.T) {
 	}
 }
 
-func TestHasSuccessfulNonTodoReceipt(t *testing.T) {
+func TestHasSuccessfulTodoProgressReceipt(t *testing.T) {
 	cases := []struct {
 		name     string
 		receipts []Receipt
@@ -38,9 +38,12 @@ func TestHasSuccessfulNonTodoReceipt(t *testing.T) {
 	}{
 		{"nil", nil, false},
 		{"todo only", []Receipt{{ToolName: "todo_write", Success: true}}, false},
-		{"failed non-todo only", []Receipt{{ToolName: "bash", Success: false}}, false},
-		{"successful non-todo", []Receipt{{ToolName: "bash", Success: true}}, true},
-		{"mixed with todo", []Receipt{{ToolName: "todo_write", Success: true}, {ToolName: "read_file", Success: true, Read: true}}, true},
+		{"read-only context only", []Receipt{{ToolName: "read_file", Success: true, Read: true}}, false},
+		{"failed execution only", []Receipt{{ToolName: "bash", Success: false}}, false},
+		{"successful command counts", []Receipt{{ToolName: "bash", Success: true}}, true},
+		{"complete_step counts", []Receipt{{ToolName: "complete_step", Success: true, Step: "done"}}, true},
+		{"todo plus read-only context still does not count", []Receipt{{ToolName: "todo_write", Success: true}, {ToolName: "read_file", Success: true, Read: true}}, false},
+		{"todo plus writer counts", []Receipt{{ToolName: "todo_write", Success: true}, {ToolName: "write_file", Success: true, Write: true}}, true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -51,8 +54,8 @@ func TestHasSuccessfulNonTodoReceipt(t *testing.T) {
 					l.Record(r)
 				}
 			}
-			if got := l.HasSuccessfulNonTodoReceipt(); got != tc.want {
-				t.Fatalf("HasSuccessfulNonTodoReceipt() = %v, want %v", got, tc.want)
+			if got := l.HasSuccessfulTodoProgressReceipt(); got != tc.want {
+				t.Fatalf("HasSuccessfulTodoProgressReceipt() = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/evidence/readiness_test.go
+++ b/internal/evidence/readiness_test.go
@@ -29,3 +29,31 @@ func TestHasSuccessfulTodoWriteMatchesOnlySuccessfulTodoWrite(t *testing.T) {
 		})
 	}
 }
+
+func TestHasSuccessfulNonTodoReceipt(t *testing.T) {
+	cases := []struct {
+		name     string
+		receipts []Receipt
+		want     bool
+	}{
+		{"nil", nil, false},
+		{"todo only", []Receipt{{ToolName: "todo_write", Success: true}}, false},
+		{"failed non-todo only", []Receipt{{ToolName: "bash", Success: false}}, false},
+		{"successful non-todo", []Receipt{{ToolName: "bash", Success: true}}, true},
+		{"mixed with todo", []Receipt{{ToolName: "todo_write", Success: true}, {ToolName: "read_file", Success: true, Read: true}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var l *Ledger
+			if tc.receipts != nil {
+				l = NewLedger()
+				for _, r := range tc.receipts {
+					l.Record(r)
+				}
+			}
+			if got := l.HasSuccessfulNonTodoReceipt(); got != tc.want {
+				t.Fatalf("HasSuccessfulNonTodoReceipt() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR cleans up the blocking prompt / approval card experience and fixes the todo panel state flow across the desktop frontend and agent readiness checks.

## What changed

- simplified blocking ask / approval cards by removing redundant detail sections from decision-blocking flows
- aligned the prompt shelf header, status copy, and secondary actions into a tighter single-row layout
- removed the numbered option chip treatment and kept option rows as clean, vertically stacked, fully clickable actions
- normalized secondary button styling so `Esc` and the passive fallback action share the same visual weight
- tightened text truncation and CSS sizing so long option labels and todo summaries expand naturally instead of fighting fixed-height rows
- restored the bottom todo panel visibility inside the prompt shelf flow
- kept the todo panel bound to the latest successful top-level `todo_write` snapshot instead of retaining every archived snapshot as canonical state
- narrowed final-answer readiness gating so read-only context gathering plus `todo_write` does not get treated like execution progress

## Root cause

Two separate regressions were involved:

1. The frontend archived full structured arguments for every `todo_write` snapshot, including synthetic snapshots emitted after `complete_step`. That let stale snapshots compete with the latest task state.
2. The backend readiness relaxation still treated any successful non-`todo_write` receipt as progress, so pure read-only context turns could still trigger incomplete-todo blocking.

## Validation

- `go test ./internal/evidence ./internal/agent -run 'Test(HasSuccessfulTodoProgressReceipt|ReceiptFromToolCall|FinalReadiness|TodoWriteOnlyTurnMayEndWithIncompleteTodos|ReadOnlyContextAndTodoTurnMayEndWithIncompleteTodos)'`
- `node --import tsx src/__tests__/tool-data-archive.test.ts`
- `node --import tsx src/__tests__/history-tool-status.test.ts`
- `npm run typecheck`
- `go test ./internal/agent -run 'Test(RunPopulatesCacheDiagnosticsOnUsageEvents|CompactRewriteVersionFeedsCacheDiagnostics|MaybeCompactThreshold|UsageLineReportsPrefixChurn)'`

## Impact

Users now get a cleaner blocking-card layout, the bottom todo panel stays visible and tracks the current canonical task state, and todo-only or read-only-plus-todo turns can end normally without false readiness blocks. Real write / execution turns still keep the incomplete-todo safeguard in place.

Cache-impact: none - the touched code in `internal/agent/agent.go` is limited to post-turn final-readiness gating and does not change composed prompt prefixes, tool schema ordering, or provider request serialization.
Cache-guard: `go test ./internal/agent -run 'Test(RunPopulatesCacheDiagnosticsOnUsageEvents|CompactRewriteVersionFeedsCacheDiagnostics|MaybeCompactThreshold|UsageLineReportsPrefixChurn)'` plus code inspection confirmed the diff does not touch prefix-shaping paths.