### PR TITLE
feat(coordinator): post-exec verify + /orchestrate + shouldPlan classifier + plan-exec auto-dispatch

### DIFF
--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -57,6 +57,13 @@ type Coordinator struct {
 	// trivial, non-work turn (a question, a greeting) skip straight to the
 	// executor instead of paying a planner round on it.
 	shouldPlan func(string) bool
+	// verify, when set, runs after the executor completes (best-effort).
+	verify func(ctx context.Context) string
+}
+
+// SetVerify configures a best-effort post-execution verification step.
+func (c *Coordinator) SetVerify(fn func(ctx context.Context) string) {
+	c.verify = fn
 }
 
 // NewCoordinator wires a planner provider (with its own session) to an executor.
@@ -161,7 +168,13 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 	c.sink.Emit(event.Event{Kind: event.TurnStarted})
 	if c.shouldPlan != nil && !c.shouldPlan(input) {
 		c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
-		return c.executor.Run(ctx, input)
+		err := c.executor.Run(ctx, input)
+		if err == nil && c.verify != nil {
+			if msg := c.verify(ctx); msg != "" {
+				c.sink.Emit(event.Event{Kind: event.Notice, Text: "verify: " + msg})
+			}
+		}
+		return err
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.planner.Name() + " · planning"})
 	plan, err := c.plan(ctx, input)
@@ -169,7 +182,13 @@ func (c *Coordinator) Run(ctx context.Context, input string) error {
 		return fmt.Errorf("planner: %w", err)
 	}
 	c.sink.Emit(event.Event{Kind: event.Phase, Text: c.executor.prov.Name() + " · executing"})
-	return c.executor.Run(ctx, formatHandoff(input, plan))
+	err = c.executor.Run(ctx, formatHandoff(input, plan))
+	if err == nil && c.verify != nil {
+		if msg := c.verify(ctx); msg != "" {
+			c.sink.Emit(event.Event{Kind: event.Notice, Text: "verify: " + msg})
+		}
+	}
+	return err
 }
 
 // plan streams a plan from the planner and appends it to the planner session, so

--- a/internal/agent/parallel_tasks.go
+++ b/internal/agent/parallel_tasks.go
@@ -228,6 +228,7 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 
 				subID := fmt.Sprintf("%s/sub-%d", parentID, idx+1)
 				dispatchArgs, _ := json.Marshal(map[string]string{"prompt": prompt, "description": label})
+				emitProgress(sink, parentID, label, idx+1, n, "running")
 				sink.Emit(event.Event{
 					Kind: event.ToolDispatch,
 					Tool: event.Tool{
@@ -272,12 +273,14 @@ func (p *ParallelTasksTool) Execute(ctx context.Context, args json.RawMessage) (
 				}, nested)
 
 				if runErr != nil {
+					emitProgress(sink, parentID, label, idx+1, n, "failed")
 					sink.Emit(event.Event{
 						Kind: event.ToolResult,
 						Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Err: runErr.Error()},
 					})
 					doneCh <- subResult{index: idx, err: runErr}
 				} else {
+					emitProgress(sink, parentID, label, idx+1, n, "completed")
 					sink.Emit(event.Event{
 						Kind: event.ToolResult,
 						Tool: event.Tool{ID: subID, ParentID: parentID, Name: "task", Output: output},
@@ -454,4 +457,20 @@ func extractJobID(msg string) string {
 		return ""
 	}
 	return msg[quote+1 : quote+1+end]
+}
+
+// emitProgress sends a SubAgentProgress event for parallel task tracking.
+func emitProgress(sink event.Sink, parentID, label string, current, total int, status string) {
+	sink.Emit(event.Event{
+		Kind: event.SubAgentProgress,
+		Text: label,
+		Progress: &event.ProgressInfo{
+			Current: current,
+			Total:   total,
+			Status:  status,
+		},
+		Tool: event.Tool{
+			ParentID: parentID,
+		},
+	})
 }

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -9,12 +9,14 @@
 package boot
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -884,6 +886,13 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 			plannerSess := agent.NewSession(agent.PlannerPromptWithContext(mem.Block()))
 			plannerTools := agent.PlannerToolRegistry(reg)
+			shouldPlan := control.TaskWarrantsPlanner
+			if classifier != nil {
+				cls := classifier
+				shouldPlan = func(input string) bool {
+					return control.TaskWarrantsPlannerClassified(ctx, input, cls)
+				}
+			}
 			runner = agent.NewCoordinator(plannerProv, plannerSess, pe.Price, plannerTools, agent.Options{
 				MaxSteps:          cfg.Agent.PlannerMaxSteps,
 				MaxStepsKey:       "agent.planner_max_steps",
@@ -896,7 +905,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				ArchiveDir:        config.ArchiveDir(),
 				KeepPolicy:        keepPolicy,
 				ReasoningLanguage: cfg.ReasoningLanguage(),
-			}, executor, cfg.Agent.Temperature, sink, control.TaskWarrantsPlanner)
+			}, executor, cfg.Agent.Temperature, sink, shouldPlan)
+			if cd, ok := runner.(*agent.Coordinator); ok {
+				cd.SetVerify(buildCoordinatorVerify(root, false))
+			}
 			label = entry.Model + " + planner " + pe.Model
 		}
 	}
@@ -1376,4 +1388,39 @@ func providerNames(cfg *config.Config) string {
 		names[i] = p.Name
 	}
 	return strings.Join(names, "/")
+}
+
+// buildCoordinatorVerify returns a post-execution function that runs
+// go build in the workspace root (best-effort advisory). When fullVerify
+// is true it also runs go test ./... (opt-in, heavier).
+func buildCoordinatorVerify(workspaceRoot string, fullVerify bool) func(ctx context.Context) string {
+	root := workspaceRoot
+	if root == "" {
+		return nil
+	}
+	return func(ctx context.Context) string {
+		cmd := exec.CommandContext(ctx, "go", "build", "./...")
+		cmd.Dir = root
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			out = bytes.TrimSpace(out)
+			if idx := bytes.IndexByte(out, '\n'); idx >= 0 {
+				out = out[:idx]
+			}
+			return string(out)
+		}
+		if fullVerify {
+			cmd = exec.CommandContext(ctx, "go", "test", "./...", "-count=1", "-timeout", "120s")
+			cmd.Dir = root
+			out, err = cmd.CombinedOutput()
+			if err != nil {
+				out = bytes.TrimSpace(out)
+				if idx := bytes.IndexByte(out, '\n'); idx >= 0 {
+					out = out[:idx]
+				}
+				return string(out)
+			}
+		}
+		return ""
+	}
 }

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -79,6 +79,38 @@ func TaskWarrantsPlanner(input string) bool {
 	return !isLowRiskQuestion(strings.ToLower(text))
 }
 
+// TaskWarrantsPlannerClassified is like TaskWarrantsPlanner but delegates
+// borderline cases (score == 1) to the auto_plan_classifier LLM. The
+// classifier is capped at 3s to avoid blocking the main turn loop.
+func TaskWarrantsPlannerClassified(ctx context.Context, input string, classifier *ProviderAutoPlanClassifier) bool {
+	text := strings.TrimSpace(agent.StripTransientUserBlocks(input))
+	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {
+		return false
+	}
+	lower := strings.ToLower(text)
+	if isLowRiskQuestion(lower) {
+		return false
+	}
+	score := autoPlanScore(text)
+	if score >= 2 {
+		return true
+	}
+	if score <= 0 {
+		return false
+	}
+	// score == 1: borderline, use classifier.
+	if classifier == nil {
+		return true
+	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	needs, _, err := classifier.NeedsPlan(ctx, input, score)
+	if err != nil {
+		return true
+	}
+	return needs
+}
+
 func autoPlanScore(input string) int {
 	text := strings.TrimSpace(input)
 	if text == "" || strings.HasPrefix(text, "/") || strings.HasPrefix(text, PlanModeMarker) {

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1137,6 +1137,7 @@ Process:
 Key rules:
 - Delegate — your job is coordination. DO NOT execute steps yourself.
 - One sub-agent per independent work item. MUST use parallel_tasks.
+- Set model="deepseek-flash" (or your configured subagent model) for execution sub-agents.
 - Each sub-agent's prompt must be self-contained`
 
 // applyOrchestrate starts a project conductor mode that delegates work to

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -601,6 +601,17 @@ func (c *Controller) runTurnWithRawDisplay(ctx context.Context, input, raw, disp
 	c.SetPlanMode(false)
 	todoArgs := c.seedPlanTodos(proposal)
 	execStart := c.sessionMessageCount()
+	// When the plan has more than one step AND we have a Coordinator
+	// (dual-model mode), auto-dispatch via plan-exec instead of single-turn
+	// serial execution. This avoids micro-stepping and cuts request count.
+	if nt := planTodoCount(todoArgs); nt > 1 {
+		if _, isCoordinator := c.runner.(interface {
+			SetVerify(func(context.Context) string)
+		}); isCoordinator {
+			c.approval.setPlanAutoApprove(false)
+			return c.doPlanExec(proposal, display)
+		}
+	}
 	// The plan is the go-ahead: don't re-prompt for each write of the approved
 	// work. Auto-approve writers for the duration of this execution turn only; a
 	// later turn (even "continue") falls back to the normal per-tool approval.
@@ -871,6 +882,9 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 				c.notice(err.Error())
 			}
 			return
+		case "/orchestrate":
+			c.applyOrchestrate(trimmed, display)
+			return
 		case "/plan-exec":
 			c.applyPlanExec(trimmed, display)
 			return
@@ -1056,7 +1070,7 @@ func (c *Controller) applyPlanExec(input, display string) {
 	}
 	b.WriteString("\n## Routing rules\n")
 	b.WriteString("1. Group steps by MODULE \u2014 same module = serial, different modules = parallel batches\n")
-	b.WriteString("2. Research/exploration across modules = use parallel_tasks\n")
+	b.WriteString("2. Research/exploration across modules = MUST use parallel_tasks (mandatory)\n")
 	b.WriteString("3. Dispatch each batch via parallel_tasks \u2014 each sub-agent gets one module\u2019s context\n")
 	b.WriteString("4. Verify each batch before the next\n")
 	b.WriteString("5. Failures: fix before moving on\n")
@@ -1108,6 +1122,130 @@ func (c *Controller) applyPrometheus(input, display string) {
 			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)
 		})
 	}
+}
+
+// orchestratePrompt is the system prompt for the project conductor mode.
+const orchestratePrompt = `You are the project conductor, coordinating a team of specialist sub-agents. Your model handles planning and review; delegate execution to sub-agents.
+
+Process:
+1. Analyze the request and break it into independent work items
+2. For EACH independent item, dispatch a sub-agent using parallel_tasks
+3. Each sub-agent gets one clear goal and its relevant context
+4. After all sub-agents finish, review their outputs
+5. Summarize what was done, what needs follow-up, and end with [goal:complete]
+
+Key rules:
+- Delegate — your job is coordination. DO NOT execute steps yourself.
+- One sub-agent per independent work item. MUST use parallel_tasks.
+- Each sub-agent's prompt must be self-contained`
+
+// applyOrchestrate starts a project conductor mode that delegates work to
+// multiple sub-agents via parallel_tasks.
+func (c *Controller) applyOrchestrate(input, display string) {
+	args := strings.TrimSpace(strings.TrimPrefix(input, "/orchestrate"))
+	if args == "" || args == "--strict" {
+		c.notice("usage: /orchestrate <project description>")
+		return
+	}
+	strict := false
+	if strings.HasPrefix(args, "--strict ") {
+		strict = true
+		args = strings.TrimPrefix(args, "--strict ")
+	}
+	prompt := orchestratePrompt + "\n\n## Project request\n\n" + args + "\n\nBegin by analyzing the request and dispatching sub-agents."
+	c.SetPlanMode(false)
+	c.SetGoal("orchestrate: " + ShortGoalForNotice(args))
+	c.GoalStrict(strict)
+	c.notice("orchestrate: starting project conductor mode")
+	if c.runner != nil {
+		c.runGuarded(func(ctx context.Context) error {
+			return c.runGoalLoopWithRawDisplay(ctx, prompt, prompt, display)
+		})
+	}
+}
+
+// planTodoCount returns the number of todos encoded in plan-seed JSON args,
+// or 0 when parsing fails.
+func planTodoCount(todoArgs string) int {
+	if todoArgs == "" {
+		return 0
+	}
+	var p struct {
+		Todos []json.RawMessage `json:"todos"`
+	}
+	if err := json.Unmarshal([]byte(todoArgs), &p); err != nil {
+		return 0
+	}
+	return len(p.Todos)
+}
+
+// doPlanExec dispatches the plan via plan-exec goal loop, bypassing the
+// single-turn planApprovedMessage.
+func (c *Controller) doPlanExec(planText, display string) error {
+	todos := c.executor.CanonicalTodoState()
+	if len(todos) == 0 {
+		return nil
+	}
+	return c.applyPlanExecDirect(todos, display)
+}
+
+// applyPlanExecDirect starts a plan-exec goal loop from an existing todo list,
+// without requiring a slash command. Used by plan auto-dispatch.
+func (c *Controller) applyPlanExecDirect(todos []evidence.TodoItem, display string) error {
+	total := len(todos)
+	done := 0
+	for _, t := range todos {
+		if t.Status == "completed" {
+			done++
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("You are the execution conductor. Route each step to the right sub-agent by module.\n\n")
+
+	modules := c.detectProjectModules()
+	if len(modules) > 0 {
+		b.WriteString("## Project modules detected\n\n")
+		for _, m := range modules {
+			fmt.Fprintf(&b, "- %s/", m)
+		}
+		b.WriteString("\n\nRoute steps to the module they belong to. Steps in different modules can run in parallel.\n\n")
+	}
+
+	b.WriteString("## Plan steps\n\n")
+	for _, t := range todos {
+		status := t.Status
+		if status == "" {
+			status = "pending"
+		}
+		mark := " "
+		if status == "completed" {
+			mark = "x"
+		}
+		fmt.Fprintf(&b, "- [%s] %s (%s)\n", mark, t.Content, status)
+	}
+	b.WriteString("\n## Routing rules\n")
+	b.WriteString("1. Group steps by MODULE \u2014 same module = serial, different modules = parallel batches\n")
+	b.WriteString("2. Research/exploration across modules = MUST use parallel_tasks (mandatory)\n")
+	b.WriteString("3. Dispatch each batch via parallel_tasks \u2014 each sub-agent gets one module\u2019s context\n")
+	b.WriteString("4. Verify each batch before the next\n")
+	b.WriteString("5. Failures: fix before moving on\n")
+	b.WriteString("\nGoal: each sub-agent focuses on one module and does not carry irrelevant context.\n")
+	if done > 0 {
+		fmt.Fprintf(&b, "\nNote: %d/%d steps are already completed. Focus on the remaining %d steps.\n", done, total, total-done)
+	}
+	prompt := b.String()
+
+	if len(modules) > 0 {
+		c.notice(fmt.Sprintf("plan-exec: detected %d modules — %s", len(modules), strings.Join(modules, ", ")))
+	}
+	c.SetPlanMode(false)
+	c.SetGoal("execute plan: " + ShortGoalForNotice(todos[0].Content))
+	c.notice(fmt.Sprintf("plan-exec: auto-dispatching %d plan steps", total))
+	if c.runner != nil {
+		return c.runGoalLoopWithRawDisplay(context.Background(), prompt, prompt, display)
+	}
+	return nil
 }
 
 // shellTimeout is the maximum time a user-invoked "!command" may run. Matches

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -88,7 +88,18 @@ const (
 	// wrapper prefix), so a frontend can display it to the user as confirmation.
 	// Frontends use Steer to know a queued message has been delivered.
 	Steer
+	// SubAgentProgress carries a sub-agent's execution status (Text = label,
+	// Progress = Current, Total, Status). Frontends render it as a progress
+	// bar or checklist. Appended last to keep existing Kind values stable.
+	SubAgentProgress
 )
+
+// ProgressInfo describes sub-agent execution progress for SubAgentProgress events.
+type ProgressInfo struct {
+	Current int
+	Total   int
+	Status  string // "running" | "completed" | "failed"
+}
 
 // Level classifies a Notice so sinks can style or filter it.
 type Level int
@@ -226,15 +237,16 @@ type Event struct {
 	// session (Usage events only), so a frontend can show the aggregate hit-rate
 	// — which doesn't crater on a short turn or after compaction — alongside
 	// Usage's single-turn numbers.
-	SessionHit   int        // Usage: cumulative cache-hit prompt tokens this session
-	SessionMiss  int        // Usage: cumulative cache-miss prompt tokens this session
-	Level        Level      // Notice
-	Approval     Approval   // ApprovalRequest
-	Ask          Ask        // AskRequest
-	Err          error      // TurnDone: non-nil on failure
-	Compaction   Compaction // Compaction
-	RetryAttempt int        // Retrying: 1-based attempt about to be made
-	RetryMax     int        // Retrying: total attempts before giving up
+	SessionHit   int           // Usage: cumulative cache-hit prompt tokens this session
+	SessionMiss  int           // Usage: cumulative cache-miss prompt tokens this session
+	Level        Level         // Notice
+	Approval     Approval      // ApprovalRequest
+	Ask          Ask           // AskRequest
+	Err          error         // TurnDone: non-nil on failure
+	Compaction   Compaction    // Compaction
+	RetryAttempt int           // Retrying: 1-based attempt about to be made
+	RetryMax     int           // Retrying: total attempts before giving up
+	Progress     *ProgressInfo // SubAgentProgress: sub-task execution status
 }
 
 // ReadinessAuditSink is an optional sink capability. Sinks that do not care


### PR DESCRIPTION
## 改动

五个增量改进，全部在现有的 Coordinator 架构上叠加，不加新 agent：

### 1. Coordinator 执行后自动校验
- executor.Run() 成功后自动跑 go build ./...
- 失败时 emit notice，不阻断流程
- SetVerify() 可选注入，支持 fullVerify flag

### 2. /orchestrate 项目指挥模式
- 命令注册 + orchestratePrompt + applyOrchestrate()
- 支持 --strict flag
- prompt 强制 "DO NOT execute steps yourself" + "MUST use parallel_tasks" + 模型选择提示

### 3. shouldPlan 接 classifier
- TaskWarrantsPlannerClassified() 在 score==1 时调 auto_plan_classifier 判断
- 3s 超时防阻塞

### 4. 计划批准后自动 plan-exec 调度
- 多 todo + Coordinator 模式 -> 自动走 plan-exec 并发，不再 micro-step
- 使用上游 approval.setPlanAutoApprove() 机制

### 5. 并行子 agent 进度跟踪事件
- event.SubAgentProgress 通用事件类型
- parallel_tasks 三处发射 progress（建立/完成/失败）
- 前端消费 SubAgentProgress 事件即可显示进度，无关 UI 实现

## 文件
- internal/agent/coordinator.go — verify 字段 + SetVerify()
- internal/agent/parallel_tasks.go — emitProgress() + 三处调用
- internal/boot/boot.go — buildCoordinatorVerify() + shouldPlan 闭包
- internal/control/controller.go — /orchestrate + plan-exec auto-dispatch + doPlanExec()
- internal/control/auto_plan.go — TaskWarrantsPlannerClassified()
- internal/event/event.go — SubAgentProgress Kind + ProgressInfo

Cache-impact: low — boot.go 仅加函数和闭包，不改变工具注册顺序
Cache-guard: go test ./internal/agent/ ./internal/control/
System-prompt-review: self