### PR TITLE
fix(boot): compare provider name not just model ID for planner routing

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -881,7 +881,11 @@ func Build(ctx context.Context, opts Options) (*control.Controller, error) {
 		if !ok {
 			return nil, fmt.Errorf("planner_model %q is not a configured provider", pm)
 		}
-		if pe.Model != entry.Model {
+		// Different provider instance or different model → two-model mode.
+		// The old pe.Model != entry.Model only compared model IDs, missing the
+		// case where the same model name is served by different providers (e.g.
+		// DeepSeek official vs opencode.ai gateway).
+		if pe.Name != entry.Name || pe.Model != entry.Model {
 			plannerProv, err := NewProviderWithProxy(pe, proxySpec)
 			if err != nil {
 				return nil, fmt.Errorf("planner %q: %w", pm, err)


### PR DESCRIPTION
## 问题

当 planer_model 和执行器使用**不同供应商**但**同模型名**时（例如规划器用 DeepSeek 官方的 deepseek-v4-flash，执行器用 opencode.ai 的 deepseek-v4-flash），规划器被错误跳过。

### 根因

`internal/boot/boot.go:882` 只比较了模型 ID：

```go
if pe.Model != entry.Model {  // "deepseek-v4-flash" == "deepseek-v4-flash" → false!
```

供应商不同但模型 ID 相同时，这个条件为 false → 不创建 Coordinator。

### 修复

增加供应商名称比较：

```go
if pe.Name != entry.Name || pe.Model != entry.Model {
```

### 边界覆盖

| 场景 | 旧行为 | 新行为 |
|------|--------|--------|
| 同供应商、同模型 | 单模型 | 单模型 ✅ |
| 同供应商、不同模型 | 双模型 | 双模型 ✅ |
| 不同供应商、同模型 | **单模型 ❌** | **双模型 ✅** |
| 不同供应商、不同模型 | 双模型 | 双模型 ✅ |
| planner 未配置 | 单模型 | 单模型 ✅ |
| tokenEconomy 模式 | 单模型 | 单模型 ✅ |

## 文件
internal/boot/boot.go (+4/-1)

Cache-impact: low
Cache-guard: go test ./internal/boot/ -run New
System-prompt-review: none