### PR TITLE
Fix short choice replies in dual-model context / 修复双模型短选项回复上下文

### DIFF
--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -145,6 +145,9 @@ func isContextDependentShortReply(text string) bool {
 		return true
 	}
 	lower := strings.ToLower(text)
+	if containsAny(lower, complexIntentTerms) || containsAny(lower, lowRiskWorkRequestTerms) {
+		return false
+	}
 	if shortContextReplies[lower] {
 		return true
 	}

--- a/internal/control/auto_plan.go
+++ b/internal/control/auto_plan.go
@@ -17,6 +17,8 @@ const (
 )
 
 var numberedListRE = regexp.MustCompile(`(?m)^\s*(?:[-*]|\d+[.)])\s+\S`)
+var directOptionReplyRE = regexp.MustCompile(`(?i)^\s*(?:\d+|[a-z])\s*[.)、。]?\s*$`)
+var prefixedOptionReplyRE = regexp.MustCompile(`(?i)^\s*(?:选|选择|就|用|按|走|执行|choose|pick|use|option|choice|方案)\s*(?:第\s*)?(?:方案|选项|option|choice)?\s*(?:\d+|[一二三四五六七八九十]|[a-z])\s*(?:个|号|项|种|条|方案|option|choice)?\s*[.)、。!！?？]?\s*$`)
 
 type AutoPlanClassifier interface {
 	NeedsPlan(ctx context.Context, input string, score int) (bool, string, error)
@@ -72,8 +74,10 @@ func (c *Controller) shouldAutoPlan(ctx context.Context, input string) bool {
 
 // TaskWarrantsPlanner reports whether a task turn is worth a planner pass in
 // two-model mode. Empty input, slash commands, and low-risk informational asks
-// (explain / show / what / why / 解释 / 查一下 …) skip straight to the executor;
-// anything that reads like a work request — even a terse one — still gets planned.
+// (explain / show / what / why / 解释 / 查一下 …) skip straight to the executor.
+// Context-dependent short replies ("1", "A", "继续", "好的") also skip the
+// planner because the executor session, not the planner session, owns the
+// previous assistant answer they refer to.
 func TaskWarrantsPlanner(input string) bool {
 	text := strings.TrimSpace(agent.StripTransientUserBlocks(input))
 	text = stripActiveGoalBlock(text)
@@ -81,6 +85,9 @@ func TaskWarrantsPlanner(input string) bool {
 		return false
 	}
 	if IsSyntheticUserMessage(text) {
+		return false
+	}
+	if isContextDependentShortReply(text) {
 		return false
 	}
 	return !isLowRiskQuestion(strings.ToLower(text))
@@ -93,6 +100,9 @@ func autoPlanScore(input string) int {
 		return 0
 	}
 	if IsSyntheticUserMessage(text) {
+		return 0
+	}
+	if isContextDependentShortReply(text) {
 		return 0
 	}
 	lower := strings.ToLower(text)
@@ -124,6 +134,71 @@ func autoPlanScore(input string) int {
 		score++
 	}
 	return score
+}
+
+func isContextDependentShortReply(text string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" || strings.ContainsAny(text, "\n\r") {
+		return false
+	}
+	if directOptionReplyRE.MatchString(text) || prefixedOptionReplyRE.MatchString(text) {
+		return true
+	}
+	lower := strings.ToLower(text)
+	if shortContextReplies[lower] {
+		return true
+	}
+	if utf8.RuneCountInString(text) > 16 {
+		return false
+	}
+	for _, prefix := range shortContextReplyPrefixes {
+		if strings.HasPrefix(lower, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+var shortContextReplies = map[string]bool{
+	"ok":          true,
+	"okay":        true,
+	"yes":         true,
+	"y":           true,
+	"no":          true,
+	"n":           true,
+	"sure":        true,
+	"go ahead":    true,
+	"proceed":     true,
+	"continue":    true,
+	"next":        true,
+	"sounds good": true,
+	"好":           true,
+	"好的":          true,
+	"可以":          true,
+	"行":           true,
+	"嗯":           true,
+	"对":           true,
+	"是":           true,
+	"确认":          true,
+	"同意":          true,
+	"继续":          true,
+	"继续吧":         true,
+	"下一步":         true,
+	"开始":          true,
+	"开始吧":         true,
+	"执行":          true,
+	"就这样":         true,
+	"没问题":         true,
+}
+
+var shortContextReplyPrefixes = []string{
+	"继续",
+	"执行",
+	"开始",
+	"下一步",
+	"go ahead",
+	"proceed",
+	"continue",
 }
 
 func isLowRiskQuestion(lower string) bool {

--- a/internal/control/auto_plan_test.go
+++ b/internal/control/auto_plan_test.go
@@ -14,6 +14,12 @@ func TestTaskWarrantsPlanner(t *testing.T) {
 		{"", false},
 		{"   ", false},
 		{"/init", false},
+		{"1", false},
+		{"2.", false},
+		{"A", false},
+		{"好的", false},
+		{"继续", false},
+		{"选 1", false},
 		{"what does this function do?", false}, // low-risk question → executor only
 		{"why did the test fail", false},
 		{"解释一下这段代码", false},

--- a/internal/control/auto_plan_test.go
+++ b/internal/control/auto_plan_test.go
@@ -28,6 +28,10 @@ func TestTaskWarrantsPlanner(t *testing.T) {
 		{reasoningLanguageBlock("en") + "\n\nfix the bug", true},
 		{"fix the bug", true},        // terse, but a work request → still planned
 		{"add a login button", true}, // ditto
+		{"执行修复", true},
+		{"开始迁移", true},
+		{"继续重构", true},
+		{"continue fixing tests", true},
 		{"implement the new caching layer across the backend", true},
 		{"who wrote this file?", false},
 		{"where is the config file?", false},

--- a/internal/control/controller_test.go
+++ b/internal/control/controller_test.go
@@ -149,6 +149,15 @@ func requestMessagesText(messages []provider.Message) string {
 	return b.String()
 }
 
+func lastUserMessage(messages []provider.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == provider.RoleUser {
+			return messages[i].Content
+		}
+	}
+	return ""
+}
+
 func TestNewTreatsTypedNilSinkAsDiscard(t *testing.T) {
 	var sink *typedNilControllerSink
 	c := New(Options{Sink: sink})
@@ -588,6 +597,43 @@ func TestResetPlannerSessionClearsPlannerHistory(t *testing.T) {
 	}
 	if !strings.Contains(second, "second task") {
 		t.Fatalf("planner request after reset missing current task:\n%s", second)
+	}
+}
+
+func TestTwoModelShortChoiceReplySkipsPlanner(t *testing.T) {
+	dir := t.TempDir()
+	planner := &recordingProvider{name: "planner", streams: [][]provider.Chunk{
+		textTurn("planner should not run for a context-dependent choice reply"),
+	}}
+	execProv := &recordingProvider{name: "executor", streams: [][]provider.Chunk{
+		textTurn("selected option 1"),
+	}}
+	execSess := agent.NewSession("exec sys")
+	execSess.Add(provider.Message{Role: provider.RoleUser, Content: "先给我两个执行方案"})
+	execSess.Add(provider.Message{Role: provider.RoleAssistant, Content: "两个执行方式可选：\n\n1. Subagent-Driven（推荐）\n2. 当前会话执行\n\n你选哪种？"})
+	exec := agent.New(execProv, tool.NewRegistry(), execSess, agent.Options{}, event.Discard)
+	coord := agent.NewCoordinator(planner, agent.NewSession("planner sys"), nil, tool.NewRegistry(), agent.Options{}, exec, 0, event.Discard, NewPlannerGate(nil))
+	c := New(Options{Runner: coord, Executor: exec, SystemPrompt: "exec sys", SessionDir: dir, SessionPath: filepath.Join(dir, "session.jsonl"), Label: "test"})
+
+	if err := c.Run(context.Background(), "1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(planner.requests) != 0 {
+		t.Fatalf("planner requests = %d, want 0 for a short context-dependent choice reply", len(planner.requests))
+	}
+	if len(execProv.requests) != 1 {
+		t.Fatalf("executor requests = %d, want 1", len(execProv.requests))
+	}
+	reqText := requestMessagesText(execProv.requests[0].Messages)
+	if !strings.Contains(reqText, "1. Subagent-Driven") {
+		t.Fatalf("executor request lost the previous assistant options:\n%s", reqText)
+	}
+	if strings.Contains(reqText, "Reasonix executor handoff") {
+		t.Fatalf("short choice reply should not be wrapped as a planner handoff:\n%s", reqText)
+	}
+	if got := lastUserMessage(execProv.requests[0].Messages); got != "1" {
+		t.Fatalf("executor last user = %q, want raw choice reply", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Treat short context-dependent replies like `1`, `A`, `好的`, `继续`, and `选 1` as executor-only turns in two-model mode, so they keep the previous assistant answer from the executor session instead of starting a fresh planner pass without context.
- Keep auto-plan scoring aligned with the same short-reply guard so these replies do not enter read-only planning.
- Add regression coverage for the reported numbered-choice flow: after the assistant offers numbered options, a user reply of `1` goes directly to the executor, preserves the previous assistant options in the request, and is not wrapped as a planner handoff.

Fixes #5027

## Verification

- `go test ./internal/control -run 'Test(TaskWarrantsPlanner|TwoModelShortChoiceReplySkipsPlanner)' -count=1`
- `go test ./internal/control -count=1`
- `go test ./internal/agent -run TestCoordinator -count=1`
- `go test ./...`
- `go test ./...` in `desktop/`
- `go vet ./...`
- `go vet ./...` in `desktop/`
- `gofmt -l .`
- `git diff --check`

## Cache impact

Cache-impact: low — this is a routing/classification change for short context-dependent replies; it does not change system prompts, tool schemas, tool ordering, request serialization, memory prefixes, compaction, or reasoning upload behavior.
Cache-guard: `go test ./internal/control -run 'Test(TaskWarrantsPlanner|TwoModelShortChoiceReplySkipsPlanner)' -count=1`
System-prompt-review: N/A
