### PR TITLE
Preserve cancelled batch results / 保留取消批次结果

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -804,11 +804,6 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 		usedAnyTool = true
 
 		results := a.executeBatch(ctx, calls)
-		// If the context was cancelled during tool execution, return immediately
-		// so the caller can detect the cancellation instead of continuing the loop.
-		if ctx.Err() != nil {
-			return ctx.Err()
-		}
 		for i, call := range calls {
 			a.session.Add(provider.Message{
 				Role:       provider.RoleTool,
@@ -816,6 +811,11 @@ func (a *Agent) Run(ctx context.Context, input string) error {
 				ToolCallID: call.ID,
 				Name:       call.Name,
 			})
+		}
+		// If the context was cancelled during tool execution, return after storing
+		// the batch results so the session keeps paired tool-call history.
+		if ctx.Err() != nil {
+			return ctx.Err()
 		}
 
 		// The prompt only grows from here; compact before the next turn so it
@@ -1452,12 +1452,12 @@ func (a *Agent) executeBatch(ctx context.Context, calls []provider.ToolCall) []s
 			break
 		}
 		if batch.parallel && batch.end-batch.start > 1 {
-			runParallel(batch.start, batch.end, run)
+			ranUntil := runParallel(ctx, batch.start, batch.end, run)
 			// After parallel execution completes, check if context was cancelled.
 			// The individual tool executions should have detected ctx.Done(), but
 			// we verify here to ensure we don't continue to subsequent batches.
 			if ctx.Err() != nil {
-				markCancelled(batch.end)
+				markCancelled(ranUntil)
 				break
 			}
 			continue
@@ -1568,14 +1568,28 @@ func parallelisable(r *tool.Registry, name string) bool {
 	return ok && t.ReadOnly()
 }
 
-func runParallel(start, end int, run func(int)) {
+func runParallel(ctx context.Context, start, end int, run func(int)) int {
 	const maxParallel = 8
 	sem := make(chan struct{}, maxParallel)
 	var wg sync.WaitGroup
+	ranUntil := start
+launch:
 	for i := start; i < end; i++ {
+		if ctx.Err() != nil {
+			break
+		}
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			break launch
+		}
+		if ctx.Err() != nil {
+			<-sem
+			break
+		}
 		i := i
-		sem <- struct{}{}
 		wg.Add(1)
+		ranUntil = i + 1
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -1583,6 +1597,7 @@ func runParallel(start, end int, run func(int)) {
 		}()
 	}
 	wg.Wait()
+	return ranUntil
 }
 
 // stormBreakThreshold is how many times in a row the same tool may fail the same

--- a/internal/agent/cancel_test.go
+++ b/internal/agent/cancel_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -248,6 +249,14 @@ func TestCancelDuringBatchStopsRemainingTools(t *testing.T) {
 	if !foundTool2Cancelled {
 		t.Log("Note: tool2 may have completed or been cancelled - check timing")
 	}
+
+	toolsByID := toolMessagesByID(a.Session().Messages)
+	if got := toolsByID["call-1"]; !strings.Contains(got, "tool1 done") {
+		t.Fatalf("completed tool result was not persisted before cancellation: %q", got)
+	}
+	if got := toolsByID["call-3"]; !strings.Contains(got, "cancelled") {
+		t.Fatalf("skipped tool result was not persisted as cancelled: %q", got)
+	}
 }
 
 // TestCancelBeforeParallelBatchSkipsTheWholeRemainingBatch verifies that a
@@ -318,4 +327,75 @@ func TestCancelBeforeParallelBatchSkipsTheWholeRemainingBatch(t *testing.T) {
 			t.Fatalf("cancelled unstarted tool result should explain cancellation: %+v", e.Tool)
 		}
 	}
+}
+
+func TestCancelInsideLargeParallelBatchStopsSchedulingNewTools(t *testing.T) {
+	executedMu.Lock()
+	executed = nil
+	executedMu.Unlock()
+
+	reg := tool.NewRegistry()
+	reg.Add(trackingTool{name: "readonly_tracking", readOnly: true})
+
+	var calls []provider.ToolCall
+	for i := 0; i < 12; i++ {
+		calls = append(calls, provider.ToolCall{
+			ID:        fmt.Sprintf("call-%02d", i),
+			Name:      "readonly_tracking",
+			Arguments: fmt.Sprintf(`{"name": "read%02d", "delay_ms": 5000}`, i),
+		})
+	}
+
+	mp := testutil.NewMock("m", testutil.Turn{ToolCalls: calls})
+	a := New(mp, reg, NewSession(""), Options{}, &recordSink{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- a.Run(ctx, "test cancel inside parallel batch")
+	}()
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Run returned nil, want context cancellation")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not complete within 5s")
+	}
+
+	executedMu.Lock()
+	executedCopy := append([]string(nil), executed...)
+	executedMu.Unlock()
+	for _, name := range executedCopy {
+		for i := 8; i < 12; i++ {
+			if strings.HasPrefix(name, fmt.Sprintf("read%02d", i)) {
+				t.Fatalf("parallel scheduler started a tool after cancellation: %v", executedCopy)
+			}
+		}
+	}
+
+	toolsByID := toolMessagesByID(a.Session().Messages)
+	if len(toolsByID) != len(calls) {
+		t.Fatalf("persisted tool messages = %d, want %d: %#v", len(toolsByID), len(calls), toolsByID)
+	}
+	if got := toolsByID["call-08"]; !strings.Contains(got, "cancelled") {
+		t.Fatalf("unstarted parallel tool result was not persisted as cancelled: %q", got)
+	}
+}
+
+func toolMessagesByID(msgs []provider.Message) map[string]string {
+	out := make(map[string]string)
+	for _, m := range msgs {
+		if m.Role == provider.RoleTool {
+			out[m.ToolCallID] = m.Content
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## Summary

Follow-up to #4975. This addresses both Codex review findings on the merged cancellation integration:

- Preserve the ordered tool results from a cancelled batch in the session before returning `ctx.Err()`.
- Stop scheduling new read-only tools inside a large parallel batch once cancellation is observed, not only between batches.

## What Changed

- Move the post-`executeBatch` cancellation return until after `RoleTool` messages are appended, keeping assistant tool calls paired with their real completed/skipped results.
- Make `runParallel` context-aware and return the first unstarted call index so `executeBatch` can mark only unstarted calls as cancelled.
- Extend cancellation coverage to verify persisted completed/skipped tool results and a 12-call read-only parallel batch that cancels while the first 8 workers are running.

## Cache Impact

Cache-impact: none - This only changes internal agent cancellation scheduling and session persistence after cancellation. It does not change system prompts, provider request serialization, tool schemas, tool ordering, memory prefixes, or reasoning upload behavior.
Cache-guard: `go test ./internal/agent -run TestCancel -v` covers the affected cancellation paths, including large parallel batches; `go test ./...` verifies the broader tree.

## Verification

- `go test ./internal/agent -run TestCancel -v`
- `go test ./internal/agent -count=1`
- `go test ./...`
- `git diff --check`

Refs #4975.
