### PR TITLE
fix: remember/forget tools should honor auto-approval mode (#5045)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1161,6 +1161,9 @@ func Default() *Config {
 		// Mode "ask" with no rules keeps `reasonix run` autonomous (no TTY → ask
 		// resolves to allow) while `reasonix` prompts before writers. Users add
 		// deny/allow rules to harden or quiet specific tools.
+		// Memory tools (remember/forget) follow the normal policy flow — prompted
+		// in ask mode, auto-allowed in auto/yolo. Add to ask to always require
+		// manual review.
 		Permissions: PermissionsConfig{Mode: "ask"},
 		// Sandbox on by default: bash is jailed (macOS), network allowed so
 		// builds/downloads work. Set bash = "off" to disable. Network=true here

--- a/internal/control/approval.go
+++ b/internal/control/approval.go
@@ -271,7 +271,7 @@ func normalizeToolApprovalMode(mode string) string {
 
 func requiresFreshApprovalTool(tool string) bool {
 	switch tool {
-	case planApprovalTool, memoryRememberTool, memoryForgetTool:
+	case planApprovalTool:
 		return true
 	default:
 		return false

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -1330,10 +1330,9 @@ func (c *Controller) newInteractiveGate() *permission.Gate {
 	default:
 		policy.Mode = permission.Ask
 	}
-	policy.Ask = append(policy.Ask,
-		permission.Rule{Tool: memoryRememberTool},
-		permission.Rule{Tool: memoryForgetTool},
-	)
+	// Memory tools (remember/forget) follow the normal policy flow:
+	// prompted in ask mode (Mode fallback), auto-allowed in auto/yolo.
+	// Add to Ask rules in config to always require manual review.
 	gate := permission.NewGate(policy, gateApprover{c})
 	gate.OnRemember = func(rule string) {
 		if c.onRemember != nil {

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -894,10 +894,10 @@ func TestMemoryApprovalSubjectsAndNotifications(t *testing.T) {
 	if forgetSubject != `Archive memory "wrong-memory"` {
 		t.Fatalf("forget approval subject = %q", forgetSubject)
 	}
-	if got := approvalNotificationText("remember", "Save/update memory with private details"); got != "approval needed: remember" {
+	if got := approvalNotificationText("remember", "Save/update memory with private details"); got != "approval needed: remember Save/update memory with private details" {
 		t.Fatalf("remember notification = %q", got)
 	}
-	if got := approvalNotificationText("forget", `Archive memory "wrong-memory"`); got != "approval needed: forget" {
+	if got := approvalNotificationText("forget", `Archive memory "wrong-memory"`); got != `approval needed: forget Archive memory "wrong-memory"` {
 		t.Fatalf("forget notification = %q", got)
 	}
 	if got := approvalNotificationText("bash", "go test ./..."); got != "approval needed: bash go test ./..." {

--- a/internal/control/yolo_test.go
+++ b/internal/control/yolo_test.go
@@ -125,12 +125,12 @@ func TestRequestApprovalHonorsAutoApproveTools(t *testing.T) {
 	}
 }
 
-func TestMemoryApprovalIgnoresAutoApproveTools(t *testing.T) {
-	approvalRequests := make(chan event.Approval, 1)
+func TestMemoryApprovalHonorsAutoApproveTools(t *testing.T) {
+	approvalRequested := false
 	c := New(Options{
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.ApprovalRequest {
-				approvalRequests <- e.Approval
+				approvalRequested = true
 			}
 		}),
 	})
@@ -147,34 +147,17 @@ func TestMemoryApprovalIgnoresAutoApproveTools(t *testing.T) {
 		done <- allow
 	}()
 
-	var approval event.Approval
 	select {
-	case approval = <-approvalRequests:
-	case <-time.After(2 * time.Second):
-		t.Fatal("memory approval request was not emitted under tool auto-approval")
-	}
-	if approval.Tool != "remember" {
-		t.Fatalf("approval tool = %q, want remember", approval.Tool)
-	}
-
-	select {
-	case err := <-errs:
-		t.Fatalf("requestApproval: %v", err)
-	case allow := <-done:
-		t.Fatalf("memory approval must wait for manual approval, got allow=%v", allow)
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	c.Approve(approval.ID, true, true, true)
-	select {
-	case err := <-errs:
-		t.Fatalf("requestApproval: %v", err)
 	case allow := <-done:
 		if !allow {
-			t.Fatal("manual approval should allow memory write")
+			t.Fatal("YOLO mode should auto-allow memory write without prompting")
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("memory approval stayed blocked after Approve")
+		t.Fatal("requestApproval blocked under YOLO mode")
+	}
+
+	if approvalRequested {
+		t.Fatal("YOLO mode must not emit an ApprovalRequest for memory tools")
 	}
 }
 
@@ -199,14 +182,14 @@ func TestToolApprovalModeAutoKeepsAskRules(t *testing.T) {
 	}
 }
 
-func TestToolApprovalModeAutoForcesMemoryAskRules(t *testing.T) {
+func TestToolApprovalModeAutoAllowsMemoryTools(t *testing.T) {
 	c := New(Options{})
 	c.SetToolApprovalMode(ToolApprovalAuto)
 
 	gate := c.newInteractiveGate()
 	for _, toolName := range []string{"remember", "forget"} {
-		if got := gate.Policy.Decide(toolName, false, json.RawMessage(`{}`)); got != permission.Ask {
-			t.Fatalf("%s under auto mode = %v, want ask", toolName, got)
+		if got := gate.Policy.Decide(toolName, false, json.RawMessage(`{}`)); got != permission.Allow {
+			t.Fatalf("%s under auto mode = %v, want allow", toolName, got)
 		}
 	}
 }
@@ -469,12 +452,15 @@ func TestSetAutoApproveToolsDoesNotDrainPendingPlanApproval(t *testing.T) {
 	}
 }
 
-func TestSetAutoApproveToolsDoesNotDrainPendingMemoryApproval(t *testing.T) {
-	approvalRequests := make(chan event.Approval, 1)
+func TestSetAutoApproveToolsDrainsPendingMemoryApproval(t *testing.T) {
+	pending := make(chan struct{}, 1)
 	c := New(Options{
 		Sink: event.FuncSink(func(e event.Event) {
 			if e.Kind == event.ApprovalRequest {
-				approvalRequests <- e.Approval
+				select {
+				case pending <- struct{}{}:
+				default:
+				}
 			}
 		}),
 	})
@@ -490,33 +476,23 @@ func TestSetAutoApproveToolsDoesNotDrainPendingMemoryApproval(t *testing.T) {
 		done <- allow
 	}()
 
-	var approval event.Approval
+	// Wait for the approval request to be emitted before flipping YOLO.
 	select {
-	case approval = <-approvalRequests:
+	case <-pending:
 	case <-time.After(2 * time.Second):
 		t.Fatal("memory approval request was not emitted")
 	}
 
 	c.SetAutoApproveTools(true)
 
+	// YOLO should auto-answer the pending memory approval.
 	select {
-	case err := <-errs:
-		t.Fatalf("requestApproval: %v", err)
-	case allow := <-done:
-		t.Fatalf("SetAutoApproveTools must not auto-answer pending memory approval; got allow=%v", allow)
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	c.Approve(approval.ID, true, true, true)
-	select {
-	case err := <-errs:
-		t.Fatalf("requestApproval: %v", err)
 	case allow := <-done:
 		if !allow {
-			t.Fatal("manual approval should allow memory archive")
+			t.Fatal("SetAutoApproveTools should auto-answer pending memory approval")
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("memory approval stayed blocked after Approve")
+		t.Fatal("memory approval stayed blocked after SetAutoApproveTools")
 	}
 }
 


### PR DESCRIPTION
Remove hardcoded always-ask rules for memory tools so they follow the
normal policy flow consistent with every other writer tool.

Two changes:
- newInteractiveGate(): no longer appends explicit Ask rules for
  remember/forget. They flow through Policy.DecideSubject normally —
  prompted in ask mode (Mode fallback), auto-allowed in auto/yolo.
- requiresFreshApprovalTool(): only planApprovalTool remains.
  Session grants, "always allow" persistence, and YOLO drain now
  work for memory tools — previously all blocked.

After fix:

| Mode | remember/forget |
|---|---|
| ask (default) | Prompt |
| auto | Auto-allow |
| yolo | Auto-allow |
| User adds Ask:remember | Prompt even in auto |
| User adds Deny:remember | Blocked in all modes |

Memory tools are safer than file-mutation tools (write to
~/.reasonix/memory/, never touch workspace code). They now receive
the same approval treatment as bash and edit_file — no special
hardcoding.

Tests updated: three renamed to match new behavior, approval
notifications now include subject text. time.Sleep replaced with
event-channel synchronization per review.

Cache-impact: low — only changes approval decision flow, no prompt
prefix or tool schema modifications

Cache-guard: go test ./internal/control/ ./internal/permission/

System-prompt-review: no system prompt, memory prefix, or skill index
changes — default config Ask rules were removed before merge