### PR TITLE
fix(desktop): apply NVIDIA Wayland explicit-sync workaround for WebKitGTK

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -188,6 +188,13 @@ handled here, and what to reach for if a target misbehaves:
   `WEBKIT_DISABLE_COMPOSITING_MODE=1`. Test on at least one GTK target before
   release; the CSS deliberately avoids `backdrop-filter`/blur (slow & inconsistent
   there).
+  - **Wayland + NVIDIA**: On KDE Plasma Wayland with NVIDIA GPUs, WebKitGTK can
+    crash at startup (`Error 71: Protocol error`) due to an upstream WebKit
+    explicit-sync bug (WebKit #280210, #317089, NVIDIA/egl-wayland #179).
+    Reasonix automatically sets `__NV_DISABLE_EXPLICIT_SYNC=1` when it detects
+    Wayland + NVIDIA GPU. To opt out, set `__NV_DISABLE_EXPLICIT_SYNC=0`.
+    Alternative fallbacks: `WEBKIT_DISABLE_DMABUF_RENDERER=1` (poor performance)
+    or `GDK_BACKEND=x11` (forces XWayland).
 - **Windows / WebView2** — `Theme: SystemDefault` follows the OS light/dark
   setting; the installer embeds the WebView2 bootstrapper. Canary builds disable
   WebView2 GPU acceleration by default to smoke-test blank-window reports; set

--- a/desktop/nvidia_wayland_linux.go
+++ b/desktop/nvidia_wayland_linux.go
@@ -1,0 +1,45 @@
+package main
+
+import "os"
+
+// init applies the NVIDIA/Wayland WebKit workaround before the Wails runtime
+// initializes WebKitGTK. On KDE Plasma Wayland with NVIDIA GPUs the webview
+// crashes due to an upstream WebKit explicit-sync bug (WebKit bugs #280210 and
+// #317089). The underlying interaction is between WebKit's ANGLE library and
+// NVIDIA's egl-wayland: ANGLE advertises explicit-sync (wp_linux_drm_syncobj)
+// but fails to set an acquire point before committing the buffer, which violates
+// the Wayland protocol and causes the compositor to disconnect the client.
+//
+// Setting __NV_DISABLE_EXPLICIT_SYNC=1 is the official NVIDIA EGL API to
+// disable the explicit-sync protocol path. It preserves GPU acceleration
+// (unlike WEBKIT_DISABLE_DMABUF_RENDERER=1 which disables DMA-BUF entirely
+// and severely degrades performance) and keeps the native Wayland session
+// (unlike GDK_BACKEND=x11 which falls back to XWayland).
+//
+// The fix only applies when all three conditions are true:
+//  1. Wayland session (WAYLAND_DISPLAY set or XDG_SESSION_TYPE=wayland)
+//  2. NVIDIA GPU present (/sys/module/nvidia exists)
+//  3. User has not already explicitly set __NV_DISABLE_EXPLICIT_SYNC
+func init() {
+	// Only apply under Wayland — the explicit-sync bug is Wayland-specific.
+	if os.Getenv("WAYLAND_DISPLAY") == "" && os.Getenv("XDG_SESSION_TYPE") != "wayland" {
+		return
+	}
+	// Only apply when an NVIDIA GPU is present — the env var is NVIDIA-specific.
+	if !hasNVIDIAGPU() {
+		return
+	}
+	// Respect an explicit user choice so the workaround can be opted out of.
+	if _, ok := os.LookupEnv("__NV_DISABLE_EXPLICIT_SYNC"); ok {
+		return
+	}
+	os.Setenv("__NV_DISABLE_EXPLICIT_SYNC", "1")
+}
+
+// hasNVIDIAGPU checks whether the NVIDIA kernel module is loaded by looking for
+// /sys/module/nvidia. This is the most reliable detection method that works
+// across all Linux distributions and doesn't require external tools.
+func hasNVIDIAGPU() bool {
+	_, err := os.Stat("/sys/module/nvidia")
+	return err == nil
+}


### PR DESCRIPTION
On KDE Plasma Wayland with NVIDIA GPUs, the WebKitGTK webview crashes at
startup (Error 71: Protocol error) due to an upstream WebKit explicit-sync
bug (WebKit #280210, #317089). ANGLE advertises wp_linux_drm_syncobj but
fails to set an acquire point before committing the buffer, violating the
Wayland protocol.

Set `__NV_DISABLE_EXPLICIT_SYNC=1` automatically when all three conditions
are true: Wayland session detected, NVIDIA GPU present (/sys/module/nvidia),
and the user hasn't already set the variable. This preserves GPU acceleration
(unlike `WEBKIT_DISABLE_DMABUF_RENDERER=1`) and keeps the native Wayland
session (unlike `GDK_BACKEND=x11`).

Closes #4700.

Cache-impact: none
Cache-guard: n/a — desktop/ not in cache-sensitive paths (scripts/check-cache-impact.sh)