### PR TITLE
fix(ui): 修复右侧面板分隔线间距和对话头部浅色模式背景

### DIFF
--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -193,8 +193,8 @@ for (const selector of [
 }
 
 ok(
-  finalDeclaration(":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar", "background") === "var(--chat-bg)",
-  "workbench topic bar uses a flat chat background",
+  finalDeclaration(":root[data-theme-style] .layout--workbench-chrome-hidden .topicbar", "background") === "var(--bg-elev)",
+  "workbench topic bar uses elevated background for light-mode white",
 );
 
 for (const selector of [

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1957,17 +1957,17 @@ a[href] {
   grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr);
 }
 .layout--workspace-open {
-  --chrome-right-toggle-offset: calc(var(--workspace-width) + var(--workspace-resizer-width));
+  --chrome-right-toggle-offset: var(--workspace-width);
   min-width: min(780px, 100vw);
-  grid-template-columns: var(--sidebar-width) minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open:not(.layout--sidebar-collapsed) {
   min-width: min(780px, 100vw);
-  grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
+  grid-template-columns: var(--sidebar-expanded-width) minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 .layout--workspace-open.layout--sidebar-collapsed {
   min-width: min(560px, 100vw);
-  grid-template-columns: 0px minmax(0, 1fr) var(--workspace-resizer-width) minmax(0, var(--workspace-width));
+  grid-template-columns: 0px minmax(0, 1fr) minmax(0, var(--workspace-width));
 }
 .layout--workspace-maximized {
   min-width: 0;
@@ -2457,32 +2457,32 @@ a[href] {
   position: relative;
   grid-row: 2;
   grid-column: 3;
-  align-self: start;
-  justify-self: stretch;
-  z-index: var(--z-layout-resizer-active);
-  width: auto;
-  min-width: var(--workspace-resizer-width);
+  align-self: stretch;
+  justify-self: start;
+  width: 1px;
+  min-width: 1px;
   height: calc(100% - var(--statusbar-height));
   padding: 0;
   border: 0;
-  background: transparent;
+  background: var(--border-soft);
   cursor: col-resize;
   touch-action: none;
+  z-index: var(--z-layout-resizer-active);
 }
-.workspace-panel-resizer::after {
+.workspace-panel-resizer::before {
   content: "";
   position: absolute;
   top: 0;
   bottom: 0;
-  left: 50%;
-  width: 1px;
-  transform: translateX(-50%);
-  background: var(--border-soft);
-  transition: background 0.12s, box-shadow 0.12s;
+  left: -3px;
+  right: -3px;
 }
-.workspace-panel-resizer:hover::after,
-.workspace-panel-resizer:focus-visible::after,
-.layout--workspace-resizing .workspace-panel-resizer::after {
+.workspace-panel-resizer::after {
+  display: none;
+}
+.workspace-panel-resizer:hover,
+.workspace-panel-resizer:focus-visible,
+.layout--workspace-resizing .workspace-panel-resizer {
   background: var(--accent);
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 24%, transparent);
 }
@@ -16481,7 +16481,7 @@ a[href] {
   gap: 10px;
   min-height: 48px;
   padding: 6px 18px;
-  background: var(--chat-bg);
+  background: var(--bg-elev);
   border-bottom: 1px solid var(--border-soft);
   --wails-draggable: drag;
   user-select: none;
@@ -18182,14 +18182,14 @@ a[href] {
 .context-inspector,
 .workbench-dock {
   grid-row: 2;
-  grid-column: 4;
+  grid-column: 3;
   min-width: 0;
   height: 100%;
   display: flex;
   flex-direction: column;
   padding-bottom: var(--statusbar-height);
   background: var(--workspace-files-bg);
-  border-left: 0;
+  border-left: 1px solid var(--border-soft);
   overflow: hidden;
 }
 
@@ -19090,7 +19090,7 @@ a[href] {
   min-height: 48px;
   padding: 6px 18px;
   gap: 10px;
-  background: color-mix(in srgb, var(--chat-bg) 96%, var(--bg-elev));
+  background: var(--bg-elev);
 }
 
 .topicbar__identity {
@@ -19281,10 +19281,6 @@ a[href] {
 .statusbar__balance,
 .statusbar__cost {
   color: var(--ok);
-}
-
-.workspace-panel-resizer::after {
-  background: var(--border-soft);
 }
 
 .workbench-dock {
@@ -20274,7 +20270,7 @@ a[href] {
   min-height: 48px;
   padding: 6px 18px;
   gap: 10px;
-  background: color-mix(in srgb, var(--chat-bg) 96%, var(--bg-elev));
+  background: var(--bg-elev);
   border-bottom: 1px solid var(--border-soft);
 }
 
@@ -20383,7 +20379,7 @@ a[href] {
 }
 
 :root[data-theme-style] .layout--workbench-chrome-hidden .topicbar {
-  background: var(--chat-bg);
+  background: var(--bg-elev);
 }
 
 :root[data-theme-style] .layout--workbench-chrome-hidden .topicbar__identity,
@@ -21152,7 +21148,7 @@ a[href] {
   box-shadow: inset 3px 0 0 var(--accent);
 }
 
-:root[data-theme-style] .workspace-panel-resizer::after,
+  
 :root[data-theme-style] .sidebar-resizer::after {
   background: var(--border-soft);
 }
@@ -24330,11 +24326,11 @@ a[href] {
   box-shadow: none;
 }
 
-.app--creation .workspace-panel-resizer::after,
-.app--creation .workspace-panel-resizer:hover::after,
-.app--creation .workspace-panel-resizer:focus-visible::after,
-.app--creation .layout--workspace-resizing .workspace-panel-resizer::after,
-:root[data-theme-style] .app--creation .workspace-panel-resizer::after {
+.app--creation .workspace-panel-resizer,
+.app--creation .workspace-panel-resizer:hover,
+.app--creation .workspace-panel-resizer:focus-visible,
+.app--creation .layout--workspace-resizing .workspace-panel-resizer,
+:root[data-theme-style] .app--creation .workspace-panel-resizer {
   background: transparent;
   box-shadow: none;
 }

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -21148,7 +21148,7 @@ a[href] {
   box-shadow: inset 3px 0 0 var(--accent);
 }
 
-  
+
 :root[data-theme-style] .sidebar-resizer::after {
   background: var(--border-soft);
 }


### PR DESCRIPTION
**改动**: styles.css (+31 -35)

1. Grid 从 4 列改为 3 列，去掉独立的 resizer 列
2. resizer 与 dock 同列，1px 宽叠在 dock border-left 上，hover 变 accent 蓝
3. ::before 左右 3px 做拖拽热区
4. topicbar 所有 background 规则统一为 var(--bg-elev)，浅色模式纯白