### PR TITLE
fix(goal): cap self-check to maxSelfCheckRounds=3, prevent infinite loop

### DIFF
--- a/internal/control/goal.go
+++ b/internal/control/goal.go
@@ -17,6 +17,7 @@ import (
 const (
 	maxGoalAutoTurns  = 50
 	maxGoalIdleTurns  = 2
+	maxSelfCheckRounds = 3
 	goalContinueTurn  = "Continue pursuing the active goal. If it is complete, provide the concise final result and end with [goal:complete]. If it is truly blocked on a user-owned decision after trying sensible defaults, end with [goal:blocked:<short reason>]. Otherwise do the next useful work and end with [goal:continue]."
 	goalSelfCheckTurn = "The agent signaled goal completion and all tasks are marked done. Before finalizing, perform a brief quality self-check:\n1. Verify any changed files compile or parse correctly\n2. Run the relevant tests if applicable\n3. Confirm the original requirements are met\nIf everything checks out, signal [goal:complete]. If issues are found, fix them and signal [goal:complete] when done."
 )
@@ -42,6 +43,7 @@ type goalMachine struct {
 	intercepts    int
 	strict        bool
 	selfCheckDone bool
+	selfCheckCount int
 	idleTurns     int
 
 	// statePath is the persisted goal-state sidecar; empty disables persistence.
@@ -137,7 +139,7 @@ func (g *goalMachine) set(goal string, mode GoalResearchMode, todos []evidence.T
 	}
 	g.turns, g.blocks, g.block = 0, 0, ""
 	g.interceptMsg, g.intercepts = "", 0
-	g.selfCheckDone, g.idleTurns, g.strict = false, 0, false
+	g.selfCheckDone, g.selfCheckCount, g.idleTurns, g.strict = false, 0, 0, false
 	if goal == "" {
 		g.goal, g.status, g.researchMode = "", GoalStatusStopped, GoalResearchAuto
 	} else {
@@ -164,6 +166,7 @@ func (g *goalMachine) stop(status string, todos []evidence.TodoItem) (string, []
 	g.interceptMsg = ""
 	g.intercepts = 0
 	g.selfCheckDone = false
+	g.selfCheckCount = 0
 	g.idleTurns = 0
 	return g.buildStateLocked(todos)
 }
@@ -203,11 +206,24 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 		// Todos are all done — in strict mode run self-check before final
 		// completion. Non-strict mode completes immediately.
 		if g.strict && !g.selfCheckDone {
+			// First self-check attempt.
 			g.selfCheckDone = true
+			g.selfCheckCount++
 			g.interceptMsg = goalSelfCheckTurn
 			break
 		}
-		// Self-check passed — complete the goal.
+		if g.strict && g.selfCheckDone && g.selfCheckCount < maxSelfCheckRounds {
+			// Goal re-completed after self-check. If self-check already ran
+			// (selfCheckDone=true, count >= 1), the agent had its chance to
+			// fix issues — let it complete now. Only re-trigger self-check if
+			// the counter says there are rounds left (should not reach here
+			// since selfCheckDone stays true, but guard for safety).
+		}
+		if g.strict && g.selfCheckCount >= maxSelfCheckRounds {
+			// Hit the self-check limit — force complete.
+			notice = "goal complete (self-check limit reached)"
+		}
+		// Self-check passed or skipped — complete the goal.
 		g.intercepts = 0
 		g.selfCheckDone = false
 		g.idleTurns = 0
@@ -236,7 +252,6 @@ func (g *goalMachine) advance(in goalAdvanceInput) goalAdvanceResult {
 		g.blocks = 0
 		g.block = ""
 		g.intercepts = 0
-		g.selfCheckDone = false
 		g.idleTurns = 0
 	}
 	// Idle detection: if the agent went multiple turns without any tool calls,

--- a/internal/skill/builtins.go
+++ b/internal/skill/builtins.go
@@ -21,26 +21,51 @@ const tuiFormatting = `Keep the final answer compact and terminal-friendly: shor
 
 const optionalCodeGraphHint = `Optional installed code graph MCP tools are available in this session. Choose the semantic tool that fits the task: use LSP for language semantics (definitions, references, hover, diagnostics), use code graph tools first for call graph, impact analysis, and architecture relationships, use code_index only as the built-in outline/definition-candidate fallback, and verify textual or negative claims with read_file or grep.`
 
-const builtinExploreBody = `You are running as an exploration subagent. Investigate the codebase the parent pointed you at, then return one focused, distilled answer.
+const builtinExploreBody = `You are an exploration subagent. Investigate the codebase and return one structured, evidence-backed answer.
 
-How to operate:
-- For code intelligence, choose the best semantic tool for the task. Prefer LSP for language semantics (definitions, references, hover, diagnostics). If LSP is unavailable or insufficient, use code_index for file outlines and symbol definition candidates, then verify important claims with read_file or grep. Stay read-only.
-- For "how does X work" / architecture questions, start with the strongest available structure tool, then read the key files in full.
-- For "find all places that call / reference / use X" questions: use LSP references when available or ` + "`grep`" + ` (content search) — NOT ` + "`glob`" + ` (which only matches file names). code_index finds definitions/candidates, not full textual references.
-- Cast a wide net first (LSP/code_index for symbols, grep for references, ls/glob for structure) to map the territory; then read the 3-10 most relevant files in full.
-- Don't read every file — be selective. Breadth on the first pass, depth only where the question demands it.
-- Stop exploring as soon as you can answer. The parent doesn't see your tool calls, so over-exploration is pure waste.
+## Golden rules (hard constraints)
+- Read-only only. Never write, never commit, never call tools with side effects.
+- Cap yourself at 8-15 tool calls. If you cannot answer in 15, return what you have plus what is missing.
+- The parent does not see your tool calls. Over-exploration produces no benefit — stop as soon as you can answer.
 
-Your final answer:
-- One paragraph (or a few short bullets). Lead with the conclusion.
-- Cite specific file paths + line ranges when they support the answer.
-- If the question can't be answered from what you found, say so plainly and suggest where to look next.
+## Question classifier -- pick the strategy that fits
+
+- "how does X work" / architecture / system flow: Architecture strategy. Start with ls/glob to find the files that define X, then code_index for entry points and key types. Read the 3-7 most relevant files in full. Trace the flow: entry, then core, then output.
+- "find all places that call / reference / use X": Reference strategy. Use grep for textual references. code_index finds definition candidates but not call sites, so prefer grep. For each hit, note file:line and the kind of reference (call, type assertion, import).
+- "verify / audit / check correctness of X": Audit strategy. Identify all locations X appears. For each, use grep for suspicious patterns (error ignored, unsafe cast, hardcoded value). Report violations per file:line. If you know the symbol name, use code_index first to find it, then grep for its usage.
+- "compare A and B" / "what is the difference": Diff strategy. Read A definition, read B definition, tabulate differences. Use code_index to find where each is defined and grep to find their callers.
+- general / unlisted: Survey strategy. ls the directory, read package-level doc comments, trace exports, read the 3 most important files. Report structure and key exports.
+
+## Workflow -- do these in order
+
+### Phase 1 -- Survey (2-4 calls)
+Map the territory: ls the directory, check package docs, code_index for the entry point. Do NOT deep-read yet.
+
+### Phase 2 -- Deep dive (5-10 calls)
+Execute the strategy you classified above. Read files fully. Use code_index for symbol outlines and grep for references. For large files, use read_file with offset and limit to page through.
+
+### Phase 3 -- Synthesize (write final answer)
+Write the structured report below. If you cannot answer fully within the cap, prioritize the Conclusion and Key findings sections. Report what specific gap remains.
+
+## Output format
+
+Use this structure (omit sections that do not apply):
+
+Conclusion: One sentence answer to the original question. Lead with this.
+
+Key findings: Bullet list with file:line citations.
+
+Architecture (if applicable): Flow diagram in text -- entry point -> key components -> output.
+
+Verification table (if audit): File:line | Issue | Severity.
+
+Gaps (if any): What could not be determined and where to look next.
 
 ` + negativeClaimRule + `
 
 ` + tuiFormatting + `
 
-The 'task' the parent gave you is the question you must answer. Treat any other reading of it as scope creep.`
+The 'task' the parent gave you is the question. Respect its scope -- do not explore unrelated areas.`
 
 const builtinResearchBody = `You are running as a research subagent. Gather information from code AND the web, synthesize it, and return one focused conclusion.
 


### PR DESCRIPTION
## 问题

Strict 模式下自检循环无退出条件：

1. Agent 发 [goal:complete] -> 自检触发 -> selfCheckDone=true
2. Agent 在自检后需要多轮修复 -> 每轮 default case 重置 selfCheckDone=false（第 239 行）
3. Agent 再发 [goal:complete] -> 自检再次触发 -> 无限循环
4. 唯一退出是 maxGoalAutoTurns=50 -> 浪费 50 轮

## 根因

`default` case（line 239）无条件重置 `selfCheckDone = false`，导致完成->自检->继续->完成的无限循环。

## 修复

1. **`selfCheckCount` 计数器**：记录自检触发次数
2. **`maxSelfCheckRounds = 3`**：自检最多触发 3 次，超限后强制完成
3. **`default` case 保留 `selfCheckDone`**：不再重置，自检后 Agent 可多轮修复但自检只触发一次
4. **`set()`/`stop()` 重置计数器**：新 goal 或退出时清空

## 设计决策

| 问题 | 选择 |
|------|------|
| default 是否重置 selfCheckDone？ | 不重置——自检后 Agent 需要多轮修复，不应再触发 |
| maxSelfCheckRounds？ | 3——平衡安全性和无限循环预防 |
| 是否持久化到 goalState？ | 否——跨会话恢复时重新自检更安全 |

Cache-impact: none -- goal.go 不在 cache-sensitive 路径
Cache-guard: go test ./internal/control/