### PR TITLE
Fix transcript bottom pinning / 修复对话滚动到底部定位

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2110,6 +2110,7 @@ export default function App() {
       await openProjectTab(workspaceRoot, topicId);
     }
     await refreshTabMetas();
+    setTabRevealSignal((signal) => signal + 1);
   }, [closeTransientOverlays, openGlobalTab, openProjectTab, openTopicSession, refreshTabMetas]);
 
   const openSidebarImConnectionSession = useCallback(async (connection: SidebarImConnection) => {
@@ -2132,6 +2133,7 @@ export default function App() {
         await openGlobalTab(target.value);
       }
       await refreshTabMetas();
+      setTabRevealSignal((value) => value + 1);
       setProjectRevision((value) => value + 1);
     } catch (err) {
       console.warn("bot sidebar open failed", err);
@@ -2182,6 +2184,7 @@ export default function App() {
           await resumeSession(session.path, targetTab.id);
         }
         await refreshTabMetas();
+        setTabRevealSignal((value) => value + 1);
       } catch (err: any) {
         setHistView(null);
         if (scope === "project" && session.workspaceRoot) {
@@ -2996,6 +2999,7 @@ export default function App() {
                 creationMode={sidebarCreation}
                 actionHoverMenus={sidebarCreation}
                 rewindSignal={rewindSignal}
+                revealSignal={tabRevealSignal}
               />
             )}
           </main>

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -5,7 +5,7 @@ import { useT } from "../lib/i18n";
 import { AssistantMessage, TurnActions, UserMessage } from "./Message";
 import { ProcessCompactIcon, ProcessPhaseIcon } from "./ProcessCard";
 import { ToolCard } from "./ToolCard";
-import { ChevronRight } from "lucide-react";
+import { ArrowDown, ChevronRight } from "lucide-react";
 import { Welcome } from "./Welcome";
 import { ReadOnlyBatch } from "./ReadOnlyBatch";
 import { ToolGroup, isCreationGroupableTool, toolGroupKind, type ToolGroupKind } from "./ToolGroup";
@@ -93,6 +93,7 @@ export function Transcript({
   creationMode = false,
   actionHoverMenus = false,
   rewindSignal = 0,
+  revealSignal = 0,
 }: {
   items: Item[];
   live?: LiveStream;
@@ -110,12 +111,15 @@ export function Transcript({
   creationMode?: boolean;
   actionHoverMenus?: boolean;
   rewindSignal?: number;
+  revealSignal?: number;
 }) {
   const {
     scrollRef,
     stick,
     onScroll,
+    isAtBottom,
     smoothScrollTo,
+    scrollToBottomAfterLayout,
     trackQuestions,
     repinIfWasPinned,
     resizeFrame,
@@ -123,6 +127,7 @@ export function Transcript({
     lastFooterHeight,
   } = useScrollManager();
   const autoScrollFrame = useRef<number | null>(null);
+  const pendingRevealBottomScroll = useRef(false);
   const sessionKey = useMemo(() => `${items[0]?.id ?? ""}|${items[items.length - 1]?.id ?? ""}`, [items]);
   const entranceRef = useEntranceAnimation<HTMLDivElement>(sessionKey, items.length);
 
@@ -150,7 +155,17 @@ export function Transcript({
   // disables auto-scroll when the user had scrolled up in the old tab (#4584).
   useEffect(() => {
     stick.current = true;
-  }, [tabId]);
+    pendingRevealBottomScroll.current = true;
+  }, [tabId, revealSignal]);
+
+  useEffect(() => {
+    if (!pendingRevealBottomScroll.current || items.length === 0) return;
+    pendingRevealBottomScroll.current = false;
+    const frame = requestAnimationFrame(() => {
+      scrollToBottomAfterLayout(5);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [items.length, revealSignal, scrollToBottomAfterLayout, tabId]);
 
   // Auto-scroll to bottom during streaming. Coalesce fast token/reasoning
   // updates into one layout read/write per animation frame.
@@ -578,52 +593,66 @@ export function Transcript({
   // don't rebuild it. The hot zone uses LiveAssistantMessage (reads live from
   // LiveStreamContext) so streaming updates are captured immediately.
   return (
-    <div
-      className={`transcript${empty ? " transcript--empty" : ""}`}
-      ref={scrollRef}
-      onScroll={onScroll}
-    >
-      {empty && <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
+    <div className="transcript-shell">
+      <div
+        className={`transcript${empty ? " transcript--empty" : ""}`}
+        ref={scrollRef}
+        onScroll={onScroll}
+      >
+        {empty && <Welcome onPrompt={onPrompt} variant={welcomeVariant} />}
 
-      {!empty && showQuestionNav && (
-        <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
-      )}
-
-      <LiveStreamContext.Provider value={live}>
-        {turnGroups.length > HOT_TURNS && (
-          <WarmZone
-            turnGroups={turnGroups}
-            expandedWarmTurns={expandedWarmTurns}
-            shownWarmStart={shownWarmStart}
-            coldTurnCount={coldTurnCount}
-            scrollRef={scrollRef}
-            warmItems={items}
-            warmSubcalls={subcallsByParent}
-            warmUserTurn={userTurn}
-            warmCheckpoints={checkpointsByTurn}
-            warmOpenAction={openAction}
-            warmActionPending={actionPending}
-            warmRewindDisabled={rewindDisabled}
-            warmActionHoverMenus={actionHoverMenus}
-            warmOnRewind={onRewind}
-            warmSetOpenAction={setOpenAction}
-            warmOnEdit={onEditPrompt}
-            tabId={tabId}
-            creationMode={creationMode}
-            onToggleColdPage={() => setColdPage((p) => p + 1)}
-            onToggleWarmTurn={(g, expand) => {
-              setExpandedWarmTurns((prev) => {
-                const next = new Set(prev);
-                if (expand) next.add(g); else next.delete(g);
-                return next;
-              });
-            }}
-          />
+        {!empty && showQuestionNav && (
+          <QuestionJumpBar questions={questions} onJump={handleJumpToQuestion} />
         )}
-        <div ref={entranceRef}>
-          {hotZoneNodes}
-        </div>
-      </LiveStreamContext.Provider>
+
+        <LiveStreamContext.Provider value={live}>
+          {turnGroups.length > HOT_TURNS && (
+            <WarmZone
+              turnGroups={turnGroups}
+              expandedWarmTurns={expandedWarmTurns}
+              shownWarmStart={shownWarmStart}
+              coldTurnCount={coldTurnCount}
+              scrollRef={scrollRef}
+              warmItems={items}
+              warmSubcalls={subcallsByParent}
+              warmUserTurn={userTurn}
+              warmCheckpoints={checkpointsByTurn}
+              warmOpenAction={openAction}
+              warmActionPending={actionPending}
+              warmRewindDisabled={rewindDisabled}
+              warmActionHoverMenus={actionHoverMenus}
+              warmOnRewind={onRewind}
+              warmSetOpenAction={setOpenAction}
+              warmOnEdit={onEditPrompt}
+              tabId={tabId}
+              creationMode={creationMode}
+              onToggleColdPage={() => setColdPage((p) => p + 1)}
+              onToggleWarmTurn={(g, expand) => {
+                setExpandedWarmTurns((prev) => {
+                  const next = new Set(prev);
+                  if (expand) next.add(g); else next.delete(g);
+                  return next;
+                });
+              }}
+            />
+          )}
+          <div ref={entranceRef}>
+            {hotZoneNodes}
+          </div>
+        </LiveStreamContext.Provider>
+      </div>
+
+      {!empty && !isAtBottom && (
+        <button
+          type="button"
+          className="transcript__jump-bottom"
+          onClick={() => scrollToBottomAfterLayout(2)}
+          aria-label="Jump to bottom"
+          title="Jump to bottom"
+        >
+          <ArrowDown size={18} strokeWidth={2.2} aria-hidden="true" />
+        </button>
+      )}
     </div>
   );
 }

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1063,6 +1063,58 @@ function makeMockApp(): AppBindings {
     return Boolean(topic && topic.label === t("mock.newSession") && !topic.turns && !topic.lastActivityAt && !topic.status);
   };
   const mockTopicRunsInScenario = (topicId: string) => runningMock && mockTopicIsRunning(topicId);
+  const mockLongTranscriptHistory = (): HistoryMessage[] => {
+    const out: HistoryMessage[] = [];
+    for (let i = 1; i <= 18; i++) {
+      out.push({
+        role: "user",
+        content: `第 ${i} 轮：检查聊天滚动定位，切换会话后应该自动停在最新消息底部。`,
+      });
+      if (i === 4) {
+        out.push({ role: "phase", content: "复现切换会话后的滚动位置" });
+      }
+      if (i === 8) {
+        const toolID = "mock-scroll-layout-check";
+        out.push({
+          role: "assistant",
+          content: "我会先读取滚动容器尺寸，再确认是否存在动态高度变化导致的底部偏移。",
+          reasoning: "旧实现只重置 stick 标志，没有主动等待布局稳定；AskCard、Approval、Todo 这类卡片可能在下一帧改变高度。",
+          toolCalls: [{ id: toolID, name: "bash", arguments: JSON.stringify({ command: "npm run check:css && pnpm typecheck" }) }],
+        });
+        out.push({
+          role: "tool",
+          toolCallId: toolID,
+          toolName: "bash",
+          content: "CSS syntax check passed\nz-index token check passed\ntsc --noEmit passed\n",
+        });
+        continue;
+      }
+      if (i === 13) {
+        out.push({ role: "notice", level: "info", content: "模拟提示：用户向上查看历史后，右下角应出现跳到底部按钮。" });
+      }
+      out.push({
+        role: "assistant",
+        content: [
+          `第 ${i} 轮结果：当前滚动契约会在切换会话或 reveal 信号到达后执行强制贴底。`,
+          "它会先立即设置 scrollTop 到 scrollHeight，再连续几个 animation frame 复查，避免动态内容把底部再次推走。",
+          "如果用户主动向上滚动，普通 streaming 不会强行拉回；只有点击跳到底部按钮或显式切换会话才会重新贴底。",
+        ].join("\n\n"),
+      });
+    }
+    out.push({
+      role: "compaction",
+      content: "",
+      trigger: "manual",
+      messages: 36,
+      summary: "Mock 长会话用于验证桌面端 Transcript 自动贴底、多帧布局修正和跳到底部按钮。",
+      archive: "mock-scroll-preview",
+    });
+    out.push({
+      role: "assistant",
+      content: "最终状态：这条消息应该位于真实底部。向上滚动后，右下角会显示跳到底部按钮；点击按钮后应回到这里。",
+    });
+    return out;
+  };
   const mockTopicHistory = (topicId: string): HistoryMessage[] => {
     switch (topicId) {
       case "topic_product":
@@ -1104,24 +1156,7 @@ function makeMockApp(): AppBindings {
           },
         ];
       case "topic_dev_standard":
-        return [
-          {
-            role: "user",
-            content: [
-              "[[reasonix-im]]",
-              "provider=lark",
-              "label=Feishu / Lark",
-              "sender=ou_mock_user_001",
-              "chat=p2p 会话",
-              "[[/reasonix-im]]",
-              "你可以做什么",
-            ].join("\n"),
-          },
-          {
-            role: "assistant",
-            content: "我可以在桌面端帮你处理代码编写、文件操作、项目分析和问题定位。来自 IM 的请求会进入同一条聊天时间线，桌面端继续承载模型调用、工具执行和上下文管理。",
-          },
-        ];
+        return mockLongTranscriptHistory();
       case "topic_p3b_pd":
         return [
           { role: "user", content: "把 p3b P&D 的范围和风险重新整理成可执行计划。" },

--- a/desktop/frontend/src/lib/useScrollManager.ts
+++ b/desktop/frontend/src/lib/useScrollManager.ts
@@ -1,6 +1,12 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import gsap from "gsap";
 import { DUR_FAST, EASE_OUT, prefersReducedMotion } from "./gsapAnimations";
+
+const BOTTOM_THRESHOLD_PX = 80;
+
+function isNearBottom(el: HTMLElement): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < BOTTOM_THRESHOLD_PX;
+}
 
 /**
  * useScrollManager — GSAP-driven auto-scroll for the transcript container.
@@ -16,29 +22,39 @@ export function useScrollManager() {
   const gsapCtx = useRef<gsap.Context | null>(null);
   const prevQuestionsLen = useRef(0);
   const resizeFrame = useRef<number | null>(null);
+  const layoutScrollFrames = useRef<number[]>([]);
   const lastClientHeight = useRef<number | null>(null);
   const lastFooterHeight = useRef<number | null>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
 
   // Kill any lingering tweens on unmount.
   useEffect(() => {
     return () => {
       gsapCtx.current?.revert();
       if (resizeFrame.current !== null) cancelAnimationFrame(resizeFrame.current);
+      for (const frame of layoutScrollFrames.current) cancelAnimationFrame(frame);
+      layoutScrollFrames.current = [];
     };
+  }, []);
+
+  const updateBottomState = useCallback((el: HTMLElement) => {
+    const atBottom = isNearBottom(el);
+    stick.current = atBottom;
+    setIsAtBottom(atBottom);
+    return atBottom;
   }, []);
 
   const onScroll = useCallback(() => {
     const el = scrollRef.current;
-    if (el) {
-      stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
-    }
-  }, []);
+    if (el) updateBottomState(el);
+  }, [updateBottomState]);
 
   /** Scroll smoothly to a specific element.  Used by the JumpBar. */
   const smoothScrollTo = useCallback((element: HTMLElement, offset = 12) => {
     const el = scrollRef.current;
     if (!el) return;
     stick.current = false;
+    setIsAtBottom(false);
     if (resizeFrame.current !== null) {
       cancelAnimationFrame(resizeFrame.current);
       resizeFrame.current = null;
@@ -51,8 +67,9 @@ export function useScrollManager() {
       scrollTo: { y: Math.max(0, top) },
       duration: reduced ? 0.001 : DUR_FAST * 2,
       ease: EASE_OUT,
+      onComplete: () => updateBottomState(el),
     });
-  }, []);
+  }, [updateBottomState]);
 
   /** Force-scroll to the bottom — used when a new question is sent. */
   const scrollToBottom = useCallback((force = false) => {
@@ -60,24 +77,64 @@ export function useScrollManager() {
     if (!el) return;
     if (force) {
       stick.current = true;
+      setIsAtBottom(true);
     }
-    if (!stick.current) return;
+    if (!stick.current && !force) return;
     if (resizeFrame.current !== null) {
       cancelAnimationFrame(resizeFrame.current);
       resizeFrame.current = null;
     }
     resizeFrame.current = requestAnimationFrame(() => {
       resizeFrame.current = null;
-      if (!stick.current) return;
+      if (!stick.current && !force) return;
+      if (force) {
+        stick.current = true;
+        setIsAtBottom(true);
+      }
       const reduced = prefersReducedMotion();
       gsap.to(el, {
         scrollTo: { y: "max" },
         duration: reduced ? 0.001 : DUR_FAST,
         ease: "none",
         overwrite: "auto",
+        onComplete: () => {
+          stick.current = true;
+          setIsAtBottom(true);
+        },
       });
     });
   }, []);
+
+  const snapToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (resizeFrame.current !== null) {
+      cancelAnimationFrame(resizeFrame.current);
+      resizeFrame.current = null;
+    }
+    gsap.killTweensOf(el);
+    stick.current = true;
+    el.scrollTop = el.scrollHeight;
+    setIsAtBottom(true);
+  }, []);
+
+  const scrollToBottomAfterLayout = useCallback((frames = 4) => {
+    for (const frame of layoutScrollFrames.current) cancelAnimationFrame(frame);
+    layoutScrollFrames.current = [];
+    snapToBottom();
+    let remaining = Math.max(0, frames);
+    const tick = () => {
+      if (remaining <= 0) return;
+      const frame = requestAnimationFrame(() => {
+        layoutScrollFrames.current = layoutScrollFrames.current.filter((id) => id !== frame);
+        snapToBottom();
+        remaining -= 1;
+        tick();
+      });
+      layoutScrollFrames.current.push(frame);
+    };
+    tick();
+  }, [snapToBottom]);
 
   /** Call when a new question is submitted — overrides stick state. */
   const onNewQuestion = useCallback(() => {
@@ -93,8 +150,9 @@ export function useScrollManager() {
       const el = scrollRef.current;
       if (!el) return;
       const bottomDistance = el.scrollHeight - el.scrollTop - el.clientHeight;
-      if (!stick.current && bottomDistance + containerHeightDelta >= 80) return;
+      if (!stick.current && bottomDistance + containerHeightDelta >= BOTTOM_THRESHOLD_PX) return;
       stick.current = true;
+      setIsAtBottom(true);
       scrollToBottom();
     },
     [scrollToBottom],
@@ -118,8 +176,10 @@ export function useScrollManager() {
     scrollRef,
     stick,
     onScroll,
+    isAtBottom,
     smoothScrollTo,
     scrollToBottom,
+    scrollToBottomAfterLayout,
     onNewQuestion,
     repinIfWasPinned,
     trackQuestions,

--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -3069,10 +3069,57 @@ a[href] {
   scrollbar-width: thin;
   scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
+.transcript-shell {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
 .transcript > * {
   max-width: var(--maxw);
   margin-left: auto;
   margin-right: auto;
+}
+.transcript__jump-bottom {
+  --wails-draggable: no-drag;
+  position: absolute;
+  left: 50%;
+  bottom: 34px;
+  z-index: var(--z-inline-sticky);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--border));
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--bg-elev) 92%, var(--accent-soft));
+  color: var(--fg);
+  box-shadow: var(--shadow-2);
+  cursor: pointer;
+  pointer-events: auto;
+  transform: translateX(-50%);
+  transition:
+    transform 0.12s ease,
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease,
+    box-shadow 0.12s ease,
+    opacity 0.12s ease;
+}
+.transcript__jump-bottom:hover {
+  transform: translate(-50%, -1px);
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+  background: color-mix(in srgb, var(--bg-elev-2) 88%, var(--accent-soft));
+  color: var(--accent);
+  box-shadow: 0 12px 30px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+.transcript__jump-bottom:focus-visible {
+  outline: none;
+  box-shadow:
+    var(--focus-ring),
+    var(--shadow-2);
 }
 .transcript--empty {
   container-type: size;

--- a/internal/cli/chat_tui.go
+++ b/internal/cli/chat_tui.go
@@ -689,10 +689,13 @@ func (m chatTUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		wrapped := wrapTranscript(strings.Join(cm.transcript, "\n"), contentW)
 		cm.viewport.SetContent(wrapped)
 		cm.wrappedLines = strings.Split(wrapped, "\n")
-		if wasAtBottom || cm.forceGotoBottom {
+		if wasAtBottom {
 			cm.viewport.GotoBottom() // tail-follow: stay pinned to newest output
-			cm.forceGotoBottom = false
 		}
+	}
+	if cm.forceGotoBottom {
+		cm.viewport.GotoBottom()
+		cm.forceGotoBottom = false
 	}
 	cm.transcriptDirty = false
 	// Any viewport scroll (wheel, PgUp/PgDn, edge auto-scroll, or tail-follow to

--- a/internal/cli/chat_tui_test.go
+++ b/internal/cli/chat_tui_test.go
@@ -1507,6 +1507,42 @@ func TestEmptyEnterScrollsToBottom(t *testing.T) {
 	})
 }
 
+// TestForceGotoBottomScrollsWithoutTranscriptChange keeps the force-bottom
+// contract independent from transcript length, width, or dirty-state changes.
+func TestForceGotoBottomScrollsWithoutTranscriptChange(t *testing.T) {
+	ctrl := control.New(control.Options{})
+	ch := make(chan event.Event, 1)
+	notice := agentEventMsg(event.Event{Kind: event.Notice, Level: event.LevelInfo, Text: "line"})
+	adv := func(m chatTUI, msg tea.Msg) chatTUI {
+		n, _ := m.Update(msg)
+		return n.(chatTUI)
+	}
+
+	cur := adv(newChatTUI(ctrl, "", ch, 80), tea.WindowSizeMsg{Width: 80, Height: 8})
+	for i := 0; i < 12; i++ {
+		cur = adv(cur, notice)
+	}
+	if !cur.viewport.AtBottom() {
+		t.Fatal("new output while pinned should keep the viewport at the bottom")
+	}
+
+	cur = adv(cur, tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	if cur.viewport.AtBottom() {
+		t.Fatal("wheel-up should break the bottom pin")
+	}
+
+	cur.forceGotoBottom = true
+	cur.transcriptDirty = false
+	cur = adv(cur, tea.WindowSizeMsg{Width: 80, Height: 8})
+
+	if !cur.viewport.AtBottom() {
+		t.Fatalf("forceGotoBottom should scroll without transcript changes, YOffset=%d", cur.viewport.YOffset())
+	}
+	if cur.forceGotoBottom {
+		t.Fatal("forceGotoBottom should be cleared after scrolling")
+	}
+}
+
 func TestFoldedPasteUsesPlaceholderAndExpandsOnSend(t *testing.T) {
 	m := newTestChatTUI()
 	pasted := "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3,\n  \"d\": 4\n}"


### PR DESCRIPTION
## Summary

- Keep the desktop transcript pinned to the latest message when a tab/topic/session is revealed, including project tree, history, and IM session entry points.
- Add a centered desktop jump-to-bottom button that appears only when the user has scrolled away from the tail.
- Make the desktop bottom snap resilient to late layout changes by retrying across animation frames.
- Make CLI/TUI `forceGotoBottom` independent from transcript length, width, or dirty-state changes.
- Add a browser-dev long transcript fixture for manual scroll regression checks.

## Related

- Addresses #4397, #4468, #4797, #4948, #4015.
- Covers the scroll-related part of #4847 item 3; #4847 remains open for its unrelated workspace and bot-session items.
- Supersedes #5009 and #4923.

## Contributor credit

- @JesonChou provided the merged groundwork in #4602: clearing replayed CLI transcripts, introducing `forceGotoBottom`, and resetting desktop stick state on tab switches.
- @tonystarknb contributed the desktop UX and implementation direction in #5009: `isAtBottom`, layout-aware bottom snapping, transcript shell overlay, and jump-to-bottom button.
- @liaoyl830 contributed the TUI edge-case fix in #4923: ensuring `forceGotoBottom` scrolls even when transcript length and width do not change.

This PR consolidates those contributions and adds reveal-signal coverage for project tree, history, and IM entry points, a centered jump-to-bottom button, a browser-dev long transcript fixture, and final integrated verification.

## Cache / provider safety

No provider request serialization, prompt prefix, tool schema, compaction, or model-cache-sensitive surface is changed.

## Verification

- `go test ./internal/cli -count=1`
- `pnpm --dir desktop/frontend check:css`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/transcript-grouping.test.ts`
- `pnpm --dir desktop/frontend exec tsx src/__tests__/render-optimization.test.ts`
- Browser preview with the dev mock: verified initial reveal lands at the transcript tail, scrolling up shows the centered jump-to-bottom button, and clicking it returns to bottom.
