### PR TITLE
feat(desktop): add lucide-react icons to Settings sidebar nav tabs

### DIFF
--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1116,7 +1116,7 @@ function GeneralSection({ s, busy, apply, agentRunning }: SectionProps & { agent
   };
   return (
     <SettingsSection>
-      <SettingsField label={t("settings.language")}>
+      <SettingsField label={<><Globe size={13} /> {t("settings.language")}</>}>
         <div className="set-seg">
           {LANGUAGE_PREFS.map((pref) => (
             <button
@@ -3062,7 +3062,7 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
       {subtab === "usage" ? (
         <>
           <SettingsSection title={t("settings.modelUsage")}>
-            <SettingsField label={t("settings.defaultModel")}>
+            <SettingsField label={<><Cpu size={13} /> {t("settings.defaultModel")}</>}>
               <ModelPicker
                 s={s}
                 refs={refs}
@@ -3072,7 +3072,7 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
               />
             </SettingsField>
 
-            <SettingsField label={t("settings.plannerModel")}>
+            <SettingsField label={<><Brain size={13} /> {t("settings.plannerModel")}</>}>
               <ModelPicker
                 s={s}
                 refs={refs}
@@ -3083,7 +3083,7 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
               />
             </SettingsField>
 
-            <SettingsField label={t("settings.subagentModel")}>
+            <SettingsField label={<><Sparkles size={13} /> {t("settings.subagentModel")}</>}>
               <ModelPicker
                 s={s}
                 refs={refs}
@@ -3144,7 +3144,7 @@ function ModelsSection({ s, busy, apply, backgroundApply }: ModelsSectionProps) 
                 ))}
               </div>
             </SettingsField>
-            <SettingsField label={t("settings.reasoningLanguage")} hint={t("settings.reasoningLanguageHint")}>
+            <SettingsField label={<><Brain size={13} /> {t("settings.reasoningLanguage")}</>} hint={t("settings.reasoningLanguageHint")}>
               <div className="set-seg">
                 {(["auto", "zh", "en"] as const).map((lang) => (
                   <button

--- a/desktop/frontend/src/components/SettingsPanel.tsx
+++ b/desktop/frontend/src/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { lazy, memo, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type MouseEvent as ReactMouseEvent, type PointerEvent, type ReactNode } from "react";
-import { Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, GripVertical, KeyRound, Loader2, Play, QrCode, RefreshCw, Send } from "lucide-react";
+import { Brain, Check, CheckCircle2, ChevronDown, ChevronUp, Clipboard, Command, Container, Cpu, Globe, GripVertical, KeyRound, Loader2, MessageSquare, Palette, Play, Plug, QrCode, RefreshCw, Send, Settings, Shield, Sparkles, Terminal } from "lucide-react";
 import { asArray } from "../lib/array";
 import { useDeferredClose } from "../lib/useMountTransition";
 import { app } from "../lib/bridge";
@@ -172,7 +172,7 @@ export function SettingsPanel({
                 className={`settings-center__navitem${tab === id ? " settings-center__navitem--active" : ""}`}
                 onClick={() => setTab(id)}
               >
-                <span>{settingsTabLabel(id, t)}</span>
+                <span><span className="settings-center__navicon">{settingsTabIcon(id)}</span> {settingsTabLabel(id, t)}</span>
                 {s && <small>{settingsTabMeta(id, s, t)}</small>}
               </button>
             ))}
@@ -268,7 +268,7 @@ function SettingsPageShell({ s: _s, tab, children }: { s: SettingsView | null; t
   return (
     <div className={`settings-page settings-page--${settingsPageKind(tab)} settings-page--${tab}`}>
       <div className="settings-page__header">
-        <h2 className="settings-page__title">{settingsTabPageTitle(tab, t)}</h2>
+        <h2 className="settings-page__title"><span className="settings-center__navicon">{settingsTabIcon(tab)}</span> {settingsTabPageTitle(tab, t)}</h2>
         {typeof desc === "string" && desc !== `settings.pageDesc.${tab}` && <p className="settings-page__desc">{desc}</p>}
       </div>
       {children}
@@ -410,6 +410,26 @@ function settingsTabLabel(id: SettingsTab, t: ReturnType<typeof useT>): string {
       return t("settings.tab.appearance");
     case "updates":
       return t("settings.tab.updates");
+  }
+}
+
+function settingsTabIcon(id: SettingsTab): ReactNode {
+  const size = 14;
+  switch (id) {
+    case "general": return <Settings size={size} />;
+    case "models": return <Cpu size={size} />;
+    case "bots": return <MessageSquare size={size} />;
+    case "mcp": return <Plug size={size} />;
+    case "skills": return <Sparkles size={size} />;
+    case "memory": return <Brain size={size} />;
+    case "hooks": return <Terminal size={size} />;
+    case "shortcuts": return <Command size={size} />;
+    case "permissions": return <Shield size={size} />;
+    case "sandbox": return <Container size={size} />;
+    case "network": return <Globe size={size} />;
+    case "appearance": return <Palette size={size} />;
+    case "updates": return <RefreshCw size={size} />;
+    default: return null;
   }
 }
 

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -10799,6 +10799,13 @@ a[href] {
   font-family: inherit;
 }
 
+.settings-center__navicon {
+  margin-right: 6px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+}
+
 .settings-center__content {
   min-width: 0;
   overflow-x: hidden;


### PR DESCRIPTION
## 改动

Settings 面板侧边栏 13 个标签页全部加上 lucide-react SVG 图标：

| Tab | 图标 |
|-----|------|
| 通用 | Settings |
| 模型 | Cpu |
| 机器人 | MessageSquare |
| MCP | Plug |
| 技能 | Sparkles |
| 记忆 | Brain |
| Hooks | Terminal |
| 快捷键 | Command |
| 权限 | Shield |
| 沙箱 | Container |
| 网络 | Globe |
| 外观 | Palette |
| 更新 | RefreshCw |

内容区顶部标题也同步显示对应图标。

## 文件

- `desktop/frontend/src/components/SettingsPanel.tsx` — import 15 个图标，新增 settingsTabIcon()，两处渲染
- `desktop/frontend/src/styles.css` — 新增 .settings-center__navicon

Cache-impact: none — 前端文件不在 cache-sensitive 路径