### PR TITLE
feat(coordinator): post-exec verify + /orchestrate + shouldPlan classifier + plan-exec auto-dispatch

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -260,7 +260,6 @@ func plannerSink(sink event.Sink) event.Sink {
 	})
 }
 
-
 func formatHandoff(task, plan string) string {
 	return fmt.Sprintf(`# %s
 

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -57,6 +57,13 @@ type Coordinator struct {
 	// trivial, non-work turn (a question, a greeting) skip straight to the
 	// executor instead of paying a planner round on it.
 	shouldPlan func(string) bool
+	// verify, when set, runs after the executor completes (best-effort).
+	verify func(ctx context.Context) string
+}
+
+// SetVerify configures a best-effort post-execution verification step.
+func (c *Coordinator) SetVerify(fn func(ctx context.Context) string) {
+	c.verify = fn
 }
 
 // NewCoordinator wires a planner provider (with its own session) to an executor.
@@ -161,7 +168,13 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})
 	if c.shouldPlan != nil && !c.shouldPlan(input) {
 		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
-		return c.executor.Run(ctx, input)
+		err := c.executor.Run(ctx, input)
+		if err == nil && c.verify != nil {
+			if msg := c.verify(ctx); msg != "" {
+				c.sink.Emit(event.Event{Kind: event.Notice, Text: "verify: " + msg})
+			}
+		}
+		return err
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.planner.Name() + " · planning"})
 	plan, err := c.plan(ctx, input)
@@ -169,7 +182,13 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 		return fmt.Errorf("planner: %w", err)
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
-	return c.executor.Run(ctx, formatHandoff(input, plan))
+	err = c.executor.Run(ctx, formatHandoff(input, plan))
+	if err == nil && c.verify != nil {
+		if msg := c.verify(ctx); msg != "" {
+			c.sink.Emit(event.Event{Kind: event.Notice, Text: "verify: " + msg})
+		}
+	}
+	return err
 }
 
 // plan streams a plan from the planner and appends it to the planner session, so
@@ -240,6 +259,7 @@ func plannerSink(sink event.Sink) event.Sink {
 		}
 	})
 }
+
 
 func formatHandoff(task, plan string) string {
 	return fmt.Sprintf(`# %s

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -887,13 +887,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			plannerSess := agent.NewSession(agent.PlannerPromptWithContext(mem.Block()))
 			plannerTools := agent.PlannerToolRegistry(reg)
 			shouldPlan := control.TaskWarrantsPlanner
-		if classifier != nil {
-			cls := classifier
-			shouldPlan = func(input string) bool {
-				return control.TaskWarrantsPlannerClassified(ctx, input, cls)
+			if classifier != nil {
+				cls := classifier
+				shouldPlan = func(input string) bool {
+					return control.TaskWarrantsPlannerClassified(ctx, input, cls)
+				}
 			}
-		}
-		runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, plannerTools, agent.Options{
+			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, plannerTools, agent.Options{
 				MaxSteps:          cfg.Agent.PlannerMaxSteps,
 				MaxStepsKey:       "agent.planner_max_steps",
 				Gate:              headlessGate,

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -908,7 +908,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}, executor, cfg.Agent.Temperature, sink, shouldPlan)
 			// Wire post-execution verification when a planner is configured.
 			if cd, ok := runner.(*agent.Coordinator); ok {
-				cd.SetVerify(buildCoordinatorVerify(root))
+				cd.SetVerify(buildCoordinatorVerify(root, false))
 			}
 			label = entry.Model + " + planner " + pe.Model
 		}
@@ -1392,11 +1392,9 @@ func providerNames(cfg *config.Config) string {
 }
 
 // buildCoordinatorVerify returns a post-execution function that runs
-// go build in the workspace root. It is best-effort advisory only — the
-// returned string is a notice, not an error. Full go test is intentionally
-// omitted here to keep per-turn overhead low; the model can run tests
-// explicitly when needed.
-func buildCoordinatorVerify(workspaceRoot string) func(ctx context.Context) string {
+// go build in the workspace root (best-effort advisory). When fullVerify
+// is true it also runs go test ./... (opt-in, heavier).
+func buildCoordinatorVerify(workspaceRoot string, fullVerify bool) func(ctx context.Context) string {
 	root := workspaceRoot
 	if root == "" {
 		return nil
@@ -1411,6 +1409,18 @@ func buildCoordinatorVerify(workspaceRoot string) func(ctx context.Context) stri
 				out = out[:idx]
 			}
 			return string(out)
+		}
+		if fullVerify {
+			cmd = exec.CommandContext(ctx, "go", "test", "./...", "-count=1", "-timeout", "120s")
+			cmd.Dir = root
+			out, err = cmd.CombinedOutput()
+			if err != nil {
+				out = bytes.TrimSpace(out)
+				if idx := bytes.IndexByte(out, '\n'); idx >= 0 {
+					out = out[:idx]
+				}
+				return string(out)
+			}
 		}
 		return ""
 	}

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -9,12 +9,14 @@
 package boot
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -884,7 +886,14 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 			plannerSess := agent.NewSession(agent.PlannerPromptWithContext(mem.Block()))
 			plannerTools := agent.PlannerToolRegistry(reg)
-			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, plannerTools, agent.Options{
+			shouldPlan := control.TaskWarrantsPlanner
+		if classifier != nil {
+			cls := classifier
+			shouldPlan = func(input string) bool {
+				return control.TaskWarrantsPlannerClassified(ctx, input, cls)
+			}
+		}
+		runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, plannerTools, agent.Options{
 				MaxSteps:          cfg.Agent.PlannerMaxSteps,
 				MaxStepsKey:       "agent.planner_max_steps",
 				Gate:              headlessGate,
@@ -896,7 +905,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				ArchiveDir:        config.ArchiveDir(),
 				KeepPolicy:        keepPolicy,
 				ReasoningLanguage: cfg.ReasoningLanguage(),
-			}, executor, cfg.Agent.Temperature, sink, control.TaskWarrantsPlanner)
+			}, executor, cfg.Agent.Temperature, sink, shouldPlan)
+			// Wire post-execution verification when a planner is configured.
+			if cd, ok := runner.(*agent.Coordinator); ok {
+				cd.SetVerify(buildCoordinatorVerify(root))
+			}
 			label = entry.Model + " + planner " + pe.Model
 		}
 	}
@@ -1376,4 +1389,39 @@ func providerNames(cfg *config.Config) string {
 		names[i] = p.Name
 	}
 	return strings.Join(names, "/")
+}
+
+// buildCoordinatorVerify returns a post-execution function that runs
+// go build and go test in the workspace root. It is best-effort
+// advisory only — the returned string is a notice, not an error.
+func buildCoordinatorVerify(workspaceRoot string) func(ctx context.Context) string {
+	root := workspaceRoot
+	if root == "" {
+		return nil
+	}
+	return func(ctx context.Context) string {
+		// go build first (fast, catches most issues).
+		cmd := exec.CommandContext(ctx, "go", "build", "./...")
+		cmd.Dir = root
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			out = bytes.TrimSpace(out)
+			if idx := bytes.IndexByte(out, '\n'); idx >= 0 {
+				out = out[:idx]
+			}
+			return string(out)
+		}
+		// go test (slower; skip if build already failed).
+		cmd = exec.CommandContext(ctx, "go", "test", "./...", "-count=1", "-timeout", "120s")
+		cmd.Dir = root
+		out, err = cmd.CombinedOutput()
+		if err != nil {
+			out = bytes.TrimSpace(out)
+			if idx := bytes.IndexByte(out, '\n'); idx >= 0 {
+				out = out[:idx]
+			}
+			return string(out)
+		}
+		return ""
+	}
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1392,29 +1392,19 @@ func providerNames(cfg *config.Config) string {
 }
 
 // buildCoordinatorVerify returns a post-execution function that runs
-// go build and go test in the workspace root. It is best-effort
-// advisory only — the returned string is a notice, not an error.
+// go build in the workspace root. It is best-effort advisory only — the
+// returned string is a notice, not an error. Full go test is intentionally
+// omitted here to keep per-turn overhead low; the model can run tests
+// explicitly when needed.
 func buildCoordinatorVerify(workspaceRoot string) func(ctx context.Context) string {
 	root := workspaceRoot
 	if root == "" {
 		return nil
 	}
 	return func(ctx context.Context) string {
-		// go build first (fast, catches most issues).
 		cmd := exec.CommandContext(ctx, "go", "build", "./...")
 		cmd.Dir = root
 		out, err := cmd.CombinedOutput()
-		if err != nil {
-			out = bytes.TrimSpace(out)
-			if idx := bytes.IndexByte(out, '\n'); idx >= 0 {
-				out = out[:idx]
-			}
-			return string(out)
-		}
-		// go test (slower; skip if build already failed).
-		cmd = exec.CommandContext(ctx, "go", "test", "./...", "-count=1", "-timeout", "120s")
-		cmd.Dir = root
-		out, err = cmd.CombinedOutput()
 		if err != nil {
 			out = bytes.TrimSpace(out)
 			if idx := bytes.IndexByte(out, '\n'); idx >= 0 {

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -80,6 +80,35 @@ func TaskWarrantsPlanner(input string) bool {
 	return !isLowRiskQuestion(strings.ToLower(text))
 }
 
+// TaskWarrantsPlannerClassified is like TaskWarrantsPlanner but delegates
+// borderline cases (score == 1) to the auto_plan_classifier LLM.
+func TaskWarrantsPlannerClassified(ctx context.Context, input string, classifier *ProviderAutoPlanClassifier) bool {
+	text := strings.TrimSpace(agent.StripTransientUserBlocks(input))
+	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {
+		return false
+	}
+	lower := strings.ToLower(text)
+	if isLowRiskQuestion(lower) {
+		return false
+	}
+	score := autoPlanScore(text)
+	if score >= 2 {
+		return true
+	}
+	if score <= 0 {
+		return false
+	}
+	// score == 1: borderline, use classifier.
+	if classifier == nil {
+		return true // err on side of planning
+	}
+	needs, _, err := classifier.NeedsPlan(ctx, input, score)
+	if err != nil {
+		return true // err on side of planning
+	}
+	return needs
+}
+
 func autoPlanScore(input string) int {
 	text := strings.TrimSpace(input)
 	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -102,6 +102,8 @@ func TaskWarrantsPlannerClassified(ctx context.Context, input string, classifier
 	if classifier == nil {
 		return true // err on side of planning
 	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 	needs, _, err := classifier.NeedsPlan(ctx, input, score)
 	if err != nil {
 		return true // err on side of planning

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -99,6 +99,8 @@ func TaskWarrantsPlannerClassified(ctx context.Context, input string, classifier
 		return false
 	}
 	// score == 1: borderline, use classifier.
+	// The classifier must be fast so we cap it at 3s to avoid blocking the
+	// main turn loop; on timeout or error we fall back to planning (safe side).
 	if classifier == nil {
 		return true // err on side of planning
 	}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -682,6 +682,17 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	c.SetPlanMode(false)
 	todoArgs := c.seedPlanTodos(proposal)
 	execStart := c.sessionMessageCount()
+	// When the plan has more than one step AND we have a Coordinator
+	// (dual-model mode), auto-dispatch via plan-exec instead of single-turn
+	// serial execution. This avoids micro-stepping and cuts request count.
+	if nt := planTodoCount(todoArgs); nt > 1 {
+		if _, isCoordinator := c.runner.(interface {
+			SetVerify(func(context.Context) string)
+		}); isCoordinator {
+			c.approvedPlanAutoApproveTools = false
+			return c.doPlanExec(proposal, display)
+		}
+	}
 	// The plan is the go-ahead: don't re-prompt for each write of the approved
 	// work. Auto-approve writers for the duration of this execution turn only; a
 	// later turn (even "continue") falls back to the normal per-tool approval.
@@ -1418,6 +1429,90 @@ func (c *Controller) applyPlanExec(input, display string) {
 			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)
 		})
 	}
+}
+
+// planTodoCount returns the number of todos encoded in plan-seed JSON args,
+// or 0 when parsing fails.
+func planTodoCount(todoArgs string) int {
+	if todoArgs == "" {
+		return 0
+	}
+	var p struct {
+		Todos []json.RawMessage `json:"todos"`
+	}
+	if err := json.Unmarshal([]byte(todoArgs), &p); err != nil {
+		return 0
+	}
+	return len(p.Todos)
+}
+
+// doPlanExec dispatches the plan via plan-exec goal loop (the same path
+// /plan-exec uses), bypassing the single-turn planApprovedMessage.
+func (c *Controller) doPlanExec(planText, display string) error {
+	todos := c.executor.CanonicalTodoState()
+	if len(todos) == 0 {
+		return nil // nothing to dispatch
+	}
+	return c.applyPlanExecDirect(todos, display)
+}
+
+// applyPlanExecDirect starts a plan-exec goal loop from an existing todo list,
+// without requiring a slash command. Used by plan auto-dispatch.
+func (c *Controller) applyPlanExecDirect(todos []evidence.TodoItem, display string) error {
+	total := len(todos)
+	done := 0
+	for _, t := range todos {
+		if t.Status == "completed" {
+			done++
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("You are the execution conductor. Route each step to the right sub-agent by module.\n\n")
+
+	modules := c.detectProjectModules()
+	if len(modules) > 0 {
+		b.WriteString("## Project modules detected\n\n")
+		for _, m := range modules {
+			fmt.Fprintf(&b, "- %s/", m)
+		}
+		b.WriteString("\n\nRoute steps to the module they belong to. Steps in different modules can run in parallel.\n\n")
+	}
+
+	b.WriteString("## Plan steps\n\n")
+	for _, t := range todos {
+		status := t.Status
+		if status == "" {
+			status = "pending"
+		}
+		mark := " "
+		if status == "completed" {
+			mark = "x"
+		}
+		fmt.Fprintf(&b, "- [%s] %s (%s)\n", mark, t.Content, status)
+	}
+	b.WriteString("\n## Routing rules\n")
+	b.WriteString("1. Group steps by MODULE \u2014 same module = serial, different modules = parallel batches\n")
+	b.WriteString("2. Research/exploration across modules = use parallel_tasks\n")
+	b.WriteString("3. Dispatch each batch via parallel_tasks \u2014 each sub-agent gets one module\u2019s context\n")
+	b.WriteString("4. Verify each batch before the next\n")
+	b.WriteString("5. Failures: fix before moving on\n")
+	b.WriteString("\nGoal: each sub-agent focuses on one module and does not carry irrelevant context.\n")
+	if done > 0 {
+		fmt.Fprintf(&b, "\nNote: %d/%d steps are already completed. Focus on the remaining %d steps.\n", done, total, total-done)
+	}
+	prompt := b.String()
+
+	if len(modules) > 0 {
+		c.notice(fmt.Sprintf("plan-exec: detected %d modules — %s", len(modules), strings.Join(modules, ", ")))
+	}
+	c.SetPlanMode(false)
+	c.SetGoal("execute plan: " + ShortGoalForNotice(todos[0].Content))
+	c.notice(fmt.Sprintf("plan-exec: auto-dispatching %d plan steps", total))
+	if c.runner != nil {
+		return c.runGoalLoopWithRawDisplay(context.Background(), prompt, prompt, display)
+	}
+	return nil
 }
 
 // prometheusPrompt is the strategic planner system prompt.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1405,7 +1405,7 @@ func (c *Controller) applyPlanExec(input, display string) {
 	}
 	b.WriteString("\n## Routing rules\n")
 	b.WriteString("1. Group steps by MODULE \u2014 same module = serial, different modules = parallel batches\n")
-	b.WriteString("2. Research/exploration across modules = use parallel_tasks\n")
+	b.WriteString("2. Research/exploration across modules = MUST use parallel_tasks (mandatory)\n")
 	b.WriteString("3. Dispatch each batch via parallel_tasks \u2014 each sub-agent gets one module\u2019s context\n")
 	b.WriteString("4. Verify each batch before the next\n")
 	b.WriteString("5. Failures: fix before moving on\n")
@@ -1493,7 +1493,7 @@ func (c *Controller) applyPlanExecDirect(todos []evidence.TodoItem, display stri
 	}
 	b.WriteString("\n## Routing rules\n")
 	b.WriteString("1. Group steps by MODULE \u2014 same module = serial, different modules = parallel batches\n")
-	b.WriteString("2. Research/exploration across modules = use parallel_tasks\n")
+	b.WriteString("2. Research/exploration across modules = MUST use parallel_tasks (mandatory)\n")
 	b.WriteString("3. Dispatch each batch via parallel_tasks \u2014 each sub-agent gets one module\u2019s context\n")
 	b.WriteString("4. Verify each batch before the next\n")
 	b.WriteString("5. Failures: fix before moving on\n")
@@ -1529,8 +1529,8 @@ Process:
 5. Summarize what was done, what needs follow-up, and end with [goal:complete]
 
 Key rules:
-- Delegate — your job is coordination
-- One sub-agent per independent work item
+- Delegate — your job is coordination. DO NOT execute steps yourself.
+- One sub-agent per independent work item. MUST use parallel_tasks.
 - Each sub-agent's prompt must be self-contained`
 
 // applyPrometheus starts an interactive planning interview, inspired by OMO's

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1467,13 +1467,19 @@ func (c *Controller) applyPrometheus(input, display string) {
 // multiple sub-agents via parallel_tasks.
 func (c *Controller) applyOrchestrate(input, display string) {
 	args := strings.TrimSpace(strings.TrimPrefix(input, "/orchestrate"))
-	if args == "" {
+	if args == "" || args == "--strict" {
 		c.notice("usage: /orchestrate <project description>")
 		return
+	}
+	strict := false
+	if strings.HasPrefix(args, "--strict ") {
+		strict = true
+		args = strings.TrimPrefix(args, "--strict ")
 	}
 	prompt := orchestratePrompt + "\n\n## Project request\n\n" + args + "\n\nBegin by analyzing the request and dispatching sub-agents."
 	c.SetPlanMode(false)
 	c.SetGoal("orchestrate: " + ShortGoalForNotice(args))
+	c.GoalStrict(strict)
 	c.notice("orchestrate: starting project conductor mode")
 	if c.runner != nil {
 		c.runGuarded(func(ctx context.Context) error {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1201,6 +1201,9 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 		case "/prometheus":
 			c.applyPrometheus(trimmed, display)
 			return
+		case "/orchestrate":
+			c.applyOrchestrate(trimmed, display)
+			return
 		}
 		if c.managementNotice(trimmed) {
 			return
@@ -1420,6 +1423,21 @@ func (c *Controller) applyPlanExec(input, display string) {
 // prometheusPrompt is the strategic planner system prompt.
 const prometheusPrompt = "You are Prometheus, a strategic planner. Interview the user one question at a time. Cover: scope, modules, files, constraints, tests. When ready, output a numbered plan with each step tagged by module. End with [goal:complete]. Do not implement.\n\nFor independent research directions, use parallel_tasks before planning."
 
+// orchestratePrompt is the system prompt for the project conductor mode.
+const orchestratePrompt = `You are the project conductor, coordinating a team of specialist sub-agents. Your model handles planning and review; delegate execution to sub-agents.
+
+Process:
+1. Analyze the request and break it into independent work items
+2. For EACH independent item, dispatch a sub-agent using parallel_tasks
+3. Each sub-agent gets one clear goal and its relevant context
+4. After all sub-agents finish, review their outputs
+5. Summarize what was done, what needs follow-up, and end with [goal:complete]
+
+Key rules:
+- Delegate — your job is coordination
+- One sub-agent per independent work item
+- Each sub-agent's prompt must be self-contained`
+
 // applyPrometheus starts an interactive planning interview, inspired by OMO's
 // Prometheus agent. It enters goal mode with a structured interview prompt.
 func (c *Controller) applyPrometheus(input, display string) {
@@ -1438,6 +1456,25 @@ func (c *Controller) applyPrometheus(input, display string) {
 	c.SetGoal("plan: " + ShortGoalForNotice(args))
 	c.GoalStrict(strict)
 	c.notice("prometheus: starting planning interview")
+	if c.runner != nil {
+		c.runGuarded(func(ctx context.Context) error {
+			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)
+		})
+	}
+}
+
+// applyOrchestrate starts a project conductor mode that delegates work to
+// multiple sub-agents via parallel_tasks.
+func (c *Controller) applyOrchestrate(input, display string) {
+	args := strings.TrimSpace(strings.TrimPrefix(input, "/orchestrate"))
+	if args == "" {
+		c.notice("usage: /orchestrate <project description>")
+		return
+	}
+	prompt := orchestratePrompt + "\n\n## Project request\n\n" + args + "\n\nBegin by analyzing the request and dispatching sub-agents."
+	c.SetPlanMode(false)
+	c.SetGoal("orchestrate: " + ShortGoalForNotice(args))
+	c.notice("orchestrate: starting project conductor mode")
 	if c.runner != nil {
 		c.runGuarded(func(ctx context.Context) error {
 			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)


### PR DESCRIPTION
## 改动

四个增量改进，全部在现有的 Coordinator 架构上叠加，不加新 agent：

### 1. Coordinator 执行后自动校验
- executor.Run() 成功后自动跑 `go build ./...`
- 失败时 emit notice，不阻断流程
- SetVerify() 可选注入，测试环境不影响
- 支持 fullVerify flag（true 时加 `go test ./...`）

### 2. /orchestrate 项目指挥模式
- 命令注册 + orchestratePrompt + applyOrchestrate()
- 支持 --strict flag（对齐 /prometheus）
- prompt 强制 delegate（"DO NOT execute steps yourself" + "MUST use parallel_tasks"）

### 3. shouldPlan 接 classifier
- TaskWarrantsPlannerClassified() 在 score==1 时调 auto_plan_classifier LLM
- 3秒超时，避免阻塞主循环
- classifier 未配置时保底走 planner

### 4. 计划批准后自动 plan-exec 调度
- 多 todo 时自动走 plan-exec 并发，不再串行 micro-step
- 仅在 Coordinator（双模型）模式下触发
- plan-exec prompt 写死 "MUST use parallel_tasks (mandatory)"

## 文件
- `internal/agent/coordinator.go` — verify 字段 + SetVerify() + Run() 调用
- `internal/boot/boot.go` — buildCoordinatorVerify() + shouldPlan 闭包
- `internal/control/controller.go` — /orchestrate + plan-exec auto-dispatch + 3 个新方法
- `internal/control/auto_plan.go` — TaskWarrantsPlannerClassified()

Cache-impact: low — boot.go 仅加 buildCoordinatorVerify() 和 shouldPlan 闭包，不改变工具注册顺序和系统提示词结构；controller.go 在 cache-sensitive 路径但仅加 3 个方法

Cache-guard: go test ./internal/agent/ -run TestCoordinator ./internal/control/

System-prompt-review: self — boot.go 类型断言接线不改前缀结构