### PR TITLE
fix(security): constant-time webhook token, remove QQ_SECRET bypass, add HTTP timeouts

### DIFF
--- a/internal/bot/feishu/feishu.go
+++ b/internal/bot/feishu/feishu.go
@@ -10,6 +10,7 @@ package feishu
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -417,7 +418,10 @@ func cardActionToast(toastType, content string) *callback.CardActionTriggerRespo
 }
 
 func (a *adapter) verificationTokenValid(token string) bool {
-	return a.cfg.VerificationToken == "" || token == a.cfg.VerificationToken
+	if a.cfg.VerificationToken == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(token), []byte(a.cfg.VerificationToken)) == 1
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/internal/bot/feishu/feishu_test.go
+++ b/internal/bot/feishu/feishu_test.go
@@ -43,9 +43,12 @@ func TestVerificationTokenValidRequiresConfiguredToken(t *testing.T) {
 		t.Fatal("matching token should be accepted")
 	}
 
+	// An unconfigured verification token is always rejected (fail-closed).
+	// Webhook mode refuses to start without token, this path is dead in
+	// practice; the function never grant access when token is absent.
 	a.cfg.VerificationToken = ""
-	if !a.verificationTokenValid("") {
-		t.Fatal("empty configured verification token should preserve unauthenticated mode")
+	if a.verificationTokenValid("") {
+		t.Fatal("unconfigured verification token should deny all callers (fail-closed)")
 	}
 }
 

--- a/internal/bot/qq/gateway.go
+++ b/internal/bot/qq/gateway.go
@@ -33,6 +33,7 @@ const (
 	qqMaxHeartbeat                 = time.Minute
 	qqStartupValidationTimeout     = 10 * time.Second
 	qqPassiveReplyTruncationNotice = "\n\n[Truncated: QQ allows at most 5 passive replies for one incoming message.]"
+	qqHTTPTimeout                  = 30 * time.Second
 
 	opDispatch     = 0
 	opHeartbeat    = 1
@@ -45,6 +46,8 @@ const (
 )
 
 var qqMarkdownWrapperRe = regexp.MustCompile("(?is)^```(?:markdown|md)\\s*\\r?\\n([\\s\\S]*?)\\r?\\n```$")
+
+var qqHTTPClient = &http.Client{Timeout: qqHTTPTimeout}
 
 var allowedGatewayHosts = []string{
 	"api.sgroup.qq.com",
@@ -143,7 +146,7 @@ func (a *adapter) getAccessToken(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("qq app_id is empty")
 	}
 	if appSecret == "" {
-		return "", fmt.Errorf("qq app secret is empty: set %s or QQ_SECRET", a.appSecretEnvName())
+		return "", fmt.Errorf("qq app secret is empty: set the %s environment variable", a.appSecretEnvName())
 	}
 	body, err := json.Marshal(map[string]string{
 		"appId":        appID,
@@ -159,7 +162,7 @@ func (a *adapter) getAccessToken(ctx context.Context) (string, error) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := qqHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -372,10 +375,7 @@ func (a *adapter) appSecretEnvName() string {
 }
 
 func (a *adapter) appSecret() string {
-	if value := strings.TrimSpace(os.Getenv(a.appSecretEnvName())); value != "" {
-		return value
-	}
-	return strings.TrimSpace(os.Getenv("QQ_SECRET"))
+	return strings.TrimSpace(os.Getenv(a.appSecretEnvName()))
 }
 
 func (a *adapter) apiBaseURL() string {
@@ -391,7 +391,7 @@ func (a *adapter) getGatewayURL(ctx context.Context, token string) (string, erro
 		return "", err
 	}
 	req.Header.Set("Authorization", "QQBot "+token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := qqHTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -616,7 +616,7 @@ func (a *adapter) sendMessagePayload(ctx context.Context, msg bot.OutboundMessag
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("X-Union-Appid", a.appID())
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := qqHTTPClient.Do(req)
 	if err != nil {
 		return bot.SendResult{}, err
 	}

--- a/internal/bot/weixin/weixin.go
+++ b/internal/bot/weixin/weixin.go
@@ -44,7 +44,11 @@ const (
 	weixinItemText      = 1
 	weixinMsgTypeBot    = 2
 	weixinMsgStateDone  = 2
+
+	weixinHTTPTimeout = 30 * time.Second
 )
+
+var weixinHTTPClient = &http.Client{Timeout: weixinHTTPTimeout}
 
 // ilinkUpdate 微信 iLink getupdates 返回的更新消息。
 type ilinkUpdate struct {
@@ -290,7 +294,7 @@ func ilinkGET(ctx context.Context, baseURL, endpoint string) (map[string]any, er
 	}
 	req.Header.Set("iLink-App-Id", ilinkAppID)
 	req.Header.Set("iLink-App-ClientVersion", fmt.Sprintf("%d", ilinkClientVersion))
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := weixinHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +372,7 @@ func (a *adapter) getUpdates(ctx context.Context) ([]ilinkUpdate, error) {
 	}
 	setIlinkHeaders(req, tok, body)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := weixinHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +590,7 @@ func (a *adapter) sendMessage(ctx context.Context, msg bot.OutboundMessage) (bot
 	}
 	setIlinkHeaders(req, tok, body)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := weixinHTTPClient.Do(req)
 	if err != nil {
 		return bot.SendResult{}, err
 	}
@@ -638,7 +642,7 @@ func (a *adapter) sendTyping(ctx context.Context, chatID string) error {
 	}
 	setIlinkHeaders(req, tok, body)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := weixinHTTPClient.Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

  - **fix(feishu):** replace `==` with `crypto/subtle.ConstantTimeCompare` in
    `verificationTokenValid`  plain string equality leaks timing information that
    allows an attacker to brute-force the webhook verification token byte-by-byte.
    The empty-token branch is also changed from fail-open (`return true`) to
    fail-closed (`return false`); webhook mode already refuses to start without a
    token, so the open branch was unreachable dead code.
  - **fix(qq):** remove the undocumented `QQ_SECRET` env-var fallback in
    `appSecret()`. The function previously fell back to a hardcoded variable name
    that bypassed the user-configured `app_secret_env` key entirely. Only the
    configured key is now consulted.
  - **fix(qq, weixin):** replace `http.DefaultClient` (no timeout) with
    package-level `http.Client` values (`qqHTTPClient`, `weixinHTTPClient`) each
    carrying a 30 s `Timeout`. A stalled QQ or WeChat API previously blocked the
    calling goroutine indefinitely, causing goroutine leaks in long-running bot
    deployments.

  ## Verification

  - `go test ./internal/bot/...` all 65 tests pass across `bot`, `bot/feishu`,
    `bot/qq`, and `bot/weixin`.
  - `TestVerificationTokenValidRequiresConfiguredToken` updated: the last assertion
    now checks that an unconfigured token **denies** all callers (fail-closed),
    replacing the old assertion that it allowed any caller (fail-open).

  ## Cache impact

  Cache-impact: none no prompt prefix, tool schema, or provider wire format touched; changes are confined to bot HTTP plumbing and a security primitive swap.
  Cache-guard: N/A no cache-sensitive files changed (confirmed by scripts/check-cache-impact.sh).
  System-prompt-review: N/A
