### PR TITLE
会话级的 todo 列表被持久化保存了，即使清空也会被 relaod。

### DIFF
--- a/desktop/frontend/src/__tests__/tool-data-archive.test.ts
+++ b/desktop/frontend/src/__tests__/tool-data-archive.test.ts
@@ -316,7 +316,7 @@ console.log("\ntool data archiving on tool_result");
   eq(failedTodo?.status, "error", "failed todo_write keeps error status");
 }
 
-// ── Test 10: A successful empty todo_write clears without losing older args ──
+// ── Test 10: A successful empty todo_write becomes canonical without unarchiving older args ──
 {
   const oldArgs = todoArgs("old");
   const clearArgs = `{"todos":[]}`;
@@ -330,8 +330,10 @@ console.log("\ntool data archiving on tool_result");
   const tools = toolItems(s);
   const oldTodo = tools.find((tool) => tool.id === "todo-old");
   const clearTodo = tools.find((tool) => tool.id === "todo-clear");
-  eq(oldTodo?.args, oldArgs, "older todo_write args survive when latest todo_write clears the list");
-  eq(clearTodo?.args, clearArgs, "empty todo_write clear keeps parseable args");
+  ok((oldTodo?.args.length ?? 0) <= 205, "older todo_write args stay archived when latest todo_write clears the list");
+  ok(oldTodo?.args !== oldArgs, "older todo_write does not keep full JSON after a clear");
+  eq(clearTodo?.args, clearArgs, "empty todo_write clear keeps parseable canonical args");
+  eq(JSON.parse(clearTodo?.args ?? "{}").todos.length, 0, "empty todo_write clear remains parseable as the latest canonical list");
 }
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);

--- a/desktop/frontend/src/__tests__/tool-data-archive.test.ts
+++ b/desktop/frontend/src/__tests__/tool-data-archive.test.ts
@@ -316,5 +316,23 @@ console.log("\ntool data archiving on tool_result");
   eq(failedTodo?.status, "error", "failed todo_write keeps error status");
 }
 
+// ── Test 10: A successful empty todo_write clears without losing older args ──
+{
+  const oldArgs = todoArgs("old");
+  const clearArgs = `{"todos":[]}`;
+  let s = initialState;
+  s = reducer(s, { type: "event", e: { kind: "turn_started" } });
+  s = reducer(s, { type: "event", e: { kind: "tool_dispatch", tool: { id: "todo-old", name: "todo_write", args: oldArgs, readOnly: true } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_result", tool: { id: "todo-old", name: "todo_write", readOnly: true, output: "Todos updated" } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_dispatch", tool: { id: "todo-clear", name: "todo_write", args: clearArgs, readOnly: true } } });
+  s = reducer(s, { type: "event", e: { kind: "tool_result", tool: { id: "todo-clear", name: "todo_write", readOnly: true, output: "Todos updated" } } });
+
+  const tools = toolItems(s);
+  const oldTodo = tools.find((tool) => tool.id === "todo-old");
+  const clearTodo = tools.find((tool) => tool.id === "todo-clear");
+  eq(oldTodo?.args, oldArgs, "older todo_write args survive when latest todo_write clears the list");
+  eq(clearTodo?.args, clearArgs, "empty todo_write clear keeps parseable args");
+}
+
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -225,15 +225,6 @@ function isCanonicalTodoTool(tool: ToolItem): boolean {
   return tool.name === "todo_write" && !tool.parentId && tool.status === "done" && !tool.error;
 }
 
-function canonicalTodoCount(tool: ToolItem): number {
-  try {
-    const parsed = JSON.parse(tool.args) as { todos?: unknown };
-    return Array.isArray(parsed.todos) ? parsed.todos.length : -1;
-  } catch {
-    return -1;
-  }
-}
-
 function latestCanonicalTodoToolIndex(items: Item[]): number {
   for (let i = items.length - 1; i >= 0; i -= 1) {
     const item = items[i];
@@ -244,10 +235,9 @@ function latestCanonicalTodoToolIndex(items: Item[]): number {
 
 function compactArchivedToolItems(items: Item[]): Item[] {
   const canonicalTodoIndex = latestCanonicalTodoToolIndex(items);
-  const canonicalTodoIsClear = canonicalTodoIndex >= 0 && canonicalTodoCount(items[canonicalTodoIndex] as ToolItem) === 0;
   return items.map((item, index) => {
     if (item.kind !== "tool" || item.status === "running") return item;
-    const preserveArgs = index === canonicalTodoIndex || (canonicalTodoIsClear && isCanonicalTodoTool(item));
+    const preserveArgs = index === canonicalTodoIndex;
     const nextArgs = preserveArgs ? item.args : archivedToolArgs(item.name, item.args);
     if (nextArgs === item.args && item.output === undefined && item.dataArchived === true) return item;
     return {

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -225,6 +225,15 @@ function isCanonicalTodoTool(tool: ToolItem): boolean {
   return tool.name === "todo_write" && !tool.parentId && tool.status === "done" && !tool.error;
 }
 
+function canonicalTodoCount(tool: ToolItem): number {
+  try {
+    const parsed = JSON.parse(tool.args) as { todos?: unknown };
+    return Array.isArray(parsed.todos) ? parsed.todos.length : -1;
+  } catch {
+    return -1;
+  }
+}
+
 function latestCanonicalTodoToolIndex(items: Item[]): number {
   for (let i = items.length - 1; i >= 0; i -= 1) {
     const item = items[i];
@@ -235,9 +244,10 @@ function latestCanonicalTodoToolIndex(items: Item[]): number {
 
 function compactArchivedToolItems(items: Item[]): Item[] {
   const canonicalTodoIndex = latestCanonicalTodoToolIndex(items);
+  const canonicalTodoIsClear = canonicalTodoIndex >= 0 && canonicalTodoCount(items[canonicalTodoIndex] as ToolItem) === 0;
   return items.map((item, index) => {
     if (item.kind !== "tool" || item.status === "running") return item;
-    const preserveArgs = index === canonicalTodoIndex;
+    const preserveArgs = index === canonicalTodoIndex || (canonicalTodoIsClear && isCanonicalTodoTool(item));
     const nextArgs = preserveArgs ? item.args : archivedToolArgs(item.name, item.args);
     if (nextArgs === item.args && item.output === undefined && item.dataArchived === true) return item;
     return {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1040,10 +1040,11 @@ func (a *Agent) rebuildTodoState(msgs []provider.Message) {
 			if tc.Name != "todo_write" || !successful[tc.ID] {
 				continue
 			}
-			if rec := evidence.ReceiptFromToolCall(tc.Name, json.RawMessage(tc.Arguments), true, true); len(rec.Todos) > 0 {
-				todos = append([]evidence.TodoItem(nil), rec.Todos...)
-				baseIdx = i
-			}
+			rec := evidence.ReceiptFromToolCall(tc.Name, json.RawMessage(tc.Arguments), true, true)
+			// A successful empty todo_write is an explicit clear. Preserve it as the
+			// latest base so history reloads do not resurrect an older non-empty list.
+			todos = append([]evidence.TodoItem(nil), rec.Todos...)
+			baseIdx = i
 		}
 	}
 	if baseIdx < 0 {

--- a/internal/agent/canonical_todo_test.go
+++ b/internal/agent/canonical_todo_test.go
@@ -141,6 +141,28 @@ func TestRebuildTodoStateRequiresToolResults(t *testing.T) {
 	}
 }
 
+func TestRebuildTodoStateHonorsEmptyTodoWriteClear(t *testing.T) {
+	msgs := []provider.Message{
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID:        "t1",
+			Name:      "todo_write",
+			Arguments: `{"todos":[{"content":"a","status":"in_progress"}]}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "t1", Name: "todo_write", Content: "Todos updated"},
+		{Role: provider.RoleAssistant, ToolCalls: []provider.ToolCall{{
+			ID:        "t2",
+			Name:      "todo_write",
+			Arguments: `{"todos":[]}`,
+		}}},
+		{Role: provider.RoleTool, ToolCallID: "t2", Name: "todo_write", Content: "Todos updated"},
+	}
+	a := &Agent{}
+	a.rebuildTodoState(msgs)
+	if len(a.todoState) != 0 {
+		t.Fatalf("empty todo_write should clear rebuilt canonical state: %+v", a.todoState)
+	}
+}
+
 func TestSeedTodoState(t *testing.T) {
 	a := &Agent{sink: event.Discard}
 	todos := []evidence.TodoItem{


### PR DESCRIPTION
## Summary

- Fixed backend todo-state rebuild so a successful `todo_write` with `{"todos":[]}` is treated as an explicit clear instead of being ignored during history/session reload.
- Fixed desktop frontend tool archiving so the latest empty `todo_write` clear remains the canonical parseable snapshot while older todo args stay archived and bounded.
- Added regression tests for:
  - backend reload/rebuild honoring empty todo clears
  - frontend archive behavior when an empty todo clear follows an older non-empty todo list

Cache-impact: none - the change only rebuilds host-side todo state and frontend archived tool-card args; it does not alter provider-visible prompts, tool schemas, tool ordering, or request serialization.
Cache-guard: `go test ./internal/agent ./internal/evidence`, `go test ./internal/tool/builtin -run 'TestTodo|TestCompleteStep'`, and `cd desktop/frontend && pnpm exec tsx src/__tests__/tool-data-archive.test.ts` cover the changed host todo reload and frontend archive contracts.

Verified:
- `go test ./internal/agent ./internal/evidence`
- `go test ./internal/tool/builtin -run 'TestTodo|TestCompleteStep'`
- `cd desktop/frontend && pnpm exec tsx src/__tests__/tool-data-archive.test.ts`
- `git diff --check`

Notes:
- Full `go test ./internal/tool/builtin` was attempted but an existing/flaky process-reaping test failed: `TestReapTreeKillsGroupStragglers`.
- `pnpm tsc --noEmit` was attempted but failed on pre-existing unrelated frontend issues:
  - missing generated Wails module `../../wailsjs/go/main/App`
  - existing type constraint error in `src/lib/bridge.ts`

Fixes #4905
