### PR TITLE
Fix removed desktop projects restoring on startup / 修复移除项目重启后恢复

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -2785,9 +2785,10 @@ func (a *App) RemoveWorkspace(dir string) error {
 	if err := removeProject(dir); err != nil {
 		return err
 	}
+	a.removeWorkspaceTabs(dir)
 	// If the removed workspace was the active one, clear the pointer
 	// so we don't leave a stale reference to a deleted project.
-	if loadWorkspace() == dir {
+	if sameDesktopPath(loadWorkspace(), dir) {
 		if remaining := loadProjectsFile(); len(remaining.Projects) > 0 {
 			// Fall back to the first remaining project
 			saveWorkspace(remaining.Projects[0].Root)

--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1470,6 +1470,90 @@ func (a *App) CloseTab(tabID string) error {
 	return nil
 }
 
+func (a *App) removeWorkspaceTabs(root string) {
+	root = normalizeProjectRoot(root)
+	if root == "" {
+		return
+	}
+
+	var removed []*WorkspaceTab
+	var fallback *WorkspaceTab
+	a.mu.Lock()
+	for id, tab := range a.tabs {
+		if tab == nil || tab.Scope != "project" || !sameDesktopPath(tab.WorkspaceRoot, root) {
+			continue
+		}
+		if tab.Ctrl != nil && !tab.ReadOnly {
+			_ = tab.Ctrl.Snapshot()
+		}
+		removed = append(removed, tab)
+		delete(a.tabs, id)
+	}
+	if len(removed) == 0 {
+		a.mu.Unlock()
+		return
+	}
+
+	nextOrder := a.tabOrder[:0]
+	for _, id := range a.tabOrder {
+		if _, ok := a.tabs[id]; ok {
+			nextOrder = append(nextOrder, id)
+		}
+	}
+	a.tabOrder = nextOrder
+	if _, ok := a.tabs[a.activeTabID]; !ok {
+		a.activeTabID = ""
+		if len(a.tabOrder) > 0 {
+			a.activeTabID = a.tabOrder[0]
+		}
+	}
+	if len(a.tabs) == 0 {
+		fallback = &WorkspaceTab{
+			ID:               a.newUniqueTabIDLocked(),
+			Scope:            "global",
+			WorkspaceRoot:    globalTabWorkspaceRoot(),
+			TopicTitle:       "Global",
+			tokenMode:        boot.TokenModeFull,
+			mode:             "normal",
+			toolApprovalMode: control.ToolApprovalAsk,
+			disabledMCP:      map[string]ServerView{},
+		}
+		fallback.sink = &tabEventSink{tabID: fallback.ID, app: a, ctx: a.ctx}
+		a.tabs[fallback.ID] = fallback
+		a.tabOrder = append(a.tabOrder, fallback.ID)
+		a.activeTabID = fallback.ID
+	}
+	dir, entries, activeID, version := a.saveTabsCollectLocked()
+	a.mu.Unlock()
+
+	a.saveTabsWrite(dir, entries, activeID, version)
+	for _, tab := range removed {
+		a.closeRemovedWorkspaceTab(tab)
+	}
+	if fallback != nil && a.ctx != nil {
+		a.startTabControllerBuild(fallback)
+	}
+}
+
+func (a *App) closeRemovedWorkspaceTab(tab *WorkspaceTab) {
+	if tab == nil {
+		return
+	}
+	if tab.Ctrl != nil {
+		if tab.hasActiveRuntimeWork() && a.detachSessionRuntime(tab) {
+			return
+		}
+		tab.Ctrl.SetSessionPath("")
+		a.quiesceTabAutosave(tab)
+		tab.Ctrl.Cancel()
+		tab.Ctrl.Close()
+		a.releaseTabSharedHost(tab)
+	}
+	if tab.sink != nil {
+		tab.sink.clearContext()
+	}
+}
+
 // buildTabController assembles a controller for a tab in the background, the
 // same way buildController works for the single-controller App. On success it
 // wires the controller and flips Ready; on failure it stores StartupErr.
@@ -2611,7 +2695,7 @@ func removeProject(root string) error {
 	f := loadProjectsFile()
 	projects := make([]desktopProject, 0, len(f.Projects))
 	for _, p := range f.Projects {
-		if p.Root != root {
+		if !sameDesktopPath(p.Root, root) {
 			projects = append(projects, p)
 		}
 	}

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -996,6 +996,7 @@ func TestRemoveWorkspaceUsesSharedProjectRegistryForCurrentProject(t *testing.T)
 	app.tabs[tab.ID] = tab
 	app.tabOrder = []string{tab.ID}
 	app.activeTabID = tab.ID
+	app.saveTabsLocked()
 
 	if err := app.RemoveWorkspace(projectRoot); err != nil {
 		t.Fatalf("remove current project: %v", err)
@@ -1005,6 +1006,15 @@ func TestRemoveWorkspaceUsesSharedProjectRegistryForCurrentProject(t *testing.T)
 	}
 	if got := app.ListProjectTree(); len(got) != 1 || got[0].Kind != "global_folder" || len(got[0].Children) != 0 {
 		t.Fatalf("project tree after remove = %+v, want empty Global folder", got)
+	}
+	saved := loadTabsFile()
+	if len(saved.Tabs) != 1 || saved.Tabs[0].Scope != "global" {
+		t.Fatalf("saved tabs after remove = %+v, want one Global fallback tab", saved.Tabs)
+	}
+	for _, entry := range saved.Tabs {
+		if normalizeProjectRoot(entry.WorkspaceRoot) == normalizeProjectRoot(projectRoot) {
+			t.Fatalf("removed project tab still persisted after remove: %+v", entry)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove project-scoped tabs for a workspace when it is removed from the desktop sidebar, so `desktop-tabs.json` cannot restore the stale project on the next startup.
- Keep the tab set valid by replacing the last removed project tab with a Global fallback tab, while reusing the existing tab shutdown/detach behavior for removed runtimes.
- Use desktop path comparison when removing workspace/project records so Windows path casing cannot leave stale entries behind.

Fixes #5079

## Verification

- `cd desktop && go test . -run 'Test(RemoveWorkspace|ListWorkspaces|ReorderProjects|CloseTab)' -count=1`
- `go test ./...`
- `cd desktop && go test ./...`
- `go vet ./...`
- `cd desktop && go vet ./...`
- `gofmt -l .`
- `git diff --check`

## Cache impact

Cache-impact: none. This is limited to desktop workspace/sidebar tab persistence; no provider-visible prompt, memory prefix, output style, skill index, tool schema, tool order, request serialization, compaction, or MCP/tool registration changes.
Cache-guard: `cd desktop && go test . -run 'Test(RemoveWorkspace|ListWorkspaces|ReorderProjects|CloseTab)' -count=1`
System-prompt-review: N/A
