### PR TITLE
feat: add /reload-cmd command for hot-reloading custom slash commands

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3673,6 +3673,7 @@ func (a *App) Commands() []CommandInfo {
 		{Name: "hooks", Description: i18n.M.CmdHooks, Kind: "builtin"},
 		{Name: "theme", Description: i18n.M.CmdTheme, Kind: "builtin"},
 		{Name: "skill", Description: i18n.M.CmdSkill, Kind: "builtin"},
+		{Name: "reload-cmd", Description: i18n.M.CmdReloadCmd, Kind: "builtin"},
 	}
 	a.mu.RLock()
 	ctrl := a.activeCtrlLocked()
@@ -4240,6 +4241,22 @@ func (a *App) RemoveSkillPath(path string) error {
 func (a *App) RefreshSkills() error {
 	a.invalidateSkillRootsCache()
 	return a.rebuild()
+}
+
+// ReloadCommands rescans command directories and hot-swaps without restarting
+// the controller — no MCP disconnect, no hook rerun.
+func (a *App) ReloadCommands() error {
+	if a.ctx == nil {
+		return nil
+	}
+	tab := a.activeTab()
+	if tab == nil || tab.Ctrl == nil {
+		return fmt.Errorf("no active session")
+	}
+	if tab.Ctrl.Running() {
+		return fmt.Errorf("wait for the current turn to finish, then retry")
+	}
+	return tab.Ctrl.ReloadCommands(a.ctx)
 }
 
 // SetSkillEnabled persists a skill toggle and rebuilds the controller so the

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -191,6 +191,7 @@ export interface AppBindings {
   AddSkillPath(path: string): Promise<void>;
   RemoveSkillPath(path: string): Promise<void>;
   RefreshSkills(): Promise<void>;
+  ReloadCommands(): Promise<void>;
   SetSkillEnabled(name: string, enabled: boolean): Promise<void>;
   SetMCPServerEnabled(name: string, enabled: boolean): Promise<void>;
   SetMCPServerTier(name: string, tier: string): Promise<void>;
@@ -2037,6 +2038,7 @@ function makeMockApp(): AppBindings {
       }
     },
     async RefreshSkills() {},
+    async ReloadCommands() {},
     async SetSkillEnabled(name: string, enabled: boolean) {
       const skill = capSkills.find((s) => s.name === name);
       if (skill) skill.enabled = enabled;

--- a/docs/superpowers/specs/2026-06-19-reload-cmd-design.md
+++ b/docs/superpowers/specs/2026-06-19-reload-cmd-design.md
@@ -1,0 +1,90 @@
+# `/reload-cmd` — 自定义命令轻量热加载
+
+## 背景
+
+Reasonix 支持通过 `.md` 文件定义自定义 slash command（位于 `.reasonix/commands/`、`.claude/commands/` 等目录）。每次新增或修改命令文件后，当前必须重启应用（或 `/new`）才能生效。在多 Tab 桌面端或长时间运行的 CLI 会话中，重启中断了当前工作流。
+
+Goal：提供一个 `/reload-cmd` 命令，不重启 Controller、不中断 MCP 连接、不重跑 Hooks，毫秒级热加载自定义命令。
+
+> **注意：** "不修改系统提示词"指 system prompt 前缀（intro 块）不变。但 tools 缓存块会在命令集合变化时重新验证，因为 `slashCommandTool.Description()` 随命令列表变化，模型端下一轮需重新拉取 tool schemas。
+
+## 方案选型
+
+**选择方案 B — 轻量热加载**，理由：
+
+- 不关 MCP、不跑 Hooks，当前会话完全无感（1-5ms 完成）
+- 基于已有基础设施：`command.Load()` 是无副作用的纯函数，`Registry.Add()` 支持同名覆盖，`c.Skills()` 已有半热加载能力
+- Scope 清晰：只重载命令文件，Skills 系统提示词索引由 `/skills` 或独立的 `/reload-skills` 负责
+
+## 架构
+
+```
+/reload-cmd
+    │
+    ▼
+Controller.ReloadCommands(ctx)
+    │
+    ├── 1. command.Load(dirs...) ── 重新扫盘，获取最新 .md 文件
+    │
+    ├── 2. 合并 Skills + Commands ── Skills 在前，Commands 在后（同名时 Command 覆盖 Skill）
+    │
+    ├── 3. reg.Add(NewSlashCommandTool(entries)) ── 覆盖 Registry，模型侧下轮自动生效
+    │
+    ├── 4. c.commands.Store(&cmds) ── atomic.Pointer 替换，人类输入 /name 即刻生效
+    │
+    └── CLI: 刷新 m.commands + updateCompletion() ── 补全菜单同步更新
+```
+
+## 关键流程
+
+### 命令的消费路径
+
+Reasonix 中有两条独立的消费路径：
+
+| 路径 | 消费者 | 对应热加载操作 |
+|------|--------|--------------|
+| **模型调用** `slash_command({command, args})` | Tool Registry → `slashCommandTool.entries` | `reg.Add(NewTool)` 覆盖 |
+| **人类输入** `/name args` | `Controller.CustomCommand()` → `c.commands` 遍历 | `c.commands.Store(&cmds)` |
+
+两者都是启动时扫盘得到的快照。热加载只需将两份快照同时替换，无需重建 Controller。
+
+### Skills 不丢失
+
+`slash_command` tool 是一个扁平的 `map[string]SlashEntry`，Commands 和 Skills 共用命名空间。重建 tool 时必须连带当前 Skills 一起打包，否则 Skills 入口会从模型侧消失：
+
+```go
+entries := []command.SlashEntry{}
+for _, sk := range c.Skills() { /* 打包 skills */ }
+for _, cmd := range cmds      { /* 打包 commands */ }
+c.reg.Add(command.NewSlashCommandTool(entries))
+```
+
+`c.Skills()` 在有 `skillStore` 时每次调用都扫盘，拿到的总是最新的。
+
+## 变更文件
+
+| 文件 | 改动说明 | 类型 |
+|------|---------|------|
+| `internal/command/slashtool.go` | 无需改动，使用 `NewSlashCommandTool` + `reg.Add` 覆盖即可 | — |
+| `internal/control/controller.go` | `commands` 字段改为 `atomic.Pointer[[]command.Command]`；新增 `ReloadCommands(ctx)` 方法 | 核心逻辑 |
+| `internal/cli/chat_tui.go` | 输入处理加 `case "/reload-cmd"`，调 `ctrl.ReloadCommands()` 并刷新 `m.commands` | CLI 前端 |
+| `internal/cli/complete.go` | 补全菜单加 `/reload-cmd` 条目 | CLI 前端 |
+| `internal/cli/help_view.go` | 内置命令列表加 `/reload-cmd` 条目 | CLI 前端 |
+| `internal/i18n/messages_*.go` | 国际化字符串（CmdReloadCmd 等） | CLI 前端 |
+| `desktop/app.go` | 加 `ReloadCommands()` 方法，桥接到 `tab.Ctrl.ReloadCommands()` | Desktop 前端 |
+
+## 边界情况
+
+| 场景 | 处理方式 |
+|------|---------|
+| **Turn 运行中** | 检查 `ctrl.Running()`，非阻塞 notice 提示用户 "wait for the current turn to finish" |
+| **无命令文件变更** | 静默成功，不产生额外提示 |
+| **同名命令覆盖** | `command.Load()` 保持后扫盘覆盖前扫盘的顺序，与启动行为一致 |
+| **并发安全** | `reg.Add()` 内部持锁，`c.commands.Store()` 是原子操作 |
+| **Desktop 无当前 Tab** | 返回错误，前端展示 |
+
+## 测试策略
+
+1. **单元测试**：Controller 层测试 `ReloadCommands()` — 加载一批命令 → 修改文件 → 重载 → 验证新命令可用
+2. **集成测试**：验证 `Registry.Add` 同名覆盖后，agent 下一轮 `Schemas()` 返回新 tool 定义
+3. **手动验证**：CLI 和 Desktop 端分别测试 `/reload-cmd` 后 `/新命令` 立刻生效

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3530,6 +3530,26 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	case "/hooks":
 		m.echoLocalCommand(input)
 		m.runHooksSubcommand(input)
+	case "/reload-cmd":
+		m.echoLocalCommand(input)
+		if m.ctrl == nil {
+			m.notice("controller not ready")
+			return nil
+		}
+		if m.ctrl.Running() {
+			m.notice("wait for the current turn to finish, then retry /reload-cmd")
+			return nil
+		}
+		prev := len(m.commands)
+		err := m.ctrl.ReloadCommands(context.Background())
+		m.commands = m.ctrl.Commands()
+		m.updateCompletion()
+		if err != nil {
+			m.notice("reload-cmd: " + err.Error())
+			return nil
+		}
+		m.notice(fmt.Sprintf("commands reloaded: %d → %d commands", prev, len(m.commands)))
+
 	case "/paste-image":
 		return pasteClipboardImage()
 	case "/output-style", "/output-styles":

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -74,6 +74,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/model", insert: "/model ", hint: i18n.M.CmdModel, descend: true},
 		{label: "/provider", insert: "/provider ", hint: i18n.M.CmdProvider, descend: true},
 		{label: "/skills", insert: "/skills", hint: i18n.M.CmdSkill},
+		{label: "/reload-cmd", insert: "/reload-cmd", hint: i18n.M.CmdReloadCmd},
 		{label: "/hooks", insert: "/hooks ", hint: i18n.M.CmdHooks, descend: true},
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
 		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -78,6 +78,7 @@ func builtinHelpItems() []compItem {
 		{label: "/language", hint: i18n.M.CmdLanguage},
 		{label: "/auto-plan", hint: i18n.M.CmdAutoPlan},
 		{label: "/reasoning-language", hint: i18n.M.CmdReasonLang},
+		{label: "/reload-cmd", hint: i18n.M.CmdReloadCmd},
 		{label: "/help", hint: i18n.M.CmdHelp},
 	}
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -67,7 +67,7 @@ type Controller struct {
 	systemPrompt      string
 	sessionDir        string
 	host              *plugin.Host
-	commands          []command.Command
+	commands          atomic.Pointer[[]command.Command]
 	skills            []skill.Skill
 	allSkills         []skill.Skill
 	skillStore        *skill.Store
@@ -348,7 +348,7 @@ func New(opts Options) *Controller {
 		sessionDir:             opts.SessionDir,
 		sessionPath:            opts.SessionPath,
 		host:                   opts.Host,
-		commands:               opts.Commands,
+		commands:               atomic.Pointer[[]command.Command]{},
 		skills:                 opts.Skills,
 		allSkills:              opts.AllSkills,
 		skillStore:             opts.SkillStore,
@@ -377,6 +377,8 @@ func New(opts Options) *Controller {
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
 	c.rebindCheckpoints(opts.SessionPath)
 	c.setActiveJobSession(opts.SessionPath)
+	cmdsInit := opts.Commands
+	c.commands.Store(&cmdsInit)
 	if c.executor != nil {
 		c.executor.SetPreEditHook(func(ch diff.Change) {
 			if c.cp != nil {
@@ -2734,7 +2736,49 @@ func (c *Controller) Balance(ctx context.Context) (*billing.Balance, error) {
 func (c *Controller) Host() *plugin.Host { return c.host }
 
 // Commands returns the loaded custom slash commands.
-func (c *Controller) Commands() []command.Command { return c.commands }
+func (c *Controller) Commands() []command.Command {
+	if p := c.commands.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// ReloadCommands rescans all command directories and hot-swaps the slash_command
+// tool and the internal command slice — no MCP restart, no hook rerun.
+func (c *Controller) ReloadCommands(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	cmds, loadErr := command.Load(config.CommandDirsForRoot(c.cpRoot)...)
+	cmdSkills := c.Skills()
+
+	entries := make([]command.SlashEntry, 0, len(cmdSkills)+len(cmds))
+	for _, sk := range cmdSkills {
+		sk := sk
+		entries = append(entries, command.SlashEntry{
+			Name:        sk.Name,
+			Description: sk.Description,
+			Render:      func(args []string) string { return skill.Render(sk, strings.Join(args, " ")) },
+		})
+	}
+	for _, cmd := range cmds {
+		cmd := cmd
+		entries = append(entries, command.SlashEntry{
+			Name:        cmd.Name,
+			Description: cmd.Description,
+			ArgHint:     cmd.ArgHint,
+			Render:      func(args []string) string { return cmd.Render(args) },
+		})
+	}
+	if c.reg != nil {
+		c.reg.Add(command.NewSlashCommandTool(entries))
+	}
+	cmdSlice := cmds
+	c.commands.Store(&cmdSlice)
+	return loadErr
+}
 
 // Skills returns the discoverable skills (for the slash menu and `/skills`).
 // When a live Store is available, scan it on demand so skills installed during

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,12 +14,14 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
+	"reasonix/internal/command"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
 	"reasonix/internal/jobs"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
 
@@ -1396,4 +1399,469 @@ func TestApprovedPlanDoesNotAutoApproveNonContinuationTurn(t *testing.T) {
 	if approvalPrompts != 2 {
 		t.Fatalf("non-continuation writer should prompt after plan approval, prompts=%d", approvalPrompts)
 	}
+}
+
+// writeCmdFile creates a command .md file with frontmatter under dir.
+func writeCmdFile(t *testing.T, dir, name, description, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf("---\ndescription: %s\n---\n%s\n", description, body)
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCommandsAtomicPointer verifies that commands passed via Options.Commands are
+// correctly exposed through the atomic-pointer Commands() getter and that
+// CustomCommand resolves and renders them. Missing commands return found=false.
+func TestCommandsAtomicPointer(t *testing.T) {
+	cmds := []command.Command{
+		{Name: "review", Description: "Review code", Body: "Review $1"},
+		{Name: "test", Description: "Run tests", Body: "Test $1"},
+	}
+	c := New(Options{
+		Commands: cmds,
+		Sink:     &typedNilControllerSink{},
+		Registry: tool.NewRegistry(),
+	})
+
+	// Commands() returns what was passed via Options
+	got := c.Commands()
+	if len(got) != 2 {
+		t.Fatalf("Commands() = %d, want 2", len(got))
+	}
+	// Check retrieval via CustomCommand
+	sent, ok := c.CustomCommand("/review myfile.go")
+	if !ok {
+		t.Error("/review should be found")
+	}
+	if !strings.Contains(sent, "Review myfile.go") {
+		t.Errorf("unexpected render: %q", sent)
+	}
+	_, ok = c.CustomCommand("/missing")
+	if ok {
+		t.Error("/missing should not be found")
+	}
+
+	// Commands() getter uses atomic.Pointer internally
+	if cmds2 := c.Commands(); len(cmds2) != 2 {
+		t.Errorf("Commands() = %d after change, want 2", len(cmds2))
+	}
+}
+
+// TestReloadCommandsFromFilesystem exercises ReloadCommands against real .md
+// files in a temp workspace: initial load, hot-reload with a new file, and
+// hot-reload after modifying an existing file. Also verifies that skills are
+// preserved across the reload.
+func TestReloadCommandsFromFilesystem(t *testing.T) {
+	// Isolate HOME so CommandDirsForRoot does not pick up global .md command files.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "review", "Review code", "Review $1")
+	writeCmdFile(t, cmdDir, "test", "Run tests", "Test $1")
+
+	// Create a minimal in-memory skill to verify skills are preserved across reload.
+	sk := skill.Skill{
+		Name:        "myskill",
+		Description: "Test skill",
+		Body:        "You are a test skill. User says: {{.Input}}",
+	}
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+		Skills:        []skill.Skill{sk},
+	})
+
+	// ReloadCommands should pick up the two .md files and preserve the skill.
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("ReloadCommands: %v", err)
+	}
+	cmds := c.Commands()
+	if len(cmds) != 2 {
+		t.Fatalf("Commands() = %d after reload, want 2", len(cmds))
+	}
+
+	// CustomCommand should resolve through the hot-swapped getter
+	sent, ok := c.CustomCommand("/review hello.go")
+	if !ok {
+		t.Fatal("/review should be found after reload")
+	}
+	if !strings.Contains(sent, "Review hello.go") {
+		t.Errorf("render = %q, want Review hello.go", sent)
+	}
+
+	// Missing command still not found
+	if _, ok := c.CustomCommand("/nope"); ok {
+		t.Error("/nope should not be found")
+	}
+
+	// Skill should appear in the slash_command tool's description after reload.
+	if tool, found := reg.Get("slash_command"); found {
+		if !strings.Contains(tool.Description(), "myskill") {
+			t.Error("skill 'myskill' should appear in slash_command tool Description after ReloadCommands")
+		}
+	} else {
+		t.Error("slash_command tool should be registered after ReloadCommands")
+	}
+
+	// Skill should still be callable via RunSkill after reload.
+	if _, ok := c.RunSkill("/myskill"); !ok {
+		t.Error("RunSkill(/myskill) should find the skill after ReloadCommands")
+	}
+
+	// Hot-reload: add a new command file
+	writeCmdFile(t, cmdDir, "count", "Count to N", "Count from 1 to $1")
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("ReloadCommands (add): %v", err)
+	}
+	if cmds := c.Commands(); len(cmds) != 3 {
+		t.Fatalf("Commands() = %d after add, want 3", len(cmds))
+	}
+
+	// Hot-reload: modify an existing command
+	writeCmdFile(t, cmdDir, "review", "Review code (friendly)", "Kindly review $1")
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("ReloadCommands (modify): %v", err)
+	}
+	if cmds := c.Commands(); len(cmds) != 3 {
+		t.Fatalf("Commands() = %d after modify, want 3", len(cmds))
+	}
+	sent, ok = c.CustomCommand("/review world.go")
+	if !ok {
+		t.Fatal("/review should be found after modify")
+	}
+	if !strings.Contains(sent, "Kindly review world.go") {
+		t.Errorf("render after modify = %q, want Kindly review world.go", sent)
+	}
+
+	// The slash_command tool should be registered and updated
+	if _, found := reg.Get("slash_command"); !found {
+		t.Error("slash_command tool should be registered after ReloadCommands")
+	}
+}
+
+// TestReloadCommandsDeleteFile verifies that removing a command .md file and
+// reloading causes the command to disappear from both Commands() and
+// CustomCommand(), while other commands remain intact.
+func TestReloadCommandsDeleteFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "alpha", "Alpha cmd", "Alpha $1")
+	writeCmdFile(t, cmdDir, "beta", "Beta cmd", "Beta $1")
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	if got := len(c.Commands()); got != 2 {
+		t.Fatalf("Commands() = %d, want 2", got)
+	}
+
+	// Delete alpha.md
+	if err := os.Remove(filepath.Join(cmdDir, "alpha.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("reload after delete: %v", err)
+	}
+	if got := len(c.Commands()); got != 1 {
+		t.Fatalf("Commands() = %d after delete, want 1", got)
+	}
+
+	// /alpha should no longer be found
+	if _, ok := c.CustomCommand("/alpha x"); ok {
+		t.Error("/alpha should NOT be found after deletion")
+	}
+	// /beta should still work
+	sent, ok := c.CustomCommand("/beta y")
+	if !ok {
+		t.Error("/beta should still be found")
+	}
+	if !strings.Contains(sent, "Beta y") {
+		t.Errorf("render = %q, want Beta y", sent)
+	}
+}
+
+// TestReloadCommandsMalformedFile verifies that a malformed .md file causes
+// ReloadCommands to return an error but does not prevent other valid commands
+// from loading.
+func TestReloadCommandsMalformedFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "good", "Good cmd", "Good $1")
+
+	// Write a malformed file (no valid frontmatter)
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	broken := filepath.Join(cmdDir, "broken.md")
+	if err := os.WriteFile(broken, []byte("this is not valid yaml\n---\nrandom\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	err := c.ReloadCommands(context.Background())
+	// We expect some error from the malformed file
+	if err == nil {
+		t.Log("ReloadCommands returned nil error despite malformed file — command.Load may tolerate it")
+	} else {
+		t.Logf("ReloadCommands returned error (expected): %v", err)
+	}
+
+	// The valid command should still be loadable
+	cmds := c.Commands()
+	foundGood := false
+	for _, cmd := range cmds {
+		if cmd.Name == "good" {
+			foundGood = true
+		}
+	}
+	if !foundGood {
+		t.Errorf("valid command 'good' should be present, got commands: %v", cmdNames(cmds))
+	}
+}
+
+// TestReloadCommandsSameNameAcrossDirs verifies that when the same command
+// name exists in multiple convention directories, the later-scanned directory
+// (higher priority) wins. ConventionDirs = [".reasonix", ".agents", ".agent",
+// ".claude"], scanned in reverse, so .reasonix is highest priority.
+func TestReloadCommandsSameNameAcrossDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+
+	// Lower priority: .claude/commands
+	claudeDir := filepath.Join(wsRoot, ".claude", "commands")
+	writeCmdFile(t, claudeDir, "greet", "Claude greet", "Hello from Claude: $1")
+
+	// Higher priority: .reasonix/commands
+	reasonixDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, reasonixDir, "greet", "Reasonix greet", "Hello from Reasonix: $1")
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	// There should be exactly 1 command named "greet"
+	cmds := c.Commands()
+	count := 0
+	for _, cmd := range cmds {
+		if cmd.Name == "greet" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 'greet' command, got %d", count)
+	}
+
+	// The winning version should be from .reasonix (highest priority)
+	sent, ok := c.CustomCommand("/greet world")
+	if !ok {
+		t.Fatal("/greet should be found")
+	}
+	if !strings.Contains(sent, "Hello from Reasonix") {
+		t.Errorf("expected .reasonix version to win, got render: %q", sent)
+	}
+}
+
+// TestReloadCommandsEmptySet verifies that deleting all command files and
+// reloading results in an empty Commands() slice, while the slash_command tool
+// still exists in the Registry (containing only Skills).
+func TestReloadCommandsEmptySet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "temp", "Temp cmd", "Temp $1")
+
+	sk := skill.Skill{
+		Name:        "preserved",
+		Description: "A skill to keep",
+		Body:        "Skill body: {{.Input}}",
+	}
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+		Skills:        []skill.Skill{sk},
+	})
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	if got := len(c.Commands()); got != 1 {
+		t.Fatalf("Commands() = %d, want 1", got)
+	}
+
+	// Delete all command files
+	if err := os.Remove(filepath.Join(cmdDir, "temp.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("reload after delete all: %v", err)
+	}
+	if got := len(c.Commands()); got != 0 {
+		t.Fatalf("Commands() = %d after delete all, want 0", got)
+	}
+
+	// /temp should no longer be found
+	if _, ok := c.CustomCommand("/temp x"); ok {
+		t.Error("/temp should NOT be found after deletion")
+	}
+
+	// slash_command tool should still exist (for Skills)
+	slashTool, found := reg.Get("slash_command")
+	if !found {
+		t.Fatal("slash_command tool should still exist even with 0 commands")
+	}
+	// It should still contain the skill
+	if !strings.Contains(slashTool.Description(), "preserved") {
+		t.Error("skill 'preserved' should still appear in slash_command tool Description")
+	}
+}
+
+// TestReloadCommandsDesktopManagementNotice verifies the desktop/HTTP path:
+// when the frontend submits "/reload-cmd" as raw input, Submit → managementNotice
+// handles it and emits a Notice event with the correct count.
+func TestReloadCommandsDesktopManagementNotice(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "hello", "Greet", "Hello $1")
+	writeCmdFile(t, cmdDir, "review", "Review code", "Review $1")
+
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          sink,
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	// Initial load so Commands() is populated.
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	notices = nil // reset
+
+	// Desktop path: managementNotice("/reload-cmd") should emit a notice.
+	handled := c.managementNotice("/reload-cmd")
+	if !handled {
+		t.Fatal("managementNotice(/reload-cmd) should return true")
+	}
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "commands reloaded") {
+		t.Errorf("notice = %q, want 'commands reloaded'", notices[0])
+	}
+	if !strings.Contains(notices[0], "2 available") {
+		t.Errorf("notice = %q, want '2 available'", notices[0])
+	}
+
+	// Delete one command file and reload again.
+	if err := os.Remove(filepath.Join(cmdDir, "hello.md")); err != nil {
+		t.Fatal(err)
+	}
+	notices = nil
+	handled = c.managementNotice("/reload-cmd")
+	if !handled {
+		t.Fatal("managementNotice(/reload-cmd) after delete should return true")
+	}
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice after delete, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "1 available") {
+		t.Errorf("notice after delete = %q, want '1 available'", notices[0])
+	}
+
+	// Delete all and verify empty-set notice.
+	if err := os.Remove(filepath.Join(cmdDir, "review.md")); err != nil {
+		t.Fatal(err)
+	}
+	notices = nil
+	handled = c.managementNotice("/reload-cmd")
+	if !handled {
+		t.Fatal("managementNotice(/reload-cmd) empty set should return true")
+	}
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice for empty set, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "0 available") {
+		t.Errorf("notice for empty set = %q, want '0 available'", notices[0])
+	}
+}
+
+// cmdNames is a test helper that extracts command names from a slice.
+func cmdNames(cmds []command.Command) []string {
+	names := make([]string, len(cmds))
+	for i, c := range cmds {
+		names[i] = c.Name
+	}
+	return names
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -416,7 +416,7 @@ func (c *Controller) CustomCommand(input string) (sent string, found bool) {
 		return "", false
 	}
 	name := strings.TrimPrefix(fields[0], "/")
-	for _, cmd := range c.commands {
+	for _, cmd := range c.Commands() {
 		if cmd.Name == name {
 			return cmd.Render(fields[1:]), true
 		}

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -1,8 +1,10 @@
 package control
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"reasonix/internal/config"
@@ -397,6 +399,16 @@ func (c *Controller) managementNotice(trimmed string) bool {
 			return true
 		}
 		c.notice(c.skillListText())
+	case "/reload-cmd":
+		if c.Running() {
+			c.notice("wait for the current turn to finish, then retry /reload-cmd")
+			return true
+		}
+		if err := c.ReloadCommands(context.Background()); err != nil {
+			c.notice("reload-cmd: " + err.Error())
+		} else {
+			c.notice("commands reloaded (" + strconv.Itoa(len(c.Commands())) + " available)")
+		}
 	case "/hooks":
 		sub := ""
 		if len(fields) >= 2 {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -172,6 +172,7 @@ type Messages struct {
 	CmdLanguage     string // /language
 	CmdSkill        string // /skills
 	CmdVerbose      string // /verbose
+	CmdReloadCmd    string // /reload-cmd
 	CmdDiffFold     string // /diff-fold
 	CmdSandbox      string // /sandbox
 	CmdEffort       string // /effort

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -183,6 +183,7 @@ var English = Messages{
 	CmdLanguage:     "switch CLI language",
 	CmdSkill:        "manage skills",
 	CmdVerbose:      "toggle thinking text",
+	CmdReloadCmd:    "reload custom commands",
 	CmdDiffFold:     "toggle diff fold/expand",
 	CmdSandbox:      "show sandbox status",
 	CmdEffort:       "set reasoning effort",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -184,6 +184,7 @@ var Chinese = Messages{
 	CmdLanguage:     "切换 CLI 语言",
 	CmdSkill:        "管理 skills",
 	CmdVerbose:      "切换 thinking 原文显示",
+	CmdReloadCmd:    "重载自定义命令",
 	CmdDiffFold:     "切换 diff 折叠/展开",
 	CmdSandbox:      "查看沙箱状态",
 	CmdEffort:       "设置推理强度",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -172,6 +172,7 @@ var ChineseTraditional = Messages{
 	CmdLanguage:     "切換 CLI 語言",
 	CmdSkill:        "管理 skills",
 	CmdVerbose:      "切換 thinking 原文顯示",
+	CmdReloadCmd:    "重載自定義命令",
 	CmdSandbox:      "檢視沙箱狀態",
 	CmdEffort:       "設定推理強度",
 	CmdAutoPlan:     "設定自動計畫模式",


### PR DESCRIPTION
## 概述

新增 `/reload-cmd` 命令，支持热加载自定义 slash 命令（`.reasonix/commands/` 等目录下的 `.md` 文件），无需重启 Controller、无需断开 MCP 连接、无需重跑 Session Hooks。

Closes #4840

## 实现方案

**轻量热加载** — 不重建 Controller（区别于现有 skills 热加载路径）：

1. `Controller.ReloadCommands()` 通过 `command.Load()` 重新扫盘（纯函数，无副作用）
2. 将当前 Skills 与 Commands 合并打包进重建的 `slash_command` tool（Skills 不会丢失）
3. `Registry.Add()` 同名覆盖已有的 `slash_command` entry — 模型侧下一轮自动生效
4. `c.commands.Store(&cmds)` 原子替换人类输入路径的命令快照 — `/name args` 即刻生效

## 架构

```
/reload-cmd
    │
    ▼
Controller.ReloadCommands(ctx)
    ├── 1. command.Load(dirs...) — 重新扫盘
    ├── 2. 合并 Skills + Commands 为 SlashEntry[]
    ├── 3. reg.Add(NewSlashCommandTool(entries)) — 模型侧
    ├── 4. c.commands.Store(&cmds) — 人类输入侧
    └── CLI: 刷新 m.commands + updateCompletion()
```

三条调度路径：CLI TUI（`runSlashCommand`）、Desktop/HTTP（`managementNotice`）、Desktop App 桥接。

## 关键设计决策

- **`atomic.Pointer`** 保护 `Controller.commands` — 无锁线程安全
- **不重建 Controller** — MCP 连接和 Session Hooks 不受影响
- **Skills 与 Commands 打包在一起** — reload 后不会丢失 Skill 入口
- **始终显示 before/after 数量** — 去掉 "no changes" 特判，避免误报

## 变更文件

| 文件 | 改动 |
|------|------|
| `internal/control/controller.go` | `commands` → `atomic.Pointer`；新增 `ReloadCommands()` |
| `internal/control/input.go` | `CustomCommand()` 使用 getter |
| `internal/control/slash.go` | `managementNotice` 加 `/reload-cmd` |
| `internal/cli/chat_tui.go` | `runSlashCommand` 加 `case "/reload-cmd"` |
| `internal/cli/complete.go` | Tab 补全条目 |
| `internal/cli/help_view.go` | 帮助菜单条目 |
| `internal/i18n/{i18n,messages_*}.go` | 中/繁/英国际化 |
| `desktop/app.go` | `App.ReloadCommands()` 桥接 |
| `internal/control/controller_test.go` | 单元测试 + 集成测试 |

## 测试

- **单元测试**: `TestCommandsAtomicPointer`（atomic getter）、`TestReloadCommandsFromFilesystem`（文件热加载 + Skills 保留 + HOME 隔离）
- **集成测试**: `go test ./internal/control/ -count=1` — 全部通过
- **手动验证**: 构建 CLI，创建测试 `.md` 命令，验证 `/reload-cmd` 热加载无需重启

---

## 手动验证报告

**测试日期**: 2026-06-20
**测试版本**: `dd3fca66` (fix: simplify reload notice, remove unused prevNames, add I-2 test fixes)
**测试环境**: Windows, DeepSeek-Reasonix CLI (本地构建)

### 测试范围

验证 `/reload-cmd` 命令的热加载行为：在不重启 CLI 的情况下，动态增删 `.reasonix/commands/` 目录中的 `.md` 命令文件后，CLI 能否正确感知变更并更新命令列表。

### 测试结果汇总

| 测试 | 场景 | 预期行为 | 实际行为 | 结果 |
|------|------|----------|----------|------|
| Test 1 | 基础热加载 (首次 /reload-cmd) | 显示命令数量 | 正确显示 | ✅ PASS |
| Test 2 | 无变更重载 | 显示数量不变 | 正确响应 | ✅ PASS |
| Test 3 | 新增命令文件 | 命令数量增加 | 正确增加 | ✅ PASS |
| Test 4 | 修改已有命令文件 | 命令描述/行为更新 | 正确更新 | ✅ PASS |
| Test 5 | 添加无效命令文件 | 忽略无效文件 | 正确忽略 | ✅ PASS |
| Test 6 | 删除命令文件 | 3 → 2 commands | "commands reloaded: 3 → 2 commands" | ✅ PASS |
| Test 7 | 格式错误的 .md 文件 | 忽略 broken.md | broken.md 被正确忽略 | ✅ PASS |
| Test 8 | 删除所有命令文件 (空集) | N → 0 commands, /help 无 custom 区 | 修复后: "3 → 0 commands", /help custom 消失 | ✅ PASS (修复后) |

### 关键测试详情

#### Test 6 — 删除单个命令文件

**操作**: 备份并删除 `count.md`，执行 `/reload-cmd`
**结果**: 提示 "commands reloaded: 3 → 2 commands"
**验证**: 命令数量从 3 正确减少到 2

![Test 6 - 删除 count.md 后 reload](https://raw.githubusercontent.com/Barsit/DeepSeek-Reasonix/test-assets/reload-cmd/test-screenshots/test6_delete_reload.png)

#### Test 7 — 格式错误的命令文件

**操作**: 创建 `broken.md`（frontmatter 格式错误），执行 `/reload-cmd`
**结果**: `command.Load()` 正确跳过无效文件，不报错
**验证**: 容错性良好，无效文件不影响有效命令的加载

![Test 7 - 格式错误文件被忽略](https://raw.githubusercontent.com/Barsit/DeepSeek-Reasonix/test-assets/reload-cmd/test-screenshots/test7_malformed_reload.png)

#### Test 8 — 空集边界 (发现 Bug → 修复验证)

**首次测试 (修复前, 版本 `f224324f`)**:

- **操作**: 删除所有 3 个命令文件，执行 `/reload-cmd`
- **预期**: "commands reloaded: 3 → 0 commands"
- **实际**: 显示 "commands reloaded (no changes)"，`/help` 仍显示旧命令
- **结论**: ❌ BUG — CLI handler 中 `prevNames` 比较逻辑在空集场景下误判

**根因分析**:

- `controller.go` 中 `ReloadCommands()` 和 `Commands()` 行为正确（单元测试已验证）
- 问题出在 `chat_tui.go` 的 `/reload-cmd` handler：当 `m.commands` 为空切片时，`prevNames` 比较逻辑产生误判，认为命令集未变化

**修复 (提交 `dd3fca66`)**:

- 移除 `prevNames` 比较逻辑
- 简化为始终显示 "commands reloaded: N → M commands" 格式
- 确保空集场景也能正确展示数量变化

**修复验证截图**:

![Test 8 修复前 - Bug 复现](https://raw.githubusercontent.com/Barsit/DeepSeek-Reasonix/test-assets/reload-cmd/test-screenshots/test8_empty_set.png)

![Test 8 修复后 - 验证通过](https://raw.githubusercontent.com/Barsit/DeepSeek-Reasonix/test-assets/reload-cmd/test-screenshots/test8_fixed.png)

### 环境恢复

所有测试完成后，已将命令文件恢复到 `.reasonix/commands/` 目录：`count.md`、`hello.md`、`review.md`。`broken.md` 等测试临时文件已清理。

### 结论

全部 8 项手动测试通过。Test 8 发现了一个 CLI 层缓存同步 Bug（`prevNames` 比较逻辑在空集场景下误判），已由提交 `dd3fca66` 修复。`/reload-cmd` 热加载功能在各种场景（增、删、改、空集、容错）下均表现正确。

---

## 桌面端验证报告

**测试日期**: 2026-06-20
**测试版本**: 本地构建 `reasonix-desktop.exe`
**测试环境**: Windows, Reasonix Desktop (Wails/WebView2)

### 验证范围

验证桌面端通过 `managementNotice` 路径处理 `/reload-cmd` 的行为，以及命令是否正确出现在斜杠菜单中。

### 桌面端修复

构建时发现 `desktop/app.go` 新增了 `App.ReloadCommands()` 方法，但前端 TypeScript `AppBindings` 接口未同步，导致编译失败。已在 `bridge.ts` 中补充绑定。同时将 `reload-cmd` 加入 `Commands()` 内置命令列表，使其出现在斜杠菜单中。

### 验证结果

| 场景 | 预期 | 实际 | 结果 |
|------|------|------|------|
| 无命令文件时 `/reload-cmd` | "commands reloaded (0 available)" | "commands reloaded (0 available)" | ✅ PASS |
| 主目录 `~/.reasonix/commands/` 下 2 个命令文件 | "commands reloaded (2 available)" | "commands reloaded (2 available)" | ✅ PASS |
| 删除命令文件后 `/reload-cmd` | "commands reloaded (0 available)" | "commands reloaded (0 available)" | ✅ PASS |
| 斜杠菜单显示 `reload-cmd` | 出现在 builtin 分类 | 正常显示"重载自定义命令" | ✅ PASS |

### 桌面端验证截图

![桌面端 /reload-cmd 完整验证: 0→2→0](https://raw.githubusercontent.com/Barsit/DeepSeek-Reasonix/test-assets/reload-cmd/test-screenshots/desktop_reload_cmd_full.png)

### 桌面端单元测试

新增 `TestReloadCommandsDesktopManagementNotice`，程序化验证桌面端 `managementNotice("/reload-cmd")` 路径的完整行为（Notice 事件内容、数量递减、空集边界），全部通过。

### 结论

桌面端 `/reload-cmd` 功能正常：命令出现在斜杠菜单、热加载正确响应、数量显示准确、空集边界处理正确。

