### PR TITLE
perf(sessions): cache turn count + preview in the .meta sidecar

### DIFF
--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -28,6 +28,14 @@ type BranchMeta struct {
 	TopicID          string    `json:"topic_id,omitempty"`
 	TopicTitle       string    `json:"topic_title,omitempty"`
 	Model            string    `json:"model,omitempty"`
+	// Turns and Preview are listing-only fields the desktop sidebar and CLI
+	// pickers show ("5 turns · 'help me debug…'") without decoding the whole
+	// .jsonl. The autosave path (Controller.snapshot) keeps them fresh from the
+	// in-memory conversation, so ListSessions stays O(1) per session instead of
+	// O(file size). Turns == 0 means "not recorded yet" — listing falls back to a
+	// one-time decode and backfills these.
+	Turns   int    `json:"turns,omitempty"`
+	Preview string `json:"preview,omitempty"`
 }
 
 func (m BranchMeta) DefaultScope() string {
@@ -266,4 +274,25 @@ func SetBranchModelPreserveUpdated(sessionPath, model string) error {
 	}
 	meta.Model = strings.TrimSpace(model)
 	return SaveBranchMetaPreserveUpdated(sessionPath, meta)
+}
+
+// UpdateSessionMeta refreshes the listing-only sidecar fields (model, preview,
+// user-turn count) the sidebar and pickers read without decoding the .jsonl.
+// markActivity bumps UpdatedAt (the autosave path passes true on a real turn);
+// false preserves it (used to backfill legacy sessions during a read). An empty
+// model leaves the stored model untouched.
+func UpdateSessionMeta(sessionPath, model, preview string, turns int, markActivity bool) error {
+	if sessionPath == "" {
+		return fmt.Errorf("empty session path")
+	}
+	m, err := EnsureBranchMeta(sessionPath)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(model) != "" {
+		m.Model = strings.TrimSpace(model)
+	}
+	m.Preview = preview
+	m.Turns = turns
+	return saveBranchMeta(sessionPath, m, markActivity)
 }

--- a/internal/agent/listsessions_bench_test.go
+++ b/internal/agent/listsessions_bench_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+// TestListSessionsScalingManual reproduces the sidebar "project list loads
+// slowly" report by timing ListSessions against a synthetically large session
+// directory. It is gated behind REASONIX_BENCH=1 so it never runs (or writes
+// hundreds of MB) during a normal `go test`.
+//
+//	REASONIX_BENCH=1 go test ./internal/agent -run TestListSessionsScalingManual -v
+func TestListSessionsScalingManual(t *testing.T) {
+	if os.Getenv("REASONIX_BENCH") != "1" {
+		t.Skip("set REASONIX_BENCH=1 to run the scaling benchmark")
+	}
+
+	type shape struct {
+		sessions int
+		turns    int // user/assistant pairs per session
+	}
+	shapes := []shape{
+		{sessions: 100, turns: 20},
+		{sessions: 300, turns: 30},
+		{sessions: 500, turns: 40},
+	}
+
+	for _, s := range shapes {
+		name := fmt.Sprintf("%dsessions_%dturns", s.sessions, s.turns)
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			totalBytes := writeSyntheticSessions(t, dir, s.sessions, s.turns)
+
+			// Metadata-only pass: ReadDir + Stat + LoadBranchMeta sidecar.
+			start := time.Now()
+			order, err := ListSessionOrder(dir)
+			if err != nil {
+				t.Fatalf("ListSessionOrder: %v", err)
+			}
+			orderDur := time.Since(start)
+
+			// Cold ListSessions: sidecars have no recorded turn count yet, so this
+			// decodes every .jsonl in full (the pre-fix behaviour) and backfills.
+			start = time.Now()
+			cold, err := ListSessions(dir)
+			if err != nil {
+				t.Fatalf("ListSessions (cold): %v", err)
+			}
+			coldDur := time.Since(start)
+
+			// Warm ListSessions: the backfill populated Turns/Preview in the
+			// sidecars, so this reads them and skips the whole-file decode — the
+			// post-fix steady state the sidebar hits on every refresh.
+			start = time.Now()
+			warm, err := ListSessions(dir)
+			if err != nil {
+				t.Fatalf("ListSessions (warm): %v", err)
+			}
+			warmDur := time.Since(start)
+
+			t.Logf("sessions=%d turns=%d onDisk=%.1fMB | order(meta)=%v (%d) | ListSessions cold(decode+backfill)=%v (%d) | ListSessions warm(sidecar)=%v (%d) | speedup=%.0fx",
+				s.sessions, s.turns, float64(totalBytes)/(1<<20),
+				orderDur.Round(time.Millisecond), len(order),
+				coldDur.Round(time.Millisecond), len(cold),
+				warmDur.Round(time.Millisecond), len(warm),
+				float64(coldDur)/float64(warmDur))
+		})
+	}
+}
+
+// writeSyntheticSessions writes n session .jsonl files (newline-delimited
+// provider.Message, like Session.Save) plus a minimal .meta sidecar each,
+// mimicking a heavy thinking-mode user: large assistant Content +
+// ReasoningContent. Returns total on-disk session bytes.
+func writeSyntheticSessions(t *testing.T, dir string, n, turns int) int64 {
+	t.Helper()
+	content := strings.Repeat("The quick brown fox jumps over the lazy dog. ", 140)    // ~6 KB
+	reasoning := strings.Repeat("Let me think step by step about this problem. ", 220) // ~10 KB
+	var total int64
+	for i := range n {
+		base := fmt.Sprintf("20260101-%06d-deepseek-chat", i)
+		path := filepath.Join(dir, base+".jsonl")
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		enc := json.NewEncoder(f)
+		for tn := range turns {
+			_ = enc.Encode(provider.Message{Role: provider.RoleUser, Content: fmt.Sprintf("user message %d %s", tn, content[:200])})
+			_ = enc.Encode(provider.Message{Role: provider.RoleAssistant, Content: content, ReasoningContent: reasoning})
+		}
+		if st, err := f.Stat(); err == nil {
+			total += st.Size()
+		}
+		f.Close()
+
+		meta := BranchMeta{
+			ID:        base,
+			CreatedAt: time.Now().Add(-time.Duration(i) * time.Minute),
+			UpdatedAt: time.Now().Add(-time.Duration(i) * time.Minute),
+			Scope:     "global",
+		}
+		b, _ := json.Marshal(meta)
+		if err := os.WriteFile(path+".meta", b, 0o644); err != nil {
+			t.Fatalf("write meta: %v", err)
+		}
+	}
+	return total
+}

--- a/internal/agent/listsessions_sidecar_test.go
+++ b/internal/agent/listsessions_sidecar_test.go
@@ -1,0 +1,117 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"reasonix/internal/provider"
+)
+
+func writeSessionFile(t *testing.T, path string, msgs []provider.Message) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, m := range msgs {
+		if err := enc.Encode(m); err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+	}
+}
+
+// SessionPreviewFromMessages must match a from-disk decode byte-for-byte, since
+// Session.Save persists exactly the messages it is handed.
+func TestSessionPreviewFromMessagesMatchesDecode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260101-000000-deepseek-chat.jsonl")
+	msgs := []provider.Message{
+		{Role: provider.RoleSystem, Content: "you are helpful"},
+		{Role: provider.RoleUser, Content: "first question about the bug"},
+		{Role: provider.RoleAssistant, Content: "here is an answer", ReasoningContent: "thinking"},
+		{Role: provider.RoleUser, Content: "follow up"},
+		{Role: provider.RoleAssistant, Content: "more"},
+	}
+	writeSessionFile(t, path, msgs)
+
+	filePreview, fileTurns := previewSession(path)
+	memPreview, memTurns := SessionPreviewFromMessages(msgs)
+	if fileTurns != memTurns || filePreview != memPreview {
+		t.Fatalf("mismatch: file=(%q,%d) mem=(%q,%d)", filePreview, fileTurns, memPreview, memTurns)
+	}
+	if memTurns != 2 {
+		t.Fatalf("expected 2 user turns, got %d", memTurns)
+	}
+}
+
+// When the sidecar records Turns/Preview, ListSessions must trust them and not
+// re-derive from the .jsonl. We prove that by planting counts that disagree with
+// the file: if ListSessions returns the planted values, it used the sidecar.
+func TestListSessionsUsesSidecarWithoutDecoding(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260101-000000-deepseek-chat.jsonl")
+	writeSessionFile(t, path, []provider.Message{
+		{Role: provider.RoleUser, Content: "real content in the file"},
+		{Role: provider.RoleAssistant, Content: "a"},
+	})
+	// Sidecar deliberately disagrees with the file (3 turns, custom preview).
+	if err := UpdateSessionMeta(path, "", "cached preview line", 3, true); err != nil {
+		t.Fatalf("UpdateSessionMeta: %v", err)
+	}
+
+	infos, err := ListSessions(dir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 session, got %d", len(infos))
+	}
+	if infos[0].Turns != 3 || infos[0].Preview != "cached preview line" {
+		t.Fatalf("expected sidecar values (3, %q), got (%d, %q)", "cached preview line", infos[0].Turns, infos[0].Preview)
+	}
+}
+
+// A legacy session whose sidecar has no recorded turn count must be decoded once
+// and then backfilled, so the second listing reads the sidecar.
+func TestListSessionsBackfillsLegacySession(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260101-000000-deepseek-chat.jsonl")
+	writeSessionFile(t, path, []provider.Message{
+		{Role: provider.RoleUser, Content: "legacy question"},
+		{Role: provider.RoleAssistant, Content: "answer"},
+		{Role: provider.RoleUser, Content: "again"},
+		{Role: provider.RoleAssistant, Content: "ok"},
+	})
+	// Sidecar exists but predates the counts (no Turns/Preview), with a fixed
+	// UpdatedAt we expect backfill to preserve.
+	updated := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := SaveBranchMetaPreserveUpdated(path, BranchMeta{ID: BranchID(path), CreatedAt: updated, UpdatedAt: updated, Scope: "global"}); err != nil {
+		t.Fatalf("SaveBranchMetaPreserveUpdated: %v", err)
+	}
+
+	infos, err := ListSessions(dir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(infos) != 1 || infos[0].Turns != 2 {
+		t.Fatalf("expected 1 session with 2 turns, got %+v", infos)
+	}
+
+	// Backfill must have written the counts into the sidecar without bumping
+	// activity time (ordering must stay stable).
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("LoadBranchMeta: ok=%v err=%v", ok, err)
+	}
+	if meta.Turns != 2 || meta.Preview != "legacy question" {
+		t.Fatalf("backfill missing: turns=%d preview=%q", meta.Turns, meta.Preview)
+	}
+	if !meta.UpdatedAt.Equal(updated) {
+		t.Fatalf("backfill bumped UpdatedAt: got %v want %v", meta.UpdatedAt, updated)
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -126,6 +126,10 @@ type SessionOrderInfo struct {
 	WorkspaceRoot  string
 	TopicID        string
 	TopicTitle     string
+	// Turns and Preview are the cached listing fields from the sidecar, when
+	// recorded (Turns > 0). ListSessions uses them to skip the whole-file decode.
+	Turns   int
+	Preview string
 }
 
 // CleanupPendingMeta records that a session was logically removed but still has
@@ -293,6 +297,8 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 		workspaceRoot := ""
 		topicID := ""
 		topicTitle := ""
+		turns := 0
+		preview := ""
 		if meta, ok, err := LoadBranchMeta(full); err == nil && ok {
 			if !meta.CreatedAt.IsZero() {
 				createdAt = meta.CreatedAt
@@ -304,6 +310,8 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			workspaceRoot = meta.WorkspaceRoot
 			topicID = meta.TopicID
 			topicTitle = meta.TopicTitle
+			turns = meta.Turns
+			preview = meta.Preview
 		}
 		out = append(out, SessionOrderInfo{
 			Path:           full,
@@ -314,6 +322,8 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			WorkspaceRoot:  workspaceRoot,
 			TopicID:        topicID,
 			TopicTitle:     topicTitle,
+			Turns:          turns,
+			Preview:        preview,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -336,12 +346,20 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 	}
 	var out []SessionInfo
 	for _, session := range ordered {
-		preview, turns := previewSession(session.Path)
-		if turns == 0 {
-			// Skip sessions that have never had user interaction — they are
-			// empty conversations that should not appear in the history panel
-			// or the resume picker.
-			continue
+		preview, turns := session.Preview, session.Turns
+		if turns <= 0 {
+			// No recorded turn count in the sidecar — a legacy session from
+			// before the counts were persisted, or a genuinely empty one. Decode
+			// the .jsonl once to find out, then backfill the sidecar so every
+			// later listing is O(1) instead of O(file size).
+			preview, turns = previewSession(session.Path)
+			if turns == 0 {
+				// Never had user interaction — an empty conversation that should
+				// not appear in the history panel or the resume picker.
+				continue
+			}
+			// Best-effort: a failure here just means we decode again next time.
+			_ = UpdateSessionMeta(session.Path, "", preview, turns, false)
 		}
 		out = append(out, SessionInfo{
 			Path:           session.Path,
@@ -365,6 +383,25 @@ func SessionPreview(path string) (string, int) {
 	return previewSession(path)
 }
 
+// SessionPreviewFromMessages computes the same preview line and user-turn count
+// as previewSession, but from an in-memory message slice. Session.Save writes
+// exactly these messages to the .jsonl, so this is byte-for-byte equivalent to
+// decoding the file — letting the autosave path persist the counts into the
+// sidecar without a disk read.
+func SessionPreviewFromMessages(msgs []provider.Message) (string, int) {
+	first := ""
+	turns := 0
+	for _, m := range msgs {
+		if m.Role == provider.RoleUser {
+			turns++
+			if first == "" {
+				first = truncatePreview(UserPreviewText(m.Content))
+			}
+		}
+	}
+	return first, turns
+}
+
 // previewSession returns the first user message (truncated) and the number of
 // user-role messages so the picker can show "5 turns · 'help me debug the…'".
 // Errors are swallowed — a malformed file just shows up with an empty preview.
@@ -385,15 +422,20 @@ func previewSession(path string) (string, int) {
 		if m.Role == provider.RoleUser {
 			turns++
 			if first == "" {
-				s := UserPreviewText(m.Content)
-				if r := []rune(s); len(r) > 80 {
-					s = string(r[:77]) + "…"
-				}
-				first = s
+				first = truncatePreview(UserPreviewText(m.Content))
 			}
 		}
 	}
 	return first, turns
+}
+
+// truncatePreview clamps a preview line to 80 runes with an ellipsis, matching
+// what the pickers render.
+func truncatePreview(s string) string {
+	if r := []rune(s); len(r) > 80 {
+		return string(r[:77]) + "…"
+	}
+	return s
 }
 
 // ContinueSessionPath returns where a conversation carried into a rebuilt

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2545,23 +2545,17 @@ func (c *Controller) snapshot(markActivity bool) error {
 			"label", c.Label(), "session_dir", c.SessionDir())
 		return errNoSessionPath
 	}
-	if !markActivity {
-		if _, err := agent.EnsureBranchMeta(path); err != nil {
-			return err
-		}
-	}
 	if err := s.Save(path); err != nil {
 		return err
 	}
-	if strings.TrimSpace(modelRef) != "" {
-		if err := agent.SetBranchModelPreserveUpdated(path, modelRef); err != nil {
-			return err
-		}
-	}
-	if markActivity {
-		return agent.TouchBranchMeta(path)
-	}
-	return nil
+	// Record the listing-only sidecar fields (model, preview, user-turn count)
+	// straight from the in-memory conversation, so the sidebar and resume picker
+	// never have to decode the whole .jsonl just to show them. markActivity bumps
+	// UpdatedAt exactly like the previous TouchBranchMeta did; false preserves it
+	// like SetBranchModelPreserveUpdated. The single write subsumes the old
+	// EnsureBranchMeta / SetBranchModel / TouchBranchMeta sequence.
+	preview, turns := agent.SessionPreviewFromMessages(s.Snapshot())
+	return agent.UpdateSessionMeta(path, modelRef, preview, turns, markActivity)
 }
 
 func (c *Controller) messageCount() int {


### PR DESCRIPTION
## Problem

A user reported the desktop sidebar's **project list takes over a minute to load**.

Root cause is in the shared session layer, not the desktop UI:

1. **`agent.ListSessions` decodes every `.jsonl` in full** just to count user turns and build the preview line (`previewSession`). Listing is therefore `O(total session bytes)`. On a large history — or slow / cloud-synced storage (iCloud / OneDrive / Dropbox), where each `os.Open` triggers an on-demand fetch — this runs into minutes.
2. The desktop disk cache (`project-session-cache.json`) is keyed by a **whole-directory signature**. Every new message changes the active session's size/mtime, busting the signature, so each sidebar refresh **re-decodes every session in the directory**. The cache is effectively useless during active use.

This only reproduces with a large/slow dataset, which is why it doesn't show up on a developer machine with a few MB of sessions.

## Fix

Persist the listing-only fields (`Turns`, `Preview`) in the `BranchMeta` (`.jsonl.meta`) sidecar:

- `Controller.snapshot()` writes them from the in-memory conversation on each autosave. `Session.Save` persists exactly those messages, so the counts are byte-for-byte identical to decoding the file. The single sidecar write subsumes the previous `EnsureBranchMeta` / `SetBranchModel` / `TouchBranchMeta` sequence (same `UpdatedAt` / `Model` semantics).
- `ListSessions` reads `Turns`/`Preview` from the sidecar and only falls back to a one-time full decode (then **backfills** the sidecar) for legacy sessions recorded before this change.

The desktop needs no changes — it benefits automatically through `ListSessions`. The per-directory disk cache becomes a redundant secondary optimization (a full re-list is now cheap), so the per-message invalidation no longer hurts.

## Results

Steady-state listing drops from `O(file size)` to `O(number of sessions)` small reads — flat regardless of session size:

| Dataset | Before (full decode) | After (sidecar) | Speedup |
|---|---|---|---|
| 100 sessions / 32 MB | 127 ms | **2 ms** | 58× |
| 300 sessions / 143 MB | 541 ms | **6 ms** | 89× |
| 500 sessions / 319 MB | 1.17 s | **11 ms** | 106× |

Cold start pays the decode once (and backfills); every refresh afterwards reads the sidecar.

## Tests

- `SessionPreviewFromMessages` matches a from-disk decode byte-for-byte.
- `ListSessions` trusts the sidecar counts when present (planted values that disagree with the file prove no decode happens).
- Legacy sessions are decoded once and backfilled without bumping `UpdatedAt` (ordering stays stable).
- `REASONIX_BENCH=1`-gated scaling benchmark (does not run in CI).

`go test ./internal/agent ./internal/control` green; `gofmt` / `go vet` clean.