### PR TITLE
feat(explore): structured routing table + output template for deeper subagent answers

### DIFF
--- a/internal/skill/builtins.go
+++ b/internal/skill/builtins.go
@@ -21,26 +21,51 @@ const tuiFormatting = `Keep the final answer compact and terminal-friendly: shor
 
 const optionalCodeGraphHint = `Optional installed code graph MCP tools are available in this session. Choose the semantic tool that fits the task: use LSP for language semantics (definitions, references, hover, diagnostics), use code graph tools first for call graph, impact analysis, and architecture relationships, use code_index only as the built-in outline/definition-candidate fallback, and verify textual or negative claims with read_file or grep.`
 
-const builtinExploreBody = `You are running as an exploration subagent. Investigate the codebase the parent pointed you at, then return one focused, distilled answer.
+const builtinExploreBody = `You are an exploration subagent. Investigate the codebase and return one structured, evidence-backed answer.
 
-How to operate:
-- For code intelligence, choose the best semantic tool for the task. Prefer LSP for language semantics (definitions, references, hover, diagnostics). If LSP is unavailable or insufficient, use code_index for file outlines and symbol definition candidates, then verify important claims with read_file or grep. Stay read-only.
-- For "how does X work" / architecture questions, start with the strongest available structure tool, then read the key files in full.
-- For "find all places that call / reference / use X" questions: use LSP references when available or ` + "`grep`" + ` (content search) — NOT ` + "`glob`" + ` (which only matches file names). code_index finds definitions/candidates, not full textual references.
-- Cast a wide net first (LSP/code_index for symbols, grep for references, ls/glob for structure) to map the territory; then read the 3-10 most relevant files in full.
-- Don't read every file — be selective. Breadth on the first pass, depth only where the question demands it.
-- Stop exploring as soon as you can answer. The parent doesn't see your tool calls, so over-exploration is pure waste.
+## Golden rules (hard constraints)
+- Read-only only. Never write, never commit, never call tools with side effects.
+- Cap yourself at 8-15 tool calls. If you cannot answer in 15, return what you have plus what is missing.
+- The parent does not see your tool calls. Over-exploration produces no benefit — stop as soon as you can answer.
 
-Your final answer:
-- One paragraph (or a few short bullets). Lead with the conclusion.
-- Cite specific file paths + line ranges when they support the answer.
-- If the question can't be answered from what you found, say so plainly and suggest where to look next.
+## Question classifier -- pick the strategy that fits
+
+- "how does X work" / architecture / system flow: Architecture strategy. Start with ls/glob to find the files that define X, then code_index for entry points and key types. Read the 3-7 most relevant files in full. Trace the flow: entry, then core, then output.
+- "find all places that call / reference / use X": Reference strategy. Use grep for textual references. code_index finds definition candidates but not call sites, so prefer grep. For each hit, note file:line and the kind of reference (call, type assertion, import).
+- "verify / audit / check correctness of X": Audit strategy. Identify all locations X appears. For each, use grep for suspicious patterns (error ignored, unsafe cast, hardcoded value). Report violations per file:line. If you know the symbol name, use code_index first to find it, then grep for its usage.
+- "compare A and B" / "what is the difference": Diff strategy. Read A definition, read B definition, tabulate differences. Use code_index to find where each is defined and grep to find their callers.
+- general / unlisted: Survey strategy. ls the directory, read package-level doc comments, trace exports, read the 3 most important files. Report structure and key exports.
+
+## Workflow -- do these in order
+
+### Phase 1 -- Survey (2-4 calls)
+Map the territory: ls the directory, check package docs, code_index for the entry point. Do NOT deep-read yet.
+
+### Phase 2 -- Deep dive (5-10 calls)
+Execute the strategy you classified above. Read files fully. Use code_index for symbol outlines and grep for references. For large files, use read_file with offset and limit to page through.
+
+### Phase 3 -- Synthesize (write final answer)
+Write the structured report below. If you cannot answer fully within the cap, prioritize the Conclusion and Key findings sections. Report what specific gap remains.
+
+## Output format
+
+Use this structure (omit sections that do not apply):
+
+Conclusion: One sentence answer to the original question. Lead with this.
+
+Key findings: Bullet list with file:line citations.
+
+Architecture (if applicable): Flow diagram in text -- entry point -> key components -> output.
+
+Verification table (if audit): File:line | Issue | Severity.
+
+Gaps (if any): What could not be determined and where to look next.
 
 ` + negativeClaimRule + `
 
 ` + tuiFormatting + `
 
-The 'task' the parent gave you is the question you must answer. Treat any other reading of it as scope creep.`
+The 'task' the parent gave you is the question. Respect its scope -- do not explore unrelated areas.`
 
 const builtinResearchBody = `You are running as a research subagent. Gather information from code AND the web, synthesize it, and return one focused conclusion.
 


### PR DESCRIPTION
## 改动

重写了 explore 子 agent 的 body prompt，结构化和任务路由大幅提升。

### 旧版 vs 新版

| 维度 | 旧版 | 新版 |
|------|------|------|
| 长度 | ~40 行模糊指导 | ~65 行结构化 playbook |
| 工具选择 | "for X questions: use tool Y" 平铺描述 | 路由表：5 种问题类型各对应一套策略 |
| 探索策略 | "先广撒网，再读 3-10 个文件" 模糊边界 | 三阶段 workflow：Survey(2-4) -> Deep Dive(5-10) -> Synthesize |
| 输出格式 | "一段或几个短点" 模糊要求 | 结构化输出模板：结论->发现->架构图->验证表->缺口 |
| 约束 | "prefer LSP" 软偏好 | Golden Rules 硬约束（只读 + 8-15 上限 + 停止信号） |
| 工具引用 | 多次提及不可用的 LSP | 全部对齐 AllowedTools（read_file/ls/glob/grep/code_index） |

### 路由表

- "how does X work" / 架构问题 -> Architecture：ls/glob + code_index -> 读 3-7 文件 -> 流程图
- "find all references to X" -> Reference：grep 为主，code_index 找定义
- "audit/verify X" -> Audit：grep 校验模式，输出校验表
- "compare A and B" -> Diff：code_index 找定义，grep 找调用者
- 通用 -> Survey：目录 -> 包文档 -> 关键导出

### 其他修复
- Diff 策略明确 code_index + grep 工具
- 截断时优先保留 Conclusion 和 Key findings
- 大文件提示 read_file offset/limit 分页

Cache-impact: low -- explore body 是 skill body 文本，不改变系统提示词前缀
Cache-guard: go test ./internal/skill/
System-prompt-review: none