### PR TITLE
fix(agent): remove executor handoff nudge for guidance-only tasks

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -82,7 +82,6 @@ var planModeGoWriteOrExecArgs = map[string]bool{
 const maxFinalReadinessBlocks = 3
 const maxEmptyFinalBlocks = 3
 const maxStreamRecoveries = 1
-const maxExecutorHandoffNudges = 1
 
 // Renderer redraws the assistant's final-answer text as styled output. It is
 // applied only after a turn's text stream completes, so the user sees raw
@@ -204,19 +203,16 @@ type ToolHooks interface {
 // Agent drives a single task: a Provider, a tool Registry, and a Session wired
 // into the main loop.
 type Agent struct {
-	prov        provider.Provider
-	tools       *tool.Registry
-	session     *Session
-	sessMu      sync.Mutex // guards the session pointer for external Session()/SetSession
-	maxSteps    int
-	maxStepsKey string
-	// executorHandoffGuard is enabled by Coordinator for the executor agent. The
-	// per-turn marker check in Run keeps ordinary single-model turns unaffected.
-	executorHandoffGuard bool
-	temperature          float64
-	pricing              *provider.Pricing
-	usageSource          string
-	reasoningLanguage    atomic.Value // string: auto|zh|en
+	prov              provider.Provider
+	tools             *tool.Registry
+	session           *Session
+	sessMu            sync.Mutex // guards the session pointer for external Session()/SetSession
+	maxSteps          int
+	maxStepsKey       string
+	temperature       float64
+	pricing           *provider.Pricing
+	usageSource       string
+	reasoningLanguage atomic.Value // string: auto|zh|en
 
 	// sink receives the turn's typed event stream (reasoning/text deltas, tool
 	// dispatch/results, usage, notices). The agent no longer formats output
@@ -686,10 +682,7 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 
 	finalReadinessBlocks := 0
 	emptyFinalBlocks := 0
-	handoffNudges := 0
-	usedAnyTool := false
 	streamRecoveries := 0
-	executorHandoff := a.executorHandoffGuard && strings.Contains(input, executorHandoffMarker)
 	for step := 0; a.maxSteps <= 0 || step < a.maxSteps; step++ {
 		// Consume a queued steer and persist it to the session so it
 		// survives tab switches and history replay. The model sees it as
@@ -781,13 +774,10 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				a.maybeCompact(ctx, usage)
 				continue
 			}
-			if executorHandoff && !usedAnyTool && handoffNudges < maxExecutorHandoffNudges {
-				handoffNudges++
-				a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "executor answered without taking any action; nudging it to use its tools"})
-				a.session.Add(provider.Message{Role: provider.RoleUser, Content: a.withReasoningLanguage(executorHandoffRetryMessage())})
-				a.maybeCompact(ctx, usage)
-				continue
-			}
+			// Executor handoff may be pure relay — guidance-only tasks don't
+			// require tool use. Skip the nudge when we have a visible final
+			// answer; the executor correctly relayed the planner's instructions.
+			// See: https://github.com/esengine/DeepSeek-Reasonix/issues/4867
 			if readiness.applies {
 				event.RecordReadinessAudit(a.sink, readiness.audit(evidence.ReadinessAllowed, finalReadinessBlocks > 0))
 			}
@@ -801,7 +791,6 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 			return nil // model gave a final answer
 		}
 		emptyFinalBlocks = 0
-		usedAnyTool = true
 
 		results := a.executeBatch(ctx, calls)
 		for i, call := range calls {
@@ -1099,13 +1088,6 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 
 func finalReadinessRetryMessage(reason string) string {
 	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
-}
-
-func executorHandoffRetryMessage() string {
-	return `You are already in the executor phase. The planner's read-only limitations do not apply to you.
-
-Do not answer as the planner and do not ask how to trigger the executor.
-Use your available tools now to carry out the task. If a write or command is blocked by permissions or workspace boundaries, state that specific blocker and ask for the needed approval/path.`
 }
 
 func hasVisibleFinalAnswer(text string) bool {

--- a/internal/agent/coordinator.go
+++ b/internal/agent/coordinator.go
@@ -78,9 +78,6 @@ func NewCoordinator(planner provider.Provider, plannerSession *Session, plannerP
 		plannerOptions.UsageSource = event.UsageSourcePlanner
 		plannerAgent = New(planner, plannerTools, plannerSession, plannerOptions, plannerSink(sink))
 	}
-	if executor != nil {
-		executor.executorHandoffGuard = true
-	}
 	return &Coordinator{
 		planner:        planner,
 		plannerSess:    plannerSession,

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -297,50 +297,43 @@ func TestCoordinatorPlannerMaxStepsZeroIsUnlimited(t *testing.T) {
 	}
 }
 
-func TestCoordinatorNudgesExecutorThatAnswersWithoutActing(t *testing.T) {
+func TestExecutorHandoffAcceptsTextOnlyFinalAnswer(t *testing.T) {
+	// Regression test for https://github.com/esengine/DeepSeek-Reasonix/issues/4867
+	// Executor handoff may be pure relay — guidance-only tasks don't require
+	// tool use. The executor should be able to give a text-only final answer
+	// without being nudged to use tools.
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
-		{Type: provider.ChunkText, Text: "Write the requested skill file."},
+		{Type: provider.ChunkText, Text: "Here is a step-by-step guide for the user."},
 		{Type: provider.ChunkDone},
 	}}
-	// The first turn is a plain final answer with no tool call and no
-	// planner-vocabulary — the nudge must fire on the missing action, not on words.
+	// Executor gives a text-only final answer (guidance relay) — no tool calls.
 	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
 		{
-			{Type: provider.ChunkText, Text: "这个计划看起来没问题,应该很好实现。"},
-			{Type: provider.ChunkDone},
-		},
-		{
-			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "write_file", Arguments: `{"path":"kan-tu.md"}`}},
-			{Type: provider.ChunkDone},
-		},
-		{
-			{Type: provider.ChunkText, Text: "Done."},
+			{Type: provider.ChunkText, Text: "Follow these steps: 1. Download the file. 2. Install it."},
 			{Type: provider.ChunkDone},
 		},
 	}}
 
 	execReg := tool.NewRegistry()
-	execReg.Add(coordinatorTestTool{name: "write_file", readOnly: false, output: "wrote file"})
 	executor := New(exec, execReg, NewSession("exec-sys"), Options{}, event.Discard)
 	coord := NewCoordinator(planner, NewSession("planner-sys"), nil, nil, Options{}, executor, 0, event.Discard, nil)
 
-	if err := coord.Run(context.Background(), "install the skill"); err != nil {
+	if err := coord.Run(context.Background(), "how do I install this?"); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if got := len(exec.requests); got != 3 {
-		t.Fatalf("executor requests = %d, want answer-without-acting, nudge tool call, final answer", got)
-	}
-	if got := lastUser(exec.requests[1]); !strings.Contains(got, "Use your available tools now to carry out the task") {
-		t.Fatalf("second executor request missing handoff nudge message: %q", got)
+	// Executor should only need one request — the text-only final answer.
+	// No nudge/retry should occur.
+	if got := len(exec.requests); got != 1 {
+		t.Fatalf("executor requests = %d, want 1 (text-only final answer, no nudge)", got)
 	}
 }
 
-func TestCoordinatorDoesNotNudgeExecutorThatActs(t *testing.T) {
+func TestCoordinatorExecutorToolUseThenFinalAnswer(t *testing.T) {
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "Write the requested skill file."},
 		{Type: provider.ChunkDone},
 	}}
-	// Executor calls a tool on its first turn, then answers — no nudge expected.
+	// Executor calls a tool on its first turn, then gives a final answer.
 	exec := &mockProvider{name: "executor", streams: [][]provider.Chunk{
 		{
 			{Type: provider.ChunkToolCall, ToolCall: &provider.ToolCall{ID: "call-1", Name: "write_file", Arguments: `{"path":"kan-tu.md"}`}},
@@ -361,12 +354,7 @@ func TestCoordinatorDoesNotNudgeExecutorThatActs(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 	if got := len(exec.requests); got != 2 {
-		t.Fatalf("executor requests = %d, want tool call + final answer with no nudge", got)
-	}
-	for i, req := range exec.requests {
-		if strings.Contains(lastUser(req), "Use your available tools now to carry out the task") {
-			t.Fatalf("request %d unexpectedly received a handoff nudge", i)
-		}
+		t.Fatalf("executor requests = %d, want tool call + final answer", got)
 	}
 }
 

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -68,14 +68,13 @@ func IsSyntheticUserMessage(content string) bool {
 
 // syntheticPrefixes must be kept in sync with the synthetic user messages
 // injected by the controller (planApprovedMessage), agent loop
-// (streamRecoveryMessage, finalReadinessRetryMessage, emptyFinalRetryMessage,
-// executorHandoffRetryMessage in internal/agent/agent.go), and compaction
+// (streamRecoveryMessage, finalReadinessRetryMessage, emptyFinalRetryMessage
+// in internal/agent/agent.go), and compaction
 // folds (internal/agent/compact.go), which store summaries as user-role
 // messages the chat UI must never render as user bubbles (#3653).
 var syntheticPrefixes = []string{
 	"Plan approved — plan mode is off",
 	"Host final-answer readiness check failed",
-	"You are already in the executor phase",
 	"The previous assistant response was interrupted while a tool call",
 	"The previous assistant response was interrupted during streaming",
 	"The previous assistant response was interrupted before visible",

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -843,11 +843,6 @@ func TestIsSyntheticUserMessage(t *testing.T) {
 			want:  true,
 		},
 		{
-			name:  "executor handoff",
-			input: "You are already in the executor phase. The planner's read-only limitations do not apply to you.",
-			want:  true,
-		},
-		{
 			name:  "regular user message",
 			input: "explain this function",
 			want:  false,


### PR DESCRIPTION
## Summary

The executor handoff guard previously nudged the executor to use tools when it gave a text-only final answer. This caused problems for guidance-only tasks where the executor legitimately just relays the planner's instructions without needing to call tools.

The nudge forced the executor to invent tasks to satisfy the tool-use requirement, leading to unnecessary file operations that contradicted the conversation state (e.g., checking import status after user already confirmed success).

## Changes

- Removed the executor handoff nudge logic from `internal/agent/agent.go`
- Removed the now-unused `executorHandoffGuard` field from the Agent struct
- Removed the `executorHandoffRetryMessage` function
- Removed the synthetic prefix entry for the handoff retry message
- Updated tests to reflect the new behavior

## Verification

- `go test ./internal/agent/... ./internal/control/...` passes
- `go vet ./...` passes
- `gofmt -l` shows no changes on modified files

Fixes #4867

## Cache impact

Cache-impact: low — Removed a conditional branch in the agent loop's final-answer path. The system prompt prefix is unchanged; only the runtime control flow is affected.
Cache-guard: N/A — No cache-sensitive prefix files were modified.