### PR TITLE
refactor(control): migrate serve and acp to the SessionAPI port

### DIFF
--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -131,12 +131,25 @@ type service struct {
 	sessions map[string]*acpSession
 }
 
+// acpController is the slice of the controller's driving port the ACP transport
+// drives: session lifecycle + persistence, turn execution, interactive approval,
+// and the capability surface (commands/skills/MCP prompts). ACP never touches
+// goals, checkpoints, or memory, so it depends on those sub-ports only — not the
+// concrete *control.Controller.
+type acpController interface {
+	control.Lifecycle
+	control.TurnControl
+	control.Approvals
+	control.Capabilities
+	control.SessionPersistence
+}
+
 // acpSession is one open session: its controller, the on-disk transcript path
 // (empty when persistence is off), and the cancel func of the in-flight turn
 // (nil when idle) so session/cancel can abort it.
 type acpSession struct {
 	id         string
-	ctrl       *control.Controller
+	ctrl       acpController
 	sink       *updateSink
 	transcript string
 	cwd        string
@@ -688,7 +701,12 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	} else if prevPath != "" {
 		newCtrl.SetSessionPath(prevPath)
 	}
-	newCtrl.InheritLifecycleFrom(cur)
+	// InheritLifecycleFrom wires two concrete controllers' turn/hook state; it's a
+	// construction concern, not part of the driving port. cur is always the
+	// *control.Controller the factory built for this session, so this is safe.
+	if prev, ok := cur.(*control.Controller); ok {
+		newCtrl.InheritLifecycleFrom(prev)
+	}
 
 	sess.ctrl = newCtrl
 	sess.model = cfgState.Model
@@ -1103,7 +1121,7 @@ func (s *service) sendAvailableCommands(sess *acpSession) {
 	})
 }
 
-func availableCommandsFor(ctrl *control.Controller) []AvailableCommand {
+func availableCommandsFor(ctrl acpController) []AvailableCommand {
 	if ctrl == nil {
 		return nil
 	}

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -4,8 +4,17 @@ import (
 	"context"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/billing"
+	"reasonix/internal/checkpoint"
+	"reasonix/internal/command"
+	"reasonix/internal/config"
 	"reasonix/internal/event"
+	"reasonix/internal/hook"
+	"reasonix/internal/jobs"
+	"reasonix/internal/memory"
+	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/skill"
 )
 
 // This file defines the driving port: the typed, segregated interface surface
@@ -73,11 +82,121 @@ type Approvals interface {
 	SetMode(plan, autoApproveTools bool)
 }
 
-// Compile-time proof that the concrete controller satisfies each sub-port, so
-// frontend migrations to the interfaces are mechanical and can never silently
-// drift from the implementation.
+// Goals covers the active-goal FSM and plan mode.
+type Goals interface {
+	Goal() string
+	GoalStatus() string
+	SetGoal(goal string)
+	SetGoalWithResearchMode(goal string, researchMode GoalResearchMode)
+	GoalStrict(strict bool)
+	ClearGoal()
+	AutoStartResearchGoal(input string) (string, bool)
+	PlanMode() bool
+	SetPlanMode(v bool)
+	SetAutoPlan(mode string)
+}
+
+// SessionHistory covers checkpoint/rewind, branch/fork, and the log-restructuring
+// operations (compact, summarize).
+type SessionHistory interface {
+	Checkpoints() []checkpoint.Meta
+	CheckpointHasBoundary(turn int) bool
+	Rewind(turn int, scope RewindScope) error
+	Fork(turn int) (string, error)
+	ForkNamed(turn int, name string) (string, error)
+	ForkSession(turn int, name string) (string, error)
+	Branch(name string) (string, error)
+	Branches() ([]agent.BranchInfo, error)
+	BranchTreeText() string
+	SwitchBranch(ref string) (agent.BranchInfo, error)
+	Compact(ctx context.Context, instructions string) error
+	CompactRatio() float64
+	SummarizeFrom(ctx context.Context, turn int) error
+	SummarizeUpTo(ctx context.Context, turn int) error
+}
+
+// MemoryControl covers session/project memory reads and mutations.
+type MemoryControl interface {
+	Memory() *memory.Set
+	QuickAdd(scope memory.Scope, note string) (string, error)
+	SaveDoc(path, body string) (string, error)
+	SaveMemory(m memory.Memory) (string, error)
+	ForgetMemory(name string) error
+	QueueMemory(note string)
+}
+
+// Capabilities covers the session's pluggable surface — MCP servers, skills,
+// slash commands, hooks — and resolving prompt/command/skill inputs.
+type Capabilities interface {
+	Host() *plugin.Host
+	Commands() []command.Command
+	Skills() []skill.Skill
+	AllSkills() []skill.Skill
+	DisabledSkills() []skill.Skill
+	SkillEnabled(name string) bool
+	SetSkillEnabled(name string, enabled bool) error
+	HookRunner() *hook.Runner
+	CustomCommand(input string) (sent string, found bool)
+	MCPPrompt(ctx context.Context, input string) (sent string, found bool, err error)
+	RunSkill(input string) (sent string, found bool)
+	AddMCPServer(e config.PluginEntry) (int, error)
+	ConnectMCPServer(e config.PluginEntry) (int, error)
+	ConnectConfiguredMCPServer(name string) (int, error)
+	DisconnectMCPServer(name string) bool
+	RemoveMCPServer(name string) (disconnected bool, err error)
+	ConfiguredMCPNames() []string
+	DisconnectedMCPNames() []string
+	UnregisterMCPServerTools(name string) bool
+	ImportMCPEntries(entries []config.PluginEntry) (total, added, updated, connected, failed, skipped int, err error)
+}
+
+// Status covers read-only run/usage/billing telemetry.
+type Status interface {
+	ContextSnapshot() (int, int)
+	LastUsage() *provider.Usage
+	Balance(ctx context.Context) (*billing.Balance, error)
+	Jobs() []jobs.View
+}
+
+// SessionPersistence covers snapshotting a session and tearing down its on-disk
+// state.
+type SessionPersistence interface {
+	Snapshot() error
+	SnapshotActivity() error
+	SessionCache() (hit, miss int)
+	BeginDestroySession(sessionPath string) SessionDestroyHandle
+	CloseAfterDestroy()
+	IsDestroyingSession(sessionPath string) bool
+	ReleaseResources()
+}
+
+// SessionAPI is the full driving port — the composition of every sub-port. A
+// rich frontend (the HTTP server, the desktop app, the TUI) depends on this;
+// leaner frontends (bot, acp) depend on just the sub-ports they use.
+type SessionAPI interface {
+	Lifecycle
+	TurnControl
+	Approvals
+	Goals
+	SessionHistory
+	MemoryControl
+	Capabilities
+	Status
+	SessionPersistence
+}
+
+// Compile-time proof that the concrete controller satisfies each sub-port and
+// the full port, so frontend migrations to the interfaces are mechanical and can
+// never silently drift from the implementation.
 var (
-	_ Lifecycle   = (*Controller)(nil)
-	_ TurnControl = (*Controller)(nil)
-	_ Approvals   = (*Controller)(nil)
+	_ Lifecycle          = (*Controller)(nil)
+	_ TurnControl        = (*Controller)(nil)
+	_ Approvals          = (*Controller)(nil)
+	_ Goals              = (*Controller)(nil)
+	_ SessionHistory     = (*Controller)(nil)
+	_ MemoryControl      = (*Controller)(nil)
+	_ Capabilities       = (*Controller)(nil)
+	_ Status             = (*Controller)(nil)
+	_ SessionPersistence = (*Controller)(nil)
+	_ SessionAPI         = (*Controller)(nil)
 )

--- a/internal/serve/serve.go
+++ b/internal/serve/serve.go
@@ -36,7 +36,7 @@ var indexHTML []byte
 // same sink the controller was constructed with, so events reach SSE clients.
 type Server struct {
 	mu         sync.RWMutex // guards ctrl, which switchModel swaps at runtime
-	ctrl       *control.Controller
+	ctrl       control.SessionAPI
 	bc         *Broadcaster
 	titleProv  provider.Provider // lightweight flash provider for session titles
 	titlePrice *provider.Pricing
@@ -44,7 +44,7 @@ type Server struct {
 }
 
 // New builds a Server. bc must be the controller's event sink.
-func New(ctrl *control.Controller, bc *Broadcaster) *Server {
+func New(ctrl control.SessionAPI, bc *Broadcaster) *Server {
 	s := &Server{ctrl: ctrl, bc: bc, titles: newTitleCache(ctrl.SessionDir())}
 	s.initTitleProvider()
 	return s
@@ -52,7 +52,7 @@ func New(ctrl *control.Controller, bc *Broadcaster) *Server {
 
 // ctl returns the current controller. Handlers must read it through here, never
 // the field directly, because switchModel replaces it under the write lock.
-func (s *Server) ctl() *control.Controller {
+func (s *Server) ctl() control.SessionAPI {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.ctrl


### PR DESCRIPTION
## What

Continues the driving-port migration (after bot, #4931). Completes the segregated port surface and moves the next two frontends — **serve** and **acp** — off the concrete `*control.Controller`.

## How

**`port.go`:** adds the remaining sub-ports — `Goals`, `SessionHistory`, `MemoryControl`, `Capabilities`, `Status`, `SessionPersistence` — plus `SessionAPI` = the composition of all nine. Compile-time assertions prove `*Controller` satisfies each.

**serve** uses ~37 controller methods spanning every domain, so it depends on the full `control.SessionAPI` (the `Server.ctrl` field, `New` param, and `ctl()` return). `switchModel` still builds a concrete controller via `boot.Build` and stores it through the interface.

**acp** uses ~17 methods across five domains; its `acpSession.ctrl` and `availableCommandsFor` now take a narrow `acpController` interface (`Lifecycle` + `TurnControl` + `Approvals` + `Capabilities` + `SessionPersistence`). The `Factory` still returns the concrete type at construction.

### One deliberate concrete dependency

`InheritLifecycleFrom` reads another controller's **private** turn/hook state — it's a construction-wiring concern between two concrete controllers, not a frontend command, so it stays out of the port. acp's one call site uses a guarded type assertion (the controller is always the one its `Factory` built).

## Plan

Two frontends remain (`desktop`, `cli`). Once migrated, the desktop `bridge.ts` hand-mirror can be **generated** from the port instead of hand-kept.

## Verification

`gofmt`, `go build ./...`, `go vet ./...` clean; `go test -race ./internal/control` + `serve`/`acp`/`bot` pass. No behavior change.