### PR TITLE
Describe pwsh chaining support / 区分 pwsh 链式命令提示

### DIFF
--- a/internal/tool/builtin/bash.go
+++ b/internal/tool/builtin/bash.go
@@ -75,15 +75,22 @@ type bash struct {
 func (bash) Name() string { return "bash" }
 
 func (b bash) Description() string {
-	if b.resolved().Kind == sandbox.ShellPowerShell {
-		return "Execute a command in the shell and return combined stdout/stderr. " +
-			"NOTE: bash is not available on this host — commands run under Windows PowerShell, so write PowerShell, not bash:\n" +
-			"  - chaining: ';' runs both regardless; 'if ($?) { ... }' is conditional. '&&' and '||' are NOT parsed.\n" +
-			"  - redirect/vars: $null not /dev/null; $env:VAR not $VAR; '2>$null' drops stderr.\n" +
-			"  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Select-String (grep).\n" +
-			"  - no head/tail/which/touch: use Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n" +
-			"  - multi-line text to a native exe (e.g. git commit -m): use a single-quoted here-string @'...'@ (closing '@ at column 0)." +
-			bashToolSteer
+	sh := b.resolved()
+	if sh.Kind == sandbox.ShellPowerShell {
+		shellName := "Windows PowerShell"
+		chaining := "';' runs both regardless; 'if ($?) { ... }' is conditional. '&&' and '||' are NOT parsed."
+		if sh.SupportsChaining() {
+			shellName = "PowerShell 7 (pwsh)"
+			chaining = "'&&' and '||' are parsed for conditional chaining; ';' runs both regardless."
+		}
+		return fmt.Sprintf("Execute a command in the shell and return combined stdout/stderr. "+
+			"NOTE: bash is not available on this host — commands run under %s, so write PowerShell, not bash:\n"+
+			"  - chaining: %s\n"+
+			"  - redirect/vars: $null not /dev/null; $env:VAR not $VAR; '2>$null' drops stderr.\n"+
+			"  - file ops: Get-ChildItem (ls), Get-Content (cat), Remove-Item -Recurse -Force (rm -rf), Copy-Item (cp), Select-String (grep).\n"+
+			"  - no head/tail/which/touch: use Select-Object -First/-Last N, (Get-Command x).Source, New-Item.\n"+
+			"  - multi-line text to a native exe (e.g. git commit -m): use a single-quoted here-string @'...'@ (closing '@ at column 0)."+
+			bashToolSteer, shellName, chaining)
 	}
 	return "Execute a command in the shell and return combined stdout/stderr." + bashToolSteer
 }

--- a/internal/tool/builtin/bash_powershell_test.go
+++ b/internal/tool/builtin/bash_powershell_test.go
@@ -103,8 +103,23 @@ func TestBashPowerShellOutputIsUTF8(t *testing.T) {
 
 func TestBashDescriptionReflectsShell(t *testing.T) {
 	ps := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "powershell"}}
-	if !strings.Contains(ps.Description(), "PowerShell") {
-		t.Errorf("powershell description should warn about PowerShell: %q", ps.Description())
+	psDesc := ps.Description()
+	if !strings.Contains(psDesc, "Windows PowerShell") {
+		t.Errorf("powershell description should name Windows PowerShell: %q", psDesc)
+	}
+	if !strings.Contains(psDesc, "'&&' and '||' are NOT parsed") {
+		t.Errorf("powershell description should warn about unsupported chaining: %q", psDesc)
+	}
+	pwsh := bash{shell: sandbox.Shell{Kind: sandbox.ShellPowerShell, Path: "pwsh"}}
+	pwshDesc := pwsh.Description()
+	if !strings.Contains(pwshDesc, "PowerShell 7 (pwsh)") {
+		t.Errorf("pwsh description should name PowerShell 7: %q", pwshDesc)
+	}
+	if !strings.Contains(pwshDesc, "'&&' and '||' are parsed") {
+		t.Errorf("pwsh description should allow conditional chaining: %q", pwshDesc)
+	}
+	if strings.Contains(pwshDesc, "NOT parsed") {
+		t.Errorf("pwsh description should not reuse the Windows PowerShell chaining warning: %q", pwshDesc)
 	}
 	sh := bash{shell: sandbox.Shell{Kind: sandbox.ShellBash, Path: "bash"}}
 	if strings.Contains(sh.Description(), "PowerShell") {


### PR DESCRIPTION
## Summary

- Teach the bash tool description to distinguish Windows PowerShell from PowerShell 7 (`pwsh`).
- Keep the Windows PowerShell warning that `&&` and `||` are not parsed.
- Tell the model that `pwsh` does parse `&&` and `||`, matching the existing `Shell.SupportsChaining()` execution guard.
- Add description coverage for `powershell`, `pwsh`, and normal bash shells.

## Why

The execution path already uses `Shell.SupportsChaining()` to allow conditional chaining under `pwsh`, but the provider-visible bash tool description always said PowerShell could not parse `&&` or `||`. That made the guidance more conservative than the runtime behavior after PS7 is selected.

Refs #4903. Complements #4957.

## Contribution Credits

- Complements the PS7 shell-resolution work in #4957 by @linze0721.
- Follows up on the PS7 compatibility report in #4903 by @baofengweilan.

## Cache impact

Cache-impact: low - this changes the provider-visible builtin bash tool description when PowerShell is selected, but the description remains deterministic and derived only from the resolved shell capability.

Cache-guard: `go test ./internal/boot -run 'TestToolOrder|Test.*Cache|TestBuildDiscoversSkills'`; `go test ./internal/tool/builtin`.

## Verification

- `go test ./internal/tool/builtin`
- `go test ./internal/boot -run 'TestToolOrder|Test.*Cache|TestBuildDiscoversSkills'`
