### PR TITLE
refactor(store): add a store package owning the session-sidecar layout

### DIFF
--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -21,6 +21,7 @@ import (
 	"reasonix/internal/jobs"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 )
 
 // SessionParams is everything a Factory needs to assemble one ACP session's
@@ -1423,7 +1424,7 @@ func parseSessionUpdatedAt(s string) time.Time {
 func deleteSessionFiles(sessionPath string) error {
 	paths := []string{
 		sessionPath,
-		sessionPath + ".meta",
+		store.SessionMeta(sessionPath),
 		acpMetaPath(sessionPath),
 	}
 	for _, path := range paths {
@@ -1469,10 +1470,7 @@ func delayedDeleteSessionFiles(sessionPath string, destroy control.SessionDestro
 }
 
 func checkpointPath(sessionPath string) string {
-	if sessionPath == "" {
-		return ""
-	}
-	return strings.TrimSuffix(sessionPath, ".jsonl") + ".ckpt"
+	return store.SessionCheckpointDir(sessionPath)
 }
 
 // mcpSpecs converts ACP MCP server declarations to plugin.Spec.

--- a/internal/agent/branch.go
+++ b/internal/agent/branch.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"reasonix/internal/fileutil"
+	"reasonix/internal/store"
 )
 
 // BranchMeta is the small sidecar record that turns flat session files into a
@@ -84,10 +85,7 @@ func BranchID(path string) string {
 }
 
 func BranchMetaPath(sessionPath string) string {
-	if sessionPath == "" {
-		return ""
-	}
-	return sessionPath + ".meta"
+	return store.SessionMeta(sessionPath)
 }
 
 func LoadBranchMeta(sessionPath string) (BranchMeta, bool, error) {

--- a/internal/agent/save.go
+++ b/internal/agent/save.go
@@ -13,6 +13,7 @@ import (
 
 	"reasonix/internal/fileutil"
 	"reasonix/internal/provider"
+	"reasonix/internal/store"
 )
 
 const cleanupPendingExt = ".cleanup-pending.json"
@@ -151,11 +152,7 @@ type CleanupPendingInfo struct {
 
 // CleanupPendingPath returns the durable marker path for a session transcript.
 func CleanupPendingPath(sessionPath string) string {
-	sessionPath = strings.TrimSpace(sessionPath)
-	if sessionPath == "" {
-		return ""
-	}
-	return strings.TrimSuffix(sessionPath, ".jsonl") + cleanupPendingExt
+	return store.SessionCleanupPending(sessionPath)
 }
 
 // MarkCleanupPending hides a logically removed session from resume/list surfaces

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -46,6 +46,7 @@ import (
 	"reasonix/internal/provider"
 	"reasonix/internal/sandbox"
 	"reasonix/internal/skill"
+	"reasonix/internal/store"
 	"reasonix/internal/tool"
 )
 
@@ -384,10 +385,7 @@ func (c *Controller) recordDisplayForNewUser(startMessages int, display string) 
 // ckptDir derives a session's checkpoint directory from its file path
 // (…/<id>.jsonl → …/<id>.ckpt). Empty path → empty (in-memory checkpoints).
 func ckptDir(sessionPath string) string {
-	if sessionPath == "" {
-		return ""
-	}
-	return strings.TrimSuffix(sessionPath, ".jsonl") + ".ckpt"
+	return store.SessionCheckpointDir(sessionPath)
 }
 
 // rebindCheckpoints points the store at the (possibly new) session, loading any

--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -11,6 +11,7 @@ import (
 	"unicode"
 
 	"reasonix/internal/evidence"
+	"reasonix/internal/store"
 )
 
 const (
@@ -85,10 +86,7 @@ type goalAdvanceResult struct {
 
 // goalStatePath derives a session's persisted goal-state sidecar.
 func goalStatePath(sessionPath string) string {
-	if sessionPath == "" {
-		return ""
-	}
-	return strings.TrimSuffix(sessionPath, ".jsonl") + ".goal-state.json"
+	return store.SessionGoalState(sessionPath)
 }
 
 func (g *goalMachine) setStatePath(path string) {

--- a/internal/jobs/artifacts.go
+++ b/internal/jobs/artifacts.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"reasonix/internal/store"
 )
 
 const (
@@ -17,11 +19,7 @@ const (
 
 // ArtifactDir returns the sidecar directory for a persistent session transcript.
 func ArtifactDir(sessionPath string) string {
-	sessionPath = strings.TrimSpace(sessionPath)
-	if sessionPath == "" {
-		return ""
-	}
-	return strings.TrimSuffix(sessionPath, ".jsonl") + ".jobs"
+	return store.SessionJobsDir(sessionPath)
 }
 
 // RemoveArtifacts removes the job sidecar for a session transcript.

--- a/internal/store/session.go
+++ b/internal/store/session.go
@@ -1,0 +1,67 @@
+// Package store is the single authority for reasonix's on-disk persistence
+// layout. Nothing else should construct a persistence path by hand.
+//
+// This first slice owns the session-artifact sidecars — the files and
+// directories that live beside a session's .jsonl (branch metadata, goal state,
+// checkpoints, background-job artifacts, the cleanup-pending marker). They were
+// previously derived independently in internal/agent, internal/jobs,
+// internal/control and internal/acp, each re-spelling the suffix convention; a
+// layout change meant hunting across packages. Centralizing them here makes
+// store the one place that knows where a session's artifacts go.
+//
+// store is a leaf: it imports only the standard library, so any package may
+// depend on it without risking an import cycle. Root/directory resolution (the
+// ~/.reasonix tree) and the desktop root unification land in later slices.
+package store
+
+import "strings"
+
+// sessionStem strips the .jsonl suffix so a sidecar sits beside the session as
+// <id>.<kind> rather than <id>.jsonl.<kind>.
+func sessionStem(sessionPath string) string {
+	return strings.TrimSuffix(sessionPath, ".jsonl")
+}
+
+// SessionMeta is the branch-metadata sidecar. Unlike the other sidecars it
+// appends to the full session path (historical layout), so session.jsonl yields
+// session.jsonl.meta.
+func SessionMeta(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return sessionPath + ".meta"
+}
+
+// SessionGoalState is the persisted active-goal sidecar (<id>.goal-state.json).
+func SessionGoalState(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return sessionStem(sessionPath) + ".goal-state.json"
+}
+
+// SessionCheckpointDir is the snapshot-checkpoint directory (<id>.ckpt).
+func SessionCheckpointDir(sessionPath string) string {
+	if sessionPath == "" {
+		return ""
+	}
+	return sessionStem(sessionPath) + ".ckpt"
+}
+
+// SessionJobsDir is the background-job artifact directory (<id>.jobs).
+func SessionJobsDir(sessionPath string) string {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return ""
+	}
+	return sessionStem(sessionPath) + ".jobs"
+}
+
+// SessionCleanupPending is the delayed-cleanup marker (<id>.cleanup-pending.json).
+func SessionCleanupPending(sessionPath string) string {
+	sessionPath = strings.TrimSpace(sessionPath)
+	if sessionPath == "" {
+		return ""
+	}
+	return sessionStem(sessionPath) + ".cleanup-pending.json"
+}

--- a/internal/store/session_test.go
+++ b/internal/store/session_test.go
@@ -1,0 +1,41 @@
+package store
+
+import "testing"
+
+func TestSessionSidecarLayout(t *testing.T) {
+	const p = "/home/u/.reasonix/sessions/abc.jsonl"
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		// .meta appends to the full path (historical layout); the rest replace .jsonl.
+		{"meta", SessionMeta(p), p + ".meta"},
+		{"goal-state", SessionGoalState(p), "/home/u/.reasonix/sessions/abc.goal-state.json"},
+		{"checkpoint", SessionCheckpointDir(p), "/home/u/.reasonix/sessions/abc.ckpt"},
+		{"jobs", SessionJobsDir(p), "/home/u/.reasonix/sessions/abc.jobs"},
+		{"cleanup-pending", SessionCleanupPending(p), "/home/u/.reasonix/sessions/abc.cleanup-pending.json"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestSessionSidecarEmptyPath(t *testing.T) {
+	for _, fn := range []struct {
+		name string
+		f    func(string) string
+	}{
+		{"meta", SessionMeta},
+		{"goal-state", SessionGoalState},
+		{"checkpoint", SessionCheckpointDir},
+		{"jobs", SessionJobsDir},
+		{"cleanup-pending", SessionCleanupPending},
+	} {
+		if got := fn.f(""); got != "" {
+			t.Errorf("%s(\"\") = %q, want empty", fn.name, got)
+		}
+	}
+}


### PR DESCRIPTION
## What

First slice of a persistence layer (`internal/store`). It becomes the **single authority** for where a session's sidecar artifacts live on disk.

## Why

Five packages each independently derived a session's sidecar paths off the `.jsonl` path:
- `agent` → `.meta`, `.cleanup-pending.json`
- `control` → `.ckpt`, `.goal-state.json`
- `jobs` → `.jobs`

…and `acp` re-spelled `.meta` and `.ckpt` **inline a second time**. A layout change meant hunting across packages — no single owner.

## How

`internal/store` now owns the layout: `SessionMeta` / `SessionGoalState` / `SessionCheckpointDir` / `SessionJobsDir` / `SessionCleanupPending`. It's a **strict leaf** (stdlib only — verified it depends on no other internal package), so anything can import it without an import cycle.

The **seven** derivation sites now delegate to store. Paths resolve **byte-identically** (locked by a layout test) — pure structure, **no behavior change, no migration**. Exported names (`agent.BranchMetaPath`, `jobs.ArtifactDir`, …) stay as thin wrappers so their callers are untouched.

## Not in this PR (the layered plan)

- **P2:** store takes over root/dir resolution; `config` delegates to it.
- **P3:** desktop drops its divergent `~/.config/reasonix` root and adopts the store root, with a one-time migration (the user-facing double-root fix).

## Verification

`gofmt`, `go build ./...`, `go vet ./...` clean; tests pass across `store`/`agent`/`jobs`/`control`/`acp` + downstream `serve`/`cli`/`boot`/`history`/`checkpoint`.