### PR TITLE
feat(skill): list scripts/ directory in skill body for bash execution

### DIFF
--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -52,6 +52,13 @@ const (
 	SkillFile = "SKILL.md"
 )
 
+// scriptExts lists executable extensions recognized in scripts/ directories,
+// separated by dots for fast contains-check. No-extension files (bare
+// executables like lint, deploy) pass through regardless.
+const scriptExts = ".sh.py.js.ts.rb.pl.php.ps1"
+
+
+
 // Skill is a loaded playbook.
 type Skill struct {
 	Name        string // canonical identifier; matches the directory / filename stem
@@ -660,12 +667,13 @@ func loadBodyWithScripts(skillPath, body string) string {
 	}
 	var names []string
 	for _, e := range entries {
+		// Filter hidden files — bash should not see config dotfiles in scripts/.
 		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
-		// Only list files that look like scripts: no extension, or common script ext.
+		// Only list files that look like scripts: no extension, or recognized ext.
 		ext := strings.ToLower(filepath.Ext(e.Name()))
-		if ext != "" && ext != ".sh" && ext != ".py" && ext != ".js" && ext != ".ts" && ext != ".rb" && ext != ".pl" && ext != ".php" && ext != ".ps1" {
+		if ext != "" && !strings.Contains(scriptExts, ext) {
 			continue
 		}
 		names = append(names, e.Name())
@@ -676,7 +684,7 @@ func loadBodyWithScripts(skillPath, body string) string {
 	sort.Strings(names)
 	var b strings.Builder
 	b.WriteString(body)
-	b.WriteString("\n\n## Scripts\n\nThe skill has the following scripts. Run them with bash.\n\n")
+	b.WriteString("## Scripts\n\nRun with bash.\n\n")
 	for _, n := range names {
 		b.WriteString("- `" + filepath.Join(scriptsDir, n) + "`\n")
 	}

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -52,13 +52,6 @@ const (
 	SkillFile = "SKILL.md"
 )
 
-// scriptExts lists executable extensions recognized in scripts/ directories,
-// separated by dots for fast contains-check. No-extension files (bare
-// executables like lint, deploy) pass through regardless.
-const scriptExts = ".sh.py.js.ts.rb.pl.php.ps1"
-
-
-
 // Skill is a loaded playbook.
 type Skill struct {
 	Name        string // canonical identifier; matches the directory / filename stem
@@ -671,9 +664,7 @@ func loadBodyWithScripts(skillPath, body string) string {
 		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
-		// Only list files that look like scripts: no extension, or recognized ext.
-		ext := strings.ToLower(filepath.Ext(e.Name()))
-		if ext != "" && !strings.Contains(scriptExts, ext) {
+		if !isScriptExt(filepath.Ext(e.Name())) {
 			continue
 		}
 		names = append(names, e.Name())
@@ -684,11 +675,20 @@ func loadBodyWithScripts(skillPath, body string) string {
 	sort.Strings(names)
 	var b strings.Builder
 	b.WriteString(body)
-	b.WriteString("## Scripts\n\nRun with bash.\n\n")
+	b.WriteString("\n\n## Scripts\n\nRun a listed script with bash using the exact path shown below; quote the path if it contains spaces.\n\n")
 	for _, n := range names {
 		b.WriteString("- `" + filepath.Join(scriptsDir, n) + "`\n")
 	}
 	return b.String()
+}
+
+func isScriptExt(ext string) bool {
+	switch strings.ToLower(ext) {
+	case "", ".sh", ".py", ".js", ".ts", ".rb", ".pl", ".php", ".ps1":
+		return true
+	default:
+		return false
+	}
 }
 
 // parseAllowedTools splits a comma-separated `allowed-tools` value into trimmed,

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -477,7 +477,7 @@ func (s *Store) parseSkill(path, stem string, scope Scope, requireSkillMarker bo
 	return Skill{
 		Name:         name,
 		Description:  desc,
-		Body:         loadBodyWithReferences(path, strings.TrimSpace(body)),
+		Body:         loadBodyWithScripts(path, loadBodyWithReferences(path, strings.TrimSpace(body))),
 		Scope:        scope,
 		Path:         path,
 		AllowedTools: parseAllowedTools(fm[skillFrontmatterAllowedTools]),
@@ -642,6 +642,38 @@ func loadBodyWithReferences(skillPath, body string) string {
 		}
 		slug := strings.TrimSuffix(n, filepath.Ext(n))
 		b.WriteString("\n\n## Reference: " + slug + "\n\n" + trimmed)
+	}
+	return b.String()
+}
+
+// loadBodyWithScripts appends a directory-layout skill's sibling scripts/
+// directory listing to the body, so the model knows what scripts are
+// available and can run them via bash (inheriting sandbox, gate, hooks).
+func loadBodyWithScripts(skillPath, body string) string {
+	if filepath.Base(skillPath) != SkillFile {
+		return body
+	}
+	scriptsDir := filepath.Join(filepath.Dir(skillPath), "scripts")
+	entries, err := os.ReadDir(scriptsDir)
+	if err != nil {
+		return body
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	if len(names) == 0 {
+		return body
+	}
+	sort.Strings(names)
+	var b strings.Builder
+	b.WriteString(body)
+	b.WriteString("\n\n## Scripts\n\n")
+	b.WriteString("The skill has the following scripts. Run them with bash, for example `python " + filepath.Join(scriptsDir, "<name>") + "`. Read a script with read_file before running if unsure.\n\n")
+	for _, n := range names {
+		b.WriteString("- `" + filepath.Join(scriptsDir, n) + "`\n")
 	}
 	return b.String()
 }

--- a/internal/skill/skill.go
+++ b/internal/skill/skill.go
@@ -660,9 +660,15 @@ func loadBodyWithScripts(skillPath, body string) string {
 	}
 	var names []string
 	for _, e := range entries {
-		if !e.IsDir() {
-			names = append(names, e.Name())
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+			continue
 		}
+		// Only list files that look like scripts: no extension, or common script ext.
+		ext := strings.ToLower(filepath.Ext(e.Name()))
+		if ext != "" && ext != ".sh" && ext != ".py" && ext != ".js" && ext != ".ts" && ext != ".rb" && ext != ".pl" && ext != ".php" && ext != ".ps1" {
+			continue
+		}
+		names = append(names, e.Name())
 	}
 	if len(names) == 0 {
 		return body
@@ -670,8 +676,7 @@ func loadBodyWithScripts(skillPath, body string) string {
 	sort.Strings(names)
 	var b strings.Builder
 	b.WriteString(body)
-	b.WriteString("\n\n## Scripts\n\n")
-	b.WriteString("The skill has the following scripts. Run them with bash, for example `python " + filepath.Join(scriptsDir, "<name>") + "`. Read a script with read_file before running if unsure.\n\n")
+	b.WriteString("\n\n## Scripts\n\nThe skill has the following scripts. Run them with bash.\n\n")
 	for _, n := range names {
 		b.WriteString("- `" + filepath.Join(scriptsDir, n) + "`\n")
 	}

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -372,7 +372,7 @@ func TestReferencesInlined(t *testing.T) {
 }
 
 func TestScriptsAppended(t *testing.T) {
-	home := t.TempDir()
+	home := filepath.Join(t.TempDir(), "home with spaces")
 	writeSkill(t, home, ".reasonix/skills/withscripts/SKILL.md", "---\ndescription: r\n---\nmain body")
 	writeScript(t, home, ".reasonix/skills/withscripts/scripts/lint.py", "#!/usr/bin/env python3\nprint('ok')")
 	writeScript(t, home, ".reasonix/skills/withscripts/scripts/deploy.sh", "#!/usr/bin/env bash\necho ok")
@@ -390,6 +390,37 @@ func TestScriptsAppended(t *testing.T) {
 	}
 	if !strings.Contains(sk.Body, "lint.py") || !strings.Contains(sk.Body, "deploy.sh") {
 		t.Error("script paths missing from body")
+	}
+	if !strings.Contains(sk.Body, "main body\n\n## Scripts") {
+		t.Errorf("scripts section should be separated from the original body:\n%s", sk.Body)
+	}
+	if !strings.Contains(sk.Body, "quote the path if it contains spaces") {
+		t.Error("scripts guidance should mention quoting paths with spaces")
+	}
+}
+
+func TestScriptsStayOutOfSkillIndex(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/withscripts/SKILL.md", "---\ndescription: cache-safe script skill\n---\nmain body")
+	writeScript(t, home, ".reasonix/skills/withscripts/scripts/lint.py", "#!/usr/bin/env python3\nprint('ok')")
+
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	sk, ok := st.Read("withscripts")
+	if !ok {
+		t.Fatal("skill not found")
+	}
+	if !strings.Contains(sk.Body, "## Scripts") || !strings.Contains(sk.Body, "lint.py") {
+		t.Fatal("test setup expected scripts in the on-demand skill body")
+	}
+
+	index := ApplyIndex("BASE", []Skill{sk})
+	if !strings.Contains(index, "withscripts") || !strings.Contains(index, "cache-safe script skill") {
+		t.Fatalf("skill index missing name/description:\n%s", index)
+	}
+	for _, forbidden := range []string{"## Scripts", "lint.py", filepath.Join("scripts", "lint.py")} {
+		if strings.Contains(index, forbidden) {
+			t.Fatalf("skill index should not include on-demand script listing %q:\n%s", forbidden, index)
+		}
 	}
 }
 
@@ -426,6 +457,7 @@ func TestScriptsFilteredByExt(t *testing.T) {
 	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/.hidden.py", "")
 	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/readme.md", "# readme")
 	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/deploy", "#!/bin/sh\necho ok")
+	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/legacy.p", "print 'ok'\n")
 	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/.gitkeep", "")
 
 	st := New(Options{HomeDir: home, DisableBuiltins: true})
@@ -449,6 +481,9 @@ func TestScriptsFilteredByExt(t *testing.T) {
 	// readme.md should NOT be listed (documentation, not a script)
 	if strings.Contains(body, "readme.md") {
 		t.Error("non-script extensions should NOT be listed")
+	}
+	if strings.Contains(body, "legacy.p") {
+		t.Error("partial extension matches should NOT be listed")
 	}
 	// .gitkeep should NOT be listed (hidden file)
 	if strings.Contains(body, ".gitkeep") {

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -419,6 +419,43 @@ func TestFlatSkillNoScripts(t *testing.T) {
 	}
 }
 
+func TestScriptsFilteredByExt(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/scriptscheck/SKILL.md", "---\ndescription: t\n---\nbody")
+	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/lint.py", "#!/usr/bin/env python3\nprint('ok')\n")
+	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/.hidden.py", "")
+	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/readme.md", "# readme")
+	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/deploy", "#!/bin/sh\necho ok")
+	writeScript(t, home, ".reasonix/skills/scriptscheck/scripts/.gitkeep", "")
+
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	sk, ok := st.Read("scriptscheck")
+	if !ok {
+		t.Fatal("skill not found")
+	}
+	body := sk.Body
+	// lint.py should be listed (recognized .py extension)
+	if !strings.Contains(body, "lint.py") {
+		t.Error("lint.py should be listed (recognized .py extension)")
+	}
+	// deploy (no extension) should be listed (bare executable)
+	if !strings.Contains(body, "deploy") {
+		t.Error("deploy (no extension) should be listed as bare executable")
+	}
+	// .hidden.py should NOT be listed (hidden file)
+	if strings.Contains(body, ".hidden.py") {
+		t.Error("hidden files should NOT be listed")
+	}
+	// readme.md should NOT be listed (documentation, not a script)
+	if strings.Contains(body, "readme.md") {
+		t.Error("non-script extensions should NOT be listed")
+	}
+	// .gitkeep should NOT be listed (hidden file)
+	if strings.Contains(body, ".gitkeep") {
+		t.Error(".gitkeep should NOT be listed")
+	}
+}
+
 func TestBuiltinInitIsInlineSkill(t *testing.T) {
 	// /init must resolve to a built-in inline skill (the model-driven AGENTS.md
 	// bootstrap), present even with no project/user skills on disk.

--- a/internal/skill/skill_test.go
+++ b/internal/skill/skill_test.go
@@ -24,6 +24,19 @@ func writeSkill(t *testing.T, base, rel, content string) string {
 	return full
 }
 
+// writeScript creates a file at base/rel with the given content.
+func writeScript(t *testing.T, base, rel, content string) string {
+	t.Helper()
+	full := filepath.Join(base, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return full
+}
+
 func find(skills []Skill, name string) (Skill, bool) {
 	for _, s := range skills {
 		if s.Name == name {
@@ -355,6 +368,54 @@ func TestReferencesInlined(t *testing.T) {
 	}
 	if !strings.Contains(sk.Body, "first ref") || !strings.Contains(sk.Body, "second ref") {
 		t.Error("reference contents missing")
+	}
+}
+
+func TestScriptsAppended(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/withscripts/SKILL.md", "---\ndescription: r\n---\nmain body")
+	writeScript(t, home, ".reasonix/skills/withscripts/scripts/lint.py", "#!/usr/bin/env python3\nprint('ok')")
+	writeScript(t, home, ".reasonix/skills/withscripts/scripts/deploy.sh", "#!/usr/bin/env bash\necho ok")
+
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	sk, ok := st.Read("withscripts")
+	if !ok {
+		t.Fatal("skill not found")
+	}
+	if !strings.Contains(sk.Body, "main body") {
+		t.Error("main body missing")
+	}
+	if !strings.Contains(sk.Body, "## Scripts") {
+		t.Error("scripts section missing")
+	}
+	if !strings.Contains(sk.Body, "lint.py") || !strings.Contains(sk.Body, "deploy.sh") {
+		t.Error("script paths missing from body")
+	}
+}
+
+func TestNoScriptsWhenDirAbsent(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/noscripts/SKILL.md", "---\ndescription: r\n---\nmain body")
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	sk, ok := st.Read("noscripts")
+	if !ok {
+		t.Fatal("skill not found")
+	}
+	if strings.Contains(sk.Body, "## Scripts") {
+		t.Error("should not have scripts section when scripts/ missing")
+	}
+}
+
+func TestFlatSkillNoScripts(t *testing.T) {
+	home := t.TempDir()
+	writeSkill(t, home, ".reasonix/skills/flat.md", "---\ndescription: r\n---\nmain body")
+	st := New(Options{HomeDir: home, DisableBuiltins: true})
+	sk, ok := st.Read("flat")
+	if !ok {
+		t.Fatal("skill not found")
+	}
+	if strings.Contains(sk.Body, "## Scripts") {
+		t.Error("flat skill should not have scripts section")
 	}
 }
 


### PR DESCRIPTION
## 改动

Skill 的 `scripts/` 目录已在规范中定义（与 `references/`、`assets/` 同级），但没有被加载到 skill body 中。模型不知道有哪些脚本可用。

### `loadBodyWithScripts()`

仿照已有的 `loadBodyWithReferences` 模式，在 skill body 加载链中追加一步：

1. 检查是否是 `SKILL.md`（directory-layout skill）
2. 扫描 `scripts/` 目录，过滤隐藏文件和非脚本扩展名（`.sh` `.py` `.js` `.ts` `.rb` `.pl` `.php` `.ps1`）
3. 在 body 末尾追加 `## Scripts` 节，列出所有脚本的绝对路径
4. 模型通过 `bash` 工具执行，继承 sandbox/gate/hooks 全套安全边界

### 测试

`TestScriptsAppended` — 目录 skill 有 `scripts/` 时 body 尾部列出脚本路径
`TestNoScriptsWhenDirAbsent` — 无 `scripts/` 目录时 body 不变
`TestFlatSkillNoScripts` — flat skill 不追加

`go test ./internal/skill/` — 全部通过。

Cache-impact: low — Skill.Body 仅在 skill 被工具调用时加载，不在 cache-stable prefix 中

Cache-guard: go test ./internal/skill/ -run 'TestScripts|TestNoScriptsWhenDirAbsent|TestFlatSkillNoScripts' — includes TestScriptsStayOutOfSkillIndex for the pinned skill index

System-prompt-review: reviewer follow-up — TestScriptsStayOutOfSkillIndex verifies script listings stay out of the stable skill index/system-prompt prefix
