### PR TITLE
Improve crash stats dashboard navigation / 优化崩溃统计看板导航

### DIFF
--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -912,8 +912,8 @@ func TestServeSessionClose(t *testing.T) {
 
 func TestSessionDeleteWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 	dir := t.TempDir()
-	grace := 500 * time.Millisecond
-	slack := 300 * time.Millisecond
+	grace := time.Second
+	maxElapsed := grace + 750*time.Millisecond
 	factory := &teardownFactory{dir: dir, grace: grace}
 	client, stop := startServer(t, factory)
 	defer stop()
@@ -937,7 +937,7 @@ func TestSessionDeleteWithStuckJobReturnsAfterSingleGrace(t *testing.T) {
 	if resp.Error != nil {
 		t.Fatalf("session/delete errored: %+v", resp.Error)
 	}
-	if elapsed > grace+slack {
+	if elapsed > maxElapsed {
 		t.Fatalf("session/delete took %s, want one teardown grace plus scheduling slack", elapsed)
 	}
 	if !agent.IsCleanupPending(path) {

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -542,10 +542,13 @@ type StatsFilters = {
   platform: string;
   newLatest: boolean;
   regressed: boolean;
+  windowDays: 7 | 30;
+  preferenceMode: "users" | "opens";
 };
 
 function statsFilters(url: URL): StatsFilters {
   const status = url.searchParams.get("status") ?? "";
+  const windowParam = url.searchParams.get("window") ?? "";
   return {
     status: ["open", "resolved", "ignored"].includes(status) ? status : "",
     source: (url.searchParams.get("source") ?? "").slice(0, 32),
@@ -554,6 +557,8 @@ function statsFilters(url: URL): StatsFilters {
     platform: (url.searchParams.get("platform") ?? "").slice(0, 80),
     newLatest: url.searchParams.get("new") === "latest",
     regressed: url.searchParams.get("regressed") === "1",
+    windowDays: windowParam === "30d" ? 30 : 7,
+    preferenceMode: url.searchParams.get("prefs") === "opens" ? "opens" : "users",
   };
 }
 
@@ -571,10 +576,22 @@ async function crashGroups(env: Env, filters: StatsFilters, latestVersion: strin
   if (filters.platform) add("last_os || ' ' || last_arch = ?", filters.platform);
   if (filters.newLatest && latestVersion) add("first_version = ?", latestVersion);
   if (filters.regressed) where.push("regressed_at <> ''");
+  let latestOrder = "";
+  if (latestVersion) {
+    latestOrder = `CASE WHEN first_version = ?${binds.length + 1} THEN 0 ELSE 1 END,`;
+    binds.push(latestVersion);
+  }
   const sql = `SELECT fingerprint, kind, count, first_version, last_version, substr(last_seen, 1, 10) AS seen,
       status, title, source, label, error_type, top_frame, severity, last_os, last_arch, regressed_at
     FROM groups ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
-    ORDER BY last_seen DESC LIMIT 50`;
+    ORDER BY
+      CASE WHEN status = 'open' THEN 0 ELSE 1 END,
+      CASE WHEN regressed_at <> '' THEN 0 ELSE 1 END,
+      ${latestOrder}
+      CASE severity WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
+      count DESC,
+      last_seen DESC
+    LIMIT 50`;
   const stmt = env.DB.prepare(sql);
   const query = binds.length ? stmt.bind(...binds) : stmt;
   return query.all<{
@@ -641,10 +658,88 @@ async function latestObservedVersion(env: Env): Promise<string> {
   return newestReleaseVersion(rows.results.map((r) => r.version));
 }
 
-async function metricUserRows(env: Env): Promise<{ signal: string; bucket: string; total: number }[]> {
+type OverviewCounts = {
+  latestAdoptionPct: number | null;
+  openReports: number;
+  newLatestReports: number;
+  regressedReports: number;
+  criticalOpenReports: number;
+};
+
+async function latestAdoptionPct(env: Env, latestVersion: string, days: 7 | 30): Promise<number | null> {
+  if (!latestVersion) return null;
+  const row = await env.DB.prepare(
+    `SELECT
+      COUNT(DISTINCT install_id) AS total_installs,
+      COUNT(DISTINCT CASE WHEN version = ?1 THEN install_id END) AS latest_installs
+    FROM pings WHERE date >= date('now', '${currentWindowSince(days)}')`,
+  )
+    .bind(latestVersion)
+    .first<{ total_installs: number; latest_installs: number }>();
+  const total = Number(row?.total_installs ?? 0);
+  if (!total) return null;
+  return (Number(row?.latest_installs ?? 0) / total) * 100;
+}
+
+async function diagnosticOverview(env: Env, latestVersion: string, days: 7 | 30): Promise<OverviewCounts> {
+  const diagnosticCounts = latestVersion
+    ? env.DB.prepare(
+        `SELECT
+          SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open_reports,
+          SUM(CASE WHEN first_version = ?1 THEN 1 ELSE 0 END) AS new_latest_reports,
+          SUM(CASE WHEN regressed_at <> '' THEN 1 ELSE 0 END) AS regressed_reports,
+          SUM(CASE WHEN status = 'open' AND severity IN ('critical', 'high') THEN 1 ELSE 0 END) AS critical_open_reports
+        FROM groups`,
+      )
+        .bind(latestVersion)
+        .first<{ open_reports: number; new_latest_reports: number; regressed_reports: number; critical_open_reports: number }>()
+    : env.DB.prepare(
+        `SELECT
+          SUM(CASE WHEN status = 'open' THEN 1 ELSE 0 END) AS open_reports,
+          0 AS new_latest_reports,
+          SUM(CASE WHEN regressed_at <> '' THEN 1 ELSE 0 END) AS regressed_reports,
+          SUM(CASE WHEN status = 'open' AND severity IN ('critical', 'high') THEN 1 ELSE 0 END) AS critical_open_reports
+        FROM groups`,
+      ).first<{ open_reports: number; new_latest_reports: number; regressed_reports: number; critical_open_reports: number }>();
+  const [row, adoptionPct] = await Promise.all([
+    diagnosticCounts,
+    latestAdoptionPct(env, latestVersion, days),
+  ]);
+  return {
+    latestAdoptionPct: adoptionPct,
+    openReports: Number(row?.open_reports ?? 0),
+    newLatestReports: Number(row?.new_latest_reports ?? 0),
+    regressedReports: Number(row?.regressed_reports ?? 0),
+    criticalOpenReports: Number(row?.critical_open_reports ?? 0),
+  };
+}
+
+function currentWindowSince(days: 7 | 30): string {
+  return `-${days - 1} day`;
+}
+
+function previousWindowSince(days: 7 | 30): string {
+  return `-${days * 2 - 1} day`;
+}
+
+function previousWindowUntil(days: 7 | 30): string {
+  return `-${days} day`;
+}
+
+async function metricRows(env: Env, days: 7 | 30, previous = false): Promise<{ signal: string; bucket: string; total: number }[]> {
+  const where = previous
+    ? `date >= date('now', '${previousWindowSince(days)}') AND date < date('now', '${previousWindowUntil(days)}')`
+    : `date >= date('now', '${currentWindowSince(days)}')`;
+  const rows = await env.DB.prepare(
+    `SELECT signal, bucket, SUM(count) AS total FROM metrics WHERE ${where} GROUP BY signal, bucket ORDER BY signal, total DESC`,
+  ).all<{ signal: string; bucket: string; total: number }>();
+  return rows.results;
+}
+
+async function metricUserRows(env: Env, days: 7 | 30): Promise<{ signal: string; bucket: string; total: number }[]> {
   try {
     const rows = await env.DB.prepare(
-      "SELECT signal, bucket, COUNT(*) AS total FROM metric_users WHERE date >= date('now', '-6 day') GROUP BY signal, bucket ORDER BY signal, total DESC",
+      `SELECT signal, bucket, COUNT(*) AS total FROM metric_users WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY signal, bucket ORDER BY signal, total DESC`,
     ).all<{ signal: string; bucket: string; total: number }>();
     return rows.results;
   } catch (err) {
@@ -657,22 +752,23 @@ async function handleStats(request: Request, env: Env, user: User): Promise<Resp
   const url = new URL(request.url);
   const filters = statsFilters(url);
   const latestVersion = await latestObservedVersion(env);
-  const [daily, versions, platforms, crashes, metrics, metricUsers, sources] = await Promise.all([
+  const days = filters.windowDays;
+  const [daily, versions, platforms, crashes, metrics, previousMetrics, metricUsers, sources, overview] = await Promise.all([
     env.DB.prepare(
-      "SELECT date, COUNT(*) AS users, SUM(opens) AS opens FROM pings WHERE date >= date('now', '-29 day') GROUP BY date",
+      `SELECT date, COUNT(*) AS users, SUM(opens) AS opens FROM pings WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY date`,
     ).all<{ date: string; users: number; opens: number }>(),
     env.DB.prepare(
-      "SELECT version AS label, COUNT(DISTINCT install_id) AS users FROM pings WHERE date >= date('now', '-6 day') GROUP BY label ORDER BY users DESC LIMIT 15",
+      `SELECT version AS label, COUNT(DISTINCT install_id) AS users FROM pings WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY label ORDER BY users DESC LIMIT 15`,
     ).all<{ label: string; users: number }>(),
     env.DB.prepare(
-      "SELECT os || ' ' || arch AS label, COUNT(DISTINCT install_id) AS users FROM pings WHERE date >= date('now', '-6 day') GROUP BY label ORDER BY users DESC",
+      `SELECT os || ' ' || arch AS label, COUNT(DISTINCT install_id) AS users FROM pings WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY label ORDER BY users DESC`,
     ).all<{ label: string; users: number }>(),
     crashGroups(env, filters, latestVersion),
-    env.DB.prepare(
-      "SELECT signal, bucket, SUM(count) AS total FROM metrics WHERE date >= date('now', '-6 day') GROUP BY signal, bucket ORDER BY signal, total DESC",
-    ).all<{ signal: string; bucket: string; total: number }>(),
-    metricUserRows(env),
+    metricRows(env, days),
+    metricRows(env, days, true),
+    metricUserRows(env, days),
     env.DB.prepare("SELECT source AS label, COUNT(*) AS users FROM groups GROUP BY source ORDER BY users DESC").all<{ label: string; users: number }>(),
+    diagnosticOverview(env, latestVersion, days),
   ]);
   return html(
     renderStats(
@@ -681,9 +777,11 @@ async function handleStats(request: Request, env: Env, user: User): Promise<Resp
         versions: versions.results,
         platforms: platforms.results,
         crashes: crashes.results,
-        metrics: metrics.results,
+        metrics,
+        previousMetrics,
         metricUsers,
         sources: sources.results,
+        overview,
         latestVersion,
         filters,
       },

--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -723,7 +723,7 @@ function previousWindowSince(days: 7 | 30): string {
 }
 
 function previousWindowUntil(days: 7 | 30): string {
-  return `-${days} day`;
+  return currentWindowSince(days);
 }
 
 async function metricRows(env: Env, days: 7 | 30, previous = false): Promise<{ signal: string; bucket: string; total: number }[]> {
@@ -739,7 +739,7 @@ async function metricRows(env: Env, days: 7 | 30, previous = false): Promise<{ s
 async function metricUserRows(env: Env, days: 7 | 30): Promise<{ signal: string; bucket: string; total: number }[]> {
   try {
     const rows = await env.DB.prepare(
-      `SELECT signal, bucket, COUNT(*) AS total FROM metric_users WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY signal, bucket ORDER BY signal, total DESC`,
+      `SELECT signal, bucket, COUNT(DISTINCT install_id) AS total FROM metric_users WHERE date >= date('now', '${currentWindowSince(days)}') GROUP BY signal, bucket ORDER BY signal, total DESC`,
     ).all<{ signal: string; bucket: string; total: number }>();
     return rows.results;
   } catch (err) {

--- a/workers/crash-report/src/shell.ts
+++ b/workers/crash-report/src/shell.ts
@@ -15,6 +15,7 @@ const CSS = `
 --sans:"Outfit","Helvetica Neue","PingFang SC","Microsoft YaHei",sans-serif;
 --mono:"JetBrains Mono","SF Mono",Menlo,Consolas,monospace}
 *{margin:0;padding:0;box-sizing:border-box}
+html{scroll-behavior:smooth}
 body{font-family:var(--sans);background:#fff;color:var(--ink);-webkit-font-smoothing:antialiased}
 .wrap{max-width:1060px;margin:0 auto;padding:0 28px 64px}
 header{display:flex;align-items:center;gap:10px;height:68px}
@@ -35,17 +36,61 @@ body[data-lang="en"] [data-i18n="zh"],body[data-lang="zh"] [data-i18n="en"]{disp
 .badge.admin{background:oklch(0.95 0.05 150);color:oklch(0.48 0.13 150)}
 h1{font-size:30px;font-weight:600;letter-spacing:-0.02em;margin:18px 0 6px}
 .sub{color:var(--ink-2);font-size:14.5px;margin-bottom:28px}
+.hero-line{display:flex;align-items:flex-start;justify-content:space-between;gap:18px;margin-top:6px}
+.hero-line .sub{margin-bottom:18px}
+.segmented{display:inline-flex;align-items:center;gap:3px;padding:3px;border:1px solid var(--line);border-radius:13px;background:var(--bg-soft);white-space:nowrap}
+.segmented a{display:inline-flex;align-items:center;justify-content:center;min-height:30px;padding:6px 11px;border-radius:10px;color:var(--ink-2);text-decoration:none;font-size:12.5px;font-weight:700}
+.segmented a.active{background:#fff;color:var(--accent);box-shadow:var(--shadow-1)}
+.overview-grid{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:10px;margin:0 0 20px}
+.overview-card{border:1px solid var(--line);border-radius:16px;background:linear-gradient(180deg,#fff,var(--bg-soft));padding:14px 15px;min-width:0;text-decoration:none}
+.overview-card:hover{border-color:color-mix(in oklch,var(--accent) 36%,var(--line));transform:translateY(-1px)}
+.overview-card span,.overview-card small{display:block;color:var(--ink-3);font-size:12.5px;line-height:1.3}
+.overview-card strong{display:block;color:var(--ink);font-family:var(--mono);font-size:24px;line-height:1.15;margin:6px 0 4px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.overview-card.good{border-color:oklch(0.88 0.05 150);background:oklch(0.985 0.015 150)}
+.overview-card.warn{border-color:oklch(0.9 0.07 80);background:oklch(0.985 0.018 80)}
+.overview-card.bad{border-color:oklch(0.89 0.06 25);background:oklch(0.985 0.016 25)}
+.module-nav{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin:0 0 20px}
+.module-link{display:grid;grid-template-columns:1fr auto;grid-template-areas:"label value" "note note";gap:4px 10px;border:1px solid var(--line);border-radius:16px;background:#fff;color:var(--ink);text-decoration:none;padding:13px 14px;box-shadow:var(--shadow-1)}
+.module-link:hover{border-color:color-mix(in oklch,var(--accent) 36%,var(--line));background:var(--accent-soft)}
+.module-link span{grid-area:label;color:var(--ink-2);font-size:13px;font-weight:700}
+.module-link b{grid-area:value;font-family:var(--mono);font-size:13px;color:var(--accent)}
+.module-link small{grid-area:note;color:var(--ink-3);font-size:12.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .grid{display:grid;grid-template-columns:1fr 1fr;gap:20px}
 .card{background:#fff;border:1px solid var(--line);border-radius:24px;padding:24px 28px;box-shadow:var(--shadow-1)}
 .card.full{grid-column:1/-1}
 .card h2{font-size:15px;font-weight:600;color:var(--ink-2);margin-bottom:16px}
 .card h2 b{color:var(--ink)}
+.module-card{scroll-margin-top:18px}
+.module-card+.module-card{margin-top:2px}
+.module-head{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:16px}
+.module-head span{display:block;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--ink-3);font-weight:800;margin-bottom:4px}
+.module-head h2{margin:0;color:var(--ink);font-size:19px}
+.module-action{color:var(--accent);text-decoration:none;font-size:13.5px;font-weight:700;white-space:nowrap}
+.module-action:hover{text-decoration:underline}
+.module-panel{border:1px solid var(--line);border-radius:18px;background:var(--bg-soft);padding:16px 18px;margin-top:12px;min-width:0}
+.module-panel.wide{margin-top:0}
+.module-panel h3{font-size:13px;font-weight:700;color:var(--ink-2);margin:0 0 12px}
+.module-panel h3 b{color:var(--ink)}
+.module-split{display:grid;grid-template-columns:1fr 1fr;gap:12px;align-items:start}
+.module-split.wide{grid-template-columns:minmax(0,1fr) minmax(0,1fr)}
+.card-title-row{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:16px}
+.card-title-row h2{margin:0}
 .empty{color:var(--ink-3);font-size:14px;padding:14px 0}
 svg.chart{width:100%;height:auto;display:block}
-.row{display:grid;grid-template-columns:minmax(90px,auto) 1fr 3.5em;align-items:center;gap:12px;padding:7px 0;font-size:14px}
+.bars-list{min-width:0}
+.row{display:grid;grid-template-columns:minmax(110px,210px) minmax(90px,1fr) 3.5em;align-items:center;gap:12px;padding:7px 0;font-size:14px;min-width:0}
 .row+.row{border-top:1px solid var(--line)}
+.row-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.row-bar{min-width:0}
 .row .bar{height:10px;border-radius:999px;background:linear-gradient(90deg,#4f9dff,#7a6bff);min-width:4px}
 .row .n{text-align:right;font-family:var(--mono);font-size:13px;color:var(--ink-2)}
+.bucket-prefix{display:inline-flex;align-items:center;margin-right:6px;padding:1px 6px;border-radius:8px;background:var(--accent-soft);color:var(--accent);font-size:12px;font-weight:700}
+.bucket-main{min-width:0}
+.bars-more{margin-top:6px}
+.bars-more summary{display:inline-flex;align-items:center;min-height:30px;padding:5px 9px;border:1px dashed var(--line);border-radius:10px;background:#fff;color:var(--accent);font-size:12.5px;font-weight:700;cursor:pointer;list-style:none}
+.bars-more summary::-webkit-details-marker{display:none}
+.bars-more summary:hover{border-color:color-mix(in oklch,var(--accent) 34%,var(--line))}
+.bars-more-list{max-height:220px;overflow:auto;margin-top:7px;padding:5px 8px;border:1px solid var(--line);border-radius:12px;background:#fff}
 table{border-collapse:collapse;width:100%;font-size:14px}
 th{text-align:left;color:var(--ink-3);font-weight:500;font-size:12.5px;padding:0 14px 8px 0}
 td{padding:8px 14px 8px 0;border-top:1px solid var(--line);vertical-align:middle}
@@ -67,13 +112,31 @@ a.fp:hover{text-decoration:underline}
 pre{background:var(--term-bg);color:#e6e8f0;border-radius:12px;padding:16px 18px;font-family:var(--mono);
 font-size:12.5px;line-height:1.55;overflow:auto;white-space:pre-wrap;word-break:break-word}
 .metrics{display:grid;grid-template-columns:1fr 1fr;gap:8px 28px}
-.metric-block h3{font-family:var(--mono);font-size:12.5px;font-weight:600;color:var(--ink-2);margin:6px 0 4px}
-.preference-dashboard{display:flex;flex-direction:column;gap:18px}
-.pref-section{border:1px solid var(--line);border-radius:18px;background:var(--bg-soft);padding:16px 18px}
-.pref-section>h3{font-size:13px;font-weight:700;color:var(--ink);margin:0 0 10px}
+.metric-block h3{display:flex;align-items:center;justify-content:space-between;gap:8px;font-family:var(--mono);font-size:12.5px;font-weight:600;color:var(--ink-2);margin:6px 0 4px}
+.metric-block h3 span{font-family:var(--mono);font-size:11px;color:var(--ink-3);font-weight:600}
+.preference-dashboard{display:flex;flex-direction:column;gap:14px}
+.pref-section{border:1px solid var(--line);border-radius:14px;background:#fff;padding:14px 15px}
+.pref-section>h3,.pref-section summary h3{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:13px;font-weight:700;color:var(--ink);margin:0 0 10px}
+.pref-section>h3 span,.pref-section summary h3 span{font-size:11.5px;color:var(--ink-3);font-weight:700;white-space:nowrap}
+.pref-section summary{cursor:pointer;list-style:none}
+.pref-section summary::-webkit-details-marker{display:none}
+.pref-section summary h3{margin:0}
+.pref-section[open] summary h3{margin-bottom:10px}
+.pref-section-collapsed summary:hover h3{color:var(--accent)}
 .pref-section .metric-block h3{color:var(--ink-3)}
 .pref-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}
-.filter-card{padding-top:22px}
+.health-grid{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:12px}
+.health-card{border:1px solid var(--line);border-radius:16px;background:var(--bg-soft);padding:14px 15px;min-width:0}
+.health-card.good{background:oklch(0.985 0.015 150);border-color:oklch(0.88 0.05 150)}
+.health-card.warn{background:oklch(0.985 0.018 80);border-color:oklch(0.9 0.07 80)}
+.health-card.bad{background:oklch(0.985 0.016 25);border-color:oklch(0.89 0.06 25)}
+.health-top{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
+.health-top span{font-size:12.5px;color:var(--ink-2);font-weight:700}
+.health-top b{font-size:11px;text-transform:uppercase;color:var(--ink-3);font-weight:800}
+.health-card strong{display:block;font-family:var(--mono);font-size:22px;color:var(--ink);margin-bottom:4px}
+.health-card small{display:block;color:var(--ink-3);font-family:var(--mono);font-size:11.5px;margin-bottom:9px}
+.health-card p{color:var(--ink-2);font-size:12.5px;line-height:1.35;word-break:break-word}
+.filter-card{margin-top:12px;padding:16px 18px;border:1px solid var(--line);border-radius:18px;background:#fff;position:sticky;top:10px;z-index:2}
 .filter-head{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:14px}
 .filter-head h2{margin:0}
 .filter-head span{font-family:var(--mono);font-size:12.5px;color:var(--ink-3);white-space:nowrap}
@@ -92,10 +155,15 @@ padding:6px 9px;border:1px solid var(--line);border-radius:11px;background:#fff;
 .facet-chip.active{background:var(--accent-soft);border-color:color-mix(in oklch,var(--accent) 45%,var(--line));color:var(--accent)}
 .facet-chip b{font-family:var(--mono);font-size:12px;color:inherit}
 .facet-label{overflow:hidden;text-overflow:ellipsis;white-space:nowrap;min-width:0}
+.facet-more{flex-basis:100%;min-width:0}
+.facet-more summary{display:inline-flex;align-items:center;min-height:32px;padding:6px 10px;border:1px dashed var(--line);border-radius:11px;background:var(--bg-soft);color:var(--accent);font-size:13px;font-weight:700;cursor:pointer;list-style:none}
+.facet-more summary::-webkit-details-marker{display:none}
+.facet-more summary:hover{border-color:color-mix(in oklch,var(--accent) 34%,var(--line))}
+.facet-more-list{display:flex;flex-wrap:wrap;gap:7px;max-height:150px;overflow:auto;margin-top:8px;padding:8px;border:1px solid var(--line);border-radius:13px;background:#fff}
 .filter-empty{font-size:13px;color:var(--ink-3)}
 .crash-card{overflow:hidden}
 .crash-list{display:flex;flex-direction:column;gap:2px}
-.crash-head,.crash-item{display:grid;grid-template-columns:110px minmax(220px,1fr) minmax(185px,.68fr) 150px 62px;gap:16px;align-items:center}
+.crash-head,.crash-item{display:grid;grid-template-columns:minmax(300px,1fr) minmax(185px,.55fr) 150px 62px;gap:16px;align-items:center}
 .crash-head{padding:0 12px 9px;color:var(--ink-3);font-size:12.5px;font-weight:600;border-bottom:1px solid var(--line)}
 .crash-item{margin:0 -12px;padding:14px 12px;border-radius:14px;color:var(--ink);text-decoration:none;border-bottom:1px solid var(--line)}
 .crash-item:hover{background:var(--bg-soft)}
@@ -104,6 +172,7 @@ padding:6px 9px;border:1px solid var(--line);border-radius:11px;background:#fff;
 .crash-fingerprint small,.crash-scope small{font-family:var(--mono);font-size:11.5px;color:var(--ink-3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .crash-summary{display:flex;flex-direction:column;gap:5px;min-width:0}
 .crash-summary>span{font-family:var(--mono);font-size:12.8px;line-height:1.45;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.crash-summary small{font-family:var(--mono);font-size:11.5px;color:var(--ink-3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .crash-summary em{font-size:12px;font-style:normal;color:oklch(0.55 0.18 25)}
 .crash-scope{display:flex;flex-direction:column;gap:4px;min-width:0}
 .crash-health{display:flex;flex-wrap:wrap;gap:6px;align-items:center}
@@ -117,6 +186,8 @@ padding:6px 9px;border:1px solid var(--line);border-radius:11px;background:#fff;
 .group-tags{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 18px}
 .group-tags span{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line);border-radius:11px;background:#fff;padding:6px 9px;font-size:13px;color:var(--ink-2)}
 .group-tags b{font-size:12px;color:var(--ink-3);font-weight:600}
+.crash-list.compact .crash-head{display:none}
+.crash-list.compact .crash-item{padding:12px;margin:0 -12px;grid-template-columns:minmax(260px,1fr) minmax(160px,.5fr) 140px 52px}
 .group-metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px}
 .group-metrics div{border:1px solid var(--line);border-radius:14px;background:var(--bg-soft);padding:12px 13px;min-width:0}
 .group-metrics span{display:block;font-size:12px;color:var(--ink-3);margin-bottom:5px}
@@ -139,6 +210,10 @@ padding:6px 9px;border:1px solid var(--line);border-radius:11px;background:#fff;
 .sample-meta span{display:inline-flex;align-items:center;gap:6px;border:1px solid var(--line);border-radius:10px;padding:5px 8px;color:var(--ink-2);font-size:12.5px}
 .sample-meta b{color:var(--ink-3);font-weight:600}
 .sample-actions{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:12px}
+.sample-more{border:1px dashed var(--line);border-radius:16px;background:var(--bg-soft);padding:10px}
+.sample-more>summary{cursor:pointer;list-style:none;color:var(--accent);font-size:13.5px;font-weight:700;padding:4px 6px}
+.sample-more>summary::-webkit-details-marker{display:none}
+.sample-more-list{display:flex;flex-direction:column;gap:10px;margin-top:10px}
 .copy-btn[data-state="copied"]{background:oklch(0.95 0.05 150);color:oklch(0.48 0.13 150)}
 .copy-btn[data-state="copied"] .copy-label{display:none}
 .copy-btn[data-state="copied"]::after{content:"Copied"}
@@ -183,10 +258,11 @@ form.inline{display:inline}
 td select{width:auto;padding:6px 10px;border-radius:10px}
 .note-edit{margin-top:12px;display:flex;gap:8px;max-width:560px}
 .note-edit input{flex:1}
-@media(max-width:900px){.facet-grid{grid-template-columns:1fr}.crash-head{display:none}.crash-item{grid-template-columns:1fr;gap:10px}
-.crash-health{justify-content:flex-start}.crash-count{text-align:left}.filter-head{align-items:flex-start;flex-direction:column;gap:6px}
+@media(max-width:1100px){.overview-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.module-nav{grid-template-columns:repeat(2,minmax(0,1fr))}.health-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.module-split,.module-split.wide{grid-template-columns:1fr}}
+@media(max-width:900px){.hero-line{flex-direction:column}.facet-grid{grid-template-columns:1fr}.crash-head{display:none}.crash-item,.crash-list.compact .crash-item{grid-template-columns:1fr;gap:10px}
+.crash-health{justify-content:flex-start}.crash-count{text-align:left}.filter-head,.module-head{align-items:flex-start;flex-direction:column;gap:8px}
 .group-metrics{grid-template-columns:1fr 1fr}.sample summary{grid-template-columns:1fr}.sample-time{text-align:left}.manage-head{flex-direction:column}.manage-actions{justify-content:flex-start}.manage-grid{grid-template-columns:1fr}.manage-form.wide{grid-column:auto}}
-@media(max-width:760px){.grid{grid-template-columns:1fr}.metrics,.pref-metrics{grid-template-columns:1fr}.wrap{padding:0 16px 48px}}
+@media(max-width:760px){header{height:auto;min-height:68px;flex-wrap:wrap;padding:14px 0}.lang-switch{margin-left:0}.nav{width:100%;flex-wrap:wrap;gap:8px}.chip{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis}.grid{grid-template-columns:1fr}.overview-grid,.module-nav,.health-grid{grid-template-columns:1fr}.metrics,.pref-metrics{grid-template-columns:1fr}.row{grid-template-columns:minmax(0,1fr) minmax(70px,.8fr) 3.2em}.card-title-row{align-items:flex-start;flex-direction:column}.filter-card{position:static}.wrap{padding:0 16px 48px}}
 `;
 
 const LANG_SWITCH = `<span class="lang-switch" role="group" aria-label="Language"><button type="button" data-lang-option="zh">中文</button><button type="button" data-lang-option="en">EN</button></span>`;

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -3,11 +3,25 @@ import { type User, userNav } from "./auth";
 
 type Daily = { date: string; users: number; opens: number };
 type MetricRow = { signal: string; bucket: string; total: number };
+type BarRow = { label: string; users: number };
+type BarListOptions = {
+  limit?: number;
+  className?: string;
+  labelFormatter?: (label: string) => string;
+};
 
-function last30Days(rows: Daily[]): Daily[] {
+type OverviewCounts = {
+  latestAdoptionPct: number | null;
+  openReports: number;
+  newLatestReports: number;
+  regressedReports: number;
+  criticalOpenReports: number;
+};
+
+function lastDays(rows: Daily[], count: 7 | 30): Daily[] {
   const byDate = new Map(rows.map((r) => [r.date, r]));
   const out: Daily[] = [];
-  for (let i = 29; i >= 0; i--) {
+  for (let i = count - 1; i >= 0; i--) {
     const date = new Date(Date.now() - i * 86400000).toISOString().slice(0, 10);
     out.push(byDate.get(date) ?? { date, users: 0, opens: 0 });
   }
@@ -75,15 +89,76 @@ ${label}</g>`;
 ${grid}${bars}</svg>`;
 }
 
-function listBars(rows: { label: string; users: number }[]): string {
-  if (!rows.length) return `<div class="empty">${i18n("No data in the last 7 days", "近 7 天暂无数据")}</div>`;
+function bucketDisplayLabel(signal: string, bucket: string): string {
+  if (signal.includes("_model") && bucket.startsWith("custom_")) {
+    const model = bucket.slice("custom_".length).replace(/_/g, " ");
+    return `<span class="bucket-prefix">custom</span><span class="bucket-main">${esc(model)}</span>`;
+  }
+  return esc(bucket);
+}
+
+function barRow(r: BarRow, max: number, labelFormatter?: (label: string) => string): string {
+  const label = labelFormatter ? labelFormatter(r.label) : esc(r.label);
+  return `<div class="row" title="${esc(r.label)}"><span class="row-label">${label}</span><div class="row-bar"><div class="bar" style="width:${Math.max(3, Math.round((r.users / max) * 100))}%"></div></div><span class="n">${r.users}</span></div>`;
+}
+
+function listBars(rows: BarRow[], options: BarListOptions = {}): string {
+  if (!rows.length) return `<div class="empty">${i18n("No data in this window", "当前时间窗口暂无数据")}</div>`;
   const max = Math.max(1, ...rows.map((r) => r.users));
-  return rows
-    .map(
-      (r) =>
-        `<div class="row"><span>${esc(r.label)}</span><div><div class="bar" style="width:${Math.max(3, Math.round((r.users / max) * 100))}%"></div></div><span class="n">${r.users}</span></div>`,
-    )
-    .join("");
+  const limit = options.limit ?? 5;
+  const visible = limit > 0 ? rows.slice(0, limit) : rows;
+  const hidden = limit > 0 ? rows.slice(limit) : [];
+  const className = options.className ? ` ${esc(options.className)}` : "";
+  const visibleRows = visible.map((r) => barRow(r, max, options.labelFormatter)).join("");
+  if (!hidden.length) return `<div class="bars-list${className}">${visibleRows}</div>`;
+  return `<div class="bars-list${className}">${visibleRows}<details class="bars-more"><summary>${i18nHTML(`More ${hidden.length}`, `更多 ${hidden.length}`)}</summary><div class="bars-more-list">${hidden
+    .map((r) => barRow(r, max, options.labelFormatter))
+    .join("")}</div></details></div>`;
+}
+
+function labelizeBucket(bucket: string): string {
+  return bucket.replace(/^n_/, "").replace(/_/g, " ");
+}
+
+function sumMetric(rows: MetricRow[], signal: string): number {
+  return rows.filter((r) => r.signal === signal).reduce((sum, r) => sum + r.total, 0);
+}
+
+function topMetricBucket(rows: MetricRow[], signal: string): string {
+  const row = rows.filter((r) => r.signal === signal).sort((a, b) => b.total - a.total)[0];
+  return row ? `${labelizeBucket(row.bucket)} · ${row.total}` : "none";
+}
+
+function cacheHitRate(rows: MetricRow[]): number | null {
+  const cacheRows = rows.filter((r) => r.signal === "cache_hit");
+  const total = cacheRows.reduce((sum, r) => sum + r.total, 0);
+  if (!total) return null;
+  const weighted = cacheRows.reduce((sum, r) => {
+    const m = r.bucket.match(/^(\d+)_(\d+)$/);
+    const midpoint = m ? (Number(m[1]) + Number(m[2])) / 2 : 0;
+    return sum + midpoint * r.total;
+  }, 0);
+  return weighted / total;
+}
+
+function pct(n: number | null): string {
+  if (n === null || !Number.isFinite(n)) return "n/a";
+  return `${Math.round(n)}%`;
+}
+
+function ratioPer100(rows: MetricRow[], signal: string): number | null {
+  const turns = sumMetric(rows, "turns");
+  if (!turns) return null;
+  return (sumMetric(rows, signal) / turns) * 100;
+}
+
+function deltaLabel(current: number | null, previous: number | null, suffix = ""): string {
+  if (current === null || previous === null) return "new";
+  const delta = current - previous;
+  if (Math.abs(delta) < 0.05) return "flat";
+  const sign = delta > 0 ? "+" : "";
+  const rounded = Math.abs(delta) >= 10 ? Math.round(delta) : Number(delta.toFixed(1));
+  return `${sign}${rounded}${suffix}`;
 }
 
 const METRIC_SIGNAL_LABELS: Record<string, { en: string; zh: string }> = {
@@ -131,6 +206,7 @@ const METRIC_SIGNAL_LABELS: Record<string, { en: string; zh: string }> = {
 };
 
 const AGENT_METRIC_SIGNALS = ["finish_reason", "empty_final", "provider_error", "cache_hit", "tool_error", "compaction", "turns"];
+const DEFAULT_OPEN_SETTING_GROUPS = new Set(["Client", "Models", "Providers"]);
 
 const SETTINGS_METRIC_GROUPS: { en: string; zh: string; signals: string[] }[] = [
   {
@@ -208,10 +284,17 @@ function metricsBySignal(rows: MetricRow[]): Map<string, { label: string; users:
   return bySignal;
 }
 
-function metricBlocks(bySignal: Map<string, { label: string; users: number }[]>, signals: string[]): string {
+function metricBlocks(bySignal: Map<string, BarRow[]>, signals: string[], options: { barLimit?: number } = {}): string {
   return signals
     .filter((signal) => bySignal.has(signal))
-    .map((signal) => `<div class="metric-block"><h3>${metricSignalLabel(signal)}</h3>${listBars(bySignal.get(signal) ?? [])}</div>`)
+    .map((signal) => {
+      const rows = bySignal.get(signal) ?? [];
+      return `<div class="metric-block"><h3>${metricSignalLabel(signal)}<span>${rows.length}</span></h3>${listBars(rows, {
+        limit: options.barLimit ?? 5,
+        className: "metric-bars",
+        labelFormatter: (label) => bucketDisplayLabel(signal, label),
+      })}</div>`;
+    })
     .join("");
 }
 
@@ -220,20 +303,93 @@ function metricsCards(rows: MetricRow[], signals = AGENT_METRIC_SIGNALS): string
     return `<div class="empty">${i18n("No metrics yet — flows in once an opt-in build ships", "暂无运行指标 — 等 opt-in 版本发布后有数据")}</div>`;
   const bySignal = metricsBySignal(rows);
   const blocks = metricBlocks(bySignal, signals);
-  return blocks ? `<div class="metrics">${blocks}</div>` : `<div class="empty">${i18n("No data in the last 7 days", "近 7 天暂无数据")}</div>`;
+  return blocks ? `<div class="metrics">${blocks}</div>` : `<div class="empty">${i18n("No data in this window", "当前时间窗口暂无数据")}</div>`;
 }
 
-function settingsDashboard(rows: MetricRow[]): string {
+function settingsDashboard(rows: MetricRow[], options: { collapseSections?: boolean } = {}): string {
   const bySignal = metricsBySignal(rows);
   const sections = SETTINGS_METRIC_GROUPS.map((group) => {
+    const availableSignals = group.signals.filter((signal) => bySignal.has(signal));
     const blocks = metricBlocks(bySignal, group.signals);
     if (!blocks) return "";
-    return `<section class="pref-section"><h3>${i18n(group.en, group.zh)}</h3><div class="metrics pref-metrics">${blocks}</div></section>`;
+    const heading = `<h3>${i18n(group.en, group.zh)}<span>${i18nHTML(`${availableSignals.length} metrics`, `${availableSignals.length} 项指标`)}</span></h3>`;
+    if (options.collapseSections && !DEFAULT_OPEN_SETTING_GROUPS.has(group.en)) {
+      return `<details class="pref-section pref-section-collapsed"><summary>${heading}</summary><div class="metrics pref-metrics">${blocks}</div></details>`;
+    }
+    return `<section class="pref-section">${heading}<div class="metrics pref-metrics">${blocks}</div></section>`;
   })
     .filter(Boolean)
     .join("");
   if (!sections) return `<div class="empty">${i18n("No settings preference metrics yet", "暂无设置偏好指标")}</div>`;
   return `<div class="preference-dashboard">${sections}</div>`;
+}
+
+function healthLevel(kind: "cache" | "rate", value: number | null): "good" | "warn" | "bad" | "unknown" {
+  if (value === null) return "unknown";
+  if (kind === "cache") {
+    if (value >= 80) return "good";
+    if (value >= 50) return "warn";
+    return "bad";
+  }
+  if (value <= 1) return "good";
+  if (value <= 5) return "warn";
+  return "bad";
+}
+
+function levelText(level: "good" | "warn" | "bad" | "unknown"): string {
+  if (level === "good") return i18n("Good", "健康");
+  if (level === "warn") return i18n("Watch", "关注");
+  if (level === "bad") return i18n("Risk", "风险");
+  return i18n("No data", "暂无数据");
+}
+
+function healthCard(
+  label: { en: string; zh: string },
+  value: string,
+  level: "good" | "warn" | "bad" | "unknown",
+  deltaHTML: string,
+  detailHTML: string,
+): string {
+  return `<div class="health-card ${level}"><div class="health-top"><span>${i18n(label.en, label.zh)}</span><b>${levelText(level)}</b></div>
+<strong>${esc(value)}</strong><small>${deltaHTML}</small><p>${detailHTML}</p></div>`;
+}
+
+function healthDeltaHTML(value: string): string {
+  return i18nHTML(`${esc(value)} vs previous window`, `${esc(value)} 较上一窗口`);
+}
+
+function healthDetailHTML(rows: MetricRow[], signal: string): string {
+  return i18nHTML(`${esc(topMetricBucket(rows, signal))} top bucket`, `主要分桶：${esc(topMetricBucket(rows, signal))}`);
+}
+
+function agentHealth(rows: MetricRow[], previousRows: MetricRow[]): string {
+  if (!rows.length) return `<div class="empty">${i18n("No agent health metrics yet", "暂无运行健康指标")}</div>`;
+  const cache = cacheHitRate(rows);
+  const prevCache = cacheHitRate(previousRows);
+  const rateCard = (signal: string, en: string, zh: string) => {
+    const value = ratioPer100(rows, signal);
+    const prev = ratioPer100(previousRows, signal);
+    return healthCard(
+      { en, zh },
+      value === null ? "n/a" : `${Number(value.toFixed(value < 10 ? 1 : 0))}/100`,
+      healthLevel("rate", value),
+      healthDeltaHTML(deltaLabel(value, prev, "/100")),
+      healthDetailHTML(rows, signal),
+    );
+  };
+  return `<div class="health-grid">
+${healthCard(
+  { en: "Cache hit rate", zh: "缓存命中率" },
+  pct(cache),
+  healthLevel("cache", cache),
+  healthDeltaHTML(deltaLabel(cache, prevCache, "pp")),
+  healthDetailHTML(rows, "cache_hit"),
+)}
+${rateCard("provider_error", "Provider errors", "Provider 错误")}
+${rateCard("tool_error", "Tool errors", "工具错误")}
+${rateCard("empty_final", "Empty final guard", "空回复拦截")}
+${rateCard("compaction", "Compactions", "压缩")}
+</div>`;
 }
 
 function statusPill(status: string): string {
@@ -269,26 +425,52 @@ function filterTab(label: string, zhLabel: string, href: string, active: boolean
   return `<a class="filter-tab${active ? " active" : ""}" href="${esc(href)}">${i18n(label, zhLabel)}</a>`;
 }
 
-function facetChips(rows: { label: string; users: number }[], active: string, hrefFor: (label: string) => string): string {
-  if (!rows.length) return `<span class="filter-empty">${i18n("none", "暂无")}</span>`;
-  return rows
-    .map((r) => {
-      const label = r.label || "legacy";
-      return `<a class="facet-chip${active === r.label ? " active" : ""}" href="${esc(hrefFor(r.label))}" title="${esc(label)}"><span class="facet-label">${esc(label)}</span><b>${r.users}</b></a>`;
-    })
-    .join("");
+function facetChip(row: { label: string; users: number }, active: string, hrefFor: (label: string) => string): string {
+  const label = row.label || "legacy";
+  return `<a class="facet-chip${active === row.label ? " active" : ""}" href="${esc(hrefFor(row.label))}" title="${esc(label)}"><span class="facet-label">${esc(label)}</span><b>${row.users}</b></a>`;
 }
 
-function reportGroups(rows: CrashRow[]): string {
+function facetChips(rows: { label: string; users: number }[], active: string, hrefFor: (label: string) => string, limit = 5): string {
+  if (!rows.length) return `<span class="filter-empty">${i18n("none", "暂无")}</span>`;
+  const visible = rows.slice(0, limit);
+  const activeRow = active ? rows.find((r) => r.label === active) : undefined;
+  if (activeRow && !visible.some((r) => r.label === activeRow.label)) visible.push(activeRow);
+  const visibleKeys = new Set(visible.map((r) => r.label));
+  const hidden = rows.filter((r) => !visibleKeys.has(r.label));
+  const chips = visible.map((r) => facetChip(r, active, hrefFor)).join("");
+  if (!hidden.length) return chips;
+  return `${chips}<details class="facet-more"><summary>${i18nHTML(`More ${hidden.length}`, `更多 ${hidden.length}`)}</summary><div class="facet-more-list">${hidden
+    .map((r) => facetChip(r, active, hrefFor))
+    .join("")}</div></details>`;
+}
+
+function statCard(label: { en: string; zh: string }, value: string, note: string, href: string, tone = ""): string {
+  return `<a class="overview-card ${tone}" href="${esc(href)}"><span>${i18n(label.en, label.zh)}</span><strong>${esc(value)}</strong><small>${note}</small></a>`;
+}
+
+function latestVersionShare(adoptionPct: number | null): string {
+  return adoptionPct === null ? "n/a" : `${Math.round(adoptionPct)}%`;
+}
+
+function topSeverityTone(openReports: number, regressedReports: number, criticalOpenReports: number): string {
+  if (criticalOpenReports || regressedReports) return "bad";
+  if (openReports) return "warn";
+  return "good";
+}
+
+function moduleLink(href: string, label: { en: string; zh: string }, value: string, note: { en: string; zh: string }): string {
+  return `<a class="module-link" href="${esc(href)}"><span>${i18n(label.en, label.zh)}</span><b>${esc(value)}</b><small>${i18n(note.en, note.zh)}</small></a>`;
+}
+
+function reportGroups(rows: CrashRow[], compact = false): string {
   if (!rows.length) return `<div class="empty">${i18n("No diagnostic reports yet — that's the good kind of empty", "还没有诊断报告，这是好消息")}</div>`;
-  return `<div class="crash-list"><div class="crash-head"><span>${i18n("fingerprint", "指纹")}</span><span>${i18n("summary", "摘要")}</span><span>${i18n("scope", "范围")}</span><span>${i18n("health", "状态")}</span><span>${i18n("count", "次数")}</span></div>${rows
+  return `<div class="crash-list${compact ? " compact" : ""}"><div class="crash-head"><span>${i18n("summary", "摘要")}</span><span>${i18n("scope", "范围")}</span><span>${i18n("health", "状态")}</span><span>${i18n("count", "次数")}</span></div>${rows
     .map((c) => {
       const platform = [c.last_os, c.last_arch].filter(Boolean).join("/");
       const versions = `${c.first_version || "?"} → ${c.last_version || "?"}`;
       const title = c.title || c.error_type || c.top_frame || c.fingerprint;
       return `<a class="crash-item" href="/stats/group/${esc(c.fingerprint)}" title="${esc(title)}">
-<span class="crash-fingerprint"><b>${esc(c.fingerprint.slice(0, 8))}</b><small>${esc(c.seen)}</small></span>
-<span class="crash-summary"><span>${c.title ? esc(clip(c.title, 112)) : `<span class="muted">${i18n("No summary captured", "暂无摘要")}</span>`}</span>${
+<span class="crash-summary"><span>${c.title ? esc(clip(c.title, compact ? 88 : 120)) : `<span class="muted">${i18n("No summary captured", "暂无摘要")}</span>`}</span><small>${esc(c.fingerprint.slice(0, 8))} · ${esc(c.seen)}</small>${
         c.regressed_at ? `<em>${i18nHTML(`regressed ${esc(c.regressed_at.slice(0, 10))}`, `回归 ${esc(c.regressed_at.slice(0, 10))}`)}</em>` : ""
       }</span>
 <span class="crash-scope"><small>${esc(c.source || "legacy")}</small><small>${esc(versions)}</small><small>${platform ? esc(platform) : "unknown platform"}</small></span>
@@ -306,19 +488,38 @@ export function renderStats(
     platforms: { label: string; users: number }[];
     crashes: CrashRow[];
     metrics: MetricRow[];
+    previousMetrics: MetricRow[];
     metricUsers: MetricRow[];
     sources: { label: string; users: number }[];
+    overview: OverviewCounts;
     latestVersion: string;
-    filters: { status: string; source: string; version: string; os: string; platform: string; newLatest: boolean; regressed: boolean };
+    filters: {
+      status: string;
+      source: string;
+      version: string;
+      os: string;
+      platform: string;
+      newLatest: boolean;
+      regressed: boolean;
+      windowDays: 7 | 30;
+      preferenceMode: "users" | "opens";
+    };
   },
   user: User,
 ): string {
-  const days = last30Days(data.daily);
+  const days = lastDays(data.daily, data.filters.windowDays);
+  const range = data.filters.windowDays;
+  const rangeText = `${range}d`;
   const totalUsers = days.at(-1)?.users ?? 0;
   const anyPing = days.some((d) => d.opens > 0);
   const agentMetrics = data.metrics.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
+  const previousAgentMetrics = data.previousMetrics.filter((r) => AGENT_METRIC_SIGNALS.includes(r.signal));
   const settingsMetrics = data.metrics.filter((r) => r.signal === "client_surface" || r.signal === "client_version" || r.signal.startsWith("settings_"));
   const settingsMetricUsers = data.metricUsers.filter((r) => r.signal === "client_surface" || r.signal === "client_version" || r.signal.startsWith("settings_"));
+  const cache = cacheHitRate(agentMetrics);
+  const providerRate = ratioPer100(agentMetrics, "provider_error");
+  const toolRate = ratioPer100(agentMetrics, "tool_error");
+  const healthWatchCount = [healthLevel("cache", cache), healthLevel("rate", providerRate), healthLevel("rate", toolRate)].filter((v) => v === "warn" || v === "bad").length;
   const filterQS = (patch: Record<string, string>) => {
     const params = new URLSearchParams();
     const put = (k: string, v: string) => {
@@ -331,6 +532,8 @@ export function renderStats(
     put("platform", data.filters.platform);
     if (data.filters.newLatest) params.set("new", "latest");
     if (data.filters.regressed) params.set("regressed", "1");
+    if (data.filters.windowDays === 30) params.set("window", "30d");
+    if (data.filters.preferenceMode === "opens") params.set("prefs", "opens");
     for (const [k, v] of Object.entries(patch)) {
       if (v) params.set(k, v);
       else params.delete(k);
@@ -338,12 +541,36 @@ export function renderStats(
     const qs = params.toString();
     return qs ? `/stats?${qs}` : "/stats";
   };
+  const clearFiltersHref = filterQS({ status: "", source: "", version: "", os: "", platform: "", new: "", regressed: "" });
   const hasFilters = Boolean(
     data.filters.status || data.filters.source || data.filters.version || data.filters.os || data.filters.platform || data.filters.newLatest || data.filters.regressed,
   );
-  const filters = `<div class="card full filter-card"><div class="filter-head"><h2>${i18n("Report filters", "诊断筛选")}</h2><span>${i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`)}</span></div>
+  const windowControls = `<div class="segmented" aria-label="Time window">
+<a class="${range === 7 ? "active" : ""}" href="${esc(filterQS({ window: "7d" }))}">7d</a>
+<a class="${range === 30 ? "active" : ""}" href="${esc(filterQS({ window: "30d" }))}">30d</a>
+</div>`;
+  const preferenceControls = `<div class="segmented" aria-label="Preference metric mode">
+<a class="${data.filters.preferenceMode === "users" ? "active" : ""}" href="${esc(filterQS({ prefs: "" }))}">${i18n("Installs", "按安装")}</a>
+<a class="${data.filters.preferenceMode === "opens" ? "active" : ""}" href="${esc(filterQS({ prefs: "opens" }))}">${i18n("Opens", "按启动")}</a>
+</div>`;
+  const overviewTone = topSeverityTone(data.overview.openReports, data.overview.regressedReports, data.overview.criticalOpenReports);
+  const overview = `<section class="overview-grid">
+${statCard({ en: "Active today", zh: "今日活跃" }, String(totalUsers), i18n("anonymous installs", "匿名安装"), "#usage")}
+${statCard({ en: "Latest adoption", zh: "最新版本占比" }, latestVersionShare(data.overview.latestAdoptionPct), i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`), "#usage")}
+${statCard({ en: "Open reports", zh: "未处理报告" }, String(data.overview.openReports), i18n("needs triage", "需要分诊"), "#diagnostics", overviewTone)}
+${statCard({ en: "New in latest", zh: "最新新增" }, String(data.overview.newLatestReports), i18n("first seen on latest", "首次出现在最新版"), "#diagnostics", data.overview.newLatestReports ? "warn" : "good")}
+${statCard({ en: "Regressions", zh: "回归问题" }, String(data.overview.regressedReports), i18n("previously resolved", "曾经解决后复现"), "#diagnostics", data.overview.regressedReports ? "bad" : "good")}
+${statCard({ en: "Agent health", zh: "运行健康" }, healthWatchCount ? String(healthWatchCount) : "OK", i18nHTML(`${pct(cache)} cache · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 provider`, `${pct(cache)} 缓存 · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 Provider`), "#health", healthWatchCount ? "warn" : "good")}
+</section>`;
+  const modules = `<nav class="module-nav" aria-label="Stats modules">
+${moduleLink("#diagnostics", { en: "Diagnostics", zh: "诊断分诊" }, String(data.crashes.length), { en: "prioritized report groups", zh: "按优先级排列的报告分组" })}
+${moduleLink("#usage", { en: "Usage", zh: "使用分布" }, rangeText, { en: "activity, versions, platforms", zh: "活跃、版本和平台" })}
+${moduleLink("#preferences", { en: "Preferences", zh: "设置偏好" }, data.filters.preferenceMode === "opens" ? "opens" : "installs", { en: "deduped and launch snapshots", zh: "安装去重与启动快照" })}
+${moduleLink("#health", { en: "Agent Health", zh: "运行健康" }, healthWatchCount ? String(healthWatchCount) : "OK", { en: "cache and error signals", zh: "缓存与错误信号" })}
+</nav>`;
+  const filters = `<div class="filter-card"><div class="filter-head"><h2>${i18n("Report filters", "诊断筛选")}</h2><span>${i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`)}</span></div>
 <div class="filter-tabs">
-${filterTab("All", "全部", "/stats", !hasFilters)}
+${filterTab("All", "全部", clearFiltersHref, !hasFilters)}
 ${filterTab("Open", "未处理", filterQS({ status: "open" }), data.filters.status === "open")}
 ${filterTab("Resolved", "已解决", filterQS({ status: "resolved" }), data.filters.status === "resolved")}
 ${filterTab("Ignored", "已忽略", filterQS({ status: "ignored" }), data.filters.status === "ignored")}
@@ -351,28 +578,46 @@ ${filterTab("New in latest", "最新新增", filterQS({ new: data.filters.newLat
 ${filterTab("Regressed", "回归", filterQS({ regressed: data.filters.regressed ? "" : "1" }), data.filters.regressed)}
 </div>
 <div class="facet-grid">
-<section><h3>${i18n("Source", "来源")}</h3><div class="facet-list">${facetChips(data.sources, data.filters.source, (label) => filterQS({ source: label }))}</div></section>
-<section><h3>${i18n("Version", "版本")}</h3><div class="facet-list">${facetChips(data.versions.slice(0, 8), data.filters.version, (label) => filterQS({ version: label }))}</div></section>
-<section><h3>${i18n("Platform", "平台")}</h3><div class="facet-list">${facetChips(data.platforms, data.filters.platform, (label) => filterQS({ platform: label }))}</div></section>
+<section><h3>${i18n("Source", "来源")}</h3><div class="facet-list">${facetChips(data.sources, data.filters.source, (label) => filterQS({ source: label }), 4)}</div></section>
+<section><h3>${i18n("Version", "版本")}</h3><div class="facet-list">${facetChips(data.versions, data.filters.version, (label) => filterQS({ version: label }), 5)}</div></section>
+<section><h3>${i18n("Platform", "平台")}</h3><div class="facet-list">${facetChips(data.platforms, data.filters.platform, (label) => filterQS({ platform: label }), 4)}</div></section>
 </div></div>`;
+  const usageModule = `<section id="usage" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Usage distribution", "使用分布")}</h2></div>${windowControls}</div>
+<div class="module-panel wide"><h3>${i18nHTML(`Daily active installs <b>— ${rangeText}</b> (solid: users, faded: opens)`, `每日活跃 <b>— ${rangeText}</b>（实线：用户，淡色：打开次数）`)}</h3>
+${anyPing ? dailyChart(days) : `<div class="empty">${i18n("No pings yet — data starts flowing once a telemetry-enabled build ships", "暂无启动 ping — 等带统计的版本发布后这里开始有数据")}</div>`}</div>
+<div class="module-split">
+<section class="module-panel"><h3>${i18nHTML(`Versions <b>— ${rangeText}</b>`, `版本分布 <b>— ${rangeText}</b>`)}</h3>${listBars(data.versions)}</section>
+<section class="module-panel"><h3>${i18nHTML(`Platforms <b>— ${rangeText}</b>`, `平台分布 <b>— ${rangeText}</b>`)}</h3>${listBars(data.platforms)}</section>
+</div></section>`;
+  const diagnosticsModule = `<section id="diagnostics" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Diagnostic triage", "诊断分诊")}</h2></div><a class="module-action" href="#top">${i18n("Back to overview", "回到概览")}</a></div>
+<section class="module-panel"><h3>${i18nHTML("Needs attention <b>— top 10 prioritized diagnostics</b>", "优先处理 <b>— 最需要看的 10 条诊断</b>")}</h3>${reportGroups(data.crashes.slice(0, 10), true)}</section>
+${filters}
+<section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes)}</section>
+</section>`;
+  const preferencesModule = `<section id="preferences" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Settings preferences", "设置偏好")}</h2></div>${preferenceControls}</div>
+<div class="module-split wide">
+<section class="module-panel"><h3>${i18nHTML(`Deduplicated installs <b>— ${rangeText}</b>`, `按安装去重 <b>— ${rangeText}</b>`)}</h3>${settingsDashboard(settingsMetricUsers, { collapseSections: true })}</section>
+<section class="module-panel"><h3>${i18nHTML(`Launch/open snapshots <b>— ${rangeText}</b>`, `启动/开启快照 <b>— ${rangeText}</b>`)}</h3>${settingsDashboard(settingsMetrics, { collapseSections: true })}</section>
+</div></section>`;
+  const healthModule = `<section id="health" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Agent health", "运行健康")}</h2></div><a class="module-action" href="#preferences">${i18n("Preferences", "设置偏好")}</a></div>
+<section class="module-panel"><h3>${i18nHTML(`Health summary <b>— ${rangeText}, compared with previous window</b>`, `健康摘要 <b>— ${rangeText}，对比上一窗口</b>`)}</h3>${agentHealth(agentMetrics, previousAgentMetrics)}</section>
+<section class="module-panel"><h3>${i18nHTML(`Signal distributions <b>— ${rangeText}, opt-in aggregate</b>`, `信号分布 <b>— ${rangeText}，opt-in 汇总</b>`)}</h3>${metricsCards(agentMetrics)}</section>
+</section>`;
 
   return page(
-    "Reasonix · Stats",
-    "stats",
-    `<h1>${i18n("Desktop stats", "桌面端统计")}</h1><p class="sub">${i18nHTML(
-      `Today: <b>${totalUsers}</b> active installs · anonymous launch pings and user-sent diagnostic reports only`,
-      `今日：<b>${totalUsers}</b> 个活跃安装 · 仅包含匿名启动 ping 和用户发送的诊断报告`,
-    )}</p>
+    "Reasonix · Crash & Telemetry",
+    "health",
+    `<div id="top" class="hero-line"><div><h1>${i18n("Crash & Telemetry", "桌面端健康看板")}</h1><p class="sub">${i18nHTML(
+      `${rangeText} window · anonymous launch pings, opt-in aggregate metrics, and user-sent diagnostic reports only`,
+      `${rangeText} 时间窗口 · 仅包含匿名启动 ping、opt-in 汇总指标和用户发送的诊断报告`,
+    )}</p></div>${windowControls}</div>
+${overview}
+${modules}
 <div class="grid">
-<div class="card full"><h2>${i18nHTML("Daily active installs <b>— 30 days</b> (solid: users, faded: opens)", "每日活跃 <b>— 30 天</b>（实线：用户，淡色：打开次数）")}</h2>
-${anyPing ? dailyChart(days) : `<div class="empty">${i18n("No pings yet — data starts flowing once a telemetry-enabled build ships", "暂无启动 ping — 等带统计的版本发布后这里开始有数据")}</div>`}</div>
-<div class="card"><h2>${i18nHTML("Versions <b>— 7 days</b>", "版本分布 <b>— 7 天</b>")}</h2>${listBars(data.versions)}</div>
-<div class="card"><h2>${i18nHTML("Platforms <b>— 7 days</b>", "平台分布 <b>— 7 天</b>")}</h2>${listBars(data.platforms)}</div>
-<div class="card full"><h2>${i18nHTML("Settings preference DAU <b>— 7 days, deduplicated by install</b>", "设置偏好 DAU <b>— 7 天，按安装去重</b>")}</h2>${settingsDashboard(settingsMetricUsers)}</div>
-<div class="card full"><h2>${i18nHTML("Settings preference snapshots <b>— 7 days, launch/open counts</b>", "设置偏好快照 <b>— 7 天，启动/开启次数</b>")}</h2>${settingsDashboard(settingsMetrics)}</div>
-<div class="card full"><h2>${i18nHTML("Agent signals <b>— 7 days, opt-in aggregate</b>", "运行指标 <b>— 7 天，opt-in 汇总</b>")}</h2>${metricsCards(agentMetrics)}</div>
-${filters}
-<div class="card full crash-card"><h2>${i18nHTML("Report groups <b>— select a row for stack samples</b>", "诊断分组 <b>— 选择一行查看堆栈样本</b>")}</h2>${reportGroups(data.crashes)}</div>
+${diagnosticsModule}
+${usageModule}
+${preferencesModule}
+${healthModule}
 </div>`,
     userNav(user),
   );
@@ -461,27 +706,24 @@ function breadcrumbsList(json: string): string {
   }
 }
 
-function sampleReports(reports: ReportSample[]): string {
-  if (!reports.length) return `<div class="empty">${i18n("No raw samples stored for this group", "这个分组没有保存原始样本")}</div>`;
-  return `<div class="sample-list">${reports
-    .map((r, i) => {
-      const dev = fmtDevice(r.device);
-      const platform = [r.os, r.arch].filter(Boolean).join("/");
-      const title = r.error_message || r.message.split("\n").find((line) => line.trim()) || r.error_type || "sample";
-      const structured = [
-        r.source && [i18n("source", "来源"), r.source],
-        r.label && [i18n("label", "标签"), r.label],
-        r.error_type && [i18n("type", "类型"), r.error_type],
-        r.top_frame && [i18n("top", "顶层"), r.top_frame],
-        r.build_commit && [i18n("build", "构建"), r.build_commit],
-        r.channel && [i18n("channel", "渠道"), r.channel],
-        r.view && [i18n("view", "视图"), r.view],
-      ]
-        .filter(Boolean)
-        .map(([label, value]) => `<span><b>${label}</b>${esc(value)}</span>`)
-        .join("");
-      const stack = r.stack || r.component_stack;
-      return `<details class="sample" ${i === 0 ? "open" : ""}><summary>
+function sampleReport(r: ReportSample, i: number): string {
+  const dev = fmtDevice(r.device);
+  const platform = [r.os, r.arch].filter(Boolean).join("/");
+  const title = r.error_message || r.message.split("\n").find((line) => line.trim()) || r.error_type || "sample";
+  const structured = [
+    r.source && [i18n("source", "来源"), r.source],
+    r.label && [i18n("label", "标签"), r.label],
+    r.error_type && [i18n("type", "类型"), r.error_type],
+    r.top_frame && [i18n("top", "顶层"), r.top_frame],
+    r.build_commit && [i18n("build", "构建"), r.build_commit],
+    r.channel && [i18n("channel", "渠道"), r.channel],
+    r.view && [i18n("view", "视图"), r.view],
+  ]
+    .filter(Boolean)
+    .map(([label, value]) => `<span><b>${label}</b>${esc(value)}</span>`)
+    .join("");
+  const stack = r.stack || r.component_stack;
+  return `<details class="sample" ${i === 0 ? "open" : ""}><summary>
 <span class="sample-id"><b>${esc(r.version)}</b><small>${esc(platform || "unknown platform")}</small></span>
 <span class="sample-title">${esc(clip(title, 110))}</span>
 <span class="sample-time">${esc((r.occurred_at || r.created_at).slice(0, 19).replace("T", " "))}</span>
@@ -489,16 +731,28 @@ function sampleReports(reports: ReportSample[]): string {
 <div class="sample-body">
 <div class="sample-meta">${dev ? `<span><b>${i18n("device", "设备")}</b>${esc(dev)}</span>` : ""}${structured}</div>
 <div class="sample-actions"><button class="btn ghost sm copy-btn" type="button" data-copy="${esc(r.message)}"><span class="copy-label">${i18n("Copy message", "复制消息")}</span></button>${
-        stack
-          ? `<button class="btn ghost sm copy-btn" type="button" data-copy="${esc(stack)}"><span class="copy-label">${i18n("Copy stack", "复制堆栈")}</span></button>`
-          : ""
-      }</div>
+    stack
+      ? `<button class="btn ghost sm copy-btn" type="button" data-copy="${esc(stack)}"><span class="copy-label">${i18n("Copy stack", "复制堆栈")}</span></button>`
+      : ""
+  }</div>
 <pre>${esc(r.message)}</pre>
 ${stack ? `<details class="sample-nested"><summary>${i18n("stack", "堆栈")}</summary><pre>${esc(stack)}</pre></details>` : ""}
 ${breadcrumbsList(r.breadcrumbs)}
 </div></details>`;
-    })
-    .join("")}</div>`;
+}
+
+function sampleReports(reports: ReportSample[], options: { limit?: number } = {}): string {
+  if (!reports.length) return `<div class="empty">${i18n("No raw samples stored for this group", "这个分组没有保存原始样本")}</div>`;
+  const limit = options.limit ?? 10;
+  const visible = reports.slice(0, limit);
+  const hidden = reports.slice(limit);
+  const visibleSamples = visible.map((r, i) => sampleReport(r, i)).join("");
+  const hiddenSamples = hidden.map((r, i) => sampleReport(r, i + limit)).join("");
+  const history =
+    hidden.length > 0
+      ? `<details class="sample-more"><summary>${i18nHTML(`Historical samples ${hidden.length}`, `历史样本 ${hidden.length}`)}</summary><div class="sample-more-list">${hiddenSamples}</div></details>`
+      : "";
+  return `<div class="sample-list">${visibleSamples}${history}</div>`;
 }
 
 export function renderGroup(


### PR DESCRIPTION
## Summary
- Reorganize the crash stats page into overview, diagnostics, usage, preferences, and agent health modules.
- Add 7d/30d window controls, prioritized diagnostics, and top-level health/adoption cards.
- Cap long-tail filter chips, bar distributions, settings groups, agent signals, and group samples with expandable overflow sections.

## Validation
- `npm --prefix workers/crash-report run typecheck`
- `git diff --check origin/main-v2...HEAD`
- Browser-verified local stats and group pages for expandable long-tail lists, language labels, sample history, and mobile overflow behavior.
