### PR TITLE
fix(agent): write zh reasoning-language block in Chinese to survive English file references

### DIFF
--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -536,7 +536,7 @@ func TestSetReasoningLanguageUpdatesLiveTabControllers(t *testing.T) {
 	}
 
 	userComposed := userCtrl.Compose("hi")
-	if !strings.Contains(userComposed, "Simplified Chinese") {
+	if !strings.Contains(userComposed, "简体中文") {
 		t.Fatalf("user-level tab Compose = %q, want zh reasoning language", userComposed)
 	}
 	projectComposed := projectCtrl.Compose("hi")

--- a/internal/agent/empty_final_test.go
+++ b/internal/agent/empty_final_test.go
@@ -58,7 +58,7 @@ func TestRunPrefixesReasoningLanguageOnSyntheticRetry(t *testing.T) {
 	}
 	for i, req := range prov.requests {
 		got := lastUser(req)
-		if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") {
+		if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") {
 			t.Fatalf("request %d last user = %q, want reasoning-language prefix", i, got)
 		}
 	}

--- a/internal/agent/reasoning_language.go
+++ b/internal/agent/reasoning_language.go
@@ -26,7 +26,7 @@ func NormalizeReasoningLanguage(lang string) string {
 func ReasoningLanguageBlock(lang string) string {
 	switch NormalizeReasoningLanguage(lang) {
 	case "zh":
-		return "<reasoning-language>\nVisible reasoning/thinking text preference: use Simplified Chinese when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
+		return "<reasoning-language>\n可见推理/思考文本的语言偏好：当提供方暴露推理文本时，请使用简体中文进行思考和推理。代码、标识符、文件路径、Shell 命令以及未翻译的技术术语保持原样。此偏好不会覆盖用户对最终回答语言的明确要求。\n</reasoning-language>"
 	case "en":
 		return "<reasoning-language>\nVisible reasoning/thinking text preference: use English when the provider exposes reasoning text. Keep code, identifiers, file paths, shell commands, and untranslated technical terms in their original form. This preference does not override an explicit user request for the final answer language.\n</reasoning-language>"
 	default:

--- a/internal/agent/reasoning_language_test.go
+++ b/internal/agent/reasoning_language_test.go
@@ -8,7 +8,7 @@ import (
 func TestWithReasoningLanguageOnlySkipsLeadingInjectedBlock(t *testing.T) {
 	userMention := "explain why <reasoning-language> appears in this file"
 	got := WithReasoningLanguage(userMention, "zh")
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, userMention) {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, userMention) {
 		t.Fatalf("WithReasoningLanguage should prefix user-authored tag mentions, got %q", got)
 	}
 

--- a/internal/agent/task_test.go
+++ b/internal/agent/task_test.go
@@ -59,7 +59,7 @@ func TestTaskToolInheritsReasoningLanguageFromContext(t *testing.T) {
 		t.Fatalf("Execute: %v", err)
 	}
 	got := lastUser(sub.lastReq)
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "inspect auth") {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, "inspect auth") {
 		t.Fatalf("sub-agent user = %q, want reasoning-language-prefixed prompt", got)
 	}
 }

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1045,7 +1045,7 @@ func TestReasoningLanguageCommandPersistsAndUpdatesController(t *testing.T) {
 		t.Fatalf("saved config missing reasoning_language=zh:\n%s", body)
 	}
 	composed := ctrl.Compose("hello")
-	if !strings.HasPrefix(composed, "<reasoning-language>") || !strings.Contains(composed, "Simplified Chinese") {
+	if !strings.HasPrefix(composed, "<reasoning-language>") || !strings.Contains(composed, "简体中文") {
 		t.Fatalf("/reasoning-language zh should affect current controller, got %q", composed)
 	}
 }

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -118,7 +118,7 @@ func TestComposeReasoningLanguagePreference(t *testing.T) {
 
 	zh := New(Options{ReasoningLanguage: "zh"})
 	got := zh.Compose("hi")
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "hi") {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, "hi") {
 		t.Fatalf("zh reasoning language should ride the user turn, got %q", got)
 	}
 	if stripped := StripComposePrefixes(got); stripped != "hi" {
@@ -137,7 +137,7 @@ func TestRunComposesReasoningLanguagePreference(t *testing.T) {
 		t.Fatalf("runner inputs = %d, want 1", len(runner.inputs))
 	}
 	got := runner.inputs[0]
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, "hi") {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, "hi") {
 		t.Fatalf("headless Run should compose the reasoning language preference, got %q", got)
 	}
 }
@@ -161,7 +161,7 @@ func TestComposeSyntheticReasoningLanguagePreference(t *testing.T) {
 	c := New(Options{ReasoningLanguage: "zh"})
 
 	got := c.ComposeSynthetic(planApprovedMessage)
-	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "Simplified Chinese") || !strings.HasSuffix(got, planApprovedMessage) {
+	if !strings.HasPrefix(got, "<reasoning-language>") || !strings.Contains(got, "简体中文") || !strings.HasSuffix(got, planApprovedMessage) {
 		t.Fatalf("ComposeSynthetic should prefix reasoning language, got %q", got)
 	}
 	if !IsSyntheticUserMessage(got) {


### PR DESCRIPTION
## Summary

修复 #4875: 在引用文件时思考语言设置失效

**问题：** 当设置思考语言为中文但引用大量英文文件内容时，模型仍使用英文思考。

**根因：** `<reasoning-language>` 指令块虽然是要求使用中文思考，但指令本身是英文写的。当用户消息中包含大量英文文件内容时，英文指令被"淹没"。

**修复：** 将中文的思考语言指令改为用简体中文编写，让模型在指令层面就看到中文，提供更强的信号。

## Verification

- `go test ./internal/agent/...` passes
- `go test ./internal/control/...` passes
- `go vet ./...` passes
- `gofmt -w` applied

Fixes #4875

## Cache impact

Cache-impact: low — 仅修改了 reasoning-language XML 块的文本内容，不改变结构或长度。
Cache-guard: N/A — 无缓存敏感文件变动。
