### PR TITLE
fix(desktop): show current workspace change details

### DIFF
--- a/desktop/frontend/src/components/WorkspacePanel.tsx
+++ b/desktop/frontend/src/components/WorkspacePanel.tsx
@@ -27,7 +27,7 @@ import {
 import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import { loadLayoutSize, saveLayoutSize } from "../lib/layoutPreferences";
-import type { DirEntry, FilePreview, GitCommitView, GitCommitDetailView, WorkspaceChangeView } from "../lib/types";
+import type { DirEntry, FilePreview, GitCommitView, GitCommitDetailView, WorkspaceChangeDetailView, WorkspaceChangeView } from "../lib/types";
 import { formatWorkspaceReference, WORKSPACE_REF_DRAG_TYPE } from "../lib/workspaceDrag";
 import { cleanGitDiff } from "../lib/diff";
 import { CodeViewer } from "./CodeViewer";
@@ -242,6 +242,8 @@ export function WorkspacePanel({
   const [viewMode, setViewMode] = useState<"files" | "changed">(initialViewMode);
   const [gitHistory, setGitHistory] = useState<GitCommitView[]>([]);
   const [workspaceChanges, setWorkspaceChanges] = useState<WorkspaceChangeView[] | null>(null);
+  const [changeDetail, setChangeDetail] = useState<WorkspaceChangeDetailView | null>(null);
+  const [loadingChangeDetail, setLoadingChangeDetail] = useState(false);
   const [loadingHistory, setLoadingHistory] = useState(false);
   const [expandedCommit, setExpandedCommit] = useState<string | null>(null);
   const [commitDetail, setCommitDetail] = useState<GitCommitDetailView | null>(null);
@@ -267,6 +269,7 @@ export function WorkspacePanel({
   const dismissedChangeListRequestIdRef = useRef<number | null>(null);
   const lastWorkspaceTabIdRef = useRef(tabId ?? "");
   const workspaceChangesRequestIdRef = useRef(0);
+  const changeDetailRequestIdRef = useRef(0);
   const gitHistoryRequestIdRef = useRef(0);
   const commitDetailRequestIdRef = useRef(0);
   const recentAnchorRef = useRef<HTMLButtonElement>(null);
@@ -315,6 +318,44 @@ export function WorkspacePanel({
       }
     }
   }, [tabId]);
+
+  const loadWorkspaceChangeDetail = useCallback(async () => {
+    const requestId = ++changeDetailRequestIdRef.current;
+    const requestTabId = tabId ?? "";
+    const requestPath = selectedPath ?? "";
+    if (!requestPath) {
+      setChangeDetail(null);
+      setLoadingChangeDetail(false);
+      return;
+    }
+    setLoadingChangeDetail(true);
+    try {
+      const result = await app.WorkspaceChangeDetail(requestTabId, requestPath);
+      if (
+        changeDetailRequestIdRef.current === requestId &&
+        lastWorkspaceTabIdRef.current === requestTabId &&
+        selectedPath === requestPath
+      ) {
+        setChangeDetail(result || null);
+      }
+    } catch {
+      if (
+        changeDetailRequestIdRef.current === requestId &&
+        lastWorkspaceTabIdRef.current === requestTabId &&
+        selectedPath === requestPath
+      ) {
+        setChangeDetail(null);
+      }
+    } finally {
+      if (
+        changeDetailRequestIdRef.current === requestId &&
+        lastWorkspaceTabIdRef.current === requestTabId &&
+        selectedPath === requestPath
+      ) {
+        setLoadingChangeDetail(false);
+      }
+    }
+  }, [selectedPath, tabId]);
 
   const toggleCommit = useCallback((hash: string) => {
     setExpandedCommit((prev) => {
@@ -388,6 +429,8 @@ export function WorkspacePanel({
     setOpenTabs([]);
     setPreview(null);
     setGitHistory([]);
+    setChangeDetail(null);
+    setLoadingChangeDetail(false);
     setExpandedCommit(null);
     setCommitDetail(null);
     setSelectionMenu(null);
@@ -405,9 +448,12 @@ export function WorkspacePanel({
     if (lastWorkspaceTabIdRef.current === nextTabId) return;
     lastWorkspaceTabIdRef.current = nextTabId;
     workspaceChangesRequestIdRef.current += 1;
+    changeDetailRequestIdRef.current += 1;
     gitHistoryRequestIdRef.current += 1;
     commitDetailRequestIdRef.current += 1;
     setWorkspaceChanges(null);
+    setChangeDetail(null);
+    setLoadingChangeDetail(false);
     setGitHistory([]);
     setExpandedCommit(null);
     setCommitDetail(null);
@@ -428,6 +474,8 @@ export function WorkspacePanel({
     setViewMode(initialViewMode);
     setExpandedCommit(null);
     setCommitDetail(null);
+    setChangeDetail(null);
+    setLoadingChangeDetail(false);
     setSelectionMenu(null);
     setTreeMenu(null);
     setRecentOpen(false);
@@ -436,6 +484,8 @@ export function WorkspacePanel({
       setSelectedPath(null);
       setOpenTabs([]);
       setPreview(null);
+      setChangeDetail(null);
+      setLoadingChangeDetail(false);
       return;
     }
     setScopedChangeRows(null);
@@ -583,17 +633,24 @@ export function WorkspacePanel({
     if (viewMode === "changed") {
       void loadGitHistory();
       void loadWorkspaceChanges();
+      if (selectedPath) void loadWorkspaceChangeDetail();
+      else {
+        changeDetailRequestIdRef.current += 1;
+        setChangeDetail(null);
+        setLoadingChangeDetail(false);
+      }
     }
-  }, [selectedPath, viewMode, loadGitHistory, loadWorkspaceChanges, open]);
+  }, [selectedPath, viewMode, loadGitHistory, loadWorkspaceChanges, loadWorkspaceChangeDetail, open]);
 
   useEffect(() => {
     if (!open || !refreshKey) return;
     if (viewMode === "changed") {
       void loadGitHistory();
       void loadWorkspaceChanges();
+      if (selectedPath) void loadWorkspaceChangeDetail();
     }
     openDirsRef.current.forEach((dir) => void loadDir(dir));
-  }, [loadGitHistory, loadWorkspaceChanges, loadDir, open, refreshKey, viewMode]);
+  }, [loadGitHistory, loadWorkspaceChanges, loadWorkspaceChangeDetail, loadDir, open, refreshKey, selectedPath, viewMode]);
 
   useEffect(() => {
     if (!selectionMenu && !treeMenu) return;
@@ -709,6 +766,7 @@ export function WorkspacePanel({
     () => workspaceChanges?.filter((c) => c.sources.includes("session")) ?? null,
     [workspaceChanges],
   );
+  const hasChangeDetail = Boolean(changeDetail?.diff || changeDetail?.binary);
 
   const changedMode = viewMode === "changed";
   const currentFileName = selectedPath ? basename(selectedPath) : t("workspace.noFile");
@@ -1321,11 +1379,20 @@ export function WorkspacePanel({
             </div>
           ) : viewMode === "changed" && selectedPath ? (
             <div className="workspace-git-history">
+              {loadingChangeDetail ? (
+                <div className="workspace-empty">{t("workspace.loadingChanges")}</div>
+              ) : changeDetail?.diff ? (
+                <div className="workspace-git-history__detail">
+                  <CodeViewer value={cleanGitDiff(changeDetail.diff)} language="diff" />
+                </div>
+              ) : changeDetail?.binary ? (
+                <div className="workspace-empty">{t("workspace.binary")}</div>
+              ) : null}
               {loadingHistory ? (
                 <div className="workspace-empty">{t("workspace.loading")}</div>
-              ) : gitHistory.length === 0 ? (
+              ) : gitHistory.length === 0 && !hasChangeDetail ? (
                 <div className="workspace-empty">{t("workspace.noChanges")}</div>
-              ) : (
+              ) : gitHistory.length > 0 ? (
                 <div className="workspace-git-history__list">
                   {gitHistory.map((commit) => (
                     <div key={commit.hash} className={`workspace-git-history__item${expandedCommit === commit.hash ? " workspace-git-history__item--expanded" : ""}`}>
@@ -1358,7 +1425,7 @@ export function WorkspacePanel({
                     </div>
                   ))}
                 </div>
-              )}
+              ) : null}
             </div>
           ) : !selectedPath ? (
             <div className="workspace-empty">{t("workspace.pickFile")}</div>

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -61,6 +61,7 @@ import type {
   UpdateProgress,
   WireEvent,
   WorkspaceChangesView,
+  WorkspaceChangeDetailView,
   GitCommitView,
   GitCommitDetailView,
   WorkspaceView,
@@ -199,6 +200,7 @@ export interface AppBindings {
   SearchFileRefs(query: string): Promise<DirEntry[]>;
   ReadFile(rel: string): Promise<FilePreview>;
   WorkspaceChanges(tabID: string): Promise<WorkspaceChangesView>;
+  WorkspaceChangeDetail(tabID: string, path: string): Promise<WorkspaceChangeDetailView>;
   GitBranches(): Promise<string[]>;
   GitCheckout(branch: string): Promise<void>;
   WorkspaceGitHistory(tabID: string, path: string): Promise<GitCommitView[]>;
@@ -2149,6 +2151,14 @@ function makeMockApp(): AppBindings {
           { path: "README.md", sources: ["git"], gitStatus: "??" },
           { path: "internal/control/controller.go", sources: ["session"], turns: [1], latestTime: Date.now() - 120_000 },
         ],
+      };
+    },
+    async WorkspaceChangeDetail(_tabID: string, path: string) {
+      return {
+        source: "session",
+        diff: `--- a/${path}\n+++ b/${path}\n@@ -1,1 +1,1 @@\n-old mock\n+new mock`,
+        added: 1,
+        removed: 1,
       };
     },
     async GitBranches() {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -474,6 +474,14 @@ export interface GitCommitDetailView {
   files?: string[];
 }
 
+export interface WorkspaceChangeDetailView {
+  diff?: string;
+  source?: string;
+  added?: number;
+  removed?: number;
+  binary?: boolean;
+}
+
 export interface ComposerInsertRequest {
   id: number;
   text: string;

--- a/desktop/workspace_changes.go
+++ b/desktop/workspace_changes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"reasonix/internal/control"
+	"reasonix/internal/diff"
 	"reasonix/internal/proc"
 )
 
@@ -298,6 +300,14 @@ type GitCommitDetailView struct {
 	Files []string `json:"files,omitempty"`
 }
 
+type WorkspaceChangeDetailView struct {
+	Diff    *string `json:"diff,omitempty"`
+	Source  string  `json:"source,omitempty"`
+	Added   int     `json:"added,omitempty"`
+	Removed int     `json:"removed,omitempty"`
+	Binary  bool    `json:"binary,omitempty"`
+}
+
 func (a *App) WorkspaceGitHistory(tabID string, path string) ([]GitCommitView, error) {
 	base, err := a.workspaceBaseForTab(tabID)
 	if err != nil {
@@ -361,4 +371,116 @@ func (a *App) WorkspaceGitCommitDetail(tabID string, hash string, path string) (
 		}
 	}
 	return GitCommitDetailView{Files: files}, nil
+}
+
+func (a *App) WorkspaceChangeDetail(tabID, path string) (WorkspaceChangeDetailView, error) {
+	workspaceRoot, ctrl, ok := a.workspaceChangesTarget(tabID)
+	if !ok {
+		return WorkspaceChangeDetailView{}, fmt.Errorf("tab %q not found", strings.TrimSpace(tabID))
+	}
+	base, err := workspaceBaseFromRoot(workspaceRoot)
+	if err != nil {
+		return WorkspaceChangeDetailView{}, err
+	}
+	rel := normalizeWorkspaceRelPath(base, path)
+	if rel == "" {
+		return WorkspaceChangeDetailView{}, os.ErrInvalid
+	}
+
+	if detail, ok := workspaceGitWorkingDiff(base, rel); ok {
+		return detail, nil
+	}
+	if ctrl != nil {
+		if detail, ok := workspaceSessionChangeDiff(base, ctrl, rel); ok {
+			return detail, nil
+		}
+	}
+	return WorkspaceChangeDetailView{}, nil
+}
+
+func workspaceGitWorkingDiff(base, rel string) (WorkspaceChangeDetailView, bool) {
+	for i, args := range [][]string{
+		{"-C", base, "diff", "--relative", "HEAD", "--", rel},
+		{"-C", base, "diff", "--relative", "--", rel},
+		{"-C", base, "diff", "--relative", "--cached", "--", rel},
+	} {
+		raw, err := workspaceGit(args...).Output()
+		if err != nil {
+			if i == 0 {
+				continue
+			}
+			return WorkspaceChangeDetailView{}, false
+		}
+		diffText := strings.TrimSpace(string(raw))
+		if diffText != "" {
+			return WorkspaceChangeDetailView{Diff: &diffText, Source: "git"}, true
+		}
+	}
+
+	entries, err := workspaceGitStatus(base)
+	if err != nil {
+		return WorkspaceChangeDetailView{}, false
+	}
+	for _, entry := range entries {
+		if entry.Path != rel || entry.Status != "??" {
+			continue
+		}
+		abs, ok, err := workspacePathForBase(base, rel)
+		if err != nil || !ok {
+			return WorkspaceChangeDetailView{}, false
+		}
+		raw, err := os.ReadFile(abs)
+		if err != nil {
+			return WorkspaceChangeDetailView{}, false
+		}
+		change := diff.Build(rel, "", string(raw), diff.Create)
+		diffText := strings.TrimSpace(change.Diff)
+		return WorkspaceChangeDetailView{
+			Diff:    &diffText,
+			Source:  "git",
+			Added:   change.Added,
+			Removed: change.Removed,
+			Binary:  change.Binary,
+		}, diffText != "" || change.Binary
+	}
+	return WorkspaceChangeDetailView{}, false
+}
+
+func workspaceSessionChangeDiff(base string, ctrl control.SessionAPI, rel string) (WorkspaceChangeDetailView, bool) {
+	state, ok := ctrl.CheckpointFileState(rel)
+	if !ok {
+		return WorkspaceChangeDetailView{}, false
+	}
+	oldText := ""
+	kind := diff.Create
+	if state.Content != nil {
+		oldText = *state.Content
+		kind = diff.Modify
+	}
+	abs, ok, err := workspacePathForBase(base, rel)
+	if err != nil || !ok {
+		return WorkspaceChangeDetailView{}, false
+	}
+	raw, err := os.ReadFile(abs)
+	newText := ""
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return WorkspaceChangeDetailView{}, false
+		}
+		if state.Content == nil {
+			return WorkspaceChangeDetailView{}, false
+		}
+		kind = diff.Delete
+	} else {
+		newText = string(raw)
+	}
+	change := diff.Build(rel, oldText, newText, kind)
+	diffText := strings.TrimSpace(change.Diff)
+	return WorkspaceChangeDetailView{
+		Diff:    &diffText,
+		Source:  "session",
+		Added:   change.Added,
+		Removed: change.Removed,
+		Binary:  change.Binary,
+	}, diffText != "" || change.Binary
 }

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -1158,6 +1158,83 @@ func TestWorkspaceGitCommitDetail(t *testing.T) {
 	}
 }
 
+func TestWorkspaceChangeDetailShowsUncommittedGitDiff(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "init")
+	runGit(t, "config", "user.email", "test@example.com")
+	runGit(t, "config", "user.name", "Test User")
+	if err := os.WriteFile("file.txt", []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "add", "file.txt")
+	runGit(t, "commit", "-m", "init")
+	if err := os.WriteFile("file.txt", []byte("middle\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, "add", "file.txt")
+	if err := os.WriteFile("file.txt", []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	detail, err := (&App{}).WorkspaceChangeDetail("", "file.txt")
+	if err != nil {
+		t.Fatalf("WorkspaceChangeDetail err = %v", err)
+	}
+	if detail.Diff == nil || !strings.Contains(*detail.Diff, "-old") || !strings.Contains(*detail.Diff, "+new") {
+		t.Fatalf("expected uncommitted git diff, got %+v", detail)
+	}
+	if detail.Source != "git" {
+		t.Fatalf("source = %q, want git", detail.Source)
+	}
+}
+
+func TestWorkspaceChangeDetailShowsSessionCheckpointDiff(t *testing.T) {
+	workspace := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workspace, "file.txt"), []byte("new\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sessionDir := t.TempDir()
+	sessionPath := filepath.Join(sessionDir, "a.jsonl")
+	ckptDir := strings.TrimSuffix(sessionPath, ".jsonl") + ".ckpt"
+	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := "old\n"
+	seedCheckpoint(t, ckptDir, checkpoint.Checkpoint{
+		Turn:   0,
+		Time:   time.Now(),
+		Prompt: "edit file",
+		Files:  []checkpoint.FileSnap{{Path: "file.txt", Content: &old}},
+	})
+	ctrl := control.New(control.Options{SessionDir: sessionDir, SessionPath: sessionPath, WorkspaceRoot: workspace, Label: "a"})
+	app := &App{
+		tabs: map[string]*WorkspaceTab{
+			"a": {ID: "a", Scope: "project", WorkspaceRoot: workspace, Ctrl: ctrl, Ready: true},
+		},
+		activeTabID: "a",
+	}
+
+	detail, err := app.WorkspaceChangeDetail("a", "file.txt")
+	if err != nil {
+		t.Fatalf("WorkspaceChangeDetail err = %v", err)
+	}
+	if detail.Diff == nil || !strings.Contains(*detail.Diff, "-old") || !strings.Contains(*detail.Diff, "+new") {
+		t.Fatalf("expected checkpoint diff, got %+v", detail)
+	}
+	if detail.Source != "session" {
+		t.Fatalf("source = %q, want session", detail.Source)
+	}
+}
+
 func runGit(t *testing.T, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)

--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -52,6 +52,16 @@ type Meta struct {
 	Paths  []string
 }
 
+// FileState is the earliest pre-edit state recorded for one file in this
+// session. Comparing it to the current file gives the total session delta.
+type FileState struct {
+	Path    string
+	Turn    int
+	Time    time.Time
+	Prompt  string
+	Content *string
+}
+
 // Store holds a session's checkpoints in memory and, when dir is set, persists one
 // JSON file per turn under it (cheap delete, corruption-isolated). All methods are
 // safe for concurrent use — the agent snapshots from tool goroutines.
@@ -220,6 +230,27 @@ func (s *Store) List() []Meta {
 		out = append(out, Meta{Turn: c.Turn, Time: c.Time, Prompt: c.Prompt, Paths: paths})
 	}
 	return out
+}
+
+// FileState returns the earliest pre-edit state recorded for path.
+func (s *Store) FileState(path string) (FileState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, c := range s.all() {
+		for _, f := range c.Files {
+			if f.Path != path {
+				continue
+			}
+			return FileState{
+				Path:    f.Path,
+				Turn:    c.Turn,
+				Time:    c.Time,
+				Prompt:  c.Prompt,
+				Content: f.Content,
+			}, true
+		}
+	}
+	return FileState{}, false
 }
 
 // all returns done + cur in turn order. Caller holds the lock.

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1697,6 +1697,13 @@ func (c *Controller) Checkpoints() []checkpoint.Meta {
 	return c.cp.List()
 }
 
+func (c *Controller) CheckpointFileState(path string) (checkpoint.FileState, bool) {
+	if c.cp == nil {
+		return checkpoint.FileState{}, false
+	}
+	return c.cp.FileState(path)
+}
+
 // rewindFail emits the error as a Warn notice (so a frontend that swallows the
 // returned error — e.g. the desktop bridge's .catch — still shows the user why
 // the rewind did nothing) and returns it.

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -102,6 +102,7 @@ type Goals interface {
 // operations (compact, summarize).
 type SessionHistory interface {
 	Checkpoints() []checkpoint.Meta
+	CheckpointFileState(path string) (checkpoint.FileState, bool)
 	CheckpointHasBoundary(turn int) bool
 	Rewind(turn int, scope RewindScope) error
 	Fork(turn int) (string, error)


### PR DESCRIPTION
﻿Fixes #4850

## Summary
- Add a desktop `WorkspaceChangeDetail` API that resolves the selected changed file against the current workspace.
- Prefer the current git working tree diff, including staged + unstaged changes, then fall back to the session checkpoint diff for non-git/session-only edits.
- Render the current change detail in the Changes tab before historical git commits so files listed by `WorkspaceChanges` no longer open to an empty detail panel.

## Root cause
`WorkspaceChanges` lists files from both session checkpoints and git status, but selecting a changed file only loaded `WorkspaceGitHistory` / `WorkspaceGitCommitDetail`. That path reads committed history (`git log` / `git show`) and has no current working-tree or checkpoint detail, so current/session-only changes could appear in the list while the detail panel said there were no changed files.

## Tests
- `go test . -run "TestWorkspaceChangeDetailShows(UncommittedGitDiff|SessionCheckpointDiff)|TestWorkspaceChangesUsesRequestedTabCheckpoints|TestWorkspaceChangesGitStatus|TestWorkspaceGitHistory" -count=1 -v` (desktop)
- `npm run typecheck` (desktop/frontend)
- `npm run test:typecheck` (desktop/frontend)
- `git diff --check`

Also ran `go test ./...` in `desktop`; it still fails on unrelated existing local/Windows cases:
- `TestUpdateMCPServerSplitsPastedCommandLine` temp dir cleanup file lock
- `TestProjectHooksSettingsUseActiveWorkspaceRootAndTrust`
- `TestTrustProjectHooksForRootUsesDisplayedProjectRoot`
- `TestAddSkillPathRestoresConventionRootWithoutCustomPath`
