### PR TITLE
perf(desktop): drop the now-redundant project-session disk cache

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3488,7 +3488,6 @@ func (a *App) setTabActivityStatus(tabID, status string) bool {
 
 func (a *App) emitProjectTreeChanged() {
 	projectSessionCache.invalidate()
-	sessionDiskCacher.invalidate()
 	if a.projectTreeChangedHook != nil {
 		a.projectTreeChangedHook()
 		return
@@ -3767,36 +3766,16 @@ func (a *App) ListProjectTree() []ProjectNode {
 		go func() {
 			defer wg.Done()
 
-			// Compute signature cheaply (ReadDir + Stat, no file content).
-			sig, _, err := topicSessionDirSnapshot(dir)
-			if err != nil {
-				return
-			}
-
-			// Disk cache check: signature match avoids LoadBranchMeta + JSONL decode.
-			if entry, ok := sessionDiskCacher.getDir(dir, sig); ok {
-				infos := fromSessionInfoJSON(entry.Sessions)
-				titles := entry.Titles
-				if titles == nil {
-					titles = map[string]string{}
-				}
-				projectSessionCache.put(dir, infos, titles, cacheToken)
-				mergeMu.Lock()
-				mergeSessionInfos(dir, infos, titles, sessionInfos, sessionTitles, topicSummaries)
-				mergeMu.Unlock()
-				return
-			}
-
-			// Full read from disk (slow path).
+			// Sidecar-backed listing: ListSessions reads turn count + preview from
+			// each session's .meta sidecar, so even large directories list in a few
+			// milliseconds without decoding any .jsonl body. The in-memory
+			// projectSessionCache still elides repeat listings within a session.
 			infos, err := agent.ListSessions(dir)
 			if err != nil {
 				return
 			}
 			titles := loadSessionTitles(dir)
 			projectSessionCache.put(dir, infos, titles, cacheToken)
-
-			// Persist to disk cache for next startup.
-			_ = sessionDiskCacher.putDir(dir, sig, infos, titles)
 
 			mergeMu.Lock()
 			mergeSessionInfos(dir, infos, titles, sessionInfos, sessionTitles, topicSummaries)
@@ -4587,179 +4566,6 @@ func mergeSessionInfos(dir string, infos []agent.SessionInfo, titles map[string]
 		topicSummaries[key] = summary
 	}
 }
-
-// --- session listing disk cache -------------------------------------------------
-
-// sessionDiskCache persists ListSessions results to disk so that the project tree
-// populates immediately on restart instead of re-reading every session file. It
-// uses the same directory-level signature (file name + mtime + size) that
-// topicSessionDirSnapshot computes — if the signature matches, the cache is valid.
-//
-// Cache file: ~/.reasonix/project-session-cache.json
-
-type sessionDiskCache struct {
-	mu    sync.Mutex
-	path  string                // cache file path
-	cache *sessionDiskCacheData // nil = not loaded / stale
-}
-
-type sessionDiskCacheData struct {
-	Version int                                 `json:"version"`
-	Updated time.Time                           `json:"updated_at"`
-	ByDir   map[string]sessionDiskCacheDirEntry `json:"dirs"`
-}
-
-type sessionDiskCacheDirEntry struct {
-	Signature []topicSessionFileSignature `json:"signature"`
-	Sessions  []sessionInfoJSON           `json:"sessions"`
-	Titles    map[string]string           `json:"titles"`
-}
-
-// sessionInfoJSON is the JSON-safe representation of agent.SessionInfo for disk.
-type sessionInfoJSON struct {
-	Path           string    `json:"path"`
-	CreatedAt      time.Time `json:"created_at"`
-	LastActivityAt time.Time `json:"last_activity_at"`
-	Preview        string    `json:"preview"`
-	Turns          int       `json:"turns"`
-	Scope          string    `json:"scope"`
-	WorkspaceRoot  string    `json:"workspace_root"`
-	TopicID        string    `json:"topic_id"`
-	TopicTitle     string    `json:"topic_title"`
-}
-
-const sessionDiskCacheVersion = 1
-
-func (c *sessionDiskCache) load() (*sessionDiskCacheData, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.cache != nil {
-		return c.cache, nil
-	}
-	if c.path == "" {
-		c.path = filepath.Join(config.MemoryUserDir(), "project-session-cache.json")
-	}
-	data, err := os.ReadFile(c.path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			c.cache = &sessionDiskCacheData{Version: sessionDiskCacheVersion, ByDir: map[string]sessionDiskCacheDirEntry{}}
-			return c.cache, nil
-		}
-		return nil, err
-	}
-	var d sessionDiskCacheData
-	if err := json.Unmarshal(data, &d); err != nil {
-		return nil, err
-	}
-	if d.Version != sessionDiskCacheVersion {
-		c.cache = &sessionDiskCacheData{Version: sessionDiskCacheVersion, ByDir: map[string]sessionDiskCacheDirEntry{}}
-		return c.cache, nil
-	}
-	if d.ByDir == nil {
-		d.ByDir = map[string]sessionDiskCacheDirEntry{}
-	}
-	c.cache = &d
-	return c.cache, nil
-}
-
-func (c *sessionDiskCache) getDir(dir string, signature []topicSessionFileSignature) (*sessionDiskCacheDirEntry, bool) {
-	key := topicSessionDirKey(dir)
-	if key == "" {
-		return nil, false
-	}
-	data, err := c.load()
-	if err != nil {
-		return nil, false
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	entry, ok := data.ByDir[key]
-	if !ok || !topicSessionSignaturesEqual(entry.Signature, signature) {
-		return nil, false
-	}
-	return &entry, true
-}
-
-func (c *sessionDiskCache) putDir(dir string, signature []topicSessionFileSignature, sessions []agent.SessionInfo, titles map[string]string) error {
-	key := topicSessionDirKey(dir)
-	if key == "" {
-		return nil
-	}
-	data, err := c.load()
-	if err != nil {
-		return err
-	}
-	entry := sessionDiskCacheDirEntry{
-		Signature: signature,
-		Sessions:  toSessionInfoJSON(sessions),
-		Titles:    titles,
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	data.ByDir[key] = entry
-	data.Updated = time.Now()
-	raw, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return err
-	}
-	path := c.path
-	if path == "" {
-		path = filepath.Join(config.MemoryUserDir(), "project-session-cache.json")
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(path, raw, 0o644)
-}
-
-func (c *sessionDiskCache) invalidate() {
-	c.mu.Lock()
-	c.cache = nil
-	c.mu.Unlock()
-	// Remove the file so a crash mid-write does not leave stale data.
-	if c.path != "" {
-		os.Remove(c.path)
-	}
-}
-
-func toSessionInfoJSON(sessions []agent.SessionInfo) []sessionInfoJSON {
-	out := make([]sessionInfoJSON, len(sessions))
-	for i, s := range sessions {
-		out[i] = sessionInfoJSON{
-			Path:           s.Path,
-			CreatedAt:      s.CreatedAt,
-			LastActivityAt: s.LastActivityAt,
-			Preview:        s.Preview,
-			Turns:          s.Turns,
-			Scope:          s.Scope,
-			WorkspaceRoot:  s.WorkspaceRoot,
-			TopicID:        s.TopicID,
-			TopicTitle:     s.TopicTitle,
-		}
-	}
-	return out
-}
-
-func fromSessionInfoJSON(list []sessionInfoJSON) []agent.SessionInfo {
-	out := make([]agent.SessionInfo, len(list))
-	for i, s := range list {
-		out[i] = agent.SessionInfo{
-			Path:           s.Path,
-			CreatedAt:      s.CreatedAt,
-			LastActivityAt: s.LastActivityAt,
-			ModTime:        s.LastActivityAt,
-			Preview:        s.Preview,
-			Turns:          s.Turns,
-			Scope:          s.Scope,
-			WorkspaceRoot:  s.WorkspaceRoot,
-			TopicID:        s.TopicID,
-			TopicTitle:     s.TopicTitle,
-		}
-	}
-	return out
-}
-
-var sessionDiskCacher = &sessionDiskCache{}
 
 var topicSessionIndexCache = struct {
 	sync.Mutex

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -144,63 +144,12 @@ func TestSessionListCacheRefillsAfterInvalidate(t *testing.T) {
 	}
 }
 
-func TestSessionDiskCachePersistsDirectorySignatures(t *testing.T) {
-	cachePath := filepath.Join(t.TempDir(), "project-session-cache.json")
-	dir := t.TempDir()
-	sessionPath := filepath.Join(dir, "one.jsonl")
-	signature := []topicSessionFileSignature{{
-		Name:    "one.jsonl",
-		Size:    42,
-		ModTime: time.Now().UnixNano(),
-	}}
-	session := agent.SessionInfo{
-		Path:           sessionPath,
-		CreatedAt:      time.Now().Add(-time.Minute),
-		LastActivityAt: time.Now(),
-		Preview:        "hello",
-		Turns:          1,
-		Scope:          "project",
-		WorkspaceRoot:  dir,
-		TopicID:        "topic-cache",
-		TopicTitle:     "Cache",
-	}
-
-	writer := &sessionDiskCache{path: cachePath}
-	if err := writer.putDir(dir, signature, []agent.SessionInfo{session}, map[string]string{"one.jsonl": "One"}); err != nil {
-		t.Fatalf("putDir: %v", err)
-	}
-	raw, err := os.ReadFile(cachePath)
-	if err != nil {
-		t.Fatalf("read cache: %v", err)
-	}
-	if text := string(raw); !strings.Contains(text, `"name": "one.jsonl"`) {
-		t.Fatalf("signature was not persisted with exported fields: %s", text)
-	}
-
-	reader := &sessionDiskCache{path: cachePath}
-	entry, ok := reader.getDir(dir, signature)
-	if !ok {
-		t.Fatalf("expected disk cache hit after reload")
-	}
-	if len(entry.Sessions) != 1 || entry.Sessions[0].Path != sessionPath || entry.Titles["one.jsonl"] != "One" {
-		t.Fatalf("disk cache entry = %+v", entry)
-	}
-	changed := append([]topicSessionFileSignature(nil), signature...)
-	changed[0].Size++
-	if _, ok := reader.getDir(dir, changed); ok {
-		t.Fatalf("disk cache hit with changed signature")
-	}
-}
-
 func TestRenameSessionInvalidatesProjectTreeCache(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	oldProjectCache := projectSessionCache
-	oldDiskCache := sessionDiskCacher
 	projectSessionCache = &sessionListCache{byDir: map[string]sessionListCacheEntry{}}
-	sessionDiskCacher = &sessionDiskCache{path: filepath.Join(t.TempDir(), "project-session-cache.json")}
 	t.Cleanup(func() {
 		projectSessionCache = oldProjectCache
-		sessionDiskCacher = oldDiskCache
 	})
 
 	dir := t.TempDir()

--- a/internal/agent/listsessions_bench_test.go
+++ b/internal/agent/listsessions_bench_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -114,4 +115,71 @@ func writeSyntheticSessions(t *testing.T, dir string, n, turns int) int64 {
 		}
 	}
 	return total
+}
+
+// TestColdStartProjectTreeManual measures the steady-state cold-start cost that
+// remains AFTER removing the desktop project-session-cache.json disk cache: a
+// heavy user spread across many workspaces, every session already carrying
+// sidecar Turns/Preview. It mirrors ListProjectTree's per-dir fan-out. The point
+// is to confirm the disk cache is now redundant — sidecar-only listing of the
+// whole tree is already in the low-millisecond range on cold start.
+//
+//	REASONIX_BENCH=1 go test ./internal/agent -run TestColdStartProjectTreeManual -v
+func TestColdStartProjectTreeManual(t *testing.T) {
+	if os.Getenv("REASONIX_BENCH") != "1" {
+		t.Skip("set REASONIX_BENCH=1 to run the cold-start benchmark")
+	}
+
+	const (
+		workspaces = 15
+		perDir     = 200
+		turns      = 25
+	)
+	root := t.TempDir()
+	dirs := make([]string, workspaces)
+	var onDisk int64
+	for w := range workspaces {
+		dir := filepath.Join(root, fmt.Sprintf("ws-%02d", w))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		dirs[w] = dir
+		onDisk += writeSyntheticSessions(t, dir, perDir, turns)
+		// Warm the sidecars (Turns/Preview), i.e. the steady state a real user is
+		// in after the one-time backfill — this is what cold start reads.
+		if _, err := ListSessions(dir); err != nil {
+			t.Fatalf("warm ListSessions: %v", err)
+		}
+	}
+
+	// Sequential cold start (sum over dirs).
+	start := time.Now()
+	seqTotal := 0
+	for _, dir := range dirs {
+		infos, err := ListSessions(dir)
+		if err != nil {
+			t.Fatalf("ListSessions: %v", err)
+		}
+		seqTotal += len(infos)
+	}
+	seqDur := time.Since(start)
+
+	// Concurrent fan-out, the way ListProjectTree actually loads dirs.
+	start = time.Now()
+	var wg sync.WaitGroup
+	counts := make([]int, len(dirs))
+	for i, dir := range dirs {
+		wg.Add(1)
+		go func(i int, dir string) {
+			defer wg.Done()
+			infos, _ := ListSessions(dir)
+			counts[i] = len(infos)
+		}(i, dir)
+	}
+	wg.Wait()
+	concDur := time.Since(start)
+
+	t.Logf("workspaces=%d sessions/dir=%d totalSessions=%d onDisk=%.0fMB | cold start sequential=%v | cold start concurrent(fan-out)=%v",
+		workspaces, perDir, seqTotal, float64(onDisk)/(1<<20),
+		seqDur.Round(time.Millisecond), concDur.Round(time.Millisecond))
 }


### PR DESCRIPTION
Follow-up to #4882 (sidecar turn-count/preview caching). Removes the `project-session-cache.json` disk cache, which that change made redundant.

## Why

`ListSessions` now reads turn count + preview from each session's `.meta` sidecar, so listing is O(small sidecar reads) — a few ms even for thousands of sessions. The `sessionDiskCache` layer existed to skip re-reading session files on restart, but:

- It now saves only **single-digit milliseconds** on cold start (it still does its own `ReadDir`+`Stat` for the signature; all it avoids is the cheap sidecar reads).
- It carries a whole consistency surface: a **per-directory** signature (`name+size+mtime` of every `.jsonl`/`.jsonl.meta`) that is busted by **every new message** (the active session's size/mtime change), forcing a full re-list of the directory on each sidebar refresh during active use, plus a full-file rewrite of the cache JSON on every change and whole-file deletion on every invalidate.

Net: it stopped pulling its weight and actively hurt the active-use path.

## What

- Remove `sessionDiskCache` (type + `load`/`getDir`/`putDir`/`invalidate`), its JSON model (`sessionDiskCacheData`/`DirEntry`/`sessionInfoJSON`/`toSessionInfoJSON`/`fromSessionInfoJSON`/version), and `sessionDiskCacher`.
- `ListProjectTree`'s per-dir goroutine now calls `agent.ListSessions(dir)` directly, still fronted by the in-memory `projectSessionCache`.
- Drop the `sessionDiskCacher.invalidate()` call from `emitProjectTreeChanged`.
- Keep `topicSessionDirSnapshot` / `topicSessionFileSignature` / `topicSessionSignaturesEqual` / `topicSessionDirKey` — `topicSessionIndexCache` still uses them.
- A leftover `project-session-cache.json` on disk is simply ignored (nothing reads it).

Net **−177 lines**.

## Cold-start benchmark (added, `REASONIX_BENCH`-gated)

Confirms the disk layer is no longer worth its cost — sidecar-only listing of the whole tree:

| Scale | Sequential | Concurrent (fan-out) |
|---|---|---|
| 15 workspaces × 200 sessions (3000 total, 1.2 GB) | 98 ms | **27 ms** |

## Verification

Local: `gofmt`/`go vet` clean on the agent package; `internal/agent` tests pass; the desktop module can't build locally (cgo/webkit toolchain), so its `go build` + `go test` + `golangci-lint` are verified by the **desktop CI job** on this PR.