### PR TITLE
perf(desktop): sidebar resilience - timeout, debounce, result cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 /bin/
+/build/
 /dist/
 /stage/
 /npm/.stage/

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -52,10 +53,26 @@ import (
 // `data:` frames.
 const eventChannel = "agent:event"
 
-// singleInstanceID is used by Wails to route a second desktop launch back to the
-// running instance. Keep it stable across releases so launcher/Dock/taskbar
-// reopen behavior remains predictable on every platform.
-const singleInstanceID = "com.reasonix.desktop"
+// singleInstanceID derives a lock ID from the binary's absolute path so that
+// binaries at different paths (e.g. a dev build vs. a packaged release .app)
+// get distinct single-instance locks and can run simultaneously. The driver is
+// `com.reasonix.desktop.<SHA256-of-path[:8]>` — the static prefix keeps the
+// names recognisable in system logs.
+//
+// When REASONIX_DEV is set, the lock is skipped entirely (see single_instance.go)
+// so contributors can run any number of dev instances without copying.
+func singleInstanceID() string {
+	abs, err := os.Executable()
+	if err != nil {
+		return "com.reasonix.desktop"
+	}
+	abs, err = filepath.EvalSymlinks(abs)
+	if err != nil {
+		abs, _ = filepath.Abs(abs)
+	}
+	h := sha256.Sum256([]byte(abs))
+	return "com.reasonix.desktop." + hex.EncodeToString(h[:8])
+}
 
 // PromptHistoryEntry is one user prompt extracted from a session JSONL file.
 // The frontend uses these for ↑/↓ prompt-history navigation.

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -18824,6 +18824,10 @@ a[href] {
   border-bottom-color: var(--border-soft);
 }
 
+:root[data-theme="light"] .topicbar {
+  background: #ffffff;
+}
+
 .app--darwin .app-chrome--tabs {
   padding-right: calc(var(--chrome-toggle-size) + var(--chrome-toggle-size) + 16px);
   background: color-mix(in srgb, var(--bg-soft) 90%, var(--bg-elev));

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -50,7 +50,7 @@ func desktopSessionDir(root string) string {
 // loadSessionTitles reads the basename→title map (missing/corrupt → empty).
 func loadSessionTitles(dir string) map[string]string {
 	m := map[string]string{}
-	b, err := os.ReadFile(sessionTitlesPath(dir))
+	b, err := readFileWithTimeout(sessionTitlesPath(dir), topicFileReadTimeout)
 	if err != nil {
 		return m
 	}

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -50,7 +50,7 @@ func desktopSessionDir(root string) string {
 // loadSessionTitles reads the basename→title map (missing/corrupt → empty).
 func loadSessionTitles(dir string) map[string]string {
 	m := map[string]string{}
-	b, err := readFileWithTimeout(sessionTitlesPath(dir), topicFileReadTimeout)
+	b, err := os.ReadFile(sessionTitlesPath(dir))
 	if err != nil {
 		return m
 	}

--- a/desktop/single_instance.go
+++ b/desktop/single_instance.go
@@ -1,19 +1,12 @@
 package main
 
 import (
-	"os"
-
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
 func singleInstanceLock(app *App) *options.SingleInstanceLock {
-	// Allow contributors to run a dev build alongside the installed app.
-	// Set REASONIX_DEV=1 to skip the single-instance lock.
-	if os.Getenv("REASONIX_DEV") != "" {
-		return nil
-	}
 	return &options.SingleInstanceLock{
-		UniqueId: singleInstanceID,
+		UniqueId: singleInstanceID(),
 		OnSecondInstanceLaunch: func(options.SecondInstanceData) {
 			app.secondInstanceLaunch()
 		},

--- a/desktop/single_instance.go
+++ b/desktop/single_instance.go
@@ -1,10 +1,16 @@
 package main
 
 import (
+	"os"
+
 	"github.com/wailsapp/wails/v2/pkg/options"
 )
 
 func singleInstanceLock(app *App) *options.SingleInstanceLock {
+	// Allow contributors to run multiple dev instances from the same binary.
+	if os.Getenv("REASONIX_DEV") != "" {
+		return nil
+	}
 	return &options.SingleInstanceLock{
 		UniqueId: singleInstanceID(),
 		OnSecondInstanceLaunch: func(options.SecondInstanceData) {

--- a/desktop/single_instance_test.go
+++ b/desktop/single_instance_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -13,8 +14,12 @@ func TestSingleInstanceLockRestoresExistingInstance(t *testing.T) {
 	if lock == nil {
 		t.Fatal("singleInstanceLock returned nil")
 	}
-	if lock.UniqueId != singleInstanceID {
-		t.Fatalf("UniqueId = %q, want %q", lock.UniqueId, singleInstanceID)
+	id := singleInstanceID()
+	if lock.UniqueId != id {
+		t.Fatalf("UniqueId = %q, want %q", lock.UniqueId, id)
+	}
+	if !strings.HasPrefix(lock.UniqueId, "com.reasonix.desktop.") {
+		t.Fatalf("UniqueId = %q, want prefix com.reasonix.desktop.", lock.UniqueId)
 	}
 	if lock.OnSecondInstanceLaunch == nil {
 		t.Fatal("OnSecondInstanceLaunch should restore the existing window")

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4149,7 +4149,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 		for _, tid := range topicIDs {
 			topicTitle := strings.TrimSpace(titleMap[tid])
 			if topicTitle == "" {
-				topicTitle = topicTitleForTab("project", p.Root, tid)
+				topicTitle = defaultTopicTitle
 			}
 			summary := topicSummaries[topicSummaryKey("project", p.Root, tid)]
 			open, running, status := topicRuntimeStatus(topicSummaryKey("project", p.Root, tid))

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -4108,7 +4108,47 @@ func (a *App) ListProjectTree() []ProjectNode {
 
 	// Project sections.
 	slog.Info("ListProjectTree: processing projects", "elapsed", time.Since(buildStart).String(), "projects", len(f.Projects))
-	for _, p := range f.Projects {
+
+	// Load all project topic files concurrently since each is independent I/O
+	// and cloud storage paths (SynologyDrive, iCloud, etc.) may block or time
+	// out for up to readFileTimeout (200ms). Sequential loading with 15+ projects
+	// would multiply worst-case latency by the number of cloud-stored projects.
+	type projectTopics struct {
+		titles     map[string]string
+		createdAts map[string]int64
+	}
+	projectTopicResults := make([]struct {
+		root string
+		p    desktopProject
+		res  projectTopics
+	}, len(f.Projects))
+	var topicLoadWg sync.WaitGroup
+	topicLoadWg.Add(len(f.Projects))
+	for i, p := range f.Projects {
+		i, p := i, p
+		go func() {
+			defer topicLoadWg.Done()
+			projectTopicResults[i] = struct {
+				root string
+				p    desktopProject
+				res  projectTopics
+			}{
+				root: p.Root,
+				p:    p,
+				res: projectTopics{
+					titles:     loadTopicTitles(p.Root),
+					createdAts: loadTopicCreatedAts(p.Root),
+				},
+			}
+		}()
+	}
+	topicLoadWg.Wait()
+
+	for _, pt := range projectTopicResults {
+		p := pt.p
+		titleMap := pt.res.titles
+		createdMap := pt.res.createdAts
+
 		title := p.Title
 		if title == "" {
 			title = workspaceName(p.Root)
@@ -4121,10 +4161,6 @@ func (a *App) ListProjectTree() []ProjectNode {
 		}
 
 		// Gather topics: explicit topic list + all known topic titles.
-		slog.Info("ListProjectTree: loadTopicTitles", "root", p.Root, "elapsed", time.Since(buildStart).String())
-		titleMap := loadTopicTitles(p.Root)
-		slog.Info("ListProjectTree: loadTopicCreatedAts", "root", p.Root, "titles", len(titleMap), "elapsed", time.Since(buildStart).String())
-		createdMap := loadTopicCreatedAts(p.Root)
 		topicIDs := pinnedTopicIDs(orderedTopicIDs(p.Topics, titleMap), p.PinnedTopics)
 
 		children := make([]ProjectNode, 0, len(topicIDs))

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2693,6 +2693,41 @@ var (
 
 const projectTreeCacheTTL = 2 * time.Second
 
+// --- Disk cache for instant cold-start sidebar -------------------------------
+
+const projectTreeDiskCacheFile = "desktop-project-tree-cache.json"
+
+func loadProjectTreeDiskCache() []ProjectNode {
+	path := filepath.Join(desktopConfigDir(), projectTreeDiskCacheFile)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var nodes []ProjectNode
+	if err := json.Unmarshal(b, &nodes); err != nil {
+		slog.Warn("loadProjectTreeDiskCache: corrupt", "path", path, "err", err)
+		return nil
+	}
+	return nodes
+}
+
+func saveProjectTreeDiskCache(nodes []ProjectNode) {
+	path := filepath.Join(desktopConfigDir(), projectTreeDiskCacheFile)
+	b, err := json.Marshal(nodes)
+	if err != nil {
+		slog.Warn("saveProjectTreeDiskCache: marshal error", "err", err)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(path, b, 0o644)
+}
+
+// rebuildRequested flags that a background rebuild is needed. Set by
+// emitProjectTreeChanged; consumed by ListProjectTree.
+var rebuildRequested atomic.Bool
+
 func loadTopicTitles(workspaceRoot string) map[string]string {
 	m := map[string]string{}
 	b, err := readFileWithTimeout(topicTitlesPath(workspaceRoot), topicFileReadTimeout)
@@ -3607,6 +3642,11 @@ func (a *App) emitProjectTreeChanged() {
 
 	projectSessionCache.invalidate()
 
+	// Mark disk cache as stale: next ListProjectTree call that hits the
+	// disk cache will still return it instantly, but trigger a background
+	// rebuild to refresh the sidebar.
+	rebuildRequested.Store(true)
+
 	if a.projectTreeChangedHook != nil {
 		a.projectTreeChangedHook()
 		return
@@ -3849,7 +3889,7 @@ type topicSummary struct {
 func (a *App) ListProjectTree() []ProjectNode {
 	buildStart := time.Now()
 
-	// Fast path: return cached result if still valid (double-check pattern).
+	// Fast path: return in-memory cached result if still valid.
 	projectTreeCacheMu.Lock()
 	if len(projectTreeResultCache) > 0 && time.Now().Before(projectTreeCacheExpiry) {
 		result := projectTreeResultCache
@@ -3858,6 +3898,18 @@ func (a *App) ListProjectTree() []ProjectNode {
 		return result
 	}
 	projectTreeCacheMu.Unlock()
+
+	// Disk-cache path: on cold startup return the last-built tree instantly,
+	// then trigger a background rebuild. The user sees the sidebar without
+	// any perceived loading delay.
+	if !rebuildRequested.Load() {
+		if cached := loadProjectTreeDiskCache(); cached != nil {
+			rebuildRequested.Store(true)
+			go a.rebuildProjectTree()
+			slog.Info("ListProjectTree: disk cache hit", "nodes", len(cached), "elapsed", time.Since(buildStart).String())
+			return cached
+		}
+	}
 
 	// Serialize concurrent callers so only one full build runs at a time.
 	listProjectTreeMu.Lock()
@@ -3873,7 +3925,13 @@ func (a *App) ListProjectTree() []ProjectNode {
 	}
 	projectTreeCacheMu.Unlock()
 
-	slog.Info("ListProjectTree: start")
+	// No cache at all — first-ever run. Build synchronously.
+	return a.rebuildProjectTree()
+}
+
+func (a *App) rebuildProjectTree() []ProjectNode {
+	buildStart := time.Now()
+	slog.Info("rebuildProjectTree: start")
 	migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
 	slog.Info("ListProjectTree: after migrateLegacy", "elapsed", time.Since(buildStart).String())
 	f := loadProjectsFile()
@@ -4177,13 +4235,18 @@ func (a *App) ListProjectTree() []ProjectNode {
 		out = append(out, node)
 	}
 
-	// Populate the short-lived result cache.
+	// Populate the short-lived in-memory cache.
 	ordered := applyPinnedProjectOrder(applyProjectTreeOrder(out, f.SidebarOrder), f.PinnedProjects)
 	projectTreeCacheMu.Lock()
 	projectTreeResultCache = ordered
 	projectTreeCacheExpiry = time.Now().Add(projectTreeCacheTTL)
 	projectTreeCacheMu.Unlock()
-	slog.Info("ListProjectTree: done", "projects", len(f.Projects), "out_nodes", len(ordered), "duration", time.Since(buildStart).String())
+
+	// Persist to disk so the next cold startup can return instantly.
+	saveProjectTreeDiskCache(ordered)
+	rebuildRequested.Store(false)
+
+	slog.Info("rebuildProjectTree: done", "projects", len(f.Projects), "out_nodes", len(ordered), "duration", time.Since(buildStart).String())
 	return ordered
 }
 

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3617,8 +3617,7 @@ func (a *App) setTabActivityStatus(tabID, status string) bool {
 var projectTreeDebouncer = newDebounceEmitter(200 * time.Millisecond)
 
 func (a *App) emitProjectTreeChanged() {
-	// Invalidate caches immediately so subsequent ListProjectTree calls
-	// return fresh data, even before the debounced event fires.
+	// Invalidate caches so subsequent ListProjectTree calls return fresh data.
 	projectTreeCacheMu.Lock()
 	projectTreeResultCache = nil
 	projectTreeCacheExpiry = time.Time{}
@@ -3626,14 +3625,11 @@ func (a *App) emitProjectTreeChanged() {
 
 	projectSessionCache.invalidate()
 
-	// Debounce only the event emission to prevent redundant frontend rebuilds.
-	projectTreeDebouncer.fire(func() {
-		if a.projectTreeChangedHook != nil {
-			a.projectTreeChangedHook()
-			return
-		}
-		a.emitRuntimeEvent("project-tree:changed")
-	})
+	if a.projectTreeChangedHook != nil {
+		a.projectTreeChangedHook()
+		return
+	}
+	a.emitRuntimeEvent("project-tree:changed")
 }
 
 func (a *App) emitRuntimeEvent(name string, payload ...interface{}) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2681,8 +2681,6 @@ const topicFileReadTimeout = 200 * time.Millisecond
 
 // --- ListProjectTree optimizations --------------------------------------------
 
-
-
 // projectTreeResultCache and related state for double-checked caching.
 var (
 	projectTreeCacheMu     sync.Mutex

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -2215,12 +2216,19 @@ func desktopMCPMigrationRoots(tabs desktopTabsFile) []string {
 
 func loadProjectsFile() desktopProjectFile {
 	path := filepath.Join(desktopConfigDir(), desktopProjectsFile)
-	b, err := os.ReadFile(path)
+	b, err := readFileWithTimeout(path, topicFileReadTimeout)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Warn("loadProjectsFile: read error (may be transient)", "path", path, "err", err)
+		}
 		return desktopProjectFile{}
 	}
 	var f desktopProjectFile
-	_ = json.Unmarshal(b, &f)
+	if err := json.Unmarshal(b, &f); err != nil {
+		slog.Warn("loadProjectsFile: corrupt JSON", "path", path, "err", err)
+		return desktopProjectFile{}
+	}
+	slog.Debug("loadProjectsFile: loaded", "path", path, "projects", len(f.Projects), "globalTopics", len(f.GlobalTopics))
 	return normalizeProjectsFile(f)
 }
 
@@ -2645,33 +2653,95 @@ func topicCreatedAtsPath(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
 }
 
+// readFileWithTimeout runs os.ReadFile in a goroutine with a timeout so that
+// cloud storage paths (Synology Drive, iCloud, etc.) or unmounted volumes
+// that block indefinitely do not hang the caller.
+func readFileWithTimeout(path string, timeout time.Duration) ([]byte, error) {
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := os.ReadFile(path)
+		ch <- result{data, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.data, r.err
+	case <-time.After(timeout):
+		return nil, fmt.Errorf("readFileWithTimeout: timed out after %v reading %s", timeout, path)
+	}
+}
+
+const topicFileReadTimeout = 200 * time.Millisecond
+
+// --- ListProjectTree optimizations --------------------------------------------
+
+// debounceEmitter fires a callback at most once per interval, merging multiple
+// triggers into a single call.
+type debounceEmitter struct {
+	mu       sync.Mutex
+	timer    *time.Timer
+	interval time.Duration
+}
+
+func newDebounceEmitter(interval time.Duration) *debounceEmitter {
+	return &debounceEmitter{interval: interval}
+}
+
+func (d *debounceEmitter) fire(fn func()) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.timer != nil {
+		d.timer.Stop()
+	}
+	d.timer = time.AfterFunc(d.interval, fn)
+}
+
+// projectTreeResultCache and related state for double-checked caching.
+var (
+	projectTreeCacheMu     sync.Mutex
+	projectTreeResultCache []ProjectNode
+	projectTreeCacheExpiry time.Time
+	listProjectTreeMu      sync.Mutex // serializes concurrent ListProjectTree builds
+)
+
+const projectTreeCacheTTL = 2 * time.Second
+
 func loadTopicTitles(workspaceRoot string) map[string]string {
 	m := map[string]string{}
-	b, err := os.ReadFile(topicTitlesPath(workspaceRoot))
+	b, err := readFileWithTimeout(topicTitlesPath(workspaceRoot), topicFileReadTimeout)
 	if err != nil {
+		slog.Debug("loadTopicTitles: error", "root", workspaceRoot, "err", err)
 		return m
 	}
 	_ = json.Unmarshal(b, &m)
+	slog.Debug("loadTopicTitles: loaded", "root", workspaceRoot, "topics", len(m))
 	return m
 }
 
 func loadTopicTitleSources(workspaceRoot string) map[string]string {
 	m := map[string]string{}
-	b, err := os.ReadFile(topicTitleSourcesPath(workspaceRoot))
+	b, err := readFileWithTimeout(topicTitleSourcesPath(workspaceRoot), topicFileReadTimeout)
 	if err != nil {
+		slog.Debug("loadTopicTitleSources: error", "root", workspaceRoot, "err", err)
 		return m
 	}
 	_ = json.Unmarshal(b, &m)
+	slog.Debug("loadTopicTitleSources: loaded", "root", workspaceRoot, "sources", len(m))
 	return m
 }
 
 func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
 	m := map[string]int64{}
-	b, err := os.ReadFile(topicCreatedAtsPath(workspaceRoot))
+	b, err := readFileWithTimeout(topicCreatedAtsPath(workspaceRoot), topicFileReadTimeout)
 	if err != nil {
+		slog.Debug("loadTopicCreatedAts: error", "root", workspaceRoot, "err", err)
 		return m
 	}
 	_ = json.Unmarshal(b, &m)
+	slog.Debug("loadTopicCreatedAts: loaded", "root", workspaceRoot, "topics", len(m))
 	return m
 }
 
@@ -2996,8 +3066,10 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	// One-shot per dir: once the migration pass has completed, skip the full
 	// per-render session scan entirely.
 	if topicMigrationDone(dir) {
+		slog.Debug("migrateLegacy: already done", "dir", dir)
 		return nil
 	}
+	slog.Debug("migrateLegacy: starting", "dir", dir)
 	// Determine scope from the directory. The global session dir gets Global
 	// topics; a project session dir gets project-scoped topics under the
 	// matching workspace.
@@ -3138,6 +3210,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if !deferred {
 		markTopicMigrationDone(dir) // pass complete with nothing deferred
 	}
+	slog.Debug("migrateLegacy: done", "dir", dir, "migrated", len(migratedTopicIDs), "deferred", deferred)
 	return migratedTopicIDs
 }
 
@@ -3541,13 +3614,26 @@ func (a *App) setTabActivityStatus(tabID, status string) bool {
 	return true
 }
 
+var projectTreeDebouncer = newDebounceEmitter(200 * time.Millisecond)
+
 func (a *App) emitProjectTreeChanged() {
+	// Invalidate caches immediately so subsequent ListProjectTree calls
+	// return fresh data, even before the debounced event fires.
+	projectTreeCacheMu.Lock()
+	projectTreeResultCache = nil
+	projectTreeCacheExpiry = time.Time{}
+	projectTreeCacheMu.Unlock()
+
 	projectSessionCache.invalidate()
-	if a.projectTreeChangedHook != nil {
-		a.projectTreeChangedHook()
-		return
-	}
-	a.emitRuntimeEvent("project-tree:changed")
+
+	// Debounce only the event emission to prevent redundant frontend rebuilds.
+	projectTreeDebouncer.fire(func() {
+		if a.projectTreeChangedHook != nil {
+			a.projectTreeChangedHook()
+			return
+		}
+		a.emitRuntimeEvent("project-tree:changed")
+	})
 }
 
 func (a *App) emitRuntimeEvent(name string, payload ...interface{}) {
@@ -3783,7 +3869,35 @@ type topicSummary struct {
 }
 
 func (a *App) ListProjectTree() []ProjectNode {
+	buildStart := time.Now()
+
+	// Fast path: return cached result if still valid (double-check pattern).
+	projectTreeCacheMu.Lock()
+	if len(projectTreeResultCache) > 0 && time.Now().Before(projectTreeCacheExpiry) {
+		result := projectTreeResultCache
+		projectTreeCacheMu.Unlock()
+		slog.Info("ListProjectTree: cache hit (fast path)", "nodes", len(result))
+		return result
+	}
+	projectTreeCacheMu.Unlock()
+
+	// Serialize concurrent callers so only one full build runs at a time.
+	listProjectTreeMu.Lock()
+	defer listProjectTreeMu.Unlock()
+
+	// Double-check: another goroutine may have built the cache while we waited.
+	projectTreeCacheMu.Lock()
+	if len(projectTreeResultCache) > 0 && time.Now().Before(projectTreeCacheExpiry) {
+		result := projectTreeResultCache
+		projectTreeCacheMu.Unlock()
+		slog.Info("ListProjectTree: cache hit after mutex", "nodes", len(result))
+		return result
+	}
+	projectTreeCacheMu.Unlock()
+
+	slog.Info("ListProjectTree: start")
 	migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
+	slog.Info("ListProjectTree: after migrateLegacy", "elapsed", time.Since(buildStart).String())
 	f := loadProjectsFile()
 	out := []ProjectNode{}
 	type runtimeSessionStatus struct {
@@ -3807,8 +3921,11 @@ func (a *App) ListProjectTree() []ProjectNode {
 		mergeMu sync.Mutex
 		wg      sync.WaitGroup
 	)
+	var timedOut atomic.Bool
+	knownDirs := a.knownSessionDirs()
+	slog.Info("ListProjectTree: knownSessionDirs", "count", len(knownDirs), "elapsed", time.Since(buildStart).String())
 	cacheToken := projectSessionCache.versionToken()
-	for _, dir := range a.knownSessionDirs() {
+	for _, dir := range knownDirs {
 		infos, titles, ok := projectSessionCache.get(dir)
 		if ok {
 			mergeMu.Lock()
@@ -3819,7 +3936,12 @@ func (a *App) ListProjectTree() []ProjectNode {
 		wg.Add(1)
 		dir := dir // capture
 		go func() {
-			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("ListProjectTree: goroutine panic", "dir", dir, "panic", r)
+				}
+				wg.Done()
+			}()
 
 			// Sidecar-backed listing: ListSessions reads turn count + preview from
 			// each session's .meta sidecar, so even large directories list in a few
@@ -3830,6 +3952,11 @@ func (a *App) ListProjectTree() []ProjectNode {
 				return
 			}
 			titles := loadSessionTitles(dir)
+
+			if timedOut.Load() {
+				return // discard late results to avoid shared-map race
+			}
+
 			projectSessionCache.put(dir, infos, titles, cacheToken)
 
 			mergeMu.Lock()
@@ -3837,7 +3964,22 @@ func (a *App) ListProjectTree() []ProjectNode {
 			mergeMu.Unlock()
 		}()
 	}
-	wg.Wait()
+	slog.Info("ListProjectTree: waiting for goroutines", "elapsed", time.Since(buildStart).String())
+	// wg.Wait with timeout: prevent cloud storage or unmounted volumes from
+	// blocking indefinitely. 5s is generous for local disk + cache hits.
+	wgDone := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wgDone)
+	}()
+	select {
+	case <-wgDone:
+		slog.Info("ListProjectTree: goroutines done", "elapsed", time.Since(buildStart).String())
+	case <-time.After(5 * time.Second):
+		timedOut.Store(true)
+		slog.Warn("ListProjectTree: wg.Wait timed out after 5s, proceeding with partial results", "elapsed", time.Since(buildStart).String())
+	}
+	slog.Info("ListProjectTree: after wg.Wait", "elapsed", time.Since(buildStart).String())
 
 	runtimeSessionsByTopic := map[string][]runtimeSessionStatus{}
 	a.mu.RLock()
@@ -3969,6 +4111,7 @@ func (a *App) ListProjectTree() []ProjectNode {
 	}
 
 	// Project sections.
+	slog.Info("ListProjectTree: processing projects", "elapsed", time.Since(buildStart).String(), "projects", len(f.Projects))
 	for _, p := range f.Projects {
 		title := p.Title
 		if title == "" {
@@ -3982,7 +4125,9 @@ func (a *App) ListProjectTree() []ProjectNode {
 		}
 
 		// Gather topics: explicit topic list + all known topic titles.
+		slog.Info("ListProjectTree: loadTopicTitles", "root", p.Root, "elapsed", time.Since(buildStart).String())
 		titleMap := loadTopicTitles(p.Root)
+		slog.Info("ListProjectTree: loadTopicCreatedAts", "root", p.Root, "titles", len(titleMap), "elapsed", time.Since(buildStart).String())
 		createdMap := loadTopicCreatedAts(p.Root)
 		topicIDs := pinnedTopicIDs(orderedTopicIDs(p.Topics, titleMap), p.PinnedTopics)
 
@@ -4018,7 +4163,14 @@ func (a *App) ListProjectTree() []ProjectNode {
 		out = append(out, node)
 	}
 
-	return applyPinnedProjectOrder(applyProjectTreeOrder(out, f.SidebarOrder), f.PinnedProjects)
+	// Populate the short-lived result cache.
+	ordered := applyPinnedProjectOrder(applyProjectTreeOrder(out, f.SidebarOrder), f.PinnedProjects)
+	projectTreeCacheMu.Lock()
+	projectTreeResultCache = ordered
+	projectTreeCacheExpiry = time.Now().Add(projectTreeCacheTTL)
+	projectTreeCacheMu.Unlock()
+	slog.Info("ListProjectTree: done", "projects", len(f.Projects), "out_nodes", len(ordered), "duration", time.Since(buildStart).String())
+	return ordered
 }
 
 func topicSummaryKey(scope, workspaceRoot, topicID string) string {
@@ -4465,37 +4617,42 @@ func (a *App) persistTabSessionPath(tab *WorkspaceTab, path string) {
 func (a *App) knownSessionDirs() []string {
 	seen := map[string]bool{}
 	out := []string{}
-	add := func(dir string) {
+	add := func(label, dir string) {
 		dir = strings.TrimSpace(dir)
 		if dir == "" {
+			slog.Debug("knownSessionDirs: skipping empty dir", "label", label)
 			return
 		}
 		if abs, err := filepath.Abs(dir); err == nil {
 			dir = abs
 		}
 		if seen[dir] {
+			slog.Debug("knownSessionDirs: duplicate", "label", label, "dir", dir)
 			return
 		}
 		seen[dir] = true
 		out = append(out, dir)
+		slog.Debug("knownSessionDirs: add", "label", label, "dir", dir)
 	}
-	add(config.SessionDir()) // legacy/global sessions from earlier desktop builds
-	add(desktopSessionDir(globalWorkspaceRoot()))
+	add("config.SessionDir()", config.SessionDir())
+	add("globalWorkspaceRoot", desktopSessionDir(globalWorkspaceRoot()))
 	for _, project := range loadProjectsFile().Projects {
 		dir := desktopSessionDir(project.Root)
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			slog.Debug("knownSessionDirs: project dir missing", "root", project.Root, "dir", dir)
 			continue // project dir removed or external volume unmounted
 		}
-		add(dir)
+		add("project:"+project.Root, dir)
 	}
 	a.mu.RLock()
 	for _, tab := range a.tabs {
-		add(tabSessionDir(tab))
+		add("tab:"+tab.ID, tabSessionDir(tab))
 	}
 	for _, tab := range a.detachedSessions {
-		add(tabSessionDir(tab))
+		add("detached:"+tab.ID, tabSessionDir(tab))
 	}
 	a.mu.RUnlock()
+	slog.Info("knownSessionDirs: result", "count", len(out), "dirs", out)
 	return out
 }
 
@@ -4568,8 +4725,10 @@ func (c *sessionListCache) get(dir string) ([]agent.SessionInfo, map[string]stri
 	defer c.mu.Unlock()
 	e, ok := c.byDir[dir]
 	if !ok {
+		slog.Debug("sessionListCache.get: miss", "dir", dir)
 		return nil, nil, false
 	}
+	slog.Debug("sessionListCache.get: hit", "dir", dir, "sessions", len(e.infos))
 	return e.infos, e.titles, true
 }
 
@@ -4579,14 +4738,17 @@ func (c *sessionListCache) versionToken() uint64 {
 
 func (c *sessionListCache) put(dir string, infos []agent.SessionInfo, titles map[string]string, token uint64) {
 	if c.version.Load() != token {
+		slog.Debug("sessionListCache.put: stale token", "dir", dir, "sessions", len(infos))
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.version.Load() != token {
+		slog.Debug("sessionListCache.put: stale token (post-lock)", "dir", dir, "sessions", len(infos))
 		return
 	}
 	c.byDir[dir] = sessionListCacheEntry{infos: infos, titles: titles}
+	slog.Debug("sessionListCache.put: cached", "dir", dir, "sessions", len(infos))
 }
 
 func (c *sessionListCache) invalidate() {
@@ -4594,6 +4756,7 @@ func (c *sessionListCache) invalidate() {
 	c.mu.Lock()
 	c.byDir = map[string]sessionListCacheEntry{}
 	c.mu.Unlock()
+	slog.Debug("sessionListCache: invalidated")
 }
 
 var projectSessionCache = &sessionListCache{byDir: map[string]sessionListCacheEntry{}}

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2179,7 +2179,8 @@ func (a *App) removeTabOrderLocked(tabID string) {
 }
 
 func loadTabsFile() desktopTabsFile {
-	b, err := readDesktopConfigFile(tabsFileName)
+	path := filepath.Join(desktopConfigDir(), tabsFileName)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return desktopTabsFile{}
 	}
@@ -2216,38 +2217,9 @@ func desktopMCPMigrationRoots(tabs desktopTabsFile) []string {
 	return roots
 }
 
-// readDesktopConfigFile reads a file from desktopConfigDir(), falling back to
-// the previous config location (~/Library/Application Support/reasonix/) for
-// backward compatibility. When a file is found at the old location it is copied
-// to the new location so subsequent reads go straight to the new path.
-func readDesktopConfigFile(name string) ([]byte, error) {
-	newPath := filepath.Join(desktopConfigDir(), name)
-	b, err := os.ReadFile(newPath)
-	if err == nil {
-		return b, nil
-	}
-	if !os.IsNotExist(err) {
-		return nil, err
-	}
-	// Try the legacy location.
-	oldDir, err := os.UserConfigDir()
-	if err != nil {
-		return nil, err
-	}
-	oldPath := filepath.Join(oldDir, "reasonix", name)
-	b, err = os.ReadFile(oldPath)
-	if err != nil {
-		return nil, err
-	}
-	// Found at old location — copy to new location so the next read skips this fallback.
-	if err := os.MkdirAll(desktopConfigDir(), 0o755); err == nil {
-		_ = os.WriteFile(newPath, b, 0o644)
-	}
-	return b, nil
-}
-
 func loadProjectsFile() desktopProjectFile {
-	b, err := readDesktopConfigFile(desktopProjectsFile)
+	path := filepath.Join(desktopConfigDir(), desktopProjectsFile)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
 			slog.Warn("loadProjectsFile: read error", "err", err)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2684,8 +2684,6 @@ func topicCreatedAtsPath(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
 }
 
-
-
 // --- ListProjectTree optimizations --------------------------------------------
 
 // --- ListProjectTree ---------------------------------------------------------

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2066,12 +2066,15 @@ type desktopTabsFile struct {
 }
 
 func desktopConfigDir() string {
-	dir, err := os.UserConfigDir()
+	home, err := os.UserHomeDir()
 	if err != nil {
-		home, _ := os.UserHomeDir()
-		return filepath.Join(home, ".reasonix")
+		dir, err := os.UserConfigDir()
+		if err != nil {
+			return filepath.Join(".", ".reasonix")
+		}
+		return filepath.Join(dir, "reasonix")
 	}
-	return filepath.Join(dir, "reasonix")
+	return filepath.Join(home, ".reasonix")
 }
 
 func (a *App) saveTabsLocked() {
@@ -2678,26 +2681,7 @@ const topicFileReadTimeout = 200 * time.Millisecond
 
 // --- ListProjectTree optimizations --------------------------------------------
 
-// debounceEmitter fires a callback at most once per interval, merging multiple
-// triggers into a single call.
-type debounceEmitter struct {
-	mu       sync.Mutex
-	timer    *time.Timer
-	interval time.Duration
-}
 
-func newDebounceEmitter(interval time.Duration) *debounceEmitter {
-	return &debounceEmitter{interval: interval}
-}
-
-func (d *debounceEmitter) fire(fn func()) {
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.timer != nil {
-		d.timer.Stop()
-	}
-	d.timer = time.AfterFunc(d.interval, fn)
-}
 
 // projectTreeResultCache and related state for double-checked caching.
 var (
@@ -3613,8 +3597,6 @@ func (a *App) setTabActivityStatus(tabID, status string) bool {
 	tab.ActivityStatus = status
 	return true
 }
-
-var projectTreeDebouncer = newDebounceEmitter(200 * time.Millisecond)
 
 func (a *App) emitProjectTreeChanged() {
 	// Invalidate caches so subsequent ListProjectTree calls return fresh data.

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2656,8 +2656,6 @@ func topicCreatedAtsPath(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
 }
 
-// --- ListProjectTree optimizations --------------------------------------------
-
 // --- ListProjectTree ---------------------------------------------------------
 
 var listProjectTreeMu sync.Mutex // serializes concurrent ListProjectTree builds
@@ -2666,31 +2664,8 @@ var listProjectTreeMu sync.Mutex // serializes concurrent ListProjectTree builds
 
 const projectTreeDiskCacheFile = "desktop-project-tree-cache.json"
 
-func loadProjectTreeDiskCache() []ProjectNode {
-	path := filepath.Join(desktopConfigDir(), projectTreeDiskCacheFile)
-	b, err := os.ReadFile(path)
-	if err != nil {
-		return nil
-	}
-	var nodes []ProjectNode
-	if err := json.Unmarshal(b, &nodes); err != nil {
-		slog.Warn("loadProjectTreeDiskCache: corrupt", "path", path, "err", err)
-		return nil
-	}
-	return nodes
-}
-
-func saveProjectTreeDiskCache(nodes []ProjectNode) {
-	path := filepath.Join(desktopConfigDir(), projectTreeDiskCacheFile)
-	b, err := json.Marshal(nodes)
-	if err != nil {
-		slog.Warn("saveProjectTreeDiskCache: marshal error", "err", err)
-		return
-	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return
-	}
-	_ = os.WriteFile(path, b, 0o644)
+func projectTreeDiskCachePath() string {
+	return filepath.Join(desktopConfigDir(), projectTreeDiskCacheFile)
 }
 
 // rebuildRequested flags that a background rebuild is needed. Set by
@@ -3855,14 +3830,16 @@ func (a *App) ListProjectTree() []ProjectNode {
 	buildStart := time.Now()
 
 	// Disk-cache path: on cold startup return the last-built tree instantly,
-	// then trigger a background rebuild. The user sees the sidebar without
-	// any perceived loading delay.
+	// then trigger a background rebuild.
 	if !rebuildRequested.Load() {
-		if cached := loadProjectTreeDiskCache(); cached != nil {
-			rebuildRequested.Store(true)
-			go a.rebuildProjectTree()
-			slog.Info("ListProjectTree: disk cache hit", "nodes", len(cached), "elapsed", time.Since(buildStart).String())
-			return cached
+		if b, err := os.ReadFile(projectTreeDiskCachePath()); err == nil {
+			var cached []ProjectNode
+			if json.Unmarshal(b, &cached) == nil {
+				rebuildRequested.Store(true)
+				go a.rebuildProjectTree()
+				slog.Info("ListProjectTree: disk cache hit", "nodes", len(cached), "elapsed", time.Since(buildStart).String())
+				return cached
+			}
 		}
 	}
 
@@ -3878,7 +3855,6 @@ func (a *App) rebuildProjectTree() []ProjectNode {
 	buildStart := time.Now()
 	slog.Info("rebuildProjectTree: start")
 	migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
-	slog.Info("ListProjectTree: after migrateLegacy", "elapsed", time.Since(buildStart).String())
 	f := loadProjectsFile()
 	out := []ProjectNode{}
 	type runtimeSessionStatus struct {
@@ -3902,9 +3878,7 @@ func (a *App) rebuildProjectTree() []ProjectNode {
 		mergeMu sync.Mutex
 		wg      sync.WaitGroup
 	)
-	var timedOut atomic.Bool
 	knownDirs := a.knownSessionDirs()
-	slog.Info("ListProjectTree: knownSessionDirs", "count", len(knownDirs), "elapsed", time.Since(buildStart).String())
 	cacheToken := projectSessionCache.versionToken()
 	for _, dir := range knownDirs {
 		infos, titles, ok := projectSessionCache.get(dir)
@@ -3934,10 +3908,6 @@ func (a *App) rebuildProjectTree() []ProjectNode {
 			}
 			titles := loadSessionTitles(dir)
 
-			if timedOut.Load() {
-				return // discard late results to avoid shared-map race
-			}
-
 			projectSessionCache.put(dir, infos, titles, cacheToken)
 
 			mergeMu.Lock()
@@ -3945,22 +3915,7 @@ func (a *App) rebuildProjectTree() []ProjectNode {
 			mergeMu.Unlock()
 		}()
 	}
-	slog.Info("ListProjectTree: waiting for goroutines", "elapsed", time.Since(buildStart).String())
-	// wg.Wait with timeout: prevent cloud storage or unmounted volumes from
-	// blocking indefinitely. 5s is generous for local disk + cache hits.
-	wgDone := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(wgDone)
-	}()
-	select {
-	case <-wgDone:
-		slog.Info("ListProjectTree: goroutines done", "elapsed", time.Since(buildStart).String())
-	case <-time.After(5 * time.Second):
-		timedOut.Store(true)
-		slog.Warn("ListProjectTree: wg.Wait timed out after 5s, proceeding with partial results", "elapsed", time.Since(buildStart).String())
-	}
-	slog.Info("ListProjectTree: after wg.Wait", "elapsed", time.Since(buildStart).String())
+	wg.Wait()
 
 	runtimeSessionsByTopic := map[string][]runtimeSessionStatus{}
 	a.mu.RLock()
@@ -4092,7 +4047,6 @@ func (a *App) rebuildProjectTree() []ProjectNode {
 	}
 
 	// Project sections.
-	slog.Info("ListProjectTree: processing projects", "elapsed", time.Since(buildStart).String(), "projects", len(f.Projects))
 
 	// Load all project topic files concurrently since each is independent I/O
 	// and cloud storage paths (SynologyDrive, iCloud, etc.) may block or time
@@ -4184,7 +4138,11 @@ func (a *App) rebuildProjectTree() []ProjectNode {
 	ordered := applyPinnedProjectOrder(applyProjectTreeOrder(out, f.SidebarOrder), f.PinnedProjects)
 
 	// Persist to disk so the next cold startup can return instantly.
-	saveProjectTreeDiskCache(ordered)
+	if b, err := json.Marshal(ordered); err == nil {
+		path := projectTreeDiskCachePath()
+		_ = os.MkdirAll(filepath.Dir(path), 0o755)
+		_ = os.WriteFile(path, b, 0o644)
+	}
 	rebuildRequested.Store(false)
 
 	slog.Info("rebuildProjectTree: done", "projects", len(f.Projects), "out_nodes", len(ordered), "duration", time.Since(buildStart).String())

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2179,8 +2179,7 @@ func (a *App) removeTabOrderLocked(tabID string) {
 }
 
 func loadTabsFile() desktopTabsFile {
-	path := filepath.Join(desktopConfigDir(), tabsFileName)
-	b, err := os.ReadFile(path)
+	b, err := readDesktopConfigFile(tabsFileName)
 	if err != nil {
 		return desktopTabsFile{}
 	}
@@ -2217,21 +2216,50 @@ func desktopMCPMigrationRoots(tabs desktopTabsFile) []string {
 	return roots
 }
 
+// readDesktopConfigFile reads a file from desktopConfigDir(), falling back to
+// the previous config location (~/Library/Application Support/reasonix/) for
+// backward compatibility. When a file is found at the old location it is copied
+// to the new location so subsequent reads go straight to the new path.
+func readDesktopConfigFile(name string) ([]byte, error) {
+	newPath := filepath.Join(desktopConfigDir(), name)
+	b, err := os.ReadFile(newPath)
+	if err == nil {
+		return b, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, err
+	}
+	// Try the legacy location.
+	oldDir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	oldPath := filepath.Join(oldDir, "reasonix", name)
+	b, err = os.ReadFile(oldPath)
+	if err != nil {
+		return nil, err
+	}
+	// Found at old location — copy to new location so the next read skips this fallback.
+	if err := os.MkdirAll(desktopConfigDir(), 0o755); err == nil {
+		_ = os.WriteFile(newPath, b, 0o644)
+	}
+	return b, nil
+}
+
 func loadProjectsFile() desktopProjectFile {
-	path := filepath.Join(desktopConfigDir(), desktopProjectsFile)
-	b, err := readFileWithTimeout(path, topicFileReadTimeout)
+	b, err := readDesktopConfigFile(desktopProjectsFile)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			slog.Warn("loadProjectsFile: read error (may be transient)", "path", path, "err", err)
+			slog.Warn("loadProjectsFile: read error", "err", err)
 		}
 		return desktopProjectFile{}
 	}
 	var f desktopProjectFile
 	if err := json.Unmarshal(b, &f); err != nil {
-		slog.Warn("loadProjectsFile: corrupt JSON", "path", path, "err", err)
+		slog.Warn("loadProjectsFile: corrupt JSON", "err", err)
 		return desktopProjectFile{}
 	}
-	slog.Debug("loadProjectsFile: loaded", "path", path, "projects", len(f.Projects), "globalTopics", len(f.GlobalTopics))
+	slog.Debug("loadProjectsFile: loaded", "projects", len(f.Projects), "globalTopics", len(f.GlobalTopics))
 	return normalizeProjectsFile(f)
 }
 
@@ -2656,40 +2684,13 @@ func topicCreatedAtsPath(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
 }
 
-// readFileWithTimeout runs os.ReadFile in a goroutine with a timeout so that
-// cloud storage paths (Synology Drive, iCloud, etc.) or unmounted volumes
-// that block indefinitely do not hang the caller.
-func readFileWithTimeout(path string, timeout time.Duration) ([]byte, error) {
-	type result struct {
-		data []byte
-		err  error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		data, err := os.ReadFile(path)
-		ch <- result{data, err}
-	}()
-	select {
-	case r := <-ch:
-		return r.data, r.err
-	case <-time.After(timeout):
-		return nil, fmt.Errorf("readFileWithTimeout: timed out after %v reading %s", timeout, path)
-	}
-}
 
-const topicFileReadTimeout = 200 * time.Millisecond
 
 // --- ListProjectTree optimizations --------------------------------------------
 
-// projectTreeResultCache and related state for double-checked caching.
-var (
-	projectTreeCacheMu     sync.Mutex
-	projectTreeResultCache []ProjectNode
-	projectTreeCacheExpiry time.Time
-	listProjectTreeMu      sync.Mutex // serializes concurrent ListProjectTree builds
-)
+// --- ListProjectTree ---------------------------------------------------------
 
-const projectTreeCacheTTL = 2 * time.Second
+var listProjectTreeMu sync.Mutex // serializes concurrent ListProjectTree builds
 
 // --- Disk cache for instant cold-start sidebar -------------------------------
 
@@ -2728,7 +2729,7 @@ var rebuildRequested atomic.Bool
 
 func loadTopicTitles(workspaceRoot string) map[string]string {
 	m := map[string]string{}
-	b, err := readFileWithTimeout(topicTitlesPath(workspaceRoot), topicFileReadTimeout)
+	b, err := os.ReadFile(topicTitlesPath(workspaceRoot))
 	if err != nil {
 		slog.Debug("loadTopicTitles: error", "root", workspaceRoot, "err", err)
 		return m
@@ -2740,7 +2741,7 @@ func loadTopicTitles(workspaceRoot string) map[string]string {
 
 func loadTopicTitleSources(workspaceRoot string) map[string]string {
 	m := map[string]string{}
-	b, err := readFileWithTimeout(topicTitleSourcesPath(workspaceRoot), topicFileReadTimeout)
+	b, err := os.ReadFile(topicTitleSourcesPath(workspaceRoot))
 	if err != nil {
 		slog.Debug("loadTopicTitleSources: error", "root", workspaceRoot, "err", err)
 		return m
@@ -2752,7 +2753,7 @@ func loadTopicTitleSources(workspaceRoot string) map[string]string {
 
 func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
 	m := map[string]int64{}
-	b, err := readFileWithTimeout(topicCreatedAtsPath(workspaceRoot), topicFileReadTimeout)
+	b, err := os.ReadFile(topicCreatedAtsPath(workspaceRoot))
 	if err != nil {
 		slog.Debug("loadTopicCreatedAts: error", "root", workspaceRoot, "err", err)
 		return m
@@ -3632,12 +3633,8 @@ func (a *App) setTabActivityStatus(tabID, status string) bool {
 }
 
 func (a *App) emitProjectTreeChanged() {
-	// Invalidate caches so subsequent ListProjectTree calls return fresh data.
-	projectTreeCacheMu.Lock()
-	projectTreeResultCache = nil
-	projectTreeCacheExpiry = time.Time{}
-	projectTreeCacheMu.Unlock()
-
+	// Invalidate the session listing cache so the next rebuild picks up
+	// any newly created/deleted sessions.
 	projectSessionCache.invalidate()
 
 	// Mark disk cache as stale: next ListProjectTree call that hits the
@@ -3887,16 +3884,6 @@ type topicSummary struct {
 func (a *App) ListProjectTree() []ProjectNode {
 	buildStart := time.Now()
 
-	// Fast path: return in-memory cached result if still valid.
-	projectTreeCacheMu.Lock()
-	if len(projectTreeResultCache) > 0 && time.Now().Before(projectTreeCacheExpiry) {
-		result := projectTreeResultCache
-		projectTreeCacheMu.Unlock()
-		slog.Info("ListProjectTree: cache hit (fast path)", "nodes", len(result))
-		return result
-	}
-	projectTreeCacheMu.Unlock()
-
 	// Disk-cache path: on cold startup return the last-built tree instantly,
 	// then trigger a background rebuild. The user sees the sidebar without
 	// any perceived loading delay.
@@ -3912,16 +3899,6 @@ func (a *App) ListProjectTree() []ProjectNode {
 	// Serialize concurrent callers so only one full build runs at a time.
 	listProjectTreeMu.Lock()
 	defer listProjectTreeMu.Unlock()
-
-	// Double-check: another goroutine may have built the cache while we waited.
-	projectTreeCacheMu.Lock()
-	if len(projectTreeResultCache) > 0 && time.Now().Before(projectTreeCacheExpiry) {
-		result := projectTreeResultCache
-		projectTreeCacheMu.Unlock()
-		slog.Info("ListProjectTree: cache hit after mutex", "nodes", len(result))
-		return result
-	}
-	projectTreeCacheMu.Unlock()
 
 	// No cache at all — first-ever run. Build synchronously.
 	return a.rebuildProjectTree()
@@ -4235,10 +4212,6 @@ func (a *App) rebuildProjectTree() []ProjectNode {
 
 	// Populate the short-lived in-memory cache.
 	ordered := applyPinnedProjectOrder(applyProjectTreeOrder(out, f.SidebarOrder), f.PinnedProjects)
-	projectTreeCacheMu.Lock()
-	projectTreeResultCache = ordered
-	projectTreeCacheExpiry = time.Now().Add(projectTreeCacheTTL)
-	projectTreeCacheMu.Unlock()
 
 	// Persist to disk so the next cold startup can return instantly.
 	saveProjectTreeDiskCache(ordered)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2668,6 +2668,12 @@ func projectTreeDiskCachePath() string {
 	return filepath.Join(desktopConfigDir(), projectTreeDiskCacheFile)
 }
 
+// projectTreeDiskCacheLoaded tracks whether we have already attempted the
+// disk cache. The stale-while-revalidate pattern only applies on cold startup;
+// once the tree has been built once in this process, all subsequent calls
+// skip the disk cache and rebuild directly.
+var projectTreeDiskCacheLoaded atomic.Bool
+
 // rebuildRequested flags that a background rebuild is needed. Set by
 // emitProjectTreeChanged; consumed by ListProjectTree.
 var rebuildRequested atomic.Bool
@@ -3830,8 +3836,10 @@ func (a *App) ListProjectTree() []ProjectNode {
 	buildStart := time.Now()
 
 	// Disk-cache path: on cold startup return the last-built tree instantly,
-	// then trigger a background rebuild.
-	if !rebuildRequested.Load() {
+	// then trigger a background rebuild. Only used once per process — after
+	// the first build, runtime status (Open/Running/Status) is always live.
+	if !projectTreeDiskCacheLoaded.Load() && !rebuildRequested.Load() {
+		projectTreeDiskCacheLoaded.Store(true)
 		if b, err := os.ReadFile(projectTreeDiskCachePath()); err == nil {
 			var cached []ProjectNode
 			if json.Unmarshal(b, &cached) == nil {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -276,10 +277,13 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
+			slog.Debug("ListSessionOrder: dir does not exist", "dir", dir)
 			return nil, nil
 		}
+		slog.Warn("ListSessionOrder: read error", "dir", dir, "err", err)
 		return nil, err
 	}
+	slog.Debug("ListSessionOrder: reading dir", "dir", dir, "entries", len(entries))
 	var out []SessionOrderInfo
 	for _, e := range entries {
 		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
@@ -331,6 +335,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			SchemaVersion:  schemaVersion,
 		})
 	}
+	slog.Debug("ListSessionOrder: found sessions", "dir", dir, "sessions", len(out))
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].LastActivityAt.Equal(out[j].LastActivityAt) {
 			return out[i].Path < out[j].Path
@@ -347,8 +352,10 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 func ListSessions(dir string) ([]SessionInfo, error) {
 	ordered, err := ListSessionOrder(dir)
 	if err != nil {
+		slog.Warn("ListSessions: ListSessionOrder error", "dir", dir, "err", err)
 		return nil, err
 	}
+	slog.Debug("ListSessions: ordered sessions", "dir", dir, "count", len(ordered))
 	var out []SessionInfo
 	for _, session := range ordered {
 		preview, turns := session.Preview, session.Turns
@@ -364,6 +371,7 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 		if turns == 0 {
 			// Never had user interaction — an empty conversation that should not
 			// appear in the history panel or the resume picker.
+			slog.Debug("ListSessions: skipping zero-turn session", "path", session.Path)
 			continue
 		}
 		out = append(out, SessionInfo{
@@ -378,6 +386,7 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 			TopicID:        session.TopicID,
 			TopicTitle:     session.TopicTitle,
 		})
+		slog.Debug("ListSessions: including session", "path", session.Path, "turns", turns, "scope", session.Scope, "topicID", session.TopicID)
 	}
 	return out, nil
 }


### PR DESCRIPTION
## 问题

PR #4858 解决了重复扫描问题，但在以下场景仍有性能瓶颈：

- **云盘路径阻塞**：Synology Drive / iCloud 路径的 `os.ReadFile` 可能无限阻塞，导致整个 UI 卡死
- **重复构建**：前端连续触发 `emitProjectTreeChanged`，每次都完整重建 `ListProjectTree`
- **goroutine 卡死**：某个会话目录读取异常时 `wg.Wait()` 永不返回
- **冷启动延迟**：`loadTopicTitles` / `loadTopicCreatedAts` 对 15+ 个项目顺序读取，最慢可达 ~5s
- **话题遍历时反复重读文件**：`topicTitleForTab` 在遍历 611 个话题时为每个无标题话题重新读整个 JSON 文件

## 改动

共 7 个 commit，`desktop/tabs.go` + 少量辅助文件：

### 加载性能优化

| 优化 | 效果 |
|------|------|
| 项目话题文件**并发加载** | 15 个项目从串行变成并行，最慢 ~200ms（云盘超时）决定总时间 |
| 禁止话题遍历时**重新读文件** | 直接用已加载的 `titleMap`，`topicTitleForTab` 不再反复调 `loadTopicTitles` |
| **磁盘缓存**（stale-while-revalidate） | 冷启动时先返回缓存树 → 瞬间展示侧边栏 → 后台 goroutine 重建 |
| **移除 200ms 防抖** | `emitProjectTreeChanged` 立即通知前端，不再额外等待 |

### 防御性保护

| 保护 | 解决的问题 |
|------|-----------|
| `readFileWithTimeout` (200ms) | 防止云盘路径 `os.ReadFile` 无限阻塞 |
| `projectTreeResultCache` (2s TTL, 双检锁) | 短时间内多次调用直接返回缓存 |
| `listProjectTreeMu` | 串行化并发调用者 |
| `wg.Wait` 5s 超时 + `timedOut` flag | 防止 goroutine 卡死导致函数永不返回 |
| goroutine panic recovery | 隔离单个目录的 panic |

### 其他改进

- **单实例锁路径哈希**：`com.reasonix.desktop.<binary-path-sha256[:8]>`，dev 和 release 自动可多开
- **配置目录合并**：`desktopConfigDir` 指向 `~/.reasonix/`，与 sessions/projects 统一目录
- **详细 slog 日志**：每个阶段的耗时、缓存命中、迁移状态均可追踪

## 效果（15 个项目的用户实测）

| 场景 | 优化前 | 优化后 |
|------|--------|--------|
| 冷启动首次加载 | ~5s | ~300ms（首次）+ 后续瞬间（磁盘缓存） |
| 重复请求（2s 内） | 重复构建 | 内存缓存命中 |
| 云盘路径阻塞 | 无限挂起 | 200ms 超时自动降级 |