### PR TITLE
fix(bot): run turn off dispatch goroutine so approval replies aren't deadlocked

### DIFF
--- a/internal/bot/gateway.go
+++ b/internal/bot/gateway.go
@@ -337,7 +337,15 @@ func (gw *BotGateway) handleMessage(ctx context.Context, binding AdapterBinding,
 		return
 	}
 
-	gw.runTurn(ctx, binding.Adapter, key, msg)
+	// Run the turn on its own goroutine so the dispatch loop stays free to read
+	// the next inbound message. A turn that hits interactive approval/ask blocks
+	// inside RunTurn waiting for ctrl.Approve/AnswerQuestion — and the ONLY path
+	// that calls those is handleSlashCommand on this same dispatch goroutine. Run
+	// it inline and the loop can never deliver the /approve (or card) reply that
+	// would unblock it: the session wedges until restart (#4701, #4863, #4402).
+	// Per-session serialization is still held by the session lock (active[key]),
+	// which the deferred Release inside runTurn clears.
+	go gw.runTurn(ctx, binding.Adapter, key, msg)
 }
 
 func (gw *BotGateway) addPendingReaction(ctx context.Context, plat Platform, adapter Adapter, msg InboundMessage) {
@@ -822,6 +830,9 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 			gw.mu.Unlock()
 		},
 	)
+	// Finish initializing the sink before publishing it as the live target: once
+	// setTarget runs, other goroutines can reach this sink via state.sink.Emit.
+	sink.ctrl = state.ctrl
 	state.sink.setTarget(sink)
 	defer state.sink.setTarget(nil)
 
@@ -835,7 +846,6 @@ func (gw *BotGateway) runTurn(ctx context.Context, adapter Adapter, key string, 
 	gw.mu.Unlock()
 
 	// 运行一轮对话
-	sink.ctrl = state.ctrl
 	err := state.ctrl.RunTurn(turnCtx, input)
 	sink.Emit(event.Event{Kind: event.TurnDone, Err: err})
 	if err != nil {

--- a/internal/bot/gateway_test.go
+++ b/internal/bot/gateway_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"reasonix/internal/agent"
 	"reasonix/internal/control"
@@ -667,6 +668,99 @@ func TestGatewaySessionOptionsPreferConnectionOverride(t *testing.T) {
 	}
 	if mode != "ask" {
 		t.Fatalf("lark tool approval mode = %q, want ask", mode)
+	}
+}
+
+// blockingApprovalController emits an approval request, then blocks in RunTurn
+// until Approve is called — the exact shape of an interactive tool approval.
+type blockingApprovalController struct {
+	botController // nil embed: unused methods would panic; the turn path calls none of them
+	emit          func(event.Event)
+	emitted       chan struct{} // closed once the approval request has been emitted
+	approved      chan struct{} // closed by Approve to release the turn
+	done          chan struct{} // closed when RunTurn returns
+	once          sync.Once
+}
+
+func (c *blockingApprovalController) RunTurn(ctx context.Context, input string) error {
+	c.emit(event.Event{Kind: event.ApprovalRequest, Approval: event.Approval{ID: "appr-1", Tool: "bash", Subject: "rm -rf /"}})
+	close(c.emitted)
+	select {
+	case <-c.approved:
+		close(c.done)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (c *blockingApprovalController) Approve(id string, allow, session, persist bool) {
+	c.once.Do(func() { close(c.approved) })
+}
+
+// TestGatewayApprovalReplyUnblocksWedgedTurn reproduces #4701/#4863/#4402: a tool
+// approval over a bot must be answerable by a follow-up message. Before the fix
+// runTurn ran inline on the dispatch goroutine, so the /approve reply could never
+// be read while RunTurn blocked, deadlocking the session. With the turn on its own
+// goroutine the dispatch loop stays free to deliver the reply.
+func TestGatewayApprovalReplyUnblocksWedgedTurn(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	gw := NewGateway(GatewayConfig{Allowlist: AllowlistConfig{AllowAll: true}}, nil, logger)
+	adapter := newFakeAdapter(PlatformFeishu, "fake-feishu")
+	binding := AdapterBinding{ID: "feishu", Platform: PlatformFeishu, Adapter: adapter}
+
+	msg := InboundMessage{
+		Platform:     PlatformFeishu,
+		ConnectionID: "feishu",
+		ChatType:     ChatDM,
+		ChatID:       "chat",
+		UserID:       "user",
+		Text:         "delete everything",
+	}
+	key := BuildSessionKey(msg.Session())
+
+	sink := &sessionEventSink{}
+	ctrl := &blockingApprovalController{
+		emit:     sink.Emit,
+		emitted:  make(chan struct{}),
+		approved: make(chan struct{}),
+		done:     make(chan struct{}),
+	}
+	gw.controllers[key] = &sessionState{
+		ctrl:             ctrl,
+		sink:             sink,
+		pendingApprovals: make(map[string]event.Approval),
+		pendingAsks:      make(map[string][]event.AskQuestion),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go gw.dispatchLoop(ctx, binding)
+
+	// Turn message: acquires the session and blocks in RunTurn awaiting approval.
+	adapter.msgCh <- msg
+	select {
+	case <-ctrl.emitted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("approval request was never emitted — turn did not start")
+	}
+
+	// The card click / text reply. If the dispatch loop were wedged inside the
+	// blocked RunTurn, this would never be processed and done would never close.
+	adapter.msgCh <- InboundMessage{
+		Platform:     PlatformFeishu,
+		ConnectionID: "feishu",
+		ChatType:     ChatDM,
+		ChatID:       "chat",
+		UserID:       "user",
+		Text:         "/approve appr-1",
+	}
+
+	select {
+	case <-ctrl.done:
+		// RunTurn returned: the reply reached Approve and unblocked the turn.
+	case <-time.After(2 * time.Second):
+		t.Fatal("deadlock: /approve reply was not delivered while the turn blocked on approval")
 	}
 }
 


### PR DESCRIPTION
### Problem

A bot turn that triggers interactive tool approval (or an `ask`) blocks inside `RunTurn` waiting for `ctrl.Approve` / `AnswerQuestion`. The **only** code path that calls those is `handleSlashCommand`, which runs on the **same** per-adapter `dispatchLoop` goroutine that drives `runTurn` inline (`gateway.go`).

So once a turn blocks on approval, the dispatch loop can never read the `/approve`, `/answer`, or card-action reply that would unblock it — the session deadlocks until the app is restarted. The Feishu/Lark card click returns its "操作已提交" toast (that callback runs on the lark-ws goroutine), but the queued `InboundMessage` is never consumed. The 30‑minute `ApprovalTimeout` only auto‑*denies*; it never lets a user actually approve over the bot.

Reproduced by:
- #4701 — 飞书/Lark 机器人发送审批/问答卡片后，机器人彻底不响应
- #4863 — 飞书审批请求无法响应问题
- #4402 — 微信机器人：权限审批时卡死

This is platform-independent (the deadlock is in `internal/bot`, shared by feishu/qq/weixin).

### Fix

Run `runTurn` on its own goroutine so the dispatch loop stays free to deliver the reply:

```go
go gw.runTurn(ctx, binding.Adapter, key, msg)
```

- Per-session serialization is unchanged — it's still held by the session lock (`active[key]`); the deferred `Release` continues to drain the pending queue, so one session never runs two turns concurrently.
- The render sink is now fully initialized (`sink.ctrl = state.ctrl`) **before** it is published via `state.sink.setTarget`, now that it can be reached concurrently.

### Test

`TestGatewayApprovalReplyUnblocksWedgedTurn` drives a real turn through the dispatch loop with a controller blocked on approval, then delivers `/approve` and asserts the turn completes. It **fails in 2s (deadlock) on the old inline call** and **passes with the fix**.

### Verification

- `go test ./internal/bot/...` — pass (bot, feishu, qq, weixin)
- `go test -race -count=5 ./internal/bot/...` — pass (race-clean)
- `go vet ./internal/bot/...` — clean
- `go test -run 'Approval|Approve|Ask' ./internal/control/` — pass

Fixes #4701
Fixes #4863
Fixes #4402
