### PR TITLE
fix(openai): add omitempty to chatFunction description/parameters

### DIFF
--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -588,8 +588,8 @@ type chatTool struct {
 
 type chatFunction struct {
 	Name        string          `json:"name"`
-	Description string          `json:"description"`
-	Parameters  json.RawMessage `json:"parameters"`
+	Description string          `json:"description,omitempty"`
+	Parameters  json.RawMessage `json:"parameters,omitempty"`
 }
 
 type chatToolCall struct {

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -613,3 +613,35 @@ func TestBuildRequestContentNullForAssistantToolCalls(t *testing.T) {
 		t.Errorf("no-param tool should serialize a valid empty-object schema: %s", s)
 	}
 }
+
+func TestBuildRequestOmitsEmptyToolDescriptionAndParameters(t *testing.T) {
+	c := &client{name: "x", model: "m", baseURL: "https://api.example.com/v1"}
+	req := provider.Request{
+		Tools: []provider.ToolSchema{{Name: "noargs"}},
+	}
+	body, err := json.Marshal(c.buildRequest(req))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var wire struct {
+		Tools []struct {
+			Function map[string]json.RawMessage `json:"function"`
+		} `json:"tools"`
+	}
+	if err := json.Unmarshal(body, &wire); err != nil {
+		t.Fatalf("unmarshal request: %v\n%s", err, body)
+	}
+	if len(wire.Tools) != 1 {
+		t.Fatalf("tools = %d, want 1: %s", len(wire.Tools), body)
+	}
+	fn := wire.Tools[0].Function
+	if string(fn["name"]) != `"noargs"` {
+		t.Fatalf("function name = %s, want noargs", fn["name"])
+	}
+	if _, ok := fn["description"]; ok {
+		t.Fatalf("empty description should be omitted: %s", body)
+	}
+	if _, ok := fn["parameters"]; ok {
+		t.Fatalf("nil parameters should be omitted: %s", body)
+	}
+}


### PR DESCRIPTION
## 问题

opencode.ai 等网关对工具定义有严格的 JSON schema 校验。Reasonix 发送的 `chatFunction` 始终包含 `description: ""` 和 `parameters: null`，在某些网关上导致：

```
Failed to deserialize the JSON body into the target type: tools[0].function: missing field `name`
```

## 修复

给 `chatFunction` 的 `Description` 和 `Parameters` 字段加上 `json:",omitempty"`。

空值不再序列化，减少 JSON 体积同时兼容严格网关。正常工具 schema 会继续通过 `CanonicalizeSchema` 发送，不会牺牲 DeepSeek、MiniMax、MiMo 等 OpenAI-compatible 主供应商的工具调用。

## 文件
internal/provider/openai/openai.go (+2/-2)
internal/provider/openai/openai_test.go (+32)

Cache-impact: low - OpenAI-compatible tool schema bytes change only when a tool has empty description or nil parameters; normal canonicalized tool schemas remain present.
Cache-guard: TestBuildRequestOmitsEmptyToolDescriptionAndParameters plus `go test ./internal/provider/openai ./internal/provider`
