### PR TITLE
fix(agent): allow guidance-only executor handoffs

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -781,7 +781,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				a.maybeCompact(ctx, usage)
 				continue
 			}
-			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges {
+			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges && shouldNudgeExecutorHandoff(input, text) {
 				handoffNudges++
 				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor answered without taking any action; nudging it to use its tools"})
 				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(executorHandoffRetryMessage())})
@@ -1099,6 +1099,133 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 
 func finalReadinessRetryMessage(reason string) string {
 	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
+}
+
+func shouldNudgeExecutorHandoff(input, answer string) bool {
+	return !executorHandoffAllowsTextOnly(input, answer)
+}
+
+func executorHandoffAllowsTextOnly(input, answer string) bool {
+	if looksLikeExecutorHandoffDeferral(answer) {
+		return false
+	}
+	task, plan, ok := parseExecutorHandoff(input)
+	if !ok {
+		return false
+	}
+	if handoffTaskLooksTextOnly(task) {
+		return true
+	}
+	return handoffPlanLooksTextOnly(plan)
+}
+
+func parseExecutorHandoff(input string) (task, plan string, ok bool) {
+	input = StripTransientUserBlocks(input)
+	marker := "# " + executorHandoffMarker
+	i := strings.Index(input, marker)
+	if i < 0 {
+		return "", "", false
+	}
+	input = input[i+len(marker):]
+	_, input, ok = strings.Cut(input, "\n\nOriginal task:\n")
+	if !ok {
+		return "", "", false
+	}
+	task, input, ok = strings.Cut(input, "\n\nPlanner output:\n")
+	if !ok {
+		return "", "", false
+	}
+	plan, _, ok = strings.Cut(input, "\n\nExecutor instructions:")
+	if !ok {
+		return "", "", false
+	}
+	return strings.TrimSpace(task), strings.TrimSpace(plan), true
+}
+
+func looksLikeExecutorHandoffDeferral(answer string) bool {
+	lower := strings.ToLower(strings.TrimSpace(answer))
+	if lower == "" {
+		return true
+	}
+	if containsAnySubstring(lower, executorHandoffDeferralPhrases) {
+		return true
+	}
+	switch strings.Trim(lower, " \t\r\n.!?。！？") {
+	case "ok", "okay", "sounds good", "done", "好的", "可以", "没问题", "收到":
+		return true
+	default:
+		return false
+	}
+}
+
+func handoffTaskLooksTextOnly(task string) bool {
+	lower := strings.ToLower(strings.TrimSpace(task))
+	if lower == "" {
+		return false
+	}
+	if strings.HasPrefix(lower, "what ") || strings.HasPrefix(lower, "why ") || strings.HasPrefix(lower, "how ") {
+		return !containsAnySubstring(lower, executorHandoffWorkRequestTerms)
+	}
+	return containsAnySubstring(lower, executorHandoffTextOnlyTaskTerms)
+}
+
+func handoffPlanLooksTextOnly(plan string) bool {
+	lower := strings.ToLower(strings.TrimSpace(plan))
+	if lower == "" {
+		return false
+	}
+	if containsAnySubstring(lower, executorHandoffLocalActionTerms) {
+		return false
+	}
+	if containsAnySubstring(lower, executorHandoffTextOnlyPlanTerms) {
+		return true
+	}
+	return strings.Contains(lower, "?") && !containsAnySubstring(lower, executorHandoffLocalActionTerms)
+}
+
+func containsAnySubstring(s string, terms []string) bool {
+	for _, term := range terms {
+		if strings.Contains(s, term) {
+			return true
+		}
+	}
+	return false
+}
+
+var executorHandoffDeferralPhrases = []string{
+	"plan looks", "looks good", "should be easy", "should be straightforward",
+	"i can implement", "i'll implement", "i will implement", "i'll get started",
+	"let me ", "i will now", "i'll now", "i can do that",
+	"计划看起来", "可以实现", "我会", "我将", "接下来我", "马上开始",
+}
+
+var executorHandoffWorkRequestTerms = []string{
+	"implement", "fix", "refactor", "migrate", "edit", "write", "create", "delete",
+	"test", "build", "repair", "patch", "修改", "修复", "实现", "新增", "重构", "迁移", "补齐",
+}
+
+var executorHandoffTextOnlyTaskTerms = []string{
+	"now what", "what next", "tl;dr", "tldr", "summarize", "summary", "explain",
+	"i installed", "i just installed", "i turned on", "i enabled", "it's on", "it is on",
+	"怎么办", "下一步", "然后呢", "总结", "解释", "说明", "装了", "装好了", "安装了", "开了", "开启了", "打开了",
+}
+
+var executorHandoffLocalActionTerms = []string{
+	"write_file", "read_file", "apply_patch", "bash", "tool", "tools",
+	"workspace", "repo", "repository", "codebase", "file", "path",
+	"write ", "edit ", "modify ", "create ", "delete ", "patch ", "refactor ", "implement ",
+	"run ", "command", "test", "build",
+	"文件", "路径", "仓库", "代码", "写入", "编辑", "修改", "创建", "删除", "运行", "命令", "测试", "构建",
+}
+
+var executorHandoffTextOnlyPlanTerms = []string{
+	"tell the user", "ask the user", "guide the user", "explain to the user",
+	"summarize", "summary", "tl;dr", "tldr", "answer the user", "respond to the user",
+	"provide guidance", "walk the user", "instruct the user", "have the user",
+	"user should", "the user should", "user can", "the user can", "manual", "manually",
+	"listen", "play a song", "compare the difference", "checkbox",
+	"告诉用户", "询问用户", "问用户", "让用户", "请用户", "指导用户", "解释", "总结", "回答",
+	"手动", "试听", "听歌", "对比", "勾选",
 }
 
 func executorHandoffRetryMessage() string {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -256,6 +256,7 @@ Executor instructions:
 - Treat the planner output as context, not as your role or capability set.
 - Ignore any planner statement such as "I cannot write", "I only have read-only tools", or "hand this to the executor"; those limitations apply to the planner, not to you.
 - Do not ask the user how to trigger the executor. You are already in the executor phase.
+- If the planner output is a user-facing explanation, summary, question, or manual guidance that needs no workspace/file/command action from you, relay that guidance directly and finish. Do not invent local tool calls only to satisfy the handoff.
 - If the task requires changes, call the appropriate tools (for example write/edit/bash) instead of only restating the plan.
 - If a target path is outside the writable workspace or otherwise blocked, explain that specific blocker and ask for the needed path/approval.
 - **Serial workflow**: establish the task list with one todo_write (first sub-task in_progress), then for EACH sub-task execute it and call complete_step with evidence. The host advances the list for you — it marks the sub-task completed and moves the next to in_progress, so you don't need another todo_write to mark completions. Sign off one sub-task at a time; never batch completions.

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -335,6 +335,65 @@ func TestCoordinatorNudgesExecutorThatAnswersWithoutActing(t *testing.T) {
 	}
 }
 
+func TestCoordinatorAllowsGuidanceOnlyExecutorHandoff(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Tell the user to open the audio app, enable the Peace checkbox, and play a song to compare the difference."},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "Open the audio app, enable the Peace checkbox, then play a familiar song and compare the sound with the switch on and off."},
+			{Type: provider.ChunkDone},
+		},
+	}}
+
+	executor := New(exec, tool.NewRegistry(), NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "I just installed EqualizerAPO, now what?"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 1 {
+		t.Fatalf("executor requests = %d, want one guidance-only final answer with no handoff nudge", got)
+	}
+}
+
+func TestCoordinatorNudgesWorkTaskEvenIfPlannerMentionsUserGuidance(t *testing.T) {
+	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
+		{Type: provider.ChunkText, Text: "Tell the user to edit main.go and add the missing branch."},
+		{Type: provider.ChunkDone},
+	}}
+	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
+		{
+			{Type: provider.ChunkText, Text: "Open main.go and add the missing branch in the handler."},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "write_file", Arguments: `{"path":"main.go"}`}},
+			{Type: provider.ChunkDone},
+		},
+		{
+			{Type: provider.ChunkText, Text: "Done."},
+			{Type: provider.ChunkDone},
+		},
+	}}
+
+	execReg := tool.NewRegistry()
+	execReg.Add(coordinatorTestTool{name: "write_file", readOnly: false, output: "wrote file"})
+	executor := New(exec, execReg, NewSession("exec-sys"), Options{}, event.Discard)
+	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
+
+	if err := coord.Run(context.Background(), "fix the bug"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got := len(exec.requests); got != 3 {
+		t.Fatalf("executor requests = %d, want text answer, nudge tool call, final answer", got)
+	}
+	if got := lastUser(exec.requests[1]); !strings.Contains(got, "Use your available tools now to carry out the task") {
+		t.Fatalf("second executor request missing handoff nudge message: %q", got)
+	}
+}
+
 func TestCoordinatorDoesNotNudgeExecutorThatActs(t *testing.T) {
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "Write the requested skill file."},


### PR DESCRIPTION
## Summary

- Fixes #4867 by allowing PE executor handoffs to finish with a text-only answer when the original turn or planner output is clearly user-facing guidance, a summary, or a follow-up question.
- Keeps the existing handoff nudge for real work tasks and deferral-style answers, so code/file changes still require executor tool calls.
- Updates the executor handoff instructions to avoid invented local tool calls for pure guidance-only turns.

## Verification

- `go test ./internal/agent -run 'TestCoordinator(AllowsGuidanceOnlyExecutorHandoff|NudgesExecutorThatAnswersWithoutActing|NudgesWorkTaskEvenIfPlannerMentionsUserGuidance|DoesNotNudgeExecutorThatActs)' -count=1`
- `go test ./internal/agent -count=1`
- `go test ./...`
- `(cd desktop && go test ./...)` (passes; local linker prints the existing duplicate `-lobjc` warning)
- `go vet ./...`
- `(cd desktop && go vet ./...)`
- `git diff --check`
- `gofmt -l .`

## Cache impact

Cache-impact: low - touches the executor handoff gate and one handoff user-turn instruction; system prompt and tool schemas are unchanged.
Cache-guard: Added focused coordinator regressions for guidance-only handoffs and for preserving the work-task nudge; also ran `go test ./internal/agent -count=1` and `go test ./...`.
System-prompt-review: N/A
