### PR TITLE
Integrate desktop sidebar runtime fixes / 整合桌面侧边栏运行态修复

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -52,10 +53,24 @@ import (
 // `data:` frames.
 const eventChannel = "agent:event"
 
+const singleInstanceIDPrefix = "com.reasonix.desktop"
+
 // singleInstanceID is used by Wails to route a second desktop launch back to the
-// running instance. Keep it stable across releases so launcher/Dock/taskbar
-// reopen behavior remains predictable on every platform.
-const singleInstanceID = "com.reasonix.desktop"
+// running instance. It is stable for a given binary path, while allowing a dev
+// build and an installed release at different paths to run side by side.
+func singleInstanceID() string {
+	abs, err := os.Executable()
+	if err != nil {
+		return singleInstanceIDPrefix
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	} else if fallback, err := filepath.Abs(abs); err == nil {
+		abs = fallback
+	}
+	sum := sha256.Sum256([]byte(abs))
+	return singleInstanceIDPrefix + "." + hex.EncodeToString(sum[:8])
+}
 
 // PromptHistoryEntry is one user prompt extracted from a session JSONL file.
 // The frontend uses these for ↑/↓ prompt-history navigation.
@@ -1611,14 +1626,17 @@ func (a *App) DeleteSession(path string) error {
 		return err
 	}
 	removed, fallback := a.removeSessionRuntimeBindings(dir, sessionPath)
-	if err := prepareRemovedSessionRuntimes(removed); err != nil {
+	if err := a.prepareRemovedSessionRuntimes(removed); err != nil {
 		a.closeRemovedSessionRuntimes(removed)
 		return err
 	}
+	closedRemoved := map[control.SessionAPI]bool{}
 	destroys := a.destroyHandlesForSession(dir, sessionPath, removed)
-	if waitDestroyHandles(destroys) {
+	teardownTimedOut := waitDestroyHandles(destroys)
+	a.closeRemovedSessionRuntimesForSessionAfterDestroy(removed, dir, sessionPath, closedRemoved)
+	if teardownTimedOut {
 		if err := agent.MarkCleanupPending(sessionPath, "delete"); err != nil {
-			a.closeRemovedSessionRuntimesAfterDestroy(removed)
+			a.closeRemainingRemovedSessionRuntimesAfterDestroy(removed, closedRemoved)
 			return err
 		}
 		go delayedDesktopSessionTrash(dir, sessionPath, key, destroys)
@@ -1626,11 +1644,11 @@ func (a *App) DeleteSession(path string) error {
 		err = trashSessionArtifacts(dir, sessionPath, key)
 		finishDestroyHandles(destroys)
 		if err != nil {
-			a.closeRemovedSessionRuntimesAfterDestroy(removed)
+			a.closeRemainingRemovedSessionRuntimesAfterDestroy(removed, closedRemoved)
 			return err
 		}
 	}
-	a.closeRemovedSessionRuntimesAfterDestroy(removed)
+	a.closeRemainingRemovedSessionRuntimesAfterDestroy(removed, closedRemoved)
 	if fallback.needs {
 		if err := a.openFallbackRuntime(fallback); err != nil {
 			return err
@@ -1764,7 +1782,7 @@ func tabMatchesSession(tab *WorkspaceTab, dir, sessionPath string) bool {
 	return err == nil && currentPath == sessionPath
 }
 
-func prepareRemovedSessionRuntimes(removed []removedSessionRuntime) error {
+func (a *App) prepareRemovedSessionRuntimes(removed []removedSessionRuntime) error {
 	for _, item := range removed {
 		if item.sink != nil {
 			item.sink.ctx = nil
@@ -1784,6 +1802,8 @@ func prepareRemovedSessionRuntimes(removed []removedSessionRuntime) error {
 		if err := item.ctrl.Snapshot(); err != nil {
 			return err
 		}
+		item.ctrl.SetSessionPath("")
+		a.quiesceTabAutosave(item.tab)
 	}
 	return nil
 }
@@ -1855,30 +1875,57 @@ func delayedDesktopSessionTrash(dir, sessionPath, key string, destroys []control
 }
 
 func (a *App) closeRemovedSessionRuntimes(removed []removedSessionRuntime) {
-	seen := map[control.SessionAPI]bool{}
+	a.closeRemainingRemovedSessionRuntimes(removed, map[control.SessionAPI]bool{})
+}
+
+func (a *App) closeRemovedSessionRuntimesForSessionAfterDestroy(removed []removedSessionRuntime, dir, sessionPath string, closed map[control.SessionAPI]bool) {
 	releasedTabs := map[*WorkspaceTab]bool{}
 	for _, item := range removed {
-		if item.tab != nil && !releasedTabs[item.tab] {
-			releasedTabs[item.tab] = true
-			a.releaseTabSharedHost(item.tab)
-		}
-		if item.ctrl == nil || seen[item.ctrl] {
+		if item.sessionDir != dir || item.sessionPath != sessionPath {
 			continue
 		}
-		seen[item.ctrl] = true
-		item.ctrl.Close()
+		a.closeRemovedSessionRuntime(item, closed, releasedTabs, true)
 	}
 }
 
-func (a *App) closeRemovedSessionRuntimesAfterDestroy(removed []removedSessionRuntime) {
-	seen := map[control.SessionAPI]bool{}
+func (a *App) closeRemainingRemovedSessionRuntimes(removed []removedSessionRuntime, closed map[control.SessionAPI]bool) {
+	releasedTabs := map[*WorkspaceTab]bool{}
 	for _, item := range removed {
-		if item.ctrl == nil || seen[item.ctrl] {
-			continue
-		}
-		seen[item.ctrl] = true
-		item.ctrl.CloseAfterDestroy()
+		a.closeRemovedSessionRuntime(item, closed, releasedTabs, false)
 	}
+}
+
+func (a *App) closeRemainingRemovedSessionRuntimesAfterDestroy(removed []removedSessionRuntime, closed map[control.SessionAPI]bool) {
+	releasedTabs := map[*WorkspaceTab]bool{}
+	for _, item := range removed {
+		a.closeRemovedSessionRuntime(item, closed, releasedTabs, true)
+	}
+}
+
+func (a *App) closeRemovedSessionRuntime(item removedSessionRuntime, closed map[control.SessionAPI]bool, releasedTabs map[*WorkspaceTab]bool, afterDestroy bool) {
+	if item.tab != nil {
+		if releasedTabs == nil || !releasedTabs[item.tab] {
+			if releasedTabs != nil {
+				releasedTabs[item.tab] = true
+			}
+			a.releaseTabSharedHost(item.tab)
+		}
+	}
+	if item.ctrl == nil {
+		return
+	}
+	if closed == nil {
+		closed = map[control.SessionAPI]bool{}
+	}
+	if closed[item.ctrl] {
+		return
+	}
+	closed[item.ctrl] = true
+	if afterDestroy {
+		item.ctrl.CloseAfterDestroy()
+		return
+	}
+	item.ctrl.Close()
 }
 
 func (a *App) openFallbackRuntime(target fallbackRuntimeTarget) error {

--- a/desktop/app_autosave_test.go
+++ b/desktop/app_autosave_test.go
@@ -32,7 +32,7 @@ func controllerWithContent(t *testing.T, path string) *control.Controller {
 	sess.Add(provider.Message{Role: provider.RoleUser, Content: "remember this turn"})
 	sess.Add(provider.Message{Role: provider.RoleAssistant, Content: "acknowledged"})
 	ag := agent.New(stubProvider{}, tool.NewRegistry(), sess, agent.Options{}, event.Discard)
-	return control.New(control.Options{Executor: ag, SessionPath: path, Sink: event.Discard})
+	return control.New(control.Options{Executor: ag, SessionDir: filepath.Dir(path), SessionPath: path, Sink: event.Discard})
 }
 
 func waitForFile(t *testing.T, path, want string) {
@@ -219,5 +219,101 @@ func TestCloseTabSurvivorKeepsAutosave(t *testing.T) {
 	}
 	if survivor.closing {
 		t.Fatal("survivor tab was marked closing — closing flag leaked across tabs")
+	}
+}
+
+func TestDeleteSessionClearsRemovedRuntimeSessionPath(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "delete-open.jsonl")
+	ctrl := controllerWithContent(t, path)
+	tab := &WorkspaceTab{
+		ID:          "delete_open",
+		Scope:       "global",
+		Ready:       true,
+		Ctrl:        ctrl,
+		disabledMCP: map[string]ServerView{},
+	}
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"delete_open": tab},
+		activeTabID: "delete_open",
+	}
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+
+	if err := app.DeleteSession(path); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	if got := ctrl.SessionPath(); got != "" {
+		t.Fatalf("removed controller session path = %q, want empty before trash move can race Windows file locks", got)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, "delete-open.jsonl", "delete-open.jsonl")
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("session should be in trash: %v", err)
+	}
+}
+
+func TestTrashTopicClearsRemovedRuntimeSessionPath(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topicID := "topic_clear_removed_runtime"
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := setTopicTitle(projectRoot, topicID, "Clear removed runtime"); err != nil {
+		t.Fatalf("set topic title: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trash-open-topic.jsonl")
+	ctrl := controllerWithContent(t, path)
+	if err := ctrl.Snapshot(); err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	if err := agent.SaveBranchMeta(path, agent.BranchMeta{
+		CreatedAt:     time.Now().Add(-time.Minute),
+		UpdatedAt:     time.Now(),
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       topicID,
+		TopicTitle:    "Clear removed runtime",
+	}); err != nil {
+		t.Fatalf("save branch meta: %v", err)
+	}
+	tab := &WorkspaceTab{
+		ID:            "trash_open",
+		Scope:         "project",
+		WorkspaceRoot: projectRoot,
+		TopicID:       topicID,
+		TopicTitle:    "Clear removed runtime",
+		Ready:         true,
+		Ctrl:          ctrl,
+		disabledMCP:   map[string]ServerView{},
+	}
+	survivor := &WorkspaceTab{
+		ID:          "survivor",
+		Scope:       "global",
+		Ready:       true,
+		disabledMCP: map[string]ServerView{},
+	}
+	app := &App{
+		tabs:        map[string]*WorkspaceTab{"trash_open": tab, "survivor": survivor},
+		tabOrder:    []string{"trash_open", "survivor"},
+		activeTabID: "trash_open",
+	}
+
+	if err := app.TrashTopic(topicID); err != nil {
+		t.Fatalf("TrashTopic: %v", err)
+	}
+
+	if got := ctrl.SessionPath(); got != "" {
+		t.Fatalf("removed topic controller session path = %q, want empty before trash move can race Windows file locks", got)
+	}
+	trashPath := filepath.Join(dir, sessionTrashDir, "trash-open-topic.jsonl", "trash-open-topic.jsonl")
+	if _, err := os.Stat(trashPath); err != nil {
+		t.Fatalf("topic session should be in trash: %v", err)
 	}
 }

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -2753,6 +2753,56 @@ func TestOpenChannelSessionForTabIsReadOnly(t *testing.T) {
 	}
 }
 
+func TestCloseReadOnlyChannelTabDoesNotSnapshotTranscript(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	dir := config.SessionDir()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, "bot-channel.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"user","content":"from channel"}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	app := NewApp()
+	ctrl := control.New(control.Options{SessionDir: dir, SessionPath: filepath.Join(dir, "active.jsonl"), Label: "test"})
+	app.setTestCtrl(ctrl, "")
+	defer ctrl.Close()
+
+	if _, err := app.OpenChannelSessionForTab("test", path); err != nil {
+		t.Fatalf("OpenChannelSessionForTab: %v", err)
+	}
+	app.mu.Lock()
+	app.tabs["survivor"] = &WorkspaceTab{ID: "survivor", Scope: "global", Ready: true, disabledMCP: map[string]ServerView{}}
+	app.tabOrder = []string{"test", "survivor"}
+	app.activeTabID = "test"
+	app.mu.Unlock()
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open append: %v", err)
+	}
+	if _, err := f.WriteString(`{"role":"user","content":"external close follow-up"}` + "\n"); err != nil {
+		f.Close()
+		t.Fatalf("append external message: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("close append: %v", err)
+	}
+
+	if err := app.CloseTab("test"); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+	afterClose, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read after close: %v", err)
+	}
+	if !strings.Contains(string(afterClose), "external close follow-up") {
+		t.Fatalf("closing read-only channel tab overwrote external append:\n%s", afterClose)
+	}
+}
+
 func TestResumeSessionRejectsCleanupPending(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -58,6 +58,10 @@ func loadSessionTitles(dir string) map[string]string {
 	return m
 }
 
+func loadSessionTitlesForUpdate(dir string) (map[string]string, error) {
+	return loadStringMapForUpdate(sessionTitlesPath(dir))
+}
+
 // saveSessionTitles writes the map atomically (temp file + rename).
 func saveSessionTitles(dir string, m map[string]string) error {
 	b, err := json.MarshalIndent(m, "", "  ")
@@ -90,7 +94,10 @@ func setSessionTitle(dir, sessionPath, title string) error {
 	if err != nil {
 		return err
 	}
-	m := loadSessionTitles(dir)
+	m, err := loadSessionTitlesForUpdate(dir)
+	if err != nil {
+		return err
+	}
 	key := filepath.Base(sessionPath)
 	if strings.TrimSpace(title) == "" {
 		delete(m, key)
@@ -315,7 +322,10 @@ func purgeTrashedSessionFile(dir, path string) error {
 	if err := os.RemoveAll(itemDir); err != nil {
 		return err
 	}
-	m := loadSessionTitles(dir)
+	m, err := loadSessionTitlesForUpdate(dir)
+	if err != nil {
+		return err
+	}
 	if _, ok := m[key]; ok {
 		delete(m, key)
 		if err := saveSessionTitles(dir, m); err != nil {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -50,7 +50,7 @@ func desktopSessionDir(root string) string {
 // loadSessionTitles reads the basename→title map (missing/corrupt → empty).
 func loadSessionTitles(dir string) map[string]string {
 	m := map[string]string{}
-	b, err := os.ReadFile(sessionTitlesPath(dir))
+	b, err := readFileWithTimeout(sessionTitlesPath(dir), topicFileReadTimeout)
 	if err != nil {
 		return m
 	}

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -10,6 +10,27 @@ import (
 	"reasonix/internal/jobs"
 )
 
+func occupyReadFileWithTimeoutSlots(t *testing.T) func() {
+	t.Helper()
+	filled := 0
+	for filled < cap(readFileWithTimeoutSlots) {
+		readFileWithTimeoutSlots <- struct{}{}
+		filled++
+	}
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		for i := 0; i < filled; i++ {
+			<-readFileWithTimeoutSlots
+		}
+	}
+	t.Cleanup(release)
+	return release
+}
+
 // --- loadSessionTitles ---
 
 func TestLoadSessionTitlesMissing(t *testing.T) {
@@ -108,6 +129,27 @@ func TestSetSessionTitleTrimsWhitespace(t *testing.T) {
 	m := loadSessionTitles(dir)
 	if m["s.jsonl"] != "trimmed" {
 		t.Errorf("title = %q, want trimmed", m["s.jsonl"])
+	}
+}
+
+func TestSetSessionTitlePreservesExistingTitlesWhenTimedReadSlotsFull(t *testing.T) {
+	dir := t.TempDir()
+	if err := saveSessionTitles(dir, map[string]string{"old.jsonl": "Old"}); err != nil {
+		t.Fatalf("save old title: %v", err)
+	}
+	sessionPath := filepath.Join(dir, "new.jsonl")
+	release := occupyReadFileWithTimeoutSlots(t)
+	if err := setSessionTitle(dir, sessionPath, "New"); err != nil {
+		t.Fatalf("setSessionTitle: %v", err)
+	}
+	release()
+
+	m := loadSessionTitles(dir)
+	if got := m["old.jsonl"]; got != "Old" {
+		t.Fatalf("old title = %q, want Old (all titles: %v)", got, m)
+	}
+	if got := m["new.jsonl"]; got != "New" {
+		t.Fatalf("new title = %q, want New (all titles: %v)", got, m)
 	}
 }
 

--- a/desktop/single_instance.go
+++ b/desktop/single_instance.go
@@ -13,7 +13,7 @@ func singleInstanceLock(app *App) *options.SingleInstanceLock {
 		return nil
 	}
 	return &options.SingleInstanceLock{
-		UniqueId: singleInstanceID,
+		UniqueId: singleInstanceID(),
 		OnSecondInstanceLaunch: func(options.SecondInstanceData) {
 			app.secondInstanceLaunch()
 		},

--- a/desktop/single_instance_test.go
+++ b/desktop/single_instance_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -13,12 +14,23 @@ func TestSingleInstanceLockRestoresExistingInstance(t *testing.T) {
 	if lock == nil {
 		t.Fatal("singleInstanceLock returned nil")
 	}
-	if lock.UniqueId != singleInstanceID {
-		t.Fatalf("UniqueId = %q, want %q", lock.UniqueId, singleInstanceID)
+	id := singleInstanceID()
+	if lock.UniqueId != id {
+		t.Fatalf("UniqueId = %q, want %q", lock.UniqueId, id)
+	}
+	if !strings.HasPrefix(lock.UniqueId, singleInstanceIDPrefix+".") {
+		t.Fatalf("UniqueId = %q, want prefix %s.", lock.UniqueId, singleInstanceIDPrefix)
 	}
 	if lock.OnSecondInstanceLaunch == nil {
 		t.Fatal("OnSecondInstanceLaunch should restore the existing window")
 	}
 
 	lock.OnSecondInstanceLaunch(options.SecondInstanceData{})
+}
+
+func TestSingleInstanceLockSkipsInDevMode(t *testing.T) {
+	t.Setenv("REASONIX_DEV", "1")
+	if lock := singleInstanceLock(NewApp()); lock != nil {
+		t.Fatalf("singleInstanceLock returned %#v, want nil in dev mode", lock)
+	}
 }

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1002,13 +1003,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			}
 			if sessionRuntimeKey(tab.currentSessionPath()) == targetKey {
 				if activate {
-					wasActive := a.activeTabID == tab.ID
 					a.activeTabID = tab.ID
-					// Reset planner session when switching to a different tab to
-					// prevent cross-session contamination in dual-model mode (#4926).
-					if !wasActive && tab.Ctrl != nil {
-						tab.Ctrl.ResetPlannerSession()
-					}
 				}
 				meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 				a.saveTabsLocked()
@@ -1020,7 +1015,6 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 
 	for _, tab := range a.tabs {
 		if tabMatchesTopicTarget(tab, scope, workspaceRoot, topicID) {
-			wasActive := a.activeTabID == tab.ID
 			if activate {
 				a.activeTabID = tab.ID
 			}
@@ -1029,11 +1023,6 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			a.saveTabsLocked()
 			a.mu.Unlock()
 			if sameSession {
-				// Reset planner session when switching to a different tab to
-				// prevent cross-session contamination in dual-model mode (#4926).
-				if activate && !wasActive && tab.Ctrl != nil {
-					tab.Ctrl.ResetPlannerSession()
-				}
 				return enrichTabMeta(meta), nil
 			}
 			if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {
@@ -1374,18 +1363,8 @@ func (a *App) SetActiveTab(tabID string) error {
 		return nil
 	}
 	a.activeTabID = tabID
-	tab := a.tabs[tabID]
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
-
-	// Reset the planner session when switching tabs to prevent cross-session
-	// contamination in dual-model (Plan+Execute) mode. Each tab's planner
-	// history should be scoped to that tab's conversation; without this reset,
-	// stale planner output from a previously active tab could leak into the
-	// newly active tab's executor handoff (#4926).
-	if tab != nil && tab.Ctrl != nil {
-		tab.Ctrl.ResetPlannerSession()
-	}
 
 	// I/O outside the lock — disk writes can block for hundreds of ms on
 	// Windows when antivirus or the search indexer briefly locks the file.
@@ -1436,7 +1415,7 @@ func (a *App) CloseTab(tabID string) error {
 	// This closes a race window with DeleteSession: if Snapshot runs
 	// after delete(a.tabs, tabID), a concurrent DeleteSession can delete
 	// the session files, and the deferred Snapshot recreates them.
-	if tab.Ctrl != nil {
+	if tab.Ctrl != nil && !tab.ReadOnly {
 		_ = tab.Ctrl.Snapshot()
 	}
 
@@ -1462,11 +1441,6 @@ func (a *App) CloseTab(tabID string) error {
 				nextIndex = len(a.tabOrder) - 1
 			}
 			a.activeTabID = a.tabOrder[nextIndex]
-			// Reset planner session on the newly active tab to prevent
-			// cross-session contamination in dual-model mode (#4926).
-			if nextTab := a.tabs[a.activeTabID]; nextTab != nil && nextTab.Ctrl != nil {
-				nextTab.Ctrl.ResetPlannerSession()
-			}
 		}
 	}
 	a.saveTabsLocked()
@@ -2734,6 +2708,48 @@ func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
 	return m
 }
 
+func loadStringMapForUpdate(path string) (map[string]string, error) {
+	m := map[string]string{}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return m, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &m); err != nil || m == nil {
+		return map[string]string{}, nil
+	}
+	return m, nil
+}
+
+func loadInt64MapForUpdate(path string) (map[string]int64, error) {
+	m := map[string]int64{}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return m, nil
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(b, &m); err != nil || m == nil {
+		return map[string]int64{}, nil
+	}
+	return m, nil
+}
+
+func loadTopicTitlesForUpdate(workspaceRoot string) (map[string]string, error) {
+	return loadStringMapForUpdate(topicTitlesPath(workspaceRoot))
+}
+
+func loadTopicTitleSourcesForUpdate(workspaceRoot string) (map[string]string, error) {
+	return loadStringMapForUpdate(topicTitleSourcesPath(workspaceRoot))
+}
+
+func loadTopicCreatedAtsForUpdate(workspaceRoot string) (map[string]int64, error) {
+	return loadInt64MapForUpdate(topicCreatedAtsPath(workspaceRoot))
+}
+
 func saveTopicTitles(workspaceRoot string, m map[string]string) error {
 	b, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
@@ -2828,7 +2844,10 @@ func setTopicTitle(workspaceRoot, topicID, title string) error {
 }
 
 func setTopicTitleWithSource(workspaceRoot, topicID, title, source string) error {
-	m := loadTopicTitles(workspaceRoot)
+	m, err := loadTopicTitlesForUpdate(workspaceRoot)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(title) == "" {
 		delete(m, topicID)
 	} else {
@@ -2838,7 +2857,10 @@ func setTopicTitleWithSource(workspaceRoot, topicID, title, source string) error
 		return err
 	}
 
-	sources := loadTopicTitleSources(workspaceRoot)
+	sources, err := loadTopicTitleSourcesForUpdate(workspaceRoot)
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(title) == "" || strings.TrimSpace(source) == "" {
 		delete(sources, topicID)
 	} else {
@@ -2848,7 +2870,10 @@ func setTopicTitleWithSource(workspaceRoot, topicID, title, source string) error
 }
 
 func setTopicCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
-	created := loadTopicCreatedAts(workspaceRoot)
+	created, err := loadTopicCreatedAtsForUpdate(workspaceRoot)
+	if err != nil {
+		return err
+	}
 	topicID = strings.TrimSpace(topicID)
 	if topicID == "" || createdAt <= 0 {
 		delete(created, topicID)
@@ -2859,7 +2884,10 @@ func setTopicCreatedAt(workspaceRoot, topicID string, createdAt int64) error {
 }
 
 func deleteTopicCreatedAt(workspaceRoot, topicID string) {
-	created := loadTopicCreatedAts(workspaceRoot)
+	created, err := loadTopicCreatedAtsForUpdate(workspaceRoot)
+	if err != nil {
+		return
+	}
 	delete(created, topicID)
 	_ = saveTopicCreatedAts(workspaceRoot, created)
 }
@@ -3621,26 +3649,46 @@ func (a *App) DeleteTopic(topicID string) error {
 	f := loadProjectsFile()
 	found := false
 	for _, p := range f.Projects {
-		m := loadTopicTitles(p.Root)
+		m, err := loadTopicTitlesForUpdate(p.Root)
+		if err != nil {
+			return err
+		}
 		if _, ok := m[topicID]; ok {
 			delete(m, topicID)
-			_ = saveTopicTitles(p.Root, m)
-			sources := loadTopicTitleSources(p.Root)
+			if err := saveTopicTitles(p.Root, m); err != nil {
+				return err
+			}
+			sources, err := loadTopicTitleSourcesForUpdate(p.Root)
+			if err != nil {
+				return err
+			}
 			delete(sources, topicID)
-			_ = saveTopicTitleSources(p.Root, sources)
+			if err := saveTopicTitleSources(p.Root, sources); err != nil {
+				return err
+			}
 			deleteTopicCreatedAt(p.Root, topicID)
 			found = true
 			break
 		}
 	}
 	if !found {
-		m := loadTopicTitles("")
+		m, err := loadTopicTitlesForUpdate("")
+		if err != nil {
+			return err
+		}
 		if _, ok := m[topicID]; ok {
 			delete(m, topicID)
-			_ = saveTopicTitles("", m)
-			sources := loadTopicTitleSources("")
+			if err := saveTopicTitles("", m); err != nil {
+				return err
+			}
+			sources, err := loadTopicTitleSourcesForUpdate("")
+			if err != nil {
+				return err
+			}
 			delete(sources, topicID)
-			_ = saveTopicTitleSources("", sources)
+			if err := saveTopicTitleSources("", sources); err != nil {
+				return err
+			}
 			deleteTopicCreatedAt("", topicID)
 			f.GlobalTopics = removeString(f.GlobalTopics, topicID)
 			f.GlobalPinnedTopics = removeString(f.GlobalPinnedTopics, topicID)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1002,7 +1002,13 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			}
 			if sessionRuntimeKey(tab.currentSessionPath()) == targetKey {
 				if activate {
+					wasActive := a.activeTabID == tab.ID
 					a.activeTabID = tab.ID
+					// Reset planner session when switching to a different tab to
+					// prevent cross-session contamination in dual-model mode (#4926).
+					if !wasActive && tab.Ctrl != nil {
+						tab.Ctrl.ResetPlannerSession()
+					}
 				}
 				meta := a.tabMeta(tab, tab.ID == a.activeTabID)
 				a.saveTabsLocked()
@@ -1014,6 +1020,7 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 
 	for _, tab := range a.tabs {
 		if tabMatchesTopicTarget(tab, scope, workspaceRoot, topicID) {
+			wasActive := a.activeTabID == tab.ID
 			if activate {
 				a.activeTabID = tab.ID
 			}
@@ -1022,6 +1029,11 @@ func (a *App) openTopicTabWithActivation(scope, workspaceRoot, topicID, sessionP
 			a.saveTabsLocked()
 			a.mu.Unlock()
 			if sameSession {
+				// Reset planner session when switching to a different tab to
+				// prevent cross-session contamination in dual-model mode (#4926).
+				if activate && !wasActive && tab.Ctrl != nil {
+					tab.Ctrl.ResetPlannerSession()
+				}
 				return enrichTabMeta(meta), nil
 			}
 			if err := a.rebindTabToSessionPath(tab, sessionPath); err != nil {
@@ -1362,8 +1374,18 @@ func (a *App) SetActiveTab(tabID string) error {
 		return nil
 	}
 	a.activeTabID = tabID
+	tab := a.tabs[tabID]
 	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
+
+	// Reset the planner session when switching tabs to prevent cross-session
+	// contamination in dual-model (Plan+Execute) mode. Each tab's planner
+	// history should be scoped to that tab's conversation; without this reset,
+	// stale planner output from a previously active tab could leak into the
+	// newly active tab's executor handoff (#4926).
+	if tab != nil && tab.Ctrl != nil {
+		tab.Ctrl.ResetPlannerSession()
+	}
 
 	// I/O outside the lock — disk writes can block for hundreds of ms on
 	// Windows when antivirus or the search indexer briefly locks the file.
@@ -1410,6 +1432,14 @@ func (a *App) CloseTab(tabID string) error {
 		a.mu.Unlock()
 		return fmt.Errorf("cannot close the last tab")
 	}
+	// Snapshot the session state before removing the tab from a.tabs.
+	// This closes a race window with DeleteSession: if Snapshot runs
+	// after delete(a.tabs, tabID), a concurrent DeleteSession can delete
+	// the session files, and the deferred Snapshot recreates them.
+	if tab.Ctrl != nil {
+		_ = tab.Ctrl.Snapshot()
+	}
+
 	ordered := a.orderedTabIDsLocked()
 	closedIndex := -1
 	for i, id := range ordered {
@@ -1432,6 +1462,11 @@ func (a *App) CloseTab(tabID string) error {
 				nextIndex = len(a.tabOrder) - 1
 			}
 			a.activeTabID = a.tabOrder[nextIndex]
+			// Reset planner session on the newly active tab to prevent
+			// cross-session contamination in dual-model mode (#4926).
+			if nextTab := a.tabs[a.activeTabID]; nextTab != nil && nextTab.Ctrl != nil {
+				nextTab.Ctrl.ResetPlannerSession()
+			}
 		}
 	}
 	a.saveTabsLocked()
@@ -1439,15 +1474,6 @@ func (a *App) CloseTab(tabID string) error {
 
 	// Tear down outside the lock.
 	if tab.Ctrl != nil {
-		// Final snapshot while the controller still owns its session path.
-		// a.mu stays free during the disk write; the two resurrection
-		// vectors are neutralized below before DeleteSession can see the
-		// tab as gone:
-		//   (1) clear the controller's session path so any later Snapshot
-		//       (including the autosave loop) is a no-op;
-		//   (2) drain any in-flight tabSnapshotLoop before returning, so no
-		//       background write can land after the file is trashed.
-		_ = a.snapshotTab(tab)
 		if tab.hasActiveRuntimeWork() && a.detachSessionRuntime(tab) {
 			// Detached runtimes keep running and must keep saving: do not
 			// clear the path or drain for them.
@@ -2645,9 +2671,42 @@ func topicCreatedAtsPath(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, ".reasonix", topicCreatedAtsFile)
 }
 
+const topicFileReadTimeout = 200 * time.Millisecond
+
+var readFileWithTimeoutSlots = make(chan struct{}, 16)
+
+func readFileWithTimeout(path string, timeout time.Duration) ([]byte, error) {
+	if timeout <= 0 {
+		return os.ReadFile(path)
+	}
+	select {
+	case readFileWithTimeoutSlots <- struct{}{}:
+	default:
+		return nil, fmt.Errorf("too many pending file reads")
+	}
+	type result struct {
+		data []byte
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		data, err := os.ReadFile(path)
+		<-readFileWithTimeoutSlots
+		ch <- result{data: data, err: err}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.data, r.err
+	case <-timer.C:
+		return nil, fmt.Errorf("timed out after %v reading %s", timeout, filepath.Base(path))
+	}
+}
+
 func loadTopicTitles(workspaceRoot string) map[string]string {
 	m := map[string]string{}
-	b, err := os.ReadFile(topicTitlesPath(workspaceRoot))
+	b, err := readFileWithTimeout(topicTitlesPath(workspaceRoot), topicFileReadTimeout)
 	if err != nil {
 		return m
 	}
@@ -2657,7 +2716,7 @@ func loadTopicTitles(workspaceRoot string) map[string]string {
 
 func loadTopicTitleSources(workspaceRoot string) map[string]string {
 	m := map[string]string{}
-	b, err := os.ReadFile(topicTitleSourcesPath(workspaceRoot))
+	b, err := readFileWithTimeout(topicTitleSourcesPath(workspaceRoot), topicFileReadTimeout)
 	if err != nil {
 		return m
 	}
@@ -2667,7 +2726,7 @@ func loadTopicTitleSources(workspaceRoot string) map[string]string {
 
 func loadTopicCreatedAts(workspaceRoot string) map[string]int64 {
 	m := map[string]int64{}
-	b, err := os.ReadFile(topicCreatedAtsPath(workspaceRoot))
+	b, err := readFileWithTimeout(topicCreatedAtsPath(workspaceRoot), topicFileReadTimeout)
 	if err != nil {
 		return m
 	}
@@ -3661,14 +3720,15 @@ func (a *App) TrashTopic(topicID string) error {
 		return err
 	}
 	removed, fallback := a.removeTopicRuntimeBindings(topicID)
-	if err := prepareRemovedSessionRuntimes(removed); err != nil {
+	if err := a.prepareRemovedSessionRuntimes(removed); err != nil {
 		a.closeRemovedSessionRuntimes(removed)
 		return err
 	}
 	destroyBegun := false
+	closedRemoved := map[control.SessionAPI]bool{}
 	defer func() {
 		if destroyBegun {
-			a.closeRemovedSessionRuntimesAfterDestroy(removed)
+			a.closeRemainingRemovedSessionRuntimesAfterDestroy(removed, closedRemoved)
 			return
 		}
 		a.closeRemovedSessionRuntimes(removed)
@@ -3679,7 +3739,9 @@ func (a *App) TrashTopic(topicID string) error {
 		if len(destroys) > 0 {
 			destroyBegun = true
 		}
-		if waitDestroyHandles(destroys) {
+		teardownTimedOut := waitDestroyHandles(destroys)
+		a.closeRemovedSessionRuntimesForSessionAfterDestroy(removed, target.dir, target.sessionPath, closedRemoved)
+		if teardownTimedOut {
 			if err := agent.MarkCleanupPending(target.sessionPath, "delete"); err != nil {
 				return err
 			}
@@ -3782,7 +3844,12 @@ type topicSummary struct {
 	lastActivityAt int64
 }
 
+var listProjectTreeMu sync.Mutex
+
 func (a *App) ListProjectTree() []ProjectNode {
+	listProjectTreeMu.Lock()
+	defer listProjectTreeMu.Unlock()
+
 	migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
 	f := loadProjectsFile()
 	out := []ProjectNode{}
@@ -3803,23 +3870,32 @@ func (a *App) ListProjectTree() []ProjectNode {
 	// Read session listings from all known directories concurrently, since
 	// each dir is independent I/O. With N workspaces × dozens of sessions,
 	// sequential reads add up to seconds of wall time on cold start.
-	var (
-		mergeMu sync.Mutex
-		wg      sync.WaitGroup
-	)
 	cacheToken := projectSessionCache.versionToken()
-	for _, dir := range a.knownSessionDirs() {
+	type sessionDirLoadResult struct {
+		dir    string
+		infos  []agent.SessionInfo
+		titles map[string]string
+		ok     bool
+	}
+	knownDirs := a.knownSessionDirs()
+	results := make(chan sessionDirLoadResult, len(knownDirs))
+	pendingLoads := 0
+	for _, dir := range knownDirs {
 		infos, titles, ok := projectSessionCache.get(dir)
 		if ok {
-			mergeMu.Lock()
 			mergeSessionInfos(dir, infos, titles, sessionInfos, sessionTitles, topicSummaries)
-			mergeMu.Unlock()
 			continue
 		}
-		wg.Add(1)
+		pendingLoads++
 		dir := dir // capture
 		go func() {
-			defer wg.Done()
+			result := sessionDirLoadResult{dir: dir}
+			defer func() {
+				if recover() != nil {
+					result.ok = false
+				}
+				results <- result
+			}()
 
 			// Sidecar-backed listing: ListSessions reads turn count + preview from
 			// each session's .meta sidecar, so even large directories list in a few
@@ -3831,13 +3907,26 @@ func (a *App) ListProjectTree() []ProjectNode {
 			}
 			titles := loadSessionTitles(dir)
 			projectSessionCache.put(dir, infos, titles, cacheToken)
-
-			mergeMu.Lock()
-			mergeSessionInfos(dir, infos, titles, sessionInfos, sessionTitles, topicSummaries)
-			mergeMu.Unlock()
+			result.infos = infos
+			result.titles = titles
+			result.ok = true
 		}()
 	}
-	wg.Wait()
+	if pendingLoads > 0 {
+		timer := time.NewTimer(5 * time.Second)
+		for received := 0; received < pendingLoads; {
+			select {
+			case result := <-results:
+				received++
+				if result.ok {
+					mergeSessionInfos(result.dir, result.infos, result.titles, sessionInfos, sessionTitles, topicSummaries)
+				}
+			case <-timer.C:
+				received = pendingLoads
+			}
+		}
+		timer.Stop()
+	}
 
 	runtimeSessionsByTopic := map[string][]runtimeSessionStatus{}
 	a.mu.RLock()
@@ -3969,7 +4058,28 @@ func (a *App) ListProjectTree() []ProjectNode {
 	}
 
 	// Project sections.
-	for _, p := range f.Projects {
+	type projectTopics struct {
+		project    desktopProject
+		titles     map[string]string
+		createdAts map[string]int64
+	}
+	projectTopicResults := make([]projectTopics, len(f.Projects))
+	var topicLoadWg sync.WaitGroup
+	for i, p := range f.Projects {
+		i, p := i, p
+		topicLoadWg.Add(1)
+		go func() {
+			defer topicLoadWg.Done()
+			projectTopicResults[i] = projectTopics{
+				project:    p,
+				titles:     loadTopicTitles(p.Root),
+				createdAts: loadTopicCreatedAts(p.Root),
+			}
+		}()
+	}
+	topicLoadWg.Wait()
+	for _, loaded := range projectTopicResults {
+		p := loaded.project
 		title := p.Title
 		if title == "" {
 			title = workspaceName(p.Root)
@@ -3982,15 +4092,15 @@ func (a *App) ListProjectTree() []ProjectNode {
 		}
 
 		// Gather topics: explicit topic list + all known topic titles.
-		titleMap := loadTopicTitles(p.Root)
-		createdMap := loadTopicCreatedAts(p.Root)
+		titleMap := loaded.titles
+		createdMap := loaded.createdAts
 		topicIDs := pinnedTopicIDs(orderedTopicIDs(p.Topics, titleMap), p.PinnedTopics)
 
 		children := make([]ProjectNode, 0, len(topicIDs))
 		for _, tid := range topicIDs {
 			topicTitle := strings.TrimSpace(titleMap[tid])
 			if topicTitle == "" {
-				topicTitle = topicTitleForTab("project", p.Root, tid)
+				topicTitle = defaultTopicTitle
 			}
 			summary := topicSummaries[topicSummaryKey("project", p.Root, tid)]
 			open, running, status := topicRuntimeStatus(topicSummaryKey("project", p.Root, tid))
@@ -4598,9 +4708,8 @@ func (c *sessionListCache) invalidate() {
 
 var projectSessionCache = &sessionListCache{byDir: map[string]sessionListCacheEntry{}}
 
-// mergeSessionInfos merges one directory's session listing into the shared maps
-// used by ListProjectTree. Called concurrently from multiple goroutines, each
-// processing a different session directory; the caller must hold mergeMu.
+// mergeSessionInfos merges one directory's session listing into the maps used by
+// ListProjectTree. The result collection loop calls it serially.
 func mergeSessionInfos(dir string, infos []agent.SessionInfo, titles map[string]string, sessionInfos map[string]agent.SessionInfo, sessionTitles map[string]string, topicSummaries map[string]topicSummary) {
 	for _, info := range infos {
 		sessionKey := sessionRuntimeKey(info.Path)

--- a/desktop/tabs_order_test.go
+++ b/desktop/tabs_order_test.go
@@ -51,6 +51,15 @@ func assertTabIDs(t *testing.T, got []TabMeta, want ...string) {
 	}
 }
 
+type resetCountingSession struct {
+	control.SessionAPI
+	resets int
+}
+
+func (s *resetCountingSession) ResetPlannerSession() {
+	s.resets++
+}
+
 func TestListTabsKeepsExplicitOrderWhenActiveChanges(t *testing.T) {
 	app := testAppWithOrderedTabs(t, "b", "a", "b", "c")
 
@@ -61,6 +70,24 @@ func TestListTabsKeepsExplicitOrderWhenActiveChanges(t *testing.T) {
 	assertTabIDs(t, app.ListTabs(), "a", "b", "c")
 	if got := app.activeTabID; got != "c" {
 		t.Fatalf("active tab = %q, want c", got)
+	}
+}
+
+func TestSetActiveTabDoesNotResetPlannerSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	ctrlA := &resetCountingSession{SessionAPI: control.New(control.Options{Label: "a"})}
+	ctrlB := &resetCountingSession{SessionAPI: control.New(control.Options{Label: "b"})}
+	defer ctrlA.Close()
+	defer ctrlB.Close()
+	app := testAppWithOrderedTabs(t, "a", "a", "b")
+	app.tabs["a"].Ctrl = ctrlA
+	app.tabs["b"].Ctrl = ctrlB
+
+	if err := app.SetActiveTab("b"); err != nil {
+		t.Fatalf("SetActiveTab: %v", err)
+	}
+	if ctrlA.resets != 0 || ctrlB.resets != 0 {
+		t.Fatalf("planner resets on tab activation = active:%d inactive:%d, want 0", ctrlA.resets, ctrlB.resets)
 	}
 }
 
@@ -141,6 +168,23 @@ func TestCloseActiveTabChoosesNeighborByOrder(t *testing.T) {
 	assertTabIDs(t, app.ListTabs(), "a")
 	if got := app.activeTabID; got != "a" {
 		t.Fatalf("active tab after closing last = %q, want a", got)
+	}
+}
+
+func TestCloseActiveTabDoesNotResetSurvivorPlannerSession(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	ctrlClosed := control.New(control.Options{Label: "closed"})
+	ctrlSurvivor := &resetCountingSession{SessionAPI: control.New(control.Options{Label: "survivor"})}
+	defer ctrlSurvivor.Close()
+	app := testAppWithOrderedTabs(t, "a", "a", "b")
+	app.tabs["a"].Ctrl = ctrlClosed
+	app.tabs["b"].Ctrl = ctrlSurvivor
+
+	if err := app.CloseTab("a"); err != nil {
+		t.Fatalf("CloseTab: %v", err)
+	}
+	if ctrlSurvivor.resets != 0 {
+		t.Fatalf("survivor planner resets = %d, want 0", ctrlSurvivor.resets)
 	}
 }
 

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -175,6 +175,52 @@ func TestRenameSessionInvalidatesProjectTreeCache(t *testing.T) {
 	}
 }
 
+func TestTopicMetadataUpdatesPreserveExistingEntriesWhenTimedReadSlotsFull(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	if err := saveTopicTitles(projectRoot, map[string]string{"old": "Old"}); err != nil {
+		t.Fatalf("save old title: %v", err)
+	}
+	if err := saveTopicTitleSources(projectRoot, map[string]string{"old": topicTitleSourceManual}); err != nil {
+		t.Fatalf("save old source: %v", err)
+	}
+	if err := saveTopicCreatedAts(projectRoot, map[string]int64{"old": 100}); err != nil {
+		t.Fatalf("save old created-at: %v", err)
+	}
+
+	release := occupyReadFileWithTimeoutSlots(t)
+	if err := setTopicTitleWithSource(projectRoot, "new", "New", topicTitleSourceAuto); err != nil {
+		t.Fatalf("setTopicTitleWithSource: %v", err)
+	}
+	if err := setTopicCreatedAt(projectRoot, "new", 200); err != nil {
+		t.Fatalf("setTopicCreatedAt: %v", err)
+	}
+	release()
+
+	titles := loadTopicTitles(projectRoot)
+	if got := titles["old"]; got != "Old" {
+		t.Fatalf("old title = %q, want Old (all titles: %v)", got, titles)
+	}
+	if got := titles["new"]; got != "New" {
+		t.Fatalf("new title = %q, want New (all titles: %v)", got, titles)
+	}
+	sources := loadTopicTitleSources(projectRoot)
+	if got := sources["old"]; got != topicTitleSourceManual {
+		t.Fatalf("old source = %q, want %q (all sources: %v)", got, topicTitleSourceManual, sources)
+	}
+	if got := sources["new"]; got != topicTitleSourceAuto {
+		t.Fatalf("new source = %q, want %q (all sources: %v)", got, topicTitleSourceAuto, sources)
+	}
+	created := loadTopicCreatedAts(projectRoot)
+	if got := created["old"]; got != 100 {
+		t.Fatalf("old created-at = %d, want 100 (all created: %v)", got, created)
+	}
+	if got := created["new"]; got != 200 {
+		t.Fatalf("new created-at = %d, want 200 (all created: %v)", got, created)
+	}
+}
+
 func TestDeleteTopicKeepsSessionHistory(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1561,7 +1561,7 @@ func (c *Controller) NewSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true // NewSession fires SessionStart itself; don't re-fire on the next turn
@@ -1605,7 +1605,7 @@ func (c *Controller) ClearSession() error {
 	}
 	c.setActiveJobSession(c.SessionPath())
 	c.executor.SetSession(agent.NewSession(c.systemPrompt))
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.rebindCheckpoints(c.SessionPath())
 	c.mu.Lock()
 	c.startedOnce = true
@@ -1826,7 +1826,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	}
 	if switchToFork {
 		c.executor.SetSession(sess)
-		c.resetPlannerSession()
+		c.ResetPlannerSession()
 		c.mu.Lock()
 		c.sessionPath = newPath
 		c.mu.Unlock()
@@ -1896,7 +1896,7 @@ func (c *Controller) Branch(name string) (string, error) {
 		return "", c.rewindFail(err)
 	}
 	c.executor.SetSession(sess)
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = newPath
 	c.mu.Unlock()
@@ -1947,7 +1947,7 @@ func (c *Controller) SwitchBranch(ref string) (agent.BranchInfo, error) {
 	if c.executor != nil {
 		c.executor.SetSession(loaded)
 	}
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = match.Path
 	c.mu.Unlock()
@@ -2047,7 +2047,7 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	if c.executor != nil {
 		c.executor.SetSession(s)
 	}
-	c.resetPlannerSession()
+	c.ResetPlannerSession()
 	c.mu.Lock()
 	c.sessionPath = path
 	c.mu.Unlock()
@@ -2056,7 +2056,11 @@ func (c *Controller) Resume(s *agent.Session, path string) {
 	c.maybeColdResumePrune(path)
 }
 
-func (c *Controller) resetPlannerSession() {
+// ResetPlannerSession clears the planner's conversation history so the next
+// plan starts fresh. In dual-model (Plan+Execute) mode, this prevents stale
+// planner output from a previous session or tab from contaminating the current
+// executor's handoff. Safe to call on a single-model controller (no-op).
+func (c *Controller) ResetPlannerSession() {
 	runner, ok := c.runner.(plannerSessionResetter)
 	if ok {
 		runner.ResetPlannerSession()

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -551,6 +551,43 @@ func TestResumeResetsTwoModelPlannerContext(t *testing.T) {
 	}
 }
 
+func TestResetPlannerSessionClearsPlannerHistory(t *testing.T) {
+	dir := t.TempDir()
+	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{
+		textTurn("FIRST PLAN: inspect alpha.go"),
+		textTurn("SECOND PLAN: inspect beta.go"),
+	}}
+	execProv := &recordingProvider{name: "executor", streams: [][]provider.Chunk{
+		textTurn("first done"),
+		textTurn("second done"),
+	}}
+	exec := agent.New(execProv, tool.NewRegistry(), agent.NewSession("exec sys"), agent.Options{}, event.Discard)
+	plannerSess := agent.NewSession("planner sys")
+	coord := agent.NewCoordinator(planner, plannerSess, nil, tool.NewRegistry(), agent.Options{}, exec, 0, event.Discard, nil)
+	path := filepath.Join(dir, "session.jsonl")
+	c := New(Options{Runner: coord, Executor: exec, SystemPrompt: "exec sys", SessionDir: dir, SessionPath: path, Label: "test"})
+
+	if err := c.Run(context.Background(), "first task"); err != nil {
+		t.Fatal(err)
+	}
+	// Explicitly reset the planner session (simulates a tab switch).
+	c.ResetPlannerSession()
+	if err := c.Run(context.Background(), "second task"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(planner.requests) != 2 {
+		t.Fatalf("planner requests = %d, want 2", len(planner.requests))
+	}
+	second := requestMessagesText(planner.requests[1].Messages)
+	if strings.Contains(second, "first task") || strings.Contains(second, "FIRST PLAN") {
+		t.Fatalf("planner request after reset leaked previous session context:\n%s", second)
+	}
+	if !strings.Contains(second, "second task") {
+		t.Fatalf("planner request after reset missing current task:\n%s", second)
+	}
+}
+
 func TestSubmitClearDiscardsCurrentContextWithoutSavingTranscript(t *testing.T) {
 	dir := t.TempDir()
 	sess := agent.NewSession("sys")

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -91,6 +91,7 @@ type Goals interface {
 	GoalStrict(strict bool)
 	ClearGoal()
 	AutoStartResearchGoal(input string) (string, bool)
+	ResetPlannerSession()
 	PlanMode() bool
 	SetPlanMode(v bool)
 	SetAutoPlan(mode string)


### PR DESCRIPTION
## Summary

This integration PR combines the directly related desktop sidebar/session runtime work into one conflict-resolved branch on top of `main-v2`.

It keeps the useful sidebar resilience and performance pieces while avoiding the unsafe full `ProjectNode` result cache from #4889: runtime fields are recomputed on each `ListProjectTree` call, so `Open`, `Running`, and `Status` cannot be served from stale tree state.

## Integrated PR contributions

| Source PR | Author | Contribution carried into this PR |
| --- | --- | --- |
| #4858 | @ttmouse | Baseline sidebar session-list performance work already merged into `main-v2`; this PR builds on that cache/fan-out direction instead of replacing it. |
| #4889 | @ttmouse | Bounded sidebar sidecar reads for read-only listing paths, serialized `ListProjectTree` rebuilds, concurrent project topic sidecar loading, avoiding repeated topic-title file reads, and path-scoped single-instance IDs. The unsafe full-tree result cache and un-migrated config-dir move are intentionally not included. |
| #4776 | @GTC2080 | Release removed session runtimes before moving session artifacts to trash, preserving Windows file-handle safety and autosave regression coverage. |
| #4934 | @liaoyl830 | Preserve planner isolation around real desktop session/controller changes. Pure tab activation is intentionally not reset after follow-up review so a tab keeps its own planner history when the user returns to it. |
| #4400 | @myipanta | Snapshot writable tabs before unregistering them so CloseTab/DeleteSession cannot resurrect deleted session files, while read-only channel transcripts remain browse-only on close. |

## Notes

- `REASONIX_DEV` still skips the single-instance lock for contributor workflows.
- `desktopConfigDir()` remains on the existing platform config path; this PR does not move tabs/projects to `~/.reasonix` without migration.
- The timeout path does not let late session-directory goroutines write shared tree maps after `ListProjectTree` has moved on.
- Metadata load-modify-save paths do not use the bounded listing timeout, so a transient slow read cannot overwrite sidecars with an empty map.
- No provider-visible prompt prefix, tool schema, provider serialization, or cache-impact surface is changed.

## Verification

- `go test -run 'TestSingleInstance|TestOpenProjectTabResolvesProjectSessionFromLegacyDir|TestProjectTreeShowsBackgroundJobStatus|TestCloseTabNoResurrectionFromAutosave|TestTurnDonePersistsSession|TestTrashTopic|TestDeleteSession' -count=1`
- `go test -run 'TestSetSessionTitlePreservesExistingTitlesWhenTimedReadSlotsFull|TestTopicMetadataUpdatesPreserveExistingEntriesWhenTimedReadSlotsFull|TestSetActiveTabDoesNotResetPlannerSession|TestCloseActiveTabDoesNotResetSurvivorPlannerSession|TestCloseReadOnlyChannelTabDoesNotSnapshotTranscript|TestOpenChannelSessionForTabIsReadOnly' -count=1`
- `go test ./...` from `desktop/`
- `git diff --check origin/main-v2...HEAD`
