### PR TITLE
Fix retry user-choice prompts through ask / 修复重试时的用户选择等待

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1120,7 +1120,7 @@ func finalReadinessCheckSource(check instruction.VerifyCheck) string {
 }
 
 func finalReadinessRetryMessage(reason string) string {
-	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied."
+	return "Host final-answer readiness check failed. Before giving a final answer, address the missing host-observable receipts: " + reason + ". Run the required tool calls, then answer when readiness is satisfied. If the blocked item needs user input, call the ask tool with concrete options and wait for its tool result; do not ask in prose, and do not claim the user answered unless an actual ask tool result or a new user message says so."
 }
 
 func shouldNudgeExecutorHandoff(input, answer string) bool {
@@ -1261,7 +1261,7 @@ func executorHandoffRetryMessage() string {
 The tool schema is still attached to this executor request. Do not invent that MCP servers or tools are unavailable; only report an unavailable tool after a real tool call or host error proves it.
 
 Do not answer as the planner and do not ask how to trigger the executor.
-Use your available tools now to carry out the task. If a write or command is blocked by permissions or workspace boundaries, state that specific blocker and ask for the needed approval/path.`
+Use your available tools now to carry out the task. If carrying out the planner's instructions requires a user-owned choice or review, call the ask tool with concrete options and wait for its tool result; do not ask in prose, and do not claim the user answered unless an actual ask tool result or a new user message says so. If a write or command is blocked by permissions or workspace boundaries, state that specific blocker and ask for the needed approval/path.`
 }
 
 func hasVisibleFinalAnswer(text string) bool {

--- a/internal/agent/coordinator_test.go
+++ b/internal/agent/coordinator_test.go
@@ -335,6 +335,20 @@ func TestCoordinatorNudgesExecutorThatAnswersWithoutActing(t *testing.T) {
 	}
 }
 
+func TestExecutorHandoffRetryMessageKeepsUserChoicesInteractive(t *testing.T) {
+	msg := executorHandoffRetryMessage()
+	lower := strings.ToLower(msg)
+	for _, want := range []string{
+		"ask tool",
+		"do not ask in prose",
+		"do not claim the user answered",
+	} {
+		if !strings.Contains(lower, want) {
+			t.Fatalf("executorHandoffRetryMessage() missing %q:\n%s", want, msg)
+		}
+	}
+}
+
 func TestCoordinatorAllowsGuidanceOnlyExecutorHandoff(t *testing.T) {
 	planner := &mockProvider{name: "planner", chunks: []provider.Chunk{
 		{Type: provider.ChunkText, Text: "Tell the user to open the audio app, enable the Peace checkbox, and play a song to compare the difference."},

--- a/internal/agent/final_readiness_test.go
+++ b/internal/agent/final_readiness_test.go
@@ -97,3 +97,17 @@ func TestFinalReadinessCheckAuditsIncompleteTodos(t *testing.T) {
 		t.Fatalf("audit.IncompleteTodos = %d, want 1", audit.IncompleteTodos)
 	}
 }
+
+func TestFinalReadinessRetryMessageKeepsUserChoicesInteractive(t *testing.T) {
+	msg := finalReadinessRetryMessage("latest successful todo_write still has incomplete items: Ask user to review the doc: in_progress")
+	lower := strings.ToLower(msg)
+	for _, want := range []string{
+		"ask tool",
+		"do not ask in prose",
+		"do not claim the user answered",
+	} {
+		if !strings.Contains(lower, want) {
+			t.Fatalf("finalReadinessRetryMessage() missing %q:\n%s", want, msg)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Route retry-time user-owned choices and reviews through the blocking `ask` tool instead of prose questions.
- Tell the executor not to claim the user answered unless an actual `ask` result or a new user message exists.
- Add regression tests for both final-readiness retry and two-model executor handoff retry guidance.

Fixes #5025

## Verification

- `go test ./internal/agent -run 'TestFinalReadinessRetryMessageKeepsUserChoicesInteractive|TestExecutorHandoffRetryMessageKeepsUserChoicesInteractive' -count=1`
- `go test ./internal/agent -count=1`
- `go test ./...`
- `go test ./...` in `desktop/`
- `go vet ./...`
- `go vet ./...` in `desktop/`
- `gofmt -l .`
- `git diff --check`

## Cache impact

Cache-impact: low. This changes transient model-facing recovery instructions after final-readiness or executor-handoff retry blocks; it does not change the cache-stable system prompt, memory prefix, tool schema, tool order, request serialization, compaction, or MCP/tool registration.
Cache-guard: `go test ./internal/agent -run 'TestFinalReadinessRetryMessageKeepsUserChoicesInteractive|TestExecutorHandoffRetryMessageKeepsUserChoicesInteractive' -count=1` covers the changed recovery prompts.
System-prompt-review: N/A.
