### PR TITLE
fix(netclient): log auto proxy misses

### DIFF
--- a/internal/netclient/netclient.go
+++ b/internal/netclient/netclient.go
@@ -6,6 +6,7 @@ package netclient
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -216,12 +217,23 @@ func environmentProxyFunc() func(*http.Request) (*url.URL, error) {
 // system proxy (Windows IE/PAC/WPAD) so corporate Windows machines work without
 // any manual HTTP_PROXY setup. Non-Windows resolves to env-only.
 func autoProxyFunc() func(*http.Request) (*url.URL, error) {
+	return autoProxyFuncWithResolver(sysproxy.ForURL, slog.Debug)
+}
+
+func autoProxyFuncWithResolver(systemProxy func(*url.URL) (*url.URL, error), debugf func(string, ...any)) func(*http.Request) (*url.URL, error) {
 	pf := httpproxy.FromEnvironment().ProxyFunc()
 	return func(req *http.Request) (*url.URL, error) {
 		if u, err := pf(req.URL); err != nil || u != nil {
 			return u, err
 		}
-		return sysproxy.ForURL(req.URL)
+		u, err := systemProxy(req.URL)
+		if err != nil || u != nil {
+			return u, err
+		}
+		if debugf != nil {
+			debugf("netclient: no proxy resolved for auto mode", "host", req.URL.Hostname())
+		}
+		return nil, nil
 	}
 }
 

--- a/internal/netclient/netclient_test.go
+++ b/internal/netclient/netclient_test.go
@@ -84,6 +84,72 @@ func TestDirectHostsBypassProxy(t *testing.T) {
 	}
 }
 
+func TestAutoProxyLogsWhenNoProxyResolved(t *testing.T) {
+	clearProxyEnv(t)
+
+	var systemCalls int
+	var gotMessage string
+	var gotArgs []any
+	pf := autoProxyFuncWithResolver(
+		func(_ *url.URL) (*url.URL, error) {
+			systemCalls++
+			return nil, nil
+		},
+		func(message string, args ...any) {
+			gotMessage = message
+			gotArgs = append([]any(nil), args...)
+		},
+	)
+
+	got, err := pf(&http.Request{URL: mustURL("https://api.deepseek.com/v1/models")})
+	if err != nil {
+		t.Fatalf("proxy lookup: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("proxy = %v, want nil", got)
+	}
+	if systemCalls != 1 {
+		t.Fatalf("system proxy calls = %d, want 1", systemCalls)
+	}
+	if gotMessage != "netclient: no proxy resolved for auto mode" {
+		t.Fatalf("debug message = %q", gotMessage)
+	}
+	if len(gotArgs) != 2 || gotArgs[0] != "host" || gotArgs[1] != "api.deepseek.com" {
+		t.Fatalf("debug args = %#v, want host api.deepseek.com", gotArgs)
+	}
+}
+
+func TestAutoProxyUsesEnvBeforeSystemProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+
+	var systemCalls int
+	var logCalls int
+	pf := autoProxyFuncWithResolver(
+		func(_ *url.URL) (*url.URL, error) {
+			systemCalls++
+			return nil, nil
+		},
+		func(string, ...any) {
+			logCalls++
+		},
+	)
+
+	got, err := pf(&http.Request{URL: mustURL("https://api.deepseek.com/v1/models")})
+	if err != nil {
+		t.Fatalf("proxy lookup: %v", err)
+	}
+	if got == nil || got.Host != "proxy.example.com:8080" {
+		t.Fatalf("proxy = %v, want proxy.example.com:8080", got)
+	}
+	if systemCalls != 0 {
+		t.Fatalf("system proxy calls = %d, want 0", systemCalls)
+	}
+	if logCalls != 0 {
+		t.Fatalf("debug calls = %d, want 0", logCalls)
+	}
+}
+
 func TestNoDirectHostsKeepsEveryoneProxied(t *testing.T) {
 	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
 	t.Setenv("NO_PROXY", "")
@@ -558,6 +624,16 @@ func mustURL(s string) *url.URL {
 		panic(err)
 	}
 	return u
+}
+
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("http_proxy", "")
+	t.Setenv("HTTPS_PROXY", "")
+	t.Setenv("https_proxy", "")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
 }
 
 func TestForceIPv4Dials(t *testing.T) {

--- a/internal/sysproxy/system_windows.go
+++ b/internal/sysproxy/system_windows.go
@@ -3,6 +3,7 @@
 package sysproxy
 
 import (
+	"log/slog"
 	"net/url"
 	"strings"
 	"unsafe"
@@ -59,7 +60,8 @@ func ForURL(target *url.URL) (*url.URL, error) {
 		return nil, nil
 	}
 	var ie ieProxyConfig
-	if r, _, _ := procGetIEProxyConfig.Call(uintptr(unsafe.Pointer(&ie))); r == 0 {
+	if r, _, err := procGetIEProxyConfig.Call(uintptr(unsafe.Pointer(&ie))); r == 0 {
+		slog.Debug("sysproxy: Windows proxy configuration unavailable", "host", target.Hostname(), "err", err)
 		return nil, nil
 	}
 	defer globalFree(ie.lpszProxy)
@@ -88,8 +90,9 @@ func ForURL(target *url.URL) (*url.URL, error) {
 }
 
 func pacProxy(target *url.URL, autoConfigURL *uint16, scheme string) *url.URL {
-	session, _, _ := procOpen.Call(0, accessTypeNoProxy, 0, 0, 0)
+	session, _, err := procOpen.Call(0, accessTypeNoProxy, 0, 0, 0)
 	if session == 0 {
+		slog.Debug("sysproxy: WinHTTP session unavailable", "host", target.Hostname(), "err", err)
 		return nil
 	}
 	defer func() { _, _, _ = procCloseHandle.Call(session) }()
@@ -108,8 +111,9 @@ func pacProxy(target *url.URL, autoConfigURL *uint16, scheme string) *url.URL {
 		return nil
 	}
 	var info proxyInfo
-	r, _, _ := procGetProxyForURL.Call(session, uintptr(unsafe.Pointer(urlPtr)), uintptr(unsafe.Pointer(&opts)), uintptr(unsafe.Pointer(&info)))
+	r, _, err := procGetProxyForURL.Call(session, uintptr(unsafe.Pointer(urlPtr)), uintptr(unsafe.Pointer(&opts)), uintptr(unsafe.Pointer(&info)))
 	if r == 0 {
+		slog.Debug("sysproxy: PAC proxy resolution failed", "host", target.Hostname(), "err", err)
 		return nil
 	}
 	defer globalFree(info.lpszProxy)


### PR DESCRIPTION
Problem
Auto proxy mode can silently fall back to a direct connection when neither env nor system proxy settings resolve a proxy, which makes Windows proxy failures hard to diagnose.

Change
Add a testable auto-proxy resolver path that logs a debug message when no proxy is resolved, and add debug logging for Windows WinHTTP/PAC failure paths.

Verification
- go test ./internal/netclient -run 'TestAutoProxyLogsWhenNoProxyResolved|TestAutoProxyUsesEnvBeforeSystemProxy' -count=1
- go test ./internal/netclient ./internal/sysproxy
- GOOS=windows GOARCH=amd64 go test -c ./internal/sysproxy -o /tmp/reasonix-sysproxy.test.exe
- GOOS=windows GOARCH=amd64 go test -c ./internal/netclient -o /tmp/reasonix-netclient.test.exe
- git diff --check

Refs #4798
