### PR TITLE
Fix desktop command failure feedback / 修复桌面命令失败反馈

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -647,22 +647,25 @@ func (a *App) domReady(_ context.Context) {
 
 // Submit runs raw user input as a turn; slash commands and @-references are
 // resolved by the controller. Output arrives asynchronously on eventChannel.
-func (a *App) Submit(input string) {
-	a.SubmitToTab("", input)
+func (a *App) Submit(input string) error {
+	return a.SubmitToTab("", input)
 }
 
-func (a *App) SubmitToTab(tabID, input string) {
-	if a.tabReadOnly(tabID) {
-		return
+func (a *App) SubmitToTab(tabID, input string) error {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab != nil && tab.ReadOnly {
+		return readOnlyChannelErr()
 	}
 	trimmed := strings.TrimSpace(input)
 	if trimmed == "/effort" || strings.HasPrefix(trimmed, "/effort ") {
 		a.runEffortCommandForTab(tabID, trimmed)
-		return
+		return nil
 	}
-	if ctrl := a.ctrlByTabID(tabID); ctrl != nil {
-		ctrl.SubmitDisplay(input, input)
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
 	}
+	ctrl.SubmitDisplay(input, input)
+	return nil
 }
 
 func (a *App) submitUserTurnToTab(tabID, input string) bool {
@@ -679,34 +682,38 @@ func (a *App) submitUserTurnToTab(tabID, input string) bool {
 
 // RunShell executes a shell command directly (bypassing the model) and streams
 // output as events on eventChannel.
-func (a *App) RunShell(command string) {
-	a.RunShellForTab("", command)
+func (a *App) RunShell(command string) error {
+	return a.RunShellForTab("", command)
 }
 
-func (a *App) RunShellForTab(tabID, command string) {
-	if a.tabReadOnly(tabID) {
-		return
+func (a *App) RunShellForTab(tabID, command string) error {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab != nil && tab.ReadOnly {
+		return readOnlyChannelErr()
 	}
-	if ctrl := a.ctrlByTabID(tabID); ctrl != nil {
-		ctrl.RunShell(command)
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
 	}
+	ctrl.RunShell(command)
+	return nil
 }
 
 // SubmitDisplay runs input as a turn while recording a shorter UI-only display
 // string for the saved desktop transcript. The model still receives input.
-func (a *App) SubmitDisplay(display, input string) {
-	a.SubmitDisplayToTab("", display, input)
+func (a *App) SubmitDisplay(display, input string) error {
+	return a.SubmitDisplayToTab("", display, input)
 }
 
-func (a *App) SubmitDisplayToTab(tabID, display, input string) {
-	if a.tabReadOnly(tabID) {
-		return
+func (a *App) SubmitDisplayToTab(tabID, display, input string) error {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab != nil && tab.ReadOnly {
+		return readOnlyChannelErr()
 	}
-	ctrl := a.ctrlByTabID(tabID)
 	if ctrl == nil {
-		return
+		return workspaceNotReadyErr(tab)
 	}
 	ctrl.SubmitDisplay(display, input)
+	return nil
 }
 
 func (a *App) bindControllerDisplayRecorder(ctrl control.SessionAPI) {
@@ -734,23 +741,36 @@ func (a *App) CancelTab(tabID string) {
 }
 
 // Steer sends mid-turn guidance to the agent without interrupting the in-flight request.
-func (a *App) Steer(text string) {
-	a.SteerForTab("", text)
+func (a *App) Steer(text string) error {
+	return a.SteerForTab("", text)
 }
 
 // SteerForTab sends mid-turn guidance to a specific tab's agent.
-func (a *App) SteerForTab(tabID, text string) {
-	if a.tabReadOnly(tabID) {
-		return
+func (a *App) SteerForTab(tabID, text string) error {
+	tab, ctrl := a.tabAndCtrlByID(tabID)
+	if tab != nil && tab.ReadOnly {
+		return readOnlyChannelErr()
 	}
-	if ctrl := a.ctrlByTabID(tabID); ctrl != nil {
-		ctrl.Steer(text)
+	if ctrl == nil {
+		return workspaceNotReadyErr(tab)
 	}
+	ctrl.Steer(text)
+	return nil
 }
 
 func (a *App) tabReadOnly(tabID string) bool {
 	tab := a.tabByID(tabID)
 	return tab != nil && tab.ReadOnly
+}
+
+func (a *App) tabAndCtrlByID(tabID string) (*WorkspaceTab, control.SessionAPI) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	tab := a.tabByIDLocked(tabID)
+	if tab == nil {
+		return nil, nil
+	}
+	return tab, tab.Ctrl
 }
 
 func readOnlyChannelErr() error {

--- a/desktop/app_test.go
+++ b/desktop/app_test.go
@@ -3063,6 +3063,64 @@ func TestOpenChannelSessionForTabIsReadOnly(t *testing.T) {
 	}
 }
 
+func TestUserTriggeredCommandsReturnErrorsWhenUnavailable(t *testing.T) {
+	tests := []struct {
+		name string
+		app  *App
+		call func(*App) error
+		want string
+	}{
+		{
+			name: "submit read-only",
+			app: &App{
+				tabs:        map[string]*WorkspaceTab{"test": {ID: "test", Scope: "global", ReadOnly: true}},
+				activeTabID: "test",
+			},
+			call: func(app *App) error { return app.SubmitToTab("test", "hello") },
+			want: "read-only",
+		},
+		{
+			name: "submit workspace unavailable",
+			app: &App{
+				tabs:        map[string]*WorkspaceTab{"test": {ID: "test", Scope: "global", StartupErr: "boom"}},
+				activeTabID: "test",
+			},
+			call: func(app *App) error { return app.SubmitToTab("test", "hello") },
+			want: "workspace failed to start: boom",
+		},
+		{
+			name: "run shell workspace unavailable",
+			app: &App{
+				tabs:        map[string]*WorkspaceTab{"test": {ID: "test", Scope: "global"}},
+				activeTabID: "test",
+			},
+			call: func(app *App) error { return app.RunShellForTab("test", "echo hi") },
+			want: "workspace is still starting",
+		},
+		{
+			name: "steer workspace unavailable",
+			app: &App{
+				tabs:        map[string]*WorkspaceTab{"test": {ID: "test", Scope: "global"}},
+				activeTabID: "test",
+			},
+			call: func(app *App) error { return app.SteerForTab("test", "please continue") },
+			want: "workspace is still starting",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call(tt.app)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.want)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
 func TestCloseReadOnlyChannelTabDoesNotSnapshotTranscript(t *testing.T) {
 	isolateDesktopUserDirs(t)
 

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1113,6 +1113,7 @@ export default function App() {
   const footerRef = useRef<HTMLElement>(null);
   const runningRef = useRef(state.running);
   const activeTabIdRef = useRef(activeTabId);
+  const commitThenSendRef = useRef<(displayText: string, submitText?: string) => Promise<void>>(async () => {});
   const rightDockDetailActive = rightDockMode !== "context" && workspacePreviewActive;
   const preferredWorkspacePanelWidth = rightDockDetailActive ? rightDockPreviewWidth : rightDockTreeWidth;
   const workspacePanelMinWidth = rightDockDetailActive ? RIGHT_DOCK_PREVIEW_MIN_WIDTH : RIGHT_DOCK_TREE_MIN_WIDTH;
@@ -1464,8 +1465,10 @@ export default function App() {
     if (!pendingPlanRevision || state.running) return;
     const text = pendingPlanRevision;
     setPendingPlanRevision(null);
-    commitThenSend(text);
-  }, [pendingPlanRevision, send, state.running]);
+    void commitThenSendRef.current(text).catch((err) => {
+      console.warn("Failed to submit pending plan revision", err);
+    });
+  }, [pendingPlanRevision, state.running]);
 
   useEffect(() => {
     setClearContextPending(false);
@@ -1513,7 +1516,7 @@ export default function App() {
           notice("usage: !<command>  (e.g. !ls -la)");
           return;
         }
-        runShell(cmd);
+        await runShell(cmd);
         return;
       }
       const model = /^\/model\s+(\S+)$/.exec(trimmed);
@@ -1549,13 +1552,13 @@ export default function App() {
           applyGoal("");
         }
         if (!controllerReady) return;
-        commitThenSend(trimmed, submitText.trim());
+        await commitThenSendRef.current(trimmed, submitText.trim());
         return;
       }
       if (collaborationMode === "goal" && !goal.trim()) {
         if (!controllerReady) return;
         applyGoal(trimmed);
-        commitThenSend(trimmed, `/goal ${submitText.trim()}`);
+        await commitThenSendRef.current(trimmed, `/goal ${submitText.trim()}`);
         return;
       }
       const theme = /^\/theme(?:\s+(\S+))?$/.exec(trimmed);
@@ -1592,12 +1595,12 @@ export default function App() {
         notice(t("settings.themeUnknown", { name: arg }), "warn");
         return;
       }
-      if (runningRef.current) { steer(submitText.trim()); return; }
+      if (runningRef.current) { await steer(submitText.trim()); return; }
       if (!controllerReady) return;
       await setControllerCollaborationMode(controllerComposerProfileCollaborationMode(composerProfile));
       await setControllerToolApprovalMode(toolApprovalMode);
       if (goal.trim()) await setControllerGoal(goal);
-      commitThenSend(trimmed, submitText.trim());
+      await commitThenSendRef.current(trimmed, submitText.trim());
     },
     [activeTabId, applyGoal, closeTransientOverlays, collaborationMode, composerProfile, controllerReady, goal, send, runShell, notice, setControllerCollaborationMode, setControllerGoal, setControllerToolApprovalMode, steer, switchModel, t, toolApprovalMode, showToast],
   );
@@ -2115,8 +2118,8 @@ export default function App() {
 
   // send wrapper: commits any pending optimistic rewind before sending.
   const commitThenSend = useCallback(async (displayText: string, submitText?: string) => {
-    if (activeTab?.readOnly) return;
-    if (!controllerReady) return;
+    if (activeTab?.readOnly) throw new Error("channel session is read-only");
+    if (!controllerReady) throw new Error("workspace is still starting");
     const rs = rewindStateRef.current;
     if (rs) {
       rewindStateRef.current = null;
@@ -2132,7 +2135,7 @@ export default function App() {
         // Rewind failed: the Go conversation is intact. Do not send; the
         // controller emits a notice with the reason.
         setRewindState(null);
-        return;
+        throw new Error("rewind failed");
       }
       setRewindSignal((v) => v + 1);
       if (rs.scope === "both") {
@@ -2141,13 +2144,16 @@ export default function App() {
         setProjectRevision((v) => v + 1);
       }
     }
-    send(displayText, submitText);
+    await send(displayText, submitText);
   }, [activeTab?.readOnly, controllerReady, send, rewind]);
 
   const handleTranscriptPrompt = useCallback((text: string) => {
     if (!controllerReady) return;
-    void commitThenSend(text);
+    void commitThenSend(text).catch((err) => {
+      console.warn("Failed to submit transcript prompt", err);
+    });
   }, [commitThenSend, controllerReady]);
+  commitThenSendRef.current = commitThenSend;
 
   const handleMessageAction = useCallback((turn: number, scope: string) => {
     if (activeTab?.readOnly) return;
@@ -2226,8 +2232,12 @@ export default function App() {
     const ok = await rewind(turn, "conversation");
     if (!ok) return false;
     setRewindSignal((v) => v + 1);
-    sendToTab(sourceTabId, next, submit);
-    return true;
+    try {
+      await sendToTab(sourceTabId, next, submit);
+      return true;
+    } catch {
+      return false;
+    }
   }, [activeTab?.readOnly, activeTabId, clearContextPending, controllerReady, hydratePlaceholderActive, sendToTab, state.approval, state.ask, state.messageAction, state.running, rewind]);
 
   const handleOpenTopic = useCallback(async (scope: string, workspaceRoot: string, topicId: string, sessionPath?: string) => {

--- a/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
+++ b/desktop/frontend/src/__tests__/composer-goal-toggle.test.tsx
@@ -100,7 +100,9 @@ async function renderComposer(props: Partial<Parameters<typeof Composer>[0]> = {
     goal: "",
     cwd: "/repo",
     modelLabel: "DeepSeek-R1",
-    onSend: (displayText) => calls.send.push(displayText),
+    onSend: (displayText) => {
+      calls.send.push(displayText);
+    },
     onCancel: () => undefined,
     onCycleMode: () => {},
     onSetMode: () => {},
@@ -366,6 +368,72 @@ console.log("\ncomposer goal toggle");
 
   await act(async () => {
     dropNavRoot.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  let rejectSubmit: (err: Error) => void = () => {};
+  const rejectedSubmit = new Promise<void>((_, reject) => {
+    rejectSubmit = reject;
+  });
+  rejectedSubmit.catch(() => {});
+  const { root, calls, rerender } = await renderComposer({
+    onSend: (displayText) => {
+      calls.send.push(displayText);
+      return rejectedSubmit;
+    },
+  });
+
+  const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("composer textarea did not render");
+
+  await rerender({ insertRequest: { id: 2, text: "keep this draft", mode: "replace" } });
+  const sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("composer send button did not render");
+
+  await act(async () => {
+    sendButton.click();
+    rejectSubmit(new Error("workspace is still starting"));
+    await flushTimers();
+  });
+
+  eq(calls.send.join(","), "keep this draft", "rejected submit attempts the send once");
+  eq(textarea.value, "keep this draft", "rejected submit preserves the composer draft");
+
+  await act(async () => {
+    root.unmount();
+  });
+  dom.window.close();
+}
+
+{
+  const dom = installDom();
+  const { root, calls, rerender } = await renderComposer({
+    onSend: (displayText) => {
+      calls.send.push(displayText);
+      return Promise.resolve();
+    },
+  });
+
+  const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+  if (!textarea) throw new Error("composer textarea did not render");
+
+  await rerender({ insertRequest: { id: 3, text: "send this draft", mode: "replace" } });
+  const sendButton = document.querySelector(".composer__btn--send") as HTMLButtonElement | null;
+  if (!sendButton) throw new Error("composer send button did not render");
+
+  await act(async () => {
+    sendButton.click();
+    await flushTimers();
+  });
+
+  eq(calls.send.join(","), "send this draft", "successful submit attempts the send once");
+  eq(textarea.value, "", "successful submit clears the composer draft");
+
+  await act(async () => {
+    root.unmount();
   });
   dom.window.close();
 }

--- a/desktop/frontend/src/__tests__/composer-profile.test.ts
+++ b/desktop/frontend/src/__tests__/composer-profile.test.ts
@@ -17,6 +17,9 @@ import {
 } from "../lib/composerProfile";
 import type { Meta, TabMeta } from "../lib/types";
 
+type LooseTabMeta = Omit<TabMeta, "toolApprovalMode"> & { toolApprovalMode?: TabMeta["toolApprovalMode"] | "" };
+type LooseMeta = Omit<Meta, "toolApprovalMode"> & { toolApprovalMode?: Meta["toolApprovalMode"] | "" };
+
 let passed = 0;
 let failed = 0;
 
@@ -30,7 +33,7 @@ function eq(a: unknown, b: unknown, label: string) {
   }
 }
 
-function tab(overrides: Partial<TabMeta> = {}): TabMeta {
+function tab(overrides: Partial<LooseTabMeta> = {}): TabMeta {
   return {
     id: "tab-1",
     scope: "project",
@@ -50,10 +53,10 @@ function tab(overrides: Partial<TabMeta> = {}): TabMeta {
     active: true,
     cwd: "/repo",
     ...overrides,
-  };
+  } as TabMeta;
 }
 
-function meta(overrides: Partial<Meta> = {}): Meta {
+function meta(overrides: Partial<LooseMeta> = {}): Meta {
   return {
     label: "DeepSeek-R1",
     ready: true,
@@ -67,7 +70,7 @@ function meta(overrides: Partial<Meta> = {}): Meta {
     goal: "",
     goalStatus: "stopped",
     ...overrides,
-  };
+  } as Meta;
 }
 
 console.log("\ncomposer profile");

--- a/desktop/frontend/src/__tests__/send-failed.test.ts
+++ b/desktop/frontend/src/__tests__/send-failed.test.ts
@@ -1,5 +1,8 @@
 // Run: tsx src/__tests__/send-failed.test.ts
 
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { initialState, reducer, replayPendingPromptsForActiveTab } from "../lib/useController";
 import type { WireEvent } from "../lib/types";
 
@@ -68,8 +71,33 @@ eq(notice.kind === "notice" && notice.level, "warn", "the notice is a warning");
 eq(failedState.running, false, "send_failed stops the running indicator");
 eq(failedState.pendingUser, undefined, "send_failed clears the pending marker");
 
+const shellSent = reducer({ ...initialState }, { type: "user", text: "!ls", seq: 0 });
+const shellFailed = reducer(shellSent, { type: "send_failed", error: "Command failed: workspace is still starting" });
+const shellNotice = shellFailed.items[shellFailed.items.length - 1];
+eq(shellNotice.kind, "notice", "rejected shell command appends a visible notice");
+eq(shellNotice.kind === "notice" && shellNotice.text.includes("workspace is still starting"), true, "shell rejection notice includes the backend error");
+
 const lateFailure = reducer(confirmed, { type: "send_failed", error: "Send failed: late" });
 eq(lateFailure, confirmed, "send_failed after backend confirmation is a no-op");
+
+const beforeMcpReady = { ...initialState };
+const mcpReady = reducer(beforeMcpReady, { type: "event", e: { kind: "mcp_surface_ready" } as WireEvent });
+eq(mcpReady, beforeMcpReady, "mcp_surface_ready is accepted as a deliberate no-op");
+const pendingMcpReady = reducer(sent, { type: "event", e: { kind: "mcp_surface_ready" } as WireEvent });
+eq(pendingMcpReady, sent, "mcp_surface_ready does not confirm a pending submit");
+const failedAfterMcpReady = reducer(pendingMcpReady, { type: "send_failed", error: "Send failed: bridge unavailable" });
+const failedAfterMcpReadyBubble = failedAfterMcpReady.items.find((it) => it.kind === "user");
+eq(
+  failedAfterMcpReadyBubble?.kind === "user" && failedAfterMcpReadyBubble.failed,
+  true,
+  "send_failed still marks a pending submit after mcp readiness",
+);
+
+const here = dirname(fileURLToPath(import.meta.url));
+const typesSource = readFileSync(resolve(here, "../lib/types.ts"), "utf8");
+const controllerSource = readFileSync(resolve(here, "../lib/useController.ts"), "utf8");
+eq(typesSource.includes('"mcp_surface_ready"'), true, "TypeScript EventKind declares mcp_surface_ready");
+eq(controllerSource.includes('e.kind === "memory_compiler_stats" || e.kind === "mcp_surface_ready"'), true, "reducer handles mcp_surface_ready before optimistic confirmation");
 
 const unsent = reducer(sent, { type: "unsend" });
 eq(unsent.pendingUser, undefined, "unsend clears the pending marker");

--- a/desktop/frontend/src/__tests__/use-controller-meta.test.ts
+++ b/desktop/frontend/src/__tests__/use-controller-meta.test.ts
@@ -3,6 +3,8 @@
 import { foregroundRunningFromRuntimeMeta, initialState, metaFromTab, reducer, sameMeta, shouldReconcileStaleTurn } from "../lib/useController";
 import type { Meta, TabMeta, WireUsage } from "../lib/types";
 
+type LooseTabMeta = Omit<TabMeta, "toolApprovalMode"> & { toolApprovalMode?: TabMeta["toolApprovalMode"] | "" };
+
 let passed = 0;
 let failed = 0;
 
@@ -37,7 +39,7 @@ function meta(overrides: Partial<Meta> = {}): Meta {
   };
 }
 
-function tab(overrides: Partial<TabMeta> = {}): TabMeta {
+function tab(overrides: Partial<LooseTabMeta> = {}): TabMeta {
   return {
     id: "tab-1",
     scope: "project",
@@ -59,7 +61,7 @@ function tab(overrides: Partial<TabMeta> = {}): TabMeta {
     active: true,
     cwd: "/repo",
     ...overrides,
-  };
+  } as TabMeta;
 }
 
 function usage(source: string): WireUsage {

--- a/desktop/frontend/src/components/Composer.tsx
+++ b/desktop/frontend/src/components/Composer.tsx
@@ -419,7 +419,7 @@ export function Composer({
   modelLabel: string;
   tabId?: string;
   effort?: EffortInfo;
-  onSend: (displayText: string, submitText?: string) => void;
+  onSend: (displayText: string, submitText?: string) => void | Promise<void>;
   // Returns the un-sent text when cancelling before the server replied (so it can
   // be restored to the input); undefined for a normal cancel.
   onCancel: () => string | undefined;
@@ -1100,25 +1100,27 @@ export function Composer({
     submittingRef.current = true;
     setSubmitting(true);
     try {
-    const orderedAttachments = sortComposerAttachments(attachments);
-    const refs = [
-      ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
-      ...orderedAttachments.map((a) => `@${a.path}`),
-    ].join(" ");
-    const displayRefs = [
-      ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
-      ...orderedAttachments.map(formatAttachmentDisplayReference),
-    ].join(" ");
-    const displayText = [trimmedText, displayRefs].filter(Boolean).join(trimmedText && displayRefs ? " " : "");
-    // PR-B: when past:chats refs are attached, prepend their formatted transcript
-    // to submitText only (displayText stays unchanged so the user still sees their
-    // original prompt in the input preview). With no refs we keep the original
-    // submitText verbatim — no header, no rewording, byte-identical to pre-PR-B.
-    const sessionContext = sessionRefs.length === 0 ? "" : await buildSessionContext(sessionRefs);
-    const baseSubmitText = [expandPastedBlocks(trimmedText), refs].filter(Boolean).join(trimmedText && refs ? " " : "");
-    const submitText = sessionContext ? `${sessionContext}${baseSubmitText}` : baseSubmitText;
-    onSend(displayText, submitText);
-    clearSubmittedDraft(submitDraftKey);
+      const orderedAttachments = sortComposerAttachments(attachments);
+      const refs = [
+        ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
+        ...orderedAttachments.map((a) => `@${a.path}`),
+      ].join(" ");
+      const displayRefs = [
+        ...workspaceRefs.map((ref) => formatWorkspaceReference(ref.path, ref.isDir)),
+        ...orderedAttachments.map(formatAttachmentDisplayReference),
+      ].join(" ");
+      const displayText = [trimmedText, displayRefs].filter(Boolean).join(trimmedText && displayRefs ? " " : "");
+      // PR-B: when past:chats refs are attached, prepend their formatted transcript
+      // to submitText only (displayText stays unchanged so the user still sees their
+      // original prompt in the input preview). With no refs we keep the original
+      // submitText verbatim — no header, no rewording, byte-identical to pre-PR-B.
+      const sessionContext = sessionRefs.length === 0 ? "" : await buildSessionContext(sessionRefs);
+      const baseSubmitText = [expandPastedBlocks(trimmedText), refs].filter(Boolean).join(trimmedText && refs ? " " : "");
+      const submitText = sessionContext ? `${sessionContext}${baseSubmitText}` : baseSubmitText;
+      await onSend(displayText, submitText);
+      clearSubmittedDraft(submitDraftKey);
+    } catch (error) {
+      showToast(error instanceof Error ? error.message : String(error), "warn");
     } finally {
       submittingRef.current = false;
       setSubmitting(false);

--- a/desktop/frontend/src/lib/useController.ts
+++ b/desktop/frontend/src/lib/useController.ts
@@ -517,7 +517,8 @@ function applyEvent(s: State, e: WireEvent): State {
     if (e.kind === "turn_done") return { ...s, discardTurn: false, running: false, turnActive: false, pendingPrompt: false, cancelRequested: false, cancellable: false, currentAssistant: undefined, live: undefined };
     return s;
   }
-  if (e.kind === "memory_compiler_stats") {
+  if (e.kind === "memory_compiler_stats" || e.kind === "mcp_surface_ready") {
+    // Background-only events must not confirm an optimistic user bubble.
     return s;
   }
   if (s.pendingUser !== undefined && e.kind !== "turn_done") {
@@ -1209,46 +1210,58 @@ export function useController() {
     replayPendingPromptsForActiveTab(activeTabId);
   }, [activeTabId]);
 
-  const sendToTab = useCallback((tabId: string, displayText: string, submitText = displayText) => {
-    if (!tabId) return;
+  const sendToTab = useCallback(async (tabId: string, displayText: string, submitText = displayText) => {
+    if (!tabId) throw new Error("workspace is still starting");
     const seq = getOrCreateState(statesRef.current, tabId).seq;
     const display = displayText.trim();
     const submit = submitText.trim();
     dispatchTo(tabId, { type: "user", text: displayText, submitText: display !== submit ? submit : undefined, seq });
     invalidateCache();
-    (display !== submit ? app.SubmitDisplayToTab(tabId, display, submit) : app.SubmitToTab(tabId, submit)).catch((error) => {
+    try {
+      await (display !== submit ? app.SubmitDisplayToTab(tabId, display, submit) : app.SubmitToTab(tabId, submit));
+    } catch (error) {
       dispatchTo(tabId, { type: "send_failed", error: `Send failed: ${error instanceof Error ? error.message : String(error)}` });
-    });
+      throw error;
+    }
   }, [dispatchTo]);
 
   const send = useCallback((displayText: string, submitText = displayText) => {
     const tabId = activeTabIdRef.current ?? activeTabId;
     if (tabId) {
-      sendToTab(tabId, displayText, submitText);
-      return;
+      return sendToTab(tabId, displayText, submitText);
     }
-    void activeTabFromBackend().then((active) => {
-      if (!active?.id) return;
+    return activeTabFromBackend().then((active) => {
+      if (!active?.id) throw new Error("workspace is still starting");
       setActiveTabId(active.id);
       activeTabIdRef.current = active.id;
       confirmBackendActiveTab(active.id);
-      sendToTab(active.id, displayText, submitText);
+      return sendToTab(active.id, displayText, submitText);
     });
   }, [activeTabFromBackend, activeTabId, confirmBackendActiveTab, sendToTab]);
 
-  const runShell = useCallback((command: string) => {
-    if (!activeTabId) return;
+  const runShell = useCallback(async (command: string) => {
+    if (!activeTabId) throw new Error("workspace is still starting");
     dispatchTo(activeTabId, { type: "user", text: `!${command}`, seq: getOrCreateState(statesRef.current, activeTabId).seq });
-    app.RunShellForTab(activeTabId, command).catch(() => {});
+    try {
+      await app.RunShellForTab(activeTabId, command);
+    } catch (error) {
+      dispatchTo(activeTabId, { type: "send_failed", error: `Command failed: ${error instanceof Error ? error.message : String(error)}` });
+      throw error;
+    }
   }, [activeTabId, dispatchTo]);
 
-  const steer = useCallback((text: string) => {
-    if (!activeTabId) return;
+  const steer = useCallback(async (text: string) => {
+    if (!activeTabId) throw new Error("workspace is still starting");
     // No optimistic user bubble: rewind/fork map turns by counting user items,
     // and a steer is not a backend turn — the Steer event's ↪ notice is the
     // visible confirmation (#3660).
-    app.SteerForTab(activeTabId, text).catch(() => {});
-  }, [activeTabId]);
+    try {
+      await app.SteerForTab(activeTabId, text);
+    } catch (error) {
+      dispatchTo(activeTabId, { type: "local_notice", level: "warn", text: `Steer failed: ${error instanceof Error ? error.message : String(error)}` });
+      throw error;
+    }
+  }, [activeTabId, dispatchTo]);
 
   const notice = useCallback((text: string, level: "info" | "warn" = "info") => {
     if (!activeTabId) return;


### PR DESCRIPTION
## Summary

- Return explicit desktop command errors when Submit, RunShell, or Steer cannot act on a read-only or unavailable tab.
- Propagate rejected desktop user actions through the frontend so failed submits keep the composer draft and rejected shell/steer actions show visible feedback.
- Add `mcp_surface_ready` to the TypeScript wire event contract and handle it as an explicit transcript-state no-op.

## Verification

- `go test ./...`
- `(cd desktop && go test ./...)`
- `(cd desktop/frontend && corepack pnpm test)`
- `(cd desktop/frontend && corepack pnpm build)`

## Cache impact

Cache-impact: none - desktop command and wire UI state only; no provider-visible prompt, tool schema, request serialization, memory prefix, or cache-sensitive behavior changed.
Cache-guard: `go test ./...`; `(cd desktop && go test ./...)`; `(cd desktop/frontend && corepack pnpm test)`; `(cd desktop/frontend && corepack pnpm build)`
System-prompt-review: N/A
