### PR TITLE
ci(crash): auto-deploy crash worker on merge to main-v2

### DIFF
--- a/.github/workflows/deploy-crash-worker.yml
+++ b/.github/workflows/deploy-crash-worker.yml
@@ -1,0 +1,34 @@
+name: Deploy crash worker
+
+on:
+  push:
+    branches: [main-v2]
+    paths:
+      - 'workers/crash-report/**'
+      - '.github/workflows/deploy-crash-worker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-crash-worker
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: workers/crash-report/package-lock.json
+      - name: Deploy
+        working-directory: workers/crash-report
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: |
+          npm ci
+          npx wrangler deploy


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy-crash-worker.yml` — auto-deploys the
`reasonix-crash-report` Cloudflare Worker (`crash.reasonix.io`) to
production whenever `workers/crash-report/**` changes land on `main-v2`.
Also exposes `workflow_dispatch` for manual runs.

## Why

Until now shipping a crash-dashboard change meant a maintainer running
`wrangler deploy` locally with the Cloudflare token on their machine.
This lets the worker ship from CI on merge, so contributors can change
the dashboard without holding the production credential.

## Setup required before this helps

Add a repository secret **`CLOUDFLARE_API_TOKEN`** (Settings → Secrets
and variables → Actions). Scope the token to: Account → Workers Scripts
(Edit), Account → D1 (Edit), Zone → Workers Routes (Edit) on
`reasonix.io`. The account/D1 ids already live in `wrangler.toml`, so no
other config is needed.

Note: merging this PR triggers the workflow once (the workflow file is in
its own path filter), so set the secret first or the first run no-ops on
auth.
