### PR TITLE
fix: honor custom OpenAI reasoning efforts

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1175,6 +1175,7 @@ func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (p
 			"thinking":           e.Thinking,
 			"effort":             config.EffectiveEffort(e),
 			"reasoning_protocol": config.ReasoningProtocolForEntry(e),
+			"supported_efforts":  e.SupportedEfforts,
 			"proxy_spec":         proxy,
 			"vision":             config.EffectiveVision(e),
 			"vision_detail":      e.VisionDetail,

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -850,6 +850,45 @@ func TestNewProviderAppliesConfiguredDefaultEffort(t *testing.T) {
 	}
 }
 
+func TestNewProviderHonorsCustomSupportedXHighEffort(t *testing.T) {
+	var gotReq map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\ndata: [DONE]\n\n"))
+	}))
+	defer srv.Close()
+
+	p, err := NewProvider(&config.ProviderEntry{
+		Name:              "custom",
+		Kind:              "openai",
+		BaseURL:           srv.URL,
+		Model:             "gpt-5.5",
+		ReasoningProtocol: "openai",
+		SupportedEfforts:  []string{"xhigh", "high"},
+		DefaultEffort:     "xhigh",
+	})
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	ch, err := p.Stream(context.Background(), provider.Request{
+		Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			t.Fatalf("stream error: %v", chunk.Err)
+		}
+	}
+	if got := gotReq["reasoning_effort"]; got != "xhigh" {
+		t.Fatalf("reasoning_effort = %#v, want xhigh from custom default_effort", got)
+	}
+}
+
 func TestNewProviderAppliesModelReasoningProtocol(t *testing.T) {
 	var gotReq map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/provider/openai/effort_test.go
+++ b/internal/provider/openai/effort_test.go
@@ -56,6 +56,26 @@ func TestEffortInvalidRejected(t *testing.T) {
 	}
 }
 
+func TestCustomSupportedEffortAllowsXHigh(t *testing.T) {
+	p, err := New(provider.Config{
+		Name:    "p",
+		BaseURL: "https://proxy.example.com/v1",
+		Model:   "gpt-5.5",
+		APIKey:  "k",
+		Extra: map[string]any{
+			"effort":             "xhigh",
+			"reasoning_protocol": "openai",
+			"supported_efforts":  []string{"xhigh", "high"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("New with custom xhigh effort: %v", err)
+	}
+	if got := p.(*client).effort; got != "xhigh" {
+		t.Fatalf("effort = %q, want xhigh", got)
+	}
+}
+
 func TestReasoningProtocolOverridesEndpointHeuristic(t *testing.T) {
 	p, err := New(provider.Config{
 		Name:    "deepseek-proxy",

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -7,7 +7,8 @@
 //   - api.minimaxi.com → emits thinking.type=adaptive|disabled (M3's binary
 //     knob) instead of reasoning_effort, since M3 has no level scale.
 //   - everything else (MiMo and other OpenAI-compatible gateways) uses the
-//     vanilla reasoning_effort scale (low/medium/high).
+//     vanilla reasoning_effort scale (low/medium/high), unless the provider
+//     config explicitly declares custom supported_efforts.
 package openai
 
 import (
@@ -60,6 +61,7 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	if effort == "auto" {
 		effort = ""
 	}
+	supportedEfforts := normalizeSupportedEfforts(cfg.Extra["supported_efforts"])
 	protocol, _ := cfg.Extra["reasoning_protocol"].(string)
 	protocol = normalizeReasoningProtocol(protocol)
 	vision, _ := cfg.Extra["vision"].(bool)
@@ -95,15 +97,22 @@ func New(cfg provider.Config) (provider.Provider, error) {
 			return nil, fmt.Errorf("openai: provider %q uses MiniMax thinking; effort must be adaptive or disabled", name)
 		}
 	case effort != "":
-		// Non-DeepSeek backends use OpenAI's reasoning_effort scale (low/medium/
-		// high); "max" is a DeepSeek-ism MiMo et al. reject with 400, so clamp it
-		// to the OpenAI ceiling and reject other values at boot, not at request time.
-		switch effort {
-		case "max":
-			effort = "high"
-		case "low", "medium", "high":
-		default:
-			return nil, fmt.Errorf("openai: provider %q: effort must be low, medium, or high", name)
+		// Non-DeepSeek backends default to OpenAI's reasoning_effort scale
+		// (low/medium/high). If the config explicitly declares custom supported
+		// efforts for a compatible gateway, trust that list and forward the
+		// selected value verbatim.
+		if len(supportedEfforts) > 0 {
+			if !containsString(supportedEfforts, effort) {
+				return nil, fmt.Errorf("openai: provider %q: effort must be one of supported_efforts: %s", name, strings.Join(supportedEfforts, ", "))
+			}
+		} else {
+			switch effort {
+			case "max":
+				effort = "high"
+			case "low", "medium", "high":
+			default:
+				return nil, fmt.Errorf("openai: provider %q: effort must be low, medium, or high", name)
+			}
 		}
 	}
 	httpClient, err := newHTTPClient(cfg)
@@ -125,6 +134,43 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		http:         httpClient,
 		idleTimeout:  defaultStreamIdleTimeout,
 	}, nil
+}
+
+func normalizeSupportedEfforts(raw any) []string {
+	var values []string
+	switch v := raw.(type) {
+	case []string:
+		values = v
+	case []any:
+		values = make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				values = append(values, s)
+			}
+		}
+	default:
+		return nil
+	}
+	out := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, value := range values {
+		level := strings.ToLower(strings.TrimSpace(value))
+		if level == "" || level == "auto" || seen[level] {
+			continue
+		}
+		seen[level] = true
+		out = append(out, level)
+	}
+	return out
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if value == needle {
+			return true
+		}
+	}
+	return false
 }
 
 func newHTTPClient(cfg provider.Config) (*http.Client, error) {


### PR DESCRIPTION
## 背景

当前配置层已经支持通过 `supported_efforts` 和 `default_effort` 为 provider 声明自定义推理强度，例如：

```toml
supported_efforts = ["xhigh", "high"]
default_effort = "xhigh"
```

但是 `openai` provider 在真正构建请求前仍然硬编码只允许 `low` / `medium` / `high`。因此对于支持 `reasoning_effort = "xhigh"` 的 OpenAI-compatible 网关，Reasonix 会在请求发出前直接报错：

```text
openai: provider "...": effort must be low, medium, or high
```

## 修改内容

- 在 `boot.NewProviderWithProxy` 中把 `ProviderEntry.SupportedEfforts` 传给底层 provider。
- 在 `internal/provider/openai` 中增加对显式 `supported_efforts` 的识别：
  - 如果配置声明了 `supported_efforts`，则按这份列表校验并原样转发选中的 effort。
  - 如果没有声明，则保持原有行为，仍然只允许默认 OpenAI scale：`low` / `medium` / `high`，并继续把 `max` 降级为 `high`。
- 添加测试覆盖 `xhigh` 自定义 effort 能从配置传递到实际请求体。

## Cache / prompt guard

Cache-impact: low - 仅增加 provider 配置元数据传递和 OpenAI-compatible effort 校验分支，不修改系统提示词文本、消息前缀或缓存 key 结构。
Cache-guard: go test ./internal/provider/openai -count=1; go test ./internal/boot -run 'TestNewProvider(AppliesConfiguredDefaultEffort|HonorsCustomSupportedXHighEffort|AppliesModelReasoningProtocol)' -count=1
System-prompt-review: Author self-review; `internal/boot/*` 因路径规则被标记为 system-prompt-sensitive，但本改动只向 provider Extra 传递 supported_efforts，不改变 system prompt 组装或提示词内容。

## 影响范围

这个改动只影响显式配置了 `supported_efforts` 的 OpenAI-compatible provider。未配置自定义 effort 的 provider 仍然沿用原来的校验逻辑，因此不会放宽默认 OpenAI provider 的输入约束。

## 验证

已在 Windows 本地执行：

```powershell
go test ./internal/provider/openai -count=1
go test ./internal/config -run 'Test(Effort|NormalizeEffort|EffectiveEffort)' -count=1
go test ./internal/boot -run 'TestNewProvider(AppliesConfiguredDefaultEffort|HonorsCustomSupportedXHighEffort|AppliesModelReasoningProtocol)' -count=1
go build -o bin\reasonix.exe .\cmd\reasonix
```

并用本地配置验证 `GPT/gpt-5.5` 可以以 `effort xhigh` 启动并完成一次 CLI 对话。