### PR TITLE
perf: 优化对话删除流程 — 前端本地移除 + 锁外写磁盘

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1711,8 +1711,10 @@ func (a *App) removeSessionRuntimeBindings(dir, sessionPath string) ([]removedSe
 		a.activeTabID = a.tabOrder[0]
 	}
 	fallback.needs = len(removed) > 0 && len(a.tabs) == 0
-	a.saveTabsLocked()
+	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
+
+	a.saveTabsWrite(dir, entries, activeID, version)
 
 	return removed, fallback
 }
@@ -1754,8 +1756,10 @@ func (a *App) removeTopicRuntimeBindings(topicID string) ([]removedSessionRuntim
 		a.activeTabID = a.tabOrder[0]
 	}
 	fallback.needs = len(removed) > 0 && len(a.tabs) == 0
-	a.saveTabsLocked()
+	dir, entries, activeID, version := a.saveTabsCollectLocked()
 	a.mu.Unlock()
+
+	a.saveTabsWrite(dir, entries, activeID, version)
 
 	return removed, fallback
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2251,16 +2251,15 @@ export default function App() {
     async (path: string) => {
       if (state.running) return;
       await deleteSession(path);
-      const sessions = await listSessions();
+      // Local state removal: filter the deleted session out of the current
+      // history view instead of re-fetching the full list from the backend.
       setHistView((cur) =>
-        cur === null
-          ? null
-          : cur.kind === "history"
-            ? { ...cur, sessions: cur.source === "scope" ? sessionsForScope(sessions, cur.filter) : sessions }
-            : cur,
+        cur === null || cur.kind !== "history"
+          ? cur
+          : { ...cur, sessions: cur.sessions.filter((s) => s.path !== path) },
       );
     },
-    [state.running, deleteSession, listSessions],
+    [state.running, deleteSession],
   );
   const onRenameSession = useCallback(
     async (path: string, title: string) => {

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2250,7 +2250,15 @@ export default function App() {
   const onDeleteSession = useCallback(
     async (path: string) => {
       if (state.running) return;
-      await deleteSession(path);
+      try {
+        await deleteSession(path);
+      } catch {
+        // If the backend could not delete the session (validation, snapshot,
+        // or I/O failure), keep it in the history panel.  The old
+        // listSessions() refresh masked this by re-reading disk; with local
+        // state removal we must let the error propagate.
+        return;
+      }
       // Local state removal: filter the deleted session out of the current
       // history view instead of re-fetching the full list from the backend.
       setHistView((cur) =>

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -1141,7 +1141,7 @@ export function useController() {
   }, [dispatchTo, refreshCheckpoints, waitForTabReady]);
 
   const previewSession = useCallback(async (path: string): Promise<HistoryMessage[]> => asArray<HistoryMessage>(await app.PreviewSession(path).catch(() => [])), []);
-  const deleteSession = useCallback((path: string) => app.DeleteSession(path).catch(() => {}).finally(() => invalidateCache()), []);
+  const deleteSession = useCallback((path: string) => app.DeleteSession(path).finally(() => invalidateCache()), []);
   const restoreSession = useCallback((path: string) => app.RestoreSession(path).catch(() => {}).finally(() => invalidateCache()), []);
   const purgeTrashedSession = useCallback((path: string) => app.PurgeTrashedSession(path).catch(() => {}).finally(() => invalidateCache()), []);
   const renameSession = useCallback((path: string, title: string) => app.RenameSession(path, title).catch(() => {}).finally(() => invalidateCache()), []);


### PR DESCRIPTION
## 优化点

**1. 前端 onDeleteSession: 删除后不调用 listSessions() 全量重拉**

改为从当前 state 中直接 filter 掉被删除的会话，省掉一次 Wails IPC 调用 + 后端全量扫描所有 .jsonl 文件的开销。

**2. removeSessionRuntimeBindings / removeTopicRuntimeBindings: 锁外写磁盘**

将 `saveTabsLocked()` 拆分为锁内收集 + 锁外写入，磁盘 I/O（序列化 JSON + 写文件）不再在持有 a.mu 大锁期间进行，减少对其他并发操作的阻塞。

## 变更文件

- `desktop/app.go` — 两处锁内收集/锁外写入拆分（+8/-2 行）
- `desktop/frontend/src/App.tsx` — onDeleteSession 本地 state 移除（+5/-8 行）