### PR TITLE
fix(desktop): summarize reverts code + plan confirm button disappears…

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2055,6 +2055,17 @@ export default function App() {
       return;
     }
 
+    // Summarize only compresses the conversation log — no files touched,
+    // no optimistic UI needed. Execute immediately like code-only rewind.
+    if (scope === "summ-from" || scope === "summ-upto") {
+      rewind(turn, scope).then((ok) => {
+        if (!ok) return;
+        setDockRefreshKey((v) => v + 1);
+        setProjectRevision((v) => v + 1);
+      });
+      return;
+    }
+
     const items = state.items;
     // Find the boundary: index of the Nth user message where N = turn.
     let boundaryIdx = 0;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -610,7 +610,13 @@ function applyEvent(s: State, e: WireEvent): State {
         return it;
       });
       let items: Item[] = e.err ? [...finalized, { kind: "notice", id: `e${s.seq}`, level: "warn", text: e.err }] : finalized;
-      return { ...s, items, live: undefined, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, approval: undefined, ask: undefined, seq: s.seq + 1 };
+      // In plan mode the controller emits TurnDone during plan generation, then
+      // ApprovalRequest for the plan gate. On Windows the Wails bridge may deliver
+      // events out of order. If ApprovalRequest arrives before TurnDone, clearing
+      // approval here would make the confirm button disappear and the system hang
+      // waiting for a response that the frontend can no longer send (#5032).
+      const keepPlanApproval = s.approval?.tool === "exit_plan_mode";
+      return { ...s, items, live: undefined, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, approval: keepPlanApproval ? s.approval : undefined, ask: undefined, seq: s.seq + 1 };
     }
     default: return s;
   }


### PR DESCRIPTION
… (#5032)

Bug 1: Clicking summarize (summ-from/summ-upto) only truncated UI optimistically — the Go backend was never called. The user perceived code as reverted because tool-result items vanished from view. Fixed by adding summ-from/summ-upto to the immediate-execution branches in handleMessageAction, mirroring the code-only rewind path.

Bug 2: In plan mode, TurnDone is emitted before ApprovalRequest on the Go side. On Windows the Wails bridge may deliver events out of order. If ApprovalRequest arrives first (sets approval → shows modal), then TurnDone clears it (approval: undefined → modal disappears), the system hangs forever waiting for a response the frontend can no longer send.
Fixed by guarding turn_done to preserve exit_plan_mode approvals.

## Summary

-

## Verification

-

## Cache impact

Cache-impact: TODO
Cache-guard: TODO
System-prompt-review: N/A

For cache-sensitive changes, fill these lines before requesting review:

- `Cache-impact`: `none`, `low`, `medium`, or `high`, plus the reason.
- `Cache-guard`: the focused guard test/command added or run, or why an existing guard covers the change.
- `System-prompt-review`: required reviewer/approval note when provider-visible system prompt, memory prefix, output style, or skill index behavior changes.
