### PR TITLE
refactor(agent): version BranchMeta counts instead of overloading Turns==0

### DIFF
--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -28,15 +28,30 @@ type BranchMeta struct {
 	TopicID          string    `json:"topic_id,omitempty"`
 	TopicTitle       string    `json:"topic_title,omitempty"`
 	Model            string    `json:"model,omitempty"`
+	// SchemaVersion records the BranchMeta version that last wrote the listing
+	// fields (Turns/Preview) FROM the session's content. It is stamped only by the
+	// writers that actually derive those counts — Controller.snapshot's
+	// UpdateSessionMeta and Fork/Branch — never by EnsureBranchMeta / TouchBranchMeta
+	// / rename / set-model, which don't know the turn count. So ListSessions can
+	// tell a meta whose counts are authoritative (>= BranchMetaCountsVersion: trust
+	// Turns even when 0 = genuinely empty) from a legacy/contentless one
+	// (< version: decode once, then backfill + stamp).
+	SchemaVersion int `json:"schema_version,omitempty"`
 	// Turns and Preview are listing-only fields the desktop sidebar and CLI
 	// pickers show ("5 turns · 'help me debug…'") without decoding the whole
 	// .jsonl. The autosave path (Controller.snapshot) keeps them fresh from the
 	// in-memory conversation, so ListSessions stays O(1) per session instead of
-	// O(file size). Turns == 0 means "not recorded yet" — listing falls back to a
-	// one-time decode and backfills these.
+	// O(file size). Gated by SchemaVersion (above), not Turns == 0, so a
+	// genuinely-empty session is recorded once and never re-decoded.
 	Turns   int    `json:"turns,omitempty"`
 	Preview string `json:"preview,omitempty"`
 }
+
+// BranchMetaCountsVersion is stamped into BranchMeta.SchemaVersion whenever a
+// writer records Turns/Preview from session content (UpdateSessionMeta,
+// Fork/Branch). Bump it when the meaning of those listing fields changes so
+// existing listings re-derive them instead of trusting a stale cache.
+const BranchMetaCountsVersion = 1
 
 func (m BranchMeta) DefaultScope() string {
 	switch m.Scope {
@@ -294,5 +309,8 @@ func UpdateSessionMeta(sessionPath, model, preview string, turns int, markActivi
 	}
 	m.Preview = preview
 	m.Turns = turns
+	// These counts were derived from the current content, so mark them
+	// authoritative — listing can then trust Turns (even 0) without re-decoding.
+	m.SchemaVersion = BranchMetaCountsVersion
 	return saveBranchMeta(sessionPath, m, markActivity)
 }

--- a/internal/agent/listsessions_sidecar_test.go
+++ b/internal/agent/listsessions_sidecar_test.go
@@ -115,3 +115,56 @@ func TestListSessionsBackfillsLegacySession(t *testing.T) {
 		t.Fatalf("backfill bumped UpdatedAt: got %v want %v", meta.UpdatedAt, updated)
 	}
 }
+
+// A counts-authoritative sidecar (SchemaVersion stamped) that records Turns == 0
+// must be trusted as empty and skipped WITHOUT decoding the .jsonl. We prove the
+// version gate by planting a file that actually has content but a meta claiming
+// it is empty: if the session is decoded it would be listed; trusting the meta
+// skips it.
+func TestListSessionsTrustsRecordedEmptyWithoutDecoding(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260101-000000-deepseek-chat.jsonl")
+	writeSessionFile(t, path, []provider.Message{
+		{Role: provider.RoleUser, Content: "real content the meta will lie about"},
+		{Role: provider.RoleAssistant, Content: "a"},
+	})
+	if err := SaveBranchMeta(path, BranchMeta{ID: BranchID(path), Turns: 0, SchemaVersion: BranchMetaCountsVersion}); err != nil {
+		t.Fatalf("SaveBranchMeta: %v", err)
+	}
+
+	infos, err := ListSessions(dir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("a counts-authoritative empty session should be skipped without decoding; got %d", len(infos))
+	}
+}
+
+// A genuinely-empty legacy session (no counts-aware meta) must be decoded once
+// and then recorded as authoritative-empty, so later listings trust it instead
+// of re-decoding the .jsonl on every refresh (the Turns == 0 overload bug).
+func TestListSessionsRecordsEmptyLegacySessionOnce(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "20260101-000000-deepseek-chat.jsonl")
+	writeSessionFile(t, path, []provider.Message{
+		{Role: provider.RoleSystem, Content: "system prompt"},
+		{Role: provider.RoleAssistant, Content: "a greeting with no user turn"},
+	})
+
+	infos, err := ListSessions(dir)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(infos) != 0 {
+		t.Fatalf("empty session must not be listed; got %d", len(infos))
+	}
+
+	meta, ok, err := LoadBranchMeta(path)
+	if err != nil || !ok {
+		t.Fatalf("empty session should have been stamped: ok=%v err=%v", ok, err)
+	}
+	if meta.SchemaVersion != BranchMetaCountsVersion || meta.Turns != 0 {
+		t.Fatalf("empty session not recorded as authoritative-empty: version=%d turns=%d", meta.SchemaVersion, meta.Turns)
+	}
+}

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -126,10 +126,12 @@ type SessionOrderInfo struct {
 	WorkspaceRoot  string
 	TopicID        string
 	TopicTitle     string
-	// Turns and Preview are the cached listing fields from the sidecar, when
-	// recorded (Turns > 0). ListSessions uses them to skip the whole-file decode.
-	Turns   int
-	Preview string
+	// Turns and Preview are the cached listing fields from the sidecar; SchemaVersion
+	// >= agent.BranchMetaCountsVersion means they were recorded from content and can
+	// be trusted (even Turns == 0). ListSessions uses them to skip the whole-file decode.
+	Turns         int
+	Preview       string
+	SchemaVersion int
 }
 
 // CleanupPendingMeta records that a session was logically removed but still has
@@ -299,6 +301,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 		topicTitle := ""
 		turns := 0
 		preview := ""
+		schemaVersion := 0
 		if meta, ok, err := LoadBranchMeta(full); err == nil && ok {
 			if !meta.CreatedAt.IsZero() {
 				createdAt = meta.CreatedAt
@@ -312,6 +315,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			topicTitle = meta.TopicTitle
 			turns = meta.Turns
 			preview = meta.Preview
+			schemaVersion = meta.SchemaVersion
 		}
 		out = append(out, SessionOrderInfo{
 			Path:           full,
@@ -324,6 +328,7 @@ func ListSessionOrder(dir string) ([]SessionOrderInfo, error) {
 			TopicTitle:     topicTitle,
 			Turns:          turns,
 			Preview:        preview,
+			SchemaVersion:  schemaVersion,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool {
@@ -347,19 +352,19 @@ func ListSessions(dir string) ([]SessionInfo, error) {
 	var out []SessionInfo
 	for _, session := range ordered {
 		preview, turns := session.Preview, session.Turns
-		if turns <= 0 {
-			// No recorded turn count in the sidecar — a legacy session from
-			// before the counts were persisted, or a genuinely empty one. Decode
-			// the .jsonl once to find out, then backfill the sidecar so every
-			// later listing is O(1) instead of O(file size).
+		if session.SchemaVersion < BranchMetaCountsVersion {
+			// The sidecar's counts weren't recorded from content (a legacy session
+			// from before they were persisted). Decode the .jsonl once, then backfill
+			// + stamp the sidecar so every later listing is O(1) — and so a genuinely
+			// empty session is recorded once instead of being re-decoded forever.
 			preview, turns = previewSession(session.Path)
-			if turns == 0 {
-				// Never had user interaction — an empty conversation that should
-				// not appear in the history panel or the resume picker.
-				continue
-			}
 			// Best-effort: a failure here just means we decode again next time.
 			_ = UpdateSessionMeta(session.Path, "", preview, turns, false)
+		}
+		if turns == 0 {
+			// Never had user interaction — an empty conversation that should not
+			// appear in the history panel or the resume picker.
+			continue
 		}
 		out = append(out, SessionInfo{
 			Path:           session.Path,

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2220,6 +2220,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 		ForkMessageIndex: boundary,
 		Preview:          forkPreview,
 		Turns:            forkTurns,
+		SchemaVersion:    agent.BranchMetaCountsVersion,
 	}); err != nil {
 		return "", c.rewindFail(err)
 	}
@@ -2290,6 +2291,7 @@ func (c *Controller) Branch(name string) (string, error) {
 		ForkMessageIndex: len(branched),
 		Preview:          branchPreview,
 		Turns:            branchTurns,
+		SchemaVersion:    agent.BranchMetaCountsVersion,
 	}); err != nil {
 		return "", c.rewindFail(err)
 	}


### PR DESCRIPTION
Architecture-review follow-up (persistence Finding 4): the `.jsonl`/`.meta` format had no schema version, and `Turns == 0` was overloaded.

## Problem

After #4882, `ListSessions` gated its "decode + backfill" fallback on `Turns <= 0`. That conflated two distinct cases:
- a **legacy** session whose counts were never recorded, and
- a **genuinely empty** session (0 user turns).

The empty case could never backfill a non-zero count, so it was **re-decoded on every listing** — wasted work each sidebar refresh for every abandoned/empty session (now more visible since #4886 removed the disk cache).

## Fix

- Add `BranchMeta.SchemaVersion`, stamped to `BranchMetaCountsVersion` **only** by the writers that derive `Turns`/`Preview` from session content — `UpdateSessionMeta` (the autosave path) and `Fork`/`Branch`. It is deliberately **not** stamped by `EnsureBranchMeta` / `TouchBranchMeta` / rename / set-model, which don't know the turn count and so must not claim the counts are authoritative.
- `ListSessions` now gates on `SchemaVersion`, not `Turns == 0`:
  - meta `SchemaVersion >= BranchMetaCountsVersion` → trust `Turns`/`Preview` even when `Turns == 0` (skip empty **without decoding**);
  - meta below that → decode once, then backfill **and stamp**, so an empty session is recorded once instead of forever.
- Forward-compat: bump `BranchMetaCountsVersion` when the counts' meaning changes to force a one-time re-derive — the versioning the format previously lacked.

Desktop needs no change (it lists through `agent.ListSessions`).

## Tests

- `TestListSessionsTrustsRecordedEmptyWithoutDecoding` — a counts-authoritative meta claiming `Turns == 0` skips the session even though the `.jsonl` actually has content, proving the version gate trusts the meta and does not decode.
- `TestListSessionsRecordsEmptyLegacySessionOnce` — an empty legacy session is decoded once and stamped authoritative-empty (`SchemaVersion` set, `Turns == 0`), so later listings won't re-decode it.
- Existing `TestListSessionsUsesSidecarWithoutDecoding` / `TestListSessionsBackfillsLegacySession` still pass.

`go test ./internal/agent ./internal/control` green; `gofmt`/`go vet` clean.