### PR TITLE
Remove lazy MCP startup mode / 移除 MCP lazy 启动模式

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3824,13 +3824,15 @@ type SkillsSettingsView struct {
 }
 
 // ServerView is one MCP server for the drawer. Status is "connected" (with
-// tool/prompt/resource counts), "deferred" (lazy/on-demand startup enabled),
-// "failed" (with the connection error), "initializing" (background startup in
-// progress), or "disabled".
+// tool/prompt/resource counts), "deferred" (enabled but idle), "failed" (with
+// the connection error), "initializing" (background startup in progress), or
+// "disabled".
 type ServerView struct {
 	Name           string     `json:"name"`
 	Transport      string     `json:"transport"`
 	Status         string     `json:"status"`
+	StartIntent    string     `json:"startIntent,omitempty"`
+	RuntimeState   string     `json:"runtimeState,omitempty"`
 	BuiltIn        bool       `json:"builtIn,omitempty"`
 	Configured     bool       `json:"configured,omitempty"`
 	AutoStart      bool       `json:"autoStart"`
@@ -3968,6 +3970,8 @@ func (a *App) mcpServersView() []ServerView {
 		for _, s := range h.Servers() {
 			if disabledView, ok := disabled[s.Name]; ok {
 				disabledView.Status = "disabled"
+				disabledView.RuntimeState = "idle"
+				disabledView.StartIntent = "off"
 				disabledView.Error = ""
 				if p, ok := configured[s.Name]; ok {
 					disabledView = withPluginConfig(disabledView, p)
@@ -3981,7 +3985,7 @@ func (a *App) mcpServersView() []ServerView {
 			seen[s.Name] = true
 			connected[s.Name] = true
 			view := ServerView{
-				Name: s.Name, Transport: s.Transport, Status: "connected",
+				Name: s.Name, Transport: s.Transport, Status: "connected", RuntimeState: "ready",
 				Tools: s.Tools, Prompts: s.Prompts, Resources: s.Resources,
 				ToolList: pluginToolsToView(s.ToolList),
 			}
@@ -3993,16 +3997,27 @@ func (a *App) mcpServersView() []ServerView {
 		for _, f := range h.Failures() {
 			seen[f.Name] = true
 			view := ServerView{
-				Name: f.Name, Transport: f.Transport, Status: "failed", Error: f.Error,
+				Name: f.Name, Transport: f.Transport, Status: "failed", RuntimeState: "issue", Error: f.Error,
 			}
 			if p, ok := configured[f.Name]; ok {
 				view = withPluginConfig(view, p)
 			}
 			out = append(out, view)
 		}
+		for _, name := range h.ConnectingServers() {
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			view := ServerView{Name: name, Status: "initializing", RuntimeState: "connecting"}
+			if p, ok := configured[name]; ok {
+				view = withPluginConfig(view, p)
+			}
+			out = append(out, view)
+		}
 	}
-	// Configured servers that are neither connected nor failed are either lazy
-	// (deferred), background/eager (initializing), or toggled off this session.
+	// Configured servers that are neither connected, connecting, nor failed are
+	// idle: disabled/off or automatic background startup waiting for its next kick.
 	if len(configuredEntries) > 0 {
 		for _, p := range configuredEntries {
 			if seen[p.Name] {
@@ -4010,6 +4025,8 @@ func (a *App) mcpServersView() []ServerView {
 			}
 			if s, ok := disabled[p.Name]; ok {
 				s.Status = "disabled"
+				s.RuntimeState = "idle"
+				s.StartIntent = "off"
 				s = withPluginConfig(s, p)
 				s.Error = ""
 				out = append(out, s)
@@ -4019,15 +4036,12 @@ func (a *App) mcpServersView() []ServerView {
 				continue
 			}
 			status := "disabled"
+			startIntent := "off"
 			if p.ShouldAutoStart() {
-				switch p.ResolvedTier() {
-				case "background", "eager":
-					status = "initializing"
-				default:
-					status = "deferred"
-				}
+				status = "deferred"
+				startIntent = mcpStartIntent(p)
 			}
-			out = append(out, withPluginConfig(ServerView{Name: p.Name, Status: status}, p))
+			out = append(out, withPluginConfig(ServerView{Name: p.Name, Status: status, StartIntent: startIntent, RuntimeState: "idle"}, p))
 			seen[p.Name] = true
 		}
 	}
@@ -4045,6 +4059,26 @@ func (a *App) mcpServersView() []ServerView {
 	return out
 }
 
+func mcpStartIntent(p config.PluginEntry) string {
+	if !p.ShouldAutoStart() {
+		return "off"
+	}
+	return "automatic"
+}
+
+func mcpRuntimeState(status string) string {
+	switch status {
+	case "connected":
+		return "ready"
+	case "initializing":
+		return "connecting"
+	case "failed":
+		return "issue"
+	default:
+		return "idle"
+	}
+}
+
 func withPluginConfig(v ServerView, p config.PluginEntry) ServerView {
 	tt := p.Type
 	if tt == "" {
@@ -4054,6 +4088,15 @@ func withPluginConfig(v ServerView, p config.PluginEntry) ServerView {
 	v.Configured = true
 	v.AutoStart = p.ShouldAutoStart()
 	v.Tier = p.ResolvedTier()
+	if v.StartIntent == "" {
+		v.StartIntent = mcpStartIntent(p)
+	}
+	if v.Status == "disabled" {
+		v.StartIntent = "off"
+	}
+	if v.RuntimeState == "" {
+		v.RuntimeState = mcpRuntimeState(v.Status)
+	}
 	v.Command = p.Command
 	v.Args = append([]string(nil), p.Args...)
 	v.URL = p.URL
@@ -4465,11 +4508,10 @@ func (a *App) UpdateMCPServer(name string, in MCPServerInput) error {
 	}
 	a.mu.RUnlock()
 	wasConnected := mcpConnected(ctrl, name)
-	wasFailed := mcpFailed(ctrl, name)
 	if wasConnected {
 		ctrl.DisconnectMCPServer(name)
 	}
-	if !sessionDisabled && (wasConnected || wasFailed || updated.ResolvedTier() != "lazy") {
+	if !sessionDisabled {
 		if _, err := ctrl.ConnectMCPServer(updated); err != nil {
 			recordMCPFailure(ctrl, updated, err)
 			return nil
@@ -4650,7 +4692,7 @@ func (a *App) SetMCPServerTier(name, tier string) error {
 	if err := a.saveDesktopMCPServer(updated); err != nil {
 		return err
 	}
-	if tier != "lazy" && tab != nil && tab.Ctrl != nil && !mcpConnected(tab.Ctrl, name) {
+	if tab != nil && tab.Ctrl != nil && !mcpConnected(tab.Ctrl, name) {
 		if _, err := tab.Ctrl.ConnectMCPServer(updated); err != nil {
 			recordMCPFailure(tab.Ctrl, updated, err)
 			return nil
@@ -4784,12 +4826,12 @@ func normalizeMCPTier(tier string) string {
 	switch strings.ToLower(strings.TrimSpace(tier)) {
 	case "eager":
 		return "eager"
-	case "background":
+	case "background", "lazy":
 		return "background"
 	case "":
 		return "background"
 	default:
-		return "lazy"
+		return "background"
 	}
 }
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"reasonix/internal/agent"
+	"reasonix/internal/boot"
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/event"
@@ -3047,7 +3048,7 @@ func TestForkCreatesActiveTabWithoutSwitchingSourceController(t *testing.T) {
 	}
 }
 
-func TestCapabilitiesShowsDefaultMCPAsInitializingNotDisabled(t *testing.T) {
+func TestCapabilitiesShowsDefaultMCPAsAutomaticIdleNotDisabled(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := robustTempDir(t)
 	t.Chdir(dir)
@@ -3071,13 +3072,72 @@ args = ["-y", "@playwright/mcp"]
 	view := app.Capabilities()
 	for _, s := range view.Servers {
 		if s.Name == "playwright" {
-			if s.Status != "initializing" {
-				t.Fatalf("default MCP status = %q, want initializing; server = %+v", s.Status, s)
+			if s.Status != "deferred" || s.StartIntent != "automatic" || s.RuntimeState != "idle" {
+				t.Fatalf("default MCP view = %+v, want deferred automatic idle", s)
 			}
 			return
 		}
 	}
 	t.Fatalf("playwright MCP missing from Capabilities: %+v", view.Servers)
+}
+
+func TestDesktopSharedHostBackgroundMCPAutoConnectsOnBoot(t *testing.T) {
+	isolateDesktopUserDirs(t)
+	dir := robustTempDir(t)
+	t.Chdir(dir)
+
+	srv := desktopMCPHTTPServer(t)
+	defer srv.Close()
+	if err := os.WriteFile(filepath.Join(dir, "reasonix.toml"), []byte(fmt.Sprintf(`
+[[plugins]]
+name = "h"
+type = "http"
+url = %q
+`, srv.URL)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sharedHost := plugin.NewHost()
+	defer sharedHost.Close()
+	ctrl, err := boot.Build(ctx, boot.Options{
+		WorkspaceRoot: dir,
+		SessionDir:    filepath.Join(dir, "sessions"),
+		SharedHost:    sharedHost,
+		Stderr:        io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("boot.Build: %v", err)
+	}
+	defer ctrl.Close()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for !sharedHost.HasClient("h") && time.Now().Before(deadline) {
+		time.Sleep(25 * time.Millisecond)
+	}
+	if !sharedHost.HasClient("h") {
+		t.Fatalf("background MCP did not auto-connect; connecting=%v failures=%+v", sharedHost.ConnectingServers(), sharedHost.Failures())
+	}
+
+	app := NewApp()
+	app.tabs = map[string]*WorkspaceTab{
+		"test": {
+			ID:            "test",
+			Scope:         "global",
+			WorkspaceRoot: dir,
+			Ready:         true,
+			Ctrl:          ctrl,
+			SharedHostKey: dir,
+			disabledMCP:   map[string]ServerView{},
+		},
+	}
+	app.activeTabID = "test"
+
+	view := app.MCPServers()
+	if len(view) != 1 || view[0].Name != "h" || view[0].Status != "connected" || view[0].StartIntent != "automatic" || view[0].RuntimeState != "ready" || view[0].Tools != 1 {
+		t.Fatalf("MCPServers() = %+v, want h connected automatic ready with one tool", view)
+	}
 }
 
 func TestMCPServersMatchesCapabilitiesServerProjection(t *testing.T) {
@@ -3398,7 +3458,7 @@ tier = "lazy"
 	view := app.Capabilities()
 	for _, s := range view.Servers {
 		if s.Name == "dida" {
-			if s.Status != "initializing" || s.AuthStatus != "possible" || s.AuthURL != "https://mcp.dida365.com" {
+			if s.Status != "deferred" || s.StartIntent != "automatic" || s.RuntimeState != "idle" || s.AuthStatus != "possible" || s.AuthURL != "https://mcp.dida365.com" {
 				t.Fatalf("dida auth diagnosis = %+v", s)
 			}
 			return
@@ -3521,7 +3581,7 @@ tier = "lazy"
 	view := app.Capabilities()
 	for _, s := range view.Servers {
 		if s.Name == "figma" {
-			if s.Status != "initializing" || s.AuthStatus != "possible" {
+			if s.Status != "deferred" || s.StartIntent != "automatic" || s.RuntimeState != "idle" || s.AuthStatus != "possible" {
 				t.Fatalf("figma should return to background possible auth: %+v", s)
 			}
 			return
@@ -3708,16 +3768,16 @@ name = "codegraph"
 	defer app.activeCtrl().Close()
 
 	view := app.Capabilities()
-	foundInitializing := false
+	foundIdle := false
 	for _, s := range view.Servers {
 		if s.Name == "codegraph" {
-			foundInitializing = true
-			if s.Status != "initializing" {
-				t.Fatalf("initial codegraph status = %q, want initializing; server = %+v", s.Status, s)
+			foundIdle = true
+			if s.Status != "deferred" || s.StartIntent != "automatic" || s.RuntimeState != "idle" {
+				t.Fatalf("initial codegraph server = %+v, want automatic idle background state", s)
 			}
 		}
 	}
-	if !foundInitializing {
+	if !foundIdle {
 		t.Fatalf("codegraph missing before reconnect: %+v", view.Servers)
 	}
 	if _, ok := reg.Get("mcp__codegraph__connect"); !ok {

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -21,16 +21,19 @@ function server(status: ServerView["status"]): ServerView {
 
 const initializing = mcpServerLifecycleActions(server("initializing"));
 ok(initializing.enabled, "initializing server should still be treated as enabled");
-ok(initializing.showRetryInRow, "initializing server row should expose a retry/reset action");
-ok(initializing.canReconnect, "initializing server details should expose reconnect");
+ok(!initializing.showRetryInRow, "initializing server should not expose retry until it fails");
+ok(!initializing.canReconnect, "initializing server should not expose reconnect while already connecting");
 ok(!initializing.canConnectNow, "initializing server should not use the deferred connect-now action");
 
 const connected = mcpServerLifecycleActions(server("connected"));
 ok(!connected.showRetryInRow, "connected server row should keep the toggle UI");
 ok(connected.canReconnect, "connected server details should expose reconnect");
 
-const deferred = mcpServerLifecycleActions(server("deferred"));
-ok(deferred.canConnectNow, "deferred server should expose connect now");
-ok(!deferred.canReconnect, "deferred server should not show reconnect separately");
+const automaticIdle = mcpServerLifecycleActions({ ...server("deferred"), startIntent: "automatic" });
+ok(!automaticIdle.canConnectNow, "automatic idle server should not look like a manual connector");
+ok(!automaticIdle.canReconnect, "automatic idle server should wait for background connection or failure");
+
+const failed = mcpServerLifecycleActions({ ...server("failed"), runtimeState: "issue" });
+ok(failed.showRetryInRow, "failed server row should expose retry");
 
 console.log("capabilities panel MCP actions");

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -1,4 +1,4 @@
-import { mcpServerLifecycleActions } from "../lib/mcpServerLifecycle";
+import { mcpServerLifecycleActions, mcpServerRetryableFromAvailableList } from "../lib/mcpServerLifecycle";
 import type { ServerView } from "../lib/types";
 
 function ok(value: unknown, message: string) {
@@ -35,5 +35,11 @@ ok(!automaticIdle.canReconnect, "automatic idle server should wait for backgroun
 
 const failed = mcpServerLifecycleActions({ ...server("failed"), runtimeState: "issue" });
 ok(failed.showRetryInRow, "failed server row should expose retry");
+
+ok(mcpServerRetryableFromAvailableList(server("initializing")), "connecting server should be included in available-list retry all");
+ok(mcpServerRetryableFromAvailableList({ ...server("deferred"), startIntent: "automatic" }), "automatic idle server should be included in available-list retry all");
+ok(!mcpServerRetryableFromAvailableList(server("connected")), "connected server should be excluded from available-list retry all");
+ok(!mcpServerRetryableFromAvailableList({ ...server("disabled"), startIntent: "off" }), "disabled server should be excluded from available-list retry all");
+ok(!mcpServerRetryableFromAvailableList({ ...server("failed"), runtimeState: "issue" }), "failed server is handled by the failure banner retry all");
 
 console.log("capabilities panel MCP actions");

--- a/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
+++ b/desktop/frontend/src/__tests__/capabilities-panel-actions.test.ts
@@ -29,6 +29,11 @@ const connected = mcpServerLifecycleActions(server("connected"));
 ok(!connected.showRetryInRow, "connected server row should keep the toggle UI");
 ok(connected.canReconnect, "connected server details should expose reconnect");
 
+const manuallyConnected = mcpServerLifecycleActions({ ...server("connected"), autoStart: false, startIntent: "off", runtimeState: "ready" });
+ok(manuallyConnected.enabled, "connected manual server should still render as enabled");
+ok(!manuallyConnected.canConnectNow, "connected manual server should not expose connect-now");
+ok(manuallyConnected.canReconnect, "connected manual server should expose reconnect");
+
 const automaticIdle = mcpServerLifecycleActions({ ...server("deferred"), startIntent: "automatic" });
 ok(!automaticIdle.canConnectNow, "automatic idle server should not look like a manual connector");
 ok(!automaticIdle.canReconnect, "automatic idle server should wait for background connection or failure");

--- a/desktop/frontend/src/components/CapabilitiesPanel.tsx
+++ b/desktop/frontend/src/components/CapabilitiesPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { asArray } from "../lib/array";
 import { app, openExternal } from "../lib/bridge";
 import { useT } from "../lib/i18n";
-import { mcpServerLifecycleActions } from "../lib/mcpServerLifecycle";
+import { mcpServerLifecycleActions, mcpServerRetryableFromAvailableList } from "../lib/mcpServerLifecycle";
 import type { CapabilitiesView, MCPServerInput, ServerView, SkillRootSkillView, SkillRootView, SkillsSettingsView, SkillView, TabMeta } from "../lib/types";
 import { InlineConfirmButton } from "./InlineConfirmButton";
 import { ResizableDrawer } from "./ResizableDrawer";
@@ -108,6 +108,7 @@ export function CapabilitiesPanel({
       active: servers.filter((s) => s.status !== "failed"),
     };
   }, [view]);
+  const retryableActiveServerNames = useMemo(() => retryableAvailableServerNames(serverGroups.active), [serverGroups.active]);
   const toggleSkill = useCallback((name: string) => {
     setExpandedSkills((prev) => {
       const next = new Set(prev);
@@ -213,7 +214,17 @@ export function CapabilitiesPanel({
                 )}
                 {serverGroups.active.length > 0 && (
                   <div className="cap-server-section">
-                    <div className="cap-server-section__title">{t("caps.availableServers")}</div>
+                    <div className="cap-server-section__head">
+                      <div className="cap-server-section__title">{t("caps.availableServers")}</div>
+                      <button
+                        className="btn btn--small"
+                        disabled={busy || retryableActiveServerNames.length === 0}
+                        type="button"
+                        onClick={() => void mutate(() => Promise.allSettled(retryableActiveServerNames.map((name) => app.ReconnectMCPServer(name))))}
+                      >
+                        {t("caps.retryAll")}
+                      </button>
+                    </div>
                     <ServerGroup
                       busy={busy}
                       servers={serverGroups.active}
@@ -1272,6 +1283,10 @@ function canBulkRemoveFailure(server: ServerView): boolean {
   return kind === "missing-command" || kind === "command-unavailable";
 }
 
+function retryableAvailableServerNames(servers: ServerView[]): string[] {
+  return servers.filter(mcpServerRetryableFromAvailableList).map((s) => s.name);
+}
+
 function serverActionLabel(s: ServerView, t: ReturnType<typeof useT>): string {
   const err = (s.error || "").toLowerCase();
   if (shouldOpenAuth(s)) return t("caps.reauthorize");
@@ -1509,6 +1524,7 @@ export function MCPServersSettingsPage() {
 			active: sorted.filter((s) => s.status !== "failed"),
 		};
 	}, [servers]);
+	const retryableActiveServerNames = useMemo(() => retryableAvailableServerNames(serverGroups.active), [serverGroups.active]);
 	const toggleError = useCallback((name: string) => {
 		setExpandedErrors((prev) => { const next = new Set(prev); if (next.has(name)) next.delete(name); else next.add(name); return next; });
 	}, []);
@@ -1561,7 +1577,17 @@ export function MCPServersSettingsPage() {
 			)}
 			{serverGroups.active.length > 0 && (
 				<div className="cap-server-section">
-					<div className="cap-server-section__title">{t("caps.availableServers")}</div>
+					<div className="cap-server-section__head">
+						<div className="cap-server-section__title">{t("caps.availableServers")}</div>
+						<button
+							className="btn btn--small"
+							disabled={actionBusy || retryableActiveServerNames.length === 0}
+							type="button"
+							onClick={() => void mutate(() => Promise.allSettled(retryableActiveServerNames.map((name) => app.ReconnectMCPServer(name))))}
+						>
+							{t("caps.retryAll")}
+						</button>
+					</div>
 						<ServerGroup
 							busy={actionBusy}
 							servers={serverGroups.active}

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1958,7 +1958,7 @@ function makeMockApp(): AppBindings {
     async UpdateMCPServer(name: string, input: MCPServerInput) {
       capServers = capServers.map((s) => {
         if (s.name !== name) return s;
-        const connected = s.status === "connected" || s.status === "failed" || s.tier !== "lazy";
+        const connected = s.status === "connected" || s.status === "failed" || s.autoStart !== false;
         const nextStatus = s.status === "disabled" ? "disabled" : connected ? "connected" : "deferred";
         const nextTools = nextStatus === "connected" ? s.tools || (input.transport === "stdio" ? 3 : 5) : 0;
         return {
@@ -1995,7 +1995,7 @@ function makeMockApp(): AppBindings {
         s.name === name
           ? {
               ...s,
-              status: s.tier === "background" || s.tier === "eager" ? "initializing" : "deferred",
+              status: s.autoStart === false ? "disabled" : "initializing",
               tools: 0,
               error: undefined,
               authStatus: s.transport !== "stdio" ? "possible" : undefined,
@@ -2056,7 +2056,6 @@ function makeMockApp(): AppBindings {
     async SetMCPServerTier(name: string, tier: string) {
       capServers = capServers.map((s) => {
         if (s.name !== name) return s;
-        if (tier === "lazy") return { ...s, tier, autoStart: true };
         const tools = s.tools || (s.transport === "stdio" ? 3 : 5);
         return { ...s, tier, autoStart: true, status: "connected", tools, error: undefined, authStatus: undefined, authUrl: undefined };
       });

--- a/desktop/frontend/src/lib/mcpServerLifecycle.ts
+++ b/desktop/frontend/src/lib/mcpServerLifecycle.ts
@@ -29,3 +29,8 @@ export function mcpServerLifecycleActions(s: ServerView): {
     canReconnect: state === "ready" || state === "issue",
   };
 }
+
+export function mcpServerRetryableFromAvailableList(s: ServerView): boolean {
+  if (s.status === "connected" || s.status === "disabled" || s.status === "failed") return false;
+  return startIntent(s) !== "off";
+}

--- a/desktop/frontend/src/lib/mcpServerLifecycle.ts
+++ b/desktop/frontend/src/lib/mcpServerLifecycle.ts
@@ -1,15 +1,31 @@
 import type { ServerView } from "./types";
 
+function startIntent(s: ServerView): "off" | "automatic" {
+  if (s.startIntent === "off" || s.startIntent === "automatic") return s.startIntent;
+  if (s.status === "disabled" || (s.configured && !s.autoStart)) return "off";
+  return "automatic";
+}
+
+function runtimeState(s: ServerView): "idle" | "connecting" | "ready" | "issue" {
+  if (s.runtimeState === "idle" || s.runtimeState === "connecting" || s.runtimeState === "ready" || s.runtimeState === "issue") return s.runtimeState;
+  if (s.status === "connected") return "ready";
+  if (s.status === "initializing") return "connecting";
+  if (s.status === "failed") return "issue";
+  return "idle";
+}
+
 export function mcpServerLifecycleActions(s: ServerView): {
   enabled: boolean;
   showRetryInRow: boolean;
   canConnectNow: boolean;
   canReconnect: boolean;
 } {
+  const intent = startIntent(s);
+  const state = runtimeState(s);
   return {
-    enabled: s.status === "connected" || s.status === "deferred" || s.status === "initializing",
-    showRetryInRow: s.status === "failed" || s.status === "initializing",
-    canConnectNow: s.status === "deferred" || s.status === "disabled",
-    canReconnect: s.status === "connected" || s.status === "initializing",
+    enabled: intent !== "off",
+    showRetryInRow: state === "issue",
+    canConnectNow: intent === "off",
+    canReconnect: state === "ready" || state === "issue",
   };
 }

--- a/desktop/frontend/src/lib/mcpServerLifecycle.ts
+++ b/desktop/frontend/src/lib/mcpServerLifecycle.ts
@@ -23,9 +23,9 @@ export function mcpServerLifecycleActions(s: ServerView): {
   const intent = startIntent(s);
   const state = runtimeState(s);
   return {
-    enabled: intent !== "off",
+    enabled: state === "ready" || intent !== "off",
     showRetryInRow: state === "issue",
-    canConnectNow: intent === "off",
+    canConnectNow: intent === "off" && state !== "ready",
     canReconnect: state === "ready" || state === "issue",
   };
 }

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -486,10 +486,12 @@ export interface ServerView {
   name: string;
   transport: string;
   status: "connected" | "deferred" | "failed" | "initializing" | "disabled";
+  startIntent?: "off" | "automatic" | string;
+  runtimeState?: "idle" | "connecting" | "ready" | "issue" | string;
   builtIn?: boolean;
   configured?: boolean;
   autoStart: boolean;
-  tier?: "lazy" | "background" | "eager" | string;
+  tier?: "background" | "eager" | string;
   command?: string;
   args?: string[];
   url?: string;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -265,7 +265,7 @@ export const en = {
   "caps.authPossibleShort": "auth may be required",
   "caps.clearAuth": "Clear auth",
   "caps.confirmClearAuth": "Confirm clear",
-  "caps.deferred": "enabled; connects when this MCP is used",
+  "caps.deferred": "enabled; preparing background connection",
   "caps.initializing": "connecting to MCP; tools will appear when ready",
   "caps.initializingShort": "Connecting",
   "caps.disabled": "disabled (off this session)",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -181,7 +181,7 @@ export const zhTW: Record<DictKey, string> = {
   "caps.authPossibleShort": "可能需要授權",
   "caps.clearAuth": "清除授權",
   "caps.confirmClearAuth": "確認清除",
-  "caps.deferred": "已啟用，用到該 MCP 時連線",
+  "caps.deferred": "已啟用，正在準備背景連線",
   "caps.initializing": "正在連線 MCP，工具可用後會自動出現",
   "caps.initializingShort": "連線中",
   "caps.disabled": "已停用（本次會話）",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -266,7 +266,7 @@ export const zh: Record<DictKey, string> = {
   "caps.authPossibleShort": "可能需要授权",
   "caps.clearAuth": "清除授权",
   "caps.confirmClearAuth": "确认清除",
-  "caps.deferred": "已启用，用到该 MCP 时连接",
+  "caps.deferred": "已启用，正在准备后台连接",
   "caps.initializing": "正在连接 MCP，工具可用后会自动出现",
   "caps.initializingShort": "连接中",
   "caps.disabled": "已停用（本次会话）",

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -9520,8 +9520,14 @@ a[href] {
 .cap-server-section {
   margin-top: 12px;
 }
-.cap-server-section__title {
+.cap-server-section__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
   margin-bottom: 4px;
+}
+.cap-server-section__title {
   color: var(--fg-faint);
   font-size: 10.5px;
   font-weight: 700;
@@ -9970,6 +9976,7 @@ a[href] {
 }
 @media (max-width: 760px) {
   .cap-mcp-toolbar,
+  .cap-server-section__head,
   .cap-failures__head,
   .cap-failure {
     display: flex;

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -276,11 +276,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		pluginHost = plugin.NewHost()
 	}
 
-	// Partition configured plugins by tier so eager/lazy/background can each
-	// take the path that fits them. User entries default to background: the
-	// session starts immediately while enabled MCP servers warm up.
+	// Partition configured plugins by tier so eager can block when explicitly
+	// requested while every other enabled MCP warms up in the background.
 	autoStartEntries := cfg.AutoStartPlugins()
-	eagerEntries, lazyEntries, bgEntries := partitionByTier(autoStartEntries)
+	eagerEntries, bgEntries := partitionByTier(autoStartEntries)
 	extraSpecs := applyKnownPluginOverrides(opts.ExtraPlugins, root)
 	onDemandMCPSpecs := map[string]plugin.Spec{}
 	onDemandMCPNames := []string{}
@@ -295,11 +294,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 			}
 			onDemandMCPSpecs[name] = spec
 		}
-		eagerEntries, lazyEntries, bgEntries = nil, nil, nil
+		eagerEntries, bgEntries = nil, nil
 	}
 
 	// Auto-demote: any eager plugin that has been chronically slow (recent
-	// samples repeatedly hit the blocking startup budget) drops to lazy
+	// samples repeatedly hit the blocking startup budget) drops to background
 	// for this session. The user keeps eager intent, just doesn't pay for it
 	// on a server that's been misbehaving. A notice surfaces the demotion.
 	var demoteMessages []string
@@ -309,7 +308,7 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		rec := plugin.Recommend(e.Name, budget, 0)
 		if rec.Demote {
 			demoteMessages = append(demoteMessages, rec.Reason)
-			lazyEntries = append(lazyEntries, e)
+			bgEntries = append(bgEntries, e)
 			continue
 		}
 		kept = append(kept, e)
@@ -317,7 +316,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	eagerEntries = kept
 
 	eagerSpecs := PluginSpecsForRoot(eagerEntries, root)
-	lazySpecs := PluginSpecsForRoot(lazyEntries, root)
 	bgSpecs := PluginSpecsForRoot(bgEntries, root)
 
 	if !tokenEconomy {
@@ -328,9 +326,6 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 	if opts.Stderr != nil {
 		for i := range eagerSpecs {
 			eagerSpecs[i].Stderr = opts.Stderr
-		}
-		for i := range lazySpecs {
-			lazySpecs[i].Stderr = opts.Stderr
 		}
 		for i := range bgSpecs {
 			bgSpecs[i].Stderr = opts.Stderr
@@ -395,11 +390,10 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		}
 	}
 
-	// Lazy / background: register placeholder tools now; the real spawn waits
-	// for either the first model call (lazy) or a goroutine kicked off here
-	// (background). Both share the same pluginHost so /mcp status, hot-add,
-	// and Close see one cohesive set of servers regardless of tier.
-	registerDeferred := func(specs []plugin.Spec, kick bool) {
+	// Background: register placeholder tools now and kick off the real spawn.
+	// Everything shares the same pluginHost so /mcp status, hot-add, and Close
+	// see one cohesive set of servers.
+	registerBackground := func(specs []plugin.Spec) {
 		for _, s := range specs {
 			// Already running on the shared host? Register tools directly.
 			if pluginHost.HasClient(s.Name) {
@@ -412,27 +406,21 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 				}
 			}
 			if opts.SharedHost != nil {
-				// Shared host: register lazy tools WITHOUT kicking so the
-				// subprocess only starts on the first actual tool call.
-				// This avoids spawning MCP processes (e.g. CodeGraph) for
-				// every workspace root on boot — a tab that sits unused for
-				// days never pays the startup cost. Known session indexers can
-				// opt in because their initialize handshake is the auto-index
-				// trigger for the active workspace root.
+				// Shared host relies on Host's spawn guard to avoid duplicate
+				// processes across tabs for the same workspace root.
 				cs, _ := plugin.LoadCachedSchema(s.Name, plugin.SpecFingerprint(s))
-				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, kick && s.SharedHostBackgroundStart) {
+				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, true) {
 					reg.Add(t)
 				}
 			} else {
 				cs, _ := plugin.LoadCachedSchema(s.Name, plugin.SpecFingerprint(s))
-				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, kick) {
+				for _, t := range plugin.LazyToolset(s, cs, pluginHost, reg, ctx, true) {
 					reg.Add(t)
 				}
 			}
 		}
 	}
-	registerDeferred(lazySpecs, false)
-	registerDeferred(bgSpecs, true)
+	registerBackground(bgSpecs)
 
 	for _, msg := range demoteMessages {
 		sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: msg})
@@ -1255,23 +1243,19 @@ func builtinToolEnabled(enabled []string, name string) bool {
 	return false
 }
 
-// partitionByTier splits configured plugin entries into the three startup
-// buckets — eager (block boot until ready), lazy (placeholder until first
-// model use), background (placeholder + start spawn now). Entries with an
-// empty tier land in background; unrecognised non-empty tiers land in lazy so a
-// typo never triggers unexpected background work.
-func partitionByTier(entries []config.PluginEntry) (eager, lazy, bg []config.PluginEntry) {
+// partitionByTier splits configured plugin entries into eager (block boot until
+// ready) and background (placeholder + start spawn now). Entries with an empty,
+// legacy lazy, or unrecognised tier land in background.
+func partitionByTier(entries []config.PluginEntry) (eager, bg []config.PluginEntry) {
 	for _, e := range entries {
 		switch e.ResolvedTier() {
 		case "eager":
 			eager = append(eager, e)
-		case "background":
-			bg = append(bg, e)
 		default:
-			lazy = append(lazy, e)
+			bg = append(bg, e)
 		}
 	}
-	return eager, lazy, bg
+	return eager, bg
 }
 
 // PluginSpecs maps configured plugin entries to plugin.Spec, expanding ${VAR}

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1873,11 +1873,9 @@ func isolateConfigHome(t *testing.T) string {
 }
 
 // TestPartitionByTier pins the bucket assignment contract that the rest of
-// boot.go's plugin orchestration depends on: each tier string maps to its own
-// slice, the original order inside a tier is preserved (so /mcp status and
-// stats land deterministically), an empty/missing tier defaults to background
-// (connects after session start without blocking chat), and unknown non-empty
-// values fall back to lazy so a typo never forces unwanted background connects.
+// boot.go's plugin orchestration depends on: eager keeps its blocking startup
+// slice, while empty, background, legacy lazy, and unknown tiers all warm up in
+// the background.
 func TestPartitionByTier(t *testing.T) {
 	entries := []config.PluginEntry{
 		{Name: "e1", Tier: "eager"},
@@ -1886,16 +1884,13 @@ func TestPartitionByTier(t *testing.T) {
 		{Name: "default", Tier: ""}, // empty defaults to background
 	}
 
-	eager, lazy, bg := partitionByTier(entries)
+	eager, bg := partitionByTier(entries)
 
 	if len(eager) != 1 || eager[0].Name != "e1" {
 		t.Fatalf("eager bucket = %+v, want [e1]", eager)
 	}
-	if len(bg) != 2 || bg[0].Name != "b1" || bg[1].Name != "default" {
-		t.Fatalf("background bucket = %+v, want [b1, default] preserving input order", bg)
-	}
-	if len(lazy) != 1 || lazy[0].Name != "l1" {
-		t.Fatalf("lazy bucket = %+v, want [l1]", lazy)
+	if len(bg) != 3 || bg[0].Name != "l1" || bg[1].Name != "b1" || bg[2].Name != "default" {
+		t.Fatalf("background bucket = %+v, want [l1, b1, default] preserving input order", bg)
 	}
 }
 
@@ -2118,13 +2113,13 @@ tier = "eager"
 
 	foundDemoteNotice := false
 	for _, n := range notices {
-		if strings.Contains(n.Text, "demoting to lazy") {
+		if strings.Contains(n.Text, "lazy") {
 			foundDemoteNotice = true
 			break
 		}
 	}
 	if foundDemoteNotice {
-		t.Fatalf("legacy tier should be migrated before demotion logic; got notices %+v", notices)
+		t.Fatalf("demotion notice should not mention legacy lazy tier; got notices %+v", notices)
 	}
 }
 

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -395,7 +395,7 @@ func TestMCPManagerHidesComposerBox(t *testing.T) {
 	ctrl := control.New(control.Options{})
 	m := newChatTUI(ctrl, "", make(chan event.Event, 1), 80)
 	m.mcp = &mcpManager{stage: mcpStageList, snapshot: mcpSnapshot{servers: []mcpServerView{
-		{Name: "github", Transport: "stdio", Status: "deferred", Configured: true, Tier: "lazy"},
+		{Name: "github", Transport: "stdio", Status: "deferred", Configured: true, Tier: "background"},
 	}}}
 
 	m0, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})

--- a/internal/cli/mcp_manager.go
+++ b/internal/cli/mcp_manager.go
@@ -93,7 +93,7 @@ type mcpExternalDoneMsg struct {
 	err    error
 }
 
-var mcpTierChoices = []string{"background", "eager", "lazy"}
+var mcpTierChoices = []string{"background", "eager"}
 
 func (m *chatTUI) openMCPManager(name string) {
 	m.mcp = &mcpManager{stage: mcpStageList, snapshot: m.buildMCPSnapshot()}
@@ -334,6 +334,17 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 			snap.servers = append(snap.servers, v)
 			seen[f.Name] = true
 		}
+		for _, name := range m.host.ConnectingServers() {
+			if seen[name] {
+				continue
+			}
+			v := mcpServerView{Name: name, Status: "initializing"}
+			if p, ok := configured[name]; ok {
+				v = withMCPPluginConfig(v, p)
+			}
+			snap.servers = append(snap.servers, v)
+			seen[name] = true
+		}
 	}
 	for _, p := range configuredEntries {
 		if seen[p.Name] {
@@ -343,8 +354,6 @@ func (m chatTUI) buildMCPSnapshot() mcpSnapshot {
 		switch {
 		case m.mcpDisabled[p.Name] || !p.ShouldAutoStart():
 			v.Status = "disabled"
-		case p.ResolvedTier() == "background" || p.ResolvedTier() == "eager":
-			v.Status = "initializing"
 		default:
 			v.Status = "deferred"
 		}

--- a/internal/cli/mcp_manager_actions.go
+++ b/internal/cli/mcp_manager_actions.go
@@ -163,7 +163,7 @@ func (m chatTUI) applyMCPMode(tier string) (tea.Model, tea.Cmd) {
 	if m.mcpDisabled != nil {
 		delete(m.mcpDisabled, v.Name)
 	}
-	if tier != "lazy" && m.ctrl != nil && !mcpConnected(m.ctrl, v.Name) {
+	if m.ctrl != nil && !mcpConnected(m.ctrl, v.Name) {
 		if _, err := m.ctrl.ConnectConfiguredMCPServer(v.Name); err != nil {
 			recordMCPModePluginFailure(m.ctrl, selected, err)
 			m.notice("saved connection mode, but connect failed: " + err.Error())
@@ -290,12 +290,12 @@ func normalizeMCPTierForCLI(tier string) string {
 	switch strings.ToLower(strings.TrimSpace(tier)) {
 	case "eager":
 		return "eager"
-	case "background":
+	case "background", "lazy":
 		return "background"
 	case "":
 		return "background"
 	default:
-		return "lazy"
+		return "background"
 	}
 }
 

--- a/internal/cli/mcp_manager_view.go
+++ b/internal/cli/mcp_manager_view.go
@@ -254,8 +254,6 @@ func mcpActionsFor(v mcpServerView, configPath string) []mcpActionItem {
 		out = append(out, mcpActionItem{mcpActionConnect, "Reconnect"})
 	case "disabled":
 		out = append(out, mcpActionItem{mcpActionConnect, "Enable and connect"})
-	default:
-		out = append(out, mcpActionItem{mcpActionConnect, "Connect now"})
 	}
 	out = appendMCPConfigActions(out, v, configPath)
 	if mcpCanClearAuth(v) {
@@ -309,7 +307,7 @@ func mcpStatusLabel(v mcpServerView) string {
 	case v.Status == "failed":
 		return red("✕ failed")
 	case v.Status == "deferred":
-		return "○ connect on use"
+		return "○ preparing in background"
 	case v.Status == "initializing":
 		return "◌ connecting..."
 	case v.Status == "disabled":

--- a/internal/cli/mcp_manager_view.go
+++ b/internal/cli/mcp_manager_view.go
@@ -252,6 +252,8 @@ func mcpActionsFor(v mcpServerView, configPath string) []mcpActionItem {
 	switch v.Status {
 	case "connected":
 		out = append(out, mcpActionItem{mcpActionConnect, "Reconnect"})
+	case "deferred":
+		out = append(out, mcpActionItem{mcpActionConnect, "Reconnect"})
 	case "disabled":
 		out = append(out, mcpActionItem{mcpActionConnect, "Enable and connect"})
 	}

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -162,8 +162,8 @@ func TestRenderMCPManagerListGroupsRuntimeAndConfiguredServers(t *testing.T) {
 		configPath: "reasonix.toml",
 		servers: []mcpServerView{
 			{Name: "managed-search", Transport: "stdio", Status: "connected", BuiltIn: true, Tools: 4},
-			{Name: "github", Transport: "stdio", Status: "deferred", Configured: true, Tier: "lazy", Tools: 12},
-			{Name: "figma", Transport: "http", Status: "failed", Configured: true, Tier: "lazy", URL: "https://mcp.figma.com", Error: "connect: 401 unauthorized"},
+			{Name: "github", Transport: "stdio", Status: "deferred", Configured: true, Tier: "background", Tools: 12},
+			{Name: "figma", Transport: "http", Status: "failed", Configured: true, Tier: "background", URL: "https://mcp.figma.com", Error: "connect: 401 unauthorized"},
 		},
 	}}
 	got := p.renderList(120)
@@ -175,7 +175,7 @@ func TestRenderMCPManagerListGroupsRuntimeAndConfiguredServers(t *testing.T) {
 		"managed-search",
 		"connected",
 		"github",
-		"connect on use",
+		"preparing in background",
 		"figma",
 		"needs authentication",
 	} {
@@ -187,7 +187,7 @@ func TestRenderMCPManagerListGroupsRuntimeAndConfiguredServers(t *testing.T) {
 
 func TestRenderMCPManagerListCompactsLongNames(t *testing.T) {
 	p := &mcpManager{snapshot: mcpSnapshot{servers: []mcpServerView{
-		{Name: "@modelcontextprotocol/server-sequential-thinking", Transport: "stdio", Status: "deferred", Configured: true, Tier: "lazy"},
+		{Name: "@modelcontextprotocol/server-sequential-thinking", Transport: "stdio", Status: "deferred", Configured: true, Tier: "background"},
 	}}}
 	got := p.renderList(80)
 	for _, line := range strings.Split(got, "\n") {
@@ -208,7 +208,7 @@ func TestRenderMCPManagerAuthFailureActions(t *testing.T) {
 			configPath: "reasonix.toml",
 			servers: []mcpServerView{{
 				Name: "figma", Transport: "http", Status: "failed", Configured: true,
-				Tier: "lazy", URL: "https://mcp.figma.com", Error: "connect: 401 unauthorized",
+				Tier: "background", URL: "https://mcp.figma.com", Error: "connect: 401 unauthorized",
 			}},
 		},
 	}
@@ -240,7 +240,7 @@ func TestRenderMCPManagerClearAuthConfirmation(t *testing.T) {
 		snapshot: mcpSnapshot{
 			servers: []mcpServerView{{
 				Name: "figma", Transport: "http", Status: "failed", Configured: true,
-				Tier: "lazy", URL: "https://mcp.figma.com", Error: "connect: 401 unauthorized",
+				Tier: "background", URL: "https://mcp.figma.com", Error: "connect: 401 unauthorized",
 			}},
 		},
 	}
@@ -267,20 +267,22 @@ func TestRenderMCPManagerRemoteDeferredAuthHint(t *testing.T) {
 			configPath: "reasonix.toml",
 			servers: []mcpServerView{{
 				Name: "dida", Transport: "http", Status: "deferred", Configured: true,
-				Tier: "lazy", URL: "https://mcp.dida365.com",
+				Tier: "background", URL: "https://mcp.dida365.com",
 			}},
 		},
 	}
 	got := p.renderDetail(100)
 	for _, want := range []string{
-		"connect on use",
+		"preparing in background",
 		"Auth:",
 		"may need authorization",
-		"Connect now",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered deferred remote details missing %q:\n%s", want, got)
 		}
+	}
+	if strings.Contains(got, "Connect now") {
+		t.Fatalf("automatic background MCP should not expose manual connect:\n%s", got)
 	}
 	if strings.Contains(got, "Authenticate") {
 		t.Fatalf("possible auth should not replace connect action before a failure:\n%s", got)
@@ -295,7 +297,7 @@ func TestRenderMCPManagerDetailCompactsConfigPath(t *testing.T) {
 			configPath: "/Users/example/Library/Application Support/reasonix/config.toml",
 			servers: []mcpServerView{{
 				Name: "github", Transport: "stdio", Status: "deferred", Configured: true,
-				Tier: "lazy", Command: "npx", Args: []string{"-y", "@modelcontextprotocol/server-github"},
+				Tier: "background", Command: "npx", Args: []string{"-y", "@modelcontextprotocol/server-github"},
 			}},
 		},
 	}
@@ -396,7 +398,7 @@ func TestApplyMCPModeDropsLegacyTier(t *testing.T) {
 		stage: mcpStageMode,
 		name:  "github",
 		snapshot: mcpSnapshot{configPath: "reasonix.toml", servers: []mcpServerView{{
-			Name: "github", Transport: "stdio", Status: "deferred", Configured: true, Tier: "lazy",
+			Name: "github", Transport: "stdio", Status: "deferred", Configured: true, Tier: "background",
 		}}},
 	}
 	_, _ = m.applyMCPMode("background")
@@ -421,7 +423,7 @@ func TestApplyMCPModeRecordsPluginConnectFailure(t *testing.T) {
 	isolateUserConfig(t)
 	t.Setenv("PATH", "")
 	cfg := config.Default()
-	cfg.Plugins = []config.PluginEntry{{Name: "broken", Command: "definitely-missing-reasonix-mcp", Tier: "lazy"}}
+	cfg.Plugins = []config.PluginEntry{{Name: "broken", Command: "definitely-missing-reasonix-mcp", Tier: "background"}}
 	if err := cfg.SaveTo("reasonix.toml"); err != nil {
 		t.Fatalf("save config: %v", err)
 	}
@@ -434,7 +436,7 @@ func TestApplyMCPModeRecordsPluginConnectFailure(t *testing.T) {
 		stage: mcpStageMode,
 		name:  "broken",
 		snapshot: mcpSnapshot{configPath: "reasonix.toml", servers: []mcpServerView{{
-			Name: "broken", Transport: "stdio", Status: "deferred", Configured: true, Tier: "lazy",
+			Name: "broken", Transport: "stdio", Status: "deferred", Configured: true, Tier: "background",
 		}}},
 	}
 

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -276,6 +276,7 @@ func TestRenderMCPManagerRemoteDeferredAuthHint(t *testing.T) {
 		"preparing in background",
 		"Auth:",
 		"may need authorization",
+		"Reconnect",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("rendered deferred remote details missing %q:\n%s", want, got)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1058,16 +1058,16 @@ type PluginEntry struct {
 	// AutoStart controls whether the server connects during session startup.
 	// Nil preserves historical behavior: configured servers start automatically.
 	AutoStart *bool `toml:"auto_start"`
-	// Tier selects how aggressively the server is connected at boot:
+	// Tier is a legacy compatibility field. New config rendering omits it; enabled
+	// MCP servers connect automatically in the background unless auto_start=false.
+	// Historical values are accepted for old files:
 	//   "eager"      — blocks startup until the handshake completes; required for
 	//                  servers whose tools the system prompt depends on.
-	//   "lazy"       — registers placeholder tools immediately (from on-disk
-	//                  schema cache when available) and only spawns the real
-	//                  subprocess on first model use. Kept for legacy configs.
+	//   "lazy"       — legacy alias for background.
 	//   "background" — placeholder + spawn fired at boot but not waited on;
 	//                  swap happens once the spawn finishes.
 	// Empty defaults to "background" so enabled MCPs connect automatically
-	// without blocking chat. Unknown non-empty values fall back to "lazy".
+	// without blocking chat. Unknown non-empty values fall back to "background".
 	Tier string `toml:"tier"`
 }
 
@@ -1075,9 +1075,9 @@ func (e PluginEntry) ShouldAutoStart() bool {
 	return e.AutoStart == nil || *e.AutoStart
 }
 
-// ResolvedTier returns the normalized tier ("eager"|"lazy"|"background") with
-// the project default applied. Unknown values fall back to "lazy" so a typo
-// never forces a slow boot.
+// ResolvedTier returns the normalized tier ("eager"|"background") with the
+// project default applied. Legacy lazy and unknown values fall back to
+// background so enabled MCPs are available without manual connection.
 func (e PluginEntry) ResolvedTier() string {
 	return resolvedMCPTier(e.Tier)
 }
@@ -1086,12 +1086,12 @@ func resolvedMCPTier(tier string) string {
 	switch strings.ToLower(strings.TrimSpace(tier)) {
 	case "eager":
 		return "eager"
-	case "background":
+	case "background", "lazy":
 		return "background"
 	case "":
 		return "background"
 	default:
-		return "lazy"
+		return "background"
 	}
 }
 

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -812,10 +812,10 @@ func TestPluginResolvedTierDefaultsToBackground(t *testing.T) {
 		want string
 	}{
 		{name: "empty", tier: "", want: "background"},
-		{name: "explicit lazy", tier: "lazy", want: "lazy"},
+		{name: "legacy lazy", tier: "lazy", want: "background"},
 		{name: "background", tier: "background", want: "background"},
 		{name: "eager", tier: "eager", want: "eager"},
-		{name: "unknown", tier: "startup", want: "lazy"},
+		{name: "unknown", tier: "startup", want: "background"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			got := (PluginEntry{Name: "mcp", Command: "mcp-server", Tier: tc.tier}).ResolvedTier()

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -2519,6 +2519,7 @@ func (c *Controller) connectMCPSpec(s plugin.Spec) (int, error) {
 		}
 	}
 	if c.reg != nil {
+		c.reg.ResumePrefix(plugin.ToolPrefix(s.Name))
 		c.reg.RemovePrefix(plugin.ToolPrefix(s.Name))
 		for _, t := range tools {
 			c.reg.Add(t)
@@ -2683,7 +2684,8 @@ func (c *Controller) UnregisterMCPServerTools(name string) bool {
 	if c.reg == nil {
 		return false
 	}
-	return c.reg.RemovePrefix(plugin.ToolPrefix(name)) > 0
+	c.reg.SuspendPrefix(plugin.ToolPrefix(name))
+	return true
 }
 
 // Label returns the human-readable model label, e.g. "deepseek-flash".

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -641,6 +641,24 @@ func TestDisconnectMCPServerRemovesLazyPlaceholder(t *testing.T) {
 	}
 }
 
+func TestUnregisterMCPServerToolsBlocksLateSharedHostSwap(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(fakeControlTool{name: "mcp__mock__connect"})
+	c := New(Options{Host: plugin.NewHost(), Registry: reg})
+
+	if ok := c.UnregisterMCPServerTools("mock"); !ok {
+		t.Fatal("UnregisterMCPServerTools returned false")
+	}
+	reg.Add(fakeControlTool{name: "mcp__mock__echo"})
+	if _, found := reg.Get("mcp__mock__echo"); found {
+		t.Fatalf("late shared-host tool swap was accepted after unregister; names=%v", reg.Names())
+	}
+	reg.Add(fakeControlTool{name: "mcp__other__echo"})
+	if _, found := reg.Get("mcp__other__echo"); !found {
+		t.Fatalf("unregister blocked unrelated MCP tools; names=%v", reg.Names())
+	}
+}
+
 func TestRemoveMCPServerRemovesUnconnectedLazyPlaceholder(t *testing.T) {
 	isolateControlConfigHome(t)
 	dir := t.TempDir()

--- a/internal/installsource/install_source.go
+++ b/internal/installsource/install_source.go
@@ -137,7 +137,7 @@ func (*installSourceTool) Schema() json.RawMessage {
   "args":{"type":"array","items":{"type":"string"},"description":"Optional stdio MCP args override."},
   "env":{"type":"object","additionalProperties":{"type":"string"},"description":"Environment variables for stdio MCP servers."},
   "headers":{"type":"object","additionalProperties":{"type":"string"},"description":"HTTP headers for remote MCP servers. Prefer ${VAR} placeholders for secrets."},
-  "tier":{"type":"string","enum":["lazy","background","eager"],"description":"Persisted MCP startup tier. Defaults to background."},
+  "tier":{"type":"string","enum":["background","eager"],"description":"Persisted MCP startup tier. Defaults to background."},
   "replace":{"type":"boolean","description":"Allow replacing an existing MCP config entry with the same name. Skills still refuse to overwrite existing files."},
   "strict":{"type":"boolean","description":"Skill install strictness. true (default) requires name+description frontmatter; false copies the file as-is (use only for files you trust)."},
   "planId":{"type":"string","description":"Optional. Echoed from a previous planned response to confirm the host is approving the same plan."}

--- a/internal/installsource/install_source_test.go
+++ b/internal/installsource/install_source_test.go
@@ -491,7 +491,7 @@ func TestPlanMCPJSONUnknownTierProducesWarning(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseMCPJSON: %v", err)
 	}
-	if len(entries) != 1 || entries[0].Tier != "lazy" {
+	if len(entries) != 1 || entries[0].Tier != "background" {
 		t.Fatalf("entries = %+v", entries)
 	}
 	found := false
@@ -522,12 +522,12 @@ func TestPlanMCPJSONDefaultTierIsBackground(t *testing.T) {
 	}
 }
 
-func TestNormalizeTierDefaultBackgroundUnknownLazy(t *testing.T) {
+func TestNormalizeTierDefaultBackgroundUnknownBackground(t *testing.T) {
 	if got, ok := normalizeTier(""); got != "background" || !ok {
 		t.Fatalf("normalizeTier(empty) = %q, %v; want background, true", got, ok)
 	}
-	if got, ok := normalizeTier("absurd"); got != "lazy" || ok {
-		t.Fatalf("normalizeTier(absurd) = %q, %v; want lazy, false", got, ok)
+	if got, ok := normalizeTier("absurd"); got != "background" || ok {
+		t.Fatalf("normalizeTier(absurd) = %q, %v; want background, false", got, ok)
 	}
 }
 

--- a/internal/installsource/mcp.go
+++ b/internal/installsource/mcp.go
@@ -19,7 +19,7 @@ func (t *installSourceTool) mcpEntryAction(req request, e config.PluginEntry, so
 	var normalizedCommand bool
 	e, normalizedCommand = config.NormalizePluginCommandLine(e)
 	// Tier comes from the call (req.Tier) or the entry; either way we
-	// validate. An unrecognised tier is silently downgraded to "lazy" by
+	// validate. An unrecognised tier is silently downgraded to "background" by
 	// normalizeTier — we capture the original value to surface a warning.
 	desired := firstNonEmpty(req.Tier, e.Tier)
 	norm, ok := normalizeTier(desired)
@@ -40,7 +40,7 @@ func (t *installSourceTool) mcpEntryAction(req request, e config.PluginEntry, so
 		entry:      e,
 	}
 	if !ok && strings.TrimSpace(desired) != "" {
-		a.RiskReasons = append(a.RiskReasons, fmt.Sprintf("tier %q is unknown; treating as lazy", desired))
+		a.RiskReasons = append(a.RiskReasons, fmt.Sprintf("tier %q is unknown; treating as background", desired))
 	}
 	if normalizedCommand {
 		a.RiskReasons = append(a.RiskReasons, "split a pasted MCP command line into command and args")
@@ -206,7 +206,7 @@ func parseMCPJSON(b []byte) ([]config.PluginEntry, []string, error) {
 		}
 		tier, ok := normalizeTier(s.Tier)
 		if !ok && strings.TrimSpace(s.Tier) != "" {
-			warnings = append(warnings, fmt.Sprintf("%s: tier %q is unknown; treating as lazy", name, s.Tier))
+			warnings = append(warnings, fmt.Sprintf("%s: tier %q is unknown; treating as background", name, s.Tier))
 		}
 		e := config.PluginEntry{
 			Name:      name,

--- a/internal/installsource/names.go
+++ b/internal/installsource/names.go
@@ -255,21 +255,19 @@ func normalizeTransport(t string) string {
 	}
 }
 
-// normalizeTier maps a tier value into a known set. The boolean returned
-// reports whether the original value was already in the set; callers use it
-// to surface a warning when a typo'd tier quietly becomes "lazy".
+// normalizeTier maps a tier value into the supported set. The boolean returned
+// reports whether the original value was already recognized; callers use it to
+// surface a warning when a typo'd tier quietly becomes "background".
 func normalizeTier(tier string) (string, bool) {
 	switch strings.ToLower(strings.TrimSpace(tier)) {
 	case "eager":
 		return "eager", true
-	case "background":
+	case "background", "lazy":
 		return "background", true
-	case "lazy":
-		return "lazy", true
 	case "":
 		return "background", true
 	default:
-		return "lazy", false
+		return "background", false
 	}
 }
 

--- a/internal/plugin/known_overrides.go
+++ b/internal/plugin/known_overrides.go
@@ -36,11 +36,6 @@ func ApplyKnownOverrides(s Spec, workspaceRoot string) Spec {
 		}
 		// codebase-memory-mcp detects the session root from its subprocess cwd
 		// during initialize, then optionally starts its own auto-index thread.
-		// Connect the background-tier server at tab startup so that handshake can
-		// happen without waiting for the first model tool call.
-		if isStdioSpecType(s.Type) {
-			s.SharedHostBackgroundStart = true
-		}
 		// Its initial full-tree indexing can be CPU-heavy; keep it out of the
 		// foreground scheduling lane just like CodeGraph.
 		s.LowPriority = true

--- a/internal/plugin/lazy.go
+++ b/internal/plugin/lazy.go
@@ -1,12 +1,11 @@
-// Lazy-tier MCP placeholder tools. A "lazy" plugin registers cheap placeholder
-// entries in the tool registry at boot — using the on-disk schema cache when
-// it exists — and defers the actual subprocess spawn / handshake to the first
-// model call. A "background" plugin is identical except it also kicks the
-// spawn off at boot so by the time the model calls, the swap is already done.
+// MCP placeholder tools. Background startup registers cheap placeholder entries
+// in the tool registry at boot — using the on-disk schema cache when it exists —
+// and kicks the real subprocess spawn / handshake immediately. By the time the
+// model calls a tool, the swap is usually already done.
 //
-// Why the indirection: a lazy/background server still needs stable placeholder
-// tools before the real handshake finishes. Once it does finish, lazySpawn swaps
-// the placeholders for real tools through tool.Registry's own lock, so the next
+// Why the indirection: a background server still needs stable placeholder tools
+// before the real handshake finishes. Once it does finish, lazySpawn swaps the
+// placeholders for real tools through tool.Registry's own lock, so the next
 // model request sees the real schemas without waiting for another placeholder
 // Execute call.
 package plugin
@@ -66,8 +65,8 @@ type lazySpawn struct {
 	removePrefix string
 }
 
-// kick starts the spawn if it has not yet started. Used by background-tier
-// registration; lazy-tier kicks on first call instead.
+// kick starts the spawn if it has not yet started. Background registration calls
+// this immediately; tests may leave it idle to exercise the placeholder path.
 func (s *lazySpawn) kick() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -296,16 +295,16 @@ func (lt *lazyTool) Execute(ctx context.Context, args json.RawMessage) (string, 
 	}
 
 	sp.mu.Unlock()
-	return "", fmt.Errorf("lazy plugin %q in unexpected state", sp.spec.Name)
+	return "", fmt.Errorf("deferred plugin %q in unexpected state", sp.spec.Name)
 }
 
-// LazyToolset returns the placeholder tools to register for one lazy/background
-// spec. When cs is non-nil (cache hit) the returned slice has one lazyTool per
-// cached tool, carrying the cached schema so the model can pass real args;
-// the first Execute runs the handshake synchronously and swaps in real tools.
-// When cs is nil (cache miss) the returned slice has a single stub named
-// "mcp__<server>__connect": the model can call it to drive the spawn, and the
-// real tools surface on the next turn.
+// LazyToolset returns the placeholder tools to register for one background spec.
+// The name is historical: when cs is non-nil (cache hit) the returned slice has
+// one lazyTool per cached tool, carrying the cached schema so the model can pass
+// real args. If the background handshake is still pending, Execute waits for it
+// and swaps in real tools. When cs is nil (cache miss) the returned slice has a
+// single stub named "mcp__<server>__connect": the model can call it to wait for
+// the spawn, and the real tools surface on the next turn.
 //
 // kick=true (background tier) also fires off the spawn immediately, so an
 // idle session warms up without waiting for the first model call.

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -61,10 +61,6 @@ type Spec struct {
 	// LowPriority runs a stdio subprocess below normal scheduling priority, for
 	// background indexers that must not starve the user's machine.
 	LowPriority bool
-	// SharedHostBackgroundStart lets a known background-tier stdio server connect
-	// at desktop tab startup even when the host is shared by several tabs. Keep
-	// this opt-in: most background MCP servers should stay deferred until used.
-	SharedHostBackgroundStart bool
 }
 
 // transport carries JSON-RPC messages to and from one MCP server. call sends a
@@ -562,6 +558,20 @@ func (h *Host) Failures() []Failure {
 	defer h.mu.RUnlock()
 	out := make([]Failure, len(h.failures))
 	copy(out, h.failures)
+	return out
+}
+
+// ConnectingServers returns server names whose startup handshake is currently in
+// flight. It is intentionally status-only: connected clients and failures remain
+// the source of truth for ready/issue states.
+func (h *Host) ConnectingServers() []string {
+	h.spawningMu.Lock()
+	defer h.spawningMu.Unlock()
+	out := make([]string, 0, len(h.spawning))
+	for name := range h.spawning {
+		out = append(out, name)
+	}
+	sort.Strings(out)
 	return out
 }
 

--- a/internal/plugin/plugin_test.go
+++ b/internal/plugin/plugin_test.go
@@ -148,9 +148,6 @@ func TestApplyKnownOverridesPinsCodebaseMemoryToWorkspace(t *testing.T) {
 	if got.Dir != "/workspace" {
 		t.Fatalf("codebase-memory-mcp stdio Dir = %q, want workspace root", got.Dir)
 	}
-	if !got.SharedHostBackgroundStart {
-		t.Fatalf("codebase-memory-mcp should opt into shared-host background start")
-	}
 	if !got.LowPriority {
 		t.Fatalf("codebase-memory-mcp should run at low priority")
 	}
@@ -164,16 +161,13 @@ func TestApplyKnownOverridesPinsCodebaseMemoryToWorkspace(t *testing.T) {
 	if httpSpec.Dir != "" {
 		t.Fatalf("http codebase-memory-mcp should not receive stdio Dir, got %q", httpSpec.Dir)
 	}
-	if httpSpec.SharedHostBackgroundStart {
-		t.Fatalf("http codebase-memory-mcp should not opt into shared-host background start")
-	}
 
 	npxSpec := ApplyKnownOverrides(Spec{
 		Name:    "custom",
 		Command: "npx",
 		Args:    []string{"-y", "codebase-memory-mcp@latest"},
 	}, "/workspace")
-	if npxSpec.Dir != "/workspace" || !npxSpec.SharedHostBackgroundStart {
+	if npxSpec.Dir != "/workspace" || !npxSpec.LowPriority {
 		t.Fatalf("npx codebase-memory-mcp override missing: %+v", npxSpec)
 	}
 }

--- a/internal/plugin/stats.go
+++ b/internal/plugin/stats.go
@@ -1,6 +1,6 @@
 // Per-plugin startup latency tracking for MCP servers. Reasonix uses these
 // samples to decide whether a chronically slow plugin should be demoted from
-// "eager" to "lazy" loading for the rest of a session — see Recommend.
+// "eager" to background loading for the rest of a session — see Recommend.
 //
 // Storage is one tiny JSON file per plugin under <cacheDir>/mcp/, written
 // atomically (tmpfile + Rename) so a crash mid-write can't corrupt history.
@@ -48,9 +48,9 @@ type StartupStats struct {
 
 // Recommendation is the result of inspecting a plugin's recent startup
 // history. Demote is the actionable bit boot.go consumes (true → switch this
-// plugin's tier to "lazy" for this session). P99 and Reason are descriptive
-// only — Reason is meant to be surfaced to the user as a Notice so a sudden
-// demotion isn't silent.
+// plugin to background startup for this session). P99 and Reason are
+// descriptive only — Reason is meant to be surfaced to the user as a Notice so a
+// sudden demotion isn't silent.
 type Recommendation struct {
 	Demote bool
 	P99    time.Duration
@@ -144,7 +144,7 @@ func Recommend(name string, budget time.Duration, demoteAfter int) Recommendatio
 	}
 	rec.Demote = true
 	rec.Reason = fmt.Sprintf(
-		"plugin %q has been slow %d startups in a row (last %dms, budget %dms); demoting to lazy this session",
+		"plugin %q has been slow %d startups in a row (last %dms, budget %dms); demoting to background startup this session",
 		name, demoteAfter, tail[len(tail)-1], budget.Milliseconds(),
 	)
 	return rec

--- a/internal/tool/registry_test.go
+++ b/internal/tool/registry_test.go
@@ -62,6 +62,29 @@ func TestRegistryRemovePrefix(t *testing.T) {
 	}
 }
 
+func TestRegistrySuspendPrefixBlocksLateAddsUntilResume(t *testing.T) {
+	r := NewRegistry()
+	r.Add(stubTool{name: "bash"})
+	r.Add(stubTool{name: "mcp__fs__connect"})
+
+	if got := r.SuspendPrefix("mcp__fs__"); got != 1 {
+		t.Fatalf("SuspendPrefix returned %d, want 1", got)
+	}
+	r.Add(stubTool{name: "mcp__fs__read"})
+	if _, ok := r.Get("mcp__fs__read"); ok {
+		t.Fatalf("suspended prefix accepted a late tool add; names=%v", r.Names())
+	}
+	if _, ok := r.Get("bash"); !ok {
+		t.Fatal("suspending an MCP prefix removed unrelated tools")
+	}
+
+	r.ResumePrefix("mcp__fs__")
+	r.Add(stubTool{name: "mcp__fs__read"})
+	if _, ok := r.Get("mcp__fs__read"); !ok {
+		t.Fatalf("resumed prefix did not accept tool add; names=%v", r.Names())
+	}
+}
+
 // TestRegistrySchemasSorted proves Schemas() emits tool definitions in
 // deterministic alphabetical order regardless of insertion order, so a logically
 // identical tool set produces a stable provider-facing request prefix (prompt

--- a/internal/tool/tool.go
+++ b/internal/tool/tool.go
@@ -98,15 +98,16 @@ func LookupBuiltin(name string) (Tool, bool) {
 
 // Registry is a per-run set of tools: enabled built-ins plus plugin tools.
 type Registry struct {
-	mu    sync.RWMutex
-	tools map[string]Tool
-	order []string
-	canon map[string]json.RawMessage
+	mu        sync.RWMutex
+	tools     map[string]Tool
+	order     []string
+	canon     map[string]json.RawMessage
+	suspended map[string]bool
 }
 
 // NewRegistry returns an empty registry.
 func NewRegistry() *Registry {
-	return &Registry{tools: map[string]Tool{}, canon: map[string]json.RawMessage{}}
+	return &Registry{tools: map[string]Tool{}, canon: map[string]json.RawMessage{}, suspended: map[string]bool{}}
 }
 
 // Add inserts (or replaces) a tool, preserving first-seen order. The schema is
@@ -117,6 +118,11 @@ func (r *Registry) Add(t Tool) {
 	defer r.mu.Unlock()
 
 	name := t.Name()
+	for prefix := range r.suspended {
+		if strings.HasPrefix(name, prefix) {
+			return
+		}
+	}
 	if _, ok := r.tools[name]; !ok {
 		r.order = append(r.order, name)
 	}
@@ -163,6 +169,37 @@ func (r *Registry) RemovePrefix(prefix string) int {
 	}
 	r.order = kept
 	return removed
+}
+
+// SuspendPrefix unregisters matching tools and prevents future Add calls for
+// that prefix until ResumePrefix is called. It is used for per-session MCP
+// disables where an in-flight background handshake may otherwise swap tools back
+// into this registry after the user turned the server off.
+func (r *Registry) SuspendPrefix(prefix string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.suspended[prefix] = true
+	kept := r.order[:0]
+	removed := 0
+	for _, name := range r.order {
+		if strings.HasPrefix(name, prefix) {
+			delete(r.tools, name)
+			delete(r.canon, name)
+			removed++
+			continue
+		}
+		kept = append(kept, name)
+	}
+	r.order = kept
+	return removed
+}
+
+// ResumePrefix allows future Add calls for a previously suspended prefix.
+func (r *Registry) ResumePrefix(prefix string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.suspended, prefix)
 }
 
 // Get looks up a tool by name.


### PR DESCRIPTION
## Summary
- Treat legacy `tier = "lazy"` and unknown MCP tiers as `background`, and remove `lazy` from new config/schema/UI/CLI choices.
- Start enabled background MCPs automatically at session/tab startup, including shared-host desktop sessions, while keeping `eager` as the explicit blocking mode and `auto_start = false` as the off switch.
- Split MCP UI state into start intent and runtime state so `initializing` means a real connection is in flight, Retry only appears after failures, and automatic idle servers no longer look like manual/on-demand connectors.
- Add a persistent `Retry all` action beside the Available MCPs header so users can retry all enabled-but-not-connected MCPs without expanding the startup-issues banner or retrying entries one by one.
- Remove the shared-host background-start opt-in field because shared background startup is now the default behavior.

Refs #4944.

## Related PRs Checked
- #4878 (`fix(plugin): persist lazy MCP schema cache`) also touches `internal/plugin/lazy.go`, but its scope is schema-cache persistence after deferred/background handshakes. This PR does not supersede or adopt that work; it focuses on removing the user-visible lazy startup mode.

## Cache Impact
- Medium and intentional: enabled background MCPs now connect immediately instead of waiting for first model use, so MCP readiness timing changes.
- Provider-visible names and placeholder schema registration still use the existing deterministic MCP tool path.
- Token-economy mode still keeps optional MCP sources behind `connect_tool_source`; this PR does not expand that lean tool surface.
- The Available MCPs `Retry all` button is UI-only and reuses the existing `ReconnectMCPServer` binding.

## Verification
- `go test ./internal/config ./internal/boot ./internal/installsource ./internal/cli ./internal/control ./internal/plugin -count=1`
- `go test . -count=1` from the desktop package
- `npx tsx src/__tests__/capabilities-panel-actions.test.ts`
- `pnpm --dir desktop/frontend check:css`
- Browser verification: opened MCP settings and confirmed a persistent `Retry all` button appears beside the Available MCPs header.
- Attempted `pnpm --dir desktop/frontend typecheck`; blocked in this local frontend checkout because generated Wails bindings are absent (`wailsjs/go/main/App`).

Cache-impact: medium - Enabled background MCPs now connect at session startup, changing MCP readiness timing while keeping deterministic provider-visible tool names and placeholder schemas.
Cache-guard: `go test ./internal/config ./internal/boot ./internal/installsource ./internal/cli ./internal/control ./internal/plugin ./internal/tool -count=1` plus `npx tsx src/__tests__/capabilities-panel-actions.test.ts` covered tier normalization, boot startup, registry suspend/resume, and UI action state.
System-prompt-review: Codex reviewed the boot/config changes for prompt and tool-surface cache impact; the PR intentionally changes MCP startup timing but does not expand the lean token-economy tool surface.