### PR TITLE
Fix transcript reveal signal and jump label / 修复正文 reveal 信号与跳底部文案

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -887,6 +887,7 @@ export default function App() {
   const [tabMetas, setTabMetas] = useState<TabMeta[]>([]);
   const [tabOrderIds, setTabOrderIds] = useState<string[]>([]);
   const [tabRevealSignal, setTabRevealSignal] = useState(0);
+  const [transcriptRevealSignal, setTranscriptRevealSignal] = useState(0);
   const [startupSplashVisible, setStartupSplashVisible] = useState<boolean>(() => shouldShowStartupSplash());
   // null until the mount probe resolves; true shows the overlay. Probed once —
   // clearing the key mid-session is the Settings panel's job, not the gate's.
@@ -1608,6 +1609,7 @@ export default function App() {
     setProjectRevision((value) => value + 1);
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
+    setTranscriptRevealSignal((signal) => signal + 1);
   }, [ensureBlankTab, refreshTabMetas]);
 
   useEffect(() => {
@@ -2111,6 +2113,7 @@ export default function App() {
     }
     await refreshTabMetas();
     setTabRevealSignal((signal) => signal + 1);
+    setTranscriptRevealSignal((signal) => signal + 1);
   }, [closeTransientOverlays, openGlobalTab, openProjectTab, openTopicSession, refreshTabMetas]);
 
   const openSidebarImConnectionSession = useCallback(async (connection: SidebarImConnection) => {
@@ -2134,6 +2137,7 @@ export default function App() {
       }
       await refreshTabMetas();
       setTabRevealSignal((value) => value + 1);
+      setTranscriptRevealSignal((value) => value + 1);
       setProjectRevision((value) => value + 1);
     } catch (err) {
       console.warn("bot sidebar open failed", err);
@@ -2185,6 +2189,7 @@ export default function App() {
         }
         await refreshTabMetas();
         setTabRevealSignal((value) => value + 1);
+        setTranscriptRevealSignal((value) => value + 1);
       } catch (err: any) {
         setHistView(null);
         if (scope === "project" && session.workspaceRoot) {
@@ -2999,7 +3004,7 @@ export default function App() {
                 creationMode={sidebarCreation}
                 actionHoverMenus={sidebarCreation}
                 rewindSignal={rewindSignal}
-                revealSignal={tabRevealSignal}
+                revealSignal={transcriptRevealSignal}
               />
             )}
           </main>

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const testDir = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(testDir, "../App.tsx"), "utf8");
 const appChromeSource = readFileSync(resolve(testDir, "../components/AppChrome.tsx"), "utf8");
+const transcriptSource = readFileSync(resolve(testDir, "../components/Transcript.tsx"), "utf8");
 const stylesSource = readFileSync(resolve(testDir, "../styles.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
 
 let passed = 0;
@@ -110,13 +111,32 @@ ok(
 );
 
 ok(
-  /\{!workbenchChromeHidden && \(/.test(appSource),
+  /\{!appChromeHidden && \(/.test(appSource),
   "workbench skips rendering the top AppChrome row",
 );
 
 ok(
   /topicbar__chrome-btn/.test(appSource),
   "workbench keeps chrome controls in the topic bar",
+);
+
+ok(
+  /const \[transcriptRevealSignal, setTranscriptRevealSignal\] = useState\(0\);/.test(appSource) &&
+    /revealActiveSignal=\{tabRevealSignal\}/.test(appSource) &&
+    /revealSignal=\{transcriptRevealSignal\}/.test(appSource),
+  "transcript bottom reveal is decoupled from tab-strip reveal",
+);
+
+const tabsReorderBlock = appSource.match(/const handleTabsReorder = useCallback\([\s\S]*?\n  \}, \[refreshTabMetas, reorderTabs\]\);/)?.[0] ?? "";
+ok(
+  /setTabRevealSignal/.test(tabsReorderBlock) && !/setTranscriptRevealSignal/.test(tabsReorderBlock),
+  "tab reordering refreshes the tab strip without snapping the transcript",
+);
+
+ok(
+  /aria-label=\{t\("transcript\.jumpToBottom"\)\}/.test(transcriptSource) &&
+    /title=\{t\("transcript\.jumpToBottom"\)\}/.test(transcriptSource),
+  "jump-to-bottom affordance uses localized transcript text",
 );
 
 for (const selector of [

--- a/desktop/frontend/src/components/Transcript.tsx
+++ b/desktop/frontend/src/components/Transcript.tsx
@@ -113,6 +113,7 @@ export function Transcript({
   rewindSignal?: number;
   revealSignal?: number;
 }) {
+  const t = useT();
   const {
     scrollRef,
     stick,
@@ -647,8 +648,8 @@ export function Transcript({
           type="button"
           className="transcript__jump-bottom"
           onClick={() => scrollToBottomAfterLayout(2)}
-          aria-label="Jump to bottom"
-          title="Jump to bottom"
+          aria-label={t("transcript.jumpToBottom")}
+          title={t("transcript.jumpToBottom")}
         >
           <ArrowDown size={18} strokeWidth={2.2} aria-hidden="true" />
         </button>

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1444,6 +1444,7 @@ export const en = {
   "msg.folderReference": "Folder · Workspace reference",
   "turnActions.summary": "Summary",
   "turnActions.rewind": "Rewind",
+  "transcript.jumpToBottom": "Jump to bottom",
   "transcript.showEarlierHistory": "Show {n} earlier turns",
   "transcript.toolCount": "{n} tools",
   "transcript.processed": "Processed",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -888,6 +888,7 @@ export const zhTW: Record<DictKey, string> = {
   "msg.folderReference": "資料夾 · 工作區引用",
   "turnActions.summary": "總結",
   "turnActions.rewind": "回溯",
+  "transcript.jumpToBottom": "跳到底部",
   "transcript.showEarlierHistory": "展開前 {n} 輪對話",
   "transcript.toolCount": "{n} 個工具",
   "transcript.processed": "已處理",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1446,6 +1446,7 @@ export const zh: Record<DictKey, string> = {
   "msg.folderReference": "文件夹 · 工作区引用",
   "turnActions.summary": "总结",
   "turnActions.rewind": "回溯",
+  "transcript.jumpToBottom": "跳到底部",
   "transcript.showEarlierHistory": "展开前 {n} 轮对话",
   "transcript.toolCount": "{n} 个工具",
   "transcript.processed": "已处理",


### PR DESCRIPTION
## Summary
- Decouple transcript bottom snapping from the tab-strip reveal signal so tab reordering cannot move the reader away from their current scroll position.
- Keep explicit transcript/session reveal paths snapping to the bottom after opening or resuming a session.
- Localize the jump-to-bottom button label for tooltip and screen-reader text.
- Add regression coverage for the separated reveal signals and localized button label.

## Follow-up
Addresses the bot review findings from #5029:
- https://github.com/esengine/DeepSeek-Reasonix/pull/5029#discussion_r3450923611
- https://github.com/esengine/DeepSeek-Reasonix/pull/5029#discussion_r3450923614

## Verification
- `pnpm --dir desktop/frontend exec tsx src/__tests__/app-chrome-tabs.test.ts`
- `pnpm --dir desktop/frontend typecheck`
- `pnpm --dir desktop/frontend check:css`
