### PR TITLE
Use Reasonix global .env for provider keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,7 @@ make cross      # -> dist/ (darwin|linux|windows × amd64|arm64)
 ## Quick start
 
 ```sh
-reasonix setup                      # config wizard → ./reasonix.toml
-export DEEPSEEK_API_KEY=sk-...      # or let setup save it to the credential store
+reasonix setup                      # config wizard; saves API keys to Reasonix home .env
 reasonix                            # then run /init to generate AGENTS.md (project memory)
 reasonix run "implement the TODOs in main.go"
 reasonix run --model deepseek-pro "add unit tests for this function"
@@ -116,10 +115,10 @@ Resolution order is **flag > `./reasonix.toml` > the user config file >
 built-in defaults**; starting with **Reasonix v1.8.1**, the user file lives at
 `~/.reasonix/config.toml` on macOS/Linux and
 `%AppData%\reasonix\config.toml` on Windows. See
-**[Configuration paths](./docs/CONFIG_PATHS.md)** for migration details. Secrets come from the environment via `api_key_env`, are
-never written to config files, and new keys default to the OS credential store
-with a Reasonix-owned file fallback. Project `.env` files are read as a
-compatibility override, but Reasonix does not write new keys there. Permissions, the sandbox, plugins (MCP), slash
+**[Configuration paths](./docs/CONFIG_PATHS.md)** for migration details. Secrets are referenced by `api_key_env`, are
+never written to config files, and are loaded from the single global
+`<Reasonix home>/.env` file that setup/settings maintain. Project `.env`, home
+`.env`, and inherited environment variables do not override saved provider keys. Permissions, the sandbox, plugins (MCP), slash
 commands, `@` references, and two-model setup are all in the
 **[Guide](./docs/GUIDE.md)**.
 

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -107,6 +107,16 @@ func isolateDesktopUserDirs(t *testing.T) string {
 	return home
 }
 
+func setDesktopTestCredential(t *testing.T, key, value string) {
+	t.Helper()
+	if _, err := config.SetCredential(key, value); err != nil {
+		t.Fatalf("SetCredential(%s): %v", key, err)
+	}
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("Unsetenv(%s): %v", key, err)
+	}
+}
+
 func providerNamesFromView(providers []ProviderView) []string {
 	out := make([]string, 0, len(providers))
 	for _, p := range providers {
@@ -707,11 +717,11 @@ func TestSettingsLoadsActiveWorkspaceCredentialsWithUserConfig(t *testing.T) {
 	got := app.Settings()
 	for _, p := range got.Providers {
 		if p.Name == "workspace-provider" {
-			if !p.KeySet {
-				t.Fatalf("workspace provider keySet = false, want true from active workspace .env: %+v", p)
+			if p.KeySet {
+				t.Fatalf("workspace provider keySet = true, want false because workspace .env is ignored: %+v", p)
 			}
-			if !p.Configured {
-				t.Fatalf("workspace provider configured = false, want true from active workspace .env: %+v", p)
+			if p.Configured {
+				t.Fatalf("workspace provider configured = true, want false because workspace .env is ignored: %+v", p)
 			}
 			return
 		}
@@ -759,8 +769,8 @@ func TestSettingsShowsGlobalCredentialWithoutMutatingWorkspaceEnv(t *testing.T) 
 		if p.Name != "settings-provider" {
 			continue
 		}
-		if !p.KeySet || p.KeySource != "Reasonix credentials" {
-			t.Fatalf("settings-provider key = set:%v source:%q, want Reasonix credentials: %+v", p.KeySet, p.KeySource, p)
+		if !p.KeySet || p.KeySource != "Reasonix credentials (.env)" {
+			t.Fatalf("settings-provider key = set:%v source:%q, want Reasonix credentials (.env): %+v", p.KeySet, p.KeySource, p)
 		}
 		if env := os.Getenv("SHARED_SETTINGS_KEY"); env != "from-project" {
 			t.Fatalf("Settings mutated SHARED_SETTINGS_KEY = %q, want existing project env", env)
@@ -823,7 +833,7 @@ status_bar_items = ["model", "cache", "balance"]
 
 func TestSettingsSubagentDefaultsRoundTrip(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
@@ -875,7 +885,7 @@ func TestSettingsSurfacesOfficialProviderTemplatesSeparately(t *testing.T) {
 
 func TestSettingsRepairsLegacyOfficialProviderWithoutModel(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
@@ -912,7 +922,7 @@ api_key_env = "DEEPSEEK_API_KEY"
 
 func TestSettingsTreatsReservedProviderNameWithExternalEndpointAsCustom(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
@@ -959,8 +969,8 @@ api_key_env = "DEEPSEEK_API_KEY"
 
 func TestSettingsInfersLegacyProviderAccessWhenMissing(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
-	t.Setenv("MIMO_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "MIMO_API_KEY", "sk-test")
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
@@ -1003,7 +1013,7 @@ api_key_env = "MIMO_API_KEY"
 
 func TestSettingsDoesNotInferProviderAccessWhenExplicitlyEmpty(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}
@@ -1034,8 +1044,8 @@ api_key_env = "DEEPSEEK_API_KEY"
 
 func TestSettingsInfersConfiguredBuiltInsWithoutConfigFile(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
-	t.Setenv("MIMO_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "MIMO_API_KEY", "sk-test")
 
 	got := NewApp().Settings()
 	providers := map[string]ProviderView{}
@@ -1270,8 +1280,8 @@ api_key_env = "MIMO_API_KEY"
 
 func TestModelsForTabOnlyListsProviderAccessWhenConfigured(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
-	t.Setenv("MIMO_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "MIMO_API_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "deepseek-flash/deepseek-v4-flash"
@@ -1407,7 +1417,7 @@ api_key_env = "LOCAL_API_KEY"
 
 func TestModelsForTabListsMimoAPIPaidAccess(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("MIMO_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "MIMO_API_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "mimo-api/mimo-v2.5-pro"
@@ -1434,8 +1444,8 @@ func TestModelsForTabListsMimoAPIPaidAccess(t *testing.T) {
 
 func TestModelsForTabKeepsUserProvidersWithProjectConfig(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
-	t.Setenv("MIMO_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "MIMO_API_KEY", "sk-test")
 
 	userCfg := config.Default()
 	userCfg.DefaultModel = "mimo-pro/mimo-v2.5-pro"
@@ -1480,8 +1490,8 @@ api_key_env = "DEEPSEEK_API_KEY"
 
 func TestSetModelForTabRejectsProviderOutsideAccess(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
-	t.Setenv("MIMO_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "MIMO_API_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "deepseek-flash/deepseek-v4-flash"
@@ -1570,7 +1580,7 @@ func TestSaveProviderPersistsReasoningProtocol(t *testing.T) {
 
 func TestDeleteProviderMigratesConfigAndOpenTabs(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "prov-a/model-a2"
@@ -1616,7 +1626,7 @@ func TestDeleteProviderMigratesConfigAndOpenTabs(t *testing.T) {
 
 func TestDeleteProviderRejectsRunningAffectedTab(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "prov-a/model-a1"
@@ -1650,7 +1660,7 @@ func TestDeleteProviderRejectsRunningAffectedTab(t *testing.T) {
 
 func TestDeleteProviderRejectsAffectedBackgroundJobs(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "prov-a/model-a1"
@@ -1688,7 +1698,7 @@ func TestDeleteProviderRejectsAffectedBackgroundJobs(t *testing.T) {
 
 func TestDeleteProviderRejectsUnaffectedBackgroundJobsBeforeSavingConfig(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	setDesktopTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "prov-b/model-b1"
@@ -1832,7 +1842,7 @@ func TestSetEffortRebuildsController(t *testing.T) {
 
 func TestSetEffortMigratesStaleOfficialDeepSeekTabModel(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "deepseek/deepseek-v4-flash"
@@ -1912,7 +1922,7 @@ func TestSetTokenModeRebuildsController(t *testing.T) {
 
 func TestSetTokenModeMigratesStaleOfficialDeepSeekTabModel(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("DEEPSEEK_API_KEY", "sk-test")
+	setDesktopTestCredential(t, "DEEPSEEK_API_KEY", "sk-test")
 
 	cfg := config.Default()
 	cfg.DefaultModel = "deepseek/deepseek-v4-flash"

--- a/desktop/dotenv.go
+++ b/desktop/dotenv.go
@@ -9,9 +9,7 @@ import (
 	"reasonix/internal/fileutil"
 )
 
-// credentialsPath is the file fallback for the reasonix-owned global credential
-// store. The settings panel writes through config.SetCredential instead, so
-// systems with a usable keyring do not need to store secrets in this file.
+// credentialsPath is the reasonix-owned global .env used for provider keys.
 func credentialsPath() string {
 	if p := config.UserCredentialsPath(); p != "" {
 		return p
@@ -22,8 +20,8 @@ func credentialsPath() string {
 	return ".env"
 }
 
-// upsertDotEnv stores KEY=value in the configured global credential store and
-// applies it to the running process so a rebuild picks it up without a restart.
+// upsertDotEnv stores KEY=value in Reasonix's global .env and applies it to the
+// running process so a rebuild picks it up without a restart.
 func upsertDotEnv(key, value string) error {
 	_, err := config.SetCredential(key, value)
 	return err
@@ -145,12 +143,9 @@ func removeEnvFile(path, key string) error {
 	return os.Unsetenv(key)
 }
 
-// promoteProviderKeysToCredentials copies any configured provider api_key_env that
-// currently resolves (from a project .env, ~/.env, or the OS env) into the global
-// credential store when it isn't there yet, so a key set for one workspace follows
-// the user across every project. Promoted keys are then stripped from ~/.env so the
-// credential store is the single source of truth; a project's own .env is
-// user-owned and left untouched.
+// promoteProviderKeysToCredentials copies any already-loaded provider api_key_env
+// into Reasonix's global .env when it isn't there yet. This is only a legacy
+// desktop upgrade bridge; normal runtime credential resolution uses global .env.
 func promoteProviderKeysToCredentials(cfg *config.Config) {
 	for _, p := range cfg.Providers {
 		env := strings.TrimSpace(p.APIKeyEnv)

--- a/desktop/settings_app.go
+++ b/desktop/settings_app.go
@@ -20,7 +20,7 @@ import (
 // resolved config and applies edits through internal/config/edit.go (the
 // purpose-built mutation API), then rebuilds the controller so the change takes
 // effect live — the same snapshot→reload→resume pattern as SetModel. Secrets are
-// the exception: they go to the global credential store (upsertDotEnv), since
+// the exception: they go to Reasonix's global .env (upsertDotEnv), since
 // config stores only the env-var name, not the key.
 
 // --- read ---
@@ -181,7 +181,7 @@ type SettingsView struct {
 
 // DesktopStartupSettingsView is the lightweight Settings subset needed during
 // frontend startup. It deliberately excludes providers and credential state so
-// slow keychain/env resolution stays off the first-render path.
+// credential file resolution stays off the first-render path.
 type DesktopStartupSettingsView struct {
 	Bot                BotSettingsView `json:"bot"`
 	DesktopLanguage    string          `json:"desktopLanguage"`
@@ -819,18 +819,6 @@ func (a *App) saveProviderCredential(apiKeyEnv, value string) (string, error) {
 }
 
 func providerCredentialShadowWarning(apiKeyEnv, value, root string, before config.CredentialResolution, beforeEnvSet bool, beforeEnvValue string) string {
-	if beforeEnvSet && beforeEnvValue != value {
-		return fmt.Sprintf("saved %s to Reasonix credentials, but an existing environment variable with the same name can override it after restart; update or remove that environment variable", apiKeyEnv)
-	}
-	if before.Set && before.Source.Kind == config.CredentialSourceEnvironment && before.Value != value {
-		return fmt.Sprintf("saved %s to Reasonix credentials, but an existing environment variable with the same name can override it after restart; update or remove that environment variable", apiKeyEnv)
-	}
-	current := config.ResolveCredentialForRoot(root, apiKeyEnv)
-	for _, source := range current.Shadowed {
-		if source.Kind == config.CredentialSourceProjectEnv {
-			return fmt.Sprintf("saved %s to Reasonix credentials, but this workspace's project .env also defines %s and can override it after restart; update or remove that project .env entry", apiKeyEnv, apiKeyEnv)
-		}
-	}
 	return ""
 }
 
@@ -1502,7 +1490,7 @@ func (a *App) deleteProviderAndRetargetTabs(name string) error {
 	return nil
 }
 
-// SetProviderKey writes a secret to the global credential store under the given
+// SetProviderKey writes a secret to Reasonix's global .env under the given
 // env-var name (the one a provider's api_key_env points at) and rebuilds so it
 // resolves immediately.
 func (a *App) SetProviderKey(apiKeyEnv, value string) (string, error) {
@@ -1576,7 +1564,7 @@ func (a *App) ensureProviderAccessForKey(apiKeyEnv string) error {
 	return cfg.SaveTo(path)
 }
 
-// ClearProviderKey removes a provider secret from the global credential store
+// ClearProviderKey removes a provider secret from Reasonix's global .env
 // and rebuilds so the provider immediately becomes unauthenticated.
 func (a *App) ClearProviderKey(apiKeyEnv string) error {
 	if strings.TrimSpace(apiKeyEnv) == "" {

--- a/desktop/settings_app_test.go
+++ b/desktop/settings_app_test.go
@@ -169,7 +169,7 @@ func TestProviderViewFromEntryExposesNoAuthAvailability(t *testing.T) {
 	}
 }
 
-func TestSetProviderKeyWarnsWhenProjectEnvWillShadowSavedKey(t *testing.T) {
+func TestSetProviderKeyIgnoresProjectEnvShadow(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	project := t.TempDir()
 	if err := os.WriteFile(filepath.Join(project, ".env"), []byte("TEST_PROVIDER_SHADOW=old-key\n"), 0o600); err != nil {
@@ -186,8 +186,8 @@ func TestSetProviderKeyWarnsWhenProjectEnvWillShadowSavedKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SetProviderKey: %v", err)
 	}
-	if !strings.Contains(warning, "project .env") {
-		t.Fatalf("SetProviderKey warning = %q, want project .env shadow warning", warning)
+	if warning != "" {
+		t.Fatalf("SetProviderKey warning = %q, want no warning because global .env wins", warning)
 	}
 	data, readErr := os.ReadFile(config.UserCredentialsPath())
 	if readErr != nil {
@@ -198,7 +198,7 @@ func TestSetProviderKeyWarnsWhenProjectEnvWillShadowSavedKey(t *testing.T) {
 	}
 }
 
-func TestSetProviderKeyWarnsWhenEmptyEnvironmentWillShadowSavedKey(t *testing.T) {
+func TestSetProviderKeyIgnoresEmptyEnvironmentShadow(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	t.Setenv("TEST_PROVIDER_EMPTY_ENV", "")
 
@@ -207,8 +207,8 @@ func TestSetProviderKeyWarnsWhenEmptyEnvironmentWillShadowSavedKey(t *testing.T)
 	if err != nil {
 		t.Fatalf("SetProviderKey: %v", err)
 	}
-	if !strings.Contains(warning, "environment variable") {
-		t.Fatalf("SetProviderKey warning = %q, want environment variable shadow warning", warning)
+	if warning != "" {
+		t.Fatalf("SetProviderKey warning = %q, want no warning because global .env wins", warning)
 	}
 	data, readErr := os.ReadFile(config.UserCredentialsPath())
 	if readErr != nil {
@@ -219,7 +219,7 @@ func TestSetProviderKeyWarnsWhenEmptyEnvironmentWillShadowSavedKey(t *testing.T)
 	}
 }
 
-func TestSetProviderKeyWarnsWhenEmptyProjectEnvWillShadowSavedKey(t *testing.T) {
+func TestSetProviderKeyIgnoresEmptyProjectEnvShadow(t *testing.T) {
 	isolateDesktopUserDirs(t)
 	project := t.TempDir()
 	if err := os.WriteFile(filepath.Join(project, ".env"), []byte("TEST_PROVIDER_EMPTY_PROJECT=\n"), 0o600); err != nil {
@@ -236,13 +236,19 @@ func TestSetProviderKeyWarnsWhenEmptyProjectEnvWillShadowSavedKey(t *testing.T) 
 	if err != nil {
 		t.Fatalf("SetProviderKey: %v", err)
 	}
-	if !strings.Contains(warning, "project .env") {
-		t.Fatalf("SetProviderKey warning = %q, want project .env shadow warning", warning)
+	if warning != "" {
+		t.Fatalf("SetProviderKey warning = %q, want no warning because global .env wins", warning)
 	}
 }
 
 func TestFetchProviderModelsFiltersNonChatModels(t *testing.T) {
-	t.Setenv("TEST_PROVIDER_KEY", "test-key")
+	isolateDesktopUserDirs(t)
+	if _, err := config.SetCredential("TEST_PROVIDER_KEY", "test-key"); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+	if err := os.Unsetenv("TEST_PROVIDER_KEY"); err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/models" {
 			http.NotFound(w, r)

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -714,7 +714,12 @@ func TestBuildTabControllerUsesPinnedSessionMetaWorkspace(t *testing.T) {
 
 func TestBuildTabControllerIgnoresStaleSessionModelWhenTabModelResolves(t *testing.T) {
 	isolateDesktopUserDirs(t)
-	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	if _, err := config.SetCredential("REASONIX_TEST_KEY", "sk-test"); err != nil {
+		t.Fatalf("SetCredential: %v", err)
+	}
+	if err := os.Unsetenv("REASONIX_TEST_KEY"); err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(config.UserConfigPath()), 0o755); err != nil {
 		t.Fatalf("mkdir config dir: %v", err)
 	}

--- a/docs/CONFIG_PATHS.md
+++ b/docs/CONFIG_PATHS.md
@@ -20,7 +20,7 @@ installations. Normal users should not need it.
 | Data | Path |
 | --- | --- |
 | Global config | `<Reasonix home>/config.toml` |
-| Global credentials file fallback | `<Reasonix home>/credentials` |
+| Global credentials `.env` | `<Reasonix home>/.env` |
 | Global slash commands | `<Reasonix home>/commands/` |
 | Global skills | `<Reasonix home>/skills/` |
 | Global hooks | `<Reasonix home>/settings.json` |
@@ -29,17 +29,12 @@ installations. Normal users should not need it.
 | Archives | `<Reasonix home>/archive/` |
 | Memory | `<Reasonix home>/memory/` and `<Reasonix home>/projects/` |
 
-Global credentials use `credentials_store = "auto"` by default. In auto mode,
-Reasonix tries the OS credential store first and falls back to
-`<Reasonix home>/credentials` when the keyring is unavailable. Set
-`credentials_store = "keyring"` to require the OS credential store, or
-`credentials_store = "file"` to always use the file fallback. `REASONIX_CREDENTIALS_STORE`
-can override the mode for CI, tests, or portable installs.
-
-New API keys saved by the setup wizard, the desktop app, or an interactive
-missing-key prompt are written to the configured credential store above. Project
-`.env` files are still loaded first for compatibility and deliberate per-project
-overrides, but Reasonix does not write new keys into a project `.env`.
+Provider API keys saved by the setup wizard, the desktop app, or an interactive
+missing-key prompt are written to `<Reasonix home>/.env`. This global `.env` is
+the single runtime source for provider credentials: project `.env`, home `.env`,
+inherited shell variables, and Windows environment variables do not override the
+keys saved through Reasonix. The old `credentials_store` option is ignored for
+new writes and remains only as a deprecated config field.
 
 Caches remain in the OS cache directory, for example
 `~/Library/Caches/reasonix` on macOS, `$XDG_CACHE_HOME/reasonix` or
@@ -81,10 +76,12 @@ Legacy config sources include:
 ~/.reasonix/config.json
 ```
 
-Legacy credentials, memory files, and sessions are also imported into the
-configured credential store / Reasonix home when the new destination does not
-already exist. If the new global config already exists, it wins and legacy
-config files are only kept as compatibility fallbacks.
+Legacy credentials from older Reasonix credential files or the former keyring
+store are imported into `<Reasonix home>/.env` when the new destination does not
+already contain that key. Legacy memory files and sessions are imported into
+Reasonix home when the new destination does not already exist. If the new global
+config already exists, it wins and legacy config files are only kept as
+compatibility fallbacks.
 
 Starting in **v1.9.1**, Reasonix also backfills MCP servers from known legacy
 paths, legacy `config.json`, desktop-registered projects, and restored tab

--- a/docs/CONFIG_PATHS.zh-CN.md
+++ b/docs/CONFIG_PATHS.zh-CN.md
@@ -17,7 +17,7 @@
 | 数据 | 路径 |
 | --- | --- |
 | 全局配置 | `<Reasonix home>/config.toml` |
-| 全局 credentials 文件 fallback | `<Reasonix home>/credentials` |
+| 全局 credentials `.env` | `<Reasonix home>/.env` |
 | 全局斜杠命令 | `<Reasonix home>/commands/` |
 | 全局 skills | `<Reasonix home>/skills/` |
 | 全局 hooks | `<Reasonix home>/settings.json` |
@@ -26,14 +26,10 @@
 | 归档 | `<Reasonix home>/archive/` |
 | 记忆 | `<Reasonix home>/memory/` 与 `<Reasonix home>/projects/` |
 
-全局 credentials 默认使用 `credentials_store = "auto"`。在 auto 模式下，
-Reasonix 会优先尝试系统密钥库；如果 keyring 不可用，再 fallback 到
-`<Reasonix home>/credentials`。设置 `credentials_store = "keyring"` 可强制使用系统密钥库；
-设置 `credentials_store = "file"` 可始终使用文件 fallback。`REASONIX_CREDENTIALS_STORE`
-可在 CI、测试或便携安装中覆盖该模式。
-
-setup 向导、桌面端或 CLI 缺 key 提示保存的新 API key 都会写入上面的凭据存储。
-项目 `.env` 仍会优先读取，用于兼容旧项目或用户主动做项目级覆盖；但 Reasonix 不会把新密钥写入项目 `.env`。
+setup 向导、桌面端或 CLI 缺 key 提示保存的新 API key 都会写入
+`<Reasonix home>/.env`。这个全局 `.env` 是 provider credentials 的唯一运行时来源：
+项目 `.env`、home `.env`、继承的 shell 环境变量和 Windows 环境变量都不会覆盖
+Reasonix 保存的 key。`credentials_store` 已弃用，仅作为旧配置字段保留。
 
 缓存仍放在系统缓存目录，例如 macOS 的 `~/Library/Caches/reasonix`、
 Linux 的 `$XDG_CACHE_HOME/reasonix` 或 `~/.cache/reasonix`、Windows 的
@@ -71,7 +67,9 @@ Windows:     %APPDATA%\reasonix\config.toml
 ~/.reasonix/config.json
 ```
 
-旧 credentials、memory 文件和 sessions 也会在新目标不存在时导入到配置的 credential store / Reasonix home。若新的全局配置已经存在，则新配置优先；旧配置只作为兼容 fallback 保留。
+旧 credentials 文件或旧 keyring 里的密钥会在新目标尚未包含该 key 时导入到
+`<Reasonix home>/.env`。旧 memory 文件和 sessions 会在新目标不存在时导入到
+Reasonix home。若新的全局配置已经存在，则新配置优先；旧配置只作为兼容 fallback 保留。
 
 从 **v1.9.1** 开始，Reasonix 还会在升级时把已知旧路径、legacy `config.json`、
 桌面端已登记项目和恢复 tabs 对应项目里的 MCP 配置汇总补齐到全局

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -30,11 +30,10 @@ built-in defaults**. Starting with **Reasonix v1.8.1**, the user config lives at
 [Configuration paths](./CONFIG_PATHS.md) for migration and related data paths.
 Fields marked user/global only, including agent step limits, are not overridden
 by `./reasonix.toml`.
-Secrets come from the environment via `api_key_env` and are never stored in
-config files. Credentials default to `credentials_store = "auto"`, which prefers
-the OS credential store and falls back to the file under Reasonix home. New keys
-saved by Reasonix are not written to a project `.env`; project `.env` files are
-only read for compatibility and explicit per-project overrides.
+Secrets are referenced by `api_key_env` and are never stored in config files.
+Reasonix loads provider keys from the single global `<Reasonix home>/.env` file
+that setup/settings maintain. Project `.env`, home `.env`, and inherited
+environment variables do not override saved provider keys.
 
 For the desktop and CLI usage of visible reasoning language, see
 [Reasoning language](./REASONING_LANGUAGE.md).

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -27,10 +27,10 @@
 优先级：**flag > `./reasonix.toml` > 用户配置文件 > 内置默认值**。从
 **Reasonix v1.8.1** 开始，用户配置位于 macOS/Linux 的
 `~/.reasonix/config.toml`，Windows 为 `%AppData%\reasonix\config.toml`；迁移和相关数据路径见
-[配置路径](./CONFIG_PATHS.zh-CN.md)。密钥经环境变量通过 `api_key_env` 注入，绝不写入配置文件。
+[配置路径](./CONFIG_PATHS.zh-CN.md)。密钥通过 `api_key_env` 引用，绝不写入配置文件。
 标注为“仅用户/全局”的字段（包括 agent 轮数上限）不会被 `./reasonix.toml` 覆盖。
-credentials 默认使用 `credentials_store = "auto"`：优先系统密钥库，不可用时 fallback 到 Reasonix home 下的文件。
-Reasonix 保存的新密钥不会写入项目 `.env`；项目 `.env` 只用于兼容读取或用户主动的项目级覆盖。
+Reasonix 从唯一的全局 `<Reasonix home>/.env` 读取 provider key；项目 `.env`、home `.env`
+和继承的环境变量都不会覆盖 Reasonix 保存的 key。
 
 桌面端和 CLI 端的可见思考语言设置，见 [思考语言](./REASONING_LANGUAGE.zh-CN.md)。
 桌面端 Hooks 的 JSON 配置、事件 key 和 payload 字段，见 [桌面端 Hooks](./DESKTOP_HOOKS.zh-CN.md)。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -450,12 +450,11 @@ at `~/.reasonix/config.toml` on macOS/Linux and
 [Configuration paths](./CONFIG_PATHS.md) for migration and related data paths.
 Fields marked user/global only, including agent step limits, are not overridden
 by project `reasonix.toml`.
-Secrets come from the environment via `api_key_env` and are never stored in
-config files. `credentials_store = "auto"` prefers the OS credential store and
-falls back to the file under Reasonix home. A `.env` in the working directory is
-loaded if present for compatibility and explicit per-project overrides, but
-Reasonix-created API keys are written to the configured credential store rather
-than a project `.env`. Step-limit preferences belong in the user config.
+Secrets are referenced by `api_key_env` and are never stored in config files.
+Reasonix-created API keys are written to and loaded from the single global
+`<Reasonix home>/.env` file. Project `.env`, home `.env`, and inherited
+environment variables do not override saved provider keys. Step-limit
+preferences belong in the user config.
 Project `reasonix.toml` does not override `agent.max_steps` or
 `agent.planner_max_steps`.
 

--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -1166,12 +1166,12 @@ func NewProvider(e *config.ProviderEntry) (provider.Provider, error) {
 // NewProviderWithProxy builds a provider.Provider with the configured ordinary
 // network proxy settings.
 func NewProviderWithProxy(e *config.ProviderEntry, proxy netclient.ProxySpec) (provider.Provider, error) {
-	keyResolution := config.ResolveCredential(e.APIKeyEnv)
+	keyResolution := config.ResolveCredentialForRootGlobalFirst(".", e.APIKeyEnv)
 	return provider.New(e.Kind, provider.Config{
 		Name:    e.Name,
 		BaseURL: e.BaseURL,
 		Model:   e.Model,
-		APIKey:  e.APIKey(),
+		APIKey:  keyResolution.Value,
 		// Pass the key's env var so auth failures can name where to fix it, plus
 		// provider-kind-specific knobs. EffectiveEffort applies a configured
 		// default_effort when the user has not explicitly selected /effort.

--- a/internal/cli/acp_test.go
+++ b/internal/cli/acp_test.go
@@ -71,7 +71,7 @@ func TestACPInitializesWithoutAPIKey(t *testing.T) {
 
 func TestACPFactoryLoadsSessionCwdProjectConfig(t *testing.T) {
 	home := isolateCLIConfigHome(t)
-	t.Setenv("REASONIX_TEST_KEY", "test-key")
+	setCLITestCredential(t, "REASONIX_TEST_KEY", "test-key")
 	project := t.TempDir()
 	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
 default_model = "local"
@@ -112,7 +112,7 @@ api_key_env = "REASONIX_TEST_KEY"
 
 func TestACPFactoryClearsEffortOverrideForUnsupportedModel(t *testing.T) {
 	isolateCLIConfigHome(t)
-	t.Setenv("REASONIX_TEST_KEY", "test-key")
+	setCLITestCredential(t, "REASONIX_TEST_KEY", "test-key")
 	project := t.TempDir()
 	if err := os.WriteFile(filepath.Join(project, "reasonix.toml"), []byte(`
 default_model = "reasoner/reasoning-model"

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -180,6 +180,16 @@ func isolateCLIConfigHome(t *testing.T) string {
 	return home
 }
 
+func setCLITestCredential(t *testing.T, key, value string) {
+	t.Helper()
+	if _, err := config.SetCredential(key, value); err != nil {
+		t.Fatalf("SetCredential(%s): %v", key, err)
+	}
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("Unsetenv(%s): %v", key, err)
+	}
+}
+
 func TestMCPMigrationWaitsForCLIWorkspace(t *testing.T) {
 	isolateCLIConfigHome(t)
 	cwd := mustGetwd(t)

--- a/internal/cli/model_test.go
+++ b/internal/cli/model_test.go
@@ -12,9 +12,9 @@ import (
 // provider/model refs (built-in defaults when no reasonix.toml is present), and
 // only those whose provider API key is set.
 func TestModelRefsFromConfig(t *testing.T) {
-	t.Chdir(t.TempDir()) // no reasonix.toml → built-in default providers
+	isolateCLIConfigHome(t) // no reasonix.toml → built-in default providers
 	// Only DeepSeek keyed → MiMo refs must be filtered out.
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	setCLITestCredential(t, "DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("MIMO_API_KEY", "")
 	refs := modelRefs()
 	if len(refs) == 0 {
@@ -33,7 +33,7 @@ func TestModelRefsFromConfig(t *testing.T) {
 // TestModelRefsSkipsUnconfigured verifies that with no provider keys set, the
 // picker offers nothing rather than listing models the user can't select.
 func TestModelRefsSkipsUnconfigured(t *testing.T) {
-	t.Chdir(t.TempDir())
+	isolateCLIConfigHome(t)
 	t.Setenv("DEEPSEEK_API_KEY", "")
 	t.Setenv("MIMO_API_KEY", "")
 	if refs := modelRefs(); len(refs) != 0 {
@@ -44,8 +44,8 @@ func TestModelRefsSkipsUnconfigured(t *testing.T) {
 // TestModelArgCompletion verifies "/model " completes to the configured refs
 // through the shared completion path.
 func TestModelArgCompletion(t *testing.T) {
-	t.Chdir(t.TempDir())
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	isolateCLIConfigHome(t)
+	setCLITestCredential(t, "DEEPSEEK_API_KEY", "test-key")
 	m := newTestChatTUI()
 	items, _, ok := m.slashArgItems("/model ")
 	if !ok || len(items) == 0 {
@@ -60,7 +60,7 @@ func TestModelArgCompletion(t *testing.T) {
 // next startup read the global default.
 func TestPersistModelWritesDefaultModel(t *testing.T) {
 	isolateUserConfig(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	setCLITestCredential(t, "DEEPSEEK_API_KEY", "test-key")
 	t.Setenv("MIMO_API_KEY", "")
 
 	m := newTestChatTUI()
@@ -83,7 +83,7 @@ func TestPersistModelWritesDefaultModel(t *testing.T) {
 // memory switch still goes through.
 func TestPersistModelRejectsUnknownRef(t *testing.T) {
 	isolateUserConfig(t)
-	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+	setCLITestCredential(t, "DEEPSEEK_API_KEY", "test-key")
 
 	m := newTestChatTUI()
 	m.persistModel("ghost/never-existed")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2681,18 +2681,17 @@ func LegacyUserConfigPaths() []string {
 // Windows.
 func ReasonixHomeDir() string { return reasonixHomeDir() }
 
-// UserCredentialsPath is the reasonix-owned global secrets file under Reasonix
-// home. It holds KEY=value lines loaded into the environment by loadDotEnv. The
-// setup wizard writes API keys here, deliberately NOT named .env: keys never
-// land in a project's own .env (which can't be selectively gitignored), never
-// get committed, and resolve from any working directory. "" when Reasonix home
-// can't be resolved.
+// UserCredentialsPath is the reasonix-owned global .env file under Reasonix
+// home. It is the single source for provider credentials saved by Reasonix, so
+// stale shell, Windows, project, or home env vars cannot silently override keys
+// the user saved through setup or settings. "" when Reasonix home can't be
+// resolved.
 func UserCredentialsPath() string {
 	dir := userSupportDir()
 	if dir == "" {
 		return ""
 	}
-	return filepath.Join(dir, "credentials")
+	return filepath.Join(dir, ".env")
 }
 
 // ArchiveDir is where compacted conversation history is archived for
@@ -2953,7 +2952,11 @@ func (e *ProviderEntry) APIKey() string {
 	if e.APIKeyEnv == "" {
 		return ""
 	}
-	return os.Getenv(e.APIKeyEnv)
+	value, _, ok := storedCredentialValue(e.APIKeyEnv)
+	if !ok {
+		return ""
+	}
+	return value
 }
 
 // RequiresAPIKey reports whether this provider should be hidden/validated when

--- a/internal/config/configured_test.go
+++ b/internal/config/configured_test.go
@@ -6,7 +6,8 @@ import "testing"
 // selected. Providers with no api_key_env are explicit no-auth providers; if an
 // env var is configured, it must resolve to a non-empty value.
 func TestProviderConfigured(t *testing.T) {
-	t.Setenv("REASONIX_TEST_KEY", "secret")
+	isolateTestCredentials(t)
+	setTestCredential(t, "REASONIX_TEST_KEY", "secret")
 	t.Setenv("REASONIX_TEST_EMPTY", "")
 
 	cases := []struct {

--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -56,6 +55,7 @@ var credentialSourceTracker = struct {
 }{byKey: map[string]trackedCredentialSource{}}
 
 var storedCredentialValueLookup = storedCredentialValue
+var legacyKeyringCredentialValueLookup = legacyKeyringCredentialValue
 
 // CredentialResolver resolves credentials repeatedly for one caller-owned view
 // build. It keeps expensive global credential-store lookups bounded to one per
@@ -72,10 +72,9 @@ func NewCredentialResolverForRoot(root string) *CredentialResolver {
 	return &CredentialResolver{root: resolveRoot(root)}
 }
 
-// ResolveGlobalFirst resolves key with the Reasonix credential store taking
-// precedence over project env files. Repeated calls for the same key reuse the
-// first result so UI views with multiple provider entries sharing api_key_env do
-// not repeatedly hit the OS credential store.
+// ResolveGlobalFirst resolves key from Reasonix's global .env only. Repeated
+// calls for the same key reuse the first result so UI views with multiple
+// provider entries sharing api_key_env stay consistent.
 func (r *CredentialResolver) ResolveGlobalFirst(key string) CredentialResolution {
 	key = strings.TrimSpace(key)
 	if key == "" {
@@ -183,45 +182,17 @@ func loadCredentialStoreForRoot(root string) {
 	if len(names) == 0 {
 		return
 	}
-	mode := credentialsStoreMode()
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreKeyring {
-		for _, name := range names {
-			if _, exists := os.LookupEnv(name); exists {
-				recordExistingCredentialSource(name)
-				continue
-			}
-			value, err := keyring.Get(credentialsKeyringService, name)
-			if err == nil && value != "" {
-				_ = os.Setenv(name, value)
-				recordCredentialSource(name, value, CredentialSource{Kind: CredentialSourceCredentials, Label: "system credential store"})
-			}
-		}
-	}
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreFile {
-		if p := UserCredentialsPath(); p != "" {
-			loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials"})
-		}
-		for _, p := range legacyCredentialsPaths() {
-			loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceLegacy, Path: p, Label: "legacy Reasonix credentials"})
-		}
+	if p := UserCredentialsPath(); p != "" {
+		loadDotEnvFileAs(p, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials (.env)"})
 	}
 }
 
-// StoreCredentialLines stores KEY=value assignments in the configured user
-// credential store and pins them into the current process environment.
+// StoreCredentialLines stores KEY=value assignments in Reasonix's global .env
+// and pins them into the current process environment.
 func StoreCredentialLines(lines []string) (string, error) {
 	assignments := parseCredentialLines(lines)
 	if len(assignments) == 0 {
 		return CredentialsTargetDescription(), nil
-	}
-	mode := credentialsStoreMode()
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreKeyring {
-		if err := storeCredentialsInKeyring(assignments); err == nil {
-			pinCredentialAssignments(assignments)
-			return "system credential store", nil
-		} else if mode == CredentialsStoreKeyring {
-			return "", err
-		}
 	}
 	if err := storeCredentialsInFile(UserCredentialsPath(), assignments); err != nil {
 		return "", err
@@ -246,18 +217,9 @@ func RemoveCredential(key string) error {
 	if key == "" {
 		return nil
 	}
-	mode := credentialsStoreMode()
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreKeyring {
-		err := keyring.Delete(credentialsKeyringService, key)
-		if err != nil && !errors.Is(err, keyring.ErrNotFound) && mode == CredentialsStoreKeyring {
+	if path := UserCredentialsPath(); path != "" {
+		if err := removeCredentialFromFile(path, key); err != nil {
 			return err
-		}
-	}
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreFile {
-		if path := UserCredentialsPath(); path != "" {
-			if err := removeCredentialFromFile(path, key); err != nil {
-				return err
-			}
 		}
 	}
 	return os.Unsetenv(key)
@@ -268,9 +230,6 @@ func CredentialIsSet(key string) bool {
 	if key == "" {
 		return false
 	}
-	if os.Getenv(key) != "" {
-		return true
-	}
 	return CredentialStored(key)
 }
 
@@ -279,20 +238,7 @@ func CredentialStored(key string) bool {
 	if key == "" {
 		return false
 	}
-	mode := credentialsStoreMode()
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreKeyring {
-		if value, err := keyring.Get(credentialsKeyringService, key); err == nil && value != "" {
-			return true
-		}
-	}
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreFile {
-		for _, path := range append([]string{UserCredentialsPath()}, legacyCredentialsPaths()...) {
-			if envFileHasKey(path, key) {
-				return true
-			}
-		}
-	}
-	return false
+	return envFileHasKey(UserCredentialsPath(), key)
 }
 
 func credentialCurrentStoreHasKey(key string) bool {
@@ -300,27 +246,20 @@ func credentialCurrentStoreHasKey(key string) bool {
 	if key == "" {
 		return false
 	}
-	mode := credentialsStoreMode()
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreKeyring {
-		if value, err := keyring.Get(credentialsKeyringService, key); err == nil && value != "" {
-			return true
-		}
+	return envFileHasKey(UserCredentialsPath(), key)
+}
+
+func legacyKeyringCredentialValue(key string) (string, bool) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "", false
 	}
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreFile {
-		return envFileHasKey(UserCredentialsPath(), key)
-	}
-	return false
+	value, err := keyring.Get(credentialsKeyringService, key)
+	return value, err == nil && value != ""
 }
 
 func CredentialsTargetDescription() string {
-	switch credentialsStoreMode() {
-	case CredentialsStoreKeyring:
-		return "system credential store"
-	case CredentialsStoreFile:
-		return UserCredentialsPath()
-	default:
-		return "system credential store or " + UserCredentialsPath()
-	}
+	return UserCredentialsPath()
 }
 
 func parseCredentialLines(lines []string) map[string]string {
@@ -344,7 +283,7 @@ func parseCredentialLines(lines []string) map[string]string {
 func pinCredentialAssignments(assignments map[string]string) {
 	for key, value := range assignments {
 		_ = os.Setenv(key, value)
-		recordCredentialSource(key, value, CredentialSource{Kind: CredentialSourceCredentials, Label: "Reasonix credentials"})
+		recordCredentialSource(key, value, CredentialSource{Kind: CredentialSourceCredentials, Path: UserCredentialsPath(), Label: "Reasonix credentials (.env)"})
 	}
 }
 
@@ -456,54 +395,13 @@ func resolveCredentialForRootGlobalFirst(root, key string) CredentialResolution 
 		res.Shadowed = shadowedCredentialSources(root, key, value, res.Source)
 		return res
 	}
-	for _, source := range credentialSourceCandidates(root) {
-		switch source.Kind {
-		case CredentialSourceProjectEnv, CredentialSourceHomeEnv, CredentialSourceLegacy:
-		default:
-			continue
-		}
-		if value, ok := envFileValue(source.Path, key); ok && value != "" {
-			res.Set = true
-			res.Value = value
-			source.Label = credentialSourceLabel(source)
-			res.Source = source
-			res.Shadowed = shadowedCredentialSources(root, key, value, source)
-			return res
-		}
-	}
-	value := os.Getenv(key)
-	if value == "" {
-		return res
-	}
-	res.Set = true
-	res.Value = value
-	if source, ok := trackedCredential(key, value); ok {
-		res.Source = source
-	} else {
-		res.Source = CredentialSource{Kind: CredentialSourceEnvironment}
-	}
-	res.Source.Label = credentialSourceLabel(res.Source)
-	res.Shadowed = shadowedCredentialSources(root, key, value, res.Source)
 	return res
 }
 
 func storedCredentialValue(key string) (string, CredentialSource, bool) {
-	mode := credentialsStoreMode()
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreKeyring {
-		if value, err := keyring.Get(credentialsKeyringService, key); err == nil && value != "" {
-			return value, CredentialSource{Kind: CredentialSourceCredentials, Label: "system credential store"}, true
-		}
-	}
-	if mode == CredentialsStoreAuto || mode == CredentialsStoreFile {
-		if p := UserCredentialsPath(); p != "" {
-			if value, ok := envFileValue(p, key); ok && value != "" {
-				return value, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials"}, true
-			}
-		}
-		for _, p := range legacyCredentialsPaths() {
-			if value, ok := envFileValue(p, key); ok && value != "" {
-				return value, CredentialSource{Kind: CredentialSourceLegacy, Path: p, Label: "legacy Reasonix credentials"}, true
-			}
+	if p := UserCredentialsPath(); p != "" {
+		if value, ok := envFileValue(p, key); ok && value != "" {
+			return value, CredentialSource{Kind: CredentialSourceCredentials, Path: p, Label: "Reasonix credentials (.env)"}, true
 		}
 	}
 	return "", CredentialSource{}, false
@@ -544,9 +442,6 @@ func credentialSourceCandidates(root string) []CredentialSource {
 	if p := UserCredentialsPath(); p != "" {
 		out = append(out, CredentialSource{Kind: CredentialSourceCredentials, Path: p})
 	}
-	for _, p := range legacyCredentialsPaths() {
-		out = append(out, CredentialSource{Kind: CredentialSourceLegacy, Path: p})
-	}
 	if home, err := os.UserHomeDir(); err == nil {
 		out = append(out, CredentialSource{Kind: CredentialSourceHomeEnv, Path: filepath.Join(home, ".env")})
 	}
@@ -561,15 +456,6 @@ func sameCredentialSource(a, b CredentialSource) bool {
 		return a.Path == b.Path
 	}
 	return samePath(a.Path, b.Path)
-}
-
-func storeCredentialsInKeyring(assignments map[string]string) error {
-	for key, value := range assignments {
-		if err := keyring.Set(credentialsKeyringService, key, value); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 func storeCredentialsInFile(path string, assignments map[string]string) error {

--- a/internal/config/dotenv.go
+++ b/internal/config/dotenv.go
@@ -7,30 +7,18 @@ import (
 	"strings"
 )
 
-// loadDotEnv loads KEY=value files into the process environment without
-// overriding variables that are already set (first file to set a key wins).
-// Order: configured Reasonix credential store (where `reasonix setup` writes
-// keys, so they resolve from any directory), then a project ./.env as a
-// read-only back-compat fallback, then ~/.env as a legacy fallback. Existing
-// environment variables always win over all credential sources.
+// loadDotEnv loads Reasonix's global .env into the process environment.
+// Reasonix-owned credentials intentionally override inherited env vars so a key
+// saved through setup/settings is the key used after restart.
 func loadDotEnv() {
 	loadDotEnvForRoot(".")
 }
 
-// loadDotEnvForRoot loads Reasonix global credentials before a root's .env file
-// (if present) and the home .env fallback. When root is "." it behaves like
-// loadDotEnv().
+// loadDotEnvForRoot loads only Reasonix's global .env. The root argument is kept
+// for callers that already pass workspace roots, but provider credentials are no
+// longer resolved from project or home .env files.
 func loadDotEnvForRoot(root string) {
-	dotEnvPath := ".env"
-	if root != "" && root != "." {
-		dotEnvPath = filepath.Join(root, ".env")
-	}
 	loadCredentialStoreForRoot(root)
-	loadDotEnvFileAs(dotEnvPath, CredentialSource{Kind: CredentialSourceProjectEnv, Path: dotEnvPath})
-	if home, err := os.UserHomeDir(); err == nil {
-		homeEnv := filepath.Join(home, ".env")
-		loadDotEnvFileAs(homeEnv, CredentialSource{Kind: CredentialSourceHomeEnv, Path: homeEnv})
-	}
 }
 
 func legacyCredentialsPaths() []string {
@@ -52,6 +40,9 @@ func legacyCredentialsPaths() []string {
 		paths = append(paths, path)
 	}
 	if dir := legacyOSSupportDir(); dir != "" {
+		add(filepath.Join(dir, "credentials"))
+	}
+	if dir := userSupportDir(); dir != "" {
 		add(filepath.Join(dir, "credentials"))
 	}
 	for _, cfg := range legacyXDGConfigPaths() {
@@ -83,7 +74,7 @@ func loadDotEnvFileAs(path string, source CredentialSource) {
 		if key == "" {
 			continue
 		}
-		if _, exists := os.LookupEnv(key); exists {
+		if _, exists := os.LookupEnv(key); exists && source.Kind != CredentialSourceCredentials {
 			recordExistingCredentialSource(key)
 			continue
 		}

--- a/internal/config/dotenv_test.go
+++ b/internal/config/dotenv_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 )
 
-// TestLoadDotEnvFallsBackToHome proves the unified-key behaviour: the working
-// directory's .env is still read as a fallback, and a key only present in ~/.env
-// is picked up too. Existing env vars beat file-backed credential sources.
-func TestLoadDotEnvFallsBackToHome(t *testing.T) {
+// TestLoadDotEnvIgnoresProjectAndHomeEnv proves provider credentials come only
+// from Reasonix's global .env, not project or home .env fallbacks.
+func TestLoadDotEnvIgnoresProjectAndHomeEnv(t *testing.T) {
 	cwd := t.TempDir()
 	home := t.TempDir()
 
@@ -24,25 +23,42 @@ func TestLoadDotEnvFallsBackToHome(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 	t.Setenv("USERPROFILE", home) // os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
 
-	// Start clean so the file values are what land (Setenv auto-restores).
+	cred := UserCredentialsPath()
+	if cred == "" {
+		t.Skip("user config dir unresolved on this platform")
+	}
+	if err := os.MkdirAll(filepath.Dir(cred), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cred, []byte("KEY_GLOBAL=from_global\nKEY_SHARED=global_wins\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	t.Setenv("KEY_CWD", "")
 	os.Unsetenv("KEY_CWD")
 	t.Setenv("KEY_HOME", "")
 	os.Unsetenv("KEY_HOME")
+	t.Setenv("KEY_GLOBAL", "")
+	os.Unsetenv("KEY_GLOBAL")
 	t.Setenv("KEY_SHARED", "")
 	os.Unsetenv("KEY_SHARED")
 
 	loadDotEnv()
 
-	if got := os.Getenv("KEY_CWD"); got != "from_cwd" {
-		t.Errorf("cwd-only key not loaded: KEY_CWD=%q", got)
+	if got := os.Getenv("KEY_GLOBAL"); got != "from_global" {
+		t.Errorf("global key not loaded: KEY_GLOBAL=%q want from_global", got)
 	}
-	if got := os.Getenv("KEY_HOME"); got != "from_home" {
-		t.Errorf("~/.env fallback failed: KEY_HOME=%q want from_home", got)
+	if got := os.Getenv("KEY_CWD"); got != "" {
+		t.Errorf("project .env should be ignored: KEY_CWD=%q", got)
 	}
-	if got := os.Getenv("KEY_SHARED"); got != "cwd_wins" {
-		t.Errorf("cwd .env should take precedence over ~/.env: KEY_SHARED=%q want cwd_wins", got)
+	if got := os.Getenv("KEY_HOME"); got != "" {
+		t.Errorf("home .env should be ignored: KEY_HOME=%q", got)
+	}
+	if got := os.Getenv("KEY_SHARED"); got != "global_wins" {
+		t.Errorf("global .env should be the only active shared key: KEY_SHARED=%q want global_wins", got)
 	}
 }
 
@@ -76,8 +92,7 @@ func TestLoadDotEnvReadsGlobalCredentials(t *testing.T) {
 
 	t.Setenv("KEY_GLOBAL", "")
 	os.Unsetenv("KEY_GLOBAL")
-	t.Setenv("KEY_SHARED", "")
-	os.Unsetenv("KEY_SHARED")
+	t.Setenv("KEY_SHARED", "from_env")
 
 	loadDotEnv()
 
@@ -85,7 +100,7 @@ func TestLoadDotEnvReadsGlobalCredentials(t *testing.T) {
 		t.Errorf("global credentials not loaded: KEY_GLOBAL=%q want from_credentials", got)
 	}
 	if got := os.Getenv("KEY_SHARED"); got != "global_wins" {
-		t.Errorf("global credentials should win over project .env: KEY_SHARED=%q want global_wins", got)
+		t.Errorf("global credentials should win over inherited env and project .env: KEY_SHARED=%q want global_wins", got)
 	}
 }
 
@@ -388,23 +403,26 @@ func TestProjectConfigCannotOverrideCredentialStoreMode(t *testing.T) {
 	}
 }
 
-// TestLoadDotEnvDoesNotOverrideEnv confirms an already-set environment variable
-// beats both .env files (the documented first-wins contract).
-func TestLoadDotEnvDoesNotOverrideEnv(t *testing.T) {
-	cwd := t.TempDir()
-	if err := os.WriteFile(filepath.Join(cwd, ".env"), []byte("PINNED=from_file\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Chdir(cwd)
+// TestLoadDotEnvOverridesStaleEnv confirms the Reasonix global .env is the
+// source of truth even when the process inherited a stale environment variable.
+func TestLoadDotEnvOverridesStaleEnv(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("REASONIX_CREDENTIALS_STORE", "file")
 	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	if err := os.MkdirAll(filepath.Dir(UserCredentialsPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(UserCredentialsPath(), []byte("PINNED=from_file\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	t.Setenv("PINNED", "from_env")
 
 	loadDotEnv()
 
-	if got := os.Getenv("PINNED"); got != "from_env" {
-		t.Errorf("env var must win over .env: PINNED=%q want from_env", got)
+	if got := os.Getenv("PINNED"); got != "from_file" {
+		t.Errorf("global .env must win over inherited env: PINNED=%q want from_file", got)
 	}
 }

--- a/internal/config/fetch_test.go
+++ b/internal/config/fetch_test.go
@@ -87,7 +87,8 @@ func TestProviderFetchModelsFallsBackToV1Models(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	t.Setenv("FETCH_MODELS_TEST_KEY", "test-key")
+	isolateTestCredentials(t)
+	setTestCredential(t, "FETCH_MODELS_TEST_KEY", "test-key")
 	p := ProviderEntry{Name: "test", BaseURL: srv.URL, APIKeyEnv: "FETCH_MODELS_TEST_KEY"}
 	got, err := p.FetchModels(context.Background())
 	if err != nil {

--- a/internal/config/loadedit_test.go
+++ b/internal/config/loadedit_test.go
@@ -73,7 +73,8 @@ model = "m"
 	}
 }
 
-func TestLoadForEditLoadsDotEnvNextToEditedProjectConfig(t *testing.T) {
+func TestLoadForEditUsesGlobalCredentialsNotProjectDotEnv(t *testing.T) {
+	isolateTestCredentials(t)
 	project := t.TempDir()
 	launch := t.TempDir()
 	path := filepath.Join(project, "reasonix.toml")
@@ -91,6 +92,7 @@ api_key_env = "PROJECT_ONLY_KEY"
 	if err := os.WriteFile(filepath.Join(project, ".env"), []byte("PROJECT_ONLY_KEY=from-project\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	setTestCredential(t, "PROJECT_ONLY_KEY", "from-global")
 	t.Chdir(launch)
 	t.Setenv("PROJECT_ONLY_KEY", "")
 	os.Unsetenv("PROJECT_ONLY_KEY")
@@ -101,9 +103,9 @@ api_key_env = "PROJECT_ONLY_KEY"
 		t.Fatalf("provider missing from edited config: %+v", cfg.Providers)
 	}
 	if !provider.Configured() {
-		t.Fatalf("provider should resolve api_key_env from project .env next to edited config")
+		t.Fatalf("provider should resolve api_key_env from Reasonix global .env")
 	}
-	if got := ResolveCredentialForRoot(project, "PROJECT_ONLY_KEY"); !got.Set || got.Value != "from-project" {
-		t.Fatalf("credential = %+v, want project .env value", got)
+	if got := ResolveCredentialForRootGlobalFirst(project, "PROJECT_ONLY_KEY"); !got.Set || got.Value != "from-global" {
+		t.Fatalf("credential = %+v, want global .env value", got)
 	}
 }

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -330,6 +330,14 @@ func normalizedMCPMigrationRoots(roots []string) []string {
 
 func migrateLegacyCredentialsIfNeeded() error {
 	missing := map[string]string{}
+	for _, key := range credentialEnvNamesForRoot(".") {
+		if credentialCurrentStoreHasKey(key) {
+			continue
+		}
+		if value, ok := legacyKeyringCredentialValueLookup(key); ok {
+			missing[key] = value
+		}
+	}
 	for _, src := range legacyCredentialsPaths() {
 		if src == "" {
 			continue

--- a/internal/config/migrate_test.go
+++ b/internal/config/migrate_test.go
@@ -18,6 +18,9 @@ func legacyHome(t *testing.T) (src, dest, home string) {
 	t.Setenv("USERPROFILE", home)                               // os.UserHomeDir on Windows
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config")) // os.UserConfigDir on Linux
 	t.Setenv("AppData", filepath.Join(home, "AppData"))         // os.UserConfigDir on Windows
+	oldKeyringLookup := legacyKeyringCredentialValueLookup
+	legacyKeyringCredentialValueLookup = func(string) (string, bool) { return "", false }
+	t.Cleanup(func() { legacyKeyringCredentialValueLookup = oldKeyringLookup })
 	return filepath.Join(home, ".reasonix", "config.json"), userConfigPath(), home
 }
 
@@ -658,6 +661,37 @@ func TestMigrateImportsLegacyCredentialsEvenWhenPrimaryConfigExists(t *testing.T
 		t.Fatalf("read migrated credentials: %v", err)
 	}
 	if string(data) != "DEEPSEEK_API_KEY=sk-old-creds\n" {
+		t.Fatalf("migrated credentials = %q", data)
+	}
+}
+
+func TestMigrateImportsLegacyKeyringCredentialsEvenWhenPrimaryConfigExists(t *testing.T) {
+	_, dest, _ := legacyHome(t)
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(dest, []byte(`default_model = "deepseek-flash/deepseek-chat"`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	legacyKeyringCredentialValueLookup = func(key string) (string, bool) {
+		if key == "DEEPSEEK_API_KEY" {
+			return "sk-old-keyring", true
+		}
+		return "", false
+	}
+
+	res, err := MigrateLegacyIfNeeded()
+	if err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if res != nil {
+		t.Fatalf("primary config exists, config migration should be skipped, got %+v", res)
+	}
+	data, err := os.ReadFile(UserCredentialsPath())
+	if err != nil {
+		t.Fatalf("read migrated credentials: %v", err)
+	}
+	if string(data) != "DEEPSEEK_API_KEY=sk-old-keyring\n" {
 		t.Fatalf("migrated credentials = %q", data)
 	}
 }

--- a/internal/config/model_fallback_test.go
+++ b/internal/config/model_fallback_test.go
@@ -7,7 +7,8 @@ import (
 
 func testModelFallbackConfig(t *testing.T) *Config {
 	t.Helper()
-	t.Setenv("REASONIX_TEST_KEY", "sk-test")
+	isolateTestCredentials(t)
+	setTestCredential(t, "REASONIX_TEST_KEY", "sk-test")
 	t.Setenv("REASONIX_TEST_EMPTY", "")
 
 	c := Default()

--- a/internal/config/render.go
+++ b/internal/config/render.go
@@ -57,7 +57,7 @@ func RenderTOMLForScope(c *Config, scope RenderScope) string {
 		b.WriteString("# language      = \"zh\"   # ui/model language; empty = auto-detect from $LANG / $REASONIX_LANG\n")
 	}
 	if scope != RenderScopeProject {
-		fmt.Fprintf(&b, "credentials_store = %q   # auto|keyring|file; auto prefers the OS keychain and falls back to ~/.reasonix/credentials\n", normalizeCredentialsStore(c.CredentialsStore))
+		fmt.Fprintf(&b, "credentials_store = %q   # deprecated; provider keys are saved in Reasonix home .env\n", normalizeCredentialsStore(c.CredentialsStore))
 	}
 	b.WriteString("\n")
 

--- a/internal/config/test_credentials_test.go
+++ b/internal/config/test_credentials_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func isolateTestCredentials(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+}
+
+func setTestCredential(t *testing.T, key, value string) {
+	t.Helper()
+	if _, err := SetCredential(key, value); err != nil {
+		t.Fatalf("SetCredential(%s): %v", key, err)
+	}
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("Unsetenv(%s): %v", key, err)
+	}
+}

--- a/internal/doctor/report_test.go
+++ b/internal/doctor/report_test.go
@@ -10,6 +10,15 @@ import (
 	"reasonix/internal/config"
 )
 
+func isolateDoctorConfigHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+}
+
 func TestRedactHome(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)        // os.UserHomeDir on unix
@@ -80,6 +89,7 @@ func TestCollectReportRedactsSecrets(t *testing.T) {
 }
 
 func TestCollectReportDoesNotRequireAPIKey(t *testing.T) {
+	isolateDoctorConfigHome(t)
 	t.Setenv("DEEPSEEK_API_KEY", "")
 
 	cfg := config.Default()

--- a/internal/i18n/messages_en.go
+++ b/internal/i18n/messages_en.go
@@ -19,7 +19,7 @@ var English = Messages{
 	StepSetKey:      "set API key",
 
 	InitHint:       "Project memory (AGENTS.md) is generated in-session: run `reasonix`, then `/init` — the model analyzes the codebase and writes it. For configuration, use `reasonix setup`.",
-	StepSetKeyHint: "run `reasonix setup`, or export DEEPSEEK_API_KEY=…",
+	StepSetKeyHint: "run `reasonix setup` to save DEEPSEEK_API_KEY",
 	StepChatDesc:   "interactive session",
 	StepRunDesc:    "one-shot task",
 	HelpFooter:     "reasonix help · all commands",
@@ -267,7 +267,7 @@ var English = Messages{
 	SetupComplete:         "Setup complete.",
 	SetupCancelled:        "setup cancelled.",
 	TryHintFmt:            "Try: %s",
-	NextHint:              "Next: set your API key (run `reasonix setup` or export DEEPSEEK_API_KEY=...), then run `reasonix run \"your task\"`.",
+	NextHint:              "Next: set your API key with `reasonix setup`, then run `reasonix run \"your task\"`.",
 	ConfirmReconfigureFmt: "%s already exists. Reconfigure and overwrite?",
 	KeepingExisting:       "Keeping existing config.",
 	NotOverwritingFmt:     "%s already exists; not overwriting",

--- a/internal/i18n/messages_zh.go
+++ b/internal/i18n/messages_zh.go
@@ -20,7 +20,7 @@ var Chinese = Messages{
 	StepSetKey:      "设置 API key",
 
 	InitHint:       "项目记忆（AGENTS.md）在会话内由模型生成：运行 `reasonix`，然后 `/init` —— 模型会分析代码库并写入。配置请用 `reasonix setup`。",
-	StepSetKeyHint: "运行 `reasonix setup`，或 export DEEPSEEK_API_KEY=…",
+	StepSetKeyHint: "运行 `reasonix setup` 保存 DEEPSEEK_API_KEY",
 	StepChatDesc:   "交互式会话",
 	StepRunDesc:    "执行单次任务",
 	HelpFooter:     "reasonix help · 查看全部命令",
@@ -268,7 +268,7 @@ var Chinese = Messages{
 	SetupComplete:         "设置完成。",
 	SetupCancelled:        "设置已取消。",
 	TryHintFmt:            "试试: %s",
-	NextHint:              "下一步：设置 API key（运行 `reasonix setup` 或 export DEEPSEEK_API_KEY=...），然后运行 `reasonix run \"你的任务\"`。",
+	NextHint:              "下一步：运行 `reasonix setup` 设置 API key，然后运行 `reasonix run \"你的任务\"`。",
 	ConfirmReconfigureFmt: "%s 已存在。重新配置并覆盖？",
 	KeepingExisting:       "保留原配置不变。",
 	NotOverwritingFmt:     "%s 已存在，不覆盖",

--- a/internal/i18n/messages_zh_tw.go
+++ b/internal/i18n/messages_zh_tw.go
@@ -20,7 +20,7 @@ var ChineseTraditional = Messages{
 	StepSetKey:      "設定 API key",
 
 	InitHint:       "專案記憶（AGENTS.md）在會話內由模型生成：執行 `reasonix`，然後 `/init` —— 模型會分析程式碼庫並寫入。設定請用 `reasonix setup`。",
-	StepSetKeyHint: "執行 `reasonix setup`，或 export DEEPSEEK_API_KEY=…",
+	StepSetKeyHint: "執行 `reasonix setup` 儲存 DEEPSEEK_API_KEY",
 	StepChatDesc:   "互動式會話",
 	StepRunDesc:    "執行單次任務",
 	HelpFooter:     "reasonix help · 檢視全部命令",
@@ -249,7 +249,7 @@ var ChineseTraditional = Messages{
 	SetupComplete:         "設定完成。",
 	SetupCancelled:        "設定已取消。",
 	TryHintFmt:            "試試: %s",
-	NextHint:              "下一步：設定 API key（執行 `reasonix setup` 或 export DEEPSEEK_API_KEY=...），然後執行 `reasonix run \"你的任務\"`。",
+	NextHint:              "下一步：執行 `reasonix setup` 設定 API key，然後執行 `reasonix run \"你的任務\"`。",
 	ConfirmReconfigureFmt: "%s 已存在。重新設定並覆蓋？",
 	KeepingExisting:       "保留原設定不變。",
 	NotOverwritingFmt:     "%s 已存在，不覆蓋",

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -614,7 +614,7 @@ func (e *AuthError) Error() string {
 	if e.KeySource != "" {
 		key += " from " + e.KeySource
 	}
-	return fmt.Sprintf("authentication failed for provider %q (HTTP %d): %s is invalid or expired — update it (in .env or your environment) and retry, or run `reasonix setup`",
+	return fmt.Sprintf("authentication failed for provider %q (HTTP %d): %s is invalid or expired — update it in Reasonix home .env, or run `reasonix setup`",
 		e.Provider, e.Status, key)
 }
 


### PR DESCRIPTION
## Summary
- Make Reasonix's global `<Reasonix home>/.env` the single runtime source for provider API keys.
- Stop loading provider credentials from project `.env`, home `.env`, inherited shell/Windows env vars, or the old keyring at runtime.
- Keep upgrade safety by migrating legacy credential files and former keyring values into the new global `.env` when missing.
- Update desktop/settings/CLI tests and docs to reflect the single-source behavior.

Fixes #5015.

## Verification
- `go test ./internal/config ./internal/boot ./internal/doctor ./internal/provider ./internal/i18n ./internal/control`
- `go test ./internal/cli -run "TestACPFactory|TestModelRefs|TestModelArgCompletion|TestPersistModel"`
- `cd desktop && go test . -run "TestProviderViewFromEntryShowsKeySource|TestSetProviderKey|TestSettings|TestDeleteProvider|TestBuildTabControllerIgnoresStaleSessionModelWhenTabModelResolves|TestFetchProviderModelsFiltersNonChatModels"`

## Notes
- Full `go test ./...` was attempted on Windows. Remaining failures were environment-specific or pre-existing: Windows symlink privilege, temp-directory file locks, a statusline test that shells out to `cat`, and a live DeepSeek cache probe returning 401 for the local key.