### PR TITLE
fix(plugin): persist lazy MCP schema cache

### DIFF
--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -90,14 +90,15 @@ func (s *lazySpawn) kick() {
 // reacquires mu to publish the result.
 func (s *lazySpawn) run() {
 	real, err := s.host.Add(s.ctx, s.spec)
+	var cacheTools []tool.Tool
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if err != nil {
 		if errors.Is(err, ErrSpawningInFlight) {
 			// Another tab is already spawning this server; reset to idle so
 			// the next call retries instead of recording a spurious failure.
 			s.state = spawnIdle
 			s.spawnErr = nil
+			s.mu.Unlock()
 			return
 		}
 		if IsServerAlreadyConnected(err) {
@@ -111,17 +112,22 @@ func (s *lazySpawn) run() {
 				}
 				s.state = spawnReady
 				s.trySwap()
+				cacheTools = tools
+				s.mu.Unlock()
+				saveLazyCachedSchema(s.spec, cacheTools)
 				return
 			}
 			// ToolsFor failed — still not a real failure; just mark failed
 			// without recording it so /mcp status stays clean.
 			s.state = spawnFailed
 			s.spawnErr = err
+			s.mu.Unlock()
 			return
 		}
 		s.state = spawnFailed
 		s.spawnErr = err
 		s.host.RecordFailure(s.spec, err)
+		s.mu.Unlock()
 		return
 	}
 	s.real = make(map[string]tool.Tool, len(real))
@@ -130,6 +136,17 @@ func (s *lazySpawn) run() {
 	}
 	s.state = spawnReady
 	s.trySwap()
+	cacheTools = real
+	s.mu.Unlock()
+	saveLazyCachedSchema(s.spec, cacheTools)
+}
+
+func saveLazyCachedSchema(spec Spec, real []tool.Tool) {
+	_ = SaveCachedSchema(spec.Name, CachedSchema{
+		SpecHash:     SpecFingerprint(spec),
+		Capabilities: map[string]bool{},
+		Tools:        cacheableToolsOf(real),
+	})
 }
 
 // trySwap installs the real tools into reg if the spawn is ready and the

--- a/internal/plugin/lazy_test.go
+++ b/internal/plugin/lazy_test.go
@@ -72,6 +72,19 @@ func waitForServer(t *testing.T, host *Host, name string, timeout time.Duration)
 	t.Fatalf("server %q never appeared in host.ServerNames() within %v (got %v)", name, timeout, host.ServerNames())
 }
 
+func waitForCachedSchema(t *testing.T, spec Spec, timeout time.Duration) *CachedSchema {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cs, ok := LoadCachedSchema(spec.Name, SpecFingerprint(spec)); ok {
+			return cs
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cached schema for %q never appeared within %v", spec.Name, timeout)
+	return nil
+}
+
 // TestLazyCacheHitSyncSpawn drives the cache-hit branch end-to-end: cache is
 // pre-populated, the model can see real schemas before any spawn, and the
 // first Execute synchronously handshakes, swaps the placeholder for the real
@@ -457,6 +470,35 @@ func TestLazyBackgroundKick(t *testing.T) {
 	// One spawn, not two — kick + Execute must collapse onto the same run.
 	if names := host.ServerNames(); len(names) != 1 {
 		t.Fatalf("host.ServerNames() = %v, want exactly one 'mock'", names)
+	}
+}
+
+func TestLazyBackgroundCacheMissPersistsSchema(t *testing.T) {
+	redirectCache(t)
+	spec := helperSpec()
+
+	host := NewHost()
+	defer host.Close()
+	reg := tool.NewRegistry()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	tools := LazyToolset(spec, nil, host, reg, ctx, true) // cache miss + background kick
+	for _, lt := range tools {
+		reg.Add(lt)
+	}
+
+	waitForServer(t, host, "mock", 5*time.Second)
+	cs := waitForCachedSchema(t, spec, 5*time.Second)
+	if len(cs.Tools) != 2 {
+		t.Fatalf("cached schema has %d tools, want 2", len(cs.Tools))
+	}
+	got := map[string]bool{}
+	for _, ct := range cs.Tools {
+		got[ct.Name] = true
+	}
+	if !got["echo"] || !got["zed"] {
+		t.Fatalf("cached tools = %v, want echo and zed", got)
 	}
 }
 


### PR DESCRIPTION
Problem
- Lazy/background MCP spawns swap real tools into the registry after a successful handshake, but cache-miss background spawns never persist the discovered schema for the next session.

Change
- Save the discovered lazy MCP tool schema after a successful deferred spawn.
- Add regression coverage for cache-miss background startup writing LoadCachedSchema data.

Verification
- go test ./internal/plugin -run TestLazyBackgroundCacheMissPersistsSchema -count=1
- go test ./internal/plugin -run 'TestLazy(BackgroundCacheMissPersistsSchema|BackgroundKick|CacheMissAsyncSpawn|CacheHitSyncSpawn|ToolsetCacheHitSchemaVisible)' -count=1
- go test ./internal/plugin -count=1

Cache-impact: low - only persists lazy MCP schemas after successful handshakes; cache writes remain best-effort.
Cache-guard: go test ./internal/plugin -run TestLazyBackgroundCacheMissPersistsSchema -count=1