### PR TITLE
fix(agent): reset planner session on tab switch to prevent cross-session contamination

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1002,7 +1002,13 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			}
 			if sessionRuntimeKey(tab.currentSessionPath()) == targetKey {
 				if activate {
+					wasActive := a.activeTabID == tab.ID
 					a.activeTabID = tab.ID
+					// Reset planner session when switching to a different tab to
+					// prevent cross-session contamination in dual-model mode (#4926).
+					if !wasActive && tab.Ctrl != nil {
+						tab.Ctrl.ResetPlannerSession()
+					}
 				}
 				meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 				a.saveTabsLocked()
@@ -1014,6 +1020,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 
 	for _, tab := range a.tabs {
 		if tabMatchesTopicTarget(tab, scope, workspaceRoot, topicID) {
+			wasActive := a.activeTabID == tab.ID
 			if activate {
 				a.activeTabID = tab.ID
 			}
@@ -1022,6 +1029,11 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			a.saveTabsLocked()
 			a.mu.Unlock()
 			if sameSession {
+				// Reset planner session when switching to a different tab to
+				// prevent cross-session contamination in dual-model mode (#4926).
+				if activate && !wasActive && tab.Ctrl != nil {
+					tab.Ctrl.ResetPlannerSession()
+				}
 				return enrichTabMeta(meta), nil
 			}
 			if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {
@@ -1362,8 +1374,18 @@ func (a *App) SetActiveTab(tabID string) error {
 		return nil
 	}
 	a.activeTabID = tabID
+	tab := a.tabs[tabID]
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
+
+	// Reset the planner session when switching tabs to prevent cross-session
+	// contamination in dual-model (Plan+Execute) mode. Each tab's planner
+	// history should be scoped to that tab's conversation; without this reset,
+	// stale planner output from a previously active tab could leak into the
+	// newly active tab's executor handoff (#4926).
+	if tab != nil && tab.Ctrl != nil {
+		tab.Ctrl.ResetPlannerSession()
+	}
 
 	// I/O outside the lock — disk writes can block for hundreds of ms on
 	// Windows when antivirus or the search indexer briefly locks the file.
@@ -1432,6 +1454,11 @@ func (a *App) CloseTab(tabID string) error {
 				nextIndex = len(a.tabOrder) - 1
 			}
 			a.activeTabID = a.tabOrder[nextIndex]
+			// Reset planner session on the newly active tab to prevent
+			// cross-session contamination in dual-model mode (#4926).
+			if nextTab := a.tabs[a.activeTabID]; nextTab != nil && nextTab.Ctrl != nil {
+				nextTab.Ctrl.ResetPlannerSession()
+			}
 		}
 	}
 	a.saveTabsLocked()

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1990,7 +1990,7 @@ func (c *Controller) NewSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
@@ -2034,7 +2034,7 @@ func (c *Controller) ClearSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true
@@ -2255,7 +2255,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	}
 	if switchToFork {
 		c.executor.SetSession(sess)
-		c.resetPlannerSession()
+		c.ResetPlannerSession()
 		c.mu.Lock()
 		c.sessionPath = newPath
 		c.mu.Unlock()
@@ -2325,7 +2325,7 @@ func (c *Controller) Branch(name string) (string, error) {
 		return "", c.rewindFail(err)
 	}
 	c.executor.SetSession(sess)
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = newPath
 	c.mu.Unlock()
@@ -2376,7 +2376,7 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	if c.executor != nil {
 		c.executor.SetSession(loaded)
 	}
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = match.Path
 	c.mu.Unlock()
@@ -2476,7 +2476,7 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	if c.executor != nil {
 		c.executor.SetSession(s)
 	}
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = path
 	c.mu.Unlock()
@@ -2485,7 +2485,11 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.maybeColdResumePrune(path)
 }
 
-func (c *Controller) resetPlannerSession() {
+// ResetPlannerSession clears the planner's conversation history so the next
+// plan starts fresh. In dual-model (Plan+Execute) mode, this prevents stale
+// planner output from a previous session or tab from contaminating the current
+// executor's handoff. Safe to call on a single-model controller (no-op).
+func (c *Controller) ResetPlannerSession() {
 	runner, ok := c.runner.(plannerSessionResetter)
 	if ok {
 		runner.ResetPlannerSession()

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -551,6 +551,43 @@ func TestResumeResetsTwoModelPlannerContext(t *testing.T) {
 	}
 }
 
+func TestResetPlannerSessionClearsPlannerHistory(t *testing.T) {
+	dir := t.TempDir()
+	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{
+		textTurn("FIRST PLAN: inspect alpha.go"),
+		textTurn("SECOND PLAN: inspect beta.go"),
+	}}
+	execProv := &recordingProvider{name: "executor", streams: [][]provider.Chunk{
+		textTurn("first done"),
+		textTurn("second done"),
+	}}
+	exec := agent.New(execProv, tool.NewRegistry(), agent.NewSession("exec sys"), agent.Options{}, event.Discard)
+	plannerSess := agent.NewSession("planner sys")
+	coord := agent.NewCoordinator(planner, plannerSess, nil, tool.NewRegistry(), agent.Options{}, exec, 0, event.Discard, nil)
+	path := filepath.Join(dir, "session.jsonl")
+	c := New(Options{Runner: coord, Executor: exec, SystemPrompt: "exec sys", SessionDir: dir, SessionPath: path, Label: "test"})
+
+	if err := c.Run(context.Background(), "first task"); err != nil {
+		t.Fatal(err)
+	}
+	// Explicitly reset the planner session (simulates a tab switch).
+	c.ResetPlannerSession()
+	if err := c.Run(context.Background(), "second task"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(planner.requests) != 2 {
+		t.Fatalf("planner requests = %d, want 2", len(planner.requests))
+	}
+	second := requestMessagesText(planner.requests[1].Messages)
+	if strings.Contains(second, "first task") || strings.Contains(second, "FIRST PLAN") {
+		t.Fatalf("planner request after reset leaked previous session context:\n%s", second)
+	}
+	if !strings.Contains(second, "second task") {
+		t.Fatalf("planner request after reset missing current task:\n%s", second)
+	}
+}
+
 func TestSubmitClearDiscardsCurrentContextWithoutSavingTranscript(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")


### PR DESCRIPTION
## Summary

修复 #4926: Plan-Execute dual-model 跨会话计划污染

**问题：** 当使用双模型 Plan+Execute 模式时，同一项目下的多个标签页会发生跨会话污染。Tab A 的 Planner 输出可能被路由到 Tab B 的 Executor。

**根因：** 切换标签页时没有重置 planner session，导致 Coordinator 的 plannerSess 中的旧状态污染新的会话。

**修复：** 将 `Controller.ResetPlannerSession()` 导出为公开方法，并在桌面层的每个标签页激活路径中调用：
- `SetActiveTab`: 用户在标签页间切换
- `openTopicTabWithActivation`: 复用现有标签页
- `CloseTab`: 关闭标签页后切换到下一个

## Changes

- `internal/control/controller.go` - 导出 `ResetPlannerSession()` 方法
- `desktop/tabs.go` - 在4个标签页激活点调用 `ResetPlannerSession()`
- `internal/control/controller_test.go` - 添加测试验证

## Verification

- `go test ./internal/agent/...` passes
- `go test ./internal/control/...` passes (包括新测试)
- `go vet ./...` clean
- `gofmt -w .` clean

Fixes #4926

## Cache impact

Cache-impact: none — 仅添加了方法调用，不改变系统提示或缓存前缀。
Cache-guard: N/A
