### PR TITLE
fix(control): strip referenced context prefix for title generation

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1996,7 +1996,9 @@ func topicTitleFromSession(path string) string {
 			return ""
 		}
 		if msg.Role == "user" {
-			return topicTitleFromText(control.StripComposePrefixes(agent.HandoffTask(msg.Content)))
+			content := control.StripComposePrefixes(agent.HandoffTask(msg.Content))
+			content = control.StripReferencedContextPrefix(content)
+			return topicTitleFromText(content)
 		}
 	}
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -49,6 +49,48 @@ func StripComposePrefixes(content string) string {
 	return s
 }
 
+// StripReferencedContextPrefix removes the "Referenced context:" preamble and
+// the trailing XML reference blocks (<file>, <dir>, <resource>, <image>) that
+// controller.ResolveRefs injects when the user @-references files or resources.
+// The user's actual input follows the reference blocks after a blank line.
+// Used for title generation and previews so the displayed text matches what
+// the user typed, not the injected context preamble (#4954).
+func StripReferencedContextPrefix(content string) string {
+	const preamble = "Referenced context:"
+	s := strings.TrimSpace(content)
+	if !strings.HasPrefix(s, preamble) {
+		return content
+	}
+	// Skip past the preamble.
+	s = strings.TrimSpace(s[len(preamble):])
+	// Skip past all XML reference blocks: <file ...>...</file>, <dir ...>...</dir>,
+	// <resource ...>...</resource>, <image ...>...</image>.
+	for {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return ""
+		}
+		// Check for a reference block start.
+		if !strings.HasPrefix(s, "<file ") && !strings.HasPrefix(s, "<dir ") &&
+			!strings.HasPrefix(s, "<resource ") && !strings.HasPrefix(s, "<image ") {
+			break
+		}
+		// Find the matching close tag.
+		tagEnd := strings.IndexByte(s, ' ')
+		if tagEnd < 0 {
+			break
+		}
+		tagName := s[1:tagEnd]
+		closeTag := "</" + tagName + ">"
+		closeIdx := strings.Index(s, closeTag)
+		if closeIdx < 0 {
+			break
+		}
+		s = strings.TrimSpace(s[closeIdx+len(closeTag):])
+	}
+	return s
+}
+
 // IsSyntheticUserMessage returns true if the content matches one of the known
 // synthetic user messages injected by the controller or agent loop (plan
 // approval, stream recovery, readiness retry, etc.). These should not be shown

--- a/internal/control/input_test.go
+++ b/internal/control/input_test.go
@@ -806,6 +806,63 @@ func TestStripComposePrefixes(t *testing.T) {
 	}
 }
 
+func TestStripReferencedContextPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "plain user message unchanged",
+			input: "explain this function",
+			want:  "explain this function",
+		},
+		{
+			name:  "file reference stripped",
+			input: "Referenced context:\n\n<file path=\"main.go\">\nfunc main() {}\n</file>\n\nexplain this function",
+			want:  "explain this function",
+		},
+		{
+			name:  "multiple file references stripped",
+			input: "Referenced context:\n\n<file path=\"a.go\">\npackage a\n</file>\n\n<file path=\"b.go\">\npackage b\n</file>\n\ncompare these files",
+			want:  "compare these files",
+		},
+		{
+			name:  "dir reference stripped",
+			input: "Referenced context:\n\n<dir path=\"src\">\nmain.go\nutil.go\n</dir>\n\nlist the files",
+			want:  "list the files",
+		},
+		{
+			name:  "resource reference stripped",
+			input: "Referenced context:\n\n<resource ref=\"@server/res\">\ndata\n</resource>\n\nanalyze this",
+			want:  "analyze this",
+		},
+		{
+			name:  "image reference stripped",
+			input: "Referenced context:\n\n<image path=\"screenshot.png\">\n[image attachment available at @screenshot.png]\n</image>\n\nwhat is in this image",
+			want:  "what is in this image",
+		},
+		{
+			name:  "only reference no user text",
+			input: "Referenced context:\n\n<file path=\"main.go\">\nfunc main() {}\n</file>\n\n",
+			want:  "",
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := StripReferencedContextPrefix(tt.input)
+			if got != tt.want {
+				t.Errorf("StripReferencedContextPrefix() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsSyntheticUserMessage(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

修复 #4954: 引入文件导致会话摘要显示异常

**问题：** 当用户通过 @ 引用文件时，会话标题/摘要显示为 "Referenced context..." 开头的字符串，而不是用户实际输入的内容。

**根因：** 控制器在处理 @ 引用时，会在用户消息前注入 "Referenced context:" 前缀和 XML 引用块（`<file>`、`<dir>`、`<resource>`、`<image>`）。标题生成逻辑没有跳过这个前缀。

**修复：** 
- 在 `internal/control/input.go` 中添加 `StripReferencedContextPrefix()` 函数，移除 "Referenced context:" 前缀和后续的 XML 引用块
- 在 `desktop/tabs.go` 的 `topicTitleFromSession()` 中调用该函数，确保标题反映用户实际输入

## Changes

- `internal/control/input.go` — 添加 `StripReferencedContextPrefix()` 函数
- `internal/control/input_test.go` — 添加测试用例（8个场景）
- `desktop/tabs.go` — 在标题生成时调用 `StripReferencedContextPrefix()`

## Verification

- `go test ./internal/control/...` passes
- `go test ./desktop/...` passes
- `go vet ./...` clean
- `gofmt -w` applied

Fixes #4954

## Cache impact

Cache-impact: none — 仅添加了一个字符串处理函数用于标题生成，不影响系统提示或缓存前缀。
Cache-guard: N/A
