### PR TITLE
refactor(control): extract memoryManager from Controller

### DIFF
--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -79,13 +79,10 @@ type Controller struct {
 	skillStore    *skill.Store
 	allSkillStore *skill.Store
 	hooks         *hook.Runner // session hook runner; nil-safe (no hooks configured)
-	mem           *memory.Set
-	// memMu serializes memory mutations (QuickAdd/SaveDoc/SaveMemory/ForgetMemory/
-	// QueueMemory) so each write+reload+swap is atomic with respect to the others,
-	// WITHOUT holding c.mu across the disk I/O. c.mu is taken only briefly — to read
-	// the snapshot pointer and to swap the reloaded snapshot in — never around a
-	// filesystem walk, so a memory-panel save can't stall an approval or status poll.
-	memMu             sync.Mutex
+	// memory owns the loaded memory snapshot, the pending turn-tail notes queue,
+	// and write serialization behind its own locks, off c.mu — so a memory-panel
+	// save never stalls an approval or status poll. See memory.go.
+	memory            memoryManager
 	cleanup           func()
 	autoPlan          string
 	reasoningLanguage string
@@ -153,13 +150,6 @@ type Controller struct {
 	sessionPath string
 	// turn counts model turns this session, passed to hooks in their payload.
 	turn int
-
-	// pendingMemory holds memory notes added mid-session (via "#" quick-add or a
-	// memory edit) that haven't yet been folded into a turn. Compose drains it
-	// onto the next outgoing turn — never into the cache-stable system prefix — so
-	// a fresh memory takes effect this session without busting the prompt cache;
-	// it joins the prefix naturally on the next session.
-	pendingMemory []string
 
 	displayRecorder func(content, display string)
 }
@@ -315,7 +305,7 @@ func New(opts Options) *Controller {
 		skillStore:             opts.SkillStore,
 		allSkillStore:          opts.AllSkillStore,
 		hooks:                  opts.Hooks,
-		mem:                    opts.Memory,
+		memory:                 newMemoryManager(opts.Memory),
 		cleanup:                opts.Cleanup,
 		autoPlan:               normalizeAutoPlan(opts.AutoPlan),
 		reasoningLanguage:      config.NormalizeReasoningLanguage(opts.ReasoningLanguage),
@@ -2886,94 +2876,34 @@ func (c *Controller) Bypass() bool {
 
 // --- memory ---
 //
-// c.mem is an immutable snapshot: reads take c.mu briefly and return the pointer.
-// Writes are serialized by memMu and do their disk I/O (the doc/store write plus
-// the memory.Load re-discovery) OFF c.mu, taking c.mu only to read the snapshot
-// pointer and to swap the freshly discovered snapshot in — so a write never holds
-// c.mu across a filesystem walk. A turn-tail note is queued for each write so the
-// change applies this session without disturbing the cache-stable system prefix
-// (it folds into the prefix on the next session). All of these are no-ops
-// returning "" when memory is disabled.
+// The memory snapshot, the pending turn-tail notes queue, and write serialization
+// live in c.memory (a memoryManager) behind its own locks, off c.mu — so a
+// memory-panel save never stalls an approval or status poll. These methods are
+// the SessionAPI surface; each is a thin delegation. See memory.go.
 
 // QuickAdd appends a one-line note to the doc-memory file for scope (project
 // REASONIX.md by default) — the write side of "#<note>". Returns the file written.
 func (c *Controller) QuickAdd(scope memory.Scope, note string) (string, error) {
-	c.memMu.Lock()
-	defer c.memMu.Unlock()
-	mem := c.memSnapshot()
-	if mem == nil {
-		return "", nil
-	}
-	path := mem.DocPath(scope)
-	if path == "" {
-		return "", fmt.Errorf("no target file for memory scope %q", scope)
-	}
-	if err := memory.AppendDoc(path, note); err != nil {
-		return "", err
-	}
-	c.applyMemoryWrite(mem, note)
-	return path, nil
+	return c.memory.quickAdd(scope, note)
 }
 
 // SaveDoc overwrites a recognized memory doc with body — the save side of the
 // desktop panel's in-place editor. Returns the file written.
 func (c *Controller) SaveDoc(path, body string) (string, error) {
-	c.memMu.Lock()
-	defer c.memMu.Unlock()
-	mem := c.memSnapshot()
-	if mem == nil {
-		return "", nil
-	}
-	written, err := mem.WriteDoc(path, body)
-	if err != nil {
-		return "", err
-	}
-	// Inject the new content once on the next turn: the cached prefix still holds
-	// the pre-edit version this session, so handing the model the current text
-	// avoids a stale-guidance gap until the next session re-folds it into the
-	// prefix. Trimmed to a single tail note (drained by Compose), not per-turn.
-	c.applyMemoryWrite(mem,
-		"Memory file "+written+" was just edited. Its current contents:\n"+strings.TrimSpace(body))
-	return written, nil
+	return c.memory.saveDoc(path, body)
 }
 
 // SaveMemory writes an active auto-memory fact and refreshes the in-session
 // snapshot. It is the explicit user-confirmed counterpart to the model-owned
 // remember tool, used by management surfaces that preview a candidate first.
 func (c *Controller) SaveMemory(m memory.Memory) (string, error) {
-	c.memMu.Lock()
-	defer c.memMu.Unlock()
-	mem := c.memSnapshot()
-	if mem == nil {
-		return "", nil
-	}
-	path, err := mem.Store.Save(m)
-	if err != nil {
-		return "", err
-	}
-	c.applyMemoryWrite(mem,
-		"Saved memory \""+m.Name+"\": "+strings.Join(strings.Fields(m.Description), " "))
-	return path, nil
+	return c.memory.saveMemory(m)
 }
 
 // ForgetMemory removes a saved auto-memory by name — the panel/TUI forget action,
-// the manual counterpart to the model's `forget` tool. It queues a turn-tail note
-// so the removal applies this session (the cached prefix still lists the fact
-// until the next session re-folds the index). The file is archived for
-// traceability by Store.Delete.
+// the manual counterpart to the model's `forget` tool.
 func (c *Controller) ForgetMemory(name string) error {
-	c.memMu.Lock()
-	defer c.memMu.Unlock()
-	mem := c.memSnapshot()
-	if mem == nil {
-		return nil
-	}
-	if err := mem.Store.Delete(name); err != nil {
-		return err
-	}
-	c.applyMemoryWrite(mem,
-		"Forgot memory \""+name+"\" — disregard its line still shown in the saved-memories index until next session.")
-	return nil
+	return c.memory.forget(name)
 }
 
 // QueueMemory implements memory.Queue: when the model runs the remember/forget
@@ -2981,50 +2911,14 @@ func (c *Controller) ForgetMemory(name string) error {
 // applies this session without touching the cache-stable prefix. It also
 // refreshes the snapshot a memory panel reads.
 func (c *Controller) QueueMemory(note string) {
-	c.memMu.Lock()
-	defer c.memMu.Unlock()
-	if mem := c.memSnapshot(); mem != nil {
-		c.applyMemoryWrite(mem, note)
-		return
-	}
-	// Memory disabled — still queue the turn-tail note; there's no snapshot to
-	// re-discover.
-	c.mu.Lock()
-	c.pendingMemory = append(c.pendingMemory, note)
-	c.mu.Unlock()
+	c.memory.queue(note)
 }
 
 // Memory returns the loaded memory snapshot (nil when memory is disabled), for
 // frontends that surface a memory panel or the /memory command. The returned
 // *Set is immutable — mutations go through QuickAdd / SaveDoc.
 func (c *Controller) Memory() *memory.Set {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.mem
-}
-
-// memSnapshot returns the current memory snapshot under a brief c.mu, so callers
-// can do the doc/store write and re-discovery off-lock. Holding memMu keeps the
-// returned pointer current until the matching applyMemoryWrite swaps it in.
-func (c *Controller) memSnapshot() *memory.Set {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.mem
-}
-
-// applyMemoryWrite re-discovers memory from disk (off-lock, the expensive part)
-// then, under a brief c.mu, swaps the fresh snapshot in and queues the turn-tail
-// note so a later Memory() reflects the just-applied write. mem is the snapshot
-// taken at the start of the memMu-serialized write and supplies the discovery
-// roots. Callers hold memMu.
-func (c *Controller) applyMemoryWrite(mem *memory.Set, note string) {
-	reloaded := memory.Load(memory.Options{CWD: mem.CWD, UserDir: mem.UserDir})
-	c.mu.Lock()
-	if note != "" {
-		c.pendingMemory = append(c.pendingMemory, note)
-	}
-	c.mem = reloaded
-	c.mu.Unlock()
+	return c.memory.current()
 }
 
 // --- approval bridge (agent gate → events) ---

--- a/internal/control/input.go
+++ b/internal/control/input.go
@@ -138,9 +138,8 @@ func (c *Controller) Compose(text string) string {
 	c.mu.Lock()
 	plan := c.planMode
 	reasoningLanguage := c.reasoningLanguage
-	notes := c.pendingMemory
-	c.pendingMemory = nil
 	c.mu.Unlock()
+	notes := c.memory.drainPending()
 	goal, goalStatus, goalResearchMode := c.goals.snapshot()
 
 	if strings.TrimSpace(goal) != "" && goalStatus == GoalStatusRunning {

--- a/internal/control/memory.go
+++ b/internal/control/memory.go
@@ -1,0 +1,175 @@
+package control
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"reasonix/internal/memory"
+)
+
+// memoryManager owns the session's loaded memory snapshot, the queue of pending
+// turn-tail notes, and the serialization of memory writes — behind its own locks
+// and off the controller's c.mu. Like goalMachine it is a strict leaf: its
+// methods only touch its own state and never call back into the Controller, so a
+// memory-panel save can't stall an approval or status poll on c.mu.
+//
+// set is an immutable snapshot: reads take mu briefly and return the pointer.
+// Writes are serialized by writeMu and do their disk I/O (the doc/store write
+// plus the memory.Load re-discovery) OFF mu, taking mu only to swap the freshly
+// discovered snapshot in and queue the turn-tail note — so a write never holds a
+// lock across a filesystem walk. A turn-tail note is queued for each write so the
+// change applies this session without disturbing the cache-stable system prefix
+// (it folds into the prefix on the next session). All write methods are no-ops
+// returning "" when memory is disabled (set == nil).
+type memoryManager struct {
+	// mu guards set (the snapshot pointer) and pending (the turn-tail queue);
+	// every critical section under it is short and non-blocking.
+	mu  sync.Mutex
+	set *memory.Set
+	// pending holds memory notes added mid-session (via "#" quick-add or a memory
+	// edit) that haven't yet been folded into a turn. Compose drains it onto the
+	// next outgoing turn — never into the cache-stable system prefix — so a fresh
+	// memory takes effect this session without busting the prompt cache; it joins
+	// the prefix naturally on the next session.
+	pending []string
+
+	// writeMu serializes memory writes so each write+reload+swap is atomic with
+	// respect to the others. Taken OFF mu, so a read (current/drainPending) never
+	// blocks behind a write's disk I/O.
+	writeMu sync.Mutex
+}
+
+func newMemoryManager(set *memory.Set) memoryManager {
+	return memoryManager{set: set}
+}
+
+// current returns the loaded snapshot (nil when memory is disabled). The returned
+// *Set is immutable — mutations go through quickAdd / saveDoc / saveMemory.
+func (m *memoryManager) current() *memory.Set {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.set
+}
+
+// drainPending returns and clears the queued turn-tail notes, for Compose to fold
+// onto the next outgoing turn.
+func (m *memoryManager) drainPending() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	notes := m.pending
+	m.pending = nil
+	return notes
+}
+
+// applyWrite re-discovers memory from disk (off-lock, the expensive part) then,
+// under a brief mu, swaps the fresh snapshot in and queues the turn-tail note so a
+// later current() reflects the just-applied write. mem is the snapshot taken at
+// the start of the writeMu-serialized write and supplies the discovery roots.
+// Callers hold writeMu.
+func (m *memoryManager) applyWrite(mem *memory.Set, note string) {
+	reloaded := memory.Load(memory.Options{CWD: mem.CWD, UserDir: mem.UserDir})
+	m.mu.Lock()
+	if note != "" {
+		m.pending = append(m.pending, note)
+	}
+	m.set = reloaded
+	m.mu.Unlock()
+}
+
+// quickAdd appends a one-line note to the doc-memory file for scope (project
+// REASONIX.md by default) — the write side of "#<note>". Returns the file written.
+func (m *memoryManager) quickAdd(scope memory.Scope, note string) (string, error) {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	mem := m.current()
+	if mem == nil {
+		return "", nil
+	}
+	path := mem.DocPath(scope)
+	if path == "" {
+		return "", fmt.Errorf("no target file for memory scope %q", scope)
+	}
+	if err := memory.AppendDoc(path, note); err != nil {
+		return "", err
+	}
+	m.applyWrite(mem, note)
+	return path, nil
+}
+
+// saveDoc overwrites a recognized memory doc with body — the save side of the
+// desktop panel's in-place editor. Returns the file written.
+func (m *memoryManager) saveDoc(path, body string) (string, error) {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	mem := m.current()
+	if mem == nil {
+		return "", nil
+	}
+	written, err := mem.WriteDoc(path, body)
+	if err != nil {
+		return "", err
+	}
+	// Inject the new content once on the next turn: the cached prefix still holds
+	// the pre-edit version this session, so handing the model the current text
+	// avoids a stale-guidance gap until the next session re-folds it into the
+	// prefix. Trimmed to a single tail note (drained by Compose), not per-turn.
+	m.applyWrite(mem,
+		"Memory file "+written+" was just edited. Its current contents:\n"+strings.TrimSpace(body))
+	return written, nil
+}
+
+// saveMemory writes an active auto-memory fact and refreshes the in-session
+// snapshot. It is the explicit user-confirmed counterpart to the model-owned
+// remember tool, used by management surfaces that preview a candidate first.
+func (m *memoryManager) saveMemory(fact memory.Memory) (string, error) {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	mem := m.current()
+	if mem == nil {
+		return "", nil
+	}
+	path, err := mem.Store.Save(fact)
+	if err != nil {
+		return "", err
+	}
+	m.applyWrite(mem,
+		"Saved memory \""+fact.Name+"\": "+strings.Join(strings.Fields(fact.Description), " "))
+	return path, nil
+}
+
+// forget removes a saved auto-memory by name — the panel/TUI forget action, the
+// manual counterpart to the model's `forget` tool. It queues a turn-tail note so
+// the removal applies this session (the cached prefix still lists the fact until
+// the next session re-folds the index). The file is archived for traceability by
+// Store.Delete.
+func (m *memoryManager) forget(name string) error {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	mem := m.current()
+	if mem == nil {
+		return nil
+	}
+	if err := mem.Store.Delete(name); err != nil {
+		return err
+	}
+	m.applyWrite(mem,
+		"Forgot memory \""+name+"\" — disregard its line still shown in the saved-memories index until next session.")
+	return nil
+}
+
+// queue rides a note on the next turn — the model's remember/forget tool path
+// (memory.Queue). It refreshes the snapshot a memory panel reads when memory is
+// enabled, and still queues the turn-tail note when it isn't (there's no snapshot
+// to re-discover).
+func (m *memoryManager) queue(note string) {
+	m.writeMu.Lock()
+	defer m.writeMu.Unlock()
+	if mem := m.current(); mem != nil {
+		m.applyWrite(mem, note)
+		return
+	}
+	m.mu.Lock()
+	m.pending = append(m.pending, note)
+	m.mu.Unlock()
+}

--- a/internal/control/memory_test.go
+++ b/internal/control/memory_test.go
@@ -12,7 +12,7 @@ import (
 
 // TestMemoryWriteReflectsInSnapshot verifies that a memory write lands on disk
 // and that Memory() returns a freshly reloaded snapshot afterwards — the behavior
-// the off-c.mu (memMu) refactor must preserve.
+// the memoryManager (off-c.mu) extraction must preserve.
 func TestMemoryWriteReflectsInSnapshot(t *testing.T) {
 	dir := t.TempDir()
 	c := New(Options{Memory: memory.Load(memory.Options{CWD: dir})})
@@ -40,14 +40,15 @@ func TestMemoryWriteReflectsInSnapshot(t *testing.T) {
 		t.Fatal("memory snapshot is nil after QuickAdd")
 	}
 	if after == before {
-		t.Fatal("Memory() returned the stale snapshot; applyMemoryWrite did not swap in a reload")
+		t.Fatal("Memory() returned the stale snapshot; the manager did not swap in a reload")
 	}
 }
 
 // TestMemoryWritesConcurrencySafe hammers memory writes from many goroutines
-// while c.mu-guarded reads run concurrently. Under -race this proves the new
-// memMu/c.mu split has no data race and no deadlock — and that holding memMu
-// (not c.mu) across the disk I/O still serializes writes so every note lands.
+// while c.mu-guarded reads run concurrently. Under -race this proves the
+// memoryManager's writeMu/mu split has no data race and no deadlock — and that
+// holding writeMu (off c.mu) across the disk I/O still serializes writes so every
+// note lands.
 func TestMemoryWritesConcurrencySafe(t *testing.T) {
 	dir := t.TempDir()
 	c := New(Options{Memory: memory.Load(memory.Options{CWD: dir})})

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -528,18 +528,19 @@ func (c *Controller) providerSwitchText(name string) string {
 }
 
 func (c *Controller) memoryListText() string {
-	if c.mem == nil {
+	mem := c.memory.current()
+	if mem == nil {
 		return i18n.M.ListMemoryNone
 	}
-	saved := c.mem.Store.List()
-	archived := c.mem.Store.ListArchived()
-	if len(c.mem.Docs) == 0 && len(saved) == 0 && len(archived) == 0 {
+	saved := mem.Store.List()
+	archived := mem.Store.ListArchived()
+	if len(mem.Docs) == 0 && len(saved) == 0 && len(archived) == 0 {
 		return i18n.M.ListMemoryNone
 	}
 	var b strings.Builder
-	if len(c.mem.Docs) > 0 {
+	if len(mem.Docs) > 0 {
 		b.WriteString(i18n.M.ListMemoryHeader + "\n")
-		for _, d := range c.mem.Docs {
+		for _, d := range mem.Docs {
 			fmt.Fprintf(&b, "  (%s) %s\n", d.Scope, d.Path)
 		}
 	}


### PR DESCRIPTION
## What

Carve the **memory subsystem** out of the `Controller` god object into a strict leaf collaborator, following the established `goalMachine` / `approvalManager` decomposition pattern (the sub-port boundaries in `port.go` are the intended split spec).

`memoryManager` (new `internal/control/memory.go`) owns the loaded snapshot, the pending turn-tail notes queue, and write serialization behind its own locks:
- `mu` guards the snapshot pointer and the pending queue (short, non-blocking).
- `writeMu` serializes the write+reload sequence, taken **off** `mu` and entirely off `c.mu`, so a memory-panel save never holds a lock across a filesystem walk or stalls an approval / status poll.

## Changes

- **New** `internal/control/memory.go` — the manager and all memory logic.
- `controller.go` drops the scattered `mem` / `memMu` / `pendingMemory` fields for a single `memory memoryManager`; `QuickAdd` / `SaveDoc` / `SaveMemory` / `ForgetMemory` / `QueueMemory` / `Memory` become one-line delegations. The internal `memSnapshot` / `applyMemoryWrite` move into the manager.
- `input.go` (`Compose`) drains pending notes via `c.memory.drainPending()`; `slash.go` (`/memory` listing) reads the snapshot via `c.memory.current()`.

## Why it's safe

- **Public `SessionAPI` surface is unchanged** → no frontend (cli/desktop/acp/serve/bot) is touched. Purely internal decomposition.
- `controller.go`: **3561 → 3455 lines, 47 → 45 fields**.

## Verification

- `gofmt` clean, `go vet ./internal/control/...` clean, `go build ./...` ok.
- `go test -race ./internal/control/...` green, including the memory concurrency test `TestMemoryWritesConcurrencySafe`.
- Full `go test ./...` — **52 packages, all green**.

First in a series continuing the Controller god-object decomposition (next candidates: checkpoint, mcp/capabilities).