### PR TITLE
修复 ACP 配置切换取消后台任务

### DIFF
--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -69,6 +69,7 @@ type configurableFactory struct {
 	withHooks  bool
 	hookEvents []hook.Event
 	behavior   func(ctx context.Context, sink event.Sink, input string, p SessionParams) error
+	managers   []*jobs.Manager
 }
 
 func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
@@ -93,6 +94,13 @@ func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*c
 	opts := control.Options{Runner: runner, Sink: p.Sink, SessionDir: f.dir}
 	if f.withHooks {
 		opts.Hooks = f.hookRunner()
+	}
+	if f.managers != nil {
+		jm := jobs.NewManager(event.Discard)
+		f.mu.Lock()
+		f.managers = append(f.managers, jm)
+		f.mu.Unlock()
+		opts.Jobs = jm
 	}
 	return control.New(opts), nil
 }
@@ -184,6 +192,19 @@ func (f *configurableFactory) buildCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return len(f.builds)
+}
+
+func (f *configurableFactory) managerAt(t *testing.T, idx int) *jobs.Manager {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.managers == nil {
+		t.Fatal("factory does not create job managers")
+	}
+	if len(f.managers) <= idx {
+		t.Fatalf("builds = %d, want manager index %d", len(f.builds), idx)
+	}
+	return f.managers[idx]
 }
 
 func (f *configurableFactory) hookRunner() *hook.Runner {
@@ -630,6 +651,58 @@ func TestServeSessionConfigQueuesDuringActivePrompt(t *testing.T) {
 	}
 	if got := factory.buildAt(t, 1).Model; got != "pro" {
 		t.Fatalf("queued rebuild model = %q, want pro", got)
+	}
+}
+
+func TestServeSessionConfigRejectsBackgroundJobsWhileIdle(t *testing.T) {
+	dir := t.TempDir()
+	factory := &configurableFactory{dir: dir, managers: []*jobs.Manager{}}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	jm := factory.managerAt(t, 0)
+	release := make(chan struct{})
+	started := make(chan struct{})
+	sessionPath := transcriptPath(dir, nr.SessionID)
+	jm.StartForSession(agent.BranchID(sessionPath), "bash", "server", func(ctx context.Context, _ io.Writer) (string, error) {
+		close(started)
+		select {
+		case <-release:
+			return "", nil
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	})
+	defer func() {
+		close(release)
+		jm.Close()
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("background job never started")
+	}
+
+	setResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "model",
+		Value:     "pro",
+	})
+	if setResp.Error == nil || !strings.Contains(setResp.Error.Message, "stop background jobs") {
+		t.Fatalf("set_config_option with background job error = %+v, want stop background jobs RPC error", setResp.Error)
+	}
+	if got := factory.buildCount(); got != 1 {
+		t.Fatalf("build count after rejected switch = %d, want 1", got)
+	}
+	if running := jm.RunningForSession(agent.BranchID(sessionPath)); len(running) != 1 {
+		t.Fatalf("running jobs after rejected switch = %+v, want original job still running", running)
 	}
 }
 

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -715,6 +715,7 @@ func TestServeSessionConfigRejectsBackgroundJobsWhileIdle(t *testing.T) {
 
 	jm := factory.managerAt(t, 0)
 	release := make(chan struct{})
+	var releaseOnce sync.Once
 	started := make(chan struct{})
 	sessionPath := transcriptPath(dir, nr.SessionID)
 	jm.StartForSession(agent.BranchID(sessionPath), "bash", "server", func(ctx context.Context, _ io.Writer) (string, error) {
@@ -727,7 +728,7 @@ func TestServeSessionConfigRejectsBackgroundJobsWhileIdle(t *testing.T) {
 		}
 	})
 	defer func() {
-		close(release)
+		releaseOnce.Do(func() { close(release) })
 		jm.Close()
 	}()
 	select {
@@ -753,6 +754,51 @@ func TestServeSessionConfigRejectsBackgroundJobsWhileIdle(t *testing.T) {
 	}
 	if running := jm.RunningForSession(agent.BranchID(sessionPath)); len(running) != 1 {
 		t.Fatalf("running jobs after rejected switch = %+v, want original job still running", running)
+	}
+
+	releaseOnce.Do(func() { close(release) })
+	_ = jm.WaitForSession(context.Background(), agent.BranchID(sessionPath), nil, 5)
+	if running := jm.RunningForSession(agent.BranchID(sessionPath)); len(running) != 0 {
+		t.Fatalf("running jobs after release = %+v, want none before retry", running)
+	}
+
+	retryResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "model",
+		Value:     "pro",
+	})
+	if retryResp.Error != nil {
+		t.Fatalf("retry set_config_option after jobs stopped errored: %+v", retryResp.Error)
+	}
+	var retry SetSessionConfigOptionResult
+	if err := json.Unmarshal(retryResp.Result, &retry); err != nil {
+		t.Fatalf("retry set_config_option result: %v", err)
+	}
+	modelOpt, _ := findConfigOption(retry.ConfigOptions, "model")
+	if modelOpt.CurrentValue != "pro" {
+		t.Fatalf("retry model currentValue = %q, want pro", modelOpt.CurrentValue)
+	}
+	if got := factory.buildCount(); got != 2 {
+		t.Fatalf("build count after retry switch = %d, want rebuild", got)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "after-switch"}},
+	})
+	notifs, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("prompt after retry switch errored: %+v", resp.Error)
+	}
+	var usedNewModel bool
+	for _, n := range notifs {
+		if text, ok := messageChunkText(t, n); ok && strings.Contains(text, "pro:after-switch") {
+			usedNewModel = true
+			break
+		}
+	}
+	if !usedNewModel {
+		t.Fatalf("prompt after retry did not use new model; notifications=%+v", notifs)
 	}
 }
 

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -378,6 +378,44 @@ func updateKind(t *testing.T, f frame) string {
 	return p.Update.SessionUpdate
 }
 
+func configOptionValueFromUpdate(t *testing.T, f frame, id string) (string, bool) {
+	t.Helper()
+	var p struct {
+		Update struct {
+			SessionUpdate string                `json:"sessionUpdate"`
+			ConfigOptions []SessionConfigOption `json:"configOptions"`
+		} `json:"update"`
+	}
+	if err := json.Unmarshal(f.Params, &p); err != nil {
+		t.Fatalf("decode config update: %v", err)
+	}
+	if p.Update.SessionUpdate != "config_option_update" {
+		return "", false
+	}
+	opt, ok := findConfigOption(p.Update.ConfigOptions, id)
+	if !ok {
+		return "", false
+	}
+	return opt.CurrentValue, true
+}
+
+func messageChunkText(t *testing.T, f frame) (string, bool) {
+	t.Helper()
+	var p struct {
+		Update struct {
+			SessionUpdate string       `json:"sessionUpdate"`
+			Content       ContentBlock `json:"content"`
+		} `json:"update"`
+	}
+	if err := json.Unmarshal(f.Params, &p); err != nil {
+		t.Fatalf("decode message update: %v", err)
+	}
+	if p.Update.SessionUpdate != "agent_message_chunk" || p.Update.Content.Type != "text" {
+		return "", false
+	}
+	return p.Update.Content.Text, true
+}
+
 // --- tests ---
 
 func TestServeLifecycle(t *testing.T) {
@@ -703,6 +741,113 @@ func TestServeSessionConfigRejectsBackgroundJobsWhileIdle(t *testing.T) {
 	}
 	if running := jm.RunningForSession(agent.BranchID(sessionPath)); len(running) != 1 {
 		t.Fatalf("running jobs after rejected switch = %+v, want original job still running", running)
+	}
+}
+
+func TestServeQueuedSessionConfigDiscardedWhenPromptLeavesBackgroundJob(t *testing.T) {
+	dir := t.TempDir()
+	releaseJob := make(chan struct{})
+	releaseTurn := make(chan struct{})
+	startedJob := make(chan struct{})
+	startedTurn := make(chan struct{})
+	var jobOnce sync.Once
+	factory := &configurableFactory{dir: dir, managers: []*jobs.Manager{}}
+	factory.behavior = func(ctx context.Context, sink event.Sink, input string, p SessionParams) error {
+		if input == "first" {
+			close(startedTurn)
+			jm := factory.managerAt(t, 0)
+			jobOnce.Do(func() {
+				jm.StartForSession(jobs.SessionFromContext(ctx), "bash", "server", func(ctx context.Context, _ io.Writer) (string, error) {
+					close(startedJob)
+					select {
+					case <-releaseJob:
+						return "", nil
+					case <-ctx.Done():
+						return "", ctx.Err()
+					}
+				})
+			})
+			select {
+			case <-startedJob:
+			case <-time.After(2 * time.Second):
+				t.Fatal("background job never started")
+			}
+			select {
+			case <-releaseTurn:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		sink.Emit(event.Event{Kind: event.Text, Text: p.Model + ":" + input})
+		return nil
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	first := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "first"}},
+	})
+	select {
+	case <-startedTurn:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prompt never started")
+	}
+	setResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "model",
+		Value:     "pro",
+	})
+	if setResp.Error != nil {
+		t.Fatalf("set_config_option while prompt is running errored: %+v", setResp.Error)
+	}
+
+	close(releaseTurn)
+	notifs, resp := drainPrompt(t, client, first)
+	if resp.Error != nil {
+		t.Fatalf("first prompt errored: %+v", resp.Error)
+	}
+	warningIndex := -1
+	for i, n := range notifs {
+		if text, ok := messageChunkText(t, n); ok && strings.Contains(text, "stop background jobs") {
+			warningIndex = i
+			break
+		}
+	}
+	if warningIndex < 0 {
+		t.Fatalf("queued switch updates = %d, want warning mentioning background jobs", len(notifs))
+	}
+	var sawOldConfig bool
+	for _, n := range notifs[warningIndex+1:] {
+		if value, ok := configOptionValueFromUpdate(t, n, "model"); ok && value == "fast" {
+			sawOldConfig = true
+			break
+		}
+	}
+	if !sawOldConfig {
+		t.Fatalf("queued switch notifications after warning did not include model currentValue=fast: %+v", notifs[warningIndex+1:])
+	}
+
+	close(releaseJob)
+	jm := factory.managerAt(t, 0)
+	_ = jm.WaitForSession(context.Background(), agent.BranchID(transcriptPath(dir, nr.SessionID)), nil, 5)
+	second := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "second"}},
+	})
+	_, resp = drainPrompt(t, client, second)
+	if resp.Error != nil {
+		t.Fatalf("second prompt errored: %+v", resp.Error)
+	}
+	if got := factory.buildCount(); got != 1 {
+		t.Fatalf("build count after discarded queued switch = %d, want 1", got)
 	}
 }
 

--- a/internal/acp/server_test.go
+++ b/internal/acp/server_test.go
@@ -70,6 +70,7 @@ type configurableFactory struct {
 	hookEvents []hook.Event
 	behavior   func(ctx context.Context, sink event.Sink, input string, p SessionParams) error
 	managers   []*jobs.Manager
+	withCtrl   func(ctx context.Context, sink event.Sink, input string, p SessionParams, ctrl *control.Controller) error
 }
 
 func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*control.Controller, error) {
@@ -87,9 +88,15 @@ func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*c
 			return nil
 		}
 	}
+	var ctrl *control.Controller
 	runner := &fakeRunner{
-		sink:     p.Sink,
-		behavior: func(ctx context.Context, sink event.Sink, input string) error { return behavior(ctx, sink, input, p) },
+		sink: p.Sink,
+		behavior: func(ctx context.Context, sink event.Sink, input string) error {
+			if f.withCtrl != nil {
+				return f.withCtrl(ctx, sink, input, p, ctrl)
+			}
+			return behavior(ctx, sink, input, p)
+		},
 	}
 	opts := control.Options{Runner: runner, Sink: p.Sink, SessionDir: f.dir}
 	if f.withHooks {
@@ -102,7 +109,8 @@ func (f *configurableFactory) NewSession(_ context.Context, p SessionParams) (*c
 		f.mu.Unlock()
 		opts.Jobs = jm
 	}
-	return control.New(opts), nil
+	ctrl = control.New(opts)
+	return ctrl, nil
 }
 
 func (f *configurableFactory) SessionDir() string { return f.dir }
@@ -736,6 +744,10 @@ func TestServeSessionConfigRejectsBackgroundJobsWhileIdle(t *testing.T) {
 	if setResp.Error == nil || !strings.Contains(setResp.Error.Message, "stop background jobs") {
 		t.Fatalf("set_config_option with background job error = %+v, want stop background jobs RPC error", setResp.Error)
 	}
+	legacyResp := client.call(t, "session/set_model", SetSessionModelParams{SessionID: nr.SessionID, ModelID: "pro"})
+	if legacyResp.Error == nil || !strings.Contains(legacyResp.Error.Message, "stop background jobs") {
+		t.Fatalf("set_model with background job error = %+v, want stop background jobs RPC error", legacyResp.Error)
+	}
 	if got := factory.buildCount(); got != 1 {
 		t.Fatalf("build count after rejected switch = %d, want 1", got)
 	}
@@ -848,6 +860,62 @@ func TestServeQueuedSessionConfigDiscardedWhenPromptLeavesBackgroundJob(t *testi
 	}
 	if got := factory.buildCount(); got != 1 {
 		t.Fatalf("build count after discarded queued switch = %d, want 1", got)
+	}
+}
+
+func TestServeSessionConfigRejectsPendingAsk(t *testing.T) {
+	factory := &configurableFactory{
+		withCtrl: func(ctx context.Context, _ event.Sink, _ string, _ SessionParams, ctrl *control.Controller) error {
+			_, err := ctrl.Ask(ctx, []event.AskQuestion{{
+				ID:      "choice",
+				Prompt:  "Pick one",
+				Options: []event.AskOption{{Label: "A"}, {Label: "B"}},
+			}})
+			return err
+		},
+	}
+	client, stop := startServer(t, factory)
+	defer stop()
+
+	client.call(t, "initialize", InitializeParams{ProtocolVersion: 1})
+	newResp := client.call(t, "session/new", SessionNewParams{Cwd: t.TempDir()})
+	var nr SessionNewResult
+	if err := json.Unmarshal(newResp.Result, &nr); err != nil {
+		t.Fatalf("session/new result: %v", err)
+	}
+
+	promptCh := client.callAsync("session/prompt", SessionPromptParams{
+		SessionID: nr.SessionID,
+		Prompt:    []ContentBlock{{Type: "text", Text: "ask"}},
+	})
+	var req frame
+	select {
+	case req = <-client.reqs:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ask request was not sent to client")
+	}
+
+	setResp := client.call(t, "session/set_config_option", SetSessionConfigOptionParams{
+		SessionID: nr.SessionID,
+		ConfigID:  "model",
+		Value:     "pro",
+	})
+	if setResp.Error == nil || !strings.Contains(setResp.Error.Message, "pending") {
+		t.Fatalf("set_config_option with pending ask error = %+v, want pending interaction RPC error", setResp.Error)
+	}
+	if got := factory.buildCount(); got != 1 {
+		t.Fatalf("build count while ask is pending = %d, want 1", got)
+	}
+
+	client.reply(req.ID, PermissionRequestResult{
+		Outcome: PermissionOutcome{Outcome: "selected", OptionID: "choice:1"},
+	})
+	_, resp := drainPrompt(t, client, promptCh)
+	if resp.Error != nil {
+		t.Fatalf("prompt errored: %+v", resp.Error)
+	}
+	if got := factory.buildCount(); got != 1 {
+		t.Fatalf("build count after answered ask = %d, want no queued rebuild", got)
 	}
 }
 

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -657,7 +657,12 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 		sess.mu.Unlock()
 		return &RPCError{Code: ErrInvalidRequest, Message: "session config: session is deleted"}
 	}
-	if sess.running || sess.ctrl.Running() {
+	status := sess.ctrl.RuntimeStatus()
+	if !sess.running && !status.Running && status.BackgroundJobs > 0 {
+		sess.mu.Unlock()
+		return &RPCError{Code: ErrInvalidRequest, Message: "session config: stop background jobs before switching config"}
+	}
+	if sess.running || status.Running {
 		pending := cloneSessionConfigState(cfgState)
 		sess.model = cfgState.Model
 		sess.effortOverride = cloneStringPtr(cfgState.EffortOverride)

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -539,6 +539,11 @@ func (s *service) sessionPrompt(ctx context.Context, raw json.RawMessage) (any, 
 		sess.finish()
 		if err := s.applyPendingSessionConfig(ctx, sess); err != nil {
 			sess.sink.Emit(event.Event{Kind: event.Notice, Level: event.LevelWarn, Text: "session config switch failed after turn: " + err.Error()})
+			if isSessionConfigActiveWorkError(err) {
+				if current, stateErr := s.configStateForSession(ctx, sess); stateErr == nil {
+					sess.sink.send(configOptionUpdate{SessionUpdate: "config_option_update", ConfigOptions: current.ConfigOptions})
+				}
+			}
 		}
 		cancel()
 	}()
@@ -660,16 +665,11 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 	status := sess.ctrl.RuntimeStatus()
 	if !sess.running && !status.Running && status.BackgroundJobs > 0 {
 		sess.mu.Unlock()
-		return &RPCError{Code: ErrInvalidRequest, Message: "session config: stop background jobs before switching config"}
+		return sessionConfigActiveWorkError("stop background jobs before switching config")
 	}
 	if sess.running || status.Running {
 		pending := cloneSessionConfigState(cfgState)
-		sess.model = cfgState.Model
-		sess.effortOverride = cloneStringPtr(cfgState.EffortOverride)
 		sess.pendingConfig = &pending
-		if sess.transcript != "" && sessionFileExists(sess.transcript) {
-			_ = saveACPMeta(sess.transcript, sess.metaLocked())
-		}
 		sess.mu.Unlock()
 		sess.sink.send(configOptionUpdate{SessionUpdate: "config_option_update", ConfigOptions: cfgState.ConfigOptions})
 		return nil
@@ -741,15 +741,26 @@ func (s *service) applyPendingSessionConfig(ctx context.Context, sess *acpSessio
 	sess.mu.Unlock()
 
 	if err := s.rebuildSession(ctx, sess, cfgState); err != nil {
-		sess.mu.Lock()
-		if !sess.deleted && sess.pendingConfig == nil {
-			pending := cloneSessionConfigState(cfgState)
-			sess.pendingConfig = &pending
+		if !isSessionConfigActiveWorkError(err) {
+			sess.mu.Lock()
+			if !sess.deleted && sess.pendingConfig == nil {
+				pending := cloneSessionConfigState(cfgState)
+				sess.pendingConfig = &pending
+			}
+			sess.mu.Unlock()
 		}
-		sess.mu.Unlock()
 		return err
 	}
 	return nil
+}
+
+func sessionConfigActiveWorkError(message string) *RPCError {
+	return &RPCError{Code: ErrInvalidRequest, Message: "session config: " + message}
+}
+
+func isSessionConfigActiveWorkError(err error) bool {
+	re, ok := err.(*RPCError)
+	return ok && re.Code == ErrInvalidRequest && strings.Contains(re.Message, "before switching config")
 }
 
 // sessionClose releases an active session. Unknown sessions are accepted as a

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -663,6 +663,10 @@ func (s *service) rebuildSession(ctx context.Context, sess *acpSession, cfgState
 		return &RPCError{Code: ErrInvalidRequest, Message: "session config: session is deleted"}
 	}
 	status := sess.ctrl.RuntimeStatus()
+	if status.PendingPrompt {
+		sess.mu.Unlock()
+		return sessionConfigActiveWorkError("answer pending prompts before switching config")
+	}
 	if !sess.running && !status.Running && status.BackgroundJobs > 0 {
 		sess.mu.Unlock()
 		return sessionConfigActiveWorkError("stop background jobs before switching config")

--- a/internal/acp/service.go
+++ b/internal/acp/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -758,13 +759,23 @@ func (s *service) applyPendingSessionConfig(ctx context.Context, sess *acpSessio
 	return nil
 }
 
-func sessionConfigActiveWorkError(message string) *RPCError {
-	return &RPCError{Code: ErrInvalidRequest, Message: "session config: " + message}
+type activeSessionConfigWorkError struct {
+	*RPCError
+}
+
+func (e *activeSessionConfigWorkError) Unwrap() error {
+	return e.RPCError
+}
+
+func sessionConfigActiveWorkError(message string) error {
+	return &activeSessionConfigWorkError{
+		RPCError: &RPCError{Code: ErrInvalidRequest, Message: "session config: " + message},
+	}
 }
 
 func isSessionConfigActiveWorkError(err error) bool {
-	re, ok := err.(*RPCError)
-	return ok && re.Code == ErrInvalidRequest && strings.Contains(re.Message, "before switching config")
+	var activeErr *activeSessionConfigWorkError
+	return errors.As(err, &activeErr)
 }
 
 // sessionClose releases an active session. Unknown sessions are accepted as a


### PR DESCRIPTION
## 背景

ACP 会话切换模型或会话级配置时，会重建 controller。后台任务由旧 controller 的 job manager 持有；如果在后台任务仍运行时释放旧 controller，就会把这些任务一起取消。

Desktop 已经把后台任务视为活跃运行时工作，会阻止这类重建。ACP 之前只保护前台 prompt，没有完整保护后台任务和 pending 用户交互。

## 做了什么

- ACP 在真正重建 controller 前统一检查运行时状态：
  - 有后台任务运行时，直接返回 RPC error，提示先停止后台任务。
  - 有 approval/ask 等 pending 用户交互时，直接返回 RPC error，不再排队。
  - 前台 prompt 正常运行且未等待用户输入时，仍保持原有排队行为。
- 如果排队的配置切换在 prompt 结束后被后台任务阻止：
  - 不重建 controller。
  - 丢弃这次排队请求，不保留到未来自动执行。
  - 通过 `session/update` 发出 warning。
  - 再发送 `config_option_update`，把可见配置恢复为旧 controller 的真实值。
- 补充 ACP 回归测试，覆盖直接拒绝、排队失败、pending ask 拒绝、legacy `session/set_model` 以及后台任务停止后重试成功。

## 为什么这样做

运行中的后台任务属于旧 controller。迁移任务到新 controller 会引入复杂生命周期问题，也和 Desktop 的用户模型不一致。更清晰的行为是：只要切换会影响仍在运行的工作，就拒绝或丢弃本次切换，并让客户端明确看到原因。

## 结果与影响

- ACP 不会再因为模型/配置切换而静默取消后台任务。
- 客户端能通过 RPC error 或 warning/config update 明确知道切换没有应用。
- 后台任务停止后，用户可以重新发起同一个切换，并正常成功。
- Desktop 现有后台任务保护行为不变。

## 验证

- `go test ./internal/acp -count=1`
- `go test . -run 'TestSetTokenModeRejectsBackgroundJobs|TestSettingsRebuildRejectsBackgroundJobs|TestSetReasoningLanguageRejectsBackgroundJobsBeforeSavingConfig' -count=1`（在 `desktop/`）

Cache-impact: none，未修改 system prompt、tool schema、provider 请求序列化、memory prefix 或 MCP/tool 注册面。
Cache-guard: `go test ./internal/acp -count=1`；本次改动不影响 prompt/cache prefix。