### PR TITLE
refactor(control): extract approval/ask bookkeeping into an approvalManager

### DIFF
--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -1,0 +1,300 @@
+package control
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"reasonix/internal/event"
+	"reasonix/internal/permission"
+)
+
+// approvalManager owns the approval/ask prompt bookkeeping and the runtime
+// approval posture, behind its own locks and off the controller's c.mu. It is a
+// strict leaf: its methods only touch its own state and never call back into the
+// Controller. The Controller keeps the I/O orchestration (emitting events,
+// firing hooks, rebuilding the executor gate) that needs its other collaborators
+// — approval, unlike the goal FSM, blocks on user input and has side effects, so
+// only the bookkeeping is extracted, not the orchestration.
+type approvalManager struct {
+	// policy is the immutable base permission policy, captured at construction.
+	// Used to decide whether a tool call would auto-approve under the writer
+	// fallback (autoApprovalWouldAllowLocked); the Controller keeps its own copy
+	// for building the executor gate.
+	policy permission.Policy
+
+	// mu guards the prompt maps and posture fields; every critical section under
+	// it is short and non-blocking.
+	mu        sync.Mutex
+	approvals map[string]pendingApproval
+	asks      map[string]pendingAsk
+	granted   map[string]bool
+	nextID    int
+	// toolApprovalMode is the runtime approval posture: "ask" prompts, "auto"
+	// lets the policy auto-approve the writer fallback while preserving ask/deny
+	// rules, and "yolo" skips every tool approval prompt except plan approval.
+	toolApprovalMode string
+	// approvalTimeout bounds how long requestApproval/Ask block on a user
+	// decision. Zero means wait indefinitely (correct for an interactive
+	// terminal); bot/headless frontends set it so a walked-away user can't wedge
+	// the session forever (#4626, #4402). Write-once at construction.
+	approvalTimeout time.Duration
+	// planAutoApprove auto-allows writer tool calls without prompting while a
+	// just-approved plan executes. Set by the turn loop, read by the bypass
+	// check. Plan approval is the go-ahead, so the model shouldn't re-prompt for
+	// every write of the work it just got cleared to do.
+	planAutoApprove bool
+
+	// promptMu serializes outstanding prompts so at most one user decision is in
+	// flight. Held across the blocking wait, so it must never be taken by the
+	// resolve paths (Approve/AnswerQuestion).
+	promptMu sync.Mutex
+}
+
+func newApprovalManager(policy permission.Policy, mode string, timeout time.Duration) approvalManager {
+	return approvalManager{
+		policy:           policy,
+		approvals:        map[string]pendingApproval{},
+		asks:             map[string]pendingAsk{},
+		granted:          map[string]bool{},
+		toolApprovalMode: mode,
+		approvalTimeout:  timeout,
+	}
+}
+
+// preApproved reports whether a tool call can skip the prompt — either the
+// posture bypasses it (YOLO / plan-execution window) or a session grant already
+// covers the scope.
+func (a *approvalManager) preApproved(tool, subject string) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.bypassAllowsLocked(tool) || a.sessionGrantAllowsLocked(tool, subject)
+}
+
+// register allocates an approval ID, records the pending prompt, and returns the
+// reply channel the resolve path will signal.
+func (a *approvalManager) register(tool, subject string) (string, chan approvalReply) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.nextID++
+	id := strconv.Itoa(a.nextID)
+	reply := make(chan approvalReply, 1)
+	a.approvals[id] = pendingApproval{tool: tool, subject: subject, autoDrain: a.autoApprovalWouldAllowLocked(tool, subject), reply: reply}
+	return id, reply
+}
+
+// grantSession records a session-scoped grant so future calls in the same scope
+// short-circuit.
+func (a *approvalManager) grantSession(tool, subject string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.granted[permission.SessionGrantRuleForScope(tool, subject)] = true
+}
+
+// cancel drops a pending approval (timeout/abort path).
+func (a *approvalManager) cancel(id string) {
+	a.mu.Lock()
+	delete(a.approvals, id)
+	a.mu.Unlock()
+}
+
+// resolve removes and returns the pending approval for id (Approve path).
+func (a *approvalManager) resolve(id string) pendingApproval {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p := a.approvals[id]
+	delete(a.approvals, id)
+	return p
+}
+
+// registerAsk allocates an ask ID, records the pending question batch, and
+// returns the reply channel.
+func (a *approvalManager) registerAsk(questions []event.AskQuestion) (string, chan []event.AskAnswer) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.nextID++
+	id := strconv.Itoa(a.nextID)
+	reply := make(chan []event.AskAnswer, 1)
+	a.asks[id] = pendingAsk{questions: questions, reply: reply}
+	return id, reply
+}
+
+// cancelAsk drops a pending ask (timeout/abort path).
+func (a *approvalManager) cancelAsk(id string) {
+	a.mu.Lock()
+	delete(a.asks, id)
+	a.mu.Unlock()
+}
+
+// resolveAsk removes and returns the pending ask for id (AnswerQuestion path).
+func (a *approvalManager) resolveAsk(id string) (pendingAsk, bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	p, ok := a.asks[id]
+	delete(a.asks, id)
+	return p, ok
+}
+
+// clearAll drops every in-flight prompt without signaling — the cancel path,
+// where blocked waiters unblock via their cancelled context instead.
+func (a *approvalManager) clearAll() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	clear(a.approvals)
+	clear(a.asks)
+}
+
+// hasPending reports whether any prompt is awaiting a user decision.
+func (a *approvalManager) hasPending() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.approvals) > 0 || len(a.asks) > 0
+}
+
+// mode returns the normalized runtime approval posture.
+func (a *approvalManager) mode() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return normalizeToolApprovalMode(a.toolApprovalMode)
+}
+
+// setMode applies a (pre-normalized) posture and drains any pending approvals
+// the new posture should auto-allow, returning their reply channels for the
+// caller to signal after unlocking.
+func (a *approvalManager) setMode(mode string) []chan approvalReply {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.toolApprovalMode = mode
+	switch mode {
+	case ToolApprovalAuto:
+		return a.drainLocked(false)
+	case ToolApprovalYolo:
+		return a.drainLocked(true)
+	}
+	return nil
+}
+
+// setPlanAutoApprove toggles the just-approved-plan execution window.
+func (a *approvalManager) setPlanAutoApprove(on bool) {
+	a.mu.Lock()
+	a.planAutoApprove = on
+	a.mu.Unlock()
+}
+
+// waitContext bounds the blocking wait by approvalTimeout when set.
+func (a *approvalManager) waitContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if a.approvalTimeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, a.approvalTimeout)
+}
+
+// snapshotPrompts copies the in-flight prompts for re-emission to a reconnected
+// frontend (ReplayPendingPrompts).
+func (a *approvalManager) snapshotPrompts() ([]event.Approval, []event.Ask) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	approvals := make([]event.Approval, 0, len(a.approvals))
+	for id, p := range a.approvals {
+		approvals = append(approvals, event.Approval{ID: id, Tool: p.tool, Subject: p.subject})
+	}
+	asks := make([]event.Ask, 0, len(a.asks))
+	for id, p := range a.asks {
+		asks = append(asks, event.Ask{ID: id, Questions: p.questions})
+	}
+	return approvals, asks
+}
+
+// --- decision helpers (caller holds a.mu) ---
+
+func (a *approvalManager) bypassAllowsLocked(tool string) bool {
+	if requiresFreshApprovalTool(tool) {
+		return false
+	}
+	return a.toolApprovalMode == ToolApprovalYolo || a.planAutoApprove
+}
+
+func (a *approvalManager) autoApprovalWouldAllowLocked(tool, subject string) bool {
+	if requiresFreshApprovalTool(tool) {
+		return false
+	}
+	policy := a.policy
+	policy.Mode = permission.Allow
+	return policy.DecideSubject(tool, false, subject) == permission.Allow
+}
+
+func (a *approvalManager) sessionGrantAllowsLocked(tool, subject string) bool {
+	if requiresFreshApprovalTool(tool) {
+		return false
+	}
+	for rule := range a.granted {
+		if permission.RuleMatchesString(rule, tool, subject) {
+			return true
+		}
+	}
+	return false
+}
+
+// drainLocked removes every pending approval the new posture should auto-allow
+// and returns their reply channels; caller holds a.mu and sends {allow:true}
+// after unlocking.
+func (a *approvalManager) drainLocked(includeExplicitAsk bool) []chan approvalReply {
+	pending := make([]chan approvalReply, 0, len(a.approvals))
+	for id, approval := range a.approvals {
+		if requiresFreshApprovalTool(approval.tool) {
+			continue
+		}
+		if !includeExplicitAsk && !approval.autoDrain {
+			continue
+		}
+		delete(a.approvals, id)
+		pending = append(pending, approval.reply)
+	}
+	return pending
+}
+
+// --- pure approval helpers ---
+
+func normalizeToolApprovalMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case ToolApprovalAuto, "approve", "allow":
+		return ToolApprovalAuto
+	case ToolApprovalYolo, "full", "full-access", "bypass":
+		return ToolApprovalYolo
+	default:
+		return ToolApprovalAsk
+	}
+}
+
+func requiresFreshApprovalTool(tool string) bool {
+	switch tool {
+	case planApprovalTool, memoryRememberTool, memoryForgetTool:
+		return true
+	default:
+		return false
+	}
+}
+
+func approvalNotificationText(tool, subject string) string {
+	if requiresFreshApprovalTool(tool) {
+		return "approval needed: " + tool
+	}
+	if subject == "" {
+		return "approval needed: " + tool
+	}
+	return "approval needed: " + tool + " " + subject
+}
+
+func permissionRequestHookPayload(tool, subject string, args json.RawMessage) (string, json.RawMessage, bool) {
+	switch tool {
+	case planApprovalTool:
+		return "", nil, false
+	case memoryRememberTool, memoryForgetTool:
+		return "", nil, true
+	default:
+		return subject, args, true
+	}
+}

--- a/internal/control/approval_e2e_test.go
+++ b/internal/control/approval_e2e_test.go
@@ -141,12 +141,12 @@ func TestApprovalTimeoutZeroWaitsIndefinitely(t *testing.T) {
 	}
 
 	// Clean up so the goroutine doesn't linger: answer the prompt.
-	c.mu.Lock()
+	c.approval.mu.Lock()
 	var ids []string
-	for id := range c.asks {
+	for id := range c.approval.asks {
 		ids = append(ids, id)
 	}
-	c.mu.Unlock()
+	c.approval.mu.Unlock()
 
 	for _, id := range ids {
 		c.AnswerQuestion(id, []event.AskAnswer{{QuestionID: "q1", Selected: []string{"x"}}})

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -134,21 +134,15 @@ type Controller struct {
 	cpTurn  int
 	cpBound map[int]int
 
-	// promptMu serialises approval and ask prompts so at most one user decision is
-	// outstanding at a time (parallel read-only tool calls don't normally gate,
-	// writers run serially — but this keeps the contract explicit). Held across
-	// the blocking wait, so it must never be taken by the Approve/Answer paths.
-	promptMu sync.Mutex
+	// approval owns the approval/ask prompt bookkeeping and the runtime approval
+	// posture (ask/auto/yolo, session grants, the just-approved-plan window)
+	// behind its own locks, off c.mu. The Controller keeps the I/O orchestration
+	// (requestApproval/Ask emit events + fire hooks + rebuild the executor gate).
+	// See approval.go.
+	approval approvalManager
 
-	// approvalTimeout bounds how long requestApproval/AnswerQuestion block waiting
-	// for a user decision. Zero (the default) means wait indefinitely, which is
-	// correct for an interactive terminal where the user is present. Bot/headless
-	// frontends set it so an unanswered approval can't wedge the session forever
-	// when the user has walked away (#4626, #4402).
-	approvalTimeout time.Duration
-
-	// mu guards the run state and approval bookkeeping; every critical section
-	// under it is short and non-blocking.
+	// mu guards the run state; every critical section under it is short and
+	// non-blocking.
 	mu          sync.Mutex
 	cancel      context.CancelFunc
 	running     bool
@@ -156,33 +150,8 @@ type Controller struct {
 	autosaveWG  sync.WaitGroup
 	planMode    bool
 	sessionPath string
-	approvals   map[string]pendingApproval
-	asks        map[string]pendingAsk
-	granted     map[string]bool
-	nextID      int
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
-	// approvedPlanAutoApproveTools auto-allows writer tool calls without prompting.
-	// Set only while executing a just-approved plan: approving the plan is the
-	// go-ahead, so the model shouldn't re-prompt for every write of the work it
-	// just got cleared to do. Deny rules still bite (those never reach the
-	// approver). Reset when the execution turn returns.
-	approvedPlanAutoApproveTools bool
-
-	// toolApprovalMode is the runtime approval posture for permission-gated tool
-	// calls. "ask" prompts by default, "auto" lets the policy auto-approve the
-	// writer fallback while preserving ask/deny rules, and "yolo" skips every
-	// tool approval prompt except plan approval. It never answers AskRequest.
-	toolApprovalMode string
-
-	// autoApproveTools is "YOLO/full access" mode: while set, every tool approval
-	// request is auto-allowed for the rest of the session (writers and bash run
-	// without asking). It is a deliberate, session-scoped opt-in (the
-	// --dangerously-skip-permissions flag or a runtime toggle), never persisted.
-	// Deny rules are unaffected — they're resolved before the approver, so a
-	// denied tool is still blocked. It never answers AskRequest or plan approval:
-	// those remain user decisions.
-	autoApproveTools bool
 
 	// pendingMemory holds memory notes added mid-session (via "#" quick-add or a
 	// memory edit) that haven't yet been folded into a turn. Compose drains it
@@ -360,11 +329,7 @@ func New(opts Options) *Controller {
 		reg:                    opts.Registry,
 		pluginCtx:              pluginCtx,
 		cpRoot:                 opts.WorkspaceRoot,
-		toolApprovalMode:       ToolApprovalAsk,
-		approvalTimeout:        opts.ApprovalTimeout,
-		approvals:              map[string]pendingApproval{},
-		asks:                   map[string]pendingAsk{},
-		granted:                map[string]bool{},
+		approval:               newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),
 	}
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
 	c.rebindCheckpoints(opts.SessionPath)
@@ -639,14 +604,8 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	// The plan is the go-ahead: don't re-prompt for each write of the approved
 	// work. Auto-approve writers for the duration of this execution turn only; a
 	// later turn (even "continue") falls back to the normal per-tool approval.
-	c.mu.Lock()
-	c.approvedPlanAutoApproveTools = true
-	c.mu.Unlock()
-	defer func() {
-		c.mu.Lock()
-		c.approvedPlanAutoApproveTools = false
-		c.mu.Unlock()
-	}()
+	c.approval.setPlanAutoApprove(true)
+	defer c.approval.setPlanAutoApprove(false)
 	if err := c.runner.Run(ctx, c.ComposeSynthetic(planApprovedMessage)); err != nil {
 		return err
 	}
@@ -1313,15 +1272,10 @@ func (c *Controller) Cancel() {
 	cancel := c.cancel
 	if cancel != nil {
 		c.canceling = true
-		for id := range c.approvals {
-			delete(c.approvals, id)
-		}
-		for id := range c.asks {
-			delete(c.asks, id)
-		}
 	}
 	c.mu.Unlock()
 	if cancel != nil {
+		c.approval.clearAll()
 		cancel()
 	}
 }
@@ -1336,18 +1290,16 @@ func (c *Controller) Running() bool {
 // PendingPrompt reports whether the current turn is blocked waiting for a user
 // approval, plan approval, memory approval, or ask-tool answer.
 func (c *Controller) PendingPrompt() bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return len(c.approvals) > 0 || len(c.asks) > 0
+	return c.approval.hasPending()
 }
 
 // RuntimeStatus reports the active work owned by the foreground controller.
 func (c *Controller) RuntimeStatus() RuntimeStatus {
 	c.mu.Lock()
 	running := c.running
-	pending := len(c.approvals) > 0 || len(c.asks) > 0
 	canceling := c.canceling
 	c.mu.Unlock()
+	pending := c.approval.hasPending()
 	backgroundJobs := len(c.Jobs())
 	return RuntimeStatus{
 		Running:         running,
@@ -1369,10 +1321,7 @@ func (c *Controller) Turn() int {
 // also remembers a grant for the rest of the session so the same approval scope
 // is not re-prompted. Unknown/expired IDs are ignored.
 func (c *Controller) Approve(id string, allow, session, persist bool) {
-	c.mu.Lock()
-	pending := c.approvals[id]
-	delete(c.approvals, id)
-	c.mu.Unlock()
+	pending := c.approval.resolve(id)
 	if pending.reply != nil {
 		pending.reply <- approvalReply{allow: allow, session: session, persist: persist} // buffered, never blocks
 	}
@@ -1390,22 +1339,9 @@ func (c *Controller) EnableInteractiveApproval() {
 	}
 }
 
-func normalizeToolApprovalMode(mode string) string {
-	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case ToolApprovalAuto, "approve", "allow":
-		return ToolApprovalAuto
-	case ToolApprovalYolo, "full", "full-access", "bypass":
-		return ToolApprovalYolo
-	default:
-		return ToolApprovalAsk
-	}
-}
-
 func (c *Controller) newInteractiveGate() *permission.Gate {
 	policy := c.policy
-	c.mu.Lock()
-	mode := normalizeToolApprovalMode(c.toolApprovalMode)
-	c.mu.Unlock()
+	mode := c.approval.mode()
 	switch mode {
 	case ToolApprovalAuto, ToolApprovalYolo:
 		policy.Mode = permission.Allow
@@ -1467,28 +1403,20 @@ func (c *Controller) SteerConsumed() bool {
 // tool exists to get a genuine user decision, and YOLO only auto-approves
 // tool calls; it must not answer the user's questions for them.
 func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error) {
-	c.promptMu.Lock()
-	defer c.promptMu.Unlock()
+	c.approval.promptMu.Lock()
+	defer c.approval.promptMu.Unlock()
 
-	c.mu.Lock()
-	c.nextID++
-	id := strconv.Itoa(c.nextID)
-	reply := make(chan []event.AskAnswer, 1)
-	c.asks[id] = pendingAsk{questions: questions, reply: reply}
-	c.mu.Unlock()
-
+	id, reply := c.approval.registerAsk(questions)
 	c.sink.Emit(event.Event{Kind: event.AskRequest, Ask: event.Ask{ID: id, Questions: questions}})
 
-	waitCtx, cancelWait := c.approvalWaitContext(ctx)
+	waitCtx, cancelWait := c.approval.waitContext(ctx)
 	defer cancelWait()
 
 	select {
 	case ans := <-reply:
 		return ans, nil
 	case <-waitCtx.Done():
-		c.mu.Lock()
-		delete(c.asks, id)
-		c.mu.Unlock()
+		c.approval.cancelAsk(id)
 		return nil, waitCtx.Err()
 	}
 }
@@ -1496,11 +1424,7 @@ func (c *Controller) Ask(ctx context.Context, questions []event.AskQuestion) ([]
 // AnswerQuestion resolves a pending AskRequest by ID with the user's selections.
 // Unknown/expired IDs are ignored.
 func (c *Controller) AnswerQuestion(id string, answers []event.AskAnswer) {
-	c.mu.Lock()
-	pending, ok := c.asks[id]
-	delete(c.asks, id)
-	c.mu.Unlock()
-	if ok {
+	if pending, ok := c.approval.resolveAsk(id); ok {
 		pending.reply <- answers // buffered, never blocks
 	}
 }
@@ -1513,16 +1437,7 @@ func (c *Controller) AnswerQuestion(id string, answers []event.AskAnswer) {
 // requestApproval, so in practice at most one prompt is outstanding; the loops
 // stay general so a future concurrent prompt would still replay correctly.
 func (c *Controller) ReplayPendingPrompts() {
-	c.mu.Lock()
-	approvals := make([]event.Approval, 0, len(c.approvals))
-	for id, p := range c.approvals {
-		approvals = append(approvals, event.Approval{ID: id, Tool: p.tool, Subject: p.subject})
-	}
-	asks := make([]event.Ask, 0, len(c.asks))
-	for id, p := range c.asks {
-		asks = append(asks, event.Ask{ID: id, Questions: p.questions})
-	}
-	c.mu.Unlock()
+	approvals, asks := c.approval.snapshotPrompts()
 	for _, a := range approvals {
 		c.sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: a})
 	}
@@ -2856,20 +2771,7 @@ func (c *Controller) Jobs() []jobs.View {
 // SetToolApprovalMode changes the runtime approval posture for permission-gated
 // tools. It does not answer business asks or plan approval.
 func (c *Controller) SetToolApprovalMode(mode string) {
-	mode = normalizeToolApprovalMode(mode)
-	var pending []chan approvalReply
-
-	c.mu.Lock()
-	c.toolApprovalMode = mode
-	c.autoApproveTools = mode == ToolApprovalYolo
-	switch mode {
-	case ToolApprovalAuto:
-		pending = c.drainApprovalsLocked(false)
-	case ToolApprovalYolo:
-		pending = c.drainApprovalsLocked(true)
-	}
-	c.mu.Unlock()
-
+	pending := c.approval.setMode(normalizeToolApprovalMode(mode))
 	c.refreshInteractiveGate()
 	for _, reply := range pending {
 		reply <- approvalReply{allow: true}
@@ -2877,9 +2779,7 @@ func (c *Controller) SetToolApprovalMode(mode string) {
 }
 
 func (c *Controller) ToolApprovalMode() string {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return normalizeToolApprovalMode(c.toolApprovalMode)
+	return c.approval.mode()
 }
 
 // SetAutoApproveTools turns YOLO/full-access mode on or off for the session:
@@ -2916,23 +2816,6 @@ func (c *Controller) SetMode(plan, autoApproveTools bool) {
 	} else {
 		c.SetToolApprovalMode(ToolApprovalAsk)
 	}
-}
-
-// drainApprovalsLocked removes every pending approval gate and returns their
-// reply channels; caller holds c.mu and sends {allow:true} after unlocking.
-func (c *Controller) drainApprovalsLocked(includeExplicitAsk bool) []chan approvalReply {
-	pending := make([]chan approvalReply, 0, len(c.approvals))
-	for id, approval := range c.approvals {
-		if requiresFreshApprovalTool(approval.tool) {
-			continue
-		}
-		if !includeExplicitAsk && !approval.autoDrain {
-			continue
-		}
-		delete(c.approvals, id)
-		pending = append(pending, approval.reply)
-	}
-	return pending
 }
 
 // AutoApproveTools reports whether YOLO/full-access tool auto-approval is on,
@@ -3097,16 +2980,9 @@ type gateApprover struct{ c *Controller }
 
 func (g gateApprover) Approve(ctx context.Context, tool, subject string, args json.RawMessage) (bool, bool, error) {
 	subject = approvalDisplaySubject(tool, subject, args)
-	// Auto-allow without prompting while executing a just-approved plan (the plan
-	// was the approval), during an explicit continuation turn of that approved
-	// plan, or while YOLO/full-access tool auto-approval is on. Deny rules already
-	// bit before this point, so they still block.
-	g.c.mu.Lock()
-	auto := g.c.approvalBypassAllowsLocked(tool)
-	g.c.mu.Unlock()
-	if auto {
-		return true, false, nil
-	}
+	// requestApproval short-circuits the YOLO / just-approved-plan window and any
+	// session grant before it emits a prompt, so the auto-allow paths need no
+	// special-casing here. Deny rules already bit before this point.
 	return g.c.requestApproval(ctx, tool, subject, args)
 }
 
@@ -3488,46 +3364,28 @@ func parseRewind(args string, cps []checkpoint.Meta) (int, RewindScope, error) {
 	return turn, scope, nil
 }
 
-// approvalWaitContext returns the context the approval/ask wait blocks on. When
-// approvalTimeout is zero it just forwards ctx (interactive: wait forever). When
-// positive it layers a timeout so a headless/bot session can't hang on a prompt
-// nobody will answer (#4626, #4402); the caller treats expiry as a denial.
-func (c *Controller) approvalWaitContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if c.approvalTimeout <= 0 {
-		return ctx, func() {}
-	}
-	return context.WithTimeout(ctx, c.approvalTimeout)
-}
-
 // requestApproval emits an ApprovalRequest and blocks until Approve(ID, …)
-// answers or ctx is cancelled. A prior session grant for the same approval scope
-// short-circuits. promptMu serialises outstanding prompts.
+// answers or ctx is cancelled. A prior session grant (or a bypass posture) for
+// the same approval scope short-circuits. The approvalManager's promptMu
+// serialises outstanding prompts; this method keeps the I/O (events, hooks,
+// remember) that the manager deliberately stays out of.
 func (c *Controller) requestApproval(ctx context.Context, tool, subject string, args json.RawMessage) (bool, bool, error) {
-	c.mu.Lock()
 	// YOLO/full access and the just-approved-plan execution window auto-allow
 	// approval-gated tools without prompting. Plan approval is a user decision,
 	// not a tool permission, so it deliberately stays interactive.
-	if c.approvalBypassAllowsLocked(tool) || c.sessionGrantAllowsLocked(tool, subject) {
-		c.mu.Unlock()
+	if c.approval.preApproved(tool, subject) {
 		return true, false, nil
 	}
-	c.mu.Unlock()
 
-	c.promptMu.Lock()
-	defer c.promptMu.Unlock()
+	c.approval.promptMu.Lock()
+	defer c.approval.promptMu.Unlock()
 
-	// Re-check the grant: a session grant may have landed while we queued behind
-	// another prompt for the same subject.
-	c.mu.Lock()
-	if c.approvalBypassAllowsLocked(tool) || c.sessionGrantAllowsLocked(tool, subject) {
-		c.mu.Unlock()
+	// Re-check: a session grant may have landed while we queued behind another
+	// prompt for the same subject.
+	if c.approval.preApproved(tool, subject) {
 		return true, false, nil
 	}
-	c.nextID++
-	id := strconv.Itoa(c.nextID)
-	reply := make(chan approvalReply, 1)
-	c.approvals[id] = pendingApproval{tool: tool, subject: subject, autoDrain: c.autoApprovalWouldAllowLocked(tool, subject), reply: reply}
-	c.mu.Unlock()
+	id, reply := c.approval.register(tool, subject)
 
 	c.sink.Emit(event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: id, Tool: tool, Subject: subject}})
 	if hookSubject, hookArgs, ok := permissionRequestHookPayload(tool, subject, args); ok {
@@ -3537,7 +3395,7 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string, 
 	// external channel (desktop notice, phone) while the run blocks on the reply.
 	go c.hooks.Notification(ctx, approvalNotificationText(tool, subject))
 
-	waitCtx, cancelWait := c.approvalWaitContext(ctx)
+	waitCtx, cancelWait := c.approval.waitContext(ctx)
 	defer cancelWait()
 
 	select {
@@ -3545,79 +3403,15 @@ func (c *Controller) requestApproval(ctx context.Context, tool, subject string, 
 		// Plan approvals are one-shot — never persist a session grant for them, or
 		// every future plan would auto-approve.
 		if r.allow && r.session && !requiresFreshApprovalTool(tool) {
-			rule := permission.SessionGrantRuleForScope(tool, subject)
-			c.mu.Lock()
-			c.granted[rule] = true
-			c.mu.Unlock()
+			c.approval.grantSession(tool, subject)
 		}
 		if r.allow && r.persist && !requiresFreshApprovalTool(tool) && c.onRemember != nil {
 			c.emitRememberResult(c.onRemember(permission.RememberRuleForScope(tool, subject)))
 		}
 		return r.allow, false, nil
 	case <-waitCtx.Done():
-		c.mu.Lock()
-		delete(c.approvals, id)
-		c.mu.Unlock()
+		c.approval.cancel(id)
 		return false, false, waitCtx.Err()
-	}
-}
-
-func approvalNotificationText(tool, subject string) string {
-	if requiresFreshApprovalTool(tool) {
-		return "approval needed: " + tool
-	}
-	if subject == "" {
-		return "approval needed: " + tool
-	}
-	return "approval needed: " + tool + " " + subject
-}
-
-func permissionRequestHookPayload(tool, subject string, args json.RawMessage) (string, json.RawMessage, bool) {
-	switch tool {
-	case planApprovalTool:
-		return "", nil, false
-	case memoryRememberTool, memoryForgetTool:
-		return "", nil, true
-	default:
-		return subject, args, true
-	}
-}
-
-func (c *Controller) approvalBypassAllowsLocked(tool string) bool {
-	if requiresFreshApprovalTool(tool) {
-		return false
-	}
-	return c.toolApprovalMode == ToolApprovalYolo ||
-		c.approvedPlanAutoApproveTools
-}
-
-func (c *Controller) autoApprovalWouldAllowLocked(tool, subject string) bool {
-	if requiresFreshApprovalTool(tool) {
-		return false
-	}
-	policy := c.policy
-	policy.Mode = permission.Allow
-	return policy.DecideSubject(tool, false, subject) == permission.Allow
-}
-
-func (c *Controller) sessionGrantAllowsLocked(tool, subject string) bool {
-	if requiresFreshApprovalTool(tool) {
-		return false
-	}
-	for rule := range c.granted {
-		if permission.RuleMatchesString(rule, tool, subject) {
-			return true
-		}
-	}
-	return false
-}
-
-func requiresFreshApprovalTool(tool string) bool {
-	switch tool {
-	case planApprovalTool, memoryRememberTool, memoryForgetTool:
-		return true
-	default:
-		return false
 	}
 }
 

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -870,9 +870,7 @@ func TestPermissionRequestHookDoesNotFireForAutoApprovalMode(t *testing.T) {
 
 func TestPermissionRequestHookDoesNotFireForSessionGrant(t *testing.T) {
 	c, _, payloads := permissionHookController(t, "bash")
-	c.mu.Lock()
-	c.granted[permission.SessionGrantRuleForScope("bash", "go test ./...")] = true
-	c.mu.Unlock()
+	c.approval.grantSession("bash", "go test ./...")
 
 	allow, _, err := c.requestApproval(context.Background(), "bash", "go test ./...", nil)
 	if err != nil || !allow {

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -771,7 +771,7 @@ func TestAskSerializesBehindPromptLockEvenWithAutoApproveTools(t *testing.T) {
 		},
 	}}
 
-	c.promptMu.Lock()
+	c.approval.promptMu.Lock()
 	started := make(chan struct{})
 	done := make(chan []event.AskAnswer, 1)
 	errs := make(chan error, 1)
@@ -804,7 +804,7 @@ func TestAskSerializesBehindPromptLockEvenWithAutoApproveTools(t *testing.T) {
 	}
 
 	// Release the lock — Ask proceeds but must still emit an AskRequest.
-	c.promptMu.Unlock()
+	c.approval.promptMu.Unlock()
 
 	var ask event.Ask
 	select {
@@ -851,7 +851,7 @@ func TestAskSerializesBehindPromptLockEvenWithBypass(t *testing.T) {
 		},
 	}}
 
-	c.promptMu.Lock()
+	c.approval.promptMu.Lock()
 	done := make(chan []event.AskAnswer, 1)
 	errs := make(chan error, 1)
 	go func() {
@@ -875,7 +875,7 @@ func TestAskSerializesBehindPromptLockEvenWithBypass(t *testing.T) {
 	// Enable bypass while Ask is queued behind promptMu.
 	c.SetBypass(true)
 	// Release the lock — Ask proceeds but must still emit an AskRequest.
-	c.promptMu.Unlock()
+	c.approval.promptMu.Unlock()
 
 	// Post-unlock assertion: Ask must emit AskRequest now that it holds the lock.
 	var ask event.Ask


### PR DESCRIPTION
## What

Extracts the approval/ask prompt bookkeeping and runtime approval posture out of `Controller` into a dedicated `approvalManager` collaborator (`internal/control/approval.go`). Follows the same playbook as the goalMachine extraction (#4918).

## Why

The approval subsystem was ~9 fields plus **two** mutexes (the catch-all `c.mu` and `promptMu`) interleaved into `Controller`. Unlike the goal FSM, approval **blocks on user input** and has side effects (events, hooks, the executor gate), so it can't be a pure leaf.

## How (hybrid: state in the collaborator, I/O in the Controller)

- `approvalManager` owns the prompt maps, session grants, the id counter, the posture (ask/auto/yolo), the timeout, and the just-approved-plan window — behind its own `mu` + `promptMu`, **all off `c.mu`**. It exposes the decision helpers and map primitives (`preApproved` / `register` / `resolve` / `grantSession` / `drain` / `snapshot` / `setMode` / `clearAll` …).
- The `Controller` keeps the thin I/O orchestration: `requestApproval`/`Ask` still emit events, fire hooks, and rebuild the executor gate. The manager is a **strict leaf** — no callbacks into `Controller`, no lock inversion.
- Drops the **write-only** `autoApproveTools` field and the now-redundant bypass pre-check in `gateApprover` (`requestApproval` already short-circuits it).

All approval bookkeeping moves off `c.mu`; `Controller` sheds 9 fields and a mutex. `controller.go`: 3712 → 3506 lines.

## Compatibility

Public API (`Approve`/`AnswerQuestion`/`SetMode`/`SetToolApprovalMode`/`SetAutoApproveTools`/`Bypass`/`AutoApproveTools`/`EnableInteractiveApproval`/`ReplayPendingPrompts`) is **unchanged** — bot/cli/serve/desktop callers are unaffected.

## Verification

- `gofmt`, `go build ./...`, `go vet ./...` clean
- `go test ./internal/control/ -race` passes (approval/yolo/ask e2e + concurrency)
- downstream `bot`/`serve`/`cli` tests pass