### PR TITLE
fix(rendering): prevent copy button from scrolling with code block content

### DIFF
--- a/desktop/frontend/src/styles.css
+++ b/desktop/frontend/src/styles.css
@@ -1656,6 +1656,7 @@ a[href] {
 }
 .code-block {
   position: relative;
+  overflow: hidden;
 }
 .code-block__copy {
   position: absolute;


### PR DESCRIPTION
## Problem

When a code block contains long lines that trigger horizontal scrolling, the copy button in the top-right corner drifts off-screen with the content instead of staying pinned to the visible area.

**Reproduction** (Issue #5096):
1. Open a conversation with a code block containing long lines
2. Scroll the code block horizontally
3. The copy button moves with the content, disappearing off the right edge

## Root Cause

The DOM structure is:

```
div.code-block          (position: relative)
  button.code-block__copy   (position: absolute, top: 7px, right: 7px)
  pre.code                  (overflow: auto, max-height: 360px)
    code
```

The `.code-block` wrapper has `position: relative` but no explicit width constraint. When the inner `<pre>` overflows horizontally, the wrapper expands to match the full scroll width. The absolutely-positioned copy button is then anchored to the right edge of this expanded container — which is off-screen.

## Fix

Add `overflow: hidden` to `.code-block`. This constrains the wrapper to its parent's width, so the absolutely-positioned button stays pinned at the top-right corner of the visible area. The inner `<pre>` retains its own `overflow: auto` for independent scrolling.

**Single-line change in `desktop/frontend/src/styles.css`:**

```css
.code-block {
  position: relative;
+ overflow: hidden;
}
```

## Testing

- Verify copy button remains visible at top-right when scrolling code blocks horizontally
- Verify vertical scrolling within code blocks still works
- Verify copy button still appears on hover and copy functionality works