### PR TITLE
fix(desktop): dedupe skill roots in settings

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4295,7 +4295,7 @@ func cloneSkillRootViews(in []SkillRootView) []SkillRootView {
 func rootActive(roots []SkillRootView, path string) bool {
 	want := config.CanonicalSkillPath(path)
 	for _, r := range roots {
-		if r.Scope == string(skill.ScopeCustom) && config.CanonicalSkillPath(r.Dir) == want {
+		if config.CanonicalSkillPath(r.Dir) == want {
 			return true
 		}
 	}

--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4196,6 +4196,7 @@ func skillRootsViewFrom(cwd string, cfg, userCfg *config.Config) []SkillRootView
 		}
 	}
 	out := []SkillRootView{}
+	seenRoots := map[string]int{}
 	for _, r := range roots {
 		dir := config.CanonicalSkillPath(r.Dir)
 		view := SkillRootView{
@@ -4208,6 +4209,11 @@ func skillRootsViewFrom(cwd string, cfg, userCfg *config.Config) []SkillRootView
 			Skills:     counts[dir],
 			SkillItems: skillItems[dir],
 		}
+		if idx, ok := seenRoots[dir]; ok {
+			out[idx] = mergeDuplicateSkillRootView(out[idx], view)
+			continue
+		}
+		seenRoots[dir] = len(out)
 		out = append(out, view)
 	}
 	if userCfg != nil {
@@ -4226,6 +4232,22 @@ func skillRootsViewFrom(cwd string, cfg, userCfg *config.Config) []SkillRootView
 		}
 	}
 	return out
+}
+
+func mergeDuplicateSkillRootView(existing, duplicate SkillRootView) SkillRootView {
+	existing.Configured = existing.Configured || duplicate.Configured
+	existing.Removable = existing.Removable || duplicate.Removable
+	if existing.Status != "ok" && duplicate.Status == "ok" {
+		existing.Status = duplicate.Status
+	}
+	if existing.Skills == 0 && duplicate.Skills > 0 {
+		existing.Skills = duplicate.Skills
+		existing.SkillItems = duplicate.SkillItems
+	}
+	if existing.Warning == "" {
+		existing.Warning = duplicate.Warning
+	}
+	return existing
 }
 
 func skillRootsCacheKey(cwd string, cfg, userCfg *config.Config) string {

--- a/desktop/skills_app_test.go
+++ b/desktop/skills_app_test.go
@@ -153,6 +153,59 @@ func TestSkillRootsViewDedupesConfiguredConventionRoot(t *testing.T) {
 	}
 }
 
+func TestSkillRootsViewDedupesConfiguredProjectConventionRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	project := t.TempDir()
+	root := filepath.Join(project, ".reasonix", "skills")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "project.md"), []byte("---\ndescription: project\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(wd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root = filepath.Join(cwd, ".reasonix", "skills")
+	cfgPath := config.UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("[skills]\npaths = [\""+root+"\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	roots := skillRootsView()
+	want := realTestPath(root)
+	var matches []SkillRootView
+	for _, r := range roots {
+		if realTestPath(r.Dir) == want {
+			matches = append(matches, r)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("project skill root %q appears %d times, want once: %+v", root, len(matches), matches)
+	}
+	if !matches[0].Configured || matches[0].Skills != 1 || len(matches[0].SkillItems) != 1 {
+		t.Fatalf("deduped project root should keep configured metadata and skills, got %+v", matches[0])
+	}
+	if matches[0].Status == "inactive" {
+		t.Fatalf("deduped project root should stay active, got %+v", matches[0])
+	}
+}
+
 func TestSkillRootsViewOmitsExcludedConventionRoot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/desktop/skills_app_test.go
+++ b/desktop/skills_app_test.go
@@ -108,6 +108,51 @@ func TestSkillRootsViewMarksEnvConfiguredCustomRoot(t *testing.T) {
 	t.Fatalf("custom skill root %q not found in %+v", root, roots)
 }
 
+func TestSkillRootsViewDedupesConfiguredConventionRoot(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("AppData", filepath.Join(home, "AppData"))
+	project := t.TempDir()
+	root := filepath.Join(home, ".reasonix", "skills")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "global.md"), []byte("---\ndescription: global\n---\nbody"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := config.UserConfigPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("[skills]\npaths = [\"~/.reasonix/skills\"]\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(wd)
+	if err := os.Chdir(project); err != nil {
+		t.Fatal(err)
+	}
+
+	roots := skillRootsView()
+	want := realTestPath(root)
+	var matches []SkillRootView
+	for _, r := range roots {
+		if realTestPath(r.Dir) == want {
+			matches = append(matches, r)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("skill root %q appears %d times, want once: %+v", root, len(matches), matches)
+	}
+	if !matches[0].Configured || matches[0].Skills != 1 || len(matches[0].SkillItems) != 1 {
+		t.Fatalf("deduped root should keep configured metadata and skills, got %+v", matches[0])
+	}
+}
+
 func TestSkillRootsViewOmitsExcludedConventionRoot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- Collapse duplicate skill source rows by canonical path in desktop Skills settings.
- Preserve configured/removable metadata and discovered skill items when a convention root is also listed in `[skills].paths`.
- Add regression coverage for `~/.reasonix/skills` being configured as a custom skill path.

Fixes #4779

## Verification

- `cd desktop && go test . -run 'TestSkillRootsView(DedupesConfiguredConventionRoot|CountsProjectSkills|MarksEnvConfiguredCustomRoot|OmitsExcludedConventionRoot)|Test(AddSkillPathRestoresConventionRootWithoutCustomPath|RemoveSkillPathPseudoDeletesConventionRoot)' -count=1`
- `cd desktop && go test ./...`
- `go test ./...`
- `cd desktop && gofmt -l .`
- `git diff --check`

## Cache impact

Cache-impact: none — desktop skills settings rendering only; no provider-visible prompt, tool schema, memory prefix, output style, skill index, or request serialization changes.
Cache-guard: not applicable — no cache-sensitive surface changed.
System-prompt-review: N/A
