### PR TITLE
Fix interrupted stream recovery / 修复长任务断流恢复

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -81,7 +81,7 @@ var planModeGoWriteOrExecArgs = map[string]bool{
 
 const maxFinalReadinessBlocks = 3
 const maxEmptyFinalBlocks = 3
-const maxStreamRecoveries = 1
+const maxStreamRecoveries = 3
 const maxExecutorHandoffNudges = 1
 
 // Renderer redraws the assistant's final-answer text as styled output. It is

--- a/internal/agent/loop_e2e_test.go
+++ b/internal/agent/loop_e2e_test.go
@@ -122,6 +122,41 @@ func TestRunRecoversInterruptedStreamAfterPartialText(t *testing.T) {
 	}
 }
 
+func TestRunRecoversRepeatedInterruptedStreams(t *testing.T) {
+	interrupted := &provider.StreamInterruptedError{Err: errors.New("deepseek-flash: read stream: unexpected EOF")}
+	mp := testutil.NewMock("m",
+		testutil.Turn{Text: "first ", ChunkError: interrupted},
+		testutil.Turn{Text: "second ", ChunkError: interrupted},
+		testutil.Turn{Text: "done"},
+	)
+	sink := &recordSink{}
+	a := New(mp, echoRegistry(), NewSession(""), Options{}, sink)
+
+	if err := a.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run should recover repeated interrupted streams, got %v", err)
+	}
+	if mp.CallCount() != 3 {
+		t.Fatalf("provider calls = %d, want 3", mp.CallCount())
+	}
+
+	var streamed strings.Builder
+	for _, e := range sink.kinds(event.Text) {
+		streamed.WriteString(e.Text)
+	}
+	if streamed.String() != "first second done" {
+		t.Fatalf("streamed text = %q, want repeated partials plus final text", streamed.String())
+	}
+	retries := sink.kinds(event.Retrying)
+	if len(retries) != 2 || retries[0].RetryAttempt != 1 || retries[1].RetryAttempt != 2 {
+		t.Fatalf("retry events = %+v, want attempts 1 and 2", retries)
+	}
+	for _, retry := range retries {
+		if retry.RetryMax != maxStreamRecoveries {
+			t.Fatalf("retry max = %d, want %d", retry.RetryMax, maxStreamRecoveries)
+		}
+	}
+}
+
 func TestRunRecoversInterruptedPartialToolCallWithoutExecutingIt(t *testing.T) {
 	interrupted := &provider.StreamInterruptedError{Err: errors.New("deepseek-flash: read stream: unexpected EOF")}
 	mp := testutil.NewMock("m",

--- a/internal/control/errmsg.go
+++ b/internal/control/errmsg.go
@@ -16,6 +16,12 @@ func explainError(err error) error {
 	if err == nil {
 		return nil
 	}
+	if provider.IsStreamInterrupted(err) {
+		return fmt.Errorf("model stream interrupted after recovery attempts: %s. The partial response was kept; retry or ask Reasonix to continue", err.Error())
+	}
+	if provider.IsConnReset(err) {
+		return fmt.Errorf("model stream disconnected before completion after retry attempts: %s. Check the provider/proxy connection, then retry or ask Reasonix to continue", err.Error())
+	}
 	var apiErr *provider.APIError
 	if errors.As(err, &apiErr) {
 		msg := i18n.M.ProviderStatusMessage(apiErr.Status)

--- a/internal/control/errmsg_test.go
+++ b/internal/control/errmsg_test.go
@@ -2,6 +2,7 @@ package control
 
 import (
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -60,6 +61,16 @@ func TestExplainError(t *testing.T) {
 	noLeak := explainError(&provider.APIError{Provider: "deepseek", Status: 429, Body: `{"error":{"message":"slow down"}}`})
 	if noLeak.Error() != i18n.M.ProviderErrRateLimited {
 		t.Errorf("429 body must not leak into the message, got %q", noLeak.Error())
+	}
+
+	interrupted := explainError(&provider.StreamInterruptedError{Err: io.ErrUnexpectedEOF})
+	if !strings.Contains(interrupted.Error(), "model stream interrupted") || !strings.Contains(interrupted.Error(), "continue") {
+		t.Errorf("stream interruption should be actionable, got %q", interrupted.Error())
+	}
+
+	disconnected := explainError(io.ErrUnexpectedEOF)
+	if !strings.Contains(disconnected.Error(), "model stream disconnected") || !strings.Contains(disconnected.Error(), "retry") {
+		t.Errorf("connection reset should be actionable, got %q", disconnected.Error())
 	}
 
 	plain := errors.New("some other failure")

--- a/internal/provider/openai/openai.go
+++ b/internal/provider/openai/openai.go
@@ -458,6 +458,9 @@ func (c *client) readStream(ctx context.Context, resp *http.Response, out chan<-
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return emitted, err
+	}
 	if stalled.Load() {
 		return emitted, fmt.Errorf("%s: stream stalled — no data for %s, connection likely dropped", c.name, idleTimeout)
 	}
@@ -593,7 +596,7 @@ type chatFunction struct {
 }
 
 type chatToolCall struct {
-	Index    int    `json:"index"`
+	Index    int    `json:"index,omitempty"`
 	ID       string `json:"id,omitempty"`
 	Type     string `json:"type,omitempty"`
 	Function struct {

--- a/internal/provider/openai/openai_test.go
+++ b/internal/provider/openai/openai_test.go
@@ -614,6 +614,31 @@ func TestBuildRequestContentNullForAssistantToolCalls(t *testing.T) {
 	}
 }
 
+func TestBuildRequestOmitsResponseOnlyToolCallIndex(t *testing.T) {
+	c := &client{name: "x", model: "m", baseURL: "https://api.example.com/v1"}
+	req := provider.Request{
+		Messages: []provider.Message{{
+			Role: provider.RoleAssistant,
+			ToolCalls: []provider.ToolCall{{
+				ID:        "call_1",
+				Name:      "bash",
+				Arguments: `{"cmd":"ls"}`,
+			}},
+		}},
+	}
+	body, err := json.Marshal(c.buildRequest(req))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(body)
+	if !strings.Contains(s, `"tool_calls"`) {
+		t.Fatalf("request body missing tool call: %s", s)
+	}
+	if strings.Contains(s, `"index"`) {
+		t.Fatalf("request body contains response-only tool_call index: %s", s)
+	}
+}
+
 func TestBuildRequestOmitsEmptyToolDescriptionAndParameters(t *testing.T) {
 	c := &client{name: "x", model: "m", baseURL: "https://api.example.com/v1"}
 	req := provider.Request{

--- a/internal/provider/openai/reconnect_test.go
+++ b/internal/provider/openai/reconnect_test.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"reasonix/internal/provider"
 )
@@ -76,6 +78,51 @@ func TestStreamReconnectsOnEarlyConnReset(t *testing.T) {
 	}
 	if reqs != 2 {
 		t.Errorf("server saw %d requests, want 2 (one reset + one replay)", reqs)
+	}
+}
+
+func TestStreamCancelDoesNotReconnect(t *testing.T) {
+	var reqs atomic.Int32
+	ready := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		first := reqs.Add(1) == 1
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.WriteString(w, ": keep-alive\n\n")
+		flush(w)
+		if first {
+			close(ready)
+		}
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	p, err := New(provider.Config{Name: "deepseek", BaseURL: srv.URL, Model: "deepseek-v4", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := p.Stream(ctx, provider.Request{Messages: []provider.Message{{Role: provider.RoleUser, Content: "hi"}}})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not receive the streaming request")
+	}
+	cancel()
+
+	var got error
+	for chunk := range ch {
+		if chunk.Type == provider.ChunkError {
+			got = chunk.Err
+		}
+	}
+	if !errors.Is(got, context.Canceled) {
+		t.Fatalf("stream error = %v, want context.Canceled", got)
+	}
+	if reqs.Load() != 1 {
+		t.Fatalf("cancelled stream reconnected; server saw %d requests, want 1", reqs.Load())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat user cancellation as cancellation instead of a dropped model stream, preventing reconnects after the user stops a long-running turn.
- Allow the agent loop to recover from up to three interrupted partial streams before surfacing an actionable error.
- Omit response-only `tool_calls[].index` from replayed assistant messages while preserving streaming delta parsing.

## Cache and provider compatibility
Cache-impact: low - Touches provider request serialization and agent recovery limits, but does not change the stable prompt prefix, tool schema bytes or order, model list, or provider thinking controls. It only omits a response-only zero-valued tool-call index from replayed assistant messages.
Cache-guard: `TestBuildRequestOmitsResponseOnlyToolCallIndex`; `go test ./...`

- Aligns replayed `tool_calls` with the OpenAI-compatible message shape (`id`, `type`, `function`) while keeping streaming `delta.tool_calls[].index` parsing intact.
- Related nearby PRs checked: #5063, #5059, #5048. They touch adjacent provider/thinking behavior but not this stream-recovery path.

## Verification
- `git diff --check`
- `go test ./...`