### PR TITLE
Support codebase-memory MCP auto-indexing / 支持 codebase-memory MCP 自动索引

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -415,9 +415,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				// subprocess only starts on the first actual tool call.
 				// This avoids spawning MCP processes (e.g. CodeGraph) for
 				// every workspace root on boot — a tab that sits unused for
-				// days never pays the startup cost.
+				// days never pays the startup cost. Known session indexers can
+				// opt in because their initialize handshake is the auto-index
+				// trigger for the active workspace root.
 				cs, _ := plugin.LoadCachedSchema(s.Name, plugin.SpecFingerprint(s))
-				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, false) {
+				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, kick && s.SharedHostBackgroundStart) {
 					reg.Add(t)
 				}
 			} else {

--- a/internal/plugin/known_overrides.go
+++ b/internal/plugin/known_overrides.go
@@ -1,6 +1,9 @@
 package plugin
 
-import "strings"
+import (
+	"path/filepath"
+	"strings"
+)
 
 const (
 	codeGraphDaemonIdleTimeoutEnv = "CODEGRAPH_DAEMON_IDLE_TIMEOUT_MS"
@@ -27,6 +30,21 @@ func ApplyKnownOverrides(s Spec, workspaceRoot string) Spec {
 		// never wired to the spec, so it stayed disabled.
 		s.LowPriority = true
 	}
+	if isCodebaseMemorySpec(s) {
+		if isStdioSpecType(s.Type) && s.Dir == "" {
+			s.Dir = strings.TrimSpace(workspaceRoot)
+		}
+		// codebase-memory-mcp detects the session root from its subprocess cwd
+		// during initialize, then optionally starts its own auto-index thread.
+		// Connect the background-tier server at tab startup so that handshake can
+		// happen without waiting for the first model tool call.
+		if isStdioSpecType(s.Type) {
+			s.SharedHostBackgroundStart = true
+		}
+		// Its initial full-tree indexing can be CPU-heavy; keep it out of the
+		// foreground scheduling lane just like CodeGraph.
+		s.LowPriority = true
+	}
 	return s
 }
 
@@ -39,6 +57,42 @@ func ApplyKnownReadOnlyOverrides(s Spec) Spec {
 
 func isCodeGraphSpecName(name string) bool {
 	return strings.EqualFold(strings.TrimSpace(name), "codegraph")
+}
+
+func isCodebaseMemorySpec(s Spec) bool {
+	if isCodebaseMemoryID(s.Name) || isCodebaseMemoryCommand(s.Command) {
+		return true
+	}
+	for _, arg := range s.Args {
+		if isCodebaseMemoryID(arg) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCodebaseMemoryCommand(command string) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	command = strings.ReplaceAll(command, `\`, `/`)
+	return isCodebaseMemoryID(filepath.Base(command))
+}
+
+func isCodebaseMemoryID(raw string) bool {
+	id := strings.ToLower(strings.TrimSpace(raw))
+	id = strings.TrimSuffix(id, ".exe")
+	id = strings.TrimPrefix(id, "io.github.deusdata/")
+	if strings.HasPrefix(id, "codebase-memory-mcp@") {
+		return true
+	}
+	switch id {
+	case "codebase-memory-mcp", "codebase-memory":
+		return true
+	default:
+		return false
+	}
 }
 
 func isStdioSpecType(typ string) bool {

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -61,6 +61,10 @@ type Spec struct {
 	// LowPriority runs a stdio subprocess below normal scheduling priority, for
 	// background indexers that must not starve the user's machine.
 	LowPriority bool
+	// SharedHostBackgroundStart lets a known background-tier stdio server connect
+	// at desktop tab startup even when the host is shared by several tabs. Keep
+	// this opt-in: most background MCP servers should stay deferred until used.
+	SharedHostBackgroundStart bool
 }
 
 // transport carries JSON-RPC messages to and from one MCP server. call sends a

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -143,6 +143,41 @@ func TestApplyKnownOverridesPinsCodeGraphStdioToWorkspace(t *testing.T) {
 	}
 }
 
+func TestApplyKnownOverridesPinsCodebaseMemoryToWorkspace(t *testing.T) {
+	got := ApplyKnownOverrides(Spec{Name: "codebase-memory-mcp"}, "/workspace")
+	if got.Dir != "/workspace" {
+		t.Fatalf("codebase-memory-mcp stdio Dir = %q, want workspace root", got.Dir)
+	}
+	if !got.SharedHostBackgroundStart {
+		t.Fatalf("codebase-memory-mcp should opt into shared-host background start")
+	}
+	if !got.LowPriority {
+		t.Fatalf("codebase-memory-mcp should run at low priority")
+	}
+
+	preset := ApplyKnownOverrides(Spec{Name: "codebase-memory-mcp", Dir: "/custom"}, "/workspace")
+	if preset.Dir != "/custom" {
+		t.Fatalf("existing Dir should be preserved, got %q", preset.Dir)
+	}
+
+	httpSpec := ApplyKnownOverrides(Spec{Name: "codebase-memory-mcp", Type: "http"}, "/workspace")
+	if httpSpec.Dir != "" {
+		t.Fatalf("http codebase-memory-mcp should not receive stdio Dir, got %q", httpSpec.Dir)
+	}
+	if httpSpec.SharedHostBackgroundStart {
+		t.Fatalf("http codebase-memory-mcp should not opt into shared-host background start")
+	}
+
+	npxSpec := ApplyKnownOverrides(Spec{
+		Name:    "custom",
+		Command: "npx",
+		Args:    []string{"-y", "codebase-memory-mcp@latest"},
+	}, "/workspace")
+	if npxSpec.Dir != "/workspace" || !npxSpec.SharedHostBackgroundStart {
+		t.Fatalf("npx codebase-memory-mcp override missing: %+v", npxSpec)
+	}
+}
+
 func TestApplyKnownOverridesPreservesConfiguredCodeGraphDaemonIdleTimeout(t *testing.T) {
 	got := ApplyKnownOverrides(Spec{
 		Name: "codegraph",


### PR DESCRIPTION
## Summary
- Pin codebase-memory-mcp stdio servers to the active workspace root so its session detection sees the opened project.
- Let known session indexers opt into shared-host background startup, allowing codebase-memory-mcp initialize-time auto-indexing to run when a desktop tab opens.
- Keep the behavior scoped to codebase-memory-mcp so existing CodeGraph and generic MCP startup behavior stays unchanged.

## Cache Review
Cache-impact: low - touches MCP/boot runtime wiring but does not change prompt text, tool schemas, or schema ordering; the new startup opt-in is scoped to codebase-memory-mcp.
Cache-guard: `scripts/check-cache-impact.sh` plus `go test ./internal/plugin ./internal/boot`.
System-prompt-review: Codex reviewed the boot/plugin diff under the Reasonix cache gate; no system prompt bytes, memory prefix, or provider-visible tool schema content changed.

## Verification
- `go test ./internal/plugin ./internal/boot`
- `scripts/check-cache-impact.sh`
- `git diff --check`
