### PR TITLE
feat: add /reload-cmd command for hot-reloading custom slash commands

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -3721,6 +3721,7 @@ func (a *App) Commands() []CommandInfo {
 		{Name: "hooks", Description: i18n.M.CmdHooks, Kind: "builtin"},
 		{Name: "theme", Description: i18n.M.CmdTheme, Kind: "builtin"},
 		{Name: "skill", Description: i18n.M.CmdSkill, Kind: "builtin"},
+		{Name: "reload-cmd", Description: i18n.M.CmdReloadCmd, Kind: "builtin"},
 	}
 	a.mu.RLock()
 	ctrl := a.activeCtrlLocked()
@@ -4331,6 +4332,22 @@ func (a *App) RemoveSkillPath(path string) error {
 func (a *App) RefreshSkills() error {
 	a.invalidateSkillRootsCache()
 	return a.rebuild()
+}
+
+// ReloadCommands rescans command directories and hot-swaps without restarting
+// the controller — no MCP disconnect, no hook rerun.
+func (a *App) ReloadCommands() error {
+	if a.ctx == nil {
+		return nil
+	}
+	tab := a.activeTab()
+	if tab == nil || tab.Ctrl == nil {
+		return fmt.Errorf("no active session")
+	}
+	if tab.Ctrl.Running() {
+		return fmt.Errorf("wait for the current turn to finish, then retry")
+	}
+	return tab.Ctrl.ReloadCommands(a.ctx)
 }
 
 // SetSkillEnabled persists a skill toggle and rebuilds the controller so the

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -191,6 +191,7 @@ export interface AppBindings {
   AddSkillPath(path: string): Promise<void>;
   RemoveSkillPath(path: string): Promise<void>;
   RefreshSkills(): Promise<void>;
+  ReloadCommands(): Promise<void>;
   SetSkillEnabled(name: string, enabled: boolean): Promise<void>;
   SetMCPServerEnabled(name: string, enabled: boolean): Promise<void>;
   SetMCPServerTier(name: string, tier: string): Promise<void>;
@@ -2034,6 +2035,7 @@ function makeMockApp(): AppBindings {
       }
     },
     async RefreshSkills() {},
+    async ReloadCommands() {},
     async SetSkillEnabled(name: string, enabled: boolean) {
       const skill = capSkills.find((s) => s.name === name);
       if (skill) skill.enabled = enabled;

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -3545,6 +3545,26 @@ func (m *chatTUI) runSlashCommand(input string) tea.Cmd {
 	case "/hooks":
 		m.echoLocalCommand(input)
 		m.runHooksSubcommand(input)
+	case "/reload-cmd":
+		m.echoLocalCommand(input)
+		if m.ctrl == nil {
+			m.notice("controller not ready")
+			return nil
+		}
+		if m.ctrl.Running() {
+			m.notice("wait for the current turn to finish, then retry /reload-cmd")
+			return nil
+		}
+		prev := len(m.commands)
+		err := m.ctrl.ReloadCommands(context.Background())
+		m.commands = m.ctrl.Commands()
+		m.updateCompletion()
+		if err != nil {
+			m.notice("reload-cmd: " + err.Error())
+			return nil
+		}
+		m.notice(fmt.Sprintf("commands reloaded: %d → %d commands", prev, len(m.commands)))
+
 	case "/paste-image":
 		return pasteClipboardImage()
 	case "/output-style", "/output-styles":

--- a/internal/cli/complete.go
+++ b/internal/cli/complete.go
@@ -74,6 +74,7 @@ func (m *chatTUI) slashItems() []compItem {
 		{label: "/model", insert: "/model ", hint: i18n.M.CmdModel, descend: true},
 		{label: "/provider", insert: "/provider ", hint: i18n.M.CmdProvider, descend: true},
 		{label: "/skills", insert: "/skills", hint: i18n.M.CmdSkill},
+		{label: "/reload-cmd", insert: "/reload-cmd", hint: i18n.M.CmdReloadCmd},
 		{label: "/hooks", insert: "/hooks ", hint: i18n.M.CmdHooks, descend: true},
 		{label: "/paste-image", insert: "/paste-image", hint: i18n.M.CmdPasteImage},
 		{label: "/output-style", insert: "/output-style", hint: i18n.M.CmdOutputStyle},

--- a/internal/cli/help_view.go
+++ b/internal/cli/help_view.go
@@ -78,6 +78,7 @@ func builtinHelpItems() []compItem {
 		{label: "/language", hint: i18n.M.CmdLanguage},
 		{label: "/auto-plan", hint: i18n.M.CmdAutoPlan},
 		{label: "/reasoning-language", hint: i18n.M.CmdReasonLang},
+		{label: "/reload-cmd", hint: i18n.M.CmdReloadCmd},
 		{label: "/help", hint: i18n.M.CmdHelp},
 	}
 }

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -73,7 +73,7 @@ type Controller struct {
 	systemPrompt  string
 	sessionDir    string
 	host          *plugin.Host
-	commands      []command.Command
+	commands      atomic.Pointer[[]command.Command]
 	skills        []skill.Skill
 	allSkills     []skill.Skill
 	skillStore    *skill.Store
@@ -309,7 +309,7 @@ func New(opts Options) *Controller {
 		sessionDir:             opts.SessionDir,
 		sessionPath:            opts.SessionPath,
 		host:                   opts.Host,
-		commands:               opts.Commands,
+		commands:               atomic.Pointer[[]command.Command]{},
 		skills:                 opts.Skills,
 		allSkills:              opts.AllSkills,
 		skillStore:             opts.SkillStore,
@@ -335,6 +335,8 @@ func New(opts Options) *Controller {
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
 	c.rebindCheckpoints(opts.SessionPath)
 	c.setActiveJobSession(opts.SessionPath)
+	cmdsInit := opts.Commands
+	c.commands.Store(&cmdsInit)
 	if c.executor != nil {
 		c.executor.SetPreEditHook(func(ch diff.Change) {
 			if c.cp != nil {
@@ -2392,7 +2394,49 @@ func (c *Controller) Balance(ctx context.Context) (*billing.Balance, error) {
 func (c *Controller) Host() *plugin.Host { return c.host }
 
 // Commands returns the loaded custom slash commands.
-func (c *Controller) Commands() []command.Command { return c.commands }
+func (c *Controller) Commands() []command.Command {
+	if p := c.commands.Load(); p != nil {
+		return *p
+	}
+	return nil
+}
+
+// ReloadCommands rescans all command directories and hot-swaps the slash_command
+// tool and the internal command slice — no MCP restart, no hook rerun.
+func (c *Controller) ReloadCommands(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	cmds, loadErr := command.Load(config.CommandDirsForRoot(c.cpRoot)...)
+	cmdSkills := c.Skills()
+
+	entries := make([]command.SlashEntry, 0, len(cmdSkills)+len(cmds))
+	for _, sk := range cmdSkills {
+		sk := sk
+		entries = append(entries, command.SlashEntry{
+			Name:        sk.Name,
+			Description: sk.Description,
+			Render:      func(args []string) string { return skill.Render(sk, strings.Join(args, " ")) },
+		})
+	}
+	for _, cmd := range cmds {
+		cmd := cmd
+		entries = append(entries, command.SlashEntry{
+			Name:        cmd.Name,
+			Description: cmd.Description,
+			ArgHint:     cmd.ArgHint,
+			Render:      func(args []string) string { return cmd.Render(args) },
+		})
+	}
+	if c.reg != nil {
+		c.reg.Add(command.NewSlashCommandTool(entries))
+	}
+	cmdSlice := cmds
+	c.commands.Store(&cmdSlice)
+	return loadErr
+}
 
 // Skills returns the discoverable skills (for the slash menu and `/skills`).
 // When a live Store is available, scan it on demand so skills installed during

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -3,6 +3,7 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,12 +14,14 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/checkpoint"
+	"reasonix/internal/command"
 	"reasonix/internal/event"
 	"reasonix/internal/hook"
 	"reasonix/internal/jobs"
 	"reasonix/internal/permission"
 	"reasonix/internal/plugin"
 	"reasonix/internal/provider"
+	"reasonix/internal/skill"
 	"reasonix/internal/tool"
 )
 
@@ -1449,4 +1452,469 @@ func TestApprovedPlanDoesNotAutoApproveNonContinuationTurn(t *testing.T) {
 	if approvalPrompts != 2 {
 		t.Fatalf("non-continuation writer should prompt after plan approval, prompts=%d", approvalPrompts)
 	}
+}
+
+// writeCmdFile creates a command .md file with frontmatter under dir.
+func writeCmdFile(t *testing.T, dir, name, description, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf("---\ndescription: %s\n---\n%s\n", description, body)
+	if err := os.WriteFile(filepath.Join(dir, name+".md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestCommandsAtomicPointer verifies that commands passed via Options.Commands are
+// correctly exposed through the atomic-pointer Commands() getter and that
+// CustomCommand resolves and renders them. Missing commands return found=false.
+func TestCommandsAtomicPointer(t *testing.T) {
+	cmds := []command.Command{
+		{Name: "review", Description: "Review code", Body: "Review $1"},
+		{Name: "test", Description: "Run tests", Body: "Test $1"},
+	}
+	c := New(Options{
+		Commands: cmds,
+		Sink:     &typedNilControllerSink{},
+		Registry: tool.NewRegistry(),
+	})
+
+	// Commands() returns what was passed via Options
+	got := c.Commands()
+	if len(got) != 2 {
+		t.Fatalf("Commands() = %d, want 2", len(got))
+	}
+	// Check retrieval via CustomCommand
+	sent, ok := c.CustomCommand("/review myfile.go")
+	if !ok {
+		t.Error("/review should be found")
+	}
+	if !strings.Contains(sent, "Review myfile.go") {
+		t.Errorf("unexpected render: %q", sent)
+	}
+	_, ok = c.CustomCommand("/missing")
+	if ok {
+		t.Error("/missing should not be found")
+	}
+
+	// Commands() getter uses atomic.Pointer internally
+	if cmds2 := c.Commands(); len(cmds2) != 2 {
+		t.Errorf("Commands() = %d after change, want 2", len(cmds2))
+	}
+}
+
+// TestReloadCommandsFromFilesystem exercises ReloadCommands against real .md
+// files in a temp workspace: initial load, hot-reload with a new file, and
+// hot-reload after modifying an existing file. Also verifies that skills are
+// preserved across the reload.
+func TestReloadCommandsFromFilesystem(t *testing.T) {
+	// Isolate HOME so CommandDirsForRoot does not pick up global .md command files.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "review", "Review code", "Review $1")
+	writeCmdFile(t, cmdDir, "test", "Run tests", "Test $1")
+
+	// Create a minimal in-memory skill to verify skills are preserved across reload.
+	sk := skill.Skill{
+		Name:        "myskill",
+		Description: "Test skill",
+		Body:        "You are a test skill. User says: {{.Input}}",
+	}
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+		Skills:        []skill.Skill{sk},
+	})
+
+	// ReloadCommands should pick up the two .md files and preserve the skill.
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("ReloadCommands: %v", err)
+	}
+	cmds := c.Commands()
+	if len(cmds) != 2 {
+		t.Fatalf("Commands() = %d after reload, want 2", len(cmds))
+	}
+
+	// CustomCommand should resolve through the hot-swapped getter
+	sent, ok := c.CustomCommand("/review hello.go")
+	if !ok {
+		t.Fatal("/review should be found after reload")
+	}
+	if !strings.Contains(sent, "Review hello.go") {
+		t.Errorf("render = %q, want Review hello.go", sent)
+	}
+
+	// Missing command still not found
+	if _, ok := c.CustomCommand("/nope"); ok {
+		t.Error("/nope should not be found")
+	}
+
+	// Skill should appear in the slash_command tool's description after reload.
+	if tool, found := reg.Get("slash_command"); found {
+		if !strings.Contains(tool.Description(), "myskill") {
+			t.Error("skill 'myskill' should appear in slash_command tool Description after ReloadCommands")
+		}
+	} else {
+		t.Error("slash_command tool should be registered after ReloadCommands")
+	}
+
+	// Skill should still be callable via RunSkill after reload.
+	if _, ok := c.RunSkill("/myskill"); !ok {
+		t.Error("RunSkill(/myskill) should find the skill after ReloadCommands")
+	}
+
+	// Hot-reload: add a new command file
+	writeCmdFile(t, cmdDir, "count", "Count to N", "Count from 1 to $1")
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("ReloadCommands (add): %v", err)
+	}
+	if cmds := c.Commands(); len(cmds) != 3 {
+		t.Fatalf("Commands() = %d after add, want 3", len(cmds))
+	}
+
+	// Hot-reload: modify an existing command
+	writeCmdFile(t, cmdDir, "review", "Review code (friendly)", "Kindly review $1")
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("ReloadCommands (modify): %v", err)
+	}
+	if cmds := c.Commands(); len(cmds) != 3 {
+		t.Fatalf("Commands() = %d after modify, want 3", len(cmds))
+	}
+	sent, ok = c.CustomCommand("/review world.go")
+	if !ok {
+		t.Fatal("/review should be found after modify")
+	}
+	if !strings.Contains(sent, "Kindly review world.go") {
+		t.Errorf("render after modify = %q, want Kindly review world.go", sent)
+	}
+
+	// The slash_command tool should be registered and updated
+	if _, found := reg.Get("slash_command"); !found {
+		t.Error("slash_command tool should be registered after ReloadCommands")
+	}
+}
+
+// TestReloadCommandsDeleteFile verifies that removing a command .md file and
+// reloading causes the command to disappear from both Commands() and
+// CustomCommand(), while other commands remain intact.
+func TestReloadCommandsDeleteFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "alpha", "Alpha cmd", "Alpha $1")
+	writeCmdFile(t, cmdDir, "beta", "Beta cmd", "Beta $1")
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	if got := len(c.Commands()); got != 2 {
+		t.Fatalf("Commands() = %d, want 2", got)
+	}
+
+	// Delete alpha.md
+	if err := os.Remove(filepath.Join(cmdDir, "alpha.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("reload after delete: %v", err)
+	}
+	if got := len(c.Commands()); got != 1 {
+		t.Fatalf("Commands() = %d after delete, want 1", got)
+	}
+
+	// /alpha should no longer be found
+	if _, ok := c.CustomCommand("/alpha x"); ok {
+		t.Error("/alpha should NOT be found after deletion")
+	}
+	// /beta should still work
+	sent, ok := c.CustomCommand("/beta y")
+	if !ok {
+		t.Error("/beta should still be found")
+	}
+	if !strings.Contains(sent, "Beta y") {
+		t.Errorf("render = %q, want Beta y", sent)
+	}
+}
+
+// TestReloadCommandsMalformedFile verifies that a malformed .md file causes
+// ReloadCommands to return an error but does not prevent other valid commands
+// from loading.
+func TestReloadCommandsMalformedFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "good", "Good cmd", "Good $1")
+
+	// Write a malformed file (no valid frontmatter)
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	broken := filepath.Join(cmdDir, "broken.md")
+	if err := os.WriteFile(broken, []byte("this is not valid yaml\n---\nrandom\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	err := c.ReloadCommands(context.Background())
+	// We expect some error from the malformed file
+	if err == nil {
+		t.Log("ReloadCommands returned nil error despite malformed file — command.Load may tolerate it")
+	} else {
+		t.Logf("ReloadCommands returned error (expected): %v", err)
+	}
+
+	// The valid command should still be loadable
+	cmds := c.Commands()
+	foundGood := false
+	for _, cmd := range cmds {
+		if cmd.Name == "good" {
+			foundGood = true
+		}
+	}
+	if !foundGood {
+		t.Errorf("valid command 'good' should be present, got commands: %v", cmdNames(cmds))
+	}
+}
+
+// TestReloadCommandsSameNameAcrossDirs verifies that when the same command
+// name exists in multiple convention directories, the later-scanned directory
+// (higher priority) wins. ConventionDirs = [".reasonix", ".agents", ".agent",
+// ".claude"], scanned in reverse, so .reasonix is highest priority.
+func TestReloadCommandsSameNameAcrossDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+
+	// Lower priority: .claude/commands
+	claudeDir := filepath.Join(wsRoot, ".claude", "commands")
+	writeCmdFile(t, claudeDir, "greet", "Claude greet", "Hello from Claude: $1")
+
+	// Higher priority: .reasonix/commands
+	reasonixDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, reasonixDir, "greet", "Reasonix greet", "Hello from Reasonix: $1")
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	// There should be exactly 1 command named "greet"
+	cmds := c.Commands()
+	count := 0
+	for _, cmd := range cmds {
+		if cmd.Name == "greet" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 'greet' command, got %d", count)
+	}
+
+	// The winning version should be from .reasonix (highest priority)
+	sent, ok := c.CustomCommand("/greet world")
+	if !ok {
+		t.Fatal("/greet should be found")
+	}
+	if !strings.Contains(sent, "Hello from Reasonix") {
+		t.Errorf("expected .reasonix version to win, got render: %q", sent)
+	}
+}
+
+// TestReloadCommandsEmptySet verifies that deleting all command files and
+// reloading results in an empty Commands() slice, while the slash_command tool
+// still exists in the Registry (containing only Skills).
+func TestReloadCommandsEmptySet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "temp", "Temp cmd", "Temp $1")
+
+	sk := skill.Skill{
+		Name:        "preserved",
+		Description: "A skill to keep",
+		Body:        "Skill body: {{.Input}}",
+	}
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          &typedNilControllerSink{},
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+		Skills:        []skill.Skill{sk},
+	})
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	if got := len(c.Commands()); got != 1 {
+		t.Fatalf("Commands() = %d, want 1", got)
+	}
+
+	// Delete all command files
+	if err := os.Remove(filepath.Join(cmdDir, "temp.md")); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("reload after delete all: %v", err)
+	}
+	if got := len(c.Commands()); got != 0 {
+		t.Fatalf("Commands() = %d after delete all, want 0", got)
+	}
+
+	// /temp should no longer be found
+	if _, ok := c.CustomCommand("/temp x"); ok {
+		t.Error("/temp should NOT be found after deletion")
+	}
+
+	// slash_command tool should still exist (for Skills)
+	slashTool, found := reg.Get("slash_command")
+	if !found {
+		t.Fatal("slash_command tool should still exist even with 0 commands")
+	}
+	// It should still contain the skill
+	if !strings.Contains(slashTool.Description(), "preserved") {
+		t.Error("skill 'preserved' should still appear in slash_command tool Description")
+	}
+}
+
+// TestReloadCommandsDesktopManagementNotice verifies the desktop/HTTP path:
+// when the frontend submits "/reload-cmd" as raw input, Submit → managementNotice
+// handles it and emits a Notice event with the correct count.
+func TestReloadCommandsDesktopManagementNotice(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+
+	wsRoot := t.TempDir()
+	cmdDir := filepath.Join(wsRoot, ".reasonix", "commands")
+	writeCmdFile(t, cmdDir, "hello", "Greet", "Hello $1")
+	writeCmdFile(t, cmdDir, "review", "Review code", "Review $1")
+
+	var notices []string
+	sink := event.FuncSink(func(e event.Event) {
+		if e.Kind == event.Notice {
+			notices = append(notices, e.Text)
+		}
+	})
+
+	reg := tool.NewRegistry()
+	c := New(Options{
+		Sink:          sink,
+		Registry:      reg,
+		WorkspaceRoot: wsRoot,
+	})
+
+	// Initial load so Commands() is populated.
+	if err := c.ReloadCommands(context.Background()); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	notices = nil // reset
+
+	// Desktop path: managementNotice("/reload-cmd") should emit a notice.
+	handled := c.managementNotice("/reload-cmd")
+	if !handled {
+		t.Fatal("managementNotice(/reload-cmd) should return true")
+	}
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "commands reloaded") {
+		t.Errorf("notice = %q, want 'commands reloaded'", notices[0])
+	}
+	if !strings.Contains(notices[0], "2 available") {
+		t.Errorf("notice = %q, want '2 available'", notices[0])
+	}
+
+	// Delete one command file and reload again.
+	if err := os.Remove(filepath.Join(cmdDir, "hello.md")); err != nil {
+		t.Fatal(err)
+	}
+	notices = nil
+	handled = c.managementNotice("/reload-cmd")
+	if !handled {
+		t.Fatal("managementNotice(/reload-cmd) after delete should return true")
+	}
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice after delete, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "1 available") {
+		t.Errorf("notice after delete = %q, want '1 available'", notices[0])
+	}
+
+	// Delete all and verify empty-set notice.
+	if err := os.Remove(filepath.Join(cmdDir, "review.md")); err != nil {
+		t.Fatal(err)
+	}
+	notices = nil
+	handled = c.managementNotice("/reload-cmd")
+	if !handled {
+		t.Fatal("managementNotice(/reload-cmd) empty set should return true")
+	}
+	if len(notices) != 1 {
+		t.Fatalf("expected 1 notice for empty set, got %d: %v", len(notices), notices)
+	}
+	if !strings.Contains(notices[0], "0 available") {
+		t.Errorf("notice for empty set = %q, want '0 available'", notices[0])
+	}
+}
+
+// cmdNames is a test helper that extracts command names from a slice.
+func cmdNames(cmds []command.Command) []string {
+	names := make([]string, len(cmds))
+	for i, c := range cmds {
+		names[i] = c.Name
+	}
+	return names
 }

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -460,7 +460,7 @@ func (c *Controller) CustomCommand(input string) (sent string, found bool) {
 		return "", false
 	}
 	name := strings.TrimPrefix(fields[0], "/")
-	for _, cmd := range c.commands {
+	for _, cmd := range c.Commands() {
 		if cmd.Name == name {
 			return cmd.Render(fields[1:]), true
 		}

--- a/internal/control/port.go
+++ b/internal/control/port.go
@@ -132,6 +132,7 @@ type MemoryControl interface {
 type Capabilities interface {
 	Host() *plugin.Host
 	Commands() []command.Command
+	ReloadCommands(ctx context.Context) error
 	Skills() []skill.Skill
 	AllSkills() []skill.Skill
 	DisabledSkills() []skill.Skill

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -1,8 +1,10 @@
 package control
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"reasonix/internal/config"
@@ -397,6 +399,16 @@ func (c *Controller) managementNotice(trimmed string) bool {
 			return true
 		}
 		c.notice(c.skillListText())
+	case "/reload-cmd":
+		if c.Running() {
+			c.notice("wait for the current turn to finish, then retry /reload-cmd")
+			return true
+		}
+		if err := c.ReloadCommands(context.Background()); err != nil {
+			c.notice("reload-cmd: " + err.Error())
+		} else {
+			c.notice("commands reloaded (" + strconv.Itoa(len(c.Commands())) + " available)")
+		}
 	case "/hooks":
 		sub := ""
 		if len(fields) >= 2 {

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -173,6 +173,7 @@ type Messages struct {
 	CmdLanguage     string // /language
 	CmdSkill        string // /skills
 	CmdVerbose      string // /verbose
+	CmdReloadCmd    string // /reload-cmd
 	CmdDiffFold     string // /diff-fold
 	CmdSandbox      string // /sandbox
 	CmdEffort       string // /effort

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -184,6 +184,7 @@ var English = Messages{
 	CmdLanguage:     "switch CLI language",
 	CmdSkill:        "manage skills",
 	CmdVerbose:      "toggle thinking text",
+	CmdReloadCmd:    "reload custom commands",
 	CmdDiffFold:     "toggle diff fold/expand",
 	CmdSandbox:      "show sandbox status",
 	CmdEffort:       "set reasoning effort",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -185,6 +185,7 @@ var Chinese = Messages{
 	CmdLanguage:     "切换 CLI 语言",
 	CmdSkill:        "管理 skills",
 	CmdVerbose:      "切换 thinking 原文显示",
+	CmdReloadCmd:    "重载自定义命令",
 	CmdDiffFold:     "切换 diff 折叠/展开",
 	CmdSandbox:      "查看沙箱状态",
 	CmdEffort:       "设置推理强度",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -173,6 +173,7 @@ var ChineseTraditional = Messages{
 	CmdLanguage:     "切換 CLI 語言",
 	CmdSkill:        "管理 skills",
 	CmdVerbose:      "切換 thinking 原文顯示",
+	CmdReloadCmd:    "重載自定義命令",
 	CmdSandbox:      "檢視沙箱狀態",
 	CmdEffort:       "設定推理強度",
 	CmdAutoPlan:     "設定自動計畫模式",


### PR DESCRIPTION
Re-lands #4899 (by @Barsit) rebased cleanly onto current `main-v2`, which couldn't merge directly: it conflicted with the recent `controller.go` memory-mutex addition and the new `internal/control/port.go` driving-port abstraction.

Adaptation on top of the original commit (authorship preserved):
- Resolve the `Controller` struct conflict — keep both `memMu sync.Mutex` and the hot-reload `commands atomic.Pointer[[]command.Command]`.
- Add `ReloadCommands(ctx) error` to the `Capabilities` sub-port in `port.go` so the CLI can call it through `SessionAPI` (the interface didn't exist when the PR was authored).
- Drop the `docs/superpowers/specs/*.md` design note to keep with the repo's no-new-docs rule.

### Feature
`/reload-cmd` hot-reloads custom slash commands from `.reasonix/commands/*.md` without restarting the Controller, dropping MCP connections, or re-running session hooks. Skills are preserved; the rebuilt `slash_command` tool takes effect on the model's next turn and `/name` works immediately on the human side (atomic snapshot swap).

### Verification
- `go build ./...` and `cd desktop && go build ./...` clean
- `go test ./internal/control/ ./internal/cli/ ./internal/acp/ ./internal/i18n/` all pass (includes the `TestReloadCommands*` suite)

Closes #4899
Closes #4840
