### PR TITLE
refactor(control): extract checkpointManager and rename cpRoot

### DIFF
--- a/internal/control/branches_test.go
+++ b/internal/control/branches_test.go
@@ -195,9 +195,9 @@ func TestSubmitBranchHonorsNumericTurnTarget(t *testing.T) {
 	}
 	rootPath := c.SessionPath()
 
-	c.mu.Lock()
-	c.cpBound[1] = 3 // displayed turn 2 starts before "second prompt"
-	c.mu.Unlock()
+	c.checkpoints.mu.Lock()
+	c.checkpoints.bound[1] = 3 // displayed turn 2 starts before "second prompt"
+	c.checkpoints.mu.Unlock()
 
 	c.Submit("/branch 2 experiment")
 	if c.SessionPath() == rootPath {

--- a/internal/control/checkpoint.go
+++ b/internal/control/checkpoint.go
@@ -1,0 +1,138 @@
+package control
+
+import (
+	"fmt"
+	"sync"
+
+	"reasonix/internal/checkpoint"
+	"reasonix/internal/diff"
+)
+
+// checkpointManager owns the snapshot-based rewind bookkeeping: the per-session
+// checkpoint store, the monotonic turn counter, and the conversation-rewind
+// boundary map. Like approvalManager it holds only the bookkeeping behind its own
+// lock, off the controller's c.mu — the Controller keeps the rewind/fork
+// orchestration (truncating the session, restoring code, emitting events) that
+// needs its other collaborators.
+//
+// turn is decoupled from the store so it never collides after a log restructure;
+// bound[turn] records len(Session.Messages) at that turn's start — the truncation
+// boundary for a conversation rewind/fork. Boundaries are persisted in each
+// checkpoint and rebuilt from the store on resume (so a reopened session can still
+// rewind conversation / fork), but dropped after a summarize restructures the log
+// so those operations report "unavailable" rather than mis-truncating; code
+// rewind (file-based) is unaffected. Every store call does its disk I/O off mu —
+// mu is taken only to read/swap the store pointer and mutate turn/bound.
+type checkpointManager struct {
+	// mu guards store, turn, and bound; every critical section under it is short
+	// and non-blocking (no disk I/O).
+	mu    sync.Mutex
+	store *checkpoint.Store
+	turn  int
+	bound map[int]int
+}
+
+// rebind points the store at the (possibly new) session, loading any checkpoints
+// already on disk, and resets the turn counter and boundaries from them. root is
+// the workspace root used to guard restore writes. Called on construction and
+// whenever the session path changes (NewSession/Resume/SetSessionPath/fork).
+func (m *checkpointManager) rebind(dir, root string) {
+	store := checkpoint.New(dir, root)
+	next := store.NextTurn() // continue numbering past any checkpoints on disk
+	bound := store.Bounds()  // rebuilt from persisted checkpoints so a resumed
+	if bound == nil {        // session can still rewind conversation / fork
+		bound = map[int]int{}
+	}
+	m.mu.Lock()
+	m.store = store
+	m.turn = next
+	m.bound = bound
+	m.mu.Unlock()
+}
+
+// enabled reports whether a checkpoint store is bound.
+func (m *checkpointManager) enabled() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.store != nil
+}
+
+// begin opens a checkpoint for the turn about to run, recording msgIndex as the
+// conversation-rewind boundary. No-op when checkpoints are disabled.
+func (m *checkpointManager) begin(input string, msgIndex int) {
+	m.mu.Lock()
+	store := m.store
+	if store == nil {
+		m.mu.Unlock()
+		return
+	}
+	turn := m.turn
+	m.turn++
+	m.bound[turn] = msgIndex
+	m.mu.Unlock()
+	store.Begin(turn, input, msgIndex)
+}
+
+// boundary returns the recorded turn-start message index, if any.
+func (m *checkpointManager) boundary(turn int) (int, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	b, ok := m.bound[turn]
+	return b, ok
+}
+
+// list returns the checkpoint metadata (nil when disabled).
+func (m *checkpointManager) list() []checkpoint.Meta {
+	m.mu.Lock()
+	store := m.store
+	m.mu.Unlock()
+	if store == nil {
+		return nil
+	}
+	return store.List()
+}
+
+// restoreCode reverts every file changed at or after turn to its pre-turn
+// content. Errors when checkpoints are disabled.
+func (m *checkpointManager) restoreCode(turn int) (written, deleted []string, err error) {
+	m.mu.Lock()
+	store := m.store
+	m.mu.Unlock()
+	if store == nil {
+		return nil, nil, fmt.Errorf("checkpoints unavailable")
+	}
+	return store.RestoreCode(turn)
+}
+
+// snapshot records a pre-edit file change into the open checkpoint — the
+// executor's pre-edit hook. No-op when disabled.
+func (m *checkpointManager) snapshot(ch diff.Change) {
+	m.mu.Lock()
+	store := m.store
+	m.mu.Unlock()
+	if store != nil {
+		store.Snapshot(ch)
+	}
+}
+
+// truncateFrom renumbers future turns from `turn` and drops every boundary at or
+// after it — the conversation-rewind renumber after the message log is cut back.
+func (m *checkpointManager) truncateFrom(turn int) {
+	m.mu.Lock()
+	m.turn = turn
+	for k := range m.bound {
+		if k >= turn {
+			delete(m.bound, k)
+		}
+	}
+	m.mu.Unlock()
+}
+
+// clearBounds drops every boundary after a summarize restructures the log (so
+// conversation rewind degrades to "unavailable" until fresh turns rebuild them)
+// while keeping turn monotonic so new turns don't collide with the store.
+func (m *checkpointManager) clearBounds() {
+	m.mu.Lock()
+	m.bound = map[int]int{}
+	m.mu.Unlock()
+}

--- a/internal/control/controller.go
+++ b/internal/control/controller.go
@@ -118,19 +118,19 @@ type Controller struct {
 	// stalls an approval or status poll on c.mu. See goal.go.
 	goals goalMachine
 
-	// Checkpoints (snapshot-based rewind). cp is the per-session store rebound when
-	// the session path changes; cpRoot is the workspace root used to guard restore
-	// writes. cpTurn is the monotonic turn counter (decoupled from the store so it
-	// never collides after a restructure); cpBound[turn] records len(Session.Messages)
-	// at that turn's start — the truncation boundary for a conversation rewind/fork.
-	// Boundaries are persisted in each checkpoint and rebuilt from the store on
-	// resume (so a reopened session can still rewind conversation / fork), but
-	// dropped after a summarize restructures the log so those operations report
-	// "unavailable" rather than mis-truncating; code rewind (file-based) is unaffected.
-	cp      *checkpoint.Store
-	cpRoot  string
-	cpTurn  int
-	cpBound map[int]int
+	// workspaceRoot is the workspace root: the base for resolving @-refs and slash
+	// path refs, the working directory for user "!" shell commands and custom
+	// command discovery, and the guard root for checkpoint restore writes. It is
+	// surfaced to frontends via WorkspaceRoot().
+	workspaceRoot string
+
+	// checkpoints owns the snapshot-based rewind bookkeeping (the per-session
+	// store, the monotonic turn counter, and the conversation-rewind boundary map)
+	// behind its own lock, off c.mu — so a boundary read for a rewind/fork never
+	// contends on the run-state lock. The Controller keeps the rewind/fork/summarize
+	// orchestration (truncating the session, restoring code, emitting events). See
+	// checkpoint.go.
+	checkpoints checkpointManager
 
 	// approval owns the approval/ask prompt bookkeeping and the runtime approval
 	// posture (ask/auto/yolo, session grants, the just-approved-plan window)
@@ -319,7 +319,7 @@ func New(opts Options) *Controller {
 		jobs:                   opts.Jobs,
 		reg:                    opts.Registry,
 		pluginCtx:              pluginCtx,
-		cpRoot:                 opts.WorkspaceRoot,
+		workspaceRoot:          opts.WorkspaceRoot,
 		approval:               newApprovalManager(opts.Policy, ToolApprovalAsk, opts.ApprovalTimeout),
 	}
 	// Checkpoints: bind a store to the session and route writer pre-edits into it.
@@ -329,9 +329,7 @@ func New(opts Options) *Controller {
 	c.commands.Store(&cmdsInit)
 	if c.executor != nil {
 		c.executor.SetPreEditHook(func(ch diff.Change) {
-			if c.cp != nil {
-				c.cp.Snapshot(ch)
-			}
+			c.checkpoints.snapshot(ch)
 		})
 		c.executor.SetMemoryQueue(c)
 	}
@@ -384,31 +382,18 @@ func ckptDir(sessionPath string) string {
 // checkpoints already on disk, and resets the turn boundaries. Called on
 // construction and whenever the session path changes (NewSession/Resume/SetSessionPath).
 func (c *Controller) rebindCheckpoints(sessionPath string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.goals.setStatePath(goalStatePath(sessionPath))
-	c.cp = checkpoint.New(ckptDir(sessionPath), c.cpRoot)
-	c.cpTurn = c.cp.NextTurn() // continue numbering past any checkpoints on disk
-	c.cpBound = c.cp.Bounds()  // rebuilt from persisted checkpoints so a resumed
-	if c.cpBound == nil {      // session can still rewind conversation / fork
-		c.cpBound = map[int]int{}
-	}
+	c.checkpoints.rebind(ckptDir(sessionPath), c.workspaceRoot)
 }
 
 // beginCheckpoint opens a checkpoint for the turn about to run, recording the
 // current message count as the conversation-rewind boundary. Called at the top of
 // runTurn, before the user message is appended.
 func (c *Controller) beginCheckpoint(input string) {
-	if c.cp == nil || c.executor == nil {
+	if c.executor == nil {
 		return
 	}
-	c.mu.Lock()
-	turn := c.cpTurn
-	c.cpTurn++
-	msgIndex := len(c.executor.Session().Messages)
-	c.cpBound[turn] = msgIndex
-	c.mu.Unlock()
-	c.cp.Begin(turn, input, msgIndex)
+	c.checkpoints.begin(input, len(c.executor.Session().Messages))
 }
 
 // --- commands (frontend → controller) ---
@@ -814,7 +799,7 @@ func (c *Controller) submitCommandOrTurn(trimmed, input, display string, scopedR
 			runRefTurn(ref, display)
 			return
 		}
-		if ref, ok := SlashPathLineRef(trimmed, c.cpRoot); ok {
+		if ref, ok := SlashPathLineRef(trimmed, c.workspaceRoot); ok {
 			runRefTurnWithRefs(input, ref, display)
 			return
 		}
@@ -1156,7 +1141,7 @@ func (c *Controller) RunShell(command string) {
 		cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 		setShellKillTree(cmd)
 		cmd.WaitDelay = shellWaitDelay
-		cmd.Dir = c.cpRoot
+		cmd.Dir = c.workspaceRoot
 		var buf bytes.Buffer
 		w := io.MultiWriter(&buf, &shellWriter{emit: func(chunk string) {
 			c.sink.Emit(event.Event{
@@ -1683,10 +1668,7 @@ const (
 
 // Checkpoints lists the session's rewind points (one per user turn), oldest first.
 func (c *Controller) Checkpoints() []checkpoint.Meta {
-	if c.cp == nil {
-		return nil
-	}
-	return c.cp.List()
+	return c.checkpoints.list()
 }
 
 // rewindFail emits the error as a Warn notice (so a frontend that swallows the
@@ -1704,19 +1686,16 @@ func (c *Controller) rewindFail(err error) error {
 // unavailable for turns inherited from a resumed session (code rewind still works).
 // Frontends re-render their transcript from History after the call.
 func (c *Controller) Rewind(turn int, scope RewindScope) error {
-	if c.cp == nil || c.executor == nil {
+	if !c.checkpoints.enabled() || c.executor == nil {
 		return c.rewindFail(fmt.Errorf("checkpoints unavailable"))
 	}
-	c.mu.Lock()
-	running := c.running
-	boundary, hasBound := c.cpBound[turn]
-	c.mu.Unlock()
-	if running {
+	if c.Running() {
 		return c.rewindFail(fmt.Errorf("cannot rewind while a turn is running"))
 	}
+	boundary, hasBound := c.checkpoints.boundary(turn)
 
 	if scope == RewindCode || scope == RewindBoth {
-		written, deleted, err := c.cp.RestoreCode(turn)
+		written, deleted, err := c.checkpoints.restoreCode(turn)
 		if err != nil {
 			return c.rewindFail(fmt.Errorf("rewind code: %w", err))
 		}
@@ -1737,14 +1716,7 @@ func (c *Controller) Rewind(turn int, scope RewindScope) error {
 			return c.rewindFail(fmt.Errorf("conversation rewind unavailable for turn %d: the conversation was compacted past this point", turn))
 		}
 		s.Messages = s.Messages[:boundary]
-		c.mu.Lock()
-		c.cpTurn = turn // renumber future turns from here; later turns are gone
-		for k := range c.cpBound {
-			if k >= turn {
-				delete(c.cpBound, k)
-			}
-		}
-		c.mu.Unlock()
+		c.checkpoints.truncateFrom(turn) // renumber future turns from here; later turns are gone
 		if err := c.Snapshot(); err != nil {
 			slog.Warn("controller: snapshot after rewind", "err", err)
 		}
@@ -1781,13 +1753,10 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 	if c.sessionDir == "" {
 		return "", c.rewindFail(fmt.Errorf("fork needs session persistence, which is disabled"))
 	}
-	c.mu.Lock()
-	running := c.running
-	boundary, hasBound := c.cpBound[turn]
-	c.mu.Unlock()
-	if running {
+	if c.Running() {
 		return "", c.rewindFail(fmt.Errorf("cannot fork while a turn is running"))
 	}
+	boundary, hasBound := c.checkpoints.boundary(turn)
 	if !hasBound {
 		return "", c.rewindFail(fmt.Errorf("fork unavailable for turn %d (resumed session)", turn))
 	}
@@ -1838,9 +1807,7 @@ func (c *Controller) forkNamed(turn int, name string, switchToFork bool) (string
 }
 
 func (c *Controller) CheckpointHasBoundary(turn int) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	boundary, ok := c.cpBound[turn]
+	boundary, ok := c.checkpoints.boundary(turn)
 	if !ok {
 		return false
 	}
@@ -2009,13 +1976,10 @@ func (c *Controller) summarizeAt(ctx context.Context, turn int, from bool) error
 	if c.executor == nil {
 		return c.rewindFail(fmt.Errorf("checkpoints unavailable"))
 	}
-	c.mu.Lock()
-	running := c.running
-	boundary, hasBound := c.cpBound[turn]
-	c.mu.Unlock()
-	if running {
+	if c.Running() {
 		return c.rewindFail(fmt.Errorf("cannot summarize while a turn is running"))
 	}
+	boundary, hasBound := c.checkpoints.boundary(turn)
 	if !hasBound {
 		return c.rewindFail(fmt.Errorf("summarize unavailable for turn %d (resumed session)", turn))
 	}
@@ -2029,11 +1993,9 @@ func (c *Controller) summarizeAt(ctx context.Context, turn int, from bool) error
 		return c.rewindFail(err)
 	}
 	// The log was restructured; existing boundaries no longer map. Drop them (keep
-	// cpTurn monotonic so new turns don't collide with the store) — conversation
-	// rewind degrades to "unavailable" until fresh turns rebuild boundaries.
-	c.mu.Lock()
-	c.cpBound = map[int]int{}
-	c.mu.Unlock()
+	// the turn counter monotonic so new turns don't collide with the store) —
+	// conversation rewind degrades to "unavailable" until fresh turns rebuild them.
+	c.checkpoints.clearBounds()
 	if err := c.Snapshot(); err != nil {
 		slog.Warn("controller: post-summarize snapshot", "err", err)
 	}
@@ -2399,7 +2361,7 @@ func (c *Controller) ReloadCommands(ctx context.Context) error {
 		return ctx.Err()
 	default:
 	}
-	cmds, loadErr := command.Load(config.CommandDirsForRoot(c.cpRoot)...)
+	cmds, loadErr := command.Load(config.CommandDirsForRoot(c.workspaceRoot)...)
 	cmdSkills := c.Skills()
 
 	entries := make([]command.SlashEntry, 0, len(cmdSkills)+len(cmds))
@@ -2735,7 +2697,7 @@ func (c *Controller) Label() string { return c.label }
 // WorkspaceRoot returns the workspace root for this controller's session
 // (the directory that file-writers and @-references are scoped to).
 // Empty means no scoping is in effect.
-func (c *Controller) WorkspaceRoot() string { return c.cpRoot }
+func (c *Controller) WorkspaceRoot() string { return c.workspaceRoot }
 
 // InheritLifecycleFrom carries same-session lifecycle state across controller
 // rebuilds, such as model switches that preserve the conversation.

--- a/internal/control/inputimages_test.go
+++ b/internal/control/inputimages_test.go
@@ -39,7 +39,7 @@ func TestControllerInputImagesResolvesWorkspaceImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	urls := (&Controller{cpRoot: workspace}).inputImages("look at @docs/diagram.png")
+	urls := (&Controller{workspaceRoot: workspace}).inputImages("look at @docs/diagram.png")
 	if len(urls) != 1 {
 		t.Fatalf("inputImages = %v, want one resolved data URL", urls)
 	}
@@ -55,7 +55,7 @@ func TestControllerInputImagesResolvesAbsoluteWorkspaceImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	urls := (&Controller{cpRoot: workspace}).inputImages("look at @" + path)
+	urls := (&Controller{workspaceRoot: workspace}).inputImages("look at @" + path)
 	if len(urls) != 1 {
 		t.Fatalf("inputImages = %v, want one resolved data URL", urls)
 	}

--- a/internal/control/refs.go
+++ b/internal/control/refs.go
@@ -123,8 +123,8 @@ func (c *Controller) detectRefsMode(line string, scopedOnly bool) []ref {
 			refs = append(refs, ref{kind: refResource, server: tok[:i], uri: tok[i+1:], raw: tok})
 			continue
 		}
-		if c.cpRoot != "" {
-			if rel, ok := workspaceRefPath(tok, c.cpRoot); ok {
+		if c.workspaceRoot != "" {
+			if rel, ok := workspaceRefPath(tok, c.workspaceRoot); ok {
 				kind := refFile
 				if isAttachmentRef(rel) && isImageAttachmentRef(rel) {
 					kind = refImage
@@ -158,7 +158,7 @@ func (c *Controller) HasRefs(line string) bool {
 func (c *Controller) inputImages(line string) []string {
 	var urls []string
 	for _, r := range c.detectRefs(line) {
-		if url, err := visionRefImageDataURL(r, c.cpRoot); err == nil {
+		if url, err := visionRefImageDataURL(r, c.workspaceRoot); err == nil {
 			urls = append(urls, url)
 		}
 	}
@@ -433,7 +433,7 @@ func (c *Controller) ResolveScopedRefs(ctx context.Context, line string) (block 
 
 func (c *Controller) resolveRefs(ctx context.Context, line string, scopedOnly bool) (block string, errs []string) {
 	refs := c.detectRefsMode(line, scopedOnly)
-	refs = resolveBareNames(refs, c.cpRoot)
+	refs = resolveBareNames(refs, c.workspaceRoot)
 	var b strings.Builder
 	for _, r := range refs {
 		switch r.kind {
@@ -445,7 +445,7 @@ func (c *Controller) resolveRefs(ctx context.Context, line string, scopedOnly bo
 			}
 			appendRefBlock(&b, "resource", `ref="@`+r.raw+`"`, text)
 		case refFile:
-			text, isDir, err := readFileRef(r.path, c.cpRoot)
+			text, isDir, err := readFileRef(r.path, c.workspaceRoot)
 			if err != nil {
 				errs = append(errs, "@"+r.raw+" — "+err.Error())
 				continue

--- a/internal/control/refs_test.go
+++ b/internal/control/refs_test.go
@@ -513,12 +513,12 @@ func TestDetectRefsUsesWorkspaceRootNotProcessCWD(t *testing.T) {
 		}
 	})
 
-	refs := (&Controller{cpRoot: workspace}).detectRefs("see @cwd-only.txt and @workspace.txt")
+	refs := (&Controller{workspaceRoot: workspace}).detectRefs("see @cwd-only.txt and @workspace.txt")
 	if len(refs) != 1 || refs[0].raw != "workspace.txt" {
 		t.Fatalf("detectRefs should only see workspace files, got %+v", refs)
 	}
 
-	block, errs := (&Controller{cpRoot: workspace}).ResolveRefs(context.Background(), "see @cwd-only.txt")
+	block, errs := (&Controller{workspaceRoot: workspace}).ResolveRefs(context.Background(), "see @cwd-only.txt")
 	if block != "" || len(errs) != 0 {
 		t.Fatalf("cwd-only file should not be treated as a ref, block=%q errs=%v", block, errs)
 	}
@@ -534,7 +534,7 @@ func TestResolveRefsWithWorkspaceRootStoresRelativePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := &Controller{cpRoot: workspace}
+	c := &Controller{workspaceRoot: workspace}
 	refs := c.detectRefs("see @" + absPath)
 	if len(refs) != 1 {
 		t.Fatalf("detectRefs absolute workspace path = %+v, want 1 ref", refs)
@@ -568,7 +568,7 @@ func TestWorkspaceImageRefsAlsoAttachAsModelImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := &Controller{cpRoot: workspace}
+	c := &Controller{workspaceRoot: workspace}
 	refs := c.detectRefs("see @" + diagram + " @" + attachment)
 	if len(refs) != 2 {
 		t.Fatalf("detectRefs = %+v, want two refs", refs)

--- a/internal/control/rewind_e2e_test.go
+++ b/internal/control/rewind_e2e_test.go
@@ -44,12 +44,12 @@ func runTwoTurns(t *testing.T) (*Controller, *agent.Agent, *[]event.Event) {
 func TestRewindConversationFailsLoudlyAfterCompaction(t *testing.T) {
 	c, ag, events := runTwoTurns(t)
 
-	c.mu.Lock()
-	lastTurn := c.cpTurn - 1
-	boundary := c.cpBound[lastTurn]
-	c.mu.Unlock()
+	c.checkpoints.mu.Lock()
+	lastTurn := c.checkpoints.turn - 1
+	boundary := c.checkpoints.bound[lastTurn]
+	c.checkpoints.mu.Unlock()
 	if boundary <= 1 {
-		t.Fatalf("expected the latest turn's boundary above 1, got cpBound=%v", c.cpBound)
+		t.Fatalf("expected the latest turn's boundary above 1, got bound=%v", c.checkpoints.bound)
 	}
 
 	// Auto-compaction replaces the prefix with a summary, shrinking the log below
@@ -77,10 +77,10 @@ func TestRewindConversationFailsLoudlyAfterCompaction(t *testing.T) {
 func TestRewindConversationSucceedsWithLiveBoundary(t *testing.T) {
 	c, ag, events := runTwoTurns(t)
 
-	c.mu.Lock()
-	lastTurn := c.cpTurn - 1
-	boundary := c.cpBound[lastTurn]
-	c.mu.Unlock()
+	c.checkpoints.mu.Lock()
+	lastTurn := c.checkpoints.turn - 1
+	boundary := c.checkpoints.bound[lastTurn]
+	c.checkpoints.mu.Unlock()
 
 	*events = nil
 	if err := c.Rewind(lastTurn, RewindConversation); err != nil {

--- a/internal/control/slash.go
+++ b/internal/control/slash.go
@@ -418,7 +418,7 @@ func (c *Controller) managementNotice(trimmed string) bool {
 		case "", "list", "ls":
 			c.notice(c.hookListText())
 		case "trust":
-			root := c.cpRoot
+			root := c.workspaceRoot
 			if root == "" {
 				root, _ = os.Getwd()
 			}


### PR DESCRIPTION
## What

Second in the series continuing the `Controller` god-object decomposition (after `memoryManager`, #5113). Carve the **snapshot-based rewind bookkeeping** out into a `checkpointManager` collaborator, and disentangle the overloaded `cpRoot` field.

`checkpointManager` (new `internal/control/checkpoint.go`) owns the per-session checkpoint store, the monotonic turn counter, and the conversation-rewind boundary map behind its own lock — moving that state **off `c.mu`**, so a boundary read for a rewind/fork no longer contends on the run-state lock. Every store call does its disk I/O off the lock.

Following the `approvalManager` precedent, **only the bookkeeping moves**; the Controller keeps the rewind/fork/summarize orchestration (truncating the session, restoring code, emitting events) that needs its other collaborators.

## The `cpRoot` rename

`cpRoot` was never checkpoint-specific — it is **the workspace root**, used for `@`-ref resolution, the `!` shell cwd, custom-command discovery, `WorkspaceRoot()`, *and* the checkpoint restore guard. With the checkpoint state moved out, the `cp` prefix was actively misleading, so it is renamed to `workspaceRoot`.

## Changes

- **New** `internal/control/checkpoint.go` — the manager (`rebind`/`begin`/`boundary`/`list`/`restoreCode`/`snapshot`/`truncateFrom`/`clearBounds`).
- `controller.go` drops `cp` / `cpRoot` / `cpTurn` / `cpBound` for `workspaceRoot` + `checkpoints`; `rebindCheckpoints`, `beginCheckpoint`, `Rewind`, `forkNamed`, `summarizeAt`, `Checkpoints`, `CheckpointHasBoundary` delegate the state ops and read run-state via `Running()` instead of a hand-rolled `c.mu` section.
- `refs.go` / `slash.go` follow the `cpRoot` → `workspaceRoot` rename.

## Why it's safe

- **Public `SessionAPI` surface is unchanged** → no frontend touched. The lock semantics are preserved: the boundary/turn state simply moves from `c.mu` to the manager's own lock (same serialization, off the run-state lock).
- `controller.go`: **3455 → 3417 lines, 45 → 43 fields**.

## Verification

- `gofmt` clean, `go vet ./internal/control/...` clean, `go build ./...` ok.
- `go test -race ./internal/control/...` green — including the rewind/fork e2e tests (`TestRewindConversation*`, `TestSubmitBranchHonorsNumericTurnTarget`) and the boundary-after-compaction regressions.
- Full `go test ./...` — **52 packages, all green**.