### PR TITLE
fix(desktop): distinguish turn-level vs cumulative rewind file count

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1140,8 +1140,9 @@ func removeDesktopSessionArtifacts(path string) error {
 type CheckpointMeta struct {
 	Turn            int      `json:"turn"`
 	Prompt          string   `json:"prompt"`
-	Files           []string `json:"files"` // paths changed during the turn
-	Time            int64    `json:"time"`  // unix milliseconds
+	Files           []string `json:"files"`         // cumulative files RestoreCode would affect from this turn
+	TurnFileCount   int      `json:"turnFileCount"` // files changed in THIS specific turn only
+	Time            int64    `json:"time"`          // unix milliseconds
 	CanCode         bool     `json:"canCode"`
 	CanConversation bool     `json:"canConversation"`
 }
@@ -1168,6 +1169,7 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 			Turn:            m.Turn,
 			Prompt:          m.Prompt,
 			Files:           m.Paths,
+			TurnFileCount:   len(m.Paths),
 			Time:            m.Time.UnixMilli(),
 			CanCode:         len(m.Paths) > 0,
 			CanConversation: ctrl.CheckpointHasBoundary(m.Turn),

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -421,7 +421,12 @@ export function TurnActions({
   };
   const actionMeta = (scope: MessageActionScope): string => {
     if ((scope === "code" || scope === "both") && checkpoint?.files?.length) {
-      return t("rewind.filesChanged", { count: checkpoint.files.length });
+      const total = checkpoint.files.length;
+      const turnCount = checkpoint.turnFileCount ?? 0;
+      if (turnCount > 0 && turnCount < total) {
+        return t("rewind.filesChanged", { count: total }) + " (" + t("rewind.turnFiles", { count: turnCount }) + ")";
+      }
+      return t("rewind.filesChanged", { count: total });
     }
     return "";
   };

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1734,7 +1734,7 @@ function makeMockApp(): AppBindings {
         async ClearSession() {},
     async Checkpoints() {
       return [
-        { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], time: Date.now() - 30_000, canCode: true, canConversation: true },
+        { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], turnFileCount: 1, time: Date.now() - 30_000, canCode: true, canConversation: true },
       ];
     },
     async CheckpointsForTab() {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -284,6 +284,7 @@ export interface CheckpointMeta {
   turn: number;
   prompt: string;
   files: string[];
+  turnFileCount: number;
   time: number; // unix ms
   canCode?: boolean;
   canConversation?: boolean;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1467,6 +1467,7 @@ export const en = {
   "rewind.disabledNoCode": "No code changes were captured after this message",
   "rewind.disabledNoEarlier": "There is nothing before this message to summarize",
   "rewind.filesChanged": "{count} files",
+  "rewind.turnFiles": "{count} this turn",
   "rewind.both": "Rewind code and conversation",
   "rewind.conversation": "Rewind conversation only",
   "rewind.code": "Rewind code only",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -911,6 +911,7 @@ export const zhTW: Record<DictKey, string> = {
   "rewind.disabledNoCode": "這條訊息之後沒有捕獲到程式碼變更",
   "rewind.disabledNoEarlier": "這條訊息之前沒有可總結內容",
   "rewind.filesChanged": "{count} 個檔案",
+  "rewind.turnFiles": "本轮 {count} 個",
   "rewind.both": "回滾程式碼和對話",
   "rewind.conversation": "僅回滾對話",
   "rewind.code": "僅回滾程式碼",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1469,6 +1469,7 @@ export const zh: Record<DictKey, string> = {
   "rewind.disabledNoCode": "这条消息之后没有捕获到代码改动",
   "rewind.disabledNoEarlier": "这条消息之前没有可总结内容",
   "rewind.filesChanged": "{count} 个文件",
+  "rewind.turnFiles": "本轮 {count} 个",
   "rewind.both": "回滚代码和对话",
   "rewind.conversation": "仅回滚对话",
   "rewind.code": "仅回滚代码",


### PR DESCRIPTION
## 问题

回溯 UI 显示 "26 个文件" 时，所有轮次都显示同样的数字，纯讨论轮次也显示 26 个文件，用户无法区分"这一轮改了多少"和"回滚到此处将还原多少文件"。

## 根因

`desktop/app.go` 的 `CheckpointsForTab` 将 `canCode` 和 `Files` 向后传播（#3438），使得每轮的文件列表变成**从该轮到末尾所有文件的并集**。这是设计意图（回滚语义是"恢复到第 N 轮的项目状态"），但 UI 没有传达这个信息。

## 修复

- `CheckpointMeta` 新增 `TurnFileCount` 字段（该轮实际改的文件数）
- 前端显示："26 个文件（本轮 2 个）"
- 添加 `rewind.turnFiles` i18n key

## 文件
desktop/app.go (+1)
desktop/frontend/src/lib/bridge.ts / types.ts / Message.tsx
desktop/frontend/src/locales/en.ts / zh.ts / zh-TW.ts