### PR TITLE
style(creation): 精简工具卡片错误框与代码块滚动条

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -25103,6 +25103,72 @@ a[href] {
     "Microsoft YaHei", sans-serif;
 }
 
+/* 工具错误信息：Creation 下去掉醒目的红底块（base 用 --del-bg），
+   改为左对齐纯文本，与命令输出同起点（base 有 30px 左缩进，这里清零）。
+   仅 .app--creation 作用域，classic/workbench 的红底错误框保持不变。 */
+.app--creation .tool__err,
+:root[data-theme-style] .app--creation .tool__err {
+  margin: 4px 0 8px;
+  padding: 0;
+  background: transparent;
+  border-radius: 0;
+  text-align: left;
+}
+
+/* 工具体内代码块（命令参数/输出/diff）底部的横向滚动条：Creation 下隐藏滑道，
+   只留一条 4px 细滑块（默认半透明，hover 略加深）。所有工具通用，不只 shell。
+   仅作用于 .app--creation .tool__body .code，不碰全局 --scrollbar-* token，
+   classic/workbench 的 10px 滚动条保持不变。
+   真因（之前没生效的原因）：全局 `* { scrollbar-width: thin }` 给每个元素都设了
+   标准属性，WebView2(Chromium M121+) 下只要 scrollbar-width 非 auto，
+   ::-webkit-scrollbar 伪元素就被整体忽略。所以必须先把 .code 的 scrollbar-width
+   重置为 auto 重新激活 webkit 伪元素，再用带 !important 的 webkit 规则覆盖尺寸/滑道，
+   写法对齐已能工作的 .transcript 滚动条（见上方 24381 区域）。 */
+.app--creation .tool__body .code,
+:root[data-theme-style] .app--creation .tool__body .code {
+  scrollbar-width: auto;
+  scrollbar-color: auto;
+}
+
+.app--creation .tool__body .code::-webkit-scrollbar,
+:root[data-theme-style] .app--creation .tool__body .code::-webkit-scrollbar {
+  width: 4px !important;
+  height: 4px !important;
+  background: transparent !important;
+}
+
+.app--creation .tool__body .code::-webkit-scrollbar-track,
+.app--creation .tool__body .code::-webkit-scrollbar-track-piece,
+.app--creation .tool__body .code::-webkit-scrollbar-corner,
+:root[data-theme-style] .app--creation .tool__body .code::-webkit-scrollbar-track,
+:root[data-theme-style] .app--creation .tool__body .code::-webkit-scrollbar-track-piece,
+:root[data-theme-style] .app--creation .tool__body .code::-webkit-scrollbar-corner {
+  background: transparent !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+.app--creation .tool__body .code::-webkit-scrollbar-button,
+:root[data-theme-style] .app--creation .tool__body .code::-webkit-scrollbar-button {
+  display: none !important;
+  width: 0 !important;
+  height: 0 !important;
+  background: transparent !important;
+}
+
+.app--creation .tool__body .code::-webkit-scrollbar-thumb,
+:root[data-theme-style] .app--creation .tool__body .code::-webkit-scrollbar-thumb {
+  border: 0 !important;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--fg-faint) 38%, transparent) !important;
+  background-clip: border-box !important;
+}
+
+.app--creation .tool__body .code::-webkit-scrollbar-thumb:hover,
+:root[data-theme-style] .app--creation .tool__body .code::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--fg-dim) 52%, transparent) !important;
+}
+
 .app--creation .tool__name,
 .app--creation .tool__summary,
 .app--creation .tool__duration,


### PR DESCRIPTION
## 改动概述

仅在 `creation` 桌面风格（`.app--creation` 作用域）下精简工具调用卡片的两处视觉，降低视觉干扰。`classic` / `workbench` 两种风格完全不受影响。

## 具体改动

均在 `desktop/frontend/src/styles.css`：

1. **工具错误信息 `.tool__err`**：去掉醒目的红色底块（base 用 `--del-bg`），清掉 base 的 30px 左缩进，改为与命令输出同起点的左对齐纯文本。错误文字色仍继承 `var(--err)`，可识别但不再抢眼。

2. **工具体代码块横向滚动条 `.tool__body .code`**：隐藏滑道（track / track-piece / corner / button 全部透明隐藏），只保留一条 4px 细滑块（默认半透明，hover 略加深）。对所有工具的输出代码块通用，不只 shell。

## 实现说明

滚动条这处的关键：全局存在 `* { scrollbar-width: thin }`，给每个元素都设了标准 `scrollbar-width`。WebView2(Chromium) 下只要元素带非 auto 的 `scrollbar-width`，`::-webkit-scrollbar` 伪元素就会被整体忽略。因此需先把 `.code` 的 `scrollbar-width` 重置为 `auto` 重新激活 webkit 伪元素，再用带 `!important` 的 webkit 规则覆盖尺寸与滑道——写法对齐了仓库内已能正常工作的 `.transcript` 滚动条。

## 作用域自检

- 所有新增规则均带 `.app--creation` 前缀，未改全局 base tokens（`--bg` / `--border` / `--scrollbar-size` 等）。
- classic / workbench 下表现与改动前完全一致。

## 验证

- `pnpm --dir desktop/frontend typecheck` 通过
- `pnpm --dir desktop/frontend run check:css`（CSS 语法 + z-index token 校验）通过
- wails dev 下 creation 风格实测：错误框红底消失、左对齐；工具输出代码块横滚动条变为 4px 细滑块、无可见滑道
