### PR TITLE
fix(desktop): surface CLI sessions in sidebar

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3049,10 +3049,10 @@ func activityStatusForTab(tab *WorkspaceTab) string {
 var legacyMigrationMu sync.Mutex
 
 // topicMigrationMarker, once written into a session dir, records that the
-// pre-topic → Global-topic migration pass completed for that dir, so the
-// per-render ListProjectTree call can skip the full session scan instead of
-// re-reading every .jsonl + sidecar only to find nothing left to migrate. New
-// sessions are born with a TopicID, so no fresh legacy files appear afterwards.
+// pre-topic → Global-topic migration pass completed for that dir. Later
+// ListProjectTree calls can skip the full session decode while the marker is
+// newer than the directory's session files, but a newly-created CLI session
+// invalidates the marker and gets a bounded re-scan.
 // It is stamped only when the pass left nothing deferred (an empty legacy
 // session that could gain content later keeps the dir unmarked), so the gate
 // never hides a session that should still be migrated.
@@ -3063,8 +3063,32 @@ func topicMigrationDone(dir string) bool {
 	if dir == "" {
 		return false
 	}
-	_, err := os.Stat(filepath.Join(dir, topicMigrationMarker))
-	return err == nil
+	markerInfo, err := os.Stat(filepath.Join(dir, topicMigrationMarker))
+	if err != nil {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return true
+	}
+	markerTime := markerInfo.ModTime()
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if filepath.Ext(name) != ".jsonl" && !strings.HasSuffix(name, ".jsonl.meta") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return false
+		}
+		if info.ModTime().After(markerTime) {
+			return false
+		}
+	}
+	return true
 }
 
 func markTopicMigrationDone(dir string) {

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -3087,25 +3087,9 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 	if topicMigrationDone(dir) {
 		return nil
 	}
-	// Determine scope from the directory. The global session dir gets Global
-	// topics; a project session dir gets project-scoped topics under the
-	// matching workspace.
-	scope := "global"
-	workspaceRoot := ""
-	topicTitleRoot := "" // workspace root for topic-title persistence
-	if dir != config.SessionDir() {
-		f := loadProjectsFile()
-		for _, p := range f.Projects {
-			if config.ProjectSessionDir(p.Root) == dir {
-				scope = "project"
-				workspaceRoot = p.Root
-				topicTitleRoot = p.Root
-				break
-			}
-		}
-		if scope != "project" {
-			return nil // not a recognized project dir; skip
-		}
+	scope, workspaceRoot, topicTitleRoot, ok := legacyMigrationTargetForDir(dir)
+	if !ok {
+		return nil
 	}
 	legacyMigrationMu.Lock()
 	defer legacyMigrationMu.Unlock()
@@ -3135,7 +3119,7 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		if meta, ok, err := agent.LoadBranchMeta(info.Path); err != nil {
 			deferred = true
 			continue
-		} else if ok && (meta.Scope != "" || strings.TrimSpace(meta.WorkspaceRoot) != "" || strings.TrimSpace(meta.TopicID) != "") {
+		} else if ok && !legacySessionMetaMatchesMigrationTarget(meta, scope, workspaceRoot) {
 			continue
 		}
 		topicID := legacySessionTopicID(info.Path)
@@ -3173,9 +3157,9 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 			deferred = true
 			continue
 		}
-		// Skip sessions that already have a scope or workspace — they were
-		// already assigned by a previous run or by the user.
-		if meta.Scope != "" || strings.TrimSpace(meta.WorkspaceRoot) != "" {
+		// Preserve scoped sessions only when their existing ownership matches
+		// the directory being migrated.
+		if !legacySessionMetaMatchesMigrationTarget(meta, scope, workspaceRoot) {
 			continue
 		}
 		meta.Scope = scope
@@ -3224,10 +3208,65 @@ func migrateLegacySessionsIntoGlobalTopics(dir string) []string {
 		_ = saveTopicTitleSources(topicTitleRoot, topicSources)
 	}
 	invalidateTopicSessionIndex(dir)
+	projectSessionCache.invalidate()
 	if !deferred {
 		markTopicMigrationDone(dir) // pass complete with nothing deferred
 	}
 	return migratedTopicIDs
+}
+
+func legacyMigrationTargetForDir(dir string) (scope, workspaceRoot, topicTitleRoot string, ok bool) {
+	dir = cleanDesktopPath(dir)
+	if dir == "" {
+		return "", "", "", false
+	}
+	if sameDesktopPath(dir, config.SessionDir()) || sameDesktopPath(dir, desktopSessionDir(globalWorkspaceRoot())) {
+		return "global", "", "", true
+	}
+	for _, p := range loadProjectsFile().Projects {
+		if sameDesktopPath(config.ProjectSessionDir(p.Root), dir) {
+			return "project", p.Root, p.Root, true
+		}
+	}
+	return "", "", "", false
+}
+
+func legacySessionMetaMatchesMigrationTarget(meta agent.BranchMeta, scope, workspaceRoot string) bool {
+	if strings.TrimSpace(meta.TopicID) != "" {
+		return false
+	}
+	metaScope := strings.TrimSpace(meta.Scope)
+	if metaScope != "" && metaScope != scope {
+		return false
+	}
+	metaRoot := normalizeProjectRoot(meta.WorkspaceRoot)
+	if scope == "project" {
+		return metaRoot == "" || normalizeProjectRoot(workspaceRoot) == metaRoot
+	}
+	return metaRoot == "" || normalizeProjectRoot(globalWorkspaceRoot()) == metaRoot
+}
+
+func cleanDesktopPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return filepath.Clean(path)
+}
+
+func sameDesktopPath(a, b string) bool {
+	a = cleanDesktopPath(a)
+	b = cleanDesktopPath(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if os.PathSeparator == '\\' {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
 }
 
 func restoreSessionTopicIndex(dir, sessionPath string) error {
@@ -3900,7 +3939,10 @@ func (a *App) ListProjectTree() []ProjectNode {
 	listProjectTreeMu.Lock()
 	defer listProjectTreeMu.Unlock()
 
-	migrateLegacySessionsIntoGlobalTopics(config.SessionDir())
+	knownDirs := a.knownSessionDirs()
+	for _, dir := range knownDirs {
+		migrateLegacySessionsIntoGlobalTopics(dir)
+	}
 	f := loadProjectsFile()
 	out := []ProjectNode{}
 	type runtimeSessionStatus struct {
@@ -3927,7 +3969,6 @@ func (a *App) ListProjectTree() []ProjectNode {
 		titles map[string]string
 		ok     bool
 	}
-	knownDirs := a.knownSessionDirs()
 	results := make(chan sessionDirLoadResult, len(knownDirs))
 	pendingLoads := 0
 	for _, dir := range knownDirs {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1844,6 +1844,51 @@ func TestLegacyMigrationSkipsProjectScopedSessions(t *testing.T) {
 	}
 }
 
+func TestProjectTreeMigratesCLISessionFromProjectDir(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	dir := config.ProjectSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessionPath := writeLegacySession(t, dir, "cli-project.jsonl", "cli project prompt", time.Now())
+	wantTopicID := legacySessionTopicID(sessionPath)
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "project" || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != wantTopicID {
+		t.Fatalf("project CLI session should appear in project tree, got %#v; want topic %q", nodes, wantTopicID)
+	}
+}
+
+func TestProjectTreeMigratesCLISessionFromGlobalWorkspaceDir(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	globalRoot := globalWorkspaceRoot()
+	dir := desktopSessionDir(globalRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sessionPath := writeLegacySession(t, dir, "cli-global.jsonl", "cli global prompt", time.Now())
+	if err := agent.SaveBranchMetaPreserveUpdated(sessionPath, agent.BranchMeta{
+		CreatedAt:     time.Now().Add(-time.Minute),
+		UpdatedAt:     time.Now(),
+		Scope:         "global",
+		WorkspaceRoot: globalRoot,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	wantTopicID := legacySessionTopicID(sessionPath)
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "global_folder" || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != wantTopicID {
+		t.Fatalf("global workspace CLI session should appear in Global, got %#v; want topic %q", nodes, wantTopicID)
+	}
+}
+
 func TestLegacyMigrationConcurrentRunsHaveNoLostUpdates(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := config.SessionDir()

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -462,7 +462,7 @@ func TestLegacySessionsMigrateIntoGlobalTopics(t *testing.T) {
 	}
 }
 
-func TestTopicMigrationMarkerGatesRescan(t *testing.T) {
+func TestTopicMigrationMarkerRescansWhenSessionFileChanges(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	dir := config.SessionDir()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -477,17 +477,17 @@ func TestTopicMigrationMarkerGatesRescan(t *testing.T) {
 		t.Fatalf("expected migration marker after a complete pass: %v", err)
 	}
 
-	// A legacy session added after the marker is left un-migrated: the gate skips
-	// the per-render scan entirely (real new sessions are born with a TopicID, so
-	// no fresh legacy files actually appear after the pass).
+	// A CLI-created session added after the marker invalidates the lightweight
+	// gate and gets a fresh migration pass.
+	time.Sleep(10 * time.Millisecond)
 	second := writeLegacySession(t, dir, "second.jsonl", "second legacy prompt", time.Now())
 	NewApp().ListProjectTree()
 	meta, ok, err := agent.LoadBranchMeta(second)
 	if err != nil {
 		t.Fatalf("load second meta: %v", err)
 	}
-	if ok && strings.TrimSpace(meta.TopicID) != "" {
-		t.Fatalf("marker should have gated re-scan, but second session was migrated: %+v", meta)
+	if !ok || strings.TrimSpace(meta.TopicID) != legacySessionTopicID(second) {
+		t.Fatalf("new session after marker should be migrated, got ok=%v meta=%+v", ok, meta)
 	}
 }
 
@@ -1861,6 +1861,41 @@ func TestProjectTreeMigratesCLISessionFromProjectDir(t *testing.T) {
 	nodes := NewApp().ListProjectTree()
 	if len(nodes) != 1 || nodes[0].Kind != "project" || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != wantTopicID {
 		t.Fatalf("project CLI session should appear in project tree, got %#v; want topic %q", nodes, wantTopicID)
+	}
+}
+
+func TestProjectTreeMigratesNewCLISessionAfterProjectDirMarker(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	projectRoot := t.TempDir()
+	if err := addProject(projectRoot, ""); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	dir := config.ProjectSessionDir(projectRoot)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first := writeLegacySession(t, dir, "first-cli-project.jsonl", "first cli project prompt", time.Now().Add(-time.Hour))
+	firstTopicID := legacySessionTopicID(first)
+
+	nodes := NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "project" || len(nodes[0].Children) != 1 || nodes[0].Children[0].TopicID != firstTopicID {
+		t.Fatalf("first project CLI session should appear in project tree, got %#v; want topic %q", nodes, firstTopicID)
+	}
+	if _, err := os.Stat(filepath.Join(dir, topicMigrationMarker)); err != nil {
+		t.Fatalf("expected migration marker after first project pass: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	second := writeLegacySession(t, dir, "second-cli-project.jsonl", "second cli project prompt", time.Now())
+	secondTopicID := legacySessionTopicID(second)
+
+	nodes = NewApp().ListProjectTree()
+	if len(nodes) != 1 || nodes[0].Kind != "project" || len(nodes[0].Children) != 2 {
+		t.Fatalf("second project CLI session should trigger re-scan, got %#v", nodes)
+	}
+	if nodes[0].Children[0].TopicID != secondTopicID || nodes[0].Children[1].TopicID != firstTopicID {
+		t.Fatalf("project CLI topics = %#v, want newest %q then %q", nodes[0].Children, secondTopicID, firstTopicID)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #4149
Fixes #4894

This updates the desktop project tree path so CLI-created sessions are migrated into sidebar topics before the tree merges session infos.

- migrate legacy/no-topic sessions from every known desktop session directory, not only the default global session directory
- recognize the desktop global-workspace session directory as a Global migration target
- preserve existing compatible scope/workspace metadata while adding topic metadata
- invalidate the project session cache after migration so the sidebar does not keep stale no-topic session entries

## Root cause

`ListProjectTree` only ran legacy topic migration for `config.SessionDir()`. The sidebar later merged sessions from additional known directories, including project session directories and the desktop global-workspace directory, but `mergeSessionInfos` intentionally skipped sessions without `TopicID`.

That left two gaps:

- CLI project sessions could exist in the project session directory but never receive topic metadata before the project tree was built.
- CLI sessions under the desktop global-workspace directory were included in the scan set, but were not recognized as a Global migration target, especially when they already had `scope: global` / `workspace_root` metadata but no `topic_id`.

## Tests

Passed:

- `go test . -run TestProjectTreeMigratesCLISessionFrom(ProjectDir|GlobalWorkspaceDir) -count=1 -v` from `desktop`
- `go test . -run TestProjectTreeMigratesCLISessionFrom(ProjectDir|GlobalWorkspaceDir)|TestV05LegacyEventSessionsImportIntoGlobalTopic|TestOpenProjectTabResolvesProjectSessionFromLegacyDir|TestLegacyMigrationSkipsProjectScopedSessions|TestLegacyMigrationConcurrentRunsHaveNoLostUpdates|TestFindTopicSessionIndexRefreshesWhenMetaChanges -count=1 -v` from `desktop`
- `git diff --check`

Also ran `go test ./...` from `desktop`. It still fails, but the same failures reproduce on a clean `origin/main-v2` worktree:

- `TestUpdateMCPServerSplitsPastedCommandLine`
- `TestProjectHooksSettingsUseActiveWorkspaceRootAndTrust`
- `TestTrustProjectHooksForRootUsesDisplayedProjectRoot`
- `TestAddSkillPathRestoresConventionRootWithoutCustomPath`