### PR TITLE
Consolidate desktop rewind and plan prompt recovery / 整合桌面回溯与计划确认恢复

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -1140,8 +1140,9 @@ func removeDesktopSessionArtifacts(path string) error {
 type CheckpointMeta struct {
 	Turn            int      `json:"turn"`
 	Prompt          string   `json:"prompt"`
-	Files           []string `json:"files"` // paths changed during the turn
-	Time            int64    `json:"time"`  // unix milliseconds
+	Files           []string `json:"files"`         // cumulative files RestoreCode would affect from this turn
+	TurnFileCount   int      `json:"turnFileCount"` // files changed during this turn only
+	Time            int64    `json:"time"`          // unix milliseconds
 	CanCode         bool     `json:"canCode"`
 	CanConversation bool     `json:"canConversation"`
 }
@@ -1168,6 +1169,7 @@ func (a *App) CheckpointsForTab(tabID string) []CheckpointMeta {
 			Turn:            m.Turn,
 			Prompt:          m.Prompt,
 			Files:           m.Paths,
+			TurnFileCount:   len(m.Paths),
 			Time:            m.Time.UnixMilli(),
 			CanCode:         len(m.Paths) > 0,
 			CanConversation: ctrl.CheckpointHasBoundary(m.Turn),

--- a/desktop/checkpoints_cancode_test.go
+++ b/desktop/checkpoints_cancode_test.go
@@ -68,4 +68,13 @@ func TestCheckpointsCanCodePropagatesToEarlierTurns(t *testing.T) {
 	if got[2] {
 		t.Error("turn 2 is after the last file-bearing turn, should NOT allow code rewind")
 	}
+	if metas[0].TurnFileCount != 0 {
+		t.Fatalf("turn 0 file count = %d, want 0 for this turn", metas[0].TurnFileCount)
+	}
+	if metas[1].TurnFileCount != 1 {
+		t.Fatalf("turn 1 file count = %d, want 1 for this turn", metas[1].TurnFileCount)
+	}
+	if len(metas[0].Files) != 1 || metas[0].Files[0] != "a.txt" {
+		t.Fatalf("turn 0 cumulative files = %#v, want [a.txt]", metas[0].Files)
+	}
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2006,7 +2006,7 @@ export default function App() {
   // Display items: truncated when an optimistic rewind is pending.
   const displayItems = useMemo(() => {
     if (!rewindState) return state.items;
-    return state.items.slice(0, rewindState.boundaryIdx);
+    return state.items.slice(0, rewindState.boundaryIdx).filter((it) => it.kind !== "compaction");
   }, [state.items, rewindState]);
 
   // send wrapper: commits any pending optimistic rewind before sending.
@@ -2014,12 +2014,12 @@ export default function App() {
     if (activeTab?.readOnly) return;
     const rs = rewindStateRef.current;
     if (rs) {
-      setRewindState(null);
       const ok = await rewind(rs.turn, rs.scope);
       if (!ok) {
-        // Rewind failed: the Go conversation is intact, so the cleared
-        // optimistic state already shows the full transcript. Don't send —
-        // the controller emits a notice with the reason.
+        // Rewind failed: the Go conversation is intact, so the
+        // optimistic state still shows the truncated transcript. Clear it and
+        // don't send — the controller emits a notice with the reason.
+        setRewindState(null);
         return;
       }
       setRewindSignal((v) => v + 1);
@@ -2028,6 +2028,7 @@ export default function App() {
         setDockRefreshKey((v) => v + 1);
         setProjectRevision((v) => v + 1);
       }
+      setRewindState(null);
     }
     send(displayText, submitText);
   }, [activeTab?.readOnly, send, rewind]);
@@ -2047,6 +2048,17 @@ export default function App() {
     // Code-only rewind only affects files — no message truncation,
     // no optimistic UI needed.  Execute immediately.
     if (scope === "code") {
+      rewind(turn, scope).then((ok) => {
+        if (!ok) return;
+        setDockRefreshKey((v) => v + 1);
+        setProjectRevision((v) => v + 1);
+      });
+      return;
+    }
+
+    // Summarize only compresses the conversation log — no files touched,
+    // no optimistic UI needed. Execute immediately like code-only rewind.
+    if (scope === "summ-from" || scope === "summ-upto") {
       rewind(turn, scope).then((ok) => {
         if (!ok) return;
         setDockRefreshKey((v) => v + 1);

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -51,6 +51,17 @@ const unsent = reducer(sent, { type: "unsend" });
 eq(unsent.pendingUser, undefined, "unsend clears the pending marker");
 eq(unsent.discardTurn, true, "unsend discards the in-flight turn");
 
+const planApprovalFirst = reducer(
+  { ...initialState },
+  { type: "event", e: { kind: "approval_request", approval: { id: "plan-1", tool: "exit_plan_mode", subject: "Approve plan" } } as WireEvent },
+);
+const planTurnDoneAfter = reducer(planApprovalFirst, { type: "event", e: { kind: "turn_done" } as WireEvent });
+eq(
+  planTurnDoneAfter.approval?.id,
+  "plan-1",
+  "turn_done preserves out-of-order plan approval",
+);
+
 let replayCalls = 0;
 replayPendingPromptsForActiveTab(undefined, () => {
   replayCalls += 1;

--- a/desktop/frontend/src/components/Message.tsx
+++ b/desktop/frontend/src/components/Message.tsx
@@ -10,6 +10,7 @@ import type { DisplayAttachment } from "../lib/attachmentDisplay";
 import { app } from "../lib/bridge";
 import { replaySubmitText } from "../lib/editReplay";
 import { useT } from "../lib/i18n";
+import { Tooltip } from "./Tooltip";
 import { useGSAPCollapse } from "../lib/useGSAPCollapse";
 import { displayReasoningText } from "../lib/reasoningDisplay";
 import type { Item, MessageActionScope } from "../lib/useController";
@@ -421,9 +422,28 @@ export function TurnActions({
   };
   const actionMeta = (scope: MessageActionScope): string => {
     if ((scope === "code" || scope === "both") && checkpoint?.files?.length) {
-      return t("rewind.filesChanged", { count: checkpoint.files.length });
+      const total = checkpoint.files.length;
+      const turnCount = checkpoint.turnFileCount ?? 0;
+      if (turnCount > 0 && turnCount < total) {
+        return `${t("rewind.filesChanged", { count: total })} (${t("rewind.turnFiles", { count: turnCount })})`;
+      }
+      return t("rewind.filesChanged", { count: total });
     }
     return "";
+  };
+  const actionTooltipLabel = (scope: MessageActionScope) => {
+    const reason = actionDisabledReason(scope);
+    if (reason) return <span>{reason}</span>;
+    if ((scope === "code" || scope === "both") && checkpoint?.files?.length) {
+      return (
+        <div className="rewind__files-tooltip">
+          {checkpoint.files.map((file) => (
+            <div key={file}>{file.split(/[/\\]/).pop() || file}</div>
+          ))}
+        </div>
+      );
+    }
+    return undefined;
   };
   const runAction = (scope: MessageActionScope) => {
     setConfirmScope(null);
@@ -441,7 +461,8 @@ export function TurnActions({
   const renderAction = (scope: MessageActionScope, danger = false) => {
     const disabledReason = actionDisabledReason(scope);
     const meta = actionMeta(scope);
-    return (
+    const tipLabel = actionTooltipLabel(scope);
+    const button = (
       <button
         className={[
           "rewind__menu-item",
@@ -450,13 +471,14 @@ export function TurnActions({
         ].filter(Boolean).join(" ")}
         type="button"
         disabled={Boolean(disabledReason)}
-        title={disabledReason || undefined}
+        {...(tipLabel ? {} : { title: disabledReason || undefined })}
         onClick={() => selectRewind(scope)}
       >
         <span>{actionLabel(scope)}</span>
         {meta && <span className="rewind__menu-meta">{meta}</span>}
       </button>
     );
+    return tipLabel ? <Tooltip key={scope} label={tipLabel} side="top" block fill>{button}</Tooltip> : button;
   };
   const forkDisabledReason = canAct ? actionDisabledReason("fork") : "";
   const toggleMenu = (menu: TurnActionMenu) => {

--- a/desktop/frontend/src/lib/bridge.ts
+++ b/desktop/frontend/src/lib/bridge.ts
@@ -1734,7 +1734,7 @@ function makeMockApp(): AppBindings {
         async ClearSession() {},
     async Checkpoints() {
       return [
-        { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], time: Date.now() - 30_000, canCode: true, canConversation: true },
+        { turn: 0, prompt: "你好呀", files: ["src/App.tsx"], turnFileCount: 1, time: Date.now() - 30_000, canCode: true, canConversation: true },
       ];
     },
     async CheckpointsForTab() {

--- a/desktop/frontend/src/lib/types.ts
+++ b/desktop/frontend/src/lib/types.ts
@@ -284,6 +284,7 @@ export interface CheckpointMeta {
   turn: number;
   prompt: string;
   files: string[];
+  turnFileCount?: number;
   time: number; // unix ms
   canCode?: boolean;
   canConversation?: boolean;

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -610,7 +610,10 @@ function applyEvent(s: State, e: WireEvent): State {
         return it;
       });
       let items: Item[] = e.err ? [...finalized, { kind: "notice", id: `e${s.seq}`, level: "warn", text: e.err }] : finalized;
-      return { ...s, items, live: undefined, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, approval: undefined, ask: undefined, seq: s.seq + 1 };
+      // Plan approval can arrive before turn_done on some Wails event paths.
+      // Keep that gate visible instead of clearing the only UI that can answer it.
+      const keepPlanApproval = s.approval?.tool === "exit_plan_mode";
+      return { ...s, items, live: undefined, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, approval: keepPlanApproval ? s.approval : undefined, ask: undefined, seq: s.seq + 1 };
     }
     default: return s;
   }
@@ -867,6 +870,9 @@ export function useController() {
       cancelRequested: Boolean(tab.cancelRequested),
       cancellable: foregroundRunning,
     });
+    // backend_status reconciliation can clear a live prompt from frontend state.
+    // If the backend is still blocked, ask it to replay the approval/ask event.
+    if (tab.pendingPrompt) replayPendingPromptsForActiveTab(tabId);
     if (needsInitialLoad || missedTurnDone) {
       await loadSessionDataForTab(tabId, missedTurnDone);
       return tabs;

--- a/desktop/frontend/src/locales/en.ts
+++ b/desktop/frontend/src/locales/en.ts
@@ -1467,6 +1467,7 @@ export const en = {
   "rewind.disabledNoCode": "No code changes were captured after this message",
   "rewind.disabledNoEarlier": "There is nothing before this message to summarize",
   "rewind.filesChanged": "{count} files",
+  "rewind.turnFiles": "{count} this turn",
   "rewind.both": "Rewind code and conversation",
   "rewind.conversation": "Rewind conversation only",
   "rewind.code": "Rewind code only",

--- a/desktop/frontend/src/locales/zh-TW.ts
+++ b/desktop/frontend/src/locales/zh-TW.ts
@@ -911,6 +911,7 @@ export const zhTW: Record<DictKey, string> = {
   "rewind.disabledNoCode": "這條訊息之後沒有捕獲到程式碼變更",
   "rewind.disabledNoEarlier": "這條訊息之前沒有可總結內容",
   "rewind.filesChanged": "{count} 個檔案",
+  "rewind.turnFiles": "本輪 {count} 個",
   "rewind.both": "回滾程式碼和對話",
   "rewind.conversation": "僅回滾對話",
   "rewind.code": "僅回滾程式碼",

--- a/desktop/frontend/src/locales/zh.ts
+++ b/desktop/frontend/src/locales/zh.ts
@@ -1469,6 +1469,7 @@ export const zh: Record<DictKey, string> = {
   "rewind.disabledNoCode": "这条消息之后没有捕获到代码改动",
   "rewind.disabledNoEarlier": "这条消息之前没有可总结内容",
   "rewind.filesChanged": "{count} 个文件",
+  "rewind.turnFiles": "本轮 {count} 个",
   "rewind.both": "回滚代码和对话",
   "rewind.conversation": "仅回滚对话",
   "rewind.code": "仅回滚代码",


### PR DESCRIPTION
## Summary

This is an integration PR for the related desktop rewind/summarize and plan-prompt recovery work discussed across several contributor PRs.

- Execute `summ-from` / `summ-upto` immediately instead of routing them through optimistic rewind UI, so summarize actually calls the backend and does not look like a code rollback.
- Preserve an already-received `exit_plan_mode` approval when `turn_done` arrives later, covering Wails event reordering on Windows.
- Replay pending approval/ask prompts after stale-turn runtime reconciliation when the backend still reports `pendingPrompt`, extending the existing reconnect/tab-switch replay paths.
- Keep optimistic rewind display truncated during the async backend rewind and filter compaction cards from the preview to avoid confusing transcript flashes/artifacts.
- Distinguish cumulative code-rewind file count from the files changed in the selected turn, and expose the cumulative file list in the rewind action tooltip.

Fixes #5032
Fixes #4461
Fixes #5060
Fixes #4474

Supersedes #5051, #5061, #4345, and #4522 if this integration PR is merged.

## Consolidation Notes

### Kept or adapted

- #5051 by @myipanta: kept the direct summarize execution path for `summ-from` / `summ-upto`, and kept the out-of-order `exit_plan_mode` approval preservation idea.
- #5061 by @eghrhegpe: kept the `turnFileCount` contract so the UI can show cumulative affected files separately from this-turn files.
- #4345 by @CVEngineer66: adapted the optimistic rewind preview improvements: compaction-card filtering, delayed optimistic-state clear until backend success, and file-list tooltip behavior.
- #4522 by @CVEngineer66: adapted the stale-turn reconcile prompt replay fix, scoped to replay only when the backend still reports a pending prompt.

### Already merged foundations this PR builds on

- #3857 by @esengine: introduced backend `ReplayPendingPrompts` for blocked approval/ask prompts on reconnect/reload.
- #4286 by @myipanta, with regression coverage by @SivanCola: replayed pending prompts on tab switch; this PR extends the same recovery model to stale-turn reconciliation.
- #3672 by @esengine: established suffix-scan `CanCode` and cumulative RestoreCode file semantics; this PR clarifies that UI contract with per-turn counts.
- #4577 by @SivanCola: introduced the user-message actions surface where summarize/rewind actions live.

### Reviewed but not adopted

- #4522 also contains Settings/ModelSwitcher CPU/render optimization work. That is useful but unrelated to this integration, so it is intentionally not included here.
- #4345's behavior was ported onto the current `main-v2` async `rewind()` contract instead of mechanically copying the older diff.

## Repository Contributor Credits

This integration treats the following GitHub users as repository contributors to the combined fix: @myipanta, @eghrhegpe, @CVEngineer66, @esengine, and @SivanCola. Their public PRs and the adopted or foundational contributions are listed above so credit remains attached to the original work and not only to this integration branch.

## Cache Impact

Cache-impact: none — this changes desktop UI/controller state handling and checkpoint metadata only; it does not change provider-visible prompts, tool schemas, tool ordering, memory prefix, or request serialization.
Cache-guard: not applicable for provider cache shape; focused desktop/frontend and checkpoint tests cover the changed behavior.
System-prompt-review: N/A.

## Verification

- `go test . -run TestCheckpointsCanCodePropagatesToEarlierTurns -count=1` in the desktop module passed.
- `pnpm exec tsx src/__tests__/send-failed.test.ts` passed.
- `pnpm run check:css` passed.
- `pnpm run typecheck` was attempted but this local checkout lacks generated Wails bindings (`desktop/wailsjs/go/main/App.d.ts`), so it fails before checking these changes.