### PR TITLE
feat: AI 回复中的文件路径可点击并直接在右侧面板打开预览

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -959,6 +959,8 @@ export default function App() {
   const appRef = useRef<HTMLDivElement>(null);
   const sidebarTogglePressTimerRef = useRef<number | null>(null);
   const workspaceTogglePressTimerRef = useRef<number | null>(null);
+  const fileLinkRevealIdRef = useRef(0);
+  const [fileLinkReveal, setFileLinkReveal] = useState<{ id: number; path: string } | null>(null);
 
   // Persist window geometry across launches.
   useWindowStatePersistence();
@@ -966,6 +968,12 @@ export default function App() {
   useEffect(() => {
     document.documentElement.setAttribute("data-platform", desktopPlatform);
   }, [desktopPlatform]);
+
+  // Clear stale file reveal requests when the active tab changes, so an
+  // old reveal from a different tab doesn't re-trigger in the new context.
+  useEffect(() => {
+    setFileLinkReveal(null);
+  }, [activeTabId]);
 
   const closeTransientOverlays = useCallback(() => {
     setTransientOverlayDismissSignal((signal) => signal + 1);
@@ -1912,6 +1920,12 @@ export default function App() {
       closeWorkspacePanel();
     }
   }, [closeWorkspacePanel, openWorkspacePanel]);
+
+  const handleFileLinkClick = useCallback((path: string) => {
+    fileLinkRevealIdRef.current += 1;
+    setFileLinkReveal({ id: fileLinkRevealIdRef.current, path });
+    openWorkspacePanel("files");
+  }, [openWorkspacePanel]);
 
   const addWorkspaceTextToComposer = useCallback((text: string) => {
     setComposerInsertRequest({ id: Date.now(), text });
@@ -2996,6 +3010,7 @@ export default function App() {
                 creationMode={sidebarCreation}
                 actionHoverMenus={sidebarCreation}
                 rewindSignal={rewindSignal}
+                onFileLinkClick={handleFileLinkClick}
               />
             )}
           </main>
@@ -3209,6 +3224,7 @@ export default function App() {
                   refreshKey={dockRefreshKey}
                   initialViewMode={rightDockMode === "changed" ? "changed" : "files"}
                   showViewTabs={false}
+                  revealPathRequest={fileLinkReveal}
                 />
               )}
             </div>

--- a/desktop/frontend/src/components/Markdown.tsx
+++ b/desktop/frontend/src/components/Markdown.tsx
@@ -5,13 +5,15 @@ const MarkdownRenderer = lazy(() => import("./MarkdownRenderer"));
 export const Markdown = memo(function Markdown({
   text,
   plainStatusBlocks = false,
+  onFileLinkClick,
 }: {
   text: string;
   plainStatusBlocks?: boolean;
+  onFileLinkClick?: (path: string) => void;
 }) {
   return (
     <Suspense fallback={<div className="md">{text}</div>}>
-      <MarkdownRenderer text={text} plainStatusBlocks={plainStatusBlocks} />
+      <MarkdownRenderer text={text} plainStatusBlocks={plainStatusBlocks} onFileLinkClick={onFileLinkClick} />
     </Suspense>
   );
 });

--- a/desktop/frontend/src/components/MarkdownRenderer.tsx
+++ b/desktop/frontend/src/components/MarkdownRenderer.tsx
@@ -18,11 +18,27 @@ import { openExternal } from "../lib/bridge";
 // delimiters to the $/$$ syntax remark-math understands, gates single-$
 // pairs through a classifier to avoid false positives on $5, $PATH, etc.,
 // and runs KaTeX-specific normalisations (text-mode escapes, |→\vert).
+//
+// When onFileLinkClick is provided, bare file paths in the text (relative
+// paths with common extensions such as src/foo.tsx, docs/sop/README.md) are
+// detected and rendered as clickable links. Clicking them calls
+// onFileLinkClick(path) instead of opening in the system browser.
 
 const STATUS_MARKER_RE = /(?:✅|☑|☒|✔️?|✓|\[[xX ]\])/;
 const STATUS_MARKER_GLOBAL_RE = /(?:✅|☑|☒|✔️?|✓|\[[xX ]\])/g;
 const BULLET_RE = /^[-*•]\s+\S/;
 const DIVIDER_RE = /^[\s\-_=─━—]+$/;
+
+// Matches relative file paths, absolute file paths, and bare filenames with
+// common extensions — used to detect bare file references in text and make them
+// clickable. Three forms are supported:
+//   - Relative:  src/foo.tsx, ./src/foo.tsx, ../config.yml
+//   - Absolute:  /Users/me/project/REASONIX.md
+//   - Bare name: README.md, go.mod (when no directory separator is present)
+// All must end with a known source/doc extension and must not be preceded
+// by a word character or `/` (to avoid matching inside URLs like
+// https://github.com/org/repo/blob/main/README.md).
+const FILE_PATH_RE = /(?<!\w)(?<!\/)(?<!\.)(?<!@)(?:\/[\w\p{L}.-]+(?:\/[\w\p{L}.\/-]+)*|[\w\p{L}.-]+\/[\w\p{L}.\/-]+|[\w\p{L}.-]+)\.(?:md|tsx?|json|jsx?|go|css|ya?ml|toml|sh|py|rs|mod|sum|s?css|less|html|svelte|vue)/giu;
 
 function splitStatusLine(line: string): string[] {
   const parts = (line.match(STATUS_MARKER_GLOBAL_RE) ?? []).length > 1
@@ -85,7 +101,7 @@ function PlainMarkdownBlock({ text }: { text: string }) {
   );
 }
 
-function createComponents(plainStatusBlocks: boolean): Components {
+function createComponents(plainStatusBlocks: boolean, onFileLinkClick?: (path: string) => void): Components {
   return {
     pre: ({ children }) => <>{children}</>,
     code: ({ className, children }) => {
@@ -98,37 +114,99 @@ function createComponents(plainStatusBlocks: boolean): Components {
       }
       return <code className="md-code">{children}</code>;
     },
-    a: ({ href, children }) => (
-      <a
-        href={href}
-        onClick={(e) => {
-          e.preventDefault();
-          if (href) openExternal(href);
-        }}
-        onAuxClick={(e) => {
-          e.preventDefault();
-          if (href) openExternal(href);
-        }}
-        onMouseDown={(e) => {
-          if (e.button === 1) e.preventDefault();
-        }}
-      >
-        {children}
-      </a>
-    ),
+    a: ({ href, children }) => {
+      const isFileLink = href != null && !/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href);
+      return (
+        <a
+          href={href}
+          onClick={(e) => {
+            e.preventDefault();
+            if (href) {
+              if (isFileLink && onFileLinkClick) {
+                onFileLinkClick(href);
+              } else {
+                openExternal(href);
+              }
+            }
+          }}
+          onAuxClick={(e) => {
+            e.preventDefault();
+            if (href) {
+              if (isFileLink && onFileLinkClick) {
+                onFileLinkClick(href);
+              } else {
+                openExternal(href);
+              }
+            }
+          }}
+          onMouseDown={(e) => {
+            if (e.button === 1) e.preventDefault();
+          }}
+        >
+          {children}
+        </a>
+      );
+    },
   };
+}
+
+/**
+ * Detects bare file paths in text and wraps them as markdown links so
+ * react-markdown renders them as clickable anchors. Skips content inside
+ * fenced code blocks and inline code to avoid false positives.
+ */
+function linkifyFilePaths(text: string): string {
+  // Protect fenced code blocks and inline code spans first
+  const fences: string[] = [];
+  let idx = 0;
+  const protectedText = text
+    // Save fenced code blocks (```...``` or ~~~...~~~)
+    .replace(/(```[\s\S]*?```|~~~[\s\S]*?~~~)/g, (_m) => {
+      const placeholder = `\x00CODEBLOCK${idx}\x00`;
+      fences[idx++] = _m;
+      return placeholder;
+    })
+    // Save unclosed fenced code blocks (streaming: closing fence not yet present)
+    .replace(/(```[\s\S]*$)/g, (_m) => {
+      const placeholder = `\x00CODEBLOCK${idx}\x00`;
+      fences[idx++] = _m;
+      return placeholder;
+    })
+    // Save inline code spans
+    .replace(/(`[^`]*`)/g, (_m) => {
+      const placeholder = `\x00CODEBLOCK${idx}\x00`;
+      fences[idx++] = _m;
+      return placeholder;
+    })
+    // Save existing markdown links [text](url)
+    .replace(/\[([^\]]*)\]\(([^)]*)\)/g, (_m) => {
+      const placeholder = `\x00CODEBLOCK${idx}\x00`;
+      fences[idx++] = _m;
+      return placeholder;
+    });
+
+  // Linkify bare file paths in unprotected text
+  const linkified = protectedText.replace(FILE_PATH_RE, (full) => {
+    return `[${full}](${full})`;
+  });
+
+  // Restore protected blocks
+  return linkified.replace(/\x00CODEBLOCK(\d+)\x00/g, (_m, id) => fences[Number(id)] ?? _m);
 }
 
 const MarkdownRenderer = memo(function MarkdownRenderer({
   text,
   plainStatusBlocks = false,
+  onFileLinkClick,
 }: {
   text: string;
   plainStatusBlocks?: boolean;
+  onFileLinkClick?: (path: string) => void;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const mathContent = useMemo(() => normalizeMath(text), [text]);
-  const components = useMemo(() => createComponents(plainStatusBlocks), [plainStatusBlocks]);
+  const linkifiedText = useMemo(() => (onFileLinkClick ? linkifyFilePaths(text) : text), [text, onFileLinkClick]);
+  const mathContent = useMemo(() => normalizeMath(linkifiedText), [linkifiedText]);
+  const components = useMemo(() => createComponents(plainStatusBlocks, onFileLinkClick), [plainStatusBlocks, onFileLinkClick]);
   return (
     <div className="md" ref={containerRef}>
       <ReactMarkdown

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -544,6 +544,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   expandWhileStreaming = true,
   truncateStreamingReasoning = false,
   creationMode = false,
+  onFileLinkClick,
 }: {
   item: AssistantItem;
   defaultExpanded?: boolean;
@@ -552,6 +553,7 @@ export const AssistantMessage = memo(function AssistantMessage({
   /** Opt-in for compact mode to keep live DeepSeek reasoning from growing an unbounded DOM. */
   truncateStreamingReasoning?: boolean;
   creationMode?: boolean;
+  onFileLinkClick?: (path: string) => void;
 }) {
   const t = useT();
   const reasoningBodyRef = useRef<HTMLDivElement>(null);
@@ -630,7 +632,7 @@ export const AssistantMessage = memo(function AssistantMessage({
       )}
       {hasText && (
         <div className="msg__body">
-          <Markdown text={item.text} plainStatusBlocks={creationMode} />
+          <Markdown text={item.text} plainStatusBlocks={creationMode} onFileLinkClick={onFileLinkClick} />
         </div>
       )}
     </div>

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -29,12 +29,14 @@ const LiveAssistantMessage = memo(function LiveAssistantMessage({
   expandWhileStreaming = true,
   truncateStreamingReasoning = false,
   creationMode = false,
+  onFileLinkClick,
 }: {
   item: AssistantItem;
   defaultExpanded?: boolean;
   expandWhileStreaming?: boolean;
   truncateStreamingReasoning?: boolean;
   creationMode?: boolean;
+  onFileLinkClick?: (path: string) => void;
 }) {
   const live = useContext(LiveStreamContext);
   const shown = useMemo(
@@ -51,6 +53,7 @@ const LiveAssistantMessage = memo(function LiveAssistantMessage({
       expandWhileStreaming={expandWhileStreaming}
       truncateStreamingReasoning={truncateStreamingReasoning}
       creationMode={creationMode}
+      onFileLinkClick={onFileLinkClick}
     />
   );
 });
@@ -93,6 +96,7 @@ export function Transcript({
   creationMode = false,
   actionHoverMenus = false,
   rewindSignal = 0,
+  onFileLinkClick,
 }: {
   items: Item[];
   live?: LiveStream;
@@ -110,6 +114,7 @@ export function Transcript({
   creationMode?: boolean;
   actionHoverMenus?: boolean;
   rewindSignal?: number;
+  onFileLinkClick?: (path: string) => void;
 }) {
   const {
     scrollRef,
@@ -396,6 +401,7 @@ export function Transcript({
             subcalls={subcallsByParent}
             tabId={tabId}
             creationMode={creationMode}
+            onFileLinkClick={onFileLinkClick}
           />,
         );
         collapseBatch = [];
@@ -452,6 +458,7 @@ export function Transcript({
               subcalls={subcallsByParent}
               tabId={tabId}
               creationMode={creationMode}
+              onFileLinkClick={onFileLinkClick}
             />,
           );
         } else if (nonAssistantItems.length > 0) {
@@ -475,6 +482,7 @@ export function Transcript({
               expandWhileStreaming={false}
               truncateStreamingReasoning={true}
               creationMode={creationMode}
+              onFileLinkClick={onFileLinkClick}
             />,
           );
           if (!it.streaming && it.text.trim() !== "") {
@@ -549,7 +557,7 @@ export function Transcript({
             break;
           }
           case "assistant":
-            out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={false} creationMode={creationMode} />);
+            out.push(<LiveAssistantMessage key={it.id} item={it as AssistantItem} defaultExpanded={false} creationMode={creationMode} onFileLinkClick={onFileLinkClick} />);
             if (!it.streaming && it.text.trim() !== "") {
               actionText = it.text;
               actionReady = true;
@@ -571,7 +579,7 @@ export function Transcript({
       if (!running) pushTurnActions();
     }
     return out;
-  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, running, onEditPrompt, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, tabId, actionHoverMenus, creationMode]);
+  }, [hotStartIdx, items, openAction, actionPending, rewindDisabled, running, onEditPrompt, onRewind, subcallsByParent, userTurn, checkpointsByTurn, displayMode, stepGroups, tabId, actionHoverMenus, creationMode, onFileLinkClick]);
 
   // ── Assemble rendered output ──────────────────────────────────────────────
   // Warm/cold zone is a separate memo'd WarmZone component so streaming tokens
@@ -610,6 +618,7 @@ export function Transcript({
             warmOnEdit={onEditPrompt}
             tabId={tabId}
             creationMode={creationMode}
+            onFileLinkClick={onFileLinkClick}
             onToggleColdPage={() => setColdPage((p) => p + 1)}
             onToggleWarmTurn={(g, expand) => {
               setExpandedWarmTurns((prev) => {
@@ -653,6 +662,7 @@ const WarmZone = memo(function WarmZone({
   creationMode,
   onToggleColdPage,
   onToggleWarmTurn,
+  onFileLinkClick,
 }: {
   turnGroups: TurnGroup[];
   expandedWarmTurns: ReadonlySet<number>;
@@ -674,6 +684,7 @@ const WarmZone = memo(function WarmZone({
   creationMode?: boolean;
   onToggleColdPage: () => void;
   onToggleWarmTurn: (g: number, expand: boolean) => void;
+  onFileLinkClick?: (path: string) => void;
 }) {
   const t = useT();
   const out: React.ReactNode[] = [];
@@ -730,6 +741,7 @@ const WarmZone = memo(function WarmZone({
               onEdit={warmOnEdit}
               tabId={tabId}
               creationMode={creationMode}
+              onFileLinkClick={onFileLinkClick}
             />
           </WarmTurnCard>,
         );
@@ -777,6 +789,7 @@ function WarmTurnItems({
   onEdit,
   tabId,
   creationMode = false,
+  onFileLinkClick,
 }: {
   startIdx: number;
   endIdx: number;
@@ -793,6 +806,7 @@ function WarmTurnItems({
   onEdit?: (turn: number, displayText: string, submitText?: string) => boolean | void | Promise<boolean | void>;
   tabId?: string;
   creationMode?: boolean;
+  onFileLinkClick?: (path: string) => void;
 }) {
   const nodes: React.ReactNode[] = [];
   let actionText = "";
@@ -881,7 +895,7 @@ function WarmTurnItems({
         break;
       }
       case "assistant": {
-        nodes.push(<AssistantMessage key={it.id} item={it} defaultExpanded={false} creationMode={creationMode} />);
+        nodes.push(<AssistantMessage key={it.id} item={it} defaultExpanded={false} creationMode={creationMode} onFileLinkClick={onFileLinkClick} />);
         if (!it.streaming && it.text.trim() !== "") {
           actionText = it.text;
           actionReady = true;
@@ -973,9 +987,10 @@ type TurnCollapseProps = {
   subcalls: Map<string, ToolItem[]>;
   tabId?: string;
   creationMode?: boolean;
+  onFileLinkClick?: (path: string) => void;
 };
 
-function TurnCollapse({ items, durationMs, mode, subcalls, tabId, creationMode = false }: TurnCollapseProps) {
+function TurnCollapse({ items, durationMs, mode, subcalls, tabId, creationMode = false, onFileLinkClick }: TurnCollapseProps) {
   const t = useT();
   const [open, setOpen] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
@@ -1054,7 +1069,7 @@ function TurnCollapse({ items, durationMs, mode, subcalls, tabId, creationMode =
       case "phase": body.push(<PhaseCard key={it.id} text={it.text} />); break;
       case "assistant": {
         const displayItem = it;
-        body.push(<AssistantMessage key={it.id} item={displayItem as AssistantItem} creationMode={creationMode} />);
+        body.push(<AssistantMessage key={it.id} item={displayItem as AssistantItem} creationMode={creationMode} onFileLinkClick={onFileLinkClick} />);
         break;
       }
     }


### PR DESCRIPTION
## 功能描述

AI 回复中提到的文件路径（如 `src/components/Foo.tsx`、`docs/sop/README.md`）现在是纯文本，无法直接导航。本 PR 实现：

1. **自动检测文件路径**：在 Markdown 文本中识别相对文件路径（含 `/` + 常见扩展名），自动转为可点击链接
2. **点击打开预览**：点击文件路径时，自动打开 Workspace 面板的文件视图并预览该文件
3. **保护代码块和已有链接**：不会误处理代码块内或已有 Markdown 链接中的文本

## 实现细节

- `MarkdownRenderer.tsx`：添加 `FILE_PATH_RE` 正则检测文件路径，`linkifyFilePaths()` 预处理（跳过代码块/已有链接），`onFileLinkClick` 回调
- `Markdown` → `AssistantMessage` → `Transcript` → `App.tsx`：逐层透传 `onFileLinkClick` 回调
- `App.tsx`：`handleFileLinkClick` 打开文件面板 + 通过 `revealPathRequest` 发送文件路径到 `WorkspacePanel`
- `WorkspacePanel`：已有的 `revealPathRequest` 机制自动处理文件预览

## Codex 审查修复

| 问题 | 修复 |
|---|---|
| P2: FILE_PATH_RE 误匹配 `//github.com/...` | 添加 `(?<!\/)` 防止在 `/` 后匹配 |
| P2: hotZoneNodes useMemo 缺少 onFileLinkClick deps | 添加到依赖数组 |
| P2: isFileLink 误判 `mailto:` 为文件路径 | 改为匹配任意 `scheme:` 格式（不只是 `://`） |
| P2: 流式传输时未闭合代码块被误处理 | 添加未闭合 fence 保护 `(```[\s\S]*$)` |
| P2: tab 切换时 stale fileLinkReveal 残留 | 添加 useEffect 在 `activeTabId` 变化时清除 |

## 改动统计

5 files changed, 135 insertions(+), 28 deletions(-)

---

Cache-impact: low — only Markdown rendering path
Cache-guard: n/a — no guard needed, rendering-only change