### PR TITLE
fix(control): Goal synthetic messages should skip Planner in two-model mode

### DIFF
--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -77,12 +77,18 @@ func TaskWarrantsPlanner(input string) bool {
 	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {
 		return false
 	}
+	if IsSyntheticUserMessage(text) {
+		return false
+	}
 	return !isLowRiskQuestion(strings.ToLower(text))
 }
 
 func autoPlanScore(input string) int {
 	text := strings.TrimSpace(input)
 	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {
+		return 0
+	}
+	if IsSyntheticUserMessage(text) {
 		return 0
 	}
 	lower := strings.ToLower(text)

--- a/internal/control/auto_plan_test.go
+++ b/internal/control/auto_plan_test.go
@@ -19,10 +19,58 @@ func TestTaskWarrantsPlanner(t *testing.T) {
 		{"fix the bug", true},        // terse, but a work request → still planned
 		{"add a login button", true}, // ditto
 		{"implement the new caching layer across the backend", true},
+		// Goal synthetic messages — should skip planner:
+		{goalContinueTurn, false},
+		{goalSelfCheckTurn, false},
+		{"No tool calls in recent turns. Either make progress with tools or signal [goal:blocked:<reason>].", false},
+		{"Goal signaled complete but issues remain:\n- the following tasks are still incomplete:\n  - Fix login (in_progress)\nFix or use todo_write/complete_step to mark done, then [goal:complete] again.", false},
 	}
 	for _, c := range cases {
 		if got := TaskWarrantsPlanner(c.input); got != c.want {
 			t.Errorf("TaskWarrantsPlanner(%q) = %v, want %v", c.input, got, c.want)
+		}
+	}
+}
+
+func TestAutoPlanScore_skipsSyntheticMessages(t *testing.T) {
+	syntheticInputs := []string{
+		"Plan approved — plan mode is off",
+		"Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: missing evidence.",
+		"You are already in the executor phase. The planner's read-only limitations do not apply to you.",
+		"The previous assistant response was interrupted while a tool call was streaming. Continue the same task now.",
+		"The previous assistant response was interrupted during streaming. Continue the same task from immediately after the partial assistant message above.",
+		"The previous assistant response was interrupted during streaming before visible answer text was completed. Continue the same task now.",
+		"The previous assistant response finished without any visible answer text. Continue the same task now and provide a concise visible answer.",
+		goalContinueTurn,
+		goalSelfCheckTurn,
+		"No tool calls in recent turns. Either make progress with tools or signal [goal:blocked:<reason>].",
+		"Goal signaled complete but issues remain:\n- the following tasks are still incomplete:\n  - Fix login (in_progress)\nFix or use todo_write/complete_step to mark done, then [goal:complete] again.",
+	}
+	for _, input := range syntheticInputs {
+		if got := autoPlanScore(input); got != 0 {
+			t.Errorf("autoPlanScore(%q) = %d, want 0 (synthetic messages should score 0)", input, got)
+		}
+	}
+}
+
+func TestAutoPlanScore_normalInputs(t *testing.T) {
+	cases := []struct {
+		input string
+		want  int
+	}{
+		{"", 0},
+		{"   ", 0},
+		{"/init", 0},
+		{"what does this function do?", 0}, // low-risk
+		{"fix the bug", 0},                 // no trigger patterns
+		// just "implement" alone → complexIntentTerms match
+		{"implement", 1},
+		// just "across" → multiSurfaceTerms match
+		{"across", 1},
+	}
+	for _, c := range cases {
+		if got := autoPlanScore(c.input); got != c.want {
+			t.Errorf("autoPlanScore(%q) = %d, want %d", c.input, got, c.want)
 		}
 	}
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -83,6 +83,12 @@ var syntheticPrefixes = []string{
 	"<compaction-summary>",
 	"Summary of the later conversation (compacted from here on):",
 	"Summary of earlier conversation (compacted up to here):",
+	// Goal loop synthetic messages — these are injected by the controller during
+	// goal continuation and should never trigger the planner in two-model mode.
+	"Continue pursuing the active goal.",
+	"The agent signaled goal completion and all tasks are marked done.",
+	"Goal signaled complete but issues remain:",
+	"No tool calls in recent turns.",
 }
 
 // Compose applies the plan-mode marker to a turn's text when plan mode is on,


### PR DESCRIPTION
## 问题
在双模型模式下，Goal loop 发的续跑消息（"Continue pursuing the active goal..."）
会不必要地触发 Planner，浪费一轮 token。#4909

## 根因
`TaskWarrantsPlanner` 没有识别合成消息——Controller 层的 `Submit` 用了
`IsSyntheticUserMessage` 过滤，但 Coordinator 的 `shouldPlan` 走的是另一条路径。

## 修复
在 `TaskWarrantsPlanner` 中加入 `IsSyntheticUserMessage` 检查，
与 Controller 层保持一致。

## 测试
`TestTaskWarrantsPlanner` 新增 4 个 goal 合成消息测试用例。

Cache-impact: low — adds two early-return branches that don't change the
  system prompt, tool schemas, or memory prefix
Cache-guard: go test ./internal/control/ -run TestTaskWarrantsPlanner