### PR TITLE
fix(tui): forceGotoBottom scrolls regardless of transcript length change (#4797)

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -689,10 +689,13 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		wrapped := wrapTranscript(strings.Join(cm.transcript, "\n"), contentW)
 		cm.viewport.SetContent(wrapped)
 		cm.wrappedLines = strings.Split(wrapped, "\n")
-		if wasAtBottom || cm.forceGotoBottom {
+		if wasAtBottom {
 			cm.viewport.GotoBottom() // tail-follow: stay pinned to newest output
-			cm.forceGotoBottom = false
 		}
+	}
+	if cm.forceGotoBottom {
+		cm.viewport.GotoBottom()
+		cm.forceGotoBottom = false
 	}
 	cm.transcriptDirty = false
 	// Any viewport scroll (wheel, PgUp/PgDn, edge auto-scroll, or tail-follow to

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -2081,3 +2081,50 @@ func TestShiftTabStillTogglesPlanUnderClassicShortcutLayout(t *testing.T) {
 		t.Fatalf("Shift+Tab changed approval mode to %q", got)
 	}
 }
+
+// TestForceGotoBottomScrollsToBottom verifies that when forceGotoBottom is set
+// (e.g., by replayActiveBranch after a session switch), the viewport always scrolls
+// to the bottom on the next Update call, even if the transcript content didn't
+// change in length. This prevents the bug where switching sessions with the same
+// number of lines leaves the viewport at an intermediate position.
+func TestForceGotoBottomScrollsToBottom(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	// Set up a session with enough lines to overflow the viewport.
+	cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 8})
+	for i := 0; i < 12; i++ {
+		cur = adv(cur, notice)
+	}
+	if !cur.viewport.AtBottom() {
+		t.Fatal("viewport should start at bottom")
+	}
+
+	// Scroll up to simulate reading history.
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if cur.viewport.AtBottom() {
+		t.Fatal("wheel-up should break the bottom pin")
+	}
+
+	// Simulate what replayActiveBranch does: clear transcript and set forceGotoBottom.
+	// The new transcript happens to have the same length as before (12 lines).
+	cur.transcript = cur.transcript[:12] // keep same length
+	cur.transcriptDirty = true
+	cur.forceGotoBottom = true
+
+	// Trigger an Update with a no-op message (resize with same dimensions).
+	cur = adv(cur, tea.WindowSizeMsg{Width: 80, Height: 8})
+
+	// Viewport must be at bottom despite transcript length not changing.
+	if !cur.viewport.AtBottom() {
+		t.Error("forceGotoBottom should scroll viewport to bottom even when transcript length unchanged")
+	}
+	if cur.forceGotoBottom {
+		t.Error("forceGotoBottom should be cleared after scrolling")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4797

When switching sessions, `replayActiveBranch()` sets `forceGotoBottom=true` to pin the viewport to the latest message. However, `GotoBottom()` was guarded inside a conditional that only fires when the transcript length changes. If the new session had the same number of lines, the viewport stayed at the intermediate scroll position.

## Root Cause

In `internal/cli/chat_tui.go`'s `Update()` wrapper, the scroll-to-bottom logic (`if wasAtBottom || cm.forceGotoBottom`) was inside the `if len(cm.transcript) != prevLines || ...` block. When session switch produced a transcript of equal length, the block was skipped entirely and `GotoBottom()` never ran.

## Fix

Move the `forceGotoBottom` check outside the transcript-change conditional so it always triggers scroll-to-bottom, regardless of content length.

## Tests

- **Added** `TestForceGotoBottomScrollsToBottom` — verifies viewport scrolls to bottom when `forceGotoBottom` is set, even with unchanged transcript length
