### PR TITLE
fix(control): seed fork/branch sidecar counts; tighten two latent issues

### DIFF
--- a/internal/agent/migrate.go
+++ b/internal/agent/migrate.go
@@ -840,7 +840,7 @@ func copyFileIfExists(src, dst string) error {
 	}
 	if _, err := os.Stat(dst); err == nil {
 		return nil
-	} else if err != nil && !os.IsNotExist(err) {
+	} else if !os.IsNotExist(err) {
 		return err
 	}
 	b, err := os.ReadFile(src)

--- a/internal/control/branches_test.go
+++ b/internal/control/branches_test.go
@@ -38,6 +38,11 @@ func TestBranchAndSwitch(t *testing.T) {
 	if meta.ParentID != rootID || meta.Name != "try something" {
 		t.Fatalf("child meta = %+v, want parent %q and name", meta, rootID)
 	}
+	// Branch must seed the listing-only sidecar fields at creation, so the
+	// sidebar never has to decode the new .jsonl to show its turn count/preview.
+	if meta.Turns != 1 || meta.Preview != "root prompt" {
+		t.Fatalf("child meta should carry turns/preview from creation: turns=%d preview=%q", meta.Turns, meta.Preview)
+	}
 
 	if _, err := c.SwitchBranch(rootID); err != nil {
 		t.Fatal(err)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -953,10 +953,16 @@ func (c *Controller) saveGoalState() {
 	}
 	data, err := json.Marshal(state)
 	if err != nil {
+		slog.Warn("controller: marshal goal state", "err", err)
 		return
 	}
-	_ = os.MkdirAll(filepath.Dir(c.goalStatePath), 0o755)
-	_ = os.WriteFile(c.goalStatePath, data, 0o644)
+	if err := os.MkdirAll(filepath.Dir(c.goalStatePath), 0o755); err != nil {
+		slog.Warn("controller: goal state dir", "err", err)
+		return
+	}
+	if err := os.WriteFile(c.goalStatePath, data, 0o644); err != nil {
+		slog.Warn("controller: write goal state", "err", err)
+	}
 }
 
 // goalState is the serializable form of a running goal.
@@ -2200,11 +2206,14 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	if err := sess.Save(newPath); err != nil {
 		return "", c.rewindFail(err)
 	}
+	forkPreview, forkTurns := agent.SessionPreviewFromMessages(forked)
 	if err := agent.SaveBranchMeta(newPath, agent.BranchMeta{
 		Name:             strings.TrimSpace(name),
 		ParentID:         parentID,
 		ForkTurn:         turn,
 		ForkMessageIndex: boundary,
+		Preview:          forkPreview,
+		Turns:            forkTurns,
 	}); err != nil {
 		return "", c.rewindFail(err)
 	}
@@ -2267,11 +2276,14 @@ func (c *Controller) Branch(name string) (string, error) {
 	if err := sess.Save(newPath); err != nil {
 		return "", c.rewindFail(err)
 	}
+	branchPreview, branchTurns := agent.SessionPreviewFromMessages(branched)
 	if err := agent.SaveBranchMeta(newPath, agent.BranchMeta{
 		Name:             strings.TrimSpace(name),
 		ParentID:         parentID,
 		ForkTurn:         -1,
 		ForkMessageIndex: len(branched),
+		Preview:          branchPreview,
+		Turns:            branchTurns,
 	}); err != nil {
 		return "", c.rewindFail(err)
 	}


### PR DESCRIPTION
Three low-risk cleanups surfaced by an architecture pass over `internal/control` and `internal/agent`. Each is independent.

## 1. Fork/Branch now seed the sidecar listing fields at creation
`Fork` and `Branch` saved the new session's `.jsonl` with content but wrote a `BranchMeta` **without** `Turns`/`Preview`. After #4882 made `ListSessions` read those from the sidecar, a freshly forked/branched session still had `Turns: 0`, so the first sidebar listing had to decode the whole transcript and backfill — the one case the fast path missed.

Populate both from the in-memory messages at creation via `SessionPreviewFromMessages` (the same source `Session.Save` persists, so they match a decode byte-for-byte). The sidecar is now authoritative the moment a fork/branch is created.

## 2. `saveGoalState` no longer fails silently
It discarded the `json.Marshal`, `os.MkdirAll`, and `os.WriteFile` errors, so goal-state persistence could fail completely invisibly. Each failure is now `slog.Warn`-logged, matching the other persistence paths in the controller.

## 3. Drop a tautological condition in `copyFileIfExists`
```go
if _, err := os.Stat(dst); err == nil {
    return nil
} else if err != nil && !os.IsNotExist(err) {  // err != nil is always true here
```
Removed the dead `err != nil &&` clause; behavior is unchanged.

## Tests
- `TestBranchAndSwitch` now asserts the child branch's sidecar carries `Turns`/`Preview` from creation (no decode/backfill needed).
- `go test ./internal/agent ./internal/control` green; `gofmt` / `go vet` clean.

Deferred (not low-risk enough for this batch): the `autosaveWG` is never `Wait()`ed, but `close()` doesn't cancel the active run, so adding a wait would either block teardown on a long turn or change "close doesn't abort an in-flight turn" semantics — worth its own change.