### PR TITLE
引入文件导致会话摘要显示异常

### DIFF
--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1390,6 +1390,29 @@ func TestAutoTitleTopicStripsReasoningLanguagePrefix(t *testing.T) {
 	}
 }
 
+func TestAutoTitleTopicStripsReferencedContextPrefix(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	topic, err := NewApp().CreateTopic("project", projectRoot, "")
+	if err != nil {
+		t.Fatalf("create topic: %v", err)
+	}
+	prompt := "Referenced context:\n\n<file path=\"README.md\">\n# Reasonix\n</file>\n\n总结这个文件"
+	sessionPath := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(sessionPath, []byte(`{"role":"user","content":`+strconv.Quote(prompt)+`}`+"\n"), 0o644); err != nil {
+		t.Fatalf("write session: %v", err)
+	}
+
+	title, updated := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath)
+	if !updated {
+		t.Fatal("auto title should update")
+	}
+	if title != "总结这个文件" {
+		t.Fatalf("generated title = %q", title)
+	}
+}
+
 func TestAutoTitleDoesNotOverrideManualTopicTitle(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/internal/agent/preview.go
+++ b/internal/agent/preview.go
@@ -25,10 +25,59 @@ func StripTransientUserBlocks(content string) string {
 	return strings.TrimLeft(s, " \t\r\n")
 }
 
+// StripInjectedContext removes model-facing context blocks prepended to a user
+// turn (for example the resolved contents of @file references) and returns the
+// user-authored prompt that followed them. The injected block is persisted as part
+// of the user message so the model can see it, but previews/titles should be
+// based on what the user actually typed.
+func StripInjectedContext(content string) string {
+	s := strings.TrimLeft(content, " \t\r\n")
+	const marker = "Referenced context:"
+	if !strings.HasPrefix(s, marker) {
+		return content
+	}
+	rest := strings.TrimLeft(s[len(marker):], " \t\r\n")
+	consumed := false
+	for {
+		rest = strings.TrimLeft(rest, " \t\r\n")
+		if !strings.HasPrefix(rest, "<") {
+			break
+		}
+		endOpen := strings.IndexByte(rest, '>')
+		if endOpen < 0 {
+			break
+		}
+		tag := rest[1:endOpen]
+		if i := strings.IndexAny(tag, " \t\r\n"); i >= 0 {
+			tag = tag[:i]
+		}
+		if tag == "" || strings.HasPrefix(tag, "/") {
+			break
+		}
+		closeTag := "</" + tag + ">"
+		endClose := strings.Index(rest[endOpen+1:], closeTag)
+		if endClose < 0 {
+			break
+		}
+		rest = rest[endOpen+1+endClose+len(closeTag):]
+		consumed = true
+	}
+	if !consumed {
+		return content
+	}
+	rest = strings.TrimLeft(rest, " \t\r\n")
+	if strings.HasPrefix(rest, marker) {
+		return StripInjectedContext(rest)
+	}
+	return strings.TrimSpace(rest)
+}
+
 // UserPreviewText returns the user-authored part of a persisted user message.
 func UserPreviewText(content string) string {
 	s := StripTransientUserBlocks(content)
+	s = StripInjectedContext(s)
 	s = HandoffTask(s)
 	s = StripTransientUserBlocks(s)
+	s = StripInjectedContext(s)
 	return strings.TrimSpace(s)
 }

--- a/internal/agent/preview_test.go
+++ b/internal/agent/preview_test.go
@@ -1,0 +1,32 @@
+package agent
+
+import "testing"
+
+func TestUserPreviewTextStripsReferencedContext(t *testing.T) {
+	content := "Referenced context:\n\n" +
+		"<file path=\"README.md\">\n# Reasonix\n</file>\n\n" +
+		"请总结这个文件"
+
+	if got := UserPreviewText(content); got != "请总结这个文件" {
+		t.Fatalf("UserPreviewText = %q, want user prompt", got)
+	}
+}
+
+func TestUserPreviewTextStripsMultipleReferencedContextBlocks(t *testing.T) {
+	content := "Referenced context:\n\n" +
+		"<file path=\"a.go\">\npackage a\n</file>\n\n" +
+		"<dir path=\"docs\">\nintro.md\n</dir>\n\n" +
+		"explain these refs"
+
+	if got := UserPreviewText(content); got != "explain these refs" {
+		t.Fatalf("UserPreviewText = %q, want user prompt", got)
+	}
+}
+
+func TestUserPreviewTextLeavesLiteralReferencedContext(t *testing.T) {
+	content := "Referenced context is a phrase the user typed"
+
+	if got := UserPreviewText(content); got != content {
+		t.Fatalf("UserPreviewText = %q, want literal prompt", got)
+	}
+}

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -45,6 +45,7 @@ func StripComposePrefixes(content string) string {
 	s := agent.StripTransientUserBlocks(content)
 	s = strings.TrimPrefix(s, PlanModeMarker+"\n\n")
 	s = strings.TrimPrefix(s, PlanModeMarker)
+	s = agent.StripInjectedContext(s)
 	s = strings.TrimSpace(s)
 	return s
 }


### PR DESCRIPTION
## Summary

- Added stripping of injected `Referenced context:` blocks when deriving user-facing preview/title text.
- Reused that stripping in `control.StripComposePrefixes`, so desktop fallback display/title generation ignores resolved `@file` contents.
- Added tests covering:
  - user previews with one or multiple referenced context blocks,
  - literal user text containing “Referenced context” remaining unchanged,
  - desktop auto-topic title generation using the actual prompt after an `@file` reference.

Verified:
- `go test ./internal/agent ./internal/control`
- `cd desktop && go test ./...`

Fixes #4954
