### PR TITLE
refactor(control): introduce the SessionAPI driving port; migrate bot to it

### DIFF
--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -85,8 +85,18 @@ type BotGateway struct {
 	logger *slog.Logger
 }
 
+// botController is the slice of the controller's driving port the gateway needs:
+// session lifecycle, turn execution, and approval/ask handling. The bot never
+// touches goals, checkpoints, or memory, so it depends on those sub-ports only —
+// not the concrete *control.Controller and its ~99 methods.
+type botController interface {
+	control.Lifecycle
+	control.TurnControl
+	control.Approvals
+}
+
 type sessionState struct {
-	ctrl             *control.Controller
+	ctrl             botController
 	sink             *sessionEventSink
 	cancel           context.CancelFunc
 	pendingAsks      map[string][]event.AskQuestion
@@ -672,7 +682,7 @@ func parseToolApprovalModeArg(arg string) (mode string, statusOnly bool, ok bool
 
 func (gw *BotGateway) setToolApprovalModeForMessage(key string, msg InboundMessage, mode string) error {
 	mode = normalizeBotToolApprovalMode(mode)
-	var ctrl *control.Controller
+	var ctrl botController
 
 	gw.mu.Lock()
 	if state, ok := gw.controllers[key]; ok {
@@ -713,7 +723,7 @@ func (gw *BotGateway) updateToolApprovalModeDefaultLocked(msg InboundMessage, mo
 }
 
 func (gw *BotGateway) currentToolApprovalMode(key string, msg InboundMessage) string {
-	var ctrl *control.Controller
+	var ctrl botController
 	gw.mu.Lock()
 	if state, ok := gw.controllers[key]; ok {
 		ctrl = state.ctrl
@@ -881,7 +891,7 @@ func (gw *BotGateway) getOrCreateSession(ctx context.Context, key string, msg In
 	return state
 }
 
-func ensureControllerSessionPath(ctrl *control.Controller) {
+func ensureControllerSessionPath(ctrl botController) {
 	if ctrl == nil || ctrl.SessionPath() != "" || ctrl.SessionDir() == "" {
 		return
 	}
@@ -917,7 +927,7 @@ func botSessionDir(workspaceRoot string) string {
 	return config.SessionDir()
 }
 
-func (gw *BotGateway) rememberSessionReady(msg InboundMessage, ctrl *control.Controller) {
+func (gw *BotGateway) rememberSessionReady(msg InboundMessage, ctrl botController) {
 	if gw.cfg.OnSessionReady == nil || ctrl == nil {
 		return
 	}

--- a/internal/bot/render.go
+++ b/internal/bot/render.go
@@ -8,7 +8,6 @@ import (
 	"time"
 	"unicode"
 
-	"reasonix/internal/control"
 	"reasonix/internal/event"
 )
 
@@ -23,7 +22,7 @@ type renderSink struct {
 	userID     string
 	replyTo    string
 	logger     *slog.Logger
-	ctrl       *control.Controller
+	ctrl       botController
 	onApproval func(event.Approval)
 	onAsk      func(event.Ask)
 

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -1,0 +1,83 @@
+package control
+
+import (
+	"context"
+
+	"reasonix/internal/agent"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+)
+
+// This file defines the driving port: the typed, segregated interface surface
+// that frontends (cli, desktop, bot, acp, serve) consume instead of coupling to
+// the concrete *Controller and its ~99 methods. Each frontend depends only on
+// the sub-ports it actually uses (interface segregation), so e.g. the bot never
+// sees checkpoint or memory methods.
+//
+// The sub-ports are also the intended decomposition boundary for Controller
+// itself: the port comes first and gives the later collaborator splits a spec to
+// follow. *Controller implements every sub-port (asserted below). The full
+// SessionAPI composition will accrete here as the remaining frontends migrate.
+
+// Lifecycle covers a session's identity and lifecycle: minting, resuming,
+// clearing, and locating the active session.
+type Lifecycle interface {
+	NewSession() error
+	ClearSession() error
+	Resume(s *agent.Session, path string)
+	SetSessionPath(p string)
+	SessionPath() string
+	SessionDir() string
+	Label() string
+	WorkspaceRoot() string
+	Close()
+}
+
+// TurnControl covers driving a model turn and observing its run state: the
+// various submit/run entry points, cancellation, steering, and status reads.
+type TurnControl interface {
+	Submit(input string)
+	SubmitDisplay(display, input string)
+	SubmitHTTP(input string)
+	SubmitUserTurn(input, display string)
+	Send(input string)
+	SendWithRaw(input, raw string)
+	Run(ctx context.Context, input string) error
+	RunTurn(ctx context.Context, input string) error
+	RunShell(command string)
+	Cancel()
+	Steer(text string)
+	SteerConsumed() bool
+	Running() bool
+	RuntimeStatus() RuntimeStatus
+	Turn() int
+	History() []provider.Message
+	ToolResult(toolID string) *ToolResultData
+}
+
+// Approvals covers tool-approval and ask prompts plus the runtime approval
+// posture (ask/auto/yolo). It mirrors the approvalManager surface.
+type Approvals interface {
+	Approve(id string, allow, session, persist bool)
+	AnswerQuestion(id string, answers []event.AskAnswer)
+	Ask(ctx context.Context, questions []event.AskQuestion) ([]event.AskAnswer, error)
+	ReplayPendingPrompts()
+	PendingPrompt() bool
+	EnableInteractiveApproval()
+	ToolApprovalMode() string
+	SetToolApprovalMode(mode string)
+	AutoApproveTools() bool
+	SetAutoApproveTools(on bool)
+	Bypass() bool
+	SetBypass(on bool)
+	SetMode(plan, autoApproveTools bool)
+}
+
+// Compile-time proof that the concrete controller satisfies each sub-port, so
+// frontend migrations to the interfaces are mechanical and can never silently
+// drift from the implementation.
+var (
+	_ Lifecycle   = (*Controller)(nil)
+	_ TurnControl = (*Controller)(nil)
+	_ Approvals   = (*Controller)(nil)
+)


### PR DESCRIPTION
## What

Starts the **driving port** — the keystone of a ports-and-adapters shape for the kernel. A segregated interface surface that frontends consume **instead of coupling to the concrete `*control.Controller` and its ~99 methods**.

## Why

Five frontends (cli/desktop/bot/acp/serve) each couple to the concrete `*control.Controller` (33 direct `*control.Controller` refs, no shared interface). There is **no inbound boundary** — which is *why* everything piles into the Controller god object: it's the only thing a frontend can reach. Adding the port is what lets the god object stop being everyone's API.

## How

`internal/control/port.go` defines segregated sub-ports — `Lifecycle`, `TurnControl`, `Approvals` — with compile-time assertions that `*Controller` satisfies each. A frontend depends only on the sub-ports it uses (interface segregation). The sub-ports double as the spec for Controller's own future decomposition: **the port leads, the collaborator splits follow.**

**First adapter migrated — the bot gateway.** It used 12 controller methods spanning exactly those three sub-ports; its `renderSink`/`sessionState` fields, locals, and helpers now take a narrow `botController` interface (`Lifecycle`+`TurnControl`+`Approvals`) instead of `*control.Controller`, so the bot can no longer reach goals/checkpoints/memory. `boot.Build` still returns the concrete type at construction; it's stored through the interface. No behavior change.

## Plan

Remaining frontends (serve → acp → desktop → cli) migrate in follow-ups; the full `SessionAPI` composition accretes as their sub-ports are added. The unified port is also what lets the desktop `bridge.ts` hand-mirror eventually be generated rather than hand-kept.

## Verification

`gofmt`, `go build ./...`, `go vet ./...` clean; `go test ./internal/control` + `./internal/bot/...` pass.