### PR TITLE
refactor(control): migrate the cli TUI to the SessionAPI port

### DIFF
--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -45,7 +45,7 @@ import (
 // prevents taps from raising the soft keyboard, so it stays in the normal buffer
 // and commits finalized output to native scrollback via tea.Println.
 type chatTUI struct {
-	ctrl    *control.Controller
+	ctrl    control.SessionAPI
 	label   string
 	missing string // missing-key warning surfaced once in the banner, "" when ready
 
@@ -298,7 +298,7 @@ type chatTUI struct {
 	// and kills plugin subprocesses, both of which corrupt the terminal's
 	// raw mode). Instead they are closed at process exit when the terminal
 	// is already being restored.
-	oldControllers []*control.Controller
+	oldControllers []control.SessionAPI
 
 	// completion is the live autocomplete menu (slash commands; @-refs later).
 	completion completion
@@ -394,8 +394,8 @@ func (m chatTUI) refreshGitStatus() tea.Cmd {
 // mode that would occur if Close() were called from the build goroutine.
 type modelSwitchMsg struct {
 	ref      string
-	ctrl     *control.Controller
-	oldCtrl  *control.Controller
+	ctrl     control.SessionAPI
+	oldCtrl  control.SessionAPI
 	label    string
 	commands []command.Command
 	skills   []skill.Skill
@@ -406,7 +406,7 @@ type modelSwitchMsg struct {
 // fetchBalance queries the provider's wallet balance off the event loop. It's a
 // no-op readout ("") when the provider declares no balance_url or the fetch
 // fails, so the status line stays quiet rather than surfacing an error.
-func fetchBalance(ctrl *control.Controller) tea.Cmd {
+func fetchBalance(ctrl control.Status) tea.Cmd {
 	return func() tea.Msg {
 		b, err := ctrl.Balance(context.Background())
 		if err != nil || b == nil {
@@ -450,7 +450,7 @@ type clipboardPasteMsg struct {
 // with an event sink that feeds eventCh; the TUI issues commands to it and
 // renders the events it emits. Label, history, host, and commands are read from
 // the controller, so a resumed session pre-populates scrollback.
-func newChatTUI(ctrl *control.Controller, missing string, eventCh chan event.Event, termW int) chatTUI {
+func newChatTUI(ctrl control.SessionAPI, missing string, eventCh chan event.Event, termW int) chatTUI {
 	ti := textarea.New()
 	configureChatTextarea(&ti)
 

--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -179,7 +179,7 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func recordMCPModePluginFailure(ctrl *control.Controller, e config.PluginEntry, err error) {
+func recordMCPModePluginFailure(ctrl control.Capabilities, e config.PluginEntry, err error) {
 	if ctrl == nil || ctrl.Host() == nil || err == nil {
 		return
 	}
@@ -405,7 +405,7 @@ func mcpCanClearAuth(v mcpServerView) bool {
 	return mcpdiag.IsRemoteTransport(v.Transport)
 }
 
-func mcpConnected(ctrl *control.Controller, name string) bool {
+func mcpConnected(ctrl control.Capabilities, name string) bool {
 	if ctrl == nil || ctrl.Host() == nil {
 		return false
 	}

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -170,6 +170,21 @@ type SessionPersistence interface {
 	ReleaseResources()
 }
 
+// Input covers composing a turn's text (plan/goal/memory injection) and
+// resolving @-references before submission.
+type Input interface {
+	Compose(text string) string
+	ComposeSynthetic(text string) string
+	ResolveRefs(ctx context.Context, line string) (block string, errs []string)
+	HasRefs(line string) bool
+}
+
+// Settings covers runtime session settings that don't fit a richer domain.
+type Settings interface {
+	SetReasoningLanguage(lang string)
+	SetDisplayRecorder(fn func(content, display string))
+}
+
 // SessionAPI is the full driving port — the composition of every sub-port. A
 // rich frontend (the HTTP server, the desktop app, the TUI) depends on this;
 // leaner frontends (bot, acp) depend on just the sub-ports they use.
@@ -183,6 +198,8 @@ type SessionAPI interface {
 	Capabilities
 	Status
 	SessionPersistence
+	Input
+	Settings
 }
 
 // Compile-time proof that the concrete controller satisfies each sub-port and
@@ -198,5 +215,7 @@ var (
 	_ Capabilities       = (*Controller)(nil)
 	_ Status             = (*Controller)(nil)
 	_ SessionPersistence = (*Controller)(nil)
+	_ Input              = (*Controller)(nil)
+	_ Settings           = (*Controller)(nil)
 	_ SessionAPI         = (*Controller)(nil)
 )


### PR DESCRIPTION
## What

Fourth and largest frontend on the driving port (after bot #4931, serve+acp #4932). The TUI used **~70 controller methods across every domain**, so it validated the port's completeness.

## How

It surfaced only two missing surfaces, now added to `port.go`:
- **`Input`** — `Compose`, `ComposeSynthetic`, `ResolveRefs`, `HasRefs`
- **`Settings`** — `SetReasoningLanguage`, `SetDisplayRecorder`

`SessionAPI` now composes all **eleven** sub-ports (asserted against `*Controller`).

`chatTUI.ctrl`, `modelSwitchMsg.ctrl`/`oldCtrl`, and `oldControllers[]` are now `control.SessionAPI`; leaf helpers narrow further (`fetchBalance` → `Status`, `mcpConnected`/`recordMCPModePluginFailure` → `Capabilities`). The model-switch plumbing that *builds* controllers (`setup`/`setupQuiet`, the `buildController` closure, `acpFactory`) stays concrete — construction returns `*Controller`, stored through the interface. cli never calls `InheritLifecycleFrom`, so no concrete escape hatch was needed.

## Status

4 of 5 frontends now depend on the port (bot, serve, acp, cli). **Only desktop remains** — once it's migrated, the desktop `bridge.ts` hand-mirror can be generated from `SessionAPI` instead of hand-kept.

## Verification

`gofmt`, `go build ./...`, `go vet ./...` clean; `go test ./internal/cli` + `-race ./internal/control` pass. No behavior change.