### PR TITLE
fix(planner): skip planning for synthetic goal-loop messages

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -156,10 +156,26 @@ func (c *Coordinator) SetPlanMode(v bool) {
 	}
 }
 
+// skipPlannerKey is a context key that marks synthetic user messages which
+// should bypass the planner entirely.
+type skipPlannerKey struct{}
+
+// WithSkipPlanner returns a context that instructs Coordinator.Run to skip
+// the planner and go directly to the executor.
+func WithSkipPlanner(ctx context.Context) context.Context {
+	return context.WithValue(ctx, skipPlannerKey{}, true)
+}
+
+// SkipPlanner reports whether the context carries the skip-planner flag.
+func SkipPlanner(ctx context.Context) bool {
+	v, _ := ctx.Value(skipPlannerKey{}).(bool)
+	return v
+}
+
 // Run plans with the planner model, then hands the plan to the executor.
 func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})
-	if c.shouldPlan != nil && !c.shouldPlan(input) {
+	if SkipPlanner(ctx) || (c.shouldPlan != nil && !c.shouldPlan(input)) {
 		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
 		return c.executor.Run(ctx, input)
 	}

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -69,15 +69,42 @@ func (c *Controller) shouldAutoPlan(ctx context.Context, input string) bool {
 }
 
 // TaskWarrantsPlanner reports whether a task turn is worth a planner pass in
-// two-model mode. Empty input, slash commands, and low-risk informational asks
-// (explain / show / what / why / 解释 / 查一下 …) skip straight to the executor;
-// anything that reads like a work request — even a terse one — still gets planned.
+// two-model mode. Empty input, slash commands, low-risk informational asks
+// (explain / show / what / why / 解释 / 查一下 …), and synthetic system
+// messages (goal loop turns, readiness retries, compaction summaries, etc.)
+// skip straight to the executor; anything that reads like a work request —
+// even a terse one — still gets planned.
 func TaskWarrantsPlanner(input string) bool {
 	text := strings.TrimSpace(agent.StripTransientUserBlocks(input))
+	// Strip active-goal block injected by Compose for goal-mode turns.
+	text = stripActiveGoalBlock(text)
 	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {
 		return false
 	}
+	if IsSyntheticUserMessage(text) {
+		return false
+	}
 	return !isLowRiskQuestion(strings.ToLower(text))
+}
+
+// stripActiveGoalBlock removes the <active-goal>...</active-goal> wrapper that
+// Compose prepends to goal-mode user turns, so the remaining text can be
+// checked against synthetic message patterns.
+func stripActiveGoalBlock(text string) string {
+	open := "<active-goal>"
+	close := "</active-goal>"
+	if !strings.Contains(text, open) {
+		return text
+	}
+	if idx := strings.Index(text, open); idx >= 0 {
+		if end := strings.Index(text, close); end >= 0 {
+			after := strings.TrimSpace(text[end+len(close):])
+			if after != "" {
+				return after
+			}
+		}
+	}
+	return text
 }
 
 func autoPlanScore(input string) int {

--- a/internal/control/auto_plan_test.go
+++ b/internal/control/auto_plan_test.go
@@ -19,6 +19,11 @@ func TestTaskWarrantsPlanner(t *testing.T) {
 		{"fix the bug", true},        // terse, but a work request → still planned
 		{"add a login button", true}, // ditto
 		{"implement the new caching layer across the backend", true},
+		// Synthetic goal-loop messages should NOT trigger the planner.
+		{activeGoalBlock("execute plan: fix the parser", GoalResearchAuto) + "\n\n" + goalContinueTurn, false},
+		{activeGoalBlock("execute plan: fix the parser", GoalResearchAuto) + "\n\n" + goalSelfCheckTurn, false},
+		// Normal user input inside an active-goal block should still trigger.
+		{activeGoalBlock("implement the new caching layer", GoalResearchAuto) + "\n\nimplement the new caching layer across the backend", true},
 	}
 	for _, c := range cases {
 		if got := TaskWarrantsPlanner(c.input); got != c.want {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -591,7 +591,7 @@ func (c *Controller) runGoalLoopWithRaw(ctx context.Context, input, raw string) 
 }
 
 func (c *Controller) runGoalLoopWithRawDisplay(ctx context.Context, input, raw, display string) error {
-	if err := c.runTurnWithRawDisplay(ctx, input, raw, display); err != nil {
+	if err := c.runTurnWithRawDisplay(agent.WithSkipPlanner(ctx), input, raw, display); err != nil {
 		if ctx.Err() != nil {
 			c.stopGoal(GoalStatusStopped)
 		}
@@ -692,7 +692,7 @@ func (c *Controller) continueGoal(ctx context.Context) error {
 		} else {
 			c.mu.Unlock()
 		}
-		if err := c.runTurnWithRawDisplay(ctx, turn, turn, ""); err != nil {
+		if err := c.runTurnWithRawDisplay(agent.WithSkipPlanner(ctx), turn, turn, ""); err != nil {
 			if ctx.Err() != nil {
 				c.stopGoal(GoalStatusStopped)
 			}

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -86,6 +86,8 @@ var syntheticPrefixes = []string{
 	"Summary of earlier conversation (compacted up to here):",
 	"Continue pursuing the active goal.",
 	"The agent signaled goal completion",
+	"No tool calls in recent turns",
+	"Goal signaled complete but issues remain",
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -67,8 +67,9 @@ func IsSyntheticUserMessage(content string) bool {
 }
 
 // syntheticPrefixes must be kept in sync with the synthetic user messages
-// injected by the controller (planApprovedMessage), agent loop
-// (streamRecoveryMessage, finalReadinessRetryMessage, emptyFinalRetryMessage,
+// injected by the controller (planApprovedMessage, goalContinueTurn,
+// goalSelfCheckTurn), agent loop (streamRecoveryMessage,
+// finalReadinessRetryMessage, emptyFinalRetryMessage,
 // executorHandoffRetryMessage in internal/agent/agent.go), and compaction
 // folds (internal/agent/compact.go), which store summaries as user-role
 // messages the chat UI must never render as user bubbles (#3653).
@@ -83,6 +84,8 @@ var syntheticPrefixes = []string{
 	"<compaction-summary>",
 	"Summary of the later conversation (compacted from here on):",
 	"Summary of earlier conversation (compacted up to here):",
+	"Continue pursuing the active goal.",
+	"The agent signaled goal completion",
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,


### PR DESCRIPTION
## 问题

两模型模式下（配置了 `planner_model`），`goalContinueTurn`、`goalSelfCheckTurn`、idle 提醒、todo 拦截等系统注入消息会触发不必要的规划器调用。每次浪费 ~400-800 tokens。goal 循环 50 轮下来累计浪费数万 tokens。

## 改动

### 1. Context flag（源头标记，推荐）
在合成消息的源头（`continueGoal`、`runGoalLoopWithRawDisplay`）用 `agent.WithSkipPlanner(ctx)` 标记上下文，`Coordinator.Run` 优先检查该标记，命中则直接跳过 planner。

### 2. 内容嗅探（defense-in-depth）
`TaskWarrantsPlanner` 剥离 `<active-goal>` 后调用 `IsSyntheticUserMessage`：
- `syntheticPrefixes` 新增 4 个前缀（goal 续跑、自检、idle、todo 拦截）
- `stripActiveGoalBlock` 去除 Compose 注入的 `<active-goal>` 包装

## 测试
`go test ./internal/control/ ./internal/agent/` — 全部通过。

Cache-impact: none — context flag 和内容嗅探都不在 cache-sensitive 路径中。
Cache-guard: go test ./internal/control/ ./internal/agent/
System-prompt-review: self — 不涉及系统提示词前缀修改。