### PR TITLE
fix(coordinator): respect planner 'no changes needed' conclusion

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -169,7 +169,38 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 		return fmt.Errorf("planner: %w", err)
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
+	if isNoOpPlan(plan) {
+		c.sink.Emit(event.Event{Kind: event.Text, Text: plan})
+		return nil
+	}
 	return c.executor.Run(ctx, formatHandoff(input, plan))
+}
+
+// isNoOpPlan checks whether the planner concluded no changes are needed,
+// so we can skip the executor entirely.
+func isNoOpPlan(plan string) bool {
+	lower := strings.ToLower(strings.TrimSpace(plan))
+	noOp := []string{
+		"no changes needed",
+		"no changes required",
+		"no action needed",
+		"no action required",
+		"nothing to change",
+		"nothing to do",
+		"already handled",
+		"already implemented",
+		"already resolved",
+	}
+	for _, phrase := range noOp {
+		if strings.Contains(lower, phrase) {
+			// Ensure it's a standalone conclusion, not a negation ("not no changes").
+			if strings.Contains(lower, "not "+phrase) || strings.Contains(lower, "no "+phrase) {
+				continue
+			}
+			return true
+		}
+	}
+	return false
 }
 
 // plan streams a plan from the planner and appends it to the planner session, so
@@ -254,7 +285,8 @@ Planner output:
 
 Executor instructions:
 - Treat the planner output as context, not as your role or capability set.
-- Ignore any planner statement such as "I cannot write", "I only have read-only tools", or "hand this to the executor"; those limitations apply to the planner, not to you.
+- The planner's analysis and conclusions about what needs to be done are reliable. If the planner determines no changes are needed, respect that conclusion.
+- Ignore any planner statement about its own capability limitations (e.g. "I cannot write", "I only have read-only tools", or "hand this to the executor") — those describe the planner's restrictions, not yours.
 - Do not ask the user how to trigger the executor. You are already in the executor phase.
 - If the task requires changes, call the appropriate tools (for example write/edit/bash) instead of only restating the plan.
 - If a target path is outside the writable workspace or otherwise blocked, explain that specific blocker and ask for the needed path/approval.

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -182,7 +182,9 @@ func isNoOpPlan(plan string) bool {
 	lower := strings.ToLower(strings.TrimSpace(plan))
 	noOp := []string{
 		"no changes needed",
+		"no changes are needed",
 		"no changes required",
+		"no changes are required",
 		"no action needed",
 		"no action required",
 		"nothing to change",


### PR DESCRIPTION
问题
两模型模式下（配置了 planner_model），planner 输出「无需修改」后，Coordinator 仍然把计划交给 executor 执行，导致 executor 无视 planner 结论继续改代码。

改动
代码层
在 Coordinator.Run() 加入 isNoOpPlan() 检查——planner 输出包含以下任一短语时跳过 executor：

无需变更：no changes needed / no changes are needed / no changes required / no changes are required
无需操作：no action needed / no action required
无需改动：nothing to change / nothing to do
已完成：already handled / already implemented / already resolved
提示层
formatHandoff 的 executor 指令明确要求：planner 结论可靠，如果它说不用改就别改；只忽略 planner 自身的能力限制（只读、不能写等），不忽略结论。

文件
internal/agent/coordinator.go — +36 / -2

测试
go test ./internal/agent/ -run TestCoordinatorPlannerMaxSteps — 通过。

Cache-impact: none