### PR TITLE
perf(desktop): lazy load secondary settings code / 延迟加载设置页次级代码

### DIFF
--- a/desktop/frontend/src/__tests__/bundle-contract.test.ts
+++ b/desktop/frontend/src/__tests__/bundle-contract.test.ts
@@ -19,6 +19,7 @@ function ok(cond: boolean, label: string) {
 
 const here = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(here, "../App.tsx"), "utf8");
+const settingsSource = readFileSync(resolve(here, "../components/SettingsPanel.tsx"), "utf8");
 const markdownSource = readFileSync(resolve(here, "../components/Markdown.tsx"), "utf8");
 
 console.log("\nbundle contract");
@@ -40,6 +41,24 @@ ok(
   appSource.includes('import("./components/SettingsPanel")') &&
     appSource.includes('import("./components/HistoryPanel")'),
   "App loads secondary drawers on demand",
+);
+ok(
+  !/import\s+\{[^}]*\b(?:MCPServersSettingsPage|SkillsSettingsPage)\b[^}]*\}\s+from\s+["']\.\/CapabilitiesPanel["']/.test(settingsSource) &&
+    !/import\s+\{[^}]*\bMemorySettingsPage\b[^}]*\}\s+from\s+["']\.\/MemoryPanel["']/.test(settingsSource),
+  "SettingsPanel keeps secondary settings pages out of the first settings chunk",
+);
+ok(
+  settingsSource.includes('import("./CapabilitiesPanel")') &&
+    settingsSource.includes('import("./MemoryPanel")'),
+  "SettingsPanel loads secondary settings pages on demand",
+);
+ok(
+  !/from\s+["']qrcode\.react["']/.test(settingsSource),
+  "SettingsPanel keeps QR rendering code out of the first settings chunk",
+);
+ok(
+  settingsSource.includes('import("qrcode.react")'),
+  "SettingsPanel loads QR rendering code on demand",
 );
 ok(
   !/from\s+["']react-markdown["']/.test(markdownSource) &&

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1,5 +1,4 @@
-import { memo, useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent, type ReactNode } from "react";
-import { QRCodeSVG } from "qrcode.react";
+import { lazy, memo, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent, type ReactNode } from "react";
 import { Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, GripVertical, KeyRound, Loader2, Play, QrCode, RefreshCw, Send } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useDeferredClose } from "../lib/useMountTransition";
@@ -49,8 +48,6 @@ import type { BotAllowlistView, BotConnectionDiagnostic, BotConnectionView, BotI
 import { InlineConfirmButton } from "./InlineConfirmButton";
 import { Tooltip } from "./Tooltip";
 import { AnchoredPopover } from "./AnchoredPopover";
-import { MCPServersSettingsPage, SkillsSettingsPage } from "./CapabilitiesPanel";
-import { MemorySettingsPage } from "./MemoryPanel";
 import { getGenerativePreset, setGenerativePreset, generativeMusic, type GenerativePreset } from "../lib/generative-music";
 import { SoundSelect } from "./SoundSelect";
 import { getSuccessPreference, setSuccessPreference, getAttentionPreference, setAttentionPreference, playSuccessChime, playAttentionChime, type SoundWavPref } from "../lib/sound";
@@ -59,6 +56,11 @@ import { ShortcutComboDisplay } from "./ShortcutComboDisplay";
 
 const SETTINGS_TABS: SettingsTab[] = ["general", "models", "bots", "mcp", "skills", "memory", "hooks", "shortcuts", "permissions", "sandbox", "network", "appearance", "updates"];
 export type SettingsInitialFocus = { target: "bot-allowlist"; connectionId?: string };
+
+const MCPServersSettingsPage = lazy(() => import("./CapabilitiesPanel").then((module) => ({ default: module.MCPServersSettingsPage })));
+const SkillsSettingsPage = lazy(() => import("./CapabilitiesPanel").then((module) => ({ default: module.SkillsSettingsPage })));
+const MemorySettingsPage = lazy(() => import("./MemoryPanel").then((module) => ({ default: module.MemorySettingsPage })));
+const QRCodeSVG = lazy(() => import("qrcode.react").then((module) => ({ default: module.QRCodeSVG })));
 
 // SettingsPanel is the desktop settings centre — a centred modal with left
 // navigation and a right content area. It hosts all settings pages plus MCP,
@@ -152,6 +154,7 @@ export function SettingsPanel({
   // sandbox, appearance, updates) need SettingsView loaded. MCP, Skills, and Memory
   // load their own data and render regardless.
   const needsSettings = tab === "general" || tab === "models" || tab === "bots" || tab === "network" || tab === "permissions" || tab === "sandbox" || tab === "appearance" || tab === "updates";
+  const lazySettingsPageFallback = <div className="empty">{t("settings.loading")}</div>;
 
   return (
     <div className="management-modal-backdrop settings-modal-backdrop" data-state={status} onClick={(e) => { if (e.target === e.currentTarget) requestClose(); }}>
@@ -184,9 +187,9 @@ export function SettingsPanel({
                 {tab === "general" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><GeneralSection s={s} busy={busy} apply={apply} agentRunning={agentRunning} /></SettingsPageShell>}
                 {tab === "models" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><ModelsSection s={s} busy={busy} apply={apply} backgroundApply={backgroundApply} /></SettingsPageShell>}
                 {tab === "bots" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><BotsSection s={s} busy={busy} apply={apply} initialFocus={initialFocus} /></SettingsPageShell>}
-                {tab === "mcp" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><MCPServersSettingsPage /></SettingsPageShell>}
-                {tab === "skills" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><SkillsSettingsPage /></SettingsPageShell>}
-                {tab === "memory" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><MemorySettingsPage /></SettingsPageShell>}
+                {tab === "mcp" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><Suspense fallback={lazySettingsPageFallback}><MCPServersSettingsPage /></Suspense></SettingsPageShell>}
+                {tab === "skills" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><Suspense fallback={lazySettingsPageFallback}><SkillsSettingsPage /></Suspense></SettingsPageShell>}
+                {tab === "memory" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><Suspense fallback={lazySettingsPageFallback}><MemorySettingsPage /></Suspense></SettingsPageShell>}
                 {tab === "hooks" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><HooksSection onChanged={onChanged} /></SettingsPageShell>}
                 {tab === "shortcuts" && <SettingsPageShell key={tab} s={s} tab={tab} busy={false} apply={apply}><ShortcutsSection /></SettingsPageShell>}
                 {tab === "permissions" && s && <SettingsPageShell key={tab} s={s} tab={tab} busy={busy} apply={apply}><PermissionsSection s={s} busy={busy} apply={apply} /></SettingsPageShell>}
@@ -2725,7 +2728,9 @@ function BotsSection({ s, busy, apply, initialFocus }: BotsSectionProps) {
                   installQrIsImage ? (
                     <img src={installQrURL} alt={t("settings.botInstallQrAlt")} />
                   ) : (
-                    <QRCodeSVG className="bot-connect-panel__qr-code" value={installQrURL} size={196} marginSize={1} />
+                    <Suspense fallback={<div className="bot-connect-panel__state"><QrCode aria-hidden="true" /></div>}>
+                      <QRCodeSVG className="bot-connect-panel__qr-code" value={installQrURL} size={196} marginSize={1} />
+                    </Suspense>
                   )
                 ) : install.status === "starting" ? (
                   <div className="bot-connect-panel__state">


### PR DESCRIPTION
## Summary

- Lazy-load the MCP/Skills and Memory settings pages from `SettingsPanel`, so opening common tabs such as General, Models, Bots, Appearance, or Updates does not parse those secondary management surfaces.
- Lazy-load the QR renderer used by the bot install flow instead of pulling `qrcode.react` into the first Settings chunk.
- Extend the desktop bundle contract to keep these secondary settings dependencies out of the first Settings chunk.

## Performance data

- `corepack pnpm --dir desktop/frontend build` now emits the first Settings chunk as `SettingsPanel-B3x1AtV-.js`: `139.20 kB`, gzip `30.60 kB`.
- Deferred chunks: `CapabilitiesPanel-xRlI3-tF.js` `32.83 kB` / gzip `7.71 kB`; `MemoryPanel-UIQSGGF8.js` `25.74 kB` / gzip `5.57 kB`; QR renderer chunk `esm-BGxTiHRR.js` `17.42 kB` / gzip `6.18 kB`.
- This keeps about `75.99 kB` minified / `19.46 kB` gzip of secondary settings code out of the ordinary Settings-open path until those tabs or the QR flow are actually used.

## Verification

- `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/bundle-contract.test.ts`
- `corepack pnpm --dir desktop/frontend test:typecheck`
- `corepack pnpm --dir desktop/frontend test:all`
- `corepack pnpm --dir desktop/frontend build`
- `git diff --check`

## Cache impact

Cache-impact: none - desktop frontend code-splitting only; provider-visible prompts, tool schemas, and cache-sensitive request bytes are unchanged.
Cache-guard: `corepack pnpm --dir desktop/frontend exec tsx src/__tests__/bundle-contract.test.ts`; `corepack pnpm --dir desktop/frontend build`.
System-prompt-review: N/A
