### PR TITLE
fix(desktop): retry auto-title when first user message is not yet persisted

### DIFF
--- a/desktop/tabs.go
+++ b/desktop/tabs.go
@@ -1955,9 +1955,9 @@ func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) bool {
 	if sessionPath == "" {
 		return false
 	}
-	nextTitle, updated := autoTitleTopicFromSession(titleRoot, tab.TopicID, sessionPath)
+	nextTitle, updated, retry := autoTitleTopicFromSession(titleRoot, tab.TopicID, sessionPath, loadTopicTitle(titleRoot, tab.TopicID))
 	if !updated {
-		return false
+		return retry
 	}
 	a.updateOpenTopicTitle(tab.TopicID, nextTitle)
 	a.updateTopicSessionTitles(tab.TopicID, nextTitle)
@@ -1965,18 +1965,24 @@ func (a *App) maybeAutoTitleTopic(tab *WorkspaceTab) bool {
 	return true
 }
 
-func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath string) (string, bool) {
+func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath, currentTitle string) (title string, updated bool, retry bool) {
 	if source := loadTopicTitleSource(workspaceRoot, topicID); source != topicTitleSourceAuto {
-		return "", false
+		return "", false, false
 	}
 	nextTitle := topicTitleFromSession(sessionPath)
-	if nextTitle == "" || nextTitle == loadTopicTitle(workspaceRoot, topicID) {
-		return "", false
+	if nextTitle == "" || nextTitle == currentTitle {
+		// If the title is still the default, the first user message may not
+		// have been persisted yet — signal the caller to retry on the next
+		// snapshot rather than giving up permanently.
+		if currentTitle == "" || currentTitle == defaultTopicTitle {
+			return "", false, true
+		}
+		return "", false, false
 	}
 	if err := setTopicTitleWithSource(workspaceRoot, topicID, nextTitle, topicTitleSourceAuto); err != nil {
-		return "", false
+		return "", false, false
 	}
-	return nextTitle, true
+	return nextTitle, true, false
 }
 
 func topicTitleFromSession(path string) string {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1352,7 +1352,7 @@ func TestAutoTitleTopicFromFirstUserMessage(t *testing.T) {
 		t.Fatalf("write session: %v", err)
 	}
 
-	title, updated := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath)
+	title, updated, _ := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath, "")
 	if !updated {
 		t.Fatal("auto title should update")
 	}
@@ -1407,7 +1407,7 @@ func TestAutoTitleDoesNotOverrideManualTopicTitle(t *testing.T) {
 		t.Fatalf("write session: %v", err)
 	}
 
-	if title, updated := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath); updated || title != "" {
+	if title, updated, _ := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath, "手动标题"); updated || title != "" {
 		t.Fatalf("manual title should not auto-update, title=%q updated=%v", title, updated)
 	}
 	if got := loadTopicTitle(projectRoot, topic.ID); got != "手动标题" {

--- a/desktop/tabs_topic_test.go
+++ b/desktop/tabs_topic_test.go
@@ -1381,7 +1381,7 @@ func TestAutoTitleTopicStripsReasoningLanguagePrefix(t *testing.T) {
 		t.Fatalf("write session: %v", err)
 	}
 
-	title, updated := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath)
+	title, updated, _ := autoTitleTopicFromSession(projectRoot, topic.ID, sessionPath, "")
 	if !updated {
 		t.Fatal("auto title should update")
 	}


### PR DESCRIPTION
## Problem

All session titles remain as the default "新的会话" (New Session) indefinitely. The `.jsonl.meta` sidecar files have an empty `topic_title` field, and the auto-title mechanism silently gives up after the first failed attempt.

**Reproduction** (Issue #5017):
1. Open Reasonix Desktop
2. Start a new conversation and send a message
3. The session title stays as "新的会话" instead of updating

## Root Cause

The auto-title flow in `desktop/tabs.go`:

1. `tabSnapshotLoop` calls `maybeAutoTitleTopic` after each successful `ctrl.Snapshot()`
2. `maybeAutoTitleTopic` calls `autoTitleTopicFromSession`
3. `autoTitleTopicFromSession` calls `topicTitleFromSession(sessionPath)` which opens the JSONL file and reads messages until it finds `role: "user"`
4. If no user message is found yet (the first message hasn't been persisted to disk at the time of the snapshot), `topicTitleFromSession` returns `""`
5. **The function returns `"", false` with no retry signal** — the title stays as default forever

The race condition: the first `Snapshot()` can complete before the user's first message is fully written to the JSONL file. The auto-title mechanism reads an empty file, gets no result, and never tries again.

## Fix

Modify `autoTitleTopicFromSession` to return a **retry flag** as a third return value. When the title extraction fails but the current title is still the default (meaning no title has ever been successfully set), signal the caller to retry on the next snapshot loop iteration instead of giving up permanently.

**Changes in `desktop/tabs.go`:**

```go
// Before
func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath string) (string, bool) {
    // ...
    if nextTitle == "" || nextTitle == loadTopicTitle(workspaceRoot, topicID) {
        return "", false  // gives up permanently
    }
    // ...
}

// After
func autoTitleTopicFromSession(workspaceRoot, topicID, sessionPath, currentTitle string) (title string, updated bool, retry bool) {
    // ...
    if nextTitle == "" || nextTitle == currentTitle {
        if currentTitle == "" || currentTitle == defaultTopicTitle {
            return "", false, true  // retry on next snapshot
        }
        return "", false, false
    }
    // ...
}
```

The caller `maybeAutoTitleTopic` now uses the retry flag:

```go
nextTitle, updated, retry := autoTitleTopicFromSession(titleRoot, tab.TopicID, sessionPath, ...)
if !updated {
    return retry  // true → snapshot loop will emit and continue; false → no change
}
```

## Testing

1. Create a new topic, send a message
2. Verify the title updates from "新的会话" to a truncated version of the first message
3. Verify manually-renamed topics are not overwritten
4. Verify the retry doesn't cause excessive emissions (only retries while title is still default)