### PR TITLE
fix(desktop): add copy+remove fallback for session trash move on Windows

### DIFF
--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -344,7 +344,7 @@ func purgeTrashedSessionFile(dir, path string) error {
 }
 
 func movePathIfExists(src, dst string) error {
-	if _, err := os.Stat(src); os.IsNotExist(err) {
+	if _, err := os.Lstat(src); os.IsNotExist(err) {
 		return nil
 	} else if err != nil {
 		return err
@@ -386,18 +386,34 @@ func isRenameCrossDeviceOrBusy(err error) bool {
 // copyAndRemove recursively copies src to dst, then removes src. Used as a
 // fallback when os.Rename fails (cross-device or Windows file-lock races).
 func copyAndRemove(src, dst string) error {
-	info, err := os.Stat(src)
+	if err := copyPath(src, dst); err != nil {
+		return err
+	}
+	// On Windows, wait briefly for any file handle release.
+	time.Sleep(10 * time.Millisecond)
+	return os.RemoveAll(src)
+}
+
+func copyPath(src, dst string) error {
+	info, err := os.Lstat(src)
 	if err != nil {
 		return err
 	}
-	if info.IsDir() {
-		return copyDir(src, dst)
+	mode := info.Mode()
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return copySymlink(src, dst)
+	case mode.IsDir():
+		return copyDir(src, dst, mode.Perm())
+	case mode.IsRegular():
+		return copyFile(src, dst, mode.Perm())
+	default:
+		return fmt.Errorf("unsupported file type in rename fallback: %s", src)
 	}
-	return copyFile(src, dst, info.Mode())
 }
 
-func copyDir(src, dst string) error {
-	if err := os.MkdirAll(dst, 0o755); err != nil {
+func copyDir(src, dst string, mode os.FileMode) error {
+	if err := os.MkdirAll(dst, mode); err != nil {
 		return err
 	}
 	entries, err := os.ReadDir(src)
@@ -407,21 +423,11 @@ func copyDir(src, dst string) error {
 	for _, e := range entries {
 		srcPath := filepath.Join(src, e.Name())
 		dstPath := filepath.Join(dst, e.Name())
-		if e.IsDir() {
-			if err := copyDir(srcPath, dstPath); err != nil {
-				return err
-			}
-		} else {
-			info, err := e.Info()
-			if err != nil {
-				return err
-			}
-			if err := copyFile(srcPath, dstPath, info.Mode()); err != nil {
-				return err
-			}
+		if err := copyPath(srcPath, dstPath); err != nil {
+			return err
 		}
 	}
-	return os.RemoveAll(src)
+	return nil
 }
 
 func copyFile(src, dst string, mode os.FileMode) error {
@@ -447,9 +453,15 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	if closeErr != nil {
 		return closeErr
 	}
-	// On Windows, wait briefly for any file handle release.
-	time.Sleep(10 * time.Millisecond)
-	return os.Remove(src)
+	return nil
+}
+
+func copySymlink(src, dst string) error {
+	target, err := os.Readlink(src)
+	if err != nil {
+		return err
+	}
+	return os.Symlink(target, dst)
 }
 
 func trashSubagentArtifacts(dir, sessionPath, itemDir string) error {

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -4,9 +4,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"time"
 
 	"reasonix/internal/agent"
@@ -350,7 +352,104 @@ func movePathIfExists(src, dst string) error {
 	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
 		return err
 	}
-	return os.Rename(src, dst)
+	// Try os.Rename first — it's atomic and fast when it works.
+	if err := os.Rename(src, dst); err == nil {
+		return nil
+	} else if !isRenameCrossDeviceOrBusy(err) {
+		return err
+	}
+	// Fallback: copy then remove. This handles cross-device moves and the
+	// Windows case where a directory rename fails because a handle is briefly
+	// held open (e.g. antivirus scan, indexing, or a just-closed file).
+	return copyAndRemove(src, dst)
+}
+
+// isRenameCrossDeviceOrBusy reports whether err is a cross-device rename or
+// a "file busy" error that a copy+remove fallback can recover from.
+func isRenameCrossDeviceOrBusy(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Cross-device link.
+	if le, ok := err.(*os.LinkError); ok {
+		if le.Err == syscall.EXDEV {
+			return true
+		}
+		// Windows: "The process cannot access the file because it is being used by another process."
+		if errno, ok := le.Err.(syscall.Errno); ok {
+			return errno == 32 // ERROR_SHARING_VIOLATION
+		}
+	}
+	return false
+}
+
+// copyAndRemove recursively copies src to dst, then removes src. Used as a
+// fallback when os.Rename fails (cross-device or Windows file-lock races).
+func copyAndRemove(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return copyDir(src, dst)
+	}
+	return copyFile(src, dst, info.Mode())
+}
+
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		srcPath := filepath.Join(src, e.Name())
+		dstPath := filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			info, err := e.Info()
+			if err != nil {
+				return err
+			}
+			if err := copyFile(srcPath, dstPath, info.Mode()); err != nil {
+				return err
+			}
+		}
+	}
+	return os.RemoveAll(src)
+}
+
+func copyFile(src, dst string, mode os.FileMode) error {
+	// Open source file.
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	// Create destination file.
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		in.Close()
+		return err
+	}
+	// Copy content.
+	_, err = io.Copy(out, in)
+	// Close both files before any removal.
+	closeErr := out.Close()
+	in.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	// On Windows, wait briefly for any file handle release.
+	time.Sleep(10 * time.Millisecond)
+	return os.Remove(src)
 }
 
 func trashSubagentArtifacts(dir, sessionPath, itemDir string) error {

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -688,6 +688,45 @@ func TestCopyAndRemoveDirectory(t *testing.T) {
 	}
 }
 
+func TestCopyAndRemoveDirectoryPreservesSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.txt")
+	if err := os.WriteFile(outside, []byte("outside"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(srcDir, "link.txt")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	dstDir := filepath.Join(dir, "dst")
+
+	if err := copyAndRemove(srcDir, dstDir); err != nil {
+		t.Fatalf("copyAndRemove: %v", err)
+	}
+	if _, err := os.Stat(srcDir); !os.IsNotExist(err) {
+		t.Fatal("src dir should be removed")
+	}
+	dstLink := filepath.Join(dstDir, "link.txt")
+	info, err := os.Lstat(dstLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dst link should remain a symlink, mode=%v", info.Mode())
+	}
+	target, err := os.Readlink(dstLink)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != outside {
+		t.Fatalf("dst link target = %q, want %q", target, outside)
+	}
+}
+
 func writeSubagentArtifact(t *testing.T, dir, ref, parentSession string) {
 	t.Helper()
 	subagentDir := filepath.Join(dir, "subagents")

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -635,6 +635,59 @@ func TestDeleteSessionFileRejectsSymlinkEscape(t *testing.T) {
 	}
 }
 
+func TestMovePathIfExistsCopyFallback(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.txt")
+	if err := os.WriteFile(src, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(dir, "dst.txt")
+
+	// Test normal move.
+	if err := movePathIfExists(src, dst); err != nil {
+		t.Fatalf("move: %v", err)
+	}
+	if _, err := os.Stat(src); !os.IsNotExist(err) {
+		t.Fatal("src should be removed")
+	}
+	if got, err := os.ReadFile(dst); err != nil || string(got) != "hello" {
+		t.Fatalf("dst content = %q, err = %v", got, err)
+	}
+
+	// Test non-existent source is no-op.
+	if err := movePathIfExists(filepath.Join(dir, "missing.txt"), filepath.Join(dir, "other.txt")); err != nil {
+		t.Fatalf("move missing: %v", err)
+	}
+}
+
+func TestCopyAndRemoveDirectory(t *testing.T) {
+	dir := t.TempDir()
+	srcDir := filepath.Join(dir, "src")
+	if err := os.MkdirAll(filepath.Join(srcDir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("file a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "sub", "b.txt"), []byte("file b"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dstDir := filepath.Join(dir, "dst")
+
+	if err := copyAndRemove(srcDir, dstDir); err != nil {
+		t.Fatalf("copyAndRemove: %v", err)
+	}
+	if _, err := os.Stat(srcDir); !os.IsNotExist(err) {
+		t.Fatal("src dir should be removed")
+	}
+	if got, err := os.ReadFile(filepath.Join(dstDir, "a.txt")); err != nil || string(got) != "file a" {
+		t.Fatalf("dst a.txt = %q, err = %v", got, err)
+	}
+	if got, err := os.ReadFile(filepath.Join(dstDir, "sub", "b.txt")); err != nil || string(got) != "file b" {
+		t.Fatalf("dst sub/b.txt = %q, err = %v", got, err)
+	}
+}
+
 func writeSubagentArtifact(t *testing.T, dir, ref, parentSession string) {
 	t.Helper()
 	subagentDir := filepath.Join(dir, "subagents")


### PR DESCRIPTION
## Summary

修复 #4956: 会话回收报错

**问题：** 用户尝试删除有对话历史的会话时，在 Windows 上可能会失败，报错信息为文件被占用。新会话（无对话）可以正常删除。

**根因：** `movePathIfExists` 函数使用 `os.Rename` 移动会话目录到回收站。在 Windows 上，如果文件句柄被短暂占用（如防病毒软件扫描、索引服务、或刚关闭的文件），`os.Rename` 会失败。

**修复：** 添加回退机制：
1. 首先尝试 `os.Rename`（快速、原子操作）
2. 如果失败且错误是跨设备（EXDEV）或文件被占用（Windows ERROR_SHARING_VIOLATION），则回退到复制+删除
3. 复制+删除：递归复制目录树，然后删除源
4. 在 Windows 上，关闭文件句柄后等待 10ms 确保文件完全释放

## Changes

- `desktop/sessions.go` — 添加 `copyAndRemove`, `copyDir`, `copyFile`, `isRenameCrossDeviceOrBusy` 函数
- `desktop/sessions_test.go` — 添加 `TestMovePathIfExistsCopyFallback`, `TestCopyAndRemoveDirectory` 测试

## Verification

- `go test ./desktop/...` passes
- `go vet ./...` clean
- `gofmt -w` applied

Fixes #4956

## Cache impact

Cache-impact: none — 仅修改桌面端会话回收逻辑，不影响系统提示或缓存前缀。
Cache-guard: N/A
