### PR TITLE
feat(ui): improve sub-agent tool card rendering with badges and icons

### DIFF
--- a/desktop/frontend/src/components/ToolCard.tsx
+++ b/desktop/frontend/src/components/ToolCard.tsx
@@ -12,7 +12,17 @@ import { ReadOnlyBatch } from "./ReadOnlyBatch";
 
 type ToolItem = Extract<Item, { kind: "tool" }>;
 
-const SUBAGENT_TOOLS = new Set(["task", "run_skill", "explore", "research", "review", "security_review"]);
+const SUBAGENT_TOOLS = new Set(["task", "run_skill", "explore", "research", "review", "security_review", "parallel_tasks"]);
+
+const SUBAGENT_ICONS: Record<string, string> = {
+  task: "\u26A1",          // ⚡ execution
+  run_skill: "\uD83E\uDDE0", // 🧠 skill
+  explore: "\uD83D\uDD0D",   // 🔍 explore
+  research: "\uD83D\uDD0D",  // 🔍 research
+  review: "\uD270",         // ✐ review
+  security_review: "\uD83D\uDEE1", // 🛡 security
+  parallel_tasks: "\uD83D\uDD01",  // 🔁 parallel
+};
 
 /** Lines shown by default in a shell output block before the "show all" button. */
 const SHELL_PREVIEW_LINES = 10;
@@ -127,11 +137,11 @@ export const ToolCard = memo(function ToolCard({ item, subcalls, tabId }: { item
         aria-expanded={hasBody ? open : undefined}
       >
         <span className="tool__label-group">
-          {hasNested && <span className="tool__nested-count">⊞{nested.length}</span>}
+          {hasNested && <span className="tool__nested-badge">{nested.length}</span>}
           {item.status === "error" && <span className="tool__status-icon tool__status-icon--err">✗</span>}
           {item.status === "done" && <span className="tool__status-icon tool__status-icon--ok">✓</span>}
           {item.status === "stopped" && <span className="tool__status-icon tool__status-icon--stopped">—</span>}
-          <span className="tool__name">{item.name}</span>
+          <span className="tool__name">{isSubagent && SUBAGENT_ICONS[item.name] ? <span className="tool__subagent-icon">{SUBAGENT_ICONS[item.name]}</span> : null}{item.name}</span>
           {subject && <span className="tool__subject">{subject}</span>}
         </span>
         {profileText && <span className="tool__profile">{profileText}</span>}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -4616,10 +4616,20 @@ a[href] {
   white-space: nowrap;
   min-width: 0;
 }
-.tool__nested-count {
+.tool__nested-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--accent);
+  color: var(--accent-text);
   font-family: var(--mono);
-  font-size: 11px;
-  color: var(--accent);
+  font-size: 10px;
+  font-weight: 650;
+  line-height: 1;
   flex-shrink: 0;
 }
 .tool__status-icon {
@@ -14709,15 +14719,24 @@ a[href] {
    tool__body already provides border-left + 12px padding, so subagent just
    needs left indent for hierarchy.  Expanded padding is handled by
    .tool--open .tool__body. */
+.tool--subagent > .tool__head {
+  border-left: 3px solid var(--accent);
+}
 .tool--subagent .tool__body {
   padding-left: 24px;
+}
+.tool__subagent-icon {
+  margin-right: 4px;
+  font-size: 12px;
+  line-height: 1;
 }
 .tool__nested {
   margin: 8px 0;
   padding-left: 16px;
+  border-left: 2px solid var(--border);
 }
 .tool__nested .tool__nested {
-  border-left: 2px solid var(--border);
+  border-left: 2px solid var(--border-soft);
   margin-left: 16px;
 }
 


### PR DESCRIPTION
## Changes

Improve sub-agent tool card visual rendering:

1. **`⊞3` → numbered badge** — rounded colored badge
2. **Emoji prefix for sub-agent names** — ⚡task, 🔍explore, 🔁parallel_tasks
3. **Colored left border for sub-agent cards** — `border-left: 3px solid var(--accent)`
4. **Nesting connector line** — `2px` vertical line on the left of nested areas
5. **`parallel_tasks` added to SUBAGENT_TOOLS** — enables sub-agent visual style

Cache-impact: none — pure frontend UI change