### PR TITLE
Fix session trash sidecars / 修复会话回收站旁路文件

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -39,7 +39,6 @@ import (
 	"reasonix/internal/fileref"
 	fileenc "reasonix/internal/fileutil/encoding"
 	"reasonix/internal/i18n"
-	"reasonix/internal/jobs"
 	"reasonix/internal/mcpdiag"
 	"reasonix/internal/memory"
 	"reasonix/internal/plugin"
@@ -1123,14 +1122,7 @@ func removeDesktopSessionArtifacts(path string) error {
 	if strings.TrimSpace(path) == "" {
 		return nil
 	}
-	if err := jobs.RemoveArtifacts(path); err != nil {
-		return err
-	}
-	paths := []string{path, agent.BranchMetaPath(path)}
-	if strings.HasSuffix(path, ".jsonl") {
-		paths = append(paths, strings.TrimSuffix(path, ".jsonl")+".ckpt")
-	}
-	for _, p := range paths {
+	for _, p := range sessionOwnedArtifactPaths(path) {
 		if strings.TrimSpace(p) == "" {
 			continue
 		}

--- a/desktop/sessions.go
+++ b/desktop/sessions.go
@@ -15,7 +15,7 @@ import (
 	"reasonix/internal/config"
 	"reasonix/internal/control"
 	"reasonix/internal/fileutil"
-	"reasonix/internal/jobs"
+	"reasonix/internal/store"
 )
 
 // sessions.go holds the desktop-only session-management state that the shared
@@ -125,6 +125,42 @@ type trashedSessionMeta struct {
 	DeletedAt int64  `json:"deletedAt"`
 }
 
+type sessionTrashArtifact struct {
+	src  string
+	name string
+}
+
+func sessionTelemetryPath(sessionPath string) string {
+	if strings.TrimSpace(sessionPath) == "" {
+		return ""
+	}
+	return sessionPath + ".telemetry.json"
+}
+
+func sessionTrashArtifacts(sessionPath, key string) []sessionTrashArtifact {
+	stem := strings.TrimSuffix(key, ".jsonl")
+	return []sessionTrashArtifact{
+		{src: sessionPath, name: key},
+		{src: store.SessionMeta(sessionPath), name: key + ".meta"},
+		{src: store.SessionGoalState(sessionPath), name: stem + ".goal-state.json"},
+		{src: sessionTelemetryPath(sessionPath), name: key + ".telemetry.json"},
+		{src: store.SessionCheckpointDir(sessionPath), name: stem + ".ckpt"},
+		{src: store.SessionJobsDir(sessionPath), name: stem + ".jobs"},
+	}
+}
+
+func sessionOwnedArtifactPaths(sessionPath string) []string {
+	key := filepath.Base(sessionPath)
+	artifacts := sessionTrashArtifacts(sessionPath, key)
+	paths := make([]string, 0, len(artifacts))
+	for _, artifact := range artifacts {
+		if strings.TrimSpace(artifact.src) != "" {
+			paths = append(paths, artifact.src)
+		}
+	}
+	return paths
+}
+
 func trashSessionArtifacts(dir, sessionPath, key string) error {
 	return trashSessionArtifactsBeforeMove(dir, sessionPath, key, nil)
 }
@@ -147,19 +183,10 @@ func reconcileDesktopTrashSessionArtifacts(dir, sessionPath, key string) error {
 	if err := os.MkdirAll(itemDir, 0o755); err != nil {
 		return err
 	}
-	if err := movePathIfExists(sessionPath, filepath.Join(itemDir, key)); err != nil {
-		return err
-	}
-	if err := movePathIfExists(sessionPath+".meta", filepath.Join(itemDir, key+".meta")); err != nil {
-		return err
-	}
-	ckptName := strings.TrimSuffix(key, ".jsonl") + ".ckpt"
-	if err := movePathIfExists(strings.TrimSuffix(sessionPath, ".jsonl")+".ckpt", filepath.Join(itemDir, ckptName)); err != nil {
-		return err
-	}
-	jobsName := strings.TrimSuffix(key, ".jsonl") + ".jobs"
-	if err := movePathIfExists(jobs.ArtifactDir(sessionPath), filepath.Join(itemDir, jobsName)); err != nil {
-		return err
+	for _, artifact := range sessionTrashArtifacts(sessionPath, key) {
+		if err := movePathIfExists(artifact.src, filepath.Join(itemDir, artifact.name)); err != nil {
+			return err
+		}
 	}
 	if err := trashSubagentArtifacts(dir, sessionPath, itemDir); err != nil {
 		return err
@@ -206,19 +233,10 @@ func trashSessionArtifactsBeforeMove(dir, sessionPath, key string, beforeMove fu
 	if beforeMove != nil {
 		beforeMove()
 	}
-	if err := movePathIfExists(sessionPath, filepath.Join(itemDir, key)); err != nil {
-		return err
-	}
-	if err := movePathIfExists(sessionPath+".meta", filepath.Join(itemDir, key+".meta")); err != nil {
-		return err
-	}
-	ckptName := strings.TrimSuffix(key, ".jsonl") + ".ckpt"
-	if err := movePathIfExists(strings.TrimSuffix(sessionPath, ".jsonl")+".ckpt", filepath.Join(itemDir, ckptName)); err != nil {
-		return err
-	}
-	jobsName := strings.TrimSuffix(key, ".jsonl") + ".jobs"
-	if err := movePathIfExists(jobs.ArtifactDir(sessionPath), filepath.Join(itemDir, jobsName)); err != nil {
-		return err
+	for _, artifact := range sessionTrashArtifacts(sessionPath, key) {
+		if err := movePathIfExists(artifact.src, filepath.Join(itemDir, artifact.name)); err != nil {
+			return err
+		}
 	}
 	if err := trashSubagentArtifacts(dir, sessionPath, itemDir); err != nil {
 		return err
@@ -280,7 +298,7 @@ func trashedSessionDeletedAt(path string) int64 {
 }
 
 func restoreTrashedSessionFile(dir, path string) error {
-	trashPath, key, itemDir, err := validateTrashedSessionPath(dir, path)
+	_, key, itemDir, err := validateTrashedSessionPath(dir, path)
 	if err != nil {
 		return err
 	}
@@ -296,19 +314,10 @@ func restoreTrashedSessionFile(dir, path string) error {
 	if err := checkRestoreSubagentConflicts(dir, itemDir); err != nil {
 		return err
 	}
-	if err := movePathIfExists(trashPath, target); err != nil {
-		return err
-	}
-	if err := movePathIfExists(trashPath+".meta", target+".meta"); err != nil {
-		return err
-	}
-	ckptName := strings.TrimSuffix(key, ".jsonl") + ".ckpt"
-	if err := movePathIfExists(filepath.Join(itemDir, ckptName), filepath.Join(dir, ckptName)); err != nil {
-		return err
-	}
-	jobsName := strings.TrimSuffix(key, ".jsonl") + ".jobs"
-	if err := movePathIfExists(filepath.Join(itemDir, jobsName), filepath.Join(dir, jobsName)); err != nil {
-		return err
+	for _, artifact := range sessionTrashArtifacts(target, key) {
+		if err := movePathIfExists(filepath.Join(itemDir, artifact.name), artifact.src); err != nil {
+			return err
+		}
 	}
 	if err := restoreSubagentArtifacts(dir, itemDir); err != nil {
 		return err

--- a/desktop/sessions_test.go
+++ b/desktop/sessions_test.go
@@ -8,6 +8,7 @@ import (
 
 	"reasonix/internal/agent"
 	"reasonix/internal/jobs"
+	"reasonix/internal/store"
 )
 
 func occupyReadFileWithTimeoutSlots(t *testing.T) func() {
@@ -161,6 +162,10 @@ func TestDeleteSessionFile(t *testing.T) {
 	os.WriteFile(sessionPath, []byte("data"), 0o644)
 	metaPath := sessionPath + ".meta"
 	os.WriteFile(metaPath, []byte("{}"), 0o644)
+	goalPath := store.SessionGoalState(sessionPath)
+	os.WriteFile(goalPath, []byte(`{"goal":"ship"}`), 0o644)
+	telemetryPath := sessionTelemetryPath(sessionPath)
+	os.WriteFile(telemetryPath, []byte(`{"version":2,"readFiles":[]}`), 0o644)
 	ckptDir := filepath.Join(dir, "session.ckpt")
 	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
 		t.Fatalf("mkdir ckpt: %v", err)
@@ -185,6 +190,8 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 	trashPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl")
 	trashMetaPath := trashPath + ".meta"
+	trashGoalPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.goal-state.json")
+	trashTelemetryPath := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jsonl.telemetry.json")
 	trashCkptDir := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.ckpt")
 	trashJobsDir := filepath.Join(dir, sessionTrashDir, "session.jsonl", "session.jobs")
 
@@ -194,6 +201,12 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(metaPath); !os.IsNotExist(err) {
 		t.Error("session meta should be removed from active sessions")
+	}
+	if _, err := os.Stat(goalPath); !os.IsNotExist(err) {
+		t.Error("session goal state should be removed from active sessions")
+	}
+	if _, err := os.Stat(telemetryPath); !os.IsNotExist(err) {
+		t.Error("session telemetry should be removed from active sessions")
 	}
 	if _, err := os.Stat(ckptDir); !os.IsNotExist(err) {
 		t.Error("session checkpoints should be removed from active sessions")
@@ -206,6 +219,12 @@ func TestDeleteSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(trashMetaPath); err != nil {
 		t.Fatalf("session meta should be in trash: %v", err)
+	}
+	if _, err := os.Stat(trashGoalPath); err != nil {
+		t.Fatalf("session goal state should be in trash: %v", err)
+	}
+	if _, err := os.Stat(trashTelemetryPath); err != nil {
+		t.Fatalf("session telemetry should be in trash: %v", err)
 	}
 	if _, err := os.Stat(trashCkptDir); err != nil {
 		t.Fatalf("session checkpoints should be in trash: %v", err)
@@ -292,6 +311,14 @@ func TestReconcileDesktopCleanupPendingDeleteMovesRemainingSidecars(t *testing.T
 	if err := os.WriteFile(sessionPath+".meta", []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	goalPath := store.SessionGoalState(sessionPath)
+	if err := os.WriteFile(goalPath, []byte(`{"goal":"finish"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	telemetryPath := sessionTelemetryPath(sessionPath)
+	if err := os.WriteFile(telemetryPath, []byte(`{"version":2,"readFiles":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ckptDir := filepath.Join(dir, "sidecars.ckpt")
 	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -324,6 +351,8 @@ func TestReconcileDesktopCleanupPendingDeleteMovesRemainingSidecars(t *testing.T
 
 	for _, p := range []string{
 		filepath.Join(itemDir, "sidecars.jsonl.meta"),
+		filepath.Join(itemDir, "sidecars.goal-state.json"),
+		filepath.Join(itemDir, "sidecars.jsonl.telemetry.json"),
 		filepath.Join(itemDir, "sidecars.ckpt", "1.json"),
 		filepath.Join(itemDir, "sidecars.jobs", "job.log"),
 		filepath.Join(itemDir, "subagents", ref+".jsonl"),
@@ -335,6 +364,8 @@ func TestReconcileDesktopCleanupPendingDeleteMovesRemainingSidecars(t *testing.T
 	}
 	for _, p := range []string{
 		sessionPath + ".meta",
+		goalPath,
+		telemetryPath,
 		ckptDir,
 		jobs.ArtifactDir(sessionPath),
 		filepath.Join(dir, "subagents", ref+".jsonl"),
@@ -406,6 +437,14 @@ func TestRestoreTrashedSessionFile(t *testing.T) {
 	if err := os.WriteFile(sessionPath+".meta", []byte("{}"), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	goalPath := store.SessionGoalState(sessionPath)
+	if err := os.WriteFile(goalPath, []byte(`{"goal":"restore"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	telemetryPath := sessionTelemetryPath(sessionPath)
+	if err := os.WriteFile(telemetryPath, []byte(`{"version":2,"readFiles":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	ckptDir := filepath.Join(dir, "session.ckpt")
 	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -437,6 +476,12 @@ func TestRestoreTrashedSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(sessionPath + ".meta"); err != nil {
 		t.Fatalf("session meta should be restored: %v", err)
+	}
+	if _, err := os.Stat(goalPath); err != nil {
+		t.Fatalf("session goal state should be restored: %v", err)
+	}
+	if _, err := os.Stat(telemetryPath); err != nil {
+		t.Fatalf("session telemetry should be restored: %v", err)
 	}
 	if _, err := os.Stat(ckptDir); err != nil {
 		t.Fatalf("session checkpoints should be restored: %v", err)
@@ -511,6 +556,10 @@ func TestPurgeTrashedSessionFile(t *testing.T) {
 	dir := t.TempDir()
 	sessionPath := filepath.Join(dir, "session.jsonl")
 	os.WriteFile(sessionPath, []byte("data"), 0o644)
+	goalPath := store.SessionGoalState(sessionPath)
+	os.WriteFile(goalPath, []byte(`{"goal":"purge"}`), 0o644)
+	telemetryPath := sessionTelemetryPath(sessionPath)
+	os.WriteFile(telemetryPath, []byte(`{"version":2,"readFiles":[]}`), 0o644)
 	jobsDir := jobs.ArtifactDir(sessionPath)
 	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -536,6 +585,12 @@ func TestPurgeTrashedSessionFile(t *testing.T) {
 	}
 	if _, err := os.Stat(jobsDir); !os.IsNotExist(err) {
 		t.Fatalf("session jobs should be removed after purge, stat err = %v", err)
+	}
+	if _, err := os.Stat(goalPath); !os.IsNotExist(err) {
+		t.Fatalf("session goal state should be removed after purge, stat err = %v", err)
+	}
+	if _, err := os.Stat(telemetryPath); !os.IsNotExist(err) {
+		t.Fatalf("session telemetry should be removed after purge, stat err = %v", err)
 	}
 	if _, ok := loadSessionTitles(dir)["session.jsonl"]; ok {
 		t.Fatal("title should be removed after purge")
@@ -589,6 +644,52 @@ func TestDeleteSessionFileMissing(t *testing.T) {
 	// Deleting a non-existent file should not error.
 	if err := deleteSessionFile(dir, filepath.Join(dir, "missing.jsonl")); err != nil {
 		t.Fatalf("delete missing: %v", err)
+	}
+}
+
+func TestRemoveDesktopSessionArtifactsRemovesOwnedSidecars(t *testing.T) {
+	dir := t.TempDir()
+	sessionPath := filepath.Join(dir, "session.jsonl")
+	for _, p := range []string{
+		sessionPath,
+		store.SessionMeta(sessionPath),
+		store.SessionGoalState(sessionPath),
+		sessionTelemetryPath(sessionPath),
+	} {
+		if err := os.WriteFile(p, []byte("{}"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	ckptDir := store.SessionCheckpointDir(sessionPath)
+	if err := os.MkdirAll(ckptDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(ckptDir, "1.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	jobsDir := jobs.ArtifactDir(sessionPath)
+	if err := os.MkdirAll(jobsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jobsDir, "job.log"), []byte("output"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := removeDesktopSessionArtifacts(sessionPath); err != nil {
+		t.Fatalf("removeDesktopSessionArtifacts: %v", err)
+	}
+
+	for _, p := range []string{
+		sessionPath,
+		store.SessionMeta(sessionPath),
+		store.SessionGoalState(sessionPath),
+		sessionTelemetryPath(sessionPath),
+		ckptDir,
+		jobsDir,
+	} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("%s should be removed, stat err = %v", p, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Centralize desktop session artifact ownership for trash, restore, purge, and direct cleanup.
- Move, restore, and remove goal-state and telemetry sidecars with their parent session.
- Add regression coverage for trash, partial-trash reconciliation, restore, purge, and direct artifact cleanup.

## Verification
- `go test . -run 'Test(DeleteSessionFile|ReconcileDesktopCleanupPendingDelete|RestoreTrashedSessionFile|PurgeTrashedSessionFile|ListTrashedSessionFiles|RemoveDesktopSessionArtifacts)' -count=1` passed in `desktop`.
- `go test . -run 'Test(TrashTopic|DeleteSession|RestoreSession|PurgeTrashedSession|ReconcileDesktopCleanupPending|RemoveDesktopSessionArtifacts)' -count=1` passed in `desktop`.
- `go test . -count=1` currently fails on the existing `TestSettingsSeedsMissingUserConfigFromLegacyProjectConfig`; the failure is unrelated to this session trash change.

Refs #5039