### PR TITLE
test(desktop): add regression test for display mode persistence (#4831)

### DIFF
--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -624,6 +624,46 @@ func TestDesktopStartupSettingsUsesUserDesktopPreferencesWithoutFullSettingsPayl
 	}
 }
 
+// TestSetDisplayModePersistsAcrossRestarts 回归测试：通过 App.SetDisplayMode 设置的
+// 会话展示模式必须在重启后仍然生效（#4831）。
+func TestSetDisplayModePersistsAcrossRestarts(t *testing.T) {
+	isolateDesktopUserDirs(t)
+
+	project := robustTempDir(t)
+	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte("# project\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	orig, _ := os.Getwd()
+	defer func() { _ = os.Chdir(orig) }()
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	app := NewApp()
+
+	// 通过 App API 设置为紧凑模式。
+	if err := app.SetDisplayMode("compact"); err != nil {
+		t.Fatalf("SetDisplayMode: %v", err)
+	}
+
+	// 验证用户配置文件里确实包含 display_mode = "compact"。
+	userPath := config.UserConfigPath()
+	raw, err := os.ReadFile(userPath)
+	if err != nil {
+		t.Fatalf("read user config: %v", err)
+	}
+	if !strings.Contains(string(raw), `display_mode = "compact"`) {
+		t.Fatalf("user config missing display_mode = \"compact\":\n%s", string(raw))
+	}
+
+	// 模拟重启：新建 App 实例，读取启动设置。
+	restarted := NewApp()
+	got := restarted.DesktopStartupSettings()
+	if got.DisplayMode != "compact" {
+		t.Fatalf("after restart DisplayMode = %q, want compact", got.DisplayMode)
+	}
+}
+
 func BenchmarkDesktopSettingsPayloads(b *testing.B) {
 	home := b.TempDir()
 	xdg := filepath.Join(home, ".config")


### PR DESCRIPTION
## Summary

回归测试 #4831: 桌面端"会话展示模式→紧凑"重启后回滚为标准

**背景：** 该 bug 已在上游 PR #4839（commit `ee36325b`）中修复。核心问题是 `RenderTOMLForScope` 函数在渲染 `[desktop]` 配置段时遗漏了 `display_mode` 字段。

**本次贡献：** 添加回归测试，确保该 bug 不会再次发生。

## Changes

- `desktop/app_test.go` — 添加 `TestSetDisplayModePersistsAcrossRestarts` 回归测试
  - 通过 `App.SetDisplayMode("compact")` 设置紧凑模式
  - 验证用户配置文件包含 `display_mode = "compact"`
  - 模拟重启（新建 App 实例），验证设置被正确加载

## Verification

- `go test ./desktop/ -run "DisplayMode|DesktopStartupSettings"` passes
- `go test ./internal/config/` passes
- `go vet ./...` clean
- `gofmt -w` applied

Fixes #4831

## Cache impact

Cache-impact: none — 仅添加测试，不影响系统提示或缓存前缀。
Cache-guard: N/A
