### PR TITLE
perf(desktop): gate legacy topic migration behind a per-dir marker

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -2959,8 +2959,43 @@ func activityStatusForTab(tab *WorkspaceTab) string {
 // and from ListProjectTree, so without it parallel runs lose each other's appends.
 var legacyMigrationMu sync.Mutex
 
+// topicMigrationMarker, once written into a session dir, records that the
+// pre-topic → Global-topic migration pass completed for that dir, so the
+// per-render ListProjectTree call can skip the full session scan instead of
+// re-reading every .jsonl + sidecar only to find nothing left to migrate. New
+// sessions are born with a TopicID, so no fresh legacy files appear afterwards.
+// It is stamped only when the pass left nothing deferred (an empty legacy
+// session that could gain content later keeps the dir unmarked), so the gate
+// never hides a session that should still be migrated.
+const topicMigrationMarker = ".topics-migrated"
+
+func topicMigrationDone(dir string) bool {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return false
+	}
+	_, err := os.Stat(filepath.Join(dir, topicMigrationMarker))
+	return err == nil
+}
+
+func markTopicMigrationDone(dir string) {
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return
+	}
+	_ = os.WriteFile(filepath.Join(dir, topicMigrationMarker), nil, 0o644)
+}
+
 func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if strings.TrimSpace(dir) == "" {
+		return nil
+	}
+	// One-shot per dir: once the migration pass has completed, skip the full
+	// per-render session scan entirely.
+	if topicMigrationDone(dir) {
 		return nil
 	}
 	// Determine scope from the directory. The global session dir gets Global
@@ -2985,20 +3020,31 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	}
 	legacyMigrationMu.Lock()
 	defer legacyMigrationMu.Unlock()
-	infos, err := agent.ListSessionOrder(dir)
-	if err != nil || len(infos) == 0 {
+	// Re-check under the lock: another render may have completed the pass while
+	// this one waited.
+	if topicMigrationDone(dir) {
 		return nil
+	}
+	infos, err := agent.ListSessionOrder(dir)
+	if err != nil {
+		return nil // transient read error — retry on the next render, leave unmarked
 	}
 
 	var migratedTopicIDs []string
 	var titles map[string]string
 	var topicTitles map[string]string
 	var topicSources map[string]string
+	// deferred stays false only when every session was either migrated or is
+	// permanently non-migratable. A transient skip (unreadable meta, empty
+	// session that may gain content, failed write) sets it, keeping the dir
+	// unmarked so the next render retries instead of the gate hiding it forever.
+	deferred := false
 	for _, info := range infos {
 		if strings.TrimSpace(info.TopicID) != "" {
 			continue
 		}
 		if meta, ok, err := agent.LoadBranchMeta(info.Path); err != nil {
+			deferred = true
 			continue
 		} else if ok && (meta.Scope != "" || strings.TrimSpace(meta.WorkspaceRoot) != "" || strings.TrimSpace(meta.TopicID) != "") {
 			continue
@@ -3009,6 +3055,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		}
 		preview, turns := agent.SessionPreview(info.Path)
 		if turns == 0 {
+			deferred = true // empty now, but a later turn could make it migratable
 			continue
 		}
 		if titles == nil {
@@ -3034,6 +3081,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 
 		meta, err := agent.EnsureBranchMeta(info.Path)
 		if err != nil {
+			deferred = true
 			continue
 		}
 		// Skip sessions that already have a scope or workspace — they were
@@ -3046,6 +3094,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		meta.TopicID = topicID
 		meta.TopicTitle = title
 		if err := agent.SaveBranchMetaPreserveUpdated(info.Path, meta); err != nil {
+			deferred = true
 			continue
 		}
 		if topicTitles == nil {
@@ -3061,6 +3110,9 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		migratedTopicIDs = append(migratedTopicIDs, topicID)
 	}
 	if len(migratedTopicIDs) == 0 {
+		if !deferred {
+			markTopicMigrationDone(dir) // nothing left to migrate — gate future scans
+		}
 		return nil
 	}
 	f := loadProjectsFile()
@@ -3083,6 +3135,9 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		_ = saveTopicTitleSources(topicTitleRoot, topicSources)
 	}
 	invalidateTopicSessionIndex(dir)
+	if !deferred {
+		markTopicMigrationDone(dir) // pass complete with nothing deferred
+	}
 	return migratedTopicIDs
 }
 

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -416,6 +416,54 @@ func TestLegacySessionsMigrateIntoGlobalTopics(t *testing.T) {
 	}
 }
 
+func TestTopicMigrationMarkerGatesRescan(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	writeLegacySession(t, dir, "first.jsonl", "first legacy prompt", time.Now().Add(-time.Hour))
+
+	// First render migrates the legacy session and, with nothing deferred, stamps
+	// the one-shot marker so later renders can skip the scan.
+	NewApp().ListProjectTree()
+	if _, err := os.Stat(filepath.Join(dir, topicMigrationMarker)); err != nil {
+		t.Fatalf("expected migration marker after a complete pass: %v", err)
+	}
+
+	// A legacy session added after the marker is left un-migrated: the gate skips
+	// the per-render scan entirely (real new sessions are born with a TopicID, so
+	// no fresh legacy files actually appear after the pass).
+	second := writeLegacySession(t, dir, "second.jsonl", "second legacy prompt", time.Now())
+	NewApp().ListProjectTree()
+	meta, ok, err := agent.LoadBranchMeta(second)
+	if err != nil {
+		t.Fatalf("load second meta: %v", err)
+	}
+	if ok && strings.TrimSpace(meta.TopicID) != "" {
+		t.Fatalf("marker should have gated re-scan, but second session was migrated: %+v", meta)
+	}
+}
+
+func TestTopicMigrationDefersEmptyLegacySession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir sessions: %v", err)
+	}
+	// An empty legacy session (no user turns) is not migratable yet but could gain
+	// content later, so the pass must NOT mark the dir done — otherwise the gate
+	// would hide it forever.
+	if err := os.WriteFile(filepath.Join(dir, "empty.jsonl"), nil, 0o644); err != nil {
+		t.Fatalf("write empty session: %v", err)
+	}
+
+	NewApp().ListProjectTree()
+	if _, err := os.Stat(filepath.Join(dir, topicMigrationMarker)); err == nil {
+		t.Fatal("an empty legacy session must defer marking, but the dir was marked done")
+	}
+}
+
 func TestV05LegacyEventSessionsImportIntoGlobalTopic(t *testing.T) {
 	home := isolateDesktopUserDirs(t)
 


### PR DESCRIPTION
Architecture-review P0 follow-up: take the legacy topic migration off the hot sidebar-render path.

## Problem

`migrateLegacySessionsIntoGlobalTopics` is the first line of `ListProjectTree` (every sidebar render) and also runs from every `buildTabController`. It takes a global lock (`legacyMigrationMu`) and does a full `agent.ListSessionOrder(dir)` — `ReadDir` + `LoadBranchMeta` per session — only to find, in steady state, that every session already has a `TopicID` and there is nothing to migrate. So each render re-pays the discovery cost under a global lock to do nothing. `internal/agent/migrate.go`'s passes are correctly marker-gated one-shots; this one wasn't.

## Fix

Gate the migration behind a **per-dir one-shot marker** (`.topics-migrated`), checked at the top (and re-checked under the lock). Once a dir's pass completes, the marker short-circuits future calls before the scan. New sessions are born with a `TopicID`, so no fresh legacy files appear after the pass. The marker file is ignored by every dir scan (they filter `.jsonl` / `.jsonl.meta`).

## Zero-regression safety

The marker is stamped **only when nothing was deferred**. A `deferred` flag is set when a session is skipped for a reason that could resolve later — an empty session (`turns == 0`, could gain content), an unreadable meta, or a failed write. While anything is deferred, the dir stays unmarked and keeps being scanned, so the gate never permanently hides a session that should still be migrated. Callers are unaffected: in steady state the function already returned `nil` (nothing new), so returning `nil` early via the marker is behavior-preserving — the project tree is built from the persisted `desktop-projects.json` + session metas, not from re-running the migration.

## Tests

- `TestTopicMigrationMarkerGatesRescan` — the marker is written after a complete pass, and a legacy session added afterwards is left un-migrated (the scan is gated).
- `TestTopicMigrationDefersEmptyLegacySession` — an empty legacy session defers marking, so the dir is not gated.
- Existing `TestLegacySessionsMigrateIntoGlobalTopics` (incl. its idempotency check) and the other migration tests still pass.

The desktop module can't build locally in my env (cgo/webkit `-arch` error), so `go build` + `go test` + `golangci-lint` are verified by the **desktop CI job** on this PR. `gofmt` clean.