### PR TITLE
feat(openai): 任意 OpenAI 供应商+deepseek 兼容思考模式开关 support thinking mode config for generic OpenAI-compatible providers

### DIFF
--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -457,17 +457,17 @@ func TestSetReasoningLanguage(t *testing.T) {
 func TestNormalizeEffortDeepSeek(t *testing.T) {
 	e := &ProviderEntry{Name: "deepseek", Kind: "openai", BaseURL: "https://api.deepseek.com", Model: "deepseek-v4"}
 	cap := EffortCapabilityForEntry(e)
-	if !cap.Supported || len(cap.Levels) != 3 || cap.Levels[0] != "auto" || cap.Levels[1] != "high" || cap.Levels[2] != "max" {
-		t.Fatalf("DeepSeek levels = %+v, want auto/high/max", cap)
+	if !cap.Supported || len(cap.Levels) != 4 || cap.Levels[0] != "auto" || cap.Levels[1] != "disabled" || cap.Levels[2] != "high" || cap.Levels[3] != "max" {
+		t.Fatalf("DeepSeek levels = %+v, want auto/disabled/high/max", cap)
 	}
-	for in, want := range map[string]string{"auto": "", "high": "high", "max": "max", "low": "high", "medium": "high", "xhigh": "max"} {
+	for in, want := range map[string]string{"auto": "", "disabled": "disabled", "high": "high", "max": "max", "low": "high", "medium": "high", "xhigh": "max"} {
 		got, err := NormalizeEffort(e, in)
 		if err != nil || got != want {
 			t.Fatalf("NormalizeEffort(%q) = %q/%v, want %q/nil", in, got, err, want)
 		}
 	}
-	if _, err := NormalizeEffort(e, "off"); err == nil {
-		t.Fatal("DeepSeek /effort must reject off")
+	if got, err := NormalizeEffort(e, "off"); err != nil || got != "disabled" {
+		t.Fatalf("NormalizeEffort(\"off\") = %q/%v, want \"disabled\"/nil", got, err)
 	}
 }
 
@@ -1298,7 +1298,7 @@ func TestEffortCapabilityUsesKnownModelRegistry(t *testing.T) {
 	if !cap.Supported {
 		t.Fatalf("deepseek model behind proxy should expose effort, got %+v", cap)
 	}
-	wantLevels := []string{"auto", "high", "max"}
+	wantLevels := []string{"auto", "disabled", "high", "max"}
 	if len(cap.Levels) != len(wantLevels) {
 		t.Fatalf("levels = %v, want %v", cap.Levels, wantLevels)
 	}

--- a/internal/config/effort.go
+++ b/internal/config/effort.go
@@ -29,8 +29,8 @@ type modelReasoningCapability struct {
 }
 
 var modelReasoningCapabilities = map[string]modelReasoningCapability{
-	"deepseek-v4-flash": {Protocol: ReasoningProtocolDeepSeek, Levels: []string{"high", "max"}, Default: "high"},
-	"deepseek-v4-pro":   {Protocol: ReasoningProtocolDeepSeek, Levels: []string{"high", "max"}, Default: "high"},
+	"deepseek-v4-flash": {Protocol: ReasoningProtocolDeepSeek, Levels: []string{"disabled", "high", "max"}, Default: "high"},
+	"deepseek-v4-pro":   {Protocol: ReasoningProtocolDeepSeek, Levels: []string{"disabled", "high", "max"}, Default: "high"},
 }
 
 // EffortCapabilityForEntry returns the user-facing /effort levels for a resolved
@@ -104,14 +104,18 @@ func NormalizeEffort(e *ProviderEntry, raw string) (string, error) {
 	switch ReasoningProtocolForEntry(e) {
 	case ReasoningProtocolDeepSeek:
 		switch level {
+		case "disabled":
+			return "disabled", nil
 		case "high", "max":
 			return level, nil
 		case "low", "medium":
 			return "high", nil
 		case "xhigh":
 			return "max", nil
+		case "off":
+			return "disabled", nil
 		default:
-			return "", fmt.Errorf("usage: /effort auto|high|max")
+			return "", fmt.Errorf("usage: /effort auto|disabled|high|max")
 		}
 	case ReasoningProtocolOpenAI:
 		switch level {
@@ -282,7 +286,7 @@ func effortCapabilityFromModel(cap modelReasoningCapability) EffortCapability {
 }
 
 func deepSeekEffortCapability() EffortCapability {
-	return EffortCapability{Supported: true, Levels: []string{"auto", "high", "max"}, Default: "high"}
+	return EffortCapability{Supported: true, Levels: []string{"auto", "disabled", "high", "max"}, Default: "high"}
 }
 
 func openAIEffortCapability() EffortCapability {

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -70,6 +70,16 @@ func New(cfg provider.Config) (provider.Provider, error) {
 	}
 	deepseek := protocol == "deepseek" || (protocol == "" && IsDeepSeek(cfg.BaseURL))
 	minimax := protocol == "" && IsMiniMax(cfg.BaseURL)
+	// Read thinking mode from config for generic providers.
+	thinkingRaw, _ := cfg.Extra["thinking"].(string)
+	thinkingType := strings.ToLower(strings.TrimSpace(thinkingRaw))
+	switch thinkingType {
+	case "enabled", "disabled":
+	case "adaptive":
+		thinkingType = "" // omit for generic providers
+	default:
+		thinkingType = "" // unrecognised → no override
+	}
 	switch {
 	case protocol == "none":
 		effort = ""
@@ -77,9 +87,12 @@ func New(cfg provider.Config) (provider.Provider, error) {
 		switch effort {
 		case "", "off": // "off" is a retired level (disabled thinking); fall back to the default depth
 			effort = "high"
+		case "disabled":
+			effort = ""
+			thinkingType = "disabled"
 		case "high", "max":
 		default:
-			return nil, fmt.Errorf("openai: provider %q uses DeepSeek thinking; effort must be high or max", name)
+			return nil, fmt.Errorf("openai: provider %q uses DeepSeek thinking; effort must be high, max, or disabled", name)
 		}
 	case minimax:
 		// M3's knob is binary. The config effort layer normalises user input
@@ -150,6 +163,7 @@ type client struct {
 	vision       bool          // model accepts image input — embed attached images as image_url parts
 	visionDetail string        // image_url detail hint (low|high); "" = auto/omit
 	effort       string        // reasoning_effort for OpenAI; thinking.type for MiniMax; "" = auto/provider default
+	thinkingType string        // "enabled"/"disabled"/"" for generic OpenAI-compatible; "" = no override
 	idleTimeout  time.Duration // SSE stall watchdog window; defaultStreamIdleTimeout unless a test overrides
 	authed       atomic.Bool   // a request has succeeded — gate transient-401 retry
 }
@@ -308,8 +322,13 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 	switch {
 	case c.deepseek:
 		// DeepSeek's CoT is controlled by `thinking` (always on) plus
-		// `reasoning_effort` for depth. We never disable thinking for DeepSeek.
-		out.Thinking = &thinkingMode{Type: "enabled"}
+		// `reasoning_effort` for depth. When `effort=disabled` or
+		// `thinking=disabled` is configured, disable thinking.
+		if c.thinkingType == "disabled" {
+			out.Thinking = &thinkingMode{Type: "disabled"}
+		} else {
+			out.Thinking = &thinkingMode{Type: "enabled"}
+		}
 	case c.minimax:
 		// M3 uses a single `thinking.type` field with two valid values:
 		// "adaptive" (default, thinking on) and "disabled" (off). Reasoning
@@ -320,6 +339,10 @@ func (c *client) buildRequest(req provider.Request) chatRequest {
 		}
 		out.Thinking = &thinkingMode{Type: t}
 		out.ReasoningEffort = ""
+	case c.thinkingType != "" && !c.deepseek:
+		// Generic OpenAI-compatible provider with configured thinking mode
+		// (e.g. Zhipu GLM, opencode.ai). DeepSeek is handled above.
+		out.Thinking = &thinkingMode{Type: c.thinkingType}
 	}
 	return out
 }


### PR DESCRIPTION
## 问题

1. 非 DeepSeek 非 MiniMax 的供应商（opencode.ai、GLM），thinking 配置字段被无视
2. DeepSeek 官方模型无法关闭思考模式

## 解决方案

### 1. 通用 thinking 支持（所有 openai-kind 供应商）
- 读取 cfg.Extra["thinking"]（来自 thinking 配置字段）
- 在 buildRequest 中设置 thinking.type = enabled/disabled

### 2. DeepSeek 禁用思考模式
- /effort 新增 disabled 级别
- effort=disabled 时设置 thinking.type=disabled
- off 退化为 disabled（不再报错）

## 文件
internal/provider/openai/openai.go
internal/config/effort.go
internal/config/edit_test.go

Cache-impact: low -- 修改 openai.go 的 buildRequest 请求构造（非系统提示词路径），effort.go 新增 disabled 枚举值
Cache-guard: go test ./internal/provider/openai/ ./internal/config/ -run Effort
System-prompt-review: @SivanCola -- 不涉及提示词变更，仅影响请求序列化层