### PR TITLE
refactor(control): extract goal FSM into a goalMachine collaborator

### DIFF
--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -43,10 +43,9 @@ func (c *Controller) shouldAutoPlan(ctx context.Context, input string) bool {
 	c.mu.Lock()
 	mode := c.autoPlan
 	plan := c.planMode
-	goalActive := strings.TrimSpace(c.goal) != "" && c.goalStatus == GoalStatusRunning
 	classifier := c.classifier
 	c.mu.Unlock()
-	if mode == autoPlanOff || plan || goalActive {
+	if mode == autoPlanOff || plan || c.goals.active() {
 		return false
 	}
 	score := autoPlanScore(input)

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -27,7 +27,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unicode"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/billing"
@@ -116,14 +115,10 @@ type Controller struct {
 	reg       *tool.Registry
 	pluginCtx context.Context
 
-	// goalStatePath is where the current goal state is persisted for session
-	// continuity. Empty means no persistence.
-	goalStatePath string
-	// goalWriteMu serializes goal-state disk writes so they happen OFF c.mu: a
-	// caller builds the JSON under c.mu (cheap) then writes it here after
-	// unlocking, keeping the per-turn goal persistence out of the critical
-	// section that approvals and status polls also take.
-	goalWriteMu sync.Mutex
+	// goals owns the active goal's FSM (status, intercepts, idle/turn counters)
+	// and its persistence, behind its own mutex so a per-turn goal save never
+	// stalls an approval or status poll on c.mu. See goal.go.
+	goals goalMachine
 
 	// Checkpoints (snapshot-based rewind). cp is the per-session store rebound when
 	// the session path changes; cpRoot is the workspace root used to guard restore
@@ -154,43 +149,17 @@ type Controller struct {
 
 	// mu guards the run state and approval bookkeeping; every critical section
 	// under it is short and non-blocking.
-	mu               sync.Mutex
-	cancel           context.CancelFunc
-	running          bool
-	canceling        bool
-	autosaveWG       sync.WaitGroup
-	planMode         bool
-	goal             string
-	goalStatus       string
-	goalResearchMode GoalResearchMode
-	goalTurns        int
-	goalBlocks       int
-	goalBlock        string
-	// goalInterceptMsg, when non-empty, overrides the generic goalContinueTurn prompt
-	// for the next continuation turn. Used by advanceGoalAfterTurn to inject specific
-	// feedback such as incomplete-todo reminders.
-	goalInterceptMsg string
-	// goalIntercepts counts consecutive incomplete-todo intercepts for the current
-	// goal. After the first intercept, the agent is reminded to update its todo
-	// list if the work is actually done; a second consecutive claim of completion
-	// is treated as an override and let through.
-	goalIntercepts int
-	// goalStrict, when true, disables the override escape hatch: every
-	// [goal:complete] while todos are incomplete is intercepted, and the
-	// agent must actually finish or update all items before it can complete.
-	goalStrict bool
-	// goalSelfCheckDone tracks whether the quality self-check prompt has been
-	// injected for the current goal. On first [goal:complete] with all todos
-	// done, the agent is asked to self-verify before final completion.
-	goalSelfCheckDone bool
-	// goalIdleTurns counts consecutive turns without any tool call. When this
-	// exceeds the threshold an idle reminder is injected via goalInterceptMsg.
-	goalIdleTurns int
-	sessionPath   string
-	approvals     map[string]pendingApproval
-	asks          map[string]pendingAsk
-	granted       map[string]bool
-	nextID        int
+	mu          sync.Mutex
+	cancel      context.CancelFunc
+	running     bool
+	canceling   bool
+	autosaveWG  sync.WaitGroup
+	planMode    bool
+	sessionPath string
+	approvals   map[string]pendingApproval
+	asks        map[string]pendingAsk
+	granted     map[string]bool
+	nextID      int
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
 	// approvedPlanAutoApproveTools auto-allows writer tool calls without prompting.
@@ -271,13 +240,6 @@ const (
 const (
 	memoryRememberTool = "remember"
 	memoryForgetTool   = "forget"
-)
-
-const (
-	maxGoalAutoTurns  = 50
-	maxGoalIdleTurns  = 2
-	goalContinueTurn  = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
-	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
 )
 
 // RememberResult describes what happened when an approval rule was persisted.
@@ -463,21 +425,13 @@ func ckptDir(sessionPath string) string {
 	return strings.TrimSuffix(sessionPath, ".jsonl") + ".ckpt"
 }
 
-// goalStatePath derives a session's persisted goal-state sidecar.
-func goalStatePath(sessionPath string) string {
-	if sessionPath == "" {
-		return ""
-	}
-	return strings.TrimSuffix(sessionPath, ".jsonl") + ".goal-state.json"
-}
-
 // rebindCheckpoints points the store at the (possibly new) session, loading any
 // checkpoints already on disk, and resets the turn boundaries. Called on
 // construction and whenever the session path changes (NewSession/Resume/SetSessionPath).
 func (c *Controller) rebindCheckpoints(sessionPath string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.goalStatePath = goalStatePath(sessionPath)
+	c.goals.setStatePath(goalStatePath(sessionPath))
 	c.cp = checkpoint.New(ckptDir(sessionPath), c.cpRoot)
 	c.cpTurn = c.cp.NextTurn() // continue numbering past any checkpoints on disk
 	c.cpBound = c.cp.Bounds()  // rebuilt from persisted checkpoints so a resumed
@@ -713,14 +667,9 @@ func (c *Controller) continueGoal(ctx context.Context) error {
 			return err
 		}
 		turn := goalContinueTurn
-		c.mu.Lock()
-		if c.goalInterceptMsg != "" {
-			turn = c.goalInterceptMsg
-			c.goalInterceptMsg = ""
-			c.mu.Unlock()
+		if msg, ok := c.goals.takeIntercept(); ok {
+			turn = msg
 			c.notice("goal intercept: incomplete todos remain (override with a second [goal:complete])")
-		} else {
-			c.mu.Unlock()
 		}
 		if err := c.runTurnWithRawDisplay(ctx, turn, turn, ""); err != nil {
 			if ctx.Err() != nil {
@@ -732,142 +681,26 @@ func (c *Controller) continueGoal(ctx context.Context) error {
 }
 
 func (c *Controller) advanceGoalAfterTurn() bool {
-	reply := lastAssistantText(c.History())
-	status, reason, _ := parseGoalStatusMarker(reply)
-	var notice string
-	c.mu.Lock()
-	if strings.TrimSpace(c.goal) == "" || c.goalStatus != GoalStatusRunning {
-		c.mu.Unlock()
-		return false
+	// Gather every input the FSM needs off the goal lock: parse the marker,
+	// snapshot the executor's todos + readiness, and check tool activity. None
+	// of these touch goal state, so the machine's critical section stays pure.
+	status, reason, _ := parseGoalStatusMarker(lastAssistantText(c.History()))
+	var readiness string
+	if c.executor != nil {
+		readiness = c.executor.GoalReadinessFailure()
 	}
-	c.goalTurns++
-	switch status {
-	case GoalStatusComplete:
-		if incomplete := c.incompleteGoalTodos(); len(incomplete) > 0 && (c.goalStrict || c.goalIntercepts == 0) {
-			// In strict mode every claim is blocked until todos are done;
-			// otherwise only the first consecutive claim is intercepted.
-			c.goalIntercepts++
-			c.goalInterceptMsg = incomplete
-			break
-		}
-		// Todos are all done — in strict mode run self-check before final
-		// completion. Non-strict mode completes immediately.
-		if c.goalStrict && !c.goalSelfCheckDone {
-			c.goalSelfCheckDone = true
-			c.goalInterceptMsg = goalSelfCheckTurn
-			break
-		}
-		// Self-check passed — complete the goal.
-		c.goalIntercepts = 0
-		c.goalSelfCheckDone = false
-		c.goalIdleTurns = 0
-		// (final state is persisted once below, after the lock is released)
-		c.goal = ""
-		c.goalStatus = GoalStatusComplete
-		c.goalBlocks = 0
-		c.goalBlock = ""
-		c.goalInterceptMsg = ""
-		notice = "goal complete"
-	case GoalStatusBlocked:
-		reason = cleanGoalBlockReason(reason)
-		if reason == "" {
-			reason = "blocked"
-		}
-		if sameGoalBlock(c.goalBlock, reason) {
-			c.goalBlocks++
-		} else {
-			c.goalBlocks = 1
-			c.goalBlock = reason
-		}
-		if c.goalBlocks >= 3 {
-			c.goalStatus = GoalStatusBlocked
-			notice = "goal blocked: " + reason
-		}
-	default:
-		c.goalBlocks = 0
-		c.goalBlock = ""
-		c.goalIntercepts = 0
-		c.goalSelfCheckDone = false
-		c.goalIdleTurns = 0
+	res := c.goals.advance(goalAdvanceInput{
+		status:     status,
+		reason:     reason,
+		toolCalled: c.toolWasCalledLastTurn(),
+		todos:      c.goalTodos(),
+		readiness:  readiness,
+	})
+	c.persistGoalState(res.path, res.data, res.ok)
+	if res.notice != "" {
+		c.notice(res.notice)
 	}
-	// Idle detection: if the agent went multiple turns without any tool
-	// calls, inject a reminder to make progress (unless the goal is already
-	// completing or hitting the auto-turn limit).
-	if notice == "" && c.goalInterceptMsg == "" {
-		if c.toolWasCalledLastTurn() {
-			c.goalIdleTurns = 0
-		} else {
-			c.goalIdleTurns++
-			if c.goalIdleTurns >= maxGoalIdleTurns {
-				c.goalIdleTurns = 0
-				c.goalInterceptMsg = "No tool calls in recent turns. Either make progress with tools or signal [goal:blocked:<reason>]."
-			}
-		}
-	}
-	if notice == "" && c.goalTurns >= maxGoalAutoTurns {
-		c.goalStatus = GoalStatusBlocked
-		c.goalBlock = "goal continuation limit reached"
-		c.goalIntercepts = 0
-		c.goalSelfCheckDone = false
-		c.goalInterceptMsg = ""
-		c.goalIdleTurns = 0
-		notice = c.goalBlock
-	}
-	var savePath string
-	var saveData []byte
-	if notice != "" {
-		savePath, saveData, _ = c.buildGoalStateLocked()
-	}
-	cont := notice == ""
-	c.mu.Unlock()
-	c.writeGoalState(savePath, saveData)
-	if notice != "" {
-		c.notice(notice)
-	}
-	return cont
-}
-
-// incompleteGoalTodos checks the executor's canonical todo state and evidence
-// readiness (project checks) for anything that should block [goal:complete].
-// Returns a formatted reminder string, or empty if nothing is blocking.
-func (c *Controller) incompleteGoalTodos() string {
-	if c.executor == nil {
-		return ""
-	}
-	var parts []string
-
-	// 1. Check canonical todos.
-	todos := c.executor.CanonicalTodoState()
-	if len(todos) > 0 {
-		incomplete := evidence.IncompleteTodos(todos)
-		if len(incomplete) > 0 {
-			var b strings.Builder
-			b.WriteString("the following tasks are still incomplete:")
-			for _, t := range incomplete {
-				fmt.Fprintf(&b, "\n  - %s (%s)", t.Content, t.Status)
-			}
-			parts = append(parts, b.String())
-		}
-	}
-
-	// 2. Check evidence readiness (project checks from AGENTS.md).
-	if reason := c.executor.GoalReadinessFailure(); reason != "" {
-		parts = append(parts, reason)
-	}
-
-	if len(parts) == 0 {
-		return ""
-	}
-
-	var b strings.Builder
-	b.WriteString("Goal signaled complete but issues remain:\n")
-	for _, p := range parts {
-		b.WriteString("- ")
-		b.WriteString(p)
-		b.WriteString("\n")
-	}
-	b.WriteString("Fix or use todo_write/complete_step to mark done, then [goal:complete] again.")
-	return b.String()
+	return res.cont
 }
 
 // toolWasCalledLastTurn reports whether the most recent assistant message
@@ -886,125 +719,9 @@ func (c *Controller) toolWasCalledLastTurn() bool {
 	return false
 }
 
-func parseGoalStatusMarker(text string) (status, reason string, ok bool) {
-	lines := strings.Split(text, "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(lines[i])
-		if line == "" {
-			continue
-		}
-		lower := strings.ToLower(line)
-		switch lower {
-		case "[goal:complete]":
-			return GoalStatusComplete, "", true
-		case "[goal:continue]":
-			return GoalStatusRunning, "", true
-		}
-		const blockedPrefix = "[goal:blocked:"
-		if strings.HasPrefix(lower, blockedPrefix) && strings.HasSuffix(line, "]") {
-			return GoalStatusBlocked, strings.TrimSpace(line[len(blockedPrefix) : len(line)-1]), true
-		}
-		return "", "", false
-	}
-	return "", "", false
-}
-
-func sameGoalBlock(a, b string) bool {
-	return normalizeGoalBlockReason(a) == normalizeGoalBlockReason(b)
-}
-
-func cleanGoalBlockReason(reason string) string {
-	return strings.Trim(strings.TrimSpace(reason), " \t\r\n:：,，.。;；!！?？-—_[]()（）")
-}
-
-func normalizeGoalBlockReason(reason string) string {
-	reason = strings.ToLower(cleanGoalBlockReason(reason))
-	var b strings.Builder
-	lastSpace := true
-	for _, r := range reason {
-		switch {
-		case unicode.IsLetter(r) || unicode.IsDigit(r):
-			b.WriteRune(r)
-			lastSpace = false
-		default:
-			if !lastSpace {
-				b.WriteByte(' ')
-				lastSpace = true
-			}
-		}
-	}
-	return strings.Join(strings.Fields(b.String()), " ")
-}
-
 func (c *Controller) stopGoal(status string) {
-	c.mu.Lock()
-	if strings.TrimSpace(c.goal) != "" && c.goalStatus == GoalStatusRunning {
-		c.goalStatus = status
-	}
-	c.goalInterceptMsg = ""
-	c.goalIntercepts = 0
-	c.goalSelfCheckDone = false
-	c.goalIdleTurns = 0
-	path, data, _ := c.buildGoalStateLocked()
-	c.mu.Unlock()
-	c.writeGoalState(path, data)
-}
-
-// buildGoalStateLocked marshals the current goal state for persistence. The
-// caller holds c.mu; this only reads in-memory state and the executor's todo
-// snapshot, never touching disk. Returns the target path and JSON, or ok=false
-// when persistence is disabled. The matching writeGoalState does the disk write
-// OFF c.mu so the per-turn save can't stall an approval or status poll.
-func (c *Controller) buildGoalStateLocked() (path string, data []byte, ok bool) {
-	if c.goalStatePath == "" || c.executor == nil {
-		return "", nil, false
-	}
-	state := goalState{
-		Goal:         c.goal,
-		Status:       c.goalStatus,
-		ResearchMode: c.goalResearchMode,
-		Turns:        c.goalTurns,
-		Blocks:       c.goalBlocks,
-		Block:        c.goalBlock,
-		Strict:       c.goalStrict,
-		Todos:        c.executor.CanonicalTodoState(),
-	}
-	b, err := json.Marshal(state)
-	if err != nil {
-		slog.Warn("controller: marshal goal state", "err", err)
-		return "", nil, false
-	}
-	return c.goalStatePath, b, true
-}
-
-// writeGoalState persists pre-marshaled goal-state bytes to disk, OFF c.mu and
-// serialized by goalWriteMu so concurrent saves don't interleave or land out of
-// order. Best-effort: failures are logged, not surfaced.
-func (c *Controller) writeGoalState(path string, data []byte) {
-	if path == "" || data == nil {
-		return
-	}
-	c.goalWriteMu.Lock()
-	defer c.goalWriteMu.Unlock()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		slog.Warn("controller: goal state dir", "err", err)
-		return
-	}
-	if err := os.WriteFile(path, data, 0o644); err != nil {
-		slog.Warn("controller: write goal state", "err", err)
-	}
-}
-
-// goalState is the serializable form of a running goal.
-type goalState struct {
-	Goal         string              `json:"goal,omitempty"`
-	Status       string              `json:"status,omitempty"`
-	ResearchMode GoalResearchMode    `json:"researchMode,omitempty"`
-	Turns        int                 `json:"turns,omitempty"`
-	Blocks       int                 `json:"blocks,omitempty"`
-	Block        string              `json:"block,omitempty"`
-	Strict       bool                `json:"strict,omitempty"`
-	Todos        []evidence.TodoItem `json:"todos,omitempty"`
+	path, data, ok := c.goals.stop(status, c.goalTodos())
+	c.persistGoalState(path, data, ok)
 }
 
 // lastAssistantText returns the content of the most recent assistant message with
@@ -1275,9 +992,8 @@ func (c *Controller) autoStartResearchGoalCandidate(input string) (string, bool)
 	c.mu.Lock()
 	plan := c.planMode
 	running := c.running
-	activeGoal := strings.TrimSpace(c.goal) != "" && c.goalStatus == GoalStatusRunning
 	c.mu.Unlock()
-	if plan || running || activeGoal {
+	if plan || running || c.goals.active() {
 		return "", false
 	}
 	return goal, true
@@ -1323,16 +1039,6 @@ func (c *Controller) applyGoalCommand(input, display string) bool {
 		}
 	}
 	return true
-}
-
-func ShortGoalForNotice(goal string) string {
-	goal = strings.Join(strings.Fields(goal), " ")
-	runes := []rune(goal)
-	const max = 160
-	if len(runes) <= max {
-		return goal
-	}
-	return string(runes[:max]) + "..."
 }
 
 // applyPlanExec reads the current canonical todo list and starts a goal that
@@ -1873,11 +1579,8 @@ func (c *Controller) PlanMode() bool {
 // cannot override an incomplete-todo intercept — it must actually finish or
 // update all items before [goal:complete] is accepted.
 func (c *Controller) GoalStrict(strict bool) {
-	c.mu.Lock()
-	c.goalStrict = strict
-	path, data, _ := c.buildGoalStateLocked()
-	c.mu.Unlock()
-	c.writeGoalState(path, data)
+	path, data, ok := c.goals.setStrict(strict, c.goalTodos())
+	c.persistGoalState(path, data, ok)
 }
 
 // SetGoal stores a session-scoped active goal. Compose injects it into outgoing
@@ -1888,43 +1591,8 @@ func (c *Controller) SetGoal(goal string) {
 }
 
 func (c *Controller) SetGoalWithResearchMode(goal string, researchMode GoalResearchMode) {
-	goal = strings.TrimSpace(goal)
-	c.mu.Lock()
-	if goal == "" {
-		c.goal = ""
-		c.goalStatus = GoalStatusStopped
-		c.goalResearchMode = GoalResearchAuto
-		c.goalTurns = 0
-		c.goalBlocks = 0
-		c.goalBlock = ""
-		c.goalInterceptMsg = ""
-		c.goalIntercepts = 0
-		c.goalSelfCheckDone = false
-		c.goalIdleTurns = 0
-		c.goalStrict = false
-		path, data, _ := c.buildGoalStateLocked()
-		c.mu.Unlock()
-		c.writeGoalState(path, data)
-		return
-	}
-	if c.goal == goal && c.goalStatus == GoalStatusRunning && c.goalResearchMode == researchMode {
-		c.mu.Unlock()
-		return
-	}
-	c.goal = goal
-	c.goalStatus = GoalStatusRunning
-	c.goalResearchMode = researchMode
-	c.goalTurns = 0
-	c.goalBlocks = 0
-	c.goalBlock = ""
-	c.goalInterceptMsg = ""
-	c.goalIntercepts = 0
-	c.goalSelfCheckDone = false
-	c.goalIdleTurns = 0
-	c.goalStrict = false
-	path, data, _ := c.buildGoalStateLocked()
-	c.mu.Unlock()
-	c.writeGoalState(path, data)
+	path, data, ok := c.goals.set(goal, researchMode, c.goalTodos())
+	c.persistGoalState(path, data, ok)
 }
 
 func (c *Controller) ClearGoal() {
@@ -1932,21 +1600,11 @@ func (c *Controller) ClearGoal() {
 }
 
 func (c *Controller) Goal() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.goal
+	return c.goals.goalText()
 }
 
 func (c *Controller) GoalStatus() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if strings.TrimSpace(c.goal) == "" && c.goalStatus == "" {
-		return GoalStatusStopped
-	}
-	if c.goalStatus == "" {
-		return GoalStatusStopped
-	}
-	return c.goalStatus
+	return c.goals.statusForDisplay()
 }
 
 // Compact runs one compaction pass on the executor's session on demand.

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -1,0 +1,428 @@
+package control
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"unicode"
+
+	"reasonix/internal/evidence"
+)
+
+const (
+	maxGoalAutoTurns  = 50
+	maxGoalIdleTurns  = 2
+	goalContinueTurn  = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
+	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
+)
+
+// goalMachine owns the active goal's finite-state machine and its persistence.
+// It is a strict leaf: its methods take only the machine's own locks and never
+// call back into the Controller, so the controller may hold c.mu while invoking
+// a getter without risking lock inversion. The FSM is pure — advance() takes
+// already-gathered inputs (the parsed marker, the executor's todo snapshot and
+// readiness, whether a tool ran) and returns what to persist plus a notice, so
+// no disk or executor work happens under mu.
+type goalMachine struct {
+	// mu guards the FSM fields below; every critical section under it is short
+	// and non-blocking (no disk I/O, no executor calls).
+	mu            sync.Mutex
+	goal          string
+	status        string
+	researchMode  GoalResearchMode
+	turns         int
+	blocks        int
+	block         string
+	interceptMsg  string
+	intercepts    int
+	strict        bool
+	selfCheckDone bool
+	idleTurns     int
+
+	// statePath is the persisted goal-state sidecar; empty disables persistence.
+	statePath string
+	// writeMu serializes goal-state disk writes so concurrent saves don't
+	// interleave or land out of order. Taken OFF mu by writeState.
+	writeMu sync.Mutex
+}
+
+// goalState is the serializable form of a running goal.
+type goalState struct {
+	Goal         string              `json:"goal,omitempty"`
+	Status       string              `json:"status,omitempty"`
+	ResearchMode GoalResearchMode    `json:"researchMode,omitempty"`
+	Turns        int                 `json:"turns,omitempty"`
+	Blocks       int                 `json:"blocks,omitempty"`
+	Block        string              `json:"block,omitempty"`
+	Strict       bool                `json:"strict,omitempty"`
+	Todos        []evidence.TodoItem `json:"todos,omitempty"`
+}
+
+// goalAdvanceInput carries everything the FSM needs for one continuation step,
+// gathered by the caller off the machine's lock.
+type goalAdvanceInput struct {
+	status     string // parsed marker status ("" when the turn carried no marker)
+	reason     string // blocked reason from the marker, if any
+	toolCalled bool   // whether the last turn made any tool call
+	todos      []evidence.TodoItem
+	readiness  string // executor.GoalReadinessFailure()
+}
+
+// goalAdvanceResult reports the FSM step's outcome. data/path/ok describe the
+// state to persist (built under mu when something changed); notice is surfaced
+// to the user; cont reports whether the goal loop should continue.
+type goalAdvanceResult struct {
+	notice string
+	cont   bool
+	path   string
+	data   []byte
+	ok     bool
+}
+
+// goalStatePath derives a session's persisted goal-state sidecar.
+func goalStatePath(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return strings.TrimSuffix(sessionPath, ".jsonl") + ".goal-state.json"
+}
+
+func (g *goalMachine) setStatePath(path string) {
+	g.mu.Lock()
+	g.statePath = path
+	g.mu.Unlock()
+}
+
+// snapshot returns the fields Compose injects into outgoing turns.
+func (g *goalMachine) snapshot() (goal, status string, mode GoalResearchMode) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.goal, g.status, g.researchMode
+}
+
+func (g *goalMachine) goalText() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.goal
+}
+
+// active reports whether a goal is currently running.
+func (g *goalMachine) active() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return strings.TrimSpace(g.goal) != "" && g.status == GoalStatusRunning
+}
+
+// statusForDisplay maps the empty zero status to "stopped" for frontends.
+func (g *goalMachine) statusForDisplay() string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.status == "" {
+		return GoalStatusStopped
+	}
+	return g.status
+}
+
+// set installs a session-scoped goal (or clears it when goal is empty), resets
+// the per-goal counters, and returns the state to persist. ok is false (no
+// persistence) when the goal is unchanged or no state path is configured.
+func (g *goalMachine) set(goal string, mode GoalResearchMode, todos []evidence.TodoItem) (string, []byte, bool) {
+	goal = strings.TrimSpace(goal)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if goal != "" && g.goal == goal && g.status == GoalStatusRunning && g.researchMode == mode {
+		return "", nil, false
+	}
+	g.turns, g.blocks, g.block = 0, 0, ""
+	g.interceptMsg, g.intercepts = "", 0
+	g.selfCheckDone, g.idleTurns, g.strict = false, 0, false
+	if goal == "" {
+		g.goal, g.status, g.researchMode = "", GoalStatusStopped, GoalResearchAuto
+	} else {
+		g.goal, g.status, g.researchMode = goal, GoalStatusRunning, mode
+	}
+	return g.buildStateLocked(todos)
+}
+
+func (g *goalMachine) setStrict(strict bool, todos []evidence.TodoItem) (string, []byte, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.strict = strict
+	return g.buildStateLocked(todos)
+}
+
+// stop transitions a running goal to the given terminal status and clears the
+// transient intercept/idle bookkeeping.
+func (g *goalMachine) stop(status string, todos []evidence.TodoItem) (string, []byte, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if strings.TrimSpace(g.goal) != "" && g.status == GoalStatusRunning {
+		g.status = status
+	}
+	g.interceptMsg = ""
+	g.intercepts = 0
+	g.selfCheckDone = false
+	g.idleTurns = 0
+	return g.buildStateLocked(todos)
+}
+
+// takeIntercept consumes a pending continuation-turn override, if any.
+func (g *goalMachine) takeIntercept() (string, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.interceptMsg == "" {
+		return "", false
+	}
+	msg := g.interceptMsg
+	g.interceptMsg = ""
+	return msg, true
+}
+
+// advance runs one continuation step of the goal FSM from already-gathered
+// inputs. It mutates the machine, decides whether to keep looping, and builds
+// the state to persist when the goal reached a terminal/notice point.
+func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if strings.TrimSpace(g.goal) == "" || g.status != GoalStatusRunning {
+		return goalAdvanceResult{cont: false}
+	}
+	g.turns++
+	var notice string
+	switch in.status {
+	case GoalStatusComplete:
+		if incomplete := formatIncompleteTodos(in.todos, in.readiness); len(incomplete) > 0 && (g.strict || g.intercepts == 0) {
+			// In strict mode every claim is blocked until todos are done;
+			// otherwise only the first consecutive claim is intercepted.
+			g.intercepts++
+			g.interceptMsg = incomplete
+			break
+		}
+		// Todos are all done — in strict mode run self-check before final
+		// completion. Non-strict mode completes immediately.
+		if g.strict && !g.selfCheckDone {
+			g.selfCheckDone = true
+			g.interceptMsg = goalSelfCheckTurn
+			break
+		}
+		// Self-check passed — complete the goal.
+		g.intercepts = 0
+		g.selfCheckDone = false
+		g.idleTurns = 0
+		g.goal = ""
+		g.status = GoalStatusComplete
+		g.blocks = 0
+		g.block = ""
+		g.interceptMsg = ""
+		notice = "goal complete"
+	case GoalStatusBlocked:
+		reason := cleanGoalBlockReason(in.reason)
+		if reason == "" {
+			reason = "blocked"
+		}
+		if sameGoalBlock(g.block, reason) {
+			g.blocks++
+		} else {
+			g.blocks = 1
+			g.block = reason
+		}
+		if g.blocks >= 3 {
+			g.status = GoalStatusBlocked
+			notice = "goal blocked: " + reason
+		}
+	default:
+		g.blocks = 0
+		g.block = ""
+		g.intercepts = 0
+		g.selfCheckDone = false
+		g.idleTurns = 0
+	}
+	// Idle detection: if the agent went multiple turns without any tool calls,
+	// inject a reminder to make progress (unless the goal is already completing
+	// or hitting the auto-turn limit).
+	if notice == "" && g.interceptMsg == "" {
+		if in.toolCalled {
+			g.idleTurns = 0
+		} else {
+			g.idleTurns++
+			if g.idleTurns >= maxGoalIdleTurns {
+				g.idleTurns = 0
+				g.interceptMsg = "No tool calls in recent turns. Either make progress with tools or signal [goal:blocked:<reason>]."
+			}
+		}
+	}
+	if notice == "" && g.turns >= maxGoalAutoTurns {
+		g.status = GoalStatusBlocked
+		g.block = "goal continuation limit reached"
+		g.intercepts = 0
+		g.selfCheckDone = false
+		g.interceptMsg = ""
+		g.idleTurns = 0
+		notice = g.block
+	}
+	res := goalAdvanceResult{notice: notice, cont: notice == ""}
+	if notice != "" {
+		res.path, res.data, res.ok = g.buildStateLocked(in.todos)
+	}
+	return res
+}
+
+// buildStateLocked marshals the current goal state for persistence. The caller
+// holds mu; this only reads in-memory state, never touching disk. Returns ok=false
+// when persistence is disabled (no state path). The matching writeState does the
+// disk write OFF mu so the per-turn save can't stall a status poll.
+func (g *goalMachine) buildStateLocked(todos []evidence.TodoItem) (path string, data []byte, ok bool) {
+	if g.statePath == "" {
+		return "", nil, false
+	}
+	state := goalState{
+		Goal:         g.goal,
+		Status:       g.status,
+		ResearchMode: g.researchMode,
+		Turns:        g.turns,
+		Blocks:       g.blocks,
+		Block:        g.block,
+		Strict:       g.strict,
+		Todos:        todos,
+	}
+	b, err := json.Marshal(state)
+	if err != nil {
+		slog.Warn("controller: marshal goal state", "err", err)
+		return "", nil, false
+	}
+	return g.statePath, b, true
+}
+
+// writeState persists pre-marshaled goal-state bytes to disk, OFF mu and
+// serialized by writeMu so concurrent saves don't interleave or land out of
+// order. Best-effort: failures are logged, not surfaced.
+func (g *goalMachine) writeState(path string, data []byte) {
+	if path == "" || data == nil {
+		return
+	}
+	g.writeMu.Lock()
+	defer g.writeMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		slog.Warn("controller: goal state dir", "err", err)
+		return
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		slog.Warn("controller: write goal state", "err", err)
+	}
+}
+
+// formatIncompleteTodos renders the reminder shown when [goal:complete] arrives
+// while the executor's canonical todos or project-readiness checks aren't done.
+// Returns empty when nothing is blocking. Pure: the caller gathers todos and the
+// readiness reason from the executor off the goal lock.
+func formatIncompleteTodos(todos []evidence.TodoItem, readiness string) string {
+	var parts []string
+	if len(todos) > 0 {
+		if incomplete := evidence.IncompleteTodos(todos); len(incomplete) > 0 {
+			var b strings.Builder
+			b.WriteString("the following tasks are still incomplete:")
+			for _, t := range incomplete {
+				fmt.Fprintf(&b, "\n  - %s (%s)", t.Content, t.Status)
+			}
+			parts = append(parts, b.String())
+		}
+	}
+	if readiness != "" {
+		parts = append(parts, readiness)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("Goal signaled complete but issues remain:\n")
+	for _, p := range parts {
+		b.WriteString("- ")
+		b.WriteString(p)
+		b.WriteString("\n")
+	}
+	b.WriteString("Fix or use todo_write/complete_step to mark done, then [goal:complete] again.")
+	return b.String()
+}
+
+func parseGoalStatusMarker(text string) (status, reason string, ok bool) {
+	lines := strings.Split(text, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line == "" {
+			continue
+		}
+		lower := strings.ToLower(line)
+		switch lower {
+		case "[goal:complete]":
+			return GoalStatusComplete, "", true
+		case "[goal:continue]":
+			return GoalStatusRunning, "", true
+		}
+		const blockedPrefix = "[goal:blocked:"
+		if strings.HasPrefix(lower, blockedPrefix) && strings.HasSuffix(line, "]") {
+			return GoalStatusBlocked, strings.TrimSpace(line[len(blockedPrefix) : len(line)-1]), true
+		}
+		return "", "", false
+	}
+	return "", "", false
+}
+
+func sameGoalBlock(a, b string) bool {
+	return normalizeGoalBlockReason(a) == normalizeGoalBlockReason(b)
+}
+
+func cleanGoalBlockReason(reason string) string {
+	return strings.Trim(strings.TrimSpace(reason), " \t\r\n:：,，.。;；!！?？-—_[]()（）")
+}
+
+func normalizeGoalBlockReason(reason string) string {
+	reason = strings.ToLower(cleanGoalBlockReason(reason))
+	var b strings.Builder
+	lastSpace := true
+	for _, r := range reason {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsDigit(r):
+			b.WriteRune(r)
+			lastSpace = false
+		default:
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		}
+	}
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// ShortGoalForNotice collapses whitespace and truncates a goal for one-line UI.
+func ShortGoalForNotice(goal string) string {
+	goal = strings.Join(strings.Fields(goal), " ")
+	runes := []rune(goal)
+	const max = 160
+	if len(runes) <= max {
+		return goal
+	}
+	return string(runes[:max]) + "..."
+}
+
+// goalTodos snapshots the executor's canonical todos for goal-state persistence.
+func (c *Controller) goalTodos() []evidence.TodoItem {
+	if c.executor == nil {
+		return nil
+	}
+	return c.executor.CanonicalTodoState()
+}
+
+// persistGoalState writes a freshly built goal state to disk, off c.mu. The
+// executor guard preserves the original behavior of skipping persistence when
+// no executor is attached.
+func (c *Controller) persistGoalState(path string, data []byte, ok bool) {
+	if !ok || c.executor == nil {
+		return
+	}
+	c.goals.writeState(path, data)
+}

--- a/internal/control/goal_test.go
+++ b/internal/control/goal_test.go
@@ -274,22 +274,23 @@ func TestGoalRestartResetsBlockedAudit(t *testing.T) {
 	}
 }
 
-// TestIncompleteGoalTodos verifies that incompleteGoalTodos detects
+// TestIncompleteGoalTodos verifies that formatIncompleteTodos detects
 // unfinished tasks and returns a formatted reminder, and returns empty
 // when all todos are complete.
 func TestIncompleteGoalTodos(t *testing.T) {
 	prov := &scriptedTurns{turns: [][]provider.Chunk{textTurn("done")}}
 	ag := agent.New(prov, tool.NewRegistry(), agent.NewSession(""), agent.Options{}, event.Discard)
 	c := New(Options{Runner: ag, Executor: ag, Sink: event.Discard})
+	reminder := func() string { return formatIncompleteTodos(c.goalTodos(), ag.GoalReadinessFailure()) }
 
 	// Seed with incomplete todos.
 	ag.SeedTodoState([]evidence.TodoItem{
 		{Content: "Fix the parser", Status: "in_progress"},
 		{Content: "Add tests", Status: "pending"},
 	})
-	msg := c.incompleteGoalTodos()
+	msg := reminder()
 	if msg == "" {
-		t.Fatal("incompleteGoalTodos() returned empty string, expected reminder")
+		t.Fatal("formatIncompleteTodos() returned empty string, expected reminder")
 	}
 	if !strings.Contains(msg, "Fix the parser") {
 		t.Fatalf("reminder should mention 'Fix the parser', got: %q", msg)
@@ -306,14 +307,14 @@ func TestIncompleteGoalTodos(t *testing.T) {
 		{Content: "Fix the parser", Status: "completed"},
 		{Content: "Add tests", Status: "completed"},
 	})
-	if got := c.incompleteGoalTodos(); got != "" {
-		t.Fatalf("incompleteGoalTodos() with all-complete = %q, want empty", got)
+	if got := reminder(); got != "" {
+		t.Fatalf("formatIncompleteTodos() with all-complete = %q, want empty", got)
 	}
 
 	// Empty todo list.
 	ag.ReplaceTodoState(nil)
-	if got := c.incompleteGoalTodos(); got != "" {
-		t.Fatalf("incompleteGoalTodos() with empty list = %q, want empty", got)
+	if got := reminder(); got != "" {
+		t.Fatalf("formatIncompleteTodos() with empty list = %q, want empty", got)
 	}
 }
 

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -91,13 +91,11 @@ var syntheticPrefixes = []string{
 func (c *Controller) Compose(text string) string {
 	c.mu.Lock()
 	plan := c.planMode
-	goal := c.goal
-	goalStatus := c.goalStatus
-	goalResearchMode := c.goalResearchMode
 	reasoningLanguage := c.reasoningLanguage
 	notes := c.pendingMemory
 	c.pendingMemory = nil
 	c.mu.Unlock()
+	goal, goalStatus, goalResearchMode := c.goals.snapshot()
 
 	if strings.TrimSpace(goal) != "" && goalStatus == GoalStatusRunning {
 		text = activeGoalBlock(goal, goalResearchMode) + "\n\n" + text


### PR DESCRIPTION
## What

Extracts the active-goal finite-state machine out of `Controller` into a dedicated `goalMachine` collaborator (`internal/control/goal.go`).

## Why

The goal FSM was ~13 fields plus its logic interleaved directly into `Controller` and guarded by the catch-all `c.mu`. Worse, the FSM ran `executor.CanonicalTodoState()` / `GoalReadinessFailure()` **while holding `c.mu`**, so per-turn goal bookkeeping could stall an approval or status poll.

## How

- `goalMachine` owns the goal fields behind its own mutex, kept as a **strict leaf**: its methods never call back into `Controller`, so `c.mu` and the goal lock can't invert.
- The FSM is now **pure** — `advance()` takes already-gathered inputs (the parsed marker, the executor's todo snapshot and readiness, whether a tool ran) and returns what to persist plus a notice. The executor calls move **off** the lock.
- `Controller` drops 13 goal fields and the goal write mutex; the goal accessors become thin delegations.
- Public API (`Goal`/`GoalStatus`/`SetGoal`/`SetGoalWithResearchMode`/`ClearGoal`/`GoalStrict`/`ShortGoalForNotice`) is **unchanged**, so cli/desktop/acp callers are unaffected. Plan mode is a separate concern and stays on `Controller`.

`controller.go`: 4054 → 3712 lines. Behavior-preserving.

## Verification

- `go build ./...` + `go vet ./...` clean
- `go test ./internal/control/ -race` passes, incl. the goal concurrency test
- downstream `cli`/`boot`/`acp` tests pass