### PR TITLE
feat: add /orchestrate command for project conductor mode

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1171,6 +1171,9 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 		case "/prometheus":
 			c.applyPrometheus(trimmed, display)
 			return
+		case "/orchestrate":
+			c.applyOrchestrate(trimmed, display)
+			return
 		}
 		if c.managementNotice(trimmed) {
 			return
@@ -1390,6 +1393,21 @@ func (c *Controller) applyPlanExec(input, display string) {
 // prometheusPrompt is the strategic planner system prompt.
 const prometheusPrompt = "You are Prometheus, a strategic planner. Interview the user one question at a time. Cover: scope, modules, files, constraints, tests. When ready, output a numbered plan with each step tagged by module. End with [goal:complete]. Do not implement.\n\nFor independent research directions, use parallel_tasks before planning."
 
+
+// orchestratePrompt is the system prompt for the project conductor mode.
+const orchestratePrompt = `You are the project conductor, coordinating a team of specialist sub-agents. Your model (Pro) handles planning and review; delegate execution to specialist sub-agents.
+
+Process:
+1. Analyze the user’s request and break it into independent work items
+2. For EACH independent item, dispatch a sub-agent using parallel_tasks
+3. Each sub-agent gets one clear goal and its relevant context
+4. After all sub-agents finish, review their outputs
+5. Summarize what was done, what needs follow-up, and end with [goal:complete]
+
+Key rules:
+- Delegate, don’t do it yourself — your job is coordination
+- One sub-agent per independent work item
+- Each sub-agent’s prompt must be self-contained (assume no shared context)`
 // applyPrometheus starts an interactive planning interview, inspired by OMO's
 // Prometheus agent. It enters goal mode with a structured interview prompt.
 func (c *Controller) applyPrometheus(input, display string) {
@@ -1408,6 +1426,32 @@ func (c *Controller) applyPrometheus(input, display string) {
 	c.SetGoal("plan: " + ShortGoalForNotice(args))
 	c.GoalStrict(strict)
 	c.notice("prometheus: starting planning interview")
+	if c.runner != nil {
+		c.runGuarded(func(ctx context.Context) error {
+			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)
+		})
+	}
+}
+
+// applyOrchestrate starts a project conductor mode that delegates work to
+// multiple sub-agents via parallel_tasks.
+func (c *Controller) applyOrchestrate(input, display string) {
+	args := strings.TrimSpace(strings.TrimPrefix(input, "/orchestrate"))
+	if args == "" {
+		c.notice("usage: /orchestrate <project description>")
+		return
+	}
+	c.mu.Lock()
+	hasGoal := c.goal != "" && c.goalStatus == GoalStatusRunning
+	c.mu.Unlock()
+	if hasGoal {
+		c.notice("orchestrate: a goal is already running; use /goal clear first")
+		return
+	}
+	prompt := orchestratePrompt + "\n\n## Project request\n\n" + args + "\n\nBegin by analyzing the request and dispatching sub-agents."
+	c.SetPlanMode(false)
+	c.SetGoal("orchestrate: " + ShortGoalForNotice(args))
+	c.notice("orchestrate: starting project conductor mode")
 	if c.runner != nil {
 		c.runGuarded(func(ctx context.Context) error {
 			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1393,7 +1393,6 @@ func (c *Controller) applyPlanExec(input, display string) {
 // prometheusPrompt is the strategic planner system prompt.
 const prometheusPrompt = "You are Prometheus, a strategic planner. Interview the user one question at a time. Cover: scope, modules, files, constraints, tests. When ready, output a numbered plan with each step tagged by module. End with [goal:complete]. Do not implement.\n\nFor independent research directions, use parallel_tasks before planning."
 
-
 // orchestratePrompt is the system prompt for the project conductor mode.
 const orchestratePrompt = `You are the project conductor, coordinating a team of specialist sub-agents. Your model (Pro) handles planning and review; delegate execution to specialist sub-agents.
 
@@ -1408,6 +1407,7 @@ Key rules:
 - Delegate, don’t do it yourself — your job is coordination
 - One sub-agent per independent work item
 - Each sub-agent’s prompt must be self-contained (assume no shared context)`
+
 // applyPrometheus starts an interactive planning interview, inspired by OMO's
 // Prometheus agent. It enters goal mode with a structured interview prompt.
 func (c *Controller) applyPrometheus(input, display string) {
@@ -1455,8 +1455,8 @@ func (c *Controller) applyOrchestrate(input, display string) {
 	}
 	prompt := orchestratePrompt + "\n\n## Project request\n\n" + args + "\n\nBegin by analyzing the request and dispatching sub-agents."
 	c.SetPlanMode(false)
-	c.GoalStrict(strict)
 	c.SetGoal("orchestrate: " + ShortGoalForNotice(args))
+	c.GoalStrict(strict)
 	c.notice(fmt.Sprintf("orchestrate: starting project conductor mode (strict=%v)", strict))
 	if c.runner != nil {
 		c.runGuarded(func(ctx context.Context) error {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1437,9 +1437,14 @@ func (c *Controller) applyPrometheus(input, display string) {
 // multiple sub-agents via parallel_tasks.
 func (c *Controller) applyOrchestrate(input, display string) {
 	args := strings.TrimSpace(strings.TrimPrefix(input, "/orchestrate"))
-	if args == "" {
+	if args == "" || args == "--strict" {
 		c.notice("usage: /orchestrate <project description>")
 		return
+	}
+	strict := false
+	if strings.HasPrefix(args, "--strict ") {
+		strict = true
+		args = strings.TrimPrefix(args, "--strict ")
 	}
 	c.mu.Lock()
 	hasGoal := c.goal != "" && c.goalStatus == GoalStatusRunning
@@ -1450,8 +1455,9 @@ func (c *Controller) applyOrchestrate(input, display string) {
 	}
 	prompt := orchestratePrompt + "\n\n## Project request\n\n" + args + "\n\nBegin by analyzing the request and dispatching sub-agents."
 	c.SetPlanMode(false)
+	c.GoalStrict(strict)
 	c.SetGoal("orchestrate: " + ShortGoalForNotice(args))
-	c.notice("orchestrate: starting project conductor mode")
+	c.notice(fmt.Sprintf("orchestrate: starting project conductor mode (strict=%v)", strict))
 	if c.runner != nil {
 		c.runGuarded(func(ctx context.Context) error {
 			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)


### PR DESCRIPTION
## 改动

新增 `/orchestrate` 命令，启动项目指挥模式。

### 工作流
```
/orchestrate 推进5个PR的改进
  ↓
AI 作为项目经理分析请求，拆解为独立工作项
  ↓
用 parallel_tasks 分配给子 agent 并行执行
  ↓
全部完成后汇总 review
```

### 改动细节
- 命令注册：`submitCommandOrTurn` switch 新增 `/orchestrate` case
- `orchestratePrompt`：Go raw string，明确要求 delegate 而非自己执行
- `applyOrchestrate()`：启动 goal 循环 + 安全检查（已有 goal 时拒绝）
- 支持 `--strict` 标志（与 `/prometheus` 对齐）

### 与 `/prometheus` 对比
| 维度 | /prometheus | /orchestrate |
|------|------------|-------------|
| 模式 | 先访谈后出计划 | 直接拆解并派发 |
| 执行方式 | 用户批准后执行 | 通过 parallel_tasks 自动派发 |
| `--strict` 支持 | ✅ | ✅ |
| 安全检查 | 无 | 有（检查已有 goal） |

## 文件
只改了 `internal/control/controller.go`，+44 行。

Cache-impact: none — controller.go 不在 cache-sensitive 路径