### PR TITLE
Fix scoped todo panel dismissal

### DIFF
--- a/desktop/frontend/scripts/test-todo-visibility.mjs
+++ b/desktop/frontend/scripts/test-todo-visibility.mjs
@@ -16,7 +16,13 @@ const transpiled = ts.transpileModule(source, {
 }).outputText;
 
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(transpiled).toString("base64")}`;
-const { shouldShowTodoPanel, todoDismissalKey } = await import(moduleUrl);
+const {
+  dismissedTodoKeyForScope,
+  scopedTodoDismissalKey,
+  shouldShowTodoPanel,
+  todoDismissalKey,
+  todoDismissalScope,
+} = await import(moduleUrl);
 
 const completedTodos = [
   { content: "Inspect the report", status: "completed" },
@@ -41,6 +47,54 @@ assert.equal(
   shouldShowTodoPanel("todo-final", "todo-final", completedTodos),
   false,
   "a user dismissal still hides that exact todo list",
+);
+
+const completedKey = todoDismissalKey(completedTodos);
+const dismissedBySession = new Set([scopedTodoDismissalKey("session:a", completedKey)]);
+assert.equal(
+  shouldShowTodoPanel(completedKey, dismissedTodoKeyForScope("session:a", dismissedBySession, completedKey), completedTodos),
+  false,
+  "a completed todo dismissal hides the list in the session where it was closed",
+);
+assert.equal(
+  shouldShowTodoPanel(completedKey, dismissedTodoKeyForScope("session:b", dismissedBySession, completedKey), completedTodos),
+  true,
+  "a completed todo dismissal in one session does not hide another session's list",
+);
+dismissedBySession.add(scopedTodoDismissalKey("session:b", completedKey));
+assert.equal(
+  shouldShowTodoPanel(completedKey, dismissedTodoKeyForScope("session:a", dismissedBySession, completedKey), completedTodos),
+  false,
+  "closing another session's todo does not forget the first session dismissal",
+);
+assert.equal(
+  todoDismissalScope({
+    activeTabId: "tab-a",
+    activeTab: {
+      id: "tab-a",
+      scope: "project",
+      workspaceRoot: "/repo",
+      topicId: "topic-a",
+      sessionPath: "/sessions/a.jsonl",
+    },
+  }),
+  "session:/sessions/a.jsonl",
+  "a restored history session uses its session path as the dismissal scope",
+);
+assert.equal(
+  todoDismissalScope({
+    activeTabId: "tab-b",
+    activeTab: {
+      id: "tab-a",
+      scope: "project",
+      workspaceRoot: "/repo",
+      topicId: "topic-a",
+      sessionPath: "/sessions/a.jsonl",
+    },
+    eventChannel: "desktop-events",
+  }),
+  "tab:tab-b",
+  "a stale active-tab fallback must not scope dismissal to the previous session",
 );
 assert.equal(shouldShowTodoPanel(null, null, completedTodos), false, "no canonical todo item means no panel");
 assert.equal(shouldShowTodoPanel("todo-empty", null, []), false, "empty todo lists do not render a panel");

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -60,7 +60,13 @@ import { HeartbeatPanel } from "./custom/features/heartbeat/HeartbeatPanel";
 import "./custom/features/heartbeat/heartbeat.css";
 import { CopyButton } from "./components/CopyButton";
 import { parseTodos } from "./lib/tools";
-import { shouldShowTodoPanel, todoDismissalKey } from "./lib/todoVisibility";
+import {
+  dismissedTodoKeyForScope,
+  scopedTodoDismissalKey,
+  shouldShowTodoPanel,
+  todoDismissalKey,
+  todoDismissalScope,
+} from "./lib/todoVisibility";
 import {
   type BotConnectionView,
   type BotRuntimeStatusView,
@@ -1391,9 +1397,24 @@ export default function App() {
   }, [state.items]);
   const todoItem = todoEntry?.item ?? null;
   const todos = useMemo(() => (todoItem ? parseTodos(todoItem.args) : []), [todoItem]);
-  const [dismissedTodo, setDismissedTodo] = useState<string | null>(null);
+  const [dismissedTodoKeys, setDismissedTodoKeys] = useState<Set<string>>(() => new Set());
   const todoKey = useMemo(() => todoDismissalKey(todos), [todos]);
+  const todoScope = useMemo(
+    () => todoDismissalScope({ activeTab, activeTabId, eventChannel: state.meta?.eventChannel }),
+    [activeTab, activeTabId, state.meta?.eventChannel],
+  );
+  const scopedTodoKey = useMemo(() => scopedTodoDismissalKey(todoScope, todoKey), [todoKey, todoScope]);
+  const dismissedTodo = dismissedTodoKeyForScope(todoScope, dismissedTodoKeys, todoKey);
   const showTodos = shouldShowTodoPanel(todoKey, dismissedTodo, todos);
+  const dismissTodos = useCallback(() => {
+    if (!scopedTodoKey) return;
+    setDismissedTodoKeys((current) => {
+      if (current.has(scopedTodoKey)) return current;
+      const next = new Set(current);
+      next.add(scopedTodoKey);
+      return next;
+    });
+  }, [scopedTodoKey]);
 
   const sessionTitle = topicTitle(activeTab);
   const sessionHasContent = state.items.length > 0 || Boolean(state.live?.text || state.live?.reasoning);
@@ -3030,7 +3051,7 @@ export default function App() {
 
           {!sidebarImDetailConnection && (
           <footer className="footer" ref={footerRef}>
-            {showTodos && <TodoPanel todoKey={todoKey} todos={todos} onDismiss={() => setDismissedTodo(todoKey)} />}
+            {showTodos && <TodoPanel todoKey={todoKey} todos={todos} onDismiss={dismissTodos} />}
             {rewindState && (
               <UndoRewindBanner
                 meta={{

--- a/desktop/frontend/src/lib/todoVisibility.ts
+++ b/desktop/frontend/src/lib/todoVisibility.ts
@@ -1,5 +1,17 @@
 import type { Todo } from "./tools";
 
+export interface TodoDismissalScopeInput {
+  activeTabId?: string | null;
+  activeTab?: {
+    id?: string | null;
+    scope?: string | null;
+    workspaceRoot?: string | null;
+    topicId?: string | null;
+    sessionPath?: string | null;
+  } | null;
+  eventChannel?: string | null;
+}
+
 export function todoDismissalKey(todos: Todo[]): string {
   if (todos.length === 0) return "";
   return JSON.stringify(todos.map((todo) => ({
@@ -8,6 +20,35 @@ export function todoDismissalKey(todos: Todo[]): string {
     activeForm: String(todo.activeForm ?? ""),
     level: typeof todo.level === "number" ? todo.level : 0,
   })));
+}
+
+export function todoDismissalScope({ activeTab, activeTabId, eventChannel }: TodoDismissalScopeInput): string {
+  const tabId = String(activeTabId ?? "").trim();
+  const tab = !tabId || activeTab?.id === tabId ? activeTab : null;
+  const sessionPath = tab?.sessionPath?.trim();
+  if (sessionPath) return `session:${sessionPath}`;
+  const topicId = tab?.topicId?.trim();
+  if (tab && topicId) return `topic:${tab.scope ?? ""}:${tab.workspaceRoot ?? ""}:${topicId}`;
+  if (tabId) return `tab:${tabId}`;
+  const channel = String(eventChannel ?? "").trim();
+  return channel ? `event:${channel}` : "";
+}
+
+export function scopedTodoDismissalKey(scope: string | null | undefined, todoKey: string | null | undefined): string {
+  const key = String(todoKey ?? "").trim();
+  if (!key) return "";
+  const prefix = String(scope ?? "").trim();
+  return prefix ? `${prefix}\0${key}` : key;
+}
+
+export function dismissedTodoKeyForScope(
+  scope: string | null | undefined,
+  dismissedKeys: ReadonlySet<string> | null | undefined,
+  todoKey: string | null | undefined,
+): string | null {
+  const key = scopedTodoDismissalKey(scope, todoKey);
+  if (!key || !dismissedKeys?.has(key)) return null;
+  return todoKey ?? null;
 }
 
 export function shouldShowTodoPanel(


### PR DESCRIPTION
## Summary
- scope completed todo panel dismissals by session/topic/tab identity instead of a single local key
- keep incomplete todo lists visible even when a matching stale dismissal exists
- add todo visibility coverage for cross-session dismissals and stale active-tab fallback

Fixes #5062

## Verification
- npm run test:todo-visibility
- npm run typecheck
- opened the Vite frontend locally and verified the mock todo panel renders and stays isolated across session switches

## Cache impact
Cache-impact: none - desktop todo panel visibility/UI state change only; no provider-visible prompt, memory prefix, tool schema, tool order, request serialization, compaction, or reasoning upload behavior changes.
Cache-guard: focused todo visibility test, frontend typecheck, and local Vite UI smoke check.
System-prompt-review: N/A
