### PR TITLE
fix(desktop): fix model selection button text overflow (#4908)

### DIFF
--- a/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
+++ b/desktop/frontend/src/__tests__/typography-overflow-contract.test.ts
@@ -128,11 +128,14 @@ for (const selector of [
   ".context-panel__metric span",
   ".context-panel__metric strong",
   ".topbar__model",
+  ".modelsw__label",
+  ".modelsw__provider",
   ".composer-modebar__item span",
   ".composer-more-menu__item span",
 ]) {
   clipsSingleLine(selector);
 }
+eq(finalDeclaration(".modelsw__provider", "display"), "inline", "model switcher provider does not force a new line");
 
 eq(finalDeclaration(".composer-modebar", "overflow"), "hidden", "chat mode switcher contains enlarged labels");
 eq(finalDeclaration(".md table", "overflow-x"), "auto", "markdown tables scroll horizontally");

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6198,7 +6198,8 @@ a[href] {
   text-overflow: ellipsis;
 }
 .modelsw__provider {
-  display: block;
+  /* 使用 inline 避免 display:block 导致文字越界，同时让 text-overflow 生效 */
+  display: inline;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -23782,11 +23783,17 @@ a[href] {
   gap: 5px;
   padding: 0 10px;
   font-size: 12px;
+  /* 限制按钮最大宽度，防止文字越界 */
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .app--creation .composer-meta .modelsw,
 :root[data-theme-style] .app--creation .composer-meta .modelsw {
   width: auto;
+  /* 防止内部按钮文字溢出容器 */
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .app--creation .composer-meta .modelsw__kind,


### PR DESCRIPTION
## Summary

修复 #4908: UI 问题，对话框下方模型选择按钮文字出现越界

**问题：** v1.10.0 版本，模型选择按钮的文字 "Deepseek 官方" 出现 UI 越界，上版本显示正常。

**根因：** `.modelsw__provider` 使用 `display: block` 导致：
- provider 成为 label flex item 的块级子元素
- label 的 `text-overflow: ellipsis` 无法作用于块级子元素的内容
- provider 块级元素撑开了 label 的最小宽度，导致文字溢出按钮边界

**修复：**
1. 将 `.modelsw__provider` 的 `display: block` 改为 `display: inline`，使 `text-overflow: ellipsis` 生效
2. 为 creation 主题的按钮和容器添加 `max-width: 100%` 和 `overflow: hidden`，防止文字溢出

## Changes

- `desktop/frontend/src/styles.css` — 3 处 CSS 修改
  - `.modelsw__provider`: `display: block` → `display: inline`
  - `.app--creation .composer-meta .modelsw__trigger`: 添加 `max-width: 100%; overflow: hidden`
  - `.app--creation .composer-meta .modelsw`: 添加 `max-width: 100%; overflow: hidden`

## Verification

- `go vet ./...` clean
- `go test ./internal/tool/builtin/ ./internal/boot/` passes
- CSS 语法检查通过

Fixes #4908

## Cache impact

Cache-impact: none — 仅修改桌面端前端 CSS，不影响系统提示或缓存前缀。
Cache-guard: N/A
