### PR TITLE
Fix post-merge bot review findings / 修复合并后 bot review 问题

### DIFF
--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -2000,6 +2000,7 @@ export default function App() {
     prompt: string;        // user message text for composer fill
   };
   const [rewindState, setRewindState] = useState<RewindState | null>(null);
+  const [rewindCommitting, setRewindCommitting] = useState(false);
   const rewindStateRef = useRef(rewindState);
   rewindStateRef.current = rewindState;
 
@@ -2014,11 +2015,18 @@ export default function App() {
     if (activeTab?.readOnly) return;
     const rs = rewindStateRef.current;
     if (rs) {
-      const ok = await rewind(rs.turn, rs.scope);
+      rewindStateRef.current = null;
+      setRewindState(null);
+      setRewindCommitting(true);
+      let ok = false;
+      try {
+        ok = await rewind(rs.turn, rs.scope);
+      } finally {
+        setRewindCommitting(false);
+      }
       if (!ok) {
-        // Rewind failed: the Go conversation is intact, so the
-        // optimistic state still shows the truncated transcript. Clear it and
-        // don't send — the controller emits a notice with the reason.
+        // Rewind failed: the Go conversation is intact. Do not send; the
+        // controller emits a notice with the reason.
         setRewindState(null);
         return;
       }
@@ -2028,7 +2036,6 @@ export default function App() {
         setDockRefreshKey((v) => v + 1);
         setProjectRevision((v) => v + 1);
       }
-      setRewindState(null);
     }
     send(displayText, submitText);
   }, [activeTab?.readOnly, send, rewind]);
@@ -2248,13 +2255,13 @@ export default function App() {
   const handleNavigateTopic = useCallback((entry: TopicShortcutEntry) => {
     void handleOpenTopic(entry.scope, entry.workspaceRoot, entry.topicId, entry.sessionPath);
   }, [handleOpenTopic]);
-  const { showBadges: showTopicBadges } = useTopicShortcuts(!sidebarCollapsed);
+  const { showBadges: showTopicBadges } = useTopicShortcuts(!sidebarCollapsed, desktopPlatform);
 
   // Register Cmd/Ctrl+1-9 shortcuts for topic navigation
   useEffect(() => {
     if (sidebarCollapsed) return;
     const onKeydown = (event: globalThis.KeyboardEvent) => {
-      const idx = topicShortcutIndexFromEvent(event);
+      const idx = topicShortcutIndexFromEvent(event, desktopPlatform);
       if (idx === null) return;
       event.preventDefault();
       const topics = visibleTopicsRef.current;
@@ -2264,7 +2271,7 @@ export default function App() {
     };
     document.addEventListener("keydown", onKeydown);
     return () => document.removeEventListener("keydown", onKeydown);
-  }, [sidebarCollapsed, handleNavigateTopic]);
+  }, [sidebarCollapsed, desktopPlatform, handleNavigateTopic]);
 
   const paletteItems = useMemo<PaletteItem[]>(() => {
     const cmds: PaletteItem[] = [
@@ -2635,6 +2642,7 @@ export default function App() {
               searchExpanded={!sidebarCreation || sidebarSearchOpen}
               searchFocusSignal={sidebarSearchFocusSignal}
               showShortcutBadges={showTopicBadges}
+              shortcutPlatform={desktopPlatform}
               onVisibleTopicsChange={handleVisibleTopicsChange}
             />
           </section>
@@ -3017,8 +3025,8 @@ export default function App() {
                 onRewind={handleMessageAction}
                 checkpoints={state.checkpoints}
                 actionPending={state.messageAction != null}
-                rewindDisabled={Boolean(activeTab?.readOnly) || rewindState != null || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
-                running={state.running}
+                rewindDisabled={Boolean(activeTab?.readOnly) || rewindState != null || rewindCommitting || state.running || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+                running={state.running || rewindCommitting}
                 welcomeVariant={sidebarCreation ? "creation" : "default"}
                 creationMode={sidebarCreation}
                 actionHoverMenus={sidebarCreation}
@@ -3087,7 +3095,7 @@ export default function App() {
               />
             )}
             <Composer
-              running={state.running}
+              running={state.running || rewindCommitting}
               collaborationMode={collaborationMode}
               toolApprovalMode={toolApprovalMode}
               tokenMode={tokenMode}
@@ -3109,8 +3117,8 @@ export default function App() {
               onSetTokenMode={applyTokenMode}
               insertRequest={composerInsertRequest}
               readOnly={Boolean(activeTab?.readOnly)}
-              disabled={state.meta?.ready === false || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
-              decisionPending={state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+              disabled={state.meta?.ready === false || rewindCommitting || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
+              decisionPending={rewindCommitting || state.messageAction != null || state.approval != null || state.ask != null || clearContextPending}
               ready={state.meta?.ready === true}
               turnStartAt={state.turnStartAt}
               turnTokens={state.turnTokens}
@@ -3122,7 +3130,7 @@ export default function App() {
               usage={state.usage}
               balance={state.balance}
               jobs={state.jobs}
-              running={state.running}
+              running={state.running || rewindCommitting}
               collaborationMode={collaborationMode}
               toolApprovalMode={toolApprovalMode}
               sessionTurns={sessionTurns}

--- a/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
+++ b/desktop/frontend/src/__tests__/app-chrome-tabs.test.ts
@@ -7,6 +7,9 @@ import { fileURLToPath } from "node:url";
 const testDir = dirname(fileURLToPath(import.meta.url));
 const appSource = readFileSync(resolve(testDir, "../App.tsx"), "utf8");
 const appChromeSource = readFileSync(resolve(testDir, "../components/AppChrome.tsx"), "utf8");
+const commandPaletteSource = readFileSync(resolve(testDir, "../components/CommandPalette.tsx"), "utf8");
+const projectTreeSource = readFileSync(resolve(testDir, "../components/ProjectTree.tsx"), "utf8");
+const topicShortcutsSource = readFileSync(resolve(testDir, "../lib/topicShortcuts.ts"), "utf8");
 const transcriptSource = readFileSync(resolve(testDir, "../components/Transcript.tsx"), "utf8");
 const stylesSource = readFileSync(resolve(testDir, "../styles.css"), "utf8").replace(/\/\*[\s\S]*?\*\//g, "");
 
@@ -137,6 +140,36 @@ ok(
   /aria-label=\{t\("transcript\.jumpToBottom"\)\}/.test(transcriptSource) &&
     /title=\{t\("transcript\.jumpToBottom"\)\}/.test(transcriptSource),
   "jump-to-bottom affordance uses localized transcript text",
+);
+
+ok(
+  /setActive\(items\.length > 0 \? 0 : -1\)/.test(commandPaletteSource),
+  "command palette highlights the first item when opened with an empty query",
+);
+
+ok(
+  /topicShortcutIndexFromEvent\(event, desktopPlatform\)/.test(appSource) &&
+    /useTopicShortcuts\(!sidebarCollapsed, desktopPlatform\)/.test(appSource),
+  "topic shortcuts use the resolved desktop platform",
+);
+
+ok(
+  /topicShortcutLabel\(shortcutIndex, shortcutPlatform\)/.test(projectTreeSource),
+  "topic shortcut badges render the platform-specific modifier",
+);
+
+ok(
+  /if \(!enabled\) hideBadges\(\);/.test(topicShortcutsSource) &&
+    /if \(heldRef\.current\) hideBadges\(\);/.test(topicShortcutsSource) &&
+    /window\.removeEventListener\("blur", onBlur\);\s*hideBadges\(\);/.test(topicShortcutsSource),
+  "topic shortcut badge state is cleared when disabled, interrupted, or cleaned up",
+);
+
+ok(
+  /const \[rewindCommitting, setRewindCommitting\] = useState\(false\);/.test(appSource) &&
+    /rewindStateRef\.current = null;/.test(appSource) &&
+    /setRewindCommitting\(true\);/.test(appSource),
+  "committing optimistic rewind clears undo state before awaiting the backend",
 );
 
 for (const selector of [

--- a/desktop/frontend/src/__tests__/keyboard-shortcuts.test.ts
+++ b/desktop/frontend/src/__tests__/keyboard-shortcuts.test.ts
@@ -9,7 +9,7 @@ import {
   shortcutConflict,
   type ShortcutPlatform,
 } from "../lib/keyboardShortcuts";
-import { topicShortcutIndexFromEvent } from "../lib/topicShortcuts";
+import { topicShortcutIndexFromEvent, topicShortcutLabel } from "../lib/topicShortcuts";
 
 let passed = 0;
 let failed = 0;
@@ -24,14 +24,15 @@ function eq(a: unknown, b: unknown, label: string) {
   }
 }
 
-function event(key: string, modifiers: { ctrlKey?: boolean; metaKey?: boolean; defaultPrevented?: boolean } = {}) {
+function event(key: string, modifiers: { ctrlKey?: boolean; metaKey?: boolean; altKey?: boolean; shiftKey?: boolean; defaultPrevented?: boolean } = {}) {
   return {
     key,
     ctrlKey: modifiers.ctrlKey ?? false,
     metaKey: modifiers.metaKey ?? false,
-    altKey: false,
-    shiftKey: false,
+    altKey: modifiers.altKey ?? false,
+    shiftKey: modifiers.shiftKey ?? false,
     defaultPrevented: modifiers.defaultPrevented ?? false,
+    target: null,
   };
 }
 
@@ -58,10 +59,15 @@ eq(JSON.stringify(formatShortcutComboParts(defaultShortcutCombo("settings.open",
 eq(formatShortcutCombo(defaultShortcutCombo("settings.open", "windows"), "windows"), "Ctrl+,", "formats Windows settings shortcut");
 eq(JSON.stringify(formatShortcutComboParts(defaultShortcutCombo("settings.open", "windows"), "windows")), JSON.stringify(["Ctrl", ","]), "splits Windows settings shortcut for display");
 eq(shortcutConflict("settings.open", defaultShortcutCombo("commandPalette.open", "darwin"), "darwin")?.action, "commandPalette.open", "detects shortcut conflicts");
-eq(topicShortcutIndexFromEvent(event("1", { metaKey: true })), 0, "Cmd+1 maps to the first topic shortcut");
-eq(topicShortcutIndexFromEvent(event("9", { ctrlKey: true })), 8, "Ctrl+9 maps to the ninth topic shortcut");
-eq(topicShortcutIndexFromEvent(event("0", { metaKey: true })), null, "Cmd+0 is not a topic shortcut");
-eq(topicShortcutIndexFromEvent(event("1", { metaKey: true, defaultPrevented: true })), null, "topic shortcuts yield to already-handled custom shortcuts");
+eq(topicShortcutIndexFromEvent(event("1", { metaKey: true }), "darwin"), 0, "Cmd+1 maps to the first topic shortcut on macOS");
+eq(topicShortcutIndexFromEvent(event("1", { ctrlKey: true }), "darwin"), null, "Ctrl+1 is not a topic shortcut on macOS");
+eq(topicShortcutIndexFromEvent(event("9", { ctrlKey: true }), "windows"), 8, "Ctrl+9 maps to the ninth topic shortcut on Windows");
+eq(topicShortcutIndexFromEvent(event("9", { metaKey: true }), "windows"), null, "Meta+9 is not a topic shortcut on Windows");
+eq(topicShortcutIndexFromEvent(event("1", { ctrlKey: true, shiftKey: true }), "linux"), null, "topic shortcuts reject extra modifiers");
+eq(topicShortcutIndexFromEvent(event("0", { metaKey: true }), "darwin"), null, "Cmd+0 is not a topic shortcut");
+eq(topicShortcutIndexFromEvent(event("1", { metaKey: true, defaultPrevented: true }), "darwin"), null, "topic shortcuts yield to already-handled custom shortcuts");
+eq(topicShortcutLabel(1, "darwin"), "⌘1", "topic badge uses the macOS command glyph");
+eq(topicShortcutLabel(1, "windows"), "Ctrl+1", "topic badge uses the Windows control modifier");
 
 console.log(`\n${passed} passed, ${failed} failed, ${passed + failed} total`);
 if (failed > 0) process.exit(1);

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -61,6 +61,8 @@ eq(
   "plan-1",
   "turn_done preserves out-of-order plan approval",
 );
+eq(planTurnDoneAfter.running, true, "preserved plan approval keeps the tab running");
+eq(planTurnDoneAfter.pendingPrompt, true, "preserved plan approval keeps the prompt gate active");
 
 let replayCalls = 0;
 replayPendingPromptsForActiveTab(undefined, () => {

--- a/desktop/frontend/src/components/CommandPalette.tsx
+++ b/desktop/frontend/src/components/CommandPalette.tsx
@@ -75,10 +75,10 @@ export function CommandPalette({
   useLayoutEffect(() => {
     if (open) {
       setQuery("");
-      setActive(-1);
+      setActive(items.length > 0 ? 0 : -1);
       inputRef.current?.focus();
     }
-  }, [open]);
+  }, [open, items.length]);
 
   // Callback ref: when the input element mounts while the palette is open,
   // focus it immediately. This handles the case where the DOM element

--- a/desktop/frontend/src/components/ProjectTree.tsx
+++ b/desktop/frontend/src/components/ProjectTree.tsx
@@ -12,6 +12,8 @@ import type { ProjectNode, ProjectTopicStatus } from "../lib/types";
 import { topicActivityTime } from "../lib/session";
 import { getLocale, useT, type DictKey, type Translator } from "../lib/i18n";
 import { PROJECT_COLOR_OPTIONS, projectColorValue } from "../lib/projectColors";
+import { topicShortcutLabel, type TopicShortcutEntry } from "../lib/topicShortcuts";
+import type { ShortcutPlatform } from "../lib/keyboardShortcuts";
 import { ContextMenu, contextMenuPointFromEvent, type ContextMenuItem, type ContextMenuPoint } from "./ContextMenu";
 import { Tooltip } from "./Tooltip";
 
@@ -34,7 +36,8 @@ interface ProjectTreeProps {
   searchExpanded?: boolean;
   searchFocusSignal?: number;
   showShortcutBadges?: boolean;
-  onVisibleTopicsChange?: (topics: import("../lib/topicShortcuts").TopicShortcutEntry[]) => void;
+  shortcutPlatform?: ShortcutPlatform;
+  onVisibleTopicsChange?: (topics: TopicShortcutEntry[]) => void;
 }
 
 type ProjectTreeImTopicSource = {
@@ -449,6 +452,7 @@ export function ProjectTree({
   searchExpanded = true,
   searchFocusSignal = 0,
   showShortcutBadges = false,
+  shortcutPlatform,
   onVisibleTopicsChange,
 }: ProjectTreeProps) {
   const t = useT();
@@ -481,7 +485,7 @@ export function ProjectTree({
   const filterTriggerRef = useRef<HTMLButtonElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const topicIndexRef = useRef(0);
-  const visibleTopicsCollectorRef = useRef<import("../lib/topicShortcuts").TopicShortcutEntry[]>([]);
+  const visibleTopicsCollectorRef = useRef<TopicShortcutEntry[]>([]);
   const [filterMenuOpen, setFilterMenuOpen] = useState(false);
   const creatingRef = useRef(false);
   const manuallyCollapsedRef = useRef(manuallyCollapsed);
@@ -1166,7 +1170,7 @@ export function ProjectTree({
           )}
           {shortcutIndex > 0 && (
             <span className="project-tree__topic-shortcut" aria-hidden="true">
-              ⌘{shortcutIndex}
+              {topicShortcutLabel(shortcutIndex, shortcutPlatform)}
             </span>
           )}
         </div>

--- a/desktop/frontend/src/lib/keyboardShortcuts.ts
+++ b/desktop/frontend/src/lib/keyboardShortcuts.ts
@@ -485,13 +485,15 @@ function isModifierKey(key: string): boolean {
   return key === "Meta" || key === "Control" || key === "Alt" || key === "Shift";
 }
 
-function isEditableTarget(target: EventTarget | null): boolean {
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (typeof HTMLElement === "undefined") return false;
   if (!(target instanceof HTMLElement)) return false;
   if (target.isContentEditable) return true;
   const tag = target.tagName.toLowerCase();
   return tag === "input" || tag === "textarea" || tag === "select";
 }
 
-function isShortcutRecorderTarget(target: EventTarget | null): boolean {
+export function isShortcutRecorderTarget(target: EventTarget | null): boolean {
+  if (typeof HTMLElement === "undefined") return false;
   return target instanceof HTMLElement && Boolean(target.closest(".shortcuts-settings__key--recording"));
 }

--- a/desktop/frontend/src/lib/topicShortcuts.ts
+++ b/desktop/frontend/src/lib/topicShortcuts.ts
@@ -1,11 +1,21 @@
 // useTopicShortcuts - Cmd/Ctrl hold detection plus 1-9 sidebar topic navigation.
 //
 // When the user holds Cmd (macOS) or Ctrl (Windows/Linux) for a brief moment
-// without pressing another key, shortcut badges (⌘1 ... ⌘9) appear over the
-// sidebar topic list. Releasing the modifier hides them immediately. Pressing
-// Cmd/Ctrl+1-9 navigates to the matching topic.
+// without pressing another key, shortcut badges appear over the sidebar topic
+// list. Releasing the modifier hides them immediately. Pressing Cmd/Ctrl+1-9
+// navigates to the matching topic.
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  defaultShortcutCombo,
+  detectShortcutPlatform,
+  formatShortcutCombo,
+  isEditableTarget,
+  isShortcutRecorderTarget,
+  matchesShortcut,
+  type ShortcutAction,
+  type ShortcutPlatform,
+} from "./keyboardShortcuts";
 
 /** Delay (ms) before showing badges after modifier is held. */
 const SHOW_DELAY_MS = 250;
@@ -17,17 +27,40 @@ type TopicShortcutEntry = {
   sessionPath?: string;
 };
 
-type TopicShortcutKeyboardEvent = Pick<globalThis.KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "defaultPrevented">;
+type TopicShortcutKeyboardEvent = Pick<globalThis.KeyboardEvent, "key" | "ctrlKey" | "metaKey" | "altKey" | "shiftKey" | "defaultPrevented" | "target">;
 
-export function topicShortcutIndexFromEvent(event: TopicShortcutKeyboardEvent): number | null {
+function topicShortcutAction(index: number): ShortcutAction {
+  return `topic.goto.${index}` as ShortcutAction;
+}
+
+function isPlatformModifierKey(key: string, platform: ShortcutPlatform): boolean {
+  return platform === "darwin" ? key === "Meta" : key === "Control";
+}
+
+function hasOnlyPlatformModifier(event: TopicShortcutKeyboardEvent, platform: ShortcutPlatform): boolean {
+  if (platform === "darwin") return Boolean(event.metaKey) && !event.ctrlKey && !event.altKey && !event.shiftKey;
+  return Boolean(event.ctrlKey) && !event.metaKey && !event.altKey && !event.shiftKey;
+}
+
+export function topicShortcutLabel(index: number, platform: ShortcutPlatform = detectShortcutPlatform()): string {
+  return formatShortcutCombo(defaultShortcutCombo(topicShortcutAction(index), platform), platform);
+}
+
+export function topicShortcutIndexFromEvent(
+  event: TopicShortcutKeyboardEvent,
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): number | null {
   if (event.defaultPrevented) return null;
-  if (!event.metaKey && !event.ctrlKey) return null;
-  if (!/^[1-9]$/.test(event.key)) return null;
-  return Number(event.key) - 1;
+  if (isShortcutRecorderTarget(event.target ?? null) || isEditableTarget(event.target ?? null)) return null;
+  for (let index = 1; index <= 9; index += 1) {
+    if (matchesShortcut(event, topicShortcutAction(index), platform)) return index - 1;
+  }
+  return null;
 }
 
 export function useTopicShortcuts(
   enabled = true,
+  platform: ShortcutPlatform = detectShortcutPlatform(),
 ) {
   const [showBadges, setShowBadges] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -47,12 +80,21 @@ export function useTopicShortcuts(
   }, [clearTimer]);
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled) hideBadges();
+  }, [enabled, hideBadges]);
 
-    const isModifier = (key: string) => key === "Meta" || key === "Control";
+  useEffect(() => {
+    if (!enabled) return undefined;
 
     const onKeydown = (event: globalThis.KeyboardEvent) => {
-      if (!isModifier(event.key)) return;
+      if (!isPlatformModifierKey(event.key, platform)) {
+        if (heldRef.current) hideBadges();
+        return;
+      }
+      if (!hasOnlyPlatformModifier(event, platform)) {
+        hideBadges();
+        return;
+      }
       if (heldRef.current) return; // already tracking
       heldRef.current = true;
       clearTimer();
@@ -63,7 +105,7 @@ export function useTopicShortcuts(
     };
 
     const onKeyup = (event: globalThis.KeyboardEvent) => {
-      if (!isModifier(event.key)) return;
+      if (!isPlatformModifierKey(event.key, platform)) return;
       hideBadges();
     };
 
@@ -77,9 +119,9 @@ export function useTopicShortcuts(
       document.removeEventListener("keydown", onKeydown);
       document.removeEventListener("keyup", onKeyup);
       window.removeEventListener("blur", onBlur);
-      clearTimer();
+      hideBadges();
     };
-  }, [enabled, clearTimer, hideBadges]);
+  }, [enabled, platform, clearTimer, hideBadges]);
 
   return { showBadges, hideBadges };
 }

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -613,7 +613,20 @@ function applyEvent(s: State, e: WireEvent): State {
       // Plan approval can arrive before turn_done on some Wails event paths.
       // Keep that gate visible instead of clearing the only UI that can answer it.
       const keepPlanApproval = s.approval?.tool === "exit_plan_mode";
-      return { ...s, items, live: undefined, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, approval: keepPlanApproval ? s.approval : undefined, ask: undefined, seq: s.seq + 1 };
+      return {
+        ...s,
+        items,
+        live: undefined,
+        running: keepPlanApproval,
+        turnActive: keepPlanApproval,
+        pendingPrompt: keepPlanApproval,
+        cancelRequested: false,
+        cancellable: keepPlanApproval,
+        currentAssistant: undefined,
+        approval: keepPlanApproval ? s.approval : undefined,
+        ask: undefined,
+        seq: s.seq + 1,
+      };
     }
     default: return s;
   }


### PR DESCRIPTION
## Summary
- Fix follow-up issues raised by the post-merge Codex bot review on #5005: command palette initial selection, topic shortcut editable-target guards, platform-exact shortcut matching, platform-specific topic badges, and stale badge cleanup.
- Fix follow-up issues raised by the post-merge Codex bot review on #5072: optimistic rewind undo is disabled while the backend commit is in flight, and preserved plan approvals keep the tab in a running/prompt-blocked state.
- Confirm #5029 findings are already addressed by follow-up PR #5034 and remain resolved.

## Refs
- Follow-up for #5005
- Follow-up for #5072
- Confirms #5029 / #5034 coverage

## Cache impact
- None. This is limited to desktop frontend shortcut, rewind, and reducer UI state handling; no provider-visible prompt prefix, tool schema, request serialization, or cache-sensitive path changes.

## Verification
- `pnpm --dir desktop/frontend exec tsx src/__tests__/keyboard-shortcuts.test.ts` passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/send-failed.test.ts` passed
- `pnpm --dir desktop/frontend exec tsx src/__tests__/app-chrome-tabs.test.ts` passed
- `pnpm --dir desktop/frontend check:css` passed
- `git diff --check` passed
- `pnpm --dir desktop/frontend typecheck` is blocked in this checkout because generated Wails bindings are absent (`src/lib/bridge.ts` cannot resolve the generated app module).
