### PR TITLE
Make running turns escapable after cancel / 取消后保持运行中任务可退出

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -804,6 +804,11 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		usedAnyTool = true
 
 		results := a.executeBatch(ctx, calls)
+		// If the context was cancelled during tool execution, return immediately
+		// so the caller can detect the cancellation instead of continuing the loop.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		for i, call := range calls {
 			a.session.Add(provider.Message{
 				Role:       provider.RoleTool,
@@ -1427,14 +1432,55 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 		durations[i] = time.Since(start).Milliseconds()
 		results[i] = outcomes[i].output
 	}
+	cancelled := false
+	markCancelled := func(start int) {
+		errMsg := context.Canceled.Error()
+		if err := ctx.Err(); err != nil {
+			errMsg = err.Error()
+		}
+		output := "cancelled: context cancelled before execution"
+		for j := start; j < len(calls); j++ {
+			results[j] = output
+			outcomes[j] = toolOutcome{output: output, errMsg: errMsg}
+		}
+		cancelled = true
+	}
 
 	for _, batch := range partitionToolCalls(a.tools, calls) {
+		if ctx.Err() != nil {
+			markCancelled(batch.start)
+			break
+		}
 		if batch.parallel && batch.end-batch.start > 1 {
 			runParallel(batch.start, batch.end, run)
+			// After parallel execution completes, check if context was cancelled.
+			// The individual tool executions should have detected ctx.Done(), but
+			// we verify here to ensure we don't continue to subsequent batches.
+			if ctx.Err() != nil {
+				markCancelled(batch.end)
+				break
+			}
 			continue
 		}
 		for i := batch.start; i < batch.end; i++ {
+			// Before executing the next tool, check if context was cancelled.
+			// This prevents starting new tools when a previous tool's execution
+			// triggered cancellation.
+			if ctx.Err() != nil {
+				markCancelled(i)
+				break
+			}
 			run(i)
+			// After each tool execution, also check if the context was cancelled.
+			// If so, stop executing remaining tools and return immediately so
+			// the agent loop can detect the cancellation and exit.
+			if ctx.Err() != nil {
+				markCancelled(i + 1)
+				break
+			}
+		}
+		if cancelled {
+			break
 		}
 	}
 
@@ -1455,7 +1501,9 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 			a.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: o.truncMsg})
 		}
 	}
-	a.applyStormBreaker(calls, outcomes, results)
+	if !cancelled {
+		a.applyStormBreaker(calls, outcomes, results)
+	}
 	return results
 }
 

--- a/internal/agent/cancel_test.go
+++ b/internal/agent/cancel_test.go
@@ -1,0 +1,321 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"reasonix/internal/agent/testutil"
+	"reasonix/internal/event"
+	"reasonix/internal/provider"
+	"reasonix/internal/tool"
+)
+
+// slowTool is a tool that takes a noticeable amount of time to execute,
+// simulating a long-running bash command or other blocking operation.
+type slowTool struct{}
+
+func (slowTool) Name() string { return "slow_tool" }
+
+func (slowTool) Description() string { return "A tool that executes slowly" }
+
+func (slowTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"duration_ms":{"type":"number","description":"How long to sleep in milliseconds"}},"required":["duration_ms"]}`)
+}
+
+func (slowTool) ReadOnly() bool { return false }
+
+func (slowTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		DurationMs int `json:"duration_ms"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", err
+	}
+	if p.DurationMs <= 0 {
+		p.DurationMs = 500
+	}
+
+	// Simulate work that respects context cancellation
+	select {
+	case <-time.After(time.Duration(p.DurationMs) * time.Millisecond):
+		return "done", nil
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// trackingTool is a tool that records when it was executed and can simulate delays.
+type trackingTool struct {
+	name     string
+	readOnly bool
+}
+
+func (t trackingTool) Name() string {
+	if t.name != "" {
+		return t.name
+	}
+	return "tracking"
+}
+func (trackingTool) Description() string { return "Tracks execution" }
+func (trackingTool) Schema() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"delay_ms":{"type":"number"},"should_fail":{"type":"boolean"}},"required":["name"]}`)
+}
+func (t trackingTool) ReadOnly() bool { return t.readOnly }
+func (trackingTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var p struct {
+		Name       string `json:"name"`
+		DelayMs    int    `json:"delay_ms"`
+		ShouldFail bool   `json:"should_fail"`
+	}
+	if err := json.Unmarshal(args, &p); err != nil {
+		return "", err
+	}
+
+	executedMu.Lock()
+	executed = append(executed, p.Name+"_start")
+	executedMu.Unlock()
+
+	if p.ShouldFail {
+		return "", context.Canceled
+	}
+
+	// Simulate work that respects context cancellation
+	if p.DelayMs > 0 {
+		select {
+		case <-time.After(time.Duration(p.DelayMs) * time.Millisecond):
+			// Completed the delay successfully
+		case <-ctx.Done():
+			executedMu.Lock()
+			executed = append(executed, p.Name+"_cancelled")
+			executedMu.Unlock()
+			return "", ctx.Err()
+		}
+	}
+
+	executedMu.Lock()
+	executed = append(executed, p.Name+"_done")
+	executedMu.Unlock()
+
+	return p.Name + " done", nil
+}
+
+// Global variables for tracking across tests
+var (
+	executedMu sync.Mutex
+	executed   []string
+)
+
+// TestCancelDuringToolExecutionBreaksOutPromptly verifies that when the context
+// is cancelled while tools are executing, the agent loop breaks out immediately
+// rather than continuing to execute remaining tools.
+func TestCancelDuringToolExecutionBreaksOutPromptly(t *testing.T) {
+	reg := tool.NewRegistry()
+	reg.Add(slowTool{})
+
+	// Script: first turn calls two slow tools, but we'll cancel after the first starts
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			Text: "",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "slow_tool", Arguments: `{"duration_ms": 2000}`}, // 2 second tool
+				{ID: "call-2", Name: "slow_tool", Arguments: `{"duration_ms": 2000}`}, // another 2 second tool
+			},
+		},
+	)
+
+	sink := &recordSink{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	// Create a cancellable context and cancel it shortly after starting
+	ctx, cancel := context.WithCancel(context.Background())
+
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx, "test cancel during tool execution")
+	}()
+
+	// Cancel after a short delay to simulate user pressing Esc mid-execution
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	// Wait for the run to complete (should be fast due to cancel, not 4+ seconds)
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not complete within 5s after cancel — context cancellation did not interrupt tool execution")
+	}
+
+	elapsed := time.Since(start)
+
+	// Should have run until the cancel (~300ms) but not completed both tools (4s+)
+	if elapsed < 250*time.Millisecond {
+		t.Fatalf("command exited too fast (%v) — cancel didn't actually interrupt execution; err=%v", elapsed, err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("cancel took too long (%v) — should have broken out after first tool, not waited for all tools", elapsed)
+	}
+
+	// The error should be related to context cancellation
+	if err == nil {
+		t.Log("Run returned nil error after cancel (acceptable if tools detected ctx.Done)")
+	} else {
+		t.Logf("Run returned error after cancel: %v (elapsed: %v)", err, elapsed)
+	}
+}
+
+// TestCancelDuringBatchStopsRemainingTools verifies that when context is
+// cancelled during a batch of tool executions, remaining tools are not executed.
+func TestCancelDuringBatchStopsRemainingTools(t *testing.T) {
+	// Reset tracking
+	executedMu.Lock()
+	executed = nil
+	executedMu.Unlock()
+
+	reg := tool.NewRegistry()
+	reg.Add(trackingTool{})
+
+	// Script: model wants to execute three tools in sequence
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			Text: "",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "tracking", Arguments: `{"name": "tool1", "delay_ms": 50}`},
+				{ID: "call-2", Name: "tracking", Arguments: `{"name": "tool2", "delay_ms": 5000}`}, // Long-running tool
+				{ID: "call-3", Name: "tracking", Arguments: `{"name": "tool3", "delay_ms": 50}`},
+			},
+		},
+	)
+
+	sink := &recordSink{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx, "test batch cancel")
+	}()
+
+	// Cancel while tool2 is still running (after tool1 completes but during tool2)
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	var err error
+	select {
+	case err = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not complete within 10s")
+	}
+
+	executedMu.Lock()
+	executedCopy := make([]string, len(executed))
+	copy(executedCopy, executed)
+	executedMu.Unlock()
+
+	t.Logf("Executed tools: %v (err=%v)", executedCopy, err)
+
+	// We expect tool1 to have completed, tool2 to have been cancelled mid-execution,
+	// and tool3 to NOT have started at all due to our ctx.Err() check after each tool.
+	if len(executedCopy) < 2 { // At least tool1_start should be there
+		t.Error("Expected at least one tool to start execution")
+	}
+
+	// Check that tool3 never started
+	for _, name := range executedCopy {
+		if strings.HasPrefix(name, "tool3") {
+			t.Error("tool3 should not have executed after cancel interrupted the batch")
+		}
+	}
+
+	// Verify tool2 was cancelled
+	foundTool2Cancelled := false
+	for _, name := range executedCopy {
+		if name == "tool2_cancelled" {
+			foundTool2Cancelled = true
+		}
+	}
+	if !foundTool2Cancelled {
+		t.Log("Note: tool2 may have completed or been cancelled - check timing")
+	}
+}
+
+// TestCancelBeforeParallelBatchSkipsTheWholeRemainingBatch verifies that a
+// cancellation in a serial writer segment prevents the next read-only parallel
+// segment from starting.
+func TestCancelBeforeParallelBatchSkipsTheWholeRemainingBatch(t *testing.T) {
+	executedMu.Lock()
+	executed = nil
+	executedMu.Unlock()
+
+	reg := tool.NewRegistry()
+	reg.Add(trackingTool{})
+	reg.Add(trackingTool{name: "readonly_tracking", readOnly: true})
+
+	mp := testutil.NewMock("m",
+		testutil.Turn{
+			Text: "",
+			ToolCalls: []provider.ToolCall{
+				{ID: "call-1", Name: "tracking", Arguments: `{"name": "writer", "delay_ms": 5000}`},
+				{ID: "call-2", Name: "readonly_tracking", Arguments: `{"name": "read1", "delay_ms": 50}`},
+				{ID: "call-3", Name: "readonly_tracking", Arguments: `{"name": "read2", "delay_ms": 50}`},
+			},
+		},
+	)
+
+	sink := &recordSink{}
+	a := New(mp, reg, NewSession(""), Options{}, sink)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx, "test cancel before parallel batch")
+	}()
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil, want context cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not complete within 5s")
+	}
+
+	executedMu.Lock()
+	executedCopy := append([]string(nil), executed...)
+	executedMu.Unlock()
+	for _, name := range executedCopy {
+		if strings.HasPrefix(name, "read") {
+			t.Fatalf("read-only parallel batch should not start after cancel, executed: %v", executedCopy)
+		}
+	}
+
+	results := sink.kinds(event.ToolResult)
+	if len(results) != 3 {
+		t.Fatalf("ToolResult events = %d, want 3", len(results))
+	}
+	for _, e := range results[1:] {
+		if e.Tool.Err == "" {
+			t.Fatalf("cancelled unstarted tool result should carry an error: %+v", e.Tool)
+		}
+		if !strings.Contains(e.Tool.Output, "cancelled") {
+			t.Fatalf("cancelled unstarted tool result should explain cancellation: %+v", e.Tool)
+		}
+	}
+}

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -1019,6 +1019,9 @@ func (m chatTUI) update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				if m.bubblePending {
 					m.unsendPending() // server not yet replied — restore text, leave no trace
+				} else if m.cancelRequested() {
+					m.ctrl.Cancel()
+					return m, tea.Quit
 				} else {
 					m.ctrl.Cancel()
 				}
@@ -2165,6 +2168,46 @@ var (
 	workingStyle        lipgloss.Style
 )
 
+func (m chatTUI) cancelRequested() bool {
+	if m.state != tuiRunning || m.ctrl == nil {
+		return false
+	}
+	return m.ctrl.CancelRequested()
+}
+
+func (m chatTUI) runningWorkingLine(cancelRequested, styled bool) string {
+	if m.state != tuiRunning {
+		return ""
+	}
+	if m.retryAttempt > 0 && !cancelRequested {
+		return fmt.Sprintf("  "+i18n.M.ChatStatusRetryingFmt, m.spinner.View(), m.retryAttempt, m.retryMax)
+	}
+
+	var working string
+	if cancelRequested {
+		working = fmt.Sprintf("  "+i18n.M.ChatStatusCancellingFmt, m.spinner.View(), m.elapsed)
+	} else {
+		working = fmt.Sprintf("  "+i18n.M.ChatStatusThinkingFmt, m.spinner.View(), m.elapsed)
+	}
+	if m.turnTokens > 0 {
+		working += " · ↓" + shortTokens(m.turnTokens)
+	}
+	if n := len(m.pendingInterject); n > 0 {
+		var queued string
+		if n == 1 {
+			queued = " · ✎ feedback queued"
+		} else {
+			queued = fmt.Sprintf(" · ✎ %d queued", n)
+		}
+		if styled {
+			working += dim(queued)
+		} else {
+			working += queued
+		}
+	}
+	return working
+}
+
 func (m chatTUI) View() tea.View {
 	boxW := m.width
 	if boxW < 10 {
@@ -2172,6 +2215,7 @@ func (m chatTUI) View() tea.View {
 	}
 	hideComposer := m.hideComposer()
 	shellMode := strings.HasPrefix(strings.TrimSpace(m.input.Value()), "!")
+	cancelRequested := m.cancelRequested()
 	var box string
 	if !hideComposer {
 		style := inputBoxStyle.Width(boxW)
@@ -2227,6 +2271,8 @@ func (m chatTUI) View() tea.View {
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusPlanApproval
 	case m.pendingApproval != nil:
 		status = "  " + modeTag + " · " + i18n.M.ChatStatusToolApproval
+	case cancelRequested:
+		status = "  " + modeTag + " · " + i18n.M.CtrlCQuitHint
 	case shellMode:
 		status = "  " + modeTag + " · " + i18n.M.ShellModeHint
 	case m.ctrl.AutoApproveTools():
@@ -2243,24 +2289,7 @@ func (m chatTUI) View() tea.View {
 	// The spinning "thinking…" indicator is its own line ABOVE the input box (shown
 	// only while a turn runs); the status/data rows stay below. This mirrors Claude
 	// Code: live progress over the composer, shortcuts + stats under it.
-	var working string
-	if m.state == tuiRunning {
-		if m.retryAttempt > 0 {
-			working = fmt.Sprintf("  "+i18n.M.ChatStatusRetryingFmt, m.spinner.View(), m.retryAttempt, m.retryMax)
-		} else {
-			working = fmt.Sprintf("  "+i18n.M.ChatStatusThinkingFmt, m.spinner.View(), m.elapsed)
-			if m.turnTokens > 0 {
-				working += " · ↓" + shortTokens(m.turnTokens)
-			}
-			if n := len(m.pendingInterject); n > 0 {
-				if n == 1 {
-					working += dim(" · ✎ feedback queued")
-				} else {
-					working += dim(fmt.Sprintf(" · ✎ %d queued", n))
-				}
-			}
-		}
-	}
+	working := m.runningWorkingLine(cancelRequested, true)
 	// Second status row: the live data (model, git, effort, context gauge, cache
 	// rates, jobs, balance). It lives on its own row so it's always visible; if it
 	// exceeds the terminal width it wraps to additional rows instead of being
@@ -2689,6 +2718,7 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 		return 2 // safe default for tests without a real controller
 	}
 	shellMode := strings.HasPrefix(strings.TrimSpace(m.input.Value()), "!")
+	cancelRequested := m.cancelRequested()
 
 	// Replicate the first status line (mode tag + state) from View().
 	// ModeTag is rendered with Padding(0,1) in View() — add the same padding
@@ -2715,6 +2745,8 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 		status += " · " + i18n.M.ChatStatusPlanApproval
 	case m.pendingApproval != nil:
 		status += " · " + i18n.M.ChatStatusToolApproval
+	case cancelRequested:
+		status += " · " + i18n.M.CtrlCQuitHint
 	case shellMode:
 		status += " · " + i18n.M.ShellModeHint
 	case m.ctrl.AutoApproveTools():
@@ -2752,24 +2784,7 @@ func (m chatTUI) computeStatusLineCount(width int) int {
 	}
 
 	// Replicate the working (spinner) line from View(), shown only while a turn runs.
-	var working string
-	if m.state == tuiRunning {
-		if m.retryAttempt > 0 {
-			working = fmt.Sprintf("  "+i18n.M.ChatStatusRetryingFmt, m.spinner.View(), m.retryAttempt, m.retryMax)
-		} else {
-			working = fmt.Sprintf("  "+i18n.M.ChatStatusThinkingFmt, m.spinner.View(), m.elapsed)
-			if m.turnTokens > 0 {
-				working += " · ↓" + shortTokens(m.turnTokens)
-			}
-			if n := len(m.pendingInterject); n > 0 {
-				if n == 1 {
-					working += " · ✎ feedback queued"
-				} else {
-					working += fmt.Sprintf(" · ✎ %d queued", n)
-				}
-			}
-		}
-	}
+	working := m.runningWorkingLine(cancelRequested, false)
 
 	// Count wrapped rows for every piece that View() renders as wrapped.
 	var lines int

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -24,6 +24,11 @@ import (
 
 type blockingTurnRunner struct{ started chan struct{} }
 
+type stubbornTurnRunner struct {
+	started chan struct{}
+	release chan struct{}
+}
+
 func TestMain(m *testing.M) {
 	old := detectTermuxTerminal
 	detectTermuxTerminal = func() bool { return false }
@@ -35,6 +40,12 @@ func TestMain(m *testing.M) {
 func (r *blockingTurnRunner) Run(ctx context.Context, _ string) error {
 	close(r.started)
 	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (r *stubbornTurnRunner) Run(ctx context.Context, _ string) error {
+	close(r.started)
+	<-r.release
 	return ctx.Err()
 }
 
@@ -1653,6 +1664,55 @@ func TestDoubleCtrlCQuit(t *testing.T) {
 	// lastCtrlCAt should be refreshed to now.
 	if time.Since(m4.lastCtrlCAt) > time.Second {
 		t.Error("expired Ctrl+C should refresh lastCtrlCAt")
+	}
+}
+
+func TestSecondCtrlCQuitsAfterCancelIsAlreadyRequested(t *testing.T) {
+	r := &stubbornTurnRunner{started: make(chan struct{}), release: make(chan struct{})}
+	ctrl := control.New(control.Options{Runner: r, Sink: event.Discard, SessionDir: t.TempDir(), Label: "test"})
+	ctrl.Send("hi")
+	<-r.started
+	defer close(r.release)
+
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+	m.state = tuiRunning
+	ctrlC := tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}
+
+	_, firstCmd := m.Update(ctrlC)
+	if firstCmd != nil {
+		t.Fatal("first Ctrl+C while running should request cancel, not quit")
+	}
+	if st := ctrl.RuntimeStatus(); !st.Running || !st.CancelRequested {
+		t.Fatalf("first Ctrl+C status = %+v, want running cancel requested", st)
+	}
+
+	_, secondCmd := m.Update(ctrlC)
+	if secondCmd == nil {
+		t.Fatal("second Ctrl+C after cancel request should quit")
+	}
+	if msg := secondCmd(); msg != (tea.QuitMsg{}) {
+		t.Fatalf("second Ctrl+C command = %T, want tea.QuitMsg", msg)
+	}
+}
+
+func TestRunningStatusShowsCancelRequested(t *testing.T) {
+	r := &stubbornTurnRunner{started: make(chan struct{}), release: make(chan struct{})}
+	ctrl := control.New(control.Options{Runner: r, Sink: event.Discard, SessionDir: t.TempDir(), Label: "test"})
+	ctrl.Send("hi")
+	<-r.started
+	defer close(r.release)
+
+	m := newTestChatTUI()
+	m.ctrl = ctrl
+	m.state = tuiRunning
+	m.width = 80
+	m.height = 24
+	ctrl.Cancel()
+
+	view := ansi.Strip(m.View().Content)
+	if !strings.Contains(view, "stopping") {
+		t.Fatalf("running status after cancel should show stopping feedback:\n%s", view)
 	}
 }
 

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1285,6 +1285,13 @@ func (c *Controller) Running() bool {
 	return c.running
 }
 
+// CancelRequested reports whether Cancel has been requested for the active turn.
+func (c *Controller) CancelRequested() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.canceling
+}
+
 // PendingPrompt reports whether the current turn is blocked waiting for a user
 // approval, plan approval, memory approval, or ask-tool answer.
 func (c *Controller) PendingPrompt() bool {

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -58,6 +58,7 @@ type TurnControl interface {
 	Steer(text string)
 	SteerConsumed() bool
 	Running() bool
+	CancelRequested() bool
 	RuntimeStatus() RuntimeStatus
 	Turn() int
 	History() []provider.Message

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -73,6 +73,7 @@ type Messages struct {
 	ChatStatusThinkingFmt       string // "%s thinking… (%ds · <cancel hint>)" — %s = spinner, %d = elapsed s
 	ChatToolWorkingFmt          string // "%s working · %ds" under a running tool — %s = spinner, %d = elapsed s
 	ChatStatusRetryingFmt       string // "%s retrying (%d/%d)…" — %s = spinner, %d/%d = attempt/max
+	ChatStatusCancellingFmt     string // "%s stopping… (%ds · Ctrl+C exits)" — %s = spinner, %d = elapsed s
 	ChatStatusIdle              string // shortcuts hint when idle
 	ChatStatusYoloIdle          string // shortcuts hint when idle in YOLO/bypass mode
 	ChatStatusCycleHint         string // plan-toggle shortcut hint shown when no modal prompt owns the status row

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -47,6 +47,7 @@ var English = Messages{
 	ChatStatusThinkingFmt:       "%s thinking… (%ds · Esc cancels)",
 	ChatToolWorkingFmt:          "%s working · %ds",
 	ChatStatusRetryingFmt:       "%s retrying (%d/%d)… (Esc cancels)",
+	ChatStatusCancellingFmt:     "%s stopping… (%ds · Ctrl+C exits)",
 	ChatStatusIdle:              "ready",
 	ChatStatusYoloIdle:          "tool approvals skipped",
 	ChatStatusCycleHint:         "shift+tab toggles plan · ctrl+y yolo",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -48,6 +48,7 @@ var Chinese = Messages{
 	ChatStatusThinkingFmt:       "%s 思考中… (%d 秒 · Esc 取消)",
 	ChatToolWorkingFmt:          "%s 运行中 · %d 秒",
 	ChatStatusRetryingFmt:       "%s 正在重试 (%d/%d)… (Esc 取消)",
+	ChatStatusCancellingFmt:     "%s 正在停止… (%d 秒 · Ctrl+C 退出)",
 	ChatStatusIdle:              "就绪",
 	ChatStatusYoloIdle:          "已跳过工具批准",
 	ChatStatusCycleHint:         "shift+tab 切换计划 · ctrl+y yolo",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -44,6 +44,7 @@ var ChineseTraditional = Messages{
 	ChatStatusThinkingFmt:       "%s 思考中… (%d 秒 · Esc 取消)",
 	ChatToolWorkingFmt:          "%s 執行中 · %d 秒",
 	ChatStatusRetryingFmt:       "%s 正在重試 (%d/%d)… (Esc 取消)",
+	ChatStatusCancellingFmt:     "%s 正在停止… (%d 秒 · Ctrl+C 退出)",
 	ChatStatusIdle:              "就緒",
 	ChatStatusYoloIdle:          "已跳過核准",
 	ChatStatusCycleHint:         "shift+tab 循環切換",


### PR DESCRIPTION
## Summary

Fixes #4860.
Supersedes #4900 and #4924 by integrating both cancellation layers into one PR against the latest `main-v2`.

This PR keeps the strongest parts of both source PRs:

- The TUI now shows an explicit cancel-pending state (`stopping...`) and lets a second `Ctrl+C` quit when the current turn is already cancelling.
- The agent now stops scheduling remaining tool calls once cancellation is observed during a batch.
- Cancelled-but-unstarted tools now emit explicit cancelled results instead of empty successful-looking tool result cards.
- The current `SessionAPI` port includes `CancelRequested()` so the TUI can depend on the interface contract instead of the concrete controller.

## Source PR Matrix

| Source | Contributor | What it contributed | Final treatment |
| --- | --- | --- | --- |
| #4860 | @weiw33 | Reported the long-running TUI cancellation failure where `Esc`/`Ctrl+C` could leave the UI stuck while other keys still responded. | Kept as the fixed issue and product symptom. |
| #4900 | @GTC2080 | Added the TUI escape hatch: cancel-pending state, second `Ctrl+C` quit behavior, `stopping...` status copy, i18n strings, and focused TUI tests. | Kept and adapted to the current `SessionAPI` interface. |
| #4924 | @liaoyl830 | Added agent-level cancellation checks around `executeBatch()` and regression coverage for cancelling during tool execution. | Kept and strengthened. |
| #4924 follow-up | @SivanCola | Reviewed the agent batch behavior, fixed the remaining-batch and empty ToolResult gaps, added coverage for cancellation before a parallel read-only batch, and integrated both source PRs on latest `main-v2`. | Kept in this integrated PR. |

## Consolidation Notes

Kept/adapted:
- #4900's UI-level escape path, including second-press quit and cancel-pending feedback.
- #4924's agent-level cancellation path, including prompt exit after a cancelled tool batch.
- The follow-up fix that prevents later batches from starting after cancellation and marks unstarted tools as cancelled.
- A small integration update to `internal/control/port.go` so the current interface-based frontend path exposes `CancelRequested()`.

Reviewed but not adopted:
- None. Both source PRs solved different layers of the same bug and are represented here.

## Repository Contributor Credits

This integrated fix credits the following people as repository contributors:

- @weiw33 contributed the original bug report and user-facing failure context in #4860.
- @GTC2080 contributed the TUI/controller escape-path design and implementation in #4900.
- @liaoyl830 contributed the agent `executeBatch()` cancellation implementation and tests in #4924.
- @SivanCola contributed review, follow-up fixes, integration on latest `main-v2`, and final verification.

## Cache Impact

Cache-impact: none - This changes CLI key handling/status rendering, controller runtime-state access, and internal agent tool scheduling after cancellation. It does not change system prompts, provider request serialization, tool schemas, tool ordering, memory prefixes, or reasoning upload behavior.
Cache-guard: `go test ./internal/agent -run TestCancel -v` covers the cache-sensitive agent cancellation path; `go test ./...` verifies the integrated change broadly.

## Verification

- `go test ./internal/agent -run TestCancel -v`
- `go test ./internal/cli -run 'Test(SecondCtrlCQuitsAfterCancelIsAlreadyRequested|RunningStatusShowsCancelRequested|EscCancelsRunningTurnWithCompletionOpen|DoubleCtrlCQuit)' -count=1 -v`
- `go test ./internal/agent ./internal/cli ./internal/control ./internal/i18n -count=1`
- `go test ./...`
- `git diff --check`

