### PR TITLE
Improve crash stats navigation / 改进崩溃统计导航

### DIFF
--- a/workers/crash-report/src/index.ts
+++ b/workers/crash-report/src/index.ts
@@ -4,7 +4,7 @@
 import { z } from "zod";
 import type { Env } from "./env";
 import { html, redirect } from "./shell";
-import { renderGroup, renderStats, type Group } from "./stats";
+import { renderGroup, renderStats, type Group, type StatsModule } from "./stats";
 import { renderLogin, renderRegister, renderAccount } from "./auth_pages";
 import { renderUsers, renderAudit, type UserRow, type AuditRow } from "./admin";
 import {
@@ -748,7 +748,7 @@ async function metricUserRows(env: Env, days: 7 | 30): Promise<{ signal: string;
   }
 }
 
-async function handleStats(request: Request, env: Env, user: User): Promise<Response> {
+async function handleStats(request: Request, env: Env, user: User, activeModule: StatsModule): Promise<Response> {
   const url = new URL(request.url);
   const filters = statsFilters(url);
   const latestVersion = await latestObservedVersion(env);
@@ -786,6 +786,7 @@ async function handleStats(request: Request, env: Env, user: User): Promise<Resp
         filters,
       },
       user,
+      activeModule,
     ),
   );
 }
@@ -945,7 +946,9 @@ export default {
       return user ? handleAccountPassword(request, env, user) : redirect("/login");
 
     const groupMatch = path.match(/^\/stats\/group\/([0-9a-f]{64})$/);
-    if (path === "/stats" && method === "GET") return requireViewer(user) ?? handleStats(request, env, user as User);
+    const statsModuleMatch = path.match(/^\/stats\/(diagnostics|usage|preferences|health)$/);
+    if ((path === "/stats" || statsModuleMatch) && method === "GET")
+      return requireViewer(user) ?? handleStats(request, env, user as User, (statsModuleMatch?.[1] as StatsModule | undefined) ?? "usage");
     if (groupMatch && method === "GET") return requireViewer(user) ?? handleGroup(env, groupMatch[1], user as User);
     if (groupMatch && method === "POST") {
       if (user?.role !== "admin") return new Response("forbidden", { status: 403 });

--- a/workers/crash-report/src/shell.ts
+++ b/workers/crash-report/src/shell.ts
@@ -25,6 +25,10 @@ header .crumb{color:var(--ink-3);font-size:15px}
 header .nav{display:flex;align-items:center;gap:14px}
 .navlink{color:var(--accent);text-decoration:none;font-size:14px;font-weight:500}
 .navlink:hover{text-decoration:underline}
+.site-nav{display:flex;align-items:center;gap:6px;margin:4px 0 10px}
+.site-nav a{display:inline-flex;align-items:center;min-height:34px;padding:7px 13px;border-radius:999px;color:var(--ink-2);text-decoration:none;font-size:14px;font-weight:600}
+.site-nav a:hover{background:var(--bg-soft);color:var(--ink)}
+.site-nav a.active,.site-nav a[aria-current="page"]{background:var(--accent-soft);color:var(--accent)}
 .chip{display:inline-flex;align-items:center;gap:8px;font-size:13.5px;color:var(--ink-2)}
 .lang-switch{margin-left:auto;display:inline-flex;align-items:center;gap:2px;padding:3px;border:1px solid var(--line);border-radius:12px;background:var(--bg-soft)}
 .lang-switch button{font:inherit;font-size:12.5px;font-weight:700;color:var(--ink-2);background:transparent;border:0;border-radius:9px;padding:5px 10px;cursor:pointer}
@@ -40,7 +44,7 @@ h1{font-size:30px;font-weight:600;letter-spacing:-0.02em;margin:18px 0 6px}
 .hero-line .sub{margin-bottom:18px}
 .segmented{display:inline-flex;align-items:center;gap:3px;padding:3px;border:1px solid var(--line);border-radius:13px;background:var(--bg-soft);white-space:nowrap}
 .segmented a{display:inline-flex;align-items:center;justify-content:center;min-height:30px;padding:6px 11px;border-radius:10px;color:var(--ink-2);text-decoration:none;font-size:12.5px;font-weight:700}
-.segmented a.active{background:#fff;color:var(--accent);box-shadow:var(--shadow-1)}
+.segmented a.active,.segmented a[aria-current="true"]{background:#fff;color:var(--accent);box-shadow:var(--shadow-1)}
 .overview-grid{display:grid;grid-template-columns:repeat(6,minmax(0,1fr));gap:10px;margin:0 0 20px}
 .overview-card{border:1px solid var(--line);border-radius:16px;background:linear-gradient(180deg,#fff,var(--bg-soft));padding:14px 15px;min-width:0;text-decoration:none}
 .overview-card:hover{border-color:color-mix(in oklch,var(--accent) 36%,var(--line));transform:translateY(-1px)}
@@ -52,6 +56,7 @@ h1{font-size:30px;font-weight:600;letter-spacing:-0.02em;margin:18px 0 6px}
 .module-nav{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:10px;margin:0 0 20px}
 .module-link{display:grid;grid-template-columns:1fr auto;grid-template-areas:"label value" "note note";gap:4px 10px;border:1px solid var(--line);border-radius:16px;background:#fff;color:var(--ink);text-decoration:none;padding:13px 14px;box-shadow:var(--shadow-1)}
 .module-link:hover{border-color:color-mix(in oklch,var(--accent) 36%,var(--line));background:var(--accent-soft)}
+.module-link.active,.module-link[aria-current="page"]{border-color:color-mix(in oklch,var(--accent) 45%,var(--line));background:var(--accent-soft)}
 .module-link span{grid-area:label;color:var(--ink-2);font-size:13px;font-weight:700}
 .module-link b{grid-area:value;font-family:var(--mono);font-size:13px;color:var(--accent)}
 .module-link small{grid-area:note;color:var(--ink-3);font-size:12.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
@@ -65,6 +70,7 @@ h1{font-size:30px;font-weight:600;letter-spacing:-0.02em;margin:18px 0 6px}
 .module-head{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-bottom:16px}
 .module-head span{display:block;font-size:11px;text-transform:uppercase;letter-spacing:.08em;color:var(--ink-3);font-weight:800;margin-bottom:4px}
 .module-head h2{margin:0;color:var(--ink);font-size:19px}
+.module-actions{display:flex;align-items:center;justify-content:flex-end;gap:10px;flex-wrap:wrap}
 .module-action{color:var(--accent);text-decoration:none;font-size:13.5px;font-weight:700;white-space:nowrap}
 .module-action:hover{text-decoration:underline}
 .module-panel{border:1px solid var(--line);border-radius:18px;background:var(--bg-soft);padding:16px 18px;margin-top:12px;min-width:0}
@@ -78,19 +84,22 @@ h1{font-size:30px;font-weight:600;letter-spacing:-0.02em;margin:18px 0 6px}
 .empty{color:var(--ink-3);font-size:14px;padding:14px 0}
 svg.chart{width:100%;height:auto;display:block}
 .bars-list{min-width:0}
-.row{display:grid;grid-template-columns:minmax(110px,210px) minmax(90px,1fr) 3.5em;align-items:center;gap:12px;padding:7px 0;font-size:14px;min-width:0}
+.row{display:grid;grid-template-columns:minmax(0,1.15fr) minmax(76px,1fr) minmax(3.8em,max-content);align-items:center;gap:12px;padding:7px 0;font-size:14px;min-width:0}
 .row+.row{border-top:1px solid var(--line)}
-.row-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.row-label{display:flex;align-items:center;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .row-bar{min-width:0}
 .row .bar{height:10px;border-radius:999px;background:linear-gradient(90deg,#4f9dff,#7a6bff);min-width:4px}
-.row .n{text-align:right;font-family:var(--mono);font-size:13px;color:var(--ink-2)}
+.row .n{text-align:right;font-family:var(--mono);font-size:13px;color:var(--ink-2);white-space:nowrap}
 .bucket-prefix{display:inline-flex;align-items:center;margin-right:6px;padding:1px 6px;border-radius:8px;background:var(--accent-soft);color:var(--accent);font-size:12px;font-weight:700}
-.bucket-main{min-width:0}
+.bucket-main{display:inline-block;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .bars-more{margin-top:6px}
 .bars-more summary{display:inline-flex;align-items:center;min-height:30px;padding:5px 9px;border:1px dashed var(--line);border-radius:10px;background:#fff;color:var(--accent);font-size:12.5px;font-weight:700;cursor:pointer;list-style:none}
 .bars-more summary::-webkit-details-marker{display:none}
 .bars-more summary:hover{border-color:color-mix(in oklch,var(--accent) 34%,var(--line))}
-.bars-more-list{max-height:220px;overflow:auto;margin-top:7px;padding:5px 8px;border:1px solid var(--line);border-radius:12px;background:#fff}
+.bars-more .more-open{display:none}
+.bars-more[open] .more-closed{display:none}
+.bars-more[open] .more-open{display:inline}
+.bars-more-list{max-height:260px;overflow-y:auto;overflow-x:hidden;margin-top:7px;padding:5px 8px;border:1px solid var(--line);border-radius:12px;background:#fff}
 table{border-collapse:collapse;width:100%;font-size:14px}
 th{text-align:left;color:var(--ink-3);font-weight:500;font-size:12.5px;padding:0 14px 8px 0}
 td{padding:8px 14px 8px 0;border-top:1px solid var(--line);vertical-align:middle}
@@ -115,16 +124,23 @@ font-size:12.5px;line-height:1.55;overflow:auto;white-space:pre-wrap;word-break:
 .metric-block h3{display:flex;align-items:center;justify-content:space-between;gap:8px;font-family:var(--mono);font-size:12.5px;font-weight:600;color:var(--ink-2);margin:6px 0 4px}
 .metric-block h3 span{font-family:var(--mono);font-size:11px;color:var(--ink-3);font-weight:600}
 .preference-dashboard{display:flex;flex-direction:column;gap:14px}
+.preference-compare{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px;align-items:start}
+.preference-panel{background:#fff}
+.preference-panel.active{border-color:color-mix(in oklch,var(--accent) 42%,var(--line));box-shadow:0 0 0 3px var(--accent-soft)}
 .pref-section{border:1px solid var(--line);border-radius:14px;background:#fff;padding:14px 15px}
 .pref-section>h3,.pref-section summary h3{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:13px;font-weight:700;color:var(--ink);margin:0 0 10px}
 .pref-section>h3 span,.pref-section summary h3 span{font-size:11.5px;color:var(--ink-3);font-weight:700;white-space:nowrap}
 .pref-section summary{cursor:pointer;list-style:none}
 .pref-section summary::-webkit-details-marker{display:none}
 .pref-section summary h3{margin:0}
+.pref-section summary h3::after{content:"+";font-family:var(--mono);font-size:13px;color:var(--accent);line-height:1}
+.pref-section[open] summary h3::after{content:"-"}
 .pref-section[open] summary h3{margin-bottom:10px}
 .pref-section-collapsed summary:hover h3{color:var(--accent)}
 .pref-section .metric-block h3{color:var(--ink-3)}
-.pref-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}
+.pref-metrics{grid-template-columns:1fr;gap:12px}
+.pref-metrics .metric-block{min-width:0}
+.pref-metrics .row{grid-template-columns:minmax(7rem,1.2fr) minmax(5rem,.9fr) minmax(4.4em,max-content)}
 .health-grid{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:12px}
 .health-card{border:1px solid var(--line);border-radius:16px;background:var(--bg-soft);padding:14px 15px;min-width:0}
 .health-card.good{background:oklch(0.985 0.015 150);border-color:oklch(0.88 0.05 150)}
@@ -258,23 +274,25 @@ form.inline{display:inline}
 td select{width:auto;padding:6px 10px;border-radius:10px}
 .note-edit{margin-top:12px;display:flex;gap:8px;max-width:560px}
 .note-edit input{flex:1}
-@media(max-width:1100px){.overview-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.module-nav{grid-template-columns:repeat(2,minmax(0,1fr))}.health-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.module-split,.module-split.wide{grid-template-columns:1fr}}
+@media(max-width:1100px){.overview-grid{grid-template-columns:repeat(3,minmax(0,1fr))}.module-nav{grid-template-columns:repeat(2,minmax(0,1fr))}.health-grid{grid-template-columns:repeat(2,minmax(0,1fr))}.module-split,.module-split.wide,.preference-compare{grid-template-columns:1fr}}
 @media(max-width:900px){.hero-line{flex-direction:column}.facet-grid{grid-template-columns:1fr}.crash-head{display:none}.crash-item,.crash-list.compact .crash-item{grid-template-columns:1fr;gap:10px}
-.crash-health{justify-content:flex-start}.crash-count{text-align:left}.filter-head,.module-head{align-items:flex-start;flex-direction:column;gap:8px}
+.crash-health{justify-content:flex-start}.crash-count{text-align:left}.filter-head,.module-head{align-items:flex-start;flex-direction:column;gap:8px}.module-actions{justify-content:flex-start}
 .group-metrics{grid-template-columns:1fr 1fr}.sample summary{grid-template-columns:1fr}.sample-time{text-align:left}.manage-head{flex-direction:column}.manage-actions{justify-content:flex-start}.manage-grid{grid-template-columns:1fr}.manage-form.wide{grid-column:auto}}
-@media(max-width:760px){header{height:auto;min-height:68px;flex-wrap:wrap;padding:14px 0}.lang-switch{margin-left:0}.nav{width:100%;flex-wrap:wrap;gap:8px}.chip{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis}.grid{grid-template-columns:1fr}.overview-grid,.module-nav,.health-grid{grid-template-columns:1fr}.metrics,.pref-metrics{grid-template-columns:1fr}.row{grid-template-columns:minmax(0,1fr) minmax(70px,.8fr) 3.2em}.card-title-row{align-items:flex-start;flex-direction:column}.filter-card{position:static}.wrap{padding:0 16px 48px}}
+@media(max-width:760px){header{height:auto;min-height:68px;flex-wrap:wrap;padding:14px 0}.lang-switch{margin-left:0}.nav{width:100%;flex-wrap:wrap;gap:8px}.site-nav{overflow-x:auto;padding-bottom:2px}.site-nav a{white-space:nowrap}.chip{min-width:0;max-width:100%;overflow:hidden;text-overflow:ellipsis}.grid{grid-template-columns:1fr}.overview-grid,.module-nav,.health-grid{grid-template-columns:1fr}.metrics,.pref-metrics{grid-template-columns:1fr}.row{grid-template-columns:minmax(0,1fr) minmax(70px,.8fr) 3.2em}.card-title-row{align-items:flex-start;flex-direction:column}.filter-card{position:static}.wrap{padding:0 16px 48px}}
 `;
 
 const LANG_SWITCH = `<span class="lang-switch" role="group" aria-label="Language"><button type="button" data-lang-option="zh">中文</button><button type="button" data-lang-option="en">EN</button></span>`;
 
 const LANG_SCRIPT = `<script>(()=>{const k="reasonix.stats.lang";const b=[...document.querySelectorAll("[data-lang-option]")];const pick=()=>{try{return localStorage.getItem(k)}catch{return""}};const fallback=()=>((navigator.language||"").toLowerCase().startsWith("zh")?"zh":"en");const set=(v)=>{const lang=v==="en"?"en":"zh";document.body.dataset.lang=lang;b.forEach((x)=>{const on=x.dataset.langOption===lang;x.classList.toggle("active",on);x.setAttribute("aria-pressed",String(on))});try{localStorage.setItem(k,lang)}catch{}};b.forEach((x)=>x.addEventListener("click",()=>set(x.dataset.langOption||"zh")));set(pick()||fallback())})();(()=>{const fallback=(t)=>{const a=document.createElement("textarea");a.value=t;a.setAttribute("readonly","");a.style.position="fixed";a.style.opacity="0";document.body.appendChild(a);a.select();let ok=false;try{ok=document.execCommand("copy")}catch{}a.remove();return ok};document.addEventListener("click",async(e)=>{const b=e.target.closest("[data-copy]");if(!b)return;const t=b.dataset.copy||"";let ok=false;try{if(navigator.clipboard){await navigator.clipboard.writeText(t);ok=true}}catch{}if(!ok)ok=fallback(t);b.dataset.state=ok?"copied":"failed";setTimeout(()=>{delete b.dataset.state},1400)})})()</script>`;
 
+const STATS_ROUTE_SCRIPT = `<script>(()=>{if(location.pathname!=="/stats"||!location.hash)return;const m={diagnostics:"diagnostics",usage:"",preferences:"preferences",health:"health"};const key=location.hash.slice(1);if(m[key]===undefined)return;location.replace("/stats"+(m[key]?"/"+m[key]:"")+location.search)})()</script>`;
+
 export function page(title: string, crumb: string, body: string, nav = ""): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1"><meta name="robots" content="noindex">
 <title>${esc(title)}</title><style>${CSS}</style></head><body><div class="wrap">
 <header><a class="brand" href="https://reasonix.io">${LOGO}</a><a class="brand" href="https://reasonix.io">Reasonix</a><span class="crumb">/ ${esc(crumb)}</span>${LANG_SWITCH}${nav ? `<span class="nav">${nav}</span>` : ""}</header>
-${body}</div>${LANG_SCRIPT}</body></html>`;
+${body}</div>${LANG_SCRIPT}${STATS_ROUTE_SCRIPT}</body></html>`;
 }
 
 export function html(body: string): Response {

--- a/workers/crash-report/src/stats.ts
+++ b/workers/crash-report/src/stats.ts
@@ -18,6 +18,8 @@ type OverviewCounts = {
   criticalOpenReports: number;
 };
 
+export type StatsModule = "diagnostics" | "usage" | "preferences" | "health";
+
 function lastDays(rows: Daily[], count: 7 | 30): Daily[] {
   const byDate = new Map(rows.map((r) => [r.date, r]));
   const out: Daily[] = [];
@@ -111,7 +113,10 @@ function listBars(rows: BarRow[], options: BarListOptions = {}): string {
   const className = options.className ? ` ${esc(options.className)}` : "";
   const visibleRows = visible.map((r) => barRow(r, max, options.labelFormatter)).join("");
   if (!hidden.length) return `<div class="bars-list${className}">${visibleRows}</div>`;
-  return `<div class="bars-list${className}">${visibleRows}<details class="bars-more"><summary>${i18nHTML(`More ${hidden.length}`, `更多 ${hidden.length}`)}</summary><div class="bars-more-list">${hidden
+  return `<div class="bars-list${className}">${visibleRows}<details class="bars-more"><summary><span class="more-closed">${i18nHTML(
+    `Show ${hidden.length} more`,
+    `展开 ${hidden.length} 项`,
+  )}</span><span class="more-open">${i18nHTML(`Hide ${hidden.length}`, `收起 ${hidden.length} 项`)}</span></summary><div class="bars-more-list">${hidden
     .map((r) => barRow(r, max, options.labelFormatter))
     .join("")}</div></details></div>`;
 }
@@ -458,8 +463,13 @@ function topSeverityTone(openReports: number, regressedReports: number, critical
   return "good";
 }
 
-function moduleLink(href: string, label: { en: string; zh: string }, value: string, note: { en: string; zh: string }): string {
-  return `<a class="module-link" href="${esc(href)}"><span>${i18n(label.en, label.zh)}</span><b>${esc(value)}</b><small>${i18n(note.en, note.zh)}</small></a>`;
+function navLink(href: string, label: { en: string; zh: string }, active = false): string {
+  return `<a${active ? ` class="active" aria-current="page"` : ""} href="${esc(href)}">${i18n(label.en, label.zh)}</a>`;
+}
+
+function preferencePanel(title: string, body: string, active: boolean): string {
+  return `<section class="module-panel preference-panel${active ? " active" : ""}"${active ? ` aria-current="true"` : ""}>
+<h3>${title}</h3>${body}</section>`;
 }
 
 function reportGroups(rows: CrashRow[], compact = false): string {
@@ -506,6 +516,7 @@ export function renderStats(
     };
   },
   user: User,
+  activeModule: StatsModule = "usage",
 ): string {
   const days = lastDays(data.daily, data.filters.windowDays);
   const range = data.filters.windowDays;
@@ -520,7 +531,8 @@ export function renderStats(
   const providerRate = ratioPer100(agentMetrics, "provider_error");
   const toolRate = ratioPer100(agentMetrics, "tool_error");
   const healthWatchCount = [healthLevel("cache", cache), healthLevel("rate", providerRate), healthLevel("rate", toolRate)].filter((v) => v === "warn" || v === "bad").length;
-  const filterQS = (patch: Record<string, string>) => {
+  const modulePath = (module: StatsModule) => (module === "usage" ? "/stats" : `/stats/${module}`);
+  const filterQS = (patch: Record<string, string>, module: StatsModule = activeModule) => {
     const params = new URLSearchParams();
     const put = (k: string, v: string) => {
       if (v) params.set(k, v);
@@ -533,40 +545,46 @@ export function renderStats(
     if (data.filters.newLatest) params.set("new", "latest");
     if (data.filters.regressed) params.set("regressed", "1");
     if (data.filters.windowDays === 30) params.set("window", "30d");
-    if (data.filters.preferenceMode === "opens") params.set("prefs", "opens");
+    if (module === "preferences" && data.filters.preferenceMode === "opens") params.set("prefs", "opens");
     for (const [k, v] of Object.entries(patch)) {
       if (v) params.set(k, v);
       else params.delete(k);
     }
     const qs = params.toString();
-    return qs ? `/stats?${qs}` : "/stats";
+    const path = modulePath(module);
+    return qs ? `${path}?${qs}` : path;
   };
   const clearFiltersHref = filterQS({ status: "", source: "", version: "", os: "", platform: "", new: "", regressed: "" });
   const hasFilters = Boolean(
     data.filters.status || data.filters.source || data.filters.version || data.filters.os || data.filters.platform || data.filters.newLatest || data.filters.regressed,
   );
   const windowControls = `<div class="segmented" aria-label="Time window">
-<a class="${range === 7 ? "active" : ""}" href="${esc(filterQS({ window: "7d" }))}">7d</a>
-<a class="${range === 30 ? "active" : ""}" href="${esc(filterQS({ window: "30d" }))}">30d</a>
+<a class="${range === 7 ? "active" : ""}"${range === 7 ? ` aria-current="true"` : ""} href="${esc(filterQS({ window: "7d" }))}">7d</a>
+<a class="${range === 30 ? "active" : ""}"${range === 30 ? ` aria-current="true"` : ""} href="${esc(filterQS({ window: "30d" }))}">30d</a>
 </div>`;
   const preferenceControls = `<div class="segmented" aria-label="Preference metric mode">
-<a class="${data.filters.preferenceMode === "users" ? "active" : ""}" href="${esc(filterQS({ prefs: "" }))}">${i18n("Installs", "按安装")}</a>
-<a class="${data.filters.preferenceMode === "opens" ? "active" : ""}" href="${esc(filterQS({ prefs: "opens" }))}">${i18n("Opens", "按启动")}</a>
+<a class="${data.filters.preferenceMode === "users" ? "active" : ""}"${data.filters.preferenceMode === "users" ? ` aria-current="true"` : ""} href="${esc(
+    filterQS({ prefs: "" }, "preferences"),
+  )}">${i18n("Installs", "按安装")}</a>
+<a class="${data.filters.preferenceMode === "opens" ? "active" : ""}"${data.filters.preferenceMode === "opens" ? ` aria-current="true"` : ""} href="${esc(
+    filterQS({ prefs: "opens" }, "preferences"),
+  )}">${i18n("Opens", "按启动")}</a>
 </div>`;
   const overviewTone = topSeverityTone(data.overview.openReports, data.overview.regressedReports, data.overview.criticalOpenReports);
   const overview = `<section class="overview-grid">
-${statCard({ en: "Active today", zh: "今日活跃" }, String(totalUsers), i18n("anonymous installs", "匿名安装"), "#usage")}
-${statCard({ en: "Latest adoption", zh: "最新版本占比" }, latestVersionShare(data.overview.latestAdoptionPct), i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`), "#usage")}
-${statCard({ en: "Open reports", zh: "未处理报告" }, String(data.overview.openReports), i18n("needs triage", "需要分诊"), "#diagnostics", overviewTone)}
-${statCard({ en: "New in latest", zh: "最新新增" }, String(data.overview.newLatestReports), i18n("first seen on latest", "首次出现在最新版"), "#diagnostics", data.overview.newLatestReports ? "warn" : "good")}
-${statCard({ en: "Regressions", zh: "回归问题" }, String(data.overview.regressedReports), i18n("previously resolved", "曾经解决后复现"), "#diagnostics", data.overview.regressedReports ? "bad" : "good")}
-${statCard({ en: "Agent health", zh: "运行健康" }, healthWatchCount ? String(healthWatchCount) : "OK", i18nHTML(`${pct(cache)} cache · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 provider`, `${pct(cache)} 缓存 · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 Provider`), "#health", healthWatchCount ? "warn" : "good")}
+${statCard({ en: "Active today", zh: "今日活跃" }, String(totalUsers), i18n("anonymous installs", "匿名安装"), filterQS({}, "usage"))}
+${statCard({ en: "Latest adoption", zh: "最新版本占比" }, latestVersionShare(data.overview.latestAdoptionPct), i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`), filterQS({}, "usage"))}
+${statCard({ en: "Open reports", zh: "未处理报告" }, String(data.overview.openReports), i18n("needs triage", "需要分诊"), filterQS({}, "diagnostics"), overviewTone)}
+${statCard({ en: "New in latest", zh: "最新新增" }, String(data.overview.newLatestReports), i18n("first seen on latest", "首次出现在最新版"), filterQS({}, "diagnostics"), data.overview.newLatestReports ? "warn" : "good")}
+${statCard({ en: "Regressions", zh: "回归问题" }, String(data.overview.regressedReports), i18n("previously resolved", "曾经解决后复现"), filterQS({}, "diagnostics"), data.overview.regressedReports ? "bad" : "good")}
+${statCard({ en: "Agent health", zh: "运行健康" }, healthWatchCount ? String(healthWatchCount) : "OK", i18nHTML(`${pct(cache)} cache · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 provider`, `${pct(cache)} 缓存 · ${providerRate === null ? "n/a" : Number(providerRate.toFixed(1))}/100 Provider`), filterQS({}, "health"), healthWatchCount ? "warn" : "good")}
 </section>`;
-  const modules = `<nav class="module-nav" aria-label="Stats modules">
-${moduleLink("#diagnostics", { en: "Diagnostics", zh: "诊断分诊" }, String(data.crashes.length), { en: "prioritized report groups", zh: "按优先级排列的报告分组" })}
-${moduleLink("#usage", { en: "Usage", zh: "使用分布" }, rangeText, { en: "activity, versions, platforms", zh: "活跃、版本和平台" })}
-${moduleLink("#preferences", { en: "Preferences", zh: "设置偏好" }, data.filters.preferenceMode === "opens" ? "opens" : "installs", { en: "deduped and launch snapshots", zh: "安装去重与启动快照" })}
-${moduleLink("#health", { en: "Agent Health", zh: "运行健康" }, healthWatchCount ? String(healthWatchCount) : "OK", { en: "cache and error signals", zh: "缓存与错误信号" })}
+  const pageOverview = activeModule === "usage" ? overview : "";
+  const dashboardNav = `<nav class="site-nav" aria-label="Stats navigation">
+${navLink(filterQS({}, "usage"), { en: "Home", zh: "主页" }, activeModule === "usage")}
+${navLink(filterQS({}, "diagnostics"), { en: "Diagnostics", zh: "诊断分诊" }, activeModule === "diagnostics")}
+${navLink(filterQS({}, "preferences"), { en: "Preferences", zh: "设置偏好" }, activeModule === "preferences")}
+${navLink(filterQS({}, "health"), { en: "Agent Health", zh: "运行健康" }, activeModule === "health")}
 </nav>`;
   const filters = `<div class="filter-card"><div class="filter-head"><h2>${i18n("Report filters", "诊断筛选")}</h2><span>${i18nHTML(`latest ${esc(data.latestVersion || "n/a")}`, `最新 ${esc(data.latestVersion || "n/a")}`)}</span></div>
 <div class="filter-tabs">
@@ -582,7 +600,7 @@ ${filterTab("Regressed", "回归", filterQS({ regressed: data.filters.regressed 
 <section><h3>${i18n("Version", "版本")}</h3><div class="facet-list">${facetChips(data.versions, data.filters.version, (label) => filterQS({ version: label }), 5)}</div></section>
 <section><h3>${i18n("Platform", "平台")}</h3><div class="facet-list">${facetChips(data.platforms, data.filters.platform, (label) => filterQS({ platform: label }), 4)}</div></section>
 </div></div>`;
-  const usageModule = `<section id="usage" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Usage distribution", "使用分布")}</h2></div>${windowControls}</div>
+  const usageModule = `<section id="usage" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Usage distribution", "使用分布")}</h2></div></div>
 <div class="module-panel wide"><h3>${i18nHTML(`Daily active installs <b>— ${rangeText}</b> (solid: users, faded: opens)`, `每日活跃 <b>— ${rangeText}</b>（实线：用户，淡色：打开次数）`)}</h3>
 ${anyPing ? dailyChart(days) : `<div class="empty">${i18n("No pings yet — data starts flowing once a telemetry-enabled build ships", "暂无启动 ping — 等带统计的版本发布后这里开始有数据")}</div>`}</div>
 <div class="module-split">
@@ -594,30 +612,41 @@ ${anyPing ? dailyChart(days) : `<div class="empty">${i18n("No pings yet — data
 ${filters}
 <section class="module-panel"><h3>${i18nHTML("All report groups <b>— open, regression, severity, count, recency</b>", "全部诊断分组 <b>— 未处理、回归、严重性、次数和最近出现</b>")}</h3>${reportGroups(data.crashes)}</section>
 </section>`;
-  const preferencesModule = `<section id="preferences" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Settings preferences", "设置偏好")}</h2></div>${preferenceControls}</div>
-<div class="module-split wide">
-<section class="module-panel"><h3>${i18nHTML(`Deduplicated installs <b>— ${rangeText}</b>`, `按安装去重 <b>— ${rangeText}</b>`)}</h3>${settingsDashboard(settingsMetricUsers, { collapseSections: true })}</section>
-<section class="module-panel"><h3>${i18nHTML(`Launch/open snapshots <b>— ${rangeText}</b>`, `启动/开启快照 <b>— ${rangeText}</b>`)}</h3>${settingsDashboard(settingsMetrics, { collapseSections: true })}</section>
-</div></section>`;
-  const healthModule = `<section id="health" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Agent health", "运行健康")}</h2></div><a class="module-action" href="#preferences">${i18n("Preferences", "设置偏好")}</a></div>
+  const installsPanel = preferencePanel(
+    i18nHTML(`Deduplicated installs <b>— ${rangeText}</b>`, `按安装去重 <b>— ${rangeText}</b>`),
+    settingsDashboard(settingsMetricUsers, { collapseSections: true }),
+    data.filters.preferenceMode === "users",
+  );
+  const opensPanel = preferencePanel(
+    i18nHTML(`Launch/open snapshots <b>— ${rangeText}</b>`, `启动/开启快照 <b>— ${rangeText}</b>`),
+    settingsDashboard(settingsMetrics, { collapseSections: true }),
+    data.filters.preferenceMode === "opens",
+  );
+  const preferencePanels = data.filters.preferenceMode === "opens" ? `${opensPanel}${installsPanel}` : `${installsPanel}${opensPanel}`;
+  const preferencesModule = `<section id="preferences" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Settings preferences", "设置偏好")}</h2></div><div class="module-actions">${preferenceControls}</div></div>
+<div class="preference-compare">${preferencePanels}</div></section>`;
+  const healthModule = `<section id="health" class="card full module-card"><div class="module-head"><div><span>${i18n("Module", "模块")}</span><h2>${i18n("Agent health", "运行健康")}</h2></div><div class="module-actions"><a class="module-action" href="${esc(filterQS({}, "preferences"))}">${i18n("Preferences", "设置偏好")}</a></div></div>
 <section class="module-panel"><h3>${i18nHTML(`Health summary <b>— ${rangeText}, compared with previous window</b>`, `健康摘要 <b>— ${rangeText}，对比上一窗口</b>`)}</h3>${agentHealth(agentMetrics, previousAgentMetrics)}</section>
 <section class="module-panel"><h3>${i18nHTML(`Signal distributions <b>— ${rangeText}, opt-in aggregate</b>`, `信号分布 <b>— ${rangeText}，opt-in 汇总</b>`)}</h3>${metricsCards(agentMetrics)}</section>
 </section>`;
+  const activeModuleHTML: Record<StatsModule, string> = {
+    diagnostics: diagnosticsModule,
+    usage: usageModule,
+    preferences: preferencesModule,
+    health: healthModule,
+  };
 
   return page(
     "Reasonix · Crash & Telemetry",
     "health",
-    `<div id="top" class="hero-line"><div><h1>${i18n("Crash & Telemetry", "桌面端健康看板")}</h1><p class="sub">${i18nHTML(
+    `${dashboardNav}
+<div id="top" class="hero-line"><div><h1>${i18n("Crash & Telemetry", "桌面端健康看板")}</h1><p class="sub">${i18nHTML(
       `${rangeText} window · anonymous launch pings, opt-in aggregate metrics, and user-sent diagnostic reports only`,
       `${rangeText} 时间窗口 · 仅包含匿名启动 ping、opt-in 汇总指标和用户发送的诊断报告`,
     )}</p></div>${windowControls}</div>
-${overview}
-${modules}
+${pageOverview}
 <div class="grid">
-${diagnosticsModule}
-${usageModule}
-${preferencesModule}
-${healthModule}
+${activeModuleHTML[activeModule]}
 </div>`,
     userNav(user),
   );


### PR DESCRIPTION
## Summary
- split crash stats modules into route-backed views and make `/stats` the home usage view
- move stats module navigation into a compact top nav and keep overview KPI cards only on the home view
- tighten settings preference layout, overflow handling, and show/hide affordances

## Verification
- npm run typecheck
- git diff --check
- verified the rendered dashboard preview for home, diagnostics, and preference layout behavior