### PR TITLE
refactor(desktop): migrate the App to the SessionAPI port

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -682,7 +682,7 @@ func (a *App) SubmitDisplayToTab(tabID, display, input string) {
 	ctrl.SubmitDisplay(display, input)
 }
 
-func (a *App) bindControllerDisplayRecorder(ctrl *control.Controller) {
+func (a *App) bindControllerDisplayRecorder(ctrl control.SessionAPI) {
 	if ctrl == nil {
 		return
 	}
@@ -824,7 +824,7 @@ func (a *App) SetModeForTab(tabID, mode string) {
 	a.mu.Unlock()
 }
 
-func applyTabModeToController(ctrl *control.Controller, mode string) {
+func applyTabModeToController(ctrl control.SessionAPI, mode string) {
 	if ctrl == nil {
 		return
 	}
@@ -840,7 +840,7 @@ func applyTabModeToController(ctrl *control.Controller, mode string) {
 	}
 }
 
-func applyTabToolApprovalModeToController(ctrl *control.Controller, mode string) {
+func applyTabToolApprovalModeToController(ctrl control.SessionAPI, mode string) {
 	if ctrl == nil {
 		return
 	}
@@ -1018,7 +1018,7 @@ func (a *App) ClearSession() error {
 	return nil
 }
 
-func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl *control.Controller) error {
+func (a *App) clearActiveSessionRuntime(tab *WorkspaceTab, oldCtrl control.SessionAPI) error {
 	if tab == nil || oldCtrl == nil {
 		return fmt.Errorf("workspace is still starting")
 	}
@@ -1146,7 +1146,7 @@ func (a *App) Checkpoints() []CheckpointMeta {
 
 func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 	a.mu.RLock()
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	if tab := a.tabByIDLocked(tabID); tab != nil {
 		ctrl = tab.Ctrl
 	}
@@ -1196,7 +1196,7 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 // collapsed tool card. Returns nil when the tool ID is not found.
 func (a *App) ToolResultForTab(tabID, toolID string) *control.ToolResultData {
 	a.mu.RLock()
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	if tab := a.tabByIDLocked(tabID); tab != nil {
 		ctrl = tab.Ctrl
 	}
@@ -1381,7 +1381,7 @@ type WorkspaceMeta struct {
 	Current bool   `json:"current"`
 }
 
-func controllerSessionDir(ctrl *control.Controller) string {
+func controllerSessionDir(ctrl control.SessionAPI) string {
 	if ctrl != nil {
 		if dir := ctrl.SessionDir(); dir != "" {
 			return dir
@@ -1643,7 +1643,7 @@ func (a *App) DeleteSession(path string) error {
 
 type removedSessionRuntime struct {
 	tab           *WorkspaceTab
-	ctrl          *control.Controller
+	ctrl          control.SessionAPI
 	sink          *tabEventSink
 	sessionDir    string
 	sessionPath   string
@@ -1788,7 +1788,7 @@ func prepareRemovedSessionRuntimes(removed []removedSessionRuntime) error {
 	return nil
 }
 
-func waitControllerStopped(ctrl *control.Controller) error {
+func waitControllerStopped(ctrl control.SessionAPI) error {
 	deadline := time.Now().Add(5 * time.Second)
 	for ctrl.Running() {
 		if time.Now().After(deadline) {
@@ -1855,7 +1855,7 @@ func delayedDesktopSessionTrash(dir, sessionPath, key string, destroys []control
 }
 
 func (a *App) closeRemovedSessionRuntimes(removed []removedSessionRuntime) {
-	seen := map[*control.Controller]bool{}
+	seen := map[control.SessionAPI]bool{}
 	releasedTabs := map[*WorkspaceTab]bool{}
 	for _, item := range removed {
 		if item.tab != nil && !releasedTabs[item.tab] {
@@ -1871,7 +1871,7 @@ func (a *App) closeRemovedSessionRuntimes(removed []removedSessionRuntime) {
 }
 
 func (a *App) closeRemovedSessionRuntimesAfterDestroy(removed []removedSessionRuntime) {
-	seen := map[*control.Controller]bool{}
+	seen := map[control.SessionAPI]bool{}
 	for _, item := range removed {
 		if item.ctrl == nil || seen[item.ctrl] {
 			continue
@@ -3421,7 +3421,7 @@ func (a *App) ContextUsage() ContextInfo {
 func (a *App) ContextUsageForTab(tabID string) ContextInfo {
 	a.mu.RLock()
 	tab := a.tabByIDLocked(tabID)
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	if tab != nil {
 		ctrl = tab.Ctrl
 	}
@@ -3495,7 +3495,7 @@ func (a *App) JobsForTab(tabID string) []JobView {
 	return a.jobsForCtrl(ctrl, out)
 }
 
-func (a *App) jobsForCtrl(ctrl *control.Controller, out []JobView) []JobView {
+func (a *App) jobsForCtrl(ctrl control.SessionAPI, out []JobView) []JobView {
 	if ctrl == nil {
 		return out
 	}
@@ -3858,7 +3858,7 @@ func (a *App) SkillsSettings() SkillsSettingsView {
 	out := SkillsSettingsView{Skills: []SkillView{}, SkillRoots: []SkillRootView{}}
 	a.mu.RLock()
 	tab := a.activeTabLocked()
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	if tab != nil {
 		ctrl = tab.Ctrl
 	}
@@ -4757,7 +4757,7 @@ func normalizeMCPTransport(transport string) string {
 	}
 }
 
-func mcpConnected(ctrl *control.Controller, name string) bool {
+func mcpConnected(ctrl control.SessionAPI, name string) bool {
 	if ctrl == nil || ctrl.Host() == nil {
 		return false
 	}
@@ -4769,7 +4769,7 @@ func mcpConnected(ctrl *control.Controller, name string) bool {
 	return false
 }
 
-func mcpFailed(ctrl *control.Controller, name string) bool {
+func mcpFailed(ctrl control.SessionAPI, name string) bool {
 	if ctrl == nil || ctrl.Host() == nil {
 		return false
 	}
@@ -4781,7 +4781,7 @@ func mcpFailed(ctrl *control.Controller, name string) bool {
 	return false
 }
 
-func recordMCPFailure(ctrl *control.Controller, e config.PluginEntry, err error) {
+func recordMCPFailure(ctrl control.SessionAPI, e config.PluginEntry, err error) {
 	if ctrl == nil || ctrl.Host() == nil || err == nil {
 		return
 	}
@@ -4797,7 +4797,7 @@ func recordMCPFailure(ctrl *control.Controller, e config.PluginEntry, err error)
 	}, err)
 }
 
-func findMCPServerView(ctrl *control.Controller, name string) (ServerView, bool) {
+func findMCPServerView(ctrl control.SessionAPI, name string) (ServerView, bool) {
 	if ctrl == nil || ctrl.Host() == nil {
 		return ServerView{}, false
 	}
@@ -4947,7 +4947,7 @@ func modelProviderAccessAllowed(access map[string]bool, name string) bool {
 	return access[strings.TrimSpace(name)]
 }
 
-func controllerHasActiveRuntimeWork(ctrl *control.Controller) bool {
+func controllerHasActiveRuntimeWork(ctrl control.SessionAPI) bool {
 	if ctrl == nil {
 		return false
 	}
@@ -6008,7 +6008,7 @@ func (a *App) MemoryForTab(tabID string) MemoryView {
 	return a.memoryForCtrl(a.ctrlByTabID(tabID), false)
 }
 
-func (a *App) memoryForCtrl(ctrl *control.Controller, fallback bool) MemoryView {
+func (a *App) memoryForCtrl(ctrl control.SessionAPI, fallback bool) MemoryView {
 	view := MemoryView{Docs: []MemoryDoc{}, Facts: []MemoryFact{}, Archives: []MemoryArchive{}, Scopes: []MemoryScope{}}
 	if ctrl == nil {
 		if !fallback {
@@ -6068,7 +6068,7 @@ func (a *App) RememberForTab(tabID, scope, note string) (string, error) {
 	return a.rememberForCtrl(a.ctrlByTabID(tabID), scope, note, false)
 }
 
-func (a *App) rememberForCtrl(ctrl *control.Controller, scope, note string, fallback bool) (string, error) {
+func (a *App) rememberForCtrl(ctrl control.SessionAPI, scope, note string, fallback bool) (string, error) {
 	if ctrl == nil {
 		if !fallback {
 			return "", nil
@@ -6096,7 +6096,7 @@ func (a *App) ForgetForTab(tabID, name string) error {
 	return a.forgetForCtrl(a.ctrlByTabID(tabID), name, false)
 }
 
-func (a *App) forgetForCtrl(ctrl *control.Controller, name string, fallback bool) error {
+func (a *App) forgetForCtrl(ctrl control.SessionAPI, name string, fallback bool) error {
 	if ctrl == nil {
 		if !fallback {
 			return nil
@@ -6124,7 +6124,7 @@ func (a *App) SaveDocForTab(tabID, path, body string) (string, error) {
 	return a.saveDocForCtrl(a.ctrlByTabID(tabID), path, body, false)
 }
 
-func (a *App) saveDocForCtrl(ctrl *control.Controller, path, body string, fallback bool) (string, error) {
+func (a *App) saveDocForCtrl(ctrl control.SessionAPI, path, body string, fallback bool) (string, error) {
 	if ctrl == nil {
 		if !fallback {
 			return "", nil

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -69,7 +69,7 @@ func desktopMCPHTTPServer(t *testing.T) *httptest.Server {
 
 // setTestCtrl creates a minimal workspace tab (if needed) and sets its
 // controller, so tests don't depend on the old App.ctrl field.
-func (a *App) setTestCtrl(ctrl *control.Controller, model string) {
+func (a *App) setTestCtrl(ctrl control.SessionAPI, model string) {
 	if len(a.tabs) == 0 {
 		tab := &WorkspaceTab{
 			ID:          "test",
@@ -3915,7 +3915,7 @@ func startNonCooperativeSessionJob(t *testing.T, jm *jobs.Manager, sessionPath s
 	}
 }
 
-func waitNotRunning(t *testing.T, ctrl *control.Controller) {
+func waitNotRunning(t *testing.T, ctrl control.SessionAPI) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for ctrl.Running() {

--- a/desktop/memory_suggestions.go
+++ b/desktop/memory_suggestions.go
@@ -90,7 +90,7 @@ func (a *App) MemorySuggestionsForTab(tabID string) MemorySuggestionsView {
 
 	a.mu.RLock()
 	tab := a.tabByIDLocked(tabID)
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	workspaceRoot := ""
 	sessionDir := ""
 	if tab != nil {

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -1280,7 +1280,7 @@ func (a *App) RemoveProviderAccess(name string) error {
 
 type providerRemovalTab struct {
 	id       string
-	ctrl     *control.Controller
+	ctrl     control.SessionAPI
 	readOnly bool
 }
 
@@ -1839,7 +1839,7 @@ func (a *App) SetReasoningLanguage(lang string) error {
 func (a *App) applyReasoningLanguageToLiveControllers(fallback string) {
 	type liveTab struct {
 		root string
-		ctrl *control.Controller
+		ctrl control.SessionAPI
 	}
 	var tabs []liveTab
 	a.mu.RLock()

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -34,19 +34,19 @@ import (
 // memory, permissions) scoped to a workspace root, so multiple projects and
 // topics can be active concurrently without interfering.
 type WorkspaceTab struct {
-	ID            string              // stable random id
-	Scope         string              // "project" | "global"
-	WorkspaceRoot string              // project root dir (empty for global)
-	SharedHostKey string              // opaque key for the shared plugin host (set by buildTabController)
-	TopicID       string              // topic within the project
-	TopicTitle    string              // display title
-	SessionPath   string              // exact .jsonl file this tab continues
-	ReadOnly      bool                // true for external channel transcripts opened for browsing
-	Ctrl          *control.Controller // nil while booting / on error
-	Label         string              // model label (for the tab badge)
-	Ready         bool                // true once boot.Build completes
-	StartupErr    string              // build error, surfaced to the frontend
-	sink          *tabEventSink       // routes events with this tab's ID
+	ID            string             // stable random id
+	Scope         string             // "project" | "global"
+	WorkspaceRoot string             // project root dir (empty for global)
+	SharedHostKey string             // opaque key for the shared plugin host (set by buildTabController)
+	TopicID       string             // topic within the project
+	TopicTitle    string             // display title
+	SessionPath   string             // exact .jsonl file this tab continues
+	ReadOnly      bool               // true for external channel transcripts opened for browsing
+	Ctrl          control.SessionAPI // nil while booting / on error
+	Label         string             // model label (for the tab badge)
+	Ready         bool               // true once boot.Build completes
+	StartupErr    string             // build error, surfaced to the frontend
+	sink          *tabEventSink      // routes events with this tab's ID
 
 	ActivityStatus string // transient project-tree status for the in-flight turn
 
@@ -692,7 +692,7 @@ func (s *tabEventSink) recordReadTelemetry(e event.Event) {
 	}
 	s.app.mu.RLock()
 	tab := s.app.tabByEventSinkIDLocked(s.tabID)
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	if tab != nil {
 		ctrl = tab.Ctrl
 	}
@@ -778,7 +778,7 @@ func (s *tabEventSink) telemetryTab() (*WorkspaceTab, string) {
 	}
 	s.app.mu.RLock()
 	tab := s.app.tabByEventSinkIDLocked(s.tabID)
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	if tab != nil {
 		ctrl = tab.Ctrl
 	}
@@ -1816,14 +1816,14 @@ func (a *App) activeTabLocked() *WorkspaceTab {
 
 // activeCtrl returns the controller of the active tab, or nil.
 // Self-locking; safe to call from any goroutine without external lock.
-func (a *App) activeCtrl() *control.Controller {
+func (a *App) activeCtrl() control.SessionAPI {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	return a.activeCtrlLocked()
 }
 
 // activeCtrlLocked is like activeCtrl but assumes the caller already holds a.mu.
-func (a *App) activeCtrlLocked() *control.Controller {
+func (a *App) activeCtrlLocked() control.SessionAPI {
 	t := a.activeTabLocked()
 	if t == nil {
 		return nil
@@ -1844,7 +1844,7 @@ func (a *App) tabByIDLocked(tabID string) *WorkspaceTab {
 	return a.tabs[tabID]
 }
 
-func (a *App) ctrlByTabID(tabID string) *control.Controller {
+func (a *App) ctrlByTabID(tabID string) control.SessionAPI {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	tab := a.tabByIDLocked(tabID)
@@ -4099,7 +4099,7 @@ type ChangedFileInfo struct {
 func (a *App) ContextPanel(tabID string) ContextPanelInfo {
 	a.mu.RLock()
 	tab, ok := a.tabs[tabID]
-	var ctrl *control.Controller
+	var ctrl control.SessionAPI
 	if ok && tab != nil {
 		ctrl = tab.Ctrl
 	}

--- a/desktop/tabs_runtime_status_test.go
+++ b/desktop/tabs_runtime_status_test.go
@@ -245,7 +245,7 @@ func TestBackgroundJobNoticeForcesProjectTreeRefresh(t *testing.T) {
 	}
 }
 
-func waitNoJobs(t *testing.T, ctrl *control.Controller) {
+func waitNoJobs(t *testing.T, ctrl control.SessionAPI) {
 	t.Helper()
 	deadline := time.Now().Add(time.Second)
 	for len(ctrl.Jobs()) > 0 {

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -112,7 +112,7 @@ func (a *App) WorkspaceChanges(tabID string) WorkspaceChangesView {
 	return out
 }
 
-func (a *App) workspaceChangesTarget(tabID string) (string, *control.Controller, bool) {
+func (a *App) workspaceChangesTarget(tabID string) (string, control.SessionAPI, bool) {
 	a.mu.RLock()
 	defer a.mu.RUnlock()
 	var tab *WorkspaceTab


### PR DESCRIPTION
## What

**Final frontend on the driving port** (after bot #4931, serve+acp #4932, cli #4935). With this, all five frontends depend on `control.SessionAPI` instead of the concrete `*control.Controller` — the inbound boundary is complete.

## How

The desktop App held the controller as `*control.Controller` across ~35 sites (`WorkspaceTab.Ctrl`, `activeCtrl`/`ctrlByTabID`, and many per-ctrl helpers). All now take `control.SessionAPI`. cli (#4935) already forced the port to completeness, so **desktop needed no new methods** — every one of its 69 controller calls is already in the port.

- The controller is still **built concrete** (`boot.Build`) and stored through the interface.
- The dedupe maps become `map[control.SessionAPI]bool` (interface keys are comparable).
- Test helpers that *accept* a controller widen to the interface; the *constructor* helpers keep returning the concrete type.

## Verification

⚠️ The desktop module can't be built locally (cgo `-arch` toolchain issue — known), so this was verified by **manual audit**: no concrete type assertions/comparisons, no port-bypassing consumers (serve/acp), and all 69 methods confirmed present in `SessionAPI` — backed by control's compile-time `var _ SessionAPI = (*Controller)(nil)` assertion. **CI's `desktop` job is the gate.**

## Next

With every frontend on the port, the desktop `bridge.ts` hand-mirror can be **generated from `SessionAPI`** instead of hand-kept — closing the original unification gap (206 signatures, 69 stale).