### PR TITLE
Compact model switcher trigger / 精简模型切换按钮

### DIFF
--- a/desktop/frontend/src/components/ModelSwitcher.tsx
+++ b/desktop/frontend/src/components/ModelSwitcher.tsx
@@ -5,6 +5,7 @@ import { app } from "../lib/bridge";
 import { useT } from "../lib/i18n";
 import type { ModelInfo } from "../lib/types";
 import { AnchoredPopover } from "./AnchoredPopover";
+import { Tooltip } from "./Tooltip";
 
 // ModelSwitcher opens an upward popover listing configured providers. Selecting
 // one switches the active model while the current conversation continues.
@@ -79,6 +80,7 @@ export function ModelSwitcher({ label, tabId, onPick }: { label: string; tabId?:
     const cur = models.find((m) => m.current) ?? models.find((m) => m.model === label || m.ref === label);
     return cur ? providerLabel(cur.provider, t) : null;
   }, [label, models, t]);
+  const triggerLabel = currentProvider ? `${label} · ${currentProvider}` : label;
 
   const pick = (name: string) => {
     setModels((prev) => prev.map((m) => ({ ...m, current: m.ref === name })));
@@ -88,17 +90,20 @@ export function ModelSwitcher({ label, tabId, onPick }: { label: string; tabId?:
 
   return (
     <div className="modelsw">
-      <button
-        ref={triggerRef}
-        type="button"
-        className="modelsw__trigger"
-        aria-expanded={open}
-        onClick={() => setOpen((v) => !v)}
-      >
-        <Brain size={13} className="modelsw__kind" />
-        <span className="modelsw__label">{label}{currentProvider && <span className="modelsw__provider"> · {currentProvider}</span>}</span>
-        <ChevronsUpDown size={11} />
-      </button>
+      <Tooltip label={triggerLabel} fill>
+        <button
+          ref={triggerRef}
+          type="button"
+          className="modelsw__trigger"
+          aria-label={triggerLabel}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+        >
+          <Brain size={13} className="modelsw__kind" />
+          <span className="modelsw__label">{label}</span>
+          <ChevronsUpDown size={11} />
+        </button>
+      </Tooltip>
       <AnchoredPopover
         open={open}
         anchorRef={triggerRef}

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -6204,14 +6204,6 @@ a[href] {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.modelsw__provider {
-  display: block;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: var(--fg-faint);
-  font-size: 11px;
-}
 .modelsw__check {
   flex-shrink: 0;
 }
@@ -21497,7 +21489,6 @@ a[href] {
   background: var(--accent-soft);
 }
 
-:root[data-theme-style] .modelsw__provider,
 :root[data-theme-style] .modelsw__empty {
   color: var(--fg-faint);
 }
@@ -23800,9 +23791,7 @@ a[href] {
 }
 
 .app--creation .composer-meta .modelsw__kind,
-.app--creation .composer-meta .modelsw__provider,
-:root[data-theme-style] .app--creation .composer-meta .modelsw__kind,
-:root[data-theme-style] .app--creation .composer-meta .modelsw__provider {
+:root[data-theme-style] .app--creation .composer-meta .modelsw__kind {
   display: none;
 }
 


### PR DESCRIPTION
## Summary
- Show only the current model name in the composer model switcher trigger.
- Move provider detail into the trigger tooltip and accessible label.
- Remove obsolete provider sublabel styles from the trigger.

## Related
- Related to #5002, which handles model button overflow. This PR changes the trigger information hierarchy.

## Verification
- `npm --prefix desktop/frontend run check:css`
- `npm --prefix desktop/frontend run typecheck`
- `npm --prefix desktop/frontend run build`
- Browser verification: the composer model trigger text is only the model name, its accessible label includes model and provider, and there are no console errors.