### PR TITLE
perf(control): move memory-write disk I/O off the controller lock

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -68,18 +68,24 @@ type Controller struct {
 	sink     event.Sink
 	policy   permission.Policy
 
-	label             string
-	modelRef          string
-	systemPrompt      string
-	sessionDir        string
-	host              *plugin.Host
-	commands          []command.Command
-	skills            []skill.Skill
-	allSkills         []skill.Skill
-	skillStore        *skill.Store
-	allSkillStore     *skill.Store
-	hooks             *hook.Runner // session hook runner; nil-safe (no hooks configured)
-	mem               *memory.Set
+	label         string
+	modelRef      string
+	systemPrompt  string
+	sessionDir    string
+	host          *plugin.Host
+	commands      []command.Command
+	skills        []skill.Skill
+	allSkills     []skill.Skill
+	skillStore    *skill.Store
+	allSkillStore *skill.Store
+	hooks         *hook.Runner // session hook runner; nil-safe (no hooks configured)
+	mem           *memory.Set
+	// memMu serializes memory mutations (QuickAdd/SaveDoc/SaveMemory/ForgetMemory/
+	// QueueMemory) so each write+reload+swap is atomic with respect to the others,
+	// WITHOUT holding c.mu across the disk I/O. c.mu is taken only briefly — to read
+	// the snapshot pointer and to swap the reloaded snapshot in — never around a
+	// filesystem walk, so a memory-panel save can't stall an approval or status poll.
+	memMu             sync.Mutex
 	cleanup           func()
 	autoPlan          string
 	reasoningLanguage string
@@ -3253,42 +3259,45 @@ func (c *Controller) Bypass() bool {
 
 // --- memory ---
 //
-// c.mem is treated as an immutable snapshot guarded by c.mu: reads take the lock
-// and return the pointer; writes mutate disk then swap in a freshly discovered
-// snapshot. A turn-tail note is queued for each write so the change applies this
-// session without disturbing the cache-stable system prefix (it folds into the
-// prefix on the next session). All of these are no-ops returning "" when memory
-// is disabled.
+// c.mem is an immutable snapshot: reads take c.mu briefly and return the pointer.
+// Writes are serialized by memMu and do their disk I/O (the doc/store write plus
+// the memory.Load re-discovery) OFF c.mu, taking c.mu only to read the snapshot
+// pointer and to swap the freshly discovered snapshot in — so a write never holds
+// c.mu across a filesystem walk. A turn-tail note is queued for each write so the
+// change applies this session without disturbing the cache-stable system prefix
+// (it folds into the prefix on the next session). All of these are no-ops
+// returning "" when memory is disabled.
 
 // QuickAdd appends a one-line note to the doc-memory file for scope (project
 // REASONIX.md by default) — the write side of "#<note>". Returns the file written.
 func (c *Controller) QuickAdd(scope memory.Scope, note string) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.mem == nil {
+	c.memMu.Lock()
+	defer c.memMu.Unlock()
+	mem := c.memSnapshot()
+	if mem == nil {
 		return "", nil
 	}
-	path := c.mem.DocPath(scope)
+	path := mem.DocPath(scope)
 	if path == "" {
 		return "", fmt.Errorf("no target file for memory scope %q", scope)
 	}
 	if err := memory.AppendDoc(path, note); err != nil {
 		return "", err
 	}
-	c.pendingMemory = append(c.pendingMemory, note)
-	c.refreshMemoryLocked()
+	c.applyMemoryWrite(mem, note)
 	return path, nil
 }
 
 // SaveDoc overwrites a recognized memory doc with body — the save side of the
 // desktop panel's in-place editor. Returns the file written.
 func (c *Controller) SaveDoc(path, body string) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.mem == nil {
+	c.memMu.Lock()
+	defer c.memMu.Unlock()
+	mem := c.memSnapshot()
+	if mem == nil {
 		return "", nil
 	}
-	written, err := c.mem.WriteDoc(path, body)
+	written, err := mem.WriteDoc(path, body)
 	if err != nil {
 		return "", err
 	}
@@ -3296,9 +3305,8 @@ func (c *Controller) SaveDoc(path, body string) (string, error) {
 	// the pre-edit version this session, so handing the model the current text
 	// avoids a stale-guidance gap until the next session re-folds it into the
 	// prefix. Trimmed to a single tail note (drained by Compose), not per-turn.
-	c.pendingMemory = append(c.pendingMemory,
+	c.applyMemoryWrite(mem,
 		"Memory file "+written+" was just edited. Its current contents:\n"+strings.TrimSpace(body))
-	c.refreshMemoryLocked()
 	return written, nil
 }
 
@@ -3306,18 +3314,18 @@ func (c *Controller) SaveDoc(path, body string) (string, error) {
 // snapshot. It is the explicit user-confirmed counterpart to the model-owned
 // remember tool, used by management surfaces that preview a candidate first.
 func (c *Controller) SaveMemory(m memory.Memory) (string, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.mem == nil {
+	c.memMu.Lock()
+	defer c.memMu.Unlock()
+	mem := c.memSnapshot()
+	if mem == nil {
 		return "", nil
 	}
-	path, err := c.mem.Store.Save(m)
+	path, err := mem.Store.Save(m)
 	if err != nil {
 		return "", err
 	}
-	c.pendingMemory = append(c.pendingMemory,
+	c.applyMemoryWrite(mem,
 		"Saved memory \""+m.Name+"\": "+strings.Join(strings.Fields(m.Description), " "))
-	c.refreshMemoryLocked()
 	return path, nil
 }
 
@@ -3327,17 +3335,17 @@ func (c *Controller) SaveMemory(m memory.Memory) (string, error) {
 // until the next session re-folds the index). The file is archived for
 // traceability by Store.Delete.
 func (c *Controller) ForgetMemory(name string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if c.mem == nil {
+	c.memMu.Lock()
+	defer c.memMu.Unlock()
+	mem := c.memSnapshot()
+	if mem == nil {
 		return nil
 	}
-	if err := c.mem.Store.Delete(name); err != nil {
+	if err := mem.Store.Delete(name); err != nil {
 		return err
 	}
-	c.pendingMemory = append(c.pendingMemory,
+	c.applyMemoryWrite(mem,
 		"Forgot memory \""+name+"\" — disregard its line still shown in the saved-memories index until next session.")
-	c.refreshMemoryLocked()
 	return nil
 }
 
@@ -3346,10 +3354,17 @@ func (c *Controller) ForgetMemory(name string) error {
 // applies this session without touching the cache-stable prefix. It also
 // refreshes the snapshot a memory panel reads.
 func (c *Controller) QueueMemory(note string) {
+	c.memMu.Lock()
+	defer c.memMu.Unlock()
+	if mem := c.memSnapshot(); mem != nil {
+		c.applyMemoryWrite(mem, note)
+		return
+	}
+	// Memory disabled — still queue the turn-tail note; there's no snapshot to
+	// re-discover.
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.pendingMemory = append(c.pendingMemory, note)
-	c.refreshMemoryLocked()
+	c.mu.Unlock()
 }
 
 // Memory returns the loaded memory snapshot (nil when memory is disabled), for
@@ -3361,13 +3376,28 @@ func (c *Controller) Memory() *memory.Set {
 	return c.mem
 }
 
-// refreshMemoryLocked re-discovers memory from disk so a later Memory() reflects
-// a just-applied write. Caller holds c.mu.
-func (c *Controller) refreshMemoryLocked() {
-	if c.mem == nil {
-		return
+// memSnapshot returns the current memory snapshot under a brief c.mu, so callers
+// can do the doc/store write and re-discovery off-lock. Holding memMu keeps the
+// returned pointer current until the matching applyMemoryWrite swaps it in.
+func (c *Controller) memSnapshot() *memory.Set {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mem
+}
+
+// applyMemoryWrite re-discovers memory from disk (off-lock, the expensive part)
+// then, under a brief c.mu, swaps the fresh snapshot in and queues the turn-tail
+// note so a later Memory() reflects the just-applied write. mem is the snapshot
+// taken at the start of the memMu-serialized write and supplies the discovery
+// roots. Callers hold memMu.
+func (c *Controller) applyMemoryWrite(mem *memory.Set, note string) {
+	reloaded := memory.Load(memory.Options{CWD: mem.CWD, UserDir: mem.UserDir})
+	c.mu.Lock()
+	if note != "" {
+		c.pendingMemory = append(c.pendingMemory, note)
 	}
-	c.mem = memory.Load(memory.Options{CWD: c.mem.CWD, UserDir: c.mem.UserDir})
+	c.mem = reloaded
+	c.mu.Unlock()
 }
 
 // --- approval bridge (agent gate → events) ---

--- a/internal/control/memory_test.go
+++ b/internal/control/memory_test.go
@@ -1,0 +1,103 @@
+package control
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"reasonix/internal/memory"
+)
+
+// TestMemoryWriteReflectsInSnapshot verifies that a memory write lands on disk
+// and that Memory() returns a freshly reloaded snapshot afterwards — the behavior
+// the off-c.mu (memMu) refactor must preserve.
+func TestMemoryWriteReflectsInSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	c := New(Options{Memory: memory.Load(memory.Options{CWD: dir})})
+
+	before := c.Memory()
+	if before == nil {
+		t.Fatal("memory should be enabled")
+	}
+
+	path, err := c.QuickAdd(memory.ScopeProject, "prefer tabs over spaces")
+	if err != nil {
+		t.Fatalf("QuickAdd: %v", err)
+	}
+
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read doc: %v", err)
+	}
+	if !strings.Contains(string(body), "prefer tabs over spaces") {
+		t.Fatalf("note not written to disk:\n%s", body)
+	}
+
+	after := c.Memory()
+	if after == nil {
+		t.Fatal("memory snapshot is nil after QuickAdd")
+	}
+	if after == before {
+		t.Fatal("Memory() returned the stale snapshot; applyMemoryWrite did not swap in a reload")
+	}
+}
+
+// TestMemoryWritesConcurrencySafe hammers memory writes from many goroutines
+// while c.mu-guarded reads run concurrently. Under -race this proves the new
+// memMu/c.mu split has no data race and no deadlock — and that holding memMu
+// (not c.mu) across the disk I/O still serializes writes so every note lands.
+func TestMemoryWritesConcurrencySafe(t *testing.T) {
+	dir := t.TempDir()
+	c := New(Options{Memory: memory.Load(memory.Options{CWD: dir})})
+
+	const writers = 8
+	const each = 5
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = c.Running()       // takes c.mu
+				_ = c.RuntimeStatus() // takes c.mu
+				_ = c.Memory()        // takes c.mu, returns the snapshot pointer
+			}
+		}
+	}()
+
+	var writersWG sync.WaitGroup
+	for w := range writers {
+		writersWG.Add(1)
+		go func(w int) {
+			defer writersWG.Done()
+			for i := range each {
+				if _, err := c.QuickAdd(memory.ScopeProject, fmt.Sprintf("note w%d-%d", w, i)); err != nil {
+					t.Errorf("QuickAdd: %v", err)
+				}
+			}
+		}(w)
+	}
+	writersWG.Wait()
+	close(stop)
+	readers.Wait()
+
+	body, err := os.ReadFile(c.Memory().DocPath(memory.ScopeProject))
+	if err != nil {
+		t.Fatalf("read doc: %v", err)
+	}
+	for w := range writers {
+		for i := range each {
+			want := fmt.Sprintf("note w%d-%d", w, i)
+			if !strings.Contains(string(body), want) {
+				t.Fatalf("memory doc missing %q after concurrent writes:\n%s", want, body)
+			}
+		}
+	}
+}


### PR DESCRIPTION
First slice of the architecture-review finding "disk I/O and executor calls under `c.mu`" (which can stall approvals/status polls).

## Problem

The memory mutators — `QuickAdd`, `SaveDoc`, `SaveMemory`, `ForgetMemory`, `QueueMemory` — held `c.mu` across **both** the doc/store write **and** `refreshMemoryLocked` → `memory.Load` (a filesystem walk of the memory roots). Since `requestApproval`, `RuntimeStatus`, and `Running` also take `c.mu`, a memory-panel save (or the model's `remember`/`forget` tool) could block an approval decision or a UI status poll for the duration of that I/O.

## Fix

- Add a dedicated `memMu` that serializes memory mutations so each write+reload+swap stays atomic with respect to the others.
- Do the disk I/O **off `c.mu`**: `c.mu` is now taken only briefly to read the snapshot pointer (`memSnapshot`) and to swap the freshly reloaded snapshot in + queue the turn-tail note (`applyMemoryWrite`). It is never held around the doc/store write or the `memory.Load` re-discovery.
- `refreshMemoryLocked` is removed; the lock-ordering is always `memMu` → (brief) `c.mu`, with no path taking `c.mu` before `memMu`, so no inversion.

Write semantics are unchanged: writes are still serialized with respect to each other, still queue a turn-tail note, and are still reflected by the next `Memory()`. `QueueMemory` still queues its note even when memory is disabled.

## Tests

- `TestMemoryWriteReflectsInSnapshot` — a write lands on disk and `Memory()` returns a freshly reloaded snapshot (not the stale pointer).
- `TestMemoryWritesConcurrencySafe` — 8 writers × 5 notes with concurrent `c.mu`-guarded readers (`Running`/`RuntimeStatus`/`Memory`); passes under `-race`, proving no data race or deadlock in the new split and that every note still lands.

`go test -race ./internal/control` green; `gofmt`/`go vet` clean.

## Not in scope

The hotter goal-state path (`saveGoalState` writes under `c.mu`, 6 call sites inside the goal FSM) is more entangled and is left for a separate change — ideally alongside extracting the goal FSM into its own collaborator.