### PR TITLE
feat: mobile drawer for sidebar on small screen / 移动端侧边栏抽屉适配

### DIFF
--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -257,6 +257,37 @@ input,textarea{font:inherit;color:inherit}
 .stat-card__value.ok{color:var(--success)}
 .stat-card--wide{grid-column:1/-1}
 .sidebar__item--danger{color:var(--danger)}
+
+/* ── mobile drawer ── */
+.mobile-hamburger{display:none}
+.sidebar-overlay{display:none}
+
+@media(max-width:768px){
+  .mobile-hamburger{
+    display:inline-flex;align-items:center;
+    justify-content:center;width:32px;height:32px;
+    border-radius:6px;cursor:pointer;color:var(--fg-2);
+    flex-shrink:0
+  }
+  .mobile-hamburger:hover{background:var(--panel);color:var(--fg)}
+
+  .sidebar{
+    display:flex!important;
+    position:fixed;top:0;left:0;z-index:300;
+    width:280px;max-width:85vw;height:100vh;
+    transform:translateX(-100%);
+    transition:transform .25s ease;
+    box-shadow:var(--shadow-lg)
+  }
+  .sidebar.open{transform:translateX(0)}
+
+  .sidebar-overlay{
+    display:block;position:fixed;inset:0;z-index:299;
+    background:oklch(0% 0 0/.5);
+    opacity:0;pointer-events:none;transition:opacity .25s ease
+  }
+  .sidebar-overlay.open{opacity:1;pointer-events:auto}
+}
 </style>
 </head>
 <body>
@@ -352,6 +383,9 @@ input,textarea{font:inherit;color:inherit}
       <div class="toolbar__spacer"></div>
       <div class="status" id="turn-info"></div>
       <div class="status" id="balance-info"></div>
+      <button class="mobile-hamburger" id="btn-menu" aria-label="Menu">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+      </button>
     </div>
     <div class="composer">
       <span class="composer__caret">&#8250;</span>
@@ -1164,6 +1198,24 @@ $$('.welcome__ex').forEach(btn=>{btn.onclick=()=>{input.value=btn.dataset.prompt
 
 // initial fetch
 fetchStatus();
+
+// ── mobile drawer toggle ──
+function toggleSidebar(open){
+  const s=document.querySelector('.sidebar');
+  const o=document.getElementById('sidebar-overlay');
+  if(!s||!o)return;
+  s.classList.toggle('open',open);
+  o.classList.toggle('open',open);
+}
+document.getElementById('btn-menu')?.addEventListener('click',()=>toggleSidebar(true));
+document.getElementById('sidebar-overlay')?.addEventListener('click',()=>toggleSidebar(false));
+document.querySelector('.sidebar__nav')?.addEventListener('click',()=>toggleSidebar(false));
+document.getElementById('session-list')?.addEventListener('click',()=>toggleSidebar(false));
+// click on non-interactive sidebar area (brand, status, gaps) also closes
+document.querySelector('.sidebar')?.addEventListener('click',e=>{
+  if(!e.target.closest('.sidebar__item,.session-item,button,a,input,textarea,.session-del'))toggleSidebar(false);
+});
 </script>
+<div class="sidebar-overlay" id="sidebar-overlay"></div>
 </body>
 </html>

--- a/internal/serve/index.html
+++ b/internal/serve/index.html
@@ -443,6 +443,7 @@ input,textarea{font:inherit;color:inherit}
     </div>
   </div>
 </div>
+<div class="sidebar-overlay" id="sidebar-overlay"></div>
 <script>
 // ── i18n ──
 const __LANG_PREF = '__LANG__';
@@ -1216,6 +1217,5 @@ document.querySelector('.sidebar')?.addEventListener('click',e=>{
   if(!e.target.closest('.sidebar__item,.session-item,button,a,input,textarea,.session-del'))toggleSidebar(false);
 });
 </script>
-<div class="sidebar-overlay" id="sidebar-overlay"></div>
 </body>
 </html>


### PR DESCRIPTION
## Title

**feat: mobile drawer for sidebar on small screen / 移动端侧边栏抽屉适配**

---

## Body

### Summary

Add a slide-in drawer for the sidebar on screens ≤768px. Previously the sidebar was simply `display:none` on mobile, making navigation, session list, and status metrics inaccessible. This PR transforms it into a swipeable drawer with a hamburger toggle — all changes are appended to the end of each section (52 lines added, 0 existing lines modified) for clean upstream merges.

为 ≤768px 小屏幕添加侧边栏滑动抽屉。此前手机端仅做了 `display:none` 隐藏，导致导航、会话列表和状态完全不可用。本 PR 改为汉堡菜单触发的滑动抽屉，所有改动均为末尾追加（新增 52 行，零修改已有代码），便于干净合并上游更新。

### Changes / 变更

- **CSS** (~30 lines): `.mobile-hamburger`, `.sidebar-overlay`, and `@media(max-width:768px)` — sidebar becomes fixed-position drawer with `transform: translateX` + 0.25s transition, overlay provides semi-transparent backdrop.
- **HTML** (+3 lines): Hamburger button in footer toolbar; overlay `<div>` before `<script>`.
- **JS** (~14 lines): `toggleSidebar()` function; click handlers for hamburger, overlay, nav, session list, and non-interactive sidebar areas.

### Interaction / 交互

| 操作 | 效果 |
|---|---|
| Tap hamburger (☰) / 点击汉堡图标 | Drawer slides in from left, backdrop darkens |
| Tap nav item or session / 点击导航或会话 | Auto-close |
| Tap overlay / 点击遮罩 | Close |
| Tap blank sidebar area / 点击侧边栏空白 | Close |

---

### Verification

```bash
go build ./internal/serve/          # builds successfully
go test ./internal/tool/builtin/ ./internal/boot/  # all tests pass
git diff main-v2..feat/mobile-drawer --stat
# → 1 file changed, 52 insertions(+), 0 deletions(-)
```

Tested manually in browser DevTools mobile viewport (375px–428px wide):
- Hamburger button appears only at ≤768px ✓
- Sidebar slides in/out with smooth transition ✓
- Overlay click closes drawer ✓
- Session selection and navigation buttons close drawer ✓
- Clicking blank sidebar area closes drawer ✓

---

### Cache impact

Cache-impact: none — only `internal/serve/index.html` (frontend HTML/CSS/JS) changed; no Go runtime, agent, provider, tool, or boot code touched.

Cache-guard: none needed — no cache-sensitive path changed.

System-prompt-review: N/A — no system-prompt, memory prefix, output style, or skill index changes.

---

### Branch

`feat/mobile-drawer` → base: `main-v2`