### PR TITLE
feat(desktop): 支持切换对话自动滚动到底部并添加跳转按钮

### DIFF
--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -5,7 +5,7 @@ import { useT } from "../lib/i18n";
 import { AssistantMessage, TurnActions, UserMessage } from "./Message";
 import { ProcessCompactIcon, ProcessPhaseIcon } from "./ProcessCard";
 import { ToolCard } from "./ToolCard";
-import { ChevronRight } from "lucide-react";
+import { ArrowDown, ChevronRight } from "lucide-react";
 import { Welcome } from "./Welcome";
 import { ReadOnlyBatch } from "./ReadOnlyBatch";
 import { getDisplayMode, onDisplayModeChange, type DisplayMode } from "../lib/displayMode";
@@ -109,7 +109,9 @@ export function Transcript({
     scrollRef,
     stick,
     onScroll,
+    isAtBottom,
     smoothScrollTo,
+    scrollToBottomAfterLayout,
     trackQuestions,
     repinIfWasPinned,
     resizeFrame,
@@ -117,6 +119,7 @@ export function Transcript({
     lastFooterHeight,
   } = useScrollManager();
   const autoScrollFrame = useRef<number | null>(null);
+  const pendingTabBottomScroll = useRef(false);
   const sessionKey = useMemo(() => `${items[0]?.id ?? ""}|${items[items.length - 1]?.id ?? ""}`, [items]);
   const entranceRef = useEntranceAnimation<HTMLDivElement>(sessionKey, items.length);
 
@@ -144,7 +147,17 @@ export function Transcript({
   // disables auto-scroll when the user had scrolled up in the old tab (#4584).
   useEffect(() => {
     stick.current = true;
+    pendingTabBottomScroll.current = true;
   }, [tabId]);
+
+  useEffect(() => {
+    if (!pendingTabBottomScroll.current || items.length === 0) return;
+    pendingTabBottomScroll.current = false;
+    const frame = requestAnimationFrame(() => {
+      scrollToBottomAfterLayout(5);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [tabId, items.length, scrollToBottomAfterLayout]);
 
   // Auto-scroll to bottom during streaming. Coalesce fast token/reasoning
   // updates into one layout read/write per animation frame.
@@ -549,51 +562,65 @@ export function Transcript({
   // don't rebuild it. The hot zone uses LiveAssistantMessage (reads live from
   // LiveStreamContext) so streaming updates are captured immediately.
   return (
-    <div
-      className={`transcript${empty ? " transcript--empty" : ""}`}
-      ref={scrollRef}
-      onScroll={onScroll}
-    >
-      {empty && <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
+    <div className="transcript-shell">
+      <div
+        className={`transcript${empty ? " transcript--empty" : ""}`}
+        ref={scrollRef}
+        onScroll={onScroll}
+      >
+        {empty && <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
 
-      {!empty && showQuestionNav && (
-        <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
-      )}
-
-      <LiveStreamContext.Provider value={live}>
-        {turnGroups.length > HOT_TURNS && (
-          <WarmZone
-            turnGroups={turnGroups}
-            expandedWarmTurns={expandedWarmTurns}
-            shownWarmStart={shownWarmStart}
-            coldTurnCount={coldTurnCount}
-            scrollRef={scrollRef}
-            warmItems={items}
-            warmSubcalls={subcallsByParent}
-            warmUserTurn={userTurn}
-            warmCheckpoints={checkpointsByTurn}
-            warmOpenAction={openAction}
-            warmActionPending={actionPending}
-            warmRewindDisabled={rewindDisabled}
-            warmActionHoverMenus={actionHoverMenus}
-            warmOnRewind={onRewind}
-            warmSetOpenAction={setOpenAction}
-            warmOnEdit={onEditPrompt}
-            tabId={tabId}
-            onToggleColdPage={() => setColdPage((p) => p + 1)}
-            onToggleWarmTurn={(g, expand) => {
-              setExpandedWarmTurns((prev) => {
-                const next = new Set(prev);
-                if (expand) next.add(g); else next.delete(g);
-                return next;
-              });
-            }}
-          />
+        {!empty && showQuestionNav && (
+          <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
         )}
-        <div ref={entranceRef}>
-          {hotZoneNodes}
-        </div>
-      </LiveStreamContext.Provider>
+
+        <LiveStreamContext.Provider value={live}>
+          {turnGroups.length > HOT_TURNS && (
+            <WarmZone
+              turnGroups={turnGroups}
+              expandedWarmTurns={expandedWarmTurns}
+              shownWarmStart={shownWarmStart}
+              coldTurnCount={coldTurnCount}
+              scrollRef={scrollRef}
+              warmItems={items}
+              warmSubcalls={subcallsByParent}
+              warmUserTurn={userTurn}
+              warmCheckpoints={checkpointsByTurn}
+              warmOpenAction={openAction}
+              warmActionPending={actionPending}
+              warmRewindDisabled={rewindDisabled}
+              warmActionHoverMenus={actionHoverMenus}
+              warmOnRewind={onRewind}
+              warmSetOpenAction={setOpenAction}
+              warmOnEdit={onEditPrompt}
+              tabId={tabId}
+              onToggleColdPage={() => setColdPage((p) => p + 1)}
+              onToggleWarmTurn={(g, expand) => {
+                setExpandedWarmTurns((prev) => {
+                  const next = new Set(prev);
+                  if (expand) next.add(g); else next.delete(g);
+                  return next;
+                });
+              }}
+            />
+          )}
+          <div ref={entranceRef}>
+            {hotZoneNodes}
+          </div>
+        </LiveStreamContext.Provider>
+      </div>
+
+      {!empty && !isAtBottom && (
+        <button
+          type="button"
+          className="transcript__jump-bottom"
+          onClick={() => scrollToBottomAfterLayout(2)}
+          aria-label="Jump to bottom"
+          title="Jump to bottom"
+        >
+          <ArrowDown size={18} strokeWidth={2.2} aria-hidden="true" />
+        </button>
+      )}
     </div>
   );
 }

--- a/desktop/frontend/src/lib/useScrollManager.ts
+++ b/desktop/frontend/src/lib/useScrollManager.ts
@@ -1,6 +1,12 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import gsap from "gsap";
 import { DUR_FAST, EASE_OUT, prefersReducedMotion } from "./gsapAnimations";
+
+const BOTTOM_THRESHOLD_PX = 80;
+
+function isNearBottom(el: HTMLElement): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_THRESHOLD_PX;
+}
 
 /**
  * useScrollManager — GSAP-driven auto-scroll for the transcript container.
@@ -16,29 +22,39 @@ export function useScrollManager() {
   const gsapCtx = useRef<gsap.Context | null>(null);
   const prevQuestionsLen = useRef(0);
   const resizeFrame = useRef<number | null>(null);
+  const layoutScrollFrames = useRef<number[]>([]);
   const lastClientHeight = useRef<number | null>(null);
   const lastFooterHeight = useRef<number | null>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
 
   // Kill any lingering tweens on unmount.
   useEffect(() => {
     return () => {
       gsapCtx.current?.revert();
       if (resizeFrame.current !== null) cancelAnimationFrame(resizeFrame.current);
+      for (const frame of layoutScrollFrames.current) cancelAnimationFrame(frame);
+      layoutScrollFrames.current = [];
     };
+  }, []);
+
+  const updateBottomState = useCallback((el: HTMLElement) => {
+    const atBottom = isNearBottom(el);
+    stick.current = atBottom;
+    setIsAtBottom(atBottom);
+    return atBottom;
   }, []);
 
   const onScroll = useCallback(() => {
     const el = scrollRef.current;
-    if (el) {
-      stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-    }
-  }, []);
+    if (el) updateBottomState(el);
+  }, [updateBottomState]);
 
   /** Scroll smoothly to a specific element.  Used by the JumpBar. */
   const smoothScrollTo = useCallback((element: HTMLElement, offset = 12) => {
     const el = scrollRef.current;
     if (!el) return;
     stick.current = false;
+    setIsAtBottom(false);
     if (resizeFrame.current !== null) {
       cancelAnimationFrame(resizeFrame.current);
       resizeFrame.current = null;
@@ -51,8 +67,9 @@ export function useScrollManager() {
       scrollTo: { y: Math.max(0, top) },
       duration: reduced ? 0.001 : DUR_FAST * 2,
       ease: EASE_OUT,
+      onComplete: () => updateBottomState(el),
     });
-  }, []);
+  }, [updateBottomState]);
 
   /** Force-scroll to the bottom — used when a new question is sent. */
   const scrollToBottom = useCallback((force = false) => {
@@ -60,24 +77,64 @@ export function useScrollManager() {
     if (!el) return;
     if (force) {
       stick.current = true;
+      setIsAtBottom(true);
     }
-    if (!stick.current) return;
+    if (!stick.current && !force) return;
     if (resizeFrame.current !== null) {
       cancelAnimationFrame(resizeFrame.current);
       resizeFrame.current = null;
     }
     resizeFrame.current = requestAnimationFrame(() => {
       resizeFrame.current = null;
-      if (!stick.current) return;
+      if (!stick.current && !force) return;
+      if (force) {
+        stick.current = true;
+        setIsAtBottom(true);
+      }
       const reduced = prefersReducedMotion();
       gsap.to(el, {
         scrollTo: { y: "max" },
         duration: reduced ? 0.001 : DUR_FAST,
         ease: "none",
         overwrite: "auto",
+        onComplete: () => {
+          stick.current = true;
+          setIsAtBottom(true);
+        },
       });
     });
   }, []);
+
+  const snapToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (resizeFrame.current !== null) {
+      cancelAnimationFrame(resizeFrame.current);
+      resizeFrame.current = null;
+    }
+    gsap.killTweensOf(el);
+    stick.current = true;
+    el.scrollTop = el.scrollHeight;
+    setIsAtBottom(true);
+  }, []);
+
+  const scrollToBottomAfterLayout = useCallback((frames = 4) => {
+    for (const frame of layoutScrollFrames.current) cancelAnimationFrame(frame);
+    layoutScrollFrames.current = [];
+    snapToBottom();
+    let remaining = Math.max(0, frames);
+    const tick = () => {
+      if (remaining <= 0) return;
+      const frame = requestAnimationFrame(() => {
+        layoutScrollFrames.current = layoutScrollFrames.current.filter((id) => id !== frame);
+        snapToBottom();
+        remaining -= 1;
+        tick();
+      });
+      layoutScrollFrames.current.push(frame);
+    };
+    tick();
+  }, [snapToBottom]);
 
   /** Call when a new question is submitted — overrides stick state. */
   const onNewQuestion = useCallback(() => {
@@ -93,8 +150,9 @@ export function useScrollManager() {
       const el = scrollRef.current;
       if (!el) return;
       const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (!stick.current && bottomDistance + containerHeightDelta >= 80) return;
+      if (!stick.current && bottomDistance + containerHeightDelta >= BOTTOM_THRESHOLD_PX) return;
       stick.current = true;
+      setIsAtBottom(true);
       scrollToBottom();
     },
     [scrollToBottom],
@@ -118,8 +176,10 @@ export function useScrollManager() {
     scrollRef,
     stick,
     onScroll,
+    isAtBottom,
     smoothScrollTo,
     scrollToBottom,
+    scrollToBottomAfterLayout,
     onNewQuestion,
     repinIfWasPinned,
     trackQuestions,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3060,6 +3060,12 @@ a[href] {
     transform: scale(1);
   }
 }
+.transcript-shell {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
 .transcript {
   position: relative;
   height: 100%;
@@ -3073,6 +3079,46 @@ a[href] {
   max-width: var(--maxw);
   margin-left: auto;
   margin-right: auto;
+}
+.transcript__jump-bottom {
+  --wails-draggable: no-drag;
+  position: absolute;
+  right: max(24px, calc((100% - var(--maxw)) / 2 + 18px));
+  bottom: 18px;
+  z-index: var(--z-inline-sticky);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-elev) 92%, var(--accent-soft));
+  color: var(--fg);
+  box-shadow: var(--shadow-2);
+  cursor: pointer;
+  pointer-events: auto;
+  transition:
+    transform 0.12s ease,
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease,
+    box-shadow 0.12s ease,
+    opacity 0.12s ease;
+}
+.transcript__jump-bottom:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  background: color-mix(in srgb, var(--bg-elev-2) 88%, var(--accent-soft));
+  color: var(--accent);
+  box-shadow: 0 12px 30px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.transcript__jump-bottom:focus-visible {
+  outline: none;
+  box-shadow:
+    var(--focus-ring),
+    var(--shadow-2);
 }
 .transcript--empty {
   container-type: size;


### PR DESCRIPTION
## 背景

桌面端在查看较长对话时，如果用户手动向上滚动，后续想回到最新消息位置需要连续滚动到底部，操作成本较高。

同时，在切换对话后，期望默认回到该对话的最新消息位置，避免进入旧对话时停留在历史中间位置。

## 改动内容

本 PR 为桌面端 Transcript 增加两个滚动体验改进：

1. 切换对话后自动滚动到当前对话底部。
2. 当当前视图不在对话底部时，显示一个向下箭头按钮，点击后立即跳转到底部。

实现细节：

- 在 `useScrollManager` 中增加 `isAtBottom` 状态，用于判断当前是否接近底部。
- 增加 `scrollToBottomAfterLayout()`，通过多帧 `requestAnimationFrame` 适配 AskCard、Approval、Todo 等动态内容高度变化，减少“差一点到底”的情况。
- 在 `Transcript` 外层增加 `transcript-shell`，让跳转按钮作为滚动区域外的 overlay 展示，而不是放在滚动内容内部。
- 跳转按钮样式使用现有主题 CSS 变量，适配当前桌面端主题。

## 验证

已在本地执行：

- `npm run check:css`
- `npm run typecheck`
- `git diff --check`

均通过。

## 影响范围

主要影响桌面端对话 Transcript 的滚动体验。

不涉及后端逻辑、模型调用、MCP、配置迁移或会话存储格式。