### PR TITLE
兼容ps7

### DIFF
--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -125,7 +125,7 @@ func TestResolveShellDecisionTable(t *testing.T) {
 		{"wsl bash on PATH, no git → powershell not wsl", "windows", onPath("bash", "powershell"), gitBash, never, always, wslIsPathBash, ShellPowerShell, ""},
 	}
 	for _, c := range cases {
-		got := resolveShell("", "", nil, c.goos, c.lookPath, c.exists, c.candidates, c.probe, c.isWSL)
+		got := resolveShell("", "", nil, c.goos, c.lookPath, c.exists, c.candidates, nil, c.probe, c.isWSL)
 		if got.Kind != c.wantKind {
 			t.Errorf("%s: kind = %s, want %s (path=%s)", c.name, got.Kind, c.wantKind, got.Path)
 		}
@@ -154,26 +154,35 @@ func TestResolveShellPrefer(t *testing.T) {
 	noWSL := func(string) bool { return false }
 
 	// prefer=powershell forces PowerShell even when bash is present and probes ok.
-	got := resolveShell("powershell", "", nil, "windows", onPath("bash", "powershell", "pwsh"), never, gitBash, always, noWSL)
+	got := resolveShell("powershell", "", nil, "windows", onPath("bash", "powershell", "pwsh"), never, gitBash, nil, always, noWSL)
 	if got.Kind != ShellPowerShell {
 		t.Errorf(`prefer="powershell": kind = %s, want powershell`, got.Kind)
 	}
 
 	// prefer=bash forces bash even on a host where PowerShell exists.
-	got = resolveShell("bash", "", nil, "windows", onPath("bash", "powershell"), never, gitBash, always, noWSL)
+	got = resolveShell("bash", "", nil, "windows", onPath("bash", "powershell"), never, gitBash, nil, always, noWSL)
 	if got.Kind != ShellBash {
 		t.Errorf(`prefer="bash": kind = %s, want bash`, got.Kind)
 	}
 
 	// An explicit path is honoured for the forced kind.
-	got = resolveShell("pwsh", `C:\custom\pwsh.exe`, nil, "windows", onPath(), always, gitBash, never, noWSL)
+	got = resolveShell("pwsh", `C:\custom\pwsh.exe`, nil, "windows", onPath(), always, gitBash, nil, never, noWSL)
 	if got.Kind != ShellPowerShell || got.Path != `C:\custom\pwsh.exe` {
 		t.Errorf(`prefer="pwsh" path: got {%s %q}, want {powershell "C:\custom\pwsh.exe"}`, got.Kind, got.Path)
 	}
 
+	// prefer=pwsh finds PowerShell 7 in its standard install path even when that
+	// directory has not been added to PATH.
+	got = resolveShell("pwsh", "", nil, "windows", onPath("powershell"), func(p string) bool {
+		return p == `C:/Program Files/PowerShell/7/pwsh.exe`
+	}, gitBash, []string{`C:/Program Files/PowerShell/7/pwsh.exe`}, never, noWSL)
+	if got.Kind != ShellPowerShell || got.Path != `C:/Program Files/PowerShell/7/pwsh.exe` {
+		t.Errorf(`prefer="pwsh" standard path: got {%s %q}, want {powershell "C:/Program Files/PowerShell/7/pwsh.exe"}`, got.Kind, got.Path)
+	}
+
 	// A forced shell that isn't installed warns and falls back to auto-detection.
 	var warn strings.Builder
-	got = resolveShell("powershell", "", &warn, "linux", onPath("bash"), never, gitBash, always, noWSL)
+	got = resolveShell("powershell", "", &warn, "linux", onPath("bash"), never, gitBash, nil, always, noWSL)
 	if got.Kind != ShellBash {
 		t.Errorf("missing forced powershell should fall back to bash, got %s", got.Kind)
 	}
@@ -182,7 +191,7 @@ func TestResolveShellPrefer(t *testing.T) {
 	}
 
 	// An unrecognised value is treated as auto, not an error.
-	got = resolveShell("fish", "", nil, "windows", onPath("bash"), never, gitBash, always, noWSL)
+	got = resolveShell("fish", "", nil, "windows", onPath("bash"), never, gitBash, nil, always, noWSL)
 	if got.Kind != ShellBash {
 		t.Errorf("unknown prefer should auto-detect, got %s", got.Kind)
 	}

--- a/internal/sandbox/shell.go
+++ b/internal/sandbox/shell.go
@@ -49,14 +49,14 @@ type Shell struct {
 // warning to warn and falling back to auto-detection if the forced one is
 // missing — so a typo or an uninstalled shell can never leave the tool broken.
 func ResolveShell(prefer, path string, warn io.Writer) Shell {
-	return resolveShell(prefer, path, warn, runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates(), probeBash, isWindowsWSLBash)
+	return resolveShell(prefer, path, warn, runtime.GOOS, exec.LookPath, fileExists, windowsBashCandidates(), windowsPowerShellCandidates(), probeBash, isWindowsWSLBash)
 }
 
 // resolveShell is ResolveShell with its environment lookups injected — including
 // the Git-for-Windows bash candidates, which derive from %ProgramFiles% and so
 // are empty off Windows — so the decision table is deterministically testable on
 // any host.
-func resolveShell(prefer, path string, warn io.Writer, goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string, probe func(string) bool, isWSL func(string) bool) Shell {
+func resolveShell(prefer, path string, warn io.Writer, goos string, lookPath func(string) (string, error), exists func(string) bool, winBashCandidates []string, winPowerShellCandidates []string, probe func(string) bool, isWSL func(string) bool) Shell {
 	findBash := func() (Shell, bool) {
 		if p, err := lookPath("bash"); err == nil && !isWSL(p) && probe(p) {
 			return Shell{Kind: ShellBash, Path: p}, true
@@ -70,6 +70,15 @@ func resolveShell(prefer, path string, warn io.Writer, goos string, lookPath fun
 	}
 	findPowerShell := func(order []string) (Shell, bool) {
 		for _, name := range order {
+			for _, p := range winPowerShellCandidates {
+				base := strings.ToLower(pathBase(p))
+				if base != strings.ToLower(name) && strings.TrimSuffix(base, ".exe") != strings.ToLower(name) {
+					continue
+				}
+				if exists(p) {
+					return Shell{Kind: ShellPowerShell, Path: p}, true
+				}
+			}
 			if p, err := lookPath(name); err == nil {
 				return Shell{Kind: ShellPowerShell, Path: p}, true
 			}
@@ -167,6 +176,13 @@ func fileExists(p string) bool {
 	return err == nil && !fi.IsDir()
 }
 
+func pathBase(p string) string {
+	if i := strings.LastIndexAny(p, `/\\`); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}
+
 // windowsBashCandidates lists the bash.exe paths a Git-for-Windows install
 // ships, across the usual program-files roots and a per-user install.
 func windowsBashCandidates() []string {
@@ -185,6 +201,27 @@ func windowsBashCandidates() []string {
 			filepath.Join(r, "Git", "bin", "bash.exe"),
 			filepath.Join(r, "Git", "usr", "bin", "bash.exe"),
 		)
+	}
+	return out
+}
+
+// windowsPowerShellCandidates lists common PowerShell executables that are not
+// always present on PATH, especially PowerShell 7's default MSI install path.
+func windowsPowerShellCandidates() []string {
+	var roots []string
+	for _, env := range []string{"ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"} {
+		if v := os.Getenv(env); v != "" {
+			roots = append(roots, v)
+		}
+	}
+	var out []string
+	for _, r := range roots {
+		out = append(out, filepath.Join(r, "PowerShell", "7", "pwsh.exe"))
+	}
+	if v := os.Getenv("SystemRoot"); v != "" {
+		out = append(out, filepath.Join(v, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"))
+	} else if v := os.Getenv("windir"); v != "" {
+		out = append(out, filepath.Join(v, "System32", "WindowsPowerShell", "v1.0", "powershell.exe"))
 	}
 	return out
 }
@@ -224,9 +261,6 @@ func (s Shell) SupportsChaining() bool {
 	if s.Kind != ShellPowerShell {
 		return true
 	}
-	base := strings.ToLower(s.Path)
-	if i := strings.LastIndexAny(base, `/\`); i >= 0 {
-		base = base[i+1:] // Windows path; split on either separator off-Windows too
-	}
+	base := strings.ToLower(pathBase(s.Path))
 	return base == "pwsh" || base == "pwsh.exe"
 }

--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -75,15 +75,22 @@ type bash struct {
 func (bash) Name() string { return "bash" }
 
 func (b bash) Description() string {
-	if b.resolved().Kind == sandbox.ShellPowerShell {
-		return "Execute a command in the shell and return combined stdout/stderr. " +
-			"NOTE: bash is not available on this host — commands run under Windows PowerShell, so write PowerShell, not bash:\n" +
-			"  - chaining: ';' runs both regardless; 'if ($?) { ... }' is conditional. '&&' and '||' are NOT parsed.\n" +
-			"  - redirect/vars: $null not /dev/null; $env:VAR not $VAR; '2>$null' drops stderr.\n" +
-			"  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Select-String (grep).\n" +
-			"  - no head/tail/which/touch: use Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n" +
-			"  - multi-line text to a native exe (e.g. git commit -m): use a single-quoted here-string @'...'@ (closing '@ at column 0)." +
-			bashToolSteer
+	sh := b.resolved()
+	if sh.Kind == sandbox.ShellPowerShell {
+		shellName := "Windows PowerShell"
+		chaining := "';' runs both regardless; 'if ($?) { ... }' is conditional. '&&' and '||' are NOT parsed."
+		if sh.SupportsChaining() {
+			shellName = "PowerShell 7 (pwsh)"
+			chaining = "'&&' and '||' are parsed for conditional chaining; ';' runs both regardless."
+		}
+		return fmt.Sprintf("Execute a command in the shell and return combined stdout/stderr. "+
+			"NOTE: bash is not available on this host — commands run under %s, so write PowerShell, not bash:\n"+
+			"  - chaining: %s\n"+
+			"  - redirect/vars: $null not /dev/null; $env:VAR not $VAR; '2>$null' drops stderr.\n"+
+			"  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Select-String (grep).\n"+
+			"  - no head/tail/which/touch: use Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n"+
+			"  - multi-line text to a native exe (e.g. git commit -m): use a single-quoted here-string @'...'@ (closing '@ at column 0)."+
+			bashToolSteer, shellName, chaining)
 	}
 	return "Execute a command in the shell and return combined stdout/stderr." + bashToolSteer
 }

--- a/internal/tool/builtin/bash_powershell_test.go
+++ b/internal/tool/builtin/bash_powershell_test.go
@@ -103,8 +103,23 @@ func TestBashPowerShellOutputIsUTF8(t *testing.T) {
 
 func TestBashDescriptionReflectsShell(t *testing.T) {
 	ps := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "powershell"}}
-	if !strings.Contains(ps.Description(), "PowerShell") {
-		t.Errorf("powershell description should warn about PowerShell: %q", ps.Description())
+	psDesc := ps.Description()
+	if !strings.Contains(psDesc, "Windows PowerShell") {
+		t.Errorf("powershell description should name Windows PowerShell: %q", psDesc)
+	}
+	if !strings.Contains(psDesc, "'&&' and '||' are NOT parsed") {
+		t.Errorf("powershell description should warn about unsupported chaining: %q", psDesc)
+	}
+	pwsh := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "pwsh"}}
+	pwshDesc := pwsh.Description()
+	if !strings.Contains(pwshDesc, "PowerShell 7 (pwsh)") {
+		t.Errorf("pwsh description should name PowerShell 7: %q", pwshDesc)
+	}
+	if !strings.Contains(pwshDesc, "'&&' and '||' are parsed") {
+		t.Errorf("pwsh description should allow conditional chaining: %q", pwshDesc)
+	}
+	if strings.Contains(pwshDesc, "NOT parsed") {
+		t.Errorf("pwsh description should not reuse the Windows PowerShell chaining warning: %q", pwshDesc)
 	}
 	sh := bash{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "bash"}}
 	if strings.Contains(sh.Description(), "PowerShell") {


### PR DESCRIPTION
## Summary

- Updated shell resolution to look for PowerShell executables in common Windows install locations, including:
  - `C:\Program Files\PowerShell\7\pwsh.exe`
  - Windows PowerShell fallback under `%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`
- Added test coverage for resolving `pwsh` from the standard PowerShell 7 install path when it is not on `PATH`.
- Reused a shared path basename helper for Windows-style paths.
- Aligned the bash tool description with `Shell.SupportsChaining()` so Windows PowerShell still warns that `&&` and `||` are not parsed, while PowerShell 7 (`pwsh`) is described as supporting conditional chaining.
- Merged the latest `main-v2` into the PR branch to clear stale-base compile risk.

## Cache impact

Cache-impact: low - this changes provider-visible bash tool guidance when PowerShell is selected, but the text remains deterministic and derived from the resolved shell capability.

Cache-guard: `go test ./internal/boot -run 'TestToolOrder|Test.*Cache|TestBuildDiscoversSkills'`; `go test ./internal/tool/builtin`; `go test ./...`.

## Verification

- `go test ./internal/sandbox`
- `go test ./internal/tool/builtin`
- `go test ./internal/boot -run 'TestToolOrder|Test.*Cache|TestBuildDiscoversSkills'`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

Fixes #4903

Authorship note: @linze0721 is the primary author of this PR. @SivanCola contributed as a collaborator by reviewing the PS7 shell behavior, adding the follow-up tool-description fix, merging the latest `main-v2`, and verifying the final state.