### PR TITLE
perf(control): write goal state off the controller lock

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -119,6 +119,11 @@ type Controller struct {
 	// goalStatePath is where the current goal state is persisted for session
 	// continuity. Empty means no persistence.
 	goalStatePath string
+	// goalWriteMu serializes goal-state disk writes so they happen OFF c.mu: a
+	// caller builds the JSON under c.mu (cheap) then writes it here after
+	// unlocking, keeping the per-turn goal persistence out of the critical
+	// section that approvals and status polls also take.
+	goalWriteMu sync.Mutex
 
 	// Checkpoints (snapshot-based rewind). cp is the per-session store rebound when
 	// the session path changes; cpRoot is the workspace root used to guard restore
@@ -756,7 +761,7 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.goalIntercepts = 0
 		c.goalSelfCheckDone = false
 		c.goalIdleTurns = 0
-		c.saveGoalState()
+		// (final state is persisted once below, after the lock is released)
 		c.goal = ""
 		c.goalStatus = GoalStatusComplete
 		c.goalBlocks = 0
@@ -808,11 +813,14 @@ func (c *Controller) advanceGoalAfterTurn() bool {
 		c.goalIdleTurns = 0
 		notice = c.goalBlock
 	}
+	var savePath string
+	var saveData []byte
 	if notice != "" {
-		c.saveGoalState()
+		savePath, saveData, _ = c.buildGoalStateLocked()
 	}
 	cont := notice == ""
 	c.mu.Unlock()
+	c.writeGoalState(savePath, saveData)
 	if notice != "" {
 		c.notice(notice)
 	}
@@ -937,16 +945,20 @@ func (c *Controller) stopGoal(status string) {
 	c.goalIntercepts = 0
 	c.goalSelfCheckDone = false
 	c.goalIdleTurns = 0
-	c.saveGoalState()
+	path, data, _ := c.buildGoalStateLocked()
 	c.mu.Unlock()
+	c.writeGoalState(path, data)
 }
 
-// saveGoalState persists the current goal state to disk for session continuity.
-func (c *Controller) saveGoalState() {
+// buildGoalStateLocked marshals the current goal state for persistence. The
+// caller holds c.mu; this only reads in-memory state and the executor's todo
+// snapshot, never touching disk. Returns the target path and JSON, or ok=false
+// when persistence is disabled. The matching writeGoalState does the disk write
+// OFF c.mu so the per-turn save can't stall an approval or status poll.
+func (c *Controller) buildGoalStateLocked() (path string, data []byte, ok bool) {
 	if c.goalStatePath == "" || c.executor == nil {
-		return
+		return "", nil, false
 	}
-	todos := c.executor.CanonicalTodoState()
 	state := goalState{
 		Goal:         c.goal,
 		Status:       c.goalStatus,
@@ -955,18 +967,30 @@ func (c *Controller) saveGoalState() {
 		Blocks:       c.goalBlocks,
 		Block:        c.goalBlock,
 		Strict:       c.goalStrict,
-		Todos:        todos,
+		Todos:        c.executor.CanonicalTodoState(),
 	}
-	data, err := json.Marshal(state)
+	b, err := json.Marshal(state)
 	if err != nil {
 		slog.Warn("controller: marshal goal state", "err", err)
+		return "", nil, false
+	}
+	return c.goalStatePath, b, true
+}
+
+// writeGoalState persists pre-marshaled goal-state bytes to disk, OFF c.mu and
+// serialized by goalWriteMu so concurrent saves don't interleave or land out of
+// order. Best-effort: failures are logged, not surfaced.
+func (c *Controller) writeGoalState(path string, data []byte) {
+	if path == "" || data == nil {
 		return
 	}
-	if err := os.MkdirAll(filepath.Dir(c.goalStatePath), 0o755); err != nil {
+	c.goalWriteMu.Lock()
+	defer c.goalWriteMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		slog.Warn("controller: goal state dir", "err", err)
 		return
 	}
-	if err := os.WriteFile(c.goalStatePath, data, 0o644); err != nil {
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		slog.Warn("controller: write goal state", "err", err)
 	}
 }
@@ -1851,8 +1875,9 @@ func (c *Controller) PlanMode() bool {
 func (c *Controller) GoalStrict(strict bool) {
 	c.mu.Lock()
 	c.goalStrict = strict
-	c.saveGoalState()
+	path, data, _ := c.buildGoalStateLocked()
 	c.mu.Unlock()
+	c.writeGoalState(path, data)
 }
 
 // SetGoal stores a session-scoped active goal. Compose injects it into outgoing
@@ -1865,7 +1890,6 @@ func (c *Controller) SetGoal(goal string) {
 func (c *Controller) SetGoalWithResearchMode(goal string, researchMode GoalResearchMode) {
 	goal = strings.TrimSpace(goal)
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if goal == "" {
 		c.goal = ""
 		c.goalStatus = GoalStatusStopped
@@ -1878,10 +1902,13 @@ func (c *Controller) SetGoalWithResearchMode(goal string, researchMode GoalResea
 		c.goalSelfCheckDone = false
 		c.goalIdleTurns = 0
 		c.goalStrict = false
-		c.saveGoalState()
+		path, data, _ := c.buildGoalStateLocked()
+		c.mu.Unlock()
+		c.writeGoalState(path, data)
 		return
 	}
 	if c.goal == goal && c.goalStatus == GoalStatusRunning && c.goalResearchMode == researchMode {
+		c.mu.Unlock()
 		return
 	}
 	c.goal = goal
@@ -1895,7 +1922,9 @@ func (c *Controller) SetGoalWithResearchMode(goal string, researchMode GoalResea
 	c.goalSelfCheckDone = false
 	c.goalIdleTurns = 0
 	c.goalStrict = false
-	c.saveGoalState()
+	path, data, _ := c.buildGoalStateLocked()
+	c.mu.Unlock()
+	c.writeGoalState(path, data)
 }
 
 func (c *Controller) ClearGoal() {

--- a/internal/control/goal_concurrency_test.go
+++ b/internal/control/goal_concurrency_test.go
@@ -1,0 +1,71 @@
+package control
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+)
+
+// TestGoalStateWritesAreConcurrencySafe hammers goal-state persistence from many
+// goroutines (each GoalStrict builds the JSON under c.mu, then writes off-lock via
+// goalWriteMu) while c.mu-guarded reads run concurrently. Under -race this proves
+// the new build-under-lock / write-off-lock split has no data race, and that
+// goalWriteMu keeps the on-disk file from being torn by interleaved writes.
+func TestGoalStateWritesAreConcurrencySafe(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.jsonl")
+	sess := agent.NewSession("sys")
+	exec := agent.New(nil, nil, sess, agent.Options{}, event.Discard)
+	c := New(Options{Executor: exec, SessionDir: dir, SessionPath: path, Label: "test"})
+	c.SetGoalWithResearchMode("concurrent goal", GoalResearchOn)
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = c.Running()       // takes c.mu
+				_ = c.RuntimeStatus() // takes c.mu
+				_ = c.Goal()          // takes c.mu
+				_ = c.GoalStatus()    // takes c.mu
+			}
+		}
+	}()
+
+	var writers sync.WaitGroup
+	for w := range 8 {
+		writers.Add(1)
+		go func(w int) {
+			defer writers.Done()
+			for i := range 10 {
+				c.GoalStrict(i%2 == 0) // build under c.mu, write off-lock
+			}
+		}(w)
+	}
+	writers.Wait()
+	close(stop)
+	readers.Wait()
+
+	// goalWriteMu must have kept the file intact: still valid JSON, goal preserved.
+	data, err := os.ReadFile(goalStatePath(path))
+	if err != nil {
+		t.Fatalf("read goal state: %v", err)
+	}
+	var state goalState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("goal state file torn by concurrent writes: %v\n%s", err, data)
+	}
+	if state.Goal != "concurrent goal" || state.Status != GoalStatusRunning {
+		t.Fatalf("goal state = %+v, want the active goal preserved", state)
+	}
+}


### PR DESCRIPTION
Stage 1 of the goal-FSM extraction (architecture-review P0: "disk I/O under `c.mu`"). This PR does only the lock fix; the structural move of the goal state into a dedicated collaborator is a deliberate follow-up.

## Problem

`saveGoalState` built the goal-state JSON (including `c.executor.CanonicalTodoState()`) **and** wrote it to disk (`os.MkdirAll` + `os.WriteFile`) all under `c.mu`. It runs after **every** goal-loop turn (`advanceGoalAfterTurn`) and on `SetGoal`/`ClearGoal`/`GoalStrict`/`stopGoal`. Since `requestApproval`, `RuntimeStatus`, and `Running` also take `c.mu`, the lock was held across a filesystem write between every goal turn — so an approval decision or a status poll could stall on goal persistence.

## Fix

Split `saveGoalState` into:
- **`buildGoalStateLocked()`** — caller holds `c.mu`; reads the goal fields + executor todo snapshot and marshals to JSON. Cheap, in-memory, no disk.
- **`writeGoalState(path, data)`** — runs **off `c.mu`**, serialized by a new `goalWriteMu` so concurrent saves can't interleave or land out of order.

Each caller (`advanceGoalAfterTurn`, `stopGoal`, `GoalStrict`, `SetGoalWithResearchMode`) now captures the snapshot under the lock and writes after releasing it.

Behavior preserved:
- Writes stay **synchronous** in the calling goroutine, so persistence completes before the method returns (a caller reading the file immediately still sees it — `TestGoalStatePersistsNextToSessionPath`).
- The persisted result is identical. `advanceGoalAfterTurn`'s redundant pre-clear save in the complete path (always immediately overwritten by the final save) is dropped — the final on-disk state is unchanged.

## Tests

- All of `goal_test.go` (11 tests: auto-continue loop, blocked audit, intercepts, strict mode) + `TestGoalStatePersistsNextToSessionPath` pass under `-race`.
- Added `TestGoalStateWritesAreConcurrencySafe`: 8 writers hammering goal persistence with concurrent `c.mu`-guarded readers; under `-race` proves no data race and that `goalWriteMu` keeps the on-disk file intact.

`go test -race ./internal/control` green; `gofmt`/`go vet` clean.

## Follow-up

Stage 2 (separate PR): move the ~12 `goal*` fields + the FSM logic into a dedicated `goalMachine` collaborator with its own mutex, so the goal state stops sharing the run-state lock entirely.