### PR TITLE
fix(agent): check ctx cancellation between tool executions (#4860)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1297,14 +1297,32 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 		durations[i] = time.Since(start).Milliseconds()
 		results[i] = outcomes[i].output
 	}
+	cancelled := false
+	markCancelled := func(start int) {
+		errMsg := context.Canceled.Error()
+		if err := ctx.Err(); err != nil {
+			errMsg = err.Error()
+		}
+		output := "cancelled: context cancelled before execution"
+		for j := start; j < len(calls); j++ {
+			results[j] = output
+			outcomes[j] = toolOutcome{output: output, errMsg: errMsg}
+		}
+		cancelled = true
+	}
 
 	for _, batch := range partitionToolCalls(a.tools, calls) {
+		if ctx.Err() != nil {
+			markCancelled(batch.start)
+			break
+		}
 		if batch.parallel && batch.end-batch.start > 1 {
 			runParallel(batch.start, batch.end, run)
 			// After parallel execution completes, check if context was cancelled.
 			// The individual tool executions should have detected ctx.Done(), but
 			// we verify here to ensure we don't continue to subsequent batches.
 			if ctx.Err() != nil {
+				markCancelled(batch.end)
 				break
 			}
 			continue
@@ -1314,10 +1332,7 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 			// This prevents starting new tools when a previous tool's execution
 			// triggered cancellation.
 			if ctx.Err() != nil {
-				// Fill remaining results so the session message count stays consistent
-				for j := i; j < len(calls); j++ {
-					results[j] = "cancelled: context cancelled before execution"
-				}
+				markCancelled(i)
 				break
 			}
 			run(i)
@@ -1325,13 +1340,12 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 			// If so, stop executing remaining tools and return immediately so
 			// the agent loop can detect the cancellation and exit.
 			if ctx.Err() != nil {
-				// Fill remaining results with empty strings so the session
-				// message count stays consistent, but don't execute them.
-				for j := i + 1; j < len(calls); j++ {
-					results[j] = "cancelled: context cancelled before execution"
-				}
+				markCancelled(i + 1)
 				break
 			}
+		}
+		if cancelled {
+			break
 		}
 	}
 
@@ -1352,7 +1366,9 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: o.truncMsg})
 		}
 	}
-	a.applyStormBreaker(calls, outcomes, results)
+	if !cancelled {
+		a.applyStormBreaker(calls, outcomes, results)
+	}
 	return results
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -804,6 +804,11 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		usedAnyTool = true
 
 		results := a.executeBatch(ctx, calls)
+		// If the context was cancelled during tool execution, return immediately
+		// so the caller can detect the cancellation instead of continuing the loop.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		for i, call := range calls {
 			a.session.Add(provider.Message{
 				Role:       provider.RoleTool,
@@ -1296,10 +1301,37 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 	for _, batch := range partitionToolCalls(a.tools, calls) {
 		if batch.parallel && batch.end-batch.start > 1 {
 			runParallel(batch.start, batch.end, run)
+			// After parallel execution completes, check if context was cancelled.
+			// The individual tool executions should have detected ctx.Done(), but
+			// we verify here to ensure we don't continue to subsequent batches.
+			if ctx.Err() != nil {
+				break
+			}
 			continue
 		}
 		for i := batch.start; i < batch.end; i++ {
+			// Before executing the next tool, check if context was cancelled.
+			// This prevents starting new tools when a previous tool's execution
+			// triggered cancellation.
+			if ctx.Err() != nil {
+				// Fill remaining results so the session message count stays consistent
+				for j := i; j < len(calls); j++ {
+					results[j] = "cancelled: context cancelled before execution"
+				}
+				break
+			}
 			run(i)
+			// After each tool execution, also check if the context was cancelled.
+			// If so, stop executing remaining tools and return immediately so
+			// the agent loop can detect the cancellation and exit.
+			if ctx.Err() != nil {
+				// Fill remaining results with empty strings so the session
+				// message count stays consistent, but don't execute them.
+				for j := i + 1; j < len(calls); j++ {
+					results[j] = "cancelled: context cancelled before execution"
+				}
+				break
+			}
 		}
 	}
 

--- a/internal/agent/cancel_test.go
+++ b/internal/agent/cancel_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
 	"reasonix/internal/provider"
 	"reasonix/internal/tool"
 )
@@ -48,14 +49,22 @@ func (slowTool) Execute(ctx context.Context, args json.RawMessage) (string, erro
 }
 
 // trackingTool is a tool that records when it was executed and can simulate delays.
-type trackingTool struct{}
+type trackingTool struct {
+	name     string
+	readOnly bool
+}
 
-func (trackingTool) Name() string        { return "tracking" }
+func (t trackingTool) Name() string {
+	if t.name != "" {
+		return t.name
+	}
+	return "tracking"
+}
 func (trackingTool) Description() string { return "Tracks execution" }
 func (trackingTool) Schema() json.RawMessage {
 	return json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"delay_ms":{"type":"number"},"should_fail":{"type":"boolean"}},"required":["name"]}`)
 }
-func (trackingTool) ReadOnly() bool { return false }
+func (t trackingTool) ReadOnly() bool { return t.readOnly }
 func (trackingTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var p struct {
 		Name       string `json:"name"`
@@ -238,5 +247,75 @@ func TestCancelDuringBatchStopsRemainingTools(t *testing.T) {
 	}
 	if !foundTool2Cancelled {
 		t.Log("Note: tool2 may have completed or been cancelled - check timing")
+	}
+}
+
+// TestCancelBeforeParallelBatchSkipsTheWholeRemainingBatch verifies that a
+// cancellation in a serial writer segment prevents the next read-only parallel
+// segment from starting.
+func TestCancelBeforeParallelBatchSkipsTheWholeRemainingBatch(t *testing.T) {
+	executedMu.Lock()
+	executed = nil
+	executedMu.Unlock()
+
+	reg := tool.NewRegistry()
+	reg.Add(trackingTool{})
+	reg.Add(trackingTool{name: "readonly_tracking", readOnly: true})
+
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			Text: "",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "tracking", Arguments: `{"name": "writer", "delay_ms": 5000}`},
+				{ID: "call-2", Name: "readonly_tracking", Arguments: `{"name": "read1", "delay_ms": 50}`},
+				{ID: "call-3", Name: "readonly_tracking", Arguments: `{"name": "read2", "delay_ms": 50}`},
+			},
+		},
+	)
+
+	sink := &recordSink{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx, "test cancel before parallel batch")
+	}()
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil, want context cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not complete within 5s")
+	}
+
+	executedMu.Lock()
+	executedCopy := append([]string(nil), executed...)
+	executedMu.Unlock()
+	for _, name := range executedCopy {
+		if strings.HasPrefix(name, "read") {
+			t.Fatalf("read-only parallel batch should not start after cancel, executed: %v", executedCopy)
+		}
+	}
+
+	results := sink.kinds(event.ToolResult)
+	if len(results) != 3 {
+		t.Fatalf("ToolResult events = %d, want 3", len(results))
+	}
+	for _, e := range results[1:] {
+		if e.Tool.Err == "" {
+			t.Fatalf("cancelled unstarted tool result should carry an error: %+v", e.Tool)
+		}
+		if !strings.Contains(e.Tool.Output, "cancelled") {
+			t.Fatalf("cancelled unstarted tool result should explain cancellation: %+v", e.Tool)
+		}
 	}
 }

--- a/internal/agent/cancel_test.go
+++ b/internal/agent/cancel_test.go
@@ -1,0 +1,242 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// slowTool is a tool that takes a noticeable amount of time to execute,
+// simulating a long-running bash command or other blocking operation.
+type slowTool struct{}
+
+func (slowTool) Name() string { return "slow_tool" }
+
+func (slowTool) Description() string { return "A tool that executes slowly" }
+
+func (slowTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"duration_ms":{"type":"number","description":"How long to sleep in milliseconds"}},"required":["duration_ms"]}`)
+}
+
+func (slowTool) ReadOnly() bool { return false }
+
+func (slowTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		DurationMs int `json:"duration_ms"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", err
+	}
+	if p.DurationMs <= 0 {
+		p.DurationMs = 500
+	}
+
+	// Simulate work that respects context cancellation
+	select {
+	case <-time.After(time.Duration(p.DurationMs) * time.Millisecond):
+		return "done", nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// trackingTool is a tool that records when it was executed and can simulate delays.
+type trackingTool struct{}
+
+func (trackingTool) Name() string        { return "tracking" }
+func (trackingTool) Description() string { return "Tracks execution" }
+func (trackingTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"delay_ms":{"type":"number"},"should_fail":{"type":"boolean"}},"required":["name"]}`)
+}
+func (trackingTool) ReadOnly() bool { return false }
+func (trackingTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Name       string `json:"name"`
+		DelayMs    int    `json:"delay_ms"`
+		ShouldFail bool   `json:"should_fail"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", err
+	}
+
+	executedMu.Lock()
+	executed = append(executed, p.Name+"_start")
+	executedMu.Unlock()
+
+	if p.ShouldFail {
+		return "", context.Canceled
+	}
+
+	// Simulate work that respects context cancellation
+	if p.DelayMs > 0 {
+		select {
+		case <-time.After(time.Duration(p.DelayMs) * time.Millisecond):
+			// Completed the delay successfully
+		case <-ctx.Done():
+			executedMu.Lock()
+			executed = append(executed, p.Name+"_cancelled")
+			executedMu.Unlock()
+			return "", ctx.Err()
+		}
+	}
+
+	executedMu.Lock()
+	executed = append(executed, p.Name+"_done")
+	executedMu.Unlock()
+
+	return p.Name + " done", nil
+}
+
+// Global variables for tracking across tests
+var (
+	executedMu sync.Mutex
+	executed   []string
+)
+
+// TestCancelDuringToolExecutionBreaksOutPromptly verifies that when the context
+// is cancelled while tools are executing, the agent loop breaks out immediately
+// rather than continuing to execute remaining tools.
+func TestCancelDuringToolExecutionBreaksOutPromptly(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(slowTool{})
+
+	// Script: first turn calls two slow tools, but we'll cancel after the first starts
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			Text: "",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "slow_tool", Arguments: `{"duration_ms": 2000}`}, // 2 second tool
+				{ID: "call-2", Name: "slow_tool", Arguments: `{"duration_ms": 2000}`}, // another 2 second tool
+			},
+		},
+	)
+
+	sink := &recordSink{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	// Create a cancellable context and cancel it shortly after starting
+	ctx, cancel := context.WithCancel(context.Background())
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx, "test cancel during tool execution")
+	}()
+
+	// Cancel after a short delay to simulate user pressing Esc mid-execution
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	// Wait for the run to complete (should be fast due to cancel, not 4+ seconds)
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not complete within 5s after cancel — context cancellation did not interrupt tool execution")
+	}
+
+	elapsed := time.Since(start)
+
+	// Should have run until the cancel (~300ms) but not completed both tools (4s+)
+	if elapsed < 250*time.Millisecond {
+		t.Fatalf("command exited too fast (%v) — cancel didn't actually interrupt execution; err=%v", elapsed, err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("cancel took too long (%v) — should have broken out after first tool, not waited for all tools", elapsed)
+	}
+
+	// The error should be related to context cancellation
+	if err == nil {
+		t.Log("Run returned nil error after cancel (acceptable if tools detected ctx.Done)")
+	} else {
+		t.Logf("Run returned error after cancel: %v (elapsed: %v)", err, elapsed)
+	}
+}
+
+// TestCancelDuringBatchStopsRemainingTools verifies that when context is
+// cancelled during a batch of tool executions, remaining tools are not executed.
+func TestCancelDuringBatchStopsRemainingTools(t *testing.T) {
+	// Reset tracking
+	executedMu.Lock()
+	executed = nil
+	executedMu.Unlock()
+
+	reg := tool.NewRegistry()
+	reg.Add(trackingTool{})
+
+	// Script: model wants to execute three tools in sequence
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			Text: "",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "tracking", Arguments: `{"name": "tool1", "delay_ms": 50}`},
+				{ID: "call-2", Name: "tracking", Arguments: `{"name": "tool2", "delay_ms": 5000}`}, // Long-running tool
+				{ID: "call-3", Name: "tracking", Arguments: `{"name": "tool3", "delay_ms": 50}`},
+			},
+		},
+	)
+
+	sink := &recordSink{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx, "test batch cancel")
+	}()
+
+	// Cancel while tool2 is still running (after tool1 completes but during tool2)
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not complete within 10s")
+	}
+
+	executedMu.Lock()
+	executedCopy := make([]string, len(executed))
+	copy(executedCopy, executed)
+	executedMu.Unlock()
+
+	t.Logf("Executed tools: %v (err=%v)", executedCopy, err)
+
+	// We expect tool1 to have completed, tool2 to have been cancelled mid-execution,
+	// and tool3 to NOT have started at all due to our ctx.Err() check after each tool.
+	if len(executedCopy) < 2 { // At least tool1_start should be there
+		t.Error("Expected at least one tool to start execution")
+	}
+
+	// Check that tool3 never started
+	for _, name := range executedCopy {
+		if strings.HasPrefix(name, "tool3") {
+			t.Error("tool3 should not have executed after cancel interrupted the batch")
+		}
+	}
+
+	// Verify tool2 was cancelled
+	foundTool2Cancelled := false
+	for _, name := range executedCopy {
+		if name == "tool2_cancelled" {
+			foundTool2Cancelled = true
+		}
+	}
+	if !foundTool2Cancelled {
+		t.Log("Note: tool2 may have completed or been cancelled - check timing")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #4860

When the user presses Escape/Ctrl+C during a running turn, `Cancel()` cancels the context. However, the agent's `executeBatch()` continued executing remaining tools in the batch even after one tool detected `ctx.Done()`. The TUI appeared frozen until all tools finished.

## Root Cause

In `internal/agent/agent.go`, the `executeBatch()` function ran all tools in a serial batch without checking `ctx.Err()` between executions. After `Cancel()` fired, the first tool would detect `ctx.Done()` and return, but the loop continued to start the next tool.

## Fix

- Add `ctx.Err()` checks **before** and **after** each tool execution in serial batches
- When context is cancelled, stop executing remaining tools immediately and fill their results with cancellation markers
- Add `ctx.Err()` check in the main `Run()` loop after `executeBatch()` to exit promptly

## Tests

- **Added** `TestCancelDuringToolExecutionBreaksOutPromptly` — verifies agent exits ~300ms after cancel instead of waiting for all tools (~4s)
- **Added** `TestCancelDuringBatchStopsRemainingTools` — verifies cancelled tools don't start subsequent tools in the batch

## Cache Metadata

Cache-impact: low — changes are confined to the agent's tool execution loop. No system prompt, tool schema, or provider surface modifications. The prompt prefix is unaffected.
Cache-guard: `go test ./internal/agent/ -run TestCancel -v` covers the cancel-during-execution path. Existing `TestRunCancelledMidStreamLeavesResumableSession` in loop_e2e_test.go covers the broader cancel flow.
System-prompt-review: No system prompt paths touched. Changes are internal to the agent execution loop only.
