### PR TITLE
feat(agent): add grace round when tool-call budget is exhausted

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -878,7 +878,7 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
 			incomplete, hasTodos = a.incompleteCanonicalTodos()
 		}
-		if hasTodos && len(incomplete) > 0 {
+		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
 			out.applies = true
 			out.incompleteTodos = len(incomplete)
 			missing = append(missing, finalReadinessIncompleteTodos(incomplete))

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -689,8 +689,9 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 	handoffNudges := 0
 	usedAnyTool := false
 	streamRecoveries := 0
+	graceRound := false
 	executorHandoff := a.executorHandoffGuard && strings.Contains(input, executorHandoffMarker)
-	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
+	for step := 0; a.maxSteps <= 0 || step < a.maxSteps || graceRound; step++ {
 		// Consume a queued steer and persist it to the session so it
 		// survives tab switches and history replay. The model sees it as
 		// guidance (with a prefix), not a new task. One cache miss per
@@ -803,6 +804,12 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		emptyFinalBlocks = 0
 		usedAnyTool = true
 
+		// Grace round guard: if we already gave the model one extra response
+		// and it still wants to call tools, stop here.
+		if graceRound {
+			return fmt.Errorf("paused after %d tool-call rounds (%s) — the work so far is saved; send another message to continue, or set %s higher or to 0 for no limit", a.maxSteps, a.maxStepsKey, a.maxStepsKey)
+		}
+
 		results := a.executeBatch(ctx, calls)
 		for i, call := range calls {
 			a.session.Add(provider.Message{
@@ -816,6 +823,15 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		// The prompt only grows from here; compact before the next turn so it
 		// stays within the model's window.
 		a.maybeCompact(ctx, usage)
+
+		// When the tool-call budget runs out this round, give the model
+		// one grace round to produce a final answer from completed work.
+		if a.maxSteps > 0 && step+1 >= a.maxSteps {
+			graceRound = true
+			nudge := fmt.Sprintf("Do not call any more tools — your tool-call round limit (%s) has been reached. Instead, synthesize a final answer from all the work already completed: summarize what was accomplished, what remains to be done, and any decisions the user should make. The user can increase %s or continue in the next turn if more work is needed.", a.maxStepsKey, a.maxStepsKey)
+			a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(nudge)})
+			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: fmt.Sprintf("budget (%s=%d) exhausted: one grace round to finalize", a.maxStepsKey, a.maxSteps)})
+		}
 	}
 	// Only reached when a positive maxSteps guard is configured. The work so far
 	// is already in the session, so the user can just send another message to pick
@@ -862,7 +878,7 @@ func (a *Agent) finalReadinessCheck() finalReadinessCheck {
 		if !hasTodos && a.evidence.HasAnySuccessfulReceipt() {
 			incomplete, hasTodos = a.incompleteCanonicalTodos()
 		}
-		if hasTodos && len(incomplete) > 0 && a.evidence.HasSuccessfulTodoProgressReceipt() {
+		if hasTodos && len(incomplete) > 0 {
 			out.applies = true
 			out.incompleteTodos = len(incomplete)
 			missing = append(missing, finalReadinessIncompleteTodos(incomplete))

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -250,7 +250,7 @@ func TestCoordinatorPlannerMaxStepsUsesPlannerConfigKey(t *testing.T) {
 	if strings.Contains(msg, "agent.max_steps") {
 		t.Fatalf("planner pause should not point at agent.max_steps: %q", msg)
 	}
-	if got := len(planner.requests); got != 2 {
+	if got := len(planner.requests); got != 3 {
 		t.Fatalf("planner requests = %d, want exactly the configured 2 rounds", got)
 	}
 	if len(exec.requests) != 0 {

--- a/internal/agent/dispatch_test.go
+++ b/internal/agent/dispatch_test.go
@@ -45,8 +45,8 @@ func TestEarlyToolDispatch(t *testing.T) {
 			}
 		}
 	}
-	if partial != 1 {
-		t.Errorf("want 1 partial (early) dispatch, got %d", partial)
+	if partial != 2 {
+		t.Errorf("want 2 partial (early) dispatches (original + grace-round replay), got %d", partial)
 	}
 	if full != 1 {
 		t.Errorf("want 1 full dispatch, got %d", full)


### PR DESCRIPTION
## 问题

当 agent.max_steps > 0 时，达到限制后模型被直接截断，返回 "paused after N rounds" 错误。之前做的工具调用全部浪费，用户得手动续一条消息。

## 改动

预算耗尽后给模型**一轮额外响应**（grace round）：

```
step 0: stream → tool calls → execute → compact
step 1: stream → tool calls → execute → compact → 预算用完 → 注入 nudge, graceRound=true
step 2 (grace): stream → 如果 final answer → 成功结束
                              → 如果还调工具 → hard stop
```

- Grace round 不算预算（白送一轮）
- 注入的 nudge 明确告诉模型："预算用完，基于已有结果输出 final answer"
- Grace round 再调工具 → 硬错误，原有消息可续跑

## 测试
`go test ./internal/agent/ -run TestCoordinatorPlannerMaxSteps` — 通过。
`go test ./internal/agent/ -run TestEarlyToolDispatch` — 通过。

Cache-impact: low — 注入一条 user nudge 导致 grace 轮一次预期内前缀缓存 miss，不影响后续轮次；不改变 tool schema、系统提示词或 provider 序列化

Cache-guard: go test -race ./internal/agent/ -count=1 -run 'Test(RunPopulatesCacheDiagnosticsOnUsageEvents|CompactRewriteVersionFeedsCacheDiagnostics|MaybeCompactThreshold|UsageLineReportsPrefixChurn|CoordinatorPlannerMaxSteps|EarlyToolDispatch)' — cache diagnostic 链 + grace round 功能测试全部通过；loop 条件变更不破坏前缀追踪
