### PR TITLE
fix: Cmd+K 命令面板需按两次才能打开

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2205,7 +2205,7 @@ export default function App() {
   useGlobalShortcut("commandPalette.open", () => {
     setPaletteOpen((current) => {
       if (!current) void openPalette();
-      return current;
+      return !current; // ← fix: toggle the state so the palette actually opens/closes
     });
   }, [openPalette]);
   useGlobalShortcut("app.newSession", () => void handleNewTab(), [handleNewTab]);

--- a/desktop/frontend/src/components/CommandPalette.tsx
+++ b/desktop/frontend/src/components/CommandPalette.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { Command, Search } from "lucide-react";
 import { useMountTransition } from "../lib/useMountTransition";
@@ -58,8 +58,10 @@ export function CommandPalette({
   emptyText: string;
 }) {
   const [query, setQuery] = useState("");
-  const [active, setActive] = useState(0);
+  const [active, setActive] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
+  const isOpenRef = useRef(false);
+  isOpenRef.current = open;
   // Keep the palette mounted through its exit animation after `open` flips
   // false; `status` drives the enter/exit keyframes via data-state.
   const { mounted, status } = useMountTransition(open, 200);
@@ -67,13 +69,27 @@ export function CommandPalette({
   // Re-init whenever the palette opens: clear the query, reset the
   // highlight, and steal focus. Doing it on the open edge (not on every
   // render) means a previously-typed query doesn't leak across opens.
-  useEffect(() => {
+  // useLayoutEffect fires synchronously after DOM mutations, before the
+  // browser paints — ensures focus lands before any paint-time transitions
+  // can interfere.
+  useLayoutEffect(() => {
     if (open) {
       setQuery("");
-      setActive(0);
-      requestAnimationFrame(() => inputRef.current?.focus());
+      setActive(-1);
+      inputRef.current?.focus();
     }
   }, [open]);
+
+  // Callback ref: when the input element mounts while the palette is open,
+  // focus it immediately. This handles the case where the DOM element
+  // becomes available after the useLayoutEffect already ran.
+  const inputCallbackRef = useCallback(
+    (el: HTMLInputElement | null) => {
+      inputRef.current = el;
+      if (el && isOpenRef.current) el.focus();
+    },
+    [],
+  );
 
   // score is the fuzzy match: every space-separated query token must
   // appear (case-insensitively) in the candidate's haystack, in the order
@@ -130,11 +146,11 @@ export function CommandPalette({
   // Clamp the active index whenever the result set shrinks (e.g. user
   // typed something that filtered out the previously-highlighted item).
   useEffect(() => {
-    if (active >= flat.length) setActive(Math.max(0, flat.length - 1));
+    if (active >= 0 && active >= flat.length) setActive(Math.max(0, flat.length - 1));
   }, [flat.length, active]);
 
-  // Reset the highlight to 0 on every query change — the user just refined
-  // their search, the old highlight is rarely still interesting.
+  // Reset the highlight to the first match on every query change — the user
+  // just refined their search, the old highlight is rarely still interesting.
   useEffect(() => {
     setActive(0);
   }, [query]);
@@ -152,12 +168,12 @@ export function CommandPalette({
       }
       if (e.key === "ArrowDown") {
         e.preventDefault();
-        setActive((i) => (flat.length === 0 ? 0 : (i + 1) % flat.length));
+        setActive((i) => (flat.length === 0 ? -1 : i < 0 ? 0 : (i + 1) % flat.length));
         return;
       }
       if (e.key === "ArrowUp") {
         e.preventDefault();
-        setActive((i) => (flat.length === 0 ? 0 : (i - 1 + flat.length) % flat.length));
+        setActive((i) => (flat.length === 0 ? -1 : i <= 0 ? flat.length - 1 : i - 1));
         return;
       }
       if (e.key === "Enter") {
@@ -189,7 +205,7 @@ export function CommandPalette({
         <div className="palette__inputrow">
           <Search className="palette__search-icon" size={18} aria-hidden="true" />
           <input
-            ref={inputRef}
+            ref={inputCallbackRef}
             className="palette__input"
             value={query}
             onChange={(e) => setQuery(e.target.value)}


### PR DESCRIPTION
## 问题

Cmd+K 打开命令面板需要按两次才能生效，且打开后输入框无焦点、面板内已有选中项。

## 根因

1. App.tsx 中 useGlobalShortcut 回调里 return current 从未切换状态，首次按键无效
2. CommandPalette.tsx 中 requestAnimationFrame 延迟焦点，被 paint-time 动画干扰
3. CommandPalette.tsx 中 active 初始值 0，打开面板时第一个选项已高亮

## 修复

- return current 改为 return !current，状态正确切换
- requestAnimationFrame 改为 useLayoutEffect + callback ref，双重保障焦点
- active 初始值 0 改为 -1，打开面板无选中项，方向键从头开始导航

## 测试

- keyboard-shortcuts.test.ts 21 passed
- command-palette-css.test.ts 10 passed